### PR TITLE
fix(rag): align SearchKbChunks tsquery config to the search_vector column

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/SearchKbChunks/SearchKbChunksHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/SearchKbChunks/SearchKbChunksHandler.cs
@@ -10,7 +10,7 @@ namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.SearchKbChunks;
 ///
 /// Performs PostgreSQL full-text search within a single KB document using:
 /// <list type="bullet">
-///   <item><c>plainto_tsquery('simple', ...)</c> — sanitises user input, preventing tsquery operator injection</item>
+///   <item><c>plainto_tsquery('italian', ...)</c> — sanitises user input, preventing tsquery operator injection (config matches the search_vector column, #2569)</item>
 ///   <item><c>ts_rank_cd</c> — cover-density ranking for result ordering</item>
 ///   <item><c>ts_headline</c> — generates text snippets with <c>&lt;mark&gt;</c> tags</item>
 /// </list>
@@ -82,6 +82,12 @@ internal sealed class SearchKbChunksHandler : IQueryHandler<SearchKbChunksQuery,
         // FTS ranked query using plainto_tsquery (prevents operator injection).
         // Column names: PdfDocumentId, Id, PageNumber, ChunkIndex are PascalCase (migration convention).
         // search_vector is lowercase snake_case via [Column("search_vector")] on the entity.
+        //
+        // The tsquery config MUST match the config the search_vector column is GENERATED with
+        // (AddSearchVectorColumns, #2559 = 'italian') or `@@` silently returns nothing — the
+        // previous 'simple' here mismatched the column and made every keyword chunk search return
+        // 0 rows. ts_headline must use the same config so highlighted lexemes line up. (#2569 will
+        // move the column — and these — to 'english'; keep all three in sync with the column.)
         const string ftsSQL = @"
             WITH ranked AS (
               SELECT
@@ -89,9 +95,9 @@ internal sealed class SearchKbChunksHandler : IQueryHandler<SearchKbChunksQuery,
                 tc.""PageNumber"",
                 tc.""ChunkIndex"",
                 ts_rank_cd(tc.search_vector, q) AS ""Rank"",
-                ts_headline('simple', tc.""Content"", q,
+                ts_headline('italian', tc.""Content"", q,
                   'StartSel=<mark>, StopSel=</mark>, MaxFragments=2, MaxWords=20, MinWords=5') AS ""Snippet""
-              FROM text_chunks tc, plainto_tsquery('simple', {1}) q
+              FROM text_chunks tc, plainto_tsquery('italian', {1}) q
               WHERE tc.""PdfDocumentId"" = {0}
                 AND tc.search_vector @@ q
             )
@@ -111,7 +117,7 @@ internal sealed class SearchKbChunksHandler : IQueryHandler<SearchKbChunksQuery,
         // Count total matches (without pagination).
         const string countSQL = @"
             SELECT COUNT(*)::int AS ""Value""
-            FROM text_chunks tc, plainto_tsquery('simple', {1}) q
+            FROM text_chunks tc, plainto_tsquery('italian', {1}) q
             WHERE tc.""PdfDocumentId"" = {0} AND tc.search_vector @@ q";
         // No trailing ';' — composed with .Select(r => r.Value).FirstAsync(),
         // EF Core wraps this in a subquery and an inner semicolon produces


### PR DESCRIPTION
## Sintomo (pre-esistente su main-dev)

Integration test `KbChunkEndpointsIntegrationTests.SearchChunks_KeywordPresent_ReturnsRankedMatches` falliva: `Expected TotalCount to be 3, but found 0`. La per-document chunk keyword search (`POST /api/v1/kb-docs/{id}/chunks/search`) restituiva 0 righe.

## Root cause

`SearchKbChunksHandler` interroga `tc.search_vector` con `plainto_tsquery('simple', …)` + `ts_headline('simple', …)`, ma la colonna `search_vector` è GENERATED con config **`'italian'`** (`AddSearchVectorColumns`, #2559). Config diverse ai due lati di `@@` → "initiative" stemmato diversamente ('simple' lo lascia, 'italian' lo stemma) → nessun match → 0 risultati.

Diagnosi: ci sono **3 consumer** di `search_vector` con config divergenti — `KeywordSearchService` ('italian', combaciava la colonna), `SearchKbChunksHandler` ('simple', rotto), `TextChunkSearchService` ('english', latente ma i suoi test usano parole non divergenti). La colonna può averne **una sola**.

## Fix

Allineo i 3 riferimenti del handler ('italian'): `plainto_tsquery` (ranked + count) + `ts_headline`, così match, ranking e snippet usano la stessa config della colonna. Aggiunto un commento che vincola la config del handler a quella della colonna.

## Verifica
- ✅ `SearchChunks_KeywordPresent_ReturnsRankedMatches`: RED → GREEN
- ✅ Intera classe `KbChunkEndpointsIntegrationTests`: 11/11
- ✅ Build 0/0. Nessuna migration (mergeable senza re-bake).

## Nota
La config keyword deve sempre tracciare la config della colonna `search_vector`. **#2569** unificherà colonna + tutti i consumer (KeywordSearchService + SearchKbChunks) a **'english'** (TextChunkSearchService è già english) — a quel punto questo handler passerà a 'english'.

🤖 Generated with [Claude Code](https://claude.com/claude-code)