### PR TITLE
feat(gamebook): #2619 DELETE glossary entry endpoint

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/DeleteGlossaryEntryCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/DeleteGlossaryEntryCommand.cs
@@ -1,0 +1,15 @@
+using MediatR;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Commands;
+
+/// <summary>
+/// Deletes a single gamebook glossary entry. Complements the upsert flow: the PUT
+/// endpoint keeps <c>TermEn</c> immutable, so renaming a term is done by deleting the
+/// old entry and recreating it. Hard delete — <see cref="Domain.Entities.GamebookGlossaryEntry"/>
+/// has no soft-delete state (glossary rows are per-campaign, low-value, and regenerable
+/// via bootstrap).
+/// </summary>
+public sealed record DeleteGlossaryEntryCommand(
+    Guid CampaignId,
+    Guid EntryId,
+    Guid CallerUserId) : IRequest<Unit>;

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/DeleteGlossaryEntryCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/DeleteGlossaryEntryCommandHandler.cs
@@ -1,0 +1,46 @@
+using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using MediatR;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Commands;
+
+internal sealed class DeleteGlossaryEntryCommandHandler
+    : IRequestHandler<DeleteGlossaryEntryCommand, Unit>
+{
+    private readonly IGamebookCampaignSessionRepository _campaigns;
+    private readonly IGamebookGlossaryRepository _glossary;
+
+    public DeleteGlossaryEntryCommandHandler(
+        IGamebookCampaignSessionRepository campaigns,
+        IGamebookGlossaryRepository glossary)
+    {
+        _campaigns = campaigns ?? throw new ArgumentNullException(nameof(campaigns));
+        _glossary = glossary ?? throw new ArgumentNullException(nameof(glossary));
+    }
+
+    public async Task<Unit> Handle(DeleteGlossaryEntryCommand cmd, CancellationToken cancellationToken)
+    {
+        var campaign = await _campaigns.GetByIdAsync(cmd.CampaignId, cancellationToken).ConfigureAwait(false)
+            ?? throw new NotFoundException($"Campaign {cmd.CampaignId} not found");
+
+        if (campaign.OwnerUserId != cmd.CallerUserId)
+        {
+            throw new ForbiddenException("Forbidden");
+        }
+
+        var entry = await _glossary.GetByIdAsync(cmd.EntryId, cancellationToken).ConfigureAwait(false)
+            ?? throw new NotFoundException($"Glossary entry {cmd.EntryId} not found");
+
+        // An entry belonging to a different campaign is treated as not-found for this
+        // campaign (avoids leaking existence across campaigns; the caller only owns this one).
+        if (entry.CampaignId != cmd.CampaignId)
+        {
+            throw new NotFoundException($"Glossary entry {cmd.EntryId} not found");
+        }
+
+        _glossary.Remove(entry);
+        await _glossary.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        return Unit.Value;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/DeleteGlossaryEntryCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/DeleteGlossaryEntryCommandValidator.cs
@@ -1,0 +1,13 @@
+using FluentValidation;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Commands;
+
+internal sealed class DeleteGlossaryEntryCommandValidator : AbstractValidator<DeleteGlossaryEntryCommand>
+{
+    public DeleteGlossaryEntryCommandValidator()
+    {
+        RuleFor(x => x.CampaignId).NotEqual(Guid.Empty);
+        RuleFor(x => x.EntryId).NotEqual(Guid.Empty);
+        RuleFor(x => x.CallerUserId).NotEqual(Guid.Empty);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Repositories/IGamebookGlossaryRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Repositories/IGamebookGlossaryRepository.cs
@@ -18,5 +18,9 @@ public interface IGamebookGlossaryRepository
     Task<GamebookGlossaryEntry?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
     Task AddRangeAsync(IEnumerable<GamebookGlossaryEntry> entries, CancellationToken cancellationToken = default);
     Task AddAsync(GamebookGlossaryEntry entry, CancellationToken cancellationToken = default);
+
+    /// <summary>Marks a glossary entry for hard deletion (flushed on the next SaveChanges).</summary>
+    void Remove(GamebookGlossaryEntry entry);
+
     Task SaveChangesAsync(CancellationToken cancellationToken = default);
 }

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Persistence/GamebookGlossaryRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Persistence/GamebookGlossaryRepository.cs
@@ -49,6 +49,9 @@ internal sealed class GamebookGlossaryRepository : IGamebookGlossaryRepository
     public Task AddAsync(GamebookGlossaryEntry entry, CancellationToken cancellationToken = default)
         => _db.GamebookGlossaryEntries.AddAsync(entry, cancellationToken).AsTask();
 
+    public void Remove(GamebookGlossaryEntry entry)
+        => _db.GamebookGlossaryEntries.Remove(entry);
+
     public Task SaveChangesAsync(CancellationToken cancellationToken = default)
         => _db.SaveChangesAsync(cancellationToken);
 }

--- a/apps/api/src/Api/Routing/GamebookPhotoEndpoints.cs
+++ b/apps/api/src/Api/Routing/GamebookPhotoEndpoints.cs
@@ -33,6 +33,7 @@ internal static class GamebookPhotoEndpoints
         MapGetGlossaryEndpoint(group);
         MapBootstrapGlossaryEndpoint(group);
         MapUpsertGlossaryEntryEndpoint(group);
+        MapDeleteGlossaryEntryEndpoint(group);
         MapEncounterParseEndpoint(group);
 
         return group;
@@ -503,6 +504,36 @@ internal static class GamebookPhotoEndpoints
         .WithTags("Gamebook")
         .WithSummary("Create or update a glossary entry")
         .WithDescription("If the entry with the given id does not exist, creates a new manual entry. If it exists, updates the Italian translation and sets Source to Manual. Note: TermEn is immutable on update; to rename a term, delete and recreate.")
+        .WithOpenApi();
+    }
+
+    private static void MapDeleteGlossaryEntryEndpoint(RouteGroupBuilder group)
+    {
+        group.MapDelete("/gamebook/campaigns/{campaignId:guid}/glossary/{entryId:guid}", async (
+            Guid campaignId,
+            Guid entryId,
+            IMediator mediator,
+            HttpContext context,
+            CancellationToken ct) =>
+        {
+            var (authenticated, session, error) = context.TryGetAuthenticatedUser();
+            if (!authenticated) return error!;
+            if (!TryGetUserId(context, session, out var userId)) return Results.Unauthorized();
+
+            await mediator.Send(
+                new DeleteGlossaryEntryCommand(campaignId, entryId, userId), ct).ConfigureAwait(false);
+
+            return Results.NoContent();
+        })
+        .RequireAuthenticatedUser()
+        .Produces(StatusCodes.Status204NoContent)
+        .Produces(StatusCodes.Status400BadRequest)
+        .Produces(StatusCodes.Status401Unauthorized)
+        .Produces(StatusCodes.Status403Forbidden)
+        .Produces(StatusCodes.Status404NotFound)
+        .WithTags("Gamebook")
+        .WithSummary("Delete a glossary entry")
+        .WithDescription("Hard-deletes a glossary entry from the campaign. Returns 403 if the caller does not own the campaign, 404 if the campaign or entry does not exist (or the entry belongs to another campaign). Enables removing a term or — combined with recreate — renaming one (TermEn is immutable on update).")
         .WithOpenApi();
     }
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Commands/DeleteGlossaryEntryCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Commands/DeleteGlossaryEntryCommandHandlerTests.cs
@@ -1,0 +1,119 @@
+using Api.BoundedContexts.SessionTracking.Application.Commands;
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+using Api.BoundedContexts.SessionTracking.Domain.Enums;
+using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Domain.ValueObjects;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SessionTracking.Application.Commands;
+
+[Trait("Category", TestCategories.Unit)]
+public class DeleteGlossaryEntryCommandHandlerTests
+{
+    private static GamebookCampaignSession Campaign(Guid ownerId)
+        => GamebookCampaignSession.Create(GameRef.Shared(Guid.NewGuid()), ownerId, "My Campaign");
+
+    private static GamebookGlossaryEntry Entry(Guid campaignId, Guid createdBy)
+        => GamebookGlossaryEntry.Create(campaignId, "sentinel", "sentinella", GlossarySource.Manual, createdBy);
+
+    [Fact]
+    public async Task Handle_ByOwner_RemovesEntryAndSaves()
+    {
+        var ownerId = Guid.NewGuid();
+        var campaign = Campaign(ownerId);
+        var entry = Entry(campaign.Id, ownerId);
+
+        var campaigns = new Mock<IGamebookCampaignSessionRepository>();
+        campaigns.Setup(r => r.GetByIdAsync(campaign.Id, It.IsAny<CancellationToken>())).ReturnsAsync(campaign);
+        var glossary = new Mock<IGamebookGlossaryRepository>();
+        glossary.Setup(r => r.GetByIdAsync(entry.Id, It.IsAny<CancellationToken>())).ReturnsAsync(entry);
+        var handler = new DeleteGlossaryEntryCommandHandler(campaigns.Object, glossary.Object);
+
+        await handler.Handle(
+            new DeleteGlossaryEntryCommand(campaign.Id, entry.Id, ownerId),
+            TestContext.Current.CancellationToken);
+
+        glossary.Verify(r => r.Remove(entry), Times.Once);
+        glossary.Verify(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ByNonOwner_ThrowsForbiddenAndDoesNotRemove()
+    {
+        var ownerId = Guid.NewGuid();
+        var otherUserId = Guid.NewGuid();
+        var campaign = Campaign(ownerId);
+
+        var campaigns = new Mock<IGamebookCampaignSessionRepository>();
+        campaigns.Setup(r => r.GetByIdAsync(campaign.Id, It.IsAny<CancellationToken>())).ReturnsAsync(campaign);
+        var glossary = new Mock<IGamebookGlossaryRepository>();
+        var handler = new DeleteGlossaryEntryCommandHandler(campaigns.Object, glossary.Object);
+
+        var act = () => handler.Handle(
+            new DeleteGlossaryEntryCommand(campaign.Id, Guid.NewGuid(), otherUserId),
+            TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<ForbiddenException>();
+        glossary.Verify(r => r.Remove(It.IsAny<GamebookGlossaryEntry>()), Times.Never);
+        glossary.Verify(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_CampaignNotFound_ThrowsNotFound()
+    {
+        var campaigns = new Mock<IGamebookCampaignSessionRepository>();
+        campaigns.Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((GamebookCampaignSession?)null);
+        var glossary = new Mock<IGamebookGlossaryRepository>();
+        var handler = new DeleteGlossaryEntryCommandHandler(campaigns.Object, glossary.Object);
+
+        var act = () => handler.Handle(
+            new DeleteGlossaryEntryCommand(Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid()),
+            TestContext.Current.CancellationToken);
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+
+    [Fact]
+    public async Task Handle_EntryNotFound_ThrowsNotFoundAndDoesNotRemove()
+    {
+        var ownerId = Guid.NewGuid();
+        var campaign = Campaign(ownerId);
+
+        var campaigns = new Mock<IGamebookCampaignSessionRepository>();
+        campaigns.Setup(r => r.GetByIdAsync(campaign.Id, It.IsAny<CancellationToken>())).ReturnsAsync(campaign);
+        var glossary = new Mock<IGamebookGlossaryRepository>();
+        glossary.Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((GamebookGlossaryEntry?)null);
+        var handler = new DeleteGlossaryEntryCommandHandler(campaigns.Object, glossary.Object);
+
+        var act = () => handler.Handle(
+            new DeleteGlossaryEntryCommand(campaign.Id, Guid.NewGuid(), ownerId),
+            TestContext.Current.CancellationToken);
+        await act.Should().ThrowAsync<NotFoundException>();
+        glossary.Verify(r => r.Remove(It.IsAny<GamebookGlossaryEntry>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_EntryFromAnotherCampaign_ThrowsNotFoundAndDoesNotRemove()
+    {
+        var ownerId = Guid.NewGuid();
+        var campaign = Campaign(ownerId);
+        var foreignEntry = Entry(Guid.NewGuid(), ownerId); // belongs to a different campaign
+
+        var campaigns = new Mock<IGamebookCampaignSessionRepository>();
+        campaigns.Setup(r => r.GetByIdAsync(campaign.Id, It.IsAny<CancellationToken>())).ReturnsAsync(campaign);
+        var glossary = new Mock<IGamebookGlossaryRepository>();
+        glossary.Setup(r => r.GetByIdAsync(foreignEntry.Id, It.IsAny<CancellationToken>())).ReturnsAsync(foreignEntry);
+        var handler = new DeleteGlossaryEntryCommandHandler(campaigns.Object, glossary.Object);
+
+        var act = () => handler.Handle(
+            new DeleteGlossaryEntryCommand(campaign.Id, foreignEntry.Id, ownerId),
+            TestContext.Current.CancellationToken);
+        await act.Should().ThrowAsync<NotFoundException>();
+        glossary.Verify(r => r.Remove(It.IsAny<GamebookGlossaryEntry>()), Times.Never);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Queries/TranslateGamebookSegmentQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Queries/TranslateGamebookSegmentQueryHandlerTests.cs
@@ -122,6 +122,7 @@ public sealed class TranslateGamebookSegmentQueryHandlerTests
         { Store.AddRange(entries); return Task.CompletedTask; }
 
         public Task AddAsync(GamebookGlossaryEntry entry, CancellationToken cancellationToken = default) { Store.Add(entry); return Task.CompletedTask; }
+        public void Remove(GamebookGlossaryEntry entry) => Store.Remove(entry);
         public Task SaveChangesAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
     }
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Queries/TranslateGamebookTextQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Queries/TranslateGamebookTextQueryHandlerTests.cs
@@ -61,6 +61,8 @@ public sealed class TranslateGamebookTextQueryHandlerTests
         public Task AddAsync(GamebookGlossaryEntry entry, CancellationToken cancellationToken = default)
         { Store.Add(entry); return Task.CompletedTask; }
 
+        public void Remove(GamebookGlossaryEntry entry) => Store.Remove(entry);
+
         public Task SaveChangesAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
     }
 


### PR DESCRIPTION
## Summary
Adds the missing glossary-CRUD verb: `DELETE /api/v1/gamebook/campaigns/{campaignId}/glossary/{entryId}` (gap report p.11). The PUT endpoint keeps `TermEn` immutable and its own description says *"to rename a term, delete and recreate"* — but no delete existed. This unblocks term removal + rename in the glossary editor.

## Changes
- `DeleteGlossaryEntryCommand` + `Validator` + `Handler` (mirrors `UpsertGlossaryEntryCommandHandler`).
- **Ownership guard by design** (lesson from #2624 IDOR): `campaign.OwnerUserId != CallerUserId` → `ForbiddenException` (403). Entry from another campaign → 404 (no cross-campaign existence leak).
- `IGamebookGlossaryRepository.Remove` + EF impl (hard delete — `GamebookGlossaryEntry` has no soft-delete state, is per-campaign and regenerable via bootstrap; no inbound FK, confirmed in review).
- Endpoint mirrors the PUT auth/`Produces` contract (204/400/401/403/404).

## Tests
5 handler unit tests (owner-removes, non-owner-403, campaign-404, entry-404, entry-other-campaign-404) — **5/5 green**. Updated 2 `FakeGlossaryRepo` test doubles for the new interface member.

## Review
`feature-dev:code-reviewer` — 0 blocking issues. 1 minor (missing `.Produces(400)`) fixed in follow-up commit; 1 important finding self-resolved (ownership order matches existing sibling pattern, guard sufficient).

Refs #2619

🤖 Generated with [Claude Code](https://claude.com/claude-code)