### PR TITLE
feat(libro-game): #2632 SI-1b Phase 2 — attach gamebook campaign to GameNight

### DIFF
--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/AttachGamebookCampaignToGameNightCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/AttachGamebookCampaignToGameNightCommand.cs
@@ -1,0 +1,37 @@
+using Api.SharedKernel.Application.Interfaces;
+using FluentValidation;
+
+namespace Api.BoundedContexts.GameManagement.Application.Commands.GameNights;
+
+/// <summary>
+/// #2632 (SI-1b): attaches a libro-game campaign to a <c>Published</c> GameNight as a new
+/// live sitting. Creates a SessionTracking <c>Session</c> linked to the campaign
+/// (<c>GamebookCampaignId</c>), adds a <c>GameNightSession</c>, and starts it — so the #15
+/// promotion + #10 max-1-live guard fire through the existing GameNight machinery
+/// (the guard lives in <c>StartCurrentSession()</c>, hence the <c>AddSession → StartCurrentSession</c>
+/// sequence must both run). Limited to shared-game campaigns (D-SHARED): a private-game
+/// campaign cannot become a Session because <c>Session.GameId</c> FK-restricts to shared_games.
+/// </summary>
+internal record AttachGamebookCampaignToGameNightCommand(
+    Guid GameNightId,
+    Guid CampaignId,
+    Guid CallerUserId
+) : ICommand<AttachGamebookCampaignToGameNightResult>;
+
+/// <summary>Result of <see cref="AttachGamebookCampaignToGameNightCommand"/>.</summary>
+internal record AttachGamebookCampaignToGameNightResult(
+    Guid SessionId,
+    Guid GameNightSessionId,
+    string SessionCode,
+    int PlayOrder);
+
+internal sealed class AttachGamebookCampaignToGameNightCommandValidator
+    : AbstractValidator<AttachGamebookCampaignToGameNightCommand>
+{
+    public AttachGamebookCampaignToGameNightCommandValidator()
+    {
+        RuleFor(x => x.GameNightId).NotEmpty();
+        RuleFor(x => x.CampaignId).NotEmpty();
+        RuleFor(x => x.CallerUserId).NotEmpty();
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/AttachGamebookCampaignToGameNightCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/AttachGamebookCampaignToGameNightCommandHandler.cs
@@ -1,3 +1,4 @@
+using Api.BoundedContexts.Authentication.Application.Queries;
 using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
 using Api.BoundedContexts.SessionTracking.Application.Commands;
 using Api.BoundedContexts.SessionTracking.Application.DTOs;
@@ -60,6 +61,12 @@ internal sealed class AttachGamebookCampaignToGameNightCommandHandler
         if (gameNight.OrganizerId != command.CallerUserId)
             throw new ForbiddenException("Only the organizer can attach a campaign to this game night.");
 
+        // Resolve the caller's real display name (mirrors StartGameNightSessionCommandHandler);
+        // a hardcoded literal would persist to session_participants and surface in the player list.
+        var caller = await _mediator.Send(new GetUserByIdQuery(command.CallerUserId), cancellationToken).ConfigureAwait(false)
+            ?? throw new NotFoundException("User", command.CallerUserId.ToString());
+        var displayName = !string.IsNullOrWhiteSpace(caller.DisplayName) ? caller.DisplayName : caller.Email;
+
         // Seed the caller as the sole owner participant (a gamebook sitting is typically solo).
         var participants = new List<ParticipantDto>
         {
@@ -67,7 +74,7 @@ internal sealed class AttachGamebookCampaignToGameNightCommandHandler
             {
                 Id = Guid.NewGuid(),
                 UserId = command.CallerUserId,
-                DisplayName = "Owner",
+                DisplayName = displayName,
                 IsOwner = true,
                 JoinOrder = 0
             }
@@ -102,8 +109,9 @@ internal sealed class AttachGamebookCampaignToGameNightCommandHandler
         }
         catch (InvalidOperationException ex)
         {
-            // AddSession (not Published) and StartCurrentSession (#10) throw InvalidOperationException /
-            // MaxLiveSessionsExceededException → surface as 409 Conflict.
+            // AddSession's "not Published" guard throws a plain InvalidOperationException → wrap as 409.
+            // (StartCurrentSession's #10 guard throws MaxLiveSessionsExceededException, which already
+            // IS a ConflictException and maps to 409 via middleware — it propagates past this catch.)
             throw new ConflictException(ex.Message);
         }
     }

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/AttachGamebookCampaignToGameNightCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/AttachGamebookCampaignToGameNightCommandHandler.cs
@@ -1,0 +1,110 @@
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.BoundedContexts.SessionTracking.Application.Commands;
+using Api.BoundedContexts.SessionTracking.Application.DTOs;
+using Api.BoundedContexts.SessionTracking.Application.Queries;
+using Api.BoundedContexts.SessionTracking.Domain.Services;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Domain.ValueObjects;
+using Api.SharedKernel.Infrastructure.Persistence;
+using MediatR;
+
+namespace Api.BoundedContexts.GameManagement.Application.Commands.GameNights;
+
+/// <summary>
+/// Handles <see cref="AttachGamebookCampaignToGameNightCommand"/> — the "writer" of the
+/// Session ↔ GamebookCampaign link (#2632 SI-1b). Mirrors <see cref="StartGameNightSessionCommandHandler"/>:
+/// dispatches <see cref="CreateSessionCommand"/> to SessionTracking (now carrying the campaign link),
+/// then attaches + starts the resulting session on the GameNight aggregate so #15/#10 fire.
+/// </summary>
+internal sealed class AttachGamebookCampaignToGameNightCommandHandler
+    : ICommandHandler<AttachGamebookCampaignToGameNightCommand, AttachGamebookCampaignToGameNightResult>
+{
+    private readonly IGameNightEventRepository _repository;
+    private readonly IMediator _mediator;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly IAutoSaveSchedulerService _autoSaveScheduler;
+
+    public AttachGamebookCampaignToGameNightCommandHandler(
+        IGameNightEventRepository repository,
+        IMediator mediator,
+        IUnitOfWork unitOfWork,
+        IAutoSaveSchedulerService autoSaveScheduler)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+        _autoSaveScheduler = autoSaveScheduler ?? throw new ArgumentNullException(nameof(autoSaveScheduler));
+    }
+
+    public async Task<AttachGamebookCampaignToGameNightResult> Handle(
+        AttachGamebookCampaignToGameNightCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        // Load the campaign; the query throws NotFound if missing and Forbidden if the caller
+        // is not the campaign owner (ownership guard is handled there).
+        var campaign = await _mediator.Send(
+            new GetGamebookCampaignQuery(command.CampaignId, command.CallerUserId), cancellationToken)
+            .ConfigureAwait(false);
+
+        // D-SHARED: only shared-game campaigns can be played in a GameNight — Session.GameId
+        // FK-restricts to shared_games, so a private-game campaign would violate the FK.
+        if (campaign.GameRefKind != (int)GameRefKind.Shared)
+            throw new ConflictException(
+                "Only shared-game libro-game campaigns can be played in a game night.");
+
+        var gameNight = await _repository.GetByIdAsync(command.GameNightId, cancellationToken).ConfigureAwait(false)
+            ?? throw new NotFoundException("GameNightEvent", command.GameNightId.ToString());
+
+        if (gameNight.OrganizerId != command.CallerUserId)
+            throw new ForbiddenException("Only the organizer can attach a campaign to this game night.");
+
+        // Seed the caller as the sole owner participant (a gamebook sitting is typically solo).
+        var participants = new List<ParticipantDto>
+        {
+            new()
+            {
+                Id = Guid.NewGuid(),
+                UserId = command.CallerUserId,
+                DisplayName = "Owner",
+                IsOwner = true,
+                JoinOrder = 0
+            }
+        };
+
+        // Cross-BC: create the Session carrying the campaign link. GameNight linkage is done
+        // below via AddSession (mirroring StartGameNightSessionCommandHandler, which also leaves
+        // CreateSessionCommand.GameNightEventId null and links via the aggregate).
+        var createResult = await _mediator.Send(new CreateSessionCommand(
+            command.CallerUserId,
+            campaign.GameRefId,
+            "GameSpecific",
+            DateTime.UtcNow,
+            null,
+            participants,
+            GamebookCampaignId: command.CampaignId), cancellationToken).ConfigureAwait(false);
+
+        try
+        {
+            // Both calls are required: AddSession registers the sitting; StartCurrentSession is
+            // where the #10 max-1-live guard lives (throws MaxLiveSessionsExceededException).
+            var gns = gameNight.AddSession(createResult.SessionId, campaign.GameRefId, campaign.Title);
+            gameNight.StartCurrentSession();
+
+            await _repository.UpdateAsync(gameNight, cancellationToken).ConfigureAwait(false);
+            await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+            await _autoSaveScheduler.RegisterAsync(createResult.SessionId, cancellationToken).ConfigureAwait(false);
+
+            return new AttachGamebookCampaignToGameNightResult(
+                createResult.SessionId, gns.Id, createResult.SessionCode, gns.PlayOrder);
+        }
+        catch (InvalidOperationException ex)
+        {
+            // AddSession (not Published) and StartCurrentSession (#10) throw InvalidOperationException /
+            // MaxLiveSessionsExceededException → surface as 409 Conflict.
+            throw new ConflictException(ex.Message);
+        }
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/CreateSessionCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/CreateSessionCommand.cs
@@ -22,7 +22,8 @@ public record CreateSessionCommand(
     List<ParticipantDto> Participants,
     Guid? GameNightEventId = null,
     IReadOnlyList<string>? GuestNames = null,
-    GameStateTier StateTier = GameStateTier.Minimal
+    GameStateTier StateTier = GameStateTier.Minimal,
+    Guid? GamebookCampaignId = null
 ) : ICommand<CreateSessionResult>;
 
 /// <summary>

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/CreateSessionCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/CreateSessionCommandHandler.cs
@@ -105,7 +105,8 @@ public class CreateSessionCommandHandler : ICommandHandler<CreateSessionCommand,
                 request.GameId,
                 sessionType,
                 request.Location,
-                request.SessionDate);
+                request.SessionDate,
+                request.GamebookCampaignId);
 
             // Populate participants on the domain aggregate BEFORE persisting so that
             // SessionRepository.AddAsync maps the full graph in a single insert — this keeps

