### PR TITLE
fix(session-live): #2552 SP0 follow-up — duplicate session-code to 409 + nits

### DIFF
--- a/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/DependencyInjection/GameManagementServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/DependencyInjection/GameManagementServiceExtensions.cs
@@ -36,10 +36,8 @@ internal static class GameManagementServiceExtensions
         services.AddScoped<IPlayRecordVersionRepository, PlayRecordVersionRepository>(); // #2437-3: version history + restore
         services.AddScoped<IRuleConflictFaqRepository, RuleConflictFaqRepository>(); // ISSUE-3761: Conflict FAQ
         services.AddScoped<ILiveSessionRepository, LiveSessionRepository>(); // Issue #2097 / ADR-060: EF-backed persistence
-        services.AddScoped<Api.BoundedContexts.GameManagement.Application.Services.ICompanionSessionService,
-            Api.BoundedContexts.GameManagement.Infrastructure.Services.CompanionSessionService>(); // #2501 SP0 ACL companion
-        services.AddScoped<Api.BoundedContexts.GameManagement.Application.Services.ILiveSessionStreamGateway,
-            Api.BoundedContexts.GameManagement.Infrastructure.Services.LiveSessionStreamGateway>(); // #2561 SP2 T3 ACL stream gateway
+        services.AddScoped<ICompanionSessionService, CompanionSessionService>(); // #2501 SP0 ACL companion
+        services.AddScoped<ILiveSessionStreamGateway, LiveSessionStreamGateway>(); // #2561 SP2 T3 ACL stream gateway
         services.AddScoped<IToolStateRepository, ToolStateRepository>(); // Issue #4754: ToolState persistence
         services.AddScoped<ISessionSnapshotRepository, SessionSnapshotRepository>(); // Issue #4755: SessionSnapshot persistence
         services.AddScoped<IPauseSnapshotRepository, PauseSnapshotRepository>(); // Game Night: full-state pause snapshots

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Persistence/SessionRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Persistence/SessionRepository.cs
@@ -2,6 +2,7 @@ using Api.BoundedContexts.SessionTracking.Domain.Entities;
 using Api.BoundedContexts.SessionTracking.Domain.Repositories;
 using Api.Infrastructure;
 using Api.Infrastructure.Entities.SessionTracking;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Application.Services;
 using Api.SharedKernel.Infrastructure;
 using Microsoft.EntityFrameworkCore;
@@ -79,7 +80,9 @@ public class SessionRepository : RepositoryBase, ISessionRepository
 
         if (exists)
         {
-            throw new InvalidOperationException($"Session code {session.SessionCode} already exists.");
+            // #2552: a duplicate session code is a 409 Conflict, not a 500. (The DB also has a
+            // unique index idx_sessions_code; the concurrent-race path is documented as deferred.)
+            throw new ConflictException($"Session code {session.SessionCode} already exists.");
         }
 
         // BE-3 #1590 (C2): collect domain events (e.g. session.created) before persistence

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/LiveSessions/LiveSessionCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/LiveSessions/LiveSessionCommandHandlerTests.cs
@@ -187,6 +187,15 @@ public class LiveSessionCommandHandlerTests
         var handler = new CreateLiveSessionCommandHandler(_repositoryMock.Object, _timeProvider, _unitOfWorkMock.Object, _companionSessionServiceMock.Object);
         var gameId = Guid.NewGuid();
         var groupId = Guid.NewGuid();
+
+        // #2552: with a non-null GameId the companion saga runs; configure the mock to return a real
+        // id so we can assert it flows into TrackingSessionId (the default mock returned Guid.Empty
+        // silently and the assertion below was missing).
+        var expectedTrackingSessionId = Guid.NewGuid();
+        _companionSessionServiceMock
+            .Setup(s => s.CreateCompanionAsync(DefaultUserId, gameId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedTrackingSessionId);
+
         var command = new CreateLiveSessionCommand(
             DefaultUserId,
             "Spirit Island",
@@ -210,6 +219,9 @@ public class LiveSessionCommandHandlerTests
         capturedSession.Visibility.Should().Be(PlayRecordVisibility.Group);
         capturedSession.GroupId.Should().Be(groupId);
         capturedSession.AgentMode.Should().Be(AgentSessionMode.Assistant);
+        capturedSession.TrackingSessionId.Should().Be(expectedTrackingSessionId);
+        _companionSessionServiceMock.Verify(
+            s => s.CreateCompanionAsync(DefaultUserId, gameId, It.IsAny<CancellationToken>()), Times.Once);
     }
 
     #endregion

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/Entities/LiveGameSessionReconstituteTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/Entities/LiveGameSessionReconstituteTests.cs
@@ -71,4 +71,56 @@ public class LiveGameSessionReconstituteTests
         session.Xmin.Should().Be(42u);
         session.DomainEvents.Should().BeEmpty("Reconstitute MUST NOT raise events");
     }
