### PR TITLE
release: #2650 follow-up fixes + #2666 PdfSeeder repair mode (main-dev -> main-staging)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Jobs/PdfProcessingQuartzJob.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Jobs/PdfProcessingQuartzJob.cs
@@ -183,6 +183,16 @@ public sealed class PdfProcessingQuartzJob : IJob
             // CancelJobCommand changes status to Cancelled in DB without stopping the worker,
             // so we must not overwrite it with Completed.
             await _dbContext.Entry(jobEntity).ReloadAsync(ct).ConfigureAwait(false);
+
+            // Issue #2661: also reload pdfDoc. The pipeline's ExtractTextAsync sets
+            // PdfDocument.PageCount + SaveChangesAsync on its own scoped DbContext instance,
+            // so the copy tracked by this job stays stale (PageCount == null). Without this
+            // reload, RecordStepMetricsSafeAsync below would pass "PageCount ?? 0" == 0, which
+            // trips the "Page count must be positive" guard in ProcessingMetricsService and
+            // silently drops the metric. pdfDoc is tracked (loaded via AsTracking), so
+            // ReloadAsync refreshes it from the value the pipeline persisted.
+            await _dbContext.Entry(pdfDoc).ReloadAsync(ct).ConfigureAwait(false);
+
             if (string.Equals(jobEntity.Status, nameof(JobStatus.Cancelled), StringComparison.Ordinal))
             {
                 _logger.LogInformation(

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/AttachGamebookCampaignToGameNightCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/AttachGamebookCampaignToGameNightCommandHandler.cs
@@ -1,5 +1,6 @@
 using Api.BoundedContexts.Authentication.Application.Queries;
 using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.BoundedContexts.GameManagement.Domain.Exceptions;
 using Api.BoundedContexts.SessionTracking.Application.Commands;
 using Api.BoundedContexts.SessionTracking.Application.DTOs;
 using Api.BoundedContexts.SessionTracking.Application.Queries;
@@ -9,6 +10,7 @@ using Api.SharedKernel.Application.Interfaces;
 using Api.SharedKernel.Domain.ValueObjects;
 using Api.SharedKernel.Infrastructure.Persistence;
 using MediatR;
+using Microsoft.EntityFrameworkCore;
 
 namespace Api.BoundedContexts.GameManagement.Application.Commands.GameNights;
 
@@ -61,6 +63,10 @@ internal sealed class AttachGamebookCampaignToGameNightCommandHandler
         if (gameNight.OrganizerId != command.CallerUserId)
             throw new ForbiddenException("Only the organizer can attach a campaign to this game night.");
 
+        // WS1 DEC-4/DEC-8: guard-before-create — reject a blocked 2nd-open (409) before the
+        // cross-BC CreateSessionCommand commits a durable (orphan) tracking Session.
+        gameNight.EnsureCanStartSession();
+
         // Resolve the caller's real display name (mirrors StartGameNightSessionCommandHandler);
         // a hardcoded literal would persist to session_participants and surface in the player list.
         var caller = await _mediator.Send(new GetUserByIdQuery(command.CallerUserId), cancellationToken).ConfigureAwait(false)
@@ -80,20 +86,31 @@ internal sealed class AttachGamebookCampaignToGameNightCommandHandler
             }
         };
 
-        // Cross-BC: create the Session carrying the campaign link. GameNight linkage is done
-        // below via AddSession (mirroring StartGameNightSessionCommandHandler, which also leaves
-        // CreateSessionCommand.GameNightEventId null and links via the aggregate).
-        var createResult = await _mediator.Send(new CreateSessionCommand(
-            command.CallerUserId,
-            campaign.GameRefId,
-            "GameSpecific",
-            DateTime.UtcNow,
-            null,
-            participants,
-            GamebookCampaignId: command.CampaignId), cancellationToken).ConfigureAwait(false);
+        // WS1 DEC-5/DEC-8 (atomicity): create the Session carrying the campaign link and attach it
+        // to the aggregate in ONE explicit transaction. CreateSessionCommand's inner SaveChangesAsync
+        // enlists in this ambient tx (same scoped DbContext), so if the aggregate save loses the xmin
+        // race — or a guard trips — the Session INSERT rolls back with it and no orphan is left.
+        // Mirrors StartGameNightSessionCommandHandler.
+        CreateSessionResult createResult;
+        AttachGamebookCampaignToGameNightResult result;
+        await _unitOfWork.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
 
+        // Once CommitTransactionAsync starts it owns rollback-on-failure (self-rolls-back + disposes),
+        // so the catch blocks must not roll back a second time.
+        var commitStarted = false;
         try
         {
+            // WS1 DEC-3/DEC-8: SkipGameNightEnvelope=true — the aggregate is the sole linker (no phantom night).
+            createResult = await _mediator.Send(new CreateSessionCommand(
+                command.CallerUserId,
+                campaign.GameRefId,
+                "GameSpecific",
+                DateTime.UtcNow,
+                null,
+                participants,
+                GamebookCampaignId: command.CampaignId,
+                SkipGameNightEnvelope: true), cancellationToken).ConfigureAwait(false);
+
             // Both calls are required: AddSession registers the sitting; StartCurrentSession is
             // where the #10 max-1-live guard lives (throws MaxLiveSessionsExceededException).
             var gns = gameNight.AddSession(createResult.SessionId, campaign.GameRefId, campaign.Title);
@@ -102,17 +119,42 @@ internal sealed class AttachGamebookCampaignToGameNightCommandHandler
             await _repository.UpdateAsync(gameNight, cancellationToken).ConfigureAwait(false);
             await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
-            await _autoSaveScheduler.RegisterAsync(createResult.SessionId, cancellationToken).ConfigureAwait(false);
+            commitStarted = true;
+            await _unitOfWork.CommitTransactionAsync(cancellationToken).ConfigureAwait(false);
 
-            return new AttachGamebookCampaignToGameNightResult(
+            result = new AttachGamebookCampaignToGameNightResult(
                 createResult.SessionId, gns.Id, createResult.SessionCode, gns.PlayOrder);
+        }
+        catch (DbUpdateConcurrencyException)
+        {
+            // WS1 DEC-5/DEC-8: the xmin loser rolls the whole tx (incl. the Session INSERT) back —
+            // no orphan — then maps to the blocked-modal 409.
+            if (!commitStarted)
+                await _unitOfWork.RollbackTransactionAsync(cancellationToken).ConfigureAwait(false);
+            throw new MaxLiveSessionsExceededException(command.GameNightId);
         }
         catch (InvalidOperationException ex)
         {
             // AddSession's "not Published" guard throws a plain InvalidOperationException → wrap as 409.
-            // (StartCurrentSession's #10 guard throws MaxLiveSessionsExceededException, which already
-            // IS a ConflictException and maps to 409 via middleware — it propagates past this catch.)
+            if (!commitStarted)
+                await _unitOfWork.RollbackTransactionAsync(cancellationToken).ConfigureAwait(false);
             throw new ConflictException(ex.Message);
         }
+        catch (Exception)
+        {
+            // Any other post-INSERT failure (incl. StartCurrentSession's #10 MaxLiveSessionsExceededException)
+            // rolls back so the Session is never orphaned; the original exception then propagates.
+            if (!commitStarted)
+                await _unitOfWork.RollbackTransactionAsync(cancellationToken).ConfigureAwait(false);
+            throw;
+        }
+
+        // WS1 DEC-1/DEC-8 (#2647): open live mode LAST, after the link is committed, so the
+        // GameNight promotes Published → InProgress. Idempotent.
+        await _mediator.Send(new OpenSessionLiveModeCommand(createResult.SessionId), cancellationToken).ConfigureAwait(false);
+
+        await _autoSaveScheduler.RegisterAsync(createResult.SessionId, cancellationToken).ConfigureAwait(false);
+
+        return result;
     }
 }

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/StartGameNightSessionCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/StartGameNightSessionCommandHandler.cs
@@ -1,5 +1,6 @@
 using Api.BoundedContexts.Authentication.Application.Queries;
 using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.BoundedContexts.GameManagement.Domain.Exceptions;
 using Api.BoundedContexts.GameToolbox.Application.Commands;
 using Api.BoundedContexts.GameToolbox.Application.Queries;
 using Api.BoundedContexts.SessionTracking.Application.Commands;
@@ -9,6 +10,7 @@ using Api.Middleware.Exceptions;
 using Api.SharedKernel.Application.Interfaces;
 using Api.SharedKernel.Infrastructure.Persistence;
 using MediatR;
+using Microsoft.EntityFrameworkCore;
 
 namespace Api.BoundedContexts.GameManagement.Application.Commands.GameNights;
 
@@ -50,41 +52,90 @@ internal sealed class StartGameNightSessionCommandHandler : ICommandHandler<Star
         if (gameNight.OrganizerId != command.UserId)
             throw new ForbiddenException("Only the organizer can start sessions.");
 
+        // WS1 DEC-4: guard-before-create. Reject a blocked 2nd-open (409) BEFORE the
+        // cross-BC CreateSessionCommand commits a durable (orphan) tracking Session.
+        gameNight.EnsureCanStartSession();
+
         // Build participant list: auto-seed organizer when command provides none.
         var participants = await BuildParticipantsAsync(command, cancellationToken).ConfigureAwait(false);
 
-        // Cross-BC: create Session via MediatR dispatch to SessionTracking
-        var createResult = await _mediator.Send(new CreateSessionCommand(
-            command.UserId,
-            command.GameId,
-            "GameSpecific",
-            DateTime.UtcNow,
-            null,
-            participants,
-            StateTier: command.StateTier), cancellationToken).ConfigureAwait(false);
+        // WS1 DEC-5 (atomicity): the cross-BC Session INSERT and the aggregate link run in ONE
+        // explicit transaction. CreateSessionCommand's inner SaveChangesAsync enlists in this
+        // ambient tx (same scoped DbContext) instead of committing on its own, so if the aggregate
+        // save loses the xmin race — or any guard trips — the whole thing rolls back and no orphan
+        // Session is left behind.
+        CreateSessionResult createResult;
+        StartGameNightSessionResult result;
+        await _unitOfWork.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
 
-        // Link the new session to the GameNight aggregate and start it
+        // Once CommitTransactionAsync starts, it owns rollback-on-failure (it self-rolls-back and
+        // disposes the tx); the catch blocks must not roll back a second time.
+        var commitStarted = false;
         try
         {
+            // WS1 DEC-3: SkipGameNightEnvelope=true — the GameNightEvent aggregate (AddSession
+            // below) is the SOLE linker against command.GameNightId, so CreateSessionCommand does
+            // NOT mint a phantom ad-hoc night that would double-link the session.
+            createResult = await _mediator.Send(new CreateSessionCommand(
+                command.UserId,
+                command.GameId,
+                "GameSpecific",
+                DateTime.UtcNow,
+                null,
+                participants,
+                StateTier: command.StateTier,
+                SkipGameNightEnvelope: true), cancellationToken).ConfigureAwait(false);
+
             var gns = gameNight.AddSession(createResult.SessionId, command.GameId, command.GameTitle);
             gameNight.StartCurrentSession();
 
             await _repository.UpdateAsync(gameNight, cancellationToken).ConfigureAwait(false);
+            // The xmin race is detected here (aggregate UPDATE with a stale row version), while the
+            // tx is still open, so the catch below can roll the Session INSERT back with it.
             await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
-            await _autoSaveScheduler.RegisterAsync(createResult.SessionId, cancellationToken).ConfigureAwait(false);
+            commitStarted = true;
+            await _unitOfWork.CommitTransactionAsync(cancellationToken).ConfigureAwait(false);
 
-            // Best-effort fire-and-forget: detach from the handler's CancellationToken so the
-            // warm-up does not block the response and is not cancelled on client disconnect.
-            _ = TryApplyToolboxTemplateAsync(command.GameId, CancellationToken.None);
-
-            return new StartGameNightSessionResult(
+            result = new StartGameNightSessionResult(
                 createResult.SessionId, gns.Id, createResult.SessionCode, gns.PlayOrder);
+        }
+        catch (DbUpdateConcurrencyException)
+        {
+            // WS1 DEC-5: the xmin loser rolls the whole tx (incl. the Session INSERT) back — no
+            // orphan — then maps to the same blocked-modal 409 instead of an uncaught 500.
+            if (!commitStarted)
+                await _unitOfWork.RollbackTransactionAsync(cancellationToken).ConfigureAwait(false);
+            throw new MaxLiveSessionsExceededException(command.GameNightId);
         }
         catch (InvalidOperationException ex)
         {
+            if (!commitStarted)
+                await _unitOfWork.RollbackTransactionAsync(cancellationToken).ConfigureAwait(false);
             throw new ConflictException(ex.Message);
         }
+        catch (Exception)
+        {
+            // Any other post-INSERT failure (incl. MaxLiveSessionsExceededException from
+            // StartCurrentSession's #10 guard) rolls back so the Session is never orphaned;
+            // the original exception then propagates unchanged.
+            if (!commitStarted)
+                await _unitOfWork.RollbackTransactionAsync(cancellationToken).ConfigureAwait(false);
+            throw;
+        }
+
+        // WS1 DEC-1 (#2647): open live mode LAST — AFTER the session↔night link is
+        // committed — so the SessionStartedDomainEvent resolves the parent unambiguously
+        // and promotes the night Published → InProgress. Idempotent.
+        await _mediator.Send(new OpenSessionLiveModeCommand(createResult.SessionId), cancellationToken).ConfigureAwait(false);
+
+        await _autoSaveScheduler.RegisterAsync(createResult.SessionId, cancellationToken).ConfigureAwait(false);
+
+        // Best-effort fire-and-forget: detach from the handler's CancellationToken so the
+        // warm-up does not block the response and is not cancelled on client disconnect.
+        _ = TryApplyToolboxTemplateAsync(command.GameId, CancellationToken.None);
+
+        return result;
     }
 
     private async Task TryApplyToolboxTemplateAsync(Guid gameId, CancellationToken cancellationToken)

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/GameNights/GameNightLiveDto.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/GameNights/GameNightLiveDto.cs
@@ -12,7 +12,19 @@ public sealed record GameNightLiveDto(
     Guid Id,
     string Title,
     GameNightStatus Status,
-    IReadOnlyList<GameNightSessionDto> Sessions);
+    IReadOnlyList<GameNightSessionDto> Sessions,
+    // WS1 DEC-9: true when the caller is the night's organizer — gates the FE
+    // organizer-only "Avvia prossimo gioco" CTA. The read admits organizer + invited
+    // participants, so a viewer flag is needed to distinguish them.
+    bool IsViewerOrganizer,
+    // WS1 DEC-9: the planned games not yet turned into a Session, in planned order.
+    // The CTA starts the first of these (needs GameId + GameTitle for POST /sessions).
+    IReadOnlyList<GameNightLineupItemDto> PlannedLineup);
+
+/// <summary>
+/// A planned game in the night's line-up that has not yet been started as a Session.
+/// </summary>
+public sealed record GameNightLineupItemDto(Guid GameId, string GameTitle);
 
 /// <summary>
 /// A single sitting within the night — a projection of the <c>GameNightSession</c> child entity.

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GetGameNightLiveQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GetGameNightLiveQueryHandler.cs
@@ -1,22 +1,26 @@
 using Api.BoundedContexts.GameManagement.Application.DTOs.GameNights;
 using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.Infrastructure;
 using Api.Middleware.Exceptions;
 using Api.SharedKernel.Application.Interfaces;
+using Microsoft.EntityFrameworkCore;
 
 namespace Api.BoundedContexts.GameManagement.Application.Queries.GameNights;
 
 /// <summary>
 /// Handles <see cref="GetGameNightLiveQuery"/>. Loads the <c>GameNightEvent</c> (its child
 /// <c>Sessions</c> are already Included by the repository) and projects it to the live read model,
-/// ordering sessions by play order.
+/// ordering sessions by play order. Also surfaces the un-started planned line-up (WS1 DEC-9).
 /// </summary>
 internal sealed class GetGameNightLiveQueryHandler : IQueryHandler<GetGameNightLiveQuery, GameNightLiveDto>
 {
     private readonly IGameNightEventRepository _repository;
+    private readonly MeepleAiDbContext _db;
 
-    public GetGameNightLiveQueryHandler(IGameNightEventRepository repository)
+    public GetGameNightLiveQueryHandler(IGameNightEventRepository repository, MeepleAiDbContext db)
     {
         _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _db = db ?? throw new ArgumentNullException(nameof(db));
     }
 
     public async Task<GameNightLiveDto> Handle(GetGameNightLiveQuery query, CancellationToken cancellationToken)
@@ -27,7 +31,8 @@ internal sealed class GetGameNightLiveQueryHandler : IQueryHandler<GetGameNightL
             ?? throw new NotFoundException("GameNightEvent", query.GameNightId.ToString());
 
         // Participant-only: the live read exposes per-session WinnerId (user GUIDs) + progression.
-        var isParticipant = gameNight.OrganizerId == query.CallerUserId
+        var isOrganizer = gameNight.OrganizerId == query.CallerUserId;
+        var isParticipant = isOrganizer
             || gameNight.Rsvps.Any(r => r.UserId == query.CallerUserId);
         if (!isParticipant)
             throw new ForbiddenException("Only the organizer or an invited player can view the night-live state.");
@@ -45,6 +50,21 @@ internal sealed class GetGameNightLiveQueryHandler : IQueryHandler<GetGameNightL
                 s.CompletedAt))
             .ToList();
 
