### PR TITLE
fix(health): #2675 seed_state usa sum(VectorDocument.ChunkCount) non row-count

### DIFF
--- a/apps/api/src/Api/Infrastructure/Health/Checks/SeedStateHealthCheck.cs
+++ b/apps/api/src/Api/Infrastructure/Health/Checks/SeedStateHealthCheck.cs
@@ -33,7 +33,10 @@ namespace Api.Infrastructure.Health.Checks;
 ///     <c>chunk_count != embedding_count</c>, OR at least one PDF is in
 ///     state <c>Failed</c>. RAG returns degraded recall. Equivalent to
 ///     <c>snapshot-verify.sh</c> exit code 6 (#2126 D7) but applied to the
-///     live DB.</description>
+///     live DB. Note (#2675): <c>embedding_count</c> is the SUM of
+///     <c>VectorDocument.ChunkCount</c> across VectorDocuments (chunks indexed),
+///     not the VectorDocuments row-count (which is per-PDF), so it is directly
+///     comparable to <c>chunk_count</c> from TextChunks.</description>
 ///   </item>
 ///   <item>
 ///     <description><c>ready</c> — every PDF is <c>Ready</c>, chunks and
@@ -90,9 +93,15 @@ public sealed class SeedStateHealthCheck : IHealthCheck
                 .CountAsync(cancellationToken)
                 .ConfigureAwait(false);
 
+            // VectorDocuments holds ONE row per PDF (an indexing-status record with a
+            // ChunkCount), not one row per chunk. Counting rows would compare per-PDF
+            // (≈ pdf_ready) against TextChunks' per-chunk count and never match for
+            // multi-chunk PDFs, pinning seed_state to partial_failed forever (#2675).
+            // Sum the per-PDF ChunkCount so both sides count chunks. Same idiom as
+            // VectorDocumentRepository.GetTotalChunkCountAsync.
             var embeddingCount = await _db.VectorDocuments
                 .AsNoTracking()
-                .CountAsync(cancellationToken)
+                .SumAsync(v => v.ChunkCount, cancellationToken)
                 .ConfigureAwait(false);
 
             string seedState = DeriveSeedState(pdfTotal, pdfReady, pdfFailed, chunkCount, embeddingCount);

