### PR TITLE
fix(session-live): per-session participant authz on live-session endpoints (#2573)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNight/CastVoteOnDisputeCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNight/CastVoteOnDisputeCommand.cs
@@ -7,6 +7,7 @@ namespace Api.BoundedContexts.GameManagement.Application.Commands.GameNight;
 /// Part of the democratic override voting system.
 /// </summary>
 internal record CastVoteOnDisputeCommand(
+    Guid SessionId,
     Guid DisputeId,
     Guid PlayerId,
     bool AcceptsVerdict

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNight/CastVoteOnDisputeCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNight/CastVoteOnDisputeCommandHandler.cs
@@ -53,6 +53,11 @@ internal sealed class CastVoteOnDisputeCommandHandler
             .ConfigureAwait(false)
             ?? throw new NotFoundException("RuleDispute", command.DisputeId.ToString());
 
+        // Cross-session authz (#2573): the dispute must belong to the route session.
+        // 404 (not 403) to avoid leaking the existence of disputes in other sessions.
+        if (dispute.SessionId != command.SessionId)
+            throw new NotFoundException("RuleDispute", command.DisputeId.ToString());
+
         // 3. Cast vote (domain validates duplicate votes)
         dispute.CastVote(command.PlayerId, command.AcceptsVerdict);
 

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNight/RespondToDisputeCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNight/RespondToDisputeCommand.cs
@@ -6,6 +6,7 @@ namespace Api.BoundedContexts.GameManagement.Application.Commands.GameNight;
 /// Adds a respondent's counter-claim to an existing dispute.
 /// </summary>
 internal record RespondToDisputeCommand(
+    Guid SessionId,
     Guid DisputeId,
     Guid RespondentPlayerId,
     string RespondentClaim

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNight/RespondToDisputeCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNight/RespondToDisputeCommandHandler.cs
@@ -36,6 +36,11 @@ internal sealed class RespondToDisputeCommandHandler
             .ConfigureAwait(false)
             ?? throw new NotFoundException("RuleDispute", command.DisputeId.ToString());
 
+        // Cross-session authz (#2573): the dispute must belong to the route session.
+        // 404 (not 403) to avoid leaking the existence of disputes in other sessions.
+        if (dispute.SessionId != command.SessionId)
+            throw new NotFoundException("RuleDispute", command.DisputeId.ToString());
+
         // 2. Add respondent claim
         dispute.AddRespondentClaim(command.RespondentPlayerId, command.RespondentClaim);
 

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNight/RespondentTimeoutCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNight/RespondentTimeoutCommand.cs
@@ -7,5 +7,6 @@ namespace Api.BoundedContexts.GameManagement.Application.Commands.GameNight;
 /// The dispute proceeds with the initiator's claim only.
 /// </summary>
 internal record RespondentTimeoutCommand(
+    Guid SessionId,
     Guid DisputeId
 ) : ICommand;

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNight/RespondentTimeoutCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNight/RespondentTimeoutCommandHandler.cs
@@ -27,10 +27,15 @@ internal sealed class RespondentTimeoutCommandHandler
         ArgumentNullException.ThrowIfNull(command);
 
         // 1. Get dispute — throw if not found
-        _ = await _disputeRepository
+        var dispute = await _disputeRepository
             .GetByIdAsync(command.DisputeId, cancellationToken)
             .ConfigureAwait(false)
             ?? throw new NotFoundException("RuleDispute", command.DisputeId.ToString());
+
+        // Cross-session authz (#2573): the dispute must belong to the route session.
+        // 404 (not 403) to avoid leaking the existence of disputes in other sessions.
+        if (dispute.SessionId != command.SessionId)
+            throw new NotFoundException("RuleDispute", command.DisputeId.ToString());
 
         // 2. No-op if respondent already set (or not).
         //    Dispute proceeds with initiator claim only.

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNight/TallyDisputeVotesCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNight/TallyDisputeVotesCommand.cs
@@ -8,6 +8,7 @@ namespace Api.BoundedContexts.GameManagement.Application.Commands.GameNight;
 /// Appends a legacy entry to the session for backward compatibility.
 /// </summary>
 internal record TallyDisputeVotesCommand(
+    Guid SessionId,
     Guid DisputeId,
     string? OverrideRule = null
 ) : ICommand;

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNight/TallyDisputeVotesCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNight/TallyDisputeVotesCommandHandler.cs
@@ -43,6 +43,11 @@ internal sealed class TallyDisputeVotesCommandHandler
             .ConfigureAwait(false)
             ?? throw new NotFoundException("RuleDispute", command.DisputeId.ToString());
 
+        // Cross-session authz (#2573): the dispute must belong to the route session.
+        // 404 (not 403) to avoid leaking the existence of disputes in other sessions.
+        if (dispute.SessionId != command.SessionId)
+            throw new NotFoundException("RuleDispute", command.DisputeId.ToString());
+
         // 2. Tally votes — sets FinalOutcome
         dispute.TallyVotes();
 

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/LiveSessions/AddDiaryEntryCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/LiveSessions/AddDiaryEntryCommandHandler.cs
@@ -40,8 +40,7 @@ internal sealed class AddDiaryEntryCommandHandler : ICommandHandler<AddDiaryEntr
 
         // Authz: caller must be the session creator or an active linked player.
         // Mirrors GetLiveSessionStreamContextQueryHandler (SP2 T4).
-        var isParticipant = session.CreatedByUserId == command.AuthorId
-            || session.Players.Any(p => p.IsActive && p.UserId == command.AuthorId);
+        var isParticipant = session.IsAuthorizedParticipant(command.AuthorId);
         if (!isParticipant)
             throw new ForbiddenException("Only the session creator or an active participant may add diary entries.");
 

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/LiveSessions/GetLiveSessionDiaryQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/LiveSessions/GetLiveSessionDiaryQueryHandler.cs
@@ -33,8 +33,7 @@ internal sealed class GetLiveSessionDiaryQueryHandler
 
         // Authz: caller must be the session creator or an active linked player.
         // Mirrors GetLiveSessionStreamContextQueryHandler (SP2 T4, issue #2561).
-        var isParticipant = session.CreatedByUserId == query.UserId
-            || session.Players.Any(p => p.IsActive && p.UserId == query.UserId);
+        var isParticipant = session.IsAuthorizedParticipant(query.UserId);
         if (!isParticipant)
             throw new ForbiddenException("Only the session creator or an active participant may read diary entries.");
 

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/LiveSessions/GetLiveSessionParticipantContextQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/LiveSessions/GetLiveSessionParticipantContextQuery.cs
@@ -1,0 +1,20 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.GameManagement.Application.Queries.LiveSessions;
+
+/// <summary>
+/// Result of the live-session participant authorization query.
+/// <c>Found</c> = a session with <c>SessionId</c> exists; <c>Authorized</c> = <c>UserId</c> is the
+/// session creator or an active linked player. Non-throwing so the RequireLiveSessionParticipant
+/// endpoint filter maps the flags to 404/403. Issue #2573.
+/// </summary>
+/// <param name="Found">True if a <c>LiveGameSession</c> with <c>SessionId</c> exists.</param>
+/// <param name="Authorized">True if <c>UserId</c> is the session creator or an active linked player.</param>
+internal record LiveSessionParticipantContextResult(bool Found, bool Authorized);
+
+/// <summary>
+/// Query to resolve per-session participant authorization for live-session write/read endpoints.
+/// Mirrors <c>GetLiveSessionStreamContextQuery</c> without companion-presence. Issue #2573.
+/// </summary>
+internal record GetLiveSessionParticipantContextQuery(Guid SessionId, Guid UserId)
+    : IQuery<LiveSessionParticipantContextResult>;

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/LiveSessions/GetLiveSessionParticipantContextQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/LiveSessions/GetLiveSessionParticipantContextQueryHandler.cs
@@ -1,0 +1,41 @@
+using Api.BoundedContexts.GameManagement.Domain.Repositories;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.GameManagement.Application.Queries.LiveSessions;
+
+/// <summary>
+/// Handles <see cref="GetLiveSessionParticipantContextQuery"/>. Resolves session-found and
+/// caller-authorized without throwing, so the RequireLiveSessionParticipant endpoint filter
+/// controls the HTTP response shape. Mirrors <see cref="GetLiveSessionStreamContextQueryHandler"/>.
+/// Issue #2573.
+/// </summary>
+internal sealed class GetLiveSessionParticipantContextQueryHandler
+    : IQueryHandler<GetLiveSessionParticipantContextQuery, LiveSessionParticipantContextResult>
+{
+    private readonly ILiveSessionRepository _sessionRepository;
+
+    public GetLiveSessionParticipantContextQueryHandler(ILiveSessionRepository sessionRepository)
+    {
+        _sessionRepository = sessionRepository ?? throw new ArgumentNullException(nameof(sessionRepository));
+    }
+
+    public async Task<LiveSessionParticipantContextResult> Handle(
+        GetLiveSessionParticipantContextQuery query,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var session = await _sessionRepository
+            .GetByIdAsync(query.SessionId, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (session is null)
+        {
+            return new LiveSessionParticipantContextResult(Found: false, Authorized: false);
+        }
+
+        return new LiveSessionParticipantContextResult(
+            Found: true,
+            Authorized: session.IsAuthorizedParticipant(query.UserId));
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/LiveSessions/GetLiveSessionStreamContextQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/LiveSessions/GetLiveSessionStreamContextQueryHandler.cs
@@ -33,9 +33,8 @@ internal sealed class GetLiveSessionStreamContextQueryHandler
             return new LiveSessionStreamContextResult(Found: false, Authorized: false, HasCompanion: false);
 
         // Authz: creator or any active linked player (registered user) may subscribe.
-        // Inactive (removed/kicked) players lose stream access.
-        var isAuthorized = session.CreatedByUserId == query.UserId
-            || session.Players.Any(p => p.IsActive && p.UserId == query.UserId);
+        // Inactive (removed/kicked) players lose stream access. Single source of truth (#2573).
+        var isAuthorized = session.IsAuthorizedParticipant(query.UserId);
 
         var hasCompanion = session.TrackingSessionId.HasValue;
 

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/LiveGameSession.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/LiveGameSession.cs
@@ -91,6 +91,23 @@ internal sealed class LiveGameSession : AggregateRoot<Guid>
     public bool IsActive => Status is LiveSessionStatus.InProgress or LiveSessionStatus.Paused or LiveSessionStatus.Setup;
     public LiveSessionPlayer? Host => _players.FirstOrDefault(p => p.Role == PlayerRole.Host && p.IsActive);
 
+    /// <summary>
+    /// Returns true if <paramref name="userId"/> is authorized to act on this session as a participant:
+    /// the session creator, OR an active linked player. Guest players (UserId == null) never match,
+    /// and a removed/deactivated player (IsActive == false) loses access (#2561).
+    /// Single source of truth for live-session participant authorization. Issue #2573.
+    /// </summary>
+    public bool IsAuthorizedParticipant(Guid userId)
+    {
+        if (userId == Guid.Empty)
+        {
+            return false;
+        }
+
+        return CreatedByUserId == userId
+            || _players.Any(p => p.IsActive && p.UserId == userId);
+    }
+
     // === Factory Methods ===
 
     /// <summary>

--- a/apps/api/src/Api/Extensions/EndpointFilterExtensions.cs
+++ b/apps/api/src/Api/Extensions/EndpointFilterExtensions.cs
@@ -94,6 +94,19 @@ internal static class EndpointFilterExtensions
     }
 
     /// <summary>
+    /// Requires the caller to be a participant (creator or active linked player) of the live session
+    /// identified by the {sessionId} route value. Returns 401 if unauthenticated, 404 if the session
+    /// is missing, 403 if authenticated but not a participant. Apply AFTER .RequireAuthenticatedUser().
+    /// </summary>
+    /// <param name="builder">The route handler builder.</param>
+    /// <returns>The builder for method chaining.</returns>
+    /// <remarks>Issue: #2573 - live-session write/read endpoints lack per-session participant authz.</remarks>
+    public static RouteHandlerBuilder RequireLiveSessionParticipant(this RouteHandlerBuilder builder)
+    {
+        return builder.AddEndpointFilter<RequireLiveSessionParticipantFilter>();
+    }
+
+    /// <summary>
     /// Applies notification-specific rate limiting for bulk operations.
     /// Uses stricter limits than global rate limiting to prevent abuse.
     ///

--- a/apps/api/src/Api/Filters/RequireLiveSessionParticipantFilter.cs
+++ b/apps/api/src/Api/Filters/RequireLiveSessionParticipantFilter.cs
@@ -1,0 +1,55 @@
+using Api.BoundedContexts.GameManagement.Application.Queries.LiveSessions;
+using Api.Extensions;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Api.Filters;
+
+/// <summary>
+/// Endpoint filter enforcing per-session participant authorization on live-session endpoints (#2573).
+/// The caller must be the session creator or an active linked player.
+/// Returns 401 if unauthenticated, 404 if the session does not exist (or the route lacks a parsable
+/// {sessionId}), 403 if authenticated but not a participant. Reads the {sessionId} route value.
+///
+/// Apply via .RequireLiveSessionParticipant() AFTER .RequireAuthenticatedUser().
+/// Mirrors the response convention of RequireAuthenticatedUser/RequireAdminSession (returns Results.*),
+/// delegating the authz decision to <see cref="GetLiveSessionParticipantContextQuery"/>.
+/// </summary>
+internal sealed class RequireLiveSessionParticipantFilter : IEndpointFilter
+{
+    public async ValueTask<object?> InvokeAsync(
+        EndpointFilterInvocationContext context,
+        EndpointFilterDelegate next)
+    {
+        var httpContext = context.HttpContext;
+
+        var userId = httpContext.User.GetUserId();
+        if (userId == Guid.Empty)
+        {
+            return Results.Unauthorized();
+        }
+
+        if (!httpContext.Request.RouteValues.TryGetValue("sessionId", out var rawSessionId)
+            || !Guid.TryParse(rawSessionId?.ToString(), out var sessionId))
+        {
+            return Results.NotFound(new { error = "Live session not found" });
+        }
+
+        var mediator = httpContext.RequestServices.GetRequiredService<IMediator>();
+        var ctx = await mediator
+            .Send(new GetLiveSessionParticipantContextQuery(sessionId, userId), httpContext.RequestAborted)
+            .ConfigureAwait(false);
+
+        if (!ctx.Found)
+        {
+            return Results.NotFound(new { error = "Live session not found" });
+        }
+
+        if (!ctx.Authorized)
+        {
+            return Results.StatusCode(403);
+        }
+
+        return await next(context).ConfigureAwait(false);
+    }
+}

--- a/apps/api/src/Api/Routing/LiveSessionEndpoints.cs
+++ b/apps/api/src/Api/Routing/LiveSessionEndpoints.cs
@@ -781,7 +781,7 @@ internal static class LiveSessionEndpoints
         CancellationToken cancellationToken)
     {
         await mediator.Send(
-            new RespondToDisputeCommand(disputeId, request.RespondentPlayerId, request.RespondentClaim),
+            new RespondToDisputeCommand(sessionId, disputeId, request.RespondentPlayerId, request.RespondentClaim),
             cancellationToken).ConfigureAwait(false);
         return Results.NoContent();
     }
@@ -792,7 +792,7 @@ internal static class LiveSessionEndpoints
         [FromServices] IMediator mediator,
         CancellationToken cancellationToken)
     {
-        await mediator.Send(new RespondentTimeoutCommand(disputeId), cancellationToken).ConfigureAwait(false);
+        await mediator.Send(new RespondentTimeoutCommand(sessionId, disputeId), cancellationToken).ConfigureAwait(false);
         return Results.NoContent();
     }
 
@@ -804,7 +804,7 @@ internal static class LiveSessionEndpoints
         CancellationToken cancellationToken)
     {
         await mediator.Send(
-            new CastVoteOnDisputeCommand(disputeId, request.PlayerId, request.AcceptsVerdict),
+            new CastVoteOnDisputeCommand(sessionId, disputeId, request.PlayerId, request.AcceptsVerdict),
             cancellationToken).ConfigureAwait(false);
         return Results.NoContent();
     }
@@ -817,7 +817,7 @@ internal static class LiveSessionEndpoints
         CancellationToken cancellationToken)
     {
         await mediator.Send(
-            new TallyDisputeVotesCommand(disputeId, request.OverrideRule),
+            new TallyDisputeVotesCommand(sessionId, disputeId, request.OverrideRule),
             cancellationToken).ConfigureAwait(false);
         return Results.NoContent();
     }

--- a/apps/api/src/Api/Routing/LiveSessionEndpoints.cs
+++ b/apps/api/src/Api/Routing/LiveSessionEndpoints.cs
@@ -44,6 +44,7 @@ internal static class LiveSessionEndpoints
 
         group.MapPost("/live-sessions/{sessionId}/start", HandleStartSession)
             .RequireAuthenticatedUser()
+            .RequireLiveSessionParticipant()
             .Produces(204)
             .Produces(404)
             .Produces(409)
@@ -53,6 +54,7 @@ internal static class LiveSessionEndpoints
 
         group.MapPost("/live-sessions/{sessionId}/pause", HandlePauseSession)
             .RequireAuthenticatedUser()
+            .RequireLiveSessionParticipant()
             .Produces(204)
             .Produces(404)
             .Produces(409)
@@ -61,6 +63,7 @@ internal static class LiveSessionEndpoints
 
         group.MapPost("/live-sessions/{sessionId}/resume", HandleResumeSession)
             .RequireAuthenticatedUser()
+            .RequireLiveSessionParticipant()
             .Produces(204)
             .Produces(404)
             .Produces(409)
@@ -69,6 +72,7 @@ internal static class LiveSessionEndpoints
 
         group.MapPost("/live-sessions/{sessionId}/complete", HandleCompleteSession)
             .RequireAuthenticatedUser()
+            .RequireLiveSessionParticipant()
             .Produces(204)
             .Produces(404)
             .Produces(409)
@@ -78,6 +82,7 @@ internal static class LiveSessionEndpoints
 
         group.MapPost("/live-sessions/{sessionId}/save", HandleSaveSession)
             .RequireAuthenticatedUser()
+            .RequireLiveSessionParticipant()
             .Produces(204)
             .Produces(404)
             .Produces(409)
@@ -86,6 +91,7 @@ internal static class LiveSessionEndpoints
 
         group.MapPost("/live-sessions/{sessionId}/players", HandleAddPlayer)
             .RequireAuthenticatedUser()
+            .RequireLiveSessionParticipant()
             .Produces<Guid>(201)
             .Produces(400)
             .Produces(404)
@@ -94,6 +100,7 @@ internal static class LiveSessionEndpoints
 
         group.MapDelete("/live-sessions/{sessionId}/players/{playerId}", HandleRemovePlayer)
             .RequireAuthenticatedUser()
+            .RequireLiveSessionParticipant()
             .Produces(204)
             .Produces(404)
             .Produces(409)
@@ -102,6 +109,7 @@ internal static class LiveSessionEndpoints
 
         group.MapPut("/live-sessions/{sessionId}/turn-order", HandleUpdateTurnOrder)
             .RequireAuthenticatedUser()
+            .RequireLiveSessionParticipant()
             .Produces(204)
             .Produces(400)
             .Produces(404)
@@ -110,6 +118,7 @@ internal static class LiveSessionEndpoints
 
         group.MapPost("/live-sessions/{sessionId}/teams", HandleCreateTeam)
             .RequireAuthenticatedUser()
+            .RequireLiveSessionParticipant()
             .Produces<Guid>(201)
             .Produces(400)
             .Produces(404)
@@ -118,6 +127,7 @@ internal static class LiveSessionEndpoints
 
         group.MapPut("/live-sessions/{sessionId}/teams/{teamId}/players/{playerId}", HandleAssignPlayerToTeam)
             .RequireAuthenticatedUser()
+            .RequireLiveSessionParticipant()
             .Produces(204)
             .Produces(404)
             .WithTags("LiveSessions")
@@ -125,6 +135,7 @@ internal static class LiveSessionEndpoints
 
         group.MapPost("/live-sessions/{sessionId}/scores", HandleRecordScore)
             .RequireAuthenticatedUser()
+            .RequireLiveSessionParticipant()
             .Produces(204)
             .Produces(400)
             .Produces(404)
@@ -133,6 +144,7 @@ internal static class LiveSessionEndpoints
 
         group.MapPut("/live-sessions/{sessionId}/scores", HandleEditScore)
             .RequireAuthenticatedUser()
+            .RequireLiveSessionParticipant()
             .Produces(204)
             .Produces(400)
             .Produces(404)
@@ -141,6 +153,7 @@ internal static class LiveSessionEndpoints
 
         group.MapPost("/live-sessions/{sessionId}/advance-turn", HandleAdvanceTurn)
             .RequireAuthenticatedUser()
+            .RequireLiveSessionParticipant()
             .Produces(204)
             .Produces(404)
             .Produces(409)
@@ -149,6 +162,7 @@ internal static class LiveSessionEndpoints
 
         group.MapPost("/live-sessions/{sessionId}/advance-phase", HandleAdvancePhase)
             .RequireAuthenticatedUser()
+            .RequireLiveSessionParticipant()
             .Produces(204)
             .Produces(400)
             .Produces(404)
@@ -159,6 +173,7 @@ internal static class LiveSessionEndpoints
 
         group.MapPut("/live-sessions/{sessionId}/phases", HandleConfigurePhases)
             .RequireAuthenticatedUser()
+            .RequireLiveSessionParticipant()
             .Produces(204)
             .Produces(400)
             .Produces(404)
@@ -168,6 +183,7 @@ internal static class LiveSessionEndpoints
 
         group.MapPost("/live-sessions/{sessionId}/trigger-snapshot", HandleTriggerSnapshot)
             .RequireAuthenticatedUser()
+            .RequireLiveSessionParticipant()
             .Produces<SessionSnapshotDto>(201)
             .Produces(204)
             .Produces(400)
@@ -178,6 +194,7 @@ internal static class LiveSessionEndpoints
 
         group.MapPut("/live-sessions/{sessionId}/notes", HandleUpdateNotes)
             .RequireAuthenticatedUser()
+            .RequireLiveSessionParticipant()
             .Produces(204)
             .Produces(404)
             .WithTags("LiveSessions")
@@ -185,6 +202,7 @@ internal static class LiveSessionEndpoints
 
         group.MapPost("/live-sessions/{sessionId}/scores/parse", HandleParseScore)
             .RequireAuthenticatedUser()
+            .RequireLiveSessionParticipant()
             .Produces<ScoreParseResultDto>(200)
             .Produces(400)
             .Produces(404)
@@ -194,6 +212,7 @@ internal static class LiveSessionEndpoints
 
         group.MapPost("/live-sessions/{sessionId}/scores/confirm", HandleConfirmScore)
             .RequireAuthenticatedUser()
+            .RequireLiveSessionParticipant()
             .Produces(204)
             .Produces(400)
             .Produces(404)
@@ -202,6 +221,7 @@ internal static class LiveSessionEndpoints
 
         group.MapPost("/live-sessions/{sessionId}/save-complete", HandleSaveComplete)
             .RequireAuthenticatedUser()
+            .RequireLiveSessionParticipant()
             .Produces<SessionSaveResultDto>(200)
             .Produces(404)
             .Produces(409)
@@ -211,6 +231,7 @@ internal static class LiveSessionEndpoints
 
         group.MapPost("/live-sessions/{sessionId}/setup-checklist", HandleGenerateSetupChecklist)
             .RequireAuthenticatedUser()
+            .RequireLiveSessionParticipant()
             .Produces<SetupChecklistData>(200)
             .Produces(400)
             .Produces(404)
@@ -221,6 +242,7 @@ internal static class LiveSessionEndpoints
 
         group.MapPut("/live-sessions/{sessionId}/setup-checklist", HandleUpdateSetupChecklist)
             .RequireAuthenticatedUser()
+            .RequireLiveSessionParticipant()
             .Produces(204)
             .Produces(400)
             .Produces(404)
@@ -257,6 +279,7 @@ internal static class LiveSessionEndpoints
 
         group.MapPost("/live-sessions/{sessionId}/disputes", HandleOpenDispute)
             .RequireAuthenticatedUser()
+            .RequireLiveSessionParticipant()
             .Produces<Guid>(201)
             .Produces(400)
             .Produces(404)
@@ -266,6 +289,7 @@ internal static class LiveSessionEndpoints
 
         group.MapPut("/live-sessions/{sessionId}/disputes/{disputeId}/respond", HandleRespondToDispute)
             .RequireAuthenticatedUser()
+            .RequireLiveSessionParticipant()
             .Produces(204)
             .Produces(400)
             .Produces(404)
@@ -275,6 +299,7 @@ internal static class LiveSessionEndpoints
 
         group.MapPost("/live-sessions/{sessionId}/disputes/{disputeId}/timeout", HandleRespondentTimeout)
             .RequireAuthenticatedUser()
+            .RequireLiveSessionParticipant()
             .Produces(204)
             .Produces(400)
             .Produces(404)
@@ -284,6 +309,7 @@ internal static class LiveSessionEndpoints
 
         group.MapPost("/live-sessions/{sessionId}/disputes/{disputeId}/vote", HandleCastVote)
             .RequireAuthenticatedUser()
+            .RequireLiveSessionParticipant()
             .Produces(204)
             .Produces(400)
             .Produces(404)
@@ -293,6 +319,7 @@ internal static class LiveSessionEndpoints
 
         group.MapPost("/live-sessions/{sessionId}/disputes/{disputeId}/tally", HandleTallyVotes)
             .RequireAuthenticatedUser()
+            .RequireLiveSessionParticipant()
             .Produces(204)
             .Produces(400)
             .Produces(404)
@@ -328,6 +355,7 @@ internal static class LiveSessionEndpoints
 
         group.MapGet("/live-sessions/{sessionId}", HandleGetSession)
             .RequireAuthenticatedUser()
+            .RequireLiveSessionParticipant()
             .Produces<LiveSessionDto>(200)
             .Produces(404)
             .WithTags("LiveSessions")
@@ -336,6 +364,7 @@ internal static class LiveSessionEndpoints
 
         group.MapGet("/live-sessions/{sessionId}/scores", HandleGetSessionScores)
             .RequireAuthenticatedUser()
+            .RequireLiveSessionParticipant()
             .Produces<IReadOnlyList<LiveSessionRoundScoreDto>>(200)
             .Produces(404)
             .WithTags("LiveSessions")
@@ -343,6 +372,7 @@ internal static class LiveSessionEndpoints
 
         group.MapGet("/live-sessions/{sessionId}/players", HandleGetSessionPlayers)
             .RequireAuthenticatedUser()
+            .RequireLiveSessionParticipant()
             .Produces<IReadOnlyList<LiveSessionPlayerDto>>(200)
             .Produces(404)
             .WithTags("LiveSessions")
@@ -350,6 +380,7 @@ internal static class LiveSessionEndpoints
 
         group.MapGet("/live-sessions/{sessionId}/phases", HandleGetTurnPhases)
             .RequireAuthenticatedUser()
+            .RequireLiveSessionParticipant()
             .Produces<TurnPhasesDto>(200)
             .Produces(404)
             .WithTags("LiveSessions")
@@ -358,6 +389,7 @@ internal static class LiveSessionEndpoints
 
         group.MapGet("/live-sessions/{sessionId}/tools", HandleGetSessionTools)
             .RequireAuthenticatedUser()
+            .RequireLiveSessionParticipant()
             .Produces<SessionToolsDto>(200)
             .Produces(404)
             .WithTags("LiveSessions")
@@ -366,6 +398,7 @@ internal static class LiveSessionEndpoints
 
         group.MapGet("/live-sessions/{sessionId}/context", HandleGetSessionContext)
             .RequireAuthenticatedUser()
+            .RequireLiveSessionParticipant()
             .Produces<GameSessionContextDto>(200)
             .Produces(404)
             .WithTags("LiveSessions")
@@ -374,6 +407,7 @@ internal static class LiveSessionEndpoints
 
         group.MapPost("/live-sessions/{sessionId}/context/refresh", HandleRefreshSessionContext)
             .RequireAuthenticatedUser()
+            .RequireLiveSessionParticipant()
             .Produces<GameSessionContextDto>(200)
             .Produces(404)
             .WithTags("LiveSessions")
@@ -382,6 +416,7 @@ internal static class LiveSessionEndpoints
 
         group.MapGet("/live-sessions/{sessionId}/resume-context", HandleGetResumeContext)
             .RequireAuthenticatedUser()
+            .RequireLiveSessionParticipant()
             .Produces<SessionResumeContextDto>(200)
             .Produces(404)
             .WithTags("LiveSessions")

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/GameNight/CastVoteOnDisputeCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/GameNight/CastVoteOnDisputeCommandHandlerTests.cs
@@ -87,7 +87,8 @@ public class CastVoteOnDisputeCommandHandlerTests
         SetupDisputeGetById(disputeId, dispute);
 
         var command = new CastVoteOnDisputeCommand(
-            disputeId,
+            DefaultSessionId,
+disputeId,
             DefaultVoterPlayerId,
             AcceptsVerdict: true);
 
@@ -111,7 +112,8 @@ public class CastVoteOnDisputeCommandHandlerTests
         SetupFeatureFlagEnabled(false);
 
         var command = new CastVoteOnDisputeCommand(
-            Guid.NewGuid(),
+            DefaultSessionId,
+Guid.NewGuid(),
             DefaultVoterPlayerId,
             AcceptsVerdict: true);
 
@@ -132,7 +134,8 @@ public class CastVoteOnDisputeCommandHandlerTests
         SetupDisputeGetById(disputeId, null);
 
         var command = new CastVoteOnDisputeCommand(
-            disputeId,
+            DefaultSessionId,
+disputeId,
             DefaultVoterPlayerId,
             AcceptsVerdict: true);
 
@@ -156,7 +159,8 @@ public class CastVoteOnDisputeCommandHandlerTests
         SetupDisputeGetById(disputeId, dispute);
 
         var command = new CastVoteOnDisputeCommand(
-            disputeId,
+            DefaultSessionId,
+disputeId,
             DefaultVoterPlayerId,
             AcceptsVerdict: false);
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/GameNight/DisputeCrossSessionAuthzTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/GameNight/DisputeCrossSessionAuthzTests.cs
@@ -1,0 +1,93 @@
+using Api.BoundedContexts.GameManagement.Application.Commands.GameNight;
+using Api.BoundedContexts.GameManagement.Domain.Entities;
+using Api.BoundedContexts.GameManagement.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using Api.Services;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Application.Handlers.GameNight;
+
+/// <summary>
+/// Cross-session authorization tests for the dispute sub-resource handlers (#2573 review finding).
+/// The endpoint filter gates on the route {sessionId}; these handlers must additionally verify that
+/// the dispute (loaded by {disputeId}) actually belongs to that session — otherwise a participant of
+/// session A could mutate a dispute belonging to session B. The mismatch yields 404 (not 403) to
+/// avoid leaking the existence of disputes in other sessions.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "GameManagement")]
+public class DisputeCrossSessionAuthzTests
+{
+    private readonly Mock<IRuleDisputeRepository> _disputeRepo = new();
+
+    private static RuleDispute OpenDisputeInSession(Guid sessionId)
+        => RuleDispute.Open(sessionId, Guid.NewGuid(), Guid.NewGuid(), "Initiator claim");
+
+    private void SetupGetById(RuleDispute dispute)
+        => _disputeRepo.Setup(r => r.GetByIdAsync(dispute.Id, It.IsAny<CancellationToken>()))
+                       .ReturnsAsync(dispute);
+
+    [Fact]
+    public async Task RespondToDispute_DisputeBelongsToDifferentSession_ThrowsNotFound()
+    {
+        var dispute = OpenDisputeInSession(Guid.NewGuid());
+        SetupGetById(dispute);
+        var handler = new RespondToDisputeCommandHandler(_disputeRepo.Object, Mock.Of<IUnitOfWork>());
+
+        var command = new RespondToDisputeCommand(
+            SessionId: Guid.NewGuid(), DisputeId: dispute.Id,
+            RespondentPlayerId: Guid.NewGuid(), RespondentClaim: "counter");
+
+        var act = () => handler.Handle(command, CancellationToken.None);
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+
+    [Fact]
+    public async Task RespondentTimeout_DisputeBelongsToDifferentSession_ThrowsNotFound()
+    {
+        var dispute = OpenDisputeInSession(Guid.NewGuid());
+        SetupGetById(dispute);
+        var handler = new RespondentTimeoutCommandHandler(_disputeRepo.Object);
+
+        var command = new RespondentTimeoutCommand(SessionId: Guid.NewGuid(), DisputeId: dispute.Id);
+
+        var act = () => handler.Handle(command, CancellationToken.None);
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+
+    [Fact]
+    public async Task CastVote_DisputeBelongsToDifferentSession_ThrowsNotFound()
+    {
+        var dispute = OpenDisputeInSession(Guid.NewGuid());
+        SetupGetById(dispute);
+        var flag = new Mock<IFeatureFlagService>();
+        flag.Setup(x => x.IsEnabledAsync("Features:Arbitro.DemocraticOverride", null)).ReturnsAsync(true);
+        var handler = new CastVoteOnDisputeCommandHandler(_disputeRepo.Object, flag.Object, Mock.Of<IUnitOfWork>());
+
+        var command = new CastVoteOnDisputeCommand(
+            SessionId: Guid.NewGuid(), DisputeId: dispute.Id,
+            PlayerId: Guid.NewGuid(), AcceptsVerdict: true);
+
+        var act = () => handler.Handle(command, CancellationToken.None);
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+
+    [Fact]
+    public async Task TallyVotes_DisputeBelongsToDifferentSession_ThrowsNotFound()
+    {
+        var dispute = OpenDisputeInSession(Guid.NewGuid());
+        SetupGetById(dispute);
+        var handler = new TallyDisputeVotesCommandHandler(
+            _disputeRepo.Object, Mock.Of<ILiveSessionRepository>(), Mock.Of<IUnitOfWork>());
+
+        var command = new TallyDisputeVotesCommand(
+            SessionId: Guid.NewGuid(), DisputeId: dispute.Id);
+
+        var act = () => handler.Handle(command, CancellationToken.None);
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/GameNight/OpenStructuredDisputeCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/GameNight/OpenStructuredDisputeCommandHandlerTests.cs
@@ -248,6 +248,7 @@ public class OpenStructuredDisputeCommandHandlerTests
         SetupDisputeGetById(disputeId, dispute);
 
         var command = new RespondToDisputeCommand(
+            DefaultSessionId,
             disputeId,
             DefaultRespondentPlayerId,
             "I disagree, the rule says otherwise");
@@ -272,6 +273,7 @@ public class OpenStructuredDisputeCommandHandlerTests
         SetupDisputeGetById(disputeId, null);
 
         var command = new RespondToDisputeCommand(
+            DefaultSessionId,
             disputeId,
             DefaultRespondentPlayerId,
             "Some response");
@@ -296,7 +298,7 @@ public class OpenStructuredDisputeCommandHandlerTests
 
         SetupDisputeGetById(disputeId, dispute);
 
-        var command = new RespondentTimeoutCommand(disputeId);
+        var command = new RespondentTimeoutCommand(DefaultSessionId, disputeId);
 
         // Act — should not throw (no-op)
         await _timeoutHandler.Handle(command, CancellationToken.None);
@@ -313,7 +315,7 @@ public class OpenStructuredDisputeCommandHandlerTests
         var disputeId = Guid.NewGuid();
         SetupDisputeGetById(disputeId, null);
 
-        var command = new RespondentTimeoutCommand(disputeId);
+        var command = new RespondentTimeoutCommand(DefaultSessionId, disputeId);
 
         // Act & Assert
         var act =

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/GameNight/TallyDisputeVotesCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/GameNight/TallyDisputeVotesCommandHandlerTests.cs
@@ -104,7 +104,7 @@ public class TallyDisputeVotesCommandHandlerTests
         SetupDisputeGetById(disputeId, dispute);
         SetupSessionGetById(DefaultSessionId, session);
 
-        var command = new TallyDisputeVotesCommand(disputeId);
+        var command = new TallyDisputeVotesCommand(DefaultSessionId, disputeId);
 
         // Act
         await _handler.Handle(command, CancellationToken.None);
@@ -129,7 +129,7 @@ public class TallyDisputeVotesCommandHandlerTests
         SetupDisputeGetById(disputeId, dispute);
         SetupSessionGetById(DefaultSessionId, session);
 
-        var command = new TallyDisputeVotesCommand(disputeId, OverrideRule: "House rule: two moves allowed");
+        var command = new TallyDisputeVotesCommand(DefaultSessionId, disputeId, OverrideRule: "House rule: two moves allowed");
 
         // Act
         await _handler.Handle(command, CancellationToken.None);
@@ -154,7 +154,7 @@ public class TallyDisputeVotesCommandHandlerTests
         SetupDisputeGetById(disputeId, dispute);
         SetupSessionGetById(DefaultSessionId, session);
 
-        var command = new TallyDisputeVotesCommand(disputeId);
+        var command = new TallyDisputeVotesCommand(DefaultSessionId, disputeId);
 
         // Act
         await _handler.Handle(command, CancellationToken.None);
@@ -175,7 +175,7 @@ public class TallyDisputeVotesCommandHandlerTests
         var disputeId = Guid.NewGuid();
         SetupDisputeGetById(disputeId, null);
 
-        var command = new TallyDisputeVotesCommand(disputeId);
+        var command = new TallyDisputeVotesCommand(DefaultSessionId, disputeId);
 
         // Act & Assert
         var act =

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/LiveSessions/GetLiveSessionParticipantContextQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/LiveSessions/GetLiveSessionParticipantContextQueryHandlerTests.cs
@@ -1,0 +1,71 @@
+using Api.BoundedContexts.GameManagement.Application.Queries.LiveSessions;
+using Api.BoundedContexts.GameManagement.Domain.Entities;
+using Api.BoundedContexts.GameManagement.Domain.Repositories;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Application.Handlers.LiveSessions;
+
+/// <summary>
+/// Unit tests for <see cref="GetLiveSessionParticipantContextQueryHandler"/> — the non-throwing
+/// authz-resolution query backing the RequireLiveSessionParticipant endpoint filter (#2573).
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "GameManagement")]
+public class GetLiveSessionParticipantContextQueryHandlerTests
+{
+    private readonly Mock<ILiveSessionRepository> _repositoryMock = new();
+
+    private GetLiveSessionParticipantContextQueryHandler Sut() => new(_repositoryMock.Object);
+
+    private static LiveGameSession CreateSession(Guid sessionId, Guid creatorId) =>
+        LiveGameSession.Create(sessionId, creatorId, "Test Game", TimeProvider.System);
+
+    [Fact]
+    public async Task Handle_SessionNotFound_ReturnsNotFoundAndUnauthorized()
+    {
+        var id = Guid.NewGuid();
+        _repositoryMock
+            .Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((LiveGameSession?)null);
+
+        var result = await Sut().Handle(
+            new GetLiveSessionParticipantContextQuery(id, Guid.NewGuid()), CancellationToken.None);
+
+        result.Found.Should().BeFalse();
+        result.Authorized.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Handle_Creator_ReturnsFoundAndAuthorized()
+    {
+        var id = Guid.NewGuid();
+        var creator = Guid.NewGuid();
+        _repositoryMock
+            .Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateSession(id, creator));
+
+        var result = await Sut().Handle(
+            new GetLiveSessionParticipantContextQuery(id, creator), CancellationToken.None);
+
+        result.Found.Should().BeTrue();
+        result.Authorized.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Handle_NonParticipant_ReturnsFoundButUnauthorized()
+    {
+        var id = Guid.NewGuid();
+        _repositoryMock
+            .Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateSession(id, Guid.NewGuid()));
+
+        var result = await Sut().Handle(
+            new GetLiveSessionParticipantContextQuery(id, Guid.NewGuid()), CancellationToken.None);
+
+        result.Found.Should().BeTrue();
+        result.Authorized.Should().BeFalse();
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/Entities/LiveGameSessionAuthorizationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/Entities/LiveGameSessionAuthorizationTests.cs
@@ -1,0 +1,80 @@
+using Api.BoundedContexts.GameManagement.Domain.Entities;
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Domain.Entities;
+
+/// <summary>
+/// Unit tests for <see cref="LiveGameSession.IsAuthorizedParticipant"/> — the single source of
+/// truth for live-session participant authorization (#2573). Mirrors the canonical predicate
+/// (creator OR active linked player) and the IsActive / guest semantics from #2561.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "GameManagement")]
+public class LiveGameSessionAuthorizationTests
+{
+    private static LiveGameSession NewSession(Guid creatorId) =>
+        LiveGameSession.Create(Guid.NewGuid(), creatorId, "Test Game");
+
+    [Fact]
+    public void IsAuthorizedParticipant_Creator_ReturnsTrue()
+    {
+        var creator = Guid.NewGuid();
+        var session = NewSession(creator);
+
+        session.IsAuthorizedParticipant(creator).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsAuthorizedParticipant_ActiveLinkedPlayer_ReturnsTrue()
+    {
+        var creator = Guid.NewGuid();
+        var playerUserId = Guid.NewGuid();
+        var session = NewSession(creator);
+        session.AddPlayer(playerUserId, "Alice", PlayerColor.Red);
+
+        session.IsAuthorizedParticipant(playerUserId).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsAuthorizedParticipant_RemovedPlayer_ReturnsFalse()
+    {
+        var creator = Guid.NewGuid();
+        var playerUserId = Guid.NewGuid();
+        var session = NewSession(creator);
+        var player = session.AddPlayer(playerUserId, "Alice", PlayerColor.Red);
+
+        session.RemovePlayer(player.Id);
+
+        session.IsAuthorizedParticipant(playerUserId).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsAuthorizedParticipant_GuestPlayerPresent_DoesNotAuthorizeArbitraryUser()
+    {
+        var creator = Guid.NewGuid();
+        var session = NewSession(creator);
+        // Guest player has a null UserId; its presence must never authorize an arbitrary caller.
+        session.AddPlayer(null, "Guest", PlayerColor.Blue);
+
+        session.IsAuthorizedParticipant(Guid.NewGuid()).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsAuthorizedParticipant_Stranger_ReturnsFalse()
+    {
+        var session = NewSession(Guid.NewGuid());
+
+        session.IsAuthorizedParticipant(Guid.NewGuid()).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsAuthorizedParticipant_EmptyUserId_ReturnsFalse()
+    {
+        var session = NewSession(Guid.NewGuid());
+
+        session.IsAuthorizedParticipant(Guid.Empty).Should().BeFalse();
+    }
+}

--- a/apps/api/tests/Api.Tests/Filters/RequireLiveSessionParticipantFilterTests.cs
+++ b/apps/api/tests/Api.Tests/Filters/RequireLiveSessionParticipantFilterTests.cs
@@ -1,0 +1,125 @@
+using System.Security.Claims;
+using Api.BoundedContexts.GameManagement.Application.Queries.LiveSessions;
+using Api.Filters;
+using Api.Tests.Constants;
+using FluentAssertions;
+using MediatR;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.Filters;
+
+/// <summary>
+/// Unit tests for <see cref="RequireLiveSessionParticipantFilter"/> — the endpoint filter enforcing
+/// per-session participant authorization on live-session endpoints (#2573).
+/// 401 if unauthenticated, 404 if session missing/unresolvable, 403 if not a participant, else next().
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "GameManagement")]
+public class RequireLiveSessionParticipantFilterTests
+{
+    private readonly Mock<EndpointFilterDelegate> _nextMock = new();
+
+    private static EndpointFilterInvocationContext CreateContext(
+        Guid? userId, string? sessionIdRoute, IMediator? mediator)
+    {
+        var httpContext = new DefaultHttpContext();
+
+        if (userId.HasValue)
+        {
+            httpContext.User = new ClaimsPrincipal(new ClaimsIdentity(
+                new[] { new Claim(ClaimTypes.NameIdentifier, userId.Value.ToString()) }, "test"));
+        }
+
+        if (sessionIdRoute is not null)
+        {
+            httpContext.Request.RouteValues["sessionId"] = sessionIdRoute;
+        }
+
+        var services = new ServiceCollection();
+        if (mediator is not null)
+        {
+            services.AddSingleton(mediator);
+        }
+        httpContext.RequestServices = services.BuildServiceProvider();
+
+        return new DefaultEndpointFilterInvocationContext(httpContext);
+    }
+
+    private static Mock<IMediator> MediatorReturning(bool found, bool authorized)
+    {
+        var mock = new Mock<IMediator>();
+        mock.Setup(m => m.Send(
+                It.IsAny<GetLiveSessionParticipantContextQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new LiveSessionParticipantContextResult(found, authorized));
+        return mock;
+    }
+
+    [Fact]
+    public async Task InvokeAsync_NoAuthenticatedUser_Returns401_AndDoesNotCallNext()
+    {
+        var filter = new RequireLiveSessionParticipantFilter();
+        var context = CreateContext(userId: null, sessionIdRoute: Guid.NewGuid().ToString(), mediator: null);
+
+        var result = await filter.InvokeAsync(context, _nextMock.Object);
+
+        result.Should().BeAssignableTo<IStatusCodeHttpResult>().Which.StatusCode.Should().Be(401);
+        _nextMock.Verify(n => n(It.IsAny<EndpointFilterInvocationContext>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_MissingSessionIdRoute_Returns404_AndDoesNotCallNext()
+    {
+        var filter = new RequireLiveSessionParticipantFilter();
+        var context = CreateContext(userId: Guid.NewGuid(), sessionIdRoute: null, mediator: null);
+
+        var result = await filter.InvokeAsync(context, _nextMock.Object);
+
+        result.Should().BeAssignableTo<IStatusCodeHttpResult>().Which.StatusCode.Should().Be(404);
+        _nextMock.Verify(n => n(It.IsAny<EndpointFilterInvocationContext>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_SessionNotFound_Returns404_AndDoesNotCallNext()
+    {
+        var filter = new RequireLiveSessionParticipantFilter();
+        var mediator = MediatorReturning(found: false, authorized: false);
+        var context = CreateContext(Guid.NewGuid(), Guid.NewGuid().ToString(), mediator.Object);
+
+        var result = await filter.InvokeAsync(context, _nextMock.Object);
+
+        result.Should().BeAssignableTo<IStatusCodeHttpResult>().Which.StatusCode.Should().Be(404);
+        _nextMock.Verify(n => n(It.IsAny<EndpointFilterInvocationContext>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_NotParticipant_Returns403_AndDoesNotCallNext()
+    {
+        var filter = new RequireLiveSessionParticipantFilter();
+        var mediator = MediatorReturning(found: true, authorized: false);
+        var context = CreateContext(Guid.NewGuid(), Guid.NewGuid().ToString(), mediator.Object);
+
+        var result = await filter.InvokeAsync(context, _nextMock.Object);
+
+        result.Should().BeAssignableTo<IStatusCodeHttpResult>().Which.StatusCode.Should().Be(403);
+        _nextMock.Verify(n => n(It.IsAny<EndpointFilterInvocationContext>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_Participant_CallsNext()
+    {
+        var filter = new RequireLiveSessionParticipantFilter();
+        var mediator = MediatorReturning(found: true, authorized: true);
+        var context = CreateContext(Guid.NewGuid(), Guid.NewGuid().ToString(), mediator.Object);
+
+        var expected = Results.Ok("passed");
+        _nextMock.Setup(n => n(It.IsAny<EndpointFilterInvocationContext>())).ReturnsAsync(expected);
+
+        var result = await filter.InvokeAsync(context, _nextMock.Object);
+
+        result.Should().Be(expected);
+        _nextMock.Verify(n => n(It.IsAny<EndpointFilterInvocationContext>()), Times.Once);
+    }
+}

--- a/apps/api/tests/Api.Tests/Integration/GameManagement/LiveSessionParticipantAuthzEndpointTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/GameManagement/LiveSessionParticipantAuthzEndpointTests.cs
@@ -1,0 +1,276 @@
+using System.Net;
+using System.Net.Http.Json;
+using Api.BoundedContexts.GameManagement.Application.Commands.LiveSessions;
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.Integration.GameManagement;
+
+/// <summary>
+/// Integration tests for the per-session participant authorization filter (#2573),
+/// proving end-to-end that RequireLiveSessionParticipant blocks non-participants with 403,
+/// returns 404 before 403 for unknown sessions, 401 for anonymous callers, and lets the
+/// creator/active participant through. Covers representative write + read endpoints; the
+/// per-handler authz breadth is unit-tested in LiveGameSessionAuthorizationTests /
+/// GetLiveSessionParticipantContextQueryHandlerTests / RequireLiveSessionParticipantFilterTests.
+///
+/// Mirrors LiveSessionDiaryEndpointTests (Testcontainers fixture, cookie auth, IMediator setup).
+/// </summary>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "GameManagement")]
+[Trait("Issue", "2573")]
+public sealed class LiveSessionParticipantAuthzEndpointTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly string _databaseName = $"live_authz_{Guid.NewGuid():N}";
+    private Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<Program> _factory = null!;
+
+    public LiveSessionParticipantAuthzEndpointTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+        await TestcontainersWaitHelpers.WaitForPostgresReadyAsync(connectionString);
+
+        _factory = IntegrationWebApplicationFactory.Create(connectionString);
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        await db.Database.MigrateAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_factory != null)
+        {
+            await _factory.DisposeAsync();
+        }
+        await _fixture.DropIsolatedDatabaseAsync(_databaseName);
+    }
+
+    // ── Write 403s ──────────────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "PUT /notes returns 403 for an authenticated non-participant")]
+    public async Task Write_Notes_NonParticipant_Returns403()
+    {
+        var (_, sessionId) = await CreateCreatorSessionAsync();
+        var (clientB, tokenB) = await CreateOtherUserClientAsync();
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Put, $"/api/v1/live-sessions/{sessionId}/notes", tokenB);
+        request.Content = JsonContent.Create(new { notes = "intruder" });
+
+        var response = await clientB.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact(DisplayName = "POST /scores returns 403 for an authenticated non-participant")]
+    public async Task Write_RecordScore_NonParticipant_Returns403()
+    {
+        var (_, sessionId) = await CreateCreatorSessionAsync();
+        var (clientB, tokenB) = await CreateOtherUserClientAsync();
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Post, $"/api/v1/live-sessions/{sessionId}/scores", tokenB);
+        request.Content = JsonContent.Create(new { playerId = Guid.NewGuid(), round = 1, dimension = "points", value = 0 });
+
+        var response = await clientB.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact(DisplayName = "POST /complete returns 403 for an authenticated non-participant")]
+    public async Task Write_Complete_NonParticipant_Returns403()
+    {
+        var (_, sessionId) = await CreateCreatorSessionAsync();
+        var (clientB, tokenB) = await CreateOtherUserClientAsync();
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Post, $"/api/v1/live-sessions/{sessionId}/complete", tokenB);
+
+        var response = await clientB.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    // ── Read 403s ───────────────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "GET /{sessionId} returns 403 for an authenticated non-participant")]
+    public async Task Read_GetSession_NonParticipant_Returns403()
+    {
+        var (_, sessionId) = await CreateCreatorSessionAsync();
+        var (clientB, tokenB) = await CreateOtherUserClientAsync();
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get, $"/api/v1/live-sessions/{sessionId}", tokenB);
+
+        var response = await clientB.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact(DisplayName = "GET /resume-context returns 403 for an authenticated non-participant")]
+    public async Task Read_ResumeContext_NonParticipant_Returns403()
+    {
+        var (_, sessionId) = await CreateCreatorSessionAsync();
+        var (clientB, tokenB) = await CreateOtherUserClientAsync();
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get, $"/api/v1/live-sessions/{sessionId}/resume-context", tokenB);
+
+        var response = await clientB.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    // ── Positive path ─────────────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "PUT /notes succeeds (204) for the session creator")]
+    public async Task Write_Notes_Creator_Succeeds()
+    {
+        var (client, sessionId) = await CreateCreatorSessionAsync();
+
+        var token = client.DefaultRequestHeaders.GetValues("X-Test-Session-Token").First();
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Put, $"/api/v1/live-sessions/{sessionId}/notes", token);
+        request.Content = JsonContent.Create(new { notes = "session notes by the owner" });
+
+        var response = await client.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent,
+            "the creator is a participant and the session is not Completed");
+    }
+
+    // ── 404 before 403 ────────────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "PUT /notes on a nonexistent session returns 404 (not 403)")]
+    public async Task Write_Notes_NonexistentSession_Returns404()
+    {
+        var (clientB, tokenB) = await CreateOtherUserClientAsync();
+        var unknownSessionId = Guid.NewGuid();
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Put, $"/api/v1/live-sessions/{unknownSessionId}/notes", tokenB);
+        request.Content = JsonContent.Create(new { notes = "no such session" });
+
+        var response = await clientB.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound,
+            "a missing session must yield 404 before the participant check produces 403");
+    }
+
+    // ── 401 anonymous ─────────────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "PUT /notes without a session cookie returns 401")]
+    public async Task Write_Notes_Unauthenticated_Returns401()
+    {
+        var anon = _factory.CreateClient();
+        var sessionId = Guid.NewGuid();
+
+        var response = await anon.PutAsJsonAsync(
+            $"/api/v1/live-sessions/{sessionId}/notes", new { notes = "anon" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    // ── Removed player loses access (#2561 IsActive semantics) ─────────────────────
+
+    [Fact(DisplayName = "Removed linked player gets 403 on a write endpoint")]
+    public async Task Write_RemovedPlayer_Returns403()
+    {
+        // Arrange: creator owns the session; user B is added as a linked player, then removed.
+        var (_, sessionId) = await CreateCreatorSessionAsync();
+
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+        var userBId = await SeedUserAsync(db);
+        var (_, tokenB) = await TestSessionHelper.CreateUserSessionAsync(db, userBId);
+
+        var playerId = await mediator.Send(new AddPlayerToLiveSessionCommand(
+            SessionId: sessionId, DisplayName: "B", Color: PlayerColor.Blue,
+            UserId: userBId, Role: null, AvatarUrl: null));
+        await mediator.Send(new RemovePlayerFromLiveSessionCommand(sessionId, playerId));
+
+        var clientB = _factory.CreateClient();
+        clientB.DefaultRequestHeaders.Add("Cookie", $"{TestSessionHelper.SessionCookieName}={tokenB}");
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Put, $"/api/v1/live-sessions/{sessionId}/notes", tokenB);
+        request.Content = JsonContent.Create(new { notes = "I was removed" });
+
+        // Act
+        var response = await clientB.SendAsync(request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden,
+            "a removed (deactivated) player loses participant access per #2561");
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────────
+
+    /// <summary>Seeds a user + session, creates a LiveGameSession owned by that user, returns an authenticated client.</summary>
+    private async Task<(HttpClient Client, Guid SessionId)> CreateCreatorSessionAsync()
+    {
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+        var userId = await SeedUserAsync(db);
+        var (_, token) = await TestSessionHelper.CreateUserSessionAsync(db, userId);
+
+        var sessionId = await mediator.Send(new CreateLiveSessionCommand(
+            UserId: userId, GameName: "Authz Test Game", GameId: null));
+
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Add("Cookie", $"{TestSessionHelper.SessionCookieName}={token}");
+        client.DefaultRequestHeaders.Add("X-Test-Session-Token", token);
+        return (client, sessionId);
+    }
+
+    /// <summary>Creates an authenticated client for a different user who is NOT a participant of any session.</summary>
+    private async Task<(HttpClient Client, string Token)> CreateOtherUserClientAsync()
+    {
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, token) = await TestSessionHelper.CreateUserSessionAsync(db);
+
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Add("Cookie", $"{TestSessionHelper.SessionCookieName}={token}");
+        return (client, token);
+    }
+
+    private static async Task<Guid> SeedUserAsync(MeepleAiDbContext db)
+    {
+        var userId = Guid.NewGuid();
+        db.Users.Add(new UserEntity
+        {
+            Id = userId,
+            Email = $"authz-test-{userId:N}@test.local",
+            DisplayName = "Authz Test User",
+            PasswordHash = "not-a-real-hash",
+            Role = "user",
+            Tier = "free",
+            Status = "Active",
+            EmailVerified = true,
+            CreatedAt = DateTime.UtcNow
+        });
+        await db.SaveChangesAsync();
+        return userId;
+    }
+}

--- a/docs/superpowers/plans/2026-06-29-issue-2573-live-session-participant-authz.md
+++ b/docs/superpowers/plans/2026-06-29-issue-2573-live-session-participant-authz.md
@@ -1,0 +1,632 @@
+# Live-Session Participant Authorization (#2573) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close the systemic IDOR on live-session endpoints — any authenticated user can currently mutate or read another user's live session — by enforcing per-session participant authorization on all `{sessionId}`-scoped write and sensitive-read endpoints.
+
+**Architecture:** Single source of truth as a domain method `LiveGameSession.IsAuthorizedParticipant(userId)`; a non-throwing CQRS query `GetLiveSessionParticipantContextQuery` (dedicated file, mirrors the existing stream-context query); a reusable ASP.NET endpoint filter `RequireLiveSessionParticipantFilter` exposed via `.RequireLiveSessionParticipant()`, applied to ~35 endpoints in `LiveSessionEndpoints.cs`. The filter returns 401/404/403 directly (same convention as the existing `RequireAuthenticatedUser`/`RequireAdminSession` filters). No `Handle*` body signatures and no command/query records are modified, keeping the diff isolated from the in-flight epic #2501 work.
+
+**Tech Stack:** .NET 9, ASP.NET Minimal APIs + endpoint filters, MediatR (CQRS), EF Core, xUnit + FluentAssertions + Testcontainers (integration).
+
+## Global Constraints
+
+- **CQRS (CLAUDE.md):** endpoints use `IMediator.Send()` only; no direct service injection. The filter resolves `IMediator` from `HttpContext.RequestServices` — acceptable for a cross-cutting filter, consistent with the stream endpoint's mediator use.
+- **Authz rule (canonical, verbatim):** `CreatedByUserId == userId || Players.Any(p => p.IsActive && p.UserId == userId)`.
+- **404-before-403 ordering:** a non-existent session yields 404, never 403.
+- **Guests never match:** `LiveSessionPlayer.UserId` is `Guid?`; a guest (`null`) must never authorize a caller. Never compare `null == null`.
+- **`IsActive` is load-bearing (#2561):** a removed/kicked player (soft-deactivated) loses access. Do not drop the `p.IsActive` clause.
+- **ADR-060:** unchanged here — no mutating handler is added; the filter only reads.
+- **Exceptions:** `ForbiddenException` / `NotFoundException` live in `Api.Middleware.Exceptions`. The filter, however, returns `Results.*` directly (it is not in a handler), matching existing filters.
+- **Scope (locked):** write **and** sensitive reads (35 endpoints). Admin actions use the **same** participant rule (no host-only tier). Exempt: create, join-by-code, `/active`, `/games/{gameId}/dispute-history`, diary POST/GET (already covered), stream (already covered).
+- **Branch:** `feature/issue-2573-live-session-authz` (parent `main-dev`).
+
+## File Structure
+
+**Create:**
+- `apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/LiveSessions/GetLiveSessionParticipantContextQuery.cs` — query + result records.
+- `apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/LiveSessions/GetLiveSessionParticipantContextQueryHandler.cs` — non-throwing handler.
+- `apps/api/src/Api/Filters/RequireLiveSessionParticipantFilter.cs` — the endpoint filter.
+- `apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/Entities/LiveGameSessionAuthorizationTests.cs` — unit tests for the domain method.
+- `apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/LiveSessions/GetLiveSessionParticipantContextQueryHandlerTests.cs` — unit tests for the handler.
+- `apps/api/tests/Api.Tests/Integration/GameManagement/LiveSessionParticipantAuthzEndpointTests.cs` — integration tests for the filter wiring.
+
+**Modify:**
+- `apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/LiveGameSession.cs` — add `IsAuthorizedParticipant`.
+- `apps/api/src/Api/Extensions/EndpointFilterExtensions.cs` — add `RequireLiveSessionParticipant()`.
+- `apps/api/src/Api/Routing/LiveSessionEndpoints.cs` — add `.RequireLiveSessionParticipant()` to 35 endpoints (+ `.Produces(403)` where missing).
+- (Refactor, Task 6) `GetLiveSessionStreamContextQueryHandler.cs`, `GetLiveSessionDiaryQueryHandler.cs`, `AddDiaryEntryCommandHandler.cs` — reuse the domain method.
+
+---
+
+### Task 1: Domain method `IsAuthorizedParticipant`
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/LiveGameSession.cs`
+- Test: `apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/Entities/LiveGameSessionAuthorizationTests.cs`
+
+**Interfaces:**
+- Produces: `public bool IsAuthorizedParticipant(Guid userId)` on `LiveGameSession`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `LiveGameSessionAuthorizationTests.cs`. Build sessions via the existing factory `LiveGameSession.Create(...)` and `AddPlayer(...)` (match the constructor signature already used in `LiveGameSessionTests.cs`; inspect that file for the exact `Create` parameters before writing).
+
+```csharp
+using Api.BoundedContexts.GameManagement.Domain.Entities;
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Domain.Entities;
+
+public class LiveGameSessionAuthorizationTests
+{
+    private static LiveGameSession NewSession(Guid creatorId) =>
+        LiveGameSession.Create(creatorId, "Test Game", gameId: null);
+
+    [Fact]
+    public void IsAuthorizedParticipant_Creator_ReturnsTrue()
+    {
+        var creator = Guid.NewGuid();
+        var session = NewSession(creator);
+        session.IsAuthorizedParticipant(creator).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsAuthorizedParticipant_ActiveLinkedPlayer_ReturnsTrue()
+    {
+        var creator = Guid.NewGuid();
+        var player = Guid.NewGuid();
+        var session = NewSession(creator);
+        session.AddPlayer(player, "Alice", PlayerColor.Red, role: null, avatarUrl: null);
+        session.IsAuthorizedParticipant(player).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsAuthorizedParticipant_RemovedPlayer_ReturnsFalse()
+    {
+        var creator = Guid.NewGuid();
+        var player = Guid.NewGuid();
+        var session = NewSession(creator);
+        var playerId = session.AddPlayer(player, "Alice", PlayerColor.Red, role: null, avatarUrl: null);
+        session.RemovePlayer(playerId);
+        session.IsAuthorizedParticipant(player).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsAuthorizedParticipant_GuestPlayer_NullUser_DoesNotAuthorizeEmptyCaller()
+    {
+        var creator = Guid.NewGuid();
+        var session = NewSession(creator);
+        session.AddPlayer(userId: null, "Guest", PlayerColor.Blue, role: null, avatarUrl: null);
+        session.IsAuthorizedParticipant(Guid.Empty).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsAuthorizedParticipant_Stranger_ReturnsFalse()
+    {
+        var session = NewSession(Guid.NewGuid());
+        session.IsAuthorizedParticipant(Guid.NewGuid()).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsAuthorizedParticipant_EmptyUserId_ReturnsFalse()
+    {
+        var session = NewSession(Guid.NewGuid());
+        session.IsAuthorizedParticipant(Guid.Empty).Should().BeFalse();
+    }
+}
+```
+
+> NOTE before writing: open `apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/Entities/LiveGameSessionTests.cs` and copy the EXACT `LiveGameSession.Create(...)` and `AddPlayer(...)` signatures (parameter order, optional args, return type of `AddPlayer`). The calls above assume `Create(Guid createdByUserId, string gameName, Guid? gameId)` and `AddPlayer(Guid? userId, string displayName, PlayerColor color, PlayerRole? role, string? avatarUrl) -> Guid playerId`. Adjust to the real signatures if they differ.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `dotnet test apps/api/tests/Api.Tests --filter "FullyQualifiedName~LiveGameSessionAuthorizationTests"`
+Expected: FAIL — `LiveGameSession` has no `IsAuthorizedParticipant` (compile error).
+
+- [ ] **Step 3: Add the domain method**
+
+In `LiveGameSession.cs`, add this method next to the computed members (e.g. after the `Host` property / `HasPlayers`). `_players` is the backing `List<LiveSessionPlayer>`; if the private field has a different name, use the public `Players` collection instead.
+
+```csharp
+/// <summary>
+/// Returns true if <paramref name="userId"/> is authorized to act on this session as a participant:
+/// the session creator, OR an active linked player. Guest players (UserId == null) never match,
+/// and a removed/deactivated player (IsActive == false) loses access (#2561).
+/// Single source of truth for live-session participant authorization. Issue #2573.
+/// </summary>
+public bool IsAuthorizedParticipant(Guid userId)
+{
+    if (userId == Guid.Empty)
+    {
+        return false;
+    }
+
+    return CreatedByUserId == userId
+        || _players.Any(p => p.IsActive && p.UserId == userId);
+}
+```
+
+Ensure `using System.Linq;` is present (it usually already is in the aggregate).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `dotnet test apps/api/tests/Api.Tests --filter "FullyQualifiedName~LiveGameSessionAuthorizationTests"`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/LiveGameSession.cs \
+        apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/Entities/LiveGameSessionAuthorizationTests.cs
+git commit -m "feat(session-live): add LiveGameSession.IsAuthorizedParticipant domain method (#2573)"
+```
+
+---
+
+### Task 2: Participant-context query + handler
+
+**Files:**
+- Create: `.../Application/Queries/LiveSessions/GetLiveSessionParticipantContextQuery.cs`
+- Create: `.../Application/Queries/LiveSessions/GetLiveSessionParticipantContextQueryHandler.cs`
+- Test: `apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/LiveSessions/GetLiveSessionParticipantContextQueryHandlerTests.cs`
+
+**Interfaces:**
+- Consumes: `LiveGameSession.IsAuthorizedParticipant(Guid)` (Task 1); `ILiveSessionRepository.GetByIdAsync(Guid, CancellationToken)`.
+- Produces: `internal record GetLiveSessionParticipantContextQuery(Guid SessionId, Guid UserId) : IQuery<LiveSessionParticipantContextResult>` and `internal record LiveSessionParticipantContextResult(bool Found, bool Authorized)`.
+
+- [ ] **Step 1: Write the failing handler test**
+
+Mirror `GetLiveSessionDiaryQueryHandlerTests` (mock `ILiveSessionRepository`). Inspect that file for the mock setup helper before writing.
+
+```csharp
+using Api.BoundedContexts.GameManagement.Application.Queries.LiveSessions;
+using Api.BoundedContexts.GameManagement.Domain.Entities;
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+using Api.BoundedContexts.GameManagement.Domain.Repositories;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Application.Handlers.LiveSessions;
+
+public class GetLiveSessionParticipantContextQueryHandlerTests
+{
+    private readonly Mock<ILiveSessionRepository> _repo = new();
+    private GetLiveSessionParticipantContextQueryHandler Sut() => new(_repo.Object);
+
+    [Fact]
+    public async Task Handle_SessionNotFound_ReturnsNotFoundAndUnauthorized()
+    {
+        var id = Guid.NewGuid();
+        _repo.Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>()))
+             .ReturnsAsync((LiveGameSession?)null);
+
+        var result = await Sut().Handle(new GetLiveSessionParticipantContextQuery(id, Guid.NewGuid()), default);
+
+        result.Found.Should().BeFalse();
+        result.Authorized.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Handle_Creator_ReturnsFoundAndAuthorized()
+    {
+        var creator = Guid.NewGuid();
+        var session = LiveGameSession.Create(creator, "Test Game", gameId: null);
+        _repo.Setup(r => r.GetByIdAsync(session.Id, It.IsAny<CancellationToken>()))
+             .ReturnsAsync(session);
+
+        var result = await Sut().Handle(new GetLiveSessionParticipantContextQuery(session.Id, creator), default);
+
+        result.Found.Should().BeTrue();
+        result.Authorized.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Handle_NonParticipant_ReturnsFoundButUnauthorized()
+    {
+        var session = LiveGameSession.Create(Guid.NewGuid(), "Test Game", gameId: null);
+        _repo.Setup(r => r.GetByIdAsync(session.Id, It.IsAny<CancellationToken>()))
+             .ReturnsAsync(session);
+
+        var result = await Sut().Handle(new GetLiveSessionParticipantContextQuery(session.Id, Guid.NewGuid()), default);
+
+        result.Found.Should().BeTrue();
+        result.Authorized.Should().BeFalse();
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `dotnet test apps/api/tests/Api.Tests --filter "FullyQualifiedName~GetLiveSessionParticipantContextQueryHandlerTests"`
+Expected: FAIL (types don't exist — compile error).
+
+- [ ] **Step 3: Create the query + result records**
+
+`GetLiveSessionParticipantContextQuery.cs`:
+
+```csharp
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.GameManagement.Application.Queries.LiveSessions;
+
+/// <summary>
+/// Result of the live-session participant authorization query.
+/// Found = a session with SessionId exists; Authorized = UserId is the creator or an active linked player.
+/// Non-throwing so the RequireLiveSessionParticipant endpoint filter maps the flags to 404/403. Issue #2573.
+/// </summary>
+internal record LiveSessionParticipantContextResult(bool Found, bool Authorized);
+
+/// <summary>
+/// Query to resolve per-session participant authorization for live-session write/read endpoints.
+/// Mirrors GetLiveSessionStreamContextQuery without companion-presence. Issue #2573.
+/// </summary>
+internal record GetLiveSessionParticipantContextQuery(Guid SessionId, Guid UserId)
+    : IQuery<LiveSessionParticipantContextResult>;
+```
+
+- [ ] **Step 4: Create the handler**
+
+`GetLiveSessionParticipantContextQueryHandler.cs`:
+
+```csharp
+using Api.BoundedContexts.GameManagement.Domain.Repositories;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.GameManagement.Application.Queries.LiveSessions;
+
+/// <summary>
+/// Handles <see cref="GetLiveSessionParticipantContextQuery"/>. Resolves session-found + caller-authorized
+/// without throwing, so the RequireLiveSessionParticipant endpoint filter controls the HTTP response. Issue #2573.
+/// </summary>
+internal sealed class GetLiveSessionParticipantContextQueryHandler
+    : IQueryHandler<GetLiveSessionParticipantContextQuery, LiveSessionParticipantContextResult>
+{
+    private readonly ILiveSessionRepository _sessionRepository;
+
+    public GetLiveSessionParticipantContextQueryHandler(ILiveSessionRepository sessionRepository)
+    {
+        _sessionRepository = sessionRepository ?? throw new ArgumentNullException(nameof(sessionRepository));
+    }
+
+    public async Task<LiveSessionParticipantContextResult> Handle(
+        GetLiveSessionParticipantContextQuery query,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var session = await _sessionRepository
+            .GetByIdAsync(query.SessionId, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (session is null)
+        {
+            return new LiveSessionParticipantContextResult(Found: false, Authorized: false);
+        }
+
+        return new LiveSessionParticipantContextResult(
+            Found: true,
+            Authorized: session.IsAuthorizedParticipant(query.UserId));
+    }
+}
+```
+
+> NOTE: confirm `IQueryHandler<,>` and `IQuery<>` namespaces against `GetLiveSessionStreamContextQueryHandler.cs` (it uses `Api.SharedKernel.Application.Interfaces`). MediatR handler auto-registration: verify these query handlers are discovered by the existing assembly scan (the stream/diary handlers are, so a sibling file in the same namespace will be too).
+
+- [ ] **Step 5: Run to verify it passes**
+
+Run: `dotnet test apps/api/tests/Api.Tests --filter "FullyQualifiedName~GetLiveSessionParticipantContextQueryHandlerTests"`
+Expected: PASS (3 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/LiveSessions/GetLiveSessionParticipantContextQuery.cs \
+        apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/LiveSessions/GetLiveSessionParticipantContextQueryHandler.cs \
+        apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/LiveSessions/GetLiveSessionParticipantContextQueryHandlerTests.cs
+git commit -m "feat(session-live): add GetLiveSessionParticipantContextQuery (#2573)"
+```
+
+---
+
+### Task 3: `RequireLiveSessionParticipant` endpoint filter + extension
+
+**Files:**
+- Create: `apps/api/src/Api/Filters/RequireLiveSessionParticipantFilter.cs`
+- Modify: `apps/api/src/Api/Extensions/EndpointFilterExtensions.cs`
+
+**Interfaces:**
+- Consumes: `GetLiveSessionParticipantContextQuery` (Task 2); `ClaimsPrincipal.GetUserId()` (`Api.Extensions`).
+- Produces: `RequireLiveSessionParticipantFilter : IEndpointFilter`; `RouteHandlerBuilder.RequireLiveSessionParticipant()`.
+
+- [ ] **Step 1: Create the filter**
+
+`RequireLiveSessionParticipantFilter.cs`:
+
+```csharp
+using Api.BoundedContexts.GameManagement.Application.Queries.LiveSessions;
+using Api.Extensions;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Api.Filters;
+
+/// <summary>
+/// Endpoint filter enforcing per-session participant authorization on live-session endpoints (#2573).
+/// The caller must be the session creator or an active linked player.
+/// Returns 401 if unauthenticated, 404 if the session does not exist, 403 if not a participant.
+/// Reads the {sessionId} route value. Apply AFTER .RequireAuthenticatedUser().
+/// Mirrors the response convention of RequireAuthenticatedUser/RequireAdminSession (returns Results.*).
+/// </summary>
+internal sealed class RequireLiveSessionParticipantFilter : IEndpointFilter
+{
+    public async ValueTask<object?> InvokeAsync(
+        EndpointFilterInvocationContext context,
+        EndpointFilterDelegate next)
+    {
+        var httpContext = context.HttpContext;
+
+        var userId = httpContext.User.GetUserId();
+        if (userId == Guid.Empty)
+        {
+            return Results.Unauthorized();
+        }
+
+        if (!httpContext.Request.RouteValues.TryGetValue("sessionId", out var rawSessionId)
+            || !Guid.TryParse(rawSessionId?.ToString(), out var sessionId))
+        {
+            return Results.NotFound(new { error = "Live session not found" });
+        }
+
+        var mediator = httpContext.RequestServices.GetRequiredService<IMediator>();
+        var ctx = await mediator
+            .Send(new GetLiveSessionParticipantContextQuery(sessionId, userId), httpContext.RequestAborted)
+            .ConfigureAwait(false);
+
+        if (!ctx.Found)
+        {
+            return Results.NotFound(new { error = "Live session not found" });
+        }
+
+        if (!ctx.Authorized)
+        {
+            return Results.StatusCode(403);
+        }
+
+        return await next(context).ConfigureAwait(false);
+    }
+}
+```
+
+- [ ] **Step 2: Add the fluent extension**
+
+In `EndpointFilterExtensions.cs`, add after `RequireAuthenticatedUser`:
+
+```csharp
+/// <summary>
+/// Requires the caller to be a participant (creator or active linked player) of the live session
+/// identified by the {sessionId} route value. Returns 401 / 404 / 403. Apply AFTER .RequireAuthenticatedUser().
+/// Issue #2573.
+/// </summary>
+public static RouteHandlerBuilder RequireLiveSessionParticipant(this RouteHandlerBuilder builder)
+{
+    return builder.AddEndpointFilter<RequireLiveSessionParticipantFilter>();
+}
+```
+
+- [ ] **Step 3: Build to verify it compiles**
+
+Run: `dotnet build apps/api/src/Api/Api.csproj`
+Expected: Build succeeded (filter not yet wired to any endpoint).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/api/src/Api/Filters/RequireLiveSessionParticipantFilter.cs \
+        apps/api/src/Api/Extensions/EndpointFilterExtensions.cs
+git commit -m "feat(session-live): add RequireLiveSessionParticipant endpoint filter (#2573)"
+```
+
+---
+
+### Task 4: Wire the filter to the 35 endpoints
+
+**Files:**
+- Modify: `apps/api/src/Api/Routing/LiveSessionEndpoints.cs`
+
+**Interfaces:**
+- Consumes: `RouteHandlerBuilder.RequireLiveSessionParticipant()` (Task 3).
+
+- [ ] **Step 1: Add `.RequireLiveSessionParticipant()` after `.RequireAuthenticatedUser()` on each of these 35 routes.** Also add `.Produces(403)` to each (and `.Produces(404)` if not already present) for OpenAPI accuracy.
+
+WRITE (28):
+`/live-sessions/{sessionId}/start`, `/pause`, `/resume`, `/complete`, `/save`,
+`/players` (POST), `/players/{playerId}` (DELETE), `/turn-order` (PUT),
+`/teams` (POST), `/teams/{teamId}/players/{playerId}` (PUT),
+`/scores` (POST), `/scores` (PUT), `/advance-turn`, `/advance-phase`,
+`/phases` (PUT), `/trigger-snapshot`, `/notes` (PUT), `/scores/parse`,
+`/scores/confirm`, `/save-complete`, `/setup-checklist` (POST), `/setup-checklist` (PUT),
+`/disputes` (POST), `/disputes/{disputeId}/respond` (PUT), `/disputes/{disputeId}/timeout` (POST),
+`/disputes/{disputeId}/vote` (POST), `/disputes/{disputeId}/tally` (POST), `/context/refresh` (POST)
+
+SENSITIVE READS (7):
+`/live-sessions/{sessionId}` (GET), `/scores` (GET), `/players` (GET), `/phases` (GET),
+`/tools` (GET), `/context` (GET), `/resume-context` (GET)
+
+Example transformation (start):
+
+```csharp
+group.MapPost("/live-sessions/{sessionId}/start", HandleStartSession)
+    .RequireAuthenticatedUser()
+    .RequireLiveSessionParticipant()
+    .Produces(204)
+    .Produces(401)
+    .Produces(403)
+    .Produces(404)
+    .Produces(409)
+    .WithTags("LiveSessions")
+    .WithSummary("Start a live session")
+    .WithDescription("Transitions session from Created/Setup to InProgress. 403 if caller is not a participant.");
+```
+
+**DO NOT** add the filter to: `/live-sessions` (POST create), `/live-sessions/code/{code}` (GET), `/live-sessions/active` (GET), `/games/{gameId}/dispute-history` (GET), `/live-sessions/{sessionId}/diary` (POST + GET — already enforced in handler), `/live-sessions/{sessionId:guid}/stream` (GET — already enforced).
+
+> Dispute sub-endpoints (`respond`/`timeout`/`vote`/`tally`) carry `{sessionId}` in the route; the filter gates on that. KNOWN LIMITATION to note in the PR: the filter checks participation in the route's sessionId, not that the dispute actually belongs to that session (cross-consistency `dispute.SessionId == route sessionId` is a separate validation — out of scope for #2573).
+
+- [ ] **Step 2: Build**
+
+Run: `dotnet build apps/api/src/Api/Api.csproj`
+Expected: Build succeeded.
+
+- [ ] **Step 3: Run the full GameManagement live-session unit/integration suite to catch regressions from the new filter**
+
+Run: `dotnet test apps/api/tests/Api.Tests --filter "FullyQualifiedName~LiveSession"`
+Expected: PASS (existing tests unaffected; the new filter only blocks non-participants, and existing tests act as the creator/participant). If any existing test now 403s, it was acting as a non-participant against a write endpoint — fix the test setup to add the acting user as a participant (this is the bug-surfacing value of the filter).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/api/src/Api/Routing/LiveSessionEndpoints.cs
+git commit -m "feat(session-live): enforce participant authz on 35 live-session endpoints (#2573)"
+```
+
+---
+
+### Task 5: Integration tests (filter wiring, end-to-end)
+
+**Files:**
+- Create: `apps/api/tests/Api.Tests/Integration/GameManagement/LiveSessionParticipantAuthzEndpointTests.cs`
+
+**Interfaces:**
+- Consumes: `IntegrationWebApplicationFactory`, `TestSessionHelper` (cookie auth), `IMediator` setup commands.
+
+- [ ] **Step 1: Write the integration tests.** Model the class on `LiveSessionStreamEndpointTests` / `LiveSessionDiaryEndpointTests` (same `[Collection]`, fixture, `IAsyncLifetime`). Cover representative verbs end-to-end; rely on Task 1/2 units for breadth.
+
+Tests to write (one method each):
+1. `Write_Complete_NonParticipant_Returns403` — user A creates + AddPlayer + Start; user B (valid session, not linked) `POST /complete` → 403.
+2. `Write_RecordScore_NonParticipant_Returns403` — user B `POST /scores` → 403.
+3. `Read_GetSession_NonParticipant_Returns403` — user B `GET /live-sessions/{id}` → 403.
+4. `Read_ResumeContext_NonParticipant_Returns403` — user B `GET /resume-context` → 403 (the photo-leak read).
+5. `Write_RecordScore_Creator_Succeeds` — user A (creator) `POST /scores` → 204 (positive path; proves the filter does not block participants).
+6. `Write_RecordScore_NonexistentSession_Returns404` — any authed user, random Guid → 404 (404-before-403).
+7. `Write_RecordScore_Unauthenticated_Returns401` — no cookie → 401.
+8. `Write_AdvanceTurn_RemovedPlayer_Returns403` — user A creates + AddPlayer(B) + RemovePlayer(B); user B → 403 (#2561 IsActive semantics end-to-end).
+
+Use the recipe from the analysis (seed users with `EmailVerified = true`, `Status = "Active"`; create/seed session state via `IMediator`, not HTTP; auth user B via `TestSessionHelper.CreateUserSessionAsync` + `CreateAuthenticatedRequest`). Seed each target into a domain-valid state so the ONLY failure cause is the authz gate.
+
+```csharp
+[Fact(DisplayName = "POST /scores returns 403 when caller is authenticated but not a participant")]
+public async Task Write_RecordScore_NonParticipant_Returns403()
+{
+    await using var scope = _factory.Services.CreateAsyncScope();
+    var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+    var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+    var userAId = Guid.NewGuid();
+    db.Users.Add(new UserEntity
+    {
+        Id = userAId, Email = $"a-{userAId:N}@test.local", DisplayName = "User A",
+        PasswordHash = "x", Role = "user", Tier = "free", Status = "Active",
+        EmailVerified = true, CreatedAt = DateTime.UtcNow
+    });
+    await db.SaveChangesAsync();
+
+    var sessionId = await mediator.Send(new CreateLiveSessionCommand(userAId, "Game", GameId: null));
+    var playerId = await mediator.Send(new AddPlayerToLiveSessionCommand(sessionId, "P", PlayerColor.Red, userAId, null, null));
+    await mediator.Send(new StartLiveSessionCommand(sessionId));
+
+    var (_, tokenB) = await TestSessionHelper.CreateUserSessionAsync(db);
+    var clientB = _factory.CreateClient();
+
+    var body = JsonContent.Create(new { playerId, round = 1, dimension = "points", value = 10 });
+    var request = TestSessionHelper.CreateAuthenticatedRequest(HttpMethod.Post,
+        $"/api/v1/live-sessions/{sessionId}/scores", tokenB);
+    request.Content = body;
+
+    var resp = await clientB.SendAsync(request);
+
+    resp.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+}
+```
+
+> Adjust the exact request DTO shape (`RecordScoreRequest`) and command signatures to the real ones (verify `CreateLiveSessionCommand`, `AddPlayerToLiveSessionCommand`, `StartLiveSessionCommand` parameter lists). For test #5 the creator's call must satisfy the command's domain preconditions (player exists, session started) so the 204 is genuine.
+
+- [ ] **Step 2: Run the integration tests**
+
+Run: `dotnet test apps/api/tests/Api.Tests --filter "FullyQualifiedName~LiveSessionParticipantAuthzEndpointTests"`
+Expected: PASS (8 tests). (Requires Docker for Testcontainers.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/api/tests/Api.Tests/Integration/GameManagement/LiveSessionParticipantAuthzEndpointTests.cs
+git commit -m "test(session-live): integration coverage for participant authz filter (#2573)"
+```
+
+---
+
+### Task 6: Refactor existing handlers to the single source of truth (DRY)
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/LiveSessions/GetLiveSessionStreamContextQueryHandler.cs`
+- Modify: `apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/LiveSessions/GetLiveSessionDiaryQueryHandler.cs`
+- Modify: `apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/LiveSessions/AddDiaryEntryCommandHandler.cs`
+
+**Interfaces:**
+- Consumes: `LiveGameSession.IsAuthorizedParticipant(Guid)` (Task 1).
+
+- [ ] **Step 1: Replace the inlined predicate in each handler** with `session.IsAuthorizedParticipant(userId)`.
+
+In `GetLiveSessionStreamContextQueryHandler.cs` (lines 37-38), replace:
+```csharp
+var isAuthorized = session.CreatedByUserId == query.UserId
+    || session.Players.Any(p => p.IsActive && p.UserId == query.UserId);
+```
+with:
+```csharp
+var isAuthorized = session.IsAuthorizedParticipant(query.UserId);
+```
+
+Apply the equivalent replacement in `GetLiveSessionDiaryQueryHandler.cs` and `AddDiaryEntryCommandHandler.cs` (find the `CreatedByUserId == ... || Players.Any(...)` expression in each and replace with `session.IsAuthorizedParticipant(<userId/authorId var>)`). Keep each handler's surrounding throw/flag logic and action-specific message unchanged.
+
+- [ ] **Step 2: Run the affected suites to verify no behavior change**
+
+Run: `dotnet test apps/api/tests/Api.Tests --filter "FullyQualifiedName~LiveSessionStream|FullyQualifiedName~Diary"`
+Expected: PASS (all existing stream + diary tests green — pure refactor).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/LiveSessions/GetLiveSessionStreamContextQueryHandler.cs \
+        apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/LiveSessions/GetLiveSessionDiaryQueryHandler.cs \
+        apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/LiveSessions/AddDiaryEntryCommandHandler.cs
+git commit -m "refactor(session-live): route stream/diary authz through IsAuthorizedParticipant (#2573)"
+```
+
+---
+
+### Task 7: Full build + suite + issue DoD
+
+- [ ] **Step 1: Full backend build + unit suite**
+
+Run: `dotnet build apps/api/src/Api/Api.csproj` then `dotnet test apps/api/tests/Api.Tests --filter "Category=Unit|FullyQualifiedName~LiveSession"`
+Expected: Build succeeded; all targeted tests PASS; no growth over the known-flaky baseline.
+
+- [ ] **Step 2: Update the issue checklist + note the dispute cross-consistency follow-up** in the PR body (see below). If the read-side decision (`get-by-code`/lobby/spectator) needs a separate ticket, file it.
+
+- [ ] **Step 3: Final commit if any docs changed**, then open PR `feature/issue-2573-live-session-authz` → `main-dev` with `Closes #2573`.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** every `participant-check-needed` write endpoint + the 7 sensitive reads are in Task 4's list (35). Already-covered (stream, diary) refactored in Task 6, not double-gated. Public-by-design + not-session-scoped explicitly excluded. ✔
+- **Placeholder scan:** all code blocks are concrete; the only "verify signature" notes point at real existing files to copy from (unavoidable given exact constructor params aren't pre-fetched). ✔
+- **Type consistency:** `IsAuthorizedParticipant(Guid)` (Task 1) consumed identically in Tasks 2 & 6; `GetLiveSessionParticipantContextQuery(Guid,Guid)` + `LiveSessionParticipantContextResult(bool,bool)` consistent across Tasks 2 & 3. ✔
+
+## Known limitations / follow-ups (document in PR)
+- Dispute sub-endpoints gate on the route `{sessionId}`, not on `dispute.SessionId == route sessionId` cross-consistency — separate validation, out of scope.
+- Read-side gating of `GetSessionByCode` and lobby/spectator UX is intentionally **not** changed; if spectator read access is desired, file a follow-up.
+- The filter performs one extra `GetByIdAsync` per request (the command/query handler re-loads). Acceptable for live-session throughput; HybridCache mitigates. Revisit only if profiling shows it matters.


### PR DESCRIPTION
## Problem
Every `{sessionId}`-scoped live-session HTTP endpoint enforced only `RequireAuthenticatedUser()`, with **no per-session participant/owner check** — a systemic IDOR where any authenticated user could mutate or read another user's live session (record scores, complete the game, remove players, read scores/players/photos, …).

## Fix
Per-session participant authorization: the caller must be the **session creator OR an active linked player** (mirrors the existing stream/diary check, `#2561` `IsActive` semantics).

- **Domain**: `LiveGameSession.IsAuthorizedParticipant(Guid userId)` — single source of truth (`CreatedByUserId == userId || _players.Any(p => p.IsActive && p.UserId == userId)`; `Guid.Empty` and guest `UserId == null` never match).
- **Application**: non-throwing `GetLiveSessionParticipantContextQuery → (Found, Authorized)` (dedicated file, mirrors `GetLiveSessionStreamContextQuery`).
- **Filter**: `RequireLiveSessionParticipantFilter` (`.RequireLiveSessionParticipant()`), same convention as `RequireAuthenticatedUser`/`RequireAdminSession` — returns 401 / 404 / 403 or `next()`. **404-before-403** preserved.
- **Wiring**: applied to **35** endpoints (28 write + 7 sensitive reads). Excluded (verified correct): create, join-by-code, `/active`, `/games/{gameId}/dispute-history`, diary POST/GET (already enforced in handler), stream (already enforced).
- **Refactor (DRY)**: stream + both diary handlers now route through `IsAuthorizedParticipant`.

### Code-review finding fixed in-PR
- **Dispute sub-endpoints cross-session IDOR**: `respond`/`timeout`/`vote`/`tally` keyed off `{disputeId}` alone, so a participant of session A could mutate a dispute belonging to session B. Now `SessionId` is threaded from the route into the 4 commands and each handler asserts `dispute.SessionId == command.SessionId`, throwing `NotFoundException` (404, not 403, to avoid cross-session dispute enumeration).

## Tests
- **18 new unit** (6 domain + 3 query + 5 filter + 4 dispute cross-session) + existing dispute handler tests updated.
- **9 new integration** (`LiveSessionParticipantAuthzEndpointTests`): write/read 403, 404-before-403, 401, creator-positive, removed-player `#2561`.
- 342 unit live-session + 118 unit dispute + 9 integration — all green. Build 0 errors.
- ⚠️ Pre-existing baseline failure `LiveSessionDiaryChainIntegrationTests.Post_DiaryEntry_PersistsAndBroadcastsSessionDiaryEvent` (outbox→broadcast timeout) — confirmed failing on the pre-PR state via stash, **not** a regression here.

## Out of scope / follow-ups
- **#2590** (filed): `GET /live-sessions/code/{code}` discloses the full session DTO (notes/scores/UserIds) to non-participants — pre-existing, design exclusion, requires a join-flow DTO redesign.
- TOCTOU between the filter's read and the handler's reload: inherent to the filter pattern, low severity (removing a player is itself participant-gated). Documented.

Plan: `docs/superpowers/plans/2026-06-29-issue-2573-live-session-participant-authz.md`

Closes #2573

🤖 Generated with [Claude Code](https://claude.com/claude-code)