### PR TITLE
feat(libro-game): #2632 SI-1b Phase 1 — Session↔GamebookCampaign link + migration

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Entities/Session.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Entities/Session.cs
@@ -57,6 +57,14 @@ public class Session : IDomainEventSource
     public Guid GameId { get; private set; }
 
     /// <summary>
+    /// Optional link to the libro-game campaign this sitting advances (#2632, SI-1).
+    /// Non-null only for GameNight-attached gamebook play (D-WHEN); standalone play
+    /// stays Session-less. The persistent reading position remains in SessionBookProgress —
+    /// this Session is the spine attachment + lifecycle carrier only.
+    /// </summary>
+    public Guid? GamebookCampaignId { get; private set; }
+
+    /// <summary>
     /// Unique 6-character session code for easy sharing.
     /// </summary>
     [MaxLength(6)]
@@ -206,13 +214,15 @@ public class Session : IDomainEventSource
     /// <param name="sessionType">Session type.</param>
     /// <param name="location">Optional location.</param>
     /// <param name="sessionDate">Optional session date (defaults to now).</param>
+    /// <param name="gamebookCampaignId">Optional libro-game campaign link (#2632 SI-1); non-null only for GameNight-attached gamebook play.</param>
     /// <returns>New session instance.</returns>
     public static Session Create(
         Guid userId,
         Guid gameId,
         SessionType sessionType,
         string? location = null,
-        DateTime? sessionDate = null)
+        DateTime? sessionDate = null,
+        Guid? gamebookCampaignId = null)
     {
         if (userId == Guid.Empty)
             throw new ArgumentException("User ID cannot be empty.", nameof(userId));
@@ -225,6 +235,7 @@ public class Session : IDomainEventSource
             Id = Guid.NewGuid(),
             UserId = userId,
             GameId = gameId,
+            GamebookCampaignId = gamebookCampaignId,
             SessionCode = GenerateSessionCode(),
             SessionType = sessionType,
             Status = SessionStatus.Active,

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Persistence/Configurations/SessionConfiguration.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Persistence/Configurations/SessionConfiguration.cs
@@ -28,6 +28,12 @@ public class SessionConfiguration : IEntityTypeConfiguration<SessionEntity>
             .HasColumnName("game_id")
             .IsRequired();
 
+        // #2632 SI-1: optional link to the libro-game campaign (GameNight-attached play).
+        // Logical FK to gamebook_campaign_sessions; no hard DB constraint (cross-aggregate,
+        // nullable) — the invariant is enforced in the attach command.
+        builder.Property(s => s.GamebookCampaignId)
+            .HasColumnName("gamebook_campaign_id");
+
         builder.Property(s => s.SessionCode)
             .HasColumnName("session_code")
             .HasMaxLength(6)
@@ -136,6 +142,11 @@ public class SessionConfiguration : IEntityTypeConfiguration<SessionEntity>
             .HasDatabaseName("idx_sessions_game_date")
             .IsDescending(false, true) // DESC on SessionDate
             .HasFilter("is_deleted = false");
+
+        // #2632 SI-1: resolve a campaign's GameNight-attached sittings (the spine read path).
+        builder.HasIndex(s => s.GamebookCampaignId)
+            .HasDatabaseName("idx_sessions_gamebook_campaign")
+            .HasFilter("gamebook_campaign_id IS NOT NULL");
 
         // Relationship: Session has many Participants
         builder.HasMany(s => s.Participants)

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Persistence/SessionMapper.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Persistence/SessionMapper.cs
@@ -18,6 +18,7 @@ internal static class SessionMapper
             Id = domain.Id,
             UserId = domain.UserId,
             GameId = domain.GameId,
+            GamebookCampaignId = domain.GamebookCampaignId,
             SessionCode = domain.SessionCode,
             SessionType = domain.SessionType.ToString(),
             Status = domain.Status.ToString(),
@@ -54,6 +55,7 @@ internal static class SessionMapper
         typeof(Session).GetProperty(nameof(Session.Id))!.SetValue(session, entity.Id);
         typeof(Session).GetProperty(nameof(Session.UserId))!.SetValue(session, entity.UserId);
         typeof(Session).GetProperty(nameof(Session.GameId))!.SetValue(session, entity.GameId);
+        typeof(Session).GetProperty(nameof(Session.GamebookCampaignId))!.SetValue(session, entity.GamebookCampaignId);
         typeof(Session).GetProperty(nameof(Session.SessionCode))!.SetValue(session, entity.SessionCode);
         typeof(Session).GetProperty(nameof(Session.SessionType))!.SetValue(session, Enum.Parse<SessionType>(entity.SessionType));
         typeof(Session).GetProperty(nameof(Session.Status))!.SetValue(session, Enum.Parse<SessionStatus>(entity.Status));

--- a/apps/api/src/Api/Infrastructure/Entities/SessionTracking/SessionEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/SessionTracking/SessionEntity.cs
@@ -12,6 +12,9 @@ public class SessionEntity
     public Guid UserId { get; set; }
     public Guid? GameId { get; set; }
 
+    /// <summary>#2632 SI-1: optional link to the libro-game campaign (GameNight-attached play).</summary>
+    public Guid? GamebookCampaignId { get; set; }
+
     [MaxLength(6)]
     public string SessionCode { get; set; } = string.Empty;
 

--- a/apps/api/src/Api/Infrastructure/Migrations/20260701103136_AddSessionGamebookCampaignId.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260701103136_AddSessionGamebookCampaignId.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260701103136_AddSessionGamebookCampaignId")]
+    partial class AddSessionGamebookCampaignId
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260701103136_AddSessionGamebookCampaignId.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260701103136_AddSessionGamebookCampaignId.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSessionGamebookCampaignId : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "gamebook_campaign_id",
+                table: "session_tracking_sessions",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "idx_sessions_gamebook_campaign",
+                table: "session_tracking_sessions",
+                column: "gamebook_campaign_id",
+                filter: "gamebook_campaign_id IS NOT NULL");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "idx_sessions_gamebook_campaign",
+                table: "session_tracking_sessions");
+
+            migrationBuilder.DropColumn(
+                name: "gamebook_campaign_id",
+                table: "session_tracking_sessions");
+        }
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Domain/Entities/SessionGamebookLinkTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Domain/Entities/SessionGamebookLinkTests.cs
@@ -1,0 +1,55 @@
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SessionTracking.Domain.Entities;
+
+/// <summary>
+/// #2632 (SI-1): the optional Session -> GamebookCampaignSession link (D-LINK).
+/// A GameNight-attached gamebook sitting IS a Session that points at the persistent campaign.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SessionTracking")]
+public sealed class SessionGamebookLinkTests
+{
+    [Fact]
+    public void Create_WithGamebookCampaignId_SetsTheLink()
+    {
+        var campaignId = Guid.NewGuid();
+
+        var session = Session.Create(
+            userId: Guid.NewGuid(),
+            gameId: Guid.NewGuid(),
+            sessionType: SessionType.Generic,
+            gamebookCampaignId: campaignId);
+
+        session.GamebookCampaignId.Should().Be(campaignId);
+    }
+
+    [Fact]
+    public void Create_WithoutGamebookCampaignId_LeavesLinkNull()
+    {
+        var session = Session.Create(
+            userId: Guid.NewGuid(),
+            gameId: Guid.NewGuid(),
+            sessionType: SessionType.Generic);
+
+        session.GamebookCampaignId.Should().BeNull();
+    }
+
+    [Fact]
+    public void Create_WithGamebookLink_StillSeedsOwnerParticipant()
+    {
+        // The link must not disturb the existing owner-participant seeding.
+        var userId = Guid.NewGuid();
+
+        var session = Session.Create(
+            userId: userId,
+            gameId: Guid.NewGuid(),
+            sessionType: SessionType.Generic,
+            gamebookCampaignId: Guid.NewGuid());
+
+        session.Participants.Should().ContainSingle(p => p.IsOwner && p.UserId == userId);
+    }
+}


