### PR TITLE
chore(security): #2662 Scriban.Signed 7.0.6->7.2.0 (GHSA-24c8-4792-22hx)

### DIFF
--- a/apps/api/tests/Api.Tests/Api.Tests.csproj
+++ b/apps/api/tests/Api.Tests/Api.Tests.csproj
@@ -52,6 +52,12 @@
     <PackageReference Include="Serilog.Sinks.TestCorrelator" Version="4.0.0" />
     <PackageReference Include="Testcontainers.PostgreSql" Version="4.9.0" />
     <PackageReference Include="Testcontainers.Redis" Version="4.9.0" />
+    <!-- Issue #2662 / GHSA-24c8-4792-22hx (HIGH): WireMock.Net tira transitive
+         Scriban.Signed 7.0.6 (array.insert_at unbounded fill loop → OOM/DoS,
+         vulnerabile <=7.1.0). Override alla versione patchata 7.2.0 per far
+         passare il check CI "Dependency Vulnerabilities" (fail su HIGH/CRITICAL).
+         Solo test project — Scriban non è nel path di produzione (Api pulito). -->
+    <PackageReference Include="Scriban.Signed" Version="7.2.0" />
     <PackageReference Include="WireMock.Net" Version="2.5.0" />
     <PackageReference Include="xunit.abstractions" Version="2.0.3" />
     <PackageReference Include="xunit.v3" Version="3.2.1" />


### PR DESCRIPTION
Closes #2662.

Il check CI `Dependency Vulnerabilities` (`dotnet list package --vulnerable --include-transitive` in security-scan.yml) falliva su **Scriban.Signed 7.0.6** (HIGH, GHSA-24c8-4792-22hx), tirato **transitive da WireMock.Net** in `Api.Tests`. Il progetto di produzione `Api` era già pulito.

**Vuln**: `array.insert_at` unbounded fill loop → OOM/DoS (vulnerabile `<=7.1.0`, patched **7.2.0**).

**Fix**: override diretto `<PackageReference Include="Scriban.Signed" Version="7.2.0" />` in `Api.Tests.csproj` (pattern già usato nel repo per vuln transitive).

**Verifica** (eseguita localmente):
- `dotnet restore` OK → 7.2.0 compatibile con WireMock.Net 2.5.0
- `dotnet list package --vulnerable --include-transitive` → *"il progetto Api.Tests non contiene pacchetti vulnerabili"*

🤖 Generated with [Claude Code](https://claude.com/claude-code)