### PR TITLE
release: #2671 storage-key READ fix (abilita re-seed RAG) + #2633 diary

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Jobs/BackfillPdfCoversJob.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Jobs/BackfillPdfCoversJob.cs
@@ -243,8 +243,12 @@ public sealed class BackfillPdfCoversJob : IJob
         // backfill is intended for production-like environments where the PDF
         // lives in blob storage. The filesystem fallback in the pipeline
         // service exists for dev/test, which doesn't need a backfill job.
-        var fileId = PdfStorageKey.ForPdf(pdf.Id);
-        var stream = await blob.RetrieveAsync(fileId, BlobCategory.Pdf, fileId, ct).ConfigureAwait(false);
+        // Issue #2671: the blob lives under a random fileId embedded in FilePath, not pdfId.
+        // Recover it from the persisted path; ForPdf(Id) is the resourceKey folder. The ??
+        // fallback preserves legacy behaviour for records with an empty/unparsable FilePath.
+        var resourceKey = PdfStorageKey.ForPdf(pdf.Id);
+        var fileId = PdfStorageKey.FileIdFromPath(pdf.FilePath) ?? resourceKey;
+        var stream = await blob.RetrieveAsync(fileId, BlobCategory.Pdf, resourceKey, ct).ConfigureAwait(false);
         if (stream is null)
         {
             return null;

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs
@@ -450,8 +450,12 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
     {
         // Issue #501: Use blob storage with correct GUID format (no hyphens) to match StoreAsync key format
         // Task 4: bucket key decoupled from gameId — uses pdf.Id (see PdfStorageKey + rebucket scripts)
-        var fileId = PdfStorageKey.ForPdf(pdfDoc.Id);
-        var fileStream = await _blobStorageService.RetrieveAsync(fileId, BlobCategory.Pdf, fileId, cancellationToken).ConfigureAwait(false);
+        // Issue #2671: StoreAsync writes the blob under a RANDOM fileId (persisted in FilePath), NOT pdfId.
+        // Recover that fileId from FilePath; ForPdf(Id) is the resourceKey folder, not the fileId. The
+        // ?? fallback preserves legacy behaviour for records with an empty/unparsable FilePath.
+        var resourceKey = PdfStorageKey.ForPdf(pdfDoc.Id);
+        var fileId = PdfStorageKey.FileIdFromPath(pdfDoc.FilePath) ?? resourceKey;
+        var fileStream = await _blobStorageService.RetrieveAsync(fileId, BlobCategory.Pdf, resourceKey, cancellationToken).ConfigureAwait(false);
 
         if (fileStream == null)
         {
@@ -978,9 +982,13 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
         string filePath,
         CancellationToken cancellationToken)
     {
-        var fileId = PdfStorageKey.ForPdf(pdfDocumentId);
+        // Issue #2671: the blob lives under a random fileId embedded in FilePath, not pdfId.
+        // Recover it from the persisted path; ForPdf(Id) is the resourceKey folder. The ??
+        // fallback preserves legacy behaviour for records with an empty/unparsable FilePath.
+        var resourceKey = PdfStorageKey.ForPdf(pdfDocumentId);
+        var fileId = PdfStorageKey.FileIdFromPath(filePath) ?? resourceKey;
         var stream = await _blobStorageService
-            .RetrieveAsync(fileId, BlobCategory.Pdf, fileId, cancellationToken)
+            .RetrieveAsync(fileId, BlobCategory.Pdf, resourceKey, cancellationToken)
             .ConfigureAwait(false);
 
         if (stream is null)

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfStorageKey.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfStorageKey.cs
@@ -1,10 +1,54 @@
+using System.Buffers;
+
 namespace Api.BoundedContexts.DocumentProcessing.Application.Services;
 
 public static class PdfStorageKey
 {
+    private static readonly SearchValues<char> PathSeparators = SearchValues.Create("/\\");
+
     /// <summary>
     /// Bucket key for PDF storage. Uses pdf.Id to decouple from game lifecycle.
     /// Pre-migration PDFs stored under gameId bucket must be rebucket-ed by scripts/rebucket-pdfs.*
     /// </summary>
     public static string ForPdf(Guid pdfId) => pdfId.ToString("N");
+
+    /// <summary>
+    /// Extracts the bare fileId embedded in a stored blob path of shape
+    /// <c>{category}/{resourceKey}/{fileId}_{sanitizedFileName}</c> (S3 forward-slash
+    /// or Windows-local backslash layout). The fileId is the segment after the last path
+    /// separator and before the first underscore.
+    /// </summary>
+    /// <remarks>
+    /// Issue #2671: <c>IBlobStorageService.StoreAsync</c> generates a RANDOM fileId
+    /// (<c>Guid.NewGuid().ToString("N")</c>) that is persisted inside the returned
+    /// <c>FilePath</c>. The READ path MUST recover that same fileId from the persisted
+    /// <c>FilePath</c> — it can NOT be reconstructed from <see cref="ForPdf"/> (the pdfId is
+    /// only the <c>resourceKey</c> folder, not the fileId). Returns <c>null</c> for
+    /// null/empty input or any path that does not match the expected layout (no separator,
+    /// trailing separator, no underscore in the last segment, leading underscore).
+    /// </remarks>
+    public static string? FileIdFromPath(string? filePath)
+    {
+        if (string.IsNullOrEmpty(filePath))
+        {
+            return null;
+        }
+
+        // Platform-independent separators: '/' for S3 + URL-style, '\\' on Windows local FS.
+        var lastSeparator = filePath.AsSpan().LastIndexOfAny(PathSeparators);
+        if (lastSeparator < 0 || lastSeparator == filePath.Length - 1)
+        {
+            return null;
+        }
+
+        var fileName = filePath[(lastSeparator + 1)..];
+        var underscoreIndex = fileName.IndexOf('_', StringComparison.Ordinal);
+        // <= 0 covers: not found (-1) AND leading underscore (= 0 ⇒ empty fileId).
+        if (underscoreIndex <= 0)
+        {
+            return null;
+        }
+
+        return fileName[..underscoreIndex];
+    }
 }

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GetGameNightDiaryQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GetGameNightDiaryQuery.cs
@@ -5,8 +5,10 @@ namespace Api.BoundedContexts.GameManagement.Application.Queries.GameNights;
 /// <summary>
 /// Query to get the cross-game diary timeline for a game night.
 /// Returns all session events tagged with the game night ID, ordered chronologically.
+/// Participant-scoped (#2633 C2): only the organizer or an RSVP'd player may read it — parity
+/// with <c>GetGameNightLiveQuery</c>, which the live hub already enforces.
 /// </summary>
-internal record GetGameNightDiaryQuery(Guid GameNightId) : IQuery<GameNightDiaryDto>;
+internal record GetGameNightDiaryQuery(Guid GameNightId, Guid CallerUserId) : IQuery<GameNightDiaryDto>;
 
 internal record GameNightDiaryDto(
     Guid GameNightId,

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GetGameNightDiaryQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GetGameNightDiaryQueryHandler.cs
@@ -1,4 +1,6 @@
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
 using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Application.Interfaces;
 
 namespace Api.BoundedContexts.GameManagement.Application.Queries.GameNights;
@@ -6,14 +8,25 @@ namespace Api.BoundedContexts.GameManagement.Application.Queries.GameNights;
 /// <summary>
 /// Handles fetching the cross-game diary timeline for a game night.
 /// Queries SessionEvents tagged with the game night ID from the SessionTracking BC.
+/// Participant-scoped (#2633 C2): 404 if the night is missing, 403 if the caller is neither the
+/// organizer nor an RSVP'd player — same predicate as <c>GetGameNightLiveQueryHandler</c>.
 /// </summary>
 internal sealed class GetGameNightDiaryQueryHandler
     : IQueryHandler<GetGameNightDiaryQuery, GameNightDiaryDto>
 {
+    // Cap the read so a long night can't return an unbounded payload; newest-first so the truncated
+    // window is the RECENT tail (#2633 C2 must-fix), then re-sorted to chronological for render.
+    private const int DiaryReadCap = 200;
+
+    private readonly IGameNightEventRepository _gameNightRepository;
     private readonly ISessionEventRepository _sessionEventRepository;
 
-    public GetGameNightDiaryQueryHandler(ISessionEventRepository sessionEventRepository)
+    public GetGameNightDiaryQueryHandler(
+        IGameNightEventRepository gameNightRepository,
+        ISessionEventRepository sessionEventRepository)
     {
+        _gameNightRepository = gameNightRepository
+            ?? throw new ArgumentNullException(nameof(gameNightRepository));
         _sessionEventRepository = sessionEventRepository
             ?? throw new ArgumentNullException(nameof(sessionEventRepository));
     }
@@ -23,18 +36,30 @@ internal sealed class GetGameNightDiaryQueryHandler
     {
         ArgumentNullException.ThrowIfNull(query);
 
+        // Participant guard (parity with the live query): load the aggregate to 404 a bogus id and
+        // 403 a non-participant — the old handler returned 200+empty for any id (an existence oracle).
+        var gameNight = await _gameNightRepository.GetByIdAsync(query.GameNightId, cancellationToken).ConfigureAwait(false)
+            ?? throw new NotFoundException("GameNightEvent", query.GameNightId.ToString());
+
+        var isParticipant = gameNight.OrganizerId == query.CallerUserId
+            || gameNight.Rsvps.Any(r => r.UserId == query.CallerUserId);
+        if (!isParticipant)
+            throw new ForbiddenException("Only the organizer or an invited player can view the night diary.");
+
         var events = await _sessionEventRepository
-            .GetByGameNightIdAsync(query.GameNightId, ct: cancellationToken)
+            .GetByGameNightIdAsync(query.GameNightId, limit: DiaryReadCap, newestFirst: true, ct: cancellationToken)
             .ConfigureAwait(false);
 
-        var entries = events.Select(e => new GameNightDiaryEntryDto(
-            e.Id,
-            e.SessionId,
-            e.EventType,
-            GenerateDescription(e.EventType, e.Payload),
-            e.Payload,
-            e.CreatedBy,
-            e.Timestamp)).ToList();
+        var entries = events
+            .OrderBy(e => e.Timestamp) // chronological render even though we read the recent tail first
+            .Select(e => new GameNightDiaryEntryDto(
+                e.Id,
+                e.SessionId,
+                e.EventType,
+                GenerateDescription(e.EventType, e.Payload),
+                e.Payload,
+                e.CreatedBy,
+                e.Timestamp)).ToList();
 
         return new GameNightDiaryDto(query.GameNightId, entries);
     }

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Repositories/ISessionEventRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Repositories/ISessionEventRepository.cs
@@ -39,12 +39,16 @@ public interface ISessionEventRepository
     Task AddAsync(SessionEvent sessionEvent, CancellationToken ct = default);
 
     /// <summary>
-    /// Gets session events by game night ID, ordered chronologically.
-    /// Used for the cross-game diary timeline.
+    /// Gets session events by game night ID, ordered chronologically (ASC).
+    /// Used for the cross-game diary timeline. When <paramref name="newestFirst"/> is true the
+    /// query orders DESC before applying <paramref name="limit"/> — so a long night keeps its
+    /// MOST RECENT events instead of truncating them (#2633 C2 must-fix); the result is still
+    /// returned newest-first, callers re-sort to chronological if needed.
     /// </summary>
     Task<IEnumerable<SessionEvent>> GetByGameNightIdAsync(
         Guid gameNightId,
         int limit = 200,
         int offset = 0,
+        bool newestFirst = false,
         CancellationToken ct = default);
 }

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Persistence/SessionEventRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Persistence/SessionEventRepository.cs
@@ -86,12 +86,20 @@ public class SessionEventRepository : RepositoryBase, ISessionEventRepository
         Guid gameNightId,
         int limit = 200,
         int offset = 0,
+        bool newestFirst = false,
         CancellationToken ct = default)
     {
-        var entities = await DbContext.SessionEvents
+        var filtered = DbContext.SessionEvents
             .AsNoTracking()
-            .Where(e => e.GameNightId == gameNightId && !e.IsDeleted)
-            .OrderBy(e => e.Timestamp)
+            .Where(e => e.GameNightId == gameNightId && !e.IsDeleted);
+
+        // #2633 C2 must-fix: newest-first keeps the MOST RECENT `limit` events on a long night;
+        // the default ASC path preserves the legacy chronological read for existing callers.
+        var ordered = newestFirst
+            ? filtered.OrderByDescending(e => e.Timestamp)
+            : filtered.OrderBy(e => e.Timestamp);
+
+        var entities = await ordered
             .Skip(offset)
             .Take(limit)
             .ToListAsync(ct)

--- a/apps/api/src/Api/Infrastructure/Seeders/Catalog/PdfSeeder.cs
+++ b/apps/api/src/Api/Infrastructure/Seeders/Catalog/PdfSeeder.cs
@@ -1,4 +1,3 @@
-using System.Buffers;
 using Api.BoundedContexts.DocumentProcessing.Application.Services;
 using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
 using Api.Infrastructure.Entities;
@@ -142,7 +141,7 @@ internal static class PdfSeeder
                     {
                         // fileId is embedded in the stored FilePath (pdfs/{resourceKey}/{fileId}_{name});
                         // extract it so ExistsAsync can locate the blob for the EXISTING record.
-                        var existingFileId = ExtractFileIdFromPath(existing.FilePath);
+                        var existingFileId = PdfStorageKey.FileIdFromPath(existing.FilePath);
                         var blobPresent = !string.IsNullOrEmpty(existingFileId)
                             && await primaryBlob.ExistsAsync(existingFileId, BlobCategory.Pdf, PdfStorageKey.ForPdf(existing.Id), ct).ConfigureAwait(false);
 
@@ -417,7 +416,7 @@ internal static class PdfSeeder
         {
             try
             {
-                var fileId = ExtractFileIdFromPath(filePath);
+                var fileId = PdfStorageKey.FileIdFromPath(filePath);
                 if (!string.IsNullOrEmpty(fileId))
                 {
                     await primaryBlob.DeleteAsync(fileId, BlobCategory.Pdf, gameIdStr, ct).ConfigureAwait(false);
@@ -440,40 +439,5 @@ internal static class PdfSeeder
             db.PdfDocuments.Remove(entity);
             await db.SaveChangesAsync(ct).ConfigureAwait(false);
         }
-    }
-
-    private static readonly SearchValues<char> PathSeparators = SearchValues.Create("/\\");
-
-    /// <summary>
-    /// Extracts the bare fileId from a storage path of shape
-    /// <c>pdf_uploads/{resourceKey}/{fileId}_{sanitizedFileName}</c>.
-    /// Returns null if the path does not match the expected layout.
-    /// Exposed as <c>internal</c> for unit testing the null-return branches
-    /// (no path separator, trailing slash, no underscore in segment, leading
-    /// underscore in segment).
-    /// </summary>
-    internal static string? ExtractFileIdFromPath(string filePath)
-    {
-        if (string.IsNullOrEmpty(filePath))
-        {
-            return null;
-        }
-
-        // Platform-independent separators: '/' for S3 + URL-style, '\\' on Windows local FS.
-        var lastSeparator = filePath.AsSpan().LastIndexOfAny(PathSeparators);
-        if (lastSeparator < 0 || lastSeparator == filePath.Length - 1)
-        {
-            return null;
-        }
-
-        var fileName = filePath[(lastSeparator + 1)..];
-        var underscoreIndex = fileName.IndexOf('_', StringComparison.Ordinal);
-        // <= 0 covers: not found (-1) AND leading underscore (= 0 ⇒ empty fileId).
-        if (underscoreIndex <= 0)
-        {
-            return null;
-        }
-
-        return fileName[..underscoreIndex];
     }
 }

--- a/apps/api/src/Api/Routing/GameNightEndpoints.cs
+++ b/apps/api/src/Api/Routing/GameNightEndpoints.cs
@@ -244,11 +244,12 @@ internal static class GameNightEndpoints
         gameNights.MapGet("/{id:guid}/diary", HandleGetGameNightDiary)
             .RequireAuthenticatedUser()
             .Produces<GameNightDiaryDto>(200)
+            .Produces(403)
             .Produces(404)
             .Produces(401)
             .WithName("GetGameNightDiary")
             .WithSummary("Get game night diary timeline")
-            .WithDescription("Retrieves the cross-game diary timeline with all session events for the game night.");
+            .WithDescription("Retrieves the cross-game diary timeline with all session events for the game night. Participant-scoped (organizer or RSVP'd player).");
 
         return group;
     }
@@ -500,9 +501,12 @@ internal static class GameNightEndpoints
     private static async Task<IResult> HandleGetGameNightDiary(
         Guid id,
         [FromServices] IMediator mediator,
+        HttpContext httpContext,
         CancellationToken cancellationToken)
     {
-        var result = await mediator.Send(new GetGameNightDiaryQuery(id), cancellationToken).ConfigureAwait(false);
+        // #2633 C2: participant-scoped — pass the caller so the handler can 403 a non-participant.
+        var userId = httpContext.User.GetUserId();
+        var result = await mediator.Send(new GetGameNightDiaryQuery(id, userId), cancellationToken).ConfigureAwait(false);
         return Results.Ok(result);
     }
 

--- a/apps/api/src/Api/Routing/SessionFlowEndpoints.cs
+++ b/apps/api/src/Api/Routing/SessionFlowEndpoints.cs
@@ -242,34 +242,13 @@ internal static class SessionFlowEndpoints
         .Produces(200)
         .Produces(401);
 
-        // GameNight diary (read) — C2 fix: passes RequesterId for ownership check
-        app.MapGet("/game-nights/{gameNightId:guid}/diary", async (
-            Guid gameNightId,
-            HttpContext httpContext,
-            IMediator mediator,
-            CancellationToken ct,
-            string? eventTypes = null,
-            DateTime? since = null,
-            int? limit = null) =>
-        {
-            var userId = httpContext.User.GetUserId();
-            var types = string.IsNullOrWhiteSpace(eventTypes)
-                ? null
-                : eventTypes
-                    .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
-                    .ToArray();
-
-            var result = await mediator
-                .Send(new GetGameNightDiaryQuery(gameNightId, userId, types, since, limit ?? 500), ct)
-                .ConfigureAwait(false);
-            return Results.Ok(result);
-        })
-        .RequireAuthenticatedUser()
-        .WithName("SessionFlow_GetGameNightDiary")
-        .WithTags("SessionFlow")
-        .WithSummary("Read the append-only diary for a whole game night (unions all attached sessions).")
-        .Produces(200)
-        .Produces(401);
+        // NOTE (#2633 C2): the GameNight diary GET used to be registered HERE too
+        // ("/game-nights/{gameNightId}/diary") — colliding with GameNightEndpoints' canonical
+        // "GetGameNightDiary" on the same v1 group → AmbiguousMatchException (HTTP 500) on every
+        // diary GET. Retired: the canonical, participant-guarded endpoint is
+        // GameNightEndpoints.HandleGetGameNightDiary (GameManagement, returns GameNightDiaryDto with
+        // server-side Descriptions). The SessionTracking GetGameNightDiaryQuery (5-arg, raw
+        // SessionEventDto[]) remains for unit-test coverage but is no longer routed.
 
         // Current session probe (orphan recovery — NFR-9)
         app.MapGet("/sessions/current", async (

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Services/PdfStorageKeyReadPathRegressionTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Services/PdfStorageKeyReadPathRegressionTests.cs
@@ -1,0 +1,142 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Api.BoundedContexts.DocumentProcessing.Application.Services;
+using Api.Services.Pdf;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.DocumentProcessing.Application.Services;
+
+/// <summary>
+/// Issue #2671 regression: the PDF blob READ path must recover the RANDOM fileId that
+/// <see cref="IBlobStorageService.StoreAsync"/> embeds in the returned <c>FilePath</c>.
+/// Reconstructing the fileId from <see cref="PdfStorageKey.ForPdf"/> (which is only the
+/// resourceKey folder) never matches the stored blob, so extraction 404s.
+/// Exercised end-to-end against the real local <see cref="BlobStorageService"/> (filesystem,
+/// no Docker/S3) which shares the exact <c>{resourceKey}/{randomFileId}_{name}</c> layout
+/// with <see cref="S3BlobStorageService"/>.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "DocumentProcessing")]
+public sealed class PdfStorageKeyReadPathRegressionTests : IDisposable
+{
+    private readonly string _tempRoot;
+    private readonly BlobStorageService _storage;
+
+    public PdfStorageKeyReadPathRegressionTests()
+    {
+        _tempRoot = Path.Combine(Path.GetTempPath(), "meepleai-2671-" + Guid.NewGuid().ToString("N"));
+        var config = new Mock<IConfiguration>();
+        config.Setup(c => c["PDF_STORAGE_PATH"]).Returns(_tempRoot);
+        _storage = new BlobStorageService(config.Object, NullLogger<BlobStorageService>.Instance);
+    }
+
+    public void Dispose()
+    {
+        try
+        {
+            if (Directory.Exists(_tempRoot))
+            {
+                Directory.Delete(_tempRoot, recursive: true);
+            }
+        }
+#pragma warning disable CA1031 // best-effort temp cleanup
+        catch
+        {
+            // Ignore cleanup failures (locked file / antivirus) — temp dir, not load-bearing.
+        }
+#pragma warning restore CA1031
+    }
+
+    [Fact]
+    public async Task ReadPath_RecoversRandomFileIdFromFilePath_FindsBlob()
+    {
+        // Arrange — WRITE: StoreAsync generates a random fileId (≠ pdfId), persisted in FilePath.
+        var pdfId = Guid.NewGuid();
+        var resourceKey = PdfStorageKey.ForPdf(pdfId);
+        var content = "the-real-pdf-bytes"u8.ToArray();
+
+        BlobStorageResult writeResult;
+        using (var ms = new MemoryStream(content))
+        {
+            writeResult = await _storage.StoreAsync(ms, "file", BlobCategory.Pdf, resourceKey, CancellationToken.None);
+        }
+
+        writeResult.Success.Should().BeTrue();
+        writeResult.FileId.Should().NotBeNullOrEmpty();
+        writeResult.FileId.Should().NotBe(resourceKey, "the write fileId is a random GUID, not the pdfId");
+        writeResult.FilePath.Should().NotBeNullOrEmpty();
+
+        // Act — FIXED READ path (Issue #2671): recover fileId from FilePath; resourceKey = ForPdf(Id).
+        var recoveredFileId = PdfStorageKey.FileIdFromPath(writeResult.FilePath);
+        recoveredFileId.Should().Be(writeResult.FileId);
+
+        var stream = await _storage.RetrieveAsync(recoveredFileId!, BlobCategory.Pdf, resourceKey, CancellationToken.None);
+
+        // Assert — the fixed path locates the blob and returns the exact bytes written.
+        stream.Should().NotBeNull("the fixed READ path must locate the blob written by StoreAsync");
+        await using (stream!.ConfigureAwait(false))
+        {
+            using var read = new MemoryStream();
+            await stream.CopyToAsync(read, CancellationToken.None);
+            read.ToArray().Should().Equal(content);
+        }
+    }
+
+    [Fact]
+    public async Task ReadPath_OldBehaviour_UsingForPdfAsFileId_DoesNotFindBlob_RedProof()
+    {
+        // Arrange — same WRITE as the fixed test.
+        var pdfId = Guid.NewGuid();
+        var resourceKey = PdfStorageKey.ForPdf(pdfId);
+        using (var ms = new MemoryStream("bytes"u8.ToArray()))
+        {
+            var writeResult = await _storage.StoreAsync(ms, "file", BlobCategory.Pdf, resourceKey, CancellationToken.None);
+            writeResult.Success.Should().BeTrue();
+            writeResult.FileId.Should().NotBe(resourceKey);
+        }
+
+        // Act — OLD (pre-#2671, buggy) READ path: ForPdf(Id) passed as BOTH fileId and resourceKey.
+        var buggyFileId = PdfStorageKey.ForPdf(pdfId);
+        var stream = await _storage.RetrieveAsync(buggyFileId, BlobCategory.Pdf, buggyFileId, CancellationToken.None);
+
+        // Assert — RED proof: the old fileId==pdfId lookup never matches the random StoreAsync fileId.
+        stream.Should().BeNull("the buggy fileId==pdfId lookup cannot match the random StoreAsync fileId");
+    }
+
+    [Fact]
+    public async Task ReadPath_LegacyEmptyFilePath_FallsBackToForPdf_FindsBlob()
+    {
+        // A legacy blob written the pre-#2671 way (fileId == pdfId) with a record whose FilePath is
+        // empty/unparsable must still resolve via the ForPdf(Id) fallback (`FileIdFromPath(x) ?? ForPdf(Id)`).
+        var pdfId = Guid.NewGuid();
+        var resourceKey = PdfStorageKey.ForPdf(pdfId);
+        var legacyContent = "legacy-pdf-bytes"u8.ToArray();
+
+        // Materialise a legacy on-disk blob whose fileId segment IS the pdfId, using the service's
+        // own path contract (avoids hard-coding the internal on-disk layout).
+        var legacyBlobPath = _storage.GetStoragePath(resourceKey, BlobCategory.Pdf, resourceKey, "file.pdf");
+        Directory.CreateDirectory(Path.GetDirectoryName(legacyBlobPath)!);
+        await File.WriteAllBytesAsync(legacyBlobPath, legacyContent, CancellationToken.None);
+
+        // Act — READ path with an empty FilePath → helper returns null → fallback to ForPdf(Id).
+        var fileId = PdfStorageKey.FileIdFromPath(string.Empty) ?? resourceKey;
+        fileId.Should().Be(resourceKey, "empty FilePath must fall back to the pdfId-derived key");
+
+        var stream = await _storage.RetrieveAsync(fileId, BlobCategory.Pdf, resourceKey, CancellationToken.None);
+
+        // Assert — the fallback preserves the pre-#2671 behaviour for legacy records.
+        stream.Should().NotBeNull("legacy records without a parsable FilePath must resolve via the ForPdf(Id) fallback");
+        await using (stream!.ConfigureAwait(false))
+        {
+            using var read = new MemoryStream();
+            await stream.CopyToAsync(read, CancellationToken.None);
+            read.ToArray().Should().Equal(legacyContent);
+        }
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Services/PdfStorageKeyTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Services/PdfStorageKeyTests.cs
@@ -5,6 +5,8 @@ using Xunit;
 
 namespace Api.Tests.BoundedContexts.DocumentProcessing.Application.Services;
 
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "DocumentProcessing")]
 public class PdfStorageKeyTests
 {
     [Fact]
@@ -12,5 +14,55 @@ public class PdfStorageKeyTests
     {
         var pdfId = Guid.Parse("11111111-1111-1111-1111-111111111111");
         PdfStorageKey.ForPdf(pdfId).Should().Be("11111111111111111111111111111111");
+    }
+
+    // -------------------------------------------------------------------
+    // FileIdFromPath (Issue #2671): recover the RANDOM fileId StoreAsync
+    // embeds in the persisted FilePath. Helper moved here from PdfSeeder.
+    // -------------------------------------------------------------------
+
+    [Theory]
+    // Happy paths — S3 forward-slash + Windows backslash layouts
+    [InlineData("pdf_uploads/gameId/abc123_rulebook.pdf", "abc123")]
+    [InlineData("pdf_uploads\\gameId\\abc123_rulebook.pdf", "abc123")]
+    [InlineData("C:\\storage\\pdf_uploads\\gameId\\fedcba_doc.pdf", "fedcba")]
+    // Production S3 shape — hyphen-less GUID-N resourceKey dir + GUID-N fileId
+    [InlineData("pdfs/abcdef01234567890123456789abcdef/00112233445566778899aabbccddeeff_file", "00112233445566778899aabbccddeeff")]
+    // resourceKey dir WITH hyphens (canonical uuid) — fileId still after last '/', before first '_'
+    [InlineData("pdfs/11111111-1111-1111-1111-111111111111/deadbeefcafe_file.pdf", "deadbeefcafe")]
+    // Filename contains underscores — only the FIRST underscore in the last segment splits fileId/filename
+    [InlineData("pdf_uploads/gameId/abc123_my_file_v2.pdf", "abc123")]
+    public void FileIdFromPath_ValidPaths_ReturnsFileId(string filePath, string expectedFileId)
+    {
+        PdfStorageKey.FileIdFromPath(filePath).Should().Be(expectedFileId);
+    }
+
+    [Theory]
+    // Null / empty
+    [InlineData(null)]
+    [InlineData("")]
+    // No path separator → can't isolate last segment
+    [InlineData("singleSegment_file.pdf")]
+    [InlineData("noSeparatorNorUnderscore")]
+    // Trailing separator → no filename after last separator
+    [InlineData("pdfs/gameId/")]
+    [InlineData("pdfs\\gameId\\")]
+    // Last segment has no underscore → can't isolate fileId from filename
+    [InlineData("pdfs/gameId/justAFile.pdf")]
+    [InlineData("pdfs/gameId/no-underscore-here")]
+    // Leading underscore in last segment → fileId would be empty
+    [InlineData("pdfs/gameId/_leadingUnderscore.pdf")]
+    public void FileIdFromPath_InvalidPaths_ReturnsNull(string? filePath)
+    {
+        PdfStorageKey.FileIdFromPath(filePath).Should().BeNull();
+    }
+
+    [Fact]
+    public void FileIdFromPath_LegacyEmptyPath_CoalescesToForPdf()
+    {
+        // Caller pattern in the READ path: FileIdFromPath(FilePath) ?? ForPdf(Id).
+        var pdfId = Guid.NewGuid();
+        var fileId = PdfStorageKey.FileIdFromPath(string.Empty) ?? PdfStorageKey.ForPdf(pdfId);
+        fileId.Should().Be(PdfStorageKey.ForPdf(pdfId));
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/GameNight/GetGameNightDiaryQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/GameNight/GetGameNightDiaryQueryHandlerTests.cs
@@ -1,0 +1,159 @@
+using Api.BoundedContexts.GameManagement.Application.Queries.GameNights;
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Application.GameNight;
+
+/// <summary>
+/// #2633 C2: the GameManagement night-diary read is now participant-scoped (404 missing / 403
+/// non-participant, parity with the live query) and reads the RECENT window newest-first, then
+/// re-sorts to chronological. (The colliding SessionFlow twin route was retired.)
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "GameManagement")]
+public class GetGameNightDiaryQueryHandlerTests
+{
+    private readonly Mock<IGameNightEventRepository> _gameNightRepo = new();
+    private readonly Mock<ISessionEventRepository> _eventRepo = new();
+    private readonly GetGameNightDiaryQueryHandler _handler;
+
+    public GetGameNightDiaryQueryHandlerTests()
+    {
+        _handler = new GetGameNightDiaryQueryHandler(_gameNightRepo.Object, _eventRepo.Object);
+        // Default: no events unless a test sets some.
+        _eventRepo
+            .Setup(r => r.GetByGameNightIdAsync(
+                It.IsAny<Guid>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<SessionEvent>());
+    }
+
+    private static GameNightEvent PublishedNight(Guid? organizerId = null, List<Guid>? invited = null)
+    {
+        var evt = GameNightEvent.Create(
+            organizerId ?? Guid.NewGuid(), "Serata", DateTimeOffset.UtcNow.AddHours(1),
+            gameIds: [Guid.NewGuid()]);
+        evt.Publish(invited ?? []);
+        return evt;
+    }
+
+    private static SessionEvent EventAt(Guid gameNightId, string type, DateTime timestamp)
+    {
+        var e = SessionEvent.Create(Guid.NewGuid(), type, gameNightId: gameNightId);
+        // Timestamp has a private setter (factory pins it to UtcNow) — set it explicitly the same
+        // way the persistence mappers hydrate domain entities.
+        typeof(SessionEvent).GetProperty(nameof(SessionEvent.Timestamp))!.SetValue(e, timestamp);
+        return e;
+    }
+
+    [Fact]
+    public async Task Handle_MissingNight_ThrowsNotFound()
+    {
+        _gameNightRepo.Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((GameNightEvent?)null);
+
+        var act = () => _handler.Handle(
+            new GetGameNightDiaryQuery(Guid.NewGuid(), Guid.NewGuid()), TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+
+    [Fact]
+    public async Task Handle_NonParticipant_ThrowsForbidden()
+    {
+        var evt = PublishedNight();
+        _gameNightRepo.Setup(r => r.GetByIdAsync(evt.Id, It.IsAny<CancellationToken>())).ReturnsAsync(evt);
+
+        var act = () => _handler.Handle(
+            new GetGameNightDiaryQuery(evt.Id, Guid.NewGuid()), TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<ForbiddenException>();
+    }
+
+    [Fact]
+    public async Task Handle_NonParticipant_NeverReadsTheDiary()
+    {
+        var evt = PublishedNight();
+        _gameNightRepo.Setup(r => r.GetByIdAsync(evt.Id, It.IsAny<CancellationToken>())).ReturnsAsync(evt);
+
+        await _handler.Invoking(h => h.Handle(
+                new GetGameNightDiaryQuery(evt.Id, Guid.NewGuid()), TestContext.Current.CancellationToken))
+            .Should().ThrowAsync<ForbiddenException>();
+
+        _eventRepo.Verify(r => r.GetByGameNightIdAsync(
+            It.IsAny<Guid>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_Organizer_ReturnsDiaryEnvelope()
+    {
+        var evt = PublishedNight();
+        _gameNightRepo.Setup(r => r.GetByIdAsync(evt.Id, It.IsAny<CancellationToken>())).ReturnsAsync(evt);
+
+        var result = await _handler.Handle(
+            new GetGameNightDiaryQuery(evt.Id, evt.OrganizerId), TestContext.Current.CancellationToken);
+
+        result.GameNightId.Should().Be(evt.Id);
+        result.Entries.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Handle_InvitedRsvpPlayer_IsAllowed()
+    {
+        var invited = Guid.NewGuid();
+        var evt = PublishedNight(invited: [invited]);
+        _gameNightRepo.Setup(r => r.GetByIdAsync(evt.Id, It.IsAny<CancellationToken>())).ReturnsAsync(evt);
+
+        var act = () => _handler.Handle(
+            new GetGameNightDiaryQuery(evt.Id, invited), TestContext.Current.CancellationToken);
+
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task Handle_ReadsRecentWindowNewestFirst_ButReturnsChronological()
+    {
+        var evt = PublishedNight();
+        _gameNightRepo.Setup(r => r.GetByIdAsync(evt.Id, It.IsAny<CancellationToken>())).ReturnsAsync(evt);
+
+        var t1 = new DateTime(2026, 7, 4, 20, 0, 0, DateTimeKind.Utc);
+        var t2 = new DateTime(2026, 7, 4, 20, 1, 0, DateTimeKind.Utc);
+        var t3 = new DateTime(2026, 7, 4, 20, 2, 0, DateTimeKind.Utc);
+        // Repo returns newest-first (as newestFirst:true would): t3, t2, t1.
+        _eventRepo
+            .Setup(r => r.GetByGameNightIdAsync(evt.Id, It.IsAny<int>(), It.IsAny<int>(), true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { EventAt(evt.Id, "score_updated", t3), EventAt(evt.Id, "turn_advanced", t2), EventAt(evt.Id, "game_started", t1) });
+
+        var result = await _handler.Handle(
+            new GetGameNightDiaryQuery(evt.Id, evt.OrganizerId), TestContext.Current.CancellationToken);
+
+        // Handler re-sorts to chronological ASC for render.
+        result.Entries.Select(e => e.Timestamp).Should().ContainInOrder(t1, t2, t3);
+        // Recency contract: it must have requested the newest-first window.
+        _eventRepo.Verify(r => r.GetByGameNightIdAsync(
+            evt.Id, It.IsAny<int>(), It.IsAny<int>(), true, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_GeneratesItalianDescription_ForKnownEventType()
+    {
+        var evt = PublishedNight();
+        _gameNightRepo.Setup(r => r.GetByIdAsync(evt.Id, It.IsAny<CancellationToken>())).ReturnsAsync(evt);
+        _eventRepo
+            .Setup(r => r.GetByGameNightIdAsync(evt.Id, It.IsAny<int>(), It.IsAny<int>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { EventAt(evt.Id, "game_started", DateTime.UtcNow) });
+
+        var result = await _handler.Handle(
+            new GetGameNightDiaryQuery(evt.Id, evt.OrganizerId), TestContext.Current.CancellationToken);
+
+        result.Entries.Should().ContainSingle();
+        result.Entries[0].EventType.Should().Be("game_started");
+        result.Entries[0].Description.Should().Be("🎲 Partita iniziata");
+    }
+}

--- a/apps/api/tests/Api.Tests/Infrastructure/Seeders/Catalog/PdfSeederBlobTests.cs
+++ b/apps/api/tests/Api.Tests/Infrastructure/Seeders/Catalog/PdfSeederBlobTests.cs
@@ -505,43 +505,7 @@ public sealed class PdfSeederBlobTests
         db.ProcessingJobs.Should().BeEmpty();
     }
 
-    // ---------------------------------------------------------------
-    // ExtractFileIdFromPath edge cases (review finding #3 follow-up)
-    // ---------------------------------------------------------------
-
-    [Theory]
-    // Happy paths — S3 forward-slash + Windows backslash layouts
-    [InlineData("pdf_uploads/gameId/abc123_rulebook.pdf", "abc123")]
-    [InlineData("pdf_uploads\\gameId\\abc123_rulebook.pdf", "abc123")]
-    [InlineData("C:\\storage\\pdf_uploads\\gameId\\fedcba_doc.pdf", "fedcba")]
-    // GUID-N fileId (32 hex chars, no underscores, no hyphens) — production shape
-    [InlineData("pdf_uploads/game/abcdef01234567890123456789abcdef_file.pdf", "abcdef01234567890123456789abcdef")]
-    // Filename contains underscore — only FIRST underscore in last segment splits fileId/filename
-    [InlineData("pdf_uploads/gameId/abc123_my_file_v2.pdf", "abc123")]
-    public void ExtractFileIdFromPath_ValidPaths_ReturnsFileId(string filePath, string expectedFileId)
-    {
-        var result = PdfSeeder.ExtractFileIdFromPath(filePath);
-        result.Should().Be(expectedFileId);
-    }
-
-    [Theory]
-    // Null / empty
-    [InlineData(null)]
-    [InlineData("")]
-    // No path separator → can't isolate last segment
-    [InlineData("singleSegment_file.pdf")]
-    [InlineData("noSeparatorNorUnderscore")]
-    // Trailing slash → no filename after last separator
-    [InlineData("pdf_uploads/gameId/")]
-    [InlineData("pdf_uploads\\gameId\\")]
-    // Last segment has no underscore → can't isolate fileId from filename
-    [InlineData("pdf_uploads/gameId/justAFile.pdf")]
-    [InlineData("pdf_uploads/gameId/no-underscore-here")]
-    // Leading underscore in last segment → fileId would be empty
-    [InlineData("pdf_uploads/gameId/_leadingUnderscore.pdf")]
-    public void ExtractFileIdFromPath_InvalidPaths_ReturnsNull(string? filePath)
-    {
-        var result = PdfSeeder.ExtractFileIdFromPath(filePath!);
-        result.Should().BeNull();
-    }
+    // NOTE (Issue #2671): the fileId-from-path parsing helper was extracted from
+    // PdfSeeder.ExtractFileIdFromPath into the shared PdfStorageKey.FileIdFromPath.
+    // Its edge-case unit tests now live in PdfStorageKeyTests (single source of truth).
 }

--- a/apps/api/tests/Api.Tests/Integration/GameManagement/GameNightDiaryRouteUniquenessTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/GameManagement/GameNightDiaryRouteUniquenessTests.cs
@@ -1,0 +1,61 @@
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.Integration.GameManagement;
+
+/// <summary>
+/// #2633 C2 — regression guard for the diary route collision. The GameNight diary GET was
+/// registered twice on the v1 group (GameManagement + SessionFlow), same route template →
+/// <c>AmbiguousMatchException</c> (HTTP 500) on every request. This test boots the real host and
+/// asserts the endpoint is registered exactly once, so a future duplicate fails CI, not prod.
+/// </summary>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "GameManagement")]
+public sealed class GameNightDiaryRouteUniquenessTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly string _testDbName;
+    private WebApplicationFactory<Program> _factory = null!;
+
+    public GameNightDiaryRouteUniquenessTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+        _testDbName = $"gn_diary_route_{Guid.NewGuid():N}";
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_testDbName);
+        _factory = IntegrationWebApplicationFactory.Create(connectionString);
+        _ = _factory.Services; // force host build so the EndpointDataSource is populated
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _factory.DisposeAsync();
+        await _fixture.DropIsolatedDatabaseAsync(_testDbName);
+    }
+
+    [Fact]
+    public void GameNightDiary_IsRegisteredExactlyOnce()
+    {
+        var dataSource = _factory.Services.GetRequiredService<EndpointDataSource>();
+
+        var diaryEndpoints = dataSource.Endpoints
+            .OfType<RouteEndpoint>()
+            .Where(e => e.RoutePattern.RawText is { } raw
+                && raw.Contains("game-nights", StringComparison.OrdinalIgnoreCase)
+                && raw.EndsWith("/diary", StringComparison.OrdinalIgnoreCase))
+            .ToList();
+
+        diaryEndpoints.Should().ContainSingle(
+            "the GameNight diary GET must map to exactly one endpoint — a duplicate route template " +
+            "throws AmbiguousMatchException (HTTP 500) at request time (#2633 C2)");
+    }
+}

--- a/apps/web/src/app/(authenticated)/game-nights/[id]/live/_components/NightLiveClientView.tsx
+++ b/apps/web/src/app/(authenticated)/game-nights/[id]/live/_components/NightLiveClientView.tsx
@@ -20,7 +20,9 @@ import { useRouter } from 'next/navigation';
 import { BlockedLiveSessionModal, NightLiveHub } from '@/components/features/game-nights/live';
 import { ForbiddenError, NotFoundError, UnauthorizedError } from '@/lib/api/core/errors';
 import { useGameNightLive } from '@/lib/game-nights/hooks/useGameNightLive';
+import { useNightLiveDiary } from '@/lib/game-nights/hooks/useNightLiveDiary';
 import { isMaxLiveBlockedError, useStartNextGame } from '@/lib/game-nights/hooks/useStartNextGame';
+import { mapDiary } from '@/lib/game-nights/mapDiary';
 
 export interface NightLiveClientViewProps {
   readonly nightId: string;
@@ -29,6 +31,10 @@ export interface NightLiveClientViewProps {
 export function NightLiveClientView({ nightId }: NightLiveClientViewProps) {
   const router = useRouter();
   const { data: vm, isLoading, isError, error } = useGameNightLive(nightId);
+  // Slice C2: the diary is a SEPARATE participant-guarded read; composed with the live VM
+  // below via mapDiary (panel D2). Its own error/loading is non-fatal — the hub renders an
+  // empty diary rather than blocking the live view.
+  const { data: diaryDto } = useNightLiveDiary(nightId);
 
   const handleBack = useCallback(() => {
     router.push(`/game-nights/${nightId}`);
@@ -123,6 +129,13 @@ export function NightLiveClientView({ nightId }: NightLiveClientViewProps) {
   // next game when the current one is over. The 409 modal is the backstop for races.
   const showStartCta = vm.isViewerOrganizer && nextGame !== null && vm.status !== 'live';
 
+  // Slice C2 (panel D2): compose the diary here, keyed off the live sessionId→game lookup.
+  // A pending/errored diary read yields empty arrays — the hub degrades to an empty diary
+  // rather than blocking the live view (AC6).
+  const diary = diaryDto
+    ? mapDiary(diaryDto, vm.sessions)
+    : { diaryEvents: [], diaryGames: [], diaryPlayers: [] };
+
   return (
     <>
       <NightLiveHub
@@ -136,9 +149,9 @@ export function NightLiveClientView({ nightId }: NightLiveClientViewProps) {
         totalPlayers={vm.totalPlayers}
         plannedGames={vm.plannedGames}
         currentGame={vm.currentGame}
-        diaryEvents={vm.diaryEvents}
-        diaryGames={vm.diaryGames}
-        diaryPlayers={vm.diaryPlayers}
+        diaryEvents={diary.diaryEvents}
+        diaryGames={diary.diaryGames}
+        diaryPlayers={diary.diaryPlayers}
         onBack={handleBack}
         onJumpToSession={handleJumpToSession}
       />

--- a/apps/web/src/app/(authenticated)/game-nights/[id]/live/_components/__tests__/NightLiveClientView.test.tsx
+++ b/apps/web/src/app/(authenticated)/game-nights/[id]/live/_components/__tests__/NightLiveClientView.test.tsx
@@ -42,6 +42,17 @@ vi.mock('@/lib/game-nights/hooks/useStartNextGame', async importActual => {
   };
 });
 
+// Slice C2: the view composes a second read (the diary). Mock it to a resolved-empty default so
+// these live-focused tests don't need a QueryClient; a dedicated block drives it for diary render.
+const useNightLiveDiaryMock = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/game-nights/hooks/useNightLiveDiary', () => ({
+  useNightLiveDiary: useNightLiveDiaryMock,
+  nightLiveDiaryKeys: {
+    all: ['game-nights', 'diary'],
+    detail: (id: string) => ['game-nights', 'diary', id],
+  },
+}));
+
 const pushMock = vi.fn();
 const replaceMock = vi.fn();
 vi.mock('next/navigation', () => ({
@@ -86,9 +97,7 @@ function vm(over: Partial<NightLiveViewModel> = {}): NightLiveViewModel {
       },
     ],
     currentGame: null,
-    diaryEvents: [],
-    diaryGames: [],
-    diaryPlayers: [],
+    sessions: [],
     ...over,
   };
 }
@@ -106,6 +115,7 @@ function mockQuery(over: Record<string, unknown>) {
 beforeEach(() => {
   vi.clearAllMocks();
   startNextState.isPending = false;
+  useNightLiveDiaryMock.mockReturnValue({ data: undefined });
 });
 
 const NEXT_GAME = { gameId: '77777777-7777-4777-8777-777777777777', gameTitle: 'Catan' };
@@ -237,6 +247,50 @@ describe('NightLiveClientView — organizer interactive start (WS1 DEC-10)', () 
     render(<NightLiveClientView nightId={NIGHT_ID} />);
     await userEvent.click(screen.getByRole('button', { name: /Avvia: Catan/i }));
     expect(screen.queryByRole('dialog')).toBeNull();
+  });
+});
+
+describe('NightLiveClientView — diary composition (Slice C2)', () => {
+  const GAME_ID = '88888888-8888-4888-8888-888888888888';
+
+  it('renders diary events composed from the diary read + the live sessionId→game lookup', () => {
+    useNightLiveDiaryMock.mockReturnValue({
+      data: {
+        gameNightId: NIGHT_ID,
+        entries: [
+          {
+            id: '99999999-9999-4999-8999-999999999999',
+            sessionId: IN_PROGRESS_SESSION_ID,
+            eventType: 'score_updated',
+            description: '📊 Punteggio aggiornato',
+            payload: null,
+            actorId: null,
+            timestamp: '2026-07-04T20:00:00',
+          },
+        ],
+      },
+    });
+    mockQuery({
+      data: vm({
+        sessions: [
+          { sessionId: IN_PROGRESS_SESSION_ID, gameId: GAME_ID, gameTitle: 'Spirit Island' },
+        ],
+      }),
+    });
+
+    render(<NightLiveClientView nightId={NIGHT_ID} />);
+
+    expect(screen.getAllByText(/Punteggio aggiornato/i).length).toBeGreaterThan(0);
+  });
+
+  it('renders the hub with an empty diary when the diary read has not resolved (AC6)', () => {
+    useNightLiveDiaryMock.mockReturnValue({ data: undefined });
+    mockQuery({ data: vm() });
+
+    render(<NightLiveClientView nightId={NIGHT_ID} />);
+
+    // the live hub still renders (no crash / no dependency on the diary read)
+    expect(screen.getByText('Serata Eldoria')).toBeInTheDocument();
   });
 });
 

--- a/apps/web/src/lib/api/schemas/__tests__/game-nights-diary.schemas.test.ts
+++ b/apps/web/src/lib/api/schemas/__tests__/game-nights-diary.schemas.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+import { parseGameNightDiaryResilient } from '@/lib/api/schemas/game-nights.schemas';
+
+const GN = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
+const validEntry = (over: Record<string, unknown> = {}) => ({
+  id: '11111111-1111-4111-8111-111111111111',
+  sessionId: '22222222-2222-4222-8222-222222222222',
+  eventType: 'score_updated',
+  description: '📊 Punteggio aggiornato',
+  payload: null,
+  actorId: null,
+  timestamp: '2026-07-04T20:00:00',
+  ...over,
+});
+
+describe('parseGameNightDiaryResilient (panel D8)', () => {
+  beforeEach(() => vi.spyOn(console, 'warn').mockImplementation(() => undefined));
+  afterEach(() => vi.restoreAllMocks());
+
+  it('parses a well-formed diary', () => {
+    const result = parseGameNightDiaryResilient({ gameNightId: GN, entries: [validEntry()] });
+    expect(result.gameNightId).toBe(GN);
+    expect(result.entries).toHaveLength(1);
+  });
+
+  it('accepts an OPEN eventType (a new BE type is NOT rejected)', () => {
+    const result = parseGameNightDiaryResilient({
+      gameNightId: GN,
+      entries: [validEntry({ eventType: 'brand_new_event_type' })],
+    });
+    expect(result.entries).toHaveLength(1);
+    expect(result.entries[0].eventType).toBe('brand_new_event_type');
+  });
+
+  it('skips ONE malformed entry without dropping the whole array', () => {
+    const result = parseGameNightDiaryResilient({
+      gameNightId: GN,
+      entries: [
+        validEntry(),
+        { id: 'not-a-uuid', garbage: true },
+        validEntry({ id: '33333333-3333-4333-8333-333333333333' }),
+      ],
+    });
+    expect(result.entries).toHaveLength(2);
+    expect(console.warn).toHaveBeenCalled();
+  });
+
+  it('degrades a malformed envelope to an empty diary (no throw)', () => {
+    expect(() => parseGameNightDiaryResilient({ nope: 1 })).not.toThrow();
+    const result = parseGameNightDiaryResilient({ nope: 1 });
+    expect(result.entries).toEqual([]);
+  });
+
+  it('degrades null/undefined to an empty diary (no throw)', () => {
+    expect(parseGameNightDiaryResilient(null).entries).toEqual([]);
+    expect(parseGameNightDiaryResilient(undefined).entries).toEqual([]);
+  });
+});

--- a/apps/web/src/lib/api/schemas/game-nights.schemas.ts
+++ b/apps/web/src/lib/api/schemas/game-nights.schemas.ts
@@ -95,6 +95,62 @@ export const GameNightLiveDtoSchema = z.object({
 });
 export type GameNightLiveDto = z.infer<typeof GameNightLiveDtoSchema>;
 
+// ──────────────────────────────────────────────────────────────────────
+// #2633 C2 — night diary read model (GET /game-nights/{id}/diary).
+// Mirrors the C# GameNightDiaryDto / GameNightDiaryEntryDto. Per panel D8:
+// `eventType` is an OPEN z.string() — mapDiary derives a CLOSED DiaryEventKind
+// with a total default→system, so a new/unlisted BE event type renders instead
+// of being silently dropped as "malformed".
+// ──────────────────────────────────────────────────────────────────────
+
+export const GameNightDiaryEntryDtoSchema = z.object({
+  id: z.string().uuid(),
+  sessionId: z.string().uuid(),
+  eventType: z.string(),
+  description: z.string(),
+  payload: z.string().nullish(),
+  actorId: z.string().uuid().nullish(),
+  timestamp: z.string(),
+});
+export type GameNightDiaryEntryDto = z.infer<typeof GameNightDiaryEntryDtoSchema>;
+
+export const GameNightDiaryDtoSchema = z.object({
+  gameNightId: z.string().uuid(),
+  entries: z.array(GameNightDiaryEntryDtoSchema),
+});
+export type GameNightDiaryDto = z.infer<typeof GameNightDiaryDtoSchema>;
+
+/**
+ * Panel D8 / must-fix #2: per-row resilient parse. One malformed diary entry must
+ * NOT blow up the whole timeline (the array-level `.parse()` throw the shipped SSE
+ * hook suffered via unguarded JSON.parse). Skips + warns on bad rows, keeps the
+ * valid ones; a malformed envelope degrades to an empty diary rather than throwing.
+ */
+export function parseGameNightDiaryResilient(raw: unknown): GameNightDiaryDto {
+  const envelope = z
+    .object({ gameNightId: z.string().uuid(), entries: z.array(z.unknown()) })
+    .safeParse(raw);
+
+  if (!envelope.success) {
+    if (typeof console !== 'undefined') {
+      console.warn('[night-diary] malformed envelope, rendering empty diary', envelope.error);
+    }
+    const maybeId = (raw as { gameNightId?: unknown } | null)?.gameNightId;
+    return { gameNightId: typeof maybeId === 'string' ? maybeId : '', entries: [] };
+  }
+
+  const entries: GameNightDiaryEntryDto[] = [];
+  for (const row of envelope.data.entries) {
+    const parsed = GameNightDiaryEntryDtoSchema.safeParse(row);
+    if (parsed.success) {
+      entries.push(parsed.data);
+    } else if (typeof console !== 'undefined') {
+      console.warn('[night-diary] skipping malformed entry', parsed.error);
+    }
+  }
+  return { gameNightId: envelope.data.gameNightId, entries };
+}
+
 export const CreateGameNightInputSchema = z.object({
   title: z.string().min(3).max(200),
   description: z.string().max(2000).optional(),

--- a/apps/web/src/lib/domain-hooks/useGameNightDiary.ts
+++ b/apps/web/src/lib/domain-hooks/useGameNightDiary.ts
@@ -6,6 +6,19 @@ import { gameNightSessionClient } from '@/lib/api/clients/gameNightSessionClient
 import { useGameNightStore } from '@/stores/game-night/store';
 import type { DiaryEntry } from '@/stores/game-night/types';
 
+/** #2633 C2: parse a diary payload without ever throwing — a malformed row must not vanish the diary. */
+function safeParsePayload(payload: string | undefined): Record<string, unknown> | undefined {
+  if (!payload) return undefined;
+  try {
+    const parsed: unknown = JSON.parse(payload);
+    return parsed !== null && typeof parsed === 'object' && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 /**
  * Hook for managing game night diary entries.
  *
@@ -36,7 +49,9 @@ export function useGameNightDiary(gameNightId: string) {
               gameNightId,
               eventType: e.eventType as DiaryEntry['eventType'],
               description: e.description ?? '',
-              payload: e.payload ? JSON.parse(e.payload) : undefined,
+              // #2633 C2 (panel must-fix #2): guard the parse per-row — a single malformed payload
+              // must NOT throw and vanish the whole diary (it did, silently, via the outer .catch).
+              payload: safeParsePayload(e.payload),
               actorId: e.actorId,
               timestamp: e.timestamp,
             }))

--- a/apps/web/src/lib/game-nights/__tests__/mapDiary.test.ts
+++ b/apps/web/src/lib/game-nights/__tests__/mapDiary.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect } from 'vitest';
+
+import type { GameNightDiaryDto } from '@/lib/api/schemas/game-nights.schemas';
+import { mapDiary, toKind, toTimeLabel } from '@/lib/game-nights/mapDiary';
+import type { NightSessionRef } from '@/lib/game-nights/mapNightLive';
+
+const S1 = '11111111-1111-4111-8111-111111111111';
+const S2 = '22222222-2222-4222-8222-222222222222';
+const G1 = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const G2 = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+
+const SESSIONS: readonly NightSessionRef[] = [
+  { sessionId: S1, gameId: G1, gameTitle: 'Brass' },
+  { sessionId: S2, gameId: G2, gameTitle: 'Spirit Island' },
+];
+
+function entry(
+  over: Partial<GameNightDiaryDto['entries'][number]> = {}
+): GameNightDiaryDto['entries'][number] {
+  return {
+    id: crypto.randomUUID(),
+    sessionId: S1,
+    eventType: 'game_started',
+    description: '🎲 Partita iniziata',
+    payload: null,
+    actorId: null,
+    timestamp: '2026-07-04T20:00:00',
+    ...over,
+  };
+}
+
+function dto(entries: GameNightDiaryDto['entries']): GameNightDiaryDto {
+  return { gameNightId: 'cccccccc-cccc-4ccc-8ccc-cccccccccccc', entries };
+}
+
+describe('toKind — emitter vocabulary (panel D6)', () => {
+  it('maps the write-side emitter strings to their kinds', () => {
+    expect(toKind('score_updated')).toBe('score');
+    expect(toKind('turn_advanced')).toBe('turn');
+    expect(toKind('dice_rolled')).toBe('custom');
+    expect(toKind('session_paused')).toBe('system');
+    expect(toKind('game_completed')).toBe('end');
+  });
+
+  it('also maps the legacy display-switch aliases', () => {
+    expect(toKind('score_update')).toBe('score');
+    expect(toKind('dice_roll')).toBe('custom');
+    expect(toKind('pause_resume')).toBe('system');
+  });
+
+  it('falls back to system for unknown/new event types (D8 — never dropped)', () => {
+    expect(toKind('some_future_event')).toBe('system');
+    expect(toKind('')).toBe('system');
+  });
+});
+
+describe('toTimeLabel — UTC pinning (panel timezone must-fix)', () => {
+  it('reads a bare BE timestamp as UTC (append Z), not browser-local', () => {
+    // 20:00 UTC must render 20:00 regardless of the runner's timezone.
+    expect(toTimeLabel('2026-07-04T20:00:00')).toBe('20:00');
+    expect(toTimeLabel('2026-07-04T09:05:00')).toBe('09:05');
+  });
+
+  it('respects an explicit offset when present', () => {
+    expect(toTimeLabel('2026-07-04T20:00:00Z')).toBe('20:00');
+    expect(toTimeLabel('2026-07-04T22:00:00+02:00')).toBe('20:00');
+  });
+
+  it('returns empty for an unparseable timestamp', () => {
+    expect(toTimeLabel('not-a-date')).toBe('');
+  });
+});
+
+describe('mapDiary', () => {
+  it('groups events under the game resolved from the live sessionId lookup (D4)', () => {
+    const result = mapDiary(
+      dto([
+        entry({ sessionId: S1, eventType: 'turn_advanced' }),
+        entry({ sessionId: S2, eventType: 'score_updated' }),
+      ]),
+      SESSIONS
+    );
+
+    expect(result.diaryEvents.map(e => e.gameId)).toEqual([G1, G2]);
+    expect(result.diaryEvents.map(e => e.kind)).toEqual(['turn', 'score']);
+    // one DiaryGameRef per distinct game, titles from the live lookup
+    expect(result.diaryGames).toEqual([
+      { id: G1, title: 'Brass', emoji: expect.any(String) },
+      { id: G2, title: 'Spirit Island', emoji: expect.any(String) },
+    ]);
+  });
+
+  it('maps an event whose session is not in the live lookup to gameId=null (AC3, no crash)', () => {
+    const orphanSession = '99999999-9999-4999-8999-999999999999';
+    const result = mapDiary(dto([entry({ sessionId: orphanSession })]), SESSIONS);
+
+    expect(result.diaryEvents).toHaveLength(1);
+    expect(result.diaryEvents[0].gameId).toBeNull();
+    // a null-game (night-level) event contributes no DiaryGameRef
+    expect(result.diaryGames).toEqual([]);
+  });
+
+  it('keeps the server Description as text and derives the icon from the kind, not Description[0] (D7)', () => {
+    const result = mapDiary(
+      dto([entry({ eventType: 'score_updated', description: '📊 Punteggio aggiornato' })]),
+      SESSIONS
+    );
+    expect(result.diaryEvents[0].text).toBe('📊 Punteggio aggiornato');
+    expect(result.diaryEvents[0].icon).toBe('📊'); // ICON_BY_KIND['score'], not sliced from the text
+  });
+
+  it('deduplicates DiaryGameRef when a game has multiple events', () => {
+    const result = mapDiary(
+      dto([entry({ sessionId: S1 }), entry({ sessionId: S1, eventType: 'turn_advanced' })]),
+      SESSIONS
+    );
+    expect(result.diaryGames).toHaveLength(1);
+    expect(result.diaryGames[0].id).toBe(G1);
+  });
+
+  it('is minimal (D5): no actor avatars, no diary players', () => {
+    const result = mapDiary(dto([entry(), entry({ eventType: 'score_updated' })]), SESSIONS);
+    expect(result.diaryEvents.every(e => e.actors.length === 0)).toBe(true);
+    expect(result.diaryPlayers).toEqual([]);
+  });
+
+  it('handles an empty diary', () => {
+    const result = mapDiary(dto([]), SESSIONS);
+    expect(result.diaryEvents).toEqual([]);
+    expect(result.diaryGames).toEqual([]);
+    expect(result.diaryPlayers).toEqual([]);
+  });
+
+  it('is deterministic (pure): same input → identical output', () => {
+    const input = dto([
+      entry({ sessionId: S1 }),
+      entry({ sessionId: S2, eventType: 'score_updated' }),
+    ]);
+    expect(mapDiary(input, SESSIONS)).toEqual(mapDiary(input, SESSIONS));
+  });
+});

--- a/apps/web/src/lib/game-nights/__tests__/mapNightLive.test.ts
+++ b/apps/web/src/lib/game-nights/__tests__/mapNightLive.test.ts
@@ -353,11 +353,15 @@ describe('mapNightLiveToViewModel — empty night (LD-11) + Slice-C seam (LD-3)'
     expect(vm.night.title).toBe('Serata Eldoria');
   });
 
-  it('emits the diary arrays as their true empty contract (Slice C2/C4)', () => {
+  it('exposes the sessionId→game lookup mapDiary joins against (Slice C2)', () => {
     const vm = mapNightLiveToViewModel(HAPPY, NOW);
-    expect(vm.diaryEvents).toEqual([]);
-    expect(vm.diaryGames).toEqual([]);
-    expect(vm.diaryPlayers).toEqual([]);
+    // The VM is live-only now — no diary fields (panel D2).
+    expect(vm).not.toHaveProperty('diaryEvents');
+    expect(vm.sessions).toEqual([
+      { sessionId: S1, gameId: G1, gameTitle: 'Brass' },
+      { sessionId: S2, gameId: G2, gameTitle: 'Spirit Island' },
+      { sessionId: S3, gameId: G3, gameTitle: 'Wingspan' },
+    ]);
   });
 
   it('leaves confirmedPlayers/totalPlayers undefined (no RSVP fetch in Slice B)', () => {

--- a/apps/web/src/lib/game-nights/hooks/__tests__/useNightLiveDiary.test.tsx
+++ b/apps/web/src/lib/game-nights/hooks/__tests__/useNightLiveDiary.test.tsx
@@ -1,0 +1,64 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * useNightLiveDiary unit tests — #2633 Slice C2.
+ */
+
+import { type ReactNode } from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { useNightLiveDiary } from '../useNightLiveDiary';
+
+const getDiaryMock = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/api/clients/gameNightSessionClient', () => ({
+  gameNightSessionClient: { getDiary: getDiaryMock },
+}));
+
+const GN = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const entry = (over: Record<string, unknown> = {}) => ({
+  id: '11111111-1111-4111-8111-111111111111',
+  sessionId: '22222222-2222-4222-8222-222222222222',
+  eventType: 'score_updated',
+  description: '📊',
+  payload: null,
+  actorId: null,
+  timestamp: '2026-07-04T20:00:00',
+  ...over,
+});
+
+function wrapper() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+  };
+}
+
+describe('useNightLiveDiary', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('loads + resiliently parses the diary (drops a malformed row, keeps the rest)', async () => {
+    getDiaryMock.mockResolvedValue({
+      gameNightId: GN,
+      entries: [
+        entry(),
+        { id: 'not-a-uuid' },
+        entry({ id: '33333333-3333-4333-8333-333333333333' }),
+      ],
+    });
+
+    const { result } = renderHook(() => useNightLiveDiary(GN), { wrapper: wrapper() });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(getDiaryMock).toHaveBeenCalledWith(GN);
+    expect(result.current.data?.entries).toHaveLength(2);
+  });
+
+  it('is disabled for an empty id', () => {
+    const { result } = renderHook(() => useNightLiveDiary(''), { wrapper: wrapper() });
+    expect(result.current.fetchStatus).toBe('idle');
+    expect(getDiaryMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/game-nights/hooks/useNightLiveDiary.ts
+++ b/apps/web/src/lib/game-nights/hooks/useNightLiveDiary.ts
@@ -1,0 +1,42 @@
+'use client';
+
+/**
+ * useNightLiveDiary — #2633 Slice C2.
+ *
+ * React Query loader over the canonical, participant-guarded diary read
+ * (`GET /game-nights/{id}/diary` via `gameNightSessionClient.getDiary` — the single
+ * client method for that endpoint, panel must-fix #2). `select` runs the per-row
+ * resilient parse so one malformed entry cannot blow up the whole timeline (D8).
+ *
+ * Deliberately NOT named `useGameNightDiary`: that name is the pre-existing Zustand+SSE
+ * hook (game-night session flow) with its own consumers — this is the RQ loader for the
+ * night-live hub, composed with `useGameNightLive` in `NightLiveClientView`.
+ */
+
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+
+import { gameNightSessionClient } from '@/lib/api/clients/gameNightSessionClient';
+import {
+  parseGameNightDiaryResilient,
+  type GameNightDiaryDto,
+} from '@/lib/api/schemas/game-nights.schemas';
+
+/** Query key factory — distinct from the live key so each read caches/invalidates on its own. */
+export const nightLiveDiaryKeys = {
+  all: ['game-nights', 'diary'] as const,
+  detail: (id: string) => [...nightLiveDiaryKeys.all, id] as const,
+};
+
+export function useNightLiveDiary(
+  id: string,
+  enabled: boolean = true
+): UseQueryResult<GameNightDiaryDto, Error> {
+  return useQuery({
+    queryKey: nightLiveDiaryKeys.detail(id),
+    queryFn: () => gameNightSessionClient.getDiary(id),
+    select: parseGameNightDiaryResilient,
+    enabled: enabled && !!id,
+    staleTime: 30_000,
+    retry: false,
+  });
+}

--- a/apps/web/src/lib/game-nights/hooks/useStartNextGame.ts
+++ b/apps/web/src/lib/game-nights/hooks/useStartNextGame.ts
@@ -17,6 +17,7 @@ import { ConflictError } from '@/lib/api/core/errors';
 import type { StartGameNightSessionResult } from '@/lib/api/schemas/game-nights.schemas';
 
 import { gameNightLiveKeys } from './useGameNightLive';
+import { nightLiveDiaryKeys } from './useNightLiveDiary';
 
 export const MAX_LIVE_SESSIONS_EXCEEDED = 'MAX_LIVE_SESSIONS_EXCEEDED';
 
@@ -39,7 +40,11 @@ export function useStartNextGame(
     mutationFn: ({ gameId, gameTitle }: StartNextGameVars) =>
       api.gameNights.startNextGame(gameNightId, gameId, gameTitle),
     onSuccess: () => {
+      // Refetch BOTH reads: the live sessions gain the new InProgress row AND the diary gains
+      // its game_started event — invalidating only the live key would leave the diary mis-grouped
+      // until its own staleTime elapsed (#2633 C2 must-fix #6, the two-query race).
       void queryClient.invalidateQueries({ queryKey: gameNightLiveKeys.detail(gameNightId) });
+      void queryClient.invalidateQueries({ queryKey: nightLiveDiaryKeys.detail(gameNightId) });
     },
     retry: false,
   });

--- a/apps/web/src/lib/game-nights/mapDiary.ts
+++ b/apps/web/src/lib/game-nights/mapDiary.ts
@@ -1,0 +1,140 @@
+/**
+ * mapDiary — #2633 Slice C2.
+ *
+ * PURE projection from the night diary read (`GET /game-nights/{id}/diary` →
+ * `GameNightDiaryDto`) onto the `NightLiveHub`'s three diary arrays. Composed with the
+ * live view model in `NightLiveClientView` (panel D2): the live read supplies the
+ * `sessionId → gameId/title` lookup this mapper joins against.
+ *
+ * Determinism (mirrors mapNightLive's purity contract): no `Date.now()`, no
+ * `Math.random()`, no module-level mutable state. Timestamps are read as UTC (the BE
+ * serializes a bare `DateTime` with no offset — parsing it as browser-local would skew
+ * ordering, panel timezone must-fix), and the displayed label is UTC `HH:MM`.
+ */
+
+import type {
+  DiaryEvent,
+  DiaryEventKind,
+  DiaryGameRef,
+} from '@/components/features/game-nights/live';
+import type { GameNightDiaryDto } from '@/lib/api/schemas/game-nights.schemas';
+import type { NightSessionRef } from '@/lib/game-nights/mapNightLive';
+import { hashToHue } from '@/lib/games/cover-utils';
+
+export interface NightDiaryViewModel {
+  readonly diaryEvents: readonly DiaryEvent[];
+  readonly diaryGames: readonly DiaryGameRef[];
+  readonly diaryPlayers: readonly import('@/components/features/game-nights/live').DiaryPlayerRef[];
+}
+
+/**
+ * Panel D6: keyed off the WRITE-SIDE emitter vocabulary (score_updated, turn_advanced,
+ * dice_rolled, session_paused…), with the legacy display-switch aliases (score_update,
+ * dice_roll, pause_resume) mapped too. Any unlisted type falls through to `system` in
+ * {@link toKind} — never dropped (D8).
+ */
+const KIND_BY_EVENT_TYPE: Readonly<Record<string, DiaryEventKind>> = {
+  // score
+  score_updated: 'score',
+  score_update: 'score',
+  score: 'score',
+  // turn
+  turn_advanced: 'turn',
+  turn: 'turn',
+  // lifecycle milestones → end (KIND_TO_ENTITY: end → event)
+  game_started: 'end',
+  game_completed: 'end',
+  night_started: 'end',
+  night_finalized: 'end',
+  // discrete player actions → custom
+  dice_rolled: 'custom',
+  dice_roll: 'custom',
+  card_draw: 'custom',
+  card_drawn: 'custom',
+  photo: 'custom',
+  note_added: 'custom',
+  resource_update: 'custom',
+  // ambient / meta → system
+  session_paused: 'system',
+  session_resumed: 'system',
+  pause_resume: 'system',
+  player_joined: 'system',
+  dispute_resolved: 'system',
+};
+
+/** D8: unknown/new event types render as `system` rather than being silently skipped. */
+export function toKind(eventType: string): DiaryEventKind {
+  return KIND_BY_EVENT_TYPE[eventType] ?? 'system';
+}
+
+// D7: the row icon comes STRICTLY from the FE kind map — never from Description[0]
+// (multi-codepoint emoji → surrogate-pair mojibake). The server Description keeps its
+// own inline emoji in `text`; the icon is the categorical kind glyph.
+const ICON_BY_KIND: Readonly<Record<DiaryEventKind, string>> = {
+  turn: '🔄',
+  score: '📊',
+  custom: '📝',
+  end: '🏁',
+  system: '⚙️',
+};
+
+// Deterministic placeholder emoji per game (no BGG asset, no emoji field on the wire).
+const GAME_EMOJI_PALETTE = ['🎲', '🃏', '🎯', '🧩', '♟️', '🎴', '🀄', '🎰'] as const;
+function gameEmoji(gameId: string): string {
+  return GAME_EMOJI_PALETTE[hashToHue(gameId) % GAME_EMOJI_PALETTE.length];
+}
+
+const OFFSET_RE = /([zZ]|[+-]\d{2}:?\d{2})$/;
+
+/** UTC `HH:MM`. The bare BE timestamp is pinned to UTC (append `Z`) so ordering + label
+ * are stable regardless of the browser timezone. */
+export function toTimeLabel(timestamp: string): string {
+  const iso = OFFSET_RE.test(timestamp) ? timestamp : `${timestamp}Z`;
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '';
+  const hh = String(d.getUTCHours()).padStart(2, '0');
+  const mm = String(d.getUTCMinutes()).padStart(2, '0');
+  return `${hh}:${mm}`;
+}
+
+/**
+ * Projects the diary entries into the hub's arrays. `sessions` is the live read's
+ * `sessionId → {gameId, gameTitle}` lookup (D4: the join stays FE-side, zero BE change).
+ * An entry whose SessionId is not in the live sessions (night-level or not-yet-cached)
+ * maps to `gameId: null` — rendered as an ungrouped event, never a crash (D4/AC3).
+ */
+export function mapDiary(
+  dto: GameNightDiaryDto,
+  sessions: readonly NightSessionRef[]
+): NightDiaryViewModel {
+  const gameIdBySession = new Map(sessions.map(s => [s.sessionId, s.gameId]));
+  const titleByGame = new Map(sessions.map(s => [s.gameId, s.gameTitle]));
+
+  const diaryEvents: DiaryEvent[] = dto.entries.map(e => {
+    const kind = toKind(e.eventType);
+    return {
+      id: e.id,
+      time: toTimeLabel(e.timestamp),
+      gameId: gameIdBySession.get(e.sessionId) ?? null,
+      kind,
+      icon: ICON_BY_KIND[kind],
+      actors: [], // D5 minimal: no actor avatars (guest-capable roster is #2634)
+      text: e.description,
+    };
+  });
+
+  // One DiaryGameRef per distinct game that actually has events, titles from the live lookup.
+  const seen = new Set<string>();
+  const diaryGames: DiaryGameRef[] = [];
+  for (const event of diaryEvents) {
+    if (event.gameId == null || seen.has(event.gameId)) continue;
+    seen.add(event.gameId);
+    diaryGames.push({
+      id: event.gameId,
+      title: titleByGame.get(event.gameId) ?? 'Gioco',
+      emoji: gameEmoji(event.gameId),
+    });
+  }
+
+  return { diaryEvents, diaryGames, diaryPlayers: [] };
+}

--- a/apps/web/src/lib/game-nights/mapNightLive.ts
+++ b/apps/web/src/lib/game-nights/mapNightLive.ts
@@ -13,9 +13,6 @@
  */
 
 import type {
-  DiaryEvent,
-  DiaryGameRef,
-  DiaryPlayerRef,
   NightLiveHubCurrentGame,
   NightLiveHubNight,
   NightLiveStatus,
@@ -30,7 +27,22 @@ import type {
 } from '@/lib/api/schemas/game-nights.schemas';
 import { hashToHue } from '@/lib/games/cover-utils';
 
-/** The single seam type Slice B produces and Slice C extends. */
+/**
+ * The live read's `sessionId → gameId/title` lookup. Consumed by `mapDiary` (Slice C2) to
+ * group diary entries per game — the join stays FE-side (panel D4), so the diary never needs
+ * a GameId added to its own wire DTO.
+ */
+export interface NightSessionRef {
+  readonly sessionId: string;
+  readonly gameId: string;
+  readonly gameTitle: string;
+}
+
+/**
+ * The single seam type mapNightLive produces. It is LIVE-only (panel D2): the diary arrays
+ * live on a separate read path (`GET /diary`) and are composed with this VM in the view via
+ * `mapDiary`, keyed off {@link NightSessionRef}. Do NOT re-add diary fields here.
+ */
 export interface NightLiveViewModel {
   readonly night: NightLiveHubNight;
   /** Raw GameNight lifecycle status — drives terminal-night routing (LD-14). */
@@ -47,9 +59,8 @@ export interface NightLiveViewModel {
   readonly totalPlayers?: number;
   readonly plannedGames: readonly PlannedGame[];
   readonly currentGame: NightLiveHubCurrentGame | null;
-  readonly diaryEvents: readonly DiaryEvent[];
-  readonly diaryGames: readonly DiaryGameRef[];
-  readonly diaryPlayers: readonly DiaryPlayerRef[];
+  /** Slice C2: sessionId → gameId/title lookup for the diary join (not rendered directly). */
+  readonly sessions: readonly NightSessionRef[];
 }
 
 const MINUTE_MS = 60_000;
@@ -191,8 +202,11 @@ export function mapNightLiveToViewModel(dto: GameNightLiveDto, now: Date): Night
     totalPlayers: undefined,
     plannedGames,
     currentGame, // Slice C1
-    diaryEvents: [], // LD-3: Slice C2/C4
-    diaryGames: [],
-    diaryPlayers: [],
+    // Slice C2: the sessionId→game lookup the view feeds to mapDiary (diary is a separate read).
+    sessions: sessions.map(s => ({
+      sessionId: s.sessionId,
+      gameId: s.gameId,
+      gameTitle: toTitle(s),
+    })),
   };
 }

--- a/docs/for-developers/specs/2026-07-04-issue-2633-slice-c2c4-design.md
+++ b/docs/for-developers/specs/2026-07-04-issue-2633-slice-c2c4-design.md
@@ -1,0 +1,114 @@
+# Slice C2/C4 — Diary reale + Winner resolution sul night-live hub (#2633)
+
+**Data**: 2026-07-04 · **Issue**: #2633 (SI-2, umbrella #2619) · **Predecessori**: Slice B (PR #2656), C1 (PR #2657), WS1 (PR #2665)
+**Stato**: DRAFT per `/sc:spec-panel` · **Seam**: `NightLiveViewModel` (`apps/web/src/lib/game-nights/mapNightLive.ts`)
+
+## 1. Contesto e discovery
+
+Slice B ha reso `NightLiveClientView` data-driven dal read model `GET /game-nights/{id}/live`; C1 ha riempito `currentGame`. Restano **stub a `[]`** (mapper righe 194-196) i tre campi diary del seam — `diaryEvents`, `diaryGames`, `diaryPlayers` — e **mai popolato** il `winner` risolto su `PlannedGame` (solo il `winnerId` grezzo passa, LD-2). WS1 ha riabilitato l'avvio live delle partite, quindi ora **esistono dati reali** (almeno `game_started`/`night_started`) da renderizzare.
+
+### Fatti accertati (discovery workflow, 3 reader)
+
+**BE — due read path SEPARATI:**
+- `GET /game-nights/{id}/live` → `GameNightLiveDto` (header + `GameNightSessionDto[]` + `isViewerOrganizer` + `plannedLineup`). **Nessun diary.** Winner = solo `Guid? WinnerId` per sessione. **Guardia participant** (organizer OR RSVP).
+- `GET /game-nights/{id}/diary` → `GameNightDiaryDto(GameNightId, List<GameNightDiaryEntryDto>)`, dove `GameNightDiaryEntryDto(Id, SessionId, EventType, Description, Payload?, ActorId?, Timestamp)`. Legge cross-BC `SessionEvent WHERE GameNightId==id` ORDER BY Timestamp ASC. `Description` = label italiane emoji generate server-side. `ActorId` = `SessionEvent.CreatedBy` (UserId, non risolto).
+
+**6 gap per C2/C4:**
+1. **[SECURITY] Diary senza guardia** — `GetGameNightDiaryQuery(Guid GameNightId)` NON ha `CallerUserId` né participant-check; l'endpoint fa solo `RequireAuthenticatedUser` → **qualsiasi utente autenticato legge il diary di qualsiasi serata**. Il live query invece è participant-guarded. Esporre il diary nell'hub participant-scoped senza parità è una regressione di sicurezza.
+2. **Diary non nel live DTO** — per un diary reale il FE deve consumare l'endpoint separato (secondo query/hook); nulla li fonde oggi.
+3. **Grouping per-gioco** — le entry diary hanno `SessionId`, non `GameId`. Il `DiaryEvent.gameId` FE deve essere un **game id** (chiave contro `DiaryGameRef.id`). Il live DTO `sessions[]` ha già `sessionId→gameId→gameTitle` → **join FE possibile senza modifica BE**.
+4. **Winner display** — solo `winnerId:GUID`; nessun display name. `WinnerId` è **ambiguo**: doc dice UserId, ma `SessionTests` lo setta con `Participant.Id` (guest-capable). Risolvere via RSVP (User-only) **perde i guest** (LD-2).
+5. **Actor display** — `ActorId`=UserId non risolto; le avatar-per-attore nel diary richiedono un roster {id→name,initials,color}. Il live DTO non ha roster.
+6. **Type mismatch** — live timing `DateTimeOffset?` vs diary `Timestamp DateTime` → normalizzare FE.
+
+**FE — contratti già definiti, non alimentati:**
+- Tipi diary (in `CrossGameDiaryTimeline.tsx`, ri-esportati dal barrel): `DiaryEvent{id,time:string,gameId:string|null,kind,icon:string,actors:string[],text}`; `DiaryEventKind='turn'|'score'|'custom'|'end'|'system'`; `DiaryGameRef{id,title,emoji}`; `DiaryPlayerRef{id,initials,color:number}` (color=HSL hue); `DiaryFilter='all'|'turn'|'score'|'custom'` (4 valori, `end`/`system` non filtrabili). `KIND_TO_ENTITY`: turn→session, score→player, custom→chat, end→event, system→toolkit.
+- `PlannedGame` porta **sia** `winnerId?:string` **sia** `winner?:PlannedGameWinner{name,initials,color:number}` + `score?:string`. Chip winner rende su `isCompleted && game.winner` (oggi dead code).
+- Util FE disponibili: `userHue(userId):number` + `userHsl(userId):string` (match esatto `color:number`+`hsl(h,60%,55%)`); `hashToHue`+`extractInitials` (ma `extractInitials` è tarato su titoli di gioco, **sbagliato per nomi persona** — nessun util initials-persona esiste).
+- Mapper è **puro** (clock iniettato `now:Date`, no `Date.now()`/random/module-state). Nessuno schema Zod per il diary.
+
+### Insight architetturale chiave
+**C4 (winner display) è accoppiato a SI-3 #2634 (close strip che PRODUCE il winner).** Nessuna partita ha un winner finché il flusso di chiusura non esiste in UI. Renderizzare un winner oggi = dead code garantito. Inoltre #2634 definirà cosa `WinnerId` È (UserId vs Participant.Id), risolvendo il gap #4. → **sequencing naturale: C2 (diary) ora, C4 (winner) dentro/dopo #2634.**
+
+## 2. Decisioni proposte (per il panel)
+
+| # | Decisione | Opzione raccomandata | Alternative |
+|---|-----------|---------------------|-------------|
+| **D1 Scope** | C2 e C4 insieme? | **C2 (diary) ora; C4 (winner) rinviato a #2634** — winner è dead code senza il close flow, e #2634 disambigua `WinnerId`. | C2+C4 insieme (winner renderizza vuoto fino a #2634) |
+| **D2 Diary source** | come alimentare il diary | **2° hook `useGameNightDiary` + mapper puro dedicato `mapDiary(diaryDto, liveSessions, now)`**; il view compone i due (live + diary). Il seam `NightLiveViewModel` NON cambia signature: i 3 campi diary si spostano su un secondo viewmodel `NightDiaryViewModel` iniettato nell'hub. | BE fonde il diary nel live DTO (1 query) — più lavoro BE, rompe la separazione dei due read path esistenti |
+| **D3 [SECURITY] guardia diary** | fix in-slice? | **In-slice**: aggiungere `CallerUserId` a `GetGameNightDiaryQuery` + participant-check identico al live handler (403 non-participant). Prerequisito hard per esporre il diary. | Issue di sicurezza separata prima di C2 |
+| **D4 Grouping** | SessionId→GameId | **Join FE-side**: `mapDiary` risolve `entry.SessionId → liveSessions.find().gameId` (il live DTO ha già la mappa). Zero modifica BE. | BE aggiunge `GameId`/`GameTitle` a `GameNightDiaryEntryDto` |
+| **D5 Profondità diary C2** | actor avatars? | **Minimale**: timeline con `Description` server-side + grouping per-gioco + `DiaryGameRef` (emoji deterministica da gameId via `hashToHue`/placeholder). `DiaryEvent.actors=[]` + `diaryPlayers=[]` (nessuna avatar-per-attore) → **nessun roster BE**. | Full: risolvere `ActorId→{name,initials,color}` (richiede roster BE + endpoint partecipanti incl. guest) |
+| **D6 Kind mapping** | EventType BE → DiaryEventKind | Mappa esplicita: `score_update/score→score`; `game_started/game_completed/night_started/night_finalized→end`; `note_added/photo/card_draw/dice_roll/pause_resume→custom`; `player_joined/dispute_resolved/resource_update→system`; default→`system`. `turn` non ha sorgente BE oggi. | — |
+| **D7 icon/text** | icona ed etichetta | `text` = `Description` (già italiano emoji); `icon` = derivata dal kind (o estratta dal primo char emoji di `Description`). | — |
+| **D8 Corrupted-safe** | entry malformata | Come Slice B (LD-4): schema Zod diary con enum esaustivo + una entry non-parsabile non fa fallire `.parse()` dell'array (skip con log, non throw). | — |
+
+## 3. Scope raccomandato per C2 (questa slice)
+
+**IN**: (a) fix sicurezza guardia diary [D3]; (b) `useGameNightDiary` hook + `GameNightDiaryDtoSchema` Zod; (c) `mapDiary` puro (join per-gioco [D4], kind mapping [D6], corrupted-safe [D8]) → `DiaryEvent[]` + `DiaryGameRef[]`; (d) wire nel view (secondo viewmodel) → `CrossGameDiaryTimeline` off-`[]`. **OUT** (→ #2634/dopo): winner resolution [D1], actor avatars/roster [D5-full], `turn` events, `score` sui planned rows.
+
+## 4. Acceptance criteria (C2)
+
+- **AC1** Non-participant → `GET /diary` risponde 403 (parità col live). Test integration.
+- **AC2** Participant → il diary hub mostra le entry reali della serata in ordine cronologico, raggruppate per gioco (gameId risolto dal live sessions).
+- **AC3** Entry con `SessionId` non presente in `liveSessions` → `gameId=null` (evento night-level), renderizzata senza crash.
+- **AC4** Array diary con 1 entry malformata → le altre renderizzano (no throw), la malformata skippata.
+- **AC5** `mapDiary` è puro/deterministico (table-test con `now` iniettato).
+- **AC6** Serata senza eventi → empty-state diary definito (no crash, no spinner infinito).
+- **AC7** Nessuna regressione su Slice B/C1 (live header/planned/currentGame invariati).
+
+## 5. Test plan
+
+- **FE unit** (Vitest): `mapDiary` table-tests (grouping, kind mapping, corrupted-skip, night-level null gameId, empty); `useGameNightDiary` (success/401→UnauthorizedError/403); schema parse (valido/malformato).
+- **BE** (unit + integration Testcontainers): `GetGameNightDiaryQueryHandler` con `CallerUserId` — participant OK / non-participant 403 / organizer OK; parità guardia col live.
+- **Regressione**: suite game-nights FE + il cluster BE GameNight.
+
+## 6. Rischi / questioni aperte per l'utente
+
+- **Q-SCOPE** [D1]: C2-only (diary) ora e C4 con #2634, oppure C2+C4 insieme?
+- **Q-DEPTH** [D5]: diary minimale (text+grouping, no avatar-attore, zero BE roster) oppure full (actor avatars → richiede roster BE + endpoint partecipanti guest-capable)?
+- **Q-SEC** [D3]: fix guardia diary in-slice (raccomandato) o come issue prerequisito separata?
+
+---
+
+## 7. Spec-Panel Verdict (4 esperti: Fowler / Nygard / Wiegers / Crispin)
+
+> Il panel è unanime che il *framing* è corretto (C2 ora, mapper puro, corrupted-safe, Zod-at-the-wire) ma che il draft poggia su una **lettura incompleta del BE** che spedirebbe un'implementazione 500-ante o insicura. **3/4 reviewer hanno indipendentemente trovato lo stesso blocker #1 che il draft non aveva visto.**
+
+### 🔴 Blocker #1 — Route collision (500 latente in prod, VERIFICATO in codice)
+`GET /api/v1/game-nights/{id}/diary` è registrato **due volte** su `v1Api`: `GameNightEndpoints.cs:244` (GameManagement, envelope + `Description` italiana, **unguarded**) **e** `SessionFlowEndpoints.cs:246` (SessionTracking, `SessionEventDto[]` raw, **organizer-guarded**). I nomi param (`id`/`gameNightId`) sono irrilevanti per il matching ASP.NET → **`AmbiguousMatchException` a ogni GET**. Il diary GameNight **non ha mai funzionato**. Va risolto a UN endpoint canonico **prima** di qualsiasi guardia/FE, con un route-uniqueness startup test.
+
+### 🔴 Blocker #2 — Hook `useGameNightDiary` già in prod
+`apps/web/src/lib/domain-hooks/useGameNightDiary.ts` esiste (Zustand+SSE, `gameNightSessionClient.getDiary` → la rotta collisa, `JSON.parse(e.payload)` non protetto riga 39 → una entry malformata fa sparire l'INTERO diary). Va riconciliato/ritirato — **non** un secondo hook con lo stesso nome.
+
+### Decisioni lockate (aggiorna §2)
+| # | Verdetto | Forma lockata |
+|---|----------|---------------|
+| D1 | ✅ AGREE | C2 ora, C4 con #2634. **+** landare ORA un test pending/xfail che fissa la semantica di `WinnerId` (UserId vs `Participant.Id`) così #2634 non stranda i guest. |
+| D2 | ❌ OVERTURNED | I 3 campi diary sono GIÀ su `NightLiveViewModel` (righe 50-52): impossibile "non cambiare signature" **e** spostarli. **Locked: RIMUOVERE `diaryEvents/diaryGames/diaryPlayers` da `NightLiveViewModel`**, `mapNightLive` resta live-only, **comporre live+diary in `NightLiveClientView`** (composition root) sulle prop 3-array esistenti dell'hub. Riconciliare l'hook già shipped. |
+| D3 | ⚠️ REFINED | Non "aggiungi guardia": esiste già un twin organizer-only su rotta collisa. **Locked**: (1) risolvi la collisione a UN endpoint canonico; (2) applica UNA guardia participant-parity (organizer OR RSVP, come il live) con parità 404-missing/403-non-participant. |
+| D4 | ✅ AGREE+refine | Join FE-side. **+** gate del grouping su live-sessions risolte (o accetta+documenta null transitorio); `Guid.Empty`/night-level/session-non-in-live → `gameId=null`; **invalidare la query diary insieme alla live** su session-start. |
+| D5 | ✅ AGREE | Minimale, no roster. **Fix**: `DiaryGameRef.emoji` è string ma `hashToHue`→number: serve palette emoji deterministica/placeholder. Roster guest-capable risolto UNA volta in #2634 (sblocca D5-full + C4 insieme). |
+| D6 | ❌ OVERTURNED (BLOCKING) | Le chiavi sono indovinate dallo switch `GenerateDescription` (display-side), non dagli **emitter** (write-side): reali `score_updated`/`turn_advanced`/`dice_rolled`/`session_paused` vs draft `score_update`/`dice_roll`/`pause_resume`; `game_started`/`night_started` **mai emessi**. **Locked**: enumerare la mappa dagli **emitter**; `turn_advanced→turn`; default→system nel mapper; AC che asserisce ogni tipo reale mappa al kind giusto (non default). |
+| D7 | ❌ OVERTURNED | icona SOLO dalla mappa kind FE (mai `Description[0]` → surrogate pair → mojibake). Regola double-emoji esplicita. Se vince il `SessionEventDto` (senza `Description`), il FE deve generare label+i18n → budget reale. |
+| D8 | ⚠️ REFINED | Per-row `safeParse` skip-with-log (mai `.parse()` array-level). **Overturn enum esaustivo su `eventType`**: resta `z.string()` aperto al wire; enum chiuso solo sul `DiaryEventKind` derivato FE (default→system). AC: evento con `eventType` non mappato **renderizza** (kind=system), non droppato. |
+
+### Nuovi must-fix (oltre i 2 blocker): 
+guard-scope divergence (organizer-only→participant non deve regredire consumer recap); race a due query (gate su live-resolved); **pagination truncation** (`ORDER BY Timestamp ASC` + `Take(200)` → una serata lunga perde gli eventi PIÙ RECENTI — decidere cap **e direzione DESC** in-slice); timezone skew (diary `DateTime` Kind Unspecified vs live `DateTimeOffset` → assume-UTC/append `Z`, table-test non-UTC); AC1 deve guidare la rotta HTTP reale (non handler-level).
+
+### Q aperte — raccomandazioni panel
+- **Q-SCOPE** → **C2-only ora** (unanime). + decidere cap/direzione in-slice.
+- **Q-DEPTH** → **Minimale** (full bloccato sul roster guest = lavoro di #2634).
+- **Q-SEC** → **In-slice, non-negoziabile, primo commit — riformulato come bug-fix**: risolvi la collisione + allarga la guardia, testato via pipeline HTTP reale.
+
+### Disaccordo esperti
+- **D3/Q-SEC**: Fowler la vedeva come semplice "aggiungi guardia"; Nygard/Wiegers/Crispin (maggioranza) la riformulano come **bug-fix prerequisito** (collisione+guardia), più grande. Risoluzione: maggioranza.
+- **D6 vocabolario**: conflitto factuale display-switch vs emitter → **write-side/emitter è autoritativo**.
+
+**Ship order**: (1) fix route collision + guardia participant, (2) riconcilia hook/DTO source-of-truth, (3) mapper puro sul vocabolario reale, (4) componi in `NightLiveClientView`.
+
+## 8. Decisioni utente (2026-07-04, lockate)
+- **Q-SCOPE/sequencing** → **UNA PR combinata C2** (fix infra collisione+guardia + render nello stesso diff BE+FE).
+- **Canonical diary endpoint** → **GameManagement** (`GetGameNightDiaryQuery`, envelope + `Description` italiana server-side): aggiungi guardia participant, **ritira il twin `SessionFlowEndpoints.cs:246`**. FE usa `Description` come `text` (i18n non per-locale accettato per ora; il catalogo label FE è deferred).
+- **Q-DEPTH** → **minimale** (no actor-avatar, `actors=[]`, `diaryPlayers=[]`; roster guest-capable = lavoro #2634).
+- Adottate come default tutte le decisioni lockate del §7 (D2 rimozione stub VM + compose in view; D6 kind-map dagli emitter; D8 `eventType` open al wire).


### PR DESCRIPTION
Release main-dev -> main-staging (2 commit).

- #2671 (PR #2672): fix del READ path storage-key (usa fileId dal FilePath). Abilita il re-seed RAG corretto su staging (#2670) — i PDF seedati ora troveranno i blob e diventeranno Ready.
- #2633: C2 real cross-game diary + route collision fix.

Nessun cambiamento AI service. Deploy staging automatico al merge. Dopo il deploy eseguiro' il re-seed per validare il fix end-to-end.