### PR TITLE
fix(libro-game): #2636 lock canonical Eldoria identity across SP6 mockups (SI-5)

### DIFF
--- a/admin-mockups/design_files/librogame-game-night-storyboard.html
+++ b/admin-mockups/design_files/librogame-game-night-storyboard.html
@@ -9,7 +9,7 @@
   Scope: timeline narrativa end-to-end di una game night Eldoria.
          Single-file storyboard che embedda gli iframe dei 10 mockup librogame-runthrough-*
          organizzati in 3 fasi (T-30 preparazione, T0 sessione attiva, T+post save/resume).
-         Use case: agente Tutor per regole, traduzione paragrafi (storybook + encounter
+         Use case: agente Arbitro Eldoria per regole, traduzione paragrafi (storybook + encounter
          book), gestione glossary, quota tier free.
   Persona: Aaron (badsworm@gmail.com), gruppo A (Marco/Giulia/Luca), Eldoria libro game.
   Goal:    validazione visuale del flusso completo prima dell'implementazione FE.
@@ -223,12 +223,12 @@
 <header class="hero">
   <span class="kicker">📖 Storyboard end-to-end</span>
   <h1>Game Night Eldoria</h1>
-  <p class="sub">Aaron + gruppo A (Marco · Giulia · Luca) giocano una sera Eldoria — libro game inglese — con l'assistente AI Tutor per regole, tutorial, traduzione paragrafi e gestione del libro game.</p>
+  <p class="sub">Aaron + gruppo A (Marco · Giulia · Luca) giocano una sera Eldoria — libro game inglese — con l'assistente AI Arbitro Eldoria per regole, tutorial, traduzione paragrafi e gestione del libro game.</p>
   <div class="meta">
     <span class="item">👤 Aaron · badsworm@gmail.com</span>
     <span class="item">🎲 Eldoria · Side Room 2024</span>
     <span class="item">📅 Sera tipo · 20:30 → 01:00</span>
-    <span class="item">🤖 Game Tutor · DeepSeek IT</span>
+    <span class="item">🤖 Arbitro Eldoria · DeepSeek IT</span>
     <span class="item">📄 KB 142 pag indicizzate</span>
   </div>
 </header>
@@ -237,7 +237,7 @@
   <span class="it"><span class="d kb"></span>kb (pagine)</span>
   <span class="it"><span class="d chat"></span>chat (Q&A)</span>
   <span class="it"><span class="d session"></span>session</span>
-  <span class="it"><span class="d agent"></span>agent (Tutor)</span>
+  <span class="it"><span class="d agent"></span>agent (Arbitro Eldoria)</span>
   <span class="it"><span class="d player"></span>player</span>
   <span class="it"><span class="d event"></span>event (encounter)</span>
   <span class="it"><span class="d toolkit"></span>toolkit (glossario)</span>
@@ -251,7 +251,7 @@
     <span class="time">T−30 · 20:30</span>
     <h2 id="ph1">Fase 1 · Preparazione pre-sera</h2>
   </div>
-  <p class="ph-desc">30 minuti prima dell'arrivo del gruppo, Aaron apre l'app sul telefono, trova Eldoria in libreria, crea la campagna e fa qualche domanda di setup all'agente Tutor.</p>
+  <p class="ph-desc">30 minuti prima dell'arrivo del gruppo, Aaron apre l'app sul telefono, trova Eldoria in libreria, crea la campagna e fa qualche domanda di setup all'agente Arbitro Eldoria.</p>
   <div class="jtbd"><strong>🔨 JTBD J1 · Rules tutor</strong> — "Voglio essere pronto a guidare il setup senza leggere 24 pagine di Press Start in inglese."</div>
 
   <div class="steps">
@@ -410,7 +410,7 @@
         <div class="info">
           <div class="ts">20:42</div>
           <h3>Setup chat · "come si fa il setup per 4 giocatori?"</h3>
-          <p class="desc">Aaron query Tutor IT. Risposta 5-step + citation <strong>Press Start p.3-7</strong>. Confidence alta, &lt;8s.</p>
+          <p class="desc">Aaron query Arbitro Eldoria IT. Risposta 5-step + citation <strong>Press Start p.3-7</strong>. Confidence alta, &lt;8s.</p>
         </div>
       </header>
       <div class="pips"><span class="manapip kb"><span class="badge">142</span></span><span class="manapip chat"><span class="badge">9</span></span><span class="manapip agent"><span class="badge">1</span></span></div>
@@ -443,7 +443,7 @@
         <div class="info">
           <div class="ts">21:00 · play shell</div>
           <h3>Play session · paragrafo §289</h3>
-          <p class="desc">Vista runtime default. Story tab con paragrafo IT + glossary pill inline (Voidstone, Goblin). Toolbar: 📷 photo · ⚔️ encounter · 📚 glossary. Chat strip laterale (Tutor live).</p>
+          <p class="desc">Vista runtime default. Story tab con paragrafo IT + glossary pill inline (Voidstone, Goblin). Toolbar: 📷 photo · ⚔️ encounter · 📚 glossary. Chat strip laterale (Arbitro Eldoria live).</p>
         </div>
       </header>
       <div class="pips"><span class="manapip kb"><span class="badge">142</span></span><span class="manapip chat"><span class="badge">12</span></span><span class="manapip event"><span class="badge">3</span></span><span class="manapip toolkit"><span class="badge">34</span></span></div>
@@ -515,7 +515,7 @@
         <div class="info">
           <div class="ts">22:33 · J1 rules</div>
           <h3>Chat overlay · regola stacking malus</h3>
-          <p class="desc">Marco chiede: "se ho 2 ferite il malus −2 si cumula?". Aaron query Tutor. Risposta streaming + citation <strong>Rules p.94 §6.3.2</strong> + conf alta in 7.2s.</p>
+          <p class="desc">Marco chiede: "se ho 2 ferite il malus −2 si cumula?". Aaron query Arbitro Eldoria. Risposta streaming + citation <strong>Rules p.94 §6.3.2</strong> + conf alta in 7.2s.</p>
         </div>
       </header>
       <div class="pips"><span class="manapip chat"><span class="badge">15</span></span><span class="manapip kb"><span class="badge">142</span></span></div>
@@ -593,7 +593,7 @@
           <span class="num">E2</span>
           <div class="info">
             <div class="ts">edge · out of context</div>
-            <h3>Chat · "setup di Tainted Grail"</h3>
+            <h3>Chat · "setup di Eldoria"</h3>
             <p class="desc">Aaron chiede di un altro gioco. Agente declina educatamente + suggerisce change game.</p>
           </div>
         </header>
@@ -765,7 +765,7 @@
      ═══════════════════════════════════════════════════════════ -->
 <section class="summary">
   <h2>📊 Game night Eldoria · counter totali agente</h2>
-  <p style="color: var(--text-sec); margin: 0 0 var(--s-5);">Stima singola sera con gruppo A. Tier free, agente Game Tutor (DeepSeek IT).</p>
+  <p style="color: var(--text-sec); margin: 0 0 var(--s-5);">Stima singola sera con gruppo A. Tier free, agente Arbitro Eldoria (DeepSeek IT).</p>
   <div class="grid">
     <div class="stat kb"><div class="v">142</div><div class="l">📄 KB pagine indicizzate</div></div>
     <div class="stat chat"><div class="v">15–17</div><div class="l">💬 Q&A regole (T2 cap)</div></div>

--- a/admin-mockups/design_files/librogame-runthrough-game-detail.html
+++ b/admin-mockups/design_files/librogame-runthrough-game-detail.html
@@ -10,7 +10,7 @@
   Scope:  Phase A runthrough — gating page con CTA primary "Avvia libro game"
   Stati:  default · loading · error · not-found
   Persona: Aaron (badsworm@gmail.com), superadmin, ha Eldoria in collection,
-          KB Press Start + Rules indicizzati, agente "Game Tutor" creato.
+          KB Press Start + Rules indicizzati, agente "Arbitro Eldoria" creato.
 -->
 <!--
   @route /library/{gameId}
@@ -374,7 +374,7 @@
               <span class="nano-mark">In collezione · 142 pag KB</span>
               <div>
                 <h2>Eldoria</h2>
-                <span class="pub">Side Room Studios · 2024</span>
+                <span class="pub">Side Room · 2024</span>
               </div>
             </div>
             <div class="hero-meta">
@@ -386,7 +386,7 @@
             <div class="conn-bar" role="list" aria-label="Entità collegate">
               <span class="pip kb" role="listitem" aria-label="142 pagine indicizzate">📄 142</span>
               <span class="pip chat" role="listitem" aria-label="8 conversazioni">💬 8</span>
-              <span class="pip agent" role="listitem" aria-label="Game Tutor agente">🤖 Tutor</span>
+              <span class="pip agent" role="listitem" aria-label="Arbitro Eldoria agente">🤖 Arbitro Eldoria</span>
               <span class="pip player" role="listitem" aria-label="Party 4 personaggi">👤 4</span>
               <span class="pip session empty" role="listitem" aria-label="Nessuna sessione attiva">🎯 0</span>
             </div>
@@ -462,7 +462,7 @@
                 <span class="nano-mark">In collezione · 142 pag KB</span>
                 <div>
                   <h2>Eldoria</h2>
-                  <span class="pub">Side Room Studios · 2024 · campagna narrativa-tattica</span>
+                  <span class="pub">Side Room · 2024 · campagna narrativa-tattica</span>
                 </div>
               </div>
               <div class="hero-meta">
@@ -474,7 +474,7 @@
               <div class="conn-bar">
                 <span class="pip kb">📄 142</span>
                 <span class="pip chat">💬 8</span>
-                <span class="pip agent">🤖 Tutor</span>
+                <span class="pip agent">🤖 Arbitro Eldoria</span>
                 <span class="pip player">👤 4</span>
                 <span class="pip session empty">🎯 0</span>
               </div>

--- a/admin-mockups/design_files/librogame-runthrough-game-onboarding.html
+++ b/admin-mockups/design_files/librogame-runthrough-game-onboarding.html
@@ -8,7 +8,7 @@
   Mockup: librogame-runthrough-game-onboarding
   Route:  /library/{gameId}  (libro game con prerequisiti non soddisfatti)
   Scope:  Phase A runthrough — gating prerequisiti pre-CTA "Avvia libro game" (N1 hardening)
-  Stati:  A · prereq-missing   (3 step todo: PDF upload, KB indexing, agente Tutor)
+  Stati:  A · prereq-missing   (3 step todo: PDF upload, KB indexing, agente Arbitro Eldoria)
           B · pdf-uploading    (drag-and-drop attivo + progress 2 PDF: Press Start + Rules)
           C · kb-indexing      (PDF ok, chunks/embeddings/index in corso; ETA stimato)
           D · ready            (tutti i pre-step ok; CTA primary session attiva)
@@ -337,7 +337,7 @@
             <div class="hero-cover">
               <span class="nano-mark">📖 libro game</span>
               <h2>Eldoria</h2>
-              <span class="pub">Mythic Games · 2024</span>
+              <span class="pub">Side Room · 2024</span>
             </div>
             <div class="hero-meta">
               <div class="stat"><span class="v">3-4</span><span class="l">giocatori</span></div>
@@ -377,7 +377,7 @@
             <span class="ico">🤖</span>
             <div class="body">
               <div class="row1">
-                <span class="name">Crea agente Tutor</span>
+                <span class="name">Crea agente Arbitro Eldoria</span>
                 <span class="badge">3 di 3</span>
               </div>
               <div class="row2">linked a regolamento + Press Start · 1 click</div>
@@ -399,7 +399,7 @@
             <div class="hero-cover lg">
               <span class="nano-mark">📖 libro game</span>
               <h2 style="font-size: var(--fs-4xl);">Eldoria</h2>
-              <span class="pub">Mythic Games · 2024 · campaign-driven storybook RPG</span>
+              <span class="pub">Side Room · 2024 · campaign-driven storybook RPG</span>
             </div>
             <div class="hero-meta">
               <div class="stat"><span class="v">3-4</span><span class="l">giocatori</span></div>
@@ -408,7 +408,7 @@
               <div class="stat"><span class="v">EN</span><span class="l">lingua</span></div>
             </div>
             <div style="padding: 0 var(--s-4) var(--s-4); color: var(--text-sec); font-size: var(--fs-sm);">
-              Campaign mista (Storybook + Encounter Book), narrativa multi-sessione, paragrafi numerati e branching. Per giocare via app servono: regolamento PDF, Press Start PDF, agente Tutor.
+              Campaign mista (Storybook + Encounter Book), narrativa multi-sessione, paragrafi numerati e branching. Per giocare via app servono: regolamento PDF, Press Start PDF, agente Arbitro Eldoria.
             </div>
           </article>
           <div class="prereq" style="padding: 0;">
@@ -434,7 +434,7 @@
             <div class="step todo">
               <span class="ico">🤖</span>
               <div class="body">
-                <div class="row1"><span class="name">Crea agente Tutor</span><span class="badge">3 di 3</span></div>
+                <div class="row1"><span class="name">Crea agente Arbitro Eldoria</span><span class="badge">3 di 3</span></div>
                 <div class="row2">linked a regolamento + Press Start · 1 click</div>
               </div>
             </div>
@@ -465,7 +465,7 @@
         </div>
         <div class="hero">
           <article class="hero-card">
-            <div class="hero-cover"><span class="nano-mark">📖 libro game</span><h2>Eldoria</h2><span class="pub">Mythic Games · 2024</span></div>
+            <div class="hero-cover"><span class="nano-mark">📖 libro game</span><h2>Eldoria</h2><span class="pub">Side Room · 2024</span></div>
           </article>
         </div>
         <div class="prereq">
@@ -558,7 +558,7 @@
             </div>
             <div class="step todo">
               <span class="ico">🤖</span>
-              <div class="body"><div class="row1"><span class="name">Crea agente Tutor</span><span class="badge">3 di 3</span></div><div class="row2">in attesa</div></div>
+              <div class="body"><div class="row1"><span class="name">Crea agente Arbitro Eldoria</span><span class="badge">3 di 3</span></div><div class="row2">in attesa</div></div>
             </div>
           </div>
         </div>
@@ -584,7 +584,7 @@
         </div>
         <div class="hero">
           <article class="hero-card">
-            <div class="hero-cover"><span class="nano-mark">📖 libro game</span><h2>Eldoria</h2><span class="pub">Mythic Games · 2024</span></div>
+            <div class="hero-cover"><span class="nano-mark">📖 libro game</span><h2>Eldoria</h2><span class="pub">Side Room · 2024</span></div>
           </article>
         </div>
         <div class="prereq">
@@ -624,7 +624,7 @@
           <div class="step todo">
             <span class="ico">🤖</span>
             <div class="body">
-              <div class="row1"><span class="name">Crea agente Tutor</span><span class="badge">3 di 3</span></div>
+              <div class="row1"><span class="name">Crea agente Arbitro Eldoria</span><span class="badge">3 di 3</span></div>
               <div class="row2">in attesa indicizzazione</div>
             </div>
           </div>
@@ -640,7 +640,7 @@
             <div class="hero-cover lg">
               <span class="nano-mark">📖 libro game · indexing</span>
               <h2 style="font-size: var(--fs-4xl);">Eldoria</h2>
-              <span class="pub">Mythic Games · 2024 · 1.842 chunks / 272 pag</span>
+              <span class="pub">Side Room · 2024 · 1.842 chunks / 272 pag</span>
             </div>
             <div class="hero-meta" style="grid-template-columns: repeat(3, 1fr);">
               <div class="stat"><span class="v" style="color: hsl(var(--c-success));">137 MB</span><span class="l">PDF caricati</span></div>
@@ -669,7 +669,7 @@
             </div>
             <div class="step todo">
               <span class="ico">🤖</span>
-              <div class="body"><div class="row1"><span class="name">Crea agente Tutor</span><span class="badge">3 di 3</span></div><div class="row2">attesa indicizzazione</div></div>
+              <div class="body"><div class="row1"><span class="name">Crea agente Arbitro Eldoria</span><span class="badge">3 di 3</span></div><div class="row2">attesa indicizzazione</div></div>
             </div>
           </div>
         </div>
@@ -699,7 +699,7 @@
             <div class="hero-cover">
               <span class="nano-mark">📖 libro game · pronto</span>
               <h2>Eldoria</h2>
-              <span class="pub">Mythic Games · 2024</span>
+              <span class="pub">Side Room · 2024</span>
             </div>
             <div class="hero-meta">
               <div class="stat"><span class="v">3-4</span><span class="l">giocatori</span></div>
@@ -756,7 +756,7 @@
             <div class="hero-cover lg">
               <span class="nano-mark">📖 libro game · pronto</span>
               <h2 style="font-size: var(--fs-4xl);">Eldoria</h2>
-              <span class="pub">Mythic Games · 2024 · campaign-driven storybook RPG</span>
+              <span class="pub">Side Room · 2024 · campaign-driven storybook RPG</span>
             </div>
             <div class="hero-meta">
               <div class="stat"><span class="v">3-4</span><span class="l">giocatori</span></div>

--- a/admin-mockups/design_files/librogame-runthrough-glossary-editor.html
+++ b/admin-mockups/design_files/librogame-runthrough-glossary-editor.html
@@ -9,7 +9,7 @@
           Migrato da sp6-libro-game-glossary-editor.html (persona Sara → Aaron,
           route /gamebook/* → /library/*/play, issue #871 chiusa).
 
-  Narrative cluster: "Sera con i ragazzi · Runa di Ardenel · §147" (coerente
+  Narrative cluster: "Sera con i ragazzi · Eldoria · §147" (coerente
                      con Task 1 error-states + Task 2 translate-viewer).
                      Termini esempio: sentinel, ferrigni, runa, threshold.
                      Books esempio: Press Start + Rules Game.
@@ -297,7 +297,7 @@
         Modale che si apre SOPRA il viewer D <code>translation-viewer</code>
         quando Aaron tappa una glossary pill cliccabile inline al testo.
         Persona <strong>Aaron (badsworm@gmail.com)</strong> in dogfooding,
-        narrative <em>"Sera con i ragazzi · Runa di Ardenel · §147"</em>.
+        narrative <em>"Sera con i ragazzi · Eldoria · §147"</em>.
         4 stati base (modal edit) + 4 NUOVI sub-screen <em>context-aware</em>:
         conflict-dialog · bulk-import-card · variant-expansion · filter-strip.
         Coverage scenario <strong>N3.5</strong> + spec <strong>sezione 1c</strong>

--- a/admin-mockups/design_files/librogame-runthrough-play-session.html
+++ b/admin-mockups/design_files/librogame-runthrough-play-session.html
@@ -287,7 +287,7 @@
           </div>
           <div class="chat-strip" role="button">
             <div class="ico">💬</div>
-            <div class="info"><div class="ti">Game Tutor</div><div class="sub">Pronto · ultima Q&A 8 min fa · 12 oggi</div></div>
+            <div class="info"><div class="ti">Arbitro Eldoria</div><div class="sub">Pronto · ultima Q&A 8 min fa · 12 oggi</div></div>
             <span class="arrow">›</span>
           </div>
         </div>
@@ -341,7 +341,7 @@
           <div class="d-chat">
             <div class="c-h" style="padding: var(--s-2) var(--s-3); border-bottom: 1px solid var(--border-light); display: flex; align-items: center; gap: var(--s-2);">
               <div class="ag" style="width: 28px; height: 28px; border-radius: 50%; background: hsl(var(--c-agent) / 0.18); display: flex; align-items: center; justify-content: center; font-size: 14px;">🤖</div>
-              <span style="flex: 1; font-family: var(--f-display); font-weight: var(--fw-bold); font-size: var(--fs-sm);">Game Tutor</span>
+              <span style="flex: 1; font-family: var(--f-display); font-weight: var(--fw-bold); font-size: var(--fs-sm);">Arbitro Eldoria</span>
               <span class="live">● live</span>
             </div>
             <div class="messages" style="flex: 1; overflow-y: auto; padding: var(--s-3); display: flex; flex-direction: column; gap: var(--s-2);">
@@ -400,7 +400,7 @@
           </div>
           <div class="chat-strip">
             <div class="ico">💬</div>
-            <div class="info"><div class="ti">Chiedi al Tutor</div><div class="sub">Es. "il Goblin può attaccare 2 volte?"</div></div>
+            <div class="info"><div class="ti">Chiedi all'Arbitro Eldoria</div><div class="sub">Es. "il Goblin può attaccare 2 volte?"</div></div>
             <span class="arrow">›</span>
           </div>
         </div>
@@ -428,7 +428,7 @@
             </div>
           </div>
           <div class="d-chat" style="background: var(--bg-card);">
-            <div style="padding: var(--s-2) var(--s-3); border-bottom: 1px solid var(--border-light); display: flex; align-items: center; gap: var(--s-2);"><div style="width: 28px; height: 28px; border-radius: 50%; background: hsl(var(--c-agent) / 0.18); display: flex; align-items: center; justify-content: center;">🤖</div><span style="flex: 1; font-family: var(--f-display); font-weight: var(--fw-bold); font-size: var(--fs-sm);">Tutor</span><span class="live">● live</span></div>
+            <div style="padding: var(--s-2) var(--s-3); border-bottom: 1px solid var(--border-light); display: flex; align-items: center; gap: var(--s-2);"><div style="width: 28px; height: 28px; border-radius: 50%; background: hsl(var(--c-agent) / 0.18); display: flex; align-items: center; justify-content: center;">🤖</div><span style="flex: 1; font-family: var(--f-display); font-weight: var(--fw-bold); font-size: var(--fs-sm);">Arbitro Eldoria</span><span class="live">● live</span></div>
             <div style="flex: 1; padding: var(--s-3); display: flex; flex-direction: column; gap: var(--s-2);">
               <div class="bubble agent">Encounter caricato. Vuoi i suggerimenti tattici?</div>
             </div>
@@ -456,11 +456,11 @@
             <div class="e-head"><div class="ico">⚔️</div><div class="info"><h3 class="ti">2 × Goblin</h3></div></div>
           </div>
         </div>
-        <div class="chat-overlay" role="dialog" aria-label="Chat Tutor">
+        <div class="chat-overlay" role="dialog" aria-label="Chat Arbitro Eldoria">
           <div class="handle"></div>
           <div class="c-h">
             <div class="ag">🤖</div>
-            <span class="nm">Game Tutor</span>
+            <span class="nm">Arbitro Eldoria</span>
             <span class="live">● live · 8s</span>
           </div>
           <div class="messages">
@@ -472,7 +472,7 @@
             <div class="bubble agent typing" aria-label="agente sta scrivendo"><span></span><span></span><span></span></div>
           </div>
           <div class="input-row">
-            <input type="text" placeholder="Chiedi al Tutor…">
+            <input type="text" placeholder="Chiedi all'Arbitro Eldoria…">
             <button class="send" aria-label="invia">➤</button>
           </div>
         </div>
@@ -494,7 +494,7 @@
           <div class="d-chat" style="border-left: 2px solid hsl(var(--c-chat));">
             <div style="padding: var(--s-2) var(--s-3); border-bottom: 1px solid var(--border-light); display: flex; align-items: center; gap: var(--s-2); background: hsl(var(--c-chat) / 0.05);">
               <div style="width: 28px; height: 28px; border-radius: 50%; background: hsl(var(--c-agent) / 0.18); display: flex; align-items: center; justify-content: center;">🤖</div>
-              <span style="flex: 1; font-family: var(--f-display); font-weight: var(--fw-bold);">Tutor · streaming</span>
+              <span style="flex: 1; font-family: var(--f-display); font-weight: var(--fw-bold);">Arbitro Eldoria · streaming</span>
               <span class="live">● 8s</span>
             </div>
             <div style="flex: 1; padding: var(--s-3); display: flex; flex-direction: column; gap: var(--s-2); overflow-y: auto;">
@@ -593,7 +593,7 @@
   <!-- SP8 · Function #4 Note/diary utente. Append-only: i 4 stati sopra restano congelati.
        Tab system esteso (+ Diary = 4a tab). Tutti i classi nuove sono prefissate .dy- per evitare collisioni.
        Mapping: entry = session base + player accent · §badge = kb · CTA nuova nota = session.
-       Dati: Tainted Grail "La grotta dei Goblin", Cap 4, §214 corrente. NB: gli stati congelati usano §289/Eldoria
+       Dati: Eldoria "La grotta dei Goblin", Cap 4, §214 corrente. NB: gli stati congelati usano §289/Eldoria
        (vedi nota deviazione) — i nuovi stati usano i dati canonici del brief SP8 (§214, glossario Niamh/Korak). -->
   <style id="sp8-diary-styles">
     /* tab esteso: con 4 tab restiamo entro 375px; scroll-x di sicurezza se servisse */
@@ -691,7 +691,7 @@
       <div class="phone" role="region" aria-label="Mobile · diary default">
         <span class="frame-label">Mobile · default</span>
         <div class="phone-sbar"><span>22:36</span><span>📶 🔋 58%</span></div>
-        <div class="session-h"><span class="crumbs"><strong>Avalon</strong> · La grotta dei Goblin · <span class="para">§214</span></span><button class="menu" aria-label="Menu sessione">⋯</button></div>
+        <div class="session-h"><span class="crumbs"><strong>Eldoria</strong> · La grotta dei Goblin · <span class="para">§214</span></span><button class="menu" aria-label="Menu sessione">⋯</button></div>
         <div class="header-pips">
           <span class="manapip kb"><span class="badge">47</span></span>
           <span class="manapip chat"><span class="badge">15</span></span>
@@ -731,7 +731,7 @@
       <div class="phone" role="region" aria-label="Mobile · diary editor pristine">
         <span class="frame-label">Mobile · editor pristine</span>
         <div class="phone-sbar"><span>22:37</span><span>📶 🔋 58%</span></div>
-        <div class="session-h"><span class="crumbs"><strong>Avalon</strong> · <span class="para">§214</span> · diary</span><button class="menu" aria-label="Menu sessione">⋯</button></div>
+        <div class="session-h"><span class="crumbs"><strong>Eldoria</strong> · <span class="para">§214</span> · diary</span><button class="menu" aria-label="Menu sessione">⋯</button></div>
         <div class="header-pips"><span class="manapip kb"><span class="badge">47</span></span><span class="manapip session"><span class="badge">1</span></span><span class="manapip toolkit"><span class="badge">12</span></span></div>
         <div class="tabs dy-scroll"><button class="tab" aria-selected="false"><span class="em">📖</span>Story</button><button class="tab" aria-selected="false"><span class="em">⚔️</span>Encounter</button><button class="tab" aria-selected="false"><span class="em">📚</span>Glossario</button><button class="tab dy-diary" aria-selected="true"><span class="em">📓</span>Diary</button></div>
         <div class="content" style="padding: 0; position: relative;">
@@ -754,7 +754,7 @@
       <div class="phone" role="region" aria-label="Mobile · diary editor typed">
         <span class="frame-label">Mobile · editor typed</span>
         <div class="phone-sbar"><span>22:38</span><span>📶 🔋 57%</span></div>
-        <div class="session-h"><span class="crumbs"><strong>Avalon</strong> · <span class="para">§214</span> · diary</span><button class="menu" aria-label="Menu sessione">⋯</button></div>
+        <div class="session-h"><span class="crumbs"><strong>Eldoria</strong> · <span class="para">§214</span> · diary</span><button class="menu" aria-label="Menu sessione">⋯</button></div>
         <div class="header-pips"><span class="manapip kb"><span class="badge">47</span></span><span class="manapip session"><span class="badge">1</span></span><span class="manapip toolkit"><span class="badge">12</span></span></div>
         <div class="tabs dy-scroll"><button class="tab" aria-selected="false"><span class="em">📖</span>Story</button><button class="tab" aria-selected="false"><span class="em">⚔️</span>Encounter</button><button class="tab" aria-selected="false"><span class="em">📚</span>Glossario</button><button class="tab dy-diary" aria-selected="true"><span class="em">📓</span>Diary</button></div>
         <div class="content" style="padding: 0; position: relative;">
@@ -781,7 +781,7 @@
       <div class="phone" role="region" aria-label="Mobile · diary empty">
         <span class="frame-label">Mobile · empty</span>
         <div class="phone-sbar"><span>22:40</span><span>📶 🔋 57%</span></div>
-        <div class="session-h"><span class="crumbs"><strong>Avalon</strong> · <span class="para">§214</span></span><button class="menu" aria-label="Menu sessione">⋯</button></div>
+        <div class="session-h"><span class="crumbs"><strong>Eldoria</strong> · <span class="para">§214</span></span><button class="menu" aria-label="Menu sessione">⋯</button></div>
         <div class="header-pips"><span class="manapip kb"><span class="badge">47</span></span><span class="manapip session"><span class="badge">1</span></span><span class="manapip toolkit"><span class="badge">12</span></span><span class="lbl-mini">· note 0</span></div>
         <div class="tabs dy-scroll"><button class="tab" aria-selected="false"><span class="em">📖</span>Story</button><button class="tab" aria-selected="false"><span class="em">⚔️</span>Encounter</button><button class="tab" aria-selected="false"><span class="em">📚</span>Glossario</button><button class="tab dy-diary" aria-selected="true"><span class="em">📓</span>Diary</button></div>
         <div class="content">
@@ -798,7 +798,7 @@
       <div class="phone" role="region" aria-label="Mobile · diary loading">
         <span class="frame-label">Mobile · loading</span>
         <div class="phone-sbar"><span>22:41</span><span>📶 🔋 56%</span></div>
-        <div class="session-h"><span class="crumbs"><strong>Avalon</strong> · <span class="para">§214</span></span><button class="menu" aria-label="Menu sessione">⋯</button></div>
+        <div class="session-h"><span class="crumbs"><strong>Eldoria</strong> · <span class="para">§214</span></span><button class="menu" aria-label="Menu sessione">⋯</button></div>
         <div class="header-pips"><span class="manapip kb"><span class="badge">47</span></span><span class="manapip session"><span class="badge">1</span></span><span class="manapip toolkit"><span class="badge">12</span></span></div>
         <div class="tabs dy-scroll"><button class="tab" aria-selected="false"><span class="em">📖</span>Story</button><button class="tab" aria-selected="false"><span class="em">⚔️</span>Encounter</button><button class="tab" aria-selected="false"><span class="em">📚</span>Glossario</button><button class="tab dy-diary" aria-selected="true"><span class="em">📓</span>Diary</button></div>
         <div class="content" aria-busy="true">
@@ -812,7 +812,7 @@
       <div class="phone" role="region" aria-label="Mobile · diary error save">
         <span class="frame-label">Mobile · error save</span>
         <div class="phone-sbar"><span>22:42</span><span>📶 🔋 56%</span></div>
-        <div class="session-h"><span class="crumbs"><strong>Avalon</strong> · <span class="para">§214</span> · diary</span><button class="menu" aria-label="Menu sessione">⋯</button></div>
+        <div class="session-h"><span class="crumbs"><strong>Eldoria</strong> · <span class="para">§214</span> · diary</span><button class="menu" aria-label="Menu sessione">⋯</button></div>
         <div class="header-pips"><span class="manapip kb"><span class="badge">47</span></span><span class="manapip session"><span class="badge">1</span></span><span class="manapip toolkit"><span class="badge">12</span></span></div>
         <div class="tabs dy-scroll"><button class="tab" aria-selected="false"><span class="em">📖</span>Story</button><button class="tab" aria-selected="false"><span class="em">⚔️</span>Encounter</button><button class="tab" aria-selected="false"><span class="em">📚</span>Glossario</button><button class="tab dy-diary" aria-selected="true"><span class="em">📓</span>Diary</button></div>
         <div class="content">
@@ -835,7 +835,7 @@
       <div class="phone" role="region" aria-label="Mobile · diary offline">
         <span class="frame-label">Mobile · offline</span>
         <div class="phone-sbar"><span>22:44</span><span>✈️ 🔋 55%</span></div>
-        <div class="session-h"><span class="crumbs"><strong>Avalon</strong> · <span class="para">§214</span> · diary</span><button class="menu" aria-label="Menu sessione">⋯</button></div>
+        <div class="session-h"><span class="crumbs"><strong>Eldoria</strong> · <span class="para">§214</span> · diary</span><button class="menu" aria-label="Menu sessione">⋯</button></div>
         <div class="header-pips"><span class="manapip kb"><span class="badge">47</span></span><span class="manapip session"><span class="badge">1</span></span><span class="manapip toolkit"><span class="badge">12</span></span></div>
         <div class="tabs dy-scroll"><button class="tab" aria-selected="false"><span class="em">📖</span>Story</button><button class="tab" aria-selected="false"><span class="em">⚔️</span>Encounter</button><button class="tab" aria-selected="false"><span class="em">📚</span>Glossario</button><button class="tab dy-diary" aria-selected="true"><span class="em">📓</span>Diary</button></div>
         <div class="content">
@@ -857,7 +857,7 @@
       <!-- Desktop · diary default (left context panel + content) -->
       <div class="desktop" role="region" aria-label="Desktop · diary default">
         <span class="frame-label">Desktop · 1440px (scaled)</span>
-        <div class="titlebar"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="url">meepleai.app/library/librogame/play/camp-avalon-1?tab=diary</span></div>
+        <div class="titlebar"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="url">meepleai.app/library/librogame/play/camp-eldoria-1?tab=diary</span></div>
         <div class="d-body">
           <aside class="d-side" style="width: 260px; display: flex; flex-direction: column;">
             <div class="side-card" style="margin-bottom: var(--s-2);">
@@ -899,7 +899,7 @@
       <!-- Desktop · editor inline-expand -->
       <div class="desktop" role="region" aria-label="Desktop · diary editor">
         <span class="frame-label">Desktop · editor inline-expand</span>
-        <div class="titlebar"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="url">meepleai.app/library/librogame/play/camp-avalon-1?tab=diary&edit=new</span></div>
+        <div class="titlebar"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="url">meepleai.app/library/librogame/play/camp-eldoria-1?tab=diary&edit=new</span></div>
         <div class="d-body">
           <aside class="d-side" style="width: 260px; display: flex; flex-direction: column;">
             <nav aria-label="Sezioni sessione" style="display: flex; flex-direction: column; gap: 2px;">
@@ -1045,7 +1045,7 @@
       <div class="phone" role="region" aria-label="Mobile · history default">
         <span class="frame-label">Mobile · default</span>
         <div class="phone-sbar"><span>22:46</span><span>📶 🔋 55%</span></div>
-        <div class="session-h"><span class="crumbs"><strong>Avalon</strong> · La grotta dei Goblin · <span class="para">§214</span></span><button class="hy-trigger" aria-label="Paragrafi visitati">🕰</button></div>
+        <div class="session-h"><span class="crumbs"><strong>Eldoria</strong> · La grotta dei Goblin · <span class="para">§214</span></span><button class="hy-trigger" aria-label="Paragrafi visitati">🕰</button></div>
         <div class="header-pips"><span class="manapip kb"><span class="badge">47</span></span><span class="manapip session"><span class="badge">1</span></span><span class="manapip toolkit"><span class="badge">12</span></span><span class="lbl-mini">· Cap 4</span></div>
         <div class="tabs"><button class="tab" aria-selected="true"><span class="em">📖</span>Story</button><button class="tab" aria-selected="false"><span class="em">⚔️</span>Encounter</button><button class="tab" aria-selected="false"><span class="em">📚</span>Glossario</button></div>
         <div class="content" aria-hidden="true" style="filter: blur(1px); opacity: 0.5;"><div class="para-card"><div class="num-row"><span class="num">§214</span><span class="chap">Cap 4</span></div><p class="text">La grotta si apre davanti a te…</p></div></div>
@@ -1080,7 +1080,7 @@
       <div class="phone" role="region" aria-label="Mobile · history jump-back confirm">
         <span class="frame-label">Mobile · jump-back confirm</span>
         <div class="phone-sbar"><span>22:47</span><span>📶 🔋 55%</span></div>
-        <div class="session-h"><span class="crumbs"><strong>Avalon</strong> · <span class="para">§214</span></span><button class="hy-trigger" aria-label="Paragrafi visitati">🕰</button></div>
+        <div class="session-h"><span class="crumbs"><strong>Eldoria</strong> · <span class="para">§214</span></span><button class="hy-trigger" aria-label="Paragrafi visitati">🕰</button></div>
         <div class="header-pips"><span class="manapip kb"><span class="badge">47</span></span><span class="manapip session"><span class="badge">1</span></span><span class="manapip toolkit"><span class="badge">12</span></span></div>
         <div class="tabs"><button class="tab" aria-selected="true"><span class="em">📖</span>Story</button><button class="tab" aria-selected="false"><span class="em">⚔️</span>Encounter</button><button class="tab" aria-selected="false"><span class="em">📚</span>Glossario</button></div>
         <div class="content" aria-hidden="true" style="filter: blur(1px); opacity: 0.4;"></div>
@@ -1104,7 +1104,7 @@
       <div class="phone" role="region" aria-label="Mobile · history empty">
         <span class="frame-label">Mobile · empty</span>
         <div class="phone-sbar"><span>20:02</span><span>📶 🔋 88%</span></div>
-        <div class="session-h"><span class="crumbs"><strong>Avalon</strong> · <span class="para">§1</span></span><button class="hy-trigger">🕰</button></div>
+        <div class="session-h"><span class="crumbs"><strong>Eldoria</strong> · <span class="para">§1</span></span><button class="hy-trigger">🕰</button></div>
         <div class="header-pips"><span class="manapip session"><span class="badge">1</span></span><span class="lbl-mini">· Cap 1</span></div>
         <div class="tabs"><button class="tab" aria-selected="true"><span class="em">📖</span>Story</button><button class="tab" aria-selected="false"><span class="em">⚔️</span>Encounter</button><button class="tab" aria-selected="false"><span class="em">📚</span>Glossario</button></div>
         <div class="content" aria-hidden="true" style="opacity: 0.4;"></div>
@@ -1126,7 +1126,7 @@
       <div class="phone" role="region" aria-label="Mobile · history loading">
         <span class="frame-label">Mobile · loading</span>
         <div class="phone-sbar"><span>22:48</span><span>📶 🔋 54%</span></div>
-        <div class="session-h"><span class="crumbs"><strong>Avalon</strong> · <span class="para">§214</span></span><button class="hy-trigger">🕰</button></div>
+        <div class="session-h"><span class="crumbs"><strong>Eldoria</strong> · <span class="para">§214</span></span><button class="hy-trigger">🕰</button></div>
         <div class="header-pips"><span class="manapip kb"><span class="badge">47</span></span><span class="manapip session"><span class="badge">1</span></span></div>
         <div class="tabs"><button class="tab" aria-selected="true"><span class="em">📖</span>Story</button><button class="tab" aria-selected="false"><span class="em">⚔️</span>Encounter</button><button class="tab" aria-selected="false"><span class="em">📚</span>Glossario</button></div>
         <div class="content" aria-hidden="true" style="opacity: 0.4;"></div>
@@ -1148,7 +1148,7 @@
       <div class="phone" role="region" aria-label="Mobile · history error">
         <span class="frame-label">Mobile · error</span>
         <div class="phone-sbar"><span>22:49</span><span>📶 🔋 54%</span></div>
-        <div class="session-h"><span class="crumbs"><strong>Avalon</strong> · <span class="para">§214</span></span><button class="hy-trigger">🕰</button></div>
+        <div class="session-h"><span class="crumbs"><strong>Eldoria</strong> · <span class="para">§214</span></span><button class="hy-trigger">🕰</button></div>
         <div class="header-pips"><span class="manapip kb"><span class="badge">47</span></span><span class="manapip session"><span class="badge">1</span></span></div>
         <div class="tabs"><button class="tab" aria-selected="true"><span class="em">📖</span>Story</button><button class="tab" aria-selected="false"><span class="em">⚔️</span>Encounter</button><button class="tab" aria-selected="false"><span class="em">📚</span>Glossario</button></div>
         <div class="content" aria-hidden="true" style="opacity: 0.4;"></div>
@@ -1170,7 +1170,7 @@
       <div class="phone" role="region" aria-label="Mobile · history offline">
         <span class="frame-label">Mobile · offline</span>
         <div class="phone-sbar"><span>22:51</span><span>✈️ 🔋 53%</span></div>
-        <div class="session-h"><span class="crumbs"><strong>Avalon</strong> · <span class="para">§214</span></span><button class="hy-trigger">🕰</button></div>
+        <div class="session-h"><span class="crumbs"><strong>Eldoria</strong> · <span class="para">§214</span></span><button class="hy-trigger">🕰</button></div>
         <div class="header-pips"><span class="manapip kb"><span class="badge">47</span></span><span class="manapip session"><span class="badge">1</span></span></div>
         <div class="tabs"><button class="tab" aria-selected="true"><span class="em">📖</span>Story</button><button class="tab" aria-selected="false"><span class="em">⚔️</span>Encounter</button><button class="tab" aria-selected="false"><span class="em">📚</span>Glossario</button></div>
         <div class="content" aria-hidden="true" style="opacity: 0.4;"></div>
@@ -1202,7 +1202,7 @@
       <!-- Desktop · default (side-panel from left) -->
       <div class="desktop" role="region" aria-label="Desktop · history default">
         <span class="frame-label">Desktop · 1440px (scaled)</span>
-        <div class="titlebar"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="url">meepleai.app/library/librogame/play/camp-avalon-1?history=open</span></div>
+        <div class="titlebar"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="url">meepleai.app/library/librogame/play/camp-eldoria-1?history=open</span></div>
         <div class="d-body" style="position: relative;">
           <aside class="d-side" style="width: 260px; display: flex; flex-direction: column;">
             <div class="side-card" style="margin-bottom: var(--s-2);"><h4>Campagna</h4><div class="row"><span class="k">Capitolo</span><span class="v">4 · §214</span></div></div>
@@ -1246,7 +1246,7 @@
       <!-- Desktop · jump-back confirm -->
       <div class="desktop" role="region" aria-label="Desktop · history confirm">
         <span class="frame-label">Desktop · jump-back confirm</span>
-        <div class="titlebar"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="url">meepleai.app/library/librogame/play/camp-avalon-1?history=open&jump=189</span></div>
+        <div class="titlebar"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="url">meepleai.app/library/librogame/play/camp-eldoria-1?history=open&jump=189</span></div>
         <div class="d-body" style="position: relative;">
           <aside class="d-side" style="width: 260px;"><div class="side-card"><h4>Campagna</h4><div class="row"><span class="k">Capitolo</span><span class="v">4 · §214</span></div></div></aside>
           <div class="d-main" aria-hidden="true" style="opacity: 0.4;"></div>
@@ -1385,7 +1385,7 @@
       <div class="phone" role="region" aria-label="Mobile · kebab menu">
         <span class="frame-label">Mobile · kebab menu</span>
         <div class="phone-sbar"><span>23:02</span><span>📶 🔋 50%</span></div>
-        <div class="session-h"><span class="crumbs"><strong>Avalon</strong> · La grotta dei Goblin · <span class="para">§214</span></span><button class="menu" aria-label="Menu sessione" aria-expanded="true">⋮</button></div>
+        <div class="session-h"><span class="crumbs"><strong>Eldoria</strong> · La grotta dei Goblin · <span class="para">§214</span></span><button class="menu" aria-label="Menu sessione" aria-expanded="true">⋮</button></div>
         <div class="header-pips"><span class="manapip kb"><span class="badge">47</span></span><span class="manapip session"><span class="badge">1</span></span><span class="manapip toolkit"><span class="badge">12</span></span></div>
         <div class="tabs"><button class="tab" aria-selected="true"><span class="em">📖</span>Story</button><button class="tab" aria-selected="false"><span class="em">⚔️</span>Encounter</button><button class="tab" aria-selected="false"><span class="em">📚</span>Glossario</button></div>
         <div class="content" aria-hidden="true" style="opacity: 0.45;"><div class="para-card"><div class="num-row"><span class="num">§214</span><span class="chap">Cap 4</span></div><p class="text">La grotta si apre davanti a te…</p></div></div>
@@ -1402,7 +1402,7 @@
       <div class="phone" role="region" aria-label="Mobile · dialog 3-vie">
         <span class="frame-label">Mobile · dialog 3-vie</span>
         <div class="phone-sbar"><span>23:03</span><span>📶 🔋 50%</span></div>
-        <div class="session-h"><span class="crumbs"><strong>Avalon</strong> · <span class="para">§214</span></span><button class="menu">⋮</button></div>
+        <div class="session-h"><span class="crumbs"><strong>Eldoria</strong> · <span class="para">§214</span></span><button class="menu">⋮</button></div>
         <div class="header-pips"><span class="manapip kb"><span class="badge">47</span></span><span class="manapip session"><span class="badge">1</span></span><span class="manapip toolkit"><span class="badge">12</span></span></div>
         <div class="tabs"><button class="tab" aria-selected="true"><span class="em">📖</span>Story</button><button class="tab" aria-selected="false"><span class="em">⚔️</span>Encounter</button><button class="tab" aria-selected="false"><span class="em">📚</span>Glossario</button></div>
         <div class="content" aria-hidden="true" style="opacity: 0.3;"></div>
@@ -1437,7 +1437,7 @@
       <div class="phone" role="region" aria-label="Mobile · closing loading">
         <span class="frame-label">Mobile · loading</span>
         <div class="phone-sbar"><span>23:03</span><span>📶 🔋 49%</span></div>
-        <div class="session-h"><span class="crumbs"><strong>Avalon</strong> · <span class="para">§214</span></span><button class="menu">⋮</button></div>
+        <div class="session-h"><span class="crumbs"><strong>Eldoria</strong> · <span class="para">§214</span></span><button class="menu">⋮</button></div>
         <div class="header-pips"><span class="manapip kb"><span class="badge">47</span></span><span class="manapip session"><span class="badge">1</span></span></div>
         <div class="tabs"><button class="tab" aria-selected="true"><span class="em">📖</span>Story</button><button class="tab" aria-selected="false"><span class="em">⚔️</span>Encounter</button><button class="tab" aria-selected="false"><span class="em">📚</span>Glossario</button></div>
         <div class="content" aria-hidden="true" style="opacity: 0.3;"></div>
@@ -1452,7 +1452,7 @@
       <div class="phone" role="region" aria-label="Mobile · close error">
         <span class="frame-label">Mobile · error</span>
         <div class="phone-sbar"><span>23:04</span><span>📶 🔋 49%</span></div>
-        <div class="session-h"><span class="crumbs"><strong>Avalon</strong> · <span class="para">§214</span></span><button class="menu">⋮</button></div>
+        <div class="session-h"><span class="crumbs"><strong>Eldoria</strong> · <span class="para">§214</span></span><button class="menu">⋮</button></div>
         <div class="header-pips"><span class="manapip kb"><span class="badge">47</span></span><span class="manapip session"><span class="badge">1</span></span></div>
         <div class="tabs"><button class="tab" aria-selected="true"><span class="em">📖</span>Story</button><button class="tab" aria-selected="false"><span class="em">⚔️</span>Encounter</button><button class="tab" aria-selected="false"><span class="em">📚</span>Glossario</button></div>
         <div class="content">
@@ -1467,7 +1467,7 @@
       <div class="phone" role="region" aria-label="Mobile · close offline">
         <span class="frame-label">Mobile · offline (pending sync)</span>
         <div class="phone-sbar"><span>23:06</span><span>✈️ 🔋 48%</span></div>
-        <div class="session-h"><span class="crumbs"><strong>Avalon</strong> · La grotta dei Goblin</span><button class="menu">⋮</button></div>
+        <div class="session-h"><span class="crumbs"><strong>Eldoria</strong> · La grotta dei Goblin</span><button class="menu">⋮</button></div>
         <div class="header-pips"><span class="manapip kb"><span class="badge">47</span></span><span class="manapip session"><span class="badge">1</span></span></div>
         <div class="tabs"><button class="tab" aria-selected="false"><span class="em">📖</span>Story</button><button class="tab" aria-selected="false"><span class="em">⚔️</span>Encounter</button><button class="tab" aria-selected="false"><span class="em">📚</span>Glossario</button></div>
         <div class="content">
@@ -1488,7 +1488,7 @@
       <div class="phone" role="region" aria-label="Mobile · post-close completata">
         <span class="frame-label">Mobile · post-close · Completata</span>
         <div class="phone-sbar"><span>23:04</span><span>📶 🔋 49%</span></div>
-        <div class="session-h"><span class="crumbs"><strong>Avalon</strong> · La grotta dei Goblin</span></div>
+        <div class="session-h"><span class="crumbs"><strong>Eldoria</strong> · La grotta dei Goblin</span></div>
         <div class="content" style="padding: 0;">
           <div class="ec-confetti" aria-hidden="true">
             <i style="left: 12%; background: hsl(var(--c-toolkit)); animation-delay: 0s;"></i>
@@ -1501,7 +1501,7 @@
             <div class="ec-s-badge">🏆</div>
             <span class="ec-s-kick">Completata</span>
             <h2>Hai finito la storia!</h2>
-            <p class="ec-s-camp">"La grotta dei Goblin" · Tainted Grail</p>
+            <p class="ec-s-camp">"La grotta dei Goblin" · Eldoria</p>
             <div class="ec-stats">
               <div class="ec-stat"><div class="ec-st-v">3h 24m</div><div class="ec-st-k">Durata</div></div>
               <div class="ec-stat"><div class="ec-st-v">47</div><div class="ec-st-k">Paragrafi visitati</div></div>
@@ -1522,7 +1522,7 @@
       <div class="phone" role="region" aria-label="Mobile · post-close archivia">
         <span class="frame-label">Mobile · post-close · Archivia</span>
         <div class="phone-sbar"><span>23:05</span><span>📶 🔋 49%</span></div>
-        <div class="session-h"><span class="crumbs"><strong>Avalon</strong> · La grotta dei Goblin</span></div>
+        <div class="session-h"><span class="crumbs"><strong>Eldoria</strong> · La grotta dei Goblin</span></div>
         <div class="content" style="padding: 0;">
           <div class="ec-summary ec-arch">
             <div class="ec-s-badge">📥</div>
@@ -1546,7 +1546,7 @@
       <!-- Desktop · dialog 3-vie -->
       <div class="desktop" role="region" aria-label="Desktop · dialog 3-vie">
         <span class="frame-label">Desktop · dialog 3-vie</span>
-        <div class="titlebar"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="url">meepleai.app/library/librogame/play/camp-avalon-1?close=1</span></div>
+        <div class="titlebar"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="url">meepleai.app/library/librogame/play/camp-eldoria-1?close=1</span></div>
         <div class="d-body" style="position: relative;">
           <aside class="d-side" style="width: 260px; display: flex; flex-direction: column;">
             <div class="side-card" style="margin-bottom: var(--s-2);"><h4>Campagna</h4><div class="row"><span class="k">Capitolo</span><span class="v">4 · §214</span></div></div>
@@ -1572,14 +1572,14 @@
       <!-- Desktop · post-close Completata -->
       <div class="desktop" role="region" aria-label="Desktop · post-close completata">
         <span class="frame-label">Desktop · post-close · Completata</span>
-        <div class="titlebar"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="url">meepleai.app/library/librogame/play/camp-avalon-1/summary</span></div>
+        <div class="titlebar"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="url">meepleai.app/library/librogame/play/camp-eldoria-1/summary</span></div>
         <div class="d-body" style="justify-content: center; align-items: center; position: relative;">
           <div class="ec-confetti" aria-hidden="true"><i style="left: 20%; background: hsl(var(--c-toolkit));"></i><i style="left: 40%; background: hsl(var(--c-session)); animation-delay: 0.2s;"></i><i style="left: 60%; background: hsl(var(--c-kb)); animation-delay: 0.1s;"></i><i style="left: 78%; background: hsl(var(--c-game)); animation-delay: 0.3s;"></i></div>
           <div class="ec-summary ec-done" style="max-width: 460px; overflow: visible;">
             <div class="ec-s-badge">🏆</div>
             <span class="ec-s-kick">Completata</span>
             <h2>Hai finito la storia!</h2>
-            <p class="ec-s-camp">"La grotta dei Goblin" · Tainted Grail</p>
+            <p class="ec-s-camp">"La grotta dei Goblin" · Eldoria</p>
             <div class="ec-stats" style="grid-template-columns: repeat(3, 1fr);">
               <div class="ec-stat"><div class="ec-st-v">3h 24m</div><div class="ec-st-k">Durata</div></div>
               <div class="ec-stat"><div class="ec-st-v">47</div><div class="ec-st-k">Paragrafi</div></div>

--- a/admin-mockups/design_files/librogame-runthrough-play-session.jsx
+++ b/admin-mockups/design_files/librogame-runthrough-play-session.jsx
@@ -12,7 +12,7 @@
    Stato      : ⏳ state-05 Diary (questa risposta).
                 state-06 Paragrafi drawer + state-07 End campaign verranno
                 APPESI in coda a questo file nelle risposte 2 e 3.
-   Dati       : inline (data.js è read-only). Tainted Grail · "La grotta dei
+   Dati       : inline (data.js è read-only). Eldoria · "La grotta dei
                 Goblin" · Cap 4 · §214 · glossario Niamh/Korak/Pietra Spettrale.
    ════════════════════════════════════════════════════════════════ */
 
@@ -257,7 +257,7 @@ function PhoneFrame({ d, lisaState }) {
       <span className="frame-label">Mobile · 375px</span>
       <div className="phone-sbar"><span>22:36</span><span>{offline ? '✈️' : '📶'} 🔋 58%</span></div>
       <div className="session-h">
-        <span className="crumbs"><strong>Avalon</strong> · La grotta dei Goblin · <span className="para">{CURRENT_PARA}</span></span>
+        <span className="crumbs"><strong>Eldoria</strong> · La grotta dei Goblin · <span className="para">{CURRENT_PARA}</span></span>
         <button className="menu" aria-label="Menu sessione">⋯</button>
       </div>
       <div className="header-pips">
@@ -287,7 +287,7 @@ function DesktopFrame({ d, lisaState }) {
       <span className="frame-label">Desktop · 1440px (scaled)</span>
       <div className="titlebar">
         <span className="dot r"></span><span className="dot y"></span><span className="dot g"></span>
-        <span className="url">meepleai.app/library/librogame/play/camp-avalon-1?tab=diary</span>
+        <span className="url">meepleai.app/library/librogame/play/camp-eldoria-1?tab=diary</span>
       </div>
       <div className="d-body">
         <aside className="d-side" style={{ width: 260, display: 'flex', flexDirection: 'column' }}>
@@ -530,7 +530,7 @@ function HistoryPhone({ h }) {
       <span className="frame-label">Mobile · 375px</span>
       <div className="phone-sbar"><span>22:46</span><span>{offline ? '✈️' : '📶'} 🔋 55%</span></div>
       <div className="session-h">
-        <span className="crumbs"><strong>Avalon</strong> · La grotta dei Goblin · <span className="para">{h.currentPara}</span></span>
+        <span className="crumbs"><strong>Eldoria</strong> · La grotta dei Goblin · <span className="para">{h.currentPara}</span></span>
         <button className="hy-trigger" aria-label="Paragrafi visitati" aria-expanded={h.open} onClick={() => h.setOpen(true)}>🕰</button>
       </div>
       <div className="header-pips"><span className="manapip kb"><span className="badge">47</span></span><span className="manapip session"><span className="badge">1</span></span><span className="manapip toolkit"><span className="badge">12</span></span><span className="lbl-mini">· Cap 4</span></div>
@@ -560,7 +560,7 @@ function HistoryDesktop({ h }) {
   return (
     <div className="desktop" role="region" aria-label="Desktop · history interattiva">
       <span className="frame-label">Desktop · 1440px (scaled)</span>
-      <div className="titlebar"><span className="dot r"></span><span className="dot y"></span><span className="dot g"></span><span className="url">meepleai.app/library/librogame/play/camp-avalon-1?history={h.open ? 'open' : 'closed'}</span></div>
+      <div className="titlebar"><span className="dot r"></span><span className="dot y"></span><span className="dot g"></span><span className="url">meepleai.app/library/librogame/play/camp-eldoria-1?history={h.open ? 'open' : 'closed'}</span></div>
       <div className="d-body" style={{ position: 'relative' }}>
         <aside className="d-side" style={{ width: 260, display: 'flex', flexDirection: 'column' }}>
           <div className="side-card" style={{ marginBottom: 'var(--s-2)' }}><h4>Campagna</h4><div className="row"><span className="k">Capitolo</span><span className="v">4 · {h.currentPara}</span></div></div>
@@ -668,7 +668,7 @@ function CloseSummary({ outcomeId, server, onReopen, onLib, onRetry, onForce }) 
         <div className="ec-s-badge">{isDone ? '🏆' : '📥'}</div>
         <span className="ec-s-kick">{isDone ? 'Completata' : (server === 'offline' ? 'Archiviata · in coda' : (isArchive ? 'Archiviata' : 'Abbandonata'))}</span>
         <h2>{isDone ? 'Hai finito la storia!' : (isArchive ? 'Campagna messa via' : 'Campagna chiusa')}</h2>
-        <p className="ec-s-camp">"La grotta dei Goblin"{isDone ? ' · Tainted Grail' : ' · la riprendi quando vuoi'}</p>
+        <p className="ec-s-camp">"La grotta dei Goblin"{isDone ? ' · Eldoria' : ' · la riprendi quando vuoi'}</p>
         {server === 'offline' && <span className="ec-pending"><span className="dot"></span>Pending sync · si completa online</span>}
         {server !== 'offline' && (
           <div className="ec-stats">
@@ -776,7 +776,7 @@ function EndPhone({ ec, server }) {
       <span className="frame-label">Mobile · 375px</span>
       <div className="phone-sbar"><span>23:02</span><span>{server === 'offline' ? '✈️' : '📶'} 🔋 50%</span></div>
       <div className="session-h">
-        <span className="crumbs"><strong>Avalon</strong> · La grotta dei Goblin · <span className="para">§214</span></span>
+        <span className="crumbs"><strong>Eldoria</strong> · La grotta dei Goblin · <span className="para">§214</span></span>
         {!showSummary && <button className="menu" aria-label="Menu sessione" aria-expanded={ec.phase === 'kebab'} onClick={() => ec.setPhase(ec.phase === 'kebab' ? 'idle' : 'kebab')}>⋮</button>}
       </div>
       {!showSummary && (
@@ -814,7 +814,7 @@ function EndDesktop({ ec, server }) {
   return (
     <div className="desktop" role="region" aria-label="Desktop · end campaign interattivo">
       <span className="frame-label">Desktop · 1440px (scaled)</span>
-      <div className="titlebar"><span className="dot r"></span><span className="dot y"></span><span className="dot g"></span><span className="url">meepleai.app/library/librogame/play/camp-avalon-1{showSummary ? '/summary' : '?close=' + (ec.phase === 'dialog' ? '1' : '0')}</span></div>
+      <div className="titlebar"><span className="dot r"></span><span className="dot y"></span><span className="dot g"></span><span className="url">meepleai.app/library/librogame/play/camp-eldoria-1{showSummary ? '/summary' : '?close=' + (ec.phase === 'dialog' ? '1' : '0')}</span></div>
       <div className="d-body" style={{ position: 'relative', justifyContent: showSummary ? 'center' : undefined, alignItems: showSummary ? 'center' : undefined }}>
         {!showSummary && (
           <React.Fragment>

--- a/admin-mockups/design_files/librogame-runthrough-setup-chat.html
+++ b/admin-mockups/design_files/librogame-runthrough-setup-chat.html
@@ -10,9 +10,9 @@
   Scope:  Phase A runthrough — chat panel laterale per setup pre-sessione (N1 baseline)
   Stati:  default            (Aaron query setup 4 giocatori + risposta IT 5 step + citation Press Start + confidence alta)
           confidence-bassa   (Aaron edge "setup variante 5 giocatori" + disclaimer "non sono sicuro")
-          out-of-context     (Aaron chiede setup di Tainted Grail, agente declina con suggestion change game)
+          out-of-context     (Aaron chiede setup di Gloomhaven, agente declina con suggestion change game)
           loading            (skeleton bubble agent typing)
-  Persona: Aaron (badsworm@gmail.com), 30 minuti prima dell'arrivo amici, agente "Game Tutor" con KB Press Start.
+  Persona: Aaron (badsworm@gmail.com), 30 minuti prima dell'arrivo amici, agente "Arbitro Eldoria" con KB Press Start.
   Vincolo: SMART N1 P95 ≤ 8s, citation accuracy ≥ 90%, confidence badge visibile.
 -->
 <link rel="preconnect" href="https://fonts.googleapis.com"/>
@@ -354,11 +354,11 @@
           <div class="bubble agent">
             <div class="header">
               <span class="avatar" aria-hidden="true">🤖</span>
-              <span class="name">Game Tutor</span>
+              <span class="name">Arbitro Eldoria</span>
             </div>
             <p>Per una partita a 4 giocatori, segui questi step:</p>
             <ol>
-              <li><strong>Tabellone Avalon</strong> al centro del tavolo, lato A in alto.</li>
+              <li><strong>Tabellone Eldoria</strong> al centro del tavolo, lato A in alto.</li>
               <li>Distribuisci <strong>4 carte personaggio</strong> casuali — uno per giocatore.</li>
               <li>Posiziona <strong>5 dadi neri</strong> sulla pista combattimento e <strong>3 dadi bianchi</strong> sulla pista esplorazione.</li>
               <li>Mescola il mazzo <strong>Encounter</strong> (24 carte) e mettilo coperto vicino al tabellone.</li>
@@ -409,15 +409,15 @@
           <div class="desktop-main">
             <div class="session-head">
               <span class="pulse"></span>
-              <div><div class="title">Sera con i ragazzi · Chat regole</div><div class="sub">🎯 Setup pre-sessione · §1 · agente: Game Tutor</div></div>
+              <div><div class="title">Sera con i ragazzi · Chat regole</div><div class="sub">🎯 Setup pre-sessione · §1 · agente: Arbitro Eldoria</div></div>
             </div>
             <div class="conv" role="log" aria-live="polite">
               <div class="bubble user">come si setupa Eldoria per 4 giocatori?</div>
               <div class="bubble agent">
-                <div class="header"><span class="avatar">🤖</span><span class="name">Game Tutor</span></div>
+                <div class="header"><span class="avatar">🤖</span><span class="name">Arbitro Eldoria</span></div>
                 <p>Per una partita a 4 giocatori, segui questi step:</p>
                 <ol>
-                  <li><strong>Tabellone Avalon</strong> al centro del tavolo, lato A in alto.</li>
+                  <li><strong>Tabellone Eldoria</strong> al centro del tavolo, lato A in alto.</li>
                   <li>Distribuisci <strong>4 carte personaggio</strong> casuali — uno per giocatore.</li>
                   <li>Posiziona <strong>5 dadi neri</strong> sulla pista combattimento e <strong>3 dadi bianchi</strong> sulla pista esplorazione.</li>
                   <li>Mescola il mazzo <strong>Encounter</strong> (24 carte) e mettilo coperto vicino al tabellone.</li>
@@ -476,7 +476,7 @@
         <div class="conv" role="log">
           <div class="bubble user">e per 5 giocatori?</div>
           <div class="bubble agent">
-            <div class="header"><span class="avatar">🤖</span><span class="name">Game Tutor</span></div>
+            <div class="header"><span class="avatar">🤖</span><span class="name">Arbitro Eldoria</span></div>
             <p>Non sono sicuro — il quickstart Press Start copre solo configurazioni 2-4 giocatori. Per varianti 5+ ti suggerisco di:</p>
             <div class="disclaimer">
               <strong>⚠️ Non sono certo.</strong> Controlla pag. 18 del regolamento completo (Rules KB) per la variante "Avventura epica" che potrebbe estendere a 5-6 giocatori.
@@ -510,11 +510,11 @@
             </div>
           </aside>
           <div class="desktop-main">
-            <div class="session-head"><span class="pulse"></span><div><div class="title">Chat regole</div><div class="sub">🎯 Setup · agente: Game Tutor</div></div></div>
+            <div class="session-head"><span class="pulse"></span><div><div class="title">Chat regole</div><div class="sub">🎯 Setup · agente: Arbitro Eldoria</div></div></div>
             <div class="conv">
               <div class="bubble user">come si setupa Eldoria per 4 giocatori?</div>
               <div class="bubble agent" style="opacity: 0.65;">
-                <div class="header"><span class="avatar">🤖</span><span class="name">Game Tutor</span></div>
+                <div class="header"><span class="avatar">🤖</span><span class="name">Arbitro Eldoria</span></div>
                 <p>Per una partita a 4 giocatori… <em>(risposta confidence alta, vedi stato 1)</em></p>
                 <div class="conf-row" style="margin-top: var(--s-2);">
                   <span class="conf-badge alta">🟢 Alta · 0.92</span>
@@ -522,7 +522,7 @@
               </div>
               <div class="bubble user">e per 5 giocatori?</div>
               <div class="bubble agent">
-                <div class="header"><span class="avatar">🤖</span><span class="name">Game Tutor</span></div>
+                <div class="header"><span class="avatar">🤖</span><span class="name">Arbitro Eldoria</span></div>
                 <p>Non sono sicuro — il quickstart Press Start copre solo configurazioni 2-4 giocatori.</p>
                 <div class="disclaimer">
                   <strong>⚠️ Non sono certo.</strong> Controlla pag. 18 del regolamento completo (Rules KB) per la variante "Avventura epica" che potrebbe estendere a 5-6 giocatori.
@@ -555,7 +555,7 @@
   <section class="state-section" aria-labelledby="s3">
     <span class="label">Stato 3 · Edge · Out of Context</span>
     <h2 id="s3">Domanda fuori contesto — Decline + suggerimento switch</h2>
-    <p class="desc">Aaron per errore chiede setup di Tainted Grail (gioco diverso, KB non collegato). L'agente declina esplicitamente, NON inventa, suggerisce di cambiare gioco o agente.</p>
+    <p class="desc">Aaron per errore chiede setup di Gloomhaven (gioco diverso, KB non collegato). L'agente declina esplicitamente, NON inventa, suggerisce di cambiare gioco o agente.</p>
 
     <div class="frames">
       <div class="phone" role="region" aria-label="Mobile – out of context">
@@ -568,13 +568,13 @@
           <button class="tab" role="tab" aria-selected="false">🧰 Toolbox</button>
         </nav>
         <div class="conv" role="log">
-          <div class="bubble user">qual è il setup ottimale di Tainted Grail?</div>
+          <div class="bubble user">qual è il setup ottimale di Gloomhaven?</div>
           <div class="bubble agent">
-            <div class="header"><span class="avatar">🤖</span><span class="name">Game Tutor</span></div>
-            <p><strong>Non ho informazioni su Tainted Grail nel mio knowledge base.</strong> Il mio scope è il gioco Eldoria (Press Start + Rules). Cosa vuoi fare?</p>
+            <div class="header"><span class="avatar">🤖</span><span class="name">Arbitro Eldoria</span></div>
+            <p><strong>Non ho informazioni su Gloomhaven nel mio knowledge base.</strong> Il mio scope è il gioco Eldoria (Press Start + Rules). Cosa vuoi fare?</p>
             <div class="out-of-context-actions">
-              <button class="action-pill" type="button" onclick="window.location.href='librogame-runthrough-game-onboarding.html'" /* DEMO-NAV */>🎲 Cambia gioco a Tainted Grail</button>
-              <button class="action-pill" type="button">🤖 Cerca un agente Tainted Grail</button>
+              <button class="action-pill" type="button" onclick="window.location.href='librogame-runthrough-game-onboarding.html'" /* DEMO-NAV */>🎲 Cambia gioco a Gloomhaven</button>
+              <button class="action-pill" type="button">🤖 Cerca un agente Gloomhaven</button>
               <button class="action-pill" type="button" onclick="window.location.href='librogame-runthrough-game-onboarding.html'" /* DEMO-NAV */>↩️ Resta su Eldoria</button>
             </div>
             <div class="conf-row">
@@ -598,18 +598,18 @@
           <aside class="desktop-side">
             <div class="game-mini"><div class="nm">🎲 Eldoria</div><div class="sub">Scope agente</div></div>
             <h4>KB collegati</h4>
-            <div style="font-size: var(--fs-xs); color: var(--text-muted); padding: var(--s-2);">📄 Press Start ✓<br/>📄 Rules ✓<br/><span style="color: hsl(var(--c-danger));">✕ NO Tainted Grail</span></div>
+            <div style="font-size: var(--fs-xs); color: var(--text-muted); padding: var(--s-2);">📄 Press Start ✓<br/>📄 Rules ✓<br/><span style="color: hsl(var(--c-danger));">✕ NO Gloomhaven</span></div>
           </aside>
           <div class="desktop-main">
-            <div class="session-head"><span class="pulse"></span><div><div class="title">Chat regole · scope: Eldoria</div><div class="sub">🤖 agente: Game Tutor</div></div></div>
+            <div class="session-head"><span class="pulse"></span><div><div class="title">Chat regole · scope: Eldoria</div><div class="sub">🤖 agente: Arbitro Eldoria</div></div></div>
             <div class="conv">
-              <div class="bubble user">qual è il setup ottimale di Tainted Grail?</div>
+              <div class="bubble user">qual è il setup ottimale di Gloomhaven?</div>
               <div class="bubble agent">
-                <div class="header"><span class="avatar">🤖</span><span class="name">Game Tutor</span></div>
-                <p><strong>Non ho informazioni su Tainted Grail nel mio knowledge base.</strong> Il mio scope è il gioco Eldoria (Press Start + Rules). Cosa vuoi fare?</p>
+                <div class="header"><span class="avatar">🤖</span><span class="name">Arbitro Eldoria</span></div>
+                <p><strong>Non ho informazioni su Gloomhaven nel mio knowledge base.</strong> Il mio scope è il gioco Eldoria (Press Start + Rules). Cosa vuoi fare?</p>
                 <div class="out-of-context-actions">
-                  <button class="action-pill">🎲 Cambia gioco a Tainted Grail</button>
-                  <button class="action-pill">🤖 Cerca un agente Tainted Grail</button>
+                  <button class="action-pill">🎲 Cambia gioco a Gloomhaven</button>
+                  <button class="action-pill">🤖 Cerca un agente Gloomhaven</button>
                   <button class="action-pill">↩️ Resta su Eldoria</button>
                 </div>
                 <div class="conf-row">
@@ -646,7 +646,7 @@
         <div class="conv" role="log" aria-live="polite" aria-busy="true">
           <div class="bubble user">come si setupa Eldoria per 4 giocatori?</div>
           <div class="bubble agent" aria-label="Agente sta scrivendo">
-            <div class="header"><span class="avatar">🤖</span><span class="name">Game Tutor</span></div>
+            <div class="header"><span class="avatar">🤖</span><span class="name">Arbitro Eldoria</span></div>
             <div class="typing" aria-hidden="true"><span></span><span></span><span></span></div>
             <div class="typing-meta">⏱️ Cerco in 24 pag · 1.8s elapsed (budget 8s)</div>
           </div>
@@ -669,7 +669,7 @@
             <div class="conv" aria-busy="true">
               <div class="bubble user">come si setupa Eldoria per 4 giocatori?</div>
               <div class="bubble agent">
-                <div class="header"><span class="avatar">🤖</span><span class="name">Game Tutor</span></div>
+                <div class="header"><span class="avatar">🤖</span><span class="name">Arbitro Eldoria</span></div>
                 <div class="typing"><span></span><span></span><span></span></div>
                 <div class="typing-meta">⏱️ Cerco in 24 pag Press Start · 1.8s / 8s budget · streaming SSE</div>
               </div>

--- a/admin-mockups/design_files/librogame-runthrough-setup-wizard.html
+++ b/admin-mockups/design_files/librogame-runthrough-setup-wizard.html
@@ -375,7 +375,7 @@
             <div style="padding: var(--s-3); background: hsl(var(--c-agent) / 0.08); border: 1px solid hsl(var(--c-agent) / 0.25); border-radius: var(--r-md); display: flex; gap: var(--s-3); align-items: flex-start;">
               <span style="font-size: 18px;">🤖</span>
               <div style="flex: 1; font-size: var(--fs-sm); color: var(--text-sec);">
-                <strong style="color: hsl(var(--c-agent)); font-family: var(--f-display);">Game Tutor</strong> consiglia <strong>4 giocatori</strong> per la prima campagna (difficoltà bilanciata).
+                <strong style="color: hsl(var(--c-agent)); font-family: var(--f-display);">Arbitro Eldoria</strong> consiglia <strong>4 giocatori</strong> per la prima campagna (difficoltà bilanciata).
               </div>
             </div>
           </div>

--- a/admin-mockups/design_files/librogame-runthrough-translate-viewer.html
+++ b/admin-mockups/design_files/librogame-runthrough-translate-viewer.html
@@ -70,7 +70,7 @@
     - sp6-libro-game-photo-upload.html — kebab ⋮ "Digita manualmente" (sez 1d Task 4)
 
   Mobile-first 375px CANONICAL (Aaron al tavolo). Desktop full parity (1280px breakpoint).
-  Narrative coherent: "Sera con i ragazzi · Runa di Ardenel · §147" — same campaign as librogame-runthrough-error-states.html (Task 1).
+  Narrative coherent: "Sera con i ragazzi · Eldoria · §147" — same campaign as librogame-runthrough-error-states.html (Task 1).
 -->
 <link rel="preconnect" href="https://fonts.googleapis.com"/>
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
@@ -1418,7 +1418,7 @@
         <div class="phone-sbar"><span>21:34</span><span>📶 🔋 78%</span></div>
         <div class="appbar">
           <button class="back">←</button>
-          <span class="crumbs"><strong>Sera con i ragazzi</strong> · Runa di Ardenel · §147</span>
+          <span class="crumbs"><strong>Sera con i ragazzi</strong> · Eldoria · §147</span>
         </div>
         <div class="loading-4step">
           <div class="step-list-v" role="status" aria-live="polite">
@@ -1452,7 +1452,7 @@
       <div class="desktop" role="region" aria-label="Desktop – step 1 upload" aria-busy="true">
         <span class="frame-label">Desktop · 1280px · step 1 (breadcrumb)</span>
         <div class="titlebar"><span class="dot r"></span><span class="dot y"></span><span class="dot g"></span><span class="url">meepleai.app/library/librogame/play/cmp-1234/translate</span></div>
-        <div class="appbar"><button class="back">←</button><span class="crumbs"><strong>Sera con i ragazzi</strong> · Runa di Ardenel · §147 · Elaborazione</span></div>
+        <div class="appbar"><button class="back">←</button><span class="crumbs"><strong>Sera con i ragazzi</strong> · Eldoria · §147 · Elaborazione</span></div>
         <div style="flex: 1; padding: var(--s-7); display: flex; flex-direction: column; gap: var(--s-5);">
           <!-- Step list orizzontale breadcrumb -->
           <div class="step-list-h" role="status" aria-live="polite">
@@ -1700,7 +1700,7 @@
         </div>
         <div class="viewer-page" role="main">
           <header class="viewer-header">
-            <div class="ch">Capitolo 4 — Runa di Ardenel</div>
+            <div class="ch">Capitolo 4 — Eldoria</div>
             <div class="pn-big">§147</div>
           </header>
           <div class="reader-mode-content" aria-live="polite">
@@ -1728,7 +1728,7 @@
         </div>
         <div class="viewer-page" role="main">
           <header class="viewer-header">
-            <div class="ch">Capitolo 4 — Runa di Ardenel</div>
+            <div class="ch">Capitolo 4 — Eldoria</div>
             <div class="pn-big">§147</div>
           </header>
           <div class="reader-mode-content reader-mode" aria-live="polite">
@@ -1813,7 +1813,7 @@
         </div>
         <div class="viewer-page" role="main">
           <header class="viewer-header">
-            <div class="ch">Capitolo 4 — Runa di Ardenel</div>
+            <div class="ch">Capitolo 4 — Eldoria</div>
             <div class="pn-big">§147</div>
           </header>
           <div class="viewer-text">
@@ -1845,7 +1845,7 @@
         </div>
         <div class="viewer-page" role="main">
           <header class="viewer-header">
-            <div class="ch">Capitolo 4 — Runa di Ardenel</div>
+            <div class="ch">Capitolo 4 — Eldoria</div>
             <div class="pn-big">§147</div>
           </header>
           <div class="viewer-text">
@@ -1879,7 +1879,7 @@
         </div>
         <div class="viewer-page" role="main">
           <header class="viewer-header">
-            <div class="ch">Capitolo 4 — Runa di Ardenel</div>
+            <div class="ch">Capitolo 4 — Eldoria</div>
             <div class="pn-big">§147</div>
           </header>
           <div class="viewer-text">
@@ -1927,7 +1927,7 @@
         </div>
         <div class="viewer-page" role="main">
           <header class="viewer-header">
-            <div class="ch">Capitolo 4 — Runa di Ardenel</div>
+            <div class="ch">Capitolo 4 — Eldoria</div>
             <div class="pn-big">§147</div>
             <span class="contrast-badge" style="margin-top: var(--s-2);">✓ AAA ≥7:1</span>
           </header>
@@ -1959,7 +1959,7 @@
         </div>
         <div class="viewer-page" style="padding: var(--s-7);">
           <header class="viewer-header">
-            <div class="ch">Capitolo 4 — Runa di Ardenel</div>
+            <div class="ch">Capitolo 4 — Eldoria</div>
             <div class="pn-big" style="font-size: 56px;">§147</div>
             <div style="display: flex; gap: var(--s-2); justify-content: center; margin-top: var(--s-2);">
               <span class="contrast-badge">✓ AAA ≥7:1</span>
@@ -2020,7 +2020,7 @@
         </div>
         <div class="viewer-page" role="main">
           <header class="viewer-header">
-            <div class="ch">Capitolo 4 — Runa di Ardenel</div>
+            <div class="ch">Capitolo 4 — Eldoria</div>
             <div class="pn-big">§147</div>
           </header>
           <div class="viewer-text" aria-live="polite">
@@ -2316,8 +2316,8 @@
                 <span class="flag">🇬🇧</span><span>EN</span><span class="chevron">▾</span>
               </button>
               <!-- Book ref chip pre-filled -->
-              <span class="book-ref-chip" aria-label="Libro corrente — Runa di Ardenel">
-                <span class="lock">🔒</span>📕 Runa di Ardenel
+              <span class="book-ref-chip" aria-label="Libro corrente — Eldoria">
+                <span class="lock">🔒</span>📕 Eldoria
               </span>
             </div>
           </div>
@@ -2364,7 +2364,7 @@
             </div>
             <div class="meta-row">
               <button class="manual-lang-dropdown" type="button"><span class="flag">🇩🇪</span><span>DE</span><span class="chevron">▾</span></button>
-              <span class="book-ref-chip"><span class="lock">🔒</span>📕 Runa di Ardenel</span>
+              <span class="book-ref-chip"><span class="lock">🔒</span>📕 Eldoria</span>
             </div>
           </div>
           <div class="manual-input-body">
@@ -2405,7 +2405,7 @@
               <button class="manual-lang-dropdown" type="button" aria-label="Lingua sorgente — 5 lingue v1: EN · FR · DE · ES · IT">
                 <span class="flag">🇬🇧</span><span>English (EN)</span><span class="chevron">▾</span>
               </button>
-              <span class="book-ref-chip"><span class="lock">🔒</span>📕 Runa di Ardenel · Sera con i ragazzi</span>
+              <span class="book-ref-chip"><span class="lock">🔒</span>📕 Eldoria · Sera con i ragazzi</span>
               <span style="margin-left: auto; font-family: var(--f-mono); font-size: 10px; color: var(--text-muted);">
                 Target lingua: <strong style="color: hsl(var(--c-game));">🇮🇹 IT</strong> (da profilo · v1 fixed)
               </span>

--- a/admin-mockups/design_files/sp6-libro-game-house-rule.jsx
+++ b/admin-mockups/design_files/sp6-libro-game-house-rule.jsx
@@ -31,7 +31,7 @@ const MANUAL_EXCERPT =
   'Quando il gruppo perde il proprio leader, lo Stato del gruppo entra in stallo ' +
   'finché Niamh non designa un nuovo portavoce secondo le regole del capitolo corrente.';
 
-// Tainted Grail rules (2) + ISS Vanguard (1) — group headers per gioco.
+// Eldoria rules (2) + ISS Vanguard (1) — group headers per gioco.
 const RULES_TG = [
   {
     id: 'r1',
@@ -163,7 +163,7 @@ function DrawerHeader({ viewport, onClose }) {
           flex: 1, minWidth: 0, fontFamily: 'var(--f-display)', fontSize: 'var(--fs-xl)',
           fontWeight: 'var(--fw-bold)', color: 'var(--text)',
         }}>House rules</h2>
-        <EntityChip entity="game" icon="🎲">Tainted Grail</EntityChip>
+        <EntityChip entity="game" icon="🎲">Eldoria</EntityChip>
         <button
           type="button"
           aria-label="Chiudi drawer house rule"
@@ -355,7 +355,7 @@ function CreateTab({ mode, value, saving }) {
               }}>Salvataggio house rule in corso</span>
             </>
           ) : (
-            isEdit ? 'Aggiorna house rule' : 'Salva house rule per Tainted Grail'
+            isEdit ? 'Aggiorna house rule' : 'Salva house rule per Eldoria'
           )}
         </button>
         <button type="button" style={{
@@ -440,7 +440,7 @@ function ListTab({ empty, highlightId }) {
           <div style={{
             fontFamily: 'var(--f-display)', fontWeight: 'var(--fw-bold)', fontSize: 'var(--fs-lg)',
             color: 'var(--text)',
-          }}>Nessuna house rule definita per Tainted Grail</div>
+          }}>Nessuna house rule definita per Eldoria</div>
           <p style={{ margin: 0, fontSize: 'var(--fs-base)', color: 'var(--text-muted)', maxWidth: 280, lineHeight: 'var(--lh-body)' }}>
             Le rules personalizzate sostituiscono o estendono il manuale ufficiale per il vostro gruppo.
           </p>
@@ -469,7 +469,7 @@ function ListTab({ empty, highlightId }) {
       id="panel-list" role="tabpanel" aria-labelledby="tab-list"
       style={{ display: 'flex', flexDirection: 'column', gap: 'var(--s-4)' }}
     >
-      <Group name="Tainted Grail" emoji="🎲" entity="game" rules={RULES_TG} />
+      <Group name="Eldoria" emoji="🎲" entity="game" rules={RULES_TG} />
       <Group name="ISS Vanguard" emoji="🎲" entity="game" rules={RULES_IV} />
     </div>
   );
@@ -673,7 +673,7 @@ function ParentChat() {
         background: 'var(--bg-card)', flexShrink: 0,
       }}>
         <span style={{ flex: 1, fontFamily: 'var(--f-display)', fontWeight: 'var(--fw-bold)', fontSize: 'var(--fs-md)' }}>
-          💬 Chat · Tainted Grail
+          💬 Chat · Eldoria
         </span>
         {/* DEC-1 entry-point secondary → apre drawer con defaultTab='list' */}
         <button type="button" aria-label="Apri house rules attive" style={{ background: 'none', border: 'none', padding: 0 }}>
@@ -832,7 +832,7 @@ const STATES = [
   { n: '05', id: 'state-05-create-saved-success', name: 'Salvato (transition)', Comp: State05_CreateSavedSuccess,
     desc: 'MAJ-1 — frame intermedio t≈600ms: Tab 1 collapsed (height auto→0) + switch a Tab 2 con rule in cima + highlight border 2px entityHsl(agent,0.6) (fade 600-2600ms) + toast entity=agent (autodismiss 3000ms).' },
   { n: '06', id: 'state-06-list-3-rules', name: 'Le tue rules · 3', Comp: State06_List3Rules,
-    desc: 'Tab Le tue rules con 3 rules: Tainted Grail (2) + ISS Vanguard (1), group header per gioco.' },
+    desc: 'Tab Le tue rules con 3 rules: Eldoria (2) + ISS Vanguard (1), group header per gioco.' },
   { n: '07', id: 'state-07-list-empty', name: 'Le tue rules · empty', Comp: State07_ListEmpty,
     desc: 'Empty state illustrato (role=status aria-live=polite) + CTA “＋ Crea la prima rule”.' },
   { n: '08', id: 'state-08-create-edit-mode-prefilled', name: 'Crea · edit', Comp: State08_CreateEditModePrefilled,
@@ -861,7 +861,7 @@ function Backdrop({ closed }) {
           background: `linear-gradient(135deg, ${entityHsl('game', 0.8)}, ${entityHsl('session', 0.5)})`,
           display: 'flex', alignItems: 'flex-end', padding: 'var(--s-2)', color: '#fff',
           fontFamily: 'var(--f-display)', fontWeight: 'var(--fw-bold)',
-        }}>§214 · Tainted Grail</div>
+        }}>§214 · Eldoria</div>
         <div style={{ height: 10, width: '90%', background: 'var(--bg-muted)', borderRadius: 4, marginBottom: 8 }} />
         <div style={{ height: 10, width: '80%', background: 'var(--bg-muted)', borderRadius: 4, marginBottom: 8 }} />
         <div style={{ height: 10, width: '85%', background: 'var(--bg-muted)', borderRadius: 4 }} />


### PR DESCRIPTION
First slice of the #2619 decomposition (SI-5). Retires the cross-mockup identity drift from the #1888 gap report — every SP6 libro-game mockup now converges on ONE canonical identity.

## Canonicalization
- **Game** → `Eldoria` (from drift: Avalon, Tainted Grail, Runa di Ardenel)
- **Studio** → `Side Room` (from drift: Side Room Studios, Mythic Games)
- **AI agent** → `Arbitro Eldoria` (from drift: Game Tutor, bare Tutor)

## Context-aware, NOT a blind rename — deliberately preserved
- `Tutorial` (PDF quick-start feature, not the agent) — word-boundary spared it
- `Spada di Avalon` (in-fiction item) — lookbehind-protected while Avalon-the-game → Eldoria
- `ISS Vanguard` (legit 2nd game in the house-rule multi-game demo)
- Discover cards Gloomhaven/Catan/Wingspan/Nanolith

## Two over-replacements caught by adversarial review + fixed
1. **error-states.html**: `Runa di Ardenel` there was the OCR'd in-fiction ITEM ("the Rune of Ardenel"), not the game → fully reverted.
2. **setup-chat.html State 3 out-of-context**: the wrong-game the agent DECLINES was collapsed to Eldoria, breaking the two-game contrast → re-anchored to Gloomhaven so the scope-decline reads correctly.

## Verification
10 files, 126/126 symmetric string-swap. 0 residual primary drift · 0 mangling (`Tutorial`/`Spada di Avalon` intact) · protect-list intact. library-search + resume-picker intentionally unchanged (already canonical / all-`Tutorial`). Workflow-audited (13 parallel readers) + 1 adversarial reviewer.

Closes #2636 · part of #2619

🤖 Generated with [Claude Code](https://claude.com/claude-code)