### PR TITLE
release: #2683 auto-recovery stuck jobs + #2679 rimozione 3 rulebook (re-bake completo)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/Services/ProcessingQueueMonitorService.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/Services/ProcessingQueueMonitorService.cs
@@ -1,4 +1,5 @@
 using Api.BoundedContexts.DocumentProcessing.Application.DTOs;
+using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
 using Api.Infrastructure;
 using Api.Infrastructure.Entities.DocumentProcessing;
 using Microsoft.EntityFrameworkCore;
@@ -37,6 +38,12 @@ internal sealed class ProcessingQueueMonitorService : BackgroundService
 
     private TimeSpan StuckJobTimeout =>
         TimeSpan.FromMinutes(_configuration.GetValue("ProcessingQueueMonitor:StuckJobTimeoutMinutes", 10));
+
+    // Recovery threshold — deliberately higher than the alert threshold so an early
+    // "stuck" warning fires first (10 min) but automatic requeue only kicks in once a
+    // job is clearly dead (30 min), never resetting a job that is merely slow. #2683.
+    private TimeSpan StuckJobRecoveryTimeout =>
+        TimeSpan.FromMinutes(_configuration.GetValue("ProcessingQueueMonitor:StuckJobRecoveryTimeoutMinutes", 30));
 
     private int QueueDepthThreshold =>
         _configuration.GetValue("ProcessingQueueMonitor:QueueDepthThreshold", 20);
@@ -117,6 +124,98 @@ internal sealed class ProcessingQueueMonitorService : BackgroundService
                 DateTimeOffset.UtcNow);
 
             await streamService.PublishQueueEventAsync(evt, ct).ConfigureAwait(false);
