### PR TITLE
feat(session-live): #2501 SP4 — foto in EndgameDialog

### DIFF
--- a/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx
@@ -80,6 +80,7 @@ import {
 
 import { useParams, usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { useIntl } from 'react-intl';
+import { toast } from 'sonner';
 
 import {
   ActionLogTimeline,
@@ -115,6 +116,7 @@ import { useLiveSession } from '@/hooks/queries/useLiveSession';
 import { useSessionAgentLaunch } from '@/hooks/queries/useSessionAgentLaunch';
 import { useTranslation } from '@/hooks/useTranslation';
 import { api } from '@/lib/api';
+import { ConflictError } from '@/lib/api/core/errors';
 import { useSessionAgentChat } from '@/lib/domain-hooks/useSessionAgentChat';
 import { getNavigationLinks } from '@/lib/navigation';
 import { composeSessionLiveState } from '@/lib/session-live/compose-session-live-state';
@@ -573,6 +575,16 @@ export function SessionLiveView(): ReactElement {
         handleDialogChange('endgame');
         if (gameId) startResolvePlayRecord(gameId, previousRecordId);
       },
+      onError: (err: Error) => {
+        // AC-MEDIA-4: if the session was already Completed (409 Conflict), show a toast
+        // and do NOT open the endgame dialog or start polling.
+        if (err instanceof ConflictError || (err as { statusCode?: number }).statusCode === 409) {
+          toast.error(t('pages.sessionLive.endgameDialog.alreadyCompletedToast'), {
+            id: 'endgame-already-completed',
+          });
+        }
+        // Other errors: no additional handling (mutation error state is available to callers).
+      },
     });
   }, [
     sessionId,
@@ -580,6 +592,7 @@ export function SessionLiveView(): ReactElement {
     handleDialogChange,
     sessionQuery.data?.gameId,
     startResolvePlayRecord,
+    t,
   ]);
 
   /**
@@ -1501,6 +1514,7 @@ export function SessionLiveView(): ReactElement {
             }
             endedAt={endgameEvent?.endedAt ?? '—'}
             endedBy={endgameEvent?.endedBy ?? '—'}
+            recordId={resolvedPlayRecordId}
             onAcknowledge={() => handleDialogChange('none')}
             onSave={hasRequiredRole(activeSession.viewerRole, 'Host') ? handleSaveGame : undefined}
             saving={saveIntent && resolveStatus === 'resolving'}

--- a/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/__tests__/SessionLiveView.test.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/__tests__/SessionLiveView.test.tsx
@@ -162,6 +162,17 @@ vi.mock('@/hooks/mutations/useAddLivePlayer', () => ({
   }),
 }));
 
+// ─── usePlayRecordPhotoUpload mock (#2501 SP4: EndgamePhotoUploadSection calls this) ──
+// Prevent "No QueryClient set" errors when EndgameDialog (with EndgamePhotoUploadSection)
+// is rendered in tests that don't provide a QueryClientProvider.
+
+vi.mock('@/hooks/mutations/usePlayRecordPhotoUpload', () => ({
+  usePlayRecordPhotoUpload: () => ({
+    mutateAsync: vi.fn(),
+    isPending: false,
+  }),
+}));
+
 // ─── useCompleteLiveSession mock (#2503) ─────────────────────────────────────
 // Controllable: completeMutate captures the (undefined, { onSuccess }) call;
 // completeIsPending toggles the confirm-CTA disabled state.
@@ -396,6 +407,7 @@ const MESSAGES: Record<string, string> = {
   // #2503
   'pages.sessionLive.endgameDialog.saveGameCta': 'Salva partita',
   'pages.sessionLive.endgameDialog.savingLabel': 'Salvataggio…',
+  'pages.sessionLive.endgameDialog.alreadyCompletedToast': 'Partita già conclusa',
   'pages.sessionLive.endgameConfirm.title': 'Terminare la partita?',
   'pages.sessionLive.endgameConfirm.body':
     "L'azione è irreversibile. I punteggi finali verranno registrati.",
@@ -2066,5 +2078,112 @@ describe('SessionLiveView — #2503: endgame complete + save-game nav', () => {
     // EndgameDialog is mounted with a resolved record, but the Host never clicked
     // "Salva partita" → no navigation must fire.
     expect(routerPush).not.toHaveBeenCalledWith('/play-records/rec-99');
+  });
+});
+
+// ─── #2501 SP4 Task 3 — recordId wire + 409 handler ─────────────────────────
+
+describe('SessionLiveView — #2501 SP4 Task 3: recordId wire + 409 handler', () => {
+  const HOST_USER_ID = 'user-44444444-4444-4444-4444-444444444444';
+
+  const HOST_DTO = {
+    ...MOCK_SESSION_DTO,
+    gameId: 'game-00000001',
+    players: [
+      {
+        id: 'player-001',
+        displayName: 'Marco',
+        userId: HOST_USER_ID,
+        color: 'Blue',
+        role: 'Host',
+        totalScore: 0,
+        isActive: true,
+      },
+    ],
+  } as unknown as import('@/lib/api/schemas/live-sessions.schemas').LiveSessionDto;
+
+  function emptyHistory() {
+    return { records: [], totalCount: 0, page: 1, pageSize: 1, totalPages: 0 };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.keys(searchParamsMap).forEach(k => delete searchParamsMap[k]);
+    mockParamsId = 'session-abc-123';
+    IS_VISUAL_TEST_BUILD_MOCK = false;
+    useSessionLiveStreamMock.mockReturnValue({ ...mockLiveStreamResult });
+    useCurrentUserMock.mockReturnValue({ data: { id: HOST_USER_ID } });
+    useLiveSessionMock.mockReturnValue({
+      data: HOST_DTO,
+      isLoading: false,
+      isError: false,
+      isSuccess: true,
+      error: null,
+    });
+    completeIsPending = false;
+    resolveStatusMock = 'idle';
+    resolvePlayRecordIdMock = null;
+    getHistoryMock.mockResolvedValue(emptyHistory());
+  });
+
+  it('SP4-T3-1: passes resolvedPlayRecordId to EndgameDialog, enabling photo upload when recordId is set', async () => {
+    // Set a resolved play record id before mounting with ?dialog=endgame.
+    resolveStatusMock = 'resolved';
+    resolvePlayRecordIdMock = 'rec-sp4-001';
+    searchParamsMap['dialog'] = 'endgame';
+
+    renderWithIntl(<SessionLiveView />);
+    // Flush lazy Suspense.
+    await act(async () => {});
+
+    // EndgameDialog must be mounted.
+    const dialog = document.querySelector('[data-slot="endgame-dialog"]');
+    expect(dialog).toBeInTheDocument();
+
+    // EndgamePhotoUploadSection must be rendered inside the dialog (SP4 D1+D2+T3).
+    const photoSection = dialog?.querySelector('[data-slot="endgame-photo-upload"]');
+    expect(photoSection).not.toBeNull();
+
+    // When recordId is non-null (resolved), the upload CTA button must NOT be disabled
+    // (the button is disabled only during the polling window when recordId === null).
+    // The upload button is present (even if no file selected yet, section always renders).
+    // This verifies recordId flows from SessionLiveView → EndgameDialog → section.
+    const uploadBtn = dialog?.querySelector('button[data-slot="endgame-photo-upload-btn"]');
+    // If no files are selected the upload button may not exist — so verify section itself.
+    // The section is always rendered when recordId is present (not gated).
+    expect(photoSection).toBeInTheDocument();
+  });
+
+  it('SP4-T3-2: complete 409 shows "Partita già conclusa" toast and does NOT navigate', async () => {
+    // completeLiveSession.mutate calls onError with a ConflictError (statusCode 409).
+    const { ConflictError } = await import('@/lib/api/core/errors');
+    completeMutate.mockImplementation(
+      (_input: unknown, opts?: { onSuccess?: () => void; onError?: (err: Error) => void }) => {
+        opts?.onError?.(new ConflictError({ message: 'Session already completed' }));
+      }
+    );
+
+    const { container } = renderWithIntl(<SessionLiveView />);
+
+    // Open the confirm dialog and click confirm.
+    await act(async () => {
+      fireEvent.click(container.querySelector('[data-slot="session-live-top-bar-endgame"]')!);
+    });
+    await act(async () => {
+      fireEvent.click(document.querySelector('[data-slot="endgame-confirm-cta"]')!);
+    });
+    await act(async () => {});
+
+    // toast.error should have been called with the already-completed message.
+    const { toast } = await import('sonner');
+    expect(toast.error).toHaveBeenCalledWith(
+      expect.stringMatching(/già conclusa|already finished/i),
+      expect.anything()
+    );
+
+    // Must NOT navigate to play-records.
+    expect(routerPush).not.toHaveBeenCalledWith(expect.stringContaining('/play-records'));
+    // Must NOT open the endgame dialog (no handleDialogChange('endgame') call).
+    expect(document.querySelector('[data-slot="endgame-dialog"]')).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/features/session-live/EndgameDialog.tsx
+++ b/apps/web/src/components/features/session-live/EndgameDialog.tsx
@@ -24,9 +24,11 @@
  * data-slot="endgame-dialog" — required by unit tests.
  */
 
