### PR TITLE
fix(seed): correct wrong bggId for 3 games in manifests (#2528)

### DIFF
--- a/apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/dev.yml
+++ b/apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/dev.yml
@@ -7577,7 +7577,7 @@ catalog:
     - Zvezda
     - 本长文化
   - title: 'Skytear: Arena of Legends'
-    bggId: 373106
+    bggId: 259061
     language: en
     pdfBlobKey: rulebooks/v1/skytear_rulebook.pdf
     pdfSha256: 2f316d16c5001b55097b9966c7c697bbde6a50e7e5c9b1c3df336ff5c3775960
@@ -8869,7 +8869,7 @@ catalog:
     pdfSha256: 31e496fdc97b9df7a8f38ccbd36561dc16265c142ff1cc3597fe6217f4707cc9
     pdfVersion: '1.0'
   - title: 'Great Western Trail: Argentina'
-    bggId: 380607
+    bggId: 364011
     language: en
     pdfBlobKey: rulebooks/v1/great-western-trail-argentina_rulebook.pdf
     pdfSha256: 88be4a0b83dda037566941e46d1e936ec6280c37e9860c0405a58a9bd412c2fa
@@ -9302,7 +9302,7 @@ catalog:
     pdfSha256: a43d7ee00276e963ea7afd327711cd52cee609712a8128e0f4a164290c2754d4
     pdfVersion: '1.0'
   - title: Voidfall
-    bggId: 338111
+    bggId: 337627
     language: en
     pdfBlobKey: rulebooks/v1/voidfall_rulebook.pdf
     pdfSha256: 29847a547dcec0deac860cfb658cd3ea694dcaab319258fcf286c27161243157

--- a/apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/prod.yml
+++ b/apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/prod.yml
@@ -7577,7 +7577,7 @@ catalog:
     - Zvezda
     - 本长文化
   - title: 'Skytear: Arena of Legends'
-    bggId: 373106
+    bggId: 259061
     language: en
     pdfBlobKey: rulebooks/v1/skytear_rulebook.pdf
     pdfSha256: 2f316d16c5001b55097b9966c7c697bbde6a50e7e5c9b1c3df336ff5c3775960
@@ -8869,7 +8869,7 @@ catalog:
     pdfSha256: 31e496fdc97b9df7a8f38ccbd36561dc16265c142ff1cc3597fe6217f4707cc9
     pdfVersion: '1.0'
   - title: 'Great Western Trail: Argentina'
-    bggId: 380607
+    bggId: 364011
     language: en
     pdfBlobKey: rulebooks/v1/great-western-trail-argentina_rulebook.pdf
     pdfSha256: 88be4a0b83dda037566941e46d1e936ec6280c37e9860c0405a58a9bd412c2fa
@@ -9302,7 +9302,7 @@ catalog:
     pdfSha256: a43d7ee00276e963ea7afd327711cd52cee609712a8128e0f4a164290c2754d4
     pdfVersion: '1.0'
   - title: Voidfall
-    bggId: 338111
+    bggId: 337627
     language: en
     pdfBlobKey: rulebooks/v1/voidfall_rulebook.pdf
     pdfSha256: 29847a547dcec0deac860cfb658cd3ea694dcaab319258fcf286c27161243157

--- a/apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/staging.yml
+++ b/apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/staging.yml
@@ -7577,7 +7577,7 @@ catalog:
     - Zvezda
     - 本长文化
   - title: 'Skytear: Arena of Legends'
-    bggId: 373106
+    bggId: 259061
     language: en
     pdfBlobKey: rulebooks/v1/skytear_rulebook.pdf
     pdfSha256: 2f316d16c5001b55097b9966c7c697bbde6a50e7e5c9b1c3df336ff5c3775960
@@ -8869,7 +8869,7 @@ catalog:
     pdfSha256: 31e496fdc97b9df7a8f38ccbd36561dc16265c142ff1cc3597fe6217f4707cc9
     pdfVersion: '1.0'
   - title: 'Great Western Trail: Argentina'
-    bggId: 380607
+    bggId: 364011
     language: en
     pdfBlobKey: rulebooks/v1/great-western-trail-argentina_rulebook.pdf
     pdfSha256: 88be4a0b83dda037566941e46d1e936ec6280c37e9860c0405a58a9bd412c2fa
@@ -9302,7 +9302,7 @@ catalog:
     pdfSha256: a43d7ee00276e963ea7afd327711cd52cee609712a8128e0f4a164290c2754d4
     pdfVersion: '1.0'
   - title: Voidfall
-    bggId: 338111
+    bggId: 337627
     language: en
     pdfBlobKey: rulebooks/v1/voidfall_rulebook.pdf
     pdfSha256: 29847a547dcec0deac860cfb658cd3ea694dcaab319258fcf286c27161243157


### PR DESCRIPTION
## Problema

3 entry del catalogo in `dev.yml` (e — scoperto durante il fix — anche in `prod.yml` e `staging.yml`) avevano un `bggId` che puntava a un gioco **completamente diverso**. Il bake BGG-autenticato (Path B) fetchava quindi titolo + metadati del gioco sbagliato (latent data corruption nel catalogo + RAG); in CI senza BGG questi 3 restavano senza `description` ed esclusi dallo snapshot.

## Fix

| Gioco (manifest) | bggId prima → dopo | Verifica |
|---|---|---|
| Skytear: Arena of Legends | `373106` (*Sky Team*) → **`259061`** (*Skytear*) | "Arena of Legends" non esiste su BGG → base *Skytear*, coerente con `skytear_rulebook.pdf` |
| Great Western Trail: Argentina | `380607` (*GWT New Zealand*) → **`364011`** | [pagina BGG diretta](https://boardgamegeek.com/boardgame/364011/great-western-trail-argentina) |
| Voidfall | `338111` (*Naval War*) → **`337627`** | [pagina BGG diretta](https://boardgamegeek.com/boardgame/337627/voidfall) (Mindclash) |

Corretti in **dev.yml + prod.yml + staging.yml** (9 occorrenze). `ci.yml`/`e2e.yml` non contengono questi giochi.

> Nota: il suggerimento `380596` nell'issue per GWT Argentina era anch'esso errato; il valore reale verificato è `364011`.

## Validazione

- ✅ Diff = sole 9 righe `bggId`, nessun'altra modifica
- ✅ YAML parsabile (struttura `{profile, catalog}` intatta)
- ✅ Nuovi id univoci nel manifest (1 occorrenza ciascuno, nessuna collisione)
- ✅ Zero residui dei vecchi id errati

## Scope / follow-up

- **Description backfill (azione 3 dell'issue)**: le 3 entry non hanno `description` inline; il backfill era *bloccato* proprio dal bggId errato. Questo PR lo **sblocca** — la `description` corretta verrà popolata al prossimo bake (CI seed-bake o ri-bake locale).
- **Confidenza Skytear media**: `259061` (base *Skytear*) è la scelta più difendibile dato che "Arena of Legends" non è un titolo BGG; comunque nettamente migliore dello status quo (`373106` = *Sky Team*). Al bake, titolo e metadati vengono sovrascritti dai dati BGG dell'id.

Closes #2528

🤖 Generated with [Claude Code](https://claude.com/claude-code)