### PR TITLE
feat(session-live): #2588 Slice A4 — Arbitro dispute tab in canonical view

### DIFF
--- a/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx
@@ -109,6 +109,7 @@ import {
   type ScoringPanelRendererLabels,
   type ToolkitRendererLabels,
 } from '@/components/features/session-live';
+import { AgentDisputeTabContent } from '@/components/features/session-live/AgentDisputeTabContent';
 import type { ChatMessage as LiveAgentChatMessage } from '@/components/features/session-live/LiveAgentChat';
 import { PhotosTabContent } from '@/components/features/session-live/PhotosTabContent';
 import { useAddDiaryEntry } from '@/hooks/mutations/useAddDiaryEntry';
@@ -122,6 +123,7 @@ import { useTranslation } from '@/hooks/useTranslation';
 import { api } from '@/lib/api';
 import { ConflictError } from '@/lib/api/core/errors';
 import { useSessionAgentChat } from '@/lib/domain-hooks/useSessionAgentChat';
+import { useSignalRSession } from '@/lib/domain-hooks/useSignalrSession';
 import { getNavigationLinks } from '@/lib/navigation';
 import { composeSessionLiveState } from '@/lib/session-live/compose-session-live-state';
 import { mapConnectionState } from '@/lib/session-live/map-connection-state';
@@ -196,10 +198,17 @@ function resolveFixtureVariant(variantParam: string | null): LiveSessionFixture 
 //   - legacy ?tab=chat   → 'score'   (chat is no longer a tab; live in LEFT mainColumn)
 //   - legacy/missing     → 'score'   (new default)
 
-type LiveTab = 'score' | 'turn' | 'widget' | 'notes' | 'photos';
+type LiveTab = 'score' | 'turn' | 'widget' | 'notes' | 'photos' | 'agent';
 
 function parseLiveTab(raw: string | null): LiveTab {
-  if (raw === 'turn' || raw === 'widget' || raw === 'notes' || raw === 'score' || raw === 'photos')
+  if (
+    raw === 'turn' ||
+    raw === 'widget' ||
+    raw === 'notes' ||
+    raw === 'score' ||
+    raw === 'photos' ||
+    raw === 'agent'
+  )
     return raw;
   // Back-compat aliases (R-1): legacy URL bookmarks must not 404.
   if (raw === 'tools') return 'widget';
@@ -212,7 +221,14 @@ function parseLiveTab(raw: string | null): LiveTab {
 // Legacy ?mtab=chat   → 'score'  (chat always-visible in main column)
 // Legacy ?mtab=log    → 'score'  (log always-visible in main column)
 function parseMobileTab(raw: string | null): LiveTab {
-  if (raw === 'turn' || raw === 'widget' || raw === 'notes' || raw === 'score' || raw === 'photos')
+  if (
+    raw === 'turn' ||
+    raw === 'widget' ||
+    raw === 'notes' ||
+    raw === 'score' ||
+    raw === 'photos' ||
+    raw === 'agent'
+  )
     return raw;
   if (raw === 'tools') return 'widget';
   if (raw === 'chat' || raw === 'log') return 'score';
@@ -859,6 +875,7 @@ export function SessionLiveView(): ReactElement {
       tabWidget: t('pages.sessionLive.rightColumn.tabWidget'),
       tabNotes: t('pages.sessionLive.rightColumn.tabNotes'),
       tabPhotos: t('pages.sessionLive.rightColumn.tabPhotos'),
+      tabAgent: t('pages.sessionLive.rightColumn.tabAgent'),
     }),
     [t]
   );
@@ -885,6 +902,7 @@ export function SessionLiveView(): ReactElement {
       tabWidget: t('pages.sessionLive.rightColumn.tabWidget'),
       tabNotes: t('pages.sessionLive.rightColumn.tabNotes'),
       tabPhotos: t('pages.sessionLive.rightColumn.tabPhotos'),
+      tabAgent: t('pages.sessionLive.rightColumn.tabAgent'),
     }),
     [t]
   );
@@ -1065,6 +1083,13 @@ export function SessionLiveView(): ReactElement {
     persistHistory: !fixture,
     gameContext: agentGameContext,
   });
+
+  // #2588 A4: SignalR connection for dispute hydration.
+  // Mounted once at orchestrator level so DisputeResolved events populate
+  // useLiveSessionStore.disputes even when the user is on another tab.
+  // Self-tears-down on unmount/sessionId change (hook contract).
+  // Disabled in fixture/visual-test builds to avoid real hub connections.
+  useSignalRSession(!fixture ? (sessionId ?? '') : '');
 
   // #2588 A3: local state for image-path messages (ask-agent JSON endpoint).
   // These are merged into agentChatMessages below so they appear in the same panel.
