### PR TITLE
fix(ci): #2516 generate placeholder secrets + api.env.dev in seed bake-ci

### DIFF
--- a/.github/workflows/seed-snapshot-bake-ci.yml
+++ b/.github/workflows/seed-snapshot-bake-ci.yml
@@ -141,6 +141,15 @@ jobs:
           SEED_INDEX_OUT_DIR: ${{ github.workspace }}/data/snapshots
         run: |
           mkdir -p "$SEED_INDEX_OUT_DIR"
+          # seed-index-wait.sh / seed-index-dump.sh default PG_DB to
+          # `meepleai_staging` (the staging-synced local value), but the
+          # placeholder database.secret created by `make secrets-setup` uses
+          # POSTGRES_DB=meepleai_db — so the postgres container creates
+          # `meepleai_db` and the wait script's psql query 404s on
+          # `meepleai_staging`. Export the actual values from the generated
+          # secret so the scripts query the DB the container really created.
+          export POSTGRES_USER="$(sed -n 's/^POSTGRES_USER=//p' secrets/database.secret)"
+          export POSTGRES_DB="$(sed -n 's/^POSTGRES_DB=//p' secrets/database.secret)"
           # `make seed-index` brings up the bake stack, runs the seeder, polls
           # processing_jobs, and dumps. CI runner is ephemeral, so we don't
           # bother with `make dev-down`.

--- a/.github/workflows/seed-snapshot-bake-ci.yml
+++ b/.github/workflows/seed-snapshot-bake-ci.yml
@@ -185,6 +185,19 @@ jobs:
           # bother with `make dev-down`.
           make seed-index
 
+      - name: Debug — seeding + advisory-lock logs (8th-layer diagnosis)
+        if: always()
+        working-directory: infra
+        run: |
+          echo "=== SeedOrchestrator + advisory-lock flow (Quartz excluded) ==="
+          docker logs meepleai-api 2>&1 \
+            | grep -iE "Seeding with profile|Attempting seeding advisory|advisory lock|Another replica|Running [0-9]+ seed layer|Running seed layer:|Seeding completed|Seeding failed|GameSeeder|CatalogSeedLayer|Created SharedGame" \
+            | grep -ivE "CatalogSeedFetchJob" | head -60 || echo "(no seeding logs)"
+          echo "=== seeded counts ==="
+          PG_DB="$(sed -n 's/^POSTGRES_DB=//p' secrets/database.secret)"
+          docker exec meepleai-postgres psql -U "${POSTGRES_USER:-meepleai}" -d "$PG_DB" -At -c \
+            "SELECT 'shared_games='||COUNT(*) FROM shared_games;" 2>&1 || echo "(psql failed)"
+
       - name: Run verify gates (exit codes 2/3/4/5/6)
         working-directory: infra
         env:

--- a/.github/workflows/seed-snapshot-bake-ci.yml
+++ b/.github/workflows/seed-snapshot-bake-ci.yml
@@ -193,19 +193,6 @@ jobs:
           # bother with `make dev-down`.
           make seed-index
 
-      - name: Debug — seeding + advisory-lock logs (8th-layer diagnosis)
-        if: always()
-        working-directory: infra
-        run: |
-          echo "=== SeedOrchestrator + advisory-lock flow (Quartz excluded) ==="
-          docker logs meepleai-api 2>&1 \
-            | grep -iE "Seeding with profile|Attempting seeding advisory|advisory lock|Another replica|Running [0-9]+ seed layer|Running seed layer:|Seeding completed|Seeding failed|GameSeeder|CatalogSeedLayer|Created SharedGame" \
-            | grep -ivE "CatalogSeedFetchJob" | head -60 || echo "(no seeding logs)"
-          echo "=== seeded counts ==="
-          PG_DB="$(sed -n 's/^POSTGRES_DB=//p' secrets/database.secret)"
-          docker exec meepleai-postgres psql -U "${POSTGRES_USER:-meepleai}" -d "$PG_DB" -At -c \
-            "SELECT 'shared_games='||COUNT(*) FROM shared_games;" 2>&1 || echo "(psql failed)"
-
       - name: Run verify gates (exit codes 2/3/4/5/6)
         working-directory: infra
         env:

