### PR TITLE
feat(seed): consumer snapshot setup — fix fetch cwd + document R2 config

### DIFF
--- a/docs/for-developers/workflows/snapshot-seed-workflow.md
+++ b/docs/for-developers/workflows/snapshot-seed-workflow.md
@@ -61,6 +61,36 @@ Cosa fa:
 
 Se qualcosa fallisce, il messaggio di errore ti dice esattamente cosa fare. **Fallback sempre disponibile**: `make dev`.
 
+#### Credenziali consumer (`storage.secret`)
+
+Su una macchina **senza cache locale**, `snapshot-fetch.sh` scarica lo snapshot dal
+bucket dedicato **`meepleai-seed-snapshots`**. Lo fa leggendo da `infra/secrets/storage.secret`:
+
+| Key | Valore |
+|---|---|
+| `SEED_BLOB_BUCKET` | `meepleai-seed-snapshots` |
+| `S3_ENDPOINT` | il tuo endpoint R2 EU (`https://<account>.eu.r2.cloudflarestorage.com`) |
+| `S3_ACCESS_KEY` / `S3_SECRET_KEY` | un token R2 **"Object Read only"** scoped a `meepleai-seed-snapshots` |
+
+⚠️ `snapshot-fetch.sh` usa le `S3_*` (non un pair `SEED_BLOB_S3_*`), quindi quelle
+credenziali devono avere **read** sul bucket snapshot. Per un consumer puro
+(nessun upload S3 in dev) la config raccomandata è:
+
+```
+STORAGE_PROVIDER=local          # l'app salva i PDF su disco; le S3_* servono SOLO a snapshot-fetch.sh
+S3_ENDPOINT=https://<account>.eu.r2.cloudflarestorage.com
+S3_ACCESS_KEY=<readonly key del token scoped a meepleai-seed-snapshots>
+S3_SECRET_KEY=<readonly secret>
+SEED_BLOB_BUCKET=meepleai-seed-snapshots
+```
+
+Template completo + commenti: `infra/secrets/storage.secret.example`. Se hai già
+una snapshot in `data/snapshots/`, il fetch usa quella e **non** tocca il bucket
+(le credenziali servono solo al primo download su macchina nuova).
+
+> **Nota cron / publisher**: la pubblicazione (full-bake settimanale) usa i GH
+> Actions secrets `SEED_BLOB_S3_*` del repo, non questo file. Vedi § *Secret richiesti*.
+
 ### Force reset
 
 Se hai già un DB non vuoto e vuoi ripartire dallo snapshot, serve il force:
@@ -196,7 +226,7 @@ I 2 workflow leggono `secrets.SEED_BLOB_*` solo quando *pubblicano*. Da configur
 | `SEED_BLOB_S3_SECRET_KEY` | `…` | secret key gemella |
 | `SEED_BLOB_BUCKET` | `meepleai-seed-snapshots` | name del bucket |
 
