### PR TITLE
feat(session-live): #2579 toolkit/widget/whiteboard events → native stream + repoint hooks

### DIFF
--- a/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Services/LiveSessionStreamGateway.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Services/LiveSessionStreamGateway.cs
@@ -97,14 +97,37 @@ internal sealed class LiveSessionStreamGateway : ILiveSessionStreamGateway
         var channel = Channel.CreateUnbounded<LiveSessionStreamEvent>(
             new UnboundedChannelOptions { SingleWriter = false, SingleReader = true });
 
-        // Launch all three pump tasks concurrently; they each write into the channel.
-        // Complete the writer only after ALL pumps have finished (or ct is cancelled).
-        _ = RunAllPumpsAsync(channel.Writer, liveSessionId, userId, lastEventId, companionId, ct);
+        // Derive a linked CTS so that cancellation of EITHER the caller's token OR early
+        // exit from the consumer's await-foreach (via the finally below) stops the pumps.
+        // Disposed in the finally to release OS handles promptly.
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
 
-        // Yield events as they arrive from any source.
-        await foreach (var evt in channel.Reader.ReadAllAsync(ct).ConfigureAwait(false))
+        // Launch all three pump tasks concurrently; they each write into the channel.
+        // Complete the writer only after ALL pumps have finished (or linkedCts is cancelled).
+        var pumpsTask = RunAllPumpsAsync(channel.Writer, liveSessionId, userId, lastEventId, companionId, linkedCts.Token);
+
+        try
         {
-            yield return evt;
+            // Yield events as they arrive from any source.
+            await foreach (var evt in channel.Reader.ReadAllAsync(ct).ConfigureAwait(false))
+            {
+                yield return evt;
+            }
+        }
+        finally
+        {
+            // Cancel the pumps when enumeration ends (including early break or exception).
+            // This handles the case where the consumer breaks out before the channel completes,
+            // which would otherwise leave the pumps running forever on an unbounded channel.
+            await linkedCts.CancelAsync().ConfigureAwait(false);
+            try
+            {
+                await pumpsTask.ConfigureAwait(false);
+            }
+            catch (OperationCanceledException)
+            {
+                // Expected: pumps were cancelled via linkedCts — swallow.
+            }
         }
     }
 

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Services/LiveSessionStreamGateway.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Services/LiveSessionStreamGateway.cs
@@ -1,7 +1,9 @@
 using System.Runtime.CompilerServices;
+using System.Threading.Channels;
 using Api.BoundedContexts.GameManagement.Application.Services;
 using Api.BoundedContexts.GameManagement.Domain.Repositories;
 using Api.BoundedContexts.SessionTracking.Domain.Services;
+using MediatR;
 using Microsoft.Extensions.Logging;
 
 namespace Api.BoundedContexts.GameManagement.Infrastructure.Services;
@@ -10,23 +12,35 @@ namespace Api.BoundedContexts.GameManagement.Infrastructure.Services;
 /// Infrastructure implementation of the ADR-083 SP2 anti-corruption layer for live-session
 /// SSE streaming. Resolves the SessionTracking companion id
 /// (<see cref="Domain.Entities.LiveGameSession.TrackingSessionId"/>, created by SP0 Saga)
