### PR TITLE
feat(observability): #2501 SP5-b — live-RAG observability completion (latency + counters + SLO)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentCommandHandler.cs
@@ -146,6 +146,10 @@ internal sealed class ChatWithSessionAgentCommandHandler : IStreamingQueryHandle
         ChatWithSessionAgentCommand command,
         [EnumeratorCancellation] CancellationToken cancellationToken)
     {
+        // SP5-b T2: measure wall-clock time from handler entry to first token.
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        var firstTokenRecorded = false;
+
         _logger.LogInformation(
             "Starting session agent chat for AgentSession {SessionId}, User {UserId}, Thread {ChatThreadId}",
             command.AgentSessionId, command.UserId, command.ChatThreadId);
@@ -380,6 +384,21 @@ internal sealed class ChatWithSessionAgentCommandHandler : IStreamingQueryHandle
             {
                 fullResponse.Append(chunk.Content);
                 yield return CreateEvent(StreamingEventType.Token, new StreamingToken(chunk.Content));
+
+                // SP5-b T2: record first-token latency AFTER the yield (metrics must not block/throw the stream).
+                // C# forbids yield inside try/catch — the try/catch wraps only the Record() call.
+                if (!firstTokenRecorded)
+                {
+                    try
+                    {
+                        MeepleAiMetrics.RagFirstTokenLatency.Record(sw.Elapsed.TotalMilliseconds);
+                    }
+                    catch (Exception ex)
+                    {
+                        _logger.LogDebug(ex, "SP5-b: RagFirstTokenLatency recording failed (metrics must not break the stream)");
+                    }
+                    firstTokenRecorded = true;
+                }
             }
 
             if (chunk.IsFinal)
@@ -555,6 +574,18 @@ internal sealed class ChatWithSessionAgentCommandHandler : IStreamingQueryHandle
             c.CopyrightTier.ToString().ToLowerInvariant(),
             c.ParaphrasedSnippet,
             c.IsPublic)).ToList();
+
+        // SP5-b T2: record citations-per-answer ONCE, post-stream, using citationDtos.Count
+        // (the broadcast-authoritative list — NOT the earlier assembled.Citations or resolvedCitations).
+        // try/catch: a metrics fault must NEVER abort the user's stream.
+        try
+        {
+            MeepleAiMetrics.RecordCitationsPerAnswer(citationDtos.Count);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogDebug(ex, "SP5-b: RagCitationsPerAnswer recording failed (metrics must not break the stream)");
+        }
 
         // SP2 T8 — Broadcast session:chat on the live-session stream (ADR-083).
         // Fires exactly once per completed chat, AFTER DB persist (DB is record-of-truth).

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/RagPromptAssemblyService.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/RagPromptAssemblyService.cs
@@ -282,6 +282,9 @@ internal sealed class RagPromptAssemblyService : IRagPromptAssemblyService
             if (filteredChunks.Count == 0)
             {
                 _logger.LogInformation("No chunks above minScore {MinScore} for game {GameId}", profile.MinScore, gameId);
+                // SP5-b T3: single-source detection site — increment counter here, NOT in the handler.
+                // Guarded: metrics must never abort the retrieval path.
+                try { MeepleAiMetrics.RecordRetrievalEmpty(); } catch { /* metrics must not break retrieval */ }
                 return (string.Empty, citations);
             }
 

--- a/apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.Rag.cs
+++ b/apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.Rag.cs
@@ -6,6 +6,46 @@ namespace Api.Observability;
 
 internal static partial class MeepleAiMetrics
 {
+    // === Issue #2582 SP5-b RAG Observability ===
+
+    /// <summary>
+    /// Counter incremented each time a RAG retrieval returns zero chunks.
+    /// Distinct from <see cref="RagRetrievalFallbacks"/> (which means "fallback fired").
+    /// NO tags — cardinality rule (no session/user labels).
+    /// </summary>
+    public static readonly Counter<long> RagRetrievalEmpty = Meter.CreateCounter<long>(
+        name: "meepleai.rag.retrieval_empty",
+        unit: "retrievals",
+        description: "Count of RAG retrievals that returned zero chunks");
+
+    /// <summary>
+    /// Histogram recording the number of citations included per RAG answer.
+    /// The <c>le=0</c> bucket captures grounded-but-uncited responses.
+    /// NO tags — cardinality rule (no session/user labels).
+    /// </summary>
+    public static readonly Histogram<long> RagCitationsPerAnswer = Meter.CreateHistogram<long>(
+        name: "meepleai.rag.citations_per_answer",
+        unit: "citations",
+        description: "Number of citations included per RAG answer");
+
+    /// <summary>
+    /// Records a RAG retrieval that returned zero chunks.
+    /// Call at the detection site — do NOT call inside a streaming yield block without a try/catch.
+    /// </summary>
+    public static void RecordRetrievalEmpty()
+    {
+        RagRetrievalEmpty.Add(1);
+    }
+
+    /// <summary>
+    /// Records the number of citations included in a RAG answer.
+    /// Call once, post-stream, using the final citation list count.
+    /// </summary>
+    public static void RecordCitationsPerAnswer(long count)
+    {
+        RagCitationsPerAnswer.Record(count);
+    }
+
     /// <summary>
     /// Counter for total RAG requests
     /// </summary>

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentMetricsTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentMetricsTests.cs
@@ -39,12 +39,14 @@ namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Commands;
 ///
 /// Tests:
 /// 1. <c>meepleai.rag.first_token_latency</c> is recorded EXACTLY once per streamed chat
-///    and the observation is ≥ 0 ms.
+///    (even when the LLM stream emits multiple content chunks — proves the once-only guard).
+///    Observation is ≥ 0 ms.
 /// 2. <c>meepleai.rag.citations_per_answer</c> is recorded EXACTLY once per streamed chat
 ///    with the correct citation count.
 /// 3. The zero-citation case records 0 (grounded-but-uncited signal).
-/// 4. A metrics fault (simulated via a broken instrument) does NOT abort the stream
-///    (streaming safety — the try/catch guard).
+/// 4. Both metrics are recorded in the same streamed request (end-to-end happy path).
+///    NOTE: streaming-safety under metrics fault (try/catch guard) is covered by
+///    SP5-b Task 4 (#2582 T4) — not in this file.
 ///
 /// Uses <see cref="MeterListener"/> to capture measurement events, mirroring
 /// <see cref="SseMetricsTests"/> and <see cref="RagObservabilityMetricsTests"/>.
@@ -365,10 +367,17 @@ public sealed class ChatWithSessionAgentMetricsTests
             liveSessionStreamGateway: gateway.Object);
     }
 
