### PR TITLE
feat(session-live): #2588 Slice A1 — photos tab (in-session gallery) in canonical view

### DIFF
--- a/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx
@@ -110,6 +110,7 @@ import {
   type ToolkitRendererLabels,
 } from '@/components/features/session-live';
 import type { ChatMessage as LiveAgentChatMessage } from '@/components/features/session-live/LiveAgentChat';
+import { PhotosTabContent } from '@/components/features/session-live/PhotosTabContent';
 import { useAddDiaryEntry } from '@/hooks/mutations/useAddDiaryEntry';
 import { useCompleteLiveSession } from '@/hooks/mutations/useCompleteLiveSession';
 import { useCurrentUser } from '@/hooks/queries/useCurrentUser';
@@ -194,10 +195,11 @@ function resolveFixtureVariant(variantParam: string | null): LiveSessionFixture 
 //   - legacy ?tab=chat   → 'score'   (chat is no longer a tab; live in LEFT mainColumn)
 //   - legacy/missing     → 'score'   (new default)
 
-type LiveTab = 'score' | 'turn' | 'widget' | 'notes';
+type LiveTab = 'score' | 'turn' | 'widget' | 'notes' | 'photos';
 
 function parseLiveTab(raw: string | null): LiveTab {
-  if (raw === 'turn' || raw === 'widget' || raw === 'notes' || raw === 'score') return raw;
+  if (raw === 'turn' || raw === 'widget' || raw === 'notes' || raw === 'score' || raw === 'photos')
+    return raw;
   // Back-compat aliases (R-1): legacy URL bookmarks must not 404.
   if (raw === 'tools') return 'widget';
   if (raw === 'chat') return 'score';
@@ -209,7 +211,8 @@ function parseLiveTab(raw: string | null): LiveTab {
 // Legacy ?mtab=chat   → 'score'  (chat always-visible in main column)
 // Legacy ?mtab=log    → 'score'  (log always-visible in main column)
 function parseMobileTab(raw: string | null): LiveTab {
-  if (raw === 'turn' || raw === 'widget' || raw === 'notes' || raw === 'score') return raw;
+  if (raw === 'turn' || raw === 'widget' || raw === 'notes' || raw === 'score' || raw === 'photos')
+    return raw;
   if (raw === 'tools') return 'widget';
   if (raw === 'chat' || raw === 'log') return 'score';
   return 'score';
@@ -854,6 +857,7 @@ export function SessionLiveView(): ReactElement {
       tabTurn: t('pages.sessionLive.rightColumn.tabTurn'),
       tabWidget: t('pages.sessionLive.rightColumn.tabWidget'),
       tabNotes: t('pages.sessionLive.rightColumn.tabNotes'),
+      tabPhotos: t('pages.sessionLive.rightColumn.tabPhotos'),
     }),
     [t]
   );
@@ -879,6 +883,7 @@ export function SessionLiveView(): ReactElement {
       tabTurn: t('pages.sessionLive.rightColumn.tabTurn'),
       tabWidget: t('pages.sessionLive.rightColumn.tabWidget'),
       tabNotes: t('pages.sessionLive.rightColumn.tabNotes'),
+      tabPhotos: t('pages.sessionLive.rightColumn.tabPhotos'),
     }),
     [t]
   );
@@ -1239,6 +1244,8 @@ export function SessionLiveView(): ReactElement {
             labels={notesLabels}
           />
         );
+      case 'photos':
+        return <PhotosTabContent sessionId={sessionId ?? ''} />;
       case 'score':
       default:
         return (
@@ -1428,6 +1435,7 @@ export function SessionLiveView(): ReactElement {
           labels={notesLabels}
         />
       )}
+      {tab === 'photos' && <PhotosTabContent sessionId={sessionId ?? ''} />}
     </RightColumnTabs>
   );
 