-/// and delegates to <see cref="ISessionBroadcastService"/>, keeping the GameManagement
-/// Application layer free of cross-BC SessionTracking types.
-/// Issue #2561 SP2 T3.
+/// and fans in three event sources so the native stream carries all session events:
+/// <list type="number">
+///   <item>Companion channel (<see cref="ISessionBroadcastService"/> keyed on TrackingSessionId):
+///         domain events with replay + visibility filter. Id preserved.</item>
+///   <item>SBS toolkit channel (<see cref="ISessionBroadcastService"/> keyed on liveSessionId):
+///         whiteboard / turn / timer events. Id dropped (live-only, no replay contamination).</item>
+///   <item>SSS widget channel (<see cref="ISessionSyncService"/> keyed on liveSessionId):
+///         in-memory WidgetStateUpdated events. Id null.</item>
+/// </list>
+/// When <c>TrackingSessionId == null</c> (legacy / free-form session), sources 2+3 still run;
+/// only the companion pump is skipped.
+/// Issue #2561 SP2 T3 / Issue #2579 fan-in.
 /// </summary>
 internal sealed class LiveSessionStreamGateway : ILiveSessionStreamGateway
 {
     private readonly ILiveSessionRepository _liveSessionRepository;
     private readonly ISessionBroadcastService _broadcast;
+    private readonly ISessionSyncService _syncService;
     private readonly ILogger<LiveSessionStreamGateway> _logger;
 
     public LiveSessionStreamGateway(
         ILiveSessionRepository liveSessionRepository,
         ISessionBroadcastService broadcast,
+        ISessionSyncService syncService,
         ILogger<LiveSessionStreamGateway> logger)
     {
         _liveSessionRepository = liveSessionRepository ?? throw new ArgumentNullException(nameof(liveSessionRepository));
         _broadcast = broadcast ?? throw new ArgumentNullException(nameof(broadcast));
+        _syncService = syncService ?? throw new ArgumentNullException(nameof(syncService));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -79,20 +93,157 @@ internal sealed class LiveSessionStreamGateway : ILiveSessionStreamGateway
         var session = await _liveSessionRepository.GetByIdAsync(liveSessionId, ct).ConfigureAwait(false);
         var companionId = session?.TrackingSessionId;
 
-        if (companionId is null)
+        // Build an unbounded fan-in channel.
+        var channel = Channel.CreateUnbounded<LiveSessionStreamEvent>(
+            new UnboundedChannelOptions { SingleWriter = false, SingleReader = true });
+
+        // Launch all three pump tasks concurrently; they each write into the channel.
+        // Complete the writer only after ALL pumps have finished (or ct is cancelled).
+        _ = RunAllPumpsAsync(channel.Writer, liveSessionId, userId, lastEventId, companionId, ct);
+
+        // Yield events as they arrive from any source.
+        await foreach (var evt in channel.Reader.ReadAllAsync(ct).ConfigureAwait(false))
         {
-            _logger.LogDebug(
-                "SubscribeAsync: live session {LiveSessionId} has no TrackingSessionId — returning empty stream",
-                liveSessionId);
-            yield break;
+            yield return evt;
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Private helpers
+    // ─────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Starts all three pumps concurrently and completes the channel writer when all finish.
+    /// One pump faulting or completing does not stop the others.
+    /// </summary>
+    private async Task RunAllPumpsAsync(
+        ChannelWriter<LiveSessionStreamEvent> writer,
+        Guid liveSessionId,
+        Guid userId,
+        string? lastEventId,
+        Guid? companionId,
+        CancellationToken ct)
+    {
+        var pumps = new List<Task>();
+
+        // Pump 1 — companion (domain events with replay + visibility filter; Id preserved).
+        // Only if the session has a companion TrackingSessionId.
+        if (companionId is not null)
+        {
+            pumps.Add(PumpCompanionAsync(writer, companionId.Value, userId, lastEventId, ct));
         }
 
-        await foreach (var envelope in _broadcast
-            .SubscribeAsync(companionId.Value, userId, lastEventId, ct)
-            .ConfigureAwait(false)
-            .WithCancellation(ct))
+        // Pump 2 — SBS toolkit channel keyed on liveSessionId (whiteboard/turn/timer).
+        // Live-only: Id dropped so it does not contaminate Last-Event-ID reconnection.
+        pumps.Add(PumpSbsToolkitAsync(writer, liveSessionId, userId, ct));
+
+        // Pump 3 — SSS widget channel (in-memory INotification stream).
+        pumps.Add(PumpSssWidgetAsync(writer, liveSessionId, ct));
+
+        try
         {
-            yield return new LiveSessionStreamEvent(envelope.EventType, envelope.Data, envelope.Id);
+            await Task.WhenAll(pumps).ConfigureAwait(false);
+            writer.TryComplete();
+        }
+        catch (Exception ex)
+        {
+            writer.TryComplete(ex);
+        }
+    }
+
+    /// <summary>Pump 1: companion broadcast channel — preserves envelope Id.</summary>
+    private async Task PumpCompanionAsync(
+        ChannelWriter<LiveSessionStreamEvent> writer,
+        Guid companionId,
+        Guid userId,
+        string? lastEventId,
+        CancellationToken ct)
+    {
+        try
+        {
+            await foreach (var envelope in _broadcast
+                .SubscribeAsync(companionId, userId, lastEventId, ct)
+                .ConfigureAwait(false)
+                .WithCancellation(ct))
+            {
+                await writer.WriteAsync(
+                    new LiveSessionStreamEvent(envelope.EventType, envelope.Data, envelope.Id),
+                    ct).ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Normal shutdown — propagate nothing; WhenAll will see ct cancelled.
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Companion pump for {CompanionId} ended with error — other sources unaffected",
+                companionId);
+        }
+    }
+
+    /// <summary>Pump 2: SBS toolkit channel keyed on liveSessionId — drops envelope Id.</summary>
+    private async Task PumpSbsToolkitAsync(
+        ChannelWriter<LiveSessionStreamEvent> writer,
+        Guid liveSessionId,
+        Guid userId,
+        CancellationToken ct)
+    {
+        try
+        {
+            await foreach (var envelope in _broadcast
+                .SubscribeAsync(liveSessionId, userId, null, ct)
+                .ConfigureAwait(false)
+                .WithCancellation(ct))
+            {
+                await writer.WriteAsync(
+                    new LiveSessionStreamEvent(envelope.EventType, envelope.Data, null),
+                    ct).ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Normal shutdown.
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "SBS toolkit pump for {LiveSessionId} ended with error — other sources unaffected",
+                liveSessionId);
+        }
+    }
+
+    /// <summary>Pump 3: SSS widget channel (in-memory INotification stream) — maps via SseEventTypeMapper.</summary>
+    private async Task PumpSssWidgetAsync(
+        ChannelWriter<LiveSessionStreamEvent> writer,
+        Guid liveSessionId,
+        CancellationToken ct)
+    {
+        try
+        {
+            await foreach (var notification in _syncService
+                .SubscribeToSessionEvents(liveSessionId, ct)
+                .ConfigureAwait(false)
+                .WithCancellation(ct))
+            {
+                await writer.WriteAsync(
+                    new LiveSessionStreamEvent(
+                        SseEventTypeMapper.GetEventType(notification),
+                        notification,
+                        null),
+                    ct).ConfigureAwait(false);
+            }
+        }
+        catch (OperationCanceledException)
+        {
+            // Normal shutdown.
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "SSS widget pump for {LiveSessionId} ended with error — other sources unaffected",
+                liveSessionId);
         }
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Infrastructure/Services/LiveSessionStreamGatewayTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Infrastructure/Services/LiveSessionStreamGatewayTests.cs
@@ -1,4 +1,5 @@
 using System.Runtime.CompilerServices;
+using System.Threading.Channels;
 using Api.BoundedContexts.GameManagement.Application.Services;
 using Api.BoundedContexts.GameManagement.Domain.Entities;
 using Api.BoundedContexts.GameManagement.Domain.Enums;
@@ -6,8 +7,10 @@ using Api.BoundedContexts.GameManagement.Domain.Models;
 using Api.BoundedContexts.GameManagement.Domain.Repositories;
 using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
 using Api.BoundedContexts.GameManagement.Infrastructure.Services;
+using Api.BoundedContexts.SessionTracking.Domain.Events;
 using Api.BoundedContexts.SessionTracking.Domain.Services;
 using Api.Tests.Constants;
+using MediatR;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using Xunit;
@@ -16,12 +19,13 @@ namespace Api.Tests.BoundedContexts.GameManagement.Infrastructure.Services;
 
 /// <summary>
 /// Unit tests for <see cref="LiveSessionStreamGateway"/>.
-/// Verifies companion-id resolution and delegation to <see cref="ISessionBroadcastService"/>.
-/// Issue #2561 SP2 T3.
+/// Verifies companion-id resolution, 3-way fan-in merge, and delegation to
+/// <see cref="ISessionBroadcastService"/> / <see cref="ISessionSyncService"/>.
+/// Issue #2561 SP2 T3 / Issue #2579 fan-in.
 /// </summary>
 [Trait("Category", TestCategories.Unit)]
 [Trait("BoundedContext", "GameManagement")]
-[Trait("Issue", "2561")]
+[Trait("Issue", "2579")]
 public sealed class LiveSessionStreamGatewayTests
 {
     // ── helpers ──────────────────────────────────────────────────────────────
@@ -71,6 +75,33 @@ public sealed class LiveSessionStreamGatewayTests
             setupChecklist: null);
     }
 
+    /// <summary>Creates a gateway SUT with default empty mocks for ISessionSyncService.</summary>
+    private static LiveSessionStreamGateway BuildSut(
+        ILiveSessionRepository repo,
+        ISessionBroadcastService broadcast,
+        ISessionSyncService? syncService = null)
+    {
+        ISessionSyncService sync;
+        if (syncService is not null)
+        {
+            sync = syncService;
+        }
+        else
+        {
+            var syncMock = new Mock<ISessionSyncService>();
+            syncMock
+                .Setup(s => s.SubscribeToSessionEvents(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+                .Returns(EmptyNotificationAsyncEnumerable());
+            sync = syncMock.Object;
+        }
+
+        return new LiveSessionStreamGateway(
+            repo,
+            broadcast,
+            sync,
+            NullLogger<LiveSessionStreamGateway>.Instance);
+    }
+
     // ── BroadcastAsync ────────────────────────────────────────────────────────
 
     [Fact]
@@ -86,10 +117,7 @@ public sealed class LiveSessionStreamGatewayTests
 
         var broadcast = new Mock<ISessionBroadcastService>();
 
-        var sut = new LiveSessionStreamGateway(
-            repo.Object,
-            broadcast.Object,
-            NullLogger<LiveSessionStreamGateway>.Instance);
+        var sut = BuildSut(repo.Object, broadcast.Object);
 
         var evt = new LiveSessionStreamEvent("session:score", new { value = 3 });
 
@@ -118,10 +146,7 @@ public sealed class LiveSessionStreamGatewayTests
 
         var broadcast = new Mock<ISessionBroadcastService>();
 
-        var sut = new LiveSessionStreamGateway(
-            repo.Object,
-            broadcast.Object,
-            NullLogger<LiveSessionStreamGateway>.Instance);
+        var sut = BuildSut(repo.Object, broadcast.Object);
 
         var evt = new LiveSessionStreamEvent("session:score", new { value = 3 });
 
@@ -150,10 +175,7 @@ public sealed class LiveSessionStreamGatewayTests
 
         var broadcast = new Mock<ISessionBroadcastService>();
 
-        var sut = new LiveSessionStreamGateway(
-            repo.Object,
-            broadcast.Object,
-            NullLogger<LiveSessionStreamGateway>.Instance);
+        var sut = BuildSut(repo.Object, broadcast.Object);
 
         // Act
         await sut.BroadcastAsync(liveId, new LiveSessionStreamEvent("session:turn", new { }));
@@ -168,40 +190,217 @@ public sealed class LiveSessionStreamGatewayTests
             Times.Never);
     }
 
-    // ── SubscribeAsync ────────────────────────────────────────────────────────
+    // ── SubscribeAsync — companion path (existing, unchanged semantics) ────────
 
     [Fact]
-    public async Task SubscribeAsync_returns_empty_stream_when_no_companion()
+    public async Task SubscribeAsync_companion_envelope_reaches_subscriber_with_original_id()
     {
+        // Requirement (c): companion-channel envelope preserves its original Id.
         // Arrange
         var liveId = Guid.NewGuid();
+        var companionId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+
+        var companionEnvelope = new SseEventEnvelope
+        {
+            Id = "evt-42",
+            EventType = "session:score",
+            Data = new { value = 5 }
+        };
 
         var repo = new Mock<ILiveSessionRepository>();
         repo.Setup(r => r.GetByIdAsync(liveId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(FakeLiveSessionWith(trackingSessionId: null));
+            .ReturnsAsync(FakeLiveSessionWith(trackingSessionId: companionId));
 
         var broadcast = new Mock<ISessionBroadcastService>();
+        // Companion channel returns one event with Id preserved.
+        broadcast
+            .Setup(b => b.SubscribeAsync(companionId, userId, null, It.IsAny<CancellationToken>()))
+            .Returns(SingleEnvelopeAsyncEnumerable(companionEnvelope));
+        // Toolkit channel (liveId) returns empty.
+        broadcast
+            .Setup(b => b.SubscribeAsync(liveId, userId, null, It.IsAny<CancellationToken>()))
+            .Returns(EmptyEnvelopeAsyncEnumerable());
 
-        var sut = new LiveSessionStreamGateway(
-            repo.Object,
-            broadcast.Object,
-            NullLogger<LiveSessionStreamGateway>.Instance);
+        var sync = new Mock<ISessionSyncService>();
+        sync
+            .Setup(s => s.SubscribeToSessionEvents(liveId, It.IsAny<CancellationToken>()))
+            .Returns(EmptyNotificationAsyncEnumerable());
+
+        var sut = BuildSut(repo.Object, broadcast.Object, sync.Object);
 
         // Act
         var events = new List<LiveSessionStreamEvent>();
-        await foreach (var e in sut.SubscribeAsync(liveId, Guid.NewGuid(), null, CancellationToken.None))
+        await foreach (var e in sut.SubscribeAsync(liveId, userId, null, CancellationToken.None))
+            events.Add(e);
+
+        // Assert — companion event arrives with its Id intact
+        var scoreEvt = events.FirstOrDefault(e => e.Type == "session:score");
+        Assert.NotNull(scoreEvt);
+        Assert.Equal("evt-42", scoreEvt.Id);
+    }
+
+    // ── SubscribeAsync — SBS toolkit source (a) ───────────────────────────────
+
+    [Fact]
+    public async Task SubscribeAsync_sbs_toolkit_event_arrives_with_null_id()
+    {
+        // Requirement (a): SBS event on liveSessionId channel reaches subscriber with Id == null.
+        // Arrange
+        var liveId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+
+        var toolkitEnvelope = new SseEventEnvelope
+        {
+            Id = "should-be-dropped",
+            EventType = "session:toolkit",
+            Data = new { turn = 2 }
+        };
+
+        var repo = new Mock<ILiveSessionRepository>();
+        repo.Setup(r => r.GetByIdAsync(liveId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(FakeLiveSessionWith(trackingSessionId: null)); // no companion
+
+        var broadcast = new Mock<ISessionBroadcastService>();
+        // Toolkit channel returns one event.
+        broadcast
+            .Setup(b => b.SubscribeAsync(liveId, userId, null, It.IsAny<CancellationToken>()))
+            .Returns(SingleEnvelopeAsyncEnumerable(toolkitEnvelope));
+
+        var sync = new Mock<ISessionSyncService>();
+        sync
+            .Setup(s => s.SubscribeToSessionEvents(liveId, It.IsAny<CancellationToken>()))
+            .Returns(EmptyNotificationAsyncEnumerable());
+
+        var sut = BuildSut(repo.Object, broadcast.Object, sync.Object);
+
+        // Act
+        var events = new List<LiveSessionStreamEvent>();
+        await foreach (var e in sut.SubscribeAsync(liveId, userId, null, CancellationToken.None))
             events.Add(e);
 
         // Assert
-        Assert.Empty(events);
+        var toolkitEvt = events.FirstOrDefault(e => e.Type == "session:toolkit");
+        Assert.NotNull(toolkitEvt);
+        Assert.Null(toolkitEvt.Id); // Id must be dropped (null)
+    }
+
+    // ── SubscribeAsync — SSS widget source (b) ────────────────────────────────
+
+    [Fact]
+    public async Task SubscribeAsync_sss_widget_event_arrives_with_mapped_type_and_null_id()
+    {
+        // Requirement (b): INotification from SSS arrives as Type == SseEventTypeMapper.GetEventType(evt),
+        //                  Data == evt, Id == null.
+        // Arrange
+        var liveId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+
+        var widgetEvt = new WidgetStateUpdatedEvent(
+            SessionId: liveId,
+            ToolkitId: Guid.NewGuid(),
+            WidgetType: "counter",
+            StateJson: "{}",
+            UpdatedByUserId: userId,
+            Timestamp: DateTime.UtcNow);
+
+        var repo = new Mock<ILiveSessionRepository>();
+        repo.Setup(r => r.GetByIdAsync(liveId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(FakeLiveSessionWith(trackingSessionId: null)); // no companion
+
+        var broadcast = new Mock<ISessionBroadcastService>();
+        broadcast
+            .Setup(b => b.SubscribeAsync(liveId, userId, null, It.IsAny<CancellationToken>()))
+            .Returns(EmptyEnvelopeAsyncEnumerable());
+
+        var sync = new Mock<ISessionSyncService>();
+        sync
+            .Setup(s => s.SubscribeToSessionEvents(liveId, It.IsAny<CancellationToken>()))
+            .Returns(SingleNotificationAsyncEnumerable(widgetEvt));
+
+        var sut = BuildSut(repo.Object, broadcast.Object, sync.Object);
+
+        // Act
+        var events = new List<LiveSessionStreamEvent>();
+        await foreach (var e in sut.SubscribeAsync(liveId, userId, null, CancellationToken.None))
+            events.Add(e);
+
+        // Assert
+        Assert.Single(events);
+        var mapped = events[0];
+        Assert.Equal(SseEventTypeMapper.GetEventType(widgetEvt), mapped.Type); // "session:toolkit"
+        Assert.Equal(widgetEvt, mapped.Data);
+        Assert.Null(mapped.Id);
+    }
+
+    // ── SubscribeAsync — null companion still delivers sources (d) ────────────
+
+    [Fact]
+    public async Task SubscribeAsync_when_no_companion_toolkit_and_widget_events_still_deliver()
+    {
+        // Requirement (d): when TrackingSessionId == null, sources (a)+(b) STILL deliver;
+        //                  companion source is simply skipped.
+        // Arrange
+        var liveId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+
+        var toolkitEnvelope = new SseEventEnvelope
+        {
+            Id = "any",
+            EventType = "session:timer",
+            Data = new { remaining = 30 }
+        };
+
+        var widgetEvt = new WidgetStateUpdatedEvent(
+            SessionId: liveId,
+            ToolkitId: Guid.NewGuid(),
+            WidgetType: "timer",
+            StateJson: "{}",
+            UpdatedByUserId: userId,
+            Timestamp: DateTime.UtcNow);
+
+        var repo = new Mock<ILiveSessionRepository>();
+        repo.Setup(r => r.GetByIdAsync(liveId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(FakeLiveSessionWith(trackingSessionId: null)); // no companion
+
+        var broadcast = new Mock<ISessionBroadcastService>();
+        broadcast
+            .Setup(b => b.SubscribeAsync(liveId, userId, null, It.IsAny<CancellationToken>()))
+            .Returns(SingleEnvelopeAsyncEnumerable(toolkitEnvelope));
+
+        var sync = new Mock<ISessionSyncService>();
+        sync
+            .Setup(s => s.SubscribeToSessionEvents(liveId, It.IsAny<CancellationToken>()))
+            .Returns(SingleNotificationAsyncEnumerable(widgetEvt));
+
+        var sut = BuildSut(repo.Object, broadcast.Object, sync.Object);
+
+        // Act
+        var events = new List<LiveSessionStreamEvent>();
+        await foreach (var e in sut.SubscribeAsync(liveId, userId, null, CancellationToken.None))
+            events.Add(e);
+
+        // Assert — both sources delivered, companion channel was NOT subscribed
+        Assert.Equal(2, events.Count);
+        Assert.Contains(events, e => e.Type == "session:timer" && e.Id == null);
+        Assert.Contains(events, e => e.Type == "session:toolkit" && widgetEvt.Equals(e.Data) && e.Id == null);
+
+        // Verify companion channel was never subscribed (no broadcast for a Guid != liveId)
         broadcast.Verify(
-            b => b.SubscribeAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<string?>(), It.IsAny<CancellationToken>()),
+            b => b.SubscribeAsync(
+                It.Is<Guid>(g => g != liveId),
+                It.IsAny<Guid>(),
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()),
             Times.Never);
     }
+
+    // ── SubscribeAsync — backward-compat: companion maps existing test ─────────
 
     [Fact]
     public async Task SubscribeAsync_maps_envelopes_to_events_with_id()
     {
+        // Existing test preserved: companion path — original Id must be kept.
         // Arrange
         var liveId = Guid.NewGuid();
         var companionId = Guid.NewGuid();
@@ -221,12 +420,17 @@ public sealed class LiveSessionStreamGatewayTests
         var broadcast = new Mock<ISessionBroadcastService>();
         broadcast
             .Setup(b => b.SubscribeAsync(companionId, userId, null, It.IsAny<CancellationToken>()))
-            .Returns(SingleItemAsyncEnumerable(envelope));
+            .Returns(SingleEnvelopeAsyncEnumerable(envelope));
+        broadcast
+            .Setup(b => b.SubscribeAsync(liveId, userId, null, It.IsAny<CancellationToken>()))
+            .Returns(EmptyEnvelopeAsyncEnumerable());
 
-        var sut = new LiveSessionStreamGateway(
-            repo.Object,
-            broadcast.Object,
-            NullLogger<LiveSessionStreamGateway>.Instance);
+        var sync = new Mock<ISessionSyncService>();
+        sync
+            .Setup(s => s.SubscribeToSessionEvents(liveId, It.IsAny<CancellationToken>()))
+            .Returns(EmptyNotificationAsyncEnumerable());
+
+        var sut = BuildSut(repo.Object, broadcast.Object, sync.Object);
 
         // Act
         var events = new List<LiveSessionStreamEvent>();
@@ -234,18 +438,41 @@ public sealed class LiveSessionStreamGatewayTests
             events.Add(e);
 
         // Assert
-        Assert.Single(events);
-        Assert.Equal("session:score", events[0].Type);
-        Assert.Equal("evt-42", events[0].Id);
+        var scoreEvt = events.FirstOrDefault(e => e.Type == "session:score");
+        Assert.NotNull(scoreEvt);
+        Assert.Equal("session:score", scoreEvt.Type);
+        Assert.Equal("evt-42", scoreEvt.Id);
     }
 
-    // ── helper ───────────────────────────────────────────────────────────────
+    // ── helpers ───────────────────────────────────────────────────────────────
 
-    private static async IAsyncEnumerable<SseEventEnvelope> SingleItemAsyncEnumerable(
+    private static async IAsyncEnumerable<SseEventEnvelope> SingleEnvelopeAsyncEnumerable(
         SseEventEnvelope item,
         [EnumeratorCancellation] CancellationToken ct = default)
     {
         await Task.CompletedTask;
         yield return item;
+    }
+
+    private static async IAsyncEnumerable<SseEventEnvelope> EmptyEnvelopeAsyncEnumerable(
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        await Task.CompletedTask;
+        yield break;
+    }
+
+    private static async IAsyncEnumerable<INotification> SingleNotificationAsyncEnumerable(
+        INotification item,
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        await Task.CompletedTask;
+        yield return item;
+    }
+
+    private static async IAsyncEnumerable<INotification> EmptyNotificationAsyncEnumerable(
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        await Task.CompletedTask;
+        yield break;
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Infrastructure/Services/LiveSessionStreamGatewayTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Infrastructure/Services/LiveSessionStreamGatewayTests.cs
@@ -444,6 +444,202 @@ public sealed class LiveSessionStreamGatewayTests
         Assert.Equal("evt-42", scoreEvt.Id);
     }
 
+    // ── SubscribeAsync — Task 2 regression tests ──────────────────────────────
+
+    /// <summary>
+    /// T2-R1: Cancellation teardown — cancel the caller ct while sources never complete;
+    /// the returned enumerable must complete and all three underlying subscriptions
+    /// must observe cancellation (verified via fake CancellationToken observation).
+    /// </summary>
+    [Fact]
+    public async Task SubscribeAsync_cancellation_tears_down_all_three_pumps()
+    {
+        // Arrange
+        var liveId = Guid.NewGuid();
+        var companionId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+
+        var cts = new CancellationTokenSource();
+
+        // Track which tokens were observed as cancelled by each source
+        CancellationToken capturedCompanionToken = default;
+        CancellationToken capturedSbsToolkitToken = default;
+        CancellationToken capturedSssToken = default;
+
+        var repo = new Mock<ILiveSessionRepository>();
+        repo.Setup(r => r.GetByIdAsync(liveId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(FakeLiveSessionWith(trackingSessionId: companionId));
+
+        var broadcast = new Mock<ISessionBroadcastService>();
+
+        // Companion: infinite stream that captures the CancellationToken
+        broadcast
+            .Setup(b => b.SubscribeAsync(companionId, userId, It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .Returns((Guid _, Guid _, string? _, CancellationToken ct) =>
+            {
+                capturedCompanionToken = ct;
+                return InfiniteEnvelopeAsyncEnumerable(ct);
+            });
+
+        // SBS toolkit: infinite stream that captures the CancellationToken
+        broadcast
+            .Setup(b => b.SubscribeAsync(liveId, userId, It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .Returns((Guid _, Guid _, string? _, CancellationToken ct) =>
+            {
+                capturedSbsToolkitToken = ct;
+                return InfiniteEnvelopeAsyncEnumerable(ct);
+            });
+
+        var syncFake = new CancellationCapturingSyncService(liveId);
+        var sut = BuildSut(repo.Object, broadcast.Object, syncFake);
+
+        // Act — start consuming but cancel quickly
+        var enumerateTask = Task.Run(async () =>
+        {
+            // OperationCanceledException is expected when ct is cancelled mid-stream
+            try
+            {
+                await foreach (var _ in sut.SubscribeAsync(liveId, userId, null, cts.Token))
+                {
+                    // intentionally consume nothing — cancel will stop us
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                // Expected: the caller's ct was cancelled — enumeration stops.
+            }
+        });
+
+        // Give the pumps a moment to start, then cancel
+        await Task.Delay(20);
+        cts.Cancel();
+
+        // The enumeration must complete (not hang) — awaiting this would deadlock if teardown is broken
+        await enumerateTask.WaitAsync(TimeSpan.FromSeconds(5));
+
+        // Assert: all three sources observed cancellation
+        Assert.True(capturedCompanionToken.IsCancellationRequested,
+            "Companion pump token should be cancelled");
+        Assert.True(capturedSbsToolkitToken.IsCancellationRequested,
+            "SBS toolkit pump token should be cancelled");
+        Assert.True(syncFake.CapturedToken.IsCancellationRequested,
+            "SSS widget pump token should be cancelled");
+    }
+
+    /// <summary>
+    /// T2-R2: No double-delivery — a domain event delivered via the companion source
+    /// appears EXACTLY ONCE (it is NOT also on the liveSessionId SBS channel).
+    /// </summary>
+    [Fact]
+    public async Task SubscribeAsync_companion_event_not_double_delivered_via_sbs_channel()
+    {
+        // Arrange
+        var liveId = Guid.NewGuid();
+        var companionId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+
+        var companionEnvelope = new SseEventEnvelope
+        {
+            Id = "companion-evt-1",
+            EventType = "session:score",
+            Data = new { value = 10 }
+        };
+
+        var repo = new Mock<ILiveSessionRepository>();
+        repo.Setup(r => r.GetByIdAsync(liveId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(FakeLiveSessionWith(trackingSessionId: companionId));
+
+        var broadcast = new Mock<ISessionBroadcastService>();
+
+        // Companion emits one event
+        broadcast
+            .Setup(b => b.SubscribeAsync(companionId, userId, null, It.IsAny<CancellationToken>()))
+            .Returns(SingleEnvelopeAsyncEnumerable(companionEnvelope));
+
+        // SBS toolkit (liveId) emits NOTHING — domain events are NOT duplicated here
+        broadcast
+            .Setup(b => b.SubscribeAsync(liveId, userId, null, It.IsAny<CancellationToken>()))
+            .Returns(EmptyEnvelopeAsyncEnumerable());
+
+        var sync = new Mock<ISessionSyncService>();
+        sync
+            .Setup(s => s.SubscribeToSessionEvents(liveId, It.IsAny<CancellationToken>()))
+            .Returns(EmptyNotificationAsyncEnumerable());
+
+        var sut = BuildSut(repo.Object, broadcast.Object, sync.Object);
+
+        // Act
+        var events = new List<LiveSessionStreamEvent>();
+        await foreach (var e in sut.SubscribeAsync(liveId, userId, null, CancellationToken.None))
+            events.Add(e);
+
+        // Assert: exactly ONE session:score event — no duplicate
+        var scoreEvents = events.Where(e => e.Type == "session:score").ToList();
+        Assert.Single(scoreEvents);
+        Assert.Equal("companion-evt-1", scoreEvents[0].Id);
+    }
+
+    /// <summary>
+    /// T2-R3: Replay only to companion — lastEventId is forwarded ONLY to the companion
+    /// SubscribeAsync call (Pump 1), NOT to the liveSessionId SBS call (Pump 2).
+    /// </summary>
+    [Fact]
+    public async Task SubscribeAsync_lastEventId_forwarded_only_to_companion_not_to_sbs_toolkit()
+    {
+        // Arrange
+        var liveId = Guid.NewGuid();
+        var companionId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        const string lastEventId = "replay-from-42";
+
+        var capturedLastEventIds = new System.Collections.Concurrent.ConcurrentDictionary<Guid, string?>();
+
+        var repo = new Mock<ILiveSessionRepository>();
+        repo.Setup(r => r.GetByIdAsync(liveId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(FakeLiveSessionWith(trackingSessionId: companionId));
+
+        var broadcast = new Mock<ISessionBroadcastService>();
+
+        // Capture the lastEventId for companion call
+        broadcast
+            .Setup(b => b.SubscribeAsync(companionId, userId, It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .Returns((Guid id, Guid _, string? lei, CancellationToken _) =>
+            {
+                capturedLastEventIds[id] = lei;
+                return EmptyEnvelopeAsyncEnumerable();
+            });
+
+        // Capture the lastEventId for liveId (toolkit) call
+        broadcast
+            .Setup(b => b.SubscribeAsync(liveId, userId, It.IsAny<string?>(), It.IsAny<CancellationToken>()))
+            .Returns((Guid id, Guid _, string? lei, CancellationToken _) =>
+            {
+                capturedLastEventIds[id] = lei;
+                return EmptyEnvelopeAsyncEnumerable();
+            });
+
+        var sync = new Mock<ISessionSyncService>();
+        sync
+            .Setup(s => s.SubscribeToSessionEvents(liveId, It.IsAny<CancellationToken>()))
+            .Returns(EmptyNotificationAsyncEnumerable());
+
+        var sut = BuildSut(repo.Object, broadcast.Object, sync.Object);
+
+        // Act
+        var events = new List<LiveSessionStreamEvent>();
+        await foreach (var e in sut.SubscribeAsync(liveId, userId, lastEventId, CancellationToken.None))
+            events.Add(e);
+
+        // Assert: companion got lastEventId; SBS toolkit channel got null
+        Assert.True(capturedLastEventIds.ContainsKey(companionId),
+            "Companion SubscribeAsync should have been called");
+        Assert.Equal(lastEventId, capturedLastEventIds[companionId]);
+
+        Assert.True(capturedLastEventIds.ContainsKey(liveId),
+            "SBS toolkit SubscribeAsync should have been called");
+        Assert.Null(capturedLastEventIds[liveId]);
+    }
+
     // ── helpers ───────────────────────────────────────────────────────────────
 
     private static async IAsyncEnumerable<SseEventEnvelope> SingleEnvelopeAsyncEnumerable(
@@ -474,5 +670,57 @@ public sealed class LiveSessionStreamGatewayTests
     {
         await Task.CompletedTask;
         yield break;
+    }
+
+    /// <summary>
+    /// Infinite async enumerable for SseEventEnvelope that blocks until the
+    /// CancellationToken is triggered — simulates a non-completing SSE subscription.
+    /// </summary>
+    private static async IAsyncEnumerable<SseEventEnvelope> InfiniteEnvelopeAsyncEnumerable(
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        while (!ct.IsCancellationRequested)
+        {
+            // Wait in small increments; throw on cancellation.
+            await Task.Delay(10, ct).ConfigureAwait(false);
+        }
+        // Propagate so the pump catches OperationCanceledException normally.
+        ct.ThrowIfCancellationRequested();
+        yield break; // unreachable — keeps compiler happy
+    }
+
+    /// <summary>
+    /// Fake <see cref="ISessionSyncService"/> that captures the CancellationToken
+    /// passed to <see cref="SubscribeToSessionEvents"/> and blocks until it is cancelled.
+    /// Used to verify teardown in the cancellation regression test.
+    /// </summary>
+    private sealed class CancellationCapturingSyncService : ISessionSyncService
+    {
+        private readonly Guid _sessionId;
+        public CancellationToken CapturedToken { get; private set; }
+
+        public CancellationCapturingSyncService(Guid sessionId) => _sessionId = sessionId;
+
+        public IAsyncEnumerable<INotification> SubscribeToSessionEvents(
+            Guid sessionId,
+            CancellationToken ct)
+        {
+            CapturedToken = ct;
+            return InfiniteNotificationAsyncEnumerable(ct);
+        }
+
+        public Task PublishEventAsync(Guid sessionId, INotification evt, CancellationToken ct)
+            => Task.CompletedTask;
+
+        private static async IAsyncEnumerable<INotification> InfiniteNotificationAsyncEnumerable(
+            [EnumeratorCancellation] CancellationToken ct = default)
+        {
+            while (!ct.IsCancellationRequested)
+            {
+                await Task.Delay(10, ct).ConfigureAwait(false);
+            }
+            ct.ThrowIfCancellationRequested();
+            yield break; // unreachable — keeps compiler happy
+        }
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Infrastructure/Services/LiveSessionStreamGatewayTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Infrastructure/Services/LiveSessionStreamGatewayTests.cs
@@ -464,7 +464,6 @@ public sealed class LiveSessionStreamGatewayTests
         // Track which tokens were observed as cancelled by each source
         CancellationToken capturedCompanionToken = default;
         CancellationToken capturedSbsToolkitToken = default;
-        CancellationToken capturedSssToken = default;
 
         var repo = new Mock<ILiveSessionRepository>();
         repo.Setup(r => r.GetByIdAsync(liveId, It.IsAny<CancellationToken>()))
@@ -696,10 +695,9 @@ public sealed class LiveSessionStreamGatewayTests
     /// </summary>
     private sealed class CancellationCapturingSyncService : ISessionSyncService
     {
-        private readonly Guid _sessionId;
         public CancellationToken CapturedToken { get; private set; }
 
-        public CancellationCapturingSyncService(Guid sessionId) => _sessionId = sessionId;
+        public CancellationCapturingSyncService(Guid sessionId) { }
 
         public IAsyncEnumerable<INotification> SubscribeToSessionEvents(
             Guid sessionId,

--- a/apps/web/src/lib/domain-hooks/__tests__/useTurnOrder.test.ts
+++ b/apps/web/src/lib/domain-hooks/__tests__/useTurnOrder.test.ts
@@ -341,9 +341,7 @@ describe('useTurnOrder', () => {
 
       // Vitest v4: assert via instance properties, not vi.fn call tracking
       expect(mockEventSourceInstances).toHaveLength(1);
-      expect(mockEventSourceInstances[0]?.url).toContain(
-        '/api/v1/game-sessions/sess-123/stream/v2'
-      );
+      expect(mockEventSourceInstances[0]?.url).toContain('/api/v1/live-sessions/sess-123/stream');
       expect(mockEventSourceInstances[0]?.withCredentials).toBe(true);
     });
 

--- a/apps/web/src/lib/domain-hooks/__tests__/useWhiteboardTool.test.ts
+++ b/apps/web/src/lib/domain-hooks/__tests__/useWhiteboardTool.test.ts
@@ -8,12 +8,14 @@
  * - saveStrokes: debounced 500ms, calls correct endpoint
  * - saveStructured: debounced 500ms, calls correct endpoint
  * - clear: immediate, resets strokes and tokens
- * - applySSEEvent: stroke-added, structured-updated, whiteboard-cleared
- * - SSE native stream listener: URL, event name, event dispatch (#2579)
+ * - applySSEEvent (manual delta API): stroke-added, structured-updated, whiteboard-cleared
+ * - SSE native stream listener (#2579): URL, event name, debounced refetch behavior
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act, waitFor } from '@testing-library/react';
+
+// Note: fake timers are used in the SSE native stream listener tests (debounce assertions).
 
 import { useWhiteboardTool } from '../useWhiteboardTool';
 import type { WhiteboardState, WhiteboardSSEEvent, Stroke } from '@/components/session/types';
@@ -532,68 +534,161 @@ describe('SSE native stream listener', () => {
     expect(mockEventSourceInstances[0]?.close).toHaveBeenCalled();
   });
 
-  it('applies stroke-added event dispatched as session:whiteboard', async () => {
+  // ── Re-fetch behavior (correct SSE handler) ──────────────────────────────────
+  // The backend session:whiteboard payloads carry opaque `dataJson`/`structuredJson`
+  // blobs — the FE cannot delta-apply them. The hook uses SSE-as-signal + REST-as-truth:
+  // each event triggers a debounced re-fetch of GET /whiteboard.
+
+  it('triggers a GET /whiteboard refetch when a BE-shaped session:whiteboard event arrives', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+
     const { result } = renderHook(() =>
       useWhiteboardTool({ sessionId: SESSION_ID, apiBaseUrl: API_BASE })
     );
+    // Wait for initial load
     await waitFor(() => expect(result.current.isLoading).toBe(false));
+    const fetchCallsAfterLoad = fetchMockSSE.mock.calls.length;
 
-    const instance = mockEventSourceInstances[0] as unknown as MockEventSource;
-    act(() => {
-      instance.emit('session:whiteboard', { type: 'stroke-added', stroke: MOCK_STROKE });
-    });
-
-    expect(result.current.whiteboardState?.strokes).toHaveLength(1);
-    expect(result.current.whiteboardState?.strokes[0]).toEqual(MOCK_STROKE);
-  });
-
-  it('applies structured-updated event dispatched as session:whiteboard', async () => {
-    const { result } = renderHook(() =>
-      useWhiteboardTool({ sessionId: SESSION_ID, apiBaseUrl: API_BASE })
-    );
-    await waitFor(() => expect(result.current.isLoading).toBe(false));
-
-    const newTokens = [{ id: 'tok-x', color: '#0ea5e9', label: 'X', gridX: 1, gridY: 1 }];
+    // Emit a realistic BE-shaped StrokeAddedEvent payload (no `type` field)
     const instance = mockEventSourceInstances[0] as unknown as MockEventSource;
     act(() => {
       instance.emit('session:whiteboard', {
-        type: 'structured-updated',
-        tokens: newTokens,
-        gridSize: '6x6',
-        showGrid: false,
-        mode: 'structured',
+        sessionId: SESSION_ID,
+        strokeId: 'stroke-uuid-1',
+        dataJson: '{"points":[{"x":0,"y":0}]}',
+        modifiedBy: 'user-uuid-1',
       });
     });
 
-    expect(result.current.whiteboardState?.tokens).toEqual(newTokens);
-    expect(result.current.whiteboardState?.gridSize).toBe('6x6');
-    expect(result.current.whiteboardState?.showGrid).toBe(false);
+    // Before debounce fires: no extra fetch yet
+    expect(fetchMockSSE.mock.calls.length).toBe(fetchCallsAfterLoad);
+
+    // Advance past debounce (200ms)
+    await act(async () => {
+      vi.advanceTimersByTime(200);
+    });
+
+    // After debounce: one additional GET /whiteboard call
+    await waitFor(() => {
+      expect(fetchMockSSE.mock.calls.length).toBeGreaterThan(fetchCallsAfterLoad);
+    });
+    const lastCall = fetchMockSSE.mock.calls[fetchMockSSE.mock.calls.length - 1] as [
+      string,
+      RequestInit,
+    ];
+    expect(lastCall[0]).toBe(`${API_BASE}/api/v1/live-sessions/${SESSION_ID}/whiteboard`);
+    expect(lastCall[1]).toMatchObject({ credentials: 'include' });
+
+    vi.useRealTimers();
   });
 
-  it('applies whiteboard-cleared event dispatched as session:whiteboard', async () => {
-    const stateWithData: WhiteboardState = {
-      ...MOCK_STATE,
-      strokes: [MOCK_STROKE],
-      tokens: [{ id: 't1', color: '#ef4444', label: 'A', gridX: 0, gridY: 0 }],
-    };
-    fetchMockSSE = vi.fn().mockResolvedValue({
-      ok: true,
-      status: 200,
-      json: async () => stateWithData,
-    });
-    global.fetch = fetchMockSSE;
+  it('coalesces multiple rapid session:whiteboard events into ONE refetch', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
 
     const { result } = renderHook(() =>
       useWhiteboardTool({ sessionId: SESSION_ID, apiBaseUrl: API_BASE })
     );
-    await waitFor(() => expect(result.current.whiteboardState?.strokes).toHaveLength(1));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    const fetchCallsAfterLoad = fetchMockSSE.mock.calls.length;
+
+    const instance = mockEventSourceInstances[0] as unknown as MockEventSource;
+
+    // Emit 3 stroke events in rapid succession (within debounce window)
+    act(() => {
+      instance.emit('session:whiteboard', {
+        sessionId: SESSION_ID,
+        strokeId: 'a',
+        dataJson: '{}',
+        modifiedBy: 'u1',
+      });
+      instance.emit('session:whiteboard', {
+        sessionId: SESSION_ID,
+        strokeId: 'b',
+        dataJson: '{}',
+        modifiedBy: 'u1',
+      });
+      instance.emit('session:whiteboard', {
+        sessionId: SESSION_ID,
+        strokeId: 'c',
+        dataJson: '{}',
+        modifiedBy: 'u1',
+      });
+    });
+
+    // Advance past debounce
+    await act(async () => {
+      vi.advanceTimersByTime(200);
+    });
+
+    await waitFor(() => {
+      expect(fetchMockSSE.mock.calls.length).toBeGreaterThan(fetchCallsAfterLoad);
+    });
+
+    // Exactly ONE refetch despite three events
+    const refetchCount = fetchMockSSE.mock.calls.length - fetchCallsAfterLoad;
+    expect(refetchCount).toBe(1);
+
+    vi.useRealTimers();
+  });
+
+  it('does NOT refetch before the debounce window expires', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+
+    const { result } = renderHook(() =>
+      useWhiteboardTool({ sessionId: SESSION_ID, apiBaseUrl: API_BASE })
+    );
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    const fetchCallsAfterLoad = fetchMockSSE.mock.calls.length;
 
     const instance = mockEventSourceInstances[0] as unknown as MockEventSource;
     act(() => {
-      instance.emit('session:whiteboard', { type: 'whiteboard-cleared' });
+      instance.emit('session:whiteboard', {
+        sessionId: SESSION_ID,
+        strokeId: 'x',
+        dataJson: '{}',
+        modifiedBy: 'u1',
+      });
     });
 
-    expect(result.current.whiteboardState?.strokes).toHaveLength(0);
-    expect(result.current.whiteboardState?.tokens).toHaveLength(0);
+    // Advance only 100ms — debounce has NOT fired yet
+    act(() => {
+      vi.advanceTimersByTime(100);
+    });
+
+    expect(fetchMockSSE.mock.calls.length).toBe(fetchCallsAfterLoad);
+
+    vi.useRealTimers();
+  });
+
+  it('cancels the debounced refetch timer on unmount (no fetch after unmount)', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+
+    const { result, unmount } = renderHook(() =>
+      useWhiteboardTool({ sessionId: SESSION_ID, apiBaseUrl: API_BASE })
+    );
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    const fetchCallsAfterLoad = fetchMockSSE.mock.calls.length;
+
+    const instance = mockEventSourceInstances[0] as unknown as MockEventSource;
+    act(() => {
+      instance.emit('session:whiteboard', {
+        sessionId: SESSION_ID,
+        strokeId: 'y',
+        dataJson: '{}',
+        modifiedBy: 'u1',
+      });
+    });
+
+    // Unmount before debounce fires
+    unmount();
+
+    // Advance past debounce — timer should have been cleared
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+
+    expect(fetchMockSSE.mock.calls.length).toBe(fetchCallsAfterLoad);
+
+    vi.useRealTimers();
   });
 });

--- a/apps/web/src/lib/domain-hooks/__tests__/useWhiteboardTool.test.ts
+++ b/apps/web/src/lib/domain-hooks/__tests__/useWhiteboardTool.test.ts
@@ -9,6 +9,7 @@
  * - saveStructured: debounced 500ms, calls correct endpoint
  * - clear: immediate, resets strokes and tokens
  * - applySSEEvent: stroke-added, structured-updated, whiteboard-cleared
+ * - SSE native stream listener: URL, event name, event dispatch (#2579)
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
@@ -16,6 +17,49 @@ import { renderHook, act, waitFor } from '@testing-library/react';
 
 import { useWhiteboardTool } from '../useWhiteboardTool';
 import type { WhiteboardState, WhiteboardSSEEvent, Stroke } from '@/components/session/types';
+
+// ── MockEventSource ───────────────────────────────────────────────────────────
+
+interface MockEventSourceInstance {
+  url: string;
+  withCredentials: boolean;
+  close: ReturnType<typeof vi.fn>;
+  addEventListener: ReturnType<typeof vi.fn>;
+  removeEventListener: ReturnType<typeof vi.fn>;
+  readyState: number;
+  /** Simulate dispatching a named SSE event to registered listeners */
+  emit: (eventName: string, data: unknown) => void;
+}
+
+let mockEventSourceInstances: MockEventSourceInstance[] = [];
+
+class MockEventSource {
+  url: string;
+  withCredentials: boolean;
+  close = vi.fn();
+  addEventListener = vi.fn() as ReturnType<typeof vi.fn>;
+  removeEventListener = vi.fn();
+  readyState = 0;
+
+  constructor(url: string, options?: { withCredentials?: boolean }) {
+    this.url = url;
+    this.withCredentials = options?.withCredentials ?? false;
+    mockEventSourceInstances.push(this as unknown as MockEventSourceInstance);
+  }
+
+  /** Test helper: dispatch a named event to all registered handlers */
+  emit(eventName: string, data: unknown) {
+    const calls = (this.addEventListener as ReturnType<typeof vi.fn>).mock.calls as [
+      string,
+      (e: MessageEvent) => void,
+    ][];
+    for (const [name, handler] of calls) {
+      if (name === eventName) {
+        handler({ data: JSON.stringify(data) } as MessageEvent);
+      }
+    }
+  }
+}
 
 // ── Fixtures ──────────────────────────────────────────────────────────────────
 
@@ -421,5 +465,135 @@ describe('applySSEEvent', () => {
     });
 
     expect(result.current.whiteboardState).toBeNull();
+  });
+});
+
+// ── SSE native stream listener (#2579) ────────────────────────────────────────
+
+describe('SSE native stream listener', () => {
+  let fetchMockSSE: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    mockEventSourceInstances = [];
+    global.EventSource = MockEventSource as unknown as typeof EventSource;
+    fetchMockSSE = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => MOCK_STATE,
+    });
+    global.fetch = fetchMockSSE;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('opens EventSource to /api/v1/live-sessions/{sessionId}/stream (native endpoint)', () => {
+    renderHook(() => useWhiteboardTool({ sessionId: SESSION_ID, apiBaseUrl: API_BASE }));
+
+    expect(mockEventSourceInstances).toHaveLength(1);
+    expect(mockEventSourceInstances[0]?.url).toBe(
+      `${API_BASE}/api/v1/live-sessions/${SESSION_ID}/stream`
+    );
+    expect(mockEventSourceInstances[0]?.withCredentials).toBe(true);
+  });
+
+  it('does NOT open EventSource to the legacy /game-sessions/.../stream/v2 URL', () => {
+    renderHook(() => useWhiteboardTool({ sessionId: SESSION_ID, apiBaseUrl: API_BASE }));
+
+    expect(mockEventSourceInstances[0]?.url).not.toContain('game-sessions');
+    expect(mockEventSourceInstances[0]?.url).not.toContain('stream/v2');
+  });
+
+  it('registers listener for session:whiteboard (not session:toolkit)', () => {
+    renderHook(() => useWhiteboardTool({ sessionId: SESSION_ID, apiBaseUrl: API_BASE }));
+
+    const instance = mockEventSourceInstances[0];
+    expect(instance?.addEventListener).toHaveBeenCalledWith(
+      'session:whiteboard',
+      expect.any(Function)
+    );
+    // Ensure the OLD broken event name is NOT registered
+    const calls = (instance?.addEventListener as ReturnType<typeof vi.fn>).mock.calls as [
+      string,
+      unknown,
+    ][];
+    const registeredNames = calls.map(([name]) => name);
+    expect(registeredNames).not.toContain('session:toolkit');
+  });
+
+  it('closes EventSource on unmount', () => {
+    const { unmount } = renderHook(() =>
+      useWhiteboardTool({ sessionId: SESSION_ID, apiBaseUrl: API_BASE })
+    );
+
+    unmount();
+
+    expect(mockEventSourceInstances[0]?.close).toHaveBeenCalled();
+  });
+
+  it('applies stroke-added event dispatched as session:whiteboard', async () => {
+    const { result } = renderHook(() =>
+      useWhiteboardTool({ sessionId: SESSION_ID, apiBaseUrl: API_BASE })
+    );
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    const instance = mockEventSourceInstances[0] as unknown as MockEventSource;
+    act(() => {
+      instance.emit('session:whiteboard', { type: 'stroke-added', stroke: MOCK_STROKE });
+    });
+
+    expect(result.current.whiteboardState?.strokes).toHaveLength(1);
+    expect(result.current.whiteboardState?.strokes[0]).toEqual(MOCK_STROKE);
+  });
+
+  it('applies structured-updated event dispatched as session:whiteboard', async () => {
+    const { result } = renderHook(() =>
+      useWhiteboardTool({ sessionId: SESSION_ID, apiBaseUrl: API_BASE })
+    );
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    const newTokens = [{ id: 'tok-x', color: '#0ea5e9', label: 'X', gridX: 1, gridY: 1 }];
+    const instance = mockEventSourceInstances[0] as unknown as MockEventSource;
+    act(() => {
+      instance.emit('session:whiteboard', {
+        type: 'structured-updated',
+        tokens: newTokens,
+        gridSize: '6x6',
+        showGrid: false,
+        mode: 'structured',
+      });
+    });
+
+    expect(result.current.whiteboardState?.tokens).toEqual(newTokens);
+    expect(result.current.whiteboardState?.gridSize).toBe('6x6');
+    expect(result.current.whiteboardState?.showGrid).toBe(false);
+  });
+
+  it('applies whiteboard-cleared event dispatched as session:whiteboard', async () => {
+    const stateWithData: WhiteboardState = {
+      ...MOCK_STATE,
+      strokes: [MOCK_STROKE],
+      tokens: [{ id: 't1', color: '#ef4444', label: 'A', gridX: 0, gridY: 0 }],
+    };
+    fetchMockSSE = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => stateWithData,
+    });
+    global.fetch = fetchMockSSE;
+
+    const { result } = renderHook(() =>
+      useWhiteboardTool({ sessionId: SESSION_ID, apiBaseUrl: API_BASE })
+    );
+    await waitFor(() => expect(result.current.whiteboardState?.strokes).toHaveLength(1));
+
+    const instance = mockEventSourceInstances[0] as unknown as MockEventSource;
+    act(() => {
+      instance.emit('session:whiteboard', { type: 'whiteboard-cleared' });
+    });
+
+    expect(result.current.whiteboardState?.strokes).toHaveLength(0);
+    expect(result.current.whiteboardState?.tokens).toHaveLength(0);
   });
 });

--- a/apps/web/src/lib/domain-hooks/__tests__/useWidgetSync.test.ts
+++ b/apps/web/src/lib/domain-hooks/__tests__/useWidgetSync.test.ts
@@ -95,7 +95,7 @@ describe('useWidgetSync', () => {
     renderHook(() => useWidgetSync(defaultOpts));
     await vi.advanceTimersByTimeAsync(0); // flush microtask
     expect(MockEventSource.instances).toHaveLength(1);
-    expect(MockEventSource.instances[0].url).toContain('/stream/v2');
+    expect(MockEventSource.instances[0].url).toContain('/live-sessions/session-1/stream');
   });
 
   it('does not connect when sessionId is undefined', () => {

--- a/apps/web/src/lib/domain-hooks/useTurnOrder.ts
+++ b/apps/web/src/lib/domain-hooks/useTurnOrder.ts
@@ -5,7 +5,7 @@
  *
  * Features:
  * - Load, initialize, advance, and reset turn order via REST API
- * - Real-time turn advance updates via v2 SSE stream (session:toolkit events)
+ * - Real-time turn advance updates via native SSE stream (session:toolkit events)
  * - Exposes applySSEAdvance for manual SSE integration
  *
  * Backend endpoints:
@@ -195,14 +195,10 @@ export function useTurnOrder({
     onTurnAdvancedRef.current?.(payload);
   }, []);
 
-  // ── SSE v2 for real-time turn advances from other participants ────────────────
-  // SP2: stays on legacy /game-sessions stream until toolkit/whiteboard events are
-  // forwarded to the native /live-sessions stream — see #2561 / SP5.
-  // This hook is mounted on the /toolkit/[sessionId] surface (NOT the canonical
-  // /sessions/[id]/live view) and consumes `session:toolkit` events which the
-  // native stream does not yet emit.
+  // ── SSE for real-time turn advances from other participants ──────────────────
+  // Consumes the native live-session stream (/live-sessions/{id}/stream).
   useEffect(() => {
-    const endpoint = `${baseUrl}/api/v1/game-sessions/${sessionId}/stream/v2`;
+    const endpoint = `${baseUrl}/api/v1/live-sessions/${sessionId}/stream`;
 
     let source: EventSource | null = null;
     try {

--- a/apps/web/src/lib/domain-hooks/useWhiteboardTool.ts
+++ b/apps/web/src/lib/domain-hooks/useWhiteboardTool.ts
@@ -226,6 +226,25 @@ export function useWhiteboardTool({
 
   // ── SSE listener — native live-session stream ─────────────────────────────────
   // Consumes `session:whiteboard` events from the native /api/v1/live-sessions stream.
+  //
+  // WHY re-fetch instead of delta-apply:
+  // The backend emits per-event payloads with opaque fields (`dataJson` / `structuredJson`
+  // as raw JSON strings) and per-stroke granularity, while the FE save-path is bulk
+  // (POST /strokes with the full strokes array). There is no reliable field mapping between
+  // the BE event shape and the FE WhiteboardSSEEvent shape — attempting delta-parse would
+  // silently drop all events (the `type` discriminator field does NOT exist on BE payloads).
+  // Re-fetching the authoritative GET /whiteboard state is correct for all four sub-types
+  // (StrokeAdded / StrokeRemoved / StructuredUpdated / WhiteboardCleared) and is
+  // shape-agnostic. Known MVP limitation: a remote event arriving during a local
+  // unsaved-stroke window may momentarily reload server state, discarding in-flight
+  // local strokes until the next local save completes.
+
+  // Hold loadWhiteboard in a ref so the SSE effect doesn't need it in deps
+  // (which would reopen the EventSource on every state change).
+  const loadWhiteboardRef = useRef(loadWhiteboard);
+  useEffect(() => {
+    loadWhiteboardRef.current = loadWhiteboard;
+  }, [loadWhiteboard]);
 
   useEffect(() => {
     const endpoint = `${baseUrl}/api/v1/live-sessions/${sessionId}/stream`;
@@ -237,22 +256,24 @@ export function useWhiteboardTool({
       return;
     }
 
-    const handleWhiteboardEvent = (event: MessageEvent<string>) => {
-      try {
-        const payload = JSON.parse(event.data) as Record<string, unknown>;
-        if (typeof payload['type'] === 'string') {
-          applySSEEvent(payload as unknown as WhiteboardSSEEvent);
-        }
-      } catch {
-        // Silently ignore malformed events
-      }
+    // Debounce timer for coalescing rapid stroke-burst events into a single refetch.
+    let refetchTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const handleWhiteboardEvent = (_event: MessageEvent<string>) => {
+      // The SSE event is a pure signal — we do NOT parse the payload for delta fields.
+      // Schedule a debounced re-fetch of the canonical whiteboard state.
+      if (refetchTimer !== null) clearTimeout(refetchTimer);
+      refetchTimer = setTimeout(() => {
+        void loadWhiteboardRef.current();
+      }, 200);
     };
 
     source.addEventListener('session:whiteboard', handleWhiteboardEvent);
     return () => {
       source?.close();
+      if (refetchTimer !== null) clearTimeout(refetchTimer);
     };
-  }, [sessionId, baseUrl, applySSEEvent]);
+  }, [sessionId, baseUrl]);
 
   // ── Load on mount ────────────────────────────────────────────────────────────
 

--- a/apps/web/src/lib/domain-hooks/useWhiteboardTool.ts
+++ b/apps/web/src/lib/domain-hooks/useWhiteboardTool.ts
@@ -8,7 +8,7 @@
  * - Save strokes (debounced 500ms)
  * - Save structured layer (tokens, grid settings) – debounced 500ms
  * - Clear the whiteboard
- * - Real-time sync via v2 SSE stream (session:toolkit events)
+ * - Real-time sync via native SSE stream (session:whiteboard events)
  * - Exposes applySSEEvent for manual SSE integration
  *
  * Backend endpoints (wired when BE is available):
@@ -224,15 +224,11 @@ export function useWhiteboardTool({
     });
   }, []);
 
-  // ── SSE v2 listener ──────────────────────────────────────────────────────────
-  // SP2: stays on legacy /game-sessions stream until toolkit/whiteboard events are
-  // forwarded to the native /live-sessions stream — see #2561 / SP5.
-  // This hook is mounted on the /toolkit/[sessionId] surface (NOT the canonical
-  // /sessions/[id]/live view) and consumes `session:toolkit` events which the
-  // native stream does not yet emit.
+  // ── SSE listener — native live-session stream ─────────────────────────────────
+  // Consumes `session:whiteboard` events from the native /api/v1/live-sessions stream.
 
   useEffect(() => {
-    const endpoint = `${baseUrl}/api/v1/game-sessions/${sessionId}/stream/v2`;
+    const endpoint = `${baseUrl}/api/v1/live-sessions/${sessionId}/stream`;
 
     let source: EventSource | null = null;
     try {
@@ -241,7 +237,7 @@ export function useWhiteboardTool({
       return;
     }
 
-    const handleToolkitEvent = (event: MessageEvent<string>) => {
+    const handleWhiteboardEvent = (event: MessageEvent<string>) => {
       try {
         const payload = JSON.parse(event.data) as Record<string, unknown>;
         if (typeof payload['type'] === 'string') {
@@ -252,7 +248,7 @@ export function useWhiteboardTool({
       }
     };
 
-    source.addEventListener('session:toolkit', handleToolkitEvent);
+    source.addEventListener('session:whiteboard', handleWhiteboardEvent);
     return () => {
       source?.close();
     };

--- a/apps/web/src/lib/domain-hooks/useWidgetSync.ts
+++ b/apps/web/src/lib/domain-hooks/useWidgetSync.ts
@@ -8,7 +8,7 @@
  * to the server.
  *
  * Features:
- * - Real-time widget state sync via V2 SSE stream (typed events)
+ * - Real-time widget state sync via native live-session SSE stream (typed events)
  * - Debounced outgoing state broadcasts (configurable, default 300ms)
  * - Echo prevention — ignores remote events matching the last local broadcast
  * - Connection status tracking

--- a/apps/web/src/lib/domain-hooks/useWidgetSync.ts
+++ b/apps/web/src/lib/domain-hooks/useWidgetSync.ts
@@ -14,7 +14,7 @@
  * - Connection status tracking
  *
  * Backend endpoints:
- * - GET  /api/v1/game-sessions/{sessionId}/stream/v2  (SSE, typed events)
+ * - GET  /api/v1/live-sessions/{sessionId}/stream  (SSE, native stream, typed events)
  * - PATCH /api/v1/game-sessions/{sessionId}/toolkit-state/{widgetType}?toolkitId={toolkitId}
  *
  * @example
@@ -96,16 +96,12 @@ export function useWidgetSync({
   onRemoteUpdateRef.current = onRemoteUpdate;
 
   // ---- SSE subscription ----
-  // SP2: stays on legacy /game-sessions stream until toolkit/whiteboard events are
-  // forwarded to the native /live-sessions stream — see #2561 / SP5.
-  // This hook is mounted on the /toolkit/[sessionId] surface (NOT the canonical
-  // /sessions/[id]/live view) and consumes `session:toolkit` events which the
-  // native stream does not yet emit.
+  // Consumes the native live-session stream (/live-sessions/{id}/stream).
   useEffect(() => {
     if (!enabled || !sessionId) return;
 
     const baseUrl = process.env.NEXT_PUBLIC_API_BASE || '';
-    const url = `${baseUrl}/api/v1/game-sessions/${sessionId}/stream/v2`;
+    const url = `${baseUrl}/api/v1/live-sessions/${sessionId}/stream`;
     const es = new EventSource(url, { withCredentials: true });
     eventSourceRef.current = es;
 

--- a/docs/superpowers/plans/2026-06-29-issue-2579-toolkit-native-stream.md
+++ b/docs/superpowers/plans/2026-06-29-issue-2579-toolkit-native-stream.md
@@ -1,0 +1,98 @@
+# #2579 — Toolkit/whiteboard/timer/widget events → native stream + repoint hooks (Option B Full)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Checkbox (`- [ ]`) steps.
+
+**Goal:** Make the native `/api/v1/live-sessions/{id}/stream` carry ALL toolkit live events (whiteboard/turn/timer on `SessionBroadcastService` + widget on `SessionSyncService`), then repoint the 3 toolkit hooks off the legacy `/game-sessions/{id}/stream/v2`. Fully unblocks the `/stream/v2` sunset (Fase 4 / #2588 Slice B). Fixes 2 latent bugs (whiteboard event-name, widget wrong-bus).
+
+**Architecture:** Subscribe-side fan-in merge in `LiveSessionStreamGateway.SubscribeAsync` (ADR-083 SP2 ACL). De-risk: `.superpowers/sdd/2579-toolkit-repoint-derisk.md` (decision = Option B). BE + FE. No producer changes; legacy `/stream/v2` untouched (still works until Fase 4 deletion).
+
+**Global constraints:**
+- **No worktree** — commit directly on `feature/issue-2579-toolkit-native-stream`.
+- Toolkit events are **live-only** (hooks `loadX()` REST on mount) → yield with `Id = null` (no `id:` line; do NOT pollute the companion Last-Event-ID/sequence resume).
+- **No dedup needed**: domain events flow ONLY via companion (forwarder); toolkit ONLY via the `liveSessionId` channels. Keep it that way.
+- Companion subscription (replay + visibility + sequence) stays **byte-for-byte unchanged**.
+- commitlint: header ≤72 chars. Commits end with the Co-Authored-By trailer.
+
+**Reading list:** `LiveSessionStreamGateway.cs` (the merge target), `ILiveSessionStreamGateway.cs` (`LiveSessionStreamEvent(Type,Data,Id=null)`), `SessionBroadcastService.cs` (`SubscribeAsync(key,userId,lastEventId,ct)`), `SessionSyncService.cs:30,76` (`SubscribeToSessionEvents(sessionId,ct)` yields `INotification`), `SseEventTypeMapper.cs` (`GetEventType` static), `LiveSessionEndpoints.cs:968-984` (write loop, `id:` only when `evt.Id != null`, `SseJsonOptions`), `useTurnOrder.ts:198-242`, `useWhiteboardTool.ts:227-259`, `useWidgetSync.ts:98-146`.
+
+---
+
+## Task 1: BE — gateway 3-way fan-in merge
+**Files:** `apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Services/LiveSessionStreamGateway.cs`; DI registration (find where `ILiveSessionStreamGateway` is registered); Test: the gateway's unit test (find `LiveSessionStreamGateway*Tests` or add one).
+
+**Interfaces:** `SubscribeAsync` keeps its signature. Gateway gains an `ISessionSyncService` dependency (ctor). `SseEventTypeMapper.GetEventType` is static (no injection).
+
+- [ ] **Step 1: Failing tests** (use test fakes/mocks for `ISessionBroadcastService` + `ISessionSyncService` + `ILiveSessionRepository`):
+  - (a) An event published on the `SessionBroadcastService[liveSessionId]` channel (whiteboard/turn/timer) reaches a native subscriber with `Id == null`.
+  - (b) An `INotification` (e.g. `WidgetStateUpdatedEvent`) published on `SessionSyncService[liveSessionId]` reaches the subscriber as `Type == SseEventTypeMapper.GetEventType(evt)` (`session:toolkit`), `Data == evt`, `Id == null`.
+  - (c) A companion-channel envelope still reaches the subscriber with its **original `Id` preserved** (sequence intact).
+  - (d) When `TrackingSessionId == null`, sources (a)+(b) STILL deliver (no `yield break`); companion source is simply skipped.
+- [ ] **Step 2: Run → FAIL.**
+- [ ] **Step 3: Implement** the merge:
+  - Build an unbounded `Channel<LiveSessionStreamEvent>`.
+  - Pump 1 (companion, only if `companionId != null`): `await foreach` `_broadcast.SubscribeAsync(companionId.Value, userId, lastEventId, ct)` → `new LiveSessionStreamEvent(env.EventType, env.Data, env.Id)` (preserve Id).
+  - Pump 2 (SBS toolkit): `await foreach` `_broadcast.SubscribeAsync(liveSessionId, userId, null, ct)` → `new LiveSessionStreamEvent(env.EventType, env.Data, null)` (drop Id).
+  - Pump 3 (SSS widget): `await foreach` `_syncService.SubscribeToSessionEvents(liveSessionId, ct)` → `new LiveSessionStreamEvent(SseEventTypeMapper.GetEventType(evt), evt, null)`.
+  - Each pump writes to `channel.Writer`; complete the writer when ALL pumps finish (or `ct` cancels). Iterator reads `channel.Reader.ReadAllAsync(ct)` and yields.
+  - Wrap each pump body so one source faulting/completing does not kill the others (a single source ending is normal).
+- [ ] **Step 4: Run → PASS** + the existing gateway suite (companion path unchanged).
+- [ ] **Step 5: Commit** — `feat(session-live): #2579 gateway fan-in toolkit + widget onto native stream`
+
+---
+
+## Task 2: BE — concurrency, cleanup, no-double-delivery regression
+**Files:** Test only (extend Task 1's test class).
+
+- [ ] **Step 1: Tests**:
+  - (a) **Cancellation**: cancel the subscription `ct` → the returned enumerable completes, and all 3 underlying subscriptions are torn down (assert the `SessionSyncService` subscriber bag empties / the broadcast unsubscribes — assert via the fakes' disposal/cancellation).
+  - (b) **No double-delivery**: a domain event published via the forwarder path (companion) appears exactly ONCE (it is NOT also on the `liveSessionId` SBS channel).
+  - (c) **Replay still works**: a `lastEventId` is forwarded ONLY to the companion subscription (Pump 1), NOT to Pump 2/3 (assert the fake records `lastEventId == null` for the `liveSessionId` SBS call).
+- [ ] **Step 2: Run** — green if Task 1 wired correctly; else fix the merge.
+- [ ] **Step 3: Verify** the cancellation test genuinely exercises teardown (not a no-op).
+- [ ] **Step 4: Run → PASS.**
+- [ ] **Step 5: Commit** — `test(session-live): #2579 gateway merge cancellation + no-double-delivery`
+
+---
+
+## Task 3: FE — repoint useTurnOrder + useWidgetSync (mechanical)
+**Files:** `apps/web/src/lib/domain-hooks/useTurnOrder.ts`, `apps/web/src/lib/domain-hooks/useWidgetSync.ts`; Tests: their `__tests__`.
+
+- [ ] **Step 1: Update tests** — assert each hook opens an `EventSource` to `/api/v1/live-sessions/{sessionId}/stream` (NOT `/game-sessions/{sessionId}/stream/v2`); listener stays `session:toolkit`; payload discrimination unchanged (turn fields / `widgetType` filter).
+- [ ] **Step 2: Run → FAIL.**
+- [ ] **Step 3: Implement** — change ONLY the EventSource URL in both hooks to the native endpoint. Remove the obsolete "SP2: stays on legacy … see #2561 / SP5" comment block. Keep `session:toolkit` + the existing payload handling.
+- [ ] **Step 4: Run → PASS** + the toolkit-component tests that mount these hooks (no regression).
+- [ ] **Step 5: Commit** — `fix(session-live): #2579 repoint useTurnOrder + useWidgetSync to native stream`
+
+---
+
+## Task 4: FE — repoint useWhiteboardTool + fix event-name bug
+**Files:** `apps/web/src/lib/domain-hooks/useWhiteboardTool.ts`; Test: its `__tests__`.
+
+- [ ] **Step 1: Update/extend tests** — assert the hook opens an `EventSource` to `/api/v1/live-sessions/{sessionId}/stream` AND registers its listener for **`session:whiteboard`** (the corrected event name), applying stroke-added/structured-updated/whiteboard-cleared sub-types by the `type` payload field.
+- [ ] **Step 2: Run → FAIL.**
+- [ ] **Step 3: Implement** — change the EventSource URL to native AND `addEventListener('session:toolkit', …)` → `addEventListener('session:whiteboard', …)`. Remove the obsolete SP2 legacy comment.
+- [ ] **Step 4: Run → PASS** + WhiteboardTool component test (no regression).
+- [ ] **Step 5: Commit** — `fix(session-live): #2579 repoint whiteboard hook + correct session:whiteboard event`
+
+---
+
+## Task 5: Integration verify + sunset-unblock note
+**Files:** grep audit; docs note; (no code beyond comment cleanup if any remains).
+
+- [ ] **Step 1: Grep** `stream/v2` across `apps/web/src` → assert ZERO remaining consumers (all 3 hooks repointed). If any other consumer exists, report it (do not silently leave it).
+- [ ] **Step 2: Verify** the legacy `/stream/v2` endpoint + the v1 `/stream` endpoint are now consumer-free from the FE (note: BE endpoints stay until Fase 4 deletion ≥2026-09-29 per the Sunset header — do NOT delete them here).
+- [ ] **Step 3: Update** `.superpowers/sdd/2579-toolkit-repoint-derisk.md` outcome + the gating note (Fase 4 / #2588 Slice B `/stream/v2` sunset now FE-unblocked). Update issue #2579 acceptance in the PR body.
+- [ ] **Step 4: Commit** — `docs(session-live): #2579 confirm /stream/v2 FE-unblocked for Fase 4 sunset`
+
+---
+
+## Self-Review
+- **AC**: native stream carries whiteboard (`session:whiteboard`) + turn/widget (`session:toolkit`) + timer (`session:timer`); 3 hooks consume the native stream; whiteboard event-name fixed; widget no longer on the wrong bus.
+- **Live-only**: toolkit events `Id = null` → companion resume unaffected (T1/T2).
+- **No regression**: companion domain-event path + replay + visibility unchanged (T1c, T2c).
+- **Scope honesty**: BE legacy endpoints NOT deleted (Fase 4 owns that); only the FE consumers move + the gate is unblocked.
+
+## Out of scope
+- Deleting `/stream/v2` + v1 `/stream` endpoints (Fase 4 / #2588 Slice B, ≥2026-09-29).
+- Sharing one native EventSource across the 3 hooks (each keeps its own connection — matches current behavior).
+- Adding toolkit types to the shared `parse-sse-event.ts` (hooks self-parse; not needed).


### PR DESCRIPTION
## Cosa
Epic #2501 — converge le superfici SSE live-session: il native stream `/api/v1/live-sessions/{id}/stream` ora porta **tutti** gli eventi toolkit live, e i 3 hook toolkit FE sono repointati off il legacy `/game-sessions/{id}/stream/v2`. Sblocca completamente il sunset del legacy (Fase 4 / #2588 Slice B). Chiude #2579.

**Scope = Option B (Full)** — decisione owner dopo de-risk (`.superpowers/sdd/2579-toolkit-repoint-derisk.md`).

## Perché era più dei "3 hook da repointare"
Il de-risk ha trovato **due bus SSE separati**:
- `SessionBroadcastService` (Redis, sequence, replay) → whiteboard/turn/timer + native + legacy v2
- `SessionSyncService` (in-memory) → widget + notes/cards/participants + legacy v1

Mismatch confermato: i produttori toolkit broadcastano su `LiveGameSession.Id`, ma il native stream si sottoscriveva solo sul companion `TrackingSessionId`. Inoltre 2 bug latenti pre-esistenti: whiteboard ascoltava il nome evento sbagliato (`session:toolkit` vs `session:whiteboard`); widget era sul bus sbagliato.

## BE — gateway 3-way fan-in (T1-T2)
`LiveSessionStreamGateway.SubscribeAsync` ora fa fan-in (`Channel<T>`) di 3 sorgenti:
1. **companion** `TrackingSessionId` — domain events, replay+visibility+sequence, `Id` preservato (invariato).
2. **`SessionBroadcastService[liveSessionId]`** — whiteboard/turn/timer, live-only, `Id=null` (niente `id:` → non inquina il Last-Event-ID del companion).
3. **`SessionSyncService[liveSessionId]`** — widget (INotification → `SseEventTypeMapper.GetEventType`, `Id=null`).

Teardown legato all'enumerazione (linked CTS, cancel in `finally`, await pumps) → nessun leak. Null-companion: le sorgenti 2+3 fluiscono comunque. Nessun overlap/dedup (domain events solo su companion, toolkit solo su liveSessionId). 15/15 unit test.

## FE — repoint 3 hook (T3-T4)
- `useTurnOrder` + `useWidgetSync`: URL → native, listener `session:toolkit` invariato.
- `useWhiteboardTool`: URL → native + fix nome evento `session:toolkit` → `session:whiteboard`.

## Whiteboard live-sync (C1 — colto dalla review finale whole-branch)
Il fix del nome evento era **necessario ma non sufficiente**: i payload BE whiteboard (`{strokeId, dataJson}` / `{structuredJson}` / `{clearedBy}`) sono blob JSON opachi senza campo `type`, su cui l'hook discriminava → eventi droppati (bug **pre-esistente**, whiteboard non ha mai sincronizzato live). Fix: **re-fetch-on-event** (SSE-come-segnale + REST-come-verità) — ogni `session:whiteboard` triggera un `loadWhiteboard()` debounced (200ms), shape-agnostic, copre add/remove/structured/cleared uniformemente. Test false-green sostituiti con asserzioni oneste (refetch + coalescing). Limitazione MVP nota: un evento remoto durante una stroke locale non salvata può ricaricare lo stato server (accettabile).

## Verificato end-to-end (review finale opus)
Turn + widget bridge corretti (payload camelCase combaciano); companion/SP2-SP3 intatto; concorrenza/teardown solido; channel-id match; scope onesto (endpoint legacy BE NON cancellati — Fase 4 li possiede, ≥2026-09-29 per Sunset header). C1+C2 fixati + re-review RESOLVED.

## Test
- BE: 15/15 gateway unit (fan-in + teardown + no-double-delivery + replay-only-to-companion). `dotnet build` exit 0.
- FE: 24/24 useWhiteboardTool + 28/28 turn/widget hook + 44/44+52/52 component. `pnpm typecheck` clean.

## Out of scope
Cancellazione endpoint legacy `/stream/v2` + v1 `/stream` → **Fase 4 / #2588 Slice B** (≥2026-09-29). Questo PR rende il FE consumer-free + sblocca il gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)