### PR TITLE
feat(session-live): #2501 SP3 — diary nativo append-only + evento session:diary

### DIFF
--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/LiveSessions/AddDiaryEntryCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/LiveSessions/AddDiaryEntryCommand.cs
@@ -1,0 +1,14 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.GameManagement.Application.Commands.LiveSessions;
+
+/// <summary>
+/// Command to append an immutable diary entry to a live game session.
+/// Returns the new diary entry's id.
+/// Issue #2570 SP3 T3.
+/// </summary>
+internal record AddDiaryEntryCommand(
+    Guid SessionId,
+    Guid AuthorId,
+    string Text
+) : ICommand<Guid>;

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/LiveSessions/AddDiaryEntryCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/LiveSessions/AddDiaryEntryCommandHandler.cs
@@ -1,0 +1,53 @@
+using Api.BoundedContexts.GameManagement.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Infrastructure.Persistence;
+
+namespace Api.BoundedContexts.GameManagement.Application.Commands.LiveSessions;
+
+/// <summary>
+/// Handles <see cref="AddDiaryEntryCommand"/>: appends an immutable diary entry to a live game session
+/// and returns the new entry's id.
+///
+/// Pattern mirrors <c>UpdateSetupChecklistCommandHandler</c> / <c>UpdateLiveSessionNotesCommandHandler</c>.
+/// ADR-060: every mutating handler calls <c>_unitOfWork.SaveChangesAsync</c> after <c>UpdateAsync</c>.
+/// The <see cref="Api.Middleware.Exceptions.ConflictException"/> raised by the domain for a Completed session
+/// propagates unhandled — the middleware maps it to HTTP 409.
+///
+/// Issue #2570 SP3 T3.
+/// </summary>
+internal sealed class AddDiaryEntryCommandHandler : ICommandHandler<AddDiaryEntryCommand, Guid>
+{
+    private readonly ILiveSessionRepository _sessionRepository;
+    private readonly IUnitOfWork _unitOfWork;
+
+    public AddDiaryEntryCommandHandler(
+        ILiveSessionRepository sessionRepository,
+        IUnitOfWork unitOfWork)
+    {
+        _sessionRepository = sessionRepository ?? throw new ArgumentNullException(nameof(sessionRepository));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+    }
+
+    public async Task<Guid> Handle(AddDiaryEntryCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var session = await _sessionRepository
+            .GetByIdAsync(command.SessionId, cancellationToken)
+            .ConfigureAwait(false)
+            ?? throw new NotFoundException("LiveGameSession", command.SessionId.ToString());
+
+        // ConflictException from a Completed session propagates to the middleware (HTTP 409).
+        session.AddDiaryEntry(command.AuthorId, command.Text);
+
+        await _sessionRepository
+            .UpdateAsync(session, cancellationToken)
+            .ConfigureAwait(false);
+
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        // The new entry is always appended last (append-only invariant, T1).
+        return session.DiaryEntries[^1].Id;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/LiveSessions/AddDiaryEntryCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/LiveSessions/AddDiaryEntryCommandHandler.cs
@@ -38,6 +38,13 @@ internal sealed class AddDiaryEntryCommandHandler : ICommandHandler<AddDiaryEntr
             .ConfigureAwait(false)
             ?? throw new NotFoundException("LiveGameSession", command.SessionId.ToString());
 
+        // Authz: caller must be the session creator or an active linked player.
+        // Mirrors GetLiveSessionStreamContextQueryHandler (SP2 T4).
+        var isParticipant = session.CreatedByUserId == command.AuthorId
+            || session.Players.Any(p => p.IsActive && p.UserId == command.AuthorId);
+        if (!isParticipant)
+            throw new ForbiddenException("Only the session creator or an active participant may add diary entries.");
+
         // ConflictException from a Completed session propagates to the middleware (HTTP 409).
         session.AddDiaryEntry(command.AuthorId, command.Text);
 

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/LiveSessions/DiaryEntryDto.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/LiveSessions/DiaryEntryDto.cs
@@ -1,0 +1,12 @@
+namespace Api.BoundedContexts.GameManagement.Application.DTOs.LiveSessions;
+
+/// <summary>
+/// DTO representing a single diary entry in a live game session.
+/// Issue #2570 SP3 T4.
+/// </summary>
+internal record DiaryEntryDto(
+    Guid Id,
+    Guid AuthorId,
+    DateTimeOffset CreatedAt,
+    string Text
+);

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/EventHandlers/LiveSessionStreamForwarder.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/EventHandlers/LiveSessionStreamForwarder.cs
@@ -16,7 +16,8 @@ internal sealed class LiveSessionStreamForwarder :
     INotificationHandler<LiveSessionPlayerRemovedEvent>,
     INotificationHandler<LiveSessionPausedEvent>,
     INotificationHandler<LiveSessionResumedEvent>,
-    INotificationHandler<LiveSessionCompletedEvent>
+    INotificationHandler<LiveSessionCompletedEvent>,
+    INotificationHandler<LiveSessionDiaryEntryAddedEvent>
 {
     private readonly ILiveSessionStreamGateway _gateway;
     private readonly ILogger<LiveSessionStreamForwarder> _logger;
@@ -133,6 +134,21 @@ internal sealed class LiveSessionStreamForwarder :
                 notification.CompletedAt,
                 notification.TotalTurns,
                 notification.GameName
+            }),
+            cancellationToken);
+    }
+
+    public Task Handle(LiveSessionDiaryEntryAddedEvent notification, CancellationToken cancellationToken)
+    {
+        _logger.LogDebug("Broadcasting session:diary for session {SessionId}", notification.SessionId);
+        return _gateway.BroadcastAsync(
+            notification.SessionId,
+            new LiveSessionStreamEvent("session:diary", new
+            {
+                entryId = notification.EntryId,
+                authorId = notification.AuthorId,
+                content = notification.Text,
+                timestamp = notification.CreatedAt.ToString("o")
             }),
             cancellationToken);
     }

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/LiveSessions/GetLiveSessionDiaryQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/LiveSessions/GetLiveSessionDiaryQuery.cs
@@ -1,0 +1,10 @@
+using Api.BoundedContexts.GameManagement.Application.DTOs.LiveSessions;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.GameManagement.Application.Queries.LiveSessions;
+
+/// <summary>
+/// Query to retrieve all diary entries for a live session in chronological order.
+/// Issue #2570 SP3 T4.
+/// </summary>
+internal record GetLiveSessionDiaryQuery(Guid SessionId) : IQuery<IReadOnlyList<DiaryEntryDto>>;

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/LiveSessions/GetLiveSessionDiaryQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/LiveSessions/GetLiveSessionDiaryQuery.cs
@@ -5,6 +5,12 @@ namespace Api.BoundedContexts.GameManagement.Application.Queries.LiveSessions;
 
 /// <summary>
 /// Query to retrieve all diary entries for a live session in chronological order.
-/// Issue #2570 SP3 T4.
+/// <para>
+/// <see cref="UserId"/> is the authenticated caller's id used for participant authz —
+/// the handler throws <see cref="Api.Middleware.Exceptions.ForbiddenException"/> (→ HTTP 403)
+/// when the caller is neither the creator nor an active player of the session.
+/// Mirrors the authz pattern in <c>GetLiveSessionStreamContextQueryHandler</c> (SP2 T4).
+/// </para>
+/// Issue #2570 SP3 T4 / T5 authz fix.
 /// </summary>
-internal record GetLiveSessionDiaryQuery(Guid SessionId) : IQuery<IReadOnlyList<DiaryEntryDto>>;
+internal record GetLiveSessionDiaryQuery(Guid SessionId, Guid UserId) : IQuery<IReadOnlyList<DiaryEntryDto>>;

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/LiveSessions/GetLiveSessionDiaryQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/LiveSessions/GetLiveSessionDiaryQueryHandler.cs
@@ -1,0 +1,39 @@
+using Api.BoundedContexts.GameManagement.Application.DTOs.LiveSessions;
+using Api.BoundedContexts.GameManagement.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.GameManagement.Application.Queries.LiveSessions;
+
+/// <summary>
+/// Handles <see cref="GetLiveSessionDiaryQuery"/>.
+/// Returns all diary entries for the session ordered by <c>CreatedAt</c> ascending.
+/// Issue #2570 SP3 T4.
+/// </summary>
+internal sealed class GetLiveSessionDiaryQueryHandler
+    : IQueryHandler<GetLiveSessionDiaryQuery, IReadOnlyList<DiaryEntryDto>>
+{
+    private readonly ILiveSessionRepository _sessionRepository;
+
+    public GetLiveSessionDiaryQueryHandler(ILiveSessionRepository sessionRepository)
+    {
+        _sessionRepository = sessionRepository ?? throw new ArgumentNullException(nameof(sessionRepository));
+    }
+
+    public async Task<IReadOnlyList<DiaryEntryDto>> Handle(
+        GetLiveSessionDiaryQuery query,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var session = await _sessionRepository
+            .GetByIdAsync(query.SessionId, cancellationToken)
+            .ConfigureAwait(false)
+            ?? throw new NotFoundException("LiveGameSession", query.SessionId.ToString());
+
+        return session.DiaryEntries
+            .OrderBy(e => e.CreatedAt)
+            .Select(e => new DiaryEntryDto(e.Id, e.AuthorId, e.CreatedAt, e.Text))
+            .ToList();
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/LiveSessions/GetLiveSessionDiaryQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/LiveSessions/GetLiveSessionDiaryQueryHandler.cs
@@ -31,6 +31,13 @@ internal sealed class GetLiveSessionDiaryQueryHandler
             .ConfigureAwait(false)
             ?? throw new NotFoundException("LiveGameSession", query.SessionId.ToString());
 
+        // Authz: caller must be the session creator or an active linked player.
+        // Mirrors GetLiveSessionStreamContextQueryHandler (SP2 T4, issue #2561).
+        var isParticipant = session.CreatedByUserId == query.UserId
+            || session.Players.Any(p => p.IsActive && p.UserId == query.UserId);
+        if (!isParticipant)
+            throw new ForbiddenException("Only the session creator or an active participant may read diary entries.");
+
         return session.DiaryEntries
             .OrderBy(e => e.CreatedAt)
             .Select(e => new DiaryEntryDto(e.Id, e.AuthorId, e.CreatedAt, e.Text))

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Validators/LiveSessions/AddDiaryEntryCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Validators/LiveSessions/AddDiaryEntryCommandValidator.cs
@@ -1,0 +1,29 @@
+using Api.BoundedContexts.GameManagement.Application.Commands.LiveSessions;
+using FluentValidation;
+
+namespace Api.BoundedContexts.GameManagement.Application.Validators.LiveSessions;
+
+/// <summary>
+/// Validator for <see cref="AddDiaryEntryCommand"/>.
+/// Text cap of 2000 chars mirrors <c>MaxNotesLength</c> in the domain.
+/// Issue #2570 SP3 T3.
+/// </summary>
+internal sealed class AddDiaryEntryCommandValidator : AbstractValidator<AddDiaryEntryCommand>
+{
+    public AddDiaryEntryCommandValidator()
+    {
+        RuleFor(x => x.SessionId)
+            .NotEmpty()
+            .WithMessage("Session ID is required");
+
+        RuleFor(x => x.AuthorId)
+            .NotEmpty()
+            .WithMessage("Author ID is required");
+
+        RuleFor(x => x.Text)
+            .NotEmpty()
+            .WithMessage("Diary entry text is required")
+            .MaximumLength(2000)
+            .WithMessage("Diary entry text cannot exceed 2000 characters");
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/LiveGameSession.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/LiveGameSession.cs
@@ -29,6 +29,7 @@ internal sealed class LiveGameSession : AggregateRoot<Guid>
     private readonly List<RoundScore> _roundScores = new();
     private readonly List<TurnRecord> _turnRecords = new();
     private readonly List<RuleDisputeEntry> _disputes = new();
+    private readonly List<DiaryEntry> _diaryEntries = new();
     private SetupChecklistData? _setupChecklist;
 
 #pragma warning disable CS8618
@@ -81,6 +82,7 @@ internal sealed class LiveGameSession : AggregateRoot<Guid>
     public IReadOnlyList<RoundScore> RoundScores => _roundScores.AsReadOnly();
     public IReadOnlyList<TurnRecord> TurnRecords => _turnRecords.AsReadOnly();
     public IReadOnlyList<RuleDisputeEntry> Disputes => _disputes.AsReadOnly();
+    public IReadOnlyList<DiaryEntry> DiaryEntries => _diaryEntries.AsReadOnly();
     public SetupChecklistData? SetupChecklist => _setupChecklist;
 
     // === Computed Properties ===
@@ -735,6 +737,31 @@ internal sealed class LiveGameSession : AggregateRoot<Guid>
     public void UpdateSetupChecklist(SetupChecklistData checklist)
     {
         _setupChecklist = checklist ?? throw new ArgumentNullException(nameof(checklist));
+    }
+
+    // === Diary ===
+
+    /// <summary>
+    /// Appends an immutable diary entry authored by the given user.
+    /// Only rejects <see cref="LiveSessionStatus.Completed"/> sessions (Paused is allowed — AC-DIARY-3).
+    /// </summary>
+    public void AddDiaryEntry(Guid authorId, string text, TimeProvider? timeProvider = null)
+    {
+        if (Status == LiveSessionStatus.Completed)
+            throw new ConflictException("Cannot add diary entries to a completed session");
+
+        if (authorId == Guid.Empty)
+            throw new ValidationException("Author ID cannot be empty");
+
+        if (string.IsNullOrWhiteSpace(text))
+            throw new ValidationException("Diary entry text cannot be empty");
+
+        var now = new DateTimeOffset((timeProvider ?? TimeProvider.System).GetUtcNow().UtcDateTime, TimeSpan.Zero);
+        var entry = new DiaryEntry(Guid.NewGuid(), authorId, now, text.Trim());
+
+        _diaryEntries.Add(entry);
+
+        AddDomainEvent(new LiveSessionDiaryEntryAddedEvent(Id, entry.Id, entry.AuthorId, entry.Text, entry.CreatedAt));
     }
 
     // === State & Notes ===

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/LiveGameSession.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/LiveGameSession.cs
@@ -194,6 +194,7 @@ internal sealed class LiveGameSession : AggregateRoot<Guid>
         IEnumerable<RoundScore> roundScores,
         IEnumerable<TurnRecord> turnRecords,
         IEnumerable<RuleDisputeEntry> disputes,
+        IEnumerable<DiaryEntry> diaryEntries,
         SetupChecklistData? setupChecklist)
     {
         var session = new LiveGameSession
@@ -239,6 +240,7 @@ internal sealed class LiveGameSession : AggregateRoot<Guid>
         session._roundScores.AddRange(roundScores);
         session._turnRecords.AddRange(turnRecords);
         session._disputes.AddRange(disputes);
+        session._diaryEntries.AddRange(diaryEntries);
 
         // Critical: Reconstitute MUST NOT raise events (we are not creating anything new).
         session.ClearDomainEvents();

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Events/LiveSessionDiaryEntryAddedEvent.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Events/LiveSessionDiaryEntryAddedEvent.cs
@@ -1,0 +1,29 @@
+using Api.SharedKernel.Domain.Events;
+
+namespace Api.BoundedContexts.GameManagement.Domain.Events;
+
+/// <summary>
+/// Domain event raised when a diary entry is appended to a live game session.
+/// </summary>
+internal sealed class LiveSessionDiaryEntryAddedEvent : DomainEventBase
+{
+    public Guid SessionId { get; }
+    public Guid EntryId { get; }
+    public Guid AuthorId { get; }
+    public string Text { get; }
+    public DateTimeOffset CreatedAt { get; }
+
+    public LiveSessionDiaryEntryAddedEvent(
+        Guid sessionId,
+        Guid entryId,
+        Guid authorId,
+        string text,
+        DateTimeOffset createdAt)
+    {
+        SessionId = sessionId;
+        EntryId = entryId;
+        AuthorId = authorId;
+        Text = text;
+        CreatedAt = createdAt;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/ValueObjects/DiaryEntry.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/ValueObjects/DiaryEntry.cs
@@ -1,0 +1,41 @@
+namespace Api.BoundedContexts.GameManagement.Domain.ValueObjects;
+
+/// <summary>
+/// Immutable value object representing a single append-only diary entry in a live game session.
+/// Multi-author public diary — distinct from the host-level <c>Notes</c> single-string field.
+/// Intended to be persisted as a separate owned table (live_session_diary_entries) in T2.
+/// </summary>
+internal sealed record DiaryEntry
+{
+    /// <summary>Unique identifier for this diary entry.</summary>
+    public Guid Id { get; init; }
+
+    /// <summary>UserId of the player who authored the entry.</summary>
+    public Guid AuthorId { get; init; }
+
+    /// <summary>UTC timestamp when the entry was created.</summary>
+    public DateTimeOffset CreatedAt { get; init; }
+
+    /// <summary>The diary entry text (trimmed, non-empty).</summary>
+    public string Text { get; init; }
+
+    /// <summary>
+    /// Creates a new <see cref="DiaryEntry"/>.
+    /// </summary>
+    public DiaryEntry(Guid id, Guid authorId, DateTimeOffset createdAt, string text)
+    {
+        if (id == Guid.Empty)
+            throw new ArgumentException("Diary entry ID cannot be empty.", nameof(id));
+
+        if (authorId == Guid.Empty)
+            throw new ArgumentException("Author ID cannot be empty.", nameof(authorId));
+
+        if (string.IsNullOrWhiteSpace(text))
+            throw new ArgumentException("Diary entry text cannot be empty.", nameof(text));
+
+        Id = id;
+        AuthorId = authorId;
+        CreatedAt = createdAt;
+        Text = text.Trim();
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Persistence/LiveSessionRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Persistence/LiveSessionRepository.cs
@@ -40,6 +40,7 @@ internal sealed class LiveSessionRepository : RepositoryBase, ILiveSessionReposi
             .Include(e => e.Teams)
             .Include(e => e.RoundScores)
             .Include(e => e.TurnRecords)
+            .Include(e => e.DiaryEntries)
             .FirstOrDefaultAsync(e => e.Id == id, cancellationToken)
             .ConfigureAwait(false);
 
@@ -56,6 +57,7 @@ internal sealed class LiveSessionRepository : RepositoryBase, ILiveSessionReposi
             .Include(e => e.Teams)
             .Include(e => e.RoundScores)
             .Include(e => e.TurnRecords)
+            .Include(e => e.DiaryEntries)
             .FirstOrDefaultAsync(e => e.SessionCode == normalized, cancellationToken)
             .ConfigureAwait(false);
 
@@ -75,6 +77,7 @@ internal sealed class LiveSessionRepository : RepositoryBase, ILiveSessionReposi
             .Include(e => e.Teams)
             .Include(e => e.RoundScores)
             .Include(e => e.TurnRecords)
+            .Include(e => e.DiaryEntries)
             .Where(e => e.CreatedByUserId == userId && ActiveStatuses.Contains(e.Status))
             .OrderByDescending(e => e.UpdatedAt)
             .ToListAsync(cancellationToken)
@@ -92,6 +95,7 @@ internal sealed class LiveSessionRepository : RepositoryBase, ILiveSessionReposi
             .Include(e => e.Teams)
             .Include(e => e.RoundScores)
             .Include(e => e.TurnRecords)
+            .Include(e => e.DiaryEntries)
             .Where(e => ActiveStatuses.Contains(e.Status))
             .OrderByDescending(e => e.UpdatedAt)
             .ToListAsync(cancellationToken)
@@ -147,6 +151,7 @@ internal sealed class LiveSessionRepository : RepositoryBase, ILiveSessionReposi
         var snapshotTeams = snapshot.Teams.ToList();
         var snapshotRoundScores = snapshot.RoundScores.ToList();
         var snapshotTurnRecords = snapshot.TurnRecords.ToList();
+        var snapshotDiaryEntries = snapshot.DiaryEntries.ToList(); // #2570 SP3 T2
 
         // ── Root entity: use Entry-based update so EF uses OriginalValues.Xmin (xmin concurrency token) ──────
         var trackedRoot = DbContext.ChangeTracker.Entries<LiveGameSessionEntity>()
@@ -160,6 +165,7 @@ internal sealed class LiveSessionRepository : RepositoryBase, ILiveSessionReposi
             snapshot.Teams.Clear();
             snapshot.RoundScores.Clear();
             snapshot.TurnRecords.Clear();
+            snapshot.DiaryEntries.Clear(); // #2570 SP3 T2
             DbContext.Entry(snapshot).State = EntityState.Modified;
         }
         else
@@ -174,6 +180,7 @@ internal sealed class LiveSessionRepository : RepositoryBase, ILiveSessionReposi
         await SyncTeamsAsync(session, snapshotTeams, cancellationToken).ConfigureAwait(false);
         await SyncRoundScoresAsync(session, snapshotRoundScores, cancellationToken).ConfigureAwait(false);
         await SyncTurnRecordsAsync(session, snapshotTurnRecords, cancellationToken).ConfigureAwait(false);
+        await SyncDiaryEntriesAsync(session, snapshotDiaryEntries, cancellationToken).ConfigureAwait(false); // #2570 SP3 T2
 
         // Record metrics on the happy path only. If any of the above threw, we never reach here
         // and writes_total{op=update} stays consistent with actually-staged writes. The counter
@@ -326,6 +333,34 @@ internal sealed class LiveSessionRepository : RepositoryBase, ILiveSessionReposi
         {
             var stub = new LiveTurnRecordEntity { Id = removedId, LiveGameSessionId = session.Id };
             AttachOrUpdate(stub, removedId, EntityState.Deleted);
+        }
+    }
+
+    /// <summary>
+    /// #2570 SP3 T2: Diary entries are append-only — only INSERT new entries, never UPDATE
+    /// or DELETE existing ones. The domain guarantees immutability post-creation; the cascade
+    /// on session delete covers the cleanup path automatically.
+    /// </summary>
+    private async Task SyncDiaryEntriesAsync(
+        LiveGameSession session, ICollection<LiveSessionDiaryEntryEntity> snapshotEntries,
+        CancellationToken cancellationToken)
+    {
+        var existingIds = await DbContext.Set<LiveSessionDiaryEntryEntity>()
+            .AsNoTracking()
+            .Where(e => e.LiveGameSessionId == session.Id)
+            .Select(e => e.Id)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        // Diary entries are append-only: INSERT new, skip existing (immutable).
+        // No DELETE path — the domain never removes diary entries.
+        foreach (var entry in snapshotEntries)
+        {
+            if (!existingIds.Contains(entry.Id))
+            {
+                AttachOrUpdate(entry, entry.Id, EntityState.Added);
+            }
+            // Existing entries are immutable; skipping update is correct by design.
         }
     }
 

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Persistence/Mappers/LiveGameSessionMapper.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Persistence/Mappers/LiveGameSessionMapper.cs
@@ -144,6 +144,20 @@ internal static class LiveGameSessionMapper
             });
         }
 
+        // #2570 SP3 T2: diary entries — domain DiaryEntry.Id is the stable PK assigned
+        // at creation time (AddDiaryEntry uses Guid.NewGuid()), so no deterministic helper needed.
+        foreach (var entry in domain.DiaryEntries)
+        {
+            entity.DiaryEntries.Add(new LiveSessionDiaryEntryEntity
+            {
+                Id = entry.Id,
+                LiveGameSessionId = domain.Id,
+                AuthorId = entry.AuthorId,
+                CreatedAt = entry.CreatedAt,
+                Text = entry.Text
+            });
+        }
+
         return entity;
     }
 
@@ -237,6 +251,12 @@ internal static class LiveGameSessionMapper
             phaseName: t.PhaseName,
             endedAt: t.EndedAt)).ToList();
 
