### PR TITLE
chore(mockups): #2361 close-out — play-records hub cards + FREEZE fix

### DIFF
--- a/admin-mockups/design_files/00-hub.html
+++ b/admin-mockups/design_files/00-hub.html
@@ -363,6 +363,46 @@
     <div class="tags"><span class="tag">10 stati</span><span class="tag">3-col + Live FSM</span><span class="tag">SSE · Chat · Dispute</span></div>
   </a>
 
+  <a class="hub-card e-session" href="sp4-play-records-index.html">
+    <div class="arrow">→</div>
+    <div class="num">B19 · #2347 · 1/5</div>
+    <h3>Play Records — hub list</h3>
+    <p>Hub registrazioni partite (/play-records) per la persona Marco (host del gruppo board game padovano): lista record con MeepleCard, filter chips per esito e gioco, outcome badge entity-aware (vinta/persa/pareggio), scoring inline tabular-nums. Empty / loading / error states.</p>
+    <div class="tags"><span class="tag">Hub list</span><span class="tag">Filter chips</span><span class="tag">Outcome badge</span></div>
+  </a>
+
+  <a class="hub-card e-session" href="sp4-play-records-new.html">
+    <div class="arrow">→</div>
+    <div class="num">B19 · #2348 · 2/5</div>
+    <h3>Play Records — nuovo record</h3>
+    <p>Form creazione record (/play-records/new): selezione gioco e data, roster player (User-linked + guest free), scoring per-tipo, autosave draft localStorage, photo upload con OCR opzionale.</p>
+    <div class="tags"><span class="tag">Create form</span><span class="tag">Autosave</span><span class="tag">Photo + OCR</span></div>
+  </a>
+
+  <a class="hub-card e-session" href="sp4-play-records-detail.html">
+    <div class="arrow">→</div>
+    <div class="num">B19 · #2349 · 3/5</div>
+    <h3>Play Records — dettaglio</h3>
+    <p>Vista dettaglio record (/play-records/[id]) read-only: roster con classifica, scoring breakdown, gallery foto con lightbox, share link pubblico + access control creator-only.</p>
+    <div class="tags"><span class="tag">Read-only</span><span class="tag">Share + ACL</span><span class="tag">Photo gallery</span></div>
+  </a>
+
+  <a class="hub-card e-session" href="sp4-play-records-edit.html">
+    <div class="arrow">→</div>
+    <div class="num">B19 · #2349 · 4/5</div>
+    <h3>Play Records — modifica</h3>
+    <p>Form modifica record (/play-records/[id]/edit): prefill da record esistente, version diff inline vs versioni precedenti con restore, conflict-UI xmin per edit concorrenti.</p>
+    <div class="tags"><span class="tag">Edit form</span><span class="tag">Version diff</span><span class="tag">Conflict xmin</span></div>
+  </a>
+
+  <a class="hub-card e-session" href="sp4-play-records-stats.html">
+    <div class="arrow">→</div>
+    <div class="num">B19 · #2350 · 5/5</div>
+    <h3>Play Records — statistiche</h3>
+    <p>Dashboard statistiche cross-game (/play-records/stats): KPI grid (partite · vittorie · win-rate), trend chart temporale, leaderboard player, accordion per-game con record dettagliati.</p>
+    <div class="tags"><span class="tag">KPI grid</span><span class="tag">Trend chart</span><span class="tag">Leaderboard</span></div>
+  </a>
+
   <a class="hub-card e-event" href="sp7-game-night-live.html">
     <div class="arrow">→</div>
     <div class="num">SP7 · K · #487</div>

--- a/admin-mockups/design_files/sp4-play-records-index.jsx
+++ b/admin-mockups/design_files/sp4-play-records-index.jsx
@@ -74,7 +74,7 @@ const OutcomeBadge = ({ outcome, status }) => {
     );
   }
   const map = {
-    won:  { label:'🏆 Vinta', bg:'hsl(142 60% 45% / .14)', fg:'hsl(142 50% 32%)', bd:'hsl(142 60% 45% / .3)' },
+    won:  { label:'🏆 Vinta', bg:'hsl(var(--c-success) / .14)', fg:'hsl(var(--c-success))', bd:'hsl(var(--c-success) / .3)' },
     lost: { label:'△ Persa', bg:'hsl(var(--c-event) / .12)', fg:'hsl(var(--c-event))', bd:'hsl(var(--c-event) / .3)' },
     tie:  { label:'= Pareggio', bg:'var(--bg-muted)', fg:'var(--text-sec)', bd:'var(--border)' },
   };


### PR DESCRIPTION
## Summary
Close-out gap-fill for #2361 (Play Records mockup commission). The 5 `sp4-play-records-*` mockups already existed (PR #1669 / #1488), so this PR closes the 3 residual AC gaps:

1. **Hub integration** — added 5 hub cards (B19 cluster, `e-session`) for index/new/detail/edit/stats in `00-hub.html` (was missing).
2. **FREEZE fix** — `sp4-play-records-index.jsx:77` `won` outcome badge used hardcoded `hsl(142...)`; replaced with canonical token `hsl(var(--c-success))` (matches sibling `lost`/`tie` pattern).
3. **Designer review** — tracking issue #2488 opened (asse-* compliance, post-ship).

## Verification
- `pnpm lint:tokens:mockups --strict --max-baseline 1500` → exit 0 (baseline unchanged at 1500)
- FREEZE grep (`hsl([0-9]`) on `sp4-play-records-*` → clean
- BGG grep → clean (no user-side asset)
- `tsc --noEmit` → pass (pre-commit hook)

AC already satisfied pre-PR: 5 HTML+JSX files, 5 fidelity.json, MOCKUPS_INDEX.md, v2-migration-matrix.md.

Closes #2361

🤖 Generated with [Claude Code](https://claude.com/claude-code)