--- a/apps/api/src/Api/Routing/GameNightEndpoints.cs
+++ b/apps/api/src/Api/Routing/GameNightEndpoints.cs
@@ -195,6 +195,19 @@ internal static class GameNightEndpoints
             .WithSummary("Start next game in the night")
             .WithDescription("Creates and starts a new game session within the game night. Only the organizer can start sessions.");
 
+        // #2632 (SI-1b): attach a libro-game campaign to a Published game night as a live sitting.
+        gameNights.MapPost("/{id:guid}/gamebook-sessions", HandleAttachGamebookCampaign)
+            .RequireAuthenticatedUser()
+            .Produces<AttachGamebookCampaignToGameNightResult>(201)
+            .Produces(400)
+            .Produces(403)
+            .Produces(404)
+            .Produces(409)
+            .Produces(401)
+            .WithName("AttachGamebookCampaignToGameNight")
+            .WithSummary("Play a libro-game campaign in the night")
+            .WithDescription("Creates a Session linked to the libro-game campaign and starts it within the game night (#15 promotion + #10 max-1-live apply). Only the organizer can attach; shared-game campaigns only.");
+
         gameNights.MapPost("/{id:guid}/sessions/complete", HandleCompleteGameNightSession)
             .RequireAuthenticatedUser()
             .Produces(204)
