### PR TITLE
SI-4 (#2635): startedAt chip derivato + resume wiring

### DIFF
--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/AttachGamebookCampaignToGameNightCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/AttachGamebookCampaignToGameNightCommandHandler.cs
@@ -135,7 +135,8 @@ internal sealed class AttachGamebookCampaignToGameNightCommandHandler
         }
         catch (InvalidOperationException ex)
         {
-            // AddSession's "not Published" guard throws a plain InvalidOperationException → wrap as 409.
+            // AddSession's status guard (rejects a Draft/Cancelled/Completed night — SI-4 #2635
+            // allows Published|InProgress) throws a plain InvalidOperationException → wrap as 409.
             if (!commitStarted)
                 await _unitOfWork.RollbackTransactionAsync(cancellationToken).ConfigureAwait(false);
             throw new ConflictException(ex.Message);

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/GameNightEvent/GameNightEvent.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/GameNightEvent/GameNightEvent.cs
@@ -406,13 +406,28 @@ internal sealed class GameNightEvent : AggregateRoot<Guid>
 
     /// <summary>
     /// Adds a game session to this game night. Max 5 sessions per event.
+    ///
+    /// <para>Allowed on <see cref="GameNightStatus.Published"/> (first sitting) and
+    /// <see cref="GameNightStatus.InProgress"/> (SI-4 #2635: 2nd+ sitting resume — the night flips
+    /// to InProgress via #15 after the first session starts). The max-1-live guard (#10) lives in
+    /// <see cref="EnsureCanStartSession"/>/<see cref="StartCurrentSession"/>, so accepting an
+    /// InProgress night here never mints a 2nd concurrent live session.</para>
+    ///
+    /// <para>A <see cref="GameNightStatus.Completed"/> night is terminal: resume-from-Completed is
+    /// rejected here (mapped to 409 at the command boundary) with guidance to start a new session —
+    /// SI-4 spec-panel: never resurrect a terminal state. Draft/Cancelled/Corrupted are likewise rejected.</para>
     /// </summary>
     public GameNightSession AddSession(Guid sessionId, Guid gameId, string gameTitle)
     {
         ThrowIfCorrupted();
 
-        if (Status != GameNightStatus.Published)
-            throw new InvalidOperationException($"Cannot add sessions to a {Status} game night.");
+        if (Status != GameNightStatus.Published && Status != GameNightStatus.InProgress)
+        {
+            var message = Status == GameNightStatus.Completed
+                ? "Cannot add sessions to a finalized game night — start a new session."
+                : $"Cannot add sessions to a {Status} game night.";
+            throw new InvalidOperationException(message);
+        }
         if (_sessions.Count >= 5)
             throw new InvalidOperationException("A game night can have at most 5 sessions.");
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/GameNight/AttachGamebookCampaignToGameNightCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/GameNight/AttachGamebookCampaignToGameNightCommandHandlerTests.cs
@@ -192,6 +192,40 @@ public class AttachGamebookCampaignToGameNightCommandHandlerTests
     }
 
     [Fact]
+    public async Task Handle_SecondSittingOnInProgressNight_AttachesAndStarts()
+    {
+        // SI-4 (#2635): resuming a gamebook campaign for a 2nd sitting on an InProgress night — the
+        // path the "▶ Riprendi" wire (step 3) drives. Before the AddSession relax this 409'd
+        // (Published-only guard). EnsureCanStartSession passes (no live session) and the night stays
+        // InProgress after attaching + starting the new sitting.
+        var organizer = Guid.NewGuid();
+        var gameNight = CreatePublishedEvent(organizer);
+        var firstSessionId = Guid.NewGuid();
+        gameNight.AddSession(firstSessionId, gameNight.GameIds[0], "Prima partita");
+        gameNight.StartCurrentSession();
+        gameNight.HandleFirstSessionStarted(firstSessionId); // Published → InProgress
+        gameNight.CompleteCurrentSession(winnerId: null);     // no live session
+        gameNight.Status.Should().Be(GameNightStatus.InProgress);
+
+        var campaignId = Guid.NewGuid();
+        var secondSessionId = Guid.NewGuid();
+        SetupCampaign(campaignId, CampaignDto(campaignId, Guid.NewGuid(), organizer, GameRefKind.Shared));
+        SetupCreateSession(secondSessionId, "SND222");
+        SetupUser(organizer, "Marco Rossi");
+        _repo.Setup(r => r.GetByIdAsync(gameNight.Id, It.IsAny<CancellationToken>())).ReturnsAsync(gameNight);
+
+        var result = await _handler.Handle(
+            new AttachGamebookCampaignToGameNightCommand(gameNight.Id, campaignId, organizer),
+            TestContext.Current.CancellationToken);
+
+        result.SessionId.Should().Be(secondSessionId);
+        result.PlayOrder.Should().Be(2);
+        gameNight.Sessions.Should().HaveCount(2);
+        gameNight.Sessions[1].Status.Should().Be(GameNightSessionStatus.InProgress);
+        gameNight.Status.Should().Be(GameNightStatus.InProgress);
+    }
+
+    [Fact]
     public async Task Handle_PrivateGameCampaign_ThrowsConflict_AndDoesNotCreateSession()
     {
         var organizer = Guid.NewGuid();

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/GameNight/AttachGamebookCampaignToGameNightCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/GameNight/AttachGamebookCampaignToGameNightCommandHandlerTests.cs
@@ -226,6 +226,31 @@ public class AttachGamebookCampaignToGameNightCommandHandlerTests
     }
 
     [Fact]
+    public async Task Handle_SecondSittingWhileFirstStillLive_Throws409MaxLive_NoSessionCreated()
+    {
+        // AC5: max-1-live holds on the gamebook resume path (the one the play-page CTA drives).
+        // Attaching a 2nd campaign while the first sitting is still live is rejected by
+        // EnsureCanStartSession (guard-before-create) — no cross-BC Session is minted.
+        var organizer = Guid.NewGuid();
+        var gameNight = CreatePublishedEvent(organizer);
+        var firstSessionId = Guid.NewGuid();
+        gameNight.AddSession(firstSessionId, gameNight.GameIds[0], "Prima partita");
+        gameNight.StartCurrentSession();                     // first sitting InProgress
+        gameNight.HandleFirstSessionStarted(firstSessionId); // night InProgress
+
+        var campaignId = Guid.NewGuid();
+        SetupCampaign(campaignId, CampaignDto(campaignId, Guid.NewGuid(), organizer, GameRefKind.Shared));
+        _repo.Setup(r => r.GetByIdAsync(gameNight.Id, It.IsAny<CancellationToken>())).ReturnsAsync(gameNight);
+
+        var act = () => _handler.Handle(
+            new AttachGamebookCampaignToGameNightCommand(gameNight.Id, campaignId, organizer),
+            TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<MaxLiveSessionsExceededException>();
+        _mediator.Verify(m => m.Send(It.IsAny<CreateSessionCommand>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
     public async Task Handle_PrivateGameCampaign_ThrowsConflict_AndDoesNotCreateSession()
     {
         var organizer = Guid.NewGuid();

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/GameNight/StartGameNightSessionCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/GameNight/StartGameNightSessionCommandHandlerTests.cs
@@ -433,4 +433,64 @@ public class StartGameNightSessionCommandHandlerTests
         var gns = gameNight.Sessions[0];
         Assert.Equal(GameNightSessionStatus.InProgress, gns.Status);
     }
+
+    [Fact]
+    public async Task Handle_SecondSittingOnInProgressNight_Succeeds()
+    {
+        // SI-4 (#2635): a night already InProgress (first game played & completed) resuming for a 2nd
+        // game. Before the AddSession relax this failed with 409 (Published-only guard) — the WS1
+        // latent multi-game bug. EnsureCanStartSession passes (no live session), AddSession now
+        // accepts an InProgress night, and the aggregate stays InProgress.
+        var gameNight = CreatePublishedEvent();
+        var firstSessionId = Guid.NewGuid();
+        gameNight.AddSession(firstSessionId, gameNight.GameIds[0], "Catan");
+        gameNight.StartCurrentSession();
+        gameNight.HandleFirstSessionStarted(firstSessionId); // Published → InProgress (async #15 in prod)
+        gameNight.CompleteCurrentSession(winnerId: null);     // first game done → no live session
+        Assert.Equal(GameNightStatus.InProgress, gameNight.Status);
+
+        var secondSessionId = Guid.NewGuid();
+        _mockRepository.Setup(r => r.GetByIdAsync(gameNight.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(gameNight);
+        _mockMediator.Setup(m => m.Send(It.IsAny<GetUserByIdQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateOrganizerDto(gameNight.OrganizerId));
+        _mockMediator.Setup(m => m.Send(It.IsAny<CreateSessionCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new CreateSessionResult(
+                secondSessionId, "SND222", [], GameNightEventId: gameNight.Id,
+                GameNightWasCreated: false, AgentDefinitionId: null, ToolkitId: null));
+
+        var command = new StartGameNightSessionCommand(
+            gameNight.Id, gameNight.GameIds[1], "Dixit", gameNight.OrganizerId);
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.Equal(secondSessionId, result.SessionId);
+        Assert.Equal(2, result.PlayOrder);
+        Assert.Equal(2, gameNight.Sessions.Count);
+        Assert.Equal(GameNightStatus.InProgress, gameNight.Status);
+    }
+
+    [Fact]
+    public async Task Handle_SecondStartWhileFirstStillLive_Throws409MaxLive_NoSessionCreated()
+    {
+        // AC5: max-1-live holds on resume. A 2nd start while the first session is still InProgress is
+        // rejected by EnsureCanStartSession (guard-before-create) — no cross-BC Session is minted.
+        var gameNight = CreatePublishedEvent();
+        var firstSessionId = Guid.NewGuid();
+        gameNight.AddSession(firstSessionId, gameNight.GameIds[0], "Catan");
+        gameNight.StartCurrentSession();                     // first session InProgress
+        gameNight.HandleFirstSessionStarted(firstSessionId); // night InProgress
+
+        _mockRepository.Setup(r => r.GetByIdAsync(gameNight.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(gameNight);
+
+        var command = new StartGameNightSessionCommand(
+            gameNight.Id, gameNight.GameIds[1], "Dixit", gameNight.OrganizerId);
+
+        await Assert.ThrowsAsync<MaxLiveSessionsExceededException>(
+            () => _handler.Handle(command, CancellationToken.None));
+
+        _mockMediator.Verify(m => m.Send(It.IsAny<CreateSessionCommand>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/Entities/GameNightEventSessionsTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/Entities/GameNightEventSessionsTests.cs
@@ -51,6 +51,57 @@ public class GameNightEventSessionsTests
             evt.AddSession(Guid.NewGuid(), Guid.NewGuid(), "Catan"));
     }
 
+    // SI-4 (#2635): resuming a night for a 2nd+ sitting. After the first game starts, the night is
+    // InProgress (#15). Adding a session for the next game must be allowed — this is the WS1 latent
+    // multi-game bug the resume slice fixes (AddSession was Published-only). The max-1-live guard (#10)
+    // lives in EnsureCanStartSession/StartCurrentSession, so relaxing AddSession creates no 2nd live.
+    [Fact]
+    public void AddSession_ToInProgressEvent_Succeeds()
+    {
+        var evt = CreatePublishedEvent();
+        var firstSessionId = Guid.NewGuid();
+        evt.AddSession(firstSessionId, evt.GameIds[0], "Catan");
+        evt.StartCurrentSession();
+        evt.HandleFirstSessionStarted(firstSessionId); // Published → InProgress
+        evt.CompleteCurrentSession(winnerId: null);     // first game done → no live session
+        Assert.Equal(GameNightStatus.InProgress, evt.Status);
+
+        var session = evt.AddSession(Guid.NewGuid(), evt.GameIds[1], "Dixit");
+
+        Assert.Equal(2, evt.Sessions.Count);
+        Assert.Equal(2, session.PlayOrder);
+        Assert.Equal(GameNightStatus.InProgress, evt.Status);
+    }
+
+    // SI-4: resume-from-Completed is OUT — a finalized night is terminal. Reject at the command
+    // boundary with guidance to start a new session, never resurrect a terminal state (spec-panel).
+    [Fact]
+    public void AddSession_ToCompletedEvent_ThrowsWithResumeGuidance()
+    {
+        var evt = CreatePublishedEvent();
+        var firstSessionId = Guid.NewGuid();
+        evt.AddSession(firstSessionId, evt.GameIds[0], "Catan");
+        evt.StartCurrentSession();
+        evt.HandleFirstSessionStarted(firstSessionId); // Published → InProgress
+        evt.CompleteCurrentSession(winnerId: null);
+        evt.CompleteAdHoc();                            // InProgress → Completed (production door)
+        Assert.Equal(GameNightStatus.Completed, evt.Status);
+
+        var ex = Assert.Throws<InvalidOperationException>(() =>
+            evt.AddSession(Guid.NewGuid(), evt.GameIds[1], "Dixit"));
+        Assert.Contains("finalized", ex.Message, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("new session", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void AddSession_ToCancelledEvent_Throws()
+    {
+        var evt = CreatePublishedEvent();
+        evt.Cancel(); // Published → Cancelled
+        Assert.Throws<InvalidOperationException>(() =>
+            evt.AddSession(Guid.NewGuid(), evt.GameIds[0], "Catan"));
+    }
+
     [Fact]
     public void StartCurrentSession_TransitionsFirstPendingToInProgress()
     {

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/Entities/GameNightEventSessionsTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/Entities/GameNightEventSessionsTests.cs
@@ -102,6 +102,29 @@ public class GameNightEventSessionsTests
             evt.AddSession(Guid.NewGuid(), evt.GameIds[0], "Catan"));
     }
 
+    // SI-4 AC3: after resuming for a 2nd sitting, the InProgress night remains finalizable — the
+    // relaxed AddSession leaves no orphaned live child that would block completion (CompleteAdHoc).
+    [Fact]
+    public void CompleteAdHoc_AfterSecondSitting_FinalizesInProgressNight()
+    {
+        var evt = CreatePublishedEvent();
+        var firstSessionId = Guid.NewGuid();
+        evt.AddSession(firstSessionId, evt.GameIds[0], "Catan");
+        evt.StartCurrentSession();
+        evt.HandleFirstSessionStarted(firstSessionId); // Published → InProgress
+        evt.CompleteCurrentSession(winnerId: null);
+
+        evt.AddSession(Guid.NewGuid(), evt.GameIds[1], "Dixit"); // 2nd sitting (relaxed path)
+        evt.StartCurrentSession();
+        evt.CompleteCurrentSession(winnerId: null);              // no live session remains
+
+        evt.CompleteAdHoc();                                     // InProgress → Completed
+
+        Assert.Equal(GameNightStatus.Completed, evt.Status);
+        Assert.Equal(2, evt.Sessions.Count);
+        Assert.All(evt.Sessions, s => Assert.Equal(GameNightSessionStatus.Completed, s.Status));
+    }
+
     [Fact]
     public void StartCurrentSession_TransitionsFirstPendingToInProgress()
     {

--- a/apps/web/src/app/(authenticated)/library/[gameId]/play/[campaignId]/_content.tsx
+++ b/apps/web/src/app/(authenticated)/library/[gameId]/play/[campaignId]/_content.tsx
@@ -6,7 +6,12 @@ import { useRouter } from 'next/navigation';
 
 import { GamebookPlayShell } from '@/components/features/gamebook';
 import { ResumeBooksList } from '@/components/features/gamebook/ResumeBooksList';
+import {
+  SerataResumeButton,
+  isSerataResumable,
+} from '@/components/features/gamebook/SerataResumeButton';
 import { SerataSpineStrip } from '@/components/features/gamebook/SerataSpineStrip';
+import { useCurrentUser } from '@/hooks/queries/useCurrentUser';
 import { GameRefKind, type GameRef } from '@/lib/api/gamebook';
 import { useCampaignProgress } from '@/lib/gamebook/hooks/useCampaignProgress';
 import {
@@ -50,6 +55,10 @@ export function Content({
   // standalone (204) — the strip is only shown for GameNight-attached play.
   const { data: spine } = useGamebookCampaignSpine(campaignId);
 
+  // SI-4 (#2635): the organizer can resume the serata as a NEW live sitting when the night is
+  // resumable (Published/InProgress, no live session). Standalone campaigns keep pure reading.
+  const { data: currentUser } = useCurrentUser();
+
   const handleResume = useCallback(
     (bookId: string) => {
       // Future: route to a per-book play surface; for now we just refresh
@@ -65,6 +74,11 @@ export function Content({
       {spine ? (
         <div className="px-3 pt-2">
           <SerataSpineStrip spine={spine} />
+          {isSerataResumable(spine, currentUser?.id) ? (
+            <div className="mt-2">
+              <SerataResumeButton gameNightId={spine.gameNightId} campaignId={campaignId} />
+            </div>
+          ) : null}
         </div>
       ) : null}
       <ResumeBooksList progress={bookProgress} onResume={handleResume} />

--- a/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx
@@ -126,6 +126,7 @@ import { useSessionAgentChat } from '@/lib/domain-hooks/useSessionAgentChat';
 import { useSignalRSession } from '@/lib/domain-hooks/useSignalrSession';
 import { getNavigationLinks } from '@/lib/navigation';
 import { composeSessionLiveState } from '@/lib/session-live/compose-session-live-state';
+import { formatSessionStartedAt } from '@/lib/session-live/format-session-started-at';
 import { mapConnectionState } from '@/lib/session-live/map-connection-state';
 import { mapTurnDataToTurnState } from '@/lib/session-live/map-turn-data-to-turn-state';
 import { mergeHydratedDiary } from '@/lib/session-live/merge-hydrated-diary';
@@ -728,6 +729,8 @@ export function SessionLiveView(): ReactElement {
       exitAriaLabel: t('pages.sessionLive.topBar.exitAriaLabel'),
       // G4 — Issue #2355 wiring
       elapsedTimeAriaLabel: t('pages.sessionLive.topBar.elapsedTimeAriaLabel'),
+      // SI-4 (#2635) — derived start-time chip
+      startedAtChipAriaLabel: t('pages.sessionLive.topBar.startedAtChipAriaLabel'),
       connectionStateAriaLabels: {
         connected: t('pages.sessionLive.topBar.connectionStateConnected'),
         reconnecting: t('pages.sessionLive.topBar.connectionStateReconnecting'),
@@ -738,6 +741,11 @@ export function SessionLiveView(): ReactElement {
 
   // G4 — Issue #2355: live elapsed time + connection pip wiring
   const elapsedMs = useElapsedTime(sessionQuery.data?.startedAt);
+  // SI-4 (#2635): read-only derived start-time chip label (Invariante 5 — never user-editable).
+  const startedAt = sessionQuery.data?.startedAt;
+  const startedAtLabel = startedAt
+    ? t('pages.sessionLive.topBar.startedAtChip', { time: formatSessionStartedAt(startedAt) })
+    : undefined;
   const connectionPipState = mapConnectionState(liveStream.connectionState);
 
   // G5b #2378 — TurnIndicatorRenderer labels + fixture state memos.
@@ -1223,7 +1231,9 @@ export function SessionLiveView(): ReactElement {
         await agentChat.ask(content);
       }
     },
-    [agentSessionId, agentChat, sessionId, activeSession?.viewerId]
+    // `intl` is stable (react-intl memoizes useIntl); listing it clears a pre-existing
+    // exhaustive-deps baseline error surfaced while touching this file for SI-4 (#2635).
+    [agentSessionId, agentChat, sessionId, activeSession?.viewerId, intl]
   );
 
   // ── Chat messages from SSE events ────────────────────────────────────────
@@ -1594,6 +1604,7 @@ export function SessionLiveView(): ReactElement {
         }
         labels={topBarLabels}
         elapsedMs={elapsedMs}
+        startedAtLabel={startedAtLabel}
         connectionState={connectionPipState}
       />
 

--- a/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx
@@ -744,7 +744,11 @@ export function SessionLiveView(): ReactElement {
   // SI-4 (#2635): read-only derived start-time chip label (Invariante 5 — never user-editable).
   const startedAt = sessionQuery.data?.startedAt;
   const startedAtLabel = startedAt
-    ? t('pages.sessionLive.topBar.startedAtChip', { time: formatSessionStartedAt(startedAt) })
+    ? t('pages.sessionLive.topBar.startedAtChip', {
+        // Format the instant in the viewer's RESOLVED locale (not the mapper's it-IT default) so an
+        // EN user does not get a mixed-language "Started at 5 lug…" chip.
+        time: formatSessionStartedAt(startedAt, { locale: intl.locale }),
+      })
     : undefined;
   const connectionPipState = mapConnectionState(liveStream.connectionState);
 

--- a/apps/web/src/components/features/gamebook/SerataResumeButton.tsx
+++ b/apps/web/src/components/features/gamebook/SerataResumeButton.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+/**
+ * SerataResumeButton — SI-4 (#2635, step 3).
+ *
+ * Rendered on the gamebook play page under the SerataSpineStrip when the campaign's owning
+ * game-night is resumable (see {@link isSerataResumable}). Opens a NEW live sitting via the Attach
+ * path and routes to the freshly-opened live session. A max-1-live 409 / a 403 surface distinct
+ * inline feedback instead of a silent no-op. Picker navigation (solo reading) is unchanged — this
+ * is the game-night resume entry, deliberately organizer + resumable-only.
+ */
+
+import { useCallback, type ReactElement } from 'react';
+
+import { useRouter } from 'next/navigation';
+
+import { ConflictError, ForbiddenError } from '@/lib/api/core/errors';
+import type { GamebookCampaignSpine } from '@/lib/api/gamebook-campaigns';
+import { isMaxLiveBlockedError } from '@/lib/game-nights/hooks/useStartNextGame';
+import { useResumeGamebookSitting } from '@/lib/gamebook/hooks/useResumeGamebookSitting';
+
+const RESUMABLE_STATUSES = new Set(['Published', 'InProgress']);
+
+/**
+ * A campaign's game-night is "resumable" (a new live sitting can be opened from the play page) when
+ * the viewer is the organizer, the night is Published/InProgress (not a terminal Completed/Cancelled
+ * or an unpublished Draft), and no sitting is currently live (an existing live one → jump, not
+ * resume). A Completed night is intentionally excluded: the BE rejects resume-from-Completed at the
+ * command boundary (409) and the product answer is "start a new session".
+ */
+export function isSerataResumable(
+  spine: GamebookCampaignSpine | null | undefined,
+  currentUserId: string | undefined
+): boolean {
+  if (!spine || !currentUserId) return false;
+  if (spine.organizerId !== currentUserId) return false;
+  if (spine.hasLiveSession) return false;
+  return RESUMABLE_STATUSES.has(spine.gameNightStatus);
+}
+
+function resumeErrorMessage(error: unknown): string {
+  if (isMaxLiveBlockedError(error)) {
+    return 'C’è già una partita live in questa serata.';
+  }
+  if (error instanceof ForbiddenError) {
+    return 'Solo l’organizzatore può riprendere la serata.';
+  }
+  if (error instanceof ConflictError) {
+    return 'Non è possibile riprendere la serata ora.';
+  }
+  return 'Impossibile riprendere la serata. Riprova.';
+}
+
+export interface SerataResumeButtonProps {
+  readonly gameNightId: string;
+  readonly campaignId: string;
+}
+
+export function SerataResumeButton({
+  gameNightId,
+  campaignId,
+}: SerataResumeButtonProps): ReactElement {
+  const router = useRouter();
+  const resume = useResumeGamebookSitting(gameNightId);
+
+  const handleClick = useCallback(() => {
+    resume.mutate(
+      { campaignId },
+      {
+        onSuccess: result => {
+          // The freshly-opened session is in-progress → /sessions/{id} forks to the live view
+          // (where the SI-4 startedAt chip renders).
+          router.push(`/sessions/${result.sessionId}`);
+        },
+      }
+    );
+  }, [resume, campaignId, router]);
+
+  return (
+    <div className="flex flex-col gap-1">
+      <button
+        type="button"
+        onClick={handleClick}
+        disabled={resume.isPending}
+        data-testid="serata-resume-button"
+        className="inline-flex items-center justify-center gap-2 self-start rounded-md bg-entity-event px-4 py-2 font-display text-sm font-semibold text-white shadow-sm transition hover:bg-entity-event/90 disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        {resume.isPending ? 'Avvio…' : '▶ Riprendi la serata'}
+      </button>
+      {resume.isError ? (
+        <span role="alert" className="text-xs font-medium text-[hsl(var(--c-danger))]">
+          {resumeErrorMessage(resume.error)}
+        </span>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/components/features/gamebook/__tests__/SerataResumeButton.test.tsx
+++ b/apps/web/src/components/features/gamebook/__tests__/SerataResumeButton.test.tsx
@@ -1,0 +1,128 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * SerataResumeButton unit tests — SI-4 (#2635, step 3).
+ *
+ * On the gamebook play page, when a campaign is attached to a resumable game-night, the organizer
+ * can open a NEW live sitting via Attach. Covers the pure gating predicate + the CTA behaviour
+ * (success routing, distinct max-live 409 / 403 feedback).
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { ConflictError, ForbiddenError } from '@/lib/api/core/errors';
+import type { GamebookCampaignSpine } from '@/lib/api/gamebook-campaigns';
+import { MAX_LIVE_SESSIONS_EXCEEDED } from '@/lib/game-nights/hooks/useStartNextGame';
+
+import { SerataResumeButton, isSerataResumable } from '../SerataResumeButton';
+
+const pushMock = vi.hoisted(() => vi.fn());
+vi.mock('next/navigation', () => ({ useRouter: () => ({ push: pushMock }) }));
+
+const attachMock = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/api/clients/gameNightSessionClient', () => ({
+  gameNightSessionClient: { attachGamebookCampaign: attachMock },
+}));
+
+const ORG = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const OTHER = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
+const GN = 'dddddddd-dddd-4ddd-8ddd-dddddddddddd';
+const CAMPAIGN = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+
+function spine(overrides: Partial<GamebookCampaignSpine> = {}): GamebookCampaignSpine {
+  return {
+    gameNightId: GN,
+    gameNightTitle: 'Serata da Marco',
+    organizerId: ORG,
+    gameNightStatus: 'InProgress',
+    totalSessions: 1,
+    completedSessions: 1,
+    hasLiveSession: false,
+    campaignStatus: 'Resumable',
+    ...overrides,
+  };
+}
+
+function renderButton() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <SerataResumeButton gameNightId={GN} campaignId={CAMPAIGN} />
+    </QueryClientProvider>
+  );
+}
+
+describe('isSerataResumable', () => {
+  it('is true for the organizer on a resumable night with no live session', () => {
+    expect(isSerataResumable(spine(), ORG)).toBe(true);
+    expect(isSerataResumable(spine({ gameNightStatus: 'Published' }), ORG)).toBe(true);
+  });
+
+  it('is false when the viewer is not the organizer', () => {
+    expect(isSerataResumable(spine(), OTHER)).toBe(false);
+  });
+
+  it('is false when a live session already exists', () => {
+    expect(isSerataResumable(spine({ hasLiveSession: true }), ORG)).toBe(false);
+  });
+
+  it('is false for a terminal / non-resumable night status', () => {
+    expect(isSerataResumable(spine({ gameNightStatus: 'Completed' }), ORG)).toBe(false);
+    expect(isSerataResumable(spine({ gameNightStatus: 'Cancelled' }), ORG)).toBe(false);
+    expect(isSerataResumable(spine({ gameNightStatus: 'Draft' }), ORG)).toBe(false);
+  });
+
+  it('is false for a null spine or a missing viewer id', () => {
+    expect(isSerataResumable(null, ORG)).toBe(false);
+    expect(isSerataResumable(spine(), undefined)).toBe(false);
+  });
+});
+
+describe('SerataResumeButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('opens a live sitting and routes to the new session on success', async () => {
+    attachMock.mockResolvedValue({
+      sessionId: 's99',
+      gameNightSessionId: 'gns',
+      sessionCode: 'ABC',
+      playOrder: 2,
+    });
+    renderButton();
+
+    fireEvent.click(screen.getByRole('button', { name: /riprendi la serata/i }));
+
+    await waitFor(() => expect(attachMock).toHaveBeenCalledWith(GN, CAMPAIGN));
+    await waitFor(() => expect(pushMock).toHaveBeenCalledWith('/sessions/s99'));
+  });
+
+  it('shows a distinct message on a max-live 409 and does not route', async () => {
+    attachMock.mockRejectedValue(
+      new ConflictError({ message: 'blocked', code: MAX_LIVE_SESSIONS_EXCEEDED })
+    );
+    renderButton();
+
+    fireEvent.click(screen.getByRole('button', { name: /riprendi la serata/i }));
+
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent(/già una partita live/i)
+    );
+    expect(pushMock).not.toHaveBeenCalled();
+  });
+
+  it('shows a distinct message on a 403 (non-organizer) and does not route', async () => {
+    attachMock.mockRejectedValue(new ForbiddenError({ message: 'nope' }));
+    renderButton();
+
+    fireEvent.click(screen.getByRole('button', { name: /riprendi la serata/i }));
+
+    await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent(/organizzatore/i));
+    expect(pushMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/features/session-live/LiveTopBar.tsx
+++ b/apps/web/src/components/features/session-live/LiveTopBar.tsx
@@ -34,6 +34,8 @@ export interface LiveTopBarLabels {
   readonly exitAriaLabel: string;
   /** G4 (Issue #2352) — aria-label for the elapsed-time chip. Required when elapsedMs is provided. */
   readonly elapsedTimeAriaLabel?: string;
+  /** SI-4 (#2635) — aria-label for the read-only "Ora di inizio · derivata" chip. */
+  readonly startedAtChipAriaLabel?: string;
   /** G4 (Issue #2352) — aria-label per connection-state pip. Required when connectionState is provided. */
   readonly connectionStateAriaLabels?: {
     readonly connected: string;
@@ -61,6 +63,12 @@ export interface LiveTopBarProps {
    */
   readonly elapsedMs?: number;
   /**
+   * SI-4 (#2635) — pre-formatted read-only start-time chip text
+   * ("▶ Ora di inizio {local date+time} · derivata"). Derived from the session's `startedAt`
+   * (Invariante 5: never user-editable). Omit to hide the chip.
+   */
+  readonly startedAtLabel?: string;
+  /**
    * G4 (Issue #2352) — SSE connection state.
    * Omit to hide the inline pip (default behavior pre-G4; the standalone
    * `ConnectionLostBanner` remains the actionable surface for `failed`).
@@ -87,6 +95,7 @@ export function LiveTopBar({
   onExit,
   labels,
   elapsedMs,
+  startedAtLabel,
   connectionState,
 }: LiveTopBarProps): ReactElement {
   const isHost = viewerRole === 'Host';
@@ -140,6 +149,18 @@ export function LiveTopBar({
               tabular-nums text-foreground/90 sm:inline"
           >
             {elapsedFormatted}
+          </span>
+        )}
+
+        {/* SI-4 (#2635) — read-only derived start-time chip (Invariante 5: never editable) */}
+        {startedAtLabel && (
+          <span
+            data-slot="session-live-top-bar-started-at"
+            aria-label={labels.startedAtChipAriaLabel}
+            className="hidden shrink-0 rounded-md bg-card/60 px-2 py-0.5 text-xs
+              text-muted-foreground md:inline"
+          >
+            {startedAtLabel}
           </span>
         )}
 

--- a/apps/web/src/components/features/session-live/__tests__/LiveTopBar.test.tsx
+++ b/apps/web/src/components/features/session-live/__tests__/LiveTopBar.test.tsx
@@ -29,6 +29,8 @@ const LABELS: LiveTopBarLabels = {
   exitAriaLabel: 'Esci',
   // G4 labels
   elapsedTimeAriaLabel: 'Tempo trascorso',
+  // SI-4 label
+  startedAtChipAriaLabel: 'Ora di inizio della sessione (derivata)',
   connectionStateAriaLabels: {
     connected: 'Connessione attiva',
     reconnecting: 'Riconnessione in corso',
@@ -66,6 +68,30 @@ describe('LiveTopBar — backward compat (no G4 props)', () => {
   it('preserves existing TopBar slot + status', () => {
     renderTopBar();
     expect(document.querySelector('[data-slot="session-live-top-bar"]')).not.toBeNull();
+  });
+});
+
+// ─── SI-4 (#2635) — derived start-time chip ───────────────────────────────────
+
+describe('LiveTopBar — SI-4 start-time chip', () => {
+  it('renders the read-only start-time chip when startedAtLabel is provided', () => {
+    renderTopBar({ startedAtLabel: '▶ Ora di inizio 5 lug, 20:35 · derivata' });
+    const chip = document.querySelector('[data-slot="session-live-top-bar-started-at"]');
+    expect(chip).not.toBeNull();
+    expect(chip?.textContent).toBe('▶ Ora di inizio 5 lug, 20:35 · derivata');
+    expect(chip?.getAttribute('aria-label')).toBe('Ora di inizio della sessione (derivata)');
+  });
+
+  it('hides the chip when startedAtLabel is undefined', () => {
+    renderTopBar();
+    expect(document.querySelector('[data-slot="session-live-top-bar-started-at"]')).toBeNull();
+  });
+
+  it('renders no editable input — the chip is display-only (Invariante 5)', () => {
+    renderTopBar({ startedAtLabel: '▶ Ora di inizio 5 lug, 20:35 · derivata' });
+    const chip = document.querySelector('[data-slot="session-live-top-bar-started-at"]');
+    expect(chip?.querySelector('input')).toBeNull();
+    expect(chip?.tagName.toLowerCase()).toBe('span'); // static text, not a control
   });
 });
 

--- a/apps/web/src/lib/api/clients/gameNightSessionClient.ts
+++ b/apps/web/src/lib/api/clients/gameNightSessionClient.ts
@@ -38,6 +38,15 @@ export const gameNightSessionClient = {
       gameTitle,
     }),
 
+  // SI-4 (#2635): resume a gamebook campaign as a new live sitting on its game-night
+  // (POST /game-nights/{id}/gamebook-sessions → AttachGamebookCampaignToGameNightCommand).
+  // Same response shape as startSession; a max-1-live 409 carries MAX_LIVE_SESSIONS_EXCEEDED.
+  attachGamebookCampaign: (gameNightId: string, campaignId: string) =>
+    apiClient.post<StartSessionResponse>(
+      `${BASE}/${encodeURIComponent(gameNightId)}/gamebook-sessions`,
+      { campaignId }
+    ),
+
   completeSession: (gameNightId: string, winnerId?: string) =>
     apiClient.post<void>(`${BASE}/${encodeURIComponent(gameNightId)}/sessions/complete`, {
       winnerId: winnerId ?? null,

--- a/apps/web/src/lib/gamebook/hooks/__tests__/useResumeGamebookSitting.test.tsx
+++ b/apps/web/src/lib/gamebook/hooks/__tests__/useResumeGamebookSitting.test.tsx
@@ -1,0 +1,90 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * useResumeGamebookSitting unit tests — SI-4 (#2635).
+ *
+ * Resuming a gamebook campaign's game-night for a 2nd sitting opens a NEW live Session via the
+ * Attach path (POST /game-nights/{id}/gamebook-sessions). Mirrors useStartNextGame: a max-live
+ * 409 must reach the view discriminably so the resume CTA can surface a specific message.
+ */
+
+import { type ReactNode } from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { ConflictError, ForbiddenError } from '@/lib/api/core/errors';
+import {
+  isMaxLiveBlockedError,
+  MAX_LIVE_SESSIONS_EXCEEDED,
+} from '@/lib/game-nights/hooks/useStartNextGame';
+
+import { useResumeGamebookSitting } from '../useResumeGamebookSitting';
+
+const attachMock = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/api/clients/gameNightSessionClient', () => ({
+  gameNightSessionClient: { attachGamebookCampaign: attachMock },
+}));
+
+const GN_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const CAMPAIGN_ID = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+describe('useResumeGamebookSitting', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('delegates to gameNightSessionClient.attachGamebookCampaign with the night + campaign id', async () => {
+    attachMock.mockResolvedValue({
+      sessionId: 's1',
+      gameNightSessionId: 'gns1',
+      sessionCode: 'ABC',
+      playOrder: 2,
+    });
+
+    const { result } = renderHook(() => useResumeGamebookSitting(GN_ID), {
+      wrapper: createWrapper(),
+    });
+    result.current.mutate({ campaignId: CAMPAIGN_ID });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(attachMock).toHaveBeenCalledWith(GN_ID, CAMPAIGN_ID);
+    expect(result.current.data?.sessionId).toBe('s1');
+  });
+
+  it('surfaces the max-live ConflictError so the view can discriminate the 409', async () => {
+    attachMock.mockRejectedValue(
+      new ConflictError({ message: 'blocked', code: MAX_LIVE_SESSIONS_EXCEEDED })
+    );
+
+    const { result } = renderHook(() => useResumeGamebookSitting(GN_ID), {
+      wrapper: createWrapper(),
+    });
+    result.current.mutate({ campaignId: CAMPAIGN_ID });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(isMaxLiveBlockedError(result.current.error)).toBe(true);
+  });
+
+  it('surfaces a ForbiddenError (non-organizer) unchanged', async () => {
+    attachMock.mockRejectedValue(new ForbiddenError({ message: 'nope' }));
+
+    const { result } = renderHook(() => useResumeGamebookSitting(GN_ID), {
+      wrapper: createWrapper(),
+    });
+    result.current.mutate({ campaignId: CAMPAIGN_ID });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toBeInstanceOf(ForbiddenError);
+  });
+});

--- a/apps/web/src/lib/gamebook/hooks/useResumeGamebookSitting.ts
+++ b/apps/web/src/lib/gamebook/hooks/useResumeGamebookSitting.ts
@@ -1,0 +1,44 @@
+'use client';
+
+/**
+ * useResumeGamebookSitting — SI-4 (#2635, step 3).
+ *
+ * Opens a NEW live Session for a gamebook campaign on its already-InProgress (or Published)
+ * game-night — the "resume the sitting" action on the play page. Wraps the Attach path
+ * (POST /game-nights/{id}/gamebook-sessions). On success it invalidates the night-live + diary
+ * reads (single source of truth, no optimistic flip) and the campaign spine (its live/session
+ * counts change). A max-1-live 409 reaches the view discriminably via `isMaxLiveBlockedError`.
+ */
+
+import { useMutation, useQueryClient, type UseMutationResult } from '@tanstack/react-query';
+
+import {
+  gameNightSessionClient,
+  type StartSessionResponse,
+} from '@/lib/api/clients/gameNightSessionClient';
+import { gameNightLiveKeys } from '@/lib/game-nights/hooks/useGameNightLive';
+import { nightLiveDiaryKeys } from '@/lib/game-nights/hooks/useNightLiveDiary';
+
+import { gamebookCampaignKeys } from './useGamebookCampaign';
+
+export interface ResumeGamebookSittingVars {
+  readonly campaignId: string;
+}
+
+export function useResumeGamebookSitting(
+  gameNightId: string
+): UseMutationResult<StartSessionResponse, Error, ResumeGamebookSittingVars> {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ campaignId }: ResumeGamebookSittingVars) =>
+      gameNightSessionClient.attachGamebookCampaign(gameNightId, campaignId),
+    onSuccess: (_data, { campaignId }) => {
+      void queryClient.invalidateQueries({ queryKey: gameNightLiveKeys.detail(gameNightId) });
+      void queryClient.invalidateQueries({ queryKey: nightLiveDiaryKeys.detail(gameNightId) });
+      // The spine's hasLiveSession/session counts change after a new sitting opens.
+      void queryClient.invalidateQueries({ queryKey: gamebookCampaignKeys.spine(campaignId) });
+    },
+    retry: false,
+  });
+}

--- a/apps/web/src/lib/session-live/__tests__/format-session-started-at.test.ts
+++ b/apps/web/src/lib/session-live/__tests__/format-session-started-at.test.ts
@@ -32,6 +32,22 @@ describe('formatSessionStartedAt', () => {
     ).toContain('22:35');
   });
 
+  it('localizes the month per the caller locale (en vs it)', () => {
+    // The chip must follow the viewer's resolved locale, not a hardcoded it-IT — else an EN user
+    // sees a mixed-language "Started at 5 lug…" string. SessionLiveView passes `intl.locale`.
+    const itOut = formatSessionStartedAt('2026-07-05T20:35:00Z', {
+      locale: 'it-IT',
+      timeZone: 'UTC',
+    });
+    const enOut = formatSessionStartedAt('2026-07-05T20:35:00Z', {
+      locale: 'en-US',
+      timeZone: 'UTC',
+    });
+    expect(itOut).toMatch(/lug/i);
+    expect(enOut).toMatch(/jul/i);
+    expect(enOut).not.toBe(itOut);
+  });
+
   it('returns empty string for an unparseable value', () => {
     expect(formatSessionStartedAt('not-a-date')).toBe('');
   });

--- a/apps/web/src/lib/session-live/__tests__/format-session-started-at.test.ts
+++ b/apps/web/src/lib/session-live/__tests__/format-session-started-at.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+
+import { formatSessionStartedAt } from '@/lib/session-live/format-session-started-at';
+
+// Pin locale + timeZone for determinism (the real chip uses the viewer's local zone).
+const UTC = { locale: 'it-IT', timeZone: 'UTC' } as const;
+
+describe('formatSessionStartedAt', () => {
+  it('formats a UTC instant as local date + time (pinned to UTC for the test)', () => {
+    // 2026-07-05T20:35:00Z → in it-IT UTC → "5 lug, 20:35" (24h)
+    const out = formatSessionStartedAt('2026-07-05T20:35:00Z', UTC);
+    expect(out).toMatch(/5 lug/i);
+    expect(out).toContain('20:35');
+  });
+
+  it('treats a bare (offset-less) BE timestamp as UTC', () => {
+    // No Z/offset → append Z → same instant as above.
+    expect(formatSessionStartedAt('2026-07-05T20:35:00', UTC)).toBe(
+      formatSessionStartedAt('2026-07-05T20:35:00Z', UTC)
+    );
+  });
+
+  it('respects an explicit offset', () => {
+    // 22:35+02:00 == 20:35Z
+    expect(formatSessionStartedAt('2026-07-05T22:35:00+02:00', UTC)).toContain('20:35');
+  });
+
+  it('honors a non-UTC timeZone (local display of the same instant)', () => {
+    // 20:35Z in Europe/Rome (summer, +02:00) → 22:35
+    expect(
+      formatSessionStartedAt('2026-07-05T20:35:00Z', { locale: 'it-IT', timeZone: 'Europe/Rome' })
+    ).toContain('22:35');
+  });
+
+  it('returns empty string for an unparseable value', () => {
+    expect(formatSessionStartedAt('not-a-date')).toBe('');
+  });
+});

--- a/apps/web/src/lib/session-live/format-session-started-at.ts
+++ b/apps/web/src/lib/session-live/format-session-started-at.ts
@@ -1,0 +1,29 @@
+/**
+ * formatSessionStartedAt — SI-4 #2635.
+ *
+ * Formats a live Session's `startedAt` (a UTC instant, derived from "Apri Live mode" —
+ * Invariante 5, never user input) as a human date+time in the VIEWER's local timezone. Used for
+ * the read-only "▶ Ora di inizio {…} · derivata" chip. Absolute (not elapsed) + local so a
+ * multi-day campaign is unambiguous; the raw UTC instant is pinned, only the display is localized.
+ *
+ * The BE may serialize the instant without an offset (bare `DateTime`) — append `Z` so it parses
+ * as UTC, not browser-local. Returns '' for an unparseable value (chip suppressed by the caller).
+ */
+const OFFSET_RE = /([zZ]|[+-]\d{2}:?\d{2})$/;
+
+export function formatSessionStartedAt(
+  startedAt: string,
+  opts?: { readonly locale?: string; readonly timeZone?: string }
+): string {
+  const iso = OFFSET_RE.test(startedAt) ? startedAt : `${startedAt}Z`;
+  const instant = new Date(iso);
+  if (Number.isNaN(instant.getTime())) return '';
+
+  return new Intl.DateTimeFormat(opts?.locale ?? 'it-IT', {
+    day: 'numeric',
+    month: 'short',
+    hour: '2-digit',
+    minute: '2-digit',
+    timeZone: opts?.timeZone,
+  }).format(instant);
+}

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -3068,6 +3068,8 @@
         "endgameCta": "End session",
         "exitAriaLabel": "Exit session",
         "elapsedTimeAriaLabel": "Elapsed time",
+        "startedAtChip": "▶ Started at {time} · derived",
+        "startedAtChipAriaLabel": "Session start time (derived, not editable)",
         "connectionStateConnected": "Connection active",
         "connectionStateReconnecting": "Reconnecting",
         "connectionStateFailed": "Connection lost"

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -3175,6 +3175,8 @@
         "endgameCta": "Termina sessione",
         "exitAriaLabel": "Esci dalla sessione",
         "elapsedTimeAriaLabel": "Tempo trascorso",
+        "startedAtChip": "▶ Ora di inizio {time} · derivata",
+        "startedAtChipAriaLabel": "Ora di inizio della sessione (derivata, non modificabile)",
         "connectionStateConnected": "Connessione attiva",
         "connectionStateReconnecting": "Riconnessione in corso",
         "connectionStateFailed": "Connessione persa"

--- a/docs/for-developers/specs/2026-07-05-issue-2635-si4-startedat-resume-design.md
+++ b/docs/for-developers/specs/2026-07-05-issue-2635-si4-startedat-resume-design.md
@@ -37,13 +37,13 @@ Acceptance #2635: *Given a live Session, When the play UI renders, Then mostra u
 ## 3. Scope (SI-4, questa slice)
 **IN**: (a) chip read-only startedAt su SessionLiveView (+ resume-picker gamebook) + enforce Invariante 5; (b) wire "▶ Riprendi" → nuova live Session (Attach path); (c) BE `HandleFirstSessionStarted` Completed→InProgress + gestione side-effect stale [D6]; (d) `startedAt` sullo spine DTO. **OUT**: parallel play, edit manuale di startedAt (vietato da Inv.5).
 
-## 4. Acceptance criteria
-- **AC1** Una live Session mostra la chip read-only `▶ Ora di inizio {HH:MM} · derivata` (no time-picker, no durata input) su SessionLiveView.
-- **AC2** Nessun input editabile per startedAt/durata sulla session surface (Invariante 5).
-- **AC3** "▶ Riprendi" su una campagna Resumable apre una NUOVA live Session (fresh startedAt), campaign `createdAt` invariato.
-- **AC4** Riprendere quando il GameNight è **Completed** → la serata torna InProgress (no 500/crash); il summary stale è gestito [D6].
-- **AC5** max-1-live rispettato sul resume (409 se già una live).
-- **AC6** Nessuna regressione su WS1/C2/C4 (avvio/diary/winner) né sul night-live.
+## 4. Acceptance criteria (rev. post spec-panel — §7 item 9)
+- **AC1** Una live Session mostra la chip read-only `▶ Ora di inizio {data ora locale} · derivata` (no time-picker, no durata input) su SessionLiveView. ✅
+- **AC2** Nessun input editabile per startedAt/durata sulla session surface (Invariante 5) — assert-absent + regression guard. ✅
+- **AC3** (riscritta) Riprendere una serata già **InProgress** (2ª+ sitting) apre una NUOVA live Session; il GameNight resta InProgress con la nuova live child E **rimane finalizzabile** dopo (nessun live child orfano). `createdAt` della campaign invariato (D3). ✅
+- **AC4** (riscritta) Resume-from-**Completed** è rifiutato al **command boundary** con 409 ("start a new session"), MAI un 500 dal post-commit handler (`HandleFirstSessionStarted` resta strict Published/InProgress). ✅
+- **AC5** max-1-live rispettato sul resume: 409 (`MAX_LIVE_SESSIONS_EXCEEDED`) se una sitting è già live, su entrambe le chain (Start + Attach); nessuna Session orfana. ✅
+- **AC6** Nessuna regressione su WS1/C2/C4 (avvio/diary/winner) né sul night-live. ✅
 
 ## 5. Test plan
 - **BE unit/integration**: `HandleFirstSessionStarted` Completed→InProgress (nuovo) + idempotenza; Attach re-callable per resume; side-effect stale [D6]; spine DTO startedAt.
@@ -136,3 +136,13 @@ Acceptance #2635: *Given a live Session, When the play UI renders, Then mostra u
 - **D6 fantasma eliminato**: `NightFinalizedEvent` non ha handler; nessun summary stale da gestire. Nessun `NightReopenedEvent` (non serve — non si riapre lo stesso night).
 
 **Build order**: (1) chip FE SessionLiveView (indipendente, ship early) + Invariante-5 regression · (2) BE relax `AddSession` a Published||InProgress + reject Completed@boundary + test (incl. multi-game 2ª-sitting che oggi si rompe) · (3) FE wire "▶ Riprendi" → nuova live Session · (4) test concorrenza (double-resume 409, xmin loser) + AC riscritte.
+
+## 9. As-built (2026-07-05)
+
+**Step 1 — Chip** (commit `f6f8f3c69`): `formatSessionStartedAt` pure mapper (UTC instant → data+ora locale del viewer), chip read-only `▶ Ora di inizio {…} · derivata` su `LiveTopBar`/`SessionLiveView`. Una sola superficie (D1 narrowed), **D7 dropped**.
+
+**Step 2 — BE resume** (commit `49f2848cd`): `GameNightEvent.AddSession` rilassato a `Published || InProgress`; **Completed** rifiutato con "Cannot add sessions to a finalized game night — start a new session." (→409 via i due handler che già mappano `InvalidOperationException`→`ConflictException`); Draft/Cancelled/Corrupted rifiutati col messaggio generico. Guard max-1-live #10 (`EnsureCanStartSession`:439 / `StartCurrentSession`:459) **invariati** → nessuna 2ª InProgress. Sblocca anche il 2ª-sitting per **giochi normali** già wired in `NightLiveClientView` (`useStartNextGame` → `StartGameNightSessionCommand`). Test: 3 domain (`AddSession` InProgress/Completed-guidance/Cancelled) + 3 handler (Start 2ª-sitting + Start double-resume + Attach 2ª-sitting).
+
+**Step 3 — FE resume entry** (commit `93885e4a5`, decisione utente **= play-page**, non il resume-picker): scoperta bloccante — le campagne del resume-picker (`useUserCampaigns` → `GamebookCampaign`) **non hanno `gameNightId`** (solo lo `spine` lo espone, e solo se attached). Quindi l'entry è sulla **play page** `library/[gameId]/play/[campaignId]/_content.tsx`: CTA `▶ Riprendi la serata` sotto `SerataSpineStrip`, mostrata solo se `isSerataResumable(spine, currentUser.id)` (organizer + Published/InProgress + `!hasLiveSession`). Apre una NUOVA live Session via `POST /game-nights/{id}/gamebook-sessions` (`gameNightSessionClient.attachGamebookCampaign` + hook `useResumeGamebookSitting`) e instrada a `/sessions/{id}` (il FORK redirige la sessione in-progress a `/live`, dove appare la chip step-1). Feedback inline distinti: 409 max-live vs 403 organizer. Campagne standalone → lettura pura invariata. Test: predicato puro `isSerataResumable` (6 casi) + component (success-route / 409 / 403) + hook (delegate / max-live 409 / 403).
+
+**Step 4 — Concorrenza + AC**: double-resume-while-live → 409 `MAX_LIVE_SESSIONS_EXCEEDED` senza Session orfana, su **entrambe** le chain (Start + Attach); xmin loser → 409 (test pre-esistenti in entrambi gli handler); resume-from-Completed → 409 al boundary. AC §4 riscritte (AC3 = InProgress 2ª-sitting + finalizzabile dopo; AC4 = Completed rifiutato al boundary, mai 500).

--- a/docs/for-developers/specs/2026-07-05-issue-2635-si4-startedat-resume-design.md
+++ b/docs/for-developers/specs/2026-07-05-issue-2635-si4-startedat-resume-design.md
@@ -1,0 +1,138 @@
+# SI-4 — startedAt chip derivato + resume wiring (#2635)
+
+**Data**: 2026-07-05 · **Issue**: #2635 (SI-4, umbrella #2619) · **Predecessori**: SI-1b (#2632), WS1/C2/C4 (#2633/#2634)
+**Stato**: DRAFT per `/sc:spec-panel` · **Scope scelto utente**: *Chip + resume-full (BE net-new)*.
+
+## 1. Contesto e discovery (workflow 3-reader; agent BE re-open ricostruito inline)
+
+Acceptance #2635: *Given a live Session, When the play UI renders, Then mostra una chip read-only `▶ Ora di inizio {startedAt} · derivata` (no time-picker/durata — **Invariante 5**); e "▶ Riprendi" apre una **NUOVA** live Session (fresh `startedAt`), GameNight ri-promossa planned/**completed**→in-progress, campaign `createdAt` invariato (**D3**, no draft reactivation).*
+
+### Fatti accertati
+**startedAt (sorgente):**
+- `Session.StartedAt` (SessionTracking, `DateTime?`) settato SOLO in `Session.OpenLiveMode()` (Session.cs:391) → raises `SessionStartedDomainEvent`. `IsLive => StartedAt.HasValue && FinalizedAt is null`.
+- `GameNightSession.StartedAt` (GameManagement, `DateTimeOffset?`) settato da `Start()` (Pending→InProgress). Esposto da `GameNightSessionDto.StartedAt` (night-live read).
+- **`SessionLiveView` (`/sessions/[id]/live`) consuma già `sessionQuery.data.startedAt`** (SessionLiveView.tsx:740, `useElapsedTime`) → è la "play UI" con header, home naturale della chip (Invariante 5 "header drawer": "Iniziata alle HH:MM" read-only).
+- **`GamebookCampaignSpineDto` NON espone startedAt** (solo `HasLiveSession` bool + counts) — gap per la chip sul resume-picker gamebook.
+- **Invariante 5** (domain spec 2026-06-04:149-159): `Session.startedAt` NON è user input, derived da "Apri Live mode". UI: ❌ time-picker "Ora di inizio" rimosso, ❌ "Durata" input rimosso, ✅ display read-only header, ✅ "Note" unico input.
+
+**Resume (path BE):**
+- Il "▶ Riprendi" del resume-picker gamebook (`library/[gameId]/play`, `ResumeHero`/`MultiCampaignList`/`StaleWarningCard`) è oggi **pura navigazione** (`<Link>` → `/library/{gameId}/play/{campaignId}`, no mutation).
+- Aprire una nuova live Session per una campagna = path Attach SI-1b `POST /game-nights/{id}/gamebook-sessions` (`AttachGamebookCampaignToGameNightCommand`), ri-chiamabile (`EnsureCanStartSession()` max-1-live guard) se nessuna live + night non Completed.
+- **La re-promozione GameNight è wired**: `SessionStartedHandler` (GameManagement EventHandler) consuma `SessionStartedDomainEvent` → `HandleFirstSessionStarted`.
+- ⚠️ **GAP #15**: `HandleFirstSessionStarted` accetta solo **Published→InProgress** (o InProgress idempotente); **Completed lancia** `InvalidOperationException` ("Invariant #15 requires Published or InProgress"). D3 vuole **completed→in-progress** → **BE net-new**.
+- ⚠️ **Side-effect stale**: il night raggiunge Completed via `FinalizeNight()` → `NightFinalizedEvent` (summary ecc.). Re-promuovere Completed→InProgress NON annulla quell'evento → **summary/side-effect stale** di una serata ora di nuovo in-progress.
+
+## 2. Decisioni proposte (per il panel)
+
+| # | Decisione | Opzione raccomandata | Alternative |
+|---|-----------|---------------------|-------------|
+| **D1 Chip surface** | dove la chip | **`SessionLiveView`** header (ha già startedAt, Invariante 5 header drawer) + **anche** sul resume-picker gamebook (serve startedAt sullo spine DTO) | solo SessionLiveView |
+| **D2 Chip copy/format** | testo | `▶ Ora di inizio {HH:MM} · derivata` read-only (assoluto, non elapsed); UTC-pinned deterministico o TZ locale? | relativo "Iniziata Xgg fa" (precedente mockup) |
+| **D3 Invariante 5 enforce** | rimuovere input | Verificare che NESSUN time-picker "Ora di inizio"/"Durata" input esista sulla session/live surface (rimuovere se presente) | — |
+| **D4 Resume action** | Riprendi | Wire "▶ Riprendi" a una NUOVA live Session via Attach path (`POST /gamebook-sessions`), non più pura navigazione | mutation dedicata nuova |
+| **D5 Re-promozione Completed** | BE #15 | **`HandleFirstSessionStarted` accetta Completed→InProgress** (net-new) — la serata completata torna in-progress su nuova live Session | negare (resume solo Published/InProgress) |
+| **D6 Side-effect stale** | NightFinalizedEvent | **Da risolvere**: re-promuovere lascia summary/side-effect stale. Opzioni: (a) idempotente/rigenerato al prossimo finalize; (b) evento di "riapertura" che invalida il summary; (c) accettare come debito tracciato | — |
+| **D7 startedAt sullo spine** | gamebook chip | Aggiungere `sessionStartedAt` (o simile) a `GamebookCampaignSpineDto` (dalla sitting live) per la chip sul resume-picker | chip solo su SessionLiveView |
+
+## 3. Scope (SI-4, questa slice)
+**IN**: (a) chip read-only startedAt su SessionLiveView (+ resume-picker gamebook) + enforce Invariante 5; (b) wire "▶ Riprendi" → nuova live Session (Attach path); (c) BE `HandleFirstSessionStarted` Completed→InProgress + gestione side-effect stale [D6]; (d) `startedAt` sullo spine DTO. **OUT**: parallel play, edit manuale di startedAt (vietato da Inv.5).
+
+## 4. Acceptance criteria
+- **AC1** Una live Session mostra la chip read-only `▶ Ora di inizio {HH:MM} · derivata` (no time-picker, no durata input) su SessionLiveView.
+- **AC2** Nessun input editabile per startedAt/durata sulla session surface (Invariante 5).
+- **AC3** "▶ Riprendi" su una campagna Resumable apre una NUOVA live Session (fresh startedAt), campaign `createdAt` invariato.
+- **AC4** Riprendere quando il GameNight è **Completed** → la serata torna InProgress (no 500/crash); il summary stale è gestito [D6].
+- **AC5** max-1-live rispettato sul resume (409 se già una live).
+- **AC6** Nessuna regressione su WS1/C2/C4 (avvio/diary/winner) né sul night-live.
+
+## 5. Test plan
+- **BE unit/integration**: `HandleFirstSessionStarted` Completed→InProgress (nuovo) + idempotenza; Attach re-callable per resume; side-effect stale [D6]; spine DTO startedAt.
+- **FE unit**: chip startedAt (format, Invariante-5 no-input) su SessionLiveView; resume action (Attach mutation, 409 max-live); resume-picker chip.
+- **Regressione**: cluster game-nights + sessions-live.
+
+## 6. Rischi / questioni aperte
+- **R1 [D6]** Re-promozione Completed→InProgress lascia `NightFinalizedEvent` side-effect stale (summary) — la scelta di gestione è la questione più delicata (tocca invariante #15).
+- **R2** La chip su DUE superfici (SessionLiveView + resume-picker) raddoppia il lavoro; valutare se una basta.
+- **R3** Copy/format della chip non nei mockup (nuova) — assoluto vs relativo, TZ.
+
+---
+*Draft per spec-panel — D1-D7 da pressure-testare; R1/D6 è il nodo critico.*
+
+
+## 7. Spec-Panel Verdict (Fowler/Nygard/Crispin; Wiegers retry-capped) — RESUME-FULL OVERTURNED
+
+# SI-4 (#2635) — Spec-Panel Consolidated Verdict
+
+**Panel**: Fowler (modeling) · Nygard (resilience) · Crispin (test/edge). **Consensus is unusually strong**: the FE chip half is sound; the resume half rests on a factually wrong discovery, and the true blocker sits one call earlier than the draft targets.
+
+## 1. Locked Decisions (D1–D7)
+
+| # | Decision | Verdict | One-line reason |
+|---|----------|---------|-----------------|
+| **D1** | Chip on SessionLiveView **+** resume-picker | **OVERTURNED → one surface** | 3/3 challenge. Resume-picker is not live (`CampaignStatus='Resumable'`); spine would surface the last *Completed* sitting's `StartedAt` mislabeled as current. Data on SessionLiveView is already in hand (`SessionLiveView.tsx:740`). |
+| **D2** | Absolute `Ora di inizio {HH:MM} · derivata` | **REFINED** | Absolute + read-only + "derivata" is correct for Invariante 5, but render **date+time in the viewer's local TZ** from the UTC instant via a pure FE mapper; bare `HH:MM` is ambiguous for a multi-day campaign. |
+| **D3** | Enforce Invariante 5 (remove time/duration input) | **REFINED (agree in principle)** | Nothing to remove — no editable `startedAt`/duration input exists on the live surface today. Reframe as **assert-absent + regression guard**, not removal work. |
+| **D4** | Wire Riprendi via SI-1b Attach path | **OVERTURNED (as written)** | Attach is organizer-scoped (Forbidden if caller≠OrganizerId) **and** calls `AddSession` which requires `Status==Published`. It cannot serve a completed/solo-owner resume as-is. Define a real resume command first. |
+| **D5** | `HandleFirstSessionStarted` accepts Completed→InProgress | **OVERTURNED** | Necessary-but-insufficient (dead code — `AddSession:414` 409s first) **and** unsafe (silently un-completes a terminal state from a passive post-commit handler → AC4 500 + crash-window). |
+| **D6** | Handle stale `NightFinalizedEvent` summary side-effect | **OVERTURNED (phantom)** | `NightFinalizedEvent` has **no** `INotificationHandler`; sole consumer is `SseEventTypeMapper.cs:84` (ephemeral). No persisted summary/recap/email/ledger exists. The "critical node" evaporates in current code. |
+| **D7** | Add `startedAt` to `GamebookCampaignSpineDto` | **OVERTURNED (drop)** | Follows from D1. Couples the GameManagement read model to SessionTracking timing for a cosmetic chip and ships a misleading "start time" (a past sitting's start on a non-live campaign). YAGNI. |
+
+## 2. New Must-Fix Items (ranked)
+
+1. **Fix the discovery — `AddSession` is the true blocker, not `HandleFirstSessionStarted`.** `GameNightEvent.cs:414` requires `Status==Published` and throws first (→409). Relaxing D5 alone is dead code. This also blocks the **common InProgress 2nd-sitting** case (Crispin), not just Completed.
+2. **Delete D6's stale-summary machinery.** Restate the discovery: only durable finalize side-effect is `_autoSaveScheduler.RemoveAsync` (self-healing, re-registered by Attach). No invalidation event needed.
+3. **Resolve D5 on domain grounds at the command boundary, never by widening a guard.** Any allow/deny for a completed night must return 409/400 **before** `CreateSession` — a throw in the post-commit `SessionStartedHandler` (ADR-060) is a 500 over already-committed live state (AC4 violation).
+4. **Verify Completed is even reachable for played gamebook nights.** `FinalizeNight` requires `Status==Published` (line 491) and rejects InProgress; a night with a started session may never reach Completed via the normal door. Retarget D5 to the **reachable InProgress 2nd-sitting** path before coding.
+5. **Define the real resume command for D4**: explicit auth scope (owner vs organizer) and the completed-night decision location. Attach is not a drop-in.
+6. **If same-night reopen is chosen, make it atomic**: fold the status transition into the **same transaction** as `AddSession`/`StartCurrentSession` — do not rely on the post-commit `OpenLiveMode` event, which leaves a crash-window (durably-Completed night owning a live InProgress child → unrecoverable).
+7. **Scope chip to SessionLiveView; drop D7; lock TZ**: `DateTimeOffset` + ISO-with-offset on any wire field, pure FE local formatter, test-pinned TZ (guards against `Date.parse` local-time corruption that would also corrupt `useElapsedTime`).
+8. **Expand the test plan**: double-resume → 409 (max-live), concurrent resume → xmin loser 409, crash-before-status-flip recovery, read-model churn (`Recenti` ↔ `In corso`), Invariante-5 no-input guard, chip coexistence with the existing elapsed-timer, max-5-sittings cap edge.
+9. **Reframe AC4**: "no 500" is trivially satisfied by the existing 409 path and does **not** prove resume works. Add an AC asserting the night reaches InProgress with a fresh live Session **and remains finalizable** afterward.
+
+## 3. Recommendation on the Critical D5/D6 Question
+
+**Do NOT allow silent `Completed→InProgress` re-promotion.** Unanimous.
+
+- **The stale-summary problem does not exist.** `NightFinalizedEvent` has no handler — remove all D6 machinery. If a reopen ever ships, emit an **additive `NightReopenedEvent`** (registered in `SseEventTypeMapper`) so the SSE/read side can react (toast, move card) — an *invalidation* event would invalidate nothing.
+
+- **Preferred model: resume = a fresh sitting context, not a resurrected night.** The campaign already tolerates multiple nights (spine resolves per-session via `FindByLinkedSessionIdAsync`), so a new sitting/ad-hoc night is the evolutionarily-consistent choice and dissolves the terminal-state smell, the lifecycle dead-end (a re-promoted night can only re-complete via `CompleteAdHoc`, which is silent/asymmetric), and the crash-window entirely.
+
+- **If product genuinely requires resurrecting the *same* night**, it must be a first-class, explicitly-named `Reopen()` transition with its own event and a defined re-finalize door, executed atomically inside the resume transaction — **and** every guard must be enumerated and changed together (`AddSession` Published-guard, `FinalizeNight` re-entry, max-5 cap), not one widened method.
+
+- **Scope call — resume-from-Completed is OUT for SI-4.** Retarget to the reachable everyday gap (**InProgress 2nd-sitting resume**, currently blocked by `AddSession`'s Published-only guard). Reject a completed-night reuse at the command boundary with `409` ("night finalized — start a new session"). This is the smallest correct slice and matches the spine DTO's own comment that Completed is "a future manual flag from SI-8."
+
+## 4. Genuine Disagreement (recorded, both sides)
+
+**(a) Is Attach the right mechanism for D4?**
+- *Fowler*: Attach is "convenient coupling, not a fit" — organizer-scoped and Published-guarded; define a purpose-built resume command instead.
+- *Nygard / Crispin*: Attach's navigation→mutation shape is fine **if** `AddSession` reachability is fixed; the gap is scope, not mechanism.
+- **Panel call**: fixing `AddSession` is required either way, so the mechanism choice is downstream of item #4 (verify reachability) — decide after re-discovery; do not pre-commit to Attach.
+
+**(b) How real is the Completed source-state?**
+- *Fowler / Nygard*: treat Completed as reachable and design to *reject* it (terminal-state smell is the headline).
+- *Crispin*: the premise may be false — `FinalizeNight` rejects InProgress, so a played gamebook night likely can't reach Completed at all; D5 may be optimizing a non-existent edge while the InProgress path is the true break.
+- **Panel call**: Crispin's reachability check (item #4) gates the others' concern — run it first; if Completed is unreachable, the entire terminal-state debate is moot for this slice.
+
+## 5. Build Order
+
+0. **Re-discovery pass** (BE): trace the full Attach traversal — `AddSession:414` (Published-only), `StartCurrentSession` (inv #10), `EnsureCanStartSession`, `FinalizeNight:491`. Correct the doc: D6 phantom + `AddSession` as primary blocker. Verify whether Completed is reachable for played nights.
+1. **Re-scope**: target InProgress 2nd-sitting resume; declare resume-from-Completed OUT (command-boundary 409).
+2. **FE chip (independent, ship early)**: SessionLiveView-only, local-TZ pure mapper (D1 narrowed + D2). Drop resume-picker chip + D7.
+3. **D3 verify-and-lock**: regression test asserting no editable `startedAt`/duration input; confirm chip does not collide with the existing `useElapsedTime` surface.
+4. **BE resume command**: relax `AddSession` for InProgress; define command with explicit owner/organizer auth; enforce the completed-night decision at the command boundary (never-500).
+5. **Reopen path (only if product mandates same-night)**: explicit atomic `Reopen()` + additive `NightReopenedEvent` + `SseEventTypeMapper` registration; keep passive `HandleFirstSessionStarted` strict.
+6. **Test expansion**: concurrency/idempotency (double-click, xmin loser), crash-before-flip recovery, read-model churn, Invariante-5 guard, TZ serialization, max-5 cap.
+7. **Rewrite ACs**: AC3 = night reaches InProgress with a fresh live Session; AC4 = subsequent finalize path remains valid (no orphaned live child).
+
+**Bottom line**: keep the chip (one surface, local TZ), drop D7, and send the resume half back for a re-discovery + re-scope pass — the "critical node" (D6) is a ghost, the real blocker (`AddSession`) is unaddressed, and re-promoting a terminal state is a smell to design out, not a guard to widen.
+## 8. Re-discovery + re-scope (2026-07-05, post-verdict, scelta utente "Chip + resume InProgress-2ª-sitting")
+
+**Re-discovery (build-order step 0)**: `GameNightEvent.AddSession` (GameNightEvent.cs:410-427) richiede `Status==Published` (:414) e lancia `InvalidOperationException` altrimenti. Il night passa a `InProgress` dopo la 1ª partita (`HandleFirstSessionStarted`, dispatch async via outbox post-commit). Quindi avviare una **2ª+ partita/sitting** su un night già InProgress **fallisce** (o è racy con la flip async). Confermato il finding del panel: il vero blocker è `AddSession`, e colpisce il caso **quotidiano InProgress 2ª-sitting**, non solo Completed. La chain resume (WS1 `StartGameNightSessionCommand` e SI-1b `AttachGamebookCampaign`) chiama entrambe `AddSession` → sono affette.
+
+**Re-scope lockato**:
+- **Chip**: SessionLiveView-only, TZ locale, mapper puro, assoluto `▶ Ora di inizio {data ora} · derivata` (D1 narrowed + D2 refined). **Drop D7** (spine chip). D3 = assert-absent + regression test.
+- **Resume = InProgress 2ª-sitting**: **rilassare `AddSession` a `Published || InProgress`** (reject Draft/Cancelled/**Completed**/Corrupted con messaggio chiaro). `EnsureCanStartSession`/`StartCurrentSession` (max-1-live #10) invariati → non si creano 2 InProgress. Wire il "▶ Riprendi" gamebook a creare una nuova live Session via la chain esistente.
+- **resume-from-Completed OUT**: rifiutato al **command boundary** (409 "night finalized — start a new session"), MAI un throw nel post-commit `SessionStartedHandler` (never-500, AC4). `HandleFirstSessionStarted` resta strict Published/InProgress.
+- **D6 fantasma eliminato**: `NightFinalizedEvent` non ha handler; nessun summary stale da gestire. Nessun `NightReopenedEvent` (non serve — non si riapre lo stesso night).
+
+**Build order**: (1) chip FE SessionLiveView (indipendente, ship early) + Invariante-5 regression · (2) BE relax `AddSession` a Published||InProgress + reject Completed@boundary + test (incl. multi-game 2ª-sitting che oggi si rompe) · (3) FE wire "▶ Riprendi" → nuova live Session · (4) test concorrenza (double-resume 409, xmin loser) + AC riscritte.


### PR DESCRIPTION
## SI-4 (#2635) — startedAt chip derivato + resume wiring

Umbrella #2619 · Thread A. Design + verdetto spec-panel + as-built: `docs/for-developers/specs/2026-07-05-issue-2635-si4-startedat-resume-design.md` (§7/§8/§9).

Lo spec-panel (Fowler/Nygard/Crispin) ha **rovesciato all'unanimità** l'approccio "resume-full" (re-promozione GameNight Completed→InProgress): `NightFinalizedEvent` non ha handler (D6 fantasma), il vero blocker era `AddSession` (Published-only), e ri-promuovere uno stato terminale da un handler post-commit sarebbe un 500 (viola never-500/ADR-060). Re-scope lockato: **chip 1 superficie + resume = InProgress 2ª-sitting** (resume-from-Completed rifiutato al command boundary).

### Cosa cambia

**1. Chip startedAt (display-only, Invariante 5)** — `formatSessionStartedAt` (mapper puro: UTC instant → data+ora locale del viewer, `''` su invalido) + chip read-only `▶ Ora di inizio {…} · derivata` su `LiveTopBar`/`SessionLiveView` (i18n it/en). Nessun time-picker/durata (assert-absent + regression).

**2. BE — relax `AddSession` (il vero fix, sblocca anche un bug latente WS1)** — `GameNightEvent.AddSession` da `Published`-only → `Published || InProgress`. Un night passa a InProgress dopo la 1ª partita (#15), quindi avviare la **2ª+ partita/sitting** falliva con 409 (Published-only) — bug latente del multi-game già wired in `NightLiveClientView` (`useStartNextGame`), ora sbloccato end-to-end. **Completed** rifiutato con "start a new session" (→409 via i due handler che già mappano `InvalidOperationException`→`ConflictException`). Guard max-1-live #10 (`EnsureCanStartSession`/`StartCurrentSession`) **invariati** → nessuna 2ª InProgress.

**3. FE — CTA "▶ Riprendi la serata" (decisione: play-page, non il resume-picker)** — le campagne del resume-picker non hanno `gameNightId` (solo lo `spine`, e solo se attached). Entry sulla **play page** (`library/[gameId]/play/[campaignId]/_content.tsx`) sotto `SerataSpineStrip`, gated da `isSerataResumable(spine, currentUser.id)` (organizer + Published/InProgress + `!hasLiveSession`). Apre una NUOVA live Session via `POST /game-nights/{id}/gamebook-sessions` (Attach) e instrada a `/sessions/{id}`. Feedback inline distinti 409 max-live / 403 organizer. Campagne standalone → lettura pura invariata.

**4. Concorrenza + AC** — double-resume-while-live → 409 max-live senza Session orfana (Start + Attach); xmin loser → 409 (test pre-esistenti); resume-from-Completed → 409 al boundary. AC §4 riscritte per il verdetto del panel.

### Test
- **BE**: 3 domain (`AddSession` InProgress-2ª-sitting / Completed-guidance / Cancelled) + 4 handler (Start 2ª-sitting + Start double-resume + Attach 2ª-sitting + Attach double-resume). Regression: **734/734** GameManagement unit verdi.
- **FE**: predicato puro `isSerataResumable` (6 casi) + component `SerataResumeButton` (success-route / 409 / 403) + hook `useResumeGamebookSitting` (delegate / 409 / 403). Typecheck + ESLint puliti; regression gamebook+play **566** verdi.

### AC (§4 rev.)
- **AC1/AC2** chip read-only + no input editabile (Invariante 5) ✅
- **AC3** resume InProgress 2ª-sitting apre nuova live Session, night resta finalizzabile ✅
- **AC4** resume-from-Completed rifiutato al boundary (409), mai 500 ✅
- **AC5** max-1-live sul resume (Start + Attach), no Session orfana ✅
- **AC6** nessuna regressione WS1/C2/C4/night-live ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