--- a/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/__tests__/SessionLiveView.test.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/__tests__/SessionLiveView.test.tsx
@@ -377,6 +377,7 @@ const MESSAGES: Record<string, string> = {
   'pages.sessionLive.rightColumn.tabTurn': 'Turni',
   'pages.sessionLive.rightColumn.tabWidget': 'Widget',
   'pages.sessionLive.rightColumn.tabNotes': 'Note',
+  'pages.sessionLive.rightColumn.tabPhotos': 'Foto',
   // Back-compat (legacy keys for older callers — not used by SessionLiveView post-T4)
   'pages.sessionLive.rightColumn.tabTools': 'Strumenti',
   'pages.sessionLive.rightColumn.tabChat': 'Chat',
@@ -711,9 +712,9 @@ describe('SessionLiveView (Wave D.2 Foundation)', () => {
     searchParamsMap['msheet'] = 'open';
     searchParamsMap['mtab'] = 'turn';
     renderWithIntl(<SessionLiveView />);
-    // Drawer has 4 tabs; the 2nd (index 1) is Turn — aria-selected="true".
+    // Drawer has 5 tabs; the 2nd (index 1) is Turn — aria-selected="true".
     const drawerTabs = document.querySelectorAll('[data-slot="mobile-bottom-sheet"] [role="tab"]');
-    expect(drawerTabs).toHaveLength(4);
+    expect(drawerTabs).toHaveLength(5);
     expect(drawerTabs[1]).toHaveAttribute('aria-selected', 'true');
   });
 

--- a/apps/web/src/components/features/session-live/MobileBody.tsx
+++ b/apps/web/src/components/features/session-live/MobileBody.tsx
@@ -45,6 +45,7 @@ export interface MobileBodyLabels {
   readonly tabTurn: string;
   readonly tabWidget: string;
   readonly tabNotes: string;
+  readonly tabPhotos: string;
 }
 
 // ─── Props ────────────────────────────────────────────────────────────────────
@@ -129,6 +130,7 @@ export function MobileBody({
           tabTurn: labels.tabTurn,
           tabWidget: labels.tabWidget,
           tabNotes: labels.tabNotes,
+          tabPhotos: labels.tabPhotos,
         }}
       >
         {sheetContent}

--- a/apps/web/src/components/features/session-live/MobileBottomSheetDrawer.tsx
+++ b/apps/web/src/components/features/session-live/MobileBottomSheetDrawer.tsx
@@ -46,6 +46,7 @@ export interface MobileBottomSheetDrawerLabels {
   readonly tabTurn: string;
   readonly tabWidget: string;
   readonly tabNotes: string;
+  readonly tabPhotos: string;
 }
 
 // ─── Props ────────────────────────────────────────────────────────────────────
@@ -67,6 +68,7 @@ const ORDERED_TABS: ReadonlyArray<{ id: LiveTab; labelKey: keyof MobileBottomShe
     { id: 'turn', labelKey: 'tabTurn' },
     { id: 'widget', labelKey: 'tabWidget' },
     { id: 'notes', labelKey: 'tabNotes' },
+    { id: 'photos', labelKey: 'tabPhotos' },
   ];
 
 // ─── Component ────────────────────────────────────────────────────────────────

--- a/apps/web/src/components/features/session-live/PhotosTabContent.tsx
+++ b/apps/web/src/components/features/session-live/PhotosTabContent.tsx
@@ -1,0 +1,187 @@
+'use client';
+
+/**
+ * PhotosTabContent — #2588 A1 photos tab for canonical session-live view.
+ *
+ * In-session photo gallery backed by the client-local IndexedDB photo-store
+ * (lib/storage/photo-store). Zero backend — local-only, session-scoped.
+ *
+ * Ported from legacy /sessions/live/[sessionId]/photos/page.tsx.
+ * Vision-AI / SessionSnapshotPanel is a later sub-slice (A2+) — NOT here.
+ */
+
+import { useRef, useState, useCallback, useEffect, type ReactElement } from 'react';
+
+import { Camera, Image as ImageIcon, Trash2 } from 'lucide-react';
+
+import { Button } from '@/components/ui/primitives/button';
+import { addPhoto, listPhotos, deletePhoto, type StoredPhoto } from '@/lib/storage/photo-store';
+
+// ─── Internal types ────────────────────────────────────────────────────────────
+
+interface DisplayPhoto {
+  id: string;
+  objectUrl: string;
+  timestamp: number;
+}
+
+function toDisplay(stored: StoredPhoto): DisplayPhoto {
+  return {
+    id: stored.id,
+    objectUrl: URL.createObjectURL(stored.blob),
+    timestamp: stored.timestamp,
+  };
+}
+
+// ─── PhotoCard sub-component ───────────────────────────────────────────────────
+
+interface PhotoCardProps {
+  photo: DisplayPhoto;
+  onDelete: (id: string) => void;
+}
+
+function PhotoCard({ photo, onDelete }: PhotoCardProps): ReactElement {
+  const date = new Date(photo.timestamp);
+  const timeLabel = date.toLocaleTimeString('it-IT', {
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+
+  return (
+    <div className="group relative rounded-xl overflow-hidden bg-muted aspect-square shadow-sm border border-border">
+      <img
+        src={photo.objectUrl}
+        alt={`Foto partita ${timeLabel}`}
+        className="w-full h-full object-cover"
+      />
+      {/* Hover overlay */}
+      <div className="absolute inset-0 bg-foreground/0 group-hover:bg-foreground/30 transition-colors" />
+      {/* Timestamp badge */}
+      <div className="absolute bottom-0 inset-x-0 bg-gradient-to-t from-black/60 to-transparent p-2">
+        <p className="text-white text-xs font-mono">{timeLabel}</p>
+      </div>
+      {/* Delete button */}
+      <button
+        type="button"
+        className="absolute top-1.5 right-1.5 h-7 w-7 rounded-full bg-foreground/40 hover:bg-destructive/80 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-all"
+        onClick={() => onDelete(photo.id)}
+        aria-label={`Elimina foto ${timeLabel}`}
+        data-testid={`delete-photo-${photo.id}`}
+      >
+        <Trash2 className="h-3.5 w-3.5 text-white" />
+      </button>
+    </div>
+  );
+}
+
+// ─── PhotosTabContent ──────────────────────────────────────────────────────────
+
+export interface PhotosTabContentProps {
+  readonly sessionId: string;
+}
+
+export function PhotosTabContent({ sessionId }: PhotosTabContentProps): ReactElement {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [photos, setPhotos] = useState<DisplayPhoto[]>([]);
+  const photosRef = useRef<DisplayPhoto[]>([]);
+
+  // Keep ref in sync so unmount cleanup sees latest object URLs
+  useEffect(() => {
+    photosRef.current = photos;
+  }, [photos]);
+
+  // Load session photos from IndexedDB on mount / sessionId change
+  useEffect(() => {
+    let cancelled = false;
+    listPhotos(sessionId).then(stored => {
+      if (cancelled) return;
+      photosRef.current.forEach(p => URL.revokeObjectURL(p.objectUrl));
+      setPhotos(stored.map(toDisplay));
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionId]);
+
+  // Revoke object URLs on unmount to prevent memory leaks
+  useEffect(() => {
+    return () => {
+      photosRef.current.forEach(p => URL.revokeObjectURL(p.objectUrl));
+    };
+  }, []);
+
+  const handleCapture = useCallback(
+    async (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (!file) return;
+      e.target.value = '';
+      const stored = await addPhoto(sessionId, file, file.name);
+      const display = toDisplay(stored);
+      setPhotos(prev => [...prev, display]);
+    },
+    [sessionId]
+  );
+
+  const handleDelete = useCallback(async (id: string) => {
+    await deletePhoto(id);
+    const target = photosRef.current.find(p => p.id === id);
+    if (target) URL.revokeObjectURL(target.objectUrl);
+    setPhotos(prev => prev.filter(p => p.id !== id));
+  }, []);
+
+  return (
+    <div className="space-y-4" data-testid="photos-tab-content">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="text-base font-semibold text-foreground">Foto partita</h3>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            {photos.length === 0 ? 'Nessuna foto ancora' : `${photos.length} foto`}
+          </p>
+        </div>
+
+        <Button
+          size="sm"
+          className="gap-2 bg-entity-session text-white hover:opacity-90 font-nunito"
+          onClick={() => fileInputRef.current?.click()}
+          data-testid="capture-button"
+        >
+          <Camera className="h-4 w-4" />
+          Scatta
+        </Button>
+      </div>
+
+      {/* Hidden file input — camera capture on mobile, file picker on desktop */}
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/*"
+        capture="environment"
+        className="hidden"
+        onChange={handleCapture}
+        data-testid="photo-input"
+      />
+
+      {/* Empty state */}
+      {photos.length === 0 && (
+        <div className="flex flex-col items-center gap-3 py-12 text-muted-foreground">
+          <ImageIcon className="h-12 w-12 opacity-30" />
+          <p className="text-sm text-center">Scatta foto per documentare lo stato della partita</p>
+          <Button variant="outline" className="gap-2" onClick={() => fileInputRef.current?.click()}>
+            <Camera className="h-4 w-4" />
+            Prima foto
+          </Button>
+        </div>
+      )}
+
+      {/* Photo grid */}
+      {photos.length > 0 && (
+        <div className="grid grid-cols-2 gap-3">
+          {photos.map(photo => (
+            <PhotoCard key={photo.id} photo={photo} onDelete={handleDelete} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/features/session-live/RightColumnTabs.tsx
+++ b/apps/web/src/components/features/session-live/RightColumnTabs.tsx
@@ -34,9 +34,9 @@ import { useTablistKeyboardNav } from '@/hooks/useTablistKeyboardNav';
 
 // ─── Tab types ────────────────────────────────────────────────────────────────
 
-export type LiveTab = 'score' | 'turn' | 'widget' | 'notes';
+export type LiveTab = 'score' | 'turn' | 'widget' | 'notes' | 'photos';
 
-const ORDERED_TABS: ReadonlyArray<LiveTab> = ['score', 'turn', 'widget', 'notes'];
+const ORDERED_TABS: ReadonlyArray<LiveTab> = ['score', 'turn', 'widget', 'notes', 'photos'];
 
 // ─── Labels ───────────────────────────────────────────────────────────────────
 
@@ -46,6 +46,7 @@ export interface RightColumnTabsLabels {
   readonly tabTurn: string;
   readonly tabWidget: string;
   readonly tabNotes: string;
+  readonly tabPhotos: string;
 }
 
 // ─── Props ────────────────────────────────────────────────────────────────────
@@ -76,8 +77,9 @@ export function RightColumnTabs({
       turn: labels.tabTurn,
       widget: labels.tabWidget,
       notes: labels.tabNotes,
+      photos: labels.tabPhotos,
     }),
-    [labels.tabScore, labels.tabTurn, labels.tabWidget, labels.tabNotes]
+    [labels.tabScore, labels.tabTurn, labels.tabWidget, labels.tabNotes, labels.tabPhotos]
   );
 
   const { tabRefs, handleKeyDown } = useTablistKeyboardNav<LiveTab>({

--- a/apps/web/src/components/features/session-live/__tests__/MobileBody.test.tsx
+++ b/apps/web/src/components/features/session-live/__tests__/MobileBody.test.tsx
@@ -33,6 +33,7 @@ const LABELS: MobileBodyLabels = {
   tabTurn: 'Turni',
   tabWidget: 'Widget',
   tabNotes: 'Note',
+  tabPhotos: 'Foto',
 };
 
 function renderBody(overrides: Partial<MobileBodyProps> = {}) {

--- a/apps/web/src/components/features/session-live/__tests__/MobileBottomSheetDrawer.test.tsx
+++ b/apps/web/src/components/features/session-live/__tests__/MobileBottomSheetDrawer.test.tsx
@@ -32,6 +32,7 @@ const LABELS: MobileBottomSheetDrawerLabels = {
   tabTurn: 'Turni',
   tabWidget: 'Widget',
   tabNotes: 'Note',
+  tabPhotos: 'Foto',
 };
 
 function renderDrawer(overrides: Partial<MobileBottomSheetDrawerProps> = {}) {
@@ -87,14 +88,15 @@ describe('MobileBottomSheetDrawer — render shape', () => {
 });
 
 describe('MobileBottomSheetDrawer — tab strip', () => {
-  it('tab strip has 4 buttons in order: Score, Turn, Widget, Notes', () => {
+  it('tab strip has 5 buttons in order: Score, Turn, Widget, Notes, Photos', () => {
     renderDrawer({ open: true });
     const tabs = screen.getAllByRole('tab');
-    expect(tabs).toHaveLength(4);
+    expect(tabs).toHaveLength(5);
     expect(tabs[0]).toHaveTextContent(LABELS.tabScore);
     expect(tabs[1]).toHaveTextContent(LABELS.tabTurn);
     expect(tabs[2]).toHaveTextContent(LABELS.tabWidget);
     expect(tabs[3]).toHaveTextContent(LABELS.tabNotes);
+    expect(tabs[4]).toHaveTextContent(LABELS.tabPhotos);
   });
 
   it('active tab has aria-selected="true" and others false', () => {
@@ -104,6 +106,7 @@ describe('MobileBottomSheetDrawer — tab strip', () => {
     expect(tabs[1]).toHaveAttribute('aria-selected', 'true');
     expect(tabs[2]).toHaveAttribute('aria-selected', 'false');
     expect(tabs[3]).toHaveAttribute('aria-selected', 'false');
+    expect(tabs[4]).toHaveAttribute('aria-selected', 'false');
   });
 
   it('clicking a tab calls onTabChange with the tab id', () => {

--- a/apps/web/src/components/features/session-live/__tests__/PhotosTabContent.test.tsx
+++ b/apps/web/src/components/features/session-live/__tests__/PhotosTabContent.test.tsx
@@ -1,0 +1,177 @@
+/**
+ * PhotosTabContent unit tests — #2588 A1
+ *
+ * Coverage:
+ *  - renders gallery container
+ *  - lists photos from mocked photo-store
+ *  - file capture calls addPhoto and displays new photo
+ *  - delete button calls deletePhoto and removes photo
+ *  - empty state shown when no photos
+ */
+
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { PhotosTabContent } from '../PhotosTabContent';
+
+// ─── Mock photo-store ─────────────────────────────────────────────────────────
+
+const mockListPhotos = vi.fn();
+const mockAddPhoto = vi.fn();
+const mockDeletePhoto = vi.fn();
+
+vi.mock('@/lib/storage/photo-store', () => ({
+  listPhotos: (...args: unknown[]) => mockListPhotos(...args),
+  addPhoto: (...args: unknown[]) => mockAddPhoto(...args),
+  deletePhoto: (...args: unknown[]) => mockDeletePhoto(...args),
+}));
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeBlob(content = 'img'): Blob {
+  return new Blob([content], { type: 'image/jpeg' });
+}
+
+function makeStoredPhoto(id: string, timestamp = 1000) {
+  return {
+    id,
+    sessionId: 'sess-1',
+    filename: `${id}.jpg`,
+    timestamp,
+    blob: makeBlob(),
+  };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('PhotosTabContent — empty state', () => {
+  beforeEach(() => {
+    mockListPhotos.mockResolvedValue([]);
+    mockAddPhoto.mockReset();
+    mockDeletePhoto.mockReset();
+  });
+
+  it('renders the gallery container', async () => {
+    render(<PhotosTabContent sessionId="sess-1" />);
+    expect(await screen.findByTestId('photos-tab-content')).toBeInTheDocument();
+  });
+
+  it('shows empty-state when no photos', async () => {
+    render(<PhotosTabContent sessionId="sess-1" />);
+    expect(await screen.findByText('Nessuna foto ancora')).toBeInTheDocument();
+  });
+
+  it('renders capture button', async () => {
+    render(<PhotosTabContent sessionId="sess-1" />);
+    expect(await screen.findByTestId('capture-button')).toBeInTheDocument();
+  });
+
+  it('renders hidden file input', async () => {
+    render(<PhotosTabContent sessionId="sess-1" />);
+    expect(await screen.findByTestId('photo-input')).toBeInTheDocument();
+  });
+});
+
+describe('PhotosTabContent — listing photos', () => {
+  beforeEach(() => {
+    mockListPhotos.mockResolvedValue([makeStoredPhoto('p1', 1000), makeStoredPhoto('p2', 2000)]);
+    mockAddPhoto.mockReset();
+    mockDeletePhoto.mockReset();
+  });
+
+  it('calls listPhotos with sessionId on mount', async () => {
+    render(<PhotosTabContent sessionId="sess-42" />);
+    await waitFor(() => expect(mockListPhotos).toHaveBeenCalledWith('sess-42'));
+  });
+
+  it('displays photo count when photos exist', async () => {
+    render(<PhotosTabContent sessionId="sess-1" />);
+    expect(await screen.findByText('2 foto')).toBeInTheDocument();
+  });
+
+  it('renders an img for each photo', async () => {
+    render(<PhotosTabContent sessionId="sess-1" />);
+    const images = await screen.findAllByRole('img');
+    expect(images).toHaveLength(2);
+  });
+
+  it('does not show empty state when photos exist', async () => {
+    render(<PhotosTabContent sessionId="sess-1" />);
+    await screen.findByText('2 foto');
+    expect(screen.queryByText('Nessuna foto ancora')).not.toBeInTheDocument();
+  });
+});
+
+describe('PhotosTabContent — capture', () => {
+  beforeEach(() => {
+    mockListPhotos.mockResolvedValue([]);
+    const newBlob = makeBlob('new');
+    mockAddPhoto.mockResolvedValue({
+      id: 'p-new',
+      sessionId: 'sess-1',
+      filename: 'new.jpg',
+      timestamp: 9000,
+      blob: newBlob,
+    });
+    mockDeletePhoto.mockReset();
+  });
+
+  it('calls addPhoto when a file is selected', async () => {
+    render(<PhotosTabContent sessionId="sess-1" />);
+    await screen.findByTestId('photo-input');
+
+    const file = new File(['img'], 'photo.jpg', { type: 'image/jpeg' });
+    const input = screen.getByTestId('photo-input');
+
+    await act(async () => {
+      fireEvent.change(input, { target: { files: [file] } });
+    });
+
+    expect(mockAddPhoto).toHaveBeenCalledWith('sess-1', file, 'photo.jpg');
+  });
+
+  it('shows the new photo after capture', async () => {
+    render(<PhotosTabContent sessionId="sess-1" />);
+    await screen.findByTestId('photo-input');
+
+    const file = new File(['img'], 'photo.jpg', { type: 'image/jpeg' });
+    const input = screen.getByTestId('photo-input');
+
+    await act(async () => {
+      fireEvent.change(input, { target: { files: [file] } });
+    });
+
+    expect(await screen.findByText('1 foto')).toBeInTheDocument();
+  });
+});
+
+describe('PhotosTabContent — delete', () => {
+  beforeEach(() => {
+    mockListPhotos.mockResolvedValue([makeStoredPhoto('p1', 1000)]);
+    mockAddPhoto.mockReset();
+    mockDeletePhoto.mockResolvedValue(undefined);
+  });
+
+  it('calls deletePhoto when delete button is clicked', async () => {
+    render(<PhotosTabContent sessionId="sess-1" />);
+    const deleteBtn = await screen.findByTestId('delete-photo-p1');
+
+    await act(async () => {
+      fireEvent.click(deleteBtn);
+    });
+
+    expect(mockDeletePhoto).toHaveBeenCalledWith('p1');
+  });
+
+  it('removes the photo from display after delete', async () => {
+    render(<PhotosTabContent sessionId="sess-1" />);
+    const deleteBtn = await screen.findByTestId('delete-photo-p1');
+
+    await act(async () => {
+      fireEvent.click(deleteBtn);
+    });
+
+    await waitFor(() => expect(screen.queryByTestId('delete-photo-p1')).not.toBeInTheDocument());
+    expect(screen.getByText('Nessuna foto ancora')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/features/session-live/__tests__/RightColumnTabs.test.tsx
+++ b/apps/web/src/components/features/session-live/__tests__/RightColumnTabs.test.tsx
@@ -31,6 +31,7 @@ const LABELS: RightColumnTabsLabels = {
   tabTurn: 'Turni',
   tabWidget: 'Widget',
   tabNotes: 'Note',
+  tabPhotos: 'Foto',
 };
 
 function renderTabs(overrides: Partial<RightColumnTabsProps> = {}) {
@@ -71,26 +72,27 @@ describe('RightColumnTabs — render shape', () => {
     expect(screen.getByRole('tablist', { name: 'Colonna destra' })).toBeInTheDocument();
   });
 
-  it('renders 4 tab buttons', () => {
+  it('renders 5 tab buttons', () => {
     renderTabs();
     const tabs = screen.getAllByRole('tab');
-    expect(tabs).toHaveLength(4);
+    expect(tabs).toHaveLength(5);
   });
 
-  it('renders tab labels (Score / Turni / Widget / Note)', () => {
+  it('renders tab labels (Score / Turni / Widget / Note / Foto)', () => {
     renderTabs();
     expect(screen.getByRole('tab', { name: 'Score' })).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: 'Turni' })).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: 'Widget' })).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: 'Note' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Foto' })).toBeInTheDocument();
   });
 
-  it('renders tab buttons in mockup order: Score, Turn, Widget, Notes', () => {
+  it('renders tab buttons in order: Score, Turn, Widget, Notes, Photos', () => {
     renderTabs();
     const tablist = screen.getByRole('tablist');
     const tabs = within(tablist).getAllByRole('tab');
     const labels = tabs.map(t => t.textContent);
-    expect(labels).toEqual(['Score', 'Turni', 'Widget', 'Note']);
+    expect(labels).toEqual(['Score', 'Turni', 'Widget', 'Note', 'Foto']);
   });
 
   it('renders tabpanel with children', () => {
@@ -116,6 +118,7 @@ describe('RightColumnTabs — aria-selected + roving tabindex', () => {
     expect(screen.getByRole('tab', { name: 'Turni' })).toHaveAttribute('aria-selected', 'false');
     expect(screen.getByRole('tab', { name: 'Widget' })).toHaveAttribute('aria-selected', 'false');
     expect(screen.getByRole('tab', { name: 'Note' })).toHaveAttribute('aria-selected', 'false');
+    expect(screen.getByRole('tab', { name: 'Foto' })).toHaveAttribute('aria-selected', 'false');
   });
 
   it('active tab has tabIndex=0', () => {
@@ -128,6 +131,7 @@ describe('RightColumnTabs — aria-selected + roving tabindex', () => {
     expect(screen.getByRole('tab', { name: 'Score' })).toHaveAttribute('tabindex', '-1');
     expect(screen.getByRole('tab', { name: 'Widget' })).toHaveAttribute('tabindex', '-1');
     expect(screen.getByRole('tab', { name: 'Note' })).toHaveAttribute('tabindex', '-1');
+    expect(screen.getByRole('tab', { name: 'Foto' })).toHaveAttribute('tabindex', '-1');
   });
 });
 
@@ -192,12 +196,23 @@ describe('RightColumnTabs — keyboard navigation', () => {
     expect(screen.getByRole('tab', { name: 'Note' })).toHaveAttribute('aria-selected', 'true');
   });
 
-  it('ArrowRight wraps from notes → score', async () => {
+  it('ArrowRight advances from notes → photos', async () => {
     const user = userEvent.setup();
     render(<ControlledTabs initialTab="notes" />);
 
     const notesTab = screen.getByRole('tab', { name: 'Note' });
     notesTab.focus();
+    await user.keyboard('{ArrowRight}');
+
+    expect(screen.getByRole('tab', { name: 'Foto' })).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('ArrowRight wraps from photos → score', async () => {
+    const user = userEvent.setup();
+    render(<ControlledTabs initialTab="photos" />);
+
+    const photosTab = screen.getByRole('tab', { name: 'Foto' });
+    photosTab.focus();
     await user.keyboard('{ArrowRight}');
 
     expect(screen.getByRole('tab', { name: 'Score' })).toHaveAttribute('aria-selected', 'true');
@@ -214,7 +229,7 @@ describe('RightColumnTabs — keyboard navigation', () => {
     expect(screen.getByRole('tab', { name: 'Score' })).toHaveAttribute('aria-selected', 'true');
   });
 
-  it('ArrowLeft wraps from score → notes', async () => {
+  it('ArrowLeft wraps from score → photos', async () => {
     const user = userEvent.setup();
     render(<ControlledTabs initialTab="score" />);
 
@@ -222,7 +237,7 @@ describe('RightColumnTabs — keyboard navigation', () => {
     scoreTab.focus();
     await user.keyboard('{ArrowLeft}');
 
-    expect(screen.getByRole('tab', { name: 'Note' })).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByRole('tab', { name: 'Foto' })).toHaveAttribute('aria-selected', 'true');
   });
 
   it('Home jumps to first tab (score)', async () => {
@@ -236,7 +251,7 @@ describe('RightColumnTabs — keyboard navigation', () => {
     expect(screen.getByRole('tab', { name: 'Score' })).toHaveAttribute('aria-selected', 'true');
   });
 
-  it('End jumps to last tab (notes)', async () => {
+  it('End jumps to last tab (photos)', async () => {
     const user = userEvent.setup();
     render(<ControlledTabs initialTab="score" />);
 
@@ -244,6 +259,6 @@ describe('RightColumnTabs — keyboard navigation', () => {
     scoreTab.focus();
     await user.keyboard('{End}');
 
-    expect(screen.getByRole('tab', { name: 'Note' })).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByRole('tab', { name: 'Foto' })).toHaveAttribute('aria-selected', 'true');
   });
 });

--- a/apps/web/src/components/features/session-live/index.ts
+++ b/apps/web/src/components/features/session-live/index.ts
@@ -133,6 +133,9 @@ export type {
   PauseOverlayProps,
 } from '@/components/features/session-live/PauseOverlay';
 
+export { PhotosTabContent } from '@/components/features/session-live/PhotosTabContent';
+export type { PhotosTabContentProps } from '@/components/features/session-live/PhotosTabContent';
+
 export { RightColumnTabs } from '@/components/features/session-live/RightColumnTabs';
 export type {
   LiveTab,

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -3208,6 +3208,7 @@
         "tabTurn": "Turn",
         "tabWidget": "Widget",
         "tabNotes": "Notes",
+        "tabPhotos": "Photos",
         "tabTools": "Tools",
         "tabChat": "Chat"
       },

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -3315,6 +3315,7 @@
         "tabTurn": "Turni",
         "tabWidget": "Widget",
         "tabNotes": "Note",
+        "tabPhotos": "Foto",
         "tabTools": "Strumenti",
         "tabChat": "Chat"
       },


### PR DESCRIPTION
## Cosa
Epic #2501 Fase 4 **Slice A** sub-slice **A1**: backport del **tab "Foto"** nel canonical session-live (`/sessions/[id]/live`) con la **gallery in-session** (photo-store IndexedDB client-local). Primo step verso il ritiro del legacy `/sessions/live/[sessionId]` (de-risk dettagliato salvato).

## Implementazione (FE-only, zero backend)
- Nuovo `PhotosTabContent.tsx` — capture/list/delete foto via il **photo-store IndexedDB riusato as-is** (session-scoped, client-local). Token semantici (no hardcoded colors), memory-safe (`revokeObjectURL` on unmount).
- Tab mechanics: `'photos'` aggiunto a tutti i sync-point (RightColumnTabs type/ORDERED_TABS/labels + SessionLiveView parseLiveTab/parseMobileTab/mobileBodyLabels + desktop conditional + mobile switch + MobileBottomSheetDrawer). Keyboard-nav auto. i18n `tabPhotos` (it "Foto" / en "Photos").

## Review
Spec ✅ 7/7 Approved, no Critical (photo-store riusato, token semantici → no CI-block, tutti i sync-point desktop+mobile, i18n entrambi i cataloghi, no agent-leakage, legacy non cancellato, test non-vacui). 163 test pass (12 nuovi PhotosTabContent), typecheck clean. 2 Minor (stringhe alt/aria IT-hardcoded, coerenti col progetto IT-primary).

## Scope / out (sub-slice future di Slice A)
- **A2**: agent tab — ArbitroModal/DisputeHistory + image-attach (decisione endpoint).
- **A3**: Vision-AI SessionSnapshotPanel (da verificare se il BE esiste).
- **A-final**: repoint 9 entry-point + delete legacy (gated su A1+A2+A3 = parità).

🤖 Generated with [Claude Code](https://claude.com/claude-code)