### PR TITLE
chore(security): bump js-yaml to >=4.2.0 (Dependabot #78, #86)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -293,7 +293,7 @@
       "flatted": ">=3.4.2",
       "glob": ">=10.5.0",
       "handlebars": ">=4.7.9",
-      "js-yaml": ">=4.1.1",
+      "js-yaml": ">=4.2.0",
       "lodash": ">=4.18.1",
       "lodash-es": ">=4.18.1",
       "markdown-it": ">=14.1.1",

--- a/apps/web/pnpm-lock.yaml
+++ b/apps/web/pnpm-lock.yaml
@@ -13,7 +13,7 @@ overrides:
   flatted: '>=3.4.2'
   glob: '>=10.5.0'
   handlebars: '>=4.7.9'
-  js-yaml: '>=4.1.1'
+  js-yaml: '>=4.2.0'
   lodash: '>=4.18.1'
   lodash-es: '>=4.18.1'
   markdown-it: '>=14.1.1'
@@ -2782,6 +2782,7 @@ packages:
 
   '@pdf-viewer/react@1.19.0':
     resolution: {integrity: sha512-XHfcldDAqHfvaaDBz6m4niZ5nQKlvmxtc5yd4P3QQldrdbp9qMTwtmjsNHUddLrHQav3EANt35Y8VrbjB4DKfw==}
+    deprecated: Package no longer supported. Contact support at https://www.react-pdf-kit.dev/contact-us for more info.
     peerDependencies:
       pdfjs-dist: 5.7.284
       react: ^18.2.0 || ^19.0.0
@@ -6816,6 +6817,7 @@ packages:
   git-raw-commits@5.0.1:
     resolution: {integrity: sha512-Y+csSm2GD/PCSh6Isd/WiMjNAydu0VBiG9J7EdQsNA5P9uXvLayqjmTsNlK5Gs9IhblFZqOU0yid5Il5JPoLiQ==}
     engines: {node: '>=18'}
+    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
     hasBin: true
 
   github-from-package@0.0.0:
@@ -7387,10 +7389,6 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
-
-  js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
-    hasBin: true
 
   js-yaml@4.2.0:
     resolution: {integrity: sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==}
@@ -10362,7 +10360,7 @@ snapshots:
     dependencies:
       '@jsdevtools/ono': 7.1.3
       '@types/json-schema': 7.0.15
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
 
   '@apidevtools/openapi-schemas@2.1.0': {}
 
@@ -11701,7 +11699,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.1.1
+      js-yaml: 4.2.0
       minimatch: 10.2.4
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -17649,10 +17647,6 @@ snapshots:
   js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
-
-  js-yaml@4.1.1:
-    dependencies:
-      argparse: 2.0.1
 
   js-yaml@4.2.0:
     dependencies:

--- a/scripts/release-gate/package.json
+++ b/scripts/release-gate/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@octokit/rest": "^21.0.2",
-    "js-yaml": "^4.1.0"
+    "js-yaml": "^4.2.0"
   },
   "devDependencies": {
     "vitest": "^3.2.6"

--- a/scripts/release-gate/pnpm-lock.yaml
+++ b/scripts/release-gate/pnpm-lock.yaml
@@ -15,8 +15,8 @@ importers:
         specifier: ^21.0.2
         version: 21.1.1
       js-yaml:
-        specifier: ^4.1.0
-        version: 4.1.1
+        specifier: ^4.2.0
+        version: 4.3.0
     devDependencies:
       vitest:
         specifier: ^3.2.6
@@ -466,8 +466,8 @@ packages:
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
-  js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+  js-yaml@4.3.0:
+    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
 
   lightningcss-android-arm64@1.32.0:
@@ -1063,7 +1063,7 @@ snapshots:
 
   js-tokens@9.0.1: {}
 
-  js-yaml@4.1.1:
+  js-yaml@4.3.0:
     dependencies:
       argparse: 2.0.1
 


### PR DESCRIPTION
## Sommario

Chiude la coda azionabile dello sweep Dependabot (#2515, già COMPLETED 2026-06-24): risolve i 2 alert MEDIUM ancora aperti su **js-yaml** (quadratic-complexity DoS in merge key handling via repeated aliases).

| Alert | Manifest | Prima | Dopo |
|---|---|---|---|
| #78 | `apps/web/pnpm-lock.yaml` | 4.1.1 (+4.2.0) | 4.2.0 only |
| #86 | `scripts/release-gate/pnpm-lock.yaml` | 4.1.1 | 4.3.0 |

## Modifiche
- `apps/web/package.json`: pnpm override `js-yaml` `>=4.1.1` → `>=4.2.0` → il lockfile elimina l'istanza stale 4.1.1 (restano solo 4.2.0).
- `scripts/release-gate/package.json`: dep diretta `^4.1.0` → `^4.2.0` → risolve a 4.3.0.
- Refresh lockfile `--lockfile-only`: diff **solo js-yaml** in entrambi (verificato — nessun altro pacchetto cambia versione).

## Verifica
- ✅ Diff chirurgico js-yaml-only (grep su version changes non-js-yaml = vuoto)
- ✅ Entrambe le versioni ≥ 4.2.0 (versione patchata) → chiudono #78/#86
- ⏳ CI lasciata girare (cambio dipendenze — niente admin-skip)

## Coda residua sweep (deferred, documentato)
- **esbuild** (#66/#67/#68, low): "arbitrary file read dev server Windows", **transitiva** → richiederebbe override per forzare 0.28.1; rischio/effort sproporzionato al valore (solo dev-server). Lasciato a Dependabot.
- **elliptic** (#3, low): **no patch disponibile** → deferred (coerente con #1455).

🤖 Generated with [Claude Code](https://claude.com/claude-code)