@@ -421,6 +434,24 @@ internal static class GameNightEndpoints
         return Results.Created($"/api/v1/game-nights/{id}/sessions/{result.GameNightSessionId}", result);
     }
 
+    private static async Task<IResult> HandleAttachGamebookCampaign(
+        Guid id,
+        [FromBody] AttachGamebookCampaignRequest request,
+        [FromServices] IMediator mediator,
+        HttpContext httpContext,
+        CancellationToken cancellationToken)
+    {
+        var userId = httpContext.User.GetUserId();
+
+        var command = new AttachGamebookCampaignToGameNightCommand(
+            GameNightId: id,
+            CampaignId: request.CampaignId,
+            CallerUserId: userId);
+
+        var result = await mediator.Send(command, cancellationToken).ConfigureAwait(false);
+        return Results.Created($"/api/v1/game-nights/{id}/sessions/{result.GameNightSessionId}", result);
+    }
+
     private static async Task<IResult> HandleCompleteGameNightSession(
         Guid id,
         [FromBody] CompleteGameNightSessionRequest? request,
@@ -604,6 +635,7 @@ internal static class GameNightEndpoints
 
     // Game Night Experience v2 request records
     private sealed record StartGameNightSessionRequest(Guid GameId, string GameTitle);
+    private sealed record AttachGamebookCampaignRequest(Guid CampaignId);
     private sealed record CompleteGameNightSessionRequest(Guid? WinnerId);
 
     #endregion

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/GameNight/AttachGamebookCampaignToGameNightCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/GameNight/AttachGamebookCampaignToGameNightCommandHandlerTests.cs
@@ -1,0 +1,186 @@
+using Api.BoundedContexts.GameManagement.Application.Commands.GameNights;
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+using Api.BoundedContexts.SessionTracking.Application.Commands;
+using Api.BoundedContexts.SessionTracking.Application.DTOs;
+using Api.BoundedContexts.SessionTracking.Application.Queries;
+using Api.BoundedContexts.SessionTracking.Domain.Services;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Domain.ValueObjects;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Tests.Constants;
+using FluentAssertions;
+using MediatR;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Application.GameNight;
+
+/// <summary>
+/// #2632 (SI-1b): the attach-and-start "writer" of the Session ↔ GamebookCampaign link.
+/// Guards (shared-only, organizer), cross-BC dispatch, and the AddSession → StartCurrentSession sequence.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "GameManagement")]
+public class AttachGamebookCampaignToGameNightCommandHandlerTests
+{
+    private readonly Mock<IGameNightEventRepository> _repo = new();
+    private readonly Mock<IMediator> _mediator = new();
+    private readonly Mock<IUnitOfWork> _uow = new();
+    private readonly Mock<IAutoSaveSchedulerService> _autoSave = new();
+    private readonly AttachGamebookCampaignToGameNightCommandHandler _handler;
+
+    public AttachGamebookCampaignToGameNightCommandHandlerTests()
+    {
+        _handler = new AttachGamebookCampaignToGameNightCommandHandler(
+            _repo.Object, _mediator.Object, _uow.Object, _autoSave.Object);
+    }
+
+    private static GameNightEvent CreatePublishedEvent(Guid organizerId)
+    {
+        var evt = GameNightEvent.Create(
+            organizerId, "Serata da Marco", DateTimeOffset.UtcNow.AddHours(1),
+            gameIds: [Guid.NewGuid()]);
+        evt.Publish([]);
+        return evt;
+    }
+
+    private static GamebookCampaignDto CampaignDto(Guid campaignId, Guid gameId, Guid ownerId, GameRefKind kind)
+        => new(
+            Id: campaignId,
+            GameRefId: gameId,
+            GameRefKind: (int)kind,
+            OwnerUserId: ownerId,
+            Title: "La Runa di Eldoria",
+            CurrentParagraph: 0,
+            History: Array.Empty<int>(),
+            LastReadAt: DateTimeOffset.UtcNow,
+            CreatedAt: DateTimeOffset.UtcNow,
+            UpdatedAt: DateTimeOffset.UtcNow);
+
+    private void SetupCampaign(Guid campaignId, GamebookCampaignDto dto)
+        => _mediator
+            .Setup(m => m.Send(It.Is<GetGamebookCampaignQuery>(q => q.CampaignId == campaignId), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(dto);
+
+    private void SetupCreateSession(Guid sessionId, string code = "ABC123")
+        => _mediator
+            .Setup(m => m.Send(It.IsAny<CreateSessionCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new CreateSessionResult(sessionId, code, [], Guid.Empty, false, null, null));
+
+    [Fact]
+    public async Task Handle_SharedCampaign_CreatesLinkedSessionAndStarts()
+    {
+        var organizer = Guid.NewGuid();
+        var gameNight = CreatePublishedEvent(organizer);
+        var campaignId = Guid.NewGuid();
+        var sessionId = Guid.NewGuid();
+        SetupCampaign(campaignId, CampaignDto(campaignId, Guid.NewGuid(), organizer, GameRefKind.Shared));
+        SetupCreateSession(sessionId);
+        _repo.Setup(r => r.GetByIdAsync(gameNight.Id, It.IsAny<CancellationToken>())).ReturnsAsync(gameNight);
+
+        var result = await _handler.Handle(
+            new AttachGamebookCampaignToGameNightCommand(gameNight.Id, campaignId, organizer),
+            TestContext.Current.CancellationToken);
+
+        result.SessionId.Should().Be(sessionId);
+        result.SessionCode.Should().Be("ABC123");
+        result.PlayOrder.Should().Be(1);
+        gameNight.Sessions.Should().ContainSingle();
+        gameNight.Sessions[0].Status.Should().Be(GameNightSessionStatus.InProgress);
+        _repo.Verify(r => r.UpdateAsync(gameNight, It.IsAny<CancellationToken>()), Times.Once);
+        _uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_DispatchesCreateSessionCarryingTheCampaignLink()
+    {
+        var organizer = Guid.NewGuid();
+        var gameNight = CreatePublishedEvent(organizer);
+        var campaignId = Guid.NewGuid();
+        var gameId = Guid.NewGuid();
+        SetupCampaign(campaignId, CampaignDto(campaignId, gameId, organizer, GameRefKind.Shared));
+        SetupCreateSession(Guid.NewGuid());
+        _repo.Setup(r => r.GetByIdAsync(gameNight.Id, It.IsAny<CancellationToken>())).ReturnsAsync(gameNight);
+
+        await _handler.Handle(
+            new AttachGamebookCampaignToGameNightCommand(gameNight.Id, campaignId, organizer),
+            TestContext.Current.CancellationToken);
+
+        _mediator.Verify(m => m.Send(
+            It.Is<CreateSessionCommand>(c =>
+                c.GamebookCampaignId == campaignId &&
+                c.GameId == gameId &&
+                c.UserId == organizer &&
+                c.Participants.Count == 1 &&
+                c.Participants[0].IsOwner),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_PrivateGameCampaign_ThrowsConflict_AndDoesNotCreateSession()
+    {
+        var organizer = Guid.NewGuid();
+        var campaignId = Guid.NewGuid();
+        SetupCampaign(campaignId, CampaignDto(campaignId, Guid.NewGuid(), organizer, GameRefKind.Private));
+
+        var act = () => _handler.Handle(
+            new AttachGamebookCampaignToGameNightCommand(Guid.NewGuid(), campaignId, organizer),
+            TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<ConflictException>();
+        _mediator.Verify(m => m.Send(It.IsAny<CreateSessionCommand>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_NonOrganizer_ThrowsForbidden_AndDoesNotCreateSession()
+    {
+        var organizer = Guid.NewGuid();
+        var caller = Guid.NewGuid();
+        var gameNight = CreatePublishedEvent(organizer);
+        var campaignId = Guid.NewGuid();
+        // The campaign is owned by the caller (query passes) but the caller is not the GameNight organizer.
+        SetupCampaign(campaignId, CampaignDto(campaignId, Guid.NewGuid(), caller, GameRefKind.Shared));
+        _repo.Setup(r => r.GetByIdAsync(gameNight.Id, It.IsAny<CancellationToken>())).ReturnsAsync(gameNight);
+
+        var act = () => _handler.Handle(
+            new AttachGamebookCampaignToGameNightCommand(gameNight.Id, campaignId, caller),
+            TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<ForbiddenException>();
+        _mediator.Verify(m => m.Send(It.IsAny<CreateSessionCommand>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_GameNightNotFound_ThrowsNotFound()
+    {
+        var organizer = Guid.NewGuid();
+        var campaignId = Guid.NewGuid();
+        var gnId = Guid.NewGuid();
+        SetupCampaign(campaignId, CampaignDto(campaignId, Guid.NewGuid(), organizer, GameRefKind.Shared));
+        _repo.Setup(r => r.GetByIdAsync(gnId, It.IsAny<CancellationToken>())).ReturnsAsync((GameNightEvent?)null);
+
+        var act = () => _handler.Handle(
+            new AttachGamebookCampaignToGameNightCommand(gnId, campaignId, organizer),
+            TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+
+    [Fact]
+    public async Task Handle_CampaignQueryThrows_Propagates_AndDoesNotTouchGameNight()
+    {
+        var organizer = Guid.NewGuid();
+        var campaignId = Guid.NewGuid();
+        _mediator
+            .Setup(m => m.Send(It.IsAny<GetGamebookCampaignQuery>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new NotFoundException("Campaign", campaignId.ToString()));
+
+        var act = () => _handler.Handle(
+            new AttachGamebookCampaignToGameNightCommand(Guid.NewGuid(), campaignId, organizer),
+            TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<NotFoundException>();
+        _repo.Verify(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/GameNight/AttachGamebookCampaignToGameNightCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/GameNight/AttachGamebookCampaignToGameNightCommandHandlerTests.cs
@@ -1,3 +1,5 @@
+using Api.BoundedContexts.Authentication.Application.DTOs;
+using Api.BoundedContexts.Authentication.Application.Queries;
 using Api.BoundedContexts.GameManagement.Application.Commands.GameNights;
 using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
 using Api.BoundedContexts.GameManagement.Domain.Enums;
@@ -68,6 +70,26 @@ public class AttachGamebookCampaignToGameNightCommandHandlerTests
             .Setup(m => m.Send(It.IsAny<CreateSessionCommand>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new CreateSessionResult(sessionId, code, [], Guid.Empty, false, null, null));
 
+    private void SetupUser(Guid userId, string displayName)
+        => _mediator
+            .Setup(m => m.Send(It.Is<GetUserByIdQuery>(q => q.UserId == userId), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new UserDto(
+                Id: userId,
+                Email: "player@example.com",
+                DisplayName: displayName,
+                Role: "User",
+                Tier: "Free",
+                CreatedAt: DateTime.UtcNow,
+                IsTwoFactorEnabled: false,
+                TwoFactorEnabledAt: null,
+                Level: 1,
+                ExperiencePoints: 0,
+                EmailVerified: true,
+                EmailVerifiedAt: DateTime.UtcNow,
+                VerificationGracePeriodEndsAt: null,
+                OnboardingCompleted: true,
+                OnboardingSkipped: false));
+
     [Fact]
     public async Task Handle_SharedCampaign_CreatesLinkedSessionAndStarts()
     {
@@ -77,6 +99,7 @@ public class AttachGamebookCampaignToGameNightCommandHandlerTests
         var sessionId = Guid.NewGuid();
         SetupCampaign(campaignId, CampaignDto(campaignId, Guid.NewGuid(), organizer, GameRefKind.Shared));
         SetupCreateSession(sessionId);
+        SetupUser(organizer, "Marco Rossi");
         _repo.Setup(r => r.GetByIdAsync(gameNight.Id, It.IsAny<CancellationToken>())).ReturnsAsync(gameNight);
 
         var result = await _handler.Handle(
@@ -101,6 +124,7 @@ public class AttachGamebookCampaignToGameNightCommandHandlerTests
         var gameId = Guid.NewGuid();
         SetupCampaign(campaignId, CampaignDto(campaignId, gameId, organizer, GameRefKind.Shared));
         SetupCreateSession(Guid.NewGuid());
+        SetupUser(organizer, "Marco Rossi");
         _repo.Setup(r => r.GetByIdAsync(gameNight.Id, It.IsAny<CancellationToken>())).ReturnsAsync(gameNight);
 
         await _handler.Handle(
@@ -113,7 +137,8 @@ public class AttachGamebookCampaignToGameNightCommandHandlerTests
                 c.GameId == gameId &&
                 c.UserId == organizer &&
                 c.Participants.Count == 1 &&
-                c.Participants[0].IsOwner),
+                c.Participants[0].IsOwner &&
+                c.Participants[0].DisplayName == "Marco Rossi"),
             It.IsAny<CancellationToken>()), Times.Once);
     }
 


### PR DESCRIPTION
**SI-1b Phase 2 of 4** for #2632 — the *writer* of the `Session.GamebookCampaignId` link (Phase 1 #2643). Plays a libro-game campaign as a live sitting within a `Published` GameNight.

## Changes
- `CreateSessionCommand` + handler: thread nullable `GamebookCampaignId` → `Session.Create` (default null; existing flows unchanged — 37 regression tests green).
- `AttachGamebookCampaignToGameNightCommand` + Result + Validator + Handler. Mirrors `StartGameNightSessionCommandHandler`: loads the campaign via `GetGamebookCampaignQuery` (enforces NotFound + owner-Forbidden), **guards `GameRefKind==Shared`** (D-SHARED → else 409; a private-game campaign can't be a Session — FK to shared_games), organizer guard, resolves the caller's real display name, dispatches `CreateSessionCommand(GamebookCampaignId=…)`, then `AddSession → StartCurrentSession` so #15 promotion + #10 max-1-live fire through the existing guard.
- Endpoint `POST /api/v1/game-nights/{id}/gamebook-sessions` (201/400/403/404/409/401).

## Tests
6 handler unit tests (shared happy-path + InProgress + link-carry + resolved display name, private→409, non-organizer→403, GN-not-found→404, campaign-query-throws propagates). 37 regression tests (StartGameNightSession + CreateSession + Phase 1) green.

## Review
`feature-dev:code-reviewer` adversarial pass — structure confirmed correct (#10/#15 sequencing, D-SHARED guard, exception hierarchy, param safety). 1 real bug caught + fixed: hardcoded `"Owner"` display name → real user lookup.

Remaining: Phase 3 (derived status query) · Phase 4 (FE Serata spine strip). Refs #2632 · part of #2619

🤖 Generated with [Claude Code](https://claude.com/claude-code)