--- a/apps/api/tests/Api.Tests/Infrastructure/Health/Checks/SeedStateHealthCheckDbBoundTests.cs
+++ b/apps/api/tests/Api.Tests/Infrastructure/Health/Checks/SeedStateHealthCheckDbBoundTests.cs
@@ -1,0 +1,128 @@
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Infrastructure.Entities.KnowledgeBase;
+using Api.Infrastructure.Health.Checks;
+using Api.SharedKernel.Application.Services;
+using Api.Tests.Constants;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.Infrastructure.Health.Checks;
+
+/// <summary>
+/// DB-bound tests for <see cref="SeedStateHealthCheck.CheckHealthAsync"/>, the
+/// path that aggregates the raw counts. The pure state-machine lives in
+/// <see cref="SeedStateHealthCheckTests"/>; this class locks down the count
+/// SEMANTICS the caller feeds into it — specifically the #2675 regression where
+/// <c>embedding_count</c> was the VectorDocuments row-count (per-PDF) instead of
+/// the SUM of ChunkCount (per-chunk), pinning any multi-chunk corpus to
+/// <c>partial_failed</c> even on a fully-successful bake.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("Issue", "2675")]
+public sealed class SeedStateHealthCheckDbBoundTests
+{
+    private static MeepleAiDbContext CreateInMemoryDb(string testName)
+    {
+        var options = new DbContextOptionsBuilder<MeepleAiDbContext>()
+            .UseInMemoryDatabase($"SeedStateHealthCheck_{testName}_{Guid.NewGuid()}")
+            .Options;
+        return new MeepleAiDbContext(
+            options,
+            Mock.Of<IMediator>(),
+            Mock.Of<IDomainEventCollector>());
+    }
+
+    private static PdfDocumentEntity ReadyPdf(Guid id) => new()
+    {
+        Id = id,
+        FileName = "rules.pdf",
+        FilePath = $"test/{id:N}.pdf",
+        UploadedByUserId = Guid.NewGuid(),
+        UploadedAt = DateTime.UtcNow,
+        ProcessingState = "Ready",
+        Language = "en",
+    };
+
+    private static VectorDocumentEntity IndexedDoc(Guid pdfId, int chunkCount) => new()
+    {
+        Id = Guid.NewGuid(),
+        GameId = Guid.NewGuid(),
+        PdfDocumentId = pdfId,
+        IndexingStatus = "completed",
+        EmbeddingModel = "test-model",
+        EmbeddingDimensions = 768,
+        ChunkCount = chunkCount,
+        IndexedAt = DateTime.UtcNow,
+    };
+
+    private static TextChunkEntity Chunk(Guid pdfId, int index) => new()
+    {
+        Id = Guid.NewGuid(),
+        GameId = Guid.NewGuid(),
+        PdfDocumentId = pdfId,
+        Content = $"chunk {index}",
+        ChunkIndex = index,
+        CharacterCount = 8,
+        CreatedAt = DateTime.UtcNow,
+    };
+
+    private static async Task<HealthCheckResult> RunAsync(MeepleAiDbContext db)
+    {
+        var check = new SeedStateHealthCheck(db, Mock.Of<ILogger<SeedStateHealthCheck>>());
+        return await check.CheckHealthAsync(new HealthCheckContext(), CancellationToken.None);
+    }
+
+    [Fact]
+    public async Task CheckHealthAsync_MultiChunkPdfsAllReady_ReturnsReady()
+    {
+        // #2675 regression: two Ready PDFs with 3 and 2 chunks respectively.
+        // VectorDocuments row-count = 2 (per-PDF), but TextChunks = 5 (per-chunk).
+        // Pre-fix embedding_count=2 != chunk_count=5 → false partial_failed.
+        // Post-fix embedding_count = sum(ChunkCount) = 3+2 = 5 == 5 → ready.
+        await using var db = CreateInMemoryDb(nameof(CheckHealthAsync_MultiChunkPdfsAllReady_ReturnsReady));
+
+        var pdf1 = Guid.NewGuid();
+        var pdf2 = Guid.NewGuid();
+        db.PdfDocuments.AddRange(ReadyPdf(pdf1), ReadyPdf(pdf2));
+        db.VectorDocuments.AddRange(IndexedDoc(pdf1, chunkCount: 3), IndexedDoc(pdf2, chunkCount: 2));
+        db.TextChunks.AddRange(
+            Chunk(pdf1, 0), Chunk(pdf1, 1), Chunk(pdf1, 2),
+            Chunk(pdf2, 0), Chunk(pdf2, 1));
+        await db.SaveChangesAsync();
+
+        var result = await RunAsync(db);
+
+        result.Status.Should().Be(HealthStatus.Healthy);
+        result.Data["seed_state"].Should().Be(SeedStateHealthCheck.SeedStates.Ready);
+        result.Data["chunk_count"].Should().Be(5);
+        result.Data["embedding_count"].Should().Be(5,
+            because: "embedding_count must SUM VectorDocument.ChunkCount, not count rows (#2675)");
+    }
+
+    [Fact]
+    public async Task CheckHealthAsync_EmbeddingServiceIndexedFewerChunksThanExtracted_ReturnsPartialFailed()
+    {
+        // The fix must NOT mask a genuine mismatch. Extraction produced 3 chunks
+        // but the embedder only recorded 2 → sum(ChunkCount)=2 != chunk_count=3.
+        await using var db = CreateInMemoryDb(nameof(CheckHealthAsync_EmbeddingServiceIndexedFewerChunksThanExtracted_ReturnsPartialFailed));
+
+        var pdf = Guid.NewGuid();
+        db.PdfDocuments.Add(ReadyPdf(pdf));
+        db.VectorDocuments.Add(IndexedDoc(pdf, chunkCount: 2));
+        db.TextChunks.AddRange(Chunk(pdf, 0), Chunk(pdf, 1), Chunk(pdf, 2));
+        await db.SaveChangesAsync();
+
+        var result = await RunAsync(db);
+
+        result.Status.Should().Be(HealthStatus.Degraded);
+        result.Data["seed_state"].Should().Be(SeedStateHealthCheck.SeedStates.PartialFailed);
+        result.Data["chunk_count"].Should().Be(3);
+        result.Data["embedding_count"].Should().Be(2);
+    }
+}


### PR DESCRIPTION
Closes #2675.

## Problema
`SeedStateHealthCheck` contava le **righe** di `VectorDocuments` (1 per PDF) come `embedding_count` e le confrontava con `TextChunks` (per-chunk). Per qualsiasi corpus multi-chunk i due non coincidono mai → `seed_state` bloccato su `partial_failed` anche a bake perfettamente riuscito (staging: `chunks=1825 embeddings=31`).

## Fix
Somma `VectorDocument.ChunkCount` invece di contare le righe — stesso idioma già in `VectorDocumentRepository.GetTotalChunkCountAsync`. Ora `sum(ChunkCount)=1825 == text_chunks=1825` → match. `partial_failed` scatta solo per il motivo legittimo (`failed_pdfs > 0`).

`DeriveSeedState` (pure function) invariata: cambia solo *cosa* il caller le passa.

## Test
- 2 nuovi test DB-bound (InMemory): multi-chunk all-Ready → `ready`; mismatch reale extraction/embedding → `partial_failed` (il fix **non** maschera i mismatch veri).
- 10 test pure-function esistenti invariati. **12/12 verdi** in locale.

## Contesto
Scoperto validando end-to-end il fix storage-key #2671 (re-bake RAG staging #2670). Il vero vector store `pgvector_embeddings` (1891 vettori) è popolato: il RAG funziona, era solo il *check* a mentire.