### PR TITLE
feat(game-night): #2633 SI-2 Slice B — night-live backend read path

### DIFF
--- a/apps/web/src/app/(authenticated)/game-nights/[id]/live/_components/NightLiveClientView.tsx
+++ b/apps/web/src/app/(authenticated)/game-nights/[id]/live/_components/NightLiveClientView.tsx
@@ -1,257 +1,37 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+/**
+ * NightLiveClientView — #2633 Slice B.
+ *
+ * Backend-driven read-only projection of the night-live hub. The header + planned
+ * line-up come from `useGameNightLive` (GET /game-nights/{id}/live → mapped
+ * NightLiveViewModel); no fixtures remain. currentGame + the diary arrives in
+ * Slice C (the mapper emits null/[] today); the LIVE badge + blocked modal is
+ * Slice D. Drive controls are hidden (read-only, LD-13).
+ *
+ * States: loading skeleton · error taxonomy (LD-10) · terminal-night routing
+ * (LD-14) · empty-published happy path (LD-11).
+ */
+
+import { useCallback, useEffect, type ReactNode } from 'react';
 
 import { useRouter } from 'next/navigation';
 
-import {
-  NightLiveHub,
-  type NightLiveHubCurrentGame,
-  type NightLiveHubNight,
-  type NightLiveStatus,
-} from '@/components/features/game-nights/live';
-import type {
-  DiaryEvent,
-  DiaryGameRef,
-  DiaryPlayerRef,
-} from '@/components/features/game-nights/live';
-import type { PlannedGame } from '@/components/features/game-nights/live';
-import {
-  GameTransitionDialog,
-  type TransitionLastGame,
-  type TransitionNextGame,
-  type TransitionSubmodal,
-} from '@/components/features/game-nights/transition';
-
-// ─── Fixture data (TODO: replace with backend hook `useGameNightLive(id)`)
-// Continuità con mockup K/L mergiati nel PR #1250 — issue #487
-// ─────────────────────────────────────────────────────────────────────────
-
-const NIGHT: NightLiveHubNight = {
-  title: 'Sabato boardgame con i Padovani',
-  shortTitle: 'Padovani · 17 mag',
-  nightCode: '#GN-042',
-};
-
-const DIARY_PLAYERS: ReadonlyArray<DiaryPlayerRef> = [
-  { id: 'p-marco', initials: 'MR', color: 262 },
-  { id: 'p-giulia', initials: 'GM', color: 10 },
-  { id: 'p-davide', initials: 'DC', color: 200 },
-  { id: 'p-luca', initials: 'LB', color: 180 },
-  { id: 'p-sara', initials: 'ST', color: 320 },
-  { id: 'p-aaron', initials: 'AK', color: 140 },
-];
-
-const DIARY_GAMES: ReadonlyArray<DiaryGameRef> = [
-  { id: 'gs-brass-1', title: 'Brass: Birmingham', emoji: '🏭' },
-  { id: 'gs-spirit-1', title: 'Spirit Island', emoji: '🌋' },
-];
-
-const PLANNED_GAMES: ReadonlyArray<PlannedGame> = [
-  {
-    id: 'gs-brass-1',
-    title: 'Brass: Birmingham',
-    publisher: 'Roxley',
-    emoji: '🏭',
-    cover: ['hsl(220 35% 28%)', 'hsl(28 60% 38%)'],
-    status: 'completed',
-    order: 1,
-    actual: '113m',
-    estimated: '120m',
-    score: '178–142',
-    winner: { name: 'Davide', initials: 'DC', color: 200 },
-  },
-  {
-    id: 'gs-spirit-1',
-    title: 'Spirit Island',
-    publisher: 'GMT · co-op',
-    emoji: '🌋',
-    cover: ['hsl(210 50% 30%)', 'hsl(150 50% 38%)'],
-    status: 'inprogress',
-    order: 2,
-    actual: '35m elapsed',
-    estimated: '90m',
-    score: 'round 2 · in corso',
-  },
-  {
-    id: 'gs-wing-1',
-    title: 'Wingspan',
-    publisher: 'Stonemaier',
-    emoji: '🦜',
-    cover: ['hsl(85 40% 45%)', 'hsl(35 60% 50%)'],
-    status: 'upcoming',
-    order: 3,
-    estimated: '60m',
-  },
-];
-
-const CURRENT_GAME: NightLiveHubCurrentGame = {
-  id: 'gs-spirit-1',
-  sessionId: 's-spirit-may17',
-  title: 'Spirit Island',
-  emoji: '🌋',
-  cover: ['hsl(210 50% 30%)', 'hsl(150 50% 38%)'],
-  score: 'round 2 · in corso',
-};
-
-const DIARY_EVENTS: ReadonlyArray<DiaryEvent> = [
-  {
-    id: 'd01',
-    time: '21:02',
-    gameId: 'gs-brass-1',
-    kind: 'turn',
-    icon: '🎯',
-    actors: ['p-marco'],
-    text: 'Marco apre il Canal Era — porto a Stoke-on-Trent',
-  },
-  {
-    id: 'd08',
-    time: '22:48',
-    gameId: 'gs-brass-1',
-    kind: 'score',
-    icon: '📊',
-    actors: ['p-marco'],
-    text: 'Marco completa rete Birmingham (+12 link points)',
-  },
-  {
-    id: 'd09',
-    time: '22:55',
-    gameId: 'gs-brass-1',
-    kind: 'end',
-    icon: '🏆',
-    actors: ['p-davide'],
-    text: '🏆 Davide vince Brass Birmingham 178–142',
-  },
-  {
-    id: 'd10',
-    time: '23:00',
-    gameId: null,
-    kind: 'system',
-    icon: '↻',
-    actors: [],
-    text: 'Setup Spirit Island · 4 spiriti scelti random',
-  },
-  {
-    id: 'd14',
-    time: '23:23',
-    gameId: 'gs-spirit-1',
-    kind: 'score',
-    icon: '📊',
-    actors: ['p-davide'],
-    text: 'Blight su Powerwala — Davide perde 1 presenza',
-  },
-];
-
-// Transition data (last game = Brass completed, next game = Spirit Island)
-const LAST_GAME: TransitionLastGame = {
-  id: 'gs-brass-1',
-  title: 'Brass: Birmingham',
-  publisher: 'Roxley',
-  emoji: '🏭',
-  cover: ['hsl(220 35% 28%)', 'hsl(28 60% 38%)'],
-  duration: '2h 45m',
-  endedAt: '22:55',
-  winner: { id: 'p-davide', name: 'Davide', initials: 'DC', color: 200, score: 178 },
-  topThree: [
-    {
-      id: 'p-davide',
-      name: 'Davide',
-      initials: 'DC',
-      color: 200,
-      score: 178,
-      delta: '+50 industria',
-    },
-    { id: 'p-marco', name: 'Marco', initials: 'MR', color: 262, score: 142, delta: '+12 network' },
-    {
-      id: 'p-giulia',
-      name: 'Giulia',
-      initials: 'GM',
-      color: 10,
-      score: 128,
-      delta: '+8 carbone',
-    },
-  ],
-};
-
-const NEXT_GAME: TransitionNextGame = {
-  id: 'gs-spirit-1',
-  title: 'Spirit Island',
-  publisher: 'GMT · co-op',
-  emoji: '🌋',
-  cover: ['hsl(210 50% 30%)', 'hsl(150 50% 38%)'],
-  estimated: '90m',
-  weight: 4.08,
-  rules: [
-    { icon: '🔁', text: 'Phase order · Growth → Fast → Slow', src: '§ 4.2' },
-    { icon: '😱', text: 'Fear deck · 9 carte iniziali (level 1/2/3)', src: '§ 5.1' },
-    { icon: '⚡', text: 'Power growth · 1 minor + 1 major per round', src: '§ 6.3' },
-  ],
-  setup: [
-    { icon: '🗺️', text: 'Tabellone · 4 isole', done: true },
-    { icon: '🧝', text: 'Spirit panels (4 spiriti scelti)', done: true },
-    { icon: '🃏', text: 'Invader deck shuffled · stage I', done: false },
-    { icon: '💀', text: 'Fear pool · 9 token', done: false },
-  ],
-};
-
-// ─── View component ─────────────────────────────────────────────────────
+import { NightLiveHub } from '@/components/features/game-nights/live';
+import { ForbiddenError, NotFoundError, UnauthorizedError } from '@/lib/api/core/errors';
+import { useGameNightLive } from '@/lib/game-nights/hooks/useGameNightLive';
 
 export interface NightLiveClientViewProps {
   readonly nightId: string;
 }
 
-export function NightLiveClientView({ nightId: _nightId }: NightLiveClientViewProps) {
+export function NightLiveClientView({ nightId }: NightLiveClientViewProps) {
   const router = useRouter();
-  const [status, setStatus] = useState<NightLiveStatus>('live');
-  const [transitionOpen, setTransitionOpen] = useState(false);
-  const [submodal, setSubmodal] = useState<TransitionSubmodal>(null);
+  const { data: vm, isLoading, isError, error } = useGameNightLive(nightId);
 
-  const handlePauseToggle = useCallback(() => {
-    setStatus(current => (current === 'paused' ? 'live' : 'paused'));
-  }, []);
-
-  const handleTransitionOpen = useCallback(() => {
-    setStatus('transition');
-    setTransitionOpen(true);
-  }, []);
-
-  const handleTransitionClose = useCallback(() => {
-    setTransitionOpen(false);
-    setSubmodal(null);
-    setStatus('live');
-  }, []);
-
-  const handlePlayNext = useCallback(() => {
-    setTransitionOpen(false);
-    setSubmodal(null);
-    setStatus('live');
-  }, []);
-
-  const handleSkipConfirmed = useCallback(() => {
-    setSubmodal(null);
-    setTransitionOpen(false);
-    setStatus('live');
-  }, []);
-
-  const handleEndNight = useCallback(() => {
-    router.push(`/game-nights/${_nightId}/summary`);
-  }, [router, _nightId]);
-
-  const handleOpenSubmodal = useCallback((which: 'skip' | 'end') => {
-    setSubmodal(which);
-  }, []);
-
-  const handleConfirmSubmodal = useCallback(() => {
-    if (submodal === 'skip') {
-      handleSkipConfirmed();
-    } else if (submodal === 'end') {
-      handleEndNight();
-    }
-  }, [submodal, handleSkipConfirmed, handleEndNight]);
-
-  const handleCancelSubmodal = useCallback(() => {
-    setSubmodal(null);
-  }, []);
+  const handleBack = useCallback(() => {
+    router.push(`/game-nights/${nightId}`);
+  }, [router, nightId]);
 
   const handleJumpToSession = useCallback(
     (sessionId: string) => {
@@ -260,75 +40,153 @@ export function NightLiveClientView({ nightId: _nightId }: NightLiveClientViewPr
     [router]
   );
 
-  const handleBack = useCallback(() => {
-    router.push(`/game-nights/${_nightId}`);
-  }, [router, _nightId]);
-
-  // Global Escape listener: closes the transition modal regardless of focus.
-  // The backdrop's local onKeyDown only fires when focus is on the backdrop,
-  // which never happens via keyboard nav. This effect ensures Escape works
-  // even when focus is inside the dialog content.
+  // LD-14: a Completed night must not render a fake-live hub over stale data —
+  // send the user to the summary they actually want. The effect fires only once
+  // the read model confirms the terminal status.
+  const isCompleted = vm?.nightStatus === 'Completed';
   useEffect(() => {
-    if (!transitionOpen) return undefined;
-    const handleEscape = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        handleTransitionClose();
-      }
-    };
-    document.addEventListener('keydown', handleEscape);
-    return () => {
-      document.removeEventListener('keydown', handleEscape);
-    };
-  }, [transitionOpen, handleTransitionClose]);
+    if (isCompleted) {
+      router.replace(`/game-nights/${nightId}/summary`);
+    }
+  }, [isCompleted, router, nightId]);
 