+
+    [Fact]
+    public void Reconstitute_WithNonNullTrackingSessionId_PreservesIt()
+    {
+        // #2552: the existing test only exercised trackingSessionId: null. A companion-backed
+        // session reconstituted with a non-null id must round-trip it unchanged (the branch was
+        // never asserted).
+        var trackingSessionId = Guid.NewGuid();
+        var gameId = Guid.NewGuid();
+        var createdAt = new DateTime(2026, 6, 13, 10, 0, 0, DateTimeKind.Utc);
+
+        var session = LiveGameSession.Reconstitute(
+            id: Guid.NewGuid(),
+            sessionCode: "XYZ789",
+            gameId: gameId,
+            gameName: "Spirit Island",
+            toolkitId: null,
+            createdByUserId: Guid.NewGuid(),
+            visibility: PlayRecordVisibility.Private,
+            groupId: null,
+            status: LiveSessionStatus.InProgress,
+            createdAt: createdAt,
+            startedAt: createdAt.AddSeconds(30),
+            pausedAt: null,
+            completedAt: null,
+            updatedAt: createdAt.AddMinutes(5),
+            lastSavedAt: null,
+            currentTurnIndex: 0,
+            currentPhaseIndex: 0,
+            phaseNames: Array.Empty<string>(),
+            snapshotTriggerConfig: null,
+            lastSnapshotTimestamp: null,
+            scoringConfig: SessionScoringConfig.CreateDefault(),
+            gameState: null,
+            notes: null,
+            agentMode: AgentSessionMode.None,
+            turnAdvancePolicy: TurnAdvancePolicy.Manual,
+            trackingSessionId: trackingSessionId,
+            xmin: 1u,
+            players: Array.Empty<LiveSessionPlayer>(),
+            teams: Array.Empty<LiveSessionTeam>(),
+            turnOrder: Array.Empty<Guid>(),
+            roundScores: Array.Empty<RoundScore>(),
+            turnRecords: Array.Empty<TurnRecord>(),
+            disputes: Array.Empty<RuleDisputeEntry>(),
+            diaryEntries: Array.Empty<DiaryEntry>(),
+            setupChecklist: null);
+
+        session.TrackingSessionId.Should().Be(trackingSessionId);
+        session.GameId.Should().Be(gameId);
+        session.DomainEvents.Should().BeEmpty("Reconstitute MUST NOT raise events");
+    }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Infrastructure/Mappers/LiveGameSessionMapperTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Infrastructure/Mappers/LiveGameSessionMapperTests.cs
@@ -90,4 +90,24 @@ public class LiveGameSessionMapperTests
         var back = LiveGameSessionMapper.ToDomain(entity);
         back.TrackingSessionId.Should().Be(trackingId);
     }
+
+    [Fact]
+    public void Mapper_RoundTrips_NullTrackingSessionId()
+    {
+        // #2552: explicit null round-trip — a free-form session (no GameId companion) must keep
+        // TrackingSessionId null through ToEntity → ToDomain, never coalescing to Guid.Empty.
+        var domain = LiveGameSession.Create(
+            id: Guid.NewGuid(),
+            createdByUserId: Guid.NewGuid(),
+            gameName: "Mage Knight",
+            timeProvider: TimeProvider.System,
+            gameId: null,
+            trackingSessionId: null);
+
+        var entity = LiveGameSessionMapper.ToEntity(domain);
+        entity.TrackingSessionId.Should().BeNull();
+
+        var back = LiveGameSessionMapper.ToDomain(entity);
+        back.TrackingSessionId.Should().BeNull();
+    }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Infrastructure/SessionRepositoryTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Infrastructure/SessionRepositoryTests.cs
@@ -2,6 +2,7 @@ using Api.BoundedContexts.SessionTracking.Domain.Entities;
 using Api.BoundedContexts.SessionTracking.Infrastructure.Persistence;
 using Api.Infrastructure;
 using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Middleware.Exceptions;
 using Api.Tests.Constants;
 using Api.Tests.Infrastructure;
 using Api.Tests.TestHelpers;
@@ -217,7 +218,7 @@ public class SessionRepositoryTests : SharedDatabaseTestBase<SessionRepository>
         };
 
         // Assert
-        await act.Should().ThrowAsync<InvalidOperationException>()
+        await act.Should().ThrowAsync<ConflictException>()
             .WithMessage("*Session code*already exists*");
     }
 


### PR DESCRIPTION
## Contesto
Follow-up non bloccanti dalla review di **#2501 SP0** (PR #2551). Implementa **3 dei 5 sotto-item**; gli altri 2 sono deferiti con motivazione.

## Implementato
| Item | Cosa | Note |
|------|------|------|
| 1a | `SessionRepository.AddAsync`: `InvalidOperationException` (500) → `ConflictException` (409) per session-code duplicato | L'unique index `idx_sessions_code` **esiste già** → nessuna migration; era sbagliato solo il tipo di eccezione (viola #2568) |
| 2.1 | `CreateLiveSession_WithAllOptionalParams`: configura il companion mock + asserisce `TrackingSessionId` | Prima il mock non configurato ritornava `Guid.Empty` silenzioso e l'assert mancava |
| 2.2 | `LiveGameSessionMapper`: round-trip **null** `TrackingSessionId` | Mancava il caso null esplicito |
| 2.3 | `Reconstitute`: branch `trackingSessionId` **non-null** | Prima solo il path null era esercitato |
| 4 | DI: rimossi FQN ridondanti su `ICompanionSessionService`/`ILiveSessionStreamGateway` | gli using erano già importati |

## Deferiti (nit non bloccanti — vedi commento su #2552)
- **DB-level 23505 concurrent-race mapping**: ~1/33M, e non esiste un middleware globale `PostgresException → 409` da estendere; il throw esplicito (qui mappato) copre il caso comune.
- **GameId FK-violation (23503) mapping**: correlato al lavoro schema `game_id` NOT NULL / companion tracciato in **#2596**.
- **`tracking_session_id` index**: YAGNI — SP2 non lo consuma ancora in una `WHERE` indicizzabile.

## Verifica
- `SessionRepository`: **34/34** (Docker integration, incl. il nuovo `ConflictException`)
- mapper + reconstitute + handler: **62/62** verde

Refs #2552