### PR TITLE
feat(session-live): #2483 wire real turnOrderType into TurnIndicatorRenderer

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/DTOs/SessionDto.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/DTOs/SessionDto.cs
@@ -25,6 +25,15 @@ public record SessionDto
     /// ObjectivesScoreData, or RankingScoreData). FE deserialises via Zod schema.
     /// </summary>
     public string? ScoreData { get; init; }
+
+    /// <summary>
+    /// Turn mode discriminator derived from the game's published GameToolkit TurnTemplate.
+    /// Mirrors <see cref="Api.BoundedContexts.GameToolkit.Domain.Enums.TurnOrderType"/>.
+    /// Null when the session has no associated game or the game has no published toolkit
+    /// with a TurnTemplate configured. Static for the session lifetime — never changes
+    /// mid-session (no SignalR event needed). Issue #2483.
+    /// </summary>
+    public string? TurnOrderType { get; init; }
 }
 
 public record ParticipantDto

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/GetActiveSessionQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/GetActiveSessionQueryHandler.cs
@@ -1,7 +1,9 @@
+using System.Text.Json;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Api.BoundedContexts.SessionTracking.Application.DTOs;
 using Api.BoundedContexts.SessionTracking.Application.Queries;
+using Api.BoundedContexts.GameToolkit.Domain.Enums;
 using Api.Infrastructure;
 using Api.Infrastructure.Entities.SessionTracking;
 
@@ -59,6 +61,11 @@ public class GetActiveSessionQueryHandler : IRequestHandler<GetActiveSessionQuer
             Timestamp = e.Timestamp
         }).ToList();
 
+        // Path B (#2483): derive TurnOrderType from the game's published toolkit.
+        // Static for the session lifetime — no new Session field, no migration, no SignalR event.
+        var turnOrderType = await ResolveTurnOrderTypeAsync(session.GameId, cancellationToken)
+            .ConfigureAwait(false);
+
         return new SessionDto
         {
             Id = session.Id,
@@ -72,8 +79,46 @@ public class GetActiveSessionQueryHandler : IRequestHandler<GetActiveSessionQuer
             FinalizedAt = session.FinalizedAt,
             ScoringType = session.ScoringType,
             ScoreData = session.ScoreData,
+            TurnOrderType = turnOrderType,
             Participants = participants,
             Scores = scores
         };
+    }
+
+    /// <summary>
+    /// Looks up the TurnOrderType from the game's first published GameToolkit TurnTemplate.
+    /// Returns null when no game is linked, no published toolkit exists, or the toolkit
+    /// has no TurnTemplate configured.
+    /// </summary>
+    private async Task<string?> ResolveTurnOrderTypeAsync(Guid? gameId, CancellationToken cancellationToken)
+    {
+        if (gameId == null)
+            return null;
+
+        var turnTemplateJson = await _context.GameToolkits
+            .Where(t => t.GameId == gameId && t.IsPublished && t.TurnTemplateJson != null)
+            .Select(t => t.TurnTemplateJson)
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        if (string.IsNullOrEmpty(turnTemplateJson))
+            return null;
+
+        try
+        {
+            using var doc = JsonDocument.Parse(turnTemplateJson);
+            if (doc.RootElement.TryGetProperty("turnOrderType", out var prop) &&
+                prop.TryGetInt32(out var value) &&
+                Enum.IsDefined(typeof(TurnOrderType), value))
+            {
+                return ((TurnOrderType)value).ToString();
+            }
+        }
+        catch (JsonException)
+        {
+            // Malformed JSON — treat as no turn template rather than throwing.
+        }
+
+        return null;
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Queries/GetActiveSessionQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Queries/GetActiveSessionQueryHandlerTests.cs
@@ -1,5 +1,6 @@
 using Api.BoundedContexts.SessionTracking.Application.Queries;
 using Api.Infrastructure;
+using Api.Infrastructure.Entities.GameToolkit;
 using Api.Infrastructure.Entities.SessionTracking;
 using Api.SharedKernel.Application.Services;
 using Api.Tests.Constants;
@@ -72,5 +73,125 @@ public sealed class GetActiveSessionQueryHandlerTests : IDisposable
         dto.Should().NotBeNull();
         dto!.ScoringType.Should().Be("Points");
         dto.ScoreData.Should().Be(scoreDataJson);
+    }
+
+    // -------------------------------------------------------------------------
+    // Issue #2483: TurnOrderType wiring (Path B — derived from GameToolkit)
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task Handle_WhenSessionGameHasToolkitWithTurnTemplate_ReturnsTurnOrderType()
+    {
+        // Arrange — game has a published toolkit whose TurnTemplate is Sequential (int=3).
+        var userId = Guid.NewGuid();
+        var gameId = Guid.NewGuid();
+
+        _db.GameToolkits.Add(new GameToolkitEntity
+        {
+            Id = Guid.NewGuid(),
+            GameId = gameId,
+            Name = "Test Toolkit",
+            CreatedByUserId = userId,
+            IsPublished = true,
+            RowVersion = [0],
+            // camelCase JSON matching JsonNamingPolicy.CamelCase used by repository
+            TurnTemplateJson = "{\"turnOrderType\":3,\"phases\":[]}"
+        });
+
+        _db.SessionTrackingSessions.Add(new SessionEntity
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            GameId = gameId,
+            SessionCode = "TOT001",
+            SessionType = "Generic",
+            Status = "Active",
+            SessionDate = DateTime.UtcNow,
+            CreatedAt = DateTime.UtcNow,
+            CreatedBy = userId,
+            ScoringType = "Points",
+            ScoreData = "{}"
+        });
+        await _db.SaveChangesAsync();
+
+        // Act
+        var dto = await _handler.Handle(new GetActiveSessionQuery(userId), CancellationToken.None);
+
+        // Assert
+        dto.Should().NotBeNull();
+        dto!.TurnOrderType.Should().Be("Sequential");
+    }
+
+    [Fact]
+    public async Task Handle_WhenSessionGameHasNoMatchingToolkit_TurnOrderTypeIsNull()
+    {
+        // Arrange — session linked to a game that has no published toolkit at all.
+        var userId = Guid.NewGuid();
+        var gameWithNoToolkit = Guid.NewGuid();
+
+        _db.SessionTrackingSessions.Add(new SessionEntity
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            GameId = gameWithNoToolkit,
+            SessionCode = "TOT002",
+            SessionType = "Generic",
+            Status = "Active",
+            SessionDate = DateTime.UtcNow,
+            CreatedAt = DateTime.UtcNow,
+            CreatedBy = userId,
+            ScoringType = "Points",
+            ScoreData = "{}"
+        });
+        await _db.SaveChangesAsync();
+
+        // Act
+        var dto = await _handler.Handle(new GetActiveSessionQuery(userId), CancellationToken.None);
+
+        // Assert
+        dto.Should().NotBeNull();
+        dto!.TurnOrderType.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_WhenToolkitHasNoTurnTemplate_TurnOrderTypeIsNull()
+    {
+        // Arrange — toolkit exists for the game but TurnTemplateJson is null.
+        var userId = Guid.NewGuid();
+        var gameId = Guid.NewGuid();
+
+        _db.GameToolkits.Add(new GameToolkitEntity
+        {
+            Id = Guid.NewGuid(),
+            GameId = gameId,
+            Name = "Toolkit No Turn",
+            CreatedByUserId = userId,
+            IsPublished = true,
+            RowVersion = [0],
+            TurnTemplateJson = null
+        });
+
+        _db.SessionTrackingSessions.Add(new SessionEntity
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            GameId = gameId,
+            SessionCode = "TOT003",
+            SessionType = "Generic",
+            Status = "Active",
+            SessionDate = DateTime.UtcNow,
+            CreatedAt = DateTime.UtcNow,
+            CreatedBy = userId,
+            ScoringType = "Points",
+            ScoreData = "{}"
+        });
+        await _db.SaveChangesAsync();
+
+        // Act
+        var dto = await _handler.Handle(new GetActiveSessionQuery(userId), CancellationToken.None);
+
+        // Assert
+        dto.Should().NotBeNull();
+        dto!.TurnOrderType.Should().BeNull();
     }
 }

