### PR TITLE
fix(session-live): #2552 map nonexistent GameId to 404 + index tracking_session_id

### DIFF
--- a/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Services/CompanionSessionService.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Services/CompanionSessionService.cs
@@ -1,6 +1,8 @@
 using Api.BoundedContexts.GameManagement.Application.Services;
 using Api.BoundedContexts.SessionTracking.Domain.Entities;
 using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Middleware.Exceptions;
 
 namespace Api.BoundedContexts.GameManagement.Infrastructure.Services;
 
@@ -14,15 +16,28 @@ namespace Api.BoundedContexts.GameManagement.Infrastructure.Services;
 internal sealed class CompanionSessionService : ICompanionSessionService
 {
     private readonly ISessionRepository _sessionRepository;
+    private readonly ISharedGameRepository _sharedGameRepository;
 
-    public CompanionSessionService(ISessionRepository sessionRepository)
+    public CompanionSessionService(
+        ISessionRepository sessionRepository,
+        ISharedGameRepository sharedGameRepository)
     {
         _sessionRepository = sessionRepository ?? throw new ArgumentNullException(nameof(sessionRepository));
+        _sharedGameRepository = sharedGameRepository ?? throw new ArgumentNullException(nameof(sharedGameRepository));
     }
 
     /// <inheritdoc />
     public async Task<Guid> CreateCompanionAsync(Guid userId, Guid gameId, CancellationToken ct)
     {
+        // #2552: the companion's game_id is an FK to shared_games (Restrict). Session.Create only
+        // validates Guid != Empty, so a valid-but-nonexistent GameId would otherwise surface as a
+        // 500 FK violation at the caller's SaveChanges. Pre-flight the existence check and map a
+        // missing game to a 404 (respects #2568 "never InvalidOperationException for constraint failures").
+        if (!await _sharedGameRepository.ExistsByIdAsync(gameId, ct).ConfigureAwait(false))
+        {
+            throw new NotFoundException("Game", gameId.ToString());
+        }
+
         var companion = Session.Create(userId, gameId, SessionType.GameSpecific);
         await _sessionRepository.AddAsync(companion, ct).ConfigureAwait(false);
         return companion.Id;

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Repositories/ISharedGameRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Repositories/ISharedGameRepository.cs
@@ -24,6 +24,17 @@ public interface ISharedGameRepository
     Task<SharedGame?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Checks whether a non-deleted shared game exists for the given ID.
+    /// Issue #2552: lightweight existence probe (no aggregate hydration) used by the
+    /// companion-saga path to reject a valid-but-nonexistent GameId with a 404 instead of
+    /// letting the FK violation surface as a 500 at SaveChanges.
+    /// </summary>
+    /// <param name="id">The game ID</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>True if a non-deleted game with that ID exists, false otherwise</returns>
+    Task<bool> ExistsByIdAsync(Guid id, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Gets multiple shared games by their IDs in a single batch query.
     /// Issue #3663: Added to prevent N+1 queries in GetUserLibraryQueryHandler.
     /// </summary>

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/SharedGameRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/SharedGameRepository.cs
@@ -68,6 +68,14 @@ internal sealed class SharedGameRepository : RepositoryBase, ISharedGameReposito
             .ConfigureAwait(false);
     }
 
+    public async Task<bool> ExistsByIdAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        return await DbContext.Set<SharedGameEntity>()
+            .AsNoTracking()
+            .AnyAsync(g => g.Id == id && !g.IsDeleted, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
     public async Task<IReadOnlyDictionary<Guid, SharedGame>> GetByIdsAsync(IEnumerable<Guid> ids, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(ids);

--- a/apps/api/src/Api/Infrastructure/Configurations/GameManagement/LiveGameSessionEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/Configurations/GameManagement/LiveGameSessionEntityConfiguration.cs
@@ -170,6 +170,12 @@ internal sealed class LiveGameSessionEntityConfiguration : IEntityTypeConfigurat
             .HasDatabaseName("ix_live_game_sessions_created_at")
             .IsDescending(true);
 
+        // #2552: cross-BC lookups since SP2 filter on tracking_session_id (the companion id).
+        // Partial index (non-null only) keeps it small — legacy pre-SP0 rows have null here.
+        builder.HasIndex(e => e.TrackingSessionId)
+            .HasDatabaseName("ix_live_game_sessions_tracking_session_id")
+            .HasFilter("tracking_session_id IS NOT NULL");
+
         // --- Relationships ---
 
         builder.HasOne(e => e.Game)

--- a/apps/api/src/Api/Infrastructure/Migrations/20260630061632_AddTrackingSessionIdIndexToLiveGameSessions.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260630061632_AddTrackingSessionIdIndexToLiveGameSessions.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260630061632_AddTrackingSessionIdIndexToLiveGameSessions")]
+    partial class AddTrackingSessionIdIndexToLiveGameSessions
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260630061632_AddTrackingSessionIdIndexToLiveGameSessions.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260630061632_AddTrackingSessionIdIndexToLiveGameSessions.cs
@@ -1,0 +1,38 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddTrackingSessionIdIndexToLiveGameSessions : Migration
+    {
+        // #2552: adds a partial index on live_game_sessions.tracking_session_id for the cross-BC
+        // companion lookups introduced since SP2 (WHERE tracking_session_id = @id).
+        //
+        // NOTE: `ef migrations add` also re-emitted a CreateTable for live_session_diary_entries
+        // because the model snapshot had drifted — the diary table was dropped from the snapshot
+        // when 20260629075250_AlignSearchVectorToEnglishFtsConfig was authored in parallel with the
+        // diary migration 20260629061044. That table already exists in every database via 061044, so
+        // recreating it here is removed; Up()/Down() keep ONLY the index. The regenerated snapshot
+        // (Designer + ModelSnapshot) realigns the diary table as a necessary side effect.
+
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateIndex(
+                name: "ix_live_game_sessions_tracking_session_id",
+                table: "live_game_sessions",
+                column: "tracking_session_id",
+                filter: "tracking_session_id IS NOT NULL");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ix_live_game_sessions_tracking_session_id",
+                table: "live_game_sessions");
+        }
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Infrastructure/Services/CompanionSessionServiceTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Infrastructure/Services/CompanionSessionServiceTests.cs
@@ -1,7 +1,10 @@
 using Api.BoundedContexts.GameManagement.Infrastructure.Services;
 using Api.BoundedContexts.SessionTracking.Domain.Entities;
 using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Middleware.Exceptions;
 using Api.Tests.Constants;
+using FluentAssertions;
 using Moq;
 using Xunit;
 
@@ -11,31 +14,57 @@ namespace Api.Tests.BoundedContexts.GameManagement.Infrastructure.Services;
 /// Unit tests for CompanionSessionService (ADR-083 SP0 anti-corruption layer).
 /// Verifies that CreateCompanionAsync adds a Session companion via ISessionRepository
 /// and returns its Id, without calling SaveChanges (that is the caller's responsibility).
-/// Issue #2501 SP0.
+/// Issue #2501 SP0. #2552: pre-flight game-existence guard mapping a missing GameId to a
+/// 404 NotFoundException instead of letting the FK violation surface as a 500 at SaveChanges.
 /// </summary>
 [Trait("Category", TestCategories.Unit)]
 [Trait("BoundedContext", "GameManagement")]
 public class CompanionSessionServiceTests
 {
+    private readonly Mock<ISessionRepository> _sessionRepo = new();
+    private readonly Mock<ISharedGameRepository> _sharedGameRepo = new();
+
+    private CompanionSessionService CreateSut() => new(_sessionRepo.Object, _sharedGameRepo.Object);
+
     [Fact]
-    public async Task CreateCompanionAsync_AddsSession_AndReturnsItsId()
+    public async Task CreateCompanionAsync_GameExists_AddsSession_AndReturnsItsId()
     {
-        var repo = new Mock<ISessionRepository>();
         Session? captured = null;
-        repo.Setup(r => r.AddAsync(It.IsAny<Session>(), It.IsAny<CancellationToken>()))
+        _sessionRepo.Setup(r => r.AddAsync(It.IsAny<Session>(), It.IsAny<CancellationToken>()))
             .Callback<Session, CancellationToken>((s, _) => captured = s)
             .Returns(Task.CompletedTask);
 
-        var sut = new CompanionSessionService(repo.Object);
         var userId = Guid.NewGuid();
         var gameId = Guid.NewGuid();
+        _sharedGameRepo.Setup(r => r.ExistsByIdAsync(gameId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
 
+        var sut = CreateSut();
         var trackingId = await sut.CreateCompanionAsync(userId, gameId, CancellationToken.None);
 
-        Assert.NotNull(captured);
-        Assert.Equal(captured!.Id, trackingId);
-        Assert.Equal(userId, captured.UserId);
-        Assert.Equal(gameId, captured.GameId);
-        repo.Verify(r => r.AddAsync(It.IsAny<Session>(), It.IsAny<CancellationToken>()), Times.Once);
+        captured.Should().NotBeNull();
+        captured!.Id.Should().Be(trackingId);
+        captured.UserId.Should().Be(userId);
+        captured.GameId.Should().Be(gameId);
+        _sessionRepo.Verify(r => r.AddAsync(It.IsAny<Session>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task CreateCompanionAsync_GameDoesNotExist_ThrowsNotFound_AndDoesNotAddSession()
+    {
+        var userId = Guid.NewGuid();
+        var gameId = Guid.NewGuid();
+        _sharedGameRepo.Setup(r => r.ExistsByIdAsync(gameId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var sut = CreateSut();
+        var act = () => sut.CreateCompanionAsync(userId, gameId, CancellationToken.None);
+
+        // A GameId that points at no catalog row must surface as 404, not a 500 FK violation
+        // at the downstream SaveChanges (#2552, respects #2568 "never InvalidOperationException").
+        var ex = (await act.Should().ThrowAsync<NotFoundException>()).Which;
+        ex.ResourceType.Should().Be("Game");
+        ex.ResourceId.Should().Be(gameId.ToString());
+        _sessionRepo.Verify(r => r.AddAsync(It.IsAny<Session>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 }

--- a/apps/api/tests/Api.Tests/Integration/GameManagement/CreateLiveSessionCompanionIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/GameManagement/CreateLiveSessionCompanionIntegrationTests.cs
@@ -2,6 +2,7 @@ using Api.BoundedContexts.GameManagement.Application.Commands.LiveSessions;
 using Api.Infrastructure;
 using Api.Infrastructure.Entities;
 using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Middleware.Exceptions;
 using Api.Tests.Constants;
 using Api.Tests.Infrastructure;
 using FluentAssertions;
@@ -93,6 +94,36 @@ public sealed class CreateLiveSessionCompanionIntegrationTests : IAsyncLifetime
 
         companionExists.Should().BeTrue(
             "the companion Session and the LiveGameSession must be committed together in one transaction");
+    }
+
+    [Fact(DisplayName = "Create live session with a nonexistent GameId throws 404 NotFound and persists nothing (#2552)")]
+    public async Task Handle_WithNonexistentGameId_ThrowsNotFound_AndPersistsNothing()
+    {
+        // Arrange — seed only the user; deliberately NO shared game, so the GameId is well-formed
+        // (Guid != Empty, passes the validator) but points at no catalog row.
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        var userId = await SeedUserAsync(db);
+        var nonexistentGameId = Guid.NewGuid();
+
+        // Act — the companion pre-flight existence check must reject the GameId BEFORE any insert,
+        // so the FK violation never reaches SaveChanges as a 500.
+        var act = () => mediator.Send(new CreateLiveSessionCommand(
+            UserId: userId,
+            GameName: "Ghost Game",
+            GameId: nonexistentGameId));
+
+        // Assert — 404 NotFound for the missing Game (#2552, respects #2568), not a 500 FK violation.
+        var ex = (await act.Should().ThrowAsync<NotFoundException>()).Which;
+        ex.ResourceType.Should().Be("Game");
+
+        // Assert — nothing persisted (no LiveGameSession, no orphan companion Session).
+        (await db.LiveGameSessions.AsNoTracking().AnyAsync(s => s.CreatedByUserId == userId))
+            .Should().BeFalse("the pre-flight guard must reject before persisting a LiveGameSession");
+        (await db.SessionTrackingSessions.AsNoTracking().AnyAsync(s => s.UserId == userId))
+            .Should().BeFalse("no orphan companion Session must be persisted when the game does not exist");
     }
 
     /// <summary>


### PR DESCRIPTION
## Cosa

Scope residuo di #2552 (follow-up non bloccante di #2501 SP0). **PR #2598 aveva già shippato** session-code→409, l'indice unique `idx_sessions_code` e i 3 test-coverage nit. Restavano 2 item:

### 1. GameId valido-ma-inesistente → 404 (era 500)
Il `game_id` del companion è una FK a `shared_games` (Restrict). `Session.Create` valida solo `Guid != Empty`, quindi un GameId che punta a nessuna riga del catalogo emergeva come **500 `DbUpdateException`** al `SaveChanges` (viola #2568). 
- Nuovo `ISharedGameRepository.ExistsByIdAsync` — probe leggero (`AnyAsync`, rispetta soft-delete come `ExistsByBggIdAsync`).
- Guard pre-flight in `CompanionSessionService.CreateCompanionAsync` → `NotFoundException("Game", id)` **prima di qualsiasi insert** (nessun orphan persistito).

### 2. Indice partial su `tracking_session_id`
Per i lookup cross-BC del companion da SP2 (`WHERE tracking_session_id = @id`, prima sequential scan). `HasFilter("tracking_session_id IS NOT NULL")`.

## ⚠️ Effetto collaterale necessario: realign snapshot drift

`ef migrations add` ha rigenerato il model snapshot che era **driftato**: `live_session_diary_entries` (migration `20260629061044`) era stata rimossa dallo snapshot quando `20260629075250_AlignSearchVectorToEnglishFtsConfig` è stata autorata in parallelo. La migration `Up()`/`Down()` tiene **SOLO l'indice** (la tabella diary esiste già via 061044); lo snapshot rigenerato ri-aggiunge l'entità diary. Conteggio tabelle 247→248 (solo diary, nessuna rimossa). `has-pending-model-changes` → "No changes".

## Test

- **2 unit** (`CompanionSessionServiceTests`): game-exists → companion creato; game-missing → `NotFoundException("Game")`, nessun `AddAsync`.
- **1 integration** (`CreateLiveSessionCompanionIntegrationTests`): `CreateLiveSession` con GameId inesistente → 404 end-to-end, **nulla persistito** (no LiveGameSession, no companion orphan).

Tutti verdi localmente (unit + Testcontainers).

## Code review

Subagent `feature-dev:code-reviewer`: **APPROVED**, 0 issue. Verificati: guard pre-insert, soft-delete (double-filter benigno via `HasQueryFilter`), migration safe (061044 crea diary first), no layering violation, TOCTOU bounded (shared_games solo soft-delete).

Closes #2552

🤖 Generated with [Claude Code](https://claude.com/claude-code)