### PR TITLE
fix(session-live): #2608 restrict live-session start to creator

### DIFF
--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/LiveSessions/LifecycleCommandHandlers.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/LiveSessions/LifecycleCommandHandlers.cs
@@ -47,6 +47,15 @@ internal class StartLiveSessionCommandHandler : ICommandHandler<StartLiveSession
             .ConfigureAwait(false)
             ?? throw new NotFoundException("LiveGameSession", command.SessionId.ToString());
 
+        // Issue #2608: Only the session creator may start a GameId-backed session.
+        // The correlated GameSession is attributed to CreatedByUserId and the quota is checked
+        // against that user — allowing any participant to start would decouple the quota gate
+        // from the quota owner (non-creator starts → B's quota gates but A's slot is consumed).
+        // .RequireLiveSessionParticipant() on the endpoint remains as defense-in-depth (rejects
+        // non-participants before this point); this guard adds the creator-only business rule.
+        if (command.UserId != session.CreatedByUserId)
+            throw new ForbiddenException("Only the session creator can start the session.");
+
         // Issue #2587 Slice 1: Create correlated GameSession on first start of a GameId-backed session.
         // Idempotent: CorrelatedGameSessionId != null means correlation already done (re-start guard).
         if (session.GameId.HasValue && session.CorrelatedGameSessionId == null)
@@ -62,6 +71,11 @@ internal class StartLiveSessionCommandHandler : ICommandHandler<StartLiveSession
                 .Where(p => p.IsActive)
                 .Select((p, i) => new SessionPlayer(p.DisplayName, i + 1))
                 .ToList();
+
+            // Issue #2608: Guard against starting with zero active players so the caller
+            // receives a clear, intentional error rather than a generic GameSession ctor failure.
+            if (players.Count == 0)
+                throw new ValidationException("Cannot start a session with no active players.");
 
             var gameSession = new GameSession(
                 id: Guid.NewGuid(),

--- a/apps/api/src/Api/Routing/LiveSessionEndpoints.cs
+++ b/apps/api/src/Api/Routing/LiveSessionEndpoints.cs
@@ -47,11 +47,13 @@ internal static class LiveSessionEndpoints
             .RequireAuthenticatedUser()
             .RequireLiveSessionParticipant()
             .Produces(204)
+            .Produces(400)  // QuotaExceededException (DomainException → 400 via middleware) or zero active players
+            .Produces(403)  // Non-creator caller (#2608: only the creator may start; maps to ForbiddenException → 403)
             .Produces(404)
-            .Produces(409)
+            .Produces(409)  // DbUpdateConcurrencyException (xmin race — concurrent start)
             .WithTags("LiveSessions")
             .WithSummary("Start a live session")
-            .WithDescription("Transitions session from Created/Setup to InProgress.");
+            .WithDescription("Transitions session from Created/Setup to InProgress. Only the session creator may start (403). Quota limit returns 400. Concurrent start race returns 409.");
 
         group.MapPost("/live-sessions/{sessionId}/pause", HandlePauseSession)
             .RequireAuthenticatedUser()

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/LiveSessions/LiveSessionCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/LiveSessions/LiveSessionCommandHandlerTests.cs
@@ -329,13 +329,13 @@ public class LiveSessionCommandHandlerTests
         _quotaServiceMock.Verify(
             q => q.CheckQuotaAsync(It.IsAny<Guid>(), It.IsAny<UserTier>(), It.IsAny<Role>(), It.IsAny<CancellationToken>()),
             Times.Never,
-            because: "the creator guard fires before the quota block");
+            "the creator guard fires before the quota block");
 
         // No GameSession must have been created
         _gameSessionRepositoryMock.Verify(
             r => r.AddAsync(It.IsAny<GameSession>(), It.IsAny<CancellationToken>()),
             Times.Never,
-            because: "the creator guard fires before any GameSession correlation");
+            "the creator guard fires before any GameSession correlation");
 
         // Session must NOT have been started
         session.Status.Should().NotBe(LiveSessionStatus.InProgress);