-Senza i secret, il **bake smoke gira lo stesso** (non pubblica), ma il **full bake fail-fast** allo step `Publish to seed blob bucket` per evitare un cron silenzioso che non muove `latest.txt`.
+Senza i secret, **entrambi** i bake girano lo stesso ma **non pubblicano**: lo step `Publish to seed blob bucket` fa **soft-skip** (warning + step summary, exit 0) e lo snapshot verificato resta scaricabile come **workflow artifact** (90gg). Quando i secret SONO presenti il publish è strict: un errore reale (creds errate, R2 down) fallisce il job. Questo evita sia un cron permanentemente rosso sia il rischio di sovrascrivere `latest.txt` con uno snapshot vuoto (#2516).
 
 ### Cosa succede se il bake fallisce
 

--- a/infra/scripts/snapshot-fetch.sh
+++ b/infra/scripts/snapshot-fetch.sh
@@ -3,6 +3,14 @@
 # Priorità: SNAPSHOT_FILE env > cache locale più recente > download da bucket.
 set -euo pipefail
 
+# Resolve infra/ relative to THIS script, not the cwd. `make dev-from-snapshot`
+# invokes this from infra/, so a hardcoded `infra/secrets/...` resolved to
+# infra/infra/... and the bucket fetch failed on a fresh machine with no local
+# cache — the exact case snapshot distribution exists for (#2516, mirrors the
+# seed-index-publish.sh fix).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INFRA_DIR="$(dirname "$SCRIPT_DIR")"
+
 OUT_DIR="${SEED_INDEX_OUT_DIR:-data/snapshots}"
 mkdir -p "$OUT_DIR"
 
@@ -19,7 +27,7 @@ elif ls "$OUT_DIR"/meepleai_seed_*.meta.json >/dev/null 2>&1; then
 else
     log "nessuna cache locale — download dal bucket"
     # shellcheck disable=SC1091
-    set -a; source infra/secrets/storage.secret; set +a
+    set -a; source "$INFRA_DIR/secrets/storage.secret"; set +a
     : "${SEED_BLOB_BUCKET:?SEED_BLOB_BUCKET mancante}"
     : "${S3_ENDPOINT:?S3_ENDPOINT mancante}"
     : "${S3_ACCESS_KEY:?S3_ACCESS_KEY mancante}"

--- a/infra/secrets/storage.secret.example
+++ b/infra/secrets/storage.secret.example
@@ -88,11 +88,26 @@ SEED_BUCKET_ACCESS_KEY='<readonly_access_key>'
 SEED_BUCKET_SECRET_KEY='<readonly_secret_key>'
 
 # ==============================================================================
-# SEED BLOB BUCKET (snapshot publish/fetch)
+# SEED BLOB BUCKET (snapshot publish/fetch) — dedicated bucket
 # ==============================================================================
-# Used by `make seed-index-publish` and `make dev-from-snapshot` to upload/download
-# pg_dump snapshots of pre-indexed RAG data. Can be the same bucket as S3_BUCKET_NAME.
-SEED_BLOB_BUCKET=meepleai-uploads
+# Used by `make dev-from-snapshot` (fetch) and `make seed-index-publish` (publish,
+# normally CI-only) to download/upload pg_dump snapshots of pre-indexed RAG data.
+# Dedicated bucket, isolated from user uploads (#2516).
+SEED_BLOB_BUCKET=meepleai-seed-snapshots
+#
+# CONSUMER NOTE (`make dev-from-snapshot`):
+#   snapshot-fetch.sh reads the snapshot bucket via S3_ENDPOINT + S3_ACCESS_KEY +
+#   S3_SECRET_KEY (above), NOT a separate SEED_BLOB_* key pair. So those S3_*
+#   credentials must have READ access to `meepleai-seed-snapshots`.
+#   Recommended for a pure consumer (no S3 uploads in dev):
+#     - STORAGE_PROVIDER=local   (app stores PDFs on local disk; the S3_* creds
+#                                 are then used ONLY by snapshot-fetch.sh)
+#     - S3_ENDPOINT  = your R2 EU endpoint (https://<account>.eu.r2.cloudflarestorage.com)
+#     - S3_ACCESS_KEY / S3_SECRET_KEY = an R2 token with "Object Read only"
+#                                 scoped to meepleai-seed-snapshots
+#   The publisher (weekly full-bake cron) uses repo GH Actions secrets
+#   SEED_BLOB_S3_ENDPOINT / SEED_BLOB_S3_ACCESS_KEY / SEED_BLOB_S3_SECRET_KEY /
+#   SEED_BLOB_BUCKET — not this file.
 
 # ==============================================================================
 # STORAGE LAYOUT MIGRATION (issue #1314)


### PR DESCRIPTION
## Sommario

Rende `make dev-from-snapshot` realmente consumabile dalla distribuzione R2 (bucket dedicato `meepleai-seed-snapshots`).

- **fix `snapshot-fetch.sh` (13° strato)**: `source infra/secrets/storage.secret` assumeva cwd=repo-root, ma è invocato da `infra/` → `infra/infra/...` → il fetch dal bucket falliva **solo su macchina fresca senza cache locale** (cioè proprio il caso d'uso della distribuzione). Risolto cwd-agnostico via `BASH_SOURCE` (mirror del fix #2539 sul publish). `bash -n` OK.
- **`storage.secret.example`**: `SEED_BLOB_BUCKET` → `meepleai-seed-snapshots` + guida credenziali consumer (snapshot-fetch usa le `S3_*` per leggere il bucket snapshot → servono read su quel bucket; raccomandato `STORAGE_PROVIDER=local` + token readonly scoped).
- **`snapshot-seed-workflow.md`**: nuova sezione "Credenziali consumer" + corretta la descrizione del publish step (soft-skip, non più fail-fast, post #2525).

Refs #2480 (lato consumer della distribuzione R2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)