### PR TITLE
feat(mockups): #2496 User/Guest player roster badges (play-records family)

### DIFF
--- a/admin-mockups/design_files/pr-form-core.jsx
+++ b/admin-mockups/design_files/pr-form-core.jsx
@@ -281,6 +281,32 @@ const Step2Quando = ({ dateLabel = 'Sabato 17 maggio 2026', time = '21:00', dura
 );
 
 // ─── STEP 3 — GIOCATORI & PUNTEGGI ─────────────────────
+// #2496 — Asse A inv #16: tiny pill distinguishes account-linked players from guest tags.
+// Used in ScoreRow next to the player title so editors see the roster mix at-a-glance.
+const KindBadge = ({ kind }) => {
+  const isGuest = kind === 'guest';
+  return (
+    <span
+      title={isGuest ? 'Giocatore ospite — non collegato a un account' : 'Giocatore con account collegato'}
+      style={{
+        fontFamily: 'var(--f-mono)',
+        fontSize: 8.5,
+        fontWeight: 800,
+        letterSpacing: '.06em',
+        textTransform: 'uppercase',
+        padding: '1px 6px',
+        borderRadius: 'var(--r-pill)',
+        color: isGuest ? 'var(--text-sec)' : entityHsl('player'),
+        background: isGuest ? 'var(--bg-muted)' : entityHsl('player', 0.12),
+        border: isGuest ? '1px solid var(--border-light)' : `1px solid ${entityHsl('player', 0.25)}`,
+        whiteSpace: 'nowrap',
+      }}
+    >
+      {isGuest ? 'Ospite' : 'Account'}
+    </span>
+  );
+};
+
 const ScoreRow = ({ player, score, isWinner }) => (
   <div style={{
     display:'flex', alignItems:'center', gap: 10, padding:'10px 12px',
@@ -290,8 +316,10 @@ const ScoreRow = ({ player, score, isWinner }) => (
   }}>
     <Avatar player={player} size={34}/>
     <div style={{ flex: 1, minWidth: 0 }}>
-      <div style={{ fontFamily:'var(--f-display)', fontSize: 13.5, fontWeight: 800, color:'var(--text)', display:'flex', alignItems:'center', gap: 6 }}>
+      <div style={{ fontFamily:'var(--f-display)', fontSize: 13.5, fontWeight: 800, color:'var(--text)', display:'flex', alignItems:'center', gap: 6, flexWrap:'wrap' }}>
         {player.title.split(' ')[0]}
+        {/* #2496 Asse A inv #16 — User/Guest pill so the editor sees the roster mix */}
+        <KindBadge kind={player.kind || 'user'}/>
         {isWinner && (
           <span style={{ display:'inline-flex', alignItems:'center', gap: 3, padding:'1px 7px', borderRadius:'var(--r-pill)', background: entityHsl('session', 0.14), color: entityHsl('session'), fontFamily:'var(--f-mono)', fontSize: 8.5, fontWeight: 800, textTransform:'uppercase', letterSpacing:'.06em' }}>🏆 Vincitore</span>
         )}

--- a/admin-mockups/design_files/sp4-play-records-data.js
+++ b/admin-mockups/design_files/sp4-play-records-data.js
@@ -40,13 +40,22 @@
   // pr-form-core PREFILL referenzia 'p-anna' che NON esiste in DS.players.
   // Lo aggiungiamo a DS.byId per evitare il fallback "?.title" undefined.
   if (!DS.byId['p-anna']) {
+    // #2496 — Anna F. is a "guest" player (tag-only, no User account linked).
+    // Used by the User-vs-Guest badge demo in detail/edit/new mockups.
     DS.byId['p-anna'] = {
       id: 'p-anna', type: 'player', title: 'Anna F.',
-      subtitle: 'Membro Set 2025 · 38 partite',
+      subtitle: 'Ospite · 38 partite registrate',
       initials: 'AF', color: 200, status: 'active',
+      kind: 'guest',
       totalWins: 14, totalSessions: 38, winRate: 0.368, fav: 'Wingspan',
     };
   }
+
+  // #2496 — Asse A invariante #16: backfill kind:'user' for the 5 core User-linked
+  // players in data.js so the badge helper has a consistent flag to read.
+  ['p-marco', 'p-sara', 'p-luca', 'p-giulia', 'p-andrea'].forEach(pid => {
+    if (DS.byId[pid] && !DS.byId[pid].kind) DS.byId[pid].kind = 'user';
+  });
 
   // ── PLAY RECORDS ──────────────────────────────────────────────────
   // pr1  : Wingspan · Marco vince (cover hero / vittoria)         [completed]
@@ -67,10 +76,12 @@
       hasChat: true, chatCount: 12,
       notes: 'Partita combattuta fino all\'ultimo turno. Marco chiude con un mega-combo wetland e ribalta il vantaggio di Sara grazie ai bonus di fine round.',
       scores: [
-        { playerId: 'p-marco',  name: 'Marco R.',  score: 89, winner: true  },
-        { playerId: 'p-sara',   name: 'Sara T.',   score: 76, winner: false },
-        { playerId: 'p-luca',   name: 'Luca B.',   score: 64, winner: false },
-        { playerId: 'p-giulia', name: 'Giulia M.', score: 58, winner: false },
+        { playerId: 'p-marco', name: 'Marco R.', score: 89, winner: true  },
+        { playerId: 'p-sara',  name: 'Sara T.',  score: 76, winner: false },
+        { playerId: 'p-luca',  name: 'Luca B.',  score: 64, winner: false },
+        // #2496 — Anna F. is the guest player demo: tag-only, no User account.
+        // Renders with the "Ospite" badge in detail Classifica + Hero podium.
+        { playerId: 'p-anna',  name: 'Anna F.',  score: 58, winner: false },
       ],
     },
     {

--- a/admin-mockups/design_files/sp4-play-records-detail.jsx
+++ b/admin-mockups/design_files/sp4-play-records-detail.jsx
@@ -46,6 +46,42 @@ const playerTitle = (s) => {
   return p ? p.title : s.name;
 };
 
+// #2496 — Asse A invariante #16: roster player mix (User-linked + guest).
+// Reads the `kind` flag injected in sp4-play-records-data.js; defaults to 'user'
+// for the 5 core players in data.js (Marco/Sara/Luca/Giulia/Andrea).
+const playerKind = (s) => {
+  const p = DS.byId[s.playerId];
+  return (p && p.kind) || 'user';
+};
+
+// Tiny pill badge — distinguishes account-linked players ("Tu") from guest tags ("Ospite").
+// Sits next to the player title in Classifica + Hero podium so the roster mix is read at-a-glance.
+const PlayerKindBadge = ({ kind, small }) => {
+  const isGuest = kind === 'guest';
+  const label = isGuest ? 'Ospite' : 'Account';
+  const ent = isGuest ? null : 'player';
+  return (
+    <span
+      title={isGuest ? 'Giocatore ospite — non collegato a un account' : 'Giocatore con account collegato'}
+      style={{
+        fontFamily: 'var(--f-mono)',
+        fontSize: small ? 8 : 9,
+        fontWeight: 800,
+        letterSpacing: '.06em',
+        textTransform: 'uppercase',
+        padding: small ? '1px 5px' : '2px 7px',
+        borderRadius: 'var(--r-pill)',
+        color: isGuest ? 'var(--text-sec)' : eHs(ent),
+        background: isGuest ? 'var(--bg-muted)' : eHs(ent, 0.12),
+        border: isGuest ? '1px solid var(--border-light)' : `1px solid ${eHs(ent, 0.25)}`,
+        whiteSpace: 'nowrap',
+      }}
+    >
+      {label}
+    </span>
+  );
+};
+
 // ── Record demo ─────────────────────────────────────────
 const REC = DS.byId['pr1'];
 const REGISTRANT = (DS.stats && DS.stats.user) || 'Marco R.';
@@ -144,6 +180,8 @@ const HeroPodium = ({ record, compact, minimal }) => {
                   <span style={{ position:'absolute', bottom:-6, right:-6, width: 22, height: 22, borderRadius:'50%', background:'var(--bg-card)', border:`2px solid ${isW ? eHs('toolkit') : 'var(--border-strong)'}`, color: isW ? eHs('toolkit') : 'var(--text-sec)', display:'flex', alignItems:'center', justifyContent:'center', fontFamily:'var(--f-mono)', fontSize: 10, fontWeight: 800 }}>{place}</span>
                 </div>
                 <div style={{ fontFamily:'var(--f-display)', fontSize: place === 1 ? (compact ? 14 : 16) : (compact ? 12 : 13), fontWeight: 800, color:'var(--text)' }}>{neutral ? '—' : s.name}</div>
+                {/* #2496 Asse A inv #16 — podium roster mix badge (small variant for the tighter podium layout) */}
+                {!neutral && <PlayerKindBadge kind={playerKind(s)} small/>}
                 <ScoreVal value={neutral ? null : s.score} style={{ fontFamily:'var(--f-mono)', fontSize: place === 1 ? (compact ? 18 : 24) : (compact ? 13 : 16), fontWeight: 800, color: isW ? eHs('toolkit') : 'var(--text-sec)', fontVariantNumeric:'tabular-nums', lineHeight: 1 }}/>
               </div>
             );
@@ -212,7 +250,12 @@ const Classifica = ({ record, compact, minimal }) => {
               <span style={{ width: 24, fontFamily:'var(--f-display)', fontSize: 16, fontWeight: 800, color: isW ? eHs('toolkit') : 'var(--text-muted)', textAlign:'center', flexShrink: 0 }} aria-hidden="true">{place === 1 ? '🥇' : place === 2 ? '🥈' : place === 3 ? '🥉' : place}</span>
               <span style={{ width: 38, height: 38, borderRadius:'50%', background:`hsl(${pColor(s.playerId)}, 60%, 55%)`, color:'#fff', display:'flex', alignItems:'center', justifyContent:'center', fontFamily:'var(--f-display)', fontWeight: 800, fontSize: 13, flexShrink: 0, border:'2px solid var(--bg-card)' }} aria-hidden="true">{initialsOf(s)}</span>
               <div style={{ flex: 1, minWidth: 0 }}>
-                <div style={{ fontFamily:'var(--f-display)', fontSize: 13.5, fontWeight: 800, color:'var(--text)', display:'flex', alignItems:'center', gap: 6 }}>{playerTitle(s)}{isW && <span style={{ fontFamily:'var(--f-mono)', fontSize: 8.5, fontWeight: 800, color: eHs('toolkit'), background: eHs('toolkit', 0.14), padding:'1px 6px', borderRadius:'var(--r-pill)', textTransform:'uppercase', letterSpacing:'.06em' }}>Vincitore</span>}</div>
+                <div style={{ fontFamily:'var(--f-display)', fontSize: 13.5, fontWeight: 800, color:'var(--text)', display:'flex', alignItems:'center', gap: 6, flexWrap:'wrap' }}>
+                  {playerTitle(s)}
+                  {/* #2496 Asse A inv #16 — User/Guest badge so the roster mix is visible per row */}
+                  <PlayerKindBadge kind={playerKind(s)}/>
+                  {isW && <span style={{ fontFamily:'var(--f-mono)', fontSize: 8.5, fontWeight: 800, color: eHs('toolkit'), background: eHs('toolkit', 0.14), padding:'1px 6px', borderRadius:'var(--r-pill)', textTransform:'uppercase', letterSpacing:'.06em' }}>Vincitore</span>}
+                </div>
                 <div style={{ marginTop: 5, height: 6, borderRadius:'var(--r-pill)', background:'var(--bg-muted)', overflow:'hidden' }}>
                   <div style={{ width: `${pct}%`, height:'100%', borderRadius:'var(--r-pill)', background: isW ? eHs('toolkit') : eHs('session') }}/>
                 </div>


### PR DESCRIPTION
## Summary

Wires Asse A invariante #16 (roster player mix visibility) into the SP4 play-records mockup family. Every roster row now visibly distinguishes account-linked players (\"Account\" badge) from guest tag-only players (\"Ospite\" badge) via a tiny pill next to the player title.

Spin-off from #2488 designer review self-waiver. Closes #2496.

## Changes

### Data layer (sp4-play-records-data.js)
- Added `kind: 'guest'` to the existing `p-anna` fallback entry (Anna F. is now the demo guest player)
- Backfill loop adds `kind: 'user'` to the 5 core players in `data.js` (Marco/Sara/Luca/Giulia/Andrea)
- Replaced `p-giulia` with `p-anna` in `pr1` (Wingspan) scores → guest badge becomes visible in the detail mockup's Classifica + Hero podium of the demo record

### Form-core (pr-form-core.jsx)
- New `KindBadge` primitive
- Wired into `ScoreRow` so Step 3 (\"Punteggi\") in **both** wizards renders the badge next to each player title

This single change covers `/play-records/new` AND `/play-records/edit` (both use the shared form-core ScoreRow) — issue #2496 lists them as two separate mockups but the implementation is one shared component.

### Detail mockup (sp4-play-records-detail.jsx)
- New `PlayerKindBadge` helper + `playerKind()` reader
- Wired in `Classifica` next to player title (full size variant)
- Wired in `HeroPodium` below player name (small variant for the tighter podium layout, hidden on the neutral/minimal placeholder)

### Backwards compatibility
Default kind is `'user'` (`player.kind || 'user'`) — existing fixtures without an explicit field keep working.

## Acceptance criteria

- [x] Mockup `sp4-play-records-detail.html` updated (via .jsx) with badges in Classifica + Hero podium
- [x] Mockup `sp4-play-records-edit.html` updated (via shared `ScoreRow`) with badges in Step 3 score editor
- [x] Mockup `sp4-play-records-new.html` updated (via shared `ScoreRow`) with badges in Step 3 score editor (Step 2 is \"Quando\" date/time — the roster is selected in Step 3 contextually with scores, NOT in Step 2; the issue body was slightly imprecise on this point but the badge lands where roster rows are visible)
- [x] `.fidelity.json` files untouched (`design_intent: \"current\"`, no version bump)
- [x] Visual verification deferred to next designer pass

## Out of scope (deferred)

- **Polymorphic ScoreType form UI** (BinaryWin/Objectives/Ranking) — only Points type implemented; tracked separately per #2488 review.
- **Stats winRate ScoreType variants** — deferred (low impact, aggregation-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)