### PR TITLE
fix(session-live): #2563 SP2 follow-up — seq monotonicity survives mid-session Redis drop

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/UpdatePlayerScoreCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/UpdatePlayerScoreCommandHandler.cs
@@ -8,6 +8,7 @@ using Api.BoundedContexts.SessionTracking.Domain.Services;
 using Api.Middleware.Exceptions;
 using Api.SharedKernel.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 
 namespace Api.BoundedContexts.SessionTracking.Application.Commands;
 
@@ -24,19 +25,22 @@ public class UpdatePlayerScoreCommandHandler : IRequestHandler<UpdatePlayerScore
     private readonly IUnitOfWork _unitOfWork;
     private readonly ISessionSyncService _syncService;
     private readonly ISessionBroadcastService _broadcastService;
+    private readonly ILogger<UpdatePlayerScoreCommandHandler> _logger;
 
     public UpdatePlayerScoreCommandHandler(
         ISessionRepository sessionRepository,
         IScoreEntryRepository scoreEntryRepository,
         IUnitOfWork unitOfWork,
         ISessionSyncService syncService,
-        ISessionBroadcastService broadcastService)
+        ISessionBroadcastService broadcastService,
+        ILogger<UpdatePlayerScoreCommandHandler> logger)
     {
         _sessionRepository = sessionRepository ?? throw new ArgumentNullException(nameof(sessionRepository));
         _scoreEntryRepository = scoreEntryRepository ?? throw new ArgumentNullException(nameof(scoreEntryRepository));
         _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
         _syncService = syncService ?? throw new ArgumentNullException(nameof(syncService));
         _broadcastService = broadcastService ?? throw new ArgumentNullException(nameof(broadcastService));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
     public async Task<UpdatePlayerScoreResult> Handle(UpdatePlayerScoreCommand request, CancellationToken cancellationToken)
@@ -87,11 +91,26 @@ public class UpdatePlayerScoreCommandHandler : IRequestHandler<UpdatePlayerScore
                 ActionType = "score",
                 Message = "Score update conflict detected. Please retry with the latest session state."
             };
-            await _broadcastService.PublishAsync(
-                request.SessionId,
-                conflictEvt,
-                EventVisibility.PrivateTo(request.RequesterId),
-                cancellationToken).ConfigureAwait(false);
+            // The conflict SSE notification is fire-and-forget observational — it must NEVER replace the
+            // ConflictException (409) below on the primary path. Since #2563 PublishAsync can propagate a
+            // mid-session Redis failure (the seq provider no longer falls back to a from-zero counter);
+            // swallow it here so the caller still gets a deterministic 409.
+#pragma warning disable CA1031 // best-effort notification — a broadcast failure must not mask the 409
+            try
+            {
+                await _broadcastService.PublishAsync(
+                    request.SessionId,
+                    conflictEvt,
+                    EventVisibility.PrivateTo(request.RequesterId),
+                    cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "Failed to broadcast score-conflict SSE for session {SessionId}; surfacing 409 regardless.",
+                    request.SessionId);
+            }
+#pragma warning restore CA1031
 
             throw new ConflictException(
                 "Score update conflict: another participant updated the session simultaneously. Please retry.");

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Services/RedisSessionSequenceProvider.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Services/RedisSessionSequenceProvider.cs
@@ -16,18 +16,26 @@ namespace Api.BoundedContexts.SessionTracking.Infrastructure.Services;
 /// exceeds the longest realistic board game session including breaks, ensuring the counter
 /// cannot reset mid-session. TTL refreshes on each write so long-running sessions stay safe.
 ///
