### PR TITLE
feat(staging): #2650 genera la migration SQL sul cloud (Opzione 3 #2613)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -53,24 +53,31 @@ on:
 # Switching to true makes a fresh trigger CANCEL the stuck run and start clean,
 # so the pipeline is self-healing. This is safe because every stage is
 # idempotent and re-runnable:
-#   - deploy.steps."Generate idempotent migration SQL": produces SQL with every
-#     migration wrapped in IF NOT EXISTS vs __EFMigrationsHistory. Re-running
-#     re-emits identical SQL — no DB side effects yet.
-#   - deploy.steps."Apply migrations on staging": uses that idempotent SQL,
-#     so re-applying is a no-op when no new migrations exist. Includes a
-#     pre-flight check against __EFMigrationsHistory (fixes #2020) to skip
-#     psql apply when the script's target migration is already recorded —
-#     necessary because EF's idempotent generator hoists CREATE TABLE /
+#   - generate-migration job (issue #2650): produces SQL with every migration
+#     wrapped in IF NOT EXISTS vs __EFMigrationsHistory. Re-running re-emits
+#     identical SQL — no DB side effects yet. Runs on the CLOUD runner.
+#   - deploy.steps."Apply migrations on staging": uses that idempotent SQL
+#     (downloaded as artifact), so re-applying is a no-op when no new migrations
+#     exist. Includes a pre-flight check against __EFMigrationsHistory (fixes
+#     #2020) to skip psql apply when the script's target migration is already
+#     recorded — necessary because EF's idempotent generator hoists CREATE TABLE /
 #     CREATE EXTENSION outside the IF NOT EXISTS guard for squashed
 #     InitialCreate migrations, causing "relation already exists" otherwise.
 #   - deploy.steps."Deploy via SSH": `docker compose up --force-recreate`
 #     converges to the target image regardless of partial prior state.
 # A mid-flight cancel therefore can't corrupt staging; the next run re-converges.
 #
-# Architectural rework (also tracked in #1573, NOW SHIPPED with this commit):
-#   - migrate-db job collapsed: SQL generation AND apply moved as steps INSIDE
+# Architectural rework (tracked in #1573, then #2650):
+#   - #1573: migrate-db job collapsed — SQL generation AND apply moved INSIDE
 #     the deploy job (Plan B, fully inline). If the deploy is never picked by
-#     the runner, the migration is never applied — atomicity is now job-level.
+#     the runner, the migration is never applied — atomicity is job-level.
+#   - #2650 (Opzione 3): SQL GENERATION lifted back out to the `generate-migration`
+#     CLOUD job (removes the .NET build from the resource-constrained self-hosted
+#     host → no Roslyn OOM). APPLY stays inline in deploy, so job-level atomicity
+#     is preserved: the side-effect-free generation moved upstream; the DB write
+#     did not. The #1596 skip-propagation trap (a cloud SQL-gen job skipped under
+#     workflow_dispatch+skip_tests) is avoided via `always()`-based gating on the
+#     new job, identical to build/build-ai.
 # Still deferred: queue-time watchdog for self-hosted jobs (#1573 P1).
 concurrency:
   group: deploy-staging
@@ -125,7 +132,7 @@ jobs:
       commit_sha: ${{ github.event.workflow_run.head_sha || github.sha }}
       commit_message: ${{ github.event.workflow_run.head_commit.message || github.event.head_commit.message || 'Manual trigger' }}
       run_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-      job_list: '["detect-changes", "pre-deploy-check", "build", "snapshot-baseline", "deploy", "validate", "e2e-staging"]'
+      job_list: '["detect-changes", "pre-deploy-check", "build", "generate-migration", "snapshot-baseline", "deploy", "validate", "e2e-staging"]'
       caller_workflow_id: ${{ github.workflow_id }}
     secrets:
       SLACK_GITNOTIFY_WEBHOOK_URL: ${{ secrets.SLACK_GITNOTIFY_WEBHOOK_URL }}
