### PR TITLE
fix(seed): key snapshot-fetch cache on .dump, not committed .meta.json

### DIFF
--- a/infra/scripts/snapshot-fetch.sh
+++ b/infra/scripts/snapshot-fetch.sh
@@ -21,8 +21,13 @@ if [ -n "${SNAPSHOT_FILE:-}" ]; then
     [ -f "$SNAPSHOT_FILE" ] || fail "SNAPSHOT_FILE non esiste: $SNAPSHOT_FILE"
     BASENAME=$(basename "$SNAPSHOT_FILE" .dump)
     log "override esplicito: $BASENAME"
-elif ls "$OUT_DIR"/meepleai_seed_*.meta.json >/dev/null 2>&1; then
-    BASENAME=$(ls -t "$OUT_DIR"/meepleai_seed_*.meta.json | head -1 | xargs basename | sed 's/\.meta\.json$//')
+elif ls "$OUT_DIR"/meepleai_seed_*.dump >/dev/null 2>&1; then
+    # Cache hit keys on the .dump (the heavy, gitignored data artifact), NOT the
+    # .meta.json. The .meta.json files are committed as a historical log, so a
+    # fresh git checkout always has them but WITHOUT their .dump — keying on
+    # .meta.json made dev-from-snapshot pick a basename with no data and skip the
+    # R2 download entirely, then fail at restore (#2480).
+    BASENAME=$(ls -t "$OUT_DIR"/meepleai_seed_*.dump | head -1 | xargs basename | sed 's/\.dump$//')
     log "cache locale: $BASENAME"
 else
     log "nessuna cache locale — download dal bucket"


### PR DESCRIPTION
## Sommario

14° strato della distribuzione R2 — emerso catturando la baseline #2480.

`snapshot-fetch.sh` trattava qualunque `meepleai_seed_*.meta.json` locale come cache-hit e **saltava il download da R2**. Ma i `.meta.json` sono committati come log storico, quindi un checkout fresco (CI, o un dev appena fatto `git pull`) li ha **sempre** ma SENZA il `.dump` (gitignored) → fetch sceglieva un basename senza dati, settava `.latest`, e il run falliva al restore.

Osservato nel run di cattura baseline ([28323260972](https://github.com/meepleAi-app/meepleai-monorepo/actions/runs/28323260972)): ha usato il meta committato `20260422..._1e3a1f485` e non ha mai scaricato lo snapshot pubblicato.

## Fix

La cache-hit si basa ora sul **`.dump`** (l'artifact dati reale, gitignored). I `.meta.json` committati non si mascherano più da cache; un bake/fetch locale genuino (`.dump` presente) continua a corto-circuitare il download.

`bash -n` OK. Refs #2480.

🤖 Generated with [Claude Code](https://claude.com/claude-code)