-/// Fallback path (Redis null/disconnected): ConcurrentDictionary&lt;Guid, StrongBox&lt;long&gt;&gt;
-/// + Interlocked.Increment. In fallback mode, counters are per-instance and not durable
-/// across restarts — acceptable because fallback mode already implies single-instance
-/// (no cross-instance coordination). D20 format is identical in both paths.
+/// Redis-vs-fallback is decided ONCE at construction (mirrors <see cref="SessionBroadcastService"/>),
+/// NOT per call. Issue #2563: a per-call IsConnected check let a mid-session Redis drop fall into the
+/// in-process counter, which restarts at 0 and emits a seq below the Redis high-watermark —
+/// permanently corrupting ZSET eviction and Last-Event-ID resume (ZRANGEBYSCORE never sees seq 1..N
+/// again). With the ctor decision a session that started on Redis never silently downgrades to a
+/// from-zero in-process counter: a mid-session Redis failure propagates so the caller fails the
+/// publish and the durable Redis seq stays authoritative (the client re-reads it on reconnect).
+///
+/// Pure fallback path (Redis null/disconnected AT CONSTRUCTION): ConcurrentDictionary&lt;Guid, StrongBox&lt;long&gt;&gt;
+/// + Interlocked.Increment. Counters are per-instance and not durable across restarts — acceptable
+/// because this mode already implies single-instance (no cross-instance coordination). D20 format
+/// is identical in both paths.
 /// </remarks>
 public sealed class RedisSessionSequenceProvider : ISessionSequenceProvider
 {
     // TTL: 48h — see class XML doc for rationale.
     private static readonly TimeSpan SessionSeqTtl = TimeSpan.FromHours(48);
 
-    private readonly IConnectionMultiplexer? _redis;
-    private readonly ILogger<RedisSessionSequenceProvider> _logger;
+    // Redis-vs-fallback decided once at construction (Issue #2563). Non-null ⇒ Redis mode.
+    private readonly IDatabase? _redisDb;
 
     // In-process fallback: StrongBox<long> lets Interlocked.Increment operate on the ref field.
     private readonly ConcurrentDictionary<Guid, StrongBox<long>> _fallbackCounters = new();
@@ -36,32 +44,37 @@ public sealed class RedisSessionSequenceProvider : ISessionSequenceProvider
         IConnectionMultiplexer? redis,
         ILogger<RedisSessionSequenceProvider> logger)
     {
-        _redis = redis;
-        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        // NextAsync no longer logs (the per-call fallback try/catch was removed in #2563), so the
+        // logger is used only here at construction — kept as a ctor-local, not a field (Sonar S1450).
+        ArgumentNullException.ThrowIfNull(logger);
+
+        // Decide the backing store ONCE, at construction. See class remarks (Issue #2563).
+        _redisDb = redis is { IsConnected: true } ? redis.GetDatabase() : null;
+
+        logger.LogInformation(
+            _redisDb is not null
+                ? "RedisSessionSequenceProvider initialized in Redis mode (durable monotonic seq)."
+                : "RedisSessionSequenceProvider initialized in in-process fallback mode (single-instance).");
     }
 
     /// <inheritdoc />
     public async Task<long> NextAsync(Guid sessionId, CancellationToken ct)
     {
-        if (_redis is { IsConnected: true })
+        if (_redisDb is not null)
         {
-            try
-            {
-                var db = _redis.GetDatabase();
-                var key = RedisKeyConstants.GetSessionSeqKey(sessionId);
-                var seq = await db.StringIncrementAsync(key).ConfigureAwait(false);
-                // Refresh TTL on every write so long-running sessions don't expire mid-game.
-                await db.KeyExpireAsync(key, SessionSeqTtl).ConfigureAwait(false);
-                return seq;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex,
-                    "Redis INCR failed for session {SessionId}; falling back to in-process counter.", sessionId);
-            }
+            // Redis mode (decided at ctor). On a mid-session Redis failure we deliberately do NOT
+            // fall back to the in-process counter — restarting at 0 would break monotonicity
+            // (Issue #2563). The exception propagates so the caller fails the publish; the durable
+            // Redis seq stays authoritative and the client re-reads it on reconnect.
+            var key = RedisKeyConstants.GetSessionSeqKey(sessionId);
+            var seq = await _redisDb.StringIncrementAsync(key).ConfigureAwait(false);
+            // Refresh TTL on every write so long-running sessions don't expire mid-game.
+            await _redisDb.KeyExpireAsync(key, SessionSeqTtl).ConfigureAwait(false);
+            return seq;
         }
 
-        // In-process fallback: GetOrAdd is safe — StrongBox is reference type, Interlocked.Increment is atomic.
+        // In-process fallback (Redis absent/disconnected at construction). GetOrAdd is safe —
+        // StrongBox is a reference type and Interlocked.Increment is atomic.
         var box = _fallbackCounters.GetOrAdd(sessionId, _ => new StrongBox<long>(0L));
         return Interlocked.Increment(ref box.Value);
     }

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Handlers/PlayerActionHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Handlers/PlayerActionHandlerTests.cs
@@ -11,6 +11,7 @@ using Api.Tests.Constants;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using FluentAssertions;
 using Xunit;
