### PR TITLE
fix(rag): pin keyword FTS config to english, remove italian footgun

### DIFF
--- a/apps/api/src/Api/Services/KeywordSearchService.cs
+++ b/apps/api/src/Api/Services/KeywordSearchService.cs
@@ -19,25 +19,15 @@ internal class KeywordSearchService : IKeywordSearchService
     private readonly ILogger<KeywordSearchService> _logger;
 
     // PostgreSQL full-text search configuration.
-    // #2569: default is 'english' to match the content (PdfDocument.Language defaults to "en")
-    // and the pgvector path (PgVectorStoreAdapter uses 'english'). The stored search_vector
-    // columns (text_chunks/pdf_documents) are generated with 'english' too, so query config and
-    // column config agree. The previous 'italian' default silently mismatched English content.
-    // Note: ADR-016 planned custom FTS with game synonyms - tracked in follow-up issue.
+    // #2569: keyword FTS is 'english' to match the content (PdfDocument.Language defaults to
+    // "en"), the pgvector path (PgVectorStoreAdapter uses 'english'), and — critically — the
+    // GENERATED search_vector column on text_chunks/pdf_documents (also 'english'). Query config
+    // and column config MUST agree or the @@ operator silently returns nothing. There is NO
+    // per-language mapping on purpose: the column is single-config, so an 'italian' query would
+    // never match. A multilingual mapping returns only when a multilingual column exists
+    // (ADR-016 follow-up). See ResolveFtsConfig.
     private const string DefaultTextSearchConfig = "english";
-    private const string EnglishTextSearchConfig = "english";
     private const int DefaultNormalization = 1; // ts_rank_cd normalization method (1 = divide by document length)
-
-    /// <summary>
-    /// Mapping of language codes to PostgreSQL text search configurations.
-    /// </summary>
-    private static readonly Dictionary<string, string> LanguageToFtsConfig = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
-    {
-        { "it", "italian" },  // Issue #3228: Use built-in (meepleai_italian not created)
-        { "italian", "italian" },
-        { "en", "english" },
-        { "english", "english" }
-    };
 
     public KeywordSearchService(
         MeepleAiDbContext dbContext,
@@ -314,29 +304,18 @@ internal class KeywordSearchService : IKeywordSearchService
     }
 
     /// <summary>
-    /// Resolves a language code to the corresponding PostgreSQL FTS configuration.
-    /// ADR-016 Phase 3: Maps "it" → meepleai_italian (with game synonyms), "en" → english.
+    /// Resolves the PostgreSQL FTS configuration for keyword search.
+    /// #2569 footgun guard: ALWAYS returns <see cref="DefaultTextSearchConfig"/> ('english'),
+    /// ignoring <paramref name="language"/>. The <c>search_vector</c> column is a single-config
+    /// GENERATED column built with 'english'; a divergent query config (e.g. 'italian') would
+    /// make the <c>@@</c> operator silently return nothing. True per-query / multilingual FTS
+    /// requires a multilingual <c>search_vector</c> column (ADR-016 follow-up); until that
+    /// exists the query config is pinned to the column's config. The parameter is retained for
+    /// forward-compatibility (and so existing call sites need no change).
     /// </summary>
-    /// <param name="language">Language code (e.g., "it", "en", "italian", "english")</param>
-    /// <returns>PostgreSQL text search configuration name</returns>
-    private string ResolveFtsConfig(string language)
-    {
-        if (string.IsNullOrWhiteSpace(language))
-        {
-            _logger.LogDebug("Empty language provided, using default FTS config: {Config}", DefaultTextSearchConfig);
-            return DefaultTextSearchConfig;
-        }
-
-        if (LanguageToFtsConfig.TryGetValue(language, out var ftsConfig))
-        {
-            return ftsConfig;
-        }
-
-        _logger.LogWarning(
-            "Unknown language '{Language}' for FTS config, falling back to English",
-            language);
-        return EnglishTextSearchConfig;
-    }
+    /// <param name="language">Reserved; currently ignored — keyword FTS is english-only (#2569).</param>
+    /// <returns>The PostgreSQL text search configuration ('english').</returns>
+    internal static string ResolveFtsConfig(string language) => DefaultTextSearchConfig;
 
     /// <summary>
     /// Extracts matched terms from query for frontend highlighting.

--- a/apps/api/tests/Api.Tests/Services/KeywordSearchServiceTests.cs
+++ b/apps/api/tests/Api.Tests/Services/KeywordSearchServiceTests.cs
@@ -1,0 +1,32 @@
+using Api.Services;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.Services;
+
+/// <summary>
+/// #2569 footgun guard: the <c>search_vector</c> column on text_chunks/pdf_documents is a
+/// single-config GENERATED column built with the <c>'english'</c> FTS config. The keyword FTS
+/// query config MUST therefore be <c>'english'</c> regardless of any requested language —
+/// otherwise an explicit <c>language: "it"</c> would issue <c>to_tsquery('italian', …)</c>
+/// against the 'english' column and the <c>@@</c> operator would silently return nothing
+/// (the exact bug class fixed in #2569). Per-query language FTS is not supported until a
+/// multilingual column exists (ADR-016 follow-up); until then the config is pinned to english.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "KnowledgeBase")]
+public sealed class KeywordSearchServiceTests
+{
+    [Theory]
+    [InlineData("it")]
+    [InlineData("italian")]
+    [InlineData("en")]
+    [InlineData("english")]
+    [InlineData("")]
+    [InlineData("xx")]
+    public void ResolveFtsConfig_AlwaysReturnsEnglish_RegardlessOfLanguage(string language)
+    {
+        KeywordSearchService.ResolveFtsConfig(language).Should().Be("english");
+    }
+}


### PR DESCRIPTION
## Footgun (LOW, da audit #2569)

`KeywordSearchService.ResolveFtsConfig` mappava `language` `"it"/"italian"` → config FTS `'italian'`, ma la colonna `search_vector` (text_chunks/pdf_documents) è single-config GENERATED `'english'` (#2569). Un caller futuro che passasse `language:"it"` produrrebbe `to_tsquery('italian', …)` contro la colonna english → `@@` ritorna **silenziosamente zero righe** (la stessa classe-bug di #2569). Attualmente **irraggiungibile** (nessun caller passa `language`; HybridSearchService usa il default `"en"`), ma è un footgun.

## Fix

`ResolveFtsConfig` ora ritorna **sempre** `'english'`, ignorando `language`. Rimossi la mappa `LanguageToFtsConfig` e il const ridondante `EnglishTextSearchConfig`. Il param `language` resta (no signature change → nessun ripple su interfaccia/caller/mock) ma è documentato come riservato/ignorato. FTS per-query/multilingua tornerà solo con una colonna multilingua (ADR-016 follow-up).

## TDD
- `KeywordSearchServiceTests.ResolveFtsConfig_AlwaysReturnsEnglish_RegardlessOfLanguage` (Theory: it/italian/en/english/""/xx): RED (it+italian ritornavano 'italian') → GREEN (tutti 'english').
- `ResolveFtsConfig` reso `internal static` (testabile via InternalsVisibleTo).
- KB Unit 2287 pass, build 0/0.

Chiude il follow-up LOW dell'audit FTS-config di #2569.

🤖 Generated with [Claude Code](https://claude.com/claude-code)