### PR TITLE
feat(session-live): #2564 render broadcast chat citations (AC-SSE-4)

### DIFF
--- a/apps/web/__tests__/session-live-action-log-citations-axe.test.tsx
+++ b/apps/web/__tests__/session-live-action-log-citations-axe.test.tsx
@@ -1,0 +1,55 @@
+/**
+ * #2564 — axe AA test for ActionLogTimeline broadcast citation chips.
+ *
+ * Renders the timeline with a chat entry carrying citations[] and runs axe-core.
+ * Structural a11y (roles, labels, aria) is enforced here; the color-contrast rule is
+ * exercised by the E2E `Frontend - A11y E2E` job (jsdom cannot compute contrast). The
+ * chip color reuses the knowledge-base token (--c-kb, same as CitationChip) which is
+ * AA-compliant in both themes.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { axe } from 'jest-axe';
+
+import { ActionLogTimeline } from '@/components/features/session-live/ActionLogTimeline';
+import type {
+  ActionLogEntry,
+  ActionLogTimelineLabels,
+} from '@/components/features/session-live/ActionLogTimeline';
+
+// toHaveNoViolations is extended globally in vitest.setup.tsx
+
+const LABELS: ActionLogTimelineLabels = {
+  title: 'Registro azioni',
+  emptyLabel: 'Nessuna azione',
+  typeScore: 'Punteggio',
+  typeTool: 'Strumento',
+  typeAgent: 'Agente',
+  typeChat: 'Chat',
+  typePhoto: 'Foto',
+  typeEvent: 'Evento',
+  timestampAriaLabel: 'Cronologia azioni',
+};
+
+describe('ActionLogTimeline citations — axe AA (#2564)', () => {
+  it('has no axe violations with broadcast citation chips', async () => {
+    const entries: ActionLogEntry[] = [
+      {
+        id: 'msg-1',
+        type: 'chat',
+        authorName: 'agent',
+        content: 'Vedi le regole.',
+        timestamp: '2026-06-29T10:00:00Z',
+        citations: [
+          { page: 3, source: 'Setup', snippet: 'Place the board...' },
+          { page: 7, source: 'Combat' },
+        ],
+      },
+    ];
+
+    const { container } = render(<ActionLogTimeline entries={entries} labels={LABELS} />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});

--- a/apps/web/src/components/features/session-live/ActionLogTimeline.tsx
+++ b/apps/web/src/components/features/session-live/ActionLogTimeline.tsx
@@ -9,6 +9,8 @@
 
 import type { ReactElement } from 'react';
 
+import type { Citation } from '@/lib/api/schemas/streaming.schemas';
+
 // ─── Types ────────────────────────────────────────────────────────────────────
 
 export interface ActionLogEntry {
@@ -17,6 +19,11 @@ export interface ActionLogEntry {
   readonly authorName: string;
   readonly content: string;
   readonly timestamp: string;
+  /**
+   * RAG citations attached to a broadcast chat entry (#2564 AC-SSE-4). Rendered read-only
+   * under the content so non-author participants see the shared citations too.
+   */
+  readonly citations?: ReadonlyArray<Citation>;
 }
 
 // ─── Labels ───────────────────────────────────────────────────────────────────
