### PR TITLE
feat(rag): #2480 commit golden baseline + enable weekly rag-smoke cron

### DIFF
--- a/.github/workflows/rag-smoke-dispatch.yml
+++ b/.github/workflows/rag-smoke-dispatch.yml
@@ -8,16 +8,26 @@ name: RAG Smoke (canonical queries vs golden baseline)
 # retrieval regressions (embedding model / chunker / index drift) that the bake
 # smoke does not cover.
 #
-# ⚠️ DISPATCH-ONLY (no cron) until the golden baseline is committed:
-#   R2 snapshot distribution now WORKS (#2516): the dedicated meepleai-seed-snapshots
-#   bucket + SEED_BLOB_* repo secrets are configured, and dev-from-snapshot fetches
-#   the published snapshot via the read creds synthesized in "Configure snapshot
-#   bucket read credentials" below. The only remaining step before the weekly
-#   schedule is committing the golden baseline for the published snapshot: dispatch
-#   with update_baseline=true, download the artifact, and commit
-#   infra/fixtures/rag-golden-baseline.json. Flip to `schedule:` in that same PR.
+# Runs weekly (schedule) in ASSERT mode against the committed golden baseline, and
+# can be dispatched manually to re-capture the baseline (update_baseline=true) after a
+# re-bake. R2 snapshot distribution works (#2516): the dedicated meepleai-seed-snapshots
+# bucket + SEED_BLOB_* repo secrets are configured, and dev-from-snapshot fetches the
+# published snapshot via the read creds synthesized in "Configure snapshot bucket read
+# credentials" below. The golden baseline was first committed for snapshot
+# meepleai_seed_20260628T211806Z_intfloat_multilingual-e5-base_7cee37d47 (#2480).
+#
+# Re-baseline procedure (after a re-bake that changes the EF head / embedding model):
+#   1. re-bake + publish (seed-snapshot-bake-full.yml -f publish=true)
+#   2. dispatch this workflow with update_baseline=true
+#   3. download the rag-golden-baseline-<run_id> artifact, commit infra/fixtures/rag-golden-baseline.json
+#
+# On a schedule trigger github.event.inputs.update_baseline is empty → assert mode.
 
 on:
+  schedule:
+    # Weekly, Monday 05:37 UTC. Off-peak + offset minute (ADR-078: stay under the
+    # API/runner budget, avoid the top-of-hour cron stampede). Asserts only.
+    - cron: '37 5 * * 1'
   workflow_dispatch:
     inputs:
       update_baseline:

