### PR TITLE
feat(session-live): #2588 Slice A2 — Vision-AI snapshots in canonical Foto tab

### DIFF
--- a/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx
@@ -1245,7 +1245,13 @@ export function SessionLiveView(): ReactElement {
           />
         );
       case 'photos':
-        return <PhotosTabContent sessionId={sessionId ?? ''} />;
+        return (
+          <PhotosTabContent
+            sessionId={sessionId ?? ''}
+            userId={currentUser?.id ?? ''}
+            currentTurn={activeSession.currentTurn}
+          />
+        );
       case 'score':
       default:
         return (
@@ -1262,6 +1268,7 @@ export function SessionLiveView(): ReactElement {
     mobileTab,
     activeSession,
     sessionId,
+    currentUser?.id,
     scoringPanelLabels,
     turnRendererState,
     turnRendererPlayers,
@@ -1435,7 +1442,13 @@ export function SessionLiveView(): ReactElement {
           labels={notesLabels}
         />
       )}
-      {tab === 'photos' && <PhotosTabContent sessionId={sessionId ?? ''} />}
+      {tab === 'photos' && (
+        <PhotosTabContent
+          sessionId={sessionId ?? ''}
+          userId={currentUser?.id ?? ''}
+          currentTurn={activeSession.currentTurn}
+        />
+      )}
     </RightColumnTabs>
   );
 

--- a/apps/web/src/components/features/session-live/PhotosTabContent.tsx
+++ b/apps/web/src/components/features/session-live/PhotosTabContent.tsx
@@ -1,20 +1,26 @@
 'use client';
 
 /**
- * PhotosTabContent — #2588 A1 photos tab for canonical session-live view.
+ * PhotosTabContent — #2588 A1 + A2 photos tab for canonical session-live view.
  *
- * In-session photo gallery backed by the client-local IndexedDB photo-store
- * (lib/storage/photo-store). Zero backend — local-only, session-scoped.
+ * Two coexisting sections within the "Foto" tab:
+ *  1. In-session photo gallery backed by the client-local IndexedDB photo-store
+ *     (lib/storage/photo-store). Zero backend — local-only, session-scoped (A1).
+ *  2. Vision-AI snapshots via SessionSnapshotPanel (A2) — server-backed
+ *     (/live-sessions/{id}/vision-snapshots) board-state capture + game-state
+ *     extraction. Backported from legacy /sessions/live/[sessionId]/photos.
  *
  * Ported from legacy /sessions/live/[sessionId]/photos/page.tsx.
- * Vision-AI / SessionSnapshotPanel is a later sub-slice (A2+) — NOT here.
+ * Agent/dispute tab is a later sub-slice — NOT here.
  */
 
 import { useRef, useState, useCallback, useEffect, type ReactElement } from 'react';
 
 import { Camera, Image as ImageIcon, Trash2 } from 'lucide-react';
 
+import { SessionSnapshotPanel } from '@/components/session/SessionSnapshotPanel';
 import { Button } from '@/components/ui/primitives/button';
+import { useTranslation } from '@/hooks/useTranslation';
 import { addPhoto, listPhotos, deletePhoto, type StoredPhoto } from '@/lib/storage/photo-store';
 
 // ─── Internal types ────────────────────────────────────────────────────────────