--- a/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx
@@ -105,6 +105,7 @@ import { useSession } from '@/hooks/queries/useActiveSessions';
 import { useTranslation } from '@/hooks/useTranslation';
 import { composeSessionLiveState } from '@/lib/session-live/compose-session-live-state';
 import { mapConnectionState } from '@/lib/session-live/map-connection-state';
+import { mapTurnDataToTurnState } from '@/lib/session-live/map-turn-data-to-turn-state';
 import { hasRequiredRole } from '@/lib/session-live/participant-role';
 import { mapScoreDataToEndgameSummary } from '@/lib/session-live/score-data-to-endgame-summary';
 import {
@@ -388,6 +389,10 @@ export function SessionLiveView(): ReactElement {
     };
   }, [fixture, sessionQuery.data, liveStream.events]);
 
+  // #2483 Task 2: reactive selector for turnOrderType — must be declared before
+  // turnRendererState useMemo (which appears in the i18n labels section below).
+  const storeTurnOrderType = useLiveSessionStore(s => s.turnOrderType);
+
   // ── Navigation handlers ───────────────────────────────────────────────────
 
   /** Build a new search string preserving params not in overrides. */
@@ -603,15 +608,18 @@ export function SessionLiveView(): ReactElement {
     [t, intl.messages]
   );
 
+  // #2483 Task 4: replace hardcoded RoundRobin with real turnOrderType from store.
+  // mapTurnDataToTurnState is pure and handles null/unknown safely (→ 'None' fallback).
+  // storeTurnOrderType in deps so the memo re-fires when the DTO hydration effect runs.
   const turnRendererState = useMemo<TurnState>(
-    (): TurnState => ({
-      type: 'RoundRobin',
-      round: activeSession?.currentTurn ?? 0,
-      totalRounds: activeSession?.totalTurns ?? 0,
-      activePlayerId: activeSession?.activePlayerId ?? '',
-      playOrder: activeSession?.players.map(p => p.id) ?? [],
-    }),
-    [activeSession]
+    () =>
+      mapTurnDataToTurnState(storeTurnOrderType, {
+        currentTurn: activeSession?.currentTurn,
+        totalTurns: activeSession?.totalTurns,
+        activePlayerId: activeSession?.activePlayerId,
+        players: activeSession?.players,
+      }),
+    [storeTurnOrderType, activeSession]
   );
 
   const turnRendererPlayers = useMemo<ReadonlyArray<TurnPlayerInfo>>(

--- a/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx
@@ -850,6 +850,7 @@ export function SessionLiveView(): ReactElement {
   // is forwarded to ScoreTabContent via the shared useLiveSessionStore.
 
   const setScoringConfig = useLiveSessionStore(s => s.setScoringConfig);
+  const setTurnOrderType = useLiveSessionStore(s => s.setTurnOrderType);
 
   // #2431: polymorphic endgame summary — selectors feed mapScoreDataToEndgameSummary
   // below. Subscribed reactively so the EndgameDialog refreshes as scoreData
@@ -880,6 +881,15 @@ export function SessionLiveView(): ReactElement {
       });
     }
   }, [sessionQuery.data, setScoringConfig]);
+
+  // #2483 Task 2: REST hydration for turnOrderType (path B — static, no SignalR).
+  // Populate once from the DTO. No race guard needed: no SignalR event exists for
+  // turnOrderType (it never changes during the session).
+  useEffect(() => {
+    const dto = sessionQuery.data;
+    if (dto?.turnOrderType == null) return;
+    setTurnOrderType(dto.turnOrderType as import('@/lib/session-live/turn-state').TurnOrderType);
+  }, [sessionQuery.data, setTurnOrderType]);
 
   // ── G5c #2376: Zustand toolkit renderer store ─────────────────────────────
   // Store starts empty; real hydration via useQuery(['toolkit', sessionId]) is a

--- a/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/__tests__/SessionLiveView.test.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/__tests__/SessionLiveView.test.tsx
@@ -1340,3 +1340,87 @@ describe('SessionLiveView — Block B (#2389) scoring wire-up', () => {
     expect(container.querySelector('[data-slot="scoring-panel-points"]')).not.toBeNull();
   });
 });
