### PR TITLE
feat(seed): #2502 e2e.yml KB-Ready seed manifest + CI bake validation

### DIFF
--- a/.github/workflows/seed-snapshot-bake-ci.yml
+++ b/.github/workflows/seed-snapshot-bake-ci.yml
@@ -1,4 +1,4 @@
-name: Seed Snapshot Bake (CI smoke — ci.yml + e2e.yml manifests)
+name: Seed Snapshot Bake (CI smoke — ci.yml manifest)
 
 # Tier 2 D4 of #2126 — Seed snapshot freshness pipeline.
 #
@@ -180,77 +180,3 @@ jobs:
           EOF
           chmod 600 secrets/storage.secret
           bash scripts/seed-index-publish.sh
-
-  # ──────────────────────────────────────────────────────────────────────
-  # #2502: bake the e2e.yml manifest (single game — Love Letter) so the E2E
-  # suite has a guaranteed KB-Ready game. Runs on its own ubuntu runner with
-  # its own postgres/compose stack, so it does NOT clobber bake-ci-smoke.
-  # ──────────────────────────────────────────────────────────────────────
-  bake-e2e-smoke:
-    name: Bake e2e.yml (1 PDF) + verify gates
-    runs-on: ubuntu-latest
-    timeout-minutes: 25
-
-    env:
-      SEED_CATALOG_MANIFEST_OVERRIDE: e2e
-      SEED_INDEX_TIMEOUT: '1500'
-      SEED_INDEX_POLL: '10'
-      SEED_INDEX_FAILURE_PCT: '0' # the single e2e game MUST reach Ready
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Verify e2e.yml manifest is present and minimal
-        run: |
-          set -euo pipefail
-          MANIFEST=apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/e2e.yml
-          test -f "$MANIFEST" || { echo "::error::missing $MANIFEST"; exit 1; }
-          PDF_COUNT=$(grep -cE '^\s*pdfBlobKey:' "$MANIFEST" || true)
-          echo "e2e.yml declares $PDF_COUNT PDF(s)"
-          if [ "$PDF_COUNT" -lt 1 ]; then
-            echo "::error::e2e.yml must declare at least one game with a pdfBlobKey"
-            exit 1
-          fi
-          # Keep the E2E seed minimal so this stays a fast smoke.
-          if [ "$PDF_COUNT" -gt 3 ]; then
-            echo "::error::e2e.yml has grown to $PDF_COUNT PDFs — keep the E2E seed minimal (cap 3)"
-            exit 1
-          fi
-
-      - name: Install jq (required by seed scripts)
-        run: sudo apt-get update && sudo apt-get install -y jq
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
-
-      - name: Run bake
-        working-directory: infra
-        env:
-          SEED_INDEX_OUT_DIR: ${{ github.workspace }}/data/snapshots
-        run: |
-          mkdir -p "$SEED_INDEX_OUT_DIR"
-          make seed-index
-
-      - name: Run verify gates (exit codes 2/3/4/5/6)
-        working-directory: infra
-        env:
-          SEED_INDEX_OUT_DIR: ${{ github.workspace }}/data/snapshots
-        run: bash scripts/snapshot-verify.sh
-
-      - name: Surface seed-status
-        working-directory: infra
-        env:
-          SEED_INDEX_OUT_DIR: ${{ github.workspace }}/data/snapshots
-        run: bash scripts/seed-status.sh || true
-
-      - name: Upload sidecar as workflow artifact (14-day retention)
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: seed-snapshot-e2e-meta-${{ github.run_id }}
-          path: |
-            data/snapshots/*.meta.json
-            data/snapshots/.latest
-          retention-days: 14
-          if-no-files-found: warn

--- a/.github/workflows/seed-snapshot-bake-ci.yml
+++ b/.github/workflows/seed-snapshot-bake-ci.yml
@@ -1,4 +1,4 @@
-name: Seed Snapshot Bake (CI smoke — ci.yml manifest)
+name: Seed Snapshot Bake (CI smoke — ci.yml + e2e.yml manifests)
 
 # Tier 2 D4 of #2126 — Seed snapshot freshness pipeline.
 #
@@ -180,3 +180,77 @@ jobs:
           EOF
           chmod 600 secrets/storage.secret
           bash scripts/seed-index-publish.sh
+
+  # ──────────────────────────────────────────────────────────────────────
+  # #2502: bake the e2e.yml manifest (single game — Love Letter) so the E2E
+  # suite has a guaranteed KB-Ready game. Runs on its own ubuntu runner with
+  # its own postgres/compose stack, so it does NOT clobber bake-ci-smoke.
+  # ──────────────────────────────────────────────────────────────────────
+  bake-e2e-smoke:
+    name: Bake e2e.yml (1 PDF) + verify gates
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    env:
+      SEED_CATALOG_MANIFEST_OVERRIDE: e2e
+      SEED_INDEX_TIMEOUT: '1500'
+      SEED_INDEX_POLL: '10'
+      SEED_INDEX_FAILURE_PCT: '0' # the single e2e game MUST reach Ready
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Verify e2e.yml manifest is present and minimal
+        run: |
+          set -euo pipefail
+          MANIFEST=apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/e2e.yml
+          test -f "$MANIFEST" || { echo "::error::missing $MANIFEST"; exit 1; }
+          PDF_COUNT=$(grep -cE '^\s*pdfBlobKey:' "$MANIFEST" || true)
+          echo "e2e.yml declares $PDF_COUNT PDF(s)"
+          if [ "$PDF_COUNT" -lt 1 ]; then
+            echo "::error::e2e.yml must declare at least one game with a pdfBlobKey"
+            exit 1
+          fi
+          # Keep the E2E seed minimal so this stays a fast smoke.
+          if [ "$PDF_COUNT" -gt 3 ]; then
+            echo "::error::e2e.yml has grown to $PDF_COUNT PDFs — keep the E2E seed minimal (cap 3)"
+            exit 1
+          fi
+
+      - name: Install jq (required by seed scripts)
+        run: sudo apt-get update && sudo apt-get install -y jq
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
+
+      - name: Run bake
+        working-directory: infra
+        env:
+          SEED_INDEX_OUT_DIR: ${{ github.workspace }}/data/snapshots
+        run: |
+          mkdir -p "$SEED_INDEX_OUT_DIR"
+          make seed-index
+
+      - name: Run verify gates (exit codes 2/3/4/5/6)
+        working-directory: infra
+        env:
+          SEED_INDEX_OUT_DIR: ${{ github.workspace }}/data/snapshots
+        run: bash scripts/snapshot-verify.sh
+
+      - name: Surface seed-status
+        working-directory: infra
+        env:
+          SEED_INDEX_OUT_DIR: ${{ github.workspace }}/data/snapshots
+        run: bash scripts/seed-status.sh || true
+
+      - name: Upload sidecar as workflow artifact (14-day retention)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: seed-snapshot-e2e-meta-${{ github.run_id }}
+          path: |
+            data/snapshots/*.meta.json
+            data/snapshots/.latest
+          retention-days: 14
+          if-no-files-found: warn

--- a/apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/e2e.yml
+++ b/apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/e2e.yml
@@ -13,7 +13,9 @@
 # `seedAgent: true` provisions the chat agent so RAG/setup-guide E2E flows
 # (citations #2500, setup guide #2504) have a working agent for this game.
 #
-# Validated in CI by the `bake-e2e-smoke` job in seed-snapshot-bake-ci.yml.
+# Loadability/shape validated by CatalogSeederManifestOverrideTests (Backend Fast).
+# The bake itself requires infra/secrets — run in dev/staging, not CI (see
+# docs/for-developers/testing/e2e-kb-ready-seed.md).
 version: 1
 profile: dev
 catalog:

--- a/apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/e2e.yml
+++ b/apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/e2e.yml
@@ -1,0 +1,42 @@
+# E2E seed manifest — issue #2502.
+#
+# Single game with a real rulebook PDF (Love Letter, reused from ci.yml: the
+# blob + sha256 are already verified by the CI bake). When baked it reaches
+# PdfProcessingState.Ready (chunks + embeddings in pgvector), giving the E2E
+# suite a guaranteed KB-Ready game for the live-session user story (#2506)
+# without depending on a slow full bake.
+#
+# Usage:
+#   bake:    SEED_CATALOG_MANIFEST_OVERRIDE=e2e make seed-index   (infra/)
+#   consume: make dev-from-snapshot                               (SKIP_CATALOG_SEED=true)
+#
+# `seedAgent: true` provisions the chat agent so RAG/setup-guide E2E flows
+# (citations #2500, setup guide #2504) have a working agent for this game.
+#
+# Validated in CI by the `bake-e2e-smoke` job in seed-snapshot-bake-ci.yml.
+version: 1
+profile: dev
+catalog:
+  games:
+  - title: Love Letter
+    bggId: 129622
+    language: en
+    yearPublished: 2012
+    minPlayers: 2
+    maxPlayers: 4
+    playingTime: 20
+    minAge: 10
+    averageRating: 7.23
+    averageWeight: 1.18
+    publishers:
+    - Z-Man Games
+    pdfBlobKey: rulebooks/v1/love-letter_rulebook.pdf
+    pdfSha256: e6b14614ffa5da73d995eaceefd7ca99e20ea8687b873da9b67ce6f3a5e69655
+    pdfVersion: '1.0'
+    seedAgent: true
+  # seedAgent=true requires a defaultAgent section (manifest validation).
+  defaultAgent:
+    name: MeepleAssistant POC
+    model: anthropic/claude-3-haiku
+    temperature: 0.3
+    maxTokens: 2048

--- a/apps/api/tests/Api.Tests/Infrastructure/Seeders/Catalog/CatalogSeederManifestOverrideTests.cs
+++ b/apps/api/tests/Api.Tests/Infrastructure/Seeders/Catalog/CatalogSeederManifestOverrideTests.cs
@@ -31,6 +31,25 @@ public sealed class CatalogSeederManifestOverrideTests
     }
 
     [Fact]
+    public void LoadManifest_WithE2eOverride_LoadsSingleKbReadyGame()
+    {
+        // #2502: the e2e manifest provides exactly one game with a pdfBlobKey so the
+        // bake yields a guaranteed KB-Ready game for the live-session E2E suite.
+        var manifest = CatalogSeeder.LoadManifest(SeedProfile.Dev, manifestName: "e2e");
+
+        manifest.Should().NotBeNull();
+        manifest.Catalog.Games.Should().ContainSingle(
+            "the e2e seed is intentionally minimal — a single KB-Ready game");
+
+        var game = manifest.Catalog.Games[0];
+        game.Title.Should().Be("Love Letter");
+        game.PdfBlobKey.Should().NotBeNullOrWhiteSpace(
+            "the e2e game must have a rulebook blob to reach KB Ready when baked");
+        game.SeedAgent.Should().BeTrue(
+            "the e2e game needs an agent for RAG / setup-guide E2E flows");
+    }
+
+    [Fact]
     public void LoadManifest_WithMissingOverride_Throws()
     {
         var act = () => CatalogSeeder.LoadManifest(SeedProfile.Dev, manifestName: "nonexistent");

--- a/docs/for-developers/testing/e2e-kb-ready-seed.md
+++ b/docs/for-developers/testing/e2e-kb-ready-seed.md
@@ -40,17 +40,27 @@ The profile-name override mechanism is documented in
 `SEED_CATALOG_MANIFEST_OVERRIDE` accepts any manifest name (no code change needed —
 the manifests are embedded via the `Manifests\*.yml` glob).
 
-## CI validation
+## Validation
 
-`bake-e2e-smoke` in
-[`seed-snapshot-bake-ci.yml`](../../../.github/workflows/seed-snapshot-bake-ci.yml)
-bakes `e2e.yml` (1 PDF, `SEED_INDEX_FAILURE_PCT=0`) on every push/PR that touches a
-manifest, an EF migration, or a seed/snapshot script — so a broken `e2e.yml` (or a
-regression in the bake pipeline) fails the gate. It runs on its own runner alongside
-`bake-ci-smoke`, so the two do not share a postgres instance.
+`e2e.yml` is validated for **loadability + shape** by the unit test
+`CatalogSeederManifestOverrideTests.LoadManifest_WithE2eOverride_LoadsSingleKbReadyGame`
+(runs in `Backend Fast` — confirms the manifest is embedded, parses, has exactly one game
+with a `pdfBlobKey`, `seedAgent: true`, and a `defaultAgent`).
 
-The manifest is also unit-tested for loadability + shape by
-`CatalogSeederManifestOverrideTests.LoadManifest_WithE2eOverride_LoadsSingleKbReadyGame`.
+> **The actual bake is NOT validated in CI.** The `seed-snapshot-bake-ci.yml` gate
+> (`bake-ci-smoke`) requires `infra/secrets/*.secret` (redis, seed blob bucket) that are
+> not provisioned in the PR runner, so it has been failing on every run — including
+> `main-dev` — for weeks (`redis.secret not found → exit 2`). That is a pre-existing,
+> known-red gate, unrelated to this manifest. Validate the e2e bake in an environment
+> that has the secrets:
+>
+> ```bash
+> cd infra && make secrets-sync          # pull .secret files from staging
+> SEED_CATALOG_MANIFEST_OVERRIDE=e2e make seed-index
+> ```
+>
+> Fixing the CI bake gate (provisioning secrets in the runner) is tracked separately and
+> out of scope for #2502.
 
 ## Constraints
 
@@ -58,4 +68,4 @@ The manifest is also unit-tested for loadability + shape by
   has no image fields by design (`SeedManifestGameSchemaTests` guards this).
 - **`seedAgent: true` requires a `defaultAgent` section** (manifest validation), already
   present in `e2e.yml`.
-- Keep `e2e.yml` minimal (the CI job caps it at 3 PDFs) so the smoke stays fast.
+- Keep `e2e.yml` minimal (ideally one game) so the bake stays fast.

--- a/docs/for-developers/testing/e2e-kb-ready-seed.md
+++ b/docs/for-developers/testing/e2e-kb-ready-seed.md
@@ -1,0 +1,61 @@
+# E2E KB-Ready seed (`e2e.yml`)
+
+**Issue:** #2502 — provide a reproducible game with a `Ready` knowledge base for the
+live-session E2E user story ([#2506](https://github.com/meepleAi-app/meepleai-monorepo/issues/2506)).
+
+## Why
+
+The live-session user story (Mage Knight) needs at least one game whose rulebook is
+**indexed** (PDF → chunks → embeddings in pgvector, i.e. `PdfProcessingState.Ready`)
+so the RAG flows — agent chat with citations (#2500) and the setup guide (#2504) —
+have real content to retrieve. The legacy `data/rulebook/manifest.json` is a historical
+reference, **not** the runtime seed; the real seed loads from the embedded YAML manifests
+under `apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/`.
+
+`e2e.yml` is a dedicated, intentionally minimal manifest: a **single** game (Love Letter,
+reused from `ci.yml` so its blob + sha256 are already verified) with `seedAgent: true`.
+When baked it reaches `Ready`, giving the E2E suite a guaranteed KB-Ready game without the
+cost of the slow full bake.
+
+## Bake + consume
+
+```bash
+# 1. Bake the e2e snapshot (one-off / when the manifest or pipeline changes).
+#    Brings up the bake stack, seeds e2e.yml, polls processing_jobs to Ready, dumps.
+cd infra
+SEED_CATALOG_MANIFEST_OVERRIDE=e2e make seed-index
+
+# 2. (optional) publish the dump to the seed blob bucket so CI/others can fetch it
+SEED_CATALOG_MANIFEST_OVERRIDE=e2e make seed-index-publish
+
+# 3. Consume the snapshot for E2E (restores the pre-indexed DB, skips runtime seeding)
+make dev-from-snapshot   # sets SKIP_CATALOG_SEED=true
+
+# 4. Run the E2E suite — Love Letter is queryable with embeddings ready
+cd ../apps/web && pnpm test:e2e
+```
+
+The profile-name override mechanism is documented in
+[`snapshot-seed-workflow.md`](../workflows/snapshot-seed-workflow.md);
+`SEED_CATALOG_MANIFEST_OVERRIDE` accepts any manifest name (no code change needed —
+the manifests are embedded via the `Manifests\*.yml` glob).
+
+## CI validation
+
+`bake-e2e-smoke` in
+[`seed-snapshot-bake-ci.yml`](../../../.github/workflows/seed-snapshot-bake-ci.yml)
+bakes `e2e.yml` (1 PDF, `SEED_INDEX_FAILURE_PCT=0`) on every push/PR that touches a
+manifest, an EF migration, or a seed/snapshot script — so a broken `e2e.yml` (or a
+regression in the bake pipeline) fails the gate. It runs on its own runner alongside
+`bake-ci-smoke`, so the two do not share a postgres instance.
+
+The manifest is also unit-tested for loadability + shape by
+`CatalogSeederManifestOverrideTests.LoadManifest_WithE2eOverride_LoadsSingleKbReadyGame`.
+
+## Constraints
+
+- **BGG freeze (#2123):** do not add image properties to the manifest — `SeedManifestGame`
+  has no image fields by design (`SeedManifestGameSchemaTests` guards this).
+- **`seedAgent: true` requires a `defaultAgent` section** (manifest validation), already
+  present in `e2e.yml`.
+- Keep `e2e.yml` minimal (the CI job caps it at 3 PDFs) so the smoke stays fast.


### PR DESCRIPTION
## Sintesi

Issue **#2502**: fornisce un gioco con **KB Ready garantita** per gli E2E della sessione live (user story #2506).

### Finding 1 — manifest.json è legacy

Il `data/rulebook/manifest.json` citato nella issue è una **referenza storica**, **non** il seed runtime — che carica dai manifest YAML embedded (`Manifests/*.yml`). "KB Ready" = `PdfProcessingState.Ready` (chunk + embeddings in pgvector).

### Finding 2 — il bake CI gate è rotto (pre-esistente)

`seed-snapshot-bake-ci.yml` (`bake-ci-smoke`) **fallisce su ogni run da settimane** — anche su `main-dev` (`redis.secret not found → exit 2`): richiede `infra/secrets/*.secret` non provisionati nel runner. È un gate noto-rosso, **non causato da questo PR**. Di conseguenza il bake **non è validabile in CI**; ho rimosso il job `bake-e2e-smoke` che avrei aggiunto (avrebbe solo aggiunto un job rosso permanente senza validare nulla).

## Deliverable

- **`e2e.yml`**: manifest E2E dedicato e minimale — 1 gioco (Love Letter, riuso da `ci.yml` con `pdfBlobKey`+`pdfSha256` già verificati) + `seedAgent: true` + `defaultAgent`. Auto-incluso via glob `Manifests\*.yml` (nessun code change al loader). Al bake (con secrets) raggiunge `Ready`.
- **`CatalogSeederManifestOverrideTests`**: +test loadability/shape `e2e` (**8/8**, gira in `Backend Fast` ✅) — conferma manifest embedded, parse, 1 gioco con `pdfBlobKey`/`seedAgent`/`defaultAgent`.
- **doc**: `docs/for-developers/testing/e2e-kb-ready-seed.md` (bake/consume + nota sul gate rotto).

## Validazione

- **Loadability/shape**: test unit ✅ (Backend Fast).
- **Bake reale (KB → `Ready`)**: va eseguito in ambiente con secrets (`make secrets-sync && SEED_CATALOG_MANIFEST_OVERRIDE=e2e make seed-index` in dev/staging) — **non in CI** (gate rotto su secrets, fix tracciato a parte, fuori scope #2502).

## Consumo E2E

```bash
SEED_CATALOG_MANIFEST_OVERRIDE=e2e make seed-index   # bake (dev/staging, con secrets)
make dev-from-snapshot                               # consume (SKIP_CATALOG_SEED=true)
pnpm test:e2e                                         # Love Letter KB-Ready disponibile
```

## Vincoli

- **BGG freeze #2123**: nessuna image property (`SeedManifestGameSchemaTests` guard).
- `seedAgent: true` → richiede `defaultAgent` (manifest validation, catturato dal test).

## Note CI

I check rossi su questo PR — `Dependency Vulnerabilities` (scan .NET baseline) e i due `Bake …` (gate rotto su secrets) — sono **pre-esistenti, non causati da questo PR**. I check rilevanti (`Backend Fast` incl. il nuovo test, CodeQL, lint) sono verdi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)