### PR TITLE
feat(agent-memory): #2492 BE endpoint + FE hook for SP6 §F drawer ConnectionBar

### DIFF
--- a/apps/api/src/Api/BoundedContexts/AgentMemory/Application/DTOs/HouseRulesMetadataDto.cs
+++ b/apps/api/src/Api/BoundedContexts/AgentMemory/Application/DTOs/HouseRulesMetadataDto.cs
@@ -1,0 +1,12 @@
+namespace Api.BoundedContexts.AgentMemory.Application.DTOs;
+
+/// <summary>
+/// DTO representing aggregated counts for the SP6 §F drawer ConnectionBar.
+/// Wires the 4 pip counts (agent · game · session · kb) from the house-rule context.
+/// See issue #2492 for semantic counts definition.
+/// </summary>
+internal record HouseRulesMetadataDto(
+    int AgentCount,
+    int GameCount,
+    int SessionCount,
+    int KbCount);

--- a/apps/api/src/Api/BoundedContexts/AgentMemory/Application/Queries/GetHouseRulesMetadataQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/AgentMemory/Application/Queries/GetHouseRulesMetadataQuery.cs
@@ -1,0 +1,11 @@
+using Api.BoundedContexts.AgentMemory.Application.DTOs;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.AgentMemory.Application.Queries;
+
+/// <summary>
+/// Query to retrieve house-rules metadata counts for the SP6 §F drawer ConnectionBar.
+/// Returns 4 counts (agent · game · session · kb) for the given game and owner pair.
+/// </summary>
+internal record GetHouseRulesMetadataQuery(Guid GameId, Guid OwnerId)
+    : IQuery<HouseRulesMetadataDto>;

