### PR TITLE
fix(seed): publish the generated-tables.sql embeddings supplement

### DIFF
--- a/infra/scripts/seed-index-publish.sh
+++ b/infra/scripts/seed-index-publish.sh
@@ -30,6 +30,14 @@ PREFIX="snapshots"
 
 log "uploading $BASENAME.dump"
 $AWS_S3 cp "$OUT_DIR/$BASENAME.dump" "s3://$SEED_BLOB_BUCKET/$PREFIX/$BASENAME.dump"
+# Generated-columns supplement (pgvector_embeddings et al.) — REQUIRED. The main
+# .dump excludes generated-column tables' data (seed-index-dump.sh), so without
+# this file the restored snapshot has 0 embeddings (RAG cold) and the .dump.sha256
+# — which covers BOTH files — fails verification on the consumer. Always exists
+# (dump writes an empty placeholder when no generated tables). snapshot-fetch.sh
+# fetches it; it MUST be on the bucket before the meta.json atomic marker.
+log "uploading $BASENAME.generated-tables.sql (embeddings supplement)"
+$AWS_S3 cp "$OUT_DIR/$BASENAME.generated-tables.sql" "s3://$SEED_BLOB_BUCKET/$PREFIX/$BASENAME.generated-tables.sql"
 log "uploading $BASENAME.dump.sha256"
 $AWS_S3 cp "$OUT_DIR/$BASENAME.dump.sha256" "s3://$SEED_BLOB_BUCKET/$PREFIX/$BASENAME.dump.sha256"
 # META PER ULTIMO — atomic marker
@@ -50,9 +58,10 @@ $AWS_S3 ls "s3://$SEED_BLOB_BUCKET/$PREFIX/" \
     | while read -r old_meta; do
         old_base=${old_meta%.meta.json}
         log "rimuovo obsoleto: $old_base"
-        $AWS_S3 rm "s3://$SEED_BLOB_BUCKET/$PREFIX/$old_base.dump"        || true
-        $AWS_S3 rm "s3://$SEED_BLOB_BUCKET/$PREFIX/$old_base.dump.sha256" || true
-        $AWS_S3 rm "s3://$SEED_BLOB_BUCKET/$PREFIX/$old_base.meta.json"   || true
+        $AWS_S3 rm "s3://$SEED_BLOB_BUCKET/$PREFIX/$old_base.dump"                 || true
+        $AWS_S3 rm "s3://$SEED_BLOB_BUCKET/$PREFIX/$old_base.generated-tables.sql" || true
+        $AWS_S3 rm "s3://$SEED_BLOB_BUCKET/$PREFIX/$old_base.dump.sha256"          || true
+        $AWS_S3 rm "s3://$SEED_BLOB_BUCKET/$PREFIX/$old_base.meta.json"            || true
       done
 
 # ───────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Sommario

`seed-index-publish.sh` caricava solo `.dump`/`.dump.sha256`/`.meta.json`. Ma il `.dump` principale **esclude** i dati delle tabelle con colonne generate (`seed-index-dump.sh` usa `--exclude-table-data` per `pgvector_embeddings` & co.) e le dumpa a parte in `$BASENAME.generated-tables.sql`. Il consumer (`snapshot-fetch.sh:37`) scarica quel supplement, e `.dump.sha256` copre **entrambi** i file.

Senza caricare il supplement, uno snapshot pubblicato si ripristina con **0 embeddings** (RAG cold) e **fallisce la verifica sha256** sul consumer.

## Fix
- upload di `$BASENAME.generated-tables.sql` subito dopo il `.dump` (prima del marker atomico `.meta.json`)
- incluso nella rotation (retention) così i vecchi supplement non restano orfani

Il file esiste sempre (`seed-index-dump.sh` scrive un placeholder vuoto se non ci sono tabelle generate). `bash -n` OK.

Prerequisito per la distribuzione R2 dello snapshot (track #2480).

🤖 Generated with [Claude Code](https://claude.com/claude-code)