### PR TITLE
chore(session-live): #2565 SP2 follow-up — test-quality + hygiene cleanup

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Services/SessionBroadcastService.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Services/SessionBroadcastService.cs
@@ -323,7 +323,7 @@ public sealed class SessionBroadcastService : ISessionBroadcastService, IDisposa
                     var replayEntry = JsonSerializer.Deserialize<ReplayEntry>(entry!, _jsonOptions);
                     if (replayEntry is null) continue;
 
-                    // Visibility filter — EXACT mirror of CircularEventBuffer.GetSince (:661-665):
+                    // Visibility filter — EXACT mirror of CircularEventBuffer.GetSince (:671):
                     // skip only a private event (!IsPublic) addressed to a specific user
                     // (TargetUserId.HasValue) other than the current subscriber. A null TargetUserId
                     // means broadcast-to-all (codebase convention), so those events are always delivered.

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Infrastructure/SessionBroadcastReplayTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Infrastructure/SessionBroadcastReplayTests.cs
@@ -168,7 +168,8 @@ public sealed class SessionBroadcastReplayTests
         await using var fixture = await RedisFixture.CreateAsync();
         if (fixture is null)
         {
-            // Docker not available — skip gracefully
+            // Observable skip (NOT a silent no-op pass) so a green run never masks an unexecuted test.
+            Assert.Skip("Docker/Redis unavailable — Testcontainers fixture could not start.");
             return;
         }
 
@@ -243,7 +244,12 @@ public sealed class SessionBroadcastReplayTests
     public async Task Redis_CapEviction_keeps_only_newest_100_events()
     {
         await using var fixture = await RedisFixture.CreateAsync();
-        if (fixture is null) return;
+        if (fixture is null)
+        {
+            // Observable skip (NOT a silent no-op pass) so a green run never masks an unexecuted test.
+            Assert.Skip("Docker/Redis unavailable — Testcontainers fixture could not start.");
+            return;
+        }
 
         var sid = Guid.NewGuid();
         using var svc = CreateRedisService(fixture.Multiplexer);
@@ -294,7 +300,12 @@ public sealed class SessionBroadcastReplayTests
     public async Task Redis_GarbageLastEventId_triggers_graceful_fallback()
     {
         await using var fixture = await RedisFixture.CreateAsync();
-        if (fixture is null) return;
+        if (fixture is null)
+        {
+            // Observable skip (NOT a silent no-op pass) so a green run never masks an unexecuted test.
+            Assert.Skip("Docker/Redis unavailable — Testcontainers fixture could not start.");
+            return;
+        }
 
         var sid = Guid.NewGuid();
         var uid = Guid.NewGuid();
@@ -415,7 +426,10 @@ public sealed class SessionBroadcastReplayTests
         // NOT be dropped by a too-aggressive filter missing the TargetUserId.HasValue guard.
         await svcA.PublishAsync(sid, MakeScoreEvent(sid, Guid.NewGuid()), default);
 
-        await Task.Delay(50); // let writes settle into ZSET
+        // Poll until all 4 published events have settled into the replay ZSET, instead of a fixed
+        // Task.Delay(50) which races on a slow/loaded CI runner — hardens the privacy gate (#2565).
+        var replayKey = Api.SharedKernel.Constants.RedisKeyConstants.GetSessionReplayKey(sid);
+        await WaitForZsetCardinalityAsync(fixture.Multiplexer.GetDatabase(), replayKey, expected: 4);
 
         await keepAliveCts.CancelAsync();
         try { await keepAlive; } catch (OperationCanceledException) { }
@@ -488,6 +502,26 @@ public sealed class SessionBroadcastReplayTests
             ScoreEntryId = Guid.NewGuid(),
             NewScore = 10
         };
+
+    /// <summary>
+    /// Polls the replay ZSET until it holds at least <paramref name="expected"/> entries, replacing a
+    /// fixed Task.Delay that races on slow CI runners. Returns when the cardinality is reached or the
+    /// 2s budget elapses — in which case the test's own replay assertions surface the shortfall.
+    /// </summary>
+    private static async Task WaitForZsetCardinalityAsync(IDatabase db, RedisKey key, long expected)
+    {
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(2));
+        while (!cts.IsCancellationRequested)
+        {
+            if (await db.SortedSetLengthAsync(key).ConfigureAwait(false) >= expected)
+            {
+                return;
+            }
+
+            try { await Task.Delay(10, cts.Token).ConfigureAwait(false); }
+            catch (OperationCanceledException) { return; }
+        }
+    }
 
     // =========================================================================
     // Testcontainers fixture — isolated Redis per test class

--- a/apps/api/tests/Api.Tests/Observability/SseMetricsTests.cs
+++ b/apps/api/tests/Api.Tests/Observability/SseMetricsTests.cs
@@ -140,17 +140,25 @@ public sealed class SseMetricsTests
         MeepleAiMetrics.RecordLiveSseReconnect();
         MeepleAiMetrics.RecordLiveSseReconnect();
 
-        // Tolerant: concurrent tests on the same global counter may add values.
-        // We only assert that OUR two Add(1) calls flowed through the listener.
-        measurements.Should().Contain(1L).And.Contain(1L,
-            "each RecordLiveSseReconnect call emits one Add(1) measurement");
+        // The reconnect counter is ONLY ever incremented by Add(1) (RecordLiveSseReconnect),
+        // so every measurement the listener captures must be exactly 1L — even if a concurrent
+        // test on the same global counter contributes more. OnlyContain(== 1L) catches an
+        // accidental Add(2)/Add(N) regression that the previous Contain(1L) check could not.
+        // Count delta: our two calls must contribute at least two measurements.
+        measurements.Should().HaveCountGreaterThanOrEqualTo(2,
+            "our two RecordLiveSseReconnect calls each emit one measurement")
+            .And.OnlyContain(v => v == 1L,
+            "the reconnect counter must only ever be incremented by Add(1)");
     }
 