-import { type ReactElement, useId, useEffect, useRef, useCallback } from 'react';
+import { type ReactElement, useId, useEffect, useRef, useCallback, useState } from 'react';
 
 import { Trophy } from 'lucide-react';
+
+import { EndgamePhotoUploadSection } from './EndgamePhotoUploadSection';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -59,6 +61,8 @@ export interface EndgameDialogProps {
   // #2503
   readonly onSave?: () => void;
   readonly saving?: boolean;
+  // #2501 SP4 — photo upload
+  readonly recordId?: string | null;
 }
 
 // ─── Focus trap helper ────────────────────────────────────────────────────────
@@ -83,7 +87,10 @@ export function EndgameDialog({
   labels,
   onSave,
   saving,
+  recordId,
 }: EndgameDialogProps): ReactElement {
+  // #2501 SP4 — track photo upload in progress to disable save CTA (AC-MEDIA-1)
+  const [uploading, setUploading] = useState(false);
   const titleId = useId();
   const dialogRef = useRef<HTMLDivElement>(null);
   const acknowledgeRef = useRef<HTMLButtonElement>(null);
@@ -203,12 +210,19 @@ export function EndgameDialog({
           ))}
         </ol>
 
+        {/* #2501 SP4 — photo upload section (additive, above CTAs) */}
+        <EndgamePhotoUploadSection
+          recordId={recordId ?? null}
+          onUploadingChange={setUploading}
+          className="mb-4"
+        />
+
         {/* #2503 CTA primaria: "Salva partita" — solo se onSave passato */}
         {onSave != null && (
           <button
             type="button"
             onClick={onSave}
-            disabled={saving === true}
+            disabled={saving === true || uploading}
             aria-busy={saving === true}
             data-slot="endgame-save-cta"
             className="mb-3 w-full rounded-lg bg-entity-game px-4 py-3 text-sm font-semibold

--- a/apps/web/src/components/features/session-live/EndgamePhotoUploadSection.tsx
+++ b/apps/web/src/components/features/session-live/EndgamePhotoUploadSection.tsx
@@ -1,0 +1,343 @@
+'use client';
+
+/**
+ * EndgamePhotoUploadSection — SP4 #2501
+ *
+ * Inline photo upload strip shown inside EndgameDialog after the game ends.
+ * Supports per-photo state machine (idle | uploading | done | error) with retry,
+ * HEIC→JPEG conversion, and a hard cap of MAX_FILES files.
+ *
+ * Design constraints:
+ *  - Uses semantic tokens only (no hardcoded Tailwind color utilities)
+ *  - recordId may be null while the PlayRecord is being created (polling window)
+ *  - Hook must always be called (React hook rules) → use recordId ?? ''
+ *  - Upload button is disabled while recordId === null
+ */
+
+import { useState, useCallback, useEffect, useRef } from 'react';
+
+import { usePlayRecordPhotoUpload } from '@/hooks/mutations/usePlayRecordPhotoUpload';
+import { useTranslation } from '@/hooks/useTranslation';
+import { cn } from '@/lib/utils';
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const MAX_BYTES = 5 * 1024 * 1024; // 5 MB
+const MAX_FILES = 10;
+const ACCEPTED_MIME = ['image/jpeg', 'image/png', 'image/webp', 'image/heic'];
+
+// ─── Per-photo state ──────────────────────────────────────────────────────────
+
+type PhotoStatus = 'idle' | 'uploading' | 'done' | 'error';
+
+interface PhotoEntry {
+  /** Unique stable key for React list rendering */
+  key: string;
+  /** The (possibly HEIC-converted) file ready to upload */
+  file: File;
+  /** Object URL for preview thumbnail */
+  objectUrl: string;
+  status: PhotoStatus;
+  errorMsg?: string;
+}
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+export interface EndgamePhotoUploadSectionProps {
+  /** Null during polling → upload is disabled until the record is created */
+  recordId: string | null;
+  /** Called with true when any upload starts, false when all uploads finish */
+  onUploadingChange?: (uploading: boolean) => void;
+  className?: string;
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function EndgamePhotoUploadSection({
+  recordId,
+  onUploadingChange,
+  className,
+}: EndgamePhotoUploadSectionProps): React.JSX.Element {
+  const { t } = useTranslation();
+
+  // Always call the hook — satisfy React hook rules.
+  // Empty string is a valid (non-null) recordId placeholder; actual upload is
+  // gated by the disabled state of the upload button.
+  const upload = usePlayRecordPhotoUpload(recordId ?? '');
+
+  const [photos, setPhotos] = useState<PhotoEntry[]>([]);
+  const [globalWarning, setGlobalWarning] = useState<string | null>(null);
+
+  // Stable key counter so we can uniquely identify each photo entry
+  const keyCounterRef = useRef(0);
+
+  // Revoke object URLs on unmount to avoid memory leaks
+  const photosRef = useRef(photos);
+  photosRef.current = photos;
+
+  useEffect(() => {
+    return () => {
+      for (const p of photosRef.current) {
+        URL.revokeObjectURL(p.objectUrl);
+      }
+    };
+  }, []);
+
+  // ─── File selection ────────────────────────────────────────────────────────
+
+  const handleFileChange = useCallback(
+    async (e: React.ChangeEvent<HTMLInputElement>) => {
+      setGlobalWarning(null);
+
+      const selected = Array.from(e.target.files ?? []);
+      if (selected.length === 0) return;
+
+      let capped = selected;
+      if (selected.length > MAX_FILES) {
+        capped = selected.slice(0, MAX_FILES);
+        setGlobalWarning(
+          t('pages.pages.sessionLive.endgameDialog.photoUpload.tooManyFiles', { max: MAX_FILES })
+        );
+      }
+
+      const entries: PhotoEntry[] = [];
+      for (const raw of capped) {
+        // Validate MIME
+        if (!ACCEPTED_MIME.includes(raw.type)) {
+          setGlobalWarning(t('pages.sessionLive.endgameDialog.photoUpload.badFormat'));
+          continue;
+        }
+
+        let file = raw;
+
+        // Convert HEIC → JPEG
+        if (raw.type === 'image/heic') {
+          try {
+            const heic2any = (await import('heic2any')).default;
+            const result = await heic2any({ blob: raw, toType: 'image/jpeg', quality: 0.9 });
+            const jpegBlob = Array.isArray(result) ? result[0] : result;
+            file = new File([jpegBlob as Blob], raw.name.replace(/\.heic$/i, '.jpg'), {
+              type: 'image/jpeg',
+            });
+          } catch {
+            setGlobalWarning(t('pages.sessionLive.endgameDialog.photoUpload.heicFailed'));
+            continue;
+          }
+        }
+
+        // Validate size (after potential conversion)
+        if (file.size > MAX_BYTES) {
+          setGlobalWarning(t('pages.sessionLive.endgameDialog.photoUpload.tooLarge'));
+          continue;
+        }
+
+        const objectUrl = URL.createObjectURL(file);
+        keyCounterRef.current += 1;
+        entries.push({
+          key: String(keyCounterRef.current),
+          file,
+          objectUrl,
+          status: 'idle',
+        });
+      }
+
+      // Append to existing photos (up to MAX_FILES total)
+      setPhotos(prev => {
+        const combined = [...prev, ...entries];
+        return combined.slice(0, MAX_FILES);
+      });
+
+      // Reset input so the same file can be selected again if needed
+      e.target.value = '';
+    },
+    [t]
+  );
+
+  // ─── Upload all idle/error photos ─────────────────────────────────────────
+
+  const handleUpload = useCallback(async () => {
+    if (!recordId) return;
+
+    const toUpload = photos.filter(p => p.status === 'idle' || p.status === 'error');
+    if (toUpload.length === 0) return;
+
+    onUploadingChange?.(true);
+
+    for (const photo of toUpload) {
+      // Mark as uploading
+      setPhotos(prev =>
+        prev.map(p =>
+          p.key === photo.key ? { ...p, status: 'uploading', errorMsg: undefined } : p
+        )
+      );
+
+      try {
+        await upload.mutateAsync({ file: photo.file });
+        setPhotos(prev => prev.map(p => (p.key === photo.key ? { ...p, status: 'done' } : p)));
+      } catch {
+        setPhotos(prev =>
+          prev.map(p =>
+            p.key === photo.key
+              ? {
+                  ...p,
+                  status: 'error',
+                  errorMsg: t('pages.sessionLive.endgameDialog.photoUpload.errorGeneric'),
+                }
+              : p
+          )
+        );
+      }
+    }
+
+    onUploadingChange?.(false);
+  }, [recordId, photos, upload, onUploadingChange, t]);
+
+  // ─── Retry a single photo ──────────────────────────────────────────────────
+
+  const handleRetry = useCallback(
+    async (key: string) => {
+      if (!recordId) return;
+
+      const photo = photos.find(p => p.key === key);
+      if (!photo) return;
+
+      onUploadingChange?.(true);
+
+      setPhotos(prev =>
+        prev.map(p => (p.key === key ? { ...p, status: 'uploading', errorMsg: undefined } : p))
+      );
+
+      try {
+        await upload.mutateAsync({ file: photo.file });
+        setPhotos(prev => prev.map(p => (p.key === key ? { ...p, status: 'done' } : p)));
+      } catch {
+        setPhotos(prev =>
+          prev.map(p =>
+            p.key === key
+              ? {
+                  ...p,
+                  status: 'error',
+                  errorMsg: t('pages.sessionLive.endgameDialog.photoUpload.errorGeneric'),
+                }
+              : p
+          )
+        );
+      }
+
+      onUploadingChange?.(false);
+    },
+    [recordId, photos, upload, onUploadingChange, t]
+  );
+
+  // ─── Derived state ─────────────────────────────────────────────────────────
+
+  const hasFilesToUpload = photos.some(p => p.status === 'idle' || p.status === 'error');
+  const isUploading = photos.some(p => p.status === 'uploading');
+  const uploadDisabled = !recordId || !hasFilesToUpload || isUploading;
+
+  // ─── Render ────────────────────────────────────────────────────────────────
+
+  return (
+    <section
+      data-slot="endgame-photo-upload"
+      className={cn('flex flex-col gap-3', className)}
+      aria-label={t('pages.sessionLive.endgameDialog.photoUpload.sectionTitle')}
+    >
+      {/* Section title */}
+      <h3 className="text-sm font-semibold text-foreground">
+        {t('pages.sessionLive.endgameDialog.photoUpload.sectionTitle')}
+      </h3>
+
+      {/* File input */}
+      <label className="block">
+        <span className="sr-only">
+          {t('pages.sessionLive.endgameDialog.photoUpload.addPhotosCta')}
+        </span>
+        <input
+          type="file"
+          accept="image/jpeg,image/png,image/webp,image/heic"
+          multiple
+          onChange={handleFileChange}
+          aria-label={t('pages.sessionLive.endgameDialog.photoUpload.addPhotosCta')}
+          className="block w-full text-sm text-muted-foreground file:mr-3 file:rounded-md file:border-0 file:bg-card file:px-3 file:py-1 file:text-sm file:font-medium file:text-foreground hover:file:cursor-pointer"
+        />
+      </label>
+
+      {/* Global warning (too many files, bad format, too large) */}
+      {globalWarning && (
+        <p role="alert" className="text-sm text-destructive">
+          {globalWarning}
+        </p>
+      )}
+
+      {/* Per-photo preview list */}
+      {photos.length > 0 && (
+        <ul className="flex flex-col gap-2" aria-label="foto selezionate">
+          {photos.map(photo => (
+            <li
+              key={photo.key}
+              data-testid="photo-preview-item"
+              data-status={photo.status}
+              className="flex items-center gap-3 rounded-md border border-border bg-card p-2"
+            >
+              {/* Thumbnail */}
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={photo.objectUrl}
+                alt={photo.file.name}
+                className="h-10 w-10 rounded object-cover"
+              />
+
+              {/* File name + status */}
+              <span className="flex-1 truncate text-sm text-foreground">{photo.file.name}</span>
+
+              {/* Status indicators */}
+              {photo.status === 'uploading' && (
+                <span className="text-xs text-muted-foreground" aria-live="polite">
+                  {t('pages.sessionLive.endgameDialog.photoUpload.uploadingLabel')}
+                </span>
+              )}
+
+              {photo.status === 'done' && (
+                <span className="rounded-full bg-card px-2 py-0.5 text-xs font-medium text-foreground ring-1 ring-border">
+                  {t('pages.sessionLive.endgameDialog.photoUpload.doneBadge')}
+                </span>
+              )}
+
+              {photo.status === 'error' && (
+                <span className="flex items-center gap-2">
+                  <span role="alert" className="text-xs text-destructive">
+                    {photo.errorMsg ??
+                      t('pages.sessionLive.endgameDialog.photoUpload.errorGeneric')}
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => void handleRetry(photo.key)}
+                    className="text-xs font-medium text-foreground underline underline-offset-2 hover:no-underline"
+                  >
+                    {t('pages.sessionLive.endgameDialog.photoUpload.retryCta')}
+                  </button>
+                </span>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {/* Upload CTA */}
+      {photos.length > 0 && (
+        <button
+          type="button"
+          onClick={() => void handleUpload()}
+          disabled={uploadDisabled}
+          aria-busy={isUploading}
+          className="self-end rounded-md bg-card px-4 py-2 text-sm font-medium text-foreground ring-1 ring-border hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {isUploading
+            ? t('pages.sessionLive.endgameDialog.photoUpload.uploadingLabel')
+            : t('pages.sessionLive.endgameDialog.photoUpload.uploadCta')}
+        </button>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/components/features/session-live/EndgamePhotoUploadSection.tsx
+++ b/apps/web/src/components/features/session-live/EndgamePhotoUploadSection.tsx
@@ -18,13 +18,18 @@ import { useState, useCallback, useEffect, useRef } from 'react';
 
 import { usePlayRecordPhotoUpload } from '@/hooks/mutations/usePlayRecordPhotoUpload';
 import { useTranslation } from '@/hooks/useTranslation';
+import {
+  PHOTO_MAX_BYTES,
+  PHOTO_MAX_FILES,
+  PHOTO_ACCEPTED_MIME,
+} from '@/lib/play-records/photo-constants';
 import { cn } from '@/lib/utils';
 
-// ─── Constants ────────────────────────────────────────────────────────────────
+// ─── Constants (re-exported aliases for local readability) ────────────────────
 
-const MAX_BYTES = 5 * 1024 * 1024; // 5 MB
-const MAX_FILES = 10;
-const ACCEPTED_MIME = ['image/jpeg', 'image/png', 'image/webp', 'image/heic'];
+const MAX_BYTES = PHOTO_MAX_BYTES;
+const MAX_FILES = PHOTO_MAX_FILES;
+const ACCEPTED_MIME = PHOTO_ACCEPTED_MIME;
 
 // ─── Per-photo state ──────────────────────────────────────────────────────────
 
@@ -272,7 +277,10 @@ export function EndgamePhotoUploadSection({
 
       {/* Per-photo preview list */}
       {photos.length > 0 && (
-        <ul className="flex flex-col gap-2" aria-label="foto selezionate">
+        <ul
+          className="flex flex-col gap-2"
+          aria-label={t('pages.sessionLive.endgameDialog.photoUpload.selectedPhotosList')}
+        >
           {photos.map(photo => (
             <li
               key={photo.key}
@@ -335,7 +343,9 @@ export function EndgamePhotoUploadSection({
         >
           {isUploading
             ? t('pages.sessionLive.endgameDialog.photoUpload.uploadingLabel')
-            : t('pages.sessionLive.endgameDialog.photoUpload.uploadCta')}
+            : !recordId
+              ? t('pages.sessionLive.endgameDialog.photoUpload.preparingLabel')
+              : t('pages.sessionLive.endgameDialog.photoUpload.uploadCta')}
         </button>
       )}
     </section>

--- a/apps/web/src/components/features/session-live/EndgamePhotoUploadSection.tsx
+++ b/apps/web/src/components/features/session-live/EndgamePhotoUploadSection.tsx
@@ -96,7 +96,7 @@ export function EndgamePhotoUploadSection({
       if (selected.length > MAX_FILES) {
         capped = selected.slice(0, MAX_FILES);
         setGlobalWarning(
-          t('pages.pages.sessionLive.endgameDialog.photoUpload.tooManyFiles', { max: MAX_FILES })
+          t('pages.sessionLive.endgameDialog.photoUpload.tooManyFiles', { max: MAX_FILES })
         );
       }
 

--- a/apps/web/src/components/features/session-live/__tests__/EndgameDialog.test.tsx
+++ b/apps/web/src/components/features/session-live/__tests__/EndgameDialog.test.tsx
@@ -10,14 +10,35 @@
  * - Focus trap: Tab cycles within dialog
  * - Shift+Tab wraps backward
  * - aria-labelledby links to title
+ * - #2501 SP4: photo upload section mounted above CTAs (Task 2)
  */
 
-import { render, screen } from '@testing-library/react';
+import { render, screen, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { EndgameDialogLabels, EndgameDialogProps, FinalScoreEntry } from '../EndgameDialog';
 import { EndgameDialog } from '../EndgameDialog';
+
+// ─── Mock EndgamePhotoUploadSection ───────────────────────────────────────────
+// Mock so we can control onUploadingChange in isolation without needing
+// real file inputs, hooks, or i18n setup.
+
+let capturedOnUploadingChange: ((uploading: boolean) => void) | undefined;
+
+vi.mock('../EndgamePhotoUploadSection', () => ({
+  EndgamePhotoUploadSection: ({
+    recordId,
+    onUploadingChange,
+  }: {
+    recordId: string | null;
+    onUploadingChange?: (uploading: boolean) => void;
+    className?: string;
+  }) => {
+    capturedOnUploadingChange = onUploadingChange;
+    return <div data-testid="endgame-photo-upload-section" data-record-id={recordId ?? 'null'} />;
+  },
+}));
 
 // ─── Fixtures ─────────────────────────────────────────────────────────────────
 
@@ -232,5 +253,64 @@ describe('EndgameDialog — #2503: save game CTA', () => {
     renderDialog({ onSave: vi.fn() });
     expect(screen.getByRole('button', { name: 'Conferma' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Salva partita' })).toBeInTheDocument();
+  });
+});
+
+// ─── #2501 SP4 — Photo upload section (Task 2) ────────────────────────────────
+
+describe('EndgameDialog — #2501 SP4: photo upload section', () => {
+  beforeEach(() => {
+    capturedOnUploadingChange = undefined;
+  });
+
+  it('renders_photo_section_above_ctas — EndgamePhotoUploadSection is rendered above the CTAs', () => {
+    renderDialog({ onSave: vi.fn(), recordId: 'rec-123' });
+
+    const photoSection = screen.getByTestId('endgame-photo-upload-section');
+    expect(photoSection).toBeInTheDocument();
+
+    // Verify ordering: photo section must appear before the save CTA in the DOM
+    const saveBtn = screen.getByRole('button', { name: 'Salva partita' });
+    const confirmBtn = screen.getByRole('button', { name: 'Conferma' });
+
+    // compareDocumentPosition returns a bitmask; DOCUMENT_POSITION_FOLLOWING (4)
+    // means saveBtn comes after photoSection in document order.
+    expect(
+      photoSection.compareDocumentPosition(saveBtn) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+    expect(
+      photoSection.compareDocumentPosition(confirmBtn) & Node.DOCUMENT_POSITION_FOLLOWING
+    ).toBeTruthy();
+  });
+
+  it('disables_save_cta_while_photos_uploading — save CTA is disabled when onUploadingChange(true), re-enabled at (false)', async () => {
+    renderDialog({ onSave: vi.fn(), recordId: 'rec-456' });
+
+    const saveBtn = screen.getByRole('button', { name: 'Salva partita' });
+
+    // Initially enabled
+    expect(saveBtn).not.toBeDisabled();
+
+    // Trigger uploading = true via the captured callback
+    act(() => {
+      capturedOnUploadingChange?.(true);
+    });
+
+    expect(saveBtn).toBeDisabled();
+
+    // Trigger uploading = false
+    act(() => {
+      capturedOnUploadingChange?.(false);
+    });
+
+    expect(saveBtn).not.toBeDisabled();
+  });
+
+  it('save_cta_enabled_with_no_photos — save CTA remains enabled when no upload is in progress (AC-MEDIA-2)', () => {
+    renderDialog({ onSave: vi.fn(), recordId: null });
+
+    // Photo section present but no upload triggered → save CTA enabled
+    expect(screen.getByTestId('endgame-photo-upload-section')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Salva partita' })).not.toBeDisabled();
   });
 });

--- a/apps/web/src/components/features/session-live/__tests__/EndgamePhotoUploadSection.test.tsx
+++ b/apps/web/src/components/features/session-live/__tests__/EndgamePhotoUploadSection.test.tsx
@@ -1,0 +1,180 @@
+/**
+ * EndgamePhotoUploadSection tests — SP4 #2501
+ *
+ * Test cases:
+ * 1. selecting_files_shows_local_previews
+ * 2. upload_disabled_while_recordId_null
+ * 3. successful_upload_marks_photo_done_and_calls_onUploadingChange
+ * 4. failed_upload_shows_inline_error_and_retry
+ * 5. respects_max_files
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ReactNode } from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { IntlProvider } from 'react-intl';
+
+import itMessages from '@/locales/it.json';
+
+// Flatten nested i18n JSON to { 'a.b.c': 'value' } for IntlProvider
+function flattenMessages(obj: Record<string, unknown>, prefix = ''): Record<string, string> {
+  return Object.entries(obj).reduce<Record<string, string>>((acc, [key, val]) => {
+    const fullKey = prefix ? `${prefix}.${key}` : key;
+    if (typeof val === 'string') {
+      acc[fullKey] = val;
+    } else if (typeof val === 'object' && val !== null) {
+      Object.assign(acc, flattenMessages(val as Record<string, unknown>, fullKey));
+    }
+    return acc;
+  }, {});
+}
+
+const FLAT_IT = flattenMessages(itMessages as Record<string, unknown>);
+
+// ─── Mock usePlayRecordPhotoUpload ────────────────────────────────────────────
+
+const mutateAsyncMock = vi.fn();
+
+vi.mock('@/hooks/mutations/usePlayRecordPhotoUpload', () => ({
+  usePlayRecordPhotoUpload: () => ({
+    mutateAsync: mutateAsyncMock,
+    isPending: false,
+  }),
+}));
+
+// Mock heic2any to avoid browser API issues in jsdom
+vi.mock('heic2any', () => ({ default: vi.fn() }));
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeWrapper(qc?: QueryClient) {
+  const client = qc ?? new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={client}>
+        <IntlProvider locale="it" messages={FLAT_IT}>
+          {children}
+        </IntlProvider>
+      </QueryClientProvider>
+    );
+  };
+}
+
+function makeFile(name: string, type = 'image/jpeg', size = 1024): File {
+  return new File(['x'.repeat(size)], name, { type });
+}
+
+import { EndgamePhotoUploadSection } from '../EndgamePhotoUploadSection';
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('EndgamePhotoUploadSection', () => {
+  beforeEach(() => {
+    mutateAsyncMock.mockReset();
+    // jsdom does not implement URL.createObjectURL; provide a stub
+    global.URL.createObjectURL = vi.fn(() => 'blob:mock-url');
+    global.URL.revokeObjectURL = vi.fn();
+  });
+
+  it('selecting_files_shows_local_previews — 2 files shown even with recordId=null', () => {
+    render(<EndgamePhotoUploadSection recordId={null} />, {
+      wrapper: makeWrapper(),
+    });
+
+    const input = screen.getByLabelText(/seleziona foto/i);
+    const file1 = makeFile('photo1.jpg');
+    const file2 = makeFile('photo2.jpg');
+    fireEvent.change(input, { target: { files: [file1, file2] } });
+
+    expect(screen.getAllByTestId('photo-preview-item')).toHaveLength(2);
+  });
+
+  it('upload_disabled_while_recordId_null — button disabled when null, enabled when present', () => {
+    const { rerender } = render(<EndgamePhotoUploadSection recordId={null} />, {
+      wrapper: makeWrapper(),
+    });
+
+    const input = screen.getByLabelText(/seleziona foto/i);
+    fireEvent.change(input, { target: { files: [makeFile('photo1.jpg')] } });
+
+    const uploadBtn = screen.getByRole('button', { name: /carica foto/i });
+    expect(uploadBtn).toBeDisabled();
+
+    rerender(<EndgamePhotoUploadSection recordId="rec-123" />);
+    expect(screen.getByRole('button', { name: /carica foto/i })).not.toBeDisabled();
+  });
+
+  it('successful_upload_marks_photo_done_and_calls_onUploadingChange', async () => {
+    mutateAsyncMock.mockResolvedValue({
+      photoId: 'p1',
+      photoUrl: 'http://example.com/p1.jpg',
+      thumbnailUrl: null,
+      ocrText: null,
+      wasDeduplicated: false,
+    });
+
+    const onUploadingChange = vi.fn();
+    render(<EndgamePhotoUploadSection recordId="rec-123" onUploadingChange={onUploadingChange} />, {
+      wrapper: makeWrapper(),
+    });
+
+    const input = screen.getByLabelText(/seleziona foto/i);
+    fireEvent.change(input, { target: { files: [makeFile('photo1.jpg')] } });
+
+    const uploadBtn = screen.getByRole('button', { name: /carica foto/i });
+    fireEvent.click(uploadBtn);
+
+    await waitFor(() => expect(screen.getByText(/caricata/i)).toBeInTheDocument());
+    expect(onUploadingChange).toHaveBeenCalledWith(true);
+    expect(onUploadingChange).toHaveBeenCalledWith(false);
+  });
+
+  it('failed_upload_shows_inline_error_and_retry — retry resolves to done', async () => {
+    mutateAsyncMock.mockRejectedValueOnce(new Error('Upload failed')).mockResolvedValueOnce({
+      photoId: 'p2',
+      photoUrl: 'http://example.com/p2.jpg',
+      thumbnailUrl: null,
+      ocrText: null,
+      wasDeduplicated: false,
+    });
+
+    render(<EndgamePhotoUploadSection recordId="rec-123" />, {
+      wrapper: makeWrapper(),
+    });
+
+    const input = screen.getByLabelText(/seleziona foto/i);
+    fireEvent.change(input, { target: { files: [makeFile('photo1.jpg')] } });
+
+    const uploadBtn = screen.getByRole('button', { name: /carica foto/i });
+    fireEvent.click(uploadBtn);
+
+    // Should show inline error alert on per-photo item
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
+
+    // Retry button should appear
+    const retryBtn = screen.getByRole('button', { name: /riprova/i });
+    expect(retryBtn).toBeInTheDocument();
+
+    // Click retry
+    fireEvent.click(retryBtn);
+
+    // Should now show done badge
+    await waitFor(() => expect(screen.getByText(/caricata/i)).toBeInTheDocument());
+  });
+
+  it('respects_max_files — caps selection to 10, shows warning alert if more', () => {
+    render(<EndgamePhotoUploadSection recordId="rec-123" />, {
+      wrapper: makeWrapper(),
+    });
+
+    const input = screen.getByLabelText(/seleziona foto/i);
+    const files = Array.from({ length: 12 }, (_, i) => makeFile(`photo${i}.jpg`));
+    fireEvent.change(input, { target: { files } });
+
+    // Capped to 10
+    expect(screen.getAllByTestId('photo-preview-item')).toHaveLength(10);
+    // Warning alert about too many files
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/features/session-live/__tests__/EndgamePhotoUploadSection.test.tsx
+++ b/apps/web/src/components/features/session-live/__tests__/EndgamePhotoUploadSection.test.tsx
@@ -90,7 +90,7 @@ describe('EndgamePhotoUploadSection', () => {
     expect(screen.getAllByTestId('photo-preview-item')).toHaveLength(2);
   });
 
-  it('upload_disabled_while_recordId_null — button disabled when null, enabled when present', () => {
+  it('upload_disabled_while_recordId_null — shows preparing label when null, carica label when present', () => {
     const { rerender } = render(<EndgamePhotoUploadSection recordId={null} />, {
       wrapper: makeWrapper(),
     });
@@ -98,10 +98,12 @@ describe('EndgamePhotoUploadSection', () => {
     const input = screen.getByLabelText(/seleziona foto/i);
     fireEvent.change(input, { target: { files: [makeFile('photo1.jpg')] } });
 
-    const uploadBtn = screen.getByRole('button', { name: /carica foto/i });
-    expect(uploadBtn).toBeDisabled();
+    // When recordId=null the button shows the "preparing" label and is disabled
+    const preparingBtn = screen.getByRole('button', { name: /preparazione/i });
+    expect(preparingBtn).toBeDisabled();
 
     rerender(<EndgamePhotoUploadSection recordId="rec-123" />);
+    // After recordId is set the button switches to the upload label and is enabled
     expect(screen.getByRole('button', { name: /carica foto/i })).not.toBeDisabled();
   });
 
@@ -130,37 +132,65 @@ describe('EndgamePhotoUploadSection', () => {
     expect(onUploadingChange).toHaveBeenCalledWith(false);
   });
 
-  it('failed_upload_shows_inline_error_and_retry — retry resolves to done', async () => {
-    mutateAsyncMock.mockRejectedValueOnce(new Error('Upload failed')).mockResolvedValueOnce({
-      photoId: 'p2',
-      photoUrl: 'http://example.com/p2.jpg',
-      thumbnailUrl: null,
-      ocrText: null,
-      wasDeduplicated: false,
-    });
+  it('failed_upload_shows_inline_error_and_retry — first photo errors, second succeeds; retry resolves first to done', async () => {
+    // photo1 fails, photo2 succeeds on initial upload
+    mutateAsyncMock
+      .mockRejectedValueOnce(new Error('Upload failed')) // photo1 initial attempt → error
+      .mockResolvedValueOnce({
+        // photo2 initial attempt → done
+        photoId: 'p2',
+        photoUrl: 'http://example.com/p2.jpg',
+        thumbnailUrl: null,
+        ocrText: null,
+        wasDeduplicated: false,
+      })
+      .mockResolvedValueOnce({
+        // photo1 retry → done
+        photoId: 'p1',
+        photoUrl: 'http://example.com/p1.jpg',
+        thumbnailUrl: null,
+        ocrText: null,
+        wasDeduplicated: false,
+      });
 
     render(<EndgamePhotoUploadSection recordId="rec-123" />, {
       wrapper: makeWrapper(),
     });
 
     const input = screen.getByLabelText(/seleziona foto/i);
-    fireEvent.change(input, { target: { files: [makeFile('photo1.jpg')] } });
+    // Select 2 files
+    fireEvent.change(input, {
+      target: { files: [makeFile('photo1.jpg'), makeFile('photo2.jpg')] },
+    });
 
     const uploadBtn = screen.getByRole('button', { name: /carica foto/i });
     fireEvent.click(uploadBtn);
 
-    // Should show inline error alert on per-photo item
+    // (a) photo1 should show an inline error and retry button
     await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
-
-    // Retry button should appear
     const retryBtn = screen.getByRole('button', { name: /riprova/i });
     expect(retryBtn).toBeInTheDocument();
 
-    // Click retry
+    // (b) photo2 should be in the "done" state (not affected by photo1 error)
+    // The done badge appears for photo2 while photo1 still has the error
+    await waitFor(() => {
+      const items = screen.getAllByTestId('photo-preview-item');
+      expect(items).toHaveLength(2);
+      const doneItems = items.filter(el => el.getAttribute('data-status') === 'done');
+      const errorItems = items.filter(el => el.getAttribute('data-status') === 'error');
+      expect(doneItems).toHaveLength(1); // photo2 is done
+      expect(errorItems).toHaveLength(1); // photo1 is in error
+    });
+
+    // Click retry on photo1 — should resolve to done
     fireEvent.click(retryBtn);
 
-    // Should now show done badge
-    await waitFor(() => expect(screen.getByText(/caricata/i)).toBeInTheDocument());
+    // Now both should be done
+    await waitFor(() => {
+      const items = screen.getAllByTestId('photo-preview-item');
+      const doneItems = items.filter(el => el.getAttribute('data-status') === 'done');
+      expect(doneItems).toHaveLength(2);
+    });
   });
 
   it('respects_max_files — caps selection to 10, shows warning alert if more', () => {

--- a/apps/web/src/components/play-records/photos/PlayRecordPhotoUploadDialog.tsx
+++ b/apps/web/src/components/play-records/photos/PlayRecordPhotoUploadDialog.tsx
@@ -13,10 +13,15 @@ import {
 import { Button } from '@/components/ui/primitives/button';
 import { usePlayRecordPhotoUpload } from '@/hooks/mutations/usePlayRecordPhotoUpload';
 import { useTranslation } from '@/hooks/useTranslation';
+import {
+  PHOTO_MAX_BYTES,
+  PHOTO_MAX_FILES,
+  PHOTO_ACCEPTED_MIME,
+} from '@/lib/play-records/photo-constants';
 
-const MAX_BYTES = 5 * 1024 * 1024; // 5MB — matches BE validator
-const MAX_FILES = 10;
-const ACCEPTED_MIME = ['image/jpeg', 'image/png', 'image/webp', 'image/heic'];
+const MAX_BYTES = PHOTO_MAX_BYTES;
+const MAX_FILES = PHOTO_MAX_FILES;
+const ACCEPTED_MIME = PHOTO_ACCEPTED_MIME;
 
 export interface PlayRecordPhotoUploadDialogProps {
   recordId: string;

--- a/apps/web/src/lib/play-records/photo-constants.ts
+++ b/apps/web/src/lib/play-records/photo-constants.ts
@@ -1,0 +1,13 @@
+/**
+ * Shared constants for play-record photo uploads.
+ * Used by EndgamePhotoUploadSection and PlayRecordPhotoUploadDialog.
+ */
+
+/** Maximum size per photo file (5 MB) — mirrors BE validator */
+export const PHOTO_MAX_BYTES = 5 * 1024 * 1024;
+
+/** Maximum number of photos per upload batch */
+export const PHOTO_MAX_FILES = 10;
+
+/** Accepted MIME types for photo uploads */
+export const PHOTO_ACCEPTED_MIME = ['image/jpeg', 'image/png', 'image/webp', 'image/heic'];

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -3269,6 +3269,7 @@
         "viewSummaryCta": "View summary",
         "saveGameCta": "Save game",
         "savingLabel": "Saving…",
+        "alreadyCompletedToast": "Game already finished",
         "photoUpload": {
           "sectionTitle": "Game photos",
           "addPhotosCta": "Select photos",

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -3268,7 +3268,21 @@
         "acknowledgeCta": "Got it",
         "viewSummaryCta": "View summary",
         "saveGameCta": "Save game",
-        "savingLabel": "Saving…"
+        "savingLabel": "Saving…",
+        "photoUpload": {
+          "sectionTitle": "Game photos",
+          "addPhotosCta": "Select photos",
+          "uploadCta": "Upload photos",
+          "uploadingLabel": "Uploading…",
+          "preparingLabel": "Preparing…",
+          "retryCta": "Retry",
+          "doneBadge": "Uploaded",
+          "errorGeneric": "Upload failed",
+          "tooManyFiles": "You can upload at most {max} photos",
+          "tooLarge": "File too large (max 5 MB)",
+          "badFormat": "Format not supported",
+          "heicFailed": "HEIC conversion failed"
+        }
       },
       "endgameConfirm": {
         "title": "End the game?",

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -3281,7 +3281,8 @@
           "tooManyFiles": "You can upload at most {max} photos",
           "tooLarge": "File too large (max 5 MB)",
           "badFormat": "Format not supported",
-          "heicFailed": "HEIC conversion failed"
+          "heicFailed": "HEIC conversion failed",
+          "selectedPhotosList": "Selected photos"
         }
       },
       "endgameConfirm": {

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -3375,7 +3375,21 @@
         "acknowledgeCta": "Ho capito",
         "viewSummaryCta": "Vedi riepilogo",
         "saveGameCta": "Salva partita",
-        "savingLabel": "Salvataggio…"
+        "savingLabel": "Salvataggio…",
+        "photoUpload": {
+          "sectionTitle": "Foto della partita",
+          "addPhotosCta": "Seleziona foto",
+          "uploadCta": "Carica foto",
+          "uploadingLabel": "Caricamento…",
+          "preparingLabel": "Preparazione…",
+          "retryCta": "Riprova",
+          "doneBadge": "Caricata",
+          "errorGeneric": "Errore nel caricamento",
+          "tooManyFiles": "Puoi caricare al massimo {max} foto",
+          "tooLarge": "File troppo grande (max 5 MB)",
+          "badFormat": "Formato non supportato",
+          "heicFailed": "Conversione HEIC non riuscita"
+        }
       },
       "endgameConfirm": {
         "title": "Terminare la partita?",

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -3388,7 +3388,8 @@
           "tooManyFiles": "Puoi caricare al massimo {max} foto",
           "tooLarge": "File troppo grande (max 5 MB)",
           "badFormat": "Formato non supportato",
-          "heicFailed": "Conversione HEIC non riuscita"
+          "heicFailed": "Conversione HEIC non riuscita",
+          "selectedPhotosList": "Foto selezionate"
         }
       },
       "endgameConfirm": {

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -3376,6 +3376,7 @@
         "viewSummaryCta": "Vedi riepilogo",
         "saveGameCta": "Salva partita",
         "savingLabel": "Salvataggio…",
+        "alreadyCompletedToast": "Partita già conclusa",
         "photoUpload": {
           "sectionTitle": "Foto della partita",
           "addPhotosCta": "Seleziona foto",

--- a/docs/superpowers/plans/2026-06-28-issue-2501-sp4-endgame-photos.md
+++ b/docs/superpowers/plans/2026-06-28-issue-2501-sp4-endgame-photos.md
@@ -1,0 +1,161 @@
+# Epic #2501 SP4 — Foto in EndgameDialog Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Permettere all'host, alla chiusura di una sessione live, di aggiungere foto-ricordo della partita dalla finestra di endgame, caricandole sul `PlayRecord` appena creato — completando il momento 9-10 della user story #2506.
+
+**Architecture:** SP4 è **FE-only** e riusa l'infrastruttura foto `PlayRecord` già esistente (#2436/#2503). La sessione è già finalizzata (`Completed`) quando `EndgameDialog` si apre (il `/complete` è chiamato in `handleConfirmEndgame` PRIMA di montare il dialog); il `recordId` del nuovo `PlayRecord` arriva via il polling già wired `useResolvePlayRecord`. Le foto si caricano sul `PlayRecord` (endpoint `POST /play-records/{recordId}/photos`), **disaccoppiate dalla finalizzazione**: un fallimento foto non blocca il salvataggio/navigazione. Nessun nuovo BE, nessun endpoint media nativo.
+
+**Tech Stack:** Next.js 16 / React 19, Vitest + Testing Library, Tailwind 4 + shadcn/ui, React Query.
+
+## Global Constraints
+
+- **Riuso, non riscrittura**: usare gli hook/endpoint esistenti — `usePlayRecordPhotoUpload(recordId)`, `useResolvePlayRecord()`, `POST /play-records/{recordId}/photos`. NON creare un endpoint media nativo `/live-sessions/{id}/media` (out-of-scope, ADR-083 Direzione A non lo richiede per SP4).
+- **Foto opzionali (AC-MEDIA-2)**: il save/navigazione NON deve mai dipendere dalla presenza/successo delle foto.
+- **Upload disaccoppiato (AC-MEDIA-3)**: ogni foto ha il suo stato (idle/uploading/done/error) + retry inline; un errore foto resta inline e non blocca i CTA del dialog.
+- **recordId nullable durante il polling**: quando `EndgameDialog` si apre, `recordId` può essere `null` per 1-15s (polling). La sezione foto consente la **selezione + preview locale** sempre, ma l'**upload effettivo** parte solo quando `recordId != null` (durante il polling il bottone di upload è disabilitato con stato "preparazione").
+- **Token/design**: solo token semantici e utility entità (no `bg-white`/`text-gray-*` ecc.; ESLint `local/no-hardcoded-color-utility` è error). Riusare i pattern di `PlayRecordPhotoUploadDialog`/`PlayRecordPhotoGallery`.
+- **Vincoli foto** (allineati a `PlayRecordPhotoUploadDialog`): max 10 file, conversione HEIC→JPEG, validazione dimensione (riusare le costanti esistenti del dialog/uploader).
+- **i18n**: nessuna stringa hardcoded; chiavi in `it.json` + `en.json` sotto il namespace della session-live/endgame.
+- **Branch**: `feature/issue-2501-sp4-endgame-photos` (parent `main-dev`). SP4 è indipendente da SP0 (PR #2551) — NON serve quel branch.
+
+## Riferimenti di codice (verificati nell'esplorazione — leggerli prima di implementare)
+- `apps/web/src/components/features/session-live/EndgameDialog.tsx` (props `onSave?`, `saving?` ~righe 59-62; CTA ~206-243; markup punteggi ~176-204)
+- `apps/web/src/components/play-records/photos/PlayRecordPhotoUploadDialog.tsx` (reference da adattare in contentless: file multiselect, HEIC→JPEG, caption, OCR checkbox, error inline, MAX_FILES)
+- `apps/web/src/components/play-records/photos/PlayRecordPhotoGallery.tsx` (gallery read-only, props `{ photos, labels, className? }`)
+- `apps/web/src/hooks/mutations/usePlayRecordPhotoUpload.ts` (`usePlayRecordPhotoUpload(recordId)` → mutation; vars `{ file, caption?, extractScoreFromPhoto? }`; result `{ photoId, photoUrl, thumbnailUrl, ocrText, wasDeduplicated }`)
+- `apps/web/src/lib/session-live/use-resolve-play-record.ts` (`useResolvePlayRecord()` → `{ status, playRecordId, start }`)
+- `apps/web/src/hooks/mutations/useCompleteLiveSession.ts` (`useCompleteLiveSession(sessionId)`)
+- `apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx` (monta `EndgameDialog`; `resolvedPlayRecordId` ~riga 347; `handleConfirmEndgame` ~553-583; `completeLiveSession.mutate` ~571)
+
+---
+
+### Task 1: `EndgamePhotoUploadSection` (componente + i18n + test)
+
+**Files:**
+- Create: `apps/web/src/components/features/session-live/EndgamePhotoUploadSection.tsx`
+- Modify: `apps/web/src/i18n/messages/it.json`, `apps/web/src/i18n/messages/en.json`
+- Test: `apps/web/src/components/features/session-live/__tests__/EndgamePhotoUploadSection.test.tsx` (collocare seguendo il pattern dei test component esistenti — cercare con Glob i `__tests__` vicini)
+
+**Interfaces:**
+- Consumes: `usePlayRecordPhotoUpload(recordId)`; `PlayRecordPhotoGallery` (per le foto caricate, opzionale); le costanti vincoli foto di `PlayRecordPhotoUploadDialog` (MAX_FILES, validazione size, HEIC→JPEG).
+- Produces: componente `EndgamePhotoUploadSection` con props:
+  ```ts
+  interface EndgamePhotoUploadSectionProps {
+    recordId: string | null;          // null durante il polling → upload disabilitato
+    onUploadingChange?: (uploading: boolean) => void; // per disabilitare i CTA del dialog durante l'upload (AC-MEDIA-1 no doppio submit)
+    className?: string;
+  }
+  ```
+
+**Comportamento (per AC):**
+- AC-MEDIA-1: input file multiselect (max 10) → preview locale immediata (anche con `recordId === null`); un bottone "Carica foto" per file (o batch) che chiama `usePlayRecordPhotoUpload(recordId).mutateAsync({ file, caption, extractScoreFromPhoto })`. Bottone upload disabilitato quando `recordId === null` (mostra "preparazione…"). Durante l'upload chiama `onUploadingChange(true)`/`(false)`.
+- AC-MEDIA-3: ogni foto ha stato `idle|uploading|done|error`; su errore → messaggio inline sotto la preview + bottone "Riprova" che ri-chiama `mutateAsync` per quella sola foto. Un errore NON solleva eccezioni non gestite e NON blocca le altre foto.
+- AC-MEDIA-2: nessun comportamento che renda obbligatorie le foto (la sezione non espone alcun gate sul save — è il dialog a possedere i CTA).
+- AC-MEDIA-5 (read): dopo upload riuscito, mostrare le miniature (riusare `PlayRecordPhotoGallery` con le foto caricate, oppure le preview locali con badge "caricata").
+
+- [ ] **Step 1: Write the failing tests** (component test, Testing Library)
+  Test cases (asserzioni reali, non tautologiche):
+  1. `selecting_files_shows_local_previews` — selezionando 2 file appaiono 2 preview, anche con `recordId={null}`.
+  2. `upload_disabled_while_recordId_null` — con `recordId={null}` il bottone "Carica foto" è disabilitato; con `recordId="..."` è abilitato.
+  3. `successful_upload_marks_photo_done_and_calls_onUploadingChange` — mock `usePlayRecordPhotoUpload` che risolve; dopo l'upload la foto è marcata "caricata" e `onUploadingChange` è stato chiamato `true` poi `false`.
+  4. `failed_upload_shows_inline_error_and_retry` — mock che rifiuta una volta poi risolve; appare errore inline + bottone "Riprova"; al click la foto passa a "caricata"; le altre foto non sono impattate.
+  5. `respects_max_files` — selezionando >10 file ne tiene 10 e mostra un avviso.
+
+- [ ] **Step 2: Run tests to verify they fail**
+  Run: `cd apps/web && pnpm test EndgamePhotoUploadSection --run`
+  Expected: FAIL — componente non esiste.
+
+- [ ] **Step 3: Write the component + i18n keys**
+  Implementare `EndgamePhotoUploadSection` adattando la logica file/HEIC/validazione di `PlayRecordPhotoUploadDialog` (smontandola dal wrapper Dialog), con la state-machine per-foto e il retry. Aggiungere le chiavi i18n in `it.json`/`en.json` (namespace coerente con le altre chiavi session-live/endgame — verificarlo nel file): label "Aggiungi foto", "Carica foto", "Riprova", template errore, "preparazione…", avviso max foto. NESSUNA stringa hardcoded.
+
+- [ ] **Step 4: Run tests to verify they pass**
+  Run: `pnpm test EndgamePhotoUploadSection --run` → PASS. Poi `pnpm typecheck && pnpm lint` su scope (no violazioni token/i18n).
+
+- [ ] **Step 5: Commit**
+  ```bash
+  git add apps/web/src/components/features/session-live/EndgamePhotoUploadSection.tsx apps/web/src/components/features/session-live/__tests__/EndgamePhotoUploadSection.test.tsx apps/web/src/i18n/messages/it.json apps/web/src/i18n/messages/en.json
+  git commit -m "feat(session-live): #2501 SP4 EndgamePhotoUploadSection component"
+  ```
+
+---
+
+### Task 2: Montare la sezione foto in `EndgameDialog`
+
+**Files:**
+- Modify: `apps/web/src/components/features/session-live/EndgameDialog.tsx`
+- Test: estendere il test esistente di `EndgameDialog` (cercare con Glob; se assente crearlo accanto)
+
+**Interfaces:**
+- Consumes: `EndgamePhotoUploadSection` (Task 1).
+- Produces: `EndgameDialog` con nuove props:
+  ```ts
+  recordId?: string | null;   // passato a EndgamePhotoUploadSection
+  // internamente: disabilita i CTA durante l'upload via onUploadingChange
+  ```
+
+- [ ] **Step 1: Write the failing test**
+  1. `renders_photo_section_above_ctas` — quando il dialog è aperto, `EndgamePhotoUploadSection` è renderizzata sopra i CTA "Salva partita"/"Conferma".
+  2. `disables_save_cta_while_photos_uploading` — quando la sezione segnala `onUploadingChange(true)`, il CTA "Salva partita" è disabilitato; a `false` torna abilitato (AC-MEDIA-1 no doppio submit).
+  3. `save_cta_enabled_with_no_photos` — senza foto selezionate il CTA "Salva partita" resta abilitato (AC-MEDIA-2).
+
+- [ ] **Step 2: Run test to verify it fails**
+  Run: `pnpm test EndgameDialog --run` → FAIL.
+
+- [ ] **Step 3: Implement**
+  In `EndgameDialog.tsx`: aggiungere la prop `recordId?: string | null`; montare `<EndgamePhotoUploadSection recordId={recordId} onUploadingChange={setUploading} />` sopra i CTA; mantenere un `useState` `uploading` che disabilita il CTA "Salva partita" (`disabled={saving || uploading}`). NON alterare il comportamento esistente di `onSave`/`onAcknowledge`/focus-trap.
+
+- [ ] **Step 4: Run test to verify it passes**
+  Run: `pnpm test EndgameDialog --run` → PASS.
+
+- [ ] **Step 5: Commit**
+  ```bash
+  git add apps/web/src/components/features/session-live/EndgameDialog.tsx apps/web/src/components/features/session-live/__tests__
+  git commit -m "feat(session-live): #2501 SP4 mount photo section in EndgameDialog"
+  ```
+
+---
+
+### Task 3: Wiring `SessionLiveView` (recordId + 409 handler)
+
+**Files:**
+- Modify: `apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx`
+- Test: estendere i test esistenti di `SessionLiveView` (Glob)
+
+**Interfaces:**
+- Consumes: `resolvedPlayRecordId` (già presente ~riga 347), `EndgameDialog` con la nuova prop `recordId` (Task 2), `completeLiveSession` (già presente).
+
+- [ ] **Step 1: Write the failing test**
+  1. `passes_resolved_record_id_to_endgame_dialog` — quando `useResolvePlayRecord` risolve un id, `EndgameDialog` riceve `recordId={resolvedPlayRecordId}`.
+  2. `complete_409_shows_already_completed_toast_and_no_navigation` — se `completeLiveSession.mutate` fallisce con 409, viene mostrato un toast "Partita già conclusa" (sonner) e NON si naviga (AC-MEDIA-4).
+
+- [ ] **Step 2: Run test to verify it fails**
+  Run: `pnpm test SessionLiveView --run` → FAIL.
+
+- [ ] **Step 3: Implement**
+  - Passare `recordId={resolvedPlayRecordId}` al `<EndgameDialog .../>`.
+  - Aggiungere un `onError` su `completeLiveSession.mutate` (in `handleConfirmEndgame`) che, sul 409, mostra `toast` (sonner) con la chiave i18n "partita già conclusa" e non avvia il polling/navigazione. Per altri errori, comportamento esistente (o toast generico se assente). Aggiungere la chiave i18n in `it.json`/`en.json`.
+
+- [ ] **Step 4: Run test to verify it passes**
+  Run: `pnpm test SessionLiveView --run` → PASS. Poi `pnpm typecheck && pnpm lint`.
+
+- [ ] **Step 5: Run the session-live suite (no regressions)**
+  Run: `pnpm test session-live --run` (o il path della cartella) → PASS, nessuna nuova rottura.
+
+- [ ] **Step 6: Commit**
+  ```bash
+  git add apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx apps/web/src/i18n/messages/it.json apps/web/src/i18n/messages/en.json
+  git commit -m "feat(session-live): #2501 SP4 wire recordId + 409 handler in SessionLiveView"
+  ```
+
+---
+
+## Out of scope (tracciato)
+- Endpoint media nativo `/live-sessions/{id}/media` (ADR-083 non lo richiede per SP4; le foto vivono su PlayRecord).
+- AC-MEDIA-4 lato BE (il 409 su `/complete` per sessione già `Completed`): verificare che esista già in `CompleteLiveSessionCommandHandler`; se mancante, follow-up BE separato (non bloccare SP4 FE).
+- AC-MEDIA-5 BE outbox/evento: `PlayRecordDto.photos[]` è già esposto; nessun lavoro.
+
+## Self-Review
+- **Spec coverage**: AC-MEDIA-1 (sezione+CTA+upload, no doppio submit) → Task 1+2; AC-MEDIA-2 (opzionali) → Task 1+2 (nessun gate); AC-MEDIA-3 (disaccoppiato+retry) → Task 1; AC-MEDIA-4 (409) → Task 3 (FE) + verifica BE in Out-of-scope; AC-MEDIA-5 (read) → già esposto. ✓
+- **Placeholder scan**: i test hanno casi e asserzioni nominate; il codice del componente fa riferimento esplicito a `PlayRecordPhotoUploadDialog` da adattare (non "TODO"). ✓
+- **Type consistency**: `recordId: string | null` usato identico in Task 1/2/3; `onUploadingChange` coerente Task 1↔2. ✓


### PR DESCRIPTION
## Epic #2501 — SP4: foto-ricordo alla chiusura sessione live

Completa il momento 9-10 della user story #2506 («l'host fa una serie di foto per ricordo e salva la partita»): nella finestra di endgame l'host può ora aggiungere foto, caricate sul `PlayRecord` appena creato.

### Cosa fa
- **Nuovo componente** `EndgamePhotoUploadSection` (FE): selezione multi-file (max 10, HEIC→JPEG), preview locale, upload per-foto via l'hook esistente `usePlayRecordPhotoUpload(recordId)`, state-machine per-foto (`idle/uploading/done/error`) con **retry inline** isolato per foto.
- **Montato in `EndgameDialog`** sopra i CTA; il CTA "Salva partita" è disabilitato durante l'upload (no doppio submit).
- **`SessionLiveView`** passa `recordId={resolvedPlayRecordId}` (dal polling `useResolvePlayRecord` già wired) + handler **409** su `/complete` (toast "Partita già conclusa" + nessuna navigazione).

### Architettura
SP4 è **FE-only** e **indipendente da SP0/SP2/SP3**: riusa interamente l'infrastruttura foto `PlayRecord` (#2436/#2503) — `usePlayRecordPhotoUpload`, endpoint `POST /play-records/{recordId}/photos`, `PlayRecordDto.photos[]`. Nessun endpoint media nativo, nessun nuovo BE. La sessione è già `Completed` quando il dialog si apre; le foto si caricano sul `PlayRecord` (recordId via polling), **disaccoppiate dalla finalizzazione** — un errore foto non blocca il salvataggio. Costanti foto estratte in `lib/play-records/photo-constants.ts` (DRY, condivise con `PlayRecordPhotoUploadDialog`).

### Acceptance Criteria
- **AC-MEDIA-1** sezione+CTA+upload, no doppio submit ✓
- **AC-MEDIA-2** foto opzionali, save mai bloccato ✓
- **AC-MEDIA-3** upload disaccoppiato + retry per-foto, nessuna unhandled rejection ✓
- **AC-MEDIA-4** 409 idempotenza ✓ (FE toast + **BE verificato**: `LiveGameSession.Complete()` lancia `ConflictException`→409 se lo stato non è InProgress/Paused)
- **AC-MEDIA-5** foto esposte da `PlayRecordDto.photos[]` (infra esistente) ✓

### Test
- `EndgamePhotoUploadSection` 5/5 · `EndgameDialog` 26/26 · `SessionLiveView` 107/107 · cluster session-live **659/659** (verifica indipendente).
- Token semantici (no colori hardcoded), a11y (aria-label i18n, role=alert, cleanup object URL), i18n it/en allineati.

### Review
- 3 task-review per dispatch (D1 con fix wave su 4 finding, D2/D3 Approved) + review finale adversarial whole-branch: **READY_WITH_FOLLOWUPS**, 0 Critical, 0 Important.

### Follow-up (cosmetici, non bloccanti)
- Pulizia `querySelector` morto in un'asserzione di `SessionLiveView.test.tsx` (il caso enabled/disabled del bottone è già coperto da D1/D2).
- _(Nota: `recordId ?? null` in EndgameDialog è necessario per il typecheck, non un difetto; dual-409-detection è il pattern difensivo stabilito nel codebase.)_

### Riferimenti
- ADR-083, spec Fase 2 `docs/for-developers/specs/2026-06-23-epic-2501-fase2-live-session-feature-gaps.md`
- Plan: `docs/superpowers/plans/2026-06-28-issue-2501-sp4-endgame-photos.md`
- Epic #2501 · user story #2506 · infra #2436/#2503

🤖 Generated with [Claude Code](https://claude.com/claude-code)