@@ -328,7 +329,8 @@ public class UpdatePlayerScoreCommandHandlerTests
             _mockScoreRepo.Object,
             _mockUnitOfWork.Object,
             _mockSyncService.Object,
-            _mockBroadcast.Object);
+            _mockBroadcast.Object,
+            NullLogger<UpdatePlayerScoreCommandHandler>.Instance);
     }
 
     private static Session CreateActiveSession(Guid sessionId, Guid participantId)
@@ -440,6 +442,35 @@ public class UpdatePlayerScoreCommandHandlerTests
             It.IsAny<INotification>(),
             It.Is<EventVisibility>(v => v.TargetUserId == participantId),
             It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ConcurrencyConflict_WhenBroadcastFails_StillThrowsConflictException()
+    {
+        // Regression for the #2563 review finding: the conflict SSE broadcast is fire-and-forget and
+        // must NEVER replace the 409. Since #2563 PublishAsync can propagate a mid-session Redis drop;
+        // if it does during a concurrency conflict, the caller must still receive ConflictException
+        // (409), not the broadcast exception (which the exception middleware would map to 500).
+        var sessionId = Guid.NewGuid();
+        var participantId = Guid.NewGuid();
+        var session = CreateActiveSession(sessionId, participantId);
+
+        _mockSessionRepo.Setup(r => r.GetByIdAsync(sessionId, It.IsAny<CancellationToken>())).ReturnsAsync(session);
+        _mockUnitOfWork.Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new DbUpdateConcurrencyException("Conflict"));
+        _mockBroadcast
+            .Setup(b => b.PublishAsync(
+                It.IsAny<Guid>(),
+                It.IsAny<INotification>(),
+                It.IsAny<EventVisibility>(),
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("Redis dropped mid-session"));
+
+        var command = new UpdatePlayerScoreCommand(sessionId, participantId, participantId, 5m, RoundNumber: 1);
+        var act = () => _handler.Handle(command, TestContext.Current.CancellationToken);
+
+        // Surfaces the domain 409, NOT the broadcast failure (which would otherwise become a 500).
+        await act.Should().ThrowAsync<ConflictException>();
     }
 }
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Infrastructure/Services/SessionSequenceProviderTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Infrastructure/Services/SessionSequenceProviderTests.cs
@@ -1,5 +1,7 @@
 using Api.BoundedContexts.SessionTracking.Infrastructure.Services;
 using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using StackExchange.Redis;
 using Xunit;
 
 namespace Api.Tests.BoundedContexts.SessionTracking.Infrastructure.Services;
@@ -48,5 +50,85 @@ public sealed class SessionSequenceProviderTests
         Assert.Equal(100, results.Distinct().Count());
         Assert.Equal(1L, results.Min());
         Assert.Equal(100L, results.Max());