-        return new GameNightLiveDto(gameNight.Id, gameNight.Title, gameNight.Status, sessions);
+        // WS1 DEC-9: the planned games (GameIds) not yet started as a Session, in planned order.
+        var startedGameIds = gameNight.Sessions.Select(s => s.GameId).ToHashSet();
+        var unstartedGameIds = gameNight.GameIds.Distinct().Where(id => !startedGameIds.Contains(id)).ToList();
+        var titles = unstartedGameIds.Count == 0
+            ? new Dictionary<Guid, string>()
+            : await _db.SharedGames.AsNoTracking()
+                .Where(g => unstartedGameIds.Contains(g.Id))
+                .Select(g => new { g.Id, g.Title })
+                .ToDictionaryAsync(g => g.Id, g => g.Title, cancellationToken)
+                .ConfigureAwait(false);
+        var plannedLineup = unstartedGameIds
+            .Select(id => new GameNightLineupItemDto(id, titles.TryGetValue(id, out var t) ? t : "Gioco"))
+            .ToList();
+
+        return new GameNightLiveDto(
+            gameNight.Id, gameNight.Title, gameNight.Status, sessions, isOrganizer, plannedLineup);
     }
 }

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/GameNightEvent/GameNightEvent.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/GameNightEvent/GameNightEvent.cs
@@ -427,6 +427,24 @@ internal sealed class GameNightEvent : AggregateRoot<Guid>
     }
 
     /// <summary>
+    /// WS1 DEC-4 — guard-before-create. Throws <see cref="MaxLiveSessionsExceededException"/>
+    /// if any child session is already InProgress, WITHOUT mutating state. The start
+    /// handler calls this before dispatching CreateSessionCommand, so a blocked 2nd-open
+    /// returns 409 without minting an orphan tracking Session (StartCurrentSession's own
+    /// guard fires only after the Session has already been created and committed).
+    /// </summary>
+    /// <exception cref="MaxLiveSessionsExceededException">
+    /// Thrown when a session is already in InProgress status on this event.
+    /// </exception>
+    public void EnsureCanStartSession()
+    {
+        ThrowIfCorrupted();
+
+        if (_sessions.Any(s => s.Status == GameNightSessionStatus.InProgress))
+            throw new MaxLiveSessionsExceededException(Id);
+    }
+
+    /// <summary>
     /// Starts the first pending session.
     /// Enforces invariante #10 (GameNight/Session domain model): a GameNightEvent
     /// can have at most 1 GameNightSession in InProgress at a time.

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Exceptions/MaxLiveSessionsExceededException.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Exceptions/MaxLiveSessionsExceededException.cs
@@ -22,7 +22,7 @@ public sealed class MaxLiveSessionsExceededException : ConflictException
 
     [SetsRequiredMembers]
     public MaxLiveSessionsExceededException(Guid gameNightEventId)
-        : base($"GameNightEvent {gameNightEventId} already has an active live session. At most 1 session may be InProgress at a time (invariant #10).")
+        : base(Code, $"GameNightEvent {gameNightEventId} already has an active live session. At most 1 session may be InProgress at a time (invariant #10).")
     {
         GameNightEventId = gameNightEventId;
     }

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/CreateSessionCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/CreateSessionCommand.cs
@@ -12,6 +12,15 @@ namespace Api.BoundedContexts.SessionTracking.Application.Commands;
 /// <c>GameNightEvent</c> implicitly (one-click "Start playing" flow). When provided,
 /// the session is attached to the existing InProgress night (at most one active
 /// session per night is allowed — enforced by the handler).
+///
+/// <para>WS1 DEC-3 (#2633): when <paramref name="SkipGameNightEnvelope"/> is true the
+/// handler creates ONLY the tracking Session (+ participants) and skips the whole
+/// game-night envelope (ResolveGameNightAsync, the game_night_sessions link, and the
+/// game-night diary rows). The game-night orchestrators
+/// (<c>StartGameNightSessionCommandHandler</c>, <c>AttachGamebookCampaignToGameNightCommandHandler</c>)
+/// pass true so <c>GameNightEvent.AddSession</c> is the SOLE linker against the real
+/// <c>command.GameNightId</c> — eliminating the phantom ad-hoc night that otherwise
+/// double-linked the session and made <c>FindByLinkedSessionIdAsync</c> nondeterministic.</para>
 /// </summary>
 public record CreateSessionCommand(
     Guid UserId,
@@ -23,7 +32,8 @@ public record CreateSessionCommand(
     Guid? GameNightEventId = null,
     IReadOnlyList<string>? GuestNames = null,
     GameStateTier StateTier = GameStateTier.Minimal,
-    Guid? GamebookCampaignId = null
+    Guid? GamebookCampaignId = null,
+    bool SkipGameNightEnvelope = false
 ) : ICommand<CreateSessionResult>;
 
 /// <summary>

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/CreateSessionCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/CreateSessionCommandHandler.cs
@@ -77,8 +77,15 @@ public class CreateSessionCommandHandler : ICommandHandler<CreateSessionCommand,
         }
 
         // Session Flow v2.1 — T4: Resolve or create the GameNight envelope.
-        var (nightEntity, gameNightWasCreated) = await ResolveGameNightAsync(
-            request, cancellationToken).ConfigureAwait(false);
+        // WS1 DEC-3: the game-night orchestrators own the session↔night link on the
+        // GameNightEvent aggregate, so they skip the envelope here (no phantom night).
+        GameNightEventEntity? nightEntity = null;
+        var gameNightWasCreated = false;
+        if (!request.SkipGameNightEnvelope)
+        {
+            (nightEntity, gameNightWasCreated) = await ResolveGameNightAsync(
+                request, cancellationToken).ConfigureAwait(false);
+        }
 
         var sessionType = Enum.Parse<SessionType>(request.SessionType);
 
@@ -157,101 +164,109 @@ public class CreateSessionCommandHandler : ICommandHandler<CreateSessionCommand,
             {
                 await _sessionRepository.AddAsync(session, cancellationToken).ConfigureAwait(false);
 
-                // I2 fix: enforce max 5 sessions per GameNight (domain invariant bypass guard)
-                var existingSessionCount = await _db.GameNightSessions
-                    .CountAsync(gns => gns.GameNightEventId == nightEntity.Id, cancellationToken)
-                    .ConfigureAwait(false);
-                if (existingSessionCount >= 5)
-                    throw new ConflictException("A game night cannot have more than 5 sessions.");
-
-                var playOrder = Math.Max(1, nightEntity.Sessions.Count + 1);
-                var linkEntity = new GameNightSessionEntity
-                {
-                    Id = Guid.NewGuid(),
-                    GameNightEventId = nightEntity.Id,
-                    SessionId = session.Id,
-                    GameId = request.GameId,
-                    GameTitle = gameTitle,
-                    PlayOrder = playOrder,
-                    Status = GameNightSessionStatus.InProgress.ToString(),
-                    StartedAt = _timeProvider.GetUtcNow()
-                };
-
-                // Session Flow v2.1 — T5 fix: when nightEntity is loaded (Unchanged) and the
-                // child link has a non-default Guid PK, EF identity-resolution would otherwise
-                // mark the new linkEntity as Modified instead of Added (because GameNightSessionEntity.Id
-                // is configured ValueGeneratedOnAdd). Adding via the DbSet forces Added state and
-                // also keeps the in-memory navigation collection consistent for subsequent code paths.
-                await _db.GameNightSessions.AddAsync(linkEntity, cancellationToken).ConfigureAwait(false);
-                nightEntity.Sessions.Add(linkEntity);
-
-                // Session Flow v2.1 — T4: Emit diary events.
+                // Session Flow v2.1 — T4: Emit diary events (hoisted so the SSE publish loop
+                // below works whether or not the game-night envelope was written).
                 var diaryEntities = new List<Api.Infrastructure.Entities.SessionTracking.SessionEventEntity>();
 
-                var sessionCreatedPayload = System.Text.Json.JsonSerializer.Serialize(new
+                // WS1 DEC-3: the game-night orchestrators own the session↔night link on the
+                // GameNightEvent aggregate, so the envelope (link + game-night diary) is skipped
+                // here — otherwise this handler would mint a phantom ad-hoc night double-linking
+                // the session (breaking FindByLinkedSessionIdAsync).
+                if (!request.SkipGameNightEnvelope && nightEntity != null)
                 {
-                    gameId = request.GameId,
-                    gameNightEventId = nightEntity.Id,
-                    gameNightWasCreated
-                });
-                var sessionCreatedDiary = new Api.Infrastructure.Entities.SessionTracking.SessionEventEntity
-                {
-                    Id = Guid.NewGuid(),
-                    SessionId = session.Id,
-                    GameNightId = nightEntity.Id,
-                    EventType = "session_created",
-                    Timestamp = _timeProvider.GetUtcNow().UtcDateTime,
-                    Payload = sessionCreatedPayload,
-                    CreatedBy = request.UserId,
-                    Source = "system",
-                    IsDeleted = false
-                };
-                _db.SessionEvents.Add(sessionCreatedDiary);
-                diaryEntities.Add(sessionCreatedDiary);
+                    // I2 fix: enforce max 5 sessions per GameNight (domain invariant bypass guard)
+                    var existingSessionCount = await _db.GameNightSessions
+                        .CountAsync(gns => gns.GameNightEventId == nightEntity.Id, cancellationToken)
+                        .ConfigureAwait(false);
+                    if (existingSessionCount >= 5)
+                        throw new ConflictException("A game night cannot have more than 5 sessions.");
 
-                if (gameNightWasCreated)
-                {
-                    var nightCreatedPayload = System.Text.Json.JsonSerializer.Serialize(new
+                    var playOrder = Math.Max(1, nightEntity.Sessions.Count + 1);
+                    var linkEntity = new GameNightSessionEntity
                     {
+                        Id = Guid.NewGuid(),
+                        GameNightEventId = nightEntity.Id,
+                        SessionId = session.Id,
+                        GameId = request.GameId,
+                        GameTitle = gameTitle,
+                        PlayOrder = playOrder,
+                        Status = GameNightSessionStatus.InProgress.ToString(),
+                        StartedAt = _timeProvider.GetUtcNow()
+                    };
+
+                    // Session Flow v2.1 — T5 fix: when nightEntity is loaded (Unchanged) and the
+                    // child link has a non-default Guid PK, EF identity-resolution would otherwise
+                    // mark the new linkEntity as Modified instead of Added (because GameNightSessionEntity.Id
+                    // is configured ValueGeneratedOnAdd). Adding via the DbSet forces Added state and
+                    // also keeps the in-memory navigation collection consistent for subsequent code paths.
+                    await _db.GameNightSessions.AddAsync(linkEntity, cancellationToken).ConfigureAwait(false);
+                    nightEntity.Sessions.Add(linkEntity);
+
+                    var sessionCreatedPayload = System.Text.Json.JsonSerializer.Serialize(new
+                    {
+                        gameId = request.GameId,
                         gameNightEventId = nightEntity.Id,
-                        title = nightEntity.Title,
-                        isAdHoc = true
+                        gameNightWasCreated
                     });
-                    var nightCreatedDiary = new Api.Infrastructure.Entities.SessionTracking.SessionEventEntity
+                    var sessionCreatedDiary = new Api.Infrastructure.Entities.SessionTracking.SessionEventEntity
                     {
                         Id = Guid.NewGuid(),
                         SessionId = session.Id,
                         GameNightId = nightEntity.Id,
-                        EventType = "gamenight_created",
+                        EventType = "session_created",
                         Timestamp = _timeProvider.GetUtcNow().UtcDateTime,
-                        Payload = nightCreatedPayload,
+                        Payload = sessionCreatedPayload,
                         CreatedBy = request.UserId,
                         Source = "system",
                         IsDeleted = false
                     };
-                    _db.SessionEvents.Add(nightCreatedDiary);
-                    diaryEntities.Add(nightCreatedDiary);
-                }
-                else
-                {
-                    var gameAddedPayload = System.Text.Json.JsonSerializer.Serialize(new
+                    _db.SessionEvents.Add(sessionCreatedDiary);
+                    diaryEntities.Add(sessionCreatedDiary);
+
+                    if (gameNightWasCreated)
                     {
-                        addedGameId = request.GameId
-                    });
-                    var gameAddedDiary = new Api.Infrastructure.Entities.SessionTracking.SessionEventEntity
+                        var nightCreatedPayload = System.Text.Json.JsonSerializer.Serialize(new
+                        {
+                            gameNightEventId = nightEntity.Id,
+                            title = nightEntity.Title,
+                            isAdHoc = true
+                        });
+                        var nightCreatedDiary = new Api.Infrastructure.Entities.SessionTracking.SessionEventEntity
+                        {
+                            Id = Guid.NewGuid(),
+                            SessionId = session.Id,
+                            GameNightId = nightEntity.Id,
+                            EventType = "gamenight_created",
+                            Timestamp = _timeProvider.GetUtcNow().UtcDateTime,
+                            Payload = nightCreatedPayload,
+                            CreatedBy = request.UserId,
+                            Source = "system",
+                            IsDeleted = false
+                        };
+                        _db.SessionEvents.Add(nightCreatedDiary);
+                        diaryEntities.Add(nightCreatedDiary);
+                    }
+                    else
                     {
-                        Id = Guid.NewGuid(),
-                        SessionId = session.Id,
-                        GameNightId = nightEntity.Id,
-                        EventType = "gamenight_game_added",
-                        Timestamp = _timeProvider.GetUtcNow().UtcDateTime,
-                        Payload = gameAddedPayload,
-                        CreatedBy = request.UserId,
-                        Source = "system",
-                        IsDeleted = false
-                    };
-                    _db.SessionEvents.Add(gameAddedDiary);
-                    diaryEntities.Add(gameAddedDiary);
+                        var gameAddedPayload = System.Text.Json.JsonSerializer.Serialize(new
+                        {
+                            addedGameId = request.GameId
+                        });
+                        var gameAddedDiary = new Api.Infrastructure.Entities.SessionTracking.SessionEventEntity
+                        {
+                            Id = Guid.NewGuid(),
+                            SessionId = session.Id,
+                            GameNightId = nightEntity.Id,
+                            EventType = "gamenight_game_added",
+                            Timestamp = _timeProvider.GetUtcNow().UtcDateTime,
+                            Payload = gameAddedPayload,
+                            CreatedBy = request.UserId,
+                            Source = "system",
+                            IsDeleted = false
+                        };
+                        _db.SessionEvents.Add(gameAddedDiary);
+                        diaryEntities.Add(gameAddedDiary);
+                    }
                 }
 
                 // Single atomic save for session + participants + guest additions + night link + diary events.
@@ -275,7 +290,7 @@ public class CreateSessionCommandHandler : ICommandHandler<CreateSessionCommand,
                     SessionId: session.Id,
                     SessionCode: session.SessionCode,
                     Participants: session.Participants.Select(MapParticipant).ToList(),
