### PR TITLE
chore(security): #2536 bump protobufjs 8.0.3->8.6.5 (GHSA-wcpc-wj8m-hjx6)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -299,7 +299,7 @@
       "markdown-it": ">=14.1.1",
       "picomatch": ">=4.0.4",
       "postcss": ">=8.5.10",
-      "protobufjs": ">=7.5.5",
+      "protobufjs": ">=8.4.1",
       "qs": ">=6.14.2",
       "shell-quote": ">=1.8.4",
       "form-data": ">=4.0.6",

--- a/apps/web/pnpm-lock.yaml
+++ b/apps/web/pnpm-lock.yaml
@@ -19,7 +19,7 @@ overrides:
   markdown-it: '>=14.1.1'
   picomatch: '>=4.0.4'
   postcss: '>=8.5.10'
-  protobufjs: '>=7.5.5'
+  protobufjs: '>=8.4.1'
   qs: '>=6.14.2'
   shell-quote: '>=1.8.4'
   form-data: '>=4.0.6'
@@ -8555,8 +8555,8 @@ packages:
   prosemirror-view@1.41.8:
     resolution: {integrity: sha512-TnKDdohEatgyZNGCDWIdccOHXhYloJwbwU+phw/a23KBvJIR9lWQWW7WHHK3vBdOLDNuF7TaX98GObUZOWkOnA==}
 
-  protobufjs@8.0.3:
-    resolution: {integrity: sha512-LBYnMWkKLB8fE/ljROPDbCl7mgLSlI+oBe1fAAr5MTqFg4TIi0tYrVVurJvQggOjnUYMQtEZBjrej59ojMNTHQ==}
+  protobufjs@8.6.5:
+    resolution: {integrity: sha512-zeE5LPpencAGXvsxyOYmEgJhxzHY8IsmPAFzstZVhDSVT8QH03q6gMZwZRaQGApevZbAL6u28ugs4CC+YKB2jQ==}
     engines: {node: '>=12.0.0'}
 
   proxy-agent@6.5.0:
@@ -19088,7 +19088,7 @@ snapshots:
 
   prometheus-remote-write@0.5.0(node-fetch@2.7.0):
     dependencies:
-      protobufjs: 8.0.3
+      protobufjs: 8.6.5
       snappyjs: 0.6.1
     optionalDependencies:
       node-fetch: 2.7.0
@@ -19170,9 +19170,8 @@ snapshots:
       prosemirror-state: 1.4.4
       prosemirror-transform: 1.12.0
 
-  protobufjs@8.0.3:
+  protobufjs@8.6.5:
     dependencies:
-      '@types/node': 25.9.1
       long: 5.3.2
 
   proxy-agent@6.5.0:


### PR DESCRIPTION
Closes #2536. Discovered while resolving the #2515/#2531 Dependabot residuals via `pnpm audit`.

## What
`apps/web` resolved **protobufjs 8.0.3** (devDep: `playwright-prometheus-remote-write-reporter
> prometheus-remote-write > protobufjs`), vulnerable to **GHSA-wcpc-wj8m-hjx6 (HIGH)** — DoS via
unbounded Any expansion during JSON conversion (vulnerable `>=8.0.0 <=8.4.0`, patched **8.4.1**).

The existing override `protobufjs >=7.5.5` was satisfied by 8.0.3 so it never moved. protobufjs is
a real transitive dep (not a peer), so raising the override floor to `>=8.4.1` bumps it — resolves
to 8.6.5.

## Verification
- `pnpm audit --audit-level high` → **0 high / 0 critical** (was 1 high = protobufjs).
- `pnpm typecheck` clean. protobufjs is only used by a Playwright reporter (not in the app bundle
  or the vitest runtime), so no functional impact.
- Lockfile churn is protobufjs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)