--- a/apps/api/src/Api/BoundedContexts/AgentMemory/Application/Queries/GetHouseRulesMetadataQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/AgentMemory/Application/Queries/GetHouseRulesMetadataQueryHandler.cs
@@ -1,0 +1,56 @@
+using Api.BoundedContexts.AgentMemory.Application.DTOs;
+using Api.BoundedContexts.AgentMemory.Application.Services;
+using Api.BoundedContexts.AgentMemory.Domain.Repositories;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.AgentMemory.Application.Queries;
+
+/// <summary>
+/// Handles <see cref="GetHouseRulesMetadataQuery"/> by aggregating the 4 ConnectionBar pip
+/// counts (agent · game · session · kb) for the SP6 §F drawer (issue #2492).
+///
+/// Semantic counts:
+/// - <c>AgentCount</c>: number of house rules persisted for the (gameId, ownerId) pair
+/// - <c>GameCount</c>: always 1 in current scope; future-proof for multi-game rules
+/// - <c>SessionCount</c>: 0 today; requires a future <c>session_house_rule_applications</c>
+///   tracking table (out of scope here)
+/// - <c>KbCount</c>: number of indexed VectorDocuments associated with the game,
+///   read cross-BC via <see cref="IKbChunkCountReader"/>
+/// </summary>
+internal sealed class GetHouseRulesMetadataQueryHandler
+    : IQueryHandler<GetHouseRulesMetadataQuery, HouseRulesMetadataDto>
+{
+    private readonly IGameMemoryRepository _gameMemoryRepo;
+    private readonly IKbChunkCountReader _kbChunkCountReader;
+
+    public GetHouseRulesMetadataQueryHandler(
+        IGameMemoryRepository gameMemoryRepo,
+        IKbChunkCountReader kbChunkCountReader)
+    {
+        _gameMemoryRepo = gameMemoryRepo ?? throw new ArgumentNullException(nameof(gameMemoryRepo));
+        _kbChunkCountReader = kbChunkCountReader ?? throw new ArgumentNullException(nameof(kbChunkCountReader));
+    }
+
+    public async Task<HouseRulesMetadataDto> Handle(
+        GetHouseRulesMetadataQuery query,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var memory = await _gameMemoryRepo
+            .GetByGameAndOwnerAsync(query.GameId, query.OwnerId, cancellationToken)
+            .ConfigureAwait(false);
+
+        var kbCount = await _kbChunkCountReader
+            .CountByGameAsync(query.GameId, cancellationToken)
+            .ConfigureAwait(false);
+
+        var agentCount = memory?.HouseRules.Count ?? 0;
+
+        return new HouseRulesMetadataDto(
+            AgentCount: agentCount,
+            GameCount: 1,
+            SessionCount: 0,
+            KbCount: kbCount);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/AgentMemory/Application/Services/IKbChunkCountReader.cs
+++ b/apps/api/src/Api/BoundedContexts/AgentMemory/Application/Services/IKbChunkCountReader.cs
@@ -1,0 +1,17 @@
+namespace Api.BoundedContexts.AgentMemory.Application.Services;
+
+/// <summary>
+/// Cross-BC read-only service for counting indexed KB chunks per game.
+/// Defined here (AgentMemory.Application) so the BC owns the consumer contract;
+/// the implementation lives in Infrastructure and queries the shared DbContext
+/// (KnowledgeBase BC owns the VectorDocuments table).
+/// </summary>
+internal interface IKbChunkCountReader
+{
+    /// <summary>
+    /// Returns the number of indexed VectorDocuments associated with the given game.
+    /// Used by <c>GetHouseRulesMetadataQueryHandler</c> to populate the
+    /// <c>kbCount</c> pip in the SP6 §F drawer ConnectionBar.
+    /// </summary>
+    Task<int> CountByGameAsync(Guid gameId, CancellationToken ct = default);
+}

--- a/apps/api/src/Api/BoundedContexts/AgentMemory/Infrastructure/DependencyInjection/AgentMemoryServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/AgentMemory/Infrastructure/DependencyInjection/AgentMemoryServiceExtensions.cs
@@ -1,5 +1,7 @@
+using Api.BoundedContexts.AgentMemory.Application.Services;
 using Api.BoundedContexts.AgentMemory.Domain.Repositories;
 using Api.BoundedContexts.AgentMemory.Infrastructure.Persistence;
+using Api.BoundedContexts.AgentMemory.Infrastructure.Services;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Api.BoundedContexts.AgentMemory.Infrastructure.DependencyInjection;
@@ -18,6 +20,9 @@ internal static class AgentMemoryServiceExtensions
         services.AddScoped<IGameMemoryRepository, GameMemoryRepository>();
         services.AddScoped<IGroupMemoryRepository, GroupMemoryRepository>();
         services.AddScoped<IPlayerMemoryRepository, PlayerMemoryRepository>();
+
+        // Cross-BC read services (issue #2492 — SP6 §F drawer metadata)
+        services.AddScoped<IKbChunkCountReader, KbChunkCountReader>();
 
         return services;
     }

--- a/apps/api/src/Api/BoundedContexts/AgentMemory/Infrastructure/Services/KbChunkCountReader.cs
+++ b/apps/api/src/Api/BoundedContexts/AgentMemory/Infrastructure/Services/KbChunkCountReader.cs
@@ -1,0 +1,35 @@
+using Api.BoundedContexts.AgentMemory.Application.Services;
+using Api.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.AgentMemory.Infrastructure.Services;
+
+/// <summary>
+/// Reads the count of indexed VectorDocuments for a game from the shared DbContext.
+/// VectorDocuments are owned by the KnowledgeBase BC; this reader exposes a narrow
+/// cross-BC contract so the AgentMemory ConnectionBar metadata aggregation (#2492)
+/// does not depend on KnowledgeBase domain logic.
+/// </summary>
+internal sealed class KbChunkCountReader : IKbChunkCountReader
+{
+    private readonly MeepleAiDbContext _db;
+
+    public KbChunkCountReader(MeepleAiDbContext db)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+    }
+
+    public Task<int> CountByGameAsync(Guid gameId, CancellationToken ct = default)
+    {
+        if (gameId == Guid.Empty) return Task.FromResult(0);
+
+        // VectorDocumentEntity carries both a legacy GameId and the canonical
+        // SharedGameId (cross-BC ref to SharedGameCatalog). Match on either to
+        // include all "official rules" chunks for the game regardless of origin.
+        return _db.VectorDocuments
+            .AsNoTracking()
+            .CountAsync(
+                v => v.SharedGameId == gameId || v.GameId == gameId,
+                ct);
+    }
+}

--- a/apps/api/src/Api/Routing/AgentMemoryEndpoints.cs
+++ b/apps/api/src/Api/Routing/AgentMemoryEndpoints.cs
@@ -96,6 +96,15 @@ internal static class AgentMemoryEndpoints
             .Produces(401)
             .WithSummary("Get all glossary entries for a game");
 
