### PR TITLE
feat(session-live): public lobby-by-code endpoint for guest QR-join (#2590)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/LiveSessions/PublicLiveSessionDto.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/LiveSessions/PublicLiveSessionDto.cs
@@ -1,0 +1,27 @@
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+
+namespace Api.BoundedContexts.GameManagement.Application.DTOs.LiveSessions;
+
+/// <summary>
+/// Public, code-addressable read-only lobby/scoreboard projection of a live session (#2590).
+/// Deliberately narrow: NO CreatedByUserId, no player UserId, no Notes/RoundScores/Teams/GroupId/Visibility/timestamps.
+/// Served by GET /api/v1/live-sessions/code/{code}/public (AllowAnonymous + rate-limited).
+/// </summary>
+public sealed record PublicLiveSessionDto(
+    Guid Id,
+    string SessionCode,
+    string GameName,
+    string GameSlug,
+    LiveSessionStatus Status,
+    IReadOnlyList<PublicLiveSessionPlayerDto> Players);
+
+/// <summary>
+/// Public scoreboard player projection — exposes the session-scoped player Id only, never the linked UserId.
+/// </summary>
+public sealed record PublicLiveSessionPlayerDto(
+    Guid Id,
+    string DisplayName,
+    PlayerColor Color,
+    int TotalScore,
+    int CurrentRank,
+    bool IsActive);

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/LiveSessions/GetPublicLiveSessionByCodeQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/LiveSessions/GetPublicLiveSessionByCodeQuery.cs
@@ -1,0 +1,10 @@
+using Api.BoundedContexts.GameManagement.Application.DTOs.LiveSessions;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.GameManagement.Application.Queries.LiveSessions;
+
+/// <summary>
+/// Public lookup of a live session by join code, returning a narrow read-only lobby projection.
+/// Code-as-capability: any valid code resolves; a null result maps to 404 at the endpoint. Issue #2590.
+/// </summary>
+internal record GetPublicLiveSessionByCodeQuery(string SessionCode) : IQuery<PublicLiveSessionDto?>;

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/LiveSessions/GetPublicLiveSessionByCodeQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/LiveSessions/GetPublicLiveSessionByCodeQueryHandler.cs
@@ -1,0 +1,51 @@
+using Api.BoundedContexts.GameManagement.Application.DTOs.LiveSessions;
+using Api.BoundedContexts.GameManagement.Domain.Repositories;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Application.Services;
+
+namespace Api.BoundedContexts.GameManagement.Application.Queries.LiveSessions;
+
+/// <summary>
+/// Handles <see cref="GetPublicLiveSessionByCodeQuery"/>. Loads the session by code and projects it
+/// server-side into the narrow <see cref="PublicLiveSessionDto"/> (NOT the full MapToDto). Returns null
+/// for an unknown code so the endpoint maps it to 404. Code-as-capability — no visibility gate. Issue #2590.
+/// </summary>
+internal sealed class GetPublicLiveSessionByCodeQueryHandler
+    : IQueryHandler<GetPublicLiveSessionByCodeQuery, PublicLiveSessionDto?>
+{
+    private readonly ILiveSessionRepository _sessionRepository;
+
+    public GetPublicLiveSessionByCodeQueryHandler(ILiveSessionRepository sessionRepository)
+    {
+        _sessionRepository = sessionRepository ?? throw new ArgumentNullException(nameof(sessionRepository));
+    }
+
+    public async Task<PublicLiveSessionDto?> Handle(
+        GetPublicLiveSessionByCodeQuery query,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var session = await _sessionRepository
+            .GetByCodeAsync(query.SessionCode, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (session is null)
+        {
+            return null;
+        }
+
+        var players = session.Players
+            .Select(p => new PublicLiveSessionPlayerDto(
+                p.Id, p.DisplayName, p.Color, p.TotalScore, p.CurrentRank, p.IsActive))
+            .ToList();
+
+        return new PublicLiveSessionDto(
+            session.Id,
+            session.SessionCode,
+            session.GameName,
+            Slugifier.Slugify(session.GameName),
+            session.Status,
+            players);
+    }
+}

--- a/apps/api/src/Api/Extensions/RateLimitingServiceExtensions.cs
+++ b/apps/api/src/Api/Extensions/RateLimitingServiceExtensions.cs
@@ -141,6 +141,9 @@ internal static class RateLimitingServiceExtensions
                 options.AddPolicy("GameNightTokenRespond", _ =>
                     RateLimitPartition.GetNoLimiter<string>("unlimited"));
 
+                options.AddPolicy("LiveSessionCodeReadPublic", _ =>
+                    RateLimitPartition.GetNoLimiter<string>("unlimited"));
+
                 // Issue #950 (W1-PR2): authenticated user-search autocomplete (disabled in tests)
                 options.AddPolicy("UsersSearch", _ =>
                     RateLimitPartition.GetNoLimiter<string>("unlimited"));
@@ -590,6 +593,25 @@ internal static class RateLimitingServiceExtensions
 
                 return RateLimitPartition.GetSlidingWindowLimiter(
                     partitionKey: $"game-night-token-read-{ipAddress}",
+                    factory: _ => new SlidingWindowRateLimiterOptions
+                    {
+                        Window = TimeSpan.FromMinutes(1),
+                        PermitLimit = 60,
+                        SegmentsPerWindow = 6,
+                        QueueProcessingOrder = QueueProcessingOrder.OldestFirst,
+                        QueueLimit = 0,
+                    });
+            });
+
+            // Policy 23 (#2590): LiveSessionCodeReadPublic - 60 req/min per IP for the public
+            // join-by-code lobby lookup. Mirrors GameNightTokenRead: anonymous GET, ~one read per
+            // page load, 60/min gives retry/refresh headroom while making code enumeration loud.
+            options.AddPolicy("LiveSessionCodeReadPublic", httpContext =>
+            {
+                var ipAddress = GetClientIpAddress(httpContext);
+
+                return RateLimitPartition.GetSlidingWindowLimiter(
+                    partitionKey: $"live-session-code-read-{ipAddress}",
                     factory: _ => new SlidingWindowRateLimiterOptions
                     {
                         Window = TimeSpan.FromMinutes(1),

--- a/apps/api/src/Api/Routing/LiveSessionEndpoints.cs
+++ b/apps/api/src/Api/Routing/LiveSessionEndpoints.cs
@@ -353,6 +353,16 @@ internal static class LiveSessionEndpoints
             .WithTags("LiveSessions")
             .WithSummary("Get live session by join code");
 
+        group.MapGet("/live-sessions/code/{code}/public", HandleGetPublicSessionByCode)
+            .AllowAnonymous()
+            .RequireRateLimiting("LiveSessionCodeReadPublic")
+            .Produces<PublicLiveSessionDto>(200)
+            .Produces(404)
+            .Produces(429)
+            .WithTags("LiveSessions")
+            .WithSummary("Get a live session lobby by join code (public, read-only)")
+            .WithDescription("Public QR-code endpoint. Returns a narrow read-only lobby/scoreboard projection (no UserIds/Notes/scores history). Code-as-capability, optional auth. Rate-limited 60/min per IP. Issue #2590.");
+
         group.MapGet("/live-sessions/{sessionId}", HandleGetSession)
             .RequireAuthenticatedUser()
             .RequireLiveSessionParticipant()
@@ -852,6 +862,22 @@ internal static class LiveSessionEndpoints
     {
         var result = await mediator.Send(new GetLiveSessionByCodeQuery(code), cancellationToken).ConfigureAwait(false);
         return Results.Ok(result);
+    }
+
+    /// <summary>
+    /// GET /api/v1/live-sessions/code/{code}/public — Issue #2590.
+    /// Public, anonymous, rate-limited narrow lobby projection. Returns 404 for an unknown code.
+    /// </summary>
+    private static async Task<IResult> HandleGetPublicSessionByCode(
+        string code,
+        [FromServices] IMediator mediator,
+        CancellationToken cancellationToken)
+    {
+        var result = await mediator
+            .Send(new GetPublicLiveSessionByCodeQuery(code), cancellationToken)
+            .ConfigureAwait(false);
+
+        return result is null ? Results.NotFound() : Results.Ok(result);
     }
 
     private static async Task<IResult> HandleGetActiveSessions(

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/LiveSessions/GetPublicLiveSessionByCodeQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/LiveSessions/GetPublicLiveSessionByCodeQueryHandlerTests.cs
@@ -1,0 +1,70 @@
+using Api.BoundedContexts.GameManagement.Application.DTOs.LiveSessions;
+using Api.BoundedContexts.GameManagement.Application.Queries.LiveSessions;
+using Api.BoundedContexts.GameManagement.Domain.Entities;
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+using Api.BoundedContexts.GameManagement.Domain.Repositories;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Application.Handlers.LiveSessions;
+
+/// <summary>
+/// Unit tests for <see cref="GetPublicLiveSessionByCodeQueryHandler"/> — the narrow, code-as-capability
+/// public lobby projection (#2590). Asserts unknown code → null and that the projected DTO type carries
+/// no sensitive members (UserId / CreatedByUserId / Notes).
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "GameManagement")]
+public class GetPublicLiveSessionByCodeQueryHandlerTests
+{
+    private readonly Mock<ILiveSessionRepository> _repo = new();
+
+    private GetPublicLiveSessionByCodeQueryHandler Sut() => new(_repo.Object);
+
+    [Fact]
+    public async Task Handle_UnknownCode_ReturnsNull()
+    {
+        _repo.Setup(r => r.GetByCodeAsync("NOPE12", It.IsAny<CancellationToken>()))
+             .ReturnsAsync((LiveGameSession?)null);
+
+        var result = await Sut().Handle(new GetPublicLiveSessionByCodeQuery("NOPE12"), CancellationToken.None);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_KnownCode_ProjectsNarrowDto()
+    {
+        var session = LiveGameSession.Create(
+            Guid.NewGuid(), Guid.NewGuid(), "Catan", TimeProvider.System, gameId: Guid.NewGuid());
+        session.AddPlayer(Guid.NewGuid(), "Alice", PlayerColor.Red); // linked user
+        _repo.Setup(r => r.GetByCodeAsync(session.SessionCode, It.IsAny<CancellationToken>()))
+             .ReturnsAsync(session);
+
+        var result = await Sut().Handle(
+            new GetPublicLiveSessionByCodeQuery(session.SessionCode), CancellationToken.None);
+
+        result.Should().NotBeNull();
+        result!.Id.Should().Be(session.Id);
+        result.SessionCode.Should().Be(session.SessionCode);
+        result.GameName.Should().Be("Catan");
+        result.GameSlug.Should().Be("catan");
+        result.Players.Should().ContainSingle();
+        result.Players[0].DisplayName.Should().Be("Alice");
+        result.Players[0].Color.Should().Be(PlayerColor.Red);
+    }
+
+    [Fact]
+    public void PublicDto_HasNoSensitiveMembers()
+    {
+        // Compile-time + reflection guard: the public projection must never expose identity/private fields.
+        typeof(PublicLiveSessionPlayerDto).GetProperty("UserId").Should().BeNull();
+        typeof(PublicLiveSessionDto).GetProperty("CreatedByUserId").Should().BeNull();
+        typeof(PublicLiveSessionDto).GetProperty("Notes").Should().BeNull();
+        typeof(PublicLiveSessionDto).GetProperty("RoundScores").Should().BeNull();
+        typeof(PublicLiveSessionDto).GetProperty("Teams").Should().BeNull();
+        typeof(PublicLiveSessionDto).GetProperty("Visibility").Should().BeNull();
+    }
+}

--- a/apps/api/tests/Api.Tests/Integration/GameManagement/LiveSessionByCodePublicEndpointTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/GameManagement/LiveSessionByCodePublicEndpointTests.cs
@@ -1,0 +1,153 @@
+using System.Net;
+using Api.BoundedContexts.GameManagement.Application.Commands.LiveSessions;
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+using Api.BoundedContexts.GameManagement.Domain.Repositories;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.Integration.GameManagement;
+
+/// <summary>
+/// Integration tests for the public lobby-by-code endpoint (#2590):
+///   GET /api/v1/live-sessions/code/{code}/public
+/// Anonymous, narrow read-only projection. Proves the guest QR-join path works without auth,
+/// the body omits sensitive fields, unknown codes 404, and the old authenticated route is unchanged.
+/// Mirrors LiveSessionParticipantAuthzEndpointTests (Testcontainers fixture, IMediator setup).
+/// </summary>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "GameManagement")]
+[Trait("Issue", "2590")]
+public sealed class LiveSessionByCodePublicEndpointTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly string _databaseName = $"live_codepublic_{Guid.NewGuid():N}";
+    private Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<Program> _factory = null!;
+
+    public LiveSessionByCodePublicEndpointTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+        await TestcontainersWaitHelpers.WaitForPostgresReadyAsync(connectionString);
+        _factory = IntegrationWebApplicationFactory.Create(connectionString);
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        await db.Database.MigrateAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_factory != null)
+        {
+            await _factory.DisposeAsync();
+        }
+        await _fixture.DropIsolatedDatabaseAsync(_databaseName);
+    }
+
+    [Fact(DisplayName = "GET /code/{code}/public returns 200 to an anonymous caller with the narrow body")]
+    public async Task Anonymous_ValidCode_Returns200_NarrowBody()
+    {
+        var code = await CreateSessionWithCodeAsync();
+        var anon = _factory.CreateClient();
+
+        var resp = await anon.GetAsync($"/api/v1/live-sessions/code/{code}/public");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK, "the public lobby endpoint must work without auth");
+        var body = await resp.Content.ReadAsStringAsync();
+        body.Should().Contain("\"gameName\"").And.Contain("Catan");
+        body.Should().Contain("\"players\"");
+    }
+
+    [Fact(DisplayName = "GET /code/{code}/public body omits all sensitive fields")]
+    public async Task Anonymous_ValidCode_BodyOmitsSensitiveFields()
+    {
+        var code = await CreateSessionWithCodeAsync();
+        var anon = _factory.CreateClient();
+
+        var resp = await anon.GetAsync($"/api/v1/live-sessions/code/{code}/public");
+        var body = await resp.Content.ReadAsStringAsync();
+
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        body.Should().NotContain("createdByUserId")
+            .And.NotContain("\"userId\"")
+            .And.NotContain("notes")
+            .And.NotContain("roundScores")
+            .And.NotContain("teams")
+            .And.NotContain("visibility")
+            .And.NotContain("groupId");
+    }
+
+    [Fact(DisplayName = "GET /code/{code}/public returns 404 for an unknown code")]
+    public async Task UnknownCode_Returns404()
+    {
+        var anon = _factory.CreateClient();
+
+        var resp = await anon.GetAsync("/api/v1/live-sessions/code/ZZZZZZ/public");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact(DisplayName = "The old GET /code/{code} (no /public) still requires auth (401 anonymous)")]
+    public async Task OldRoute_StillRequiresAuth()
+    {
+        var code = await CreateSessionWithCodeAsync();
+        var anon = _factory.CreateClient();
+
+        var resp = await anon.GetAsync($"/api/v1/live-sessions/code/{code}");
+
+        resp.StatusCode.Should().Be(HttpStatusCode.Unauthorized,
+            "the authenticated full-DTO route must be unchanged by #2590");
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────────
+
+    /// <summary>Seeds a user + a live session (game "Catan") with one linked player, returns the SessionCode.</summary>
+    private async Task<string> CreateSessionWithCodeAsync()
+    {
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+        var repo = scope.ServiceProvider.GetRequiredService<ILiveSessionRepository>();
+
+        var userId = await SeedUserAsync(db);
+        var sessionId = await mediator.Send(new CreateLiveSessionCommand(
+            UserId: userId, GameName: "Catan", GameId: null));
+        await mediator.Send(new AddPlayerToLiveSessionCommand(
+            sessionId, "Alice", PlayerColor.Red, userId, null, null));
+
+        var session = await repo.GetByIdAsync(sessionId);
+        return session!.SessionCode;
+    }
+
+    private static async Task<Guid> SeedUserAsync(MeepleAiDbContext db)
+    {
+        var userId = Guid.NewGuid();
+        db.Users.Add(new UserEntity
+        {
+            Id = userId,
+            Email = $"codepublic-{userId:N}@test.local",
+            DisplayName = "Code Public Test User",
+            PasswordHash = "not-a-real-hash",
+            Role = "user",
+            Tier = "free",
+            Status = "Active",
+            EmailVerified = true,
+            CreatedAt = DateTime.UtcNow
+        });
+        await db.SaveChangesAsync();
+        return userId;
+    }
+}

--- a/apps/web/src/app/(public)/join/session/[code]/guest-session-view.tsx
+++ b/apps/web/src/app/(public)/join/session/[code]/guest-session-view.tsx
@@ -21,7 +21,10 @@ import { LiveScoreboard } from '@/components/game-night/LiveScoreboard';
 import type { LiveScoreboardPlayer } from '@/components/game-night/LiveScoreboard';
 import { Button } from '@/components/ui/primitives/button';
 import { GlassCard } from '@/components/ui/surfaces/GlassCard';
-import type { LiveSessionDto } from '@/lib/api/schemas/live-sessions.schemas';
+import {
+  PublicLiveSessionDtoSchema,
+  type PublicLiveSessionDto,
+} from '@/lib/api/schemas/live-sessions.schemas';
 import { PLAYER_COLOR_HEX } from '@/lib/constants/player-colors';
 
 // ========== Types ==========
@@ -38,7 +41,7 @@ export interface GuestSessionViewProps {
 
 export function GuestSessionView({ code }: GuestSessionViewProps) {
   const [viewState, setViewState] = useState<ViewState>('loading');
-  const [session, setSession] = useState<LiveSessionDto | null>(null);
+  const [session, setSession] = useState<PublicLiveSessionDto | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   const loadSession = useCallback(async () => {
@@ -47,14 +50,16 @@ export function GuestSessionView({ code }: GuestSessionViewProps) {
 
     try {
       const baseUrl = process.env.NEXT_PUBLIC_API_URL || '';
-      const res = await fetch(`${baseUrl}/api/v1/live-sessions/code/${encodeURIComponent(code)}`);
+      const res = await fetch(
+        `${baseUrl}/api/v1/live-sessions/code/${encodeURIComponent(code)}/public`
+      );
       if (!res.ok) {
         setErrorMessage('Sessione non trovata o codice non valido.');
         setViewState('error');
         return;
       }
 
-      const data = (await res.json()) as LiveSessionDto;
+      const data = PublicLiveSessionDtoSchema.parse(await res.json());
       setSession(data);
       setViewState('loaded');
     } catch {
@@ -89,9 +94,7 @@ export function GuestSessionView({ code }: GuestSessionViewProps) {
           <div className="h-16 w-16 mx-auto rounded-2xl bg-red-100 dark:bg-red-900/30 flex items-center justify-center">
             <Users className="h-8 w-8 text-red-500" />
           </div>
-          <h1 className="text-xl font-quicksand font-bold text-foreground">
-            Sessione non trovata
-          </h1>
+          <h1 className="text-xl font-quicksand font-bold text-foreground">Sessione non trovata</h1>
           <p className="text-sm font-nunito text-muted-foreground">
             {errorMessage ?? 'Il codice potrebbe essere scaduto o non valido.'}
           </p>
@@ -134,9 +137,7 @@ export function GuestSessionView({ code }: GuestSessionViewProps) {
           <div className="h-14 w-14 mx-auto rounded-2xl bg-amber-100 dark:bg-amber-900/30 flex items-center justify-center mb-3">
             <Gamepad2 className="h-7 w-7 text-amber-600 dark:text-amber-400" />
           </div>
-          <h1 className="text-2xl font-quicksand font-bold text-foreground">
-            {session.gameName}
-          </h1>
+          <h1 className="text-2xl font-quicksand font-bold text-foreground">{session.gameName}</h1>
           <div className="flex items-center justify-center gap-2 text-sm text-muted-foreground">
             <span className="inline-flex items-center gap-1 bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400 px-2 py-0.5 rounded-full text-xs font-medium">
               <Clock className="h-3 w-3" />

--- a/apps/web/src/lib/api/clients/liveSessionsClient.ts
+++ b/apps/web/src/lib/api/clients/liveSessionsClient.ts
@@ -17,6 +17,7 @@ import {
 } from '../schemas/improvvisata.schemas';
 import {
   LiveSessionDtoSchema,
+  PublicLiveSessionDtoSchema,
   LiveSessionSummaryDtoSchema,
   LiveSessionPlayerDtoSchema,
   LiveSessionRoundScoreDtoSchema,
@@ -24,6 +25,7 @@ import {
   SessionToolsDtoSchema,
   TurnPhasesDtoSchema,
   type LiveSessionDto,
+  type PublicLiveSessionDto,
   type LiveSessionSummaryDto,
   type LiveSessionPlayerDto,
   type LiveSessionRoundScoreDto,
@@ -87,6 +89,9 @@ export interface LiveSessionsClient {
 
   /** Get a session by join code */
   getByCode(code: string): Promise<LiveSessionDto>;
+
+  /** PUBLIC — anonymous-safe. Get a narrow read-only lobby/scoreboard by join code (#2590). */
+  getPublicByCode(code: string): Promise<PublicLiveSessionDto>;
 
   /** Get scores for a session */
   getScores(sessionId: string): Promise<LiveSessionRoundScoreDto[]>;
@@ -294,6 +299,15 @@ export function createLiveSessionsClient({
       );
       if (!response) throw new Error('Session not found');
       return LiveSessionDtoSchema.parse(response);
+    },
+
+    // PUBLIC — anonymous-safe; narrow DTO. Maps to GET /code/{code}/public (#2590).
+    async getPublicByCode(code) {
+      const response = await httpClient.get<PublicLiveSessionDto>(
+        `${BASE}/code/${encodeURIComponent(code)}/public`
+      );
+      if (!response) throw new Error('Session not found');
+      return PublicLiveSessionDtoSchema.parse(response);
     },
 
     async getScores(sessionId) {

--- a/apps/web/src/lib/api/schemas/__tests__/live-sessions.public.schemas.test.ts
+++ b/apps/web/src/lib/api/schemas/__tests__/live-sessions.public.schemas.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+
+import { PublicLiveSessionDtoSchema } from '../live-sessions.schemas';
+
+/**
+ * #2590 — the public lobby projection must be a NARROW contract: it accepts the
+ * whitelisted scoreboard fields and never surfaces a sensitive field that the
+ * server must not expose to an anonymous caller (userId, createdByUserId, notes, ...).
+ */
+describe('PublicLiveSessionDtoSchema (#2590 public lobby)', () => {
+  const valid = {
+    id: '11111111-1111-4111-8111-111111111111',
+    sessionCode: 'ABC234',
+    gameName: 'Catan',
+    gameSlug: 'catan',
+    status: 'InProgress',
+    players: [
+      {
+        id: '22222222-2222-4222-8222-222222222222',
+        displayName: 'Alice',
+        color: 'Red',
+        totalScore: 5,
+        currentRank: 1,
+        isActive: true,
+      },
+    ],
+  };
+
+  it('accepts the narrow lobby payload', () => {
+    const parsed = PublicLiveSessionDtoSchema.parse(valid);
+    expect(parsed.gameName).toBe('Catan');
+    expect(parsed.gameSlug).toBe('catan');
+    expect(parsed.players).toHaveLength(1);
+    expect(parsed.players[0].displayName).toBe('Alice');
+    expect(parsed.players[0].color).toBe('Red');
+  });
+
+  it('never surfaces sensitive fields even if the server includes them', () => {
+    const withSensitive = {
+      ...valid,
+      createdByUserId: '33333333-3333-4333-8333-333333333333',
+      notes: 'host private notes',
+      visibility: 'Private',
+      groupId: '44444444-4444-4444-8444-444444444444',
+      players: [{ ...valid.players[0], userId: '55555555-5555-4555-8555-555555555555' }],
+    };
+
+    // Zod strips unknown keys (a strict schema would reject them — both are safe);
+    // either way the parsed value must never expose the sensitive fields.
+    const parsed = PublicLiveSessionDtoSchema.parse(withSensitive) as Record<string, unknown>;
+
+    expect('createdByUserId' in parsed).toBe(false);
+    expect('notes' in parsed).toBe(false);
+    expect('visibility' in parsed).toBe(false);
+    expect('groupId' in parsed).toBe(false);
+    expect('userId' in (parsed.players as Record<string, unknown>[])[0]).toBe(false);
+  });
+
+  it('rejects a payload missing required fields', () => {
+    expect(() => PublicLiveSessionDtoSchema.parse({ id: valid.id })).toThrow();
+  });
+});

--- a/apps/web/src/lib/api/schemas/live-sessions.schemas.ts
+++ b/apps/web/src/lib/api/schemas/live-sessions.schemas.ts
@@ -137,6 +137,31 @@ export const LiveSessionDtoSchema = z.object({
 
 export type LiveSessionDto = z.infer<typeof LiveSessionDtoSchema>;
 
+// ── Public lobby projection (#2590) — anonymous-safe, narrow scoreboard ──────────
+// Served by GET /api/v1/live-sessions/code/{code}/public. Deliberately omits
+// userId, createdByUserId, notes, roundScores, teams, visibility, groupId, timestamps.
+export const PublicLiveSessionPlayerDtoSchema = z.object({
+  id: z.string().uuid(),
+  displayName: z.string(),
+  color: PlayerColorSchema,
+  totalScore: z.number().int(),
+  currentRank: z.number().int(),
+  isActive: z.boolean(),
+});
+
+export type PublicLiveSessionPlayerDto = z.infer<typeof PublicLiveSessionPlayerDtoSchema>;
+
+export const PublicLiveSessionDtoSchema = z.object({
+  id: z.string().uuid(),
+  sessionCode: z.string(),
+  gameName: z.string(),
+  gameSlug: z.string(),
+  status: LiveSessionStatusSchema,
+  players: z.array(PublicLiveSessionPlayerDtoSchema),
+});
+
+export type PublicLiveSessionDto = z.infer<typeof PublicLiveSessionDtoSchema>;
+
 export const LiveSessionSummaryDtoSchema = z.object({
   id: z.string().uuid(),
   sessionCode: z.string(),

--- a/docs/superpowers/plans/2026-06-29-issue-2590-public-session-lobby.md
+++ b/docs/superpowers/plans/2026-06-29-issue-2590-public-session-lobby.md
@@ -1,0 +1,339 @@
+# Public Session Lobby by Code (#2590) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans / subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** Fix the guest QR-join data-disclosure + broken-feature contradiction (#2590) by adding a dedicated **public, rate-limited, narrow** lobby endpoint, leaving the existing authenticated full-DTO route untouched.
+
+**Architecture:** Two-contract split (expand-and-contract, additive, non-breaking), mirroring the GameNight RSVP public pattern (#1169). New `GET /api/v1/live-sessions/code/{code}/public` → `.AllowAnonymous()` + `.RequireRateLimiting("LiveSessionCodeReadPublic")` → new `GetPublicLiveSessionByCodeQuery` → server-side projection into a new narrow `PublicLiveSessionDto`. The existing `GET /code/{code}` (`.RequireAuthenticatedUser()`, full `LiveSessionDto`) is unchanged so the registered-user join flow keeps working.
+
+**Tech Stack:** .NET 9 Minimal APIs + endpoint rate limiting, MediatR (CQRS), EF Core; Next.js 16 + Zod; xUnit + Testcontainers + Vitest.
+
+## Global Constraints (decisions locked with product)
+- **Code-as-capability**: NO visibility check. Any valid code resolves the narrow lobby (the code is already a voluntarily-shared secret). `PlayRecordVisibility` has only `{Private, Group}` — do not add a `Public` value here.
+- **Scope = new public endpoint only**: the existing authenticated `GET /code/{code}` + full `LiveSessionDto` is UNTOUCHED. Narrowing the authenticated tier is a separate follow-up.
+- **Narrow whitelist (exact)**: response = `{ Id, SessionCode, GameName, GameSlug, Status, Players[] }`, each player = `{ Id, DisplayName, Color, TotalScore, CurrentRank, IsActive }`. **Excluded**: `CreatedByUserId`, player `UserId`, `Notes`, `RoundScores`, `Teams`, `GroupId`, `GameId`, `Visibility`, `AgentMode`, `AvatarUrl`, all timestamps, `CurrentTurnPlayerId`.
+- **Defaults**: `displayName` shown as today; Completed session → 200 (FE renders "Completata"); unknown code → 404 (no enumeration oracle beyond existence); rate-limit 60/min per IP (mirror `GameNightTokenRead`), `GetClientIpAddress` (RemoteIp only).
+- **Backward-compat**: do NOT change `LiveSessionDtoSchema` / `getByCode`. Add a NEW FE schema + client method.
+- **Branch**: `feature/issue-2590-public-session-lobby` (parent `main-dev`).
+
+## File Structure
+
+**Create (BE):**
+- `apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/LiveSessions/PublicLiveSessionDto.cs` — narrow records.
+- `apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/LiveSessions/GetPublicLiveSessionByCodeQuery.cs` — query.
+- `apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/LiveSessions/GetPublicLiveSessionByCodeQueryHandler.cs` — projection handler.
+- `apps/api/tests/Api.Tests/.../Handlers/LiveSessions/GetPublicLiveSessionByCodeQueryHandlerTests.cs` — unit.
+- `apps/api/tests/Api.Tests/Integration/GameManagement/LiveSessionByCodePublicEndpointTests.cs` — integration.
+
+**Modify (BE):**
+- `apps/api/src/Api/Extensions/RateLimitingServiceExtensions.cs` — add `LiveSessionCodeReadPublic` policy (both blocks).
+- `apps/api/src/Api/Routing/LiveSessionEndpoints.cs` — new public endpoint + handler.
+
+**Create/Modify (FE):**
+- `apps/web/src/lib/api/schemas/live-sessions.schemas.ts` — `PublicLiveSessionDtoSchema`.
+- `apps/web/src/lib/api/clients/liveSessionsClient.ts` — `getPublicByCode(code)`.
+- `apps/web/src/app/(public)/join/session/[code]/guest-session-view.tsx` — repoint fetch to the typed public client.
+- `apps/web/src/app/(public)/join/session/[code]/__tests__/...` — FE test (schema + repoint).
+
+---
+
+### Task 1: Narrow `PublicLiveSessionDto`
+
+**Files:**
+- Create: `.../DTOs/LiveSessions/PublicLiveSessionDto.cs`
+
+**Interfaces:**
+- Produces: `public sealed record PublicLiveSessionDto(Guid Id, string SessionCode, string GameName, string GameSlug, LiveSessionStatus Status, IReadOnlyList<PublicLiveSessionPlayerDto> Players)` and `public sealed record PublicLiveSessionPlayerDto(Guid Id, string DisplayName, PlayerColor Color, int TotalScore, int CurrentRank, bool IsActive)`.
+
+- [ ] **Step 1: Create the records** (mirror the `public sealed record` style of `PublicGameNightInvitationDto`).
+
+```csharp
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+
+namespace Api.BoundedContexts.GameManagement.Application.DTOs.LiveSessions;
+
+/// <summary>
+/// Public, code-addressable read-only lobby/scoreboard projection of a live session (#2590).
+/// Deliberately narrow: NO CreatedByUserId, no player UserId, no Notes/RoundScores/Teams/GroupId/Visibility.
+/// Served by GET /api/v1/live-sessions/code/{code}/public (AllowAnonymous + rate-limited).
+/// </summary>
+public sealed record PublicLiveSessionDto(
+    Guid Id,
+    string SessionCode,
+    string GameName,
+    string GameSlug,
+    LiveSessionStatus Status,
+    IReadOnlyList<PublicLiveSessionPlayerDto> Players);
+
+/// <summary>Public scoreboard player projection — session-scoped player Id only, never the linked UserId.</summary>
+public sealed record PublicLiveSessionPlayerDto(
+    Guid Id,
+    string DisplayName,
+    PlayerColor Color,
+    int TotalScore,
+    int CurrentRank,
+    bool IsActive);
+```
+
+- [ ] **Step 2: Build** `dotnet build apps/api/src/Api/Api.csproj` → succeeds.
+- [ ] **Step 3: Commit** `feat(session-live): add narrow PublicLiveSessionDto (#2590)`
+
+---
+
+### Task 2: `GetPublicLiveSessionByCodeQuery` + projection handler
+
+**Files:**
+- Create: `.../Queries/LiveSessions/GetPublicLiveSessionByCodeQuery.cs`
+- Create: `.../Queries/LiveSessions/GetPublicLiveSessionByCodeQueryHandler.cs`
+- Test: `.../Handlers/LiveSessions/GetPublicLiveSessionByCodeQueryHandlerTests.cs`
+
+**Interfaces:**
+- Consumes: `ILiveSessionRepository.GetByCodeAsync(string, CancellationToken)`; `PublicLiveSessionDto` (Task 1).
+- Produces: `internal record GetPublicLiveSessionByCodeQuery(string SessionCode) : IQuery<PublicLiveSessionDto?>`.
+
+- [ ] **Step 1: Write the failing unit tests** (mock `ILiveSessionRepository`; build a session via `LiveGameSession.Create(...)` + `AddPlayer(...)` with Notes/scores set, assert the projection omits sensitive members and that an unknown code returns null).
+
+```csharp
+using Api.BoundedContexts.GameManagement.Application.Queries.LiveSessions;
+using Api.BoundedContexts.GameManagement.Domain.Entities;
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+using Api.BoundedContexts.GameManagement.Domain.Repositories;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Application.Handlers.LiveSessions;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "GameManagement")]
+public class GetPublicLiveSessionByCodeQueryHandlerTests
+{
+    private readonly Mock<ILiveSessionRepository> _repo = new();
+    private GetPublicLiveSessionByCodeQueryHandler Sut() => new(_repo.Object);
+
+    [Fact]
+    public async Task Handle_UnknownCode_ReturnsNull()
+    {
+        _repo.Setup(r => r.GetByCodeAsync("NOPE12", It.IsAny<CancellationToken>()))
+             .ReturnsAsync((LiveGameSession?)null);
+
+        var result = await Sut().Handle(new GetPublicLiveSessionByCodeQuery("NOPE12"), CancellationToken.None);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_KnownCode_ProjectsNarrowDto_WithoutSensitiveFields()
+    {
+        var session = LiveGameSession.Create(Guid.NewGuid(), Guid.NewGuid(), "Catan", TimeProvider.System, gameId: Guid.NewGuid());
+        var player = session.AddPlayer(Guid.NewGuid(), "Alice", PlayerColor.Red); // linked user
+        _repo.Setup(r => r.GetByCodeAsync(session.SessionCode, It.IsAny<CancellationToken>()))
+             .ReturnsAsync(session);
+
+        var result = await Sut().Handle(new GetPublicLiveSessionByCodeQuery(session.SessionCode), CancellationToken.None);
+
+        result.Should().NotBeNull();
+        result!.Id.Should().Be(session.Id);
+        result.GameName.Should().Be("Catan");
+        result.Players.Should().ContainSingle();
+        result.Players[0].DisplayName.Should().Be("Alice");
+        // Compile-time guarantee: PublicLiveSessionPlayerDto has NO UserId member, PublicLiveSessionDto has NO Notes/CreatedByUserId.
+        typeof(PublicLiveSessionPlayerDto).GetProperty("UserId").Should().BeNull();
+        typeof(PublicLiveSessionDto).GetProperty("CreatedByUserId").Should().BeNull();
+        typeof(PublicLiveSessionDto).GetProperty("Notes").Should().BeNull();
+    }
+}
+```
+
+- [ ] **Step 2: Run → FAIL** (`dotnet test ... --filter "FullyQualifiedName~GetPublicLiveSessionByCodeQueryHandlerTests"`) — types missing.
+
+- [ ] **Step 3: Create the query**
+
+```csharp
+using Api.BoundedContexts.GameManagement.Application.DTOs.LiveSessions;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.GameManagement.Application.Queries.LiveSessions;
+
+/// <summary>
+/// Public lookup of a live session by join code, returning a narrow read-only lobby projection.
+/// Code-as-capability: any valid code resolves; null result → 404 at the endpoint. Issue #2590.
+/// </summary>
+internal record GetPublicLiveSessionByCodeQuery(string SessionCode) : IQuery<PublicLiveSessionDto?>;
+```
+
+- [ ] **Step 4: Create the handler** (server-side projection — do NOT call `GetLiveSessionQueryHandler.MapToDto`).
+
+```csharp
+using Api.BoundedContexts.GameManagement.Application.DTOs.LiveSessions;
+using Api.BoundedContexts.GameManagement.Domain.Repositories;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.GameManagement.Application.Queries.LiveSessions;
+
+internal sealed class GetPublicLiveSessionByCodeQueryHandler
+    : IQueryHandler<GetPublicLiveSessionByCodeQuery, PublicLiveSessionDto?>
+{
+    private readonly ILiveSessionRepository _sessionRepository;
+
+    public GetPublicLiveSessionByCodeQueryHandler(ILiveSessionRepository sessionRepository)
+    {
+        _sessionRepository = sessionRepository ?? throw new ArgumentNullException(nameof(sessionRepository));
+    }
+
+    public async Task<PublicLiveSessionDto?> Handle(
+        GetPublicLiveSessionByCodeQuery query,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var session = await _sessionRepository
+            .GetByCodeAsync(query.SessionCode, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (session is null)
+        {
+            return null;
+        }
+
+        var players = session.Players
+            .Select(p => new PublicLiveSessionPlayerDto(
+                p.Id, p.DisplayName, p.Color, p.TotalScore, p.CurrentRank, p.IsActive))
+            .ToList();
+
+        return new PublicLiveSessionDto(
+            session.Id, session.SessionCode, session.GameName, session.GameSlug, session.Status, players);
+    }
+}
+```
+
+> NOTE: confirm `LiveGameSession.GameSlug` and `LiveSessionPlayer.{TotalScore,CurrentRank,Color,DisplayName,IsActive}` accessors exist (they back the existing `LiveSessionDto`/`LiveSessionPlayerDto` mapping). If `GameSlug` is computed in `MapToDto` rather than on the aggregate, replicate that derivation here.
+
+- [ ] **Step 5: Run → PASS.**
+- [ ] **Step 6: Commit** `feat(session-live): add GetPublicLiveSessionByCodeQuery projection (#2590)`
+
+---
+
+### Task 3: Rate-limit policy `LiveSessionCodeReadPublic`
+
+**Files:**
+- Modify: `apps/api/src/Api/Extensions/RateLimitingServiceExtensions.cs`
+
+- [ ] **Step 1: Add the policy in BOTH blocks.** First read the file: the disabled/test block (~line 138) registers each policy as `GetNoLimiter`; the real block (`services.AddRateLimiter` ~line 152) registers `GameNightTokenRead` as a 60/min per-IP sliding window via `GetClientIpAddress`. Add a sibling `LiveSessionCodeReadPublic` next to each `GameNightTokenRead` registration, copying the exact 60/min sliding-window shape from the real `GameNightTokenRead` definition (locate it in the real block; the grep at plan time only surfaced the disabled-block copy at line 138).
+
+Disabled/test block (next to line ~139):
+```csharp
+options.AddPolicy("LiveSessionCodeReadPublic", _ =>
+    RateLimitPartition.GetNoLimiter<string>("unlimited"));
+```
+
+Real block: replicate the `GameNightTokenRead` SlidingWindow policy verbatim with `partitionKey: $"live-session-code-read-{GetClientIpAddress(httpContext)}"`, `Window = 1min`, `PermitLimit = 60`, `QueueLimit = 0` (match the real `GameNightTokenRead` values exactly).
+
+- [ ] **Step 2: Build** → succeeds.
+- [ ] **Step 3: Commit** `feat(session-live): add LiveSessionCodeReadPublic rate-limit policy (#2590)`
+
+---
+
+### Task 4: Public endpoint wiring + integration tests
+
+**Files:**
+- Modify: `apps/api/src/Api/Routing/LiveSessionEndpoints.cs`
+- Test: `apps/api/tests/Api.Tests/Integration/GameManagement/LiveSessionByCodePublicEndpointTests.cs`
+
+**Interfaces:**
+- Consumes: `GetPublicLiveSessionByCodeQuery` (Task 2), `LiveSessionCodeReadPublic` policy (Task 3).
+
+- [ ] **Step 1: Write the failing integration tests** (mirror `LiveSessionParticipantAuthzEndpointTests` fixture + `GameNight` public RSVP tests). Cover:
+  1. `Anonymous_ValidCode_Returns200_NarrowBody` — no cookie → 200; body has gameName/status/players.
+  2. `Anonymous_ValidCode_BodyOmitsSensitiveFields` (load-bearing) — raw JSON `Should().NotContain("createdByUserId" / "userId" / "notes" / "roundScores" / "teams" / "visibility" / "groupId")`.
+  3. `UnknownCode_Returns404`.
+  4. `AuthenticatedNonParticipant_SameNarrowBody` — optional-auth never broadens disclosure.
+  5. `OldRoute_StillAuthenticated` — `GET /code/{code}` (no `/public`) anonymous still 401 (no-regression).
+
+```csharp
+[Fact(DisplayName = "GET /code/{code}/public returns 200 to an anonymous caller with the narrow body")]
+public async Task Anonymous_ValidCode_Returns200_NarrowBody()
+{
+    var (code, _) = await CreateSessionWithCodeAsync(); // seeds session via IMediator, returns SessionCode
+    var anon = _factory.CreateClient();
+
+    var resp = await anon.GetAsync($"/api/v1/live-sessions/code/{code}/public");
+
+    resp.StatusCode.Should().Be(HttpStatusCode.OK);
+    var body = await resp.Content.ReadAsStringAsync();
+    body.Should().NotContain("createdByUserId").And.NotContain("notes").And.NotContain("roundScores");
+}
+```
+
+> Seed helper: create a session via `CreateLiveSessionCommand`, `AddPlayerToLiveSessionCommand` (linked user), set Notes/score via the relevant commands so the projection has something to (not) leak; read `SessionCode` back via `GetLiveSessionQuery`/repo. Reuse the `SeedUserAsync` + Testcontainers fixture pattern from `LiveSessionParticipantAuthzEndpointTests`.
+
+- [ ] **Step 2: Run → FAIL** (route 404 — not wired).
+
+- [ ] **Step 3: Wire the endpoint** in `MapLiveSessionEndpoints`, beside the existing `/code/{code}` (line ~349):
+
+```csharp
+group.MapGet("/live-sessions/code/{code}/public", HandleGetPublicSessionByCode)
+    .AllowAnonymous()
+    .RequireRateLimiting("LiveSessionCodeReadPublic")
+    .Produces<PublicLiveSessionDto>(200)
+    .Produces(404)
+    .Produces(429)
+    .WithTags("LiveSessions")
+    .WithSummary("Get a live session lobby by join code (public, read-only)")
+    .WithDescription("Public QR-code endpoint. Returns a narrow read-only lobby/scoreboard projection. Optional auth. Rate-limited 60/min per IP. Issue #2590.");
+```
+
+Handler (in the Query Handlers region):
+```csharp
+private static async Task<IResult> HandleGetPublicSessionByCode(
+    string code,
+    [FromServices] IMediator mediator,
+    CancellationToken cancellationToken)
+{
+    var result = await mediator.Send(new GetPublicLiveSessionByCodeQuery(code), cancellationToken).ConfigureAwait(false);
+    return result is null ? Results.NotFound() : Results.Ok(result);
+}
+```
+
+> Route ordering: literal-segment routes are registered before `{sessionId}` routes (see the file's NOTE at ~line 312). `/code/{code}/public` is unambiguous (literal `code` + literal `public`), but register it near the other `/code/...` routes to keep the convention.
+
+- [ ] **Step 4: Run integration → PASS.** Then run `--filter "FullyQualifiedName~LiveSession&Category=Unit"` to confirm no unit regressions.
+- [ ] **Step 5: Commit** `feat(session-live): public lobby-by-code endpoint (#2590)`
+
+---
+
+### Task 5: Frontend — narrow schema, client method, repoint guest view
+
+**Files:**
+- Modify: `apps/web/src/lib/api/schemas/live-sessions.schemas.ts`
+- Modify: `apps/web/src/lib/api/clients/liveSessionsClient.ts`
+- Modify: `apps/web/src/app/(public)/join/session/[code]/guest-session-view.tsx`
+- Test: FE unit/schema test for the public client + repoint.
+
+- [ ] **Step 1: Add the Zod schema** `PublicLiveSessionDtoSchema` (exact whitelist: id, sessionCode, gameName, gameSlug, status, players[{id, displayName, color, totalScore, currentRank, isActive}]) and a `PublicLiveSessionDto` TS type. Do NOT touch `LiveSessionDtoSchema`.
+
+- [ ] **Step 2: Add the client method** `getPublicByCode(code: string): Promise<PublicLiveSessionDto>` calling `GET ${BASE}/code/${encodeURIComponent(code)}/public` and parsing with `PublicLiveSessionDtoSchema`. Mark with a JSDoc `// PUBLIC — anonymous-safe; narrow DTO`.
+
+- [ ] **Step 3: Repoint `guest-session-view.tsx`** from the raw `fetch(.../code/${code})` to `api.liveSessions.getPublicByCode(code)` (typed). Adjust the local type from `LiveSessionDto` to `PublicLiveSessionDto`. The component already only reads gameName/sessionCode/status + player {id, displayName, color, totalScore, isActive} — confirm no removed field is referenced (it is not, per the spec-panel audit).
+
+- [ ] **Step 4: FE test** — assert `getPublicByCode` hits `/code/{code}/public` and validates against the narrow schema; assert the guest view renders gameName + scoreboard from the narrow shape (mock the client). Run `pnpm test` + `pnpm typecheck` + `pnpm lint`.
+- [ ] **Step 5: Commit** `feat(web): repoint guest join view to public lobby endpoint (#2590)`
+
+---
+
+### Task 6: Build + suite + DoD/PR
+
+- [ ] **Step 1:** `dotnet build apps/api/src/Api/Api.csproj` (0 errors) + `dotnet test --filter "FullyQualifiedName~LiveSession&Category=Unit"` + the two new integration/FE suites.
+- [ ] **Step 2:** code review (security subagent) → address findings.
+- [ ] **Step 3:** PR `feature/issue-2590-public-session-lobby` → `main-dev`, `Closes #2590`. Document the deferred follow-ups (authenticated-tier narrowing; code entropy/TTL).
+
+## Self-Review
+- **Spec coverage**: AllowAnonymous (T4) + narrow DTO (T1/T2) + rate-limit (T3) + FE repoint (T5) + field-exclusion test (T4 step1 #2). Decisions honored: no visibility gate (code-as-capability), authenticated route untouched (T4 #5 regression test). ✔
+- **Type consistency**: `PublicLiveSessionDto`/`PublicLiveSessionPlayerDto` (T1) consumed identically in T2/T4; `GetPublicLiveSessionByCodeQuery(string)→PublicLiveSessionDto?` consistent T2/T4. ✔
+- **Placeholder scan**: rate-limit real-block values flagged "match GameNightTokenRead exactly" (must be read at impl time — the disabled-block copy is not the real shape). ✔
+
+## Known follow-ups (document in PR)
+- Authenticated `/code/{code}` still returns the full DTO to any logged-in non-participant (deferred per product decision — separate issue if desired).
+- Code entropy (6 chars / 1.07e9) + no TTL: rate-limit bounds online enumeration; widening to 8 chars / adding code TTL is a separate hardening ticket.
+- Optional ops follow-up (Nygard): `meepleai_live_session_code_lookup_total{result}` counter + miss-rate alert for enumeration detection.


### PR DESCRIPTION
## Problem (found in the #2573 spec-panel review)
`GET /api/v1/live-sessions/code/{code}` had `.RequireAuthenticatedUser()` but the public `(public)/join/session/[code]` QR-join page called it **anonymously** → 401 → the guest-join feature was **broken**. It also returned the **full `LiveSessionDto`** (leaking `CreatedByUserId`, every player `UserId`, `Notes`, `RoundScores`, `Teams`) to any caller.

## Fix — two-contract split (additive, non-breaking)
Mirrors the GameNight RSVP public pattern (#1169). Spec-panel synthesis + product decisions on #2590.

- **NEW** `GET /api/v1/live-sessions/code/{code}/public` — `.AllowAnonymous()` + `.RequireRateLimiting("LiveSessionCodeReadPublic")` (60/min per IP, IP-partitioned, mirrors `GameNightTokenRead`) → `GetPublicLiveSessionByCodeQuery` → **server-side projection** into a NEW narrow `PublicLiveSessionDto` = `{ Id, SessionCode, GameName, GameSlug, Status, Players[{ Id, DisplayName, Color, TotalScore, CurrentRank, IsActive }] }`. **Excludes** `CreatedByUserId`, player `UserId`, `Notes`, `RoundScores`, `Teams`, `GroupId`, `Visibility`, `AgentMode`, `AvatarUrl`, timestamps. Unknown code → 404.
- **Code-as-capability** (locked product decision): no visibility gate — any valid code resolves the narrow lobby. Residual risk bounded by narrow DTO + rate-limit.
- **Unchanged**: existing `GET /code/{code}` (`.RequireAuthenticatedUser()` + full `LiveSessionDto`) → registered-user join flow / `LiveSessionDtoSchema` untouched.
- **FE**: new `PublicLiveSessionDtoSchema` + `getPublicByCode()`; guest QR view repointed to `/public` (raw anonymous fetch, narrow parse).

## Tests
- BE: 3 unit (projection + null-on-unknown + reflection guard "no sensitive members") + 4 integration (anon 200 narrow body, **field-exclusion on raw JSON**, 404 unknown code, old route still 401). All green; build 0 errors.
- FE: 3 schema tests (narrow accept, strips sensitive, rejects missing); typecheck green.

## Code review
Security-focused subagent review: **APPROVED**, 0 issues across 6 areas (no sensitive leak, endpoint security, backward-compat, routing, FE, residual-risk).

## Deferred follow-ups (documented)
- Authenticated `/code/{code}` still returns the full DTO to any logged-in non-participant (separate ticket if desired).
- Code entropy (6 chars / ~1.07e9) + no TTL: rate-limit bounds online enumeration; widening codes / adding TTL is a separate hardening ticket.
- Optional ops: `meepleai_live_session_code_lookup_total{result}` counter + miss-rate alert (Nygard).

Plan: `docs/superpowers/plans/2026-06-29-issue-2590-public-session-lobby.md` · spec-panel synthesis on #2590.

Closes #2590

🤖 Generated with [Claude Code](https://claude.com/claude-code)