### PR TITLE
chore(security): #2542 bump SQLitePCLRaw 2.1.10->3.0.3 (GHSA-2m69-gcr7-jv3q)

### DIFF
--- a/apps/api/tests/Api.Tests/Api.Tests.csproj
+++ b/apps/api/tests/Api.Tests/Api.Tests.csproj
@@ -58,6 +58,11 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.11" />
+    <!-- Force the SQLitePCLRaw native bundle to 3.x: the transitive 2.1.10 pulled by
+         Microsoft.Data.Sqlite bundles a vulnerable SQLite (GHSA-2m69-gcr7-jv3q, HIGH,
+         vulnerable <= 2.1.11, no 2.x patch). The 3.x bundle ships SQLite 3.50.x.
+         Test-only dependency (in-memory SQLite for EndpointContractTests). -->
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="9.0.11" />
     <PackageReference Include="coverlet.collector" Version="6.0.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Closes #2542. The pre-existing backend HIGH that kept the CI "Dependency Vulnerabilities"
check red since #2515.

## What
`apps/api/tests/Api.Tests` transitively pulled **SQLitePCLRaw.lib.e_sqlite3 2.1.10** (via
`Microsoft.EntityFrameworkCore.Sqlite 9.0.11` → `Microsoft.Data.Sqlite`), bundling a vulnerable
native SQLite — **GHSA-2m69-gcr7-jv3q (HIGH)**. Advisory: vulnerable `<= 2.1.11`, no 2.x patch;
the 3.x bundle (SQLite 3.50.x) is outside the range. SQLite is **test-only** here (in-memory
`UseSqlite` in `EndpointContractTests`); production uses PostgreSQL.

## Fix
Direct `SQLitePCLRaw.bundle_e_sqlite3 3.0.3` PackageReference in `Api.Tests.csproj` forces the
whole SQLitePCLRaw stack (bundle/config/core/provider) to 3.0.3.

## Verification
- `dotnet restore` clean (no conflict with Microsoft.Data.Sqlite 9.0.11).
- `dotnet list package --vulnerable --include-transitive` no longer reports SQLitePCLRaw.
- `dotnet build` clean; `EndpointContractTests` (SQLite `:memory:`) **35/35 pass** — runtime
  compatibility with SQLitePCLRaw.core 3.0.3 confirmed.

With this + the already-merged vite (#2531) and protobufjs (#2536) bumps, the
"Dependency Vulnerabilities" gate should go green (no remaining HIGH/CRITICAL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)