+        // === House-rule Metadata (issue #2492 — SP6 §F drawer ConnectionBar) ===
+
+        agentMemory.MapGet("/house-rules/metadata", HandleGetHouseRulesMetadata)
+            .RequireAuthenticatedUser()
+            .Produces<HouseRulesMetadataDto>(200)
+            .Produces(400)
+            .Produces(401)
+            .WithSummary("Get aggregated house-rule metadata counts (agent/game/session/kb) for SP6 §F drawer");
+
         // === Player Stats ===
 
         agentMemory.MapGet("/players/me/stats", HandleGetMyStats)
@@ -252,6 +261,22 @@ internal static class AgentMemoryEndpoints
     {
         var userId = httpContext.User.GetUserId();
         var result = await mediator.Send(new GetGlossaryQuery(gameId, userId), cancellationToken).ConfigureAwait(false);
+        return Results.Ok(result);
+    }
+
+    private static async Task<IResult> HandleGetHouseRulesMetadata(
+        [FromQuery] Guid gameId,
+        [FromServices] IMediator mediator,
+        HttpContext httpContext,
+        CancellationToken cancellationToken)
+    {
+        if (gameId == Guid.Empty)
+            return Results.BadRequest(new { error = "gameId is required" });
+
+        var userId = httpContext.User.GetUserId();
+        var result = await mediator
+            .Send(new GetHouseRulesMetadataQuery(gameId, userId), cancellationToken)
+            .ConfigureAwait(false);
         return Results.Ok(result);
     }
 

--- a/apps/api/src/Api/Routing/AgentMemoryEndpoints.cs
+++ b/apps/api/src/Api/Routing/AgentMemoryEndpoints.cs
@@ -98,6 +98,9 @@ internal static class AgentMemoryEndpoints
 
         // === House-rule Metadata (issue #2492 — SP6 §F drawer ConnectionBar) ===
 
+        // Note: no Produces(404). When the (gameId, userId) pair has no GameMemory
+        // record the endpoint returns 200 with agentCount=0 and the cross-BC kb
+        // count — a missing record is a valid "zero" state, not an error.
         agentMemory.MapGet("/house-rules/metadata", HandleGetHouseRulesMetadata)
             .RequireAuthenticatedUser()
             .Produces<HouseRulesMetadataDto>(200)