@@ -1321,6 +1346,17 @@ export function SessionLiveView(): ReactElement {
             currentTurn={activeSession.currentTurn}
           />
         );
+      case 'agent':
+        return (
+          <AgentDisputeTabContent
+            sessionId={sessionId ?? ''}
+            players={activeSession.players.map(p => ({
+              id: p.id,
+              name:
+                ('displayName' in p ? (p.displayName as string | undefined) : undefined) ?? p.name,
+            }))}
+          />
+        );
       case 'score':
       default:
         return (
@@ -1516,6 +1552,16 @@ export function SessionLiveView(): ReactElement {
           sessionId={sessionId ?? ''}
           userId={currentUser?.id ?? ''}
           currentTurn={activeSession.currentTurn}
+        />
+      )}
+      {tab === 'agent' && (
+        <AgentDisputeTabContent
+          sessionId={sessionId ?? ''}
+          players={activeSession.players.map(p => ({
+            id: p.id,
+            name:
+              ('displayName' in p ? (p.displayName as string | undefined) : undefined) ?? p.name,
+          }))}
         />
       )}
     </RightColumnTabs>

--- a/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/__tests__/SessionLiveView.test.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/__tests__/SessionLiveView.test.tsx
@@ -39,6 +39,22 @@ import type { UseSessionLiveStreamResult } from '@/lib/session-live/use-session-
 import { useLiveSessionStore } from '@/lib/stores/live-session-store';
 import type { ScoreDataByType } from '@/components/sessions/score-strategies/types';
 
+// ─── useSignalRSession mock (#2588 A4: dispute hydration via SignalR) ─────────
+// The hook connects to /hubs/game-state — mock it to a no-op so tests don't try
+// to establish a real WebSocket connection. Assertions about mount/sessionId
+// come from the useSignalRSessionMock spy.
+
+const useSignalRSessionMock = vi.fn(() => ({
+  connection: null,
+  isConnected: false,
+  proposeScore: vi.fn(),
+  appBackgrounded: vi.fn(),
+}));
+
+vi.mock('@/lib/domain-hooks/useSignalrSession', () => ({
+  useSignalRSession: (...args: unknown[]) => useSignalRSessionMock(...args),
+}));
+
 // ─── next/navigation mocks ────────────────────────────────────────────────
 
 const searchParamsMap: Record<string, string> = {};