@@ -78,9 +84,24 @@ function PhotoCard({ photo, onDelete }: PhotoCardProps): ReactElement {
 
 export interface PhotosTabContentProps {
   readonly sessionId: string;
+  /**
+   * Current user id — required by SessionSnapshotPanel to attribute Vision-AI
+   * snapshot uploads. Threaded from SessionLiveView (currentUser?.id ?? '').
+   */
+  readonly userId: string;
+  /**
+   * Current turn number — seeds the snapshot upload dialog's default turn.
+   * Defaults to 1 (mirrors the legacy /photos page hardcode) when omitted.
+   */
+  readonly currentTurn?: number;
 }
 
-export function PhotosTabContent({ sessionId }: PhotosTabContentProps): ReactElement {
+export function PhotosTabContent({
+  sessionId,
+  userId,
+  currentTurn = 1,
+}: PhotosTabContentProps): ReactElement {
+  const { t } = useTranslation();
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [photos, setPhotos] = useState<DisplayPhoto[]>([]);
   const photosRef = useRef<DisplayPhoto[]>([]);
@@ -130,58 +151,76 @@ export function PhotosTabContent({ sessionId }: PhotosTabContentProps): ReactEle
   }, []);
 
   return (
-    <div className="space-y-4" data-testid="photos-tab-content">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h3 className="text-base font-semibold text-foreground">Foto partita</h3>
-          <p className="text-xs text-muted-foreground mt-0.5">
-            {photos.length === 0 ? 'Nessuna foto ancora' : `${photos.length} foto`}
-          </p>
-        </div>
+    <div className="space-y-6" data-testid="photos-tab-content">
+      {/* ─── Section 1: in-session local gallery (A1) ─────────────────────── */}
+      <section aria-label={t('pages.sessionLive.photosTab.galleryHeading')} className="space-y-4">
+        {/* Header */}
+        <div className="flex items-center justify-between">
+          <div>
+            <h3 className="text-base font-semibold text-foreground">Foto partita</h3>
+            <p className="text-xs text-muted-foreground mt-0.5">
+              {photos.length === 0 ? 'Nessuna foto ancora' : `${photos.length} foto`}
+            </p>
+          </div>
 
-        <Button
-          size="sm"
-          className="gap-2 bg-entity-session text-white hover:opacity-90 font-nunito"
-          onClick={() => fileInputRef.current?.click()}
-          data-testid="capture-button"
-        >
-          <Camera className="h-4 w-4" />
-          Scatta
-        </Button>
-      </div>
-
-      {/* Hidden file input — camera capture on mobile, file picker on desktop */}
-      <input
-        ref={fileInputRef}
-        type="file"
-        accept="image/*"
-        capture="environment"
-        className="hidden"
-        onChange={handleCapture}
-        data-testid="photo-input"
-      />
-
-      {/* Empty state */}
-      {photos.length === 0 && (
-        <div className="flex flex-col items-center gap-3 py-12 text-muted-foreground">
-          <ImageIcon className="h-12 w-12 opacity-30" />
-          <p className="text-sm text-center">Scatta foto per documentare lo stato della partita</p>
-          <Button variant="outline" className="gap-2" onClick={() => fileInputRef.current?.click()}>
+          <Button
+            size="sm"
+            className="gap-2 bg-entity-session text-white hover:opacity-90 font-nunito"
+            onClick={() => fileInputRef.current?.click()}
+            data-testid="capture-button"
+          >
             <Camera className="h-4 w-4" />
-            Prima foto
+            Scatta
           </Button>
         </div>
-      )}
 
-      {/* Photo grid */}
-      {photos.length > 0 && (
-        <div className="grid grid-cols-2 gap-3">
-          {photos.map(photo => (
-            <PhotoCard key={photo.id} photo={photo} onDelete={handleDelete} />
-          ))}
-        </div>
-      )}
+        {/* Hidden file input — camera capture on mobile, file picker on desktop */}
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/*"
+          capture="environment"
+          className="hidden"
+          onChange={handleCapture}
+          data-testid="photo-input"
+        />
+
+        {/* Empty state */}
+        {photos.length === 0 && (
+          <div className="flex flex-col items-center gap-3 py-12 text-muted-foreground">
+            <ImageIcon className="h-12 w-12 opacity-30" />
+            <p className="text-sm text-center">
+              Scatta foto per documentare lo stato della partita
+            </p>
+            <Button
+              variant="outline"
+              className="gap-2"
+              onClick={() => fileInputRef.current?.click()}
+            >
+              <Camera className="h-4 w-4" />
+              Prima foto
+            </Button>
+          </div>
+        )}
+
+        {/* Photo grid */}
+        {photos.length > 0 && (
+          <div className="grid grid-cols-2 gap-3">
+            {photos.map(photo => (
+              <PhotoCard key={photo.id} photo={photo} onDelete={handleDelete} />
+            ))}
+          </div>
+        )}
+      </section>
+
+      {/* ─── Section 2: Vision-AI snapshots (A2) ──────────────────────────── */}
+      <section
+        aria-label={t('pages.sessionLive.photosTab.snapshotsHeading')}
+        className="border-t border-border pt-6"
+        data-testid="photos-tab-snapshots"
+      >
+        <SessionSnapshotPanel sessionId={sessionId} userId={userId} currentTurn={currentTurn} />
+      </section>
     </div>
   );
 }

