### PR TITLE
feat(session-live): #2600 SP5-c lazy companion creation + LLM stream timeout

### DIFF
--- a/.superpowers/sdd/task-2-report.md
+++ b/.superpowers/sdd/task-2-report.md
@@ -1,0 +1,106 @@
+# Task 2 Report — SP5-c (#2600) Endpoint hook: ensure companion on first subscribe
+
+## Fix: stale stream-not-linked header (final-review Important)
+
+**Option chosen:** Option A — changed `EnsureCompanionCommand` from `ICommand` (void) to `ICommand<Guid?>`, returning the post-ensure `TrackingSessionId`. The endpoint uses this return value instead of the stale `ctx.HasCompanion` to decide whether to emit `X-Warning-Code: stream-not-linked`.
+
+### Files changed
+
+| File | Change |
+|------|--------|
+| `apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/LiveSessions/EnsureCompanionCommand.cs` | `ICommand` → `ICommand<Guid?>`, updated XML doc |
+| `apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/LiveSessions/EnsureCompanionCommandHandler.cs` | `ICommandHandler<EnsureCompanionCommand>` → `ICommandHandler<EnsureCompanionCommand, Guid?>`, `Task Handle(…)` → `Task<Guid?> Handle(…)`. All return paths: already-has-companion → returns existing id; free-form → returns null; created → returns new id; concurrency-race-winner → returns winner's id |
+| `apps/api/src/Api/Routing/LiveSessionEndpoints.cs` | Dispatch branch replaced with `isLinkedAfterEnsure` logic: if `ctx.HasCompanion`, skip dispatch (already linked); else dispatch and check `ensuredTrackingId.HasValue`. Warning header uses `!isLinkedAfterEnsure` instead of `!ctx.HasCompanion` |
+| `apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/LiveSessions/EnsureCompanionCommandHandlerTests.cs` | +4 new return-value tests: `Handle_NullCompanionAndGameIdPresent_ReturnsNewCompanionId`, `Handle_AlreadyHasCompanion_ReturnsExistingTrackingSessionId`, `Handle_FreeFormSession_ReturnsNull`, `Handle_ConcurrencyConflict_WhenRefetchShowsCompanionSet_ReturnsWinnersTrackingId`. Added `CreateSessionAlreadyHasCompanionWithKnownId()` helper + `ExistingCompanionId` constant. Total: 16 unit tests (12 original + 4 new) |
+| `apps/api/tests/Api.Tests/Integration/GameManagement/LazyCompanionOnSubscribeTests.cs` | Test 1 (`Subscribe_GameIdBacked_NullCompanion_CreatesCompanion`) extended: added assertion `resp.Headers.Should().NotContainKey("X-Warning-Code")` — the subscribe that just linked the session must NOT receive the warning |
+
+### Tests run locally (no Docker)
+
+16 unit tests in `EnsureCompanionCommandHandlerTests` — all passed (0 failed).
+
+```
+Superato Handle_NullCompanionAndGameIdPresent_SetsTrackingSessionId
+Superato Handle_ConcurrencyConflict_WhenRefetchShowsCompanionSet_ReturnsWinnersTrackingId
+Superato Handle_NullCompanionAndGameIdPresent_CreatesCompanionOnce
+Superato Handle_AlreadyHasCompanion_ReturnsExistingTrackingSessionId
+Superato Handle_ConcurrencyConflict_WhenRefetchStillNoCompanion_Rethrows
+Superato Handle_ConcurrencyConflict_WhenRefetchShowsCompanionSet_CompletesSuccessfully
+Superato Handle_ConcurrencyConflict_WhenRefetchShowsCompanionSet_DoesNotCreateSecondCompanion
+Superato Handle_NullCompanionAndGameIdPresent_SavesOnce
+Superato Handle_FreeFormSession_DoesNotSave
+Superato Handle_SessionNotFound_DoesNotCallCreateCompanion
+Superato Handle_FreeFormSession_ReturnsNull
+Superato Handle_AlreadyHasCompanion_DoesNotSave
+Superato Handle_AlreadyHasCompanion_DoesNotCallCreateCompanion
+Superato Handle_SessionNotFound_ThrowsNotFoundException
+Superato Handle_FreeFormSession_DoesNotCallCreateCompanion
+Superato Handle_NullCompanionAndGameIdPresent_ReturnsNewCompanionId
+```
+
+### Tests needing Docker (CI only)
+
+Integration tests in `LazyCompanionOnSubscribeTests` (Testcontainers / `Integration-GroupC`). Test 1 has been updated with the new header assertion (`NotContainKey("X-Warning-Code")`). Test 2 (free-form → `stream-not-linked` present) and Tests 3–4 unchanged. All 4 compile cleanly.
+
+### Build output
+
+```
+Api         → 0 errors, 0 warnings  (Release)
+Api.Tests   → 0 errors (build)
+Unit tests  → 16/16 passed
+```
+
+### Blocking concerns
+
+None.
+
+## Endpoint change (`LiveSessionEndpoints.cs`)
+
+Inserted after the 403 auth guard (line 983) and **before** SSE header writes (line 993):
+
+```csharp
+// SP5-c (#2600 Task 2): lazily provision a companion for legacy GameId-backed sessions
+// that pre-date the SP0 Saga (TrackingSessionId == null && GameId != null).
+if (!ctx.HasCompanion)
+    await mediator.Send(new EnsureCompanionCommand(sessionId), ct).ConfigureAwait(false);
+```
+
+- `IMediator` was already injected into the endpoint delegate — no signature change needed.
+- Context variable is named `ctx` (of type `LiveSessionStreamContextResult`) with property `HasCompanion`.
+- `EnsureCompanionCommand` import was already present via `using Api.BoundedContexts.GameManagement.Application.Commands.LiveSessions;`.
+- The `X-Warning-Code: stream-not-linked` header is preserved as-is (based on the stale `ctx.HasCompanion`). For a GameId-backed legacy session on its first subscribe, the warning fires once; on subsequent subscribes `HasCompanion == true` so no dispatch and no warning. For free-form (GameId==null) sessions the warning is always correct. Cosmetic tradeoff accepted per brief scope.
+- Auth/Found/Authorized short-circuits still fire before the dispatch — unauthorized callers never reach `EnsureCompanionCommand`.
+- The gateway re-reads the session inside `SubscribeAsync` and picks up the freshly-persisted `TrackingSessionId`.
+
+## Integration tests written
+
+File: `apps/api/tests/Api.Tests/Integration/GameManagement/LazyCompanionOnSubscribeTests.cs`
+
+| # | Test | Assertion |
+|---|------|-----------|
+| 1 | `Subscribe_GameIdBacked_NullCompanion_CreatesCompanion` | After subscribe, `TrackingSessionId` non-null AND companion `SessionTracking.Session` row exists |
+| 2 | `Subscribe_FreeForm_NoGameId_DoesNotCreateCompanion` | `TrackingSessionId` stays null, `X-Warning-Code` still set, 0 companion rows |
+| 3 | `Subscribe_AlreadyHasCompanion_CompanionIsUnchanged` | Same `TrackingSessionId`, still exactly 1 companion row, no `X-Warning-Code` |
+| 4 | `Subscribe_Concurrent_CreatesExactlyOneCompanion` | Both subscribes return 200, exactly 1 companion row, 0 orphans |
+
+All 4 tests use `HttpCompletionOption.ResponseHeadersRead` to avoid blocking on the SSE body and `Integration-GroupC` Testcontainers isolation. Legacy row seeding uses direct `LiveGameSessionEntity` insert (bypassing `CreateLiveSessionCommand` which would auto-create via SP0 Saga). Test 3 seeds a `SessionTracking.SessionEntity` with string-enum values (`SessionType="GameSpecific"`, `Status="Active"`) matching `SessionMapper.ToEntity`.
+
+## Tests executed vs. need Docker
+
+- **Ran and passed (no Docker)**: `Category=Unit` filter — 20,162 unit tests, 0 failures. Includes Task 1's `EnsureCompanionCommandHandlerTests`.
+- **Need Docker (Testcontainers)**: All 4 new integration tests in `LazyCompanionOnSubscribeTests`. Not executed locally — Testcontainers requires Docker which is unavailable in this environment. Tests compile cleanly (`dotnet build` 0 errors).
+
+## Build output
+
+```
+Api         → 0 warnings, 0 errors  (54s)
+Api.Tests   → 0 errors (202 pre-existing xUnit/Sonar warnings, unchanged)  (23s)
+Unit tests  → 20162 passed, 0 failed
+```
+
+## Concurrency test (Test 4) feasibility
+
+The in-process `TestHost` dispatches concurrent HTTP requests in separate Task contexts with independent DI scopes, so both `EnsureCompanionCommand` handlers execute concurrently against the same DB row. The xmin optimistic-concurrency token (ADR-060) ensures only one `SaveChanges` wins; the loser catches `DbUpdateConcurrencyException`, re-fetches, sees `TrackingSessionId != null`, and returns idempotently. Test 4 is valid in the Testcontainers harness.
+
+## Blocking concerns
+
+None. Change is minimal (1 guard + 1 await), handler is idempotent + race-safe (Task 1), existing `LiveSessionStreamEndpointTests` (AC-1 to AC-4) are unaffected.

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/LiveSessions/EnsureCompanionCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/LiveSessions/EnsureCompanionCommand.cs
@@ -1,0 +1,17 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.GameManagement.Application.Commands.LiveSessions;
+
+/// <summary>
+/// Idempotent command that ensures a <c>SessionTracking.Session</c> companion exists for a
+/// live game session. Intended for legacy sessions created before SP0 (ADR-083) that have
+/// <c>TrackingSessionId == null</c>.
+/// <para>
+/// No-op if the session already has a companion or if <c>GameId == null</c> (free-form sessions
+/// cannot have a GameSpecific companion).
+/// </para>
+/// Dispatched by the <c>GET /live-sessions/{id}/stream</c> endpoint before subscribing, so that
+/// the SSE gateway can forward domain events via the companion channel (SP5-c, Issue #2600).
+/// </summary>
+/// <param name="LiveSessionId">Id of the <see cref="Domain.Entities.LiveGameSession"/> to ensure has a companion.</param>
+internal sealed record EnsureCompanionCommand(Guid LiveSessionId) : ICommand;

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/LiveSessions/EnsureCompanionCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/LiveSessions/EnsureCompanionCommand.cs
@@ -10,8 +10,17 @@ namespace Api.BoundedContexts.GameManagement.Application.Commands.LiveSessions;
 /// No-op if the session already has a companion or if <c>GameId == null</c> (free-form sessions
 /// cannot have a GameSpecific companion).
 /// </para>
+/// <para>
+/// Returns the <c>TrackingSessionId</c> of the companion after the command completes:
+/// <list type="bullet">
+///   <item>Non-null → companion exists (pre-existing or just created); stream will have events.</item>
+///   <item><c>null</c> → free-form session; no companion was created; stream will be empty.</item>
+/// </list>
+/// The caller uses this to decide whether to emit the <c>X-Warning-Code: stream-not-linked</c>
+/// response header, avoiding a stale warning on the subscribe that first links the session.
+/// </para>
 /// Dispatched by the <c>GET /live-sessions/{id}/stream</c> endpoint before subscribing, so that
 /// the SSE gateway can forward domain events via the companion channel (SP5-c, Issue #2600).
 /// </summary>
 /// <param name="LiveSessionId">Id of the <see cref="Domain.Entities.LiveGameSession"/> to ensure has a companion.</param>
