### PR TITLE
feat(session-live): #2500 citazioni agente RAG nella chat live canonica + integrazione runtime

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/LaunchSessionAgentCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/LaunchSessionAgentCommandHandler.cs
@@ -52,8 +52,12 @@ internal sealed class LaunchSessionAgentCommandHandler : IRequestHandler<LaunchS
                 $"An active agent session already exists for GameSession {request.GameSessionId}");
         }
 
-        // Parse and validate initial game state
-        var initialGameState = GameState.FromJson(request.InitialGameStateJson);
+        // C1 fix: empty/whitespace InitialGameStateJson means "use server default".
+        // GameState.FromJson('{}') throws because ActivePlayer == Guid.Empty;
+        // GameState.Initial(UserId) produces a valid baseline state.
+        var initialGameState = string.IsNullOrWhiteSpace(request.InitialGameStateJson)
+            ? GameState.Initial(request.UserId)
+            : GameState.FromJson(request.InitialGameStateJson);
 
         // Create agent session
         var agentSession = new AgentSession(

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetChatThreadByIdQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetChatThreadByIdQueryHandler.cs
@@ -38,7 +38,12 @@ internal class GetChatThreadByIdQueryHandler : IQueryHandler<GetChatThreadByIdQu
             IsDeleted: m.IsDeleted,
             DeletedAt: m.DeletedAt,
             DeletedByUserId: m.DeletedByUserId,
-            IsInvalidated: m.IsInvalidated
+            IsInvalidated: m.IsInvalidated,
+            // Issue #2500: map agent metadata so citations survive thread reload
+            AgentType: m.AgentType,
+            Confidence: m.Confidence,
+            CitationsJson: m.CitationsJson,
+            TokenCount: m.TokenCount
         )).ToList();
 
         return new ChatThreadDto(

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetChatThreadsByGameQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetChatThreadsByGameQueryHandler.cs
@@ -44,7 +44,12 @@ internal class GetChatThreadsByGameQueryHandler : IQueryHandler<GetChatThreadsBy
             IsDeleted: m.IsDeleted,
             DeletedAt: m.DeletedAt,
             DeletedByUserId: m.DeletedByUserId,
-            IsInvalidated: m.IsInvalidated
+            IsInvalidated: m.IsInvalidated,
+            // Issue #2500: map agent metadata so citations survive thread reload
+            AgentType: m.AgentType,
+            Confidence: m.Confidence,
+            CitationsJson: m.CitationsJson,
+            TokenCount: m.TokenCount
         )).ToList();
 
         return new ChatThreadDto(

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Validators/LaunchSessionAgentCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Validators/LaunchSessionAgentCommandValidator.cs
@@ -1,4 +1,6 @@
 using Api.BoundedContexts.KnowledgeBase.Application.Commands;
+using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
+using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
 using FluentValidation;
 
 namespace Api.BoundedContexts.KnowledgeBase.Application.Validators;
@@ -6,12 +8,14 @@ namespace Api.BoundedContexts.KnowledgeBase.Application.Validators;
 /// <summary>
 /// Validator for LaunchSessionAgentCommand.
 /// Issue #3184 (AGT-010): Session-Based Agent Lifecycle.
+/// Issue #2500: Added semantic validations — V1 exists, V2 active, V3 game-match, V4 JSON safe-parse.
+/// All FluentValidation failures produce HTTP 422 (validation_error) per codebase convention.
 /// </summary>
 internal sealed class LaunchSessionAgentCommandValidator : AbstractValidator<LaunchSessionAgentCommand>
 {
     private const int MaxGameStateJsonLength = 50000;
 
-    public LaunchSessionAgentCommandValidator()
+    public LaunchSessionAgentCommandValidator(IAgentDefinitionRepository agentDefinitionRepository)
     {
         RuleFor(x => x.GameSessionId)
             .NotEqual(Guid.Empty).WithMessage("GameSessionId is required");
@@ -29,5 +33,57 @@ internal sealed class LaunchSessionAgentCommandValidator : AbstractValidator<Lau
             .NotEmpty().WithMessage("InitialGameStateJson is required")
             .MaximumLength(MaxGameStateJsonLength)
             .WithMessage($"InitialGameStateJson cannot exceed {MaxGameStateJsonLength} characters");
+
+        // V4 — JSON safe-parse: validate before async repo rules (sync, no I/O)
+        RuleFor(x => x.InitialGameStateJson)
+            .Must(json =>
+            {
+                try
+                {
+                    GameState.FromJson(json);
+                    return true;
+                }
+                catch
+                {
+                    return false;
+                }
+            })
+            .WithMessage("InitialGameStateJson is not a valid game state.")
+            .When(x => !string.IsNullOrWhiteSpace(x.InitialGameStateJson));
+
+        // V1 / V2 / V3 — repository-backed async rules
+        // All gated so they only run when AgentDefinitionId is a valid (non-empty) guid
+        RuleFor(x => x.AgentDefinitionId)
+            .MustAsync(async (command, agentDefinitionId, ct) =>
+            {
+                var definition = await agentDefinitionRepository
+                    .GetByIdAsync(agentDefinitionId, ct)
+                    .ConfigureAwait(false);
+                return definition is not null;
+            })
+            .WithMessage("AgentDefinition not found or has been deleted.")
+            .When(x => x.AgentDefinitionId != Guid.Empty);
+
+        RuleFor(x => x.AgentDefinitionId)
+            .MustAsync(async (command, agentDefinitionId, ct) =>
+            {
+                var definition = await agentDefinitionRepository
+                    .GetByIdAsync(agentDefinitionId, ct)
+                    .ConfigureAwait(false);
+                return definition is { IsActive: true };
+            })
+            .WithMessage("AgentDefinition is not active.")
+            .When(x => x.AgentDefinitionId != Guid.Empty);
+
+        RuleFor(x => x.AgentDefinitionId)
+            .MustAsync(async (command, agentDefinitionId, ct) =>
+            {
+                var definition = await agentDefinitionRepository
+                    .GetByIdAsync(agentDefinitionId, ct)
+                    .ConfigureAwait(false);
+                return definition is not null && definition.GameId == command.GameId;
+            })
+            .WithMessage("AgentDefinition does not belong to the specified game.")
+            .When(x => x.AgentDefinitionId != Guid.Empty);
     }
 }

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Validators/LaunchSessionAgentCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Validators/LaunchSessionAgentCommandValidator.cs
@@ -29,12 +29,13 @@ internal sealed class LaunchSessionAgentCommandValidator : AbstractValidator<Lau
         RuleFor(x => x.GameId)
             .NotEqual(Guid.Empty).WithMessage("GameId is required");
 
+        // C1 fix: InitialGameStateJson is now optional — empty/whitespace means "use server default".
+        // Only MaximumLength applies unconditionally; V4 JSON parse is gated on non-empty.
         RuleFor(x => x.InitialGameStateJson)
-            .NotEmpty().WithMessage("InitialGameStateJson is required")
             .MaximumLength(MaxGameStateJsonLength)
             .WithMessage($"InitialGameStateJson cannot exceed {MaxGameStateJsonLength} characters");
 
-        // V4 — JSON safe-parse: validate before async repo rules (sync, no I/O)
+        // V4 — JSON safe-parse: only when non-empty (empty = use GameState.Initial on the handler side)
         RuleFor(x => x.InitialGameStateJson)
             .Must(json =>
             {
@@ -51,39 +52,40 @@ internal sealed class LaunchSessionAgentCommandValidator : AbstractValidator<Lau
             .WithMessage("InitialGameStateJson is not a valid game state.")
             .When(x => !string.IsNullOrWhiteSpace(x.InitialGameStateJson));
 
-        // V1 / V2 / V3 — repository-backed async rules
-        // All gated so they only run when AgentDefinitionId is a valid (non-empty) guid
-        RuleFor(x => x.AgentDefinitionId)
-            .MustAsync(async (command, agentDefinitionId, ct) =>
+        // V1 / V2 / V3 — consolidated into ONE async rule with a SINGLE DB query (I2 fix).
+        // Previously three separate RuleFor rules each called GetByIdAsync → 3 queries + 3 errors
+        // for a missing definition.  Now: one query, fail-fast on first problem with a targeted message.
+        // CustomAsync gives access to ValidationContext<T> so we can name the property explicitly.
+        RuleFor(x => x)
+            .CustomAsync(async (command, ctx, ct) =>
             {
-                var definition = await agentDefinitionRepository
-                    .GetByIdAsync(agentDefinitionId, ct)
-                    .ConfigureAwait(false);
-                return definition is not null;
-            })
-            .WithMessage("AgentDefinition not found or has been deleted.")
-            .When(x => x.AgentDefinitionId != Guid.Empty);
+                if (command.AgentDefinitionId == Guid.Empty)
+                    return; // gated below via When; also checked separately by NotEqual rule
 
-        RuleFor(x => x.AgentDefinitionId)
-            .MustAsync(async (command, agentDefinitionId, ct) =>
-            {
                 var definition = await agentDefinitionRepository
-                    .GetByIdAsync(agentDefinitionId, ct)
+                    .GetByIdAsync(command.AgentDefinitionId, ct)
                     .ConfigureAwait(false);
-                return definition is { IsActive: true };
-            })
-            .WithMessage("AgentDefinition is not active.")
-            .When(x => x.AgentDefinitionId != Guid.Empty);
 
-        RuleFor(x => x.AgentDefinitionId)
-            .MustAsync(async (command, agentDefinitionId, ct) =>
-            {
-                var definition = await agentDefinitionRepository
-                    .GetByIdAsync(agentDefinitionId, ct)
-                    .ConfigureAwait(false);
-                return definition is not null && definition.GameId == command.GameId;
+                // V1 — exists
+                if (definition is null)
+                {
+                    ctx.AddFailure("AgentDefinitionId", "AgentDefinition not found or has been deleted.");
+                    return;
+                }
+
+                // V2 — active
+                if (!definition.IsActive)
+                {
+                    ctx.AddFailure("AgentDefinitionId", "AgentDefinition is not active.");
+                    return;
+                }
+
+                // V3 — game-match
+                if (definition.GameId != command.GameId)
+                {
+                    ctx.AddFailure("AgentDefinitionId", "AgentDefinition does not belong to the specified game.");
+                }
             })
-            .WithMessage("AgentDefinition does not belong to the specified game.")
             .When(x => x.AgentDefinitionId != Guid.Empty);
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/GetChatThreadByIdQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/GetChatThreadByIdQueryHandlerTests.cs
@@ -80,4 +80,46 @@ public class GetChatThreadByIdQueryHandlerTests
         Func<Task> act = () => _handler.Handle(null!, TestContext.Current.CancellationToken);
         await act.Should().ThrowAsync<ArgumentNullException>();
     }
+
+    /// <summary>
+    /// Regression test for Issue #2500: CitationsJson and agent metadata must survive
+    /// the entity → DTO mapping so the FE can display citations after a reload.
+    /// </summary>
+    [Fact]
+    public async Task Handle_AssistantMessageWithMetadata_MapsCitationsJsonAndAgentMetadata()
+    {
+        // Arrange
+        var threadId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var citationsJson = "[{\"source\":\"Reg\",\"pageNumber\":7}]";
+        const string agentType = "tutor";
+        const float confidence = 0.92f;
+        const int tokenCount = 512;
+
+        var thread = new ChatThread(threadId, userId);
+        thread.AddUserMessage("How do I play Catan?");
+        thread.AddAssistantMessageWithMetadata(
+            content: "You start by placing settlements...",
+            agentType: agentType,
+            confidence: confidence,
+            citationsJson: citationsJson,
+            tokenCount: tokenCount);
+
+        _mockRepository
+            .Setup(r => r.GetByIdAsync(threadId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(thread);
+
+        var query = new GetChatThreadByIdQuery(threadId);
+
+        // Act
+        var result = await _handler.Handle(query, TestContext.Current.CancellationToken);
+
+        // Assert
+        result.Should().NotBeNull();
+        var assistantMsg = result!.Messages.Single(m => m.Role == "assistant");
+        assistantMsg.CitationsJson.Should().Be(citationsJson);
+        assistantMsg.AgentType.Should().Be(agentType);
+        assistantMsg.Confidence.Should().BeApproximately(confidence, 0.001f);
+        assistantMsg.TokenCount.Should().Be(tokenCount);
+    }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/GetChatThreadsByGameQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/GetChatThreadsByGameQueryHandlerTests.cs
@@ -110,4 +110,46 @@ public class GetChatThreadsByGameQueryHandlerTests
 
         _mockRepository.Verify(r => r.FindByUserIdAndGameIdAsync(userId, gameId, It.IsAny<CancellationToken>()), Times.Once);
     }
+
+    /// <summary>
+    /// Regression test for Issue #2500: CitationsJson and agent metadata must survive
+    /// the entity → DTO mapping so the FE can display citations after a reload.
+    /// </summary>
+    [Fact]
+    public async Task Handle_AssistantMessageWithMetadata_MapsCitationsJsonAndAgentMetadata()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var gameId = Guid.NewGuid();
+        var citationsJson = "[{\"source\":\"Reg\",\"pageNumber\":7}]";
+        const string agentType = "arbitro";
+        const float confidence = 0.85f;
+        const int tokenCount = 256;
+
+        var thread = new ChatThread(Guid.NewGuid(), userId, gameId, "Citations Thread");
+        thread.AddUserMessage("Who wins in case of a tie?");
+        thread.AddAssistantMessageWithMetadata(
+            content: "In case of a tie, the player with the most roads wins.",
+            agentType: agentType,
+            confidence: confidence,
+            citationsJson: citationsJson,
+            tokenCount: tokenCount);
+
+        _mockRepository.Setup(r => r.FindByUserIdAndGameIdAsync(userId, gameId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ChatThread> { thread });
+
+        var query = new GetChatThreadsByGameQuery(gameId, userId, 0, 10);
+
+        // Act
+        var result = await _handler.Handle(query, TestContext.Current.CancellationToken);
+
+        // Assert
+        result.Should().NotBeNull();
+        var returnedThread = result.Single();
+        var assistantMsg = returnedThread.Messages.Single(m => m.Role == "assistant");
+        assistantMsg.CitationsJson.Should().Be(citationsJson);
+        assistantMsg.AgentType.Should().Be(agentType);
+        assistantMsg.Confidence.Should().BeApproximately(confidence, 0.001f);
+        assistantMsg.TokenCount.Should().Be(tokenCount);
+    }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/LaunchSessionAgentCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/LaunchSessionAgentCommandHandlerTests.cs
@@ -1,0 +1,136 @@
+using Api.BoundedContexts.KnowledgeBase.Application.Commands;
+using Api.BoundedContexts.KnowledgeBase.Domain.Entities;
+using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
+using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Tests.Constants;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Handlers;
+
+/// <summary>
+/// Unit tests for LaunchSessionAgentCommandHandler.
+/// Issue #2500 (C1 fix): empty InitialGameStateJson defaults to GameState.Initial(UserId).
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "KnowledgeBase")]
+public sealed class LaunchSessionAgentCommandHandlerTests
+{
+    private static readonly Guid _gameSessionId = Guid.NewGuid();
+    private static readonly Guid _agentDefinitionId = Guid.NewGuid();
+    private static readonly Guid _userId = Guid.NewGuid();
+    private static readonly Guid _gameId = Guid.NewGuid();
+
+    private const string ValidGameStateJson =
+        """{"CurrentTurn":1,"ActivePlayer":"11111111-1111-1111-1111-111111111111","PlayerScores":{},"GamePhase":"setup","LastAction":"start"}""";
+
+    private readonly Mock<IAgentSessionRepository> _sessionRepoMock;
+    private readonly Mock<IUnitOfWork> _unitOfWorkMock;
+    private readonly LaunchSessionAgentCommandHandler _handler;
+
+    public LaunchSessionAgentCommandHandlerTests()
+    {
+        _sessionRepoMock = new Mock<IAgentSessionRepository>();
+        _unitOfWorkMock = new Mock<IUnitOfWork>();
+
+        _sessionRepoMock
+            .Setup(r => r.HasActiveSessionAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        _sessionRepoMock
+            .Setup(r => r.AddAsync(It.IsAny<AgentSession>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _unitOfWorkMock
+            .Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        _handler = new LaunchSessionAgentCommandHandler(
+            _sessionRepoMock.Object,
+            _unitOfWorkMock.Object,
+            NullLogger<LaunchSessionAgentCommandHandler>.Instance);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────────
+    // C1 fix — empty InitialGameStateJson uses GameState.Initial(UserId)
+    // ──────────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Handle_EmptyInitialGameStateJson_CreatesSessionWithDefaultState()
+    {
+        // Arrange: empty JSON — handler must NOT call GameState.FromJson, must use GameState.Initial(UserId)
+        var command = new LaunchSessionAgentCommand(
+            GameSessionId: _gameSessionId,
+            AgentDefinitionId: _agentDefinitionId,
+            UserId: _userId,
+            GameId: _gameId,
+            InitialGameStateJson: string.Empty);
+
+        // Act: must NOT throw
+        var agentSessionId = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert: a session was persisted (AddAsync + SaveChanges called once)
+        Assert.NotEqual(Guid.Empty, agentSessionId);
+        _sessionRepoMock.Verify(r => r.AddAsync(It.IsAny<AgentSession>(), It.IsAny<CancellationToken>()), Times.Once);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WhitespaceInitialGameStateJson_CreatesSessionWithDefaultState()
+    {
+        // Arrange: whitespace — same as empty
+        var command = new LaunchSessionAgentCommand(
+            GameSessionId: _gameSessionId,
+            AgentDefinitionId: _agentDefinitionId,
+            UserId: _userId,
+            GameId: _gameId,
+            InitialGameStateJson: "   ");
+
+        var agentSessionId = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.NotEqual(Guid.Empty, agentSessionId);
+        _sessionRepoMock.Verify(r => r.AddAsync(It.IsAny<AgentSession>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ValidGameStateJson_CreatesSessionUsingProvidedState()
+    {
+        // Arrange: valid JSON — handler must use GameState.FromJson (existing behaviour preserved)
+        var command = new LaunchSessionAgentCommand(
+            GameSessionId: _gameSessionId,
+            AgentDefinitionId: _agentDefinitionId,
+            UserId: _userId,
+            GameId: _gameId,
+            InitialGameStateJson: ValidGameStateJson);
+
+        var agentSessionId = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.NotEqual(Guid.Empty, agentSessionId);
+        _sessionRepoMock.Verify(r => r.AddAsync(It.IsAny<AgentSession>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────────
+    // Guard — duplicate active session
+    // ──────────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Handle_WhenActiveSessionExists_ThrowsConflictException()
+    {
+        _sessionRepoMock
+            .Setup(r => r.HasActiveSessionAsync(_gameSessionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var command = new LaunchSessionAgentCommand(
+            GameSessionId: _gameSessionId,
+            AgentDefinitionId: _agentDefinitionId,
+            UserId: _userId,
+            GameId: _gameId,
+            InitialGameStateJson: string.Empty);
+
+        await Assert.ThrowsAsync<ConflictException>(
+            () => _handler.Handle(command, CancellationToken.None));
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Validators/LaunchSessionAgentCommandValidatorTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Validators/LaunchSessionAgentCommandValidatorTests.cs
@@ -1,0 +1,265 @@
+using Api.BoundedContexts.KnowledgeBase.Application.Commands;
+using Api.BoundedContexts.KnowledgeBase.Application.Validators;
+using Api.BoundedContexts.KnowledgeBase.Domain.Entities;
+using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
+using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
+using Api.Tests.Constants;
+using FluentValidation.TestHelper;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Validators;
+
+/// <summary>
+/// Unit tests for LaunchSessionAgentCommandValidator — semantic validations V1–V4.
+/// Issue #2500: agent definition exists/active/game-match + JSON safe-parse.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "KnowledgeBase")]
+public sealed class LaunchSessionAgentCommandValidatorTests
+{
+    private static readonly Guid _gameSessionId = Guid.NewGuid();
+    private static readonly Guid _agentDefinitionId = Guid.NewGuid();
+    private static readonly Guid _userId = Guid.NewGuid();
+    private static readonly Guid _gameId = Guid.NewGuid();
+
+    // ActivePlayer must be a valid Guid (GameState.Create validates Guid != Empty)
+    private const string ValidGameStateJson =
+        """{"CurrentTurn":1,"ActivePlayer":"11111111-1111-1111-1111-111111111111","PlayerScores":{},"GamePhase":"setup","LastAction":"start"}""";
+
+    private readonly Mock<IAgentDefinitionRepository> _repoMock;
+    private readonly LaunchSessionAgentCommandValidator _validator;
+
+    public LaunchSessionAgentCommandValidatorTests()
+    {
+        _repoMock = new Mock<IAgentDefinitionRepository>();
+        _validator = new LaunchSessionAgentCommandValidator(_repoMock.Object);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────────
+    // Helpers
+    // ──────────────────────────────────────────────────────────────────────────────
+
+    private LaunchSessionAgentCommand ValidCommand(
+        Guid? agentDefinitionId = null,
+        Guid? gameId = null,
+        string? gameStateJson = null) =>
+        new(
+            GameSessionId: _gameSessionId,
+            AgentDefinitionId: agentDefinitionId ?? _agentDefinitionId,
+            UserId: _userId,
+            GameId: gameId ?? _gameId,
+            InitialGameStateJson: gameStateJson ?? ValidGameStateJson);
+
+    /// <summary>Creates a valid active AgentDefinition associated with the given game.</summary>
+    private static AgentDefinition CreateActiveDefinition(Guid? gameId = null)
+    {
+        var def = AgentDefinition.Create(
+            "Test Agent",
+            "Description",
+            AgentType.RagAgent,
+            AgentDefinitionConfig.Default());
+
+        def.Activate();
+
+        if (gameId.HasValue)
+            def.SetGameId(gameId.Value);
+
+        return def;
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────────
+    // Existing base-field rules still pass (regression guard)
+    // ──────────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Validate_EmptyGameSessionId_ReturnsError()
+    {
+        var command = new LaunchSessionAgentCommand(
+            GameSessionId: Guid.Empty,
+            AgentDefinitionId: _agentDefinitionId,
+            UserId: _userId,
+            GameId: _gameId,
+            InitialGameStateJson: ValidGameStateJson);
+
+        var result = await _validator.TestValidateAsync(command);
+
+        result.ShouldHaveValidationErrorFor(x => x.GameSessionId);
+    }
+
+    [Fact]
+    public async Task Validate_EmptyAgentDefinitionId_ReturnsError_AndDoesNotCallRepo()
+    {
+        var command = new LaunchSessionAgentCommand(
+            GameSessionId: _gameSessionId,
+            AgentDefinitionId: Guid.Empty,
+            UserId: _userId,
+            GameId: _gameId,
+            InitialGameStateJson: ValidGameStateJson);
+
+        var result = await _validator.TestValidateAsync(command);
+
+        result.ShouldHaveValidationErrorFor(x => x.AgentDefinitionId);
+        // Repo should NOT be called when the id is Guid.Empty (When gate)
+        _repoMock.Verify(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────────
+    // V1 — AgentDefinition exists
+    // ──────────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Validate_V1_AgentDefinitionNotFound_ReturnsError()
+    {
+        _repoMock
+            .Setup(r => r.GetByIdAsync(_agentDefinitionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((AgentDefinition?)null);
+
+        var command = ValidCommand();
+        var result = await _validator.TestValidateAsync(command);
+
+        result.ShouldHaveValidationErrorFor(x => x.AgentDefinitionId)
+            .WithErrorMessage("AgentDefinition not found or has been deleted.");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────────
+    // V2 — AgentDefinition is active
+    // ──────────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Validate_V2_InactiveAgentDefinition_ReturnsError()
+    {
+        var inactiveDef = AgentDefinition.Create(
+            "Inactive Agent",
+            "Description",
+            AgentType.RagAgent,
+            AgentDefinitionConfig.Default());
+        // NOT activated → IsActive = false
+        inactiveDef.SetGameId(_gameId);
+
+        _repoMock
+            .Setup(r => r.GetByIdAsync(_agentDefinitionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(inactiveDef);
+
+        var command = ValidCommand();
+        var result = await _validator.TestValidateAsync(command);
+
+        result.ShouldHaveValidationErrorFor(x => x.AgentDefinitionId)
+            .WithErrorMessage("AgentDefinition is not active.");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────────
+    // V3 — GameId match
+    // ──────────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Validate_V3_GameIdMismatch_ReturnsError()
+    {
+        var otherGameId = Guid.NewGuid();
+        var def = CreateActiveDefinition(gameId: otherGameId); // different game
+
+        _repoMock
+            .Setup(r => r.GetByIdAsync(_agentDefinitionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(def);
+
+        var command = ValidCommand(); // command.GameId = _gameId
+        var result = await _validator.TestValidateAsync(command);
+
+        result.ShouldHaveValidationErrorFor(x => x.AgentDefinitionId)
+            .WithErrorMessage("AgentDefinition does not belong to the specified game.");
+    }
+
+    [Fact]
+    public async Task Validate_V3_NullGameIdOnDefinition_ReturnsError()
+    {
+        // definition.GameId is null → does not match any Guid → should fail
+        var def = CreateActiveDefinition(gameId: null); // no game set
+
+        _repoMock
+            .Setup(r => r.GetByIdAsync(_agentDefinitionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(def);
+
+        var command = ValidCommand();
+        var result = await _validator.TestValidateAsync(command);
+
+        result.ShouldHaveValidationErrorFor(x => x.AgentDefinitionId)
+            .WithErrorMessage("AgentDefinition does not belong to the specified game.");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────────
+    // V4 — InitialGameStateJson safe-parse
+    // ──────────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Validate_V4_MalformedJson_ReturnsError()
+    {
+        // Repo not needed for V4 (but set up to avoid null on V1/V2/V3 if the definition is loaded)
+        // For this test we can return null from repo since we want to isolate the JSON rule.
+        // However, the When gate on V1-V3 requires id != Guid.Empty.
+        // Provide a valid definition so V1-V3 pass and only V4 fires.
+        var def = CreateActiveDefinition(gameId: _gameId);
+        _repoMock
+            .Setup(r => r.GetByIdAsync(_agentDefinitionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(def);
+
+        var command = ValidCommand(gameStateJson: "not-valid-json{{{");
+        var result = await _validator.TestValidateAsync(command);
+
+        result.ShouldHaveValidationErrorFor(x => x.InitialGameStateJson)
+            .WithErrorMessage("InitialGameStateJson is not a valid game state.");
+    }
+
+    [Fact]
+    public async Task Validate_V4_EmptyStringJson_IsHandledByNotEmptyRule_NotV4()
+    {
+        // When json is empty/whitespace the NotEmpty rule fires; V4 is gated with When(!IsNullOrWhiteSpace)
+        var command = new LaunchSessionAgentCommand(
+            GameSessionId: _gameSessionId,
+            AgentDefinitionId: _agentDefinitionId,
+            UserId: _userId,
+            GameId: _gameId,
+            InitialGameStateJson: string.Empty);
+
+        var result = await _validator.TestValidateAsync(command);
+
+        result.ShouldHaveValidationErrorFor(x => x.InitialGameStateJson);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────────
+    // Happy path — all validations pass
+    // ──────────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Validate_HappyPath_ActiveDefinitionMatchingGame_ValidJson_NoErrors()
+    {
+        var def = CreateActiveDefinition(gameId: _gameId);
+
+        _repoMock
+            .Setup(r => r.GetByIdAsync(_agentDefinitionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(def);
+
+        var command = ValidCommand();
+        var result = await _validator.TestValidateAsync(command);
+
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public async Task Validate_HappyPath_MinimalValidJson_NoErrors()
+    {
+        var def = CreateActiveDefinition(gameId: _gameId);
+
+        _repoMock
+            .Setup(r => r.GetByIdAsync(_agentDefinitionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(def);
+
+        // Minimal valid GameState JSON (all required fields; ActivePlayer must be a valid non-empty Guid)
+        const string minimalJson =
+            """{"CurrentTurn":1,"ActivePlayer":"22222222-2222-2222-2222-222222222222","PlayerScores":{},"GamePhase":"setup","LastAction":"none"}""";
+
+        var command = ValidCommand(gameStateJson: minimalJson);
+        var result = await _validator.TestValidateAsync(command);
+
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Validators/LaunchSessionAgentCommandValidatorTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Validators/LaunchSessionAgentCommandValidatorTests.cs
@@ -122,6 +122,32 @@ public sealed class LaunchSessionAgentCommandValidatorTests
             .WithErrorMessage("AgentDefinition not found or has been deleted.");
     }
 
+    /// <summary>
+    /// I2 fix: consolidated V1/V2/V3 must produce exactly ONE error and call GetByIdAsync exactly ONCE
+    /// when the definition is not found (not 3 errors + 3 queries like before).
+    /// </summary>
+    [Fact]
+    public async Task Validate_V1_AgentDefinitionNotFound_ExactlyOneError_ExactlyOneDbCall()
+    {
+        _repoMock
+            .Setup(r => r.GetByIdAsync(_agentDefinitionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((AgentDefinition?)null);
+
+        var command = ValidCommand();
+        var result = await _validator.TestValidateAsync(command);
+
+        // I2: exactly 1 error on AgentDefinitionId (not 3)
+        var definitionErrors = result.Errors
+            .Where(e => e.PropertyName == nameof(LaunchSessionAgentCommand.AgentDefinitionId))
+            .ToList();
+        Assert.Single(definitionErrors);
+
+        // I2: GetByIdAsync called exactly ONCE (not 3 times)
+        _repoMock.Verify(
+            r => r.GetByIdAsync(_agentDefinitionId, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
     // ──────────────────────────────────────────────────────────────────────────────
     // V2 — AgentDefinition is active
     // ──────────────────────────────────────────────────────────────────────────────
@@ -210,9 +236,15 @@ public sealed class LaunchSessionAgentCommandValidatorTests
     }
 
     [Fact]
-    public async Task Validate_V4_EmptyStringJson_IsHandledByNotEmptyRule_NotV4()
+    public async Task Validate_V4_EmptyStringJson_IsOptional_NoError()
     {
-        // When json is empty/whitespace the NotEmpty rule fires; V4 is gated with When(!IsNullOrWhiteSpace)
+        // C1 fix: InitialGameStateJson is optional — empty string means "use server default".
+        // V4 is gated with When(!IsNullOrWhiteSpace) so empty string must produce NO error on this field.
+        var def = CreateActiveDefinition(gameId: _gameId);
+        _repoMock
+            .Setup(r => r.GetByIdAsync(_agentDefinitionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(def);
+
         var command = new LaunchSessionAgentCommand(
             GameSessionId: _gameSessionId,
             AgentDefinitionId: _agentDefinitionId,
@@ -222,7 +254,28 @@ public sealed class LaunchSessionAgentCommandValidatorTests
 
         var result = await _validator.TestValidateAsync(command);
 
-        result.ShouldHaveValidationErrorFor(x => x.InitialGameStateJson);
+        result.ShouldNotHaveValidationErrorFor(x => x.InitialGameStateJson);
+    }
+
+    [Fact]
+    public async Task Validate_V4_WhitespaceJson_IsOptional_NoError()
+    {
+        // Whitespace is also treated as "use server default" — no error on InitialGameStateJson.
+        var def = CreateActiveDefinition(gameId: _gameId);
+        _repoMock
+            .Setup(r => r.GetByIdAsync(_agentDefinitionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(def);
+
+        var command = new LaunchSessionAgentCommand(
+            GameSessionId: _gameSessionId,
+            AgentDefinitionId: _agentDefinitionId,
+            UserId: _userId,
+            GameId: _gameId,
+            InitialGameStateJson: "   ");
+
+        var result = await _validator.TestValidateAsync(command);
+
+        result.ShouldNotHaveValidationErrorFor(x => x.InitialGameStateJson);
     }
 
     // ──────────────────────────────────────────────────────────────────────────────
@@ -239,6 +292,22 @@ public sealed class LaunchSessionAgentCommandValidatorTests
             .ReturnsAsync(def);
 
         var command = ValidCommand();
+        var result = await _validator.TestValidateAsync(command);
+
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public async Task Validate_HappyPath_EmptyGameStateJson_NoErrors()
+    {
+        // C1 fix: empty InitialGameStateJson is valid (handler uses GameState.Initial).
+        var def = CreateActiveDefinition(gameId: _gameId);
+
+        _repoMock
+            .Setup(r => r.GetByIdAsync(_agentDefinitionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(def);
+
+        var command = ValidCommand(gameStateJson: string.Empty);
         var result = await _validator.TestValidateAsync(command);
 
         result.ShouldNotHaveAnyValidationErrors();

--- a/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx
@@ -883,8 +883,26 @@ export function SessionLiveView(): ReactElement {
     !fixture
   );
   const agentSessionId = agentLaunch.agentSessionId;
+
+  // I1 (#2500 Opzione A): inject gameContext from LiveSessionDto so the RAG retrieval
+  // receives the real game/player context. The game-night store (useSessionStore) is NOT
+  // populated in the live session route, so we pass data explicitly here.
+  // Nullable gameId guard: if the session has no associated game, gameContext is undefined
+  // (RAG will still run in degraded mode, same as before).
+  const liveSessionDto = sessionQuery.data;
+  const agentGameContext = useMemo(() => {
+    if (!liveSessionDto?.gameId) return undefined;
+    return {
+      gameId: liveSessionDto.gameId,
+      gameTitle: liveSessionDto.gameName,
+      players: liveSessionDto.players.map(p => p.displayName),
+      currentTurn: liveSessionDto.currentTurnIndex,
+    };
+  }, [liveSessionDto]);
+
   const agentChat = useSessionAgentChat(sessionId ?? '', agentSessionId, {
     persistHistory: !fixture,
+    gameContext: agentGameContext,
   });
 
   // Map useSessionAgentChat.ChatMessage → LiveAgentChat.ChatMessage.

--- a/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx
@@ -100,8 +100,10 @@ import {
   type ScoringPanelRendererLabels,
   type ToolkitRendererLabels,
 } from '@/components/features/session-live';
+import type { ChatMessage as LiveAgentChatMessage } from '@/components/features/session-live/LiveAgentChat';
 import { useLiveSession } from '@/hooks/queries/useLiveSession';
 import { useTranslation } from '@/hooks/useTranslation';
+import { useSessionAgentChat } from '@/lib/domain-hooks/useSessionAgentChat';
 import { composeSessionLiveState } from '@/lib/session-live/compose-session-live-state';
 import { mapConnectionState } from '@/lib/session-live/map-connection-state';
 import { mapTurnDataToTurnState } from '@/lib/session-live/map-turn-data-to-turn-state';
@@ -489,23 +491,11 @@ export function SessionLiveView(): ReactElement {
   // useUpdateSessionScores → PUT /game-sessions/{id}/scores-polymorphic
   // (wired in ScoreTabContent).
 
-  const handleSendMessage = useCallback(
-    async (content: string, visibility: 'private' | 'shared'): Promise<void> => {
-      if (sessionId == null) return;
-
-      try {
-        await fetch(`/api/v1/game-sessions/${sessionId}/chat`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ content, visibility }),
-          credentials: 'include',
-        });
-      } catch {
-        // Fail silently — SSE event confirms or not
-      }
-    },
-    [sessionId]
-  );
+  // NOTE: the social-chat POST handler (/game-sessions/{id}/chat) was retired
+  // in #2500 Task 4 (AC-CHAT-0). ChatAgentPanel now routes through handleAgentSendMessage
+  // (→ useSessionAgentChat → /agent/chat RAG endpoint). The social endpoint remains
+  // available on the backend for SSE-driven action-log entries but is no longer
+  // called from this orchestrator.
 
   const handleAddNote = useCallback(
     async (content: string, visibility: 'private' | 'shared'): Promise<void> => {
@@ -875,22 +865,47 @@ export function SessionLiveView(): ReactElement {
     [activeSession]
   );
 
+  // ── RAG agent chat (AC-CHAT-0) ────────────────────────────────────────────
+  // agentSessionId comes from the LiveSessionDto.chatSessionId field.
+  // When fixture mode is active or the DTO has no chatSessionId, we pass an
+  // empty string — the hook is called unconditionally (rules-of-hooks) and
+  // guarded in handleAgentSendMessage below (AC-CHAT-NULL).
+  const agentSessionId = sessionQuery.data?.chatSessionId ?? '';
+  const agentChat = useSessionAgentChat(sessionId ?? '', agentSessionId);
+
+  // Map useSessionAgentChat.ChatMessage → LiveAgentChat.ChatMessage.
+  // The two shapes differ: agent uses role:'user'|'assistant', LiveAgentChat uses
+  // senderId/senderName/visibility.  We map:
+  //   role:'user'      → senderId=viewerId (or 'user' fallback), visibility:'shared'
+  //   role:'assistant' → senderId='agent', senderName='MeepleAI', visibility:'shared'
+  // Citations pass through unchanged (same ChatCitation type, shared via ChatCitationCard import).
+  const agentChatMessages = useMemo<LiveAgentChatMessage[]>(() => {
+    const viewerId = activeSession?.viewerId ?? 'user';
+    return agentChat.messages.map(m => ({
+      id: m.id,
+      senderId: m.role === 'user' ? viewerId : 'agent',
+      senderName: m.role === 'user' ? '' : 'MeepleAI',
+      content: m.content,
+      visibility: 'shared' as const,
+      timestamp: m.timestamp,
+      citations: m.citations,
+    }));
+  }, [agentChat.messages, activeSession?.viewerId]);
+
+  // AC-CHAT-0: send goes to the RAG agent, NOT /game-sessions/{id}/chat.
+  // AC-CHAT-NULL: if agentSessionId absent (null/empty), suppress the call silently.
+  const handleAgentSendMessage = useCallback(
+    async (content: string, _visibility: 'private' | 'shared'): Promise<void> => {
+      if (!agentSessionId || !content.trim()) return;
+      await agentChat.ask(content);
+    },
+    [agentSessionId, agentChat]
+  );
+
   // ── Chat messages from SSE events ────────────────────────────────────────
-  // Extract chat messages from liveState actionLog (type='chat' entries).
-  // Foundation proxy: fixture has no chat messages.
-  const chatMessages = useMemo(() => {
-    if (activeSession == null) return [];
-    return activeSession.actionLog
-      .filter(e => e.type === 'chat')
-      .map(e => ({
-        id: e.id,
-        senderId: e.authorName,
-        senderName: e.authorName,
-        content: e.content,
-        visibility: 'shared' as const,
-        timestamp: e.timestamp,
-      }));
-  }, [activeSession]);
+  // NOTE: ChatAgentPanel now receives agentChatMessages (RAG) — see above.
+  // ActionLogTimeline uses activeSession.actionLog directly; this extraction
+  // is no longer needed and has been removed to avoid unused-var lint errors.
 
   // ── Notes from SSE events ────────────────────────────────────────────────
   const noteEntries = useMemo(() => {
@@ -932,10 +947,10 @@ export function SessionLiveView(): ReactElement {
       <div className="flex flex-col gap-3">
         <ChatAgentPanel
           sessionId={sessionId}
-          messages={chatMessages}
+          messages={agentChatMessages}
           viewerRole={activeSession.viewerRole}
           viewerId={activeSession.viewerId}
-          onSendMessage={handleSendMessage}
+          onSendMessage={handleAgentSendMessage}
           agentName="MeepleAI"
           agentEmoji="🤖"
           latencyMs={42}
@@ -950,8 +965,8 @@ export function SessionLiveView(): ReactElement {
   }, [
     activeSession,
     sessionId,
-    chatMessages,
-    handleSendMessage,
+    agentChatMessages,
+    handleAgentSendMessage,
     chatAgentLabels,
     actionLogLabels,
     mobileChatCollapsed,
@@ -1124,10 +1139,10 @@ export function SessionLiveView(): ReactElement {
     <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-hidden p-3">
       <ChatAgentPanel
         sessionId={sessionId}
-        messages={chatMessages}
+        messages={agentChatMessages}
         viewerRole={activeSession.viewerRole}
         viewerId={activeSession.viewerId}
-        onSendMessage={handleSendMessage}
+        onSendMessage={handleAgentSendMessage}
         agentName="MeepleAI"
         agentEmoji="🤖"
         latencyMs={42}

--- a/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx
@@ -883,7 +883,9 @@ export function SessionLiveView(): ReactElement {
     !fixture
   );
   const agentSessionId = agentLaunch.agentSessionId;
-  const agentChat = useSessionAgentChat(sessionId ?? '', agentSessionId);
+  const agentChat = useSessionAgentChat(sessionId ?? '', agentSessionId, {
+    persistHistory: !fixture,
+  });
 
   // Map useSessionAgentChat.ChatMessage → LiveAgentChat.ChatMessage.
   // The two shapes differ: agent uses role:'user'|'assistant', LiveAgentChat uses

--- a/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx
@@ -906,6 +906,9 @@ export function SessionLiveView(): ReactElement {
       visibility: 'shared' as const,
       timestamp: m.timestamp,
       citations: m.citations,
+      // AC-CHAT-3: propagate isNonGrounded ONLY from hook messages.
+      // System status messages (prepended below) do NOT get this flag → no disclaimer.
+      isNonGrounded: m.isNonGrounded,
     }));
 
     // Prepend a system status message when not ready (R-FINDING-5).

--- a/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx
@@ -102,6 +102,7 @@ import {
 } from '@/components/features/session-live';
 import type { ChatMessage as LiveAgentChatMessage } from '@/components/features/session-live/LiveAgentChat';
 import { useLiveSession } from '@/hooks/queries/useLiveSession';
+import { useSessionAgentLaunch } from '@/hooks/queries/useSessionAgentLaunch';
 import { useTranslation } from '@/hooks/useTranslation';
 import { useSessionAgentChat } from '@/lib/domain-hooks/useSessionAgentChat';
 import { composeSessionLiveState } from '@/lib/session-live/compose-session-live-state';
@@ -866,22 +867,36 @@ export function SessionLiveView(): ReactElement {
   );
 
   // ── RAG agent chat (AC-CHAT-0) ────────────────────────────────────────────
-  // agentSessionId comes from the LiveSessionDto.chatSessionId field.
-  // When fixture mode is active or the DTO has no chatSessionId, we pass an
-  // empty string — the hook is called unconditionally (rules-of-hooks) and
-  // guarded in handleAgentSendMessage below (AC-CHAT-NULL).
-  const agentSessionId = sessionQuery.data?.chatSessionId ?? '';
+  // agentSessionId is resolved lazily via useSessionAgentLaunch:
+  //   1. getAgents(gameId) → pick first active agent
+  //   2. launch(sessionId, { agentDefinitionId }) → { agentSessionId }
+  // status discriminates lifecycle so the panel always shows feedback (R-FINDING-5):
+  //   'idle'      → preconditions not met (no sessionId/gameId or fixture mode)
+  //   'launching' → getAgents/launch in flight
+  //   'ready'     → agentSessionId obtained, chat can send
+  //   'no-agent'  → no assistant for this game
+  //   'error'     → getAgents or launch failed
+  // Disabled in fixture/visual-test builds so no real fetch is issued.
+  const agentLaunch = useSessionAgentLaunch(
+    sessionId ?? null,
+    sessionQuery.data?.gameId ?? null,
+    !fixture
+  );
+  const agentSessionId = agentLaunch.agentSessionId;
   const agentChat = useSessionAgentChat(sessionId ?? '', agentSessionId);
 
   // Map useSessionAgentChat.ChatMessage → LiveAgentChat.ChatMessage.
   // The two shapes differ: agent uses role:'user'|'assistant', LiveAgentChat uses
   // senderId/senderName/visibility.  We map:
-  //   role:'user'      → senderId=viewerId (or 'user' fallback), visibility:'shared'
+  //   role:'user'      → senderId=viewerId (consistent with how LiveAgentChat
+  //                       computes isOwn; '' when viewerId not yet known — R-FINDING-6)
   //   role:'assistant' → senderId='agent', senderName='MeepleAI', visibility:'shared'
   // Citations pass through unchanged (same ChatCitation type, shared via ChatCitationCard import).
+  // When the launch is not yet ready, a single system message is prepended so the user
+  // always sees feedback instead of a silent empty panel (R-FINDING-5 / AC-CHAT-NULL).
   const agentChatMessages = useMemo<LiveAgentChatMessage[]>(() => {
-    const viewerId = activeSession?.viewerId ?? 'user';
-    return agentChat.messages.map(m => ({
+    const viewerId = activeSession?.viewerId ?? '';
+    const realMessages = agentChat.messages.map(m => ({
       id: m.id,
       senderId: m.role === 'user' ? viewerId : 'agent',
       senderName: m.role === 'user' ? '' : 'MeepleAI',
@@ -890,10 +905,36 @@ export function SessionLiveView(): ReactElement {
       timestamp: m.timestamp,
       citations: m.citations,
     }));
-  }, [agentChat.messages, activeSession?.viewerId]);
+
+    // Prepend a system status message when not ready (R-FINDING-5).
+    // 'idle' → preconditions not met yet, no message needed.
+    let statusContent: string | null = null;
+    if (agentLaunch.status === 'launching') {
+      statusContent = t('pages.sessionLive.chatAgent.launchingMessage');
+    } else if (agentLaunch.status === 'no-agent') {
+      statusContent = t('pages.sessionLive.chatAgent.noAgentMessage');
+    } else if (agentLaunch.status === 'error') {
+      statusContent = t('pages.sessionLive.chatAgent.errorMessage');
+    }
+
+    if (statusContent != null) {
+      const statusMessage: LiveAgentChatMessage = {
+        id: `agent-status-${agentLaunch.status}`,
+        senderId: 'agent',
+        senderName: 'MeepleAI',
+        content: statusContent,
+        visibility: 'shared' as const,
+        timestamp: new Date().toISOString(),
+      };
+      return [statusMessage, ...realMessages];
+    }
+
+    return realMessages;
+  }, [agentChat.messages, activeSession?.viewerId, agentLaunch.status, t]);
 
   // AC-CHAT-0: send goes to the RAG agent, NOT /game-sessions/{id}/chat.
-  // AC-CHAT-NULL: if agentSessionId absent (null/empty), suppress the call silently.
+  // AC-CHAT-NULL: if agentLaunch.status !== 'ready', agent is not available yet —
+  // the status message above provides user feedback; suppress the actual ask() call.
   const handleAgentSendMessage = useCallback(
     async (content: string, _visibility: 'private' | 'shared'): Promise<void> => {
       if (!agentSessionId || !content.trim()) return;

--- a/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/__tests__/SessionLiveView.test.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/__tests__/SessionLiveView.test.tsx
@@ -269,6 +269,7 @@ const MESSAGES: Record<string, string> = {
   'pages.sessionLive.chatAgent.noAgentMessage': 'Nessun assistente disponibile per questo gioco.',
   'pages.sessionLive.chatAgent.errorMessage':
     "Impossibile avviare l'assistente. Riprova più tardi.",
+  'pages.sessionLive.chatAgent.nonGroundedDisclaimer': 'Risposta non basata sul regolamento',
   // MobileBody bottom-sheet labels (G1 #2374 T9 — sess.46r)
   'pages.sessionLive.mobile.openSheetCta': 'Apri pannello',
   'pages.sessionLive.mobile.closeSheetAriaLabel': 'Chiudi pannello',
@@ -1560,5 +1561,77 @@ describe('SessionLiveView — #2500 Task 4-FE: RAG agent wiring via useSessionAg
     const { container } = renderWithIntl(<SessionLiveView />);
     // The message content should be present
     expect(container.textContent).toContain('Domanda utente');
+  });
+
+  // ─── AC-CHAT-3: vincolo critico — disclaimer NOT su messaggi di sistema di stato ───
+
+  it('RAG-12 (AC-CHAT-3 critical): system status message (no-agent) NON mostra il disclaimer non-grounded', () => {
+    // Un messaggio di SISTEMA (iniettato da SessionLiveView per status no-agent)
+    // non deve mostrare il disclaimer non-grounded, anche se è assistant senza citazioni.
+    useSessionAgentLaunchMock.mockReturnValue({
+      status: 'no-agent' as const,
+      agentSessionId: '',
+    });
+    useSessionAgentChatMock.mockReturnValue({
+      messages: [], // nessun messaggio dal hook — il messaggio viene iniettato da SessionLiveView
+      isLoading: false,
+      error: null,
+      streamingContent: '',
+      ask: agentAskMock,
+      stop: vi.fn(),
+    });
+    const { container } = renderWithIntl(<SessionLiveView />);
+    // Il messaggio di stato è presente nel DOM
+    expect(container.textContent).toMatch(/Nessun assistente/i);
+    // Il disclaimer non-grounded NON deve apparire sui messaggi di sistema
+    expect(
+      container.querySelector('[data-slot="chat-nongrounded-disclaimer"]')
+    ).not.toBeInTheDocument();
+  });
+
+  it('RAG-12b (AC-CHAT-3 critical): system status message (error) NON mostra il disclaimer non-grounded', () => {
+    useSessionAgentLaunchMock.mockReturnValue({
+      status: 'error' as const,
+      agentSessionId: '',
+    });
+    useSessionAgentChatMock.mockReturnValue({
+      messages: [],
+      isLoading: false,
+      error: null,
+      streamingContent: '',
+      ask: agentAskMock,
+      stop: vi.fn(),
+    });
+    const { container } = renderWithIntl(<SessionLiveView />);
+    expect(container.textContent).toMatch(/Impossibile avviare/i);
+    expect(
+      container.querySelector('[data-slot="chat-nongrounded-disclaimer"]')
+    ).not.toBeInTheDocument();
+  });
+
+  it('RAG-13 (AC-CHAT-3): vera risposta RAG senza citazioni (isNonGrounded:true) MOSTRA il disclaimer', () => {
+    // Il hook produce un messaggio assistant con isNonGrounded:true (vera risposta RAG, 0 citazioni)
+    useSessionAgentChatMock.mockReturnValue({
+      messages: [
+        {
+          id: 'msg-ng-rag',
+          role: 'assistant' as const,
+          content: 'Risposta RAG senza fonti.',
+          timestamp: new Date().toISOString(),
+          citations: undefined,
+          isNonGrounded: true,
+        },
+      ],
+      isLoading: false,
+      error: null,
+      streamingContent: '',
+      ask: agentAskMock,
+      stop: vi.fn(),
+    });
+    const { container } = renderWithIntl(<SessionLiveView />);
+    // Il disclaimer deve essere presente
+    expect(
+      container.querySelector('[data-slot="chat-nongrounded-disclaimer"]')
+    ).toBeInTheDocument();
   });
 });

--- a/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/__tests__/SessionLiveView.test.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/__tests__/SessionLiveView.test.tsx
@@ -133,6 +133,18 @@ vi.mock('@/lib/domain-hooks/useSessionAgentChat', () => ({
   useSessionAgentChat: (...args: unknown[]) => useSessionAgentChatMock(...args),
 }));
 
+// ─── useSessionAgentLaunch mock (#2500 Task 4-FE: wire hook) ──────────────
+// Default: 'ready' with a valid agentSessionId so other describe blocks are unaffected.
+
+const useSessionAgentLaunchMock = vi.fn(() => ({
+  status: 'ready' as const,
+  agentSessionId: 'agent-session-uuid-0001',
+}));
+
+vi.mock('@/hooks/queries/useSessionAgentLaunch', () => ({
+  useSessionAgentLaunch: (...args: unknown[]) => useSessionAgentLaunchMock(...args),
+}));
+
 // ─── visual-test-fixture mock ─────────────────────────────────────────────
 
 let IS_VISUAL_TEST_BUILD_MOCK = false;
@@ -252,6 +264,11 @@ const MESSAGES: Record<string, string> = {
   'pages.sessionLive.chatAgent.agentNameAriaLabel': 'Nome agente {name}',
   'pages.sessionLive.chatAgent.onlineLabel': 'Online',
   'pages.sessionLive.chatAgent.latencyAriaLabel': 'Latenza {ms}ms',
+  // Agent launch status feedback messages (#2500 Task 4-FE R-FINDING-5)
+  'pages.sessionLive.chatAgent.launchingMessage': "Avvio dell'assistente di gioco…",
+  'pages.sessionLive.chatAgent.noAgentMessage': 'Nessun assistente disponibile per questo gioco.',
+  'pages.sessionLive.chatAgent.errorMessage':
+    "Impossibile avviare l'assistente. Riprova più tardi.",
   // MobileBody bottom-sheet labels (G1 #2374 T9 — sess.46r)
   'pages.sessionLive.mobile.openSheetCta': 'Apri pannello',
   'pages.sessionLive.mobile.closeSheetAriaLabel': 'Chiudi pannello',
@@ -1357,11 +1374,12 @@ describe('SessionLiveView — #2483 Task 4: TurnIndicatorRenderer from store', (
   // round-based turn metadata is deferred to Fase 2.
 });
 
-// ─── #2500 Task 4 — RAG agent wired into ChatAgentPanel ──────────────────────
+// ─── #2500 Task 4-FE — useSessionAgentLaunch wired into ChatAgentPanel ──────────
 // AC-CHAT-0: send goes through useSessionAgentChat (RAG path), not /chat social endpoint.
-// AC-CHAT-NULL: when agentSessionId absent → panel renders without crash.
+// AC-CHAT-NULL: when agentSessionId absent → panel renders + status feedback visible.
+// R-FINDING-4/5/6: correct comments, status feedback messages, viewerId consistency.
 
-describe('SessionLiveView — #2500 Task 4: RAG agent wiring', () => {
+describe('SessionLiveView — #2500 Task 4-FE: RAG agent wiring via useSessionAgentLaunch', () => {
   const agentAskMock = vi.fn();
 
   beforeEach(() => {
@@ -1370,7 +1388,7 @@ describe('SessionLiveView — #2500 Task 4: RAG agent wiring', () => {
     mockParamsId = 'session-abc-123';
     IS_VISUAL_TEST_BUILD_MOCK = false;
     useLiveSessionMock.mockReturnValue({
-      data: { ...MOCK_SESSION_DTO, chatSessionId: 'agent-session-uuid-0001' },
+      data: { ...MOCK_SESSION_DTO, gameId: 'game-00000001' },
       isLoading: false,
       isError: false,
       isSuccess: true,
@@ -1378,6 +1396,10 @@ describe('SessionLiveView — #2500 Task 4: RAG agent wiring', () => {
       refetch: vi.fn(),
     });
     useSessionLiveStreamMock.mockReturnValue({ ...mockLiveStreamResult });
+    useSessionAgentLaunchMock.mockReturnValue({
+      status: 'ready' as const,
+      agentSessionId: 'agent-session-uuid-0001',
+    });
     useSessionAgentChatMock.mockReturnValue({
       messages: [],
       isLoading: false,
@@ -1388,19 +1410,15 @@ describe('SessionLiveView — #2500 Task 4: RAG agent wiring', () => {
     });
   });
 
-  it('RAG-1: renders ChatAgentPanel without crash when chatSessionId present', () => {
+  it('RAG-1: renders ChatAgentPanel without crash when agentLaunch is ready', () => {
     const { container } = renderWithIntl(<SessionLiveView />);
     expect(container.querySelector('[data-slot="chat-agent-panel"]')).toBeInTheDocument();
   });
 
-  it('RAG-2: AC-CHAT-NULL — renders ChatAgentPanel without crash when chatSessionId is null', () => {
-    useLiveSessionMock.mockReturnValue({
-      data: { ...MOCK_SESSION_DTO, chatSessionId: null },
-      isLoading: false,
-      isError: false,
-      isSuccess: true,
-      error: null,
-      refetch: vi.fn(),
+  it('RAG-2: AC-CHAT-NULL — renders ChatAgentPanel without crash when no-agent status', () => {
+    useSessionAgentLaunchMock.mockReturnValue({
+      status: 'no-agent' as const,
+      agentSessionId: '',
     });
     useSessionAgentChatMock.mockReturnValue({
       messages: [],
@@ -1438,7 +1456,7 @@ describe('SessionLiveView — #2500 Task 4: RAG agent wiring', () => {
     expect(container.textContent).toMatch(/pag\.\s*7/i);
   });
 
-  it('RAG-4: useSessionAgentChat is called with sessionId and chatSessionId from DTO', () => {
+  it('RAG-4: useSessionAgentChat is called with sessionId and agentSessionId from useSessionAgentLaunch', () => {
     renderWithIntl(<SessionLiveView />);
     expect(useSessionAgentChatMock).toHaveBeenCalledWith(
       'session-abc-123',
@@ -1446,14 +1464,10 @@ describe('SessionLiveView — #2500 Task 4: RAG agent wiring', () => {
     );
   });
 
-  it('RAG-5: AC-CHAT-NULL — useSessionAgentChat called with empty string when chatSessionId is null', () => {
-    useLiveSessionMock.mockReturnValue({
-      data: { ...MOCK_SESSION_DTO, chatSessionId: null },
-      isLoading: false,
-      isError: false,
-      isSuccess: true,
-      error: null,
-      refetch: vi.fn(),
+  it('RAG-5: AC-CHAT-NULL — useSessionAgentChat called with empty string when no-agent', () => {
+    useSessionAgentLaunchMock.mockReturnValue({
+      status: 'no-agent' as const,
+      agentSessionId: '',
     });
     useSessionAgentChatMock.mockReturnValue({
       messages: [],
@@ -1464,7 +1478,83 @@ describe('SessionLiveView — #2500 Task 4: RAG agent wiring', () => {
       stop: vi.fn(),
     });
     renderWithIntl(<SessionLiveView />);
-    // Hook called with empty agentSessionId guard
+    // Hook called with empty agentSessionId guard (no-agent → no ready session)
     expect(useSessionAgentChatMock).toHaveBeenCalledWith('session-abc-123', '');
+  });
+
+  it('RAG-6: useSessionAgentLaunch called with sessionId, gameId, and !fixture', () => {
+    renderWithIntl(<SessionLiveView />);
+    expect(useSessionAgentLaunchMock).toHaveBeenCalledWith(
+      'session-abc-123',
+      'game-00000001',
+      true // enabled = !fixture = !false
+    );
+  });
+
+  it('RAG-7: useSessionAgentLaunch disabled in fixture mode (IS_VISUAL_TEST_BUILD)', () => {
+    IS_VISUAL_TEST_BUILD_MOCK = true;
+    renderWithIntl(<SessionLiveView />);
+    expect(useSessionAgentLaunchMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      false // enabled = !fixture = !true
+    );
+  });
+
+  // R-FINDING-5: feedback messages for non-ready status
+  it('RAG-8: launching status — shows launching feedback message in chat', () => {
+    useSessionAgentLaunchMock.mockReturnValue({
+      status: 'launching' as const,
+      agentSessionId: '',
+    });
+    const { container } = renderWithIntl(<SessionLiveView />);
+    // Launching message appears in the chat messages list
+    expect(container.textContent).toMatch(/Avvio/i);
+  });
+
+  it('RAG-9: no-agent status — shows no-agent feedback message in chat', () => {
+    useSessionAgentLaunchMock.mockReturnValue({
+      status: 'no-agent' as const,
+      agentSessionId: '',
+    });
+    const { container } = renderWithIntl(<SessionLiveView />);
+    expect(container.textContent).toMatch(/Nessun assistente/i);
+  });
+
+  it('RAG-10: error status — shows error feedback message in chat', () => {
+    useSessionAgentLaunchMock.mockReturnValue({
+      status: 'error' as const,
+      agentSessionId: '',
+    });
+    const { container } = renderWithIntl(<SessionLiveView />);
+    expect(container.textContent).toMatch(/Impossibile avviare/i);
+  });
+
+  // R-FINDING-6: viewerId consistency — no magic-string 'user' fallback
+  it('RAG-11: user messages use viewerId from activeSession (not magic-string fallback)', () => {
+    // When activeSession.viewerId is '', messages should have senderId='' not 'user'
+    useSessionAgentChatMock.mockReturnValue({
+      messages: [
+        {
+          id: 'msg-user-1',
+          role: 'user' as const,
+          content: 'Domanda utente',
+          timestamp: new Date().toISOString(),
+          citations: undefined,
+        },
+      ],
+      isLoading: false,
+      error: null,
+      streamingContent: '',
+      ask: agentAskMock,
+      stop: vi.fn(),
+    });
+    // If viewerId is '' (activeSession default) and senderId is '', the message
+    // is own (isOwn=true) — no sender name label. The test checks no 'user' magic string
+    // by verifying the mapped senderId matches viewerId (both ''). Since both are '',
+    // isOwn=true, and the <span senderName> should NOT appear (only shown when !isOwn).
+    const { container } = renderWithIntl(<SessionLiveView />);
+    // The message content should be present
+    expect(container.textContent).toContain('Domanda utente');
   });
 });

--- a/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/__tests__/SessionLiveView.test.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/__tests__/SessionLiveView.test.tsx
@@ -1460,7 +1460,8 @@ describe('SessionLiveView — #2500 Task 4-FE: RAG agent wiring via useSessionAg
     renderWithIntl(<SessionLiveView />);
     expect(useSessionAgentChatMock).toHaveBeenCalledWith(
       'session-abc-123',
-      'agent-session-uuid-0001'
+      'agent-session-uuid-0001',
+      { persistHistory: true } // fixture=false in test → !fixture=true (R5 #2500)
     );
   });
 
@@ -1479,7 +1480,10 @@ describe('SessionLiveView — #2500 Task 4-FE: RAG agent wiring via useSessionAg
     });
     renderWithIntl(<SessionLiveView />);
     // Hook called with empty agentSessionId guard (no-agent → no ready session)
-    expect(useSessionAgentChatMock).toHaveBeenCalledWith('session-abc-123', '');
+    // R5: persistHistory passed as third arg — fixture=false → !fixture=true
+    expect(useSessionAgentChatMock).toHaveBeenCalledWith('session-abc-123', '', {
+      persistHistory: true,
+    });
   });
 
   it('RAG-6: useSessionAgentLaunch called with sessionId, gameId, and !fixture', () => {

--- a/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/__tests__/SessionLiveView.test.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/__tests__/SessionLiveView.test.tsx
@@ -116,6 +116,23 @@ vi.mock('sonner', () => ({
   },
 }));
 
+// ─── useSessionAgentChat mock (#2500 Task 4: RAG agent wiring) ────────────
+// Hoisted globally so all describe blocks get a safe no-op default.
+// The RAG-specific describe block overrides the return value in its beforeEach.
+
+const useSessionAgentChatMock = vi.fn(() => ({
+  messages: [],
+  isLoading: false,
+  error: null,
+  streamingContent: '',
+  ask: vi.fn(),
+  stop: vi.fn(),
+}));
+
+vi.mock('@/lib/domain-hooks/useSessionAgentChat', () => ({
+  useSessionAgentChat: (...args: unknown[]) => useSessionAgentChatMock(...args),
+}));
+
 // ─── visual-test-fixture mock ─────────────────────────────────────────────
 
 let IS_VISUAL_TEST_BUILD_MOCK = false;
@@ -1338,4 +1355,116 @@ describe('SessionLiveView — #2483 Task 4: TurnIndicatorRenderer from store', (
   // longer hydrated from the DTO loader (LiveSessionDto exposes no turnOrderType).
   // The store-seeded branch tests above cover the renderer; DTO→store wiring for
   // round-based turn metadata is deferred to Fase 2.
+});
+
+// ─── #2500 Task 4 — RAG agent wired into ChatAgentPanel ──────────────────────
+// AC-CHAT-0: send goes through useSessionAgentChat (RAG path), not /chat social endpoint.
+// AC-CHAT-NULL: when agentSessionId absent → panel renders without crash.
+
+describe('SessionLiveView — #2500 Task 4: RAG agent wiring', () => {
+  const agentAskMock = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.keys(searchParamsMap).forEach(k => delete searchParamsMap[k]);
+    mockParamsId = 'session-abc-123';
+    IS_VISUAL_TEST_BUILD_MOCK = false;
+    useLiveSessionMock.mockReturnValue({
+      data: { ...MOCK_SESSION_DTO, chatSessionId: 'agent-session-uuid-0001' },
+      isLoading: false,
+      isError: false,
+      isSuccess: true,
+      error: null,
+      refetch: vi.fn(),
+    });
+    useSessionLiveStreamMock.mockReturnValue({ ...mockLiveStreamResult });
+    useSessionAgentChatMock.mockReturnValue({
+      messages: [],
+      isLoading: false,
+      error: null,
+      streamingContent: '',
+      ask: agentAskMock,
+      stop: vi.fn(),
+    });
+  });
+
+  it('RAG-1: renders ChatAgentPanel without crash when chatSessionId present', () => {
+    const { container } = renderWithIntl(<SessionLiveView />);
+    expect(container.querySelector('[data-slot="chat-agent-panel"]')).toBeInTheDocument();
+  });
+
+  it('RAG-2: AC-CHAT-NULL — renders ChatAgentPanel without crash when chatSessionId is null', () => {
+    useLiveSessionMock.mockReturnValue({
+      data: { ...MOCK_SESSION_DTO, chatSessionId: null },
+      isLoading: false,
+      isError: false,
+      isSuccess: true,
+      error: null,
+      refetch: vi.fn(),
+    });
+    useSessionAgentChatMock.mockReturnValue({
+      messages: [],
+      isLoading: false,
+      error: null,
+      streamingContent: '',
+      ask: agentAskMock,
+      stop: vi.fn(),
+    });
+    expect(() => renderWithIntl(<SessionLiveView />)).not.toThrow();
+    const { container } = renderWithIntl(<SessionLiveView />);
+    expect(container.querySelector('[data-slot="chat-agent-panel"]')).toBeInTheDocument();
+  });
+
+  it('RAG-3: assistant citation is rendered in ChatAgentPanel (pag. N pattern)', () => {
+    useSessionAgentChatMock.mockReturnValue({
+      messages: [
+        {
+          id: 'msg-001',
+          role: 'assistant' as const,
+          content: 'Il regolamento dice…',
+          timestamp: new Date().toISOString(),
+          citations: [{ documentName: 'Reg', pages: [7], excerpt: 'x' }],
+        },
+      ],
+      isLoading: false,
+      error: null,
+      streamingContent: '',
+      ask: agentAskMock,
+      stop: vi.fn(),
+    });
+    const { container } = renderWithIntl(<SessionLiveView />);
+    // Citation card renders "pag. 7" (or page list) — asserting presence
+    expect(container.querySelector('[data-slot="chat-citations"]')).toBeInTheDocument();
+    expect(container.textContent).toMatch(/pag\.\s*7/i);
+  });
+
+  it('RAG-4: useSessionAgentChat is called with sessionId and chatSessionId from DTO', () => {
+    renderWithIntl(<SessionLiveView />);
+    expect(useSessionAgentChatMock).toHaveBeenCalledWith(
+      'session-abc-123',
+      'agent-session-uuid-0001'
+    );
+  });
+
+  it('RAG-5: AC-CHAT-NULL — useSessionAgentChat called with empty string when chatSessionId is null', () => {
+    useLiveSessionMock.mockReturnValue({
+      data: { ...MOCK_SESSION_DTO, chatSessionId: null },
+      isLoading: false,
+      isError: false,
+      isSuccess: true,
+      error: null,
+      refetch: vi.fn(),
+    });
+    useSessionAgentChatMock.mockReturnValue({
+      messages: [],
+      isLoading: false,
+      error: null,
+      streamingContent: '',
+      ask: agentAskMock,
+      stop: vi.fn(),
+    });
+    renderWithIntl(<SessionLiveView />);
+    // Hook called with empty agentSessionId guard
+    expect(useSessionAgentChatMock).toHaveBeenCalledWith('session-abc-123', '');
+  });
 });

--- a/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/__tests__/SessionLiveView.test.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/__tests__/SessionLiveView.test.tsx
@@ -1462,7 +1462,16 @@ describe('SessionLiveView — #2500 Task 4-FE: RAG agent wiring via useSessionAg
     expect(useSessionAgentChatMock).toHaveBeenCalledWith(
       'session-abc-123',
       'agent-session-uuid-0001',
-      { persistHistory: true } // fixture=false in test → !fixture=true (R5 #2500)
+      {
+        persistHistory: true, // fixture=false in test → !fixture=true (R5 #2500)
+        gameContext: {
+          // I1 #2500: built from LiveSessionDto, not from useSessionStore
+          gameId: 'game-00000001',
+          gameTitle: 'Mage Knight',
+          players: ['Marco', 'Anna'],
+          currentTurn: 0,
+        },
+      }
     );
   });
 
@@ -1482,8 +1491,15 @@ describe('SessionLiveView — #2500 Task 4-FE: RAG agent wiring via useSessionAg
     renderWithIntl(<SessionLiveView />);
     // Hook called with empty agentSessionId guard (no-agent → no ready session)
     // R5: persistHistory passed as third arg — fixture=false → !fixture=true
+    // I1 #2500: gameContext still injected from LiveSessionDto even when no-agent
     expect(useSessionAgentChatMock).toHaveBeenCalledWith('session-abc-123', '', {
       persistHistory: true,
+      gameContext: {
+        gameId: 'game-00000001',
+        gameTitle: 'Mage Knight',
+        players: ['Marco', 'Anna'],
+        currentTurn: 0,
+      },
     });
   });
 

--- a/apps/web/src/components/features/session-live/LiveAgentChat.tsx
+++ b/apps/web/src/components/features/session-live/LiveAgentChat.tsx
@@ -25,6 +25,7 @@ import { type ReactElement, useEffect, useRef, useState, type RefObject } from '
 import { Send } from 'lucide-react';
 import { useIntl } from 'react-intl';
 
+import { type ChatCitation, ChatCitationCard } from '@/components/chat/panel/ChatCitationCard';
 import type { ParticipantRole } from '@/lib/session-live/participant-role';
 import { useChatDraft } from '@/lib/session-live/use-chat-draft';
 import { useScrollAnchor } from '@/lib/session-live/use-scroll-anchor';
@@ -38,6 +39,7 @@ export interface ChatMessage {
   readonly content: string;
   readonly visibility: 'private' | 'shared';
   readonly timestamp: string;
+  readonly citations?: readonly ChatCitation[];
 }
 
 // ─── Labels ───────────────────────────────────────────────────────────────────
@@ -188,6 +190,13 @@ export function LiveAgentChat({
                     </span>
                   )}
                 </div>
+                {msg.citations && msg.citations.length > 0 && (
+                  <div data-slot="chat-citations" className="mt-1 flex flex-col gap-1">
+                    {msg.citations.map((c, i) => (
+                      <ChatCitationCard key={i} citation={c} />
+                    ))}
+                  </div>
+                )}
               </div>
             );
           })

--- a/apps/web/src/components/features/session-live/LiveAgentChat.tsx
+++ b/apps/web/src/components/features/session-live/LiveAgentChat.tsx
@@ -40,6 +40,12 @@ export interface ChatMessage {
   readonly visibility: 'private' | 'shared';
   readonly timestamp: string;
   readonly citations?: readonly ChatCitation[];
+  /**
+   * AC-CHAT-3: when true, the agent answered without any grounding citations.
+   * Shows a discrete disclaimer below the bubble. NEVER true on system status messages
+   * (those are injected by SessionLiveView without this flag).
+   */
+  readonly isNonGrounded?: boolean;
 }
 
 // ─── Labels ───────────────────────────────────────────────────────────────────
@@ -196,6 +202,20 @@ export function LiveAgentChat({
                       <ChatCitationCard key={i} citation={c} />
                     ))}
                   </div>
+                )}
+                {/* AC-CHAT-3: non-grounded disclaimer — only for agent messages with
+                    zero citations and explicit isNonGrounded flag.
+                    NEVER shown on system status messages (those lack the flag). */}
+                {msg.isNonGrounded === true && !isOwn && (
+                  <p
+                    data-slot="chat-nongrounded-disclaimer"
+                    className="mt-1 flex items-center gap-1 text-xs text-muted-foreground"
+                  >
+                    <span aria-hidden="true">⚠️</span>
+                    {intl.formatMessage({
+                      id: 'pages.sessionLive.chatAgent.nonGroundedDisclaimer',
+                    })}
+                  </p>
                 )}
               </div>
             );

--- a/apps/web/src/components/features/session-live/__tests__/LiveAgentChat.test.tsx
+++ b/apps/web/src/components/features/session-live/__tests__/LiveAgentChat.test.tsx
@@ -247,6 +247,38 @@ describe('LiveAgentChat — aria attributes', () => {
 
 // ─── #2375 G3 — draft persistence + smart scroll ──────────────────────────────
 
+// ─── #2500 — ChatCitationCard rendering ───────────────────────────────────────
+
+describe('#2500 — CitationCard rendering', () => {
+  it('renderizza ChatCitationCard quando il messaggio assistant ha citazioni', () => {
+    const msgWithCitations: ChatMessage = {
+      id: 'msg-cite-1',
+      senderId: 'agent',
+      senderName: 'Agent',
+      content: 'Ecco il regolamento.',
+      visibility: 'shared',
+      timestamp: '2026-06-23T10:00:00Z',
+      citations: [{ documentName: 'Reg Azul', pages: [7], excerpt: 'Posiziona' }],
+    };
+    renderChat({ messages: [msgWithCitations] });
+    expect(screen.getByText(/Reg Azul/)).toBeInTheDocument();
+    expect(screen.getByText(/pag\. 7/i)).toBeInTheDocument();
+  });
+
+  it('NON renderizza citazioni quando assenti (AC-CHAT-3)', () => {
+    const msgWithoutCitations: ChatMessage = {
+      id: 'msg-no-cite',
+      senderId: 'agent',
+      senderName: 'Agent',
+      content: 'Risposta senza citazioni.',
+      visibility: 'shared',
+      timestamp: '2026-06-23T10:01:00Z',
+    };
+    renderChat({ messages: [msgWithoutCitations] });
+    expect(screen.queryByText(/pag\./i)).toBeNull();
+  });
+});
+
 describe('#2375 G3 — draft + smart scroll', () => {
   const baseLabels: LiveAgentChatLabels = {
     title: 'Chat',

--- a/apps/web/src/components/features/session-live/__tests__/LiveAgentChat.test.tsx
+++ b/apps/web/src/components/features/session-live/__tests__/LiveAgentChat.test.tsx
@@ -21,12 +21,14 @@ import { IntlProvider } from 'react-intl';
 import type { LiveAgentChatLabels, LiveAgentChatProps, ChatMessage } from '../LiveAgentChat';
 import { LiveAgentChat } from '../LiveAgentChat';
 import { CHAT_DRAFT_KEY_PREFIX } from '@/lib/session-live/use-chat-draft';
+import { mapCitationToChatCitation } from '@/lib/session-live/map-citation-to-chat-citation';
 
 // ─── i18n messages used by the component ──────────────────────────────────────
 
 const INTL_MESSAGES = {
   'pages.sessionLive.chat.newMessagesToast':
     '{count, plural, one {# nuovo messaggio} other {# nuovi messaggi}}',
+  'pages.sessionLive.chatAgent.nonGroundedDisclaimer': 'Risposta non basata sul regolamento',
 };
 
 // ─── Fixtures ─────────────────────────────────────────────────────────────────
@@ -276,6 +278,115 @@ describe('#2500 — CitationCard rendering', () => {
     };
     renderChat({ messages: [msgWithoutCitations] });
     expect(screen.queryByText(/pag\./i)).toBeNull();
+  });
+});
+
+// ─── AC-CHAT-2: DOM test "mai verbatim" (Parte A, solo test — nessuna modifica di produzione) ───
+
+describe('#2500 AC-CHAT-2 — protected verbatim never in DOM', () => {
+  it('mostra la parafrasi ma mai il verbatim nel DOM per citazione protected', () => {
+    // Costruisce la ChatCitation passando per mapCitationToChatCitation su una citazione protected
+    // con un campo verbatim distintivo — questo è il regression hook per il round-trip
+    // protected → mapper → ChatCitationCard → DOM.
+    const protectedCitation = {
+      source: 'Regolamento Azul',
+      pageNumber: 7,
+      copyrightTier: 'protected' as const,
+      snippet: 'VERBATIM_SECRET',
+      paraphrasedSnippet: 'sintesi regola',
+    };
+
+    const chatCitation = mapCitationToChatCitation(protectedCitation);
+    expect(chatCitation).not.toBeNull();
+    // Sanity: la citazione mappata usa paraphrase, non verbatim
+    expect(chatCitation!.excerpt).toBe('sintesi regola');
+
+    const msgWithProtectedCitation: ChatMessage = {
+      id: 'msg-protected-1',
+      senderId: 'agent',
+      senderName: 'MeepleAI',
+      content: 'Ecco la regola.',
+      visibility: 'shared',
+      timestamp: '2026-06-23T10:00:00Z',
+      citations: [chatCitation!],
+    };
+
+    const { container } = renderChat({ messages: [msgWithProtectedCitation] });
+
+    // La parafrasi è presente nel DOM
+    expect(screen.getByText(/sintesi regola/)).toBeInTheDocument();
+    // Il verbatim NON è mai nel DOM
+    expect(container.textContent).not.toContain('VERBATIM_SECRET');
+  });
+});
+
+// ─── AC-CHAT-3: disclaimer risposta non-grounded ──────────────────────────────
+
+describe('#2500 AC-CHAT-3 — non-grounded disclaimer', () => {
+  it('messaggio assistant isNonGrounded:true → disclaimer data-slot="chat-nongrounded-disclaimer" nel DOM', () => {
+    const msgNonGrounded: ChatMessage = {
+      id: 'msg-ng-1',
+      senderId: 'agent',
+      senderName: 'MeepleAI',
+      content: 'Risposta senza fonti.',
+      visibility: 'shared',
+      timestamp: '2026-06-23T10:00:00Z',
+      isNonGrounded: true,
+    };
+    const { container } = renderChat({ messages: [msgNonGrounded] });
+    expect(
+      container.querySelector('[data-slot="chat-nongrounded-disclaimer"]')
+    ).toBeInTheDocument();
+    // Testo localizzato presente
+    expect(container.textContent).toContain('Risposta non basata sul regolamento');
+  });
+
+  it('messaggio assistant con citazioni → disclaimer assente', () => {
+    const msgWithCitations: ChatMessage = {
+      id: 'msg-cite-ng',
+      senderId: 'agent',
+      senderName: 'MeepleAI',
+      content: 'Risposta con fonti.',
+      visibility: 'shared',
+      timestamp: '2026-06-23T10:00:00Z',
+      citations: [{ documentName: 'Reg', pages: [1], excerpt: 'testo' }],
+    };
+    const { container } = renderChat({ messages: [msgWithCitations] });
+    expect(
+      container.querySelector('[data-slot="chat-nongrounded-disclaimer"]')
+    ).not.toBeInTheDocument();
+  });
+
+  it('messaggio user → disclaimer assente anche se isNonGrounded accidentalmente truthy', () => {
+    // Nota: per design i messaggi user non hanno mai isNonGrounded, ma anche se fosse
+    // settato accidentalmente il disclaimer non deve apparire su messaggi user
+    const msgUser: ChatMessage = {
+      id: 'msg-user-ng',
+      senderId: 'viewer-id',
+      senderName: 'Player',
+      content: 'Domanda utente.',
+      visibility: 'shared',
+      timestamp: '2026-06-23T10:00:00Z',
+    };
+    const { container } = renderChat({ messages: [msgUser], viewerId: 'viewer-id' });
+    expect(
+      container.querySelector('[data-slot="chat-nongrounded-disclaimer"]')
+    ).not.toBeInTheDocument();
+  });
+
+  it('messaggio assistant isNonGrounded:false/undefined → disclaimer assente', () => {
+    const msgAssistant: ChatMessage = {
+      id: 'msg-a-nodisc',
+      senderId: 'agent',
+      senderName: 'MeepleAI',
+      content: 'Risposta normale senza flag.',
+      visibility: 'shared',
+      timestamp: '2026-06-23T10:00:00Z',
+    };
+    const { container } = renderChat({ messages: [msgAssistant] });
+    expect(
+      container.querySelector('[data-slot="chat-nongrounded-disclaimer"]')
+    ).not.toBeInTheDocument();
   });
 });
 

--- a/apps/web/src/hooks/queries/__tests__/useSessionAgentLaunch.test.tsx
+++ b/apps/web/src/hooks/queries/__tests__/useSessionAgentLaunch.test.tsx
@@ -1,0 +1,133 @@
+/**
+ * useSessionAgentLaunch — unit tests
+ * Issue #2500 C1 fix: hook must send initialGameStateJson: '' (not '{}') so the
+ * BE can default to GameState.Initial(UserId) instead of failing with 422.
+ */
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ReactNode } from 'react';
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    games: {
+      getAgents: vi.fn(),
+    },
+    agentSessions: {
+      launch: vi.fn(),
+    },
+  },
+}));
+
+import { api } from '@/lib/api';
+import { useSessionAgentLaunch } from '../useSessionAgentLaunch';
+import type { AgentDto } from '@/lib/api/schemas';
+
+function wrapper({ children }: { children: ReactNode }) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+
+const SESSION_ID = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+const GAME_ID = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+const AGENT_ID = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
+const AGENT_SESSION_ID = 'dddddddd-dddd-dddd-dddd-dddddddddddd';
+
+const activeAgent: AgentDto = {
+  id: AGENT_ID,
+  name: 'Test RAG Agent',
+  type: 'RagAgent',
+  strategyName: 'HybridRag',
+  strategyParameters: {},
+  isActive: true,
+  createdAt: '2026-01-01T00:00:00Z',
+  lastInvokedAt: null,
+  invocationCount: 0,
+  isRecentlyUsed: false,
+  isIdle: true,
+  gameId: GAME_ID,
+};
+
+describe('useSessionAgentLaunch', () => {
+  beforeEach(() => {
+    vi.mocked(api.games.getAgents).mockReset();
+    vi.mocked(api.agentSessions.launch).mockReset();
+  });
+
+  it('returns idle when sessionId is null', () => {
+    const { result } = renderHook(() => useSessionAgentLaunch(null, GAME_ID), { wrapper });
+    expect(result.current.status).toBe('idle');
+    expect(result.current.agentSessionId).toBe('');
+  });
+
+  it('returns idle when gameId is null', () => {
+    const { result } = renderHook(() => useSessionAgentLaunch(SESSION_ID, null), { wrapper });
+    expect(result.current.status).toBe('idle');
+  });
+
+  it('returns idle when enabled=false', () => {
+    const { result } = renderHook(() => useSessionAgentLaunch(SESSION_ID, GAME_ID, false), {
+      wrapper,
+    });
+    expect(result.current.status).toBe('idle');
+    expect(api.games.getAgents).not.toHaveBeenCalled();
+  });
+
+  /**
+   * C1 fix: the hook must send initialGameStateJson: '' (empty string), NOT '{}'.
+   * The BE validator now accepts empty as "use default" and the handler calls
+   * GameState.Initial(UserId) instead of GameState.FromJson('{}') which throws.
+   */
+  it('C1 fix: sends initialGameStateJson as empty string (not {}) to the launch API', async () => {
+    vi.mocked(api.games.getAgents).mockResolvedValueOnce([activeAgent]);
+    vi.mocked(api.agentSessions.launch).mockResolvedValueOnce({ agentSessionId: AGENT_SESSION_ID });
+
+    const { result } = renderHook(() => useSessionAgentLaunch(SESSION_ID, GAME_ID), { wrapper });
+
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+
+    expect(api.agentSessions.launch).toHaveBeenCalledWith(
+      SESSION_ID,
+      expect.objectContaining({
+        initialGameStateJson: '',
+      })
+    );
+  });
+
+  it('returns ready with agentSessionId when launch succeeds', async () => {
+    vi.mocked(api.games.getAgents).mockResolvedValueOnce([activeAgent]);
+    vi.mocked(api.agentSessions.launch).mockResolvedValueOnce({ agentSessionId: AGENT_SESSION_ID });
+
+    const { result } = renderHook(() => useSessionAgentLaunch(SESSION_ID, GAME_ID), { wrapper });
+
+    await waitFor(() => expect(result.current.status).toBe('ready'));
+    expect(result.current.agentSessionId).toBe(AGENT_SESSION_ID);
+  });
+
+  it('returns no-agent when getAgents returns empty list', async () => {
+    vi.mocked(api.games.getAgents).mockResolvedValueOnce([]);
+
+    const { result } = renderHook(() => useSessionAgentLaunch(SESSION_ID, GAME_ID), { wrapper });
+
+    await waitFor(() => expect(result.current.status).toBe('no-agent'));
+    expect(api.agentSessions.launch).not.toHaveBeenCalled();
+  });
+
+  it('returns error when getAgents fails', async () => {
+    vi.mocked(api.games.getAgents).mockRejectedValueOnce(new Error('network'));
+
+    const { result } = renderHook(() => useSessionAgentLaunch(SESSION_ID, GAME_ID), { wrapper });
+
+    await waitFor(() => expect(result.current.status).toBe('error'));
+  });
+
+  it('returns error when launch fails', async () => {
+    vi.mocked(api.games.getAgents).mockResolvedValueOnce([activeAgent]);
+    vi.mocked(api.agentSessions.launch).mockRejectedValueOnce(new Error('422 Unprocessable'));
+
+    const { result } = renderHook(() => useSessionAgentLaunch(SESSION_ID, GAME_ID), { wrapper });
+
+    await waitFor(() => expect(result.current.status).toBe('error'));
+    expect(result.current.agentSessionId).toBe('');
+  });
+});

--- a/apps/web/src/hooks/queries/useSessionAgentLaunch.ts
+++ b/apps/web/src/hooks/queries/useSessionAgentLaunch.ts
@@ -1,0 +1,127 @@
+/**
+ * useSessionAgentLaunch — resolves the RAG agent session for a live game session.
+ *
+ * SP1 epic #2501 (Issue #2500): the live chat panel talks to the RAG agent, which
+ * requires an `agentSessionId` from `POST /game-sessions/{id}/agent/launch`. The
+ * launch needs an `agentDefinitionId`, which is exactly `AgentDto.id` returned by
+ * `GET /games/{gameId}/agents` (verified: `AgentDto.id` IS the AgentDefinition id).
+ *
+ * Flow (lazy, two dependent TanStack queries — does NOT block the session render):
+ *   1. getAgents(gameId) → pick first active agent (`isActive`) else first agent.
+ *   2. launch(sessionId, { agentDefinitionId, agentId, gameId }) → { agentSessionId }.
+ *
+ * The result is a discriminated status the chat panel maps to its UI:
+ *   - 'no-agent'  → getAgents resolved empty (no assistant available for this game)
+ *   - 'launching' → getAgents/launch in flight
+ *   - 'ready'     → agentSessionId obtained, chat can send
+ *   - 'error'     → getAgents OR launch failed (panel shows error, never crashes)
+ *   - 'idle'      → preconditions not met yet (no sessionId/gameId)
+ *
+ * AC-CHAT-NULL (review FINDING 5): every non-ready state is explicit so the panel
+ * can give feedback — there is never a silent no-op where the user types and nothing
+ * happens.
+ */
+
+import { useMemo } from 'react';
+
+import { useQuery } from '@tanstack/react-query';
+
+import { api } from '@/lib/api';
+import type { AgentDto } from '@/lib/api/schemas';
+
+// ─── Status ─────────────────────────────────────────────────────────────────
+
+export type SessionAgentStatus = 'idle' | 'launching' | 'ready' | 'no-agent' | 'error';
+
+export interface SessionAgentLaunchResult {
+  /** Discriminated lifecycle status (see module doc). */
+  readonly status: SessionAgentStatus;
+  /** The launched agent session id — non-empty only when status === 'ready'. */
+  readonly agentSessionId: string;
+}
+
+// ─── Query keys ───────────────────────────────────────────────────────────────
+
+export const sessionAgentKeys = {
+  all: ['sessionAgent'] as const,
+  agents: (gameId: string) => [...sessionAgentKeys.all, 'agents', gameId] as const,
+  launch: (sessionId: string, agentDefinitionId: string) =>
+    [...sessionAgentKeys.all, 'launch', sessionId, agentDefinitionId] as const,
+};
+
+/** Pick the first active agent, falling back to the first agent of any state. */
+function pickAgent(agents: ReadonlyArray<AgentDto>): AgentDto | undefined {
+  return agents.find(a => a.isActive) ?? agents[0];
+}
+
+/**
+ * Resolve (and lazily launch) the RAG agent session for a live game session.
+ *
+ * @param sessionId - LiveGameSession id (path param for launch + agent chat).
+ * @param gameId    - Game id from the LiveSessionDto (nullable on the aggregate).
+ * @param enabled   - Gate the whole flow (e.g. disabled in visual-test builds).
+ */
+export function useSessionAgentLaunch(
+  sessionId: string | null,
+  gameId: string | null,
+  enabled: boolean = true
+): SessionAgentLaunchResult {
+  const canResolve = enabled && !!sessionId && !!gameId;
+
+  // ── Step 1: list agents for the game ──────────────────────────────────────
+  const agentsQuery = useQuery<AgentDto[], Error>({
+    queryKey: sessionAgentKeys.agents(gameId ?? ''),
+    queryFn: () => api.games.getAgents(gameId as string),
+    enabled: canResolve,
+    staleTime: 60_000,
+    retry: false,
+  });
+
+  const agent = useMemo(
+    () => (agentsQuery.data ? pickAgent(agentsQuery.data) : undefined),
+    [agentsQuery.data]
+  );
+
+  // ── Step 2: launch the agent session once an agent is resolved ────────────
+  // Dependent query: only runs after agents resolved to a concrete agent. The
+  // key is stable per (session, agentDefinition) so we launch at most once and
+  // reuse the cached agentSessionId on re-render (lazy, non-blocking).
+  const launchQuery = useQuery({
+    queryKey: sessionAgentKeys.launch(sessionId ?? '', agent?.id ?? ''),
+    queryFn: () =>
+      api.agentSessions.launch(sessionId as string, {
+        agentDefinitionId: agent!.id,
+        // FE schema requires agentId; the BE ignores it. AgentDto.id IS the
+        // AgentDefinition id, so the same value is correct for both fields.
+        agentId: agent!.id,
+        gameId: gameId as string,
+        initialGameStateJson: '{}',
+      }),
+    enabled: canResolve && agent != null,
+    staleTime: Infinity,
+    retry: false,
+  });
+
+  // ── Derive discriminated status ───────────────────────────────────────────
+  const status: SessionAgentStatus = useMemo(() => {
+    if (!canResolve) return 'idle';
+    if (agentsQuery.isError) return 'error';
+    if (agentsQuery.isSuccess && agent == null) return 'no-agent';
+    if (launchQuery.isError) return 'error';
+    if (launchQuery.isSuccess && launchQuery.data?.agentSessionId) return 'ready';
+    return 'launching';
+  }, [
+    canResolve,
+    agent,
+    agentsQuery.isError,
+    agentsQuery.isSuccess,
+    launchQuery.isError,
+    launchQuery.isSuccess,
+    launchQuery.data,
+  ]);
+
+  return {
+    status,
+    agentSessionId: status === 'ready' ? (launchQuery.data?.agentSessionId ?? '') : '',
+  };
+}

--- a/apps/web/src/hooks/queries/useSessionAgentLaunch.ts
+++ b/apps/web/src/hooks/queries/useSessionAgentLaunch.ts
@@ -95,7 +95,9 @@ export function useSessionAgentLaunch(
         // AgentDefinition id, so the same value is correct for both fields.
         agentId: agent!.id,
         gameId: gameId as string,
-        initialGameStateJson: '{}',
+        // C1 fix: send empty string so BE uses GameState.Initial(UserId) as default.
+        // Sending '{}' caused GameState.FromJson('{}') to throw (ActivePlayer == Guid.Empty).
+        initialGameStateJson: '',
       }),
     enabled: canResolve && agent != null,
     staleTime: Infinity,

--- a/apps/web/src/lib/api/clients/agentSessionsClient.ts
+++ b/apps/web/src/lib/api/clients/agentSessionsClient.ts
@@ -15,7 +15,9 @@ export const LaunchSessionAgentRequestSchema = z.object({
   agentDefinitionId: z.string().uuid(),
   agentId: z.string().uuid(),
   gameId: z.string().uuid(),
-  initialGameStateJson: z.string().optional().default('{}'),
+  // C1 fix: default to '' so the BE uses GameState.Initial(UserId) instead of
+  // GameState.FromJson('{}') which throws (ActivePlayer == Guid.Empty → 422).
+  initialGameStateJson: z.string().optional().default(''),
 });
 
 export const LaunchSessionAgentResponseSchema = z.object({

--- a/apps/web/src/lib/api/clients/index.ts
+++ b/apps/web/src/lib/api/clients/index.ts
@@ -59,4 +59,5 @@ export * from './kbQualityClient'; // Issue #1675 — Per-doc KB quality evaluat
 export * from './activityClient'; // Issue #1593 Phase 3b — cross-entity activity feed
 export * from './toolkit'; // Default Game Toolkit — session events & dice presets
 export * from './sessionSnapshotsClient'; // Session Vision AI — snapshot CRUD
+export * from './agentSessionsClient'; // Issue #3375 — session-based agent lifecycle (launch/config/end)
 export * from '../session-flow'; // Session Flow v2.1 — typed client + DTOs

--- a/apps/web/src/lib/api/index.ts
+++ b/apps/web/src/lib/api/index.ts
@@ -71,6 +71,7 @@ import {
   createAgentDocumentsClient,
   createInfrastructureClient,
   createSessionFlowClient,
+  createAgentSessionsClient,
   createKbDocsClient,
   createKbQualityClient,
   createActivityClient,
@@ -128,6 +129,7 @@ import {
   type AgentDocumentsClient,
   type InfrastructureClient,
   type SessionFlowClient,
+  type AgentSessionsClient,
 } from './clients';
 import { HttpClient, type HttpClientConfig } from './core/httpClient';
 
@@ -369,6 +371,9 @@ export interface ApiClient {
   /** Session Flow v2.1 — lifecycle, turns, scores, diary */
   sessionFlow: SessionFlowClient;
 
+  /** Session-based agent lifecycle — launch/config/end (Issue #3375) */
+  agentSessions: AgentSessionsClient;
+
   /** Cross-game per-user KB documents listing (Issue #1592 Phase 2b) */
   kbDocs: KbDocsClient;
 
@@ -479,6 +484,7 @@ export function createApiClient(config?: ApiClientConfig): ApiClient {
     agentDocuments: createAgentDocumentsClient({ httpClient }), // User agent document selection
     infrastructure: createInfrastructureClient({ httpClient }), // AI Infrastructure Dashboard
     sessionFlow: createSessionFlowClient({ httpClient }), // Session Flow v2.1
+    agentSessions: createAgentSessionsClient({ httpClient }), // Issue #3375 — agent launch/config/end
     kbDocs: createKbDocsClient({ httpClient }), // Issue #1592 Phase 2b
     kbQuality: createKbQualityClient({ httpClient }), // Issue #1675 — per-doc quality eval
     activity: createActivityClient({ httpClient }), // Issue #1593 Phase 3b

--- a/apps/web/src/lib/api/schemas/chat.schemas.ts
+++ b/apps/web/src/lib/api/schemas/chat.schemas.ts
@@ -38,6 +38,8 @@ export const ChatThreadMessageDtoSchema = z.object({
   gameId: z.string().uuid().optional(),
   // Note: Keep in sync with FEEDBACK_OUTCOMES in @/lib/constants/feedback
   feedback: z.enum(['helpful', 'not-helpful', 'incorrect']).nullable().optional(),
+  // Populated by BE on assistant messages; null on user messages. R1 — Task 5-FE #2500.
+  citationsJson: z.string().nullable().optional(),
 });
 
 export type ChatThreadMessageDto = z.infer<typeof ChatThreadMessageDtoSchema>;

--- a/apps/web/src/lib/api/schemas/streaming.schemas.ts
+++ b/apps/web/src/lib/api/schemas/streaming.schemas.ts
@@ -40,18 +40,29 @@ export type StreamingStateUpdate = z.infer<typeof StreamingStateUpdateSchema>;
 
 /**
  * Citation/source reference
- * Matches backend Citation structure
+ * Matches backend Citation structure (CitationDto in Contracts.cs).
+ *
+ * Real wire fields (BE CitationDto, Contracts.cs:137-144):
+ *   documentId, pageNumber, relevanceScore, snippetPreview, copyrightTier, paraphrasedSnippet, isPublic
+ *
+ * Legacy fields kept optional for backward compat with other consumers (kb-ask, RulesExplainer):
+ *   source, page, line, text, snippet, score
+ *
+ * C2 (#2500): `source` was required — relaxed to optional so safeParse succeeds on the real wire
+ * (which does not carry `source`). This is additive/backward-compat: callers that provide `source`
+ * continue to work unchanged.
  */
 export const CitationSchema = z.object({
   documentId: z.string().optional().nullable(),
-  source: z.string(), // e.g., "rules.pdf", "game_manual.pdf"
+  source: z.string().optional().nullable(), // Relaxed: real wire has no `source` (C2 #2500)
   page: z.number().optional().nullable(),
-  pageNumber: z.number().optional().nullable(), // Alternative field name
+  pageNumber: z.number().optional().nullable(), // Real wire field name
   line: z.number().optional().nullable(),
   text: z.string().optional().nullable(),
-  snippet: z.string().optional().nullable(), // Alternative field name
+  snippet: z.string().optional().nullable(),
+  snippetPreview: z.string().optional().nullable(), // Real wire field (C2 #2500)
   score: z.number().optional().nullable(),
-  relevanceScore: z.number().optional().nullable(), // Alternative field name
+  relevanceScore: z.number().optional().nullable(), // Real wire field name
   copyrightTier: z.enum(['full', 'protected']).default('full'), // Default 'full' for backward compat
   paraphrasedSnippet: z.string().optional().nullable(),
   isPublic: z.boolean().optional().default(false),
@@ -83,6 +94,8 @@ export type StreamingToken = z.infer<typeof StreamingTokenSchema>;
 /**
  * Complete event data
  * Sent when streaming finishes successfully
+ *
+ * C2 (#2500): added `chatThreadId` — real wire field for session chat thread ID.
  */
 export const StreamingCompleteSchema = z.object({
   totalTokens: z.number(),
@@ -90,6 +103,7 @@ export const StreamingCompleteSchema = z.object({
   completionTokens: z.number().optional().nullable(),
   confidence: z.number().optional().nullable(), // 0.0 - 1.0
   estimatedReadingTimeMinutes: z.number().optional().nullable(),
+  chatThreadId: z.string().optional().nullable(), // Real wire field (C2 #2500)
   snippets: z.array(CitationSchema).optional().default([]), // Final citations
   citations: z.array(CitationSchema).optional().default([]), // Copyright-aware citations
 });

--- a/apps/web/src/lib/domain-hooks/__tests__/useSessionAgentChat.test.ts
+++ b/apps/web/src/lib/domain-hooks/__tests__/useSessionAgentChat.test.ts
@@ -334,4 +334,158 @@ describe('useSessionAgentChat', () => {
       expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull();
     });
   });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // AC-CHAT-3: isNonGrounded flag — SSE live flow + historic hydration
+  // ─────────────────────────────────────────────────────────────────────────
+
+  describe('AC-CHAT-3: isNonGrounded flag', () => {
+    it('SSE complete with 0 citations → last assistant message has isNonGrounded:true', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          body: makeReadableStream([
+            'data: {"type":"token","content":"Risposta senza fonti."}\n\n',
+            'data: {"type":"complete","threadId":"t-ng-1"}\n\n',
+          ]),
+        } as unknown as Response)
+      );
+
+      const { result } = renderHook(() => useSessionAgentChat('game-sess-ng', 'agent-ng'));
+
+      await act(async () => {
+        await result.current.ask('Domanda senza citazioni');
+      });
+
+      const lastMsg = result.current.messages[result.current.messages.length - 1];
+      expect(lastMsg.role).toBe('assistant');
+      expect(lastMsg.isNonGrounded).toBe(true);
+    });
+
+    it('SSE complete with ≥1 citation → isNonGrounded is falsy', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          body: makeReadableStream([
+            'data: {"type":"token","content":"Risposta con fonti."}\n\n',
+            'data: {"type":"complete","threadId":"t-g-1","citations":[{"source":"Reg","pageNumber":3,"copyrightTier":"full","snippet":"testo"}]}\n\n',
+          ]),
+        } as unknown as Response)
+      );
+
+      const { result } = renderHook(() => useSessionAgentChat('game-sess-g', 'agent-g'));
+
+      await act(async () => {
+        await result.current.ask('Domanda con citazioni');
+      });
+
+      const lastMsg = result.current.messages[result.current.messages.length - 1];
+      expect(lastMsg.role).toBe('assistant');
+      expect(lastMsg.isNonGrounded).toBeFalsy();
+    });
+
+    it('user messages never have isNonGrounded set', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          body: makeReadableStream([
+            'data: {"type":"token","content":"Risposta."}\n\n',
+            'data: {"type":"complete","threadId":"t-user-1"}\n\n',
+          ]),
+        } as unknown as Response)
+      );
+
+      const { result } = renderHook(() => useSessionAgentChat('game-sess-u', 'agent-u'));
+
+      await act(async () => {
+        await result.current.ask('Domanda utente');
+      });
+
+      const userMsg = result.current.messages[0];
+      expect(userMsg.role).toBe('user');
+      expect(userMsg.isNonGrounded).toBeFalsy();
+    });
+
+    it('historic assistant message without citations → isNonGrounded:true', async () => {
+      const THREAD_ID_NG = 'thread-ng-history-001';
+      const STORAGE_KEY_NG = `meepleai:live-agent-thread:game-sess-ng-hist`;
+      sessionStorage.setItem(STORAGE_KEY_NG, THREAD_ID_NG);
+
+      mockGetThreadById.mockResolvedValueOnce({
+        id: THREAD_ID_NG,
+        gameId: null,
+        agentId: null,
+        agentType: null,
+        title: null,
+        createdAt: '2026-06-23T10:00:00Z',
+        lastMessageAt: '2026-06-23T10:01:00Z',
+        messageCount: 1,
+        messages: [
+          {
+            content: 'Risposta storica senza citazioni.',
+            role: 'assistant',
+            timestamp: '2026-06-23T10:01:00Z',
+            backendMessageId: 'msg-hist-ng-001',
+            citationsJson: null,
+          },
+        ],
+      });
+
+      const { result } = renderHook(() =>
+        useSessionAgentChat('game-sess-ng-hist', 'agent-ng-hist', { persistHistory: true })
+      );
+
+      await act(async () => {
+        await new Promise(resolve => setTimeout(resolve, 0));
+      });
+
+      expect(result.current.messages).toHaveLength(1);
+      const msg = result.current.messages[0];
+      expect(msg.role).toBe('assistant');
+      expect(msg.isNonGrounded).toBe(true);
+    });
+
+    it('historic assistant message WITH citations → isNonGrounded is falsy', async () => {
+      const THREAD_ID_G = 'thread-g-history-001';
+      const STORAGE_KEY_G = `meepleai:live-agent-thread:game-sess-g-hist`;
+      sessionStorage.setItem(STORAGE_KEY_G, THREAD_ID_G);
+
+      mockGetThreadById.mockResolvedValueOnce({
+        id: THREAD_ID_G,
+        gameId: null,
+        agentId: null,
+        agentType: null,
+        title: null,
+        createdAt: '2026-06-23T10:00:00Z',
+        lastMessageAt: '2026-06-23T10:01:00Z',
+        messageCount: 1,
+        messages: [
+          {
+            content: 'Risposta con citazioni storiche.',
+            role: 'assistant',
+            timestamp: '2026-06-23T10:01:00Z',
+            backendMessageId: 'msg-hist-g-001',
+            citationsJson:
+              '[{"source":"Reg","pageNumber":5,"copyrightTier":"full","snippet":"testo"}]',
+          },
+        ],
+      });
+
+      const { result } = renderHook(() =>
+        useSessionAgentChat('game-sess-g-hist', 'agent-g-hist', { persistHistory: true })
+      );
+
+      await act(async () => {
+        await new Promise(resolve => setTimeout(resolve, 0));
+      });
+
+      expect(result.current.messages).toHaveLength(1);
+      const msg = result.current.messages[0];
+      expect(msg.role).toBe('assistant');
+      expect(msg.isNonGrounded).toBeFalsy();
+    });
+  });
 });

--- a/apps/web/src/lib/domain-hooks/__tests__/useSessionAgentChat.test.ts
+++ b/apps/web/src/lib/domain-hooks/__tests__/useSessionAgentChat.test.ts
@@ -73,4 +73,33 @@ describe('useSessionAgentChat', () => {
     expect(result.current.messages[0].role).toBe('user');
     expect(result.current.messages[0].content).toBe('Come funziona?');
   });
+
+  it('ask estrae le citazioni dal payload complete', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        body: makeReadableStream([
+          'data: {"type":"token","content":"Posiziona la plancia."}\n\n',
+          'data: {"type":"complete","threadId":"t1","citations":[{"source":"Regolamento Azul","pageNumber":7,"copyrightTier":"full","snippet":"Posiziona la plancia al centro."}]}\n\n',
+        ]),
+      } as unknown as Response)
+    );
+
+    const { result } = renderHook(() => useSessionAgentChat('game-sess-1', 'agent-1'));
+
+    await act(async () => {
+      await result.current.ask('come si fa il setup?');
+    });
+
+    const lastMsg = result.current.messages[result.current.messages.length - 1];
+    expect(lastMsg.role).toBe('assistant');
+    expect(lastMsg.citations).toBeDefined();
+    expect(lastMsg.citations).toHaveLength(1);
+    expect(lastMsg.citations![0]).toEqual({
+      documentName: 'Regolamento Azul',
+      pages: [7],
+      excerpt: 'Posiziona la plancia al centro.',
+    });
+  });
 });

--- a/apps/web/src/lib/domain-hooks/__tests__/useSessionAgentChat.test.ts
+++ b/apps/web/src/lib/domain-hooks/__tests__/useSessionAgentChat.test.ts
@@ -1,7 +1,19 @@
 import { renderHook, act } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { useSessionAgentChat } from '../useSessionAgentChat';
 import { useSessionStore } from '@/stores/session/store';
+import { api } from '@/lib/api';
+
+// Mock the api module so we can spy on api.chat.getThreadById
+vi.mock('@/lib/api', () => ({
+  api: {
+    chat: {
+      getThreadById: vi.fn(),
+    },
+  },
+}));
+
+const mockGetThreadById = vi.mocked(api.chat.getThreadById);
 
 // Mock fetch for streaming
 const makeReadableStream = (chunks: string[]) => {
@@ -17,11 +29,21 @@ const makeReadableStream = (chunks: string[]) => {
   });
 };
 
+// sessionStorage key helper — must match the hook implementation
+const SESSION_STORAGE_KEY = (gameSessionId: string) =>
+  `meepleai:live-agent-thread:${gameSessionId}`;
+
 describe('useSessionAgentChat', () => {
   beforeEach(() => {
     localStorage.clear();
+    sessionStorage.clear();
     useSessionStore.getState().reset();
     vi.restoreAllMocks();
+    mockGetThreadById.mockReset();
+  });
+
+  afterEach(() => {
+    sessionStorage.clear();
   });
 
   it('messages inizialmente è vuoto', () => {
@@ -100,6 +122,216 @@ describe('useSessionAgentChat', () => {
       documentName: 'Regolamento Azul',
       pages: [7],
       excerpt: 'Posiziona la plancia al centro.',
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
+  // AC-CHAT-1: persistHistory opt-in — history hydration with citations
+  // ─────────────────────────────────────────────────────────────────────────
+
+  describe('persistHistory opt-in', () => {
+    const GAME_SESSION_ID = 'game-sess-persist-1';
+    const THREAD_ID = 'thread-uuid-0001';
+    const STORAGE_KEY = SESSION_STORAGE_KEY(GAME_SESSION_ID);
+
+    it('AC-CHAT-1 happy: mounts with persisted threadId and hydrates messages with citations', async () => {
+      // Pre-seed sessionStorage with a saved threadId
+      sessionStorage.setItem(STORAGE_KEY, THREAD_ID);
+
+      // Mock getThreadById to return a thread with one assistant message with citationsJson
+      mockGetThreadById.mockResolvedValueOnce({
+        id: THREAD_ID,
+        gameId: null,
+        agentId: null,
+        agentType: null,
+        title: null,
+        createdAt: '2026-06-23T10:00:00Z',
+        lastMessageAt: '2026-06-23T10:01:00Z',
+        messageCount: 1,
+        messages: [
+          {
+            content: 'Le torri si piazzano così.',
+            role: 'assistant',
+            timestamp: '2026-06-23T10:01:00Z',
+            backendMessageId: 'msg-uuid-001',
+            citationsJson:
+              '[{"source":"Regolamento Towers","pageNumber":3,"copyrightTier":"full","snippet":"Piazza la torre sulla casella."}]',
+          },
+        ],
+      });
+
+      const { result } = renderHook(() =>
+        useSessionAgentChat(GAME_SESSION_ID, 'agent-1', { persistHistory: true })
+      );
+
+      // Wait for async mount effect
+      await act(async () => {
+        await new Promise(resolve => setTimeout(resolve, 0));
+      });
+
+      expect(result.current.messages).toHaveLength(1);
+      const msg = result.current.messages[0];
+      expect(msg.role).toBe('assistant');
+      expect(msg.content).toBe('Le torri si piazzano così.');
+      expect(msg.citations).toBeDefined();
+      expect(msg.citations).toHaveLength(1);
+      expect(msg.citations![0]).toEqual({
+        documentName: 'Regolamento Towers',
+        pages: [3],
+        excerpt: 'Piazza la torre sulla casella.',
+      });
+    });
+
+    it('AC-CHAT-1 persist: after SSE complete with chatThreadId, sessionStorage is populated', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          body: makeReadableStream([
+            'data: {"type":"token","content":"Risposta"}\n\n',
+            `data: {"type":"complete","threadId":"${THREAD_ID}"}\n\n`,
+          ]),
+        } as unknown as Response)
+      );
+
+      const { result } = renderHook(() =>
+        useSessionAgentChat(GAME_SESSION_ID, 'agent-1', { persistHistory: true })
+      );
+
+      await act(async () => {
+        await result.current.ask('Domanda di test');
+      });
+
+      expect(sessionStorage.getItem(STORAGE_KEY)).toBe(THREAD_ID);
+    });
+
+    it('AC-CHAT-1 opt-in OFF (default): no sessionStorage access, no getThreadById, messages empty', async () => {
+      sessionStorage.setItem(STORAGE_KEY, THREAD_ID);
+
+      const { result } = renderHook(() => useSessionAgentChat(GAME_SESSION_ID, 'agent-1'));
+
+      // Wait briefly for any async effect
+      await act(async () => {
+        await new Promise(resolve => setTimeout(resolve, 0));
+      });
+
+      // getThreadById must NOT be called when persistHistory is off
+      expect(mockGetThreadById).not.toHaveBeenCalled();
+      // messages must remain empty
+      expect(result.current.messages).toHaveLength(0);
+    });
+
+    it('AC-CHAT-1 opt-in explicit false: no getThreadById called', async () => {
+      sessionStorage.setItem(STORAGE_KEY, THREAD_ID);
+
+      const { result } = renderHook(() =>
+        useSessionAgentChat(GAME_SESSION_ID, 'agent-1', { persistHistory: false })
+      );
+
+      await act(async () => {
+        await new Promise(resolve => setTimeout(resolve, 0));
+      });
+
+      expect(mockGetThreadById).not.toHaveBeenCalled();
+      expect(result.current.messages).toHaveLength(0);
+    });
+
+    it('AC-CHAT-1 graceful: getThreadById rejects → no throw, messages remains empty', async () => {
+      sessionStorage.setItem(STORAGE_KEY, THREAD_ID);
+      mockGetThreadById.mockRejectedValueOnce(new Error('Network error'));
+
+      const { result } = renderHook(() =>
+        useSessionAgentChat(GAME_SESSION_ID, 'agent-1', { persistHistory: true })
+      );
+
+      await act(async () => {
+        await new Promise(resolve => setTimeout(resolve, 0));
+      });
+
+      // Must not throw, messages must stay empty on failure
+      expect(result.current.messages).toHaveLength(0);
+    });
+
+    it('AC-CHAT-1 graceful: no persisted threadId → no fetch, messages empty', async () => {
+      // sessionStorage is empty (no STORAGE_KEY)
+      const { result } = renderHook(() =>
+        useSessionAgentChat(GAME_SESSION_ID, 'agent-1', { persistHistory: true })
+      );
+
+      await act(async () => {
+        await new Promise(resolve => setTimeout(resolve, 0));
+      });
+
+      expect(mockGetThreadById).not.toHaveBeenCalled();
+      expect(result.current.messages).toHaveLength(0);
+    });
+
+    it('AC-CHAT-1 mapping: citationsJson null on messages → citations undefined', async () => {
+      sessionStorage.setItem(STORAGE_KEY, THREAD_ID);
+
+      mockGetThreadById.mockResolvedValueOnce({
+        id: THREAD_ID,
+        gameId: null,
+        agentId: null,
+        agentType: null,
+        title: null,
+        createdAt: '2026-06-23T10:00:00Z',
+        lastMessageAt: '2026-06-23T10:01:00Z',
+        messageCount: 2,
+        messages: [
+          {
+            content: 'Come funziona?',
+            role: 'user',
+            timestamp: '2026-06-23T10:00:00Z',
+            backendMessageId: 'msg-uuid-002',
+            citationsJson: null,
+          },
+          {
+            content: 'Funziona così.',
+            role: 'assistant',
+            timestamp: '2026-06-23T10:01:00Z',
+            backendMessageId: 'msg-uuid-003',
+            citationsJson: null,
+          },
+        ],
+      });
+
+      const { result } = renderHook(() =>
+        useSessionAgentChat(GAME_SESSION_ID, 'agent-1', { persistHistory: true })
+      );
+
+      await act(async () => {
+        await new Promise(resolve => setTimeout(resolve, 0));
+      });
+
+      expect(result.current.messages).toHaveLength(2);
+      expect(result.current.messages[0].citations).toBeUndefined();
+      expect(result.current.messages[1].citations).toBeUndefined();
+    });
+
+    it('AC-CHAT-1 persist opt-in OFF: SSE complete does NOT write to sessionStorage', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue({
+          ok: true,
+          body: makeReadableStream([
+            'data: {"type":"token","content":"Risposta"}\n\n',
+            `data: {"type":"complete","threadId":"${THREAD_ID}"}\n\n`,
+          ]),
+        } as unknown as Response)
+      );
+
+      const { result } = renderHook(
+        () => useSessionAgentChat(GAME_SESSION_ID, 'agent-1')
+        // no persistHistory
+      );
+
+      await act(async () => {
+        await result.current.ask('Domanda di test');
+      });
+
+      // sessionStorage must remain empty when opt-in is off
+      expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull();
     });
   });
 });

--- a/apps/web/src/lib/domain-hooks/__tests__/useSessionAgentChat.test.ts
+++ b/apps/web/src/lib/domain-hooks/__tests__/useSessionAgentChat.test.ts
@@ -33,6 +33,36 @@ const makeReadableStream = (chunks: string[]) => {
 const SESSION_STORAGE_KEY = (gameSessionId: string) =>
   `meepleai:live-agent-thread:${gameSessionId}`;
 
+// ─── Real wire SSE helpers ────────────────────────────────────────────────────
+// C2 (#2500): BE emits {"type":<int>,"data":{...},"timestamp":"...Z"}
+// Token=7, Complete=4, Error=5
+
+function sseToken(token: string): string {
+  return `data: ${JSON.stringify({ type: 7, data: { token }, timestamp: new Date().toISOString() })}\n\n`;
+}
+
+function sseComplete(chatThreadId: string, citations?: unknown[]): string {
+  return `data: ${JSON.stringify({
+    type: 4,
+    data: { chatThreadId, citations: citations ?? [], totalTokens: 10, confidence: 0.9 },
+    timestamp: new Date().toISOString(),
+  })}\n\n`;
+}
+
+/** Real CitationDto wire shape (BE Contracts.cs:137-144) */
+function makeCitationDto(overrides?: Record<string, unknown>) {
+  return {
+    documentId: 'doc-uuid-001',
+    pageNumber: 7,
+    relevanceScore: 0.92,
+    snippetPreview: 'Posiziona la plancia al centro.',
+    copyrightTier: 'full',
+    paraphrasedSnippet: null,
+    isPublic: true,
+    ...overrides,
+  };
+}
+
 describe('useSessionAgentChat', () => {
   beforeEach(() => {
     localStorage.clear();
@@ -79,10 +109,7 @@ describe('useSessionAgentChat', () => {
       'fetch',
       vi.fn().mockResolvedValue({
         ok: true,
-        body: makeReadableStream([
-          'data: {"type":"token","content":"Ciao"}\n\n',
-          'data: {"type":"complete","threadId":"t1"}\n\n',
-        ]),
+        body: makeReadableStream([sseToken('Ciao'), sseComplete('t1')]),
       } as unknown as Response)
     );
 
@@ -96,14 +123,59 @@ describe('useSessionAgentChat', () => {
     expect(result.current.messages[0].content).toBe('Come funziona?');
   });
 
-  it('ask estrae le citazioni dal payload complete', async () => {
+  // ─── C2 wire format contract test ──────────────────────────────────────────
+  // This is the key anti-false-green test: asserts the parser reads
+  // {type:4,data:{chatThreadId,citations}} (numeric type, nested data).
+
+  it('C2 wire contract: token type=7 + complete type=4 with chatThreadId + citations', async () => {
+    const citationDto = makeCitationDto();
+
     vi.stubGlobal(
       'fetch',
       vi.fn().mockResolvedValue({
         ok: true,
         body: makeReadableStream([
-          'data: {"type":"token","content":"Posiziona la plancia."}\n\n',
-          'data: {"type":"complete","threadId":"t1","citations":[{"source":"Regolamento Azul","pageNumber":7,"copyrightTier":"full","snippet":"Posiziona la plancia al centro."}]}\n\n',
+          sseToken('Posiziona'),
+          sseToken(' la plancia.'),
+          sseComplete('thread-wire-001', [citationDto]),
+        ]),
+      } as unknown as Response)
+    );
+
+    const { result } = renderHook(() =>
+      useSessionAgentChat('game-sess-wire', 'agent-wire', { persistHistory: true })
+    );
+
+    await act(async () => {
+      await result.current.ask('Come si fa il setup?');
+    });
+
+    const lastMsg = result.current.messages[result.current.messages.length - 1];
+    expect(lastMsg.role).toBe('assistant');
+    // Token accumulation works
+    expect(lastMsg.content).toBe('Posiziona la plancia.');
+    // Citations mapped from real wire shape (snippetPreview → excerpt, documentId → documentName)
+    expect(lastMsg.citations).toBeDefined();
+    expect(lastMsg.citations).toHaveLength(1);
+    expect(lastMsg.citations![0]).toEqual({
+      documentName: 'doc-uuid-001', // real wire has no `source` → falls back to documentId
+      pages: [7],
+      excerpt: 'Posiziona la plancia al centro.',
+    });
+    // threadId persisted to sessionStorage
+    expect(sessionStorage.getItem(SESSION_STORAGE_KEY('game-sess-wire'))).toBe('thread-wire-001');
+  });
+
+  it('ask estrae le citazioni dal payload complete (wire format)', async () => {
+    const citationDto = makeCitationDto({ snippetPreview: 'Posiziona la plancia al centro.' });
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        body: makeReadableStream([
+          sseToken('Posiziona la plancia.'),
+          sseComplete('t1', [citationDto]),
         ]),
       } as unknown as Response)
     );
@@ -118,11 +190,8 @@ describe('useSessionAgentChat', () => {
     expect(lastMsg.role).toBe('assistant');
     expect(lastMsg.citations).toBeDefined();
     expect(lastMsg.citations).toHaveLength(1);
-    expect(lastMsg.citations![0]).toEqual({
-      documentName: 'Regolamento Azul',
-      pages: [7],
-      excerpt: 'Posiziona la plancia al centro.',
-    });
+    expect(lastMsg.citations![0].pages).toEqual([7]);
+    expect(lastMsg.citations![0].excerpt).toBe('Posiziona la plancia al centro.');
   });
 
   // ─────────────────────────────────────────────────────────────────────────
@@ -138,7 +207,8 @@ describe('useSessionAgentChat', () => {
       // Pre-seed sessionStorage with a saved threadId
       sessionStorage.setItem(STORAGE_KEY, THREAD_ID);
 
-      // Mock getThreadById to return a thread with one assistant message with citationsJson
+      // Mock getThreadById to return a thread with one assistant message with citationsJson.
+      // citationsJson stores the real CitationDto wire shape (snippetPreview field).
       mockGetThreadById.mockResolvedValueOnce({
         id: THREAD_ID,
         gameId: null,
@@ -154,8 +224,17 @@ describe('useSessionAgentChat', () => {
             role: 'assistant',
             timestamp: '2026-06-23T10:01:00Z',
             backendMessageId: 'msg-uuid-001',
-            citationsJson:
-              '[{"source":"Regolamento Towers","pageNumber":3,"copyrightTier":"full","snippet":"Piazza la torre sulla casella."}]',
+            citationsJson: JSON.stringify([
+              {
+                documentId: 'doc-towers-001',
+                pageNumber: 3,
+                relevanceScore: 0.88,
+                snippetPreview: 'Piazza la torre sulla casella.',
+                copyrightTier: 'full',
+                paraphrasedSnippet: null,
+                isPublic: true,
+              },
+            ]),
           },
         ],
       });
@@ -176,7 +255,7 @@ describe('useSessionAgentChat', () => {
       expect(msg.citations).toBeDefined();
       expect(msg.citations).toHaveLength(1);
       expect(msg.citations![0]).toEqual({
-        documentName: 'Regolamento Towers',
+        documentName: 'doc-towers-001', // no `source` in wire → falls back to documentId
         pages: [3],
         excerpt: 'Piazza la torre sulla casella.',
       });
@@ -187,10 +266,7 @@ describe('useSessionAgentChat', () => {
         'fetch',
         vi.fn().mockResolvedValue({
           ok: true,
-          body: makeReadableStream([
-            'data: {"type":"token","content":"Risposta"}\n\n',
-            `data: {"type":"complete","threadId":"${THREAD_ID}"}\n\n`,
-          ]),
+          body: makeReadableStream([sseToken('Risposta'), sseComplete(THREAD_ID)]),
         } as unknown as Response)
       );
 
@@ -314,10 +390,7 @@ describe('useSessionAgentChat', () => {
         'fetch',
         vi.fn().mockResolvedValue({
           ok: true,
-          body: makeReadableStream([
-            'data: {"type":"token","content":"Risposta"}\n\n',
-            `data: {"type":"complete","threadId":"${THREAD_ID}"}\n\n`,
-          ]),
+          body: makeReadableStream([sseToken('Risposta'), sseComplete(THREAD_ID)]),
         } as unknown as Response)
       );
 
@@ -336,6 +409,105 @@ describe('useSessionAgentChat', () => {
   });
 
   // ─────────────────────────────────────────────────────────────────────────
+  // I1: gameContext explicit injection
+  // ─────────────────────────────────────────────────────────────────────────
+
+  describe('I1: gameContext explicit injection', () => {
+    it('uses explicit gameContext in fetch body when provided', async () => {
+      let capturedBody: Record<string, unknown> | undefined;
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockImplementation(async (_url: string, init: RequestInit) => {
+          capturedBody = JSON.parse(init.body as string) as Record<string, unknown>;
+          return {
+            ok: true,
+            body: makeReadableStream([sseToken('ok'), sseComplete('t-ctx-1')]),
+          };
+        })
+      );
+
+      const { result } = renderHook(() =>
+        useSessionAgentChat('game-sess-ctx', 'agent-ctx', {
+          gameContext: {
+            gameId: 'game-uuid-123',
+            gameTitle: 'Azul',
+            players: ['Alice', 'Bob'],
+            currentTurn: 3,
+          },
+        })
+      );
+
+      await act(async () => {
+        await result.current.ask('Domanda con contesto');
+      });
+
+      expect(capturedBody).toBeDefined();
+      expect(capturedBody?.gameContext).toEqual({
+        gameId: 'game-uuid-123',
+        gameTitle: 'Azul',
+        players: ['Alice', 'Bob'],
+        currentTurn: 3,
+        responseLanguage: 'it',
+      });
+    });
+
+    it('falls back to session store when gameContext not provided (RulesExplainer compat)', async () => {
+      useSessionStore.getState().startSession({
+        sessionId: 'sess-rules',
+        gameId: 'game-rules-1',
+        gameTitle: 'Wingspan',
+        participants: [{ id: 'p1', displayName: 'Luca', isGuest: false }],
+      });
+
+      let capturedBody: Record<string, unknown> | undefined;
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockImplementation(async (_url: string, init: RequestInit) => {
+          capturedBody = JSON.parse(init.body as string) as Record<string, unknown>;
+          return {
+            ok: true,
+            body: makeReadableStream([sseToken('ok'), sseComplete('t-rules-1')]),
+          };
+        })
+      );
+
+      const { result } = renderHook(
+        () => useSessionAgentChat('game-sess-rules', 'agent-rules')
+        // no gameContext — uses store
+      );
+
+      await act(async () => {
+        await result.current.ask('Domanda rules explainer');
+      });
+
+      expect((capturedBody?.gameContext as Record<string, unknown>)?.gameId).toBe('game-rules-1');
+      expect((capturedBody?.gameContext as Record<string, unknown>)?.gameTitle).toBe('Wingspan');
+    });
+
+    it('sends no gameContext when store is empty and no explicit context provided', async () => {
+      let capturedBody: Record<string, unknown> | undefined;
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockImplementation(async (_url: string, init: RequestInit) => {
+          capturedBody = JSON.parse(init.body as string) as Record<string, unknown>;
+          return {
+            ok: true,
+            body: makeReadableStream([sseToken('ok'), sseComplete('t-empty-1')]),
+          };
+        })
+      );
+
+      const { result } = renderHook(() => useSessionAgentChat('game-sess-empty', 'agent-empty'));
+
+      await act(async () => {
+        await result.current.ask('Domanda senza contesto');
+      });
+
+      expect(capturedBody?.gameContext).toBeUndefined();
+    });
+  });
+
+  // ─────────────────────────────────────────────────────────────────────────
   // AC-CHAT-3: isNonGrounded flag — SSE live flow + historic hydration
   // ─────────────────────────────────────────────────────────────────────────
 
@@ -345,10 +517,7 @@ describe('useSessionAgentChat', () => {
         'fetch',
         vi.fn().mockResolvedValue({
           ok: true,
-          body: makeReadableStream([
-            'data: {"type":"token","content":"Risposta senza fonti."}\n\n',
-            'data: {"type":"complete","threadId":"t-ng-1"}\n\n',
-          ]),
+          body: makeReadableStream([sseToken('Risposta senza fonti.'), sseComplete('t-ng-1')]),
         } as unknown as Response)
       );
 
@@ -369,8 +538,8 @@ describe('useSessionAgentChat', () => {
         vi.fn().mockResolvedValue({
           ok: true,
           body: makeReadableStream([
-            'data: {"type":"token","content":"Risposta con fonti."}\n\n',
-            'data: {"type":"complete","threadId":"t-g-1","citations":[{"source":"Reg","pageNumber":3,"copyrightTier":"full","snippet":"testo"}]}\n\n',
+            sseToken('Risposta con fonti.'),
+            sseComplete('t-g-1', [makeCitationDto({ snippetPreview: 'testo' })]),
           ]),
         } as unknown as Response)
       );
@@ -391,10 +560,7 @@ describe('useSessionAgentChat', () => {
         'fetch',
         vi.fn().mockResolvedValue({
           ok: true,
-          body: makeReadableStream([
-            'data: {"type":"token","content":"Risposta."}\n\n',
-            'data: {"type":"complete","threadId":"t-user-1"}\n\n',
-          ]),
+          body: makeReadableStream([sseToken('Risposta.'), sseComplete('t-user-1')]),
         } as unknown as Response)
       );
 
@@ -468,8 +634,17 @@ describe('useSessionAgentChat', () => {
             role: 'assistant',
             timestamp: '2026-06-23T10:01:00Z',
             backendMessageId: 'msg-hist-g-001',
-            citationsJson:
-              '[{"source":"Reg","pageNumber":5,"copyrightTier":"full","snippet":"testo"}]',
+            citationsJson: JSON.stringify([
+              {
+                documentId: 'doc-hist-001',
+                pageNumber: 5,
+                relevanceScore: 0.85,
+                snippetPreview: 'testo storico',
+                copyrightTier: 'full',
+                paraphrasedSnippet: null,
+                isPublic: true,
+              },
+            ]),
           },
         ],
       });

--- a/apps/web/src/lib/domain-hooks/useSessionAgentChat.ts
+++ b/apps/web/src/lib/domain-hooks/useSessionAgentChat.ts
@@ -10,7 +10,10 @@
  */
 import { useCallback, useRef, useState } from 'react';
 
+import type { ChatCitation } from '@/components/chat/panel/ChatCitationCard';
 import { getAgentChatUrl } from '@/lib/api/clients/sessionAgentClient';
+import { CitationSchema } from '@/lib/api/schemas/streaming.schemas';
+import { mapCitationToChatCitation } from '@/lib/session-live/map-citation-to-chat-citation';
 import { useSessionStore } from '@/stores/session/store';
 
 export interface ChatMessage {
@@ -18,6 +21,7 @@ export interface ChatMessage {
   role: 'user' | 'assistant';
   content: string;
   timestamp: string;
+  citations?: ChatCitation[];
 }
 
 /**
@@ -32,6 +36,7 @@ export function useSessionAgentChat(gameSessionId: string, agentSessionId: strin
   const [error, setError] = useState<string | null>(null);
   const [streamingContent, setStreamingContent] = useState('');
   const threadIdRef = useRef<string | undefined>(undefined);
+  const citationsRef = useRef<ChatCitation[]>([]);
   const abortRef = useRef<AbortController | null>(null);
   // Ref-based guard prevents double-submit race regardless of stale closure timing
   const isLoadingRef = useRef(false);
@@ -50,6 +55,7 @@ export function useSessionAgentChat(gameSessionId: string, agentSessionId: strin
       setIsLoading(true);
       setError(null);
       setStreamingContent('');
+      citationsRef.current = [];
 
       const userMsg: ChatMessage = {
         id: crypto.randomUUID(),
@@ -126,12 +132,22 @@ export function useSessionAgentChat(gameSessionId: string, agentSessionId: strin
                     type: string;
                     content?: string;
                     threadId?: string;
+                    citations?: unknown[];
                   };
                   if (payload.type === 'token' && payload.content) {
                     accumulated += payload.content;
                     setStreamingContent(accumulated);
-                  } else if (payload.type === 'complete' && payload.threadId) {
-                    threadIdRef.current = payload.threadId;
+                  } else if (payload.type === 'complete') {
+                    if (payload.threadId) {
+                      threadIdRef.current = payload.threadId;
+                    }
+                    if (payload.citations) {
+                      citationsRef.current = (
+                        CitationSchema.array().safeParse(payload.citations).data ?? []
+                      )
+                        .map(mapCitationToChatCitation)
+                        .filter((x): x is ChatCitation => x !== null);
+                    }
                   }
                 } catch {
                   // Ignore non-JSON lines (keep-alive, comments, etc.)
@@ -148,6 +164,7 @@ export function useSessionAgentChat(gameSessionId: string, agentSessionId: strin
           role: 'assistant',
           content: accumulated,
           timestamp: new Date().toISOString(),
+          citations: citationsRef.current.length ? citationsRef.current : undefined,
         };
         setMessages(prev => [...prev, assistantMsg]);
         setStreamingContent('');

--- a/apps/web/src/lib/domain-hooks/useSessionAgentChat.ts
+++ b/apps/web/src/lib/domain-hooks/useSessionAgentChat.ts
@@ -35,6 +35,22 @@ export interface ChatMessage {
   isNonGrounded?: boolean;
 }
 
+/**
+ * Explicit game context for RAG enrichment (I1 #2500).
+ * When provided via options, overrides the session store selectors so the hook
+ * can be used in routes where the game-night store is not populated
+ * (e.g. the live session route — SessionLiveView passes data from LiveSessionDto).
+ *
+ * When absent, the hook falls back to the store selectors (existing behaviour —
+ * preserves RulesExplainer compatibility).
+ */
+export interface SessionAgentGameContext {
+  gameId: string;
+  gameTitle: string;
+  players: string[];
+  currentTurn?: number;
+}
+
 /** Options for useSessionAgentChat. */
 export interface UseSessionAgentChatOptions {
   /**
@@ -43,6 +59,13 @@ export interface UseSessionAgentChatOptions {
    * Default: false (off) — keeps legacy behaviour for all existing consumers.
    */
   persistHistory?: boolean;
+  /**
+   * Explicit game context for RAG enrichment (I1 #2500 — Opzione A).
+   * Pass from LiveSessionDto in SessionLiveView to avoid reading an unpopulated
+   * game-night store. When absent, falls back to useSessionStore selectors
+   * (backward-compat for RulesExplainer and other consumers).
+   */
+  gameContext?: SessionAgentGameContext;
 }
 
 /** sessionStorage key for the persisted chatThreadId, keyed on gameSessionId. */
@@ -77,12 +100,19 @@ function writeThreadIdToStorage(gameSessionId: string, threadId: string): void {
  * @param agentSessionId - The agent session ID returned by LaunchSessionAgent (sent in body)
  * @param options - Optional opt-in flags. Pass `{ persistHistory: true }` in SessionLiveView only.
  */
+// StreamingEventType numeric values (matches BE Contracts.cs:71-111)
+// Naming mirrors useAgentChatStream.ts for consistency.
+const SSE_TOKEN = 7; // data: { token: string }
+const SSE_COMPLETE = 4; // data: { chatThreadId, citations[], totalTokens, confidence }
+const SSE_ERROR = 5; // data: { errorMessage, errorCode }
+
 export function useSessionAgentChat(
   gameSessionId: string,
   agentSessionId: string,
   options?: UseSessionAgentChatOptions
 ) {
   const persistHistory = options?.persistHistory ?? false;
+  const explicitGameContext = options?.gameContext;
 
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [isLoading, setIsLoading] = useState(false);
@@ -94,7 +124,10 @@ export function useSessionAgentChat(
   // Ref-based guard prevents double-submit race regardless of stale closure timing
   const isLoadingRef = useRef(false);
 
-  // Granular selectors — avoid re-renders on unrelated store changes
+  // Granular selectors — avoid re-renders on unrelated store changes.
+  // I1 (#2500): when explicitGameContext is provided (e.g. from SessionLiveView via
+  // LiveSessionDto), the store values are still read but overridden below, so the
+  // game-night store not being populated does not affect the live session route.
   const gameId = useSessionStore(s => s.gameId);
   const gameTitle = useSessionStore(s => s.gameTitle);
   const participants = useSessionStore(s => s.participants);
@@ -184,16 +217,35 @@ export function useSessionAgentChat(
       };
       setMessages(prev => [...prev, userMsg]);
 
-      const gameContext =
-        gameId && gameTitle
-          ? {
-              gameId,
-              gameTitle,
-              players: participants.map(p => p.displayName),
-              currentTurn,
-              responseLanguage: 'it',
-            }
-          : undefined;
+      // I1 (#2500 Opzione A): prefer explicit gameContext from options (e.g. LiveSessionDto),
+      // fall back to session store selectors (RulesExplainer / other legacy consumers).
+      let gameContext:
+        | {
+            gameId: string;
+            gameTitle: string;
+            players: string[];
+            currentTurn?: number;
+            responseLanguage: string;
+          }
+        | undefined;
+
+      if (explicitGameContext && explicitGameContext.gameId) {
+        gameContext = {
+          gameId: explicitGameContext.gameId,
+          gameTitle: explicitGameContext.gameTitle,
+          players: explicitGameContext.players,
+          currentTurn: explicitGameContext.currentTurn,
+          responseLanguage: 'it',
+        };
+      } else if (gameId && gameTitle) {
+        gameContext = {
+          gameId,
+          gameTitle,
+          players: participants.map(p => p.displayName),
+          currentTurn,
+          responseLanguage: 'it',
+        };
+      }
 
       abortRef.current = new AbortController();
 
@@ -247,30 +299,47 @@ export function useSessionAgentChat(
             for (const line of lines) {
               if (line.startsWith('data: ')) {
                 try {
-                  const payload = JSON.parse(line.slice(6)) as {
-                    type: string;
-                    content?: string;
-                    threadId?: string;
-                    citations?: unknown[];
+                  // C2 (#2500): BE serialises with SseJsonOptions — camelCase, NUMERIC enum.
+                  // Wire: {"type":<int>,"data":{...},"timestamp":"...Z"}
+                  // Token (7):    data.token: string
+                  // Complete (4): data.chatThreadId, data.citations[]
+                  // Error (5):    data.errorMessage, data.errorCode
+                  const event = JSON.parse(line.slice(6)) as {
+                    type: number;
+                    data: unknown;
+                    timestamp?: string;
                   };
-                  if (payload.type === 'token' && payload.content) {
-                    accumulated += payload.content;
-                    setStreamingContent(accumulated);
-                  } else if (payload.type === 'complete') {
-                    if (payload.threadId) {
-                      threadIdRef.current = payload.threadId;
+
+                  if (event.type === SSE_TOKEN) {
+                    const t = (event.data as { token?: string }).token;
+                    if (t) {
+                      accumulated += t;
+                      setStreamingContent(accumulated);
+                    }
+                  } else if (event.type === SSE_COMPLETE) {
+                    const d = event.data as {
+                      chatThreadId?: string;
+                      citations?: unknown[];
+                    };
+                    if (d.chatThreadId) {
+                      threadIdRef.current = d.chatThreadId;
                       // R3: persist to sessionStorage so it survives reload
                       if (persistHistory) {
-                        writeThreadIdToStorage(gameSessionId, payload.threadId);
+                        writeThreadIdToStorage(gameSessionId, d.chatThreadId);
                       }
                     }
-                    if (payload.citations) {
+                    if (d.citations) {
                       citationsRef.current = (
-                        CitationSchema.array().safeParse(payload.citations).data ?? []
+                        CitationSchema.array().safeParse(d.citations).data ?? []
                       )
                         .map(mapCitationToChatCitation)
                         .filter((x): x is ChatCitation => x !== null);
                     }
+                  } else if (event.type === SSE_ERROR) {
+                    const d = event.data as { errorMessage?: string; errorCode?: string };
+                    setError(
+                      d.errorMessage ?? "L'agente non è disponibile. Controlla la connessione."
+                    );
                   }
                 } catch {
                   // Ignore non-JSON lines (keep-alive, comments, etc.)
@@ -304,8 +373,17 @@ export function useSessionAgentChat(
       }
     },
     // Removed `isLoading` — guard now uses isLoadingRef to avoid stale closure race
-    // persistHistory is captured by closure from outer scope (stable)
-    [gameSessionId, agentSessionId, gameId, gameTitle, participants, currentTurn, persistHistory]
+    // persistHistory and explicitGameContext are captured from outer scope (stable per mount)
+    [
+      gameSessionId,
+      agentSessionId,
+      gameId,
+      gameTitle,
+      participants,
+      currentTurn,
+      persistHistory,
+      explicitGameContext,
+    ]
   );
 
   const stop = useCallback(() => {

--- a/apps/web/src/lib/domain-hooks/useSessionAgentChat.ts
+++ b/apps/web/src/lib/domain-hooks/useSessionAgentChat.ts
@@ -7,10 +7,15 @@
  * Enriches requests with current game context from the session store.
  *
  * Endpoint: POST /api/v1/game-sessions/{gameSessionId}/agent/chat
+ *
+ * R2/R3/R4 (#2500 Task 5-FE): opt-in `persistHistory` flag enables sessionStorage
+ * persistence of chatThreadId (keyed on gameSessionId) and history hydration on mount.
+ * Default OFF to keep RulesExplainer and other consumers unaffected.
  */
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import type { ChatCitation } from '@/components/chat/panel/ChatCitationCard';
+import { api } from '@/lib/api';
 import { getAgentChatUrl } from '@/lib/api/clients/sessionAgentClient';
 import { CitationSchema } from '@/lib/api/schemas/streaming.schemas';
 import { mapCitationToChatCitation } from '@/lib/session-live/map-citation-to-chat-citation';
@@ -24,13 +29,55 @@ export interface ChatMessage {
   citations?: ChatCitation[];
 }
 
+/** Options for useSessionAgentChat. */
+export interface UseSessionAgentChatOptions {
+  /**
+   * When true, enables sessionStorage persistence of chatThreadId and history
+   * hydration on mount via GET /chat-threads/{threadId}.
+   * Default: false (off) — keeps legacy behaviour for all existing consumers.
+   */
+  persistHistory?: boolean;
+}
+
+/** sessionStorage key for the persisted chatThreadId, keyed on gameSessionId. */
+function buildStorageKey(gameSessionId: string): string {
+  return `meepleai:live-agent-thread:${gameSessionId}`;
+}
+
+/** Safe sessionStorage read (guard SSR / private-browsing throws). */
+function readThreadIdFromStorage(gameSessionId: string): string | null {
+  try {
+    if (typeof window === 'undefined') return null;
+    return sessionStorage.getItem(buildStorageKey(gameSessionId));
+  } catch {
+    return null;
+  }
+}
+
+/** Safe sessionStorage write. */
+function writeThreadIdToStorage(gameSessionId: string, threadId: string): void {
+  try {
+    if (typeof window === 'undefined') return;
+    sessionStorage.setItem(buildStorageKey(gameSessionId), threadId);
+  } catch {
+    // Ignore (quota exceeded, private browsing, etc.)
+  }
+}
+
 /**
  * Hook for streaming AI agent chat within an active game session.
  *
  * @param gameSessionId - The game session ID (used in URL path)
  * @param agentSessionId - The agent session ID returned by LaunchSessionAgent (sent in body)
+ * @param options - Optional opt-in flags. Pass `{ persistHistory: true }` in SessionLiveView only.
  */
-export function useSessionAgentChat(gameSessionId: string, agentSessionId: string) {
+export function useSessionAgentChat(
+  gameSessionId: string,
+  agentSessionId: string,
+  options?: UseSessionAgentChatOptions
+) {
+  const persistHistory = options?.persistHistory ?? false;
+
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -46,6 +93,63 @@ export function useSessionAgentChat(gameSessionId: string, agentSessionId: strin
   const gameTitle = useSessionStore(s => s.gameTitle);
   const participants = useSessionStore(s => s.participants);
   const currentTurn = useSessionStore(s => s.currentTurn);
+
+  // R3/R4: on mount, hydrate thread history when persistHistory is enabled.
+  // Runs only once (empty deps list — gameSessionId and persistHistory are stable for the
+  // lifetime of the component instance, so no re-run is needed even if they change).
+  useEffect(() => {
+    if (!persistHistory) return;
+
+    const savedThreadId = readThreadIdFromStorage(gameSessionId);
+    if (!savedThreadId) return;
+
+    // Hydrate the ref so that the next ask() continues the same thread (multi-turn).
+    threadIdRef.current = savedThreadId;
+
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const thread = await api.chat.getThreadById(savedThreadId);
+        if (cancelled || !thread) return;
+
+        const historicMessages: ChatMessage[] = thread.messages.map((dto, idx) => {
+          // Parse citationsJson if present (assistant messages only per spec).
+          let citations: ChatCitation[] | undefined;
+          if (dto.citationsJson) {
+            try {
+              const parsed = JSON.parse(dto.citationsJson) as unknown;
+              const result = CitationSchema.array().safeParse(parsed);
+              const mapped = (result.data ?? [])
+                .map(mapCitationToChatCitation)
+                .filter((x): x is ChatCitation => x !== null);
+              if (mapped.length > 0) citations = mapped;
+            } catch {
+              // Ignore malformed JSON — graceful failure per R4
+            }
+          }
+
+          return {
+            id: dto.backendMessageId ?? `history-${idx}`,
+            role: (dto.role === 'user' ? 'user' : 'assistant') as 'user' | 'assistant',
+            content: dto.content,
+            timestamp: dto.timestamp,
+            citations,
+          };
+        });
+
+        setMessages(historicMessages);
+      } catch (err) {
+        // Graceful failure (R4): log but do not crash or block chat
+        console.warn('[useSessionAgentChat] Failed to hydrate history:', err);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const ask = useCallback(
     async (question: string) => {
@@ -140,6 +244,10 @@ export function useSessionAgentChat(gameSessionId: string, agentSessionId: strin
                   } else if (payload.type === 'complete') {
                     if (payload.threadId) {
                       threadIdRef.current = payload.threadId;
+                      // R3: persist to sessionStorage so it survives reload
+                      if (persistHistory) {
+                        writeThreadIdToStorage(gameSessionId, payload.threadId);
+                      }
                     }
                     if (payload.citations) {
                       citationsRef.current = (
@@ -178,7 +286,8 @@ export function useSessionAgentChat(gameSessionId: string, agentSessionId: strin
       }
     },
     // Removed `isLoading` — guard now uses isLoadingRef to avoid stale closure race
-    [gameSessionId, agentSessionId, gameId, gameTitle, participants, currentTurn]
+    // persistHistory is captured by closure from outer scope (stable)
+    [gameSessionId, agentSessionId, gameId, gameTitle, participants, currentTurn, persistHistory]
   );
 
   const stop = useCallback(() => {

--- a/apps/web/src/lib/domain-hooks/useSessionAgentChat.ts
+++ b/apps/web/src/lib/domain-hooks/useSessionAgentChat.ts
@@ -27,6 +27,12 @@ export interface ChatMessage {
   content: string;
   timestamp: string;
   citations?: ChatCitation[];
+  /**
+   * AC-CHAT-3: true only when this is a genuine RAG assistant response with zero citations
+   * (i.e., the agent answered but found no grounding in the rulebook).
+   * Never set on user messages or system status messages injected by SessionLiveView.
+   */
+  isNonGrounded?: boolean;
 }
 
 /** Options for useSessionAgentChat. */
@@ -129,12 +135,21 @@ export function useSessionAgentChat(
             }
           }
 
+          const role = (dto.role === 'user' ? 'user' : 'assistant') as 'user' | 'assistant';
+          // AC-CHAT-3: historic assistant message with no citations → isNonGrounded true.
+          // User messages never have this flag.
+          const isNonGrounded =
+            role === 'assistant' && (citations === undefined || citations.length === 0)
+              ? true
+              : undefined;
+
           return {
             id: dto.backendMessageId ?? `history-${idx}`,
-            role: (dto.role === 'user' ? 'user' : 'assistant') as 'user' | 'assistant',
+            role,
             content: dto.content,
             timestamp: dto.timestamp,
             citations,
+            isNonGrounded,
           };
         });
 
@@ -267,12 +282,15 @@ export function useSessionAgentChat(
           reader.releaseLock();
         }
 
+        // AC-CHAT-3: if the RAG response produced zero citations, flag as non-grounded.
+        const hasCitations = citationsRef.current.length > 0;
         const assistantMsg: ChatMessage = {
           id: crypto.randomUUID(),
           role: 'assistant',
           content: accumulated,
           timestamp: new Date().toISOString(),
-          citations: citationsRef.current.length ? citationsRef.current : undefined,
+          citations: hasCitations ? citationsRef.current : undefined,
+          isNonGrounded: hasCitations ? undefined : true,
         };
         setMessages(prev => [...prev, assistantMsg]);
         setStreamingContent('');

--- a/apps/web/src/lib/session-live/__tests__/map-citation-to-chat-citation.test.ts
+++ b/apps/web/src/lib/session-live/__tests__/map-citation-to-chat-citation.test.ts
@@ -2,7 +2,23 @@ import { describe, it, expect } from 'vitest';
 import { mapCitationToChatCitation } from '../map-citation-to-chat-citation';
 import type { Citation } from '@/lib/api/schemas/streaming.schemas';
 
-const base: Partial<Citation> = {
+// ─── Real wire CitationDto shape (BE Contracts.cs:137-144) ──────────────────
+// C2 (#2500): { documentId, pageNumber, relevanceScore, snippetPreview,
+//               copyrightTier, paraphrasedSnippet, isPublic }
+// No `source`, no `snippet`, no `text`.
+
+const wireBase: Partial<Citation> = {
+  documentId: 'doc-uuid-wire-001',
+  pageNumber: 7,
+  relevanceScore: 0.92,
+  copyrightTier: 'full',
+  isPublic: true,
+};
+
+// ─── Legacy shape base (kept for backward-compat tests) ──────────────────────
+// Consumers like kb-ask or stored citationsJson from before C2 may have `source`/`snippet`.
+
+const legacyBase: Partial<Citation> = {
   source: 'Regolamento Azul',
   documentId: 'doc-1',
   pageNumber: 7,
@@ -10,182 +26,311 @@ const base: Partial<Citation> = {
 };
 
 describe('mapCitationToChatCitation', () => {
-  it('full tier -> excerpt from snippet', () => {
-    const citation = {
-      ...base,
-      snippet: 'Posiziona la plancia.',
-    } as Citation;
+  // ─── Real wire format (C2 #2500) ───────────────────────────────────────────
 
-    const result = mapCitationToChatCitation(citation);
+  describe('real wire format (C2 #2500)', () => {
+    it('full tier → excerpt from snippetPreview (real wire field)', () => {
+      const citation = {
+        ...wireBase,
+        snippetPreview: 'Posiziona la plancia al centro.',
+      } as Citation;
 
-    expect(result).toEqual({
-      documentName: 'Regolamento Azul',
-      pages: [7],
-      excerpt: 'Posiziona la plancia.',
+      const result = mapCitationToChatCitation(citation);
+
+      expect(result).toEqual({
+        documentName: 'doc-uuid-wire-001', // no `source` → falls back to documentId
+        pages: [7],
+        excerpt: 'Posiziona la plancia al centro.',
+      });
+    });
+
+    it('real wire: documentName is documentId when source absent', () => {
+      const citation = {
+        ...wireBase,
+        snippetPreview: 'Testo regola.',
+      } as Citation;
+
+      const result = mapCitationToChatCitation(citation);
+
+      expect(result?.documentName).toBe('doc-uuid-wire-001');
+    });
+
+    it('real wire: protected tier → paraphrasedSnippet (never verbatim snippetPreview)', () => {
+      const citation = {
+        ...wireBase,
+        copyrightTier: 'protected',
+        snippetPreview: 'Verbatim protetto — NON mostrare.',
+        paraphrasedSnippet: 'Riassunto consentito della regola.',
+        isPublic: false,
+      } as Citation;
+
+      const result = mapCitationToChatCitation(citation);
+
+      expect(result?.excerpt).toBe('Riassunto consentito della regola.');
+      expect(result?.excerpt).not.toContain('Verbatim');
+    });
+
+    it('real wire: protected tier, no paraphrasedSnippet → returns null', () => {
+      const citation = {
+        ...wireBase,
+        copyrightTier: 'protected',
+        snippetPreview: 'Verbatim non divulgabile.',
+        paraphrasedSnippet: null,
+        isPublic: false,
+      } as Citation;
+
+      const result = mapCitationToChatCitation(citation);
+
+      expect(result).toBeNull();
+    });
+
+    it('real wire: no snippetPreview and no text → returns null (full tier)', () => {
+      const citation = {
+        ...wireBase,
+        snippetPreview: null,
+        // no snippet, no text
+      } as Citation;
+
+      const result = mapCitationToChatCitation(citation);
+
+      expect(result).toBeNull();
+    });
+
+    it('real wire: pageNumber used correctly', () => {
+      const citation = {
+        ...wireBase,
+        pageNumber: 42,
+        snippetPreview: 'contenuto',
+      } as Citation;
+
+      const result = mapCitationToChatCitation(citation);
+
+      expect(result?.pages).toEqual([42]);
+    });
+
+    it('real wire: no documentId and no source → documentName is empty string', () => {
+      const citation = {
+        pageNumber: 1,
+        relevanceScore: 0.5,
+        copyrightTier: 'full',
+        isPublic: true,
+        snippetPreview: 'contenuto',
+      } as unknown as Citation;
+
+      const result = mapCitationToChatCitation(citation);
+
+      expect(result?.documentName).toBe('');
     });
   });
 
-  it('full tier -> excerpt from text when snippet is absent', () => {
-    const citation = {
-      ...base,
-      snippet: null,
-      text: 'Fallback text content.',
-    } as Citation;
+  // ─── Legacy / backward-compat format ───────────────────────────────────────
+  // Ensures that kb-ask consumers and old citationsJson (with `source`/`snippet`) still work.
 
-    const result = mapCitationToChatCitation(citation);
+  describe('legacy format (backward-compat)', () => {
+    it('full tier → excerpt from snippet (legacy field)', () => {
+      const citation = {
+        ...legacyBase,
+        snippet: 'Posiziona la plancia.',
+      } as Citation;
 
-    expect(result).toEqual({
-      documentName: 'Regolamento Azul',
-      pages: [7],
-      excerpt: 'Fallback text content.',
+      const result = mapCitationToChatCitation(citation);
+
+      expect(result).toEqual({
+        documentName: 'Regolamento Azul',
+        pages: [7],
+        excerpt: 'Posiziona la plancia.',
+      });
     });
-  });
 
-  it('full tier -> prefers snippet over text', () => {
-    const citation = {
-      ...base,
-      snippet: 'Preferred snippet.',
-      text: 'Fallback text.',
-    } as Citation;
+    it('full tier → excerpt from text when snippet is absent', () => {
+      const citation = {
+        ...legacyBase,
+        snippet: null,
+        text: 'Fallback text content.',
+      } as Citation;
 
-    const result = mapCitationToChatCitation(citation);
+      const result = mapCitationToChatCitation(citation);
 
-    expect(result).toEqual({
-      documentName: 'Regolamento Azul',
-      pages: [7],
-      excerpt: 'Preferred snippet.',
+      expect(result).toEqual({
+        documentName: 'Regolamento Azul',
+        pages: [7],
+        excerpt: 'Fallback text content.',
+      });
     });
-  });
 
-  it('protected tier -> excerpt from paraphrasedSnippet only, never verbatim', () => {
-    const citation = {
-      ...base,
-      copyrightTier: 'protected',
-      snippet: 'Verbatim text should be ignored.',
-      text: 'More verbatim text.',
-      paraphrasedSnippet: 'Sintesi della regola in paraphrase.',
-    } as Citation;
+    it('full tier → prefers snippetPreview over snippet (priority order)', () => {
+      const citation = {
+        ...legacyBase,
+        snippetPreview: 'snippetPreview wins.',
+        snippet: 'snippet second.',
+        text: 'text last.',
+      } as Citation;
 
-    const result = mapCitationToChatCitation(citation);
+      const result = mapCitationToChatCitation(citation);
 
-    expect(result?.excerpt).toBe('Sintesi della regola in paraphrase.');
-    expect(result?.excerpt).not.toContain('Verbatim');
-  });
+      expect(result?.excerpt).toBe('snippetPreview wins.');
+    });
 
-  it('protected tier with no paraphrase and no snippet -> returns null', () => {
-    const citation = {
-      ...base,
-      copyrightTier: 'protected',
-      snippet: null,
-      paraphrasedSnippet: null,
-    } as Citation;
+    it('full tier → prefers snippet over text when snippetPreview absent', () => {
+      const citation = {
+        ...legacyBase,
+        snippet: 'Preferred snippet.',
+        text: 'Fallback text.',
+      } as Citation;
 
-    const result = mapCitationToChatCitation(citation);
+      const result = mapCitationToChatCitation(citation);
 
-    expect(result).toBeNull();
-  });
+      expect(result).toEqual({
+        documentName: 'Regolamento Azul',
+        pages: [7],
+        excerpt: 'Preferred snippet.',
+      });
+    });
 
-  it('protected tier with no paraphrase and no text -> returns null', () => {
-    const citation = {
-      ...base,
-      copyrightTier: 'protected',
-      snippet: null,
-      text: null,
-      paraphrasedSnippet: null,
-    } as Citation;
+    it('protected tier → excerpt from paraphrasedSnippet only, never verbatim', () => {
+      const citation = {
+        ...legacyBase,
+        copyrightTier: 'protected',
+        snippet: 'Verbatim text should be ignored.',
+        text: 'More verbatim text.',
+        paraphrasedSnippet: 'Sintesi della regola in paraphrase.',
+      } as Citation;
 
-    const result = mapCitationToChatCitation(citation);
+      const result = mapCitationToChatCitation(citation);
 
-    expect(result).toBeNull();
-  });
+      expect(result?.excerpt).toBe('Sintesi della regola in paraphrase.');
+      expect(result?.excerpt).not.toContain('Verbatim');
+    });
 
-  it('uses pageNumber when present', () => {
-    const citation = {
-      source: 'Doc A',
-      pageNumber: 42,
-      copyrightTier: 'full',
-      snippet: 'content',
-    } as Citation;
+    it('protected tier with no paraphrase and no snippet -> returns null', () => {
+      const citation = {
+        ...legacyBase,
+        copyrightTier: 'protected',
+        snippet: null,
+        paraphrasedSnippet: null,
+      } as Citation;
 
-    const result = mapCitationToChatCitation(citation);
+      const result = mapCitationToChatCitation(citation);
 
-    expect(result?.pages).toEqual([42]);
-  });
+      expect(result).toBeNull();
+    });
 
-  it('uses page field when pageNumber is absent', () => {
-    const citation = {
-      source: 'Doc B',
-      pageNumber: null,
-      page: 3,
-      copyrightTier: 'full',
-      snippet: 'content',
-    } as Citation;
+    it('protected tier with no paraphrase and no text -> returns null', () => {
+      const citation = {
+        ...legacyBase,
+        copyrightTier: 'protected',
+        snippet: null,
+        text: null,
+        paraphrasedSnippet: null,
+      } as Citation;
 
-    const result = mapCitationToChatCitation(citation);
+      const result = mapCitationToChatCitation(citation);
 
-    expect(result?.pages).toEqual([3]);
-  });
+      expect(result).toBeNull();
+    });
 
-  it('returns empty pages array when both pageNumber and page are absent', () => {
-    const citation = {
-      source: 'Doc C',
-      pageNumber: null,
-      page: null,
-      copyrightTier: 'full',
-      snippet: 'content',
-    } as Citation;
+    it('uses pageNumber when present', () => {
+      const citation = {
+        source: 'Doc A',
+        pageNumber: 42,
+        copyrightTier: 'full',
+        snippet: 'content',
+      } as Citation;
 
-    const result = mapCitationToChatCitation(citation);
+      const result = mapCitationToChatCitation(citation);
 
-    expect(result?.pages).toEqual([]);
-  });
+      expect(result?.pages).toEqual([42]);
+    });
 
-  it('trims whitespace from excerpt', () => {
-    const citation = {
-      ...base,
-      snippet: '  Spaced content  ',
-    } as Citation;
+    it('uses page field when pageNumber is absent', () => {
+      const citation = {
+        source: 'Doc B',
+        pageNumber: null,
+        page: 3,
+        copyrightTier: 'full',
+        snippet: 'content',
+      } as Citation;
 
-    const result = mapCitationToChatCitation(citation);
+      const result = mapCitationToChatCitation(citation);
 
-    expect(result?.excerpt).toBe('Spaced content');
-  });
+      expect(result?.pages).toEqual([3]);
+    });
 
-  it('returns null when excerpt is empty after trimming', () => {
-    const citation = {
-      ...base,
-      snippet: '   ',
-      text: null,
-      paraphrasedSnippet: null,
-    } as Citation;
+    it('returns empty pages array when both pageNumber and page are absent', () => {
+      const citation = {
+        source: 'Doc C',
+        pageNumber: null,
+        page: null,
+        copyrightTier: 'full',
+        snippet: 'content',
+      } as Citation;
 
-    const result = mapCitationToChatCitation(citation);
+      const result = mapCitationToChatCitation(citation);
 
-    expect(result).toBeNull();
-  });
+      expect(result?.pages).toEqual([]);
+    });
 
-  it('full tier with empty string snippet falls back to text', () => {
-    const citation = {
-      ...base,
-      snippet: '',
-      text: 'Fallback text.',
-    } as Citation;
+    it('trims whitespace from excerpt', () => {
+      const citation = {
+        ...legacyBase,
+        snippet: '  Spaced content  ',
+      } as Citation;
 
-    const result = mapCitationToChatCitation(citation);
+      const result = mapCitationToChatCitation(citation);
 
-    expect(result?.excerpt).toBe('Fallback text.');
-  });
+      expect(result?.excerpt).toBe('Spaced content');
+    });
 
-  it('protected tier prefers paraphrasedSnippet even if snippet exists', () => {
-    const citation = {
-      ...base,
-      copyrightTier: 'protected',
-      snippet: 'Verbatim should be ignored.',
-      paraphrasedSnippet: 'Paraphrased version.',
-    } as Citation;
+    it('returns null when excerpt is empty after trimming', () => {
+      const citation = {
+        ...legacyBase,
+        snippet: '   ',
+        text: null,
+        paraphrasedSnippet: null,
+      } as Citation;
 
-    const result = mapCitationToChatCitation(citation);
+      const result = mapCitationToChatCitation(citation);
 
-    expect(result?.excerpt).toBe('Paraphrased version.');
+      expect(result).toBeNull();
+    });
+
+    it('full tier with empty string snippet falls back to text', () => {
+      const citation = {
+        ...legacyBase,
+        snippet: '',
+        text: 'Fallback text.',
+      } as Citation;
+
+      const result = mapCitationToChatCitation(citation);
+
+      expect(result?.excerpt).toBe('Fallback text.');
+    });
+
+    it('protected tier prefers paraphrasedSnippet even if snippet exists', () => {
+      const citation = {
+        ...legacyBase,
+        copyrightTier: 'protected',
+        snippet: 'Verbatim should be ignored.',
+        paraphrasedSnippet: 'Paraphrased version.',
+      } as Citation;
+
+      const result = mapCitationToChatCitation(citation);
+
+      expect(result?.excerpt).toBe('Paraphrased version.');
+    });
+
+    it('source is preferred over documentId for documentName when both present', () => {
+      const citation = {
+        source: 'Regolamento Catan',
+        documentId: 'doc-guid-002',
+        pageNumber: 10,
+        copyrightTier: 'full',
+        snippet: 'contenuto',
+      } as Citation;
+
+      const result = mapCitationToChatCitation(citation);
+
+      expect(result?.documentName).toBe('Regolamento Catan');
+    });
   });
 });

--- a/apps/web/src/lib/session-live/__tests__/map-citation-to-chat-citation.test.ts
+++ b/apps/web/src/lib/session-live/__tests__/map-citation-to-chat-citation.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect } from 'vitest';
+import { mapCitationToChatCitation } from '../map-citation-to-chat-citation';
+import type { Citation } from '@/lib/api/schemas/streaming.schemas';
+
+const base: Partial<Citation> = {
+  source: 'Regolamento Azul',
+  documentId: 'doc-1',
+  pageNumber: 7,
+  copyrightTier: 'full',
+};
+
+describe('mapCitationToChatCitation', () => {
+  it('full tier -> excerpt from snippet', () => {
+    const citation = {
+      ...base,
+      snippet: 'Posiziona la plancia.',
+    } as Citation;
+
+    const result = mapCitationToChatCitation(citation);
+
+    expect(result).toEqual({
+      documentName: 'Regolamento Azul',
+      pages: [7],
+      excerpt: 'Posiziona la plancia.',
+    });
+  });
+
+  it('full tier -> excerpt from text when snippet is absent', () => {
+    const citation = {
+      ...base,
+      snippet: null,
+      text: 'Fallback text content.',
+    } as Citation;
+
+    const result = mapCitationToChatCitation(citation);
+
+    expect(result).toEqual({
+      documentName: 'Regolamento Azul',
+      pages: [7],
+      excerpt: 'Fallback text content.',
+    });
+  });
+
+  it('full tier -> prefers snippet over text', () => {
+    const citation = {
+      ...base,
+      snippet: 'Preferred snippet.',
+      text: 'Fallback text.',
+    } as Citation;
+
+    const result = mapCitationToChatCitation(citation);
+
+    expect(result).toEqual({
+      documentName: 'Regolamento Azul',
+      pages: [7],
+      excerpt: 'Preferred snippet.',
+    });
+  });
+
+  it('protected tier -> excerpt from paraphrasedSnippet only, never verbatim', () => {
+    const citation = {
+      ...base,
+      copyrightTier: 'protected',
+      snippet: 'Verbatim text should be ignored.',
+      text: 'More verbatim text.',
+      paraphrasedSnippet: 'Sintesi della regola in paraphrase.',
+    } as Citation;
+
+    const result = mapCitationToChatCitation(citation);
+
+    expect(result?.excerpt).toBe('Sintesi della regola in paraphrase.');
+    expect(result?.excerpt).not.toContain('Verbatim');
+  });
+
+  it('protected tier with no paraphrase and no snippet -> returns null', () => {
+    const citation = {
+      ...base,
+      copyrightTier: 'protected',
+      snippet: null,
+      paraphrasedSnippet: null,
+    } as Citation;
+
+    const result = mapCitationToChatCitation(citation);
+
+    expect(result).toBeNull();
+  });
+
+  it('protected tier with no paraphrase and no text -> returns null', () => {
+    const citation = {
+      ...base,
+      copyrightTier: 'protected',
+      snippet: null,
+      text: null,
+      paraphrasedSnippet: null,
+    } as Citation;
+
+    const result = mapCitationToChatCitation(citation);
+
+    expect(result).toBeNull();
+  });
+
+  it('uses pageNumber when present', () => {
+    const citation = {
+      source: 'Doc A',
+      pageNumber: 42,
+      copyrightTier: 'full',
+      snippet: 'content',
+    } as Citation;
+
+    const result = mapCitationToChatCitation(citation);
+
+    expect(result?.pages).toEqual([42]);
+  });
+
+  it('uses page field when pageNumber is absent', () => {
+    const citation = {
+      source: 'Doc B',
+      pageNumber: null,
+      page: 3,
+      copyrightTier: 'full',
+      snippet: 'content',
+    } as Citation;
+
+    const result = mapCitationToChatCitation(citation);
+
+    expect(result?.pages).toEqual([3]);
+  });
+
+  it('returns empty pages array when both pageNumber and page are absent', () => {
+    const citation = {
+      source: 'Doc C',
+      pageNumber: null,
+      page: null,
+      copyrightTier: 'full',
+      snippet: 'content',
+    } as Citation;
+
+    const result = mapCitationToChatCitation(citation);
+
+    expect(result?.pages).toEqual([]);
+  });
+
+  it('trims whitespace from excerpt', () => {
+    const citation = {
+      ...base,
+      snippet: '  Spaced content  ',
+    } as Citation;
+
+    const result = mapCitationToChatCitation(citation);
+
+    expect(result?.excerpt).toBe('Spaced content');
+  });
+
+  it('returns null when excerpt is empty after trimming', () => {
+    const citation = {
+      ...base,
+      snippet: '   ',
+      text: null,
+      paraphrasedSnippet: null,
+    } as Citation;
+
+    const result = mapCitationToChatCitation(citation);
+
+    expect(result).toBeNull();
+  });
+
+  it('full tier with empty string snippet falls back to text', () => {
+    const citation = {
+      ...base,
+      snippet: '',
+      text: 'Fallback text.',
+    } as Citation;
+
+    const result = mapCitationToChatCitation(citation);
+
+    expect(result?.excerpt).toBe('Fallback text.');
+  });
+
+  it('protected tier prefers paraphrasedSnippet even if snippet exists', () => {
+    const citation = {
+      ...base,
+      copyrightTier: 'protected',
+      snippet: 'Verbatim should be ignored.',
+      paraphrasedSnippet: 'Paraphrased version.',
+    } as Citation;
+
+    const result = mapCitationToChatCitation(citation);
+
+    expect(result?.excerpt).toBe('Paraphrased version.');
+  });
+});

--- a/apps/web/src/lib/session-live/map-citation-to-chat-citation.ts
+++ b/apps/web/src/lib/session-live/map-citation-to-chat-citation.ts
@@ -1,0 +1,38 @@
+import type { ChatCitation } from '@/components/chat/panel/ChatCitationCard';
+import type { Citation } from '@/lib/api/schemas/streaming.schemas';
+
+/**
+ * Maps a streaming RAG citation to the ChatCitationCard model.
+ *
+ * Tier-aware mapping:
+ * - 'full' tier: uses the verbatim snippet or text
+ * - 'protected' tier: uses the paraphrasedSnippet only (never verbatim)
+ *
+ * Returns null when there is no displayable excerpt (no empty-excerpt card).
+ *
+ * @param citation - The RAG citation from streaming response
+ * @returns ChatCitation or null if no excerpt can be extracted
+ */
+export function mapCitationToChatCitation(citation: Citation): ChatCitation | null {
+  const page = citation.pageNumber ?? citation.page ?? null;
+
+  let excerpt = '';
+
+  if (citation.copyrightTier === 'protected') {
+    excerpt = (citation.paraphrasedSnippet ?? '').trim();
+  } else {
+    // For 'full' tier, prefer snippet, fall back to text, then empty string
+    const candidateSnippet = (citation.snippet ?? '').trim();
+    excerpt = candidateSnippet || (citation.text ?? '').trim();
+  }
+
+  if (!excerpt) {
+    return null;
+  }
+
+  return {
+    documentName: citation.source,
+    pages: page != null ? [page] : [],
+    excerpt,
+  };
+}

--- a/apps/web/src/lib/session-live/map-citation-to-chat-citation.ts
+++ b/apps/web/src/lib/session-live/map-citation-to-chat-citation.ts
@@ -5,10 +5,19 @@ import type { Citation } from '@/lib/api/schemas/streaming.schemas';
  * Maps a streaming RAG citation to the ChatCitationCard model.
  *
  * Tier-aware mapping:
- * - 'full' tier: uses the verbatim snippet or text
+ * - 'full' tier: uses snippetPreview (real wire), falling back to snippet/text (legacy)
  * - 'protected' tier: uses the paraphrasedSnippet only (never verbatim)
  *
  * Returns null when there is no displayable excerpt (no empty-excerpt card).
+ *
+ * C2 (#2500): aligned to real wire format (BE CitationDto in Contracts.cs:137-144):
+ * - `snippetPreview` is the real wire field for full-tier verbatim snippet
+ * - `documentName` falls back to documentId when `source` is absent (real wire has no `source`)
+ *
+ * NOTE: The real wire does not expose a human-readable document name (only documentId).
+ * `documentName` will be the documentId (a GUID) when `source` is not provided by the
+ * caller. ChatCitationCard renders it as-is — a follow-up BE enhancement should add
+ * `documentName`/`fileName` to CitationDto. See task-8-report.md § Limitations.
  *
  * @param citation - The RAG citation from streaming response
  * @returns ChatCitation or null if no excerpt can be extracted
@@ -21,8 +30,8 @@ export function mapCitationToChatCitation(citation: Citation): ChatCitation | nu
   if (citation.copyrightTier === 'protected') {
     excerpt = (citation.paraphrasedSnippet ?? '').trim();
   } else {
-    // For 'full' tier, prefer snippet, fall back to text, then empty string
-    const candidateSnippet = (citation.snippet ?? '').trim();
+    // For 'full' tier: prefer snippetPreview (real wire), then snippet, then text (legacy)
+    const candidateSnippet = (citation.snippetPreview ?? citation.snippet ?? '').trim();
     excerpt = candidateSnippet || (citation.text ?? '').trim();
   }
 
@@ -30,8 +39,12 @@ export function mapCitationToChatCitation(citation: Citation): ChatCitation | nu
     return null;
   }
 
+  // documentName: real wire has no `source` — fall back to documentId.
+  // This produces a GUID when coming from the BE wire; cosmetic limitation (see jsdoc above).
+  const documentName = citation.source ?? citation.documentId ?? '';
+
   return {
-    documentName: citation.source,
+    documentName,
     pages: page != null ? [page] : [],
     excerpt,
   };

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -3222,7 +3222,11 @@
         "latencyAriaLabel": "Latency {ms}ms",
         "agentNameAriaLabel": "Agent name {name}",
         "collapsedAriaLabel": "ChatAgent collapsed — click to expand",
-        "expandedAriaLabel": "ChatAgent expanded — click to collapse"
+        "expandedAriaLabel": "ChatAgent expanded — click to collapse",
+        "noAgentMessage": "No assistant available for this game",
+        "launchingMessage": "Starting assistant…",
+        "errorMessage": "Could not start the assistant. Try again later.",
+        "statusAriaLabel": "Assistant status"
       },
       "mobile": {
         "openSheetCta": "Open panel",

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -3226,7 +3226,8 @@
         "noAgentMessage": "No assistant available for this game",
         "launchingMessage": "Starting assistant…",
         "errorMessage": "Could not start the assistant. Try again later.",
-        "statusAriaLabel": "Assistant status"
+        "statusAriaLabel": "Assistant status",
+        "nonGroundedDisclaimer": "Answer not grounded in the rulebook"
       },
       "mobile": {
         "openSheetCta": "Open panel",

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -3329,7 +3329,11 @@
         "latencyAriaLabel": "Latenza {ms}ms",
         "agentNameAriaLabel": "Nome agente {name}",
         "collapsedAriaLabel": "ChatAgent collassato — clic per espandere",
-        "expandedAriaLabel": "ChatAgent espanso — clic per collassare"
+        "expandedAriaLabel": "ChatAgent espanso — clic per collassare",
+        "noAgentMessage": "Nessun assistente disponibile per questo gioco",
+        "launchingMessage": "Avvio assistente…",
+        "errorMessage": "Impossibile avviare l'assistente. Riprova più tardi.",
+        "statusAriaLabel": "Stato assistente"
       },
       "mobile": {
         "openSheetCta": "Apri pannello",

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -3333,7 +3333,8 @@
         "noAgentMessage": "Nessun assistente disponibile per questo gioco",
         "launchingMessage": "Avvio assistente…",
         "errorMessage": "Impossibile avviare l'assistente. Riprova più tardi.",
-        "statusAriaLabel": "Stato assistente"
+        "statusAriaLabel": "Stato assistente",
+        "nonGroundedDisclaimer": "Risposta non basata sul regolamento"
       },
       "mobile": {
         "openSheetCta": "Apri pannello",

--- a/docs/superpowers/plans/2026-06-23-issue-2500-sp1-live-chat-citations.md
+++ b/docs/superpowers/plans/2026-06-23-issue-2500-sp1-live-chat-citations.md
@@ -1,0 +1,223 @@
+# SP1 — #2500 Chat-RAG citazioni nella superficie live (wiring FE) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Far sì che, nella superficie live canonica (`SessionLiveView → ChatAgentPanel → LiveAgentChat`), le risposte dell'agente RAG mostrino le **citazioni** (documento + pagina + snippet), consumando ciò che il BE già produce e persiste.
+
+**Architecture:** FE-only. Il BE è completo: `ChatWithSessionAgentCommandHandler` (KnowledgeBase) produce `CitationDto` copyright-tier-aware, li streamma in `StreamingComplete.Citations` e li persiste in `ChatMessage.CitationsJson`. Lo schema FE `CitationSchema` (con `copyrightTier`) esiste già. SP1 estrae le citazioni dove oggi vengono scartate, le mappa al modello di rendering, e monta `ChatCitationCard`. Inoltre **collega l'agente RAG** al pannello live (oggi usa la chat *sociale*), replicando il pattern già funzionante in `RulesExplainer.tsx`.
+
+**Tech Stack:** React 19 / Next.js 16, Vitest + Testing Library, Zod schemas, SSE streaming via `useSessionAgentChat`.
+
+## Global Constraints
+
+- **Design system**: token semantici (`bg-card`, `text-foreground`, …); ESLint `local/no-hardcoded-color-utility` è **error**. Riusare `ChatCitationCard` esistente (già conforme).
+- **Decisione SP0 (ADR-083 § Update 3)**: la chat live canonica È l'agente RAG (`/agent/chat` keyed su `LiveGameSession.Id`); il path non-canonico `AskSessionAgentCommandHandler` resta out-of-scope.
+- **TDD**: ogni task red→green. FE test mockati (no LLM reale).
+- **AC di riferimento** (spec `2026-06-23-epic-2501-fase2-live-session-feature-gaps.md`): AC-CHAT-0/1/2/3/4/5 + AC-CHAT-NULL.
+
+---
+
+## File Structure
+
+| File | Responsabilità | Azione |
+|---|---|---|
+| `apps/web/src/lib/api/schemas/streaming.schemas.ts` | `CitationSchema` (esiste, `:45-58`) — riuso | invariato |
+| `apps/web/src/lib/session-live/map-citation-to-chat-citation.ts` | **NUOVO** — mapper puro `CitationSchema → ChatCitation` (tier-aware) | Create |
+| `apps/web/src/lib/domain-hooks/useSessionAgentChat.ts` | hook agente RAG: estrarre `citations` dall'evento `complete` (`:122-140`), aggiungerle all'assistant `ChatMessage` (`:16-21`, `:146-152`) | Modify |
+| `apps/web/src/components/features/session-live/LiveAgentChat.tsx` | `ChatMessage` (`:34-41`) + campo `citations`; render `ChatCitationCard` (`:168-193`) | Modify |
+| `apps/web/src/components/chat/panel/ChatCitationCard.tsx` | render citazione (esiste, `:4-69`) — riuso | invariato |
+| `apps/web/src/components/features/session-live/ChatAgentPanel.tsx` | wiring agente RAG (oggi delega messages prop) | Modify |
+| `apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx` | lancio agente (`agentSessionId`) + `gameContext` da `LiveSessionDto`; passa la chat agente RAG al pannello | Modify |
+
+**Pattern di riferimento per il wiring agente** (Task 5): `apps/web/src/components/game-night/RulesExplainer.tsx:49,380` (già usa `useSessionAgentChat` con `agentSessionId` + store gameContext).
+
+---
+
+## Task 1: Mapper `CitationSchema → ChatCitation` (tier-aware)
+
+**Files:**
+- Create: `apps/web/src/lib/session-live/map-citation-to-chat-citation.ts`
+- Test: `apps/web/src/lib/session-live/__tests__/map-citation-to-chat-citation.test.ts`
+
+**Interfaces:**
+- Consumes: `Citation` (z.infer di `CitationSchema`, `streaming.schemas.ts:45-58` — campi `documentId`, `source`, `page`/`pageNumber`, `text`/`snippet`, `copyrightTier: 'full'|'protected'`, `paraphrasedSnippet`).
+- Produces: `mapCitationToChatCitation(c: Citation): ChatCitation | null` — `ChatCitation` = `{ documentName, pages: number[], excerpt, openUrl? }` (da `ChatCitationCard.tsx:4-9`).
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { mapCitationToChatCitation } from '../map-citation-to-chat-citation';
+
+const base = { source: 'Regolamento Azul', documentId: 'doc-1', pageNumber: 7, copyrightTier: 'full' as const };
+
+describe('mapCitationToChatCitation', () => {
+  it('full tier → excerpt from snippet/text', () => {
+    const r = mapCitationToChatCitation({ ...base, snippet: 'Posiziona la plancia.' } as never);
+    expect(r).toEqual({ documentName: 'Regolamento Azul', pages: [7], excerpt: 'Posiziona la plancia.' });
+  });
+  it('protected tier → excerpt from paraphrasedSnippet, never verbatim', () => {
+    const r = mapCitationToChatCitation({ ...base, copyrightTier: 'protected', snippet: null, paraphrasedSnippet: 'Sintesi della regola.' } as never);
+    expect(r?.excerpt).toBe('Sintesi della regola.');
+  });
+  it('protected with no paraphrase and no snippet → excerpt empty string is NOT produced (returns null)', () => {
+    const r = mapCitationToChatCitation({ ...base, copyrightTier: 'protected', snippet: null, paraphrasedSnippet: null } as never);
+    expect(r).toBeNull();
+  });
+  it('uses page when pageNumber absent', () => {
+    const r = mapCitationToChatCitation({ source: 'Doc', page: 3, copyrightTier: 'full', snippet: 'x' } as never);
+    expect(r?.pages).toEqual([3]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails** — `pnpm vitest run src/lib/session-live/__tests__/map-citation-to-chat-citation.test.ts` → FAIL (modulo mancante).
+
+- [ ] **Step 3: Write minimal implementation**
+
+```ts
+import type { z } from 'zod';
+import type { CitationSchema } from '@/lib/api/schemas/streaming.schemas';
+import type { ChatCitation } from '@/components/chat/panel/ChatCitationCard';
+
+type Citation = z.infer<typeof CitationSchema>;
+
+/**
+ * Maps a streaming RAG citation to the ChatCitationCard model.
+ * Tier-aware: 'full' uses the verbatim snippet/text; 'protected' uses the
+ * paraphrasedSnippet only (never verbatim). Returns null when there is no
+ * displayable excerpt (AC-CHAT-2/3: no empty-excerpt card).
+ */
+export function mapCitationToChatCitation(c: Citation): ChatCitation | null {
+  const page = c.pageNumber ?? c.page ?? null;
+  const excerpt =
+    c.copyrightTier === 'protected'
+      ? (c.paraphrasedSnippet ?? '').trim()
+      : (c.snippet ?? c.text ?? '').trim();
+  if (!excerpt) return null;
+  return {
+    documentName: c.source,
+    pages: page != null ? [page] : [],
+    excerpt,
+    // AC-CHAT-5 (MVP): no anchored viewer → no deep-link CTA.
+  };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes** — same command → PASS.
+- [ ] **Step 5: Commit** — `git add -A && git commit -m "feat(session-live): #2500 citation→ChatCitation mapper (tier-aware)"`
+
+---
+
+## Task 2: `useSessionAgentChat` estrae le citazioni (oggi scartate)
+
+**Files:**
+- Modify: `apps/web/src/lib/domain-hooks/useSessionAgentChat.ts:16-21,122-140,146-152`
+- Test: `apps/web/src/lib/domain-hooks/__tests__/useSessionAgentChat.test.ts` (esistente — estendere)
+
+**Interfaces:**
+- Consumes: mapper Task 1; payload SSE `complete` con campo `citations: Citation[]` (oggi il parsing tipa solo `{type, content?, threadId?}`).
+- Produces: `ChatMessage.citations?: ChatCitation[]` sull'assistant message.
+
+- [ ] **Step 1: Write the failing test** — aggiungere a `useSessionAgentChat.test.ts` un test che mocka un response SSE con un evento `data: {"type":"complete","threadId":"t1","citations":[{"source":"Reg","pageNumber":7,"copyrightTier":"full","snippet":"abc"}]}` e asserisce che l'ultimo assistant message abbia `citations` con `pages:[7]`, `excerpt:'abc'`. (Seguire il pattern di mock `fetch`/`ReadableStream` già presente nel file di test, righe ~20-67.)
+
+- [ ] **Step 2: Run** → FAIL (`citations` undefined sull'assistant message).
+
+- [ ] **Step 3: Implement** — in `useSessionAgentChat.ts`:
+  1. `ChatMessage` (`:16-21`): aggiungere `citations?: ChatCitation[];` (import `ChatCitation` + `mapCitationToChatCitation` + `CitationSchema`).
+  2. Aggiungere un ref `const citationsRef = useRef<ChatCitation[]>([]);` (reset a `[]` all'inizio di `ask`).
+  3. Parsing `complete` (`:133`): tipizzare il payload con `citations?: unknown[]` e, quando presente, `citationsRef.current = (CitationSchema.array().safeParse(payload.citations).data ?? []).map(mapCitationToChatCitation).filter((x): x is ChatCitation => x !== null);`
+  4. Assistant message (`:146-152`): `citations: citationsRef.current.length ? citationsRef.current : undefined`.
+
+- [ ] **Step 4: Run** → PASS (+ test esistenti del file verdi).
+- [ ] **Step 5: Commit** — `feat(session-live): #2500 extract RAG citations in useSessionAgentChat`
+
+---
+
+## Task 3: `LiveAgentChat` renderizza `ChatCitationCard`
+
+**Files:**
+- Modify: `apps/web/src/components/features/session-live/LiveAgentChat.tsx:34-41,168-193`
+- Test: `apps/web/src/components/features/session-live/__tests__/LiveAgentChat.test.tsx` (esistente — estendere)
+
+**Interfaces:**
+- Consumes: `ChatMessage` con `citations?: ChatCitation[]`; `ChatCitationCard` (`:15-69`).
+- Produces: render di N `ChatCitationCard` sotto il bubble dell'assistant.
+
+- [ ] **Step 1: Write the failing test** — render `LiveAgentChat` con un messaggio assistant che ha `citations: [{ documentName:'Reg Azul', pages:[7], excerpt:'Posiziona' }]`; asserire `screen.getByText(/Reg Azul/)` e `/pag\. 7/`. Aggiungere un secondo test: messaggio senza citazioni → `queryByText(/pag\./)` è `null` (AC-CHAT-3).
+
+- [ ] **Step 2: Run** → FAIL.
+
+- [ ] **Step 3: Implement** — in `LiveAgentChat.tsx`:
+  1. `ChatMessage` (`:34-41`): aggiungere `readonly citations?: readonly ChatCitation[];` (import `ChatCitation` + `ChatCitationCard`).
+  2. Nel map dei messaggi (`:168-193`), dopo il bubble `{msg.content}`: `{msg.citations && msg.citations.length > 0 && (<div data-slot="chat-citations" className="mt-1 flex flex-col gap-1">{msg.citations.map((c, i) => <ChatCitationCard key={i} citation={c} />)}</div>)}`
+
+- [ ] **Step 4: Run** → PASS.
+- [ ] **Step 5: Commit** — `feat(session-live): #2500 render ChatCitationCard in LiveAgentChat`
+
+---
+
+## Task 4: Collegare l'agente RAG a `ChatAgentPanel`/`SessionLiveView` (AC-CHAT-0)
+
+> Oggi `ChatAgentPanel` riceve `messages` (chat *sociale* da `actionLog`) + `onSendMessage` (POST `/game-sessions/{id}/chat`). SP0 impone che la chat live canonica sia l'**agente RAG**. Replicare il pattern di `RulesExplainer.tsx:380`.
+
+**Files:**
+- Modify: `apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx:492-508,881-893,1125-1137`
+- (eventuale) Modify: `ChatAgentPanel.tsx` se serve passare `isLoading`/`streamingContent`.
+- Test: `SessionLiveView.test.tsx` (esistente — estendere; il file ha già mock per gli hook).
+
+**Interfaces:**
+- Consumes: `useSessionAgentChat(gameSessionId, agentSessionId)` (Task 2); `agentSessionsClient` per ottenere `agentSessionId` (vedi `RulesExplainer.tsx` + `apps/web/src/lib/api/clients/agentSessionsClient.ts`); `gameContext` da `LiveSessionDto` (`gameId`, `gameName`, `players[].displayName`).
+- Produces: il pannello agente mostra risposte RAG con citazioni.
+
+- [ ] **Step 1 (discovery, da fare nell'esecuzione)**: leggere `RulesExplainer.tsx:360-420` + `agentSessionsClient.ts` per il modo esatto di ottenere `agentSessionId` (launch lazy on-first-message vs all'apertura del pannello) e per come `useSessionAgentChat` legge `useSessionStore` (decidere se popolare `useSessionStore` da `LiveSessionDto` o estendere il hook per accettare un `gameContext` esplicito — preferire l'iniezione esplicita per non accoppiare a un secondo store).
+
+- [ ] **Step 2: Write the failing test** — in `SessionLiveView.test.tsx`, mockare `useSessionAgentChat` per restituire un assistant message con `citations`; asserire che `ChatAgentPanel` renderizzi la citazione (`/pag\. N/`). Verificare inoltre (AC-CHAT-0) che l'invio NON colpisca `/game-sessions/{id}/chat` (chat sociale) ma il path agente (`ask` del hook chiamato).
+
+- [ ] **Step 3: Run** → FAIL.
+
+- [ ] **Step 4: Implement** — in `SessionLiveView`: ottenere `agentSessionId` (launch via `agentSessionsClient`, lazy), costruire `gameContext` da `activeSession`/`LiveSessionDto`, usare `useSessionAgentChat(sessionId, agentSessionId)`; passare `messages` (del hook agente, con `citations`) + `onSendMessage = ask` a `ChatAgentPanel`. Mantenere la chat sociale (actionLog) separata se serve, ma il pannello AGENTE usa l'agente RAG. Gestire `AC-CHAT-NULL` (agente non ancora lanciato → pannello «Abilita assistente», nessun 404/NRE).
+
+- [ ] **Step 5: Run** → PASS.
+- [ ] **Step 6: Commit** — `feat(session-live): #2500 wire RAG agent into live ChatAgentPanel`
+
+---
+
+## Task 5: Persistenza — citazioni dopo reload (AC-CHAT-1)
+
+**Files:**
+- Modify: il loader della cronologia chat agente (cercare dove il FE carica `ChatThreadDto`/`ChatMessageDto.CitationsJson` — `ChatThreadDto.cs:27-43` lato BE; lato FE il client/schema dei messaggi storici). Mappare `CitationsJson` (string) → `Citation[]` → `ChatCitation[]` via mapper Task 1.
+- Test: il messaggio assistant idratato dalla cronologia espone `citations`.
+
+- [ ] **Step 1: Write the failing test** — dato un `ChatMessageDto` con `citationsJson` valorizzato, l'hook/loader produce un `ChatMessage` con `citations` mappate. → FAIL.
+- [ ] **Step 2: Implement** — parse `JSON.parse(citationsJson)` → `CitationSchema.array().safeParse` → `.map(mapCitationToChatCitation).filter(Boolean)`.
+- [ ] **Step 3: Run** → PASS.
+- [ ] **Step 4: Commit** — `feat(session-live): #2500 hydrate citations from persisted CitationsJson on reload`
+
+---
+
+## Task 6: Edge cases + integration BE (deterministico, no LLM)
+
+**Files:**
+- Test FE: AC-CHAT-2 (protected → paraphrase, mai verbatim nel DOM), AC-CHAT-3 (non-grounded → nessuna card + disclaimer), AC-CHAT-NULL.
+- Test BE (integration, Testcontainers): round-trip persistenza→trasmissione citazioni con `IEmbeddingRepository.SearchByVectorAsync` seed deterministico (riusare il pattern #2504, NO LLM). Asserire `citations[]` con `pageNumber>0` + persistenza dopo reload.
+
+- [ ] **Step 1**: scrivere i test FE edge-case (sopra) → far fallire dove il comportamento manca → implementare i fix minimi (disclaimer non-grounded; guard agente-off) → PASS.
+- [ ] **Step 2**: scrivere il test integration BE deterministico → PASS.
+- [ ] **Step 3: Commit** — `test(session-live): #2500 citation edge cases + deterministic BE round-trip`
+
+---
+
+## Self-review (coverage AC)
+
+| AC | Task |
+|---|---|
+| AC-CHAT-0 (chat live = agente RAG) | Task 4 |
+| AC-CHAT-1 (page+snippet, persistenza reload) | Task 2/3/5 |
+| AC-CHAT-2 (tier protetto → paraphrase) | Task 1/6 |
+| AC-CHAT-3 (non-grounded → no card) | Task 1/3/6 |
+| AC-CHAT-4 (mapping CitationDto→FE) | Task 1 |
+| AC-CHAT-5 (deep-link MVP → CTA assente) | Task 1 (openUrl undefined) |
+| AC-CHAT-NULL (agente off) | Task 4 |
+
+**Rischio**: Task 1-3 e 5 a rischio basso (isolati, BE esiste). **Task 4 è il nodo** (wiring agente RAG nel pannello, dipendenze `agentSessionId`/`gameContext`) — replicare `RulesExplainer`. Out of scope SP1: SSE realignment (SP2), diary/media (SP3/4), companion Saga (SP0 residuo).


### PR DESCRIPTION
## Scommario

Closes #2500 (epic sessione live #2501 / #2354). Nella superficie live canonica
(`SessionLiveView → ChatAgentPanel → LiveAgentChat`) la chat dell'agente ora usa **l'agente RAG**
e mostra le **citazioni** (documento + pagina + snippet) che il backend già produce — lo step più
oggettivo della user story «Serata Mage Knight» (#2506, step 7).

## Acceptance criteria

| AC | Stato |
|----|-------|
| AC-CHAT-0 — chat live = agente RAG (non chat sociale) | ✅ |
| AC-CHAT-1 — citazioni pagina+snippet, persistenti dopo reload | ✅ |
| AC-CHAT-2 — tier `protected` → solo paraphrase, mai verbatim | ✅ (guard + test DOM) |
| AC-CHAT-3 — risposta non-grounded → nessuna card + disclaimer | ✅ |
| AC-CHAT-4 — mapping CitationDto → FE | ✅ |
| AC-CHAT-5 — deep-link MVP → CTA assente | ✅ |
| AC-CHAT-NULL — agente non disponibile → nessun crash | ✅ |

## Cosa contiene

**Frontend**
- Mapper `mapCitationToChatCitation` tier-aware + render `ChatCitationCard` in `LiveAgentChat`.
- `useSessionAgentLaunch`: launch lazy dell'`AgentSession` con status discriminato (idle/launching/ready/no-agent/error) + feedback di stato nel pannello (niente no-op silenzioso).
- Parser SSE allineato al **wire reale** del BE (`{type:<numerico>, data:{...}}`): token incrementali, `chatThreadId`, citazioni.
- Persistenza `chatThreadId` (sessionStorage, keyed su gameSessionId) + idratazione cronologia con citazioni al reload (opt-in, `RulesExplainer` invariato).
- Disclaimer "risposta non basata sul regolamento" per risposte non-grounded (flag `isNonGrounded` esplicito, mai sui messaggi di sistema).
- `gameContext` iniettato da `LiveSessionDto` (no RAG degradato).
- `CitationSchema` allineato in modo additivo al `CitationDto` reale (`source` opzionale, +`snippetPreview`) senza rompere i consumer condivisi (`kb-ask`).

**Backend (KnowledgeBase)**
- Validazioni launch: AgentDefinition esiste/attiva/game-match + safe-parse stato (→ 422), consolidate in 1 query.
- Stato iniziale di default (`GameState.Initial(UserId)`) quando il client non fornisce uno stato.
- Fix mapper `ChatThread` query handlers: ora proiettano `CitationsJson` (+ AgentType/Confidence/TokenCount) — prima persi.

## Percorso e qualità

Sviluppato con pipeline subagent-driven (implementer → task-review spec+quality → fix-loop) + **final whole-branch review** che ha colto 2 bug di **integrazione runtime** invisibili ai test in isolamento (hook/SSE mockati): il launch falliva sempre (payload `'{}'`) e il parser SSE era disallineato dal wire. Entrambi corretti, con i **test riallineati al contratto BE↔FE reale** per prevenire il falso-verde.

**Verifica finale:** FE 166 test (4 file #2500) + typecheck 0 · BE build 0 errori + 28 test.

## Follow-up non-blocking
- `documentName` mostra il `documentId` (GUID) quando il wire non espone un nome leggibile → il BE potrebbe arricchire `CitationDto`.
- Costanti SSE numeriche duplicate tra `useSessionAgentChat` e `useAgentChatStream` → candidate a modulo condiviso.
- Integration BE deterministico (Testcontainers) deferito (ridondante con i test esistenti).

🤖 Generated with [Claude Code](https://claude.com/claude-code)