### PR TITLE
feat(game-night): #2633 Slice C1 — currentGame from InProgress session

### DIFF
--- a/apps/web/src/lib/game-nights/__tests__/mapNightLive.test.ts
+++ b/apps/web/src/lib/game-nights/__tests__/mapNightLive.test.ts
@@ -230,6 +230,60 @@ describe('mapNightLiveToViewModel — planned games', () => {
   });
 });
 
+describe('mapNightLiveToViewModel — currentGame (Slice C1)', () => {
+  it('derives currentGame from the InProgress session', () => {
+    const cg = mapNightLiveToViewModel(HAPPY, NOW).currentGame;
+    expect(cg?.sessionId).toBe(S2);
+    expect(cg?.id).toBe(G2); // NightLiveHubCurrentGame.id = GameId
+    expect(cg?.title).toBe('Spirit Island');
+    expect(cg?.cover).toHaveLength(2);
+    expect(cg?.cover?.[0]).toContain(`hsl(${hashToHue(G2)}`);
+  });
+
+  it('leaves currentGame emoji + score undefined (fixture-only, D-SCORE/TIME)', () => {
+    const cg = mapNightLiveToViewModel(HAPPY, NOW).currentGame;
+    expect(cg?.emoji).toBeUndefined();
+    expect(cg?.score).toBeUndefined();
+  });
+
+  it('currentGame is null when no session is InProgress', () => {
+    const allDone = live({
+      sessions: [
+        session({
+          status: 'Completed',
+          startedAt: '2026-07-04T20:00:00Z',
+          completedAt: '2026-07-04T21:00:00Z',
+        }),
+      ],
+    });
+    expect(mapNightLiveToViewModel(allDone, NOW).currentGame).toBeNull();
+  });
+
+  it('picks the lowest-playOrder InProgress session when >1 (racy read)', () => {
+    const dto = live({
+      sessions: [
+        session({
+          sessionId: S2,
+          gameId: G2,
+          gameTitle: 'Later',
+          playOrder: 3,
+          status: 'InProgress',
+          startedAt: '2026-07-04T22:00:00Z',
+        }),
+        session({
+          sessionId: S1,
+          gameId: G1,
+          gameTitle: 'Earlier',
+          playOrder: 2,
+          status: 'InProgress',
+          startedAt: '2026-07-04T22:10:00Z',
+        }),
+      ],
+    });
+    expect(mapNightLiveToViewModel(dto, NOW).currentGame?.sessionId).toBe(S1);
+  });
+});
+
 describe('mapNightLiveToViewModel — time (LD-7)', () => {
   it("elapsed is 'Hh Mm' from the earliest StartedAt to now", () => {
     expect(mapNightLiveToViewModel(HAPPY, NOW).elapsed).toBe('2h 35m');
@@ -274,9 +328,8 @@ describe('mapNightLiveToViewModel — empty night (LD-11) + Slice-C seam (LD-3)'
     expect(vm.night.title).toBe('Serata Eldoria');
   });
 
-  it('emits the Slice-C props as their true empty contract', () => {
+  it('emits the diary arrays as their true empty contract (Slice C2/C4)', () => {
     const vm = mapNightLiveToViewModel(HAPPY, NOW);
-    expect(vm.currentGame).toBeNull();
     expect(vm.diaryEvents).toEqual([]);
     expect(vm.diaryGames).toEqual([]);
     expect(vm.diaryPlayers).toEqual([]);

--- a/apps/web/src/lib/game-nights/mapNightLive.ts
+++ b/apps/web/src/lib/game-nights/mapNightLive.ts
@@ -161,6 +161,19 @@ export function mapNightLiveToViewModel(dto: GameNightLiveDto, now: Date): Night
   // LD-8: 'live' iff a session is running; no 'paused' signal from the BE.
   const status: NightLiveStatus = inProgress.length > 0 ? 'live' : 'transition';
 
+  // Slice C1: currentGame is the InProgress session (lowest PlayOrder if racy).
+  // `inProgress` preserves the play-order sort, so [0] is the lowest. emoji/score
+  // stay undefined (fixture-only, D-SCORE/TIME); the diary is Slice C2/C4.
+  const currentSession = inProgress[0];
+  const currentGame: NightLiveHubCurrentGame | null = currentSession
+    ? {
+        id: currentSession.gameId,
+        sessionId: currentSession.sessionId,
+        title: toTitle(currentSession),
+        cover: coverFromGameId(currentSession.gameId),
+      }
+    : null;
+
   return {
     night: { title: dto.title }, // LD-15: shortTitle/nightCode undefined in Slice B
     nightStatus: dto.status, // LD-14: raw lifecycle status for terminal routing
@@ -171,8 +184,8 @@ export function mapNightLiveToViewModel(dto: GameNightLiveDto, now: Date): Night
     confirmedPlayers: undefined, // LD-8: no RSVP fetch in Slice B
     totalPlayers: undefined,
     plannedGames,
-    currentGame: null, // LD-3: Slice C
-    diaryEvents: [],
+    currentGame, // Slice C1
+    diaryEvents: [], // LD-3: Slice C2/C4
     diaryGames: [],
     diaryPlayers: [],
   };


### PR DESCRIPTION
## Cosa

**Slice C1** del wire-up night-live (#2633, epic #2619). Riempie il branch `NightLiveViewModel.currentGame` (era `null` da Slice B): la sessione InProgress → `NightLiveHubCurrentGame`.

## Come

- `mapNightLiveToViewModel` deriva `currentGame` dalla sessione InProgress (PlayOrder più basso se racy): `{ id: gameId, sessionId, title, cover: hashToHue(gameId) }`. `emoji`/`score` restano `undefined` (fixture-only, D-SCORE/TIME).
- Nessuna sessione InProgress → `null` (la `CurrentGameCard` renderizza già lo stato vuoto "Nessun gioco corrente").
- **Cambio solo-mapper**: la view inoltra già `currentGame={vm.currentGame}` a `NightLiveHub`. Le diary array restano `[]` (Slice C2/C4).

## Test

4 nuovi test mapper (derivazione, null quando no-InProgress, lowest-playOrder racy, emoji/score undefined). 270 test area game-nights verdi · typecheck + lint puliti.

## Nota di scoping

Durante C1 ho mappato che C2/C3/C4 (winner + diary) leggono dati da flussi write oggi read-only (Slice B ha nascosto i drive-control) → prossimo step deciso col maintainer: **riabilitare il write-side (live interattivo)**, che accende i read-model. C1 è indipendente e shippabile subito.

Refs #2633 #2619

🤖 Generated with [Claude Code](https://claude.com/claude-code)