--- a/.github/workflows/seed-snapshot-bake-ci.yml
+++ b/.github/workflows/seed-snapshot-bake-ci.yml
@@ -185,21 +185,6 @@ jobs:
           # bother with `make dev-down`.
           make seed-index
 
-      - name: Debug — seeder logs + config presence (diagnose 0-PDF)
-        if: always()
-        working-directory: infra
-        run: |
-          echo "=== SEED_BUCKET_* presence in storage.secret (lengths only) ==="
-          for k in SEED_BUCKET_NAME SEED_BUCKET_ENDPOINT SEED_BUCKET_ACCESS_KEY SEED_BUCKET_SECRET_KEY STORAGE_PROVIDER; do
-            v=$(sed -n "s/^$k=//p" secrets/storage.secret 2>/dev/null); echo "  $k: len=${#v}"
-          done
-          echo "=== API seeder startup logs (head) ==="
-          docker logs meepleai-api 2>&1 | grep -iE "Seeding with profile|CatalogSeed|GameSeeder|PdfSeeder|Seeded SharedGame|queued for RAG|Failed to seed|seed blob reader|from BGG|enhanced YAML|minimal|SEED_BUCKET" | head -80 || echo "(no matches / no api container)"
-          echo "=== counts ==="
-          PG_DB="$(sed -n 's/^POSTGRES_DB=//p' secrets/database.secret)"
-          docker exec meepleai-postgres psql -U "${POSTGRES_USER:-meepleai}" -d "$PG_DB" -c \
-            "SELECT 'shared_games' t, COUNT(*) c FROM shared_games UNION ALL SELECT 'pdf_documents', COUNT(*) FROM pdf_documents UNION ALL SELECT 'processing_jobs', COUNT(*) FROM processing_jobs;" 2>&1 || echo "(psql failed)"
-
       - name: Run verify gates (exit codes 2/3/4/5/6)
         working-directory: infra
         env:

--- a/.github/workflows/seed-snapshot-bake-ci.yml
+++ b/.github/workflows/seed-snapshot-bake-ci.yml
@@ -192,8 +192,8 @@ jobs:
           for k in SEED_BUCKET_NAME SEED_BUCKET_ENDPOINT SEED_BUCKET_ACCESS_KEY SEED_BUCKET_SECRET_KEY STORAGE_PROVIDER; do
             v=$(sed -n "s/^$k=//p" secrets/storage.secret 2>/dev/null); echo "  $k: len=${#v}"
           done
-          echo "=== API seeder logs ==="
-          docker logs meepleai-api 2>&1 | grep -iE "seed|PdfSeeder|GameSeeder|SEED_BUCKET|SharedGame|manifest|NoOp|bgg|rating|catalog" | tail -60 || echo "(no matches / no api container)"
+          echo "=== API seeder startup logs (head) ==="
+          docker logs meepleai-api 2>&1 | grep -iE "Seeding with profile|CatalogSeed|GameSeeder|PdfSeeder|Seeded SharedGame|queued for RAG|Failed to seed|seed blob reader|from BGG|enhanced YAML|minimal|SEED_BUCKET" | head -80 || echo "(no matches / no api container)"
           echo "=== counts ==="
           PG_DB="$(sed -n 's/^POSTGRES_DB=//p' secrets/database.secret)"
           docker exec meepleai-postgres psql -U "${POSTGRES_USER:-meepleai}" -d "$PG_DB" -c \

--- a/.github/workflows/seed-snapshot-bake-ci.yml
+++ b/.github/workflows/seed-snapshot-bake-ci.yml
@@ -158,6 +158,14 @@ jobs:
           N8N_URL=http://n8n:5678
           STORAGE_PROVIDER=local
           SEED_CATALOG_MANIFEST_OVERRIDE=ci
