### PR TITLE
fix(session-live): #2596 seed GameId + valid SessionType in StreamV2 deprecation test

### DIFF
--- a/apps/api/tests/Api.Tests/Integration/SessionTracking/StreamV2DeprecationHeadersEndpointTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/SessionTracking/StreamV2DeprecationHeadersEndpointTests.cs
@@ -162,14 +162,26 @@ public sealed class StreamV2DeprecationHeadersEndpointTests : IAsyncLifetime
         // Create a user and a valid auth session (returns userId + raw cookie token).
         var (userId, sessionToken) = await TestSessionHelper.CreateUserSessionAsync(dbContext);
 
+        // Seed a SharedGame to satisfy the SessionEntity.GameId FK. Although the C#
+        // property SessionEntity.GameId is Guid?, the column game_id is NOT NULL and
+        // carries a foreign key to shared_games with DeleteBehavior.Restrict
+        // (SessionConfiguration.cs:27-29,155-159). A random Guid would fail the FK,
+        // so we seed a real shared game and reference its id. (Issue #2596)
+        var gameId = await TestSessionHelper.SeedSharedGameAsync(dbContext, "StreamV2 Deprecation Test Game");
+
         // Seed a SessionEntity owned by that user so GetSessionStreamQuery succeeds.
         var trackingSessionId = Guid.NewGuid();
         dbContext.SessionTrackingSessions.Add(new SessionEntity
         {
             Id = trackingSessionId,
             UserId = userId,
+            GameId = gameId,
             SessionCode = "TST001",
-            SessionType = "Standard",
+            // Must be a valid SessionType enum member ("Generic" | "GameSpecific") —
+            // SessionMapper.ToDomain does Enum.Parse<SessionType>, so an invalid value
+            // (the previous "Standard") throws ArgumentException → 400. With a GameId set,
+            // "GameSpecific" is the semantically correct value. (Issue #2596)
+            SessionType = "GameSpecific",
             Status = "Active",
             SessionDate = DateTime.UtcNow,
             CreatedAt = DateTime.UtcNow,


### PR DESCRIPTION
## Cosa

Fix del baseline test failure documentato in #2596. `StreamV2_AuthenticatedOwner_ReceivesDeprecationHeaders_On200` falliva su `main-dev` puro — invisibile in CI PR-time perché gli integration test (Testcontainers) non girano nel job `Backend Fast (build + unit)`.

## Root cause (due difetti nel seed, mai eseguito con successo)

1. **`game_id` NOT NULL violation** — `SessionEntity.GameId` non era impostato. La property C# è `Guid?` ma la colonna `game_id` è **NOT NULL** con una **FK a `shared_games`** (`DeleteBehavior.Restrict`, `SessionConfiguration.cs:27-29,155-159`). Un `Guid.NewGuid()` casuale fallirebbe la FK → si seeda un `SharedGame` reale via `TestSessionHelper.SeedSharedGameAsync` e se ne referenzia l'id.

2. **`SessionType = "Standard"` invalido** (emerso solo dopo il fix #1) — non è un membro valido dell'enum `SessionType` (`Generic` | `GameSpecific`). `SessionMapper.ToDomain` fa `Enum.Parse<SessionType>` → `ArgumentException` → **400** invece di 200. Con un `GameId` impostato, `GameSpecific` è il valore semanticamente corretto.

## Scope

Test-only (1 file, +13/-1). Il drift entity↔schema (`GameId` `Guid?` vs colonna NOT NULL) è **fuori scope** e lasciato a **#2552** (validazione GameId / mapping constraint-violation sullo stesso aggregato), come da nota "candidato a fix congiunto" nella issue.

## Verifica

```
dotnet test --filter "FullyQualifiedName~StreamV2DeprecationHeadersEndpointTests"
→ Superato! Non superati: 0. Superati: 3. Totale: 3.
```

Closes #2596

🤖 Generated with [Claude Code](https://claude.com/claude-code)