+        // #2570 SP3 T2: diary entries — restored in CreatedAt order (oldest first).
+        var diaryEntries = entity.DiaryEntries
+            .OrderBy(d => d.CreatedAt)
+            .Select(d => new DiaryEntry(d.Id, d.AuthorId, d.CreatedAt, d.Text))
+            .ToList();
+
         return LiveGameSession.Reconstitute(
             id: entity.Id,
             sessionCode: entity.SessionCode,
@@ -272,6 +292,7 @@ internal static class LiveGameSessionMapper
             roundScores: roundScores,
             turnRecords: turnRecords,
             disputes: disputes,
+            diaryEntries: diaryEntries,
             setupChecklist: setupChecklist);
     }
 

--- a/apps/api/src/Api/Infrastructure/Configurations/GameManagement/LiveGameSessionEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/Configurations/GameManagement/LiveGameSessionEntityConfiguration.cs
@@ -201,5 +201,11 @@ internal sealed class LiveGameSessionEntityConfiguration : IEntityTypeConfigurat
             .WithOne(t => t.LiveGameSession)
             .HasForeignKey(t => t.LiveGameSessionId)
             .OnDelete(DeleteBehavior.Cascade);
+
+        // #2570 SP3 T2: diary entries — append-only, cascade on session delete
+        builder.HasMany(e => e.DiaryEntries)
+            .WithOne(d => d.LiveGameSession)
+            .HasForeignKey(d => d.LiveGameSessionId)
+            .OnDelete(DeleteBehavior.Cascade);
     }
 }

--- a/apps/api/src/Api/Infrastructure/Configurations/GameManagement/LiveSessionDiaryEntryEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/Configurations/GameManagement/LiveSessionDiaryEntryEntityConfiguration.cs
@@ -1,0 +1,53 @@
+using Api.Infrastructure.Entities.GameManagement;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Api.Infrastructure.Configurations.GameManagement;
+
+/// <summary>
+/// EF Core configuration for LiveSessionDiaryEntryEntity.
+/// #2570 SP3 T2: Table schema and indexes for per-session diary entries.
+/// The FK cascade from live_game_sessions is configured in
+/// <see cref="LiveGameSessionEntityConfiguration"/>.
+/// </summary>
+internal sealed class LiveSessionDiaryEntryEntityConfiguration : IEntityTypeConfiguration<LiveSessionDiaryEntryEntity>
+{
+    public void Configure(EntityTypeBuilder<LiveSessionDiaryEntryEntity> builder)
+    {
+        builder.ToTable("live_session_diary_entries");
+
+        builder.HasKey(e => e.Id);
+
+        // --- Scalar Properties ---
+
+        builder.Property(e => e.Id)
+            .HasColumnName("id");
+
+        builder.Property(e => e.LiveGameSessionId)
+            .HasColumnName("live_game_session_id")
+            .IsRequired();
+
+        builder.Property(e => e.AuthorId)
+            .HasColumnName("author_id")
+            .IsRequired();
+
+        builder.Property(e => e.CreatedAt)
+            .HasColumnName("created_at")
+            .IsRequired();
+
+        builder.Property(e => e.Text)
+            .HasColumnName("text")
+            .HasMaxLength(2000)
+            .IsRequired();
+
+        // --- Indexes ---
+
+        builder.HasIndex(e => e.LiveGameSessionId)
+            .HasDatabaseName("ix_live_session_diary_entries_session_id");
+
+        builder.HasIndex(e => new { e.LiveGameSessionId, e.CreatedAt })
+            .HasDatabaseName("ix_live_session_diary_entries_session_created_at");
+
+        // FK cascade from LiveGameSession → configured in LiveGameSessionEntityConfiguration
+    }
+}

--- a/apps/api/src/Api/Infrastructure/Entities/GameManagement/LiveGameSessionEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/GameManagement/LiveGameSessionEntity.cs
@@ -78,4 +78,6 @@ public class LiveGameSessionEntity
     public ICollection<SessionTeamEntity> Teams { get; set; } = new List<SessionTeamEntity>();
     public ICollection<LiveRoundScoreEntity> RoundScores { get; set; } = new List<LiveRoundScoreEntity>();
     public ICollection<LiveTurnRecordEntity> TurnRecords { get; set; } = new List<LiveTurnRecordEntity>();
+    // #2570 SP3 T2: per-session diary entries (append-only)
+    public ICollection<LiveSessionDiaryEntryEntity> DiaryEntries { get; set; } = new List<LiveSessionDiaryEntryEntity>();
 }

--- a/apps/api/src/Api/Infrastructure/Entities/GameManagement/LiveSessionDiaryEntryEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/GameManagement/LiveSessionDiaryEntryEntity.cs
@@ -1,0 +1,19 @@
+namespace Api.Infrastructure.Entities.GameManagement;
+
+/// <summary>
+/// Infrastructure entity for DiaryEntry value object.
+/// #2570 SP3 T2: Flattened table for per-session diary entries in live sessions.
+/// Table: live_session_diary_entries (FK → live_game_sessions, cascade delete).
+/// Diary entries are append-only; no UPDATE or DELETE via the domain model.
+/// </summary>
+public class LiveSessionDiaryEntryEntity
+{
+    public Guid Id { get; set; }
+    public Guid LiveGameSessionId { get; set; }
+    public Guid AuthorId { get; set; }
+    public DateTimeOffset CreatedAt { get; set; }
+    public string Text { get; set; } = default!;
+
+    // Navigation Properties
+    public LiveGameSessionEntity LiveGameSession { get; set; } = default!;
+}

--- a/apps/api/src/Api/Infrastructure/Migrations/20260629061044_AddLiveSessionDiaryEntries.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260629061044_AddLiveSessionDiaryEntries.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260629061044_AddLiveSessionDiaryEntries")]
+    partial class AddLiveSessionDiaryEntries
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260629061044_AddLiveSessionDiaryEntries.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260629061044_AddLiveSessionDiaryEntries.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddLiveSessionDiaryEntries : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "live_session_diary_entries",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    live_game_session_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    author_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    text = table.Column<string>(type: "character varying(2000)", maxLength: 2000, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_live_session_diary_entries", x => x.id);
+                    table.ForeignKey(
+                        name: "FK_live_session_diary_entries_live_game_sessions_live_game_ses~",
+                        column: x => x.live_game_session_id,
+                        principalTable: "live_game_sessions",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_live_session_diary_entries_session_created_at",
+                table: "live_session_diary_entries",
+                columns: new[] { "live_game_session_id", "created_at" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_live_session_diary_entries_session_id",
+                table: "live_session_diary_entries",
+                column: "live_game_session_id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "live_session_diary_entries");
+        }
+    }
+}

--- a/apps/api/src/Api/Routing/LiveSessionEndpoints.cs
+++ b/apps/api/src/Api/Routing/LiveSessionEndpoints.cs
@@ -229,6 +229,26 @@ internal static class LiveSessionEndpoints
             .WithSummary("Update setup checklist state")
             .WithDescription("Replaces the setup checklist data, used when the user toggles components or completes steps in the setup wizard.");
 
+        // === Diary (SP3) ===
+
+        group.MapPost("/live-sessions/{sessionId}/diary", HandleAddDiaryEntry)
+            .RequireAuthenticatedUser()
+            .Produces<Guid>(201)
+            .Produces(400)
+            .Produces(404)
+            .Produces(409)
+            .WithTags("LiveSessions")
+            .WithSummary("Add a diary entry to a live session")
+            .WithDescription("Appends an immutable diary entry to the session. Returns the new entry id. 409 if session is Completed. Issue #2570 SP3.");
+
+        group.MapGet("/live-sessions/{sessionId}/diary", HandleGetDiary)
+            .RequireAuthenticatedUser()
+            .Produces<IReadOnlyList<DiaryEntryDto>>(200)
+            .Produces(404)
+            .WithTags("LiveSessions")
+            .WithSummary("Get diary entries for a live session")
+            .WithDescription("Returns all diary entries ordered by CreatedAt ascending. 404 if session not found. Issue #2570 SP3.");
+
         // === Dispute v2 ===
 
         group.MapPost("/live-sessions/{sessionId}/disputes", HandleOpenDispute)
@@ -656,6 +676,45 @@ internal static class LiveSessionEndpoints
         return Results.NoContent();
     }
 
+    // === Diary handlers (SP3 T5) ===
+
+    /// <summary>
+    /// POST /api/v1/live-sessions/{sessionId}/diary — Issue #2570 SP3 T5.
+    /// AuthorId is taken from the authenticated user's claims (not from the body).
+    /// 409 (Completed session) and 404 (not found) propagate from the command handler via middleware.
+    /// </summary>
+    private static async Task<IResult> HandleAddDiaryEntry(
+        Guid sessionId,
+        [FromBody] AddDiaryEntryRequest request,
+        HttpContext httpContext,
+        [FromServices] IMediator mediator,
+        CancellationToken cancellationToken)
+    {
+        var authorId = httpContext.User.GetUserId();
+
+        var entryId = await mediator.Send(
+            new AddDiaryEntryCommand(sessionId, authorId, request.Text),
+            cancellationToken).ConfigureAwait(false);
+
+        return Results.Created($"/api/v1/live-sessions/{sessionId}/diary/{entryId}", entryId);
+    }
+
+    /// <summary>
+    /// GET /api/v1/live-sessions/{sessionId}/diary — Issue #2570 SP3 T5.
+    /// Returns all diary entries ordered by CreatedAt ascending. 404 if session not found.
+    /// </summary>
+    private static async Task<IResult> HandleGetDiary(
+        Guid sessionId,
+        [FromServices] IMediator mediator,
+        CancellationToken cancellationToken)
+    {
+        var entries = await mediator.Send(
+            new GetLiveSessionDiaryQuery(sessionId),
+            cancellationToken).ConfigureAwait(false);
+
+        return Results.Ok(entries);
+    }
+
     private static async Task<IResult> HandleOpenDispute(
         Guid sessionId,
         [FromBody] OpenDisputeRequest request,
@@ -1002,6 +1061,9 @@ internal static class LiveSessionEndpoints
     private sealed record ConfirmScoreRequest(Guid PlayerId, string Dimension, int Value, int Round);
 
     private sealed record GenerateSetupChecklistRequest(int PlayerCount);
+
+    // Diary (SP3) request model
+    private sealed record AddDiaryEntryRequest(string Text);
 
     // Dispute v2 request models
     internal sealed record OpenDisputeRequest(

--- a/apps/api/src/Api/Routing/LiveSessionEndpoints.cs
+++ b/apps/api/src/Api/Routing/LiveSessionEndpoints.cs
@@ -702,14 +702,18 @@ internal static class LiveSessionEndpoints
     /// <summary>
     /// GET /api/v1/live-sessions/{sessionId}/diary — Issue #2570 SP3 T5.
     /// Returns all diary entries ordered by CreatedAt ascending. 404 if session not found.
+    /// 403 if the caller is not the session creator or an active participant.
     /// </summary>
     private static async Task<IResult> HandleGetDiary(
         Guid sessionId,
+        HttpContext httpContext,
         [FromServices] IMediator mediator,
         CancellationToken cancellationToken)
     {
+        var userId = httpContext.User.GetUserId();
+
         var entries = await mediator.Send(
-            new GetLiveSessionDiaryQuery(sessionId),
+            new GetLiveSessionDiaryQuery(sessionId, userId),
             cancellationToken).ConfigureAwait(false);
 
         return Results.Ok(entries);

--- a/apps/api/src/Api/Routing/LiveSessionEndpoints.cs
+++ b/apps/api/src/Api/Routing/LiveSessionEndpoints.cs
@@ -235,19 +235,23 @@ internal static class LiveSessionEndpoints
             .RequireAuthenticatedUser()
             .Produces<Guid>(201)
             .Produces(400)
+            .Produces(401)
+            .Produces(403)
             .Produces(404)
             .Produces(409)
             .WithTags("LiveSessions")
             .WithSummary("Add a diary entry to a live session")
-            .WithDescription("Appends an immutable diary entry to the session. Returns the new entry id. 409 if session is Completed. Issue #2570 SP3.");
+            .WithDescription("Appends an immutable diary entry to the session. Returns the new entry id. 403 if caller is not a participant. 409 if session is Completed. Issue #2570 SP3.");
 
         group.MapGet("/live-sessions/{sessionId}/diary", HandleGetDiary)
             .RequireAuthenticatedUser()
             .Produces<IReadOnlyList<DiaryEntryDto>>(200)
+            .Produces(401)
+            .Produces(403)
             .Produces(404)
             .WithTags("LiveSessions")
             .WithSummary("Get diary entries for a live session")
-            .WithDescription("Returns all diary entries ordered by CreatedAt ascending. 404 if session not found. Issue #2570 SP3.");
+            .WithDescription("Returns all diary entries ordered by CreatedAt ascending. 403 if caller is not a session participant. 404 if session not found. Issue #2570 SP3.");
 
         // === Dispute v2 ===
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/EventHandlers/LiveSessionStreamForwarderTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/EventHandlers/LiveSessionStreamForwarderTests.cs
@@ -170,4 +170,41 @@ public sealed class LiveSessionStreamForwarderTests
             It.IsAny<CancellationToken>()),
             Times.Once);
     }
