### PR TITLE
feat(session-live): #2587-A Slice 1 — correlate GameSession + quota at live-session start

### DIFF
--- a/.superpowers/sdd/task-2-report.md
+++ b/.superpowers/sdd/task-2-report.md
@@ -1,106 +1,35 @@
-# Task 2 Report — SP5-c (#2600) Endpoint hook: ensure companion on first subscribe
+# Task 2 Report — #2587 Slice 1: Correlate GameSession + Quota on Live-Session Start
 
-## Fix: stale stream-not-linked header (final-review Important)
+## Status: COMPLETE ✅
 
-**Option chosen:** Option A — changed `EnsureCompanionCommand` from `ICommand` (void) to `ICommand<Guid?>`, returning the post-ensure `TrackingSessionId`. The endpoint uses this return value instead of the stale `ctx.HasCompanion` to decide whether to emit `X-Warning-Code: stream-not-linked`.
+## Changes Made
 
-### Files changed
+### Production Code
+- **`StartLiveSessionCommand.cs`** — enriched record: added `UserId`, `UserTier`, `UserRole` fields
+- **`LifecycleCommandHandlers.cs`** — `StartLiveSessionCommandHandler` rewritten with 2 new dependencies (`IGameSessionRepository`, `ISessionQuotaService`):
+  - Guard `GameId.HasValue && CorrelatedGameSessionId == null`: check quota, create `GameSession`, call `SetCorrelatedGameSessionId`
+  - Single `SaveChangesAsync` commits both atomically
+  - `DbUpdateConcurrencyException` catch → re-fetch → idempotent return if already correlated
+  - Free-form guard (`GameId == null`): skips quota + GameSession creation
+- **`LiveSessionEndpoints.cs`** — `HandleStartSession`: resolves `UserId`/`UserTier`/`UserRole` from `TryGetActiveSession()`, passes to command
 
-| File | Change |
-|------|--------|
-| `apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/LiveSessions/EnsureCompanionCommand.cs` | `ICommand` → `ICommand<Guid?>`, updated XML doc |
-| `apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/LiveSessions/EnsureCompanionCommandHandler.cs` | `ICommandHandler<EnsureCompanionCommand>` → `ICommandHandler<EnsureCompanionCommand, Guid?>`, `Task Handle(…)` → `Task<Guid?> Handle(…)`. All return paths: already-has-companion → returns existing id; free-form → returns null; created → returns new id; concurrency-race-winner → returns winner's id |
-| `apps/api/src/Api/Routing/LiveSessionEndpoints.cs` | Dispatch branch replaced with `isLinkedAfterEnsure` logic: if `ctx.HasCompanion`, skip dispatch (already linked); else dispatch and check `ensuredTrackingId.HasValue`. Warning header uses `!isLinkedAfterEnsure` instead of `!ctx.HasCompanion` |
-| `apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/LiveSessions/EnsureCompanionCommandHandlerTests.cs` | +4 new return-value tests: `Handle_NullCompanionAndGameIdPresent_ReturnsNewCompanionId`, `Handle_AlreadyHasCompanion_ReturnsExistingTrackingSessionId`, `Handle_FreeFormSession_ReturnsNull`, `Handle_ConcurrencyConflict_WhenRefetchShowsCompanionSet_ReturnsWinnersTrackingId`. Added `CreateSessionAlreadyHasCompanionWithKnownId()` helper + `ExistingCompanionId` constant. Total: 16 unit tests (12 original + 4 new) |
-| `apps/api/tests/Api.Tests/Integration/GameManagement/LazyCompanionOnSubscribeTests.cs` | Test 1 (`Subscribe_GameIdBacked_NullCompanion_CreatesCompanion`) extended: added assertion `resp.Headers.Should().NotContainKey("X-Warning-Code")` — the subscribe that just linked the session must NOT receive the warning |
+### Test Code
+- **`LiveSessionCommandHandlerTests.cs`** — updated 4 existing call sites (constructor + command arity); added 5 new TDD tests (a–e); added usings for `QuotaExceededException` and `DbUpdateConcurrencyException`
+- **`LiveSessionValidatorTests.cs`** — updated 2 command instantiations to 4-arg form
+- **`LiveSessionRepositoryIntegrationTests.cs`** — added using; fixed 2 call sites
+- **`LiveSessionDiaryChainIntegrationTests.cs`** — added using; fixed 1 call site
+- **`LiveSessionDiaryEndpointTests.cs`** — added using; fixed 1 call site
 
-### Tests run locally (no Docker)
+## Test Summary
 
-16 unit tests in `EnsureCompanionCommandHandlerTests` — all passed (0 failed).
+**GameManagement Unit Suite**: 1498 passed, 0 failed (+5 new vs 1493 baseline)
 
-```
-Superato Handle_NullCompanionAndGameIdPresent_SetsTrackingSessionId
-Superato Handle_ConcurrencyConflict_WhenRefetchShowsCompanionSet_ReturnsWinnersTrackingId
-Superato Handle_NullCompanionAndGameIdPresent_CreatesCompanionOnce
-Superato Handle_AlreadyHasCompanion_ReturnsExistingTrackingSessionId
-Superato Handle_ConcurrencyConflict_WhenRefetchStillNoCompanion_Rethrows
-Superato Handle_ConcurrencyConflict_WhenRefetchShowsCompanionSet_CompletesSuccessfully
-Superato Handle_ConcurrencyConflict_WhenRefetchShowsCompanionSet_DoesNotCreateSecondCompanion
-Superato Handle_NullCompanionAndGameIdPresent_SavesOnce
-Superato Handle_FreeFormSession_DoesNotSave
-Superato Handle_SessionNotFound_DoesNotCallCreateCompanion
-Superato Handle_FreeFormSession_ReturnsNull
-Superato Handle_AlreadyHasCompanion_DoesNotSave
-Superato Handle_AlreadyHasCompanion_DoesNotCallCreateCompanion
-Superato Handle_SessionNotFound_ThrowsNotFoundException
-Superato Handle_FreeFormSession_DoesNotCallCreateCompanion
-Superato Handle_NullCompanionAndGameIdPresent_ReturnsNewCompanionId
-```
+### New Tests (a–e)
+- **(a)** `StartLiveSession_GameIdBacked_CreatesCorrelatedGameSessionAndChecksQuota` — quota checked, GameSession added, correlation set, single SaveChanges
+- **(b)** `StartLiveSession_QuotaDenied_ThrowsQuotaExceededAndDoesNotCreateGameSession` — QuotaExceededException thrown, no AddAsync, no Start
+- **(c)** `StartLiveSession_AlreadyCorrelated_SkipsGameSessionCreation` — no quota check, no AddAsync, correlation unchanged
+- **(d)** `StartLiveSession_FreeForm_SkipsQuotaAndGameSessionCreation` — no quota, no AddAsync, starts, CorrelatedGameSessionId null
+- **(e)** `StartLiveSession_ConcurrencyException_RefetchShowsCorrelated_ReturnsIdempotently` — DbUpdateConcurrencyException → re-fetch → correlated → returns; SaveChanges once
 
-### Tests needing Docker (CI only)
-
-Integration tests in `LazyCompanionOnSubscribeTests` (Testcontainers / `Integration-GroupC`). Test 1 has been updated with the new header assertion (`NotContainKey("X-Warning-Code")`). Test 2 (free-form → `stream-not-linked` present) and Tests 3–4 unchanged. All 4 compile cleanly.
-
-### Build output
-
-```
-Api         → 0 errors, 0 warnings  (Release)
-Api.Tests   → 0 errors (build)
-Unit tests  → 16/16 passed
-```
-
-### Blocking concerns
-
+## Blocking Concerns
 None.
-
-## Endpoint change (`LiveSessionEndpoints.cs`)
-
-Inserted after the 403 auth guard (line 983) and **before** SSE header writes (line 993):
-
-```csharp
-// SP5-c (#2600 Task 2): lazily provision a companion for legacy GameId-backed sessions
-// that pre-date the SP0 Saga (TrackingSessionId == null && GameId != null).
-if (!ctx.HasCompanion)
-    await mediator.Send(new EnsureCompanionCommand(sessionId), ct).ConfigureAwait(false);
-```
-
-- `IMediator` was already injected into the endpoint delegate — no signature change needed.
-- Context variable is named `ctx` (of type `LiveSessionStreamContextResult`) with property `HasCompanion`.
-- `EnsureCompanionCommand` import was already present via `using Api.BoundedContexts.GameManagement.Application.Commands.LiveSessions;`.
-- The `X-Warning-Code: stream-not-linked` header is preserved as-is (based on the stale `ctx.HasCompanion`). For a GameId-backed legacy session on its first subscribe, the warning fires once; on subsequent subscribes `HasCompanion == true` so no dispatch and no warning. For free-form (GameId==null) sessions the warning is always correct. Cosmetic tradeoff accepted per brief scope.
-- Auth/Found/Authorized short-circuits still fire before the dispatch — unauthorized callers never reach `EnsureCompanionCommand`.
-- The gateway re-reads the session inside `SubscribeAsync` and picks up the freshly-persisted `TrackingSessionId`.
-
-## Integration tests written
-
-File: `apps/api/tests/Api.Tests/Integration/GameManagement/LazyCompanionOnSubscribeTests.cs`
-
-| # | Test | Assertion |
-|---|------|-----------|
-| 1 | `Subscribe_GameIdBacked_NullCompanion_CreatesCompanion` | After subscribe, `TrackingSessionId` non-null AND companion `SessionTracking.Session` row exists |
-| 2 | `Subscribe_FreeForm_NoGameId_DoesNotCreateCompanion` | `TrackingSessionId` stays null, `X-Warning-Code` still set, 0 companion rows |
-| 3 | `Subscribe_AlreadyHasCompanion_CompanionIsUnchanged` | Same `TrackingSessionId`, still exactly 1 companion row, no `X-Warning-Code` |
-| 4 | `Subscribe_Concurrent_CreatesExactlyOneCompanion` | Both subscribes return 200, exactly 1 companion row, 0 orphans |
-
-All 4 tests use `HttpCompletionOption.ResponseHeadersRead` to avoid blocking on the SSE body and `Integration-GroupC` Testcontainers isolation. Legacy row seeding uses direct `LiveGameSessionEntity` insert (bypassing `CreateLiveSessionCommand` which would auto-create via SP0 Saga). Test 3 seeds a `SessionTracking.SessionEntity` with string-enum values (`SessionType="GameSpecific"`, `Status="Active"`) matching `SessionMapper.ToEntity`.
-
-## Tests executed vs. need Docker
-
-- **Ran and passed (no Docker)**: `Category=Unit` filter — 20,162 unit tests, 0 failures. Includes Task 1's `EnsureCompanionCommandHandlerTests`.
-- **Need Docker (Testcontainers)**: All 4 new integration tests in `LazyCompanionOnSubscribeTests`. Not executed locally — Testcontainers requires Docker which is unavailable in this environment. Tests compile cleanly (`dotnet build` 0 errors).
-
-## Build output
-
-```
-Api         → 0 warnings, 0 errors  (54s)
-Api.Tests   → 0 errors (202 pre-existing xUnit/Sonar warnings, unchanged)  (23s)
-Unit tests  → 20162 passed, 0 failed
-```
-
-## Concurrency test (Test 4) feasibility
-
-The in-process `TestHost` dispatches concurrent HTTP requests in separate Task contexts with independent DI scopes, so both `EnsureCompanionCommand` handlers execute concurrently against the same DB row. The xmin optimistic-concurrency token (ADR-060) ensures only one `SaveChanges` wins; the loser catches `DbUpdateConcurrencyException`, re-fetches, sees `TrackingSessionId != null`, and returns idempotently. Test 4 is valid in the Testcontainers harness.
-
-## Blocking concerns
-
-None. Change is minimal (1 guard + 1 await), handler is idempotent + race-safe (Task 1), existing `LiveSessionStreamEndpointTests` (AC-1 to AC-4) are unaffected.

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/LiveSessions/LifecycleCommandHandlers.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/LiveSessions/LifecycleCommandHandlers.cs
@@ -205,9 +205,11 @@ internal class CompleteLiveSessionCommandHandler : ICommandHandler<CompleteLiveS
 
         // Issue #2587 Slice 1: Lifecycle-sync — complete the correlated GameSession so it
         // is no longer counted as active in the user's quota.
