### PR TITLE
feat(mechanic): #526 BulkRejectMechanicClaimsCommand (admin review M1.4)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/BulkRejectMechanicClaimsCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/BulkRejectMechanicClaimsCommand.cs
@@ -1,0 +1,24 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands.MechanicExtractor;
+
+/// <summary>
+/// Rejects an explicit set of claims on the given analysis in a single transaction (#526
+/// ME-M1.4). Unlike <see cref="BulkApproveMechanicClaimsCommand"/> — which approves every
+/// <c>Pending</c> claim implicitly — bulk-reject takes an explicit <paramref name="ClaimIds"/>
+/// list (decision D3): the admin UI computes the set client-side (e.g. all claims with a
+/// &gt;20-word quote, or all T2-fail) and sends the ids, so the reviewer sees exactly what is
+/// being rejected. Claims already <c>Rejected</c> are skipped (idempotent); a missing claim id
+/// fails the whole batch with 404. Valid only while the parent analysis is <c>InReview</c>; the
+/// domain guard surfaces as 409.
+/// </summary>
+/// <param name="AnalysisId">Parent aggregate id.</param>
+/// <param name="ClaimIds">Explicit claim ids to reject (computed client-side).</param>
+/// <param name="Reason">Shared rejection note applied to every rejected claim (1..500 chars).</param>
+/// <param name="ReviewerId">Admin user id from the validated session.</param>
+internal record BulkRejectMechanicClaimsCommand(
+    Guid AnalysisId,
+    IReadOnlyList<Guid> ClaimIds,
+    string Reason,
+    Guid ReviewerId) : ICommand<BulkRejectMechanicClaimsResponseDto>;

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/BulkRejectMechanicClaimsCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/BulkRejectMechanicClaimsCommandHandler.cs
@@ -65,12 +65,14 @@ internal sealed class BulkRejectMechanicClaimsCommandHandler
         // De-duplicate the requested ids, then fail the batch if any does not exist (stale client).
         var requestedIds = request.ClaimIds.Distinct().ToList();
         var existingIds = analysis.Claims.Select(c => c.Id).ToHashSet();