@@ -533,6 +540,101 @@ jobs:
           echo "  API built: ${{ needs.detect-changes.outputs.deploy_api }}"
           echo "  Web built: ${{ needs.detect-changes.outputs.deploy_web }}"
 
+  # Generate the idempotent migration SQL in the CLOUD (issue #2650, Opzione 3).
+  # ============================================================================
+  # Rationale: il job Deploy gira sul runner self-hosted (staging VPS ~8GB, cap
+  # MemoryMax=3G). Compilare Api.csproj lì per far girare dotnet-ef mandava in OOM
+  # il Roslyn AnalyzerDriver (#2613, mitigato con SkipAnalyzers in #2649). Questo
+  # job sposta la compilazione .NET + dotnet-ef sul cloud runner (ubuntu-latest,
+  # RAM abbondante), produce lo script SQL idempotente e lo passa al Deploy come
+  # artifact. Il Deploy non compila più .NET per i punti #2/#3 (vedi issue #2650).
+  #
+  # Vincolo #1596 (Plan A fallito): un job cloud separato che genera SQL fu già
+  # tentato e falliva perché GHA lo SKIPPAVA sotto workflow_dispatch+skip_tests,
+  # lasciando il download senza artifact. Fix qui: gating `always() && (...)`
+  # IDENTICO ai job build/build-ai — così questo job NON viene skippato dalla
+  # propagazione. Il download nel Deploy e questo job condividono lo stesso gate
+  # (`vars.DEPLOY_METHOD == 'ssh'`), quindi l'artifact esiste sempre quando serve.
+  #
+  # Atomicità (#1573) e idempotenza (#2020) PRESERVATE: qui si GENERA solo lo SQL
+  # (nessun side-effect sul DB). L'APPLY (backup + pre-flight __EFMigrationsHistory
+  # + psql ON_ERROR_STOP) resta inline nel job Deploy, invariato.
+  generate-migration:
+    name: Generate Migration SQL (cloud)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    needs: [pre-deploy-check, detect-changes]
+    if: always() && (needs.pre-deploy-check.result == 'success' || (github.event_name == 'workflow_dispatch' && inputs.skip_tests == true)) && vars.DEPLOY_METHOD == 'ssh'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ env.DEPLOY_SHA }}  # Spec R2: pin to actual deploy SHA
+          # apps/api/ per il build; data/rulebook/golden/ (~52K) IS included:
+          # Api.csproj embeds these JSON fixtures come risorse (ADR-051). Senza,
+          # dotnet build fallisce con CS1566 (Error reading resource ...golden-claims.json).
+          sparse-checkout: |
+            apps/api/
+            data/rulebook/golden/
+          sparse-checkout-cone-mode: true
+
+      - name: Setup .NET SDK
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: Install dotnet-ef tool
+        run: |
+          if dotnet tool list --global | awk '{print $1}' | grep -qx 'dotnet-ef'; then
+            echo "dotnet-ef already installed globally — using existing version:"
+            dotnet tool list --global | grep '^dotnet-ef'
+          else
+            dotnet tool install --global dotnet-ef --version 9.*
+          fi
+          echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
+
+      - name: Restore and build API project
+        working-directory: apps/api/src/Api
+        # SkipAnalyzers=true: qui NON per OOM (il cloud runner ha RAM), ma per
+        # velocità e coerenza — gli analyzer sono già enforced in modo autoritativo
+        # da CodeQL/CI su main-dev (Api.csproj:11-17); ri-eseguirli al deploy è
+        # ridondante (stessa logica dei commenti "Verify CI passed" del workflow).
+        env:
+          SkipAnalyzers: 'true'
+        run: |
+          dotnet restore
+          dotnet build --no-restore -c Release
+
+      - name: Generate idempotent migration SQL
+        working-directory: apps/api/src/Api
+        env:
+          SkipAnalyzers: 'true'
+        run: |
+          # --no-build: riusa l'assembly appena prodotto dallo step precedente
+          # (evita che dotnet-ef ricompili). --configuration Release è OBBLIGATORIO
+          # con --no-build: dotnet ef NON eredita la config dell'ultima build e
+          # risolverebbe l'assembly in Debug (default), fallendo con
+          # "bin/Debug/.../Api.deps.json does not exist" (exit 129) perché abbiamo
+          # buildato solo Release. Verificato empiricamente su dotnet-ef 9.0.11.
+          dotnet ef migrations script --idempotent --no-build --configuration Release -o "$RUNNER_TEMP/migrations.sql"
+          test -f "$RUNNER_TEMP/migrations.sql" || { echo "❌ dotnet ef non ha prodotto il file SQL"; exit 1; }
+          lines=$(wc -l < "$RUNNER_TEMP/migrations.sql")
+          echo "✅ Generated ${lines} lines of SQL at $RUNNER_TEMP/migrations.sql"
+          if [ "$lines" -lt 10 ]; then
+            echo "❌ SQL output suspiciously small (< 10 lines). Aborting."
+            exit 1
+          fi
+
+      - name: Upload migration SQL artifact
+        uses: actions/upload-artifact@v7
+        with:
+          # run-id suffix per coerenza con la convenzione repo (ci.yml) e per
+          # isolamento cross-run difensivo, oltre al concurrency group.
+          name: migration-sql-${{ github.run_id }}
+          path: ${{ runner.temp }}/migrations.sql
+          retention-days: 1
+          if-no-files-found: error
+
   # Build and push AI service images (only changed ones). Issue #1578.
   # Separate from `build` so the slow torch QEMU builds run in parallel
   # (matrix), with per-service timeout, and a single failure does not block