+    /// <summary>
+    /// Emits TWO content chunks followed by the final/usage chunk.
+    /// Two chunks are required so that the once-only guard (<c>if (!firstTokenRecorded)</c>)
+    /// is genuinely exercised: a regression that records on every token would produce 2
+    /// observations, causing <c>ContainSingle</c> to fail.
+    /// </summary>
     private static async IAsyncEnumerable<StreamChunk> CreateLlmStream(string content)
     {
         await Task.Yield();
-        yield return new StreamChunk(Content: content);
+        yield return new StreamChunk(Content: content);          // first token → records latency
+        yield return new StreamChunk(Content: content + " (2)"); // second token → guard must suppress
         yield return new StreamChunk(
             Content: null,
             Usage: new LlmUsage(10, 5, 15),

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentMetricsTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentMetricsTests.cs
@@ -1,0 +1,377 @@
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+using Api.BoundedContexts.Administration.Application.Services;
+using Api.BoundedContexts.GameManagement.Application.Services;
+using Api.BoundedContexts.GameManagement.Domain.Entities;
+using Api.BoundedContexts.GameManagement.Domain.Repositories;
+using Api.BoundedContexts.KnowledgeBase.Application.Commands;
+using Api.BoundedContexts.KnowledgeBase.Application.Models;
+using Api.BoundedContexts.KnowledgeBase.Application.Services;
+using Api.BoundedContexts.KnowledgeBase.Domain.Enums;
+using Api.BoundedContexts.KnowledgeBase.Domain.Entities;
+using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
+using Api.BoundedContexts.KnowledgeBase.Domain.Services;
+using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
+using Api.Models;
+using Api.Observability;
+using Api.Services;
+using Api.SharedKernel.Application;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Domain.ValueObjects;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+// Disambiguate UserTier from two namespaces
+using SharedUserTier = Api.SharedKernel.Domain.ValueObjects.UserTier;
+
+namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Commands;
+
+/// <summary>
+/// SP5-b T2 (Issue #2582): Verifies that <see cref="ChatWithSessionAgentCommandHandler"/>
+/// records the RAG first-token latency and citations-per-answer metrics inside the
+/// streaming handler.
+///
+/// Tests:
+/// 1. <c>meepleai.rag.first_token_latency</c> is recorded EXACTLY once per streamed chat
+///    and the observation is ≥ 0 ms.
+/// 2. <c>meepleai.rag.citations_per_answer</c> is recorded EXACTLY once per streamed chat
+///    with the correct citation count.
+/// 3. The zero-citation case records 0 (grounded-but-uncited signal).
+/// 4. A metrics fault (simulated via a broken instrument) does NOT abort the stream
+///    (streaming safety — the try/catch guard).
+///
+/// Uses <see cref="MeterListener"/> to capture measurement events, mirroring
+/// <see cref="SseMetricsTests"/> and <see cref="RagObservabilityMetricsTests"/>.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "KnowledgeBase")]
+[Trait("Area", "Observability")]
+[Trait("Issue", "2582")]
+public sealed class ChatWithSessionAgentMetricsTests
+{
+    private const string FirstTokenLatencyName = "meepleai.rag.first_token_latency";
+    private const string CitationsPerAnswerName = "meepleai.rag.citations_per_answer";
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // T2-AC-1: first-token latency recorded exactly once, value ≥ 0
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "T2-AC-1: first-token latency is recorded exactly once per streamed chat (≥ 0 ms)")]
+    public async Task Handle_StreamedChat_RecordsFirstTokenLatencyExactlyOnce()
+    {
+        // Arrange
+        var observations = new List<double>();
+        using var listener = BuildHistogramListener<double>(FirstTokenLatencyName, observations);
+
+        var handler = BuildHandler(resolvedCitations: new List<ChunkCitation>(), tokenContent: "Hello world");
+        var command = BuildCommand();
+
+        // Act — drain to completion
+        await foreach (var _ in handler.Handle(command, CancellationToken.None)) { }
+
+        // Assert — exactly one observation, ≥ 0 ms
+        observations.Should().ContainSingle(
+            "first-token latency must be recorded exactly once per request");
+        observations[0].Should().BeGreaterThanOrEqualTo(0d,
+            "elapsed time cannot be negative");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // T2-AC-2: citations-per-answer recorded once with correct count (non-zero)
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "T2-AC-2: citations-per-answer is recorded exactly once with the citation count")]
+    public async Task Handle_StreamedChatWithCitations_RecordsCitationCountExactlyOnce()
+    {
+        // Arrange — two Full-tier citations
+        var citations = new List<ChunkCitation>
+        {
+            new ChunkCitation(
+                DocumentId: "doc-1",
+                PageNumber: 1,
+                RelevanceScore: 0.9f,
+                SnippetPreview: "snippet A",
+                CopyrightTier: CopyrightTier.Full,
+                IsPublic: true),
+            new ChunkCitation(
+                DocumentId: "doc-2",
+                PageNumber: 2,
+                RelevanceScore: 0.8f,
+                SnippetPreview: "snippet B",
+                CopyrightTier: CopyrightTier.Full,
+                IsPublic: true),
+        };
+
+        var observations = new List<long>();
+        using var listener = BuildHistogramListener<long>(CitationsPerAnswerName, observations);
+
+        var handler = BuildHandler(resolvedCitations: citations, tokenContent: "Answer with citations");
+        var command = BuildCommand();
+
+        // Act
+        await foreach (var _ in handler.Handle(command, CancellationToken.None)) { }
+
+        // Assert
+        observations.Should().ContainSingle(
+            "citations-per-answer must be recorded exactly once per request");
+        observations[0].Should().Be(2L,
+            "two citations → observation must be 2");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // T2-AC-3: zero-citation case records 0 (grounded-but-uncited signal)
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "T2-AC-3: zero-citation case records 0 for citations-per-answer (le=0 bucket)")]
+    public async Task Handle_StreamedChatNoCitations_RecordsZeroCitationsPerAnswer()
+    {
+        // Arrange — no citations
+        var observations = new List<long>();
+        using var listener = BuildHistogramListener<long>(CitationsPerAnswerName, observations);
+
+        var handler = BuildHandler(resolvedCitations: new List<ChunkCitation>(), tokenContent: "Grounded but uncited");
+        var command = BuildCommand();
+
+        // Act
+        await foreach (var _ in handler.Handle(command, CancellationToken.None)) { }
+
+        // Assert
+        observations.Should().ContainSingle(
+            "citations-per-answer must be recorded exactly once even when there are no citations");
+        observations[0].Should().Be(0L,
+            "grounded-but-uncited signal: le=0 bucket must be populated");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // T2-AC-4: both metrics are recorded in the same request
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "T2-AC-4: both first-token latency and citations-per-answer are recorded in the same streamed chat")]
+    public async Task Handle_StreamedChat_RecordsBothMetrics()
+    {
+        // Arrange
+        var latencyObs = new List<double>();
+        var citationsObs = new List<long>();
+        using var latencyListener = BuildHistogramListener<double>(FirstTokenLatencyName, latencyObs);
+        using var citationsListener = BuildHistogramListener<long>(CitationsPerAnswerName, citationsObs);
+
+        var handler = BuildHandler(resolvedCitations: new List<ChunkCitation>(), tokenContent: "Token");
+        var command = BuildCommand();
+
+        // Act
+        await foreach (var _ in handler.Handle(command, CancellationToken.None)) { }
+
+        // Assert — both recorded
+        latencyObs.Should().ContainSingle("first-token latency must be recorded");
+        citationsObs.Should().ContainSingle("citations-per-answer must be recorded");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Helpers
+    // ──────────────────────────────────────────────────────────────────────────
+
+    private static MeterListener BuildHistogramListener<T>(string metricName, List<T> observations)
+        where T : struct
+    {
+        var listener = new MeterListener
+        {
+            InstrumentPublished = (instrument, l) =>
+            {
+                if (instrument.Meter.Name == MeepleAiMetrics.MeterName
+                    && instrument.Name == metricName)
+                {
+                    l.EnableMeasurementEvents(instrument);
+                }
+            },
+        };
+        listener.SetMeasurementEventCallback<T>((_, value, _, _) => observations.Add(value));
+        listener.Start();
+        return listener;
+    }
+
+    private static ChatWithSessionAgentCommand BuildCommand() =>
+        new ChatWithSessionAgentCommand(
+            AgentSessionId: Guid.NewGuid(),
+            UserQuestion: "What are the rules?",
+            UserId: Guid.NewGuid());
+
+    /// <summary>
+    /// Builds a fully-wired handler with happy-path mocks.
+    /// <paramref name="resolvedCitations"/> controls the citation list returned by the
+    /// copyright resolver. <paramref name="tokenContent"/> controls what the LLM emits.
+    /// </summary>
+    private static ChatWithSessionAgentCommandHandler BuildHandler(
+        IReadOnlyList<ChunkCitation> resolvedCitations,
+        string tokenContent = "Hello world")
+    {
+        // --- AgentSession repo ---
+        var playerId = Guid.NewGuid();
+        var initialState = GameState.Create(
+            currentTurn: 1,
+            activePlayer: playerId,
+            playerScores: new Dictionary<Guid, decimal> { [playerId] = 0 },
+            gamePhase: "Setup",
+            lastAction: "Game started");
+
+        var agentSession = new AgentSession(
+            id: Guid.NewGuid(),
+            agentDefinitionId: Guid.NewGuid(),
+            gameSessionId: Guid.NewGuid(),
+            userId: Guid.NewGuid(),
+            gameId: Guid.NewGuid(),
+            initialState: initialState);
+
+        var sessionRepo = new Mock<IAgentSessionRepository>();
+        sessionRepo
+            .Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(agentSession);
+
+        // --- AgentDefinition repo ---
+        var definition = AgentDefinition.Create(
+            name: "tutor",
+            description: "Test agent",
+            type: AgentType.Custom("tutor", "Tutor"),
+            config: AgentDefinitionConfig.Default());
+
+        var definitionRepo = new Mock<IAgentDefinitionRepository>();
+        definitionRepo
+            .Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(definition);
+
+        // --- Game core data ---
+        var gameCoreData = new Mock<IGameCoreDataProvider>();
+        gameCoreData
+            .Setup(g => g.GetCoreDataAsync(It.IsAny<GameRef>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((GameCoreData?)null);
+
+        // --- ChatThread repo: null → auto-create ---
+        var chatThreadRepo = new Mock<IChatThreadRepository>();
+        chatThreadRepo
+            .Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ChatThread?)null);
+        chatThreadRepo
+            .Setup(r => r.AddAsync(It.IsAny<ChatThread>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        chatThreadRepo
+            .Setup(r => r.UpdateAsync(It.IsAny<ChatThread>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        // --- LiveSession repo → null (no live session needed for metrics) ---
+        var liveSessionRepo = new Mock<ILiveSessionRepository>();
+        liveSessionRepo
+            .Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((LiveGameSession?)null);
+
+        // --- UoW ---
+        var unitOfWork = new Mock<IUnitOfWork>();
+        unitOfWork
+            .Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        // --- RAG prompt assembly → citations become the resolved set ---
+        var assembled = new AssembledPrompt(
+            SystemPrompt: "You are a helpful assistant.",
+            UserPrompt: "What are the rules?",
+            Citations: resolvedCitations.ToList(),
+            EstimatedTokens: 100);
+
+        var ragPromptService = new Mock<IRagPromptAssemblyService>();
+        ragPromptService
+            .Setup(r => r.AssemblePromptAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<GameState?>(),
+                It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<ChatThread?>(),
+                It.IsAny<SharedUserTier?>(), It.IsAny<string>(), It.IsAny<CancellationToken>(),
+                It.IsAny<IRagDebugEventCollector?>(), It.IsAny<RetrievalProfile?>()))
+            .ReturnsAsync(assembled);
+
+        // --- Copyright tier resolver → pass-through ---
+        var tierResolver = new Mock<ICopyrightTierResolver>();
+        tierResolver
+            .Setup(r => r.ResolveAsync(
+                It.IsAny<IReadOnlyList<ChunkCitation>>(),
+                It.IsAny<Guid>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(resolvedCitations);
+
+        // --- Agent memory context builder ---
+        var memoryBuilder = new Mock<IAgentMemoryContextBuilder>();
+        memoryBuilder
+            .Setup(b => b.BuildContextAsync(
+                It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<Guid?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string?)null);
+
+        // --- LLM service: one content token + final ---
+        var llmService = new Mock<ILlmService>();
+        llmService
+            .Setup(l => l.GenerateCompletionStreamAsync(
+                It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<RequestSource>(), It.IsAny<CancellationToken>()))
+            .Returns(CreateLlmStream(tokenContent));
+
+        // --- Budget service ---
+        var budgetService = new Mock<IUserBudgetService>();
+        budgetService
+            .Setup(b => b.HasBudgetForQueryAsync(
+                It.IsAny<Guid>(), It.IsAny<decimal>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        // --- Circuit breaker ---
+        var registry = new Mock<ICircuitBreakerRegistry>();
+        registry
+            .Setup(r => r.GetMonitoringStatus())
+            .Returns(new Dictionary<string, (string, string)>());
+
+        // --- ServiceScopeFactory (chunk usage increment fire-and-forget) ---
+        var scopeFactory = new Mock<IServiceScopeFactory>();
+
+        // --- Copyright leak guard (no leak) ---
+        var noLeak = new CopyrightLeakResult(HasLeak: false, Matches: Array.Empty<LeakMatch>());
+        var leakGuard = new Mock<ICopyrightLeakGuard>();
+        leakGuard
+            .Setup(g => g.ScanAsync(
+                It.IsAny<string>(), It.IsAny<IReadOnlyList<ChunkCitation>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(noLeak);
+
+        var fallbackProvider = new Mock<ICopyrightFallbackMessageProvider>();
+
+        var gateway = new Mock<ILiveSessionStreamGateway>();
+
+        return new ChatWithSessionAgentCommandHandler(
+            sessionRepository: sessionRepo.Object,
+            definitionRepository: definitionRepo.Object,
+            chatThreadRepository: chatThreadRepo.Object,
+            gameCoreData: gameCoreData.Object,
+            liveSessionRepository: liveSessionRepo.Object,
+            unitOfWork: unitOfWork.Object,
+            ragPromptService: ragPromptService.Object,
+            copyrightTierResolver: tierResolver.Object,
+            agentMemoryContextBuilder: memoryBuilder.Object,
+            llmService: llmService.Object,
+            userBudgetService: budgetService.Object,
+            circuitBreakerRegistry: registry.Object,
+            scopeFactory: scopeFactory.Object,
+            logger: NullLogger<ChatWithSessionAgentCommandHandler>.Instance,
+            copyrightLeakGuard: leakGuard.Object,
+            fallbackMessageProvider: fallbackProvider.Object,
+            copyrightOptions: Options.Create(new CopyrightLeakGuardOptions()),
+            liveSessionStreamGateway: gateway.Object);
+    }
+
+    private static async IAsyncEnumerable<StreamChunk> CreateLlmStream(string content)
+    {
+        await Task.Yield();
+        yield return new StreamChunk(Content: content);
+        yield return new StreamChunk(
+            Content: null,
+            Usage: new LlmUsage(10, 5, 15),
+            IsFinal: true);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentStreamingSafetyTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentStreamingSafetyTests.cs
@@ -1,0 +1,439 @@
+using System.Collections.Generic;
+using System.Diagnostics.Metrics;
+using System.Threading;
+using Api.BoundedContexts.Administration.Application.Services;
+using Api.BoundedContexts.GameManagement.Application.Services;
+using Api.BoundedContexts.GameManagement.Domain.Entities;
+using Api.BoundedContexts.GameManagement.Domain.Repositories;
+using Api.BoundedContexts.KnowledgeBase.Application.Commands;
+using Api.BoundedContexts.KnowledgeBase.Application.Models;
+using Api.BoundedContexts.KnowledgeBase.Application.Services;
+using Api.BoundedContexts.KnowledgeBase.Domain.Enums;
+using Api.BoundedContexts.KnowledgeBase.Domain.Entities;
+using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
+using Api.BoundedContexts.KnowledgeBase.Domain.Services;
+using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
+using Api.Models;
+using Api.Observability;
+using Api.Services;
+using Api.SharedKernel.Application;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Domain.ValueObjects;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+// Disambiguate UserTier from two namespaces
+using SharedUserTier = Api.SharedKernel.Domain.ValueObjects.UserTier;
+
+namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Commands;
+
+/// <summary>
+/// SP5-b T4 (Issue #2582): Streaming-safety regression tests.
+///
+/// GUARANTEE: a metrics <c>Record()</c> / <c>Add()</c> fault inside
+/// <see cref="ChatWithSessionAgentCommandHandler"/> MUST NOT abort the user's
+/// live-chat stream.  The handler wraps every Record() call in try/catch — these
+/// tests lock in that contract so a future refactor cannot silently remove the guard.
+///
+/// Fault-injection mechanism
+/// ─────────────────────────
+/// <see cref="MeterListener.SetMeasurementEventCallback{T}"/> fires SYNCHRONOUSLY
+/// when an instrument's <c>Record()</c> or <c>Add()</c> is called.  When the
+/// callback throws, the exception propagates back to the caller's <c>Record()</c>
+/// site.  This is the standard .NET SDK mechanism; no special interception layer is
+/// needed.  T4-AC-4 (probe) empirically confirms the mechanism works before the
+/// integration tests rely on it.
+///
+/// Tests
+/// ─────
+/// T4-AC-4  probe: confirms the MeterListener-throws mechanism actually propagates to Record()
+/// T4-AC-1  first-token latency fault  → stream reaches StreamingComplete, no exception escapes
+/// T4-AC-2  citations-per-answer fault → stream reaches StreamingComplete, no exception escapes
+/// T4-AC-3  both metrics fault simultaneously → stream reaches StreamingComplete, no exception escapes
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "KnowledgeBase")]
+[Trait("Area", "Observability")]
+[Trait("Issue", "2582")]
+public sealed class ChatWithSessionAgentStreamingSafetyTests
+{
+    private const string FirstTokenLatencyName = "meepleai.rag.first_token_latency";
+    private const string CitationsPerAnswerName = "meepleai.rag.citations_per_answer";
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // T4-AC-4 (probe): verify the fault-injection mechanism is real, not a no-op
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "T4-AC-4 (probe): MeterListener throwing callback propagates exception to Record() call site")]
+    public void MeterListenerThrowingCallback_PropagatesExceptionToRecordCallSite()
+    {
+        // Use an isolated meter so this probe doesn't interfere with shared instruments.
+        using var probeMeter = new Meter("Test.StreamingSafety.Probe", "1.0.0");
+        var probeHistogram = probeMeter.CreateHistogram<double>("probe.histogram");
+
+        var counter = new int[1]; // array so lambda can mutate
+        using var listener = new MeterListener
+        {
+            InstrumentPublished = (instrument, l) =>
+            {
+                if (instrument.Meter.Name == "Test.StreamingSafety.Probe"
+                    && instrument.Name == "probe.histogram")
+                {
+                    l.EnableMeasurementEvents(instrument);
+                }
+            },
+        };
+        listener.SetMeasurementEventCallback<double>((_, _, _, _) =>
+        {
+            Interlocked.Increment(ref counter[0]);
+            throw new InvalidOperationException("Simulated metric fault (probe)");
+        });
+        listener.Start();
+
+        // Record() MUST propagate the callback exception
+        var act = () => probeHistogram.Record(42.0);
+        act.Should().Throw<InvalidOperationException>(
+            "MeterListener callback exceptions propagate synchronously to the Record() call site");
+
+        counter[0].Should().Be(1,
+            "the throwing callback must have been invoked exactly once during the probe");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // T4-AC-1: first-token latency metric THROWS → stream still completes
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "T4-AC-1: first-token latency metric fault does not abort the live chat stream")]
+    public async Task Handle_FirstTokenLatencyRecordThrows_StreamStillCompletesNoExceptionEscapes()
+    {
+        // Arrange — listener whose callback throws on first-token latency
+        var faultCounter = new int[1];
+        using var faultListener = BuildThrowingListener<double>(FirstTokenLatencyName, faultCounter);
+
+        var handler = BuildHandler(resolvedCitations: new List<ChunkCitation>(), tokenContent: "Hello");
+        var command = BuildCommand();
+
+        var events = new List<RagStreamingEvent>();
+
+        // Act — drain entire stream; MUST NOT throw
+        var act = async () =>
+        {
+            await foreach (var ev in handler.Handle(command, CancellationToken.None))
+            {
+                events.Add(ev);
+            }
+        };
+
+        await act.Should().NotThrowAsync(
+            "a metrics Record() fault must never abort the user's live-chat stream");
+
+        // Assert: stream reached StreamingComplete
+        events.Should().Contain(
+            e => e.Type == StreamingEventType.Complete,
+            "StreamingComplete must be yielded even when the first-token latency metric fault is injected");
+
+        // Assert: fault path was genuinely triggered (try/catch caught a REAL throw)
+        faultCounter[0].Should().BeGreaterThan(0,
+            "the throwing MeterListener callback must have been invoked, proving the try/catch caught a real throw");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // T4-AC-2: citations-per-answer metric THROWS → stream still completes
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "T4-AC-2: citations-per-answer metric fault does not abort the live chat stream")]
+    public async Task Handle_CitationsPerAnswerRecordThrows_StreamStillCompletesNoExceptionEscapes()
+    {
+        // Arrange — listener whose callback throws on citations-per-answer
+        var faultCounter = new int[1];
+        using var faultListener = BuildThrowingListener<long>(CitationsPerAnswerName, faultCounter);
+
+        var citations = new List<ChunkCitation>
+        {
+            new ChunkCitation(
+                DocumentId: "doc-1",
+                PageNumber: 1,
+                RelevanceScore: 0.9f,
+                SnippetPreview: "snippet",
+                CopyrightTier: CopyrightTier.Full,
+                IsPublic: true),
+        };
+
+        var handler = BuildHandler(resolvedCitations: citations, tokenContent: "Answer");
+        var command = BuildCommand();
+
+        var events = new List<RagStreamingEvent>();
+
+        // Act — drain; MUST NOT throw
+        var act = async () =>
+        {
+            await foreach (var ev in handler.Handle(command, CancellationToken.None))
+            {
+                events.Add(ev);
+            }
+        };
+
+        await act.Should().NotThrowAsync(
+            "a citations metric Record() fault must never abort the user's live-chat stream");
+
+        // Assert: stream reached StreamingComplete
+        events.Should().Contain(
+            e => e.Type == StreamingEventType.Complete,
+            "StreamingComplete must be yielded even when the citations-per-answer metric fault is injected");
+
+        // Assert: fault path was genuinely triggered
+        faultCounter[0].Should().BeGreaterThan(0,
+            "the throwing MeterListener callback must have been invoked, proving the try/catch caught a real throw");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // T4-AC-3: BOTH metrics throw simultaneously → stream still completes
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "T4-AC-3: both first-token AND citations metric faults do not abort the live chat stream")]
+    public async Task Handle_BothMetricsRecordThrow_StreamStillCompletesNoExceptionEscapes()
+    {
+        // Arrange — two throwing listeners, one per metric
+        var latencyFaultCounter = new int[1];
+        var citationsFaultCounter = new int[1];
+
+        using var latencyFault = BuildThrowingListener<double>(FirstTokenLatencyName, latencyFaultCounter);
+        using var citationsFault = BuildThrowingListener<long>(CitationsPerAnswerName, citationsFaultCounter);
+
+        var handler = BuildHandler(resolvedCitations: new List<ChunkCitation>(), tokenContent: "Hi");
+        var command = BuildCommand();
+
+        var events = new List<RagStreamingEvent>();
+
+        // Act — drain; MUST NOT throw
+        var act = async () =>
+        {
+            await foreach (var ev in handler.Handle(command, CancellationToken.None))
+            {
+                events.Add(ev);
+            }
+        };
+
+        await act.Should().NotThrowAsync(
+            "simultaneous metric faults must never abort the user's live-chat stream");
+
+        // Assert: stream reached StreamingComplete
+        events.Should().Contain(
+            e => e.Type == StreamingEventType.Complete,
+            "StreamingComplete must be yielded despite both metric faults being injected");
+
+        // Assert: BOTH fault paths were genuinely exercised
+        latencyFaultCounter[0].Should().BeGreaterThan(0,
+            "first-token latency throwing callback must have been invoked");
+        citationsFaultCounter[0].Should().BeGreaterThan(0,
+            "citations-per-answer throwing callback must have been invoked");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Helpers
+    // ──────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Builds a <see cref="MeterListener"/> whose measurement callback:
+    /// 1. Atomically increments <paramref name="invokeCounter"/>[0] (so callers can
+    ///    assert the fault path was genuinely exercised).
+    /// 2. Throws <see cref="InvalidOperationException"/> (propagates to <c>Record()</c>).
+    ///
+    /// Array trick: C# forbids capturing ref locals in lambdas, so we use a single-element
+    /// int[] as a mutable box that the lambda can close over.
+    /// </summary>
+    private static MeterListener BuildThrowingListener<T>(string metricName, int[] invokeCounter)
+        where T : struct
+    {
+        var listener = new MeterListener
+        {
+            InstrumentPublished = (instrument, l) =>
+            {
+                if (instrument.Meter.Name == MeepleAiMetrics.MeterName
+                    && instrument.Name == metricName)
+                {
+                    l.EnableMeasurementEvents(instrument);
+                }
+            },
+        };
+        listener.SetMeasurementEventCallback<T>((_, _, _, _) =>
+        {
+            Interlocked.Increment(ref invokeCounter[0]);
+            throw new InvalidOperationException($"Simulated metric fault for '{metricName}'");
+        });
+        listener.Start();
+        return listener;
+    }
+
+    private static ChatWithSessionAgentCommand BuildCommand() =>
+        new ChatWithSessionAgentCommand(
+            AgentSessionId: Guid.NewGuid(),
+            UserQuestion: "What are the rules?",
+            UserId: Guid.NewGuid());
+
+    /// <summary>
+    /// Builds a fully-wired handler with happy-path mocks, identical to the setup
+    /// in <see cref="ChatWithSessionAgentMetricsTests"/> — copied here to keep the
+    /// streaming-safety tests self-contained and avoid cross-test class coupling.
+    /// </summary>
+    private static ChatWithSessionAgentCommandHandler BuildHandler(
+        IReadOnlyList<ChunkCitation> resolvedCitations,
+        string tokenContent = "Hello world")
+    {
+        var playerId = Guid.NewGuid();
+        var initialState = GameState.Create(
+            currentTurn: 1,
+            activePlayer: playerId,
+            playerScores: new Dictionary<Guid, decimal> { [playerId] = 0 },
+            gamePhase: "Setup",
+            lastAction: "Game started");
+
+        var agentSession = new AgentSession(
+            id: Guid.NewGuid(),
+            agentDefinitionId: Guid.NewGuid(),
+            gameSessionId: Guid.NewGuid(),
+            userId: Guid.NewGuid(),
+            gameId: Guid.NewGuid(),
+            initialState: initialState);
+
+        var sessionRepo = new Mock<IAgentSessionRepository>();
+        sessionRepo
+            .Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(agentSession);
+
+        var definition = AgentDefinition.Create(
+            name: "tutor",
+            description: "Test agent",
+            type: AgentType.Custom("tutor", "Tutor"),
+            config: AgentDefinitionConfig.Default());
+
+        var definitionRepo = new Mock<IAgentDefinitionRepository>();
+        definitionRepo
+            .Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(definition);
+
+        var gameCoreData = new Mock<IGameCoreDataProvider>();
+        gameCoreData
+            .Setup(g => g.GetCoreDataAsync(It.IsAny<GameRef>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((GameCoreData?)null);
+
+        var chatThreadRepo = new Mock<IChatThreadRepository>();
+        chatThreadRepo
+            .Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ChatThread?)null);
+        chatThreadRepo
+            .Setup(r => r.AddAsync(It.IsAny<ChatThread>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        chatThreadRepo
+            .Setup(r => r.UpdateAsync(It.IsAny<ChatThread>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var liveSessionRepo = new Mock<ILiveSessionRepository>();
+        liveSessionRepo
+            .Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((LiveGameSession?)null);
+
+        var unitOfWork = new Mock<IUnitOfWork>();
+        unitOfWork
+            .Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        var assembled = new AssembledPrompt(
+            SystemPrompt: "You are a helpful assistant.",
+            UserPrompt: "What are the rules?",
+            Citations: resolvedCitations.ToList(),
+            EstimatedTokens: 100);
+
+        var ragPromptService = new Mock<IRagPromptAssemblyService>();
+        ragPromptService
+            .Setup(r => r.AssemblePromptAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<GameState?>(),
+                It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<ChatThread?>(),
+                It.IsAny<SharedUserTier?>(), It.IsAny<string>(), It.IsAny<CancellationToken>(),
+                It.IsAny<IRagDebugEventCollector?>(), It.IsAny<RetrievalProfile?>()))
+            .ReturnsAsync(assembled);
+
+        var tierResolver = new Mock<ICopyrightTierResolver>();
+        tierResolver
+            .Setup(r => r.ResolveAsync(
+                It.IsAny<IReadOnlyList<ChunkCitation>>(),
+                It.IsAny<Guid>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(resolvedCitations);
+
+        var memoryBuilder = new Mock<IAgentMemoryContextBuilder>();
+        memoryBuilder
+            .Setup(b => b.BuildContextAsync(
+                It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<Guid?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string?)null);
+
+        var llmService = new Mock<ILlmService>();
+        llmService
+            .Setup(l => l.GenerateCompletionStreamAsync(
+                It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<RequestSource>(), It.IsAny<CancellationToken>()))
+            .Returns(CreateLlmStream(tokenContent));
+
+        var budgetService = new Mock<IUserBudgetService>();
+        budgetService
+            .Setup(b => b.HasBudgetForQueryAsync(
+                It.IsAny<Guid>(), It.IsAny<decimal>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var registry = new Mock<ICircuitBreakerRegistry>();
+        registry
+            .Setup(r => r.GetMonitoringStatus())
+            .Returns(new Dictionary<string, (string, string)>());
+
+        var scopeFactory = new Mock<IServiceScopeFactory>();
+
+        var noLeak = new CopyrightLeakResult(HasLeak: false, Matches: Array.Empty<LeakMatch>());
+        var leakGuard = new Mock<ICopyrightLeakGuard>();
+        leakGuard
+            .Setup(g => g.ScanAsync(
+                It.IsAny<string>(), It.IsAny<IReadOnlyList<ChunkCitation>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(noLeak);
+
+        var fallbackProvider = new Mock<ICopyrightFallbackMessageProvider>();
+        var gateway = new Mock<ILiveSessionStreamGateway>();
+
+        return new ChatWithSessionAgentCommandHandler(
+            sessionRepository: sessionRepo.Object,
+            definitionRepository: definitionRepo.Object,
+            chatThreadRepository: chatThreadRepo.Object,
+            gameCoreData: gameCoreData.Object,
+            liveSessionRepository: liveSessionRepo.Object,
+            unitOfWork: unitOfWork.Object,
+            ragPromptService: ragPromptService.Object,
+            copyrightTierResolver: tierResolver.Object,
+            agentMemoryContextBuilder: memoryBuilder.Object,
+            llmService: llmService.Object,
+            userBudgetService: budgetService.Object,
+            circuitBreakerRegistry: registry.Object,
+            scopeFactory: scopeFactory.Object,
+            logger: NullLogger<ChatWithSessionAgentCommandHandler>.Instance,
+            copyrightLeakGuard: leakGuard.Object,
+            fallbackMessageProvider: fallbackProvider.Object,
+            copyrightOptions: Options.Create(new CopyrightLeakGuardOptions()),
+            liveSessionStreamGateway: gateway.Object);
+    }
+
+    private static async IAsyncEnumerable<StreamChunk> CreateLlmStream(string content)
+    {
+        await Task.Yield();
+        yield return new StreamChunk(Content: content);           // first token → triggers latency metric
+        yield return new StreamChunk(Content: content + " (2)"); // second chunk → once-only guard tested
+        yield return new StreamChunk(
+            Content: null,
+            Usage: new LlmUsage(10, 5, 15),
+            IsFinal: true);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/RagPromptAssemblyServiceRetrievalEmptyMetricsTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/RagPromptAssemblyServiceRetrievalEmptyMetricsTests.cs
@@ -1,0 +1,254 @@
+using System.Diagnostics.Metrics;
+using Api.BoundedContexts.KnowledgeBase.Application.Models;
+using Api.BoundedContexts.KnowledgeBase.Application.Services;
+using Api.BoundedContexts.KnowledgeBase.Domain.Enums;
+using Api.BoundedContexts.KnowledgeBase.Domain.Services.Enhancements;
+using Api.BoundedContexts.KnowledgeBase.Domain.Services.Reranking;
+using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
+using Api.Models;
+using Api.Observability;
+using Api.Services;
+using Api.SharedKernel.Domain.ValueObjects;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+using SearchResultItem = Api.Services.SearchResultItem;
+
+namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Services;
+
+/// <summary>
+/// SP5-b T3 — Verifies that <c>meepleai.rag.retrieval_empty</c> is incremented by 1
+/// at the single detection site in <see cref="RagPromptAssemblyService.RetrieveRagContextAsync"/>
+/// (<c>if (filteredChunks.Count == 0)</c>), and NOT incremented when chunks are present.
+///
+/// Single-source guarantee: the handler (<c>ChatWithSessionAgentCommandHandler</c>) does NOT
+/// call <see cref="MeepleAiMetrics.RecordRetrievalEmpty"/>; only the service does.
+/// </summary>
+/// <remarks>
+/// The [Collection] attribute serializes these tests to prevent a parallel T3-AC-1
+/// (which fires the global counter) from contaminating the T3-AC-2 "must NOT fire" assertion.
+/// </remarks>
+[Collection("RetrievalEmptyMetrics")]
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "KnowledgeBase")]
+[Trait("Area", "Observability")]
+[Trait("Issue", "2582")]
+public class RagPromptAssemblyServiceRetrievalEmptyMetricsTests
+{
+    private const string CounterName = "meepleai.rag.retrieval_empty";
+
+    private readonly Mock<IEmbeddingService> _embeddingMock = new();
+    private readonly Mock<ICrossEncoderReranker> _rerankerMock = new();
+    private readonly Mock<ILlmService> _llmMock = new();
+    private readonly Mock<ITextChunkSearchService> _textSearchMock = new();
+    private readonly Mock<IExpansionGameResolver> _expansionResolverMock = new();
+    private readonly Mock<IRagEnhancementService> _ragEnhancementMock = new();
+    private readonly Mock<IQueryComplexityClassifier> _complexityClassifierMock = new();
+    private readonly Mock<IRetrievalRelevanceEvaluator> _relevanceEvaluatorMock = new();
+    private readonly Mock<IQueryExpander> _queryExpanderMock = new();
+    private readonly Mock<IGraphRetrievalService> _graphRetrievalMock = new();
+    private readonly Mock<ILogger<RagPromptAssemblyService>> _loggerMock = new();
+
+    private static readonly Guid TestGameId = Guid.NewGuid();
+    private static readonly float[] TestEmbedding = [0.1f, 0.2f, 0.3f];
+
+    public RagPromptAssemblyServiceRetrievalEmptyMetricsTests()
+    {
+        _llmMock
+            .Setup(l => l.GenerateCompletionAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<RequestSource>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new LlmCompletionResult { Success = false });
+
+        _expansionResolverMock
+            .Setup(r => r.GetExpansionGameIdsAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<Guid>());
+
+        _ragEnhancementMock
+            .Setup(r => r.GetActiveEnhancementsAsync(It.IsAny<UserTier>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(RagEnhancement.None);
+
+        SetupSuccessfulEmbedding();
+    }
+
+    private RagPromptAssemblyService CreateService()
+    {
+        return new RagPromptAssemblyService(
+            _embeddingMock.Object,
+            _rerankerMock.Object,
+            _llmMock.Object,
+            _textSearchMock.Object,
+            _expansionResolverMock.Object,
+            _ragEnhancementMock.Object,
+            _complexityClassifierMock.Object,
+            _relevanceEvaluatorMock.Object,
+            _queryExpanderMock.Object,
+            _graphRetrievalMock.Object,
+            _loggerMock.Object);
+    }
+
+    /// <summary>
+    /// MeterListener capture scoped to <c>meepleai.rag.retrieval_empty</c>.
+    /// Uses tolerant Contain() assertion (global static counter may fire from concurrent tests).
+    /// </summary>
+    private sealed class RetrievalEmptyCapture : IDisposable
+    {
+        private readonly MeterListener _listener;
+        public List<long> Measurements { get; } = new();
+
+        public RetrievalEmptyCapture()
+        {
+            _listener = new MeterListener
+            {
+                InstrumentPublished = (instrument, l) =>
+                {
+                    if (instrument.Meter.Name == MeepleAiMetrics.MeterName
+                        && instrument.Name == CounterName)
+                    {
+                        l.EnableMeasurementEvents(instrument);
+                    }
+                }
+            };
+            _listener.SetMeasurementEventCallback<long>((_, value, _, _) => Measurements.Add(value));
+            _listener.Start();
+        }
+
+        public void Dispose() => _listener.Dispose();
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // T3-AC-1: zero chunks → counter increments
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "T3-AC-1: retrieval_empty increments by 1 when retrieval returns zero chunks")]
+    public async Task WhenRetrievalReturnsZeroChunks_RetrievalEmptyCounterIncrements()
+    {
+        // Arrange — FTS returns empty list → allChunks stays empty → filteredChunks.Count == 0
+        SetupEmptyTextSearch();
+        using var capture = new RetrievalEmptyCapture();
+        var service = CreateService();
+
+        // Act
+        var result = await service.AssemblePromptAsync(
+            "tutor", "Chess", null, "How do pawns move?",
+            TestGameId, null, null, "it", CancellationToken.None);
+
+        // Assert — returned fallback prompt (expected for empty context) AND counter fired
+        result.Should().NotBeNull();
+        result.Citations.Should().BeEmpty("no chunks means no citations");
+        capture.Measurements.Should().Contain(1L,
+            "meepleai.rag.retrieval_empty must fire Add(1) when filteredChunks.Count == 0");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // T3-AC-2: non-empty chunks → counter does NOT increment
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "T3-AC-2: retrieval_empty does NOT increment when retrieval returns chunks")]
+    public async Task WhenRetrievalReturnsChunks_RetrievalEmptyCounterDoesNotIncrement()
+    {
+        // Arrange — FTS returns chunks with scores above MinScore=0 (profileOverride).
+        // With MinScore=0, RRF-normalised chunks survive the score filter.
+        SetupTextSearchResults(
+            CreateChunk(Guid.NewGuid().ToString(), 0, 0.95f, "Pawns move forward one square."));
+        SetupRerankerPassthrough();
+        var service = CreateService();
+
+        // Arrange — bool flag toggled by listener while the call is in flight.
+        // We track whether ANY measurement fired during the invocation window.
+        bool counterFiredDuringCall = false;
+        using var listener = new MeterListener
+        {
+            InstrumentPublished = (instrument, l) =>
+            {
+                if (instrument.Meter.Name == MeepleAiMetrics.MeterName
+                    && instrument.Name == CounterName)
+                {
+                    l.EnableMeasurementEvents(instrument);
+                }
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((_, _, _, _) => counterFiredDuringCall = true);
+        listener.Start();
+
+        // Act — use MinScore=0 so the chunk survives the score filter
+        await service.AssemblePromptAsync(
+            "tutor", "Chess", null, "How do pawns move?",
+            TestGameId, null, null, "it", CancellationToken.None,
+            profileOverride: new RetrievalProfile(TopK: 5, MinScore: 0f, FtsTopK: 10, WindowRadius: 1));
+
+        listener.Dispose();
+
+        // Assert — the listener was active only for the duration of this call.
+        // Parallel tests on the global counter are a known concern; however, the
+        // test class name is unique to this suite and T3-AC-1 uses a separate Capture
+        // instance. The listener is disposed immediately after Act, minimising the window.
+        // If this assertion is flaky under heavy parallelism it is an environmental issue,
+        // not a code defect — documented here per SP5-b cardinality rules.
+        counterFiredDuringCall.Should().BeFalse(
+            "meepleai.rag.retrieval_empty must NOT fire when filteredChunks.Count > 0");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Setup helpers (mirror FallbackMetricsTests)
+    // ──────────────────────────────────────────────────────────────────────────
+
+    private void SetupSuccessfulEmbedding()
+    {
+        _embeddingMock
+            .Setup(e => e.GenerateEmbeddingAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(EmbeddingResult.CreateSuccess([TestEmbedding]));
+    }
+
+    private void SetupEmptyTextSearch()
+    {
+        _textSearchMock
+            .Setup(t => t.FullTextSearchAsync(
+                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<int>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<TextChunkMatch>());
+    }
+
+    private void SetupTextSearchResults(params SearchResultItem[] items)
+    {
+        var ftsResults = items.Select(i => new TextChunkMatch(
+            PdfDocumentId: Guid.TryParse(i.PdfId, out var pid) ? pid : Guid.NewGuid(),
+            Content: i.Text,
+            ChunkIndex: i.ChunkIndex,
+            PageNumber: i.Page,
+            Rank: i.Score)).ToList();
+        _textSearchMock
+            .Setup(t => t.FullTextSearchAsync(
+                It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<int>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ftsResults);
+    }
+
+    private void SetupRerankerPassthrough()
+    {
+        _rerankerMock
+            .Setup(r => r.RerankAsync(
+                It.IsAny<string>(), It.IsAny<IReadOnlyList<RerankChunk>>(),
+                It.IsAny<int?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string _, IReadOnlyList<RerankChunk> chunks, int? topK, CancellationToken _) =>
+            {
+                var reranked = chunks.Take(topK ?? chunks.Count)
+                    .Select((c, i) => new RerankedChunk(c.Id, c.Content, 0.9 - (i * 0.1), c.OriginalScore))
+                    .ToList();
+                return new RerankResult(reranked, "test-model", 10.0);
+            });
+    }
+
+    private static SearchResultItem CreateChunk(string pdfId, int chunkIndex, float score, string text = "Rule text", int page = 1)
+    {
+        return new SearchResultItem
+        {
+            Score = score,
+            Text = text,
+            PdfId = pdfId,
+            Page = page,
+            ChunkIndex = chunkIndex
+        };
+    }
+}

--- a/apps/api/tests/Api.Tests/Observability/RagObservabilityMetricsTests.cs
+++ b/apps/api/tests/Api.Tests/Observability/RagObservabilityMetricsTests.cs
@@ -1,0 +1,146 @@
+using System.Diagnostics.Metrics;
+using Api.Observability;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.Observability;
+
+/// <summary>
+/// Unit tests for SP5-b RAG observability metrics (Issue #2582):
+///   - <c>meepleai.rag.retrieval_empty</c> (<see cref="MeepleAiMetrics.RagRetrievalEmpty"/>, Counter&lt;long&gt;)
+///   - <c>meepleai.rag.citations_per_answer</c> (<see cref="MeepleAiMetrics.RagCitationsPerAnswer"/>, Histogram&lt;long&gt;)
+/// </summary>
+/// <remarks>
+/// Pattern mirrors <see cref="SseMetricsTests"/> (MeterListener-based capture, lines 88-105):
+/// InstrumentPublished callback + SetMeasurementEventCallback + Start/RecordObservableInstruments.
+/// No tags on either metric — cardinality rule (no session/user labels).
+/// <see cref="MeepleAiMetrics.RagFirstTokenLatency"/> is intentionally NOT tested here; it is
+/// declared in MeepleAiMetrics.Rag.cs:38-41 and will be wired in a subsequent task.
+/// </remarks>
+[Collection("RagObservabilityMetrics")]
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "Observability")]
+[Trait("Issue", "2582")]
+public sealed class RagObservabilityMetricsTests
+{
+    // ──────────────────────────────────────────────────────────────────────────
+    // RagRetrievalEmpty: naming
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "RagRetrievalEmpty metric name matches SP5-b contract")]
+    public void RagRetrievalEmpty_Name_MatchesSp5bContract()
+    {
+        MeepleAiMetrics.RagRetrievalEmpty.Name
+            .Should().Be("meepleai.rag.retrieval_empty");
+    }
+
+    [Fact(DisplayName = "RagRetrievalEmpty is a Counter<long>")]
+    public void RagRetrievalEmpty_IsCounterOfLong()
+    {
+        MeepleAiMetrics.RagRetrievalEmpty.Should().BeOfType<Counter<long>>();
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // RagRetrievalEmpty: recording via MeterListener
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "RecordRetrievalEmpty increments counter and is observable via MeterListener")]
+    public void RecordRetrievalEmpty_IncrementsCounterAndIsObservable()
+    {
+        // Capture Add() measurements fired by OUR call only (shared global counter — tolerant assertion).
+        var measurements = new List<long>();
+        using var listener = new MeterListener
+        {
+            InstrumentPublished = (instrument, l) =>
+            {
+                if (instrument.Name == "meepleai.rag.retrieval_empty")
+                    l.EnableMeasurementEvents(instrument);
+            },
+        };
+        listener.SetMeasurementEventCallback<long>((_, value, _, _) => measurements.Add(value));
+        listener.Start();
+
+        MeepleAiMetrics.RecordRetrievalEmpty();
+
+        // Tolerant: concurrent tests on the same global counter may add values.
+        // We only assert that OUR Add(1) call flowed through the listener.
+        measurements.Should().Contain(1L,
+            "RecordRetrievalEmpty must emit one Add(1) measurement");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // RagCitationsPerAnswer: naming
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "RagCitationsPerAnswer metric name matches SP5-b contract")]
+    public void RagCitationsPerAnswer_Name_MatchesSp5bContract()
+    {
+        MeepleAiMetrics.RagCitationsPerAnswer.Name
+            .Should().Be("meepleai.rag.citations_per_answer");
+    }
+
+    [Fact(DisplayName = "RagCitationsPerAnswer is a Histogram<long>")]
+    public void RagCitationsPerAnswer_IsHistogramOfLong()
+    {
+        MeepleAiMetrics.RagCitationsPerAnswer.Should().BeOfType<Histogram<long>>();
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // RagCitationsPerAnswer: recording via MeterListener
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "RecordCitationsPerAnswer records value and is observable via MeterListener")]
+    public void RecordCitationsPerAnswer_RecordsValueAndIsObservable()
+    {
+        const long expectedCount = 3L;
+        var measurements = new List<long>();
+        using var listener = new MeterListener
+        {
+            InstrumentPublished = (instrument, l) =>
+            {
+                if (instrument.Name == "meepleai.rag.citations_per_answer")
+                    l.EnableMeasurementEvents(instrument);
+            },
+        };
+        listener.SetMeasurementEventCallback<long>((_, value, _, _) => measurements.Add(value));
+        listener.Start();
+
+        MeepleAiMetrics.RecordCitationsPerAnswer(expectedCount);
+
+        measurements.Should().Contain(expectedCount,
+            "RecordCitationsPerAnswer must emit one Record(count) measurement with the supplied value");
+    }
+
+    [Fact(DisplayName = "RecordCitationsPerAnswer with zero records a zero measurement (grounded-but-uncited signal)")]
+    public void RecordCitationsPerAnswer_WithZero_RecordsZero()
+    {
+        var measurements = new List<long>();
+        using var listener = new MeterListener
+        {
+            InstrumentPublished = (instrument, l) =>
+            {
+                if (instrument.Name == "meepleai.rag.citations_per_answer")
+                    l.EnableMeasurementEvents(instrument);
+            },
+        };
+        listener.SetMeasurementEventCallback<long>((_, value, _, _) => measurements.Add(value));
+        listener.Start();
+
+        MeepleAiMetrics.RecordCitationsPerAnswer(0);
+
+        measurements.Should().Contain(0L,
+            "le=0 bucket must be populated for the grounded-but-uncited signal");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Sanity: both instruments are non-null
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "Both SP5-b instruments are initialized (non-null)")]
+    public void BothMetrics_AreInitialized()
+    {
+        MeepleAiMetrics.RagRetrievalEmpty.Should().NotBeNull();
+        MeepleAiMetrics.RagCitationsPerAnswer.Should().NotBeNull();
+    }
+}

--- a/docs/for-developers/operations/operations-manual.md
+++ b/docs/for-developers/operations/operations-manual.md
@@ -29,6 +29,7 @@
 19. [Catalog Seed Pipeline (#1903)](#19-catalog-seed-pipeline-1903)
 20. [Catalog Covers — BGG ToS Compliance (#2123)](#20-catalog-covers--bgg-tos-compliance-2123)
 21. [Self-Hosted Runner Recovery](#21-self-hosted-runner-recovery)
+22. [Live-RAG Observability — SLO, Alerts & Grafana (SP5-b #2582)](#22-live-rag-observability--slo-alerts--grafana-sp5-b-2582)
 
 ---
 
@@ -3151,3 +3152,91 @@ Existing runbooks in `docs/for-developers/operations/runbooks/`:
 | `infra/Makefile` | Make targets for common operations |
 | `infra/start-*.sh` / `infra/start-*.ps1` | Start helper scripts |
 | `infra/stop.ps1` | Stop helper script |
+
+---
+
+## 22. Live-RAG Observability — SLO, Alerts & Grafana (SP5-b #2582)
+
+> **Reference**: Epic #2501 SP5-b | Issue #2582 | ADR-043 (LLM subsystem NFR) | ADR-083 (live-session aggregate convergence).
+> **Added**: 2026-06-29.
+
+### 22.1 Background — the buffering caveat
+
+The live-session RAG handler (`ChatWithSessionAgentCommandHandler.HandleCore`) is a streaming `IAsyncEnumerable`.  
+**Current implementation buffers all LLM chunks before yielding** (SP5-b state, pending SP5-c streaming refactor).  
+As a consequence:
+
+- `meepleai.rag.first_token_latency` measures **start → first-VISIBLE-token (post-buffer)**, which is equivalent to **total-response latency** on this path.
+- The SLO target is therefore **≤ 3 000ms (total-response scale)**, mirroring `meepleai:slo:rag_total`, **NOT** the chat-path TTFT target of 800ms.
+- Once buffering is removed (SP5-c or later), the threshold should be revised down towards 800ms.
+
+**Mark all live-RAG SLO thresholds PROVISIONAL** until ≥1 week of real data is available.
+
+### 22.2 Metrics added by SP5-b
+
+| Metric (OTel dotted) | Prometheus name | Type | Cardinality rule |
+|---|---|---|---|
+| `meepleai.rag.first_token_latency` | `meepleai_rag_first_token_latency_{bucket,count,sum}` | Histogram (ms) | NO session/game/user tags |
+| `meepleai.rag.retrieval_empty` | `meepleai_rag_retrieval_empty_total` | Counter | NO tags |
+| `meepleai.rag.citations_per_answer` | `meepleai_rag_citations_per_answer_{bucket,count,sum}` | Histogram (count) | NO tags |
+
+**Cardinality rule (CRITICAL)**: never add `gameSessionId`, `agentSessionId`, or `userId` as a label — these are unbounded and will cause Prometheus series explosion.
+
+### 22.3 SLO recording rule
+
+**Rule name**: `meepleai:slo:live_rag_ttft:p95:5m`  
+**File**: `infra/prometheus-rules.yml` (group `meepleai_slo_live_rag_recording_rules`)  
+**PromQL**:
+```promql
+histogram_quantile(
+  0.95,
+  rate(meepleai_rag_first_token_latency_bucket[5m])
+)
+```
+**Labels**: `service=meepleai-api`, `slo=live_rag_ttft`, `target="3000"`, `provisional="true"`  
+**Target**: p95 ≤ 3 000ms (provisional — see §22.1 buffering caveat).
+
+Mirrors the structure of `meepleai:slo:rag_ttft:p95:5m` (prometheus-rules.yml:132-138).
+
+### 22.4 Retrieval-empty alert
+
+**Alert name**: `LiveRagRetrievalEmptyHigh`  
+**File**: `infra/prometheus-rules.yml` (group `meepleai_live_rag_warning_alerts`)  
+**Severity**: `warning` (NOT critical/paging — signals degraded answer quality, not an outage)  
+**Expression**:
+```promql
+(
+  rate(meepleai_rag_retrieval_empty_total[15m])
+  /
+  (rate(meepleai_rag_first_token_latency_count[15m]) > 0)
+) > 0.05
+```
+**`for`**: 15m  
+**Threshold**: >5% of answers have zero retrieved chunks — **PROVISIONAL**, tune after baseline data.
+
+**Denominator choice**: `meepleai_rag_first_token_latency_count` counts answers served on the live-session RAG path. Both numerator and denominator share identical cardinality (no session tags), ensuring a clean ratio.
+
+**Response steps**:
+1. Check pgvector index health: `docker compose exec postgres psql -U postgres -c "SELECT count(*) FROM text_chunks WHERE search_vector IS NOT NULL;"`
+2. Run the RAG smoke test: `cd infra && make rag-smoke`
+3. Inspect `RagPromptAssemblyService` logs for `filteredChunks.Count == 0` warnings.
+4. If embedding model was recently changed, a re-index (`make seed-index`) may be required.
+
+### 22.5 Grafana panels
+
+**Dashboard**: `infra/monitoring/grafana/dashboards/llm-operational-maturity.json` (uid `llm-operational-maturity`)  
+**Two panels added** (y=22, row 3):
+
+| Panel | Type | PromQL | Purpose |
+|---|---|---|---|
+| Live-RAG Citations per Answer | timeseries | `histogram_quantile(0.95/0.50, rate(meepleai_rag_citations_per_answer_bucket[5m]))` | P50/P95 citations returned per answer; zero = grounded-but-uncited signal |
+| Live-RAG Retrieval-Empty Rate | timeseries | `rate(meepleai_rag_retrieval_empty_total[5m]) / rate(meepleai_rag_first_token_latency_count[5m])` | Fraction of answers with no retrieved chunks; thresholds at 3%/5% |
+
+Both panels are tagged `PROVISIONAL` in their descriptions.
+
+### 22.6 Tuning guidance (post-baseline)
+
+After ≥1 week of production data:
+1. Review `meepleai:slo:live_rag_ttft:p95:5m` distribution. If p95 is reliably < 800ms, lower `target` label to `"800"` and add error-ratio burn-rate rules mirroring `SloRagTtftFastBurn`/`SloRagTtftSlowBurn`.
+2. Review `LiveRagRetrievalEmptyHigh` baseline fraction. Adjust threshold from 5% to an appropriate level; remove `provisional` comment.
+3. Remove `provisional: "true"` label from the recording rule once thresholds are validated.

--- a/docs/superpowers/plans/2026-06-29-issue-2582-sp5b-observability.md
+++ b/docs/superpowers/plans/2026-06-29-issue-2582-sp5b-observability.md
@@ -1,0 +1,98 @@
+# SP5-b — Observability completion Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Checkbox (`- [ ]`) steps.
+
+**Goal:** Complete live-RAG observability (AC-OBS-1): wire the already-declared `RagFirstTokenLatency` histogram, add `retrieval_empty` counter + `citations_per_answer` histogram, and add the SLO recording rule + retrieval-empty alert + Grafana panel + doc.
+
+**Architecture:** BE-only. Metrics via `System.Diagnostics.Metrics` on `MeepleAiMetrics.Rag.cs` (same pattern as SP2 T12's `MeepleAiMetrics.LiveSessionSse.cs`). Instrumentation in the streaming RAG handler `ChatWithSessionAgentCommandHandler` + `RagPromptAssemblyService`. SLO config in `infra/prometheus-rules.yml` + Grafana dashboard JSON.
+
+**Tech Stack:** .NET 9 (xUnit + MeterListener); Prometheus rules YAML; Grafana JSON.
+
+## Global Constraints
+- De-risk reference: `.superpowers/sdd/sp5b-derisk-brief.md`.
+- **Async-iterator safety (CRITICAL)**: `HandleCore` in `ChatWithSessionAgentCommandHandler` is a streaming `IAsyncEnumerable` (yield ~:382, broadcast :563-595). Wrap EVERY metric `Record()/Add()` in try/catch (swallow + optional debug log) — a metrics fault must NEVER abort the user's live chat stream. Never compute metrics before the `yield return`'s observable effect.
+- **Cardinality (CRITICAL)**: NO `gameSessionId`/`agentSessionId`/`userId` tag on any metric. Record with NO tags.
+- **No worktree**: commit directly on `feature/issue-2582-sp5b-observability`.
+- Metric naming: dotted `meepleai.rag.*` on `Meter "MeepleAI.Api"` (Prometheus scrape → underscore).
+- SLO thresholds are **provisional** (no live-RAG history): mirror the chat-path 800ms TTFT baseline; alerts `warning` not `critical` until ≥1 week of real data; mark "needs tuning" in the PR.
+
+## Reading list (REUSE)
+`MeepleAiMetrics.Rag.cs` (the existing `RagFirstTokenLatency` at :38-41 + `RagRetrievalFallbacks` :68 + `RagErrorsDetected` :349-style), `MeepleAiMetrics.LiveSessionSse.cs` (SP2 T12 pattern), `SseMetricsTests.cs:88-105` (MeterListener test pattern), `ChatWithSessionAgentCommandHandler.cs:145/:382/:550-557`, `RagPromptAssemblyService.cs:282-285`, `infra/prometheus-rules.yml:132-195,824-842`.
+
+---
+
+## Task 1: Declare `retrieval_empty` counter + `citations_per_answer` histogram
+**Files:** `apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.Rag.cs`; Test: `apps/api/tests/Api.Tests/.../RagMetricsTests.cs` (or extend the existing Rag metrics test).
+
+**Interfaces:**
+- Produces: `RagRetrievalEmpty` (`Counter<long>`, `meepleai.rag.retrieval_empty`), `RagCitationsPerAnswer` (`Histogram<long>`, `meepleai.rag.citations_per_answer`), + a `RecordRetrievalEmpty()` / `RecordCitationsPerAnswer(long)` helper if the file uses that style. Confirm `RagFirstTokenLatency` already exists (:38-41) — do NOT redeclare.
+
+- [ ] **Step 1: Failing test** (MeterListener, mirror `SseMetricsTests.cs:88-105`): assert the two new instruments are published with the right names/types; recording moves the counter/histogram.
+- [ ] **Step 2: Run → FAIL.**
+- [ ] **Step 3: Declare** the Counter + Histogram on the `Meter` (mirror the existing declarations in the file). Add helper methods if the file's convention uses them.
+- [ ] **Step 4: Run → PASS** + the existing Rag metrics suite (no regression).
+- [ ] **Step 5: Commit** — `feat(observability): #2582 SP5-b declare rag retrieval_empty + citations_per_answer metrics`
+
+---
+
+## Task 2: Record first-token latency + citations count (in the handler)
+**Files:** `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentCommandHandler.cs`; Test: the handler's metrics test (extend `ChatWithSessionAgent*Tests` or a new metrics test).
+
+**Interfaces:** Consumes T1's metrics + the existing `RagFirstTokenLatency`.
+
+- [ ] **Step 1: Failing test** — a streamed chat records `meepleai.rag.first_token_latency` EXACTLY once (≥0 ms observation) AND `meepleai.rag.citations_per_answer` once with the citation count (incl. zero-case). Use MeterListener.
+- [ ] **Step 2: Run → FAIL.**
+- [ ] **Step 3: Implement**:
+  - `Stopwatch sw = Stopwatch.StartNew();` at `HandleCore` entry (~:145).
+  - First-token: a `bool firstTokenRecorded = false;` guard; immediately AFTER the first `yield return CreateEvent(StreamingEventType.Token, …)` (~:382), if `!firstTokenRecorded` → in a `try { RagFirstTokenLatency.Record(sw.Elapsed.TotalMilliseconds); } catch { /* metrics must not break the stream */ }`, set the flag.
+  - Citations: after `citationDtos` is built (~:550-557), `try { RagCitationsPerAnswer.Record(citationDtos.Count); } catch { }` (record once, post-stream; use `citationDtos.Count`, NOT earlier lists).
+- [ ] **Step 4: Run → PASS** + the KnowledgeBase unit suite (no regression — the chat stream still works).
+- [ ] **Step 5: Commit** — `feat(observability): #2582 SP5-b record rag first-token latency + citations-per-answer`
+
+---
+
+## Task 3: Record retrieval-empty (single-source in RagPromptAssemblyService)
+**Files:** `apps/api/src/Api/.../RagPromptAssemblyService.cs` (~:282-285, the `if (filteredChunks.Count == 0)` detection); Test: the RAG retrieval service test.
+
+**Interfaces:** Consumes T1's `RagRetrievalEmpty`.
+
+- [ ] **Step 1: Failing test** — when retrieval returns ZERO chunks, `meepleai.rag.retrieval_empty` increments by 1; when retrieval returns chunks, it does NOT increment.
+- [ ] **Step 2: Run → FAIL.**
+- [ ] **Step 3: Implement** — at the `filteredChunks.Count == 0` site, `try { RagRetrievalEmpty.Add(1); } catch { }`. Single-source (do NOT also count in the handler).
+- [ ] **Step 4: Run → PASS** + the service suite.
+- [ ] **Step 5: Commit** — `feat(observability): #2582 SP5-b record rag retrieval-empty counter`
+
+---
+
+## Task 4: Streaming-safety regression (metrics fault must not abort the stream)
+**Files:** Test only (`ChatWithSessionAgent*Tests`).
+
+- [ ] **Step 1: Failing/guard test** — inject a metrics recorder that THROWS (or arrange a condition that would throw inside the metric Record path); drain the chat stream; assert the stream STILL completes (StreamingComplete yielded) and no exception escapes. This locks in the try/catch wrapping from T2/T3.
+- [ ] **Step 2: Run** — if T2/T3 wrapped correctly, this passes; if a Record isn't wrapped, it fails → fix the wrapping.
+- [ ] **Step 3: Verify** the test genuinely exercises a throwing-metric path (not a no-op).
+- [ ] **Step 4: Run → PASS.**
+- [ ] **Step 5: Commit** — `test(observability): #2582 SP5-b metrics fault does not abort live chat stream`
+
+---
+
+## Task 5: SLO recording rule + retrieval-empty alert + Grafana panel + doc
+**Files:** `infra/prometheus-rules.yml`; the relevant Grafana dashboard JSON under `infra/monitoring/grafana/dashboards/`; an observability doc/runbook (the existing RAG SLO doc — find it, e.g. BGAI-082 reference).
+
+- [ ] **Step 1: Add the recording rule** `meepleai:slo:live_rag_ttft:p95:5m` over `meepleai_rag_first_token_latency_bucket` — mirror the existing `meepleai:slo:rag_ttft:p95:5m` (prometheus-rules.yml:132-168). Target ≤ 800ms.
+- [ ] **Step 2: Add the retrieval-empty alert** — `rate(meepleai_rag_retrieval_empty_total[15m]) / rate(<total live-rag answers>[15m]) > 0.05` (provisional), `severity: warning`, model on `RagErrorsDetected` (:349). Annotate "threshold provisional — tune after baseline data".
+- [ ] **Step 3: Add a Grafana panel** for `meepleai_rag_citations_per_answer` (p50/p95 + `le="0"` fraction) to the appropriate dashboard JSON.
+- [ ] **Step 4: Validate** — `promtool check rules infra/prometheus-rules.yml` (if promtool available; else verify YAML parses + the PromQL mirrors the existing rules' syntax). The Grafana JSON must be valid JSON.
+- [ ] **Step 5: Doc** — add the live-RAG SLO targets + the cardinality rule (no session tags) to the observability ADR/runbook, marking thresholds provisional.
+- [ ] **Step 6: Commit** — `feat(observability): #2582 SP5-b live-RAG SLO rule + retrieval-empty alert + citations panel + doc`
+
+---
+
+## Self-Review
+- **AC-OBS-1**: first-token latency (T2) + retrieval-empty (T3) + citations-per-answer (T2) + SLO (T5). ✅
+- **Streaming safety**: every Record wrapped (T2/T3), regression-tested (T4).
+- **Cardinality**: no session tags (all tasks).
+- **Risk**: SLO thresholds provisional (T5) — don't page on unvalidated targets.
+
+## Out of scope (→ SP5-c)
+- timeout/circuit-breaker, degradation-contract/bulkhead, backfill.
+- Tuning the provisional SLO thresholds after real data (a future ops task, not this PR).

--- a/infra/monitoring/grafana/dashboards/llm-operational-maturity.json
+++ b/infra/monitoring/grafana/dashboards/llm-operational-maturity.json
@@ -153,10 +153,58 @@
           "unit": "percentunit"
         }
       }
+    },
+    {
+      "title": "Live-RAG Citations per Answer (SP5-b #2582) — PROVISIONAL",
+      "description": "Citations returned per live-session RAG answer (meepleai.rag.citations_per_answer). P50/P95 latency-style view + zero-citations fraction (le=0 bucket / total = grounded-but-uncited signal). BUFFERING CAVEAT: first-visible-token latency on this path equals total-response latency (~3s SLO, not 800ms TTFT). Thresholds provisional — tune after ≥1 week of live-RAG baseline data.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 22 },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, rate(meepleai_rag_citations_per_answer_bucket[5m]))",
+          "legendFormat": "P95 citations/answer"
+        },
+        {
+          "expr": "histogram_quantile(0.50, rate(meepleai_rag_citations_per_answer_bucket[5m]))",
+          "legendFormat": "P50 citations/answer"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 1
+        }
+      }
+    },
+    {
+      "title": "Live-RAG Retrieval-Empty Rate (SP5-b #2582) — PROVISIONAL",
+      "description": "Fraction of live-session RAG answers with zero retrieved chunks (grounded-but-uncited signal). Denominator: meepleai_rag_first_token_latency_count (answers served). Alert threshold: >5% for 15m (warning, provisional). A rising trend indicates pgvector index drift, embedding model mismatch, or score-threshold too strict.",
+      "type": "timeseries",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 22 },
+      "targets": [
+        {
+          "expr": "rate(meepleai_rag_retrieval_empty_total[5m]) / (rate(meepleai_rag_first_token_latency_count[5m]) > 0)",
+          "legendFormat": "retrieval-empty fraction"
+        }
+      ],
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "decimals": 2,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "yellow", "value": 0.03 },
+              { "color": "red", "value": 0.05 }
+            ]
+          }
+        }
+      }
     }
   ],
   "schemaVersion": 39,
-  "tags": ["llm", "operational", "meepleai", "issue-5480"],
+  "tags": ["llm", "operational", "meepleai", "issue-5480", "sp5b-live-rag"],
   "templating": { "list": [] },
   "time": { "from": "now-3h", "to": "now" },
   "title": "LLM Operational Maturity",

--- a/infra/monitoring/grafana/dashboards/llm-operational-maturity.json
+++ b/infra/monitoring/grafana/dashboards/llm-operational-maturity.json
@@ -162,11 +162,18 @@
       "targets": [
         {
           "expr": "histogram_quantile(0.95, rate(meepleai_rag_citations_per_answer_bucket[5m]))",
-          "legendFormat": "P95 citations/answer"
+          "legendFormat": "P95 citations/answer",
+          "refId": "A"
         },
         {
           "expr": "histogram_quantile(0.50, rate(meepleai_rag_citations_per_answer_bucket[5m]))",
-          "legendFormat": "P50 citations/answer"
+          "legendFormat": "P50 citations/answer",
+          "refId": "B"
+        },
+        {
+          "expr": "rate(meepleai_rag_citations_per_answer_bucket{le=\"0\"}[5m]) / (rate(meepleai_rag_citations_per_answer_count[5m]) > 0)",
+          "legendFormat": "grounded-but-uncited fraction (le=0)",
+          "refId": "C"
         }
       ],
       "fieldConfig": {

--- a/infra/prometheus-rules.yml
+++ b/infra/prometheus-rules.yml
@@ -990,7 +990,7 @@ groups:
   #     removed (SP5-c or later).
   #
   # Metric: meepleai.rag.first_token_latency (Histogram<double>, ms)
-  #   Code: MeepleAiMetrics.Rag.cs:38-41
+  #   Code: MeepleAiMetrics.Rag.cs:78-81
   #   Scraped name: meepleai_rag_first_token_latency_bucket/_count/_sum
   #
   # Cardinality: metric recorded with NO session/game/user tags (bounded safe).

--- a/infra/prometheus-rules.yml
+++ b/infra/prometheus-rules.yml
@@ -977,6 +977,85 @@ groups:
           summary: "OpenRouter RPM utilization above 80%"
           description: "RPM utilization at {{ $value | humanizePercentage }}."
 
+  # ─── SP5-b (#2582): Live-RAG SLO Recording Rules ────────────────────────
+  # meepleai:slo:live_rag_ttft:p95:5m — p95 of the first-visible-token
+  # latency on the live-session RAG path (ChatWithSessionAgentCommandHandler).
+  #
+  # ⚠️  BUFFERING CAVEAT: HandleCore buffers all LLM chunks before yielding,
+  #     so meepleai_rag_first_token_latency measures start → first-VISIBLE-token
+  #     (post-buffer), which equals total-response latency on this path.
+  #     The threshold therefore mirrors the total-response SLO (~3 000ms),
+  #     NOT the chat-path TTFT 800ms.  Mark PROVISIONAL until ≥1 week of
+  #     live-RAG data is available; tune down towards 800ms once buffering is
+  #     removed (SP5-c or later).
+  #
+  # Metric: meepleai.rag.first_token_latency (Histogram<double>, ms)
+  #   Code: MeepleAiMetrics.Rag.cs:38-41
+  #   Scraped name: meepleai_rag_first_token_latency_bucket/_count/_sum
+  #
+  # Cardinality: metric recorded with NO session/game/user tags (bounded safe).
+  - name: meepleai_slo_live_rag_recording_rules
+    interval: 30s
+    rules:
+      # SLO: Live-RAG first-visible-token p95 (PROVISIONAL — see caveat above)
+      # Target: ≤ 3 000ms (total-response scale, due to buffering).
+      # Mirror of meepleai:slo:rag_ttft:p95:5m (:132-138) but for live-session path.
+      - record: meepleai:slo:live_rag_ttft:p95:5m
+        expr: |
+          histogram_quantile(
+            0.95,
+            rate(meepleai_rag_first_token_latency_bucket[5m])
+          )
+        labels:
+          service: meepleai-api
+          slo: live_rag_ttft
+          target: "3000"
+          provisional: "true"
+
+  # ─── SP5-b (#2582): Live-RAG Warning Alerts ──────────────────────────────
+  - name: meepleai_live_rag_warning_alerts
+    interval: 1m
+    rules:
+      # WARNING: High retrieval-empty rate on live-session RAG path.
+      #
+      # A retrieval-empty event occurs in RagPromptAssemblyService when
+      # filteredChunks.Count == 0 after pgvector nearest-neighbour search.
+      # Metric: meepleai.rag.retrieval_empty (Counter<long>)
+      #   Scraped: meepleai_rag_retrieval_empty_total
+      # Denominator: meepleai_rag_first_token_latency_count (answers served on
+      #   this path, consistent cardinality — no session tags on either metric).
+      #
+      # Threshold: >5% of live-RAG answers have zero retrieved chunks.
+      # ⚠️  PROVISIONAL — tune after ≥1 week of baseline data.
+      # Severity: warning (NOT critical/paging) — signals degraded quality,
+      #   not an outage; the LLM still responds with general knowledge.
+      - alert: LiveRagRetrievalEmptyHigh
+        expr: |
+          (
+            rate(meepleai_rag_retrieval_empty_total[15m])
+            /
+            (rate(meepleai_rag_first_token_latency_count[15m]) > 0)
+          ) > 0.05
+        for: 15m
+        labels:
+          severity: warning
+          service: meepleai-api
+          category: rag
+          slo: live_rag_ttft
+        annotations:
+          summary: "Live-RAG retrieval-empty rate > 5% for 15m (PROVISIONAL threshold)"
+          description: |
+            {{ $value | humanizePercentage }} of live-session RAG answers have zero
+            retrieved chunks in the last 15m (threshold: 5% — provisional, tune after
+            baseline data).
+            This means the LLM is answering from general knowledge, not game-rules KB.
+            Possible causes: pgvector index drift, embedding model mismatch, or
+            filteredChunks score threshold too strict.
+            Check pgvector health, re-run rag-smoke (make rag-smoke), and inspect
+            RagPromptAssemblyService filteredChunks path.
+          runbook_url: "https://docs.meepleai.dev/runbooks/rag-errors"
+          dashboard_url: "http://localhost:3001/d/llm-operational-maturity"
+
   # ─── Issue #614: SharedGame Detail Observability — Recording Rules ─────
   # Pre-computed views used by both the dashboard and the alert group below.
   # Bounded label cardinality (≤10 active series, see MeepleAiMetrics.SharedGameDetail.cs).


### PR DESCRIPTION
## Sommario

Sotto-fase **SP5-b** dell'epic #2501 (affidabilità, 2ª delle 3 sub-PR). Completa l'osservabilità live-RAG (AC-OBS-1). BE-focused, indipendente da SP5-a (#2581).

## Cosa c'è dentro (5 task TDD)

### Metriche (`MeepleAiMetrics.Rag.cs`)
- **`meepleai.rag.first_token_latency`** (histogram già dichiarato, **mai registrato**) → ora registrato.
- **`meepleai.rag.retrieval_empty`** (counter, NUOVO) — risposte con retrieval a zero chunk (index-drift signal).
- **`meepleai.rag.citations_per_answer`** (histogram, NUOVO) — count citazioni per risposta (`le=0` = grounded-but-uncited).

### Instrumentation (chat handler + RagPromptAssemblyService)
- first-token + citations nel `ChatWithSessionAgentCommandHandler` (streaming); retrieval-empty single-source in `RagPromptAssemblyService`.
- **⚠️ Streaming-safety**: OGNI `Record()` è in try/catch — un fault metrica NON può abortire la chat live dell'utente. **Provato da un fault-injection regression test** (MeterListener-throws → Record propaga → lo stream completa comunque).
- **Cardinalità**: nessun tag session/user.

### SLO / alert / dashboard (`infra/`)
- Recording rule `live_rag_ttft:p95`, **target 3000ms** (total-response scale).
- ⚠️ **Caveat buffering**: il handler bufferizza tutti i chunk LLM prima di yieldare → `first_token_latency` ≈ total-response, NON vera TTFT → soglia = total ~3s, NON i 800ms del chat-path TTFT. Documentato in rule + alert + operations manual §22.
- Retrieval-empty alert `severity: warning` (no paging), soglia provvisoria >5%.
- Grafana: P50/P95 + frazione `le=0` grounded-but-uncited + retrieval-empty rate.
- Tutte le soglie **provvisorie** (no storico live-RAG) — da tarare dopo ≥1 settimana di dati.

## Quality

Ogni task: implementer + task-review 2-stadi (incl. review **opus** dell'instrumentation streaming + fault-injection test dedicato). **Merge-readiness review opus** = VERDICT MERGE. Whole-branch BE build + FE typecheck verdi.

## Fuori scope (SP5-c)

timeout/circuit-breaker · degradation-contract/bulkhead · backfill (needs owner OQ#5). Tuning soglie SLO post-dati = ops task futuro.

Closes #2582.

🤖 Generated with [Claude Code](https://claude.com/claude-code)