### PR TITLE
feat(mockups): #2028 SP7 notifications hub + preferences v2

### DIFF
--- a/admin-mockups/MOCKUPS_INDEX.md
+++ b/admin-mockups/MOCKUPS_INDEX.md
@@ -62,7 +62,9 @@
 |------|------|---------------|
 | `auth-flow.html` | page-mock | `/login`, `/register`, `/reset-password`, `/oauth-callback`, `/verify-email`, `/verification-pending`, `/verification-success`, `/invitation-expired` |
 | `onboarding.html` | page-mock | `/welcome`, `/onboarding`, `/setup`, `/setup-account` |
-| `notifications.html` | page-mock | `/notifications`, `/notifications/preferences` |
+| `notifications.html` | page-mock | _(SP1 legacy archive — superseded by `sp7-notifications-*`, #2028)_ |
+| `sp7-notifications-hub.html` | page-mock | `/notifications` |
+| `sp7-notifications-preferences.html` | page-mock | `/notifications/preferences` |
 | `public.html` | page-mock | `/` (landing) |
 | `settings.html` | page-mock | `/settings` + 7 sub-route (`/ai-consent`, `/api-keys`, `/notifications`, `/preferences`, `/profile`, `/security`, `/services`) |
 

--- a/admin-mockups/design_files/00-hub.html
+++ b/admin-mockups/design_files/00-hub.html
@@ -426,6 +426,22 @@
     <p>6 stati per il recap full-screen post-serata: hero MVP + KPI grid 4 stat + cross-game timeline collapsed + per-game recap (co-op variant) + foto gallery (empty state) + share/archive CTA. MVP heuristic da definire backend-side.</p>
     <div class="tags"><span class="tag">6 stati</span><span class="tag">MVP banner</span><span class="tag">Co-op variant</span></div>
   </a>
+
+  <a class="hub-card e-event" href="sp7-notifications-hub.html">
+    <div class="arrow">→</div>
+    <div class="num">SP7 · I · #2028</div>
+    <h3>Notifications hub v2</h3>
+    <p>8 stati feed notifiche (/notifications): empty, 15 miste (5 unread, gruppi Oggi/Ieri/Settimana), filtro Non lette, bulk "segna tutte" confirm, action drawer long-press (4 azioni), snooze toast, error network, mobile stack. Severity entity-driven (critica event · importante agent · info toolkit).</p>
+    <div class="tags"><span class="tag">8 stati</span><span class="tag">Bulk actions</span><span class="tag">Severity color</span></div>
+  </a>
+
+  <a class="hub-card e-event" href="sp7-notifications-preferences.html">
+    <div class="arrow">→</div>
+    <div class="num">SP7 · J · #2028</div>
+    <h3>Notifications preferences</h3>
+    <p>5 stati settings (/notifications/preferences): default all-on, real-time solo critiche + daily digest, quiet hours 22-08 con time picker, nessun device mobile (CTA installa app), save success toast. 3 channel sections + matrice severità per canale.</p>
+    <div class="tags"><span class="tag">5 stati</span><span class="tag">Quiet hours</span><span class="tag">Multi-channel</span></div>
+  </a>
 </div>
 
 <section class="palette-row">

--- a/admin-mockups/design_files/sp7-notifications-hub.fidelity.json
+++ b/admin-mockups/design_files/sp7-notifications-hub.fidelity.json
@@ -1,0 +1,39 @@
+{
+  "_comment": "SP7-I Notifications Hub — route /notifications, persona Marco (mobile mass-check). 8 screen states (canonical-mapped): empty-no-notifications (empty), mixed-15-notifications (default), only-unread-filter (default), bulk-mark-read-confirm (default), action-drawer-on-tap (default), snooze-success (default), error-network (error), mobile-stack (default). Brief: admin-mockups/briefs/SP7-game-night-agent-builder.md § I.",
+  "mockup": {
+    "source": "admin-mockups/design_files/sp7-notifications-hub.html",
+    "states": [
+      "default",
+      "empty",
+      "error"
+    ]
+  },
+  "acceptance": {
+    "visual_diff_max_px": 5,
+    "color_delta_e_max": 3,
+    "tokens_used": "canonical_only",
+    "legacy_token_names_forbidden": true,
+    "states_covered": [
+      "default",
+      "empty",
+      "error"
+    ],
+    "a11y_axe": "AA",
+    "a11y_violations_max": 0,
+    "responsive_breakpoints": [
+      375,
+      768,
+      1024,
+      1440
+    ],
+    "designer_approved_by": "",
+    "designer_approved_on": "",
+    "story_path": "",
+    "fixtures_path": "",
+    "design_intent": "current",
+    "viewports": [
+      "mobile"
+    ],
+    "obsolete_tracking_issue": ""
+  }
+}

--- a/admin-mockups/design_files/sp7-notifications-hub.html
+++ b/admin-mockups/design_files/sp7-notifications-hub.html
@@ -1,0 +1,301 @@
+<!doctype html>
+<html lang="it" data-theme="light">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>MeepleAI — Notifications Hub (SP7-I)</title>
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="tokens.css"/>
+<link rel="stylesheet" href="components.css"/>
+
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+
+<style>
+  /* ── Stage ── */
+  .stage { padding: 96px 24px 80px; }
+
+  /* ── Phones grid ── */
+  .phones-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(380px, 380px));
+    gap: 36px 28px;
+    justify-content: center;
+    margin-top: 32px;
+  }
+
+  /* ── Phone frame ── */
+  .phone {
+    width: 380px; height: 720px;
+    border-radius: 32px;
+    background: var(--bg-card);
+    border: 1px solid var(--border-strong);
+    box-shadow: var(--shadow-lg), inset 0 0 0 7px var(--bg-sunken);
+    overflow: hidden;
+    display: flex; flex-direction: column;
+    position: relative;
+  }
+  .phone::before {
+    content: ''; position: absolute;
+    top: 11px; left: 50%; transform: translateX(-50%);
+    width: 104px; height: 26px;
+    background: #000; border-radius: 999px; z-index: 99;
+  }
+
+  /* ── Phone status bar ── */
+  .phone-sbar {
+    display: flex; justify-content: space-between; align-items: center;
+    padding: 14px 24px 6px;
+    font-family: var(--f-mono); font-size: 12px; font-weight: 700;
+    color: var(--text-sec);
+    flex-shrink: 0;
+  }
+  .phone-sbar .ind {
+    display: inline-flex; align-items: center; gap: 6px;
+    font-size: 10px; letter-spacing: .04em;
+  }
+
+  /* ── Phone scrollbar hide ── */
+  .phone * { scrollbar-width: none; }
+  .phone *::-webkit-scrollbar { display: none; }
+
+  /* ── Slide-up animation for drawer / toast ── */
+  @keyframes slideUp {
+    from { transform: translateY(100%); opacity: 0; }
+    to   { transform: translateY(0);    opacity: 1; }
+  }
+
+  /* ── Screen label pill ── */
+  .screen-label {
+    font-family: var(--f-mono); font-size: 10px;
+    color: var(--text-muted); text-transform: uppercase;
+    letter-spacing: .1em; text-align: center;
+    margin-top: 12px;
+  }
+
+  /* ── Phone label wrap ── */
+  .phone-wrap { display: flex; flex-direction: column; }
+
+  /* ── Tweaks panel ── */
+  #tweaks-panel {
+    position: fixed; bottom: 24px; right: 24px; z-index: 9999;
+    display: none;
+    background: var(--glass-bg); backdrop-filter: blur(16px);
+    border: 1px solid var(--border); border-radius: var(--r-xl);
+    box-shadow: var(--shadow-lg);
+    padding: 16px 18px; min-width: 220px;
+    font-family: var(--f-display); font-size: 13px; color: var(--text);
+  }
+  #tweaks-panel h4 {
+    font-size: 11px; font-weight: 700; margin: 0 0 12px;
+    text-transform: uppercase; letter-spacing: .08em;
+    color: var(--text-muted); font-family: var(--f-mono);
+  }
+  #tweaks-panel label {
+    display: flex; align-items: center; justify-content: space-between;
+    gap: 10px; font-size: 12px; margin-bottom: 10px;
+    color: var(--text-sec);
+  }
+  #tweaks-panel select {
+    font-family: inherit; font-size: 12px;
+    padding: 3px 6px; border-radius: var(--r-sm);
+    border: 1px solid var(--border); background: var(--bg);
+    color: var(--text); cursor: pointer;
+  }
+</style>
+</head>
+<body>
+
+<!-- ── Hub nav ── -->
+<nav class="hub-nav">
+  <a href="00-hub.html" class="brand" style="color:inherit;text-decoration:none;">
+    <span class="brand-mark">M</span>
+    <span>MeepleAI</span>
+  </a>
+  <span style="font-size:11px;padding:3px 8px;border-radius:6px;background:var(--bg-muted);font-family:var(--f-mono);color:var(--text-muted);">SP7-I · Notifications Hub</span>
+  <div class="spacer"></div>
+  <a href="notifications.html" /* DEMO-NAV */>Notifications v1</a>
+  <a href="sp7-game-night-detail-rsvp.html" /* DEMO-NAV */>Game Night</a>
+  <a href="sp7-notifications-hub.html" class="active">Notifications Hub</a>
+</nav>
+
+<!-- ── Theme toggle ── -->
+<button class="theme-toggle" id="themeToggle">🌗 <span id="themeLabel">Light</span></button>
+
+<!-- ── Stage ── -->
+<div class="stage">
+  <div class="stage-wrap">
+    <h1>Notifications Hub <span style="color:hsl(var(--c-event));">timeline</span></h1>
+    <p class="lead">
+      8 stati mobile per il mass-check di Marco al risveglio: feed raggruppato per data, bulk actions,
+      filtri [Tutte / Non lette / Mention / Critiche], action drawer su long-press, snooze, error e empty.
+      Severity colorata per tipo — rosso critico, ambra importante, verde info, grigio già letto.
+    </p>
+
+    <!-- Feature chips -->
+    <div style="display:flex;flex-wrap:wrap;gap:8px;margin-bottom:32px;">
+      <span class="e-event e-chip">🔔 8 stati</span>
+      <span class="e-session e-chip">📋 Timeline + gruppi</span>
+      <span class="e-agent e-chip">✓ Bulk actions</span>
+      <span class="e-chat e-chip">@ Mention filter</span>
+      <span class="e-toolkit e-chip">👆 Action drawer</span>
+      <span class="e-game e-chip">🕘 Snooze 1h</span>
+    </div>
+
+    <div id="root"></div>
+  </div>
+</div>
+
+<!-- ── Tweaks panel ── -->
+<div id="tweaks-panel">
+  <h4>Tweaks</h4>
+  <label>
+    <span>Tema</span>
+    <select id="tweak-theme">
+      <option value="light">Light</option>
+      <option value="dark">Dark</option>
+    </select>
+  </label>
+  <label>
+    <span>Layout</span>
+    <select id="tweak-layout">
+      <option value="grid">Griglia phones</option>
+      <option value="single">Phone singolo</option>
+    </select>
+  </label>
+  <label>
+    <span>Stato singolo</span>
+    <select id="tweak-screen">
+      <option value="1">01 · Empty</option>
+      <option value="2">02 · 15 miste</option>
+      <option value="3">03 · Non lette</option>
+      <option value="4">04 · Bulk confirm</option>
+      <option value="5">05 · Action drawer</option>
+      <option value="6">06 · Snooze toast</option>
+      <option value="7">07 · Error network</option>
+      <option value="8">08 · Mobile stack</option>
+    </select>
+  </label>
+</div>
+
+<!-- ── Theme + Tweaks scripts ── -->
+<script>
+  const root = document.documentElement;
+  const saved = localStorage.getItem('mai-theme') || 'light';
+  root.setAttribute('data-theme', saved);
+  document.getElementById('themeLabel').textContent = saved === 'dark' ? 'Dark' : 'Light';
+  document.getElementById('themeToggle').addEventListener('click', () => {
+    const next = root.getAttribute('data-theme') === 'light' ? 'dark' : 'light';
+    root.setAttribute('data-theme', next);
+    localStorage.setItem('mai-theme', next);
+    document.getElementById('themeLabel').textContent = next === 'dark' ? 'Dark' : 'Light';
+    document.getElementById('tweak-theme').value = next;
+    window.parent.postMessage({ type: '__edit_mode_set_keys', edits: { theme: next } }, '*');
+  });
+
+  const TWEAK_DEFAULTS = /*EDITMODE-BEGIN*/{
+    "theme": "light",
+    "layout": "grid",
+    "screen": "2"
+  }/*EDITMODE-END*/;
+
+  window.addEventListener('message', e => {
+    if (e.data?.type === '__activate_edit_mode')
+      document.getElementById('tweaks-panel').style.display = 'block';
+    if (e.data?.type === '__deactivate_edit_mode')
+      document.getElementById('tweaks-panel').style.display = 'none';
+  });
+  window.parent.postMessage({ type: '__edit_mode_available' }, '*');
+
+  document.getElementById('tweak-theme').value = saved;
+  document.getElementById('tweak-theme').addEventListener('change', e => {
+    const next = e.target.value;
+    root.setAttribute('data-theme', next);
+    localStorage.setItem('mai-theme', next);
+    document.getElementById('themeLabel').textContent = next === 'dark' ? 'Dark' : 'Light';
+    window.parent.postMessage({ type: '__edit_mode_set_keys', edits: { theme: next } }, '*');
+  });
+
+  // Layout / single-screen tweaks are handled after React mounts
+  document.getElementById('tweak-layout').addEventListener('change', e => {
+    window.__notifTweakLayout = e.target.value;
+    window.__notifTweakLayoutCb?.();
+    window.parent.postMessage({ type: '__edit_mode_set_keys', edits: { layout: e.target.value } }, '*');
+  });
+  document.getElementById('tweak-screen').addEventListener('change', e => {
+    window.__notifTweakScreen = e.target.value;
+    window.__notifTweakLayoutCb?.();
+    window.parent.postMessage({ type: '__edit_mode_set_keys', edits: { screen: e.target.value } }, '*');
+  });
+</script>
+
+<!-- ── React app ── -->
+<script type="text/babel" src="sp7-notifications-hub.jsx"></script>
+
+<script type="text/babel">
+const { useState, useEffect } = React;
+
+const SCREENS = [
+  { id: '1', label: '01 · Empty',           Comp: State01Empty },
+  { id: '2', label: '02 · 15 miste',        Comp: State02Mixed },
+  { id: '3', label: '03 · Non lette',       Comp: State03Unread },
+  { id: '4', label: '04 · Bulk confirm',    Comp: State04BulkConfirm },
+  { id: '5', label: '05 · Action drawer',   Comp: State05ActionDrawer },
+  { id: '6', label: '06 · Snooze toast',    Comp: State06SnoozeSuccess },
+  { id: '7', label: '07 · Error network',   Comp: State07Error },
+  { id: '8', label: '08 · Mobile stack',    Comp: State08MobileStack },
+];
+
+function PhoneFrame({ label, Comp }) {
+  return (
+    <div className="phone-wrap" data-screen-label={label}>
+      <div className="phone">
+        <div className="phone-sbar">
+          <span>09:41</span>
+          <div className="ind"><span>●●●</span><span>WiFi</span><span>100%</span></div>
+        </div>
+        <Comp />
+      </div>
+      <div className="screen-label">{label}</div>
+    </div>
+  );
+}
+
+function App() {
+  const [layout, setLayout] = useState('grid');
+  const [screen, setScreen] = useState('2');
+
+  useEffect(() => {
+    window.__notifTweakLayoutCb = () => {
+      if (window.__notifTweakLayout) setLayout(window.__notifTweakLayout);
+      if (window.__notifTweakScreen) setScreen(window.__notifTweakScreen);
+    };
+    return () => { window.__notifTweakLayoutCb = null; };
+  }, []);
+
+  if (layout === 'single') {
+    const s = SCREENS.find(s => s.id === screen) || SCREENS[0];
+    return (
+      <div style={{ display: 'flex', justifyContent: 'center', marginTop: 32 }}>
+        <PhoneFrame label={s.label} Comp={s.Comp} />
+      </div>
+    );
+  }
+
+  return (
+    <div className="phones-grid">
+      {SCREENS.map(s => (
+        <PhoneFrame key={s.id} label={s.label} Comp={s.Comp} />
+      ))}
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App />);
+</script>
+
+</body>
+</html>

--- a/admin-mockups/design_files/sp7-notifications-hub.jsx
+++ b/admin-mockups/design_files/sp7-notifications-hub.jsx
@@ -1,0 +1,734 @@
+// ── sp7-notifications-hub.jsx — MeepleAI Design System v1 · SP7-I
+// Route: /notifications · Persona: Marco al risveglio (mobile mass-check)
+// Pattern: timeline + grouping + bulk actions
+// Components: SeverityDot, EntityIcon, FilterTabs, BulkActionsBar,
+//             GroupDivider, NotificationItem, ActionDrawer, ConfirmModal,
+//             Toast, ErrorBanner, EmptyState, NotificationsFeed
+// 8 stati esportati a window per sp7-notifications-hub.html
+//
+// Severity → entity color mapping (via entityHsl helper, FREEZE-safe):
+//   🔴 Critica    = entityHsl('event')   rose
+//   🟡 Importante = entityHsl('agent')   amber
+//   🟢 Info       = entityHsl('toolkit') green
+//   ⚫ Lette      = var(--text-muted) / var(--text-sec)
+
+const { useState, useRef, useCallback } = React;
+
+// ── Helpers — FREEZE-safe: emette `hsl(var(--c-*))`, mai `hsl(<numero>` ──
+const entityHsl = (entity, alpha) =>
+  alpha !== undefined
+    ? `hsl(var(--c-${entity}) / ${alpha})`
+    : `hsl(var(--c-${entity}))`;
+
+// Mappa severity → entity token (single source of truth)
+const SEVERITY = {
+  critical:  { entity: 'event',   dot: '🔴', label: 'Critica' },
+  important: { entity: 'agent',   dot: '🟡', label: 'Importante' },
+  info:      { entity: 'toolkit', dot: '🟢', label: 'Info' },
+};
+const sevColor = (sev, alpha) => entityHsl(SEVERITY[sev].entity, alpha);
+
+// ── Demo data — persona italiana (Marco), 15 notifiche miste ──────
+// group: oggi | ieri | settimana ; sev: critical|important|info ; read: bool
+// mention: true → compare nel filtro "Mention"
+const NOTIFICATIONS = [
+  // ── OGGI ──
+  { id: 1, entity: 'event', icon: '🎉', sev: 'critical', read: false, mention: false,
+    title: 'Davide ha annullato all\'ultimo',
+    desc: 'Davide si è tirato indietro da "Sabato boardgame con i Padovani". Ora siete in 5.',
+    time: '3 min fa', timeAbs: 'Oggi alle 08:12', group: 'oggi', cta: 'Apri serata' },
+  { id: 2, entity: 'agent', icon: '🤖', sev: 'important', read: false, mention: false,
+    title: 'Training agente fallito per Wingspan',
+    desc: 'L\'indicizzazione del manuale Wingspan si è interrotta al 60%. Controlla il documento sorgente.',
+    time: '12 min fa', timeAbs: 'Oggi alle 08:03', group: 'oggi', cta: 'Riprova training' },
+  { id: 3, entity: 'player', icon: '👤', sev: 'important', read: false, mention: false,
+    title: 'Giulia ha confermato per Sabato boardgame',
+    desc: 'Giulia B. ha accettato l\'invito per sabato 27 alle 21:00. Conferme: 6 su 8.',
+    time: '38 min fa', timeAbs: 'Oggi alle 07:37', group: 'oggi', cta: 'Vedi RSVP' },
+  { id: 4, entity: 'chat', icon: '💬', sev: 'info', read: false, mention: true,
+    title: 'Luca ti ha menzionato',
+    desc: '@Marco hai ancora il manuale di Terraforming Mars? Servirebbe per giovedì.',
+    time: '1 ora fa', timeAbs: 'Oggi alle 07:15', group: 'oggi', cta: 'Rispondi' },
+  { id: 5, entity: 'toolkit', icon: '🧰', sev: 'info', read: false, mention: false,
+    title: 'Suggerimento agente: nuova house rule',
+    desc: 'L\'agente propone di salvare la variante "porto rapido" usata nelle ultime 3 partite di Catan.',
+    time: '2 ore fa', timeAbs: 'Oggi alle 06:20', group: 'oggi', cta: 'Vedi suggerimento' },
+  // ── IERI ──
+  { id: 6, entity: 'kb', icon: '📖', sev: 'important', read: true, mention: false,
+    title: 'Embedding KB completato',
+    desc: 'Il manuale di Ark Nova è stato indicizzato. 142 chunk pronti per le domande dell\'agente.',
+    time: 'ieri 18:32', timeAbs: 'Ieri alle 18:32', group: 'ieri', cta: 'Apri knowledge base' },
+  { id: 7, entity: 'player', icon: '👤', sev: 'info', read: true, mention: false,
+    title: 'Sara si è unita alla partita',
+    desc: 'Sara F. ha accettato il tuo invito per Carcassonne di domenica. Ora siete in 4.',
+    time: 'ieri 17:05', timeAbs: 'Ieri alle 17:05', group: 'ieri', cta: 'Vedi partita' },
+  { id: 8, entity: 'event', icon: '🎉', sev: 'critical', read: true, mention: false,
+    title: 'Serata di venerdì a rischio',
+    desc: 'Solo 2 conferme su 6 per "Aperitivo & Azul". Manda un promemoria agli indecisi?',
+    time: 'ieri 15:40', timeAbs: 'Ieri alle 15:40', group: 'ieri', cta: 'Invia promemoria' },
+  { id: 9, entity: 'chat', icon: '💬', sev: 'info', read: true, mention: true,
+    title: 'Federica ti ha menzionato',
+    desc: '@Marco grazie per il riepilogo, ci vediamo sabato! 🎲',
+    time: 'ieri 14:18', timeAbs: 'Ieri alle 14:18', group: 'ieri', cta: 'Apri chat' },
+  { id: 10, entity: 'agent', icon: '🤖', sev: 'important', read: true, mention: false,
+    title: 'Training agente completato per Wingspan',
+    desc: 'L\'agente Regolamento Wingspan è pronto. Puoi già fargli domande sulle regole.',
+    time: 'ieri 11:02', timeAbs: 'Ieri alle 11:02', group: 'ieri', cta: 'Chiedi all\'agente' },
+  // ── QUESTA SETTIMANA ──
+  { id: 11, entity: 'toolkit', icon: '🧰', sev: 'info', read: true, mention: false,
+    title: 'Riepilogo settimanale pronto',
+    desc: 'Questa settimana: 4 partite giocate, 2 serate organizzate, striscia di 3 settimane attiva.',
+    time: 'lun 09:00', timeAbs: 'Lunedì alle 09:00', group: 'settimana', cta: 'Vedi riepilogo' },
+  { id: 12, entity: 'player', icon: '👤', sev: 'info', read: true, mention: false,
+    title: 'Luca ha confermato per la serata',
+    desc: 'Luca M. parteciperà a "Sabato boardgame con i Padovani". Conferme: 5 su 8.',
+    time: 'lun 08:30', timeAbs: 'Lunedì alle 08:30', group: 'settimana', cta: 'Vedi RSVP' },
+  { id: 13, entity: 'kb', icon: '📖', sev: 'important', read: true, mention: false,
+    title: 'House rule aggiunta da Davide',
+    desc: 'Davide ha aggiunto a Risiko: "Prima mossa — dadi una sola volta per territorio".',
+    time: 'dom 20:14', timeAbs: 'Domenica alle 20:14', group: 'settimana', cta: 'Vedi regola' },
+  { id: 14, entity: 'game', icon: '🏆', sev: 'info', read: true, mention: false,
+    title: 'Nuovo record personale',
+    desc: 'Hai battuto il tuo punteggio massimo a Wingspan: 98 punti nella partita di sabato.',
+    time: 'dom 19:00', timeAbs: 'Domenica alle 19:00', group: 'settimana', cta: 'Vedi statistiche' },
+  { id: 15, entity: 'event', icon: '🎉', sev: 'critical', read: true, mention: false,
+    title: 'Federica ha annullato la serata di domenica',
+    desc: 'La serata "Domenica leggera con Patchwork" è stata cancellata dall\'organizzatrice.',
+    time: 'sab 22:45', timeAbs: 'Sabato alle 22:45', group: 'settimana', cta: 'Vedi dettagli' },
+];
+
+const GROUPS = [
+  { key: 'oggi',      label: 'Oggi' },
+  { key: 'ieri',      label: 'Ieri' },
+  { key: 'settimana', label: 'Questa settimana' },
+];
+
+const FILTERS = [
+  { key: 'all',      label: 'Tutte',    entity: 'game' },
+  { key: 'unread',   label: 'Non lette', entity: 'agent' },
+  { key: 'mention',  label: 'Mention',  entity: 'chat' },
+  { key: 'critical', label: 'Critiche', entity: 'event' },
+];
+
+// Predicate per ogni filtro
+const matchFilter = (n, key) => {
+  if (key === 'unread')   return !n.read;
+  if (key === 'mention')  return n.mention;
+  if (key === 'critical') return n.sev === 'critical';
+  return true; // all
+};
+
+// ── PhoneTopBar — header con title + counter ─────────────────────
+function PhoneTopBar({ unreadCount, totalCount }) {
+  return (
+    <div style={{
+      padding: '12px 14px 10px',
+      borderBottom: '1px solid var(--border)',
+      background: 'var(--bg)', flexShrink: 0,
+    }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+        <span style={{
+          fontFamily: 'var(--f-display)', fontWeight: 800,
+          fontSize: 19, flex: 1, letterSpacing: '-.01em', color: 'var(--text)',
+        }}>Notifiche</span>
+        {unreadCount > 0 && (
+          <div aria-hidden="true" style={{
+            minWidth: 22, height: 22, borderRadius: 11,
+            background: entityHsl('event'), color: '#fff',
+            display: 'flex', alignItems: 'center', justifyContent: 'center',
+            fontSize: 11, fontWeight: 800, fontFamily: 'var(--f-mono)',
+            padding: '0 6px', border: '2px solid var(--bg)',
+          }}>{unreadCount > 9 ? '9+' : unreadCount}</div>
+        )}
+        <button aria-label="Altre opzioni" style={{
+          width: 32, height: 32, borderRadius: '50%',
+          background: 'var(--bg-muted)', border: 'none', cursor: 'pointer',
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+          fontSize: 14, color: 'var(--text-sec)',
+        }}>⋯</button>
+      </div>
+      <div style={{
+        marginTop: 4, fontSize: 11.5, color: 'var(--text-muted)',
+        fontFamily: 'var(--f-mono)', letterSpacing: '.01em',
+      }}>
+        <span style={{ color: 'var(--text-sec)', fontWeight: 700 }}>{unreadCount} nuove</span>
+        {' · '}{totalCount} totali
+      </div>
+    </div>
+  );
+}
+
+// ── FilterTabs — [Tutte][Non lette][Mention][Critiche] ───────────
+function FilterTabs({ active, onChange, counts }) {
+  return (
+    <div role="tablist" aria-label="Filtra notifiche" style={{
+      display: 'flex', gap: 5, padding: '8px 12px',
+      overflowX: 'auto', flexShrink: 0,
+      borderBottom: '1px solid var(--border)',
+      background: 'var(--bg)', scrollbarWidth: 'none',
+    }}>
+      {FILTERS.map(f => {
+        const isActive = active === f.key;
+        const count = counts?.[f.key] ?? 0;
+        return (
+          <button key={f.key} role="tab" aria-selected={isActive}
+            onClick={() => onChange(f.key)} style={{
+              display: 'flex', alignItems: 'center', gap: 5,
+              padding: '6px 11px', borderRadius: 'var(--r-pill)',
+              border: 'none', cursor: 'pointer', whiteSpace: 'nowrap',
+              fontSize: 11.5, fontWeight: 700, fontFamily: 'var(--f-display)',
+              transition: 'all var(--dur-sm) var(--ease-out)',
+              background: isActive ? entityHsl(f.entity, 0.12) : 'transparent',
+              color: isActive ? entityHsl(f.entity) : 'var(--text-sec)',
+            }}>
+            <span>{f.label}</span>
+            {count > 0 && (
+              <span style={{
+                background: isActive ? entityHsl(f.entity) : 'var(--bg-muted)',
+                color: isActive ? '#fff' : 'var(--text-muted)',
+                borderRadius: 'var(--r-pill)', fontSize: 9, fontWeight: 800,
+                padding: '1px 5px', lineHeight: 1.6, fontFamily: 'var(--f-mono)',
+              }}>{count}</span>
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+// ── BulkActionsBar — visibile se > 5 unread ──────────────────────
+function BulkActionsBar({ unreadCount, onMarkAll }) {
+  return (
+    <div style={{
+      display: 'flex', alignItems: 'center', gap: 8,
+      padding: '8px 14px',
+      background: entityHsl('agent', 0.07),
+      borderBottom: '1px solid var(--border-light)', flexShrink: 0,
+    }}>
+      <span style={{
+        flex: 1, fontSize: 11.5, color: 'var(--text-sec)',
+        fontFamily: 'var(--f-display)', fontWeight: 600,
+      }}>{unreadCount} non lette</span>
+      <button onClick={onMarkAll} style={{
+        padding: '5px 11px', fontSize: 11, fontWeight: 700,
+        borderRadius: 'var(--r-pill)', cursor: 'pointer',
+        background: entityHsl('agent', 0.14), color: entityHsl('agent'),
+        border: 'none', fontFamily: 'var(--f-display)',
+      }}>Segna tutte come lette</button>
+      <button style={{
+        padding: '5px 11px', fontSize: 11, fontWeight: 700,
+        borderRadius: 'var(--r-pill)', cursor: 'pointer',
+        background: 'var(--bg-muted)', color: 'var(--text-muted)',
+        border: 'none', fontFamily: 'var(--f-display)',
+      }}>Archivia tutte</button>
+    </div>
+  );
+}
+
+// ── SeverityDot ──────────────────────────────────────────────────
+function SeverityDot({ sev, read }) {
+  return (
+    <span aria-hidden="true" style={{
+      width: 8, height: 8, borderRadius: '50%', flexShrink: 0,
+      background: read ? 'var(--text-muted)' : sevColor(sev),
+      opacity: read ? 0.5 : 1,
+    }} />
+  );
+}
+
+// ── EntityIcon ───────────────────────────────────────────────────
+function EntityIcon({ entity, icon, sev, read, size = 40 }) {
+  // Lette → tinta neutra; non lette → tinta severity
+  const bg = read ? 'var(--bg-muted)' : sevColor(sev, 0.14);
+  const fg = read ? 'var(--text-muted)' : sevColor(sev);
+  return (
+    <div aria-hidden="true" style={{
+      width: size, height: size, borderRadius: 'var(--r-lg)',
+      background: bg, color: fg,
+      display: 'flex', alignItems: 'center', justifyContent: 'center',
+      fontSize: Math.round(size * 0.45), flexShrink: 0,
+    }}>{icon}</div>
+  );
+}
+
+// ── TimestampRelative ────────────────────────────────────────────
+function TimestampRelative({ time }) {
+  return (
+    <span style={{
+      fontFamily: 'var(--f-mono)', fontSize: 10,
+      color: 'var(--text-muted)', whiteSpace: 'nowrap',
+    }}>{time}</span>
+  );
+}
+
+// ── GroupDivider ─────────────────────────────────────────────────
+function GroupDivider({ label, count }) {
+  return (
+    <div style={{
+      display: 'flex', alignItems: 'center', gap: 8,
+      padding: '12px 14px 6px',
+      fontFamily: 'var(--f-mono)', fontSize: 10,
+      color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '.08em',
+    }}>
+      <span>{label}</span>
+      <span style={{
+        background: 'var(--bg-muted)', borderRadius: 10,
+        padding: '1px 6px', fontSize: 9, fontWeight: 700,
+      }}>{count}</span>
+      <div style={{ flex: 1, height: 1, background: 'var(--border-light)' }} />
+    </div>
+  );
+}
+
+// ── NotificationItem ─────────────────────────────────────────────
+function NotificationItem({ notif, onLongPress }) {
+  const [hover, setHover] = useState(false);
+  const timer = useRef(null);
+
+  const startPress = () => {
+    timer.current = setTimeout(() => onLongPress?.(notif), 480);
+  };
+  const cancelPress = () => {
+    if (timer.current) { clearTimeout(timer.current); timer.current = null; }
+  };
+
+  return (
+    <div
+      role="listitem"
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => { setHover(false); cancelPress(); }}
+      onTouchStart={startPress}
+      onTouchEnd={cancelPress}
+      onTouchMove={cancelPress}
+      style={{
+        display: 'flex', alignItems: 'flex-start', gap: 12,
+        padding: '12px 14px',
+        borderLeft: `3px solid ${notif.read ? 'var(--border)' : sevColor(notif.sev)}`,
+        background: hover ? 'var(--bg-hover)' : 'transparent',
+        cursor: 'pointer',
+        transition: 'background var(--dur-xs) var(--ease-out)',
+        minHeight: 64,
+      }}
+    >
+      <EntityIcon entity={notif.entity} icon={notif.icon} sev={notif.sev} read={notif.read} />
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div style={{
+          display: 'flex', alignItems: 'center',
+          justifyContent: 'space-between', gap: 8, marginBottom: 2,
+        }}>
+          <span style={{
+            display: 'flex', alignItems: 'center', gap: 6, minWidth: 0,
+          }}>
+            <SeverityDot sev={notif.sev} read={notif.read} />
+            <span style={{
+              fontSize: 13, fontWeight: notif.read ? 500 : 700,
+              color: notif.read ? 'var(--text-sec)' : 'var(--text)',
+              fontFamily: 'var(--f-display)',
+              overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+            }}>{notif.title}</span>
+          </span>
+          <TimestampRelative time={notif.time} />
+        </div>
+        <div style={{
+          fontSize: 12, color: 'var(--text-sec)', lineHeight: 1.45,
+          display: '-webkit-box', WebkitLineClamp: 2,
+          WebkitBoxOrient: 'vertical', overflow: 'hidden',
+        }}>{notif.desc}</div>
+        {hover && (
+          <div style={{ display: 'flex', gap: 5, marginTop: 8 }}>
+            {notif.cta && (
+              <button style={{
+                padding: '3px 9px', fontSize: 10, fontWeight: 700,
+                borderRadius: 'var(--r-sm)',
+                background: sevColor(notif.sev, 0.14), color: sevColor(notif.sev),
+                border: 'none', cursor: 'pointer', fontFamily: 'var(--f-display)',
+              }}>{notif.cta}</button>
+            )}
+            <button style={{
+              padding: '3px 9px', fontSize: 10, fontWeight: 700,
+              borderRadius: 'var(--r-sm)',
+              background: 'var(--bg-muted)', color: 'var(--text-muted)',
+              border: 'none', cursor: 'pointer', fontFamily: 'var(--f-display)',
+            }}>Posticipa 1h</button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── ActionDrawer — bottom drawer 4 azioni (long-press) ───────────
+function ActionDrawer({ notif, onClose }) {
+  if (!notif) return null;
+  const actions = [
+    { icon: '✓',  label: 'Segna come letta', tint: entityHsl('toolkit', 0.14), fg: entityHsl('toolkit') },
+    { icon: '🕘', label: 'Posticipa di 1 ora', tint: entityHsl('agent', 0.14),   fg: entityHsl('agent') },
+    { icon: '📦', label: 'Archivia',          tint: 'var(--bg-muted)',           fg: 'var(--text-sec)' },
+    { icon: '↗',  label: 'Apri',              tint: sevColor(notif.sev, 0.14),   fg: sevColor(notif.sev) },
+  ];
+  return (
+    <div role="dialog" aria-label="Azioni notifica" style={{
+      position: 'absolute', bottom: 0, left: 0, right: 0,
+      background: 'var(--bg-card)',
+      borderRadius: 'var(--r-2xl) var(--r-2xl) 0 0',
+      boxShadow: 'var(--shadow-drawer)', zIndex: 10,
+      animation: 'slideUp var(--dur-md) var(--ease-out)',
+    }}>
+      {/* Handle */}
+      <div style={{ display: 'flex', justifyContent: 'center', padding: '10px 0 4px' }}>
+        <div style={{ width: 36, height: 4, borderRadius: 2, background: 'var(--border-strong)' }} />
+      </div>
+      {/* Context header */}
+      <div style={{ padding: '6px 16px 12px', display: 'flex', gap: 10, alignItems: 'center' }}>
+        <EntityIcon entity={notif.entity} icon={notif.icon} sev={notif.sev} read={notif.read} size={36} />
+        <span style={{
+          fontSize: 13, fontWeight: 700, fontFamily: 'var(--f-display)',
+          color: 'var(--text)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap',
+        }}>{notif.title}</span>
+      </div>
+      <div style={{ height: 1, background: 'var(--border-light)', margin: '0 16px' }} />
+      {/* Actions */}
+      <div style={{ padding: '8px 12px 4px' }}>
+        {actions.map((a, i) => (
+          <button key={i} onClick={onClose} style={{
+            display: 'flex', alignItems: 'center', gap: 12, width: '100%',
+            padding: '11px 12px', background: 'transparent', border: 'none',
+            borderRadius: 'var(--r-lg)', cursor: 'pointer', textAlign: 'left',
+            fontFamily: 'var(--f-display)',
+          }}>
+            <span aria-hidden="true" style={{
+              width: 34, height: 34, borderRadius: 'var(--r-md)',
+              background: a.tint, color: a.fg,
+              display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 15,
+            }}>{a.icon}</span>
+            <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--text)' }}>{a.label}</span>
+          </button>
+        ))}
+      </div>
+      <div style={{ padding: '4px 16px 24px' }}>
+        <button onClick={onClose} style={{
+          width: '100%', padding: '10px 16px',
+          background: 'var(--bg-muted)', color: 'var(--text-sec)',
+          border: 'none', borderRadius: 'var(--r-lg)', cursor: 'pointer',
+          fontSize: 12, fontWeight: 700, fontFamily: 'var(--f-display)',
+        }}>Annulla</button>
+      </div>
+    </div>
+  );
+}
+
+// ── ConfirmModal — "Segna tutte come lette" ──────────────────────
+function ConfirmModal({ count, onCancel, onConfirm }) {
+  return (
+    <div role="dialog" aria-modal="true" aria-label="Conferma azione" style={{
+      position: 'absolute', inset: 0, zIndex: 20,
+      display: 'flex', alignItems: 'center', justifyContent: 'center',
+      padding: 22,
+    }}>
+      <div style={{
+        position: 'absolute', inset: 0,
+        background: 'rgba(0,0,0,0.28)', backdropFilter: 'blur(2px)',
+      }} onClick={onCancel} />
+      <div style={{
+        position: 'relative', width: '100%', maxWidth: 300,
+        background: 'var(--bg-card)', borderRadius: 'var(--r-2xl)',
+        boxShadow: 'var(--shadow-lg)', padding: '22px 20px 18px', textAlign: 'center',
+      }}>
+        <div aria-hidden="true" style={{
+          width: 52, height: 52, borderRadius: '50%', margin: '0 auto 14px',
+          background: entityHsl('agent', 0.14), color: entityHsl('agent'),
+          display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 24,
+        }}>✓</div>
+        <div style={{
+          fontFamily: 'var(--f-display)', fontWeight: 800, fontSize: 16,
+          color: 'var(--text)', marginBottom: 6, letterSpacing: '-.01em',
+        }}>Segnare tutte come lette?</div>
+        <div style={{
+          fontSize: 12.5, color: 'var(--text-muted)', lineHeight: 1.5, marginBottom: 18,
+        }}>{count} notifiche non lette verranno marcate come lette. L&apos;azione non è reversibile.</div>
+        <div style={{ display: 'flex', gap: 9 }}>
+          <button onClick={onCancel} style={{
+            flex: 1, padding: '10px 14px', background: 'var(--bg-muted)',
+            color: 'var(--text-sec)', border: 'none', borderRadius: 'var(--r-lg)',
+            cursor: 'pointer', fontSize: 12.5, fontWeight: 700, fontFamily: 'var(--f-display)',
+          }}>Annulla</button>
+          <button onClick={onConfirm} style={{
+            flex: 1, padding: '10px 14px', background: entityHsl('agent'),
+            color: '#fff', border: 'none', borderRadius: 'var(--r-lg)',
+            cursor: 'pointer', fontSize: 12.5, fontWeight: 700, fontFamily: 'var(--f-display)',
+          }}>Conferma</button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Toast — success "Notifica posticipata di 1h" ─────────────────
+function Toast({ icon, text, entity }) {
+  return (
+    <div role="status" style={{
+      position: 'absolute', left: 14, right: 14, bottom: 18, zIndex: 30,
+      display: 'flex', alignItems: 'center', gap: 10,
+      padding: '12px 14px', borderRadius: 'var(--r-lg)',
+      background: 'var(--bg-card)', boxShadow: 'var(--shadow-lg)',
+      border: `1px solid ${entityHsl(entity, 0.3)}`,
+      animation: 'slideUp var(--dur-md) var(--ease-out)',
+    }}>
+      <span aria-hidden="true" style={{
+        width: 32, height: 32, borderRadius: 'var(--r-md)', flexShrink: 0,
+        background: entityHsl(entity, 0.14), color: entityHsl(entity),
+        display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 16,
+      }}>{icon}</span>
+      <span style={{
+        flex: 1, fontSize: 12.5, fontWeight: 600, color: 'var(--text)',
+        fontFamily: 'var(--f-display)',
+      }}>{text}</span>
+      <button style={{
+        padding: '3px 9px', fontSize: 11, fontWeight: 700,
+        background: 'transparent', color: entityHsl(entity),
+        border: 'none', cursor: 'pointer', fontFamily: 'var(--f-display)',
+      }}>Annulla</button>
+    </div>
+  );
+}
+
+// ── ErrorBanner — "Impossibile caricare nuove notifiche" ─────────
+function ErrorBanner({ onRetry }) {
+  return (
+    <div role="alert" style={{
+      display: 'flex', alignItems: 'center', gap: 10,
+      margin: '10px 12px', padding: '11px 13px',
+      borderRadius: 'var(--r-lg)', flexShrink: 0,
+      background: entityHsl('event', 0.1),
+      border: `1px solid ${entityHsl('event', 0.3)}`,
+    }}>
+      <span aria-hidden="true" style={{
+        width: 30, height: 30, borderRadius: 'var(--r-md)', flexShrink: 0,
+        background: entityHsl('event', 0.16), color: entityHsl('event'),
+        display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 15,
+      }}>⚠️</span>
+      <div style={{ flex: 1 }}>
+        <div style={{
+          fontSize: 12.5, fontWeight: 700, color: entityHsl('event'),
+          fontFamily: 'var(--f-display)',
+        }}>Impossibile caricare nuove notifiche</div>
+        <div style={{ fontSize: 11, color: 'var(--text-muted)', marginTop: 1 }}>
+          Connessione assente. Le notifiche mostrate potrebbero non essere aggiornate.
+        </div>
+      </div>
+      <button onClick={onRetry} style={{
+        padding: '5px 12px', fontSize: 11, fontWeight: 700, flexShrink: 0,
+        borderRadius: 'var(--r-pill)', cursor: 'pointer',
+        background: entityHsl('event'), color: '#fff',
+        border: 'none', fontFamily: 'var(--f-display)',
+      }}>Riprova</button>
+    </div>
+  );
+}
+
+// ── EmptyState — "Nessuna notifica" + suggested actions ──────────
+function EmptyState() {
+  const suggestions = [
+    { icon: '🎉', label: 'Organizza una serata gioco', entity: 'event' },
+    { icon: '🤖', label: 'Crea un agente regolamento', entity: 'agent' },
+    { icon: '📖', label: 'Aggiungi un gioco alla libreria', entity: 'toolkit' },
+  ];
+  return (
+    <div style={{
+      flex: 1, display: 'flex', flexDirection: 'column',
+      alignItems: 'center', justifyContent: 'center',
+      padding: '36px 22px', gap: 14, textAlign: 'center',
+    }}>
+      <div aria-hidden="true" style={{
+        width: 96, height: 96, borderRadius: '50%',
+        background: entityHsl('toolkit', 0.1),
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        fontSize: 42, marginBottom: 2,
+      }}>🔔</div>
+      <div style={{
+        fontFamily: 'var(--f-display)', fontWeight: 800,
+        fontSize: 17, color: 'var(--text)', letterSpacing: '-.01em',
+      }}>Nessuna notifica</div>
+      <div style={{
+        fontSize: 13, color: 'var(--text-muted)',
+        lineHeight: 1.55, maxWidth: 250,
+      }}>
+        Sei in pari! Qui appariranno aggiornamenti su serate, agenti, RSVP e altro.
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 8, width: '100%', maxWidth: 280, marginTop: 6 }}>
+        {suggestions.map((s, i) => (
+          <button key={i} style={{
+            display: 'flex', alignItems: 'center', gap: 11, width: '100%',
+            padding: '11px 13px', borderRadius: 'var(--r-lg)', cursor: 'pointer',
+            background: 'var(--bg-card)', border: '1px solid var(--border)',
+            fontFamily: 'var(--f-display)', textAlign: 'left',
+          }}>
+            <span aria-hidden="true" style={{
+              width: 32, height: 32, borderRadius: 'var(--r-md)', flexShrink: 0,
+              background: entityHsl(s.entity, 0.12), color: entityHsl(s.entity),
+              display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 15,
+            }}>{s.icon}</span>
+            <span style={{ flex: 1, fontSize: 12.5, fontWeight: 700, color: 'var(--text)' }}>{s.label}</span>
+            <span aria-hidden="true" style={{ color: 'var(--text-muted)', fontSize: 15 }}>›</span>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ── NotificationsFeed (shared logic) ─────────────────────────────
+function NotificationsFeed({ notifs, onLongPress, dim }) {
+  const grouped = GROUPS.map(g => ({
+    ...g,
+    items: notifs.filter(n => n.group === g.key),
+  })).filter(g => g.items.length > 0);
+
+  return (
+    <div role="feed" aria-label="Notifiche" style={{
+      flex: 1, overflowY: 'auto', display: 'flex', flexDirection: 'column',
+      opacity: dim ? 0.4 : 1,
+    }}>
+      {grouped.map(g => (
+        <div key={g.key}>
+          <GroupDivider label={g.label} count={g.items.length} />
+          {g.items.map(n => (
+            <NotificationItem key={n.id} notif={n} onLongPress={onLongPress} />
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// Conteggi per i filter tabs (sul dataset completo)
+function filterCounts(notifs) {
+  const c = {};
+  FILTERS.forEach(f => {
+    c[f.key] = f.key === 'all'
+      ? notifs.length
+      : notifs.filter(n => matchFilter(n, f.key)).length;
+  });
+  return c;
+}
+
+const UNREAD = NOTIFICATIONS.filter(n => !n.read).length; // 5
+const TOTAL = NOTIFICATIONS.length;                       // 15
+
+// ── STATE 01 — Empty, nessuna notifica ───────────────────────────
+function State01Empty() {
+  return (
+    <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+      <PhoneTopBar unreadCount={0} totalCount={0} />
+      <FilterTabs active="all" onChange={() => {}} counts={{ all: 0, unread: 0, mention: 0, critical: 0 }} />
+      <EmptyState />
+    </div>
+  );
+}
+
+// ── STATE 02 — 15 notifiche miste, 5 unread, gruppi ──────────────
+function State02Mixed() {
+  return (
+    <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+      <PhoneTopBar unreadCount={UNREAD} totalCount={TOTAL} />
+      <FilterTabs active="all" onChange={() => {}} counts={filterCounts(NOTIFICATIONS)} />
+      <BulkActionsBar unreadCount={UNREAD} onMarkAll={() => {}} />
+      <NotificationsFeed notifs={NOTIFICATIONS} />
+    </div>
+  );
+}
+
+// ── STATE 03 — Filtro "Non lette" → 5 ────────────────────────────
+function State03Unread() {
+  const filtered = NOTIFICATIONS.filter(n => matchFilter(n, 'unread'));
+  return (
+    <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+      <PhoneTopBar unreadCount={UNREAD} totalCount={TOTAL} />
+      <FilterTabs active="unread" onChange={() => {}} counts={filterCounts(NOTIFICATIONS)} />
+      <NotificationsFeed notifs={filtered} />
+    </div>
+  );
+}
+
+// ── STATE 04 — Bulk "Segna tutte come lette" → confirm modal ─────
+function State04BulkConfirm() {
+  return (
+    <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden', position: 'relative' }}>
+      <PhoneTopBar unreadCount={UNREAD} totalCount={TOTAL} />
+      <FilterTabs active="all" onChange={() => {}} counts={filterCounts(NOTIFICATIONS)} />
+      <BulkActionsBar unreadCount={UNREAD} onMarkAll={() => {}} />
+      <NotificationsFeed notifs={NOTIFICATIONS} dim />
+      <ConfirmModal count={UNREAD} onCancel={() => {}} onConfirm={() => {}} />
+    </div>
+  );
+}
+
+// ── STATE 05 — Long-press → action drawer (4 azioni) ─────────────
+function State05ActionDrawer() {
+  const target = NOTIFICATIONS[0]; // notifica critica "Davide ha annullato"
+  return (
+    <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden', position: 'relative' }}>
+      <PhoneTopBar unreadCount={UNREAD} totalCount={TOTAL} />
+      <FilterTabs active="all" onChange={() => {}} counts={filterCounts(NOTIFICATIONS)} />
+      <NotificationsFeed notifs={NOTIFICATIONS} dim />
+      <div style={{
+        position: 'absolute', inset: 0, zIndex: 5,
+        background: 'rgba(0,0,0,0.22)', backdropFilter: 'blur(1px)',
+      }} />
+      <ActionDrawer notif={target} onClose={() => {}} />
+    </div>
+  );
+}
+
+// ── STATE 06 — Snooze success toast ──────────────────────────────
+function State06SnoozeSuccess() {
+  return (
+    <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden', position: 'relative' }}>
+      <PhoneTopBar unreadCount={UNREAD - 1} totalCount={TOTAL} />
+      <FilterTabs active="all" onChange={() => {}} counts={filterCounts(NOTIFICATIONS)} />
+      {/* notifica 1 posticipata → rimossa dal feed visibile */}
+      <NotificationsFeed notifs={NOTIFICATIONS.filter(n => n.id !== 1)} />
+      <Toast icon="🕘" entity="agent" text="Notifica posticipata di 1 ora" />
+    </div>
+  );
+}
+
+// ── STATE 07 — Error network banner + retry ──────────────────────
+function State07Error() {
+  return (
+    <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+      <PhoneTopBar unreadCount={UNREAD} totalCount={TOTAL} />
+      <FilterTabs active="all" onChange={() => {}} counts={filterCounts(NOTIFICATIONS)} />
+      <ErrorBanner onRetry={() => {}} />
+      <NotificationsFeed notifs={NOTIFICATIONS} />
+    </div>
+  );
+}
+
+// ── STATE 08 — Mobile stack (vertical, compact) ──────────────────
+// Variante stack verticale: feed denso senza divisori interni, ideale
+// per il "mass-check" mobile di Marco al risveglio.
+function State08MobileStack() {
+  const sample = NOTIFICATIONS.slice(0, 8);
+  return (
+    <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden' }}>
+      <PhoneTopBar unreadCount={UNREAD} totalCount={TOTAL} />
+      <div role="feed" aria-label="Notifiche" style={{ flex: 1, overflowY: 'auto' }}>
+        {sample.map((n, i) => (
+          <div key={n.id} style={{
+            borderBottom: i < sample.length - 1 ? '1px solid var(--border-light)' : 'none',
+          }}>
+            <NotificationItem notif={n} onLongPress={() => {}} />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// ── Export to window ─────────────────────────────────────────────
+Object.assign(window, {
+  State01Empty, State02Mixed, State03Unread, State04BulkConfirm,
+  State05ActionDrawer, State06SnoozeSuccess, State07Error, State08MobileStack,
+});

--- a/admin-mockups/design_files/sp7-notifications-preferences.fidelity.json
+++ b/admin-mockups/design_files/sp7-notifications-preferences.fidelity.json
@@ -1,0 +1,37 @@
+{
+  "_comment": "SP7-J Notifications Preferences — route /notifications/preferences, persona Marco. 5 screen states (canonical-mapped): default-all-on (default), customized-realtime-only-critical (default), quiet-hours-22-08 (default), no-mobile-device-registered (empty), save-success-toast (default). Brief: admin-mockups/briefs/SP7-game-night-agent-builder.md § J.",
+  "mockup": {
+    "source": "admin-mockups/design_files/sp7-notifications-preferences.html",
+    "states": [
+      "default",
+      "empty"
+    ]
+  },
+  "acceptance": {
+    "visual_diff_max_px": 5,
+    "color_delta_e_max": 3,
+    "tokens_used": "canonical_only",
+    "legacy_token_names_forbidden": true,
+    "states_covered": [
+      "default",
+      "empty"
+    ],
+    "a11y_axe": "AA",
+    "a11y_violations_max": 0,
+    "responsive_breakpoints": [
+      375,
+      768,
+      1024,
+      1440
+    ],
+    "designer_approved_by": "",
+    "designer_approved_on": "",
+    "story_path": "",
+    "fixtures_path": "",
+    "design_intent": "current",
+    "viewports": [
+      "mobile"
+    ],
+    "obsolete_tracking_issue": ""
+  }
+}

--- a/admin-mockups/design_files/sp7-notifications-preferences.html
+++ b/admin-mockups/design_files/sp7-notifications-preferences.html
@@ -1,0 +1,279 @@
+<!doctype html>
+<html lang="it" data-theme="light">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<title>MeepleAI — Notifications Preferences</title>
+<link rel="preconnect" href="https://fonts.googleapis.com"/>
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+<link href="https://fonts.googleapis.com/css2?family=Quicksand:wght@400;500;600;700&family=Nunito:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="tokens.css"/>
+<link rel="stylesheet" href="components.css"/>
+
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+
+<style>
+  /* ── Stage ── */
+  .stage { padding: 96px 24px 80px; }
+
+  /* ── Phones grid ── */
+  .phones-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(380px, 380px));
+    gap: 36px 28px;
+    justify-content: center;
+    margin-top: 32px;
+  }
+
+  /* ── Phone scrollbar hide ── */
+  .phone * { scrollbar-width: none; }
+  .phone *::-webkit-scrollbar { display: none; }
+
+  /* ── Toast slide-up ── */
+  @keyframes prefToastIn {
+    from { transform: translate(-50%, 14px); opacity: 0; }
+    to   { transform: translate(-50%, 0);    opacity: 1; }
+  }
+
+  /* ── Reduced motion ── */
+  @media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after {
+      animation-duration: 0.001ms !important;
+      animation-iteration-count: 1 !important;
+      transition-duration: 0.001ms !important;
+    }
+  }
+
+  /* ── Screen label pill ── */
+  .screen-label {
+    font-family: var(--f-mono); font-size: 10px;
+    color: var(--text-muted); text-transform: uppercase;
+    letter-spacing: .1em; text-align: center;
+    margin-top: 12px;
+  }
+
+  /* ── Phone label ── */
+  .phone-wrap { display: flex; flex-direction: column; }
+
+  /* ── Focus ring ── */
+  button:focus-visible, a:focus-visible, input:focus-visible, select:focus-visible {
+    outline: 2px solid hsl(var(--c-event));
+    outline-offset: 2px;
+  }
+
+  /* ── Tweaks panel ── */
+  #tweaks-panel {
+    position: fixed; bottom: 24px; right: 24px; z-index: 9999;
+    display: none;
+    background: var(--glass-bg); backdrop-filter: blur(16px);
+    border: 1px solid var(--border); border-radius: var(--r-xl);
+    box-shadow: var(--shadow-lg);
+    padding: 16px 18px; min-width: 220px;
+    font-family: var(--f-display); font-size: 13px; color: var(--text);
+  }
+  #tweaks-panel h4 {
+    font-size: 11px; font-weight: 700; margin: 0 0 12px;
+    text-transform: uppercase; letter-spacing: .08em;
+    color: var(--text-muted); font-family: var(--f-mono);
+  }
+  #tweaks-panel label {
+    display: flex; align-items: center; justify-content: space-between;
+    gap: 10px; font-size: 12px; margin-bottom: 10px;
+    color: var(--text-sec);
+  }
+  #tweaks-panel select {
+    font-family: inherit; font-size: 12px;
+    padding: 3px 6px; border-radius: var(--r-sm);
+    border: 1px solid var(--border); background: var(--bg);
+    color: var(--text); cursor: pointer;
+  }
+</style>
+</head>
+<body>
+
+<!-- ── Hub nav ── -->
+<nav class="hub-nav">
+  <a href="00-hub.html" class="brand" style="color:inherit;text-decoration:none;">
+    <span class="brand-mark">M</span>
+    <span>MeepleAI</span>
+  </a>
+  <span style="font-size:11px;padding:3px 8px;border-radius:6px;background:var(--bg-muted);font-family:var(--f-mono);color:var(--text-muted);">SP7-J · Notif. Preferences</span>
+  <div class="spacer"></div>
+  <a href="notifications.html" /* DEMO-NAV */>Notifiche</a>
+  <a href="settings.html" /* DEMO-NAV */>Settings</a>
+  <a href="sp7-notifications-preferences.html" class="active">Preferenze</a>
+</nav>
+
+<!-- ── Theme toggle ── -->
+<button class="theme-toggle" id="themeToggle">🌗 <span id="themeLabel">Light</span></button>
+
+<!-- ── Stage ── -->
+<div class="stage">
+  <div class="stage-wrap">
+    <h1>Notifications <span style="color:hsl(var(--c-event));">preferences</span></h1>
+    <p class="lead">
+      5 screen mobile per la configurazione delle notifiche: canali (in-app, email, push),
+      matrice severità × canale, frequency e quiet hours. Form one-time setup per Marco —
+      ogni severità è entity-colored (Critica = event, Importante = agent, Info = toolkit).
+    </p>
+
+    <!-- Feature chips -->
+    <div style="display:flex;flex-wrap:wrap;gap:8px;margin-bottom:32px;">
+      <span class="e-event e-chip">🔔 5 screen</span>
+      <span class="e-agent e-chip">🎚️ Toggle canali</span>
+      <span class="e-toolkit e-chip">🗂️ Matrice severità</span>
+      <span class="e-kb e-chip">⏰ Quiet hours</span>
+      <span class="e-session e-chip">📱 Empty device</span>
+      <span class="e-game e-chip">✓ Save toast</span>
+    </div>
+
+    <div id="root"></div>
+  </div>
+</div>
+
+<!-- ── Tweaks panel ── -->
+<div id="tweaks-panel">
+  <h4>Tweaks</h4>
+  <label>
+    <span>Tema</span>
+    <select id="tweak-theme">
+      <option value="light">Light</option>
+      <option value="dark">Dark</option>
+    </select>
+  </label>
+  <label>
+    <span>Layout</span>
+    <select id="tweak-layout">
+      <option value="grid">Griglia phones</option>
+      <option value="single">Phone singolo</option>
+    </select>
+  </label>
+  <label>
+    <span>Screen singolo</span>
+    <select id="tweak-screen">
+      <option value="1">1 · Default all-on</option>
+      <option value="2">2 · Customized</option>
+      <option value="3">3 · Quiet hours</option>
+      <option value="4">4 · No device</option>
+      <option value="5">5 · Save toast</option>
+    </select>
+  </label>
+</div>
+
+<!-- ── Theme + Tweaks scripts ── -->
+<script>
+  const root = document.documentElement;
+  const saved = localStorage.getItem('mai-theme') || 'light';
+  root.setAttribute('data-theme', saved);
+  document.getElementById('themeLabel').textContent = saved === 'dark' ? 'Dark' : 'Light';
+  document.getElementById('themeToggle').addEventListener('click', () => {
+    const next = root.getAttribute('data-theme') === 'light' ? 'dark' : 'light';
+    root.setAttribute('data-theme', next);
+    localStorage.setItem('mai-theme', next);
+    document.getElementById('themeLabel').textContent = next === 'dark' ? 'Dark' : 'Light';
+    document.getElementById('tweak-theme').value = next;
+    window.parent.postMessage({ type: '__edit_mode_set_keys', edits: { theme: next } }, '*');
+  });
+
+  const TWEAK_DEFAULTS = /*EDITMODE-BEGIN*/{
+    "theme": "light",
+    "layout": "grid",
+    "screen": "1"
+  }/*EDITMODE-END*/;
+
+  window.addEventListener('message', e => {
+    if (e.data?.type === '__activate_edit_mode')
+      document.getElementById('tweaks-panel').style.display = 'block';
+    if (e.data?.type === '__deactivate_edit_mode')
+      document.getElementById('tweaks-panel').style.display = 'none';
+  });
+  window.parent.postMessage({ type: '__edit_mode_available' }, '*');
+
+  document.getElementById('tweak-theme').value = saved;
+  document.getElementById('tweak-theme').addEventListener('change', e => {
+    const next = e.target.value;
+    root.setAttribute('data-theme', next);
+    localStorage.setItem('mai-theme', next);
+    document.getElementById('themeLabel').textContent = next === 'dark' ? 'Dark' : 'Light';
+    window.parent.postMessage({ type: '__edit_mode_set_keys', edits: { theme: next } }, '*');
+  });
+
+  // Layout / single-screen tweaks are handled after React mounts
+  document.getElementById('tweak-layout').addEventListener('change', e => {
+    window.__prefTweakLayout = e.target.value;
+    window.__prefTweakLayoutCb?.();
+    window.parent.postMessage({ type: '__edit_mode_set_keys', edits: { layout: e.target.value } }, '*');
+  });
+  document.getElementById('tweak-screen').addEventListener('change', e => {
+    window.__prefTweakScreen = e.target.value;
+    window.__prefTweakLayoutCb?.();
+    window.parent.postMessage({ type: '__edit_mode_set_keys', edits: { screen: e.target.value } }, '*');
+  });
+</script>
+
+<!-- ── React app ── -->
+<script type="text/babel" src="sp7-notifications-preferences.jsx"></script>
+
+<script type="text/babel">
+const { useState, useEffect } = React;
+
+const SCREENS = [
+  { id: '1', label: '01 · Default all-on',     Comp: Screen1DefaultAllOn },
+  { id: '2', label: '02 · Real-time critiche', Comp: Screen2Customized },
+  { id: '3', label: '03 · Quiet hours 22-08',  Comp: Screen3QuietHours },
+  { id: '4', label: '04 · No device mobile',   Comp: Screen4NoDevice },
+  { id: '5', label: '05 · Save success toast',  Comp: Screen5SaveToast },
+];
+
+function PhoneFrame({ label, Comp }) {
+  return (
+    <div className="phone-wrap" data-screen-label={label}>
+      <div className="phone">
+        <div className="phone-sbar">
+          <span>09:41</span>
+          <div className="ind"><span>●●●</span><span>WiFi</span><span>100%</span></div>
+        </div>
+        <Comp />
+      </div>
+      <div className="screen-label">{label}</div>
+    </div>
+  );
+}
+
+function App() {
+  const [layout, setLayout] = useState('grid');
+  const [screen, setScreen] = useState('1');
+
+  useEffect(() => {
+    window.__prefTweakLayoutCb = () => {
+      if (window.__prefTweakLayout) setLayout(window.__prefTweakLayout);
+      if (window.__prefTweakScreen) setScreen(window.__prefTweakScreen);
+    };
+    return () => { window.__prefTweakLayoutCb = null; };
+  }, []);
+
+  if (layout === 'single') {
+    const s = SCREENS.find(s => s.id === screen) || SCREENS[0];
+    return (
+      <div style={{ display: 'flex', justifyContent: 'center', marginTop: 32 }}>
+        <PhoneFrame label={s.label} Comp={s.Comp} />
+      </div>
+    );
+  }
+
+  return (
+    <div className="phones-grid">
+      {SCREENS.map(s => (
+        <PhoneFrame key={s.id} label={s.label} Comp={s.Comp} />
+      ))}
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App />);
+</script>
+
+</body>
+</html>

--- a/admin-mockups/design_files/sp7-notifications-preferences.jsx
+++ b/admin-mockups/design_files/sp7-notifications-preferences.jsx
@@ -1,0 +1,661 @@
+// ── sp7-notifications-preferences.jsx — MeepleAI Design System v1
+// Route: /notifications/preferences · Persona: Marco (one-time setup)
+// Components: ToggleSwitch, ChannelToggleRow, FrequencyRadio, TimePicker,
+//             QuietHoursCard, SeverityMatrix, DeviceList, EmptyDevice,
+//             SaveToast, PrefSection, PhoneTopBar, PrefScreen
+// Screens 1–5 exported to window for sp7-notifications-preferences.html
+//
+// FREEZE: every color goes through entityHsl(entity, alpha) or var(--token).
+//         No raw numeric hsl() literals anywhere. No external catalog hosts.
+
+const { useState, useCallback } = React;
+
+// ── Helper: entity color (HSL triplet token + optional alpha) ────────
+// entityHsl('event')        -> hsl(var(--c-event))
+// entityHsl('event', 0.12)  -> hsl(var(--c-event) / 0.12)
+const entityHsl = (type, alpha) =>
+  alpha === undefined
+    ? `hsl(var(--c-${type}))`
+    : `hsl(var(--c-${type}) / ${alpha})`;
+
+// ── Severity → entity mapping (task spec) ────────────────────────────
+// Critica = event · Importante = agent · Info = toolkit
+const SEVERITY_ENTITY = { critica: 'event', importante: 'agent', info: 'toolkit' };
+
+// ══════════════════════════════════════════════════════════════════
+// ── PRIMITIVES ────────────────────────────────────────────────────
+// ══════════════════════════════════════════════════════════════════
+
+// ── ToggleSwitch ──────────────────────────────────────────────────
+function ToggleSwitch({ checked, onChange, entity = 'game', label, size = 'md' }) {
+  const W = size === 'sm' ? 38 : 48;
+  const H = size === 'sm' ? 22 : 28;
+  const K = size === 'sm' ? 16 : 22;
+  const pad = 2;
+  return (
+    <button
+      role="switch" aria-checked={checked} aria-label={label || ''}
+      onClick={() => onChange(!checked)}
+      style={{
+        width: W, height: H, borderRadius: H / 2, padding: 0, flexShrink: 0,
+        border: checked
+          ? `1px solid ${entityHsl(entity)}`
+          : '1px solid var(--border)',
+        background: checked ? entityHsl(entity) : 'var(--bg-muted)',
+        position: 'relative', cursor: 'pointer',
+        transition: 'background var(--dur-sm) var(--ease-out), border-color var(--dur-sm) var(--ease-out)',
+        outline: 'none',
+      }}
+    >
+      <div style={{
+        position: 'absolute', top: pad, left: checked ? W - K - pad : pad,
+        width: K, height: K, borderRadius: '50%', background: '#fff',
+        boxShadow: '0 1px 4px rgba(0,0,0,.25)',
+        transition: 'left var(--dur-sm) var(--ease-out)',
+      }} />
+    </button>
+  );
+}
+
+// ── Lbl (uppercase micro-label) ──────────────────────────────────
+function Lbl({ children }) {
+  return (
+    <div style={{
+      fontSize: 11, fontWeight: 700, fontFamily: 'var(--f-display)',
+      color: 'var(--text-sec)', textTransform: 'uppercase',
+      letterSpacing: '.08em', marginBottom: 6,
+    }}>{children}</div>
+  );
+}
+
+// ── PrefSection (auth-card style grouping) ───────────────────────
+function PrefSection({ icon, entity = 'game', title, subtitle, children, footer }) {
+  return (
+    <div style={{
+      margin: '0 14px 14px',
+      border: '1px solid var(--border)', borderRadius: 'var(--r-xl)',
+      background: 'var(--bg-card)', overflow: 'hidden',
+    }}>
+      <div style={{
+        display: 'flex', alignItems: 'center', gap: 11,
+        padding: '13px 15px 12px',
+        borderBottom: '1px solid var(--border-light)',
+      }}>
+        <div style={{
+          width: 34, height: 34, borderRadius: 'var(--r-md)', flexShrink: 0,
+          background: entityHsl(entity, 0.12), color: entityHsl(entity),
+          display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 16,
+        }}>{icon}</div>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{
+            fontSize: 13.5, fontWeight: 700, fontFamily: 'var(--f-display)',
+            color: 'var(--text)', letterSpacing: '-.01em',
+          }}>{title}</div>
+          {subtitle && (
+            <div style={{ fontSize: 11, color: 'var(--text-muted)', marginTop: 1, lineHeight: 1.4 }}>
+              {subtitle}
+            </div>
+          )}
+        </div>
+      </div>
+      <div style={{ padding: '6px 15px 12px' }}>{children}</div>
+      {footer}
+    </div>
+  );
+}
+
+// ── ChannelToggleRow (one channel: in-app / email / push) ────────
+function ChannelToggleRow({ icon, label, hint, entity, checked, onChange, children }) {
+  return (
+    <div style={{ padding: '9px 0', borderTop: '1px solid var(--border-light)' }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 11 }}>
+        <span style={{ fontSize: 16, width: 22, textAlign: 'center', flexShrink: 0 }}>{icon}</span>
+        <div style={{ flex: 1, minWidth: 0 }}>
+          <div style={{
+            fontSize: 13, fontWeight: 700, fontFamily: 'var(--f-display)', color: 'var(--text)',
+          }}>{label}</div>
+          {hint && (
+            <div style={{ fontSize: 10.5, color: 'var(--text-muted)', marginTop: 1, lineHeight: 1.4 }}>
+              {hint}
+            </div>
+          )}
+        </div>
+        <ToggleSwitch checked={checked} onChange={onChange} entity={entity} label={label} />
+      </div>
+      {checked && children && <div style={{ paddingLeft: 33, marginTop: 8 }}>{children}</div>}
+    </div>
+  );
+}
+
+// ── FrequencyRadio (Real-time / Daily digest / Off) ──────────────
+const FREQ_OPTIONS = [
+  { value: 'realtime', label: 'Real-time', desc: 'Push immediato', icon: '⚡' },
+  { value: 'daily',    label: 'Daily digest', desc: 'Una mail al mattino', icon: '📬' },
+  { value: 'off',      label: 'Off', desc: 'Solo notifiche critiche', icon: '🔕' },
+];
+
+function FrequencyRadio({ value, onChange, entity = 'agent', name }) {
+  return (
+    <div role="radiogroup" aria-label="Frequenza notifiche"
+      style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+      {FREQ_OPTIONS.map(opt => {
+        const active = value === opt.value;
+        return (
+          <label key={opt.value} style={{
+            display: 'flex', alignItems: 'center', gap: 10, cursor: 'pointer',
+            padding: '8px 10px', borderRadius: 'var(--r-md)',
+            border: active ? `1px solid ${entityHsl(entity, 0.5)}` : '1px solid var(--border)',
+            background: active ? entityHsl(entity, 0.08) : 'transparent',
+            transition: 'all var(--dur-sm) var(--ease-out)',
+          }}>
+            <input type="radio" name={name} value={opt.value} checked={active}
+              onChange={() => onChange(opt.value)}
+              style={{ accentColor: entityHsl(entity), width: 15, height: 15, flexShrink: 0 }}
+            />
+            <span style={{ fontSize: 14, width: 18, textAlign: 'center' }}>{opt.icon}</span>
+            <div style={{ flex: 1 }}>
+              <div style={{
+                fontSize: 12.5, fontWeight: 700, fontFamily: 'var(--f-display)',
+                color: active ? entityHsl(entity) : 'var(--text)',
+              }}>{opt.label}</div>
+              <div style={{ fontSize: 10.5, color: 'var(--text-muted)', marginTop: 1 }}>{opt.desc}</div>
+            </div>
+          </label>
+        );
+      })}
+    </div>
+  );
+}
+
+// ── TimePicker (HH:MM select pair) ───────────────────────────────
+const HOURS = Array.from({ length: 24 }, (_, h) => `${String(h).padStart(2, '0')}:00`);
+
+function TimePicker({ label, value, onChange, entity = 'kb' }) {
+  return (
+    <div style={{ flex: 1, minWidth: 0 }}>
+      <Lbl>{label}</Lbl>
+      <div style={{ position: 'relative' }}>
+        <select value={value} onChange={e => onChange(e.target.value)}
+          aria-label={label}
+          style={{
+            display: 'block', width: '100%', height: 38, padding: '0 32px 0 12px',
+            boxSizing: 'border-box', borderRadius: 'var(--r-md)',
+            border: '1px solid var(--border)', background: 'var(--bg)',
+            color: 'var(--text)', fontSize: 13, fontFamily: 'var(--f-mono)',
+            outline: 'none', cursor: 'pointer', appearance: 'none',
+          }}>
+          {HOURS.map(h => <option key={h} value={h}>{h}</option>)}
+        </select>
+        <span style={{
+          position: 'absolute', right: 11, top: '50%', transform: 'translateY(-50%)',
+          color: entityHsl(entity), fontSize: 13, pointerEvents: 'none',
+        }}>🕐</span>
+      </div>
+    </div>
+  );
+}
+
+// ── PhoneTopBar ──────────────────────────────────────────────────
+function PhoneTopBar({ title, onBack, onSave, saving }) {
+  return (
+    <div style={{
+      display: 'flex', alignItems: 'center', gap: 10,
+      padding: '10px 14px 8px',
+      borderBottom: '1px solid var(--border)',
+      background: 'var(--bg)', flexShrink: 0,
+    }}>
+      <button onClick={onBack} aria-label="Indietro" style={{
+        width: 32, height: 32, borderRadius: '50%',
+        background: 'var(--bg-muted)', border: 'none', cursor: 'pointer',
+        display: 'flex', alignItems: 'center', justifyContent: 'center',
+        color: 'var(--text-sec)', fontSize: 16,
+      }}>←</button>
+      <span style={{
+        fontFamily: 'var(--f-display)', fontWeight: 800,
+        fontSize: 16, flex: 1, letterSpacing: '-.01em',
+      }}>{title}</span>
+      <button onClick={onSave} style={{
+        padding: '6px 13px', borderRadius: 'var(--r-pill)',
+        background: saving ? entityHsl('toolkit') : entityHsl('event'),
+        color: '#fff', border: 'none', cursor: 'pointer',
+        fontSize: 11.5, fontWeight: 800, fontFamily: 'var(--f-display)',
+        transition: 'background var(--dur-sm) var(--ease-out)',
+      }}>{saving ? '✓ Salvato' : 'Salva'}</button>
+    </div>
+  );
+}
+
+// ── SeverityMatrix (severity rows × channel columns) ─────────────
+const SEVERITY_ROWS = [
+  { key: 'critica',    label: 'Critica',    desc: 'Inviti, cancellazioni, errori' },
+  { key: 'importante', label: 'Importante', desc: 'RSVP, training completato' },
+  { key: 'info',       label: 'Info',       desc: 'Digest, riepiloghi, novità' },
+];
+const SEVERITY_CHANNELS = [
+  { key: 'inapp', icon: '🔔', label: 'In-app' },
+  { key: 'email', icon: '✉️', label: 'Email' },
+  { key: 'push',  icon: '📱', label: 'Push' },
+];
+
+function SeverityMatrix({ matrix, onToggle, pushDisabled }) {
+  return (
+    <div>
+      {/* Column header */}
+      <div style={{
+        display: 'flex', alignItems: 'center', gap: 8,
+        padding: '4px 0 8px',
+      }}>
+        <div style={{ flex: 1 }} />
+        {SEVERITY_CHANNELS.map(c => (
+          <div key={c.key} style={{
+            width: 48, textAlign: 'center',
+            fontSize: 9.5, fontWeight: 700, fontFamily: 'var(--f-mono)',
+            color: 'var(--text-muted)', textTransform: 'uppercase', letterSpacing: '.04em',
+          }}>
+            <div style={{ fontSize: 14, marginBottom: 2 }}>{c.icon}</div>
+            {c.label}
+          </div>
+        ))}
+      </div>
+      {SEVERITY_ROWS.map(row => {
+        const ent = SEVERITY_ENTITY[row.key];
+        return (
+          <div key={row.key} style={{
+            display: 'flex', alignItems: 'center', gap: 8,
+            padding: '10px 0', borderTop: '1px solid var(--border-light)',
+          }}>
+            <div style={{
+              flex: 1, minWidth: 0, display: 'flex', alignItems: 'flex-start', gap: 8,
+              borderLeft: `3px solid ${entityHsl(ent)}`, paddingLeft: 9,
+            }}>
+              <div>
+                <div style={{
+                  fontSize: 12.5, fontWeight: 700, fontFamily: 'var(--f-display)',
+                  color: entityHsl(ent),
+                }}>{row.label}</div>
+                <div style={{ fontSize: 10, color: 'var(--text-muted)', marginTop: 1, lineHeight: 1.35 }}>
+                  {row.desc}
+                </div>
+              </div>
+            </div>
+            {SEVERITY_CHANNELS.map(c => {
+              const isPush = c.key === 'push';
+              const disabled = isPush && pushDisabled;
+              return (
+                <div key={c.key} style={{ width: 48, display: 'flex', justifyContent: 'center', opacity: disabled ? 0.35 : 1 }}>
+                  <ToggleSwitch
+                    size="sm"
+                    entity={ent}
+                    checked={!disabled && matrix[row.key][c.key]}
+                    onChange={() => !disabled && onToggle(row.key, c.key)}
+                    label={`${row.label} ${c.label}`}
+                  />
+                </div>
+              );
+            })}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// ── QuietHoursCard ───────────────────────────────────────────────
+function QuietHoursCard({ enabled, from, to, onToggle, onFromChange, onToChange }) {
+  return (
+    <PrefSection
+      icon="⏰" entity="kb"
+      title="Quiet hours"
+      subtitle="Silenzia le notifiche in una fascia oraria"
+    >
+      <div style={{
+        display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+        gap: 12, padding: '4px 0 2px',
+      }}>
+        <div style={{ fontSize: 12.5, color: 'var(--text-sec)', fontFamily: 'var(--f-display)', fontWeight: 600 }}>
+          {enabled ? `Attivo · ${from} → ${to}` : 'Disattivato'}
+        </div>
+        <ToggleSwitch checked={enabled} onChange={onToggle} entity="kb" label="Quiet hours" />
+      </div>
+      {enabled && (
+        <div style={{ display: 'flex', gap: 12, marginTop: 12, alignItems: 'flex-end' }}>
+          <TimePicker label="Da" value={from} onChange={onFromChange} entity="kb" />
+          <div style={{ paddingBottom: 9, color: 'var(--text-muted)', fontSize: 16 }}>→</div>
+          <TimePicker label="A" value={to} onChange={onToChange} entity="kb" />
+        </div>
+      )}
+    </PrefSection>
+  );
+}
+
+// ── DeviceList (registered push devices) ─────────────────────────
+function DeviceList({ devices }) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+      {devices.map(d => (
+        <div key={d.id} style={{
+          display: 'flex', alignItems: 'center', gap: 11,
+          padding: '10px 12px', borderRadius: 'var(--r-md)',
+          background: 'var(--bg-muted)', border: '1px solid var(--border-light)',
+        }}>
+          <span style={{ fontSize: 18, flexShrink: 0 }}>{d.icon}</span>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div style={{
+              fontSize: 12.5, fontWeight: 700, fontFamily: 'var(--f-display)', color: 'var(--text)',
+            }}>{d.name}</div>
+            <div style={{ fontSize: 10, color: 'var(--text-muted)', fontFamily: 'var(--f-mono)' }}>
+              {d.lastSeen}
+            </div>
+          </div>
+          {d.current && (
+            <span style={{
+              padding: '2px 8px', borderRadius: 'var(--r-pill)', whiteSpace: 'nowrap',
+              background: entityHsl('toolkit', 0.14), color: entityHsl('toolkit'),
+              fontSize: 9.5, fontWeight: 800, fontFamily: 'var(--f-display)',
+            }}>● Questo device</span>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ── EmptyDevice (no mobile registered) ───────────────────────────
+function EmptyDevice() {
+  return (
+    <div style={{
+      display: 'flex', flexDirection: 'column', alignItems: 'center',
+      textAlign: 'center', padding: '18px 16px 6px', gap: 10,
+    }}>
+      <div style={{
+        width: 60, height: 60, borderRadius: '50%',
+        background: entityHsl('session', 0.1), color: entityHsl('session'),
+        display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 28,
+      }}>📭</div>
+      <div style={{
+        fontSize: 13.5, fontWeight: 700, fontFamily: 'var(--f-display)', color: 'var(--text)',
+      }}>Nessun device mobile registrato</div>
+      <div style={{ fontSize: 11.5, color: 'var(--text-muted)', lineHeight: 1.5, maxWidth: 240 }}>
+        Installa l'app MeepleAI sul telefono per ricevere le notifiche push.
+      </div>
+      <button style={{
+        marginTop: 4, padding: '9px 18px',
+        background: entityHsl('session'), color: '#fff',
+        border: 'none', borderRadius: 'var(--r-lg)', cursor: 'pointer',
+        fontSize: 12, fontWeight: 700, fontFamily: 'var(--f-display)',
+        display: 'inline-flex', alignItems: 'center', gap: 7,
+      }} onClick={() => { setTimeout(() => { window.location.href = 'notifications.html'; }, 0); /* DEMO-NAV */ }}>
+        <span>⬇️</span> Installa app
+      </button>
+    </div>
+  );
+}
+
+// ── SaveToast ────────────────────────────────────────────────────
+function SaveToast({ message }) {
+  return (
+    <div role="status" aria-live="polite" style={{
+      position: 'absolute', bottom: 24, left: '50%',
+      transform: 'translateX(-50%)',
+      display: 'flex', alignItems: 'center', gap: 9,
+      padding: '11px 18px', borderRadius: 'var(--r-pill)',
+      background: entityHsl('toolkit'), color: '#fff',
+      boxShadow: 'var(--shadow-lg)', zIndex: 20, whiteSpace: 'nowrap',
+      fontSize: 13, fontWeight: 700, fontFamily: 'var(--f-display)',
+      animation: 'prefToastIn var(--dur-md) var(--ease-out)',
+    }}>
+      <span style={{
+        width: 20, height: 20, borderRadius: '50%',
+        background: 'rgba(255,255,255,0.24)',
+        display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: 12,
+      }}>✓</span>
+      {message}
+    </div>
+  );
+}
+
+// ── ChannelsSection (in-app, email + freq, push) ─────────────────
+function ChannelsSection({ channels, onToggle, freq, onFreqChange, pushVariant, devices, freqName }) {
+  return (
+    <PrefSection
+      icon="🎚️" entity="agent"
+      title="Canali"
+      subtitle="Dove vuoi ricevere le notifiche"
+    >
+      {/* In-app */}
+      <ChannelToggleRow
+        icon="🔔" label="In-app" hint="Centro notifiche dentro MeepleAI"
+        entity="event"
+        checked={channels.inapp} onChange={() => onToggle('inapp')}
+      />
+      {/* Email + frequency */}
+      <ChannelToggleRow
+        icon="✉️" label="Email" hint="marco@example.com"
+        entity="agent"
+        checked={channels.email} onChange={() => onToggle('email')}
+      >
+        <FrequencyRadio value={freq} onChange={onFreqChange} entity="agent" name={freqName} />
+      </ChannelToggleRow>
+      {/* Mobile push — toggle OR empty-state */}
+      {pushVariant === 'empty' ? (
+        <div style={{ paddingTop: 12, borderTop: '1px solid var(--border-light)', marginTop: 2 }}>
+          <EmptyDevice />
+        </div>
+      ) : (
+        <ChannelToggleRow
+          icon="📱" label="Push mobile" hint="Notifiche sul telefono"
+          entity="session"
+          checked={channels.push} onChange={() => onToggle('push')}
+        >
+          {devices && devices.length > 0 && <DeviceList devices={devices} />}
+        </ChannelToggleRow>
+      )}
+    </PrefSection>
+  );
+}
+
+// ── PrefScreen (shared shell + scroll body) ──────────────────────
+function PrefScreen({ children, onSave, saving, toast }) {
+  return (
+    <div style={{ flex: 1, display: 'flex', flexDirection: 'column', overflow: 'hidden', position: 'relative' }}>
+      <PhoneTopBar
+        title="Preferenze notifiche"
+        onBack={() => { setTimeout(() => { window.location.href = 'notifications.html'; }, 0); /* DEMO-NAV */ }}
+        onSave={onSave}
+        saving={saving}
+      />
+      <div style={{ flex: 1, overflowY: 'auto', padding: '14px 0 28px' }}>
+        {children}
+      </div>
+      {toast && <SaveToast message={toast} />}
+    </div>
+  );
+}
+
+// ── Default datasets ─────────────────────────────────────────────
+const ALL_ON_MATRIX = {
+  critica:    { inapp: true, email: true, push: true },
+  importante: { inapp: true, email: true, push: true },
+  info:       { inapp: true, email: true, push: true },
+};
+const CRITICAL_ONLY_MATRIX = {
+  critica:    { inapp: true,  email: true,  push: true  },
+  importante: { inapp: true,  email: true,  push: false },
+  info:       { inapp: true,  email: false, push: false },
+};
+const DEVICES = [
+  { id: 1, icon: '📱', name: 'iPhone 15 di Marco', lastSeen: 'Attivo ora', current: true },
+  { id: 2, icon: '💻', name: 'MacBook Pro · Chrome', lastSeen: 'Visto 2h fa', current: false },
+];
+
+// ══════════════════════════════════════════════════════════════════
+// ── SCREEN 1 — Default · all toggles ON ───────────────────────────
+// ══════════════════════════════════════════════════════════════════
+function Screen1DefaultAllOn() {
+  const [channels, setChannels] = useState({ inapp: true, email: true, push: true });
+  const [matrix, setMatrix] = useState(ALL_ON_MATRIX);
+  const [freq, setFreq] = useState('realtime');
+  const [quiet, setQuiet] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  const toggleChannel = k => setChannels(c => ({ ...c, [k]: !c[k] }));
+  const toggleMatrix = (r, c) => setMatrix(m => ({ ...m, [r]: { ...m[r], [c]: !m[r][c] } }));
+  const save = useCallback(() => { setSaving(true); setTimeout(() => setSaving(false), 2000); }, []);
+
+  return (
+    <PrefScreen onSave={save} saving={saving}>
+      <ChannelsSection
+        channels={channels} onToggle={toggleChannel}
+        freq={freq} onFreqChange={setFreq} freqName="freq-s1"
+        pushVariant="toggle" devices={DEVICES}
+      />
+      <PrefSection icon="🗂️" entity="event" title="Per severità"
+        subtitle="Scegli i canali per ogni livello">
+        <SeverityMatrix matrix={matrix} onToggle={toggleMatrix} />
+      </PrefSection>
+      <QuietHoursCard
+        enabled={quiet} from="22:00" to="08:00"
+        onToggle={setQuiet} onFromChange={() => {}} onToChange={() => {}}
+      />
+    </PrefScreen>
+  );
+}
+
+// ══════════════════════════════════════════════════════════════════
+// ── SCREEN 2 — Customized · real-time only critical ───────────────
+// ══════════════════════════════════════════════════════════════════
+function Screen2Customized() {
+  const [channels, setChannels] = useState({ inapp: true, email: true, push: true });
+  const [matrix, setMatrix] = useState(CRITICAL_ONLY_MATRIX);
+  const [freq, setFreq] = useState('daily');
+  const [quiet, setQuiet] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  const toggleChannel = k => setChannels(c => ({ ...c, [k]: !c[k] }));
+  const toggleMatrix = (r, c) => setMatrix(m => ({ ...m, [r]: { ...m[r], [c]: !m[r][c] } }));
+  const save = useCallback(() => { setSaving(true); setTimeout(() => setSaving(false), 2000); }, []);
+
+  return (
+    <PrefScreen onSave={save} saving={saving}>
+      <ChannelsSection
+        channels={channels} onToggle={toggleChannel}
+        freq={freq} onFreqChange={setFreq} freqName="freq-s2"
+        pushVariant="toggle" devices={DEVICES}
+      />
+      <PrefSection icon="🗂️" entity="event" title="Per severità"
+        subtitle="Real-time solo per le critiche · digest per il resto">
+        <SeverityMatrix matrix={matrix} onToggle={toggleMatrix} />
+      </PrefSection>
+      <QuietHoursCard
+        enabled={quiet} from="22:00" to="08:00"
+        onToggle={setQuiet} onFromChange={() => {}} onToChange={() => {}}
+      />
+    </PrefScreen>
+  );
+}
+
+// ══════════════════════════════════════════════════════════════════
+// ── SCREEN 3 — Quiet hours 22:00 → 08:00 configured ───────────────
+// ══════════════════════════════════════════════════════════════════
+function Screen3QuietHours() {
+  const [channels, setChannels] = useState({ inapp: true, email: true, push: true });
+  const [matrix, setMatrix] = useState(ALL_ON_MATRIX);
+  const [freq, setFreq] = useState('realtime');
+  const [quiet, setQuiet] = useState(true);
+  const [from, setFrom] = useState('22:00');
+  const [to, setTo] = useState('08:00');
+  const [saving, setSaving] = useState(false);
+
+  const toggleChannel = k => setChannels(c => ({ ...c, [k]: !c[k] }));
+  const toggleMatrix = (r, c) => setMatrix(m => ({ ...m, [r]: { ...m[r], [c]: !m[r][c] } }));
+  const save = useCallback(() => { setSaving(true); setTimeout(() => setSaving(false), 2000); }, []);
+
+  return (
+    <PrefScreen onSave={save} saving={saving}>
+      <QuietHoursCard
+        enabled={quiet} from={from} to={to}
+        onToggle={setQuiet} onFromChange={setFrom} onToChange={setTo}
+      />
+      <ChannelsSection
+        channels={channels} onToggle={toggleChannel}
+        freq={freq} onFreqChange={setFreq} freqName="freq-s3"
+        pushVariant="toggle" devices={DEVICES}
+      />
+      <PrefSection icon="🗂️" entity="event" title="Per severità"
+        subtitle="Le critiche superano sempre il silenzio">
+        <SeverityMatrix matrix={matrix} onToggle={toggleMatrix} />
+      </PrefSection>
+    </PrefScreen>
+  );
+}
+
+// ══════════════════════════════════════════════════════════════════
+// ── SCREEN 4 — No mobile device registered ────────────────────────
+// ══════════════════════════════════════════════════════════════════
+function Screen4NoDevice() {
+  const [channels, setChannels] = useState({ inapp: true, email: true, push: false });
+  const [matrix, setMatrix] = useState(ALL_ON_MATRIX);
+  const [freq, setFreq] = useState('realtime');
+  const [quiet, setQuiet] = useState(false);
+  const [saving, setSaving] = useState(false);
+
+  const toggleChannel = k => setChannels(c => ({ ...c, [k]: !c[k] }));
+  // push column disabled in matrix because no device is registered
+  const toggleMatrix = (r, c) => setMatrix(m => ({ ...m, [r]: { ...m[r], [c]: !m[r][c] } }));
+  const save = useCallback(() => { setSaving(true); setTimeout(() => setSaving(false), 2000); }, []);
+
+  return (
+    <PrefScreen onSave={save} saving={saving}>
+      <ChannelsSection
+        channels={channels} onToggle={toggleChannel}
+        freq={freq} onFreqChange={setFreq} freqName="freq-s4"
+        pushVariant="empty"
+      />
+      <PrefSection icon="🗂️" entity="event" title="Per severità"
+        subtitle="Push disabilitato finché non registri un device">
+        <SeverityMatrix matrix={matrix} onToggle={toggleMatrix} pushDisabled />
+      </PrefSection>
+      <QuietHoursCard
+        enabled={quiet} from="22:00" to="08:00"
+        onToggle={setQuiet} onFromChange={() => {}} onToChange={() => {}}
+      />
+    </PrefScreen>
+  );
+}
+
+// ══════════════════════════════════════════════════════════════════
+// ── SCREEN 5 — Save success toast ─────────────────────────────────
+// ══════════════════════════════════════════════════════════════════
+function Screen5SaveToast() {
+  const [channels, setChannels] = useState({ inapp: true, email: true, push: true });
+  const [matrix, setMatrix] = useState(CRITICAL_ONLY_MATRIX);
+  const [freq, setFreq] = useState('realtime');
+  const [quiet, setQuiet] = useState(true);
+
+  const toggleChannel = k => setChannels(c => ({ ...c, [k]: !c[k] }));
+  const toggleMatrix = (r, c) => setMatrix(m => ({ ...m, [r]: { ...m[r], [c]: !m[r][c] } }));
+
+  return (
+    <PrefScreen onSave={() => {}} saving toast="Preferenze aggiornate">
+      <ChannelsSection
+        channels={channels} onToggle={toggleChannel}
+        freq={freq} onFreqChange={setFreq} freqName="freq-s5"
+        pushVariant="toggle" devices={DEVICES}
+      />
+      <PrefSection icon="🗂️" entity="event" title="Per severità"
+        subtitle="Configurazione salvata">
+        <SeverityMatrix matrix={matrix} onToggle={toggleMatrix} />
+      </PrefSection>
+      <QuietHoursCard
+        enabled={quiet} from="22:00" to="08:00"
+        onToggle={() => {}} onFromChange={() => {}} onToChange={() => {}}
+      />
+    </PrefScreen>
+  );
+}
+
+// ── Export to window ─────────────────────────────────────────────
+Object.assign(window, {
+  Screen1DefaultAllOn, Screen2Customized, Screen3QuietHours,
+  Screen4NoDevice, Screen5SaveToast,
+});

--- a/docs/for-developers/frontend/v2-migration-matrix.md
+++ b/docs/for-developers/frontend/v2-migration-matrix.md
@@ -703,7 +703,7 @@ instead.
 | `/discover` | `sp4-discover.html` | Tier L, pending |
 | `/profile` · `/profile/achievements` | `sp4-player-detail.html` ↻ + `sp5-profile-settings.html` [partial] | `/profile?tab=settings` coperto da sp5; self-view + achievements via sp4-player-detail reuse |
 | `/settings` (+ `/ai-consent`, `/api-keys`, `/notifications`, `/preferences`, `/profile`, `/security`, `/services`) | `settings.html` | Shell unica per 7 sub-route |
-| `/notifications` · `/notifications/preferences` | `notifications.html` | — |
+| `/notifications` · `/notifications/preferences` | `sp7-notifications-hub.html` · `sp7-notifications-preferences.html` | SP7 v2 (#2028); `notifications.html` SP1 legacy archive |
 | `/versions` | — | gap (changelog) |
 
 ### Authenticated — Library


### PR DESCRIPTION
## Summary
2 new design-system mockups for SP7 Wave 3 notifications v2 (brief `SP7-game-night-agent-builder.md` §I/§J), replacing the SP1 `notifications.html`.

- **sp7-notifications-hub** (`/notifications`) — 8 states: empty, mixed-15 (5 unread, grouped Oggi/Ieri/Settimana), unread filter, bulk mark-read confirm, action drawer (long-press, 4 actions), snooze toast, error-network, mobile stack. Severity entity-driven (critica=event · importante=agent · info=toolkit).
- **sp7-notifications-preferences** (`/notifications/preferences`) — 5 states: default all-on, customized (real-time critical only), quiet hours 22-08, no mobile device (CTA install), save toast. 3 channel sections + per-severity matrix.

## Integration
- 2 hub cards (`e-event`) in `00-hub.html`
- `MOCKUPS_INDEX.md` + `v2-migration-matrix.md`: route `/notifications` · `/notifications/preferences` remapped to sp7-* (notifications.html kept as SP1 legacy archive)

## Verification (new files)
- `lint:tokens:mockups` exit 0 · `lint:bgg-mockups` exit 0 · `lint:fidelity` PASS for both sp7-notifications-*
- FREEZE grep (`hsl([0-9]`) clean · no BGG refs · entityHsl helper only
- HTML↔JSX wiring validated; hub JSX transpiles via esbuild

Built via 2 parallel subagents (P244 scaffold) + orchestrator integration + fidelity canonicalization. Pre-existing baseline FAIL `sp6-libro-game-house-rule.fidelity.json` (from #2491) is unrelated.

Closes #2028

🤖 Generated with [Claude Code](https://claude.com/claude-code)