@@ -681,47 +783,56 @@ jobs:
 
   # Deploy to staging server (only changed services).
   #
-  # Issue #1573 — atomicity rework (Plan B: fully inline)
-  # ============================================
-  # The migration GENERATE AND APPLY steps both live in this job (the previous
-  # separate `migrate-db` job ran BEFORE deploy and could leave the DB ahead of
-  # the containers if deploy was orphaned in the runner queue — 2026-05-26
-  # incident, 1h45m of schema/code drift). The sequence inside this job is:
-  #   1. Setup .NET + dotnet-ef + Restore/build API
-  #   2. Generate idempotent migration SQL via dotnet ef migrations script
-  #   3. Apply migrations via SSH (pre-migration backup + psql ON_ERROR_STOP)
-  #   4. Deploy via SSH (docker pull + compose up + health checks)
+  # Issue #1573 — atomicity rework; Issue #2650 — SQL generation lifted to cloud
+  # ============================================================================
+  # The migration APPLY step lives in this job (the previous separate `migrate-db`
+  # job ran BEFORE deploy and could leave the DB ahead of the containers if deploy
+  # was orphaned in the runner queue — 2026-05-26 incident, 1h45m of schema/code
+  # drift). The sequence inside this job is now:
+  #   1. Download migration SQL artifact (generated by the cloud generate-migration job, #2650)
+  #   2. Apply migrations via SSH (pre-migration backup + psql ON_ERROR_STOP)
+  #   3. Deploy via SSH (docker pull + compose up + health checks)
   # All steps gated on vars.DEPLOY_METHOD == 'ssh' so non-SSH deploys skip them.
   # If this job is never picked by the runner, NO migration is applied —
-  # atomicity is guaranteed by job-level pickup.
+  # atomicity is guaranteed by job-level pickup (the APPLY is here; only the
+  # side-effect-free GENERATION moved upstream to the cloud in #2650).
   #
+  # HISTORY — Plan A / #1596 / #2650:
   # Plan A (split: generate-migration-sql cloud job + deploy with artifact