### PR DESCRIPTION
**SI-1b Phase 1 of 4** (foundation) for #2632, per the ratified [link architecture spec](../blob/main-dev/docs/for-developers/specs/2026-07-01-issue-2632-gamebook-gamenight-link-design.md) (D-LINK = Option A).

Establishes the nullable `Session → GamebookCampaignSession` link so a GameNight-attached gamebook sitting can *be* a `Session` pointing at its persistent campaign — the edge the spine read path needs (`campaign ← Session.GamebookCampaignId ← GameNightSession.SessionId ← GameNightEvent`).

## This PR (Phase 1 — foundation)
- `Session` aggregate: nullable `GamebookCampaignId` + optional `Create` param (default null → existing non-gamebook Sessions unchanged).
- EF: `SessionEntity` field + `SessionConfiguration` (`gamebook_campaign_id`) + **filtered index** `idx_sessions_gamebook_campaign` (`WHERE ... IS NOT NULL`) for the spine read path. Logical FK only (nullable, cross-aggregate; enforced in the Phase-2 attach command).
- `SessionMapper`: both directions.
- Migration `AddSessionGamebookCampaignId`: additive nullable column + filtered index; symmetric `Down`. **No change to `GamebookCampaignSession` schema** (honours D4).
- 3 domain unit tests (link set / null default / owner-participant seeding unaffected). Build clean.

## Remaining SI-1b phases (follow-up)
- **Phase 2** — attach+start command (thread `CreateSessionCommand.GamebookCampaignId`; guard `GameRef.Kind==Shared` + ownership; replicate `AddSession→StartCurrentSession` so #15/#10 fire; endpoint) + unit/integration tests.
- **Phase 3** — derived campaign-status query (in-progress/resumable/completed from Sessions).
- **Phase 4** — FE "Serata" spine strip (renders only when GameNight-attached).

Non-breaking, additive. Refs #2632 · part of #2619

🤖 Generated with [Claude Code](https://claude.com/claude-code)