-    [Fact(DisplayName = "LiveSseReconnectTotal and LiveSseActiveConnections are not null")]
-    public void BothMetrics_AreInitialized()
+    [Fact(DisplayName = "Both live-SSE metrics expose a non-empty Description for observability dashboards")]
+    public void BothMetrics_HaveNonEmptyDescription()
     {
-        MeepleAiMetrics.LiveSseReconnectTotal.Should().NotBeNull();
-        MeepleAiMetrics.LiveSseActiveConnections.Should().NotBeNull();
+        // A NotBeNull() assertion on a `static readonly` field is vacuous — it is initialized at
+        // type load and can never be null. Assert the real observability contract instead: every
+        // metric must carry a human-readable Description so Grafana/SLO dashboards stay legible.
+        MeepleAiMetrics.LiveSseReconnectTotal.Description.Should().NotBeNullOrWhiteSpace();
+        MeepleAiMetrics.LiveSseActiveConnections.Description.Should().NotBeNullOrWhiteSpace();
     }
 
     // ──────────────────────────────────────────────────────────────────────────

--- a/apps/web/e2e/session-live.smoke.spec.ts
+++ b/apps/web/e2e/session-live.smoke.spec.ts
@@ -89,6 +89,16 @@ test.describe('#2561 SP2 T11 — Session live SSE stream surface smoke', () => {
   test('A1: canonical /live-sessions/{id}/stream is intercepted (mock route handler, not blind abort)', async ({
     page,
   }) => {
+    // KNOWN GAP (#2565): in fixture mode nativeStreamCallCount cannot reach >= 1 (no real backend
+    // session), so this test's real enforcement is only the co-located A2 contract below. The
+    // native-intercept assertion is deferred to the smoke-real-backend/ harness — tagged as a
+    // machine-readable annotation so the gap is visible in the Playwright report.
+    test.info().annotations.push({
+      type: 'known-gap',
+      description:
+        'nativeStreamCallCount >= 1 not assertable in fixture mode; deferred to smoke-real-backend/ (#2565).',
+    });
+
     let nativeStreamCallCount = 0;
 
     // Explicit route handler for the canonical stream endpoint.
@@ -182,9 +192,19 @@ test.describe('#2561 SP2 T11 — Session live SSE stream surface smoke', () => {
 
   // ── B) Deprecation headers on the legacy endpoint (documented expectation) ─
 
-  test('B1: /game-sessions/{id}/stream/v2 carries Deprecation, Sunset, and Link headers when reached', async ({
+  test('B1 [doc-test]: /game-sessions/{id}/stream/v2 deprecation-header SHAPE (real gate is the BE integration test)', async ({
     page,
   }) => {
+    // DOC-TEST (#2565): tautological by design — it asserts the shape of the FE-provided mock
+    // response, NOT real BE behavior. The authoritative gate for the deprecation headers is the BE
+    // integration test StreamV2DeprecationHeadersEndpointTests.cs. Kept as living FE documentation
+    // of the expected response shape during legacy-consumer migration.
+    test.info().annotations.push({
+      type: 'doc-test',
+      description:
+        'Asserts the FE mock shape, not BE behavior. Authoritative gate: StreamV2DeprecationHeadersEndpointTests.cs (BE).',
+    });
+
     // This test documents the EXPECTED deprecation headers on the /stream/v2 endpoint
     // (Part B of T11). It intercepts the route and inspects what the BROWSER sees
     // in the response headers via network request listener.


### PR DESCRIPTION
## Contesto
Follow-up #2501 SP2 (#2561). Raggruppa 6 nit non-bloccanti emersi dalla review finale whole-branch. **Nessuna logica di produzione cambiata** — solo qualità test + commenti.

## Item
| # | Cosa | Perché |
|---|------|--------|
| 1 | `SseMetricsTests` reconnect: `Contain(1L)` → `HaveCountGreaterThanOrEqualTo(2)` + `OnlyContain(v => v == 1L)` | il counter è solo `Add(1)`; `OnlyContain` intercetta un `Add(N)` accidentale che `Contain(1L)` non vedeva |
| 2 | `BothMetrics_AreInitialized` → `BothMetrics_HaveNonEmptyDescription` | `NotBeNull()` su `static readonly` è vacuo; ora asserisce il contratto observability (Description non-empty) |
| 3 | 3 Redis test `if (fixture is null) return` → `Assert.Skip(...)` | skip osservabile, non no-op silenzioso che maschera un test non eseguito |
| 4 | privacy test: `Task.Delay(50)` → `WaitForZsetCardinalityAsync` poll | hardening del gate privacy su CI lenta (no race fisso) |
| 5 | `SessionBroadcastService.cs:326` anchor `:661-665` → `:671` | il visibility-filter mirror vive a `GetSince:671`; `:661-665` è l'id-match block |
| 6a | E2E A1 `nativeStreamCallCount` | known-gap taggato via annotation Playwright (deferred a `smoke-real-backend/`) |
| 6b | E2E B1 self-mock tautologico | documentato come `[doc-test]` — gate reale = BE `StreamV2DeprecationHeadersEndpointTests.cs` |

## Verifica
- API build: **0 errori**
- `SseMetrics` + `SessionBroadcastReplay`: **14/14 verde** (inclusi 4 Redis integration via Docker reale → privacy poll funziona)
- E2E lint: **clean**

Closes #2565