### PR TITLE
fix(security): #1455 bump transformers 4.53→5.12.1 (resolve Trainer RCE alert)

### DIFF
--- a/apps/embedding-service/main.py
+++ b/apps/embedding-service/main.py
@@ -92,7 +92,11 @@ async def lifespan(app: FastAPI):
     logger.info(f"Loading model {MODEL_NAME} on device {DEVICE}...")
     try:
         model = SentenceTransformer(MODEL_NAME, device=DEVICE)
-        logger.info(f"Model loaded successfully. Embedding dimension: {model.get_sentence_embedding_dimension()}")
+        # sentence-transformers 5.x renamed get_sentence_embedding_dimension() ->
+        # get_embedding_dimension() (old name deprecated). Prefer the new name and
+        # fall back to the old so this works across the 3.x->5.x upgrade (#1455 review).
+        _get_dim = getattr(model, "get_embedding_dimension", None) or model.get_sentence_embedding_dimension
+        logger.info(f"Model loaded successfully. Embedding dimension: {_get_dim()}")
 
         logger.info("Warming up embedding model...")
         warmup_texts = ["warmup"]

--- a/apps/embedding-service/requirements.txt
+++ b/apps/embedding-service/requirements.txt
@@ -7,9 +7,12 @@ uvicorn[standard]==0.32.0
 pydantic==2.9.2
 
 # ML/NLP
-sentence-transformers==3.3.0
-torch==2.8.0
-transformers==4.53.0
+# transformers bumped 4.53.0 -> 5.12.1 to resolve Dependabot alert GHSA-69w3-r845-3855
+# (#1455): the Trainer-class RCE advisory. Service is inference-only (no Trainer).
+# sentence-transformers 3.3.0 pinned transformers<5; 5.6.0 supports transformers<6.
+sentence-transformers==5.6.0
+torch==2.12.1
+transformers==5.12.1
 
 # Utilities
 numpy==1.26.4

--- a/apps/embedding-service/tests/test_compat.py
+++ b/apps/embedding-service/tests/test_compat.py
@@ -1,0 +1,44 @@
+"""Regression guard for the transformers 5.x / sentence-transformers 5.x bump (issue #1455).
+
+The embedding service is inference-only — it uses SentenceTransformer.encode() and
+get_sentence_embedding_dimension() (see main.py). These tests pin the major versions
+that resolve Dependabot alert GHSA-69w3-r845-3855 and confirm the encode interface the
+service relies on survives the 3.x -> 5.x upgrade, WITHOUT downloading the model.
+"""
+import sentence_transformers
+import transformers
+from sentence_transformers import SentenceTransformer
+
+
+def _major(version: str) -> int:
+    return int(version.split(".")[0])
+
+
+def test_transformers_major_is_5_plus():
+    # >=5 (GA) is the condition that closes alert #1455's transformers half.
+    assert _major(transformers.__version__) >= 5, (
+        f"transformers must be >=5.x to resolve alert #1455; got {transformers.__version__}"
+    )
+
+
+def test_sentence_transformers_major_is_5_plus():
+    # sentence-transformers 3.x pinned transformers<5; >=5 is required for the bump.
+    assert _major(sentence_transformers.__version__) >= 5, (
+        f"sentence-transformers must be >=5.x for transformers 5.x compat; "
+        f"got {sentence_transformers.__version__}"
+    )
+
+
+def test_inference_interface_intact():
+    # The only two SentenceTransformer methods the service calls (main.py:94-100,193).
+    # Confirm they still exist after the upgrade without instantiating (no model download).
+    assert hasattr(SentenceTransformer, "encode")
+    assert hasattr(SentenceTransformer, "get_sentence_embedding_dimension")
+
+
+def test_main_imports_under_upgraded_stack():
+    # Importing main must not break with the upgraded deps; the model is loaded lazily
+    # in the FastAPI lifespan, so this does not trigger a download.
+    import main  # noqa: F401
+
+    assert hasattr(main, "app")

--- a/apps/embedding-service/tests/test_compat.py
+++ b/apps/embedding-service/tests/test_compat.py
@@ -30,10 +30,14 @@ def test_sentence_transformers_major_is_5_plus():
 
 
 def test_inference_interface_intact():
-    # The only two SentenceTransformer methods the service calls (main.py:94-100,193).
+    # The SentenceTransformer methods the service calls (main.py:94-100,193).
     # Confirm they still exist after the upgrade without instantiating (no model download).
     assert hasattr(SentenceTransformer, "encode")
-    assert hasattr(SentenceTransformer, "get_sentence_embedding_dimension")
+    # 5.x renamed get_sentence_embedding_dimension -> get_embedding_dimension; the
+    # service uses a getattr fallback, so at least one of the two must exist.
+    assert hasattr(SentenceTransformer, "get_embedding_dimension") or hasattr(
+        SentenceTransformer, "get_sentence_embedding_dimension"
+    )
 
 
 def test_main_imports_under_upgraded_stack():


### PR DESCRIPTION
## Cosa

Risolve la **metà transformers** dell'alert Dependabot #1455 (GHSA-69w3-r845-3855 — RCE nella classe `Trainer`), ora che transformers 5.x è GA.

L'embedding-service è **inference-only** (`SentenceTransformer.encode` / `get_sentence_embedding_dimension`, `main.py`) — la classe `Trainer` non è mai importata, quindi la vuln era dormiente; il bump la elimina.

## Bump

| Pacchetto | Da | A |
|---|---|---|
| transformers | 4.53.0 | 5.12.1 |
| sentence-transformers | 3.3.0 | 5.6.0 (3.3.0 pinnava transformers<5) |
| torch | 2.8.0 | 2.12.1 |
| numpy | 1.26.4 | invariato (compatibile) |

## Validazione

- `pip` risolve tutte le deps **senza conflitti** (dry-run + install reale).
- **6/6 pytest pass**: 4 nuovi (`tests/test_compat.py` — guard di regressione su major version + interfaccia `encode`) + 2 esistenti (`test_metrics.py`, girano con le nuove deps via `FakeModel`).
- L'inference `encode()` sul modello reale (e5) è coperta da CI/staging (modello non scaricato in locale).

## Out of scope

La metà **elliptic** di #1455 resta deferred (nessun patch upstream; catena dev-only Storybook). #1455 resta aperta per quella.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
