### PR TITLE
feat(session-live): #2501 SP0 — TrackingSessionId + companion saga (atomic)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/LiveSessions/CreateLiveSessionCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/LiveSessions/CreateLiveSessionCommandHandler.cs
@@ -1,4 +1,5 @@
 using Api.BoundedContexts.GameManagement.Application.Commands.LiveSessions;
+using Api.BoundedContexts.GameManagement.Application.Services;
 using Api.BoundedContexts.GameManagement.Domain.Entities;
 using Api.BoundedContexts.GameManagement.Domain.Repositories;
 using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
@@ -16,15 +17,18 @@ internal class CreateLiveSessionCommandHandler : ICommandHandler<CreateLiveSessi
     private readonly ILiveSessionRepository _sessionRepository;
     private readonly TimeProvider _timeProvider;
     private readonly IUnitOfWork _unitOfWork;
+    private readonly ICompanionSessionService _companionSessionService;
 
     public CreateLiveSessionCommandHandler(
         ILiveSessionRepository sessionRepository,
         TimeProvider timeProvider,
-        IUnitOfWork unitOfWork)
+        IUnitOfWork unitOfWork,
+        ICompanionSessionService companionSessionService)
     {
         _sessionRepository = sessionRepository ?? throw new ArgumentNullException(nameof(sessionRepository));
         _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
         _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+        _companionSessionService = companionSessionService ?? throw new ArgumentNullException(nameof(companionSessionService));
     }
 
     public async Task<Guid> Handle(CreateLiveSessionCommand command, CancellationToken cancellationToken)
@@ -43,6 +47,18 @@ internal class CreateLiveSessionCommandHandler : ICommandHandler<CreateLiveSessi
             scoringConfig = SessionScoringConfig.CreateDefault();
         }
 
+        // ADR-083 SP0: create the SessionTracking.Session companion at-creation (Saga).
+        // Add-only (no SaveChanges here): the single SaveChangesAsync below commits the
+        // companion and the LiveGameSession atomically in one EF transaction — a companion
+        // failure rolls back the LiveGameSession, so no orphan is ever persisted.
+        Guid? trackingSessionId = null;
+        if (command.GameId.HasValue)
+        {
+            trackingSessionId = await _companionSessionService
+                .CreateCompanionAsync(command.UserId, command.GameId.Value, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
         var session = LiveGameSession.Create(
             Guid.NewGuid(),
             command.UserId,
@@ -52,7 +68,8 @@ internal class CreateLiveSessionCommandHandler : ICommandHandler<CreateLiveSessi
             command.Visibility,
             command.GroupId,
             scoringConfig,
-            command.AgentMode);
+            command.AgentMode,
+            trackingSessionId: trackingSessionId);
 
         await _sessionRepository.AddAsync(session, cancellationToken).ConfigureAwait(false);
         await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Services/ICompanionSessionService.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Services/ICompanionSessionService.cs
@@ -1,0 +1,15 @@
+namespace Api.BoundedContexts.GameManagement.Application.Services;
+
+/// <summary>
+/// Anti-corruption boundary (ADR-083 SP0): GameManagement creates a SessionTracking.Session
+/// companion at-creation without referencing SessionTracking types in its Application layer.
+/// The companion's id becomes LiveGameSession.TrackingSessionId (cross-BC correlation bridge).
+/// </summary>
+public interface ICompanionSessionService
+{
+    /// <summary>
+    /// Adds (no SaveChanges) a companion Session and returns its id.
+    /// Caller commits it atomically together with the LiveGameSession via IUnitOfWork.
+    /// </summary>
+    Task<Guid> CreateCompanionAsync(Guid userId, Guid gameId, CancellationToken ct);
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/LiveGameSession.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/LiveGameSession.cs
@@ -64,6 +64,13 @@ internal sealed class LiveGameSession : AggregateRoot<Guid>
     public AgentSessionMode AgentMode { get; private set; }
     public Guid? ChatSessionId { get; private set; }
     public TurnAdvancePolicy TurnAdvancePolicy { get; private set; }
+    /// <summary>
+    /// Id of the SessionTracking.Session companion created at-creation (Saga, ADR-083 SP0).
+    /// Non-null for new sessions created with a catalog GameId; null for legacy rows and
+    /// free-form sessions without a GameId (backfill tracked as OQ#5 follow-up).
+    /// This is the real cross-BC correlation bridge (replaces the dead-code ChatSessionId).
+    /// </summary>
+    public Guid? TrackingSessionId { get; private set; }
     public uint Xmin { get; private set; }
 
     // === Read-only collections ===
@@ -98,7 +105,8 @@ internal sealed class LiveGameSession : AggregateRoot<Guid>
         Guid? groupId = null,
         SessionScoringConfig? scoringConfig = null,
         AgentSessionMode agentMode = AgentSessionMode.None,
-        TurnAdvancePolicy turnAdvancePolicy = TurnAdvancePolicy.Manual)
+        TurnAdvancePolicy turnAdvancePolicy = TurnAdvancePolicy.Manual,
+        Guid? trackingSessionId = null)
     {
         if (id == Guid.Empty)
             throw new ValidationException("Session ID cannot be empty");
@@ -134,7 +142,8 @@ internal sealed class LiveGameSession : AggregateRoot<Guid>
             CurrentTurnIndex = 0,
             ScoringConfig = scoringConfig ?? SessionScoringConfig.CreateDefault(),
             AgentMode = agentMode,
-            TurnAdvancePolicy = turnAdvancePolicy
+            TurnAdvancePolicy = turnAdvancePolicy,
+            TrackingSessionId = trackingSessionId
         };
 
         session.AddDomainEvent(new LiveSessionCreatedEvent(id, createdByUserId, trimmedName, gameId));
@@ -175,6 +184,7 @@ internal sealed class LiveGameSession : AggregateRoot<Guid>
         AgentSessionMode agentMode,
         Guid? chatSessionId,
         TurnAdvancePolicy turnAdvancePolicy,
+        Guid? trackingSessionId,
         uint xmin,
         IEnumerable<LiveSessionPlayer> players,
         IEnumerable<LiveSessionTeam> teams,
@@ -212,6 +222,7 @@ internal sealed class LiveGameSession : AggregateRoot<Guid>
             AgentMode = agentMode,
             ChatSessionId = chatSessionId,
             TurnAdvancePolicy = turnAdvancePolicy,
+            TrackingSessionId = trackingSessionId,
             Xmin = xmin
         };
 

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/DependencyInjection/GameManagementServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/DependencyInjection/GameManagementServiceExtensions.cs
@@ -36,6 +36,8 @@ internal static class GameManagementServiceExtensions
         services.AddScoped<IPlayRecordVersionRepository, PlayRecordVersionRepository>(); // #2437-3: version history + restore
         services.AddScoped<IRuleConflictFaqRepository, RuleConflictFaqRepository>(); // ISSUE-3761: Conflict FAQ
         services.AddScoped<ILiveSessionRepository, LiveSessionRepository>(); // Issue #2097 / ADR-060: EF-backed persistence
+        services.AddScoped<Api.BoundedContexts.GameManagement.Application.Services.ICompanionSessionService,
+            Api.BoundedContexts.GameManagement.Infrastructure.Services.CompanionSessionService>(); // #2501 SP0 ACL companion
         services.AddScoped<IToolStateRepository, ToolStateRepository>(); // Issue #4754: ToolState persistence
         services.AddScoped<ISessionSnapshotRepository, SessionSnapshotRepository>(); // Issue #4755: SessionSnapshot persistence
         services.AddScoped<IPauseSnapshotRepository, PauseSnapshotRepository>(); // Game Night: full-state pause snapshots

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Persistence/Mappers/LiveGameSessionMapper.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Persistence/Mappers/LiveGameSessionMapper.cs
@@ -66,6 +66,7 @@ internal static class LiveGameSessionMapper
             Notes = domain.Notes,
             AgentMode = (int)domain.AgentMode,
             ChatSessionId = domain.ChatSessionId,
