### PR TITLE
test(session-live): #2579 verify timer reaches native stream + fix gateway doc

### DIFF
--- a/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Services/LiveSessionStreamGateway.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Services/LiveSessionStreamGateway.cs
@@ -15,9 +15,12 @@ namespace Api.BoundedContexts.GameManagement.Infrastructure.Services;
 /// and fans in three event sources so the native stream carries all session events:
 /// <list type="number">
 ///   <item>Companion channel (<see cref="ISessionBroadcastService"/> keyed on TrackingSessionId):
-///         domain events with replay + visibility filter. Id preserved.</item>
+///         domain events (replay + visibility filter) AND SessionTracking toolkit events published
+///         on the companion id — notably timer events (Start/Pause/Resume/Reset), whose RandomTool
+///         handlers publish on the SessionTracking session id (== TrackingSessionId). Id preserved.</item>
 ///   <item>SBS toolkit channel (<see cref="ISessionBroadcastService"/> keyed on liveSessionId):
-///         whiteboard / turn / timer events. Id dropped (live-only, no replay contamination).</item>
+///         GameManagement-published whiteboard / turn events. Id dropped (live-only, no replay
+///         contamination).</item>
 ///   <item>SSS widget channel (<see cref="ISessionSyncService"/> keyed on liveSessionId):
 ///         in-memory WidgetStateUpdated events. Id null.</item>
 /// </list>
@@ -156,7 +159,9 @@ internal sealed class LiveSessionStreamGateway : ILiveSessionStreamGateway
             pumps.Add(PumpCompanionAsync(writer, companionId.Value, userId, lastEventId, ct));
         }
 
-        // Pump 2 — SBS toolkit channel keyed on liveSessionId (whiteboard/turn/timer).
+        // Pump 2 — SBS toolkit channel keyed on liveSessionId (whiteboard/turn, published by
+        // GameManagement handlers). Timer events arrive via Pump 1 instead — they are published
+        // on the SessionTracking session id (== TrackingSessionId), not liveSessionId.
         // Live-only: Id dropped so it does not contaminate Last-Event-ID reconnection.
         pumps.Add(PumpSbsToolkitAsync(writer, liveSessionId, userId, ct));
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Infrastructure/Services/LiveSessionStreamGatewayTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Infrastructure/Services/LiveSessionStreamGatewayTests.cs
@@ -240,6 +240,54 @@ public sealed class LiveSessionStreamGatewayTests
         Assert.Equal("evt-42", scoreEvt.Id);
     }
 
+    [Fact]
+    public async Task SubscribeAsync_timer_event_on_companion_channel_reaches_subscriber()
+    {
+        // #2579: timer events (Start/Pause/Resume/Reset) are published by the SessionTracking
+        // RandomTool handlers via ISessionBroadcastService.PublishAsync(SessionId, ...), where
+        // SessionId is the SessionTracking session id == the companion's TrackingSessionId. The
+        // native stream therefore carries them via the COMPANION pump (keyed on TrackingSessionId),
+        // NOT the SBS toolkit pump (keyed on liveSessionId). This guards that "session:timer"
+        // reaches the native /live-sessions/{id}/stream surface.
+        // Arrange
+        var liveId = Guid.NewGuid();
+        var companionId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+
+        var timerEnvelope = new SseEventEnvelope
+        {
+            Id = "timer-evt-1",
+            EventType = "session:timer",
+            Data = new { durationSeconds = 60 }
+        };
+
+        var repo = new Mock<ILiveSessionRepository>();
+        repo.Setup(r => r.GetByIdAsync(liveId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(FakeLiveSessionWith(trackingSessionId: companionId));
+
+        var broadcast = new Mock<ISessionBroadcastService>();
+        // Timer arrives on the companion channel (TrackingSessionId) → Pump 1.
+        broadcast
+            .Setup(b => b.SubscribeAsync(companionId, userId, null, It.IsAny<CancellationToken>()))
+            .Returns(SingleEnvelopeAsyncEnumerable(timerEnvelope));
+        // Toolkit channel (liveId) is empty — the timer does NOT come through here.
+        broadcast
+            .Setup(b => b.SubscribeAsync(liveId, userId, null, It.IsAny<CancellationToken>()))
+            .Returns(EmptyEnvelopeAsyncEnumerable());
+
+        var sut = BuildSut(repo.Object, broadcast.Object);
+
+        // Act
+        var events = new List<LiveSessionStreamEvent>();
+        await foreach (var e in sut.SubscribeAsync(liveId, userId, null, CancellationToken.None))
+            events.Add(e);
+
+        // Assert — the timer event reaches the native stream with its type intact
+        var timerEvt = events.FirstOrDefault(e => e.Type == "session:timer");
+        Assert.NotNull(timerEvt);
+        Assert.Equal("timer-evt-1", timerEvt.Id); // companion pump preserves the Id
+    }
+
     // ── SubscribeAsync — SBS toolkit source (a) ───────────────────────────────
 
     [Fact]


### PR DESCRIPTION
## TL;DR

Il "Fix proposto" di #2579 è stato **interamente shippato da PR #2594** (commit `3302ccbd0`): gateway 3-pump che forwarda toolkit/whiteboard/turn/timer/widget al native stream, repoint dei 3 hook (`useTurnOrder`/`useWidgetSync`/`useWhiteboardTool`), fix del bug whiteboard (`session:toolkit`→`session:whiteboard`), e timer mappings in `SseEventTypeMapper`. Questo PR **chiude il gap di verifica** e corregge un commento doc fuorviante. **Nessun cambio di logica di produzione.**

## Investigazione (perché la issue sembrava incompleta)

Il timer **arriva** al native stream, ma via il **companion pump (Pump 1, keyed su `TrackingSessionId`)**, NON il SBS toolkit pump (Pump 2, keyed su `liveSessionId`):
- I `RandomTool` handler (SessionTracking) pubblicano il timer via `PublishAsync(request.SessionId, ...)` dove `request.SessionId` == il SessionTracking session id == `TrackingSessionId` — esattamente il canale a cui Pump 1 si sottoscrive.
- whiteboard/turn, invece, sono pubblicati dai handler **GameManagement** su `liveSessionId` → arrivano via Pump 2.

(Verificato anche end-to-end: `Timer.tsx` consuma `session:timer` via `useSessionStream` sull'endpoint SessionTracking `/api/v1/game-sessions/{id}/stream` — coerente con la pubblicazione su TrackingSessionId.)

## Changes

- **Test di regressione** (`LiveSessionStreamGatewayTests`): un envelope `session:timer` pubblicato sul companion channel raggiunge il native stream con l'Id preservato. **12/12 verdi.**
- **Doc fix** (`LiveSessionStreamGateway`): la XML doc + il commento di Pump 2 elencavano erroneamente il timer sotto la toolkit channel (`liveSessionId`); ora indicano correttamente che il timer arriva via Pump 1 (companion).

Closes #2579

🤖 Generated with [Claude Code](https://claude.com/claude-code)