### PR TITLE
chore(seed): #2679 rimuovi 6 rulebook non-indicizzabili dai manifest

### DIFF
--- a/apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/dev.yml
+++ b/apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/dev.yml
@@ -1189,9 +1189,6 @@ catalog:
     - Hobby World
     - Korea Boardgames
     - MYBG Co., Ltd.
-    pdfBlobKey: rulebooks/v1/gloomhaven_rulebook.pdf
-    pdfSha256: a8bb3b2e3d875f325d12da48ca4c6fd7807876b3b0353bf4052a74678d339f27
-    pdfVersion: '1.0'
   - title: Small World
     bggId: 40692
     language: en
@@ -1938,9 +1935,6 @@ catalog:
     - Rozum
     - Siam Board Games
     - Super Impulse
-    pdfBlobKey: rulebooks/v1/exploding-kittens_rulebook.pdf
-    pdfSha256: 1585eb968604bd7652b3e8f276e5a7409c5bfca8fc1217ca75792ae3b44b654c
-    pdfVersion: '1.0'
   - title: Agricola
     bggId: 31260
     language: en
@@ -2440,9 +2434,6 @@ catalog:
     - Wizards of the Coast
     - asmodee
     - Hasbro
-    pdfBlobKey: rulebooks/v1/betrayal-at-house-on-the-hill_rulebook.pdf
-    pdfSha256: 806700be2b34ee26d0dee42c4b600bc57b0d1c4c520ddfeaf9db171441ba9f9e
-    pdfVersion: '1.0'
   - title: Ark Nova
     bggId: 342942
     language: en
@@ -2638,9 +2629,6 @@ catalog:
     - Rebel Sp. z o.o.
     - Spilbræt.dk
     - White Goblin Games
-    pdfBlobKey: rulebooks/v1/lost-ruins-of-arnak_rulebook.pdf
-    pdfSha256: d697b0612bbab7b16d183bdaee061d17fea25d6be485329e0c98bc90a1af11c1
-    pdfVersion: '1.0'
   - title: The Castles of Burgundy
     bggId: 84876
     language: en
@@ -3006,9 +2994,6 @@ catalog:
     - Vendetta
     - Zhiyanjia
     - Ігромаг
-    pdfBlobKey: rulebooks/v1/hive-pocket_rulebook.pdf
-    pdfSha256: d5dc5809bc293ef53f13b4aa92bbf833d6f7d95852b14bf491a4e2713478d1d5
-    pdfVersion: '1.0'
   - title: Raiders of the North Sea
     bggId: 170042
     language: en
@@ -3207,9 +3192,6 @@ catalog:
     - Hasbro
     - Play Factory
     - PS-Games
-    pdfBlobKey: rulebooks/v1/guillotine_rulebook.pdf
-    pdfSha256: 6272d65910f05a2a9ada9aa79d1247b3d015cc3b2b402d465f32894ef0928b76
-    pdfVersion: '1.0'
   - title: Harmonies
     bggId: 414317
     language: en

--- a/apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/prod.yml
+++ b/apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/prod.yml
@@ -1189,9 +1189,6 @@ catalog:
     - Hobby World
     - Korea Boardgames
     - MYBG Co., Ltd.
-    pdfBlobKey: rulebooks/v1/gloomhaven_rulebook.pdf
-    pdfSha256: a8bb3b2e3d875f325d12da48ca4c6fd7807876b3b0353bf4052a74678d339f27
-    pdfVersion: '1.0'
   - title: Small World
     bggId: 40692
     language: en
@@ -1938,9 +1935,6 @@ catalog:
     - Rozum
     - Siam Board Games
     - Super Impulse
-    pdfBlobKey: rulebooks/v1/exploding-kittens_rulebook.pdf
-    pdfSha256: 1585eb968604bd7652b3e8f276e5a7409c5bfca8fc1217ca75792ae3b44b654c
-    pdfVersion: '1.0'
   - title: Agricola
     bggId: 31260
     language: en
@@ -2440,9 +2434,6 @@ catalog:
     - Wizards of the Coast
     - asmodee
     - Hasbro
-    pdfBlobKey: rulebooks/v1/betrayal-at-house-on-the-hill_rulebook.pdf
-    pdfSha256: 806700be2b34ee26d0dee42c4b600bc57b0d1c4c520ddfeaf9db171441ba9f9e
-    pdfVersion: '1.0'
   - title: Ark Nova
     bggId: 342942
     language: en
@@ -2638,9 +2629,6 @@ catalog:
     - Rebel Sp. z o.o.
     - Spilbræt.dk
     - White Goblin Games
-    pdfBlobKey: rulebooks/v1/lost-ruins-of-arnak_rulebook.pdf
-    pdfSha256: d697b0612bbab7b16d183bdaee061d17fea25d6be485329e0c98bc90a1af11c1
-    pdfVersion: '1.0'
   - title: The Castles of Burgundy
     bggId: 84876
     language: en
@@ -3006,9 +2994,6 @@ catalog:
     - Vendetta
     - Zhiyanjia
     - Ігромаг
-    pdfBlobKey: rulebooks/v1/hive-pocket_rulebook.pdf
-    pdfSha256: d5dc5809bc293ef53f13b4aa92bbf833d6f7d95852b14bf491a4e2713478d1d5
-    pdfVersion: '1.0'
   - title: Raiders of the North Sea
     bggId: 170042
     language: en
