### PR TITLE
fix(staging): #2613 SkipAnalyzers nei build .NET del deploy per evitare OOM Roslyn

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -354,6 +354,17 @@ jobs:
 
       - name: Backend build check
         if: needs.detect-changes.outputs.deploy_api == 'true'
+        # Issue #2613: SkipAnalyzers=true evita l'OutOfMemoryException del Roslyn
+        # AnalyzerDriver sotto il cap MemoryMax=3G del runner self-hosted (#2336).
+        # MSBuild raccoglie la env var come proprietà globale, attivando il
+        # PropertyGroup condizionale di Api.csproj (righe 40-45) che disabilita
+        # l'intera suite analyzer (NetAnalyzers/Sonar/Meziantou/NoPiiInLog) —
+        # stesso meccanismo già usato dal Dockerfile per lo stesso OOM durante
+        # `dotnet publish`. Nessuna perdita di copertura reale: CodeQL su PR/push
+        # + CI su main-dev sono l'enforcement autoritativo (Api.csproj:11-17) e
+        # questo commit vi è già passato (vedi "Verify CI passed" sopra).
+        env:
+          SkipAnalyzers: 'true'
         run: |
           echo "🔨 Verifying backend compiles..."
           cd apps/api/src/Api
@@ -761,6 +772,10 @@ jobs:
       - name: Restore and build API project (for ef tools)
         if: vars.DEPLOY_METHOD == 'ssh'
         working-directory: apps/api/src/Api
+        # Issue #2613: vedi "Backend build check" — stessa env var per evitare
+        # l'OOM del Roslyn AnalyzerDriver. Copre questo `dotnet build` esplicito.
+        env:
+          SkipAnalyzers: 'true'
         run: |
           dotnet restore
           dotnet build --no-restore -c Release
@@ -768,6 +783,12 @@ jobs:
       - name: Generate idempotent migration SQL
         if: vars.DEPLOY_METHOD == 'ssh'
         working-directory: apps/api/src/Api
+        # Issue #2613: dotnet ef qui ricompila il progetto (nessun --no-build,
+        # per scelta deliberata sotto). Quel rebuild implicito riattiverebbe gli
+        # analyzer e andrebbe in OOM come gli step `dotnet build` espliciti — la
+        # env var SkipAnalyzers=true copre anche questo path (3° punto di build).
+        env:
+          SkipAnalyzers: 'true'
         run: |
           # No --no-build: dotnet-ef needs the project built. Built in prior
           # step; let ef trigger its own build without the flag to avoid


### PR DESCRIPTION
## Contesto

Closes #2613. Sblocca #1990 Phase B (parent), tracked in epic #1535.

Il `dotnet build` di `Api.csproj` lancia `System.OutOfMemoryException` nel Roslyn `AnalyzerDriver` sotto il cap `MemoryMax=3G` del runner self-hosted introdotto da #2336. Il fix di #2336 non ha causato un nuovo bug: ha spostato una failure latente da "kernel OOM-killer uccide il runner" (#2019, CLOSED) a "processo di build OOM sotto il cap". Risultato: zero deploy staging verdi, container live indietro di ~99 commit.

## Soluzione — Opzione 2 (spec-panel)

Applica `SkipAnalyzers=true` come **variabile d'ambiente** ai punti di build .NET del deploy. MSBuild la raccoglie come proprietà globale, attivando il `PropertyGroup` condizionale **già presente** in `Api.csproj:40-45`, che disabilita l'intera suite analyzer (NetAnalyzers / SonarAnalyzer / Meziantou / NoPiiInLog).

**3 punti coperti** (l'issue ne citava 2):
1. Pre-deploy Validation → **Backend build check** (`dotnet build` Release)
2. Deploy → **Restore and build API project (for ef tools)** (`dotnet build` Release)
3. Deploy → **Generate idempotent migration SQL** — `dotnet ef migrations script` gira **senza `--no-build`** e ricompila (in Debug) riattivando gli analyzer. Non menzionato nell'issue; è il motivo per cui serve la env var e non un `-p:` sul singolo `dotnet build`.

## Perché env var e non `-p:RunAnalyzersDuringBuild=false` (Opzione 2 originale)

- `RunAnalyzersDuringBuild=false` da solo è **parziale**: non tocca `EnableNETAnalyzers` né `EnforceCodeStyleInBuild`, entrambi attivi con `TreatWarningsAsErrors=true`. `SkipAnalyzers=true` li disabilita tutti insieme (meccanismo atomico già collaudato).
- La env var copre uniformemente anche il **rebuild implicito di `dotnet ef`** (sub-processo MSBuild separato).
- Stesso identico meccanismo già usato dal `Dockerfile:51-54` (`-p:SkipAnalyzers=true`) per lo stesso OOM durante `dotnet publish`.

## Nessuna perdita di copertura

Gli analyzer restano enforced dove sono **autoritativi**: CodeQL su PR/push + CI su `main-dev` (`Api.csproj:11-17`). `main-staging` riceve solo commit già passati da quel gate (`deploy-staging.yml` step "Verify CI passed on this commit"). L'immagine effettivamente deployata **già** compila con analyzer OFF (`Dockerfile:54`) — farli girare al deploy non copriva alcun artefatto reale.

## Opzioni scartate

- **Opzione 1 (host headroom: swap / alzare `MemoryMax`)** — reintroduce la failure di #2336 (kernel OOM-killer) e lo **swap thrashing** già causa di incidente sul VPS (`deploy-staging.yml:385-388`, run 25563055758). Non versionata. Documentabile solo come runbook di emergenza manuale, non come fix.
- **Opzione 3 (immagine con `dotnet-ef` pre-installato)** — direzione architetturale più pulita (elimina il build .NET dall'host di deploy) ma overkill per lo sblocco immediato e non copre il "Backend build check" della Pre-deploy Validation. Candidata a issue di follow-up (debito tecnico).

## Verifica

- ✅ Sintassi YAML validata (`yaml.safe_load`, 12 job parsati)
- ✅ 3 env var `SkipAnalyzers: 'true'` in posizione
- ✅ Pre-commit hooks verdi (typecheck FE)
- ⚠️ **Verifica end-to-end** (deploy staging verde) richiede l'esecuzione del workflow sul runner self-hosted — non replicabile localmente. Da confermare al primo `workflow_dispatch` / merge su `main-staging`.

## Refs
- Closes #2613
- Parent: #1990 (Phase B soak, bloccata su questo)
- #2336 (runner `MemoryMax=3G`, ha spostato il failure mode)
- #2019 (runner OOM, CLOSED — failure mode diverso)
- #2020 (idempotenza migration già gestita nello step "Apply migrations")

🤖 Generated with [Claude Code](https://claude.com/claude-code)