-        // The correlated GameSession is created in Setup status at live-session start and is
-        // never explicitly progressed, so we drive it through Start → Complete to honour the
-        // GameSession state machine (Complete() guards InProgress/Paused).
+        // Use MarkCorrelatedComplete (event-free bookkeeping) rather than Start()+Complete()
+        // so that no spurious GameSessionStartedEvent / GameSessionCompletedEvent is raised.
+        // The real session lifecycle side-effects are owned by LiveGameSession and its own
+        // domain events; firing them here would generate wrong audit entries and unintentionally
+        // credit SharedGameCatalog contributors (SessionCompletedForContributorsHandler).
         if (session.CorrelatedGameSessionId.HasValue)
         {
             var gameSession = await _gameSessionRepository
@@ -216,11 +218,7 @@ internal class CompleteLiveSessionCommandHandler : ICommandHandler<CompleteLiveS
 
             if (gameSession != null && !gameSession.Status.IsFinished)
             {
-                // Drive from Setup → InProgress → Completed so the domain invariants are met.
-                if (gameSession.Status == SessionStatus.Setup)
-                    gameSession.Start();
-
-                gameSession.Complete();
+                gameSession.MarkCorrelatedComplete(_timeProvider);
                 await _gameSessionRepository.UpdateAsync(gameSession, cancellationToken).ConfigureAwait(false);
             }
             // If gameSession is null or already finished → idempotent, no action.

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/LiveSessions/LifecycleCommandHandlers.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/LiveSessions/LifecycleCommandHandlers.cs
@@ -59,6 +59,7 @@ internal class StartLiveSessionCommandHandler : ICommandHandler<StartLiveSession
                 throw new QuotaExceededException("SessionQuota", quotaResult.DenialReason ?? "Session limit reached");
 
             var players = session.Players
+                .Where(p => p.IsActive)
                 .Select((p, i) => new SessionPlayer(p.DisplayName, i + 1))
                 .ToList();
 
@@ -168,19 +169,25 @@ internal class ResumeLiveSessionCommandHandler : ICommandHandler<ResumeLiveSessi
 /// Handles completing a live session.
 /// Triggers PlayRecord generation via domain events.
 /// Issue #4749: CQRS commands for live sessions.
+/// Issue #2587 Slice 1 T3: Also completes the correlated GameSession (if any) so it stops
+/// counting against the user's active quota. Guard against double-complete when the
+/// GameSession is already in a terminal state (Completed/Abandoned).
 /// </summary>
 internal class CompleteLiveSessionCommandHandler : ICommandHandler<CompleteLiveSessionCommand>
 {
     private readonly ILiveSessionRepository _sessionRepository;
+    private readonly IGameSessionRepository _gameSessionRepository;
     private readonly TimeProvider _timeProvider;
     private readonly IUnitOfWork _unitOfWork;
 
     public CompleteLiveSessionCommandHandler(
         ILiveSessionRepository sessionRepository,
+        IGameSessionRepository gameSessionRepository,
         TimeProvider timeProvider,
         IUnitOfWork unitOfWork)
     {
         _sessionRepository = sessionRepository ?? throw new ArgumentNullException(nameof(sessionRepository));
+        _gameSessionRepository = gameSessionRepository ?? throw new ArgumentNullException(nameof(gameSessionRepository));
         _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
         _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
     }
@@ -195,6 +202,30 @@ internal class CompleteLiveSessionCommandHandler : ICommandHandler<CompleteLiveS
 
         session.Complete(_timeProvider);
         await _sessionRepository.UpdateAsync(session, cancellationToken).ConfigureAwait(false);
+
+        // Issue #2587 Slice 1: Lifecycle-sync — complete the correlated GameSession so it
+        // is no longer counted as active in the user's quota.
+        // The correlated GameSession is created in Setup status at live-session start and is
+        // never explicitly progressed, so we drive it through Start → Complete to honour the
+        // GameSession state machine (Complete() guards InProgress/Paused).
+        if (session.CorrelatedGameSessionId.HasValue)
+        {
+            var gameSession = await _gameSessionRepository
+                .GetByIdAsync(session.CorrelatedGameSessionId.Value, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (gameSession != null && !gameSession.Status.IsFinished)
+            {
+                // Drive from Setup → InProgress → Completed so the domain invariants are met.
+                if (gameSession.Status == SessionStatus.Setup)
+                    gameSession.Start();
+
+                gameSession.Complete();
+                await _gameSessionRepository.UpdateAsync(gameSession, cancellationToken).ConfigureAwait(false);
+            }
+            // If gameSession is null or already finished → idempotent, no action.
+        }
+
         await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
     }
 }

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/LiveSessions/LifecycleCommandHandlers.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/LiveSessions/LifecycleCommandHandlers.cs
@@ -1,27 +1,40 @@
 using Api.BoundedContexts.GameManagement.Application.Commands.LiveSessions;
+using Api.BoundedContexts.GameManagement.Domain.Entities;
 using Api.BoundedContexts.GameManagement.Domain.Repositories;
+using Api.BoundedContexts.GameManagement.Domain.Services;
+using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
 using Api.Middleware.Exceptions;
 using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Domain.Exceptions;
 using Api.SharedKernel.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
 
 namespace Api.BoundedContexts.GameManagement.Application.Commands.LiveSessions;
 
 /// <summary>
 /// Handles starting a live session.
 /// Issue #4749: CQRS commands for live sessions.
+/// Issue #2587 Slice 1 T2: On GameId-backed sessions, enforces quota and creates a correlated
+/// GameSession aggregate so the session appears in history and consumes the user's quota slot.
 /// </summary>
 internal class StartLiveSessionCommandHandler : ICommandHandler<StartLiveSessionCommand>
 {
     private readonly ILiveSessionRepository _sessionRepository;
+    private readonly IGameSessionRepository _gameSessionRepository;
+    private readonly ISessionQuotaService _quotaService;
     private readonly TimeProvider _timeProvider;
     private readonly IUnitOfWork _unitOfWork;
 
     public StartLiveSessionCommandHandler(
         ILiveSessionRepository sessionRepository,
+        IGameSessionRepository gameSessionRepository,
+        ISessionQuotaService quotaService,
         TimeProvider timeProvider,
         IUnitOfWork unitOfWork)
     {
         _sessionRepository = sessionRepository ?? throw new ArgumentNullException(nameof(sessionRepository));
+        _gameSessionRepository = gameSessionRepository ?? throw new ArgumentNullException(nameof(gameSessionRepository));
+        _quotaService = quotaService ?? throw new ArgumentNullException(nameof(quotaService));
         _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
         _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
     }
@@ -34,9 +47,52 @@ internal class StartLiveSessionCommandHandler : ICommandHandler<StartLiveSession
             .ConfigureAwait(false)
             ?? throw new NotFoundException("LiveGameSession", command.SessionId.ToString());
 
+        // Issue #2587 Slice 1: Create correlated GameSession on first start of a GameId-backed session.
+        // Idempotent: CorrelatedGameSessionId != null means correlation already done (re-start guard).
+        if (session.GameId.HasValue && session.CorrelatedGameSessionId == null)
+        {
+            var quotaResult = await _quotaService
+                .CheckQuotaAsync(command.UserId, command.UserTier, command.UserRole, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (!quotaResult.IsAllowed)
+                throw new QuotaExceededException("SessionQuota", quotaResult.DenialReason ?? "Session limit reached");
+
+            var players = session.Players
+                .Select((p, i) => new SessionPlayer(p.DisplayName, i + 1))
+                .ToList();
+
+            var gameSession = new GameSession(
+                id: Guid.NewGuid(),
+                gameId: session.GameId.Value,
+                players: players,
+                createdByUserId: session.CreatedByUserId);
+
+            session.SetCorrelatedGameSessionId(gameSession.Id);
+
+            await _gameSessionRepository.AddAsync(gameSession, cancellationToken).ConfigureAwait(false);
+        }
+
         session.Start(_timeProvider);
         await _sessionRepository.UpdateAsync(session, cancellationToken).ConfigureAwait(false);
-        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (DbUpdateConcurrencyException)
+        {
+            // Race: another concurrent caller already started this session.
+            // Re-fetch to check whether they completed correlation.
+            var refreshed = await _sessionRepository
+                .GetByIdAsync(command.SessionId, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (refreshed?.CorrelatedGameSessionId != null)
+                return; // The winner already correlated — idempotent success.
+
+            throw;
+        }
     }
 }
 

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/LiveSessions/StartLiveSessionCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/LiveSessions/StartLiveSessionCommand.cs
@@ -1,9 +1,16 @@
 using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Domain.ValueObjects;
 
 namespace Api.BoundedContexts.GameManagement.Application.Commands.LiveSessions;
 
 /// <summary>
 /// Command to start a live game session.
 /// Issue #4749: CQRS commands for live sessions.
+/// Issue #2587: Added UserId/UserTier/UserRole for quota enforcement and GameSession correlation at start.
 /// </summary>
-internal record StartLiveSessionCommand(Guid SessionId) : ICommand;
+internal record StartLiveSessionCommand(
+    Guid SessionId,
+    Guid UserId,
+    UserTier UserTier,
+    Role UserRole
+) : ICommand;

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/GameSession.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/GameSession.cs
@@ -224,6 +224,39 @@ internal sealed class GameSession : AggregateRoot<Guid>
     }
 
     /// <summary>
+    /// Transitions the shadow/correlated GameSession directly to Completed from any
+    /// non-terminal state, WITHOUT raising domain events.
+    ///
+    /// Use ONLY when this GameSession is a quota/history shadow of a
+    /// <c>LiveGameSession</c> — i.e. it was created by the Slice 1 correlation saga
+    /// and its lifecycle side-effects (audit, contributor credits) are owned entirely
+    /// by the <c>LiveGameSession</c> and its own domain events. Raising
+    /// <c>GameSessionStartedEvent</c> or <c>GameSessionCompletedEvent</c> here would
+    /// generate spurious audit entries and unintentionally credit SharedGameCatalog
+    /// contributors for sessions they didn't participate in through the normal flow.
+    ///
+    /// Idempotent: if the session is already in a terminal state
+    /// (<see cref="SessionStatus.IsFinished"/>) this is a safe no-op.
+    /// </summary>
+    /// <param name="timeProvider">
+    /// Time provider used to stamp <see cref="CompletedAt"/>. Pass
+    /// <see cref="TimeProvider.System"/> in production; use a fake in tests.
+    /// </param>
+    public void MarkCorrelatedComplete(TimeProvider timeProvider)
+    {
+        ArgumentNullException.ThrowIfNull(timeProvider);
+
+        if (Status.IsFinished)
+            return; // Idempotent: already terminal — no-op.
+
+        Status = SessionStatus.Completed;
+        CompletedAt = timeProvider.GetUtcNow().UtcDateTime;
+
+        // Intentionally NO AddDomainEvent call.
+        // Events for the real session lifecycle are dispatched by LiveGameSession.
+    }
+
+    /// <summary>
     /// Terminates the session due to quota enforcement.
     /// Issue #3671: Automatic termination when user exceeds session quota.
     /// </summary>

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/LiveGameSession.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/LiveGameSession.cs
@@ -71,6 +71,19 @@ internal sealed class LiveGameSession : AggregateRoot<Guid>
     /// This is the real cross-BC correlation bridge (replaces the dead-code ChatSessionId).
     /// </summary>
     public Guid? TrackingSessionId { get; private set; }
+
+    /// <summary>
+    /// Id of the GameManagement <c>GameSession</c> aggregate correlated at session-start
+    /// (Direzione A, ADR-083, Issue #2587 Slice 1).
+    /// Non-null for sessions that were started with a catalog <see cref="GameId"/>; null for
+    /// free-form sessions (no <c>GameId</c>) and sessions started before Slice 1 was deployed
+    /// (lazy back-fill tracked separately).
+    /// This link is the quota/lifecycle/history bridge: the <c>GameSession</c> owns
+    /// the per-user quota counter and the public play-history visible in
+    /// <c>UserLibrary</c>.
+    /// </summary>
+    public Guid? CorrelatedGameSessionId { get; private set; }
+
     public uint Xmin { get; private set; }
 
     // === Read-only collections ===
@@ -124,7 +137,8 @@ internal sealed class LiveGameSession : AggregateRoot<Guid>
         SessionScoringConfig? scoringConfig = null,
         AgentSessionMode agentMode = AgentSessionMode.None,
         TurnAdvancePolicy turnAdvancePolicy = TurnAdvancePolicy.Manual,
-        Guid? trackingSessionId = null)
+        Guid? trackingSessionId = null,
+        Guid? correlatedGameSessionId = null)
     {
         if (id == Guid.Empty)
             throw new ValidationException("Session ID cannot be empty");
@@ -161,7 +175,8 @@ internal sealed class LiveGameSession : AggregateRoot<Guid>
             ScoringConfig = scoringConfig ?? SessionScoringConfig.CreateDefault(),
             AgentMode = agentMode,
             TurnAdvancePolicy = turnAdvancePolicy,
-            TrackingSessionId = trackingSessionId
+            TrackingSessionId = trackingSessionId,
+            CorrelatedGameSessionId = correlatedGameSessionId
         };
 
         session.AddDomainEvent(new LiveSessionCreatedEvent(id, createdByUserId, trimmedName, gameId));