@@ -378,6 +394,7 @@ const MESSAGES: Record<string, string> = {
   'pages.sessionLive.rightColumn.tabWidget': 'Widget',
   'pages.sessionLive.rightColumn.tabNotes': 'Note',
   'pages.sessionLive.rightColumn.tabPhotos': 'Foto',
+  'pages.sessionLive.rightColumn.tabAgent': 'Arbitro',
   // Back-compat (legacy keys for older callers — not used by SessionLiveView post-T4)
   'pages.sessionLive.rightColumn.tabTools': 'Strumenti',
   'pages.sessionLive.rightColumn.tabChat': 'Chat',
@@ -506,6 +523,8 @@ beforeEach(() => {
   useLiveSessionStore.getState().reset();
   // #2505: reset currentUser to null by default; individual tests can override.
   useCurrentUserMock.mockReturnValue({ data: null });
+  // #2588 A4: reset SignalR mock so call counts don't bleed between tests.
+  useSignalRSessionMock.mockClear();
 });
 
 describe('SessionLiveView (Wave D.2 Foundation)', () => {
@@ -712,9 +731,9 @@ describe('SessionLiveView (Wave D.2 Foundation)', () => {
     searchParamsMap['msheet'] = 'open';
     searchParamsMap['mtab'] = 'turn';
     renderWithIntl(<SessionLiveView />);
-    // Drawer has 5 tabs; the 2nd (index 1) is Turn — aria-selected="true".
+    // Drawer has 6 tabs (score/turn/widget/notes/photos/agent); the 2nd (index 1) is Turn.
     const drawerTabs = document.querySelectorAll('[data-slot="mobile-bottom-sheet"] [role="tab"]');
-    expect(drawerTabs).toHaveLength(5);
+    expect(drawerTabs).toHaveLength(6);
     expect(drawerTabs[1]).toHaveAttribute('aria-selected', 'true');
   });
 
@@ -2463,5 +2482,125 @@ describe('SessionLiveView — diary write response-ack (SP5-a finding #16)', () 
       expect.stringContaining('Impossibile salvare la nota'),
       expect.anything()
     );
+  });
+});
+
+// ─── #2588 A4 — Arbitro (agent) tab wiring + SignalR dispute hydration ────────
+//
+// Verifies:
+//  A4-1: useSignalRSession called with sessionId on a live session
+//  A4-2: useSignalRSession called with '' in fixture mode (no real WS)
+//  A4-3: ?tab=agent shows data-active-tab="agent" on RightColumnTabs
+//  A4-4: ?mtab=agent selects the 6th tab (index 5) in the mobile drawer
+//  A4-5: desktop agent tab renders AgentDisputeTabContent slot
+
+describe('SessionLiveView — #2588 A4: Arbitro tab + dispute SignalR hydration', () => {
+  const SESSION_ID = 'session-abc-123';
+
+  const BASE_DTO = {
+    id: SESSION_ID,
+    sessionCode: 'A4TEST',
+    gameId: 'game-00000001',
+    gameName: 'Test Game',
+    gameSlug: 'test-game',
+    createdByUserId: 'user-a4-host',
+    status: 'InProgress',
+    visibility: 'Private',
+    groupId: null,
+    createdAt: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
+    startedAt: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+    pausedAt: null,
+    completedAt: null,
+    updatedAt: new Date(Date.now() - 5 * 60 * 1000).toISOString(),
+    lastSavedAt: null,
+    currentTurnIndex: 0,
+    currentTurnPlayerId: null,
+    agentMode: 'Active',
+    notes: null,
+    players: [
+      {
+        id: 'player-a4-001',
+        displayName: 'Marco',
+        userId: 'user-a4-host',
+        color: 'Blue',
+        role: 'Host',
+        totalScore: 0,
+        isActive: true,
+      },
+      {
+        id: 'player-a4-002',
+        displayName: 'Anna',
+        userId: null,
+        color: 'Red',
+        role: 'Player',
+        totalScore: 0,
+        isActive: true,
+      },
+    ],
+    teams: [],
+    roundScores: [],
+    scoringConfig: { enabledDimensions: [], dimensionUnits: {} },
+  } as unknown as LiveSessionDto;
+
+  function emptyHistoryA4() {
+    return { records: [], totalCount: 0, page: 1, pageSize: 1, totalPages: 0 };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.keys(searchParamsMap).forEach(k => delete searchParamsMap[k]);
+    mockParamsId = SESSION_ID;
+    IS_VISUAL_TEST_BUILD_MOCK = false;
+    useSessionLiveStreamMock.mockReturnValue({ ...mockLiveStreamResult });
+    useCurrentUserMock.mockReturnValue({ data: { id: 'user-a4-host' } });
+    useLiveSessionMock.mockReturnValue({
+      data: BASE_DTO,
+      isLoading: false,
+      isError: false,
+      isSuccess: true,
+      error: null,
+    });
+    completeIsPending = false;
+    resolveStatusMock = 'idle';
+    resolvePlayRecordIdMock = null;
+    getHistoryMock.mockResolvedValue(emptyHistoryA4());
+  });
+
+  it('A4-1: useSignalRSession is called with the session id', () => {
+    renderWithIntl(<SessionLiveView />);
+    expect(useSignalRSessionMock).toHaveBeenCalledWith(SESSION_ID);
+  });
+
+  it('A4-2: useSignalRSession called with "" in fixture mode (no WS in tests)', () => {
+    IS_VISUAL_TEST_BUILD_MOCK = true;
+    renderWithIntl(<SessionLiveView />);
+    // fixture mode passes '' to prevent WebSocket handshake in CI
+    expect(useSignalRSessionMock).toHaveBeenCalledWith('');
+  });
+
+  it('A4-3: ?tab=agent sets data-active-tab="agent" on RightColumnTabs', () => {
+    searchParamsMap['tab'] = 'agent';
+    const { container } = renderWithIntl(<SessionLiveView />);
+    const tabsRoot = container.querySelector('[data-slot="right-column-tabs"]');
+    expect(tabsRoot).toBeInTheDocument();
+    expect(tabsRoot).toHaveAttribute('data-active-tab', 'agent');
+  });
+
+  it('A4-4: ?mtab=agent selects the agent tab in mobile drawer (aria-selected="true")', () => {
+    searchParamsMap['mtab'] = 'agent';
+    searchParamsMap['msheet'] = 'open'; // parseMobileSheetOpen: 'open' → true
+    renderWithIntl(<SessionLiveView />);
+    // Drawer portals to document.body — query document directly (not container).
+    // The 6th tab (index 5, data-tab="agent") must have aria-selected="true".
+    const drawerTabs = document.querySelectorAll('[data-slot="mobile-bottom-sheet"] [role="tab"]');
+    expect(drawerTabs).toHaveLength(6);
+    expect(drawerTabs[5]).toHaveAttribute('aria-selected', 'true'); // agent = index 5
+    expect(drawerTabs[5]).toHaveAttribute('data-tab', 'agent');
+  });
+
+  it('A4-5: desktop ?tab=agent renders AgentDisputeTabContent slot', () => {
+    searchParamsMap['tab'] = 'agent';
+    const { container } = renderWithIntl(<SessionLiveView />);
+    expect(container.querySelector('[data-slot="agent-dispute-tab-content"]')).toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/features/session-live/AgentDisputeTabContent.tsx
+++ b/apps/web/src/components/features/session-live/AgentDisputeTabContent.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+/**
+ * AgentDisputeTabContent — #2588 A4 dispute-tab backport.
+ *
+ * Renders the "Arbitro" tab content for the canonical session-live view.
+ * Hosts ArbitroModal (open-dispute CTA + form) and DisputeHistory (past verdicts).
+ *
+ * Dispute hydration: `useSignalRSession` is mounted at the SessionLiveView
+ * orchestrator level (NOT here) so the SignalR connection persists across tab
+ * changes and populates `useLiveSessionStore.disputes` in real-time.
+ *
+ * Known limitations:
+ *   - No REST hydration on mount: disputes are SignalR-only (lost on reload).
+ *   - Dual transport: disputes come via SignalR; rest of live state via SSE.
+ *
+ * @see ArbitroModal  — self-contained, POSTs to legacy endpoint, owns verdict UX.
+ * @see DisputeHistory — reads disputes from useLiveSessionStore.
+ * @see useSignalRSession — wired in SessionLiveView, populates store on 'DisputeResolved'.
+ */
+
+import type { ReactElement } from 'react';
+
+import { ArbitroModal } from '@/components/session/live/ArbitroModal';
+import { DisputeHistory } from '@/components/session/live/DisputeHistory';
+
+// ─── Props ────────────────────────────────────────────────────────────────────
+
+export interface AgentDisputeTabContentProps {
+  /** Canonical live-session id (LiveGameSession.id). */
+  readonly sessionId: string;
+  /** Players for the ArbitroModal "raised-by" selector. */
+  readonly players: ReadonlyArray<{ id?: string; name: string }>;
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function AgentDisputeTabContent({
+  sessionId,
+  players,
+}: AgentDisputeTabContentProps): ReactElement {
+  return (
+    <div data-slot="agent-dispute-tab-content" className="flex flex-col gap-4 p-3">
+      {/* Open-dispute CTA — ArbitroModal self-manages open/close state.
+          Spread converts ReadonlyArray → mutable Array as required by ArbitroModal prop. */}
+      <ArbitroModal sessionId={sessionId} players={[...players]} />
+
+      {/* Past verdicts — reads from useLiveSessionStore.disputes */}
+      <DisputeHistory sessionId={sessionId} />
+    </div>
+  );
+}

--- a/apps/web/src/components/features/session-live/MobileBody.tsx
+++ b/apps/web/src/components/features/session-live/MobileBody.tsx
@@ -46,6 +46,7 @@ export interface MobileBodyLabels {
   readonly tabWidget: string;
   readonly tabNotes: string;
   readonly tabPhotos: string;
+  readonly tabAgent: string;
 }
 
 // ─── Props ────────────────────────────────────────────────────────────────────
@@ -131,6 +132,7 @@ export function MobileBody({
           tabWidget: labels.tabWidget,
           tabNotes: labels.tabNotes,
           tabPhotos: labels.tabPhotos,
+          tabAgent: labels.tabAgent,
         }}
       >
         {sheetContent}

--- a/apps/web/src/components/features/session-live/MobileBottomSheetDrawer.tsx
+++ b/apps/web/src/components/features/session-live/MobileBottomSheetDrawer.tsx
@@ -47,6 +47,7 @@ export interface MobileBottomSheetDrawerLabels {
   readonly tabWidget: string;
   readonly tabNotes: string;
   readonly tabPhotos: string;
+  readonly tabAgent: string;
 }
 
 // ─── Props ────────────────────────────────────────────────────────────────────
@@ -69,6 +70,7 @@ const ORDERED_TABS: ReadonlyArray<{ id: LiveTab; labelKey: keyof MobileBottomShe
     { id: 'widget', labelKey: 'tabWidget' },
     { id: 'notes', labelKey: 'tabNotes' },
     { id: 'photos', labelKey: 'tabPhotos' },
+    { id: 'agent', labelKey: 'tabAgent' },
   ];
 
 // ─── Component ────────────────────────────────────────────────────────────────

--- a/apps/web/src/components/features/session-live/RightColumnTabs.tsx
+++ b/apps/web/src/components/features/session-live/RightColumnTabs.tsx
@@ -34,9 +34,16 @@ import { useTablistKeyboardNav } from '@/hooks/useTablistKeyboardNav';
 
 // ─── Tab types ────────────────────────────────────────────────────────────────
 
-export type LiveTab = 'score' | 'turn' | 'widget' | 'notes' | 'photos';
+export type LiveTab = 'score' | 'turn' | 'widget' | 'notes' | 'photos' | 'agent';
 
-const ORDERED_TABS: ReadonlyArray<LiveTab> = ['score', 'turn', 'widget', 'notes', 'photos'];
+const ORDERED_TABS: ReadonlyArray<LiveTab> = [
+  'score',
+  'turn',
+  'widget',
+  'notes',
+  'photos',
+  'agent',
+];
 
 // ─── Labels ───────────────────────────────────────────────────────────────────
 
@@ -47,6 +54,7 @@ export interface RightColumnTabsLabels {
   readonly tabWidget: string;
   readonly tabNotes: string;
   readonly tabPhotos: string;
+  readonly tabAgent: string;
 }
 
 // ─── Props ────────────────────────────────────────────────────────────────────
@@ -78,8 +86,16 @@ export function RightColumnTabs({
       widget: labels.tabWidget,
       notes: labels.tabNotes,
       photos: labels.tabPhotos,
+      agent: labels.tabAgent,
     }),
-    [labels.tabScore, labels.tabTurn, labels.tabWidget, labels.tabNotes, labels.tabPhotos]
+    [
+      labels.tabScore,
+      labels.tabTurn,
+      labels.tabWidget,
+      labels.tabNotes,
+      labels.tabPhotos,
+      labels.tabAgent,
+    ]
   );
 
   const { tabRefs, handleKeyDown } = useTablistKeyboardNav<LiveTab>({

--- a/apps/web/src/components/features/session-live/__tests__/AgentDisputeTabContent.test.tsx
+++ b/apps/web/src/components/features/session-live/__tests__/AgentDisputeTabContent.test.tsx
@@ -1,0 +1,152 @@
+/**
+ * AgentDisputeTabContent unit tests — #2588 A4
+ *
+ * Coverage:
+ *   - renders data-slot="agent-dispute-tab-content"
+ *   - renders the ArbitroModal trigger button ("⚖️ Arbitro")
+ *   - clicking the button opens ArbitroModal (modal renders in DOM)
+ *   - renders DisputeHistory (hidden when 0 disputes, visible when disputes exist)
+ *   - DisputeHistory shows verdicts from useLiveSessionStore.disputes
+ */
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AgentDisputeTabContent } from '../AgentDisputeTabContent';
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+// Mock the api (ArbitroModal calls api.liveSessions.submitDispute)
+vi.mock('@/lib/api', () => ({
+  api: {
+    liveSessions: {
+      submitDispute: vi.fn(),
+    },
+  },
+}));
+
+// Mock useLiveSessionStore — controllable disputes array
+let mockDisputes: Array<{
+  id: string;
+  description: string;
+  verdict: string;
+  ruleReferences: string[];
+  raisedByPlayerName: string;
+  timestamp: string;
+}> = [];
+
+vi.mock('@/lib/stores/live-session-store', () => ({
+  useLiveSessionStore: (
+    selector: (s: { disputes: typeof mockDisputes; addDispute: () => void }) => unknown
+  ) => selector({ disputes: mockDisputes, addDispute: vi.fn() }),
+}));
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const PLAYERS = [
+  { id: 'p1', name: 'Marco' },
+  { id: 'p2', name: 'Anna' },
+];
+
+function renderContent(sessionId = 'sess-001') {
+  return render(<AgentDisputeTabContent sessionId={sessionId} players={PLAYERS} />);
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('AgentDisputeTabContent — render shape', () => {
+  beforeEach(() => {
+    mockDisputes = [];
+  });
+
+  it('renders data-slot="agent-dispute-tab-content"', () => {
+    renderContent();
+    expect(document.querySelector('[data-slot="agent-dispute-tab-content"]')).toBeInTheDocument();
+  });
+
+  it('renders the ArbitroModal trigger button', () => {
+    renderContent();
+    // ArbitroModal renders a DialogTrigger Button with "⚖️ Arbitro"
+    expect(screen.getByRole('button', { name: /Arbitro/i })).toBeInTheDocument();
+  });
+
+  it('DisputeHistory is not rendered when disputes list is empty', () => {
+    mockDisputes = [];
+    renderContent();
+    // DisputeHistory returns null when disputes.length === 0
+    expect(screen.queryByRole('button', { name: /Verdetti precedenti/i })).not.toBeInTheDocument();
+  });
+});
+
+describe('AgentDisputeTabContent — ArbitroModal interaction', () => {
+  beforeEach(() => {
+    mockDisputes = [];
+  });
+
+  it('clicking the Arbitro button opens the dialog', async () => {
+    const user = userEvent.setup();
+    renderContent();
+
+    const triggerBtn = screen.getByRole('button', { name: /Arbitro/i });
+    await user.click(triggerBtn);
+
+    // The dialog is now open — the form heading "Chiedi all'Arbitro" should be present
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /Chiedi all.Arbitro/i })).toBeInTheDocument();
+  });
+
+  it('dialog contains the player select with correct options', async () => {
+    const user = userEvent.setup();
+    renderContent();
+
+    await user.click(screen.getByRole('button', { name: /Arbitro/i }));
+
+    const select = screen.getByRole('combobox', { name: /Sollevata da/i });
+    expect(select).toBeInTheDocument();
+    // Players are rendered as options
+    expect(screen.getByRole('option', { name: 'Marco' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Anna' })).toBeInTheDocument();
+  });
+});
+
+describe('AgentDisputeTabContent — DisputeHistory', () => {
+  it('DisputeHistory renders toggle button when disputes exist', () => {
+    mockDisputes = [
+      {
+        id: 'd1',
+        description: 'Può giocare questa carta?',
+        verdict: 'No, non può.',
+        ruleReferences: ['Rule 5.3'],
+        raisedByPlayerName: 'Marco',
+        timestamp: '2026-06-30T10:00:00Z',
+      },
+    ];
+
+    renderContent();
+
+    expect(screen.getByRole('button', { name: /Verdetti precedenti \(1\)/i })).toBeInTheDocument();
+  });
+
+  it('expanding DisputeHistory shows the verdict for a dispute', async () => {
+    mockDisputes = [
+      {
+        id: 'd1',
+        description: 'Può giocare questa carta?',
+        verdict: 'No, non può.',
+        ruleReferences: ['Rule 5.3'],
+        raisedByPlayerName: 'Marco',
+        timestamp: '2026-06-30T10:00:00Z',
+      },
+    ];
+
+    const user = userEvent.setup();
+    renderContent();
+
+    const toggleBtn = screen.getByRole('button', { name: /Verdetti precedenti/i });
+    await user.click(toggleBtn);
+
+    // After expanding, the dispute description should appear
+    expect(screen.getByText(/Può giocare questa carta/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/features/session-live/__tests__/MobileBody.test.tsx
+++ b/apps/web/src/components/features/session-live/__tests__/MobileBody.test.tsx
@@ -34,6 +34,7 @@ const LABELS: MobileBodyLabels = {
   tabWidget: 'Widget',
   tabNotes: 'Note',
   tabPhotos: 'Foto',
+  tabAgent: 'Arbitro',
 };
 
 function renderBody(overrides: Partial<MobileBodyProps> = {}) {

--- a/apps/web/src/components/features/session-live/__tests__/MobileBottomSheetDrawer.test.tsx
+++ b/apps/web/src/components/features/session-live/__tests__/MobileBottomSheetDrawer.test.tsx
@@ -33,6 +33,7 @@ const LABELS: MobileBottomSheetDrawerLabels = {
   tabWidget: 'Widget',
   tabNotes: 'Note',
   tabPhotos: 'Foto',
+  tabAgent: 'Arbitro',
 };
 
 function renderDrawer(overrides: Partial<MobileBottomSheetDrawerProps> = {}) {
@@ -88,15 +89,16 @@ describe('MobileBottomSheetDrawer — render shape', () => {
 });
 
 describe('MobileBottomSheetDrawer — tab strip', () => {
-  it('tab strip has 5 buttons in order: Score, Turn, Widget, Notes, Photos', () => {
+  it('tab strip has 6 buttons in order: Score, Turn, Widget, Notes, Photos, Arbitro', () => {
     renderDrawer({ open: true });
     const tabs = screen.getAllByRole('tab');
-    expect(tabs).toHaveLength(5);
+    expect(tabs).toHaveLength(6);
     expect(tabs[0]).toHaveTextContent(LABELS.tabScore);
     expect(tabs[1]).toHaveTextContent(LABELS.tabTurn);
     expect(tabs[2]).toHaveTextContent(LABELS.tabWidget);
     expect(tabs[3]).toHaveTextContent(LABELS.tabNotes);
     expect(tabs[4]).toHaveTextContent(LABELS.tabPhotos);
+    expect(tabs[5]).toHaveTextContent(LABELS.tabAgent);
   });
 
   it('active tab has aria-selected="true" and others false', () => {
@@ -107,6 +109,7 @@ describe('MobileBottomSheetDrawer — tab strip', () => {
     expect(tabs[2]).toHaveAttribute('aria-selected', 'false');
     expect(tabs[3]).toHaveAttribute('aria-selected', 'false');
     expect(tabs[4]).toHaveAttribute('aria-selected', 'false');
+    expect(tabs[5]).toHaveAttribute('aria-selected', 'false');
   });
 
   it('clicking a tab calls onTabChange with the tab id', () => {

--- a/apps/web/src/components/features/session-live/__tests__/RightColumnTabs.test.tsx
+++ b/apps/web/src/components/features/session-live/__tests__/RightColumnTabs.test.tsx
@@ -32,6 +32,7 @@ const LABELS: RightColumnTabsLabels = {
   tabWidget: 'Widget',
   tabNotes: 'Note',
   tabPhotos: 'Foto',
+  tabAgent: 'Arbitro',
 };
 
 function renderTabs(overrides: Partial<RightColumnTabsProps> = {}) {
@@ -72,27 +73,28 @@ describe('RightColumnTabs — render shape', () => {
     expect(screen.getByRole('tablist', { name: 'Colonna destra' })).toBeInTheDocument();
   });
 
-  it('renders 5 tab buttons', () => {
+  it('renders 6 tab buttons', () => {
     renderTabs();
     const tabs = screen.getAllByRole('tab');
-    expect(tabs).toHaveLength(5);
+    expect(tabs).toHaveLength(6);
   });
 
-  it('renders tab labels (Score / Turni / Widget / Note / Foto)', () => {
+  it('renders tab labels (Score / Turni / Widget / Note / Foto / Arbitro)', () => {
     renderTabs();
     expect(screen.getByRole('tab', { name: 'Score' })).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: 'Turni' })).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: 'Widget' })).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: 'Note' })).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: 'Foto' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Arbitro' })).toBeInTheDocument();
   });
 
-  it('renders tab buttons in order: Score, Turn, Widget, Notes, Photos', () => {
+  it('renders tab buttons in order: Score, Turn, Widget, Notes, Photos, Agent', () => {
     renderTabs();
     const tablist = screen.getByRole('tablist');
     const tabs = within(tablist).getAllByRole('tab');
     const labels = tabs.map(t => t.textContent);
-    expect(labels).toEqual(['Score', 'Turni', 'Widget', 'Note', 'Foto']);
+    expect(labels).toEqual(['Score', 'Turni', 'Widget', 'Note', 'Foto', 'Arbitro']);
   });
 
   it('renders tabpanel with children', () => {
@@ -119,6 +121,7 @@ describe('RightColumnTabs — aria-selected + roving tabindex', () => {
     expect(screen.getByRole('tab', { name: 'Widget' })).toHaveAttribute('aria-selected', 'false');
     expect(screen.getByRole('tab', { name: 'Note' })).toHaveAttribute('aria-selected', 'false');
     expect(screen.getByRole('tab', { name: 'Foto' })).toHaveAttribute('aria-selected', 'false');
+    expect(screen.getByRole('tab', { name: 'Arbitro' })).toHaveAttribute('aria-selected', 'false');
   });
 
   it('active tab has tabIndex=0', () => {
@@ -132,6 +135,7 @@ describe('RightColumnTabs — aria-selected + roving tabindex', () => {
     expect(screen.getByRole('tab', { name: 'Widget' })).toHaveAttribute('tabindex', '-1');
     expect(screen.getByRole('tab', { name: 'Note' })).toHaveAttribute('tabindex', '-1');
     expect(screen.getByRole('tab', { name: 'Foto' })).toHaveAttribute('tabindex', '-1');
+    expect(screen.getByRole('tab', { name: 'Arbitro' })).toHaveAttribute('tabindex', '-1');
   });
 });
 
@@ -207,12 +211,23 @@ describe('RightColumnTabs — keyboard navigation', () => {
     expect(screen.getByRole('tab', { name: 'Foto' })).toHaveAttribute('aria-selected', 'true');
   });
 
-  it('ArrowRight wraps from photos → score', async () => {
+  it('ArrowRight advances from photos → agent', async () => {
     const user = userEvent.setup();
     render(<ControlledTabs initialTab="photos" />);
 
     const photosTab = screen.getByRole('tab', { name: 'Foto' });
     photosTab.focus();
+    await user.keyboard('{ArrowRight}');
+
+    expect(screen.getByRole('tab', { name: 'Arbitro' })).toHaveAttribute('aria-selected', 'true');
+  });
+
+  it('ArrowRight wraps from agent → score', async () => {
+    const user = userEvent.setup();
+    render(<ControlledTabs initialTab="agent" />);
+
+    const agentTab = screen.getByRole('tab', { name: 'Arbitro' });
+    agentTab.focus();
     await user.keyboard('{ArrowRight}');
 
     expect(screen.getByRole('tab', { name: 'Score' })).toHaveAttribute('aria-selected', 'true');
@@ -229,7 +244,7 @@ describe('RightColumnTabs — keyboard navigation', () => {
     expect(screen.getByRole('tab', { name: 'Score' })).toHaveAttribute('aria-selected', 'true');
   });
 
-  it('ArrowLeft wraps from score → photos', async () => {
+  it('ArrowLeft wraps from score → agent', async () => {
     const user = userEvent.setup();
     render(<ControlledTabs initialTab="score" />);
 
@@ -237,7 +252,7 @@ describe('RightColumnTabs — keyboard navigation', () => {
     scoreTab.focus();
     await user.keyboard('{ArrowLeft}');
 
-    expect(screen.getByRole('tab', { name: 'Foto' })).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByRole('tab', { name: 'Arbitro' })).toHaveAttribute('aria-selected', 'true');
   });
 
   it('Home jumps to first tab (score)', async () => {
@@ -251,7 +266,7 @@ describe('RightColumnTabs — keyboard navigation', () => {
     expect(screen.getByRole('tab', { name: 'Score' })).toHaveAttribute('aria-selected', 'true');
   });
 
-  it('End jumps to last tab (photos)', async () => {
+  it('End jumps to last tab (agent)', async () => {
     const user = userEvent.setup();
     render(<ControlledTabs initialTab="score" />);
 
@@ -259,6 +274,6 @@ describe('RightColumnTabs — keyboard navigation', () => {
     scoreTab.focus();
     await user.keyboard('{End}');
 
-    expect(screen.getByRole('tab', { name: 'Foto' })).toHaveAttribute('aria-selected', 'true');
+    expect(screen.getByRole('tab', { name: 'Arbitro' })).toHaveAttribute('aria-selected', 'true');
   });
 });

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -3209,6 +3209,7 @@
         "tabWidget": "Widget",
         "tabNotes": "Notes",
         "tabPhotos": "Photos",
+        "tabAgent": "Arbiter",
         "tabTools": "Tools",
         "tabChat": "Chat"
       },

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -3316,6 +3316,7 @@
         "tabWidget": "Widget",
         "tabNotes": "Note",
         "tabPhotos": "Foto",
+        "tabAgent": "Arbitro",
         "tabTools": "Strumenti",
         "tabChat": "Chat"
       },


### PR DESCRIPTION
## Cosa
Epic #2501 Fase 4 Slice A sub-slice **A4** (ultima feature): backport del **dispute system** (System A legacy) nel canonical session-live come tab **"Arbitro"**. Completa la parità feature col legacy `/agent` (foto A1+A2, image-attach A3, dispute A4).

## Implementazione (FE, riuso componenti + SignalR esistenti)
- Tab `'agent'` ("Arbitro"/"Arbiter") aggiunto a tutti gli 8 sync-point (mirror A1), desktop+mobile.
- `AgentDisputeTabContent` — monta `ArbitroModal` (apri-disputa → `/game-night/sessions/{id}/disputes` System A) + `DisputeHistory`, **riusati as-is**.
- **`useSignalRSession(sessionId)` montato once al top-level** di SessionLiveView (persistente cross-tab) → idrata `useLiveSessionStore.disputes` in real-time (verificato: il GUID reale arriva all'hook in prod; empty solo in visual-test).
- Player-prop mapping crash-safe (`displayName ?? name`, guard per fixture-shape).

## Review (opus, core-view + SignalR adversarial)
**READY_WITH_FOLLOWUPS, nessun Critical/Important**. ✅ SignalR-real-sessionId verificato (disputes idratano in prod, no double-connection/leak, hooks-compliant) · tab simmetrico desktop+mobile · ArbitroModal/DisputeHistory as-is · no-regressione (puramente additivo) · test non-vacui (no false-green). 117/117 SessionLiveView + 249/249 components (12 nuovi), typecheck clean.

## Limitazioni documentate (follow-up #2618)
- **M1** (priority): no idratazione REST su mount — disputes vuote al reload fino a nuovo evento SignalR (serve GET `/live-sessions/{id}/disputes` + hydration on-mount).
- **M2**: dual-transport (disputes via SignalR, resto via SSE) — unificazione = forward dispute-event su SSE (BE).
- System B (vote lifecycle canonical) = enhancement futura separata, NON un backport.

## Scope / out
**A-final** (ora sbloccata): repoint 9 entry-point legacy → `/sessions/[id]/live` + delete `/sessions/live/[sessionId]` tree (parità A1-A4 raggiunta).

🤖 Generated with [Claude Code](https://claude.com/claude-code)