### PR TITLE
feat(ci): #2480 wire rag-smoke to fetch R2 snapshot + snapshot admin auth

### DIFF
--- a/.github/workflows/rag-smoke-dispatch.yml
+++ b/.github/workflows/rag-smoke-dispatch.yml
@@ -8,13 +8,14 @@ name: RAG Smoke (canonical queries vs golden baseline)
 # retrieval regressions (embedding model / chunker / index drift) that the bake
 # smoke does not cover.
 #
-# ⚠️ DISPATCH-ONLY (no cron) until snapshot distribution over R2 is fixed:
-#   `dev-from-snapshot` calls snapshot-fetch.sh which downloads the .dump from the
-#   seed blob bucket. That publish path is broken (SEED_BLOB_* repo secrets are not
-#   configured + R2 PUT is broken, #2271), so a scheduled run would fail at fetch.
-#   The golden baseline is captured locally (see docs/.../rag-smoke-runbook.md).
-#   Flip to a weekly `schedule:` once snapshot publish works AND the golden baseline
-#   has been committed for the published snapshot.
+# ⚠️ DISPATCH-ONLY (no cron) until the golden baseline is committed:
+#   R2 snapshot distribution now WORKS (#2516): the dedicated meepleai-seed-snapshots
+#   bucket + SEED_BLOB_* repo secrets are configured, and dev-from-snapshot fetches
+#   the published snapshot via the read creds synthesized in "Configure snapshot
+#   bucket read credentials" below. The only remaining step before the weekly
+#   schedule is committing the golden baseline for the published snapshot: dispatch
+#   with update_baseline=true, download the artifact, and commit
+#   infra/fixtures/rag-golden-baseline.json. Flip to `schedule:` in that same PR.
 
 on:
   workflow_dispatch:
@@ -71,12 +72,35 @@ jobs:
           STORAGE_PROVIDER=local
           APIENV
 
+      - name: Configure snapshot bucket read credentials
+        working-directory: infra
+        env:
+          SEED_BLOB_S3_ENDPOINT: ${{ secrets.SEED_BLOB_S3_ENDPOINT }}
+          SEED_BLOB_S3_ACCESS_KEY: ${{ secrets.SEED_BLOB_S3_ACCESS_KEY }}
+          SEED_BLOB_S3_SECRET_KEY: ${{ secrets.SEED_BLOB_S3_SECRET_KEY }}
+          SEED_BLOB_BUCKET: ${{ secrets.SEED_BLOB_BUCKET }}
+        run: |
+          # snapshot-fetch.sh reads the snapshot bucket via S3_ENDPOINT/S3_ACCESS_KEY/
+          # S3_SECRET_KEY + SEED_BLOB_BUCKET from storage.secret. Map the dedicated
+          # SEED_BLOB_* repo secrets onto those keys (overwriting the make secrets-setup
+          # placeholder). STORAGE_PROVIDER=local so the app uses disk — RAG retrieval
+          # reads the restored DB index, not blob storage. #2480.
+          : "${SEED_BLOB_S3_ENDPOINT:?SEED_BLOB_S3_ENDPOINT secret not configured}"
+          cat > secrets/storage.secret <<EOF
+          STORAGE_PROVIDER=local
+          S3_ENDPOINT=${SEED_BLOB_S3_ENDPOINT}
+          S3_ACCESS_KEY=${SEED_BLOB_S3_ACCESS_KEY}
+          S3_SECRET_KEY=${SEED_BLOB_S3_SECRET_KEY}
+          S3_REGION=auto
+          SEED_BLOB_BUCKET=${SEED_BLOB_BUCKET}
+          EOF
+          chmod 600 secrets/storage.secret
+
       - name: Boot from published snapshot
         working-directory: infra
         run: |
-          # Requires the seed snapshot to be fetchable from R2 (snapshot-fetch.sh).
-          # Until SEED_BLOB_* + publish are configured this step fails fast with a
-          # clear message; that is expected and is why the workflow is dispatch-only.
+          # Fetches the latest snapshot from R2 (snapshot-fetch.sh) using the read
+          # creds synthesized above, restores it, and brings up the AI stack.
           make dev-from-snapshot
           bash scripts/wait-for-healthy.sh api 300
 
@@ -85,8 +109,11 @@ jobs:
         working-directory: infra
         env:
           API_BASE_URL: http://localhost:8080
-          SMOKE_EMAIL: ${{ secrets.SMOKE_USER_EMAIL }}
-          SMOKE_PASSWORD: ${{ secrets.SMOKE_USER_PASSWORD }}
+          # The published snapshot is baked with the INITIAL_ADMIN user (same creds
+          # as the bake workflows). Auth as that user — SMOKE_USER_* secrets don't
+          # exist and wouldn't be present in the snapshot DB anyway. #2480.
+          SMOKE_EMAIL: bake-admin@meepleai.test
+          SMOKE_PASSWORD: BakeSeed1!Admin
         run: |
           if [ "${{ github.event.inputs.update_baseline }}" = "true" ]; then
             bash scripts/rag-smoke-assert.sh --update-baseline


### PR DESCRIPTION
## Sommario

Prerequisito per catturare la golden baseline RAG ora che la distribuzione R2 funziona (#2516).

- **Step "Configure snapshot bucket read credentials"**: sintetizza `storage.secret` dai repo secret `SEED_BLOB_*` (mappati sulle key `S3_*` che `snapshot-fetch.sh` legge) + `STORAGE_PROVIDER=local`, così `make dev-from-snapshot` scarica lo snapshot pubblicato da `meepleai-seed-snapshots`.
- **Auth smoke** come utente `INITIAL_ADMIN` presente nello snapshot (`bake-admin@meepleai.test`) invece dei `SMOKE_USER_*` inesistenti.
- **Header aggiornato**: R2 funziona; unico gate residuo prima del cron = committare la golden baseline.

Resta dispatch-only — il flip a cron arriverà nella PR che committa la baseline (subito dopo la cattura via `update_baseline=true`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)