### PR TITLE
fix(ci): #2516 use runner AWS CLI v2, drop broken apt awscli install

### DIFF
--- a/.github/workflows/seed-snapshot-bake-ci.yml
+++ b/.github/workflows/seed-snapshot-bake-ci.yml
@@ -259,4 +259,11 @@ jobs:
           SEED_BLOB_BUCKET=${SEED_BLOB_BUCKET}
           EOF
           chmod 600 secrets/storage.secret
+          # seed-index-publish.sh uses `aws s3 cp`. AWS CLI v2 is pre-installed on
+          # GitHub-hosted runners; install it on demand only if it's somehow absent.
+          if ! command -v aws >/dev/null 2>&1; then
+            curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip
+            unzip -q /tmp/awscliv2.zip -d /tmp
+            sudo /tmp/aws/install
+          fi
           bash scripts/seed-index-publish.sh

--- a/.github/workflows/seed-snapshot-bake-full.yml
+++ b/.github/workflows/seed-snapshot-bake-full.yml
@@ -81,10 +81,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install jq + AWS CLI (required by seed-index-publish.sh)
+      - name: Install jq (seed scripts) — AWS CLI v2 is pre-installed on the runner
         run: |
+          # `awscli` was removed from the Ubuntu 24.04 (noble) apt repos
+          # ("no installation candidate"), so we no longer apt-install it.
+          # GitHub-hosted ubuntu-latest ships AWS CLI v2; the publish step adds a
+          # defensive fallback installer if `aws` is ever missing.
           sudo apt-get update
-          sudo apt-get install -y jq awscli
+          sudo apt-get install -y jq
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
@@ -263,6 +267,13 @@ jobs:
           SEED_BLOB_BUCKET=${SEED_BLOB_BUCKET}
           EOF
           chmod 600 secrets/storage.secret
+          # seed-index-publish.sh uses `aws s3 cp`. AWS CLI v2 is pre-installed on
+          # GitHub-hosted runners; install it on demand only if it's somehow absent.
+          if ! command -v aws >/dev/null 2>&1; then
+            curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip
+            unzip -q /tmp/awscliv2.zip -d /tmp
+            sudo /tmp/aws/install
+          fi
           bash scripts/seed-index-publish.sh
 
       - name: Notify on failure (placeholder for D6 audit trail)


### PR DESCRIPTION
## Sommario

Il primo dispatch del full-bake ([run 28091493219](https://github.com/meepleAi-app/meepleai-monorepo/actions/runs/28091493219)) è fallito **allo step 1** `Install jq + AWS CLI`:

```
apt-get install -y jq awscli
E: Package 'awscli' has no installation candidate
```

Ubuntu 24.04 (noble) ha **rimosso `awscli` dai repo apt**. È un **9° strato** pre-esistente della rottura del full-bake (riga non toccata dai boot-fix #2525), emerso solo ora che i boot-fix fanno arrivare il run oltre il dispatch.

## Fix

`seed-index-publish.sh` usa `aws s3 cp` — ma solo nel **publish step** (che con il soft-skip #2525 esce prima quando `SEED_BLOB_*` è assente).

- **full-bake**: installa solo `jq` via apt. GitHub-hosted `ubuntu-latest` ha **AWS CLI v2 pre-installato**, quindi `aws s3 cp` funziona senza install.
- **full-bake + bake-ci publish step**: aggiunto installer AWS CLI v2 on-demand difensivo, guardato da `command -v aws`, dopo il check di presenza `SEED_BLOB_*`. Così i run di validazione/soft-skip non lo toccano mai, ma il publish reale funziona anche se un futuro runner image perdesse la CLI pre-installata.
- **bake-ci** aveva lo stesso latent gap (installava solo `jq`, mai `awscli`, ma il suo publish opt-in chiama lo stesso script) → fixato dallo stesso guard.

## Test

- ✅ Entrambi gli YAML validi
- ⚠️ Validazione e2e: re-dispatch del full-bake dopo il merge

Parte del lavoro #2516.

🤖 Generated with [Claude Code](https://claude.com/claude-code)