@@ -210,7 +225,8 @@ internal sealed class LiveGameSession : AggregateRoot<Guid>
         IEnumerable<TurnRecord> turnRecords,
         IEnumerable<RuleDisputeEntry> disputes,
         IEnumerable<DiaryEntry> diaryEntries,
-        SetupChecklistData? setupChecklist)
+        SetupChecklistData? setupChecklist,
+        Guid? correlatedGameSessionId = null)
     {
         var session = new LiveGameSession
         {
@@ -240,6 +256,7 @@ internal sealed class LiveGameSession : AggregateRoot<Guid>
             AgentMode = agentMode,
             TurnAdvancePolicy = turnAdvancePolicy,
             TrackingSessionId = trackingSessionId,
+            CorrelatedGameSessionId = correlatedGameSessionId,
             Xmin = xmin
         };
 
@@ -873,6 +890,42 @@ internal sealed class LiveGameSession : AggregateRoot<Guid>
                 $"Cannot overwrite with a different companion id {companionId}.");
 
         TrackingSessionId = companionId;
+    }
+
+    /// <summary>
+    /// Associates the <c>GameManagement.GameSession</c> quota/lifecycle aggregate with this
+    /// live session (Direzione A, ADR-083, Issue #2587 Slice 1).
+    /// Called by <c>StartLiveSessionCommandHandler</c> immediately after creating the
+    /// correlated <c>GameSession</c> during session start.
+    /// <para>
+    /// Idempotency semantics (mirror of <see cref="SetTrackingSessionId"/>):
+    /// <list type="bullet">
+    ///   <item>If <see cref="CorrelatedGameSessionId"/> is <see langword="null"/> → sets the property.</item>
+    ///   <item>If <see cref="CorrelatedGameSessionId"/> equals <paramref name="companionId"/> → no-op (idempotent re-start guard).</item>
+    ///   <item>If <see cref="CorrelatedGameSessionId"/> is already set to a <em>different</em> value →
+    ///         throws <see cref="InvalidOperationException"/> (programmer error: two conflicting companions).</item>
+    /// </list>
+    /// </para>
+    /// </summary>
+    /// <param name="companionId">The id of the newly-created <c>GameManagement.GameSession</c> aggregate.</param>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="companionId"/> is <see cref="Guid.Empty"/>.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown when <see cref="CorrelatedGameSessionId"/> is already set to a different, non-empty value.
+    /// </exception>
+    public void SetCorrelatedGameSessionId(Guid companionId)
+    {
+        if (companionId == Guid.Empty)
+            throw new ArgumentException("Correlated GameSession id cannot be empty.", nameof(companionId));
+
+        if (CorrelatedGameSessionId == companionId)
+            return; // no-op — idempotent re-start guard
+
+        if (CorrelatedGameSessionId.HasValue)
+            throw new InvalidOperationException(
+                $"CorrelatedGameSessionId is already set to {CorrelatedGameSessionId.Value} on live session {Id}. " +
+                $"Cannot overwrite with a different companion id {companionId}.");
+
+        CorrelatedGameSessionId = companionId;
     }
 
     // === Query Methods ===

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Persistence/Mappers/LiveGameSessionMapper.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Persistence/Mappers/LiveGameSessionMapper.cs
@@ -66,6 +66,7 @@ internal static class LiveGameSessionMapper
             Notes = domain.Notes,
             AgentMode = (int)domain.AgentMode,
             TrackingSessionId = domain.TrackingSessionId,
+            CorrelatedGameSessionId = domain.CorrelatedGameSessionId,
             // Xmin is Postgres-system-owned (Issue #2305); EF round-trips it via xid mapping.
             // Mapper passes the current domain value back so EF emits WHERE xmin = @original.
             Xmin = domain.Xmin
@@ -291,7 +292,8 @@ internal static class LiveGameSessionMapper
             turnRecords: turnRecords,
             disputes: disputes,
             diaryEntries: diaryEntries,
-            setupChecklist: setupChecklist);
+            setupChecklist: setupChecklist,
+            correlatedGameSessionId: entity.CorrelatedGameSessionId);
     }
 
     // ── Serialization helpers for types not directly deserializable by STJ ──

--- a/apps/api/src/Api/Infrastructure/Configurations/GameManagement/LiveGameSessionEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/Configurations/GameManagement/LiveGameSessionEntityConfiguration.cs
@@ -113,6 +113,10 @@ internal sealed class LiveGameSessionEntityConfiguration : IEntityTypeConfigurat
         builder.Property(e => e.TrackingSessionId)
             .HasColumnName("tracking_session_id");
 
+        // ADR-083 #2587 Slice 1: correlated GameManagement.GameSession (quota/lifecycle aggregate).
+        builder.Property(e => e.CorrelatedGameSessionId)
+            .HasColumnName("correlated_game_session_id");
+
         // --- JSON Columns ---
 
         builder.Property(e => e.ScoringConfigJson)

--- a/apps/api/src/Api/Infrastructure/Entities/GameManagement/LiveGameSessionEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/GameManagement/LiveGameSessionEntity.cs
@@ -67,6 +67,9 @@ public class LiveGameSessionEntity
     // ADR-083 SP0: id of the SessionTracking.Session companion (cross-BC correlation bridge).
     public Guid? TrackingSessionId { get; set; }
 
+    // ADR-083 #2587 Slice 1: id of the GameManagement.GameSession quota/lifecycle aggregate correlated at start.
+    public Guid? CorrelatedGameSessionId { get; set; }
+
     // Optimistic concurrency via PostgreSQL's xmin system column (Issue #2305).
     // Postgres assigns xmin = transaction-id-of-last-write per row; EF reads back via the
     // xid type-mapped uint property. Server-owned: NO mapper assignment, NO client default,

--- a/apps/api/src/Api/Infrastructure/Migrations/20260630084208_AddCorrelatedGameSessionId.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260630084208_AddCorrelatedGameSessionId.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260630084208_AddCorrelatedGameSessionId")]
+    partial class AddCorrelatedGameSessionId
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260630084208_AddCorrelatedGameSessionId.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260630084208_AddCorrelatedGameSessionId.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCorrelatedGameSessionId : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "correlated_game_session_id",
+                table: "live_game_sessions",
+                type: "uuid",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "correlated_game_session_id",
+                table: "live_game_sessions");
+        }
+    }
+}

--- a/apps/api/src/Api/Routing/LiveSessionEndpoints.cs
+++ b/apps/api/src/Api/Routing/LiveSessionEndpoints.cs
@@ -18,6 +18,7 @@ using Api.BoundedContexts.GameManagement.Domain.Models;
 using Api.BoundedContexts.KnowledgeBase.Application.Commands;
 using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
 using Api.Extensions;
+using Api.SharedKernel.Domain.ValueObjects;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
 
@@ -478,9 +479,20 @@ internal static class LiveSessionEndpoints
     private static async Task<IResult> HandleStartSession(
         Guid sessionId,
         [FromServices] IMediator mediator,
+        HttpContext httpContext,
         CancellationToken cancellationToken)
     {
-        await mediator.Send(new StartLiveSessionCommand(sessionId), cancellationToken).ConfigureAwait(false);
+        // Issue #2587 Slice 1: Resolve user identity for quota enforcement and GameSession correlation.
+        var (authenticated, session, error) = httpContext.TryGetActiveSession();
+        if (!authenticated) return error!;
+
+        var userId = session!.Principal!.Subject.Id;
+        var userTier = UserTier.Parse(session.Principal!.Subject.Tier);
+        var userRole = Role.Parse(session.Principal!.EffectiveActor.Role);
+
+        await mediator.Send(
+            new StartLiveSessionCommand(sessionId, userId, userTier, userRole),
+            cancellationToken).ConfigureAwait(false);
         return Results.NoContent();
     }
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/LiveSessions/LiveSessionCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/LiveSessions/LiveSessionCommandHandlerTests.cs
@@ -421,6 +421,10 @@ public class LiveSessionCommandHandlerTests
 
     #region CompleteLiveSessionCommandHandler
 