--- a/apps/api/tests/Api.Tests/BoundedContexts/AgentMemory/Application/Handlers/GetHouseRulesMetadataQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/AgentMemory/Application/Handlers/GetHouseRulesMetadataQueryHandlerTests.cs
@@ -1,0 +1,186 @@
+using Api.BoundedContexts.AgentMemory.Application.Queries;
+using Api.BoundedContexts.AgentMemory.Application.Services;
+using Api.BoundedContexts.AgentMemory.Domain.Entities;
+using Api.BoundedContexts.AgentMemory.Domain.Enums;
+using Api.BoundedContexts.AgentMemory.Domain.Repositories;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.AgentMemory.Application.Handlers;
+
+/// <summary>
+/// Tests for GetHouseRulesMetadataQueryHandler covering the 4 ConnectionBar counts
+/// (agent · game · session · kb) per issue #2492.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "AgentMemory")]
+public class GetHouseRulesMetadataQueryHandlerTests
+{
+    private readonly Mock<IGameMemoryRepository> _gameMemoryRepoMock = new();
+    private readonly Mock<IKbChunkCountReader> _kbChunkCountReaderMock = new();
+    private readonly GetHouseRulesMetadataQueryHandler _handler;
+
+    public GetHouseRulesMetadataQueryHandlerTests()
+    {
+        _handler = new GetHouseRulesMetadataQueryHandler(
+            _gameMemoryRepoMock.Object,
+            _kbChunkCountReaderMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_MemoryNotFound_ReturnsZeroAgentCountWithKbAndGameCount()
+    {
+        // Arrange — user never opened the drawer before; no GameMemory exists yet.
+        var gameId = Guid.NewGuid();
+        var ownerId = Guid.NewGuid();
+
+        _gameMemoryRepoMock
+            .Setup(r => r.GetByGameAndOwnerAsync(gameId, ownerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((GameMemory?)null);
+
+        _kbChunkCountReaderMock
+            .Setup(r => r.CountByGameAsync(gameId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(7);
+
+        var query = new GetHouseRulesMetadataQuery(gameId, ownerId);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.AgentCount.Should().Be(0);
+        result.GameCount.Should().Be(1, "gameCount is always 1 in current scope per issue #2492");
+        result.SessionCount.Should().Be(0, "sessionCount placeholder — no session_house_rule_applications tracking yet");
+        result.KbCount.Should().Be(7);
+    }
+
+    [Fact]
+    public async Task Handle_MemoryWithNoHouseRules_ReturnsZeroAgentCount()
+    {
+        // Arrange
+        var gameId = Guid.NewGuid();
+        var ownerId = Guid.NewGuid();
+        var memory = GameMemory.Create(gameId, ownerId);
+        // Memory exists but no house rules added
+
+        _gameMemoryRepoMock
+            .Setup(r => r.GetByGameAndOwnerAsync(gameId, ownerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(memory);
+
+        _kbChunkCountReaderMock
+            .Setup(r => r.CountByGameAsync(gameId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(12);
+
+        var query = new GetHouseRulesMetadataQuery(gameId, ownerId);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.AgentCount.Should().Be(0);
+        result.GameCount.Should().Be(1);
+        result.SessionCount.Should().Be(0);
+        result.KbCount.Should().Be(12);
+    }
+
+    [Fact]
+    public async Task Handle_MemoryWithThreeHouseRules_ReturnsAgentCountThree()
+    {
+        // Arrange
+        var gameId = Guid.NewGuid();
+        var ownerId = Guid.NewGuid();
+        var memory = GameMemory.Create(gameId, ownerId);
+        memory.AddHouseRule("No phones at table", HouseRuleSource.UserAdded);
+        memory.AddHouseRule("Robber cannot rob on first turn", HouseRuleSource.UserAdded);
+        memory.AddHouseRule("Trade with bank only after first roll", HouseRuleSource.DisputeOverride);
+
+        _gameMemoryRepoMock
+            .Setup(r => r.GetByGameAndOwnerAsync(gameId, ownerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(memory);
+
+        _kbChunkCountReaderMock
+            .Setup(r => r.CountByGameAsync(gameId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(20);
+
+        var query = new GetHouseRulesMetadataQuery(gameId, ownerId);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.AgentCount.Should().Be(3);
+        result.GameCount.Should().Be(1);
+        result.SessionCount.Should().Be(0);
+        result.KbCount.Should().Be(20);
+    }
+
+    [Fact]
+    public async Task Handle_ZeroKbChunks_ReturnsKbCountZero()
+    {
+        // Arrange — early-onboarding scenario: PDFs not indexed yet
+        var gameId = Guid.NewGuid();
+        var ownerId = Guid.NewGuid();
+        var memory = GameMemory.Create(gameId, ownerId);
+        memory.AddHouseRule("Custom rule", HouseRuleSource.UserAdded);
+
+        _gameMemoryRepoMock
+            .Setup(r => r.GetByGameAndOwnerAsync(gameId, ownerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(memory);
+
+        _kbChunkCountReaderMock
+            .Setup(r => r.CountByGameAsync(gameId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(0);
+
+        var query = new GetHouseRulesMetadataQuery(gameId, ownerId);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.AgentCount.Should().Be(1);
+        result.GameCount.Should().Be(1);
+        result.SessionCount.Should().Be(0);
+        result.KbCount.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Handle_PassesGameAndOwnerCorrectly()
+    {
+        // Arrange — guard that the handler forwards the right ids to both deps
+        var gameId = Guid.NewGuid();
+        var ownerId = Guid.NewGuid();
+
+        _gameMemoryRepoMock
+            .Setup(r => r.GetByGameAndOwnerAsync(gameId, ownerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((GameMemory?)null);
+
+        _kbChunkCountReaderMock
+            .Setup(r => r.CountByGameAsync(gameId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(0);
+
+        var query = new GetHouseRulesMetadataQuery(gameId, ownerId);
+
+        // Act
+        await _handler.Handle(query, CancellationToken.None);
+
+        // Assert — verify both deps were called with the right gameId; ownerId only flows
+        // into the GameMemoryRepository (KB is per-game, not per-user)
+        _gameMemoryRepoMock.Verify(
+            r => r.GetByGameAndOwnerAsync(gameId, ownerId, It.IsAny<CancellationToken>()),
+            Times.Once);
+        _kbChunkCountReaderMock.Verify(
+            r => r.CountByGameAsync(gameId, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_NullQuery_ThrowsArgumentNullException()
+    {
+        // Act / Assert
+        await FluentActions.Invoking(() => _handler.Handle(null!, CancellationToken.None))
+            .Should()
+            .ThrowAsync<ArgumentNullException>();
+    }
+}

--- a/apps/web/src/hooks/queries/__tests__/useHouseRulesMetadata.test.tsx
+++ b/apps/web/src/hooks/queries/__tests__/useHouseRulesMetadata.test.tsx
@@ -72,6 +72,23 @@ describe('useHouseRulesMetadata — constants', () => {
       GAME_ID,
     ]);
   });
+
+  it('queryKey is unique per gameId value including null/undefined/empty', () => {
+    // Guard against cache collision when callers pass null/undefined — each
+    // case gets a distinct entry rather than colliding on a shared `all` key.
+    const nullKey = houseRulesMetadataKeys.byGame(null);
+    const undefKey = houseRulesMetadataKeys.byGame(undefined);
+    const emptyKey = houseRulesMetadataKeys.byGame('');
+    const idKey = houseRulesMetadataKeys.byGame(GAME_ID);
+
+    // null/undefined/'' all stringify to the same '' tail — that's fine because
+    // `enabled: false` means queryFn never runs for any of them. The valid id
+    // case stays distinct.
+    expect(nullKey).toEqual(['agent-memory', 'house-rules', 'metadata', '']);
+    expect(undefKey).toEqual(['agent-memory', 'house-rules', 'metadata', '']);
+    expect(emptyKey).toEqual(['agent-memory', 'house-rules', 'metadata', '']);
+    expect(idKey).not.toEqual(emptyKey);
+  });
 });
 
 describe('useHouseRulesMetadata — auto-enable gate', () => {

--- a/apps/web/src/hooks/queries/__tests__/useHouseRulesMetadata.test.tsx
+++ b/apps/web/src/hooks/queries/__tests__/useHouseRulesMetadata.test.tsx
@@ -1,0 +1,175 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * useHouseRulesMetadata unit tests — Issue #2492.
+ *
+ * Coverage:
+ *   - 5-minute staleTime constant
+ *   - Disabled when gameId is null / undefined / empty (no fetch)
+ *   - Manual `enabled: false` overrides auto-enable
+ *   - Calls `api.agentMemory.getHouseRulesMetadata(gameId)` with the right contract
+ *   - Surfaces success / error / null (401) states from the underlying client
+ */
+
+import { type ReactNode } from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import {
+  HOUSE_RULES_METADATA_STALE_TIME_MS,
+  houseRulesMetadataKeys,
+  useHouseRulesMetadata,
+} from '../useHouseRulesMetadata';
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    agentMemory: {
+      getHouseRulesMetadata: vi.fn(),
+    },
+  },
+}));
+
+import { api } from '@/lib/api';
+
+const mockGetHouseRulesMetadata = api.agentMemory.getHouseRulesMetadata as ReturnType<typeof vi.fn>;
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+const GAME_ID = '11111111-1111-1111-1111-111111111111';
+
+const SAMPLE_METADATA = {
+  agentCount: 2,
+  gameCount: 1,
+  sessionCount: 0,
+  kbCount: 12,
+};
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('useHouseRulesMetadata — constants', () => {
+  it('exports a 5-minute staleTime in milliseconds', () => {
+    expect(HOUSE_RULES_METADATA_STALE_TIME_MS).toBe(5 * 60 * 1000);
+  });
+
+  it('exposes a stable queryKey structure scoped by gameId', () => {
+    expect(houseRulesMetadataKeys.byGame(GAME_ID)).toEqual([
+      'agent-memory',
+      'house-rules',
+      'metadata',
+      GAME_ID,
+    ]);
+  });
+});
+
+describe('useHouseRulesMetadata — auto-enable gate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does NOT fire when gameId is null', () => {
+    renderHook(() => useHouseRulesMetadata({ gameId: null }), {
+      wrapper: createWrapper(),
+    });
+
+    expect(mockGetHouseRulesMetadata).not.toHaveBeenCalled();
+  });
+
+  it('does NOT fire when gameId is undefined', () => {
+    renderHook(() => useHouseRulesMetadata({ gameId: undefined }), {
+      wrapper: createWrapper(),
+    });
+
+    expect(mockGetHouseRulesMetadata).not.toHaveBeenCalled();
+  });
+
+  it('does NOT fire when gameId is empty string', () => {
+    renderHook(() => useHouseRulesMetadata({ gameId: '' }), {
+      wrapper: createWrapper(),
+    });
+
+    expect(mockGetHouseRulesMetadata).not.toHaveBeenCalled();
+  });
+
+  it('fires when gameId is a valid string', async () => {
+    mockGetHouseRulesMetadata.mockResolvedValue(SAMPLE_METADATA);
+
+    const { result } = renderHook(() => useHouseRulesMetadata({ gameId: GAME_ID }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockGetHouseRulesMetadata).toHaveBeenCalledTimes(1);
+    expect(mockGetHouseRulesMetadata).toHaveBeenCalledWith(GAME_ID);
+  });
+});
+
+describe('useHouseRulesMetadata — manual enabled override', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does NOT fire when enabled=false even with a valid gameId', () => {
+    renderHook(() => useHouseRulesMetadata({ gameId: GAME_ID, enabled: false }), {
+      wrapper: createWrapper(),
+    });
+
+    expect(mockGetHouseRulesMetadata).not.toHaveBeenCalled();
+  });
+});
+
+describe('useHouseRulesMetadata — query result', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns counts on success', async () => {
+    mockGetHouseRulesMetadata.mockResolvedValue(SAMPLE_METADATA);
+
+    const { result } = renderHook(() => useHouseRulesMetadata({ gameId: GAME_ID }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual(SAMPLE_METADATA);
+  });
+
+  it('returns null when the apiClient returns null (401)', async () => {
+    mockGetHouseRulesMetadata.mockResolvedValue(null);
+
+    const { result } = renderHook(() => useHouseRulesMetadata({ gameId: GAME_ID }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toBeNull();
+  });
+
+  it('exposes error state when the API rejects', async () => {
+    const apiError = new Error('Backend unavailable');
+    mockGetHouseRulesMetadata.mockRejectedValue(apiError);
+
+    const { result } = renderHook(() => useHouseRulesMetadata({ gameId: GAME_ID }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error?.message).toBe('Backend unavailable');
+  });
+});

--- a/apps/web/src/hooks/queries/useHouseRulesMetadata.ts
+++ b/apps/web/src/hooks/queries/useHouseRulesMetadata.ts
@@ -22,7 +22,8 @@ export const HOUSE_RULES_METADATA_STALE_TIME_MS = 5 * 60 * 1000; // 5 min.
 
 export const houseRulesMetadataKeys = {
   all: ['agent-memory', 'house-rules', 'metadata'] as const,
-  byGame: (gameId: string) => [...houseRulesMetadataKeys.all, gameId] as const,
+  byGame: (gameId: string | null | undefined) =>
+    [...houseRulesMetadataKeys.all, gameId ?? ''] as const,
 };
 
 export interface UseHouseRulesMetadataOptions {
@@ -41,7 +42,10 @@ export function useHouseRulesMetadata({ gameId, enabled = true }: UseHouseRulesM
   const isValid = typeof gameId === 'string' && gameId.length > 0;
 
   return useQuery<HouseRulesMetadataDto | null, Error>({
-    queryKey: isValid ? houseRulesMetadataKeys.byGame(gameId) : houseRulesMetadataKeys.all,
+    // Always include gameId in the key so each game has its own cache entry,
+    // even when invalid (the `enabled` guard prevents the fetch). Avoids
+    // collision under the shared `all` key when multiple mounts pass null.
+    queryKey: houseRulesMetadataKeys.byGame(gameId),
     queryFn: async () => {
       if (!isValid) {
         throw new Error('gameId is required');

--- a/apps/web/src/hooks/queries/useHouseRulesMetadata.ts
+++ b/apps/web/src/hooks/queries/useHouseRulesMetadata.ts
@@ -1,0 +1,54 @@
+/**
+ * useHouseRulesMetadata — TanStack Query useQuery hook for the SP6 §F drawer
+ * ConnectionBar 4-pip counts (agent · game · session · kb).
+ *
+ * Issue #2492. Wires the BE endpoint shipped alongside this hook:
+ *   GET /api/v1/agent-memory/house-rules/metadata?gameId={gameId}
+ *
+ * - 200 OK: HouseRulesMetadataDto (4 counts)
+ * - 401: apiClient returns null; the hook surfaces null in data
+ * - 400: caller forgot to pass a valid gameId — handled by `enabled` guard
+ *
+ * Cache: 5-minute staleTime per issue spec. ConnectionBar is fetch-once on
+ * drawer open per DEC-2 (no SSE).
+ */
+
+import { useQuery } from '@tanstack/react-query';
+
+import { api } from '@/lib/api';
+import type { HouseRulesMetadataDto } from '@/lib/api/clients/agentMemoryClient';
+
+export const HOUSE_RULES_METADATA_STALE_TIME_MS = 5 * 60 * 1000; // 5 min.
+
+export const houseRulesMetadataKeys = {
+  all: ['agent-memory', 'house-rules', 'metadata'] as const,
+  byGame: (gameId: string) => [...houseRulesMetadataKeys.all, gameId] as const,
+};
+
+export interface UseHouseRulesMetadataOptions {
+  readonly gameId: string | null | undefined;
+  readonly enabled?: boolean;
+}
+
+/**
+ * Fetch the 4 ConnectionBar counts for a game's house-rule context.
+ *
+ * @example
+ * const { data, isLoading } = useHouseRulesMetadata({ gameId });
+ * if (data) renderPips(data.agentCount, data.gameCount, data.sessionCount, data.kbCount);
+ */
+export function useHouseRulesMetadata({ gameId, enabled = true }: UseHouseRulesMetadataOptions) {
+  const isValid = typeof gameId === 'string' && gameId.length > 0;
+
+  return useQuery<HouseRulesMetadataDto | null, Error>({
+    queryKey: isValid ? houseRulesMetadataKeys.byGame(gameId) : houseRulesMetadataKeys.all,
+    queryFn: async () => {
+      if (!isValid) {
+        throw new Error('gameId is required');
+      }
+      return api.agentMemory.getHouseRulesMetadata(gameId);
+    },
+    enabled: enabled && isValid,
+    staleTime: HOUSE_RULES_METADATA_STALE_TIME_MS,
+  });
+}

--- a/apps/web/src/lib/api/clients/agentMemoryClient.ts
+++ b/apps/web/src/lib/api/clients/agentMemoryClient.ts
@@ -81,6 +81,17 @@ export const ClaimableGuestDtoSchema = z.object({
   groupName: z.string().nullable(),
 });
 
+/**
+ * Issue #2492: aggregated counts (agent · game · session · kb) for the SP6 §F
+ * drawer ConnectionBar. Backend returns all four counts in a single GET.
+ */
+export const HouseRulesMetadataDtoSchema = z.object({
+  agentCount: z.number().int().nonnegative(),
+  gameCount: z.number().int().nonnegative(),
+  sessionCount: z.number().int().nonnegative(),
+  kbCount: z.number().int().nonnegative(),
+});
+
 // --- Types ---
 
 export type HouseRuleDto = z.infer<typeof HouseRuleDtoSchema>;
@@ -93,6 +104,7 @@ export type GroupMemoryDto = z.infer<typeof GroupMemoryDtoSchema>;
 export type PlayerGameStatsDto = z.infer<typeof PlayerGameStatsDtoSchema>;
 export type PlayerMemoryDto = z.infer<typeof PlayerMemoryDtoSchema>;
 export type ClaimableGuestDto = z.infer<typeof ClaimableGuestDtoSchema>;
+export type HouseRulesMetadataDto = z.infer<typeof HouseRulesMetadataDtoSchema>;
 
 // --- Client ---
 
@@ -142,6 +154,17 @@ export function createAgentMemoryClient({ httpClient }: CreateAgentMemoryClientP
 
     async addNote(gameId: string, content: string): Promise<void> {
       await httpClient.post(`${BASE}/games/${gameId}/memory/notes`, { content });
+    },
+
+    /**
+     * Issue #2492: fetch the 4 ConnectionBar counts for the SP6 §F drawer.
+     * Returns null on 401 (apiClient convention).
+     */
+    async getHouseRulesMetadata(gameId: string): Promise<HouseRulesMetadataDto | null> {
+      return httpClient.get(
+        `${BASE}/house-rules/metadata?gameId=${encodeURIComponent(gameId)}`,
+        HouseRulesMetadataDtoSchema
+      );
     },
 
     // === Player Stats ===


### PR DESCRIPTION
## Summary

Wires the 4-pip ConnectionBar (agent · game · session · kb) of the SP6 §F house-rule drawer from the mockup placeholder (PR #2491) to dynamic counts.

- **BE**: new `GET /api/v1/agent-memory/house-rules/metadata?gameId={guid}` endpoint + CQRS query/handler + cross-BC `IKbChunkCountReader` service.
- **FE**: `useHouseRulesMetadata({ gameId })` React Query hook with 5-min staleTime + Zod schema + API client method.

Closes #2492.

## Backend

- New `HouseRulesMetadataDto(agentCount, gameCount, sessionCount, kbCount)` record.
- `GetHouseRulesMetadataQuery(GameId, OwnerId)` → `IQuery<HouseRulesMetadataDto>`.
- `GetHouseRulesMetadataQueryHandler` aggregates from `IGameMemoryRepository.HouseRules.Count` + `IKbChunkCountReader`.
- `IKbChunkCountReader` + `KbChunkCountReader` impl — narrow cross-BC contract counting VectorDocuments matched on `SharedGameId == gameId || GameId == gameId`. No leakage of KnowledgeBase domain logic into AgentMemory.
- Endpoint wired in `AgentMemoryEndpoints` under the existing `/agent-memory` group, with `RequireAuthenticatedUser`. Returns 400 on empty `gameId`, 200 with shape otherwise.
- DI registered in `AgentMemoryServiceExtensions`.

### Semantic counts (per issue body)

| Field | Source | Notes |
|---|---|---|
| `agentCount` | `GameMemory.HouseRules.Count` for (gameId, ownerId) | real |
| `gameCount` | Constant `1` | always 1 in current scope, future-proof per spec |
| `sessionCount` | `0` placeholder | no `session_house_rule_applications` tracking table yet in SessionTracking BC — see "Gaps" below |
| `kbCount` | `VectorDocuments` count for the game | semantic interpretation: "regole ufficiali del gioco" (no direct `HouseRule → KbChunk` FK exists) |

### Gaps surfaced during discovery (NOT addressed here)

- ⚠️ **`sessionCount` always 0**: `SessionHouseRuleApplication` entity does not exist in `SessionTracking` BC. To actually return a meaningful count, a tracking row needs to be persisted whenever a house rule is applied in a session. Out of scope here — should be a separate spec issue when the SP6 drawer is wired to live session UI.
- ⚠️ **`kbCount` semantics**: counts VectorDocuments per game (= total official rule chunks), not chunks specifically referenced by house rules. There is no `HouseRule.RelatedKbChunks` relation today. Wording in the spec said "KB chunks that house rules substitute/extend"; without a tracked relation, the cleanest available number is the per-game KB depth. Documented in the handler XML doc.

## Frontend

- `HouseRulesMetadataDtoSchema` (Zod) + `HouseRulesMetadataDto` type in `agentMemoryClient.ts`.
- `agentMemoryClient.getHouseRulesMetadata(gameId)` method.
- `useHouseRulesMetadata({ gameId, enabled })` hook in `apps/web/src/hooks/queries/`. Uses TanStack `useQuery` + 5-min `staleTime`. Gates on empty/null `gameId` (returns disabled, no fetch).

### ⚠️ ConnectionBar wire-in deferred

The `HouseRuleDrawer` React component does NOT exist yet — PR #2491 shipped HTML mockup only (`admin-mockups/design_files/sp6-libro-game-house-rule.html`). The actual `// MOCKUP PLACEHOLDER — FE wire TBD` substitution will happen as part of the React implementation work for the SP6 §F drawer (tracked under #2027).

This PR ships the BE + the hook so the future drawer implementation can wire `useHouseRulesMetadata({ gameId })` directly without further BE work.

## Tests

- **BE**: 6 unit tests for the handler (`GetHouseRulesMetadataQueryHandlerTests`): memory not-found / empty memory / 3 rules / zero kb chunks / id forwarding to deps / null query guard. All pass.
- **FE**: 10 unit tests for the hook (`useHouseRulesMetadata.test.tsx`): constants + 4 enable-gate scenarios + manual enabled=false + success / null-on-401 / error. All pass.

## Test plan

- [x] BE: `dotnet test --filter "FullyQualifiedName~GetHouseRulesMetadataQueryHandlerTests"` → 6/6 ✅
- [x] FE: `pnpm test useHouseRulesMetadata --run` → 10/10 ✅
- [x] BE build (`dotnet build`) → 0 errors, 0 warnings
- [x] FE typecheck (`pnpm typecheck`) → 0 errors
- [x] FE lint (new files) → 0 errors
- [ ] Manual QA: actual ConnectionBar pip render — deferred to #2027 drawer impl

🤖 Generated with [Claude Code](https://claude.com/claude-code)