@@ -3207,9 +3192,6 @@ catalog:
     - Hasbro
     - Play Factory
     - PS-Games
-    pdfBlobKey: rulebooks/v1/guillotine_rulebook.pdf
-    pdfSha256: 6272d65910f05a2a9ada9aa79d1247b3d015cc3b2b402d465f32894ef0928b76
-    pdfVersion: '1.0'
   - title: Harmonies
     bggId: 414317
     language: en

--- a/apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/staging.yml
+++ b/apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/staging.yml
@@ -1189,9 +1189,6 @@ catalog:
     - Hobby World
     - Korea Boardgames
     - MYBG Co., Ltd.
-    pdfBlobKey: rulebooks/v1/gloomhaven_rulebook.pdf
-    pdfSha256: a8bb3b2e3d875f325d12da48ca4c6fd7807876b3b0353bf4052a74678d339f27
-    pdfVersion: '1.0'
   - title: Small World
     bggId: 40692
     language: en
@@ -1938,9 +1935,6 @@ catalog:
     - Rozum
     - Siam Board Games
     - Super Impulse
-    pdfBlobKey: rulebooks/v1/exploding-kittens_rulebook.pdf
-    pdfSha256: 1585eb968604bd7652b3e8f276e5a7409c5bfca8fc1217ca75792ae3b44b654c
-    pdfVersion: '1.0'
   - title: Agricola
     bggId: 31260
     language: en
@@ -2440,9 +2434,6 @@ catalog:
     - Wizards of the Coast
     - asmodee
     - Hasbro
-    pdfBlobKey: rulebooks/v1/betrayal-at-house-on-the-hill_rulebook.pdf
-    pdfSha256: 806700be2b34ee26d0dee42c4b600bc57b0d1c4c520ddfeaf9db171441ba9f9e
-    pdfVersion: '1.0'
   - title: Ark Nova
     bggId: 342942
     language: en
@@ -2638,9 +2629,6 @@ catalog:
     - Rebel Sp. z o.o.
     - Spilbræt.dk
     - White Goblin Games
-    pdfBlobKey: rulebooks/v1/lost-ruins-of-arnak_rulebook.pdf
-    pdfSha256: d697b0612bbab7b16d183bdaee061d17fea25d6be485329e0c98bc90a1af11c1
-    pdfVersion: '1.0'
   - title: The Castles of Burgundy
     bggId: 84876
     language: en
@@ -3006,9 +2994,6 @@ catalog:
     - Vendetta
     - Zhiyanjia
     - Ігромаг
-    pdfBlobKey: rulebooks/v1/hive-pocket_rulebook.pdf
-    pdfSha256: d5dc5809bc293ef53f13b4aa92bbf833d6f7d95852b14bf491a4e2713478d1d5
-    pdfVersion: '1.0'
   - title: Raiders of the North Sea
     bggId: 170042
     language: en
@@ -3207,9 +3192,6 @@ catalog:
     - Hasbro
     - Play Factory
     - PS-Games
-    pdfBlobKey: rulebooks/v1/guillotine_rulebook.pdf
-    pdfSha256: 6272d65910f05a2a9ada9aa79d1247b3d015cc3b2b402d465f32894ef0928b76
-    pdfVersion: '1.0'
   - title: Harmonies
     bggId: 414317
     language: en


### PR DESCRIPTION
Closes #2679.

Coda dell'investigazione dei 6 PDF `Failed` nel seed RAG staging (#2670/#2671). I fallimenti sono di **contenuto**, non del codice (il fix storage-key #2671 funziona: i blob si scaricano).

## Diagnosi
**3 corrotti** (master in `data/rulebook/` compromesso, `pdfUrl: null`):
- `exploding-kittens`, `lost-ruins-of-arnak` → pagina HTML salvata come .pdf
- `betrayal-at-house-on-the-hill` → PDF troncato (no `%%EOF`)

**3 scan-only** (PDF validi, 0 caratteri → serve OCR): `gloomhaven`, `guillotine`, `hive-pocket`. Lo staging usa Docnet locale by design; OCR cloud (`unstructured`/`smoldocling`) è gated su profilo `pdf-cloud-extractors` non attivo.

## Modifica (decisione owner)
Rimossi `pdfBlobKey`/`pdfSha256`/`pdfVersion` dai 6 giochi in `staging.yml` + `prod.yml` + `dev.yml` (18 righe/manifest). **I giochi restano nel catalogo**, senza rulebook indicizzato. OCR resta disabilitato.

Il `PdfSeeder` già skippa i giochi senza blob key (`PdfSeeder.cs:57-66`, coperto da `SeedAsync_ManifestWithoutBlobKey_DoesNothing`). Effetto: `seed_state` raggiunge `failed_pdfs=0` — segnale onesto, allineato al fix #2675.

## Verifica
- YAML valido, 6/6 giochi ancora presenti, con_pdf 136→130.
- 25/25 test unit seeder/manifest verdi (PdfSeederBlob + SeedManifestGameSchema + CatalogSeederManifestOverride).

## Follow-up (fuori scope)
Ri-aggiungere i rulebook richiederebbe: PDF validi da fonte esterna per i 3 corrotti (copyright ADR-059), OCR cloud attivo per i 3 scan-only. Cleanup post-deploy: rimuovere i 6 record `Failed` dal DB staging (guarded).