### PR TITLE
fix(document-processing): #2661 reload pdfDoc dopo ProcessAsync (pageCount stale)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Jobs/PdfProcessingQuartzJob.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Jobs/PdfProcessingQuartzJob.cs
@@ -183,6 +183,16 @@ public sealed class PdfProcessingQuartzJob : IJob
             // CancelJobCommand changes status to Cancelled in DB without stopping the worker,
             // so we must not overwrite it with Completed.
             await _dbContext.Entry(jobEntity).ReloadAsync(ct).ConfigureAwait(false);
+
+            // Issue #2661: also reload pdfDoc. The pipeline's ExtractTextAsync sets
+            // PdfDocument.PageCount + SaveChangesAsync on its own scoped DbContext instance,
+            // so the copy tracked by this job stays stale (PageCount == null). Without this
+            // reload, RecordStepMetricsSafeAsync below would pass "PageCount ?? 0" == 0, which
+            // trips the "Page count must be positive" guard in ProcessingMetricsService and
+            // silently drops the metric. pdfDoc is tracked (loaded via AsTracking), so
+            // ReloadAsync refreshes it from the value the pipeline persisted.
+            await _dbContext.Entry(pdfDoc).ReloadAsync(ct).ConfigureAwait(false);
+
             if (string.Equals(jobEntity.Status, nameof(JobStatus.Cancelled), StringComparison.Ordinal))
             {
                 _logger.LogInformation(

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Jobs/PdfProcessingQuartzJobTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Jobs/PdfProcessingQuartzJobTests.cs
@@ -1,0 +1,141 @@
+using Api.BoundedContexts.DocumentProcessing.Application.Jobs;
+using Api.BoundedContexts.DocumentProcessing.Application.Services;
+using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
+using Api.BoundedContexts.DocumentProcessing.Infrastructure.Services;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Infrastructure.Entities.DocumentProcessing;
+using Api.Tests.TestHelpers;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Quartz;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.DocumentProcessing.Application.Jobs;
+
+/// <summary>
+/// Regression tests for Issue #2661.
+///
+/// The pipeline (<see cref="IPdfProcessingPipelineService"/>) populates
+/// <c>PdfDocument.PageCount</c> and calls SaveChangesAsync on its own scoped
+/// DbContext instance. The job holds a separately-tracked copy of the same
+/// PdfDocument, so that copy stays stale (PageCount == null) unless it is reloaded.
+/// Before the fix, the job passed <c>PageCount ?? 0</c> == 0 into
+/// <see cref="IProcessingMetricsService.RecordStepDurationAsync"/>, tripping its
+/// "Page count must be positive" guard and silently dropping every step metric.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "DocumentProcessing")]
+public sealed class PdfProcessingQuartzJobTests
+{
+    private const int PersistedPageCount = 42;
+
+    private static readonly string[] StepNames =
+        { "Upload", "Extract", "Chunk", "Embed", "Index" };
+
+    [Fact]
+    public async Task Execute_ReloadsPdfDocAfterPipeline_PassesPersistedPageCountToMetrics()
+    {
+        // Arrange — two DbContexts over ONE shared in-memory store (same database name).
+        // jobContext is what the job holds; pipelineContext simulates the pipeline's own
+        // scoped context that persists PageCount out-of-band.
+        var dbName = $"issue-2661-{Guid.NewGuid()}";
+        using var jobContext = TestDbContextFactory.CreateInMemoryDbContext(dbName);
+        using var pipelineContext = TestDbContextFactory.CreateInMemoryDbContext(dbName);
+
+        var pdfId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var jobId = Guid.NewGuid();
+
+        // PDF seeded with PageCount == null: the exact stale/unpopulated state the job
+        // observes before the pipeline runs.
+        jobContext.PdfDocuments.Add(new PdfDocumentEntity
+        {
+            Id = pdfId,
+            FileName = "rules.pdf",
+            FilePath = "/tmp/rules.pdf",
+            FileSizeBytes = 2048,
+            UploadedByUserId = userId,
+            ProcessingState = "Pending",
+            PageCount = null,
+        });
+        jobContext.ProcessingJobs.Add(new ProcessingJobEntity
+        {
+            Id = jobId,
+            PdfDocumentId = pdfId,
+            UserId = userId,
+            Status = nameof(JobStatus.Queued),
+            Priority = 0,
+            CreatedAt = DateTimeOffset.UtcNow,
+        });
+        foreach (var stepName in StepNames)
+        {
+            jobContext.ProcessingSteps.Add(new ProcessingStepEntity
+            {
+                Id = Guid.NewGuid(),
+                ProcessingJobId = jobId,
+                StepName = stepName,
+                Status = nameof(StepStatus.Pending),
+            });
+        }
+        await jobContext.SaveChangesAsync();
+
+        // Pipeline mock: simulate ExtractTextAsync writing PageCount via its OWN context,
+        // committing to the shared store. This is what leaves the job's tracked copy stale.
+        var pipeline = new Mock<IPdfProcessingPipelineService>();
+        pipeline
+            .Setup(p => p.ProcessAsync(pdfId, It.IsAny<string>(), userId, It.IsAny<CancellationToken>()))
+            .Returns(async (Guid id, string _, Guid _, CancellationToken innerCt) =>
+            {
+                var doc = await pipelineContext.PdfDocuments.AsTracking()
+                    .FirstAsync(d => d.Id == id, innerCt);
+                doc.PageCount = PersistedPageCount;
+                await pipelineContext.SaveChangesAsync(innerCt);
+            });
+
+        var metrics = new Mock<IProcessingMetricsService>();
+        var stream = new Mock<IQueueStreamService>();
+
+        var services = new ServiceCollection();
+        services.AddSingleton(pipeline.Object);
+        services.AddSingleton(metrics.Object);
+        services.AddSingleton(stream.Object);
+        using var serviceProvider = services.BuildServiceProvider();
+
+        var job = new PdfProcessingQuartzJob(
+            jobContext,
+            serviceProvider,
+            NullLogger<PdfProcessingQuartzJob>.Instance,
+            TimeProvider.System);
+
+        var executionContext = new Mock<IJobExecutionContext>();
+        executionContext.SetupGet(c => c.CancellationToken).Returns(CancellationToken.None);
+
+        // Act
+        await job.Execute(executionContext.Object);
+
+        // Assert — after the reload, every step metric receives the value the pipeline
+        // persisted (42), never the stale 0 that would trip the guard.
+        metrics.Verify(m => m.RecordStepDurationAsync(
+                pdfId,
+                It.IsAny<PdfProcessingState>(),
+                It.IsAny<TimeSpan>(),
+                It.IsAny<long>(),
+                PersistedPageCount,
+                It.IsAny<Guid?>(),
+                It.IsAny<CancellationToken>()),
+            Times.Exactly(StepNames.Length));
+
+        metrics.Verify(m => m.RecordStepDurationAsync(
+                It.IsAny<Guid>(),
+                It.IsAny<PdfProcessingState>(),
+                It.IsAny<TimeSpan>(),
+                It.IsAny<long>(),
+                0,
+                It.IsAny<Guid?>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Infrastructure/Services/ProcessingMetricsServiceTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Infrastructure/Services/ProcessingMetricsServiceTests.cs
@@ -77,6 +77,54 @@ public sealed class ProcessingMetricsServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task RecordStepDurationAsync_ZeroPageCount_ThrowsArgumentException()
+    {
+        // Regression for Issue #2661: a stale/unpopulated PageCount reaches this service
+        // as 0 (PdfProcessingQuartzJob passes "PageCount ?? 0"). The guard must reject it so
+        // the caller never persists a metric with an invalid page count.
+        // Arrange
+        var pdfId = Guid.NewGuid();
+
+        // Act
+        var act = async () => await _service.RecordStepDurationAsync(
+            pdfId,
+            PdfProcessingState.Extracting,
+            TimeSpan.FromSeconds(10),
+            1024000,
+            pageCount: 0);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage("*Page count must be positive*")
+            .Where(ex => ex.ParamName == "pageCount");
+
+        // And nothing was persisted
+        var metric = await _context.ProcessingMetrics
+            .FirstOrDefaultAsync(m => m.PdfDocumentId == pdfId);
+        metric.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task RecordStepDurationAsync_NegativePageCount_ThrowsArgumentException()
+    {
+        // Arrange
+        var pdfId = Guid.NewGuid();
+
+        // Act
+        var act = async () => await _service.RecordStepDurationAsync(
+            pdfId,
+            PdfProcessingState.Extracting,
+            TimeSpan.FromSeconds(10),
+            1024000,
+            pageCount: -1);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage("*Page count must be positive*")
+            .Where(ex => ex.ParamName == "pageCount");
+    }
+
+    [Fact]
     public async Task GetAverageDurationAsync_NoData_ReturnsZeroStatistics()
     {
         // Arrange


### PR DESCRIPTION
Closes #2661

## Root cause
`PdfProcessingQuartzJob.ExecutePipelineAsync` (`apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Jobs/PdfProcessingQuartzJob.cs`) runs the PDF pipeline and, afterwards, reloads **only** `jobEntity` (to detect external cancellation):

```csharp
await pipelineService.ProcessAsync(pdfDoc.Id, pdfDoc.FilePath, jobEntity.UserId, ct);
await _dbContext.Entry(jobEntity).ReloadAsync(ct); // jobEntity only
```

The pipeline's `ExtractTextAsync` sets `PdfDocument.PageCount` and calls `SaveChangesAsync` on its **own scoped `DbContext` instance** (`PdfProcessingPipelineService.cs:485-489`). The DB row is updated, but the job's separately-tracked `pdfDoc` stays stale (`PageCount == null`).

Downstream, per step:

```csharp
await RecordStepMetricsSafeAsync(
    pdfDoc.Id, stepName, ..., pdfDoc.FileSizeBytes, pdfDoc.PageCount ?? 0, ct);
```

`pdfDoc.PageCount ?? 0` becomes `0`, which trips the guard in `ProcessingMetricsService.RecordStepDurationAsync`:

```csharp
if (pageCount <= 0)
    throw new ArgumentException("Page count must be positive", nameof(pageCount));
```

`RecordStepMetricsSafeAsync` catches this as a warning, so the pipeline does not break — but **every step metric is silently dropped** (observed on 107 PDFs on staging), losing the historical data used for ETA calculation.

## Fix (Option A)
Reload `pdfDoc` alongside `jobEntity` so `PageCount` reflects the value the pipeline persisted. `pdfDoc` is tracked (loaded via `.AsTracking()`), so `ReloadAsync` is valid.

```csharp
await _dbContext.Entry(jobEntity).ReloadAsync(ct);
await _dbContext.Entry(pdfDoc).ReloadAsync(ct); // Issue #2661
```

The `?? 1` fallback was intentionally **not** used — it would mask the real page count and still record wrong metrics.

## Tests
- `ProcessingMetricsServiceTests`: added guard cases `pageCount == 0` and `pageCount == -1` (both must throw `ArgumentException("Page count must be positive")`, param `pageCount`, and persist nothing).
- `PdfProcessingQuartzJobTests` (new): reproduces the stale-copy scenario with **two `DbContext` instances over one in-memory store** — the mock pipeline writes `PageCount` on its own context, mirroring production. Asserts the metrics service receives the persisted page count (42) for all 5 steps and **never** 0. Confirmed the test **fails without the fix** (metrics get 0) and passes with it.

## Verification (real output)
- `cd apps/api/src/Api && dotnet build` → `Compilazione completata. Avvisi: 0 Errori: 0`
- `dotnet test tests/Api.Tests --filter "FullyQualifiedName~ProcessingMetricsServiceTests|FullyQualifiedName~PdfProcessingQuartzJobTests"` → `Superato! - Non superati: 0. Superati: 9. Ignorati: 1. Totale: 10` (the 1 skip is the pre-existing `CleanupOldMetricsAsync` InMemory-unsupported test).
- Regression proof: with the reload removed, `PdfProcessingQuartzJobTests` → `Non superati: 1`.
- Pre-commit + pre-push hooks (frontend typecheck + build, backend build) passed.

No unrelated files touched. Unit tests require no Docker (EF InMemory only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)