-                    GameNightEventId: nightEntity.Id,
+                    GameNightEventId: nightEntity?.Id ?? Guid.Empty, // WS1 DEC-3: Empty when the envelope is skipped
                     GameNightWasCreated: gameNightWasCreated,
                     AgentDefinitionId: agentDefinitionId,
                     ToolkitId: toolkitId);

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/OpenSessionLiveModeCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/OpenSessionLiveModeCommand.cs
@@ -1,0 +1,20 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Commands;
+
+/// <summary>
+/// WS1 DEC-1/6 (issue #2647): opens live mode on a tracking <c>Session</c> — sets
+/// <c>StartedAt</c> and raises <c>SessionStartedDomainEvent</c> so the GameManagement
+/// <c>SessionStartedHandler</c> promotes the parent GameNight Published → InProgress
+/// (invariante #15).
+///
+/// <para>Dispatched by the game-night start / gamebook-attach orchestrators as the
+/// LAST step, AFTER the session↔night link is committed, so
+/// <c>FindByLinkedSessionIdAsync</c> resolves the parent unambiguously (placing it
+/// inside <c>CreateSessionCommandHandler</c> would dispatch the event before the link
+/// exists and silently skip the promotion — the original #2647 trap).</para>
+///
+/// <para>Idempotent: a no-op when the session is already live (the use case spans
+/// multiple SaveChanges, so a retry can reach an already-live session).</para>
+/// </summary>
+internal sealed record OpenSessionLiveModeCommand(Guid SessionId) : ICommand;

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/OpenSessionLiveModeCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/OpenSessionLiveModeCommandHandler.cs
@@ -1,0 +1,42 @@
+using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Infrastructure.Persistence;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Commands;
+
+/// <summary>
+/// Handles <see cref="OpenSessionLiveModeCommand"/> (WS1 DEC-1/6). Loads the Session,
+/// opens live mode (unless already live — DEC-6 idempotency), and saves. The
+/// <c>SessionStartedDomainEvent</c> raised by <c>Session.OpenLiveMode()</c> is
+/// collected by <c>ISessionRepository.UpdateAsync</c> and dispatched post-commit
+/// (ADR-060), driving the GameNight Published → InProgress promotion.
+/// </summary>
+internal sealed class OpenSessionLiveModeCommandHandler : ICommandHandler<OpenSessionLiveModeCommand>
+{
+    private readonly ISessionRepository _sessionRepository;
+    private readonly IUnitOfWork _unitOfWork;
+
+    public OpenSessionLiveModeCommandHandler(ISessionRepository sessionRepository, IUnitOfWork unitOfWork)
+    {
+        _sessionRepository = sessionRepository ?? throw new ArgumentNullException(nameof(sessionRepository));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+    }
+
+    public async Task Handle(OpenSessionLiveModeCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var session = await _sessionRepository.GetByIdAsync(command.SessionId, cancellationToken).ConfigureAwait(false)
+            ?? throw new NotFoundException($"Session {command.SessionId} not found");
+
+        // DEC-6: idempotent — a retry across the multi-SaveChanges use case can reach an
+        // already-live session; treat as success, do NOT surface the max-1-live 409.
+        if (session.IsLive)
+            return;
+
+        session.OpenLiveMode();
+        await _sessionRepository.UpdateAsync(session, cancellationToken).ConfigureAwait(false);
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Persistence/SessionRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Persistence/SessionRepository.cs
@@ -113,8 +113,13 @@ public class SessionRepository : RepositoryBase, ISessionRepository
         // so they are dispatched atomically with the SaveChangesAsync call upstream.
         CollectDomainEvents(session);
 
-        // Retrieve existing entity to preserve EF Core tracking
+        // Retrieve existing entity to preserve EF Core tracking.
+        // #2660: the DbContext default is QueryTrackingBehavior.NoTracking (PERF-06), so
+        // .AsTracking() is REQUIRED here — otherwise `existing` is loaded untracked and every
+        // scalar mutation below (Status/StartedAt/FinalizedAt/ScoreData/...) is a silent no-op
+        // that SaveChangesAsync never persists.
         var existing = await DbContext.SessionTrackingSessions
+            .AsTracking()
             .Include(s => s.Participants)
             .FirstOrDefaultAsync(s => s.Id == session.Id, ct)
             .ConfigureAwait(false);

--- a/apps/api/src/Api/Infrastructure/Seeders/Catalog/PdfSeeder.cs
+++ b/apps/api/src/Api/Infrastructure/Seeders/Catalog/PdfSeeder.cs
@@ -92,6 +92,7 @@ internal static class PdfSeeder
 
         var seeded = 0;
         var skipped = 0;
+        var repaired = 0;
 
         foreach (var entry in pdfEntries)
         {
@@ -128,14 +129,43 @@ internal static class PdfSeeder
                 // Idempotency: check if SharedGameId + FileName pair already exists
                 if (existingMap.TryGetValue(idempotencyKey, out var existing))
                 {
-                    // Hash match → skip (no changes)
+                    // Hash match → the DB record is up to date, so normally we skip. BUT
+                    // repair mode (#2666): a DB-only snapshot restore re-creates the record
+                    // while the actual blob stays absent from the runtime bucket, leaving the
+                    // PDF stuck in Failed with "PDF file not found in blob storage". Verify the
+                    // blob is really present before skipping; if it's gone, re-upload it from the
+                    // seed bucket against the EXISTING id and reset the record to Pending so the
+                    // pipeline reprocesses it. Idempotent: once repaired the blob is present and
+                    // the next run skips normally.
                     if (!string.IsNullOrEmpty(manifestHash) &&
                         string.Equals(existing.ContentHash, manifestHash, StringComparison.OrdinalIgnoreCase))
                     {
-                        logger.LogDebug(
-                            "PdfSeeder: PDF '{FileName}' for game '{Title}' has matching hash. Skipping.",
-                            fileName, entry.Title);
-                        skipped++;
+                        // fileId is embedded in the stored FilePath (pdfs/{resourceKey}/{fileId}_{name});
+                        // extract it so ExistsAsync can locate the blob for the EXISTING record.
+                        var existingFileId = ExtractFileIdFromPath(existing.FilePath);
+                        var blobPresent = !string.IsNullOrEmpty(existingFileId)
+                            && await primaryBlob.ExistsAsync(existingFileId, BlobCategory.Pdf, PdfStorageKey.ForPdf(existing.Id), ct).ConfigureAwait(false);
+
+                        if (blobPresent)
+                        {
+                            logger.LogDebug(
+                                "PdfSeeder: PDF '{FileName}' for game '{Title}' has matching hash and blob present. Skipping.",
+                                fileName, entry.Title);
+                            skipped++;
+                            continue;
+                        }
+
+                        // Blob missing from the runtime bucket → attempt repair from the seed bucket.
+                        if (await TryRepairMissingBlobAsync(
+                                db, primaryBlob, seedBlob, existing.Id, blobKey, fileName,
+                                entry, systemUserId, logger, ct).ConfigureAwait(false))
+                        {
+                            repaired++;
+                        }
+                        else
+                        {
+                            skipped++;
+                        }
                         continue;
                     }
 
@@ -256,8 +286,111 @@ internal static class PdfSeeder
         }
 
         logger.LogInformation(
-            "PdfSeeder completed: {Seeded} queued for RAG processing, {Skipped} skipped",
-            seeded, skipped);
+            "PdfSeeder completed: {Seeded} queued for RAG processing, {Repaired} repaired (missing blob re-uploaded), {Skipped} skipped",
+            seeded, repaired, skipped);
+    }
+
+    /// <summary>
+    /// Repair mode (#2666): re-uploads a PDF blob that is missing from the runtime bucket
+    /// (typically after a DB-only snapshot restore) using the EXISTING pdf id, then resets
+    /// the record to <see cref="PdfProcessingState.Pending"/> and re-enqueues a ProcessingJob
+    /// so the RAG pipeline reprocesses it (extract → chunk → embed → index → Ready).
+    ///
+    /// Uses <paramref name="existingId"/> for BOTH the storage bucket key and the DB record so
+    /// the persisted FilePath (pdfs/{existingId}/...) keeps matching what the database already
+    /// references — minting a fresh Guid would orphan the blob from the record.
+    ///
+    /// Returns true when the record was repaired; false when it could not be repaired (blob is
+    /// missing in the seed bucket too, the re-upload failed, or the record vanished mid-run).
+    /// Never throws for the recoverable cases: irrecoverable blobs are logged and left untouched.
+    /// </summary>
+    private static async Task<bool> TryRepairMissingBlobAsync(
+        MeepleAiDbContext db,
+        IBlobStorageService primaryBlob,
+        ISeedBlobReader seedBlob,
+        Guid existingId,
+        string blobKey,
+        string fileName,
+        SeedManifestGame entry,
+        Guid systemUserId,
+        ILogger logger,
+        CancellationToken ct)
+    {
+        // The blob is gone from the runtime bucket — it can only be repaired if the source
+        // still exists in the seed bucket. If neither has it, the PDF is irrecoverable here.
+        if (!await seedBlob.ExistsAsync(blobKey, ct).ConfigureAwait(false))
+        {
+            logger.LogWarning(
+                "PdfSeeder: PDF '{FileName}' (pdfId {Id}, game '{Title}') blob missing in both runtime and seed bucket, cannot repair. Leaving record untouched.",
+                fileName, existingId, entry.Title);
+            return false;
+        }
+
+        // Re-upload against the EXISTING id (NOT a new Guid) so pdfs/{existingId}/ stays
+        // consistent with the FilePath the DB record already points at.
+        var stream = await seedBlob.OpenReadAsync(blobKey, ct).ConfigureAwait(false);
+        await using var _ = stream.ConfigureAwait(false);
+        var result = await primaryBlob.StoreAsync(stream, fileName, BlobCategory.Pdf, PdfStorageKey.ForPdf(existingId), ct).ConfigureAwait(false);
+
+        if (!result.Success)
+        {
+            logger.LogWarning(
+                "PdfSeeder: repair failed to re-upload blob for '{FileName}' (pdfId {Id}, game '{Title}'): {Error}",
+                fileName, existingId, entry.Title, result.ErrorMessage);
+            return false;
+        }
+
+        // Load the existing record tracked and reset it to Pending, clearing every error field
+        // left over from the previous Failed run so the pipeline reprocesses it cleanly.
+        var pdfEntity = await db.PdfDocuments
+            .FirstOrDefaultAsync(p => p.Id == existingId, ct)
+            .ConfigureAwait(false);
+        if (pdfEntity is null)
+        {
+            logger.LogWarning(
+                "PdfSeeder: repair could not load PdfDocument {Id} ('{FileName}') for update. Skipping.",
+                existingId, fileName);
+            return false;
+        }
+
+        pdfEntity.ProcessingState = nameof(PdfProcessingState.Pending);
+        pdfEntity.FilePath = result.FilePath ?? string.Empty;
+        pdfEntity.FileSizeBytes = result.FileSizeBytes;
+        pdfEntity.ProcessingError = null;
+        pdfEntity.ErrorCategory = null;
+        pdfEntity.FailedAtState = null;
+        pdfEntity.RetryCount = 0;
+        await db.SaveChangesAsync(ct).ConfigureAwait(false);
+
+        // Re-enqueue a ProcessingJob with the five standard pipeline steps (identical to the
+        // new-record flow) so PdfProcessingQuartzJob picks the repaired PDF up again.
+        var now = DateTimeOffset.UtcNow;
+        var jobEntity = new ProcessingJobEntity
+        {
+            Id = Guid.NewGuid(),
+            PdfDocumentId = existingId,
+            UserId = systemUserId,
+            Status = nameof(JobStatus.Queued),
+            Priority = 0,
+            CreatedAt = now,
+            MaxRetries = 3,
+            RetryCount = 0,
+        };
+        jobEntity.Steps = new List<ProcessingStepEntity>
+        {
+            new() { Id = Guid.NewGuid(), ProcessingJobId = jobEntity.Id, StepName = nameof(ProcessingStepType.Upload),  Status = "Pending" },
+            new() { Id = Guid.NewGuid(), ProcessingJobId = jobEntity.Id, StepName = nameof(ProcessingStepType.Extract), Status = "Pending" },
+            new() { Id = Guid.NewGuid(), ProcessingJobId = jobEntity.Id, StepName = nameof(ProcessingStepType.Chunk),   Status = "Pending" },
+            new() { Id = Guid.NewGuid(), ProcessingJobId = jobEntity.Id, StepName = nameof(ProcessingStepType.Embed),   Status = "Pending" },
+            new() { Id = Guid.NewGuid(), ProcessingJobId = jobEntity.Id, StepName = nameof(ProcessingStepType.Index),   Status = "Pending" },
+        };
+        db.Set<ProcessingJobEntity>().Add(jobEntity);
+        await db.SaveChangesAsync(ct).ConfigureAwait(false);
+
+        logger.LogInformation(
+            "PdfSeeder: repaired: re-uploaded missing blob for '{FileName}' (pdfId {Id}, JobId={JobId}, {Size} bytes) and reset to Pending",
+            fileName, existingId, jobEntity.Id, result.FileSizeBytes);
+        return true;
     }
 
     /// <summary>

--- a/apps/api/src/Api/Middleware/Exceptions/ConflictException.cs
+++ b/apps/api/src/Api/Middleware/Exceptions/ConflictException.cs
@@ -15,6 +15,17 @@ public class ConflictException : HttpException
     {
     }
 
+    /// <summary>
+    /// Creates a 409 with an explicit machine-readable <paramref name="errorCode"/>
+    /// so subclasses (e.g. <see cref="Api.BoundedContexts.GameManagement.Domain.Exceptions.MaxLiveSessionsExceededException"/>)
+    /// can carry a discriminable code into the HTTP body (WS1 DEC-7).
+    /// </summary>
+    [SetsRequiredMembers]
+    public ConflictException(string errorCode, string message)
+        : base(StatusCodes.Status409Conflict, errorCode, message)
+    {
+    }
+
     [SetsRequiredMembers]
     public ConflictException(string message, Exception innerException)
         : base(StatusCodes.Status409Conflict, "conflict", message, innerException)

--- a/apps/api/tests/Api.Tests/Api.Tests.csproj
+++ b/apps/api/tests/Api.Tests/Api.Tests.csproj
@@ -52,6 +52,12 @@
     <PackageReference Include="Serilog.Sinks.TestCorrelator" Version="4.0.0" />
     <PackageReference Include="Testcontainers.PostgreSql" Version="4.9.0" />
     <PackageReference Include="Testcontainers.Redis" Version="4.9.0" />
+    <!-- Issue #2662 / GHSA-24c8-4792-22hx (HIGH): WireMock.Net tira transitive
+         Scriban.Signed 7.0.6 (array.insert_at unbounded fill loop → OOM/DoS,
+         vulnerabile <=7.1.0). Override alla versione patchata 7.2.0 per far
+         passare il check CI "Dependency Vulnerabilities" (fail su HIGH/CRITICAL).
+         Solo test project — Scriban non è nel path di produzione (Api pulito). -->
+    <PackageReference Include="Scriban.Signed" Version="7.2.0" />
     <PackageReference Include="WireMock.Net" Version="2.5.0" />
     <PackageReference Include="xunit.abstractions" Version="2.0.3" />
     <PackageReference Include="xunit.v3" Version="3.2.1" />

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Jobs/PdfProcessingQuartzJobTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Jobs/PdfProcessingQuartzJobTests.cs
@@ -1,0 +1,141 @@
+using Api.BoundedContexts.DocumentProcessing.Application.Jobs;
+using Api.BoundedContexts.DocumentProcessing.Application.Services;
+using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
+using Api.BoundedContexts.DocumentProcessing.Infrastructure.Services;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Infrastructure.Entities.DocumentProcessing;
+using Api.Tests.TestHelpers;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Quartz;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.DocumentProcessing.Application.Jobs;
+
+/// <summary>
+/// Regression tests for Issue #2661.
+///
+/// The pipeline (<see cref="IPdfProcessingPipelineService"/>) populates
+/// <c>PdfDocument.PageCount</c> and calls SaveChangesAsync on its own scoped
+/// DbContext instance. The job holds a separately-tracked copy of the same
+/// PdfDocument, so that copy stays stale (PageCount == null) unless it is reloaded.
+/// Before the fix, the job passed <c>PageCount ?? 0</c> == 0 into
+/// <see cref="IProcessingMetricsService.RecordStepDurationAsync"/>, tripping its
+/// "Page count must be positive" guard and silently dropping every step metric.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "DocumentProcessing")]
+public sealed class PdfProcessingQuartzJobTests
+{
+    private const int PersistedPageCount = 42;
+
+    private static readonly string[] StepNames =
+        { "Upload", "Extract", "Chunk", "Embed", "Index" };
+
+    [Fact]
+    public async Task Execute_ReloadsPdfDocAfterPipeline_PassesPersistedPageCountToMetrics()
+    {
+        // Arrange — two DbContexts over ONE shared in-memory store (same database name).
+        // jobContext is what the job holds; pipelineContext simulates the pipeline's own
+        // scoped context that persists PageCount out-of-band.
+        var dbName = $"issue-2661-{Guid.NewGuid()}";
+        using var jobContext = TestDbContextFactory.CreateInMemoryDbContext(dbName);
+        using var pipelineContext = TestDbContextFactory.CreateInMemoryDbContext(dbName);
+
+        var pdfId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var jobId = Guid.NewGuid();
+
+        // PDF seeded with PageCount == null: the exact stale/unpopulated state the job
+        // observes before the pipeline runs.
+        jobContext.PdfDocuments.Add(new PdfDocumentEntity
+        {
+            Id = pdfId,
+            FileName = "rules.pdf",
+            FilePath = "/tmp/rules.pdf",
+            FileSizeBytes = 2048,
+            UploadedByUserId = userId,
+            ProcessingState = "Pending",
+            PageCount = null,
+        });
+        jobContext.ProcessingJobs.Add(new ProcessingJobEntity
+        {
+            Id = jobId,
+            PdfDocumentId = pdfId,
+            UserId = userId,
+            Status = nameof(JobStatus.Queued),
+            Priority = 0,
+            CreatedAt = DateTimeOffset.UtcNow,
+        });
+        foreach (var stepName in StepNames)
+        {
+            jobContext.ProcessingSteps.Add(new ProcessingStepEntity
+            {
+                Id = Guid.NewGuid(),
+                ProcessingJobId = jobId,
+                StepName = stepName,
+                Status = nameof(StepStatus.Pending),
+            });
+        }
+        await jobContext.SaveChangesAsync();
+
+        // Pipeline mock: simulate ExtractTextAsync writing PageCount via its OWN context,
+        // committing to the shared store. This is what leaves the job's tracked copy stale.
+        var pipeline = new Mock<IPdfProcessingPipelineService>();
+        pipeline
+            .Setup(p => p.ProcessAsync(pdfId, It.IsAny<string>(), userId, It.IsAny<CancellationToken>()))
+            .Returns(async (Guid id, string _, Guid _, CancellationToken innerCt) =>
+            {
+                var doc = await pipelineContext.PdfDocuments.AsTracking()
+                    .FirstAsync(d => d.Id == id, innerCt);
+                doc.PageCount = PersistedPageCount;
+                await pipelineContext.SaveChangesAsync(innerCt);
+            });
+
+        var metrics = new Mock<IProcessingMetricsService>();
+        var stream = new Mock<IQueueStreamService>();
+
+        var services = new ServiceCollection();
+        services.AddSingleton(pipeline.Object);
+        services.AddSingleton(metrics.Object);
+        services.AddSingleton(stream.Object);
+        using var serviceProvider = services.BuildServiceProvider();
+
+        var job = new PdfProcessingQuartzJob(
+            jobContext,
+            serviceProvider,
+            NullLogger<PdfProcessingQuartzJob>.Instance,
+            TimeProvider.System);
+
+        var executionContext = new Mock<IJobExecutionContext>();
+        executionContext.SetupGet(c => c.CancellationToken).Returns(CancellationToken.None);
+
+        // Act
+        await job.Execute(executionContext.Object);
+
+        // Assert — after the reload, every step metric receives the value the pipeline
+        // persisted (42), never the stale 0 that would trip the guard.
+        metrics.Verify(m => m.RecordStepDurationAsync(
+                pdfId,
+                It.IsAny<PdfProcessingState>(),
+                It.IsAny<TimeSpan>(),
+                It.IsAny<long>(),
+                PersistedPageCount,
+                It.IsAny<Guid?>(),
+                It.IsAny<CancellationToken>()),
+            Times.Exactly(StepNames.Length));
+
+        metrics.Verify(m => m.RecordStepDurationAsync(
+                It.IsAny<Guid>(),
+                It.IsAny<PdfProcessingState>(),
+                It.IsAny<TimeSpan>(),
+                It.IsAny<long>(),
+                0,
+                It.IsAny<Guid?>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Infrastructure/Services/ProcessingMetricsServiceTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Infrastructure/Services/ProcessingMetricsServiceTests.cs
@@ -77,6 +77,54 @@ public sealed class ProcessingMetricsServiceTests : IDisposable
     }
 
     [Fact]
+    public async Task RecordStepDurationAsync_ZeroPageCount_ThrowsArgumentException()
+    {
+        // Regression for Issue #2661: a stale/unpopulated PageCount reaches this service
+        // as 0 (PdfProcessingQuartzJob passes "PageCount ?? 0"). The guard must reject it so
+        // the caller never persists a metric with an invalid page count.
+        // Arrange
+        var pdfId = Guid.NewGuid();
+
+        // Act
+        var act = async () => await _service.RecordStepDurationAsync(
+            pdfId,
+            PdfProcessingState.Extracting,
+            TimeSpan.FromSeconds(10),
+            1024000,
+            pageCount: 0);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage("*Page count must be positive*")
+            .Where(ex => ex.ParamName == "pageCount");
+
+        // And nothing was persisted
+        var metric = await _context.ProcessingMetrics
+            .FirstOrDefaultAsync(m => m.PdfDocumentId == pdfId);
+        metric.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task RecordStepDurationAsync_NegativePageCount_ThrowsArgumentException()
+    {
+        // Arrange
+        var pdfId = Guid.NewGuid();
+
+        // Act
+        var act = async () => await _service.RecordStepDurationAsync(
+            pdfId,
+            PdfProcessingState.Extracting,
+            TimeSpan.FromSeconds(10),
+            1024000,
+            pageCount: -1);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentException>()
+            .WithMessage("*Page count must be positive*")
+            .Where(ex => ex.ParamName == "pageCount");
+    }
+
+    [Fact]
     public async Task GetAverageDurationAsync_NoData_ReturnsZeroStatistics()
     {
         // Arrange

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/GameNight/AttachGamebookCampaignToGameNightCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/GameNight/AttachGamebookCampaignToGameNightCommandHandlerTests.cs
@@ -3,6 +3,7 @@ using Api.BoundedContexts.Authentication.Application.Queries;
 using Api.BoundedContexts.GameManagement.Application.Commands.GameNights;
 using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
 using Api.BoundedContexts.GameManagement.Domain.Enums;
+using Api.BoundedContexts.GameManagement.Domain.Exceptions;
 using Api.BoundedContexts.SessionTracking.Application.Commands;
 using Api.BoundedContexts.SessionTracking.Application.DTOs;
 using Api.BoundedContexts.SessionTracking.Application.Queries;
@@ -13,6 +14,7 @@ using Api.SharedKernel.Infrastructure.Persistence;
 using Api.Tests.Constants;
 using FluentAssertions;
 using MediatR;
+using Microsoft.EntityFrameworkCore;
 using Moq;
 using Xunit;
 
@@ -140,6 +142,53 @@ public class AttachGamebookCampaignToGameNightCommandHandlerTests
                 c.Participants[0].IsOwner &&
                 c.Participants[0].DisplayName == "Marco Rossi"),
             It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_HappyPath_WrapsWorkInCommittedTransaction()
+    {
+        var organizer = Guid.NewGuid();
+        var gameNight = CreatePublishedEvent(organizer);
+        var campaignId = Guid.NewGuid();
+        SetupCampaign(campaignId, CampaignDto(campaignId, Guid.NewGuid(), organizer, GameRefKind.Shared));
+        SetupCreateSession(Guid.NewGuid());
+        SetupUser(organizer, "Marco Rossi");
+        _repo.Setup(r => r.GetByIdAsync(gameNight.Id, It.IsAny<CancellationToken>())).ReturnsAsync(gameNight);
+
+        await _handler.Handle(
+            new AttachGamebookCampaignToGameNightCommand(gameNight.Id, campaignId, organizer),
+            TestContext.Current.CancellationToken);
+
+        _uow.Verify(u => u.BeginTransactionAsync(It.IsAny<CancellationToken>()), Times.Once);
+        _uow.Verify(u => u.CommitTransactionAsync(It.IsAny<CancellationToken>()), Times.Once);
+        _uow.Verify(u => u.RollbackTransactionAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_ConcurrentXminLoser_RollsBackTransaction_Throws409()
+    {
+        // The xmin loser's aggregate SaveChanges throws; the whole tx (incl. the cross-BC Session
+        // INSERT) must roll back so no orphan Session survives, then map to the blocked-modal 409.
+        var organizer = Guid.NewGuid();
+        var gameNight = CreatePublishedEvent(organizer);
+        var campaignId = Guid.NewGuid();
+        SetupCampaign(campaignId, CampaignDto(campaignId, Guid.NewGuid(), organizer, GameRefKind.Shared));
+        SetupCreateSession(Guid.NewGuid());
+        SetupUser(organizer, "Marco Rossi");
+        _repo.Setup(r => r.GetByIdAsync(gameNight.Id, It.IsAny<CancellationToken>())).ReturnsAsync(gameNight);
+        _uow.Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new DbUpdateConcurrencyException());
+
+        var act = () => _handler.Handle(
+            new AttachGamebookCampaignToGameNightCommand(gameNight.Id, campaignId, organizer),
+            TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<MaxLiveSessionsExceededException>();
+        _uow.Verify(u => u.BeginTransactionAsync(It.IsAny<CancellationToken>()), Times.Once);
+        _uow.Verify(u => u.RollbackTransactionAsync(It.IsAny<CancellationToken>()), Times.Once);
+        _uow.Verify(u => u.CommitTransactionAsync(It.IsAny<CancellationToken>()), Times.Never);
+        _mediator.Verify(m => m.Send(It.IsAny<OpenSessionLiveModeCommand>(), It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 
     [Fact]

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/GameNight/GetGameNightLiveQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/GameNight/GetGameNightLiveQueryHandlerTests.cs
@@ -1,9 +1,13 @@
 using Api.BoundedContexts.GameManagement.Application.Queries.GameNights;
 using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
 using Api.BoundedContexts.GameManagement.Domain.Enums;
+using Api.Infrastructure;
 using Api.Middleware.Exceptions;
+using Api.SharedKernel.Application.Services;
 using Api.Tests.Constants;
 using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
 using Moq;
 using Xunit;
 
@@ -15,14 +19,26 @@ namespace Api.Tests.BoundedContexts.GameManagement.Application.GameNight;
 /// </summary>
 [Trait("Category", TestCategories.Unit)]
 [Trait("BoundedContext", "GameManagement")]
-public class GetGameNightLiveQueryHandlerTests
+public class GetGameNightLiveQueryHandlerTests : IDisposable
 {
     private readonly Mock<IGameNightEventRepository> _repo = new();
+    private readonly MeepleAiDbContext _db;
     private readonly GetGameNightLiveQueryHandler _handler;
 
     public GetGameNightLiveQueryHandlerTests()
     {
-        _handler = new GetGameNightLiveQueryHandler(_repo.Object);
+        var options = new DbContextOptionsBuilder<MeepleAiDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        _db = new MeepleAiDbContext(
+            options, new Mock<IMediator>().Object, new Mock<IDomainEventCollector>().Object);
+        _handler = new GetGameNightLiveQueryHandler(_repo.Object, _db);
+    }
+
+    public void Dispose()
+    {
+        _db.Dispose();
+        GC.SuppressFinalize(this);
     }
 
     [Fact]
@@ -57,6 +73,62 @@ public class GetGameNightLiveQueryHandlerTests
         result.Sessions[1].GameTitle.Should().Be("Spirit Island");
         result.Sessions[1].Status.Should().Be(GameNightSessionStatus.Pending);
         result.Sessions[1].StartedAt.Should().BeNull();
+    }
+
+    // WS1 DEC-9: the read model exposes whether the viewer is the organizer, so the FE
+    // renders the organizer-only "Avvia prossimo gioco" CTA only for them.
+    [Fact]
+    public async Task Handle_ViewerIsOrganizer_IsViewerOrganizerTrue()
+    {
+        var evt = GameNightEvent.Create(
+            Guid.NewGuid(), "Serata", DateTimeOffset.UtcNow.AddHours(1), gameIds: [Guid.NewGuid()]);
+        evt.Publish([]);
+        _repo.Setup(r => r.GetByIdAsync(evt.Id, It.IsAny<CancellationToken>())).ReturnsAsync(evt);
+
+        var result = await _handler.Handle(
+            new GetGameNightLiveQuery(evt.Id, evt.OrganizerId), TestContext.Current.CancellationToken);
+
+        result.IsViewerOrganizer.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Handle_ViewerIsInvitedNonOrganizer_IsViewerOrganizerFalse()
+    {
+        var invitedUserId = Guid.NewGuid();
+        var evt = GameNightEvent.Create(
+            Guid.NewGuid(), "Serata", DateTimeOffset.UtcNow.AddHours(1), gameIds: [Guid.NewGuid()]);
+        evt.Publish([invitedUserId]); // creates an RSVP → invited participant
+        _repo.Setup(r => r.GetByIdAsync(evt.Id, It.IsAny<CancellationToken>())).ReturnsAsync(evt);
+
+        var result = await _handler.Handle(
+            new GetGameNightLiveQuery(evt.Id, invitedUserId), TestContext.Current.CancellationToken);
+
+        result.IsViewerOrganizer.Should().BeFalse();
+    }
+
+    // WS1 DEC-9: the read model exposes the un-started planned games (with titles) so the
+    // organizer CTA knows which game to start next.
+    [Fact]
+    public async Task Handle_ExposesUnstartedPlannedLineupWithTitles()
+    {
+        var g1 = Guid.NewGuid();
+        var g2 = Guid.NewGuid();
+        _db.SharedGames.Add(new Api.Infrastructure.Entities.SharedGameCatalog.SharedGameEntity { Id = g1, Title = "Brass" });
+        _db.SharedGames.Add(new Api.Infrastructure.Entities.SharedGameCatalog.SharedGameEntity { Id = g2, Title = "Catan" });
+        await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var evt = GameNightEvent.Create(
+            Guid.NewGuid(), "Serata", DateTimeOffset.UtcNow.AddHours(1), gameIds: [g1, g2]);
+        evt.Publish([]);
+        evt.AddSession(Guid.NewGuid(), g1, "Brass"); // g1 started; g2 remains un-started
+        _repo.Setup(r => r.GetByIdAsync(evt.Id, It.IsAny<CancellationToken>())).ReturnsAsync(evt);
+
+        var result = await _handler.Handle(
+            new GetGameNightLiveQuery(evt.Id, evt.OrganizerId), TestContext.Current.CancellationToken);
+
+        result.PlannedLineup.Should().ContainSingle();
+        result.PlannedLineup[0].GameId.Should().Be(g2);
+        result.PlannedLineup[0].GameTitle.Should().Be("Catan");
     }
 
     [Fact]

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/GameNight/StartGameNightSessionCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/GameNight/StartGameNightSessionCommandHandlerTests.cs
@@ -6,10 +6,12 @@ using Api.BoundedContexts.GameManagement.Domain.Enums;
 using Api.BoundedContexts.SessionTracking.Application.Commands;
 using Api.BoundedContexts.SessionTracking.Application.DTOs;
 using Api.BoundedContexts.SessionTracking.Domain.Services;
+using Api.BoundedContexts.GameManagement.Domain.Exceptions;
 using Api.Middleware.Exceptions;
 using Api.SharedKernel.Infrastructure.Persistence;
 using Api.Tests.Constants;
 using MediatR;
+using Microsoft.EntityFrameworkCore;
 using Moq;
 using Xunit;
 
@@ -291,6 +293,68 @@ public class StartGameNightSessionCommandHandlerTests
             () => _handler.Handle(command, CancellationToken.None));
 
         _mockMediator.Verify(m => m.Send(It.IsAny<CreateSessionCommand>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_HappyPath_WrapsWorkInCommittedTransaction()
+    {
+        // Arrange — the cross-BC Session INSERT + the aggregate link must be ONE atomic tx so a
+        // later failure cannot leave the Session orphaned (WS1 DEC-5 hardening).
+        var gameNight = CreatePublishedEvent();
+
+        _mockRepository.Setup(r => r.GetByIdAsync(gameNight.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(gameNight);
+        _mockMediator.Setup(m => m.Send(It.IsAny<GetUserByIdQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateOrganizerDto(gameNight.OrganizerId));
+        _mockMediator.Setup(m => m.Send(It.IsAny<CreateSessionCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new CreateSessionResult(
+                Guid.NewGuid(), "ABC123", [], GameNightEventId: gameNight.Id,
+                GameNightWasCreated: false, AgentDefinitionId: null, ToolkitId: null));
+
+        var command = new StartGameNightSessionCommand(
+            gameNight.Id, gameNight.GameIds[0], "Catan", gameNight.OrganizerId);
+
+        // Act
+        await _handler.Handle(command, CancellationToken.None);
+
+        // Assert — begun + committed exactly once, never rolled back.
+        _mockUnitOfWork.Verify(u => u.BeginTransactionAsync(It.IsAny<CancellationToken>()), Times.Once);
+        _mockUnitOfWork.Verify(u => u.CommitTransactionAsync(It.IsAny<CancellationToken>()), Times.Once);
+        _mockUnitOfWork.Verify(u => u.RollbackTransactionAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_ConcurrentXminLoser_RollsBackTransaction_Throws409()
+    {
+        // Arrange — two concurrent starts both pass the in-memory guard; the xmin loser's aggregate
+        // SaveChanges throws DbUpdateConcurrencyException. The whole tx (incl. the cross-BC Session
+        // INSERT) must roll back so no orphan Session survives, then map to the blocked-modal 409.
+        var gameNight = CreatePublishedEvent();
+
+        _mockRepository.Setup(r => r.GetByIdAsync(gameNight.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(gameNight);
+        _mockMediator.Setup(m => m.Send(It.IsAny<GetUserByIdQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateOrganizerDto(gameNight.OrganizerId));
+        _mockMediator.Setup(m => m.Send(It.IsAny<CreateSessionCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new CreateSessionResult(
+                Guid.NewGuid(), "ABC123", [], GameNightEventId: gameNight.Id,
+                GameNightWasCreated: false, AgentDefinitionId: null, ToolkitId: null));
+        _mockUnitOfWork.Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new DbUpdateConcurrencyException());
+
+        var command = new StartGameNightSessionCommand(
+            gameNight.Id, gameNight.GameIds[0], "Catan", gameNight.OrganizerId);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<MaxLiveSessionsExceededException>(
+            () => _handler.Handle(command, CancellationToken.None));
+
+        _mockUnitOfWork.Verify(u => u.BeginTransactionAsync(It.IsAny<CancellationToken>()), Times.Once);
+        _mockUnitOfWork.Verify(u => u.RollbackTransactionAsync(It.IsAny<CancellationToken>()), Times.Once);
+        _mockUnitOfWork.Verify(u => u.CommitTransactionAsync(It.IsAny<CancellationToken>()), Times.Never);
+        // The blocked start must NOT open live mode on a rolled-back session.
+        _mockMediator.Verify(m => m.Send(It.IsAny<OpenSessionLiveModeCommand>(), It.IsAny<CancellationToken>()),
             Times.Never);
     }
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/Entities/GameNightEventMaxLiveTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/Entities/GameNightEventMaxLiveTests.cs
@@ -79,10 +79,44 @@ public class GameNightEventMaxLiveTests
         gn.Sessions[1].Status.Should().Be(GameNightSessionStatus.InProgress);
     }
 
+    // WS1 DEC-4: guard-before-create. EnsureCanStartSession() lets the handler reject
+    // a blocked 2nd-open BEFORE CreateSessionCommand mints a durable (orphan) Session.
+    [Fact]
+    public void EnsureCanStartSession_WhenAnotherLiveActive_ThrowsMaxLiveSessionsExceeded()
+    {
+        var gn = CreatePublishedEventWithTwoSessions();
+        gn.StartCurrentSession(); // first InProgress
+
+        var act = () => gn.EnsureCanStartSession();
+
+        act.Should().Throw<MaxLiveSessionsExceededException>()
+            .Where(ex => ex.GameNightEventId == gn.Id);
+    }
+
+    [Fact]
+    public void EnsureCanStartSession_WhenNoneLive_DoesNotThrow()
+    {
+        var gn = CreatePublishedEventWithTwoSessions(); // both Pending
+
+        var act = () => gn.EnsureCanStartSession();
+
+        act.Should().NotThrow();
+    }
+
     [Fact]
     public void MaxLiveSessionsExceededException_ExposesCorrectErrorCode()
     {
         MaxLiveSessionsExceededException.Code.Should().Be("MAX_LIVE_SESSIONS_EXCEEDED");
+    }
+
+    // WS1 DEC-7: the HTTP-layer ErrorCode (which reaches the 409 body) must carry
+    // the discriminable Code, not the generic "conflict", so the FE can tell the
+    // max-1-live 409 apart from a "no pending session" 409.
+    [Fact]
+    public void MaxLiveSessionsExceededException_ErrorCodeProperty_IsDiscriminable()
+    {
+        var ex = new MaxLiveSessionsExceededException(Guid.NewGuid());
+        ex.ErrorCode.Should().Be("MAX_LIVE_SESSIONS_EXCEEDED");
     }
 
     [Fact]

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Commands/OpenSessionLiveModeCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Commands/OpenSessionLiveModeCommandHandlerTests.cs
@@ -1,0 +1,69 @@
+using Api.BoundedContexts.SessionTracking.Application.Commands;
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SessionTracking.Application.Commands;
+
+/// <summary>
+/// Unit tests for <see cref="OpenSessionLiveModeCommandHandler"/> (WS1 DEC-1/6, issue #2647):
+/// opens live mode on a tracking Session, idempotent when already live, NotFound when missing.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SessionTracking")]
+public sealed class OpenSessionLiveModeCommandHandlerTests
+{
+    private readonly Mock<ISessionRepository> _repo = new();
+    private readonly Mock<IUnitOfWork> _uow = new();
+
+    private OpenSessionLiveModeCommandHandler CreateHandler() => new(_repo.Object, _uow.Object);
+
+    private static Session NewSession() =>
+        Session.Create(Guid.NewGuid(), Guid.NewGuid(), SessionType.GameSpecific);
+
+    [Fact]
+    public async Task Handle_OpensLiveMode_SetsStartedAt_AndSaves()
+    {
+        var session = NewSession();
+        _repo.Setup(r => r.GetByIdAsync(session.Id, It.IsAny<CancellationToken>())).ReturnsAsync(session);
+
+        await CreateHandler().Handle(new OpenSessionLiveModeCommand(session.Id), CancellationToken.None);
+
+        session.IsLive.Should().BeTrue();
+        session.StartedAt.Should().NotBeNull();
+        _repo.Verify(r => r.UpdateAsync(session, It.IsAny<CancellationToken>()), Times.Once);
+        _uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WhenAlreadyLive_IsIdempotent_NoThrow_NoSave()
+    {
+        var session = NewSession();
+        session.OpenLiveMode(); // already live
+        _repo.Setup(r => r.GetByIdAsync(session.Id, It.IsAny<CancellationToken>())).ReturnsAsync(session);
+
+        var act = async () =>
+            await CreateHandler().Handle(new OpenSessionLiveModeCommand(session.Id), CancellationToken.None);
+
+        await act.Should().NotThrowAsync();
+        _repo.Verify(r => r.UpdateAsync(It.IsAny<Session>(), It.IsAny<CancellationToken>()), Times.Never);
+        _uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_WhenSessionMissing_ThrowsNotFound()
+    {
+        _repo.Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Session?)null);
+
+        var act = async () =>
+            await CreateHandler().Handle(new OpenSessionLiveModeCommand(Guid.NewGuid()), CancellationToken.None);
+
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Handlers/CreateSessionCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Handlers/CreateSessionCommandHandlerTests.cs
@@ -261,4 +261,91 @@ public sealed class CreateSessionCommandHandlerTests : IDisposable
         _sessionRepoMock.Verify(r => r.AddAsync(It.IsAny<Api.BoundedContexts.SessionTracking.Domain.Entities.Session>(), It.IsAny<CancellationToken>()), Times.Once);
         _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.AtLeastOnce);
     }
+
+    // WS1 DEC-3 (#2633): the game-night orchestrators own the session↔night link on the
+    // GameNightEvent aggregate, so SkipGameNightEnvelope=true must create ONLY the tracking
+    // Session — no phantom ad-hoc night, no game_night_sessions link, no game-night diary rows.
+    // (This is the fix for the phantom double-link that made FindByLinkedSessionIdAsync
+    // nondeterministic and broke #2633.)
+    [Fact]
+    public async Task Handle_WithSkipGameNightEnvelope_CreatesNoNightNoLinkNoDiary()
+    {
+        var userId = Guid.NewGuid();
+        _db.Users.Add(new Api.Infrastructure.Entities.UserEntity
+        {
+            Id = userId,
+            Email = "skip@example.com",
+            Role = "user",
+            Tier = "free"
+        });
+        await _db.SaveChangesAsync();
+
+        _quotaServiceMock
+            .Setup(s => s.CheckQuotaAsync(
+                userId,
+                It.IsAny<Api.SharedKernel.Domain.ValueObjects.UserTier>(),
+                It.IsAny<Api.SharedKernel.Domain.ValueObjects.Role>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SessionQuotaResult.Allowed(0, 3));
+
+        var command = new CreateSessionCommand(
+            userId,
+            Guid.NewGuid(),
+            "Generic",
+            null,
+            null,
+            [new ParticipantDto { DisplayName = "Owner", IsOwner = true, UserId = userId }],
+            SkipGameNightEnvelope: true);
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.Equal(Guid.Empty, result.GameNightEventId);
+        Assert.False(result.GameNightWasCreated);
+        Assert.Empty(_db.ChangeTracker.Entries<Api.Infrastructure.Entities.GameManagement.GameNightEventEntity>());
+        Assert.Empty(_db.ChangeTracker.Entries<Api.Infrastructure.Entities.GameManagement.GameNightSessionEntity>());
+        Assert.Empty(_db.ChangeTracker.Entries<Api.Infrastructure.Entities.SessionTracking.SessionEventEntity>());
+        _sessionRepoMock.Verify(
+            r => r.AddAsync(It.IsAny<Api.BoundedContexts.SessionTracking.Domain.Entities.Session>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    // Regression: the direct one-click flow (default SkipGameNightEnvelope=false) still mints
+    // the ad-hoc InProgress night + link + diary — WS1 must not change it.
+    [Fact]
+    public async Task Handle_WithoutSkip_CreatesAdHocNightAndLinkAndDiary()
+    {
+        var userId = Guid.NewGuid();
+        _db.Users.Add(new Api.Infrastructure.Entities.UserEntity
+        {
+            Id = userId,
+            Email = "noskip@example.com",
+            Role = "user",
+            Tier = "free"
+        });
+        await _db.SaveChangesAsync();
+
+        _quotaServiceMock
+            .Setup(s => s.CheckQuotaAsync(
+                userId,
+                It.IsAny<Api.SharedKernel.Domain.ValueObjects.UserTier>(),
+                It.IsAny<Api.SharedKernel.Domain.ValueObjects.Role>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SessionQuotaResult.Allowed(0, 3));
+
+        var command = new CreateSessionCommand(
+            userId,
+            Guid.NewGuid(),
+            "Generic",
+            null,
+            null,
+            [new ParticipantDto { DisplayName = "Owner", IsOwner = true, UserId = userId }]);
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.NotEqual(Guid.Empty, result.GameNightEventId);
+        Assert.True(result.GameNightWasCreated);
+        Assert.Single(_db.ChangeTracker.Entries<Api.Infrastructure.Entities.GameManagement.GameNightEventEntity>());
+        Assert.Single(_db.ChangeTracker.Entries<Api.Infrastructure.Entities.GameManagement.GameNightSessionEntity>());
+        Assert.NotEmpty(_db.ChangeTracker.Entries<Api.Infrastructure.Entities.SessionTracking.SessionEventEntity>());
+    }
 }

--- a/apps/api/tests/Api.Tests/Infrastructure/Seeders/Catalog/PdfSeederBlobTests.cs
+++ b/apps/api/tests/Api.Tests/Infrastructure/Seeders/Catalog/PdfSeederBlobTests.cs
@@ -1,3 +1,4 @@
+using Api.BoundedContexts.DocumentProcessing.Application.Services;
 using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
 using Api.Infrastructure;
 using Api.Infrastructure.Entities;
@@ -296,6 +297,212 @@ public sealed class PdfSeederBlobTests
         _seedBlob.Verify(x => x.OpenReadAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
         _primaryBlob.Verify(x => x.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
         db.PdfDocuments.Should().BeEmpty();
+    }
+
+    // ===============================================================
+    // Repair mode (#2666): DB-only snapshot restore leaves the record
+    // intact but the blob missing from the runtime bucket. The seeder
+    // must verify blob presence before the idempotency skip and re-upload
+    // from the seed bucket using the EXISTING id when the blob is gone.
+    // ===============================================================
+
+    // ---------------------------------------------------------------
+    // Repair (a): record exists + blob PRESENT in runtime → plain skip
+    // ---------------------------------------------------------------
+    [Fact]
+    public async Task SeedAsync_ExistingHash_BlobPresentInRuntime_SkipsWithoutReupload()
+    {
+        // Arrange
+        var gameId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var existingId = Guid.NewGuid();
+        _seedBlob.Setup(x => x.IsConfigured).Returns(true);
+
+        // Runtime blob is present → seeder must NOT re-upload nor mutate the record.
+        _primaryBlob.Setup(x => x.ExistsAsync(It.IsAny<string>(), BlobCategory.Pdf, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var manifest = CreateManifest(CreateBlobEntry(pdfSha256: "samehash"));
+        var gameMap = new Dictionary<int, Guid> { { 174430, gameId } };
+        using var db = TestDbContextFactory.CreateInMemoryDbContext();
+
+        db.Users.Add(new UserEntity { Id = userId, Email = "system@test.com", PasswordHash = "hash" });
+        db.SharedGames.Add(new SharedGameEntity { Id = gameId, Title = "Gloomhaven" });
+        db.PdfDocuments.Add(new PdfDocumentEntity
+        {
+            Id = existingId,
+            SharedGameId = gameId,
+            FileName = "gloomhaven.pdf",
+            // FilePath carries the fileId (deadbeef) so ExtractFileIdFromPath can build the ExistsAsync probe.
+            FilePath = $"pdfs/{PdfStorageKey.ForPdf(existingId)}/deadbeef_gloomhaven.pdf",
+            ContentHash = "samehash",
+            ProcessingState = nameof(PdfProcessingState.Ready),
+            UploadedByUserId = userId,
+            DocumentType = "base",
+            DocumentCategory = "Rulebook",
+        });
+        await db.SaveChangesAsync();
+
+        // Act
+        await PdfSeeder.SeedAsync(db, manifest, gameMap, userId,
+            _primaryBlob.Object, _seedBlob.Object, _logger.Object, CancellationToken.None);
+
+        // Assert — presence check happened, but no re-upload and no state change.
+        _primaryBlob.Verify(x => x.ExistsAsync(It.IsAny<string>(), BlobCategory.Pdf, It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
+        _seedBlob.Verify(x => x.OpenReadAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        _primaryBlob.Verify(x => x.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+
+        var doc = db.PdfDocuments.Single(p => p.Id == existingId);
+        doc.ProcessingState.Should().Be(nameof(PdfProcessingState.Ready));
+        db.ProcessingJobs.Should().BeEmpty();
+    }
+
+    // ---------------------------------------------------------------
+    // Repair (b): record exists + blob ABSENT in runtime + present in
+    //             seed → repair: re-upload against existing id, reset to
+    //             Pending, clear error fields, re-enqueue ProcessingJob.
+    // ---------------------------------------------------------------
+    [Fact]
+    public async Task SeedAsync_ExistingHash_BlobMissingInRuntimeButInSeed_RepairsInPlace()
+    {
+        // Arrange
+        var gameId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var existingId = Guid.NewGuid();
+        _seedBlob.Setup(x => x.IsConfigured).Returns(true);
+
+        // Runtime blob is GONE (snapshot DB-only restore), but the seed bucket still has it.
+        _primaryBlob.Setup(x => x.ExistsAsync(It.IsAny<string>(), BlobCategory.Pdf, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        _seedBlob.Setup(x => x.ExistsAsync("rulebooks/v1/gloomhaven.pdf", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        _seedBlob.Setup(x => x.OpenReadAsync("rulebooks/v1/gloomhaven.pdf", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new MemoryStream(new byte[] { 0x25, 0x50, 0x44, 0x46 }));
+
+        string? capturedResourceKey = null;
+        _primaryBlob.Setup(x => x.StoreAsync(It.IsAny<Stream>(), "gloomhaven.pdf", BlobCategory.Pdf, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Callback<Stream, string, BlobCategory, string, CancellationToken>((_, _, _, rk, _) => capturedResourceKey = rk)
+            .ReturnsAsync(new BlobStorageResult(true, "newfile", "pdfs/repaired/newfile_gloomhaven.pdf", 4));
+
+        var manifest = CreateManifest(CreateBlobEntry(pdfSha256: "samehash"));
+        var gameMap = new Dictionary<int, Guid> { { 174430, gameId } };
+        using var db = TestDbContextFactory.CreateInMemoryDbContext();
+
+        db.Users.Add(new UserEntity { Id = userId, Email = "system@test.com", PasswordHash = "hash" });
+        db.SharedGames.Add(new SharedGameEntity { Id = gameId, Title = "Gloomhaven" });
+        db.PdfDocuments.Add(new PdfDocumentEntity
+        {
+            Id = existingId,
+            SharedGameId = gameId,
+            FileName = "gloomhaven.pdf",
+            FilePath = $"pdfs/{PdfStorageKey.ForPdf(existingId)}/deadbeef_gloomhaven.pdf",
+            FileSizeBytes = 999,
+            ContentHash = "samehash",
+            // The exact broken state observed on staging.
+            ProcessingState = nameof(PdfProcessingState.Failed),
+            ProcessingError = "PDF file not found in blob storage",
+            ErrorCategory = "Service",
+            FailedAtState = "Extracting",
+            RetryCount = 2,
+            UploadedByUserId = userId,
+            DocumentType = "base",
+            DocumentCategory = "Rulebook",
+        });
+        await db.SaveChangesAsync();
+
+        // Act
+        await PdfSeeder.SeedAsync(db, manifest, gameMap, userId,
+            _primaryBlob.Object, _seedBlob.Object, _logger.Object, CancellationToken.None);
+
+        // Assert — re-uploaded against the EXISTING id's bucket key (NOT a new Guid).
+        _primaryBlob.Verify(x => x.StoreAsync(It.IsAny<Stream>(), "gloomhaven.pdf", BlobCategory.Pdf, It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
+        capturedResourceKey.Should().Be(PdfStorageKey.ForPdf(existingId));
+
+        // Record is repaired in place: same id, reset to Pending, error fields cleared, new blob path/size.
+        var docs = db.PdfDocuments.ToList();
+        docs.Should().HaveCount(1);
+        var doc = docs[0];
+        doc.Id.Should().Be(existingId);
+        doc.ProcessingState.Should().Be(nameof(PdfProcessingState.Pending));
+        doc.FilePath.Should().Be("pdfs/repaired/newfile_gloomhaven.pdf");
+        doc.FileSizeBytes.Should().Be(4);
+        doc.ProcessingError.Should().BeNull();
+        doc.ErrorCategory.Should().BeNull();
+        doc.FailedAtState.Should().BeNull();
+        doc.RetryCount.Should().Be(0);
+
+        // A fresh ProcessingJob is enqueued for the repaired PDF (5 Queued steps).
+        var jobs = db.ProcessingJobs.Include(j => j.Steps).ToList();
+        jobs.Should().HaveCount(1);
+        var job = jobs[0];
+        job.PdfDocumentId.Should().Be(existingId);
+        job.UserId.Should().Be(userId);
+        job.Status.Should().Be(nameof(JobStatus.Queued));
+        job.Steps.Should().HaveCount(5);
+        job.Steps.Select(s => s.StepName).Should().BeEquivalentTo(new[]
+        {
+            nameof(ProcessingStepType.Upload),
+            nameof(ProcessingStepType.Extract),
+            nameof(ProcessingStepType.Chunk),
+            nameof(ProcessingStepType.Embed),
+            nameof(ProcessingStepType.Index),
+        });
+        job.Steps.Should().OnlyContain(s => s.Status == "Pending");
+    }
+
+    // ---------------------------------------------------------------
+    // Repair (c): record exists + blob ABSENT in BOTH runtime and seed
+    //             → log warning, no crash, no re-upload, no state change.
+    // ---------------------------------------------------------------
+    [Fact]
+    public async Task SeedAsync_ExistingHash_BlobMissingInRuntimeAndSeed_LeavesRecordUntouched()
+    {
+        // Arrange
+        var gameId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var existingId = Guid.NewGuid();
+        _seedBlob.Setup(x => x.IsConfigured).Returns(true);
+
+        // Blob gone from BOTH buckets → irrecoverable, must not crash and must not mutate.
+        _primaryBlob.Setup(x => x.ExistsAsync(It.IsAny<string>(), BlobCategory.Pdf, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        _seedBlob.Setup(x => x.ExistsAsync("rulebooks/v1/gloomhaven.pdf", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var manifest = CreateManifest(CreateBlobEntry(pdfSha256: "samehash"));
+        var gameMap = new Dictionary<int, Guid> { { 174430, gameId } };
+        using var db = TestDbContextFactory.CreateInMemoryDbContext();
+
+        db.Users.Add(new UserEntity { Id = userId, Email = "system@test.com", PasswordHash = "hash" });
+        db.SharedGames.Add(new SharedGameEntity { Id = gameId, Title = "Gloomhaven" });
+        db.PdfDocuments.Add(new PdfDocumentEntity
+        {
+            Id = existingId,
+            SharedGameId = gameId,
+            FileName = "gloomhaven.pdf",
+            FilePath = $"pdfs/{PdfStorageKey.ForPdf(existingId)}/deadbeef_gloomhaven.pdf",
+            ContentHash = "samehash",
+            ProcessingState = nameof(PdfProcessingState.Failed),
+            ProcessingError = "PDF file not found in blob storage",
+            UploadedByUserId = userId,
+            DocumentType = "base",
+            DocumentCategory = "Rulebook",
+        });
+        await db.SaveChangesAsync();
+
+        // Act
+        Func<Task> act = () => PdfSeeder.SeedAsync(db, manifest, gameMap, userId,
+            _primaryBlob.Object, _seedBlob.Object, _logger.Object, CancellationToken.None);
+
+        // Assert — no crash, no re-upload, record untouched, no job enqueued.
+        await act.Should().NotThrowAsync();
+        _seedBlob.Verify(x => x.OpenReadAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        _primaryBlob.Verify(x => x.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+
+        var doc = db.PdfDocuments.Single(p => p.Id == existingId);
+        doc.ProcessingState.Should().Be(nameof(PdfProcessingState.Failed));
+        doc.ProcessingError.Should().Be("PDF file not found in blob storage");
+        db.ProcessingJobs.Should().BeEmpty();
     }
 
     // ---------------------------------------------------------------

--- a/apps/api/tests/Api.Tests/Integration/SeedCatalogBlobIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/SeedCatalogBlobIntegrationTests.cs
@@ -247,8 +247,16 @@ public sealed class SeedCatalogBlobIntegrationTests
             .ReturnsAsync(() => new BlobStorageResult(
                 Success: true,
                 FileId: Guid.NewGuid().ToString(),
-                FilePath: "/blobs/x",
+                // Repair mode (#2666): FilePath must carry an extractable fileId so the
+                // second run can probe the runtime bucket for the existing record.
+                FilePath: "pdfs/bucket/abc123_barrage_rulebook.pdf",
                 FileSizeBytes: 4));
+        // Repair mode (#2666): the runtime blob IS present after the first store, so the
+        // second run's presence check must return true and short-circuit to a plain skip
+        // (no re-upload). Without this the seeder would treat the blob as missing and repair.
+        _primaryBlob
+            .Setup(x => x.ExistsAsync(It.IsAny<string>(), BlobCategory.Pdf, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
 
         // Act — run the seeder twice
         await PdfSeeder.SeedAsync(

--- a/apps/api/tests/Api.Tests/Integration/SessionTracking/SessionRepositoryUpdatePersistenceTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/SessionTracking/SessionRepositoryUpdatePersistenceTests.cs
@@ -1,0 +1,90 @@
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using Api.Infrastructure;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.Integration.SessionTracking;
+
+/// <summary>
+/// Regression for #2660: <see cref="ISessionRepository.UpdateAsync"/> must persist scalar
+/// domain mutations (StartedAt/FinalizedAt/Status/...) through the real pipeline.
+///
+/// The DbContext defaults to <c>QueryTrackingBehavior.NoTracking</c> (PERF-06), so the
+/// entity <c>UpdateAsync</c> loads to copy scalars onto must be loaded <c>.AsTracking()</c> —
+/// otherwise the mutation is a silent no-op and SaveChanges persists nothing. Existing tests
+/// missed this because they asserted <c>domain_event_logs</c> (which persist via the collector
+/// regardless of entity tracking), not the scalar columns.
+/// </summary>
+[Collection("Integration-GroupD")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "SessionTracking")]
+[Trait("Issue", "2660")]
+public sealed class SessionRepositoryUpdatePersistenceTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly string _databaseName = $"session_update_persist_{Guid.NewGuid():N}";
+    private WebApplicationFactory<Program> _factory = null!;
+
+    public SessionRepositoryUpdatePersistenceTests(SharedTestcontainersFixture fixture) => _fixture = fixture;
+
+    public async ValueTask InitializeAsync()
+    {
+        var conn = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+        await TestcontainersWaitHelpers.WaitForPostgresReadyAsync(conn);
+        _factory = IntegrationWebApplicationFactory.Create(conn);
+        using var scope = _factory.Services.CreateScope();
+        await scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>().Database.MigrateAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_factory != null) await _factory.DisposeAsync();
+        await _fixture.DropIsolatedDatabaseAsync(_databaseName);
+    }
+
+    [Fact(DisplayName = "#2660: UpdateAsync persists Session.StartedAt (OpenLiveMode) to the scalar column")]
+    public async Task UpdateAsync_PersistsStartedAt()
+    {
+        Guid sessionId;
+        await using (var scope = _factory.Services.CreateAsyncScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            var repo = scope.ServiceProvider.GetRequiredService<ISessionRepository>();
+            var uow = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+
+            var (userId, _) = await TestSessionHelper.CreateUserSessionAsync(db);
+            var gameId = await TestSessionHelper.SeedSharedGameAsync(db, title: "Update-Persist Game");
+            var session = Session.Create(userId, gameId, SessionType.Generic);
+            await repo.AddAsync(session, CancellationToken.None);
+            await uow.SaveChangesAsync(CancellationToken.None);
+            sessionId = session.Id;
+        }
+
+        await using (var scope = _factory.Services.CreateAsyncScope())
+        {
+            var repo = scope.ServiceProvider.GetRequiredService<ISessionRepository>();
+            var uow = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+
+            var session = await repo.GetByIdAsync(sessionId, CancellationToken.None);
+            session!.OpenLiveMode();
+            await repo.UpdateAsync(session, CancellationToken.None);
+            await uow.SaveChangesAsync(CancellationToken.None);
+        }
+
+        await using (var scope = _factory.Services.CreateAsyncScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            var entity = await db.SessionTrackingSessions.AsNoTracking().FirstAsync(s => s.Id == sessionId);
+            entity.StartedAt.Should().NotBeNull(
+                "UpdateAsync must persist the StartedAt scalar set by OpenLiveMode (#2660 — .AsTracking() under the NoTracking default)");
+        }
+    }
+}

--- a/apps/web/e2e/smoke.spec.ts
+++ b/apps/web/e2e/smoke.spec.ts
@@ -40,8 +40,16 @@ test.describe('Smoke Test — 8 step pre-deploy', () => {
 
   test('2. Auth login form visibile', async ({ page }) => {
     await page.goto('/login', { waitUntil: 'domcontentloaded' });
+    // Il login form è client-only: nell'SSR /login rende il fallback <Suspense>
+    // (useSearchParams), quindi l'input email esiste SOLO dopo l'hydration del
+    // bundle client. Sul runner self-hosted (chromium headless, VPS con cap
+    // memoria 3G) l'hydration supera consistentemente gli 8s → falso negativo
+    // (il form è renderizzato e funzionante, verificato in un browser reale).
+    // Timeout ampio (30s) per assorbire l'hydration lenta senza rallentare il
+    // caso normale (l'expect passa appena l'elemento appare). NON mockare
+    // /auth/me qui: simulerebbe un utente loggato → redirect via da /login.
     await expect(page.locator('input[type="email"], input[name="email"]').first()).toBeVisible({
-      timeout: 8000,
+      timeout: 30000,
     });
   });
 

--- a/apps/web/src/app/(authenticated)/game-nights/[id]/live/_components/NightLiveClientView.tsx
+++ b/apps/web/src/app/(authenticated)/game-nights/[id]/live/_components/NightLiveClientView.tsx
@@ -13,13 +13,14 @@
  * (LD-14) · empty-published happy path (LD-11).
  */
 
-import { useCallback, useEffect, type ReactNode } from 'react';
+import { useCallback, useEffect, useState, type ReactNode } from 'react';
 
 import { useRouter } from 'next/navigation';
 
-import { NightLiveHub } from '@/components/features/game-nights/live';
+import { BlockedLiveSessionModal, NightLiveHub } from '@/components/features/game-nights/live';
 import { ForbiddenError, NotFoundError, UnauthorizedError } from '@/lib/api/core/errors';
 import { useGameNightLive } from '@/lib/game-nights/hooks/useGameNightLive';
+import { isMaxLiveBlockedError, useStartNextGame } from '@/lib/game-nights/hooks/useStartNextGame';
 
 export interface NightLiveClientViewProps {
   readonly nightId: string;
@@ -43,6 +44,25 @@ export function NightLiveClientView({ nightId }: NightLiveClientViewProps) {
   const handleLogin = useCallback(() => {
     router.push('/login');
   }, [router]);
+
+  // WS1 DEC-10: organizer-only interactive start. The mutation is server-authoritative —
+  // on success we invalidate the read model (no optimistic flip); a max-1-live 409 surfaces
+  // the blocked modal instead of a generic toast.
+  const startNextGame = useStartNextGame(nightId);
+  const [blockedModalOpen, setBlockedModalOpen] = useState(false);
+  const handleStartNext = useCallback(
+    (gameId: string, gameTitle: string) => {
+      startNextGame.mutate(
+        { gameId, gameTitle },
+        {
+          onError: err => {
+            if (isMaxLiveBlockedError(err)) setBlockedModalOpen(true);
+          },
+        }
+      );
+    },
+    [startNextGame]
+  );
 
   // LD-14: a Completed night must not render a fake-live hub over stale data —
   // send the user to the summary they actually want. The effect fires only once
@@ -96,25 +116,52 @@ export function NightLiveClientView({ nightId }: NightLiveClientViewProps) {
     );
   }
 
-  // Published → the read-only live hub.
+  // Published → the read-only live hub + the organizer's interactive start CTA (WS1).
+  const nextGame = vm.nextGame;
+  const liveSessionId = vm.currentGame?.sessionId ?? null;
+  // DEC-10: hidden when a game is already live (status==='live') — you can only start the
+  // next game when the current one is over. The 409 modal is the backstop for races.
+  const showStartCta = vm.isViewerOrganizer && nextGame !== null && vm.status !== 'live';
+
   return (
-    <NightLiveHub
-      readOnly
-      night={vm.night}
-      status={vm.status}
-      current={vm.current}
-      total={vm.total}
-      elapsed={vm.elapsed}
-      confirmedPlayers={vm.confirmedPlayers}
-      totalPlayers={vm.totalPlayers}
-      plannedGames={vm.plannedGames}
-      currentGame={vm.currentGame}
-      diaryEvents={vm.diaryEvents}
-      diaryGames={vm.diaryGames}
-      diaryPlayers={vm.diaryPlayers}
-      onBack={handleBack}
-      onJumpToSession={handleJumpToSession}
-    />
+    <>
+      <NightLiveHub
+        readOnly
+        night={vm.night}
+        status={vm.status}
+        current={vm.current}
+        total={vm.total}
+        elapsed={vm.elapsed}
+        confirmedPlayers={vm.confirmedPlayers}
+        totalPlayers={vm.totalPlayers}
+        plannedGames={vm.plannedGames}
+        currentGame={vm.currentGame}
+        diaryEvents={vm.diaryEvents}
+        diaryGames={vm.diaryGames}
+        diaryPlayers={vm.diaryPlayers}
+        onBack={handleBack}
+        onJumpToSession={handleJumpToSession}
+      />
+
+      {showStartCta && nextGame ? (
+        <div className="fixed inset-x-0 bottom-0 z-40 flex justify-center p-4">
+          <button
+            type="button"
+            onClick={() => handleStartNext(nextGame.gameId, nextGame.gameTitle)}
+            disabled={startNextGame.isPending}
+            className="flex items-center gap-2 rounded-full border border-entity-session/40 bg-entity-session px-5 py-2.5 font-display text-sm font-extrabold text-white shadow-lg transition hover:bg-entity-session/90 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {startNextGame.isPending ? 'Avvio…' : `▶ Avvia: ${nextGame.gameTitle}`}
+          </button>
+        </div>
+      ) : null}
+
+      <BlockedLiveSessionModal
+        open={blockedModalOpen}
+        onClose={() => setBlockedModalOpen(false)}
+        onJumpToLive={liveSessionId ? () => handleJumpToSession(liveSessionId) : undefined}
+      />
+    </>
   );
 }
 

--- a/apps/web/src/app/(authenticated)/game-nights/[id]/live/_components/__tests__/NightLiveClientView.test.tsx
+++ b/apps/web/src/app/(authenticated)/game-nights/[id]/live/_components/__tests__/NightLiveClientView.test.tsx
@@ -14,11 +14,13 @@ import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 import {
+  ConflictError,
   ForbiddenError,
   NotFoundError,
   UnauthorizedError,
   NetworkError,
 } from '@/lib/api/core/errors';
+import { MAX_LIVE_SESSIONS_EXCEEDED } from '@/lib/game-nights/hooks/useStartNextGame';
 import type { NightLiveViewModel } from '@/lib/game-nights/mapNightLive';
 
 import { NightLiveClientView } from '../NightLiveClientView';
@@ -27,6 +29,18 @@ const useGameNightLiveMock = vi.hoisted(() => vi.fn());
 vi.mock('@/lib/game-nights/hooks/useGameNightLive', () => ({
   useGameNightLive: useGameNightLiveMock,
 }));
+
+// Mock only the mutation hook; keep isMaxLiveBlockedError + MAX_LIVE_SESSIONS_EXCEEDED real so the
+// view's real 409 discrimination is exercised (no QueryClientProvider needed in these tests).
+const startNextMutateMock = vi.hoisted(() => vi.fn());
+const startNextState = vi.hoisted(() => ({ isPending: false }));
+vi.mock('@/lib/game-nights/hooks/useStartNextGame', async importActual => {
+  const actual = await importActual<typeof import('@/lib/game-nights/hooks/useStartNextGame')>();
+  return {
+    ...actual,
+    useStartNextGame: () => ({ mutate: startNextMutateMock, isPending: startNextState.isPending }),
+  };
+});
 
 const pushMock = vi.fn();
 const replaceMock = vi.fn();
@@ -41,6 +55,8 @@ function vm(over: Partial<NightLiveViewModel> = {}): NightLiveViewModel {
   return {
     night: { title: 'Serata Eldoria' },
     nightStatus: 'Published',
+    isViewerOrganizer: false,
+    nextGame: null,
     status: 'live',
     current: 2,
     total: 3,
@@ -89,7 +105,10 @@ function mockQuery(over: Record<string, unknown>) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  startNextState.isPending = false;
 });
+
+const NEXT_GAME = { gameId: '77777777-7777-4777-8777-777777777777', gameTitle: 'Catan' };
 
 describe('NightLiveClientView — loading', () => {
   it('renders a loading skeleton while the query is pending', () => {
@@ -152,6 +171,72 @@ describe('NightLiveClientView — Published happy path', () => {
     });
     render(<NightLiveClientView nightId={NIGHT_ID} />);
     expect(screen.getByText('Nessun gioco pianificato')).toBeInTheDocument();
+  });
+});
+
+describe('NightLiveClientView — organizer interactive start (WS1 DEC-10)', () => {
+  it('does NOT render the start CTA for a non-organizer viewer', () => {
+    mockQuery({
+      data: vm({ isViewerOrganizer: false, nextGame: NEXT_GAME, status: 'transition' }),
+    });
+    render(<NightLiveClientView nightId={NIGHT_ID} />);
+    expect(screen.queryByRole('button', { name: /Avvia:/i })).toBeNull();
+  });
+
+  it('does NOT render the start CTA when there is no next game', () => {
+    mockQuery({ data: vm({ isViewerOrganizer: true, nextGame: null, status: 'transition' }) });
+    render(<NightLiveClientView nightId={NIGHT_ID} />);
+    expect(screen.queryByRole('button', { name: /Avvia:/i })).toBeNull();
+  });
+
+  it('hides the start CTA while a game is already live (status==="live")', () => {
+    mockQuery({ data: vm({ isViewerOrganizer: true, nextGame: NEXT_GAME, status: 'live' }) });
+    render(<NightLiveClientView nightId={NIGHT_ID} />);
+    expect(screen.queryByRole('button', { name: /Avvia:/i })).toBeNull();
+  });
+
+  it('renders the start CTA for the organizer when a next game is queued and no game is live', () => {
+    mockQuery({ data: vm({ isViewerOrganizer: true, nextGame: NEXT_GAME, status: 'transition' }) });
+    render(<NightLiveClientView nightId={NIGHT_ID} />);
+    expect(screen.getByRole('button', { name: /Avvia: Catan/i })).toBeInTheDocument();
+  });
+
+  it('starts the next game with its id + title on click', async () => {
+    mockQuery({ data: vm({ isViewerOrganizer: true, nextGame: NEXT_GAME, status: 'transition' }) });
+    render(<NightLiveClientView nightId={NIGHT_ID} />);
+    await userEvent.click(screen.getByRole('button', { name: /Avvia: Catan/i }));
+    expect(startNextMutateMock).toHaveBeenCalledWith(
+      { gameId: NEXT_GAME.gameId, gameTitle: NEXT_GAME.gameTitle },
+      expect.objectContaining({ onError: expect.any(Function) })
+    );
+  });
+
+  it('disables the CTA while the mutation is pending', () => {
+    startNextState.isPending = true;
+    mockQuery({ data: vm({ isViewerOrganizer: true, nextGame: NEXT_GAME, status: 'transition' }) });
+    render(<NightLiveClientView nightId={NIGHT_ID} />);
+    expect(screen.getByRole('button', { name: /Avvio/i })).toBeDisabled();
+  });
+
+  it('surfaces the blocked modal when the start returns a max-1-live 409', async () => {
+    startNextMutateMock.mockImplementation((_vars, opts) => {
+      opts?.onError?.(new ConflictError({ message: 'blocked', code: MAX_LIVE_SESSIONS_EXCEEDED }));
+    });
+    mockQuery({ data: vm({ isViewerOrganizer: true, nextGame: NEXT_GAME, status: 'transition' }) });
+    render(<NightLiveClientView nightId={NIGHT_ID} />);
+    await userEvent.click(screen.getByRole('button', { name: /Avvia: Catan/i }));
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /già una partita live/i })).toBeInTheDocument();
+  });
+
+  it('does NOT surface the blocked modal for a non-409 error', async () => {
+    startNextMutateMock.mockImplementation((_vars, opts) => {
+      opts?.onError?.(new Error('boom'));
+    });
+    mockQuery({ data: vm({ isViewerOrganizer: true, nextGame: NEXT_GAME, status: 'transition' }) });
+    render(<NightLiveClientView nightId={NIGHT_ID} />);
+    await userEvent.click(screen.getByRole('button', { name: /Avvia: Catan/i }));
+    expect(screen.queryByRole('dialog')).toBeNull();
   });
 });
 

--- a/apps/web/src/components/features/game-nights/live/BlockedLiveSessionModal.test.tsx
+++ b/apps/web/src/components/features/game-nights/live/BlockedLiveSessionModal.test.tsx
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { BlockedLiveSessionModal } from './BlockedLiveSessionModal';
+
+describe('BlockedLiveSessionModal', () => {
+  it('renders nothing when closed', () => {
+    render(<BlockedLiveSessionModal open={false} onClose={() => undefined} />);
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('renders the honest max-live copy when open', () => {
+    render(<BlockedLiveSessionModal open onClose={() => undefined} />);
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /già una partita live/i })).toBeInTheDocument();
+    expect(screen.getByText(/una sola partita live/i)).toBeInTheDocument();
+  });
+
+  it('renders the jump-to-live action only when onJumpToLive is provided', () => {
+    const { rerender } = render(<BlockedLiveSessionModal open onClose={() => undefined} />);
+    expect(screen.queryByRole('button', { name: /Apri la partita live/i })).toBeNull();
+
+    rerender(
+      <BlockedLiveSessionModal open onClose={() => undefined} onJumpToLive={() => undefined} />
+    );
+    expect(screen.getByRole('button', { name: /Apri la partita live/i })).toBeInTheDocument();
+  });
+
+  it('invokes onJumpToLive on the jump button', async () => {
+    const onJumpToLive = vi.fn();
+    render(<BlockedLiveSessionModal open onClose={() => undefined} onJumpToLive={onJumpToLive} />);
+    await userEvent.click(screen.getByRole('button', { name: /Apri la partita live/i }));
+    expect(onJumpToLive).toHaveBeenCalledTimes(1);
+  });
+
+  it('invokes onClose on the Chiudi button and on Escape', async () => {
+    const onClose = vi.fn();
+    render(<BlockedLiveSessionModal open onClose={onClose} />);
+    await userEvent.click(screen.getByRole('button', { name: 'Chiudi' }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    await userEvent.keyboard('{Escape}');
+    expect(onClose).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/web/src/components/features/game-nights/live/BlockedLiveSessionModal.tsx
+++ b/apps/web/src/components/features/game-nights/live/BlockedLiveSessionModal.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import { useEffect, type JSX } from 'react';
+
+export interface BlockedLiveSessionModalProps {
+  readonly open: boolean;
+  readonly onClose: () => void;
+  /** Jump to the session that is already live ("Aprila per continuare"). */
+  readonly onJumpToLive?: () => void;
+}
+
+/**
+ * #2633 WS1 DEC-10 / DEC-13: shown when starting a game returns the max-1-live 409
+ * (`MAX_LIVE_SESSIONS_EXCEEDED`). Honest copy — WS1 cannot complete a game, so it points the
+ * organizer at the running session rather than promising a resolution it does not offer.
+ */
+export function BlockedLiveSessionModal({
+  open,
+  onClose,
+  onJumpToLive,
+}: BlockedLiveSessionModalProps): JSX.Element | null {
+  // Global Escape: closes regardless of focus (mirrors NightLiveClientView's transition modal).
+  useEffect(() => {
+    if (!open) return undefined;
+    const handle = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handle);
+    return () => document.removeEventListener('keydown', handle);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4 backdrop-blur-sm"
+      style={{ background: 'rgba(0,0,0,0.45)' }}
+      role="presentation"
+      onClick={onClose}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="blocked-live-session-title"
+        onClick={e => e.stopPropagation()}
+        className="w-full max-w-sm rounded-xl border border-border bg-card p-5 text-center shadow-lg"
+      >
+        <h2
+          id="blocked-live-session-title"
+          className="font-display text-lg font-extrabold text-foreground"
+        >
+          C&apos;è già una partita live
+        </h2>
+        <p className="mt-2 font-mono text-sm text-muted-foreground">
+          Puoi avere una sola partita live per serata. Aprila per continuare.
+        </p>
+        <div className="mt-4 flex items-center justify-center gap-2">
+          {onJumpToLive ? (
+            <button
+              type="button"
+              onClick={onJumpToLive}
+              className="rounded-md border border-entity-session/30 bg-entity-session/10 px-4 py-2 font-display text-[13px] font-extrabold text-entity-session hover:bg-entity-session/15"
+            >
+              Apri la partita live
+            </button>
+          ) : null}
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md border border-border bg-card px-4 py-2 font-display text-[13px] font-extrabold text-foreground hover:bg-muted"
+          >
+            Chiudi
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/features/game-nights/live/index.ts
+++ b/apps/web/src/components/features/game-nights/live/index.ts
@@ -19,6 +19,9 @@ export type {
   PlannedGameWinner,
 } from '@/components/features/game-nights/live/PlannedGamesPane';
 
+export { BlockedLiveSessionModal } from '@/components/features/game-nights/live/BlockedLiveSessionModal';
+export type { BlockedLiveSessionModalProps } from '@/components/features/game-nights/live/BlockedLiveSessionModal';
+
 export { NightLiveHub } from '@/components/features/game-nights/live/NightLiveHub';
 export type {
   NightLiveHubProps,

--- a/apps/web/src/lib/api/clients/__tests__/gameNightsClient.live.test.ts
+++ b/apps/web/src/lib/api/clients/__tests__/gameNightsClient.live.test.ts
@@ -14,9 +14,10 @@ import { UnauthorizedError } from '@/lib/api/core/errors';
 import { createGameNightsClient } from '../gameNightsClient';
 
 const mockGet = vi.fn();
+const mockPost = vi.fn();
 const mockHttpClient = {
   get: mockGet,
-  post: vi.fn(),
+  post: mockPost,
   put: vi.fn(),
   delete: vi.fn(),
 };
@@ -39,6 +40,8 @@ const LIVE = {
       completedAt: null,
     },
   ],
+  isViewerOrganizer: true,
+  plannedLineup: [],
 };
 
 describe('gameNightsClient.getLive', () => {
@@ -74,5 +77,40 @@ describe('gameNightsClient.getLive', () => {
     mockGet.mockResolvedValue(poison);
 
     await expect(client.getLive(GN_ID)).rejects.toThrow();
+  });
+});
+
+describe('gameNightsClient.startNextGame (WS1 DEC-10)', () => {
+  let client: ReturnType<typeof createGameNightsClient>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    client = createGameNightsClient({ httpClient: mockHttpClient as never });
+  });
+
+  it('POSTs /game-nights/{id}/sessions with gameId+gameTitle and returns the parsed result', async () => {
+    const gameId = '22222222-2222-4222-8222-222222222222';
+    mockPost.mockResolvedValue({
+      sessionId: '33333333-3333-4333-8333-333333333333',
+      gameNightSessionId: '44444444-4444-4444-8444-444444444444',
+      sessionCode: 'ABC123',
+      playOrder: 2,
+    });
+
+    const result = await client.startNextGame(GN_ID, gameId, 'Catan');
+
+    expect(mockPost).toHaveBeenCalledWith(`/api/v1/game-nights/${GN_ID}/sessions`, {
+      gameId,
+      gameTitle: 'Catan',
+    });
+    expect(result.sessionId).toBe('33333333-3333-4333-8333-333333333333');
+    expect(result.playOrder).toBe(2);
+  });
+
+  it('throws UnauthorizedError when the client returns null (401 path)', async () => {
+    mockPost.mockResolvedValue(null);
+    await expect(
+      client.startNextGame(GN_ID, '22222222-2222-4222-8222-222222222222', 'Catan')
+    ).rejects.toBeInstanceOf(UnauthorizedError);
   });
 });

--- a/apps/web/src/lib/api/clients/gameNightsClient.ts
+++ b/apps/web/src/lib/api/clients/gameNightsClient.ts
@@ -12,6 +12,7 @@ import {
   GameNightLiveDtoSchema,
   GameNightRsvpDtoSchema,
   RegularDtoSchema,
+  StartGameNightSessionResultSchema,
   type ConflictCheckDto,
   type CreateGameNightInput,
   type GameNightDto,
@@ -19,6 +20,7 @@ import {
   type GameNightRsvpDto,
   type RegularDto,
   type RsvpStatus,
+  type StartGameNightSessionResult,
   type UpdateGameNightInput,
 } from '../schemas/game-nights.schemas';
 
@@ -32,6 +34,12 @@ export interface GameNightsClient {
   getById(id: string): Promise<GameNightDto>;
   // #2633 Slice B: night-live read model (header + session progression).
   getLive(id: string): Promise<GameNightLiveDto>;
+  // #2633 WS1 DEC-10: start the next planned game (throws ConflictError on 409 max-live).
+  startNextGame(
+    gameNightId: string,
+    gameId: string,
+    gameTitle: string
+  ): Promise<StartGameNightSessionResult>;
   getRsvps(id: string): Promise<GameNightRsvpDto[]>;
   create(data: CreateGameNightInput): Promise<string>;
   update(id: string, data: UpdateGameNightInput): Promise<void>;
@@ -88,6 +96,19 @@ export function createGameNightsClient({
         });
       }
       return GameNightLiveDtoSchema.parse(data);
+    },
+
+    async startNextGame(gameNightId, gameId, gameTitle) {
+      // POST throws ConflictError (statusCode 409, code MAX_LIVE_SESSIONS_EXCEEDED) when a
+      // session is already live — the caller discriminates on that to mount the blocked modal.
+      const data = await httpClient.post<StartGameNightSessionResult>(
+        `/api/v1/game-nights/${gameNightId}/sessions`,
+        { gameId, gameTitle }
+      );
+      if (data === null) {
+        throw new UnauthorizedError({ message: 'Authentication required to start a game.' });
+      }
+      return StartGameNightSessionResultSchema.parse(data);
     },
 
     async getRsvps(id) {

--- a/apps/web/src/lib/api/core/errors.ts
+++ b/apps/web/src/lib/api/core/errors.ts
@@ -14,6 +14,8 @@ export interface ApiErrorDetails {
   response?: Response;
   endpoint?: string;
   timestamp?: string;
+  /** Machine-readable error code from the response body's `error` field (e.g. MAX_LIVE_SESSIONS_EXCEEDED). */
+  code?: string;
 }
 
 /**
@@ -25,6 +27,7 @@ export class ApiError extends Error {
   public readonly response?: Response;
   public readonly endpoint?: string;
   public readonly timestamp: string;
+  public readonly code?: string;
 
   constructor(details: ApiErrorDetails) {
     super(details.message);
@@ -34,6 +37,7 @@ export class ApiError extends Error {
     this.response = details.response;
     this.endpoint = details.endpoint;
     this.timestamp = details.timestamp || new Date().toISOString();
+    this.code = details.code;
 
     // Maintains proper stack trace for where error was thrown
     if (Error.captureStackTrace) {
@@ -297,9 +301,14 @@ export async function createApiError(endpoint: string, response: Response): Prom
   // Extract error message from response body
   let message = `API ${endpoint} failed with status ${statusCode}`;
   let validationErrors: Record<string, string[]> | undefined;
+  // Machine-readable code from body.error (BE middleware writes HttpException.ErrorCode there).
+  let code: string | undefined;
 
   try {
     const body = await response.json();
+    if (typeof body?.error === 'string') {
+      code = body.error;
+    }
     // Prefer body.message (user-friendly message) over body.error (error type)
     if (body?.message) {
       message = body.message;
@@ -320,6 +329,7 @@ export async function createApiError(endpoint: string, response: Response): Prom
     correlationId,
     response,
     endpoint,
+    code,
   };
 
   // Map status codes to specific error types

--- a/apps/web/src/lib/api/schemas/__tests__/game-nights-live.schemas.test.ts
+++ b/apps/web/src/lib/api/schemas/__tests__/game-nights-live.schemas.test.ts
@@ -27,6 +27,8 @@ const LIVE = {
   title: 'Serata Eldoria',
   status: 'Published',
   sessions: [SESSION],
+  isViewerOrganizer: true,
+  plannedLineup: [],
 };
 
 describe('GameNightSessionStatusSchema', () => {

--- a/apps/web/src/lib/api/schemas/game-nights.schemas.ts
+++ b/apps/web/src/lib/api/schemas/game-nights.schemas.ts
@@ -68,11 +68,30 @@ export const GameNightSessionDtoSchema = z.object({
 });
 export type GameNightSessionDto = z.infer<typeof GameNightSessionDtoSchema>;
 
+export const GameNightLineupItemDtoSchema = z.object({
+  gameId: z.string().uuid(),
+  gameTitle: z.string(),
+});
+export type GameNightLineupItemDto = z.infer<typeof GameNightLineupItemDtoSchema>;
+
+// WS1 DEC-10: result of POST /game-nights/{id}/sessions (start next game).
+export const StartGameNightSessionResultSchema = z.object({
+  sessionId: z.string().uuid(),
+  gameNightSessionId: z.string().uuid(),
+  sessionCode: z.string(),
+  playOrder: z.number().int(),
+});
+export type StartGameNightSessionResult = z.infer<typeof StartGameNightSessionResultSchema>;
+
 export const GameNightLiveDtoSchema = z.object({
   id: z.string().uuid(),
   title: z.string(),
   status: GameNightStatusSchema,
   sessions: z.array(GameNightSessionDtoSchema),
+  // WS1 DEC-9: gates the organizer-only "Avvia prossimo gioco" CTA on the FE.
+  isViewerOrganizer: z.boolean(),
+  // WS1 DEC-9: planned games not yet started, in order — the CTA starts the first.
+  plannedLineup: z.array(GameNightLineupItemDtoSchema),
 });
 export type GameNightLiveDto = z.infer<typeof GameNightLiveDtoSchema>;
 

--- a/apps/web/src/lib/game-nights/__tests__/mapNightLive.test.ts
+++ b/apps/web/src/lib/game-nights/__tests__/mapNightLive.test.ts
@@ -41,6 +41,8 @@ function live(over: Partial<GameNightLiveDto> = {}): GameNightLiveDto {
     title: 'Serata Eldoria',
     status: 'Published',
     sessions: [],
+    isViewerOrganizer: false,
+    plannedLineup: [],
     ...over,
   };
 }
@@ -104,6 +106,29 @@ describe('mapNightLiveToViewModel — header + progression', () => {
     );
     expect(mapNightLiveToViewModel(live({ status: 'Completed' }), NOW).nightStatus).toBe(
       'Completed'
+    );
+  });
+
+  it('derives nextGame from the first planned-lineup item (WS1 DEC-9)', () => {
+    const withLineup = live({
+      plannedLineup: [
+        { gameId: G3, gameTitle: 'Wingspan' },
+        { gameId: G1, gameTitle: 'Brass' },
+      ],
+    });
+    expect(mapNightLiveToViewModel(withLineup, NOW).nextGame).toEqual({
+      gameId: G3,
+      gameTitle: 'Wingspan',
+    });
+    expect(mapNightLiveToViewModel(live({ plannedLineup: [] }), NOW).nextGame).toBeNull();
+  });
+
+  it('threads isViewerOrganizer from the DTO (WS1 DEC-9)', () => {
+    expect(mapNightLiveToViewModel(live({ isViewerOrganizer: true }), NOW).isViewerOrganizer).toBe(
+      true
+    );
+    expect(mapNightLiveToViewModel(live({ isViewerOrganizer: false }), NOW).isViewerOrganizer).toBe(
+      false
     );
   });
 

--- a/apps/web/src/lib/game-nights/hooks/__tests__/useGameNightLive.test.tsx
+++ b/apps/web/src/lib/game-nights/hooks/__tests__/useGameNightLive.test.tsx
@@ -63,6 +63,8 @@ const LIVE_DTO: GameNightLiveDto = {
       completedAt: null,
     },
   ],
+  isViewerOrganizer: true,
+  plannedLineup: [],
 };
 
 describe('useGameNightLive — query key factory', () => {

--- a/apps/web/src/lib/game-nights/hooks/__tests__/useStartNextGame.test.tsx
+++ b/apps/web/src/lib/game-nights/hooks/__tests__/useStartNextGame.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * useStartNextGame unit tests — #2633 WS1 DEC-10.
+ */
+
+import { type ReactNode } from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { ConflictError, NotFoundError } from '@/lib/api/core/errors';
+
+import {
+  isMaxLiveBlockedError,
+  MAX_LIVE_SESSIONS_EXCEEDED,
+  useStartNextGame,
+} from '../useStartNextGame';
+
+const startNextGameMock = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/api', () => ({
+  api: { gameNights: { startNextGame: startNextGameMock } },
+}));
+
+const GN_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+
+function createWrapper() {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+describe('isMaxLiveBlockedError', () => {
+  it('is true only for a ConflictError carrying the MAX_LIVE code', () => {
+    expect(
+      isMaxLiveBlockedError(new ConflictError({ message: 'x', code: MAX_LIVE_SESSIONS_EXCEEDED }))
+    ).toBe(true);
+    expect(isMaxLiveBlockedError(new ConflictError({ message: 'x', code: 'other' }))).toBe(false);
+    expect(isMaxLiveBlockedError(new ConflictError({ message: 'x' }))).toBe(false);
+    expect(isMaxLiveBlockedError(new NotFoundError({ message: 'x' }))).toBe(false);
+    expect(isMaxLiveBlockedError(new Error('x'))).toBe(false);
+  });
+});
+
+describe('useStartNextGame', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('delegates to api.gameNights.startNextGame with the game id + title', async () => {
+    startNextGameMock.mockResolvedValue({
+      sessionId: 's1',
+      gameNightSessionId: 'gns1',
+      sessionCode: 'ABC',
+      playOrder: 2,
+    });
+
+    const { result } = renderHook(() => useStartNextGame(GN_ID), { wrapper: createWrapper() });
+    result.current.mutate({ gameId: 'g1', gameTitle: 'Catan' });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(startNextGameMock).toHaveBeenCalledWith(GN_ID, 'g1', 'Catan');
+  });
+
+  it('surfaces the ConflictError so the view can discriminate the max-live 409', async () => {
+    startNextGameMock.mockRejectedValue(
+      new ConflictError({ message: 'blocked', code: MAX_LIVE_SESSIONS_EXCEEDED })
+    );
+
+    const { result } = renderHook(() => useStartNextGame(GN_ID), { wrapper: createWrapper() });
+    result.current.mutate({ gameId: 'g1', gameTitle: 'Catan' });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(isMaxLiveBlockedError(result.current.error)).toBe(true);
+  });
+});

--- a/apps/web/src/lib/game-nights/hooks/useStartNextGame.ts
+++ b/apps/web/src/lib/game-nights/hooks/useStartNextGame.ts
@@ -1,0 +1,46 @@
+'use client';
+
+/**
+ * useStartNextGame — #2633 WS1 DEC-10.
+ *
+ * Mutation that starts the next planned game (POST /game-nights/{id}/sessions). On success it
+ * invalidates the night-live query so the badge/current-game re-derive from the read model
+ * (single source of truth — no optimistic flip). A 409 with code MAX_LIVE_SESSIONS_EXCEEDED is
+ * the server-authoritative signal that a session is already live; the view discriminates via
+ * `isMaxLiveBlockedError` to mount the blocked modal.
+ */
+
+import { useMutation, useQueryClient, type UseMutationResult } from '@tanstack/react-query';
+
+import { api } from '@/lib/api';
+import { ConflictError } from '@/lib/api/core/errors';
+import type { StartGameNightSessionResult } from '@/lib/api/schemas/game-nights.schemas';
+
+import { gameNightLiveKeys } from './useGameNightLive';
+
+export const MAX_LIVE_SESSIONS_EXCEEDED = 'MAX_LIVE_SESSIONS_EXCEEDED';
+
+/** DEC-10: true iff the error is the max-1-live 409 (→ blocked modal, not a generic toast). */
+export function isMaxLiveBlockedError(error: unknown): boolean {
+  return error instanceof ConflictError && error.code === MAX_LIVE_SESSIONS_EXCEEDED;
+}
+
+export interface StartNextGameVars {
+  readonly gameId: string;
+  readonly gameTitle: string;
+}
+
+export function useStartNextGame(
+  gameNightId: string
+): UseMutationResult<StartGameNightSessionResult, Error, StartNextGameVars> {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ gameId, gameTitle }: StartNextGameVars) =>
+      api.gameNights.startNextGame(gameNightId, gameId, gameTitle),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: gameNightLiveKeys.detail(gameNightId) });
+    },
+    retry: false,
+  });
+}

--- a/apps/web/src/lib/game-nights/mapNightLive.ts
+++ b/apps/web/src/lib/game-nights/mapNightLive.ts
@@ -35,6 +35,10 @@ export interface NightLiveViewModel {
   readonly night: NightLiveHubNight;
   /** Raw GameNight lifecycle status — drives terminal-night routing (LD-14). */
   readonly nightStatus: GameNightStatus;
+  /** WS1 DEC-9: gates the organizer-only "Avvia prossimo gioco" CTA. */
+  readonly isViewerOrganizer: boolean;
+  /** WS1 DEC-9: the next un-started planned game the CTA starts, or null if none. */
+  readonly nextGame: { readonly gameId: string; readonly gameTitle: string } | null;
   readonly status: NightLiveStatus;
   readonly current: number;
   readonly total: number;
@@ -177,6 +181,8 @@ export function mapNightLiveToViewModel(dto: GameNightLiveDto, now: Date): Night
   return {
     night: { title: dto.title }, // LD-15: shortTitle/nightCode undefined in Slice B
     nightStatus: dto.status, // LD-14: raw lifecycle status for terminal routing
+    isViewerOrganizer: dto.isViewerOrganizer, // WS1 DEC-9
+    nextGame: dto.plannedLineup.length > 0 ? dto.plannedLineup[0] : null, // WS1 DEC-9
     status,
     current,
     total,

--- a/docs/for-developers/specs/2026-07-04-ws1-interactive-start-nightlive-design.md
+++ b/docs/for-developers/specs/2026-07-04-ws1-interactive-start-nightlive-design.md
@@ -1,0 +1,57 @@
+# WS1 — interactive start-next-game + max-1-live blocked modal + LIVE badge + #2647 fix
+
+**Issues**: closes [#2633](https://github.com/meepleAi-app/meepleai-monorepo/issues/2633) (SI-2 acceptance) + [#2647](https://github.com/meepleAi-app/meepleai-monorepo/issues/2647) (OpenLiveMode gap) · epic [#2619](https://github.com/meepleAi-app/meepleai-monorepo/issues/2619)
+**Date**: 2026-07-04
+**Method**: `/sc:spec-panel` (Fowler · Newman · Nygard · Adzic · Cockburn) → synthesis
+**Status**: DESIGNED — 11 locked decisions; 3 product calls open (§4).
+
+---
+
+## 1. What the panel uncovered (real bugs, not just #2647)
+
+The naive WS1 ("re-enable start + catch 409") sits on top of **serious pre-existing domain defects** in the start flow:
+
+1. **Phantom double-night ownership** — `StartGameNightSessionCommandHandler` dispatches `CreateSessionCommand` with `GameNightEventId=null` → `CreateSessionCommandHandler.ResolveGameNightAsync` mints a **new ad-hoc InProgress night** + link, while the outer handler ALSO links the same session via `AddSession` → the tracking Session is owned by **two** `GameNightEvent`s → `FindByLinkedSessionIdAsync` is nondeterministic. **This breaks #2633** (the live session must belong to the night you opened).
+2. **Orphan session on blocked 2nd-open** — `CreateSessionCommand` commits a durable Session *before* `StartCurrentSession`'s max-1-live 409 fires → every blocked open leaks an orphan.
+3. **Concurrency 500** — two concurrent starts both pass the in-memory guard; the xmin loser throws an uncaught `DbUpdateConcurrencyException` (the `catch` only handles `InvalidOperationException`) → HTTP 500 + orphan.
+4. **Error code dropped** — `ConflictException(string)` hardcodes `errorCode='conflict'`, so `MaxLiveSessionsExceededException.Code` never reaches the HTTP body → FE can't discriminate the max-live 409.
+5. **#2647 mis-fix trap** — putting `OpenLiveMode` inside `CreateSessionCommandHandler` dispatches `SessionStartedDomainEvent` *before* the aggregate link is committed → `FindByLinkedSessionIdAsync` resolves null/phantom → promotion silently skipped. The fix must be a dedicated command dispatched **last**.
+
+## 2. Locked decisions
+
+| ID | Decision |
+|---|---|
+| **DEC-1** | New SessionTracking `OpenSessionLiveModeCommand(SessionId, CallerUserId)` dispatched from the start handler (+ gamebook twin) as the **LAST** step, AFTER `AddSession`+`StartCurrentSession`+`SaveChanges`. NOT inside `CreateSessionCommandHandler`. |
+| **DEC-2** | Keep the Published→InProgress promotion **event-driven** via the existing `SessionStartedHandler` → `GameNightEvent.HandleFirstSessionStarted`. No direct `Status` mutation. |
+| **DEC-3** | Add `bool SkipGameNightEnvelope=false` to `CreateSessionCommand`. Both orchestrators pass `true` → `CreateSessionCommandHandler` skips `ResolveGameNightAsync` + the link + game-night diary rows; `GameNightEvent.AddSession` is the **sole** linker against `command.GameNightId`. Kills the phantom + the Published-precondition collision. |
+| **DEC-4** | Guard-before-create: `GameNightEvent.EnsureCanStartSession()` (throws `MaxLiveSessionsExceededException` if any child InProgress) called at the TOP of `Handle`, before `CreateSessionCommand`. Blocked 2nd-open persists **zero rows**. |
+| **DEC-5** | Wrap the aggregate `SaveChangesAsync`, catch `DbUpdateConcurrencyException` (xmin) → rethrow `MaxLiveSessionsExceededException` → 409 (not 500). |
+| **DEC-6** | `OpenSessionLiveModeCommandHandler` idempotent: `if session.IsLive return Unit` (no 409); else `OpenLiveMode()`; save. |
+| **DEC-7** | Add `ConflictException(string errorCode, string message)` ctor; `MaxLiveSessionsExceededException` passes `Code='MAX_LIVE_SESSIONS_EXCEEDED'` so the FE can discriminate. |
+| **DEC-8** | Apply DEC-1/3/4/5 identically to `AttachGamebookCampaignToGameNightCommandHandler` via a shared private helper. |
+| **DEC-9** | FE read-only by default; organizer-only "Avvia prossimo gioco" CTA. Add `bool IsViewerOrganizer` to `GameNightLiveDto` (from `gameNight.OrganizerId==query.CallerUserId`, already computed) → threaded through `mapNightLive` into the VM. |
+| **DEC-10** | FE race avoidance = optimistic disable + server-409 authority. CTA disabled while pending AND when `vm.status==='live'`. On success invalidate `gameNightLiveKeys.detail(id)` and re-derive; do NOT wire `useGameNightMultiSession` (0 consumers, split-brain). On 409 `MAX_LIVE_SESSIONS_EXCEEDED` → blocked modal; other 409 → generic toast. |
+| **DEC-11** | LIVE badge derives PURELY from the read-model InProgress session; **#2647 is NOT a prerequisite for the badge** (status/currentGame already derive from `GameNightSession.Status==InProgress`, set synchronously by `StartCurrentSession`). #2647's payoff = `Session.StartedAt` for the `/sessions/[id]` timer + the night promotion that gates gamebook-attach/completion. |
+
+## 3. Backend flow (resolved) + file-by-file plan
+
+**Flow** (`StartGameNightSessionCommandHandler`, mirrored in the gamebook-attach twin):
+1. Load `GameNightEvent` (Published), authorize organizer.
+2. `gameNight.EnsureCanStartSession()` — 409 if any child InProgress (zero rows on block).
+3. `CreateSessionCommand` with `SkipGameNightEnvelope=true` — tracking Session + participants only (StartedAt null), no phantom night/link/diary.
+4. `AddSession` + `StartCurrentSession` → `SaveChanges`, wrapped to map `DbUpdateConcurrencyException`→409. Single durable link; **badge already correct**.
+5. `OpenSessionLiveModeCommand(sessionId, userId)` — idempotent, `OpenLiveMode()` sets StartedAt + raises event → existing handler promotes Published→InProgress. **This is where #2647 is fixed.**
+
+**Transaction/event boundary** (locked): two aggregates, three SaveChanges, eventually consistent within one request (ADR-060, not a distributed tx). Ordering is load-bearing: OpenLiveMode strictly after the link commit; `SkipGameNightEnvelope` guarantees exactly one link → deterministic resolution.
+
+**Files** — BE: (1) `CreateSessionCommand.cs` +flag · (2) `CreateSessionCommandHandler.cs` skip-branch · (3) `GameNightEvent.cs` `EnsureCanStartSession()` · (4) NEW `OpenSessionLiveModeCommand.cs`+handler · (5) `ConflictException.cs` ctor · (6) `MaxLiveSessionsExceededException.cs` code · (7) `StartGameNightSessionCommandHandler.cs` reorder+dispatch · (8) `AttachGamebookCampaignToGameNightCommandHandler.cs` parity · (9) `GameNightLiveDto.cs` `IsViewerOrganizer` · (10) `GetGameNightLiveQueryHandler.cs` populate. FE: (11) `game-nights.schemas.ts` · (12) `mapNightLive.ts` thread flag + expose next-Pending game · (13) `gameNightSessionClient.ts` surface `errorCode` · (14) NEW start-next RQ mutation · (15) `NightLiveClientView.tsx`/`NightLiveHub.tsx` CTA + modal · (16) NEW `BlockedLiveSessionModal`.
+
+## 4. Product calls — RESOLVED 2026-07-04
+
+1. **CTA "next game" source = next Pending from the lineup.** The read model exposes the night's **un-started lineup** (GameIds in `GameIdsJson` that have no `GameNightSession` yet) as planned/upcoming slots; the CTA starts the next un-started GameId (`AddSession`+`StartCurrentSession` create+start it). No lineup → CTA hidden. This extends `mapNightLive` + the live DTO to surface un-started games (Slice B's `plannedGames` today only reflects *started* sessions).
+2. **Blocked-modal copy = honest.** "C'è già una partita live. Aprila per continuare." + a jump-to-session action. WS1 cannot complete a game, so no "resolve it" promise.
+3. **Direct POST /sessions one-click flow IS reconciled in WS1.** Its `Session.StartedAt` is also set (total consistency — every started session goes live). Mechanism: the final `OpenSessionLiveMode` step runs for the direct/ad-hoc path too (its ad-hoc night is already InProgress → `HandleFirstSessionStarted` is an idempotent no-op, only `StartedAt` is set). DEC-1's "not inside CreateSessionCommandHandler" still holds for the game-night orchestrators; the exact wiring for the direct path (endpoint-level dispatch vs handler) is settled during implementation, keeping OpenLiveMode a single dedicated command.
+
+## 5. Acceptance (Given/When/Then) — see synthesis; BE via real pipeline (not fixtures)
+
+Happy path (StartedAt set, 1 event, 1 night, 1 link, Published→InProgress once) · blocked no-race (409 `MAX_LIVE_SESSIONS_EXCEEDED`, zero rows) · concurrency (loser 409 not 500) · idempotent re-start · direct-flow regression · gamebook parity · FE badge from read model · organizer gate · optimistic disable · 409 discrimination · post-success derivation · scope boundary (start only, no complete).


### PR DESCRIPTION
Release main-dev -> main-staging (5 commit).

Abilita il re-upload dei 107 PDF mancanti su staging (#2666): il repair mode del PdfSeeder ricarica i blob assenti dal seed bucket al successivo re-trigger del seed.

Commit inclusi:
- #2666 PdfSeeder repair mode (re-upload blob mancanti) — PR #2667
- #2633 WS1 interactive live write-side — PR #2647
- #2661 pageCount stale reload — PR #2664
- #2662 Scriban.Signed 7.2.0 (GHSA HIGH) — PR #2663
- #2659 smoke login form timeout 8s->30s — PR #2659

Nessun cambiamento alle AI service (no pull AI). Il deploy staging parte in automatico al merge.