### PR TITLE
feat(game-night): night-live read model GET /game-nights/{id}/live (Slice A, #2633)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/GameNights/GameNightLiveDto.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/GameNights/GameNightLiveDto.cs
@@ -1,0 +1,31 @@
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+
+namespace Api.BoundedContexts.GameManagement.Application.DTOs.GameNights;
+
+/// <summary>
+/// Read model for the night-live view (SI-2 #2633 prerequisite, spec
+/// 2026-07-01-game-night-live-wire-design). The list <see cref="GameNightDto"/> stays lean;
+/// this is the distinct live read concern — the night header + its session progression, which
+/// the FE <c>useGameNightLive(id)</c> hook maps onto the (currently fixture) NightLiveHub.
+/// </summary>
+public sealed record GameNightLiveDto(
+    Guid Id,
+    string Title,
+    GameNightStatus Status,
+    IReadOnlyList<GameNightSessionDto> Sessions);
+
+/// <summary>
+/// A single sitting within the night — a projection of the <c>GameNightSession</c> child entity.
+/// Score and estimated-time (fixture-only in the mockup) are intentionally omitted: they are not
+/// in the domain (spec decision D-SCORE/TIME). Elapsed/duration is derivable from
+/// <see cref="StartedAt"/>/<see cref="CompletedAt"/> on the FE.
+/// </summary>
+public sealed record GameNightSessionDto(
+    Guid SessionId,
+    Guid GameId,
+    string GameTitle,
+    int PlayOrder,
+    GameNightSessionStatus Status,
+    Guid? WinnerId,
+    DateTimeOffset? StartedAt,
+    DateTimeOffset? CompletedAt);

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GetGameNightLiveQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GetGameNightLiveQuery.cs
@@ -5,6 +5,8 @@ namespace Api.BoundedContexts.GameManagement.Application.Queries.GameNights;
 
 /// <summary>
 /// #2633 Slice A: the night-live read model — the night header + its session progression.
-/// Any authenticated user can read it (mirrors <c>GetGameNightByIdQuery</c>).
+/// Restricted to participants (organizer or an invited player) — unlike the lean
+/// <c>GetGameNightByIdQuery</c>, this exposes per-session <c>WinnerId</c> (user GUIDs) + progression,
+/// so it must not be readable by arbitrary authenticated users (code-review finding).
 /// </summary>
-internal record GetGameNightLiveQuery(Guid GameNightId) : IQuery<GameNightLiveDto>;
+internal record GetGameNightLiveQuery(Guid GameNightId, Guid CallerUserId) : IQuery<GameNightLiveDto>;

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GetGameNightLiveQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GetGameNightLiveQuery.cs
@@ -1,0 +1,10 @@
+using Api.BoundedContexts.GameManagement.Application.DTOs.GameNights;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.GameManagement.Application.Queries.GameNights;
+
+/// <summary>
+/// #2633 Slice A: the night-live read model — the night header + its session progression.
+/// Any authenticated user can read it (mirrors <c>GetGameNightByIdQuery</c>).
+/// </summary>
+internal record GetGameNightLiveQuery(Guid GameNightId) : IQuery<GameNightLiveDto>;

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GetGameNightLiveQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GetGameNightLiveQueryHandler.cs
@@ -1,0 +1,44 @@
+using Api.BoundedContexts.GameManagement.Application.DTOs.GameNights;
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.GameManagement.Application.Queries.GameNights;
+
+/// <summary>
+/// Handles <see cref="GetGameNightLiveQuery"/>. Loads the <c>GameNightEvent</c> (its child
+/// <c>Sessions</c> are already Included by the repository) and projects it to the live read model,
+/// ordering sessions by play order.
+/// </summary>
+internal sealed class GetGameNightLiveQueryHandler : IQueryHandler<GetGameNightLiveQuery, GameNightLiveDto>
+{
+    private readonly IGameNightEventRepository _repository;
+
+    public GetGameNightLiveQueryHandler(IGameNightEventRepository repository)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+    }
+
+    public async Task<GameNightLiveDto> Handle(GetGameNightLiveQuery query, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var gameNight = await _repository.GetByIdAsync(query.GameNightId, cancellationToken).ConfigureAwait(false)
+            ?? throw new NotFoundException("GameNightEvent", query.GameNightId.ToString());
+
+        var sessions = gameNight.Sessions
+            .OrderBy(s => s.PlayOrder)
+            .Select(s => new GameNightSessionDto(
+                s.SessionId,
+                s.GameId,
+                s.GameTitle,
+                s.PlayOrder,
+                s.Status,
+                s.WinnerId,
+                s.StartedAt,
+                s.CompletedAt))
+            .ToList();
+
+        return new GameNightLiveDto(gameNight.Id, gameNight.Title, gameNight.Status, sessions);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GetGameNightLiveQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GetGameNightLiveQueryHandler.cs
@@ -26,6 +26,12 @@ internal sealed class GetGameNightLiveQueryHandler : IQueryHandler<GetGameNightL
         var gameNight = await _repository.GetByIdAsync(query.GameNightId, cancellationToken).ConfigureAwait(false)
             ?? throw new NotFoundException("GameNightEvent", query.GameNightId.ToString());
 
+        // Participant-only: the live read exposes per-session WinnerId (user GUIDs) + progression.
+        var isParticipant = gameNight.OrganizerId == query.CallerUserId
+            || gameNight.Rsvps.Any(r => r.UserId == query.CallerUserId);
+        if (!isParticipant)
+            throw new ForbiddenException("Only the organizer or an invited player can view the night-live state.");
+
         var sessions = gameNight.Sessions
             .OrderBy(s => s.PlayOrder)
             .Select(s => new GameNightSessionDto(

--- a/apps/api/src/Api/Routing/GameNightEndpoints.cs
+++ b/apps/api/src/Api/Routing/GameNightEndpoints.cs
@@ -83,6 +83,16 @@ internal static class GameNightEndpoints
             .WithSummary("Get a game night by ID")
             .WithDescription("Retrieves full details of a game night event.");
 
+        // #2633 Slice A: night-live read model (header + session progression) for useGameNightLive.
+        gameNights.MapGet("/{id:guid}/live", HandleGetGameNightLive)
+            .RequireAuthenticatedUser()
+            .Produces<GameNightLiveDto>(200)
+            .Produces(404)
+            .Produces(401)
+            .WithName("GetGameNightLive")
+            .WithSummary("Get the night-live read model")
+            .WithDescription("Returns the game night header + its session progression (status/winner/timing per game) for the live view.");
+
         gameNights.MapPut("/{id:guid}", HandleUpdateGameNight)
             .RequireAuthenticatedUser()
             .Produces(204)
@@ -571,6 +581,15 @@ internal static class GameNightEndpoints
         CancellationToken cancellationToken)
     {
         var result = await mediator.Send(new GetGameNightByIdQuery(id), cancellationToken).ConfigureAwait(false);
+        return Results.Ok(result);
+    }
+
+    private static async Task<IResult> HandleGetGameNightLive(
+        Guid id,
+        [FromServices] IMediator mediator,
+        CancellationToken cancellationToken)
+    {
+        var result = await mediator.Send(new GetGameNightLiveQuery(id), cancellationToken).ConfigureAwait(false);
         return Results.Ok(result);
     }
 

--- a/apps/api/src/Api/Routing/GameNightEndpoints.cs
+++ b/apps/api/src/Api/Routing/GameNightEndpoints.cs
@@ -87,6 +87,7 @@ internal static class GameNightEndpoints
         gameNights.MapGet("/{id:guid}/live", HandleGetGameNightLive)
             .RequireAuthenticatedUser()
             .Produces<GameNightLiveDto>(200)
+            .Produces(403)
             .Produces(404)
             .Produces(401)
             .WithName("GetGameNightLive")
@@ -587,9 +588,11 @@ internal static class GameNightEndpoints
     private static async Task<IResult> HandleGetGameNightLive(
         Guid id,
         [FromServices] IMediator mediator,
+        HttpContext httpContext,
         CancellationToken cancellationToken)
     {
-        var result = await mediator.Send(new GetGameNightLiveQuery(id), cancellationToken).ConfigureAwait(false);
+        var userId = httpContext.User.GetUserId();
+        var result = await mediator.Send(new GetGameNightLiveQuery(id, userId), cancellationToken).ConfigureAwait(false);
         return Results.Ok(result);
     }
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/GameNight/GetGameNightLiveQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/GameNight/GetGameNightLiveQueryHandlerTests.cs
@@ -1,0 +1,87 @@
+using Api.BoundedContexts.GameManagement.Application.Queries.GameNights;
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+using Api.Middleware.Exceptions;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Application.GameNight;
+
+/// <summary>
+/// #2633 Slice A: the night-live read model projects the night header + its session progression
+/// (status/order/winner/timing) so the FE can wire NightLiveClientView off fixtures.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "GameManagement")]
+public class GetGameNightLiveQueryHandlerTests
+{
+    private readonly Mock<IGameNightEventRepository> _repo = new();
+    private readonly GetGameNightLiveQueryHandler _handler;
+
+    public GetGameNightLiveQueryHandlerTests()
+    {
+        _handler = new GetGameNightLiveQueryHandler(_repo.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ProjectsSessions_OrderedByPlayOrderWithStatuses()
+    {
+        var evt = GameNightEvent.Create(
+            Guid.NewGuid(), "Serata da Marco", DateTimeOffset.UtcNow.AddHours(1),
+            gameIds: [Guid.NewGuid(), Guid.NewGuid()]);
+        evt.Publish([]);
+        var s1 = Guid.NewGuid();
+        var s2 = Guid.NewGuid();
+        evt.AddSession(s1, evt.GameIds[0], "Brass: Birmingham"); // PlayOrder 1
+        evt.AddSession(s2, evt.GameIds[1], "Spirit Island"); // PlayOrder 2
+        evt.StartCurrentSession(); // s1 → InProgress
+        _repo.Setup(r => r.GetByIdAsync(evt.Id, It.IsAny<CancellationToken>())).ReturnsAsync(evt);
+
+        var result = await _handler.Handle(
+            new GetGameNightLiveQuery(evt.Id), TestContext.Current.CancellationToken);
+
+        result.Id.Should().Be(evt.Id);
+        result.Title.Should().Be("Serata da Marco");
+        result.Status.Should().Be(GameNightStatus.Published);
+        result.Sessions.Should().HaveCount(2);
+
+        result.Sessions[0].PlayOrder.Should().Be(1);
+        result.Sessions[0].SessionId.Should().Be(s1);
+        result.Sessions[0].GameTitle.Should().Be("Brass: Birmingham");
+        result.Sessions[0].Status.Should().Be(GameNightSessionStatus.InProgress);
+        result.Sessions[0].StartedAt.Should().NotBeNull();
+
+        result.Sessions[1].PlayOrder.Should().Be(2);
+        result.Sessions[1].GameTitle.Should().Be("Spirit Island");
+        result.Sessions[1].Status.Should().Be(GameNightSessionStatus.Pending);
+        result.Sessions[1].StartedAt.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_NoSessions_ReturnsEmptyList()
+    {
+        var evt = GameNightEvent.Create(
+            Guid.NewGuid(), "Serata vuota", DateTimeOffset.UtcNow.AddHours(1), gameIds: [Guid.NewGuid()]);
+        evt.Publish([]);
+        _repo.Setup(r => r.GetByIdAsync(evt.Id, It.IsAny<CancellationToken>())).ReturnsAsync(evt);
+
+        var result = await _handler.Handle(
+            new GetGameNightLiveQuery(evt.Id), TestContext.Current.CancellationToken);
+
+        result.Sessions.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Handle_NotFound_ThrowsNotFound()
+    {
+        _repo.Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((GameNightEvent?)null);
+
+        var act = () => _handler.Handle(
+            new GetGameNightLiveQuery(Guid.NewGuid()), TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/GameNight/GetGameNightLiveQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/GameNight/GetGameNightLiveQueryHandlerTests.cs
@@ -40,7 +40,7 @@ public class GetGameNightLiveQueryHandlerTests
         _repo.Setup(r => r.GetByIdAsync(evt.Id, It.IsAny<CancellationToken>())).ReturnsAsync(evt);
 
         var result = await _handler.Handle(
-            new GetGameNightLiveQuery(evt.Id), TestContext.Current.CancellationToken);
+            new GetGameNightLiveQuery(evt.Id, evt.OrganizerId), TestContext.Current.CancellationToken);
 
         result.Id.Should().Be(evt.Id);
         result.Title.Should().Be("Serata da Marco");
@@ -68,9 +68,24 @@ public class GetGameNightLiveQueryHandlerTests
         _repo.Setup(r => r.GetByIdAsync(evt.Id, It.IsAny<CancellationToken>())).ReturnsAsync(evt);
 
         var result = await _handler.Handle(
-            new GetGameNightLiveQuery(evt.Id), TestContext.Current.CancellationToken);
+            new GetGameNightLiveQuery(evt.Id, evt.OrganizerId), TestContext.Current.CancellationToken);
 
         result.Sessions.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Handle_NonParticipant_ThrowsForbidden()
+    {
+        var evt = GameNightEvent.Create(
+            Guid.NewGuid(), "Serata privata", DateTimeOffset.UtcNow.AddHours(1), gameIds: [Guid.NewGuid()]);
+        evt.Publish([]);
+        _repo.Setup(r => r.GetByIdAsync(evt.Id, It.IsAny<CancellationToken>())).ReturnsAsync(evt);
+
+        // A random authenticated user who is neither the organizer nor invited.
+        var act = () => _handler.Handle(
+            new GetGameNightLiveQuery(evt.Id, Guid.NewGuid()), TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<ForbiddenException>();
     }
 
     [Fact]
@@ -80,7 +95,7 @@ public class GetGameNightLiveQueryHandlerTests
             .ReturnsAsync((GameNightEvent?)null);
 
         var act = () => _handler.Handle(
-            new GetGameNightLiveQuery(Guid.NewGuid()), TestContext.Current.CancellationToken);
+            new GetGameNightLiveQuery(Guid.NewGuid(), Guid.NewGuid()), TestContext.Current.CancellationToken);
 
         await act.Should().ThrowAsync<NotFoundException>();
     }


### PR DESCRIPTION
First slice of the night-live wire-up ([spec](../blob/main-dev/docs/for-developers/specs/2026-07-01-game-night-live-wire-design.md)), the prerequisite for **SI-2 (#2633)**. Surfaces the night's session progression that `GameNightDto` omits, unblocking the FE `useGameNightLive(id)` hook (Slice B).

## Changes
- `GameNightLiveDto` (Id, Title, Status, Sessions[]) + `GameNightSessionDto` (SessionId, GameId, GameTitle, PlayOrder, Status, WinnerId, StartedAt, CompletedAt) — projection of the `GameNightSession` children (already Included by the repo). Score/estimated-time omitted (D-SCORE/TIME: fixture-only, not in domain).
- `GetGameNightLiveQuery` + handler (mirrors `GetGameNightByIdQuery`; ordered by PlayOrder).
- Endpoint `GET /api/v1/game-nights/{id}/live` (200/403/404/401).

## Review
Adversarial pass: 0 critical; confirmed correct (projection, null-safety, enum→string via JsonStringEnumConverter, CQRS conventions). **1 fix applied**: the read exposes `WinnerId` user GUIDs → added a **participant-only guard** (organizer OR invited player → else 403), tightening the spec's D-READ.

## Tests
4 unit (ordered projection w/ statuses+timing, empty sessions, non-participant→403, not-found). Build clean. Additive read-only, no new domain.

Next: Slice B (FE `useGameNightLive` + header + planned games). Refs #2633 · relates #2632

🤖 Generated with [Claude Code](https://claude.com/claude-code)