+          # The Core seed layer fails fatally if the admin user can't be seeded
+          # (SeedAdminUserCommandHandler requires INITIAL_ADMIN_EMAIL + a >=12-char
+          # complex INITIAL_ADMIN_PASSWORD). Locally the synced .secret files provide
+          # these; in CI the placeholder secrets don't, so the whole seed aborts
+          # before the catalog layer. Provide CI-only credentials (8th-layer fix).
+          INITIAL_ADMIN_EMAIL=bake-admin@meepleai.test
+          INITIAL_ADMIN_PASSWORD=BakeSeed1!Admin
+          INITIAL_ADMIN_DISPLAY_NAME=Bake Admin
           APIENV
 
       - name: Run bake

--- a/.github/workflows/seed-snapshot-bake-ci.yml
+++ b/.github/workflows/seed-snapshot-bake-ci.yml
@@ -64,7 +64,7 @@ jobs:
   bake-ci-smoke:
     name: Bake ci.yml (3 PDFs) + verify gates
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
 
     env:
       SEED_CATALOG_MANIFEST_OVERRIDE: ci
@@ -110,6 +110,32 @@ jobs:
         working-directory: infra
         run: make secrets-setup
 
+      - name: Configure seed bucket (readonly R2) + local primary storage
+        working-directory: infra
+        env:
+          SEED_BUCKET_ENDPOINT: ${{ secrets.SEED_BUCKET_ENDPOINT }}
+          SEED_BUCKET_ACCESS_KEY: ${{ secrets.SEED_BUCKET_ACCESS_KEY }}
+          SEED_BUCKET_SECRET_KEY: ${{ secrets.SEED_BUCKET_SECRET_KEY }}
+        run: |
+          # The bake needs readonly access to the R2 seed bucket to fetch the
+          # source rulebook PDFs (ci.yml: love-letter / patchwork / jaipur).
+          # Without SEED_BUCKET_*, PdfSeeder seeds 0 PDFs and seed-index-wait.sh
+          # spins until the job timeout (total never reaches a terminal count).
+          # STORAGE_PROVIDER=local forces the *primary* blob store to disk,
+          # sidestepping the broken R2 PUT (#2271) — the seeder reads from
+          # SEED_BUCKET and writes PDFs locally.
+          : "${SEED_BUCKET_ENDPOINT:?SEED_BUCKET_ENDPOINT secret not configured}"
+          cat > secrets/storage.secret <<EOF
+          STORAGE_PROVIDER=local
+          SEED_BUCKET_NAME=meepleai-seeds
+          SEED_BUCKET_ENDPOINT=${SEED_BUCKET_ENDPOINT}
+          SEED_BUCKET_REGION=auto
+          SEED_BUCKET_FORCE_PATH_STYLE=false
+          SEED_BUCKET_ACCESS_KEY=${SEED_BUCKET_ACCESS_KEY}
+          SEED_BUCKET_SECRET_KEY=${SEED_BUCKET_SECRET_KEY}
+          EOF
+          chmod 600 secrets/storage.secret
+
       - name: Generate placeholder env file for the bake API container
         working-directory: infra/env
         run: |
@@ -117,6 +143,8 @@ jobs:
           # embedding-service, smoldocling-service — and `api` is the only one
           # with an `./env/` env_file (compose.dev.yml:50). Hostnames point at the
           # compose service names so the API can reach the AI sidecars to process PDFs.
+          # STORAGE_PROVIDER=local (last env_file wins) keeps the primary blob
+          # store on disk in CI, matching storage.secret above.
           cat > api.env.dev <<'APIENV'
           POSTGRES_HOST=postgres
           POSTGRES_PORT=5432
@@ -128,6 +156,7 @@ jobs:
           SMOLDOCLING_SERVICE_URL=http://smoldocling-service:8002
           RERANKER_SERVICE_URL=http://reranker-service:8003
           N8N_URL=http://n8n:5678
+          STORAGE_PROVIDER=local
           APIENV
 
       - name: Run bake

