### PR TITLE
feat(libro-game): #2632 SI-1b Phase 3 — gamebook campaign spine read path

### DIFF
--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNight/GetGamebookCampaignSpineQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNight/GetGamebookCampaignSpineQuery.cs
@@ -1,0 +1,26 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.GameManagement.Application.Queries.GameNight;
+
+/// <summary>
+/// #2632 (SI-1b, Phase 3): the spine read path. Given a libro-game campaign, returns the owning
+/// GameNight "Serata" spine (title, organizer, status, session pip) plus the derived campaign
+/// status — or <c>null</c> when the campaign has no GameNight-attached play (standalone, no spine).
+/// </summary>
+internal sealed record GetGamebookCampaignSpineQuery(Guid CampaignId, Guid CallerUserId)
+    : IQuery<GamebookCampaignSpineDto?>;
+
+/// <summary>
+/// The "Serata" spine for a libro-game campaign. <see cref="CampaignStatus"/> is derived
+/// ("InProgress" when a live sitting exists, else "Resumable"; "Completed" is a future manual
+/// flag from SI-8). Session pip = <see cref="CompletedSessions"/> of <see cref="TotalSessions"/>.
+/// </summary>
+internal sealed record GamebookCampaignSpineDto(
+    Guid GameNightId,
+    string GameNightTitle,
+    Guid OrganizerId,
+    string GameNightStatus,
+    int TotalSessions,
+    int CompletedSessions,
+    bool HasLiveSession,
+    string CampaignStatus);

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNight/GetGamebookCampaignSpineQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNight/GetGamebookCampaignSpineQueryHandler.cs
@@ -29,41 +29,49 @@ internal sealed class GetGamebookCampaignSpineQueryHandler
     {
         ArgumentNullException.ThrowIfNull(request);
 
-        // Ownership + existence are enforced inside ListGamebookCampaignSessionsQuery.
-        var sittings = await _mediator.Send(
+        // Ownership + existence are enforced inside ListGamebookCampaignSessionsQuery (fires even for
+        // a zero-sitting standalone campaign, so a non-owner can't probe existence via this endpoint).
+        var sessionIds = await _mediator.Send(
             new ListGamebookCampaignSessionsQuery(request.CampaignId, request.CallerUserId), cancellationToken)
             .ConfigureAwait(false);
 
-        if (sittings.Count == 0)
+        if (sessionIds.Count == 0)
             return null; // never played → no spine
 
-        var hasLiveSession = sittings.Any(s => s.IsLive);
-
-        // Prefer the live sitting; otherwise the most-recently started. Resolve the first sitting
-        // that actually resolves to an owning GameNight (all attach-created sittings do).
-        var ordered = sittings
-            .OrderByDescending(s => s.IsLive)
-            .ThenByDescending(s => s.StartedAt)
-            .ToList();
-
-        Domain.Entities.GameNightEvent.GameNightEvent? gameNight = null;
-        foreach (var sitting in ordered)
+        // Resolve each linked Session to its owning GameNight + that night's GameNightSession (the
+        // authoritative liveness/timing carrier — Session.StartedAt is never set outside OpenLiveMode).
+        var resolved = new List<(Domain.Entities.GameNightEvent.GameNightEvent Night, GameNightSession Sitting)>();
+        foreach (var sessionId in sessionIds)
         {
-            gameNight = await _repository
-                .FindByLinkedSessionIdAsync(sitting.SessionId, cancellationToken)
+            var night = await _repository
+                .FindByLinkedSessionIdAsync(sessionId, cancellationToken)
                 .ConfigureAwait(false);
-            if (gameNight is not null)
-                break;
+            var sitting = night?.Sessions.FirstOrDefault(x => x.SessionId == sessionId);
+            if (night is not null && sitting is not null)
+                resolved.Add((night, sitting));
         }
 
-        if (gameNight is null)
+        if (resolved.Count == 0)
             return null; // sittings exist but none is GameNight-attached (standalone)
+
+        var hasLiveSession = resolved.Any(r => r.Sitting.Status == GameNightSessionStatus.InProgress);
+
+        // Prefer the live sitting's night; else the most-recently started (Pending → null → last).
+        var chosen = resolved
+            .OrderByDescending(r => r.Sitting.Status == GameNightSessionStatus.InProgress)
+            .ThenByDescending(r => r.Sitting.StartedAt ?? DateTimeOffset.MinValue)
+            .First();
+        var gameNight = chosen.Night;
 
         return new GamebookCampaignSpineDto(
             GameNightId: gameNight.Id,
             GameNightTitle: gameNight.Title,
             OrganizerId: gameNight.OrganizerId,
             GameNightStatus: gameNight.Status.ToString(),
+            // Pip is the whole "Serata" (all games that evening), matching the demo strip — not just
+            // this campaign's sitting. See #2632 note: the GameNight Published->InProgress promotion
+            // (#15) is a pre-existing gap (SessionStartedDomainEvent is never raised), so GameNightStatus
+            // may read "Published" during play; CampaignStatus below uses the authoritative sitting status.
             TotalSessions: gameNight.Sessions.Count,
             CompletedSessions: gameNight.Sessions.Count(s => s.Status == GameNightSessionStatus.Completed),
             HasLiveSession: hasLiveSession,

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNight/GetGamebookCampaignSpineQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNight/GetGamebookCampaignSpineQueryHandler.cs
@@ -1,0 +1,72 @@
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+using Api.BoundedContexts.SessionTracking.Application.Queries;
+using Api.SharedKernel.Application.Interfaces;
+using MediatR;
+
+namespace Api.BoundedContexts.GameManagement.Application.Queries.GameNight;
+
+/// <summary>
+/// Handles <see cref="GetGamebookCampaignSpineQuery"/>. Reads the campaign's sittings (cross-BC via
+/// <see cref="ListGamebookCampaignSessionsQuery"/>, which enforces ownership), resolves the owning
+/// GameNight via <see cref="IGameNightEventRepository.FindByLinkedSessionIdAsync"/>, and assembles
+/// the spine. Returns null when the campaign has no GameNight-attached play (standalone).
+/// </summary>
+internal sealed class GetGamebookCampaignSpineQueryHandler
+    : IQueryHandler<GetGamebookCampaignSpineQuery, GamebookCampaignSpineDto?>
+{
+    private readonly IMediator _mediator;
+    private readonly IGameNightEventRepository _repository;
+
+    public GetGamebookCampaignSpineQueryHandler(IMediator mediator, IGameNightEventRepository repository)
+    {
+        _mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+    }
+
+    public async Task<GamebookCampaignSpineDto?> Handle(
+        GetGamebookCampaignSpineQuery request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        // Ownership + existence are enforced inside ListGamebookCampaignSessionsQuery.
+        var sittings = await _mediator.Send(
+            new ListGamebookCampaignSessionsQuery(request.CampaignId, request.CallerUserId), cancellationToken)
+            .ConfigureAwait(false);
+
+        if (sittings.Count == 0)
+            return null; // never played → no spine
+
+        var hasLiveSession = sittings.Any(s => s.IsLive);
+
+        // Prefer the live sitting; otherwise the most-recently started. Resolve the first sitting
+        // that actually resolves to an owning GameNight (all attach-created sittings do).
+        var ordered = sittings
+            .OrderByDescending(s => s.IsLive)
+            .ThenByDescending(s => s.StartedAt)
+            .ToList();
+
+        Domain.Entities.GameNightEvent.GameNightEvent? gameNight = null;
+        foreach (var sitting in ordered)
+        {
+            gameNight = await _repository
+                .FindByLinkedSessionIdAsync(sitting.SessionId, cancellationToken)
+                .ConfigureAwait(false);
+            if (gameNight is not null)
+                break;
+        }
+
+        if (gameNight is null)
+            return null; // sittings exist but none is GameNight-attached (standalone)
+
+        return new GamebookCampaignSpineDto(
+            GameNightId: gameNight.Id,
+            GameNightTitle: gameNight.Title,
+            OrganizerId: gameNight.OrganizerId,
+            GameNightStatus: gameNight.Status.ToString(),
+            TotalSessions: gameNight.Sessions.Count,
+            CompletedSessions: gameNight.Sessions.Count(s => s.Status == GameNightSessionStatus.Completed),
+            HasLiveSession: hasLiveSession,
+            CampaignStatus: hasLiveSession ? "InProgress" : "Resumable");
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/ListGamebookCampaignSessionsHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/ListGamebookCampaignSessionsHandler.cs
@@ -5,11 +5,11 @@ namespace Api.BoundedContexts.SessionTracking.Application.Queries;
 
 /// <summary>
 /// Handles <see cref="ListGamebookCampaignSessionsQuery"/>. Enforces ownership by delegating to
-/// <see cref="GetGamebookCampaignQuery"/> (which throws NotFound / Forbidden), then projects the
-/// campaign's Sessions to the spine-relevant <see cref="GamebookSittingDto"/>.
+/// <see cref="GetGamebookCampaignQuery"/> (which throws NotFound / Forbidden), then returns the
+/// campaign's linked Session IDs.
 /// </summary>
 public sealed class ListGamebookCampaignSessionsHandler
-    : IRequestHandler<ListGamebookCampaignSessionsQuery, IReadOnlyList<GamebookSittingDto>>
+    : IRequestHandler<ListGamebookCampaignSessionsQuery, IReadOnlyList<Guid>>
 {
     private readonly ISessionRepository _sessions;
     private readonly IMediator _mediator;
@@ -20,12 +20,13 @@ public sealed class ListGamebookCampaignSessionsHandler
         _mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
     }
 
-    public async Task<IReadOnlyList<GamebookSittingDto>> Handle(
+    public async Task<IReadOnlyList<Guid>> Handle(
         ListGamebookCampaignSessionsQuery request, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(request);
 
         // Ownership + existence guard (throws NotFound if missing, Forbidden if not the owner).
+        // Fires even when the campaign has zero sittings (standalone) — no existence leak.
         _ = await _mediator.Send(
             new GetGamebookCampaignQuery(request.CampaignId, request.CallerUserId), cancellationToken)
             .ConfigureAwait(false);
@@ -34,11 +35,6 @@ public sealed class ListGamebookCampaignSessionsHandler
             .ListByGamebookCampaignAsync(request.CampaignId, cancellationToken)
             .ConfigureAwait(false);
 
-        return sittings
-            .Select(s => new GamebookSittingDto(
-                s.Id,
-                IsLive: s.StartedAt.HasValue && !s.FinalizedAt.HasValue,
-                s.StartedAt))
-            .ToList();
+        return sittings.Select(s => s.Id).ToList();
     }
 }

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/ListGamebookCampaignSessionsHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/ListGamebookCampaignSessionsHandler.cs
@@ -1,0 +1,44 @@
+using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using MediatR;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Queries;
+
+/// <summary>
+/// Handles <see cref="ListGamebookCampaignSessionsQuery"/>. Enforces ownership by delegating to
+/// <see cref="GetGamebookCampaignQuery"/> (which throws NotFound / Forbidden), then projects the
+/// campaign's Sessions to the spine-relevant <see cref="GamebookSittingDto"/>.
+/// </summary>
+public sealed class ListGamebookCampaignSessionsHandler
+    : IRequestHandler<ListGamebookCampaignSessionsQuery, IReadOnlyList<GamebookSittingDto>>
+{
+    private readonly ISessionRepository _sessions;
+    private readonly IMediator _mediator;
+
+    public ListGamebookCampaignSessionsHandler(ISessionRepository sessions, IMediator mediator)
+    {
+        _sessions = sessions ?? throw new ArgumentNullException(nameof(sessions));
+        _mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
+    }
+
+    public async Task<IReadOnlyList<GamebookSittingDto>> Handle(
+        ListGamebookCampaignSessionsQuery request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        // Ownership + existence guard (throws NotFound if missing, Forbidden if not the owner).
+        _ = await _mediator.Send(
+            new GetGamebookCampaignQuery(request.CampaignId, request.CallerUserId), cancellationToken)
+            .ConfigureAwait(false);
+
+        var sittings = await _sessions
+            .ListByGamebookCampaignAsync(request.CampaignId, cancellationToken)
+            .ConfigureAwait(false);
+
+        return sittings
+            .Select(s => new GamebookSittingDto(
+                s.Id,
+                IsLive: s.StartedAt.HasValue && !s.FinalizedAt.HasValue,
+                s.StartedAt))
+            .ToList();
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/ListGamebookCampaignSessionsQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/ListGamebookCampaignSessionsQuery.cs
@@ -1,0 +1,14 @@
+using MediatR;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Queries;
+
+/// <summary>
+/// #2632 (SI-1b): lists the sittings (Sessions) that advance a libro-game campaign, most-recent
+/// first. Enforces campaign ownership (via <see cref="GetGamebookCampaignQuery"/>). Consumed by the
+/// GameManagement spine query to derive the campaign status + owning GameNight.
+/// </summary>
+public sealed record ListGamebookCampaignSessionsQuery(Guid CampaignId, Guid CallerUserId)
+    : IRequest<IReadOnlyList<GamebookSittingDto>>;
+
+/// <summary>A single gamebook sitting's spine-relevant projection.</summary>
+public sealed record GamebookSittingDto(Guid SessionId, bool IsLive, DateTime? StartedAt);

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/ListGamebookCampaignSessionsQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/ListGamebookCampaignSessionsQuery.cs
@@ -3,12 +3,11 @@ using MediatR;
 namespace Api.BoundedContexts.SessionTracking.Application.Queries;
 
 /// <summary>
-/// #2632 (SI-1b): lists the sittings (Sessions) that advance a libro-game campaign, most-recent
-/// first. Enforces campaign ownership (via <see cref="GetGamebookCampaignQuery"/>). Consumed by the
-/// GameManagement spine query to derive the campaign status + owning GameNight.
+/// #2632 (SI-1b): the Session IDs that advance a libro-game campaign (ownership-enforced via
+/// <see cref="GetGamebookCampaignQuery"/>). Consumed by the GameManagement spine query, which
+/// resolves each to its owning GameNight — liveness/timing live on the <c>GameNightSession</c>
+/// (Status/StartedAt), NOT on <c>Session.StartedAt</c> (never set outside <c>OpenLiveMode</c>),
+/// so only the IDs are returned here.
 /// </summary>
 public sealed record ListGamebookCampaignSessionsQuery(Guid CampaignId, Guid CallerUserId)
-    : IRequest<IReadOnlyList<GamebookSittingDto>>;
-
-/// <summary>A single gamebook sitting's spine-relevant projection.</summary>
-public sealed record GamebookSittingDto(Guid SessionId, bool IsLive, DateTime? StartedAt);
+    : IRequest<IReadOnlyList<Guid>>;

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Repositories/ISessionRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Repositories/ISessionRepository.cs
@@ -40,6 +40,15 @@ public interface ISessionRepository
     Task<IEnumerable<Session>> GetActiveByUserIdAsync(Guid userId, CancellationToken ct);
 
     /// <summary>
+    /// #2632 (SI-1b): lists the sittings that advance a given libro-game campaign, most-recent first.
+    /// Backed by the filtered index <c>idx_sessions_gamebook_campaign</c>. Used by the spine read path
+    /// to derive the campaign's status + owning GameNight.
+    /// </summary>
+    /// <param name="gamebookCampaignId">The libro-game campaign id.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task<IReadOnlyList<Session>> ListByGamebookCampaignAsync(Guid gamebookCampaignId, CancellationToken ct);
+
+    /// <summary>
     /// Adds a new session.
     /// </summary>
     /// <param name="session">Session to add.</param>

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Persistence/SessionRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Persistence/SessionRepository.cs
@@ -69,6 +69,18 @@ public class SessionRepository : RepositoryBase, ISessionRepository
         return entities.Select(SessionMapper.ToDomain);
     }
 
+    public async Task<IReadOnlyList<Session>> ListByGamebookCampaignAsync(Guid gamebookCampaignId, CancellationToken ct)
+    {
+        var entities = await DbContext.SessionTrackingSessions
+            .Include(s => s.Participants)
+            .Where(s => s.GamebookCampaignId == gamebookCampaignId)
+            .OrderByDescending(s => s.StartedAt)
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+
+        return entities.Select(SessionMapper.ToDomain).ToList();
+    }
+
     public async Task AddAsync(Session session, CancellationToken ct)
     {
         ArgumentNullException.ThrowIfNull(session);

--- a/apps/api/src/Api/Routing/GamebookCampaignEndpoints.cs
+++ b/apps/api/src/Api/Routing/GamebookCampaignEndpoints.cs
@@ -1,5 +1,6 @@
 using System.Security.Claims;
 using Api.BoundedContexts.Authentication.Application.DTOs;
+using Api.BoundedContexts.GameManagement.Application.Queries.GameNight;
 using Api.BoundedContexts.SessionTracking.Application.Commands;
 using Api.BoundedContexts.SessionTracking.Application.DTOs;
 using Api.BoundedContexts.SessionTracking.Application.Queries;
@@ -20,6 +21,7 @@ internal static class GamebookCampaignEndpoints
         MapCreateCampaignEndpoint(group);
         MapListCampaignsEndpoint(group);
         MapGetCampaignEndpoint(group);
+        MapGetCampaignSpineEndpoint(group);
         MapGetCampaignProgressEndpoint(group);
         MapUpdateProgressEndpoint(group);
         MapRenameCampaignEndpoint(group);
@@ -121,6 +123,42 @@ internal static class GamebookCampaignEndpoints
         .WithTags("Gamebook")
         .WithSummary("Get a gamebook campaign by ID")
         .WithDescription("Returns the gamebook campaign with the specified ID, if it belongs to the authenticated user.")
+        .WithOpenApi();
+    }
+
+    private static void MapGetCampaignSpineEndpoint(RouteGroupBuilder group)
+    {
+        // #2632 (SI-1b, Phase 3): the GameNight "Serata" spine for a campaign, or 204 if the
+        // campaign has no GameNight-attached play (standalone → no spine).
+        group.MapGet("/gamebook/campaigns/{id:guid}/spine", async (
+            Guid id,
+            IMediator mediator,
+            HttpContext context,
+            CancellationToken ct) =>
+        {
+            var (authenticated, session, error) = context.TryGetAuthenticatedUser();
+            if (!authenticated) return error!;
+
+            if (!TryGetUserId(context, session, out var userId))
+            {
+                return Results.Unauthorized();
+            }
+
+            var spine = await mediator.Send(
+                new GetGamebookCampaignSpineQuery(id, userId), ct
+            ).ConfigureAwait(false);
+
+            return spine is null ? Results.NoContent() : Results.Ok(spine);
+        })
+        .RequireAuthenticatedUser()
+        .Produces<GamebookCampaignSpineDto>(StatusCodes.Status200OK)
+        .Produces(StatusCodes.Status204NoContent)
+        .Produces(StatusCodes.Status401Unauthorized)
+        .Produces(StatusCodes.Status403Forbidden)
+        .Produces(StatusCodes.Status404NotFound)
+        .WithTags("Gamebook")
+        .WithSummary("Get the GameNight spine for a campaign")
+        .WithDescription("Returns the owning GameNight 'Serata' spine (title, organizer, status, session pip) + derived campaign status, or 204 if the campaign has no GameNight-attached play.")
         .WithOpenApi();
     }
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/GameNight/GetGamebookCampaignSpineQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/GameNight/GetGamebookCampaignSpineQueryHandlerTests.cs
@@ -1,0 +1,138 @@
+using Api.BoundedContexts.GameManagement.Application.Queries.GameNight;
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.BoundedContexts.SessionTracking.Application.Queries;
+using Api.Tests.Constants;
+using FluentAssertions;
+using MediatR;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Application.GameNight;
+
+/// <summary>
+/// #2632 (SI-1b Phase 3): the spine read path — derives the owning GameNight "Serata" + campaign
+/// status from a campaign's sittings.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "GameManagement")]
+public class GetGamebookCampaignSpineQueryHandlerTests
+{
+    private readonly Mock<IMediator> _mediator = new();
+    private readonly Mock<IGameNightEventRepository> _repo = new();
+    private readonly GetGamebookCampaignSpineQueryHandler _handler;
+
+    public GetGamebookCampaignSpineQueryHandlerTests()
+    {
+        _handler = new GetGamebookCampaignSpineQueryHandler(_mediator.Object, _repo.Object);
+    }
+
+    private void SetupSittings(Guid campaignId, params GamebookSittingDto[] sittings)
+        => _mediator
+            .Setup(m => m.Send(
+                It.Is<ListGamebookCampaignSessionsQuery>(q => q.CampaignId == campaignId),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(sittings.ToList());
+
+    private static GameNightEvent PublishedWithSession(Guid sessionId, string title = "Serata da Marco")
+    {
+        var evt = GameNightEvent.Create(
+            Guid.NewGuid(), title, DateTimeOffset.UtcNow.AddHours(1), gameIds: [Guid.NewGuid()]);
+        evt.Publish([]);
+        evt.AddSession(sessionId, evt.GameIds[0], "Eldoria");
+        return evt;
+    }
+
+    [Fact]
+    public async Task Handle_NoSittings_ReturnsNull()
+    {
+        var campaignId = Guid.NewGuid();
+        SetupSittings(campaignId); // empty
+
+        var result = await _handler.Handle(
+            new GetGamebookCampaignSpineQuery(campaignId, Guid.NewGuid()),
+            TestContext.Current.CancellationToken);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_LiveSitting_ReturnsInProgressSpine()
+    {
+        var campaignId = Guid.NewGuid();
+        var sittingId = Guid.NewGuid();
+        SetupSittings(campaignId, new GamebookSittingDto(sittingId, IsLive: true, DateTime.UtcNow));
+        var gameNight = PublishedWithSession(sittingId);
+        _repo.Setup(r => r.FindByLinkedSessionIdAsync(sittingId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(gameNight);
+
+        var result = await _handler.Handle(
+            new GetGamebookCampaignSpineQuery(campaignId, Guid.NewGuid()),
+            TestContext.Current.CancellationToken);
+
+        result.Should().NotBeNull();
+        result!.HasLiveSession.Should().BeTrue();
+        result.CampaignStatus.Should().Be("InProgress");
+        result.GameNightTitle.Should().Be("Serata da Marco");
+        result.GameNightId.Should().Be(gameNight.Id);
+        result.TotalSessions.Should().Be(1);
+        result.CompletedSessions.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Handle_NoLiveSitting_ReturnsResumableSpine()
+    {
+        var campaignId = Guid.NewGuid();
+        var sittingId = Guid.NewGuid();
+        SetupSittings(campaignId, new GamebookSittingDto(sittingId, IsLive: false, DateTime.UtcNow.AddDays(-1)));
+        _repo.Setup(r => r.FindByLinkedSessionIdAsync(sittingId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(PublishedWithSession(sittingId));
+
+        var result = await _handler.Handle(
+            new GetGamebookCampaignSpineQuery(campaignId, Guid.NewGuid()),
+            TestContext.Current.CancellationToken);
+
+        result.Should().NotBeNull();
+        result!.HasLiveSession.Should().BeFalse();
+        result.CampaignStatus.Should().Be("Resumable");
+    }
+
+    [Fact]
+    public async Task Handle_SittingsButNoGameNightAttached_ReturnsNull()
+    {
+        var campaignId = Guid.NewGuid();
+        var sittingId = Guid.NewGuid();
+        SetupSittings(campaignId, new GamebookSittingDto(sittingId, IsLive: false, DateTime.UtcNow));
+        _repo.Setup(r => r.FindByLinkedSessionIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((GameNightEvent?)null);
+
+        var result = await _handler.Handle(
+            new GetGamebookCampaignSpineQuery(campaignId, Guid.NewGuid()),
+            TestContext.Current.CancellationToken);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_LiveSittingPreferredOverOlder()
+    {
+        // Two sittings: an older non-live and a current live one. The live one's GameNight wins.
+        var campaignId = Guid.NewGuid();
+        var oldSitting = Guid.NewGuid();
+        var liveSitting = Guid.NewGuid();
+        SetupSittings(campaignId,
+            new GamebookSittingDto(oldSitting, IsLive: false, DateTime.UtcNow.AddDays(-2)),
+            new GamebookSittingDto(liveSitting, IsLive: true, DateTime.UtcNow));
+        _repo.Setup(r => r.FindByLinkedSessionIdAsync(liveSitting, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(PublishedWithSession(liveSitting, "Serata Live"));
+        _repo.Setup(r => r.FindByLinkedSessionIdAsync(oldSitting, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(PublishedWithSession(oldSitting, "Serata Vecchia"));
+
+        var result = await _handler.Handle(
+            new GetGamebookCampaignSpineQuery(campaignId, Guid.NewGuid()),
+            TestContext.Current.CancellationToken);
+
+        result.Should().NotBeNull();
+        result!.GameNightTitle.Should().Be("Serata Live");
+        result.HasLiveSession.Should().BeTrue();
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/GameNight/GetGamebookCampaignSpineQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/GameNight/GetGamebookCampaignSpineQueryHandlerTests.cs
@@ -11,7 +11,8 @@ namespace Api.Tests.BoundedContexts.GameManagement.Application.GameNight;
 
 /// <summary>
 /// #2632 (SI-1b Phase 3): the spine read path — derives the owning GameNight "Serata" + campaign
-/// status from a campaign's sittings.
+/// status from a campaign's sittings. Liveness comes from the authoritative
+/// <c>GameNightSession.Status</c> (InProgress), not <c>Session.StartedAt</c>.
 /// </summary>
 [Trait("Category", TestCategories.Unit)]
 [Trait("BoundedContext", "GameManagement")]
@@ -26,27 +27,30 @@ public class GetGamebookCampaignSpineQueryHandlerTests
         _handler = new GetGamebookCampaignSpineQueryHandler(_mediator.Object, _repo.Object);
     }
 
-    private void SetupSittings(Guid campaignId, params GamebookSittingDto[] sittings)
+    private void SetupSessionIds(Guid campaignId, params Guid[] ids)
         => _mediator
             .Setup(m => m.Send(
                 It.Is<ListGamebookCampaignSessionsQuery>(q => q.CampaignId == campaignId),
                 It.IsAny<CancellationToken>()))
-            .ReturnsAsync(sittings.ToList());
+            .ReturnsAsync(ids.ToList());
 
-    private static GameNightEvent PublishedWithSession(Guid sessionId, string title = "Serata da Marco")
+    /// <summary>A Published GameNight with one sitting; <paramref name="started"/> makes it InProgress (live).</summary>
+    private static GameNightEvent WithSession(Guid sessionId, string title, bool started)
     {
         var evt = GameNightEvent.Create(
             Guid.NewGuid(), title, DateTimeOffset.UtcNow.AddHours(1), gameIds: [Guid.NewGuid()]);
         evt.Publish([]);
         evt.AddSession(sessionId, evt.GameIds[0], "Eldoria");
+        if (started)
+            evt.StartCurrentSession();
         return evt;
     }
 
     [Fact]
-    public async Task Handle_NoSittings_ReturnsNull()
+    public async Task Handle_NoSessions_ReturnsNull()
     {
         var campaignId = Guid.NewGuid();
-        SetupSittings(campaignId); // empty
+        SetupSessionIds(campaignId); // empty
 
         var result = await _handler.Handle(
             new GetGamebookCampaignSpineQuery(campaignId, Guid.NewGuid()),
@@ -59,10 +63,10 @@ public class GetGamebookCampaignSpineQueryHandlerTests
     public async Task Handle_LiveSitting_ReturnsInProgressSpine()
     {
         var campaignId = Guid.NewGuid();
-        var sittingId = Guid.NewGuid();
-        SetupSittings(campaignId, new GamebookSittingDto(sittingId, IsLive: true, DateTime.UtcNow));
-        var gameNight = PublishedWithSession(sittingId);
-        _repo.Setup(r => r.FindByLinkedSessionIdAsync(sittingId, It.IsAny<CancellationToken>()))
+        var sessionId = Guid.NewGuid();
+        SetupSessionIds(campaignId, sessionId);
+        var gameNight = WithSession(sessionId, "Serata da Marco", started: true);
+        _repo.Setup(r => r.FindByLinkedSessionIdAsync(sessionId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(gameNight);
 
         var result = await _handler.Handle(
@@ -82,10 +86,10 @@ public class GetGamebookCampaignSpineQueryHandlerTests
     public async Task Handle_NoLiveSitting_ReturnsResumableSpine()
     {
         var campaignId = Guid.NewGuid();
-        var sittingId = Guid.NewGuid();
-        SetupSittings(campaignId, new GamebookSittingDto(sittingId, IsLive: false, DateTime.UtcNow.AddDays(-1)));
-        _repo.Setup(r => r.FindByLinkedSessionIdAsync(sittingId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(PublishedWithSession(sittingId));
+        var sessionId = Guid.NewGuid();
+        SetupSessionIds(campaignId, sessionId);
+        _repo.Setup(r => r.FindByLinkedSessionIdAsync(sessionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(WithSession(sessionId, "Serata", started: false));
 
         var result = await _handler.Handle(
             new GetGamebookCampaignSpineQuery(campaignId, Guid.NewGuid()),
@@ -97,11 +101,11 @@ public class GetGamebookCampaignSpineQueryHandlerTests
     }
 
     [Fact]
-    public async Task Handle_SittingsButNoGameNightAttached_ReturnsNull()
+    public async Task Handle_SessionsButNoGameNightAttached_ReturnsNull()
     {
         var campaignId = Guid.NewGuid();
-        var sittingId = Guid.NewGuid();
-        SetupSittings(campaignId, new GamebookSittingDto(sittingId, IsLive: false, DateTime.UtcNow));
+        var sessionId = Guid.NewGuid();
+        SetupSessionIds(campaignId, sessionId);
         _repo.Setup(r => r.FindByLinkedSessionIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((GameNightEvent?)null);
 
@@ -113,19 +117,17 @@ public class GetGamebookCampaignSpineQueryHandlerTests
     }
 
     [Fact]
-    public async Task Handle_LiveSittingPreferredOverOlder()
+    public async Task Handle_LiveSittingPreferredOverOlderNight()
     {
-        // Two sittings: an older non-live and a current live one. The live one's GameNight wins.
+        // Two sittings in different nights: an older non-live and a current live one. The live one wins.
         var campaignId = Guid.NewGuid();
-        var oldSitting = Guid.NewGuid();
-        var liveSitting = Guid.NewGuid();
-        SetupSittings(campaignId,
-            new GamebookSittingDto(oldSitting, IsLive: false, DateTime.UtcNow.AddDays(-2)),
-            new GamebookSittingDto(liveSitting, IsLive: true, DateTime.UtcNow));
-        _repo.Setup(r => r.FindByLinkedSessionIdAsync(liveSitting, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(PublishedWithSession(liveSitting, "Serata Live"));
-        _repo.Setup(r => r.FindByLinkedSessionIdAsync(oldSitting, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(PublishedWithSession(oldSitting, "Serata Vecchia"));
+        var oldSession = Guid.NewGuid();
+        var liveSession = Guid.NewGuid();
+        SetupSessionIds(campaignId, oldSession, liveSession);
+        _repo.Setup(r => r.FindByLinkedSessionIdAsync(liveSession, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(WithSession(liveSession, "Serata Live", started: true));
+        _repo.Setup(r => r.FindByLinkedSessionIdAsync(oldSession, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(WithSession(oldSession, "Serata Vecchia", started: false));
 
         var result = await _handler.Handle(
             new GetGamebookCampaignSpineQuery(campaignId, Guid.NewGuid()),
@@ -134,5 +136,6 @@ public class GetGamebookCampaignSpineQueryHandlerTests
         result.Should().NotBeNull();
         result!.GameNightTitle.Should().Be("Serata Live");
         result.HasLiveSession.Should().BeTrue();
+        result.CampaignStatus.Should().Be("InProgress");
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Queries/ListGamebookCampaignSessionsHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Queries/ListGamebookCampaignSessionsHandlerTests.cs
@@ -38,27 +38,24 @@ public class ListGamebookCampaignSessionsHandlerTests
                 0, Array.Empty<int>(), DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow));
 
     [Fact]
-    public async Task Handle_ProjectsSittings_WithIsLiveComputed()
+    public async Task Handle_ReturnsCampaignSessionIds()
     {
         var campaignId = Guid.NewGuid();
         var caller = Guid.NewGuid();
         SetupOwnershipOk(campaignId, caller);
 
-        var live = Session.Create(caller, Guid.NewGuid(), SessionType.Generic, gamebookCampaignId: campaignId);
-        live.OpenLiveMode();
-        var draft = Session.Create(caller, Guid.NewGuid(), SessionType.Generic, gamebookCampaignId: campaignId);
+        var s1 = Session.Create(caller, Guid.NewGuid(), SessionType.Generic, gamebookCampaignId: campaignId);
+        var s2 = Session.Create(caller, Guid.NewGuid(), SessionType.Generic, gamebookCampaignId: campaignId);
 
         _sessions
             .Setup(r => r.ListByGamebookCampaignAsync(campaignId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new List<Session> { live, draft });
+            .ReturnsAsync(new List<Session> { s1, s2 });
 
         var result = await _handler.Handle(
             new ListGamebookCampaignSessionsQuery(campaignId, caller),
             TestContext.Current.CancellationToken);
 
-        result.Should().HaveCount(2);
-        result.Single(s => s.SessionId == live.Id).IsLive.Should().BeTrue();
-        result.Single(s => s.SessionId == draft.Id).IsLive.Should().BeFalse();
+        result.Should().BeEquivalentTo(new[] { s1.Id, s2.Id });
     }
 
     [Fact]

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Queries/ListGamebookCampaignSessionsHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Queries/ListGamebookCampaignSessionsHandlerTests.cs
@@ -1,0 +1,80 @@
+using Api.BoundedContexts.SessionTracking.Application.DTOs;
+using Api.BoundedContexts.SessionTracking.Application.Queries;
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using Api.Tests.Constants;
+using FluentAssertions;
+using MediatR;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SessionTracking.Application.Queries;
+
+/// <summary>
+/// #2632 (SI-1b Phase 3): projects a campaign's sittings, enforcing ownership via
+/// <see cref="GetGamebookCampaignQuery"/> and computing IsLive.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SessionTracking")]
+public class ListGamebookCampaignSessionsHandlerTests
+{
+    private readonly Mock<ISessionRepository> _sessions = new();
+    private readonly Mock<IMediator> _mediator = new();
+    private readonly ListGamebookCampaignSessionsHandler _handler;
+
+    public ListGamebookCampaignSessionsHandlerTests()
+    {
+        _handler = new ListGamebookCampaignSessionsHandler(_sessions.Object, _mediator.Object);
+    }
+
+    private void SetupOwnershipOk(Guid campaignId, Guid caller)
+        => _mediator
+            .Setup(m => m.Send(
+                It.Is<GetGamebookCampaignQuery>(q => q.CampaignId == campaignId && q.CallerUserId == caller),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GamebookCampaignDto(
+                campaignId, Guid.NewGuid(), 0, caller, "La Runa di Eldoria",
+                0, Array.Empty<int>(), DateTimeOffset.UtcNow, DateTimeOffset.UtcNow, DateTimeOffset.UtcNow));
+
+    [Fact]
+    public async Task Handle_ProjectsSittings_WithIsLiveComputed()
+    {
+        var campaignId = Guid.NewGuid();
+        var caller = Guid.NewGuid();
+        SetupOwnershipOk(campaignId, caller);
+
+        var live = Session.Create(caller, Guid.NewGuid(), SessionType.Generic, gamebookCampaignId: campaignId);
+        live.OpenLiveMode();
+        var draft = Session.Create(caller, Guid.NewGuid(), SessionType.Generic, gamebookCampaignId: campaignId);
+
+        _sessions
+            .Setup(r => r.ListByGamebookCampaignAsync(campaignId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<Session> { live, draft });
+
+        var result = await _handler.Handle(
+            new ListGamebookCampaignSessionsQuery(campaignId, caller),
+            TestContext.Current.CancellationToken);
+
+        result.Should().HaveCount(2);
+        result.Single(s => s.SessionId == live.Id).IsLive.Should().BeTrue();
+        result.Single(s => s.SessionId == draft.Id).IsLive.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Handle_OwnershipQueryThrows_Propagates_AndDoesNotQueryRepo()
+    {
+        _mediator
+            .Setup(m => m.Send(It.IsAny<GetGamebookCampaignQuery>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new ForbiddenException("Forbidden"));
+
+        var act = () => _handler.Handle(
+            new ListGamebookCampaignSessionsQuery(Guid.NewGuid(), Guid.NewGuid()),
+            TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<ForbiddenException>();
+        _sessions.Verify(
+            r => r.ListByGamebookCampaignAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+}


### PR DESCRIPTION
**SI-1b Phase 3 of 4** for #2632 — the query the FE spine strip (Phase 4) consumes. Given a campaign, returns the owning GameNight "Serata" spine + derived campaign status, or 204 when standalone.

## Changes
- `ISessionRepository.ListByGamebookCampaignAsync` + EF impl (backed by the Phase-1 filtered index).
- `ListGamebookCampaignSessionsQuery` + handler (SessionTracking): ownership-enforced, returns the campaign's linked Session IDs.
- `GetGamebookCampaignSpineQuery` + handler (GameManagement): resolves each Session to its owning GameNight via `FindByLinkedSessionIdAsync`, assembles `GamebookCampaignSpineDto` (title/organizer/status + session pip + HasLiveSession + derived CampaignStatus).
- Endpoint `GET /api/v1/gamebook/campaigns/{id}/spine` (200 / 204 standalone / 401/403/404).

## Adversarial review (confidence 95) caught + fixed
Liveness was derived from `Session.StartedAt`, but neither the attach handler nor its sibling calls `Session.OpenLiveMode()`, so `StartedAt` is never set → `CampaignStatus='InProgress'` was unreachable. **Fixed**: derive liveness from the authoritative `GameNightSession.Status==InProgress` (set by the existing `AddSession→StartCurrentSession` flow both handlers run).

## ⚠️ Pre-existing gap noted (out of scope)
`OpenLiveMode()` is never called in **either** GameNight-start flow (boardgame `StartGameNightSession` too), so `SessionStartedDomainEvent` never fires and the GameNight `Published→InProgress` promotion (#15) never happens — `GameNightStatus` may read "Published" during play. The spine reports it faithfully and uses the authoritative sitting status for `CampaignStatus`. **Should be fixed separately** (affects the shipped boardgame flow, not introduced by SI-1b).

## Tests
7 unit tests (5 spine incl. live→InProgress + live-preferred + 2 projection). Build clean.

Remaining: Phase 4 (FE "Serata" spine strip). Refs #2632 · part of #2619

🤖 Generated with [Claude Code](https://claude.com/claude-code)