### PR TITLE
feat(game-night): #2634 C4 — winner display + per-game Completa (SI-3)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/CompleteGameNightSessionCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/CompleteGameNightSessionCommandHandler.cs
@@ -1,26 +1,40 @@
 using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.BoundedContexts.SessionTracking.Application.Commands;
+using Api.BoundedContexts.SessionTracking.Domain.Repositories;
 using Api.BoundedContexts.SessionTracking.Domain.Services;
 using Api.Middleware.Exceptions;
 using Api.SharedKernel.Application.Interfaces;
 using Api.SharedKernel.Infrastructure.Persistence;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
 
 namespace Api.BoundedContexts.GameManagement.Application.Commands.GameNights;
 
 /// <summary>
-/// Handles completing the current in-progress session within a game night.
+/// Handles completing the current in-progress session within a game night (#2634 C4).
+/// Atomically: completes the GameNightSession (setting the winner) AND finalizes the correlated
+/// tracking Session via <see cref="FinalizeSessionCommand"/> — so the tracking Session doesn't
+/// stay live (no orphan / no diverging winner) and its finalize events fire. The WinnerId is
+/// write-validated as a participant of the session (409, never a silent no-winner).
 /// </summary>
 internal sealed class CompleteGameNightSessionCommandHandler : ICommandHandler<CompleteGameNightSessionCommand>
 {
     private readonly IGameNightEventRepository _repository;
+    private readonly ISessionRepository _sessionRepository;
+    private readonly IMediator _mediator;
     private readonly IUnitOfWork _unitOfWork;
     private readonly IAutoSaveSchedulerService _autoSaveScheduler;
 
     public CompleteGameNightSessionCommandHandler(
         IGameNightEventRepository repository,
+        ISessionRepository sessionRepository,
+        IMediator mediator,
         IUnitOfWork unitOfWork,
         IAutoSaveSchedulerService autoSaveScheduler)
     {
         _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _sessionRepository = sessionRepository ?? throw new ArgumentNullException(nameof(sessionRepository));
+        _mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
         _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
         _autoSaveScheduler = autoSaveScheduler ?? throw new ArgumentNullException(nameof(autoSaveScheduler));
     }
@@ -35,19 +49,64 @@ internal sealed class CompleteGameNightSessionCommandHandler : ICommandHandler<C
         if (gameNight.OrganizerId != command.UserId)
             throw new ForbiddenException("Only the organizer can complete sessions.");
 
+        var currentSession = gameNight.CurrentSession
+            ?? throw new ConflictException("No in-progress session to complete.");
+        var trackingSessionId = currentSession.SessionId;
+
+        // Load the tracking Session up front to (a) write-validate the winner and (b) build the
+        // finalize ranks — a WinnerId that is not a participant is a 409, not a silent no-winner
+        // (panel must-fix #3).
+        var session = await _sessionRepository.GetByIdAsync(trackingSessionId, cancellationToken).ConfigureAwait(false)
+            ?? throw new NotFoundException("Session", trackingSessionId.ToString());
+
+        if (command.WinnerId.HasValue && session.Participants.All(p => p.Id != command.WinnerId.Value))
+            throw new ConflictException("Winner must be a participant of the session.");
+
+        // FinalizeSessionCommand requires a rank for every participant: winner = 1, everyone else = 2;
+        // no winner → all 2 (no rank-1 → the finalize event records no winner).
+        var finalRanks = session.Participants.ToDictionary(
+            p => p.Id,
+            p => command.WinnerId.HasValue && p.Id == command.WinnerId.Value ? 1 : 2);
+
+        await _unitOfWork.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+        // Once CommitTransactionAsync starts it owns rollback-on-failure; the catch blocks must not
+        // roll back a second time (mirrors StartGameNightSessionCommandHandler).
+        var commitStarted = false;
         try
         {
-            var currentSession = gameNight.CurrentSession;
             gameNight.CompleteCurrentSession(command.WinnerId);
             await _repository.UpdateAsync(gameNight, cancellationToken).ConfigureAwait(false);
             await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
-            if (currentSession != null)
-                await _autoSaveScheduler.RemoveAsync(currentSession.SessionId, cancellationToken).ConfigureAwait(false);
+            // Cross-BC: finalize the tracking Session in the SAME transaction. Session.Finalize
+            // enforces Active/Paused; its inner SaveChangesAsync enlists in this ambient tx, so a
+            // later failure rolls back BOTH the GameNightSession completion and the finalize.
+            await _mediator.Send(new FinalizeSessionCommand(trackingSessionId, finalRanks), cancellationToken).ConfigureAwait(false);
+
+            commitStarted = true;
+            await _unitOfWork.CommitTransactionAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (DbUpdateConcurrencyException)
+        {
+            if (!commitStarted)
+                await _unitOfWork.RollbackTransactionAsync(cancellationToken).ConfigureAwait(false);
+            throw new ConflictException("The session was modified concurrently. Please retry.");
         }
         catch (InvalidOperationException ex)
         {
+            if (!commitStarted)
+                await _unitOfWork.RollbackTransactionAsync(cancellationToken).ConfigureAwait(false);
             throw new ConflictException(ex.Message);
         }
+        catch (Exception)
+        {
+            // ConflictException from FinalizeSessionCommand (wrong status / rank mismatch) and any
+            // other failure roll back atomically, then propagate unchanged.
+            if (!commitStarted)
+                await _unitOfWork.RollbackTransactionAsync(cancellationToken).ConfigureAwait(false);
+            throw;
+        }
+
+        await _autoSaveScheduler.RemoveAsync(trackingSessionId, cancellationToken).ConfigureAwait(false);
     }
 }

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/CompleteGameNightSessionCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/CompleteGameNightSessionCommandHandler.cs
@@ -79,8 +79,12 @@ internal sealed class CompleteGameNightSessionCommandHandler : ICommandHandler<C
             await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
             // Cross-BC: finalize the tracking Session in the SAME transaction. Session.Finalize
-            // enforces Active/Paused; its inner SaveChangesAsync enlists in this ambient tx, so a
-            // later failure rolls back BOTH the GameNightSession completion and the finalize.
+            // enforces Active/Paused; its inner SaveChangesAsync enlists in this ambient tx, so the
+            // DB changes (GameNightSession complete + tracking Session finalize) roll back together.
+            // KNOWN RISK (accepted, → SI-3-proper): FinalizeSessionCommandHandler's SSE side-effects
+            // (_diaryStream.Publish + _syncService.PublishEventAsync) fire before CommitTransactionAsync,
+            // so a rare commit failure leaves phantom broadcasts — clients self-correct on the next
+            // poll. See must-fix #5 in the C4 spec (2026-07-05-issue-2634-c4-winner-completa-design.md).
             await _mediator.Send(new FinalizeSessionCommand(trackingSessionId, finalRanks), cancellationToken).ConfigureAwait(false);
 
             commitStarted = true;

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/StartGameNightSessionCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/StartGameNightSessionCommandHandler.cs
@@ -1,5 +1,7 @@
+using Api.BoundedContexts.Authentication.Application.DTOs;
 using Api.BoundedContexts.Authentication.Application.Queries;
 using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.BoundedContexts.GameManagement.Domain.Enums;
 using Api.BoundedContexts.GameManagement.Domain.Exceptions;
 using Api.BoundedContexts.GameToolbox.Application.Commands;
 using Api.BoundedContexts.GameToolbox.Application.Queries;
@@ -57,7 +59,7 @@ internal sealed class StartGameNightSessionCommandHandler : ICommandHandler<Star
         gameNight.EnsureCanStartSession();
 
         // Build participant list: auto-seed organizer when command provides none.
-        var participants = await BuildParticipantsAsync(command, cancellationToken).ConfigureAwait(false);
+        var participants = await BuildParticipantsAsync(gameNight, command, cancellationToken).ConfigureAwait(false);
 
         // WS1 DEC-5 (atomicity): the cross-BC Session INSERT and the aggregate link run in ONE
         // explicit transaction. CreateSessionCommand's inner SaveChangesAsync enlists in this
@@ -160,7 +162,7 @@ internal sealed class StartGameNightSessionCommandHandler : ICommandHandler<Star
     }
 
     private async Task<List<ParticipantDto>> BuildParticipantsAsync(
-        StartGameNightSessionCommand command, CancellationToken cancellationToken)
+        GameNightEvent gameNight, StartGameNightSessionCommand command, CancellationToken cancellationToken)
     {
         if (command.Participants is not null && command.Participants.Count > 0)
         {
@@ -169,24 +171,50 @@ internal sealed class StartGameNightSessionCommandHandler : ICommandHandler<Star
             return command.Participants.ToList();
         }
 
-        // Auto-seed: look up organizer via Authentication BC (cross-BC MediatR dispatch)
+        // #2634 C4: seed the roster from the night — the organizer as owner (JoinOrder 0) plus every
+        // ACCEPTED-RSVP player. This replaces the WS1 organizer-only auto-seed so a real night carries
+        // its confirmed players (and the winner picker has real candidates). RSVPs are User-linked, so
+        // this seeds Users only; a guest-player mechanism is out of C4 scope.
         var organizer = await _mediator.Send(new GetUserByIdQuery(command.UserId), cancellationToken).ConfigureAwait(false)
             ?? throw new NotFoundException("User", command.UserId.ToString());
 
-        var displayName = !string.IsNullOrWhiteSpace(organizer.DisplayName)
-            ? organizer.DisplayName
-            : organizer.Email;
-
-        return new List<ParticipantDto>
+        var participants = new List<ParticipantDto>
         {
             new()
             {
                 Id = Guid.NewGuid(),
                 UserId = command.UserId,
-                DisplayName = displayName,
+                DisplayName = DisplayNameOf(organizer),
                 IsOwner = true,
                 JoinOrder = 0
             }
         };
+
+        var acceptedPlayerIds = gameNight.Rsvps
+            .Where(r => r.Status == RsvpStatus.Accepted && r.UserId != command.UserId)
+            .Select(r => r.UserId)
+            .Distinct()
+            .ToList();
+
+        var joinOrder = 1;
+        foreach (var userId in acceptedPlayerIds)
+        {
+            var player = await _mediator.Send(new GetUserByIdQuery(userId), cancellationToken).ConfigureAwait(false);
+            if (player is null) continue; // an accepted RSVP whose user no longer resolves is skipped, not fatal
+
+            participants.Add(new ParticipantDto
+            {
+                Id = Guid.NewGuid(),
+                UserId = userId,
+                DisplayName = DisplayNameOf(player),
+                IsOwner = false,
+                JoinOrder = joinOrder++
+            });
+        }
+
+        return participants;
     }
+
+    private static string DisplayNameOf(UserDto user) =>
+        !string.IsNullOrWhiteSpace(user.DisplayName) ? user.DisplayName : user.Email;
 }

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/GameNights/GameNightLiveDto.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/GameNights/GameNightLiveDto.cs
@@ -19,12 +19,22 @@ public sealed record GameNightLiveDto(
     bool IsViewerOrganizer,
     // WS1 DEC-9: the planned games not yet turned into a Session, in planned order.
     // The CTA starts the first of these (needs GameId + GameTitle for POST /sessions).
-    IReadOnlyList<GameNightLineupItemDto> PlannedLineup);
+    IReadOnlyList<GameNightLineupItemDto> PlannedLineup,
+    // #2634 C4: the in-progress session's participants (Participant.Id + DisplayName), sourced from
+    // this already-participant-guarded read so the winner picker never hits the unguarded
+    // GET /game-sessions/{id} roster (IDOR). Empty when no game is live.
+    IReadOnlyList<GameNightRosterMemberDto> CurrentSessionRoster);
 
 /// <summary>
 /// A planned game in the night's line-up that has not yet been started as a Session.
 /// </summary>
 public sealed record GameNightLineupItemDto(Guid GameId, string GameTitle);
