### PR TITLE
fix(rag): #2568 break cross-game RRF ties by raw cosine, not GUID

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/MultiGameHybridSearchService.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/MultiGameHybridSearchService.cs
@@ -94,13 +94,29 @@ internal sealed class MultiGameHybridSearchService : IMultiGameHybridSearchServi
         if (minScore > 0.0)
             aggregated = aggregated.Where(r => r.HybridScore >= (float)minScore).ToList();
 
-        // Step 4: Deterministic ordering (EC-4): score DESC, then ChunkIndex ASC, then PdfDocumentId ASC.
+        // Step 4: Ordering. Primary key is the fused HybridScore DESC.
+        //
+        // #2568: per-game RRF is rank-only, so EVERY game's rank-1 chunk gets the
+        // IDENTICAL fused HybridScore (vectorWeight/(rrfK+1) ≈ 0.01148). A bare
+        // ChunkIndex/PdfDocumentId tiebreak is query-agnostic, so the same lowest-index
+        // /lowest-GUID chunk won the tie for EVERY cross-game query (one document
+        // dominated unrelated-game queries). Break the tie by the globally-comparable
+        // raw vector cosine (VectorScore) DESC — the chunk actually most similar to THIS
+        // query wins — then keyword relevance (ts_rank_cd) DESC, and only then fall back
+        // to the deterministic ChunkIndex/PdfDocumentId ordering for true ties.
         aggregated.Sort(static (a, b) =>
         {
             var scoreCmp = b.HybridScore.CompareTo(a.HybridScore); // DESC
             if (scoreCmp != 0) return scoreCmp;
 
-            var chunkCmp = a.ChunkIndex.CompareTo(b.ChunkIndex);   // ASC
+            // null cosine (keyword-only hit) sorts below any real cosine match.
+            var vecCmp = (b.VectorScore ?? float.MinValue).CompareTo(a.VectorScore ?? float.MinValue); // DESC
+            if (vecCmp != 0) return vecCmp;
+
+            var kwCmp = (b.KeywordScore ?? float.MinValue).CompareTo(a.KeywordScore ?? float.MinValue); // DESC
+            if (kwCmp != 0) return kwCmp;
+
+            var chunkCmp = a.ChunkIndex.CompareTo(b.ChunkIndex);   // ASC (deterministic fallback)
             if (chunkCmp != 0) return chunkCmp;
 
             return string.Compare(a.PdfDocumentId, b.PdfDocumentId, StringComparison.Ordinal); // ASC

--- a/apps/api/src/Api/Services/HybridSearchService.cs
+++ b/apps/api/src/Api/Services/HybridSearchService.cs
@@ -127,19 +127,23 @@ internal class HybridSearchService : IHybridSearchService
 
         var results = vectorResults.Select((r, index) =>
         {
-            var chunkRoleTags = (GameBookRole)r.RoleTags;
+            var embedding = r.Embedding;
+            var chunkRoleTags = (GameBookRole)embedding.RoleTags;
             var baseScore = 1.0f / (index + 1); // normalized rank score
             var roleBoost = ComputeRoleMatchBoost(queryRoleHint, chunkRoleTags);
             return new HybridSearchResult
             {
-                ChunkId = $"{r.VectorDocumentId}_{r.ChunkIndex}",
-                Content = r.TextContent,
-                PdfDocumentId = r.VectorDocumentId.ToString(),
+                ChunkId = $"{embedding.VectorDocumentId}_{embedding.ChunkIndex}",
+                Content = embedding.TextContent,
+                PdfDocumentId = embedding.VectorDocumentId.ToString(),
                 GameId = gameId,
-                ChunkIndex = r.ChunkIndex,
-                PageNumber = r.PageNumber,
+                ChunkIndex = embedding.ChunkIndex,
+                PageNumber = embedding.PageNumber,
+                // HybridScore stays the rank-based base (+ role boost) so within-game ordering
+                // is unchanged. VectorScore carries the RAW cosine (#2568) so the cross-game
+                // merge can break rank-only ties by true query relevance.
                 HybridScore = baseScore + roleBoost,
-                VectorScore = baseScore,
+                VectorScore = (float)r.Score,
                 KeywordScore = null,
                 VectorRank = index + 1,
                 KeywordRank = null,
@@ -268,14 +272,17 @@ internal class HybridSearchService : IHybridSearchService
             : keywordResults.Where(r => documentIds.Any(id =>
                 string.Equals(id.ToString(), r.PdfDocumentId, StringComparison.Ordinal))).ToList();
 
-        // Convert pgvector results to SearchResultItem for RRF fusion
-        var vectorItems = vectorEmbeddings.Select(e => new SearchResultItem
+        // Convert pgvector results to SearchResultItem for RRF fusion.
+        // #2568: carry the raw cosine similarity (was hard-coded 1.0f) so the fused
+        // VectorScore reflects true relevance for the cross-game tiebreak. RRF still ranks
+        // by list position (Rank), so this does NOT change within-game ordering.
+        var vectorItems = vectorEmbeddings.Select(se => new SearchResultItem
         {
-            Score = 1.0f,
-            Text = e.TextContent,
-            PdfId = e.VectorDocumentId.ToString(),
-            ChunkIndex = e.ChunkIndex,
-            Page = e.PageNumber
+            Score = (float)se.Score,
+            Text = se.Embedding.TextContent,
+            PdfId = se.Embedding.VectorDocumentId.ToString(),
+            ChunkIndex = se.Embedding.ChunkIndex,
+            Page = se.Embedding.PageNumber
         }).ToArray();
 
         _logger.LogInformation(
@@ -309,7 +316,7 @@ internal class HybridSearchService : IHybridSearchService
     /// Generates query embedding and performs pgvector cosine similarity search.
     /// Falls back to empty results if embedding generation or search fails (graceful degradation).
     /// </summary>
-    private async Task<List<KbEntities.Embedding>> ExecuteVectorSearchAsync(
+    private async Task<List<KbEntities.ScoredEmbedding>> ExecuteVectorSearchAsync(
         string query,
         Guid gameId,
         int limit,
@@ -327,12 +334,16 @@ internal class HybridSearchService : IHybridSearchService
                 _logger.LogWarning(
                     "Query embedding generation failed: {Error}. Falling back to keyword-only.",
                     embeddingResult.ErrorMessage);
-                return new List<KbEntities.Embedding>();
+                return new List<KbEntities.ScoredEmbedding>();
             }
 
             var queryVector = new Vector(embeddingResult.Embeddings[0]);
 
-            var results = await _vectorStore.SearchAsync(
+            // #2568: use the scored variant so the raw cosine similarity is preserved on each
+            // hit. The cross-game merge (MultiGameHybridSearchService) needs a globally-
+            // comparable signal to break rank-only RRF ties; the cosine is that signal.
+            // Same SQL / ordering / minScore as SearchAsync — additive method (#1653).
+            var results = await _vectorStore.SearchWithScoresAsync(
                 gameId,
                 queryVector,
                 topK: limit,
@@ -352,7 +363,7 @@ internal class HybridSearchService : IHybridSearchService
             _logger.LogWarning(ex,
                 "Vector search failed, falling back to keyword-only for gameId={GameId}",
                 gameId);
-            return new List<KbEntities.Embedding>();
+            return new List<KbEntities.ScoredEmbedding>();
         }
 #pragma warning restore CA1031
     }

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/MultiGameHybridSearchServiceTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/MultiGameHybridSearchServiceTests.cs
@@ -237,6 +237,105 @@ public class MultiGameHybridSearchServiceTests
     }
 
     // ---------------------------------------------------------------------------
+    // #2568: cross-game ranking degeneracy. Per-game RRF is rank-only, so EVERY
+    // game's rank-1 chunk gets the IDENTICAL fused HybridScore (0.7/(60+1) ≈ 0.01148).
+    // With only a ChunkIndex/PdfDocumentId tiebreak the merge picks the same
+    // query-agnostic (lowest-index / lowest-GUID) chunk for every cross-game query.
+    // The tie MUST be broken by the globally-comparable raw vector cosine
+    // (VectorScore) DESC so the chunk actually most relevant to THIS query wins.
+    // ---------------------------------------------------------------------------
+
+    [Fact]
+    public async Task TiedHybridScore_BrokenByVectorScoreDesc_NotChunkIndex()
+    {
+        // Arrange
+        var lowRelevanceGame = Guid.NewGuid();
+        var highRelevanceGame = Guid.NewGuid();
+        const float tiedHybrid = 0.01148f; // the rank-1 RRF value every game ties on
+
+        // low-relevance game: chunkIndex 0 → would WIN the legacy ChunkIndex-ASC
+        // tiebreak, but only a weak cosine match to the query.
+        _hybridSearchMock
+            .Setup(s => s.SearchAsync(
+                It.IsAny<string>(), lowRelevanceGame,
+                It.IsAny<SearchMode>(), It.IsAny<int>(), null,
+                It.IsAny<float>(), It.IsAny<float>(), It.IsAny<double>(),
+                It.IsAny<GameBookRole>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<HybridSearchResult>
+            {
+                MakeResultWithScores(lowRelevanceGame, chunkIndex: 0, hybridScore: tiedHybrid, vectorScore: 0.45f),
+            });
+
+        // high-relevance game: chunkIndex 7 → would LOSE the legacy tiebreak, but a
+        // strong cosine match → it is the genuinely relevant result for the query.
+        _hybridSearchMock
+            .Setup(s => s.SearchAsync(
+                It.IsAny<string>(), highRelevanceGame,
+                It.IsAny<SearchMode>(), It.IsAny<int>(), null,
+                It.IsAny<float>(), It.IsAny<float>(), It.IsAny<double>(),
+                It.IsAny<GameBookRole>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<HybridSearchResult>
+            {
+                MakeResultWithScores(highRelevanceGame, chunkIndex: 7, hybridScore: tiedHybrid, vectorScore: 0.92f),
+            });
+
+        var sut = CreateSut();
+
+        // Act
+        var result = await sut.SearchAsync("test", new[] { lowRelevanceGame, highRelevanceGame }, limit: 10);
+
+        // Assert — higher cosine wins the HybridScore tie, despite higher ChunkIndex
+        result.Should().HaveCount(2);
+        result[0].GameId.Should().Be(highRelevanceGame,
+            "the higher raw cosine (VectorScore) must win a HybridScore tie, not the lower ChunkIndex");
+        result[0].VectorScore.Should().Be(0.92f);
+        result[1].GameId.Should().Be(lowRelevanceGame);
+    }
+
+    [Fact]
+    public async Task TiedHybridScoreAndVectorScore_FallsBackToChunkIndexAsc()
+    {
+        // Arrange — when cosine ALSO ties, the deterministic ChunkIndex-ASC fallback
+        // still applies (preserves stable ordering, no nondeterminism).
+        var gameId1 = Guid.NewGuid();
+        var gameId2 = Guid.NewGuid();
+        const float tiedHybrid = 0.5f;
+        const float tiedVector = 0.6f;
+
+        _hybridSearchMock
+            .Setup(s => s.SearchAsync(
+                It.IsAny<string>(), gameId1,
+                It.IsAny<SearchMode>(), It.IsAny<int>(), null,
+                It.IsAny<float>(), It.IsAny<float>(), It.IsAny<double>(),
+                It.IsAny<GameBookRole>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<HybridSearchResult>
+            {
+                MakeResultWithScores(gameId1, chunkIndex: 3, hybridScore: tiedHybrid, vectorScore: tiedVector),
+            });
+
+        _hybridSearchMock
+            .Setup(s => s.SearchAsync(
+                It.IsAny<string>(), gameId2,
+                It.IsAny<SearchMode>(), It.IsAny<int>(), null,
+                It.IsAny<float>(), It.IsAny<float>(), It.IsAny<double>(),
+                It.IsAny<GameBookRole>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<HybridSearchResult>
+            {
+                MakeResultWithScores(gameId2, chunkIndex: 1, hybridScore: tiedHybrid, vectorScore: tiedVector),
+            });
+
+        var sut = CreateSut();
+
+        // Act
+        var result = await sut.SearchAsync("test", new[] { gameId1, gameId2 }, limit: 10);
+
+        // Assert — cosine ties → ChunkIndex ASC fallback → chunkIndex 1 before 3
+        result.Should().HaveCount(2);
+        result[0].ChunkIndex.Should().Be(1);
+        result[1].ChunkIndex.Should().Be(3);
+    }
+
+    // ---------------------------------------------------------------------------
     // EC-7: limit truncates final result
     // ---------------------------------------------------------------------------
 
@@ -499,6 +598,28 @@ public class MultiGameHybridSearchServiceTests
             KeywordScore = null,
             VectorRank = chunkIndex + 1,
             KeywordRank = null,
+            MatchedTerms = new List<string>(),
+            Mode = SearchMode.Hybrid,
+            RoleTags = GameBookRole.None
+        };
+
+    // #2568: lets a test pin HybridScore, VectorScore and KeywordScore independently
+    // so the cross-game tiebreak can be exercised (HybridScore tie + differing cosine).
+    private static HybridSearchResult MakeResultWithScores(
+        Guid gameId, int chunkIndex, float hybridScore, float vectorScore, float? keywordScore = null) =>
+        new()
+        {
+            ChunkId = $"{Guid.NewGuid()}_{chunkIndex}",
+            Content = $"chunk content {chunkIndex}",
+            PdfDocumentId = Guid.NewGuid().ToString(),
+            GameId = gameId,
+            ChunkIndex = chunkIndex,
+            PageNumber = chunkIndex + 1,
+            HybridScore = hybridScore,
+            VectorScore = vectorScore,
+            KeywordScore = keywordScore,
+            VectorRank = chunkIndex + 1,
+            KeywordRank = keywordScore.HasValue ? chunkIndex + 1 : (int?)null,
             MatchedTerms = new List<string>(),
             Mode = SearchMode.Hybrid,
             RoleTags = GameBookRole.None

--- a/apps/api/tests/Api.Tests/Services/HybridSearchServiceRoleBoostTests.cs
+++ b/apps/api/tests/Api.Tests/Services/HybridSearchServiceRoleBoostTests.cs
@@ -125,8 +125,13 @@ public sealed class HybridSearchServiceRoleBoostTests
     private static HybridSearchService BuildSut(
         Mock<IVectorStoreAdapter> vectorStoreMock,
         Mock<IEmbeddingService> embeddingMock)
+        => BuildSut(vectorStoreMock, embeddingMock, BuildEmptyKeywordMock());
+
+    private static HybridSearchService BuildSut(
+        Mock<IVectorStoreAdapter> vectorStoreMock,
+        Mock<IEmbeddingService> embeddingMock,
+        Mock<IKeywordSearchService> keywordMock)
     {
-        var keywordMock = new Mock<IKeywordSearchService>();
         var config = Options.Create(new HybridSearchConfiguration());
         return new HybridSearchService(
             keywordMock.Object,
@@ -135,6 +140,25 @@ public sealed class HybridSearchServiceRoleBoostTests
             NullLogger<HybridSearchService>.Instance,
             config);
     }
+
+    private static Mock<IKeywordSearchService> BuildEmptyKeywordMock()
+    {
+        var mock = new Mock<IKeywordSearchService>();
+        mock
+            .Setup(k => k.SearchAsync(
+                It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<int>(), It.IsAny<bool>(),
+                It.IsAny<List<string>?>(), It.IsAny<string>(), It.IsAny<double>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<KeywordSearchResult>());
+        return mock;
+    }
+
+    // #2568: ExecuteVectorSearchAsync now consumes the scored variant. Wrap embeddings in
+    // ScoredEmbedding with descending cosines (0.9, 0.8, …) preserving the input order
+    // (pgvector returns cosine-DESC). Semantic HybridScore stays rank-based, so the cosine
+    // value only surfaces as VectorScore.
+    private static List<ScoredEmbedding> Scored(params Embedding[] embeddings)
+        => embeddings.Select((e, i) => new ScoredEmbedding(e, 0.9 - i * 0.1)).ToList();
 
     private static Embedding BuildEmbedding(int chunkIndex, GameBookRole roleTags)
     {
@@ -170,10 +194,10 @@ public sealed class HybridSearchServiceRoleBoostTests
         // Arrange: one matching chunk; boost MUST appear on HybridScore.
         var vectorStore = new Mock<IVectorStoreAdapter>();
         vectorStore
-            .Setup(v => v.SearchAsync(
+            .Setup(v => v.SearchWithScoresAsync(
                 It.IsAny<Guid>(), It.IsAny<Vector>(), It.IsAny<int>(),
                 It.IsAny<double>(), It.IsAny<IReadOnlyList<Guid>?>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<Embedding> { BuildEmbedding(chunkIndex: 0, GameBookRole.Tutorial) });
+            .ReturnsAsync(Scored(BuildEmbedding(chunkIndex: 0, GameBookRole.Tutorial)));
 
         var sut = BuildSut(vectorStore, BuildEmbeddingMock());
 
@@ -187,7 +211,8 @@ public sealed class HybridSearchServiceRoleBoostTests
         results.Should().HaveCount(1);
         results[0].RoleTags.Should().Be(GameBookRole.Tutorial);
         results[0].HybridScore.Should().BeApproximately(1.0f + HybridSearchService.RoleMatchBoost, 0.0001f);
-        results[0].VectorScore.Should().BeApproximately(1.0f, 0.0001f);
+        // #2568: VectorScore now carries the raw cosine (0.9 from Scored()), not a constant 1.0.
+        results[0].VectorScore.Should().BeApproximately(0.9f, 0.0001f);
     }
 
     [Fact]
@@ -196,10 +221,10 @@ public sealed class HybridSearchServiceRoleBoostTests
         // Arrange: chunk role disjoint from hint — no boost.
         var vectorStore = new Mock<IVectorStoreAdapter>();
         vectorStore
-            .Setup(v => v.SearchAsync(
+            .Setup(v => v.SearchWithScoresAsync(
                 It.IsAny<Guid>(), It.IsAny<Vector>(), It.IsAny<int>(),
                 It.IsAny<double>(), It.IsAny<IReadOnlyList<Guid>?>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<Embedding> { BuildEmbedding(chunkIndex: 0, GameBookRole.RulesReference) });
+            .ReturnsAsync(Scored(BuildEmbedding(chunkIndex: 0, GameBookRole.RulesReference)));
 
         var sut = BuildSut(vectorStore, BuildEmbeddingMock());
 
@@ -222,10 +247,10 @@ public sealed class HybridSearchServiceRoleBoostTests
         var second = BuildEmbedding(chunkIndex: 1, GameBookRole.Tutorial);
         var vectorStore = new Mock<IVectorStoreAdapter>();
         vectorStore
-            .Setup(v => v.SearchAsync(
+            .Setup(v => v.SearchWithScoresAsync(
                 It.IsAny<Guid>(), It.IsAny<Vector>(), It.IsAny<int>(),
                 It.IsAny<double>(), It.IsAny<IReadOnlyList<Guid>?>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<Embedding> { first, second });
+            .ReturnsAsync(Scored(first, second));
 
         var sut = BuildSut(vectorStore, BuildEmbeddingMock());
 
@@ -260,10 +285,10 @@ public sealed class HybridSearchServiceRoleBoostTests
         };
         var vectorStore = new Mock<IVectorStoreAdapter>();
         vectorStore
-            .Setup(v => v.SearchAsync(
+            .Setup(v => v.SearchWithScoresAsync(
                 It.IsAny<Guid>(), It.IsAny<Vector>(), It.IsAny<int>(),
                 It.IsAny<double>(), It.IsAny<IReadOnlyList<Guid>?>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(ranked);
+            .ReturnsAsync(Scored(ranked.ToArray()));
 
         var sut = BuildSut(vectorStore, BuildEmbeddingMock());
 
@@ -280,5 +305,45 @@ public sealed class HybridSearchServiceRoleBoostTests
         results[2].ChunkIndex.Should().Be(3);
         results[2].HybridScore.Should().BeApproximately(0.25f + HybridSearchService.RoleMatchBoost, 0.0001f);
         results[3].ChunkIndex.Should().Be(2);
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // #2568: the fused VectorScore must carry the RAW pgvector cosine similarity (not a
+    // hard-coded 1.0f) so the cross-game merge in MultiGameHybridSearchService can break
+    // rank-only RRF ties by actual query relevance instead of a query-agnostic GUID tiebreak.
+    // -----------------------------------------------------------------------------------------
+
+    [Fact]
+    public async Task SearchAsync_HybridMode_VectorScore_CarriesRawCosine_NotConstant()
+    {
+        // Arrange
+        const double cosine = 0.77;
+        var embedding = BuildEmbedding(chunkIndex: 0, GameBookRole.None);
+
+        var vectorStore = new Mock<IVectorStoreAdapter>();
+        // Scored path (post-fix): carries the cosine.
+        vectorStore
+            .Setup(v => v.SearchWithScoresAsync(
+                It.IsAny<Guid>(), It.IsAny<Vector>(), It.IsAny<int>(),
+                It.IsAny<double>(), It.IsAny<IReadOnlyList<Guid>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ScoredEmbedding> { new(embedding, cosine) });
+        // Legacy unscored path (pre-fix) — also returns the chunk so the test fails on the
+        // VECTORSCORE VALUE (1.0 vs 0.77), not on an empty result set.
+        vectorStore
+            .Setup(v => v.SearchAsync(
+                It.IsAny<Guid>(), It.IsAny<Vector>(), It.IsAny<int>(),
+                It.IsAny<double>(), It.IsAny<IReadOnlyList<Guid>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<Embedding> { embedding });
+
+        var sut = BuildSut(vectorStore, BuildEmbeddingMock(), BuildEmptyKeywordMock());
+
+        // Act
+        var results = await sut.SearchAsync(
+            "anything", Guid.NewGuid(), SearchMode.Hybrid,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        // Assert — VectorScore equals the cosine the vector store returned.
+        results.Should().HaveCount(1);
+        results[0].VectorScore.Should().BeApproximately((float)cosine, 0.0001f);
     }
 }


### PR DESCRIPTION
## Problema

Scoperto chiudendo #2480: `ask/global` cross-game restituiva lo **stesso chunk page-1** in cima per ogni query di giochi diversi (es. `13dc2236` in tutte e 5 le query canoniche). Non è rilevanza — è un artefatto di tiebreak.

**Root cause** (confermato per lettura diretta):
1. L'RRF è **rank-only** (`HybridSearchService.cs:418,423`: `weight/(rrfK + Rank)`) → il rank-1 vettoriale di **ogni gioco** ottiene lo stesso identico HybridScore (`0.7/(60+1) ≈ 0.01148`).
2. Il merge cross-game (`MultiGameHybridSearchService.cs:98-107`) a parità di HybridScore rompeva il pareggio in modo **query-agnostico** (`ChunkIndex ASC`, poi `PdfDocumentId ASC`) → vinceva sempre il chunk page-1 col GUID più basso, per qualsiasi query.

## Fix (2 parti)

- **`HybridSearchService`**: porta la **cosine grezza** in `VectorScore` (era hardcoded `1.0f`) via l'esistente `SearchWithScoresAsync` (#1653, stesso SQL/ordering — metodo additivo). L'RRF continua a rankare per posizione (Rank), quindi l'ordering **within-game è invariato**.
- **`MultiGameHybridSearchService`**: rompe i pareggi di HybridScore per `VectorScore` (cosine) DESC → `KeywordScore` DESC → poi il fallback deterministico `ChunkIndex`/`PdfDocumentId`. Il chunk realmente più simile a *questa* query vince.

## TDD

- `TiedHybridScore_BrokenByVectorScoreDesc_NotChunkIndex` (RED→GREEN): cosine alta vince il pareggio nonostante ChunkIndex più alto.
- `TiedHybridScoreAndVectorScore_FallsBackToChunkIndexAsc`: il fallback deterministico resta su cosine pari.
- `SearchAsync_HybridMode_VectorScore_CarriesRawCosine_NotConstant`: VectorScore = cosine, non 1.0f.
- Aggiornati i 4 test semantic role-boost al vettore scored.

**26 test mirati + 2281 unit KnowledgeBase + 87 RagService/Hybrid/Keyword verdi, 0 regressioni.** Build 0/0.

## Note
- Non è un re-RRF globale (redesign più ampio): è il fix chirurgico del pareggio osservato, deterministico, senza nuova latenza/dipendenza.
- Migliora anche il valore del gate rag-smoke (#2480): la baseline non pinna più solo l'ordine di tiebreak.

Closes #2568.

🤖 Generated with [Claude Code](https://claude.com/claude-code)