+
+            // #2683: once a job is stuck well past the alert threshold, requeue it so the
+            // pipeline can pick it up again. Left unrecovered, a job orphaned by an API
+            // restart mid-processing stays in Processing forever.
+            if (stuckMinutes >= StuckJobRecoveryTimeout.TotalMinutes)
+            {
+                await RecoverStuckJobAsync(db, job.Id, job.FileName, stuckMinutes, ct).ConfigureAwait(false);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Requeues a job that has been stuck in <c>Processing</c> long past the recovery
+    /// threshold. Reuses the existing job row (Processing → Queued, <c>RetryCount</c>++)
+    /// so the counter persists across cycles — once it reaches <c>MaxRetries</c> the job
+    /// and its PDF are marked <c>Failed</c> instead of looping forever. Mirrors the reset
+    /// performed by <c>ReindexDocumentCommandHandler</c> (clear chunks, PDF → Pending).
+    /// </summary>
+    // internal (not private) so ProcessingQueueMonitorRecoveryTests can exercise the
+    // recovery logic directly against an in-memory DbContext (InternalsVisibleTo=Api.Tests).
+    internal async Task RecoverStuckJobAsync(
+        MeepleAiDbContext db,
+        Guid jobId,
+        string fileName,
+        double stuckMinutes,
+        CancellationToken ct)
+    {
+        var job = await db.Set<ProcessingJobEntity>()
+            .Include(j => j.PdfDocument)
+            .FirstOrDefaultAsync(j => j.Id == jobId && j.Status == "Processing", ct)
+            .ConfigureAwait(false);
+
+        // Status changed between the detection query and now — nothing to recover.
+        if (job is null)
+        {
+            return;
+        }
+
+        if (job.RetryCount >= job.MaxRetries)
+        {
+            _logger.LogError(
+                "Stuck PDF {FileName} (job {JobId}) exhausted {Max} recovery attempts after {Minutes:F0} min; marking Failed",
+                fileName, jobId, job.MaxRetries, stuckMinutes);
+
+            var stuckState = job.PdfDocument.ProcessingState;
+            job.Status = "Failed";
+            job.CompletedAt = DateTimeOffset.UtcNow;
+            job.ErrorMessage =
+                $"Processing stalled for {stuckMinutes:F0} min; automatic recovery exhausted ({job.MaxRetries} attempts).";
+            job.PdfDocument.FailedAtState = stuckState;
+            job.PdfDocument.ProcessingState = nameof(PdfProcessingState.Failed);
+            job.PdfDocument.ProcessingError = "Processing stalled and could not be recovered automatically.";
+        }
+        else
+        {
+            _logger.LogWarning(
+                "Recovering stuck PDF {FileName} (job {JobId}) after {Minutes:F0} min; requeue attempt {Attempt}/{Max}",
+                fileName, jobId, stuckMinutes, job.RetryCount + 1, job.MaxRetries);
+
+            // Clear any partial chunks so re-processing does not duplicate them
+            // (same as ReindexDocumentCommandHandler).
+            var chunks = await db.TextChunks
+                .Where(tc => tc.PdfDocumentId == job.PdfDocumentId)
+                .ToListAsync(ct)
+                .ConfigureAwait(false);
+            if (chunks.Count > 0)
+            {
+                db.TextChunks.RemoveRange(chunks);
+            }
+
+            // Reset the PDF to Pending (direct assignment, mirror of reindex).
+            job.PdfDocument.ProcessingState = nameof(PdfProcessingState.Pending);
+            job.PdfDocument.ProcessedAt = null;
+            job.PdfDocument.ProcessingError = null;
+            job.PdfDocument.FailedAtState = null;
+
+            // Reuse the existing job: back to Queued, bump RetryCount for loop-prevention.
+            job.Status = "Queued";
+            job.StartedAt = null;
+            job.CurrentStep = null;
+            job.RetryCount++;
+        }
+
+        try
+        {
+            await db.SaveChangesAsync(ct).ConfigureAwait(false);
+        }
+        catch (DbUpdateConcurrencyException ex)
+        {
+            // Another operation touched the row first — skip; the next cycle re-evaluates.
+            _logger.LogWarning(ex,
+                "Concurrency conflict recovering stuck job {JobId}; will retry next cycle", jobId);
         }
     }
 

--- a/apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/dev.yml
+++ b/apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/dev.yml
@@ -8466,9 +8466,6 @@ catalog:
     - Swan Panasia Co., Ltd.
     - テンデイズゲームズ (TendaysGames)
     - White Goblin Games
-    pdfBlobKey: rulebooks/v1/age-of-innovation_rulebook.pdf
-    pdfSha256: 8f1150d295498a2df9ac6da4de3e73eb7efb2e8da8298aa6377afb1af6dc65e5
-    pdfVersion: '1.0'
   - title: 'Clank!: A Deck-Building Adventure'
     bggId: 201808
     language: en
@@ -8578,9 +8575,6 @@ catalog:
     - Portal Games
     - Reflexshop
     - TLAMA games
-    pdfBlobKey: rulebooks/v1/the-white-castle_rulebook.pdf
-    pdfSha256: dd14099d0194afad2402875e6eb6a27e0b8fbdc631713b16eca1026ad4b225b2
-    pdfVersion: '1.0'
   - title: Paladins of the West Kingdom
     bggId: 266810
     language: en
@@ -8727,9 +8721,6 @@ catalog:
     - Maldito Games
     - sternenschimmermeer
     - YOKA Games
-    pdfBlobKey: rulebooks/v1/the-gallerist_rulebook.pdf
-    pdfSha256: 4c1cc0f09c85177e05e890208a2377ab229a8563976b88e7c5d6f38d7e690dea
-    pdfVersion: '1.0'
   - title: 'Android: Netrunner'
     bggId: 124742
     language: en

--- a/apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/prod.yml
+++ b/apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/prod.yml
@@ -8466,9 +8466,6 @@ catalog:
     - Swan Panasia Co., Ltd.
     - テンデイズゲームズ (TendaysGames)
     - White Goblin Games
-    pdfBlobKey: rulebooks/v1/age-of-innovation_rulebook.pdf
-    pdfSha256: 8f1150d295498a2df9ac6da4de3e73eb7efb2e8da8298aa6377afb1af6dc65e5
-    pdfVersion: '1.0'
   - title: 'Clank!: A Deck-Building Adventure'
     bggId: 201808
     language: en
@@ -8578,9 +8575,6 @@ catalog:
     - Portal Games
     - Reflexshop
     - TLAMA games
-    pdfBlobKey: rulebooks/v1/the-white-castle_rulebook.pdf
-    pdfSha256: dd14099d0194afad2402875e6eb6a27e0b8fbdc631713b16eca1026ad4b225b2
-    pdfVersion: '1.0'
   - title: Paladins of the West Kingdom
     bggId: 266810
     language: en
@@ -8727,9 +8721,6 @@ catalog:
     - Maldito Games
     - sternenschimmermeer
     - YOKA Games
-    pdfBlobKey: rulebooks/v1/the-gallerist_rulebook.pdf
-    pdfSha256: 4c1cc0f09c85177e05e890208a2377ab229a8563976b88e7c5d6f38d7e690dea
-    pdfVersion: '1.0'
   - title: 'Android: Netrunner'
     bggId: 124742
     language: en

--- a/apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/staging.yml
+++ b/apps/api/src/Api/Infrastructure/Seeders/Catalog/Manifests/staging.yml
@@ -8466,9 +8466,6 @@ catalog:
     - Swan Panasia Co., Ltd.
     - テンデイズゲームズ (TendaysGames)
     - White Goblin Games
-    pdfBlobKey: rulebooks/v1/age-of-innovation_rulebook.pdf
-    pdfSha256: 8f1150d295498a2df9ac6da4de3e73eb7efb2e8da8298aa6377afb1af6dc65e5
-    pdfVersion: '1.0'
   - title: 'Clank!: A Deck-Building Adventure'
     bggId: 201808
     language: en
@@ -8578,9 +8575,6 @@ catalog:
     - Portal Games
     - Reflexshop
     - TLAMA games
-    pdfBlobKey: rulebooks/v1/the-white-castle_rulebook.pdf
-    pdfSha256: dd14099d0194afad2402875e6eb6a27e0b8fbdc631713b16eca1026ad4b225b2
-    pdfVersion: '1.0'
   - title: Paladins of the West Kingdom
     bggId: 266810
     language: en
@@ -8727,9 +8721,6 @@ catalog:
     - Maldito Games
     - sternenschimmermeer
     - YOKA Games
-    pdfBlobKey: rulebooks/v1/the-gallerist_rulebook.pdf
-    pdfSha256: 4c1cc0f09c85177e05e890208a2377ab229a8563976b88e7c5d6f38d7e690dea
-    pdfVersion: '1.0'
   - title: 'Android: Netrunner'
     bggId: 124742
     language: en

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Infrastructure/Services/ProcessingQueueMonitorRecoveryTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Infrastructure/Services/ProcessingQueueMonitorRecoveryTests.cs
@@ -1,0 +1,133 @@
+using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
+using Api.BoundedContexts.DocumentProcessing.Infrastructure.Services;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Infrastructure.Entities.DocumentProcessing;
+using Api.Infrastructure.Entities.KnowledgeBase;
+using Api.SharedKernel.Application.Services;
+using Api.Tests.Constants;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.DocumentProcessing.Infrastructure.Services;
+
+/// <summary>
+/// Tests for ProcessingQueueMonitorService.RecoverStuckJobAsync — the #2683 auto-recovery
+/// that requeues jobs orphaned in Processing (e.g. after an API restart mid-pipeline).
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("Issue", "2683")]
+public sealed class ProcessingQueueMonitorRecoveryTests
+{
+    private static MeepleAiDbContext CreateDb(string name)
+    {
+        var options = new DbContextOptionsBuilder<MeepleAiDbContext>()
+            .UseInMemoryDatabase($"StuckRecovery_{name}_{Guid.NewGuid()}")
+            .Options;
+        return new MeepleAiDbContext(options, Mock.Of<IMediator>(), Mock.Of<IDomainEventCollector>());
+    }
+
+    private static ProcessingQueueMonitorService CreateService()
+    {
+        var config = new ConfigurationBuilder().AddInMemoryCollection().Build();
+        return new ProcessingQueueMonitorService(
+            Mock.Of<IServiceScopeFactory>(),
+            config,
+            Mock.Of<ILogger<ProcessingQueueMonitorService>>());
+    }
+
+    private static (PdfDocumentEntity pdf, ProcessingJobEntity job) Seed(
+        MeepleAiDbContext db, string state, int retryCount, int maxRetries, string jobStatus = "Processing")
+    {
+        var pdf = new PdfDocumentEntity
+        {
+            Id = Guid.NewGuid(),
+            FileName = "carcassone_rulebook.pdf",
+            FilePath = "pdfs/x/y_carcassone_rulebook.pdf",
+            UploadedByUserId = Guid.NewGuid(),
+            UploadedAt = DateTime.UtcNow.AddHours(-6),
+            ProcessingState = state,
+            Language = "en",
+        };
+        var job = new ProcessingJobEntity
+        {
+            Id = Guid.NewGuid(),
+            PdfDocumentId = pdf.Id,
+            UserId = pdf.UploadedByUserId,
+            Status = jobStatus,
+            Priority = 0,
+            CurrentStep = "Embedding",
+            CreatedAt = DateTimeOffset.UtcNow.AddHours(-6),
+            StartedAt = DateTimeOffset.UtcNow.AddHours(-6),
+            RetryCount = retryCount,
+            MaxRetries = maxRetries,
+            PdfDocument = pdf,
+        };
+        db.PdfDocuments.Add(pdf);
+        db.Set<ProcessingJobEntity>().Add(job);
+        return (pdf, job);
+    }
+
+    [Fact]
+    public async Task RecoverStuckJobAsync_UnderMaxRetries_RequeuesAndResetsPdfToPending()
+    {
+        await using var db = CreateDb(nameof(RecoverStuckJobAsync_UnderMaxRetries_RequeuesAndResetsPdfToPending));
+        var (pdf, job) = Seed(db, nameof(PdfProcessingState.Embedding), retryCount: 0, maxRetries: 3);
+        db.TextChunks.AddRange(
+            new TextChunkEntity { Id = Guid.NewGuid(), GameId = Guid.NewGuid(), PdfDocumentId = pdf.Id, Content = "partial", ChunkIndex = 0, CharacterCount = 7, CreatedAt = DateTime.UtcNow },
+            new TextChunkEntity { Id = Guid.NewGuid(), GameId = Guid.NewGuid(), PdfDocumentId = pdf.Id, Content = "partial2", ChunkIndex = 1, CharacterCount = 8, CreatedAt = DateTime.UtcNow });
+        await db.SaveChangesAsync();
+
+        await CreateService().RecoverStuckJobAsync(db, job.Id, pdf.FileName, 350.0, CancellationToken.None);
+
+        var reloadedJob = await db.Set<ProcessingJobEntity>().AsNoTracking().FirstAsync(j => j.Id == job.Id);
+        var reloadedPdf = await db.PdfDocuments.AsNoTracking().FirstAsync(p => p.Id == pdf.Id);
+        reloadedJob.Status.Should().Be("Queued");
+        reloadedJob.RetryCount.Should().Be(1, "the recovery bumps RetryCount for loop-prevention");
+        reloadedJob.StartedAt.Should().BeNull();
+        reloadedPdf.ProcessingState.Should().Be(nameof(PdfProcessingState.Pending));
+        reloadedPdf.ProcessingError.Should().BeNull();
+        (await db.TextChunks.CountAsync(c => c.PdfDocumentId == pdf.Id))
+            .Should().Be(0, "partial chunks are cleared before re-processing");
+    }
+
+    [Fact]
+    public async Task RecoverStuckJobAsync_AtMaxRetries_MarksJobAndPdfFailed()
+    {
+        await using var db = CreateDb(nameof(RecoverStuckJobAsync_AtMaxRetries_MarksJobAndPdfFailed));
+        var (pdf, job) = Seed(db, nameof(PdfProcessingState.Embedding), retryCount: 3, maxRetries: 3);
+        await db.SaveChangesAsync();
+
+        await CreateService().RecoverStuckJobAsync(db, job.Id, pdf.FileName, 400.0, CancellationToken.None);
+
+        var reloadedJob = await db.Set<ProcessingJobEntity>().AsNoTracking().FirstAsync(j => j.Id == job.Id);
+        var reloadedPdf = await db.PdfDocuments.AsNoTracking().FirstAsync(p => p.Id == pdf.Id);
+        reloadedJob.Status.Should().Be("Failed", "recovery is exhausted — do not loop forever");
+        reloadedJob.CompletedAt.Should().NotBeNull();
+        reloadedJob.ErrorMessage.Should().Contain("exhausted");
+        reloadedPdf.ProcessingState.Should().Be(nameof(PdfProcessingState.Failed));
+        reloadedPdf.FailedAtState.Should().Be(nameof(PdfProcessingState.Embedding), "the state it was stuck in is preserved");
+    }
+
+    [Fact]
+    public async Task RecoverStuckJobAsync_JobNoLongerProcessing_IsNoOp()
+    {
+        await using var db = CreateDb(nameof(RecoverStuckJobAsync_JobNoLongerProcessing_IsNoOp));
+        // Status changed to Completed between detection and recovery — must not touch it.
+        var (pdf, job) = Seed(db, nameof(PdfProcessingState.Ready), retryCount: 0, maxRetries: 3, jobStatus: "Completed");
+        await db.SaveChangesAsync();
+
+        await CreateService().RecoverStuckJobAsync(db, job.Id, pdf.FileName, 350.0, CancellationToken.None);
+
+        var reloadedJob = await db.Set<ProcessingJobEntity>().AsNoTracking().FirstAsync(j => j.Id == job.Id);
+        var reloadedPdf = await db.PdfDocuments.AsNoTracking().FirstAsync(p => p.Id == pdf.Id);
+        reloadedJob.Status.Should().Be("Completed", "only Processing jobs are recovered");
+        reloadedPdf.ProcessingState.Should().Be(nameof(PdfProcessingState.Ready));
+    }
+}


### PR DESCRIPTION
Release main-dev -> main-staging (2 commit).

- #2683 (PR #2684): auto-recovery dei job stuck in ProcessingQueueMonitorService. Al deploy, i 4 PDF zombie fermi in Embedding da 350+ min si auto-recuperano (soglia recovery 30 min) e ri-processano. Previene futuri orfani da deploy concorrenti.
- #2679 est. (PR #2682): rimuove 3 rulebook non-indicizzabili aggiuntivi (the-gallerist corrotto, age-of-innovation + the-white-castle scan-only) emersi dal re-bake completo.

Nessun cambio AI service. Deploy staging automatico al merge. Post-deploy: cleanup dei 3 record Failed contenuto dal DB + verifica auto-recovery dei 4 zombie.