+
+/// <summary>
+/// #2634 C4: a candidate winner in the current live session — a tracking-Session Participant.
+/// <see cref="ParticipantId"/> is what the FE sends as the winner on POST /sessions/complete.
+/// </summary>
+public sealed record GameNightRosterMemberDto(Guid ParticipantId, string DisplayName);
 
 /// <summary>
 /// A single sitting within the night — a projection of the <c>GameNightSession</c> child entity.
@@ -39,5 +49,9 @@ public sealed record GameNightSessionDto(
     int PlayOrder,
     GameNightSessionStatus Status,
     Guid? WinnerId,
+    // #2634 C4: the WinnerId (a tracking-Session Participant.Id) resolved to a display name,
+    // scoped by (SessionId, WinnerId) so a stray/foreign id fails closed to null. null when the
+    // session has no winner (or it could not be resolved).
+    string? WinnerName,
     DateTimeOffset? StartedAt,
     DateTimeOffset? CompletedAt);

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GetGameNightLiveQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GetGameNightLiveQueryHandler.cs
@@ -1,5 +1,6 @@
 using Api.BoundedContexts.GameManagement.Application.DTOs.GameNights;
 using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.BoundedContexts.GameManagement.Domain.Enums;
 using Api.Infrastructure;
 using Api.Middleware.Exceptions;
 using Api.SharedKernel.Application.Interfaces;
@@ -37,6 +38,28 @@ internal sealed class GetGameNightLiveQueryHandler : IQueryHandler<GetGameNightL
         if (!isParticipant)
             throw new ForbiddenException("Only the organizer or an invited player can view the night-live state.");
 
+        // #2634 C4: batch-load the tracking-Session participants for winner-name resolution + the
+        // in-progress roster (the winner picker). Deliberate GameManagement→SessionTracking cross-BC
+        // read over the participant table; scoped to this night's sessions only.
+        var sessionIds = gameNight.Sessions.Select(s => s.SessionId).ToList();
+        var participants = sessionIds.Count == 0
+            ? new List<ParticipantRef>()
+            : await _db.SessionTrackingParticipants.AsNoTracking()
+                .Where(p => sessionIds.Contains(p.SessionId))
+                .Select(p => new ParticipantRef(p.Id, p.SessionId, p.DisplayName))
+                .ToListAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+        // Scoped by (SessionId, WinnerId): a stray/foreign Participant.Id fails closed to null
+        // rather than resolving a plausible-but-wrong name (panel D2).
+        string? WinnerNameFor(GameNightSession s) =>
+            s.WinnerId is { } wid
+                ? participants
+                    .Where(p => p.SessionId == s.SessionId && p.Id == wid)
+                    .Select(p => p.DisplayName)
+                    .FirstOrDefault()
+                : null;
+
         var sessions = gameNight.Sessions
             .OrderBy(s => s.PlayOrder)
             .Select(s => new GameNightSessionDto(
@@ -46,9 +69,20 @@ internal sealed class GetGameNightLiveQueryHandler : IQueryHandler<GetGameNightL
                 s.PlayOrder,
                 s.Status,
                 s.WinnerId,
+                WinnerNameFor(s),
                 s.StartedAt,
                 s.CompletedAt))
             .ToList();
+
+        // The winner picker candidates = the participants of the (single) in-progress session.
+        var inProgressSessionId = gameNight.Sessions
+            .FirstOrDefault(s => s.Status == GameNightSessionStatus.InProgress)?.SessionId;
+        var currentSessionRoster = inProgressSessionId is { } liveId
+            ? participants
+                .Where(p => p.SessionId == liveId)
+                .Select(p => new GameNightRosterMemberDto(p.Id, p.DisplayName))
+                .ToList()
+            : new List<GameNightRosterMemberDto>();
 
         // WS1 DEC-9: the planned games (GameIds) not yet started as a Session, in planned order.
         var startedGameIds = gameNight.Sessions.Select(s => s.GameId).ToHashSet();
@@ -65,6 +99,10 @@ internal sealed class GetGameNightLiveQueryHandler : IQueryHandler<GetGameNightL
             .ToList();
 
         return new GameNightLiveDto(
-            gameNight.Id, gameNight.Title, gameNight.Status, sessions, isOrganizer, plannedLineup);
+            gameNight.Id, gameNight.Title, gameNight.Status, sessions, isOrganizer, plannedLineup,
+            currentSessionRoster);
     }
