### PR TITLE
feat(mechanic): #525 ME-M1.3 guardrails — T1-T4 chain + retry loop + observability

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Configuration/MechanicGuardrailOptions.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Configuration/MechanicGuardrailOptions.cs
@@ -1,0 +1,28 @@
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Configuration;
+
+/// <summary>
+/// ME-M1.3 (#525) tunable guardrail thresholds (ADR-051).
+/// Bound from configuration section <see cref="SectionName"/>.
+/// </summary>
+public sealed class MechanicGuardrailOptions
+{
+    public const string SectionName = "MechanicGuardrails";
+
+    /// <summary>T1: max words per citation quote.</summary>
+    public int MaxQuoteWords { get; init; } = 25;
+
+    /// <summary>T2: max contiguous normalized words from source allowed outside citation quotes.</summary>
+    public int MaxConsecutiveSourceWords { get; init; } = 10;
+
+    /// <summary>T3: minimum cosine similarity between a claim and its cited chunk.</summary>
+    public double MinClaimGroundingSimilarity { get; init; } = 0.65;
+
+    /// <summary>T8: hard cost cap (USD) for one analysis run, retry-inclusive.</summary>
+    public decimal MaxAnalysisCostUsd { get; init; } = 2.00m;
+
+    /// <summary>Max re-prompt retries per section (total attempts = value + 1).</summary>
+    public int MaxRetriesPerSection { get; init; } = 2;
+
+    /// <summary>Typical retry inflation factor for cost projection (1.3 = +30%).</summary>
+    public decimal RetryCostInflationFactor { get; init; } = 1.3m;
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/Guardrails/CitationPresenceGuardrail.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/Guardrails/CitationPresenceGuardrail.cs
@@ -1,0 +1,56 @@
+using System.Text.Json;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Services.MechanicExtractor.Guardrails;
+
+/// <summary>
+/// T3a — any object carrying a claim-bearing field (<c>claim</c>/<c>description</c>/<c>text</c>/
+/// <c>answer</c>/<c>primary</c>) must have a non-empty <c>citations</c> array at the same level.
+/// (Extracted from the M1.2 stub; rule renamed from <c>T4_citation_required</c> to
+/// <c>T3_citation_required</c> per the ADR-051 / #525 naming.)
+/// </summary>
+internal sealed class CitationPresenceGuardrail : IMechanicGuardrail
+{
+    public string RuleFamily => "T3";
+    public int Order => 15;
+
+    private static readonly string[] ClaimFields = { "claim", "description", "text", "answer", "primary" };
+
+    public Task<IReadOnlyList<MechanicValidationViolation>> EvaluateAsync(
+        MechanicGuardrailContext context, CancellationToken cancellationToken)
+    {
+        var violations = new List<MechanicValidationViolation>();
+        MechanicJsonWalker.ForEachObject(context.Root, "$", (obj, path) =>
+        {
+            if (obj.ValueKind != JsonValueKind.Object)
+            {
+                return;
+            }
+            foreach (var field in ClaimFields)
+            {
+                if (obj.TryGetProperty(field, out var claimElement)
+                    && claimElement.ValueKind == JsonValueKind.String
+                    && !string.IsNullOrWhiteSpace(claimElement.GetString()))
+                {
+                    if (!HasNonEmptyCitations(obj))
+                    {
+                        violations.Add(new MechanicValidationViolation(
+                            "T3_citation_required",
+                            $"Field '{field}' is a claim but no non-empty 'citations' array is present at the same level.",
+                            $"{path}.{field}"));
+                    }
+                    break; // one violation per object is enough
+                }
+            }
+        });
+        return Task.FromResult<IReadOnlyList<MechanicValidationViolation>>(violations);
+    }
+
+    private static bool HasNonEmptyCitations(JsonElement obj)
+    {
+        if (!obj.TryGetProperty("citations", out var citations))
+        {
+            return false;
+        }
+        return citations.ValueKind == JsonValueKind.Array && citations.GetArrayLength() > 0;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/Guardrails/CitationPresenceGuardrail.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/Guardrails/CitationPresenceGuardrail.cs
@@ -10,7 +10,7 @@ namespace Api.BoundedContexts.SharedGameCatalog.Application.Services.MechanicExt
 /// </summary>
 internal sealed class CitationPresenceGuardrail : IMechanicGuardrail
 {
-    public string RuleFamily => "T3";
+    public string RuleFamily => "T3a";
     public int Order => 15;
 
     private static readonly string[] ClaimFields = { "claim", "description", "text", "answer", "primary" };

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/Guardrails/GroundingGuardrail.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/Guardrails/GroundingGuardrail.cs
@@ -1,0 +1,144 @@
+using System.Text.Json;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Services;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Services.MechanicExtractor.Guardrails;
+
+/// <summary>
+/// T3b — semantic grounding. For each claim-bearing object with citations, embeds the claim text
+/// and its cited chunk and computes cosine similarity; flags claims below
+/// <see cref="Configuration.MechanicGuardrailOptions.MinClaimGroundingSimilarity"/>.
+/// Fails closed (blocks the section) if the embedding service is unavailable — IP &gt; latency in M1.
+/// </summary>
+internal sealed class GroundingGuardrail : IMechanicGuardrail
+{
+    private readonly IEmbeddingService _embeddings;
+
+    public GroundingGuardrail(IEmbeddingService embeddings) => _embeddings = embeddings;
+
+    public string RuleFamily => "T3";
+    public int Order => 40;
+
+    private static readonly string[] ClaimFields = { "claim", "description", "text", "answer", "primary" };
+
+    public async Task<IReadOnlyList<MechanicValidationViolation>> EvaluateAsync(
+        MechanicGuardrailContext context, CancellationToken cancellationToken)
+    {
+        var violations = new List<MechanicValidationViolation>();
+        var targets = new List<(string claim, string path, MechanicSourceChunk chunk)>();
+
+        MechanicJsonWalker.ForEachObject(context.Root, "$", (obj, path) =>
+        {
+            if (obj.ValueKind != JsonValueKind.Object)
+            {
+                return;
+            }
+            string? claim = null;
+            foreach (var f in ClaimFields)
+            {
+                if (obj.TryGetProperty(f, out var e) && e.ValueKind == JsonValueKind.String)
+                {
+                    var s = e.GetString();
+                    if (!string.IsNullOrWhiteSpace(s))
+                    {
+                        claim = s;
+                        break;
+                    }
+                }
+            }
+            if (claim is null)
+            {
+                return;
+            }
+            if (!obj.TryGetProperty("citations", out var cits) || cits.ValueKind != JsonValueKind.Array)
+            {
+                return;
+            }
+            foreach (var c in cits.EnumerateArray())
+            {
+                var chunk = ResolveChunk(c, context.SourceChunks);
+                if (chunk != null)
+                {
+                    targets.Add((claim!, path, chunk));
+                }
+            }
+        });
+
+        foreach (var (claim, path, chunk) in targets)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            try
+            {
+                var a = await _embeddings.EmbedAsync(claim, cancellationToken).ConfigureAwait(false);
+                var b = await _embeddings.EmbedAsync(chunk.Content, cancellationToken).ConfigureAwait(false);
+                var cos = Cosine(a, b);
+                if (cos < context.Options.MinClaimGroundingSimilarity)
+                {
+                    violations.Add(new MechanicValidationViolation(
+                        "T3_grounding",
+                        $"claim '{Trunc(claim)}' has cosine {cos:0.00} with cited chunk #{chunk.ChunkIndex} " +
+                        $"(page {chunk.PageNumber}), below threshold {context.Options.MinClaimGroundingSimilarity}",
+                        path));
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                violations.Add(new MechanicValidationViolation(
+                    "T3_grounding_unavailable",
+                    $"embedding service unavailable, failing closed: {ex.Message}",
+                    path));
+                break; // outage is global; no point retrying each claim
+            }
+        }
+
+        return violations;
+    }
+
+    private static MechanicSourceChunk? ResolveChunk(JsonElement citation, IReadOnlyList<MechanicSourceChunk> pool)
+    {
+        if (citation.ValueKind != JsonValueKind.Object)
+        {
+            return null;
+        }
+        if (citation.TryGetProperty("chunk_id", out var idEl) && idEl.ValueKind == JsonValueKind.String
+            && Guid.TryParse(idEl.GetString(), out var cid))
+        {
+            var byId = pool.FirstOrDefault(p => p.ChunkId == cid);
+            if (byId != null)
+            {
+                return byId;
+            }
+        }
+        if (citation.TryGetProperty("pdf_page", out var pEl) && pEl.ValueKind == JsonValueKind.Number
+            && pEl.TryGetInt32(out var page))
+        {
+            return pool.FirstOrDefault(p => p.PageNumber == page);
+        }
+        return null;
+    }
+
+    internal static double Cosine(float[] a, float[] b)
+    {
+        if (a.Length == 0 || b.Length == 0 || a.Length != b.Length)
+        {
+            return 0;
+        }
+        double dot = 0, na = 0, nb = 0;
+        for (var i = 0; i < a.Length; i++)
+        {
+            dot += a[i] * b[i];
+            na += a[i] * a[i];
+            nb += b[i] * b[i];
+        }
+        if (na <= 0d || nb <= 0d)
+        {
+            return 0;
+        }
+        return dot / (Math.Sqrt(na) * Math.Sqrt(nb));
+    }
+
+    private static string Trunc(string s) => s.Length <= 50 ? s : s[..50];
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/Guardrails/GroundingGuardrail.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/Guardrails/GroundingGuardrail.cs
@@ -15,7 +15,7 @@ internal sealed class GroundingGuardrail : IMechanicGuardrail
 
     public GroundingGuardrail(IEmbeddingService embeddings) => _embeddings = embeddings;
 
-    public string RuleFamily => "T3";
+    public string RuleFamily => "T3b";
     public int Order => 40;
 
     private static readonly string[] ClaimFields = { "claim", "description", "text", "answer", "primary" };

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/Guardrails/IMechanicGuardrail.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/Guardrails/IMechanicGuardrail.cs
@@ -1,0 +1,40 @@
+using System.Text.Json;
+using Api.BoundedContexts.SharedGameCatalog.Application.Configuration;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Services.MechanicExtractor.Guardrails;
+
+/// <summary>A retrieved source chunk pinned for the analysis run (T2/T3/T4 source pool).</summary>
+public sealed record MechanicSourceChunk(int ChunkIndex, int? PageNumber, Guid? ChunkId, string Content);
+
+/// <summary>Everything a guardrail needs to evaluate one section output.</summary>
+public sealed record MechanicGuardrailContext(
+    MechanicSection Section,
+    JsonElement Root,
+    IReadOnlyList<MechanicSourceChunk> SourceChunks,
+    int? PdfPageCount,
+    MechanicGuardrailOptions Options)
+{
+    /// <summary>Analysis id, for structured logging (AC-7). Optional for unit tests.</summary>
+    public Guid AnalysisId { get; init; } = Guid.Empty;
+
+    /// <summary>Current retry attempt, for structured logging (AC-7).</summary>
+    public int RetryCount { get; init; }
+}
+
+/// <summary>
+/// One ADR-051 guardrail (T1 quote cap, T2 long-verbatim, T3 citation present/grounded,
+/// T4 page+substring). Returns an empty list when the output passes.
+/// </summary>
+public interface IMechanicGuardrail
+{
+    /// <summary>Stable rule family prefix, e.g. "T1". Used for fail-fast ordering + metrics.</summary>
+    string RuleFamily { get; }
+
+    /// <summary>Lower runs first (cheapest-first). T1=10, T3a=15, T4=20, T2=30, T3b=40.</summary>
+    int Order { get; }
+
+    Task<IReadOnlyList<MechanicValidationViolation>> EvaluateAsync(
+        MechanicGuardrailContext context,
+        CancellationToken cancellationToken);
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/Guardrails/MechanicJsonWalker.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/Guardrails/MechanicJsonWalker.cs
@@ -1,0 +1,33 @@
+using System.Text.Json;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Services.MechanicExtractor.Guardrails;
+
+/// <summary>
+/// Shared recursive JSON walker used by the guardrails. Mirrors the original walk in the
+/// M1.2 <c>MechanicOutputValidator</c> stub: visits every object node with its JSONPath-ish path.
+/// </summary>
+internal static class MechanicJsonWalker
+{
+    public static void ForEachObject(JsonElement el, string path, Action<JsonElement, string> visit)
+    {
+        switch (el.ValueKind)
+        {
+            case JsonValueKind.Object:
+                visit(el, path);
+                foreach (var p in el.EnumerateObject())
+                {
+                    ForEachObject(p.Value, $"{path}.{p.Name}", visit);
+                }
+                break;
+
+            case JsonValueKind.Array:
+                var idx = 0;
+                foreach (var item in el.EnumerateArray())
+                {
+                    ForEachObject(item, $"{path}[{idx}]", visit);
+                    idx++;
+                }
+                break;
+        }
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/Guardrails/PageSubstringGuardrail.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/Guardrails/PageSubstringGuardrail.cs
@@ -58,9 +58,25 @@ internal sealed class PageSubstringGuardrail : IMechanicGuardrail
                 return;
             }
 
-            var candidates = normalizedChunksByPage.TryGetValue(page, out var byPage) && byPage.Count > 0
-                ? byPage
-                : allNormalized;
+            // Verify against chunks covering the cited page. Three cases:
+            //  - page has indexed chunks → check those
+            //  - pool HAS page metadata but not for this page (partial indexing) → unverifiable, skip.
+            //    Do NOT widen to the whole document, or a fabricated page citation could pass when the
+            //    quoted text happens to appear on another page.
+            //  - pool has NO page metadata at all → best-effort whole-document check.
+            List<string> candidates;
+            if (normalizedChunksByPage.TryGetValue(page, out var byPage) && byPage.Count > 0)
+            {
+                candidates = byPage;
+            }
+            else if (normalizedChunksByPage.Count > 0)
+            {
+                return; // page in range but not indexed — unverifiable, skip (no false positive)
+            }
+            else
+            {
+                candidates = allNormalized;
+            }
             if (candidates.Count == 0)
             {
                 return; // no source pool to verify against (e.g. unit context) — skip, not a violation

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/Guardrails/PageSubstringGuardrail.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/Guardrails/PageSubstringGuardrail.cs
@@ -1,0 +1,108 @@
+using System.Text;
+using System.Text.Json;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Services.MechanicExtractor.Guardrails;
+
+/// <summary>
+/// T4 — every citation's <c>pdf_page</c> must be within the PDF page range, and its <c>quote</c>
+/// must be a normalized substring of at least one source chunk covering that page (or any chunk
+/// when no page metadata is available).
+/// </summary>
+internal sealed class PageSubstringGuardrail : IMechanicGuardrail
+{
+    public string RuleFamily => "T4";
+    public int Order => 20;
+
+    public Task<IReadOnlyList<MechanicValidationViolation>> EvaluateAsync(
+        MechanicGuardrailContext context, CancellationToken cancellationToken)
+    {
+        var violations = new List<MechanicValidationViolation>();
+
+        var normalizedChunksByPage = context.SourceChunks
+            .Where(c => c.PageNumber.HasValue)
+            .GroupBy(c => c.PageNumber!.Value)
+            .ToDictionary(g => g.Key, g => g.Select(c => Normalize(c.Content)).ToList());
+        var allNormalized = context.SourceChunks.Select(c => Normalize(c.Content)).ToList();
+
+        MechanicJsonWalker.ForEachObject(context.Root, "$", (obj, path) =>
+        {
+            if (obj.ValueKind != JsonValueKind.Object)
+            {
+                return;
+            }
+            if (!obj.TryGetProperty("pdf_page", out var pageEl) || pageEl.ValueKind != JsonValueKind.Number)
+            {
+                return;
+            }
+            if (!pageEl.TryGetInt32(out var page))
+            {
+                return;
+            }
+
+            if (page < 1 || (context.PdfPageCount is int pc && page > pc))
+            {
+                violations.Add(new MechanicValidationViolation(
+                    "T4_page_out_of_range",
+                    $"expected 1..{context.PdfPageCount?.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? "?"}, got {page}",
+                    $"{path}.pdf_page"));
+                return;
+            }
+
+            if (!obj.TryGetProperty("quote", out var qEl) || qEl.ValueKind != JsonValueKind.String)
+            {
+                return;
+            }
+            var quote = Normalize(qEl.GetString() ?? string.Empty);
+            if (quote.Length == 0)
+            {
+                return;
+            }
+
+            var candidates = normalizedChunksByPage.TryGetValue(page, out var byPage) && byPage.Count > 0
+                ? byPage
+                : allNormalized;
+            if (candidates.Count == 0)
+            {
+                return; // no source pool to verify against (e.g. unit context) — skip, not a violation
+            }
+
+            var found = candidates.Any(c => c.Contains(quote, StringComparison.Ordinal));
+            if (!found)
+            {
+                var expected = candidates[0];
+                violations.Add(new MechanicValidationViolation(
+                    "T4_quote_not_substring",
+                    $"quote not found on page {page}. expected≈\"{Truncate(expected, 80)}\" actual=\"{Truncate(quote, 80)}\"",
+                    $"{path}.quote"));
+            }
+        });
+
+        return Task.FromResult<IReadOnlyList<MechanicValidationViolation>>(violations);
+    }
+
+    /// <summary>Lowercase, strip punctuation/symbols, collapse whitespace to single spaces.</summary>
+    internal static string Normalize(string s)
+    {
+        var sb = new StringBuilder(s.Length);
+        var lastSpace = false;
+        foreach (var ch in s)
+        {
+            if (char.IsLetterOrDigit(ch))
+            {
+                sb.Append(char.ToLowerInvariant(ch));
+                lastSpace = false;
+            }
+            else if (char.IsWhiteSpace(ch) || char.IsPunctuation(ch) || char.IsSymbol(ch))
+            {
+                if (!lastSpace && sb.Length > 0)
+                {
+                    sb.Append(' ');
+                    lastSpace = true;
+                }
+            }
+        }
+        return sb.ToString().TrimEnd();
+    }
+
+    private static string Truncate(string s, int n) => s.Length <= n ? s : s[..n];
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/Guardrails/QuoteCapGuardrail.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/Guardrails/QuoteCapGuardrail.cs
@@ -1,0 +1,79 @@
+using System.Text.Json;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Services.MechanicExtractor.Guardrails;
+
+/// <summary>
+/// T1 — every <c>citation.quote</c> must be ≤ <see cref="Configuration.MechanicGuardrailOptions.MaxQuoteWords"/>
+/// words. Tokenizer is hardened against Unicode whitespace (NBSP, thin space), em/en dashes,
+/// and pure-punctuation tokens.
+/// </summary>
+internal sealed class QuoteCapGuardrail : IMechanicGuardrail
+{
+    public string RuleFamily => "T1";
+    public int Order => 10;
+
+    public Task<IReadOnlyList<MechanicValidationViolation>> EvaluateAsync(
+        MechanicGuardrailContext context, CancellationToken cancellationToken)
+    {
+        var violations = new List<MechanicValidationViolation>();
+        MechanicJsonWalker.ForEachObject(context.Root, "$", (obj, path) =>
+        {
+            if (obj.TryGetProperty("quote", out var q) && q.ValueKind == JsonValueKind.String)
+            {
+                var text = q.GetString();
+                if (!string.IsNullOrWhiteSpace(text))
+                {
+                    var count = CountWords(text!);
+                    if (count > context.Options.MaxQuoteWords)
+                    {
+                        violations.Add(new MechanicValidationViolation(
+                            "T1_quote_cap",
+                            $"quote has {count} words, max is {context.Options.MaxQuoteWords}",
+                            $"{path}.quote"));
+                    }
+                }
+            }
+        });
+        return Task.FromResult<IReadOnlyList<MechanicValidationViolation>>(violations);
+    }
+
+    /// <summary>
+    /// Counts word tokens: any maximal run of non-separator chars containing ≥1 letter or digit.
+    /// Unicode whitespace and em/en dashes split words; pure-punctuation runs are NOT counted.
+    /// </summary>
+    internal static int CountWords(string text)
+    {
+        var count = 0;
+        var i = 0;
+        var n = text.Length;
+        while (i < n)
+        {
+            while (i < n && IsSeparator(text[i]))
+            {
+                i++;
+            }
+            if (i >= n)
+            {
+                break;
+            }
+
+            var hasAlnum = false;
+            while (i < n && !IsSeparator(text[i]))
+            {
+                if (char.IsLetterOrDigit(text[i]))
+                {
+                    hasAlnum = true;
+                }
+                i++;
+            }
+            if (hasAlnum)
+            {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    private static bool IsSeparator(char c) =>
+        char.IsWhiteSpace(c) || c == '—' || c == '–'; // em-dash, en-dash
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/Guardrails/RejectionSamplingGuardrail.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/Guardrails/RejectionSamplingGuardrail.cs
@@ -1,0 +1,148 @@
+using System.Text;
+using System.Text.Json;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Services.MechanicExtractor.Guardrails;
+
+/// <summary>
+/// T2 — detects long verbatim copying. Flags any contiguous N-gram (N =
+/// <see cref="Configuration.MechanicGuardrailOptions.MaxConsecutiveSourceWords"/>) of normalized
+/// words in a claim-bearing field that exact-matches a contiguous N-gram in the source chunk pool.
+/// Citation <c>quote</c> fields are excluded (they are allowed verbatim, capped by T1).
+/// Uses a rolling FNV-1a hash index (Rabin-Karp style) with token-equality confirmation.
+/// </summary>
+internal sealed class RejectionSamplingGuardrail : IMechanicGuardrail
+{
+    public string RuleFamily => "T2";
+    public int Order => 30;
+
+    private static readonly string[] ScannedFields = { "claim", "description", "text", "answer", "primary" };
+
+    public Task<IReadOnlyList<MechanicValidationViolation>> EvaluateAsync(
+        MechanicGuardrailContext context, CancellationToken cancellationToken)
+    {
+        var n = context.Options.MaxConsecutiveSourceWords;
+        var violations = new List<MechanicValidationViolation>();
+
+        if (n <= 0 || context.SourceChunks.Count == 0)
+        {
+            return Task.FromResult<IReadOnlyList<MechanicValidationViolation>>(violations);
+        }
+
+        var sourceNgrams = new Dictionary<long, List<(int chunk, int offset, string[] gram)>>();
+        foreach (var sc in context.SourceChunks)
+        {
+            var tokens = Tokenize(sc.Content);
+            IndexNgrams(tokens, n, sc.ChunkIndex, sourceNgrams);
+        }
+
+        if (sourceNgrams.Count == 0)
+        {
+            return Task.FromResult<IReadOnlyList<MechanicValidationViolation>>(violations);
+        }
+
+        MechanicJsonWalker.ForEachObject(context.Root, "$", (obj, path) =>
+        {
+            if (obj.ValueKind != JsonValueKind.Object)
+            {
+                return;
+            }
+            foreach (var field in ScannedFields)
+            {
+                if (!obj.TryGetProperty(field, out var el) || el.ValueKind != JsonValueKind.String)
+                {
+                    continue;
+                }
+                var candidate = Tokenize(el.GetString() ?? string.Empty);
+                if (candidate.Length < n)
+                {
+                    continue;
+                }
+
+                for (var i = 0; i + n <= candidate.Length; i++)
+                {
+                    var hash = HashWindow(candidate, i, n);
+                    if (!sourceNgrams.TryGetValue(hash, out var bucket))
+                    {
+                        continue;
+                    }
+                    var window = candidate.AsSpan(i, n);
+                    foreach (var entry in bucket)
+                    {
+                        if (window.SequenceEqual(entry.gram))
+                        {
+                            var seq = string.Join(' ', window.ToArray());
+                            violations.Add(new MechanicValidationViolation(
+                                "T2_long_verbatim",
+                                $"{n}-word sequence matches chunk #{entry.chunk} at offset {entry.offset}: '{seq}'",
+                                $"{path}.{field}"));
+                            return; // one violation per object is enough
+                        }
+                    }
+                }
+            }
+        });
+
+        return Task.FromResult<IReadOnlyList<MechanicValidationViolation>>(violations);
+    }
+
+    private static void IndexNgrams(string[] tokens, int n, int chunk,
+        Dictionary<long, List<(int, int, string[])>> index)
+    {
+        for (var i = 0; i + n <= tokens.Length; i++)
+        {
+            var hash = HashWindow(tokens, i, n);
+            var gram = tokens.AsSpan(i, n).ToArray();
+            if (!index.TryGetValue(hash, out var list))
+            {
+                list = new List<(int, int, string[])>();
+                index[hash] = list;
+            }
+            list.Add((chunk, i, gram));
+        }
+    }
+
+    // FNV-1a over the joined normalized tokens of the window (deterministic).
+    private static long HashWindow(string[] tokens, int start, int n)
+    {
+        unchecked
+        {
+            const long prime = 1099511628211L;
+            var hash = 1469598103934665603L;
+            for (var k = 0; k < n; k++)
+            {
+                foreach (var ch in tokens[start + k])
+                {
+                    hash ^= ch;
+                    hash *= prime;
+                }
+                hash ^= ' ';
+                hash *= prime;
+            }
+            return hash;
+        }
+    }
+
+    // Normalize: lowercase, strip punctuation, collapse whitespace, NO stemming, NO diacritic folding.
+    internal static string[] Tokenize(string s)
+    {
+        var result = new List<string>();
+        var current = new StringBuilder();
+        foreach (var ch in s)
+        {
+            if (char.IsLetterOrDigit(ch))
+            {
+                current.Append(char.ToLowerInvariant(ch));
+            }
+            else if (current.Length > 0)
+            {
+                result.Add(current.ToString());
+                current.Clear();
+            }
+        }
+        if (current.Length > 0)
+        {
+            result.Add(current.ToString());
+        }
+        return result.ToArray();
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/IMechanicAnalysisPipeline.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/IMechanicAnalysisPipeline.cs
@@ -1,3 +1,4 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Services.MechanicExtractor.Guardrails;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
 using Api.Infrastructure.Entities.SharedGameCatalog;
 
@@ -35,7 +36,15 @@ public sealed record MechanicPipelineRequest(
     string Model,
     decimal EffectiveCostCapUsd,
     decimal InputCostPerMillionTokens,
-    decimal OutputCostPerMillionTokens);
+    decimal OutputCostPerMillionTokens)
+{
+    /// <summary>T2/T3/T4 source pool: pinned retrieved chunks per section (#525).</summary>
+    public IReadOnlyDictionary<MechanicSection, IReadOnlyList<MechanicSourceChunk>> SourceChunksBySection { get; init; }
+        = new Dictionary<MechanicSection, IReadOnlyList<MechanicSourceChunk>>();
+
+    /// <summary>T4 page-range upper bound (PDF page count), null when unknown.</summary>
+    public int? PdfPageCount { get; init; }
+}
 
 /// <summary>Outcome of a pipeline run.</summary>
 public sealed record MechanicPipelineResult(

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/IMechanicOutputValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/IMechanicOutputValidator.cs
@@ -1,24 +1,24 @@
-using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using Api.BoundedContexts.SharedGameCatalog.Application.Services.MechanicExtractor.Guardrails;
 
 namespace Api.BoundedContexts.SharedGameCatalog.Application.Services.MechanicExtractor;
 
 /// <summary>
-/// Validates LLM output against ADR-051 guardrails T1-T4 (quote cap, no long verbatim,
-/// citation required, grounding). ISSUE-524 / M1.2 ships a stub that only enforces the
-/// cheap checks (quote word count, presence of citations) — the deeper guardrails
-/// (semantic grounding via embedding similarity, long-sequence detection against source)
-/// land in M1.3.
+/// Validates LLM output against ADR-051 guardrails. ISSUE-525 / M1.3 evaluates a chain of
+/// injectable <see cref="IMechanicGuardrail"/> (T1 quote cap, T2 long-verbatim, T3 citation
+/// present/grounded, T4 page+substring) cheapest-first / fail-fast.
 /// </summary>
 public interface IMechanicOutputValidator
 {
     /// <summary>
-    /// Validate a raw JSON section output.
+    /// Validate a parsed section output against the guardrail chain.
     /// </summary>
-    /// <param name="section">Target section of this output.</param>
-    /// <param name="rawJson">Raw JSON text as returned by the LLM.</param>
+    /// <param name="context">Section output + source chunk pool + page count + options.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
     /// <returns>Aggregated validation result — <see cref="MechanicValidationResult.IsValid"/>
-    /// is <c>false</c> if any violation is detected.</returns>
-    MechanicValidationResult Validate(MechanicSection section, string rawJson);
+    /// is <c>false</c> if any guardrail produces violations (fail-fast at the first one).</returns>
+    Task<MechanicValidationResult> ValidateAsync(
+        MechanicGuardrailContext context,
+        CancellationToken cancellationToken);
 }
 
 /// <summary>Outcome of validation — either valid or a list of violations.</summary>

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/MechanicAnalysisExecutor.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/MechanicAnalysisExecutor.cs
@@ -1,4 +1,5 @@
 using System.Text;
+using Api.BoundedContexts.SharedGameCatalog.Application.Services.MechanicExtractor.Guardrails;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
@@ -156,6 +157,13 @@ internal sealed class MechanicAnalysisExecutor : IMechanicAnalysisExecutor
         // section semantic retrieval.
         var contextBySection = AllSections.ToDictionary(s => s, _ => retrievalContext);
 
+        // M1.3 (#525): pin the structured source chunk pool + page count for the guardrails
+        // (T2 long-verbatim, T3 grounding, T4 page/substring). Same bundle per section in M1.3.
+        var (sourceChunks, pdfPageCount) = await LoadSourcePoolAsync(analysis.PdfDocumentId, cancellationToken)
+            .ConfigureAwait(false);
+        var sourceChunksBySection = AllSections.ToDictionary(
+            s => s, _ => sourceChunks);
+
         var request = new MechanicPipelineRequest(
             AnalysisId: analysis.Id,
             SharedGameId: analysis.SharedGameId,
@@ -167,7 +175,11 @@ internal sealed class MechanicAnalysisExecutor : IMechanicAnalysisExecutor
             Model: analysis.ModelUsed,
             EffectiveCostCapUsd: analysis.CostCapUsd,
             InputCostPerMillionTokens: DefaultInputCostPerMillion,
-            OutputCostPerMillionTokens: DefaultOutputCostPerMillion);
+            OutputCostPerMillionTokens: DefaultOutputCostPerMillion)
+        {
+            SourceChunksBySection = sourceChunksBySection,
+            PdfPageCount = pdfPageCount
+        };
 
         var result = await _pipeline.RunAsync(request, cancellationToken).ConfigureAwait(false);
 
@@ -444,5 +456,31 @@ internal sealed class MechanicAnalysisExecutor : IMechanicAnalysisExecutor
         }
 
         return builder.ToString();
+    }
+
+    /// <summary>
+    /// M1.3 (#525): loads the structured source chunk pool (with page numbers + chunk ids) and the
+    /// PDF page count, pinned for the analysis run so the guardrails (T2/T3/T4) validate against the
+    /// same snapshot the LLM saw.
+    /// </summary>
+    private async Task<(IReadOnlyList<MechanicSourceChunk> Chunks, int? PageCount)> LoadSourcePoolAsync(
+        Guid pdfDocumentId, CancellationToken cancellationToken)
+    {
+        var chunks = await _dbContext.TextChunks
+            .AsNoTracking()
+            .Where(c => c.PdfDocumentId == pdfDocumentId)
+            .OrderBy(c => c.ChunkIndex)
+            .Select(c => new MechanicSourceChunk(c.ChunkIndex, c.PageNumber, c.Id, c.Content))
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var pageCount = await _dbContext.PdfDocuments
+            .AsNoTracking()
+            .Where(p => p.Id == pdfDocumentId)
+            .Select(p => p.PageCount)
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return (chunks, pageCount);
     }
 }

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/MechanicAnalysisPipeline.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/MechanicAnalysisPipeline.cs
@@ -1,8 +1,14 @@
 using System.Diagnostics;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Api.BoundedContexts.SharedGameCatalog.Application.Configuration;
+using Api.BoundedContexts.SharedGameCatalog.Application.Services.MechanicExtractor.Guardrails;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
 using Api.Infrastructure.Entities.SharedGameCatalog;
 using Api.Services;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace Api.BoundedContexts.SharedGameCatalog.Application.Services.MechanicExtractor;
 
@@ -18,8 +24,6 @@ namespace Api.BoundedContexts.SharedGameCatalog.Application.Services.MechanicExt
 /// </remarks>
 internal sealed class MechanicAnalysisPipeline : IMechanicAnalysisPipeline
 {
-    private const int MaxValidationRetries = 1;
-
     // Per-section max_tokens cap. ADR-051 originally targeted 1500, but live runs on
     // dense rulebooks (e.g. Dune: Imperium Setup section) truncate at the 1500 boundary
     // — the validator catches it via the well_formed rule ("Expected depth to be zero")
@@ -35,18 +39,21 @@ internal sealed class MechanicAnalysisPipeline : IMechanicAnalysisPipeline
     private readonly IMechanicOutputValidator _validator;
     private readonly TimeProvider _timeProvider;
     private readonly ILogger<MechanicAnalysisPipeline> _logger;
+    private readonly MechanicGuardrailOptions _options;
 
     public MechanicAnalysisPipeline(
         ILlmService llmService,
         IMechanicPromptProvider promptProvider,
         IMechanicOutputValidator validator,
         TimeProvider timeProvider,
+        IOptions<MechanicGuardrailOptions> options,
         ILogger<MechanicAnalysisPipeline> logger)
     {
         _llmService = llmService ?? throw new ArgumentNullException(nameof(llmService));
         _promptProvider = promptProvider ?? throw new ArgumentNullException(nameof(promptProvider));
         _validator = validator ?? throw new ArgumentNullException(nameof(validator));
         _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+        _options = options?.Value ?? throw new ArgumentNullException(nameof(options));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -132,7 +139,15 @@ internal sealed class MechanicAnalysisPipeline : IMechanicAnalysisPipeline
         var startedAt = _timeProvider.GetUtcNow().UtcDateTime;
         var stopwatch = Stopwatch.StartNew();
         string? lastValidationError = null;
-        var attempts = MaxValidationRetries + 1;
+        string? lastOutputHash = null;
+        var currentSystemPrompt = systemPrompt;
+        var attempts = _options.MaxRetriesPerSection + 1;
+
+        // Accumulate tokens/cost across all attempts (retries share the T8 cap, AC-6).
+        var accPromptTokens = 0;
+        var accCompletionTokens = 0;
+        decimal accCostUsd = 0m;
+        LlmCompletionResult? lastResult = null;
 
         for (var attempt = 1; attempt <= attempts; attempt++)
         {
@@ -140,7 +155,7 @@ internal sealed class MechanicAnalysisPipeline : IMechanicAnalysisPipeline
 
             var result = await _llmService.GenerateCompletionWithModelAsync(
                 explicitModel: request.Model,
-                systemPrompt: systemPrompt,
+                systemPrompt: currentSystemPrompt,
                 userPrompt: userPrompt,
                 source: RequestSource.Manual,
                 maxTokens: SectionMaxTokens,
@@ -164,11 +179,18 @@ internal sealed class MechanicAnalysisPipeline : IMechanicAnalysisPipeline
                     Abort: MechanicPipelineOutcome.AbortedLlmFailed);
             }
 
+            lastResult = result;
+            accPromptTokens += result.Usage.PromptTokens;
+            accCompletionTokens += result.Usage.CompletionTokens;
+            accCostUsd += result.Cost.TotalCost;
+
             // DeepSeek (and some other chat models) wrap JSON in markdown code fences
             // (```json ... ``` or ``` ... ```). The validator and downstream parser expect
             // raw JSON, so strip fences before validation and persist the cleaned output.
             var cleanedResponse = StripCodeFences(result.Response);
-            var validation = _validator.Validate(section, cleanedResponse);
+            var validation = await ValidateSectionAsync(
+                request, section, cleanedResponse, attempt - 1, cancellationToken).ConfigureAwait(false);
+
             if (validation.IsValid)
             {
                 stopwatch.Stop();
@@ -181,10 +203,10 @@ internal sealed class MechanicAnalysisPipeline : IMechanicAnalysisPipeline
                     RunOrder = runOrder,
                     Provider = string.IsNullOrWhiteSpace(result.Cost.Provider) ? request.Provider : result.Cost.Provider,
                     ModelUsed = string.IsNullOrWhiteSpace(result.Cost.ModelId) ? request.Model : result.Cost.ModelId,
-                    PromptTokens = result.Usage.PromptTokens,
-                    CompletionTokens = result.Usage.CompletionTokens,
-                    TotalTokens = result.Usage.TotalTokens,
-                    EstimatedCostUsd = decimal.Round(result.Cost.TotalCost, 6, MidpointRounding.AwayFromZero),
+                    PromptTokens = accPromptTokens,
+                    CompletionTokens = accCompletionTokens,
+                    TotalTokens = accPromptTokens + accCompletionTokens,
+                    EstimatedCostUsd = decimal.Round(accCostUsd, 6, MidpointRounding.AwayFromZero),
                     LatencyMs = (int)Math.Min(int.MaxValue, stopwatch.ElapsedMilliseconds),
                     Status = 0,
                     ErrorMessage = null,
@@ -200,6 +222,20 @@ internal sealed class MechanicAnalysisPipeline : IMechanicAnalysisPipeline
             _logger.LogWarning(
                 "Mechanic section '{Section}' attempt {Attempt}/{Total} failed validation: {Error}",
                 section, attempt, attempts, lastValidationError);
+
+            // AC-6 stable-output detection: identical regeneration → stop early.
+            var outputHash = ComputeHash(cleanedResponse);
+            if (string.Equals(outputHash, lastOutputHash, StringComparison.Ordinal))
+            {
+                _logger.LogWarning(
+                    "Mechanic section '{Section}' produced identical output on retry; breaking loop (RegenerationDivergent=false).",
+                    section);
+                break;
+            }
+            lastOutputHash = outputHash;
+
+            // Augment the system prompt with the violations (JSON) for self-correction.
+            currentSystemPrompt = AugmentSystemPrompt(systemPrompt, validation.Violations);
         }
 
         stopwatch.Stop();
@@ -210,12 +246,12 @@ internal sealed class MechanicAnalysisPipeline : IMechanicAnalysisPipeline
             AnalysisId = request.AnalysisId,
             Section = (int)section,
             RunOrder = runOrder,
-            Provider = request.Provider,
-            ModelUsed = request.Model,
-            PromptTokens = 0,
-            CompletionTokens = 0,
-            TotalTokens = 0,
-            EstimatedCostUsd = 0m,
+            Provider = lastResult is null || string.IsNullOrWhiteSpace(lastResult.Cost.Provider) ? request.Provider : lastResult.Cost.Provider,
+            ModelUsed = lastResult is null || string.IsNullOrWhiteSpace(lastResult.Cost.ModelId) ? request.Model : lastResult.Cost.ModelId,
+            PromptTokens = accPromptTokens,
+            CompletionTokens = accCompletionTokens,
+            TotalTokens = accPromptTokens + accCompletionTokens,
+            EstimatedCostUsd = decimal.Round(accCostUsd, 6, MidpointRounding.AwayFromZero),
             LatencyMs = (int)Math.Min(int.MaxValue, stopwatch.ElapsedMilliseconds),
             Status = 1,
             ErrorMessage = $"Validation failed after {attempts} attempts: {lastValidationError}",
@@ -223,6 +259,76 @@ internal sealed class MechanicAnalysisPipeline : IMechanicAnalysisPipeline
             CompletedAt = completedAtValidationFail
         };
         return (validationFailureRun, Output: null, Abort: MechanicPipelineOutcome.AbortedValidation);
+    }
+
+    /// <summary>
+    /// Parses the cleaned LLM output, builds the guardrail context (source pool + page count +
+    /// options), and runs the validator chain. A JSON parse failure becomes a
+    /// <c>well_formed</c> violation (so the retry loop re-prompts).
+    /// </summary>
+    private async Task<MechanicValidationResult> ValidateSectionAsync(
+        MechanicPipelineRequest request,
+        MechanicSection section,
+        string cleanedResponse,
+        int retryCount,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(cleanedResponse))
+        {
+            return MechanicValidationResult.Invalid(new[]
+            {
+                new MechanicValidationViolation("well_formed", "Output is empty or whitespace.")
+            });
+        }
+
+        JsonDocument doc;
+        try
+        {
+            doc = JsonDocument.Parse(cleanedResponse);
+        }
+        catch (JsonException ex)
+        {
+            return MechanicValidationResult.Invalid(new[]
+            {
+                new MechanicValidationViolation("well_formed", $"Output is not valid JSON: {ex.Message}")
+            });
+        }
+
+        try
+        {
+            var chunks = request.SourceChunksBySection.TryGetValue(section, out var sc)
+                ? sc
+                : Array.Empty<MechanicSourceChunk>();
+            var context = new MechanicGuardrailContext(
+                section, doc.RootElement, chunks, request.PdfPageCount, _options)
+            {
+                AnalysisId = request.AnalysisId,
+                RetryCount = retryCount
+            };
+            return await _validator.ValidateAsync(context, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            doc.Dispose();
+        }
+    }
+
+    private static string AugmentSystemPrompt(
+        string baseSystemPrompt, IReadOnlyList<MechanicValidationViolation> violations)
+    {
+        var payload = JsonSerializer.Serialize(
+            violations.Select(v => new { rule = v.Rule, message = v.Message, path = v.Path }));
+        return baseSystemPrompt
+            + "\n\n## PREVIOUS_ATTEMPT_VIOLATIONS\n"
+            + "Your previous output was rejected by the guardrails below. Fix every violation and "
+            + "return corrected JSON only (no prose):\n"
+            + payload;
+    }
+
+    private static string ComputeHash(string text)
+    {
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(text.Trim()));
+        return Convert.ToHexString(bytes);
     }
 
     private static MechanicAnalysisSectionRunEntity BuildFailedRun(

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/MechanicOutputValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/MechanicOutputValidator.cs
@@ -1,149 +1,66 @@
-using System.Text.Json;
-using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using System.Diagnostics;
+using Api.BoundedContexts.SharedGameCatalog.Application.Services.MechanicExtractor.Guardrails;
+using Api.Observability;
+using Microsoft.Extensions.Logging;
 
 namespace Api.BoundedContexts.SharedGameCatalog.Application.Services.MechanicExtractor;
 
 /// <summary>
-/// M1.2 stub implementation of <see cref="IMechanicOutputValidator"/>. Enforces the
-/// cheap-to-check guardrails from ADR-051:
-/// <list type="bullet">
-/// <item><description><b>T1 (quote cap)</b>: every <c>citation.quote</c> must be ≤ 25 words.</description></item>
-/// <item><description><b>T4 (citation required)</b>: any object carrying a <c>claim</c>/<c>description</c>/<c>text</c>/<c>answer</c> field must have a non-empty <c>citations</c> array alongside it at the same level, unless it is the top-level section envelope.</description></item>
-/// <item><description><b>JSON well-formedness</b>: output must parse as JSON.</description></item>
-/// </list>
-/// The deeper checks (T2 long-verbatim detection, T3 semantic grounding) require access
-/// to the retrieved chunks and ship in M1.3 as a follow-up.
+/// M1.3 (#525) guardrail chain orchestrator. Runs the registered <see cref="IMechanicGuardrail"/>
+/// instances ordered by <see cref="IMechanicGuardrail.Order"/> (cheapest-first) and returns at the
+/// first guardrail that produces violations (fail-fast). Emits per-guardrail metrics + structured
+/// logs (AC-7).
 /// </summary>
 internal sealed class MechanicOutputValidator : IMechanicOutputValidator
 {
-    private const int MaxQuoteWords = 25;
+    private readonly IReadOnlyList<IMechanicGuardrail> _guardrails;
+    private readonly ILogger<MechanicOutputValidator> _logger;
 
-    public MechanicValidationResult Validate(MechanicSection section, string rawJson)
+    public MechanicOutputValidator(
+        IEnumerable<IMechanicGuardrail> guardrails,
+        ILogger<MechanicOutputValidator> logger)
     {
-        if (string.IsNullOrWhiteSpace(rawJson))
+        _guardrails = guardrails.OrderBy(g => g.Order).ToList();
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<MechanicValidationResult> ValidateAsync(
+        MechanicGuardrailContext context, CancellationToken cancellationToken)
+    {
+        foreach (var guardrail in _guardrails)
         {
-            return MechanicValidationResult.Invalid(new[]
+            cancellationToken.ThrowIfCancellationRequested();
+            var stopwatch = Stopwatch.StartNew();
+            var violations = await guardrail.EvaluateAsync(context, cancellationToken).ConfigureAwait(false);
+            stopwatch.Stop();
+
+            var outcome = violations.Count == 0 ? "pass" : "fail";
+            MeepleAiMetrics.MechanicValidatorInvocations.Add(1, new System.Diagnostics.TagList
             {
-                new MechanicValidationViolation("well_formed", "Output is empty or whitespace.")
+                { "validator", guardrail.RuleFamily },
+                { "outcome", outcome }
             });
-        }
 
-        JsonDocument doc;
-        try
-        {
-            doc = JsonDocument.Parse(rawJson);
-        }
-        catch (JsonException ex)
-        {
-            return MechanicValidationResult.Invalid(new[]
+            _logger.LogInformation(
+                "Mechanic guardrail {Validator} {Outcome} for analysis {AnalysisId} section {Section} " +
+                "(retry {RetryCount}) in {LatencyMs}ms{ViolationRule}",
+                guardrail.RuleFamily, outcome, context.AnalysisId, context.Section, context.RetryCount,
+                stopwatch.ElapsedMilliseconds,
+                violations.Count == 0 ? string.Empty : $" — {violations[0].Rule}");
+
+            if (violations.Count > 0)
             {
-                new MechanicValidationViolation("well_formed", $"Output is not valid JSON: {ex.Message}")
-            });
-        }
-
-        var violations = new List<MechanicValidationViolation>();
-        try
-        {
-            WalkAndValidate(doc.RootElement, path: "$", violations);
-        }
-        finally
-        {
-            doc.Dispose();
-        }
-
-        return violations.Count == 0
-            ? MechanicValidationResult.Valid()
-            : MechanicValidationResult.Invalid(violations);
-    }
-
-    private static void WalkAndValidate(JsonElement element, string path, List<MechanicValidationViolation> violations)
-    {
-        switch (element.ValueKind)
-        {
-            case JsonValueKind.Object:
-                ValidateObject(element, path, violations);
-                foreach (var property in element.EnumerateObject())
+                foreach (var v in violations)
                 {
-                    WalkAndValidate(property.Value, $"{path}.{property.Name}", violations);
+                    MeepleAiMetrics.MechanicValidatorViolations.Add(1, new System.Diagnostics.TagList
+                    {
+                        { "rule", v.Rule }
+                    });
                 }
-                break;
-
-            case JsonValueKind.Array:
-                var index = 0;
-                foreach (var item in element.EnumerateArray())
-                {
-                    WalkAndValidate(item, $"{path}[{index}]", violations);
-                    index++;
-                }
-                break;
-        }
-    }
-
-    private static void ValidateObject(JsonElement obj, string path, List<MechanicValidationViolation> violations)
-    {
-        // T1: quote word cap
-        if (obj.TryGetProperty("quote", out var quoteElement) && quoteElement.ValueKind == JsonValueKind.String)
-        {
-            var quote = quoteElement.GetString();
-            if (!string.IsNullOrWhiteSpace(quote))
-            {
-                var wordCount = CountWords(quote);
-                if (wordCount > MaxQuoteWords)
-                {
-                    violations.Add(new MechanicValidationViolation(
-                        Rule: "T1_quote_cap",
-                        Message: $"Citation quote has {wordCount} words, exceeds cap of {MaxQuoteWords}.",
-                        Path: $"{path}.quote"));
-                }
+                return MechanicValidationResult.Invalid(violations); // fail-fast
             }
         }
 
-        // T4: citation required for claim-bearing fields
-        var claimFields = new[] { "claim", "description", "text", "answer", "primary" };
-        foreach (var field in claimFields)
-        {
-            if (obj.TryGetProperty(field, out var claimElement)
-                && claimElement.ValueKind == JsonValueKind.String
-                && !string.IsNullOrWhiteSpace(claimElement.GetString()))
-            {
-                if (!HasNonEmptyCitations(obj))
-                {
-                    violations.Add(new MechanicValidationViolation(
-                        Rule: "T4_citation_required",
-                        Message: $"Field '{field}' is a claim but no non-empty 'citations' array is present at the same level.",
-                        Path: $"{path}.{field}"));
-                }
-                break; // one violation per object is enough
-            }
-        }
-    }
-
-    private static bool HasNonEmptyCitations(JsonElement obj)
-    {
-        if (!obj.TryGetProperty("citations", out var citations))
-        {
-            return false;
-        }
-        return citations.ValueKind == JsonValueKind.Array && citations.GetArrayLength() > 0;
-    }
-
-    private static int CountWords(string text)
-    {
-        var count = 0;
-        var inWord = false;
-        foreach (var c in text)
-        {
-            if (char.IsWhiteSpace(c))
-            {
-                if (inWord) count++;
-                inWord = false;
-            }
-            else
-            {
-                inWord = true;
-            }
-        }
-        if (inWord) count++;
-        return count;
+        return MechanicValidationResult.Valid();
     }
 }

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs
@@ -4,6 +4,7 @@ using Api.BoundedContexts.SharedGameCatalog.Application.Jobs;
 using Api.BoundedContexts.SharedGameCatalog.Application.Services;
 using Api.BoundedContexts.SharedGameCatalog.Application.Services.BackgroundAnalysis;
 using Api.BoundedContexts.SharedGameCatalog.Application.Services.MechanicExtractor;
+using Api.BoundedContexts.SharedGameCatalog.Application.Services.MechanicExtractor.Guardrails;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Services;
 using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Providers;
@@ -38,6 +39,10 @@ internal static class SharedGameCatalogServiceExtensions
         // Issue #2454: Configure background analysis options
         services.Configure<BackgroundAnalysisOptions>(
             configuration.GetSection(BackgroundAnalysisOptions.SectionName));
+
+        // Issue #525 / M1.3: Mechanic guardrail thresholds (ADR-051).
+        services.Configure<MechanicGuardrailOptions>(
+            configuration.GetSection(MechanicGuardrailOptions.SectionName));
 
 
         // Register repositories
@@ -90,6 +95,13 @@ internal static class SharedGameCatalogServiceExtensions
         // Singleton: prompts are embedded assembly resources + internal ConcurrentDictionary cache.
         // Scoped would silently defeat the cache (new instance per request).
         services.AddSingleton<IMechanicPromptProvider, EmbeddedMechanicPromptProvider>();
+        // Issue #525 / M1.3: guardrail chain (T1 quote cap, T3a citation presence, T4 page/substring,
+        // T2 long-verbatim, T3b grounding) — evaluated cheapest-first / fail-fast by the orchestrator.
+        services.AddScoped<IMechanicGuardrail, QuoteCapGuardrail>();
+        services.AddScoped<IMechanicGuardrail, CitationPresenceGuardrail>();
+        services.AddScoped<IMechanicGuardrail, PageSubstringGuardrail>();
+        services.AddScoped<IMechanicGuardrail, RejectionSamplingGuardrail>();
+        services.AddScoped<IMechanicGuardrail, GroundingGuardrail>();
         services.AddScoped<IMechanicOutputValidator, MechanicOutputValidator>();
         services.AddScoped<IAnalysisCostEstimator, AnalysisCostEstimator>();
         services.AddScoped<IMechanicAnalysisPipeline, MechanicAnalysisPipeline>();

--- a/apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.MechanicGuardrails.cs
+++ b/apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.MechanicGuardrails.cs
@@ -1,0 +1,22 @@
+using System.Diagnostics.Metrics;
+
+namespace Api.Observability;
+
+/// <summary>
+/// ME-M1.3 (#525) guardrail observability (AC-7). Counters for guardrail evaluations and
+/// violations, tagged by validator family / rule.
+/// </summary>
+internal static partial class MeepleAiMetrics
+{
+    /// <summary>Guardrail evaluations, tagged {validator, outcome=pass|fail}.</summary>
+    public static readonly Counter<long> MechanicValidatorInvocations =
+        Meter.CreateCounter<long>(
+            "mechanic_validator_invocations_total",
+            description: "Mechanic guardrail evaluations by validator family and outcome.");
+
+    /// <summary>Guardrail violations, tagged {rule}.</summary>
+    public static readonly Counter<long> MechanicValidatorViolations =
+        Meter.CreateCounter<long>(
+            "mechanic_validator_violations_total",
+            description: "Mechanic guardrail violations by rule.");
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/MechanicExtractor/Guardrails/MechanicGuardrailTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/MechanicExtractor/Guardrails/MechanicGuardrailTests.cs
@@ -131,6 +131,17 @@ public sealed class PageSubstringGuardrailTests
         var r = await Eval(json, chunks, pageCount: 50);
         r.Should().ContainSingle().Which.Rule.Should().Be("T4_quote_not_substring");
     }
+
+    [Fact]
+    public async Task PageInRangeButNotIndexed_SkipsCheck()
+    {
+        // Pool has page metadata (page 3) but the citation cites page 5 (in range, not indexed).
+        // Must skip — NOT widen to the whole document (would let a fabricated page citation pass).
+        var chunks = new[] { new MechanicSourceChunk(0, 3, null, "the deck has cards") };
+        var json = "{\"claim\":\"x\",\"citations\":[{\"pdf_page\":5,\"quote\":\"anything not present\"}]}";
+        var r = await Eval(json, chunks, pageCount: 50);
+        r.Should().BeEmpty();
+    }
 }
 
 public sealed class RejectionSamplingGuardrailTests

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/MechanicExtractor/Guardrails/MechanicGuardrailTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/MechanicExtractor/Guardrails/MechanicGuardrailTests.cs
@@ -1,0 +1,243 @@
+using System.Text.Json;
+using Api.BoundedContexts.SharedGameCatalog.Application.Configuration;
+using Api.BoundedContexts.SharedGameCatalog.Application.Services.MechanicExtractor;
+using Api.BoundedContexts.SharedGameCatalog.Application.Services.MechanicExtractor.Guardrails;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Services;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.MechanicExtractor.Guardrails;
+
+public sealed class MechanicGuardrailOptionsTests
+{
+    [Fact]
+    public void Defaults_MatchAdr051()
+    {
+        var o = new MechanicGuardrailOptions();
+        o.MaxQuoteWords.Should().Be(25);
+        o.MaxConsecutiveSourceWords.Should().Be(10);
+        o.MinClaimGroundingSimilarity.Should().Be(0.65);
+        o.MaxAnalysisCostUsd.Should().Be(2.00m);
+        o.MaxRetriesPerSection.Should().Be(2);
+        MechanicGuardrailOptions.SectionName.Should().Be("MechanicGuardrails");
+    }
+}
+
+internal static class GuardrailTestContext
+{
+    public static MechanicGuardrailContext Ctx(
+        string json,
+        IReadOnlyList<MechanicSourceChunk>? chunks = null,
+        int? pageCount = 50)
+        => new(
+            MechanicSection.Mechanics,
+            JsonDocument.Parse(json).RootElement,
+            chunks ?? Array.Empty<MechanicSourceChunk>(),
+            pageCount,
+            new MechanicGuardrailOptions());
+}
+
+public sealed class QuoteCapGuardrailTests
+{
+    private static string QuoteOfWords(int n) =>
+        "{\"citations\":[{\"quote\":\"" + string.Join(' ', Enumerable.Range(1, n).Select(i => "w" + i)) + "\"}]}";
+
+    [Theory]
+    [InlineData(24, true)]
+    [InlineData(25, true)]
+    [InlineData(26, false)]
+    public async Task WordCountBoundary(int words, bool ok)
+    {
+        var result = await new QuoteCapGuardrail()
+            .EvaluateAsync(GuardrailTestContext.Ctx(QuoteOfWords(words)), default);
+        result.Any().Should().Be(!ok);
+        if (!ok)
+        {
+            result[0].Rule.Should().Be("T1_quote_cap");
+        }
+    }
+
+    [Fact]
+    public async Task UnicodeWhitespaceAndEmDash_CountAsSeparators()
+    {
+        // 26 tokens, one separated by an em-dash → must fail.
+        var quote = "a b c—d e f g h i j k l m n o p q r s t u v w x y z";
+        var json = "{\"citations\":[{\"quote\":\"" + quote + "\"}]}";
+        var result = await new QuoteCapGuardrail().EvaluateAsync(GuardrailTestContext.Ctx(json), default);
+        result.Should().ContainSingle().Which.Rule.Should().Be("T1_quote_cap");
+    }
+
+    [Fact]
+    public async Task PurePunctuationTokens_AreExcluded()
+    {
+        // 25 real words + standalone punctuation tokens → still 25 → pass.
+        var quote = string.Join(' ', Enumerable.Range(1, 25).Select(i => "w" + i)) + " - —";
+        var json = "{\"citations\":[{\"quote\":\"" + quote + "\"}]}";
+        var result = await new QuoteCapGuardrail().EvaluateAsync(GuardrailTestContext.Ctx(json), default);
+        result.Should().BeEmpty();
+    }
+}
+
+public sealed class CitationPresenceGuardrailTests
+{
+    [Fact]
+    public async Task ClaimWithoutCitations_Fails()
+    {
+        var json = "{\"claim\":\"x\"}";
+        var r = await new CitationPresenceGuardrail().EvaluateAsync(GuardrailTestContext.Ctx(json), default);
+        r.Should().ContainSingle().Which.Rule.Should().Be("T3_citation_required");
+    }
+
+    [Fact]
+    public async Task ClaimWithCitations_Passes()
+    {
+        var json = "{\"claim\":\"x\",\"citations\":[{\"pdf_page\":1,\"quote\":\"q\"}]}";
+        var r = await new CitationPresenceGuardrail().EvaluateAsync(GuardrailTestContext.Ctx(json), default);
+        r.Should().BeEmpty();
+    }
+}
+
+public sealed class PageSubstringGuardrailTests
+{
+    private static Task<IReadOnlyList<MechanicValidationViolation>> Eval(
+        string json, IReadOnlyList<MechanicSourceChunk> chunks, int? pageCount)
+        => new PageSubstringGuardrail().EvaluateAsync(GuardrailTestContext.Ctx(json, chunks, pageCount), default);
+
+    [Fact]
+    public async Task QuoteIsNormalizedSubstringOfChunk_Passes()
+    {
+        var chunks = new[] { new MechanicSourceChunk(0, 3, null, "Players take turns drawing cards from the deck.") };
+        var json = "{\"claim\":\"x\",\"citations\":[{\"pdf_page\":3,\"quote\":\"drawing cards from the deck\"}]}";
+        var r = await Eval(json, chunks, pageCount: 50);
+        r.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task PageOutOfRange_Fails()
+    {
+        var json = "{\"claim\":\"x\",\"citations\":[{\"pdf_page\":51,\"quote\":\"anything\"}]}";
+        var r = await Eval(json, Array.Empty<MechanicSourceChunk>(), pageCount: 50);
+        r.Should().ContainSingle().Which.Rule.Should().Be("T4_page_out_of_range");
+    }
+
+    [Fact]
+    public async Task QuoteNotSubstring_Fails()
+    {
+        var chunks = new[] { new MechanicSourceChunk(0, 3, null, "The board has nineteen spaces.") };
+        var json = "{\"claim\":\"x\",\"citations\":[{\"pdf_page\":3,\"quote\":\"dragons breathe fire\"}]}";
+        var r = await Eval(json, chunks, pageCount: 50);
+        r.Should().ContainSingle().Which.Rule.Should().Be("T4_quote_not_substring");
+    }
+}
+
+public sealed class RejectionSamplingGuardrailTests
+{
+    private static Task<IReadOnlyList<MechanicValidationViolation>> Eval(
+        string json, IReadOnlyList<MechanicSourceChunk> chunks)
+        => new RejectionSamplingGuardrail().EvaluateAsync(GuardrailTestContext.Ctx(json, chunks), default);
+
+    [Fact]
+    public async Task TenWordVerbatimFromClaim_Fails()
+    {
+        var src = "players take turns drawing cards from the top of the deck each round";
+        var chunks = new[] { new MechanicSourceChunk(0, 1, null, src) };
+        var json = "{\"claim\":\"players take turns drawing cards from the top of the deck\"}"; // 11 words verbatim
+        var r = await Eval(json, chunks);
+        r.Should().ContainSingle().Which.Rule.Should().Be("T2_long_verbatim");
+    }
+
+    [Fact]
+    public async Task ShortOverlap_Passes()
+    {
+        var chunks = new[] { new MechanicSourceChunk(0, 1, null, "players take turns drawing cards from the top deck") };
+        var json = "{\"claim\":\"players take turns drawing cards from the top\"}"; // 8 words < 10
+        var r = await Eval(json, chunks);
+        r.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task CitationQuote_IsExcluded()
+    {
+        var src = "players take turns drawing cards from the top of the deck each round";
+        var chunks = new[] { new MechanicSourceChunk(0, 1, null, src) };
+        var json = "{\"citations\":[{\"quote\":\"players take turns drawing cards from the top of the deck\"}]}";
+        var r = await Eval(json, chunks);
+        r.Should().BeEmpty();
+    }
+}
+
+public sealed class GroundingGuardrailTests
+{
+    [Fact]
+    public async Task LowCosine_Fails()
+    {
+        var embed = new Mock<IEmbeddingService>();
+        embed.Setup(e => e.EmbedAsync("cards have suits", It.IsAny<CancellationToken>()))
+             .ReturnsAsync(new[] { 1f, 0f });
+        embed.Setup(e => e.EmbedAsync(It.Is<string>(s => s != "cards have suits"), It.IsAny<CancellationToken>()))
+             .ReturnsAsync(new[] { 0f, 1f }); // orthogonal → cosine 0 < 0.65
+        var chunks = new[] { new MechanicSourceChunk(7, 12, null, "the board is hexagonal") };
+        var json = "{\"claim\":\"cards have suits\",\"citations\":[{\"pdf_page\":12,\"quote\":\"q\"}]}";
+        var r = await new GroundingGuardrail(embed.Object)
+            .EvaluateAsync(GuardrailTestContext.Ctx(json, chunks), default);
+        r.Should().ContainSingle().Which.Rule.Should().Be("T3_grounding");
+    }
+
+    [Fact]
+    public async Task EmbeddingOutage_FailsClosed()
+    {
+        var embed = new Mock<IEmbeddingService>();
+        embed.Setup(e => e.EmbedAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+             .ThrowsAsync(new InvalidOperationException("down"));
+        var chunks = new[] { new MechanicSourceChunk(7, 12, null, "x") };
+        var json = "{\"claim\":\"c\",\"citations\":[{\"pdf_page\":12,\"quote\":\"q\"}]}";
+        var r = await new GroundingGuardrail(embed.Object)
+            .EvaluateAsync(GuardrailTestContext.Ctx(json, chunks), default);
+        r.Should().ContainSingle().Which.Rule.Should().Be("T3_grounding_unavailable");
+    }
+
+    [Fact]
+    public async Task HighCosine_Passes()
+    {
+        var embed = new Mock<IEmbeddingService>();
+        embed.Setup(e => e.EmbedAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+             .ReturnsAsync(new[] { 1f, 1f }); // identical → cosine 1.0
+        var chunks = new[] { new MechanicSourceChunk(7, 12, null, "the board is hexagonal") };
+        var json = "{\"claim\":\"cards have suits\",\"citations\":[{\"pdf_page\":12,\"quote\":\"q\"}]}";
+        var r = await new GroundingGuardrail(embed.Object)
+            .EvaluateAsync(GuardrailTestContext.Ctx(json, chunks), default);
+        r.Should().BeEmpty();
+    }
+}
+
+public sealed class MechanicOutputValidatorChainTests
+{
+    [Fact]
+    public async Task FailFast_StopsAtFirstFailingFamily()
+    {
+        // T1 fails (26-word quote) AND T4 would fail (page 999) → only T1 reported (Order 10 < 20).
+        var json = "{\"claim\":\"x\",\"citations\":[{\"pdf_page\":999,\"quote\":\"" +
+                   string.Join(' ', Enumerable.Range(1, 26).Select(i => "w" + i)) + "\"}]}";
+        var sut = new MechanicOutputValidator(
+            new IMechanicGuardrail[] { new QuoteCapGuardrail(), new PageSubstringGuardrail() },
+            NullLogger<MechanicOutputValidator>.Instance);
+        var result = await sut.ValidateAsync(GuardrailTestContext.Ctx(json, pageCount: 50), default);
+        result.IsValid.Should().BeFalse();
+        result.Violations.Should().OnlyContain(v => v.Rule.StartsWith("T1"));
+    }
+
+    [Fact]
+    public async Task AllPass_ReturnsValid()
+    {
+        var chunks = new[] { new MechanicSourceChunk(0, 3, null, "players draw a card") };
+        var json = "{\"claim\":\"players draw\",\"citations\":[{\"pdf_page\":3,\"quote\":\"draw a card\"}]}";
+        var sut = new MechanicOutputValidator(
+            new IMechanicGuardrail[] { new QuoteCapGuardrail(), new CitationPresenceGuardrail(), new PageSubstringGuardrail() },
+            NullLogger<MechanicOutputValidator>.Instance);
+        var result = await sut.ValidateAsync(GuardrailTestContext.Ctx(json, chunks, pageCount: 50), default);
+        result.IsValid.Should().BeTrue();
+    }
+}

--- a/docs/superpowers/plans/2026-06-22-issue-525-mechanic-guardrails.md
+++ b/docs/superpowers/plans/2026-06-22-issue-525-mechanic-guardrails.md
@@ -1,0 +1,973 @@
+# ME-M1.3 Mechanic Extractor Guardrails (#525) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add validation guardrails (T1–T4 + cost cap + retry loop + observability) to the Mechanic Extractor pipeline so IP-violating, hallucinated, or runaway-cost LLM outputs are blocked before reaching the admin review queue, with auditable rejection reasons.
+
+**Architecture:** Refactor the context-free `IMechanicOutputValidator.Validate(section, rawJson)` stub into an async **chain of injectable `IMechanicGuardrail`** evaluated cheapest-first / fail-fast. Each guardrail receives a `MechanicGuardrailContext` carrying the parsed JSON, the source chunk pool (text + page metadata), the PDF page count, and the options. The pipeline builds the context, runs the chain, and drives a configurable re-prompt retry loop. Cost-cap projection becomes retry-inclusive. New Prometheus counters + structured logging.
+
+**Tech Stack:** .NET 9, xUnit v3, FluentAssertions 8.8.0, Moq 4.20.72, System.Diagnostics.Metrics (Prometheus via OTel), `IEmbeddingService.EmbedAsync` (e5-base).
+
+---
+
+## Design Decisions (locked)
+
+1. **USD not EUR.** The body says `MaxAnalysisCostEur` / €2.00, but the entire codebase uses USD (`CostCapUsd`, `EstimatedCostUsd`, `InputCostPerMillionTokens`). Use `MaxAnalysisCostUsd` (default `2.00m`) for consistency. Document the deviation in the PR.
+
+2. **Guardrail naming reconciliation.** The M1.2 stub labels citation-presence as `T4_citation_required`. The ADR-051/#525 spec uses: T1=quote length, T2=long-verbatim, T3=citation present+grounded, T4=page+substring. We adopt the **spec naming**: rename the existing presence check rule to `T3_citation_required` and reserve `T4_*` for page/substring. (No existing tests reference the old rule string — verified: no Mechanic validator tests exist.)
+
+3. **Source pool = retrieved chunks.** `LoadRetrievalContextAsync` already loads `TextChunks` (with `PageNumber`) then concatenates to a string. We add a parallel structured list `IReadOnlyList<MechanicSourceChunk>` passed through the pipeline so T2 (n-gram), T3 (grounding), T4 (substring) can operate per-chunk. No schema change, no `chunk_version_id` column — the in-memory retrieval snapshot IS the pinned pool for the run.
+
+4. **Async chain, fail-fast, cheapest-first order:** T1 (word count) → T4 (substring/page, string ops) → T2 (rolling hash) → T3 (embedding, network). Within a section, on first guardrail producing violations the chain stops (fail-fast) and the retry loop kicks in.
+
+5. **Fail-closed on embedding outage (T3).** If `IEmbeddingService.EmbedAsync` throws, the section fails validation (IP > latency in M1), surfaced as `Rule="T3_grounding_unavailable"`.
+
+6. **Cost in USD; grounding similarity 0.65; consecutive source words 10; max quote words 25; max retries 2** — all in `MechanicGuardrailOptions` with these defaults.
+
+---
+
+## File Structure
+
+**Create:**
+- `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Configuration/MechanicGuardrailOptions.cs` — options record (single responsibility: tunables).
+- `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/Guardrails/IMechanicGuardrail.cs` — guardrail interface + `MechanicGuardrailContext` + `MechanicSourceChunk`.
+- `.../Guardrails/QuoteCapGuardrail.cs` (T1)
+- `.../Guardrails/PageSubstringGuardrail.cs` (T4)
+- `.../Guardrails/RejectionSamplingGuardrail.cs` (T2)
+- `.../Guardrails/GroundingGuardrail.cs` (T3)
+- `.../Guardrails/CitationPresenceGuardrail.cs` (T3a — extracted from stub)
+- `apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.MechanicGuardrails.cs` — counters.
+- Tests under `apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/MechanicExtractor/Guardrails/` (one file per guardrail) + fixtures `apps/api/tests/Api.Tests/Fixtures/MechanicValidator/T1/`.
+
+**Modify:**
+- `.../MechanicExtractor/IMechanicOutputValidator.cs` — new async signature `ValidateAsync(MechanicGuardrailContext, CancellationToken)`.
+- `.../MechanicExtractor/MechanicOutputValidator.cs` — becomes the chain orchestrator.
+- `.../MechanicExtractor/MechanicAnalysisExecutor.cs` — build structured chunk list; pass through.
+- `.../MechanicExtractor/IMechanicAnalysisPipeline.cs` — add `SourceChunksBySection` + `PdfPageCount` to request.
+- `.../MechanicExtractor/MechanicAnalysisPipeline.cs` — build context, run async chain, configurable retry loop + augmented re-prompt + stable-output detection; retry-inclusive cost cap.
+- `.../Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs` — register options + guardrails.
+- `apps/api/src/Api/appsettings.json` — `MechanicGuardrails` section.
+
+---
+
+## Task 0: MechanicGuardrailOptions + DI registration
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Configuration/MechanicGuardrailOptions.cs`
+- Modify: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs`
+- Modify: `apps/api/src/Api/appsettings.json`
+- Test: `apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/MechanicExtractor/MechanicGuardrailOptionsTests.cs`
+
+- [ ] **Step 1: Write the failing test** — defaults are correct.
+
+```csharp
+using Api.BoundedContexts.SharedGameCatalog.Application.Configuration;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.MechanicExtractor;
+
+public sealed class MechanicGuardrailOptionsTests
+{
+    [Fact]
+    public void Defaults_MatchAdr051()
+    {
+        var o = new MechanicGuardrailOptions();
+        o.MaxQuoteWords.Should().Be(25);
+        o.MaxConsecutiveSourceWords.Should().Be(10);
+        o.MinClaimGroundingSimilarity.Should().Be(0.65);
+        o.MaxAnalysisCostUsd.Should().Be(2.00m);
+        o.MaxRetriesPerSection.Should().Be(2);
+        MechanicGuardrailOptions.SectionName.Should().Be("MechanicGuardrails");
+    }
+}
+```
+
+- [ ] **Step 2: Run test, verify FAIL** — `dotnet test --filter MechanicGuardrailOptionsTests` → FAIL (type missing).
+
+- [ ] **Step 3: Implement** (mirror `BackgroundAnalysisOptions` style — sealed, init props, const SectionName):
+
+```csharp
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Configuration;
+
+/// <summary>ME-M1.3 (#525) tunable guardrail thresholds (ADR-051).</summary>
+public sealed class MechanicGuardrailOptions
+{
+    public const string SectionName = "MechanicGuardrails";
+
+    /// <summary>T1: max words per citation quote.</summary>
+    public int MaxQuoteWords { get; init; } = 25;
+
+    /// <summary>T2: max contiguous normalized words from source allowed outside citation quotes.</summary>
+    public int MaxConsecutiveSourceWords { get; init; } = 10;
+
+    /// <summary>T3: minimum cosine similarity between a claim and its cited chunk.</summary>
+    public double MinClaimGroundingSimilarity { get; init; } = 0.65;
+
+    /// <summary>T8: hard cost cap (USD) for one analysis run, retry-inclusive.</summary>
+    public decimal MaxAnalysisCostUsd { get; init; } = 2.00m;
+
+    /// <summary>Max re-prompt retries per section (total attempts = value + 1).</summary>
+    public int MaxRetriesPerSection { get; init; } = 2;
+
+    /// <summary>Typical retry inflation factor for cost projection (1.3 = +30%).</summary>
+    public decimal RetryCostInflationFactor { get; init; } = 1.3m;
+}
+```
+
+- [ ] **Step 4: Register DI** — in `SharedGameCatalogServiceExtensions.cs`, next to the existing `services.Configure<BackgroundAnalysisOptions>(...)` line:
+
+```csharp
+services.Configure<MechanicGuardrailOptions>(
+    configuration.GetSection(MechanicGuardrailOptions.SectionName));
+```
+
+- [ ] **Step 5: appsettings.json** — add section (place near other SharedGameCatalog config):
+
+```json
+"MechanicGuardrails": {
+  "MaxQuoteWords": 25,
+  "MaxConsecutiveSourceWords": 10,
+  "MinClaimGroundingSimilarity": 0.65,
+  "MaxAnalysisCostUsd": 2.00,
+  "MaxRetriesPerSection": 2,
+  "RetryCostInflationFactor": 1.3
+}
+```
+
+- [ ] **Step 6: Run test, verify PASS.** Commit: `git commit -m "feat(mechanic): #525 MechanicGuardrailOptions + DI"`
+
+---
+
+## Task 1: MechanicSourceChunk + MechanicGuardrailContext + IMechanicGuardrail
+
+**Files:**
+- Create: `.../MechanicExtractor/Guardrails/IMechanicGuardrail.cs`
+- Test: none yet (pure type definitions; exercised by guardrail tasks).
+
+- [ ] **Step 1: Define the contracts** (no test — these are data carriers verified transitively):
+
+```csharp
+using System.Text.Json;
+using Api.BoundedContexts.SharedGameCatalog.Application.Configuration;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Services.MechanicExtractor.Guardrails;
+
+/// <summary>A retrieved source chunk pinned for the analysis run (T2/T3/T4 source pool).</summary>
+public sealed record MechanicSourceChunk(int ChunkIndex, int? PageNumber, Guid? ChunkId, string Content);
+
+/// <summary>Everything a guardrail needs to evaluate one section output.</summary>
+public sealed record MechanicGuardrailContext(
+    MechanicSection Section,
+    JsonElement Root,
+    IReadOnlyList<MechanicSourceChunk> SourceChunks,
+    int? PdfPageCount,
+    MechanicGuardrailOptions Options);
+
+/// <summary>One ADR-051 guardrail. Returns empty list when the output passes.</summary>
+public interface IMechanicGuardrail
+{
+    /// <summary>Stable rule family prefix, e.g. "T1". Used for fail-fast ordering + metrics.</summary>
+    string RuleFamily { get; }
+
+    /// <summary>Lower runs first (cheapest-first). T1=10, T4=20, T2=30, T3=40.</summary>
+    int Order { get; }
+
+    Task<IReadOnlyList<MechanicValidationViolation>> EvaluateAsync(
+        MechanicGuardrailContext context,
+        CancellationToken cancellationToken);
+}
+```
+
+- [ ] **Step 2: Build** — `dotnet build apps/api/src/Api` → success. Commit: `git commit -m "feat(mechanic): #525 guardrail contracts (context + source chunk + interface)"`
+
+---
+
+## Task 2: T1 QuoteCapGuardrail (hardened Unicode tokenizer)
+
+**Files:**
+- Create: `.../Guardrails/QuoteCapGuardrail.cs`
+- Test: `apps/api/tests/.../Guardrails/QuoteCapGuardrailTests.cs`
+- Fixtures: `apps/api/tests/Api.Tests/Fixtures/MechanicValidator/T1/*.json` (≥10, incl. Unicode)
+
+- [ ] **Step 1: Write failing tests** — boundary 24/25 pass, 26 fail; Unicode whitespace (` `, ` `) and em-dash counted as separators; pure-punctuation tokens excluded.
+
+```csharp
+using System.Text.Json;
+using Api.BoundedContexts.SharedGameCatalog.Application.Configuration;
+using Api.BoundedContexts.SharedGameCatalog.Application.Services.MechanicExtractor.Guardrails;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.MechanicExtractor.Guardrails;
+
+public sealed class QuoteCapGuardrailTests
+{
+    private static MechanicGuardrailContext Ctx(string json) => new(
+        MechanicSection.Mechanics,
+        JsonDocument.Parse(json).RootElement,
+        Array.Empty<MechanicSourceChunk>(),
+        PdfPageCount: 50,
+        new MechanicGuardrailOptions());
+
+    private static string QuoteOfWords(int n) =>
+        "{\"citations\":[{\"quote\":\"" + string.Join(' ', Enumerable.Range(1, n).Select(i => "w" + i)) + "\"}]}";
+
+    [Theory]
+    [InlineData(24, true)]
+    [InlineData(25, true)]
+    [InlineData(26, false)]
+    public async Task WordCountBoundary(int words, bool ok)
+    {
+        var result = await new QuoteCapGuardrail().EvaluateAsync(Ctx(QuoteOfWords(words)), default);
+        result.Any().Should().Be(!ok);
+        if (!ok) result[0].Rule.Should().Be("T1_quote_cap");
+    }
+
+    [Fact]
+    public async Task UnicodeWhitespaceAndEmDash_CountAsSeparators()
+    {
+        // 26 words separated by NBSP, thin-space, em-dash → must fail
+        var quote = "a b c—d e f g h i j k l m n o p q r s t u v w x y z";
+        var json = "{\"citations\":[{\"quote\":\"" + quote + "\"}]}";
+        var result = await new QuoteCapGuardrail().EvaluateAsync(Ctx(json), default);
+        result.Should().ContainSingle().Which.Rule.Should().Be("T1_quote_cap");
+    }
+
+    [Fact]
+    public async Task PurePunctuationTokens_AreExcluded()
+    {
+        // 25 real words + standalone "-" and "—" punctuation tokens → still 25 → pass
+        var quote = string.Join(' ', Enumerable.Range(1, 25).Select(i => "w" + i)) + " - —";
+        var json = "{\"citations\":[{\"quote\":\"" + quote + "\"}]}";
+        var result = await new QuoteCapGuardrail().EvaluateAsync(Ctx(json), default);
+        result.Should().BeEmpty();
+    }
+}
+```
+
+- [ ] **Step 2: Run, verify FAIL** (type missing).
+
+- [ ] **Step 3: Implement** — walk JSON for `quote` strings, tokenize with a hardened counter:
+
+```csharp
+using System.Globalization;
+using System.Text.Json;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Services.MechanicExtractor.Guardrails;
+
+internal sealed class QuoteCapGuardrail : IMechanicGuardrail
+{
+    public string RuleFamily => "T1";
+    public int Order => 10;
+
+    public Task<IReadOnlyList<MechanicValidationViolation>> EvaluateAsync(
+        MechanicGuardrailContext context, CancellationToken cancellationToken)
+    {
+        var violations = new List<MechanicValidationViolation>();
+        MechanicJsonWalker.ForEachObject(context.Root, "$", (obj, path) =>
+        {
+            if (obj.TryGetProperty("quote", out var q) && q.ValueKind == JsonValueKind.String)
+            {
+                var text = q.GetString();
+                if (!string.IsNullOrWhiteSpace(text))
+                {
+                    var count = CountWords(text!);
+                    if (count > context.Options.MaxQuoteWords)
+                    {
+                        violations.Add(new MechanicValidationViolation(
+                            "T1_quote_cap",
+                            $"quote has {count} words, max is {context.Options.MaxQuoteWords}",
+                            $"{path}.quote"));
+                    }
+                }
+            }
+        });
+        return Task.FromResult<IReadOnlyList<MechanicValidationViolation>>(violations);
+    }
+
+    /// <summary>Counts word tokens: any maximal run of non-whitespace chars containing ≥1 letter or digit.
+    /// Unicode whitespace (incl. NBSP  , thin space  ) and em-dash split words; pure-punctuation
+    /// runs (e.g. "-", "—") are NOT counted.</summary>
+    internal static int CountWords(string text)
+    {
+        var count = 0;
+        var i = 0;
+        var n = text.Length;
+        while (i < n)
+        {
+            while (i < n && IsSeparator(text[i])) i++;
+            if (i >= n) break;
+            var hasAlnum = false;
+            while (i < n && !IsSeparator(text[i]))
+            {
+                if (char.IsLetterOrDigit(text[i])) hasAlnum = true;
+                i++;
+            }
+            if (hasAlnum) count++;
+        }
+        return count;
+    }
+
+    private static bool IsSeparator(char c) =>
+        char.IsWhiteSpace(c) || c == '—' || c == '–'; // em-dash, en-dash
+}
+```
+
+> NOTE: `MechanicJsonWalker` is a small static helper extracted from the existing recursive walk in `MechanicOutputValidator.WalkAndValidate`. Define it in `Guardrails/MechanicJsonWalker.cs` in this task (Step 3b): a static `ForEachObject(JsonElement, string path, Action<JsonElement,string>)` doing the same Object/Array recursion as the current stub (lines 59–80).
+
+```csharp
+// Guardrails/MechanicJsonWalker.cs
+using System.Text.Json;
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Services.MechanicExtractor.Guardrails;
+internal static class MechanicJsonWalker
+{
+    public static void ForEachObject(JsonElement el, string path, Action<JsonElement, string> visit)
+    {
+        switch (el.ValueKind)
+        {
+            case JsonValueKind.Object:
+                visit(el, path);
+                foreach (var p in el.EnumerateObject())
+                    ForEachObject(p.Value, $"{path}.{p.Name}", visit);
+                break;
+            case JsonValueKind.Array:
+                var idx = 0;
+                foreach (var item in el.EnumerateArray())
+                    ForEachObject(item, $"{path}[{idx++}]", visit);
+                break;
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Create ≥10 T1 fixtures** in `Fixtures/MechanicValidator/T1/` — `pass_24_words.json`, `pass_25_words.json`, `fail_26_words.json`, `pass_nbsp.json`, `fail_nbsp_26.json`, `pass_emdash.json`, `pass_punctuation_only_extra.json`, `pass_empty_citations.json`, `fail_multiple_quotes.json`, `pass_unicode_naive.json`. Add a `[Theory]` loading each via `File.ReadAllText` with expected violation count (use `Directory.GetCurrentDirectory()` + relative path; mirror how other Api.Tests load fixtures — check an existing fixture-loading test first).
+
+- [ ] **Step 5: Run, verify PASS.** Commit: `git commit -m "feat(mechanic): #525 T1 quote-cap guardrail + Unicode tokenizer + fixtures"`
+
+---
+
+## Task 3: T4 PageSubstringGuardrail
+
+**Files:**
+- Create: `.../Guardrails/PageSubstringGuardrail.cs`
+- Test: `.../Guardrails/PageSubstringGuardrailTests.cs`
+
+- [ ] **Step 1: Write failing tests** — page in range + quote is normalized substring of some chunk → pass; page out of range → `T4_page_out_of_range`; quote not substring → `T4_quote_not_substring`.
+
+```csharp
+[Fact]
+public async Task QuoteIsNormalizedSubstringOfChunk_Passes()
+{
+    var chunks = new[] { new MechanicSourceChunk(0, 3, null, "Players take turns drawing cards from the deck.") };
+    var json = "{\"claim\":\"x\",\"citations\":[{\"pdf_page\":3,\"quote\":\"drawing cards from the deck\"}]}";
+    var r = await Eval(json, chunks, pageCount: 50);
+    r.Should().BeEmpty();
+}
+
+[Fact]
+public async Task PageOutOfRange_Fails()
+{
+    var json = "{\"claim\":\"x\",\"citations\":[{\"pdf_page\":51,\"quote\":\"anything\"}]}";
+    var r = await Eval(json, Array.Empty<MechanicSourceChunk>(), pageCount: 50);
+    r.Should().ContainSingle().Which.Rule.Should().Be("T4_page_out_of_range");
+}
+
+[Fact]
+public async Task QuoteNotSubstring_Fails()
+{
+    var chunks = new[] { new MechanicSourceChunk(0, 3, null, "The board has nineteen spaces.") };
+    var json = "{\"claim\":\"x\",\"citations\":[{\"pdf_page\":3,\"quote\":\"dragons breathe fire\"}]}";
+    var r = await Eval(json, chunks, pageCount: 50);
+    r.Should().ContainSingle().Which.Rule.Should().Be("T4_quote_not_substring");
+}
+```
+
+(Helper `Eval(json, chunks, pageCount)` builds the context and calls `new PageSubstringGuardrail().EvaluateAsync`.)
+
+- [ ] **Step 2: Run, verify FAIL.**
+
+- [ ] **Step 3: Implement** — normalize (lowercase, strip punctuation, collapse whitespace) both quote and candidate chunks (those whose `PageNumber == pdf_page`, or all chunks if no page metadata), then `Contains`:
+
+```csharp
+using System.Text;
+using System.Text.Json;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Services.MechanicExtractor.Guardrails;
+
+internal sealed class PageSubstringGuardrail : IMechanicGuardrail
+{
+    public string RuleFamily => "T4";
+    public int Order => 20;
+
+    public Task<IReadOnlyList<MechanicValidationViolation>> EvaluateAsync(
+        MechanicGuardrailContext context, CancellationToken cancellationToken)
+    {
+        var violations = new List<MechanicValidationViolation>();
+        var normalizedChunksByPage = context.SourceChunks
+            .GroupBy(c => c.PageNumber)
+            .ToDictionary(g => g.Key, g => g.Select(c => Normalize(c.Content)).ToList());
+        var allNormalized = context.SourceChunks.Select(c => Normalize(c.Content)).ToList();
+
+        MechanicJsonWalker.ForEachObject(context.Root, "$", (obj, path) =>
+        {
+            if (obj.ValueKind != JsonValueKind.Object) return;
+            if (!obj.TryGetProperty("pdf_page", out var pageEl) || pageEl.ValueKind != JsonValueKind.Number) return;
+            if (!pageEl.TryGetInt32(out var page)) return;
+
+            if (page < 1 || (context.PdfPageCount is int pc && page > pc))
+            {
+                violations.Add(new MechanicValidationViolation(
+                    "T4_page_out_of_range",
+                    $"expected 1..{context.PdfPageCount?.ToString() ?? "?"}, got {page}",
+                    $"{path}.pdf_page"));
+                return;
+            }
+
+            if (!obj.TryGetProperty("quote", out var qEl) || qEl.ValueKind != JsonValueKind.String) return;
+            var quote = Normalize(qEl.GetString() ?? string.Empty);
+            if (quote.Length == 0) return;
+
+            var candidates = normalizedChunksByPage.TryGetValue(page, out var byPage) && byPage.Count > 0
+                ? byPage
+                : allNormalized;
+            var found = candidates.Any(c => c.Contains(quote, StringComparison.Ordinal));
+            if (!found)
+            {
+                var expected = candidates.Count > 0 ? candidates[0] : "(no source)";
+                violations.Add(new MechanicValidationViolation(
+                    "T4_quote_not_substring",
+                    $"quote not found on page {page}. expected≈\"{Truncate(expected, 80)}\" actual=\"{Truncate(quote, 80)}\"",
+                    $"{path}.quote"));
+            }
+        });
+        return Task.FromResult<IReadOnlyList<MechanicValidationViolation>>(violations);
+    }
+
+    internal static string Normalize(string s)
+    {
+        var sb = new StringBuilder(s.Length);
+        var lastSpace = false;
+        foreach (var ch in s)
+        {
+            if (char.IsLetterOrDigit(ch)) { sb.Append(char.ToLowerInvariant(ch)); lastSpace = false; }
+            else if (char.IsWhiteSpace(ch) || char.IsPunctuation(ch) || char.IsSymbol(ch))
+            {
+                if (!lastSpace && sb.Length > 0) { sb.Append(' '); lastSpace = true; }
+            }
+        }
+        return sb.ToString().TrimEnd();
+    }
+
+    private static string Truncate(string s, int n) => s.Length <= n ? s : s[..n];
+}
+```
+
+- [ ] **Step 4: Run, verify PASS.** Commit: `git commit -m "feat(mechanic): #525 T4 page+substring guardrail"`
+
+---
+
+## Task 4: T2 RejectionSamplingGuardrail (Rabin-Karp)
+
+**Files:**
+- Create: `.../Guardrails/RejectionSamplingGuardrail.cs`
+- Test: `.../Guardrails/RejectionSamplingGuardrailTests.cs`
+
+- [ ] **Step 1: Write failing tests** — a ≥10-word contiguous run from a non-citation field that exact-matches source → `T2_long_verbatim`; citation `quote` fields are excluded; 9-word overlap passes; diacritics preserved (`naïve` ≠ `naive`).
+
+```csharp
+[Fact]
+public async Task TenWordVerbatimFromClaim_Fails()
+{
+    var src = "players take turns drawing cards from the top of the deck each round";
+    var chunks = new[] { new MechanicSourceChunk(0, 1, null, src) };
+    var json = "{\"claim\":\"players take turns drawing cards from the top of the deck\"}"; // 11 words verbatim
+    var r = await Eval(json, chunks);
+    r.Should().ContainSingle().Which.Rule.Should().Be("T2_long_verbatim");
+}
+
+[Fact]
+public async Task NineWordOverlap_Passes()
+{
+    var chunks = new[] { new MechanicSourceChunk(0, 1, null, "players take turns drawing cards from the top deck") };
+    var json = "{\"claim\":\"players take turns drawing cards from the top\"}"; // 8 words
+    var r = await Eval(json, chunks);
+    r.Should().BeEmpty();
+}
+
+[Fact]
+public async Task CitationQuote_IsExcluded()
+{
+    var src = "players take turns drawing cards from the top of the deck each round";
+    var chunks = new[] { new MechanicSourceChunk(0, 1, null, src) };
+    var json = "{\"citations\":[{\"quote\":\"players take turns drawing cards from the top of the deck\"}]}";
+    var r = await Eval(json, chunks);
+    r.Should().BeEmpty();
+}
+```
+
+- [ ] **Step 2: Run, verify FAIL.**
+
+- [ ] **Step 3: Implement** — normalize source pool to a token list; build a set of all N-gram rolling hashes (N = `MaxConsecutiveSourceWords`); for each non-`quote` string field, tokenize and slide an N-window, flag on hash hit confirmed by token equality (guard against hash collision):
+
+```csharp
+using System.Text.Json;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Services.MechanicExtractor.Guardrails;
+
+internal sealed class RejectionSamplingGuardrail : IMechanicGuardrail
+{
+    public string RuleFamily => "T2";
+    public int Order => 30;
+
+    private static readonly string[] ScannedFields = { "claim", "description", "text", "answer", "primary" };
+
+    public Task<IReadOnlyList<MechanicValidationViolation>> EvaluateAsync(
+        MechanicGuardrailContext context, CancellationToken cancellationToken)
+    {
+        var n = context.Options.MaxConsecutiveSourceWords;
+        var violations = new List<MechanicValidationViolation>();
+
+        // Build source n-gram index (page-tagged for the message).
+        var sourceTokensByChunk = context.SourceChunks
+            .Select(c => (c.ChunkIndex, Tokens: Tokenize(c.Content)))
+            .ToList();
+        var sourceNgrams = new Dictionary<long, List<(int chunk, int offset, string[] gram)>>();
+        foreach (var (chunkIdx, tokens) in sourceTokensByChunk)
+            IndexNgrams(tokens, n, chunkIdx, sourceNgrams);
+
+        if (sourceNgrams.Count == 0)
+            return Task.FromResult<IReadOnlyList<MechanicValidationViolation>>(violations);
+
+        MechanicJsonWalker.ForEachObject(context.Root, "$", (obj, path) =>
+        {
+            foreach (var field in ScannedFields)
+            {
+                if (!obj.TryGetProperty(field, out var el) || el.ValueKind != JsonValueKind.String) continue;
+                var candidate = Tokenize(el.GetString() ?? string.Empty);
+                if (candidate.Length < n) continue;
+
+                for (var i = 0; i + n <= candidate.Length; i++)
+                {
+                    var hash = HashWindow(candidate, i, n);
+                    if (!sourceNgrams.TryGetValue(hash, out var bucket)) continue;
+                    var window = candidate.AsSpan(i, n);
+                    var match = bucket.FirstOrDefault(b => window.SequenceEqual(b.gram));
+                    if (match.gram != null)
+                    {
+                        var seq = string.Join(' ', window.ToArray());
+                        violations.Add(new MechanicValidationViolation(
+                            "T2_long_verbatim",
+                            $"{n}-word sequence matches chunk #{match.chunk} at offset {match.offset}: '{seq}'",
+                            $"{path}.{field}"));
+                        return; // one per object is enough (fail-fast intra-object)
+                    }
+                }
+            }
+        });
+        return Task.FromResult<IReadOnlyList<MechanicValidationViolation>>(violations);
+    }
+
+    private static void IndexNgrams(string[] tokens, int n, int chunk,
+        Dictionary<long, List<(int, int, string[])>> index)
+    {
+        for (var i = 0; i + n <= tokens.Length; i++)
+        {
+            var hash = HashWindow(tokens, i, n);
+            var gram = tokens.AsSpan(i, n).ToArray();
+            if (!index.TryGetValue(hash, out var list)) { list = new(); index[hash] = list; }
+            list.Add((chunk, i, gram));
+        }
+    }
+
+    // FNV-1a over the joined normalized tokens of the window (deterministic, no Math.random/Date).
+    private static long HashWindow(string[] tokens, int start, int n)
+    {
+        unchecked
+        {
+            const long prime = 1099511628211L;
+            var hash = 1469598103934665603L;
+            for (var k = 0; k < n; k++)
+            {
+                foreach (var ch in tokens[start + k]) { hash ^= ch; hash *= prime; }
+                hash ^= ' '; hash *= prime;
+            }
+            return hash;
+        }
+    }
+
+    // Normalize: lowercase, strip punctuation, collapse whitespace, NO stemming, NO diacritic folding.
+    internal static string[] Tokenize(string s)
+    {
+        var result = new List<string>();
+        var current = new System.Text.StringBuilder();
+        foreach (var ch in s)
+        {
+            if (char.IsLetterOrDigit(ch)) current.Append(char.ToLowerInvariant(ch));
+            else { if (current.Length > 0) { result.Add(current.ToString()); current.Clear(); } }
+        }
+        if (current.Length > 0) result.Add(current.ToString());
+        return result.ToArray();
+    }
+}
+```
+
+- [ ] **Step 4: Run, verify PASS.** Commit: `git commit -m "feat(mechanic): #525 T2 rejection-sampling guardrail (Rabin-Karp/FNV)"`
+
+---
+
+## Task 5: T3a CitationPresenceGuardrail + T3b GroundingGuardrail
+
+**Files:**
+- Create: `.../Guardrails/CitationPresenceGuardrail.cs` (T3a, sync, extracted from stub)
+- Create: `.../Guardrails/GroundingGuardrail.cs` (T3b, embedding)
+- Test: `.../Guardrails/CitationPresenceGuardrailTests.cs`, `.../Guardrails/GroundingGuardrailTests.cs`
+
+- [ ] **Step 1 (T3a): Write failing test** — claim-bearing object without non-empty `citations` → `T3_citation_required` (renamed from stub's `T4_citation_required`).
+
+```csharp
+[Fact]
+public async Task ClaimWithoutCitations_Fails()
+{
+    var json = "{\"claim\":\"x\"}";
+    var r = await new CitationPresenceGuardrail().EvaluateAsync(Ctx(json), default);
+    r.Should().ContainSingle().Which.Rule.Should().Be("T3_citation_required");
+}
+```
+
+- [ ] **Step 2 (T3a): Implement** — lift the stub's claim-field/`HasNonEmptyCitations` logic into a guardrail (`RuleFamily="T3"`, `Order=15`, sync wrapped in `Task.FromResult`). Rule string `T3_citation_required`.
+
+- [ ] **Step 3 (T3b): Write failing test with mocked `IEmbeddingService`** — claim cosine below threshold → `T3_grounding`; fail-closed on outage → `T3_grounding_unavailable`.
+
+```csharp
+[Fact]
+public async Task LowCosine_Fails()
+{
+    var embed = new Mock<IEmbeddingService>(); // Domain.Services.IEmbeddingService
+    embed.Setup(e => e.EmbedAsync("cards have suits", It.IsAny<CancellationToken>()))
+         .ReturnsAsync(new[] { 1f, 0f });
+    embed.Setup(e => e.EmbedAsync(It.Is<string>(s => s != "cards have suits"), It.IsAny<CancellationToken>()))
+         .ReturnsAsync(new[] { 0f, 1f }); // orthogonal → cosine 0 < 0.65
+    var chunks = new[] { new MechanicSourceChunk(7, 12, null, "the board is hexagonal") };
+    var json = "{\"claim\":\"cards have suits\",\"citations\":[{\"pdf_page\":12,\"quote\":\"q\",\"chunk_id\":null}]}";
+    var r = await new GroundingGuardrail(embed.Object).EvaluateAsync(Ctx(json, chunks), default);
+    r.Should().ContainSingle().Which.Rule.Should().Be("T3_grounding");
+}
+
+[Fact]
+public async Task EmbeddingOutage_FailsClosed()
+{
+    var embed = new Mock<IEmbeddingService>();
+    embed.Setup(e => e.EmbedAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+         .ThrowsAsync(new InvalidOperationException("down"));
+    var chunks = new[] { new MechanicSourceChunk(7, 12, null, "x") };
+    var json = "{\"claim\":\"c\",\"citations\":[{\"pdf_page\":12,\"quote\":\"q\"}]}";
+    var r = await new GroundingGuardrail(embed.Object).EvaluateAsync(Ctx(json, chunks), default);
+    r.Should().ContainSingle().Which.Rule.Should().Be("T3_grounding_unavailable");
+}
+```
+
+- [ ] **Step 4 (T3b): Implement** — for each claim-bearing object with citations, embed claim text + cited chunk (resolve by `chunk_id` then `pdf_page`), cosine; fail-closed on throw:
+
+```csharp
+using System.Text.Json;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Services;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Services.MechanicExtractor.Guardrails;
+
+internal sealed class GroundingGuardrail : IMechanicGuardrail
+{
+    private readonly IEmbeddingService _embeddings;
+    public GroundingGuardrail(IEmbeddingService embeddings) => _embeddings = embeddings;
+
+    public string RuleFamily => "T3";
+    public int Order => 40;
+
+    private static readonly string[] ClaimFields = { "claim", "description", "text", "answer", "primary" };
+
+    public async Task<IReadOnlyList<MechanicValidationViolation>> EvaluateAsync(
+        MechanicGuardrailContext context, CancellationToken cancellationToken)
+    {
+        var violations = new List<MechanicValidationViolation>();
+        var targets = new List<(string claim, string path, MechanicSourceChunk chunk)>();
+
+        MechanicJsonWalker.ForEachObject(context.Root, "$", (obj, path) =>
+        {
+            if (obj.ValueKind != JsonValueKind.Object) return;
+            var claim = ClaimFields
+                .Where(f => obj.TryGetProperty(f, out var e) && e.ValueKind == JsonValueKind.String)
+                .Select(f => obj.GetProperty(f).GetString())
+                .FirstOrDefault(s => !string.IsNullOrWhiteSpace(s));
+            if (claim is null) return;
+            if (!obj.TryGetProperty("citations", out var cits) || cits.ValueKind != JsonValueKind.Array) return;
+            foreach (var c in cits.EnumerateArray())
+            {
+                var chunk = ResolveChunk(c, context.SourceChunks);
+                if (chunk != null) targets.Add((claim!, path, chunk));
+            }
+        });
+
+        foreach (var (claim, path, chunk) in targets)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            try
+            {
+                var a = await _embeddings.EmbedAsync(claim, cancellationToken);
+                var b = await _embeddings.EmbedAsync(chunk.Content, cancellationToken);
+                var cos = Cosine(a, b);
+                if (cos < context.Options.MinClaimGroundingSimilarity)
+                    violations.Add(new MechanicValidationViolation(
+                        "T3_grounding",
+                        $"claim '{Trunc(claim)}' has cosine {cos:0.00} with cited chunk #{chunk.ChunkIndex}" +
+                        $" (page {chunk.PageNumber}), below threshold {context.Options.MinClaimGroundingSimilarity}",
+                        $"{path}"));
+            }
+            catch (OperationCanceledException) { throw; }
+            catch (Exception ex)
+            {
+                violations.Add(new MechanicValidationViolation(
+                    "T3_grounding_unavailable",
+                    $"embedding service unavailable, failing closed: {ex.Message}", path));
+                break; // outage is global; no point retrying each claim
+            }
+        }
+        return violations;
+    }
+
+    private static MechanicSourceChunk? ResolveChunk(JsonElement citation, IReadOnlyList<MechanicSourceChunk> pool)
+    {
+        if (citation.ValueKind != JsonValueKind.Object) return null;
+        if (citation.TryGetProperty("chunk_id", out var idEl) && idEl.ValueKind == JsonValueKind.String
+            && Guid.TryParse(idEl.GetString(), out var cid))
+        {
+            var byId = pool.FirstOrDefault(p => p.ChunkId == cid);
+            if (byId != null) return byId;
+        }
+        if (citation.TryGetProperty("pdf_page", out var pEl) && pEl.ValueKind == JsonValueKind.Number
+            && pEl.TryGetInt32(out var page))
+            return pool.FirstOrDefault(p => p.PageNumber == page);
+        return null;
+    }
+
+    internal static double Cosine(float[] a, float[] b)
+    {
+        if (a.Length == 0 || b.Length == 0 || a.Length != b.Length) return 0;
+        double dot = 0, na = 0, nb = 0;
+        for (var i = 0; i < a.Length; i++) { dot += a[i] * b[i]; na += a[i] * a[i]; nb += b[i] * b[i]; }
+        if (na == 0 || nb == 0) return 0;
+        return dot / (Math.Sqrt(na) * Math.Sqrt(nb));
+    }
+
+    private static string Trunc(string s) => s.Length <= 50 ? s : s[..50];
+}
+```
+
+- [ ] **Step 5: Run all guardrail tests, verify PASS.** Commit: `git commit -m "feat(mechanic): #525 T3 citation-presence + grounding guardrails"`
+
+---
+
+## Task 6: MechanicOutputValidator → async chain orchestrator
+
+**Files:**
+- Modify: `.../MechanicExtractor/IMechanicOutputValidator.cs` (new async signature)
+- Modify: `.../MechanicExtractor/MechanicOutputValidator.cs` (orchestrator)
+- Modify: `.../Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs` (register 5 guardrails)
+- Test: `.../MechanicExtractor/MechanicOutputValidatorChainTests.cs`
+
+- [ ] **Step 1: Write failing test** — chain runs in `Order`, fail-fast stops at first family with violations; well-formedness handled before chain.
+
+```csharp
+[Fact]
+public async Task FailFast_StopsAtFirstFailingFamily()
+{
+    // T1 fails (26-word quote) AND T4 would fail (bad page) → only T1 reported (Order 10 < 20)
+    var json = "{\"claim\":\"x\",\"citations\":[{\"pdf_page\":999,\"quote\":\"" +
+               string.Join(' ', Enumerable.Range(1,26).Select(i=>"w"+i)) + "\"}]}";
+    var sut = new MechanicOutputValidator(new IMechanicGuardrail[]
+        { new QuoteCapGuardrail(), new PageSubstringGuardrail() });
+    var result = await sut.ValidateAsync(Ctx(json, pageCount:50), default);
+    result.IsValid.Should().BeFalse();
+    result.Violations.Should().OnlyContain(v => v.Rule.StartsWith("T1"));
+}
+```
+
+- [ ] **Step 2: New interface signature** (replace `Validate`):
+
+```csharp
+public interface IMechanicOutputValidator
+{
+    Task<MechanicValidationResult> ValidateAsync(
+        MechanicGuardrailContext context, CancellationToken cancellationToken);
+}
+```
+
+(Keep `MechanicValidationResult` / `MechanicValidationViolation` records unchanged.)
+
+- [ ] **Step 3: Orchestrator implementation** — ordered, fail-fast:
+
+```csharp
+internal sealed class MechanicOutputValidator : IMechanicOutputValidator
+{
+    private readonly IReadOnlyList<IMechanicGuardrail> _guardrails;
+    public MechanicOutputValidator(IEnumerable<IMechanicGuardrail> guardrails)
+        => _guardrails = guardrails.OrderBy(g => g.Order).ToList();
+
+    public async Task<MechanicValidationResult> ValidateAsync(
+        MechanicGuardrailContext context, CancellationToken cancellationToken)
+    {
+        foreach (var guardrail in _guardrails)
+        {
+            var violations = await guardrail.EvaluateAsync(context, cancellationToken);
+            if (violations.Count > 0)
+                return MechanicValidationResult.Invalid(violations); // fail-fast
+        }
+        return MechanicValidationResult.Valid();
+    }
+}
+```
+
+> Well-formedness: the pipeline parses raw JSON into `JsonElement` BEFORE building the context (Task 7). A JSON parse failure short-circuits to a `well_formed` violation there — guardrails always receive valid JSON.
+
+- [ ] **Step 4: DI registration** — replace the single `services.AddScoped<IMechanicOutputValidator, MechanicOutputValidator>();` with guardrail registrations + validator:
+
+```csharp
+services.AddScoped<IMechanicGuardrail, QuoteCapGuardrail>();
+services.AddScoped<IMechanicGuardrail, CitationPresenceGuardrail>();
+services.AddScoped<IMechanicGuardrail, PageSubstringGuardrail>();
+services.AddScoped<IMechanicGuardrail, RejectionSamplingGuardrail>();
+services.AddScoped<IMechanicGuardrail, GroundingGuardrail>();
+services.AddScoped<IMechanicOutputValidator, MechanicOutputValidator>();
+```
+
+- [ ] **Step 5: Run, verify PASS.** Commit: `git commit -m "feat(mechanic): #525 async guardrail chain orchestrator + DI"`
+
+---
+
+## Task 7: Pipeline wiring — context build + configurable retry re-prompt loop (AC-6)
+
+**Files:**
+- Modify: `.../MechanicExtractor/IMechanicAnalysisPipeline.cs` (request: + `SourceChunksBySection`, `PdfPageCount`)
+- Modify: `.../MechanicExtractor/MechanicAnalysisExecutor.cs` (load structured chunks + page count)
+- Modify: `.../MechanicExtractor/MechanicAnalysisPipeline.cs` (build context, async validate, retry loop)
+- Test: `.../MechanicExtractor/MechanicAnalysisPipelineRetryTests.cs`
+
+- [ ] **Step 1: Extend request record** — add `IReadOnlyDictionary<MechanicSection, IReadOnlyList<MechanicSourceChunk>> SourceChunksBySection` and `int? PdfPageCount`.
+
+- [ ] **Step 2: Executor builds structured chunks** — in `MechanicAnalysisExecutor.LoadRetrievalContextAsync`, additionally project the loaded chunks into `MechanicSourceChunk` (already selecting `ChunkIndex`, `PageNumber`, `Content`; add `Id` for `ChunkId`). Return both the concatenated string (LLM context) and the list. Load `PdfDocument.PageCount` via the existing DbContext.
+
+- [ ] **Step 3: Write failing retry test** — first attempt invalid (T1), re-prompt augments system message with violations JSON, second attempt valid → succeeds with `RetryCount=1`; identical normalized output twice → break early (`RegenerationDivergent=false`).
+
+```csharp
+[Fact]
+public async Task InvalidThenValid_RetriesOnceAndSucceeds()
+{
+    // llm returns 26-word-quote JSON first, clean JSON second
+    var llm = new Mock<ILlmService>();
+    llm.SetupSequence(s => s.GenerateCompletionAsync(It.IsAny<string>(), It.IsAny<string>(),
+            It.IsAny<RequestSource>(), It.IsAny<CancellationToken>()))
+       .ReturnsAsync(LlmCompletionResult.CreateSuccess(BadJson))
+       .ReturnsAsync(LlmCompletionResult.CreateSuccess(GoodJson));
+    // ... build pipeline with real validator (QuoteCap only) + options MaxRetriesPerSection=2 ...
+    var result = await pipeline.RunAsync(request, default);
+    result.Outcome.Should().Be(MechanicPipelineOutcome.Succeeded);
+    // assert second system prompt contained the T1 violation
+    llm.Verify(s => s.GenerateCompletionAsync(
+        It.Is<string>(p => p.Contains("T1_quote_cap")), It.IsAny<string>(),
+        It.IsAny<RequestSource>(), It.IsAny<CancellationToken>()), Times.Once);
+}
+```
+
+- [ ] **Step 4: Implement retry loop** in `RunSectionAsync` — replace hardcoded `MaxValidationRetries=1` with `options.MaxRetriesPerSection`; on validation failure, build augmented system prompt appending `"PREVIOUS_ATTEMPT_VIOLATIONS": [...]` JSON; compute SHA256 of normalized output to detect stable/divergent-free regeneration and break early; accumulate retry tokens into the run cost.
+
+```csharp
+// pseudocode shape — real edit integrates into existing RunSectionAsync
+var attempt = 0;
+string? lastHash = null;
+while (true)
+{
+    var completion = await _llmService.GenerateCompletionAsync(systemPrompt, userPrompt, RequestSource.Manual, ct);
+    // ... cost accounting, strip fences ...
+    using var parsed = JsonDocument.Parse(cleanJson); // catch JsonException -> well_formed failure
+    var ctx = new MechanicGuardrailContext(section, parsed.RootElement, sourceChunks, pageCount, _options);
+    var validation = await _validator.ValidateAsync(ctx, ct);
+    if (validation.IsValid) return Success(...);
+
+    var hash = Sha256Normalized(cleanJson);
+    if (hash == lastHash) return Failed(reason: "RegenerationDivergent=false", validation.Violations);
+    lastHash = hash;
+
+    if (attempt >= _options.MaxRetriesPerSection)
+        return Failed(reason: AggregateViolations(validation.Violations), validation.Violations);
+    attempt++;
+    systemPrompt = AugmentWithViolations(baseSystemPrompt, validation.Violations); // JSON, not NL
+}
+```
+
+- [ ] **Step 5: Run, verify PASS.** Commit: `git commit -m "feat(mechanic): #525 AC-6 configurable re-prompt retry loop + stable-output detection"`
+
+---
+
+## Task 8: Retry-inclusive cost cap + mid-stream overrun (AC-5)
+
+**Files:**
+- Modify: `.../MechanicExtractor/AnalysisCostEstimator.cs` (retry-inclusive projection)
+- Modify: `.../MechanicExtractor/MechanicAnalysisPipeline.cs` (mid-stream overrun → PartiallyExtracted)
+- Test: `.../MechanicExtractor/CostCapRetryInclusiveTests.cs`
+
+- [ ] **Step 1: Write failing test** — projected cost uses `baseEstimate × RetryCostInflationFactor`; if `base × (1 + maxRetries)` exceeds cap, the inflation projection is used; mid-stream overrun stops next section and persists `PartiallyExtracted`.
+
+- [ ] **Step 2: Implement** — extend estimator to expose a retry-inflated projection; in the pipeline's per-section cost check (existing lines ~95–105), when accumulated cost crosses `MaxAnalysisCostUsd` mid-run, complete the current section, raise `MechanicAnalysisCostCapOverriddenEvent` with `Reason=MidStreamOverrun` (extend event or add reason field), stop the loop, set outcome so the executor persists `Status=PartiallyExtracted`.
+
+- [ ] **Step 3: Run, verify PASS.** Commit: `git commit -m "feat(mechanic): #525 AC-5 retry-inclusive cost cap + mid-stream overrun policy"`
+
+---
+
+## Task 9: Observability — metrics + structured logging (AC-7)
+
+**Files:**
+- Create: `apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.MechanicGuardrails.cs`
+- Modify: `.../MechanicExtractor/MechanicOutputValidator.cs` (emit per-guardrail metrics + logs)
+- Test: `.../MechanicExtractor/MechanicGuardrailMetricsTests.cs` (assert counters increment via a MeterListener)
+
+- [ ] **Step 1: Write failing test** — running the chain on an invalid output increments `mechanic_validator_invocations_total{validator,outcome}` and `mechanic_validator_violations_total{rule}` (use `System.Diagnostics.Metrics.MeterListener` to capture).
+
+- [ ] **Step 2: Implement metrics partial** (mirror `MeepleAiMetrics.MechanicValidation.cs`):
+
+```csharp
+namespace Api.Observability;
+internal static partial class MeepleAiMetrics
+{
+    public static readonly Counter<long> MechanicValidatorInvocations =
+        Meter.CreateCounter<long>("mechanic_validator_invocations_total",
+            description: "Guardrail evaluations by validator and outcome.");
+    public static readonly Counter<long> MechanicValidatorViolations =
+        Meter.CreateCounter<long>("mechanic_validator_violations_total",
+            description: "Guardrail violations by rule.");
+}
+```
+
+- [ ] **Step 3: Emit in orchestrator** — wrap each guardrail eval with a stopwatch; `MechanicValidatorInvocations.Add(1, new TagList{{"validator",g.RuleFamily},{"outcome",ok?"pass":"fail"}})`; per violation `MechanicValidatorViolations.Add(1, new TagList{{"rule",v.Rule}})`; `LogInformation` with structured fields `analysis_id`, `section`, `validator`, `outcome`, `retry_count`, `violation_rule?`, `latency_ms`. (Pass `analysis_id`/`retry_count` into the context or an overload; add `AnalysisId` + `RetryCount` to `MechanicGuardrailContext`.)
+
+- [ ] **Step 4: Run, verify PASS.** Commit: `git commit -m "feat(mechanic): #525 AC-7 guardrail metrics + structured logging"`
+
+---
+
+## Task 10: End-to-end pipeline integration test
+
+**Files:**
+- Test: `.../MechanicExtractor/MechanicGuardrailPipelineIntegrationTests.cs`
+
+- [ ] **Step 1: Write test** — a fabricated LLM output that violates T2 (long verbatim) against a known source chunk pool → pipeline retries → second clean output → `Succeeded`, section run persisted with `RetryCount=1`, metrics emitted, no IP-violating output surfaced.
+
+- [ ] **Step 2: Run, verify PASS.** Commit: `git commit -m "test(mechanic): #525 end-to-end guardrail pipeline integration"`
+
+---
+
+## Self-Review Checklist (run before execution)
+
+- **Spec coverage:** AC-1→Task 2; AC-2→Task 4; AC-3→Task 5; AC-4→Task 3; AC-5→Task 8; AC-6→Task 7; AC-7→Task 9. ✓
+- **Type consistency:** `MechanicGuardrailContext`, `MechanicSourceChunk`, `IMechanicGuardrail.EvaluateAsync`, `ValidateAsync` used identically across Tasks 1–10. ✓
+- **No placeholders:** algorithm bodies (T1 tokenizer, T2 FNV n-gram, T3 cosine, T4 normalize) are complete; Task 7/8 integration steps reference exact existing lines to edit.
+- **Open risks:** (a) `MechanicAnalysisCostCapOverriddenEvent` may need a `Reason` field for mid-stream (Task 8) — verify event shape at execution; (b) fixture-loading convention must match an existing Api.Tests fixture test — verify in Task 2 Step 4; (c) `MechanicValidationResult.Invalid` currently takes `IReadOnlyList` — confirmed compatible.


### PR DESCRIPTION
## Summary
Implements the ME-M1.3 (#525) validation guardrails for the Mechanic Extractor, per ADR-051. Refactors the M1.2 context-free validator stub into an async **chain of injectable `IMechanicGuardrail`** evaluated cheapest-first / fail-fast, wired into the pipeline.

Plan: `docs/superpowers/plans/2026-06-22-issue-525-mechanic-guardrails.md`.

## What's implemented (build green, 19 unit tests green)
| AC | Guardrail / feature | Status |
|----|---------------------|--------|
| AC-1 | **T1** quote cap — hardened Unicode/em-dash tokenizer, pure-punctuation excluded | ✅ + tests |
| AC-2 | **T2** rejection sampling — FNV n-gram index (Rabin-Karp), citation quotes excluded | ✅ + tests |
| AC-3 | **T3a** citation presence + **T3b** grounding (embedding cosine, fail-closed on outage) | ✅ + tests |
| AC-4 | **T4** page range + normalized substring verification | ✅ + tests |
| AC-6 | configurable re-prompt retry loop + augmented system message (violations JSON) + stable-output SHA256 detection | ✅ wired |
| AC-7 | per-guardrail Prometheus counters (`mechanic_validator_invocations_total`, `mechanic_validator_violations_total`) + structured logs | ✅ wired |
| AC-5 | cost cap — retry-inclusive token accounting (retries share the T8 cap) | ✅ partial (base cap retained) |

**Architecture notes:**
- The source chunk pool (`MechanicSourceChunk` with page + chunk-id) is pinned in-memory from the existing retrieval snapshot — no schema change, no `chunk_version_id` column.
- Chain order: T1 (10) → T3a presence (15) → T4 (20) → T2 (30) → T3b grounding (40, embedding, last).
- `MechanicGuardrailOptions` holds all thresholds. **USD not EUR** (codebase uses USD everywhere); documented deviation from the issue body.
- Rule `T4_citation_required` renamed to `T3_citation_required` per ADR-051 naming.

## Verification
- `dotnet build` → 0 errors
- `dotnet test --filter MechanicExtractor.Guardrails` → **19 passed, 0 failed**

## Honest follow-ups (not in this PR)
- AC-5 mid-stream overrun → `PartiallyExtracted` policy (base cost-cap abort is retained; the refined mid-stream checkpoint is deferred).
- Integration test for the pipeline retry loop (impl is wired + compiles; dedicated end-to-end test pending).
- Metrics unit test via `MeterListener` (counters emit; assertion test pending).
- T1 fixture corpus as files (currently inline `[Theory]` cases).

These are tracked against #525, which stays open until closed out.

Advances #525

🤖 Generated with [Claude Code](https://claude.com/claude-code)