+
+// ─── #2483 Task 4 — turnRendererState wired from store ────────────────────────
+
+describe('SessionLiveView — #2483 Task 4: TurnIndicatorRenderer from store', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.keys(searchParamsMap).forEach(k => delete searchParamsMap[k]);
+    // Always show the 'turn' tab so TurnIndicatorRenderer is visible.
+    searchParamsMap['tab'] = 'turn';
+    mockParamsId = 'session-abc-123';
+    IS_VISUAL_TEST_BUILD_MOCK = false;
+    useSessionMock.mockReturnValue({
+      data: MOCK_SESSION_DTO,
+      isLoading: false,
+      isError: false,
+      isSuccess: true,
+      error: null,
+      refetch: vi.fn(),
+    });
+    useSessionLiveStreamMock.mockReturnValue({ ...mockLiveStreamResult });
+  });
+
+  it('renders Sequential branch when store.turnOrderType=Sequential', () => {
+    act(() => {
+      useLiveSessionStore.getState().setTurnOrderType('Sequential');
+    });
+    const { container } = renderWithIntl(<SessionLiveView />);
+    // Sequential branch must be present; RoundRobin must NOT be present.
+    expect(container.querySelector('[data-slot="turn-branch-sequential"]')).not.toBeNull();
+    expect(container.querySelector('[data-slot="turn-branch-round-robin"]')).toBeNull();
+  });
+
+  it('renders RoundRobin branch when store.turnOrderType=RoundRobin', () => {
+    act(() => {
+      useLiveSessionStore.getState().setTurnOrderType('RoundRobin');
+    });
+    const { container } = renderWithIntl(<SessionLiveView />);
+    expect(container.querySelector('[data-slot="turn-branch-round-robin"]')).not.toBeNull();
+  });
+
+  it('renders None branch (safe fallback) when store.turnOrderType=null — no hardcoded RoundRobin', () => {
+    // turnOrderType is null by default (reset() was called in global beforeEach).
+    const { container } = renderWithIntl(<SessionLiveView />);
+    // Must NOT render round-robin silently.
+    expect(container.querySelector('[data-slot="turn-branch-round-robin"]')).toBeNull();
+    // Must render the explicit None fallback.
+    expect(container.querySelector('[data-slot="turn-branch-none"]')).not.toBeNull();
+  });
+
+  it('renders Realtime branch when store.turnOrderType=Realtime', () => {
+    act(() => {
+      useLiveSessionStore.getState().setTurnOrderType('Realtime');
+    });
+    const { container } = renderWithIntl(<SessionLiveView />);
+    expect(container.querySelector('[data-slot="turn-branch-realtime"]')).not.toBeNull();
+  });
+
+  it('renders None branch when store.turnOrderType=None', () => {
+    act(() => {
+      useLiveSessionStore.getState().setTurnOrderType('None');
+    });
+    const { container } = renderWithIntl(<SessionLiveView />);
+    expect(container.querySelector('[data-slot="turn-branch-none"]')).not.toBeNull();
+  });
+
+  it('renders None branch when DTO supplies turnOrderType=Sequential (hydration path)', () => {
+    // Test the full hydration path: DTO carries turnOrderType → store → renderer.
+    const dtoWithTurnOrder: GameSessionDto = {
+      ...MOCK_SESSION_DTO,
+      turnOrderType: 'Sequential',
+    };
+    useSessionMock.mockReturnValue({
+      data: dtoWithTurnOrder,
+      isLoading: false,
+      isError: false,
+      isSuccess: true,
+      error: null,
+      refetch: vi.fn(),
+    });
+    const { container } = renderWithIntl(<SessionLiveView />);
+    expect(container.querySelector('[data-slot="turn-branch-sequential"]')).not.toBeNull();
+    expect(container.querySelector('[data-slot="turn-branch-round-robin"]')).toBeNull();
+  });
+});

--- a/apps/web/src/lib/api/schemas/games.schemas.ts
+++ b/apps/web/src/lib/api/schemas/games.schemas.ts
@@ -110,6 +110,9 @@ export const GameSessionDtoSchema = z.object({
   // Both fields are nullable strings (scoreData is a JSON-encoded payload).
   scoringType: z.string().nullable().optional(),
   scoreData: z.string().nullable().optional(),
+  // #2483 Task 1 BE: turnOrderType derived from the game's toolkit (static for the session).
+  // Null when the game has no toolkit wired. Path B: no SignalR event, populated from DTO.
+  turnOrderType: z.string().nullable().optional(),
 });
 
 export type GameSessionDto = z.infer<typeof GameSessionDtoSchema>;

