### PR TITLE
fix(pdf-indexing): #2278 code-review followups (3 findings) — re-apply lost squash content

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/CompleteChunkedUploadCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/CompleteChunkedUploadCommandHandler.cs
@@ -752,7 +752,7 @@ internal class CompleteChunkedUploadCommandHandler : ICommandHandler<CompleteChu
     {
 
         // Update vector document with chunk count (no pgvector indexing)
-        await UpdateOrCreateVectorDocumentAsync(pdfGuid, pdfDoc, fullText, allDocumentChunks.Count, db, scope, cancellationToken).ConfigureAwait(false);
+        await UpdateOrCreateVectorDocumentAsync(pdfGuid, pdfDoc, fullText, allDocumentChunks.Count, db, scope, _logger, cancellationToken).ConfigureAwait(false);
 
         // Save text chunks to PostgreSQL for hybrid search (FTS)
         await SaveTextChunksForHybridSearchAsync(pdfGuid, pdfDoc, allDocumentChunks, db, scope, cancellationToken).ConfigureAwait(false);
@@ -772,8 +772,24 @@ internal class CompleteChunkedUploadCommandHandler : ICommandHandler<CompleteChu
         int indexedCount,
         MeepleAiDbContext db,
         IServiceScope scope,
+        ILogger logger,
         CancellationToken cancellationToken)
     {
+        // Pre-pipeline guard: IPdfIndexingPipeline.IndexAsync throws
+        // ArgumentOutOfRangeException on chunkCount <= 0 (see PdfIndexingPipeline.cs:51).
+        // This path can land here with indexedCount == 0 if extraction succeeded but
+        // every chunk was filtered out (whitespace-only, post-translation drop, etc.).
+        // PdfProcessingPipelineService already guards upstream with `if (chunks.Count == 0)`;
+        // mirror it here so the exception path doesn't trigger and the PDF gets marked
+        // failed with a clear diagnostic instead of being swallowed by the outer general catch.
+        if (indexedCount <= 0)
+        {
+            logger.LogWarning(
+                "ChunkedUpload PDF {PdfId}: no chunks produced from extracted text ({CharCount} chars) — skipping VectorDocument upsert",
+                pdfGuid, fullText.Length);
+            return;
+        }
+
         var pipeline = scope.ServiceProvider.GetRequiredService<IPdfIndexingPipeline>();
         await pipeline.IndexAsync(
             pdfDocumentId: pdfGuid,

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs
@@ -769,7 +769,21 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
             .ConfigureAwait(false);
         if (vectorDoc is null)
         {
-            // Pipeline swallowed a concurrency conflict — exit without indexing.
+            // Pipeline swallowed a DbUpdateConcurrencyException and the row was never
+            // written — Quartz must still see job success, so we cannot rethrow. But
+            // silently skipping pgvector indexing here means the PDF is "Ready" with
+            // no embeddings until something forces a re-index. Surface the loss so
+            // ops can detect it: increment the same Category-B counter the pipeline
+            // itself uses, then log a WARN with the PDF id. The companion follow-up
+            // (issue tracked in #2248 Sub #6) wires a dedicated Prometheus gauge
+            // meepleai_pdf_indexed_no_kb_flag_total — this counter feeds into the
+            // same dashboard.
+            MeepleAiMetrics.RecordPdfConcurrencyConflict(
+                nameof(PdfProcessingPipelineService),
+                MeepleAiMetrics.PdfConcurrencyCategories.B);
+            _logger.LogWarning(
+                "PdfPipeline: VectorDocument row for PDF {PdfId} missing after IndexAsync — pipeline swallowed a concurrency conflict, pgvector embeddings skipped. PDF will need re-index.",
+                pdfDoc.Id);
             return;
         }
 

--- a/apps/api/tests/Api.Tests/Integration/DocumentProcessing/PdfIndexingFlowKbFlagIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/DocumentProcessing/PdfIndexingFlowKbFlagIntegrationTests.cs
@@ -207,6 +207,15 @@ public sealed class PdfIndexingFlowKbFlagIntegrationTests : IAsyncLifetime
         // that fires after Sub #1 Block A publishes VectorDocumentIndexedEvent)
         services.AddScoped(_ => Mock.Of<Api.BoundedContexts.KnowledgeBase.Domain.Repositories.IVectorDocumentRepository>());
 
+        // Real IPdfIndexingPipeline (#2244 / epic #2242 Sub #2): the production write
+        // path that UploadPdfCommandHandler.UpdateVectorDocumentAsync now resolves at
+        // runtime via scope.ServiceProvider.GetRequiredService. Without this binding
+        // the resolver would throw InvalidOperationException and the handler's outer
+        // general catch would silently mark the PDF Failed — which is exactly the
+        // silent-fail mode this test class was written to detect.
+        services.AddScoped<Api.BoundedContexts.KnowledgeBase.Application.Services.IPdfIndexingPipeline,
+            Api.BoundedContexts.KnowledgeBase.Application.Services.PdfIndexingPipeline>();
+
         // HybridCache + dependencies — required by VectorDocumentIndexedForKbFlagHandler
         // (the handler that actually flips shared_games.has_knowledge_base = true on the event).
         services.AddSingleton<IMemoryCache, MemoryCache>();


### PR DESCRIPTION
## Cosa

Ri-applica i **3 fix di code-review** del commit `ebacdb928` che erano stati committati su `feature/issue-2244-vectordocument-factory` ma **persi nello squash-merge** della PR #2278 (il commit fu creato ~3h dopo il commit poi squashato; lo squash catturò solo lo stato precedente nonostante il body della PR dichiarasse i followups come "addressed before merge").

Verificato riga per riga che i 3 fix sono **tuttora assenti** da `main-dev`.

## I 3 fix (difensivi — guard/log/metric/DI)

1. 🔴 **BLOCKER** — `PdfIndexingFlowKbFlagIntegrationTests`: registra il vero `IPdfIndexingPipeline` → `PdfIndexingPipeline` nel container DI. Senza, il resolver lancia `InvalidOperationException` ingoiata dal catch generale dell'handler come "PDF Failed" generico → il test silent-fail che la classe esiste per rilevare **passerebbe per la ragione sbagliata**.
2. 🟠 **HIGH** — `CompleteChunkedUploadCommandHandler.UpdateOrCreateVectorDocumentAsync`: guard `indexedCount <= 0` + WARN log prima della pipeline (mirror della guard già presente in `PdfProcessingPipelineService`). Evita `ArgumentOutOfRangeException` quando l'estrazione riesce ma tutti i chunk vengono filtrati (whitespace-only / post-translation drop).
3. 🟠 **HIGH** — `PdfProcessingPipelineService`: su re-read null dopo `IndexAsync` (concurrency conflict ingoiato), emette il counter `RecordPdfConcurrencyConflict(Category.B)` + WARN log con il PDF id, invece di un `return` silenzioso che lasciava il PDF **`Ready` senza embeddings indefinitamente** (silent data loss).

## Verifica

- ✅ `dotnet build` API: 0 errori / 0 warning contro `main-dev` attuale (post-refactor #2284/#2296 — cherry-pick auto-merged senza conflitti)
- ✅ `dotnet build` Api.Tests: 0 errori
- ⏳ Integration test (`PdfIndexingFlowKbFlagIntegrationTests`, Testcontainers/Postgres) → eseguito dalla CI (Docker non disponibile nell'ambiente locale)

## Note

- Le issue #2244 / #2278 sono già CLOSED — questa PR **non le riapre** (nessun keyword `Closes`); è puro recupero di contenuto perso.
- Commit preservato as-is per mantenere autoria e contesto originale del code-review.

Refs: PR #2278, parent #2244, epic #2242