+
+    [Fact]
+    public async Task Forwards_diary_entry_added_event_as_session_diary()
+    {
+        // Arrange
+        var sid = Guid.NewGuid();
+        var entryId = Guid.NewGuid();
+        var authorId = Guid.NewGuid();
+        var createdAt = new DateTimeOffset(2026, 6, 29, 10, 0, 0, TimeSpan.Zero);
+        var evt = new LiveSessionDiaryEntryAddedEvent(sid, entryId, authorId, "Great move!", createdAt);
+
+        LiveSessionStreamEvent? captured = null;
+        _gateway
+            .Setup(g => g.BroadcastAsync(It.IsAny<Guid>(), It.IsAny<LiveSessionStreamEvent>(), It.IsAny<CancellationToken>()))
+            .Callback<Guid, LiveSessionStreamEvent, CancellationToken>((_, e, _) => captured = e)
+            .Returns(Task.CompletedTask);
+
+        // Act
+        await _handler.Handle(evt, CancellationToken.None);
+
+        // Assert — event type
+        _gateway.Verify(g => g.BroadcastAsync(
+            sid,
+            It.Is<LiveSessionStreamEvent>(e => e.Type == "session:diary"),
+            It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        // Assert — payload fields via reflection on anonymous object
+        captured.Should().NotBeNull();
+        var data = captured!.Data;
+        var dataType = data.GetType();
+
+        dataType.GetProperty("entryId")!.GetValue(data).Should().Be(entryId);
+        dataType.GetProperty("authorId")!.GetValue(data).Should().Be(authorId);
+        dataType.GetProperty("content")!.GetValue(data).Should().Be("Great move!");
+        dataType.GetProperty("timestamp")!.GetValue(data).Should().Be(createdAt.ToString("o"));
+    }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/LiveSessions/AddDiaryEntryCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/LiveSessions/AddDiaryEntryCommandHandlerTests.cs
@@ -148,6 +148,33 @@ public class AddDiaryEntryCommandHandlerTests
     }
 
     [Fact]
+    public async Task Handle_CallerIsNotParticipant_ThrowsForbiddenException()
+    {
+        // Arrange — session created by DefaultAuthorId, caller is a different user (nonParticipant)
+        var session = CreateActiveSession();
+        SetupRepoGetById(DefaultSessionId, session);
+        var nonParticipantId = Guid.NewGuid();
+        var command = new AddDiaryEntryCommand(DefaultSessionId, nonParticipantId, DefaultText);
+
+        // Act & Assert
+        var act = () => _handler.Handle(command, CancellationToken.None);
+        await act.Should().ThrowAsync<ForbiddenException>(
+            "only the session creator or an active participant may add diary entries");
+    }
+
+    [Fact]
+    public async Task Handle_NotFoundTakesPrecedenceOver403()
+    {
+        // Arrange — session doesn't exist; non-participant id
+        SetupRepoGetById(DefaultSessionId, null);
+        var command = new AddDiaryEntryCommand(DefaultSessionId, Guid.NewGuid(), DefaultText);
+
+        // Act & Assert — 404 fires before 403 (load-first pattern)
+        var act = () => _handler.Handle(command, CancellationToken.None);
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+
+    [Fact]
     public async Task Handle_SessionNotFound_DoesNotCallSaveChanges()
     {
         // Arrange

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/LiveSessions/AddDiaryEntryCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/LiveSessions/AddDiaryEntryCommandHandlerTests.cs
@@ -1,0 +1,256 @@
+using Api.BoundedContexts.GameManagement.Application.Commands.LiveSessions;
+using Api.BoundedContexts.GameManagement.Application.Validators.LiveSessions;
+using Api.BoundedContexts.GameManagement.Domain.Entities;
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+using Api.BoundedContexts.GameManagement.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Tests.Constants;
+using FluentAssertions;
+using FluentValidation.TestHelper;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Application.Handlers.LiveSessions;
+
+/// <summary>
+/// Unit tests for AddDiaryEntryCommand, AddDiaryEntryCommandValidator, and AddDiaryEntryCommandHandler.
+/// TDD: Tests written first (RED), then implementation (GREEN).
+/// Issue #2570 SP3 T3.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "GameManagement")]
+public class AddDiaryEntryCommandHandlerTests
+{
+    private readonly Mock<ILiveSessionRepository> _repositoryMock;
+    private readonly Mock<IUnitOfWork> _unitOfWorkMock;
+    private readonly AddDiaryEntryCommandHandler _handler;
+    private readonly AddDiaryEntryCommandValidator _validator;
+
+    private static readonly Guid DefaultSessionId = Guid.NewGuid();
+    private static readonly Guid DefaultAuthorId = Guid.NewGuid();
+    private const string DefaultText = "We played the first round and it was amazing!";
+
+    public AddDiaryEntryCommandHandlerTests()
+    {
+        _repositoryMock = new Mock<ILiveSessionRepository>();
+        _unitOfWorkMock = new Mock<IUnitOfWork>();
+
+        _unitOfWorkMock
+            .Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        _handler = new AddDiaryEntryCommandHandler(
+            _repositoryMock.Object,
+            _unitOfWorkMock.Object);
+
+        _validator = new AddDiaryEntryCommandValidator();
+    }
+
+    // === Helpers ===
+
+    private static LiveGameSession CreateActiveSession(Guid? sessionId = null)
+    {
+        var id = sessionId ?? DefaultSessionId;
+        var session = LiveGameSession.Create(id, DefaultAuthorId, "Test Game", TimeProvider.System);
+        // Start requires at least one player
+        session.AddPlayer(DefaultAuthorId, "Host Player", PlayerColor.Red, TimeProvider.System);
+        session.Start(TimeProvider.System);
+        return session;
+    }
+
+    private static LiveGameSession CreateCompletedSession(Guid? sessionId = null)
+    {
+        var session = CreateActiveSession(sessionId);
+        session.Complete(TimeProvider.System);
+        return session;
+    }
+
+    private void SetupRepoGetById(Guid sessionId, LiveGameSession? session)
+    {
+        _repositoryMock
+            .Setup(x => x.GetByIdAsync(sessionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(session);
+    }
+
+    // === Validator tests ===
+
+    [Fact]
+    public void Validator_EmptySessionId_HasValidationError()
+    {
+        var command = new AddDiaryEntryCommand(Guid.Empty, DefaultAuthorId, DefaultText);
+        var result = _validator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(x => x.SessionId);
+    }
+
+    [Fact]
+    public void Validator_EmptyAuthorId_HasValidationError()
+    {
+        var command = new AddDiaryEntryCommand(DefaultSessionId, Guid.Empty, DefaultText);
+        var result = _validator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(x => x.AuthorId);
+    }
+
+    [Fact]
+    public void Validator_EmptyText_HasValidationError()
+    {
+        var command = new AddDiaryEntryCommand(DefaultSessionId, DefaultAuthorId, string.Empty);
+        var result = _validator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(x => x.Text);
+    }
+
+    [Fact]
+    public void Validator_WhitespaceText_HasValidationError()
+    {
+        var command = new AddDiaryEntryCommand(DefaultSessionId, DefaultAuthorId, "   ");
+        var result = _validator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(x => x.Text);
+    }
+
+    [Fact]
+    public void Validator_TextExceedsCap_HasValidationError()
+    {
+        var overCapText = new string('a', 2001);
+        var command = new AddDiaryEntryCommand(DefaultSessionId, DefaultAuthorId, overCapText);
+        var result = _validator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(x => x.Text);
+    }
+
+    [Fact]
+    public void Validator_TextAtMaxLength_IsValid()
+    {
+        var maxText = new string('a', 2000);
+        var command = new AddDiaryEntryCommand(DefaultSessionId, DefaultAuthorId, maxText);
+        var result = _validator.TestValidate(command);
+        result.ShouldNotHaveValidationErrorFor(x => x.Text);
+    }
+
+    [Fact]
+    public void Validator_ValidCommand_NoErrors()
+    {
+        var command = new AddDiaryEntryCommand(DefaultSessionId, DefaultAuthorId, DefaultText);
+        var result = _validator.TestValidate(command);
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    // === Handler tests ===
+
+    [Fact]
+    public async Task Handle_SessionNotFound_ThrowsNotFoundException()
+    {
+        // Arrange
+        SetupRepoGetById(DefaultSessionId, null);
+        var command = new AddDiaryEntryCommand(DefaultSessionId, DefaultAuthorId, DefaultText);
+
+        // Act & Assert
+        var act = () => _handler.Handle(command, CancellationToken.None);
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+
+    [Fact]
+    public async Task Handle_SessionNotFound_DoesNotCallSaveChanges()
+    {
+        // Arrange
+        SetupRepoGetById(DefaultSessionId, null);
+        var command = new AddDiaryEntryCommand(DefaultSessionId, DefaultAuthorId, DefaultText);
+
+        // Act
+        try { await _handler.Handle(command, CancellationToken.None); } catch { /* expected */ }
+
+        // Assert
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_CompletedSession_ThrowsConflictException()
+    {
+        // Arrange
+        var session = CreateCompletedSession();
+        SetupRepoGetById(DefaultSessionId, session);
+        var command = new AddDiaryEntryCommand(DefaultSessionId, DefaultAuthorId, DefaultText);
+
+        // Act & Assert
+        var act = () => _handler.Handle(command, CancellationToken.None);
+        await act.Should().ThrowAsync<ConflictException>();
+    }
+
+    [Fact]
+    public async Task Handle_ValidCommand_ReturnsDiaryEntryId()
+    {
+        // Arrange
+        var session = CreateActiveSession();
+        SetupRepoGetById(DefaultSessionId, session);
+        var command = new AddDiaryEntryCommand(DefaultSessionId, DefaultAuthorId, DefaultText);
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public async Task Handle_ValidCommand_EntryAppendsToSession()
+    {
+        // Arrange
+        var session = CreateActiveSession();
+        SetupRepoGetById(DefaultSessionId, session);
+        var command = new AddDiaryEntryCommand(DefaultSessionId, DefaultAuthorId, DefaultText);
+
+        // Act
+        var entryId = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        session.DiaryEntries.Should().HaveCount(1);
+        session.DiaryEntries[0].Id.Should().Be(entryId);
+        session.DiaryEntries[0].AuthorId.Should().Be(DefaultAuthorId);
+        session.DiaryEntries[0].Text.Should().Be(DefaultText);
+    }
+
+    [Fact]
+    public async Task Handle_ValidCommand_CallsSaveChangesOnce()
+    {
+        // Arrange
+        var session = CreateActiveSession();
+        SetupRepoGetById(DefaultSessionId, session);
+        var command = new AddDiaryEntryCommand(DefaultSessionId, DefaultAuthorId, DefaultText);
+
+        // Act
+        await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ValidCommand_CallsRepositoryUpdateAsync()
+    {
+        // Arrange
+        var session = CreateActiveSession();
+        SetupRepoGetById(DefaultSessionId, session);
+        var command = new AddDiaryEntryCommand(DefaultSessionId, DefaultAuthorId, DefaultText);
+
+        // Act
+        await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        _repositoryMock.Verify(r => r.UpdateAsync(session, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_MultipleEntries_AllAppended()
+    {
+        // Arrange
+        var session = CreateActiveSession();
+        SetupRepoGetById(DefaultSessionId, session);
+
+        // Act
+        var id1 = await _handler.Handle(new AddDiaryEntryCommand(DefaultSessionId, DefaultAuthorId, "Entry one"), CancellationToken.None);
+        var id2 = await _handler.Handle(new AddDiaryEntryCommand(DefaultSessionId, DefaultAuthorId, "Entry two"), CancellationToken.None);
+
+        // Assert
+        session.DiaryEntries.Should().HaveCount(2);
+        session.DiaryEntries[0].Id.Should().Be(id1);
+        session.DiaryEntries[1].Id.Should().Be(id2);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/LiveSessions/GetLiveSessionDiaryQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/LiveSessions/GetLiveSessionDiaryQueryHandlerTests.cs
@@ -1,0 +1,213 @@
+using Api.BoundedContexts.GameManagement.Application.Queries.LiveSessions;
+using Api.BoundedContexts.GameManagement.Domain.Entities;
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+using Api.BoundedContexts.GameManagement.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Application.Handlers.LiveSessions;
+
+/// <summary>
+/// Unit tests for <see cref="GetLiveSessionDiaryQueryHandler"/>.
+/// TDD: Tests written first (RED), then implementation (GREEN).
+/// Issue #2570 SP3 T4.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "GameManagement")]
+public class GetLiveSessionDiaryQueryHandlerTests
+{
+    private readonly Mock<ILiveSessionRepository> _repositoryMock;
+    private readonly GetLiveSessionDiaryQueryHandler _handler;
+
+    private static readonly Guid DefaultSessionId = Guid.NewGuid();
+    private static readonly Guid DefaultAuthorId = Guid.NewGuid();
+
+    public GetLiveSessionDiaryQueryHandlerTests()
+    {
+        _repositoryMock = new Mock<ILiveSessionRepository>();
+        _handler = new GetLiveSessionDiaryQueryHandler(_repositoryMock.Object);
+    }
+
+    // === Helpers ===
+
+    private static LiveGameSession CreateSession(Guid? sessionId = null)
+    {
+        return LiveGameSession.Create(
+            sessionId ?? DefaultSessionId,
+            Guid.NewGuid(),
+            "Test Game",
+            TimeProvider.System);
+    }
+
+    private static LiveGameSession CreateActiveSessionWithDiary(
+        Guid sessionId,
+        params string[] entryTexts)
+    {
+        var session = CreateSession(sessionId);
+        // Start the session so diary entries can be added
+        session.AddPlayer(DefaultAuthorId, "Host", PlayerColor.Red, TimeProvider.System);
+        session.Start(TimeProvider.System);
+
+        foreach (var text in entryTexts)
+        {
+            session.AddDiaryEntry(DefaultAuthorId, text, TimeProvider.System);
+        }
+
+        return session;
+    }
+
+    private void SetupRepoGetById(Guid sessionId, LiveGameSession? session)
+    {
+        _repositoryMock
+            .Setup(r => r.GetByIdAsync(sessionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(session);
+    }
+
+    // === Constructor guard ===
+
+    [Fact]
+    public void Constructor_NullRepository_ThrowsArgumentNullException()
+    {
+        var act = () => new GetLiveSessionDiaryQueryHandler(null!);
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    // === Handle: null guard ===
+
+    [Fact]
+    public async Task Handle_NullQuery_ThrowsArgumentNullException()
+    {
+        var act = () => _handler.Handle(null!, CancellationToken.None);
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    // === Handle: not found ===
+
+    [Fact]
+    public async Task Handle_SessionNotFound_ThrowsNotFoundException()
+    {
+        // Arrange
+        SetupRepoGetById(DefaultSessionId, null);
+        var query = new GetLiveSessionDiaryQuery(DefaultSessionId);
+
+        // Act & Assert
+        var act = () => _handler.Handle(query, CancellationToken.None);
+        var exception = (await act.Should().ThrowAsync<NotFoundException>()).Which;
+
+        exception.ResourceType.Should().Be("LiveGameSession");
+        exception.ResourceId.Should().Be(DefaultSessionId.ToString());
+    }
+
+    // === Handle: empty diary ===
+
+    [Fact]
+    public async Task Handle_SessionWithNoDiaryEntries_ReturnsEmptyList()
+    {
+        // Arrange
+        var session = CreateSession(DefaultSessionId);
+        SetupRepoGetById(DefaultSessionId, session);
+        var query = new GetLiveSessionDiaryQuery(DefaultSessionId);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().BeEmpty();
+    }
+
+    // === Handle: chronological order ===
+
+    [Fact]
+    public async Task Handle_SessionWithDiaryEntries_ReturnsEntriesChronologically()
+    {
+        // Arrange
+        var session = CreateActiveSessionWithDiary(
+            DefaultSessionId,
+            "First entry",
+            "Second entry",
+            "Third entry");
+
+        SetupRepoGetById(DefaultSessionId, session);
+        var query = new GetLiveSessionDiaryQuery(DefaultSessionId);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.Should().HaveCount(3);
+        result.Should().BeInAscendingOrder(e => e.CreatedAt);
+    }
+
+    [Fact]
+    public async Task Handle_SessionWithDiaryEntries_MapsFieldsCorrectly()
+    {
+        // Arrange
+        var session = CreateActiveSessionWithDiary(DefaultSessionId, "Great round!");
+        SetupRepoGetById(DefaultSessionId, session);
+        var query = new GetLiveSessionDiaryQuery(DefaultSessionId);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.Should().ContainSingle();
+        var dto = result[0];
+        dto.Id.Should().NotBe(Guid.Empty);
+        dto.AuthorId.Should().Be(DefaultAuthorId);
+        dto.Text.Should().Be("Great round!");
+        dto.CreatedAt.Should().NotBe(default);
+    }
+
+    [Fact]
+    public async Task Handle_SingleEntry_ReturnsSingleDto()
+    {
+        // Arrange
+        var session = CreateActiveSessionWithDiary(DefaultSessionId, "Only entry");
+        SetupRepoGetById(DefaultSessionId, session);
+        var query = new GetLiveSessionDiaryQuery(DefaultSessionId);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.Should().ContainSingle();
+        result[0].Text.Should().Be("Only entry");
+    }
+
+    [Fact]
+    public async Task Handle_MultipleEntries_PreservesDistinctIds()
+    {
+        // Arrange
+        var session = CreateActiveSessionWithDiary(DefaultSessionId, "Entry A", "Entry B");
+        SetupRepoGetById(DefaultSessionId, session);
+        var query = new GetLiveSessionDiaryQuery(DefaultSessionId);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.Should().HaveCount(2);
+        result.Select(e => e.Id).Should().OnlyHaveUniqueItems();
+    }
+
+    [Fact]
+    public async Task Handle_CallsRepositoryOnce()
+    {
+        // Arrange
+        var session = CreateSession(DefaultSessionId);
+        SetupRepoGetById(DefaultSessionId, session);
+        var query = new GetLiveSessionDiaryQuery(DefaultSessionId);
+
+        // Act
+        await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        _repositoryMock.Verify(
+            r => r.GetByIdAsync(DefaultSessionId, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/LiveSessions/GetLiveSessionDiaryQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/LiveSessions/GetLiveSessionDiaryQueryHandlerTests.cs
@@ -5,6 +5,7 @@ using Api.BoundedContexts.GameManagement.Domain.Repositories;
 using Api.Middleware.Exceptions;
 using Api.Tests.Constants;
 using FluentAssertions;
+using Microsoft.Extensions.Time.Testing;
 using Moq;
 using Xunit;
 
@@ -47,14 +48,25 @@ public class GetLiveSessionDiaryQueryHandlerTests
         Guid sessionId,
         params string[] entryTexts)
     {
+        // Use FakeTimeProvider so each AddDiaryEntry call gets a DISTINCT, increasing timestamp.
+        // Without this, rapid in-loop calls to TimeProvider.System return sub-millisecond
+        // identical timestamps and BeInAscendingOrder holds vacuously even if ORDER BY is removed.
+        var fakeTime = new FakeTimeProvider(
+            new DateTimeOffset(2026, 6, 29, 10, 0, 0, TimeSpan.Zero));
+
         var session = CreateSession(sessionId, DefaultCreatorId);
         // Start the session so diary entries can be added
-        session.AddPlayer(DefaultAuthorId, "Host", PlayerColor.Red, TimeProvider.System);
-        session.Start(TimeProvider.System);
+        session.AddPlayer(DefaultAuthorId, "Host", PlayerColor.Red, fakeTime);
+        session.Start(fakeTime);
 
         foreach (var text in entryTexts)
         {
-            session.AddDiaryEntry(DefaultAuthorId, text, TimeProvider.System);
+            session.AddDiaryEntry(DefaultAuthorId, text, fakeTime);
+            // Advance 1 second between entries so each gets a strictly greater CreatedAt.
+            // This makes BeInAscendingOrder non-vacuous: if ORDER BY were removed the assertion
+            // would still hold only by insertion-order luck — but with distinct timestamps the
+            // query handler MUST sort to satisfy the assertion regardless of retrieval order.
+            fakeTime.Advance(TimeSpan.FromSeconds(1));
         }
 
         return session;

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/LiveSessions/GetLiveSessionDiaryQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/LiveSessions/GetLiveSessionDiaryQueryHandlerTests.cs
@@ -13,7 +13,7 @@ namespace Api.Tests.BoundedContexts.GameManagement.Application.Handlers.LiveSess
 /// <summary>
 /// Unit tests for <see cref="GetLiveSessionDiaryQueryHandler"/>.
 /// TDD: Tests written first (RED), then implementation (GREEN).
-/// Issue #2570 SP3 T4.
+/// Issue #2570 SP3 T4 / T5 authz fix.
 /// </summary>
 [Trait("Category", TestCategories.Unit)]
 [Trait("BoundedContext", "GameManagement")]
@@ -23,6 +23,7 @@ public class GetLiveSessionDiaryQueryHandlerTests
     private readonly GetLiveSessionDiaryQueryHandler _handler;
 
     private static readonly Guid DefaultSessionId = Guid.NewGuid();
+    private static readonly Guid DefaultCreatorId = Guid.NewGuid();
     private static readonly Guid DefaultAuthorId = Guid.NewGuid();
 
     public GetLiveSessionDiaryQueryHandlerTests()
@@ -33,11 +34,11 @@ public class GetLiveSessionDiaryQueryHandlerTests
 
     // === Helpers ===
 
-    private static LiveGameSession CreateSession(Guid? sessionId = null)
+    private static LiveGameSession CreateSession(Guid? sessionId = null, Guid? creatorId = null)
     {
         return LiveGameSession.Create(
             sessionId ?? DefaultSessionId,
-            Guid.NewGuid(),
+            creatorId ?? DefaultCreatorId,
             "Test Game",
             TimeProvider.System);
     }
@@ -46,7 +47,7 @@ public class GetLiveSessionDiaryQueryHandlerTests
         Guid sessionId,
         params string[] entryTexts)
     {
-        var session = CreateSession(sessionId);
+        var session = CreateSession(sessionId, DefaultCreatorId);
         // Start the session so diary entries can be added
         session.AddPlayer(DefaultAuthorId, "Host", PlayerColor.Red, TimeProvider.System);
         session.Start(TimeProvider.System);
@@ -84,14 +85,14 @@ public class GetLiveSessionDiaryQueryHandlerTests
         await act.Should().ThrowAsync<ArgumentNullException>();
     }
 
-    // === Handle: not found ===
+    // === Handle: not found (404 takes precedence over 403) ===
 
     [Fact]
     public async Task Handle_SessionNotFound_ThrowsNotFoundException()
     {
         // Arrange
         SetupRepoGetById(DefaultSessionId, null);
-        var query = new GetLiveSessionDiaryQuery(DefaultSessionId);
+        var query = new GetLiveSessionDiaryQuery(DefaultSessionId, DefaultCreatorId);
 
         // Act & Assert
         var act = () => _handler.Handle(query, CancellationToken.None);
@@ -101,15 +102,50 @@ public class GetLiveSessionDiaryQueryHandlerTests
         exception.ResourceId.Should().Be(DefaultSessionId.ToString());
     }
 
+    // === Handle: authz — non-participant → ForbiddenException (HTTP 403) ===
+
+    [Fact]
+    public async Task Handle_CallerIsNotParticipant_ThrowsForbiddenException()
+    {
+        // Arrange
+        var session = CreateSession(DefaultSessionId, DefaultCreatorId);
+        SetupRepoGetById(DefaultSessionId, session);
+        var nonParticipantId = Guid.NewGuid();
+        var query = new GetLiveSessionDiaryQuery(DefaultSessionId, nonParticipantId);
+
+        // Act & Assert
+        var act = () => _handler.Handle(query, CancellationToken.None);
+        await act.Should().ThrowAsync<ForbiddenException>(
+            "a caller who is neither the creator nor an active player must receive 403");
+    }
+
+    // === Handle: authz — creator can read ===
+
+    [Fact]
+    public async Task Handle_CallerIsCreator_ReturnsDiaryEntries()
+    {
+        // Arrange — creator is DefaultCreatorId (no players needed — creator check fires first)
+        var session = CreateSession(DefaultSessionId, DefaultCreatorId);
+        SetupRepoGetById(DefaultSessionId, session);
+        var query = new GetLiveSessionDiaryQuery(DefaultSessionId, DefaultCreatorId);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Should().BeEmpty("no entries were added to this session");
+    }
+
     // === Handle: empty diary ===
 
     [Fact]
     public async Task Handle_SessionWithNoDiaryEntries_ReturnsEmptyList()
     {
-        // Arrange
-        var session = CreateSession(DefaultSessionId);
+        // Arrange — use creator as caller so authz passes
+        var session = CreateSession(DefaultSessionId, DefaultCreatorId);
         SetupRepoGetById(DefaultSessionId, session);
-        var query = new GetLiveSessionDiaryQuery(DefaultSessionId);
+        var query = new GetLiveSessionDiaryQuery(DefaultSessionId, DefaultCreatorId);
 
         // Act
         var result = await _handler.Handle(query, CancellationToken.None);
@@ -132,7 +168,8 @@ public class GetLiveSessionDiaryQueryHandlerTests
             "Third entry");
 
         SetupRepoGetById(DefaultSessionId, session);
-        var query = new GetLiveSessionDiaryQuery(DefaultSessionId);
+        // DefaultAuthorId is an active player (added in CreateActiveSessionWithDiary)
+        var query = new GetLiveSessionDiaryQuery(DefaultSessionId, DefaultCreatorId);
 
         // Act
         var result = await _handler.Handle(query, CancellationToken.None);
@@ -148,7 +185,7 @@ public class GetLiveSessionDiaryQueryHandlerTests
         // Arrange
         var session = CreateActiveSessionWithDiary(DefaultSessionId, "Great round!");
         SetupRepoGetById(DefaultSessionId, session);
-        var query = new GetLiveSessionDiaryQuery(DefaultSessionId);
+        var query = new GetLiveSessionDiaryQuery(DefaultSessionId, DefaultCreatorId);
 
         // Act
         var result = await _handler.Handle(query, CancellationToken.None);
@@ -168,7 +205,7 @@ public class GetLiveSessionDiaryQueryHandlerTests
         // Arrange
         var session = CreateActiveSessionWithDiary(DefaultSessionId, "Only entry");
         SetupRepoGetById(DefaultSessionId, session);
-        var query = new GetLiveSessionDiaryQuery(DefaultSessionId);
+        var query = new GetLiveSessionDiaryQuery(DefaultSessionId, DefaultCreatorId);
 
         // Act
         var result = await _handler.Handle(query, CancellationToken.None);
@@ -184,7 +221,7 @@ public class GetLiveSessionDiaryQueryHandlerTests
         // Arrange
         var session = CreateActiveSessionWithDiary(DefaultSessionId, "Entry A", "Entry B");
         SetupRepoGetById(DefaultSessionId, session);
-        var query = new GetLiveSessionDiaryQuery(DefaultSessionId);
+        var query = new GetLiveSessionDiaryQuery(DefaultSessionId, DefaultCreatorId);
 
         // Act
         var result = await _handler.Handle(query, CancellationToken.None);
@@ -198,9 +235,9 @@ public class GetLiveSessionDiaryQueryHandlerTests
     public async Task Handle_CallsRepositoryOnce()
     {
         // Arrange
-        var session = CreateSession(DefaultSessionId);
+        var session = CreateSession(DefaultSessionId, DefaultCreatorId);
         SetupRepoGetById(DefaultSessionId, session);
-        var query = new GetLiveSessionDiaryQuery(DefaultSessionId);
+        var query = new GetLiveSessionDiaryQuery(DefaultSessionId, DefaultCreatorId);
 
         // Act
         await _handler.Handle(query, CancellationToken.None);

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/Entities/LiveGameSessionReconstituteTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/Entities/LiveGameSessionReconstituteTests.cs
@@ -58,6 +58,7 @@ public class LiveGameSessionReconstituteTests
             roundScores: Array.Empty<RoundScore>(),
             turnRecords: Array.Empty<TurnRecord>(),
             disputes: Array.Empty<RuleDisputeEntry>(),
+            diaryEntries: Array.Empty<DiaryEntry>(),
             setupChecklist: null);
 
         // Assert

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/Entities/LiveGameSession_DiaryTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/Entities/LiveGameSession_DiaryTests.cs
@@ -1,0 +1,230 @@
+using Api.BoundedContexts.GameManagement.Domain.Entities;
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+using Api.BoundedContexts.GameManagement.Domain.Events;
+using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Domain.Exceptions;
+using Api.Tests.Constants;
+using Microsoft.Extensions.Time.Testing;
+using Xunit;
+using FluentAssertions;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Domain.Entities;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "GameManagement")]
+public class LiveGameSession_DiaryTests
+{
+    private readonly FakeTimeProvider _timeProvider;
+    private readonly DateTimeOffset _now;
+
+    private static readonly Guid AuthorA = Guid.NewGuid();
+    private static readonly Guid AuthorB = Guid.NewGuid();
+
+    public LiveGameSession_DiaryTests()
+    {
+        _timeProvider = new FakeTimeProvider(new DateTimeOffset(2026, 6, 29, 10, 0, 0, TimeSpan.Zero));
+        _now = _timeProvider.GetUtcNow();
+    }
+
+    /// <summary>Creates a session in InProgress state.</summary>
+    private LiveGameSession CreateInProgressSession()
+    {
+        var session = LiveGameSession.Create(
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            "Mage Knight",
+            _timeProvider);
+
+        session.AddPlayer(null, "Alice", PlayerColor.Red, _timeProvider);
+        session.Start(_timeProvider);
+
+        return session;
+    }
+
+    /// <summary>Creates a session in Paused state.</summary>
+    private LiveGameSession CreatePausedSession()
+    {
+        var session = CreateInProgressSession();
+        session.Pause(_timeProvider);
+        return session;
+    }
+
+    /// <summary>Creates a session in Completed state.</summary>
+    private LiveGameSession CreateCompletedSession()
+    {
+        var session = CreateInProgressSession();
+        session.Complete(_timeProvider);
+        return session;
+    }
+
+    #region AddDiaryEntry — happy path
+
+    [Fact]
+    public void AddDiaryEntry_appends_and_raises_event()
+    {
+        // Arrange
+        var session = CreateInProgressSession();
+
+        // Act
+        session.AddDiaryEntry(AuthorA, "first", _timeProvider);
+        session.AddDiaryEntry(AuthorB, "second", _timeProvider);
+
+        // Assert — order preserved
+        session.DiaryEntries.Should().HaveCount(2);
+        session.DiaryEntries.Select(e => e.Text).Should().Equal("first", "second");
+
+        // Assert — both entries raise the event
+        var events = session.DomainEvents.OfType<LiveSessionDiaryEntryAddedEvent>().ToList();
+        events.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public void AddDiaryEntry_entry_has_correct_properties()
+    {
+        // Arrange
+        var session = CreateInProgressSession();
+
+        // Act
+        session.AddDiaryEntry(AuthorA, "  my note  ", _timeProvider);
+
+        // Assert
+        var entry = session.DiaryEntries.Single();
+        entry.Id.Should().NotBe(Guid.Empty);
+        entry.AuthorId.Should().Be(AuthorA);
+        entry.Text.Should().Be("my note"); // trimmed
+        entry.CreatedAt.Should().Be(_now);
+    }
+
+    [Fact]
+    public void AddDiaryEntry_first_entry_is_immutable_after_second_append()
+    {
+        // Arrange
+        var session = CreateInProgressSession();
+
+        // Act
+        session.AddDiaryEntry(AuthorA, "first", _timeProvider);
+        var firstEntryId = session.DiaryEntries[0].Id;
+        session.AddDiaryEntry(AuthorB, "second", _timeProvider);
+
+        // Assert — first entry unchanged
+        session.DiaryEntries[0].Id.Should().Be(firstEntryId);
+        session.DiaryEntries[0].Text.Should().Be("first");
+    }
+
+    [Fact]
+    public void AddDiaryEntry_event_carries_correct_payload()
+    {
+        // Arrange
+        var session = CreateInProgressSession();
+
+        // Act
+        session.AddDiaryEntry(AuthorA, "hello world", _timeProvider);
+
+        // Assert
+        var evt = session.DomainEvents.OfType<LiveSessionDiaryEntryAddedEvent>().Single();
+        evt.SessionId.Should().Be(session.Id);
+        evt.AuthorId.Should().Be(AuthorA);
+        evt.Text.Should().Be("hello world");
+        evt.EntryId.Should().Be(session.DiaryEntries[0].Id);
+        evt.CreatedAt.Should().Be(_now);
+    }
+
+    [Fact]
+    public void AddDiaryEntry_on_paused_session_succeeds_per_AC_DIARY_3()
+    {
+        // Arrange — AC-DIARY-3: Paused is allowed, only Completed is rejected
+        var session = CreatePausedSession();
+
+        // Act
+        var act = () => session.AddDiaryEntry(AuthorA, "note during pause", _timeProvider);
+
+        // Assert
+        act.Should().NotThrow();
+        session.DiaryEntries.Should().HaveCount(1);
+    }
+
+    #endregion
+
+    #region AddDiaryEntry — 409 guard
+
+    [Fact]
+    public void AddDiaryEntry_on_completed_session_throws_conflict()
+    {
+        // Arrange
+        var session = CreateCompletedSession();
+
+        // Act
+        var act = () => session.AddDiaryEntry(AuthorA, "too late", _timeProvider);
+
+        // Assert
+        act.Should().Throw<ConflictException>();
+    }
+
+    #endregion
+
+    #region AddDiaryEntry — validation guards
+
+    [Fact]
+    public void AddDiaryEntry_empty_authorId_throws_validation()
+    {
+        var session = CreateInProgressSession();
+        var act = () => session.AddDiaryEntry(Guid.Empty, "text", _timeProvider);
+        act.Should().Throw<ValidationException>();
+    }
+
+    [Fact]
+    public void AddDiaryEntry_empty_text_throws_validation()
+    {
+        var session = CreateInProgressSession();
+        var act = () => session.AddDiaryEntry(AuthorA, "   ", _timeProvider);
+        act.Should().Throw<ValidationException>();
+    }
+
+    #endregion
+
+    #region Notes vs Diary separation (AC-DIARY-4 pin)
+
+    [Fact]
+    public void DiaryEntries_and_Notes_are_distinct_collections()
+    {
+        // Notes is a single string overwritten by host; DiaryEntries is append-only multi-author.
+        var session = CreateInProgressSession();
+
+        session.UpdateNotes("session notes", _timeProvider);
+        session.AddDiaryEntry(AuthorA, "diary line 1", _timeProvider);
+
+        session.Notes.Should().Be("session notes");
+        session.DiaryEntries.Should().HaveCount(1);
+        session.DiaryEntries[0].Text.Should().Be("diary line 1");
+    }
+
+    [Fact]
+    public void AddDiaryEntry_does_not_affect_Notes()
+    {
+        var session = CreateInProgressSession();
+        session.UpdateNotes("original notes", _timeProvider);
+
+        session.AddDiaryEntry(AuthorA, "diary entry", _timeProvider);
+
+        session.Notes.Should().Be("original notes");
+    }
+
+    #endregion
+
+    #region Initial state
+
+    [Fact]
+    public void DiaryEntries_starts_empty()
+    {
+        var session = LiveGameSession.Create(
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            "Test Game",
+            _timeProvider);
+
+        session.DiaryEntries.Should().BeEmpty();
+    }
+
+    #endregion
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Infrastructure/LiveSessionDiaryPersistenceIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Infrastructure/LiveSessionDiaryPersistenceIntegrationTests.cs
@@ -103,8 +103,15 @@ public sealed class LiveSessionDiaryPersistenceIntegrationTests : IAsyncLifetime
         reloaded.DiaryEntries[0].Text.Should().Be("First entry");
         reloaded.DiaryEntries[1].AuthorId.Should().Be(AuthorId2);
         reloaded.DiaryEntries[1].Text.Should().Be("Second entry");
-        // Verify CreatedAt order preserved (OrderBy in mapper)
-        reloaded.DiaryEntries[0].CreatedAt.Should().BeOnOrBefore(reloaded.DiaryEntries[1].CreatedAt);
+        // Verify ordering is non-vacuous: assert entries come back in the EXACT insertion order
+        // by identity (authorId at index 0 must be AuthorId1, index 1 must be AuthorId2).
+        // This is a stronger assertion than BeOnOrBefore when PostgreSQL sub-millisecond
+        // timestamp granularity could produce identical CreatedAt values, making a
+        // "BeOnOrBefore" assertion hold vacuously even if ORDER BY CreatedAt were removed.
+        reloaded.DiaryEntries[0].AuthorId.Should().Be(AuthorId1,
+            "first entry was inserted by AuthorId1 — ORDER BY CreatedAt ASC must return it first");
+        reloaded.DiaryEntries[1].AuthorId.Should().Be(AuthorId2,
+            "second entry was inserted by AuthorId2 — ORDER BY CreatedAt ASC must return it second");
     }
 
     [Fact]

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Infrastructure/LiveSessionDiaryPersistenceIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Infrastructure/LiveSessionDiaryPersistenceIntegrationTests.cs
@@ -1,0 +1,246 @@
+using Api.BoundedContexts.GameManagement.Domain.Entities;
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+using Api.BoundedContexts.GameManagement.Infrastructure.Persistence;
+using Api.Infrastructure;
+using Api.SharedKernel.Application.Services;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Infrastructure;
+
+/// <summary>
+/// Integration tests for diary-entry persistence in <see cref="LiveSessionRepository"/>.
+/// #2570 SP3 T2: Validates that diary entries are round-tripped correctly to and from
+/// the <c>live_session_diary_entries</c> table, including:
+/// - AddAsync + reload (append-only insert round-trip)
+/// - UpdateAsync with new entries (SyncDiaryEntriesAsync append-only semantics)
+/// - FK cascade delete from parent session
+/// </summary>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "GameManagement")]
+public sealed class LiveSessionDiaryPersistenceIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private MeepleAiDbContext _dbContext = null!;
+    private LiveSessionRepository _repository = null!;
+    private string _databaseName = null!;
+
+    private static readonly Guid AuthorId1 = Guid.NewGuid();
+    private static readonly Guid AuthorId2 = Guid.NewGuid();
+
+    public LiveSessionDiaryPersistenceIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        _databaseName = $"test_diary_repo_{Guid.NewGuid():N}";
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+
+        _dbContext = _fixture.CreateDbContext(connectionString);
+        await _dbContext.Database.MigrateAsync();
+
+        var mockCollector = new Mock<IDomainEventCollector>();
+        mockCollector
+            .Setup(e => e.GetAndClearEvents())
+            .Returns(new List<Api.SharedKernel.Domain.Interfaces.IDomainEvent>().AsReadOnly());
+
+        _repository = new LiveSessionRepository(
+            _dbContext,
+            mockCollector.Object,
+            NullLogger<LiveSessionRepository>.Instance);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _dbContext.DisposeAsync();
+        await _fixture.DropIsolatedDatabaseAsync(_databaseName);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Helpers
+    // ─────────────────────────────────────────────────────────────────────────
+
+    private static LiveGameSession CreateSession()
+    {
+        return LiveGameSession.Create(
+            id: Guid.NewGuid(),
+            createdByUserId: Guid.NewGuid(),
+            gameName: "Mage Knight",
+            gameId: null);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Round-trip: AddAsync → GetByIdAsync
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task AddAsync_WithDiaryEntries_RoundTripsAllEntries()
+    {
+        // Arrange
+        var session = CreateSession();
+        session.AddDiaryEntry(AuthorId1, "First entry");
+        session.AddDiaryEntry(AuthorId2, "Second entry");
+
+        // Act
+        await _repository.AddAsync(session);
+        await _dbContext.SaveChangesAsync();
+        _dbContext.ChangeTracker.Clear();
+
+        var reloaded = await _repository.GetByIdAsync(session.Id);
+
+        // Assert
+        reloaded.Should().NotBeNull();
+        reloaded!.DiaryEntries.Should().HaveCount(2);
+        reloaded.DiaryEntries[0].AuthorId.Should().Be(AuthorId1);
+        reloaded.DiaryEntries[0].Text.Should().Be("First entry");
+        reloaded.DiaryEntries[1].AuthorId.Should().Be(AuthorId2);
+        reloaded.DiaryEntries[1].Text.Should().Be("Second entry");
+        // Verify CreatedAt order preserved (OrderBy in mapper)
+        reloaded.DiaryEntries[0].CreatedAt.Should().BeOnOrBefore(reloaded.DiaryEntries[1].CreatedAt);
+    }
+
+    [Fact]
+    public async Task AddAsync_WithNoDiaryEntries_ReturnsEmptyCollection()
+    {
+        // Arrange
+        var session = CreateSession();
+
+        // Act
+        await _repository.AddAsync(session);
+        await _dbContext.SaveChangesAsync();
+        _dbContext.ChangeTracker.Clear();
+
+        var reloaded = await _repository.GetByIdAsync(session.Id);
+
+        // Assert
+        reloaded.Should().NotBeNull();
+        reloaded!.DiaryEntries.Should().BeEmpty();
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // UpdateAsync: SyncDiaryEntriesAsync append-only semantics
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task UpdateAsync_AppendsDiaryEntry_WhilePreservingExisting()
+    {
+        // Arrange: persist session with one entry
+        var session = CreateSession();
+        session.AddDiaryEntry(AuthorId1, "Original entry");
+        await _repository.AddAsync(session);
+        await _dbContext.SaveChangesAsync();
+        _dbContext.ChangeTracker.Clear();
+
+        // Act: reload and add a second entry, then update
+        var reloaded = await _repository.GetByIdAsync(session.Id);
+        reloaded.Should().NotBeNull();
+        reloaded!.AddDiaryEntry(AuthorId2, "New entry");
+
+        await _repository.UpdateAsync(reloaded);
+        await _dbContext.SaveChangesAsync();
+        _dbContext.ChangeTracker.Clear();
+
+        // Assert: both entries survive
+        var final = await _repository.GetByIdAsync(session.Id);
+        final.Should().NotBeNull();
+        final!.DiaryEntries.Should().HaveCount(2);
+        final.DiaryEntries.Should().Contain(e => e.AuthorId == AuthorId1 && e.Text == "Original entry");
+        final.DiaryEntries.Should().Contain(e => e.AuthorId == AuthorId2 && e.Text == "New entry");
+    }
+
+    [Fact]
+    public async Task UpdateAsync_WithNoNewEntries_DoesNotCorruptExisting()
+    {
+        // Arrange: persist session with one entry
+        var session = CreateSession();
+        session.AddDiaryEntry(AuthorId1, "Stable entry");
+        await _repository.AddAsync(session);
+        await _dbContext.SaveChangesAsync();
+        _dbContext.ChangeTracker.Clear();
+
+        // Act: reload, mutate notes (not diary), update
+        var reloaded = await _repository.GetByIdAsync(session.Id);
+        reloaded.Should().NotBeNull();
+        reloaded!.UpdateNotes("some notes");
+
+        await _repository.UpdateAsync(reloaded);
+        await _dbContext.SaveChangesAsync();
+        _dbContext.ChangeTracker.Clear();
+
+        // Assert: existing diary entry still intact
+        var final = await _repository.GetByIdAsync(session.Id);
+        final.Should().NotBeNull();
+        final!.DiaryEntries.Should().HaveCount(1);
+        final.DiaryEntries[0].Text.Should().Be("Stable entry");
+        final.Notes.Should().Be("some notes");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Schema constraint: cascade delete from parent session
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task DeleteParentSession_CascadesToDiaryEntries()
+    {
+        // Arrange
+        var session = CreateSession();
+        session.AddDiaryEntry(AuthorId1, "Entry A");
+        session.AddDiaryEntry(AuthorId2, "Entry B");
+        await _repository.AddAsync(session);
+        await _dbContext.SaveChangesAsync();
+        _dbContext.ChangeTracker.Clear();
+
+        // Verify entries exist
+        var entryCount = await _dbContext.Set<Api.Infrastructure.Entities.GameManagement.LiveSessionDiaryEntryEntity>()
+            .CountAsync(e => e.LiveGameSessionId == session.Id);
+        entryCount.Should().Be(2);
+
+        // Act: delete the parent session directly via EF
+        var parent = await _dbContext.LiveGameSessions.SingleAsync(s => s.Id == session.Id);
+        _dbContext.LiveGameSessions.Remove(parent);
+        await _dbContext.SaveChangesAsync();
+        _dbContext.ChangeTracker.Clear();
+
+        // Assert: cascade removes diary entries
+        var remainingCount = await _dbContext.Set<Api.Infrastructure.Entities.GameManagement.LiveSessionDiaryEntryEntity>()
+            .CountAsync(e => e.LiveGameSessionId == session.Id);
+        remainingCount.Should().Be(0, "cascade delete must purge diary entries when the parent session is removed");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Round-trip: field fidelity (Id, AuthorId, CreatedAt, Text)
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task DiaryEntry_FieldsRoundTrip_WithFullFidelity()
+    {
+        // Arrange
+        var session = CreateSession();
+        session.AddDiaryEntry(AuthorId1, "  Trimmed entry text  "); // Text should be trimmed by domain
+        await _repository.AddAsync(session);
+        await _dbContext.SaveChangesAsync();
+        _dbContext.ChangeTracker.Clear();
+
+        // Act
+        var reloaded = await _repository.GetByIdAsync(session.Id);
+
+        // Assert
+        reloaded.Should().NotBeNull();
+        reloaded!.DiaryEntries.Should().HaveCount(1);
+
+        var entry = reloaded.DiaryEntries[0];
+        entry.Id.Should().NotBe(Guid.Empty);
+        entry.AuthorId.Should().Be(AuthorId1);
+        entry.Text.Should().Be("Trimmed entry text", "domain trims whitespace in AddDiaryEntry");
+        entry.CreatedAt.Should().NotBe(default);
+        entry.CreatedAt.Offset.Should().Be(TimeSpan.Zero, "CreatedAt is stored as UTC DateTimeOffset");
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Infrastructure/Services/LiveSessionStreamGatewayTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Infrastructure/Services/LiveSessionStreamGatewayTests.cs
@@ -68,6 +68,7 @@ public sealed class LiveSessionStreamGatewayTests
             roundScores: Enumerable.Empty<RoundScore>(),
             turnRecords: Enumerable.Empty<TurnRecord>(),
             disputes: Enumerable.Empty<RuleDisputeEntry>(),
+            diaryEntries: Enumerable.Empty<DiaryEntry>(),
             setupChecklist: null);
     }
 

--- a/apps/api/tests/Api.Tests/Integration/GameManagement/LiveSessionDiaryChainIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/GameManagement/LiveSessionDiaryChainIntegrationTests.cs
@@ -1,0 +1,338 @@
+using System.Net;
+using System.Net.Http.Json;
+using Api.BoundedContexts.GameManagement.Application.Commands.LiveSessions;
+using Api.BoundedContexts.GameManagement.Application.DTOs.LiveSessions;
+using Api.BoundedContexts.GameManagement.Application.Services;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using MediatR;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.Integration.GameManagement;
+
+/// <summary>
+/// End-to-end integration test for the diary add→event chain.
+/// Issue #2570 SP3 T8.
+///
+/// Chain exercised:
+///   POST /api/v1/live-sessions/{id}/diary
+///     → AddDiaryEntryCommandHandler (session.AddDiaryEntry → LiveSessionDiaryEntryAddedEvent raised)
+///     → UnitOfWork.SaveChangesAsync
+///     → MeepleAiDbContext.SaveChangesAsync (Hybrid mode: MediatR.Publish after commit)
+///     → LiveSessionStreamForwarder.Handle(LiveSessionDiaryEntryAddedEvent)
+///     → ILiveSessionStreamGateway.BroadcastAsync("session:diary")
+///
+/// The test stubs <see cref="ILiveSessionStreamGateway"/> so it can verify BroadcastAsync
+/// is called with type "session:diary" without needing a live Redis/SignalR connection.
+/// This is the realistic end-to-end chain short of an actual SSE subscriber.
+/// </summary>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "GameManagement")]
+[Trait("Issue", "2570")]
+public sealed class LiveSessionDiaryChainIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly string _databaseName = $"live_diary_chain_{Guid.NewGuid():N}";
+    private WebApplicationFactory<Program> _factory = null!;
+
+    // Captured BroadcastAsync calls for assertion
+    private readonly List<(Guid SessionId, LiveSessionStreamEvent Evt)> _broadcastCalls = new();
+
+    public LiveSessionDiaryChainIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+        await TestcontainersWaitHelpers.WaitForPostgresReadyAsync(connectionString);
+
+        // Build the factory from the shared helper, then extend it with a spy gateway.
+        var baseFactory = IntegrationWebApplicationFactory.Create(connectionString);
+
+        _factory = baseFactory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureServices(services =>
+            {
+                // Replace the real gateway with a spy that captures BroadcastAsync calls.
+                services.RemoveAll<ILiveSessionStreamGateway>();
+                services.AddScoped<ILiveSessionStreamGateway>(_ =>
+                {
+                    var mock = new Mock<ILiveSessionStreamGateway>();
+
+                    // Spy: capture every BroadcastAsync call
+                    mock
+                        .Setup(g => g.BroadcastAsync(
+                            It.IsAny<Guid>(),
+                            It.IsAny<LiveSessionStreamEvent>(),
+                            It.IsAny<CancellationToken>()))
+                        .Callback<Guid, LiveSessionStreamEvent, CancellationToken>((sid, evt, _) =>
+                        {
+                            lock (_broadcastCalls)
+                                _broadcastCalls.Add((sid, evt));
+                        })
+                        .Returns(Task.CompletedTask);
+
+                    // SubscribeAsync returns empty stream (not needed in this test)
+                    mock
+                        .Setup(g => g.SubscribeAsync(
+                            It.IsAny<Guid>(),
+                            It.IsAny<Guid>(),
+                            It.IsAny<string?>(),
+                            It.IsAny<CancellationToken>()))
+                        .Returns(EmptyAsyncEnumerable());
+
+                    return mock.Object;
+                });
+            });
+        });
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        await db.Database.MigrateAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_factory != null)
+            await _factory.DisposeAsync();
+
+        await _fixture.DropIsolatedDatabaseAsync(_databaseName);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // T8 — end-to-end chain: POST diary → persisted in DB → gateway receives
+    //       "session:diary" broadcast (domain event propagates the full chain)
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "POST diary: entry persisted AND session:diary event broadcast through full chain")]
+    public async Task Post_DiaryEntry_PersistsAndBroadcastsSessionDiaryEvent()
+    {
+        // Arrange
+        var (client, sessionId, userId) = await CreateSessionWithClientAsync();
+
+        var postRequest = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Post,
+            $"/api/v1/live-sessions/{sessionId}/diary",
+            GetTokenFromClient(client));
+        postRequest.Content = JsonContent.Create(new { text = "First great move of the night!" });
+
+        // Act — POST the diary entry (exercises the full BE chain)
+        var response = await client.SendAsync(postRequest);
+
+        // Assert — HTTP layer: 201 Created with Guid body
+        response.StatusCode.Should().Be(HttpStatusCode.Created,
+            "POST diary on an active session must return 201 Created");
+
+        var responseBody = await response.Content.ReadAsStringAsync();
+        var entryId = System.Text.Json.JsonSerializer.Deserialize<Guid>(responseBody);
+        entryId.Should().NotBe(Guid.Empty, "the response body must be the new entry's id");
+
+        // Assert — persistence layer: entry exists in the DB (AC-DIARY-1 append-only)
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var entryEntity = await db.Set<Api.Infrastructure.Entities.GameManagement.LiveSessionDiaryEntryEntity>()
+            .AsNoTracking()
+            .FirstOrDefaultAsync(e => e.Id == entryId);
+
+        entryEntity.Should().NotBeNull("the diary entry must be persisted to the DB");
+        entryEntity!.LiveGameSessionId.Should().Be(sessionId);
+        entryEntity.AuthorId.Should().Be(userId);
+        entryEntity.Text.Should().Be("First great move of the night!");
+
+        // Assert — event chain: ILiveSessionStreamGateway.BroadcastAsync called with session:diary
+        // The MeepleAiDbContext.SaveChangesAsync (Hybrid mode) dispatches MediatR.Publish
+        // after the commit, which triggers LiveSessionStreamForwarder → gateway.BroadcastAsync.
+        // Allow a brief propagation window (Hybrid mode dispatches inline, but async scheduling
+        // may still require a small yield on some runners).
+        await WaitForBroadcastAsync(sessionId, "session:diary", timeout: TimeSpan.FromSeconds(3));
+
+        lock (_broadcastCalls)
+        {
+            var diaryBroadcasts = _broadcastCalls
+                .Where(c => c.SessionId == sessionId && c.Evt.Type == "session:diary")
+                .ToList();
+
+            diaryBroadcasts.Should().HaveCount(1,
+                "AddDiaryEntry raises exactly one LiveSessionDiaryEntryAddedEvent which forwarder maps to session:diary");
+        }
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // AC-DIARY-2 chain pin: multi-author + GET returns entries in chronological order
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "POST two diary entries from different authors: GET returns them chronologically")]
+    public async Task Post_TwoEntries_DifferentAuthors_GetReturnsChronologicalOrder()
+    {
+        // Arrange
+        var (clientA, sessionId, _) = await CreateSessionWithClientAsync();
+
+        // Author A is the creator; Author B is a second participant
+        await using var setupScope = _factory.Services.CreateAsyncScope();
+        var db = setupScope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, tokenB) = await TestSessionHelper.CreateUserSessionAsync(db);
+
+        // Add Author B as a participant via the AddPlayer command
+        var mediator = setupScope.ServiceProvider.GetRequiredService<IMediator>();
+        var userBId = Guid.NewGuid(); // guest player
+        await mediator.Send(new AddPlayerToLiveSessionCommand(
+            SessionId: sessionId,
+            DisplayName: "Author B",
+            Color: Api.BoundedContexts.GameManagement.Domain.Enums.PlayerColor.Blue,
+            UserId: null,
+            Role: null,
+            AvatarUrl: null));
+
+        var clientB = _factory.CreateClient();
+        clientB.DefaultRequestHeaders.Add("Cookie", $"{TestSessionHelper.SessionCookieName}={tokenB}");
+        clientB.DefaultRequestHeaders.Add("X-Test-Session-Token", tokenB);
+
+        // Act — POST two entries: A first, then B (using A's client for both for simplicity — same session)
+        var post1 = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Post,
+            $"/api/v1/live-sessions/{sessionId}/diary",
+            GetTokenFromClient(clientA));
+        post1.Content = JsonContent.Create(new { text = "Entry by author A" });
+        var r1 = await clientA.SendAsync(post1);
+        r1.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var post2 = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Post,
+            $"/api/v1/live-sessions/{sessionId}/diary",
+            GetTokenFromClient(clientA));
+        post2.Content = JsonContent.Create(new { text = "Entry by author A again" });
+        var r2 = await clientA.SendAsync(post2);
+        r2.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        // GET the diary
+        var getRequest = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            $"/api/v1/live-sessions/{sessionId}/diary",
+            GetTokenFromClient(clientA));
+        var getResponse = await clientA.SendAsync(getRequest);
+
+        // Assert — AC-DIARY-2: chronological order
+        getResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var entries = await getResponse.Content.ReadFromJsonAsync<List<DiaryEntryResponse>>(
+            new System.Text.Json.JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+
+        entries.Should().NotBeNull();
+        entries!.Should().HaveCount(2);
+        entries.Should().BeInAscendingOrder(e => e.CreatedAt,
+            "diary entries must be returned in chronological (ascending) order per AC-DIARY-2");
+        entries[0].Text.Should().Be("Entry by author A");
+        entries[1].Text.Should().Be("Entry by author A again");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Helpers
+    // ──────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Seeds a user, creates a live session via IMediator (in InProgress state with
+    /// one player so the session can accept diary entries), and returns an authenticated client.
+    /// </summary>
+    private async Task<(HttpClient Client, Guid SessionId, Guid UserId)> CreateSessionWithClientAsync()
+    {
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+        var userId = await SeedUserAsync(db);
+        var (_, token) = await TestSessionHelper.CreateUserSessionAsync(db, userId);
+
+        // Create the session — creator is the user
+        var sessionId = await mediator.Send(new CreateLiveSessionCommand(
+            UserId: userId,
+            GameName: "Diary Chain Test Game",
+            GameId: null));
+
+        // Domain invariant: Start() requires ≥1 player. The creator's userId counts as a player.
+        // We need to ensure the session is InProgress so AddDiaryEntry is allowed.
+        // CreateLiveSessionCommand seeds the session in Created state — no auto-start.
+        // Add creator as player + start:
+        await mediator.Send(new AddPlayerToLiveSessionCommand(
+            SessionId: sessionId,
+            DisplayName: "Creator Player",
+            Color: Api.BoundedContexts.GameManagement.Domain.Enums.PlayerColor.Red,
+            UserId: userId,
+            Role: null,
+            AvatarUrl: null));
+        await mediator.Send(new StartLiveSessionCommand(sessionId));
+
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Add("Cookie", $"{TestSessionHelper.SessionCookieName}={token}");
+        client.DefaultRequestHeaders.Add("X-Test-Session-Token", token);
+
+        return (client, sessionId, userId);
+    }
+
+    private static string GetTokenFromClient(HttpClient client) =>
+        client.DefaultRequestHeaders.TryGetValues("X-Test-Session-Token", out var values)
+            ? values.First()
+            : throw new InvalidOperationException("X-Test-Session-Token not set on client");
+
+    private static async Task<Guid> SeedUserAsync(MeepleAiDbContext db)
+    {
+        var userId = Guid.NewGuid();
+        db.Users.Add(new UserEntity
+        {
+            Id = userId,
+            Email = $"diary-chain-{userId:N}@test.local",
+            DisplayName = "Diary Chain User",
+            PasswordHash = "not-a-real-hash",
+            Role = "user",
+            Tier = "free",
+            Status = "Active",
+            EmailVerified = true,
+            CreatedAt = DateTime.UtcNow
+        });
+        await db.SaveChangesAsync();
+        return userId;
+    }
+
+    /// <summary>
+    /// Polls <see cref="_broadcastCalls"/> until the expected broadcast arrives or <paramref name="timeout"/> elapses.
+    /// Hybrid-mode dispatch is inline (same request pipeline) so it should be near-instantaneous;
+    /// the poll loop is a safety net for thread-scheduling jitter on CI runners.
+    /// </summary>
+    private async Task WaitForBroadcastAsync(Guid sessionId, string eventType, TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            lock (_broadcastCalls)
+            {
+                if (_broadcastCalls.Any(c => c.SessionId == sessionId && c.Evt.Type == eventType))
+                    return;
+            }
+            await Task.Delay(50);
+        }
+    }
+
+    /// <summary>Returns an empty async enumerable of <see cref="LiveSessionStreamEvent"/>.</summary>
+    private static async IAsyncEnumerable<LiveSessionStreamEvent> EmptyAsyncEnumerable()
+    {
+        await Task.CompletedTask;
+        yield break;
+    }
+
+    // Local record that mirrors DiaryEntryDto (internal DTO not accessible from tests assembly)
+    private sealed record DiaryEntryResponse(
+        Guid Id,
+        Guid AuthorId,
+        DateTimeOffset CreatedAt,
+        string Text);
+}

--- a/apps/api/tests/Api.Tests/Integration/GameManagement/LiveSessionDiaryChainIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/GameManagement/LiveSessionDiaryChainIntegrationTests.cs
@@ -58,8 +58,21 @@ public sealed class LiveSessionDiaryChainIntegrationTests : IAsyncLifetime
         var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
         await TestcontainersWaitHelpers.WaitForPostgresReadyAsync(connectionString);
 
+        // C1 fix (#2570 review): IntegrationWebApplicationFactory.Create() calls Sources.Clear(),
+        // so appsettings.json is NOT loaded and IOptions<DomainEventOutboxOptions>.Value.Mode
+        // resolves to the options-class C# default DomainEventDispatchMode.OutboxOnly.
+        // Under OutboxOnly the BackgroundService (which is removed by the factory) would need to
+        // drain the outbox — the inline MediatR.Publish never fires, the gateway spy never sees
+        // BroadcastAsync, and WaitForBroadcastAsync times out.
+        // Forcing Hybrid ensures MeepleAiDbContext.SaveChangesAsync dispatches inline (Step 5),
+        // which is the only mode compatible with a spy-based assertion in a synchronous test.
+        var extraConfig = new Dictionary<string, string?>
+        {
+            ["DomainEventOutbox:Mode"] = "Hybrid"
+        };
+
         // Build the factory from the shared helper, then extend it with a spy gateway.
-        var baseFactory = IntegrationWebApplicationFactory.Create(connectionString);
+        var baseFactory = IntegrationWebApplicationFactory.Create(connectionString, extraConfig: extraConfig);
 
         _factory = baseFactory.WithWebHostBuilder(builder =>
         {
@@ -173,25 +186,29 @@ public sealed class LiveSessionDiaryChainIntegrationTests : IAsyncLifetime
     // AC-DIARY-2 chain pin: multi-author + GET returns entries in chronological order
     // ──────────────────────────────────────────────────────────────────────────
 
-    [Fact(DisplayName = "POST two diary entries from different authors: GET returns them chronologically")]
+    [Fact(DisplayName = "POST two diary entries from different authors: GET returns them chronologically with distinct authorIds")]
     public async Task Post_TwoEntries_DifferentAuthors_GetReturnsChronologicalOrder()
     {
         // Arrange
-        var (clientA, sessionId, _) = await CreateSessionWithClientAsync();
+        var (clientA, sessionId, userAId) = await CreateSessionWithClientAsync();
 
-        // Author A is the creator; Author B is a second participant
+        // I1 fix (#2570 review): create userB as a real registered user with a known ID so they
+        // can be added as a linked player (UserId: userBId). The authz guard in
+        // AddDiaryEntryCommandHandler requires the caller be the session creator OR
+        // session.Players.Any(p => p.IsActive && p.UserId == command.AuthorId).
+        // A guest player (UserId: null) would satisfy neither condition for userB's requests.
         await using var setupScope = _factory.Services.CreateAsyncScope();
         var db = setupScope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
-        var (_, tokenB) = await TestSessionHelper.CreateUserSessionAsync(db);
+        var userBId = Guid.NewGuid();
+        var (_, tokenB) = await TestSessionHelper.CreateUserSessionAsync(db, userBId);
 
-        // Add Author B as a participant via the AddPlayer command
+        // Add Author B as a linked player with UserId so the authz check passes.
         var mediator = setupScope.ServiceProvider.GetRequiredService<IMediator>();
-        var userBId = Guid.NewGuid(); // guest player
         await mediator.Send(new AddPlayerToLiveSessionCommand(
             SessionId: sessionId,
             DisplayName: "Author B",
             Color: Api.BoundedContexts.GameManagement.Domain.Enums.PlayerColor.Blue,
-            UserId: null,
+            UserId: userBId,
             Role: null,
             AvatarUrl: null));
 
@@ -199,41 +216,49 @@ public sealed class LiveSessionDiaryChainIntegrationTests : IAsyncLifetime
         clientB.DefaultRequestHeaders.Add("Cookie", $"{TestSessionHelper.SessionCookieName}={tokenB}");
         clientB.DefaultRequestHeaders.Add("X-Test-Session-Token", tokenB);
 
-        // Act — POST two entries: A first, then B (using A's client for both for simplicity — same session)
+        // Act — POST first entry via clientA (Author A), second via clientB (Author B)
         var post1 = TestSessionHelper.CreateAuthenticatedRequest(
             HttpMethod.Post,
             $"/api/v1/live-sessions/{sessionId}/diary",
             GetTokenFromClient(clientA));
         post1.Content = JsonContent.Create(new { text = "Entry by author A" });
         var r1 = await clientA.SendAsync(post1);
-        r1.StatusCode.Should().Be(HttpStatusCode.Created);
+        r1.StatusCode.Should().Be(HttpStatusCode.Created,
+            "Author A (session creator) must be allowed to add a diary entry");
 
         var post2 = TestSessionHelper.CreateAuthenticatedRequest(
             HttpMethod.Post,
             $"/api/v1/live-sessions/{sessionId}/diary",
-            GetTokenFromClient(clientA));
-        post2.Content = JsonContent.Create(new { text = "Entry by author A again" });
-        var r2 = await clientA.SendAsync(post2);
-        r2.StatusCode.Should().Be(HttpStatusCode.Created);
+            GetTokenFromClient(clientB));
+        post2.Content = JsonContent.Create(new { text = "Entry by author B" });
+        var r2 = await clientB.SendAsync(post2);
+        r2.StatusCode.Should().Be(HttpStatusCode.Created,
+            "Author B (linked player) must be allowed to add a diary entry");
 
-        // GET the diary
+        // GET the diary as Author A (creator always has read access)
         var getRequest = TestSessionHelper.CreateAuthenticatedRequest(
             HttpMethod.Get,
             $"/api/v1/live-sessions/{sessionId}/diary",
             GetTokenFromClient(clientA));
         var getResponse = await clientA.SendAsync(getRequest);
 
-        // Assert — AC-DIARY-2: chronological order
+        // Assert — AC-DIARY-2: chronological order + distinct authorIds
         getResponse.StatusCode.Should().Be(HttpStatusCode.OK);
         var entries = await getResponse.Content.ReadFromJsonAsync<List<DiaryEntryResponse>>(
             new System.Text.Json.JsonSerializerOptions { PropertyNameCaseInsensitive = true });
 
         entries.Should().NotBeNull();
-        entries!.Should().HaveCount(2);
+        entries!.Should().HaveCount(2, "both diary entries must be persisted");
         entries.Should().BeInAscendingOrder(e => e.CreatedAt,
             "diary entries must be returned in chronological (ascending) order per AC-DIARY-2");
         entries[0].Text.Should().Be("Entry by author A");
-        entries[1].Text.Should().Be("Entry by author A again");
+        entries[1].Text.Should().Be("Entry by author B");
+
+        // Genuine multi-author assertion: two distinct authorIds
+        entries[0].AuthorId.Should().Be(userAId,
+            "first entry's authorId must match Author A's user id");
+        entries[1].AuthorId.Should().Be(userBId,
+            "second entry's authorId must match Author B's user id");
     }
 
     // ──────────────────────────────────────────────────────────────────────────
@@ -320,6 +345,14 @@ public sealed class LiveSessionDiaryChainIntegrationTests : IAsyncLifetime
             }
             await Task.Delay(50);
         }
+
+        // M2 fix (#2570 review): throw on timeout so a misconfigured dispatch mode produces a
+        // clear diagnostic instead of a misleading "expected 1 item but found 0" FluentAssertions
+        // failure from the downstream HaveCount assertion.
+        throw new TimeoutException(
+            $"Timed out waiting for '{eventType}' broadcast on session {sessionId} " +
+            $"after {timeout.TotalSeconds:0}s. " +
+            "Verify DomainEventOutbox:Mode=Hybrid is configured in the test factory extraConfig.");
     }
 
     /// <summary>Returns an empty async enumerable of <see cref="LiveSessionStreamEvent"/>.</summary>

--- a/apps/api/tests/Api.Tests/Integration/GameManagement/LiveSessionDiaryEndpointTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/GameManagement/LiveSessionDiaryEndpointTests.cs
@@ -148,7 +148,68 @@ public sealed class LiveSessionDiaryEndpointTests : IAsyncLifetime
     }
 
     // ──────────────────────────────────────────────────────────────────────────
-    // Scenario 3: Unauthenticated caller → 401
+    // Scenario 3a: Authenticated non-participant → 403 on POST
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "POST diary returns 403 when caller is authenticated but not a participant")]
+    public async Task Post_NonParticipant_Returns403()
+    {
+        // Arrange — user A creates the session; user B is authenticated but NOT a participant
+        var (_, sessionId) = await CreateSessionWithClientAsync();
+
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, tokenB) = await TestSessionHelper.CreateUserSessionAsync(db);
+
+        var clientB = _factory.CreateClient();
+        clientB.DefaultRequestHeaders.Add("Cookie", $"{TestSessionHelper.SessionCookieName}={tokenB}");
+
+        var postRequest = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Post,
+            $"/api/v1/live-sessions/{sessionId}/diary",
+            tokenB);
+        postRequest.Content = JsonContent.Create(new { text = "Sneaking in" });
+
+        // Act
+        var response = await clientB.SendAsync(postRequest);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden,
+            "an authenticated user who is not a participant must receive 403");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Scenario 3b: Authenticated non-participant → 403 on GET
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "GET diary returns 403 when caller is authenticated but not a participant")]
+    public async Task Get_NonParticipant_Returns403()
+    {
+        // Arrange — user A creates the session; user B is authenticated but NOT a participant
+        var (_, sessionId) = await CreateSessionWithClientAsync();
+
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, tokenB) = await TestSessionHelper.CreateUserSessionAsync(db);
+
+        var clientB = _factory.CreateClient();
+        clientB.DefaultRequestHeaders.Add("Cookie", $"{TestSessionHelper.SessionCookieName}={tokenB}");
+
+        var getRequest = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            $"/api/v1/live-sessions/{sessionId}/diary",
+            tokenB);
+
+        // Act
+        var response = await clientB.SendAsync(getRequest);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden,
+            "an authenticated user who is not a participant must receive 403");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Scenario 4: Unauthenticated caller → 401
     // ──────────────────────────────────────────────────────────────────────────
 
     [Fact(DisplayName = "POST and GET diary return 401 when caller is not authenticated")]
@@ -172,7 +233,7 @@ public sealed class LiveSessionDiaryEndpointTests : IAsyncLifetime
     }
 
     // ──────────────────────────────────────────────────────────────────────────
-    // Scenario 4: GET on session with no diary entries → 200 + empty array
+    // Scenario 5: GET on session with no diary entries → 200 + empty array
     // ──────────────────────────────────────────────────────────────────────────
 
     [Fact(DisplayName = "GET diary on session with no entries returns 200 empty array")]

--- a/apps/api/tests/Api.Tests/Integration/GameManagement/LiveSessionDiaryEndpointTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/GameManagement/LiveSessionDiaryEndpointTests.cs
@@ -1,0 +1,292 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Api.BoundedContexts.GameManagement.Application.Commands.LiveSessions;
+using Api.BoundedContexts.GameManagement.Application.DTOs.LiveSessions;
+using Api.BoundedContexts.GameManagement.Domain.Entities;
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using MediatR;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.Integration.GameManagement;
+
+/// <summary>
+/// Integration tests for the diary endpoints:
+///   POST /api/v1/live-sessions/{sessionId}/diary
+///   GET  /api/v1/live-sessions/{sessionId}/diary
+///
+/// Issue #2570 SP3 T5.
+///
+/// Test strategy mirrors LiveSessionStreamEndpointTests:
+/// - IntegrationWebApplicationFactory + SharedTestcontainersFixture (isolated DB per test class)
+/// - TestSessionHelper for auth (session cookie)
+/// - IMediator used directly to create sessions / mutate state without going through HTTP for setup
+/// - 4 scenarios per the task brief:
+///     1. POST adds an entry → 201 + valid Guid; GET lists it
+///     2. POST on Completed session → 409
+///     3. Unauthenticated caller → 401
+///     4. GET on session with no diary entries → 200 + empty array
+/// </summary>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "GameManagement")]
+[Trait("Issue", "2570")]
+public sealed class LiveSessionDiaryEndpointTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly string _databaseName = $"live_diary_{Guid.NewGuid():N}";
+    private WebApplicationFactory<Program> _factory = null!;
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new JsonStringEnumConverter() }
+    };
+
+    public LiveSessionDiaryEndpointTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+        await TestcontainersWaitHelpers.WaitForPostgresReadyAsync(connectionString);
+
+        _factory = IntegrationWebApplicationFactory.Create(connectionString);
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        await db.Database.MigrateAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_factory != null)
+            await _factory.DisposeAsync();
+
+        await _fixture.DropIsolatedDatabaseAsync(_databaseName);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Scenario 1: POST adds an entry → 201 + Guid; GET then lists it
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "POST diary adds entry → 201 with entry id; subsequent GET returns it")]
+    public async Task Post_AddsDiaryEntry_ThenGet_ReturnsList()
+    {
+        // Arrange
+        var (client, sessionId) = await CreateSessionWithClientAsync();
+
+        var postRequest = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Post,
+            $"/api/v1/live-sessions/{sessionId}/diary",
+            // token already set on client.DefaultRequestHeaders — reuse the cookie on the client
+            GetTokenFromClient(client));
+        postRequest.Content = JsonContent.Create(new { text = "We started the game at 20:00" });
+
+        // Act — POST
+        var postResponse = await client.SendAsync(postRequest);
+
+        // Assert POST → 201 + Guid body
+        postResponse.StatusCode.Should().Be(HttpStatusCode.Created,
+            "adding a diary entry to an active session must return 201 Created");
+
+        var responseBody = await postResponse.Content.ReadAsStringAsync();
+        var entryId = JsonSerializer.Deserialize<Guid>(responseBody, JsonOptions);
+        entryId.Should().NotBe(Guid.Empty, "the response body should be the new entry's id");
+
+        // Act — GET
+        var getRequest = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            $"/api/v1/live-sessions/{sessionId}/diary",
+            GetTokenFromClient(client));
+        var getResponse = await client.SendAsync(getRequest);
+
+        // Assert GET → 200 + array with one entry
+        getResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var entries = await getResponse.Content.ReadFromJsonAsync<List<DiaryEntryResponse>>(JsonOptions);
+        entries.Should().NotBeNull();
+        entries!.Should().HaveCount(1, "one entry was added");
+        entries[0].Id.Should().Be(entryId);
+        entries[0].Text.Should().Be("We started the game at 20:00");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Scenario 2: POST on a Completed session → 409
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "POST diary on Completed session returns 409")]
+    public async Task Post_OnCompletedSession_Returns409()
+    {
+        // Arrange — create session, then complete it
+        var (client, sessionId) = await CreateSessionWithClientAsync();
+        await CompleteSessionAsync(sessionId);
+
+        var postRequest = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Post,
+            $"/api/v1/live-sessions/{sessionId}/diary",
+            GetTokenFromClient(client));
+        postRequest.Content = JsonContent.Create(new { text = "Too late" });
+
+        // Act
+        var response = await client.SendAsync(postRequest);
+
+        // Assert — ConflictException from domain → 409 via global middleware
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict,
+            "the domain raises ConflictException when the session is Completed; middleware maps it to 409");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Scenario 3: Unauthenticated caller → 401
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "POST and GET diary return 401 when caller is not authenticated")]
+    public async Task PostAndGet_Unauthenticated_Returns401()
+    {
+        var anonClient = _factory.CreateClient();
+        var sessionId = Guid.NewGuid(); // irrelevant — auth check fires first
+
+        // POST without cookie
+        var postResponse = await anonClient.PostAsJsonAsync(
+            $"/api/v1/live-sessions/{sessionId}/diary",
+            new { text = "no auth" });
+        postResponse.StatusCode.Should().Be(HttpStatusCode.Unauthorized,
+            "RequireAuthenticatedUser() must reject unauthenticated callers on POST");
+
+        // GET without cookie
+        var getResponse = await anonClient.GetAsync(
+            $"/api/v1/live-sessions/{sessionId}/diary");
+        getResponse.StatusCode.Should().Be(HttpStatusCode.Unauthorized,
+            "RequireAuthenticatedUser() must reject unauthenticated callers on GET");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Scenario 4: GET on session with no diary entries → 200 + empty array
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "GET diary on session with no entries returns 200 empty array")]
+    public async Task Get_NoDiaryEntries_Returns200EmptyArray()
+    {
+        // Arrange — create a session but don't add any diary entries
+        var (client, sessionId) = await CreateSessionWithClientAsync();
+
+        var getRequest = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get,
+            $"/api/v1/live-sessions/{sessionId}/diary",
+            GetTokenFromClient(client));
+
+        // Act
+        var getResponse = await client.SendAsync(getRequest);
+
+        // Assert
+        getResponse.StatusCode.Should().Be(HttpStatusCode.OK);
+        var entries = await getResponse.Content.ReadFromJsonAsync<List<DiaryEntryResponse>>(JsonOptions);
+        entries.Should().NotBeNull();
+        entries!.Should().BeEmpty("no diary entries have been added to this session");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Helpers
+    // ──────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Seeds a user + auth session, creates a LiveGameSession via IMediator,
+    /// and returns an authenticated HttpClient + the session id.
+    /// </summary>
+    private async Task<(HttpClient Client, Guid SessionId)> CreateSessionWithClientAsync()
+    {
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+        var userId = await SeedUserAsync(db);
+        var (_, token) = await TestSessionHelper.CreateUserSessionAsync(db, userId);
+
+        var sessionId = await mediator.Send(new CreateLiveSessionCommand(
+            UserId: userId,
+            GameName: "Diary Test Game",
+            GameId: null));
+
+        var client = _factory.CreateClient();
+        // Store the token in DefaultRequestHeaders so the helper can read it back via GetTokenFromClient.
+        // Also set it so request factory helpers can read the cookie value.
+        client.DefaultRequestHeaders.Add("Cookie", $"{TestSessionHelper.SessionCookieName}={token}");
+
+        // Tag the client with the token via a custom header so GetTokenFromClient can extract it.
+        // This avoids a second scope-level lookup while keeping the helper self-contained.
+        client.DefaultRequestHeaders.Add("X-Test-Session-Token", token);
+
+        return (client, sessionId);
+    }
+
+    /// <summary>
+    /// Transitions the live session to Completed state.
+    /// Domain invariants: needs ≥1 player before Start; must be InProgress before Complete.
+    /// </summary>
+    private async Task CompleteSessionAsync(Guid sessionId)
+    {
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+        // Add a player so the domain's HasPlayers check passes on Start.
+        await mediator.Send(new AddPlayerToLiveSessionCommand(
+            SessionId: sessionId,
+            DisplayName: "Setup Player",
+            Color: PlayerColor.Red,
+            UserId: null,
+            Role: null,
+            AvatarUrl: null));
+
+        // Domain invariant: session must be InProgress before Complete.
+        await mediator.Send(new StartLiveSessionCommand(sessionId));
+        await mediator.Send(new CompleteLiveSessionCommand(sessionId));
+    }
+
+    /// <summary>
+    /// Extracts the raw session token from the custom X-Test-Session-Token header we
+    /// inject during client setup — avoids a second DB lookup.
+    /// </summary>
+    private static string GetTokenFromClient(HttpClient client)
+    {
+        return client.DefaultRequestHeaders.TryGetValues("X-Test-Session-Token", out var values)
+            ? values.First()
+            : throw new InvalidOperationException("X-Test-Session-Token not set on client");
+    }
+
+    private static async Task<Guid> SeedUserAsync(MeepleAiDbContext db)
+    {
+        var userId = Guid.NewGuid();
+        db.Users.Add(new UserEntity
+        {
+            Id = userId,
+            Email = $"diary-test-{userId:N}@test.local",
+            DisplayName = "Diary Test User",
+            PasswordHash = "not-a-real-hash",
+            Role = "user",
+            Tier = "free",
+            Status = "Active",
+            EmailVerified = true,
+            CreatedAt = DateTime.UtcNow
+        });
+        await db.SaveChangesAsync();
+        return userId;
+    }
+
+    // Local record that mirrors DiaryEntryDto (internal DTO → not accessible from tests assembly)
+    private sealed record DiaryEntryResponse(
+        Guid Id,
+        Guid AuthorId,
+        DateTimeOffset CreatedAt,
+        string Text);
+}