--- a/apps/web/src/lib/session-live/__tests__/map-turn-data-to-turn-state.test.ts
+++ b/apps/web/src/lib/session-live/__tests__/map-turn-data-to-turn-state.test.ts
@@ -1,0 +1,176 @@
+/**
+ * mapTurnDataToTurnState — unit tests. Issue #2483 Task 3.
+ *
+ * Covers:
+ *   - All 7 FE TurnOrderType variants (1:1 BE names, explicit mapping table)
+ *   - BE-only "Free" string → FE 'None' mapping
+ *   - Unknown string → UnknownBranch-safe fallback { type: 'None' }
+ *   - null input → fallback { type: 'None' }
+ *   - Per-variant fields (round/totalRounds/activePlayerId/playOrder for RoundRobin;
+ *     phases/activePhaseIndex for Sequential/Custom/Simultaneous; etc.)
+ *
+ * mapScoreDataToPanelData pattern: pure function, no mocks needed.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { mapTurnDataToTurnState } from '../map-turn-data-to-turn-state';
+import type { TurnState } from '../turn-state';
+
+// ─── Shared session data stub ─────────────────────────────────────────────────
+
+const SESSION_DATA = {
+  currentTurn: 3,
+  totalTurns: 10,
+  activePlayerId: 'player-001',
+  players: [
+    { id: 'player-001', name: 'Alice' },
+    { id: 'player-002', name: 'Bob' },
+  ],
+} as const;
+
+const PLAY_ORDER = ['player-001', 'player-002'];
+
+// ─── RoundRobin ───────────────────────────────────────────────────────────────
+
+describe('mapTurnDataToTurnState — RoundRobin', () => {
+  it('returns RoundRobin state with round/totalRounds/activePlayerId/playOrder', () => {
+    const result = mapTurnDataToTurnState('RoundRobin', SESSION_DATA);
+    expect(result.type).toBe('RoundRobin');
+    if (result.type !== 'RoundRobin') return;
+    expect(result.round).toBe(SESSION_DATA.currentTurn);
+    expect(result.totalRounds).toBe(SESSION_DATA.totalTurns);
+    expect(result.activePlayerId).toBe(SESSION_DATA.activePlayerId);
+    expect(result.playOrder).toEqual(PLAY_ORDER);
+  });
+});
+
+// ─── Sequential ───────────────────────────────────────────────────────────────
+
+describe('mapTurnDataToTurnState — Sequential', () => {
+  it('returns Sequential state with phases + activePhaseIndex', () => {
+    const result = mapTurnDataToTurnState('Sequential', SESSION_DATA);
+    expect(result.type).toBe('Sequential');
+    if (result.type !== 'Sequential') return;
+    expect(Array.isArray(result.phases)).toBe(true);
+    expect(typeof result.activePhaseIndex).toBe('number');
+  });
+
+  it('activePhaseIndex is bounded to phases array length', () => {
+    const result = mapTurnDataToTurnState('Sequential', SESSION_DATA);
+    if (result.type !== 'Sequential') return;
+    expect(result.activePhaseIndex).toBeGreaterThanOrEqual(0);
+    // phases length must be >= 1 so that activePhaseIndex is valid
+    expect(result.phases.length).toBeGreaterThanOrEqual(1);
+    expect(result.activePhaseIndex).toBeLessThan(result.phases.length);
+  });
+});
+
+// ─── Simultaneous ─────────────────────────────────────────────────────────────
+
+describe('mapTurnDataToTurnState — Simultaneous', () => {
+  it('returns Simultaneous state', () => {
+    const result = mapTurnDataToTurnState('Simultaneous', SESSION_DATA);
+    expect(result.type).toBe('Simultaneous');
+  });
+});
+
+// ─── Realtime ────────────────────────────────────────────────────────────────
+
+describe('mapTurnDataToTurnState — Realtime', () => {
+  it('returns { type: "Realtime" }', () => {
+    const result = mapTurnDataToTurnState('Realtime', SESSION_DATA);
+    expect(result).toEqual({ type: 'Realtime' });
+  });
+});
+
+// ─── None ────────────────────────────────────────────────────────────────────
+
+describe('mapTurnDataToTurnState — None', () => {
+  it('returns { type: "None" }', () => {
+    const result = mapTurnDataToTurnState('None', SESSION_DATA);
+    expect(result).toEqual({ type: 'None' });
+  });
+});
+
+// ─── Custom ───────────────────────────────────────────────────────────────────
+
+describe('mapTurnDataToTurnState — Custom', () => {
+  it('returns Custom state with phases + activePhaseIndex', () => {
+    const result = mapTurnDataToTurnState('Custom', SESSION_DATA);
+    expect(result.type).toBe('Custom');
+    if (result.type !== 'Custom') return;
+    expect(Array.isArray(result.phases)).toBe(true);
+    expect(typeof result.activePhaseIndex).toBe('number');
+  });
+});
+
+// ─── FirstPlayerToken ─────────────────────────────────────────────────────────
+
+describe('mapTurnDataToTurnState — FirstPlayerToken', () => {
+  it('returns FirstPlayerToken state with round/totalRounds/tokenHolderId/playOrder', () => {
+    const result = mapTurnDataToTurnState('FirstPlayerToken', SESSION_DATA);
+    expect(result.type).toBe('FirstPlayerToken');
+    if (result.type !== 'FirstPlayerToken') return;
+    expect(result.round).toBe(SESSION_DATA.currentTurn);
+    expect(result.totalRounds).toBe(SESSION_DATA.totalTurns);
+    expect(result.tokenHolderId).toBe(SESSION_DATA.activePlayerId);
+    expect(result.playOrder).toEqual(PLAY_ORDER);
+  });
+});
+
+// ─── BE "Free" → FE "None" mapping ───────────────────────────────────────────
+
+describe('mapTurnDataToTurnState — BE "Free" string', () => {
+  it('maps BE "Free" to FE None variant', () => {
+    const result = mapTurnDataToTurnState('Free', SESSION_DATA);
+    expect(result.type).toBe('None');
+  });
+});
+
+// ─── Unknown string → safe None fallback ─────────────────────────────────────
+
+describe('mapTurnDataToTurnState — unknown string', () => {
+  it('maps an unknown BE string to safe None fallback', () => {
+    const result = mapTurnDataToTurnState('TotallyInventedType', SESSION_DATA);
+    expect(result.type).toBe('None');
+  });
+
+  it('safe None fallback passes as valid TurnState type', () => {
+    const result: TurnState = mapTurnDataToTurnState('???', SESSION_DATA);
+    expect(result.type).toBe('None');
+  });
+});
+
+// ─── null input ───────────────────────────────────────────────────────────────
+
+describe('mapTurnDataToTurnState — null', () => {
+  it('maps null to safe None fallback', () => {
+    const result = mapTurnDataToTurnState(null, SESSION_DATA);
+    expect(result.type).toBe('None');
+  });
+
+  it('null with no session data also returns None fallback', () => {
+    const result = mapTurnDataToTurnState(null, null);
+    expect(result.type).toBe('None');
+  });
+});
+
+// ─── null session data ────────────────────────────────────────────────────────
+
+describe('mapTurnDataToTurnState — null session data', () => {
+  it('handles null sessionData gracefully for RoundRobin', () => {
+    const result = mapTurnDataToTurnState('RoundRobin', null);
+    expect(result.type).toBe('RoundRobin');
+    if (result.type !== 'RoundRobin') return;
+    expect(result.round).toBe(0);
+    expect(result.totalRounds).toBe(0);
+    expect(result.activePlayerId).toBe('');
+    expect(result.playOrder).toEqual([]);
+  });
+
+  it('handles null sessionData gracefully for Sequential', () => {
+    const result = mapTurnDataToTurnState('Sequential', null);
+    expect(result.type).toBe('Sequential');
+  });
+});

--- a/apps/web/src/lib/session-live/map-turn-data-to-turn-state.ts
+++ b/apps/web/src/lib/session-live/map-turn-data-to-turn-state.ts
@@ -1,0 +1,135 @@
+/**
+ * mapTurnDataToTurnState — pure adapter from BE turnOrderType string to FE
+ * TurnState discriminated union (renderer input).
+ *
+ * Issue #2483 Task 3 — wires the static turnOrderType from useLiveSessionStore
+ * into SessionLiveView's TurnIndicatorRenderer.
+ *
+ * ## BE → FE mapping table
+ *
+ * | BE string       | FE TurnState.type  | Notes                               |
+ * |-----------------|--------------------|-------------------------------------|
+ * | "RoundRobin"    | 'RoundRobin'       | 1:1                                  |
+ * | "Sequential"    | 'Sequential'       | 1:1                                  |
+ * | "Simultaneous"  | 'Simultaneous'     | 1:1                                  |
+ * | "Realtime"      | 'Realtime'         | 1:1                                  |
+ * | "None"          | 'None'             | 1:1                                  |
+ * | "Custom"        | 'Custom'           | 1:1                                  |
+ * | "Free"          | 'None'             | BE legacy alias; normalised to None  |
+ * | null            | 'None'             | Safe fallback (no toolkit wired)     |
+ * | unknown string  | 'None'             | Safe fallback (future BE enum value) |
+ *
+ * Note: "FirstPlayerToken" is a FE-only variant (not produced by the current BE
+ * path B). The type exists in TurnOrderType for future compatibility; the mapping
+ * table includes it for completeness (if the BE ever sends it, it passes through
+ * 1:1). The fallback for truly unknown values uses 'None' — an explicit, neutral
+ * variant that renders a readable "no active turn" UI rather than silently
+ * impersonating a different turn mode.
+ *
+ * ## Per-variant fields
+ *
+ * Fields are populated from the sessionData object where available. When
+ * sessionData is null (no REST data yet), sensible zero defaults are used.
+ * The adapter never throws — it is defensive by design.
+ *
+ * Pure function: no side effects, no implicit imports, deterministic.
+ */
+
+import type { TurnState } from './turn-state';
+
+// ─── Session data subset ──────────────────────────────────────────────────────
+
+/**
+ * Minimal session data shape consumed by the adapter.
+ * Compatible with both `LiveSessionFixture` and the composed liveState.
+ */
+export interface TurnSessionData {
+  readonly currentTurn?: number;
+  readonly totalTurns?: number;
+  readonly activePlayerId?: string;
+  readonly players?: ReadonlyArray<{ readonly id: string; readonly name: string }>;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const SAFE_FALLBACK: TurnState = { type: 'None' };
+
+function extractPlayOrder(sessionData: TurnSessionData | null | undefined): ReadonlyArray<string> {
+  return sessionData?.players?.map(p => p.id) ?? [];
+}
+
+// ─── Exported adapter ────────────────────────────────────────────────────────
+
+/**
+ * Map a BE-supplied turnOrderType string (or null) into a concrete `TurnState`
+ * that TurnIndicatorRenderer can dispatch on.
+ *
+ * @param turnOrderType - Raw string from SessionDto.turnOrderType or store field. May be null.
+ * @param sessionData   - Current session data for per-variant fields (round, playOrder, etc.).
+ *                        Pass null/undefined when the session data is not yet available.
+ * @returns A valid `TurnState` — never null/undefined.
+ */
+export function mapTurnDataToTurnState(
+  turnOrderType: string | null | undefined,
+  sessionData: TurnSessionData | null | undefined
+): TurnState {
+  const currentTurn = sessionData?.currentTurn ?? 0;
+  const totalTurns = sessionData?.totalTurns ?? 0;
+  const activePlayerId = sessionData?.activePlayerId ?? '';
+  const playOrder = extractPlayOrder(sessionData);
+
+  // Normalise BE-only alias before the switch.
+  const normalised = turnOrderType === 'Free' ? 'None' : turnOrderType;
+
+  switch (normalised) {
+    case 'RoundRobin':
+      return {
+        type: 'RoundRobin',
+        round: currentTurn,
+        totalRounds: totalTurns,
+        activePlayerId,
+        playOrder,
+      };
+
+    case 'Sequential':
+      // Sequential phases come from the toolkit; not available in the live session
+      // data at this level. Provide a single synthetic phase keyed on currentTurn
+      // so the renderer has a non-empty array to display.
+      return {
+        type: 'Sequential',
+        phases: [`Fase ${currentTurn > 0 ? currentTurn : 1}`],
+        activePhaseIndex: 0,
+      };
+
+    case 'Simultaneous':
+      return { type: 'Simultaneous' };
+
+    case 'Realtime':
+      return { type: 'Realtime' };
+
+    case 'None':
+      return { type: 'None' };
+
+    case 'Custom':
+      return {
+        type: 'Custom',
+        phases: [`Fase ${currentTurn > 0 ? currentTurn : 1}`],
+        activePhaseIndex: 0,
+      };
+
+    case 'FirstPlayerToken':
+      // FE-only type; pass through if BE ever produces it.
+      return {
+        type: 'FirstPlayerToken',
+        round: currentTurn,
+        totalRounds: totalTurns,
+        tokenHolderId: activePlayerId,
+        playOrder,
+      };
+
+    default:
+      // Unknown BE string or null — safe neutral fallback.
+      // 'None' renders an explicit "no active turn" UI (not a silent fake type).
+      return SAFE_FALLBACK;
+  }
+}

--- a/apps/web/src/lib/stores/__tests__/live-session-store.test.ts
+++ b/apps/web/src/lib/stores/__tests__/live-session-store.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, beforeEach } from 'vitest';
 
 import { useLiveSessionStore } from '@/lib/stores/live-session-store';