-        var missingId = requestedIds.FirstOrDefault(id => !existingIds.Contains(id));
-        if (missingId != Guid.Empty)
+        // Explicit Count check (not FirstOrDefault's Guid.Empty sentinel, which would
+        // conflate "nothing missing" with "Guid.Empty was requested and is missing").
+        var missingIds = requestedIds.Where(id => !existingIds.Contains(id)).ToList();
+        if (missingIds.Count > 0)
         {
             throw new NotFoundException(
                 resourceType: "MechanicClaim",
-                resourceId: missingId.ToString());
+                resourceId: missingIds[0].ToString());
         }
 
         var requestedSet = requestedIds.ToHashSet();

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/BulkRejectMechanicClaimsCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/BulkRejectMechanicClaimsCommandHandler.cs
@@ -1,0 +1,155 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Exceptions;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands.MechanicExtractor;
+
+/// <summary>
+/// Handler for <see cref="BulkRejectMechanicClaimsCommand"/> (#526 ME-M1.4).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Rejects an explicit set of claims (decision D3) by dispatching <c>analysis.RejectClaim(...)</c>
+/// for each, applying the shared <c>Reason</c>. All transitions land in one
+/// <c>SaveChangesAsync</c>, so a partial failure (e.g. concurrency clash, or the parent analysis
+/// not being <c>InReview</c>) rolls back the whole batch.
+/// </para>
+/// <para>
+/// A claim id that does not exist on the analysis fails the batch with 404 (the client sent a
+/// stale id). Claims already <c>Rejected</c> are skipped silently (idempotent) and surfaced via
+/// <c>SkippedAlreadyRejectedCount</c>.
+/// </para>
+/// </remarks>
+internal sealed class BulkRejectMechanicClaimsCommandHandler
+    : ICommandHandler<BulkRejectMechanicClaimsCommand, BulkRejectMechanicClaimsResponseDto>
+{
+    private readonly IMechanicAnalysisRepository _analysisRepository;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<BulkRejectMechanicClaimsCommandHandler> _logger;
+
+    public BulkRejectMechanicClaimsCommandHandler(
+        IMechanicAnalysisRepository analysisRepository,
+        IUnitOfWork unitOfWork,
+        TimeProvider timeProvider,
+        ILogger<BulkRejectMechanicClaimsCommandHandler> logger)
+    {
+        _analysisRepository = analysisRepository ?? throw new ArgumentNullException(nameof(analysisRepository));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<BulkRejectMechanicClaimsResponseDto> Handle(
+        BulkRejectMechanicClaimsCommand request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var analysis = await _analysisRepository
+            .GetByIdWithClaimsIgnoringFiltersAsync(request.AnalysisId, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (analysis is null)
+        {
+            throw new NotFoundException(
+                resourceType: "MechanicAnalysis",
+                resourceId: request.AnalysisId.ToString());
+        }
+
+        // De-duplicate the requested ids, then fail the batch if any does not exist (stale client).
+        var requestedIds = request.ClaimIds.Distinct().ToList();
+        var existingIds = analysis.Claims.Select(c => c.Id).ToHashSet();
+        var missingId = requestedIds.FirstOrDefault(id => !existingIds.Contains(id));
+        if (missingId != Guid.Empty)
+        {
+            throw new NotFoundException(
+                resourceType: "MechanicClaim",
+                resourceId: missingId.ToString());
+        }
+
+        var requestedSet = requestedIds.ToHashSet();
+        var targetClaims = analysis.Claims.Where(c => requestedSet.Contains(c.Id)).ToList();
+        var toRejectIds = targetClaims
+            .Where(c => c.Status != MechanicClaimStatus.Rejected)
+            .Select(c => c.Id)
+            .ToList();
+        var skippedAlreadyRejectedCount = targetClaims.Count - toRejectIds.Count;
+
+        var utcNow = _timeProvider.GetUtcNow().UtcDateTime;
+
+        try
+        {
+            foreach (var claimId in toRejectIds)
+            {
+                analysis.RejectClaim(claimId, request.ReviewerId, request.Reason, utcNow);
+            }
+        }
+        catch (InvalidMechanicAnalysisStateException ex)
+        {
+            // Parent analysis is not InReview — fail the whole batch.
+            throw new ConflictException(ex.Message, ex);
+        }
+
+        if (toRejectIds.Count > 0)
+        {
+            _analysisRepository.Update(analysis);
+
+            try
+            {
+                await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (DbUpdateConcurrencyException ex)
+            {
+                _logger.LogWarning(
+                    ex,
+                    "Optimistic concurrency failure bulk-rejecting claims on MechanicAnalysis {AnalysisId}.",
+                    request.AnalysisId);
+
+                throw new ConflictException(
+                    "Mechanic analysis was modified by another operation. Please retry.",
+                    ex);
+            }
+        }
+
+        _logger.LogInformation(
+            "Bulk-rejected {RejectedCount} claims on MechanicAnalysis {AnalysisId} (skipped {SkippedAlreadyRejectedCount} already-rejected) by admin {ReviewerId}.",
+            toRejectIds.Count,
+            analysis.Id,
+            skippedAlreadyRejectedCount,
+            request.ReviewerId);
+
+        var claims = analysis.Claims
+            .OrderBy(c => c.Section)
+            .ThenBy(c => c.DisplayOrder)
+            .Select(c => new MechanicClaimDto(
+                Id: c.Id,
+                AnalysisId: analysis.Id,
+                Section: c.Section,
+                Text: c.Text,
+                DisplayOrder: c.DisplayOrder,
+                Status: c.Status,
+                ReviewedBy: c.ReviewedBy,
+                ReviewedAt: c.ReviewedAt,
+                RejectionNote: c.RejectionNote,
+                Citations: c.Citations
+                    .OrderBy(citation => citation.DisplayOrder)
+                    .Select(citation => new MechanicCitationDto(
+                        Id: citation.Id,
+                        PdfPage: citation.PdfPage,
+                        Quote: citation.Quote,
+                        DisplayOrder: citation.DisplayOrder))
+                    .ToList()))
+            .ToList();
+
+        return new BulkRejectMechanicClaimsResponseDto(
+            RejectedCount: toRejectIds.Count,
+            SkippedAlreadyRejectedCount: skippedAlreadyRejectedCount,
+            Claims: claims);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/BulkRejectMechanicClaimsCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/BulkRejectMechanicClaimsCommandValidator.cs
@@ -1,0 +1,37 @@
+using FluentValidation;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands.MechanicExtractor;
+
+/// <summary>
+/// FluentValidation rules for <see cref="BulkRejectMechanicClaimsCommand"/>. The 1..500 char
+/// range on <c>Reason</c> matches <see cref="RejectMechanicClaimCommandValidator"/>; the
+/// non-empty <c>ClaimIds</c> rule enforces decision D3 (explicit client-computed id set).
+/// </summary>
+internal sealed class BulkRejectMechanicClaimsCommandValidator
+    : AbstractValidator<BulkRejectMechanicClaimsCommand>
+{
+    public const int MinReasonLength = 1;
+    public const int MaxReasonLength = 500;
+
+    public BulkRejectMechanicClaimsCommandValidator()
+    {
+        RuleFor(c => c.AnalysisId)
+            .NotEmpty().WithMessage("AnalysisId is required.");
+
+        RuleFor(c => c.ReviewerId)
+            .NotEmpty().WithMessage("ReviewerId is required.");
+
+        RuleFor(c => c.ClaimIds)
+            .NotNull().WithMessage("ClaimIds is required.")
+            .Must(ids => ids is { Count: > 0 }).WithMessage("ClaimIds must contain at least one claim.")
+            .Must(ids => ids is null || ids.All(id => id != Guid.Empty))
+                .WithMessage("ClaimIds cannot contain an empty id.");
+
+        RuleFor(c => c.Reason)
+            .NotEmpty().WithMessage("Rejection reason is required.")
+            .Must(n => !string.IsNullOrWhiteSpace(n))
+                .WithMessage("Rejection reason cannot be whitespace only.")
+            .Length(MinReasonLength, MaxReasonLength)
+                .WithMessage($"Rejection reason must be between {MinReasonLength} and {MaxReasonLength} characters.");
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/DTOs/BulkRejectMechanicClaimsResponseDto.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/DTOs/BulkRejectMechanicClaimsResponseDto.cs
@@ -1,0 +1,18 @@
+namespace Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
+
+/// <summary>
+/// Response payload for bulk reject (#526 ME-M1.4). Mirrors
+/// <see cref="BulkApproveMechanicClaimsResponseDto"/>: carries the count of claims that
+/// transitioned (for the toast) and the full updated claim list (so the admin UI re-renders
+/// without a follow-up GET).
+/// </summary>
+/// <param name="RejectedCount">Number of claims that transitioned to <c>Rejected</c> in this
+/// call. Claims already <c>Rejected</c> are not counted.</param>
+/// <param name="SkippedAlreadyRejectedCount">Number of requested claims that were already
+/// <c>Rejected</c> and left untouched (idempotent).</param>
+/// <param name="Claims">The full claims list after the bulk operation, ordered by section then
+/// display order. Lets the client refresh the table without a second round-trip.</param>
+public sealed record BulkRejectMechanicClaimsResponseDto(
+    int RejectedCount,
+    int SkippedAlreadyRejectedCount,
+    IReadOnlyList<MechanicClaimDto> Claims);

--- a/apps/api/src/Api/Routing/AdminMechanicAnalysesEndpoints.cs
+++ b/apps/api/src/Api/Routing/AdminMechanicAnalysesEndpoints.cs
@@ -21,6 +21,7 @@ namespace Api.Routing;
 ///   <item><c>POST /admin/mechanic-analyses/{id}/claims/{claimId}/approve</c> — per-claim approve.</item>
 ///   <item><c>POST /admin/mechanic-analyses/{id}/claims/{claimId}/reject</c> — per-claim reject with note.</item>
 ///   <item><c>POST /admin/mechanic-analyses/{id}/claims/bulk-approve</c> — bulk approve every Pending claim.</item>
+///   <item><c>POST /admin/mechanic-analyses/{id}/claims/bulk-reject</c> — bulk reject an explicit set of claims with a shared reason (#526).</item>
 /// </list>
 /// The admin's user id is always read from the validated session (never trusted from the body).
 /// </summary>

--- a/apps/api/src/Api/Routing/AdminMechanicAnalysesEndpoints.cs
+++ b/apps/api/src/Api/Routing/AdminMechanicAnalysesEndpoints.cs
@@ -252,6 +252,32 @@ internal static class AdminMechanicAnalysesEndpoints
             "re-approve them. Returns ApprovedCount, SkippedRejectedCount, and the full " +
             "updated claims list. Parent analysis must be InReview.");
 
+        // POST /api/v1/admin/mechanic-analyses/{id}/claims/bulk-reject (#526 ME-M1.4)
+        // Bulk-reject an explicit set of claims (decision D3: client computes the id set).
+        group.MapPost("/{id:guid}/claims/bulk-reject", async (
+            Guid id,
+            BulkRejectClaimsRequest request,
+            HttpContext httpContext,
+            IMediator mediator,
+            CancellationToken ct) =>
+        {
+            var session = (SessionStatusDto)httpContext.Items[nameof(SessionStatusDto)]!;
+            var reviewerId = session!.Principal!.Subject.Id;
+
+            var command = new BulkRejectMechanicClaimsCommand(id, request.ClaimIds, request.Reason, reviewerId);
+            var response = await mediator.Send(command, ct).ConfigureAwait(false);
+
+            return Results.Ok(response);
+        })
+        .WithName("AdminBulkRejectMechanicClaims")
+        .WithSummary("Bulk-reject an explicit set of claims with a shared reason (#526)")
+        .WithDescription(
+            "Rejects the claims whose ids are in the request body (the admin UI computes the set " +
+            "client-side). Claims already Rejected are skipped (idempotent); a missing claim id " +
+            "fails the batch with 404. The shared reason (1–500 chars) is applied to every " +
+            "rejected claim. Returns RejectedCount, SkippedAlreadyRejectedCount, and the full " +
+            "updated claims list. Parent analysis must be InReview; otherwise 409.");
+
         // T5 kill-switch: orthogonal suppression allowed from any status, including Published.
         group.MapPost("/{id:guid}/suppress", async (
             Guid id,
@@ -321,3 +347,11 @@ internal sealed record SuppressMechanicAnalysisRequest(
 /// <param name="Note">Reviewer rejection note (1–500 chars). Mandatory — surfaces back
 /// in the claims viewer so the reviewer can act on it before re-approving.</param>
 internal sealed record RejectClaimRequest(string Note);
+
+/// <summary>
+/// Request body for <c>POST /admin/mechanic-analyses/{id}/claims/bulk-reject</c> (#526).
+/// The reviewer id is sourced from the validated session, never the body.
+/// </summary>
+/// <param name="ClaimIds">Explicit claim ids to reject (computed client-side, decision D3).</param>
+/// <param name="Reason">Shared rejection reason (1–500 chars) applied to every claim.</param>
+internal sealed record BulkRejectClaimsRequest(IReadOnlyList<Guid> ClaimIds, string Reason);

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/BulkRejectMechanicClaimsCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/BulkRejectMechanicClaimsCommandHandlerTests.cs
@@ -1,0 +1,151 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Commands.MechanicExtractor;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Commands.MechanicExtractor;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public class BulkRejectMechanicClaimsCommandHandlerTests
+{
+    private readonly Mock<IMechanicAnalysisRepository> _repositoryMock = new();
+    private readonly Mock<IUnitOfWork> _unitOfWorkMock = new();
+    private readonly Mock<ILogger<BulkRejectMechanicClaimsCommandHandler>> _loggerMock = new();
+    private readonly BulkRejectMechanicClaimsCommandHandler _handler;
+
+    public BulkRejectMechanicClaimsCommandHandlerTests()
+    {
+        _handler = new BulkRejectMechanicClaimsCommandHandler(
+            _repositoryMock.Object,
+            _unitOfWorkMock.Object,
+            TimeProvider.System,
+            _loggerMock.Object);
+    }
+
+    // Builds an InReview analysis with `claimCount` Pending claims.
+    private static MechanicAnalysis BuildInReviewAnalysis(int claimCount)
+    {
+        var analysis = MechanicAnalysis.Create(
+            sharedGameId: Guid.NewGuid(),
+            pdfDocumentId: Guid.NewGuid(),
+            promptVersion: "v1",
+            createdBy: Guid.NewGuid(),
+            createdAt: DateTime.UtcNow,
+            modelUsed: "test-model",
+            provider: "test-provider",
+            costCapUsd: 1.0m);
+
+        for (var i = 0; i < claimCount; i++)
+        {
+            var citation = MechanicCitation.Create(Guid.NewGuid(), pdfPage: 1, quote: "q", chunkId: null, displayOrder: 0);
+            var claim = MechanicClaim.Create(
+                analysis.Id, MechanicSection.Mechanics, $"claim {i}", displayOrder: i, new[] { citation });
+            analysis.AddClaim(claim);
+        }
+
+        analysis.SubmitForReview(Guid.NewGuid(), DateTime.UtcNow);
+        return analysis;
+    }
+
+    private void SetupRepo(MechanicAnalysis? analysis, Guid analysisId)
+    {
+        _repositoryMock
+            .Setup(r => r.GetByIdWithClaimsIgnoringFiltersAsync(analysisId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(analysis);
+    }
+
+    [Fact]
+    public async Task Handle_RejectsRequestedClaims_AndPersists()
+    {
+        var analysis = BuildInReviewAnalysis(3);
+        var ids = analysis.Claims.Select(c => c.Id).ToList();
+        SetupRepo(analysis, analysis.Id);
+
+        var command = new BulkRejectMechanicClaimsCommand(
+            analysis.Id, new[] { ids[0], ids[1] }, "verbatim copy", Guid.NewGuid());
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        result.RejectedCount.Should().Be(2);
+        result.SkippedAlreadyRejectedCount.Should().Be(0);
+        analysis.Claims.Count(c => c.Status == MechanicClaimStatus.Rejected).Should().Be(2);
+        analysis.Claims.Single(c => c.Id == ids[2]).Status.Should().Be(MechanicClaimStatus.Pending);
+        _repositoryMock.Verify(r => r.Update(analysis), Times.Once);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_AnalysisNotFound_Throws404()
+    {
+        var analysisId = Guid.NewGuid();
+        SetupRepo(null, analysisId);
+
+        var command = new BulkRejectMechanicClaimsCommand(
+            analysisId, new[] { Guid.NewGuid() }, "reason", Guid.NewGuid());
+
+        await Assert.ThrowsAsync<NotFoundException>(() => _handler.Handle(command, CancellationToken.None));
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_MissingClaimId_Throws404_AndDoesNotPersist()
+    {
+        var analysis = BuildInReviewAnalysis(2);
+        var ids = analysis.Claims.Select(c => c.Id).ToList();
+        SetupRepo(analysis, analysis.Id);
+
+        // One valid id + one stale id that does not belong to the analysis.
+        var command = new BulkRejectMechanicClaimsCommand(
+            analysis.Id, new[] { ids[0], Guid.NewGuid() }, "reason", Guid.NewGuid());
+
+        await Assert.ThrowsAsync<NotFoundException>(() => _handler.Handle(command, CancellationToken.None));
+        analysis.Claims.Should().OnlyContain(c => c.Status == MechanicClaimStatus.Pending);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_AlreadyRejectedClaim_IsSkippedIdempotently()
+    {
+        var analysis = BuildInReviewAnalysis(3);
+        var ids = analysis.Claims.Select(c => c.Id).ToList();
+        // Pre-reject the first claim.
+        analysis.RejectClaim(ids[0], Guid.NewGuid(), "earlier note", DateTime.UtcNow);
+        SetupRepo(analysis, analysis.Id);
+
+        var command = new BulkRejectMechanicClaimsCommand(
+            analysis.Id, new[] { ids[0], ids[1] }, "reason", Guid.NewGuid());
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        result.RejectedCount.Should().Be(1);              // only ids[1] transitioned
+        result.SkippedAlreadyRejectedCount.Should().Be(1); // ids[0] was already Rejected
+        analysis.Claims.Count(c => c.Status == MechanicClaimStatus.Rejected).Should().Be(2);
+    }
+
+    [Fact]
+    public async Task Handle_AnalysisNotInReview_Throws409()
+    {
+        // Draft analysis (never SubmitForReview) — RejectClaim guard fails.
+        var analysis = MechanicAnalysis.Create(
+            Guid.NewGuid(), Guid.NewGuid(), "v1", Guid.NewGuid(), DateTime.UtcNow, "m", "p", 1.0m);
+        var citation = MechanicCitation.Create(Guid.NewGuid(), 1, "q", null, 0);
+        var claim = MechanicClaim.Create(analysis.Id, MechanicSection.Mechanics, "c", 0, new[] { citation });
+        analysis.AddClaim(claim);
+        SetupRepo(analysis, analysis.Id);
+
+        var command = new BulkRejectMechanicClaimsCommand(
+            analysis.Id, new[] { claim.Id }, "reason", Guid.NewGuid());
+
+        await Assert.ThrowsAsync<ConflictException>(() => _handler.Handle(command, CancellationToken.None));
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/BulkRejectMechanicClaimsCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/BulkRejectMechanicClaimsCommandHandlerTests.cs
@@ -7,6 +7,7 @@ using Api.Middleware.Exceptions;
 using Api.SharedKernel.Infrastructure.Persistence;
 using Api.Tests.Constants;
 using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
@@ -79,6 +80,10 @@ public class BulkRejectMechanicClaimsCommandHandlerTests
         result.SkippedAlreadyRejectedCount.Should().Be(0);
         analysis.Claims.Count(c => c.Status == MechanicClaimStatus.Rejected).Should().Be(2);
         analysis.Claims.Single(c => c.Id == ids[2]).Status.Should().Be(MechanicClaimStatus.Pending);
+        // Response projection — the UI refreshes the table from this without a follow-up GET.
+        result.Claims.Should().HaveCount(3);
+        result.Claims.Where(c => c.Id == ids[0] || c.Id == ids[1])
+            .Should().OnlyContain(c => c.Status == MechanicClaimStatus.Rejected && c.RejectionNote == "verbatim copy");
         _repositoryMock.Verify(r => r.Update(analysis), Times.Once);
         _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
     }
@@ -147,5 +152,21 @@ public class BulkRejectMechanicClaimsCommandHandlerTests
 
         await Assert.ThrowsAsync<ConflictException>(() => _handler.Handle(command, CancellationToken.None));
         _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_ConcurrencyConflict_Throws409()
+    {
+        var analysis = BuildInReviewAnalysis(1);
+        var claimId = analysis.Claims.First().Id;
+        SetupRepo(analysis, analysis.Id);
+        _unitOfWorkMock
+            .Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new DbUpdateConcurrencyException());
+
+        var command = new BulkRejectMechanicClaimsCommand(
+            analysis.Id, new[] { claimId }, "reason", Guid.NewGuid());
+
+        await Assert.ThrowsAsync<ConflictException>(() => _handler.Handle(command, CancellationToken.None));
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/BulkRejectMechanicClaimsCommandValidatorTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/BulkRejectMechanicClaimsCommandValidatorTests.cs
@@ -1,0 +1,69 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Commands.MechanicExtractor;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Commands.MechanicExtractor;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public class BulkRejectMechanicClaimsCommandValidatorTests
+{
+    private readonly BulkRejectMechanicClaimsCommandValidator _validator = new();
+
+    private static BulkRejectMechanicClaimsCommand Valid(
+        IReadOnlyList<Guid>? claimIds = null, string reason = "verbatim copy") =>
+        new(Guid.NewGuid(), claimIds ?? new[] { Guid.NewGuid() }, reason, Guid.NewGuid());
+
+    [Fact]
+    public void Valid_command_passes()
+    {
+        _validator.Validate(Valid()).IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Empty_analysisId_fails()
+    {
+        var cmd = Valid() with { AnalysisId = Guid.Empty };
+        _validator.Validate(cmd).IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Empty_reviewerId_fails()
+    {
+        var cmd = Valid() with { ReviewerId = Guid.Empty };
+        _validator.Validate(cmd).IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Empty_claimIds_list_fails()
+    {
+        var result = _validator.Validate(Valid(claimIds: Array.Empty<Guid>()));
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(BulkRejectMechanicClaimsCommand.ClaimIds));
+    }
+
+    [Fact]
+    public void ClaimIds_containing_empty_guid_fails()
+    {
+        _validator.Validate(Valid(claimIds: new[] { Guid.NewGuid(), Guid.Empty })).IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Empty_reason_fails()
+    {
+        _validator.Validate(Valid(reason: "")).IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Whitespace_reason_fails()
+    {
+        _validator.Validate(Valid(reason: "   ")).IsValid.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Reason_over_500_chars_fails()
+    {
+        _validator.Validate(Valid(reason: new string('x', 501))).IsValid.Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Cosa

Prima slice del residuo di #526 (admin review UI), con le 4 decisioni lockate sul record decisionale dell'issue. Aggiunge il **bulk-reject di un set esplicito di claim** (decisione **D3**: la UI admin calcola gli id client-side e li manda, a differenza di bulk-approve che colpisce implicitamente tutti i Pending).

## Componenti
- `BulkRejectMechanicClaimsCommand` + `Validator` (AnalysisId/ReviewerId, ClaimIds non-vuota senza guid vuoti, Reason 1..500) + `ResponseDto` (RejectedCount, SkippedAlreadyRejectedCount, full Claims).
- `Handler`: 404 su claim id stale/mancante (intero batch), skip idempotente dei già-Rejected, singolo `SaveChanges` (409 su concurrency o parent-non-InReview via la guardia dominio `RejectClaim`). Replica `BulkApproveMechanicClaimsCommandHandler` + `RejectMechanicClaimCommandHandler`.
- Endpoint `POST /admin/mechanic-analyses/{id}/claims/bulk-reject`; ReviewerId **sempre dalla sessione**, mai dal body.

## Decisioni #526 applicate
- **D3** claimIds espliciti client-side ✅ (questo PR)
- **D2** finalize 409: già esistente nel codice (nessun lavoro)
- **D4** single-note reject: già esistente (PR #592)
- **D1** persistenza badge validazioni → M1.5 (fuori scope)

## Test
13/13 pass: **5 handler** (success · 404 analysis · 404 missing claim · skip-already-rejected · 409 not-InReview) + **8 validator**.

Part of #526 (slice 1/N — restano i componenti FE: GuardrailBadge presence-only, PdfQuoteHighlighter, footer/observability/a11y).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