+    // Helper: build a CompleteLiveSessionCommandHandler with both repositories injected.
+    private CompleteLiveSessionCommandHandler BuildCompleteHandler() =>
+        new(_repositoryMock.Object, _gameSessionRepositoryMock.Object, _timeProvider, _unitOfWorkMock.Object);
+
     [Fact]
     public async Task CompleteLiveSession_HappyPath_CompletesSession()
     {
@@ -429,7 +433,7 @@ public class LiveSessionCommandHandlerTests
         var session = CreateSessionInProgress(sessionId);
         SetupRepoGetById(sessionId, session);
 
-        var handler = new CompleteLiveSessionCommandHandler(_repositoryMock.Object, _timeProvider, _unitOfWorkMock.Object);
+        var handler = BuildCompleteHandler();
         var command = new CompleteLiveSessionCommand(sessionId);
 
         // Act
@@ -450,7 +454,7 @@ public class LiveSessionCommandHandlerTests
         var sessionId = Guid.NewGuid();
         SetupRepoGetById(sessionId, null);
 
-        var handler = new CompleteLiveSessionCommandHandler(_repositoryMock.Object, _timeProvider, _unitOfWorkMock.Object);
+        var handler = BuildCompleteHandler();
         var command = new CompleteLiveSessionCommand(sessionId);
 
         // Act & Assert
@@ -464,12 +468,183 @@ public class LiveSessionCommandHandlerTests
     public async Task CompleteLiveSession_NullCommand_ThrowsArgumentNullException()
     {
         // Arrange
-        var handler = new CompleteLiveSessionCommandHandler(_repositoryMock.Object, _timeProvider, _unitOfWorkMock.Object);
+        var handler = BuildCompleteHandler();
 
         // Act & Assert
         var act =
             () => handler.Handle(null!, TestContext.Current.CancellationToken);
         await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    // ─── Issue #2587 Slice 1 T3: Lifecycle-sync tests ─────────────────────────────
+
+    [Fact(DisplayName = "#2587-T3a: Complete with CorrelatedGameSessionId → GameSession loaded, completed, one SaveChanges")]
+    public async Task CompleteLiveSession_WithCorrelatedGameSession_CompletesGameSessionAndSavesOnce()
+    {
+        // Arrange
+        var sessionId = Guid.NewGuid();
+        var gameId = Guid.NewGuid();
+        var correlatedId = Guid.NewGuid();
+
+        // LiveGameSession that has a correlated GameSession
+        var session = LiveGameSession.Create(
+            sessionId, DefaultUserId, "Catan",
+            gameId: gameId,
+            correlatedGameSessionId: correlatedId);
+        session.AddPlayer(null, "Alice", PlayerColor.Red, TimeProvider.System);
+        session.Start(TimeProvider.System);
+        SetupRepoGetById(sessionId, session);
+
+        // Correlated GameSession in Setup state (as created by T2)
+        var gameSession = new GameSession(correlatedId, gameId,
+            new[] { new SessionPlayer("Alice", 1) }, DefaultUserId);
+        _gameSessionRepositoryMock
+            .Setup(r => r.GetByIdAsync(correlatedId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(gameSession);
+
+        GameSession? updatedGameSession = null;
+        _gameSessionRepositoryMock
+            .Setup(r => r.UpdateAsync(It.IsAny<GameSession>(), It.IsAny<CancellationToken>()))
+            .Callback<GameSession, CancellationToken>((gs, _) => updatedGameSession = gs)
+            .Returns(Task.CompletedTask);
+
+        var handler = BuildCompleteHandler();
+        var command = new CompleteLiveSessionCommand(sessionId);
+
+        // Act
+        await handler.Handle(command, TestContext.Current.CancellationToken);
+
+        // Assert — LiveGameSession completed
+        session.Status.Should().Be(LiveSessionStatus.Completed);
+
+        // Assert — correlated GameSession loaded and completed
+        _gameSessionRepositoryMock.Verify(
+            r => r.GetByIdAsync(correlatedId, It.IsAny<CancellationToken>()),
+            Times.Once);
+        _gameSessionRepositoryMock.Verify(
+            r => r.UpdateAsync(It.IsAny<GameSession>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        updatedGameSession.Should().NotBeNull();
+        updatedGameSession!.Status.Should().Be(SessionStatus.Completed);
+
+        // Assert — single SaveChanges commits both
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact(DisplayName = "#2587-T3b: Free-form session (CorrelatedGameSessionId == null) → no GameSession repo call")]
+    public async Task CompleteLiveSession_FreeForm_NoGameSessionRepoCall()
+    {
+        // Arrange
+        var sessionId = Guid.NewGuid();
+        var session = CreateSessionInProgress(sessionId); // no GameId, no correlation
+        SetupRepoGetById(sessionId, session);
+
+        var handler = BuildCompleteHandler();
+        var command = new CompleteLiveSessionCommand(sessionId);
+
+        // Act
+        await handler.Handle(command, TestContext.Current.CancellationToken);
+
+        // Assert — LiveGameSession completed
+        session.Status.Should().Be(LiveSessionStatus.Completed);
+
+        // Assert — GameSession repo never touched
+        _gameSessionRepositoryMock.Verify(
+            r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _gameSessionRepositoryMock.Verify(
+            r => r.UpdateAsync(It.IsAny<GameSession>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+
+        // Assert — still one SaveChanges
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact(DisplayName = "#2587-T3c: Correlated GameSession already Completed → idempotent, no double-complete")]
+    public async Task CompleteLiveSession_CorrelatedGameSessionAlreadyCompleted_NoDoubleComplete()
+    {
+        // Arrange
+        var sessionId = Guid.NewGuid();
+        var gameId = Guid.NewGuid();
+        var correlatedId = Guid.NewGuid();
+
+        var session = LiveGameSession.Create(
+            sessionId, DefaultUserId, "Catan",
+            gameId: gameId,
+            correlatedGameSessionId: correlatedId);
+        session.AddPlayer(null, "Alice", PlayerColor.Red, TimeProvider.System);
+        session.Start(TimeProvider.System);
+        SetupRepoGetById(sessionId, session);
+
+        // GameSession already in terminal Completed state
+        var gameSession = new GameSession(correlatedId, gameId,
+            new[] { new SessionPlayer("Alice", 1) }, DefaultUserId);
+        gameSession.Start();
+        gameSession.Complete();
+
+        _gameSessionRepositoryMock
+            .Setup(r => r.GetByIdAsync(correlatedId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(gameSession);
+
+        var handler = BuildCompleteHandler();
+        var command = new CompleteLiveSessionCommand(sessionId);
+
+        // Act — must not throw (idempotent)
+        await handler.Handle(command, TestContext.Current.CancellationToken);
+
+        // Assert — UpdateAsync never called on the already-completed GameSession
+        _gameSessionRepositoryMock.Verify(
+            r => r.UpdateAsync(It.IsAny<GameSession>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+
+        // Assert — LiveGameSession itself is completed
+        session.Status.Should().Be(LiveSessionStatus.Completed);
+
+        // Assert — single SaveChanges
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    // ─── Issue #2587 Slice 1 T3 Part B: active-player filter in Start ─────────────
+
+    [Fact(DisplayName = "#2587-T3-partB: Inactive player excluded from correlated GameSession player list")]
+    public async Task StartLiveSession_InactivePlayerExcluded_FromCorrelatedGameSessionPlayers()
+    {
+        // Arrange
+        var sessionId = Guid.NewGuid();
+        var gameId = Guid.NewGuid();
+
+        var session = LiveGameSession.Create(sessionId, DefaultUserId, "Catan", gameId: gameId);
+
+        // Add two players: one will be removed (deactivated), one stays active
+        var removedPlayer = session.AddPlayer(null, "Removed Player", PlayerColor.Red, TimeProvider.System);
+        session.AddPlayer(null, "Active Player", PlayerColor.Blue, TimeProvider.System);
+        // Simulate RemovePlayer which deactivates the player
+        session.RemovePlayer(removedPlayer.Id, TimeProvider.System);
+
+        SetupRepoGetById(sessionId, session);
+
+        GameSession? capturedGameSession = null;
+        _gameSessionRepositoryMock
+            .Setup(r => r.AddAsync(It.IsAny<GameSession>(), It.IsAny<CancellationToken>()))
+            .Callback<GameSession, CancellationToken>((gs, _) => capturedGameSession = gs)
+            .Returns(Task.CompletedTask);
+
+        var handler = new StartLiveSessionCommandHandler(
+            _repositoryMock.Object,
+            _gameSessionRepositoryMock.Object,
+            _quotaServiceMock.Object,
+            _timeProvider,
+            _unitOfWorkMock.Object);
+        var command = new StartLiveSessionCommand(sessionId, DefaultUserId, DefaultUserTier, DefaultUserRole);
+
+        // Act
+        await handler.Handle(command, TestContext.Current.CancellationToken);
+
+        // Assert — only the active player ("Active Player") maps to the GameSession
+        capturedGameSession.Should().NotBeNull();
+        capturedGameSession!.Players.Should().ContainSingle(
+            because: "the inactive/removed player must be excluded by the .Where(p => p.IsActive) filter");
+        capturedGameSession.Players[0].PlayerName.Should().Be("Active Player");
     }
 
     #endregion

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/LiveSessions/LiveSessionCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/LiveSessions/LiveSessionCommandHandlerTests.cs
@@ -527,6 +527,16 @@ public class LiveSessionCommandHandlerTests
         updatedGameSession.Should().NotBeNull();
         updatedGameSession!.Status.Should().Be(SessionStatus.Completed);
 
+        // Assert — event-free bookkeeping: MarkCorrelatedComplete must NOT raise
+        // GameSessionStartedEvent or GameSessionCompletedEvent (spurious audit + contributor
+        // credits via SessionCompletedForContributorsHandler — controller review finding).
+        updatedGameSession.DomainEvents.Should().NotContain(
+            e => e is Api.BoundedContexts.GameManagement.Domain.Events.GameSessionStartedEvent,
+            because: "shadow correlated complete must not fire GameSessionStartedEvent");
+        updatedGameSession.DomainEvents.Should().NotContain(
+            e => e is Api.BoundedContexts.GameManagement.Domain.Events.GameSessionCompletedEvent,
+            because: "shadow correlated complete must not fire GameSessionCompletedEvent");
+
         // Assert — single SaveChanges commits both
         _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
     }

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/LiveSessions/LiveSessionCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/LiveSessions/LiveSessionCommandHandlerTests.cs
@@ -3,9 +3,13 @@ using Api.BoundedContexts.GameManagement.Application.Services;
 using Api.BoundedContexts.GameManagement.Domain.Entities;
 using Api.BoundedContexts.GameManagement.Domain.Enums;
 using Api.BoundedContexts.GameManagement.Domain.Repositories;
+using Api.BoundedContexts.GameManagement.Domain.Services;
 using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
 using Api.Middleware.Exceptions;
+using Api.SharedKernel.Domain.Exceptions;
+using Api.SharedKernel.Domain.ValueObjects;
 using Api.SharedKernel.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
 using Api.Tests.Constants;
 using Moq;
 using Xunit;
@@ -22,6 +26,8 @@ namespace Api.Tests.BoundedContexts.GameManagement.Application.Handlers.LiveSess
 public class LiveSessionCommandHandlerTests
 {
     private readonly Mock<ILiveSessionRepository> _repositoryMock;
+    private readonly Mock<IGameSessionRepository> _gameSessionRepositoryMock;
+    private readonly Mock<ISessionQuotaService> _quotaServiceMock;
     private readonly TimeProvider _timeProvider;
     private readonly Mock<IUnitOfWork> _unitOfWorkMock;
     // #2501 SP0: companion-saga ACL dependency. Default mock returns Guid.Empty for
@@ -31,13 +37,22 @@ public class LiveSessionCommandHandlerTests
     private readonly Mock<ICompanionSessionService> _companionSessionServiceMock;
 
     private static readonly Guid DefaultUserId = Guid.NewGuid();
+    private static readonly UserTier DefaultUserTier = UserTier.Premium;
+    private static readonly Role DefaultUserRole = Role.Admin;
 
     public LiveSessionCommandHandlerTests()
     {
         _repositoryMock = new Mock<ILiveSessionRepository>();
+        _gameSessionRepositoryMock = new Mock<IGameSessionRepository>();
+        _quotaServiceMock = new Mock<ISessionQuotaService>();
         _timeProvider = TimeProvider.System;
         _unitOfWorkMock = new Mock<IUnitOfWork>();
         _companionSessionServiceMock = new Mock<ICompanionSessionService>();
+
+        // Default: quota allowed (Premium/Admin bypass)
+        _quotaServiceMock
+            .Setup(q => q.CheckQuotaAsync(It.IsAny<Guid>(), It.IsAny<UserTier>(), It.IsAny<Role>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SessionQuotaResult.Unlimited());
     }
 
     // === Shared Helpers ===
@@ -240,8 +255,8 @@ public class LiveSessionCommandHandlerTests
         var session = CreateSessionWithPlayer(sessionId);
         SetupRepoGetById(sessionId, session);
 
-        var handler = new StartLiveSessionCommandHandler(_repositoryMock.Object, _timeProvider, _unitOfWorkMock.Object);
-        var command = new StartLiveSessionCommand(sessionId);
+        var handler = new StartLiveSessionCommandHandler(_repositoryMock.Object, _gameSessionRepositoryMock.Object, _quotaServiceMock.Object, _timeProvider, _unitOfWorkMock.Object);
+        var command = new StartLiveSessionCommand(sessionId, DefaultUserId, DefaultUserTier, DefaultUserRole);
 
         // Act
         await handler.Handle(command, TestContext.Current.CancellationToken);
@@ -260,8 +275,8 @@ public class LiveSessionCommandHandlerTests
         var sessionId = Guid.NewGuid();
         SetupRepoGetById(sessionId, null);
 
-        var handler = new StartLiveSessionCommandHandler(_repositoryMock.Object, _timeProvider, _unitOfWorkMock.Object);
-        var command = new StartLiveSessionCommand(sessionId);
+        var handler = new StartLiveSessionCommandHandler(_repositoryMock.Object, _gameSessionRepositoryMock.Object, _quotaServiceMock.Object, _timeProvider, _unitOfWorkMock.Object);
+        var command = new StartLiveSessionCommand(sessionId, DefaultUserId, DefaultUserTier, DefaultUserRole);
 
         // Act & Assert
         var act =
@@ -274,7 +289,7 @@ public class LiveSessionCommandHandlerTests
     public async Task StartLiveSession_NullCommand_ThrowsArgumentNullException()
     {
         // Arrange
-        var handler = new StartLiveSessionCommandHandler(_repositoryMock.Object, _timeProvider, _unitOfWorkMock.Object);
+        var handler = new StartLiveSessionCommandHandler(_repositoryMock.Object, _gameSessionRepositoryMock.Object, _quotaServiceMock.Object, _timeProvider, _unitOfWorkMock.Object);
 
         // Act & Assert
         var act =
@@ -1187,8 +1202,8 @@ public class LiveSessionCommandHandlerTests
         var session = CreateSessionWithPlayer(sessionId);
         SetupRepoGetById(sessionId, session);
 
-        var handler = new StartLiveSessionCommandHandler(_repositoryMock.Object, _timeProvider, _unitOfWorkMock.Object);
-        var command = new StartLiveSessionCommand(sessionId);
+        var handler = new StartLiveSessionCommandHandler(_repositoryMock.Object, _gameSessionRepositoryMock.Object, _quotaServiceMock.Object, _timeProvider, _unitOfWorkMock.Object);
+        var command = new StartLiveSessionCommand(sessionId, DefaultUserId, DefaultUserTier, DefaultUserRole);
         using var cts = new CancellationTokenSource();
         var ct = cts.Token;
 
@@ -1198,6 +1213,208 @@ public class LiveSessionCommandHandlerTests
         // Assert
         _repositoryMock.Verify(r => r.GetByIdAsync(sessionId, ct), Times.Once);
         _repositoryMock.Verify(r => r.UpdateAsync(session, ct), Times.Once);
+    }
+
+    // ─── Issue #2587 Slice 1: GameSession correlation + quota enforcement ───
+
+    [Fact(DisplayName = "#2587-a: GameId-backed session — quota checked, GameSession created, correlated, one SaveChanges")]
+    public async Task StartLiveSession_GameIdBacked_CreatesCorrelatedGameSessionAndChecksQuota()
+    {
+        // Arrange
+        var sessionId = Guid.NewGuid();
+        var gameId = Guid.NewGuid();
+        var session = LiveGameSession.Create(sessionId, DefaultUserId, "Catan", gameId: gameId);
+        session.AddPlayer(null, "Alice", PlayerColor.Red, TimeProvider.System);
+        SetupRepoGetById(sessionId, session);
+
+        GameSession? capturedGameSession = null;
+        _gameSessionRepositoryMock
+            .Setup(r => r.AddAsync(It.IsAny<GameSession>(), It.IsAny<CancellationToken>()))
+            .Callback<GameSession, CancellationToken>((gs, _) => capturedGameSession = gs)
+            .Returns(Task.CompletedTask);
+
+        var handler = new StartLiveSessionCommandHandler(
+            _repositoryMock.Object,
+            _gameSessionRepositoryMock.Object,
+            _quotaServiceMock.Object,
+            _timeProvider,
+            _unitOfWorkMock.Object);
+        var command = new StartLiveSessionCommand(sessionId, DefaultUserId, DefaultUserTier, DefaultUserRole);
+
+        // Act
+        await handler.Handle(command, TestContext.Current.CancellationToken);
+
+        // Assert — quota was checked
+        _quotaServiceMock.Verify(
+            q => q.CheckQuotaAsync(DefaultUserId, DefaultUserTier, DefaultUserRole, It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        // Assert — GameSession was added with correct gameId + createdByUserId
+        _gameSessionRepositoryMock.Verify(
+            r => r.AddAsync(It.IsAny<GameSession>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        capturedGameSession.Should().NotBeNull();
+        capturedGameSession!.GameId.Should().Be(gameId);
+        capturedGameSession.CreatedByUserId.Should().Be(DefaultUserId);
+
+        // Assert — correlation set
+        session.CorrelatedGameSessionId.Should().Be(capturedGameSession.Id);
+
+        // Assert — session started
+        session.Status.Should().Be(LiveSessionStatus.InProgress);
+
+        // Assert — single SaveChanges
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact(DisplayName = "#2587-b: Quota denied — throws QuotaExceededException, no GameSession added, no Start")]
+    public async Task StartLiveSession_QuotaDenied_ThrowsQuotaExceededAndDoesNotCreateGameSession()
+    {
+        // Arrange
+        var sessionId = Guid.NewGuid();
+        var gameId = Guid.NewGuid();
+        var session = LiveGameSession.Create(sessionId, DefaultUserId, "Catan", gameId: gameId);
+        session.AddPlayer(null, "Alice", PlayerColor.Red, TimeProvider.System);
+        SetupRepoGetById(sessionId, session);
+
+        _quotaServiceMock
+            .Setup(q => q.CheckQuotaAsync(It.IsAny<Guid>(), It.IsAny<UserTier>(), It.IsAny<Role>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SessionQuotaResult.Denied("Limit reached", currentCount: 3, maxAllowed: 3));
+
+        var handler = new StartLiveSessionCommandHandler(
+            _repositoryMock.Object,
+            _gameSessionRepositoryMock.Object,
+            _quotaServiceMock.Object,
+            _timeProvider,
+            _unitOfWorkMock.Object);
+        var command = new StartLiveSessionCommand(sessionId, DefaultUserId, DefaultUserTier, DefaultUserRole);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<QuotaExceededException>(
+            () => handler.Handle(command, TestContext.Current.CancellationToken));
+
+        _gameSessionRepositoryMock.Verify(
+            r => r.AddAsync(It.IsAny<GameSession>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        session.Status.Should().Be(LiveSessionStatus.Created);
+    }
+
+    [Fact(DisplayName = "#2587-c: Already-correlated — no second GameSession, idempotent Start")]
+    public async Task StartLiveSession_AlreadyCorrelated_SkipsGameSessionCreation()
+    {
+        // Arrange
+        var sessionId = Guid.NewGuid();
+        var gameId = Guid.NewGuid();
+        var existingCorrelationId = Guid.NewGuid();
+        var session = LiveGameSession.Create(
+            sessionId, DefaultUserId, "Catan",
+            gameId: gameId,
+            correlatedGameSessionId: existingCorrelationId);
+        session.AddPlayer(null, "Alice", PlayerColor.Red, TimeProvider.System);
+        SetupRepoGetById(sessionId, session);
+
+        var handler = new StartLiveSessionCommandHandler(
+            _repositoryMock.Object,
+            _gameSessionRepositoryMock.Object,
+            _quotaServiceMock.Object,
+            _timeProvider,
+            _unitOfWorkMock.Object);
+        var command = new StartLiveSessionCommand(sessionId, DefaultUserId, DefaultUserTier, DefaultUserRole);
+
+        // Act
+        await handler.Handle(command, TestContext.Current.CancellationToken);
+
+        // Assert — AddAsync never called
+        _gameSessionRepositoryMock.Verify(
+            r => r.AddAsync(It.IsAny<GameSession>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+
+        // Assert — quota check skipped (already correlated guard short-circuits)
+        _quotaServiceMock.Verify(
+            q => q.CheckQuotaAsync(It.IsAny<Guid>(), It.IsAny<UserTier>(), It.IsAny<Role>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+
+        // Assert — correlation unchanged
+        session.CorrelatedGameSessionId.Should().Be(existingCorrelationId);
+        session.Status.Should().Be(LiveSessionStatus.InProgress);
+    }
+
+    [Fact(DisplayName = "#2587-d: Free-form (GameId==null) — no quota check, no GameSession, session starts")]
+    public async Task StartLiveSession_FreeForm_SkipsQuotaAndGameSessionCreation()
+    {
+        // Arrange
+        var sessionId = Guid.NewGuid();
+        var session = LiveGameSession.Create(sessionId, DefaultUserId, "Free Play"); // GameId = null
+        session.AddPlayer(null, "Alice", PlayerColor.Red, TimeProvider.System);
+        SetupRepoGetById(sessionId, session);
+
+        var handler = new StartLiveSessionCommandHandler(
+            _repositoryMock.Object,
+            _gameSessionRepositoryMock.Object,
+            _quotaServiceMock.Object,
+            _timeProvider,
+            _unitOfWorkMock.Object);
+        var command = new StartLiveSessionCommand(sessionId, DefaultUserId, DefaultUserTier, DefaultUserRole);
+
+        // Act
+        await handler.Handle(command, TestContext.Current.CancellationToken);
+
+        // Assert
+        _quotaServiceMock.Verify(
+            q => q.CheckQuotaAsync(It.IsAny<Guid>(), It.IsAny<UserTier>(), It.IsAny<Role>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _gameSessionRepositoryMock.Verify(
+            r => r.AddAsync(It.IsAny<GameSession>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        session.Status.Should().Be(LiveSessionStatus.InProgress);
+        session.CorrelatedGameSessionId.Should().BeNull();
+    }
+
+    [Fact(DisplayName = "#2587-e: DbUpdateConcurrencyException — re-fetch shows correlated → idempotent success")]
+    public async Task StartLiveSession_ConcurrencyException_RefetchShowsCorrelated_ReturnsIdempotently()
+    {
+        // Arrange
+        var sessionId = Guid.NewGuid();
+        var gameId = Guid.NewGuid();
+
+        // First GetByIdAsync: returns a fresh Created session (not yet correlated)
+        var session = LiveGameSession.Create(sessionId, DefaultUserId, "Catan", gameId: gameId);
+        session.AddPlayer(null, "Alice", PlayerColor.Red, TimeProvider.System);
+
+        // Re-fetch (after catch): returns a session with correlation already set by the "winner"
+        var correlationId = Guid.NewGuid();
+        var refreshedSession = LiveGameSession.Create(
+            sessionId, DefaultUserId, "Catan",
+            gameId: gameId,
+            correlatedGameSessionId: correlationId);
+
+        var callCount = 0;
+        _repositoryMock
+            .Setup(r => r.GetByIdAsync(sessionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() =>
+            {
+                callCount++;
+                return callCount == 1 ? session : refreshedSession;
+            });
+
+        // SaveChanges throws concurrency exception on the first (and only) attempt
+        _unitOfWorkMock
+            .Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new DbUpdateConcurrencyException());
+
+        var handler = new StartLiveSessionCommandHandler(
+            _repositoryMock.Object,
+            _gameSessionRepositoryMock.Object,
+            _quotaServiceMock.Object,
+            _timeProvider,
+            _unitOfWorkMock.Object);
+        var command = new StartLiveSessionCommand(sessionId, DefaultUserId, DefaultUserTier, DefaultUserRole);
+
+        // Act — must not throw (idempotent success)
+        await handler.Handle(command, TestContext.Current.CancellationToken);
+
+        // Assert — SaveChanges called exactly once (no retry loop)
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
     }
 
     #endregion

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Validators/LiveSessions/LiveSessionValidatorTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Validators/LiveSessions/LiveSessionValidatorTests.cs
@@ -1,6 +1,7 @@
 using Api.BoundedContexts.GameManagement.Application.Commands.LiveSessions;
 using Api.BoundedContexts.GameManagement.Application.Validators.LiveSessions;
 using Api.BoundedContexts.GameManagement.Domain.Enums;
+using Api.SharedKernel.Domain.ValueObjects;
 using Api.Tests.Constants;
 using FluentValidation.TestHelper;
 using Xunit;
@@ -1182,14 +1183,16 @@ public sealed class LiveSessionValidatorTests
     [Fact]
     public async Task Start_ValidSessionId_ShouldPass()
     {
-        var result = await _startValidator.TestValidateAsync(new StartLiveSessionCommand(Guid.NewGuid()));
+        var result = await _startValidator.TestValidateAsync(
+            new StartLiveSessionCommand(Guid.NewGuid(), Guid.NewGuid(), UserTier.Free, Role.User));
         result.ShouldNotHaveAnyValidationErrors();
     }
 
     [Fact]
     public async Task Start_EmptySessionId_ShouldFail()
     {
-        var result = await _startValidator.TestValidateAsync(new StartLiveSessionCommand(Guid.Empty));
+        var result = await _startValidator.TestValidateAsync(
+            new StartLiveSessionCommand(Guid.Empty, Guid.NewGuid(), UserTier.Free, Role.User));
         result.ShouldHaveValidationErrorFor(x => x.SessionId)
             .WithErrorMessage("Session ID is required");
     }

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/Entities/GameSessionTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/Entities/GameSessionTests.cs
@@ -1,4 +1,5 @@
 using Api.BoundedContexts.GameManagement.Domain.Entities;
+using Api.BoundedContexts.GameManagement.Domain.Events;
 using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
 using Api.SharedKernel.Domain.Exceptions;
 using FluentAssertions;
@@ -1041,6 +1042,87 @@ public sealed class GameSessionTests
         // Assert
         session.Status.Should().Be(SessionStatus.Abandoned);
         session.Notes.Should().Contain("Player disconnected");
+    }
+
+    #endregion
+
+    // =============================================================================
+    // region MarkCorrelatedComplete — event-free shadow lifecycle (controller review #2587)
+    // =============================================================================
+
+    #region MarkCorrelatedComplete Tests
+
+    [Fact(DisplayName = "#2587-fix: MarkCorrelatedComplete from Setup → Completed, no domain events")]
+    public void MarkCorrelatedComplete_FromSetup_TransitionsToCompletedWithNoEvents()
+    {
+        // Arrange
+        var session = CreateSetupSession();
+        session.Status.Should().Be(SessionStatus.Setup);
+
+        // Act
+        session.MarkCorrelatedComplete(TimeProvider.System);
+
+        // Assert — status and timestamp
+        session.Status.Should().Be(SessionStatus.Completed);
+        session.CompletedAt.Should().NotBeNull();
+
+        // Assert — no GameSessionStartedEvent or GameSessionCompletedEvent raised
+        session.DomainEvents.Should().NotContain(
+            e => e is GameSessionStartedEvent,
+            because: "MarkCorrelatedComplete must not raise GameSessionStartedEvent");
+        session.DomainEvents.Should().NotContain(
+            e => e is GameSessionCompletedEvent,
+            because: "MarkCorrelatedComplete must not raise GameSessionCompletedEvent");
+    }
+
+    [Fact(DisplayName = "#2587-fix: MarkCorrelatedComplete is idempotent when already Completed")]
+    public void MarkCorrelatedComplete_AlreadyCompleted_IsNoOp()
+    {
+        // Arrange — drive to Completed via normal path
+        var session = CreateSetupSession();
+        session.Start();
+        session.Complete();
+        var completedAt = session.CompletedAt;
+        session.ClearDomainEvents(); // clear events from normal path
+
+        // Act — calling MarkCorrelatedComplete on an already-terminal session must not throw
+        var act = () => session.MarkCorrelatedComplete(TimeProvider.System);
+
+        // Assert
+        act.Should().NotThrow();
+        session.Status.Should().Be(SessionStatus.Completed, because: "status must remain Completed");
+        session.CompletedAt.Should().Be(completedAt, because: "CompletedAt must not be overwritten");
+        session.DomainEvents.Should().BeEmpty(because: "no events for an already-finished shadow");
+    }
+
+    [Fact(DisplayName = "#2587-fix: MarkCorrelatedComplete is idempotent when already Abandoned")]
+    public void MarkCorrelatedComplete_AlreadyAbandoned_IsNoOp()
+    {
+        // Arrange
+        var session = CreateSetupSession();
+        session.Abandon("test");
+        var completedAt = session.CompletedAt;
+        session.ClearDomainEvents();
+
+        // Act
+        var act = () => session.MarkCorrelatedComplete(TimeProvider.System);
+
+        // Assert
+        act.Should().NotThrow();
+        session.Status.Should().Be(SessionStatus.Abandoned, because: "status must remain Abandoned");
+        session.CompletedAt.Should().Be(completedAt, because: "CompletedAt must not be overwritten");
+        session.DomainEvents.Should().BeEmpty();
+    }
+
+    [Fact(DisplayName = "#2587-fix: MarkCorrelatedComplete with null TimeProvider throws ArgumentNullException")]
+    public void MarkCorrelatedComplete_NullTimeProvider_ThrowsArgumentNullException()
+    {
+        // Arrange
+        var session = CreateSetupSession();
+
+        // Act & Assert
+        var act = () => session.MarkCorrelatedComplete(null!);
+        act.Should().Throw<ArgumentNullException>();
     }
 
     #endregion

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/Entities/LiveGameSession_SetCorrelatedGameSessionIdTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/Entities/LiveGameSession_SetCorrelatedGameSessionIdTests.cs
@@ -1,0 +1,83 @@
+using Api.BoundedContexts.GameManagement.Domain.Entities;
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Domain.Entities;
+
+/// <summary>
+/// Unit tests for <see cref="LiveGameSession.SetCorrelatedGameSessionId"/>.
+/// TDD: Tests written first (RED → GREEN).
+/// Issue #2587 Slice 1 Task 1.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "GameManagement")]
+public class LiveGameSession_SetCorrelatedGameSessionIdTests
+{
+    private static readonly Guid UserId = Guid.NewGuid();
+    private static readonly Guid GameId = Guid.NewGuid();
+
+    private static LiveGameSession CreateSession(Guid? correlatedGameSessionId = null)
+        => LiveGameSession.Create(
+            Guid.NewGuid(),
+            UserId,
+            "Test Game",
+            TimeProvider.System,
+            gameId: GameId,
+            correlatedGameSessionId: correlatedGameSessionId);
+
+    // ── Set when null ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void SetCorrelatedGameSessionId_WhenNull_SetsValue()
+    {
+        var session = CreateSession(correlatedGameSessionId: null);
+        var correlatedId = Guid.NewGuid();
+
+        session.SetCorrelatedGameSessionId(correlatedId);
+
+        session.CorrelatedGameSessionId.Should().Be(correlatedId);
+    }
+
+    // ── No-op when same value ─────────────────────────────────────────────────
+
+    [Fact]
+    public void SetCorrelatedGameSessionId_WhenSameValue_IsNoOp()
+    {
+        var correlatedId = Guid.NewGuid();
+        var session = CreateSession(correlatedGameSessionId: correlatedId);
+
+        // Must not throw and property must remain unchanged
+        var act = () => session.SetCorrelatedGameSessionId(correlatedId);
+        act.Should().NotThrow();
+        session.CorrelatedGameSessionId.Should().Be(correlatedId);
+    }
+
+    // ── Throw when different value ────────────────────────────────────────────
+
+    [Fact]
+    public void SetCorrelatedGameSessionId_WhenAlreadySetToDifferentValue_Throws()
+    {
+        var existing = Guid.NewGuid();
+        var session = CreateSession(correlatedGameSessionId: existing);
+        var different = Guid.NewGuid();
+
+        var act = () => session.SetCorrelatedGameSessionId(different);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*CorrelatedGameSessionId*");
+    }
+
+    // ── Guard: empty Guid ────────────────────────────────────────────────────
+
+    [Fact]
+    public void SetCorrelatedGameSessionId_EmptyGuid_Throws()
+    {
+        var session = CreateSession(correlatedGameSessionId: null);
+
+        var act = () => session.SetCorrelatedGameSessionId(Guid.Empty);
+
+        act.Should().Throw<ArgumentException>();
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Infrastructure/Mappers/LiveGameSessionMapperTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Infrastructure/Mappers/LiveGameSessionMapperTests.cs
@@ -110,4 +110,45 @@ public class LiveGameSessionMapperTests
         var back = LiveGameSessionMapper.ToDomain(entity);
         back.TrackingSessionId.Should().BeNull();
     }
+
+    // ── CorrelatedGameSessionId round-trips (#2587 Slice 1 Task 1) ──────────
+
+    [Fact]
+    public void Mapper_RoundTrips_CorrelatedGameSessionId()
+    {
+        // #2587: CorrelatedGameSessionId must survive ToEntity → ToDomain round-trip.
+        var correlatedId = Guid.NewGuid();
+        var domain = LiveGameSession.Create(
+            id: Guid.NewGuid(),
+            createdByUserId: Guid.NewGuid(),
+            gameName: "Mage Knight",
+            timeProvider: TimeProvider.System,
+            gameId: Guid.NewGuid(),
+            correlatedGameSessionId: correlatedId);
+
+        var entity = LiveGameSessionMapper.ToEntity(domain);
+        entity.CorrelatedGameSessionId.Should().Be(correlatedId);
+
+        var back = LiveGameSessionMapper.ToDomain(entity);
+        back.CorrelatedGameSessionId.Should().Be(correlatedId);
+    }
+
+    [Fact]
+    public void Mapper_RoundTrips_NullCorrelatedGameSessionId()
+    {
+        // #2587: null CorrelatedGameSessionId (free-form / pre-Slice1 session) must remain null.
+        var domain = LiveGameSession.Create(
+            id: Guid.NewGuid(),
+            createdByUserId: Guid.NewGuid(),
+            gameName: "Mage Knight",
+            timeProvider: TimeProvider.System,
+            gameId: null,
+            correlatedGameSessionId: null);
+
+        var entity = LiveGameSessionMapper.ToEntity(domain);
+        entity.CorrelatedGameSessionId.Should().BeNull();
+
+        var back = LiveGameSessionMapper.ToDomain(entity);
+        back.CorrelatedGameSessionId.Should().BeNull();
+    }
 }

--- a/apps/api/tests/Api.Tests/Integration/GameManagement/CorrelatedGameSessionOnStartTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/GameManagement/CorrelatedGameSessionOnStartTests.cs
@@ -1,0 +1,340 @@
+using Api.BoundedContexts.GameManagement.Application.Commands.LiveSessions;
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+using Api.BoundedContexts.GameManagement.Domain.Repositories;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.SharedKernel.Domain.Exceptions;
+using Api.SharedKernel.Domain.ValueObjects;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using MediatR;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.Integration.GameManagement;
+
+/// <summary>
+/// Integration tests for Issue #2587 Slice 1 — correlated GameSession at start + quota + lifecycle sync.
+///
+/// Proves the four acceptance criteria:
+/// T1  — GameId-backed start → GameSession created + CorrelatedGameSessionId persisted + active count +1.
+/// T2  — Quota enforced: starting beyond the Free limit (3) throws QuotaExceededException.
+/// T3  — Complete → correlated GameSession is Completed + active count drops back to 0.
+/// T4  — Free-form (GameId == null) start → no GameSession created; start succeeds.
+///
+/// Tier limits (SessionQuotaService defaults):
+///   Free  = 3 active sessions max (controllable via config key "SessionLimits:free:MaxSessions")
+///   Normal = 10 max
+///   Premium = unlimited
+///
+/// These tests use IntegrationWebApplicationFactory (which mocks Redis/embeddings) and
+/// SharedTestcontainersFixture (shared Postgres container, isolated DB per test class).
+/// </summary>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "GameManagement")]
+public sealed class CorrelatedGameSessionOnStartTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly string _databaseName = $"correlated_quota_{Guid.NewGuid():N}";
+    private WebApplicationFactory<Program> _factory = null!;
+
+    public CorrelatedGameSessionOnStartTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+        await TestcontainersWaitHelpers.WaitForPostgresReadyAsync(connectionString);
+
+        // Override the Free-tier session limit to 1 so T2 (quota enforcement) is cheap:
+        // start 1 session → next start fails without needing 3 round-trips.
+        _factory = IntegrationWebApplicationFactory.Create(
+            connectionString,
+            extraConfig: new Dictionary<string, string?>
+            {
+                ["SessionLimits:free:MaxSessions"] = "1"
+            });
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        db.Database.Migrate();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_factory != null)
+            await _factory.DisposeAsync();
+
+        await _fixture.DropIsolatedDatabaseAsync(_databaseName);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // T1 — Start GameId-backed session: GameSession row created + correlated +
+    //      active-sessions count becomes 1 (history-visibility + quota slot).
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "T1: Start GameId-backed live session creates correlated GameSession and increments active count")]
+    public async Task T1_Start_GameIdBacked_CreatesCorrelatedGameSession_And_CountsActive()
+    {
+        // Arrange
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var gameSessionRepo = scope.ServiceProvider.GetRequiredService<IGameSessionRepository>();
+
+        var userId = await SeedUserAsync(db);
+        var gameId = await SeedSharedGameAsync(db);
+
+        // Active count is 0 before start
+        var countBefore = await gameSessionRepo.CountActiveByUserIdAsync(userId);
+        countBefore.Should().Be(0, "no sessions exist yet");
+
+        var liveSessionId = await mediator.Send(new CreateLiveSessionCommand(UserId: userId, GameName: "Mage Knight", GameId: gameId));
+        await mediator.Send(new AddPlayerToLiveSessionCommand(SessionId: liveSessionId, DisplayName: "Aaron", Color: PlayerColor.Red, UserId: userId));
+
+        // Act
+        await mediator.Send(new StartLiveSessionCommand(liveSessionId, userId, UserTier.Free, Role.User));
+
+        // Assert — LiveGameSession.CorrelatedGameSessionId is non-null
+        await using var verifyScope = _factory.Services.CreateAsyncScope();
+        var verifyDb = verifyScope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        var live = await verifyDb.LiveGameSessions.AsNoTracking().SingleAsync(s => s.Id == liveSessionId);
+        live.CorrelatedGameSessionId.Should().NotBeNull(
+            "StartLiveSessionCommandHandler must set CorrelatedGameSessionId for GameId-backed sessions");
+
+        // Assert — the correlated GameSession row exists with correct fields
+        var gsRow = await verifyDb.GameSessions
+            .AsNoTracking()
+            .SingleOrDefaultAsync(gs => gs.Id == live.CorrelatedGameSessionId!.Value);
+
+        gsRow.Should().NotBeNull("a GameSession row must have been created and committed atomically with the LiveGameSession update");
+        gsRow!.CreatedByUserId.Should().Be(userId, "the session creator must be propagated to the GameSession");
+        gsRow.GameId.Should().Be(gameId, "GameSession must be linked to the same catalog game");
+        gsRow.Status.Should().Be("Setup", "new correlated GameSession starts in Setup status so it counts toward quota");
+
+        // Assert — active count is now 1 (quota-counting + history-visibility)
+        var verifyRepo = verifyScope.ServiceProvider.GetRequiredService<IGameSessionRepository>();
+        var countAfter = await verifyRepo.CountActiveByUserIdAsync(userId);
+        countAfter.Should().Be(1, "the newly created correlated GameSession (in Setup status) must count as active");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // T2 — Quota enforced: with Free limit overridden to 1, starting a second
+    //      GameId-backed session throws QuotaExceededException.
+    //
+    // Quota tier config approach: IntegrationWebApplicationFactory.Create accepts
+    // extraConfig that merges into the in-memory IConfiguration. We set
+    // "SessionLimits:free:MaxSessions" = "1" in InitializeAsync so the
+    // SessionQuotaService's GetLimitForTierAsync falls through to the configured
+    // value instead of the DefaultLimits.FreeMaxSessions (3).
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "T2: Starting beyond Free tier limit throws QuotaExceededException")]
+    public async Task T2_Start_BeyondQuota_ThrowsQuotaExceeded()
+    {
+        // Arrange — seed user + 2 shared games; start the first session (uses 1 of 1 slot)
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        var userId = await SeedUserAsync(db);
+        var gameId1 = await SeedSharedGameAsync(db);
+        var gameId2 = await SeedSharedGameAsync(db);
+
+        var session1Id = await mediator.Send(new CreateLiveSessionCommand(UserId: userId, GameName: "Game 1", GameId: gameId1));
+        await mediator.Send(new AddPlayerToLiveSessionCommand(SessionId: session1Id, DisplayName: "Aaron", Color: PlayerColor.Red, UserId: userId));
+        await mediator.Send(new StartLiveSessionCommand(session1Id, userId, UserTier.Free, Role.User));
+
+        // Confirm slot is full (active count == 1 == limit)
+        await using var checkScope = _factory.Services.CreateAsyncScope();
+        var checkRepo = checkScope.ServiceProvider.GetRequiredService<IGameSessionRepository>();
+        var countAfterFirst = await checkRepo.CountActiveByUserIdAsync(userId);
+        countAfterFirst.Should().Be(1, "first session consumed the single Free-tier slot");
+
+        // Prepare the second session up to the point of start (create + addPlayer)
+        await using var scope2 = _factory.Services.CreateAsyncScope();
+        var mediator2 = scope2.ServiceProvider.GetRequiredService<IMediator>();
+        var session2Id = await mediator2.Send(new CreateLiveSessionCommand(UserId: userId, GameName: "Game 2", GameId: gameId2));
+        await mediator2.Send(new AddPlayerToLiveSessionCommand(SessionId: session2Id, DisplayName: "Aaron", Color: PlayerColor.Blue, UserId: userId));
+
+        // Act — attempt to start beyond the quota limit
+        await using var scope3 = _factory.Services.CreateAsyncScope();
+        var mediator3 = scope3.ServiceProvider.GetRequiredService<IMediator>();
+        Func<Task> act = () => mediator3.Send(new StartLiveSessionCommand(session2Id, userId, UserTier.Free, Role.User));
+
+        // Assert — throws QuotaExceededException (mapped to 409 at the HTTP layer)
+        await act.Should().ThrowAsync<QuotaExceededException>(
+            "starting a second GameId-backed session when the Free tier limit (1) is already reached " +
+            "must be rejected by the quota check in StartLiveSessionCommandHandler");
+
+        // Assert — the second session does NOT have a correlated GameSession (creation was rolled back / never committed)
+        await using var verifyScope = _factory.Services.CreateAsyncScope();
+        var verifyDb = verifyScope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        var live2 = await verifyDb.LiveGameSessions.AsNoTracking().SingleAsync(s => s.Id == session2Id);
+        live2.CorrelatedGameSessionId.Should().BeNull(
+            "the quota check must fire BEFORE the GameSession is created; rolling back leaves CorrelatedGameSessionId null");
+
+        // Active count must still be 1 (not 2)
+        var verifyRepo = verifyScope.ServiceProvider.GetRequiredService<IGameSessionRepository>();
+        var finalCount = await verifyRepo.CountActiveByUserIdAsync(userId);
+        finalCount.Should().Be(1, "the failed start must not have created a new active GameSession");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // T3 — Complete frees the quota: after completing the live session the
+    //      correlated GameSession is Completed and CountActiveByUserId drops to 0.
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "T3: Completing live session marks correlated GameSession Completed and frees the quota slot")]
+    public async Task T3_Complete_FreesQuota_And_MarksCorrelatedCompleted()
+    {
+        // Arrange — create + addPlayer + start
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        var userId = await SeedUserAsync(db);
+        var gameId = await SeedSharedGameAsync(db);
+
+        var liveSessionId = await mediator.Send(new CreateLiveSessionCommand(UserId: userId, GameName: "Wingspan", GameId: gameId));
+        await mediator.Send(new AddPlayerToLiveSessionCommand(SessionId: liveSessionId, DisplayName: "Aaron", Color: PlayerColor.Green, UserId: userId));
+        await mediator.Send(new StartLiveSessionCommand(liveSessionId, userId, UserTier.Free, Role.User));
+
+        // Confirm slot is consumed
+        await using var preScope = _factory.Services.CreateAsyncScope();
+        var preRepo = preScope.ServiceProvider.GetRequiredService<IGameSessionRepository>();
+        var countBefore = await preRepo.CountActiveByUserIdAsync(userId);
+        countBefore.Should().Be(1, "started session must be counting as active");
+
+        // Act — complete the live session
+        await using var completeScope = _factory.Services.CreateAsyncScope();
+        var completeMediatorInstance = completeScope.ServiceProvider.GetRequiredService<IMediator>();
+        await completeMediatorInstance.Send(new CompleteLiveSessionCommand(liveSessionId));
+
+        // Assert — the correlated GameSession is now Completed (no longer Active)
+        await using var verifyScope = _factory.Services.CreateAsyncScope();
+        var verifyDb = verifyScope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        var live = await verifyDb.LiveGameSessions.AsNoTracking().SingleAsync(s => s.Id == liveSessionId);
+        live.CorrelatedGameSessionId.Should().NotBeNull("pre-condition: correlation was set at start");
+
+        var gsRow = await verifyDb.GameSessions
+            .AsNoTracking()
+            .SingleAsync(gs => gs.Id == live.CorrelatedGameSessionId!.Value);
+
+        gsRow.Status.Should().Be("Completed",
+            "CompleteLiveSessionCommandHandler must call GameSession.MarkCorrelatedComplete " +
+            "so the shadow record transitions to Completed and stops counting as active");
+        gsRow.CompletedAt.Should().NotBeNull("CompletedAt must be stamped by MarkCorrelatedComplete");
+
+        // Assert — active count is back to 0 (slot freed)
+        var verifyRepo = verifyScope.ServiceProvider.GetRequiredService<IGameSessionRepository>();
+        var countAfter = await verifyRepo.CountActiveByUserIdAsync(userId);
+        countAfter.Should().Be(0,
+            "a Completed GameSession must not be counted by CountActiveByUserIdAsync " +
+            "(which filters on Setup / InProgress / Paused statuses only)");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // T4 — Free-form (GameId == null): start succeeds but NO GameSession is created
+    //      and CorrelatedGameSessionId stays null.
+    // ──────────────────────────────────────────────────────────────────────────
+
+    [Fact(DisplayName = "T4: Free-form (GameId=null) start succeeds without creating a correlated GameSession")]
+    public async Task T4_Start_FreeForm_NoGameId_DoesNotCreateGameSession()
+    {
+        // Arrange
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        var userId = await SeedUserAsync(db);
+
+        // Create a free-form session: GameId explicitly null (no catalog game)
+        var liveSessionId = await mediator.Send(new CreateLiveSessionCommand(UserId: userId, GameName: "Quick Game", GameId: null));
+        await mediator.Send(new AddPlayerToLiveSessionCommand(SessionId: liveSessionId, DisplayName: "Aaron", Color: PlayerColor.Yellow, UserId: userId));
+
+        // Act — start succeeds without quota check (no GameId → no GameSession created)
+        Func<Task> act = () => mediator.Send(new StartLiveSessionCommand(liveSessionId, userId, UserTier.Free, Role.User));
+        await act.Should().NotThrowAsync("free-form sessions bypass quota and GameSession creation");
+
+        // Assert — CorrelatedGameSessionId is still null
+        await using var verifyScope = _factory.Services.CreateAsyncScope();
+        var verifyDb = verifyScope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        var live = await verifyDb.LiveGameSessions.AsNoTracking().SingleAsync(s => s.Id == liveSessionId);
+        live.CorrelatedGameSessionId.Should().BeNull(
+            "free-form sessions (GameId == null) must not create or link a correlated GameSession");
+
+        // Assert — NO GameSession row created for this user
+        var gsCount = await verifyDb.GameSessions
+            .AsNoTracking()
+            .CountAsync(gs => gs.CreatedByUserId == userId);
+
+        gsCount.Should().Be(0,
+            "no GameSession must be created for a free-form live session; " +
+            "only GameId-backed sessions participate in the quota/history saga");
+
+        // Assert — active count stays 0 (free-form doesn't consume a quota slot)
+        var verifyRepo = verifyScope.ServiceProvider.GetRequiredService<IGameSessionRepository>();
+        var count = await verifyRepo.CountActiveByUserIdAsync(userId);
+        count.Should().Be(0,
+            "free-form live sessions do not create a GameSession and therefore never appear in the active count");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Helpers
+    // ──────────────────────────────────────────────────────────────────────────
+
+    private static async Task<Guid> SeedUserAsync(MeepleAiDbContext db)
+    {
+        var userId = Guid.NewGuid();
+        db.Users.Add(new UserEntity
+        {
+            Id = userId,
+            Email = $"corr-quota-{userId:N}@test.local",
+            DisplayName = "Correlated Quota Test User",
+            PasswordHash = "not-a-real-hash",
+            Role = "user",
+            Tier = "free",
+            Status = "Active",
+            EmailVerified = true,
+            CreatedAt = DateTime.UtcNow
+        });
+        await db.SaveChangesAsync();
+        db.ChangeTracker.Clear();
+        return userId;
+    }
+
+    private static async Task<Guid> SeedSharedGameAsync(MeepleAiDbContext db)
+    {
+        var gameId = Guid.NewGuid();
+        db.SharedGames.Add(new SharedGameEntity
+        {
+            Id = gameId,
+            Title = $"Correlation Test Game {gameId:N}",
+            YearPublished = 2024,
+            MinPlayers = 1,
+            MaxPlayers = 4,
+            PlayingTimeMinutes = 60,
+            MinAge = 10,
+            ImageUrl = string.Empty,
+            ThumbnailUrl = string.Empty,
+            Description = string.Empty,
+            CreatedBy = Guid.NewGuid(),
+            CreatedAt = DateTime.UtcNow
+        });
+        await db.SaveChangesAsync();
+        db.ChangeTracker.Clear();
+        return gameId;
+    }
+}

--- a/apps/api/tests/Api.Tests/Integration/GameManagement/LiveSessionDiaryChainIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/GameManagement/LiveSessionDiaryChainIntegrationTests.cs
@@ -3,6 +3,7 @@ using System.Net.Http.Json;
 using Api.BoundedContexts.GameManagement.Application.Commands.LiveSessions;
 using Api.BoundedContexts.GameManagement.Application.DTOs.LiveSessions;
 using Api.BoundedContexts.GameManagement.Application.Services;
+using Api.SharedKernel.Domain.ValueObjects;
 using Api.Infrastructure;
 using Api.Infrastructure.Entities;
 using Api.Tests.Constants;
@@ -295,7 +296,7 @@ public sealed class LiveSessionDiaryChainIntegrationTests : IAsyncLifetime
             UserId: userId,
             Role: null,
             AvatarUrl: null));
-        await mediator.Send(new StartLiveSessionCommand(sessionId));
+        await mediator.Send(new StartLiveSessionCommand(sessionId, userId, UserTier.Free, Role.User));
 
         var client = _factory.CreateClient();
         client.DefaultRequestHeaders.Add("Cookie", $"{TestSessionHelper.SessionCookieName}={token}");

--- a/apps/api/tests/Api.Tests/Integration/GameManagement/LiveSessionDiaryEndpointTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/GameManagement/LiveSessionDiaryEndpointTests.cs
@@ -5,6 +5,7 @@ using System.Text.Json.Serialization;
 using Api.BoundedContexts.GameManagement.Application.Commands.LiveSessions;
 using Api.BoundedContexts.GameManagement.Application.DTOs.LiveSessions;
 using Api.BoundedContexts.GameManagement.Domain.Entities;
+using Api.SharedKernel.Domain.ValueObjects;
 using Api.BoundedContexts.GameManagement.Domain.Enums;
 using Api.Infrastructure;
 using Api.Infrastructure.Entities;
@@ -310,7 +311,7 @@ public sealed class LiveSessionDiaryEndpointTests : IAsyncLifetime
             AvatarUrl: null));
 
         // Domain invariant: session must be InProgress before Complete.
-        await mediator.Send(new StartLiveSessionCommand(sessionId));
+        await mediator.Send(new StartLiveSessionCommand(sessionId, Guid.NewGuid(), UserTier.Free, Role.User));
         await mediator.Send(new CompleteLiveSessionCommand(sessionId));
     }
 

--- a/apps/api/tests/Api.Tests/Integration/GameManagement/LiveSessionRepositoryIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/GameManagement/LiveSessionRepositoryIntegrationTests.cs
@@ -1,6 +1,7 @@
 using Api.BoundedContexts.GameManagement.Application.Commands.LiveSessions;
 using Api.BoundedContexts.GameManagement.Domain.Enums;
 using Api.BoundedContexts.GameManagement.Domain.Repositories;
+using Api.SharedKernel.Domain.ValueObjects;
 using Api.Infrastructure;
 using Api.Infrastructure.Entities;
 using Api.SharedKernel.Infrastructure.Persistence;
@@ -191,7 +192,7 @@ public sealed class LiveSessionRepositoryIntegrationTests : IAsyncLifetime
         await using (var scope2 = _factoryAC2.Services.CreateAsyncScope())
         {
             var mediator = scope2.ServiceProvider.GetRequiredService<IMediator>();
-            await mediator.Send(new StartLiveSessionCommand(sessionId));
+            await mediator.Send(new StartLiveSessionCommand(sessionId, userId, UserTier.Free, Role.User));
 
         }
 
@@ -347,7 +348,7 @@ public sealed class LiveSessionRepositoryIntegrationTests : IAsyncLifetime
                 Color: PlayerColor.Red,
                 UserId: userId));
 
-            await mediator.Send(new StartLiveSessionCommand(sessionId));
+            await mediator.Send(new StartLiveSessionCommand(sessionId, userId, UserTier.Free, Role.User));
 
             // 100 sequential score records — proves all writes are transactionally durable
             for (int round = 1; round <= 100; round++)

--- a/docs/superpowers/plans/2026-06-30-issue-2587-slice1-correlate-quota.md
+++ b/docs/superpowers/plans/2026-06-30-issue-2587-slice1-correlate-quota.md
@@ -1,0 +1,87 @@
+# #2587-A Slice 1 — correlate-at-start + quota + lifecycle-sync
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Checkbox (`- [ ]`) steps.
+
+**Goal:** Direction A core: when a `LiveGameSession` STARTS, atomically create a correlated GameManagement `GameSession` (lifecycle/quota aggregate), enforce the per-user session quota, and store `CorrelatedGameSessionId`. Sync the correlated GameSession's completion to the LiveGameSession's. Fixes the quota-bypass + history-invisibility for started GameId-backed sessions.
+
+**Architecture:** BE-only (GameManagement). De-risk: `.superpowers/sdd/2587-slice1-derisk.md`. Design: `docs/superpowers/specs/2026-06-30-issue-2587-funnel-convergence-design.md` (Direzione A ratified). Correlation happens at **START** (players exist), NOT at create.
+
+**Global constraints:**
+- **No worktree** — commit directly on `feature/issue-2587-slice1-correlate-quota`.
+- commitlint ≤72; commits end with `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+- **Free-form (GameId == null)** sessions get NO correlated GameSession (GameSession requires a gameId) — structural, like the SP0 companion. No quota for them (acceptable).
+- **Atomicity**: GameSession add + LiveGameSession update (SetCorrelatedGameSessionId) commit in ONE SaveChanges. xmin race-safe (ADR-060) — on `DbUpdateConcurrencyException` re-fetch + idempotent (SP5-c pattern).
+- **Idempotency**: a re-start of an already-correlated session must NOT create a second GameSession.
+- **Quota counts GameSessions** (`ISessionQuotaService` → `IGameSessionRepository.CountActiveByUserIdAsync`) → effective once correlation creates them. Check quota BEFORE creating the new GameSession (so it doesn't count itself).
+
+**Reading list:** `LifecycleCommandHandlers.cs:13-41` (start), `:116-144` (complete); `LiveSessionEndpoints.cs:478-485` (HandleStartSession); `GameEndpoints.cs:448-456` (tier/role resolution pattern); `StartGameSessionCommandHandler.cs` (quota + GameSession.Create + SessionPlayer mapping); `LiveGameSession.cs:78` (Players, LiveSessionPlayer shape); `EnsureCompanionCommandHandler.cs` (SP5-c xmin idempotent pattern).
+
+---
+
+## Task 1: Domain + persistence — CorrelatedGameSessionId
+**Files:** `LiveGameSession.cs`; EF config (LiveGameSession entity config); a new EF migration; Tests: domain test.
+
+- [ ] **Step 1: Failing test** — `LiveGameSession.SetCorrelatedGameSessionId(Guid)`: null→set; same→no-op; different→throw `InvalidOperationException`; empty→`ArgumentException`. (Mirror `SetTrackingSessionId` from SP5-c.)
+- [ ] **Step 2: Run → FAIL.**
+- [ ] **Step 3: Implement** — add `CorrelatedGameSessionId` (`Guid?`, private set) + the domain method (XML doc); add the EF mapping (nullable column) in the LiveGameSession entity config (mirror how `TrackingSessionId` is mapped); generate a migration `dotnet ef migrations add AddCorrelatedGameSessionId` (review the SQL: one nullable `correlated_game_session_id` column; no data change). Map in `LiveGameSessionMapper` ToEntity/ToDomain (mirror `TrackingSessionId`).
+- [ ] **Step 4: Run → PASS** + the GameManagement domain/mapper suite + `dotnet build`.
+- [ ] **Step 5: Commit** — `feat(session-live): #2587 LiveGameSession.CorrelatedGameSessionId + migration`
+
+---
+
+## Task 2: Correlate-at-start + quota
+**Files:** `LiveSessionEndpoints.cs` (HandleStartSession), `StartLiveSessionCommand.cs` (enrich), `LifecycleCommandHandlers.cs` (StartLiveSessionCommandHandler); a GameSession-creation seam (inject `IGameSessionRepository` + `ISessionQuotaService` into the start handler, OR a small `ICorrelatedGameSessionService` ACL — your choice, keep it in GameManagement); Tests: handler unit tests.
+
+- [ ] **Step 1: Failing tests** (mock repos + quota service):
+  - (a) Start of a GameId-backed session with players + `CorrelatedGameSessionId == null` → quota checked, GameSession created (players mapped: LiveSessionPlayer.displayName→PlayerName, index→PlayerOrder, default Color), `SetCorrelatedGameSessionId` applied, `session.Start` called, ONE SaveChanges.
+  - (b) Quota exceeded → `QuotaExceededException`, NO GameSession created, NO start.
+  - (c) Already-correlated session (re-start) → NO second GameSession, idempotent.
+  - (d) Free-form `GameId == null` → NO GameSession, NO quota check, `session.Start` still happens (toolkit-only session can still start).
+  - (e) Concurrency: `DbUpdateConcurrencyException` on save → re-fetch; if now correlated → idempotent success.
+- [ ] **Step 2: Run → FAIL.**
+- [ ] **Step 3: Implement**:
+  - Endpoint `HandleStartSession`: add `HttpContext`/principal; resolve `userId` + `UserTier.Parse(principal.Tier)` + `UserRole` (mirror `GameEndpoints.cs:448`); pass into an enriched `StartLiveSessionCommand(sessionId, userId, userTier, userRole)`.
+  - Handler: GetById → if `GameId.HasValue && CorrelatedGameSessionId == null`: `CheckQuotaAsync` (throw `QuotaExceededException` if denied) → create `GameSession` (map players) → `session.SetCorrelatedGameSessionId(gameSession.Id)` → `_gameSessionRepository.AddAsync(gameSession)`. Then `session.Start(_timeProvider)` → `UpdateAsync(session)` → ONE `SaveChangesAsync`. Wrap save in try/catch `DbUpdateConcurrencyException` → re-fetch + idempotent (SP5-c pattern). DI: register any new deps.
+  - Player mapping: confirm `SessionPlayer(PlayerName, PlayerOrder, Color)` — if `Color` is required and LiveSessionPlayer has none, use a deterministic default palette by index.
+- [ ] **Step 4: Run → PASS** + the GameManagement unit suite + build.
+- [ ] **Step 5: Commit** — `feat(session-live): #2587 correlate GameSession + quota on live-session start`
+
+---
+
+## Task 3: Lifecycle-sync — complete the correlated GameSession
+**Files:** `LifecycleCommandHandlers.cs` (CompleteLiveSessionCommandHandler + Abandon handler if one exists); Tests: handler unit tests.
+
+- [ ] **Step 1: Failing tests**:
+  - (a) Complete a LiveGameSession with `CorrelatedGameSessionId != null` → the correlated GameSession is loaded + Completed (so it stops counting active for quota); ONE SaveChanges.
+  - (b) Complete a session with `CorrelatedGameSessionId == null` (free-form) → no-op on GameSession, LiveGameSession still completes.
+  - (c) If an Abandon handler exists, mirror: abandon LiveGameSession → abandon/terminate the correlated GameSession.
+- [ ] **Step 2: Run → FAIL.**
+- [ ] **Step 3: Implement** — in CompleteLiveSessionCommandHandler: after `session.Complete(...)`, if `CorrelatedGameSessionId != null` → `gameSession = _gameSessionRepository.GetByIdAsync(CorrelatedGameSessionId)` → `gameSession.Complete(...)` (use the GameSession lifecycle method; check the exact name — Complete/End) → `_gameSessionRepository.UpdateAsync(gameSession)`. ONE SaveChanges for both. (Inject `IGameSessionRepository`.) Apply the same to Abandon if present.
+- [ ] **Step 4: Run → PASS** + suite + build.
+- [ ] **Step 5: Commit** — `feat(session-live): #2587 complete correlated GameSession on live-session complete`
+
+---
+
+## Task 4: Integration (Testcontainers)
+**Files:** integration test under `apps/api/tests/Api.Tests/Integration/GameManagement/`.
+
+- [ ] **Step 1: Tests**:
+  - Start a GameId-backed LiveGameSession with players → a GameSession row is created + `CorrelatedGameSessionId` persisted + the GameSession appears in the user's active-sessions query (`IGameSessionRepository` active list / `api.sessions.getActive` equivalent).
+  - Quota: with a tier whose limit is N, start N sessions → the (N+1)th start returns quota-exceeded (409/the mapped status).
+  - Complete the LiveGameSession → the correlated GameSession is Completed → it no longer counts active (a subsequent start is allowed again).
+  - Free-form (GameId == null) start → no GameSession created, start succeeds.
+- [ ] **Step 2: Run** (needs Docker; if unavailable locally, write + compile, note they run in CI — do NOT mark passing if not run).
+- [ ] **Step 3: Commit** — `test(session-live): #2587 correlate+quota+lifecycle integration`
+
+---
+
+## Self-Review
+- Quota-bypass fixed: started GameId-backed sessions now create a counted GameSession; quota enforced at start (T2); freed at complete (T3).
+- History-visibility fixed: started sessions now have a GameSession → appear in `api.sessions.getActive` (T4).
+- Atomic + idempotent + race-safe (T2). Free-form structurally excluded (no GameId).
+- Honors Opzione-B: GameSession is now populated for real sessions (its quota/history role becomes real).
+
+## Out of scope (future slices)
+- Slice 2: backfill lazy for legacy `CorrelatedGameSessionId == null` sessions.
+- Slice 3: FE e2e (create→start→visible-in-history) + scoring source-of-truth doc.
+- Pause/Resume → GameSession sync (only if quota counts pause as active differently — verify, else skip).


### PR DESCRIPTION
## Cosa
Epic #2501 #2587-A **Slice 1** (convergenza dual-creation funnel, **Direzione A** ratificata). Quando una `LiveGameSession` **parte**, crea atomicamente una `GameSession` correlata (aggregato lifecycle/quota/history) + applica la **quota** per-utente; a **completamento** la GameSession correlata passa terminale **event-free**. Design ratificato: `docs/superpowers/specs/2026-06-30-issue-2587-funnel-convergence-design.md`.

## Perché (bug severità ALTA fixati)
Il de-risk ha mostrato che il vero problema NON era "due creazioni" (SessionSetupModal è unused) ma:
- **history-invisibility**: le sessioni reali (wizard→LiveGameSession) erano giocabili ma **invisibili nella history** (`/sessions` legge GameSession);
- **quota-bypass**: `CreateLiveSessionCommandHandler` non creava GameSession → la quota (che conta GameSession) contava 0 → di fatto non applicata.

Creando una GameSession correlata allo start, **entrambi** si risolvono per il funnel reale (la GameSession in `Setup` è contata da `CountActiveByUserIdAsync` = `Setup|InProgress|Paused`).

## BE (4 task TDD + 1 fix)
- **T1**: `LiveGameSession.CorrelatedGameSessionId` (`Guid?` + `SetCorrelatedGameSessionId`, idempotente) + EF mapping + migration (1 colonna nullable, no drift).
- **T2**: endpoint start risolve userId/tier/role (`TryGetActiveSession`, rifiuta non-autenticati); `StartLiveSessionCommandHandler` → quota-check (prima di creare, throw `QuotaExceededException`) + crea GameSession (players attivi mappati) + `SetCorrelatedGameSessionId` + **single SaveChanges atomico** + race-safe xmin (re-fetch idempotente, no orphan). Free-form (GameId-null) → no GameSession (strutturale).
- **T3 + fix**: `CompleteLiveSessionCommandHandler` completa la GameSession correlata via **`GameSession.MarkCorrelatedComplete()` EVENT-FREE** (la review ha colto che `Start()+Complete()` alzava `GameSessionStartedEvent` spurio + `GameSessionCompletedEvent` → contributor-credit non intenzionale; la shadow è bookkeeping, gli eventi sono della LiveGameSession). + filtro `IsActive` sui player.
- **T4**: 4 integration test Testcontainers (start→GameSession+correlated+count 0→1; quota-limit; complete→count→0; free-form no-op) — girano in CI Integration-GroupC.

## Review
Subagent-driven + per-task review (T2/T3 review fatte dal controller per rate-limit subagent). **Review finale whole-branch (opus): READY_WITH_FOLLOWUPS** — nessun Critical; quota-fix verificato end-to-end (0→1→0), event-free shadow completo, no-orphan, idempotenza/auth/migration puliti. Whole-branch BE build exit 0. ~14 unit + 4 integration test, 1498/1498 suite.

## Follow-up (non-blocking, → #2608)
- **Important (edge)**: quota-attribution quando un **non-creator** avvia (quota verificata sul caller, slot consumato dal creator). Caso dominante (creator avvia la propria) corretto. → #2608.
- Minor: QuotaExceededException→400 non 409 (doc drift, pre-esistente); zero-player→400 generico; GameSessionCreatedEvent-audit benigno.

## Scope / out
Slice 1 = correlate-at-start + quota + lifecycle-sync. **Restano** (slice future): Slice 2 backfill lazy (legacy `CorrelatedGameSessionId==null`), Slice 3 verify e2e FE + scoring-source-of-truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)