--- a/apps/web/src/components/features/session-live/__tests__/PhotosTabContent.test.tsx
+++ b/apps/web/src/components/features/session-live/__tests__/PhotosTabContent.test.tsx
@@ -1,20 +1,71 @@
 /**
- * PhotosTabContent unit tests — #2588 A1
+ * PhotosTabContent unit tests — #2588 A1 + A2
  *
  * Coverage:
- *  - renders gallery container
- *  - lists photos from mocked photo-store
- *  - file capture calls addPhoto and displays new photo
- *  - delete button calls deletePhoto and removes photo
- *  - empty state shown when no photos
+ *  A1 (gallery):
+ *   - renders gallery container
+ *   - lists photos from mocked photo-store
+ *   - file capture calls addPhoto and displays new photo
+ *   - delete button calls deletePhoto and removes photo
+ *   - empty state shown when no photos
+ *  A2 (Vision-AI snapshots):
+ *   - SessionSnapshotPanel rendered within the Foto tab
+ *   - panel receives the correct sessionId + userId + currentTurn
+ *   - gallery and snapshot panel coexist
  */
 
+import type { ReactNode } from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import itMessages from '@/locales/it.json';
 
 import { PhotosTabContent } from '../PhotosTabContent';
 
-// ─── Mock photo-store ─────────────────────────────────────────────────────────
+// ─── i18n wrapper ──────────────────────────────────────────────────────────────
+
+function flattenMessages(obj: Record<string, unknown>, prefix = ''): Record<string, string> {
+  return Object.entries(obj).reduce<Record<string, string>>((acc, [key, val]) => {
+    const fullKey = prefix ? `${prefix}.${key}` : key;
+    if (typeof val === 'string') {
+      acc[fullKey] = val;
+    } else if (typeof val === 'object' && val !== null) {
+      Object.assign(acc, flattenMessages(val as Record<string, unknown>, fullKey));
+    }
+    return acc;
+  }, {});
+}
+
+const FLAT_IT = flattenMessages(itMessages as Record<string, unknown>);
+
+function makeWrapper(qc?: QueryClient) {
+  const client = qc ?? new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={client}>
+        <IntlProvider locale="it" messages={FLAT_IT}>
+          {children}
+        </IntlProvider>
+      </QueryClientProvider>
+    );
+  };
+}
+
+function renderTab(props?: Partial<{ sessionId: string; userId: string; currentTurn: number }>) {
+  return render(
+    <PhotosTabContent
+      sessionId={props?.sessionId ?? 'sess-1'}
+      userId={props?.userId ?? 'user-1'}
+      currentTurn={props?.currentTurn}
+    />,
+    { wrapper: makeWrapper() }
+  );
+}
+
+// ─── Mock photo-store (A1 gallery) ──────────────────────────────────────────────
 
 const mockListPhotos = vi.fn();
 const mockAddPhoto = vi.fn();
@@ -24,6 +75,28 @@ vi.mock('@/lib/storage/photo-store', () => ({
   listPhotos: (...args: unknown[]) => mockListPhotos(...args),
   addPhoto: (...args: unknown[]) => mockAddPhoto(...args),
   deletePhoto: (...args: unknown[]) => mockDeletePhoto(...args),
+}));
+
+// ─── Spy-stub SessionSnapshotPanel (A2) ─────────────────────────────────────────
+// Stub echoes received props into the DOM so threading is asserted
+// deterministically without standing up the real server-backed hooks.
+
+const snapshotPanelProps = vi.fn();
+
+vi.mock('@/components/session/SessionSnapshotPanel', () => ({
+  SessionSnapshotPanel: (props: { sessionId: string; userId: string; currentTurn?: number }) => {
+    snapshotPanelProps(props);
+    return (
+      <div
+        data-testid="mock-session-snapshot-panel"
+        data-session-id={props.sessionId}
+        data-user-id={props.userId}
+        data-current-turn={String(props.currentTurn)}
+      >
+        SessionSnapshotPanel
+      </div>
+    );
+  },
 }));
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -49,25 +122,26 @@ describe('PhotosTabContent — empty state', () => {
     mockListPhotos.mockResolvedValue([]);
     mockAddPhoto.mockReset();
     mockDeletePhoto.mockReset();
+    snapshotPanelProps.mockReset();
   });
 
   it('renders the gallery container', async () => {
-    render(<PhotosTabContent sessionId="sess-1" />);
+    renderTab();
     expect(await screen.findByTestId('photos-tab-content')).toBeInTheDocument();
   });
 
   it('shows empty-state when no photos', async () => {
-    render(<PhotosTabContent sessionId="sess-1" />);
+    renderTab();
     expect(await screen.findByText('Nessuna foto ancora')).toBeInTheDocument();
   });
 
   it('renders capture button', async () => {
-    render(<PhotosTabContent sessionId="sess-1" />);
+    renderTab();
     expect(await screen.findByTestId('capture-button')).toBeInTheDocument();
   });
 
   it('renders hidden file input', async () => {
-    render(<PhotosTabContent sessionId="sess-1" />);
+    renderTab();
     expect(await screen.findByTestId('photo-input')).toBeInTheDocument();
   });
 });
