### PR TITLE
feat(libro-game): #2632 SI-1b Phase 4 — FE Serata spine strip (completes SI-1b)

### DIFF
--- a/apps/web/src/app/(authenticated)/library/[gameId]/play/[campaignId]/_content.tsx
+++ b/apps/web/src/app/(authenticated)/library/[gameId]/play/[campaignId]/_content.tsx
@@ -6,9 +6,13 @@ import { useRouter } from 'next/navigation';
 
 import { GamebookPlayShell } from '@/components/features/gamebook';
 import { ResumeBooksList } from '@/components/features/gamebook/ResumeBooksList';
+import { SerataSpineStrip } from '@/components/features/gamebook/SerataSpineStrip';
 import { GameRefKind, type GameRef } from '@/lib/api/gamebook';
 import { useCampaignProgress } from '@/lib/gamebook/hooks/useCampaignProgress';
-import { useGamebookCampaign } from '@/lib/gamebook/hooks/useGamebookCampaign';
+import {
+  useGamebookCampaign,
+  useGamebookCampaignSpine,
+} from '@/lib/gamebook/hooks/useGamebookCampaign';
 
 export function Content({
   campaignId,
@@ -42,6 +46,10 @@ export function Content({
   // has engaged with, server-side sorted by most-recent visit first.
   const { data: bookProgress = [] } = useCampaignProgress(campaignId);
 
+  // #2632 (SI-1b Phase 4): the owning GameNight "Serata" spine. Null when the campaign is played
+  // standalone (204) — the strip is only shown for GameNight-attached play.
+  const { data: spine } = useGamebookCampaignSpine(campaignId);
+
   const handleResume = useCallback(
     (bookId: string) => {
       // Future: route to a per-book play surface; for now we just refresh
@@ -54,6 +62,11 @@ export function Content({
 
   return (
     <main className="h-[calc(100vh-var(--app-topbar-height,64px))] flex flex-col">
+      {spine ? (
+        <div className="px-3 pt-2">
+          <SerataSpineStrip spine={spine} />
+        </div>
+      ) : null}
       <ResumeBooksList progress={bookProgress} onResume={handleResume} />
       <GamebookPlayShell campaignId={campaignId} gameId={gameId} gameRef={gameRef} />
     </main>

--- a/apps/web/src/components/features/gamebook/SerataSpineStrip.tsx
+++ b/apps/web/src/components/features/gamebook/SerataSpineStrip.tsx
@@ -20,9 +20,16 @@ const STATUS_LABELS: Record<string, string> = {
   Completed: 'completata',
 };
 
+// GameNights cap at 5 sessions (BE AddSession invariant); MAX_PIPS guards the DOM against a
+// malformed/adversarial payload sending an unbounded totalSessions. The numeric label still
+// shows the true count.
+const MAX_PIPS = 12;
+
 export function SerataSpineStrip({ spine }: SerataSpineStripProps): ReactElement {
   const total = Math.max(spine.totalSessions, 0);
   const completed = Math.min(Math.max(spine.completedSessions, 0), total);
+  const pipCount = Math.min(total, MAX_PIPS);
+  const filledPips = Math.min(completed, MAX_PIPS);
   const statusLabel = STATUS_LABELS[spine.gameNightStatus] ?? spine.gameNightStatus.toLowerCase();
 
   return (
@@ -63,12 +70,12 @@ export function SerataSpineStrip({ spine }: SerataSpineStripProps): ReactElement
             data-testid="serata-session-pip"
             aria-label={`${completed} di ${total} sessioni della serata`}
           >
-            {Array.from({ length: total }).map((_, i) => (
+            {Array.from({ length: pipCount }).map((_, i) => (
               <span
                 key={i}
                 aria-hidden
                 className={
-                  i < completed
+                  i < filledPips
                     ? 'inline-block h-1.5 w-1.5 rounded-full bg-entity-event'
                     : 'inline-block h-1.5 w-1.5 rounded-full bg-entity-event/25'
                 }

--- a/apps/web/src/components/features/gamebook/SerataSpineStrip.tsx
+++ b/apps/web/src/components/features/gamebook/SerataSpineStrip.tsx
@@ -1,0 +1,85 @@
+import type { ReactElement } from 'react';
+
+import type { GamebookCampaignSpine } from '@/lib/api/gamebook-campaigns';
+
+/**
+ * #2632 (SI-1b Phase 4): the "Serata" spine strip. Rendered above the per-session libro-game UIs
+ * when a campaign is played as part of a GameNight (`GET /gamebook/campaigns/{id}/spine` returns a
+ * spine; a standalone campaign returns 204 → `null` → this strip is not rendered by the parent).
+ *
+ * Shows the owning GameNight: title, a live/status indicator, and the "Serata" session pip
+ * (completed of total games that evening). Uses the `event` entity tokens (the GameNight is an event).
+ */
+export interface SerataSpineStripProps {
+  spine: GamebookCampaignSpine;
+}
+
+const STATUS_LABELS: Record<string, string> = {
+  Published: 'programmata',
+  InProgress: 'in corso',
+  Completed: 'completata',
+};
+
+export function SerataSpineStrip({ spine }: SerataSpineStripProps): ReactElement {
+  const total = Math.max(spine.totalSessions, 0);
+  const completed = Math.min(Math.max(spine.completedSessions, 0), total);
+  const statusLabel = STATUS_LABELS[spine.gameNightStatus] ?? spine.gameNightStatus.toLowerCase();
+
+  return (
+    <div
+      data-testid="serata-spine-strip"
+      className="flex items-center gap-3 rounded-lg border border-border bg-card px-3 py-2"
+      role="group"
+      aria-label={`Serata: ${spine.gameNightTitle}`}
+    >
+      <span aria-hidden className="text-lg">
+        🗓️
+      </span>
+
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <span className="truncate font-display text-sm font-semibold text-entity-event">
+            {spine.gameNightTitle}
+          </span>
+
+          {spine.hasLiveSession ? (
+            <span
+              className="inline-flex items-center gap-1 rounded-full bg-entity-event/15 px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-entity-event"
+              data-testid="serata-live-badge"
+            >
+              <span aria-hidden className="inline-block h-1.5 w-1.5 rounded-full bg-entity-event" />
+              live
+            </span>
+          ) : (
+            <span className="rounded-full bg-muted px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+              {statusLabel}
+            </span>
+          )}
+        </div>
+
+        <div className="mt-0.5 flex items-center gap-2 text-xs text-muted-foreground">
+          <span
+            className="inline-flex items-center gap-1"
+            data-testid="serata-session-pip"
+            aria-label={`${completed} di ${total} sessioni della serata`}
+          >
+            {Array.from({ length: total }).map((_, i) => (
+              <span
+                key={i}
+                aria-hidden
+                className={
+                  i < completed
+                    ? 'inline-block h-1.5 w-1.5 rounded-full bg-entity-event'
+                    : 'inline-block h-1.5 w-1.5 rounded-full bg-entity-event/25'
+                }
+              />
+            ))}
+            <span className="ml-1">
+              {completed}/{total}
+            </span>
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/features/gamebook/__tests__/SerataSpineStrip.test.tsx
+++ b/apps/web/src/components/features/gamebook/__tests__/SerataSpineStrip.test.tsx
@@ -49,4 +49,11 @@ describe('SerataSpineStrip', () => {
     render(<SerataSpineStrip spine={{ ...base, totalSessions: 1, completedSessions: 5 }} />);
     expect(screen.getByText('1/1')).toBeInTheDocument();
   });
+
+  it('caps rendered pip dots at MAX_PIPS but shows the true total (defensive)', () => {
+    render(<SerataSpineStrip spine={{ ...base, totalSessions: 100, completedSessions: 50 }} />);
+    expect(screen.getByText('50/100')).toBeInTheDocument();
+    const dots = screen.getByTestId('serata-session-pip').querySelectorAll('span[aria-hidden]');
+    expect(dots.length).toBe(12);
+  });
 });

--- a/apps/web/src/components/features/gamebook/__tests__/SerataSpineStrip.test.tsx
+++ b/apps/web/src/components/features/gamebook/__tests__/SerataSpineStrip.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import type { GamebookCampaignSpine } from '@/lib/api/gamebook-campaigns';
+
+import { SerataSpineStrip } from '../SerataSpineStrip';
+
+const base: GamebookCampaignSpine = {
+  gameNightId: '44444444-4444-4444-a444-444444444444',
+  gameNightTitle: 'Serata da Marco',
+  organizerId: '55555555-5555-4555-a555-555555555555',
+  gameNightStatus: 'InProgress',
+  totalSessions: 3,
+  completedSessions: 1,
+  hasLiveSession: false,
+  campaignStatus: 'Resumable',
+};
+
+describe('SerataSpineStrip', () => {
+  it('renders the owning GameNight title', () => {
+    render(<SerataSpineStrip spine={base} />);
+    expect(screen.getByTestId('serata-spine-strip')).toBeInTheDocument();
+    expect(screen.getByText('Serata da Marco')).toBeInTheDocument();
+  });
+
+  it('shows the live badge when a live session exists', () => {
+    render(<SerataSpineStrip spine={{ ...base, hasLiveSession: true }} />);
+    expect(screen.getByTestId('serata-live-badge')).toBeInTheDocument();
+  });
+
+  it('shows the status label (not the live badge) when not live', () => {
+    render(
+      <SerataSpineStrip spine={{ ...base, hasLiveSession: false, gameNightStatus: 'Published' }} />
+    );
+    expect(screen.queryByTestId('serata-live-badge')).not.toBeInTheDocument();
+    expect(screen.getByText('programmata')).toBeInTheDocument();
+  });
+
+  it('renders the session pip with completed/total', () => {
+    render(<SerataSpineStrip spine={{ ...base, totalSessions: 3, completedSessions: 2 }} />);
+    expect(screen.getByText('2/3')).toBeInTheDocument();
+    expect(screen.getByTestId('serata-session-pip')).toHaveAttribute(
+      'aria-label',
+      '2 di 3 sessioni della serata'
+    );
+  });
+
+  it('clamps completed to total (defensive)', () => {
+    render(<SerataSpineStrip spine={{ ...base, totalSessions: 1, completedSessions: 5 }} />);
+    expect(screen.getByText('1/1')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/lib/api/__tests__/gamebook-campaigns.test.ts
+++ b/apps/web/src/lib/api/__tests__/gamebook-campaigns.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 
 import {
   GamebookCampaignSchema,
+  GamebookCampaignSpineSchema,
   SessionBookProgressSchema,
   createCampaign,
   getCampaign,
   getCampaignProgress,
+  getCampaignSpine,
   listMyCampaigns,
   updateProgress,
 } from '../gamebook-campaigns';
@@ -118,6 +120,32 @@ describe('gamebook-campaigns client', () => {
     const result = await getCampaign(validRow.id);
     expect(fetchMock.mock.calls[0][0]).toContain(`/api/v1/gamebook/campaigns/${validRow.id}`);
     expect(result.title).toBe('Campagna #1');
+  });
+
+  it('getCampaignSpine GETs /spine and parses the spine (#2632)', async () => {
+    const spine = {
+      gameNightId: '44444444-4444-4444-a444-444444444444',
+      gameNightTitle: 'Serata da Marco',
+      organizerId: '55555555-5555-4555-a555-555555555555',
+      gameNightStatus: 'InProgress',
+      totalSessions: 2,
+      completedSessions: 1,
+      hasLiveSession: true,
+      campaignStatus: 'InProgress',
+    };
+    fetchMock.mockResolvedValueOnce(new Response(JSON.stringify(spine), { status: 200 }));
+
+    const result = await getCampaignSpine(validRow.id);
+
+    expect(fetchMock.mock.calls[0][0]).toContain(`/api/v1/gamebook/campaigns/${validRow.id}/spine`);
+    expect(result?.gameNightTitle).toBe('Serata da Marco');
+    expect(result?.hasLiveSession).toBe(true);
+  });
+
+  it('getCampaignSpine returns null on 204 (standalone campaign)', async () => {
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 204 }));
+    const result = await getCampaignSpine(validRow.id);
+    expect(result).toBeNull();
   });
 
   it('listMyCampaigns appends gameId query when provided', async () => {

--- a/apps/web/src/lib/api/gamebook-campaigns.ts
+++ b/apps/web/src/lib/api/gamebook-campaigns.ts
@@ -59,6 +59,26 @@ export const GamebookCampaignSchema = z.object({
 
 export type GamebookCampaign = z.infer<typeof GamebookCampaignSchema>;
 
+/**
+ * #2632 (SI-1b Phase 4): the owning GameNight "Serata" spine for a campaign, returned by
+ * `GET /gamebook/campaigns/{id}/spine`. The endpoint replies 204 (→ `null` here) when the
+ * campaign has no GameNight-attached play (standalone), in which case the FE renders no strip.
+ */
+export const GamebookCampaignSpineSchema = z.object({
+  gameNightId: z.string().uuid(),
+  gameNightTitle: z.string(),
+  organizerId: z.string().uuid(),
+  /** Backend `GameNightStatus.ToString()` — e.g. Published / InProgress / Completed. */
+  gameNightStatus: z.string(),
+  totalSessions: z.number().int().min(0),
+  completedSessions: z.number().int().min(0),
+  hasLiveSession: z.boolean(),
+  /** Derived: "InProgress" (a live sitting exists) or "Resumable". */
+  campaignStatus: z.string(),
+});
+
+export type GamebookCampaignSpine = z.infer<typeof GamebookCampaignSpineSchema>;
+
 export interface CreateCampaignInput {
   gameId: string;
   title: string;
@@ -93,6 +113,18 @@ export async function getCampaign(id: string): Promise<GamebookCampaign> {
     credentials: 'include',
   });
   return parseJson(res, GamebookCampaignSchema);
+}
+
+/**
+ * #2632 (SI-1b Phase 4): fetch the owning GameNight spine for a campaign. Returns `null` when the
+ * backend replies 204 (standalone campaign — no GameNight-attached play, so no strip is rendered).
+ */
+export async function getCampaignSpine(id: string): Promise<GamebookCampaignSpine | null> {
+  const res = await fetch(`${API_BASE}/api/v1/gamebook/campaigns/${encodeURIComponent(id)}/spine`, {
+    credentials: 'include',
+  });
+  if (res.status === 204) return null;
+  return parseJson(res, GamebookCampaignSpineSchema);
 }
 
 export async function listMyCampaigns(gameId?: string): Promise<GamebookCampaign[]> {

--- a/apps/web/src/lib/gamebook/hooks/useGamebookCampaign.ts
+++ b/apps/web/src/lib/gamebook/hooks/useGamebookCampaign.ts
@@ -1,9 +1,15 @@
 import { useQuery } from '@tanstack/react-query';
 
-import { getCampaign, type GamebookCampaign } from '@/lib/api/gamebook-campaigns';
+import {
+  getCampaign,
+  getCampaignSpine,
+  type GamebookCampaign,
+  type GamebookCampaignSpine,
+} from '@/lib/api/gamebook-campaigns';
 
 export const gamebookCampaignKeys = {
   detail: (id: string) => ['gamebook', 'campaigns', id] as const,
+  spine: (id: string) => ['gamebook', 'campaigns', id, 'spine'] as const,
 };
 
 export function useGamebookCampaign(id: string | undefined) {
@@ -12,6 +18,19 @@ export function useGamebookCampaign(id: string | undefined) {
     // `enabled: !!id` guarantees queryFn only runs when id is set.
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- gated by enabled
     queryFn: () => getCampaign(id!),
+    enabled: !!id,
+  });
+}
+
+/**
+ * #2632 (SI-1b Phase 4): the owning GameNight "Serata" spine for a campaign, or `null` when the
+ * campaign has no GameNight-attached play (standalone → the strip is not rendered).
+ */
+export function useGamebookCampaignSpine(id: string | undefined) {
+  return useQuery<GamebookCampaignSpine | null>({
+    queryKey: id ? gamebookCampaignKeys.spine(id) : ['gamebook', 'campaigns', 'noop', 'spine'],
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- gated by enabled
+    queryFn: () => getCampaignSpine(id!),
     enabled: !!id,
   });
 }


### PR DESCRIPTION
**SI-1b Phase 4 of 4** for #2632 — the visible payoff. Renders the owning GameNight "Serata" strip above the per-session libro-game UIs when a campaign is GameNight-attached, consuming the Phase-3 endpoint `GET /gamebook/campaigns/{id}/spine`.

## Changes
- API client: `GamebookCampaignSpineSchema` + `getCampaignSpine` (204 → null for standalone).
- Hook: `useGamebookCampaignSpine` (React Query).
- `SerataSpineStrip`: 🗓️ + GameNight title (entity-event token) + live badge / status label + session pip. Semantic + entity-event tokens only (DS-compliant); a11y role=group + aria-labels + testids. Pip dots capped at 12 (review fix).
- Wired into the play surface — rendered only when spine present (standalone shows no strip, per D-WHEN).

## Tests + Review
6 component + 2 api-client tests; typecheck + lint clean. Adversarial review: 0 critical; 1 fix applied (unbounded pip → MAX_PIPS cap). Confirmed clean: 204 handling, React Query keys, token compliance, schema drift (camelCase matches BE), i18n consistency, a11y.

## Completes SI-1b
Phase 1 (link+migration #2643) → Phase 2 (attach #2644) → Phase 3 (spine query #2646) → **Phase 4 (FE strip)**. Note: `GameNightStatus` may read "Published" during play until #2647 (pre-existing #15 gap) is fixed; the strip shows the live badge from the authoritative `HasLiveSession`.

Refs #2632 · part of #2619

🤖 Generated with [Claude Code](https://claude.com/claude-code)