### PR TITLE
fix(seeding): #2666 PdfSeeder repair mode — re-upload missing blobs from seed bucket

### DIFF
--- a/apps/api/src/Api/Infrastructure/Seeders/Catalog/PdfSeeder.cs
+++ b/apps/api/src/Api/Infrastructure/Seeders/Catalog/PdfSeeder.cs
@@ -92,6 +92,7 @@ internal static class PdfSeeder
 
         var seeded = 0;
         var skipped = 0;
+        var repaired = 0;
 
         foreach (var entry in pdfEntries)
         {
@@ -128,14 +129,43 @@ internal static class PdfSeeder
                 // Idempotency: check if SharedGameId + FileName pair already exists
                 if (existingMap.TryGetValue(idempotencyKey, out var existing))
                 {
-                    // Hash match → skip (no changes)
+                    // Hash match → the DB record is up to date, so normally we skip. BUT
+                    // repair mode (#2666): a DB-only snapshot restore re-creates the record
+                    // while the actual blob stays absent from the runtime bucket, leaving the
+                    // PDF stuck in Failed with "PDF file not found in blob storage". Verify the
+                    // blob is really present before skipping; if it's gone, re-upload it from the
+                    // seed bucket against the EXISTING id and reset the record to Pending so the
+                    // pipeline reprocesses it. Idempotent: once repaired the blob is present and
+                    // the next run skips normally.
                     if (!string.IsNullOrEmpty(manifestHash) &&
                         string.Equals(existing.ContentHash, manifestHash, StringComparison.OrdinalIgnoreCase))
                     {
-                        logger.LogDebug(
-                            "PdfSeeder: PDF '{FileName}' for game '{Title}' has matching hash. Skipping.",
-                            fileName, entry.Title);
-                        skipped++;
+                        // fileId is embedded in the stored FilePath (pdfs/{resourceKey}/{fileId}_{name});
+                        // extract it so ExistsAsync can locate the blob for the EXISTING record.
+                        var existingFileId = ExtractFileIdFromPath(existing.FilePath);
+                        var blobPresent = !string.IsNullOrEmpty(existingFileId)
+                            && await primaryBlob.ExistsAsync(existingFileId, BlobCategory.Pdf, PdfStorageKey.ForPdf(existing.Id), ct).ConfigureAwait(false);
+
+                        if (blobPresent)
+                        {
+                            logger.LogDebug(
+                                "PdfSeeder: PDF '{FileName}' for game '{Title}' has matching hash and blob present. Skipping.",
+                                fileName, entry.Title);
+                            skipped++;
+                            continue;
+                        }
+
+                        // Blob missing from the runtime bucket → attempt repair from the seed bucket.
+                        if (await TryRepairMissingBlobAsync(
+                                db, primaryBlob, seedBlob, existing.Id, blobKey, fileName,
+                                entry, systemUserId, logger, ct).ConfigureAwait(false))
+                        {
+                            repaired++;
+                        }
+                        else
+                        {
+                            skipped++;
+                        }
                         continue;
                     }
 
@@ -256,8 +286,111 @@ internal static class PdfSeeder
         }
 
         logger.LogInformation(
-            "PdfSeeder completed: {Seeded} queued for RAG processing, {Skipped} skipped",
-            seeded, skipped);
+            "PdfSeeder completed: {Seeded} queued for RAG processing, {Repaired} repaired (missing blob re-uploaded), {Skipped} skipped",
+            seeded, repaired, skipped);
+    }
+
+    /// <summary>
+    /// Repair mode (#2666): re-uploads a PDF blob that is missing from the runtime bucket
+    /// (typically after a DB-only snapshot restore) using the EXISTING pdf id, then resets
+    /// the record to <see cref="PdfProcessingState.Pending"/> and re-enqueues a ProcessingJob
+    /// so the RAG pipeline reprocesses it (extract → chunk → embed → index → Ready).
+    ///
+    /// Uses <paramref name="existingId"/> for BOTH the storage bucket key and the DB record so
+    /// the persisted FilePath (pdfs/{existingId}/...) keeps matching what the database already
+    /// references — minting a fresh Guid would orphan the blob from the record.
+    ///
+    /// Returns true when the record was repaired; false when it could not be repaired (blob is
+    /// missing in the seed bucket too, the re-upload failed, or the record vanished mid-run).
+    /// Never throws for the recoverable cases: irrecoverable blobs are logged and left untouched.
+    /// </summary>
+    private static async Task<bool> TryRepairMissingBlobAsync(
+        MeepleAiDbContext db,
+        IBlobStorageService primaryBlob,
+        ISeedBlobReader seedBlob,
+        Guid existingId,
+        string blobKey,
+        string fileName,
+        SeedManifestGame entry,
+        Guid systemUserId,
+        ILogger logger,
+        CancellationToken ct)
+    {
+        // The blob is gone from the runtime bucket — it can only be repaired if the source
+        // still exists in the seed bucket. If neither has it, the PDF is irrecoverable here.
+        if (!await seedBlob.ExistsAsync(blobKey, ct).ConfigureAwait(false))
+        {
+            logger.LogWarning(
+                "PdfSeeder: PDF '{FileName}' (pdfId {Id}, game '{Title}') blob missing in both runtime and seed bucket, cannot repair. Leaving record untouched.",
+                fileName, existingId, entry.Title);
+            return false;
+        }
+
+        // Re-upload against the EXISTING id (NOT a new Guid) so pdfs/{existingId}/ stays
+        // consistent with the FilePath the DB record already points at.
+        var stream = await seedBlob.OpenReadAsync(blobKey, ct).ConfigureAwait(false);
+        await using var _ = stream.ConfigureAwait(false);
+        var result = await primaryBlob.StoreAsync(stream, fileName, BlobCategory.Pdf, PdfStorageKey.ForPdf(existingId), ct).ConfigureAwait(false);
+
+        if (!result.Success)
+        {
+            logger.LogWarning(
+                "PdfSeeder: repair failed to re-upload blob for '{FileName}' (pdfId {Id}, game '{Title}'): {Error}",
+                fileName, existingId, entry.Title, result.ErrorMessage);
+            return false;
+        }
+
+        // Load the existing record tracked and reset it to Pending, clearing every error field
+        // left over from the previous Failed run so the pipeline reprocesses it cleanly.
+        var pdfEntity = await db.PdfDocuments
+            .FirstOrDefaultAsync(p => p.Id == existingId, ct)
+            .ConfigureAwait(false);
+        if (pdfEntity is null)
+        {
+            logger.LogWarning(
+                "PdfSeeder: repair could not load PdfDocument {Id} ('{FileName}') for update. Skipping.",
+                existingId, fileName);
+            return false;
+        }
+
+        pdfEntity.ProcessingState = nameof(PdfProcessingState.Pending);
+        pdfEntity.FilePath = result.FilePath ?? string.Empty;
+        pdfEntity.FileSizeBytes = result.FileSizeBytes;
+        pdfEntity.ProcessingError = null;
+        pdfEntity.ErrorCategory = null;
+        pdfEntity.FailedAtState = null;
+        pdfEntity.RetryCount = 0;
+        await db.SaveChangesAsync(ct).ConfigureAwait(false);
+
+        // Re-enqueue a ProcessingJob with the five standard pipeline steps (identical to the
+        // new-record flow) so PdfProcessingQuartzJob picks the repaired PDF up again.
+        var now = DateTimeOffset.UtcNow;
+        var jobEntity = new ProcessingJobEntity
+        {
+            Id = Guid.NewGuid(),
+            PdfDocumentId = existingId,
+            UserId = systemUserId,
+            Status = nameof(JobStatus.Queued),
+            Priority = 0,
+            CreatedAt = now,
+            MaxRetries = 3,
+            RetryCount = 0,
+        };
+        jobEntity.Steps = new List<ProcessingStepEntity>
+        {
+            new() { Id = Guid.NewGuid(), ProcessingJobId = jobEntity.Id, StepName = nameof(ProcessingStepType.Upload),  Status = "Pending" },
+            new() { Id = Guid.NewGuid(), ProcessingJobId = jobEntity.Id, StepName = nameof(ProcessingStepType.Extract), Status = "Pending" },
+            new() { Id = Guid.NewGuid(), ProcessingJobId = jobEntity.Id, StepName = nameof(ProcessingStepType.Chunk),   Status = "Pending" },
+            new() { Id = Guid.NewGuid(), ProcessingJobId = jobEntity.Id, StepName = nameof(ProcessingStepType.Embed),   Status = "Pending" },
+            new() { Id = Guid.NewGuid(), ProcessingJobId = jobEntity.Id, StepName = nameof(ProcessingStepType.Index),   Status = "Pending" },
+        };
+        db.Set<ProcessingJobEntity>().Add(jobEntity);
+        await db.SaveChangesAsync(ct).ConfigureAwait(false);
+
+        logger.LogInformation(
+            "PdfSeeder: repaired: re-uploaded missing blob for '{FileName}' (pdfId {Id}, JobId={JobId}, {Size} bytes) and reset to Pending",
+            fileName, existingId, jobEntity.Id, result.FileSizeBytes);
+        return true;
     }
 
     /// <summary>