@@ -77,26 +151,27 @@ describe('PhotosTabContent — listing photos', () => {
     mockListPhotos.mockResolvedValue([makeStoredPhoto('p1', 1000), makeStoredPhoto('p2', 2000)]);
     mockAddPhoto.mockReset();
     mockDeletePhoto.mockReset();
+    snapshotPanelProps.mockReset();
   });
 
   it('calls listPhotos with sessionId on mount', async () => {
-    render(<PhotosTabContent sessionId="sess-42" />);
+    renderTab({ sessionId: 'sess-42' });
     await waitFor(() => expect(mockListPhotos).toHaveBeenCalledWith('sess-42'));
   });
 
   it('displays photo count when photos exist', async () => {
-    render(<PhotosTabContent sessionId="sess-1" />);
+    renderTab();
     expect(await screen.findByText('2 foto')).toBeInTheDocument();
   });
 
   it('renders an img for each photo', async () => {
-    render(<PhotosTabContent sessionId="sess-1" />);
+    renderTab();
     const images = await screen.findAllByRole('img');
     expect(images).toHaveLength(2);
   });
 
   it('does not show empty state when photos exist', async () => {
-    render(<PhotosTabContent sessionId="sess-1" />);
+    renderTab();
     await screen.findByText('2 foto');
     expect(screen.queryByText('Nessuna foto ancora')).not.toBeInTheDocument();
   });
@@ -114,10 +189,11 @@ describe('PhotosTabContent — capture', () => {
       blob: newBlob,
     });
     mockDeletePhoto.mockReset();