-  # download) was tried in commit 7cfc9c7a3 and skipped/failed under
-  # workflow_dispatch with skip_tests=true: the generate-migration-sql job
-  # was skipped by GHA scheduling, leaving the download step with no artifact.
-  # See PR #1596 review for full incident analysis.
+  # download) was first tried in commit 7cfc9c7a3 and skipped/failed under
+  # workflow_dispatch with skip_tests=true: the cloud job was skipped by GHA
+  # scheduling, leaving the download step with no artifact (PR #1596). It was
+  # reverted to fully-inline (Plan B). Issue #2650 re-introduces the cloud
+  # generation job (`generate-migration`) but FIXES the #1596 root cause: the
+  # new job uses `always()`-based gating IDENTICAL to build/build-ai, so GHA
+  # does not skip it under workflow_dispatch+skip_tests. Both the cloud job and
+  # this Download step share the same `vars.DEPLOY_METHOD == 'ssh'` gate, so the
+  # artifact always exists when the Download runs.
   deploy:
     name: Deploy to Staging
     runs-on: ${{ vars.RUNNER && fromJSON(vars.RUNNER) || 'ubuntu-latest' }}
     # Issue #1573: bumped 15 → 30 to absorb the inlined migration handling.
-    # Worst-case step times on cold self-hosted runner:
-    #   - Restore + build API project (for dotnet-ef): 3-8 min (NuGet network)
-    #   - Generate idempotent migration SQL: 2-3 min
+    # Issue #2650: the .NET build + `dotnet ef` (formerly ~5-11 min on cold cache)
+    # moved to the cloud generate-migration job, so the self-hosted deploy job is
+    # lighter now. Worst-case remaining step times on cold self-hosted runner:
+    #   - Download migration SQL artifact: <1 min
     #   - Apply migrations on staging (backup + scp + psql + verify): 5-10 min
     #   - Deploy via SSH (pull + compose up + health checks): 3-5 min
-    # Total: ~26 min worst case → ~4 min headroom under timeout-minutes: 30.
-    # Observed actuals (run 26472087138, push to main-staging): deploy job
-    # completed in 13m38s. Margin is tight on cold-cache builds; bump to 40
-    # if NuGet restore consistently exceeds 8 min.
+    # Total: ~16 min worst case → comfortable headroom under timeout-minutes: 30
+    # (kept at 30; could be lowered to 20 once the new timing is observed).
+    # Observed actuals pre-#2650 (run 26472087138): deploy job 13m38s.
     timeout-minutes: 30
-    needs: [detect-changes, build, build-ai, snapshot-baseline]
+    needs: [detect-changes, build, generate-migration, build-ai, snapshot-baseline]
     # Issue #1578 — skip-propagation handling. An AI-only deploy has `build`
     # (api/web) skipped, so `build` may be 'success' OR 'skipped'. build-ai may
     # be 'success' (built) or 'skipped' (no AI change); a build-ai FAILURE
     # (success||skipped false) blocks the deploy on purpose — don't deploy when
     # an image we asked to build failed. snapshot-baseline may be skipped on
     # AI-only deploys (it gates on `build`).
-    if: always() && (needs.build.result == 'success' || needs.build.result == 'skipped') && (needs.build-ai.result == 'success' || needs.build-ai.result == 'skipped') && (needs.snapshot-baseline.result == 'success' || needs.snapshot-baseline.result == 'skipped')
+    # Issue #2650 — generate-migration: 'success' su deploy SSH (genera lo SQL in
+    # cloud), 'skipped' su DEPLOY_METHOD != ssh. Un FAILURE blocca il deploy di
+    # proposito: non deployare se la generazione della migration è fallita.
+    if: always() && (needs.build.result == 'success' || needs.build.result == 'skipped') && (needs.generate-migration.result == 'success' || needs.generate-migration.result == 'skipped') && (needs.build-ai.result == 'success' || needs.build-ai.result == 'skipped') && (needs.snapshot-baseline.result == 'success' || needs.snapshot-baseline.result == 'skipped')
     environment:
       name: staging
       url: https://meepleai.app