+            TrackingSessionId = domain.TrackingSessionId,
             // Xmin is Postgres-system-owned (Issue #2305); EF round-trips it via xid mapping.
             // Mapper passes the current domain value back so EF emits WHERE xmin = @original.
             Xmin = domain.Xmin
@@ -263,6 +264,7 @@ internal static class LiveGameSessionMapper
             agentMode: (AgentSessionMode)entity.AgentMode,
             chatSessionId: entity.ChatSessionId,
             turnAdvancePolicy: (TurnAdvancePolicy)entity.TurnAdvancePolicy,
+            trackingSessionId: entity.TrackingSessionId,
             xmin: entity.Xmin,
             players: players,
             teams: teams,

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Services/CompanionSessionService.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Services/CompanionSessionService.cs
@@ -1,0 +1,30 @@
+using Api.BoundedContexts.GameManagement.Application.Services;
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+
+namespace Api.BoundedContexts.GameManagement.Infrastructure.Services;
+
+/// <summary>
+/// Infrastructure implementation of the ADR-083 SP0 anti-corruption layer.
+/// Creates a SessionTracking.Session companion at-creation of a LiveGameSession.
+/// The coupling to SessionTracking types lives exclusively in this Infrastructure class
+/// so the Application layer (ICompanionSessionService) stays free of cross-BC references.
+/// Issue #2501 SP0.
+/// </summary>
+internal sealed class CompanionSessionService : ICompanionSessionService
+{
+    private readonly ISessionRepository _sessionRepository;
+
+    public CompanionSessionService(ISessionRepository sessionRepository)
+    {
+        _sessionRepository = sessionRepository ?? throw new ArgumentNullException(nameof(sessionRepository));
+    }
+
+    /// <inheritdoc />
+    public async Task<Guid> CreateCompanionAsync(Guid userId, Guid gameId, CancellationToken ct)
+    {
+        var companion = Session.Create(userId, gameId, SessionType.GameSpecific);
+        await _sessionRepository.AddAsync(companion, ct).ConfigureAwait(false);
+        return companion.Id;
+    }
+}

--- a/apps/api/src/Api/Infrastructure/Configurations/GameManagement/LiveGameSessionEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/Configurations/GameManagement/LiveGameSessionEntityConfiguration.cs
@@ -110,6 +110,9 @@ internal sealed class LiveGameSessionEntityConfiguration : IEntityTypeConfigurat
         builder.Property(e => e.ChatSessionId)
             .HasColumnName("chat_session_id");
 
+        builder.Property(e => e.TrackingSessionId)
+            .HasColumnName("tracking_session_id");
+
         // --- JSON Columns ---
 
         builder.Property(e => e.ScoringConfigJson)

--- a/apps/api/src/Api/Infrastructure/Entities/GameManagement/LiveGameSessionEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/GameManagement/LiveGameSessionEntity.cs
@@ -64,6 +64,9 @@ public class LiveGameSessionEntity
     public int AgentMode { get; set; } // AgentSessionMode enum: 0=None,1=Assistant,2=GameMaster
     public Guid? ChatSessionId { get; set; }
 
+    // ADR-083 SP0: id of the SessionTracking.Session companion (cross-BC correlation bridge).
+    public Guid? TrackingSessionId { get; set; }
+
     // Optimistic concurrency via PostgreSQL's xmin system column (Issue #2305).
     // Postgres assigns xmin = transaction-id-of-last-write per row; EF reads back via the
     // xid type-mapped uint property. Server-owned: NO mapper assignment, NO client default,