@@ -876,10 +876,13 @@ public class LiveSessionCommandHandlerTests
 
         var session = LiveGameSession.Create(sessionId, DefaultUserId, "Catan", gameId: gameId);
 
-        // Add two players: one will be removed (deactivated), one stays active
-        var removedPlayer = session.AddPlayer(null, "Removed Player", PlayerColor.Red, TimeProvider.System);
+        // Add the host first (stays active), then a guest player that will be removed.
+        // The first player added becomes Host (AddPlayer: !HasPlayers => Host). Removing the
+        // host while other players are active is blocked by a domain guard, so the removed
+        // player must be a non-host guest (added second).
         session.AddPlayer(null, "Active Player", PlayerColor.Blue, TimeProvider.System);
-        // Simulate RemovePlayer which deactivates the player
+        var removedPlayer = session.AddPlayer(null, "Removed Player", PlayerColor.Red, TimeProvider.System);
+        // Simulate RemovePlayer which deactivates the (non-host) player
         session.RemovePlayer(removedPlayer.Id, TimeProvider.System);
 
         SetupRepoGetById(sessionId, session);

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/LiveSessions/LiveSessionCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/LiveSessions/LiveSessionCommandHandlerTests.cs
@@ -297,6 +297,89 @@ public class LiveSessionCommandHandlerTests
         await act.Should().ThrowAsync<ArgumentNullException>();
     }
 