@@ -730,10 +841,11 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ env.DEPLOY_SHA }}  # Spec R2: pin to actual deploy SHA
-          # sparse-checkout: apps/api/ needed for dotnet ef gen below.
-          # data/rulebook/golden/ (~52K) IS included: Api.csproj embeds these
-          # JSON fixtures as resources (ADR-051). Without it, dotnet build
-          # fails with CS1566 (Error reading resource ...golden-claims.json).
+          # Issue #2650: apps/api/ + data/rulebook/golden/ NON servono più a
+          # questo job per compilare .NET (il gen ef è sul cloud generate-migration
+          # job). Restano nel checkout come cleanup-candidate a basso valore —
+          # rimuoverli è un follow-up opzionale, tenuto fuori da questa PR per
+          # non allargare il blast radius. infra/ serve al Deploy via SSH.
           # Excludes the rest of data/ (1.3GB PDFs) — runner disk is limited.
           sparse-checkout: |
             apps/api/
@@ -742,64 +854,32 @@ jobs:
             data/rulebook/golden/
           sparse-checkout-cone-mode: true
 
-      # Issue #1573: migration gen + apply moved here (inline) from the removed
-      # `migrate-db` job. If this job is never picked up by the runner, no
-      # migration is applied — DB schema cannot drift from deployed code.
-      - name: Setup .NET SDK
+      # Issue #2650 (Opzione 3): lo SQL idempotente è ora generato dal job
+      # `generate-migration` sul CLOUD runner (nessuna compilazione .NET
+      # sull'host di deploy → niente OOM Roslyn). Qui lo scarichiamo come
+      # artifact in /tmp/migrations.sql, il path che lo step "Apply migrations"
+      # sotto già consuma.
+      #
+      # Presenza dell'artifact: garantita quando generate-migration ha GIRATO —
+      # cioè quando pre-deploy-check è passato OPPURE (workflow_dispatch &&
+      # skip_tests) — sotto DEPLOY_METHOD==ssh (questo è il caso #1596, risolto).
+      # Edge fail-safe residuo: su PUSH con pre-deploy-check FALLITO, il deploy
+      # gira comunque (deploy.if tollera build/generate-migration 'skipped' —
+      # weakness PRE-ESISTENTE di deploy.if, non introdotta qui) e questo Download
+      # fallisce hard (artifact assente) → il job deploy fallisce PRIMA di
+      # backup/apply/SSH: nessuna migration applicata, nessun deploy container.
+      # Fail-closed, atomicità #1573 preservata. Irrobustire deploy.if per non
+      # partire dopo un pre-deploy-check fallito su push è un follow-up separato.
+      #
+      # Atomicità (#1573) invariata: l'APPLY resta inline in questo job. Se il
+      # job non viene preso dal runner, nessuna migration è applicata. Solo la
+      # GENERAZIONE (side-effect-free) si è spostata a monte, sul cloud.
+      - name: Download migration SQL artifact
         if: vars.DEPLOY_METHOD == 'ssh'
-        uses: actions/setup-dotnet@v5
+        uses: actions/download-artifact@v7
         with:
-          dotnet-version: '9.0.x'
-
-      - name: Install dotnet-ef tool
-        if: vars.DEPLOY_METHOD == 'ssh'
-        # Idempotent: use pre-installed tool if present (self-hosted runner may
-        # already have dotnet-ef from a newer SDK). `dotnet tool install` does
-        # not support downgrades, so skipping install when a compatible version
-        # exists avoids exit 1 on runners with ef 10.x already global.
-        run: |
-          if dotnet tool list --global | awk '{print $1}' | grep -qx 'dotnet-ef'; then
-            echo "dotnet-ef already installed globally — using existing version:"
-            dotnet tool list --global | grep '^dotnet-ef'
-          else
-            dotnet tool install --global dotnet-ef --version 9.*
-          fi
-          # Self-hosted runners: $HOME/.dotnet/tools needs manual PATH append
-          # because setup-dotnet only sets DOTNET_ROOT, not the user-global
-          # tools dir. Regression caught on staging deploy run 24779812732.
-          echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
-
-      - name: Restore and build API project (for ef tools)
-        if: vars.DEPLOY_METHOD == 'ssh'
-        working-directory: apps/api/src/Api
-        # Issue #2613: vedi "Backend build check" — stessa env var per evitare
-        # l'OOM del Roslyn AnalyzerDriver. Copre questo `dotnet build` esplicito.
-        env:
-          SkipAnalyzers: 'true'
-        run: |
-          dotnet restore
-          dotnet build --no-restore -c Release
-
-      - name: Generate idempotent migration SQL
-        if: vars.DEPLOY_METHOD == 'ssh'
-        working-directory: apps/api/src/Api
-        # Issue #2613: dotnet ef qui ricompila il progetto (nessun --no-build,
-        # per scelta deliberata sotto). Quel rebuild implicito riattiverebbe gli
-        # analyzer e andrebbe in OOM come gli step `dotnet build` espliciti — la
-        # env var SkipAnalyzers=true copre anche questo path (3° punto di build).
-        env:
-          SkipAnalyzers: 'true'
-        run: |
-          # No --no-build: dotnet-ef needs the project built. Built in prior
-          # step; let ef trigger its own build without the flag to avoid
-          # Release/Debug path mismatches.
-          dotnet ef migrations script --idempotent -o /tmp/migrations.sql
-          lines=$(wc -l < /tmp/migrations.sql)
-          echo "✅ Generated ${lines} lines of SQL at /tmp/migrations.sql"
-          if [ "$lines" -lt 10 ]; then
-            echo "❌ SQL output suspiciously small (< 10 lines). Aborting."
-            exit 1
-          fi
+          name: migration-sql-${{ github.run_id }}
+          path: /tmp
 
       - name: Apply migrations on staging
         if: vars.DEPLOY_METHOD == 'ssh'
@@ -1454,7 +1534,12 @@ jobs:
 
   notify-end:
     if: always()
-    needs: [detect-changes, pre-deploy-check, build, build-ai, snapshot-baseline, deploy, validate, e2e-staging, ghcr-retention]
+    # Issue #2650: generate-migration incluso nei needs così un suo FAILURE viene
+    # contato da `contains(join(needs.*.result), 'failure')` e la notifica Slack
+    # segnala 'failed'. Senza, un fallimento della generazione SQL bloccherebbe il
+    # deploy (result 'skipped') ma verrebbe annunciato come 'completed' su una
+    # pipeline is_critical=true.
+    needs: [detect-changes, pre-deploy-check, build, generate-migration, build-ai, snapshot-baseline, deploy, validate, e2e-staging, ghcr-retention]
     uses: ./.github/workflows/notify-slack.yml
     with:
       event: ${{ contains(join(needs.*.result, ','), 'failure') && 'failed' || contains(join(needs.*.result, ','), 'cancelled') && 'cancelled' || 'completed' }}


### PR DESCRIPTION
> ⚠️ **DRAFT** — vedi § Verifica. Questa PR **non è verificabile localmente** (richiede un deploy staging reale sul runner self-hosted) ed è **impilata** su #2649.

## Cosa fa

Implementa l'**Opzione 3** di #2613 (issue di tracking: #2650). Sposta la generazione dello SQL di migrazione dal runner **self-hosted** (VPS ~8GB, cap `MemoryMax=3G`) al **cloud runner** (`ubuntu-latest`), eliminando la compilazione .NET che causava l'OOM del Roslyn AnalyzerDriver.

**Prima**: il job `Deploy` compilava `Api.csproj` sull'host per far girare `dotnet-ef` → OOM (#2613, mitigato con `SkipAnalyzers` in #2649).
**Dopo**: nuovo job `generate-migration` (cloud) → compila + `dotnet ef migrations script --idempotent` → carica lo SQL come artifact → il `Deploy` lo scarica e lo applica **come prima** (backup + pre-flight `__EFMigrationsHistory` + `psql ON_ERROR_STOP`).