+import type { TurnOrderType } from '@/lib/session-live/turn-state';
 
 describe('useLiveSessionStore — Block A #2389 contract evolution', () => {
   beforeEach(() => {
@@ -87,5 +88,43 @@ describe('useLiveSessionStore — Block A #2389 contract evolution', () => {
     });
     useLiveSessionStore.getState().resolveProposal('unknown-id', true);
     expect(useLiveSessionStore.getState().pendingProposals).toHaveLength(1);
+  });
+
+  // #2483 Task 2 — turnOrderType field
+  it('initial state — turnOrderType is null', () => {
+    expect(useLiveSessionStore.getState().turnOrderType).toBeNull();
+  });
+
+  it('setTurnOrderType writes the turnOrderType value', () => {
+    useLiveSessionStore.getState().setTurnOrderType('Sequential');
+    expect(useLiveSessionStore.getState().turnOrderType).toBe('Sequential');
+  });
+
+  it('setTurnOrderType(null) clears the value', () => {
+    useLiveSessionStore.getState().setTurnOrderType('RoundRobin');
+    useLiveSessionStore.getState().setTurnOrderType(null);
+    expect(useLiveSessionStore.getState().turnOrderType).toBeNull();
+  });
+
+  it('reset() clears turnOrderType to null', () => {
+    useLiveSessionStore.getState().setTurnOrderType('Custom');
+    useLiveSessionStore.getState().reset();
+    expect(useLiveSessionStore.getState().turnOrderType).toBeNull();
+  });
+
+  it('setTurnOrderType accepts all valid TurnOrderType variants', () => {
+    const variants: TurnOrderType[] = [
+      'RoundRobin',
+      'Sequential',
+      'Simultaneous',
+      'Realtime',
+      'None',
+      'Custom',
+      'FirstPlayerToken',
+    ];
+    for (const variant of variants) {
+      useLiveSessionStore.getState().setTurnOrderType(variant);
+      expect(useLiveSessionStore.getState().turnOrderType).toBe(variant);
+    }
   });
 });

--- a/apps/web/src/lib/stores/live-session-store.ts
+++ b/apps/web/src/lib/stores/live-session-store.ts
@@ -11,6 +11,7 @@ import { create } from 'zustand';
 import { devtools } from 'zustand/middleware';
 
 import type { ScoreDataByType, ScoreType } from '@/components/sessions/score-strategies/types';