+    snapshotPanelProps.mockReset();
   });
 
   it('calls addPhoto when a file is selected', async () => {
-    render(<PhotosTabContent sessionId="sess-1" />);
+    renderTab();
     await screen.findByTestId('photo-input');
 
     const file = new File(['img'], 'photo.jpg', { type: 'image/jpeg' });
@@ -131,7 +207,7 @@ describe('PhotosTabContent — capture', () => {
   });
 
   it('shows the new photo after capture', async () => {
-    render(<PhotosTabContent sessionId="sess-1" />);
+    renderTab();
     await screen.findByTestId('photo-input');
 
     const file = new File(['img'], 'photo.jpg', { type: 'image/jpeg' });
@@ -150,10 +226,11 @@ describe('PhotosTabContent — delete', () => {
     mockListPhotos.mockResolvedValue([makeStoredPhoto('p1', 1000)]);
     mockAddPhoto.mockReset();
     mockDeletePhoto.mockResolvedValue(undefined);
+    snapshotPanelProps.mockReset();
   });
 
   it('calls deletePhoto when delete button is clicked', async () => {
-    render(<PhotosTabContent sessionId="sess-1" />);
+    renderTab();
     const deleteBtn = await screen.findByTestId('delete-photo-p1');
 
     await act(async () => {
@@ -164,7 +241,7 @@ describe('PhotosTabContent — delete', () => {
   });
 
   it('removes the photo from display after delete', async () => {
-    render(<PhotosTabContent sessionId="sess-1" />);
+    renderTab();
     const deleteBtn = await screen.findByTestId('delete-photo-p1');
 
     await act(async () => {
@@ -173,5 +250,50 @@ describe('PhotosTabContent — delete', () => {
 
     await waitFor(() => expect(screen.queryByTestId('delete-photo-p1')).not.toBeInTheDocument());
     expect(screen.getByText('Nessuna foto ancora')).toBeInTheDocument();
+  });
+});
+
+describe('PhotosTabContent — Vision-AI snapshots (A2)', () => {
+  beforeEach(() => {
+    mockListPhotos.mockResolvedValue([]);
+    mockAddPhoto.mockReset();
+    mockDeletePhoto.mockReset();
+    snapshotPanelProps.mockReset();
+  });
+
+  it('renders SessionSnapshotPanel within the Foto tab', async () => {
+    renderTab();
+    expect(await screen.findByTestId('mock-session-snapshot-panel')).toBeInTheDocument();
+  });
+
+  it('renders the snapshots section wrapper', async () => {
+    renderTab();
+    expect(await screen.findByTestId('photos-tab-snapshots')).toBeInTheDocument();
+  });
+
+  it('passes the correct sessionId + userId + currentTurn to the panel', async () => {
+    renderTab({ sessionId: 'sess-77', userId: 'user-99', currentTurn: 5 });
+    await screen.findByTestId('mock-session-snapshot-panel');
+
+    expect(snapshotPanelProps).toHaveBeenCalledWith(
+      expect.objectContaining({ sessionId: 'sess-77', userId: 'user-99', currentTurn: 5 })
+    );
+  });
+
+  it('defaults currentTurn to 1 when not provided', async () => {
+    renderTab({ sessionId: 'sess-1', userId: 'user-1' });
+    await screen.findByTestId('mock-session-snapshot-panel');
+
+    expect(snapshotPanelProps).toHaveBeenCalledWith(expect.objectContaining({ currentTurn: 1 }));
+  });
+
+  it('gallery and snapshot panel coexist in the same tab', async () => {
+    mockListPhotos.mockResolvedValue([makeStoredPhoto('p1', 1000)]);
+    renderTab();
+
+    // Gallery present (photo card from store)
+    expect(await screen.findByTestId('delete-photo-p1')).toBeInTheDocument();
+    // Snapshot panel present alongside it
+    expect(screen.getByTestId('mock-session-snapshot-panel')).toBeInTheDocument();
   });
 });

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -3212,6 +3212,10 @@
         "tabTools": "Tools",
         "tabChat": "Chat"
       },
+      "photosTab": {
+        "galleryHeading": "Match photo gallery",
+        "snapshotsHeading": "Vision AI snapshots"
+      },
       "tools": {
         "title": "Tools",
         "toolDiceLabel": "Dice",

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -3319,6 +3319,10 @@
         "tabTools": "Strumenti",
         "tabChat": "Chat"
       },
+      "photosTab": {
+        "galleryHeading": "Galleria foto della partita",
+        "snapshotsHeading": "Snapshot Vision AI"
+      },
       "tools": {
         "title": "Strumenti",
         "toolDiceLabel": "Dado",


### PR DESCRIPTION
## Cosa
Epic #2501 Fase 4 Slice A sub-slice **A2**: aggiunge `SessionSnapshotPanel` (Vision-AI snapshots) al tab "Foto" del canonical, accanto alla gallery in-session di A1 — completa la parità foto col legacy `/sessions/live/[sessionId]/photos` (che aveva gallery + Vision-AI). Backend Vision-AI verificato esistente (`/live-sessions/{id}/vision-snapshots` + `/game-state`).

## Implementazione (FE, riuso BE esistente)
- `SessionSnapshotPanel` **riusato as-is** (hooks `useSessionVisionSnapshots`/`useLatestGameState`/`useCreateSnapshot` → endpoint esistenti; nessuna dipendenza Zustand), montato come 2a sezione in `PhotosTabContent`.
- Props `userId` + `currentTurn` threaded da **desktop + mobile** (simmetrico) in SessionLiveView. `gameId` non serve (gli hook keyano su sessionId).
- Heading i18n (it+en) per le 2 sezioni (gallery + snapshots). Token semantici.

## Review
Spec ✅ 6/6 Approved (panel as-is, threading simmetrico verificato, scope pulito no-agent/dispute, test non-vacui con hook mockati). 17/17 PhotosTabContent (5 nuovi) + 110/110 SessionLiveView, typecheck clean. 1 Minor (stringhe IT-hardcoded di A1, pre-esistenti → follow-up).

## Scope / out (sub-slice future)
- **A3**: image-attach nel chat (`/ask-agent` esiste).
- **A4**: dispute tab (ArbitroModal/DisputeHistory — complesso: canonical ha già API ricca `/live-sessions/{id}/disputes` open/respond/vote/tally, no GET → idratazione SSE).
- **A-final**: repoint 9 entry + delete legacy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)