### PR TITLE
feat(mockups): #2361 Play Records detail — extension 4 stati canonici

### DIFF
--- a/admin-mockups/design_files/sp4-play-records-detail.fidelity.json
+++ b/admin-mockups/design_files/sp4-play-records-detail.fidelity.json
@@ -3,7 +3,10 @@
   "mockup": {
     "source": "admin-mockups/design_files/sp4-play-records-detail.html",
     "states": [
-      "default"
+      "default",
+      "empty",
+      "loading",
+      "error"
     ]
   },
   "acceptance": {
@@ -12,7 +15,10 @@
     "tokens_used": "canonical_only",
     "legacy_token_names_forbidden": true,
     "states_covered": [
-      "default"
+      "default",
+      "empty",
+      "loading",
+      "error"
     ],
     "a11y_axe": "AA",
     "a11y_violations_max": 0,
@@ -28,6 +34,7 @@
     "fixtures_path": "",
     "design_intent": "current",
     "viewports": [
+      "mobile",
       "desktop"
     ],
     "obsolete_tracking_issue": ""

--- a/admin-mockups/design_files/sp4-play-records-detail.html
+++ b/admin-mockups/design_files/sp4-play-records-detail.html
@@ -4,8 +4,148 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Play records · Dettaglio partita — MeepleAI</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700;800&display=swap">
   <link rel="stylesheet" href="tokens.css">
   <link rel="stylesheet" href="scaffold.css">
+  <style>
+    /* ─── Gallery / frame chrome + skeleton (self-contained, non dipende da scaffold.css) ─── */
+    html { scroll-behavior: smooth; }
+    body { min-height: 100vh; }
+
+    /* Skeleton pulse — opacity 0.4 → 0.8 → 0.4, 2s loop */
+    @keyframes sp4-skel-pulse { 0%, 100% { opacity: .4; } 50% { opacity: .8; } }
+    .skel { animation: sp4-skel-pulse 2s var(--ease-in-out) infinite; }
+    /* In-corso badge pulse */
+    @keyframes sp4-dot-pulse { 0%, 100% { opacity: 1; } 50% { opacity: .45; } }
+    .mai-pulse { animation: sp4-dot-pulse 1.6s var(--ease-in-out) infinite; }
+    /* Hero confetti (default · festoso) */
+    @keyframes sp4-confetti-fall { 0% { transform: translateY(-24px) rotate(0deg); opacity: 0; } 12% { opacity: 1; } 100% { transform: translateY(360px) rotate(360deg); opacity: 0; } }
+    .sp4-confetti { animation: sp4-confetti-fall 3s var(--ease-out) infinite; }
+
+    /* prefers-reduced-motion → snap senza pulse/cadute */
+    @media (prefers-reduced-motion: reduce) {
+      html { scroll-behavior: auto; }
+      .skel { animation: none; opacity: .6; }
+      .mai-pulse { animation: none; }
+      .sp4-confetti { animation: none; opacity: .45; }
+    }
+
+    .gallery { min-height: 100vh; }
+
+    /* Sticky top nav con 4 link agli anchor */
+    .gallery-nav {
+      position: sticky; top: 0; z-index: var(--z-nav);
+      display: flex; align-items: center; gap: 16px; flex-wrap: wrap;
+      padding: 10px 24px;
+      background: var(--glass-bg); backdrop-filter: blur(12px);
+      border-bottom: 1px solid var(--border);
+    }
+    .gallery-nav-brand {
+      font-family: var(--f-mono); font-size: 11px; font-weight: 800;
+      letter-spacing: .06em; text-transform: uppercase; color: var(--text-sec);
+      white-space: nowrap;
+    }
+    .gallery-nav-links { display: flex; gap: 6px; flex: 1; flex-wrap: wrap; }
+    .gallery-nav-links a {
+      padding: 6px 12px; border-radius: var(--r-pill);
+      font-family: var(--f-display); font-size: 12px; font-weight: 700;
+      color: var(--text-sec); border: 1px solid var(--border); background: var(--bg-card);
+      white-space: nowrap; transition: color var(--dur-sm) var(--ease-out), border-color var(--dur-sm) var(--ease-out), background var(--dur-sm) var(--ease-out);
+    }
+    .gallery-nav-links a:hover {
+      color: hsl(var(--c-session)); border-color: hsl(var(--c-session) / .45);
+      background: hsl(var(--c-session) / .1);
+    }
+    .gallery-nav-ghost {
+      font-family: var(--f-mono); font-size: 10.5px; font-weight: 700;
+      color: var(--text-muted); padding: 6px 10px; border-radius: var(--r-pill);
+      border: 1px dashed var(--border-strong); opacity: .6; white-space: nowrap;
+    }
+    .theme-toggle {
+      display: inline-flex; align-items: center; gap: 6px;
+      padding: 6px 12px; border-radius: var(--r-pill);
+      border: 1px solid var(--border); background: var(--bg-card); color: var(--text-sec);
+      font-family: var(--f-display); font-size: 12px; font-weight: 700; white-space: nowrap;
+      transition: border-color var(--dur-sm) var(--ease-out), color var(--dur-sm) var(--ease-out);
+    }
+    .theme-toggle:hover { border-color: hsl(var(--c-session) / .45); color: hsl(var(--c-session)); }
+
+    .gallery-body { max-width: 1560px; margin: 0 auto; padding: 24px 24px 96px; }
+    .gallery-intro { padding: 16px 0 4px; }
+    .gallery-intro .kicker {
+      font-family: var(--f-mono); font-size: 11px; text-transform: uppercase;
+      letter-spacing: .08em; color: var(--text-muted); margin-bottom: 8px; font-weight: 800;
+    }
+    .gallery-intro h1 { font-size: var(--fs-3xl); margin: 0 0 10px; }
+    .gallery-intro .lead {
+      font-size: var(--fs-base); color: var(--text-sec); max-width: 820px;
+      line-height: var(--lh-relax); margin: 0; text-wrap: pretty;
+    }
+    .gallery-intro code, .state-head code {
+      font-family: var(--f-mono); font-size: .88em;
+      background: var(--bg-muted); padding: 1px 5px; border-radius: var(--r-xs);
+    }
+
+    .state-section { scroll-margin-top: 76px; padding: 40px 0 8px; border-top: 1px solid var(--border-light); margin-top: 28px; }
+    .state-head { display: flex; align-items: flex-start; gap: 14px; margin-bottom: 26px; }
+    .state-num {
+      font-family: var(--f-mono); font-size: 14px; font-weight: 800; color: #fff;
+      background: hsl(var(--c-session)); width: 36px; height: 36px; border-radius: var(--r-md);
+      display: flex; align-items: center; justify-content: center; flex-shrink: 0;
+      box-shadow: 0 4px 12px hsl(var(--c-session) / .4);
+    }
+    .state-head-text { flex: 1; min-width: 0; }
+    .state-head h2 { font-size: var(--fs-2xl); margin: 0; }
+    .state-head p { font-size: 13px; color: var(--text-sec); margin: 5px 0 0; max-width: 640px; line-height: var(--lh-snug); }
+    .state-anchor {
+      margin-left: auto; align-self: flex-start;
+      font-family: var(--f-mono); font-size: 11px; color: var(--text-muted);
+      background: var(--bg-muted); padding: 5px 10px; border-radius: var(--r-sm); white-space: nowrap;
+    }
+
+    .matrix { display: flex; flex-direction: column; gap: 32px; }
+    .matrix-row { display: flex; gap: 32px; flex-wrap: wrap; align-items: flex-start; }
+    .frame-tag {
+      font-family: var(--f-mono); font-size: 11px; color: var(--text-sec);
+      text-transform: uppercase; letter-spacing: .06em; font-weight: 700;
+    }
+
+    /* Phone 375 */
+    .phone {
+      width: 375px; height: 760px; border-radius: 38px;
+      border: 10px solid var(--text); background: var(--bg);
+      overflow: hidden; display: flex; flex-direction: column;
+      box-shadow: var(--shadow-lg); flex-shrink: 0;
+    }
+    .phone-sbar {
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 9px 24px 4px; font-family: var(--f-mono); font-size: 12px; font-weight: 700; flex-shrink: 0;
+    }
+    .phone-sbar .ind { display: flex; gap: 8px; align-items: center; font-size: 10px; letter-spacing: .1em; }
+
+    /* Desktop 1440 */
+    .desktop-frame {
+      width: 1440px; max-width: 100%; border-radius: 14px;
+      border: 1px solid var(--border); background: var(--bg); overflow: hidden;
+      box-shadow: var(--shadow-lg);
+    }
+    .desktop-bar {
+      display: flex; align-items: center; gap: 8px; padding: 10px 16px;
+      background: var(--bg-card); border-bottom: 1px solid var(--border);
+    }
+    .desktop-bar .traffic { width: 11px; height: 11px; border-radius: 50%; background: var(--border-strong); }
+    .desktop-bar .url { margin-left: 14px; font-family: var(--f-mono); font-size: 11px; color: var(--text-muted); }
+
+    .mai-cb-scroll { scrollbar-width: none; }
+    .mai-cb-scroll::-webkit-scrollbar { height: 0; width: 0; }
+
+    @media (max-width: 900px) {
+      .gallery-body { padding: 20px 16px 80px; }
+      .matrix-row { gap: 24px; }
+    }
+  </style>
 </head>
 <body>
   <div id="root"></div>

--- a/admin-mockups/design_files/sp4-play-records-detail.jsx
+++ b/admin-mockups/design_files/sp4-play-records-detail.jsx
@@ -1,133 +1,150 @@
 /* MeepleAI SP4 — /play-records/[id] · DETAIL
-   Route: /play-records/[id]
+   Route: /play-records/[id]  (read-only display dettaglio partita)
    File: admin-mockups/design_files/sp4-play-records-detail.{html,jsx}
-   Modello: sp4-session-summary — Hero podio + ConnectionBar + classifica + dettaglio punteggi + note.
+   Modello: sp4-session-summary — Hero podio + ConnectionBar + classifica + dettaglio punteggi + note + foto.
    Entity dominante: session 🎯 (240 60% 55%). Tone: festoso ma elegante.
+
+   ── Stati canonici (G7 SessionStateRenderer, PR 2357) ──────────────
+   Export per-stato (anchor #state-NN-* nell'HTML gallery):
+     State01_Default  → state-01-default   (dettaglio completo as-shipped)
+     State02_Empty    → state-02-empty     (record minimale · dati core only · null parziali)
+     State03_Loading  → state-03-loading   (skeleton primitives · aria-busy)
+     State04_Error    → state-04-error     (banner alert · retry · torna lista · dismiss)
+   state-05-sse → SKIPPED: il detail NON è SSE-driven (fetch-once read-only). Vedi nota in fondo.
+
+   FREEZE: zero hex/hsl numerico hardcoded per gli entity color → solo token --c-*
+   via eHs() (abbreviazione di entityHsl). Esente: color:'#fff' su background eHs (pattern .e-bg).
 */
 const { useState, useEffect } = React;
 const DS = window.DS;
 
-const eHs = (type, alpha) => {
-  const c = DS.EC[type] || DS.EC.session;
-  return alpha !== undefined ? `hsla(${c.h}, ${c.s}%, ${c.l}%, ${alpha})` : `hsl(${c.h}, ${c.s}%, ${c.l}%)`;
-};
+// eHs(entity, alpha?) — risolve SEMPRE sui token CSS (--c-*), così il colore
+// segue automaticamente light/dark ([data-theme]) ed è FREEZE-clean (nessun
+// valore hsl numerico hardcoded nel sorgente del mockup).
+const eHs = (entity, alpha) =>
+  alpha === undefined ? `hsl(var(--c-${entity}))` : `hsl(var(--c-${entity}) / ${alpha})`;
 
-// Record principale (Wingspan, 4 giocatori, Marco vince)
-const REC = DS.byId['pr1'];
-const REC_GAME = DS.byId[REC.game];
-
-// ranking helper
+// ── ranking + player helpers ───────────────────────────
 const ranked = (scores) => [...scores]
   .map((s, i) => ({ ...s, _orig: i }))
-  .sort((a, b) => (Number(b.score) ?? -Infinity) - (Number(a.score) ?? -Infinity));
+  .sort((a, b) => {
+    const av = a.score === null ? -Infinity : Number(a.score);
+    const bv = b.score === null ? -Infinity : Number(b.score);
+    return bv - av;
+  });
 
 const pColor = (playerId, fallbackHue = 240) => {
   const p = DS.byId[playerId];
-  return p ? p.color : fallbackHue;
+  return p ? p.color : fallbackHue; // hue identità giocatore (dato DS, non entity-token)
 };
 const initialsOf = (s) => {
   const p = DS.byId[s.playerId];
   return p ? p.initials : s.name.slice(0, 2).toUpperCase();
 };
+const playerTitle = (s) => {
+  const p = DS.byId[s.playerId];
+  return p ? p.title : s.name;
+};
 
-// ─── SECTION TITLE ─────────────────────────────────────
+// ── Record demo ─────────────────────────────────────────
+const REC = DS.byId['pr1'];
+const REGISTRANT = (DS.stats && DS.stats.user) || 'Marco R.';
+
+// Default (as-shipped): record completo + foto allegata + meta registrazione.
+const REC_DEFAULT = {
+  ...REC,
+  photo: { caption: 'Tavolo a fine partita', emoji: '📸' },
+  registeredOn: '17 mag 2026 · 22:14',
+  registeredBy: REGISTRANT,
+};
+
+// Empty (record minimale): stesso pr1 ma foto:null + notes:'' + 2 score null + nessun winner.
+const REC_EMPTY = {
+  ...REC,
+  photo: null,
+  notes: '',
+  registeredOn: '17 mag 2026 · 22:05',
+  registeredBy: REGISTRANT,
+  scores: REC.scores.map((s, i) => i >= 2 ? { ...s, score: null, winner: false } : { ...s, winner: false }),
+};
+
+// ── Score value (null → "—" + aria) ────────────────────
+const ScoreVal = ({ value, style }) =>
+  (value === null || value === undefined)
+    ? <span aria-label="Punteggio non registrato" style={style}>—</span>
+    : <span style={style}>{value}</span>;
+
+// ── SECTION TITLE ──────────────────────────────────────
 const SectionTitle = ({ em, children, extra }) => (
-  <h2 style={{ fontFamily:'var(--f-display)', fontSize: 16, fontWeight: 800, color:'var(--text)', margin:'0 0 10px', display:'inline-flex', alignItems:'center', gap: 7 }}>
+  <h2 style={{ fontFamily:'var(--f-display)', fontSize: 15, fontWeight: 800, color:'var(--text)', margin:'0 0 10px', display:'inline-flex', alignItems:'center', gap: 7 }}>
     <span aria-hidden="true">{em}</span>{children}
     {extra && <span style={{ fontFamily:'var(--f-mono)', fontSize: 11, fontWeight: 700, color:'var(--text-muted)' }}>{extra}</span>}
   </h2>
 );
 
-// ─── HERO PODIUM ───────────────────────────────────────
-const Confetti = ({ show }) => {
-  if (!show) return null;
-  const pieces = Array.from({ length: 22 });
-  const colors = [eHs('session'), eHs('toolkit'), eHs('game'), eHs('event'), eHs('agent')];
+// ── Confetti (CSS-only, decorativo) ────────────────────
+const Confetti = () => {
+  const pieces = Array.from({ length: 20 });
+  const ents = ['session', 'toolkit', 'game', 'event', 'player'];
   return (
     <div aria-hidden="true" style={{ position:'absolute', inset: 0, overflow:'hidden', pointerEvents:'none', zIndex: 1 }}>
       {pieces.map((_, i) => (
-        <span key={i} className="mai-confetti-piece" style={{
-          position:'absolute', top: 0, left: `${(i * 4.6) % 100}%`,
-          width: 7, height: 11, borderRadius: 2, background: colors[i % colors.length],
-          animationDelay: `${(i % 7) * 0.12}s`,
+        <span key={i} className="sp4-confetti" style={{
+          position:'absolute', top: 0, left: `${(i * 5.1) % 100}%`,
+          width: 7, height: 11, borderRadius: 2, background: eHs(ents[i % ents.length]),
+          animationDelay: `${(i % 7) * 0.16}s`,
         }}/>
       ))}
     </div>
   );
 };
 
-const HeroPodium = ({ record, variant, compact }) => {
+// ── HERO PODIUM ────────────────────────────────────────
+const HeroPodium = ({ record, compact, minimal }) => {
   const game = DS.byId[record.game];
-  const isTie = variant === 'tied';
-  const isInProgress = variant === 'inprogress';
-  const isPlanned = variant === 'planned';
   const rs = ranked(record.scores);
-
-  // outcome banner content
-  if (isPlanned) {
-    return (
-      <div style={{ padding: compact ? '22px 16px' : '32px 32px', background:`linear-gradient(135deg, ${eHs('event', 0.12)}, ${eHs('session', 0.1)})`, borderBottom:'1px solid var(--border-light)', position:'relative', overflow:'hidden' }}>
-        <div style={{ position:'relative', display:'flex', alignItems:'center', gap: 14, flexWrap:'wrap' }}>
-          <div style={{ width: compact ? 56 : 68, height: compact ? 56 : 68, borderRadius:'var(--r-lg)', background: game?.cover, display:'flex', alignItems:'center', justifyContent:'center', fontSize: compact ? 28 : 36 }} aria-hidden="true">{game?.coverEmoji}</div>
-          <div style={{ flex: 1, minWidth: 0 }}>
-            <span style={{ display:'inline-flex', alignItems:'center', gap: 5, padding:'2px 8px', borderRadius:'var(--r-pill)', background: eHs('event', 0.14), color: eHs('event'), fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 800, textTransform:'uppercase', letterSpacing:'.08em', border:`1px solid ${eHs('event', 0.3)}` }}>📅 Pianificata</span>
-            <h1 style={{ fontFamily:'var(--f-display)', fontSize: compact ? 22 : 30, fontWeight: 800, letterSpacing:'-.02em', margin:'6px 0 2px', color:'var(--text)' }}>{game?.title}</h1>
-            <div style={{ fontFamily:'var(--f-mono)', fontSize: 12, color:'var(--text-sec)', fontWeight: 700 }}>{record.date} · 👥 {record.playerCount} giocatori</div>
-          </div>
-          <a href="sp4-play-records-edit.html" style={{ padding:'10px 16px', borderRadius:'var(--r-md)', background: eHs('session'), color:'#fff', fontFamily:'var(--f-display)', fontSize: 13, fontWeight: 800, boxShadow:`0 4px 14px ${eHs('session', 0.4)}` }}>▶ Avvia partita</a>
-        </div>
-      </div>
-    );
-  }
-
   const top3 = rs.slice(0, 3);
   const podiumOrder = top3.length >= 3 ? [top3[1], top3[0], top3[2]] : top3.length === 2 ? [top3[1], top3[0]] : [top3[0]];
 
   return (
-    <div style={{ padding: compact ? '20px 16px 18px' : '28px 32px 24px', background:`radial-gradient(circle at 50% -10%, ${eHs('session', 0.18)} 0%, transparent 60%), var(--bg)`, borderBottom:'1px solid var(--border-light)', position:'relative', overflow:'hidden' }}>
-      <Confetti show={!isInProgress}/>
+    <div aria-label={minimal ? 'Esito partita non disponibile' : 'Vincitore partita'} style={{ padding: compact ? '20px 16px 18px' : '28px 32px 24px', background:`radial-gradient(circle at 50% -10%, ${eHs('session', 0.18)} 0%, transparent 60%), var(--bg)`, borderBottom:'1px solid var(--border-light)', position:'relative', overflow:'hidden' }}>
+      {!minimal && <Confetti/>}
       <div style={{ position:'relative', zIndex: 2 }}>
-        {/* badge + title */}
         <div style={{ textAlign:'center', marginBottom: compact ? 14 : 18 }}>
-          {isInProgress ? (
-            <span className="mai-pulse" style={{ display:'inline-flex', alignItems:'center', gap: 5, padding:'3px 10px', borderRadius:'var(--r-pill)', background: eHs('session', 0.14), color: eHs('session'), fontFamily:'var(--f-mono)', fontSize: 10, fontWeight: 800, textTransform:'uppercase', letterSpacing:'.08em', border:`1px solid ${eHs('session', 0.3)}` }}><span style={{ width: 6, height: 6, borderRadius:'50%', background: eHs('session') }}/>In corso · turno {record.turn}</span>
-          ) : isTie ? (
-            <span style={{ display:'inline-flex', alignItems:'center', gap: 5, padding:'3px 10px', borderRadius:'var(--r-pill)', background: eHs('toolkit', 0.16), color: eHs('toolkit'), fontFamily:'var(--f-mono)', fontSize: 10, fontWeight: 800, textTransform:'uppercase', letterSpacing:'.08em', border:`1px solid ${eHs('toolkit', 0.3)}` }}>🤝 Pareggio</span>
+          {minimal ? (
+            <span style={{ display:'inline-flex', alignItems:'center', gap: 5, padding:'3px 10px', borderRadius:'var(--r-pill)', background: eHs('session', 0.12), color: eHs('session'), fontFamily:'var(--f-mono)', fontSize: 10, fontWeight: 800, textTransform:'uppercase', letterSpacing:'.08em', border:`1px solid ${eHs('session', 0.3)}` }}>ℹ️ Esito non disponibile</span>
           ) : (
             <span style={{ display:'inline-flex', alignItems:'center', gap: 5, padding:'3px 10px', borderRadius:'var(--r-pill)', background: eHs('toolkit', 0.16), color: eHs('toolkit'), fontFamily:'var(--f-mono)', fontSize: 10, fontWeight: 800, textTransform:'uppercase', letterSpacing:'.08em', border:`1px solid ${eHs('toolkit', 0.3)}` }}>🏆 Vittoria</span>
           )}
-          <h1 style={{ fontFamily:'var(--f-display)', fontSize: compact ? 22 : 30, fontWeight: 800, letterSpacing:'-.02em', margin:'8px 0 2px', color:'var(--text)' }}>
-            {isInProgress ? `${game?.title} in corso` : isTie ? `Pareggio a ${rs[0].score} punti` : `${rs[0].name} vince ${game?.title}`}
+          <h1 style={{ fontFamily:'var(--f-display)', fontSize: compact ? 22 : 30, fontWeight: 800, letterSpacing:'-.02em', margin:'13px 0 3px', color:'var(--text)' }}>
+            {minimal ? game?.title : `${rs[0].name} vince ${game?.title}`}
           </h1>
           <div style={{ fontFamily:'var(--f-mono)', fontSize: 12, color:'var(--text-sec)', fontWeight: 700 }}>{record.date} · ⏱ {record.duration} · 👥 {record.playerCount} giocatori</div>
         </div>
 
-        {/* podium */}
         <div style={{ display:'flex', justifyContent:'center', alignItems:'flex-end', gap: compact ? 12 : 22 }}>
           {podiumOrder.map((s) => {
             const place = rs.indexOf(s) + 1;
-            const isW = place === 1 && !isInProgress;
-            const sharedWin = isTie && s.score === rs[0].score;
+            const isW = place === 1 && !minimal;
+            const neutral = minimal && place === 1;
             const sz = (place === 1) ? (compact ? 64 : 88) : (compact ? 48 : 64);
             return (
               <div key={s._orig} style={{ display:'flex', flexDirection:'column', alignItems:'center', gap: 4 }}>
-                {(isW || sharedWin) && <span style={{ fontSize: compact ? 16 : 22 }} aria-hidden="true">👑</span>}
+                {isW && <span style={{ fontSize: compact ? 16 : 22 }} aria-hidden="true">👑</span>}
                 <div style={{
                   width: sz, height: sz, borderRadius:'50%',
-                  background:`linear-gradient(135deg, hsl(${pColor(s.playerId)}, 70%, 62%), hsl(${pColor(s.playerId)}, 60%, 42%))`,
-                  color:'#fff', display:'flex', alignItems:'center', justifyContent:'center',
+                  background: neutral ? 'var(--bg-muted)' : `linear-gradient(135deg, hsl(${pColor(s.playerId)}, 70%, 62%), hsl(${pColor(s.playerId)}, 60%, 42%))`,
+                  color: neutral ? 'var(--text-muted)' : '#fff', display:'flex', alignItems:'center', justifyContent:'center',
                   fontFamily:'var(--f-display)', fontSize: place === 1 ? (compact ? 22 : 30) : (compact ? 16 : 22), fontWeight: 800,
-                  border: (isW || sharedWin) ? `3px solid ${eHs('toolkit')}` : `2px solid var(--bg-card)`,
-                  boxShadow: (isW || sharedWin) ? `0 6px 20px ${eHs('toolkit', 0.35)}` : 'var(--shadow-sm)',
+                  border: isW ? `3px solid ${eHs('toolkit')}` : neutral ? '2px dashed var(--border-strong)' : '2px solid var(--bg-card)',
+                  boxShadow: isW ? `0 6px 20px ${eHs('toolkit', 0.35)}` : 'var(--shadow-sm)',
                   position:'relative',
                 }}>
-                  {initialsOf(s)}
-                  {!isInProgress && (
-                    <span style={{ position:'absolute', bottom:-6, right:-6, width: 22, height: 22, borderRadius:'50%', background:'var(--bg-card)', border:`2px solid ${place===1 ? eHs('toolkit') : 'var(--border-strong)'}`, color: place===1 ? eHs('toolkit') : 'var(--text-sec)', display:'flex', alignItems:'center', justifyContent:'center', fontFamily:'var(--f-mono)', fontSize: 10, fontWeight: 800 }}>{place}</span>
-                  )}
+                  {neutral ? '—' : initialsOf(s)}
+                  <span style={{ position:'absolute', bottom:-6, right:-6, width: 22, height: 22, borderRadius:'50%', background:'var(--bg-card)', border:`2px solid ${isW ? eHs('toolkit') : 'var(--border-strong)'}`, color: isW ? eHs('toolkit') : 'var(--text-sec)', display:'flex', alignItems:'center', justifyContent:'center', fontFamily:'var(--f-mono)', fontSize: 10, fontWeight: 800 }}>{place}</span>
                 </div>
-                <div style={{ fontFamily:'var(--f-display)', fontSize: place === 1 ? (compact ? 14 : 16) : (compact ? 12 : 13), fontWeight: 800, color:'var(--text)' }}>{s.name}</div>
-                <div style={{ fontFamily:'var(--f-mono)', fontSize: place === 1 ? (compact ? 18 : 24) : (compact ? 13 : 16), fontWeight: 800, color: (isW || sharedWin) ? eHs('toolkit') : 'var(--text-sec)', fontVariantNumeric:'tabular-nums', lineHeight: 1 }}>{s.score === null ? '—' : s.score}</div>
+                <div style={{ fontFamily:'var(--f-display)', fontSize: place === 1 ? (compact ? 14 : 16) : (compact ? 12 : 13), fontWeight: 800, color:'var(--text)' }}>{neutral ? '—' : s.name}</div>
+                <ScoreVal value={neutral ? null : s.score} style={{ fontFamily:'var(--f-mono)', fontSize: place === 1 ? (compact ? 18 : 24) : (compact ? 13 : 16), fontWeight: 800, color: isW ? eHs('toolkit') : 'var(--text-sec)', fontVariantNumeric:'tabular-nums', lineHeight: 1 }}/>
               </div>
             );
           })}
@@ -137,86 +154,70 @@ const HeroPodium = ({ record, variant, compact }) => {
   );
 };
 
-// ─── CONNECTION BAR (pips) ─────────────────────────────
+// ── INFO BANNER (empty · record minimale) ──────────────
+const InfoBanner = ({ compact }) => (
+  <div role="status" aria-live="polite" style={{
+    display:'flex', alignItems:'center', gap: 10,
+    padding: compact ? '11px 14px' : '12px 18px',
+    background: eHs('session', 0.06), borderLeft:`4px solid ${eHs('session', 0.45)}`,
+    border:'1px solid var(--border-light)', borderLeftWidth: 4, borderRadius:'var(--r-md)',
+  }}>
+    <span aria-hidden="true" style={{ fontSize: compact ? 16 : 18, lineHeight: 1 }}>ℹ️</span>
+    <div style={{ fontFamily:'var(--f-display)', fontSize: compact ? 12.5 : 13.5, fontWeight: 700, color:'var(--text-sec)' }}>
+      Record minimale <span style={{ color:'var(--text-muted)' }}>· alcuni dati non sono stati registrati</span>
+    </div>
+  </div>
+);
+
+// ── CONNECTION BAR (pips game/event/session/player) ────
 const ConnectionBar = ({ record, compact }) => {
   const game = DS.byId[record.game];
   const pips = [
-    { entity:'game', label: game?.title },
-    { entity:'player', label: `${record.playerCount} giocatori` },
-    ...(record.hasChat ? [{ entity:'chat', label: `${record.chatCount} messaggi` }] : [{ entity:'chat', label:'Nessuna chat', empty:true }]),
-    { entity:'event', label: record.date },
+    { entity:'game',    label: game?.title },
+    { entity:'player',  label: `${record.playerCount} giocatori` },
+    { entity:'session', label: record.when || 'Partita' },
+    { entity:'event',   label: record.date },
   ];
   return (
-    <div className="mai-cb-scroll" style={{ display:'flex', alignItems:'center', gap: 6, padding: compact ? '10px 16px' : '12px 32px', background:'var(--bg-card)', borderBottom:'1px solid var(--border-light)', overflowX:'auto' }}>
+    <div className="mai-cb-scroll" style={{ display:'flex', alignItems:'center', gap: 6, padding: compact ? '10px 16px' : '12px 32px', background:'var(--bg-card)', borderBottom:'1px solid var(--border-light)', overflowX: compact ? 'visible' : 'auto', flexWrap: compact ? 'wrap' : 'nowrap' }}>
       <span style={{ fontFamily:'var(--f-mono)', fontSize: 9, fontWeight: 800, color:'var(--text-muted)', textTransform:'uppercase', letterSpacing:'.08em', flexShrink: 0, marginRight: 2 }}>Collegamenti</span>
       {pips.map((p, i) => (
         <span key={i} style={{
           display:'inline-flex', alignItems:'center', gap: 5, padding:'4px 10px', borderRadius:'var(--r-pill)',
-          background: p.empty ? 'transparent' : eHs(p.entity, 0.1),
-          border: p.empty ? `1px dashed ${eHs(p.entity, 0.4)}` : `1px solid ${eHs(p.entity, 0.22)}`,
+          background: eHs(p.entity, 0.1), border:`1px solid ${eHs(p.entity, 0.22)}`,
           color: eHs(p.entity), fontFamily:'var(--f-display)', fontSize: 11.5, fontWeight: 700,
-          whiteSpace:'nowrap', flexShrink: 0, opacity: p.empty ? 0.6 : 1, cursor:'pointer',
+          whiteSpace:'nowrap', flexShrink: 0,
         }}><span aria-hidden="true">{DS.EC[p.entity].em}</span>{p.label}</span>
       ))}
     </div>
   );
 };
 
-// ─── KPI GRID ──────────────────────────────────────────
-const KpiGrid = ({ record, compact }) => {
-  const nums = record.scores.map(s => Number(s.score)).filter(n => !isNaN(n));
-  const max = nums.length ? Math.max(...nums) : 0;
-  const avg = nums.length ? Math.round(nums.reduce((a, b) => a + b, 0) / nums.length) : 0;
-  const spread = nums.length ? max - Math.min(...nums) : 0;
-  const kpis = [
-    { icon:'⏱', label:'Durata', value: record.duration, entity:'event' },
-    { icon:'🏆', label:'Punteggio top', value: max, entity:'session' },
-    { icon:'📊', label:'Media', value: avg, entity:'player' },
-    { icon:'↔', label:'Distacco', value: spread, entity:'game' },
-  ];
-  return (
-    <section>
-      <SectionTitle em="📊">Statistiche partita</SectionTitle>
-      <div style={{ display:'grid', gridTemplateColumns: compact ? 'repeat(2, 1fr)' : 'repeat(4, 1fr)', gap: compact ? 8 : 12 }}>
-        {kpis.map(k => (
-          <div key={k.label} style={{ padding: compact ? '10px 12px' : '14px 16px', background:'var(--bg-card)', border:'1px solid var(--border)', borderRadius:'var(--r-md)', display:'flex', alignItems:'center', gap: 10 }}>
-            <div style={{ width: compact ? 32 : 38, height: compact ? 32 : 38, borderRadius:'var(--r-sm)', background: eHs(k.entity, 0.12), color: eHs(k.entity), display:'flex', alignItems:'center', justifyContent:'center', fontSize: compact ? 15 : 18, flexShrink: 0 }} aria-hidden="true">{k.icon}</div>
-            <div style={{ minWidth: 0 }}>
-              <div style={{ color:'var(--text-muted)', fontSize: 9, fontWeight: 700, fontFamily:'var(--f-mono)', textTransform:'uppercase', letterSpacing:'.08em' }}>{k.label}</div>
-              <div style={{ color:'var(--text)', fontSize: compact ? 17 : 21, fontWeight: 800, fontFamily:'var(--f-display)', fontVariantNumeric:'tabular-nums', lineHeight: 1.1 }}>{k.value}</div>
-            </div>
-          </div>
-        ))}
-      </div>
-    </section>
-  );
-};
-
-// ─── CLASSIFICA (ranking list) ─────────────────────────
-const Classifica = ({ record, compact }) => {
+// ── CLASSIFICA (role=list · podium 1°/2°/3°/4°) ────────
+const Classifica = ({ record, compact, minimal }) => {
   const rs = ranked(record.scores);
-  const max = Math.max(...rs.map(s => Number(s.score) || 0), 1);
+  const nums = rs.map(s => s.score === null ? 0 : Number(s.score));
+  const max = Math.max(...nums, 1);
   return (
     <section>
       <SectionTitle em="🏅" extra={`· ${rs.length} giocatori`}>Classifica</SectionTitle>
-      <div style={{ background:'var(--bg-card)', border:'1px solid var(--border)', borderRadius:'var(--r-lg)', overflow:'hidden' }}>
+      <div role="list" style={{ background:'var(--bg-card)', border:'1px solid var(--border)', borderRadius:'var(--r-lg)', overflow:'hidden' }}>
         {rs.map((s, i) => {
           const place = i + 1;
-          const isW = place === 1 && record.status === 'completed';
-          const p = DS.byId[s.playerId];
-          const pct = Math.round(((Number(s.score) || 0) / max) * 100);
+          const isNull = s.score === null;
+          const isW = place === 1 && !minimal && !isNull;
+          const pct = isNull ? 0 : Math.round((Number(s.score) / max) * 100);
           return (
-            <div key={s._orig} style={{ display:'flex', alignItems:'center', gap: 12, padding:'12px 14px', borderBottom: i < rs.length - 1 ? '1px solid var(--border-light)' : 'none', background: isW ? eHs('session', 0.05) : 'transparent' }}>
-              <span style={{ width: 24, fontFamily:'var(--f-display)', fontSize: 16, fontWeight: 800, color: isW ? eHs('toolkit') : 'var(--text-muted)', textAlign:'center', flexShrink: 0 }}>{place === 1 ? '🥇' : place === 2 ? '🥈' : place === 3 ? '🥉' : place}</span>
-              <span style={{ width: 38, height: 38, borderRadius:'50%', background:`hsl(${pColor(s.playerId)}, 60%, 55%)`, color:'#fff', display:'flex', alignItems:'center', justifyContent:'center', fontFamily:'var(--f-display)', fontWeight: 800, fontSize: 13, flexShrink: 0, border:'2px solid var(--bg-card)' }}>{initialsOf(s)}</span>
+            <div role="listitem" key={s._orig} style={{ display:'flex', alignItems:'center', gap: 12, padding:'12px 14px', borderBottom: i < rs.length - 1 ? '1px solid var(--border-light)' : 'none', background: isW ? eHs('session', 0.05) : 'transparent', opacity: isNull ? 0.62 : 1 }}>
+              <span style={{ width: 24, fontFamily:'var(--f-display)', fontSize: 16, fontWeight: 800, color: isW ? eHs('toolkit') : 'var(--text-muted)', textAlign:'center', flexShrink: 0 }} aria-hidden="true">{place === 1 ? '🥇' : place === 2 ? '🥈' : place === 3 ? '🥉' : place}</span>
+              <span style={{ width: 38, height: 38, borderRadius:'50%', background:`hsl(${pColor(s.playerId)}, 60%, 55%)`, color:'#fff', display:'flex', alignItems:'center', justifyContent:'center', fontFamily:'var(--f-display)', fontWeight: 800, fontSize: 13, flexShrink: 0, border:'2px solid var(--bg-card)' }} aria-hidden="true">{initialsOf(s)}</span>
               <div style={{ flex: 1, minWidth: 0 }}>
-                <div style={{ fontFamily:'var(--f-display)', fontSize: 13.5, fontWeight: 800, color:'var(--text)', display:'flex', alignItems:'center', gap: 6 }}>{p ? p.title : s.name}{isW && <span style={{ fontFamily:'var(--f-mono)', fontSize: 8.5, fontWeight: 800, color: eHs('toolkit'), background: eHs('toolkit', 0.14), padding:'1px 6px', borderRadius:'var(--r-pill)', textTransform:'uppercase', letterSpacing:'.06em' }}>Vincitore</span>}</div>
-                {/* score bar */}
+                <div style={{ fontFamily:'var(--f-display)', fontSize: 13.5, fontWeight: 800, color:'var(--text)', display:'flex', alignItems:'center', gap: 6 }}>{playerTitle(s)}{isW && <span style={{ fontFamily:'var(--f-mono)', fontSize: 8.5, fontWeight: 800, color: eHs('toolkit'), background: eHs('toolkit', 0.14), padding:'1px 6px', borderRadius:'var(--r-pill)', textTransform:'uppercase', letterSpacing:'.06em' }}>Vincitore</span>}</div>
                 <div style={{ marginTop: 5, height: 6, borderRadius:'var(--r-pill)', background:'var(--bg-muted)', overflow:'hidden' }}>
                   <div style={{ width: `${pct}%`, height:'100%', borderRadius:'var(--r-pill)', background: isW ? eHs('toolkit') : eHs('session') }}/>
                 </div>
               </div>
-              <span style={{ fontFamily:'var(--f-mono)', fontSize: 20, fontWeight: 800, color: isW ? eHs('toolkit') : 'var(--text-sec)', fontVariantNumeric:'tabular-nums', flexShrink: 0 }}>{s.score === null ? '—' : s.score}</span>
+              <ScoreVal value={s.score} style={{ fontFamily:'var(--f-mono)', fontSize: 20, fontWeight: 800, color: isW ? eHs('toolkit') : 'var(--text-sec)', fontVariantNumeric:'tabular-nums', flexShrink: 0 }}/>
             </div>
           );
         })}
@@ -225,12 +226,10 @@ const Classifica = ({ record, compact }) => {
   );
 };
 
-// ─── DETTAGLIO PUNTEGGI ────────────────────────────────
+// ── DETTAGLIO PUNTEGGI (tabellare) ─────────────────────
 const ScoringBreakdown = ({ record, compact }) => {
-  // categorie sintetiche per Wingspan-like games (mock realistico)
   const categories = ['Uccelli', 'Bonus', 'Fine round', 'Uova', 'Cibo cache', 'Carte tucked'];
   const rs = ranked(record.scores);
-  // genera split deterministico per ogni giocatore che somma ~ score
   const splitFor = (total) => {
     const weights = [0.32, 0.2, 0.18, 0.14, 0.09, 0.07];
     let remaining = total, out = [];
@@ -254,16 +253,21 @@ const ScoringBreakdown = ({ record, compact }) => {
           </thead>
           <tbody>
             {rs.map((s, i) => {
-              const split = splitFor(Number(s.score) || 0);
-              const isW = i === 0 && record.status === 'completed';
+              const isNull = s.score === null;
+              const split = isNull ? null : splitFor(Number(s.score));
+              const isW = i === 0 && !isNull && record.status === 'completed';
               return (
-                <tr key={s._orig} style={{ borderBottom: i < rs.length - 1 ? '1px solid var(--border-light)' : 'none', background: isW ? eHs('session', 0.04) : 'transparent' }}>
-                  <td style={{ padding:'10px 14px', display:'flex', alignItems:'center', gap: 8 }}>
-                    <span style={{ width: 26, height: 26, borderRadius:'50%', background:`hsl(${pColor(s.playerId)}, 60%, 55%)`, color:'#fff', display:'flex', alignItems:'center', justifyContent:'center', fontFamily:'var(--f-display)', fontWeight: 800, fontSize: 10, flexShrink: 0 }}>{initialsOf(s)}</span>
-                    <span style={{ fontFamily:'var(--f-display)', fontSize: 12.5, fontWeight: 800, color: isW ? eHs('session') : 'var(--text)', whiteSpace:'nowrap' }}>{s.name}{isW && ' 🏆'}</span>
+                <tr key={s._orig} style={{ borderBottom: i < rs.length - 1 ? '1px solid var(--border-light)' : 'none', background: isW ? eHs('session', 0.04) : 'transparent', opacity: isNull ? 0.6 : 1 }}>
+                  <td style={{ padding:'10px 14px' }}>
+                    <span style={{ display:'inline-flex', alignItems:'center', gap: 8 }}>
+                      <span style={{ width: 26, height: 26, borderRadius:'50%', background:`hsl(${pColor(s.playerId)}, 60%, 55%)`, color:'#fff', display:'flex', alignItems:'center', justifyContent:'center', fontFamily:'var(--f-display)', fontWeight: 800, fontSize: 10, flexShrink: 0 }} aria-hidden="true">{initialsOf(s)}</span>
+                      <span style={{ fontFamily:'var(--f-display)', fontSize: 12.5, fontWeight: 800, color: isW ? eHs('session') : 'var(--text)', whiteSpace:'nowrap' }}>{s.name}{isW && ' 🏆'}</span>
+                    </span>
                   </td>
-                  {split.map((v, ci) => <td key={ci} style={{ textAlign:'center', padding:'10px 8px', color:'var(--text-sec)', fontVariantNumeric:'tabular-nums' }}>{v}</td>)}
-                  <td style={{ textAlign:'center', padding:'10px 14px', fontWeight: 800, color: isW ? eHs('session') : 'var(--text)', fontVariantNumeric:'tabular-nums' }}>{s.score}</td>
+                  {categories.map((c, ci) => (
+                    <td key={ci} style={{ textAlign:'center', padding:'10px 8px', color:'var(--text-sec)', fontVariantNumeric:'tabular-nums' }}>{isNull ? <span aria-label="Punteggio non registrato">—</span> : split[ci]}</td>
+                  ))}
+                  <td style={{ textAlign:'center', padding:'10px 14px', fontWeight: 800, color: isW ? eHs('session') : 'var(--text)', fontVariantNumeric:'tabular-nums' }}><ScoreVal value={s.score}/></td>
                 </tr>
               );
             })}
@@ -274,15 +278,15 @@ const ScoringBreakdown = ({ record, compact }) => {
   );
 };
 
-// ─── NOTE ──────────────────────────────────────────────
+// ── NOTE ───────────────────────────────────────────────
 const Notes = ({ record, empty }) => (
   <section>
     <SectionTitle em="📝">Note</SectionTitle>
     {empty ? (
       <div style={{ padding:'22px 16px', borderRadius:'var(--r-lg)', background:'var(--bg-card)', border:'1px dashed var(--border-strong)', textAlign:'center' }}>
         <div style={{ fontSize: 28, marginBottom: 6 }} aria-hidden="true">📝</div>
-        <div style={{ fontFamily:'var(--f-display)', fontSize: 13.5, fontWeight: 800, color:'var(--text)', marginBottom: 3 }}>Nessuna nota</div>
-        <a href="sp4-play-records-edit.html" style={{ fontFamily:'var(--f-display)', fontSize: 12, fontWeight: 700, color: eHs('session') }}>+ Aggiungi una nota</a>
+        <div style={{ fontFamily:'var(--f-display)', fontSize: 13.5, fontWeight: 800, color:'var(--text)', marginBottom: 5 }}>Nessuna nota</div>
+        <a href="sp4-play-records-edit.html" style={{ fontFamily:'var(--f-display)', fontSize: 12, fontWeight: 700, color: eHs('session'), opacity: .8 }}>+ Aggiungi una nota</a>
       </div>
     ) : (
       <div style={{ padding:'14px 16px', borderRadius:'var(--r-lg)', background:'var(--bg-card)', border:'1px solid var(--border)', borderLeft:`3px solid ${eHs('session')}` }}>
@@ -292,176 +296,365 @@ const Notes = ({ record, empty }) => (
   </section>
 );
 
-// ─── BODY ──────────────────────────────────────────────
-const DetailBody = ({ stateOverride, variant, compact }) => {
-  if (stateOverride === 'loading') {
-    return (
-      <div style={{ padding: compact ? 14 : 24, display:'flex', flexDirection:'column', gap: 14 }}>
-        <div className="mai-shimmer" style={{ height: compact ? 200 : 260, borderRadius:'var(--r-xl)', background:'var(--bg-muted)' }}/>
-        <div className="mai-shimmer" style={{ height: 90, borderRadius:'var(--r-lg)', background:'var(--bg-muted)' }}/>
-        <div className="mai-shimmer" style={{ height: 220, borderRadius:'var(--r-lg)', background:'var(--bg-muted)' }}/>
+// ── FOTO ───────────────────────────────────────────────
+const PhotoSection = ({ record, empty, compact }) => (
+  <section>
+    <SectionTitle em="📷">Foto</SectionTitle>
+    {empty ? (
+      <div style={{ padding:'22px 16px', borderRadius:'var(--r-lg)', background:'var(--bg-card)', border:'1px dashed var(--border-strong)', textAlign:'center' }}>
+        <div style={{ fontSize: 28, marginBottom: 6 }} aria-hidden="true">📷</div>
+        <div style={{ fontFamily:'var(--f-display)', fontSize: 13.5, fontWeight: 800, color:'var(--text)', marginBottom: 5 }}>Nessuna foto allegata</div>
+        <a href="sp4-play-records-edit.html" style={{ fontFamily:'var(--f-display)', fontSize: 12, fontWeight: 700, color: eHs('session'), opacity: .8 }}>+ Aggiungi foto</a>
       </div>
-    );
-  }
-  if (stateOverride === 'error') {
-    return (
-      <div style={{ padding:'40px 24px', textAlign:'center', margin: compact ? 14 : 24, background:'hsl(var(--c-danger) / .06)', border:'1px solid hsl(var(--c-danger) / .25)', borderRadius:'var(--r-xl)' }}>
-        <div style={{ fontSize: 32, marginBottom: 8 }} aria-hidden="true">⚠</div>
-        <h3 style={{ fontFamily:'var(--f-display)', fontSize: 16, fontWeight: 800, margin:'0 0 4px', color:'var(--text)' }}>Partita non trovata</h3>
-        <p style={{ fontSize: 12.5, color:'var(--text-muted)', margin:'0 0 14px' }}>Impossibile caricare il dettaglio della partita.</p>
-        <button type="button" style={{ padding:'8px 14px', borderRadius:'var(--r-md)', background:'hsl(var(--c-danger))', color:'#fff', border:'none', fontFamily:'var(--f-display)', fontSize: 12.5, fontWeight: 800, cursor:'pointer' }}>↻ Riprova</button>
-      </div>
-    );
-  }
+    ) : (
+      <figure style={{ margin: 0, borderRadius:'var(--r-lg)', overflow:'hidden', border:'1px solid var(--border)', background:'var(--bg-card)' }}>
+        <div role="img" aria-label={`Foto della partita: ${record.photo.caption}`} style={{ height: compact ? 150 : 200, display:'flex', alignItems:'center', justifyContent:'center', fontSize: compact ? 44 : 58, background:`linear-gradient(135deg, ${eHs('session', 0.14)}, ${eHs('game', 0.12)})` }}>
+          <span aria-hidden="true">{DS.byId[record.game]?.coverEmoji || '🎲'}</span>
+        </div>
+        <figcaption style={{ display:'flex', alignItems:'center', gap: 7, padding:'9px 14px', fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)', fontWeight: 700 }}>
+          <span aria-hidden="true">{record.photo.emoji}</span>{record.photo.caption}
+        </figcaption>
+      </figure>
+    )}
+  </section>
+);
 
-  const record = variant === 'planned' ? DS.byId['pr9']
-    : variant === 'inprogress' ? DS.byId['pr3']
-    : variant === 'tied' ? DS.byId['pr5']
-    : REC;
-  const emptyNotes = stateOverride === 'empty-notes';
+// ── META FOOTER (data registrazione · registratore) ────
+const MetaFooter = ({ record, compact }) => (
+  <div style={{ display:'flex', alignItems:'center', flexWrap:'wrap', gap: compact ? '6px 14px' : '6px 22px', padding: compact ? '14px 16px' : '16px 32px', borderTop:'1px solid var(--border-light)', background:'var(--bg-card)' }}>
+    <span style={{ display:'inline-flex', alignItems:'center', gap: 6, fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)', fontWeight: 700 }}>
+      <span aria-hidden="true" style={{ color: eHs('event') }}>📅</span>Registrata il <strong style={{ color:'var(--text-sec)' }}>{record.registeredOn}</strong>
+    </span>
+    <span style={{ display:'inline-flex', alignItems:'center', gap: 6, fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)', fontWeight: 700 }}>
+      <span aria-hidden="true" style={{ color: eHs('player') }}>👤</span>da <strong style={{ color:'var(--text-sec)' }}>{record.registeredBy}</strong>
+    </span>
+    <span style={{ marginLeft:'auto', fontFamily:'var(--f-mono)', fontSize: 10, color:'var(--text-muted)', fontWeight: 700, letterSpacing:'.04em' }}>#{record.id}</span>
+  </div>
+);
+
+// ── TOP NAV (in-app chrome) ────────────────────────────
+const TopNav = ({ record, compact, loading }) => {
+  const game = record ? DS.byId[record.game] : null;
+  return (
+    <div style={{ display:'flex', alignItems:'center', gap: 10, padding: compact ? '8px 12px' : '10px 24px', background:'var(--glass-bg)', backdropFilter:'blur(12px)', borderBottom:'1px solid var(--border)' }}>
+      <a href="sp4-play-records-index.html" aria-label="Torna alla lista partite" style={{ width: 30, height: 30, borderRadius:'var(--r-md)', background:'var(--bg-card)', border:'1px solid var(--border)', color:'var(--text-sec)', fontSize: 13, fontWeight: 800, display:'flex', alignItems:'center', justifyContent:'center', flexShrink: 0 }}>←</a>
+      {loading ? (
+        <span aria-hidden="true" className="skel" style={{ width: compact ? 96 : 132, height: 20, borderRadius:'var(--r-pill)', background: eHs('session', 0.08) }}/>
+      ) : game ? (
+        <div style={{ display:'inline-flex', alignItems:'center', gap: 5, padding:'2px 8px', borderRadius:'var(--r-pill)', background: eHs('game', 0.1), color: eHs('game'), border:`1px solid ${eHs('game', 0.3)}`, fontFamily:'var(--f-mono)', fontSize: 9.5, fontWeight: 800, textTransform:'uppercase', letterSpacing:'.05em' }}>{game.coverEmoji} {game.title}</div>
+      ) : (
+        <span style={{ fontFamily:'var(--f-mono)', fontSize: 11, fontWeight: 800, color:'var(--text-sec)' }}>Dettaglio partita</span>
+      )}
+      <div style={{ flex: 1 }}/>
+      <a href="sp4-play-records-edit.html" style={{ padding:'6px 12px', borderRadius:'var(--r-md)', background:'var(--bg-card)', border:'1px solid var(--border)', color:'var(--text-sec)', fontFamily:'var(--f-display)', fontSize: 11.5, fontWeight: 700, flexShrink: 0 }}>✎ Modifica</a>
+    </div>
+  );
+};
+
+const PhoneSbar = () => (
+  <div className="phone-sbar" style={{ color:'var(--text)' }}>
+    <span>15:33</span>
+    <div className="ind"><span aria-hidden="true">●●●●</span><span aria-hidden="true">88%</span></div>
+  </div>
+);
+
+const Stack = ({ children, gap = 20 }) => (
+  <div style={{ display:'flex', flexDirection:'column', gap }}>{children}</div>
+);
+
+// ── DETAIL VIEW (responsive: mobile stack / desktop 2-col) ──
+// Mobile 375 : hero → connection bar → [info] → classifica → punteggi → note → foto → meta
+// Desktop 1440: hero + connection bar full-width; 2-col → [classifica] | [punteggi · note · foto]; meta full-width.
+const DetailView = ({ record, compact, minimal, emptyMedia, infoBanner }) => {
+  const classifica = <Classifica record={record} compact={compact} minimal={minimal}/>;
+  const scoring = <ScoringBreakdown record={record} compact={compact}/>;
+  const notes = <Notes record={record} empty={emptyMedia}/>;
+  const photo = <PhotoSection record={record} empty={emptyMedia} compact={compact}/>;
+
+  if (compact) {
+    return (
+      <div style={{ flex: 1, overflowY:'auto', minHeight: 0 }}>
+        <HeroPodium record={record} compact minimal={minimal}/>
+        <ConnectionBar record={record} compact/>
+        <div style={{ padding:'14px 14px 24px', display:'flex', flexDirection:'column', gap: 16 }}>
+          {infoBanner && <InfoBanner compact/>}
+          {classifica}{scoring}{notes}{photo}
+        </div>
+        <MetaFooter record={record} compact/>
+      </div>
+    );
+  }
+  return (
+    <>
+      <HeroPodium record={record} minimal={minimal}/>
+      <ConnectionBar record={record}/>
+      <div style={{ padding:'24px 32px 12px', maxWidth: 1280, margin:'0 auto', width:'100%' }}>
+        {infoBanner && <div style={{ marginBottom: 20 }}><InfoBanner/></div>}
+        <div style={{ display:'grid', gridTemplateColumns:'minmax(0, 1fr) minmax(0, 1fr)', gap: 28, alignItems:'start' }}>
+          <Stack>{classifica}</Stack>
+          <Stack>{scoring}{notes}{photo}</Stack>
+        </div>
+      </div>
+      <MetaFooter record={record}/>
+    </>
+  );
+};
+
+// ── SKELETON PRIMITIVES (loading) ──────────────────────
+const SkelRect = ({ w, h, r, style }) => (
+  <div aria-hidden="true" className="skel" style={{ width: w, height: h, borderRadius: r || 'var(--r-sm)', background: eHs('session', 0.08), flexShrink: 0, ...style }}/>
+);
+
+const SkelClassificaRow = () => (
+  <div aria-hidden="true" style={{ display:'flex', alignItems:'center', gap: 12, padding:'12px 14px', borderBottom:'1px solid var(--border-light)' }}>
+    <SkelRect w={38} h={38} r="var(--r-pill)"/>
+    <div style={{ flex: 1, display:'flex', flexDirection:'column', gap: 7 }}>
+      <SkelRect w="52%" h={13} r="var(--r-xs)"/>
+      <SkelRect w="100%" h={6} r="var(--r-pill)"/>
+    </div>
+    <SkelRect w={34} h={20} r="var(--r-xs)"/>
+  </div>
+);
+
+// ── STATO 01 · DEFAULT ─────────────────────────────────
+// state-01-default — dettaglio completo as-shipped (Marco vince).
+const State01_Default = ({ compact }) => (
+  <div style={{ flex: 1, display:'flex', flexDirection:'column', background:'var(--bg)', minHeight: 0, overflow: compact ? 'hidden' : 'visible' }}>
+    <TopNav record={REC_DEFAULT} compact={compact}/>
+    <DetailView record={REC_DEFAULT} compact={compact}/>
+  </div>
+);
+
+// ── STATO 02 · EMPTY ───────────────────────────────────
+// state-02-empty — record minimale: foto/note assenti, 2 score null, nessun winner.
+const State02_Empty = ({ compact }) => (
+  <div style={{ flex: 1, display:'flex', flexDirection:'column', background:'var(--bg)', minHeight: 0, overflow: compact ? 'hidden' : 'visible' }}>
+    <TopNav record={REC_EMPTY} compact={compact}/>
+    <DetailView record={REC_EMPTY} compact={compact} minimal emptyMedia infoBanner/>
+  </div>
+);
+
+// ── STATO 03 · LOADING ─────────────────────────────────
+// state-03-loading — skeleton primitives. aria-busy sul wrapper, skeleton aria-hidden,
+// screen-reader span. Pulse 0.4→0.8→0.4 (2s) via .skel; reduced-motion → snap.
+const State03_Loading = ({ compact }) => {
+  const body = (
+    <>
+      {/* Header skeleton (podio rect + game pip) */}
+      <div style={{ padding: compact ? '20px 16px' : '28px 32px', borderBottom:'1px solid var(--border-light)', background:`radial-gradient(circle at 50% -10%, ${eHs('session', 0.08)} 0%, transparent 60%), var(--bg)`, display:'flex', flexDirection:'column', alignItems:'center', gap: 12 }}>
+        <SkelRect w={120} h={18} r="var(--r-pill)"/>
+        <SkelRect w={compact ? '70%' : 300} h={compact ? 24 : 30} r="var(--r-md)"/>
+        <div style={{ display:'flex', alignItems:'flex-end', gap: compact ? 12 : 22, marginTop: 8 }}>
+          <SkelRect w={compact ? 48 : 64} h={compact ? 48 : 64} r="var(--r-pill)"/>
+          <SkelRect w={compact ? 64 : 88} h={compact ? 64 : 88} r="var(--r-pill)"/>
+          <SkelRect w={compact ? 48 : 64} h={compact ? 48 : 64} r="var(--r-pill)"/>
+        </div>
+      </div>
+      {/* ConnectionBar skeleton (4 chip) */}
+      <div style={{ display:'flex', gap: 6, padding: compact ? '10px 16px' : '12px 32px', background:'var(--bg-card)', borderBottom:'1px solid var(--border-light)' }}>
+        {[0,1,2,3].map(i => <SkelRect key={i} w={compact ? 64 : 96} h={26} r="var(--r-pill)"/>)}
+      </div>
+    </>
+  );
+  const classificaSkel = (
+    <div>
+      <SkelRect w={120} h={14} r="var(--r-xs)" style={{ marginBottom: 10 }}/>
+      <div style={{ background:'var(--bg-card)', border:'1px solid var(--border)', borderRadius:'var(--r-lg)', overflow:'hidden' }}>
+        {[0,1,2,3].map(i => <SkelClassificaRow key={i}/>)}
+      </div>
+    </div>
+  );
+  const notesSkel = (
+    <div>
+      <SkelRect w={70} h={14} r="var(--r-xs)" style={{ marginBottom: 10 }}/>
+      <div style={{ padding:'14px 16px', background:'var(--bg-card)', border:'1px solid var(--border)', borderRadius:'var(--r-lg)', display:'flex', flexDirection:'column', gap: 8 }}>
+        <SkelRect w="100%" h={11} r="var(--r-xs)"/>
+        <SkelRect w="92%" h={11} r="var(--r-xs)"/>
+        <SkelRect w="64%" h={11} r="var(--r-xs)"/>
+      </div>
+    </div>
+  );
+  const photoSkel = (
+    <div>
+      <SkelRect w={64} h={14} r="var(--r-xs)" style={{ marginBottom: 10 }}/>
+      <SkelRect w="100%" h={compact ? 150 : 200} r="var(--r-lg)"/>
+    </div>
+  );
+  const srSpan = (
+    <span style={{ position:'absolute', width: 1, height: 1, padding: 0, margin: -1, overflow:'hidden', clip:'rect(0 0 0 0)', whiteSpace:'nowrap', border: 0 }}>
+      Caricamento dettaglio partita…
+    </span>
+  );
 
   return (
-    <div style={{ padding: compact ? '14px 14px 32px' : '24px 32px 64px', display:'flex', flexDirection:'column', gap: compact ? 18 : 24, maxWidth: 1080, margin:'0 auto', width:'100%' }}>
-      <KpiGrid record={record} compact={compact}/>
-      <Classifica record={record} compact={compact}/>
-      {variant !== 'planned' && <ScoringBreakdown record={record} compact={compact}/>}
-      <Notes record={record} empty={emptyNotes}/>
-      {variant !== 'inprogress' && variant !== 'planned' && (
-        <section style={{ padding:'16px 18px', borderRadius:'var(--r-xl)', background:`linear-gradient(135deg, ${eHs('game', 0.1)}, ${eHs('session', 0.1)})`, border:`1px solid ${eHs('game', 0.3)}`, display:'flex', alignItems:'center', justifyContent:'space-between', gap: 14, flexWrap:'wrap' }}>
-          <div style={{ flex: 1, minWidth: 200 }}>
-            <h3 style={{ fontFamily:'var(--f-display)', fontSize: 16, fontWeight: 800, color:'var(--text)', margin:'0 0 3px' }}>🎲 Pronti per la rivincita?</h3>
-            <p style={{ fontFamily:'var(--f-body)', fontSize: 12.5, color:'var(--text-sec)', margin: 0 }}>Stessi giocatori e gioco.</p>
-          </div>
-          <a href="sp4-play-records-new.html" style={{ padding:'10px 16px', borderRadius:'var(--r-md)', background: eHs('session'), color:'#fff', fontFamily:'var(--f-display)', fontSize: 13, fontWeight: 800, boxShadow:`0 4px 14px ${eHs('session', 0.4)}` }}>▶ Registra rivincita</a>
-        </section>
+    <div aria-busy="true" style={{ flex: 1, display:'flex', flexDirection:'column', background:'var(--bg)', minHeight: 0, overflow: compact ? 'hidden' : 'visible' }}>
+      <TopNav loading compact={compact}/>
+      {srSpan}
+      {body}
+      {compact ? (
+        <div style={{ padding:'14px 14px 24px', display:'flex', flexDirection:'column', gap: 16 }}>
+          {classificaSkel}{notesSkel}{photoSkel}
+        </div>
+      ) : (
+        <div style={{ padding:'24px 32px 40px', maxWidth: 1280, margin:'0 auto', width:'100%', display:'grid', gridTemplateColumns:'minmax(0, 1fr) minmax(0, 1fr)', gap: 28, alignItems:'start' }}>
+          <Stack>{classificaSkel}</Stack>
+          <Stack>{notesSkel}{photoSkel}</Stack>
+        </div>
       )}
     </div>
   );
 };
 
-// ─── FRAMES ────────────────────────────────────────────
-const PhoneSbar = () => (
-  <div className="phone-sbar" style={{ color:'var(--text)' }}><span>15:33</span><div className="ind"><span aria-hidden="true">●●●●</span><span aria-hidden="true">88%</span></div></div>
-);
+// ── STATO 04 · ERROR ───────────────────────────────────
+// state-04-error — banner alert + retry + area vuota (torna lista) + dismiss.
+const State04_Error = ({ compact }) => (
+  <div style={{ flex: 1, display:'flex', flexDirection:'column', background:'var(--bg)', minHeight: 0, overflow: compact ? 'hidden' : 'visible' }}>
+    <TopNav record={null} compact={compact}/>
 
-const TopNav = ({ record, compact }) => {
-  const game = DS.byId[record.game];
-  return (
-    <div style={{ display:'flex', alignItems:'center', gap: 10, padding: compact ? '8px 12px' : '10px 24px', background:'var(--glass-bg)', backdropFilter:'blur(12px)', borderBottom:'1px solid var(--border)' }}>
-      <a href="sp4-play-records-index.html" aria-label="Indietro" style={{ width: 30, height: 30, borderRadius:'var(--r-md)', background:'var(--bg-card)', border:'1px solid var(--border)', color:'var(--text-sec)', fontSize: 13, fontWeight: 800, display:'flex', alignItems:'center', justifyContent:'center' }}>←</a>
-      <div style={{ display:'inline-flex', alignItems:'center', gap: 5, padding:'2px 8px', borderRadius:'var(--r-pill)', background: eHs('game', 0.1), color: eHs('game'), border:`1px solid ${eHs('game', 0.3)}`, fontFamily:'var(--f-mono)', fontSize: 9.5, fontWeight: 800, textTransform:'uppercase', letterSpacing:'.05em' }}>{game?.coverEmoji} {game?.title}</div>
-      <div style={{ flex: 1 }}/>
-      <a href="sp4-play-records-edit.html" style={{ padding:'6px 12px', borderRadius:'var(--r-md)', background:'var(--bg-card)', border:'1px solid var(--border)', color:'var(--text-sec)', fontFamily:'var(--f-display)', fontSize: 11.5, fontWeight: 700 }}>✎ Modifica</a>
-    </div>
-  );
-};
-
-const recordFor = (variant) => variant === 'planned' ? DS.byId['pr9'] : variant === 'inprogress' ? DS.byId['pr3'] : variant === 'tied' ? DS.byId['pr5'] : REC;
-
-const PhoneScreen = ({ stateOverride, variant }) => {
-  const record = recordFor(variant);
-  return (
-    <>
-      <PhoneSbar/>
-      <div style={{ flex: 1, overflow:'auto', display:'flex', flexDirection:'column', background:'var(--bg)' }}>
-        <TopNav record={record} compact/>
-        {!stateOverride && <><HeroPodium record={record} variant={variant} compact/><ConnectionBar record={record} compact/></>}
-        <DetailBody stateOverride={stateOverride} variant={variant} compact/>
+    {/* Banner errore full-width */}
+    <div role="alert" style={{ display:'flex', alignItems:'flex-start', gap: compact ? 10 : 14, padding: compact ? '12px 16px' : '14px 32px', background: eHs('event', 0.08), borderLeft:`4px solid ${eHs('event', 0.6)}`, borderBottom:'1px solid var(--border-light)' }}>
+      <span aria-hidden="true" style={{ fontSize: compact ? 18 : 20, lineHeight: 1.3 }}>⚠️</span>
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{ fontFamily:'var(--f-display)', fontSize: compact ? 13 : 14.5, fontWeight: 800, color:'var(--text)' }}>Impossibile caricare il dettaglio della partita</div>
+        <div style={{ fontFamily:'var(--f-body)', fontSize: 12, color:'var(--text-sec)', marginTop: 2, fontWeight: 500 }}>Record non trovato (404) · Verifica la connessione e riprova</div>
       </div>
-    </>
-  );
-};
-
-const DesktopFrameInner = ({ stateOverride, variant }) => {
-  const record = recordFor(variant);
-  return (
-    <div style={{ display:'flex', flexDirection:'column', minHeight: 720, background:'var(--bg)' }}>
-      <TopNav record={record}/>
-      {!stateOverride && <><HeroPodium record={record} variant={variant}/><ConnectionBar record={record}/></>}
-      <DetailBody stateOverride={stateOverride} variant={variant}/>
+      <button type="button" aria-label="Riprova caricamento dettaglio partita" style={{ padding:'7px 14px', borderRadius:'var(--r-md)', background:'transparent', color: eHs('event'), border:`1px solid ${eHs('event', 0.5)}`, fontFamily:'var(--f-display)', fontSize: 12, fontWeight: 800, cursor:'pointer', display:'inline-flex', alignItems:'center', gap: 5, whiteSpace:'nowrap', flexShrink: 0 }}><span aria-hidden="true">↻</span>Riprova</button>
     </div>
-  );
-};
 
-const PhoneShell = ({ label, desc, children }) => (
-  <div style={{ display:'flex', flexDirection:'column', alignItems:'center', gap: 10 }}>
-    <div style={{ fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-sec)', textTransform:'uppercase', letterSpacing:'.08em', fontWeight: 700 }}>{label}</div>
-    <div className="phone">{children}</div>
-    {desc && <div style={{ fontSize: 11, color:'var(--text-muted)', maxWidth: 340, textAlign:'center', lineHeight: 1.55 }}>{desc}</div>}
+    {/* Area vuota */}
+    <div style={{ flex: 1, padding: compact ? '28px 16px' : '56px 32px', display:'flex', alignItems:'flex-start', justifyContent:'center', overflowY:'auto' }}>
+      <div style={{ display:'flex', flexDirection:'column', alignItems:'center', textAlign:'center', maxWidth: 380 }}>
+        <div aria-hidden="true" style={{ width: 56, height: 56, borderRadius:'50%', background:'var(--bg-muted)', display:'flex', alignItems:'center', justifyContent:'center', fontSize: 26, marginBottom: 12 }}>🃏</div>
+        <div style={{ fontFamily:'var(--f-display)', fontSize: 14.5, fontWeight: 800, color:'var(--text-sec)', marginBottom: 6 }}>Nessun dato disponibile</div>
+        <a href="sp4-play-records-index.html" aria-label="Torna alla lista partite" style={{ fontFamily:'var(--f-display)', fontSize: 13, fontWeight: 800, color: eHs('session'), display:'inline-flex', alignItems:'center', gap: 5 }}><span aria-hidden="true">←</span>Torna alla lista partite</a>
+      </div>
+    </div>
+
+    {/* Footer dismiss */}
+    <div style={{ padding: compact ? '12px 16px' : '14px 32px', borderTop:'1px solid var(--border-light)', display:'flex', justifyContent:'center' }}>
+      <button type="button" style={{ background:'transparent', border:'none', color:'var(--text-muted)', fontFamily:'var(--f-display)', fontSize: 12.5, fontWeight: 700, cursor:'pointer', textDecoration:'underline', textUnderlineOffset: 3 }}>Chiudi</button>
+    </div>
   </div>
 );
 
-const DesktopFrame = ({ label, desc, dark, children }) => (
-  <div style={{ display:'flex', flexDirection:'column', alignItems:'center', gap: 12, width:'100%' }} data-theme={dark ? 'dark' : undefined}>
-    <div style={{ fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-sec)', textTransform:'uppercase', letterSpacing:'.08em', fontWeight: 700 }}>{label}{dark && <span style={{ color: eHs('session'), marginLeft: 6 }}>· dark</span>}</div>
+// ── STATO 05 · SSE — SKIPPED ───────────────────────────
+// Il detail /play-records/[id] NON è SSE-driven: è una read-only fetch-once
+// (nessuna sottoscrizione eventi live). Nessun State05_SSE renderizzato
+// (cfr. G7 SessionStateRenderer: lo stato `sse` si applica solo alle view con
+// streaming live). Ghost link disabled in nav → "05 · SSE · skip".
+
+// ═══════════════════════════════════════════════════════
+// ── GALLERY — frames + nav + sections ──────────────────
+// ═══════════════════════════════════════════════════════
+const MobileFrame = ({ children }) => (
+  <div style={{ display:'flex', flexDirection:'column', alignItems:'center', gap: 8 }}>
+    <div className="frame-tag">Mobile · 375</div>
+    <div className="phone">
+      <PhoneSbar/>
+      <div style={{ flex: 1, overflow:'hidden', display:'flex', flexDirection:'column', background:'var(--bg)' }}>{children}</div>
+    </div>
+  </div>
+);
+
+const DesktopFrame = ({ children }) => (
+  <div style={{ display:'flex', flexDirection:'column', gap: 8, flex: 1, minWidth: 0 }}>
+    <div className="frame-tag">Desktop · 1440</div>
     <div className="desktop-frame">
-      <div className="desktop-bar"><span className="traffic"/><span className="traffic"/><span className="traffic"/><span className="url">meepleai.app/play-records/pr1</span></div>
-      {children}
+      <div className="desktop-bar">
+        <span className="traffic"/><span className="traffic"/><span className="traffic"/>
+        <span className="url">meepleai.app/play-records/pr1</span>
+      </div>
+      <div style={{ display:'flex', flexDirection:'column', minHeight: 660, background:'var(--bg)' }}>{children}</div>
     </div>
-    {desc && <div style={{ fontSize: 11, color:'var(--text-muted)', maxWidth: 720, textAlign:'center', lineHeight: 1.55 }}>{desc}</div>}
   </div>
 );
 
-const MOBILE_STATES = [
-  { id:'m1', variant:'default', label:'01 · Default · vittoria', desc:'Hero podio 3-place con confetti + corona toolkit 1°. ConnectionBar pip. KPI + classifica + dettaglio + note + rivincita.' },
-  { id:'m2', variant:'tied', label:'02 · Pareggio', desc:'Banner "🤝 Pareggio" + 2 corone shared 1°. Hero score-based title.' },
-  { id:'m3', variant:'inprogress', label:'03 · In corso', desc:'Badge "In corso · turno" pulsante, no confetti, no rivincita. Classifica provvisoria.' },
-  { id:'m4', variant:'planned', label:'04 · Pianificata (empty)', desc:'Pre-partita: hero ridotto entity-event + CTA Avvia. Nessun punteggio ancora.' },
-  { id:'m5', variant:'default', state:'empty-notes', label:'05 · Note vuote', desc:'Sezione note in empty-state + CTA Aggiungi nota.' },
-  { id:'m6', state:'loading', label:'06 · Loading', desc:'Skeleton hero 200 + KPI + tabella shimmer.' },
-  { id:'m7', state:'error', label:'07 · Error', desc:'Partita non trovata + CTA Riprova in danger color.' },
+// 2 viewport per stato (Mobile 375 + Desktop 1440). Tema light/dark globale via
+// <html data-theme> (toggle in nav) — token dark scoping su :root, niente wrapper annidati.
+const StateMatrix = ({ Comp }) => (
+  <div className="matrix">
+    <div className="matrix-row">
+      <MobileFrame><Comp compact/></MobileFrame>
+      <DesktopFrame><Comp/></DesktopFrame>
+    </div>
+  </div>
+);
+
+const STATES = [
+  { id:'state-01-default', num:'01', title:'Default', sub:'Dettaglio completo as-shipped: hero podio (Marco vince) + ConnectionBar + classifica 1°–4° + dettaglio punteggi tabellare + note + foto allegata + meta footer. Stato base, invariato.', Comp: State01_Default },
+  { id:'state-02-empty',   num:'02', title:'Empty',   sub:'Record minimale: hero con vincitore "—", banner info role="status", classifica con score parziali (null → "—"), note e foto in empty-state con CTA dimmed.', Comp: State02_Empty },
+  { id:'state-03-loading', num:'03', title:'Loading', sub:'Fetch dettaglio in corso: skeleton header (podio + pip) + ConnectionBar + classifica + note + foto. aria-busy, skeleton aria-hidden, pulse 2s (snap con reduced-motion).', Comp: State03_Loading },
+  { id:'state-04-error',   num:'04', title:'Error',   sub:'Errore fetch (404 / rete): banner role="alert" + Riprova, area vuota con link "Torna alla lista partite", footer "Chiudi".', Comp: State04_Error },
+];
+
+const NAV = [
+  { id:'state-01-default', label:'01 · Default' },
+  { id:'state-02-empty',   label:'02 · Empty' },
+  { id:'state-03-loading', label:'03 · Loading' },
+  { id:'state-04-error',   label:'04 · Error' },
 ];
 
 function ThemeToggle() {
-  const [dark, setDark] = useState(false);
-  useEffect(() => { document.documentElement.setAttribute('data-theme', dark ? 'dark' : 'light'); }, [dark]);
+  const initial = (() => { try { return localStorage.getItem('sp4-pr-theme') === 'dark'; } catch (e) { return false; } })();
+  const [dark, setDark] = useState(initial);
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', dark ? 'dark' : 'light');
+    try { localStorage.setItem('sp4-pr-theme', dark ? 'dark' : 'light'); } catch (e) {}
+  }, [dark]);
   return (
-    <button onClick={() => setDark(d => !d)} className="theme-toggle" aria-label={dark ? 'Tema chiaro' : 'Tema scuro'}>
+    <button type="button" className="theme-toggle" onClick={() => setDark(d => !d)} aria-pressed={dark}
+      aria-label={dark ? 'Passa a tema chiaro' : 'Passa a tema scuro'}>
       <span aria-hidden="true">{dark ? '🌙' : '☀️'}</span><span>{dark ? 'Dark' : 'Light'}</span>
     </button>
   );
 }
 
+function GalleryNav() {
+  return (
+    <nav className="gallery-nav" aria-label="Stati canonici">
+      <div className="gallery-nav-brand"><span aria-hidden="true">🎯</span> SP4 · /play-records/[id]</div>
+      <div className="gallery-nav-links">
+        {NAV.map(n => <a key={n.id} href={`#${n.id}`}>{n.label}</a>)}
+      </div>
+      <a className="gallery-nav-ghost" href="#state-05-sse-skipped" aria-disabled="true" title="state-05-sse: skipped — detail non SSE-driven (fetch-once read-only)">05 · SSE · skip</a>
+      <ThemeToggle/>
+    </nav>
+  );
+}
+
+function StateSection({ id, num, title, sub, Comp }) {
+  return (
+    <section id={id} className="state-section" data-screen-label={id}>
+      <header className="state-head">
+        <div className="state-num">{num}</div>
+        <div className="state-head-text">
+          <h2>{title}</h2>
+          <p>{sub}</p>
+        </div>
+        <code className="state-anchor">#{id}</code>
+      </header>
+      <StateMatrix Comp={Comp}/>
+    </section>
+  );
+}
+
 function App() {
   return (
-    <div className="stage">
-      <ThemeToggle/>
-      <div className="stage-wrap">
-        <div style={{ fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)', textTransform:'uppercase', letterSpacing:'.08em', marginBottom: 8 }}>SP4 · /play-records · Detail 🏆</div>
-        <h1>Play records — /play-records/[id]</h1>
-        <p className="lead">
-          Pagina dettaglio partita. <strong>Hero podio 3-place</strong> con confetti CSS-only + ConnectionBar pip cliccabili.
-          Body: KPI grid · <strong>classifica</strong> (rank/avatar/punti + barra) · <strong>dettaglio punteggi</strong> (tabella per-categoria) · note · rivincita.
-          Varianti: vittoria · pareggio · in corso · pianificata. Tone festoso ma elegante, prefers-reduced-motion rispettato.
-        </p>
+    <div className="gallery">
+      <GalleryNav/>
+      <div className="gallery-body">
+        <header className="gallery-intro">
+          <div className="kicker">SP4 · /play-records/[id] · Detail 🏆 — canonical states</div>
+          <h1>Dettaglio partita — Stati canonici</h1>
+          <p className="lead">
+            Vista read-only dettaglio partita allineata al pattern <strong>G7 SessionStateRenderer</strong> (PR 2357).
+            4 stati canonici × viewport mobile&nbsp;375 / desktop&nbsp;1440 (8 frame), × tema light/dark via toggle = 16 combinazioni.
+            Entity dominante <strong>session 🎯</strong>; colori esclusivamente da token <code>--c-*</code> via <code>eHs()</code>.
+            Lo stato <code>state-05-sse</code> è intenzionalmente <strong>saltato</strong> (detail non SSE-driven, fetch-once).
+          </p>
+        </header>
 
-        <div className="section-label">Mobile · 375 — 7 stati</div>
-        <div className="phones-grid">
-          {MOBILE_STATES.map(s => (
-            <PhoneShell key={s.id} label={s.label} desc={s.desc}>
-              <PhoneScreen stateOverride={s.state} variant={s.variant || 'default'}/>
-            </PhoneShell>
-          ))}
-        </div>
-
-        <div className="section-label">Desktop · 1280 — 5 stati chiave</div>
-        <div style={{ display:'flex', flexDirection:'column', gap: 36 }}>
-          <DesktopFrame label="08 · Desktop · Default vittoria" desc="Container 1080. Podio hero 88/64 + corona. ConnectionBar. KPI 4-col + classifica + tabella dettaglio + note + rivincita.">
-            <DesktopFrameInner variant="default"/>
-          </DesktopFrame>
-          <DesktopFrame label="09 · Desktop · Pareggio" desc="2 corone shared 1°, titolo score-based.">
-            <DesktopFrameInner variant="tied"/>
-          </DesktopFrame>
-          <DesktopFrame label="10 · Desktop · Dark mode" dark desc="Confetti glow + accent entity-session/toolkit verificati in dark.">
-            <DesktopFrameInner variant="default"/>
-          </DesktopFrame>
-          <DesktopFrame label="11 · Desktop · In corso" desc="Badge live, classifica provvisoria, no rivincita.">
-            <DesktopFrameInner variant="inprogress"/>
-          </DesktopFrame>
-          <DesktopFrame label="12 · Desktop · Pianificata (empty)" desc="Pre-partita, hero entity-event + CTA Avvia, nessun punteggio.">
-            <DesktopFrameInner variant="planned"/>
-          </DesktopFrame>
-        </div>
+        {STATES.map(s => <StateSection key={s.id} {...s}/>)}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Mockup 3 di 5 del cluster Tier 2 P1 (umbrella #2342 US-INT-2c).

Estende il mockup read-only \`sp4-play-records-detail.{html,jsx,fidelity.json}\` con i 3 nuovi stati canonici (empty + loading + error) allineati al G7 SessionStateRenderer pattern (PR #2357).

## Stati aggiunti (semantic read-only)

| Anchor | Component | Semantic | A11y |
|---|---|---|---|
| \`state-02-empty\` | \`State02_Empty\` | Record minimale: dati core only, no foto, no note, alcuni score \`null\`. Hero podio con winner "—". Banner info top + sezioni foto/note empty-state con CTA dimmed. | \`role="status"\` + \`aria-live="polite"\` + \`aria-label="Punteggio non registrato"\` (su null) + \`aria-label="Esito partita non disponibile"\` hero |
| \`state-03-loading\` | \`State03_Loading\` | Skeleton primitives: header (podio + pip) + ConnectionBar + classifica + note + foto. Pulse 2s. | \`aria-busy="true"\` wrapper + skeleton \`aria-hidden="true"\` + screen-reader span |
| \`state-04-error\` | \`State04_Error\` | Errore fetch (404 record not found / errore rete): banner full-width + retry + area vuota con link "Torna alla lista partite" + footer dismiss. | \`role="alert"\` + \`aria-label="Riprova caricamento dettaglio partita"\` + \`aria-label="Torna alla lista partite"\` |

## state-05-sse SKIPPED

Detail view NON è SSE-driven (fetch-once read-only). Skip esplicito con commento JSX + nav ghost link.

## state-01-default INVARIATO

Dettaglio completo as-shipped (Wingspan, vincitore Marco). Zero regressioni layout.

## FREEZE compliance

- ✅ Zero hex hardcoded — 4× \`color:'#fff'\` su \`background: eHs(...)\` o \`background: hsl(\${pColor(...)})\` (avatar player) — pattern \`.e-bg\` esentato.
- ✅ Zero asset BGG/hosting esterno user-side (ban #2123).
- ✅ Token-only via \`tokens.css\`.
- ✅ \`pnpm lint:bgg-mockups\` clean (NOT in violations baseline).

## A11y completa

- Hero \`aria-label\` condizionale (vincitore/esito non disponibile)
- Classifica \`role="list"\` + items \`role="listitem"\`
- Score \`null\` ovunque con \`aria-label="Punteggio non registrato"\`
- Foto \`role="img"\` con caption semantico
- Loading: \`aria-busy\` wrapper + screen-reader span
- Error: \`role="alert"\` + retry + link torna-lista
- Tutti i back button con \`aria-label\` semantico

## Motion

- \`prefers-reduced-motion\` → snap senza pulse
- Mobile 375 (single-column stack) + Desktop 1440 (2-col split)
- Gallery scaffold sticky nav (4 link + ThemeToggle + SSE skip ghost) allineata Mockup 1+2

## File changed

| File | Change |
|---|---|
| \`sp4-play-records-detail.html\` | shell + gallery scaffold |
| \`sp4-play-records-detail.jsx\` | 4 React components + Gallery App + GalleryNav + ThemeToggle |
| \`sp4-play-records-detail.fidelity.json\` | \`states_covered: [default, empty, loading, error]\`; \`viewports: [mobile, desktop]\` |

## Test plan

- [x] \`pnpm lint:bgg-mockups\` clean
- [x] \`pnpm lint:tokens:mockups\` no regressions
- [x] \`pnpm typecheck\` pass
- [x] Manual grep zero BGG mentions
- [ ] Reviewer: browser test 4 anchor + ThemeToggle + responsive + SR navigation

## Refs

- Issue: #2361 (Tier 2 P1 umbrella #2342 US-INT-2c)
- Mockup precedenti: #2481 (index), #2484 (new)
- Pattern: G7 SessionStateRenderer PR #2357

🤖 Generated with [Claude Code](https://claude.com/claude-code)