+import type { TurnOrderType } from '@/lib/session-live/turn-state';
 
 export interface PlayerInfo {
   id: string;
@@ -59,6 +60,13 @@ interface LiveSessionState {
   scoringType: ScoreType | null;
   scoreData: ScoreDataByType[ScoreType] | null;
   /**
+   * Turn order type for the session — populated from the REST DTO on initial load.
+   * Static for the session lifecycle (path B, no SignalR event).
+   * Null until the DTO is loaded (or if the session has no toolkit wired).
+   * Issue #2483 Task 2.
+   */
+  turnOrderType: TurnOrderType | null;
+  /**
    * Rate-limit deadline (Unix timestamp in ms). `null` when not rate-limited.
    * Set by `ScoreTabContent` on 429 response (Date.now() + 30000).
    * Persists across tab change (ScoreTabContent unmount/remount) so the
@@ -79,6 +87,8 @@ interface LiveSessionState {
     scoringType: T;
     scoreData: ScoreDataByType[T];
   }) => void;
+  /** Sets the turn order type from the REST DTO. Issue #2483 Task 2. */
+  setTurnOrderType: (type: TurnOrderType | null) => void;
   setRateLimitedUntil: (ts: number | null) => void;
   addProposal: (proposal: ScoreProposal) => void;
   resolveProposal: (proposalId: string, accepted: boolean) => void;
@@ -92,6 +102,7 @@ const initialState: Omit<
   LiveSessionState,
   | 'setSession'
   | 'setScoringConfig'
+  | 'setTurnOrderType'
   | 'setRateLimitedUntil'
   | 'addProposal'
   | 'resolveProposal'
@@ -108,6 +119,7 @@ const initialState: Omit<
   players: [],
   scoringType: null,
   scoreData: null,
+  turnOrderType: null,
   rateLimitedUntil: null,
   pendingProposals: [],
   disputes: [],
@@ -125,6 +137,8 @@ export const useLiveSessionStore = create<LiveSessionState>()(
 
       setScoringConfig: ({ scoringType, scoreData }) =>
         set({ scoringType, scoreData }, false, 'setScoringConfig'),
+
+      setTurnOrderType: type => set({ turnOrderType: type }, false, 'setTurnOrderType'),
 
       setRateLimitedUntil: ts => set({ rateLimitedUntil: ts }, false, 'setRateLimitedUntil'),
 

--- a/docs/superpowers/plans/2026-06-22-issue-2483-turnordertype-wiring.md
+++ b/docs/superpowers/plans/2026-06-22-issue-2483-turnordertype-wiring.md
@@ -1,0 +1,81 @@
+# Wire real turnOrderType into TurnIndicatorRenderer — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`).
+
+**Goal:** Sostituire il placeholder hardcoded `type: 'RoundRobin'` in `SessionLiveView` con il `turnOrderType` reale, alimentando `TurnIndicatorRenderer` (G5b, già fatto) dai dati della session.
+
+**Architecture:** BE source = **B (derive dal toolkit) con fallback ad A (field Session + migration + SignalR event)** — deciso in Task 1. FE: store field + adapter + view wiring. Replica il pattern G5a (scoringType, #2389/#2430).
+
+**Tech Stack:** .NET 9 (SessionTracking BC, EF Core, SignalR `GameStateHub`) · Next.js 16 · Zustand (`useLiveSessionStore`) · Vitest · xUnit.
+
+**Spec:** `docs/superpowers/specs/2026-06-22-issue-2483-turnordertype-wiring-design.md`
+
+---
+
+## Template G5a (scoringType) — riferimenti file:line (l'esecutore li legge)
+- BE DTO: `apps/api/src/Api/BoundedContexts/SessionTracking/Application/DTOs/SessionDto.cs:21,27` (`ScoringType`/`ScoreData`)
+- BE query handler: `…/Application/Queries/GetActiveSessionQueryHandler.cs:62-76` (costruisce il DTO)
+- BE event+handler+hub (path A): `…/Domain/Events/SessionScoresUpdatedEvent.cs`, `…/Application/EventHandlers/SessionScoresUpdatedSignalRHandler.cs`, `Api/Hubs/GameStateHub.cs:317-325`
+- BE Session aggregate: `…/Domain/Entities/Session.cs:112,453-463` (`ScoringType` + `SetScores`)
+- FE store: `apps/web/src/lib/stores/live-session-store.ts:59-81` (`scoringType` + `setScoringConfig`)
+- FE adapter: `apps/web/src/lib/session-live/score-data-to-panel-data.ts:35-108` (`mapScoreDataToPanelData`)
+- FE SignalR (path A): `apps/web/src/lib/domain-hooks/useSignalrSession.ts:49-143` (`'ScoringConfigured'`)
+- FE view: `apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx` (scoringPanelData → `ScoringPanelRenderer`; turnRendererState hardcoded `:606-615`)
+- FE types: `apps/web/src/lib/session-live/turn-state.ts:12-58` (`TurnOrderType` union + `TurnState`)
+- BE enum: `apps/api/src/Api/BoundedContexts/GameToolkit/Domain/Enums/TurnOrderType.cs:10-20` (7 values)
+
+---
+
+### Task 1 (BE): decidi B vs A ed esponi `turnOrderType` nel session DTO
+
+**Files:**
+- Read: `GetActiveSessionQueryHandler.cs`, `Session.cs`, `Game` aggregate + `GameToolkit` aggregate (cerca la FK `Game → toolkit` e `GameToolkit.TurnOrderType`), `SessionDto.cs`
+- Modify: `SessionDto.cs` (+ `string? TurnOrderType`), `GetActiveSessionQueryHandler.cs`
+- (path A only) Create: `SessionTurnOrderTypeUpdatedEvent.cs` + `SessionTurnOrderTypeUpdatedSignalRHandler.cs`; Modify `Session.cs` (+ field + `SetTurnOrderType`) + `GameStateHub.cs` + EF migration
+- Test: `GetActiveSessionQueryHandlerTests` (+ handler test if A)
+
+- [ ] **Step 1 — Decidi B vs A.** Verifica se il query handler può risolvere `GameToolkit.TurnOrderType` per il game della session (catena `Session.GameId → Game → GameToolkit.TurnOrderType`). Cerca la relazione Game↔GameToolkit. **Se accessibile pulito → B** (deriva nel handler, no nuovo field/migration/event). **Se no → A** (field `Session.TurnOrderType` + migration + `SetTurnOrderType` + event + SignalR handler + hub, replicando G5a). Documenta la scelta nel commit.
+- [ ] **Step 2 — Test (TDD).** Scrivi il test che il DTO espone `TurnOrderType` (B: dal toolkit del game; A: dal field). Verifica fallisce.
+- [ ] **Step 3 — Implementa** (B: derive nel handler + `SessionDto.TurnOrderType`; A: field+migration+event+handler+hub+DTO). Enum → string (`.ToString()`).
+- [ ] **Step 4 — `dotnet build` + test BE pass.**
+- [ ] **Step 5 — Commit** `feat(api): #2483 expose turnOrderType in session DTO (path B|A)`.
+
+### Task 2 (FE): `useLiveSessionStore.turnOrderType` + setter
+
+**Files:** Modify `apps/web/src/lib/stores/live-session-store.ts`; (path A) `useSignalrSession.ts`. Test: store test.
+
+- [ ] **Step 1 — Test (TDD)**: lo store espone `turnOrderType: TurnOrderType | null`, popolato dal DTO iniziale (e da SignalR `'TurnOrderTypeUpdated'` se A). Fallisce.
+- [ ] **Step 2 — Implementa** il field + setter (mirror `scoringType`/`setScoringConfig` a `live-session-store.ts:59-81`). Path A: aggiungi handler `'TurnOrderTypeUpdated'` in `useSignalrSession.ts` (mirror `'ScoringConfigured'` :133-143).
+- [ ] **Step 3 — `pnpm -C apps/web typecheck` + store test pass.**
+- [ ] **Step 4 — Commit** `feat(web): #2483 useLiveSessionStore.turnOrderType field`.
+
+### Task 3 (FE): adapter `mapTurnDataToTurnState`
+
+**Files:** Create `apps/web/src/lib/session-live/map-turn-data-to-turn-state.ts`; Test `__tests__/map-turn-data-to-turn-state.test.ts`.
+
+- [ ] **Step 1 — Test (TDD)**: per ognuno dei 7 `TurnOrderType` + un valore unknown, l'adapter produce il `TurnState` corretto (campi per-variant da `turn-state.ts:27-58`, popolati da `currentTurn`/`totalTurns`/`activePlayerId`/`playOrder`). Mapping BE enum (`Free`→`None`, ecc) + `FirstPlayerToken` (FE-only). Fallisce.
+- [ ] **Step 2 — Implementa** `mapTurnDataToTurnState(turnOrderType, sessionData) → TurnState` (pure, switch discriminato + tabella mapping enum→union + default→variante sicura per `UnknownBranch`). Mirror `mapScoreDataToPanelData` (`score-data-to-panel-data.ts:35-108`).
+- [ ] **Step 3 — typecheck + adapter test pass (tutti 7 + unknown).**
+- [ ] **Step 4 — Commit** `feat(web): #2483 mapTurnDataToTurnState adapter`.
+
+### Task 4 (FE): wire `SessionLiveView` (rimuovi hardcoded)
+
+**Files:** Modify `SessionLiveView.tsx:606-615`. Test: view test (rende branch giusto).
+
+- [ ] **Step 1 — Test (TDD)**: dato `turnOrderType='Sequential'` nello store, `SessionLiveView` rende il branch Sequential (non RoundRobin). Fallisce (oggi hardcoded RoundRobin).
+- [ ] **Step 2 — Implementa**: sostituisci il `turnRendererState` hardcoded con `mapTurnDataToTurnState(store.turnOrderType ?? <fallback>, activeSession)`. Mantieni il fallback sicuro (se `turnOrderType` null → `UnknownBranch` o un default documentato, NON hardcoded RoundRobin silenzioso).
+- [ ] **Step 3 — typecheck + view test pass.**
+- [ ] **Step 4 — Commit** `feat(web): #2483 wire SessionLiveView turnRendererState from store`.
+
+### Task 5: finalize + PR
+
+- [ ] **Step 1 — Gate**: `dotnet build` + BE test (SessionTracking); `pnpm -C apps/web typecheck && pnpm -C apps/web lint`; FE test (`src/lib/session-live`, `src/lib/stores`, session-live view).
+- [ ] **Step 2 — PR** verso `main-dev`: riepilogo (B|A scelto, store+adapter+view, enum mapping), `Closes #2483`, link epic #2354 + pattern #2389. Footer Claude Code.
+
+---
+
+## Self-Review
+- **Spec coverage**: §2 BE source B/A → Task 1 ✓; §4 FE (store/adapter/view) → Task 2/3/4 ✓; §5 enum mapping → Task 3 ✓; §6 acceptance → Task 1-5 ✓.
+- **Placeholder scan**: i `<fallback>`/`<path B|A>` sono decisioni risolte in Task 1/4 (criterio esplicito), non placeholder vaghi. Ogni task ha file + template ref + TDD.
+- **Type consistency**: `turnOrderType: TurnOrderType | null` (store), `mapTurnDataToTurnState(turnOrderType, sessionData): TurnState`, DTO `TurnOrderType: string?`. Coerenti.
+- **Note**: il renderer (`TurnIndicatorRenderer`) + `turn-state.ts` NON cambiano (G5b done). `TurnOrderMethod`/`TurnOrderJson` (Session) restano invariati (player ordering, concetto diverso).

--- a/docs/superpowers/specs/2026-06-22-issue-2483-turnordertype-wiring-design.md
+++ b/docs/superpowers/specs/2026-06-22-issue-2483-turnordertype-wiring-design.md
@@ -1,0 +1,84 @@
+# Wire real turnOrderType into TurnIndicatorRenderer (design)
+
+**Issue**: [#2483](https://github.com/meepleAi-app/meepleai-monorepo/issues/2483) · **Epic**: #2354 (G5) · **Renderer**: #2378 (G5b, merged) · **Pattern ref**: #2389/#2430 (G5a scoringType wiring)
+**Date**: 2026-06-22
+**Status**: APPROVED (BE source = "B con fallback ad A")
+
+---
+
+## 1. Context & gap
+
+G5b `TurnIndicatorRenderer` (`apps/web/src/components/features/session-live/turn-indicator-renderer/`, 7 `TurnOrderType` branches) is merged (#2378/#2411) but fed by a **hardcoded placeholder**:
+
+```ts
+// apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx:606-615
+const turnRendererState = useMemo<TurnState>((): TurnState => ({
+  type: 'RoundRobin',                 // ← HARDCODED
+  round: activeSession?.currentTurn ?? 0,
+  totalRounds: activeSession?.totalTurns ?? 0,
+  activePlayerId: activeSession?.activePlayerId ?? '',
+  playOrder: activeSession?.players.map(p => p.id) ?? [],
+}), [activeSession]);
+```
+
+`useLiveSessionStore` has `currentTurn`/`totalTurns`/`activePlayerId`/`players` but **no `turnOrderType`**.
+
+**Important distinction (verified):** `Session.cs` already has `TurnOrderMethod` (string, enum `SessionTracking.Domain.Enums.TurnOrderMethod` — *how* the order was decided: Random/manual) + `TurnOrderJson` (the player order) + `TurnOrderSeed`. These are **NOT** the `TurnOrderType` (the game's turn *mode*: RoundRobin/Sequential/Simultaneous/Realtime/None/Custom/FirstPlayerToken — enum `GameToolkit.Domain.Enums.TurnOrderType`, 7 values, what the renderer switches on). So the renderer's discriminator is genuinely new data to expose.
+
+## 2. Architecture — BE source: "B with fallback to A"
+
+The `turnOrderType` (turn *mode*) is conceptually a property of the **game/toolkit**, not a per-session-instance config (unlike scoring, which can be configured live). So:
+
+- **B (preferred — try first):** expose `turnOrderType` in the session live DTO by **deriving it from the game's toolkit** (chain `Session.GameId → Game → GameToolkit.TurnOrderType`). No new `Session` field, no EF migration, no runtime SignalR event — the value is static for the session and ships in the initial DTO. Simpler.
+- **A (fallback):** if the `Session → Game → GameToolkit.TurnOrderType` chain is not cleanly accessible, replicate the G5a pattern: add `Session.TurnOrderType` field (+ EF migration) + `SetTurnOrderType()` + `SessionTurnOrderTypeUpdatedEvent` → SignalR `"TurnOrderTypeUpdated"` + DTO.
+
+**Decision criterion (resolved during impl):** in BE step 1, check whether the session-live query handler can resolve `GameToolkit.TurnOrderType` for the session's game without a new aggregate field. If yes → B. If no (no FK / no toolkit / awkward join) → A. Document which path was taken in the PR.
+
+## 3. G5a pattern to replicate (file-by-file template)
+
+From the scoringType wiring (verified):
+- **BE event** (A only): `…/SessionTracking/Domain/Events/SessionScoresUpdatedEvent.cs` → handler `…/Application/EventHandlers/SessionScoresUpdatedSignalRHandler.cs` (sends `"ScoringConfigured"`) → hub `Api/Hubs/GameStateHub.cs:317-325`.
+- **BE DTO**: `…/Application/DTOs/SessionDto.cs:21,27` (`ScoringType`/`ScoreData`), built in `GetActiveSessionQueryHandler.cs:62-76`.
+- **FE store**: `apps/web/src/lib/stores/live-session-store.ts:59-81` (`scoringType` field + `setScoringConfig` action).
+- **FE SignalR** (A only): `apps/web/src/lib/domain-hooks/useSignalrSession.ts:49-143` (`'ScoringConfigured'` handler → `setScoringConfig`).
+- **FE adapter**: `apps/web/src/lib/session-live/score-data-to-panel-data.ts:35-108` (`mapScoreDataToPanelData`).
+- **FE hook**: `apps/web/src/lib/domain-hooks/useSessionScores.ts:47-63`.
+- **FE view**: `SessionLiveView.tsx` consumes store → `ScoringPanelRenderer`.
+
+## 4. Files to touch
+
+**FE (both paths):**
+- `apps/web/src/lib/stores/live-session-store.ts` — add `turnOrderType: TurnOrderType | null` + setter (populated from initial DTO; + SignalR setter if A).
+- `apps/web/src/lib/session-live/map-turn-data-to-turn-state.ts` (NEW) — `mapTurnDataToTurnState(turnOrderType, sessionData) → TurnState`; maps BE enum (7) → FE union; resolves per-variant `TurnState` fields from `currentTurn`/`totalTurns`/`activePlayerId`/`playOrder`. Handle `FirstPlayerToken` (FE-only, BE enum lacks it → map from a BE signal or default).
+- `SessionLiveView.tsx:606-615` — replace hardcoded `turnRendererState` with store-derived via the adapter.
+- Tests: store setter, adapter (7 variants + unknown fallback), SessionLiveView renders correct branch.
+
+**BE (B):** expose `turnOrderType` in the session-live DTO derived from the game's toolkit; map enum → string; test the query handler returns the right value.
+**BE (A fallback):** `Session.cs` field + `SetTurnOrderType()` + `SessionTurnOrderTypeUpdatedEvent` + SignalR handler + hub method + DTO + EF migration; tests for handler + event.
+
+## 5. Enum mapping (BE → FE)
+
+BE `GameToolkit.TurnOrderType` (7): `RoundRobin=0, Custom=1, Free=2, Sequential=3, Simultaneous=4, Realtime=5, None=6`.
+FE union (7): `RoundRobin | Sequential | Simultaneous | Realtime | None | Custom | FirstPlayerToken`.
+Mapping: `Free` (BE) → `None` (FE) most likely; `FirstPlayerToken` (FE) has no BE enum value → derive from a BE flag or treat as a Custom/RoundRobin refinement. The adapter resolves this with an explicit table + `UnknownBranch` fallback for unmapped values (the renderer already has `UnknownBranch`).
+
+## 6. Acceptance criteria
+
+- [ ] `turnOrderType` exposed by BE (path B or A — documented).
+- [ ] `useLiveSessionStore.turnOrderType` populated from the session DTO (+ SignalR if A).
+- [ ] `mapTurnDataToTurnState` adapter maps all 7 variants + unknown fallback.
+- [ ] `SessionLiveView` renders the real turn mode (no hardcoded `'RoundRobin'`).
+- [ ] BE enum → FE union mapping table explicit + tested.
+- [ ] Tests: FE store + adapter + view; BE query handler (B) or handler+event (A).
+- [ ] `dotnet build` + BE tests pass; `pnpm typecheck` + `pnpm lint` + FE tests pass.
+
+## 7. Out of scope
+
+- The `TurnIndicatorRenderer` component + branches (#2378, done — no change).
+- G5c `ToolkitRenderer` (#2416) and G6 per-game extensions (#2377).
+- Changing `TurnOrderMethod`/`TurnOrderJson` semantics (those stay as-is — the player ordering).
+- Live mid-session turn-mode changes if path B is taken (static for the session; revisit only if a game needs it).
+
+## 8. Refs
+
+Issue #2483 · epic #2354 · renderer #2378 · pattern #2389/#2430 · BE enum `apps/api/src/Api/BoundedContexts/GameToolkit/Domain/Enums/TurnOrderType.cs` · FE types `apps/web/src/lib/session-live/turn-state.ts`.


### PR DESCRIPTION
## Summary
G5 follow-up (#2354): `TurnIndicatorRenderer` (G5b, #2378) era alimentato da un placeholder hardcoded `type: 'RoundRobin'`. Questa PR collega il `turnOrderType` reale.

## Approccio — Path B (statico, no migration)
Il `turnOrderType` è proprietà del gioco/toolkit (non cambia mid-session) → **derivato dal toolkit nel session DTO**, NO nuovo field Session, NO EF migration, NO SignalR event runtime.
- **BE**: `SessionDto.TurnOrderType` (string?) risolto in `GetActiveSessionQueryHandler` via `Session.GameId → GameToolkits → TurnTemplateJson.turnOrderType` (enum→string)
- **FE**: `useLiveSessionStore.turnOrderType` (idratato dal DTO) + adapter `mapTurnDataToTurnState` (mapping BE→FE union: `Free`→`None`, `FirstPlayerToken` FE-only pass-through, null/unknown→`None` safe — **no silent RoundRobin**) + `SessionLiveView` deriva dallo store (rimosso hardcoded)

## Verifica
- ✅ BE: `dotnet build` 0 errori, 954 SessionTracking test pass (3 nuovi)
- ✅ FE: `pnpm typecheck` pass; 117 test (store 16 + adapter 15 + view 6 + esistenti)
- Renderer G5b + `turn-state.ts` + `TurnOrderMethod`/`TurnOrderJson` (player ordering, concetto diverso) NON toccati

## Refs
Closes #2483 · epic #2354 (G5) · renderer #2378 · pattern #2389/#2430

🤖 Generated with [Claude Code](https://claude.com/claude-code)