### PR TITLE
feat(mockups): #2361 Play Records stats — extension 4 stati canonici (Mockup 5/5 · cluster complete)

### DIFF
--- a/admin-mockups/design_files/sp4-play-records-stats.fidelity.json
+++ b/admin-mockups/design_files/sp4-play-records-stats.fidelity.json
@@ -3,7 +3,10 @@
   "mockup": {
     "source": "admin-mockups/design_files/sp4-play-records-stats.html",
     "states": [
-      "default"
+      "default",
+      "empty",
+      "loading",
+      "error"
     ]
   },
   "acceptance": {
@@ -12,7 +15,10 @@
     "tokens_used": "canonical_only",
     "legacy_token_names_forbidden": true,
     "states_covered": [
-      "default"
+      "default",
+      "empty",
+      "loading",
+      "error"
     ],
     "a11y_axe": "AA",
     "a11y_violations_max": 0,

--- a/admin-mockups/design_files/sp4-play-records-stats.html
+++ b/admin-mockups/design_files/sp4-play-records-stats.html
@@ -4,8 +4,137 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Play records · Statistiche — MeepleAI</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;700;800&display=swap">
   <link rel="stylesheet" href="tokens.css">
   <link rel="stylesheet" href="scaffold.css">
+  <style>
+    /* ─── Gallery / frame chrome + skeleton (self-contained, non dipende da scaffold.css) ─── */
+    html { scroll-behavior: smooth; }
+    body { min-height: 100vh; }
+
+    /* Skeleton pulse — opacity 0.4 → 0.8 → 0.4, 2s loop */
+    @keyframes sp4-skel-pulse { 0%, 100% { opacity: .4; } 50% { opacity: .8; } }
+    .skel { animation: sp4-skel-pulse 2s var(--ease-in-out) infinite; }
+
+    /* prefers-reduced-motion → snap senza pulse */
+    @media (prefers-reduced-motion: reduce) {
+      html { scroll-behavior: auto; }
+      .skel { animation: none; opacity: .6; }
+    }
+
+    .gallery { min-height: 100vh; }
+
+    /* Sticky top nav con 4 link agli anchor */
+    .gallery-nav {
+      position: sticky; top: 0; z-index: var(--z-nav);
+      display: flex; align-items: center; gap: 16px; flex-wrap: wrap;
+      padding: 10px 24px;
+      background: var(--glass-bg); backdrop-filter: blur(12px);
+      border-bottom: 1px solid var(--border);
+    }
+    .gallery-nav-brand {
+      font-family: var(--f-mono); font-size: 11px; font-weight: 800;
+      letter-spacing: .06em; text-transform: uppercase; color: var(--text-sec);
+      white-space: nowrap;
+    }
+    .gallery-nav-links { display: flex; gap: 6px; flex: 1; flex-wrap: wrap; }
+    .gallery-nav-links a {
+      padding: 6px 12px; border-radius: var(--r-pill);
+      font-family: var(--f-display); font-size: 12px; font-weight: 700;
+      color: var(--text-sec); border: 1px solid var(--border); background: var(--bg-card);
+      white-space: nowrap; transition: color var(--dur-sm) var(--ease-out), border-color var(--dur-sm) var(--ease-out), background var(--dur-sm) var(--ease-out);
+    }
+    .gallery-nav-links a:hover {
+      color: hsl(var(--c-session)); border-color: hsl(var(--c-session) / .45);
+      background: hsl(var(--c-session) / .1);
+    }
+    .gallery-nav-ghost {
+      font-family: var(--f-mono); font-size: 10.5px; font-weight: 700;
+      color: var(--text-muted); padding: 6px 10px; border-radius: var(--r-pill);
+      border: 1px dashed var(--border-strong); opacity: .6; white-space: nowrap;
+    }
+    .theme-toggle {
+      display: inline-flex; align-items: center; gap: 6px;
+      padding: 6px 12px; border-radius: var(--r-pill);
+      border: 1px solid var(--border); background: var(--bg-card); color: var(--text-sec);
+      font-family: var(--f-display); font-size: 12px; font-weight: 700; white-space: nowrap;
+      transition: border-color var(--dur-sm) var(--ease-out), color var(--dur-sm) var(--ease-out);
+    }
+    .theme-toggle:hover { border-color: hsl(var(--c-session) / .45); color: hsl(var(--c-session)); }
+
+    .gallery-body { max-width: 1560px; margin: 0 auto; padding: 24px 24px 96px; }
+    .gallery-intro { padding: 16px 0 4px; }
+    .gallery-intro .kicker {
+      font-family: var(--f-mono); font-size: 11px; text-transform: uppercase;
+      letter-spacing: .08em; color: var(--text-muted); margin-bottom: 8px; font-weight: 800;
+    }
+    .gallery-intro h1 { font-size: var(--fs-3xl); margin: 0 0 10px; }
+    .gallery-intro .lead {
+      font-size: var(--fs-base); color: var(--text-sec); max-width: 820px;
+      line-height: var(--lh-relax); margin: 0; text-wrap: pretty;
+    }
+    .gallery-intro code, .state-head code {
+      font-family: var(--f-mono); font-size: .88em;
+      background: var(--bg-muted); padding: 1px 5px; border-radius: var(--r-xs);
+    }
+
+    .state-section { scroll-margin-top: 76px; padding: 40px 0 8px; border-top: 1px solid var(--border-light); margin-top: 28px; }
+    .state-head { display: flex; align-items: flex-start; gap: 14px; margin-bottom: 26px; }
+    .state-num {
+      font-family: var(--f-mono); font-size: 14px; font-weight: 800; color: #fff;
+      background: hsl(var(--c-session)); width: 36px; height: 36px; border-radius: var(--r-md);
+      display: flex; align-items: center; justify-content: center; flex-shrink: 0;
+      box-shadow: 0 4px 12px hsl(var(--c-session) / .4);
+    }
+    .state-head-text { flex: 1; min-width: 0; }
+    .state-head h2 { font-size: var(--fs-2xl); margin: 0; }
+    .state-head p { font-size: 13px; color: var(--text-sec); margin: 5px 0 0; max-width: 640px; line-height: var(--lh-snug); }
+    .state-anchor {
+      margin-left: auto; align-self: flex-start;
+      font-family: var(--f-mono); font-size: 11px; color: var(--text-muted);
+      background: var(--bg-muted); padding: 5px 10px; border-radius: var(--r-sm); white-space: nowrap;
+    }
+
+    .matrix { display: flex; flex-direction: column; gap: 32px; }
+    .matrix-row { display: flex; gap: 32px; flex-wrap: wrap; align-items: flex-start; }
+    .frame-tag {
+      font-family: var(--f-mono); font-size: 11px; color: var(--text-sec);
+      text-transform: uppercase; letter-spacing: .06em; font-weight: 700;
+    }
+
+    /* Phone 375 */
+    .phone {
+      width: 375px; height: 760px; border-radius: 38px;
+      border: 10px solid var(--text); background: var(--bg);
+      overflow: hidden; display: flex; flex-direction: column;
+      box-shadow: var(--shadow-lg); flex-shrink: 0;
+    }
+    .phone-sbar {
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 9px 24px 4px; font-family: var(--f-mono); font-size: 12px; font-weight: 700; flex-shrink: 0;
+    }
+    .phone-sbar .ind { display: flex; gap: 8px; align-items: center; font-size: 10px; letter-spacing: .1em; }
+
+    /* Desktop 1440 */
+    .desktop-frame {
+      width: 1440px; max-width: 100%; border-radius: 14px;
+      border: 1px solid var(--border); background: var(--bg); overflow: hidden;
+      box-shadow: var(--shadow-lg);
+    }
+    .desktop-bar {
+      display: flex; align-items: center; gap: 8px; padding: 10px 16px;
+      background: var(--bg-card); border-bottom: 1px solid var(--border);
+    }
+    .desktop-bar .traffic { width: 11px; height: 11px; border-radius: 50%; background: var(--border-strong); }
+    .desktop-bar .url { margin-left: 14px; font-family: var(--f-mono); font-size: 11px; color: var(--text-muted); }
+
+    @media (max-width: 900px) {
+      .gallery-body { padding: 20px 16px 80px; }
+      .matrix-row { gap: 24px; }
+    }
+  </style>
 </head>
 <body>
   <div id="root"></div>

--- a/admin-mockups/design_files/sp4-play-records-stats.jsx
+++ b/admin-mockups/design_files/sp4-play-records-stats.jsx
@@ -1,34 +1,61 @@
-/* MeepleAI SP4 — /play-records/stats · STATS
+/* MeepleAI SP4 — Schermata /play-records/stats · STATS
    Route: /play-records/stats
    File: admin-mockups/design_files/sp4-play-records-stats.{html,jsx}
-   Modello: sp4-dashboard — KPI strip + sezioni entity-tinted, mobile stacked + desktop grid.
+   Modello: sp4-dashboard — KPI strip + sezioni entity-tinted, mobile stack + desktop grid 2-col.
    Entity dominante: session 🎯. KPI: partite · giochi · win-rate · gioco preferito.
    Sezioni: Giochi più giocati · Win-rate per gioco.
+
+   ── Stati canonici (G7 SessionStateRenderer, PR 2357) ──────────────
+   Export per-stato (anchor #state-NN-* nello stats HTML):
+     State01_Default  → state-01-default   (dashboard completa as-shipped)
+     State02_Empty    → state-02-empty     (zero partite · banner info · CTA prima partita)
+     State03_Loading  → state-03-loading   (skeleton KPI + hero + sezioni · aria-busy)
+     State04_Error    → state-04-error     (banner alert · retry · torna-lista · dismiss)
+   state-05-sse → SKIPPED: dashboard NON è SSE-driven (fetch-once aggregate, refresh manuale).
+
+   FREEZE: zero hex/hsl numerico hardcoded per gli entity color → solo token --c-*
+   via entityHsl(). Pattern .e-bg (color:'#fff' su bg entity) esente. Nessun asset esterno.
 */
 const { useState, useEffect } = React;
 const DS = window.DS;
 
-const entityHsl = (type, alpha) => {
-  const c = DS.EC[type] || DS.EC.session;
-  return alpha !== undefined ? `hsla(${c.h}, ${c.s}%, ${c.l}%, ${alpha})` : `hsl(${c.h}, ${c.s}%, ${c.l}%)`;
-};
+// entityHsl(entity, alpha?) — risolve SEMPRE sui token CSS (--c-*), così il colore
+// segue automaticamente light/dark ([data-theme]) ed è FREEZE-clean (nessun valore
+// hsl numerico hardcoded nel sorgente del mockup).
+const entityHsl = (entity, alpha) =>
+  alpha === undefined
+    ? `hsl(var(--c-${entity}))`
+    : `hsl(var(--c-${entity}) / ${alpha})`;
 
 const STATS = DS.stats;
 const favGame = DS.byId[STATS.favoriteGame];
 
 // ═══════════════════════════════════════════════════════
-// ─── HERO + KPI STRIP ──────────────────────────────────
+// ─── KPI CARD ──────────────────────────────────────────
 // ═══════════════════════════════════════════════════════
-const KpiCard = ({ label, value, unit = '', icon, entity, sub, compact }) => (
-  <div style={{ padding: compact ? '12px 14px' : '16px 18px', background:'var(--bg-card)', border:'1px solid var(--border)', borderRadius:'var(--r-md)', display:'flex', alignItems:'center', gap: compact ? 10 : 14 }}>
-    <div style={{ width: compact ? 36 : 46, height: compact ? 36 : 46, borderRadius:'var(--r-sm)', background: entityHsl(entity, 0.12), color: entityHsl(entity), display:'flex', alignItems:'center', justifyContent:'center', fontSize: compact ? 17 : 22, flexShrink: 0 }} aria-hidden="true">{icon}</div>
-    <div style={{ minWidth: 0 }}>
-      <div style={{ color:'var(--text-muted)', fontSize: 9, fontWeight: 700, fontFamily:'var(--f-mono)', textTransform:'uppercase', letterSpacing:'.08em', marginBottom: 1 }}>{label}</div>
-      <div style={{ color:'var(--text)', fontSize: compact ? 20 : 26, fontWeight: 800, fontFamily:'var(--f-display)', fontVariantNumeric:'tabular-nums', lineHeight: 1, whiteSpace:'nowrap' }}>
-        {value}<span style={{ fontSize: 12, color:'var(--text-muted)', fontWeight: 600, marginLeft: 2 }}>{unit}</span>
+let kpiSeq = 0;
+const KpiCard = ({ label, value, unit = '', icon, entity, sub, compact, placeholder }) => {
+  const labelId = `kpi-lbl-${++kpiSeq}`;
+  return (
+    <div role="group" aria-labelledby={labelId} style={{ padding: compact ? '12px 14px' : '16px 18px', background:'var(--bg-card)', border:'1px solid var(--border)', borderRadius:'var(--r-md)', display:'flex', alignItems:'center', gap: compact ? 10 : 14, opacity: placeholder ? 0.72 : 1 }}>
+      <div style={{ width: compact ? 36 : 46, height: compact ? 36 : 46, borderRadius:'var(--r-sm)', background: entityHsl(entity, 0.12), color: entityHsl(entity), display:'flex', alignItems:'center', justifyContent:'center', fontSize: compact ? 17 : 22, flexShrink: 0 }} aria-hidden="true">{icon}</div>
+      <div style={{ minWidth: 0 }}>
+        <div id={labelId} style={{ color:'var(--text-muted)', fontSize: 9, fontWeight: 700, fontFamily:'var(--f-mono)', textTransform:'uppercase', letterSpacing:'.08em', marginBottom: 1 }}>{label}</div>
+        <div style={{ color:'var(--text)', fontSize: compact ? 20 : 26, fontWeight: 800, fontFamily:'var(--f-display)', fontVariantNumeric:'tabular-nums', lineHeight: 1, whiteSpace:'nowrap' }} aria-label={placeholder ? 'Statistica non disponibile' : undefined}>
+          {value}<span style={{ fontSize: 12, color:'var(--text-muted)', fontWeight: 600, marginLeft: 2 }}>{unit}</span>
+        </div>
+        {sub && <div style={{ fontFamily:'var(--f-mono)', fontSize: 9.5, color:'var(--text-muted)', fontWeight: 600, marginTop: 2 }}>{sub}</div>}
       </div>
-      {sub && <div style={{ fontFamily:'var(--f-mono)', fontSize: 9.5, color:'var(--text-muted)', fontWeight: 600, marginTop: 2 }}>{sub}</div>}
     </div>
+  );
+};
+
+const KpiStrip = ({ compact, empty }) => (
+  <div style={{ display:'grid', gridTemplateColumns: compact ? 'repeat(2, 1fr)' : 'repeat(4, 1fr)', gap: compact ? 8 : 14, maxWidth: 820 }}>
+    <KpiCard label="Partite" value={empty ? 0 : STATS.totals.plays} icon="🎯" entity="session" sub={empty ? 'nessuna ancora' : `${STATS.totals.hoursPlayed}h totali`} compact={compact} placeholder={empty}/>
+    <KpiCard label="Giochi" value={empty ? 0 : STATS.totals.games} icon="🎲" entity="game" sub={empty ? '—' : 'in libreria'} compact={compact} placeholder={empty}/>
+    <KpiCard label="Win rate" value={empty ? '—' : (STATS.totals.winRate * 100).toFixed(0)} unit={empty ? '' : '%'} icon="🏆" entity="toolkit" sub={empty ? '—' : `${Math.round(STATS.totals.plays * STATS.totals.winRate)} vittorie`} compact={compact} placeholder={empty}/>
+    <KpiCard label="Preferito" value={empty ? 'n.d.' : favGame.coverEmoji} icon="⭐" entity="player" sub={empty ? '—' : favGame.title} compact={compact} placeholder={empty}/>
   </div>
 );
 
@@ -39,20 +66,15 @@ const StatsHero = ({ compact, empty }) => (
     </div>
     <h1 style={{ fontFamily:'var(--f-display)', fontWeight: 800, fontSize: compact ? 24 : 34, letterSpacing:'-.02em', lineHeight: 1.05, color:'var(--text)', margin:'0 0 4px' }}>Le tue statistiche <span aria-hidden="true">📊</span></h1>
     <p style={{ color:'var(--text-sec)', fontSize: compact ? 13 : 14, lineHeight: 1.55, margin:'0 0 16px', maxWidth: 620 }}>Una panoramica delle partite registrate: quante ne hai giocate, i giochi preferiti e il tuo win-rate.</p>
-    <div style={{ display:'grid', gridTemplateColumns: compact ? 'repeat(2, 1fr)' : 'repeat(4, 1fr)', gap: compact ? 8 : 14, maxWidth: 820 }}>
-      <KpiCard label="Partite" value={empty ? 0 : STATS.totals.plays} icon="🎯" entity="session" sub={empty ? 'nessuna ancora' : `${STATS.totals.hoursPlayed}h totali`} compact={compact}/>
-      <KpiCard label="Giochi" value={empty ? 0 : STATS.totals.games} icon="🎲" entity="game" sub={empty ? '—' : 'in libreria'} compact={compact}/>
-      <KpiCard label="Win rate" value={empty ? '—' : (STATS.totals.winRate * 100).toFixed(0)} unit={empty ? '' : '%'} icon="🏆" entity="toolkit" sub={empty ? '—' : `${Math.round(STATS.totals.plays * STATS.totals.winRate)} vittorie`} compact={compact}/>
-      <KpiCard label="Preferito" value={empty ? '—' : favGame.coverEmoji} icon="⭐" entity="player" sub={empty ? '—' : favGame.title} compact={compact}/>
-    </div>
+    <KpiStrip compact={compact} empty={empty}/>
   </header>
 );
 
 // ═══════════════════════════════════════════════════════
 // ─── SECTION WRAPPER ───────────────────────────────────
 // ═══════════════════════════════════════════════════════
-const StatsSection = ({ entity, icon, title, meta, children, compact, fullWidth }) => (
-  <section style={{ background:'var(--bg-card)', border:'1px solid var(--border)', borderRadius:'var(--r-xl)', padding: compact ? 14 : 18, display:'flex', flexDirection:'column', gap: compact ? 10 : 14, gridColumn: fullWidth ? '1 / -1' : 'auto' }}>
+const StatsSection = ({ entity, icon, title, meta, children, compact, ariaLabel }) => (
+  <section role="region" aria-label={ariaLabel || title} style={{ background:'var(--bg-card)', border:'1px solid var(--border)', borderRadius:'var(--r-xl)', padding: compact ? 14 : 18, display:'flex', flexDirection:'column', gap: compact ? 10 : 14 }}>
     <header style={{ display:'flex', alignItems:'center', gap: compact ? 8 : 10 }}>
       <div style={{ width: compact ? 26 : 32, height: compact ? 26 : 32, borderRadius:'var(--r-sm)', background: entityHsl(entity, 0.12), color: entityHsl(entity), display:'flex', alignItems:'center', justifyContent:'center', fontSize: compact ? 14 : 17, flexShrink: 0 }} aria-hidden="true">{icon}</div>
       <h2 style={{ fontFamily:'var(--f-display)', fontWeight: 800, fontSize: compact ? 14 : 17, lineHeight: 1.15, color:'var(--text)', margin: 0 }}>{title}</h2>
@@ -63,19 +85,10 @@ const StatsSection = ({ entity, icon, title, meta, children, compact, fullWidth 
   </section>
 );
 
-const EmptySection = ({ entity, icon, message, compact }) => (
-  <div style={{ display:'flex', flexDirection:'column', alignItems:'center', textAlign:'center', padding: compact ? '20px 12px' : '28px 16px', background:'var(--bg)', border:`1px dashed ${entityHsl(entity, 0.3)}`, borderRadius:'var(--r-md)', flex: 1 }}>
-    <div style={{ width: 48, height: 48, borderRadius:'50%', background: entityHsl(entity, 0.12), color: entityHsl(entity), display:'flex', alignItems:'center', justifyContent:'center', fontSize: 22, marginBottom: 8 }} aria-hidden="true">{icon}</div>
-    <p style={{ fontSize: 12, color:'var(--text-muted)', maxWidth: 240, margin:'0 0 10px', lineHeight: 1.4 }}>{message}</p>
-    <a href="sp4-play-records-new.html" style={{ padding:'6px 12px', borderRadius:'var(--r-sm)', background: entityHsl(entity), color:'#fff', fontFamily:'var(--f-display)', fontSize: 11, fontWeight: 800 }}>+ Registra partita</a>
-  </div>
-);
-
 // ═══════════════════════════════════════════════════════
-// ─── MOST PLAYED ───────────────────────────────────────
+// ─── MOST PLAYED (bar list) ────────────────────────────
 // ═══════════════════════════════════════════════════════
-const MostPlayed = ({ items, compact }) => {
-  if (!items.length) return <EmptySection entity="game" icon="🎲" message="Nessuna partita registrata. Le statistiche appariranno qui." compact={compact}/>;
+const MostPlayed = ({ items }) => {
   const max = Math.max(...items.map(i => i.plays), 1);
   return (
     <div style={{ display:'flex', flexDirection:'column', gap: 10 }}>
@@ -103,10 +116,9 @@ const MostPlayed = ({ items, compact }) => {
 };
 
 // ═══════════════════════════════════════════════════════
-// ─── WIN RATE BY GAME ──────────────────────────────────
+// ─── WIN RATE BY GAME (bar list) ───────────────────────
 // ═══════════════════════════════════════════════════════
-const WinByGame = ({ items, compact }) => {
-  if (!items.length) return <EmptySection entity="toolkit" icon="🏆" message="Nessun esito registrato. Gioca per vedere il tuo win-rate." compact={compact}/>;
+const WinByGame = ({ items }) => {
   const sorted = [...items].sort((a, b) => (b.won / b.played) - (a.won / a.played));
   return (
     <div style={{ display:'flex', flexDirection:'column', gap: 10 }}>
@@ -133,85 +145,108 @@ const WinByGame = ({ items, compact }) => {
 };
 
 // ═══════════════════════════════════════════════════════
-// ─── SKELETON / ERROR ──────────────────────────────────
+// ─── EMPTY DASHBOARD CARD (state-02) ───────────────────
 // ═══════════════════════════════════════════════════════
-const SectionSkeleton = ({ compact, height = 200 }) => (
-  <div style={{ background:'var(--bg-card)', border:'1px solid var(--border)', borderRadius:'var(--r-xl)', padding: compact ? 14 : 18, display:'flex', flexDirection:'column', gap: 10, minHeight: height }}>
-    <div style={{ display:'flex', alignItems:'center', gap: 8 }}>
-      <div className="mai-shimmer" style={{ width: 28, height: 28, borderRadius:'var(--r-sm)', background:'var(--bg-muted)' }}/>
-      <div className="mai-shimmer" style={{ height: 14, width:'40%', borderRadius: 4, background:'var(--bg-muted)' }}/>
+const EmptyDashCard = ({ compact }) => (
+  <div style={{ gridColumn:'1 / -1', display:'flex', flexDirection:'column', alignItems:'center', textAlign:'center', padding: compact ? '40px 22px' : '56px 28px', background:'var(--bg-card)', border:'1px dashed var(--border-strong)', borderRadius:'var(--r-xl)' }}>
+    <div aria-hidden="true" style={{ width: 88, height: 88, borderRadius:'50%', background:`radial-gradient(circle, ${entityHsl('session', 0.18)} 0%, transparent 70%)`, display:'flex', alignItems:'center', justifyContent:'center', fontSize: 42, marginBottom: 14 }}>📊</div>
+    <h2 style={{ fontFamily:'var(--f-display)', fontSize: compact ? 18 : 20, fontWeight: 800, color:'var(--text)', margin:'0 0 8px' }}>Nessun dato ancora</h2>
+    <p style={{ fontFamily:'var(--f-body)', fontSize: compact ? 13 : 13.5, color:'var(--text-sec)', margin:'0 0 20px', maxWidth: 360, lineHeight: 1.55, fontWeight: 500 }}>Registra le tue partite per vedere statistiche aggregate</p>
+    <a href="sp4-play-records-new.html" style={{ padding:'10px 18px', borderRadius:'var(--r-md)', background: entityHsl('session'), color:'#fff', fontFamily:'var(--f-display)', fontSize: 13.5, fontWeight: 800, display:'inline-flex', alignItems:'center', gap: 6, boxShadow:`0 4px 14px ${entityHsl('session', 0.4)}` }}><span aria-hidden="true">+</span>Registra prima partita</a>
+  </div>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── SKELETON PRIMITIVES (state-03) ────────────────────
+// Pulse 0.4→0.8→0.4 (2s) via .skel; prefers-reduced-motion → snap.
+// ═══════════════════════════════════════════════════════
+const SkelRect = ({ w, h, r, style }) => (
+  <div aria-hidden="true" className="skel" style={{ width: w, height: h, borderRadius: r || 'var(--r-sm)', background: entityHsl('session', 0.1), flexShrink: 0, ...style }}/>
+);
+
+const KpiCardSkel = ({ compact }) => (
+  <div aria-hidden="true" style={{ padding: compact ? '12px 14px' : '16px 18px', background:'var(--bg-card)', border:'1px solid var(--border)', borderRadius:'var(--r-md)', display:'flex', alignItems:'center', gap: compact ? 10 : 14 }}>
+    <SkelRect w={compact ? 36 : 46} h={compact ? 36 : 46} r="var(--r-sm)"/>
+    <div style={{ flex: 1, minWidth: 0, display:'flex', flexDirection:'column', gap: 6 }}>
+      <SkelRect w="52%" h={9} r="var(--r-xs)"/>
+      <SkelRect w="70%" h={compact ? 18 : 22} r="var(--r-xs)"/>
     </div>
-    {[0,1,2,3].map(i => <div key={i} className="mai-shimmer" style={{ height: 22, borderRadius: 4, background:'var(--bg-muted)' }}/>)}
   </div>
 );
 
-const ErrorState = ({ compact }) => (
-  <div style={{ gridColumn:'1 / -1', padding: compact ? '32px 20px' : '48px 32px', background:'hsl(var(--c-danger) / .08)', border:'1px solid hsl(var(--c-danger) / .3)', borderRadius:'var(--r-xl)', display:'flex', flexDirection:'column', alignItems:'center', textAlign:'center' }}>
-    <div style={{ width: 56, height: 56, borderRadius:'50%', background:'hsl(var(--c-danger) / .15)', color:'hsl(var(--c-danger))', display:'flex', alignItems:'center', justifyContent:'center', fontSize: 26, marginBottom: 12 }} aria-hidden="true">⚠</div>
-    <h3 style={{ fontFamily:'var(--f-display)', fontSize: 16, fontWeight: 800, color:'var(--text)', margin:'0 0 4px' }}>Impossibile caricare le statistiche</h3>
-    <p style={{ fontSize: 12.5, color:'var(--text-muted)', maxWidth: 360, margin:'0 0 16px' }}>Si è verificato un errore di rete. Verifica la connessione e riprova.</p>
-    <button type="button" style={{ padding:'8px 16px', borderRadius:'var(--r-md)', background:'hsl(var(--c-danger))', color:'#fff', border:'none', fontFamily:'var(--f-display)', fontSize: 12, fontWeight: 800, cursor:'pointer' }}>↻ Riprova</button>
+const SectionRowSkel = () => (
+  <div aria-hidden="true" style={{ display:'flex', alignItems:'center', gap: 10 }}>
+    <SkelRect w={32} h={32} r="var(--r-sm)"/>
+    <div style={{ flex: 1, display:'flex', flexDirection:'column', gap: 5 }}>
+      <SkelRect w="60%" h={12} r="var(--r-xs)"/>
+      <SkelRect w="100%" h={8} r="var(--r-pill)"/>
+    </div>
+  </div>
+);
+
+const SectionSkel = ({ rows = 5, compact }) => (
+  <div aria-hidden="true" style={{ background:'var(--bg-card)', border:'1px solid var(--border)', borderRadius:'var(--r-xl)', padding: compact ? 14 : 18, display:'flex', flexDirection:'column', gap: 12 }}>
+    <div style={{ display:'flex', alignItems:'center', gap: 10 }}>
+      <SkelRect w={compact ? 26 : 32} h={compact ? 26 : 32} r="var(--r-sm)"/>
+      <SkelRect w="44%" h={15} r="var(--r-xs)"/>
+    </div>
+    {Array.from({ length: rows }).map((_, i) => <SectionRowSkel key={i}/>)}
+  </div>
+);
+
+const HeroSkel = ({ compact }) => (
+  <header aria-hidden="true" style={{ padding: compact ? '20px 16px 16px' : '30px 32px 22px', background:`linear-gradient(135deg, ${entityHsl('session', 0.06)} 0%, ${entityHsl('toolkit', 0.04)} 100%)`, borderBottom:'1px solid var(--border-light)', display:'flex', flexDirection:'column', gap: 12 }}>
+    <SkelRect w={compact ? 190 : 230} h={18} r="var(--r-pill)"/>
+    <SkelRect w={compact ? '70%' : 320} h={compact ? 26 : 34} r="var(--r-md)"/>
+    <SkelRect w={compact ? '92%' : 460} h={13} r="var(--r-xs)" style={{ marginBottom: 6 }}/>
+    <div style={{ display:'grid', gridTemplateColumns: compact ? 'repeat(2, 1fr)' : 'repeat(4, 1fr)', gap: compact ? 8 : 14, maxWidth: 820 }}>
+      {[0,1,2,3].map(i => <KpiCardSkel key={i} compact={compact}/>)}
+    </div>
+  </header>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── BANNERS (empty info / error) ──────────────────────
+// ═══════════════════════════════════════════════════════
+const EmptyInfoBanner = ({ compact }) => (
+  <div role="status" aria-live="polite" style={{ display:'flex', alignItems:'center', gap: compact ? 9 : 12, padding: compact ? '11px 16px' : '13px 32px', background: entityHsl('session', 0.06), borderLeft:`4px solid ${entityHsl('session', 0.45)}`, borderBottom:'1px solid var(--border-light)' }}>
+    <span aria-hidden="true" style={{ fontSize: compact ? 16 : 18, lineHeight: 1 }}>ℹ️</span>
+    <div style={{ flex: 1, minWidth: 0, fontFamily:'var(--f-body)', fontSize: compact ? 12.5 : 13.5, fontWeight: 600, color:'var(--text-sec)' }}>Le statistiche compaiono dopo la prima partita registrata</div>
+  </div>
+);
+
+const ErrorBanner = ({ compact }) => (
+  <div role="alert" style={{ display:'flex', alignItems:'center', gap: compact ? 10 : 14, padding: compact ? '12px 16px' : '14px 32px', background: entityHsl('event', 0.08), borderLeft:`4px solid ${entityHsl('event', 0.6)}`, borderBottom:'1px solid var(--border-light)' }}>
+    <span aria-hidden="true" style={{ fontSize: compact ? 18 : 20, lineHeight: 1 }}>⚠️</span>
+    <div style={{ flex: 1, minWidth: 0 }}>
+      <div style={{ fontFamily:'var(--f-display)', fontSize: compact ? 13 : 14.5, fontWeight: 800, color:'var(--text)' }}>Impossibile caricare le statistiche</div>
+      <div style={{ fontFamily:'var(--f-body)', fontSize: compact ? 11.5 : 12.5, fontWeight: 600, color:'var(--text-muted)', marginTop: 2 }}>Verifica la connessione e riprova</div>
+    </div>
+    <button type="button" aria-label="Riprova caricamento statistiche" style={{ padding:'7px 14px', borderRadius:'var(--r-md)', background:'transparent', color: entityHsl('event'), border:`1px solid ${entityHsl('event', 0.5)}`, fontFamily:'var(--f-display)', fontSize: 12, fontWeight: 800, cursor:'pointer', display:'inline-flex', alignItems:'center', gap: 5, whiteSpace:'nowrap', flexShrink: 0 }}><span aria-hidden="true">↻</span>Riprova</button>
   </div>
 );
 
 // ═══════════════════════════════════════════════════════
-// ─── BODY ──────────────────────────────────────────────
+// ─── DASHBOARD BODY (shared) ───────────────────────────
 // ═══════════════════════════════════════════════════════
-const StatsBody = ({ stateOverride, compact }) => {
-  const isLoading = stateOverride === 'loading';
-  const isError = stateOverride === 'error';
-  const isEmpty = stateOverride === 'empty';
-
-  if (isError) {
-    return (
-      <>
-        <StatsHero compact={compact}/>
-        <div style={{ padding: compact ? '16px' : '24px 32px' }}><ErrorState compact={compact}/></div>
-      </>
-    );
-  }
-
-  const mostPlayed = isEmpty ? [] : STATS.mostPlayed;
-  const winByGame = isEmpty ? [] : STATS.winByGame;
-
-  return (
-    <>
-      <StatsHero compact={compact} empty={isEmpty}/>
-      <div style={{ padding: compact ? '14px 16px 24px' : '24px 32px 64px', display:'grid', gridTemplateColumns: compact ? '1fr' : 'repeat(2, 1fr)', gap: compact ? 12 : 16 }}>
-        {isLoading ? (
-          <>
-            <SectionSkeleton compact={compact} height={compact ? 200 : 240}/>
-            <SectionSkeleton compact={compact} height={compact ? 200 : 240}/>
-          </>
-        ) : (
-          <>
-            <StatsSection entity="game" icon="🎲" title="Giochi più giocati" meta={isEmpty ? '' : `top ${mostPlayed.length}`} compact={compact}>
-              <MostPlayed items={mostPlayed} compact={compact}/>
-            </StatsSection>
-            <StatsSection entity="toolkit" icon="🏆" title="Win-rate per gioco" meta={isEmpty ? '' : 'ordinato per %'} compact={compact}>
-              <WinByGame items={winByGame} compact={compact}/>
-            </StatsSection>
-          </>
-        )}
-      </div>
-    </>
-  );
-};
+const SectionGrid = ({ compact, children }) => (
+  <div style={{ padding: compact ? '14px 16px 24px' : '24px 32px 64px', display:'grid', gridTemplateColumns: compact ? '1fr' : 'repeat(2, 1fr)', gap: compact ? 12 : 16 }}>{children}</div>
+);
 
 // ═══════════════════════════════════════════════════════
-// ─── SHELLS ────────────────────────────────────────────
+// ─── APP CHROME ────────────────────────────────────────
 // ═══════════════════════════════════════════════════════
 const DesktopNav = () => {
-  const items = [{ id:'dash', label:'Dashboard' }, { id:'lib', label:'Libreria' }, { id:'rec', label:'Play records', active: true }, { id:'stats', label:'Statistiche', active: true }];
+  const items = [{ id:'dash', label:'Dashboard' }, { id:'lib', label:'Libreria' }, { id:'rec', label:'Play records' }, { id:'stats', label:'Statistiche', active: true }];
   return (
     <div style={{ display:'flex', alignItems:'center', gap: 14, padding:'10px 32px', background:'var(--glass-bg)', backdropFilter:'blur(12px)', borderBottom:'1px solid var(--border)' }}>
       <div style={{ display:'flex', alignItems:'center', gap: 9 }}>
-        <div style={{ width: 26, height: 26, borderRadius: 7, background:'linear-gradient(135deg, hsl(var(--c-game)), hsl(var(--c-event)))', color:'#fff', display:'flex', alignItems:'center', justifyContent:'center', fontWeight: 800, fontSize: 13, fontFamily:'var(--f-display)' }}>M</div>
+        <div style={{ width: 26, height: 26, borderRadius: 7, background:`linear-gradient(135deg, ${entityHsl('game')}, ${entityHsl('event')})`, color:'#fff', display:'flex', alignItems:'center', justifyContent:'center', fontWeight: 800, fontSize: 13, fontFamily:'var(--f-display)' }}>M</div>
         <span style={{ fontFamily:'var(--f-display)', fontWeight: 800, fontSize: 14 }}>MeepleAI</span>
       </div>
       <div style={{ display:'flex', alignItems:'center', gap: 2, marginLeft: 18 }}>
         {items.map(it => (
-          <span key={it.id} style={{ padding:'6px 12px', borderRadius:'var(--r-md)', fontFamily:'var(--f-display)', fontSize: 13, fontWeight: 700, color: it.active && it.id === 'stats' ? entityHsl('session') : 'var(--text-sec)', background: it.active && it.id === 'stats' ? entityHsl('session', 0.1) : 'transparent' }}>{it.label}</span>
+          <span key={it.id} style={{ padding:'6px 12px', borderRadius:'var(--r-md)', fontFamily:'var(--f-display)', fontSize: 13, fontWeight: 700, color: it.active ? entityHsl('session') : 'var(--text-sec)', background: it.active ? entityHsl('session', 0.1) : 'transparent' }}>{it.label}</span>
         ))}
       </div>
       <div style={{ flex: 1 }}/>
@@ -223,13 +258,6 @@ const DesktopNav = () => {
   );
 };
 
-const DesktopScreen = ({ stateOverride }) => (
-  <div style={{ minHeight: 640, background:'var(--bg)' }}>
-    <DesktopNav/>
-    <StatsBody stateOverride={stateOverride}/>
-  </div>
-);
-
 const PhoneSbar = () => (
   <div className="phone-sbar" style={{ color:'var(--text)' }}><span>14:32</span><div className="ind"><span aria-hidden="true">●●●●</span><span aria-hidden="true">100%</span></div></div>
 );
@@ -237,11 +265,11 @@ const PhoneTopNav = () => (
   <div style={{ display:'flex', alignItems:'center', gap: 9, padding:'10px 14px', borderBottom:'1px solid var(--border)', background:'var(--bg)' }}>
     <a href="sp4-play-records-index.html" aria-label="Indietro" style={{ width: 32, height: 32, borderRadius:'var(--r-md)', background:'transparent', border:'1px solid var(--border)', color:'var(--text)', fontSize: 14, display:'flex', alignItems:'center', justifyContent:'center' }}>←</a>
     <div style={{ flex: 1, fontFamily:'var(--f-display)', fontSize: 14, fontWeight: 700, textAlign:'center' }}>Statistiche</div>
-    <button aria-label="Filtra periodo" style={{ width: 32, height: 32, borderRadius:'var(--r-md)', background:'transparent', border:'1px solid var(--border)', color:'var(--text)', fontSize: 14, cursor:'pointer' }}>⚙</button>
+    <span style={{ width: 32, height: 32, borderRadius:'var(--r-md)', border:'1px solid var(--border)', color:'var(--text)', fontSize: 14, display:'flex', alignItems:'center', justifyContent:'center' }} aria-hidden="true">⚙</span>
   </div>
 );
 const MobileBottomBar = () => {
-  const tabs = [{ id:'home', icon:'⌂', label:'Home' }, { id:'lib', icon:'📚', label:'Libreria' }, { id:'rec', icon:'🎯', label:'Partite', active: true }, { id:'chat', icon:'💬', label:'Chat' }, { id:'me', icon:'👤', label:'Profilo' }];
+  const tabs = [{ id:'home', icon:'⌂', label:'Home' }, { id:'lib', icon:'📚', label:'Libreria' }, { id:'rec', icon:'🎯', label:'Partite' }, { id:'stats', icon:'📊', label:'Stats', active: true }, { id:'me', icon:'👤', label:'Profilo' }];
   return (
     <div style={{ position:'absolute', bottom: 0, left: 0, right: 0, display:'flex', padding:'8px 10px 12px', background:'var(--glass-bg)', backdropFilter:'blur(14px)', borderTop:'1px solid var(--border)', zIndex: 5 }}>
       {tabs.map(t => (
@@ -252,87 +280,211 @@ const MobileBottomBar = () => {
     </div>
   );
 };
-const MobileScreen = ({ stateOverride }) => (
-  <>
-    <PhoneSbar/>
-    <div style={{ flex: 1, overflowY:'auto', position:'relative', background:'var(--bg)' }}>
-      <PhoneTopNav/>
-      <div style={{ paddingBottom: 70 }}><StatsBody stateOverride={stateOverride} compact/></div>
-      <MobileBottomBar/>
-    </div>
-  </>
-);
 
-const PhoneShell = ({ label, desc, children }) => (
-  <div style={{ display:'flex', flexDirection:'column', alignItems:'center', gap: 10 }}>
-    <div style={{ fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-sec)', textTransform:'uppercase', letterSpacing:'.08em', fontWeight: 700 }}>{label}</div>
-    <div className="phone">{children}</div>
-    {desc && <div style={{ fontSize: 11, color:'var(--text-muted)', maxWidth: 340, textAlign:'center', lineHeight: 1.55 }}>{desc}</div>}
-  </div>
-);
-
-const DesktopFrame = ({ label, desc, dark, children }) => (
-  <div style={{ display:'flex', flexDirection:'column', alignItems:'center', gap: 12, width:'100%' }} data-theme={dark ? 'dark' : undefined}>
-    <div style={{ fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-sec)', textTransform:'uppercase', letterSpacing:'.08em', fontWeight: 700 }}>{label}{dark && <span style={{ color: entityHsl('session'), marginLeft: 6 }}>· dark</span>}</div>
-    <div className="desktop-frame">
-      <div className="desktop-bar"><span className="traffic"/><span className="traffic"/><span className="traffic"/><span className="url">meepleai.app/play-records/stats</span></div>
+// Screen: renders one state's full dashboard, in mobile (compact) or desktop chrome.
+const Screen = ({ children, compact }) => {
+  if (compact) {
+    return (
+      <>
+        <PhoneSbar/>
+        <div style={{ flex: 1, overflowY:'auto', position:'relative', background:'var(--bg)' }}>
+          <PhoneTopNav/>
+          <div style={{ paddingBottom: 70 }}>{children}</div>
+          <MobileBottomBar/>
+        </div>
+      </>
+    );
+  }
+  return (
+    <div style={{ display:'flex', flexDirection:'column', minHeight: 0, background:'var(--bg)' }}>
+      <DesktopNav/>
       {children}
     </div>
-    {desc && <div style={{ fontSize: 11, color:'var(--text-muted)', maxWidth: 720, textAlign:'center', lineHeight: 1.55 }}>{desc}</div>}
+  );
+};
+
+// ═══════════════════════════════════════════════════════
+// ─── STATO 01 · DEFAULT ────────────────────────────────
+// state-01-default — dashboard completa as-shipped (INVARIATO).
+// ═══════════════════════════════════════════════════════
+const State01_Default = ({ compact }) => (
+  <Screen compact={compact}>
+    <StatsHero compact={compact}/>
+    <SectionGrid compact={compact}>
+      <StatsSection entity="game" icon="🎲" title="Giochi più giocati" ariaLabel="Giochi più giocati per numero di partite" meta={`top ${STATS.mostPlayed.length}`} compact={compact}>
+        <MostPlayed items={STATS.mostPlayed}/>
+      </StatsSection>
+      <StatsSection entity="toolkit" icon="🏆" title="Win-rate per gioco" ariaLabel="Win-rate per gioco ordinato per percentuale" meta="ordinato per %" compact={compact}>
+        <WinByGame items={STATS.winByGame}/>
+      </StatsSection>
+    </SectionGrid>
+  </Screen>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── STATO 02 · EMPTY ──────────────────────────────────
+// state-02-empty — utente nuovo, zero partite. Banner info role="status",
+// KPI a 0/—/n.d. (placeholder), sezioni sostituite da empty-state card + CTA.
+// ═══════════════════════════════════════════════════════
+const State02_Empty = ({ compact }) => (
+  <Screen compact={compact}>
+    <EmptyInfoBanner compact={compact}/>
+    <StatsHero compact={compact} empty/>
+    <SectionGrid compact={compact}>
+      <EmptyDashCard compact={compact}/>
+    </SectionGrid>
+  </Screen>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── STATO 03 · LOADING ────────────────────────────────
+// state-03-loading — fetch aggregati in corso. aria-busy sul wrapper,
+// screen-reader span, skeleton aria-hidden. Pulse 2s / snap reduced-motion.
+// ═══════════════════════════════════════════════════════
+const State03_Loading = ({ compact }) => (
+  <Screen compact={compact}>
+    <div aria-busy="true" style={{ position:'relative' }}>
+      <span style={{ position:'absolute', width: 1, height: 1, padding: 0, margin: -1, overflow:'hidden', clip:'rect(0 0 0 0)', whiteSpace:'nowrap', border: 0 }}>
+        Caricamento statistiche partite…
+      </span>
+      <HeroSkel compact={compact}/>
+      <SectionGrid compact={compact}>
+        <SectionSkel rows={5} compact={compact}/>
+        <SectionSkel rows={5} compact={compact}/>
+      </SectionGrid>
+    </div>
+  </Screen>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── STATO 04 · ERROR ──────────────────────────────────
+// state-04-error — banner full-width role="alert" + retry, area vuota con
+// link torna-lista, footer dismiss.
+// ═══════════════════════════════════════════════════════
+const State04_Error = ({ compact }) => (
+  <Screen compact={compact}>
+    <ErrorBanner compact={compact}/>
+    <div style={{ flex: 1, padding: compact ? '28px 16px' : '56px 32px', display:'flex', alignItems:'flex-start', justifyContent:'center' }}>
+      <div style={{ display:'flex', flexDirection:'column', alignItems:'center', textAlign:'center', maxWidth: 360 }}>
+        <div aria-hidden="true" style={{ width: 54, height: 54, borderRadius:'50%', background:'var(--bg-muted)', display:'flex', alignItems:'center', justifyContent:'center', fontSize: 24, marginBottom: 12 }}>🃏</div>
+        <div style={{ fontFamily:'var(--f-display)', fontSize: 14, fontWeight: 700, color:'var(--text-sec)', marginBottom: 4 }}>Nessun dato disponibile</div>
+        <p style={{ fontFamily:'var(--f-body)', fontSize: 12.5, color:'var(--text-muted)', margin:'0 0 16px', lineHeight: 1.5 }}>Le statistiche verranno mostrate qui una volta ripristinata la connessione.</p>
+        <a href="sp4-play-records-index.html" aria-label="Torna alla lista partite" style={{ padding:'8px 14px', borderRadius:'var(--r-md)', background:'transparent', color: entityHsl('session'), border:`1px solid ${entityHsl('session', 0.4)}`, fontFamily:'var(--f-display)', fontSize: 12.5, fontWeight: 800 }}>Torna alla lista partite</a>
+      </div>
+    </div>
+    <div style={{ padding: compact ? '12px 16px' : '14px 32px', borderTop:'1px solid var(--border-light)', display:'flex', justifyContent:'center' }}>
+      <button type="button" style={{ background:'transparent', border:'none', color:'var(--text-muted)', fontFamily:'var(--f-display)', fontSize: 12.5, fontWeight: 700, cursor:'pointer', textDecoration:'underline', textUnderlineOffset: 3 }}>Chiudi</button>
+    </div>
+  </Screen>
+);
+
+// ═══════════════════════════════════════════════════════
+// ─── STATO 05 · SSE — SKIPPED ──────────────────────────
+// La dashboard /play-records/stats NON è SSE-driven: gli aggregati sono
+// fetch-once (refresh manuale), non uno stream di eventi live. Nessun
+// State05_SSE renderizzato (cfr. G7 SessionStateRenderer: lo stato `sse` si
+// applica solo agli hub con sottoscrizione eventi live).
+// ═══════════════════════════════════════════════════════
+
+// ═══════════════════════════════════════════════════════
+// ─── GALLERY (scaffold allineato a sp4-play-records-index) ──
+// ═══════════════════════════════════════════════════════
+const MobileFrame = ({ Comp }) => (
+  <div style={{ display:'flex', flexDirection:'column', alignItems:'center', gap: 8 }}>
+    <div className="frame-tag">Mobile · 375</div>
+    <div className="phone"><Comp compact/></div>
   </div>
 );
 
-const MOBILE_STATES = [
-  { id:'m1', label:'01 · Default', desc:'KPI strip 2×2 (partite/giochi/win-rate/preferito) + Giochi più giocati + Win-rate per gioco con barre.' },
-  { id:'m2', state:'empty', label:'02 · Empty (first-run)', desc:'KPI a 0 + sezioni con empty-state entity-tinted + CTA Registra partita.' },
-  { id:'m3', state:'loading', label:'03 · Loading', desc:'KPI server-rendered + 2 section skeleton shimmer.' },
-  { id:'m4', state:'error', label:'04 · Error', desc:'Banner danger inline + retry, hero resta visibile.' },
+const DesktopFrame = ({ Comp }) => (
+  <div style={{ display:'flex', flexDirection:'column', gap: 8, flex: 1, minWidth: 0 }}>
+    <div className="frame-tag">Desktop · 1440</div>
+    <div className="desktop-frame">
+      <div className="desktop-bar"><span className="traffic"/><span className="traffic"/><span className="traffic"/><span className="url">meepleai.app/play-records/stats</span></div>
+      <div style={{ display:'flex', flexDirection:'column', minHeight: 640, background:'var(--bg)' }}><Comp/></div>
+    </div>
+  </div>
+);
+
+const StateMatrix = ({ Comp }) => (
+  <div className="matrix"><div className="matrix-row"><MobileFrame Comp={Comp}/><DesktopFrame Comp={Comp}/></div></div>
+);
+
+const STATES = [
+  { id:'state-01-default', num:'01', title:'Default', sub:'Dashboard completa as-shipped: KPI strip (89 partite · 9 giochi · 47% win-rate · preferito) + hero session 🎯 + Giochi più giocati + Win-rate per gioco. Stato base, invariato.', Comp: State01_Default },
+  { id:'state-02-empty',   num:'02', title:'Empty',   sub:'Utente nuovo, zero partite. Banner info role="status", KPI a 0/—/n.d., sezioni sostituite da empty-state card 📊 + CTA "Registra prima partita".', Comp: State02_Empty },
+  { id:'state-03-loading', num:'03', title:'Loading', sub:'Fetch aggregati in corso: skeleton KPI strip + hero + 2 sezioni (pulse 2s, snap con reduced-motion). aria-busy + screen-reader span.', Comp: State03_Loading },
+  { id:'state-04-error',   num:'04', title:'Error',   sub:'Errore fetch (role="alert") con retry inline, area vuota 🃏 + link "Torna alla lista partite", footer "Chiudi".', Comp: State04_Error },
+];
+
+const NAV = [
+  { id:'state-01-default', label:'01 · Default' },
+  { id:'state-02-empty',   label:'02 · Empty' },
+  { id:'state-03-loading', label:'03 · Loading' },
+  { id:'state-04-error',   label:'04 · Error' },
 ];
 
 function ThemeToggle() {
-  const [dark, setDark] = useState(false);
-  useEffect(() => { document.documentElement.setAttribute('data-theme', dark ? 'dark' : 'light'); }, [dark]);
+  const initial = (() => { try { return localStorage.getItem('sp4-pr-theme') === 'dark'; } catch (e) { return false; } })();
+  const [dark, setDark] = useState(initial);
+  useEffect(() => {
+    document.documentElement.setAttribute('data-theme', dark ? 'dark' : 'light');
+    try { localStorage.setItem('sp4-pr-theme', dark ? 'dark' : 'light'); } catch (e) {}
+  }, [dark]);
   return (
-    <button onClick={() => setDark(d => !d)} className="theme-toggle" aria-label={dark ? 'Tema chiaro' : 'Tema scuro'}>
+    <button type="button" className="theme-toggle" onClick={() => setDark(d => !d)} aria-pressed={dark}
+      aria-label={dark ? 'Passa a tema chiaro' : 'Passa a tema scuro'}>
       <span aria-hidden="true">{dark ? '🌙' : '☀️'}</span><span>{dark ? 'Dark' : 'Light'}</span>
     </button>
   );
 }
 
+function GalleryNav() {
+  return (
+    <nav className="gallery-nav" aria-label="Stati canonici">
+      <div className="gallery-nav-brand"><span aria-hidden="true">📊</span> SP4 · /play-records/stats</div>
+      <div className="gallery-nav-links">
+        {NAV.map(n => <a key={n.id} href={`#${n.id}`}>{n.label}</a>)}
+      </div>
+      <a className="gallery-nav-ghost" href="#state-05-sse-skipped" aria-disabled="true" title="state-05-sse: skipped — dashboard non SSE-driven (fetch-once aggregate)">05 · SSE · skip</a>
+      <ThemeToggle/>
+    </nav>
+  );
+}
+
+function StateSection({ id, num, title, sub, Comp }) {
+  return (
+    <section id={id} className="state-section" data-screen-label={id}>
+      <header className="state-head">
+        <div className="state-num">{num}</div>
+        <div className="state-head-text">
+          <h2>{title}</h2>
+          <p>{sub}</p>
+        </div>
+        <code className="state-anchor">#{id}</code>
+      </header>
+      <StateMatrix Comp={Comp}/>
+    </section>
+  );
+}
+
 function App() {
   return (
-    <div className="stage">
-      <ThemeToggle/>
-      <div className="stage-wrap">
-        <div style={{ fontFamily:'var(--f-mono)', fontSize: 11, color:'var(--text-muted)', textTransform:'uppercase', letterSpacing:'.08em', marginBottom: 8 }}>SP4 · /play-records · Stats 📊</div>
-        <h1>Play records — /play-records/stats</h1>
-        <p className="lead">
-          Dashboard statistiche partite. <strong>KPI strip</strong> (partite · giochi · win-rate · gioco preferito) +
-          sezioni <strong>Giochi più giocati</strong> (barre per partite) e <strong>Win-rate per gioco</strong> (barre %).
-          Mobile stacked + bottom-bar, desktop grid 2-col. 4 stati mobile + 3 desktop.
-        </p>
+    <div className="gallery">
+      <GalleryNav/>
+      <div className="gallery-body">
+        <header className="gallery-intro">
+          <div className="kicker">SP4 · /play-records/stats · Stats 📊 — canonical states</div>
+          <h1>Statistiche — Stati canonici</h1>
+          <p className="lead">
+            Dashboard statistiche partite allineata al pattern <strong>G7 SessionStateRenderer</strong> (PR 2357).
+            4 stati canonici × viewport mobile&nbsp;375 / desktop&nbsp;1440, × tema light/dark via toggle.
+            Entity dominante <strong>session 🎯</strong>; colori esclusivamente da token <code>--c-*</code> via <code>entityHsl()</code>.
+            Lo stato <code>state-05-sse</code> è intenzionalmente <strong>saltato</strong> (dashboard non SSE-driven, fetch-once aggregate).
+          </p>
+        </header>
 
-        <div className="section-label">Mobile · 375 — 4 stati</div>
-        <div className="phones-grid">
-          {MOBILE_STATES.map(s => (
-            <PhoneShell key={s.id} label={s.label} desc={s.desc}>
-              <MobileScreen stateOverride={s.state}/>
-            </PhoneShell>
-          ))}
-        </div>
-
-        <div className="section-label">Desktop · 1280 — 3 stati</div>
-        <div style={{ display:'flex', flexDirection:'column', gap: 36 }}>
-          <DesktopFrame label="05 · Desktop · Default" desc="Hero gradient + 4 KPI 4-col. Grid 2-col: Giochi più giocati + Win-rate per gioco.">
-            <DesktopScreen stateOverride={null}/>
-          </DesktopFrame>
-          <DesktopFrame label="06 · Desktop · Dark mode" dark desc="Barre entity game/toolkit + KPI verificati in dark.">
-            <DesktopScreen stateOverride={null}/>
-          </DesktopFrame>
-          <DesktopFrame label="07 · Desktop · Empty (first-run)" desc="Tutte le sezioni in empty-state con CTA Registra partita.">
-            <DesktopScreen stateOverride="empty"/>
-          </DesktopFrame>
-        </div>
+        {STATES.map(s => <StateSection key={s.id} {...s}/>)}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

**Mockup 5 di 5** del cluster Tier 2 P1 (umbrella #2342 US-INT-2d). **Conclude il cluster Play Records #2361.**

Estende il mockup dashboard \`sp4-play-records-stats.{html,jsx,fidelity.json}\` con i 3 nuovi stati canonici (empty + loading + error) allineati al G7 SessionStateRenderer pattern (PR #2357).

## Stati aggiunti (semantic stats-specific)

| Anchor | Component | Semantic | A11y |
|---|---|---|---|
| \`state-02-empty\` | \`State02_Empty\` | Utente nuovo (zero partite): KPI strip 0/—/n.d. dimmed, sezioni sostituite da empty-state card 📊 + CTA "Registra prima partita". | \`role="status"\` + \`aria-live="polite"\` + KPI value placeholder \`aria-label="Statistica non disponibile"\` |
| \`state-03-loading\` | \`State03_Loading\` | Skeleton primitives: KPI strip (4 KpiCard skel) + hero + 2 sezioni (header rect + 5 row skel + grid 3-col 9 card skel). Pulse 2s. | \`aria-busy="true"\` wrapper + skeleton \`aria-hidden\` + SR span |
| \`state-04-error\` | \`State04_Error\` | Errore fetch stats: banner alert + retry + area vuota con link "Torna alla lista partite" + footer dismiss. | \`role="alert"\` + \`aria-label="Riprova caricamento statistiche"\` |

## state-05-sse SKIPPED

Stats dashboard NON è SSE-driven (fetch-once aggregate, refresh manuale). Skip esplicito con commento JSX + nav ghost link.

## state-01-default INVARIATO

Dashboard completa as-shipped: KPI strip (89 partite · 9 giochi · 47% win-rate · Wingspan favorite) + Hero session 🎯 + Giochi più giocati (top 5 bar chart) + Win-rate per gioco (grid 3-col percentage). Zero regressioni.

## FREEZE compliance

- ✅ Zero hex hardcoded — 4× \`color:'#fff'\` su \`background: entityHsl(...)\` o \`linear-gradient\` entity colors (pattern \`.e-bg\` esentato).
- ✅ Zero asset BGG/hosting esterno user-side (ban #2123).
- ✅ Token-only via \`tokens.css\` (canonical_only).
- ✅ \`pnpm lint:bgg-mockups\` clean (NOT in violations baseline).

## A11y eccellente

- KPI card \`role="group"\` + \`aria-labelledby\` per ogni label/value pair
- KPI value placeholder \`aria-label="Statistica non disponibile"\`
- Sezioni \`role="region"\` + \`aria-label\` semantico
- Empty/Loading/Error a11y patterns standard (table sopra)

## File changed

| File | Change |
|---|---|
| \`sp4-play-records-stats.html\` | shell + gallery scaffold |
| \`sp4-play-records-stats.jsx\` | 4 React components + Gallery App + KPI/Section primitives state-aware |
| \`sp4-play-records-stats.fidelity.json\` | \`states_covered: [default, empty, loading, error]\` |

## Test plan

- [x] \`pnpm lint:bgg-mockups\` clean
- [x] \`pnpm typecheck\` pass
- [x] Manual grep zero BGG mentions
- [ ] Reviewer: browser test 4 anchor + ThemeToggle + responsive + KPI placeholder SR

## 🎉 Cluster #2361 complete (5/5)

| # | Mockup | PR | Status |
|---|---|---|---|
| 1 | \`sp4-play-records-index\` | #2481 | OPEN |
| 2 | \`sp4-play-records-new\` (+ pr-form-core estesa) | #2484 | OPEN |
| 3 | \`sp4-play-records-detail\` | #2485 | OPEN |
| 4 | \`sp4-play-records-edit\` | #2487 | OPEN |
| 5 | \`sp4-play-records-stats\` | **questa PR** | OPEN |

Sblocca **Tier 2 #2342 US-INT-2a/b/c/d** (Play Records family completa al livello mockup).

## Refs

- Issue: #2361 (Tier 2 P1 umbrella #2342 US-INT-2d)
- Pattern reference: G7 SessionStateRenderer PR #2357

🤖 Generated with [Claude Code](https://claude.com/claude-code)