-  return (
-    <>
-      <NightLiveHub
-        night={NIGHT}
-        status={status}
-        current={2}
-        total={3}
-        elapsed="2h 35m"
-        confirmedPlayers={6}
-        totalPlayers={6}
-        plannedGames={PLANNED_GAMES}
-        currentGame={status === 'transition' ? null : CURRENT_GAME}
-        diaryEvents={DIARY_EVENTS}
-        diaryGames={DIARY_GAMES}
-        diaryPlayers={DIARY_PLAYERS}
+  if (isLoading) {
+    return <NightLiveSkeleton />;
+  }
+
+  if (isError) {
+    return <NightLiveError error={error} onBack={handleBack} />;
+  }
+
+  if (!vm) {
+    return null;
+  }
+
+  // LD-14: terminal / non-viewable lifecycle states.
+  if (vm.nightStatus === 'Completed') {
+    // router.replace has been scheduled; render a neutral placeholder meanwhile.
+    return (
+      <NightLiveNotice
+        title="Serata conclusa"
+        body="Ti stiamo portando al riepilogo…"
         onBack={handleBack}
-        onPauseToggle={handlePauseToggle}
-        onTransition={handleTransitionOpen}
-        onEnd={handleEndNight}
-        onJumpToSession={handleJumpToSession}
       />
+    );
+  }
+  if (vm.nightStatus === 'Cancelled') {
+    return (
+      <NightLiveNotice
+        title="Serata annullata"
+        body="Questa serata è stata annullata e non ha una modalità live."
+        onBack={handleBack}
+      />
+    );
+  }
+  if (vm.nightStatus === 'Draft') {
+    return (
+      <NightLiveNotice
+        title="Serata non ancora avviata"
+        body="Pubblica la serata per aprirne la modalità live."
+        onBack={handleBack}
+      />
+    );
+  }
 
-      {transitionOpen ? (
-        <div
-          className="fixed inset-0 z-50 flex items-center justify-center p-4 backdrop-blur-sm"
-          style={{ background: 'rgba(0,0,0,0.45)' }}
-          onClick={handleTransitionClose}
-          onKeyDown={e => {
-            if (e.key === 'Escape') handleTransitionClose();
-          }}
-          role="presentation"
-        >
-          <div onClick={e => e.stopPropagation()} role="presentation">
-            <GameTransitionDialog
-              open
-              lastGame={LAST_GAME}
-              nextGame={NEXT_GAME}
-              nightCode={NIGHT.nightCode}
-              submodal={submodal}
-              onClose={handleTransitionClose}
-              onPlayNext={handlePlayNext}
-              onOpenSubmodal={handleOpenSubmodal}
-              onConfirmSubmodal={handleConfirmSubmodal}
-              onCancelSubmodal={handleCancelSubmodal}
-            />
-          </div>
-        </div>
-      ) : null}
-    </>
+  // Published → the read-only live hub.
+  return (
+    <NightLiveHub
+      readOnly
+      night={vm.night}
+      status={vm.status}
+      current={vm.current}
+      total={vm.total}
+      elapsed={vm.elapsed}
+      confirmedPlayers={vm.confirmedPlayers}
+      totalPlayers={vm.totalPlayers}
+      plannedGames={vm.plannedGames}
+      currentGame={vm.currentGame}
+      diaryEvents={vm.diaryEvents}
+      diaryGames={vm.diaryGames}
+      diaryPlayers={vm.diaryPlayers}
+      onBack={handleBack}
+      onJumpToSession={handleJumpToSession}
+    />
+  );
+}
+
+function NightLiveSkeleton() {
+  return (
+    <div
+      role="status"
+      aria-label="Caricamento serata live"
+      aria-live="polite"
+      className="flex h-full min-h-0 flex-col gap-3 bg-background p-4"
+    >
+      <div className="h-16 w-full animate-pulse rounded-md bg-muted" />
+      <div className="flex flex-1 gap-3">
+        <div className="h-full w-[280px] shrink-0 animate-pulse rounded-md bg-muted" />
+        <div className="h-full flex-1 animate-pulse rounded-md bg-muted" />
+        <div className="h-full w-[320px] shrink-0 animate-pulse rounded-md bg-muted" />
+      </div>
+      <span className="sr-only">Caricamento serata live…</span>
+    </div>
+  );
+}
+
+/** LD-10: distinct copy per error class; a generic fallback for the rest. */
+function NightLiveError({ error, onBack }: { error: unknown; onBack: () => void }) {
+  let title = 'Qualcosa è andato storto';
+  let body = 'Non è stato possibile caricare la serata live. Riprova più tardi.';
+
+  if (error instanceof UnauthorizedError) {
+    title = 'Sessione scaduta';
+    body = 'Effettua di nuovo l’accesso per vedere la serata live.';
+  } else if (error instanceof ForbiddenError) {
+    title = 'Accesso riservato';
+    body = 'Solo l’organizzatore o un giocatore invitato può vedere questa serata.';
+  } else if (error instanceof NotFoundError) {
+    title = 'Serata non trovata';
+    body = 'La serata richiesta non esiste o è stata rimossa.';
+  } else if (
+    error instanceof Error &&
+    (error.name === 'NetworkError' || error.name === 'CircuitBreakerError')
+  ) {
+    title = 'Connessione persa';
+    body = 'Controlla la connessione e riprova.';
+  }
+
+  return <NightLiveNotice title={title} body={body} onBack={onBack} tone="error" />;
+}
+
+function NightLiveNotice({
+  title,
+  body,
+  onBack,
+  tone = 'neutral',
+}: {
+  title: string;
+  body: ReactNode;
+  onBack: () => void;
+  tone?: 'neutral' | 'error';
+}) {
+  return (
+    <div className="flex h-full min-h-0 flex-col items-center justify-center gap-3 bg-background p-6 text-center">
+      <h1
+        className={[
+          'font-display text-xl font-extrabold',
+          tone === 'error' ? 'text-[hsl(var(--c-danger))]' : 'text-foreground',
+        ].join(' ')}
+      >
+        {title}
+      </h1>
+      <p className="max-w-sm font-mono text-sm text-muted-foreground">{body}</p>
+      <button
+        type="button"
+        onClick={onBack}
+        className="mt-2 rounded-md border border-border bg-card px-4 py-2 font-display text-[13px] font-extrabold text-foreground hover:bg-muted"
+      >
+        ← Torna alla serata
+      </button>
+    </div>
   );
 }

--- a/apps/web/src/app/(authenticated)/game-nights/[id]/live/_components/NightLiveClientView.tsx
+++ b/apps/web/src/app/(authenticated)/game-nights/[id]/live/_components/NightLiveClientView.tsx
@@ -40,6 +40,10 @@ export function NightLiveClientView({ nightId }: NightLiveClientViewProps) {
     [router]
   );
 
+  const handleLogin = useCallback(() => {
+    router.push('/login');
+  }, [router]);
+
   // LD-14: a Completed night must not render a fake-live hub over stale data —
   // send the user to the summary they actually want. The effect fires only once
   // the read model confirms the terminal status.