+    // ─── Issue #2608: Creator-only guard ──────────────────────────────────────────
+
+    [Fact(DisplayName = "#2608: Non-creator caller → ForbiddenException, no quota check, no GameSession created, no start")]
+    public async Task StartLiveSession_NonCreatorCaller_ThrowsForbiddenException_BeforeQuotaOrGameSession()
+    {
+        // Arrange
+        var sessionId = Guid.NewGuid();
+        var creatorId = Guid.NewGuid();
+        var nonCreatorId = Guid.NewGuid(); // different from creatorId
+
+        var session = LiveGameSession.Create(sessionId, creatorId, "Catan", gameId: Guid.NewGuid());
+        session.AddPlayer(null, "Creator Player", PlayerColor.Red, TimeProvider.System);
+        SetupRepoGetById(sessionId, session);
+
+        var handler = new StartLiveSessionCommandHandler(
+            _repositoryMock.Object,
+            _gameSessionRepositoryMock.Object,
+            _quotaServiceMock.Object,
+            _timeProvider,
+            _unitOfWorkMock.Object);
+
+        // Command issued by nonCreatorId (participant but not creator)
+        var command = new StartLiveSessionCommand(sessionId, nonCreatorId, DefaultUserTier, DefaultUserRole);
+
+        // Act & Assert — must throw before reaching quota or GameSession creation
+        var act = () => handler.Handle(command, TestContext.Current.CancellationToken);
+        await act.Should().ThrowAsync<ForbiddenException>();
+
+        // Quota service must NOT have been consulted
+        _quotaServiceMock.Verify(
+            q => q.CheckQuotaAsync(It.IsAny<Guid>(), It.IsAny<UserTier>(), It.IsAny<Role>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            because: "the creator guard fires before the quota block");
+
+        // No GameSession must have been created
+        _gameSessionRepositoryMock.Verify(
+            r => r.AddAsync(It.IsAny<GameSession>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            because: "the creator guard fires before any GameSession correlation");
+
+        // Session must NOT have been started
+        session.Status.Should().NotBe(LiveSessionStatus.InProgress);
+
+        // Repository UpdateAsync must NOT have been called
+        _repositoryMock.Verify(
+            r => r.UpdateAsync(It.IsAny<LiveGameSession>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact(DisplayName = "#2608: Zero active players (GameId-backed) → ValidationException before GameSession ctor")]
+    public async Task StartLiveSession_ZeroActivePlayers_GameIdBacked_ThrowsValidationException()
+    {
+        // Arrange
+        var sessionId = Guid.NewGuid();
+        var gameId = Guid.NewGuid();
+
+        // Session created by DefaultUserId with a GameId but all players removed
+        var session = LiveGameSession.Create(sessionId, DefaultUserId, "Catan", gameId: gameId);
+        var p1 = session.AddPlayer(null, "Player One", PlayerColor.Red, TimeProvider.System);
+        session.RemovePlayer(p1.Id, TimeProvider.System); // deactivates the only player
+        SetupRepoGetById(sessionId, session);
+
+        var handler = new StartLiveSessionCommandHandler(
+            _repositoryMock.Object,
+            _gameSessionRepositoryMock.Object,
+            _quotaServiceMock.Object,
+            _timeProvider,
+            _unitOfWorkMock.Object);
+
+        // Creator starts — passes creator guard, hits zero-players guard
+        var command = new StartLiveSessionCommand(sessionId, DefaultUserId, DefaultUserTier, DefaultUserRole);
+
+        // Act & Assert
+        var act = () => handler.Handle(command, TestContext.Current.CancellationToken);
+        await act.Should().ThrowAsync<ValidationException>(
+            because: "starting with zero active players is an intentional validation error (400), not a generic ctor failure");
+
+        // No GameSession must have been created
+        _gameSessionRepositoryMock.Verify(
+            r => r.AddAsync(It.IsAny<GameSession>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
     #endregion
 
     // =============================================================================


### PR DESCRIPTION
## #2608 — Quota attribution edge (non-creator start)

Da review finale di #2587-A Slice 1. `POST /live-sessions/{id}/start` (filtro participant) permetteva a **qualsiasi partecipante** di avviare: la quota era verificata sul chiamante ma la `GameSession` correlata è attribuita al `CreatedByUserId` (il creator) → quando un non-creator avviava la sessione del creator A, la quota di B gatava ma lo slot di A veniva consumato.

### Fix (decisione owner: Opzione 1 — restrict-to-creator)
- **Creator guard** in `StartLiveSessionCommandHandler`: `command.UserId != session.CreatedByUserId → ForbiddenException` (403), prima del blocco quota/correlazione. Ora caller == creator sempre → quota + attribuzione coerenti.
- `.RequireLiveSessionParticipant()` **mantenuto** sull'endpoint (defense in depth).

### Minor (stessa review)
- **Doc drift 400/409**: `QuotaExceededException` mappa a **400** (DomainException→400, condivisa con PDF/BGG → non toccata). L'endpoint dichiarava `409` senza contesto; ora esplicita `.Produces(400)` (quota/zero-player), `.Produces(403)` (creator), e `409` re-annotato come `DbUpdateConcurrencyException` (race xmin, il vero 409).
- **Zero active players**: guard esplicito (`ValidationException` → 400) prima del ctor GameSession, invece di un 400 generico.

### Review fixes (in-PR, secondo commit)
- I nuovi test usavano Moq `Verify(…, because:)` — Moq prende `failMessage` posizionale (`because:` è FluentAssertions) → **CS1739 compile error** che impediva la build del test project. Corretto.
- **#2587-T3-partB** era **rosso pre-esistente** su main-dev (Slice 1 #2609 admin-merge senza CI): il setup rimuoveva l'host (primo player aggiunto) con altri player attivi → host-guard `ConflictException`. Riordinato (removed = guest non-host). Ora **71/71** pass.

### Verifica
`dotnet build` exit 0 · `LiveSessionCommandHandlerTests` **71/71** pass · `QuotaExceededException` + middleware **untouched** · filtro participant mantenuto.

Ref: #2587 · epic #2501.

🤖 Generated with [Claude Code](https://claude.com/claude-code)