--- a/docs/for-developers/operations/rag-smoke-runbook.md
+++ b/docs/for-developers/operations/rag-smoke-runbook.md
@@ -37,16 +37,16 @@ make rag-smoke          # or: bash scripts/rag-smoke-assert.sh
 ```
 Exit 0 = all queries match. Exit 1 = a query drifted (prints expected vs got) or returned no citations.
 
-## CI status — DISPATCH-ONLY
+## CI status — WEEKLY CRON (assert) + manual re-baseline
 
-`.github/workflows/rag-smoke-dispatch.yml` is `workflow_dispatch` only (no cron). It cannot run on a schedule yet because `make dev-from-snapshot` → `snapshot-fetch.sh` downloads the `.dump` from the R2 seed blob bucket, and that publish path is **broken**:
+`.github/workflows/rag-smoke-dispatch.yml` runs **weekly on a schedule** (Monday 05:37 UTC) in **assert** mode against the committed golden baseline, and can still be dispatched manually to re-capture the baseline (`update_baseline=true`). R2 snapshot distribution works ([#2516](https://github.com/meepleAi-app/meepleai-monorepo/issues/2516)): the dedicated `meepleai-seed-snapshots` bucket + `SEED_BLOB_*` repo secrets are configured, and `dev-from-snapshot` fetches the published snapshot via the read creds synthesized in the workflow's "Configure snapshot bucket read credentials" step. On a `schedule` trigger `github.event.inputs.update_baseline` is empty → assert mode; a drift opens a tracking issue automatically.
 
-- `SEED_BLOB_*` repo secrets are not configured (only `SEED_BUCKET_*` for the source PDFs exist).
-- R2 PUT is broken ([#2271](https://github.com/meepleAi-app/meepleai-monorepo/issues/2271)).
+The golden baseline was first committed for snapshot `meepleai_seed_20260628T211806Z_intfloat_multilingual-e5-base_7cee37d47` (#2480), after the RAG retrieval fixes in #2556 (cross-game DbContext concurrency) + #2559 (restored `text_chunks`/`pdf_documents.search_vector` columns).
 
-**To enable the weekly cron**: (1) fix snapshot publish (configure `SEED_BLOB_*` + resolve #2271), (2) publish a fresh snapshot, (3) capture + commit the golden baseline for it, (4) add a `schedule:` trigger to the workflow.
-
-Until then the golden baseline is captured locally against the fresh snapshot.
+**Re-baseline after an intentional re-bake** (EF head / embedding-model / chunker change):
+1. re-bake + publish: `seed-snapshot-bake-full.yml -f publish=true`
+2. dispatch this workflow with `update_baseline=true`
+3. download the `rag-golden-baseline-<run_id>` artifact, commit `infra/fixtures/rag-golden-baseline.json`
 
 ## Canonical queries
 

--- a/infra/fixtures/rag-golden-baseline.json
+++ b/infra/fixtures/rag-golden-baseline.json
@@ -1,8 +1,79 @@
 {
   "schemaVersion": 1,
   "_comment": "Golden baseline for the RAG smoke harness (#2480). Captured once against a fresh, verified snapshot by running `bash infra/scripts/rag-smoke-assert.sh --update-baseline` after `make dev-from-snapshot`. Each entry pins the top-3 retrieved chunks (source + page) for a canonical query; the harness then fails if retrieval drifts. relevanceScore is advisory (compared with tolerance, not exact). Regenerate after an intentional re-index (embedding model change, chunker change, seed-table schema-version bump). See docs/for-developers/operations/rag-smoke-runbook.md.",
-  "capturedAt": null,
-  "snapshot": null,
-  "embeddingModel": null,
-  "baseline": {}
+  "capturedAt": "2026-06-28T22:08:07Z",
+  "snapshot": "meepleai_seed_20260628T211806Z_intfloat_multilingual-e5-base_7cee37d47",
+  "embeddingModel": "intfloat/multilingual-e5-base",
+  "baseline": {
+    "catan-setup": [
+      {
+        "source": "13dc2236-f2bb-40de-b8de-ae7e8bdd4c19",
+        "page": 1
+      },
+      {
+        "source": "5a3acd1c-cd07-4442-b1fa-289b8039a22f",
+        "page": 1
+      },
+      {
+        "source": "99167cf5-8e69-43ec-80ea-f38d1dfe1722",
+        "page": 1
+      }
+    ],
+    "wingspan-round-goals": [
+      {
+        "source": "13dc2236-f2bb-40de-b8de-ae7e8bdd4c19",
+        "page": 1
+      },
+      {
+        "source": "142799c3-5ebc-4b44-b4e5-f89b614ec372",
+        "page": 1
+      },
+      {
+        "source": "5a3acd1c-cd07-4442-b1fa-289b8039a22f",
+        "page": 1
+      }
+    ],
+    "dominion-buy-phase": [
+      {
+        "source": "13dc2236-f2bb-40de-b8de-ae7e8bdd4c19",
+        "page": 1
+      },
+      {
+        "source": "19c2bc2a-4141-4a4a-bf3b-30a0e901d981",
+        "page": 1
+      },
+      {
+        "source": "5a3acd1c-cd07-4442-b1fa-289b8039a22f",
+        "page": 1
+      }
+    ],
+    "ark-nova-conservation": [
+      {
+        "source": "13dc2236-f2bb-40de-b8de-ae7e8bdd4c19",
+        "page": 1
+      },
+      {
+        "source": "aa3fcffa-010f-4a97-83ea-91b69559db1c",
+        "page": 1
+      },
+      {
+        "source": "c2eee70b-20b4-468c-8d42-04efff9e5cb8",
+        "page": 1
+      }
+    ],
+    "seven-wonders-military": [
+      {
+        "source": "13dc2236-f2bb-40de-b8de-ae7e8bdd4c19",
+        "page": 1
+      },
+      {
+        "source": "5a3acd1c-cd07-4442-b1fa-289b8039a22f",
+        "page": 1
+      },
+      {
+        "source": "8fd0666f-ddc1-4b6a-9d5b-ae4060528e16",
+        "page": 1
+      }
+    ]
+  }
 }


### PR DESCRIPTION
## Sommario

Chiude #2480: la RAG smoke harness ora restituisce citazioni e gira settimanalmente in assert mode contro la golden baseline committata.

## Contesto — root cause RAG risolta a monte
La smoke restituiva 0 citazioni per due bug di prodotto reali, ora mergiati:
- **#2556** — `MultiGameHybridSearchService` condivideva il DbContext scoped tra `Task.WhenAll` per-game → "A second operation was started on this context". Fix: `IServiceScopeFactory` per-task + `SemaphoreSlim`.
- **#2559** — colonne `text_chunks.search_vector` + `pdf_documents.search_vector` perse nello squash → keyword search lanciava `42703 column search_vector does not exist` → `Task.WhenAll` abortiva l'intero hybrid. Fix: migration `AddSearchVectorColumns` (GENERATED tsvector config `italian`, per combaciare col query path runtime).

Dopo un re-bake fresco (run 28333487514, snapshot `…_7cee37d47`) la baseline capture (run 28337120477) ha restituito **3 citazioni per ognuna delle 5 query canoniche** (catan / wingspan / dominion / ark-nova / seven-wonders).

## Cosa fa questo PR
1. **Committa la golden baseline** popolata in `infra/fixtures/rag-golden-baseline.json` (era placeholder vuoto), snapshot `meepleai_seed_20260628T211806Z_intfloat_multilingual-e5-base_7cee37d47`, model e5-base.
2. **Flip a cron weekly**: aggiunge `schedule: '37 5 * * 1'` (Monday 05:37 UTC, off-peak + minuto offset per ADR-078) a `rag-smoke-dispatch.yml`. Su schedule → assert mode (`github.event.inputs.update_baseline` vuoto); un drift apre automaticamente una issue. Resta dispatchabile manualmente per re-baseline.
3. **Riconcilia il runbook** `rag-smoke-runbook.md` (claim obsoleti "R2 publish broken / SEED_BLOB unconfigured" → ora veri post-#2516).

## Verifica
- ✅ Baseline capture run 28337120477 SUCCESS (boot snapshot ✓, smoke ✓, 5/5 query con citazioni)
- ✅ YAML valido (`yaml.safe_load` OK)
- ✅ Schedule-mode sicuro: assert mode, upload-baseline skipped, drift-issue su failure

## Nota di follow-up (non bloccante)
Due source (`13dc2236…`, `5a3acd1c…`) ricorrono in quasi tutte le query — possibile relevance generica nel cross-game retrieval. La baseline cattura il comportamento attuale (scopo: regression detection); l'eventuale tuning di rilevanza è separato da #2480.

Closes #2480.

🤖 Generated with [Claude Code](https://claude.com/claude-code)