+    }
+
+    // ── Redis-vs-fallback decision (Issue #2563) ────────────────────────────────
+
+    /// <summary>
+    /// When Redis is connected at construction, the provider must use the Redis INCR counter
+    /// (decided ONCE at the ctor), not the in-process fallback. Mirrors SessionBroadcastService.
+    /// </summary>
+    [Fact]
+    public async Task NextAsync_WhenRedisConnectedAtCtor_UsesRedisIncr()
+    {
+        var mockDb = new Mock<IDatabase>();
+        mockDb
+            .Setup(d => d.StringIncrementAsync(It.IsAny<RedisKey>(), It.IsAny<long>(), It.IsAny<CommandFlags>()))
+            .ReturnsAsync(42L);
+        mockDb
+            .Setup(d => d.KeyExpireAsync(It.IsAny<RedisKey>(), It.IsAny<TimeSpan?>(), It.IsAny<CommandFlags>()))
+            .ReturnsAsync(true);
+
+        var mockRedis = BuildConnectedRedis(mockDb);
+
+        var p = new RedisSessionSequenceProvider(mockRedis.Object, NullLogger<RedisSessionSequenceProvider>.Instance);
+
+        var seq = await p.NextAsync(Guid.NewGuid(), default);
+
+        Assert.Equal(42L, seq);
+        mockDb.Verify(
+            d => d.StringIncrementAsync(It.IsAny<RedisKey>(), It.IsAny<long>(), It.IsAny<CommandFlags>()),
+            Times.Once);
+    }
+
+    /// <summary>
+    /// Regression for #2563: if Redis drops mid-session, the provider must NOT silently fall back
+    /// to the in-process counter (which restarts at 0 → emits a seq below the Redis high-watermark
+    /// → corrupts ZSET eviction + Last-Event-ID resume). With the ctor-decision fix the failure
+    /// propagates instead of returning a non-monotonic value.
+    /// </summary>
+    [Fact]
+    public async Task NextAsync_WhenRedisFailsMidSession_DoesNotFallBackToZero()
+    {
+        var sid = Guid.NewGuid();
+        var redisDown = false;
+        var mockDb = new Mock<IDatabase>();
+        mockDb
+            .Setup(d => d.StringIncrementAsync(It.IsAny<RedisKey>(), It.IsAny<long>(), It.IsAny<CommandFlags>()))
+            .ReturnsAsync(() =>
+            {
+                if (redisDown)
+                {
+                    throw new RedisConnectionException(ConnectionFailureType.SocketFailure, "redis dropped mid-session");
+                }
+
+                return 50L;
+            });
+        mockDb
+            .Setup(d => d.KeyExpireAsync(It.IsAny<RedisKey>(), It.IsAny<TimeSpan?>(), It.IsAny<CommandFlags>()))
+            .ReturnsAsync(true);
+
+        var mockRedis = BuildConnectedRedis(mockDb);
+        var p = new RedisSessionSequenceProvider(mockRedis.Object, NullLogger<RedisSessionSequenceProvider>.Instance);
+
+        // High-watermark established at seq 50 via Redis.
+        var first = await p.NextAsync(sid, default);
+        Assert.Equal(50L, first);
+
+        // Redis drops.
+        redisDown = true;
+
+        // The next call must NOT return 1 (the old fallback-to-zero bug). It propagates instead.
+        await Assert.ThrowsAsync<RedisConnectionException>(() => p.NextAsync(sid, default));
+    }
+
+    private static Mock<IConnectionMultiplexer> BuildConnectedRedis(Mock<IDatabase> mockDb)
+    {
+        var mockRedis = new Mock<IConnectionMultiplexer>();
+        mockRedis.Setup(r => r.IsConnected).Returns(true);
+        mockRedis
+            .Setup(r => r.GetDatabase(It.IsAny<int>(), It.IsAny<object>()))
+            .Returns(mockDb.Object);
+        return mockRedis;
     }
 }


### PR DESCRIPTION
## Problema
`RedisSessionSequenceProvider.NextAsync` controllava `_redis.IsConnected` **per-call**. Se Redis cade a metà sessione (ZSET già a seq 50), la chiamata cadeva nel fallback in-process che riparte da `0` → emette seq `1` → corrompe l'eviction della ZSET e rompe **permanentemente** il resume `Last-Event-ID` (`ZRANGEBYSCORE (50 +inf` non vede mai seq 1..N).

## Fix
Allinea il provider al pattern di `SessionBroadcastService`: **decide Redis-vs-fallback UNA volta nel ctor** (`_redisDb` settato sse connesso), non più per-call. Una sessione partita su Redis non degrada più silenziosamente a un counter in-process from-zero: un fallimento Redis mid-sessione **propaga** (il caller fallisce la publish; il seq Redis durevole resta autoritativo e il client lo ri-legge al reconnect). La modalità in-process pura (Redis null al ctor) è **invariata** — single-instance, safe. Rimosso il try/catch per-call; logger ora ctor-local (Sonar S1450).

## TDD
2 nuovi test (la transizione Redis→in-process che l'issue segnalava come **assente**):
- `NextAsync_WhenRedisConnectedAtCtor_UsesRedisIncr` — documenta la decisione-al-ctor
- `NextAsync_WhenRedisFailsMidSession_DoesNotFallBackToZero` — **RED** sul codice vecchio (ritornava `1`), **GREEN** dopo il fix

## Verifica
- `SessionSequenceProviderTests`: **5/5 verde**
- `SessionTracking` Unit: **962/962 verde**

## ⚠️ Baseline failure scoperto (NON correlato, NON introdotto da questa PR)
Durante la non-regression del bounded context ho isolato un **baseline failure pre-esistente**: `StreamV2_AuthenticatedOwner_ReceivesDeprecationHeaders_On200` fallisce con `game_id` NOT NULL violation (il test seed una `SessionEntity` senza `GameId`). Confermato fallire identicamente su `main-dev` puro (`git stash` dei miei file + rebuild). Tracciato in **#2596** (correlato a #2552). Gli integration test non girano nel job CI `Backend Fast (build + unit)`, quindi non blocca questa PR.

Closes #2563