### PR TITLE
feat(setup-guide): #2504 wire RAG retrieval + propagate playerCount

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/StreamSetupGuideQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/StreamSetupGuideQueryHandler.cs
@@ -1,4 +1,7 @@
 using Api.BoundedContexts.KnowledgeBase.Application.Queries;
+using Api.BoundedContexts.KnowledgeBase.Domain.Entities;
+using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
+using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
 using Api.Models;
 using Api.Services;
 using Api.SharedKernel.Application.Interfaces;
@@ -23,11 +26,17 @@ namespace Api.BoundedContexts.KnowledgeBase.Application.Queries;
 internal class StreamSetupGuideQueryHandler : IStreamingQueryHandler<StreamSetupGuideQuery, RagStreamingEvent>
 {
     private readonly IEmbeddingService _embeddingService;
+    private readonly IEmbeddingRepository _embeddingRepository;
     private readonly ILlmService _llmService;
     private readonly IPromptTemplateService _promptTemplateService;
     private readonly IConfiguration _configuration;
     private readonly ILogger<StreamSetupGuideQueryHandler> _logger;
     private readonly TimeProvider _timeProvider;
+
+    // ADR-083 Fase 1 (#2504): setup-guide RAG retrieval tuning. Mirrors the QA
+    // agent's hybrid defaults so the LLM receives real rulebook context.
+    private const int SetupSearchTopK = 5;
+    private const double SetupSearchMinScore = 0.55;
 
     /// <summary>
     /// ADMIN-01 Phase 3: Hardcoded fallback prompt for backward compatibility
@@ -52,6 +61,7 @@ STEP 2: <title>
 etc.";
     public StreamSetupGuideQueryHandler(
         IEmbeddingService embeddingService,
+        IEmbeddingRepository embeddingRepository,
         ILlmService llmService,
         IPromptTemplateService promptTemplateService,
         IConfiguration configuration,
@@ -59,6 +69,7 @@ etc.";
         TimeProvider? timeProvider = null)
     {
         _embeddingService = embeddingService ?? throw new ArgumentNullException(nameof(embeddingService));
+        _embeddingRepository = embeddingRepository ?? throw new ArgumentNullException(nameof(embeddingRepository));
         _llmService = llmService ?? throw new ArgumentNullException(nameof(llmService));
         _promptTemplateService = promptTemplateService ?? throw new ArgumentNullException(nameof(promptTemplateService));
         _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
@@ -210,13 +221,53 @@ etc.";
     /// Searches for setup-related context chunks.
     /// Returns (success, context, references, confidence).
     /// </summary>
-    private Task<(bool success, string? context, List<Snippet>? references, double? confidence)> SearchSetupContextAsync(
+    private async Task<(bool success, string? context, List<Snippet>? references, double? confidence)> SearchSetupContextAsync(
         string gameId,
         float[] queryEmbedding,
         CancellationToken cancellationToken)
     {
-        _logger.LogInformation("No RAG results for game {GameId}  (legacy path) using default steps", gameId);
-        return Task.FromResult<(bool, string?, List<Snippet>?, double?)>((false, null, null, null));
+        // ADR-083 Fase 1 (#2504): retrieve setup-related chunks from pgvector
+        // (mirrors the QA agent's vector path). Empty results fall back to default
+        // steps, so a game with no indexed KB still yields a generic guide.
+        if (!Guid.TryParse(gameId, out var gameGuid))
+        {
+            _logger.LogWarning("Setup guide: gameId {GameId} is not a valid GUID, using default steps", gameId);
+            return (false, null, null, null);
+        }
+
+        var embeddings = await _embeddingRepository.SearchByVectorAsync(
+            gameGuid,
+            new Vector(queryEmbedding),
+            SetupSearchTopK,
+            SetupSearchMinScore,
+            documentIds: null,
+            cancellationToken).ConfigureAwait(false);
+
+        if (embeddings == null || embeddings.Count == 0)
+        {
+            _logger.LogInformation("No RAG results for game {GameId}, using default steps", gameId);
+            return (false, null, null, null);
+        }
+
+        // Build citation snippets + context string (same shape the QA agent uses).
+        // pgvector already ranked/filtered by minScore, so we use a rank-based score.
+        var snippets = embeddings
+            .Select((e, index) => new Snippet(
+                e.TextContent,
+                $"PDF:{e.VectorDocumentId}",
+                e.PageNumber,
+                0,
+                (float)Math.Max(SetupSearchMinScore, 1.0 - (index * 0.05))))
+            .ToList();
+
+        var context = string.Join("\n\n", snippets.Select(s => $"[Page {s.page}] {s.text}"));
+        var confidence = Math.Max(SetupSearchMinScore, 1.0 - ((embeddings.Count - 1) * 0.05));
+
+        _logger.LogInformation(
+            "Setup guide RAG search returned {Count} chunks for game {GameId}",
+            embeddings.Count, gameId);
+
+        return (true, context, snippets, confidence);
     }
 
     /// <summary>

--- a/apps/api/src/Api/Models/Contracts.cs
+++ b/apps/api/src/Api/Models/Contracts.cs
@@ -325,7 +325,8 @@ internal record FollowUpQuestionClickEvent(
 );
 
 // AI-03: RAG Setup Guide models
-internal record SetupGuideRequest(string gameId, Guid? chatId = null);
+// #2504: playerCount (0 = generic setup, >0 = guide adapted to the player count).
+internal record SetupGuideRequest(string gameId, Guid? chatId = null, int playerCount = 0);
 internal record SetupGuideResponse(
     string gameTitle,
     IReadOnlyList<SetupGuideStep> steps,

--- a/apps/api/src/Api/Routing/AiEndpoints.cs
+++ b/apps/api/src/Api/Routing/AiEndpoints.cs
@@ -561,6 +561,14 @@ internal static class AiEndpoints
             return Results.BadRequest(new { error = "gameId is required" });
         }
 
+        // #2504: validate GUID format up-front, mirroring /agents/qa. Without this,
+        // a malformed gameId silently degraded to generic default steps (HTTP 200)
+        // instead of surfacing a 400 — masking frontend integration bugs.
+        if (!Guid.TryParse(req.gameId, out _))
+        {
+            return Results.BadRequest(new { error = "Invalid game ID format" });
+        }
+
         var startTime = DateTime.UtcNow;
         logger.LogInformation("Setup guide streaming request from user {UserId} for game {GameId}",
             session.Principal!.Subject.Id, req.gameId);
@@ -574,7 +582,7 @@ internal static class AiEndpoints
 
         try
         {
-            var query = new StreamSetupGuideQuery(req.gameId);
+            var query = new StreamSetupGuideQuery(req.gameId, req.playerCount);
             await ExecuteSetupGuideStreamingAsync(query, context, mediator, streamContext, ct).ConfigureAwait(false);
 
             logger.LogInformation("Setup guide streaming completed for game {GameId}, {StepCount} steps, estimated {Minutes} min",

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/StreamSetupGuideQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/StreamSetupGuideQueryHandlerTests.cs
@@ -1,5 +1,8 @@
 using Api.BoundedContexts.KnowledgeBase.Application.Commands;
 using Api.BoundedContexts.KnowledgeBase.Application.Queries;
+using Api.BoundedContexts.KnowledgeBase.Domain.Entities;
+using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
+using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
 using Api.Models;
 using Api.Services;
 using Microsoft.Extensions.Configuration;
@@ -21,6 +24,7 @@ namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Handlers;
 public class StreamSetupGuideQueryHandlerTests
 {
     private readonly Mock<IEmbeddingService> _embeddingServiceMock;
+    private readonly Mock<IEmbeddingRepository> _embeddingRepositoryMock;
     private readonly Mock<ILlmService> _llmServiceMock;
     private readonly Mock<IPromptTemplateService> _promptTemplateServiceMock;
     private readonly IConfiguration _configuration;
@@ -31,6 +35,18 @@ public class StreamSetupGuideQueryHandlerTests
     public StreamSetupGuideQueryHandlerTests()
     {
         _embeddingServiceMock = new Mock<IEmbeddingService>();
+        _embeddingRepositoryMock = new Mock<IEmbeddingRepository>();
+        // Default: no RAG context (empty search). Tests that exercise the LLM path
+        // override this via SetupVectorSearchMock.
+        _embeddingRepositoryMock
+            .Setup(x => x.SearchByVectorAsync(
+                It.IsAny<Guid>(),
+                It.IsAny<Vector>(),
+                It.IsAny<int>(),
+                It.IsAny<double>(),
+                It.IsAny<IReadOnlyList<Guid>?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<Embedding>());
         _llmServiceMock = new Mock<ILlmService>();
         _promptTemplateServiceMock = new Mock<IPromptTemplateService>();
         _loggerMock = new Mock<ILogger<StreamSetupGuideQueryHandler>>();
@@ -42,6 +58,7 @@ public class StreamSetupGuideQueryHandlerTests
 
         _handler = new StreamSetupGuideQueryHandler(
             _embeddingServiceMock.Object,
+            _embeddingRepositoryMock.Object,
             _llmServiceMock.Object,
             _promptTemplateServiceMock.Object,
             _configuration,
@@ -49,10 +66,41 @@ public class StreamSetupGuideQueryHandlerTests
             _fakeTimeProvider
         );
     }
-    [Fact]
-    public async Task Handle_ValidGameId_StreamsSetupSteps()
+
+    /// <summary>
+    /// ADR-083 Fase 1 (#2504): configure pgvector to return setup chunks so the
+    /// handler reaches the LLM path (instead of the default-steps fallback).
+    /// </summary>
+    private void SetupVectorSearchMock(string gameId, params string[] chunkTexts)
     {
-        // Arrange
+        var embeddings = chunkTexts
+            .Select((text, i) => new Embedding(
+                Guid.NewGuid(),
+                Guid.NewGuid(),
+                text,
+                new Vector(new float[] { 0.1f, 0.2f, 0.3f }),
+                "test-model",
+                chunkIndex: i,
+                pageNumber: i + 1))
+            .ToList();
+
+        _embeddingRepositoryMock
+            .Setup(x => x.SearchByVectorAsync(
+                It.IsAny<Guid>(),
+                It.IsAny<Vector>(),
+                It.IsAny<int>(),
+                It.IsAny<double>(),
+                It.IsAny<IReadOnlyList<Guid>?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(embeddings);
+    }
+    [Fact]
+    public async Task Handle_NonGuidGameId_FallsBackToDefaultSteps()
+    {
+        // ADR-083 Fase 1 (#2504): a non-GUID gameId fails the pgvector lookup guard
+        // (Guid.TryParse in SearchSetupContextAsync) and falls back to the 5 default
+        // steps. The RAG/LLM path for a valid gameId is covered by the
+        // Handle_VectorSearchReturnsResults_* tests above.
         var gameId = "game123";
         var query = new StreamSetupGuideQuery(gameId);
 
@@ -92,6 +140,61 @@ public class StreamSetupGuideQueryHandlerTests
         completeEvent.Should().NotBeNull();
         var complete = completeEvent.Data.Should().BeOfType<StreamingComplete>().Which;
         (complete.estimatedReadingTimeMinutes >= 5).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Handle_VectorSearchReturnsResults_CallsLlmWithRetrievedContext()
+    {
+        // ADR-083 Fase 1 (#2504): when pgvector returns setup chunks, the handler
+        // must call the LLM with that retrieved context (not fall back to default steps).
+        var gameId = Guid.NewGuid().ToString();
+        var query = new StreamSetupGuideQuery(gameId);
+
+        SetupEmbeddingMock();
+        SetupVectorSearchMock(gameId, "Place the board in the center and shuffle the deck.");
+        SetupLlmMock("STEP 1: Place the Board\nPut the game board in the center.");
+
+        var events = new List<RagStreamingEvent>();
+        await foreach (var evt in _handler.Handle(query, TestContext.Current.CancellationToken))
+        {
+            events.Add(evt);
+        }
+
+        // The LLM was called with the retrieved chunk text embedded in the user prompt.
+        _llmServiceMock.Verify(
+            x => x.GenerateCompletionAsync(
+                It.IsAny<string>(),
+                It.Is<string>(p => p.Contains("Place the board in the center")),
+                It.IsAny<RequestSource>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_VectorSearchResults_WithPlayerCount_IncludesPlayerCountInstruction()
+    {
+        // ADR-083 Fase 1 (#2504): the player count must reach the LLM prompt so the
+        // guide adapts to 4 players. Only reachable once the RAG context exists.
+        var gameId = Guid.NewGuid().ToString();
+        var query = new StreamSetupGuideQuery(gameId, PlayerCount: 4);
+
+        SetupEmbeddingMock();
+        SetupVectorSearchMock(gameId, "Setup varies by the number of players.");
+        SetupLlmMock("STEP 1: Setup\nPrepare for the players.");
+
+        var events = new List<RagStreamingEvent>();
+        await foreach (var evt in _handler.Handle(query, TestContext.Current.CancellationToken))
+        {
+            events.Add(evt);
+        }
+
+        _llmServiceMock.Verify(
+            x => x.GenerateCompletionAsync(
+                It.IsAny<string>(),
+                It.Is<string>(p => p.Contains("PLAYER COUNT: 4 players")),
+                It.IsAny<RequestSource>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 
     [Fact]
@@ -411,6 +514,7 @@ public class StreamSetupGuideQueryHandlerTests
         var configWithPromptDb = CreateConfiguration(promptDatabaseEnabled: true);
         var handlerWithPromptDb = new StreamSetupGuideQueryHandler(
             _embeddingServiceMock.Object,
+            _embeddingRepositoryMock.Object,
             _llmServiceMock.Object,
             _promptTemplateServiceMock.Object,
             configWithPromptDb,
@@ -488,6 +592,7 @@ public class StreamSetupGuideQueryHandlerTests
         var configWithPromptDb = CreateConfiguration(promptDatabaseEnabled: true);
         var handlerWithPromptDb = new StreamSetupGuideQueryHandler(
             _embeddingServiceMock.Object,
+            _embeddingRepositoryMock.Object,
             _llmServiceMock.Object,
             _promptTemplateServiceMock.Object,
             configWithPromptDb,


### PR DESCRIPTION
## Sintesi

Issue **#2504** (ADR-083 Fase 1, dipendenza #2502). L'endpoint `/agents/setup` ora **propaga `playerCount`** e il setup guide usa il **retrieval pgvector reale** invece dello stub.

### Finding chiave (verificato)

`SearchSetupContextAsync` era uno **stub** (`return (false, null, null, null)` — "legacy path"): il setup guide ritornava **sempre i 5 default steps**, il LLM non veniva **mai** chiamato, e `playerCount` (anche se propagato) era **inerte**. Quindi il solo wiring di `playerCount` non avrebbe soddisfatto l'AC «la guida varia tra 2 e 4 giocatori».

## Modifiche

- **`SearchSetupContextAsync` ricablato** su pgvector: `IEmbeddingRepository.SearchByVectorAsync(gameId, vector, topK=5, minScore=0.55)`, come il QA agent. Costruisce il `context` (`[Page N] testo`) + le `Snippet` citations. Empty/parse-fail → fallback ai default steps (comportamento invariato).
- **`SetupGuideRequest` + `playerCount`** (default 0); l'endpoint propaga a `StreamSetupGuideQuery`.
- **Validazione GUID nell'endpoint** `/agents/setup` (400 su `gameId` malformato), allineandosi a `/agents/qa` — prima degradava silenziosamente a default steps con 200 (code review).
- Con risultati RAG → LLM chiamato con `context` + (se `playerCount>0`) le istruzioni player-count → la guida si adatta a 2/4 giocatori.

## Acceptance criteria

- [x] Il DTO di `/agents/setup` accetta `playerCount`.
- [x] L'endpoint propaga `playerCount` a `StreamSetupGuideQuery`.
- [~] La guida varia in modo osservabile tra 2 e 4 giocatori — **codice pronto**; l'osservabilità end-to-end richiede una **KB Ready** (issue **#2502**, snapshot bake). Senza KB indicizzata, il fallback ai default steps è invariato.

## Verifica

- **19 test** (`StreamSetupGuideQueryHandlerTests`): 17 aggiornati + 2 nuovi (search→LLM con context; `+playerCount` nel prompt). `dotnet test` verde, build pulito (analyzer S-rules).
- Nessuna altra istanziazione del handler (MediatR auto-DI risolve `IEmbeddingRepository`). Consumer interno `GenerateSetupChecklistCommandHandler` mocka `IMediator` → non impattato.

## Code review

Adversariale → 2 fix applicati: (1) validazione GUID endpoint; (2) rinominato il test fallback non-GUID (`Handle_NonGuidGameId_FallsBackToDefaultSteps`) — il path RAG è coperto dai 2 nuovi test con GUID validi.

## Note

Backend-only. Pre-commit: typecheck FE verde (no FE changes). Verifica RAG end-to-end reale dipende da #2502 (Docker + KB indicizzata, non disponibili in locale).

🤖 Generated with [Claude Code](https://claude.com/claude-code)