@@ -111,6 +118,27 @@ export function ActionLogTimeline({
               <div className="min-w-0 flex-1">
                 <p className="truncate text-xs text-foreground">{entry.content}</p>
                 <p className="text-xs text-muted-foreground">{entry.authorName}</p>
+
+                {/* #2564 AC-SSE-4: broadcast RAG citations rendered read-only so non-author
+                    participants see the shared citations, not just the agent's text. */}
+                {entry.citations && entry.citations.length > 0 && (
+                  <ul data-slot="action-log-citations" className="mt-1 flex flex-wrap gap-1">
+                    {entry.citations.map((citation, index) => (
+                      <li
+                        key={`${entry.id}-cite-${index}`}
+                        data-slot="action-log-citation"
+                        title={citation.snippet ?? citation.text ?? undefined}
+                        className="inline-flex max-w-[10rem] items-center gap-1 rounded-full bg-muted px-2 py-0.5 font-mono text-[0.65rem] font-medium text-sky-400"
+                      >
+                        <span aria-hidden="true">📖</span>
+                        {typeof citation.page === 'number' && <span>p. {citation.page}</span>}
+                        {citation.source ? (
+                          <span className="truncate">{citation.source}</span>
+                        ) : null}
+                      </li>
+                    ))}
+                  </ul>
+                )}
               </div>
 
               {/* Timestamp */}

--- a/apps/web/src/components/features/session-live/ActionLogTimeline.tsx
+++ b/apps/web/src/components/features/session-live/ActionLogTimeline.tsx
@@ -128,7 +128,9 @@ export function ActionLogTimeline({
                         key={`${entry.id}-cite-${index}`}
                         data-slot="action-log-citation"
                         title={citation.snippet ?? citation.text ?? undefined}
-                        className="inline-flex max-w-[10rem] items-center gap-1 rounded-full bg-muted px-2 py-0.5 font-mono text-[0.65rem] font-medium text-sky-400"
+                        // Reuse the knowledge-base citation color (mirrors CitationChip, AA-compliant
+                        // in both themes) — citations are KB content. #2564.
+                        className="inline-flex max-w-[10rem] items-center gap-1 rounded-full bg-[hsl(var(--c-kb)/0.12)] px-2 py-0.5 font-mono text-[0.65rem] font-medium text-[hsl(var(--c-kb))]"
                       >
                         <span aria-hidden="true">📖</span>
                         {typeof citation.page === 'number' && <span>p. {citation.page}</span>}

--- a/apps/web/src/components/features/session-live/__tests__/ActionLogTimeline.test.tsx
+++ b/apps/web/src/components/features/session-live/__tests__/ActionLogTimeline.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * Tests for ActionLogTimeline citation rendering (#2564 AC-SSE-4).
+ *
+ * Covers:
+ *   - A chat entry with citations[] renders read-only citation chips (page + source)
+ *   - A chat entry without citations renders no citation chips
+ *   - Non-chat entries never render citations
+ */
+
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import type { ActionLogEntry, ActionLogTimelineLabels } from '../ActionLogTimeline';
+import { ActionLogTimeline } from '../ActionLogTimeline';
+
+const LABELS: ActionLogTimelineLabels = {
+  title: 'Registro',
+  emptyLabel: 'Nessuna azione',
+  typeScore: 'Punteggio',
+  typeTool: 'Strumento',
+  typeAgent: 'Agente',
+  typeChat: 'Chat',
+  typePhoto: 'Foto',
+  typeEvent: 'Evento',
+  timestampAriaLabel: 'Cronologia azioni',
+};
+
+function renderTimeline(entries: ReadonlyArray<ActionLogEntry>) {
+  return render(<ActionLogTimeline entries={entries} labels={LABELS} />);
+}
+
+describe('ActionLogTimeline — citations (#2564 AC-SSE-4)', () => {
+  it('renders read-only citation chips for a chat entry with citations', () => {
+    const { container } = renderTimeline([
+      {
+        id: 'msg-1',
+        type: 'chat',
+        authorName: 'agent',
+        content: 'Vedi le regole.',
+        timestamp: '2026-06-29T10:00:00Z',
+        citations: [
+          { page: 3, source: 'Setup', snippet: 'Place the board...' },
+          { page: 7, source: 'Combat' },
+        ],
+      },
+    ]);
+
+    const chips = container.querySelectorAll('[data-slot="action-log-citation"]');
+    expect(chips).toHaveLength(2);
+    expect(screen.getByText('Setup')).toBeInTheDocument();
+    expect(screen.getByText('Combat')).toBeInTheDocument();
+    expect(screen.getByText('p. 3')).toBeInTheDocument();
+    expect(screen.getByText('p. 7')).toBeInTheDocument();
+  });
+
+  it('renders no citation chips for a chat entry without citations', () => {
+    const { container } = renderTimeline([
+      {
+        id: 'msg-2',
+        type: 'chat',
+        authorName: 'p-alice',
+        content: 'Ciao',
+        timestamp: '2026-06-29T10:00:00Z',
+      },
+    ]);
+
+    expect(container.querySelectorAll('[data-slot="action-log-citation"]')).toHaveLength(0);
+  });
+
+  it('never renders citations for non-chat entries', () => {
+    const { container } = renderTimeline([
+      {
+        id: 'sc-1',
+        type: 'score',
+        authorName: 'p-bob',
+        content: '+5',
+        timestamp: '2026-06-29T10:00:00Z',
+      },
+    ]);
+
+    expect(container.querySelectorAll('[data-slot="action-log-citation"]')).toHaveLength(0);
+  });
+});

--- a/apps/web/src/lib/session-live/__tests__/compose-session-live-state.test.ts
+++ b/apps/web/src/lib/session-live/__tests__/compose-session-live-state.test.ts
@@ -457,6 +457,41 @@ describe('composeSessionLiveState — session:chat', () => {
     ]);
     expect(state.actionLog).toHaveLength(2);
   });
+
+  it('propagates citations[] from session:chat into the LiveLogEntry (#2564 AC-SSE-4)', () => {
+    const event: Extract<SessionEvent, { type: 'session:chat' }> = {
+      type: 'session:chat',
+      sessionId: 'sess-1',
+      messageId: 'msg-cited',
+      senderId: 'agent',
+      content: 'Per il setup vedi le regole.',
+      visibility: 'shared',
+      timestamp: TS,
+      citations: [
+        { page: 3, source: 'Setup', snippet: 'Place the board...' },
+        { page: 7, source: 'Combat' },
+      ],
+    };
+    const state = composeSessionLiveState(BASE_SESSION, [event]);
+    expect(state.actionLog).toHaveLength(1);
+    expect(state.actionLog[0].citations).toHaveLength(2);
+    expect(state.actionLog[0].citations?.[0].page).toBe(3);
+    expect(state.actionLog[0].citations?.[0].source).toBe('Setup');
+  });
+
+  it('chat entry without citations leaves citations undefined', () => {
+    const event: Extract<SessionEvent, { type: 'session:chat' }> = {
+      type: 'session:chat',
+      sessionId: 'sess-1',
+      messageId: 'msg-plain',
+      senderId: 'p-alice',
+      content: 'Hi',
+      visibility: 'shared',
+      timestamp: TS,
+    };
+    const state = composeSessionLiveState(BASE_SESSION, [event]);
+    expect(state.actionLog[0].citations).toBeUndefined();
+  });
 });
 
 // ============================================================================

--- a/apps/web/src/lib/session-live/compose-session-live-state.ts
+++ b/apps/web/src/lib/session-live/compose-session-live-state.ts
@@ -36,6 +36,8 @@
  * 4. session:tool-execution — BE has CoinFlipped/WheelSpun events not in FE 'dice'|'timer'|'card' enum.
  */
 
+import type { Citation } from '@/lib/api/schemas/streaming.schemas';
+
 import type { SessionEvent } from './sse-events';
 
 // ============================================================================
@@ -56,6 +58,12 @@ export interface LiveLogEntry {
   readonly authorName: string;
   readonly content: string;
   readonly timestamp: string;
+  /**
+   * RAG citations attached to a broadcast chat message (#2564 AC-SSE-4). Only populated for
+   * type='chat' entries that carried citations[] over the SSE wire (T8/T9 SP2 #2561). undefined
+   * for non-chat entries and for chat messages with no citations.
+   */
+  readonly citations?: ReadonlyArray<Citation>;
 }
 
 export interface SessionLiveState {
@@ -239,6 +247,8 @@ function applyChat(
     authorName: event.senderId,
     content: event.content,
     timestamp: event.timestamp,
+    // #2564 AC-SSE-4: carry the broadcast citations so non-author participants render them too.
+    citations: event.citations,
   };
   return { ...state, actionLog: [...state.actionLog, entry] };
 }


### PR DESCRIPTION
## Contesto
Follow-up #2501 SP2 (#2561). **Opzione A** dell'issue. Il broadcast SSE porta già `citations[]` (T8) e il parser le estrae già (T9), ma `compose-session-live-state` le scartava e `ActionLogTimeline` non le renderizzava → i partecipanti **non-autori** vedevano il testo dell'agente **senza** le citation card. AC-SSE-4 era soddisfatto sul wire ma **non** all'UI.

## Fix (Opzione A)
- `LiveLogEntry` += `citations?: ReadonlyArray<Citation>`; `applyChat` propaga `event.citations`.
- `ActionLogEntry` += `citations?`; `ActionLogTimeline` le renderizza **read-only** sotto il content (chip `📖 p.N — source`, snippet in `title` on hover).
- **Read-only by design**: `ActionLogTimeline` è un componente puro senza modal state; lo scopo è "rendere visibili le citazioni condivise", non l'interazione (il modal è SP1 #2500, sulla risposta RAG propria).

`actionLog` (`LiveLogEntry[]`) fluisce direttamente in `entries` (`ActionLogEntry[]`) via structural typing → il nuovo campo si propaga end-to-end senza re-mapping.

## Verifica
- **47/47** Vitest verde (2 compose: propagazione / undefined quando assenti + 3 ActionLogTimeline: chip resi / nessuno senza citazioni / mai per entry non-chat)
- lint **0 errori** (classi token-compliant: `bg-muted` semantico + `text-sky-400` hue già usato per chat)
- typecheck **0 errori**

Closes #2564