--- a/apps/api/src/Api/Infrastructure/Migrations/20260628131953_AddTrackingSessionIdToLiveGameSession.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260628131953_AddTrackingSessionIdToLiveGameSession.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260628131953_AddTrackingSessionIdToLiveGameSession")]
+    partial class AddTrackingSessionIdToLiveGameSession
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260628131953_AddTrackingSessionIdToLiveGameSession.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260628131953_AddTrackingSessionIdToLiveGameSession.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTrackingSessionIdToLiveGameSession : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "tracking_session_id",
+                table: "live_game_sessions",
+                type: "uuid",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "tracking_session_id",
+                table: "live_game_sessions");
+        }
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Commands/LiveSessions/CreateLiveSessionCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Commands/LiveSessions/CreateLiveSessionCommandHandlerTests.cs
@@ -1,0 +1,89 @@
+using Api.BoundedContexts.GameManagement.Application.Commands.LiveSessions;
+using Api.BoundedContexts.GameManagement.Application.Services;
+using Api.BoundedContexts.GameManagement.Domain.Entities;
+using Api.BoundedContexts.GameManagement.Domain.Repositories;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Tests.Constants;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Application.Commands.LiveSessions;
+
+/// <summary>
+/// Unit tests for <see cref="CreateLiveSessionCommandHandler"/> companion-saga wiring (ADR-083 SP0).
+///
+/// Verifies the atomic Saga contract introduced in Issue #2501 SP0:
+///   - When <c>command.GameId</c> is present, the handler creates a SessionTracking.Session
+///     companion via <see cref="ICompanionSessionService"/> BEFORE building the LiveGameSession,
+///     populates <c>LiveGameSession.TrackingSessionId</c> with the companion id, and commits both
+///     aggregates in a single <see cref="IUnitOfWork.SaveChangesAsync"/> (one EF transaction →
+///     no orphan LiveGameSession is ever persisted if the companion insert fails).
+///   - When <c>command.GameId</c> is null, no companion is created and TrackingSessionId stays null.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "GameManagement")]
+public sealed class CreateLiveSessionCommandHandlerTests
+{
+    [Fact]
+    public async Task Handle_WhenCompanionFails_DoesNotPersistLiveSession()
+    {
+        var sessionRepo = new Mock<ILiveSessionRepository>();
+        var uow = new Mock<IUnitOfWork>();
+        var companion = new Mock<ICompanionSessionService>();
+        companion.Setup(c => c.CreateCompanionAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("companion insert failed"));
+
+        var sut = new CreateLiveSessionCommandHandler(sessionRepo.Object, TimeProvider.System, uow.Object, companion.Object);
+        var cmd = new CreateLiveSessionCommand(UserId: Guid.NewGuid(), GameName: "Mage Knight", GameId: Guid.NewGuid());
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => sut.Handle(cmd, CancellationToken.None));
+
+        sessionRepo.Verify(r => r.AddAsync(It.IsAny<LiveGameSession>(), It.IsAny<CancellationToken>()), Times.Never);
+        uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_WithGameId_SetsTrackingSessionIdToCompanionId()
+    {
+        var trackingId = Guid.NewGuid();
+        LiveGameSession? added = null;
+        var sessionRepo = new Mock<ILiveSessionRepository>();
+        sessionRepo.Setup(r => r.AddAsync(It.IsAny<LiveGameSession>(), It.IsAny<CancellationToken>()))
+            .Callback<LiveGameSession, CancellationToken>((s, _) => added = s)
+            .Returns(Task.CompletedTask);
+        var uow = new Mock<IUnitOfWork>();
+        var companion = new Mock<ICompanionSessionService>();
+        companion.Setup(c => c.CreateCompanionAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(trackingId);
+
+        var sut = new CreateLiveSessionCommandHandler(sessionRepo.Object, TimeProvider.System, uow.Object, companion.Object);
+        var cmd = new CreateLiveSessionCommand(UserId: Guid.NewGuid(), GameName: "Mage Knight", GameId: Guid.NewGuid());
+
+        await sut.Handle(cmd, CancellationToken.None);
+
+        Assert.NotNull(added);
+        Assert.Equal(trackingId, added!.TrackingSessionId);
+        uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WithoutGameId_DoesNotCreateCompanion()
+    {
+        LiveGameSession? added = null;
+        var sessionRepo = new Mock<ILiveSessionRepository>();
+        sessionRepo.Setup(r => r.AddAsync(It.IsAny<LiveGameSession>(), It.IsAny<CancellationToken>()))
+            .Callback<LiveGameSession, CancellationToken>((s, _) => added = s)
+            .Returns(Task.CompletedTask);
+        var uow = new Mock<IUnitOfWork>();
+        var companion = new Mock<ICompanionSessionService>();
+
+        var sut = new CreateLiveSessionCommandHandler(sessionRepo.Object, TimeProvider.System, uow.Object, companion.Object);
+        var cmd = new CreateLiveSessionCommand(UserId: Guid.NewGuid(), GameName: "Free session", GameId: null);
+
+        await sut.Handle(cmd, CancellationToken.None);
+
+        Assert.NotNull(added);
+        Assert.Null(added!.TrackingSessionId);
+        companion.Verify(c => c.CreateCompanionAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/LiveSessions/LiveSessionCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/LiveSessions/LiveSessionCommandHandlerTests.cs
@@ -1,4 +1,5 @@
 using Api.BoundedContexts.GameManagement.Application.Commands.LiveSessions;
+using Api.BoundedContexts.GameManagement.Application.Services;
 using Api.BoundedContexts.GameManagement.Domain.Entities;
 using Api.BoundedContexts.GameManagement.Domain.Enums;
 using Api.BoundedContexts.GameManagement.Domain.Repositories;
@@ -23,6 +24,11 @@ public class LiveSessionCommandHandlerTests
     private readonly Mock<ILiveSessionRepository> _repositoryMock;
     private readonly TimeProvider _timeProvider;
     private readonly Mock<IUnitOfWork> _unitOfWorkMock;
+    // #2501 SP0: companion-saga ACL dependency. Default mock returns Guid.Empty for
+    // CreateCompanionAsync, which is harmless for these existing assertions (they verify
+    // AddAsync/captured properties, not TrackingSessionId). Companion behavior itself is
+    // covered by CreateLiveSessionCommandHandlerTests (dedicated saga unit tests).
+    private readonly Mock<ICompanionSessionService> _companionSessionServiceMock;
 
     private static readonly Guid DefaultUserId = Guid.NewGuid();
 
@@ -31,6 +37,7 @@ public class LiveSessionCommandHandlerTests
         _repositoryMock = new Mock<ILiveSessionRepository>();
         _timeProvider = TimeProvider.System;
         _unitOfWorkMock = new Mock<IUnitOfWork>();
+        _companionSessionServiceMock = new Mock<ICompanionSessionService>();
     }
 
     // === Shared Helpers ===
@@ -97,7 +104,7 @@ public class LiveSessionCommandHandlerTests
     public async Task CreateLiveSession_HappyPath_DefaultConfig_ReturnsSessionId()
     {
         // Arrange
-        var handler = new CreateLiveSessionCommandHandler(_repositoryMock.Object, _timeProvider, _unitOfWorkMock.Object);
+        var handler = new CreateLiveSessionCommandHandler(_repositoryMock.Object, _timeProvider, _unitOfWorkMock.Object, _companionSessionServiceMock.Object);
         var command = new CreateLiveSessionCommand(DefaultUserId, "Catan");
 
         // Act
@@ -118,7 +125,7 @@ public class LiveSessionCommandHandlerTests
     public async Task CreateLiveSession_HappyPath_CustomScoring_ReturnsSessionId()
     {
         // Arrange
-        var handler = new CreateLiveSessionCommandHandler(_repositoryMock.Object, _timeProvider, _unitOfWorkMock.Object);
+        var handler = new CreateLiveSessionCommandHandler(_repositoryMock.Object, _timeProvider, _unitOfWorkMock.Object, _companionSessionServiceMock.Object);
         var scoringDimensions = new List<string> { "Points", "Bonus" };
         var dimensionUnits = new Dictionary<string, string> { { "Points", "pts" }, { "Bonus", "pts" } };
         var command = new CreateLiveSessionCommand(
@@ -142,7 +149,7 @@ public class LiveSessionCommandHandlerTests
     public async Task CreateLiveSession_NullCommand_ThrowsArgumentNullException()
     {
         // Arrange
-        var handler = new CreateLiveSessionCommandHandler(_repositoryMock.Object, _timeProvider, _unitOfWorkMock.Object);
+        var handler = new CreateLiveSessionCommandHandler(_repositoryMock.Object, _timeProvider, _unitOfWorkMock.Object, _companionSessionServiceMock.Object);
 
         // Act & Assert
         var act =
@@ -154,7 +161,7 @@ public class LiveSessionCommandHandlerTests
     public async Task CreateLiveSession_VerifiesAddAsyncCalled()
     {
         // Arrange
-        var handler = new CreateLiveSessionCommandHandler(_repositoryMock.Object, _timeProvider, _unitOfWorkMock.Object);
+        var handler = new CreateLiveSessionCommandHandler(_repositoryMock.Object, _timeProvider, _unitOfWorkMock.Object, _companionSessionServiceMock.Object);
         var command = new CreateLiveSessionCommand(DefaultUserId, "Ticket to Ride");
 
         LiveGameSession? capturedSession = null;
@@ -177,7 +184,7 @@ public class LiveSessionCommandHandlerTests
     public async Task CreateLiveSession_WithAllOptionalParams_CreatesCorrectly()
     {
         // Arrange
-        var handler = new CreateLiveSessionCommandHandler(_repositoryMock.Object, _timeProvider, _unitOfWorkMock.Object);
+        var handler = new CreateLiveSessionCommandHandler(_repositoryMock.Object, _timeProvider, _unitOfWorkMock.Object, _companionSessionServiceMock.Object);
         var gameId = Guid.NewGuid();
         var groupId = Guid.NewGuid();
         var command = new CreateLiveSessionCommand(
@@ -1146,7 +1153,7 @@ public class LiveSessionCommandHandlerTests
     public async Task CreateLiveSession_PassesCancellationTokenToRepository()
     {
         // Arrange
-        var handler = new CreateLiveSessionCommandHandler(_repositoryMock.Object, _timeProvider, _unitOfWorkMock.Object);
+        var handler = new CreateLiveSessionCommandHandler(_repositoryMock.Object, _timeProvider, _unitOfWorkMock.Object, _companionSessionServiceMock.Object);
         var command = new CreateLiveSessionCommand(DefaultUserId, "Token Test Game");
         using var cts = new CancellationTokenSource();
         var ct = cts.Token;

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/Entities/LiveGameSessionCreateTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/Entities/LiveGameSessionCreateTests.cs
@@ -1,0 +1,37 @@
+using Api.BoundedContexts.GameManagement.Domain.Entities;
+using Api.Tests.Constants;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Domain.Entities;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "GameManagement")]
+public class LiveGameSessionCreateTests
+{
+    [Fact]
+    public void Create_WithTrackingSessionId_SetsProperty()
+    {
+        var trackingId = Guid.NewGuid();
+        var session = LiveGameSession.Create(
+            id: Guid.NewGuid(),
+            createdByUserId: Guid.NewGuid(),
+            gameName: "Mage Knight",
+            timeProvider: TimeProvider.System,
+            gameId: Guid.NewGuid(),
+            trackingSessionId: trackingId);
+
+        Assert.Equal(trackingId, session.TrackingSessionId);
+    }
+
+    [Fact]
+    public void Create_WithoutTrackingSessionId_LeavesNull()
+    {
+        var session = LiveGameSession.Create(
+            id: Guid.NewGuid(),
+            createdByUserId: Guid.NewGuid(),
+            gameName: "Free session",
+            timeProvider: TimeProvider.System);
+
+        Assert.Null(session.TrackingSessionId);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/Entities/LiveGameSessionReconstituteTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/Entities/LiveGameSessionReconstituteTests.cs
@@ -50,6 +50,7 @@ public class LiveGameSessionReconstituteTests
             agentMode: AgentSessionMode.None,
             chatSessionId: null,
             turnAdvancePolicy: TurnAdvancePolicy.Manual,
+            trackingSessionId: null,
             xmin: 42u,
             players: Array.Empty<LiveSessionPlayer>(),
             teams: Array.Empty<LiveSessionTeam>(),

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Infrastructure/Mappers/LiveGameSessionMapperTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Infrastructure/Mappers/LiveGameSessionMapperTests.cs
@@ -71,4 +71,23 @@ public class LiveGameSessionMapperTests
         // holds — not that the value is non-zero at this point.
         entity.Xmin.Should().Be(session.Xmin);
     }
+
+    [Fact]
+    public void Mapper_RoundTrips_TrackingSessionId()
+    {
+        var trackingId = Guid.NewGuid();
+        var domain = LiveGameSession.Create(
+            id: Guid.NewGuid(),
+            createdByUserId: Guid.NewGuid(),
+            gameName: "Mage Knight",
+            timeProvider: TimeProvider.System,
+            gameId: Guid.NewGuid(),
+            trackingSessionId: trackingId);
+
+        var entity = LiveGameSessionMapper.ToEntity(domain);
+        entity.TrackingSessionId.Should().Be(trackingId);
+
+        var back = LiveGameSessionMapper.ToDomain(entity);
+        back.TrackingSessionId.Should().Be(trackingId);
+    }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Infrastructure/Services/CompanionSessionServiceTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Infrastructure/Services/CompanionSessionServiceTests.cs
@@ -14,6 +14,7 @@ namespace Api.Tests.BoundedContexts.GameManagement.Infrastructure.Services;
 /// Issue #2501 SP0.
 /// </summary>
 [Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "GameManagement")]
 public class CompanionSessionServiceTests
 {
     [Fact]

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Infrastructure/Services/CompanionSessionServiceTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Infrastructure/Services/CompanionSessionServiceTests.cs
@@ -1,0 +1,40 @@
+using Api.BoundedContexts.GameManagement.Infrastructure.Services;
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using Api.Tests.Constants;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Infrastructure.Services;
+
+/// <summary>
+/// Unit tests for CompanionSessionService (ADR-083 SP0 anti-corruption layer).
+/// Verifies that CreateCompanionAsync adds a Session companion via ISessionRepository
+/// and returns its Id, without calling SaveChanges (that is the caller's responsibility).
+/// Issue #2501 SP0.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+public class CompanionSessionServiceTests
+{
+    [Fact]
+    public async Task CreateCompanionAsync_AddsSession_AndReturnsItsId()
+    {
+        var repo = new Mock<ISessionRepository>();
+        Session? captured = null;
+        repo.Setup(r => r.AddAsync(It.IsAny<Session>(), It.IsAny<CancellationToken>()))
+            .Callback<Session, CancellationToken>((s, _) => captured = s)
+            .Returns(Task.CompletedTask);
+
+        var sut = new CompanionSessionService(repo.Object);
+        var userId = Guid.NewGuid();
+        var gameId = Guid.NewGuid();
+
+        var trackingId = await sut.CreateCompanionAsync(userId, gameId, CancellationToken.None);
+
+        Assert.NotNull(captured);
+        Assert.Equal(captured!.Id, trackingId);
+        Assert.Equal(userId, captured.UserId);
+        Assert.Equal(gameId, captured.GameId);
+        repo.Verify(r => r.AddAsync(It.IsAny<Session>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/apps/api/tests/Api.Tests/Integration/GameManagement/CreateLiveSessionCompanionIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/GameManagement/CreateLiveSessionCompanionIntegrationTests.cs
@@ -1,0 +1,143 @@
+using Api.BoundedContexts.GameManagement.Application.Commands.LiveSessions;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using MediatR;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.Integration.GameManagement;
+
+/// <summary>
+/// Integration test for the ADR-083 SP0 companion Saga wired into
+/// <see cref="CreateLiveSessionCommandHandler"/> (Issue #2501 SP0).
+///
+/// Proves the happy path end-to-end against a real PostgreSQL (Testcontainers):
+/// creating a live session with a catalog GameId persists BOTH the LiveGameSession
+/// (with a non-null TrackingSessionId) AND a companion SessionTracking.Session whose
+/// Id equals that TrackingSessionId — committed atomically in one EF transaction.
+///
+/// The companion Session FKs both <c>users</c> and <c>shared_games</c> (Restrict), so the
+/// test seeds a user and a shared game before sending the command.
+/// </summary>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "GameManagement")]
+public sealed class CreateLiveSessionCompanionIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly string _databaseName = $"create_live_companion_{Guid.NewGuid():N}";
+    private WebApplicationFactory<Program> _factory = null!;
+
+    public CreateLiveSessionCompanionIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+        await TestcontainersWaitHelpers.WaitForPostgresReadyAsync(connectionString);
+
+        _factory = IntegrationWebApplicationFactory.Create(connectionString);
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        db.Database.Migrate();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_factory != null)
+        {
+            await _factory.DisposeAsync();
+        }
+
+        await _fixture.DropIsolatedDatabaseAsync(_databaseName);
+    }
+
+    [Fact(DisplayName = "Create live session with GameId persists a companion Session atomically and links TrackingSessionId")]
+    public async Task Handle_WithGameId_PersistsCompanion_AndLinksTrackingSessionId()
+    {
+        // Arrange — seed a user + a shared game (both FK targets of the companion Session)
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        var userId = await SeedUserAsync(db);
+        var gameId = await SeedSharedGameAsync(db);
+
+        // Act — create the live session linked to the catalog game
+        var liveId = await mediator.Send(new CreateLiveSessionCommand(
+            UserId: userId,
+            GameName: "Mage Knight",
+            GameId: gameId));
+
+        // Assert — LiveGameSession persisted with a non-null TrackingSessionId
+        var live = await db.LiveGameSessions
+            .AsNoTracking()
+            .SingleAsync(s => s.Id == liveId);
+
+        live.TrackingSessionId.Should().NotBeNull(
+            "creating a live session with a catalog GameId must populate the companion id");
+
+        // Assert — a companion SessionTracking.Session row exists with that exact id (atomic commit)
+        var companionExists = await db.SessionTrackingSessions
+            .AsNoTracking()
+            .AnyAsync(s => s.Id == live.TrackingSessionId);
+
+        companionExists.Should().BeTrue(
+            "the companion Session and the LiveGameSession must be committed together in one transaction");
+    }
+
+    /// <summary>
+    /// Seeds a minimal user entity required by CreateLiveSessionCommand and the companion Session FK.
+    /// </summary>
+    private static async Task<Guid> SeedUserAsync(MeepleAiDbContext db)
+    {
+        var userId = Guid.NewGuid();
+        db.Users.Add(new UserEntity
+        {
+            Id = userId,
+            Email = $"test-{userId:N}@companion-test.local",
+            DisplayName = "Companion Test User",
+            PasswordHash = "not-a-real-hash",
+            Role = "user",
+            Tier = "free",
+            Status = "Active",
+            CreatedAt = DateTime.UtcNow
+        });
+        await db.SaveChangesAsync();
+        return userId;
+    }
+
+    /// <summary>
+    /// Seeds a minimal shared game entity — the companion Session FKs shared_games.id (Restrict).
+    /// </summary>
+    private static async Task<Guid> SeedSharedGameAsync(MeepleAiDbContext db)
+    {
+        var gameId = Guid.NewGuid();
+        db.SharedGames.Add(new SharedGameEntity
+        {
+            Id = gameId,
+            Title = "Mage Knight",
+            YearPublished = 2011,
+            MinPlayers = 1,
+            MaxPlayers = 4,
+            PlayingTimeMinutes = 240,
+            MinAge = 14,
+            ImageUrl = string.Empty,
+            ThumbnailUrl = string.Empty,
+            Description = string.Empty,
+            CreatedBy = Guid.NewGuid(),
+            CreatedAt = DateTime.UtcNow
+        });
+        await db.SaveChangesAsync();
+        return gameId;
+    }
+}

--- a/docs/superpowers/plans/2026-06-28-issue-2501-sp0-tracking-session-companion.md
+++ b/docs/superpowers/plans/2026-06-28-issue-2501-sp0-tracking-session-companion.md
@@ -1,0 +1,532 @@
+# Epic #2501 SP0 — TrackingSessionId + Session Companion (Saga at-creation) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Garantire che ogni nuova `LiveGameSession` con un gioco catalogato possieda, at-creation e in modo atomico, una `SessionTracking.Session` companion, esponendo il suo id come `TrackingSessionId` — il ponte di correlazione reale per chat/diary/media delle fasi successive (SP2/SP3/SP4).
+
+**Architecture:** `CreateLiveSessionCommandHandler` (GameManagement) chiama un'interfaccia anti-corruption `ICompanionSessionService` (ACL, rispetta l'invariante ADR-083: GameManagement→SessionTracking unidirezionale via interfaccia dedicata) che crea una `Session` companion via `ISessionRepository.AddAsync` **senza** SaveChanges proprio. L'handler crea poi la `LiveGameSession` con `trackingSessionId = companion.Id` e committa **entrambi gli aggregati in un solo `IUnitOfWork.SaveChangesAsync`** → atomicità transazionale EF (nessuna `LiveGameSession` orfana). La colonna DB è nullable (legacy + sessioni improvvisate senza GameId restano null; backfill = follow-up OQ#5).
+
+**Tech Stack:** .NET 9, EF Core (PostgreSQL), MediatR (CQRS), xUnit + Testcontainers.
+
+## Global Constraints
+
+- **CQRS**: endpoint usano solo `IMediator.Send()`; handler non vengono iniettati negli endpoint.
+- **DDD**: entity con setter privati + factory; repository interface nel Domain, impl in Infrastructure.
+- **Invariante ADR-083**: `GameManagement` NON importa mai `KnowledgeBase`. `GameManagement → SessionTracking` è ammesso ma SOLO via interfaccia ACL dedicata (no riferimenti diretti ai tipi SessionTracking nell'Application layer di GameManagement; il coupling vive nell'Infrastructure impl dell'ACL).
+- **Atomicità (ADR-060)**: ogni handler che chiama `AddAsync` deve poi chiamare `await _unitOfWork.SaveChangesAsync(ct)`; un solo SaveChanges per Handle.
+- **Concorrenza**: `xmin` Postgres, server-owned, nessuna assegnazione nel mapper.
+- **Eccezioni (#2568)**: `ConflictException`(409)/`NotFoundException`(404), mai `InvalidOperationException`(500) per condizioni note.
+- **Nullable garantito at-creation per nuove sessioni CON GameId**: `TrackingSessionId` è `Guid?` nel dominio/DB (null = legacy/improvvisata); la factory `Create` lo popola sempre quando il chiamante passa un valore; l'handler lo passa sempre quando `command.GameId.HasValue`.
+- **Branch**: `feature/issue-2501-sp0-saga-tracking-session` (parent `main-dev`).
+
+---
+
+### Task 1: Dominio — `TrackingSessionId` su `LiveGameSession`
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/LiveGameSession.cs`
+- Test: collocare accanto ai test dominio esistenti di `LiveGameSession` (cercare con `Glob "**/*LiveGameSession*Test*.cs"` sotto `tests/`; se assenti per la factory, creare `tests/Api.Tests/Unit/GameManagement/LiveGameSessionCreateTests.cs` seguendo il pattern xUnit del progetto).
+
+**Interfaces:**
+- Produces: `LiveGameSession.TrackingSessionId` (`Guid?`, getter pubblico, setter privato); `LiveGameSession.Create(..., Guid? trackingSessionId = null)` nuovo parametro opzionale in coda; `LiveGameSession.Reconstitute(..., Guid? trackingSessionId)` nuovo parametro.
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+[Fact]
+public void Create_WithTrackingSessionId_SetsProperty()
+{
+    var trackingId = Guid.NewGuid();
+    var session = LiveGameSession.Create(
+        id: Guid.NewGuid(),
+        createdByUserId: Guid.NewGuid(),
+        gameName: "Mage Knight",
+        timeProvider: TimeProvider.System,
+        gameId: Guid.NewGuid(),
+        trackingSessionId: trackingId);
+
+    Assert.Equal(trackingId, session.TrackingSessionId);
+}
+
+[Fact]
+public void Create_WithoutTrackingSessionId_LeavesNull()
+{
+    var session = LiveGameSession.Create(
+        id: Guid.NewGuid(),
+        createdByUserId: Guid.NewGuid(),
+        gameName: "Free session",
+        timeProvider: TimeProvider.System);
+
+    Assert.Null(session.TrackingSessionId);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/api/src/Api && dotnet build` then `dotnet test ../../../../tests/Api.Tests --filter "FullyQualifiedName~LiveGameSessionCreateTests"`
+Expected: FAIL — compile error (`trackingSessionId` parameter / `TrackingSessionId` property not defined).
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `LiveGameSession.cs`, add the property next to the other scalar properties (after `ChatSessionId` at line ~65):
+
+```csharp
+    /// <summary>
+    /// Id of the SessionTracking.Session companion created at-creation (Saga, ADR-083 SP0).
+    /// Non-null for new sessions created with a catalog GameId; null for legacy rows and
+    /// free-form sessions without a GameId (backfill tracked as OQ#5 follow-up).
+    /// This is the real cross-BC correlation bridge (replaces the dead-code ChatSessionId).
+    /// </summary>
+    public Guid? TrackingSessionId { get; private set; }
+```
+
+In the `Create` factory signature, add the parameter at the end of the list (after `turnAdvancePolicy`):
+
+```csharp
+        TurnAdvancePolicy turnAdvancePolicy = TurnAdvancePolicy.Manual,
+        Guid? trackingSessionId = null)
+```
+
+In the object initializer inside `Create` (the `new LiveGameSession { ... }` block at line ~122), add:
+
+```csharp
+            TurnAdvancePolicy = turnAdvancePolicy,
+            TrackingSessionId = trackingSessionId
+```
+
+In `Reconstitute`, add the parameter (after `xmin` or near the scalar params) and set it in the reconstituted instance object initializer (the `new LiveGameSession { ... }` block at line ~200 that ends near line 216):
+
+```csharp
+            // signature: add after the existing scalar params, before the collection params
+            Guid? trackingSessionId,
+```
+```csharp
+            // object initializer: alongside ChatSessionId/TurnAdvancePolicy/Xmin
+            TrackingSessionId = trackingSessionId,
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dotnet test ../../../../tests/Api.Tests --filter "FullyQualifiedName~LiveGameSessionCreateTests"`
+Expected: PASS (2 tests). NOTE: this will break `LiveGameSessionMapper.ToDomain` callers of `Reconstitute` — fixed in Task 2; build of the Api project may fail until Task 2. If so, proceed to Task 2 and re-run.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/LiveGameSession.cs tests/Api.Tests
+git commit -m "feat(session-live): #2501 SP0 add TrackingSessionId to LiveGameSession domain"
+```
+
+---
+
+### Task 2: Persistenza — entity, EF config, mapper
+
+**Files:**
+- Modify: `apps/api/src/Api/Infrastructure/Entities/GameManagement/LiveGameSessionEntity.cs`
+- Modify: `apps/api/src/Api/Infrastructure/Configurations/GameManagement/LiveGameSessionEntityConfiguration.cs`
+- Modify: `apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Persistence/Mappers/LiveGameSessionMapper.cs`
+- Test: `tests/Api.Tests` mapper round-trip (cercare un test esistente `LiveGameSessionMapper*Test*.cs` con `Glob`; se esiste, estenderlo; altrimenti aggiungere un unit test round-trip).
+
+**Interfaces:**
+- Consumes: `LiveGameSession.TrackingSessionId` (Task 1).
+- Produces: `LiveGameSessionEntity.TrackingSessionId` (`Guid?`); colonna `tracking_session_id`; mapper round-trip del campo.
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+[Fact]
+public void Mapper_RoundTrips_TrackingSessionId()
+{
+    var trackingId = Guid.NewGuid();
+    var domain = LiveGameSession.Create(
+        id: Guid.NewGuid(),
+        createdByUserId: Guid.NewGuid(),
+        gameName: "Mage Knight",
+        timeProvider: TimeProvider.System,
+        gameId: Guid.NewGuid(),
+        trackingSessionId: trackingId);
+
+    var entity = LiveGameSessionMapper.ToEntity(domain);
+    Assert.Equal(trackingId, entity.TrackingSessionId);
+
+    var back = LiveGameSessionMapper.ToDomain(entity);
+    Assert.Equal(trackingId, back.TrackingSessionId);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test ../../../../tests/Api.Tests --filter "FullyQualifiedName~LiveGameSessionMapper"`
+Expected: FAIL — `LiveGameSessionEntity.TrackingSessionId` not defined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `LiveGameSessionEntity.cs`, after `ChatSessionId` (line ~65):
+
+```csharp
+    // ADR-083 SP0: id of the SessionTracking.Session companion (cross-BC correlation bridge).
+    public Guid? TrackingSessionId { get; set; }
+```
+
+In `LiveGameSessionEntityConfiguration.cs`, after the `ChatSessionId` property mapping (line ~111):
+
+```csharp
+        builder.Property(e => e.TrackingSessionId)
+            .HasColumnName("tracking_session_id");
+```
+
+In `LiveGameSessionMapper.ToEntity`, in the `new LiveGameSessionEntity { ... }` initializer (after `ChatSessionId = domain.ChatSessionId,` at line ~68):
+
+```csharp
+            TrackingSessionId = domain.TrackingSessionId,
+```
+
+In `LiveGameSessionMapper.ToDomain`, in the `Reconstitute(...)` call (after `chatSessionId: entity.ChatSessionId,` at line ~264):
+
+```csharp
+            trackingSessionId: entity.TrackingSessionId,
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/api/src/Api && dotnet build && dotnet test ../../../../tests/Api.Tests --filter "FullyQualifiedName~LiveGameSessionMapper"`
+Expected: PASS. The whole Api project now builds (Reconstitute signature satisfied).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/Api/Infrastructure tests/Api.Tests apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Persistence/Mappers/LiveGameSessionMapper.cs
+git commit -m "feat(session-live): #2501 SP0 persist tracking_session_id (entity+config+mapper)"
+```
+
+---
+
+### Task 3: Migration EF — colonna `tracking_session_id`
+
+**Files:**
+- Create: `apps/api/src/Api/Infrastructure/Migrations/<timestamp>_AddTrackingSessionIdToLiveGameSession.cs` (auto-generata)
+
+**Interfaces:**
+- Consumes: entity/config di Task 2.
+- Produces: colonna nullable `tracking_session_id uuid NULL` su `live_game_sessions`.
+
+- [ ] **Step 1: Generate the migration**
+
+Run: `cd apps/api/src/Api && dotnet ef migrations add AddTrackingSessionIdToLiveGameSession`
+Expected: nuovo file migration generato.
+
+- [ ] **Step 2: Review the generated SQL**
+
+Apri il file migration generato. VERIFICA che `Up()` contenga SOLO:
+```csharp
+migrationBuilder.AddColumn<Guid>(
+    name: "tracking_session_id",
+    table: "live_game_sessions",
+    type: "uuid",
+    nullable: true);
+```
+e `Down()` il `DropColumn` corrispondente. Se la migration include altre modifiche di schema impreviste (drift), FERMARSI e investigare prima di procedere.
+
+- [ ] **Step 3: Apply + verify it builds**
+
+Run: `dotnet build`
+Expected: PASS. (Non serve `database update` qui: i test integration usano Testcontainers che applica le migration automaticamente.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/api/src/Api/Infrastructure/Migrations
+git commit -m "feat(session-live): #2501 SP0 migration add tracking_session_id (nullable)"
+```
+
+---
+
+### Task 4: ACL — `ICompanionSessionService` + impl + DI
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/GameManagement/Application/Abstractions/ICompanionSessionService.cs` (allineare alla cartella di astrazioni già usata in GameManagement Application; se non esiste, `Application/Services/`)
+- Create: `apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Services/CompanionSessionService.cs`
+- Modify: `apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/DependencyInjection/GameManagementServiceExtensions.cs` (registra accanto a `ILiveSessionRepository` alla riga ~38)
+- Test: `tests/Api.Tests/Unit/GameManagement/CompanionSessionServiceTests.cs`
+
+**Interfaces:**
+- Consumes: `Api.BoundedContexts.SessionTracking.Domain.Repositories.ISessionRepository` (ha `Task AddAsync(Session, CancellationToken)`); `Api.BoundedContexts.SessionTracking.Domain.Entities.Session.Create(Guid userId, Guid gameId, SessionType sessionType, string? location = null, DateTime? sessionDate = null)`; `SessionType.GameSpecific`.
+- Produces: `ICompanionSessionService.CreateCompanionAsync(Guid userId, Guid gameId, CancellationToken ct) : Task<Guid>` — crea (Add, NO SaveChanges) la companion e ritorna il suo `Id`.
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+[Fact]
+public async Task CreateCompanionAsync_AddsSession_AndReturnsItsId()
+{
+    var repo = new Mock<Api.BoundedContexts.SessionTracking.Domain.Repositories.ISessionRepository>();
+    Session? captured = null;
+    repo.Setup(r => r.AddAsync(It.IsAny<Session>(), It.IsAny<CancellationToken>()))
+        .Callback<Session, CancellationToken>((s, _) => captured = s)
+        .Returns(Task.CompletedTask);
+
+    var sut = new CompanionSessionService(repo.Object);
+    var userId = Guid.NewGuid();
+    var gameId = Guid.NewGuid();
+
+    var trackingId = await sut.CreateCompanionAsync(userId, gameId, CancellationToken.None);
+
+    Assert.NotNull(captured);
+    Assert.Equal(captured!.Id, trackingId);
+    Assert.Equal(userId, captured.UserId);
+    Assert.Equal(gameId, captured.GameId);
+    repo.Verify(r => r.AddAsync(It.IsAny<Session>(), It.IsAny<CancellationToken>()), Times.Once);
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test ../../../../tests/Api.Tests --filter "FullyQualifiedName~CompanionSessionServiceTests"`
+Expected: FAIL — `CompanionSessionService` / `ICompanionSessionService` not defined.
+
+- [ ] **Step 3: Write minimal implementation**
+
+`ICompanionSessionService.cs`:
+```csharp
+namespace Api.BoundedContexts.GameManagement.Application.Abstractions;
+
+/// <summary>
+/// Anti-corruption boundary (ADR-083 SP0): GameManagement creates a SessionTracking.Session
+/// companion at-creation without referencing SessionTracking types in its Application layer.
+/// The companion's id becomes LiveGameSession.TrackingSessionId.
+/// </summary>
+public interface ICompanionSessionService
+{
+    /// <summary>Adds (no SaveChanges) a companion Session and returns its id.
+    /// Caller commits it atomically together with the LiveGameSession via IUnitOfWork.</summary>
+    Task<Guid> CreateCompanionAsync(Guid userId, Guid gameId, CancellationToken ct);
+}
+```
+
+`CompanionSessionService.cs`:
+```csharp
+using Api.BoundedContexts.GameManagement.Application.Abstractions;
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+
+namespace Api.BoundedContexts.GameManagement.Infrastructure.Services;
+
+internal sealed class CompanionSessionService : ICompanionSessionService
+{
+    private readonly ISessionRepository _sessionRepository;
+
+    public CompanionSessionService(ISessionRepository sessionRepository)
+    {
+        _sessionRepository = sessionRepository ?? throw new ArgumentNullException(nameof(sessionRepository));
+    }
+
+    public async Task<Guid> CreateCompanionAsync(Guid userId, Guid gameId, CancellationToken ct)
+    {
+        var companion = Session.Create(userId, gameId, SessionType.GameSpecific);
+        await _sessionRepository.AddAsync(companion, ct).ConfigureAwait(false);
+        return companion.Id;
+    }
+}
+```
+
+In `GameManagementServiceExtensions.cs` (after line ~38):
+```csharp
+        services.AddScoped<Api.BoundedContexts.GameManagement.Application.Abstractions.ICompanionSessionService,
+            Api.BoundedContexts.GameManagement.Infrastructure.Services.CompanionSessionService>(); // #2501 SP0 ACL companion
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dotnet build && dotnet test ../../../../tests/Api.Tests --filter "FullyQualifiedName~CompanionSessionServiceTests"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/GameManagement tests/Api.Tests
+git commit -m "feat(session-live): #2501 SP0 add ICompanionSessionService ACL + impl + DI"
+```
+
+---
+
+### Task 5: Wire `CreateLiveSessionCommandHandler` — companion atomica
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/LiveSessions/CreateLiveSessionCommandHandler.cs`
+- Test (unit, atomicità): `tests/Api.Tests/Unit/GameManagement/CreateLiveSessionCommandHandlerTests.cs`
+- Test (integration, happy path): collocare accanto ai test integration GameManagement esistenti (cercare con `Glob "tests/**/Integration/**/*.cs"`; usare il pattern Testcontainers + `MeepleAiDbContext` reale già in uso nel progetto). Se non esiste una base integration per LiveSession, creare `tests/Api.Tests/Integration/GameManagement/CreateLiveSessionCompanionIntegrationTests.cs` seguendo un test integration esistente come modello.
+
+**Interfaces:**
+- Consumes: `ICompanionSessionService.CreateCompanionAsync` (Task 4); `LiveGameSession.Create(..., trackingSessionId:)` (Task 1).
+- Produces: handler che, quando `command.GameId.HasValue`, popola `TrackingSessionId` con la companion id e committa entrambi in un solo SaveChanges.
+
+- [ ] **Step 1: Write the failing tests**
+
+Unit (atomicità — companion fallisce → niente commit, niente LiveGameSession aggiunta):
+```csharp
+[Fact]
+public async Task Handle_WhenCompanionFails_DoesNotPersistLiveSession()
+{
+    var sessionRepo = new Mock<ILiveSessionRepository>();
+    var uow = new Mock<IUnitOfWork>();
+    var companion = new Mock<ICompanionSessionService>();
+    companion.Setup(c => c.CreateCompanionAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+        .ThrowsAsync(new InvalidOperationException("companion insert failed"));
+
+    var sut = new CreateLiveSessionCommandHandler(sessionRepo.Object, TimeProvider.System, uow.Object, companion.Object);
+    var cmd = new CreateLiveSessionCommand(UserId: Guid.NewGuid(), GameName: "Mage Knight", GameId: Guid.NewGuid());
+
+    await Assert.ThrowsAsync<InvalidOperationException>(() => sut.Handle(cmd, CancellationToken.None));
+
+    sessionRepo.Verify(r => r.AddAsync(It.IsAny<LiveGameSession>(), It.IsAny<CancellationToken>()), Times.Never);
+    uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+}
+
+[Fact]
+public async Task Handle_WithGameId_SetsTrackingSessionIdToCompanionId()
+{
+    var trackingId = Guid.NewGuid();
+    LiveGameSession? added = null;
+    var sessionRepo = new Mock<ILiveSessionRepository>();
+    sessionRepo.Setup(r => r.AddAsync(It.IsAny<LiveGameSession>(), It.IsAny<CancellationToken>()))
+        .Callback<LiveGameSession, CancellationToken>((s, _) => added = s)
+        .Returns(Task.CompletedTask);
+    var uow = new Mock<IUnitOfWork>();
+    var companion = new Mock<ICompanionSessionService>();
+    companion.Setup(c => c.CreateCompanionAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+        .ReturnsAsync(trackingId);
+
+    var sut = new CreateLiveSessionCommandHandler(sessionRepo.Object, TimeProvider.System, uow.Object, companion.Object);
+    var cmd = new CreateLiveSessionCommand(UserId: Guid.NewGuid(), GameName: "Mage Knight", GameId: Guid.NewGuid());
+
+    await sut.Handle(cmd, CancellationToken.None);
+
+    Assert.NotNull(added);
+    Assert.Equal(trackingId, added!.TrackingSessionId);
+    uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+}
+
+[Fact]
+public async Task Handle_WithoutGameId_DoesNotCreateCompanion()
+{
+    LiveGameSession? added = null;
+    var sessionRepo = new Mock<ILiveSessionRepository>();
+    sessionRepo.Setup(r => r.AddAsync(It.IsAny<LiveGameSession>(), It.IsAny<CancellationToken>()))
+        .Callback<LiveGameSession, CancellationToken>((s, _) => added = s)
+        .Returns(Task.CompletedTask);
+    var uow = new Mock<IUnitOfWork>();
+    var companion = new Mock<ICompanionSessionService>();
+
+    var sut = new CreateLiveSessionCommandHandler(sessionRepo.Object, TimeProvider.System, uow.Object, companion.Object);
+    var cmd = new CreateLiveSessionCommand(UserId: Guid.NewGuid(), GameName: "Free session", GameId: null);
+
+    await sut.Handle(cmd, CancellationToken.None);
+
+    Assert.NotNull(added);
+    Assert.Null(added!.TrackingSessionId);
+    companion.Verify(c => c.CreateCompanionAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+}
+```
+
+Integration (happy path — entrambi persistiti atomicamente, ids correlati): seed un user + uno shared game validi (seguendo le fixture esistenti), invia `CreateLiveSessionCommand` con quel `GameId`, poi:
+```csharp
+// dopo Handle:
+var liveId = result; // Guid ritornato
+var live = await db.LiveGameSessions.AsNoTracking().SingleAsync(s => s.Id == liveId);
+Assert.NotNull(live.TrackingSessionId);
+var companionExists = await db.SessionTrackingSessions.AsNoTracking()
+    .AnyAsync(s => s.Id == live.TrackingSessionId);
+Assert.True(companionExists);
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `dotnet test ../../../../tests/Api.Tests --filter "FullyQualifiedName~CreateLiveSessionCommandHandlerTests|FullyQualifiedName~CreateLiveSessionCompanionIntegrationTests"`
+Expected: FAIL — il ctor dell'handler non accetta `ICompanionSessionService`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `CreateLiveSessionCommandHandler.cs`, inietta `ICompanionSessionService` e usalo prima di creare la live session:
+
+```csharp
+using Api.BoundedContexts.GameManagement.Application.Abstractions;
+// ...
+    private readonly ICompanionSessionService _companionSessionService;
+
+    public CreateLiveSessionCommandHandler(
+        ILiveSessionRepository sessionRepository,
+        TimeProvider timeProvider,
+        IUnitOfWork unitOfWork,
+        ICompanionSessionService companionSessionService)
+    {
+        _sessionRepository = sessionRepository ?? throw new ArgumentNullException(nameof(sessionRepository));
+        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+        _companionSessionService = companionSessionService ?? throw new ArgumentNullException(nameof(companionSessionService));
+    }
+```
+
+In `Handle`, after building `scoringConfig` and BEFORE `LiveGameSession.Create`:
+
+```csharp
+        // ADR-083 SP0: create the SessionTracking.Session companion at-creation (Saga).
+        // Add-only (no SaveChanges here): the single SaveChangesAsync below commits the
+        // companion and the LiveGameSession atomically in one EF transaction — a companion
+        // failure rolls back the LiveGameSession, so no orphan is ever persisted.
+        Guid? trackingSessionId = null;
+        if (command.GameId.HasValue)
+        {
+            trackingSessionId = await _companionSessionService
+                .CreateCompanionAsync(command.UserId, command.GameId.Value, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        var session = LiveGameSession.Create(
+            Guid.NewGuid(),
+            command.UserId,
+            command.GameName,
+            _timeProvider,
+            command.GameId,
+            command.Visibility,
+            command.GroupId,
+            scoringConfig,
+            command.AgentMode,
+            trackingSessionId: trackingSessionId);
+
+        await _sessionRepository.AddAsync(session, cancellationToken).ConfigureAwait(false);
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        return session.Id;
+```
+
+(Note: `LiveGameSession.Create` ha `turnAdvancePolicy` come penultimo param con default; passare `trackingSessionId:` come argomento nominato evita ambiguità posizionali.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `dotnet build && dotnet test ../../../../tests/Api.Tests --filter "FullyQualifiedName~CreateLiveSessionCommandHandlerTests|FullyQualifiedName~CreateLiveSessionCompanionIntegrationTests"`
+Expected: PASS (3 unit + 1 integration).
+
+- [ ] **Step 5: Run the full GameManagement + SessionTracking suite (no regressions)**
+
+Run: `dotnet test ../../../../tests/Api.Tests --filter "BoundedContext=GameManagement|BoundedContext=SessionTracking"`
+Expected: PASS, no new failures vs baseline.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/LiveSessions/CreateLiveSessionCommandHandler.cs tests/Api.Tests
+git commit -m "feat(session-live): #2501 SP0 wire companion saga into CreateLiveSessionCommandHandler (atomic)"
+```
+
+---
+
+## Out of scope (tracciato per le sub-fasi successive)
+- Rimozione `ChatSessionId`/`SetAgentMode` dead-code (SP5.1) — NON in questo plan.
+- SSE nativo `/live-sessions/{id}/stream` (SP2), diary (SP3), media/foto (SP4).
+- Backfill companion per righe legacy + sessioni improvvisate senza GameId (OQ#5) — colonna nullable lo consente; follow-up.
+- Esposizione `TrackingSessionId` nel `LiveSessionDto` FE — non necessaria finché SP2/SP3/SP4 non la consumano.
+
+## Self-Review
+- **Spec coverage**: SP0 = «Session-companion canonica (Saga + TrackingSessionId)» → Task 1-5 coprono campo dominio, persistenza, migration, ACL, wiring atomico. La garanzia non-nullable «per le nuove con GameId» è implementata; il caso GameId-null e legacy è esplicitamente nullable+follow-up (delta documentato per review owner). ✓
+- **Placeholder scan**: ogni step di codice mostra il codice reale; i path test non-confermati hanno istruzione esplicita di Glob + pattern da seguire. ✓
+- **Type consistency**: `CreateCompanionAsync(Guid,Guid,CancellationToken):Task<Guid>` e `Create(...,trackingSessionId:)` usati identici in Task 1/4/5; `SessionType.GameSpecific` verificato (Session.cs:652). ✓


### PR DESCRIPTION
## Epic #2501 — SP0: fondamento di convergenza sessione live

Implementa il **fondamento SP0** dell'epic #2501 (convergenza sessione live su `LiveGameSession`, ADR-083 Direzione A): il ponte di correlazione cross-BC **reale** `TrackingSessionId` + la **Saga companion at-creation**. Sblocca le fasi successive (SP2 SSE / SP3 diary / SP4 media), che si correleranno chat/diary/media via questo id.

### Cosa fa
- Aggiunge `LiveGameSession.TrackingSessionId` (`Guid?`) — dominio, entity, EF config, mapper, migration `tracking_session_id` (nullable).
- Introduce un **anti-corruption layer** `ICompanionSessionService` (invariante ADR-083: GameManagement→SessionTracking solo via interfaccia dedicata; il coupling vive nell'Infrastructure impl, mai nell'Application layer).
- Cabla `CreateLiveSessionCommandHandler`: quando il comando ha un `GameId`, crea una `SessionTracking.Session` companion e popola `TrackingSessionId` con il suo id, **committando entrambi gli aggregati in un solo `SaveChangesAsync`** (atomicità transazionale EF → nessuna `LiveGameSession` orfana). Senza `GameId` → nessuna companion.

### Architettura — atomicità
La companion è **Add-only** (nessun `SaveChanges` proprio) e condivide lo stesso `MeepleAiDbContext` scoped dell'handler. Ordine garantito: companion → live session → singolo commit. Se la companion fallisce, la live session non viene mai aggiunta/committata. Verificato sul codice reale e con un **integration test Testcontainers** (round-trip su Postgres reale, eseguito localmente).

### Delta di design (documentato per review)
La spec SP0 chiedeva `TrackingSessionId` *non-nullable garantito*. Qui è **nullable a livello DB**, popolato sempre per le nuove sessioni **con** `GameId` (= caso user story Mage Knight #2506), null per sessioni improvvisate senza gioco e righe legacy. Scelta MVP: evita di toccare l'aggregato condiviso `Session` e una migrazione NOT-NULL su righe esistenti. Il backfill è un follow-up (OQ#5). La variante stretta (companion sempre + colonna NOT NULL) è additiva.

### Test
- **9 unit** (dominio Create/null, mapper round-trip, ACL, 3 di atomicità sull'handler) + **1 integration Testcontainers** (con Docker).
- **0 regressioni** su 2342 test (1388 GameManagement + 954 SessionTracking) + 56 test handler pre-esistenti.
- Verifica indipendente: build pulito, 9 test SP0 verdi.

### Review
- 3 task-review per dispatch (D1 persistenza, D2 ACL, D3 wiring atomico — quest'ultimo con focus dedicato sull'atomicità): tutti **Spec ✅ / Code quality Approved**.
- Review finale adversarial whole-branch (3 prospettive: atomicità · architettura/ADR-083 · test): **READY_WITH_FOLLOWUPS**, 0 Critical.

### Follow-up (tracciati separatamente — non bloccanti)
- Mapping `constraint-violation → 409`: session-code TOCTOU + `GameId` valido-ma-inesistente → FK violation (entrambi **pre-esistenti**, atomicità intatta/no-orphan).
- 4 gap di test-coverage Minor (assert su mock companion, round-trip null su mapper/reconstitute).
- Indice su `tracking_session_id` (per i lookup di SP2+).

### Riferimenti
- ADR-083 (Direzione A), spec Fase 2 `docs/for-developers/specs/2026-06-23-epic-2501-fase2-live-session-feature-gaps.md`
- Plan: `docs/superpowers/plans/2026-06-28-issue-2501-sp0-tracking-session-companion.md`
- Epic #2501 · user story #2506

🤖 Generated with [Claude Code](https://claude.com/claude-code)