### PR TITLE
fix(pdf-indexing): align chunked-upload zero-chunk handling to Failed state

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/CompleteChunkedUploadCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/CompleteChunkedUploadCommandHandler.cs
@@ -433,7 +433,7 @@ internal class CompleteChunkedUploadCommandHandler : ICommandHandler<CompleteChu
     /// Triggers asynchronous PDF processing after chunked upload completion.
     /// Orchestrates extraction, chunking, embedding generation, and indexing.
     /// </summary>
-    private async Task TriggerPdfProcessingAsync(string pdfId, string filePath, CancellationToken cancellationToken)
+    internal async Task TriggerPdfProcessingAsync(string pdfId, string filePath, CancellationToken cancellationToken)
     {
         using var scope = _scopeFactory.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
@@ -465,6 +465,32 @@ internal class CompleteChunkedUploadCommandHandler : ICommandHandler<CompleteChu
             // Step 2: Chunk text for embedding
             var allDocumentChunks = await ChunkTextContentAsync(
                 pdfId, fullText!, scope).ConfigureAwait(false);
+
+            // Guard: zero usable chunks → mark Failed. Mirrors PdfProcessingPipelineService
+            // (the non-chunked Quartz path) which fails on chunks.Count == 0. Without this,
+            // embedding/index become no-ops and the PDF would reach Ready with no indexed
+            // content — an unusable RAG state and an asymmetry with the other pipeline.
+            if (allDocumentChunks.Count == 0)
+            {
+                _logger.LogWarning("No usable chunks produced for chunked upload {PdfId}, marking as failed", pdfId);
+                pdfDoc.ProcessingState = nameof(PdfProcessingState.Failed);
+                pdfDoc.ProcessingError = "Text extraction produced no usable chunks";
+                pdfDoc.ProcessedAt = _timeProvider.GetUtcNow().UtcDateTime;
+                try
+                {
+                    await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+                }
+                catch (DbUpdateConcurrencyException ex)
+                {
+                    MeepleAiMetrics.RecordPdfConcurrencyConflict(
+                        nameof(CompleteChunkedUploadCommandHandler),
+                        MeepleAiMetrics.PdfConcurrencyCategories.B);
+                    _logger.LogWarning(ex,
+                        "Concurrency conflict on PdfDocument {PdfId} in {Handler} (Category B) — admin mutation wins, pipeline will re-read on next tick",
+                        pdfId, nameof(CompleteChunkedUploadCommandHandler));
+                }
+                return;
+            }
 
             // Step 3: Generate embeddings
             var (embeddingsSuccess, embeddings) = await GenerateEmbeddingsAsync(

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Commands/CompleteChunkedUploadCommandHandlerZeroChunkTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Commands/CompleteChunkedUploadCommandHandlerZeroChunkTests.cs
@@ -29,6 +29,7 @@ namespace Api.Tests.BoundedContexts.DocumentProcessing.Application.Commands;
 /// zero chunks => Failed.
 /// </summary>
 [Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "DocumentProcessing")]
 public class CompleteChunkedUploadCommandHandlerZeroChunkTests
 {
     [Fact]

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Commands/CompleteChunkedUploadCommandHandlerZeroChunkTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Commands/CompleteChunkedUploadCommandHandlerZeroChunkTests.cs
@@ -1,0 +1,130 @@
+using Api.BoundedContexts.DocumentProcessing.Application.Commands;
+using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
+using Api.BoundedContexts.DocumentProcessing.Domain.Repositories;
+using Api.BoundedContexts.DocumentProcessing.Infrastructure.External;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Services;
+using Api.Services.Pdf;
+using Api.Tests.Constants;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.DocumentProcessing.Application.Commands;
+
+/// <summary>
+/// Regression test for the chunked-upload "zero chunk" asymmetry bug.
+///
+/// The Quartz path (PdfProcessingPipelineService) marks a PDF Failed when text
+/// extraction yields zero usable chunks. The chunked-upload path
+/// (CompleteChunkedUploadCommandHandler.TriggerPdfProcessingAsync) historically
+/// lacked the equivalent guard: with zero chunks the empty-embedding mismatch
+/// check (0 == 0) passed, indexing was a no-op, and the PDF reached Ready with no
+/// indexed content — an unusable RAG state. This test pins the aligned behavior:
+/// zero chunks => Failed.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+public class CompleteChunkedUploadCommandHandlerZeroChunkTests
+{
+    [Fact]
+    public async Task TriggerPdfProcessing_WhenZeroChunksProduced_MarksPdfFailed()
+    {
+        // Arrange ----------------------------------------------------------------
+        var db = TestDbContextFactory.CreateInMemoryDbContext();
+
+        var pdfId = Guid.NewGuid();
+        var entity = new PdfDocumentEntity
+        {
+            Id = pdfId,
+            SharedGameId = Guid.NewGuid(),
+            UploadedByUserId = Guid.NewGuid(),
+            FileName = "test.pdf",
+            FilePath = "/test/test.pdf",
+            FileSizeBytes = 1024,
+            ContentType = "application/pdf",
+            UploadedAt = DateTime.UtcNow,
+            ProcessingState = nameof(PdfProcessingState.Extracting)
+        };
+        db.PdfDocuments.Add(entity);
+        await db.SaveChangesAsync();
+
+        // The method opens the file with a real FileStream, so a real temp file
+        // must exist on disk.
+        var tmp = Path.GetTempFileName();
+        await File.WriteAllTextAsync(tmp, "dummy pdf bytes");
+
+        try
+        {
+            // Chunking yields ZERO usable chunks — this is the bug scenario.
+            var chunkingMock = new Mock<ITextChunkingService>();
+            chunkingMock
+                .Setup(c => c.PrepareForEmbedding(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
+                .Returns(new List<DocumentChunkInput>());
+
+            // Embedding returns an empty (successful) result. Without the fix the
+            // pipeline reaches here, the count mismatch check (0 == 0) passes, and
+            // the PDF wrongly advances to Ready.
+            var embeddingMock = new Mock<IEmbeddingService>();
+            embeddingMock
+                .Setup(e => e.GenerateEmbeddingsAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(EmbeddingResult.CreateSuccess(new List<float[]>()));
+
+            // Text extraction succeeds with a single non-empty page.
+            var extractorMock = new Mock<IPdfTextExtractor>();
+            extractorMock
+                .Setup(e => e.ExtractPagedTextAsync(It.IsAny<Stream>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(PagedTextExtractionResult.CreateSuccess(
+                    new[] { new PageTextChunk(1, "extracted text", 0, 14) },
+                    totalPages: 1,
+                    totalCharacters: 14,
+                    ocrTriggered: false));
+
+            // Structured-content extraction fails (Success=false) so the method
+            // returns without serializing tables/diagrams.
+            var tableExtractorMock = new Mock<IPdfTableExtractor>();
+            tableExtractorMock
+                .Setup(t => t.ExtractStructuredContentAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(StructuredContentResult.CreateFailure("no structured content in test"));
+
+            // Real scope provider supplying the services TriggerPdfProcessingAsync
+            // resolves via the scope. IPdfIndexingPipeline is intentionally NOT
+            // registered: with zero chunks the internal guard returns before it is
+            // resolved.
+            var sc = new ServiceCollection();
+            sc.AddSingleton(db); // MeepleAiDbContext — same instance for the assert
+            sc.AddSingleton(chunkingMock.Object);
+            sc.AddSingleton(embeddingMock.Object);
+            var provider = sc.BuildServiceProvider();
+            var scopeFactory = provider.GetRequiredService<IServiceScopeFactory>();
+
+            var handler = new CompleteChunkedUploadCommandHandler(
+                Mock.Of<IChunkedUploadSessionRepository>(),
+                db,
+                Mock.Of<IBlobStorageService>(),
+                Mock.Of<IBackgroundTaskService>(),
+                NullLogger<CompleteChunkedUploadCommandHandler>.Instance,
+                scopeFactory,
+                extractorMock.Object,
+                tableExtractorMock.Object,
+                Mock.Of<IMediator>(),
+                TimeProvider.System);
+
+            // Act --------------------------------------------------------------------
+            await handler.TriggerPdfProcessingAsync(pdfId.ToString(), tmp, CancellationToken.None);
+
+            // Assert -----------------------------------------------------------------
+            var updated = await db.PdfDocuments.FindAsync(pdfId);
+            updated!.ProcessingState.Should().Be(nameof(PdfProcessingState.Failed));
+            updated.ProcessingError.Should().Contain("no usable chunks");
+        }
+        finally
+        {
+            File.Delete(tmp);
+        }
+    }
+}


### PR DESCRIPTION
## Cosa

Allinea il path di **chunked upload** al path **Quartz** sullo scenario "zero chunk", correggendo un'asimmetria comportamentale emersa dalla code review della PR #2509.

## Il bug

`PdfProcessingPipelineService` (path Quartz) marca un PDF **`Failed`** quando l'estrazione produce zero chunk usabili (`chunks.Count == 0`, righe 186-191). Il path di chunked upload (`CompleteChunkedUploadCommandHandler.TriggerPdfProcessingAsync`) **non aveva il guard equivalente**: con zero chunk, il check di mismatch sugli embedding vuoti (0 == 0) passava, l'indicizzazione era un no-op, e il PDF raggiungeva **`Ready` senza alcun contenuto indicizzato** — uno stato RAG inutilizzabile.

## Fix

- Guard `allDocumentChunks.Count == 0` subito dopo il chunking → marca `Failed` con `"Text extraction produced no usable chunks"` (stesso messaggio e semantica del path Quartz). Usa il pattern `Failed` inline + gestione `DbUpdateConcurrencyException` (Category B) già presente 3 volte nel file.
- `TriggerPdfProcessingAsync` esposto come `internal` per testabilità (`InternalsVisibleTo "Api.Tests"` già configurato).
- Il guard interno preesistente in `UpdateOrCreateVectorDocumentAsync` (`indexedCount <= 0`) resta come difesa in profondità.

## Test (TDD)

Nuovo unit test `CompleteChunkedUploadCommandHandlerZeroChunkTests` (InMemory DbContext, **nessun Docker**):
- **RED** verificato sul codice pre-fix: `ProcessingState == "Ready"` (≠ atteso `"Failed"`) → il test cattura il bug.
- **GREEN** col fix: zero chunk → `Failed` + `ProcessingError` contiene `"no usable chunks"`.

## Verifica

- ✅ Build prod `apps/api/src/Api`: 0 errori / 0 warning
- ✅ Cluster `Category=Unit & DocumentProcessing`: 1323 passed, 0 failed, 1 skipped — zero regressioni
- ✅ Nuovo test eseguito singolarmente: passed

Refs: code review PR #2509 (asimmetria pre-esistente, fuori scope lì).
