### PR TITLE
fix(document-processing): #2671 READ path usa fileId dal FilePath (blob S3 non trovato)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Jobs/BackfillPdfCoversJob.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Jobs/BackfillPdfCoversJob.cs
@@ -243,8 +243,12 @@ public sealed class BackfillPdfCoversJob : IJob
         // backfill is intended for production-like environments where the PDF
         // lives in blob storage. The filesystem fallback in the pipeline
         // service exists for dev/test, which doesn't need a backfill job.
-        var fileId = PdfStorageKey.ForPdf(pdf.Id);
-        var stream = await blob.RetrieveAsync(fileId, BlobCategory.Pdf, fileId, ct).ConfigureAwait(false);
+        // Issue #2671: the blob lives under a random fileId embedded in FilePath, not pdfId.
+        // Recover it from the persisted path; ForPdf(Id) is the resourceKey folder. The ??
+        // fallback preserves legacy behaviour for records with an empty/unparsable FilePath.
+        var resourceKey = PdfStorageKey.ForPdf(pdf.Id);
+        var fileId = PdfStorageKey.FileIdFromPath(pdf.FilePath) ?? resourceKey;
+        var stream = await blob.RetrieveAsync(fileId, BlobCategory.Pdf, resourceKey, ct).ConfigureAwait(false);
         if (stream is null)
         {
             return null;

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs
@@ -450,8 +450,12 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
     {
         // Issue #501: Use blob storage with correct GUID format (no hyphens) to match StoreAsync key format
         // Task 4: bucket key decoupled from gameId — uses pdf.Id (see PdfStorageKey + rebucket scripts)
-        var fileId = PdfStorageKey.ForPdf(pdfDoc.Id);
-        var fileStream = await _blobStorageService.RetrieveAsync(fileId, BlobCategory.Pdf, fileId, cancellationToken).ConfigureAwait(false);
+        // Issue #2671: StoreAsync writes the blob under a RANDOM fileId (persisted in FilePath), NOT pdfId.
+        // Recover that fileId from FilePath; ForPdf(Id) is the resourceKey folder, not the fileId. The
+        // ?? fallback preserves legacy behaviour for records with an empty/unparsable FilePath.
+        var resourceKey = PdfStorageKey.ForPdf(pdfDoc.Id);
+        var fileId = PdfStorageKey.FileIdFromPath(pdfDoc.FilePath) ?? resourceKey;
+        var fileStream = await _blobStorageService.RetrieveAsync(fileId, BlobCategory.Pdf, resourceKey, cancellationToken).ConfigureAwait(false);
 
         if (fileStream == null)
         {
@@ -978,9 +982,13 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
         string filePath,
         CancellationToken cancellationToken)
     {
-        var fileId = PdfStorageKey.ForPdf(pdfDocumentId);
+        // Issue #2671: the blob lives under a random fileId embedded in FilePath, not pdfId.
+        // Recover it from the persisted path; ForPdf(Id) is the resourceKey folder. The ??
+        // fallback preserves legacy behaviour for records with an empty/unparsable FilePath.
+        var resourceKey = PdfStorageKey.ForPdf(pdfDocumentId);
+        var fileId = PdfStorageKey.FileIdFromPath(filePath) ?? resourceKey;
         var stream = await _blobStorageService
-            .RetrieveAsync(fileId, BlobCategory.Pdf, fileId, cancellationToken)
+            .RetrieveAsync(fileId, BlobCategory.Pdf, resourceKey, cancellationToken)
             .ConfigureAwait(false);
 
         if (stream is null)

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfStorageKey.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfStorageKey.cs
@@ -1,10 +1,54 @@
+using System.Buffers;
+
 namespace Api.BoundedContexts.DocumentProcessing.Application.Services;
 
 public static class PdfStorageKey
 {
+    private static readonly SearchValues<char> PathSeparators = SearchValues.Create("/\\");
+
     /// <summary>
     /// Bucket key for PDF storage. Uses pdf.Id to decouple from game lifecycle.
     /// Pre-migration PDFs stored under gameId bucket must be rebucket-ed by scripts/rebucket-pdfs.*
     /// </summary>
     public static string ForPdf(Guid pdfId) => pdfId.ToString("N");
+
+    /// <summary>
+    /// Extracts the bare fileId embedded in a stored blob path of shape
+    /// <c>{category}/{resourceKey}/{fileId}_{sanitizedFileName}</c> (S3 forward-slash
+    /// or Windows-local backslash layout). The fileId is the segment after the last path
+    /// separator and before the first underscore.
+    /// </summary>
+    /// <remarks>
+    /// Issue #2671: <c>IBlobStorageService.StoreAsync</c> generates a RANDOM fileId
+    /// (<c>Guid.NewGuid().ToString("N")</c>) that is persisted inside the returned
+    /// <c>FilePath</c>. The READ path MUST recover that same fileId from the persisted
+    /// <c>FilePath</c> — it can NOT be reconstructed from <see cref="ForPdf"/> (the pdfId is
+    /// only the <c>resourceKey</c> folder, not the fileId). Returns <c>null</c> for
+    /// null/empty input or any path that does not match the expected layout (no separator,
+    /// trailing separator, no underscore in the last segment, leading underscore).
+    /// </remarks>
+    public static string? FileIdFromPath(string? filePath)
+    {
+        if (string.IsNullOrEmpty(filePath))
+        {
+            return null;
+        }
+
+        // Platform-independent separators: '/' for S3 + URL-style, '\\' on Windows local FS.
+        var lastSeparator = filePath.AsSpan().LastIndexOfAny(PathSeparators);
+        if (lastSeparator < 0 || lastSeparator == filePath.Length - 1)
+        {
+            return null;
+        }
+
+        var fileName = filePath[(lastSeparator + 1)..];
+        var underscoreIndex = fileName.IndexOf('_', StringComparison.Ordinal);
+        // <= 0 covers: not found (-1) AND leading underscore (= 0 ⇒ empty fileId).
+        if (underscoreIndex <= 0)
+        {
+            return null;
+        }
+
+        return fileName[..underscoreIndex];
+    }
 }

--- a/apps/api/src/Api/Infrastructure/Seeders/Catalog/PdfSeeder.cs
+++ b/apps/api/src/Api/Infrastructure/Seeders/Catalog/PdfSeeder.cs
@@ -1,4 +1,3 @@
-using System.Buffers;
 using Api.BoundedContexts.DocumentProcessing.Application.Services;
 using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
 using Api.Infrastructure.Entities;
@@ -142,7 +141,7 @@ internal static class PdfSeeder
                     {
                         // fileId is embedded in the stored FilePath (pdfs/{resourceKey}/{fileId}_{name});
                         // extract it so ExistsAsync can locate the blob for the EXISTING record.
-                        var existingFileId = ExtractFileIdFromPath(existing.FilePath);
+                        var existingFileId = PdfStorageKey.FileIdFromPath(existing.FilePath);
                         var blobPresent = !string.IsNullOrEmpty(existingFileId)
                             && await primaryBlob.ExistsAsync(existingFileId, BlobCategory.Pdf, PdfStorageKey.ForPdf(existing.Id), ct).ConfigureAwait(false);
 
@@ -417,7 +416,7 @@ internal static class PdfSeeder
         {
             try
             {
-                var fileId = ExtractFileIdFromPath(filePath);
+                var fileId = PdfStorageKey.FileIdFromPath(filePath);
                 if (!string.IsNullOrEmpty(fileId))
                 {
                     await primaryBlob.DeleteAsync(fileId, BlobCategory.Pdf, gameIdStr, ct).ConfigureAwait(false);
@@ -440,40 +439,5 @@ internal static class PdfSeeder
             db.PdfDocuments.Remove(entity);
             await db.SaveChangesAsync(ct).ConfigureAwait(false);
         }
-    }
-
-    private static readonly SearchValues<char> PathSeparators = SearchValues.Create("/\\");
-
-    /// <summary>
-    /// Extracts the bare fileId from a storage path of shape
-    /// <c>pdf_uploads/{resourceKey}/{fileId}_{sanitizedFileName}</c>.
-    /// Returns null if the path does not match the expected layout.
-    /// Exposed as <c>internal</c> for unit testing the null-return branches
-    /// (no path separator, trailing slash, no underscore in segment, leading
-    /// underscore in segment).
-    /// </summary>
-    internal static string? ExtractFileIdFromPath(string filePath)
-    {
-        if (string.IsNullOrEmpty(filePath))
-        {
-            return null;
-        }
-
-        // Platform-independent separators: '/' for S3 + URL-style, '\\' on Windows local FS.
-        var lastSeparator = filePath.AsSpan().LastIndexOfAny(PathSeparators);
-        if (lastSeparator < 0 || lastSeparator == filePath.Length - 1)
-        {
-            return null;
-        }
-
-        var fileName = filePath[(lastSeparator + 1)..];
-        var underscoreIndex = fileName.IndexOf('_', StringComparison.Ordinal);
-        // <= 0 covers: not found (-1) AND leading underscore (= 0 ⇒ empty fileId).
-        if (underscoreIndex <= 0)
-        {
-            return null;
-        }
-
-        return fileName[..underscoreIndex];
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Services/PdfStorageKeyReadPathRegressionTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Services/PdfStorageKeyReadPathRegressionTests.cs
@@ -1,0 +1,142 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Api.BoundedContexts.DocumentProcessing.Application.Services;
+using Api.Services.Pdf;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.DocumentProcessing.Application.Services;
+
+/// <summary>
+/// Issue #2671 regression: the PDF blob READ path must recover the RANDOM fileId that
+/// <see cref="IBlobStorageService.StoreAsync"/> embeds in the returned <c>FilePath</c>.
+/// Reconstructing the fileId from <see cref="PdfStorageKey.ForPdf"/> (which is only the
+/// resourceKey folder) never matches the stored blob, so extraction 404s.
+/// Exercised end-to-end against the real local <see cref="BlobStorageService"/> (filesystem,
+/// no Docker/S3) which shares the exact <c>{resourceKey}/{randomFileId}_{name}</c> layout
+/// with <see cref="S3BlobStorageService"/>.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "DocumentProcessing")]
+public sealed class PdfStorageKeyReadPathRegressionTests : IDisposable
+{
+    private readonly string _tempRoot;
+    private readonly BlobStorageService _storage;
+
+    public PdfStorageKeyReadPathRegressionTests()
+    {
+        _tempRoot = Path.Combine(Path.GetTempPath(), "meepleai-2671-" + Guid.NewGuid().ToString("N"));
+        var config = new Mock<IConfiguration>();
+        config.Setup(c => c["PDF_STORAGE_PATH"]).Returns(_tempRoot);
+        _storage = new BlobStorageService(config.Object, NullLogger<BlobStorageService>.Instance);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_tempRoot))
+            {
+                Directory.Delete(_tempRoot, recursive: true);
+            }
+        }
+#pragma warning disable CA1031 // best-effort temp cleanup
+        catch
+        {
+            // Ignore cleanup failures (locked file / antivirus) — temp dir, not load-bearing.
+        }
+#pragma warning restore CA1031
+    }
+
+    [Fact]
+    public async Task ReadPath_RecoversRandomFileIdFromFilePath_FindsBlob()
+    {
+        // Arrange — WRITE: StoreAsync generates a random fileId (≠ pdfId), persisted in FilePath.
+        var pdfId = Guid.NewGuid();
+        var resourceKey = PdfStorageKey.ForPdf(pdfId);
+        var content = "the-real-pdf-bytes"u8.ToArray();
+
+        BlobStorageResult writeResult;
+        using (var ms = new MemoryStream(content))
+        {
+            writeResult = await _storage.StoreAsync(ms, "file", BlobCategory.Pdf, resourceKey, CancellationToken.None);
+        }
+
+        writeResult.Success.Should().BeTrue();
+        writeResult.FileId.Should().NotBeNullOrEmpty();
+        writeResult.FileId.Should().NotBe(resourceKey, "the write fileId is a random GUID, not the pdfId");
+        writeResult.FilePath.Should().NotBeNullOrEmpty();
+
+        // Act — FIXED READ path (Issue #2671): recover fileId from FilePath; resourceKey = ForPdf(Id).
+        var recoveredFileId = PdfStorageKey.FileIdFromPath(writeResult.FilePath);
+        recoveredFileId.Should().Be(writeResult.FileId);
+
+        var stream = await _storage.RetrieveAsync(recoveredFileId!, BlobCategory.Pdf, resourceKey, CancellationToken.None);
+
+        // Assert — the fixed path locates the blob and returns the exact bytes written.
+        stream.Should().NotBeNull("the fixed READ path must locate the blob written by StoreAsync");
+        await using (stream!.ConfigureAwait(false))
+        {
+            using var read = new MemoryStream();
+            await stream.CopyToAsync(read, CancellationToken.None);
+            read.ToArray().Should().Equal(content);
+        }
+    }
+
+    [Fact]
+    public async Task ReadPath_OldBehaviour_UsingForPdfAsFileId_DoesNotFindBlob_RedProof()
+    {
+        // Arrange — same WRITE as the fixed test.
+        var pdfId = Guid.NewGuid();
+        var resourceKey = PdfStorageKey.ForPdf(pdfId);
+        using (var ms = new MemoryStream("bytes"u8.ToArray()))
+        {
+            var writeResult = await _storage.StoreAsync(ms, "file", BlobCategory.Pdf, resourceKey, CancellationToken.None);
+            writeResult.Success.Should().BeTrue();
+            writeResult.FileId.Should().NotBe(resourceKey);
+        }
+
+        // Act — OLD (pre-#2671, buggy) READ path: ForPdf(Id) passed as BOTH fileId and resourceKey.
+        var buggyFileId = PdfStorageKey.ForPdf(pdfId);
+        var stream = await _storage.RetrieveAsync(buggyFileId, BlobCategory.Pdf, buggyFileId, CancellationToken.None);
+
+        // Assert — RED proof: the old fileId==pdfId lookup never matches the random StoreAsync fileId.
+        stream.Should().BeNull("the buggy fileId==pdfId lookup cannot match the random StoreAsync fileId");
+    }
+
+    [Fact]
+    public async Task ReadPath_LegacyEmptyFilePath_FallsBackToForPdf_FindsBlob()
+    {
+        // A legacy blob written the pre-#2671 way (fileId == pdfId) with a record whose FilePath is
+        // empty/unparsable must still resolve via the ForPdf(Id) fallback (`FileIdFromPath(x) ?? ForPdf(Id)`).
+        var pdfId = Guid.NewGuid();
+        var resourceKey = PdfStorageKey.ForPdf(pdfId);
+        var legacyContent = "legacy-pdf-bytes"u8.ToArray();
+
+        // Materialise a legacy on-disk blob whose fileId segment IS the pdfId, using the service's
+        // own path contract (avoids hard-coding the internal on-disk layout).
+        var legacyBlobPath = _storage.GetStoragePath(resourceKey, BlobCategory.Pdf, resourceKey, "file.pdf");
+        Directory.CreateDirectory(Path.GetDirectoryName(legacyBlobPath)!);
+        await File.WriteAllBytesAsync(legacyBlobPath, legacyContent, CancellationToken.None);
+
+        // Act — READ path with an empty FilePath → helper returns null → fallback to ForPdf(Id).
+        var fileId = PdfStorageKey.FileIdFromPath(string.Empty) ?? resourceKey;
+        fileId.Should().Be(resourceKey, "empty FilePath must fall back to the pdfId-derived key");
+
+        var stream = await _storage.RetrieveAsync(fileId, BlobCategory.Pdf, resourceKey, CancellationToken.None);
+
+        // Assert — the fallback preserves the pre-#2671 behaviour for legacy records.
+        stream.Should().NotBeNull("legacy records without a parsable FilePath must resolve via the ForPdf(Id) fallback");
+        await using (stream!.ConfigureAwait(false))
+        {
+            using var read = new MemoryStream();
+            await stream.CopyToAsync(read, CancellationToken.None);
+            read.ToArray().Should().Equal(legacyContent);
+        }
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Services/PdfStorageKeyTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Services/PdfStorageKeyTests.cs
@@ -5,6 +5,8 @@ using Xunit;
 
 namespace Api.Tests.BoundedContexts.DocumentProcessing.Application.Services;
 
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "DocumentProcessing")]
 public class PdfStorageKeyTests
 {
     [Fact]
@@ -12,5 +14,55 @@ public class PdfStorageKeyTests
     {
         var pdfId = Guid.Parse("11111111-1111-1111-1111-111111111111");
         PdfStorageKey.ForPdf(pdfId).Should().Be("11111111111111111111111111111111");
+    }
+
+    // -------------------------------------------------------------------
+    // FileIdFromPath (Issue #2671): recover the RANDOM fileId StoreAsync
+    // embeds in the persisted FilePath. Helper moved here from PdfSeeder.
+    // -------------------------------------------------------------------
+
+    [Theory]
+    // Happy paths — S3 forward-slash + Windows backslash layouts
+    [InlineData("pdf_uploads/gameId/abc123_rulebook.pdf", "abc123")]
+    [InlineData("pdf_uploads\\gameId\\abc123_rulebook.pdf", "abc123")]
+    [InlineData("C:\\storage\\pdf_uploads\\gameId\\fedcba_doc.pdf", "fedcba")]
+    // Production S3 shape — hyphen-less GUID-N resourceKey dir + GUID-N fileId
+    [InlineData("pdfs/abcdef01234567890123456789abcdef/00112233445566778899aabbccddeeff_file", "00112233445566778899aabbccddeeff")]
+    // resourceKey dir WITH hyphens (canonical uuid) — fileId still after last '/', before first '_'
+    [InlineData("pdfs/11111111-1111-1111-1111-111111111111/deadbeefcafe_file.pdf", "deadbeefcafe")]
+    // Filename contains underscores — only the FIRST underscore in the last segment splits fileId/filename
+    [InlineData("pdf_uploads/gameId/abc123_my_file_v2.pdf", "abc123")]
+    public void FileIdFromPath_ValidPaths_ReturnsFileId(string filePath, string expectedFileId)
+    {
+        PdfStorageKey.FileIdFromPath(filePath).Should().Be(expectedFileId);
+    }
+
+    [Theory]
+    // Null / empty
+    [InlineData(null)]
+    [InlineData("")]
+    // No path separator → can't isolate last segment
+    [InlineData("singleSegment_file.pdf")]
+    [InlineData("noSeparatorNorUnderscore")]
+    // Trailing separator → no filename after last separator
+    [InlineData("pdfs/gameId/")]
+    [InlineData("pdfs\\gameId\\")]
+    // Last segment has no underscore → can't isolate fileId from filename
+    [InlineData("pdfs/gameId/justAFile.pdf")]
+    [InlineData("pdfs/gameId/no-underscore-here")]
+    // Leading underscore in last segment → fileId would be empty
+    [InlineData("pdfs/gameId/_leadingUnderscore.pdf")]
+    public void FileIdFromPath_InvalidPaths_ReturnsNull(string? filePath)
+    {
+        PdfStorageKey.FileIdFromPath(filePath).Should().BeNull();
+    }
+
+    [Fact]
+    public void FileIdFromPath_LegacyEmptyPath_CoalescesToForPdf()
+    {
+        // Caller pattern in the READ path: FileIdFromPath(FilePath) ?? ForPdf(Id).
+        var pdfId = Guid.NewGuid();
+        var fileId = PdfStorageKey.FileIdFromPath(string.Empty) ?? PdfStorageKey.ForPdf(pdfId);
+        fileId.Should().Be(PdfStorageKey.ForPdf(pdfId));
     }
 }

--- a/apps/api/tests/Api.Tests/Infrastructure/Seeders/Catalog/PdfSeederBlobTests.cs
+++ b/apps/api/tests/Api.Tests/Infrastructure/Seeders/Catalog/PdfSeederBlobTests.cs
@@ -505,43 +505,7 @@ public sealed class PdfSeederBlobTests
         db.ProcessingJobs.Should().BeEmpty();
     }
 
-    // ---------------------------------------------------------------
-    // ExtractFileIdFromPath edge cases (review finding #3 follow-up)
-    // ---------------------------------------------------------------
-
-    [Theory]
-    // Happy paths — S3 forward-slash + Windows backslash layouts
-    [InlineData("pdf_uploads/gameId/abc123_rulebook.pdf", "abc123")]
-    [InlineData("pdf_uploads\\gameId\\abc123_rulebook.pdf", "abc123")]
-    [InlineData("C:\\storage\\pdf_uploads\\gameId\\fedcba_doc.pdf", "fedcba")]
-    // GUID-N fileId (32 hex chars, no underscores, no hyphens) — production shape
-    [InlineData("pdf_uploads/game/abcdef01234567890123456789abcdef_file.pdf", "abcdef01234567890123456789abcdef")]
-    // Filename contains underscore — only FIRST underscore in last segment splits fileId/filename
-    [InlineData("pdf_uploads/gameId/abc123_my_file_v2.pdf", "abc123")]
-    public void ExtractFileIdFromPath_ValidPaths_ReturnsFileId(string filePath, string expectedFileId)
-    {
-        var result = PdfSeeder.ExtractFileIdFromPath(filePath);
-        result.Should().Be(expectedFileId);
-    }
-
-    [Theory]
-    // Null / empty
-    [InlineData(null)]
-    [InlineData("")]
-    // No path separator → can't isolate last segment
-    [InlineData("singleSegment_file.pdf")]
-    [InlineData("noSeparatorNorUnderscore")]
-    // Trailing slash → no filename after last separator
-    [InlineData("pdf_uploads/gameId/")]
-    [InlineData("pdf_uploads\\gameId\\")]
-    // Last segment has no underscore → can't isolate fileId from filename
-    [InlineData("pdf_uploads/gameId/justAFile.pdf")]
-    [InlineData("pdf_uploads/gameId/no-underscore-here")]
-    // Leading underscore in last segment → fileId would be empty
-    [InlineData("pdf_uploads/gameId/_leadingUnderscore.pdf")]
-    public void ExtractFileIdFromPath_InvalidPaths_ReturnsNull(string? filePath)
-    {
-        var result = PdfSeeder.ExtractFileIdFromPath(filePath!);
-        result.Should().BeNull();
-    }
+    // NOTE (Issue #2671): the fileId-from-path parsing helper was extracted from
+    // PdfSeeder.ExtractFileIdFromPath into the shared PdfStorageKey.FileIdFromPath.
+    // Its edge-case unit tests now live in PdfStorageKeyTests (single source of truth).
 }


### PR DESCRIPTION
## Root cause

Mismatch tra **WRITE** e **READ** della storage key del PDF blob.

- **WRITE** — `S3BlobStorageService.StoreAsync` genera un `fileId = Guid.NewGuid().ToString("N")` **RANDOM** e scrive il blob su `pdfs/{resourceKey}/{fileId-random}_file`; `result.FilePath` = questa key (persistita su `PdfDocument.FilePath`).
- **READ** — `PdfProcessingPipelineService` passava `PdfStorageKey.ForPdf(pdfDoc.Id)` (= `pdfId`) **sia come fileId sia come resourceKey**. Ma `ForPdf(Id)` e' solo la cartella `resourceKey`, non il fileId → prefix `pdfs/{pdfId}/{pdfId}_` non matcha il blob reale `pdfs/{pdfId}/{fileId-random}_` → `FileNotFoundException` su **ogni PDF letto via S3/R2** (osservato su staging, 134 PDF seedati; #2666 "riparava" i blob ma il RAG restava vuoto — stessa causa).

Il pattern corretto esisteva gia' in `PdfSeeder` (estrae il fileId dal `FilePath`).

## Fix

1. **Helper condiviso** `PdfStorageKey.FileIdFromPath(string?)` — estrae il fileId dal `FilePath` (segmento dopo l'ultimo separatore `/`|`\`, prima del primo `_`; null-safe su formati imprevisti). Rimosso il duplicato privato `ExtractFileIdFromPath` da `PdfSeeder`, che ora usa l'helper condiviso (2 callsite: repair `ExistsAsync` + `DeletePdfCascadeAsync`).
2. **READ path** in `PdfProcessingPipelineService` corretto in **2 punti** — `ExtractTextAsync` e `LoadPdfBytesAsync` (`ExtractCoverImageAsync` passa da `LoadPdfBytesAsync`, quindi cascading = i 3 punti dell'issue):
   ```csharp
   var resourceKey = PdfStorageKey.ForPdf(pdfDoc.Id);
   var fileId = PdfStorageKey.FileIdFromPath(pdfDoc.FilePath) ?? resourceKey; // fallback legacy
   var stream = await _blobStorageService.RetrieveAsync(fileId, BlobCategory.Pdf, resourceKey, ct);
   ```
   Fallback al filesystem locale (dev/legacy) invariato.
3. **4a istanza dello stesso bug** trovata durante l'implementazione e corretta: `BackfillPdfCoversJob.LoadPdfBytesAsync` (mirror R2-only della pipeline — i cover backfill 404avano identicamente). Non era nell'elenco dell'issue ma e' la stessa root cause.

## Retrocompatibilita' (non regredisce i PDF funzionanti)

- Il fallback `?? ForPdf(Id)` preserva il comportamento pre-fix quando `FilePath` e' vuoto/non parsabile.
- Il `resourceKey` resta `PdfStorageKey.ForPdf(pdfDoc.Id)` (invariato): cambia solo il **fileId** usato per il match dentro quella cartella.
- `FileIdFromPath` gestisce sia `pdfs/{uuid-con-trattini}/{fileId}_file` sia `pdfs/{uuid-senza-trattini}/{fileId}_file` (fileId sempre dopo l'ultimo `/`, prima del primo `_`).

## Test (TDD, no Docker)

- `PdfStorageKeyTests.FileIdFromPath_*` — formati validi (dir con/senza trattini, GUID-N, filename con underscore, backslash Windows) + invalidi (null, empty, senza `_`, senza separatore, underscore iniziale) + coalescing legacy.
- `PdfStorageKeyReadPathRegressionTests` (usa il **local `BlobStorageService`** reale, stesso layout di S3):
  - `ReadPath_RecoversRandomFileIdFromFilePath_FindsBlob` — round-trip `StoreAsync` (fileId random) → READ con `FileIdFromPath(FilePath)` **trova** il blob e i byte esatti (green).
  - `ReadPath_OldBehaviour_UsingForPdfAsFileId_DoesNotFindBlob_RedProof` — **RED proof**: il vecchio `ForPdf(Id)`-come-fileId ritorna `null` (blob non trovato).
  - `ReadPath_LegacyEmptyFilePath_FallsBackToForPdf_FindsBlob` — fallback legacy `FilePath` vuoto → `ForPdf(Id)` trova un blob pre-fix.

Le edge-case di parsing sono state spostate da `PdfSeederBlobTests` a `PdfStorageKeyTests` (single source of truth col codice spostato).

**Build**: `dotnet build` → 0 warning, 0 errori.
**Test**: `dotnet test --filter "…PdfStorageKey|…PdfProcessingPipeline|…PdfSeeder|…BackfillPdfCovers"` → 43/43 verdi.

Closes #2671

🤖 Generated with [Claude Code](https://claude.com/claude-code)