@@ -55,7 +59,7 @@ export function NightLiveClientView({ nightId }: NightLiveClientViewProps) {
   }
 
   if (isError) {
-    return <NightLiveError error={error} onBack={handleBack} />;
+    return <NightLiveError error={error} onBack={handleBack} onLogin={handleLogin} />;
   }
 
   if (!vm) {
@@ -134,13 +138,25 @@ function NightLiveSkeleton() {
 }
 
 /** LD-10: distinct copy per error class; a generic fallback for the rest. */
-function NightLiveError({ error, onBack }: { error: unknown; onBack: () => void }) {
+function NightLiveError({
+  error,
+  onBack,
+  onLogin,
+}: {
+  error: unknown;
+  onBack: () => void;
+  onLogin: () => void;
+}) {
   let title = 'Qualcosa è andato storto';
   let body = 'Non è stato possibile caricare la serata live. Riprova più tardi.';
+  // LD-10: a lapsed session (401) is a dead end without a recovery path — offer
+  // an explicit login action so the user is not stuck behind another auth wall.
+  let primaryAction: { label: string; onClick: () => void } | undefined;
 
   if (error instanceof UnauthorizedError) {
     title = 'Sessione scaduta';
     body = 'Effettua di nuovo l’accesso per vedere la serata live.';
+    primaryAction = { label: 'Accedi di nuovo', onClick: onLogin };
   } else if (error instanceof ForbiddenError) {
     title = 'Accesso riservato';
     body = 'Solo l’organizzatore o un giocatore invitato può vedere questa serata.';
@@ -155,7 +171,15 @@ function NightLiveError({ error, onBack }: { error: unknown; onBack: () => void 
     body = 'Controlla la connessione e riprova.';
   }
 
-  return <NightLiveNotice title={title} body={body} onBack={onBack} tone="error" />;
+  return (
+    <NightLiveNotice
+      title={title}
+      body={body}
+      onBack={onBack}
+      tone="error"
+      primaryAction={primaryAction}
+    />
+  );
 }
 
 function NightLiveNotice({
@@ -163,11 +187,13 @@ function NightLiveNotice({
   body,
   onBack,
   tone = 'neutral',
+  primaryAction,
 }: {
   title: string;
   body: ReactNode;
   onBack: () => void;
   tone?: 'neutral' | 'error';
+  primaryAction?: { label: string; onClick: () => void };
 }) {
   return (
     <div className="flex h-full min-h-0 flex-col items-center justify-center gap-3 bg-background p-6 text-center">
@@ -180,13 +206,24 @@ function NightLiveNotice({
         {title}
       </h1>
       <p className="max-w-sm font-mono text-sm text-muted-foreground">{body}</p>
-      <button
-        type="button"
-        onClick={onBack}
-        className="mt-2 rounded-md border border-border bg-card px-4 py-2 font-display text-[13px] font-extrabold text-foreground hover:bg-muted"
-      >
-        ← Torna alla serata
-      </button>
+      <div className="mt-2 flex items-center gap-2">
+        {primaryAction ? (
+          <button
+            type="button"
+            onClick={primaryAction.onClick}
+            className="rounded-md border border-entity-session/30 bg-entity-session/10 px-4 py-2 font-display text-[13px] font-extrabold text-entity-session hover:bg-entity-session/15"
+          >
+            {primaryAction.label}
+          </button>
+        ) : null}
+        <button
+          type="button"
+          onClick={onBack}
+          className="rounded-md border border-border bg-card px-4 py-2 font-display text-[13px] font-extrabold text-foreground hover:bg-muted"
+        >
+          ← Torna alla serata
+        </button>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/app/(authenticated)/game-nights/[id]/live/_components/__tests__/NightLiveClientView.test.tsx
+++ b/apps/web/src/app/(authenticated)/game-nights/[id]/live/_components/__tests__/NightLiveClientView.test.tsx
@@ -1,0 +1,189 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * NightLiveClientView integration tests — #2633 Slice B.
+ *
+ * The view is now backend-driven via useGameNightLive: no header/planned-games
+ * fixtures remain. These tests cover the resilience matrix (LD-10), terminal-night
+ * routing (LD-14), the empty happy-path (LD-11), the read-only projection (LD-13),
+ * and the real session jump (AC3).
+ */
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import {
+  ForbiddenError,
+  NotFoundError,
+  UnauthorizedError,
+  NetworkError,
+} from '@/lib/api/core/errors';
+import type { NightLiveViewModel } from '@/lib/game-nights/mapNightLive';
+
+import { NightLiveClientView } from '../NightLiveClientView';
+
+const useGameNightLiveMock = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/game-nights/hooks/useGameNightLive', () => ({
+  useGameNightLive: useGameNightLiveMock,
+}));
+
+const pushMock = vi.fn();
+const replaceMock = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: pushMock, replace: replaceMock }),
+}));
+
+const NIGHT_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const IN_PROGRESS_SESSION_ID = '33333333-3333-4333-8333-333333333333';
+
+function vm(over: Partial<NightLiveViewModel> = {}): NightLiveViewModel {
+  return {
+    night: { title: 'Serata Eldoria' },
+    nightStatus: 'Published',
+    status: 'live',
+    current: 2,
+    total: 3,
+    elapsed: '2h 35m',
+    confirmedPlayers: undefined,
+    totalPlayers: undefined,
+    plannedGames: [
+      {
+        id: '11111111-1111-4111-8111-111111111111',
+        title: 'Brass',
+        status: 'completed',
+        order: 1,
+        actual: '113m',
+      },
+      {
+        id: IN_PROGRESS_SESSION_ID,
+        title: 'Spirit Island',
+        status: 'inprogress',
+        order: 2,
+        actual: '35m',
+      },
+      {
+        id: '55555555-5555-4555-8555-555555555555',
+        title: 'Wingspan',
+        status: 'upcoming',
+        order: 3,
+      },
+    ],
+    currentGame: null,
+    diaryEvents: [],
+    diaryGames: [],
+    diaryPlayers: [],
+    ...over,
+  };
+}
+
+function mockQuery(over: Record<string, unknown>) {
+  useGameNightLiveMock.mockReturnValue({
+    data: undefined,
+    isLoading: false,
+    isError: false,
+    error: null,
+    ...over,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('NightLiveClientView — loading', () => {
+  it('renders a loading skeleton while the query is pending', () => {
+    mockQuery({ isLoading: true });
+    render(<NightLiveClientView nightId={NIGHT_ID} />);
+    expect(screen.getByRole('status', { name: /Caricamento serata/i })).toBeInTheDocument();
+    // the hub is NOT mounted with placeholder data
+    expect(screen.queryByText('Serata Eldoria')).toBeNull();
+  });
+});
+
+describe('NightLiveClientView — Published happy path', () => {
+  it('renders the hub header + planned games from the backend viewmodel (no fixtures)', () => {
+    mockQuery({ data: vm() });
+    render(<NightLiveClientView nightId={NIGHT_ID} />);
+    expect(screen.getByText('Serata Eldoria')).toBeInTheDocument();
+    expect(screen.getByText('Brass')).toBeInTheDocument();
+    expect(screen.getByText('Spirit Island')).toBeInTheDocument();
+    expect(screen.getByText('Wingspan')).toBeInTheDocument();
+    // the old fixture night title is gone
+    expect(screen.queryByText('Sabato boardgame con i Padovani')).toBeNull();
+  });
+
+  it('is a read-only projection: no pause/transition/end drive controls (LD-13)', () => {
+    mockQuery({ data: vm() });
+    render(<NightLiveClientView nightId={NIGHT_ID} />);
+    expect(screen.queryByRole('button', { name: /Transition/ })).toBeNull();
+    expect(screen.queryByRole('button', { name: /Pausa/ })).toBeNull();
+    expect(screen.queryByRole('button', { name: /^End$/ })).toBeNull();
+  });
+
+  it('jumps to the real session on "Apri sessione live" (AC3)', async () => {
+    // currentGame is Slice C (null), so the jump is exercised via a planned-game
+    // row; here we assert the back navigation + jump handler wiring end-to-end.
+    mockQuery({ data: vm() });
+    render(<NightLiveClientView nightId={NIGHT_ID} />);
+    // back button navigates to the night detail
+    await userEvent.click(screen.getByRole('button', { name: 'Indietro' }));
+    expect(pushMock).toHaveBeenCalledWith(`/game-nights/${NIGHT_ID}`);
+  });
+
+  it('renders a defined empty state for a Published night with 0 sessions (LD-11)', () => {
+    mockQuery({
+      data: vm({ plannedGames: [], current: 0, total: 0, elapsed: '0h 0m', status: 'transition' }),
+    });
+    render(<NightLiveClientView nightId={NIGHT_ID} />);
+    expect(screen.getByText('Nessun gioco pianificato')).toBeInTheDocument();
+  });
+});
+
+describe('NightLiveClientView — terminal nights (LD-14)', () => {
+  it('redirects a Completed night to the summary route', () => {
+    mockQuery({ data: vm({ nightStatus: 'Completed' }) });
+    render(<NightLiveClientView nightId={NIGHT_ID} />);
+    expect(replaceMock).toHaveBeenCalledWith(`/game-nights/${NIGHT_ID}/summary`);
+  });
+
+  it('renders a cancelled state for a Cancelled night (no hub)', () => {
+    mockQuery({ data: vm({ nightStatus: 'Cancelled' }) });
+    render(<NightLiveClientView nightId={NIGHT_ID} />);
+    expect(screen.getByRole('heading', { name: /annullata/i })).toBeInTheDocument();
+    expect(screen.queryByText('Brass')).toBeNull();
+  });
+
+  it('renders a not-live state for a Draft night (no hub)', () => {
+    mockQuery({ data: vm({ nightStatus: 'Draft' }) });
+    render(<NightLiveClientView nightId={NIGHT_ID} />);
+    expect(screen.getByText(/non ancora avviata/i)).toBeInTheDocument();
+    expect(screen.queryByText('Brass')).toBeNull();
+  });
+});
+
+describe('NightLiveClientView — error taxonomy (LD-10)', () => {
+  it('401 UnauthorizedError → session-expired copy', () => {
+    mockQuery({ isError: true, error: new UnauthorizedError({ message: 'x' }) });
+    render(<NightLiveClientView nightId={NIGHT_ID} />);
+    expect(screen.getByText(/Sessione scaduta/i)).toBeInTheDocument();
+  });
+
+  it('403 ForbiddenError → non-participant copy', () => {
+    mockQuery({ isError: true, error: new ForbiddenError({ message: 'x' }) });
+    render(<NightLiveClientView nightId={NIGHT_ID} />);
+    expect(screen.getByRole('heading', { name: /riservato/i })).toBeInTheDocument();
+  });
+
+  it('404 NotFoundError → not-found copy', () => {
+    mockQuery({ isError: true, error: new NotFoundError({ message: 'x' }) });
+    render(<NightLiveClientView nightId={NIGHT_ID} />);
+    expect(screen.getByText(/non trovata/i)).toBeInTheDocument();
+  });
+
+  it('NetworkError → connection-lost copy', () => {
+    mockQuery({ isError: true, error: new NetworkError({ message: 'x' }) });
+    render(<NightLiveClientView nightId={NIGHT_ID} />);
+    expect(screen.getByRole('heading', { name: /Connessione persa/i })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/(authenticated)/game-nights/[id]/live/_components/__tests__/NightLiveClientView.test.tsx
+++ b/apps/web/src/app/(authenticated)/game-nights/[id]/live/_components/__tests__/NightLiveClientView.test.tsx
@@ -121,14 +121,29 @@ describe('NightLiveClientView — Published happy path', () => {
     expect(screen.queryByRole('button', { name: /^End$/ })).toBeNull();
   });
 
-  it('jumps to the real session on "Apri sessione live" (AC3)', async () => {
-    // currentGame is Slice C (null), so the jump is exercised via a planned-game
-    // row; here we assert the back navigation + jump handler wiring end-to-end.
+  it('navigates back to the night detail on "Indietro"', async () => {
     mockQuery({ data: vm() });
     render(<NightLiveClientView nightId={NIGHT_ID} />);
-    // back button navigates to the night detail
     await userEvent.click(screen.getByRole('button', { name: 'Indietro' }));
     expect(pushMock).toHaveBeenCalledWith(`/game-nights/${NIGHT_ID}`);
+  });
+
+  it('jumps to the session via its SessionId route key (AC3)', async () => {
+    // currentGame is Slice C (null from the mapper today) — but the jump handler
+    // is wired now, so we exercise it with a non-null currentGame to assert the
+    // /sessions/{SessionId} routing contract Slice C will rely on.
+    mockQuery({
+      data: vm({
+        currentGame: {
+          id: IN_PROGRESS_SESSION_ID,
+          sessionId: IN_PROGRESS_SESSION_ID,
+          title: 'Spirit Island',
+        },
+      }),
+    });
+    render(<NightLiveClientView nightId={NIGHT_ID} />);
+    await userEvent.click(screen.getByRole('button', { name: /Apri sessione live/i }));
+    expect(pushMock).toHaveBeenCalledWith(`/sessions/${IN_PROGRESS_SESSION_ID}`);
   });
 
   it('renders a defined empty state for a Published night with 0 sessions (LD-11)', () => {
@@ -167,6 +182,21 @@ describe('NightLiveClientView — error taxonomy (LD-10)', () => {
     mockQuery({ isError: true, error: new UnauthorizedError({ message: 'x' }) });
     render(<NightLiveClientView nightId={NIGHT_ID} />);
     expect(screen.getByText(/Sessione scaduta/i)).toBeInTheDocument();
+  });
+
+  it('401 UnauthorizedError → offers a login action routing to /login (LD-10 recovery)', async () => {
+    mockQuery({ isError: true, error: new UnauthorizedError({ message: 'x' }) });
+    render(<NightLiveClientView nightId={NIGHT_ID} />);
+    await userEvent.click(screen.getByRole('button', { name: /Accedi/i }));
+    expect(pushMock).toHaveBeenCalledWith('/login');
+  });
+
+  it('CircuitBreakerError → connection-lost copy (AC9)', () => {
+    const err = new Error('circuit open');
+    err.name = 'CircuitBreakerError';
+    mockQuery({ isError: true, error: err });
+    render(<NightLiveClientView nightId={NIGHT_ID} />);
+    expect(screen.getByRole('heading', { name: /Connessione persa/i })).toBeInTheDocument();
   });
 
   it('403 ForbiddenError → non-participant copy', () => {

--- a/apps/web/src/components/features/game-nights/live/NightLiveHub.test.tsx
+++ b/apps/web/src/components/features/game-nights/live/NightLiveHub.test.tsx
@@ -294,6 +294,25 @@ describe('NightLiveHub', () => {
     });
   });
 
+  describe('readOnly projection (#2633 Slice B · LD-13)', () => {
+    it('hides the pause/transition/end drive controls when readOnly', () => {
+      render(<NightLiveHub {...baseProps} readOnly />);
+      expect(screen.queryByRole('button', { name: /Pausa/ })).toBeNull();
+      expect(screen.queryByRole('button', { name: /Transition/ })).toBeNull();
+      expect(screen.queryByRole('button', { name: /^End$/ })).toBeNull();
+    });
+
+    it('still renders the read-only jump-to-session action', () => {
+      render(<NightLiveHub {...baseProps} readOnly onJumpToSession={() => undefined} />);
+      expect(screen.getByRole('button', { name: /Apri sessione live/ })).toBeInTheDocument();
+    });
+
+    it('renders the drive controls by default (readOnly omitted)', () => {
+      render(<NightLiveHub {...baseProps} />);
+      expect(screen.getByRole('button', { name: /Pausa/ })).toBeInTheDocument();
+    });
+  });
+
   it('accepts custom className override', () => {
     const { container } = render(<NightLiveHub {...baseProps} className="custom-hub-class" />);
     expect(container.firstChild).toHaveClass('custom-hub-class');

--- a/apps/web/src/components/features/game-nights/live/NightLiveHub.tsx
+++ b/apps/web/src/components/features/game-nights/live/NightLiveHub.tsx
@@ -45,6 +45,12 @@ export interface NightLiveHubProps {
   readonly diaryGames: ReadonlyArray<DiaryGameRef>;
   readonly diaryPlayers: ReadonlyArray<DiaryPlayerRef>;
   readonly autoSaveToast?: { readonly visible: boolean; readonly timestamp: string };
+  /**
+   * #2633 Slice B (LD-13): render as a read-only projection — hides the
+   * pause/transition/end drive controls so the surface does not advertise
+   * interactions it cannot yet perform. The jump-to-session action stays.
+   */
+  readonly readOnly?: boolean;
   readonly mobile?: boolean;
   readonly initialMobileTab?: MobileTab;
   readonly onBack?: () => void;
@@ -82,6 +88,7 @@ export function NightLiveHub({
   diaryGames,
   diaryPlayers,
   autoSaveToast,
+  readOnly = false,
   mobile = false,
   initialMobileTab = 'current',
   onBack,
@@ -115,6 +122,7 @@ export function NightLiveHub({
         totalPlayers={totalPlayers}
         compact={mobile}
         isPaused={isPaused}
+        readOnly={readOnly}
         onBack={onBack}
         onPauseToggle={onPauseToggle}
         onTransition={onTransition}
@@ -170,6 +178,7 @@ interface NightLiveTopBarProps {
   readonly totalPlayers?: number;
   readonly compact: boolean;
   readonly isPaused: boolean;
+  readonly readOnly: boolean;
   readonly onBack?: () => void;
   readonly onPauseToggle?: () => void;
   readonly onTransition?: () => void;
@@ -186,6 +195,7 @@ function NightLiveTopBar({
   totalPlayers,
   compact,
   isPaused,
+  readOnly,
   onBack,
   onPauseToggle,
   onTransition,
@@ -302,21 +312,23 @@ function NightLiveTopBar({
           </div>
         ) : null}
 
-        <div className="flex shrink-0 items-center gap-1.5">
-          <ToolbarButton
-            icon={isPaused ? '▶' : '⏸'}
-            label={compact ? null : isPaused ? 'Riprendi' : 'Pausa'}
-            tone={isPaused ? 'session' : null}
-            onClick={onPauseToggle}
-          />
-          <ToolbarButton
-            icon="➡️"
-            label={compact ? null : 'Transition'}
-            tone="event"
-            onClick={onTransition}
-          />
-          <ToolbarButton icon="🛑" label={compact ? null : 'End'} tone="danger" onClick={onEnd} />
-        </div>
+        {readOnly ? null : (
+          <div className="flex shrink-0 items-center gap-1.5">
+            <ToolbarButton
+              icon={isPaused ? '▶' : '⏸'}
+              label={compact ? null : isPaused ? 'Riprendi' : 'Pausa'}
+              tone={isPaused ? 'session' : null}
+              onClick={onPauseToggle}
+            />
+            <ToolbarButton
+              icon="➡️"
+              label={compact ? null : 'Transition'}
+              tone="event"
+              onClick={onTransition}
+            />
+            <ToolbarButton icon="🛑" label={compact ? null : 'End'} tone="danger" onClick={onEnd} />
+          </div>
+        )}
       </div>
 
       {compact ? (

--- a/apps/web/src/components/features/game-nights/live/PlannedGamesPane.test.tsx
+++ b/apps/web/src/components/features/game-nights/live/PlannedGamesPane.test.tsx
@@ -182,4 +182,21 @@ describe('PlannedGamesPane', () => {
     const completedRow = container.querySelector('[data-status="completed"]');
     expect(completedRow?.className).toContain('opacity-80');
   });
+
+  // #2633 Slice B (LD-4): a Skipped session maps to status 'completed' + muted.
+  it('renders a muted (Skipped) tile with a SALTATA marker and data-muted flag', () => {
+    const skipped: PlannedGame = {
+      id: 's-skip',
+      title: 'Gioco Saltato',
+      status: 'completed',
+      order: 1,
+      muted: true,
+    };
+    const { container } = render(<PlannedGamesPane games={[skipped]} />);
+    expect(screen.getByText('SALTATA')).toBeInTheDocument();
+    expect(screen.queryByText('FINITO')).toBeNull();
+    const row = container.querySelector('[data-status="completed"]');
+    expect(row?.getAttribute('data-muted')).toBe('true');
+    expect(row?.className).toContain('opacity-50');
+  });
 });

--- a/apps/web/src/components/features/game-nights/live/PlannedGamesPane.tsx
+++ b/apps/web/src/components/features/game-nights/live/PlannedGamesPane.tsx
@@ -20,6 +20,17 @@ export interface PlannedGame {
   readonly estimated?: string;
   readonly score?: string;
   readonly winner?: PlannedGameWinner;
+  /**
+   * #2633 Slice B (LD-2): the raw session winner GUID, carried through the live
+   * mapper untouched. Winner {name,initials,color} resolution against the
+   * participant read model is deferred to Slice C — this is the seam it fills.
+   */
+  readonly winnerId?: string;
+  /**
+   * #2633 Slice B (LD-4): a Skipped session, rendered as a muted/struck tile
+   * kept in the line-up (not filtered out).
+   */
+  readonly muted?: boolean;
 }
 
 export interface PlannedGamesPaneProps {
@@ -116,12 +127,13 @@ function PlannedGameRow({ game }: { readonly game: PlannedGame }): JSX.Element {
   return (
     <li
       data-status={game.status}
+      data-muted={game.muted ? 'true' : undefined}
       className={[
         'relative rounded-md px-3 py-2.5 border-l-4',
         isInProgress
           ? 'bg-entity-session/[0.08] border border-entity-session/35'
           : 'bg-card border border-border',
-        isCompleted ? 'opacity-80' : '',
+        game.muted ? 'opacity-50' : isCompleted ? 'opacity-80' : '',
       ]
         .filter(Boolean)
         .join(' ')}
@@ -140,7 +152,14 @@ function PlannedGameRow({ game }: { readonly game: PlannedGame }): JSX.Element {
           {game.emoji ?? '🎲'}
         </span>
         <div className="min-w-0 flex-1">
-          <div className="truncate font-display text-[12.5px] font-extrabold text-foreground">
+          <div
+            className={[
+              'truncate font-display text-[12.5px] font-extrabold text-foreground',
+              game.muted ? 'line-through' : '',
+            ]
+              .filter(Boolean)
+              .join(' ')}
+          >
             {game.title}
           </div>
           {game.publisher ? (
@@ -180,9 +199,13 @@ function PlannedGameRow({ game }: { readonly game: PlannedGame }): JSX.Element {
       >
         {isCompleted ? (
           <>
-            <span>FINITO</span>
-            <span className="text-muted-foreground">·</span>
-            <span className="text-foreground/70">{game.actual ?? '—'}</span>
+            <span>{game.muted ? 'SALTATA' : 'FINITO'}</span>
+            {game.muted ? null : (
+              <>
+                <span className="text-muted-foreground">·</span>
+                <span className="text-foreground/70">{game.actual ?? '—'}</span>
+              </>
+            )}
           </>
         ) : null}
         {isInProgress ? (

--- a/apps/web/src/hooks/__tests__/useNow.test.ts
+++ b/apps/web/src/hooks/__tests__/useNow.test.ts
@@ -1,0 +1,55 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * useNow unit tests — #2633 Slice B (LD-7).
+ *
+ * The night-live header/elapsed derives from an injected `now`; this hook is the
+ * ticking clock that keeps it live without polling the server. Keeping the tick
+ * OUTSIDE the pure mapper is what makes the mapper deterministic.
+ */
+
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { useNow } from '../useNow';
+
+describe('useNow', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-04T20:00:00Z'));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns a Date on first render', () => {
+    const { result } = renderHook(() => useNow(60_000));
+    expect(result.current).toBeInstanceOf(Date);
+    expect(result.current.toISOString()).toBe('2026-07-04T20:00:00.000Z');
+  });
+
+  it('advances the returned time after the interval elapses', () => {
+    const { result } = renderHook(() => useNow(60_000));
+    const first = result.current.getTime();
+    act(() => {
+      vi.advanceTimersByTime(60_000);
+    });
+    expect(result.current.getTime()).toBeGreaterThan(first);
+  });
+
+  it('does not tick before the interval elapses', () => {
+    const { result } = renderHook(() => useNow(60_000));
+    const first = result.current.getTime();
+    act(() => {
+      vi.advanceTimersByTime(59_000);
+    });
+    expect(result.current.getTime()).toBe(first);
+  });
+
+  it('clears the interval on unmount', () => {
+    const clearSpy = vi.spyOn(globalThis, 'clearInterval');
+    const { unmount } = renderHook(() => useNow(60_000));
+    unmount();
+    expect(clearSpy).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/hooks/useNow.ts
+++ b/apps/web/src/hooks/useNow.ts
@@ -1,0 +1,24 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+/**
+ * A ticking clock hook — #2633 Slice B (LD-7).
+ *
+ * Returns the current `Date`, re-rendering every `intervalMs` (default 60s, which
+ * matches the minute-granularity `'Hh Mm'` / `'Nm'` formats the night-live view
+ * renders). Injecting this value into the pure `mapNightLiveToViewModel(dto, now)`
+ * keeps the elapsed/actual times live while leaving the mapper deterministic.
+ *
+ * @param intervalMs tick interval in milliseconds (default 60000).
+ */
+export function useNow(intervalMs: number = 60_000): Date {
+  const [now, setNow] = useState<Date>(() => new Date());
+
+  useEffect(() => {
+    const id = setInterval(() => setNow(new Date()), intervalMs);
+    return () => clearInterval(id);
+  }, [intervalMs]);
+
+  return now;
+}

--- a/apps/web/src/lib/api/clients/__tests__/gameNightsClient.live.test.ts
+++ b/apps/web/src/lib/api/clients/__tests__/gameNightsClient.live.test.ts
@@ -65,4 +65,14 @@ describe('gameNightsClient.getLive', () => {
 
     await expect(client.getLive(GN_ID)).rejects.toBeInstanceOf(UnauthorizedError);
   });
+
+  it('rejects an unknown session status at the parse boundary — not the mapper (AC5)', async () => {
+    const poison = {
+      ...LIVE,
+      sessions: [{ ...LIVE.sessions[0], status: 'NewFutureStatus' }],
+    };
+    mockGet.mockResolvedValue(poison);
+
+    await expect(client.getLive(GN_ID)).rejects.toThrow();
+  });
 });

--- a/apps/web/src/lib/api/clients/__tests__/gameNightsClient.live.test.ts
+++ b/apps/web/src/lib/api/clients/__tests__/gameNightsClient.live.test.ts
@@ -1,0 +1,68 @@
+/**
+ * gameNightsClient.getLive tests — #2633 Slice B (LD-10).
+ *
+ * The night-live read (GET /game-nights/{id}/live) must NOT feed a 401→null
+ * response into GameNightLiveDtoSchema.parse() (which would surface a
+ * SchemaValidationError indistinguishable from a corrupt 500). Instead null is
+ * detected and rethrown as a typed UnauthorizedError.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { UnauthorizedError } from '@/lib/api/core/errors';
+
+import { createGameNightsClient } from '../gameNightsClient';
+
+const mockGet = vi.fn();
+const mockHttpClient = {
+  get: mockGet,
+  post: vi.fn(),
+  put: vi.fn(),
+  delete: vi.fn(),
+};
+
+const GN_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+
+const LIVE = {
+  id: GN_ID,
+  title: 'Serata Eldoria',
+  status: 'Published',
+  sessions: [
+    {
+      sessionId: '11111111-1111-4111-8111-111111111111',
+      gameId: '22222222-2222-4222-8222-222222222222',
+      gameTitle: 'Eldoria',
+      playOrder: 1,
+      status: 'InProgress',
+      winnerId: null,
+      startedAt: '2026-07-04T20:00:00Z',
+      completedAt: null,
+    },
+  ],
+};
+
+describe('gameNightsClient.getLive', () => {
+  let client: ReturnType<typeof createGameNightsClient>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    client = createGameNightsClient({ httpClient: mockHttpClient as never });
+  });
+
+  it('GETs /game-nights/{id}/live and returns the parsed live dto', async () => {
+    mockGet.mockResolvedValue(LIVE);
+
+    const result = await client.getLive(GN_ID);
+
+    expect(mockGet).toHaveBeenCalledWith(`/api/v1/game-nights/${GN_ID}/live`);
+    expect(result.title).toBe('Serata Eldoria');
+    expect(result.sessions).toHaveLength(1);
+    expect(result.sessions[0].status).toBe('InProgress');
+  });
+
+  it('throws UnauthorizedError when the client returns null (401 path) — never parses null', async () => {
+    mockGet.mockResolvedValue(null);
+
+    await expect(client.getLive(GN_ID)).rejects.toBeInstanceOf(UnauthorizedError);
+  });
+});

--- a/apps/web/src/lib/api/clients/gameNightsClient.ts
+++ b/apps/web/src/lib/api/clients/gameNightsClient.ts
@@ -5,14 +5,17 @@
 
 import { z } from 'zod';
 
+import { UnauthorizedError } from '../core/errors';
 import {
   ConflictCheckDtoSchema,
   GameNightDtoSchema,
+  GameNightLiveDtoSchema,
   GameNightRsvpDtoSchema,
   RegularDtoSchema,
   type ConflictCheckDto,
   type CreateGameNightInput,
   type GameNightDto,
+  type GameNightLiveDto,
   type GameNightRsvpDto,
   type RegularDto,
   type RsvpStatus,
@@ -27,6 +30,8 @@ export interface GameNightsClient {
   getCompleted(limit?: number): Promise<GameNightDto[]>;
   getMine(): Promise<GameNightDto[]>;
   getById(id: string): Promise<GameNightDto>;
+  // #2633 Slice B: night-live read model (header + session progression).
+  getLive(id: string): Promise<GameNightLiveDto>;
   getRsvps(id: string): Promise<GameNightRsvpDto[]>;
   create(data: CreateGameNightInput): Promise<string>;
   update(id: string, data: UpdateGameNightInput): Promise<void>;
@@ -70,6 +75,19 @@ export function createGameNightsClient({
     async getById(id) {
       const data = await httpClient.get<GameNightDto>(`/api/v1/game-nights/${id}`);
       return GameNightDtoSchema.parse(data);
+    },
+
+    async getLive(id) {
+      // #2633 Slice B (LD-10): httpClient.get returns null on a 401 (optional-auth
+      // path). Detect it BEFORE parsing so a lapsed session surfaces as a typed
+      // UnauthorizedError, not a SchemaValidationError masquerading as a 500.
+      const data = await httpClient.get<GameNightLiveDto>(`/api/v1/game-nights/${id}/live`);
+      if (data === null) {
+        throw new UnauthorizedError({
+          message: 'Authentication required to view the night-live state.',
+        });
+      }
+      return GameNightLiveDtoSchema.parse(data);
     },
 
     async getRsvps(id) {

--- a/apps/web/src/lib/api/schemas/__tests__/game-nights-live.schemas.test.ts
+++ b/apps/web/src/lib/api/schemas/__tests__/game-nights-live.schemas.test.ts
@@ -1,0 +1,69 @@
+/**
+ * game-nights-live schema tests — #2633 Slice B (LD-4).
+ *
+ * The live read model (GET /game-nights/{id}/live → GameNightLiveDto) must:
+ *  - accept ALL 5 GameNightSessionStatus wire strings (incl. Skipped/Corrupted),
+ *    so a single Skipped/Corrupted row never fails the whole array `.parse()`;
+ *  - reject an unknown 6th status at the parse boundary (fail-fast, not silent).
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { GameNightLiveDtoSchema, GameNightSessionStatusSchema } from '../game-nights.schemas';
+
+const SESSION = {
+  sessionId: '11111111-1111-4111-8111-111111111111',
+  gameId: '22222222-2222-4222-8222-222222222222',
+  gameTitle: 'Eldoria',
+  playOrder: 1,
+  status: 'InProgress',
+  winnerId: null,
+  startedAt: '2026-07-04T20:00:00+00:00',
+  completedAt: null,
+};
+
+const LIVE = {
+  id: '33333333-3333-4333-8333-333333333333',
+  title: 'Serata Eldoria',
+  status: 'Published',
+  sessions: [SESSION],
+};
+
+describe('GameNightSessionStatusSchema', () => {
+  it.each(['Pending', 'InProgress', 'Completed', 'Skipped', 'Corrupted'])(
+    'accepts the wire string %s',
+    value => {
+      expect(GameNightSessionStatusSchema.parse(value)).toBe(value);
+    }
+  );
+
+  it('rejects an unknown 6th status at the boundary', () => {
+    expect(() => GameNightSessionStatusSchema.parse('Abandoned')).toThrow();
+  });
+});
+
+describe('GameNightLiveDtoSchema', () => {
+  it('parses a valid live payload', () => {
+    const parsed = GameNightLiveDtoSchema.parse(LIVE);
+    expect(parsed.sessions).toHaveLength(1);
+    expect(parsed.sessions[0].status).toBe('InProgress');
+  });
+
+  it('parses a payload containing a Corrupted session without throwing', () => {
+    const corrupted = {
+      ...LIVE,
+      sessions: [{ ...SESSION, status: 'Corrupted', startedAt: null }],
+    };
+    expect(() => GameNightLiveDtoSchema.parse(corrupted)).not.toThrow();
+  });
+
+  it('parses an empty-sessions Published night (happy path)', () => {
+    const empty = { ...LIVE, sessions: [] };
+    expect(GameNightLiveDtoSchema.parse(empty).sessions).toEqual([]);
+  });
+
+  it('throws when a session carries an unknown status (poison record fails fast)', () => {
+    const poison = { ...LIVE, sessions: [{ ...SESSION, status: 'WhoKnows' }] };
+    expect(() => GameNightLiveDtoSchema.parse(poison)).toThrow();
+  });
+});

--- a/apps/web/src/lib/api/schemas/game-nights.schemas.ts
+++ b/apps/web/src/lib/api/schemas/game-nights.schemas.ts
@@ -40,6 +40,42 @@ export const GameNightDtoSchema = z.object({
 });
 export type GameNightDto = z.infer<typeof GameNightDtoSchema>;
 
+// ──────────────────────────────────────────────────────────────────────
+// #2633 Slice B — night-live read model (GET /game-nights/{id}/live).
+// Mirrors the shipped C# GameNightLiveDto / GameNightSessionDto (Slice A).
+// LD-4: the status enum MUST list all 5 wire strings so a Skipped/Corrupted
+// row never fails the whole array .parse(); an unknown 6th value fails fast.
+// ──────────────────────────────────────────────────────────────────────
+
+export const GameNightSessionStatusSchema = z.enum([
+  'Pending',
+  'InProgress',
+  'Completed',
+  'Skipped',
+  'Corrupted',
+]);
+export type GameNightSessionStatus = z.infer<typeof GameNightSessionStatusSchema>;
+
+export const GameNightSessionDtoSchema = z.object({
+  sessionId: z.string().uuid(),
+  gameId: z.string().uuid(),
+  gameTitle: z.string(),
+  playOrder: z.number().int(),
+  status: GameNightSessionStatusSchema,
+  winnerId: z.string().uuid().nullable(),
+  startedAt: z.string().nullable(),
+  completedAt: z.string().nullable(),
+});
+export type GameNightSessionDto = z.infer<typeof GameNightSessionDtoSchema>;
+
+export const GameNightLiveDtoSchema = z.object({
+  id: z.string().uuid(),
+  title: z.string(),
+  status: GameNightStatusSchema,
+  sessions: z.array(GameNightSessionDtoSchema),
+});
+export type GameNightLiveDto = z.infer<typeof GameNightLiveDtoSchema>;
+
 export const CreateGameNightInputSchema = z.object({
   title: z.string().min(3).max(200),
   description: z.string().max(2000).optional(),

--- a/apps/web/src/lib/game-nights/__tests__/mapNightLive.test.ts
+++ b/apps/web/src/lib/game-nights/__tests__/mapNightLive.test.ts
@@ -1,0 +1,290 @@
+/**
+ * mapNightLive unit tests — #2633 Slice B (LD-1, LD-4..LD-11).
+ *
+ * The mapper is a PURE function: mapNightLiveToViewModel(dto, now) with no
+ * internal clock/random/global read. These tests pin every field→source rule
+ * from the spec-panel verdict (2026-07-04-issue-2633-sliceb-spec-panel-verdict).
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import type { GameNightLiveDto } from '@/lib/api/schemas/game-nights.schemas';
+import { hashToHue } from '@/lib/games/cover-utils';
+
+import { mapNightLiveToViewModel, toPlannedGameStatus } from '../mapNightLive';
+
+const GN_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const G1 = '11111111-1111-4111-8111-111111111111';
+const G2 = '22222222-2222-4222-8222-222222222222';
+const G3 = '33333333-3333-4333-8333-333333333333';
+const S1 = 'aaaa1111-1111-4111-8111-111111111111';
+const S2 = 'aaaa2222-2222-4222-8222-222222222222';
+const S3 = 'aaaa3333-3333-4333-8333-333333333333';
+
+function session(over: Partial<GameNightLiveDto['sessions'][number]>) {
+  return {
+    sessionId: S1,
+    gameId: G1,
+    gameTitle: 'Eldoria',
+    playOrder: 1,
+    status: 'Pending' as const,
+    winnerId: null,
+    startedAt: null,
+    completedAt: null,
+    ...over,
+  };
+}
+
+function live(over: Partial<GameNightLiveDto> = {}): GameNightLiveDto {
+  return {
+    id: GN_ID,
+    title: 'Serata Eldoria',
+    status: 'Published',
+    sessions: [],
+    ...over,
+  };
+}
+
+const NOW = new Date('2026-07-04T22:35:00Z');
+
+// Happy-path 3-session night: Completed + InProgress + Pending.
+const HAPPY = live({
+  sessions: [
+    session({
+      sessionId: S1,
+      gameId: G1,
+      gameTitle: 'Brass',
+      playOrder: 1,
+      status: 'Completed',
+      winnerId: null,
+      startedAt: '2026-07-04T20:00:00Z',
+      completedAt: '2026-07-04T21:53:00Z',
+    }),
+    session({
+      sessionId: S2,
+      gameId: G2,
+      gameTitle: 'Spirit Island',
+      playOrder: 2,
+      status: 'InProgress',
+      startedAt: '2026-07-04T22:00:00Z',
+    }),
+    session({
+      sessionId: S3,
+      gameId: G3,
+      gameTitle: 'Wingspan',
+      playOrder: 3,
+      status: 'Pending',
+    }),
+  ],
+});
+
+describe('toPlannedGameStatus', () => {
+  it('maps the 5 wire statuses to the 3 planned buckets', () => {
+    expect(toPlannedGameStatus('Pending')).toBe('upcoming');
+    expect(toPlannedGameStatus('InProgress')).toBe('inprogress');
+    expect(toPlannedGameStatus('Completed')).toBe('completed');
+    expect(toPlannedGameStatus('Skipped')).toBe('completed');
+    expect(toPlannedGameStatus('Corrupted')).toBe('completed');
+  });
+});
+
+describe('mapNightLiveToViewModel — header + progression', () => {
+  it('maps title from dto.Title and total from sessions.length', () => {
+    const vm = mapNightLiveToViewModel(HAPPY, NOW);
+    expect(vm.night.title).toBe('Serata Eldoria');
+    expect(vm.night.shortTitle).toBeUndefined();
+    expect(vm.night.nightCode).toBeUndefined();
+    expect(vm.total).toBe(3);
+  });
+
+  it('carries the raw GameNightStatus as nightStatus (LD-14 terminal routing)', () => {
+    expect(mapNightLiveToViewModel(HAPPY, NOW).nightStatus).toBe('Published');
+    expect(mapNightLiveToViewModel(live({ status: 'Cancelled' }), NOW).nightStatus).toBe(
+      'Cancelled'
+    );
+    expect(mapNightLiveToViewModel(live({ status: 'Completed' }), NOW).nightStatus).toBe(
+      'Completed'
+    );
+  });
+
+  it('sets current to the PlayOrder of the single InProgress session', () => {
+    expect(mapNightLiveToViewModel(HAPPY, NOW).current).toBe(2);
+  });
+
+  it("status is 'live' when a session is InProgress", () => {
+    expect(mapNightLiveToViewModel(HAPPY, NOW).status).toBe('live');
+  });
+
+  it("status is 'transition' when no session is InProgress", () => {
+    const allDone = live({
+      sessions: [
+        session({
+          status: 'Completed',
+          startedAt: '2026-07-04T20:00:00Z',
+          completedAt: '2026-07-04T21:00:00Z',
+        }),
+      ],
+    });
+    expect(mapNightLiveToViewModel(allDone, NOW).status).toBe('transition');
+  });
+
+  it('current with no InProgress = count of terminal sessions (Completed/Skipped/Corrupted)', () => {
+    const dto = live({
+      sessions: [
+        session({
+          sessionId: S1,
+          playOrder: 1,
+          status: 'Completed',
+          startedAt: '2026-07-04T20:00:00Z',
+          completedAt: '2026-07-04T20:30:00Z',
+        }),
+        session({ sessionId: S2, playOrder: 2, status: 'Skipped' }),
+        session({ sessionId: S3, playOrder: 3, status: 'Pending' }),
+      ],
+    });
+    // Completed + Skipped = 2 terminal, no InProgress.
+    expect(mapNightLiveToViewModel(dto, NOW).current).toBe(2);
+  });
+
+  it('with >1 InProgress (racy read) picks the lowest PlayOrder and does not throw', () => {
+    const dto = live({
+      sessions: [
+        session({
+          sessionId: S2,
+          playOrder: 3,
+          status: 'InProgress',
+          startedAt: '2026-07-04T22:00:00Z',
+        }),
+        session({
+          sessionId: S1,
+          playOrder: 2,
+          status: 'InProgress',
+          startedAt: '2026-07-04T22:10:00Z',
+        }),
+      ],
+    });
+    expect(() => mapNightLiveToViewModel(dto, NOW)).not.toThrow();
+    expect(mapNightLiveToViewModel(dto, NOW).current).toBe(2);
+  });
+});
+
+describe('mapNightLiveToViewModel — planned games', () => {
+  it('maps id from SessionId (not GameId) and preserves PlayOrder', () => {
+    const vm = mapNightLiveToViewModel(HAPPY, NOW);
+    expect(vm.plannedGames.map(g => g.id)).toEqual([S1, S2, S3]);
+    expect(vm.plannedGames.map(g => g.order)).toEqual([1, 2, 3]);
+  });
+
+  it('maps status per bucket', () => {
+    const vm = mapNightLiveToViewModel(HAPPY, NOW);
+    expect(vm.plannedGames.map(g => g.status)).toEqual(['completed', 'inprogress', 'upcoming']);
+  });
+
+  it('derives a deterministic cover gradient from GameId', () => {
+    const vm = mapNightLiveToViewModel(HAPPY, NOW);
+    const cover = vm.plannedGames[0].cover;
+    expect(cover).toHaveLength(2);
+    expect(cover?.[0]).toContain(`hsl(${hashToHue(G1)}`);
+    // deterministic: same input, same cover
+    expect(mapNightLiveToViewModel(HAPPY, NOW).plannedGames[0].cover).toEqual(cover);
+  });
+
+  it('leaves publisher/emoji/estimated/score/winner undefined (Slice B)', () => {
+    const g = mapNightLiveToViewModel(HAPPY, NOW).plannedGames[0];
+    expect(g.publisher).toBeUndefined();
+    expect(g.emoji).toBeUndefined();
+    expect(g.estimated).toBeUndefined();
+    expect(g.score).toBeUndefined();
+    expect(g.winner).toBeUndefined();
+  });
+
+  it('carries winnerId through untouched (winner resolution is Slice C)', () => {
+    const dto = live({
+      sessions: [
+        session({
+          status: 'Completed',
+          winnerId: G2,
+          startedAt: '2026-07-04T20:00:00Z',
+          completedAt: '2026-07-04T21:00:00Z',
+        }),
+      ],
+    });
+    const g = mapNightLiveToViewModel(dto, NOW).plannedGames[0];
+    expect(g.winnerId).toBe(G2);
+    expect(g.winner).toBeUndefined();
+  });
+
+  it('marks a Skipped session muted and keeps it in the list', () => {
+    const dto = live({ sessions: [session({ status: 'Skipped', gameTitle: 'Saltata' })] });
+    const g = mapNightLiveToViewModel(dto, NOW).plannedGames[0];
+    expect(g.status).toBe('completed');
+    expect(g.muted).toBe(true);
+  });
+
+  it('renders a Corrupted session with a non-empty title and never throws', () => {
+    const dto = live({ sessions: [session({ status: 'Corrupted', gameTitle: '' })] });
+    expect(() => mapNightLiveToViewModel(dto, NOW)).not.toThrow();
+    const g = mapNightLiveToViewModel(dto, NOW).plannedGames[0];
+    expect(g.status).toBe('completed');
+    expect(g.title.length).toBeGreaterThan(0);
+  });
+});
+
+describe('mapNightLiveToViewModel — time (LD-7)', () => {
+  it("elapsed is 'Hh Mm' from the earliest StartedAt to now", () => {
+    expect(mapNightLiveToViewModel(HAPPY, NOW).elapsed).toBe('2h 35m');
+  });
+
+  it("actual is 'Nm' for a Completed session (CompletedAt - StartedAt)", () => {
+    expect(mapNightLiveToViewModel(HAPPY, NOW).plannedGames[0].actual).toBe('113m');
+  });
+
+  it("actual is 'Nm' for an InProgress session (now - StartedAt)", () => {
+    expect(mapNightLiveToViewModel(HAPPY, NOW).plannedGames[1].actual).toBe('35m');
+  });
+
+  it('actual is undefined for a Pending session', () => {
+    expect(mapNightLiveToViewModel(HAPPY, NOW).plannedGames[2].actual).toBeUndefined();
+  });
+});
+
+describe('mapNightLiveToViewModel — determinism (LD-1)', () => {
+  it('is deeply-equal across two calls with the same now', () => {
+    expect(mapNightLiveToViewModel(HAPPY, NOW)).toEqual(mapNightLiveToViewModel(HAPPY, NOW));
+  });
+
+  it('a different now changes ONLY the InProgress actual + elapsed, not the Completed actual', () => {
+    const later = new Date('2026-07-04T23:00:00Z');
+    const a = mapNightLiveToViewModel(HAPPY, NOW);
+    const b = mapNightLiveToViewModel(HAPPY, later);
+    expect(b.plannedGames[0].actual).toBe(a.plannedGames[0].actual); // Completed row stable
+    expect(b.plannedGames[1].actual).not.toBe(a.plannedGames[1].actual); // InProgress row moves
+    expect(b.elapsed).not.toBe(a.elapsed);
+  });
+});
+
+describe('mapNightLiveToViewModel — empty night (LD-11) + Slice-C seam (LD-3)', () => {
+  it('a Published night with 0 sessions is a zeroed happy-path viewmodel', () => {
+    const vm = mapNightLiveToViewModel(live({ sessions: [] }), NOW);
+    expect(vm.plannedGames).toEqual([]);
+    expect(vm.current).toBe(0);
+    expect(vm.total).toBe(0);
+    expect(vm.elapsed).toBe('0h 0m');
+    expect(vm.status).toBe('transition');
+    expect(vm.night.title).toBe('Serata Eldoria');
+  });
+
+  it('emits the Slice-C props as their true empty contract', () => {
+    const vm = mapNightLiveToViewModel(HAPPY, NOW);
+    expect(vm.currentGame).toBeNull();
+    expect(vm.diaryEvents).toEqual([]);
+    expect(vm.diaryGames).toEqual([]);
+    expect(vm.diaryPlayers).toEqual([]);
+  });
+
+  it('leaves confirmedPlayers/totalPlayers undefined (no RSVP fetch in Slice B)', () => {
+    const vm = mapNightLiveToViewModel(HAPPY, NOW);
+    expect(vm.confirmedPlayers).toBeUndefined();
+    expect(vm.totalPlayers).toBeUndefined();
+  });
+});

--- a/apps/web/src/lib/game-nights/hooks/__tests__/useGameNightLive.test.tsx
+++ b/apps/web/src/lib/game-nights/hooks/__tests__/useGameNightLive.test.tsx
@@ -1,0 +1,114 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * useGameNightLive unit tests — #2633 Slice B (LD-1, LD-12).
+ *
+ * The hook is a single-endpoint React Query loader over GET /game-nights/{id}/live
+ * that wires the PURE mapper through `select`, returning a NightLiveViewModel. The
+ * clock is injected from `useNow` (mocked here to a fixed instant for determinism).
+ */
+
+import { type ReactNode } from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import type { GameNightLiveDto } from '@/lib/api/schemas/game-nights.schemas';
+
+import { gameNightLiveKeys, useGameNightLive } from '../useGameNightLive';
+
+const getLiveMock = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/api', () => ({
+  api: { gameNights: { getLive: getLiveMock } },
+}));
+vi.mock('@/hooks/useNow', () => ({
+  useNow: () => new Date('2026-07-04T22:35:00Z'),
+}));
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+const GN_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+
+const LIVE_DTO: GameNightLiveDto = {
+  id: GN_ID,
+  title: 'Serata Eldoria',
+  status: 'Published',
+  sessions: [
+    {
+      sessionId: '11111111-1111-4111-8111-111111111111',
+      gameId: '22222222-2222-4222-8222-222222222222',
+      gameTitle: 'Brass',
+      playOrder: 1,
+      status: 'Completed',
+      winnerId: null,
+      startedAt: '2026-07-04T20:00:00Z',
+      completedAt: '2026-07-04T21:53:00Z',
+    },
+    {
+      sessionId: '33333333-3333-4333-8333-333333333333',
+      gameId: '44444444-4444-4444-8444-444444444444',
+      gameTitle: 'Spirit Island',
+      playOrder: 2,
+      status: 'InProgress',
+      winnerId: null,
+      startedAt: '2026-07-04T22:00:00Z',
+      completedAt: null,
+    },
+  ],
+};
+
+describe('useGameNightLive — query key factory', () => {
+  it('namespaces the detail key under game-nights/live', () => {
+    expect(gameNightLiveKeys.detail(GN_ID)).toEqual(['game-nights', 'live', GN_ID]);
+  });
+});
+
+describe('useGameNightLive — mapping', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('delegates to api.gameNights.getLive and exposes the mapped viewmodel', async () => {
+    getLiveMock.mockResolvedValue(LIVE_DTO);
+
+    const { result } = renderHook(() => useGameNightLive(GN_ID), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(getLiveMock).toHaveBeenCalledWith(GN_ID);
+    const vm = result.current.data!;
+    expect(vm.night.title).toBe('Serata Eldoria');
+    expect(vm.total).toBe(2);
+    expect(vm.current).toBe(2);
+    expect(vm.status).toBe('live');
+    expect(vm.plannedGames.map(g => g.id)).toEqual([
+      '11111111-1111-4111-8111-111111111111',
+      '33333333-3333-4333-8333-333333333333',
+    ]);
+    // time derived against the mocked fixed `now` (22:35Z)
+    expect(vm.elapsed).toBe('2h 35m');
+    expect(vm.plannedGames[0].actual).toBe('113m');
+  });
+
+  it('does not fire when id is empty', () => {
+    renderHook(() => useGameNightLive(''), { wrapper: createWrapper() });
+    expect(getLiveMock).not.toHaveBeenCalled();
+  });
+
+  it('surfaces the rejection on error', async () => {
+    getLiveMock.mockRejectedValue(new Error('boom'));
+
+    const { result } = renderHook(() => useGameNightLive(GN_ID), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe('boom');
+  });
+});

--- a/apps/web/src/lib/game-nights/hooks/useGameNightLive.ts
+++ b/apps/web/src/lib/game-nights/hooks/useGameNightLive.ts
@@ -1,0 +1,52 @@
+'use client';
+
+/**
+ * useGameNightLive — #2633 Slice B (LD-1, LD-12).
+ *
+ * Single-endpoint React Query loader over `GET /game-nights/{id}/live`
+ * (`api.gameNights.getLive`). It wires the PURE `mapNightLiveToViewModel` through
+ * React Query `select`, returning `UseQueryResult<NightLiveViewModel, Error>` — the
+ * raw-UseQueryResult convention of `useGameNightConflictCheck`, so the view keeps
+ * its full isLoading/isError/error branching (the LD-10 error taxonomy).
+ *
+ * The clock is injected from `useNow(60_000)` so elapsed/actual stay live while the
+ * mapper remains deterministic. `retry: false` mirrors the sibling game-night hook.
+ */
+
+import { useCallback } from 'react';
+
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+
+import { useNow } from '@/hooks/useNow';
+import { api } from '@/lib/api';
+import type { GameNightLiveDto } from '@/lib/api/schemas/game-nights.schemas';
+import { mapNightLiveToViewModel, type NightLiveViewModel } from '@/lib/game-nights/mapNightLive';
+
+/** Query key factory for the night-live read (distinct from the lean game-night keys). */
+export const gameNightLiveKeys = {
+  all: ['game-nights', 'live'] as const,
+  detail: (id: string) => [...gameNightLiveKeys.all, id] as const,
+};
+
+export function useGameNightLive(
+  id: string,
+  enabled: boolean = true
+): UseQueryResult<NightLiveViewModel, Error> {
+  const now = useNow(60_000);
+
+  // Stable per `now` tick: `select` re-runs only when the data or the clock
+  // changes, not on every render.
+  const select = useCallback(
+    (dto: GameNightLiveDto): NightLiveViewModel => mapNightLiveToViewModel(dto, now),
+    [now]
+  );
+
+  return useQuery({
+    queryKey: gameNightLiveKeys.detail(id),
+    queryFn: () => api.gameNights.getLive(id),
+    select,
+    enabled: enabled && !!id,
+    staleTime: 30_000,
+    retry: false,
+  });
+}

--- a/apps/web/src/lib/game-nights/mapNightLive.ts
+++ b/apps/web/src/lib/game-nights/mapNightLive.ts
@@ -1,0 +1,179 @@
+/**
+ * mapNightLive — #2633 Slice B (LD-1).
+ *
+ * PURE projection from the shipped `GameNightLiveDto` (GET /game-nights/{id}/live)
+ * onto the `NightLiveViewModel` the `NightLiveHub` renders. The single seam type
+ * `NightLiveViewModel` is what Slice C extends (it fills currentGame + the diary
+ * arrays + winner resolution by changing only its own branch, never the view wiring).
+ *
+ * Purity contract (LD-1, LD-7): the clock is INJECTED via `now`. This function
+ * must never read `Date.now()`/`new Date()` without an argument, `performance.now()`,
+ * `Math.random()`, or module-level mutable state — so every field is deterministic
+ * and table-testable. The hook seeds `now` from a `useNow(60_000)` tick.
+ */
+
+import type {
+  DiaryEvent,
+  DiaryGameRef,
+  DiaryPlayerRef,
+  NightLiveHubCurrentGame,
+  NightLiveHubNight,
+  NightLiveStatus,
+  PlannedGame,
+  PlannedGameStatus,
+} from '@/components/features/game-nights/live';
+import type {
+  GameNightLiveDto,
+  GameNightSessionDto,
+  GameNightSessionStatus,
+  GameNightStatus,
+} from '@/lib/api/schemas/game-nights.schemas';
+import { hashToHue } from '@/lib/games/cover-utils';
+
+/** The single seam type Slice B produces and Slice C extends. */
+export interface NightLiveViewModel {
+  readonly night: NightLiveHubNight;
+  /** Raw GameNight lifecycle status — drives terminal-night routing (LD-14). */
+  readonly nightStatus: GameNightStatus;
+  readonly status: NightLiveStatus;
+  readonly current: number;
+  readonly total: number;
+  readonly elapsed: string;
+  readonly confirmedPlayers?: number;
+  readonly totalPlayers?: number;
+  readonly plannedGames: readonly PlannedGame[];
+  readonly currentGame: NightLiveHubCurrentGame | null;
+  readonly diaryEvents: readonly DiaryEvent[];
+  readonly diaryGames: readonly DiaryGameRef[];
+  readonly diaryPlayers: readonly DiaryPlayerRef[];
+}
+
+const MINUTE_MS = 60_000;
+
+/** Sessions that count as "played" for the progress counter (LD-6). */
+const TERMINAL: ReadonlySet<GameNightSessionStatus> = new Set([
+  'Completed',
+  'Skipped',
+  'Corrupted',
+]);
+
+/**
+ * LD-4: total 5→3 projection. Exhaustive (the `never` default makes a new BE
+ * status a compile break, not a silent `default → 'upcoming'` misrender).
+ * Skipped/Corrupted collapse to `completed` (past/terminal), differentiated at
+ * render time via `muted` (Skipped) and a non-empty fallback title (Corrupted).
+ */
+export function toPlannedGameStatus(status: GameNightSessionStatus): PlannedGameStatus {
+  switch (status) {
+    case 'Pending':
+      return 'upcoming';
+    case 'InProgress':
+      return 'inprogress';
+    case 'Completed':
+      return 'completed';
+    case 'Skipped':
+      return 'completed';
+    case 'Corrupted':
+      return 'completed';
+    default: {
+      const exhaustive: never = status;
+      return exhaustive;
+    }
+  }
+}
+
+/** LD-9: deterministic 2-stop cover gradient from the game id (BGG-ban compliant). */
+function coverFromGameId(gameId: string): readonly [string, string] {
+  const h1 = hashToHue(gameId);
+  const h2 = (h1 + 40) % 360;
+  return [`hsl(${h1} 40% 30%)`, `hsl(${h2} 45% 38%)`];
+}
+
+function minutesBetween(fromIso: string, toMs: number): number {
+  const fromMs = new Date(fromIso).getTime();
+  return Math.max(0, Math.floor((toMs - fromMs) / MINUTE_MS));
+}
+
+/**
+ * LD-7: per-game elapsed as `'Nm'`.
+ *  - Completed: CompletedAt − StartedAt (stable for any `now`)
+ *  - InProgress: now − StartedAt (the only `now`-dependent value)
+ *  - Pending/Skipped/Corrupted, or missing StartedAt: undefined
+ */
+function toActual(session: GameNightSessionDto, nowMs: number): string | undefined {
+  if (!session.startedAt) return undefined;
+  if (session.status === 'Completed') {
+    if (!session.completedAt) return undefined;
+    return `${minutesBetween(session.startedAt, new Date(session.completedAt).getTime())}m`;
+  }
+  if (session.status === 'InProgress') {
+    return `${minutesBetween(session.startedAt, nowMs)}m`;
+  }
+  return undefined;
+}
+
+/** LD-4: Corrupted (or otherwise blank) titles never render empty. */
+function toTitle(session: GameNightSessionDto): string {
+  const trimmed = session.gameTitle.trim();
+  if (trimmed.length > 0) return trimmed;
+  return session.status === 'Corrupted' ? 'Partita non disponibile' : 'Partita';
+}
+
+/** LD-7: header elapsed as `'Hh Mm'` from the earliest StartedAt to `now`. */
+function formatElapsed(fromMs: number, toMs: number): string {
+  const total = Math.max(0, Math.floor((toMs - fromMs) / MINUTE_MS));
+  return `${Math.floor(total / 60)}h ${total % 60}m`;
+}
+
+export function mapNightLiveToViewModel(dto: GameNightLiveDto, now: Date): NightLiveViewModel {
+  const nowMs = now.getTime();
+  const sessions = [...dto.sessions].sort((a, b) => a.playOrder - b.playOrder);
+
+  const plannedGames: PlannedGame[] = sessions.map(session => ({
+    id: session.sessionId, // LD-5: SessionId, not GameId
+    title: toTitle(session),
+    status: toPlannedGameStatus(session.status),
+    order: session.playOrder,
+    actual: toActual(session, nowMs),
+    cover: coverFromGameId(session.gameId),
+    winnerId: session.winnerId ?? undefined, // LD-2: carried for Slice C
+    muted: session.status === 'Skipped' ? true : undefined, // LD-4
+  }));
+
+  const total = sessions.length;
+
+  // LD-6: current = PlayOrder of the (lowest, if racy) InProgress session;
+  // if none InProgress, the count of terminal sessions. Clamped, never throws.
+  const inProgress = sessions.filter(s => s.status === 'InProgress');
+  const rawCurrent =
+    inProgress.length > 0
+      ? Math.min(...inProgress.map(s => s.playOrder))
+      : sessions.filter(s => TERMINAL.has(s.status)).length;
+  const current = Math.max(0, Math.min(rawCurrent, total));
+
+  // LD-7: elapsed from the earliest StartedAt across all sessions.
+  const startTimes = sessions
+    .map(s => s.startedAt)
+    .filter((v): v is string => v != null)
+    .map(v => new Date(v).getTime());
+  const elapsed = startTimes.length > 0 ? formatElapsed(Math.min(...startTimes), nowMs) : '0h 0m';
+
+  // LD-8: 'live' iff a session is running; no 'paused' signal from the BE.
+  const status: NightLiveStatus = inProgress.length > 0 ? 'live' : 'transition';
+
+  return {
+    night: { title: dto.title }, // LD-15: shortTitle/nightCode undefined in Slice B
+    nightStatus: dto.status, // LD-14: raw lifecycle status for terminal routing
+    status,
+    current,
+    total,
+    elapsed,
+    confirmedPlayers: undefined, // LD-8: no RSVP fetch in Slice B
+    totalPlayers: undefined,
+    plannedGames,
+    currentGame: null, // LD-3: Slice C
+    diaryEvents: [],
+    diaryGames: [],
+    diaryPlayers: [],
+  };
+}

--- a/docs/for-developers/specs/2026-07-01-game-night-live-wire-design.md
+++ b/docs/for-developers/specs/2026-07-01-game-night-live-wire-design.md
@@ -4,6 +4,7 @@
 **Date**: 2026-07-01
 **Related**: #2632 (SI-1 done) · #2633 (SI-2, blocked) · #2647 (OpenLiveMode/#15 gap)
 **Status**: PROPOSED — slice breakdown for review before implementation.
+**Update 2026-07-04**: Slice A shipped (PR #2652). Slice B ratified via `/sc:spec-panel` — see [`2026-07-04-issue-2633-sliceb-spec-panel-verdict.md`](./2026-07-04-issue-2633-sliceb-spec-panel-verdict.md). **Winner display is RE-SCOPED out of Slice B into Slice C** (LD-2): `getRsvps` returns only User-linked participants, so guest/organizer winners would silently vanish — the mapper carries `winnerId` through and Slice C resolves `{name,initials,color}` against the participant read model (extended for guests).
 
 ---
 

--- a/docs/for-developers/specs/2026-07-04-issue-2633-sliceb-spec-panel-verdict.md
+++ b/docs/for-developers/specs/2026-07-04-issue-2633-sliceb-spec-panel-verdict.md
@@ -1,0 +1,93 @@
+# #2633 Slice B — spec-panel verdict & implementation contract
+
+**Issue**: [#2633](https://github.com/meepleAi-app/meepleai-monorepo/issues/2633) — SI-2 night-live wire-up, **Slice B** (FE hook + header + planned games)
+**Parent**: [#2619](https://github.com/meepleAi-app/meepleai-monorepo/issues/2619) · **Thread A**
+**Date**: 2026-07-04
+**Method**: `/sc:spec-panel` critique (Fowler · Wiegers · Nygard · Adzic · Cockburn) → consolidated synthesis
+**Predecessor**: [`2026-07-01-game-night-live-wire-design.md`](./2026-07-01-game-night-live-wire-design.md) (Slices A–D). Slice A (`GET /game-nights/{id}/live` → `GameNightLiveDto`) is **shipped & frozen** (PR #2652).
+**Status**: RATIFIED 2026-07-04 — 15 locked decisions + 3 product calls confirmed by the issue owner.
+
+---
+
+## 1. Scope
+
+Slice B replaces the `NIGHT` + `PLANNED_GAMES` **fixtures** in `NightLiveClientView.tsx` with a backend-driven
+read path over the already-shipped `GET /api/v1/game-nights/{id}/live`. It is a **read-only projection** of the
+night header + planned line-up + real session jump. It does **not** implement the LIVE badge / blocked modal
+(Slice D = SI-2 proper), the currentGame + diary (Slice C), or any write/drive interaction.
+
+## 2. Locked decisions (LD-1 … LD-15)
+
+| ID | Decision |
+|---|---|
+| **LD-1** | One exported seam type `NightLiveViewModel` + one **pure** module fn `mapNightLiveToViewModel(dto, now: Date): NightLiveViewModel` in `apps/web/src/lib/game-nights/mapNightLive.ts`. No internal `Date.now()`/`new Date()`/`performance.now()`/`Math.random()`/module-level mutable state. Hook wires it via React Query `select`. |
+| **LD-2** | Winner `{name,initials,color}` is **OUT of Slice B** (product-confirmed). Mapper carries `winnerId?: string` through untouched; card renders no winner chip. Resolution deferred to Slice C. Hook is single-endpoint (no `getRsvps`). |
+| **LD-3** | Mapper emits Slice-C props as true empty contract: `currentGame: null`, `diaryEvents/diaryGames/diaryPlayers: []`. **Delete** `CURRENT_GAME` + `DIARY_*` module fixtures from `NightLiveClientView.tsx`. |
+| **LD-4** | (a) `GameNightSessionStatusSchema = z.enum(['Pending','InProgress','Completed','Skipped','Corrupted'])` (all 5). (b) Pure `toPlannedGameStatus` exhaustive switch (TS `never` default). Table: Pending→`upcoming`, InProgress→`inprogress`, Completed→`completed`, **Skipped→`completed` (muted marker, excluded from `current`)**, Corrupted→`completed` (neutral fallback, never throws). Unknown 6th string fails at the parse boundary. |
+| **LD-5** | `PlannedGame.id = SessionId` (a game may be played twice a night; SessionId is the stable diary/jump key). |
+| **LD-6** | `total = dto.Sessions.length` (incl. Skipped/Corrupted). `current` = 1-based PlayOrder of the single InProgress session; if none, count of terminal sessions {Completed, Skipped, Corrupted} clamped to `[0, total]`. If >1 InProgress (racy read), pick lowest PlayOrder, never throw. |
+| **LD-7** | `elapsed`/`actual` derived in B from timestamps vs injected `now`. Formats match fixtures: `elapsed = 'Hh Mm'` from earliest StartedAt→now; `actual = 'Nm'` (Completed: CompletedAt−StartedAt; InProgress: now−StartedAt; Pending/Skipped/Corrupted: `undefined`). `estimated`/`score` = `undefined` (no DTO source, D-SCORE/TIME). Hook seeds `now` via `useNow(60_000)` so the clock ticks; mapper stays pure. |
+| **LD-8** | `status` = `'live'` if any InProgress else `'transition'`. No `'paused'` (no BE signal). `confirmedPlayers`/`totalPlayers` = `undefined` (no RSVP fetch). |
+| **LD-9** | `cover` = deterministic 2-stop gradient from `hashToHue(GameId)` (`cover-utils`, BGG-ban compliant). `emoji` = `undefined` (no deterministic source; decorative/optional). `publisher` = `undefined`. No catalog fetch → mapper stays synchronous. |
+| **LD-10** | Error taxonomy against real client shapes: `httpClient.get` returns `null` on 401 (`httpClient.ts:136`) → detect `null` **before** `.parse()`, throw typed `UnauthenticatedError` → login redirect. `NetworkError`/`CircuitBreakerError` by `error.name` → retryable "connection lost". `ApiError.statusCode` 403 → non-participant, 404 → not-found. Hook `retry: false`. |
+| **LD-11** | Published night with 0 sessions = **happy-path 200**: `plannedGames: []`, `current: 0`, `total: 0`, `elapsed: '0h 0m'`, `status: 'transition'`, header from `dto.Title`. View renders a defined empty state (distinct from loading/error). |
+| **LD-12** | Hook returns `UseQueryResult<NightLiveViewModel, Error>` (not a bespoke object); pure mapper via `select`. Follows `useGameNightConflictCheck` convention (`xxxKeys` + raw `UseQueryResult`). |
+| **LD-13** | Pause/transition/skip/end drive-controls + `GameTransitionDialog` are **OUT of Slice B**: hidden/disabled so the read-only projection doesn't advertise faked interactions. |
+| **LD-14** | Terminal/non-viewable nights (product-confirmed = **redirect + inline**): `Completed` → redirect to `/game-nights/{id}/summary`; `Cancelled` → explicit "serata annullata" state; `Draft` → not-live/empty. Only `Published` mounts the live hub. |
+| **LD-15** | Field→source acceptance table (§4) is the pass/fail contract. "Done" = every row test-verified AND **no header/planned value remains a module-level constant** in the view. |
+
+## 3. Product calls (confirmed 2026-07-04)
+
+1. **Winner** → deferred to Slice C (LD-2). Wire-design updated.
+2. **Terminal nights** → redirect Completed→`/summary` + inline Cancelled/Draft states, in Slice B (LD-14).
+3. **Skipped** → muted tile kept in list, excluded from `current` (LD-4/LD-6).
+
+## 4. Field → source acceptance table (LD-15)
+
+| ViewModel field | Source |
+|---|---|
+| `night.title` | `dto.Title` |
+| `night.shortTitle` / `night.nightCode` | `undefined` (Slice B) |
+| `total` | `dto.Sessions.length` |
+| `plannedGames[i].id` | `Sessions[i].SessionId` |
+| `plannedGames[i].title` | `Sessions[i].GameTitle` |
+| `plannedGames[i].status` | `toPlannedGameStatus(Sessions[i].Status)` (LD-4) |
+| `plannedGames[i].order` | `Sessions[i].PlayOrder` |
+| `plannedGames[i].actual` | derived from StartedAt/CompletedAt + `now` (LD-7) |
+| `plannedGames[i].cover` | `hashToHue(Sessions[i].GameId)` gradient (LD-9) |
+| `plannedGames[i].winnerId` | `Sessions[i].WinnerId` (carried; no chip) |
+| `plannedGames[i].winner` / `emoji` / `publisher` / `estimated` / `score` | `undefined` (Slice B) |
+| `current` | derived (LD-6) |
+| `elapsed` | derived (LD-7) |
+| `status` | derived (LD-8) |
+| `confirmedPlayers` / `totalPlayers` | `undefined` (LD-8) |
+| `currentGame` | `null` (LD-3) |
+| `diaryEvents` / `diaryGames` / `diaryPlayers` | `[]` (LD-3) |
+
+## 5. Acceptance criteria (Given/When/Then)
+
+1. **Determinism**: Given any DTO + fixed `now`, `mapNightLiveToViewModel(dto, now)` called twice is deeply-equal; no clock/random/global read inside.
+2. **Happy path**: Published night, 3 sessions (PlayOrder 1..3, Completed/InProgress/Pending) → `title=dto.Title`, `total=3`, `current=2`, 3 games in PlayOrder with status completed/inprogress/upcoming — all DTO-sourced, zero module constants left in the view.
+3. **Real jump**: an InProgress/Completed game tapped → navigates to `/sessions/{SessionId}` (`PlannedGame.id === SessionId`).
+4. **Enum totality/no-throw**: one `Skipped` + one `Corrupted(999)` session → Skipped→`completed` muted (excluded from `current`), Corrupted→`completed` neutral title, no exception, exhaustive `never` switch over all 5.
+5. **Parse robustness**: 200 body with `Status='Corrupted'` parses OK (enum lists all 5); unknown 6th string throws at the boundary (not the mapper emitting `upcoming`).
+6. **Elapsed/actual**: InProgress StartedAt 35m before `fixedNow` → `actual='35m'`; header `elapsed='Hh Mm'` from earliest StartedAt; a Completed row's `actual` is identical for ANY `now`; `estimated`/`score` undefined.
+7. **Empty happy-path**: Published, 0 sessions → `plannedGames=[]`, `current=0`, `total=0`, `status='transition'`, header renders, defined empty state (not error).
+8. **Winner deferred**: Completed session with WinnerId → `winnerId` carried, no winner chip, never throws.
+9. **Error taxonomy**: 401 (null) → `UnauthenticatedError`→login redirect; 403 → non-participant copy; 404 → not-found copy; Network/CircuitBreaker → retryable "connection lost" — each asserted separately, never keyed on message string.
+10. **Slice-C seam**: `currentGame=null` + `diary*=[]` from the mapper; no `CURRENT_GAME`/`DIARY_*` fixtures remain.
+11. **Terminal nights**: Completed → not rendered live (redirect to `/summary`); Cancelled → cancelled state; Draft → not-live/empty; only Published mounts the hub.
+12. **Loading**: pending query → skeleton, `NightLiveHub` not mounted with placeholder data.
+
+## 6. Out of scope (Slice C/D / later)
+
+Winner name/initials/color + participant-with-guests read model (C) · currentGame + diary arrays (C) · LIVE badge + blocked modal (D) · pause/transition/skip/end interactive behavior (later; disabled in B) · `confirmedPlayers`/`totalPlayers` real counts (later) · per-game score/estimated (not in domain, D-SCORE/TIME) · publisher & catalog cosmetics beyond `cover-utils` placeholder · `'paused'` status · any BE/DTO change (Slice A frozen).
+
+## 7. File plan
+
+- **new** `apps/web/src/lib/game-nights/mapNightLive.ts` (+ `.test.ts`) — `NightLiveViewModel`, `mapNightLiveToViewModel`, `toPlannedGameStatus`, time/cover helpers.
+- **new** `apps/web/src/hooks/useNow.ts` (+ test) — interval clock, 60s default.
+- **new** `apps/web/src/lib/game-nights/hooks/useGameNightLive.ts` (+ test) — RQ hook.
+- **edit** `apps/web/src/lib/api/schemas/game-nights.schemas.ts` — `GameNightSessionStatusSchema`, `GameNightSessionDtoSchema`, `GameNightLiveDtoSchema`.
+- **edit** `apps/web/src/lib/api/clients/gameNightsClient.ts` — `getLive(id)` (null→typed error), interface entry.
+- **edit** `apps/web/src/app/(authenticated)/game-nights/[id]/live/_components/NightLiveClientView.tsx` — consume hook, delete fixtures, loading/error/empty/terminal states, disable drive-controls.


### PR DESCRIPTION
## Cosa

**Slice B** di **SI-2 (#2633)** — sostituisce le fixture `NIGHT` + `PLANNED_GAMES` di `NightLiveClientView` con un read path backend-driven sopra `GET /game-nights/{id}/live` (Slice A, già mergiata #2652). Parte della epic **#2619** (allineamento SP6 UI ↔ dominio GameNight/GameBook), Thread A.

Progettata via `/sc:spec-panel` (Fowler · Wiegers · Nygard · Adzic · Cockburn) → **15 decisioni lockate** + 12 acceptance criteria in [`docs/for-developers/specs/2026-07-04-issue-2633-sliceb-spec-panel-verdict.md`](../blob/feature/issue-2633-nightlive-slice-b/docs/for-developers/specs/2026-07-04-issue-2633-sliceb-spec-panel-verdict.md).

## Come

- **Mapper puro** `mapNightLiveToViewModel(dto, now: Date) → NightLiveViewModel` (`lib/game-nights/mapNightLive.ts`) — seam type che Slice C estenderà; clock iniettato via `useNow(60_000)`, mapper deterministico (no `Date.now`/random/global) — LD-1, LD-7.
- **Schemi Zod** `GameNightSessionStatusSchema` con tutti e 5 i wire-string (una sessione `Skipped`/`Corrupted` non fa fallire l'intero `.parse()` dell'array); switch esaustivo `toPlannedGameStatus` (LD-4).
- **Derivazioni**: `PlannedGame.id = SessionId` (LD-5), `current`/`total`/`elapsed`/`status` da sessioni (LD-6/7/8), cover deterministico da `hashToHue` (LD-9), `winnerId` portato attraverso ma winner display rinviato a Slice C (LD-2), `Skipped` → tile muted tenuta in lista (LD-4).
- **`getLive`** intercetta il path 401→`null` del client e lancia `UnauthorizedError` invece di dare `null` in pasto a `.parse()` (LD-10). Taxonomy errori nella view: 401 (con azione "Accedi di nuovo" → `/login`) / 403 / 404 / network·circuit-breaker.
- **Seam Slice-C**: `currentGame=null` + `diary*=[]` emessi come vero contratto vuoto; fixture cancellate (LD-3). Proiezione **read-only**: drive-control nascosti via nuova prop `NightLiveHub readOnly` (LD-13).
- **Terminal nights** (LD-14): `Completed` → redirect a `/game-nights/{id}/summary`; `Cancelled`/`Draft` → stati inline; solo `Published` monta l'hub. Serata Published con 0 sessioni = empty-state happy-path (LD-11).

## Fuori scope (slice successive)

Winner name/initials/color + read model partecipanti con guest, `currentGame` + diary (Slice C) · LIVE badge + blocked modal (Slice D) · drive-control interattivi · `confirmedPlayers`/`totalPlayers` reali · score/estimated (fuori dal dominio, D-SCORE/TIME) · nessun cambiamento BE (Slice A congelata).

## Test

- **116 test** nuovi/modificati (schemi, mapper 24, hub readOnly, muted tile, `useNow`, `getLive`, hook, view integration) — copertura di tutti i 12 acceptance criteria.
- **399 test** area game-nights verdi (nessuna regressione consumer) · typecheck + lint puliti.
- Code review adversariale (subagent): **0 blocker**; 4 finding indirizzati (401 login recovery + gap test AC3/AC5/AC9).

Closes #2633
Refs #2619

🤖 Generated with [Claude Code](https://claude.com/claude-code)