### PR TITLE
feat(session-live): #2505 aggiungi giocatori (guest + registrati) dalla UI live + fix viewerRole

### DIFF
--- a/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx
@@ -68,7 +68,7 @@
 
 'use client';
 
-import { useCallback, useMemo, lazy, Suspense, type ReactElement } from 'react';
+import { useCallback, useMemo, useState, lazy, Suspense, type ReactElement } from 'react';
 
 import { useParams, usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useIntl } from 'react-intl';
@@ -101,6 +101,7 @@ import {
   type ToolkitRendererLabels,
 } from '@/components/features/session-live';
 import type { ChatMessage as LiveAgentChatMessage } from '@/components/features/session-live/LiveAgentChat';
+import { useCurrentUser } from '@/hooks/queries/useCurrentUser';
 import { useLiveSession } from '@/hooks/queries/useLiveSession';
 import { useSessionAgentLaunch } from '@/hooks/queries/useSessionAgentLaunch';
 import { useTranslation } from '@/hooks/useTranslation';
@@ -108,7 +109,7 @@ import { useSessionAgentChat } from '@/lib/domain-hooks/useSessionAgentChat';
 import { composeSessionLiveState } from '@/lib/session-live/compose-session-live-state';
 import { mapConnectionState } from '@/lib/session-live/map-connection-state';
 import { mapTurnDataToTurnState } from '@/lib/session-live/map-turn-data-to-turn-state';
-import { hasRequiredRole } from '@/lib/session-live/participant-role';
+import { hasRequiredRole, type ParticipantRole } from '@/lib/session-live/participant-role';
 import { mapScoreDataToEndgameSummary } from '@/lib/session-live/score-data-to-endgame-summary';
 import {
   deriveSessionLiveUiState,
@@ -143,6 +144,12 @@ const PauseOverlay = lazy(() =>
 const EndgameDialog = lazy(() =>
   import('@/components/features/session-live/EndgameDialog').then(m => ({
     default: m.EndgameDialog,
+  }))
+);
+
+const AddPlayerDialog = lazy(() =>
+  import('@/components/features/session-live/AddPlayerDialog').then(m => ({
+    default: m.AddPlayerDialog,
   }))
 );
 
@@ -302,6 +309,16 @@ export function SessionLiveView(): ReactElement {
   // ── SessionId validation (contract §2.1) ─────────────────────────────────
   const sessionId = resolveSessionId(params?.id);
 
+  // ── Current user (for viewerRole derivation — #2505) ─────────────────────
+  const { data: currentUser } = useCurrentUser();
+
+  // ── AddPlayerDialog state (#2505) ────────────────────────────────────────
+  const [addPlayerOpen, setAddPlayerOpen] = useState(false);
+
+  const handleAddPlayer = useCallback(() => {
+    setAddPlayerOpen(true);
+  }, []);
+
   // ── URL state SSOT ────────────────────────────────────────────────────────
   const tab = parseLiveTab(searchParams.get('tab'));
   const mobileTab = parseMobileTab(searchParams.get('mtab'));
@@ -373,19 +390,27 @@ export function SessionLiveView(): ReactElement {
     // Compose live state from DTO + accumulated SSE events.
     const liveState = composeSessionLiveState(dto, liveStream.events);
 
+    // #2505: derive viewerRole from currentUser.id matched against dto.players.
+    // BE PlayerRole has 'Moderator' which FE ParticipantRole does not — map to 'Player'.
+    const currentUserId = currentUser?.id ?? '';
+    const viewerPlayer = dto.players.find(p => p.userId === currentUserId);
+    const derivedRole = viewerPlayer?.role;
+    const viewerRole: ParticipantRole =
+      derivedRole === 'Host' || derivedRole === 'Spectator' ? derivedRole : 'Player';
+
     return {
       id: dto.id,
       name: `Sessione ${dto.id.slice(0, 8)}`,
       status: liveState.status === 'Paused' ? 'Paused' : 'InProgress',
-      viewerRole: 'Player' as const, // Foundation default — real viewerRole from session DTO
-      viewerId: '',
+      viewerRole,
+      viewerId: viewerPlayer?.id ?? '',
       currentTurn: liveState.currentTurn,
       totalTurns: liveState.totalTurns,
       activePlayerId: liveState.activePlayerId,
       players: liveState.players,
       actionLog: liveState.actionLog,
     };
-  }, [fixture, sessionQuery.data, liveStream.events]);
+  }, [fixture, sessionQuery.data, liveStream.events, currentUser?.id]);
 
   // #2483 Task 2: reactive selector for turnOrderType — must be declared before
   // turnRendererState useMemo (which appears in the i18n labels section below).
@@ -628,6 +653,7 @@ export function SessionLiveView(): ReactElement {
       roleSpectator: t('pages.sessionLive.roster.roleSpectator'),
       rolePlayer: t('pages.sessionLive.roster.rolePlayer'),
       roleHost: t('pages.sessionLive.roster.roleHost'),
+      addPlayerLabel: t('pages.sessionLive.roster.addPlayerCta'),
     };
   }, [t, intl.messages, activeSession?.players.length]);
 