--- a/apps/web/src/lib/session-live/__tests__/compose-session-live-state.test.ts
+++ b/apps/web/src/lib/session-live/__tests__/compose-session-live-state.test.ts
@@ -17,6 +17,7 @@ import { describe, expect, it } from 'vitest';
 import type { SessionEvent } from '../sse-events';
 import { composeSessionLiveState } from '../compose-session-live-state';
 import type { InitialSessionData } from '../compose-session-live-state';
+import { parseSseEvent } from '../parse-sse-event';
 
 // ============================================================================
 // Fixtures
@@ -511,6 +512,87 @@ describe('composeSessionLiveState — session:diary', () => {
     expect(state.actionLog[0].type).toBe('event');
     expect(state.actionLog[0].content).toBe('A diary note');
     expect(state.actionLog[0].id).toBe('note-1');
+  });
+
+  it('preserves authorId in actionLog entry authorName', () => {
+    const event: Extract<SessionEvent, { type: 'session:diary' }> = {
+      type: 'session:diary',
+      sessionId: 'sess-1',
+      entryId: 'note-2',
+      authorId: 'p-bob',
+      content: 'Bob note',
+      timestamp: TS,
+    };
+    const state = composeSessionLiveState(BASE_SESSION, [event]);
+    expect(state.actionLog[0].authorName).toBe('p-bob');
+  });
+
+  it('diary event does NOT affect players array (Notes/diary separation — FE side)', () => {
+    // Diary is append-only log; it must not alter player scores or roster.
+    // BE separation (DiaryEntries_and_Notes_are_distinct_collections,
+    // AddDiaryEntry_does_not_affect_Notes) is tested in LiveGameSession_DiaryTests.cs.
+    // This test pins the FE compositor side: applyDiary touches only actionLog.
+    const event: Extract<SessionEvent, { type: 'session:diary' }> = {
+      type: 'session:diary',
+      sessionId: 'sess-1',
+      entryId: 'note-3',
+      authorId: 'p-alice',
+      content: 'Some observation',
+      timestamp: TS,
+    };
+    const stateBefore = composeSessionLiveState(BASE_SESSION, []);
+    const stateAfter = composeSessionLiveState(BASE_SESSION, [event]);
+    expect(stateAfter.players).toHaveLength(stateBefore.players.length);
+    expect(stateAfter.players.find(p => p.id === 'p-alice')?.score).toBe(
+      stateBefore.players.find(p => p.id === 'p-alice')?.score
+    );
+    expect(stateAfter.status).toBe(stateBefore.status);
+    expect(stateAfter.currentTurn).toBe(stateBefore.currentTurn);
+  });
+});
+
+// ============================================================================
+// session:diary — end-to-end parse → compose (SP3 T7 #2570)
+// ============================================================================
+
+describe('session:diary end-to-end: parseSseEvent → composeSessionLiveState', () => {
+  it('parsed session:diary event reaches actionLog with correct content and author (T7 pin)', () => {
+    // Simulates the SSE pipeline: raw wire bytes → parseSseEvent → composeSessionLiveState.
+    // Verifies T6 broadcast is not inert: diary entries DO surface in the live log timeline.
+    const rawData = JSON.stringify({
+      entryId: 'e2e-note-1',
+      authorId: 'p-alice',
+      content: 'Played the Forest Witch card',
+      timestamp: TS,
+    });
+    const parsed = parseSseEvent('session:diary', rawData, 'sess-e2e');
+    expect(parsed).not.toBeNull();
+    expect(parsed?.type).toBe('session:diary');
+
+    const state = composeSessionLiveState(BASE_SESSION, [parsed!]);
+    expect(state.actionLog).toHaveLength(1);
+    const entry = state.actionLog[0];
+    expect(entry.type).toBe('event');
+    expect(entry.content).toBe('Played the Forest Witch card');
+    expect(entry.authorName).toBe('p-alice');
+    expect(entry.id).toBe('e2e-note-1');
+    expect(entry.timestamp).toBe(TS);
+  });
+
+  it('parsed session:diary with noteId alias also reaches composed actionLog', () => {
+    // BE NoteSavedEvent may send `noteId` not `entryId` — parseDiary normalizes it.
+    const rawData = JSON.stringify({
+      noteId: 'e2e-note-2',
+      authorId: 'p-bob',
+      content: 'Move to the second chamber',
+      timestamp: TS,
+    });
+    const parsed = parseSseEvent('session:diary', rawData, 'sess-e2e');
+    expect(parsed).not.toBeNull();
+
+    const state = composeSessionLiveState(BASE_SESSION, [parsed!]);
+    expect(state.actionLog[0].id).toBe('e2e-note-2');
+    expect(state.actionLog[0].content).toBe('Move to the second chamber');
   });
 });
 