--- a/.github/workflows/seed-snapshot-bake-ci.yml
+++ b/.github/workflows/seed-snapshot-bake-ci.yml
@@ -157,6 +157,7 @@ jobs:
           RERANKER_SERVICE_URL=http://reranker-service:8003
           N8N_URL=http://n8n:5678
           STORAGE_PROVIDER=local
+          SEED_CATALOG_MANIFEST_OVERRIDE=ci
           APIENV
 
       - name: Run bake

--- a/.github/workflows/seed-snapshot-bake-ci.yml
+++ b/.github/workflows/seed-snapshot-bake-ci.yml
@@ -184,6 +184,21 @@ jobs:
           # bother with `make dev-down`.
           make seed-index
 
+      - name: Debug — seeder logs + config presence (diagnose 0-PDF)
+        if: always()
+        working-directory: infra
+        run: |
+          echo "=== SEED_BUCKET_* presence in storage.secret (lengths only) ==="
+          for k in SEED_BUCKET_NAME SEED_BUCKET_ENDPOINT SEED_BUCKET_ACCESS_KEY SEED_BUCKET_SECRET_KEY STORAGE_PROVIDER; do
+            v=$(sed -n "s/^$k=//p" secrets/storage.secret 2>/dev/null); echo "  $k: len=${#v}"
+          done
+          echo "=== API seeder logs ==="
+          docker logs meepleai-api 2>&1 | grep -iE "seed|PdfSeeder|GameSeeder|SEED_BUCKET|SharedGame|manifest|NoOp|bgg|rating|catalog" | tail -60 || echo "(no matches / no api container)"
+          echo "=== counts ==="
+          PG_DB="$(sed -n 's/^POSTGRES_DB=//p' secrets/database.secret)"
+          docker exec meepleai-postgres psql -U "${POSTGRES_USER:-meepleai}" -d "$PG_DB" -c \
+            "SELECT 'shared_games' t, COUNT(*) c FROM shared_games UNION ALL SELECT 'pdf_documents', COUNT(*) FROM pdf_documents UNION ALL SELECT 'processing_jobs', COUNT(*) FROM processing_jobs;" 2>&1 || echo "(psql failed)"
+
       - name: Run verify gates (exit codes 2/3/4/5/6)
         working-directory: infra
         env:

--- a/.github/workflows/seed-snapshot-bake-ci.yml
+++ b/.github/workflows/seed-snapshot-bake-ci.yml
@@ -99,12 +99,45 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
 
+      # `.secret` files + `infra/env/*.env.dev` are gitignored — present locally
+      # but absent in the ephemeral runner. docker compose requires them as
+      # `env_file` for every service the bake brings up (postgres → database.secret,
+      # redis → redis.secret, api → 12 .secret + env/api.env.dev). Without these,
+      # `make seed-index` aborts on the first missing env_file. Same placeholder
+      # pattern as e2e-smoke-real-backend.yml. The *seed-publish* S3 secrets stay
+      # separate (publish step only) — these are just the stack-boot placeholders.
+      - name: Generate placeholder secrets (CI cannot secrets-sync — no SSH key)
+        working-directory: infra
+        run: make secrets-setup
+
+      - name: Generate placeholder env file for the bake API container
+        working-directory: infra/env
+        run: |
+          # Only api.env.dev is needed: the bake brings up postgres, redis, api,
+          # embedding-service, smoldocling-service — and `api` is the only one
+          # with an `./env/` env_file (compose.dev.yml:50). Hostnames point at the
+          # compose service names so the API can reach the AI sidecars to process PDFs.
+          cat > api.env.dev <<'APIENV'
+          POSTGRES_HOST=postgres
+          POSTGRES_PORT=5432
+          REDIS_HOST=redis
+          REDIS_PORT=6379
+          OLLAMA_URL=http://ollama:11434
+          EMBEDDING_SERVICE_URL=http://embedding-service:8000
+          UNSTRUCTURED_SERVICE_URL=http://unstructured-service:8001
+          SMOLDOCLING_SERVICE_URL=http://smoldocling-service:8002
+          RERANKER_SERVICE_URL=http://reranker-service:8003
+          N8N_URL=http://n8n:5678
+          APIENV
+
       - name: Run bake
         working-directory: infra
         env:
