### PR TITLE
test(e2e): #2650 smoke login form timeout 8s->30s

### DIFF
--- a/apps/web/e2e/smoke.spec.ts
+++ b/apps/web/e2e/smoke.spec.ts
@@ -40,8 +40,16 @@ test.describe('Smoke Test — 8 step pre-deploy', () => {
 
   test('2. Auth login form visibile', async ({ page }) => {
     await page.goto('/login', { waitUntil: 'domcontentloaded' });
+    // Il login form è client-only: nell'SSR /login rende il fallback <Suspense>
+    // (useSearchParams), quindi l'input email esiste SOLO dopo l'hydration del
+    // bundle client. Sul runner self-hosted (chromium headless, VPS con cap
+    // memoria 3G) l'hydration supera consistentemente gli 8s → falso negativo
+    // (il form è renderizzato e funzionante, verificato in un browser reale).
+    // Timeout ampio (30s) per assorbire l'hydration lenta senza rallentare il
+    // caso normale (l'expect passa appena l'elemento appare). NON mockare
+    // /auth/me qui: simulerebbe un utente loggato → redirect via da /login.
     await expect(page.locator('input[type="email"], input[name="email"]').first()).toBeVisible({
-      timeout: 8000,
+      timeout: 30000,
     });
   });
 


### PR DESCRIPTION
Follow-up dell'investigazione del deploy staging #2650. Lo smoke test `2. Auth login form visibile` falliva deterministicamente (anche su re-run) sul deploy staging da main-staging.

**Root cause** (investigata via browser reale + confronto con gli altri 7 test): NON e' una regressione del login — il form renderizza e funziona (verificato caricando /login in un browser reale: email/password/Accedi/OAuth tutti presenti). Il form e' **client-only** (nell'SSR /login rende il fallback `<Suspense>` per via di `useSearchParams`), quindi l'input email esiste **solo dopo l'hydration**. Sul runner self-hosted (chromium headless, VPS con cap memoria 3G) l'hydration supera consistentemente gli **8s** del timeout → falso negativo.

Gli altri test passano perche' verificano contenuto **SSR** (test 1 homepage heading) o solo `body` visibile con **mock auth** (test 3-8). Il test 2 e' l'unico che verifica un elemento client-only reale senza mock.

**Fix**: timeout 8s → 30s. Non rallenta il caso normale (l'expect passa appena l'elemento appare). Non si mocka `/auth/me`: simulerebbe un utente loggato → redirect via da /login.

Si valida al prossimo deploy staging (dove il test gira sul VPS headless).

🤖 Generated with [Claude Code](https://claude.com/claude-code)