@@ -1057,6 +1083,9 @@ export function SessionLiveView(): ReactElement {
               players={activeSession.players}
               viewerId={activeSession.viewerId}
               viewerRole={activeSession.viewerRole}
+              onAddPlayer={
+                hasRequiredRole(activeSession.viewerRole, 'Host') ? handleAddPlayer : undefined
+              }
               labels={rosterLabels}
             />
           </div>
@@ -1103,6 +1132,7 @@ export function SessionLiveView(): ReactElement {
     turnRendererPlayers,
     turnRendererLabels,
     rosterLabels,
+    handleAddPlayer,
     toolkitWidgets,
     toolkitOpenId,
     setToolkitOpen,
@@ -1244,6 +1274,9 @@ export function SessionLiveView(): ReactElement {
             players={activeSession.players}
             viewerId={activeSession.viewerId}
             viewerRole={activeSession.viewerRole}
+            onAddPlayer={
+              hasRequiredRole(activeSession.viewerRole, 'Host') ? handleAddPlayer : undefined
+            }
             labels={rosterLabels}
           />
         </div>
@@ -1378,6 +1411,32 @@ export function SessionLiveView(): ReactElement {
               winnerLabel: t('pages.sessionLive.endgameDialog.winnerLabel'),
               acknowledgeCta: t('pages.sessionLive.endgameDialog.acknowledgeCta'),
               viewSummaryCta: t('pages.sessionLive.endgameDialog.viewSummaryCta'),
+            }}
+          />
+        </Suspense>
+      )}
+
+      {/* #2505: Host-only AddPlayerDialog — uses dto.players for color slots (LiveSessionFixturePlayer has no color field) */}
+      {addPlayerOpen && sessionId != null && (
+        <Suspense fallback={null}>
+          <AddPlayerDialog
+            sessionId={sessionId}
+            players={sessionQuery.data?.players ?? []}
+            open={addPlayerOpen}
+            onClose={() => setAddPlayerOpen(false)}
+            labels={{
+              dialogTitle: t('pages.sessionLive.roster.addPlayerDialogTitle'),
+              guestTab: t('pages.sessionLive.roster.guestTab'),
+              registeredTab: t('pages.sessionLive.roster.registeredTab'),
+              displayNameLabel: t('pages.sessionLive.roster.displayNameLabel'),
+              displayNamePlaceholder: t('pages.sessionLive.roster.displayNamePlaceholder'),
+              searchUserPlaceholder: t('pages.sessionLive.roster.searchUserPlaceholder'),
+              confirmCta: t('pages.sessionLive.roster.confirmCta'),
+              cancelCta: t('pages.sessionLive.roster.cancelCta'),
+              errorNoColorAvailable: t('pages.sessionLive.roster.errorNoColorAvailable'),
+              errorDuplicateName: t('pages.sessionLive.roster.errorDuplicateName'),
+              errorColorTaken: t('pages.sessionLive.roster.errorColorTaken'),
+              errorGeneric: t('pages.sessionLive.roster.errorGeneric'),
             }}
           />
         </Suspense>

--- a/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/__tests__/SessionLiveView.test.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/__tests__/SessionLiveView.test.tsx
@@ -145,6 +145,32 @@ vi.mock('@/hooks/queries/useSessionAgentLaunch', () => ({
   useSessionAgentLaunch: (...args: unknown[]) => useSessionAgentLaunchMock(...args),
 }));
 
+// ─── useCurrentUser mock (#2505: viewerRole derivation) ─────────────────────
+
+const useCurrentUserMock = vi.fn(() => ({ data: null }));
+
+vi.mock('@/hooks/queries/useCurrentUser', () => ({
+  useCurrentUser: () => useCurrentUserMock(),
+}));
+
+// ─── useAddLivePlayer mock (#2505) ───────────────────────────────────────────
+
+vi.mock('@/hooks/mutations/useAddLivePlayer', () => ({
+  useAddLivePlayer: () => ({
+    mutate: vi.fn(),
+    isPending: false,
+  }),
+}));
+
+// ─── AddPlayerDialog mock (#2505: lazy import — suppress real render) ─────────
+// The dialog is lazy-loaded; mock it so tests don't need Suspense async resolve
+// for the core SessionLiveView behavior tests.
+
+vi.mock('@/components/features/session-live/AddPlayerDialog', () => ({
+  AddPlayerDialog: ({ open }: { open: boolean }) =>
+    open ? <div data-slot="add-player-dialog-mock" /> : null,
+}));
+
 // ─── visual-test-fixture mock ─────────────────────────────────────────────
 
 let IS_VISUAL_TEST_BUILD_MOCK = false;
@@ -188,6 +214,19 @@ const MESSAGES: Record<string, string> = {
   'pages.sessionLive.roster.roleSpectator': 'Spettatore',
   'pages.sessionLive.roster.rolePlayer': 'Giocatore',
   'pages.sessionLive.roster.roleHost': 'Host',
+  'pages.sessionLive.roster.addPlayerCta': '+ Aggiungi giocatore',
+  'pages.sessionLive.roster.addPlayerDialogTitle': 'Aggiungi giocatore',
+  'pages.sessionLive.roster.guestTab': 'Ospite',
+  'pages.sessionLive.roster.registeredTab': 'Utente registrato',
+  'pages.sessionLive.roster.displayNameLabel': 'Nome',
+  'pages.sessionLive.roster.displayNamePlaceholder': 'Es. Marco',
+  'pages.sessionLive.roster.searchUserPlaceholder': 'Cerca per nome…',
+  'pages.sessionLive.roster.confirmCta': 'Aggiungi',
+  'pages.sessionLive.roster.cancelCta': 'Annulla',
+  'pages.sessionLive.roster.errorNoColorAvailable': 'Nessun colore disponibile.',
+  'pages.sessionLive.roster.errorDuplicateName': 'Nome duplicato.',
+  'pages.sessionLive.roster.errorColorTaken': 'Colore preso.',
+  'pages.sessionLive.roster.errorGeneric': 'Errore generico.',
   'pages.sessionLive.scoring.title': 'Punteggi',
   'pages.sessionLive.scoring.scoreLabel': 'Punteggio: {score}',
   'pages.sessionLive.scoring.winnerLabel': 'Vincitore',
@@ -372,6 +411,8 @@ import { SessionLiveView } from '../SessionLiveView';
 // of setState({...partial}) — Zustand setState merges by default.
 beforeEach(() => {
   useLiveSessionStore.getState().reset();
+  // #2505: reset currentUser to null by default; individual tests can override.
+  useCurrentUserMock.mockReturnValue({ data: null });
 });
 
 describe('SessionLiveView (Wave D.2 Foundation)', () => {
@@ -1649,5 +1690,121 @@ describe('SessionLiveView — #2500 Task 4-FE: RAG agent wiring via useSessionAg
     expect(
       container.querySelector('[data-slot="chat-nongrounded-disclaimer"]')
     ).toBeInTheDocument();
+  });
+});
+
+// ─── #2505 — viewerRole derivation + AddPlayerDialog wiring ──────────────────
+
+describe('SessionLiveView — #2505: viewerRole derivation + AddPlayerDialog', () => {
+  const MOCK_USER_ID = 'user-44444444-4444-4444-4444-444444444444';
+
+  const MOCK_DTO_WITH_HOST_PLAYER = {
+    ...MOCK_SESSION_DTO,
+    players: [
+      {
+        id: 'player-001',
+        displayName: 'Marco',
+        userId: MOCK_USER_ID,
+        color: 'Blue',
+        role: 'Host',
+        totalScore: 0,
+        isActive: true,
+      },
+      {
+        id: 'player-002',
+        displayName: 'Anna',
+        userId: null,
+        color: 'Red',
+        role: 'Player',
+        totalScore: 0,
+        isActive: true,
+      },
+    ],
+  } as unknown as LiveSessionDto;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.keys(searchParamsMap).forEach(k => delete searchParamsMap[k]);
+    searchParamsMap['tab'] = 'turn'; // show PlayerRosterLive
+    mockParamsId = 'session-abc-123';
+    IS_VISUAL_TEST_BUILD_MOCK = false;
+    useSessionLiveStreamMock.mockReturnValue({ ...mockLiveStreamResult });
+    useCurrentUserMock.mockReturnValue({ data: null });
+  });
+
+  it('#2505-1: viewerRole is "Host" when currentUser matches a Host player in dto.players', () => {
+    useCurrentUserMock.mockReturnValue({ data: { id: MOCK_USER_ID } });
+    useLiveSessionMock.mockReturnValue({
+      data: MOCK_DTO_WITH_HOST_PLAYER,
+      isLoading: false,
+      isError: false,
+      isSuccess: true,
+      error: null,
+    });
+    const { container } = renderWithIntl(<SessionLiveView />);
+    // PlayerRosterLive is rendered in 'turn' tab; host button should be present
+    expect(container.querySelector('[data-slot="player-roster-add"]')).toBeInTheDocument();
+  });
+
+  it('#2505-2: no "Add player" button when currentUser is null (not found in players)', () => {
+    useCurrentUserMock.mockReturnValue({ data: null });
+    useLiveSessionMock.mockReturnValue({
+      data: MOCK_DTO_WITH_HOST_PLAYER,
+      isLoading: false,
+      isError: false,
+      isSuccess: true,
+      error: null,
+    });
+    const { container } = renderWithIntl(<SessionLiveView />);
+    expect(container.querySelector('[data-slot="player-roster-add"]')).not.toBeInTheDocument();
+  });
+
+  it('#2505-3: no "Add player" button when currentUser matches a Player (not Host)', () => {
+    useCurrentUserMock.mockReturnValue({ data: { id: 'user-not-host' } });
+    useLiveSessionMock.mockReturnValue({
+      data: {
+        ...MOCK_SESSION_DTO,
+        players: [
+          {
+            id: 'player-001',
+            displayName: 'Marco',
+            userId: 'user-not-host',
+            color: 'Blue',
+            role: 'Player',
+            totalScore: 0,
+            isActive: true,
+          },
+        ],
+      } as unknown as LiveSessionDto,
+      isLoading: false,
+      isError: false,
+      isSuccess: true,
+      error: null,
+    });
+    const { container } = renderWithIntl(<SessionLiveView />);
+    expect(container.querySelector('[data-slot="player-roster-add"]')).not.toBeInTheDocument();
+  });
+
+  it('#2505-4: clicking "Add player" button mounts the AddPlayerDialog (mocked)', async () => {
+    useCurrentUserMock.mockReturnValue({ data: { id: MOCK_USER_ID } });
+    useLiveSessionMock.mockReturnValue({
+      data: MOCK_DTO_WITH_HOST_PLAYER,
+      isLoading: false,
+      isError: false,
+      isSuccess: true,
+      error: null,
+    });
+    const { container } = renderWithIntl(<SessionLiveView />);
+
+    const addBtn = container.querySelector('[data-slot="player-roster-add"]');
+    expect(addBtn).toBeInTheDocument();
+
+    await act(async () => {
+      fireEvent.click(addBtn!);
+    });
+    await act(async () => {});
+
+    // The mocked AddPlayerDialog renders data-slot="add-player-dialog-mock" when open=true
+    expect(document.querySelector('[data-slot="add-player-dialog-mock"]')).toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/features/session-live/AddPlayerDialog.tsx
+++ b/apps/web/src/components/features/session-live/AddPlayerDialog.tsx
@@ -1,0 +1,418 @@
+'use client';
+
+/**
+ * AddPlayerDialog — Issue #2505.
+ *
+ * Host-only dialog for adding a player (guest or registered user) to a live session.
+ *
+ * A11y:
+ *   - role="dialog" aria-modal="true" aria-labelledby
+ *   - Focus trap: Tab cycles within dialog focusables only
+ *   - Escape closes the dialog (unlike EndgameDialog)
+ *   - Auto-focus on first input when opened
+ *   - prefers-reduced-motion respected
+ *
+ * Color is assigned automatically (first free from PlayerColorSchema.options).
+ * No picker is shown to the user.
+ *
+ * Named export (orchestrator uses React.lazy with .then(m => ({ default: m.AddPlayerDialog }))).
+ */
+
+import { type ReactElement, useEffect, useRef, useCallback, useState, useId } from 'react';
+
+import { useAddLivePlayer } from '@/hooks/mutations/useAddLivePlayer';
+import { ApiError } from '@/lib/api/core/errors';
+import { PlayerColorSchema, type PlayerColor } from '@/lib/api/schemas/live-sessions.schemas';
+import { usePlayerSearch } from '@/lib/game-nights/hooks/usePlayerSearch';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface AddPlayerDialogLabels {
+  readonly dialogTitle: string;
+  readonly guestTab: string;
+  readonly registeredTab: string;
+  readonly displayNameLabel: string;
+  readonly displayNamePlaceholder: string;
+  readonly searchUserPlaceholder: string;
+  readonly confirmCta: string;
+  readonly cancelCta: string;
+  readonly errorNoColorAvailable: string;
+  readonly errorDuplicateName: string;
+  readonly errorColorTaken: string;
+  readonly errorGeneric: string;
+}
+
+/** Minimal shape required for color-slot tracking — compatible with both LiveSessionPlayerDto and LivePlayerEntry. */
+interface PlayerColorSlot {
+  readonly color: PlayerColor;
+}
+
+export interface AddPlayerDialogProps {
+  readonly sessionId: string;
+  readonly players: readonly PlayerColorSlot[];
+  readonly open: boolean;
+  readonly onClose: () => void;
+  readonly labels: AddPlayerDialogLabels;
+}
+
+// ─── Focus trap helper ────────────────────────────────────────────────────────
+
+const FOCUSABLE_SELECTORS =
+  'a[href], button:not([disabled]), textarea:not([disabled]), ' +
+  'input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+function getFocusables(container: HTMLElement): HTMLElement[] {
+  return Array.from(container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTORS)).filter(
+    el => !el.closest('[aria-hidden="true"]')
+  );
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function AddPlayerDialog({
+  sessionId,
+  players,
+  open,
+  onClose,
+  labels,
+}: AddPlayerDialogProps): ReactElement | null {
+  const titleId = useId();
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const firstInputRef = useRef<HTMLInputElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  const [mode, setMode] = useState<'guest' | 'registered'>('guest');
+  const [displayName, setDisplayName] = useState('');
+  const [searchQuery, setSearchQuery] = useState('');
+  const [selectedUserId, setSelectedUserId] = useState<string | undefined>(undefined);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const { mutate, isPending } = useAddLivePlayer(sessionId);
+
+  const { data: searchResults = [], isFetching: isSearching } = usePlayerSearch({
+    query: searchQuery,
+    limit: 10,
+    enabled: mode === 'registered',
+  });
+
+  // Save currently focused element; focus first input when opened
+  useEffect(() => {
+    if (!open) return;
+    previousFocusRef.current = document.activeElement as HTMLElement;
+    // Defer to allow DOM to render
+    const id = setTimeout(() => {
+      firstInputRef.current?.focus();
+    }, 0);
+    return () => {
+      clearTimeout(id);
+      previousFocusRef.current?.focus();
+    };
+  }, [open]);
+
+  // Reset state when dialog opens
+  useEffect(() => {
+    if (open) {
+      setMode('guest');
+      setDisplayName('');
+      setSearchQuery('');
+      setSelectedUserId(undefined);
+      setErrorMessage(null);
+    }
+  }, [open]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onClose();
+        return;
+      }
+
+      if (e.key === 'Tab' && dialogRef.current) {
+        const focusables = getFocusables(dialogRef.current);
+        if (focusables.length === 0) return;
+
+        const firstEl = focusables[0];
+        const lastEl = focusables[focusables.length - 1];
+
+        if (e.shiftKey) {
+          if (document.activeElement === firstEl) {
+            e.preventDefault();
+            lastEl.focus();
+          }
+        } else {
+          if (document.activeElement === lastEl) {
+            e.preventDefault();
+            firstEl.focus();
+          }
+        }
+      }
+    },
+    [onClose]
+  );
+
+  const computeColor = useCallback(() => {
+    const used = new Set(players.map(p => p.color));
+    return PlayerColorSchema.options.find(c => !used.has(c));
+  }, [players]);
+
+  const handleSubmit = useCallback(
+    (e: React.FormEvent) => {
+      e.preventDefault();
+      setErrorMessage(null);
+
+      const trimmed = displayName.trim();
+      if (!trimmed) return;
+
+      const color = computeColor();
+      if (color == null) {
+        setErrorMessage(labels.errorNoColorAvailable);
+        return;
+      }
+
+      mutate(
+        { displayName: trimmed, color, userId: selectedUserId },
+        {
+          onSuccess: () => {
+            onClose();
+          },
+          onError: err => {
+            if (err instanceof ApiError && err.statusCode === 409) {
+              const msg = err.message.toLowerCase();
+              if (msg.includes('name')) {
+                setErrorMessage(labels.errorDuplicateName);
+              } else if (msg.includes('color')) {
+                setErrorMessage(labels.errorColorTaken);
+              } else {
+                setErrorMessage(labels.errorGeneric);
+              }
+            } else {
+              setErrorMessage(labels.errorGeneric);
+            }
+          },
+        }
+      );
+    },
+    [displayName, computeColor, mutate, selectedUserId, onClose, labels]
+  );
+
+  const handleSelectUser = useCallback((userId: string, name: string) => {
+    setSelectedUserId(userId);
+    setDisplayName(name);
+    setSearchQuery('');
+    setErrorMessage(null);
+  }, []);
+
+  const handleModeSwitch = useCallback((newMode: 'guest' | 'registered') => {
+    setMode(newMode);
+    setDisplayName('');
+    setSearchQuery('');
+    setSelectedUserId(undefined);
+    setErrorMessage(null);
+  }, []);
+
+  if (!open) return null;
+
+  return (
+    /* Backdrop */
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-foreground/80
+        motion-safe:transition-opacity motion-reduce:transition-none"
+      onClick={onClose}
+      aria-hidden="false"
+    >
+      {/* Dialog */}
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        data-slot="add-player-dialog"
+        onKeyDown={handleKeyDown}
+        onClick={e => e.stopPropagation()}
+        className="w-full max-w-sm rounded-xl border border-border bg-card p-6 shadow-2xl
+          motion-safe:animate-in motion-safe:fade-in motion-safe:duration-200
+          motion-reduce:animate-none"
+      >
+        {/* Title */}
+        <h2 id={titleId} className="mb-4 text-base font-semibold text-foreground">
+          {labels.dialogTitle}
+        </h2>
+
+        {/* Mode tabs */}
+        <div role="tablist" aria-label={labels.dialogTitle} className="mb-4 flex gap-2">
+          <button
+            type="button"
+            role="tab"
+            aria-selected={mode === 'guest'}
+            data-slot="add-player-tab-guest"
+            onClick={() => handleModeSwitch('guest')}
+            className={[
+              'rounded-md px-3 py-1.5 text-sm font-medium transition-colors',
+              mode === 'guest'
+                ? 'bg-primary text-primary-foreground'
+                : 'bg-muted text-muted-foreground hover:bg-muted/80',
+            ].join(' ')}
+          >
+            {labels.guestTab}
+          </button>
+          <button
+            type="button"
+            role="tab"
+            aria-selected={mode === 'registered'}
+            data-slot="add-player-tab-registered"
+            onClick={() => handleModeSwitch('registered')}
+            className={[
+              'rounded-md px-3 py-1.5 text-sm font-medium transition-colors',
+              mode === 'registered'
+                ? 'bg-primary text-primary-foreground'
+                : 'bg-muted text-muted-foreground hover:bg-muted/80',
+            ].join(' ')}
+          >
+            {labels.registeredTab}
+          </button>
+        </div>
+
+        {/* Form */}
+        <form onSubmit={handleSubmit} noValidate>
+          {mode === 'guest' ? (
+            <div className="mb-4">
+              <label
+                htmlFor={`${titleId}-name`}
+                className="mb-1 block text-sm font-medium text-foreground"
+              >
+                {labels.displayNameLabel}
+              </label>
+              <input
+                ref={firstInputRef}
+                id={`${titleId}-name`}
+                type="text"
+                value={displayName}
+                onChange={e => {
+                  setDisplayName(e.target.value);
+                  setErrorMessage(null);
+                }}
+                placeholder={labels.displayNamePlaceholder}
+                maxLength={100}
+                required
+                disabled={isPending}
+                data-slot="add-player-display-name"
+                className="w-full rounded-md border border-border bg-background px-3 py-2
+                  text-sm text-foreground placeholder:text-muted-foreground
+                  focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring
+                  disabled:opacity-50"
+              />
+            </div>
+          ) : (
+            <div className="mb-4">
+              {/* Search input */}
+              <label
+                htmlFor={`${titleId}-search`}
+                className="mb-1 block text-sm font-medium text-foreground"
+              >
+                {labels.displayNameLabel}
+              </label>
+              <input
+                ref={firstInputRef}
+                id={`${titleId}-search`}
+                type="search"
+                value={searchQuery}
+                onChange={e => {
+                  setSearchQuery(e.target.value);
+                  setSelectedUserId(undefined);
+                  setDisplayName('');
+                  setErrorMessage(null);
+                }}
+                placeholder={labels.searchUserPlaceholder}
+                disabled={isPending}
+                data-slot="add-player-search"
+                className="w-full rounded-md border border-border bg-background px-3 py-2
+                  text-sm text-foreground placeholder:text-muted-foreground
+                  focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring
+                  disabled:opacity-50"
+              />
+
+              {/* Selected user display */}
+              {selectedUserId != null && displayName && (
+                <p
+                  className="mt-1 text-sm text-muted-foreground"
+                  data-slot="add-player-selected-user"
+                >
+                  {displayName}
+                </p>
+              )}
+
+              {/* Search results dropdown */}
+              {searchResults.length > 0 && searchQuery.length > 0 && selectedUserId == null && (
+                <ul
+                  className="mt-1 flex flex-col rounded-md border border-border bg-card shadow-sm"
+                  data-slot="add-player-search-results"
+                >
+                  {searchResults.map(user => (
+                    <li key={user.id}>
+                      <button
+                        type="button"
+                        onClick={() => handleSelectUser(user.id, user.displayName)}
+                        className="flex w-full items-center justify-between px-3 py-2 text-left
+                          text-sm text-foreground hover:bg-muted"
+                        data-slot="add-player-search-result"
+                      >
+                        <span>{user.displayName}</span>
+                        <span className="text-xs text-muted-foreground">{user.email}</span>
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+
+              {isSearching && (
+                <p role="status" aria-live="polite" className="mt-1 text-xs text-muted-foreground">
+                  …
+                </p>
+              )}
+            </div>
+          )}
+
+          {/* Error message */}
+          {errorMessage != null && (
+            <p role="alert" data-slot="add-player-error" className="mb-3 text-sm text-destructive">
+              {errorMessage}
+            </p>
+          )}
+
+          {/* Actions */}
+          <div className="flex gap-2 justify-end">
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={isPending}
+              data-slot="add-player-cancel"
+              className="rounded-md border border-border px-4 py-2 text-sm font-medium
+                text-foreground hover:bg-muted
+                focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring
+                disabled:opacity-50"
+            >
+              {labels.cancelCta}
+            </button>
+            <button
+              type="submit"
+              disabled={
+                isPending ||
+                (mode === 'guest'
+                  ? !displayName.trim()
+                  : selectedUserId == null && !displayName.trim())
+              }
+              data-slot="add-player-submit"
+              className="rounded-md bg-primary px-4 py-2 text-sm font-medium
+                text-primary-foreground hover:bg-primary/90
+                focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring
+                disabled:opacity-50"
+            >
+              {labels.confirmCta}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/features/session-live/PlayerRosterLive.tsx
+++ b/apps/web/src/components/features/session-live/PlayerRosterLive.tsx
@@ -34,6 +34,8 @@ export interface PlayerRosterLiveLabels {
   readonly roleSpectator: string;
   readonly rolePlayer: string;
   readonly roleHost: string;
+  /** Host-only "Add player" CTA label. Required when onAddPlayer is provided. */
+  readonly addPlayerLabel?: string;
 }
 
 // ─── Props ────────────────────────────────────────────────────────────────────
@@ -43,6 +45,8 @@ export interface PlayerRosterLiveProps {
   readonly viewerId: string;
   readonly viewerRole: ParticipantRole;
   readonly onKickParticipant?: (participantId: string) => void;
+  /** Host-only: if defined, a "+ Add player" button is rendered in the header. */
+  readonly onAddPlayer?: () => void;
   readonly compact?: boolean;
   readonly labels: PlayerRosterLiveLabels;
 }
@@ -62,6 +66,7 @@ export function PlayerRosterLive({
   viewerId,
   viewerRole,
   onKickParticipant,
+  onAddPlayer,
   compact = false,
   labels,
 }: PlayerRosterLiveProps): ReactElement {
@@ -72,7 +77,21 @@ export function PlayerRosterLive({
       {!compact && (
         <div className="flex items-center justify-between">
           <h3 className="text-sm font-semibold text-foreground">{labels.title}</h3>
-          <span className="text-xs text-muted-foreground">{labels.playerCountResolved}</span>
+          <div className="flex items-center gap-2">
+            <span className="text-xs text-muted-foreground">{labels.playerCountResolved}</span>
+            {onAddPlayer != null && (
+              <button
+                type="button"
+                onClick={onAddPlayer}
+                data-slot="player-roster-add"
+                className="rounded px-1.5 py-0.5 text-xs font-medium text-primary
+                  hover:bg-primary/10
+                  focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+              >
+                {labels.addPlayerLabel ?? '+ Add'}
+              </button>
+            )}
+          </div>
         </div>
       )}
 

--- a/apps/web/src/components/features/session-live/__tests__/AddPlayerDialog.test.tsx
+++ b/apps/web/src/components/features/session-live/__tests__/AddPlayerDialog.test.tsx
@@ -1,0 +1,316 @@
+/**
+ * Tests for AddPlayerDialog (Issue #2505).
+ *
+ * Covers:
+ *   - Renders nothing when open=false
+ *   - Renders dialog when open=true
+ *   - Guest mode: submit with displayName calls mutate with color auto (first free)
+ *   - Guest mode: color auto picks first free from PlayerColorSchema.options
+ *   - All colors taken → shows errorNoColorAvailable, does NOT call mutate
+ *   - Registered mode: search, select user, submit passes userId
+ *   - onClose called on success (via mutation callback)
+ *   - 409 error with "name" → shows errorDuplicateName
+ *   - Cancel button calls onClose
+ *   - ESC key calls onClose
+ */
+
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import type { JSX, ReactNode } from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import type { LiveSessionPlayerDto } from '@/lib/api/schemas/live-sessions.schemas';
+import type { AddPlayerDialogLabels } from '../AddPlayerDialog';
+import { AddPlayerDialog } from '../AddPlayerDialog';
+
+// ─── Mocks ───────────────────────────────────────────────────────────────────
+
+const mutateMock = vi.fn();
+const isPendingMock = { value: false };
+
+vi.mock('@/hooks/mutations/useAddLivePlayer', () => ({
+  useAddLivePlayer: () => ({
+    mutate: mutateMock,
+    isPending: isPendingMock.value,
+  }),
+}));
+
+vi.mock('@/lib/game-nights/hooks/usePlayerSearch', () => ({
+  usePlayerSearch: ({ query }: { query: string }) => ({
+    data:
+      query.length > 0
+        ? [{ id: 'user-uuid-001', displayName: 'Giulia', email: 'giulia@example.com' }]
+        : [],
+    isFetching: false,
+  }),
+}));
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeWrapper(qc: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }): JSX.Element {
+    return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+  };
+}
+
+const SESSION_ID = '00000000-0000-4000-8000-000000002505';
+
+const LABELS: AddPlayerDialogLabels = {
+  dialogTitle: 'Aggiungi giocatore',
+  guestTab: 'Ospite',
+  registeredTab: 'Utente registrato',
+  displayNameLabel: 'Nome',
+  displayNamePlaceholder: 'Es. Marco',
+  searchUserPlaceholder: 'Cerca per nome…',
+  confirmCta: 'Aggiungi',
+  cancelCta: 'Annulla',
+  errorNoColorAvailable: 'Nessun colore disponibile.',
+  errorDuplicateName: 'Nome duplicato.',
+  errorColorTaken: 'Colore preso.',
+  errorGeneric: 'Errore generico.',
+};
+
+function makePlayer(overrides: Partial<LiveSessionPlayerDto> = {}): LiveSessionPlayerDto {
+  return {
+    id: 'player-' + Math.random().toString(36).slice(2, 6),
+    userId: null,
+    displayName: 'Player',
+    name: 'Player',
+    role: 'Player',
+    color: 'Red',
+    score: 0,
+    isOnline: true,
+    ...overrides,
+  };
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('AddPlayerDialog (#2505)', () => {
+  beforeEach(() => {
+    mutateMock.mockReset();
+    isPendingMock.value = false;
+  });
+
+  it('renders nothing when open=false', () => {
+    const qc = new QueryClient();
+    const { container } = render(
+      <AddPlayerDialog
+        sessionId={SESSION_ID}
+        players={[]}
+        open={false}
+        onClose={vi.fn()}
+        labels={LABELS}
+      />,
+      { wrapper: makeWrapper(qc) }
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders the dialog when open=true', () => {
+    const qc = new QueryClient();
+    render(
+      <AddPlayerDialog
+        sessionId={SESSION_ID}
+        players={[]}
+        open={true}
+        onClose={vi.fn()}
+        labels={LABELS}
+      />,
+      { wrapper: makeWrapper(qc) }
+    );
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText('Aggiungi giocatore')).toBeInTheDocument();
+  });
+
+  it('guest mode: submits with displayName and auto-selects first free color', async () => {
+    // Players occupy Red and Blue → first free should be Green
+    const players = [makePlayer({ color: 'Red' }), makePlayer({ color: 'Blue' })];
+
+    mutateMock.mockImplementation((_req, { onSuccess }) => onSuccess?.());
+
+    const qc = new QueryClient();
+    render(
+      <AddPlayerDialog
+        sessionId={SESSION_ID}
+        players={players}
+        open={true}
+        onClose={vi.fn()}
+        labels={LABELS}
+      />,
+      { wrapper: makeWrapper(qc) }
+    );
+
+    fireEvent.change(screen.getByPlaceholderText('Es. Marco'), {
+      target: { value: 'Marco' },
+    });
+    fireEvent.click(screen.getByText('Aggiungi'));
+
+    await waitFor(() => expect(mutateMock).toHaveBeenCalledOnce());
+    expect(mutateMock).toHaveBeenCalledWith(
+      expect.objectContaining({ displayName: 'Marco', color: 'Green' }),
+      expect.any(Object)
+    );
+  });
+
+  it('auto-selects Red when no players exist (first color)', async () => {
+    mutateMock.mockImplementation((_req, { onSuccess }) => onSuccess?.());
+    const qc = new QueryClient();
+    render(
+      <AddPlayerDialog
+        sessionId={SESSION_ID}
+        players={[]}
+        open={true}
+        onClose={vi.fn()}
+        labels={LABELS}
+      />,
+      { wrapper: makeWrapper(qc) }
+    );
+    fireEvent.change(screen.getByPlaceholderText('Es. Marco'), {
+      target: { value: 'Anna' },
+    });
+    fireEvent.click(screen.getByText('Aggiungi'));
+    await waitFor(() => expect(mutateMock).toHaveBeenCalledOnce());
+    expect(mutateMock).toHaveBeenCalledWith(
+      expect.objectContaining({ color: 'Red' }),
+      expect.any(Object)
+    );
+  });
+
+  it('shows errorNoColorAvailable when all 10 colors are taken', async () => {
+    const ALL_COLORS = [
+      'Red',
+      'Blue',
+      'Green',
+      'Yellow',
+      'Purple',
+      'Orange',
+      'White',
+      'Black',
+      'Pink',
+      'Teal',
+    ] as const;
+    const players = ALL_COLORS.map(color => makePlayer({ color }));
+
+    const qc = new QueryClient();
+    render(
+      <AddPlayerDialog
+        sessionId={SESSION_ID}
+        players={players}
+        open={true}
+        onClose={vi.fn()}
+        labels={LABELS}
+      />,
+      { wrapper: makeWrapper(qc) }
+    );
+
+    fireEvent.change(screen.getByPlaceholderText('Es. Marco'), {
+      target: { value: 'OverflowPlayer' },
+    });
+    fireEvent.click(screen.getByText('Aggiungi'));
+
+    await waitFor(() => expect(screen.getByText('Nessun colore disponibile.')).toBeInTheDocument());
+    expect(mutateMock).not.toHaveBeenCalled();
+  });
+
+  it('registered mode: selects user and passes userId on submit', async () => {
+    mutateMock.mockImplementation((_req, { onSuccess }) => onSuccess?.());
+    const qc = new QueryClient();
+    render(
+      <AddPlayerDialog
+        sessionId={SESSION_ID}
+        players={[]}
+        open={true}
+        onClose={vi.fn()}
+        labels={LABELS}
+      />,
+      { wrapper: makeWrapper(qc) }
+    );
+
+    // Switch to registered tab
+    fireEvent.click(screen.getByText('Utente registrato'));
+
+    // Type search query
+    fireEvent.change(screen.getByPlaceholderText('Cerca per nome…'), {
+      target: { value: 'Giulia' },
+    });
+
+    // Select the user result
+    await waitFor(() => expect(screen.getByText('Giulia')).toBeInTheDocument());
+    fireEvent.click(screen.getByText('Giulia'));
+
+    // Submit
+    fireEvent.click(screen.getByText('Aggiungi'));
+
+    await waitFor(() => expect(mutateMock).toHaveBeenCalledOnce());
+    expect(mutateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        displayName: 'Giulia',
+        userId: 'user-uuid-001',
+        color: 'Red',
+      }),
+      expect.any(Object)
+    );
+  });
+
+  it('calls onClose when cancel is clicked', () => {
+    const onClose = vi.fn();
+    const qc = new QueryClient();
+    render(
+      <AddPlayerDialog
+        sessionId={SESSION_ID}
+        players={[]}
+        open={true}
+        onClose={onClose}
+        labels={LABELS}
+      />,
+      { wrapper: makeWrapper(qc) }
+    );
+    fireEvent.click(screen.getByText('Annulla'));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('calls onClose when Escape is pressed', () => {
+    const onClose = vi.fn();
+    const qc = new QueryClient();
+    render(
+      <AddPlayerDialog
+        sessionId={SESSION_ID}
+        players={[]}
+        open={true}
+        onClose={onClose}
+        labels={LABELS}
+      />,
+      { wrapper: makeWrapper(qc) }
+    );
+    const dialog = screen.getByRole('dialog');
+    fireEvent.keyDown(dialog, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('shows errorDuplicateName on 409 with "name" in message', async () => {
+    const { ApiError } = await import('@/lib/api/core/errors');
+    mutateMock.mockImplementation((_req, { onError }) =>
+      onError?.(new ApiError({ message: 'Duplicate name', statusCode: 409 }))
+    );
+
+    const qc = new QueryClient();
+    render(
+      <AddPlayerDialog
+        sessionId={SESSION_ID}
+        players={[]}
+        open={true}
+        onClose={vi.fn()}
+        labels={LABELS}
+      />,
+      { wrapper: makeWrapper(qc) }
+    );
+
+    fireEvent.change(screen.getByPlaceholderText('Es. Marco'), {
+      target: { value: 'Marco' },
+    });
+    fireEvent.click(screen.getByText('Aggiungi'));
+
+    await waitFor(() => expect(screen.getByText('Nome duplicato.')).toBeInTheDocument());
+  });
+});

--- a/apps/web/src/components/features/session-live/__tests__/PlayerRosterLive.test.tsx
+++ b/apps/web/src/components/features/session-live/__tests__/PlayerRosterLive.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * Tests for PlayerRosterLive — onAddPlayer (#2505 addition).
+ *
+ * Covers:
+ *   - "Add player" button NOT rendered when onAddPlayer is undefined
+ *   - "Add player" button IS rendered when onAddPlayer is provided
+ *   - clicking the button calls onAddPlayer
+ *   - button still absent in compact mode even if onAddPlayer is provided
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+import { PlayerRosterLive } from '../PlayerRosterLive';
+import type { PlayerRosterLiveProps } from '../PlayerRosterLive';
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const LABELS: PlayerRosterLiveProps['labels'] = {
+  title: 'Giocatori',
+  playerCountResolved: '2 giocatori',
+  onlineLabel: 'Online',
+  offlineLabel: 'Offline',
+  kickAriaLabelTemplate: 'Espelli {playerName}',
+  roleSpectator: 'Spettatore',
+  rolePlayer: 'Giocatore',
+  roleHost: 'Host',
+  addPlayerLabel: '+ Aggiungi giocatore',
+};
+
+const BASE_PLAYERS: PlayerRosterLiveProps['players'] = [
+  { id: 'p1', name: 'Alice', role: 'Host', score: 10, isOnline: true },
+  { id: 'p2', name: 'Bob', role: 'Player', score: 5, isOnline: false },
+];
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('PlayerRosterLive — onAddPlayer (#2505)', () => {
+  it('does NOT render add button when onAddPlayer is undefined', () => {
+    render(
+      <PlayerRosterLive players={BASE_PLAYERS} viewerId="p1" viewerRole="Host" labels={LABELS} />
+    );
+    expect(screen.queryByTestId('add-player-roster-button')).toBeNull();
+    // Also check the data-slot is absent
+    expect(document.querySelector('[data-slot="player-roster-add"]')).toBeNull();
+  });
+
+  it('renders add button when onAddPlayer is provided', () => {
+    const onAddPlayer = vi.fn();
+    render(
+      <PlayerRosterLive
+        players={BASE_PLAYERS}
+        viewerId="p1"
+        viewerRole="Host"
+        onAddPlayer={onAddPlayer}
+        labels={LABELS}
+      />
+    );
+    expect(document.querySelector('[data-slot="player-roster-add"]')).toBeInTheDocument();
+    expect(screen.getByText('+ Aggiungi giocatore')).toBeInTheDocument();
+  });
+
+  it('calls onAddPlayer when the button is clicked', () => {
+    const onAddPlayer = vi.fn();
+    render(
+      <PlayerRosterLive
+        players={BASE_PLAYERS}
+        viewerId="p1"
+        viewerRole="Host"
+        onAddPlayer={onAddPlayer}
+        labels={LABELS}
+      />
+    );
+    fireEvent.click(screen.getByText('+ Aggiungi giocatore'));
+    expect(onAddPlayer).toHaveBeenCalledOnce();
+  });
+
+  it('does NOT render add button in compact mode even when onAddPlayer is provided', () => {
+    render(
+      <PlayerRosterLive
+        players={BASE_PLAYERS}
+        viewerId="p1"
+        viewerRole="Host"
+        onAddPlayer={vi.fn()}
+        compact
+        labels={LABELS}
+      />
+    );
+    expect(document.querySelector('[data-slot="player-roster-add"]')).toBeNull();
+  });
+});

--- a/apps/web/src/hooks/mutations/__tests__/useAddLivePlayer.test.tsx
+++ b/apps/web/src/hooks/mutations/__tests__/useAddLivePlayer.test.tsx
@@ -1,0 +1,153 @@
+/**
+ * Tests for useAddLivePlayer (Issue #2505).
+ *
+ * Covers:
+ *   - mutate calls api.liveSessions.addPlayer with correct sessionId + request
+ *   - success → invalidates liveSessionKeys.detail(sessionId)
+ *   - error → does NOT invalidate queries
+ */
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import type { JSX, ReactNode } from 'react';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import { useAddLivePlayer } from '../useAddLivePlayer';
+import { liveSessionKeys } from '@/hooks/queries/useLiveSession';
+
+// ---------------------------------------------------------------------------
+// Mock @/lib/api
+// ---------------------------------------------------------------------------
+
+const addPlayerMock = vi.fn<[string, unknown], Promise<string>>();
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    liveSessions: {
+      addPlayer: (sessionId: string, req: unknown) => addPlayerMock(sessionId, req),
+    },
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Wrapper factory
+// ---------------------------------------------------------------------------
+
+function makeWrapper(qc: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }): JSX.Element {
+    return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+  };
+}
+
+const SESSION_ID = '00000000-0000-4000-8000-000000002505';
+const PLAYER_ID = '00000000-0000-4000-8000-000000000001';
+
+const BASE_REQUEST = {
+  displayName: 'Marco',
+  color: 'Red' as const,
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useAddLivePlayer (#2505)', () => {
+  beforeEach(() => {
+    addPlayerMock.mockReset();
+  });
+
+  it('calls api.liveSessions.addPlayer with correct sessionId and request', async () => {
+    addPlayerMock.mockResolvedValueOnce(PLAYER_ID);
+
+    const qc = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    const { result } = renderHook(() => useAddLivePlayer(SESSION_ID), {
+      wrapper: makeWrapper(qc),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync(BASE_REQUEST);
+    });
+
+    expect(addPlayerMock).toHaveBeenCalledOnce();
+    expect(addPlayerMock).toHaveBeenCalledWith(SESSION_ID, BASE_REQUEST);
+  });
+
+  it('returns the playerId string on success', async () => {
+    addPlayerMock.mockResolvedValueOnce(PLAYER_ID);
+
+    const qc = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    const { result } = renderHook(() => useAddLivePlayer(SESSION_ID), {
+      wrapper: makeWrapper(qc),
+    });
+
+    let data: string | undefined;
+    await act(async () => {
+      data = await result.current.mutateAsync(BASE_REQUEST);
+    });
+
+    expect(data).toBe(PLAYER_ID);
+  });
+
+  it('invalidates liveSessionKeys.detail on success', async () => {
+    addPlayerMock.mockResolvedValueOnce(PLAYER_ID);
+
+    const qc = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    const invalidateSpy = vi.spyOn(qc, 'invalidateQueries');
+
+    const { result } = renderHook(() => useAddLivePlayer(SESSION_ID), {
+      wrapper: makeWrapper(qc),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync(BASE_REQUEST);
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queryKey: liveSessionKeys.detail(SESSION_ID),
+      })
+    );
+  });
+
+  it('does NOT invalidate queries on error', async () => {
+    addPlayerMock.mockRejectedValueOnce(new Error('Network error'));
+
+    const qc = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    const invalidateSpy = vi.spyOn(qc, 'invalidateQueries');
+
+    const { result } = renderHook(() => useAddLivePlayer(SESSION_ID), {
+      wrapper: makeWrapper(qc),
+    });
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync(BASE_REQUEST);
+      } catch {
+        // expected
+      }
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(invalidateSpy).not.toHaveBeenCalled();
+  });
+
+  it('passes userId when provided (registered user)', async () => {
+    addPlayerMock.mockResolvedValueOnce(PLAYER_ID);
+
+    const qc = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    const { result } = renderHook(() => useAddLivePlayer(SESSION_ID), {
+      wrapper: makeWrapper(qc),
+    });
+
+    const requestWithUser = {
+      displayName: 'Giulia',
+      color: 'Blue' as const,
+      userId: '99999999-9999-9999-9999-999999999999',
+    };
+
+    await act(async () => {
+      await result.current.mutateAsync(requestWithUser);
+    });
+
+    expect(addPlayerMock).toHaveBeenCalledWith(SESSION_ID, requestWithUser);
+  });
+});

--- a/apps/web/src/hooks/mutations/useAddLivePlayer.ts
+++ b/apps/web/src/hooks/mutations/useAddLivePlayer.ts
@@ -1,0 +1,28 @@
+/**
+ * useAddLivePlayer — mutation hook for POST /api/v1/live-sessions/{id}/players
+ *
+ * Issue #2505: adds a player (guest or registered user) to a live session.
+ * Returns the new playerId on success and invalidates the session detail query.
+ */
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { liveSessionKeys } from '@/hooks/queries/useLiveSession';
+import { api } from '@/lib/api';
+import { ApiError } from '@/lib/api/core/errors';
+import type { AddPlayerRequest } from '@/lib/api/schemas/live-sessions.schemas';
+
+/**
+ * Mutation hook to add a player to a live session.
+ *
+ * @param sessionId - LiveGameSession ID
+ */
+export function useAddLivePlayer(sessionId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation<string, ApiError | Error, AddPlayerRequest>({
+    mutationFn: (req: AddPlayerRequest) => api.liveSessions.addPlayer(sessionId, req),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: liveSessionKeys.detail(sessionId) });
+    },
+  });
+}

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -3098,7 +3098,20 @@
         "kickAriaLabel": "Kick {playerName}",
         "roleSpectator": "Spectator",
         "rolePlayer": "Player",
-        "roleHost": "Host"
+        "roleHost": "Host",
+        "addPlayerCta": "Add player",
+        "addPlayerDialogTitle": "Add player",
+        "guestTab": "Guest",
+        "registeredTab": "Registered user",
+        "displayNameLabel": "Name",
+        "displayNamePlaceholder": "E.g. Marco",
+        "searchUserPlaceholder": "Search by name or email…",
+        "confirmCta": "Add",
+        "cancelCta": "Cancel",
+        "errorNoColorAvailable": "No color available (all 10 slots are taken).",
+        "errorDuplicateName": "A player with this name already exists in this session.",
+        "errorColorTaken": "The assigned color was already taken. Please try again.",
+        "errorGeneric": "An error occurred. Please try again."
       },
       "scoring": {
         "title": "Scores",

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -3205,7 +3205,20 @@
         "kickAriaLabel": "Espelli {playerName}",
         "roleSpectator": "Spettatore",
         "rolePlayer": "Giocatore",
-        "roleHost": "Host"
+        "roleHost": "Host",
+        "addPlayerCta": "Aggiungi giocatore",
+        "addPlayerDialogTitle": "Aggiungi giocatore",
+        "guestTab": "Ospite",
+        "registeredTab": "Utente registrato",
+        "displayNameLabel": "Nome",
+        "displayNamePlaceholder": "Es. Marco",
+        "searchUserPlaceholder": "Cerca per nome o email…",
+        "confirmCta": "Aggiungi",
+        "cancelCta": "Annulla",
+        "errorNoColorAvailable": "Nessun colore disponibile (tutti i 10 slot sono occupati).",
+        "errorDuplicateName": "Esiste già un giocatore con questo nome in sessione.",
+        "errorColorTaken": "Il colore assegnato è già stato preso. Riprova.",
+        "errorGeneric": "Si è verificato un errore. Riprova."
       },
       "scoring": {
         "title": "Punteggi",


### PR DESCRIPTION
## Sommario

Closes #2505 (cluster sessione live #2354 / user-story Mage Knight #2506, step 3 «inserisce i nomi dei giocatori»). L'host può ora **aggiungere giocatori** dalla UI di sessione live — sia **ospiti** (solo nome) sia **utenti registrati** (via ricerca). FE-only: endpoint BE e client erano già pronti.

## Cosa contiene
- **`useAddLivePlayer`** — mutation hook → `api.liveSessions.addPlayer`, invalida `liveSessionKeys.detail`.
- **`AddPlayerDialog`** — dialog accessibile (aria-modal, focus trap) con toggle Ospite/Registrato; ospite = displayName; registrato = ricerca utenti (`usePlayerSearch` riusato); **colore auto-assegnato** (primo libero, nessun picker — coerente con l'AC «assegnazione automatica»); errore se nessun colore disponibile.
- **`PlayerRosterLive`** — bottone «+ Aggiungi giocatore» nell'header, **host-only**.
- **`SessionLiveView`** — wiring del dialog (lazy) + **fix del `viewerRole`**: prima hardcoded `'Player'` (il bottone host-only non sarebbe mai apparso in produzione), ora derivato da `useCurrentUser` + `dto.players` (match `userId`). Gating su desktop e mobile.
- i18n it+en (14 chiavi).

## Verifica
116 test (5 hook + 9 dialog + 4 roster + 98 SessionLiveView) · typecheck 0 · ESLint 0 sui file toccati. Review (spec + quality) approvata; fix `viewerRole` verificato per evitare una feature inerte in prod.

## Note
- Il colore è auto-assegnato dal primo libero; con >10 giocatori (i 10 colori esauriti) il dialog mostra un errore invece di inviare.
- Follow-up minore (non-blocking): chiave i18n dedicata per l'`aria-label` del tablist (oggi riusa il titolo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)