-internal sealed record EnsureCompanionCommand(Guid LiveSessionId) : ICommand;
+internal sealed record EnsureCompanionCommand(Guid LiveSessionId) : ICommand<Guid?>;

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/LiveSessions/EnsureCompanionCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/LiveSessions/EnsureCompanionCommandHandler.cs
@@ -1,0 +1,107 @@
+using Api.BoundedContexts.GameManagement.Application.Services;
+using Api.BoundedContexts.GameManagement.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.GameManagement.Application.Commands.LiveSessions;
+
+/// <summary>
+/// Handles <see cref="EnsureCompanionCommand"/>: lazily creates a <c>SessionTracking.Session</c>
+/// companion for live sessions that pre-date SP0 (ADR-083), wiring <c>TrackingSessionId</c> so
+/// that the SSE forwarder can broadcast domain events to the companion channel.
+///
+/// <para><strong>Guard semantics (no-op early exits):</strong></para>
+/// <list type="bullet">
+///   <item><c>TrackingSessionId != null</c> → already has a companion; return immediately.</item>
+///   <item><c>GameId == null</c> → free-form session; cannot have a <c>GameSpecific</c> companion; return.</item>
+/// </list>
+///
+/// <para><strong>Happy path:</strong></para>
+/// <list type="number">
+///   <item>Fetch session via <see cref="ILiveSessionRepository.GetByIdAsync"/>.</item>
+///   <item>Call <see cref="ICompanionSessionService.CreateCompanionAsync"/> (add-only, no SaveChanges).</item>
+///   <item><see cref="Domain.Entities.LiveGameSession.SetTrackingSessionId"/> → set the cross-BC bridge.</item>
+///   <item><see cref="ILiveSessionRepository.UpdateAsync"/> → stage the change.</item>
+///   <item><see cref="IUnitOfWork.SaveChangesAsync"/> → single atomic commit (ADR-060).</item>
+/// </list>
+///
+/// <para><strong>Race safety (xmin optimistic concurrency, ADR-060):</strong></para>
+/// On <see cref="DbUpdateConcurrencyException"/>: re-fetch the session. If <c>TrackingSessionId</c>
+/// is now non-null another concurrent caller already won the race → return successfully (idempotent).
+/// Otherwise rethrow so the caller can decide.
+/// The losing caller's <c>CreateCompanionAsync</c> companion is discarded (its <c>AddAsync</c>
+/// was not committed — rollback is natural).
+///
+/// Issue #2600 SP5-c Task 1.
+/// </summary>
+internal sealed class EnsureCompanionCommandHandler : ICommandHandler<EnsureCompanionCommand>
+{
+    private readonly ILiveSessionRepository _liveSessionRepository;
+    private readonly ICompanionSessionService _companionSessionService;
+    private readonly IUnitOfWork _unitOfWork;
+
+    public EnsureCompanionCommandHandler(
+        ILiveSessionRepository liveSessionRepository,
+        ICompanionSessionService companionSessionService,
+        IUnitOfWork unitOfWork)
+    {
+        _liveSessionRepository = liveSessionRepository
+            ?? throw new ArgumentNullException(nameof(liveSessionRepository));
+        _companionSessionService = companionSessionService
+            ?? throw new ArgumentNullException(nameof(companionSessionService));
+        _unitOfWork = unitOfWork
+            ?? throw new ArgumentNullException(nameof(unitOfWork));
+    }
+
+    public async Task Handle(EnsureCompanionCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var session = await _liveSessionRepository
+            .GetByIdAsync(command.LiveSessionId, cancellationToken)
+            .ConfigureAwait(false)
+            ?? throw new NotFoundException("LiveGameSession", command.LiveSessionId.ToString());
+
+        // Guard: already has a companion OR free-form (no GameId) → no-op.
+        if (session.TrackingSessionId != null || session.GameId == null)
+            return;
+
+        // Create the companion (add-only — no SaveChanges inside).
+        var companionId = await _companionSessionService
+            .CreateCompanionAsync(session.CreatedByUserId, session.GameId.Value, cancellationToken)
+            .ConfigureAwait(false);
+
+        session.SetTrackingSessionId(companionId);
+
+        await _liveSessionRepository
+            .UpdateAsync(session, cancellationToken)
+            .ConfigureAwait(false);
+
+        try
+        {
+            await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (DbUpdateConcurrencyException)
+        {
+            // Race: another concurrent subscriber already created the companion.
+            // Re-fetch to check.
+            var refreshed = await _liveSessionRepository
+                .GetByIdAsync(command.LiveSessionId, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (refreshed?.TrackingSessionId != null)
+            {
+                // Another caller won the race and committed successfully.
+                // The companion we added (via CreateCompanionAsync) was never committed
+                // (SaveChanges failed → EF rolled back the transaction) — no orphan.
+                // Return idempotently.
+                return;
+            }
+
+            // Genuine concurrency conflict with something else → rethrow for the caller.
+            throw;
+        }
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/LiveSessions/EnsureCompanionCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/LiveSessions/EnsureCompanionCommandHandler.cs
@@ -14,8 +14,8 @@ namespace Api.BoundedContexts.GameManagement.Application.Commands.LiveSessions;
 ///
 /// <para><strong>Guard semantics (no-op early exits):</strong></para>
 /// <list type="bullet">
-///   <item><c>TrackingSessionId != null</c> → already has a companion; return immediately.</item>
-///   <item><c>GameId == null</c> → free-form session; cannot have a <c>GameSpecific</c> companion; return.</item>
+///   <item><c>TrackingSessionId != null</c> → already has a companion; returns existing id.</item>
+///   <item><c>GameId == null</c> → free-form session; cannot have a <c>GameSpecific</c> companion; returns null.</item>
 /// </list>
 ///
 /// <para><strong>Happy path:</strong></para>
@@ -25,18 +25,25 @@ namespace Api.BoundedContexts.GameManagement.Application.Commands.LiveSessions;
 ///   <item><see cref="Domain.Entities.LiveGameSession.SetTrackingSessionId"/> → set the cross-BC bridge.</item>
 ///   <item><see cref="ILiveSessionRepository.UpdateAsync"/> → stage the change.</item>
 ///   <item><see cref="IUnitOfWork.SaveChangesAsync"/> → single atomic commit (ADR-060).</item>
+///   <item>Returns the new <c>TrackingSessionId</c>.</item>
 /// </list>
 ///
 /// <para><strong>Race safety (xmin optimistic concurrency, ADR-060):</strong></para>
 /// On <see cref="DbUpdateConcurrencyException"/>: re-fetch the session. If <c>TrackingSessionId</c>
-/// is now non-null another concurrent caller already won the race → return successfully (idempotent).
+/// is now non-null another concurrent caller already won the race → return that winner's id (idempotent).
 /// Otherwise rethrow so the caller can decide.
 /// The losing caller's <c>CreateCompanionAsync</c> companion is discarded (its <c>AddAsync</c>
 /// was not committed — rollback is natural).
 ///
+/// <para><strong>Return value:</strong></para>
+/// <c>Guid?</c> — the <c>TrackingSessionId</c> after the command completes:
+/// non-null = companion linked (pre-existing or just created); null = free-form, no companion.
+/// The caller uses this to avoid emitting a stale <c>X-Warning-Code: stream-not-linked</c>
+/// header on the subscribe that first links the session (Issue #2600 final-review fix).
+///
 /// Issue #2600 SP5-c Task 1.
 /// </summary>
-internal sealed class EnsureCompanionCommandHandler : ICommandHandler<EnsureCompanionCommand>
+internal sealed class EnsureCompanionCommandHandler : ICommandHandler<EnsureCompanionCommand, Guid?>
 {
     private readonly ILiveSessionRepository _liveSessionRepository;
     private readonly ICompanionSessionService _companionSessionService;
@@ -55,7 +62,7 @@ internal sealed class EnsureCompanionCommandHandler : ICommandHandler<EnsureComp
             ?? throw new ArgumentNullException(nameof(unitOfWork));
     }
 
-    public async Task Handle(EnsureCompanionCommand command, CancellationToken cancellationToken)
+    public async Task<Guid?> Handle(EnsureCompanionCommand command, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(command);
 
@@ -64,9 +71,14 @@ internal sealed class EnsureCompanionCommandHandler : ICommandHandler<EnsureComp
             .ConfigureAwait(false)
             ?? throw new NotFoundException("LiveGameSession", command.LiveSessionId.ToString());
 
-        // Guard: already has a companion OR free-form (no GameId) → no-op.
-        if (session.TrackingSessionId != null || session.GameId == null)
-            return;
+        // Guard: already has a companion → no-op; return the existing id so the caller knows
+        // the session IS linked.
+        if (session.TrackingSessionId != null)
+            return session.TrackingSessionId;
+
+        // Guard: free-form session (no GameId) → cannot have a GameSpecific companion; return null.
+        if (session.GameId == null)
+            return null;
 
         // Create the companion (add-only — no SaveChanges inside).
         var companionId = await _companionSessionService
@@ -82,6 +94,7 @@ internal sealed class EnsureCompanionCommandHandler : ICommandHandler<EnsureComp
         try
         {
             await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            return companionId;
         }
         catch (DbUpdateConcurrencyException)
         {
@@ -96,8 +109,8 @@ internal sealed class EnsureCompanionCommandHandler : ICommandHandler<EnsureComp
                 // Another caller won the race and committed successfully.
                 // The companion we added (via CreateCompanionAsync) was never committed
                 // (SaveChanges failed → EF rolled back the transaction) — no orphan.
-                // Return idempotently.
-                return;
+                // Return the winner's TrackingSessionId so the caller knows the session IS linked.
+                return refreshed.TrackingSessionId;
             }
 
             // Genuine concurrency conflict with something else → rethrow for the caller.

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/LiveGameSession.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/LiveGameSession.cs
@@ -838,6 +838,43 @@ internal sealed class LiveGameSession : AggregateRoot<Guid>
         UpdatedAt = now;
     }
 
+    // === Companion ===
+
+    /// <summary>
+    /// Lazily assigns the SessionTracking companion id to a legacy live session
+    /// that was created before SP0 (i.e. <see cref="TrackingSessionId"/> is <see langword="null"/>).
+    /// <para>
+    /// Idempotency semantics (explicit, by owner decision B):
+    /// <list type="bullet">
+    ///   <item>If <see cref="TrackingSessionId"/> is <see langword="null"/> → sets the property.</item>
+    ///   <item>If <see cref="TrackingSessionId"/> equals <paramref name="companionId"/> → no-op (idempotent).</item>
+    ///   <item>If <see cref="TrackingSessionId"/> is already set to a <em>different</em> value →
+    ///         throws <see cref="InvalidOperationException"/> (programmer error: two conflicting companions).</item>
+    /// </list>
+    /// </para>
+    /// Invoked exclusively by <c>EnsureCompanionCommandHandler</c> (ADR-083 SP5-c, Issue #2600).
+    /// </summary>
+    /// <param name="companionId">The id of the newly-created <c>SessionTracking.Session</c> companion.</param>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="companionId"/> is <see cref="Guid.Empty"/>.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when <see cref="TrackingSessionId"/> is already set to a different, non-empty value.
+    /// </exception>
+    public void SetTrackingSessionId(Guid companionId)
+    {
+        if (companionId == Guid.Empty)
+            throw new ArgumentException("Companion id cannot be empty.", nameof(companionId));
+
+        if (TrackingSessionId == companionId)
+            return; // no-op — idempotent
+
+        if (TrackingSessionId.HasValue)
+            throw new InvalidOperationException(
+                $"TrackingSessionId is already set to {TrackingSessionId.Value} on live session {Id}. " +
+                $"Cannot overwrite with a different companion id {companionId}.");
+
+        TrackingSessionId = companionId;
+    }
+
     // === Query Methods ===
 
     /// <summary>

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentCommandHandler.cs
@@ -3,6 +3,7 @@ using System.Text;
 using System.Text.Json;
 using Api.BoundedContexts.Administration.Application.Services;
 using Api.BoundedContexts.KnowledgeBase.Application.Commands;
+using Api.BoundedContexts.KnowledgeBase.Application.Configuration;
 using Api.BoundedContexts.KnowledgeBase.Application.Models;
 using Api.BoundedContexts.KnowledgeBase.Application.Services;
 using Api.BoundedContexts.KnowledgeBase.Domain.Entities;
@@ -55,6 +56,7 @@ internal sealed class ChatWithSessionAgentCommandHandler : IStreamingQueryHandle
     private readonly ICopyrightFallbackMessageProvider _fallbackMessageProvider;
     private readonly IOptions<CopyrightLeakGuardOptions> _copyrightOptions;
     private readonly ILiveSessionStreamGateway _liveSessionStreamGateway;
+    private readonly IOptions<SessionAgentOptions> _sessionAgentOptions;
 
     // Summary generation thresholds
     private const int SummaryThreshold = 10;
@@ -64,6 +66,9 @@ internal sealed class ChatWithSessionAgentCommandHandler : IStreamingQueryHandle
     internal const string AgentUnavailableErrorCode = "AGENT_TEMPORARILY_UNAVAILABLE";
     internal const string AgentUnavailableItalianMessage =
         "Agente AI temporaneamente non disponibile. Riprova tra qualche minuto o usa gli strumenti manuali.";
+
+    // SP5-c #2600: per-chunk LLM stream timeout error code
+    internal const string LlmTimeoutErrorCode = "LLM_TIMEOUT";
 
     public ChatWithSessionAgentCommandHandler(
         IAgentSessionRepository sessionRepository,
@@ -83,7 +88,8 @@ internal sealed class ChatWithSessionAgentCommandHandler : IStreamingQueryHandle
         ICopyrightLeakGuard copyrightLeakGuard,
         ICopyrightFallbackMessageProvider fallbackMessageProvider,
         IOptions<CopyrightLeakGuardOptions> copyrightOptions,
-        ILiveSessionStreamGateway liveSessionStreamGateway)
+        ILiveSessionStreamGateway liveSessionStreamGateway,
+        IOptions<SessionAgentOptions>? sessionAgentOptions = null)
     {
         _sessionRepository = sessionRepository ?? throw new ArgumentNullException(nameof(sessionRepository));
         _definitionRepository = definitionRepository ?? throw new ArgumentNullException(nameof(definitionRepository));
@@ -103,6 +109,7 @@ internal sealed class ChatWithSessionAgentCommandHandler : IStreamingQueryHandle
         _fallbackMessageProvider = fallbackMessageProvider ?? throw new ArgumentNullException(nameof(fallbackMessageProvider));
         _copyrightOptions = copyrightOptions ?? throw new ArgumentNullException(nameof(copyrightOptions));
         _liveSessionStreamGateway = liveSessionStreamGateway ?? throw new ArgumentNullException(nameof(liveSessionStreamGateway));
+        _sessionAgentOptions = sessionAgentOptions ?? Options.Create(new SessionAgentOptions());
     }
 
     /// <summary>
@@ -334,24 +341,94 @@ internal sealed class ChatWithSessionAgentCommandHandler : IStreamingQueryHandle
         var fullResponse = new StringBuilder();
         LlmUsage? finalUsage = null;
 
-        // Note: yield return cannot be in try-catch, so we collect chunks and capture errors
+        // SP5-c #2600: per-chunk deadline.
+        // NEEDS TUNING: observe p99 inter-chunk latency in production before tightening.
+        var perChunkTimeout = TimeSpan.FromSeconds(
+            _sessionAgentOptions.Value.LlmPerChunkTimeoutSeconds);
+
+        // Note: yield return cannot be in try-catch, so we collect chunks and capture errors.
+        // The per-chunk timeout is applied via a linked CancellationTokenSource whose deadline
+        // is armed just before each MoveNextAsync and disarmed immediately after a chunk arrives,
+        // so chunk-processing time (buffering, logging) does NOT count against the next deadline.
         var chunks = new List<StreamChunk>();
         string? streamError = null;
+        bool chunkTimedOut = false;
+        bool clientDisconnected = false;
         try
         {
-            await foreach (var chunk in _llmService.GenerateCompletionStreamAsync(
+            using var streamCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            var enumerator = _llmService.GenerateCompletionStreamAsync(
                 systemPrompt,
                 assembled.UserPrompt,
                 RequestSource.AgentTask,
-                cancellationToken).ConfigureAwait(false))
+                streamCts.Token).GetAsyncEnumerator(streamCts.Token);
+            await using (enumerator.ConfigureAwait(false))
             {
-                chunks.Add(chunk);
+                while (true)
+                {
+                    // Arm per-chunk deadline before awaiting the next chunk.
+                    streamCts.CancelAfter(perChunkTimeout);
+
+                    bool moved;
+                    try
+                    {
+                        moved = await enumerator.MoveNextAsync().ConfigureAwait(false);
+                    }
+                    catch (OperationCanceledException)
+                    {
+                        if (streamCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
+                        {
+                            // The streamCts deadline fired — the chunk took too long.
+                            chunkTimedOut = true;
+                        }
+                        else
+                        {
+                            // The original client ct was cancelled (normal disconnect).
+                            clientDisconnected = true;
+                        }
+                        break;
+                    }
+
+                    // Disarm the deadline now that a chunk has arrived (or the stream ended).
+                    // Processing the chunk does NOT count against the NEXT chunk's deadline.
+                    streamCts.CancelAfter(Timeout.InfiniteTimeSpan);
+
+                    if (!moved)
+                    {
+                        break;
+                    }
+
+                    chunks.Add(enumerator.Current);
+                }
             }
         }
         catch (Exception ex)
         {
             _logger.LogError(ex, "LLM streaming failed for session {SessionId}", command.AgentSessionId);
             streamError = ex.Message;
+        }
+
+        // Handle timeout — yield the timeout error event (outside the try/catch per C# iterator rules).
+        if (chunkTimedOut)
+        {
+            _logger.LogWarning(
+                "LLM stream per-chunk timeout ({Timeout:g}) exceeded for session {SessionId}",
+                perChunkTimeout, command.AgentSessionId);
+            yield return CreateEvent(
+                StreamingEventType.Error,
+                new StreamingError(
+                    $"LLM stream timed out waiting for next chunk (deadline: {perChunkTimeout.TotalSeconds:0.#}s)",
+                    LlmTimeoutErrorCode));
+            yield break;
+        }
+
+        // Handle client disconnect — stop silently (normal disconnect, no error event).
+        if (clientDisconnected)
+        {
+            _logger.LogDebug(
+                "Client disconnected mid-stream for session {SessionId}; stream stopped",
+                command.AgentSessionId);
+            yield break;
         }
 
         if (streamError != null)

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Configuration/SessionAgentOptions.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Configuration/SessionAgentOptions.cs
@@ -1,0 +1,20 @@
+namespace Api.BoundedContexts.KnowledgeBase.Application.Configuration;
+
+/// <summary>
+/// Configuration for the session-agent chat handler (Issue #2600 — SP5-c).
+/// Bound from the "SessionAgent" section of appsettings.json.
+/// </summary>
+internal sealed class SessionAgentOptions
+{
+    /// <summary>
+    /// Maximum time (in seconds) allowed between consecutive LLM stream chunks
+    /// before the handler treats the stream as hung and surfaces a timeout error.
+    /// Default: 30 seconds.
+    ///
+    /// NEEDS TUNING: observe p99 inter-chunk latency in production before tightening.
+    /// A per-chunk budget of 30 s is intentionally generous to avoid false positives
+    /// on slow first-chunks from cold providers. Fractional values (e.g. 0.05) are
+    /// valid and used in unit tests to avoid waiting 30 s.
+    /// </summary>
+    public double LlmPerChunkTimeoutSeconds { get; set; } = 30.0;
+}

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/DependencyInjection/KnowledgeBaseServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/DependencyInjection/KnowledgeBaseServiceExtensions.cs
@@ -68,6 +68,17 @@ internal static class KnowledgeBaseServiceExtensions
         services.AddSingleton<ICopyrightLeakGuard, NgramCopyrightLeakGuard>();
         services.AddSingleton<ICopyrightFallbackMessageProvider, DefaultCopyrightFallbackMessageProvider>();
 
+        // SP5-c #2600: session-agent options (per-chunk LLM stream timeout).
+        var sessionAgentOptionsBuilder = services.AddOptions<SessionAgentOptions>()
+            .Validate(
+                opts => opts.LlmPerChunkTimeoutSeconds > 0,
+                "SessionAgent:LlmPerChunkTimeoutSeconds must be > 0");
+        if (configuration != null)
+        {
+            sessionAgentOptionsBuilder.Bind(configuration.GetSection("SessionAgent"));
+        }
+        sessionAgentOptionsBuilder.ValidateOnStart();
+
         return services;
     }
 

--- a/apps/api/src/Api/Routing/LiveSessionEndpoints.cs
+++ b/apps/api/src/Api/Routing/LiveSessionEndpoints.cs
@@ -982,6 +982,14 @@ internal static class LiveSessionEndpoints
         if (!ctx.Authorized)
             return Results.StatusCode(403);
 
+        // SP5-c (#2600 Task 2): lazily provision a companion for legacy GameId-backed sessions
+        // that pre-date the SP0 Saga (TrackingSessionId == null && GameId != null).
+        // The handler is idempotent and is a no-op for free-form (GameId == null) sessions and
+        // for sessions that already have a companion. The gateway re-reads the session inside
+        // SubscribeAsync so it will pick up the freshly-persisted TrackingSessionId.
+        if (!ctx.HasCompanion)
+            await mediator.Send(new EnsureCompanionCommand(sessionId), ct).ConfigureAwait(false);
+
         // Set SSE response headers — must happen before the first Write call.
         httpContext.Response.Headers.Append("Content-Type", "text/event-stream");
         httpContext.Response.Headers.Append("Cache-Control", "no-cache");

--- a/apps/api/src/Api/Routing/LiveSessionEndpoints.cs
+++ b/apps/api/src/Api/Routing/LiveSessionEndpoints.cs
@@ -987,8 +987,25 @@ internal static class LiveSessionEndpoints
         // The handler is idempotent and is a no-op for free-form (GameId == null) sessions and
         // for sessions that already have a companion. The gateway re-reads the session inside
         // SubscribeAsync so it will pick up the freshly-persisted TrackingSessionId.
-        if (!ctx.HasCompanion)
-            await mediator.Send(new EnsureCompanionCommand(sessionId), ct).ConfigureAwait(false);
+        //
+        // EnsureCompanionCommand returns the post-ensure TrackingSessionId:
+        //   non-null → session is now linked (pre-existing OR just created on this subscribe)
+        //   null     → free-form session; genuinely unlinked; stream will be empty.
+        // We use this POST-ensure value for the warning header to avoid emitting a stale
+        // "stream-not-linked" on the exact subscribe that just fixed the session (final-review fix).
+        bool isLinkedAfterEnsure;
+        if (ctx.HasCompanion)
+        {
+            // Already linked before we ran — skip the command, preserve the known state.
+            isLinkedAfterEnsure = true;
+        }
+        else
+        {
+            var ensuredTrackingId = await mediator
+                .Send(new EnsureCompanionCommand(sessionId), ct)
+                .ConfigureAwait(false);
+            isLinkedAfterEnsure = ensuredTrackingId.HasValue;
+        }
 
         // Set SSE response headers — must happen before the first Write call.
         httpContext.Response.Headers.Append("Content-Type", "text/event-stream");
@@ -998,7 +1015,8 @@ internal static class LiveSessionEndpoints
 
         // Warn caller when session has no companion: stream will be empty (gateway yields nothing).
         // The connection stays open with heartbeats so the client can reconnect after SP0 is provisioned.
-        if (!ctx.HasCompanion)
+        // Uses the POST-ensure value so a lazy-created companion on this subscribe does NOT trigger the warning.
+        if (!isLinkedAfterEnsure)
             httpContext.Response.Headers.Append("X-Warning-Code", "stream-not-linked");
 
         // Commit the 200 status + SSE headers immediately, before any blocking gateway call.

--- a/apps/api/src/Api/appsettings.json
+++ b/apps/api/src/Api/appsettings.json
@@ -305,6 +305,10 @@
     "UseAlternativeModel": false,
     "AlternativeModelTrafficPercentage": 0
   },
+  "SessionAgent": {
+    "_Comment": "SP5-c #2600: LlmPerChunkTimeoutSeconds — max seconds between consecutive LLM stream chunks. NEEDS TUNING: observe p99 inter-chunk latency in production before tightening. Default 30 s is intentionally generous.",
+    "LlmPerChunkTimeoutSeconds": 30.0
+  },
   "LlmRouting": {
     "Comment": "ISSUE-958: Hybrid LLM architecture - user-tier based routing with traffic split",
     "AnonymousModel": "meta-llama/llama-3.3-70b-instruct:free",

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/LiveSessions/EnsureCompanionCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/LiveSessions/EnsureCompanionCommandHandlerTests.cs
@@ -1,0 +1,341 @@
+using Api.BoundedContexts.GameManagement.Application.Commands.LiveSessions;
+using Api.BoundedContexts.GameManagement.Application.Services;
+using Api.BoundedContexts.GameManagement.Domain.Entities;
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+using Api.BoundedContexts.GameManagement.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Application.Handlers.LiveSessions;
+
+/// <summary>
+/// Unit tests for <see cref="EnsureCompanionCommandHandler"/>.
+/// TDD: Tests written first (RED → GREEN).
+/// Issue #2600 SP5-c Task 1.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "GameManagement")]
+public class EnsureCompanionCommandHandlerTests
+{
+    private readonly Mock<ILiveSessionRepository> _repoMock;
+    private readonly Mock<ICompanionSessionService> _companionMock;
+    private readonly Mock<IUnitOfWork> _uowMock;
+    private readonly EnsureCompanionCommandHandler _handler;
+
+    private static readonly Guid DefaultSessionId = Guid.NewGuid();
+    private static readonly Guid DefaultUserId = Guid.NewGuid();
+    private static readonly Guid DefaultGameId = Guid.NewGuid();
+    private static readonly Guid DefaultCompanionId = Guid.NewGuid();
+
+    public EnsureCompanionCommandHandlerTests()
+    {
+        _repoMock = new Mock<ILiveSessionRepository>();
+        _companionMock = new Mock<ICompanionSessionService>();
+        _uowMock = new Mock<IUnitOfWork>();
+
+        _uowMock
+            .Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        _handler = new EnsureCompanionCommandHandler(
+            _repoMock.Object,
+            _companionMock.Object,
+            _uowMock.Object);
+    }
+
+    // ── Helpers ────────────────────────────────────────────────────────────────
+
+    /// <summary>Creates a session with TrackingSessionId == null and a valid GameId.</summary>
+    private static LiveGameSession CreateSessionNeedsCompanion()
+        => LiveGameSession.Create(
+            DefaultSessionId,
+            DefaultUserId,
+            "Mage Knight",
+            TimeProvider.System,
+            gameId: DefaultGameId,
+            trackingSessionId: null);
+
+    /// <summary>Creates a session that already has a companion.</summary>
+    private static LiveGameSession CreateSessionAlreadyHasCompanion()
+        => LiveGameSession.Create(
+            DefaultSessionId,
+            DefaultUserId,
+            "Mage Knight",
+            TimeProvider.System,
+            gameId: DefaultGameId,
+            trackingSessionId: Guid.NewGuid());
+
+    /// <summary>Creates a free-form session (GameId == null).</summary>
+    private static LiveGameSession CreateFreeFormSession()
+        => LiveGameSession.Create(
+            DefaultSessionId,
+            DefaultUserId,
+            "Free Play",
+            TimeProvider.System,
+            gameId: null,
+            trackingSessionId: null);
+
+    private void SetupRepoGetById(Guid sessionId, LiveGameSession? session)
+    {
+        _repoMock
+            .Setup(r => r.GetByIdAsync(sessionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(session);
+    }
+
+    private void SetupCompanion(Guid companionId)
+    {
+        _companionMock
+            .Setup(c => c.CreateCompanionAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(companionId);
+    }
+
+    // ── (a) Session needs companion (null TrackingSessionId + GameId present) ──
+
+    [Fact]
+    public async Task Handle_NullCompanionAndGameIdPresent_CreatesCompanionOnce()
+    {
+        // Arrange
+        var session = CreateSessionNeedsCompanion();
+        SetupRepoGetById(DefaultSessionId, session);
+        SetupCompanion(DefaultCompanionId);
+        var cmd = new EnsureCompanionCommand(DefaultSessionId);
+
+        // Act
+        await _handler.Handle(cmd, CancellationToken.None);
+
+        // Assert
+        _companionMock.Verify(
+            c => c.CreateCompanionAsync(DefaultUserId, DefaultGameId, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_NullCompanionAndGameIdPresent_SetsTrackingSessionId()
+    {
+        // Arrange
+        var session = CreateSessionNeedsCompanion();
+        SetupRepoGetById(DefaultSessionId, session);
+        SetupCompanion(DefaultCompanionId);
+        var cmd = new EnsureCompanionCommand(DefaultSessionId);
+
+        // Act
+        await _handler.Handle(cmd, CancellationToken.None);
+
+        // Assert
+        session.TrackingSessionId.Should().Be(DefaultCompanionId);
+    }
+
+    [Fact]
+    public async Task Handle_NullCompanionAndGameIdPresent_SavesOnce()
+    {
+        // Arrange
+        var session = CreateSessionNeedsCompanion();
+        SetupRepoGetById(DefaultSessionId, session);
+        SetupCompanion(DefaultCompanionId);
+        var cmd = new EnsureCompanionCommand(DefaultSessionId);
+
+        // Act
+        await _handler.Handle(cmd, CancellationToken.None);
+
+        // Assert
+        _uowMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+        _repoMock.Verify(r => r.UpdateAsync(session, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    // ── (b) Session already has a companion → no-op ────────────────────────────
+
+    [Fact]
+    public async Task Handle_AlreadyHasCompanion_DoesNotCallCreateCompanion()
+    {
+        // Arrange
+        var session = CreateSessionAlreadyHasCompanion();
+        SetupRepoGetById(DefaultSessionId, session);
+        var cmd = new EnsureCompanionCommand(DefaultSessionId);
+
+        // Act
+        await _handler.Handle(cmd, CancellationToken.None);
+
+        // Assert
+        _companionMock.Verify(
+            c => c.CreateCompanionAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_AlreadyHasCompanion_DoesNotSave()
+    {
+        // Arrange
+        var session = CreateSessionAlreadyHasCompanion();
+        SetupRepoGetById(DefaultSessionId, session);
+        var cmd = new EnsureCompanionCommand(DefaultSessionId);
+
+        // Act
+        await _handler.Handle(cmd, CancellationToken.None);
+
+        // Assert
+        _uowMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    // ── (c) Free-form session (GameId == null) → no-op ────────────────────────
+
+    [Fact]
+    public async Task Handle_FreeFormSession_DoesNotCallCreateCompanion()
+    {
+        // Arrange
+        var session = CreateFreeFormSession();
+        SetupRepoGetById(DefaultSessionId, session);
+        var cmd = new EnsureCompanionCommand(DefaultSessionId);
+
+        // Act
+        await _handler.Handle(cmd, CancellationToken.None);
+
+        // Assert
+        _companionMock.Verify(
+            c => c.CreateCompanionAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_FreeFormSession_DoesNotSave()
+    {
+        // Arrange
+        var session = CreateFreeFormSession();
+        SetupRepoGetById(DefaultSessionId, session);
+        var cmd = new EnsureCompanionCommand(DefaultSessionId);
+
+        // Act
+        await _handler.Handle(cmd, CancellationToken.None);
+
+        // Assert
+        _uowMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    // ── Session not found → NotFoundException ─────────────────────────────────
+
+    [Fact]
+    public async Task Handle_SessionNotFound_ThrowsNotFoundException()
+    {
+        // Arrange
+        SetupRepoGetById(DefaultSessionId, null);
+        var cmd = new EnsureCompanionCommand(DefaultSessionId);
+
+        // Act & Assert
+        var act = () => _handler.Handle(cmd, CancellationToken.None);
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+
+    [Fact]
+    public async Task Handle_SessionNotFound_DoesNotCallCreateCompanion()
+    {
+        // Arrange
+        SetupRepoGetById(DefaultSessionId, null);
+        var cmd = new EnsureCompanionCommand(DefaultSessionId);
+
+        // Act
+        try { await _handler.Handle(cmd, CancellationToken.None); } catch { /* expected */ }
+
+        // Assert
+        _companionMock.Verify(
+            c => c.CreateCompanionAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    // ── (d) Race: DbUpdateConcurrencyException → idempotent success ───────────
+
+    [Fact]
+    public async Task Handle_ConcurrencyConflict_WhenRefetchShowsCompanionSet_CompletesSuccessfully()
+    {
+        // Arrange — first GetById returns a session that needs companion;
+        // after the conflict, second GetById returns one already set by the winner.
+        var sessionNeedsCompanion = CreateSessionNeedsCompanion();
+        var sessionWinnerSet = CreateSessionAlreadyHasCompanion();
+
+        var callCount = 0;
+        _repoMock
+            .Setup(r => r.GetByIdAsync(DefaultSessionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() =>
+            {
+                callCount++;
+                return callCount == 1 ? sessionNeedsCompanion : sessionWinnerSet;
+            });
+
+        SetupCompanion(DefaultCompanionId);
+
+        _uowMock
+            .Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new DbUpdateConcurrencyException("xmin conflict"));
+
+        var cmd = new EnsureCompanionCommand(DefaultSessionId);
+
+        // Act — should NOT throw
+        var act = () => _handler.Handle(cmd, CancellationToken.None);
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task Handle_ConcurrencyConflict_WhenRefetchShowsCompanionSet_DoesNotCreateSecondCompanion()
+    {
+        // Arrange
+        var sessionNeedsCompanion = CreateSessionNeedsCompanion();
+        var sessionWinnerSet = CreateSessionAlreadyHasCompanion();
+
+        var callCount = 0;
+        _repoMock
+            .Setup(r => r.GetByIdAsync(DefaultSessionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() =>
+            {
+                callCount++;
+                return callCount == 1 ? sessionNeedsCompanion : sessionWinnerSet;
+            });
+
+        SetupCompanion(DefaultCompanionId);
+
+        _uowMock
+            .Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new DbUpdateConcurrencyException("xmin conflict"));
+
+        var cmd = new EnsureCompanionCommand(DefaultSessionId);
+
+        // Act
+        try { await _handler.Handle(cmd, CancellationToken.None); } catch { /* expected */ }
+
+        // Assert — CreateCompanionAsync was called exactly once (not a second time)
+        _companionMock.Verify(
+            c => c.CreateCompanionAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ConcurrencyConflict_WhenRefetchStillNoCompanion_Rethrows()
+    {
+        // Arrange — both fetches return a session without companion → genuine conflict, rethrow
+        var session1 = CreateSessionNeedsCompanion();
+        var session2 = CreateSessionNeedsCompanion();
+
+        var callCount = 0;
+        _repoMock
+            .Setup(r => r.GetByIdAsync(DefaultSessionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() =>
+            {
+                callCount++;
+                return callCount == 1 ? session1 : session2;
+            });
+
+        SetupCompanion(DefaultCompanionId);
+
+        _uowMock
+            .Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new DbUpdateConcurrencyException("xmin conflict"));
+
+        var cmd = new EnsureCompanionCommand(DefaultSessionId);
+
+        // Act & Assert — should rethrow
+        var act = () => _handler.Handle(cmd, CancellationToken.None);
+        await act.Should().ThrowAsync<DbUpdateConcurrencyException>();
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/LiveSessions/EnsureCompanionCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/LiveSessions/EnsureCompanionCommandHandlerTests.cs
@@ -147,7 +147,38 @@ public class EnsureCompanionCommandHandlerTests
         _repoMock.Verify(r => r.UpdateAsync(session, It.IsAny<CancellationToken>()), Times.Once);
     }
 
+    [Fact]
+    public async Task Handle_NullCompanionAndGameIdPresent_ReturnsNewCompanionId()
+    {
+        // Arrange — the command must return the newly created TrackingSessionId so the
+        // endpoint can avoid a stale X-Warning-Code: stream-not-linked on the linking subscribe.
+        var session = CreateSessionNeedsCompanion();
+        SetupRepoGetById(DefaultSessionId, session);
+        SetupCompanion(DefaultCompanionId);
+        var cmd = new EnsureCompanionCommand(DefaultSessionId);
+
+        // Act
+        var result = await _handler.Handle(cmd, CancellationToken.None);
+
+        // Assert
+        result.Should().Be(DefaultCompanionId,
+            "handler must return the newly created TrackingSessionId so the caller " +
+            "knows the session is now linked");
+    }
+
     // ── (b) Session already has a companion → no-op ────────────────────────────
+
+    private static readonly Guid ExistingCompanionId = Guid.NewGuid();
+
+    /// <summary>Creates a session that already has a companion with a known, captured id.</summary>
+    private static LiveGameSession CreateSessionAlreadyHasCompanionWithKnownId()
+        => LiveGameSession.Create(
+            DefaultSessionId,
+            DefaultUserId,
+            "Mage Knight",
+            TimeProvider.System,
+            gameId: DefaultGameId,
+            trackingSessionId: ExistingCompanionId);
 
     [Fact]
     public async Task Handle_AlreadyHasCompanion_DoesNotCallCreateCompanion()
@@ -179,6 +210,24 @@ public class EnsureCompanionCommandHandlerTests
 
         // Assert
         _uowMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_AlreadyHasCompanion_ReturnsExistingTrackingSessionId()
+    {
+        // Arrange — session already has a companion; the command must return the existing id
+        // (not null) so the endpoint knows the session is still linked.
+        var session = CreateSessionAlreadyHasCompanionWithKnownId();
+        SetupRepoGetById(DefaultSessionId, session);
+        var cmd = new EnsureCompanionCommand(DefaultSessionId);
+
+        // Act
+        var result = await _handler.Handle(cmd, CancellationToken.None);
+
+        // Assert
+        result.Should().Be(ExistingCompanionId,
+            "handler must return the pre-existing TrackingSessionId so the caller " +
+            "knows the session is already linked");
     }
 
     // ── (c) Free-form session (GameId == null) → no-op ────────────────────────
@@ -213,6 +262,23 @@ public class EnsureCompanionCommandHandlerTests
 
         // Assert
         _uowMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_FreeFormSession_ReturnsNull()
+    {
+        // Arrange — free-form session (GameId == null) must return null so the endpoint
+        // correctly emits X-Warning-Code: stream-not-linked (stream genuinely unlinked).
+        var session = CreateFreeFormSession();
+        SetupRepoGetById(DefaultSessionId, session);
+        var cmd = new EnsureCompanionCommand(DefaultSessionId);
+
+        // Act
+        var result = await _handler.Handle(cmd, CancellationToken.None);
+
+        // Assert
+        result.Should().BeNull(
+            "free-form sessions cannot have a companion; caller must still warn the client");
     }
 
     // ── Session not found → NotFoundException ─────────────────────────────────
@@ -275,6 +341,43 @@ public class EnsureCompanionCommandHandlerTests
         // Act — should NOT throw
         var act = () => _handler.Handle(cmd, CancellationToken.None);
         await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task Handle_ConcurrencyConflict_WhenRefetchShowsCompanionSet_ReturnsWinnersTrackingId()
+    {
+        // Arrange — after a race the loser re-fetches and must return the winner's TrackingSessionId
+        // so the endpoint knows the session IS now linked (no stale warning).
+        var sessionNeedsCompanion = CreateSessionNeedsCompanion();
+        var winnersCompanionId = Guid.NewGuid();
+        var sessionWinnerSet = LiveGameSession.Create(
+            DefaultSessionId, DefaultUserId, "Mage Knight", TimeProvider.System,
+            gameId: DefaultGameId, trackingSessionId: winnersCompanionId);
+
+        var callCount = 0;
+        _repoMock
+            .Setup(r => r.GetByIdAsync(DefaultSessionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() =>
+            {
+                callCount++;
+                return callCount == 1 ? sessionNeedsCompanion : sessionWinnerSet;
+            });
+
+        SetupCompanion(DefaultCompanionId);
+
+        _uowMock
+            .Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new DbUpdateConcurrencyException("xmin conflict"));
+
+        var cmd = new EnsureCompanionCommand(DefaultSessionId);
+
+        // Act
+        var result = await _handler.Handle(cmd, CancellationToken.None);
+
+        // Assert
+        result.Should().Be(winnersCompanionId,
+            "the losing concurrent caller must return the winner's TrackingSessionId " +
+            "so the endpoint does not emit a stale stream-not-linked warning");
     }
 
     [Fact]

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/Entities/LiveGameSession_SetTrackingSessionIdTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/Entities/LiveGameSession_SetTrackingSessionIdTests.cs
@@ -1,0 +1,83 @@
+using Api.BoundedContexts.GameManagement.Domain.Entities;
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Domain.Entities;
+
+/// <summary>
+/// Unit tests for <see cref="LiveGameSession.SetTrackingSessionId"/>.
+/// TDD: Tests written first (RED → GREEN).
+/// Issue #2600 SP5-c Task 1.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "GameManagement")]
+public class LiveGameSession_SetTrackingSessionIdTests
+{
+    private static readonly Guid UserId = Guid.NewGuid();
+    private static readonly Guid GameId = Guid.NewGuid();
+
+    private static LiveGameSession CreateSession(Guid? trackingSessionId = null)
+        => LiveGameSession.Create(
+            Guid.NewGuid(),
+            UserId,
+            "Test Game",
+            TimeProvider.System,
+            gameId: GameId,
+            trackingSessionId: trackingSessionId);
+
+    // ── Set when null ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void SetTrackingSessionId_WhenNull_SetsValue()
+    {
+        var session = CreateSession(trackingSessionId: null);
+        var companionId = Guid.NewGuid();
+
+        session.SetTrackingSessionId(companionId);
+
+        session.TrackingSessionId.Should().Be(companionId);
+    }
+
+    // ── No-op when same value ─────────────────────────────────────────────────
+
+    [Fact]
+    public void SetTrackingSessionId_WhenSameValue_IsNoOp()
+    {
+        var companionId = Guid.NewGuid();
+        var session = CreateSession(trackingSessionId: companionId);
+
+        // Must not throw and property must remain unchanged
+        var act = () => session.SetTrackingSessionId(companionId);
+        act.Should().NotThrow();
+        session.TrackingSessionId.Should().Be(companionId);
+    }
+
+    // ── Throw when different value ────────────────────────────────────────────
+
+    [Fact]
+    public void SetTrackingSessionId_WhenAlreadySetToDifferentValue_Throws()
+    {
+        var existing = Guid.NewGuid();
+        var session = CreateSession(trackingSessionId: existing);
+        var different = Guid.NewGuid();
+
+        var act = () => session.SetTrackingSessionId(different);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*TrackingSessionId*");
+    }
+
+    // ── Guard: empty Guid ────────────────────────────────────────────────────
+
+    [Fact]
+    public void SetTrackingSessionId_EmptyGuid_Throws()
+    {
+        var session = CreateSession(trackingSessionId: null);
+
+        var act = () => session.SetTrackingSessionId(Guid.Empty);
+
+        act.Should().Throw<ArgumentException>();
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentPerChunkTimeoutTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentPerChunkTimeoutTests.cs
@@ -1,0 +1,459 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using Api.BoundedContexts.Administration.Application.Services;
+using Api.BoundedContexts.GameManagement.Application.Services;
+using Api.BoundedContexts.GameManagement.Domain.Entities;
+using Api.BoundedContexts.GameManagement.Domain.Repositories;
+using Api.BoundedContexts.KnowledgeBase.Application.Commands;
+using Api.BoundedContexts.KnowledgeBase.Application.Configuration;
+using Api.BoundedContexts.KnowledgeBase.Application.Models;
+using Api.BoundedContexts.KnowledgeBase.Application.Services;
+using Api.BoundedContexts.KnowledgeBase.Domain.Entities;
+using Api.BoundedContexts.KnowledgeBase.Domain.Enums;
+using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
+using Api.BoundedContexts.KnowledgeBase.Domain.Services;
+using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
+using Api.Models;
+using Api.Services;
+using Api.SharedKernel.Application;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Domain.ValueObjects;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+// Disambiguate UserTier from two namespaces
+using SharedUserTier = Api.SharedKernel.Domain.ValueObjects.UserTier;
+
+namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Commands;
+
+/// <summary>
+/// SP5-c Task 3 (Issue #2600): Per-chunk LLM stream timeout in session agent chat.
+///
+/// Tests:
+/// T3-AC-1  A stalled chunk (no data within perChunkTimeout) → handler emits
+///          LLM_TIMEOUT error event and completes gracefully (no hang, no escaping exception).
+/// T3-AC-2  A valid stream whose chunks each arrive within the timeout, but TOTAL
+///          duration exceeds one chunk-timeout → NOT killed; full response delivered.
+///          (Verifies the disarm-between-chunks logic.)
+/// T3-AC-3  Client disconnect (original CancellationToken cancelled mid-stream) → stream
+///          stops WITHOUT emitting a timeout error event.
+/// T3-AC-4  Happy-path regression: normal fast stream yields all tokens + StreamingComplete.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "KnowledgeBase")]
+[Trait("Area", "Reliability")]
+[Trait("Issue", "2600")]
+public sealed class ChatWithSessionAgentPerChunkTimeoutTests
+{
+    // ──────────────────────────────────────────────────────────────────────────
+    // T3-AC-1: stalled chunk → LLM_TIMEOUT error, graceful completion (no hang)
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "T3-AC-1: stalled LLM chunk exceeds per-chunk timeout → LLM_TIMEOUT error event, stream completes gracefully")]
+    public async Task Handle_StalledChunk_EmitsLlmTimeoutErrorAndCompletesGracefully()
+    {
+        // Arrange: tiny per-chunk timeout (50 ms) so the test finishes quickly.
+        // The fake LLM stream stalls 500 ms — guaranteed to exceed the 50 ms deadline.
+        const double perChunkTimeoutSeconds = 0.05; // 50 ms
+
+        var llmService = new Mock<ILlmService>();
+        llmService
+            .Setup(l => l.GenerateCompletionStreamAsync(
+                It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<RequestSource>(), It.IsAny<CancellationToken>()))
+            .Returns(StalledStream(delayMs: 500));
+
+        var handler = BuildHandler(llmService.Object, perChunkTimeoutSeconds);
+        var command = BuildCommand();
+
+        var events = new List<RagStreamingEvent>();
+
+        // Overall test guard: if the handler HANGS, this CTS will unblock the drain.
+        using var testCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+        var act = async () =>
+        {
+            await foreach (var ev in handler.Handle(command, testCts.Token))
+            {
+                events.Add(ev);
+            }
+        };
+
+        // Must NOT throw — timeout must surface as a streaming error event.
+        await act.Should().NotThrowAsync(
+            "per-chunk timeout must be surfaced as a streaming error event, not an escaping exception");
+
+        // Must emit exactly one Error event with the timeout / LLM error code.
+        events.Should().Contain(
+            e => e.Type == StreamingEventType.Error,
+            "an error event must be emitted when the per-chunk deadline is exceeded");
+
+        var errorPayload = events
+            .Where(e => e.Type == StreamingEventType.Error)
+            .Select(e => e.Data)
+            .OfType<StreamingError>()
+            .FirstOrDefault();
+
+        errorPayload.Should().NotBeNull("the error event must carry a StreamingError payload");
+        errorPayload!.errorCode.Should().BeOneOf("LLM_TIMEOUT", "LLM_ERROR",
+            "the timeout must use LLM_TIMEOUT (preferred) or fallback to LLM_ERROR");
+
+        // StreamingComplete must NOT appear (the error short-circuits the happy path).
+        events.Should().NotContain(
+            e => e.Type == StreamingEventType.Complete,
+            "StreamingComplete must not be emitted when the LLM stream timed out");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // T3-AC-2: slow-but-steady stream (each chunk within timeout, total > timeout)
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "T3-AC-2: slow-but-steady stream delivers full response even when total exceeds one chunk deadline")]
+    public async Task Handle_SlowButSteadyStream_DeliversFullResponseWhenEachChunkArrrivesWithinDeadline()
+    {
+        // per-chunk timeout = 200 ms; each chunk takes 80 ms.
+        // 3 chunks × 80 ms = 240 ms total > one 200 ms chunk-timeout.
+        // The disarm-between-chunks logic must reset the deadline after each received chunk.
+        const double perChunkTimeoutSeconds = 0.2; // 200 ms
+        const int chunkDelayMs = 80;               // each chunk arrives in 80 ms
+        const string expectedToken = "hello";
+
+        var llmService = new Mock<ILlmService>();
+        llmService
+            .Setup(l => l.GenerateCompletionStreamAsync(
+                It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<RequestSource>(), It.IsAny<CancellationToken>()))
+            .Returns(SlowButSteadyStream(delayPerChunkMs: chunkDelayMs, content: expectedToken, chunkCount: 3));
+
+        var handler = BuildHandler(llmService.Object, perChunkTimeoutSeconds);
+        var command = BuildCommand();
+
+        var events = new List<RagStreamingEvent>();
+
+        using var testCts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+
+        await foreach (var ev in handler.Handle(command, testCts.Token))
+        {
+            events.Add(ev);
+        }
+
+        // No error — each chunk arrived before its deadline.
+        events.Should().NotContain(
+            e => e.Type == StreamingEventType.Error,
+            "no error must be emitted when each individual chunk arrives within the per-chunk deadline");
+
+        // Full response delivered.
+        events.Should().Contain(
+            e => e.Type == StreamingEventType.Complete,
+            "StreamingComplete must be yielded for a slow-but-steady stream");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // T3-AC-3: client disconnect → no spurious timeout error event
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "T3-AC-3: client disconnect does NOT emit a LLM_TIMEOUT error event")]
+    public async Task Handle_ClientDisconnect_StreamStopsWithoutTimeoutErrorEvent()
+    {
+        // per-chunk timeout = 5 s (long), but the client disconnects after ~100 ms.
+        // The handler must stop without emitting LLM_TIMEOUT or LLM_ERROR.
+        const double perChunkTimeoutSeconds = 5.0;
+
+        using var clientCts = new CancellationTokenSource();
+
+        var llmService = new Mock<ILlmService>();
+        llmService
+            .Setup(l => l.GenerateCompletionStreamAsync(
+                It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<RequestSource>(), It.IsAny<CancellationToken>()))
+            .Returns(StalledStream(delayMs: 2000)); // would stall 2 s
+
+        var handler = BuildHandler(llmService.Object, perChunkTimeoutSeconds);
+        var command = BuildCommand();
+
+        var events = new List<RagStreamingEvent>();
+
+        // Fire client disconnect ~100 ms after the test starts.
+        _ = Task.Delay(100).ContinueWith(_ => clientCts.Cancel(), TaskScheduler.Default);
+
+        var act = async () =>
+        {
+            await foreach (var ev in handler.Handle(command, clientCts.Token))
+            {
+                events.Add(ev);
+            }
+        };
+
+        // Must NOT throw (client disconnect is normal flow).
+        await act.Should().NotThrowAsync(
+            "client disconnect must not propagate as an unhandled exception");
+
+        // No timeout / LLM error event.
+        var timeoutOrLlmErrors = events
+            .Where(e => e.Type == StreamingEventType.Error)
+            .Select(e => e.Data as StreamingError)
+            .Where(err => err is not null
+                && (err.errorCode == "LLM_TIMEOUT" || err.errorCode == "LLM_ERROR"))
+            .ToList();
+
+        timeoutOrLlmErrors.Should().BeEmpty(
+            "client disconnect must NOT surface as a LLM_TIMEOUT or LLM_ERROR event");
+
+        // No StreamingComplete (stream was cut short by client).
+        events.Should().NotContain(
+            e => e.Type == StreamingEventType.Complete,
+            "StreamingComplete must not be emitted when the client disconnected mid-stream");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // T3-AC-4: happy-path regression — normal stream → tokens + StreamingComplete
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "T3-AC-4: happy-path regression — normal stream delivers all tokens and StreamingComplete")]
+    public async Task Handle_NormalStream_DeliversAllTokensAndStreamingComplete()
+    {
+        const string tokenContent = "The answer is 42";
+        const double perChunkTimeoutSeconds = 30.0; // generous — won't fire
+
+        var llmService = new Mock<ILlmService>();
+        llmService
+            .Setup(l => l.GenerateCompletionStreamAsync(
+                It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<RequestSource>(), It.IsAny<CancellationToken>()))
+            .Returns(InstantStream(tokenContent));
+
+        var handler = BuildHandler(llmService.Object, perChunkTimeoutSeconds);
+        var command = BuildCommand();
+
+        var events = new List<RagStreamingEvent>();
+
+        await foreach (var ev in handler.Handle(command, CancellationToken.None))
+        {
+            events.Add(ev);
+        }
+
+        events.Should().Contain(
+            e => e.Type == StreamingEventType.Token,
+            "Token events must be yielded on the happy path");
+
+        events.Should().ContainSingle(
+            e => e.Type == StreamingEventType.Complete,
+            "StreamingComplete must be yielded exactly once on the happy path");
+
+        events.Should().NotContain(
+            e => e.Type == StreamingEventType.Error,
+            "no error events must be emitted on the happy path");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Fake LLM streams
+    // ──────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// A stream that delays <paramref name="delayMs"/> ms without yielding any chunk.
+    /// Propagates OperationCanceledException so the handler's per-chunk catch can
+    /// distinguish a timeout (streamCts fired) from a client disconnect (original ct).
+    /// </summary>
+    private static async IAsyncEnumerable<StreamChunk> StalledStream(
+        int delayMs,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        // Do NOT catch — let the OperationCanceledException propagate to MoveNextAsync().
+        await Task.Delay(delayMs, cancellationToken).ConfigureAwait(false);
+        yield break;
+    }
+
+    /// <summary>
+    /// Yields <paramref name="chunkCount"/> content chunks, each after
+    /// <paramref name="delayPerChunkMs"/> ms, then a final usage chunk.
+    /// </summary>
+    private static async IAsyncEnumerable<StreamChunk> SlowButSteadyStream(
+        int delayPerChunkMs,
+        string content,
+        int chunkCount,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        for (int i = 0; i < chunkCount; i++)
+        {
+            await Task.Delay(delayPerChunkMs, cancellationToken).ConfigureAwait(false);
+            yield return new StreamChunk(Content: content);
+        }
+        yield return new StreamChunk(Content: null, Usage: new LlmUsage(10, 5, 15), IsFinal: true);
+    }
+
+    /// <summary>Yields chunks immediately (no delay).</summary>
+    private static async IAsyncEnumerable<StreamChunk> InstantStream(
+        string content,
+        [EnumeratorCancellation] CancellationToken cancellationToken = default)
+    {
+        await Task.Yield();
+        yield return new StreamChunk(Content: content);
+        yield return new StreamChunk(Content: null, Usage: new LlmUsage(10, 5, 15), IsFinal: true);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Builder helpers
+    // ──────────────────────────────────────────────────────────────────────────
+
+    private static ChatWithSessionAgentCommand BuildCommand() =>
+        new ChatWithSessionAgentCommand(
+            AgentSessionId: Guid.NewGuid(),
+            UserQuestion: "What are the rules?",
+            UserId: Guid.NewGuid());
+
+    /// <summary>
+    /// Builds a fully-wired handler with the given <paramref name="llmService"/> and
+    /// a <see cref="SessionAgentOptions"/> whose <c>LlmPerChunkTimeoutSeconds</c> is
+    /// set to <paramref name="perChunkTimeoutSeconds"/>.
+    /// </summary>
+    private static ChatWithSessionAgentCommandHandler BuildHandler(
+        ILlmService llmService,
+        double perChunkTimeoutSeconds)
+    {
+        var playerId = Guid.NewGuid();
+        var initialState = GameState.Create(
+            currentTurn: 1,
+            activePlayer: playerId,
+            playerScores: new Dictionary<Guid, decimal> { [playerId] = 0 },
+            gamePhase: "Setup",
+            lastAction: "Game started");
+
+        var agentSession = new AgentSession(
+            id: Guid.NewGuid(),
+            agentDefinitionId: Guid.NewGuid(),
+            gameSessionId: Guid.NewGuid(),
+            userId: Guid.NewGuid(),
+            gameId: Guid.NewGuid(),
+            initialState: initialState);
+
+        var sessionRepo = new Mock<IAgentSessionRepository>();
+        sessionRepo
+            .Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(agentSession);
+
+        var definition = AgentDefinition.Create(
+            name: "tutor",
+            description: "Test agent",
+            type: AgentType.Custom("tutor", "Tutor"),
+            config: AgentDefinitionConfig.Default());
+
+        var definitionRepo = new Mock<IAgentDefinitionRepository>();
+        definitionRepo
+            .Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(definition);
+
+        var gameCoreData = new Mock<IGameCoreDataProvider>();
+        gameCoreData
+            .Setup(g => g.GetCoreDataAsync(It.IsAny<GameRef>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((GameCoreData?)null);
+
+        var chatThreadRepo = new Mock<IChatThreadRepository>();
+        chatThreadRepo
+            .Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ChatThread?)null);
+        chatThreadRepo
+            .Setup(r => r.AddAsync(It.IsAny<ChatThread>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        chatThreadRepo
+            .Setup(r => r.UpdateAsync(It.IsAny<ChatThread>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        var liveSessionRepo = new Mock<ILiveSessionRepository>();
+        liveSessionRepo
+            .Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((LiveGameSession?)null);
+
+        var unitOfWork = new Mock<IUnitOfWork>();
+        unitOfWork
+            .Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        var assembled = new AssembledPrompt(
+            SystemPrompt: "You are a helpful assistant.",
+            UserPrompt: "What are the rules?",
+            Citations: new List<ChunkCitation>(),
+            EstimatedTokens: 100);
+
+        var ragPromptService = new Mock<IRagPromptAssemblyService>();
+        ragPromptService
+            .Setup(r => r.AssemblePromptAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<GameState?>(),
+                It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<ChatThread?>(),
+                It.IsAny<SharedUserTier?>(), It.IsAny<string>(), It.IsAny<CancellationToken>(),
+                It.IsAny<IRagDebugEventCollector?>(), It.IsAny<RetrievalProfile?>()))
+            .ReturnsAsync(assembled);
+
+        var tierResolver = new Mock<ICopyrightTierResolver>();
+        tierResolver
+            .Setup(r => r.ResolveAsync(
+                It.IsAny<IReadOnlyList<ChunkCitation>>(),
+                It.IsAny<Guid>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ChunkCitation>());
+
+        var memoryBuilder = new Mock<IAgentMemoryContextBuilder>();
+        memoryBuilder
+            .Setup(b => b.BuildContextAsync(
+                It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<Guid?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string?)null);
+
+        var budgetService = new Mock<IUserBudgetService>();
+        budgetService
+            .Setup(b => b.HasBudgetForQueryAsync(
+                It.IsAny<Guid>(), It.IsAny<decimal>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var registry = new Mock<ICircuitBreakerRegistry>();
+        registry
+            .Setup(r => r.GetMonitoringStatus())
+            .Returns(new Dictionary<string, (string, string)>());
+
+        var scopeFactory = new Mock<IServiceScopeFactory>();
+
+        var noLeak = new CopyrightLeakResult(HasLeak: false, Matches: Array.Empty<LeakMatch>());
+        var leakGuard = new Mock<ICopyrightLeakGuard>();
+        leakGuard
+            .Setup(g => g.ScanAsync(
+                It.IsAny<string>(), It.IsAny<IReadOnlyList<ChunkCitation>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(noLeak);
+
+        var fallbackProvider = new Mock<ICopyrightFallbackMessageProvider>();
+        var gateway = new Mock<ILiveSessionStreamGateway>();
+
+        var sessionAgentOptions = Options.Create(new SessionAgentOptions
+        {
+            LlmPerChunkTimeoutSeconds = perChunkTimeoutSeconds,
+        });
+
+        return new ChatWithSessionAgentCommandHandler(
+            sessionRepository: sessionRepo.Object,
+            definitionRepository: definitionRepo.Object,
+            chatThreadRepository: chatThreadRepo.Object,
+            gameCoreData: gameCoreData.Object,
+            liveSessionRepository: liveSessionRepo.Object,
+            unitOfWork: unitOfWork.Object,
+            ragPromptService: ragPromptService.Object,
+            copyrightTierResolver: tierResolver.Object,
+            agentMemoryContextBuilder: memoryBuilder.Object,
+            llmService: llmService,
+            userBudgetService: budgetService.Object,
+            circuitBreakerRegistry: registry.Object,
+            scopeFactory: scopeFactory.Object,
+            logger: NullLogger<ChatWithSessionAgentCommandHandler>.Instance,
+            copyrightLeakGuard: leakGuard.Object,
+            fallbackMessageProvider: fallbackProvider.Object,
+            copyrightOptions: Options.Create(new CopyrightLeakGuardOptions()),
+            liveSessionStreamGateway: gateway.Object,
+            sessionAgentOptions: sessionAgentOptions);
+    }
+}

--- a/apps/api/tests/Api.Tests/Integration/GameManagement/LazyCompanionOnSubscribeTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/GameManagement/LazyCompanionOnSubscribeTests.cs
@@ -103,6 +103,13 @@ public sealed class LazyCompanionOnSubscribeTests : IAsyncLifetime
         // Assert — request succeeded
         resp.StatusCode.Should().Be(HttpStatusCode.OK);
 
+        // Assert — NO X-Warning-Code: stream-not-linked on the subscribe that just linked the session.
+        // This is the stale-header fix (final-review Important finding): the endpoint must use the
+        // POST-ensure result, not the stale ctx.HasCompanion, for the warning decision.
+        resp.Headers.Should().NotContainKey("X-Warning-Code",
+            "GameId-backed session was just linked by EnsureCompanionCommand on this very subscribe; " +
+            "emitting stream-not-linked would mislead the client into thinking the stream is empty");
+
         // Assert — companion persisted after subscribe
         // Use a fresh DbContext scope to avoid stale tracking.
         await using var verifyScope = _factory.Services.CreateAsyncScope();

--- a/apps/api/tests/Api.Tests/Integration/GameManagement/LazyCompanionOnSubscribeTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/GameManagement/LazyCompanionOnSubscribeTests.cs
@@ -1,0 +1,444 @@
+using System.Net;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Infrastructure.Entities.GameManagement;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.Integration.GameManagement;
+
+/// <summary>
+/// Integration tests for SP5-c (#2600) Task 2 — lazy companion provisioning on first
+/// <c>GET /api/v1/live-sessions/{id}/stream</c> subscribe.
+///
+/// Strategy: directly insert legacy <see cref="LiveGameSessionEntity"/> rows with
+/// <c>TrackingSessionId == null</c> to simulate pre-SP0 rows, then assert that a
+/// subscribe creates (or does not create) the companion as per guard semantics.
+///
+/// All tests use <see cref="HttpCompletionOption.ResponseHeadersRead"/> to avoid
+/// blocking on the infinite SSE body.
+/// </summary>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "GameManagement")]
+public sealed class LazyCompanionOnSubscribeTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly string _databaseName = $"lazy_companion_{Guid.NewGuid():N}";
+    private WebApplicationFactory<Program> _factory = null!;
+
+    public LazyCompanionOnSubscribeTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+        await TestcontainersWaitHelpers.WaitForPostgresReadyAsync(connectionString);
+
+        _factory = IntegrationWebApplicationFactory.Create(connectionString);
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        await db.Database.MigrateAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_factory != null)
+            await _factory.DisposeAsync();
+
+        await _fixture.DropIsolatedDatabaseAsync(_databaseName);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Test 1: GameId-backed legacy session (TrackingSessionId == null)
+    //         → subscribe → companion created and persisted.
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "Subscribe to GameId-backed legacy session creates companion and persists TrackingSessionId")]
+    public async Task Subscribe_GameIdBacked_NullCompanion_CreatesCompanion()
+    {
+        // Arrange — seed a user + shared game, then insert a LEGACY live session
+        // (TrackingSessionId == null) that has a GameId. This simulates a pre-SP0 row.
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        var userId = await SeedUserAsync(db);
+        var gameId = await SeedSharedGameAsync(db);
+
+        // Insert a legacy live session row directly (bypassing CreateLiveSessionCommand
+        // which would trigger the SP0 Saga and create a companion automatically).
+        var sessionId = Guid.NewGuid();
+        var legacySession = BuildLegacySessionEntity(sessionId, userId, gameId, trackingSessionId: null);
+        db.LiveGameSessions.Add(legacySession);
+        await db.SaveChangesAsync();
+        db.ChangeTracker.Clear();
+
+        // Verify setup: no companion yet
+        var before = await db.LiveGameSessions.AsNoTracking().SingleAsync(s => s.Id == sessionId);
+        before.TrackingSessionId.Should().BeNull("pre-condition: legacy row has no companion");
+
+        // Create an authenticated HTTP client
+        var (_, token) = await TestSessionHelper.CreateUserSessionAsync(db, userId);
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Add("Cookie", $"{TestSessionHelper.SessionCookieName}={token}");
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+
+        // Act — subscribe (ResponseHeadersRead avoids blocking on the infinite SSE body)
+        using var resp = await client.GetAsync(
+            $"/api/v1/live-sessions/{sessionId}/stream",
+            HttpCompletionOption.ResponseHeadersRead,
+            cts.Token);
+
+        // Assert — request succeeded
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        // Assert — companion persisted after subscribe
+        // Use a fresh DbContext scope to avoid stale tracking.
+        await using var verifyScope = _factory.Services.CreateAsyncScope();
+        var verifyDb = verifyScope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        var after = await verifyDb.LiveGameSessions
+            .AsNoTracking()
+            .SingleAsync(s => s.Id == sessionId);
+
+        after.TrackingSessionId.Should().NotBeNull(
+            "EnsureCompanionCommand must have created and persisted a companion for the legacy session");
+
+        // Assert — the companion Session row actually exists in SessionTracking
+        var companionExists = await verifyDb.SessionTrackingSessions
+            .AsNoTracking()
+            .AnyAsync(s => s.Id == after.TrackingSessionId!.Value);
+
+        companionExists.Should().BeTrue(
+            "the companion SessionTracking.Session row must exist after lazy creation");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Test 2: Free-form session (GameId == null) — EnsureCompanionCommand no-ops.
+    //         TrackingSessionId stays null; request still returns 200.
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "Subscribe to free-form session (GameId=null) is a no-op: TrackingSessionId stays null")]
+    public async Task Subscribe_FreeForm_NoGameId_DoesNotCreateCompanion()
+    {
+        // Arrange — seed a user, insert a free-form live session (no GameId, no companion)
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        var userId = await SeedUserAsync(db);
+
+        var sessionId = Guid.NewGuid();
+        var freeFormSession = BuildLegacySessionEntity(sessionId, userId, gameId: null, trackingSessionId: null);
+        db.LiveGameSessions.Add(freeFormSession);
+        await db.SaveChangesAsync();
+        db.ChangeTracker.Clear();
+
+        var (_, token) = await TestSessionHelper.CreateUserSessionAsync(db, userId);
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Add("Cookie", $"{TestSessionHelper.SessionCookieName}={token}");
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+
+        // Act
+        using var resp = await client.GetAsync(
+            $"/api/v1/live-sessions/{sessionId}/stream",
+            HttpCompletionOption.ResponseHeadersRead,
+            cts.Token);
+
+        // Assert — request still succeeds (free-form is allowed, just no domain events forwarded)
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        // Assert — X-Warning-Code is present (free-form: stream-not-linked is correct behaviour)
+        resp.Headers.Should().ContainKey("X-Warning-Code");
+        resp.Headers.GetValues("X-Warning-Code").Should().Contain("stream-not-linked");
+
+        // Assert — TrackingSessionId is STILL null (command must not create a companion for free-form)
+        await using var verifyScope = _factory.Services.CreateAsyncScope();
+        var verifyDb = verifyScope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        var after = await verifyDb.LiveGameSessions
+            .AsNoTracking()
+            .SingleAsync(s => s.Id == sessionId);
+
+        after.TrackingSessionId.Should().BeNull(
+            "EnsureCompanionCommand must be a no-op for free-form sessions (GameId == null)");
+
+        // Assert — no companion row was created
+        var companionCount = await verifyDb.SessionTrackingSessions.AsNoTracking().CountAsync();
+        companionCount.Should().Be(0, "no companion must be created for a free-form session");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Test 3: Session that already has a companion → subscribe → same TrackingSessionId
+    //         (no new companion, no orphan).
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "Subscribe to session that already has a companion leaves TrackingSessionId unchanged")]
+    public async Task Subscribe_AlreadyHasCompanion_CompanionIsUnchanged()
+    {
+        // Arrange — create a session that already has a companion (i.e. SP0 Saga ran normally).
+        // We insert the session entity with a pre-existing TrackingSessionId and a matching
+        // SessionTracking.Session row so the FK and assertion both work.
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        var userId = await SeedUserAsync(db);
+        var gameId = await SeedSharedGameAsync(db);
+
+        var existingCompanionId = Guid.NewGuid();
+        await SeedCompanionSessionAsync(db, existingCompanionId, userId, gameId);
+
+        var sessionId = Guid.NewGuid();
+        var sessionWithCompanion = BuildLegacySessionEntity(
+            sessionId, userId, gameId, trackingSessionId: existingCompanionId);
+        db.LiveGameSessions.Add(sessionWithCompanion);
+        await db.SaveChangesAsync();
+        db.ChangeTracker.Clear();
+
+        var (_, token) = await TestSessionHelper.CreateUserSessionAsync(db, userId);
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Add("Cookie", $"{TestSessionHelper.SessionCookieName}={token}");
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(15));
+
+        // Act — subscribe
+        using var resp = await client.GetAsync(
+            $"/api/v1/live-sessions/{sessionId}/stream",
+            HttpCompletionOption.ResponseHeadersRead,
+            cts.Token);
+
+        // Assert — request succeeds, no warning
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+        resp.Headers.Should().NotContainKey("X-Warning-Code",
+            "session already has a companion — no warning should be emitted");
+
+        // Assert — TrackingSessionId is STILL the original companion id (not replaced)
+        await using var verifyScope = _factory.Services.CreateAsyncScope();
+        var verifyDb = verifyScope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        var after = await verifyDb.LiveGameSessions
+            .AsNoTracking()
+            .SingleAsync(s => s.Id == sessionId);
+
+        after.TrackingSessionId.Should().Be(existingCompanionId,
+            "the existing companion must not be overwritten by a second EnsureCompanionCommand");
+
+        // Assert — STILL exactly one companion row
+        var companionCount = await verifyDb.SessionTrackingSessions
+            .AsNoTracking()
+            .CountAsync(s => s.Id == existingCompanionId);
+
+        companionCount.Should().Be(1, "the pre-existing companion row must still exist and not be duplicated");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Test 4: Concurrency — two concurrent subscribes → exactly ONE companion row.
+    //
+    // NOTE on feasibility: The concurrency test requires two concurrent HTTP requests
+    // to race on the same null-TrackingSessionId row. The xmin optimistic-concurrency
+    // mechanism (ADR-060) means only one SaveChanges wins; the loser catches
+    // DbUpdateConcurrencyException, re-fetches, sees TrackingSessionId != null, and
+    // returns idempotently. Both requests return 200.
+    //
+    // In the in-process TestHost the concurrent requests DO run concurrently (different
+    // Task contexts with their own DI scopes), so this test is valid.
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "Two concurrent subscribes to null-companion session create exactly one companion (race-safe)")]
+    public async Task Subscribe_Concurrent_CreatesExactlyOneCompanion()
+    {
+        // Arrange — seed a legacy session (null companion) with a GameId
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        var userId = await SeedUserAsync(db);
+        var gameId = await SeedSharedGameAsync(db);
+
+        var sessionId = Guid.NewGuid();
+        var legacySession = BuildLegacySessionEntity(sessionId, userId, gameId, trackingSessionId: null);
+        db.LiveGameSessions.Add(legacySession);
+        await db.SaveChangesAsync();
+        db.ChangeTracker.Clear();
+
+        var (_, token) = await TestSessionHelper.CreateUserSessionAsync(db, userId);
+
+        // Create two independent clients (independent DI scopes, no shared state)
+        var clientA = _factory.CreateClient();
+        clientA.DefaultRequestHeaders.Add("Cookie", $"{TestSessionHelper.SessionCookieName}={token}");
+
+        var clientB = _factory.CreateClient();
+        clientB.DefaultRequestHeaders.Add("Cookie", $"{TestSessionHelper.SessionCookieName}={token}");
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(20));
+
+        // Act — fire both subscribes concurrently
+        var taskA = clientA.GetAsync(
+            $"/api/v1/live-sessions/{sessionId}/stream",
+            HttpCompletionOption.ResponseHeadersRead,
+            cts.Token);
+        var taskB = clientB.GetAsync(
+            $"/api/v1/live-sessions/{sessionId}/stream",
+            HttpCompletionOption.ResponseHeadersRead,
+            cts.Token);
+
+        var results = await Task.WhenAll(taskA, taskB);
+
+        // Assert — both requests succeeded
+        results[0].StatusCode.Should().Be(HttpStatusCode.OK,
+            "first concurrent subscriber must succeed");
+        results[1].StatusCode.Should().Be(HttpStatusCode.OK,
+            "second concurrent subscriber must succeed (idempotent race resolution)");
+
+        // Dispose responses to release connections
+        results[0].Dispose();
+        results[1].Dispose();
+
+        // Assert — exactly ONE companion row in SessionTracking
+        await using var verifyScope = _factory.Services.CreateAsyncScope();
+        var verifyDb = verifyScope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        var after = await verifyDb.LiveGameSessions
+            .AsNoTracking()
+            .SingleAsync(s => s.Id == sessionId);
+
+        after.TrackingSessionId.Should().NotBeNull(
+            "at least one of the concurrent subscribers must have created the companion");
+
+        var companionCount = await verifyDb.SessionTrackingSessions
+            .AsNoTracking()
+            .CountAsync(s => s.Id == after.TrackingSessionId!.Value);
+
+        companionCount.Should().Be(1,
+            "the xmin optimistic-concurrency guard must ensure exactly ONE companion is created " +
+            "regardless of how many concurrent subscribers raced");
+
+        // Overall companion count across ALL sessions must also be 1 (no orphans)
+        var totalCompanions = await verifyDb.SessionTrackingSessions.AsNoTracking().CountAsync();
+        totalCompanions.Should().Be(1,
+            "the losing concurrent EnsureCompanionCommand must not have committed an orphaned companion");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Helpers
+    // ──────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Builds a minimal <see cref="LiveGameSessionEntity"/> that simulates a pre-SP0 "legacy" row:
+    /// it has a <paramref name="gameId"/> but <c>TrackingSessionId == null</c>.
+    /// Inserted directly into the DB to bypass <c>CreateLiveSessionCommand</c> (which would trigger
+    /// the SP0 Saga and auto-create the companion).
+    /// </summary>
+    private static LiveGameSessionEntity BuildLegacySessionEntity(
+        Guid sessionId,
+        Guid userId,
+        Guid? gameId,
+        Guid? trackingSessionId)
+    {
+        var now = DateTime.UtcNow;
+        return new LiveGameSessionEntity
+        {
+            Id = sessionId,
+            SessionCode = Guid.NewGuid().ToString("N")[..6].ToUpperInvariant(),
+            GameId = gameId,
+            GameName = "Legacy Test Game",
+            CreatedByUserId = userId,
+            Visibility = 0,  // Private
+            Status = 0,       // Created
+            CreatedAt = now,
+            UpdatedAt = now,
+            CurrentTurnIndex = 0,
+            CurrentPhaseIndex = 0,
+            TurnAdvancePolicy = 0,  // Manual
+            AgentMode = 0,           // None
+            ScoringConfigJson = """{"type":0,"dimensions":[{"name":"Points","unit":null,"scoreType":0}]}""",
+            TrackingSessionId = trackingSessionId
+        };
+    }
+
+    private static async Task<Guid> SeedUserAsync(MeepleAiDbContext db)
+    {
+        var userId = Guid.NewGuid();
+        db.Users.Add(new UserEntity
+        {
+            Id = userId,
+            Email = $"lazy-companion-{userId:N}@test.local",
+            DisplayName = "Lazy Companion Test User",
+            PasswordHash = "not-a-real-hash",
+            Role = "user",
+            Tier = "free",
+            Status = "Active",
+            EmailVerified = true,
+            CreatedAt = DateTime.UtcNow
+        });
+        await db.SaveChangesAsync();
+        db.ChangeTracker.Clear();
+        return userId;
+    }
+
+    private static async Task<Guid> SeedSharedGameAsync(MeepleAiDbContext db)
+    {
+        var gameId = Guid.NewGuid();
+        db.SharedGames.Add(new SharedGameEntity
+        {
+            Id = gameId,
+            Title = $"Lazy Companion Test Game {gameId:N}",
+            YearPublished = 2024,
+            MinPlayers = 1,
+            MaxPlayers = 4,
+            PlayingTimeMinutes = 60,
+            MinAge = 10,
+            ImageUrl = string.Empty,
+            ThumbnailUrl = string.Empty,
+            Description = string.Empty,
+            CreatedBy = Guid.NewGuid(),
+            CreatedAt = DateTime.UtcNow
+        });
+        await db.SaveChangesAsync();
+        db.ChangeTracker.Clear();
+        return gameId;
+    }
+
+    /// <summary>
+    /// Seeds a minimal <c>SessionTracking.Session</c> row to act as a pre-existing companion.
+    /// Used by Test 3 to verify that an already-companion session is left unchanged.
+    /// String-enum values ("GameSpecific", "Active") match <see cref="SessionMapper.ToEntity"/>
+    /// which calls <c>domain.SessionType.ToString()</c> / <c>domain.Status.ToString()</c>.
+    /// </summary>
+    private static async Task SeedCompanionSessionAsync(
+        MeepleAiDbContext db,
+        Guid companionId,
+        Guid userId,
+        Guid gameId)
+    {
+        var now = DateTime.UtcNow;
+        db.SessionTrackingSessions.Add(new Api.Infrastructure.Entities.SessionTracking.SessionEntity
+        {
+            Id = companionId,
+            UserId = userId,
+            GameId = gameId,
+            SessionCode = Guid.NewGuid().ToString("N")[..6].ToUpperInvariant(),
+            SessionType = "GameSpecific",
+            Status = "Active",
+            SessionDate = now,
+            ScoreData = "{}",
+            ScoringType = "Points",
+            CreatedAt = now,
+            UpdatedAt = now,
+            CreatedBy = userId,
+            IsDeleted = false
+        });
+        await db.SaveChangesAsync();
+        db.ChangeTracker.Clear();
+    }
+}

--- a/docs/for-claude/architecture/adr/adr-083-live-session-aggregate-convergence.md
+++ b/docs/for-claude/architecture/adr/adr-083-live-session-aggregate-convergence.md
@@ -208,8 +208,18 @@ La Fase 4 NON rimuove GameSession. Le rimozioni legacy genuine sono spezzate in 
 - **Slice D** (owner-gated): cleanup `/sessions/[id]/notes`+`/players` solo se confermati dead.
 - **Debito separato**: convergere il **dual-creation funnel** (SessionSetupModal→GameSession vs wizard→LiveGameSession), **#2587** — indipendente dalla rimozione.
 
+## Update 2026-06-30 (SP5-c #2600) — TrackingSessionId backfill via LAZY companion creation (OQ#5 risolta = B)
+
+OQ1 prevedeva un `TrackingSessionId` "non-nullable garantito"; SP0 lo shippò **nullable** (delta MVP) → sessioni **legacy pre-SP0** e **free-form senza GameId** hanno `TrackingSessionId == null` → niente broadcast SSE live dei domain-event forwarded (score/turn/phase/player/diary-event). Il "backfill/coexistence" menzionato per SP5 è risolto via **lazy on-demand (decisione owner B, 2026-06-29)**, non backfill eager su dati storici.
+
+- **Trigger** = primo subscribe al native stream (`GET /live-sessions/{id}/stream`): se `!HasCompanion` → `EnsureCompanionCommand` (DOPO auth/403, PRIMA di SubscribeAsync) → crea il companion + `LiveGameSession.SetTrackingSessionId(companionId)` + single SaveChanges atomico (SP0 no-orphan); il gateway re-legge la session e fonde il canale companion. Idempotente + race-safe (xmin → re-fetch, niente 2° companion né orphan).
+- **Vincolo strutturale**: il companion richiede un GameId (`Session.Create(userId, gameId, GameSpecific)`) → le **free-form senza GameId restano toolkit-only** (no companion). Il **diary è nativo** (SP3) e NON richiede companion.
+- Companion: **SSE-Companion** (#2579) per whiteboard/turn/timer/widget fluisce comunque senza companion (canale `liveSessionId`); il lazy companion riguarda solo i **domain-event forwarded**.
+- Implementazione: branch `feature/issue-2600-sp5c-lazy-companion-llm-timeout` (T1 dominio+command, T2 endpoint+integration, T3 LLM per-chunk timeout, T4 docs). De-risk: `.superpowers/sdd/sp5c-derisk.md`.
+
 ## Riferimenti
 - Epic #2501; user story di validazione #2506; gap issue #2500/#2503/#2505/#2504/#2502.
+- **SP5-c**: lazy companion + LLM per-chunk timeout #2600 (de-risk `.superpowers/sdd/sp5c-derisk.md`).
 - **Fase 4**: decomposition #2588 · dual-creation funnel #2587 · removal-safety-map + gamesession-architecture-decision (`.superpowers/sdd/`).
 - **Spec Fase 2**: `docs/for-developers/specs/2026-06-23-epic-2501-fase2-live-session-feature-gaps.md` (spec-panel).
 - ADR-060 (LiveGameSession persistence, EPIC #2097), ADR-065 (namespace split), ADR-071 (5-state FSM).

--- a/docs/superpowers/plans/2026-06-30-issue-2600-sp5c-lazy-companion-llm-timeout.md
+++ b/docs/superpowers/plans/2026-06-30-issue-2600-sp5c-lazy-companion-llm-timeout.md
@@ -1,0 +1,87 @@
+# SP5-c (#2600) — Lazy companion creation + LLM stream timeout
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Checkbox (`- [ ]`) steps.
+
+**Goal:** (1) Lazily create the SessionTracking companion (decision B) for GameId-backed `LiveGameSession`s that have `TrackingSessionId == null`, triggered on first native-stream subscribe — so legacy sessions get live domain-event broadcast. (2) Add a per-chunk timeout to the LLM stream in the session-agent chat handler so a hung chunk yields an error instead of stalling the live chat.
+
+**Architecture:** BE-only. De-risk: `.superpowers/sdd/sp5c-derisk.md`. Owner decisions: backfill = **B (lazy on-demand)**; scope = **lazy companion + LLM-timeout**.
+
+**Global constraints:**
+- **No worktree** — commit directly on `feature/issue-2600-sp5c-lazy-companion-llm-timeout`.
+- commitlint header ≤72 chars; commits end with `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+- **Free-form sessions (GameId == null) NEVER get a companion** — structural (companion factory requires a gameId). Lazy applies ONLY to `TrackingSessionId == null && GameId != null`.
+- **Diary is native** (SP3) — it does NOT depend on the companion; do NOT add a companion dependency to diary.
+- **Atomicity**: companion creation + `SetTrackingSessionId` must commit in ONE `SaveChangesAsync` (SP0 no-orphan pattern). On `DbUpdateConcurrencyException` (xmin, ADR-060) re-fetch + idempotent no-op if companion now set.
+- **Async-iterator safety** (T3): the LLM-timeout must NOT break the chat stream; yield a graceful error (same discipline as SP5-b).
+
+**Reading list:** `CompanionSessionService.cs:24-29`, `ICompanionSessionService.cs`, `CreateLiveSessionCommandHandler.cs:50-78` (companion-create pattern), `LiveGameSession.cs:68-73,99-153` (TrackingSessionId private set + Create), `AddDiaryEntryCommandHandler.cs:32-59` (handler pattern), `LiveSessionEndpoints.cs:900-985` (stream endpoint), `LiveSessionStreamGateway.cs:79-97` (re-reads session in SubscribeAsync), `ChatWithSessionAgentCommandHandler.cs:337-378` (LLM collect-loop + error yields), `OpenRouterLlmClient.cs:45,72`.
+
+---
+
+## Task 1: Domain method + EnsureCompanionCommand (idempotent, race-safe)
+**Files:** `LiveGameSession.cs`; new `EnsureCompanionCommand.cs` + `EnsureCompanionCommandHandler.cs` (GameManagement/Application/Commands/LiveSessions); DI registration; Tests: handler unit tests + a `LiveGameSession.SetTrackingSessionId` domain test.
+
+**Interfaces:** `EnsureCompanionCommand(Guid LiveSessionId) : IRequest` (no return, or return the companion Guid?). Uses `ILiveSessionRepository`, `ICompanionSessionService`, `IUnitOfWork`.
+
+- [ ] **Step 1: Failing tests**:
+  - Domain: `LiveGameSession.SetTrackingSessionId(companionId)` sets the property when currently null; throws (or no-ops) if already set to a different value; no-op if same value. Pick ONE explicit idempotency semantic and test it.
+  - Handler: (a) session with `TrackingSessionId == null && GameId != null` → calls `CreateCompanionAsync(CreatedByUserId, GameId)`, sets TrackingSessionId, saves once; (b) session that already HAS a companion → no-op, does NOT call CreateCompanionAsync, does NOT save; (c) session with `GameId == null` → no-op (free-form, can't create), does NOT call CreateCompanionAsync; (d) concurrency: when SaveChanges throws `DbUpdateConcurrencyException`, the handler re-fetches and if TrackingSessionId is now non-null, completes successfully (idempotent) without creating a second companion.
+- [ ] **Step 2: Run → FAIL.**
+- [ ] **Step 3: Implement**:
+  - `LiveGameSession.SetTrackingSessionId(Guid companionId)` domain method (guards per the chosen semantic).
+  - `EnsureCompanionCommandHandler`: `GetByIdAsync` → guard `TrackingSessionId == null && GameId != null` (else return) → `CreateCompanionAsync(session.CreatedByUserId, session.GameId.Value, ct)` → `session.SetTrackingSessionId(companionId)` → `UpdateAsync` → `SaveChangesAsync`. Wrap in a try/catch for `DbUpdateConcurrencyException`: re-fetch; if `TrackingSessionId != null` now, return (someone else won the race — do NOT create another companion); else rethrow.
+  - Register the handler in DI if needed.
+- [ ] **Step 4: Run → PASS** + the GameManagement unit suite (no regression).
+- [ ] **Step 5: Commit** — `feat(session-live): #2600 EnsureCompanionCommand + lazy SetTrackingSessionId`
+
+---
+
+## Task 2: Endpoint hook — ensure companion on first stream subscribe
+**Files:** `LiveSessionEndpoints.cs` (the `GET /api/v1/live-sessions/{id}/stream` endpoint); Test: an integration test (Testcontainers) under `apps/api/tests/Api.Tests/Integration/GameManagement/`.
+
+- [ ] **Step 1: Failing integration test** — create a GameId-backed `LiveGameSession` with `TrackingSessionId == null` (simulate a legacy row: insert without a companion). Subscribe to `/live-sessions/{id}/stream` as a participant. Assert: after the request starts, the session now HAS a `TrackingSessionId` persisted (companion created), AND a forwarded domain event (e.g. record a score → `session:score`) is delivered on the stream. Also a control: a `GameId == null` free-form session subscribe does NOT create a companion (TrackingSessionId stays null) and still delivers toolkit events.
+- [ ] **Step 2: Run → FAIL.**
+- [ ] **Step 3: Implement** — in the stream endpoint, AFTER auth + the `GetLiveSessionStreamContextQuery` resolution + connection-limit check, BEFORE `gateway.SubscribeAsync`: `if (!context.HasCompanion) await mediator.Send(new EnsureCompanionCommand(sessionId), ct);`. The gateway re-reads the session internally so it picks up the now-non-null companion. (The handler no-ops for free-form/already-has-companion, so the guard `!HasCompanion` just avoids the extra dispatch when a companion already exists.) Keep all existing SSE headers/heartbeat/error-handling unchanged.
+- [ ] **Step 4: Run → PASS** + the existing stream-endpoint tests (no regression — sessions that already have a companion are unaffected).
+- [ ] **Step 5: Commit** — `feat(session-live): #2600 ensure companion on first live-stream subscribe`
+
+---
+
+## Task 3: LLM per-chunk stream timeout
+**Files:** `ChatWithSessionAgentCommandHandler.cs` (the LLM collect-loop ~:337-349) + config (a timeout setting, e.g. `appsettings.json` under the RAG/LLM section); Test: the handler's tests.
+
+- [ ] **Step 1: Failing tests** (use a fake `ILlmService` whose stream stalls — a chunk that never arrives / `Task.Delay` beyond the deadline):
+  - A chunk that exceeds the per-chunk timeout → the handler yields a timeout error event (a `LLM_TIMEOUT` code or reuse `LLM_ERROR`) and completes the stream gracefully (does NOT hang, does NOT throw out).
+  - A valid stream whose chunks each arrive within the timeout is NOT killed (full response delivered) even if the TOTAL time exceeds a single chunk timeout.
+  - Client disconnect (original `ct` cancelled) is NOT reported as a timeout error (no spurious timeout event; the stream just ends).
+  - The stream still completes (`StreamingComplete`) on the happy path (no regression).
+- [ ] **Step 2: Run → FAIL.**
+- [ ] **Step 3: Implement** — wrap the LLM `await foreach` consumption with a per-chunk deadline:
+  - `using var streamCts = CancellationTokenSource.CreateLinkedTokenSource(ct);` → `await using var e = llmStream.GetAsyncEnumerator(streamCts.Token);`
+  - Loop: `streamCts.CancelAfter(perChunkTimeout)` (arm), `await e.MoveNextAsync()`, on success `streamCts.CancelAfter(Timeout.Infinite)` (disarm during processing), process/buffer the chunk, repeat.
+  - On `OperationCanceledException` where `streamCts.IsCancellationRequested && !ct.IsCancellationRequested` → it's a TIMEOUT → yield the timeout error event, stop. Where `ct.IsCancellationRequested` → client disconnect → just stop (no error event).
+  - `perChunkTimeout` from config (provisional, e.g. 30s; mark "needs tuning"). Keep the existing buffering/citation/broadcast logic after the collect loop unchanged.
+  - Respect async-iterator safety: the timeout path yields the error (outside any try that contains a yield, per C# rules) and does not abort the surrounding stream machinery.
+- [ ] **Step 4: Run → PASS** + the KnowledgeBase chat suite (no regression).
+- [ ] **Step 5: Commit** — `feat(session-live): #2600 per-chunk LLM stream timeout in session chat`
+
+---
+
+## Task 4: Integration verify + docs
+**Files:** docs; issue acceptance.
+
+- [ ] **Step 1: Build + suite** — `dotnet build` the Api project + run the GameManagement + KnowledgeBase unit suites; confirm green.
+- [ ] **Step 2: Docs** — update `.superpowers/sdd/sp5c-derisk.md` with an "## Outcome" section; note in ADR-083 (or the SP0 OQ#5 reference) that lazy companion creation is shipped (on-subscribe, GameId-backed only; free-form stays toolkit-only). Add the LLM per-chunk timeout config + its provisional value to the observability/ops note.
+- [ ] **Step 3: Commit** — `docs(session-live): #2600 SP5-c lazy companion + LLM timeout outcome`
+
+---
+
+## Self-Review
+- **Lazy companion**: GameId-backed null-companion session → companion created on first subscribe, atomic, idempotent, race-safe (T1/T2). Free-form stays toolkit-only. Diary untouched (native).
+- **LLM timeout**: per-chunk deadline, timeout→error event, valid stream preserved, client-disconnect distinguished, async-iterator-safe (T3).
+- **No regression**: existing companion-backed sessions + chat happy-path unchanged.
+
+## Out of scope
+- Eager backfill of historical rows (decision B = lazy).
+- Resilience beyond the LLM-timeout gap (already mature: Polly/circuit-breaker/graceful-degradation).
+- A companion for free-form (no-GameId) sessions (structurally impossible; toolkit-only by design).


### PR DESCRIPTION
## Cosa
Epic #2501 SP5-c (affidabilità). Chiude #2600. Due concern session-live:
1. **Lazy companion creation** (decisione owner B = lazy on-demand)
2. **LLM per-chunk stream timeout** (unico gap resilience reale)

De-risk: `.superpowers/sdd/sp5c-derisk.md`. Segue SP5-a (#2578) + SP5-b (#2582).

## 1. Lazy companion (T1-T2)
Le sessioni legacy GameId-backed con `TrackingSessionId == null` (create prima di SP0) non ricevono il broadcast SSE live dei domain-event forwarded (score/turn/phase/player/diary-event). Ora il companion si crea **lazy al primo subscribe**:
- **T1**: `LiveGameSession.SetTrackingSessionId(companionId)` (null→set, same→no-op, different→throw) + `EnsureCompanionCommand : ICommand<Guid?>` + handler. Guard `TrackingSessionId==null && GameId!=null`; `CreateCompanionAsync(CreatedByUserId, GameId)` → set → **single SaveChanges atomico** (SP0 no-orphan). Race xmin (ADR-060) → `DbUpdateConcurrencyException` re-fetch idempotente (niente 2° companion né orphan — verificato safe-by-construction su DbContext condiviso). Ritorna il `TrackingSessionId` post-stato su tutti i path. 16 unit test.
- **T2**: hook nell'endpoint `GET /live-sessions/{id}/stream`: `if (!ctx.HasCompanion) ensuredId = mediator.Send(EnsureCompanionCommand)` **dopo** auth/403, **prima** di `SubscribeAsync` (il gateway re-legge la session AsNoTracking → companion fresco). 4 integration test Testcontainers (lazy-create / free-form no-op / already-companion / 2 concurrent→1 row).

**Vincolo strutturale**: le free-form senza GameId restano **toolkit-only** (il companion richiede un GameId). Il **diario è nativo** (SP3) — non richiede companion, invariato.

## 2. LLM per-chunk timeout (T3)
`ChatWithSessionAgentCommandHandler` non aveva timeout per-chunk sullo stream LLM (solo 60s connection timeout) → un chunk hung stallava la chat live. Ora: linked CTS, arm `CancelAfter(perChunkTimeout)` prima di ogni `MoveNextAsync`, disarm `CancelAfter(Infinite)` dopo il chunk; **timeout** (`streamCts cancelled && !ct`) → yield error event `LLM_TIMEOUT`; **client-disconnect** (`ct cancelled`) → stop silenzioso. Iterator-safe (yield fuori try). Config `SessionAgent:LlmPerChunkTimeoutSeconds` default 30s (provisional, needs tuning). Nessuna regressione su SP5-b (first-token-latency/citations metrics). 4 unit test.

## Review
Subagent-driven (4 task TDD + fix), ogni task task-review (2-stadi). **Review finale whole-branch (opus): READY_WITH_FOLLOWUPS** — catena lazy-companion verificata end-to-end (gateway re-legge, atomicità/no-orphan, auth-before-ensure, diary disaccoppiato, LLM-timeout no-regress, nessun false-green). 1 Important fixato in-PR (header `X-Warning-Code: stream-not-linked` stale dopo lazy-create → ora dal post-stato). Whole-branch BE build exit 0.

## Follow-up (Minor, non-blocking)
- Test1 integration non asserisce delivery end-to-end (coperto transitivamente da SP2 gateway tests).
- Default 30s LLM-timeout da tunare con dati reali (ops).

## Out of scope
Backfill eager su dati storici (decisione B = lazy). Companion per free-form (strutturalmente impossibile). Resilience oltre il gap LLM-timeout (già matura: Polly/circuit-breaker/graceful-degradation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)