+
+    /// <summary>A tracking-Session participant, flattened for the cross-BC roster read.</summary>
+    private sealed record ParticipantRef(Guid Id, Guid SessionId, string DisplayName);
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/GameNight/CompleteGameNightSessionCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/GameNight/CompleteGameNightSessionCommandHandlerTests.cs
@@ -1,0 +1,162 @@
+using Api.BoundedContexts.GameManagement.Application.Commands.GameNights;
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.BoundedContexts.SessionTracking.Application.Commands;
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using Api.BoundedContexts.SessionTracking.Domain.Services;
+using Api.BoundedContexts.SessionTracking.Domain.ValueObjects;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Tests.Constants;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Application.GameNight;
+
+/// <summary>
+/// #2634 C4: completing a game night session sets the GameNightSession winner AND atomically
+/// finalizes the correlated tracking Session (no orphan / canonical winner), with the WinnerId
+/// write-validated as a participant and concurrency mapped to 409.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "GameManagement")]
+public class CompleteGameNightSessionCommandHandlerTests
+{
+    private readonly Mock<IGameNightEventRepository> _gameNightRepo = new();
+    private readonly Mock<ISessionRepository> _sessionRepo = new();
+    private readonly Mock<IMediator> _mediator = new();
+    private readonly Mock<IUnitOfWork> _uow = new();
+    private readonly Mock<IAutoSaveSchedulerService> _autoSave = new();
+    private readonly CompleteGameNightSessionCommandHandler _handler;
+
+    public CompleteGameNightSessionCommandHandlerTests()
+    {
+        _handler = new CompleteGameNightSessionCommandHandler(
+            _gameNightRepo.Object, _sessionRepo.Object, _mediator.Object, _uow.Object, _autoSave.Object);
+        _mediator.Setup(m => m.Send(It.IsAny<FinalizeSessionCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new FinalizeSessionResult(null, new Dictionary<Guid, decimal>()));
+    }
+
+    /// <summary>Builds a started night whose current session is a tracking Session with 2 participants.</summary>
+    private (GameNightEvent night, Session session) StartedNightWithTwoPlayers(Guid organizerId)
+    {
+        var gameId = Guid.NewGuid();
+        var session = Session.Create(organizerId, gameId, SessionType.GameSpecific); // owner participant
+        session.AddParticipant(ParticipantInfo.Create("Player Two", isOwner: false, joinOrder: 2), Guid.NewGuid());
+
+        var night = GameNightEvent.Create(
+            organizerId, "Serata", DateTimeOffset.UtcNow.AddHours(1), gameIds: [gameId]);
+        night.Publish([]);
+        night.AddSession(session.Id, gameId, "Catan");
+        night.StartCurrentSession(); // InProgress
+
+        _gameNightRepo.Setup(r => r.GetByIdAsync(night.Id, It.IsAny<CancellationToken>())).ReturnsAsync(night);
+        _sessionRepo.Setup(r => r.GetByIdAsync(session.Id, It.IsAny<CancellationToken>())).ReturnsAsync(session);
+        return (night, session);
+    }
+
+    [Fact]
+    public async Task Handle_NonOrganizer_ThrowsForbidden()
+    {
+        var (night, _) = StartedNightWithTwoPlayers(Guid.NewGuid());
+        var act = () => _handler.Handle(
+            new CompleteGameNightSessionCommand(night.Id, null, Guid.NewGuid()), CancellationToken.None);
+        await act.Should().ThrowAsync<ForbiddenException>();
+    }
+
+    [Fact]
+    public async Task Handle_NightNotFound_ThrowsNotFound()
+    {
+        _gameNightRepo.Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((GameNightEvent?)null);
+        var act = () => _handler.Handle(
+            new CompleteGameNightSessionCommand(Guid.NewGuid(), null, Guid.NewGuid()), CancellationToken.None);
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+
+    [Fact]
+    public async Task Handle_NoInProgressSession_ThrowsConflict()
+    {
+        var organizerId = Guid.NewGuid();
+        var night = GameNightEvent.Create(organizerId, "Serata", DateTimeOffset.UtcNow.AddHours(1), gameIds: [Guid.NewGuid()]);
+        night.Publish([]); // no session started → no CurrentSession
+        _gameNightRepo.Setup(r => r.GetByIdAsync(night.Id, It.IsAny<CancellationToken>())).ReturnsAsync(night);
+
+        var act = () => _handler.Handle(
+            new CompleteGameNightSessionCommand(night.Id, null, organizerId), CancellationToken.None);
+        await act.Should().ThrowAsync<ConflictException>();
+    }
+
+    [Fact]
+    public async Task Handle_WinnerNotAParticipant_ThrowsConflict_AndDoesNotFinalize()
+    {
+        var organizerId = Guid.NewGuid();
+        var (night, _) = StartedNightWithTwoPlayers(organizerId);
+
+        var act = () => _handler.Handle(
+            new CompleteGameNightSessionCommand(night.Id, Guid.NewGuid() /* stranger */, organizerId),
+            CancellationToken.None);
+
+        await act.Should().ThrowAsync<ConflictException>();
+        _mediator.Verify(m => m.Send(It.IsAny<FinalizeSessionCommand>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_WithWinner_CompletesAndFinalizesWithWinnerRankOne()
+    {
+        var organizerId = Guid.NewGuid();
+        var (night, session) = StartedNightWithTwoPlayers(organizerId);
+        var winner = session.Participants.ElementAt(1); // Player Two
+        var loser = session.Participants.ElementAt(0);
+
+        await _handler.Handle(
+            new CompleteGameNightSessionCommand(night.Id, winner.Id, organizerId), CancellationToken.None);
+
+        night.Sessions[0].WinnerId.Should().Be(winner.Id);
+        _uow.Verify(u => u.BeginTransactionAsync(It.IsAny<CancellationToken>()), Times.Once);
+        _uow.Verify(u => u.CommitTransactionAsync(It.IsAny<CancellationToken>()), Times.Once);
+        _uow.Verify(u => u.RollbackTransactionAsync(It.IsAny<CancellationToken>()), Times.Never);
+        _mediator.Verify(m => m.Send(
+            It.Is<FinalizeSessionCommand>(c =>
+                c.SessionId == session.Id &&
+                c.FinalRanks[winner.Id] == 1 &&
+                c.FinalRanks[loser.Id] == 2),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_NoWinner_FinalizesWithEveryoneRankTwo()
+    {
+        var organizerId = Guid.NewGuid();
+        var (night, session) = StartedNightWithTwoPlayers(organizerId);
+
+        await _handler.Handle(
+            new CompleteGameNightSessionCommand(night.Id, null, organizerId), CancellationToken.None);
+
+        _mediator.Verify(m => m.Send(
+            It.Is<FinalizeSessionCommand>(c =>
+                c.SessionId == session.Id &&
+                c.FinalRanks.Count == 2 &&
+                c.FinalRanks.Values.All(r => r == 2)),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ConcurrencyOnSave_RollsBackAndThrows409()
+    {
+        var organizerId = Guid.NewGuid();
+        var (night, _) = StartedNightWithTwoPlayers(organizerId);
+        _uow.Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new DbUpdateConcurrencyException());
+
+        var act = () => _handler.Handle(
+            new CompleteGameNightSessionCommand(night.Id, null, organizerId), CancellationToken.None);
+
+        await act.Should().ThrowAsync<ConflictException>();
+        _uow.Verify(u => u.RollbackTransactionAsync(It.IsAny<CancellationToken>()), Times.Once);
+        _uow.Verify(u => u.CommitTransactionAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/GameNight/GetGameNightLiveQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/GameNight/GetGameNightLiveQueryHandlerTests.cs
@@ -171,4 +171,105 @@ public class GetGameNightLiveQueryHandlerTests : IDisposable
 
         await act.Should().ThrowAsync<NotFoundException>();
     }
+
+    // #2634 C4: resolve GameNightSession.WinnerId (a tracking Participant.Id) to a display name,
+    // scoped by (SessionId, WinnerId) so a foreign id fails closed to null.
+    [Fact]
+    public async Task Handle_ResolvesWinnerNameScopedBySession_AndNullsForeignIds()
+    {
+        var organizerId = Guid.NewGuid();
+        var sessionId = Guid.NewGuid();
+        var winnerId = Guid.NewGuid();
+        _db.SessionTrackingParticipants.Add(new Api.Infrastructure.Entities.SessionTracking.ParticipantEntity
+        {
+            Id = winnerId, SessionId = sessionId, DisplayName = "Alice", UserId = Guid.NewGuid(), JoinOrder = 1
+        });
+        // A participant with the SAME id but a DIFFERENT session must NOT resolve (scoping).
+        _db.SessionTrackingParticipants.Add(new Api.Infrastructure.Entities.SessionTracking.ParticipantEntity
+        {
+            Id = Guid.NewGuid(), SessionId = Guid.NewGuid(), DisplayName = "Bob", UserId = Guid.NewGuid(), JoinOrder = 1
+        });
+        await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var evt = GameNightEvent.Create(
+            organizerId, "Serata", DateTimeOffset.UtcNow.AddHours(1), gameIds: [Guid.NewGuid()]);
+        evt.Publish([]);
+        evt.AddSession(sessionId, evt.GameIds[0], "Catan");
+        evt.StartCurrentSession();
+        evt.CompleteCurrentSession(winnerId); // Completed with winner
+        _repo.Setup(r => r.GetByIdAsync(evt.Id, It.IsAny<CancellationToken>())).ReturnsAsync(evt);
+
+        var result = await _handler.Handle(
+            new GetGameNightLiveQuery(evt.Id, organizerId), TestContext.Current.CancellationToken);
+
+        result.Sessions[0].WinnerId.Should().Be(winnerId);
+        result.Sessions[0].WinnerName.Should().Be("Alice");
+    }
+
+    [Fact]
+    public async Task Handle_ForeignWinnerId_ResolvesToNullName()
+    {
+        var organizerId = Guid.NewGuid();
+        var sessionId = Guid.NewGuid();
+        var evt = GameNightEvent.Create(
+            organizerId, "Serata", DateTimeOffset.UtcNow.AddHours(1), gameIds: [Guid.NewGuid()]);
+        evt.Publish([]);
+        evt.AddSession(sessionId, evt.GameIds[0], "Catan");
+        evt.StartCurrentSession();
+        evt.CompleteCurrentSession(Guid.NewGuid()); // winner id with NO matching participant row
+        _repo.Setup(r => r.GetByIdAsync(evt.Id, It.IsAny<CancellationToken>())).ReturnsAsync(evt);
+
+        var result = await _handler.Handle(
+            new GetGameNightLiveQuery(evt.Id, organizerId), TestContext.Current.CancellationToken);
+
+        result.Sessions[0].WinnerName.Should().BeNull();
+    }
+
+    // #2634 C4: the in-progress session's participants feed the winner picker off this guarded read.
+    [Fact]
+    public async Task Handle_ExposesInProgressSessionRoster()
+    {
+        var organizerId = Guid.NewGuid();
+        var liveSessionId = Guid.NewGuid();
+        var p1 = Guid.NewGuid();
+        var p2 = Guid.NewGuid();
+        _db.SessionTrackingParticipants.Add(new Api.Infrastructure.Entities.SessionTracking.ParticipantEntity
+        {
+            Id = p1, SessionId = liveSessionId, DisplayName = "Host", UserId = organizerId, IsOwner = true, JoinOrder = 1
+        });
+        _db.SessionTrackingParticipants.Add(new Api.Infrastructure.Entities.SessionTracking.ParticipantEntity
+        {
+            Id = p2, SessionId = liveSessionId, DisplayName = "Guest Gina", UserId = null, JoinOrder = 2
+        });
+        await _db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var evt = GameNightEvent.Create(
+            organizerId, "Serata", DateTimeOffset.UtcNow.AddHours(1), gameIds: [Guid.NewGuid()]);
+        evt.Publish([]);
+        evt.AddSession(liveSessionId, evt.GameIds[0], "Catan");
+        evt.StartCurrentSession(); // InProgress
+        _repo.Setup(r => r.GetByIdAsync(evt.Id, It.IsAny<CancellationToken>())).ReturnsAsync(evt);
+
+        var result = await _handler.Handle(
+            new GetGameNightLiveQuery(evt.Id, organizerId), TestContext.Current.CancellationToken);
+
+        result.CurrentSessionRoster.Should().HaveCount(2);
+        result.CurrentSessionRoster.Should().Contain(m => m.ParticipantId == p1 && m.DisplayName == "Host");
+        result.CurrentSessionRoster.Should().Contain(m => m.ParticipantId == p2 && m.DisplayName == "Guest Gina");
+    }
+
+    [Fact]
+    public async Task Handle_NoLiveSession_RosterIsEmpty()
+    {
+        var organizerId = Guid.NewGuid();
+        var evt = GameNightEvent.Create(
+            organizerId, "Serata", DateTimeOffset.UtcNow.AddHours(1), gameIds: [Guid.NewGuid()]);
+        evt.Publish([]); // no session started
+        _repo.Setup(r => r.GetByIdAsync(evt.Id, It.IsAny<CancellationToken>())).ReturnsAsync(evt);
+
+        var result = await _handler.Handle(
+            new GetGameNightLiveQuery(evt.Id, organizerId), TestContext.Current.CancellationToken);
+
+        result.CurrentSessionRoster.Should().BeEmpty();
+    }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/GameNight/StartGameNightSessionCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/GameNight/StartGameNightSessionCommandHandlerTests.cs
@@ -196,6 +196,48 @@ public class StartGameNightSessionCommandHandlerTests
     }
 
     [Fact]
+    public async Task Handle_NoParticipants_SeedsOrganizerOwnerPlusAcceptedRsvpPlayers()
+    {
+        // #2634 C4: when the start command carries no explicit roster, seed from the night —
+        // the organizer as owner + every ACCEPTED-RSVP player (Pending/Declined excluded).
+        var organizerId = Guid.NewGuid();
+        var player2 = Guid.NewGuid();
+        var player3 = Guid.NewGuid();
+        var pendingPlayer = Guid.NewGuid();
+        var gameNight = GameNightEvent.Create(
+            organizerId, "Serata", DateTimeOffset.UtcNow.AddHours(1), gameIds: [Guid.NewGuid()]);
+        gameNight.Publish([player2, player3, pendingPlayer]); // 3 invited → Pending RSVPs
+        gameNight.GetRsvp(player2)!.Accept();
+        gameNight.GetRsvp(player3)!.Accept();
+        // pendingPlayer stays Pending → excluded from the seeded roster
+
+        _mockRepository.Setup(r => r.GetByIdAsync(gameNight.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(gameNight);
+        _mockMediator.Setup(m => m.Send(It.IsAny<GetUserByIdQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((GetUserByIdQuery q, CancellationToken _) =>
+                CreateOrganizerDto(q.UserId, $"User-{q.UserId.ToString()[..4]}"));
+        _mockMediator.Setup(m => m.Send(It.IsAny<CreateSessionCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new CreateSessionResult(
+                Guid.NewGuid(), "ABC123", [], GameNightEventId: gameNight.Id,
+                GameNightWasCreated: false, AgentDefinitionId: null, ToolkitId: null));
+
+        var command = new StartGameNightSessionCommand(
+            gameNight.Id, gameNight.GameIds[0], "Catan", organizerId);
+
+        await _handler.Handle(command, CancellationToken.None);
+
+        _mockMediator.Verify(m => m.Send(
+            It.Is<CreateSessionCommand>(c =>
+                c.Participants.Count == 3 &&
+                c.Participants.Count(p => p.IsOwner) == 1 &&
+                c.Participants.Any(p => p.UserId == organizerId && p.IsOwner) &&
+                c.Participants.Any(p => p.UserId == player2 && !p.IsOwner) &&
+                c.Participants.Any(p => p.UserId == player3 && !p.IsOwner) &&
+                c.Participants.All(p => p.UserId != pendingPlayer)),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
     public async Task Handle_WithProvidedParticipants_UsesThemDirectly()
     {
         // Arrange

--- a/apps/web/src/app/(authenticated)/game-nights/[id]/live/_components/NightLiveClientView.tsx
+++ b/apps/web/src/app/(authenticated)/game-nights/[id]/live/_components/NightLiveClientView.tsx
@@ -203,7 +203,10 @@ export function NightLiveClientView({ nightId }: NightLiveClientViewProps) {
         <div className="fixed inset-x-0 bottom-0 z-40 flex justify-center p-4">
           <button
             type="button"
-            onClick={() => setWinnerPickerOpen(true)}
+            onClick={() => {
+              completeGame.reset(); // clear a stale 409/403 from a previous attempt before re-opening
+              setWinnerPickerOpen(true);
+            }}
             disabled={completeGame.isPending}
             className="flex items-center gap-2 rounded-full border border-entity-session/40 bg-entity-session px-5 py-2.5 font-display text-sm font-extrabold text-white shadow-lg transition hover:bg-entity-session/90 disabled:cursor-not-allowed disabled:opacity-60"
           >

--- a/apps/web/src/app/(authenticated)/game-nights/[id]/live/_components/NightLiveClientView.tsx
+++ b/apps/web/src/app/(authenticated)/game-nights/[id]/live/_components/NightLiveClientView.tsx
@@ -17,8 +17,18 @@ import { useCallback, useEffect, useState, type ReactNode } from 'react';
 
 import { useRouter } from 'next/navigation';
 
-import { BlockedLiveSessionModal, NightLiveHub } from '@/components/features/game-nights/live';
-import { ForbiddenError, NotFoundError, UnauthorizedError } from '@/lib/api/core/errors';
+import {
+  BlockedLiveSessionModal,
+  NightLiveHub,
+  WinnerPickerModal,
+} from '@/components/features/game-nights/live';
+import {
+  ConflictError,
+  ForbiddenError,
+  NotFoundError,
+  UnauthorizedError,
+} from '@/lib/api/core/errors';
+import { useCompleteGameNightSession } from '@/lib/game-nights/hooks/useCompleteGameNightSession';
 import { useGameNightLive } from '@/lib/game-nights/hooks/useGameNightLive';
 import { useNightLiveDiary } from '@/lib/game-nights/hooks/useNightLiveDiary';
 import { isMaxLiveBlockedError, useStartNextGame } from '@/lib/game-nights/hooks/useStartNextGame';
@@ -68,6 +78,17 @@ export function NightLiveClientView({ nightId }: NightLiveClientViewProps) {
       );
     },
     [startNextGame]
+  );
+
+  // #2634 C4: organizer completes the live game, optionally picking a winner from the guarded
+  // roster. Complementary to the WS1 start CTA (live → Completa → transition → Avvia prossimo).
+  const completeGame = useCompleteGameNightSession(nightId);
+  const [winnerPickerOpen, setWinnerPickerOpen] = useState(false);
+  const handleCompleteConfirm = useCallback(
+    (winnerId?: string) => {
+      completeGame.mutate({ winnerId }, { onSuccess: () => setWinnerPickerOpen(false) });
+    },
+    [completeGame]
   );
 
   // LD-14: a Completed night must not render a fake-live hub over stale data —
@@ -128,6 +149,15 @@ export function NightLiveClientView({ nightId }: NightLiveClientViewProps) {
   // DEC-10: hidden when a game is already live (status==='live') — you can only start the
   // next game when the current one is over. The 409 modal is the backstop for races.
   const showStartCta = vm.isViewerOrganizer && nextGame !== null && vm.status !== 'live';
+  // #2634 C4: the organizer completes the live game. Mutually exclusive with the start CTA above.
+  const showCompleteCta = vm.isViewerOrganizer && vm.status === 'live';
+  const completeErrorMessage = completeGame.isError
+    ? completeGame.error instanceof ForbiddenError
+      ? 'Solo l’organizzatore può completare la partita.'
+      : completeGame.error instanceof ConflictError
+        ? 'Non è possibile completare ora (nessuna partita live o vincitore non valido).'
+        : 'Impossibile completare la partita. Riprova.'
+    : null;
 
   // Slice C2 (panel D2): compose the diary here, keyed off the live sessionId→game lookup.
   // A pending/errored diary read yields empty arrays — the hub degrades to an empty diary
@@ -168,6 +198,28 @@ export function NightLiveClientView({ nightId }: NightLiveClientViewProps) {
           </button>
         </div>
       ) : null}
+
+      {showCompleteCta ? (
+        <div className="fixed inset-x-0 bottom-0 z-40 flex justify-center p-4">
+          <button
+            type="button"
+            onClick={() => setWinnerPickerOpen(true)}
+            disabled={completeGame.isPending}
+            className="flex items-center gap-2 rounded-full border border-entity-session/40 bg-entity-session px-5 py-2.5 font-display text-sm font-extrabold text-white shadow-lg transition hover:bg-entity-session/90 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            🏁 Completa partita
+          </button>
+        </div>
+      ) : null}
+
+      <WinnerPickerModal
+        open={winnerPickerOpen}
+        candidates={vm.winnerCandidates}
+        pending={completeGame.isPending}
+        errorMessage={winnerPickerOpen ? completeErrorMessage : null}
+        onCancel={() => setWinnerPickerOpen(false)}
+        onConfirm={handleCompleteConfirm}
+      />
 
       <BlockedLiveSessionModal
         open={blockedModalOpen}

--- a/apps/web/src/app/(authenticated)/game-nights/[id]/live/_components/__tests__/NightLiveClientView.test.tsx
+++ b/apps/web/src/app/(authenticated)/game-nights/[id]/live/_components/__tests__/NightLiveClientView.test.tsx
@@ -55,6 +55,7 @@ vi.mock('@/lib/game-nights/hooks/useNightLiveDiary', () => ({
 
 // #2634 C4: the organizer "Completa" mutation.
 const completeMutateMock = vi.hoisted(() => vi.fn());
+const completeResetMock = vi.hoisted(() => vi.fn());
 const completeState = vi.hoisted(() => ({
   isPending: false,
   isError: false,
@@ -63,6 +64,7 @@ const completeState = vi.hoisted(() => ({
 vi.mock('@/lib/game-nights/hooks/useCompleteGameNightSession', () => ({
   useCompleteGameNightSession: () => ({
     mutate: completeMutateMock,
+    reset: completeResetMock,
     isPending: completeState.isPending,
     isError: completeState.isError,
     error: completeState.error,
@@ -347,6 +349,17 @@ describe('NightLiveClientView — organizer Completa + winner picker (C4)', () =
     expect(screen.getByRole('dialog')).toBeInTheDocument();
     expect(screen.getByText('Alice')).toBeInTheDocument();
     expect(screen.getByText('Bob')).toBeInTheDocument();
+  });
+
+  it('resets a stale mutation error before re-opening the picker', async () => {
+    // A previous attempt left a 409 on the mutation; opening the picker must clear it first so
+    // the re-opened modal does not immediately show the old error (review MINOR #2).
+    completeState.isError = true;
+    completeState.error = new ConflictError({ message: 'no live' });
+    mockQuery({ data: vm({ isViewerOrganizer: true, status: 'live', winnerCandidates: ROSTER }) });
+    render(<NightLiveClientView nightId={NIGHT_ID} />);
+    await userEvent.click(screen.getByRole('button', { name: /Completa partita/i }));
+    expect(completeResetMock).toHaveBeenCalledTimes(1);
   });
 
   it('completes with the selected winner participant id', async () => {

--- a/apps/web/src/app/(authenticated)/game-nights/[id]/live/_components/__tests__/NightLiveClientView.test.tsx
+++ b/apps/web/src/app/(authenticated)/game-nights/[id]/live/_components/__tests__/NightLiveClientView.test.tsx
@@ -53,6 +53,22 @@ vi.mock('@/lib/game-nights/hooks/useNightLiveDiary', () => ({
   },
 }));
 
+// #2634 C4: the organizer "Completa" mutation.
+const completeMutateMock = vi.hoisted(() => vi.fn());
+const completeState = vi.hoisted(() => ({
+  isPending: false,
+  isError: false,
+  error: null as Error | null,
+}));
+vi.mock('@/lib/game-nights/hooks/useCompleteGameNightSession', () => ({
+  useCompleteGameNightSession: () => ({
+    mutate: completeMutateMock,
+    isPending: completeState.isPending,
+    isError: completeState.isError,
+    error: completeState.error,
+  }),
+}));
+
 const pushMock = vi.fn();
 const replaceMock = vi.fn();
 vi.mock('next/navigation', () => ({
@@ -98,6 +114,7 @@ function vm(over: Partial<NightLiveViewModel> = {}): NightLiveViewModel {
     ],
     currentGame: null,
     sessions: [],
+    winnerCandidates: [],
     ...over,
   };
 }
@@ -115,6 +132,9 @@ function mockQuery(over: Record<string, unknown>) {
 beforeEach(() => {
   vi.clearAllMocks();
   startNextState.isPending = false;
+  completeState.isPending = false;
+  completeState.isError = false;
+  completeState.error = null;
   useNightLiveDiaryMock.mockReturnValue({ data: undefined });
 });
 
@@ -291,6 +311,65 @@ describe('NightLiveClientView — diary composition (Slice C2)', () => {
 
     // the live hub still renders (no crash / no dependency on the diary read)
     expect(screen.getByText('Serata Eldoria')).toBeInTheDocument();
+  });
+});
+
+describe('NightLiveClientView — organizer Completa + winner picker (C4)', () => {
+  const ROSTER = [
+    { id: '77777777-7777-4777-8777-777777777777', displayName: 'Alice' },
+    { id: '88888888-8888-4888-8888-888888888888', displayName: 'Bob' },
+  ];
+
+  it('shows the "Completa partita" CTA for the organizer while a game is live', () => {
+    mockQuery({ data: vm({ isViewerOrganizer: true, status: 'live', winnerCandidates: ROSTER }) });
+    render(<NightLiveClientView nightId={NIGHT_ID} />);
+    expect(screen.getByRole('button', { name: /Completa partita/i })).toBeInTheDocument();
+  });
+
+  it('does NOT show the Completa CTA for a non-organizer', () => {
+    mockQuery({ data: vm({ isViewerOrganizer: false, status: 'live', winnerCandidates: ROSTER }) });
+    render(<NightLiveClientView nightId={NIGHT_ID} />);
+    expect(screen.queryByRole('button', { name: /Completa partita/i })).toBeNull();
+  });
+
+  it('does NOT show the Completa CTA when no game is live', () => {
+    mockQuery({
+      data: vm({ isViewerOrganizer: true, status: 'transition', winnerCandidates: [] }),
+    });
+    render(<NightLiveClientView nightId={NIGHT_ID} />);
+    expect(screen.queryByRole('button', { name: /Completa partita/i })).toBeNull();
+  });
+
+  it('opens the winner picker with the live roster candidates', async () => {
+    mockQuery({ data: vm({ isViewerOrganizer: true, status: 'live', winnerCandidates: ROSTER }) });
+    render(<NightLiveClientView nightId={NIGHT_ID} />);
+    await userEvent.click(screen.getByRole('button', { name: /Completa partita/i }));
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+    expect(screen.getByText('Bob')).toBeInTheDocument();
+  });
+
+  it('completes with the selected winner participant id', async () => {
+    mockQuery({ data: vm({ isViewerOrganizer: true, status: 'live', winnerCandidates: ROSTER }) });
+    render(<NightLiveClientView nightId={NIGHT_ID} />);
+    await userEvent.click(screen.getByRole('button', { name: /Completa partita/i }));
+    await userEvent.click(screen.getByRole('radio', { name: 'Alice' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Completa' }));
+    expect(completeMutateMock).toHaveBeenCalledWith(
+      { winnerId: ROSTER[0].id },
+      expect.objectContaining({ onSuccess: expect.any(Function) })
+    );
+  });
+
+  it('completes with no winner when "Nessun vincitore" is selected (default)', async () => {
+    mockQuery({ data: vm({ isViewerOrganizer: true, status: 'live', winnerCandidates: ROSTER }) });
+    render(<NightLiveClientView nightId={NIGHT_ID} />);
+    await userEvent.click(screen.getByRole('button', { name: /Completa partita/i }));
+    await userEvent.click(screen.getByRole('button', { name: 'Completa' }));
+    expect(completeMutateMock).toHaveBeenCalledWith(
+      { winnerId: undefined },
+      expect.objectContaining({ onSuccess: expect.any(Function) })
+    );
   });
 });
 

--- a/apps/web/src/components/features/game-nights/live/WinnerPickerModal.test.tsx
+++ b/apps/web/src/components/features/game-nights/live/WinnerPickerModal.test.tsx
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { WinnerPickerModal } from './WinnerPickerModal';
+
+const CANDIDATES = [
+  { id: 'p1', displayName: 'Alice' },
+  { id: 'p2', displayName: 'Guest Gina' },
+];
+
+describe('WinnerPickerModal', () => {
+  it('renders nothing when closed', () => {
+    render(
+      <WinnerPickerModal
+        open={false}
+        candidates={CANDIDATES}
+        onCancel={() => undefined}
+        onConfirm={() => undefined}
+      />
+    );
+    expect(screen.queryByRole('dialog')).toBeNull();
+  });
+
+  it('lists the candidates + a "no winner" option', () => {
+    render(
+      <WinnerPickerModal
+        open
+        candidates={CANDIDATES}
+        onCancel={() => undefined}
+        onConfirm={() => undefined}
+      />
+    );
+    expect(screen.getByRole('radio', { name: 'Alice' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'Guest Gina' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: /Nessun vincitore/i })).toBeInTheDocument();
+  });
+
+  it('confirms with the selected participant id', async () => {
+    const onConfirm = vi.fn();
+    render(
+      <WinnerPickerModal
+        open
+        candidates={CANDIDATES}
+        onCancel={() => undefined}
+        onConfirm={onConfirm}
+      />
+    );
+    await userEvent.click(screen.getByRole('radio', { name: 'Guest Gina' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Completa' }));
+    expect(onConfirm).toHaveBeenCalledWith('p2');
+  });
+
+  it('confirms with undefined for "no winner" (default selection)', async () => {
+    const onConfirm = vi.fn();
+    render(
+      <WinnerPickerModal
+        open
+        candidates={CANDIDATES}
+        onCancel={() => undefined}
+        onConfirm={onConfirm}
+      />
+    );
+    await userEvent.click(screen.getByRole('button', { name: 'Completa' }));
+    expect(onConfirm).toHaveBeenCalledWith(undefined);
+  });
+
+  it('surfaces an inline error message', () => {
+    render(
+      <WinnerPickerModal
+        open
+        candidates={CANDIDATES}
+        errorMessage="Non è possibile completare ora."
+        onCancel={() => undefined}
+        onConfirm={() => undefined}
+      />
+    );
+    expect(screen.getByRole('alert')).toHaveTextContent(/Non è possibile completare/i);
+  });
+
+  it('locks the buttons while pending', () => {
+    render(
+      <WinnerPickerModal
+        open
+        pending
+        candidates={CANDIDATES}
+        onCancel={() => undefined}
+        onConfirm={() => undefined}
+      />
+    );
+    expect(screen.getByRole('button', { name: /Completamento/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Annulla' })).toBeDisabled();
+  });
+
+  it('cancels via Annulla', async () => {
+    const onCancel = vi.fn();
+    render(
+      <WinnerPickerModal
+        open
+        candidates={CANDIDATES}
+        onCancel={onCancel}
+        onConfirm={() => undefined}
+      />
+    );
+    await userEvent.click(screen.getByRole('button', { name: 'Annulla' }));
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/components/features/game-nights/live/WinnerPickerModal.tsx
+++ b/apps/web/src/components/features/game-nights/live/WinnerPickerModal.tsx
@@ -1,0 +1,135 @@
+'use client';
+
+import { useEffect, useState, type JSX } from 'react';
+
+import type { WinnerCandidate } from '@/lib/game-nights/mapNightLive';
+
+export interface WinnerPickerModalProps {
+  readonly open: boolean;
+  readonly candidates: readonly WinnerCandidate[];
+  readonly pending?: boolean;
+  /** Distinct 409/403 feedback surfaced inline (panel D6). */
+  readonly errorMessage?: string | null;
+  readonly onCancel: () => void;
+  /** winnerId = a Participant.Id, or undefined for "no winner". */
+  readonly onConfirm: (winnerId?: string) => void;
+}
+
+const NO_WINNER = '__none__';
+
+/**
+ * #2634 C4: the organizer picks the winner (or "no winner") when completing the live game.
+ * Candidates come from the guarded night-live read model's roster — never the unguarded
+ * GET /game-sessions/{id} (panel D4). Pending-locked while the completion mutation is in flight.
+ */
+export function WinnerPickerModal({
+  open,
+  candidates,
+  pending,
+  errorMessage,
+  onCancel,
+  onConfirm,
+}: WinnerPickerModalProps): JSX.Element | null {
+  const [selected, setSelected] = useState<string>(NO_WINNER);
+
+  // Reset the choice each time the picker opens.
+  useEffect(() => {
+    if (open) setSelected(NO_WINNER);
+  }, [open]);
+
+  // Escape cancels (but not while a completion is in flight).
+  useEffect(() => {
+    if (!open) return undefined;
+    const handle = (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && !pending) onCancel();
+    };
+    document.addEventListener('keydown', handle);
+    return () => document.removeEventListener('keydown', handle);
+  }, [open, pending, onCancel]);
+
+  if (!open) return null;
+
+  const confirm = () => onConfirm(selected === NO_WINNER ? undefined : selected);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4 backdrop-blur-sm"
+      style={{ background: 'rgba(0,0,0,0.45)' }}
+      role="presentation"
+      onClick={() => {
+        if (!pending) onCancel();
+      }}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="winner-picker-title"
+        onClick={e => e.stopPropagation()}
+        className="w-full max-w-sm rounded-xl border border-border bg-card p-5 shadow-lg"
+      >
+        <h2
+          id="winner-picker-title"
+          className="font-display text-lg font-extrabold text-foreground"
+        >
+          Chi ha vinto?
+        </h2>
+        <p className="mt-1 font-mono text-sm text-muted-foreground">
+          Completa la partita scegliendo il vincitore.
+        </p>
+
+        <fieldset className="mt-3 space-y-1" disabled={pending}>
+          {candidates.map(candidate => (
+            <label
+              key={candidate.id}
+              className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 hover:bg-muted"
+            >
+              <input
+                type="radio"
+                name="winner"
+                value={candidate.id}
+                checked={selected === candidate.id}
+                onChange={() => setSelected(candidate.id)}
+              />
+              <span className="font-display text-sm text-foreground">{candidate.displayName}</span>
+            </label>
+          ))}
+          <label className="flex cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 hover:bg-muted">
+            <input
+              type="radio"
+              name="winner"
+              value={NO_WINNER}
+              checked={selected === NO_WINNER}
+              onChange={() => setSelected(NO_WINNER)}
+            />
+            <span className="font-display text-sm text-muted-foreground">Nessun vincitore</span>
+          </label>
+        </fieldset>
+
+        {errorMessage ? (
+          <p role="alert" className="mt-2 font-mono text-xs text-destructive">
+            {errorMessage}
+          </p>
+        ) : null}
+
+        <div className="mt-4 flex items-center justify-end gap-2">
+          <button
+            type="button"
+            onClick={onCancel}
+            disabled={pending}
+            className="rounded-md border border-border bg-card px-4 py-2 font-display text-[13px] font-extrabold text-foreground hover:bg-muted disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            Annulla
+          </button>
+          <button
+            type="button"
+            onClick={confirm}
+            disabled={pending}
+            className="rounded-md border border-entity-session/40 bg-entity-session px-4 py-2 font-display text-[13px] font-extrabold text-white hover:bg-entity-session/90 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {pending ? 'Completamento…' : 'Completa'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/features/game-nights/live/index.ts
+++ b/apps/web/src/components/features/game-nights/live/index.ts
@@ -22,6 +22,9 @@ export type {
 export { BlockedLiveSessionModal } from '@/components/features/game-nights/live/BlockedLiveSessionModal';
 export type { BlockedLiveSessionModalProps } from '@/components/features/game-nights/live/BlockedLiveSessionModal';
 
+export { WinnerPickerModal } from '@/components/features/game-nights/live/WinnerPickerModal';
+export type { WinnerPickerModalProps } from '@/components/features/game-nights/live/WinnerPickerModal';
+
 export { NightLiveHub } from '@/components/features/game-nights/live/NightLiveHub';
 export type {
   NightLiveHubProps,

--- a/apps/web/src/lib/api/schemas/__tests__/game-nights-live.schemas.test.ts
+++ b/apps/web/src/lib/api/schemas/__tests__/game-nights-live.schemas.test.ts
@@ -18,6 +18,7 @@ const SESSION = {
   playOrder: 1,
   status: 'InProgress',
   winnerId: null,
+  winnerName: null, // #2634 C4
   startedAt: '2026-07-04T20:00:00+00:00',
   completedAt: null,
 };
@@ -29,6 +30,7 @@ const LIVE = {
   sessions: [SESSION],
   isViewerOrganizer: true,
   plannedLineup: [],
+  currentSessionRoster: [], // #2634 C4
 };
 
 describe('GameNightSessionStatusSchema', () => {
@@ -67,5 +69,29 @@ describe('GameNightLiveDtoSchema', () => {
   it('throws when a session carries an unknown status (poison record fails fast)', () => {
     const poison = { ...LIVE, sessions: [{ ...SESSION, status: 'WhoKnows' }] };
     expect(() => GameNightLiveDtoSchema.parse(poison)).toThrow();
+  });
+
+  // #2634 C4: round-trip the winner name + the live roster.
+  it('round-trips winnerName + currentSessionRoster (C4)', () => {
+    const withWinner = {
+      ...LIVE,
+      sessions: [
+        {
+          ...SESSION,
+          status: 'Completed',
+          winnerId: '44444444-4444-4444-8444-444444444444',
+          winnerName: 'Alice',
+          completedAt: '2026-07-04T21:00:00+00:00',
+        },
+      ],
+      currentSessionRoster: [
+        { participantId: '44444444-4444-4444-8444-444444444444', displayName: 'Alice' },
+        { participantId: '55555555-5555-4555-8555-555555555555', displayName: 'Guest Gina' },
+      ],
+    };
+    const parsed = GameNightLiveDtoSchema.parse(withWinner);
+    expect(parsed.sessions[0].winnerName).toBe('Alice');
+    expect(parsed.currentSessionRoster).toHaveLength(2);
+    expect(parsed.currentSessionRoster[1].displayName).toBe('Guest Gina');
   });
 });

--- a/apps/web/src/lib/api/schemas/game-nights.schemas.ts
+++ b/apps/web/src/lib/api/schemas/game-nights.schemas.ts
@@ -63,6 +63,9 @@ export const GameNightSessionDtoSchema = z.object({
   playOrder: z.number().int(),
   status: GameNightSessionStatusSchema,
   winnerId: z.string().uuid().nullable(),
+  // #2634 C4: the winner's display name, BE-resolved from winnerId (a Participant.Id), scoped by
+  // session and guest-capable. null when there is no winner (or it could not be resolved).
+  winnerName: z.string().nullable(),
   startedAt: z.string().nullable(),
   completedAt: z.string().nullable(),
 });
@@ -73,6 +76,13 @@ export const GameNightLineupItemDtoSchema = z.object({
   gameTitle: z.string(),
 });
 export type GameNightLineupItemDto = z.infer<typeof GameNightLineupItemDtoSchema>;
+
+// #2634 C4: a candidate winner in the current live session — a tracking Participant.
+export const GameNightRosterMemberDtoSchema = z.object({
+  participantId: z.string().uuid(),
+  displayName: z.string(),
+});
+export type GameNightRosterMemberDto = z.infer<typeof GameNightRosterMemberDtoSchema>;
 
 // WS1 DEC-10: result of POST /game-nights/{id}/sessions (start next game).
 export const StartGameNightSessionResultSchema = z.object({
@@ -92,6 +102,9 @@ export const GameNightLiveDtoSchema = z.object({
   isViewerOrganizer: z.boolean(),
   // WS1 DEC-9: planned games not yet started, in order — the CTA starts the first.
   plannedLineup: z.array(GameNightLineupItemDtoSchema),
+  // #2634 C4: the in-progress session's participants — the winner-picker candidates. Empty when
+  // no game is live.
+  currentSessionRoster: z.array(GameNightRosterMemberDtoSchema),
 });
 export type GameNightLiveDto = z.infer<typeof GameNightLiveDtoSchema>;
 

--- a/apps/web/src/lib/format/__tests__/person-initials.test.ts
+++ b/apps/web/src/lib/format/__tests__/person-initials.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+
+import { personInitials } from '@/lib/format/person-initials';
+
+describe('personInitials', () => {
+  it('takes the first + last word initials for multi-word names', () => {
+    expect(personInitials('Mario Rossi')).toBe('MR');
+    expect(personInitials('Mario Luigi Rossi')).toBe('MR');
+    expect(personInitials('Guest Gina')).toBe('GG');
+  });
+
+  it('takes up to the first two code points for a single word', () => {
+    expect(personInitials('Alice')).toBe('AL');
+    expect(personInitials('A')).toBe('A');
+  });
+
+  it('is code-point safe for emoji (never splits a surrogate pair)', () => {
+    // "🎲" is a surrogate pair; charAt(0) would return a broken half. Spread keeps it whole.
+    expect(personInitials('🎲')).toBe('🎲');
+    expect(personInitials('🎲 Player')).toBe('🎲P');
+  });
+
+  it('falls back to "?" for empty / whitespace-only names', () => {
+    expect(personInitials('')).toBe('?');
+    expect(personInitials('   ')).toBe('?');
+  });
+
+  it('trims surrounding whitespace', () => {
+    expect(personInitials('  Bob Smith  ')).toBe('BS');
+  });
+});

--- a/apps/web/src/lib/format/person-initials.ts
+++ b/apps/web/src/lib/format/person-initials.ts
@@ -1,0 +1,30 @@
+/**
+ * personInitials — #2634 C4.
+ *
+ * Avatar initials for a PERSON's display name (not a game title — `extractInitials` is
+ * game-title-tuned with stop-words and would mangle a player name). Code-point safe: it never
+ * uses `charAt(0)`, which splits a surrogate pair (emoji) into a broken half (panel must-fix #7);
+ * a guest DisplayName (max 50 chars) may legitimately contain emoji.
+ *
+ * - Two+ words → first code point of the first and last words ("Mario Rossi" → "MR").
+ * - One word → up to the first two code points ("Alice" → "AL", "🎲" → "🎲").
+ * - Empty / whitespace-only → a stable "?" fallback.
+ */
+export function personInitials(name: string): string {
+  const trimmed = name.trim();
+  if (trimmed.length === 0) return '?';
+
+  const words = trimmed.split(/\s+/).filter(Boolean);
+  const firstCodePoint = (word: string): string => {
+    const cp = [...word][0]; // spread iterates by code point, not UTF-16 unit
+    return cp ? cp.toUpperCase() : '';
+  };
+
+  if (words.length === 1) {
+    const initials = [...words[0]].slice(0, 2).join('').toUpperCase();
+    return initials.length > 0 ? initials : '?';
+  }
+
+  const initials = firstCodePoint(words[0]) + firstCodePoint(words[words.length - 1]);
+  return initials.length > 0 ? initials : '?';
+}

--- a/apps/web/src/lib/game-nights/__tests__/mapNightLive.test.ts
+++ b/apps/web/src/lib/game-nights/__tests__/mapNightLive.test.ts
@@ -29,6 +29,7 @@ function session(over: Partial<GameNightLiveDto['sessions'][number]>) {
     playOrder: 1,
     status: 'Pending' as const,
     winnerId: null,
+    winnerName: null,
     startedAt: null,
     completedAt: null,
     ...over,
@@ -43,6 +44,7 @@ function live(over: Partial<GameNightLiveDto> = {}): GameNightLiveDto {
     sessions: [],
     isViewerOrganizer: false,
     plannedLineup: [],
+    currentSessionRoster: [],
     ...over,
   };
 }
@@ -351,6 +353,38 @@ describe('mapNightLiveToViewModel — empty night (LD-11) + Slice-C seam (LD-3)'
     expect(vm.elapsed).toBe('0h 0m');
     expect(vm.status).toBe('transition');
     expect(vm.night.title).toBe('Serata Eldoria');
+  });
+
+  it('populates the resolved winner on a completed session (C4)', () => {
+    const winnerId = 'bbbb1111-1111-4111-8111-111111111111';
+    const vm = mapNightLiveToViewModel(
+      live({
+        sessions: [
+          session({
+            status: 'Completed',
+            winnerId,
+            winnerName: 'Guest Gina',
+            startedAt: '2026-07-04T20:00:00Z',
+            completedAt: '2026-07-04T21:00:00Z',
+          }),
+        ],
+      }),
+      NOW
+    );
+
+    const winner = vm.plannedGames[0].winner;
+    expect(winner).toBeDefined();
+    expect(winner?.name).toBe('Guest Gina');
+    expect(winner?.initials).toBe('GG');
+    expect(typeof winner?.color).toBe('number'); // hue for the chip's hsl(color,60%,55%)
+  });
+
+  it('leaves winner undefined when the BE resolved no name (D7 — no synthesized winner)', () => {
+    const vm = mapNightLiveToViewModel(
+      live({ sessions: [session({ status: 'Completed', winnerId: null, winnerName: null })] }),
+      NOW
+    );
+    expect(vm.plannedGames[0].winner).toBeUndefined();
   });
 
   it('exposes the sessionId→game lookup mapDiary joins against (Slice C2)', () => {

--- a/apps/web/src/lib/game-nights/hooks/__tests__/useCompleteGameNightSession.test.tsx
+++ b/apps/web/src/lib/game-nights/hooks/__tests__/useCompleteGameNightSession.test.tsx
@@ -1,0 +1,63 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * useCompleteGameNightSession unit tests — #2634 C4.
+ */
+
+import { type ReactNode } from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { ConflictError } from '@/lib/api/core/errors';
+
+import { useCompleteGameNightSession } from '../useCompleteGameNightSession';
+
+const completeSessionMock = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/api/clients/gameNightSessionClient', () => ({
+  gameNightSessionClient: { completeSession: completeSessionMock },
+}));
+
+const GN = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+
+function wrapper() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+  };
+}
+
+describe('useCompleteGameNightSession', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('completes with the winner participant id', async () => {
+    completeSessionMock.mockResolvedValue(undefined);
+    const { result } = renderHook(() => useCompleteGameNightSession(GN), { wrapper: wrapper() });
+
+    result.current.mutate({ winnerId: 'participant-1' });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(completeSessionMock).toHaveBeenCalledWith(GN, 'participant-1');
+  });
+
+  it('completes with no winner (undefined)', async () => {
+    completeSessionMock.mockResolvedValue(undefined);
+    const { result } = renderHook(() => useCompleteGameNightSession(GN), { wrapper: wrapper() });
+
+    result.current.mutate({});
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(completeSessionMock).toHaveBeenCalledWith(GN, undefined);
+  });
+
+  it('surfaces the error so the view can discriminate 409 vs 403', async () => {
+    completeSessionMock.mockRejectedValue(new ConflictError({ message: 'no live session' }));
+    const { result } = renderHook(() => useCompleteGameNightSession(GN), { wrapper: wrapper() });
+
+    result.current.mutate({});
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toBeInstanceOf(ConflictError);
+  });
+});

--- a/apps/web/src/lib/game-nights/hooks/__tests__/useGameNightLive.test.tsx
+++ b/apps/web/src/lib/game-nights/hooks/__tests__/useGameNightLive.test.tsx
@@ -49,6 +49,7 @@ const LIVE_DTO: GameNightLiveDto = {
       playOrder: 1,
       status: 'Completed',
       winnerId: null,
+      winnerName: null,
       startedAt: '2026-07-04T20:00:00Z',
       completedAt: '2026-07-04T21:53:00Z',
     },
@@ -59,12 +60,14 @@ const LIVE_DTO: GameNightLiveDto = {
       playOrder: 2,
       status: 'InProgress',
       winnerId: null,
+      winnerName: null,
       startedAt: '2026-07-04T22:00:00Z',
       completedAt: null,
     },
   ],
   isViewerOrganizer: true,
   plannedLineup: [],
+  currentSessionRoster: [],
 };
 
 describe('useGameNightLive — query key factory', () => {

--- a/apps/web/src/lib/game-nights/hooks/useCompleteGameNightSession.ts
+++ b/apps/web/src/lib/game-nights/hooks/useCompleteGameNightSession.ts
@@ -1,0 +1,40 @@
+'use client';
+
+/**
+ * useCompleteGameNightSession — #2634 C4.
+ *
+ * Mutation that completes the current live game (POST /game-nights/{id}/sessions/complete via the
+ * single client method `gameNightSessionClient.completeSession`). On success it invalidates the
+ * live AND diary reads (the game flips to completed with its winner, and a completion diary event
+ * appears). `retry: false` so a 409/403 surfaces once; the view discriminates ForbiddenError (403,
+ * non-organizer) vs ConflictError (409, no live session / winner not a participant) for distinct
+ * feedback and keeps the action pending-locked while in flight.
+ */
+
+import { useMutation, useQueryClient, type UseMutationResult } from '@tanstack/react-query';
+
+import { gameNightSessionClient } from '@/lib/api/clients/gameNightSessionClient';
+
+import { gameNightLiveKeys } from './useGameNightLive';
+import { nightLiveDiaryKeys } from './useNightLiveDiary';
+
+export interface CompleteGameNightSessionVars {
+  /** A tracking-Session Participant.Id, or undefined to complete with no winner. */
+  readonly winnerId?: string;
+}
+
+export function useCompleteGameNightSession(
+  gameNightId: string
+): UseMutationResult<void, Error, CompleteGameNightSessionVars> {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ winnerId }: CompleteGameNightSessionVars) =>
+      gameNightSessionClient.completeSession(gameNightId, winnerId),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: gameNightLiveKeys.detail(gameNightId) });
+      void queryClient.invalidateQueries({ queryKey: nightLiveDiaryKeys.detail(gameNightId) });
+    },
+    retry: false,
+  });
+}

--- a/apps/web/src/lib/game-nights/mapNightLive.ts
+++ b/apps/web/src/lib/game-nights/mapNightLive.ts
@@ -25,6 +25,8 @@ import type {
   GameNightSessionStatus,
   GameNightStatus,
 } from '@/lib/api/schemas/game-nights.schemas';
+import { userHue } from '@/lib/colors/user-hue';
+import { personInitials } from '@/lib/format/person-initials';
 import { hashToHue } from '@/lib/games/cover-utils';
 
 /**
@@ -152,6 +154,16 @@ export function mapNightLiveToViewModel(dto: GameNightLiveDto, now: Date): Night
     actual: toActual(session, nowMs),
     cover: coverFromGameId(session.gameId),
     winnerId: session.winnerId ?? undefined, // LD-2: carried for Slice C
+    // #2634 C4: populate the resolved winner ONLY when the BE gave a name (D7: never synthesize
+    // one for a null winner). Skipped/Corrupted sessions have no winnerName → no chip. Colour is a
+    // deterministic hue off the Participant.Id (guest-capable); initials come from the person name.
+    winner: session.winnerName
+      ? {
+          name: session.winnerName,
+          initials: personInitials(session.winnerName),
+          color: userHue(session.winnerId ?? session.winnerName),
+        }
+      : undefined,
     muted: session.status === 'Skipped' ? true : undefined, // LD-4
   }));
 

--- a/apps/web/src/lib/game-nights/mapNightLive.ts
+++ b/apps/web/src/lib/game-nights/mapNightLive.ts
@@ -63,6 +63,14 @@ export interface NightLiveViewModel {
   readonly currentGame: NightLiveHubCurrentGame | null;
   /** Slice C2: sessionId → gameId/title lookup for the diary join (not rendered directly). */
   readonly sessions: readonly NightSessionRef[];
+  /** #2634 C4: the live session's participants — the "Completa" winner-picker candidates. */
+  readonly winnerCandidates: readonly WinnerCandidate[];
+}
+
+/** #2634 C4: a candidate winner (a tracking-Session Participant) for the Completa picker. */
+export interface WinnerCandidate {
+  readonly id: string; // Participant.Id — sent as winnerId on complete
+  readonly displayName: string;
 }
 
 const MINUTE_MS = 60_000;
@@ -219,6 +227,11 @@ export function mapNightLiveToViewModel(dto: GameNightLiveDto, now: Date): Night
       sessionId: s.sessionId,
       gameId: s.gameId,
       gameTitle: toTitle(s),
+    })),
+    // #2634 C4: the live session's roster → the Completa winner-picker candidates.
+    winnerCandidates: dto.currentSessionRoster.map(m => ({
+      id: m.participantId,
+      displayName: m.displayName,
     })),
   };
 }

--- a/docs/for-developers/specs/2026-07-05-issue-2634-c4-winner-completa-design.md
+++ b/docs/for-developers/specs/2026-07-05-issue-2634-c4-winner-completa-design.md
@@ -1,0 +1,126 @@
+# C4 — Winner display + per-game "Completa" sul night-live hub (#2634)
+
+**Data**: 2026-07-05 · **Issue**: #2634 (SI-3, umbrella #2619) · **Predecessori**: WS1 (PR #2665), C2 (PR #2669)
+**Stato**: DRAFT per `/sc:spec-panel` · **Scope scelto dall'utente**: *Winner + Completa (BE shipped)* — Abbandona/Archivia rinviati a SI-3-proper.
+
+## 1. Contesto e discovery (workflow 4-reader)
+
+WS1 ha riabilitato l'avvio live (`Avvia prossimo gioco`); C2 ha renderizzato il diary. Manca il **completamento** di una partita con **winner**, e la chip winner (`PlannedGamesPane`, `isCompleted && game.winner`) è **dead code** perché il mapper non popola mai `PlannedGame.winner`.
+
+### Fatti accertati
+**Close flow (BE):**
+- **Completa** (per-partita, con winner opzionale) È SHIPPED: `CompleteGameNightSessionCommand(GameNightId, Guid? WinnerId, UserId)` → `gameNight.CompleteCurrentSession(WinnerId)` → `GameNightSession.Complete(winnerId)` setta `WinnerId` + `CompletedAt` (InProgress→Completed **sulla sessione**, la serata resta InProgress). Route `POST /api/v1/game-nights/{id}/sessions/complete` (204, organizer-guarded, 409 se nessuna live). Body `CompleteGameNightSessionRequest(Guid? WinnerId)`.
+- **Abbandona/Archivia**: nessun concetto BE (fuori scope, → SI-3-proper).
+- ⚠️ *Landmine documentato*: due night-close path contraddittori (`FinalizeGameNightCommand` Published-only vs `CompleteGameNightCommand` EF-level InProgress-only). **Non li tocchiamo** — C4 usa solo il per-session `CompleteGameNightSessionCommand`; il night-finalize è SI-3-proper.
+
+**Winner semantics (D1 risolta):**
+- `GameNightSession.WinnerId` è un `Guid?` **opaco, non validato, non risolto a nome**.
+- Il tracking Session (`GameNightSession.SessionId == Session.Id`) ha una convenzione winner consolidata: `Session.Finalize(winnerId)` valida che `winnerId` sia un **`Participant.Id`** → `SetFinalRank(1)`; il nome = `Participant.DisplayName` (**guest-capable**, `UserId` nullable, `DisplayName` per-row).
+- **Decisione D1 (pinned)**: `GameNightSession.WinnerId` È un **`Participant.Id`** del tracking Session correlato. Il BE risolve il nome via i Participants di quel Session.
+
+**Roster (guest-capable) — già esiste:**
+- `Participant` (owned by tracking Session): `Id, SessionId, UserId (Guid? = guest), DisplayName (MaxLen 50), IsOwner, FinalRank`.
+- Query esistenti: `GetSessionDetailsQuery` → `SessionDetailsDto.Participants` (`ParticipantDto{Id, UserId, DisplayName, IsOwner, JoinOrder, FinalRank, TotalScore}`), route `GET /api/v1/game-sessions/{sessionId}`. Guest inclusi.
+
+**FE:**
+- `PlannedGameWinner{name, initials, color:number}` — `color` = hue 0-359 (`hsl(color,60%,55%)`). Chip a `PlannedGamesPane.tsx:241-264`.
+- Mapper `mapNightLiveToViewModel(dto, now)` — nessun input roster; `GameNightSessionDto` non ha nome winner (`winnerId:uuid?` solo).
+- Util: `userHue(id):number` (FNV-1a, funziona su qualsiasi id incl. Participant.Id), `userHsl`. `extractInitials` è game-title-tuned → serve un helper **person-initials**.
+- Nessun 3-way selector; solo `gameNightSessionClient.completeSession(gameNightId, winnerId?)` (non wired al read-model view). La `Completa` fa coppia con la CTA WS1 `Avvia prossimo gioco` (game loop: live→Completa→transition→Avvia prossimo).
+
+## 2. Decisioni proposte (per il panel)
+
+| # | Decisione | Opzione raccomandata | Alternative |
+|---|-----------|---------------------|-------------|
+| **D1 WinnerId** | cosa È WinnerId | **`Participant.Id`** del tracking Session (guest-capable, convenzione esistente). Test che pinna la semantica. | UserId (perde i guest) |
+| **D2 Name resolution** | dove risolvere il nome | **BE**: `GetGameNightLiveQueryHandler` risolve `WinnerId→DisplayName` via i Participants (batch, il handler ha già `MeepleAiDbContext`), aggiunge `WinnerName` a `GameNightSessionDto`. | FE fetch roster (più round-trip, id-space sul FE) |
+| **D3 Completa command** | quale path | **Riusa `CompleteGameNightSessionCommand`** shipped (per-session, non tocca il night-finalize landmine). | nuovo comando |
+| **D4 Winner picker source** | roster per il picker | **Riusa `GET /game-sessions/{sessionId}`** (`SessionDetailsDto.Participants`, guest-capable) per la sessione live — zero nuovo endpoint. | nuovo endpoint roster |
+| **D5 Chip color/initials** | come costruire `winner` | `color = userHue(winnerId)` (hash del Participant.Id, deterministico anche per guest); `initials = personInitials(winnerName)` (nuovo helper, non `extractInitials`); `name = session.winnerName`. | — |
+| **D6 Completa UX** | dove/come | Azione organizer-only nel `NightLiveClientView`, sulla partita live (`status==='live'`); apre un picker winner (opzionale "nessun winner") → `completeSession(winnerId?)` → invalida live+diary key. Complementare alla CTA WS1. | inline senza picker (no winner) |
+| **D7 No-winner** | Completa senza winner | Consentito (BE `WinnerId` nullable) → partita completata senza chip winner. | winner obbligatorio |
+
+## 3. Scope (C4, questa slice)
+**IN**: (a) BE `WinnerName` su `GameNightSessionDto` + risoluzione batch via Participants (guest-capable) + test che pinna `WinnerId=Participant.Id`; (b) FE `completeSession` wired (hook RQ) + winner picker (roster da `GET /game-sessions/{sessionId}`) + azione organizer "Completa" nel view; (c) mapper popola `PlannedGame.winner` da `winnerId`+`winnerName` (`personInitials` + `userHue`). **OUT** (→ SI-3-proper): Abbandona, Archivia/resumable, night-level in-progress→completed transition, riconciliazione dei 2 finalize path, actor-avatar diary (D5-full).
+
+## 4. Acceptance criteria
+- **AC1** Organizer completa la partita live con un winner (Participant) → la chip mostra `🏆 {DisplayName} ha vinto` con avatar (initials + hue deterministico), incl. **winner guest** (no UserId).
+- **AC2** Completa senza winner → partita completed, nessuna chip winner, no crash.
+- **AC3** Dopo Completa, la partita passa a `completed` e la serata torna `transition` (nessuna live) → la CTA WS1 "Avvia prossimo gioco" ridiventa disponibile.
+- **AC4** Non-organizer non vede l'azione Completa; il BE 403 è il backstop.
+- **AC5** Completa quando nessuna partita è live → 409 gestito (no crash, feedback).
+- **AC6** `WinnerName` risolto correttamente per un `Participant.Id` valido; `null`/sconosciuto → nessun nome (no crash).
+- **AC7** Nessuna regressione su WS1 (avvio) / C2 (diary) / C1 (currentGame).
+
+## 5. Test plan
+- **BE unit**: `GetGameNightLiveQueryHandler` risolve `WinnerName` (Participant match, guest, WinnerId null, WinnerId sconosciuto→null); pin test `WinnerId=Participant.Id`.
+- **BE integration** (Testcontainers): complete-with-participant-winner → live DTO espone `WinnerName`; guest winner.
+- **FE unit**: `personInitials`; mapper popola `winner{name,initials,color}` (+ null-winner); `useCompleteGameNightSession` mutation (success invalida keys, 409/403 error); winner-picker component; view azione Completa (organizer-gated, live-only).
+- **Regressione**: cluster game-nights FE + BE GameNight.
+
+## 6. Rischi / questioni aperte
+- **R1** Il picker roster viene dal tracking Session (`GET /game-sessions/{sessionId}`): verificare che sia participant-guarded e che il `sessionId` (GameNightSession.SessionId) risolva i Participants attesi.
+- **R2** `personInitials` su nomi con 1 parola / emoji / vuoti — fallback robusto.
+- **R3** Landmine dei 2 finalize path: **non toccato** in C4, ma da segnalare per SI-3-proper.
+
+---
+*Draft per spec-panel — D1-D7 da pressure-testare.*
+
+
+## 7. Spec-Panel Verdict (Nygard/Wiegers/Crispin; Fowler retry-capped)
+
+# Spec-Panel Verdict — C4 Design (#2634)
+
+**Panel:** Nygard (failure-modes) · Wiegers (requirements) · Crispin (test strategy). Convergence is high: the happy path and id-space premise are sound, but the draft rests on three code-contradicted assumptions (roster endpoint is unguarded; WinnerId write is unvalidated; per-session complete never finalizes the tracking Session). Two of these puncture the headline AC. None block the slice, but each needs an explicit decision before coding.
+
+## 1. LOCKED-DECISIONS (D1–D7)
+
+| # | Decision | Verdict | One-line reason |
+|---|----------|---------|-----------------|
+| **D1** | WinnerId IS a Participant.Id of the correlated tracking Session | **REFINED** | Semantic is correct and guest-capable, but it is an *unenforced* convention — `Complete(winnerId)` stores the Guid opaquely and the validator checks only GameNightId/UserId. A read-side pin-test documents intent; it does not make the field non-opaque. Must be enforced on write OR paired with a fail-closed read (see §2). Drop the `FinalRank==1` framing — Completa never finalizes the tracking Session. |
+| **D2** | Resolve WinnerId→DisplayName in BE (GetGameNightLiveQueryHandler) | **REFINED** | Right layer (handler already participant-guarded + has DbContext). MUST scope the lookup by **(SessionId, WinnerId)**, not Participant.Id alone, so a stray/cross-session id fails closed to null instead of resolving a plausible wrong name. One batched query over all completed sessions. Explicitly label as a deliberate GameManagement→SessionTracking cross-BC read. |
+| **D3** | Reuse shipped per-session CompleteGameNightSessionCommand | **AGREE (w/ mandatory note)** | Strongest decision — avoids the two contradictory night-finalize commands; 409/403 backstops already exist. Note is load-bearing: this command completes the sub-aggregate and never calls `Session.Finalize`, leaving the tracking Session live/un-finalized (see §2.5). |
+| **D4** | Source picker roster from GET /game-sessions/{sessionId} | **OVERTURNED** | Rationale is factually wrong: endpoint is `.RequireAuthenticatedUser()` only, handler filters on `s.Id && !IsDeleted` — a pre-existing IDOR, not participant-guarded. Re-source the roster from the **already-guarded night-live read model** (extend GameNightLiveDto with in-progress Participant.Id + DisplayName), unifying the id-space with D2 and removing the unguarded round-trip. |
+| **D5** | Chip: color=userHue(winnerId), initials=personInitials(winnerName) | **AGREE (w/ refinement)** | Pure and guest-capable (Participant.Id is a GUID PK → deterministic hue for guests). Confirm the mapper emits color as a **hue number 0–359** (chip does `hsl(${color},…)`), not an hsl string. Pin `personInitials` with codepoint-safe + empty-fallback tests. Per-session hue means the same guest changes color per game — cosmetic, non-blocking. |
+| **D6** | Organizer-only, live-only "Completa" with winner picker | **REFINED** | FE gate + BE 403 backstop is the right shape. MUST pending-lock while in flight (Complete handler does not catch `DbUpdateConcurrencyException` → double-submit returns 500) and render 409 (no live) vs 403 (non-organizer) as distinct feedback. Reconcile with the **existing** `useGameNightMultiSession.completeSession` write path — do not ship two divergent mutation/cache strategies. |
+| **D7** | Allow Completa with no winner (WinnerId nullable) | **AGREE** | Nullable end-to-end (command → aggregate → DTO). Add one assertion: mapper does not synthesize a winner object when winnerName is null (chip suppressed, no crash). |
+
+## 2. NEW MUST-FIX ITEMS THE DRAFT MISSED (ranked)
+
+1. **[BLOCKER] Re-source the picker roster off the guarded read model.** The draft asserts GET /game-sessions/{sessionId} is participant-guarded; it is not (IDOR exposing any session's DisplayNames/scores/notes to any authenticated user). Extend GameNightLiveDto with the in-progress session's Participant.Id + DisplayName, or add userId+membership scoping to the query. Do not build on an endpoint mislabeled as guarded.
+2. **[BLOCKER] Make AC1 (guest winner) testable against the real pipeline.** WS1's start path posts no participants, so `BuildParticipantsAsync` auto-seeds **organizer-only**. For any WS1-started game the roster is `{organizer}` and the guest-winner AC is unreachable except via a hand-seeded fixture — the exact "acceptance-tests-must-exercise-the-real-pipeline" failure mode. Decide: scope AC1 down to organizer-as-winner for the WS1 flow (guest-winner deferred + tracking issue), OR pull RSVP roster seeding into scope (out of C4 → tracking issue). No AC may be demonstrable only via a hand-seeded fixture.
+3. **[BLOCKER] Enforce WinnerId integrity, or fail closed + document.** Mirror `Session.Finalize`'s `_participants.Any(p=>p.Id==winnerId)` guard on the complete path, throwing **ConflictException (409) / ValidationException (400) — never ArgumentException/500**. If not enforced, the D2 read MUST scope by SessionId and null out non-members, AND AC6 must explicitly cover "WinnerId set but not a current participant → no name, no crash" as accepted, tracked risk.
+4. **[HIGH] Map xmin concurrency loss to 409 in CompleteGameNightSessionCommandHandler.** The handler catches only `InvalidOperationException`; a stale-xmin double-complete throws `DbUpdateConcurrencyException` → uncaught → 500, violating never-500 (ADR-060). The Start handler already handles this; the Complete handler does not. Catch → ConflictException + FE pending-lock.
+5. **[HIGH] Document the session-level "un-finalized tracking Session / dual winner source" landmine.** Completa completes the sub-aggregate but never `Finalize()`s the tracking Session: it stays `IsLive=true`, `FinalRank` unset, `SessionFinalizedEvent` consumers (KB index, play records, summary) never fire, `GetActiveSessionQuery` may keep surfacing the "completed" game as active, and GameNightSession.WinnerId diverges from the tracking-Session winner. The draft's OUT-of-scope note covers the *night*-finalize commands, not this *session*-level gap. Record as SI-3-proper tracking issue + AC tolerating a null/divergent winner.
+6. **[MEDIUM] Add WinnerName to the wire contract with a round-trip test.** New field needs the C# GameNightSessionDto change AND the Zod `GameNightSessionDtoSchema` (project "Zod at the wire" rule) + a schema round-trip test — omitted from the test plan.
+7. **[MEDIUM] Pin personInitials edge cases.** Emoji/surrogate-safe (spread / `Intl.Segmenter` / `codePointAt` — never `charAt(0)`, which splits surrogate pairs; guest DisplayName MaxLen 50 permits emoji), single-word → 1–2 letters, empty/whitespace → stable fallback glyph. Add a test that a Skipped/Corrupted row never renders a winner chip.
+8. **[LOW/UX] Surface the last-game dead-end.** Completing the final planned game yields `status='transition'`, `nextGame=null`, and no night-finalize CTA in C4 (night-finalize is out of scope) — the organizer has no affordance to end the night. Flag as a UX risk even if resolution is deferred.
+
+## 3. GENUINE EXPERT DISAGREEMENT
+
+**Is write-side WinnerId validation mandatory in C4, or optional-with-mitigation?**
+- **Nygard (mandatory):** C4 is the *first consumer* to assign meaning to WinnerId, therefore C4 is where the invariant must become enforced — "not merely documented." A read-side pin-test alone leaves a data-integrity error that AC6 codifies as acceptable, masking rather than rejecting it.
+- **Wiegers / Crispin (enforce-OR-accept):** Enforcing is preferred, but an explicitly-documented unvalidated write **plus** a session-scoped fail-closed read is an acceptable ship, provided the accepted risk is tracked and AC6 spells out the null-resolution behavior. The key demand is *an explicit decision*, not necessarily enforcement.
+
+**Facilitator ruling:** Enforce on write. The cost is one participant existence-check the handler can run against the same roster D2/D4 already load, it converts D1 from convention to invariant, and it removes the need for defensive-read scaffolding downstream. Fail-closed read is retained anyway as defense-in-depth (D2 scoping), so we get both. This is the lower-regret path and closes the AC6 "masks a wrong write" objection.
+
+Secondary (not a true two-sided split): Wiegers questions whether a full picker modal is even justified while the WS1 roster is organizer-only ("justify or defer until roster is populated"). Resolved by must-fix #2 — once AC1 scope is decided, the picker's shape follows.
+
+## 4. RECOMMENDED BUILD ORDER
+
+1. **Roster + AC1 scope decision first (must-fix #1, #2).** Extend GameNightLiveDto to carry the in-progress session's Participant.Id + DisplayName; lock the AC1 scope (organizer-winner now, guest-winner tracked). This unblocks D2/D4 and fixes the id-space.
+2. **BE WinnerId write guard (#3).** Add participant-membership validation in CompleteGameNightSessionCommandHandler → ConflictException/ValidationException.
+3. **BE concurrency mapping (#4).** Catch `DbUpdateConcurrencyException` → ConflictException in the Complete handler.
+4. **BE name resolution (D2, #5-scoping).** Single batched query scoped by (SessionId, WinnerId); add nullable WinnerName to GameNightSessionDto; label the cross-BC read.
+5. **Wire contract (#6).** Zod schema + round-trip test.
+6. **FE mutation (D6).** Reconcile into a single completeSession source of truth (extend `useGameNightMultiSession.completeSession`); pending-lock; distinct 409/403 feedback.
+7. **FE chip mapper (D5, #7).** personInitials codepoint-safe + fallback; color as hue number; Skipped/Corrupted-no-chip test.
+8. **Docs/tracking (#5, #8).** SI-3-proper tracking issue for the un-finalized tracking Session + AC for null/divergent winner; note last-game dead-end.
+
+**Gate:** Steps 1–3 are the blockers — the slice must not enter review until the roster is re-sourced off a guarded surface, AC1 is testable through the real pipeline, and no path on the Completa flow can return 500.
+## 8. Decisioni utente (2026-07-05, lockate)
+- **AC1/guest-winner** → **Includi RSVP seeding in C4**: lo start flow seeda il roster dai partecipanti (accepted RSVP) invece del solo organizer → winner multi-giocatore reale. Guest-capable per design; il dato guest dipende dal meccanismo guest-player (se assente, tracked).
+- **Tracking Session** → **Finalizza anche il tracking Session**: Completa dispatcha `Session.Finalize(winnerId)` cross-BC → (a) write-validation del WinnerId GRATIS (guard esistente `Session.Finalize`), (b) no orphan/active-session, (c) winner canonico `FinalRank==1` + eventi (play records/summary). Transazione atomica.
+- Adottate le altre lockate del §7: D4→roster sul read model live guardato (no IDOR endpoint), D2 scoped by (SessionId,WinnerId) fail-closed, catch `DbUpdateConcurrencyException`→409 + pending-lock FE, `personInitials` codepoint-safe, `WinnerName`+roster su DTO con Zod round-trip, D5/D7.
+
+**Build order**: (1) RSVP roster seeding nello start flow · (2) Completa+`Session.Finalize` cross-BC atomico + concurrency→409 · (3) `GameNightLiveDto` +`WinnerName` (scoped) +roster in-progress · (4) Zod wire + round-trip · (5) FE mutation completeSession (pending-lock, 409/403 distinti) · (6) FE winner picker + azione Completa · (7) FE mapper chip (`personInitials` + `userHue`) · (8) docs/tracking.


### PR DESCRIPTION
## C4 — Winner display + per-game "Completa" sul night-live hub (#2634 SI-3)

La chip winner (`PlannedGamesPane`, `isCompleted && game.winner`) era **dead code** — il mapper non popolava mai `PlannedGame.winner`. Questa slice rende la winner-story reale end-to-end: l'organizer **completa la partita live** scegliendo un vincitore, e la chip mostra `🏆 {nome} ha vinto`.

Progettata via `/sc:spec-panel` (discovery 4-reader + critica 4-esperti). Design+verdetto: [`docs/for-developers/specs/2026-07-05-issue-2634-c4-winner-completa-design.md`](docs/for-developers/specs/2026-07-05-issue-2634-c4-winner-completa-design.md). Scope scelto: **Winner + Completa** (Abbandona/Archivia rinviati a SI-3-proper: nessun BE). Part of #2619; **#2634 SI-3** parzialmente coperta (close-strip 3-way non completo).

### Backend
- **RSVP roster seeding**: `StartGameNightSessionCommandHandler` seeda organizer(owner) + accepted-RSVP players (era solo organizer) → il picker ha candidati reali. WS1 no-RSVP invariato.
- **Completa atomico + no orphan** (2 scelte utente): il complete handler **valida WinnerId come partecipante→409**, completa la GameNightSession, **e dispatcha `FinalizeSessionCommand` per il tracking Session correlato in UNA tx esplicita** → il tracking Session non resta più live (no orphan, no winner divergente, eventi finalize scattano). FinalRanks win=1/others=2 (no-winner→tutti 2). `DbUpdateConcurrencyException`→409 (era 500).
- **WinnerName + roster sul read model**: `GameNightSessionDto.WinnerName` (risolto da WinnerId=`Participant.Id`, **scoped by (SessionId,WinnerId)** → fail-closed→null, guest-capable) + `GameNightLiveDto.CurrentSessionRoster` (partecipanti della sessione in-progress = candidati picker, dal read **già guardato** — non l'IDOR `GET /game-sessions/{id}`, panel D4). Read cross-BC batched su `SessionTrackingParticipants`.

### Frontend
- Zod `winnerName` + `currentSessionRoster` (round-trip).
- `useCompleteGameNightSession`: mutation sulla singola client method `completeSession`, invalida live+diary key, `retry:false`.
- `WinnerPickerModal`: l'organizer sceglie il vincitore (o "Nessun vincitore"), candidati dal roster della VM, **pending-lock**, feedback 403/409 distinto inline.
- `personInitials` codepoint-safe (mai `charAt(0)` → no mojibake da surrogate pair).
- Mapper popola `PlannedGame.winner` da `winnerName`/`winnerId` (name/personInitials/`userHue`), **solo se il BE ha risolto un nome** (D7); `NightLiveViewModel`+`winnerCandidates`.
- `NightLiveClientView`: CTA organizer-only "Completa partita" (live-only, complementare alla CTA WS1 "Avvia prossimo" → game loop) → apre il picker → completa.

### Test
- BE: +7 complete handler (validazione/no-session/concurrency→409/finalize FinalRanks/no-winner) + +4 live handler (WinnerName scoped, foreign→null, roster, empty) + +1 seeding. Cluster GameNight **148/148**, build 0 errori.
- FE: picker 7 + view 6 + mutation 3 + personInitials 5 + mapper 2 + schema round-trip. **517/517** cluster game-nights, typecheck+eslint puliti.

### Follow-up noti (step 8, non-blocking)
- **Phantom-SSE su rollback**: `FinalizeSessionCommand` emette SSE/diary in-memory (non-outboxed) prima del commit esterno; se il commit fallisce dopo il suo save interno, l'SSE è già partito (edge stretto, live-update → il FE refetch corregge). Da tracciare per SI-3-proper.
- **Last-game dead-end**: completare l'ultima partita lascia `status='transition'`, `nextGame=null` e nessun CTA di night-finalize (il finalize serata è SI-3-proper). Da tracciare.
- **Guest-winner**: risoluzione + picker sono guest-capable by design, ma il seeding RSVP produce solo Users; guest-proper (no User) resta tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
