### PR TITLE
fix(rag): isolate DbContext per game in cross-game search (#2480)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/MultiGameHybridSearchService.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/MultiGameHybridSearchService.cs
@@ -1,4 +1,5 @@
 using Api.Services;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Api.BoundedContexts.KnowledgeBase.Application.Services;
 
@@ -7,7 +8,12 @@ namespace Api.BoundedContexts.KnowledgeBase.Application.Services;
 ///
 /// Strategy (R3 verdict b):
 /// 1. Early-exit when gameIds is empty (EC-1).
-/// 2. Launch one <see cref="IHybridSearchService.SearchAsync"/> task per game (parallel via Task.WhenAll).
+/// 2. Launch one <see cref="IHybridSearchService.SearchAsync"/> task per game. Each task runs in its
+///    OWN DI scope so it gets its OWN <c>MeepleAiDbContext</c> — the per-game services are scoped and
+///    a single request-scoped DbContext is NOT safe for concurrent use ("A second operation was
+///    started on this context instance…"), which previously made every cross-game search throw and
+///    return 0 results (#2480). A <see cref="SemaphoreSlim"/> caps concurrency so a user with many
+///    accessible games (e.g. an admin) cannot exhaust the connection pool.
 /// 3. Per-game exceptions are caught and logged as warnings; the query continues with the remaining
 ///    games (EC-2 / EC-7 resilience: a game with no indexed content should not abort the whole search).
 /// 4. Per-game already-fused results are tagged with their origin gameId and aggregated.
@@ -21,14 +27,19 @@ namespace Api.BoundedContexts.KnowledgeBase.Application.Services;
 /// </summary>
 internal sealed class MultiGameHybridSearchService : IMultiGameHybridSearchService
 {
-    private readonly IHybridSearchService _hybridSearch;
+    // Cap concurrent per-game searches. Each acquires its own DI scope (own DbContext +
+    // DB connection), so the bound also bounds the connection-pool draw when a user has
+    // many accessible games.
+    private const int MaxConcurrentGameSearches = 4;
+
+    private readonly IServiceScopeFactory _scopeFactory;
     private readonly ILogger<MultiGameHybridSearchService> _logger;
 
     public MultiGameHybridSearchService(
-        IHybridSearchService hybridSearch,
+        IServiceScopeFactory scopeFactory,
         ILogger<MultiGameHybridSearchService> logger)
     {
-        _hybridSearch = hybridSearch;
+        _scopeFactory = scopeFactory;
         _logger = logger;
     }
 
@@ -60,11 +71,13 @@ internal sealed class MultiGameHybridSearchService : IMultiGameHybridSearchServi
         // prevent per-game over-fetching when limit is very large.
         var perGameLimit = Math.Min(Math.Max(limit, 1), 50);
 
+        using var throttle = new SemaphoreSlim(MaxConcurrentGameSearches);
         var tasks = gameIds
-            .Select(gameId => SearchGameSafeAsync(query, gameId, perGameLimit, mode, documentIdsList, cancellationToken))
+            .Select(gameId => SearchGameSafeAsync(query, gameId, perGameLimit, mode, documentIdsList, throttle, cancellationToken))
             .ToList();
 
-        // Task.WhenAll guarantees parallel execution (all tasks start before any is awaited).
+        // Task.WhenAll guarantees parallel execution (all tasks start before any is awaited);
+        // the semaphore inside each task bounds how many run the DB work concurrently.
         var perGameResultArrays = await Task.WhenAll(tasks).ConfigureAwait(false);
 
         // Step 2: Aggregate, project to MultiGameSearchResultItem (preserving origin gameId).
@@ -105,10 +118,11 @@ internal sealed class MultiGameHybridSearchService : IMultiGameHybridSearchServi
     }
 
     /// <summary>
-    /// Issues a single-game search, catching and logging any exception so that
-    /// one failing game does not abort the entire cross-game query (EC-2 resilience).
-    /// The <paramref name="documentIds"/> allowlist (Issue #1686) restricts the per-game
-    /// hit set to a subset of PDF documents; <c>null</c> = no document filter.
+    /// Issues a single-game search in its OWN DI scope (own DbContext), catching and logging any
+    /// exception so that one failing game does not abort the entire cross-game query (EC-2 resilience).
+    /// The <paramref name="throttle"/> bounds how many per-game searches hit the DB concurrently.
+    /// The <paramref name="documentIds"/> allowlist (Issue #1686) restricts the per-game hit set to a
+    /// subset of PDF documents; <c>null</c> = no document filter.
     /// </summary>
     private async Task<(Guid GameId, List<HybridSearchResult> Results)> SearchGameSafeAsync(
         string query,
@@ -116,11 +130,19 @@ internal sealed class MultiGameHybridSearchService : IMultiGameHybridSearchServi
         int limit,
         SearchMode mode,
         List<Guid>? documentIds,
+        SemaphoreSlim throttle,
         CancellationToken cancellationToken)
     {
+        await throttle.WaitAsync(cancellationToken).ConfigureAwait(false);
         try
         {
-            var results = await _hybridSearch.SearchAsync(
+            // Own scope → own scoped MeepleAiDbContext, so concurrent per-game searches never
+            // share a DbContext instance (the root cause of the cross-game "second operation on
+            // this context" failures that returned 0 results, #2480).
+            using var scope = _scopeFactory.CreateScope();
+            var hybridSearch = scope.ServiceProvider.GetRequiredService<IHybridSearchService>();
+
+            var results = await hybridSearch.SearchAsync(
                 query,
                 gameId,
                 mode,
@@ -139,6 +161,10 @@ internal sealed class MultiGameHybridSearchService : IMultiGameHybridSearchServi
             return (gameId, new List<HybridSearchResult>());
         }
 #pragma warning restore CA1031
+        finally
+        {
+            throttle.Release();
+        }
     }
 
     /// <summary>

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/MultiGameHybridSearchServiceTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/MultiGameHybridSearchServiceTests.cs
@@ -3,6 +3,8 @@ using Api.BoundedContexts.KnowledgeBase.Application.Services;
 using Api.Services;
 using Api.Tests.Constants;
 using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Xunit;
 
@@ -18,9 +20,20 @@ namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Services;
 public class MultiGameHybridSearchServiceTests
 {
     private readonly Mock<IHybridSearchService> _hybridSearchMock = new(MockBehavior.Strict);
+    private readonly Mock<IServiceScopeFactory> _scopeFactoryMock = new();
 
-    private MultiGameHybridSearchService CreateSut() =>
-        new(_hybridSearchMock.Object, Microsoft.Extensions.Logging.Abstractions.NullLogger<MultiGameHybridSearchService>.Instance);
+    // Each per-game search resolves IHybridSearchService from its OWN DI scope (own DbContext).
+    // Wire the scope factory so every CreateScope() yields a provider returning the single mock,
+    // keeping the existing Setup/Verify on _hybridSearchMock valid while exercising the scope path.
+    private MultiGameHybridSearchService CreateSut()
+    {
+        var provider = new Mock<IServiceProvider>();
+        provider.Setup(p => p.GetService(typeof(IHybridSearchService))).Returns(_hybridSearchMock.Object);
+        var scope = new Mock<IServiceScope>();
+        scope.SetupGet(s => s.ServiceProvider).Returns(provider.Object);
+        _scopeFactoryMock.Setup(f => f.CreateScope()).Returns(scope.Object);
+        return new(_scopeFactoryMock.Object, NullLogger<MultiGameHybridSearchService>.Instance);
+    }
 
     // ---------------------------------------------------------------------------
     // EC-1: empty gameIds → empty result, no calls to HybridSearchService
@@ -117,6 +130,34 @@ public class MultiGameHybridSearchServiceTests
                 It.IsAny<float>(), It.IsAny<float>(), It.IsAny<double>(),
                 It.IsAny<GameBookRole>(), It.IsAny<CancellationToken>()),
             Times.Once);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Regression (#2480): each per-game search runs in its OWN DI scope so it gets
+    // its OWN DbContext. Sharing the request-scoped DbContext across the concurrent
+    // per-game searches threw "A second operation was started on this context
+    // instance…" and made every cross-game search return 0 results.
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task MultipleGames_CreatesOneDiScopePerGame()
+    {
+        // Arrange
+        var gameId1 = Guid.NewGuid();
+        var gameId2 = Guid.NewGuid();
+        var gameId3 = Guid.NewGuid();
+
+        SetupHybridSearchForGame(gameId1, count: 1, baseScore: 0.8f);
+        SetupHybridSearchForGame(gameId2, count: 1, baseScore: 0.7f);
+        SetupHybridSearchForGame(gameId3, count: 1, baseScore: 0.6f);
+
+        var sut = CreateSut();
+
+        // Act
+        await sut.SearchAsync("test", new[] { gameId1, gameId2, gameId3 }, limit: 20);
+
+        // Assert — one scope (→ one DbContext) per game, never a shared context.
+        _scopeFactoryMock.Verify(f => f.CreateScope(), Times.Exactly(3));
     }
 
     // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Root cause (22° strato della saga #2480/#2516)

Il persistente "no citations" della RAG smoke non era CI-config né snapshot incompleto (lo snapshot ha vector_documents + embeddings + chunks). Il diagnostic run ha catturato l'errore reale:

\`\`\`
System.InvalidOperationException: A second operation was started on this context instance before a previous operation completed
   at KeywordSearchService.SearchAsync → HybridSearchService.SearchHybridAsync
[WRN] MultiGameHybridSearch: search failed for gameId=..., skipping game
[INF] MultiGameHybridSearch aggregated 0 results → returning 0 results
\`\`\`

`MultiGameHybridSearchService` lanciava una task per-gioco via `Task.WhenAll`, ma `IHybridSearchService`/`IKeywordSearchService`/`MeepleAiDbContext` sono **scoped** → tutte le task parallele condividevano l'unico DbContext della richiesta → eccezione concurrent-operation → ogni gioco falliva → 0 risultati → zero Citations. **Rompe il global cross-game ask ogni volta che copre più giochi** (es. admin su tutto il catalogo), non solo in CI.

## Fix

Ogni ricerca per-gioco gira nel **proprio scope `IServiceScopeFactory`** → proprio DbContext, con `SemaphoreSlim(4)` per non esaurire il connection pool con molti giochi. Aggregazione/ordinamento/resilienza invariati.

## Test
- Costruttore ora prende `IServiceScopeFactory` (test wira scope→provider→mock).
- Nuovo regression `MultipleGames_CreatesOneDiScopePerGame` (uno scope/DbContext per gioco).
- **13/13 unit test verdi** in locale.

Refs #2480.

🤖 Generated with [Claude Code](https://claude.com/claude-code)