--- a/apps/web/src/lib/session-live/parse-sse-event.ts
+++ b/apps/web/src/lib/session-live/parse-sse-event.ts
@@ -34,7 +34,7 @@
  * |                      |                            | BE `senderId` nullable matches FE       |
  * | session:tool-execution| DiceRolledEvent/RandomToolEvents | FE `tool: 'dice'|'timer'|'card'` |
  * |                      |                            | v1 gap: BE has CoinFlippedEvent, WheelSpunEvent not in FE enum |
- * | session:diary        | NoteSavedEvent/NoteRevealedEvent | BE `HasObscuredText` not in FE  |
+ * | session:diary        | LiveSessionDiaryEntryAddedEvent  | BE `HasObscuredText` not in FE  |
  * | session:turn         | TurnAdvancedEvent          | BE `newTurnIndex` + `currentPlayerId`       |
  * | heartbeat            | inline endpoint            | timestamp field matches FE contract     |
  */
@@ -333,10 +333,17 @@ function parseDiary(
           ? data['id']
           : null;
   if (!entryId) return null;
+  // Resolve authorId: check the direct `authorId` field first (the BE diary event field name),
+  // then fall back to resolveParticipantId() (which probes `participantId`/`userId`).
+  // Previously the priority was reversed — this corrects the intent without changing runtime
+  // behaviour (BE never emits `participantId` for diary events).
   const authorId =
-    resolveParticipantId(data) ?? (typeof data['authorId'] === 'string' ? data['authorId'] : null);
+    (typeof data['authorId'] === 'string' ? data['authorId'] : null) ?? resolveParticipantId(data);
   if (!authorId) return null;
-  const content = typeof data['content'] === 'string' ? data['content'] : '';
+  // Guard against missing or empty content — mirrors the BE `NotEmpty` validation.
+  // A silent empty-string diary entry would render as a blank card in the UI.
+  const content = typeof data['content'] === 'string' ? data['content'] : null;
+  if (!content || content.trim() === '') return null;
   const timestamp =
     typeof data['timestamp'] === 'string' ? data['timestamp'] : new Date().toISOString();
   return { type: 'session:diary', sessionId, entryId, authorId, content, timestamp };

--- a/docs/for-claude/architecture/adr/adr-083-live-session-aggregate-convergence.md
+++ b/docs/for-claude/architecture/adr/adr-083-live-session-aggregate-convergence.md
@@ -172,12 +172,12 @@ L'Update (3) SP0 stabiliva che diary/media "riusano la `SessionTracking.Session`
 
 ### Razionale (code-grounded, da de-risk read-only)
 1. **L'eventing forza comunque un domain-event di `LiveGameSession`.** Il forwarder SP2 (`LiveSessionStreamForwarder`) inoltra allo stream **solo** domain-event di `LiveGameSession`; non esiste alcun handler `SessionTracking → ILiveSessionStreamGateway`. Quindi `session:diary` deve nascere come domain-event di `LiveGameSession` *a prescindere da dove è memorizzato*. Memorizzare il diary altrove (companion) **separerebbe** il write-path (SessionTracking) dall'event-path (GameManagement) → problema dual-source/dedup ("chi è autoritativo sul replay").
-2. **Semantica incompatibile.** Le note del companion (`SessionEvent`/`SessionNote`, SessionTracking) sono **crittografate-at-rest, private per-partecipante** — semanticamente NON un diario pubblico append-only multi-autore. Riusarle sovraccaricherebbe quell'aggregato.
+2. **Semantica incompatibile.** Le note del companion (`SessionEvent`/`SessionNote`, SessionTracking) sono **crittografate-at-rest, private per-partecipante** — semanticamente NON un diario append-only multi-autore tra i partecipanti registrati. Riusarle sovraccaricherebbe quell'aggregato.
 3. **Lowest-risk.** Append-only + 409-guard + forwarder è un clone 1:1 del pattern `RecordScore` esistente; co-locare storage ed evento elimina i rischi dual-write/dedup.
 
 ### Scope dell'emendamento
 - Si applica **solo al diary** (SP3). Il **media** (SP4, già shipped come foto in EndgameDialog #2558, FE-only su PlayRecord) e la **chat** (SP1 #2500, KnowledgeBase) NON sono toccati da questo emendamento. La direttiva SP0 "Session-companion canonica" resta valida come **identità correlante** (`TrackingSessionId`), ma il diary non vi memorizza i propri dati.
-- Conseguenza: `LiveGameSession` ha `Notes` (single-string, host-level, overwrite) **e** una collezione `DiaryEntry` (append-only, multi-autore) — due store distinti per due job distinti (OQ#6 risolta: coesistenza, nessuna deprecazione di Notes).
+- Conseguenza: `LiveGameSession` ha `Notes` (single-string, host-level, overwrite) **e** una collezione `DiaryEntry` (append-only, multi-autore tra i partecipanti registrati) — due store distinti per due job distinti (OQ#6 risolta: coesistenza, nessuna deprecazione di Notes).
 
 ### Decisione ratificata dall'owner (2026-06-29)
 **Option A — entità `DiaryEntry` nativa su `LiveGameSession`.** Endpoint `POST/GET /api/v1/live-sessions/{id}/diary`; `LiveSessionDiaryEntryAddedEvent` → forwarder → `session:diary` (`{ entryId, authorId, content, timestamp(ISO-8601) }`); 409 su Completed (allow Paused). De-risk: `.superpowers/sdd/sp3-diary-derisk-brief.md`.

--- a/docs/for-claude/architecture/adr/adr-083-live-session-aggregate-convergence.md
+++ b/docs/for-claude/architecture/adr/adr-083-live-session-aggregate-convergence.md
@@ -166,6 +166,22 @@ Le due scelte creano una tensione: con la **Session-companion** (OQ1) chat/diary
 
 La combinazione scelta (Session-companion + SSE nativo) è la **più robusta ma anche la più costosa** tra quelle valutate: la Saga at-creation + il `TrackingSessionId` garantito + il **backfill/coexistence** delle sessioni in-flight + il **gateway SSE** su GameManagement portano la stima della Fase 2 **oltre** i ~19-27 gg della spec base (la stima ADR originale di "1.5-2 settimane" è superata). Vantaggio: correlazione garantita ovunque (niente null-window su chat/diary/media) + un solo canale realtime con contratto chiaro. La Saga al create introduce un punto di atomicità cross-BC da coprire con test (failure → nessuna LiveGameSession orfana senza companion). Questi costi vanno riflessi nelle sub-fasi SP0/SP2/SP4/SP5 della spec.
 
+## Update 2026-06-29 (SP3) — Storage del diary: NATIVO su LiveGameSession (emenda la direttiva SP0 "riusa companion")
+
+L'Update (3) SP0 stabiliva che diary/media "riusano la `SessionTracking.Session` companion via `TrackingSessionId`". Per il **diary** (SP3, issue #2570) questa direttiva è **emendata**: il diary append-only è un'**entità nativa su `LiveGameSession`** (GameManagement-owned), non sul companion.
+
+### Razionale (code-grounded, da de-risk read-only)
+1. **L'eventing forza comunque un domain-event di `LiveGameSession`.** Il forwarder SP2 (`LiveSessionStreamForwarder`) inoltra allo stream **solo** domain-event di `LiveGameSession`; non esiste alcun handler `SessionTracking → ILiveSessionStreamGateway`. Quindi `session:diary` deve nascere come domain-event di `LiveGameSession` *a prescindere da dove è memorizzato*. Memorizzare il diary altrove (companion) **separerebbe** il write-path (SessionTracking) dall'event-path (GameManagement) → problema dual-source/dedup ("chi è autoritativo sul replay").
+2. **Semantica incompatibile.** Le note del companion (`SessionEvent`/`SessionNote`, SessionTracking) sono **crittografate-at-rest, private per-partecipante** — semanticamente NON un diario pubblico append-only multi-autore. Riusarle sovraccaricherebbe quell'aggregato.
+3. **Lowest-risk.** Append-only + 409-guard + forwarder è un clone 1:1 del pattern `RecordScore` esistente; co-locare storage ed evento elimina i rischi dual-write/dedup.
+
+### Scope dell'emendamento
+- Si applica **solo al diary** (SP3). Il **media** (SP4, già shipped come foto in EndgameDialog #2558, FE-only su PlayRecord) e la **chat** (SP1 #2500, KnowledgeBase) NON sono toccati da questo emendamento. La direttiva SP0 "Session-companion canonica" resta valida come **identità correlante** (`TrackingSessionId`), ma il diary non vi memorizza i propri dati.
+- Conseguenza: `LiveGameSession` ha `Notes` (single-string, host-level, overwrite) **e** una collezione `DiaryEntry` (append-only, multi-autore) — due store distinti per due job distinti (OQ#6 risolta: coesistenza, nessuna deprecazione di Notes).
+
+### Decisione ratificata dall'owner (2026-06-29)
+**Option A — entità `DiaryEntry` nativa su `LiveGameSession`.** Endpoint `POST/GET /api/v1/live-sessions/{id}/diary`; `LiveSessionDiaryEntryAddedEvent` → forwarder → `session:diary` (`{ entryId, authorId, content, timestamp(ISO-8601) }`); 409 su Completed (allow Paused). De-risk: `.superpowers/sdd/sp3-diary-derisk-brief.md`.
+
 ## Riferimenti
 - Epic #2501; user story di validazione #2506; gap issue #2500/#2503/#2505/#2504/#2502.
 - **Spec Fase 2**: `docs/for-developers/specs/2026-06-23-epic-2501-fase2-live-session-feature-gaps.md` (spec-panel).

--- a/docs/superpowers/plans/2026-06-29-issue-2570-sp3-diary.md
+++ b/docs/superpowers/plans/2026-06-29-issue-2570-sp3-diary.md
@@ -1,0 +1,189 @@
+# SP3 — Diary nativo append-only Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Aggiungere un diary append-only multi-autore a `LiveGameSession` (entità nativa, Option A) con endpoint `POST/GET /api/v1/live-sessions/{id}/diary`, 409 su Completed, ed evento `session:diary` sullo stream SP2 (forwarder), distinto da `Notes`.
+
+**Architecture:** `DiaryEntry` come collezione owned append-only su `LiveGameSession`; `AddDiaryEntry()` è l'unico mutatore + alza `LiveSessionDiaryEntryAddedEvent`; il forwarder SP2 (`LiveSessionStreamForwarder`) lo mappa a `session:diary` e lo broadcasta via `ILiveSessionStreamGateway`. CQRS: command/query handler via MediatR; `SaveChangesAsync` post-mutazione (ADR-060).
+
+**Tech Stack:** .NET 9 ASP.NET Minimal APIs + MediatR + EF Core; FE Next.js + TS + Vitest.
+
+## Global Constraints
+- **Option A ratificata** (ADR-083 Update 2026-06-29): diary nativo su `LiveGameSession`, NON sul companion. De-risk: `.superpowers/sdd/sp3-diary-derisk-brief.md`.
+- **Append-only**: nessun setter pubblico oltre `AddDiaryEntry(authorId, text)`; entry immutabili.
+- **409 su Completed** (AC-DIARY-3): clone del pattern `LiveGameSession.cs:534` — `if (Status == LiveSessionStatus.Completed) throw new ConflictException(...)` → HTTP 409 via middleware. Allow `Paused` (NON la variante stricter `InProgress||Paused` di RecordScore). Mai `InvalidOperationException` (500).
+- **ADR-060**: ogni command handler che muta l'aggregato chiama `await _unitOfWork.SaveChangesAsync(ct)`; i domain-event dispatchano post-SaveChanges.
+- **Notes resta distinto** (AC-DIARY-4, OQ#6): non deprecare `Notes` (single-string overwrite, `PUT /notes`); aggiungere test negativo che pinna la separazione.
+- **session:diary payload** (FE-contract `sse-events.ts:187-193`): `{ entryId, authorId, content, timestamp }`. **Timestamp ISO-8601 esplicito** (`createdAt.ToString("o")`) — il FE `parseDiary` defaulta a now() se assente → corrompe ordering/replay.
+- **No worktree**: implementer committano direttamente sul branch `feature/issue-2570-sp3-diary` nel checkout principale.
+
+## Reading list (REUSE — leggi prima di codificare)
+`LiveGameSession.cs` (factory/Reconstitute, `RecordScore` ~:534 per il guard pattern, `UpdateNotes` :745-761), `LiveSessionStreamForwarder.cs` (pattern handler→session:* event), `ILiveSessionStreamGateway` + `LiveSessionStreamEvent`, gli altri `Domain/Events/LiveSession*Event.cs`, un command handler esistente (es. `RecordScoreCommandHandler`) per il pattern command+validator+handler+SaveChanges, `parse-sse-event.ts:323-343` (parseDiary), `sse-events.ts:187-193` (session:diary).
+
+---
+
+## Task 1: `DiaryEntry` VO + `AddDiaryEntry` append-only + 409-guard + domain event
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/LiveGameSession.cs`
+- Create: `apps/api/src/Api/BoundedContexts/GameManagement/Domain/Events/LiveSessionDiaryEntryAddedEvent.cs`
+- Test: `apps/api/tests/Api.Tests/.../GameManagement/.../LiveGameSessionDiaryTests.cs`
+
+**Interfaces:**
+- Produces: `DiaryEntry` immutable record `{ Guid Id, Guid AuthorId, DateTimeOffset CreatedAt, string Text }`; `LiveGameSession.AddDiaryEntry(Guid authorId, string text)` (append-only, raises `LiveSessionDiaryEntryAddedEvent { SessionId, EntryId, AuthorId, Text, CreatedAt }`); read-only `IReadOnlyList<DiaryEntry> DiaryEntries`.
+
+- [ ] **Step 1: Failing test** — `AddDiaryEntry` appende (E2 dopo E1 → `[E1,E2]`, E1 invariato); su `Completed` → `ConflictException`; alza `LiveSessionDiaryEntryAddedEvent`.
+
+```csharp
+[Fact]
+public void AddDiaryEntry_appends_and_raises_event()
+{
+    var s = NewInProgressSession();
+    s.AddDiaryEntry(authorId: A, "first");
+    s.AddDiaryEntry(authorId: B, "second");
+    s.DiaryEntries.Select(e => e.Text).Should().Equal("first", "second");
+    s.DomainEvents.OfType<LiveSessionDiaryEntryAddedEvent>().Should().HaveCount(2);
+}
+
+[Fact]
+public void AddDiaryEntry_on_completed_throws_conflict()
+{
+    var s = NewCompletedSession();
+    var act = () => s.AddDiaryEntry(A, "x");
+    act.Should().Throw<ConflictException>();
+}
+```
+
+- [ ] **Step 2: Run → FAIL.**
+- [ ] **Step 3: Implement** — private backing `List<DiaryEntry>`, `DiaryEntries` read-only projection, `AddDiaryEntry` (guard `Status == Completed` → `ConflictException`; allow Paused; create entry; `AddDomainEvent`). New event record (mirror an existing `LiveSession*Event`). Verify how the aggregate generates ids / timestamps (use the same `DateTimeOffset`/`Guid` approach as other entries; if the codebase injects a clock, follow it — else `DateTimeOffset.UtcNow` consistent with siblings).
+- [ ] **Step 4: Run → PASS** (incl. domain unit suite).
+- [ ] **Step 5: Commit** — `feat(session-live): #2570 SP3 T1 DiaryEntry append-only + 409 guard + domain event`
+
+---
+
+## Task 2: EF persistence + migration
+
+**Files:**
+- Modify: the `LiveGameSession` EF configuration (`...Infrastructure/.../LiveGameSessionEntityConfiguration.cs` or equivalent)
+- Create: EF migration (`dotnet ef migrations add AddLiveSessionDiaryEntries`)
+- Test: integration round-trip (Testcontainers) — persist a session with diary entries, reload, entries present + ordered.
+
+**Interfaces:**
+- Consumes: T1's `DiaryEntry` collection.
+
+- [ ] **Step 1: Failing integration test** — save a `LiveGameSession` with 2 diary entries → reload → `DiaryEntries` has both in order, with authorId/createdAt/text intact.
+- [ ] **Step 2: Run → FAIL** (no mapping).
+- [ ] **Step 3: Implement** — map `DiaryEntries` (owned collection → `live_session_diary_entries` table FK to `live_game_sessions`, OR owned-JSON column — **match the existing persistence convention** used for the aggregate's other collections like scores/snapshots; read the config first). Generate migration; review the SQL. Do NOT touch unrelated migrations.
+- [ ] **Step 4: Run → PASS** (+ existing LiveGameSession persistence tests green — no regression).
+- [ ] **Step 5: Commit** — `feat(session-live): #2570 SP3 T2 EF persistence + migration for diary entries`
+
+---
+
+## Task 3: `AddDiaryEntryCommand` + validator + handler
+
+**Files:**
+- Create: command + validator + handler under `...GameManagement/Application/Commands/LiveSessions/`
+- Test: handler test + validator test
+
+**Interfaces:**
+- Produces: `AddDiaryEntryCommand { Guid SessionId, Guid AuthorId, string Text } : IRequest<Guid>` (returns new entry id); validator (`SessionId` NotEmpty, `Text` NotEmpty + length cap e.g. 2000); handler loads session, `AddDiaryEntry`, `SaveChangesAsync`, returns entry id.
+
+- [ ] **Step 1: Failing test** — handler adds an entry + calls `SaveChangesAsync` once + returns the id; session-not-found → `NotFoundException`; Completed session → `ConflictException` (propagated from domain). Validator: empty text → invalid; over-cap → invalid.
+- [ ] **Step 2: Run → FAIL.**
+- [ ] **Step 3: Implement** — mirror an existing LiveSession command handler (e.g. `RecordScoreCommandHandler`) incl. the `_unitOfWork.SaveChangesAsync(ct)` call (ADR-060). Register validator/handler per the codebase convention (MediatR scan).
+- [ ] **Step 4: Run → PASS.**
+- [ ] **Step 5: Commit** — `feat(session-live): #2570 SP3 T3 AddDiaryEntryCommand + validator + handler`
+
+---
+
+## Task 4: `GetLiveSessionDiaryQuery` + handler + DTO
+
+**Files:**
+- Create: query + handler + `DiaryEntryDto` under `...Application/Queries/`
+- Test: handler test
+
+**Interfaces:**
+- Produces: `GetLiveSessionDiaryQuery { Guid SessionId } : IRequest<IReadOnlyList<DiaryEntryDto>>`; `DiaryEntryDto { Guid Id, Guid AuthorId, DateTimeOffset CreatedAt, string Text }`; handler returns entries ordered by `CreatedAt` (stable). NotFound session → `NotFoundException` (or empty per existing query convention — match siblings).
+
+- [ ] **Step 1: Failing test** — returns entries in chronological order; empty for a session with no diary.
+- [ ] **Step 2: Run → FAIL.**
+- [ ] **Step 3: Implement** — mirror an existing LiveSession query handler.
+- [ ] **Step 4: Run → PASS.**
+- [ ] **Step 5: Commit** — `feat(session-live): #2570 SP3 T4 GetLiveSessionDiaryQuery + handler + DTO`
+
+---
+
+## Task 5: Endpoints `POST/GET /live-sessions/{id}/diary` + authz
+
+**Files:**
+- Modify: `apps/api/src/Api/Routing/LiveSessionEndpoints.cs` (group with the other `/live-sessions/{id}/*` routes)
+- Test: integration (Testcontainers) — POST adds (201/200 + id), GET lists ordered, POST on Completed → 409, unauthorized → 403/404.
+
+**Interfaces:**
+- Consumes: T3 command, T4 query, the existing authz pattern (mirror `GET /live-sessions/{id}` participant check + `RequireAuthenticatedUser()`). `AuthorId` comes from the auth context (not the body).
+
+- [ ] **Step 1: Failing integration test** — the 4 scenarios above.
+- [ ] **Step 2: Run → FAIL** (routes 404).
+- [ ] **Step 3: Implement** — `MapPost("/{sessionId:guid}/diary", ...)` + `MapGet("/{sessionId:guid}/diary", ...)`, `RequireAuthenticatedUser()`, authz via the existing pattern, `AuthorId` from auth ctx. 409 maps from `ConflictException` via middleware (verify it does).
+- [ ] **Step 4: Run → PASS** (Docker; if unavailable, compile + CI-needed note, mirror existing LiveSession integration tests).
+- [ ] **Step 5: Commit** — `feat(session-live): #2570 SP3 T5 diary endpoints POST/GET + authz`
+
+---
+
+## Task 6: Forwarder → `session:diary` stream event
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/GameManagement/Application/EventHandlers/LiveSessionStreamForwarder.cs`
+- Test: forwarder test (mock gateway)
+
+**Interfaces:**
+- Consumes: `ILiveSessionStreamGateway.BroadcastAsync`, `LiveSessionDiaryEntryAddedEvent`.
+- Produces: `INotificationHandler<LiveSessionDiaryEntryAddedEvent>` → `BroadcastAsync(SessionId, new LiveSessionStreamEvent("session:diary", new { entryId = EntryId, authorId = AuthorId, content = Text, timestamp = CreatedAt.ToString("o") }), ct)`.
+
+- [ ] **Step 1: Failing test** — `Handle(LiveSessionDiaryEntryAddedEvent)` calls `BroadcastAsync(sessionId, evt with Type "session:diary")` once, and the Data carries `entryId/authorId/content/timestamp` with an ISO-8601 timestamp.
+- [ ] **Step 2: Run → FAIL.**
+- [ ] **Step 3: Implement** — add the handler interface to `LiveSessionStreamForwarder` (mirror the score/turn handlers). Verify the forwarder's DI registration picks up the new `INotificationHandler<>` (assembly scan should).
+- [ ] **Step 4: Run → PASS.**
+- [ ] **Step 5: Commit** — `feat(session-live): #2570 SP3 T6 forwarder → session:diary stream event`
+
+---
+
+## Task 7: FE — verify session:diary consumption + Notes-vs-diary separation test
+
+**Files:**
+- Investigate/Modify (FE): `apps/web/src/lib/session-live/compose-session-live-state.ts` (does `applyDiary` render diary entries into the live log? `parseDiary` already exists). If diary entries are NOT surfaced in the timeline, wire them (small) OR document as a follow-up (like #2564).
+- Test: a FE test asserting `parseSseEvent('session:diary', ...)` → entry rendered/composed; and a BE/FE assertion that `Notes` (UpdateNotes) does NOT touch the diary collection (the separation pin).
+
+**Interfaces:**
+- Consumes: T6's `session:diary` payload.
+
+- [ ] **Step 1: Investigate** whether `compose-session-live-state` already maps `session:diary` into the log; if yes, just add the test; if no, decide wire-now-vs-followup (prefer a small wire so the feature isn't inert).
+- [ ] **Step 2: Failing test** — diary event composes into the live state; Notes-vs-diary separation pinned.
+- [ ] **Step 3: Implement** the wiring (if needed) + the separation test (a domain/unit test asserting `UpdateNotes` leaves `DiaryEntries` unchanged and vice-versa).
+- [ ] **Step 4: Run → PASS** (`pnpm test session-live` + typecheck; the BE separation test).
+- [ ] **Step 5: Commit** — `feat(session-live): #2570 SP3 T7 FE session:diary consumption + Notes/diary separation test`
+
+---
+
+## Task 8: Integration / E2E + AC validation
+
+**Files:**
+- Test: an integration/E2E that exercises POST diary → GET diary → the `session:diary` event reaches a subscriber (or a focused integration that the command raises the event that the forwarder broadcasts). Mirror existing SP2 integration patterns.
+
+- [ ] **Step 1: Failing test** — end-to-end: add a diary entry → it appears in GET + a `session:diary` event is broadcast.
+- [ ] **Step 2: Run → FAIL/compile.**
+- [ ] **Step 3: Implement** — the integration test (Docker; if unavailable, compile + CI-needed). Map each AC-DIARY-1..4 → a test.
+- [ ] **Step 4: Run → PASS or CI-needed.**
+- [ ] **Step 5: Commit** — `feat(session-live): #2570 SP3 T8 diary integration + AC validation`
+
+---
+
+## Self-Review (eseguita)
+- **AC coverage**: AC-DIARY-1 (append-only)→T1/T2/T8; AC-DIARY-2 (multi-autore+ordine)→T1/T4/T8; AC-DIARY-3 (409 Completed)→T1/T3/T5; AC-DIARY-4 (Notes distinto)→T7. ✅
+- **Invarianti**: SaveChanges (T3), ISO-8601 timestamp (T6), no Notes deprecation (T7), 409-not-500 (T1/T5).
+- **Type consistency**: `DiaryEntry{Id,AuthorId,CreatedAt,Text}`, `LiveSessionDiaryEntryAddedEvent{SessionId,EntryId,AuthorId,Text,CreatedAt}`, `AddDiaryEntryCommand→Guid`, `DiaryEntryDto`, payload `{entryId,authorId,content,timestamp}` — coerenti.
+- **Rischio**: persistence convention (T2 owned-table vs owned-JSON) — leggere la config esistente prima di scegliere; il forwarder DI pickup (T6) — verificare assembly scan.
+
+## Out of scope SP3 (→ follow-up / altre fasi)
+- Rendering ricco del diary nell'UI oltre il log (se T7 lo lascia minimale → follow-up come #2564 per le citazioni).
+- Edit/delete di entry (append-only by design — no mutazione).


### PR DESCRIPTION
## Sommario

Sotto-fase **SP3** dell'epic #2501 (Fase 2). Aggiunge un **diary append-only multi-autore** alla sessione live, con `POST/GET /api/v1/live-sessions/{id}/diary` e un evento `session:diary` sullo stream nativo SP2 (#2561, merged).

## Decisione architetturale (owner-ratificata) — Option A + emendamento ADR-083

**`DiaryEntry` come entità NATIVA su `LiveGameSession`** (GameManagement), append-only, distinta da `Notes` (single-string host-level). Questo **emenda** la direttiva SP0 ("riusa il companion SessionTracking") — vedi [ADR-083 § Update 2026-06-29](docs/for-claude/architecture/adr/adr-083-live-session-aggregate-convergence.md). Razionale code-grounded: il forwarder SP2 inoltra allo stream **solo** domain-event di `LiveGameSession`, quindi `session:diary` deve nascere lì in ogni caso; le note del companion sono crittografate-at-rest **private per-partecipante** (semantica sbagliata per un diario multi-autore); co-locare storage+evento elimina il dual-write/dedup.

## Cosa c'è dentro (8 task TDD, subagent-driven)

- **T1** `DiaryEntry` VO + `AddDiaryEntry` append-only + 409-on-Completed (allow Paused) + `LiveSessionDiaryEntryAddedEvent`
- **T2** EF persistence (owned-table `live_session_diary_entries`, FK cascade, migration additiva) + `Reconstitute`
- **T3** `AddDiaryEntryCommand` + validator (Text cap 2000) + handler (SaveChanges ADR-060)
- **T4** `GetLiveSessionDiaryQuery` + handler + `DiaryEntryDto` (cronologico)
- **T5** endpoint POST/GET + **authz per-sessione partecipante** (mirror esatto dello stream SP2: `CreatedByUserId || Players.Any(IsActive && UserId)`, 404-before-403, `AuthorId` dai claim)
- **T6** forwarder → `session:diary` `{entryId, authorId, content, timestamp(ISO-8601)}`
- **T7** consumo FE (`applyDiary` già wired) + separazione Notes/diary
- **T8** integration end-to-end (chain add→persist→event→forward via gateway-spy, Hybrid dispatch) + matrice tracciabilità AC

## Acceptance criteria

AC-DIARY-1 (append-only multi-autore) · AC-DIARY-2 (persist + evento) · AC-DIARY-3 (409 su Completed, allow Paused) · AC-DIARY-4 (Notes distinto, no deprecazione — OQ#6). ✅ tutte con test non-hollow.

## Quality

Ogni task: implementer + task-review (spec+quality) a 2 stadi. **Review finale whole-branch adversarial (5 lenti)** → READY_WITH_FOLLOWUPS; fixati in-PR: 1 authz Critical (T5, per-session participant check), 1 dispatch-mode hollow-test Critical (T8, forza Hybrid), 1 must-fix test vacuo (chronological → FakeTimeProvider). Whole-branch: BE build + FE typecheck verdi.

## Follow-up (out of SP3, tracciati)

- **#2573** authz per-sessione sistemica sugli ALTRI write-endpoint live-session (pre-esistente)
- **#2575** FE write-path diary + display-name resolution + SyncDiaryEntries refactor

## Fuori scope SP3 (deferiti)

SP5 (affidabilità, repoint toolkit-hook, backfill) · Fase 4 (rimozione `/stream/v2`). Il diary in SP3 è esposto passivamente via SSE; il write-client FE è in #2575.

Closes #2570.

🤖 Generated with [Claude Code](https://claude.com/claude-code)