Rimossi i 2 punti di build .NET host che servivano solo a ef (punti #2/#3 dell'analisi in #2650). Il punto #1 (`Backend build check` in Pre-deploy Validation) **resta sull'host** con `SkipAnalyzers` (da #2649) — l'Opzione 3 riduce la superficie OOM host **da 3 a 1**.

## Vincoli rispettati (verificati in review adversariale)

- **#1596** (Plan A fallito: un job cloud-SQL-gen separato veniva skippato da GHA sotto `workflow_dispatch + skip_tests` → download senza artifact). **Risolto** via gating `always()` identico a `build`/`build-ai`. Matrice scenari verificata: S1 push / **S2 dispatch+skip_tests (il caso #1596)** / S3 dispatch / S4 non-ssh / S5 AI-only — tutti corretti.
- **#1573** atomicità: l'**APPLY resta inline** nel job Deploy. Se il job non parte, nessuna migration è applicata. Solo la generazione (side-effect-free) si è spostata a monte.
- **#2020** idempotenza: pre-flight su `__EFMigrationsHistory` **invariato**.
- **#1578** deploy AI-only: preservato.

## Review adversariale (3 lenti) — findings risolti

Una review a 3 lenti (skip-propagation GHA / atomicità-idempotenza / artifact plumbing) ha trovato e questa PR **risolve**:

- 🔴 **Critical (riprodotto empiricamente)**: `dotnet ef ... --no-build` senza `--configuration Release` risolve l'assembly in **Debug** (default) → `bin/Debug/.../Api.deps.json does not exist` → exit 129, nessun SQL (100% deploy SSH rotti, ma fail-closed). **Fix**: aggiunto `--configuration Release` (verificato: exit 0, ~11k righe SQL) + guard `test -f` difensivo.
- 🟡 **Important**: un fallimento di `generate-migration` bloccava il deploy (bene) ma `notify-end` lo annunciava su Slack come **riuscito**. **Fix**: aggiunto `generate-migration` ai `needs` di `notify-end` (+ `job_list` di `notify-start`).
- 🟢 Minor: artifact `name` con suffisso `-${{ github.run_id }}` per coerenza con `ci.yml`; commento "artifact always exists" corretto per lo scenario S1b.

## Scope boundary (fuori da questa PR)

- **Punto #1** (`Backend build check` sull'host): resta con `SkipAnalyzers`. Rimuoverlo/spostarlo è una decisione separata (vedi #2650).
- **`deploy.if` weakness pre-esistente**: su push con `pre-deploy-check` fallito, il deploy parte comunque e ora fallisce al Download (fail-closed, notificato). È un weakness **pre-esistente** (`deploy.if` tollera `build.result=='skipped'`), non introdotto qui. Follow-up separato.
- **sparse-checkout del Deploy**: `apps/api/` + `data/rulebook/golden/` non servono più al Deploy (gen ef ora in cloud) ma restano nel checkout — cleanup opzionale, tenuto fuori per non allargare il blast radius.

## ⚠️ Verifica

- ✅ YAML valido (13 job), wiring `needs`/`if` verificato, artifact name upload↔download simmetrico, Critical fix presente.
- ✅ Pre-commit hooks verdi.
- ✅ Review adversariale 3 lenti: verdetto finale post-fix = nessun Critical/Important residuo.
- ⚠️ **NON verificabile localmente**: la logica di skip-propagation GHA + il deploy SSH richiedono un **run reale del workflow** sul runner self-hosted. **Da validare con un `workflow_dispatch` su staging prima del merge.**

## Note di merge

- **Stacked su #2649** (base PR = `feature/issue-2613-deploy-analyzer-oom`). Mantiene `SkipAnalyzers` sul punto #1. **Retargettare a `main-dev` dopo il merge di #2649.**
- Closes #2650 (al merge, dopo validazione staging).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
