### PR TITLE
fix(gamebook): #2619 order resume-picker by last-played, not UpdatedAt

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/ListMyGamebookCampaignsHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/ListMyGamebookCampaignsHandler.cs
@@ -41,6 +41,16 @@ public class ListMyGamebookCampaignsHandler : IRequestHandler<ListMyGamebookCamp
             dtos.Add(CreateGamebookCampaignHandler.MapToDto(session, progress));
         }
 
-        return dtos;
+        // Resume-picker recency (#2619, gap report p.10): order by the genuine
+        // "last played" signal — LastReadAt (= SessionBookProgress.LastVisitedAt,
+        // falling back to UpdatedAt for never-played campaigns) — NOT the repo's
+        // UpdatedAt ordering, which is dirtied by rename/glossary edits (a campaign
+        // you just renamed but did not play must NOT jump to the resume hero slot).
+        // In-memory sort is fine for bounded per-user campaign counts (~5-10; see the
+        // N+1 PERF note above). CreatedAt is the deterministic tiebreak.
+        return dtos
+            .OrderByDescending(d => d.LastReadAt)
+            .ThenByDescending(d => d.CreatedAt)
+            .ToList();
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Queries/ListMyGamebookCampaignsHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Queries/ListMyGamebookCampaignsHandlerTests.cs
@@ -113,6 +113,48 @@ public sealed class ListMyGamebookCampaignsHandlerTests
     }
 
     [Fact]
+    public async Task Handle_OrdersByLastPlayed_NotByUpdatedAt()
+    {
+        // Arrange: two campaigns for the same user.
+        //   X — played long ago, then RENAMED just now (UpdatedAt is the newest).
+        //   Y — played most recently, never renamed (UpdatedAt is older than X's).
+        // The repo fake preserves insertion order [X, Y]; the resume-picker must
+        // return Y first because it was *played* most recently — the rename on X
+        // must NOT promote it to the resume hero slot (#2619).
+        var campaigns = new FakeCampaignRepo();
+        var progress = new FakeProgressRepo();
+        var handler = new ListMyGamebookCampaignsHandler(campaigns, progress);
+        var userId = Guid.NewGuid();
+
+        var x = GamebookCampaignSession.Create(GameRef.Shared(Guid.NewGuid()), userId, "X");
+        var y = GamebookCampaignSession.Create(GameRef.Shared(Guid.NewGuid()), userId, "Y");
+        campaigns.Store.Add(x);
+        campaigns.Store.Add(y);
+
+        // X played first (older LastVisitedAt), Y played after (newer LastVisitedAt).
+        var xProgress = SessionBookProgress.Create(x.Id, Guid.NewGuid(), "§10");
+        progress.Store.Add(xProgress);
+        await Task.Delay(10, TestContext.Current.CancellationToken);
+        var yProgress = SessionBookProgress.Create(y.Id, Guid.NewGuid(), "§20");
+        progress.Store.Add(yProgress);
+
+        // X renamed last → its UpdatedAt is now the newest of the two.
+        await Task.Delay(10, TestContext.Current.CancellationToken);
+        x.Rename("X renamed", userId);
+        x.UpdatedAt.Should().BeAfter(y.UpdatedAt, "the test premise is that X has the newer UpdatedAt");
+
+        var query = new ListMyGamebookCampaignsQuery(userId, GameId: null);
+
+        // Act
+        var result = await handler.Handle(query, TestContext.Current.CancellationToken);
+
+        // Assert: ordered by last-played (Y first), NOT by UpdatedAt (which would put X first).
+        result.Should().HaveCount(2);
+        result[0].Id.Should().Be(y.Id);
+        result[1].Id.Should().Be(x.Id);
+    }
+
+    [Fact]
     public async Task Handle_CampaignWithoutProgress_ReturnsZeroCurrentParagraph()
     {
         // Arrange


### PR DESCRIPTION
## Summary
The gamebook campaign list drives the **resume-picker** order (the FE reads the BE order verbatim; `ResumeHero` = first item, `MultiCampaignList` renders in sequence). The repo ordered by `UpdatedAt DESC`, dirtied by rename/glossary edits — renaming a campaign you have not played wrongly promoted it to the resume-hero slot.

**Fix:** order the mapped DTOs by `LastReadAt DESC` (= `SessionBookProgress.LastVisitedAt`, the genuine last-played signal; `UpdatedAt` fallback for never-played), `CreatedAt` tiebreak. In-memory sort — fine for bounded per-user counts (~5-10, per the existing N+1 PERF note).

## Scope note on quick-win #3
The gap item asked for a `LastPlayedAt` column (+ migration). That signal already exists end-to-end: `SessionBookProgress.LastVisitedAt` -> `GamebookCampaignDto.LastReadAt`. A denormalized column duplicates it (DRY/YAGNI) — this ships the actual value (recency ordering) with zero schema change. The other half (`Status` / completed-filter) is the session-end 3-way close (Complete/Abandon/Save), flagged architetturale + product-decision (HIGH #8, integration plan) — intentionally deferred.

## Tests
New decisive unit test `Handle_OrdersByLastPlayed_NotByUpdatedAt`. 4/4 handler tests green, 0 regression.

Refs #2619

🤖 Generated with [Claude Code](https://claude.com/claude-code)