--- a/apps/api/tests/Api.Tests/Infrastructure/Seeders/Catalog/PdfSeederBlobTests.cs
+++ b/apps/api/tests/Api.Tests/Infrastructure/Seeders/Catalog/PdfSeederBlobTests.cs
@@ -1,3 +1,4 @@
+using Api.BoundedContexts.DocumentProcessing.Application.Services;
 using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
 using Api.Infrastructure;
 using Api.Infrastructure.Entities;
@@ -296,6 +297,212 @@ public sealed class PdfSeederBlobTests
         _seedBlob.Verify(x => x.OpenReadAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
         _primaryBlob.Verify(x => x.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
         db.PdfDocuments.Should().BeEmpty();
+    }
+
+    // ===============================================================
+    // Repair mode (#2666): DB-only snapshot restore leaves the record
+    // intact but the blob missing from the runtime bucket. The seeder
+    // must verify blob presence before the idempotency skip and re-upload
+    // from the seed bucket using the EXISTING id when the blob is gone.
+    // ===============================================================
+
+    // ---------------------------------------------------------------
+    // Repair (a): record exists + blob PRESENT in runtime → plain skip
+    // ---------------------------------------------------------------
+    [Fact]
+    public async Task SeedAsync_ExistingHash_BlobPresentInRuntime_SkipsWithoutReupload()
+    {
+        // Arrange
+        var gameId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var existingId = Guid.NewGuid();
+        _seedBlob.Setup(x => x.IsConfigured).Returns(true);
+
+        // Runtime blob is present → seeder must NOT re-upload nor mutate the record.
+        _primaryBlob.Setup(x => x.ExistsAsync(It.IsAny<string>(), BlobCategory.Pdf, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var manifest = CreateManifest(CreateBlobEntry(pdfSha256: "samehash"));
+        var gameMap = new Dictionary<int, Guid> { { 174430, gameId } };
+        using var db = TestDbContextFactory.CreateInMemoryDbContext();
+
+        db.Users.Add(new UserEntity { Id = userId, Email = "system@test.com", PasswordHash = "hash" });
+        db.SharedGames.Add(new SharedGameEntity { Id = gameId, Title = "Gloomhaven" });
+        db.PdfDocuments.Add(new PdfDocumentEntity
+        {
+            Id = existingId,
+            SharedGameId = gameId,
+            FileName = "gloomhaven.pdf",
+            // FilePath carries the fileId (deadbeef) so ExtractFileIdFromPath can build the ExistsAsync probe.
+            FilePath = $"pdfs/{PdfStorageKey.ForPdf(existingId)}/deadbeef_gloomhaven.pdf",
+            ContentHash = "samehash",
+            ProcessingState = nameof(PdfProcessingState.Ready),
+            UploadedByUserId = userId,
+            DocumentType = "base",
+            DocumentCategory = "Rulebook",
+        });
+        await db.SaveChangesAsync();
+
+        // Act
+        await PdfSeeder.SeedAsync(db, manifest, gameMap, userId,
+            _primaryBlob.Object, _seedBlob.Object, _logger.Object, CancellationToken.None);
+
+        // Assert — presence check happened, but no re-upload and no state change.
+        _primaryBlob.Verify(x => x.ExistsAsync(It.IsAny<string>(), BlobCategory.Pdf, It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
+        _seedBlob.Verify(x => x.OpenReadAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        _primaryBlob.Verify(x => x.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+
+        var doc = db.PdfDocuments.Single(p => p.Id == existingId);
+        doc.ProcessingState.Should().Be(nameof(PdfProcessingState.Ready));
+        db.ProcessingJobs.Should().BeEmpty();
+    }
+
+    // ---------------------------------------------------------------
+    // Repair (b): record exists + blob ABSENT in runtime + present in
+    //             seed → repair: re-upload against existing id, reset to
+    //             Pending, clear error fields, re-enqueue ProcessingJob.
+    // ---------------------------------------------------------------
+    [Fact]
+    public async Task SeedAsync_ExistingHash_BlobMissingInRuntimeButInSeed_RepairsInPlace()
+    {
+        // Arrange
+        var gameId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var existingId = Guid.NewGuid();
+        _seedBlob.Setup(x => x.IsConfigured).Returns(true);
+
+        // Runtime blob is GONE (snapshot DB-only restore), but the seed bucket still has it.
+        _primaryBlob.Setup(x => x.ExistsAsync(It.IsAny<string>(), BlobCategory.Pdf, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        _seedBlob.Setup(x => x.ExistsAsync("rulebooks/v1/gloomhaven.pdf", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        _seedBlob.Setup(x => x.OpenReadAsync("rulebooks/v1/gloomhaven.pdf", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new MemoryStream(new byte[] { 0x25, 0x50, 0x44, 0x46 }));
+
+        string? capturedResourceKey = null;
+        _primaryBlob.Setup(x => x.StoreAsync(It.IsAny<Stream>(), "gloomhaven.pdf", BlobCategory.Pdf, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Callback<Stream, string, BlobCategory, string, CancellationToken>((_, _, _, rk, _) => capturedResourceKey = rk)
+            .ReturnsAsync(new BlobStorageResult(true, "newfile", "pdfs/repaired/newfile_gloomhaven.pdf", 4));
+
+        var manifest = CreateManifest(CreateBlobEntry(pdfSha256: "samehash"));
+        var gameMap = new Dictionary<int, Guid> { { 174430, gameId } };
+        using var db = TestDbContextFactory.CreateInMemoryDbContext();
+
+        db.Users.Add(new UserEntity { Id = userId, Email = "system@test.com", PasswordHash = "hash" });
+        db.SharedGames.Add(new SharedGameEntity { Id = gameId, Title = "Gloomhaven" });
+        db.PdfDocuments.Add(new PdfDocumentEntity
+        {
+            Id = existingId,
+            SharedGameId = gameId,
+            FileName = "gloomhaven.pdf",
+            FilePath = $"pdfs/{PdfStorageKey.ForPdf(existingId)}/deadbeef_gloomhaven.pdf",
+            FileSizeBytes = 999,
+            ContentHash = "samehash",
+            // The exact broken state observed on staging.
+            ProcessingState = nameof(PdfProcessingState.Failed),
+            ProcessingError = "PDF file not found in blob storage",
+            ErrorCategory = "Service",
+            FailedAtState = "Extracting",
+            RetryCount = 2,
+            UploadedByUserId = userId,
+            DocumentType = "base",
+            DocumentCategory = "Rulebook",
+        });
+        await db.SaveChangesAsync();
+
+        // Act
+        await PdfSeeder.SeedAsync(db, manifest, gameMap, userId,
+            _primaryBlob.Object, _seedBlob.Object, _logger.Object, CancellationToken.None);
+
+        // Assert — re-uploaded against the EXISTING id's bucket key (NOT a new Guid).
+        _primaryBlob.Verify(x => x.StoreAsync(It.IsAny<Stream>(), "gloomhaven.pdf", BlobCategory.Pdf, It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
+        capturedResourceKey.Should().Be(PdfStorageKey.ForPdf(existingId));
+
+        // Record is repaired in place: same id, reset to Pending, error fields cleared, new blob path/size.
+        var docs = db.PdfDocuments.ToList();
+        docs.Should().HaveCount(1);
+        var doc = docs[0];
+        doc.Id.Should().Be(existingId);
+        doc.ProcessingState.Should().Be(nameof(PdfProcessingState.Pending));
+        doc.FilePath.Should().Be("pdfs/repaired/newfile_gloomhaven.pdf");
+        doc.FileSizeBytes.Should().Be(4);
+        doc.ProcessingError.Should().BeNull();
+        doc.ErrorCategory.Should().BeNull();
+        doc.FailedAtState.Should().BeNull();
+        doc.RetryCount.Should().Be(0);
+
+        // A fresh ProcessingJob is enqueued for the repaired PDF (5 Queued steps).
+        var jobs = db.ProcessingJobs.Include(j => j.Steps).ToList();
+        jobs.Should().HaveCount(1);
+        var job = jobs[0];
+        job.PdfDocumentId.Should().Be(existingId);
+        job.UserId.Should().Be(userId);
+        job.Status.Should().Be(nameof(JobStatus.Queued));
+        job.Steps.Should().HaveCount(5);
+        job.Steps.Select(s => s.StepName).Should().BeEquivalentTo(new[]
+        {
+            nameof(ProcessingStepType.Upload),
+            nameof(ProcessingStepType.Extract),
+            nameof(ProcessingStepType.Chunk),
+            nameof(ProcessingStepType.Embed),
+            nameof(ProcessingStepType.Index),
+        });
+        job.Steps.Should().OnlyContain(s => s.Status == "Pending");
+    }
+
+    // ---------------------------------------------------------------
+    // Repair (c): record exists + blob ABSENT in BOTH runtime and seed
+    //             → log warning, no crash, no re-upload, no state change.
+    // ---------------------------------------------------------------
+    [Fact]
+    public async Task SeedAsync_ExistingHash_BlobMissingInRuntimeAndSeed_LeavesRecordUntouched()
+    {
+        // Arrange
+        var gameId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var existingId = Guid.NewGuid();
+        _seedBlob.Setup(x => x.IsConfigured).Returns(true);
+
+        // Blob gone from BOTH buckets → irrecoverable, must not crash and must not mutate.
+        _primaryBlob.Setup(x => x.ExistsAsync(It.IsAny<string>(), BlobCategory.Pdf, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        _seedBlob.Setup(x => x.ExistsAsync("rulebooks/v1/gloomhaven.pdf", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var manifest = CreateManifest(CreateBlobEntry(pdfSha256: "samehash"));
+        var gameMap = new Dictionary<int, Guid> { { 174430, gameId } };
+        using var db = TestDbContextFactory.CreateInMemoryDbContext();
+
+        db.Users.Add(new UserEntity { Id = userId, Email = "system@test.com", PasswordHash = "hash" });
+        db.SharedGames.Add(new SharedGameEntity { Id = gameId, Title = "Gloomhaven" });
+        db.PdfDocuments.Add(new PdfDocumentEntity
+        {
+            Id = existingId,
+            SharedGameId = gameId,
+            FileName = "gloomhaven.pdf",
+            FilePath = $"pdfs/{PdfStorageKey.ForPdf(existingId)}/deadbeef_gloomhaven.pdf",
+            ContentHash = "samehash",
+            ProcessingState = nameof(PdfProcessingState.Failed),
+            ProcessingError = "PDF file not found in blob storage",
+            UploadedByUserId = userId,
+            DocumentType = "base",
+            DocumentCategory = "Rulebook",
+        });
+        await db.SaveChangesAsync();
+
+        // Act
+        Func<Task> act = () => PdfSeeder.SeedAsync(db, manifest, gameMap, userId,
+            _primaryBlob.Object, _seedBlob.Object, _logger.Object, CancellationToken.None);
+
+        // Assert — no crash, no re-upload, record untouched, no job enqueued.
+        await act.Should().NotThrowAsync();
+        _seedBlob.Verify(x => x.OpenReadAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        _primaryBlob.Verify(x => x.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+
+        var doc = db.PdfDocuments.Single(p => p.Id == existingId);
+        doc.ProcessingState.Should().Be(nameof(PdfProcessingState.Failed));
+        doc.ProcessingError.Should().Be("PDF file not found in blob storage");
+        db.ProcessingJobs.Should().BeEmpty();
     }
 
     // ---------------------------------------------------------------

--- a/apps/api/tests/Api.Tests/Integration/SeedCatalogBlobIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/SeedCatalogBlobIntegrationTests.cs
@@ -247,8 +247,16 @@ public sealed class SeedCatalogBlobIntegrationTests
             .ReturnsAsync(() => new BlobStorageResult(
                 Success: true,
                 FileId: Guid.NewGuid().ToString(),
-                FilePath: "/blobs/x",
+                // Repair mode (#2666): FilePath must carry an extractable fileId so the
+                // second run can probe the runtime bucket for the existing record.
+                FilePath: "pdfs/bucket/abc123_barrage_rulebook.pdf",
                 FileSizeBytes: 4));
+        // Repair mode (#2666): the runtime blob IS present after the first store, so the
+        // second run's presence check must return true and short-circuit to a plain skip
+        // (no re-upload). Without this the seeder would treat the blob as missing and repair.
+        _primaryBlob
+            .Setup(x => x.ExistsAsync(It.IsAny<string>(), BlobCategory.Pdf, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
 
         // Act — run the seeder twice
         await PdfSeeder.SeedAsync(


### PR DESCRIPTION
## Problem

On staging, **107 `PdfDocument` rows are stuck in `Failed`** with `ProcessingError = "PDF file not found in blob storage"`. Root cause: a **DB-only snapshot restore** re-created the records but did **not** restore the underlying files into the runtime R2 bucket.

`PdfSeeder` was idempotent on the **DB record only** — on a hash match it did `skipped++; continue;` without ever checking whether the blob is actually present in the runtime bucket. So re-running the seed never re-uploaded the missing files.

## Repair mode (this PR)

In the hash-match idempotency branch, **before skipping**, the seeder now probes the runtime bucket for the existing record:

`primaryBlob.ExistsAsync(<fileId extracted from the stored FilePath>, BlobCategory.Pdf, PdfStorageKey.ForPdf(existing.Id), ct)`

- **Blob present** → unchanged behaviour (skip).
- **Blob missing** (repair) → if the **seed bucket** still has it, re-upload against the **EXISTING id** (`PdfStorageKey.ForPdf(existing.Id)`, *not* a fresh Guid, so `pdfs/{existing.Id}/...` keeps matching what the DB `FilePath` already references), then update the existing record in place:
  - `ProcessingState → Pending`, `FilePath`/`FileSizeBytes` from the new upload
  - reset error fields: `ProcessingError`, `ErrorCategory`, `FailedAtState` → `null`, `RetryCount → 0`
  - re-enqueue a 5-step `ProcessingJob` (Upload/Extract/Chunk/Embed/Index) so `PdfProcessingQuartzJob` reprocesses it (extract → chunk → embed → index → Ready)
  - new `repaired` counter in the completion log
- **Blob missing in both runtime and seed bucket** → `LogWarning` (irrecoverable), leave the record untouched, no crash.

**Idempotent**: once repaired the blob is present, so the next seed run skips normally. Safe to re-run.

## Tests (unit, no Docker)

Extended `PdfSeederBlobTests` with 3 cases:
- **(a)** record exists + blob present in runtime → skip (no re-upload, no state change, no job).
- **(b)** record exists + blob absent in runtime + present in seed → repair: `StoreAsync` keyed on `PdfStorageKey.ForPdf(existing.Id)`, record → `Pending`, error fields reset, new `ProcessingJob` with 5 Queued steps.
- **(c)** record exists + blob absent in **both** → warning, no crash, no re-upload, record unchanged.

**RED proof**: with the source fix stashed, test (b) fails — `Moq.MockException: Expected invocation on the mock once, but was 0 times: x => x.StoreAsync(...)` (the hash-match branch just skips, never re-uploads).

Also updated the reseed idempotency integration test (`SeedCatalogBlobIntegrationTests.PdfSeeder_Reseed_IsIdempotentAndDoesNotCreateDuplicates`) so its mock reflects reality — the runtime blob is present after the first store (`primaryBlob.ExistsAsync → true` + a parseable stored `FilePath`), so the second run short-circuits to a plain skip.

## Verification (real output)

- `cd apps/api/src/Api && dotnet build` → **0 errors, 0 warnings**.
- `dotnet test tests/Api.Tests --filter "FullyQualifiedName~PdfSeeder"` → **28/28 passed**.
- Broader seeder unit suite → **108/108 passed**.

## Why `Refs`, not `Closes`

The code fix **enables** the re-upload path, but the 107 files are only actually restored **after deploy to staging + re-trigger of the seed** (subsequent operational step). Keeping the issue open until that runs.

Refs #2666

🤖 Generated with [Claude Code](https://claude.com/claude-code)