### PR TITLE
feat(session-live): #2501 Fase 1 — caricare l'aggregato canonico LiveGameSession

### DIFF
--- a/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx
@@ -68,7 +68,7 @@
 
 'use client';
 
-import { useCallback, useEffect, useMemo, lazy, Suspense, type ReactElement } from 'react';
+import { useCallback, useMemo, lazy, Suspense, type ReactElement } from 'react';
 
 import { useParams, usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useIntl } from 'react-intl';
@@ -100,8 +100,7 @@ import {
   type ScoringPanelRendererLabels,
   type ToolkitRendererLabels,
 } from '@/components/features/session-live';
-import type { ScoreDataByType, ScoreType } from '@/components/sessions/score-strategies/types';
-import { useSession } from '@/hooks/queries/useActiveSessions';
+import { useLiveSession } from '@/hooks/queries/useLiveSession';
 import { useTranslation } from '@/hooks/useTranslation';
 import { composeSessionLiveState } from '@/lib/session-live/compose-session-live-state';
 import { mapConnectionState } from '@/lib/session-live/map-connection-state';
@@ -324,8 +323,11 @@ export function SessionLiveView(): ReactElement {
     return resolveFixtureVariant(fixtureVariantParam);
   }, [fixtureVariantParam]);
 
-  // Real data hook — disabled when fixture is active or sessionId is null
-  const sessionQuery = useSession(
+  // Real data hook — disabled when fixture is active or sessionId is null.
+  // ADR-083 Fase 1 (#2501): load the canonical LiveGameSession aggregate
+  // (LiveSessionDto) — the one the wizards actually create — instead of the empty
+  // GameSession shell, which returned 404 for funnel-created sessions.
+  const sessionQuery = useLiveSession(
     sessionId ?? '',
     /* enabled= */ !IS_VISUAL_TEST_BUILD && sessionId != null
   );
@@ -362,18 +364,11 @@ export function SessionLiveView(): ReactElement {
     const dto = sessionQuery.data;
     if (dto == null) return null;
 
-    // Adapt DTO players: SessionPlayerDto.id is optional (backward-compat Gate B).
-    // composeSessionLiveState requires id: string — synthesise from playerName+playerOrder.
-    const initialData = {
-      ...dto,
-      players: dto.players.map((p, idx) => ({
-        ...p,
-        id: p.id ?? `${p.playerName}-${p.playerOrder}-${idx}`,
-      })),
-    };
-
-    // Compose live state from DTO + accumulated SSE events
-    const liveState = composeSessionLiveState(initialData, liveStream.events);
+    // ADR-083 Fase 1 (#2501): LiveSessionDto players already carry a stable id +
+    // displayName, and the DTO exposes status/currentTurnIndex/currentTurnPlayerId
+    // — all consumed directly by composeSessionLiveState (designed for LiveSessionDto).
+    // Compose live state from DTO + accumulated SSE events.
+    const liveState = composeSessionLiveState(dto, liveStream.events);
 
     return {
       id: dto.id,
@@ -851,53 +846,20 @@ export function SessionLiveView(): ReactElement {
 
   // ── Derived data for components ───────────────────────────────────────────
   //
-  // #2430 Block B+: Block B's polymorphic scoring logic (selectors, memo,
-  // a11y placeholder) MOVED to ScoreTabContent. SessionLiveView keeps only
-  // the REST hydration useEffect because it depends on sessionQuery.data
-  // (which lives at this level via useSession). The store-write side-effect
-  // is forwarded to ScoreTabContent via the shared useLiveSessionStore.
-
-  const setScoringConfig = useLiveSessionStore(s => s.setScoringConfig);
-  const setTurnOrderType = useLiveSessionStore(s => s.setTurnOrderType);
+  // ADR-083 Fase 1 (#2501): the polymorphic REST hydration of scoringType/
+  // scoreData/turnOrderType (Block B #2389 / #2430 / #2483) was removed when the
+  // loader switched to the canonical LiveGameSession aggregate. LiveSessionDto is
+  // round-based and exposes none of those polymorphic fields; on the real funnel
+  // they were always undefined (empty GameSession shell), so the effects never ran
+  // in production. The store is still consumed below and may be populated via
+  // SignalR; wiring round-based scoring from LiveSessionDto.roundScores/
+  // scoringConfig is deferred to Fase 2.
 
   // #2431: polymorphic endgame summary — selectors feed mapScoreDataToEndgameSummary
   // below. Subscribed reactively so the EndgameDialog refreshes as scoreData
   // changes (final-tick edits before the host acknowledges).
   const endgameScoringType = useLiveSessionStore(s => s.scoringType);
   const endgameScoreData = useLiveSessionStore(s => s.scoreData);
-
-  // #2389 Block B + #2430 Block B+: REST hydration with race guard +
-  // observability. Pre-populate the store from sessionQuery.data on initial
-  // mount so the renderer paints in ~300ms instead of waiting for SignalR.
-  // Skip if SignalR already populated to avoid stale REST overwriting fresh
-  // state.
-  useEffect(() => {
-    const dto = sessionQuery.data;
-    if (dto?.scoringType == null || dto.scoreData == null) return;
-    if (useLiveSessionStore.getState().scoringType != null) return;
-    try {
-      const parsed = JSON.parse(dto.scoreData) as ScoreDataByType[ScoreType];
-      setScoringConfig({
-        scoringType: dto.scoringType as ScoreType,
-        scoreData: parsed,
-      });
-    } catch (err) {
-      console.warn('[#2389] malformed scoreData JSON, will rely on SignalR', {
-        sessionId: dto.id,
-        scoreDataLength: dto.scoreData?.length ?? 0,
-        err,
-      });
-    }
-  }, [sessionQuery.data, setScoringConfig]);
-
-  // #2483 Task 2: REST hydration for turnOrderType (path B — static, no SignalR).
-  // Populate once from the DTO. No race guard needed: no SignalR event exists for
-  // turnOrderType (it never changes during the session).
-  useEffect(() => {
-    const dto = sessionQuery.data;
-    if (dto?.turnOrderType == null) return;
-    setTurnOrderType(dto.turnOrderType as import('@/lib/session-live/turn-state').TurnOrderType);
-  }, [sessionQuery.data, setTurnOrderType]);
 
   // ── G5c #2376: Zustand toolkit renderer store ─────────────────────────────
   // Store starts empty; real hydration via useQuery(['toolkit', sessionId]) is a

--- a/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/__tests__/SessionLiveView.test.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/__tests__/SessionLiveView.test.tsx
@@ -34,7 +34,7 @@ import { IntlProvider } from 'react-intl';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ReactElement } from 'react';
 
-import type { GameSessionDto } from '@/lib/api/schemas/games.schemas';
+import type { LiveSessionDto } from '@/lib/api/schemas/live-sessions.schemas';
 import type { UseSessionLiveStreamResult } from '@/lib/session-live/use-session-live-stream';
 import { useLiveSessionStore } from '@/lib/stores/live-session-store';
 import type { ScoreDataByType } from '@/components/sessions/score-strategies/types';
@@ -59,7 +59,7 @@ vi.mock('next/navigation', () => ({
 // ─── useSession mock ──────────────────────────────────────────────────────
 
 type MockSessionReturn = {
-  data?: GameSessionDto | null;
+  data?: LiveSessionDto | null;
   isLoading: boolean;
   isError: boolean;
   isSuccess: boolean;
@@ -67,10 +67,10 @@ type MockSessionReturn = {
   refetch?: () => void;
 };
 
-const useSessionMock = vi.fn<[], MockSessionReturn>();
+const useLiveSessionMock = vi.fn<[], MockSessionReturn>();
 
-vi.mock('@/hooks/queries/useActiveSessions', () => ({
-  useSession: () => useSessionMock(),
+vi.mock('@/hooks/queries/useLiveSession', () => ({
+  useLiveSession: () => useLiveSessionMock(),
 }));
 
 // ─── useSessionLiveStream mock ────────────────────────────────────────────
@@ -278,21 +278,54 @@ function renderWithIntl(ui: ReactElement) {
 
 // ─── Fixture helpers ──────────────────────────────────────────────────────
 
-const MOCK_SESSION_DTO: GameSessionDto = {
+// ADR-083 Fase 1 (#2501): the canonical loader is now LiveGameSession
+// (LiveSessionDto). Only the fields SessionLiveView actually consumes are set;
+// the object is cast since the hook is mocked (no schema parse at this layer).
+const MOCK_SESSION_DTO = {
   id: 'session-abc-123',
+  sessionCode: 'ABC123',
   gameId: 'game-00000001',
+  gameName: 'Mage Knight',
+  gameSlug: 'mage-knight',
+  createdByUserId: '44444444-4444-4444-4444-444444444444',
   status: 'InProgress',
+  visibility: 'Private',
+  groupId: null,
+  createdAt: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
   startedAt: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+  pausedAt: null,
   completedAt: null,
-  playerCount: 2,
-  players: [
-    { id: 'player-001', playerName: 'Marco', playerOrder: 1, color: 'blue' },
-    { id: 'player-002', playerName: 'Anna', playerOrder: 2, color: 'red' },
-  ],
-  winnerName: null,
+  updatedAt: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
+  lastSavedAt: null,
+  currentTurnIndex: 0,
+  currentTurnPlayerId: null,
+  agentMode: 'Active',
+  chatSessionId: null,
   notes: null,
-  durationMinutes: 60,
-};
+  players: [
+    {
+      id: 'player-001',
+      displayName: 'Marco',
+      userId: null,
+      color: 'blue',
+      role: 'Player',
+      totalScore: 0,
+      isActive: true,
+    },
+    {
+      id: 'player-002',
+      displayName: 'Anna',
+      userId: null,
+      color: 'red',
+      role: 'Player',
+      totalScore: 0,
+      isActive: true,
+    },
+  ],
+  teams: [],
+  roundScores: [],
+  scoringConfig: { enabledDimensions: [], dimensionUnits: {} },
+} as unknown as LiveSessionDto;
 
 // ─── Import under test ─────────────────────────────────────────────────────
 
@@ -312,7 +345,7 @@ describe('SessionLiveView (Wave D.2 Foundation)', () => {
     Object.keys(searchParamsMap).forEach(k => delete searchParamsMap[k]);
     mockParamsId = 'session-abc-123';
     IS_VISUAL_TEST_BUILD_MOCK = false;
-    useSessionMock.mockReturnValue({
+    useLiveSessionMock.mockReturnValue({
       data: MOCK_SESSION_DTO,
       isLoading: false,
       isError: false,
@@ -333,7 +366,7 @@ describe('SessionLiveView (Wave D.2 Foundation)', () => {
   });
 
   it('root container has data-theme="dark" in loading state', () => {
-    useSessionMock.mockReturnValue({
+    useLiveSessionMock.mockReturnValue({
       data: undefined,
       isLoading: true,
       isError: false,
@@ -370,7 +403,7 @@ describe('SessionLiveView (Wave D.2 Foundation)', () => {
   // ─── 3.3: FSM Cell 2 — loading ─────────────────────────────────────────
 
   it('Cell 2: renders loading shell when isLoading=true', () => {
-    useSessionMock.mockReturnValue({
+    useLiveSessionMock.mockReturnValue({
       data: undefined,
       isLoading: true,
       isError: false,
@@ -385,7 +418,7 @@ describe('SessionLiveView (Wave D.2 Foundation)', () => {
   });
 
   it('Cell 2: no LiveTopBar rendered in loading state', () => {
-    useSessionMock.mockReturnValue({
+    useLiveSessionMock.mockReturnValue({
       data: undefined,
       isLoading: true,
       isError: false,
@@ -399,7 +432,7 @@ describe('SessionLiveView (Wave D.2 Foundation)', () => {
   // ─── 3.4: FSM Cell 3 — error ───────────────────────────────────────────
 
   it('Cell 3: renders error shell when isError=true', () => {
-    useSessionMock.mockReturnValue({
+    useLiveSessionMock.mockReturnValue({
       data: undefined,
       isLoading: false,
       isError: true,
@@ -416,7 +449,7 @@ describe('SessionLiveView (Wave D.2 Foundation)', () => {
 
   it('Cell 3: error retry button calls refetch', () => {
     const refetch = vi.fn();
-    useSessionMock.mockReturnValue({
+    useLiveSessionMock.mockReturnValue({
       data: undefined,
       isLoading: false,
       isError: true,
@@ -436,7 +469,7 @@ describe('SessionLiveView (Wave D.2 Foundation)', () => {
   // ─── 3.5: FSM Cell 4 — not-found (success + null data) ─────────────────
 
   it('Cell 4: renders not-found shell when data is null (session 404)', () => {
-    useSessionMock.mockReturnValue({
+    useLiveSessionMock.mockReturnValue({
       data: null,
       isLoading: false,
       isError: false,
@@ -576,7 +609,7 @@ describe('SessionLiveView (Wave D.2 Foundation)', () => {
   it('IS_VISUAL_TEST_BUILD=true: renders fixture data (not real hook)', () => {
     IS_VISUAL_TEST_BUILD_MOCK = true;
     // Even with useSession returning null, fixture renders default
-    useSessionMock.mockReturnValue({
+    useLiveSessionMock.mockReturnValue({
       data: null,
       isLoading: false,
       isError: false,
@@ -667,7 +700,7 @@ describe('SessionLiveView (Wave D.2 Interactions — Task 3)', () => {
     Object.keys(searchParamsMap).forEach(k => delete searchParamsMap[k]);
     mockParamsId = 'session-abc-123';
     IS_VISUAL_TEST_BUILD_MOCK = false;
-    useSessionMock.mockReturnValue({
+    useLiveSessionMock.mockReturnValue({
       data: MOCK_SESSION_DTO,
       isLoading: false,
       isError: false,
@@ -704,7 +737,7 @@ describe('SessionLiveView (Wave D.2 Interactions — Task 3)', () => {
   });
 
   it('T3.1c: useSessionLiveStream enabled=false when sessionQuery.isSuccess=false', () => {
-    useSessionMock.mockReturnValue({
+    useLiveSessionMock.mockReturnValue({
       data: undefined,
       isLoading: true,
       isError: false,
@@ -1032,7 +1065,7 @@ describe('SessionLiveView (#2375 G3 — accordion FSM URL SSOT)', () => {
     Object.keys(searchParamsMap).forEach(k => delete searchParamsMap[k]);
     mockParamsId = 'session-abc-123';
     IS_VISUAL_TEST_BUILD_MOCK = false;
-    useSessionMock.mockReturnValue({
+    useLiveSessionMock.mockReturnValue({
       data: MOCK_SESSION_DTO,
       isLoading: false,
       isError: false,
@@ -1123,7 +1156,7 @@ describe('SessionLiveView (#2375 G3 — accordion FSM URL SSOT)', () => {
 describe('SessionLiveView — Block B (#2389) scoring wire-up', () => {
   beforeEach(() => {
     // Default useSession + useSessionLiveStream returns for these tests.
-    useSessionMock.mockReturnValue({
+    useLiveSessionMock.mockReturnValue({
       data: MOCK_SESSION_DTO,
       isLoading: false,
       isError: false,
@@ -1134,120 +1167,16 @@ describe('SessionLiveView — Block B (#2389) scoring wire-up', () => {
     useSessionLiveStreamMock.mockReturnValue({ ...mockLiveStreamResult });
   });
 
-  // ── REST hydration (5) ──────────────────────────────────────────────────────
-
-  it('calls setScoringConfig when DTO carries scoringType+scoreData', () => {
-    const dtoWithConfig: GameSessionDto = {
-      ...MOCK_SESSION_DTO,
-      scoringType: 'Points',
-      scoreData: JSON.stringify({
-        scores: [{ playerId: 'player-001', points: 10 }],
-      }),
-    };
-    useSessionMock.mockReturnValue({
-      data: dtoWithConfig,
-      isLoading: false,
-      isError: false,
-      isSuccess: true,
-      error: null,
-      refetch: vi.fn(),
-    });
-
-    renderWithIntl(<SessionLiveView />);
-
-    expect(useLiveSessionStore.getState().scoringType).toBe('Points');
-    expect(useLiveSessionStore.getState().scoreData).toEqual({
-      scores: [{ playerId: 'player-001', points: 10 }],
-    });
-  });
-
-  it('logs console.warn on malformed scoreData JSON', () => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const dtoMalformed: GameSessionDto = {
-      ...MOCK_SESSION_DTO,
-      scoringType: 'Points',
-      scoreData: 'not-valid-json',
-    };
-    useSessionMock.mockReturnValue({
-      data: dtoMalformed,
-      isLoading: false,
-      isError: false,
-      isSuccess: true,
-      error: null,
-      refetch: vi.fn(),
-    });
-
-    renderWithIntl(<SessionLiveView />);
-
-    expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining('[#2389]'),
-      expect.objectContaining({ sessionId: MOCK_SESSION_DTO.id })
-    );
-    expect(useLiveSessionStore.getState().scoringType).toBeNull();
-    warnSpy.mockRestore();
-  });
-
-  it('does not call setScoringConfig when DTO has no scoringType (legacy session)', () => {
-    // MOCK_SESSION_DTO has no scoringType/scoreData by default.
-    renderWithIntl(<SessionLiveView />);
-    expect(useLiveSessionStore.getState().scoringType).toBeNull();
-    expect(useLiveSessionStore.getState().scoreData).toBeNull();
-  });
-
-  it('does not overwrite SignalR-hydrated store on later REST resolve (race guard)', () => {
-    // SignalR hydrates first.
-    act(() => {
-      useLiveSessionStore.setState({
-        scoringType: 'Points',
-        scoreData: {
-          scores: [{ playerId: 'player-001', points: 99 }],
-        } as ScoreDataByType['Points'],
-      });
-    });
-
-    // REST resolves with stale snapshot.
-    const dtoStale: GameSessionDto = {
-      ...MOCK_SESSION_DTO,
-      scoringType: 'Points',
-      scoreData: JSON.stringify({
-        scores: [{ playerId: 'player-001', points: 0 }],
-      }),
-    };
-    useSessionMock.mockReturnValue({
-      data: dtoStale,
-      isLoading: false,
-      isError: false,
-      isSuccess: true,
-      error: null,
-      refetch: vi.fn(),
-    });
-
-    renderWithIntl(<SessionLiveView />);
-
-    // SignalR data wins; REST does NOT overwrite.
-    expect(useLiveSessionStore.getState().scoreData).toEqual({
-      scores: [{ playerId: 'player-001', points: 99 }],
-    });
-  });
-
-  it('does not call setScoringConfig when scoringType present but scoreData null', () => {
-    const dtoPartial: GameSessionDto = {
-      ...MOCK_SESSION_DTO,
-      scoringType: 'Points',
-      scoreData: null,
-    };
-    useSessionMock.mockReturnValue({
-      data: dtoPartial,
-      isLoading: false,
-      isError: false,
-      isSuccess: true,
-      error: null,
-      refetch: vi.fn(),
-    });
-
-    renderWithIntl(<SessionLiveView />);
-    expect(useLiveSessionStore.getState().scoringType).toBeNull();
-  });
+  // ── REST hydration removed (ADR-083 Fase 1, #2501) ──────────────────────────
+  // The polymorphic scoring REST hydration (scoringType/scoreData/turnOrderType
+  // from GameSessionDto) was removed when the loader switched to the canonical
+  // LiveGameSession aggregate (LiveSessionDto, which is round-based and exposes
+  // no polymorphic fields). On the real funnel those fields were always
+  // undefined (empty GameSession shell) so the effects never ran in production.
+  // The store can still be populated directly (SignalR / explicit action) — the
+  // null-gate, placeholder and renderer-variant tests below exercise that path.
+  // Round-based scoring wiring from LiveSessionDto.roundScores/scoringConfig is
+  // deferred to Fase 2.
 
   // ── Null gate + a11y placeholder (2) ────────────────────────────────────────
 
@@ -1351,7 +1280,7 @@ describe('SessionLiveView — #2483 Task 4: TurnIndicatorRenderer from store', (
     searchParamsMap['tab'] = 'turn';
     mockParamsId = 'session-abc-123';
     IS_VISUAL_TEST_BUILD_MOCK = false;
-    useSessionMock.mockReturnValue({
+    useLiveSessionMock.mockReturnValue({
       data: MOCK_SESSION_DTO,
       isLoading: false,
       isError: false,
@@ -1405,22 +1334,8 @@ describe('SessionLiveView — #2483 Task 4: TurnIndicatorRenderer from store', (
     expect(container.querySelector('[data-slot="turn-branch-none"]')).not.toBeNull();
   });
 
-  it('renders None branch when DTO supplies turnOrderType=Sequential (hydration path)', () => {
-    // Test the full hydration path: DTO carries turnOrderType → store → renderer.
-    const dtoWithTurnOrder: GameSessionDto = {
-      ...MOCK_SESSION_DTO,
-      turnOrderType: 'Sequential',
-    };
-    useSessionMock.mockReturnValue({
-      data: dtoWithTurnOrder,
-      isLoading: false,
-      isError: false,
-      isSuccess: true,
-      error: null,
-      refetch: vi.fn(),
-    });
-    const { container } = renderWithIntl(<SessionLiveView />);
-    expect(container.querySelector('[data-slot="turn-branch-sequential"]')).not.toBeNull();
-    expect(container.querySelector('[data-slot="turn-branch-round-robin"]')).toBeNull();
-  });
+  // Hydration-path test removed (ADR-083 Fase 1, #2501): turnOrderType is no
+  // longer hydrated from the DTO loader (LiveSessionDto exposes no turnOrderType).
+  // The store-seeded branch tests above cover the renderer; DTO→store wiring for
+  // round-based turn metadata is deferred to Fase 2.
 });

--- a/apps/web/src/hooks/queries/__tests__/useLiveSession.test.tsx
+++ b/apps/web/src/hooks/queries/__tests__/useLiveSession.test.tsx
@@ -1,0 +1,144 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * useLiveSession unit tests — ADR-083 Fase 1 (Issue #2501).
+ *
+ * SessionLiveView must load the canonical LiveGameSession aggregate
+ * (`/api/v1/live-sessions/{id}` → LiveSessionDto), NOT the empty GameSession
+ * shell (`/api/v1/sessions/{id}` → GameSessionDto). This hook is the TanStack
+ * Query loader for that aggregate.
+ *
+ * Coverage:
+ *   - delegates to api.liveSessions.getSession with the sessionId
+ *   - exposes the LiveSessionDto on success
+ *   - defers the request when enabled=false
+ *   - defers the request when sessionId is empty
+ *   - surfaces the rejection on a generic API error
+ *   - maps a "Session not found" rejection to null (FSM not-found contract)
+ */
+
+import { type ReactNode } from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { NotFoundError } from '@/lib/api/core/errors';
+import type { LiveSessionDto } from '@/lib/api/schemas/live-sessions.schemas';
+
+import { liveSessionKeys, useLiveSession } from '../useLiveSession';
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+const getSessionMock = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/api', () => ({
+  api: { liveSessions: { getSession: getSessionMock } },
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+const SESSION_ID = '11111111-1111-1111-1111-111111111111';
+
+const SAMPLE_LIVE_SESSION = {
+  id: SESSION_ID,
+  sessionCode: 'ABC123',
+  gameId: '22222222-2222-2222-2222-222222222222',
+  gameName: 'Mage Knight',
+  gameSlug: 'mage-knight',
+  status: 'InProgress',
+  players: [{ id: '33333333-3333-3333-3333-333333333333', displayName: 'Alice', totalScore: 12 }],
+} as unknown as LiveSessionDto;
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('useLiveSession — query key factory', () => {
+  it('namespaces detail keys under liveSessions', () => {
+    expect(liveSessionKeys.detail(SESSION_ID)).toEqual(['liveSessions', 'detail', SESSION_ID]);
+  });
+});
+
+describe('useLiveSession — loading behaviour', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('delegates to api.liveSessions.getSession with the sessionId and exposes the dto', async () => {
+    getSessionMock.mockResolvedValue(SAMPLE_LIVE_SESSION);
+
+    const { result } = renderHook(() => useLiveSession(SESSION_ID), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(getSessionMock).toHaveBeenCalledWith(SESSION_ID);
+    expect(result.current.data).toEqual(SAMPLE_LIVE_SESSION);
+  });
+
+  it('does not fire when enabled is false', () => {
+    renderHook(() => useLiveSession(SESSION_ID, false), {
+      wrapper: createWrapper(),
+    });
+
+    expect(getSessionMock).not.toHaveBeenCalled();
+  });
+
+  it('does not fire when sessionId is empty', () => {
+    renderHook(() => useLiveSession(''), {
+      wrapper: createWrapper(),
+    });
+
+    expect(getSessionMock).not.toHaveBeenCalled();
+  });
+
+  it('surfaces the rejection on a generic API error', async () => {
+    getSessionMock.mockRejectedValue(new Error('Live session service unavailable'));
+
+    const { result } = renderHook(() => useLiveSession(SESSION_ID), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error?.message).toBe('Live session service unavailable');
+  });
+
+  it('maps a "Session not found" rejection to null (401→null client path)', async () => {
+    // api.liveSessions.getSession throws Error('Session not found') when
+    // httpClient.get returns null (the 401 path).
+    getSessionMock.mockRejectedValue(new Error('Session not found'));
+
+    const { result } = renderHook(() => useLiveSession(SESSION_ID), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toBeNull();
+  });
+
+  it('maps a real HTTP 404 (NotFoundError) to null (FSM not-found contract)', async () => {
+    // A genuine 404 surfaces as a NotFoundError (ApiError, statusCode 404) whose
+    // message comes from the backend body — NOT the literal 'Session not found'.
+    getSessionMock.mockRejectedValue(
+      new NotFoundError({ message: 'Live session with ID 1111 was not found' })
+    );
+
+    const { result } = renderHook(() => useLiveSession(SESSION_ID), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toBeNull();
+  });
+});

--- a/apps/web/src/hooks/queries/useLiveSession.ts
+++ b/apps/web/src/hooks/queries/useLiveSession.ts
@@ -1,0 +1,59 @@
+/**
+ * useLiveSession - TanStack Query loader for the canonical LiveGameSession aggregate.
+ *
+ * ADR-083 Fase 1 (Issue #2501): the live session surface (`/sessions/[id]/live`,
+ * `SessionLiveView`) must load `LiveGameSession` (`/api/v1/live-sessions/{id}` →
+ * `LiveSessionDto`), the aggregate the wizards actually create. The previous loader
+ * (`useSession` → `api.sessions.getById` → the empty `GameSession` shell) returned a
+ * 404 for funnel-created sessions, so the surface only ever ran on visual fixtures.
+ *
+ * Mirrors the `useSession` contract (`GameSessionDto | null`) so the FSM in
+ * SessionLiveView keeps the not-found path: `api.liveSessions.getSession` throws
+ * "Session not found" on a 404, which we map to `null` here.
+ */
+
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+
+import { api } from '@/lib/api';
+import { ApiError } from '@/lib/api/core/errors';
+import type { LiveSessionDto } from '@/lib/api/schemas/live-sessions.schemas';
+
+/** Query key factory for live-session queries (distinct from `sessionsKeys`). */
+export const liveSessionKeys = {
+  all: ['liveSessions'] as const,
+  detail: (id: string) => [...liveSessionKeys.all, 'detail', id] as const,
+};
+
+/** Sentinel thrown by `api.liveSessions.getSession` when the session does not exist. */
+const NOT_FOUND_MESSAGE = 'Session not found';
+
+/**
+ * Hook to fetch a single live session by ID.
+ *
+ * @param sessionId - LiveGameSession ID
+ * @param enabled - Whether to run the query (default: true)
+ * @returns UseQueryResult with the LiveSessionDto, or null when the session is not found
+ */
+export function useLiveSession(
+  sessionId: string,
+  enabled: boolean = true
+): UseQueryResult<LiveSessionDto | null, Error> {
+  return useQuery({
+    queryKey: liveSessionKeys.detail(sessionId),
+    queryFn: async (): Promise<LiveSessionDto | null> => {
+      try {
+        return await api.liveSessions.getSession(sessionId);
+      } catch (err) {
+        // Preserve the not-found FSM contract: a missing session is `null`, not an error.
+        // A real HTTP 404 surfaces as a NotFoundError (ApiError, statusCode 404) whose
+        // message comes from the backend body; the 401→null client path makes
+        // getSession throw Error('Session not found'). Both map to the not-found shell.
+        if (err instanceof ApiError && err.statusCode === 404) return null;
+        if (err instanceof Error && err.message === NOT_FOUND_MESSAGE) return null;
+        throw err;
+      }
+    },
+    enabled: enabled && !!sessionId,
+    staleTime: 30 * 1000,
+  });
+}


### PR DESCRIPTION
## Sintesi

**ADR-083 Fase 1** dell'epic #2501. `SessionLiveView` ora carica l'aggregato **canonico `LiveGameSession`** (`/api/v1/live-sessions/{id}` → `LiveSessionDto`) invece del guscio vuoto `GameSession` (`/api/v1/sessions/{id}`), che ritornava **404** per le sessioni create dal funnel reale — per questo la superficie #2354 girava solo su fixtures (`IS_VISUAL_TEST_BUILD`).

Esito: SessionLiveView mostra le sessioni reali del funnel su desktop.

## Modifiche

- **Nuovo hook `useLiveSession`** (TanStack Query) → `api.liveSessions.getSession`. Mappa il not-found su `null` per preservare la FSM `not-found`: copre sia il vero **HTTP 404** (`NotFoundError`, `statusCode 404`) sia il path 401→null del client.
- **`SessionLiveView`**: `useSession` → `useLiveSession`. `composeSessionLiveState` (già progettato per `LiveSessionDto`) consuma il DTO direttamente — i player hanno già `id`/`displayName`, niente più sintesi `id` da `playerName`/`playerOrder`.
- **Rimossa la hydration polimorfica REST** (`scoringType`/`scoreData`/`turnOrderType` da `GameSessionDto`): `LiveSessionDto` è round-based e non espone quei campi; sul funnel reale erano **sempre `undefined`** (guscio vuoto), quindi gli effect non giravano mai in produzione. Lo store scoring resta consumato (selettori endgame + turn) e popolabile via SignalR.

## Conseguenza su #2389/#2483

Lo scoring polimorfico (Points/Ranking/BinaryWin/Objectives) shippato di recente in `SessionLiveView` va **ri-orientato ai play-records storici** (dove `SessionTracking` è la source of truth), non mantenuto sul path live — coerente con la decisione owner (scoring live round-based).

## Out of scope (Fase 2)

- chat/diary/media su `/live-sessions/*` (assorbe #2500 + #2503)
- realignment SSE (`useSessionLiveStream` punta ancora a `/game-sessions/{id}/stream/v2`)
- wiring round-based scoring da `LiveSessionDto.roundScores`/`scoringConfig`
- derivazione `viewerRole` reale
- unificazione layout↔view per eliminare la doppia fetch (layout Zustand store + view TanStack)

## Code review

Code review adversariale → **1 bug critico fixato**: il mapping not-found intercettava solo `Error('Session not found')` (path 401), ma un vero 404 throwerebbe `NotFoundError` con message dal body → sarebbe finito in FSM `error` invece di `not-found`. Fix: catch su `ApiError.statusCode === 404`. Aggiunto test che riproduce il 404 reale + completato il fixture `LiveSessionDto`.

## Verifica

- **87 test** (7 `useLiveSession` + 80 `SessionLiveView`), TDD red→green
- **578** test correlati (`session-live` + `hooks/queries`) verdi
- typecheck pulito · ESLint 0 errori

🤖 Generated with [Claude Code](https://claude.com/claude-code)