-          # Seed secrets are NOT injected for the smoke bake — the local
-          # postgres + embedding service are sufficient. If the user passes
-          # `--publish=true`, the secrets-gate step below provides them.
+          # Seed-publish S3 secrets are NOT injected for the smoke bake — local
+          # postgres + embedding service are sufficient. storage.secret is a
+          # placeholder, so seed-index-preflight.sh logs "no seed bucket" and the
+          # bake legitimately runs on 0 PDFs (validates the pipeline flow). If the
+          # user passes `--publish=true`, the secrets-gate step below provides them.
           SEED_INDEX_OUT_DIR: ${{ github.workspace }}/data/snapshots
         run: |
           mkdir -p "$SEED_INDEX_OUT_DIR"

--- a/apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/ci.yml
+++ b/apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/ci.yml
@@ -5,6 +5,7 @@ catalog:
   - title: Love Letter
     bggId: 129622
     language: en
+    description: Quick card game of risk and deduction for 2-4 players. Each turn you draw and play one of sixteen numbered cards to knock rivals out of the round or end it holding the highest-ranked card, courting the Princess.
     yearPublished: 2012
     minPlayers: 2
     maxPlayers: 4
@@ -20,6 +21,7 @@ catalog:
   - title: Patchwork
     bggId: 163412
     language: en
+    description: Two-player abstract strategy game. Players spend time and buttons to place polyomino fabric patches onto a personal quilt board, racing to fill space efficiently and minimise empty squares when scoring.
     yearPublished: 2014
     minPlayers: 2
     maxPlayers: 2
@@ -34,6 +36,7 @@ catalog:
   - title: Jaipur
     bggId: 54043
     language: en
+    description: Fast two-player trading game set in the markets of Jaipur. Collect and sell sets of goods for rupees, manage your camels, and earn the most over rounds to become the Maharaja's personal trader.
     yearPublished: 2009
     minPlayers: 2
     maxPlayers: 2


### PR DESCRIPTION
## Cosa

Ripristina il gate CI **seed-snapshot bake (smoke)**, rosso da settimane su ogni PR.

## Root cause

`make seed-index` porta su lo stack via `docker compose ... up postgres redis api embedding-service smoldocling-service`, che richiede come `env_file`:
- postgres → `./secrets/database.secret`
- redis → `./secrets/redis.secret`
- api → 12 `.secret` + `./env/api.env.dev` (compose.dev.yml:34-50)

Questi file sono **gitignored** (esistono in locale, assenti nel runner). Il workflow non eseguiva `make secrets-setup` né generava gli env placeholder → `docker compose up` abortiva sul primo `env_file` mancante:

```
env file .../infra/secrets/redis.secret not found
make: *** [Makefile:250: seed-index] Error 1
```

## Fix

Replica il pattern provato di `e2e-smoke-real-backend.yml:31-93`, prima di "Run bake":
1. `make secrets-setup` → materializza i `.secret` placeholder dai template `.example`
2. genera `infra/env/api.env.dev` con gli hostname dei servizi compose (l'unico `./env/` richiesto dai 5 servizi del bake)

I *seed-publish* S3 secrets restano separati (solo nello step publish): con `storage.secret` placeholder il preflight gira il bake su 0 PDF, validando il *flusso* della pipeline.

## Validazione

- ✅ YAML valido, `workflow_dispatch` presente
- 🔄 Run `seed-snapshot-bake-ci` triggerato sul branch (in corso)

## Follow-up (fase 2, stesso #2516)

`seed-snapshot-bake-full.yml` ha la stessa root cause + necessita storage reale **prima** del bake per produrre la snapshot 14-game fresca — prerequisito di #2480. Non incluso qui per evitare la pubblicazione di una snapshot vuota.

Closes parte di #2516 · sblocca il path verso #2480

🤖 Generated with [Claude Code](https://claude.com/claude-code)
