### PR TITLE
feat(ci): #2480 add .NET SDK + dotnet-ef to rag-smoke

### DIFF
--- a/.github/workflows/rag-smoke-dispatch.yml
+++ b/.github/workflows/rag-smoke-dispatch.yml
@@ -96,6 +96,23 @@ jobs:
           EOF
           chmod 600 secrets/storage.secret
 
+      # snapshot-restore.sh applies the working-tree schema via `dotnet ef database
+      # update` on the host before pg_restore --data-only, so the consume flow needs
+      # the .NET SDK + dotnet-ef tool present (#2480).
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: Install dotnet-ef tool
+        run: |
+          if dotnet tool list --global | awk '{print $1}' | grep -qx 'dotnet-ef'; then
+            echo "dotnet-ef already installed globally:"; dotnet tool list --global | grep '^dotnet-ef'
+          else
+            dotnet tool install --global dotnet-ef --version 9.*
+          fi
+          echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
+
       - name: Boot from published snapshot
         working-directory: infra
         env:


### PR DESCRIPTION
16° strato: snapshot-restore.sh fa `dotnet ef database update` sull'host prima del pg_restore. Il runner rag-smoke aveva solo jq+docker → restore falliva. Il fetch R2 ora funziona (questo run ha scaricato il 133-game da R2 — distribuzione consumabile provata). Aggiunto setup .NET 9 + dotnet-ef (mirror deploy-staging). Refs #2480.