### PR TITLE
fix(library): #2012 AddGameDrawer choice copy parallelism (F1/F2)

### DIFF
--- a/apps/web/src/__tests__/fixtures/i18n-test-messages.ts
+++ b/apps/web/src/__tests__/fixtures/i18n-test-messages.ts
@@ -378,10 +378,10 @@ export const addGameDrawerMessages = {
   'pages.library.addGame.question': 'How do you want to add your game?',
   'pages.library.addGame.manualLabel': 'Add manually',
   'pages.library.addGame.manualDescription':
-    'Enter the game details. You can upload the rulebook and configure the AI agent later from the game detail page.',
-  'pages.library.addGame.catalogLabel': 'From shared catalog',
+    'Enter the game details. Upload the rulebook and configure the AI agent later, from the game detail page.',
+  'pages.library.addGame.catalogLabel': 'Add from the shared catalog',
   'pages.library.addGame.catalogDescription':
-    'Search the community catalog and add a game in one click. Rulebook and AI agent setup come later.',
+    'Search the community catalog and add a game in one click. Upload the rulebook and configure the AI agent later, from the game detail page.',
 } as const;
 
 export const entityLabelMessages = {

--- a/apps/web/src/app/(authenticated)/library/__tests__/AddGameDrawer.test.tsx
+++ b/apps/web/src/app/(authenticated)/library/__tests__/AddGameDrawer.test.tsx
@@ -153,7 +153,7 @@ describe('AddGameDrawer', () => {
     it('shows catalog choice card', () => {
       renderDrawer({ open: true });
       expect(screen.getByTestId('add-game-choice-catalog')).toBeInTheDocument();
-      expect(screen.getByText('From shared catalog')).toBeInTheDocument();
+      expect(screen.getByText('Add from the shared catalog')).toBeInTheDocument();
     });
 
     it('does not show wizard or catalog step on Step 0', () => {

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -2046,9 +2046,9 @@
         "catalogTitle": "Add from catalog",
         "question": "How do you want to add your game?",
         "manualLabel": "Add manually",
-        "manualDescription": "Enter the game details. You can upload the rulebook and configure the AI agent later from the game detail page.",
-        "catalogLabel": "From shared catalog",
-        "catalogDescription": "Search the community catalog and add a game in one click. Rulebook and AI agent setup come later.",
+        "manualDescription": "Enter the game details. Upload the rulebook and configure the AI agent later, from the game detail page.",
+        "catalogLabel": "Add from the shared catalog",
+        "catalogDescription": "Search the community catalog and add a game in one click. Upload the rulebook and configure the AI agent later, from the game detail page.",
         "catalog": {
           "backAriaLabel": "Back to choice",
           "searchPlaceholder": "Search games…",

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -2096,9 +2096,9 @@
         "catalogTitle": "Aggiungi da catalogo",
         "question": "Come vuoi aggiungere il tuo gioco?",
         "manualLabel": "Aggiungi manualmente",
-        "manualDescription": "Inserisci i dettagli del gioco. Potrai caricare il regolamento e configurare l'agente AI dalla pagina di dettaglio.",
-        "catalogLabel": "Da catalogo condiviso",
-        "catalogDescription": "Cerca nel catalogo della community e aggiungi un gioco con un click. Regolamento e setup agente in seguito.",
+        "manualDescription": "Inserisci i dettagli del gioco. Carica il regolamento e configura l'agente AI più tardi, dalla pagina di dettaglio.",
+        "catalogLabel": "Aggiungi dal catalogo condiviso",
+        "catalogDescription": "Cerca nel catalogo della community e aggiungi un gioco con un click. Carica il regolamento e configura l'agente AI più tardi, dalla pagina di dettaglio.",
         "catalog": {
           "backAriaLabel": "Torna alla scelta",
           "searchPlaceholder": "Cerca giochi…",


### PR DESCRIPTION
## Cosa

Spec-panel critique (modalità `critique`; panel Wiegers / Adzic / Crispin + lente Doumont) sulla copy delle due choice card di `AddGameDrawer`. Scope **deliberatamente ristretto** ai soli difetti **oggettivi** di parallelismo. I finding a livello di **ipotesi** restano deferred (richiedono dati reali).

## Perché solo F1/F2 (e non una riscrittura)

L'AC di #2012 vieta un copy change "opinion-based": serve un **observed problem** (telemetry / user feedback / hallway test). Verifica sul campo:

- ✅ Il funnel è **già instrumentato** (PR #2032 — `library_addgame_drawer_opened` / `…_closed_without_choice` / `…_choice_selected{manual|catalog}`).
- ❌ **`trackEvent` è un no-op in produzione** (`src/lib/analytics/track-event.ts` logga solo in `NODE_ENV==='development'`, nessun sink) → **zero dati raccolti**.

→ L'evidence-gate non è soddisfacibile oggi. Quindi tocco **solo** i difetti che non sono opinione: il parallelismo grammaticale.

## Modifiche (IT + EN)

**F1 — label parallele (azione + modo)**
- `catalogLabel`: `Da catalogo condiviso` → `Aggiungi dal catalogo condiviso` · `From shared catalog` → `Add from the shared catalog`
- `manualLabel` **invariata** (`Aggiungi manualmente` / `Add manually`)

**F2 — descrizioni con clausola di deferral identica**
- Entrambe le card ora chiudono con: *"Carica il regolamento e configura l'agente AI più tardi, dalla pagina di dettaglio."* / *"Upload the rulebook and configure the AI agent later, from the game detail page."*

## Deferred (fuori scope — servono dati dal funnel)

- **F3** asimmetria di framing velocità (Catalog "1 click" vs Manual nessun claim)
- **F4** claim *"con un click"* non mantenuto letteralmente dal flow — **lasciato intatto**
- **F6** ordine Manual-first vs happy-path Catalog
- **F0** (prerequisito tecnico) sink `trackEvent` no-op → senza di esso nessuna review evidence-based è possibile

## Test

- `AddGameDrawer.test.tsx`: **35/35** verde (1 assertion aggiornata: `From shared catalog` → `Add from the shared catalog`)
- Fixture `i18n-test-messages.ts` sincronizzata
- `tsc --noEmit` (pre-commit hook) passato · parità chiavi IT/EN verificata · 0 residui vecchia copy

## Files

`apps/web/src/locales/{it,en}.json` · `i18n-test-messages.ts` · `AddGameDrawer.test.tsx` (4 file, 10/10)

Closes #2012

🤖 Generated with [Claude Code](https://claude.com/claude-code)