### PR TITLE
fix(mockups): #2216 sp4-library-mobile fidelity viewports — mobile not desktop

### DIFF
--- a/admin-mockups/design_files/sp4-library-mobile.fidelity.json
+++ b/admin-mockups/design_files/sp4-library-mobile.fidelity.json
@@ -28,7 +28,7 @@
     "fixtures_path": "",
     "design_intent": "forward-refactor",
     "viewports": [
-      "desktop"
+      "mobile"
     ],
     "obsolete_tracking_issue": "#2216"
   }


### PR DESCRIPTION
## Summary

Designer review (issue #2216) flagged one MAJOR finding on `sp4-library-mobile.fidelity.json`: the metadata declared `viewports: [\"desktop\"]` but the mockup is mobile-only.

Single-line fix: `viewports: [\"mobile\"]`.

Closes #2216.

## Why this matters

The mockup HTML header explicitly says `@route /library (mobile <768px)` and the layout is 375px × 760px single-column mobile-only:
- 1-col MeepleCard grid (vs desktop multi-col)
- 3-tab primary (Games/Sessions/Chat) + overflow \"Più\" (Agents/KB)
- Bulk-select long-press pattern
- Bottom-sheet drawer 80vh (`.sheet.tall`)
- FAB bottom-right

The wrong `viewports` value would have:
1. Driven the wrong CI visual-regression viewport (no mobile screenshot baseline produced)
2. Mismatched the design-intent contract with the actual layout

## Test plan

- [x] Designer review confirmed mobile-only intent in HTML
- [x] Single-line fidelity.json correction
- [x] No mockup HTML change (layout already correct)
- [ ] Visual regression CI run will now correctly target mobile viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)