### PR TITLE
fix(concurrency): #2690 convert AlertChannel/AppBudget/GameToolkit RowVersion to xmin

### DIFF
--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/AlertChannels/UpsertAlertChannelCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/AlertChannels/UpsertAlertChannelCommand.cs
@@ -8,19 +8,19 @@ namespace Api.BoundedContexts.Administration.Application.Commands.AlertChannels;
 ///
 /// <para>The channel <see cref="Type"/> is part of the URL
 /// (PUT /admin/alert-channels/{type}) and acts as the natural key. The
-/// <see cref="RowVersion"/> field carries the Postgres xmin token; pass
-/// an empty string for first-time creation. Returning a stale token on update
+/// <see cref="Xmin"/> field carries the Postgres xmin token; pass
+/// <c>null</c> for first-time creation. Supplying a stale token on update
 /// surfaces as a 409 ConflictException.</para>
 /// </summary>
 internal sealed record UpsertAlertChannelCommand(
     string Type,
     string ConfigJson,
     bool IsEnabled,
-    string? RowVersion,
+    uint? Xmin,
     string UpdatedBy) : IRequest<AlertChannelUpsertResult>;
 
 /// <summary>Result returned to the endpoint after a successful upsert.</summary>
-internal sealed record AlertChannelUpsertResult(string Type, DateTime UpdatedAt, string RowVersion);
+internal sealed record AlertChannelUpsertResult(string Type, DateTime UpdatedAt, uint Xmin);
 
 internal sealed class UpsertAlertChannelCommandValidator : AbstractValidator<UpsertAlertChannelCommand>
 {

--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/AlertChannels/UpsertAlertChannelCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/AlertChannels/UpsertAlertChannelCommandHandler.cs
@@ -30,29 +30,12 @@ internal sealed class UpsertAlertChannelCommandHandler
         }
         else
         {
-            // Carry the RowVersion supplied by the client back into the aggregate
+            // Carry the xmin token supplied by the client back into the aggregate
             // so the repository can detect a concurrent update via Entry.OriginalValues.
             existing.UpdateConfig(request.ConfigJson, request.IsEnabled, request.UpdatedBy);
-            if (!string.IsNullOrEmpty(request.RowVersion))
+            if (request.Xmin.HasValue)
             {
-                var tokenBytes = TryDecodeRowVersion(request.RowVersion);
-                if (tokenBytes is not null)
-                {
-                    // We reconstitute a copy with the client-supplied token —
-                    // necessary because UpdateConfig doesn't touch RowVersion.
-                    existing = AlertChannel.Reconstitute(
-                        existing.Type,
-                        existing.ConfigJson,
-                        existing.IsEnabled,
-                        existing.LastTestedAt,
-                        existing.LastTestStatus,
-                        existing.LastTestMessage,
-                        existing.CreatedAt,
-                        existing.UpdatedAt,
-                        existing.CreatedBy,
-                        existing.UpdatedBy,
-                        tokenBytes);
-                }
+                existing.SetXmin(request.Xmin.Value);
             }
             aggregate = existing;
         }
@@ -68,25 +51,13 @@ internal sealed class UpsertAlertChannelCommandHandler
                 ex);
         }
 
-        // Re-fetch to surface the freshly-bumped RowVersion to the client.
+        // Re-fetch to surface the freshly-bumped xmin to the client.
         var refreshed = await _repository.GetByTypeAsync(type, cancellationToken).ConfigureAwait(false)
             ?? throw new NotFoundException("AlertChannel", request.Type);
 
         return new AlertChannelUpsertResult(
             Type: request.Type.ToLowerInvariant(),
             UpdatedAt: refreshed.UpdatedAt,
-            RowVersion: Convert.ToBase64String(refreshed.RowVersion ?? Array.Empty<byte>()));
-    }
-
-    private static byte[]? TryDecodeRowVersion(string base64)
-    {
-        try
-        {
-            return Convert.FromBase64String(base64);
-        }
-        catch (FormatException)
-        {
-            return null;
-        }
+            Xmin: refreshed.Xmin);
     }
 }

--- a/apps/api/src/Api/BoundedContexts/Administration/Application/EventHandlers/ChannelDispatchHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/EventHandlers/ChannelDispatchHandler.cs
@@ -131,7 +131,7 @@ internal sealed class ChannelDispatchHandler : INotificationHandler<AlertFiredEv
 
             // Issue #1941 / iso-2 Fix 1: only mark dispatched on real (non-dry-run, non-test)
             // alerts that completed without throwing. Concurrency: parallel sibling channels
-            // each upsert their own row, so RowVersion contention is bounded per-channel.
+            // each upsert their own row, so xmin contention is bounded per-channel.
             if (!notification.IsDryRun && !notification.IsTest)
             {
                 channel.MarkDispatched(notification.EventId);

--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Queries/AlertChannels/GetAllAlertChannelsQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Queries/AlertChannels/GetAllAlertChannelsQuery.cs
@@ -23,4 +23,4 @@ internal sealed record AlertChannelDto(
     string? LastTestMessage,
     DateTime UpdatedAt,
     string? UpdatedBy,
-    string RowVersion);
+    uint Xmin);

--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Queries/AlertChannels/GetAllAlertChannelsQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Queries/AlertChannels/GetAllAlertChannelsQueryHandler.cs
@@ -29,5 +29,5 @@ internal sealed class GetAllAlertChannelsQueryHandler
         LastTestMessage: c.LastTestMessage,
         UpdatedAt: c.UpdatedAt,
         UpdatedBy: c.UpdatedBy,
-        RowVersion: Convert.ToBase64String(c.RowVersion ?? Array.Empty<byte>()));
+        Xmin: c.Xmin);
 }

--- a/apps/api/src/Api/BoundedContexts/Administration/Domain/Aggregates/AlertChannel/AlertChannel.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Domain/Aggregates/AlertChannel/AlertChannel.cs
@@ -11,9 +11,9 @@ namespace Api.BoundedContexts.Administration.Domain.Aggregates.AlertChannels;
 /// Email) plus the most recent test-connection outcome surfaced in the
 /// admin Canali drawer.</para>
 ///
-/// <para>RowVersion enables optimistic-concurrency protection for the
-/// admin-edit flow: two simultaneous admins editing the same channel will
-/// get a 409 ConflictException via <c>DbUpdateConcurrencyException</c>
+/// <para>The <c>xmin</c> token (<see cref="Xmin"/>) enables optimistic-concurrency
+/// protection for the admin-edit flow: two simultaneous admins editing the same
+/// channel will get a 409 ConflictException via <c>DbUpdateConcurrencyException</c>
 /// translation in the upsert command handler.</para>
 /// </summary>
 internal sealed class AlertChannel
@@ -57,10 +57,15 @@ internal sealed class AlertChannel
     /// </summary>
     public Guid? LastDispatchedEventId { get; private set; }
 
-    /// <summary>SQL Server / Postgres optimistic concurrency token.
-    /// Repository populates this from <c>xmin</c> via EF's <c>[Timestamp]</c>
-    /// equivalent (<see cref="Microsoft.EntityFrameworkCore.Metadata.Builders.PropertyBuilder.IsRowVersion"/>).</summary>
-    public byte[] RowVersion { get; private set; } = Array.Empty<byte>();
+    /// <summary>Postgres <c>xmin</c> optimistic-concurrency token. Server-owned; the
+    /// repository round-trips it for the detached in-place update (ADR-060). Zero until
+    /// the row is first read back from Postgres.</summary>
+    public uint Xmin { get; private set; }
+
+    /// <summary>Repository/handler-only: restore the xmin token after loading from
+    /// persistence, or override it with a client-supplied stale token for concurrency
+    /// checking on the upsert path.</summary>
+    internal void SetXmin(uint xmin) => Xmin = xmin;
 
     private AlertChannel() { /* EF Core / reconstitution */ }
 
@@ -98,7 +103,7 @@ internal sealed class AlertChannel
         return new AlertChannel(type, configJson, isEnabled, now, now, createdBy, createdBy);
     }
 
-    /// <summary>Repository-only reconstitution; preserves stored RowVersion and timestamps.</summary>
+    /// <summary>Repository-only reconstitution; preserves stored xmin and timestamps.</summary>
     public static AlertChannel Reconstitute(
         AlertChannelType type,
         string configJson,
@@ -110,7 +115,7 @@ internal sealed class AlertChannel
         DateTime updatedAt,
         string? createdBy,
         string? updatedBy,
-        byte[] rowVersion,
+        uint xmin,
         Guid? lastDispatchedEventId = null)
     {
         return new AlertChannel(type, configJson, isEnabled, createdAt, updatedAt, createdBy, updatedBy)
@@ -118,7 +123,7 @@ internal sealed class AlertChannel
             LastTestedAt = lastTestedAt,
             LastTestStatus = lastTestStatus,
             LastTestMessage = lastTestMessage,
-            RowVersion = rowVersion ?? Array.Empty<byte>(),
+            Xmin = xmin,
             LastDispatchedEventId = lastDispatchedEventId,
         };
     }

--- a/apps/api/src/Api/BoundedContexts/Administration/Domain/Repositories/IAlertChannelRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Domain/Repositories/IAlertChannelRepository.cs
@@ -16,7 +16,7 @@ internal interface IAlertChannelRepository
     /// <summary>
     /// Upserts a channel. When the channel already exists the implementation
     /// MUST enforce optimistic concurrency via the aggregate's
-    /// <see cref="AlertChannel.RowVersion"/> token (translated to
+    /// <see cref="AlertChannel.Xmin"/> token (translated to
     /// <c>DbUpdateConcurrencyException</c> by EF Core).
     /// </summary>
     Task UpsertAsync(AlertChannel channel, CancellationToken cancellationToken = default);

--- a/apps/api/src/Api/BoundedContexts/Administration/Infrastructure/Repositories/AlertChannelRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Infrastructure/Repositories/AlertChannelRepository.cs
@@ -73,9 +73,9 @@ internal sealed class AlertChannelRepository : RepositoryBase, IAlertChannelRepo
         else
         {
             // Force EF to check the concurrency token: assigning the original
-            // RowVersion via Entry.OriginalValues makes DbUpdateConcurrencyException
+            // xmin via Entry.OriginalValues makes DbUpdateConcurrencyException
             // fire when another admin has bumped xmin since the aggregate was loaded.
-            DbContext.Entry(tracked).Property(p => p.RowVersion).OriginalValue = channel.RowVersion;
+            DbContext.Entry(tracked).Property(p => p.Xmin).OriginalValue = channel.Xmin;
 
             tracked.ConfigJson = channel.ConfigJson;
             tracked.IsEnabled = channel.IsEnabled;
@@ -102,6 +102,6 @@ internal sealed class AlertChannelRepository : RepositoryBase, IAlertChannelRepo
             e.UpdatedAt,
             e.CreatedBy,
             e.UpdatedBy,
-            e.RowVersion,
+            e.Xmin,
             e.LastDispatchedEventId);
 }

--- a/apps/api/src/Api/BoundedContexts/BusinessSimulations/Application/Commands/AppBudget/UpsertAppBudgetCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/BusinessSimulations/Application/Commands/AppBudget/UpsertAppBudgetCommand.cs
@@ -6,8 +6,8 @@ namespace Api.BoundedContexts.BusinessSimulations.Application.Commands.AppBudget
 /// <summary>
 /// Creates or updates the singleton AppBudget (Issue #1838 SP5 F4-C5).
 ///
-/// <para>The <see cref="RowVersion"/> field carries the Postgres xmin token
-/// returned by GET; pass <c>null</c> or empty for first-time creation.
+/// <para>The <see cref="Xmin"/> field carries the Postgres xmin token
+/// returned by GET; pass <c>null</c> for first-time creation.
 /// Returning a stale token on update surfaces as a 409 ConflictException via
 /// <see cref="Api.Middleware.Exceptions.ConflictException"/>.</para>
 /// </summary>
@@ -16,14 +16,14 @@ internal sealed record UpsertAppBudgetCommand(
     string MonthlyLimitCurrency,
     int AlertThresholdPct,
     int CriticalThresholdPct,
-    string? RowVersion,
+    uint? Xmin,
     string UpdatedBy) : IRequest<AppBudgetUpsertResult>;
 
 /// <summary>Result returned to the endpoint after a successful upsert.</summary>
 internal sealed record AppBudgetUpsertResult(
     Guid Id,
     DateTime UpdatedAt,
-    string RowVersion);
+    uint Xmin);
 
 internal sealed class UpsertAppBudgetCommandValidator : AbstractValidator<UpsertAppBudgetCommand>
 {

--- a/apps/api/src/Api/BoundedContexts/BusinessSimulations/Application/Commands/AppBudget/UpsertAppBudgetCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/BusinessSimulations/Application/Commands/AppBudget/UpsertAppBudgetCommandHandler.cs
@@ -42,26 +42,12 @@ internal sealed class UpsertAppBudgetCommandHandler
                 request.CriticalThresholdPct,
                 request.UpdatedBy);
 
-            if (!string.IsNullOrEmpty(request.RowVersion))
+            if (request.Xmin.HasValue)
             {
-                var tokenBytes = TryDecodeRowVersion(request.RowVersion);
-                if (tokenBytes is not null)
-                {
-                    // Reconstitute a copy carrying the client-supplied token so
-                    // the repository can detect a concurrent update via
-                    // Entry.OriginalValues — UpdateLimit doesn't touch RowVersion.
-                    existing = AppBudgetAggregate.Reconstitute(
-                        existing.Id,
-                        existing.MonthlyLimit,
-                        existing.AlertThresholdPct,
-                        existing.CriticalThresholdPct,
-                        existing.IsEnabled,
-                        existing.CreatedAt,
-                        existing.UpdatedAt,
-                        existing.CreatedBy,
-                        existing.UpdatedBy,
-                        tokenBytes);
-                }
+                // Carry the client-supplied token so the repository can detect a
+                // concurrent update via Entry.OriginalValue — UpdateLimit doesn't
+                // touch Xmin.
+                existing.SetXmin(request.Xmin.Value);
             }
             aggregate = existing;
         }
@@ -77,25 +63,13 @@ internal sealed class UpsertAppBudgetCommandHandler
                 ex);
         }
 
-        // Re-fetch to surface the freshly-bumped RowVersion to the client.
+        // Re-fetch to surface the freshly-bumped xmin to the client.
         var refreshed = await _repository.GetCurrentAsync(cancellationToken).ConfigureAwait(false)
             ?? throw new NotFoundException("AppBudget");
 
         return new AppBudgetUpsertResult(
             Id: refreshed.Id,
             UpdatedAt: refreshed.UpdatedAt,
-            RowVersion: Convert.ToBase64String(refreshed.RowVersion ?? Array.Empty<byte>()));
-    }
-
-    private static byte[]? TryDecodeRowVersion(string base64)
-    {
-        try
-        {
-            return Convert.FromBase64String(base64);
-        }
-        catch (FormatException)
-        {
-            return null;
-        }
+            Xmin: refreshed.Xmin);
     }
 }

--- a/apps/api/src/Api/BoundedContexts/BusinessSimulations/Application/Queries/AppBudget/GetAppBudgetQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/BusinessSimulations/Application/Queries/AppBudget/GetAppBudgetQuery.cs
@@ -26,7 +26,7 @@ internal sealed record AppBudgetDto(
     int DaysRemaining,
     DateTime UpdatedAt,
     string? UpdatedBy,
-    string RowVersion);
+    uint Xmin);
 
 /// <summary>Computed spend KPIs for the current calendar month + today.</summary>
 internal sealed record SpendBreakdownDto(

--- a/apps/api/src/Api/BoundedContexts/BusinessSimulations/Application/Queries/AppBudget/GetAppBudgetQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/BusinessSimulations/Application/Queries/AppBudget/GetAppBudgetQueryHandler.cs
@@ -55,7 +55,7 @@ internal sealed class GetAppBudgetQueryHandler : IRequestHandler<GetAppBudgetQue
             DaysRemaining: daysRemaining,
             UpdatedAt: budget.UpdatedAt,
             UpdatedBy: budget.UpdatedBy,
-            RowVersion: Convert.ToBase64String(budget.RowVersion ?? Array.Empty<byte>()));
+            Xmin: budget.Xmin);
     }
 
     private async Task<SpendBreakdownDto> ComputeSpendBreakdownAsync(

--- a/apps/api/src/Api/BoundedContexts/BusinessSimulations/Domain/Aggregates/AppBudget/AppBudget.cs
+++ b/apps/api/src/Api/BoundedContexts/BusinessSimulations/Domain/Aggregates/AppBudget/AppBudget.cs
@@ -17,7 +17,7 @@ namespace Api.BoundedContexts.BusinessSimulations.Domain.Aggregates.AppBudgets;
 /// constraint so the schema stays portable and future-friendly (e.g. multi-
 /// tenant scoping could add a tenant discriminator without redoing migrations).</para>
 ///
-/// <para>RowVersion enables optimistic-concurrency protection: two simultaneous
+/// <para>Xmin enables optimistic-concurrency protection: two simultaneous
 /// admins editing the budget will surface a 409 ConflictException via
 /// <c>DbUpdateConcurrencyException</c> translation in the upsert command handler.</para>
 /// </summary>
@@ -42,10 +42,12 @@ internal sealed class AppBudget
     public string? CreatedBy { get; private set; }
     public string? UpdatedBy { get; private set; }
 
-    /// <summary>SQL Server / Postgres optimistic concurrency token.
-    /// Repository populates this from <c>xmin</c> via EF's <c>[Timestamp]</c>
-    /// equivalent (<see cref="Microsoft.EntityFrameworkCore.Metadata.Builders.PropertyBuilder.IsRowVersion"/>).</summary>
-    public byte[] RowVersion { get; private set; } = Array.Empty<byte>();
+    /// <summary>Postgres xmin optimistic-concurrency token. Server-owned; the repository
+    /// round-trips it for detached update (ADR-060).</summary>
+    public uint Xmin { get; private set; }
+
+    /// <summary>Repository-only: restore the xmin token after loading from persistence.</summary>
+    internal void SetXmin(uint xmin) => Xmin = xmin;
 
     private AppBudget() { /* EF Core / reconstitution */ }
 
@@ -97,7 +99,7 @@ internal sealed class AppBudget
             updatedBy: createdBy);
     }
 
-    /// <summary>Repository-only reconstitution; preserves stored RowVersion and timestamps.</summary>
+    /// <summary>Repository-only reconstitution; preserves stored xmin and timestamps.</summary>
     public static AppBudget Reconstitute(
         Guid id,
         Money monthlyLimit,
@@ -108,14 +110,14 @@ internal sealed class AppBudget
         DateTime updatedAt,
         string? createdBy,
         string? updatedBy,
-        byte[] rowVersion)
+        uint xmin)
     {
         ArgumentNullException.ThrowIfNull(monthlyLimit);
         return new AppBudget(
             id, monthlyLimit, alertThresholdPct, criticalThresholdPct, isEnabled,
             createdAt, updatedAt, createdBy, updatedBy)
         {
-            RowVersion = rowVersion ?? Array.Empty<byte>(),
+            Xmin = xmin,
         };
     }
 

--- a/apps/api/src/Api/BoundedContexts/BusinessSimulations/Domain/Repositories/IAppBudgetRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/BusinessSimulations/Domain/Repositories/IAppBudgetRepository.cs
@@ -19,7 +19,7 @@ internal interface IAppBudgetRepository
     /// <summary>
     /// Upserts the singleton AppBudget. When a row already exists the
     /// implementation MUST enforce optimistic concurrency via the aggregate's
-    /// <see cref="AppBudget.RowVersion"/> token (translated to
+    /// <see cref="AppBudget.Xmin"/> token (translated to
     /// <c>DbUpdateConcurrencyException</c> by EF Core).
     /// </summary>
     Task UpsertAsync(AppBudget budget, CancellationToken cancellationToken = default);

--- a/apps/api/src/Api/BoundedContexts/BusinessSimulations/Infrastructure/Persistence/AppBudgetRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/BusinessSimulations/Infrastructure/Persistence/AppBudgetRepository.cs
@@ -14,7 +14,7 @@ namespace Api.BoundedContexts.BusinessSimulations.Infrastructure.Persistence;
 /// (Issue #1838 SP5 F4-C5). The singleton AppBudget row is detected
 /// application-side: <see cref="UpsertAsync"/> looks for an existing row and
 /// either inserts (first-time config) or in-place updates (admin edit), with
-/// optimistic concurrency enforced by EF's RowVersion convention.
+/// optimistic concurrency enforced by PostgreSQL's xmin system column (ADR-060).
 /// </summary>
 internal sealed class AppBudgetRepository : RepositoryBase, IAppBudgetRepository
 {
@@ -62,10 +62,11 @@ internal sealed class AppBudgetRepository : RepositoryBase, IAppBudgetRepository
         }
         else
         {
-            // Force EF to check the concurrency token: assigning the original
-            // RowVersion via Entry.OriginalValues makes DbUpdateConcurrencyException
-            // fire when another admin has bumped xmin since the aggregate was loaded.
-            DbContext.Entry(tracked).Property(p => p.RowVersion).OriginalValue = budget.RowVersion;
+            // Force EF to check the concurrency token: assigning the client-supplied
+            // xmin via Entry.OriginalValue makes DbUpdateConcurrencyException fire when
+            // another admin has bumped xmin since the aggregate was loaded (the freshly
+            // re-queried `tracked` row already carries the newer xmin).
+            DbContext.Entry(tracked).Property(p => p.Xmin).OriginalValue = budget.Xmin;
 
             tracked.MonthlyLimitAmount = budget.MonthlyLimit.Amount;
             tracked.MonthlyLimitCurrency = budget.MonthlyLimit.Currency;
@@ -90,5 +91,5 @@ internal sealed class AppBudgetRepository : RepositoryBase, IAppBudgetRepository
             e.UpdatedAt,
             e.CreatedBy,
             e.UpdatedBy,
-            e.RowVersion);
+            e.Xmin);
 }

--- a/apps/api/src/Api/Infrastructure/Entities/Administration/AlertChannelEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/Administration/AlertChannelEntity.cs
@@ -30,8 +30,8 @@ public class AlertChannelEntity
     public string? CreatedBy { get; set; }
     public string? UpdatedBy { get; set; }
 
-    /// <summary>EF Core optimistic concurrency token (PostgreSQL <c>xmin</c>).</summary>
-    public byte[] RowVersion { get; set; } = Array.Empty<byte>();
+    /// <summary>EF Core optimistic concurrency token (PostgreSQL <c>xmin</c> system column).</summary>
+    public uint Xmin { get; set; }
 
     /// <summary>Issue #1941 / iso-2 Fix 1: dedup key for AlertFiredEvent dispatch per channel.</summary>
     public Guid? LastDispatchedEventId { get; set; }

--- a/apps/api/src/Api/Infrastructure/Entities/BusinessSimulations/AppBudgetEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/BusinessSimulations/AppBudgetEntity.cs
@@ -28,6 +28,6 @@ public class AppBudgetEntity
     public string? CreatedBy { get; set; }
     public string? UpdatedBy { get; set; }
 
-    /// <summary>EF Core optimistic concurrency token (PostgreSQL <c>xmin</c>).</summary>
-    public byte[] RowVersion { get; set; } = Array.Empty<byte>();
+    /// <summary>EF Core optimistic concurrency token (PostgreSQL <c>xmin</c> system column).</summary>
+    public uint Xmin { get; set; }
 }

--- a/apps/api/src/Api/Infrastructure/Entities/GameToolkit/GameToolkitEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/GameToolkit/GameToolkitEntity.cs
@@ -72,8 +72,9 @@ public class GameToolkitEntity
     /// <summary>SemVer-shaped version string (e.g. "2.0.0"). Source of truth for the marketplace surface. Default "0.1.0". Max 50 chars.</summary>
     public string VersionSemver { get; set; } = "0.1.0";
 
-    // Concurrency
-    public byte[] RowVersion { get; set; } = default!;
+    // Concurrency — PostgreSQL xmin system column (ADR-060 pattern).
+    // Read-only, auto-populated by Postgres on every insert/update. No real column.
+    public uint Xmin { get; set; }
 
     // Navigation properties
     public SharedGameEntity? Game { get; set; }

--- a/apps/api/src/Api/Infrastructure/Entities/GameToolkit/ToolkitVersionEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/GameToolkit/ToolkitVersionEntity.cs
@@ -29,8 +29,8 @@ public class ToolkitVersionEntity
     public string? YankReason { get; set; }
     public Guid? YankedBy { get; set; }
 
-    // Concurrency token — mirrors GameToolkitEntity.RowVersion.
-    public byte[] RowVersion { get; set; } = default!;
+    // Concurrency token — PostgreSQL xmin system column (mirrors GameToolkitEntity.Xmin, ADR-060).
+    public uint Xmin { get; set; }
 
     // Navigation
     public GameToolkitEntity? Toolkit { get; set; }

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/Administration/AlertChannelEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/Administration/AlertChannelEntityConfiguration.cs
@@ -63,12 +63,14 @@ internal class AlertChannelEntityConfiguration : IEntityTypeConfiguration<AlertC
             .HasColumnName("updated_by")
             .HasMaxLength(200);
 
-        // Postgres concurrency token — uses xmin system column under the hood.
-        // We map to a bytea column for portability with the EF Core RowVersion
-        // convention used elsewhere in the codebase.
-        builder.Property(e => e.RowVersion)
-            .HasColumnName("row_version")
-            .IsRowVersion()
+        // Optimistic concurrency via PostgreSQL's xmin system column (ADR-060).
+        // xmin is a Postgres system column — EF maps it but does NOT create the column.
+        // ValueGeneratedOnAddOrUpdate tells EF the DB owns the value on every write.
+        // IsConcurrencyToken() makes EF include it in UPDATE … WHERE xmin = @original.
+        builder.Property(e => e.Xmin)
+            .HasColumnName("xmin")
+            .HasColumnType("xid")
+            .ValueGeneratedOnAddOrUpdate()
             .IsConcurrencyToken();
 
         // Issue #1941 / iso-2 Fix 1: dedup key for AlertFiredEvent dispatch per channel.

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/BusinessSimulations/AppBudgetEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/BusinessSimulations/AppBudgetEntityConfiguration.cs
@@ -66,12 +66,14 @@ internal class AppBudgetEntityConfiguration : IEntityTypeConfiguration<AppBudget
             .HasColumnName("updated_by")
             .HasMaxLength(200);
 
-        // Postgres concurrency token — uses xmin system column under the hood.
-        // We map to a bytea column for portability with the EF Core RowVersion
-        // convention used elsewhere in the codebase (mirrors AlertChannelEntity).
-        builder.Property(e => e.RowVersion)
-            .HasColumnName("row_version")
-            .IsRowVersion()
+        // Optimistic concurrency via PostgreSQL's xmin system column (ADR-060).
+        // xmin is a Postgres system column — EF maps it but does NOT create the column.
+        // ValueGeneratedOnAddOrUpdate tells EF the DB owns the value on every write.
+        // IsConcurrencyToken() makes EF include it in UPDATE … WHERE xmin = @p0.
+        builder.Property(e => e.Xmin)
+            .HasColumnName("xmin")
+            .HasColumnType("xid")
+            .ValueGeneratedOnAddOrUpdate()
             .IsConcurrencyToken();
 
         builder.ToTable(t => t.HasCheckConstraint(

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/GameToolkit/GameToolkitEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/GameToolkit/GameToolkitEntityConfiguration.cs
@@ -53,8 +53,15 @@ internal class GameToolkitEntityConfiguration : IEntityTypeConfiguration<GameToo
         builder.Property(e => e.StateTemplate).HasColumnType("jsonb");
         builder.Property(e => e.AgentConfig).HasColumnType("jsonb");
 
-        // Concurrency token
-        builder.Property(e => e.RowVersion).IsRowVersion();
+        // Optimistic concurrency via PostgreSQL's xmin system column (ADR-060).
+        // xmin is a Postgres system column — EF maps it but does NOT create the column.
+        // ValueGeneratedOnAddOrUpdate tells EF the DB owns the value on every write.
+        // IsConcurrencyToken() makes EF include it in UPDATE … WHERE xmin = @p0.
+        builder.Property(e => e.Xmin)
+            .HasColumnName("xmin")
+            .HasColumnType("xid")
+            .ValueGeneratedOnAddOrUpdate()
+            .IsConcurrencyToken();
 
         // FK to SharedGameEntity — optional
         builder.HasOne(e => e.Game)

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/GameToolkit/ToolkitVersionEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/GameToolkit/ToolkitVersionEntityConfiguration.cs
@@ -27,7 +27,13 @@ internal class ToolkitVersionEntityConfiguration : IEntityTypeConfiguration<Tool
         builder.Property(e => e.YankReason).IsRequired(false).HasMaxLength(500);
         builder.Property(e => e.YankedBy).IsRequired(false);
 
-        builder.Property(e => e.RowVersion).IsRowVersion();
+        // Optimistic concurrency via PostgreSQL's xmin system column (ADR-060).
+        // xmin is a Postgres system column — EF maps it but does NOT create the column.
+        builder.Property(e => e.Xmin)
+            .HasColumnName("xmin")
+            .HasColumnType("xid")
+            .ValueGeneratedOnAddOrUpdate()
+            .IsConcurrencyToken();
 
         // FK to GameToolkitEntity. Cascade delete: yanking the parent toolkit
         // (admin hard-delete path, not the normal soft-delete via unpublish)

--- a/apps/api/src/Api/Infrastructure/Migrations/20260706042217_RowVersionToXminSweep.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260706042217_RowVersionToXminSweep.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260706042217_RowVersionToXminSweep")]
+    partial class RowVersionToXminSweep
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260706042217_RowVersionToXminSweep.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260706042217_RowVersionToXminSweep.cs
@@ -1,0 +1,75 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class RowVersionToXminSweep : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // Switch AlertChannel / AppBudget / GameToolkit / ToolkitVersion optimistic
+            // concurrency from the broken bytea RowVersion pattern (EF omits the store-generated
+            // column on INSERT → NULL → 23502) to Postgres's `xmin` system column, mirroring
+            // 20260614113542_LiveSessionRowVersionToXmin. `xmin` is managed by Postgres and must
+            // NOT be created as a real column — EF maps it via .HasColumnType("xid"). The
+            // AddColumn("xmin", ...) operations EF scaffolds here are intentionally removed;
+            // only the legacy bytea columns are dropped.
+            migrationBuilder.DropColumn(
+                name: "RowVersion",
+                table: "ToolkitVersions");
+
+            migrationBuilder.DropColumn(
+                name: "RowVersion",
+                table: "GameToolkits");
+
+            migrationBuilder.DropColumn(
+                name: "row_version",
+                table: "app_budgets");
+
+            migrationBuilder.DropColumn(
+                name: "row_version",
+                table: "alert_channels");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            // Restore the legacy bytea concurrency columns (the reverse of Up). No xmin drop:
+            // xmin is a system column that was never created by Up.
+            migrationBuilder.AddColumn<byte[]>(
+                name: "RowVersion",
+                table: "ToolkitVersions",
+                type: "bytea",
+                rowVersion: true,
+                nullable: false,
+                defaultValue: new byte[0]);
+
+            migrationBuilder.AddColumn<byte[]>(
+                name: "RowVersion",
+                table: "GameToolkits",
+                type: "bytea",
+                rowVersion: true,
+                nullable: false,
+                defaultValue: new byte[0]);
+
+            migrationBuilder.AddColumn<byte[]>(
+                name: "row_version",
+                table: "app_budgets",
+                type: "bytea",
+                rowVersion: true,
+                nullable: false,
+                defaultValue: new byte[0]);
+
+            migrationBuilder.AddColumn<byte[]>(
+                name: "row_version",
+                table: "alert_channels",
+                type: "bytea",
+                rowVersion: true,
+                nullable: false,
+                defaultValue: new byte[0]);
+        }
+    }
+}

--- a/apps/api/src/Api/Routing/AdminBudgetEndpoints.cs
+++ b/apps/api/src/Api/Routing/AdminBudgetEndpoints.cs
@@ -10,7 +10,7 @@ namespace Api.Routing;
 /// Admin endpoints for the singleton AppBudget configuration (Issue #1838 SP5 F4-C5).
 ///
 /// <list type="bullet">
-///   <item><c>GET /api/v1/admin/budget</c> — current limit + computed spend KPIs + RowVersion</item>
+///   <item><c>GET /api/v1/admin/budget</c> — current limit + computed spend KPIs + xmin</item>
 ///   <item><c>PUT /api/v1/admin/budget</c> — upsert limit + alert/critical thresholds (concurrency-checked)</item>
 /// </list>
 ///
@@ -61,7 +61,7 @@ internal static class AdminBudgetEndpoints
                     MonthlyLimitCurrency: request.MonthlyLimitCurrency,
                     AlertThresholdPct: request.AlertThresholdPct,
                     CriticalThresholdPct: request.CriticalThresholdPct,
-                    RowVersion: request.RowVersion,
+                    Xmin: request.Xmin,
                     UpdatedBy: userId);
 
                 var result = await mediator.Send(command, ct).ConfigureAwait(false);
@@ -75,7 +75,7 @@ internal static class AdminBudgetEndpoints
 }
 
 /// <summary>
-/// Request body for <c>PUT /api/v1/admin/budget</c>. RowVersion is omitted on
+/// Request body for <c>PUT /api/v1/admin/budget</c>. Xmin is omitted on
 /// first-time creation; required for in-place updates.
 /// </summary>
 internal sealed record UpsertAppBudgetRequest(
@@ -83,4 +83,4 @@ internal sealed record UpsertAppBudgetRequest(
     string MonthlyLimitCurrency,
     int AlertThresholdPct,
     int CriticalThresholdPct,
-    string? RowVersion);
+    uint? Xmin);

--- a/apps/api/src/Api/Routing/AlertChannelsEndpoints.cs
+++ b/apps/api/src/Api/Routing/AlertChannelsEndpoints.cs
@@ -65,7 +65,7 @@ internal static class AlertChannelsEndpoints
                     Type: type,
                     ConfigJson: request.ConfigJson,
                     IsEnabled: request.IsEnabled,
-                    RowVersion: request.RowVersion,
+                    Xmin: request.Xmin,
                     UpdatedBy: userId);
 
                 var result = await mediator.Send(command, ct).ConfigureAwait(false);
@@ -96,6 +96,6 @@ internal static class AlertChannelsEndpoints
 
 /// <summary>
 /// Request body for <c>PUT /api/v1/admin/alert-channels/{type}</c>.
-/// RowVersion is omitted on first-time creation; required for in-place updates.
+/// Xmin (Postgres concurrency token) is omitted on first-time creation; required for in-place updates.
 /// </summary>
-internal sealed record UpsertAlertChannelRequest(string ConfigJson, bool IsEnabled, string? RowVersion);
+internal sealed record UpsertAlertChannelRequest(string ConfigJson, bool IsEnabled, uint? Xmin);

--- a/apps/api/tests/Api.Tests/BoundedContexts/Administration/Application/Commands/AlertChannels/UpsertAlertChannelCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Administration/Application/Commands/AlertChannels/UpsertAlertChannelCommandHandlerTests.cs
@@ -30,7 +30,7 @@ public sealed class UpsertAlertChannelCommandHandlerTests
             .Callback<AlertChannel, CancellationToken>((c, _) => capture.Add(c))
             .Returns(Task.CompletedTask);
 
-        // Refetch after upsert returns a fresh aggregate w/ RowVersion populated
+        // Refetch after upsert returns a fresh aggregate w/ xmin populated
         _repo.SetupSequence(r => r.GetByTypeAsync(AlertChannelType.Slack, It.IsAny<CancellationToken>()))
             .ReturnsAsync((AlertChannel?)null) // initial lookup
             .ReturnsAsync(AlertChannel.Reconstitute(
@@ -44,20 +44,20 @@ public sealed class UpsertAlertChannelCommandHandlerTests
                 updatedAt: DateTime.UtcNow,
                 createdBy: "admin",
                 updatedBy: "admin",
-                rowVersion: new byte[] { 1, 2, 3 }));
+                xmin: 3u));
 
         var cmd = new UpsertAlertChannelCommand(
             Type: "slack",
             ConfigJson: """{"webhookUrl":"https://hooks.slack.com/X"}""",
             IsEnabled: true,
-            RowVersion: null,
+            Xmin: null,
             UpdatedBy: "admin");
 
         var handler = CreateHandler();
         var result = await handler.Handle(cmd, CancellationToken.None);
 
         result.Type.Should().Be("slack");
-        result.RowVersion.Should().NotBeNullOrEmpty();
+        result.Xmin.Should().NotBe(0u);
         capture.Should().HaveCount(1);
     }
 
@@ -69,7 +69,7 @@ public sealed class UpsertAlertChannelCommandHandlerTests
             """{"webhookUrl":"https://hooks.slack.com/v1"}""",
             true, null, null, null,
             DateTime.UtcNow, DateTime.UtcNow, "admin", "admin",
-            rowVersion: new byte[] { 9, 9, 9 });
+            xmin: 9u);
         _repo.Setup(r => r.GetByTypeAsync(AlertChannelType.Slack, It.IsAny<CancellationToken>()))
             .ReturnsAsync(existing);
         _repo.Setup(r => r.UpsertAsync(It.IsAny<AlertChannel>(), It.IsAny<CancellationToken>()))
@@ -78,7 +78,7 @@ public sealed class UpsertAlertChannelCommandHandlerTests
         var cmd = new UpsertAlertChannelCommand(
             "slack", """{"webhookUrl":"https://hooks.slack.com/v2"}""",
             true,
-            RowVersion: Convert.ToBase64String(new byte[] { 1, 1, 1 }), // STALE
+            Xmin: 1u, // STALE
             UpdatedBy: "admin");
 
         var handler = CreateHandler();
@@ -106,7 +106,7 @@ public sealed class UpsertAlertChannelCommandHandlerTests
                 """{"recipients":["ops@meepleai.dev"]}""",
                 false, null, null, null,
                 DateTime.UtcNow, DateTime.UtcNow, "admin", "admin",
-                new byte[] { 7 }));
+                7u));
 
         var cmd = new UpsertAlertChannelCommand(
             "email", """{"recipients":["ops@meepleai.dev"]}""", false, null, "admin");

--- a/apps/api/tests/Api.Tests/BoundedContexts/Administration/Domain/Aggregates/AlertChannel/AlertChannelTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Administration/Domain/Aggregates/AlertChannel/AlertChannelTests.cs
@@ -124,9 +124,9 @@ public sealed class AlertChannelTests
     }
 
     [Fact]
-    public void Reconstitute_PreservesRowVersionAndAuditFields()
+    public void Reconstitute_PreservesXminAndAuditFields()
     {
-        var rowVersion = new byte[] { 1, 2, 3, 4 };
+        const uint xmin = 42u;
         var createdAt = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         var updatedAt = new DateTime(2026, 6, 4, 12, 0, 0, DateTimeKind.Utc);
         var lastTestedAt = new DateTime(2026, 6, 4, 11, 0, 0, DateTimeKind.Utc);
@@ -142,9 +142,9 @@ public sealed class AlertChannelTests
             updatedAt: updatedAt,
             createdBy: "founder@meepleai.dev",
             updatedBy: "ops@meepleai.dev",
-            rowVersion: rowVersion);
+            xmin: xmin);
 
-        channel.RowVersion.Should().BeEquivalentTo(rowVersion);
+        channel.Xmin.Should().Be(xmin);
         channel.CreatedAt.Should().Be(createdAt);
         channel.UpdatedAt.Should().Be(updatedAt);
         channel.LastTestedAt.Should().Be(lastTestedAt);

--- a/apps/api/tests/Api.Tests/BoundedContexts/BusinessSimulations/Application/Commands/AppBudget/UpsertAppBudgetCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/BusinessSimulations/Application/Commands/AppBudget/UpsertAppBudgetCommandHandlerTests.cs
@@ -13,7 +13,7 @@ namespace Api.Tests.BoundedContexts.BusinessSimulations.Application.Commands.App
 
 /// <summary>
 /// Unit tests for UpsertAppBudgetCommandHandler (Issue #1838 SP5 F4-C5).
-/// Covers create vs update branches, RowVersion plumbing, and 409 translation.
+/// Covers create vs update branches, xmin plumbing, and 409 translation.
 /// </summary>
 [Trait("Category", TestCategories.Unit)]
 [Trait("BoundedContext", "BusinessSimulations")]
@@ -29,7 +29,7 @@ public sealed class UpsertAppBudgetCommandHandlerTests
     {
         _repo.SetupSequence(r => r.GetCurrentAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync((AppBudgetAggregate?)null)
-            .ReturnsAsync(Reconstituted(rowVersion: new byte[] { 1, 2, 3 }));
+            .ReturnsAsync(Reconstituted(xmin: 123u));
 
         var capture = new List<AppBudgetAggregate>();
         _repo.Setup(r => r.UpsertAsync(It.IsAny<AppBudgetAggregate>(), It.IsAny<CancellationToken>()))
@@ -41,7 +41,7 @@ public sealed class UpsertAppBudgetCommandHandlerTests
             MonthlyLimitCurrency: "USD",
             AlertThresholdPct: 80,
             CriticalThresholdPct: 95,
-            RowVersion: null,
+            Xmin: null,
             UpdatedBy: "admin");
 
         var result = await CreateHandler().Handle(cmd, CancellationToken.None);
@@ -49,18 +49,18 @@ public sealed class UpsertAppBudgetCommandHandlerTests
         capture.Should().HaveCount(1);
         capture[0].MonthlyLimit.Amount.Should().Be(1500m);
         capture[0].CreatedBy.Should().Be("admin");
-        result.RowVersion.Should().Be(Convert.ToBase64String(new byte[] { 1, 2, 3 }));
+        result.Xmin.Should().Be(123u);
     }
 
     [Fact]
-    public async Task Handle_WhenBudgetExists_UpdatesAndPropagatesRowVersion()
+    public async Task Handle_WhenBudgetExists_UpdatesAndPropagatesXmin()
     {
-        var existingRowVersion = new byte[] { 5, 5, 5 };
-        var existing = Reconstituted(rowVersion: existingRowVersion);
+        const uint existingXmin = 555u;
+        var existing = Reconstituted(xmin: existingXmin);
 
         _repo.SetupSequence(r => r.GetCurrentAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(existing)
-            .ReturnsAsync(Reconstituted(rowVersion: new byte[] { 6, 6, 6 }));
+            .ReturnsAsync(Reconstituted(xmin: 666u));
 
         var capture = new List<AppBudgetAggregate>();
         _repo.Setup(r => r.UpsertAsync(It.IsAny<AppBudgetAggregate>(), It.IsAny<CancellationToken>()))
@@ -72,7 +72,7 @@ public sealed class UpsertAppBudgetCommandHandlerTests
             MonthlyLimitCurrency: "USD",
             AlertThresholdPct: 70,
             CriticalThresholdPct: 90,
-            RowVersion: Convert.ToBase64String(existingRowVersion),
+            Xmin: existingXmin,
             UpdatedBy: "admin2");
 
         var result = await CreateHandler().Handle(cmd, CancellationToken.None);
@@ -82,19 +82,22 @@ public sealed class UpsertAppBudgetCommandHandlerTests
         capture[0].AlertThresholdPct.Should().Be(70);
         capture[0].CriticalThresholdPct.Should().Be(90);
         capture[0].UpdatedBy.Should().Be("admin2");
-        capture[0].RowVersion.Should().BeEquivalentTo(existingRowVersion,
-            "Handler must reconstitute with client-supplied token for EF concurrency check");
-        result.RowVersion.Should().Be(Convert.ToBase64String(new byte[] { 6, 6, 6 }));
+        capture[0].Xmin.Should().Be(existingXmin,
+            "Handler must carry the client-supplied token for the EF concurrency check");
+        result.Xmin.Should().Be(666u);
     }
 
     [Fact]
-    public async Task Handle_WithMalformedBase64RowVersion_FallsBackToServerToken()
+    public async Task Handle_WithNullXminOnUpdate_UsesServerToken()
     {
-        var existing = Reconstituted(rowVersion: new byte[] { 1 });
+        var existing = Reconstituted(xmin: 42u);
         _repo.SetupSequence(r => r.GetCurrentAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(existing)
-            .ReturnsAsync(Reconstituted(rowVersion: new byte[] { 2 }));
+            .ReturnsAsync(Reconstituted(xmin: 43u));
+
+        var capture = new List<AppBudgetAggregate>();
         _repo.Setup(r => r.UpsertAsync(It.IsAny<AppBudgetAggregate>(), It.IsAny<CancellationToken>()))
+            .Callback<AppBudgetAggregate, CancellationToken>((b, _) => capture.Add(b))
             .Returns(Task.CompletedTask);
 
         var cmd = new UpsertAppBudgetCommand(
@@ -102,19 +105,24 @@ public sealed class UpsertAppBudgetCommandHandlerTests
             MonthlyLimitCurrency: "USD",
             AlertThresholdPct: 80,
             CriticalThresholdPct: 95,
-            RowVersion: "***not-base64***",
+            Xmin: null,
             UpdatedBy: "admin");
 
-        // Should not throw — handler silently falls back to existing aggregate's token
+        // Should not throw — with no client token the handler keeps the
+        // server-loaded aggregate's token.
         var result = await CreateHandler().Handle(cmd, CancellationToken.None);
+
         result.Should().NotBeNull();
+        capture.Should().HaveCount(1);
+        capture[0].Xmin.Should().Be(42u,
+            "with no client token the handler keeps the server-loaded xmin");
     }
 
     [Fact]
     public async Task Handle_OnConcurrencyConflict_Throws409()
     {
         _repo.SetupSequence(r => r.GetCurrentAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(Reconstituted(rowVersion: new byte[] { 1 }));
+            .ReturnsAsync(Reconstituted(xmin: 1u));
 
         _repo.Setup(r => r.UpsertAsync(It.IsAny<AppBudgetAggregate>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new DbUpdateConcurrencyException("Conflict"));
@@ -124,7 +132,7 @@ public sealed class UpsertAppBudgetCommandHandlerTests
             MonthlyLimitCurrency: "USD",
             AlertThresholdPct: 80,
             CriticalThresholdPct: 95,
-            RowVersion: Convert.ToBase64String(new byte[] { 1 }),
+            Xmin: 1u,
             UpdatedBy: "admin");
 
         var act = () => CreateHandler().Handle(cmd, CancellationToken.None);
@@ -148,7 +156,7 @@ public sealed class UpsertAppBudgetCommandHandlerTests
             MonthlyLimitCurrency: "USD",
             AlertThresholdPct: 80,
             CriticalThresholdPct: 95,
-            RowVersion: null,
+            Xmin: null,
             UpdatedBy: "admin");
 
         var act = () => CreateHandler().Handle(cmd, CancellationToken.None);
@@ -156,7 +164,7 @@ public sealed class UpsertAppBudgetCommandHandlerTests
         await act.Should().ThrowAsync<NotFoundException>();
     }
 
-    private static AppBudgetAggregate Reconstituted(byte[] rowVersion) =>
+    private static AppBudgetAggregate Reconstituted(uint xmin) =>
         AppBudgetAggregate.Reconstitute(
             id: Guid.NewGuid(),
             monthlyLimit: Money.Create(1000m, "USD"),
@@ -167,5 +175,5 @@ public sealed class UpsertAppBudgetCommandHandlerTests
             updatedAt: DateTime.UtcNow,
             createdBy: "seed",
             updatedBy: "seed",
-            rowVersion: rowVersion);
+            xmin: xmin);
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/BusinessSimulations/Application/Commands/AppBudget/UpsertAppBudgetCommandValidatorTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/BusinessSimulations/Application/Commands/AppBudget/UpsertAppBudgetCommandValidatorTests.cs
@@ -21,7 +21,7 @@ public sealed class UpsertAppBudgetCommandValidatorTests
         MonthlyLimitCurrency: "USD",
         AlertThresholdPct: 80,
         CriticalThresholdPct: 95,
-        RowVersion: null,
+        Xmin: null,
         UpdatedBy: "admin@meepleai.dev");
 
     [Fact]

--- a/apps/api/tests/Api.Tests/BoundedContexts/BusinessSimulations/Application/Queries/AppBudget/GetAppBudgetQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/BusinessSimulations/Application/Queries/AppBudget/GetAppBudgetQueryHandlerTests.cs
@@ -98,7 +98,10 @@ public sealed class GetAppBudgetQueryHandlerTests : IAsyncLifetime
         result.Spent.ProjectedMonthEnd.Should().Be(0m);
         // AnchorToday = 2026-06-01 → 30 - 1 = 29 days remaining in June.
         result.DaysRemaining.Should().Be(29);
-        result.RowVersion.Should().NotBeNull();
+        // In-memory provider doesn't populate the Postgres xmin system column;
+        // the DTO surfaces whatever the repo carried (0 here). Real xmin
+        // round-tripping is covered by the Testcontainers integration suite.
+        result.Xmin.Should().Be(0u);
     }
 
     [Fact]

--- a/apps/api/tests/Api.Tests/BoundedContexts/BusinessSimulations/Domain/Aggregates/AppBudget/AppBudgetTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/BusinessSimulations/Domain/Aggregates/AppBudget/AppBudgetTests.cs
@@ -33,7 +33,7 @@ public sealed class AppBudgetTests
         budget.UpdatedBy.Should().Be("admin@meepleai.dev");
         budget.CreatedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(5));
         budget.UpdatedAt.Should().Be(budget.CreatedAt);
-        budget.RowVersion.Should().BeEmpty("Fresh aggregates have no DB-assigned token yet");
+        budget.Xmin.Should().Be(0u, "Fresh aggregates have no DB-assigned token yet");
     }
 
     [Theory]
@@ -146,10 +146,10 @@ public sealed class AppBudgetTests
     }
 
     [Fact]
-    public void Reconstitute_PreservesRowVersionAndAuditFields()
+    public void Reconstitute_PreservesXminAndAuditFields()
     {
         var id = Guid.NewGuid();
-        var rowVersion = new byte[] { 9, 8, 7, 6 };
+        const uint xmin = 987u;
         var createdAt = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
         var updatedAt = new DateTime(2026, 6, 5, 12, 0, 0, DateTimeKind.Utc);
 
@@ -163,7 +163,7 @@ public sealed class AppBudgetTests
             updatedAt: updatedAt,
             createdBy: "founder@meepleai.dev",
             updatedBy: "ops@meepleai.dev",
-            rowVersion: rowVersion);
+            xmin: xmin);
 
         budget.Id.Should().Be(id);
         budget.MonthlyLimit.Amount.Should().Be(1500m);
@@ -174,11 +174,11 @@ public sealed class AppBudgetTests
         budget.UpdatedAt.Should().Be(updatedAt);
         budget.CreatedBy.Should().Be("founder@meepleai.dev");
         budget.UpdatedBy.Should().Be("ops@meepleai.dev");
-        budget.RowVersion.Should().BeEquivalentTo(rowVersion);
+        budget.Xmin.Should().Be(xmin);
     }
 
     [Fact]
-    public void Reconstitute_WithNullRowVersion_DefaultsToEmptyBytes()
+    public void Reconstitute_WithZeroXmin_YieldsZeroToken()
     {
         var budget = AppBudgetAggregate.Reconstitute(
             Guid.NewGuid(),
@@ -190,9 +190,8 @@ public sealed class AppBudgetTests
             updatedAt: DateTime.UtcNow,
             createdBy: "x",
             updatedBy: "x",
-            rowVersion: null!);
+            xmin: 0u);
 
-        budget.RowVersion.Should().NotBeNull();
-        budget.RowVersion.Should().BeEmpty();
+        budget.Xmin.Should().Be(0u);
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameToolkit/Application/Commands/PublishToolkitVersionCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameToolkit/Application/Commands/PublishToolkitVersionCommandHandlerTests.cs
@@ -76,9 +76,7 @@ public class PublishToolkitVersionCommandHandlerTests
             IsPublished = isPublished,
             TemplateStatus = (int)TemplateStatus.Approved,
             CreatedAt = Now,
-            UpdatedAt = Now,
-            RowVersion = [0],
-        };
+            UpdatedAt = Now,        };
 #pragma warning restore CS0618
         context.GameToolkits.Add(toolkit);
         return toolkit;

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameToolkit/Application/Commands/YankToolkitVersionCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameToolkit/Application/Commands/YankToolkitVersionCommandHandlerTests.cs
@@ -71,9 +71,7 @@ public class YankToolkitVersionCommandHandlerTests
             IsPublished = isPublished,
             TemplateStatus = (int)TemplateStatus.Approved,
             CreatedAt = Now,
-            UpdatedAt = Now,
-            RowVersion = [0],
-        };
+            UpdatedAt = Now,        };
 #pragma warning restore CS0618
         context.GameToolkits.Add(toolkit);
         return toolkit;
@@ -94,9 +92,7 @@ public class YankToolkitVersionCommandHandlerTests
             PublishedBy = AuthorId,
             YankedAt = yanked ? Now.AddHours(-1) : null,
             YankReason = yanked ? "Earlier yank" : null,
-            YankedBy = yanked ? AuthorId : null,
-            RowVersion = [0],
-        };
+            YankedBy = yanked ? AuthorId : null,        };
         context.Set<ToolkitVersionEntity>().Add(row);
         return row;
     }

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameToolkit/Application/Queries/GetSystemPromptQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameToolkit/Application/Queries/GetSystemPromptQueryHandlerTests.cs
@@ -67,9 +67,7 @@ public class GetSystemPromptQueryHandlerTests
             TemplateStatus = (int)TemplateStatus.Approved,
             CreatedAt = Now,
             UpdatedAt = Now,
-            AgentConfig = agentConfig,
-            RowVersion = [0],
-        };
+            AgentConfig = agentConfig,        };
 #pragma warning restore CS0618
         context.GameToolkits.Add(toolkit);
         return toolkit;

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameToolkit/Application/Queries/GetToolkitDetailQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameToolkit/Application/Queries/GetToolkitDetailQueryHandlerTests.cs
@@ -95,9 +95,7 @@ public class GetToolkitDetailQueryHandlerTests
             IsPublished = true,
             TemplateStatus = (int)TemplateStatus.Approved,
             CreatedAt = DateTime.UtcNow,
-            UpdatedAt = DateTime.UtcNow,
-            RowVersion = [0],
-        };
+            UpdatedAt = DateTime.UtcNow,        };
 #pragma warning restore CS0618
         configure?.Invoke(toolkit);
         context.GameToolkits.Add(toolkit);
@@ -339,9 +337,7 @@ public class GetToolkitDetailQueryHandlerTests
             // outcome by setting both in the same in-memory write.
             VersionSemver = "0.5.0",
             CreatedAt = DateTime.UtcNow,
-            UpdatedAt = DateTime.UtcNow,
-            RowVersion = [0],
-        };
+            UpdatedAt = DateTime.UtcNow,        };
         context.GameToolkits.Add(entity);
         await context.SaveChangesAsync();
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameToolkit/Application/Queries/GetToolkitVersionsQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameToolkit/Application/Queries/GetToolkitVersionsQueryHandlerTests.cs
@@ -67,9 +67,7 @@ public class GetToolkitVersionsQueryHandlerTests
             IsPublished = isPublished,
             TemplateStatus = (int)TemplateStatus.Approved,
             CreatedAt = Now,
-            UpdatedAt = Now,
-            RowVersion = [0],
-        };
+            UpdatedAt = Now,        };
 #pragma warning restore CS0618
         context.GameToolkits.Add(toolkit);
         return toolkit;

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Queries/GetActiveSessionQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Queries/GetActiveSessionQueryHandlerTests.cs
@@ -92,9 +92,7 @@ public sealed class GetActiveSessionQueryHandlerTests : IDisposable
             GameId = gameId,
             Name = "Test Toolkit",
             CreatedByUserId = userId,
-            IsPublished = true,
-            RowVersion = [0],
-            // camelCase JSON matching JsonNamingPolicy.CamelCase used by repository
+            IsPublished = true,            // camelCase JSON matching JsonNamingPolicy.CamelCase used by repository
             TurnTemplateJson = "{\"turnOrderType\":3,\"phases\":[]}"
         });
 
@@ -166,9 +164,7 @@ public sealed class GetActiveSessionQueryHandlerTests : IDisposable
             GameId = gameId,
             Name = "Toolkit No Turn",
             CreatedByUserId = userId,
-            IsPublished = true,
-            RowVersion = [0],
-            TurnTemplateJson = null
+            IsPublished = true,            TurnTemplateJson = null
         });
 
         _db.SessionTrackingSessions.Add(new SessionEntity

--- a/apps/api/tests/Api.Tests/Integration/Administration/AlertChannelRepositoryIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/Administration/AlertChannelRepositoryIntegrationTests.cs
@@ -19,7 +19,7 @@ namespace Api.Tests.Integration.Administration;
 /// Testcontainers PostgreSQL instance (Issue #1840 SP5 F4-C7).
 ///
 /// Covers: insert-on-upsert, update-on-upsert, GetByType, GetAll, optimistic
-/// concurrency via stale RowVersion.
+/// concurrency via stale xmin.
 /// </summary>
 [Collection("Integration-GroupD")]
 [Trait("Category", TestCategories.Integration)]
@@ -101,7 +101,7 @@ public sealed class AlertChannelRepositoryIntegrationTests : IAsyncLifetime
         fetched!.Type.Should().Be(AlertChannelType.Slack);
         fetched.IsEnabled.Should().BeTrue();
         fetched.UpdatedBy.Should().Be("admin@meepleai.dev");
-        fetched.RowVersion.Should().NotBeEmpty(
+        fetched.Xmin.Should().NotBe(0u,
             "Postgres xmin must populate the concurrency token on insert");
     }
 
@@ -140,7 +140,7 @@ public sealed class AlertChannelRepositoryIntegrationTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task UpsertAsync_OnStaleRowVersion_ThrowsConcurrencyException()
+    public async Task UpsertAsync_OnStaleXmin_ThrowsConcurrencyException()
     {
         // Admin A and Admin B both load the same channel.
         var initial = AlertChannel.Create(
@@ -153,11 +153,11 @@ public sealed class AlertChannelRepositoryIntegrationTests : IAsyncLifetime
         var loadedByA = await _repository.GetByTypeAsync(AlertChannelType.Slack, TestCancellationToken);
         var loadedByB = await _repository.GetByTypeAsync(AlertChannelType.Slack, TestCancellationToken);
 
-        // Admin A commits first → bumps RowVersion.
+        // Admin A commits first → bumps xmin.
         loadedByA!.UpdateConfig("""{"webhookUrl":"https://hooks.slack.com/v2"}""", true, "adminA");
         await _repository.UpsertAsync(loadedByA, TestCancellationToken);
 
-        // Admin B attempts to commit with the stale RowVersion captured BEFORE
+        // Admin B attempts to commit with the stale xmin captured BEFORE
         // Admin A's update.
         loadedByB!.UpdateConfig("""{"webhookUrl":"https://hooks.slack.com/v3"}""", true, "adminB");
 

--- a/apps/api/tests/Api.Tests/Integration/BusinessSimulations/AppBudgetRepositoryIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/BusinessSimulations/AppBudgetRepositoryIntegrationTests.cs
@@ -19,7 +19,7 @@ namespace Api.Tests.Integration.BusinessSimulations;
 ///
 /// Covers: insert-on-upsert (singleton creation), update-on-upsert (in-place
 /// edit), GetCurrentAsync semantics, optimistic concurrency via stale
-/// RowVersion, and singleton enforcement (second Upsert reuses the same row
+/// xmin, and singleton enforcement (second Upsert reuses the same row
 /// rather than creating a duplicate).
 /// </summary>
 [Collection("Integration-GroupD")]
@@ -113,7 +113,7 @@ public sealed class AppBudgetRepositoryIntegrationTests : IAsyncLifetime
         fetched.IsEnabled.Should().BeTrue();
         fetched.CreatedBy.Should().Be("admin@meepleai.dev");
         fetched.UpdatedBy.Should().Be("admin@meepleai.dev");
-        fetched.RowVersion.Should().NotBeEmpty(
+        fetched.Xmin.Should().NotBe(0u,
             "Postgres xmin must populate the concurrency token on insert");
     }
 
@@ -141,7 +141,7 @@ public sealed class AppBudgetRepositoryIntegrationTests : IAsyncLifetime
     }
 
     [Fact]
-    public async Task UpsertAsync_OnStaleRowVersion_ThrowsConcurrencyException()
+    public async Task UpsertAsync_OnStaleXmin_ThrowsConcurrencyException()
     {
         var initial = AppBudgetAggregate.Create(Money.Create(1000m, "USD"), 80, 95, "admin");
         await _repository!.UpsertAsync(initial, TestCancellationToken);
@@ -150,11 +150,11 @@ public sealed class AppBudgetRepositoryIntegrationTests : IAsyncLifetime
         var loadedByA = await _repository.GetCurrentAsync(TestCancellationToken);
         var loadedByB = await _repository.GetCurrentAsync(TestCancellationToken);
 
-        // Admin A commits first → bumps RowVersion.
+        // Admin A commits first → bumps xmin.
         loadedByA!.UpdateLimit(Money.Create(2000m, "USD"), 80, 95, "adminA");
         await _repository.UpsertAsync(loadedByA, TestCancellationToken);
 
-        // Admin B attempts to commit with the stale RowVersion captured before
+        // Admin B attempts to commit with the stale xmin captured before
         // Admin A's update.
         loadedByB!.UpdateLimit(Money.Create(3000m, "USD"), 80, 95, "adminB");
 

--- a/apps/api/tests/Api.Tests/Integration/Phase4a/RecommendedToolkitsEndpointIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/Phase4a/RecommendedToolkitsEndpointIntegrationTests.cs
@@ -259,8 +259,9 @@ public sealed class RecommendedToolkitsEndpointIntegrationTests : IAsyncLifetime
     /// <summary>
     /// Seeds an authored GameToolkit with explicit createdAt. Mirrors the raw
     /// SQL pattern from <c>ToolkitMarketplaceEndpointsIntegrationTests</c> —
-    /// the row-version + JSONB columns require a raw INSERT to bypass EF's
-    /// store-generated stripping of <c>RowVersion</c>.
+    /// the JSONB columns are seeded via raw INSERT to keep full control of the
+    /// column values. The xmin concurrency token is a Postgres system column,
+    /// auto-populated on insert, so it is never listed in the INSERT.
     /// </summary>
     private static async Task SeedToolkitAsync(
         MeepleAiDbContext dbContext,
@@ -296,8 +297,7 @@ public sealed class RecommendedToolkitsEndpointIntegrationTests : IAsyncLifetime
                 "ScoringTemplateJson", "TurnTemplateJson", "StateTemplate",
                 "AgentConfig",
                 "TemplateStatus", "IsTemplate",
-                "ReviewNotes", "ReviewedByUserId", "ReviewedAt",
-                "RowVersion"
+                "ReviewNotes", "ReviewedByUserId", "ReviewedAt"
             ) VALUES (
                 {0}, {1}, NULL, {2}, 1,
                 {3}, {4},
@@ -308,8 +308,7 @@ public sealed class RecommendedToolkitsEndpointIntegrationTests : IAsyncLifetime
                 NULL, NULL, NULL,
                 NULL,
                 {7}, {8},
-                NULL, NULL, NULL,
-                E'\\x01'
+                NULL, NULL, NULL
             )
             """;
 

--- a/apps/api/tests/Api.Tests/Integration/Phase4b/ToolkitRatingsEndpointIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/Phase4b/ToolkitRatingsEndpointIntegrationTests.cs
@@ -303,8 +303,7 @@ public sealed class ToolkitRatingsEndpointIntegrationTests : IAsyncLifetime
                 "ScoringTemplateJson", "TurnTemplateJson", "StateTemplate",
                 "AgentConfig",
                 "TemplateStatus", "IsTemplate",
-                "ReviewNotes", "ReviewedByUserId", "ReviewedAt",
-                "RowVersion"
+                "ReviewNotes", "ReviewedByUserId", "ReviewedAt"
             ) VALUES (
                 {0}, {1}, NULL, {2}, 1,
                 {3}, {4},
@@ -315,8 +314,7 @@ public sealed class ToolkitRatingsEndpointIntegrationTests : IAsyncLifetime
                 NULL, NULL, NULL,
                 NULL,
                 {7}, {8},
-                NULL, NULL, NULL,
-                E'\\x01'
+                NULL, NULL, NULL
             )
             """;
 

--- a/apps/api/tests/Api.Tests/Integration/ToolkitMarketplace/ToolkitMarketplaceEndpointsIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/ToolkitMarketplace/ToolkitMarketplaceEndpointsIntegrationTests.cs
@@ -727,19 +727,13 @@ public sealed class ToolkitMarketplaceEndpointsIntegrationTests : IAsyncLifetime
     // ──────────────────────────────────────────────────────────────────────
 
     /// <summary>
-    /// Seeds a <see cref="GameToolkitEntity"/> directly via raw SQL because
-    /// EF treats the <c>RowVersion</c> column as <c>IsRowVersion()</c> which
-    /// strips the value from INSERT statements. The migration declares the
-    /// column NOT NULL with no DB-side default, so the EF path produces a
-    /// constraint violation when seeding outside the production aggregate
-    /// repository (which similarly omits RowVersion but is exercised through
-    /// SaveChangesAsync paths that EF rewrites server-side).
-    ///
-    /// Using raw SQL bypasses the EF generator and gives us full control of
-    /// the IsPublished / TemplateStatus combinations needed for the security
-    /// boundary tests (PR #732 §5.2). FK to <see cref="SharedGameEntity"/>
-    /// (via <see cref="GameEntity"/> mapping that points to the SharedGame
-    /// row) is satisfied by inserting a sibling SharedGame first.
+    /// Seeds a <see cref="GameToolkitEntity"/> directly via raw SQL to keep full
+    /// control of the IsPublished / TemplateStatus combinations needed for the
+    /// security boundary tests (PR #732 §5.2). The xmin concurrency token is a
+    /// Postgres system column, auto-populated on insert, so it is never listed
+    /// in the INSERT. FK to <see cref="SharedGameEntity"/> (via the
+    /// <see cref="GameEntity"/> mapping that points to the SharedGame row) is
+    /// satisfied by inserting a sibling SharedGame first.
     /// </summary>
     [Obsolete]
     private static async Task<GameToolkitEntity> SeedToolkitAsync(
@@ -767,13 +761,9 @@ public sealed class ToolkitMarketplaceEndpointsIntegrationTests : IAsyncLifetime
         var templateStatusInt = (int)templateStatus;
         var isTemplate = templateStatus == TemplateStatus.Approved;
 
-        // Raw INSERT that explicitly sets RowVersion. EF treats RowVersion as
-        // store-generated under IsRowVersion(), which strips the value during
-        // INSERT and produces a NOT-NULL violation when seeding outside the
-        // production aggregate path. The aggregate's repository takes the same
-        // path through SaveChangesAsync but EF's update pipeline rewrites the
-        // RowVersion side-effect for IsRowVersion()-tagged properties — that
-        // does not happen for raw entity inserts via Add() in tests.
+        // Raw INSERT keeps full control of the seeded columns. The xmin
+        // concurrency token is a Postgres system column, auto-populated on
+        // insert, so it is not listed here.
         //
         // We embed the agentConfig literal directly when present (escaping
         // single quotes for SQL safety AND escaping curly braces because the
@@ -796,8 +786,7 @@ public sealed class ToolkitMarketplaceEndpointsIntegrationTests : IAsyncLifetime
                 "ScoringTemplateJson", "TurnTemplateJson", "StateTemplate",
                 "AgentConfig",
                 "TemplateStatus", "IsTemplate",
-                "ReviewNotes", "ReviewedByUserId", "ReviewedAt",
-                "RowVersion"
+                "ReviewNotes", "ReviewedByUserId", "ReviewedAt"
             ) VALUES (
                 {0}, {1}, NULL, {2}, 1,
                 {3}, {4},
@@ -808,8 +797,7 @@ public sealed class ToolkitMarketplaceEndpointsIntegrationTests : IAsyncLifetime
                 NULL, NULL, NULL,
                 {{agentConfigSql}},
                 {7}, {8},
-                NULL, NULL, NULL,
-                E'\\x01'
+                NULL, NULL, NULL
             )
             """;
 
@@ -838,7 +826,6 @@ public sealed class ToolkitMarketplaceEndpointsIntegrationTests : IAsyncLifetime
             TemplateStatus = templateStatusInt,
             IsTemplate = isTemplate,
             AgentConfig = agentConfig,
-            RowVersion = new byte[] { 1 },
         };
     }
 }

--- a/apps/web/src/components/admin/alert-rules/CanaliDrawer.tsx
+++ b/apps/web/src/components/admin/alert-rules/CanaliDrawer.tsx
@@ -139,7 +139,7 @@ function SlackPanel({
         body: {
           configJson: JSON.stringify(config),
           isEnabled: true,
-          rowVersion: channel?.rowVersion ?? null,
+          xmin: channel?.xmin ?? null,
         },
       });
       toast.success('Canale Slack salvato');
@@ -299,7 +299,7 @@ function EmailPanel({
         body: {
           configJson: JSON.stringify(config),
           isEnabled: true,
-          rowVersion: channel?.rowVersion ?? null,
+          xmin: channel?.xmin ?? null,
         },
       });
       toast.success('Canale Email salvato');

--- a/apps/web/src/components/admin/business/SetBudgetDialog.tsx
+++ b/apps/web/src/components/admin/business/SetBudgetDialog.tsx
@@ -7,7 +7,7 @@
  * Pre-popolato con i valori correnti se il budget è già configurato; vuoto sulla
  * prima visita (Scenario I empty state).
  *
- * Concurrency: passa il `rowVersion` corrente al PUT — il backend ritorna 409
+ * Concurrency: passa il `xmin` corrente al PUT — il backend ritorna 409
  * ConflictException se un altro admin ha modificato la riga nel frattempo.
  * In quel caso mostriamo il toast di errore e l'utente deve riaprire il modal
  * (`useBudget.refetch` parte automaticamente grazie alla invalidation).
@@ -76,7 +76,7 @@ export function SetBudgetDialog({ open, onClose }: SetBudgetDialogProps): React.
         monthlyLimitCurrency: 'USD',
         alertThresholdPct: parsedAlert,
         criticalThresholdPct: parsedCritical,
-        rowVersion: budget?.rowVersion ?? null,
+        xmin: budget?.xmin ?? null,
       });
       toast.success(budget ? 'Budget aggiornato' : 'Budget configurato', {
         description: `Limite mensile: $${parsedAmount.toFixed(2)}`,

--- a/apps/web/src/hooks/useBudget.ts
+++ b/apps/web/src/hooks/useBudget.ts
@@ -4,7 +4,7 @@
  * Query + upsert mutation for the singleton AppBudget. Returns `null` when
  * the budget has never been configured (FE shows empty-state CTA).
  *
- * 409 ConflictException on stale `rowVersion` is surfaced via React Query's
+ * 409 ConflictException on stale `xmin` is surfaced via React Query's
  * error path — callers should refetch and retry.
  */
 

--- a/apps/web/src/lib/api/alert-channels.api.ts
+++ b/apps/web/src/lib/api/alert-channels.api.ts
@@ -26,7 +26,7 @@ export const alertChannelsApi = {
   },
 
   /**
-   * Create or update a channel configuration. `rowVersion` is required when
+   * Create or update a channel configuration. `xmin` is required when
    * updating an existing channel — the backend returns 409 ConflictException
    * if the row was modified concurrently.
    */

--- a/apps/web/src/lib/api/budget.api.ts
+++ b/apps/web/src/lib/api/budget.api.ts
@@ -23,7 +23,7 @@ export const budgetApi = {
   },
 
   /**
-   * Upsert the singleton AppBudget. Pass `rowVersion` from the most recent
+   * Upsert the singleton AppBudget. Pass `xmin` from the most recent
    * GET to detect concurrent edits (409 ConflictException). Omit on first
    * creation.
    */

--- a/apps/web/src/lib/api/schemas/alert-channels.schemas.ts
+++ b/apps/web/src/lib/api/schemas/alert-channels.schemas.ts
@@ -20,15 +20,15 @@ export const alertChannelSchema = z.object({
   lastTestMessage: z.string().nullable(),
   updatedAt: z.string().datetime({ offset: true }),
   updatedBy: z.string().nullable(),
-  // Base64-encoded byte[] from PostgreSQL bytea (RowVersion concurrency token).
-  rowVersion: z.string(),
+  // Postgres xmin system column (numeric optimistic-concurrency token), not base64.
+  xmin: z.number(),
 });
 
 export const upsertAlertChannelRequestSchema = z.object({
   configJson: z.string(),
   isEnabled: z.boolean(),
   // Required when updating an existing channel, omit on first-time create.
-  rowVersion: z.string().optional().nullable(),
+  xmin: z.number().optional().nullable(),
 });
 
 // Backend: TestAlertChannelConnectionResult (TestAlertChannelConnectionCommand.cs):

--- a/apps/web/src/lib/api/schemas/budget.schemas.ts
+++ b/apps/web/src/lib/api/schemas/budget.schemas.ts
@@ -20,17 +20,17 @@ export const appBudgetSchema = z.object({
   daysRemaining: z.number().int(),
   updatedAt: z.string().datetime({ offset: true }),
   updatedBy: z.string().nullable(),
-  rowVersion: z.string(),
+  xmin: z.number(),
 });
 
 // Backend: UpsertAppBudgetRequest (AdminBudgetEndpoints.cs:81).
-// RowVersion omitted on first creation, required for in-place update (409 ConflictException on stale).
+// xmin omitted on first creation, required for in-place update (409 ConflictException on stale).
 export const upsertAppBudgetRequestSchema = z.object({
   monthlyLimitAmount: z.number().positive(),
   monthlyLimitCurrency: z.literal('USD'),
   alertThresholdPct: z.number().int().min(1).max(99),
   criticalThresholdPct: z.number().int().min(2).max(100),
-  rowVersion: z.string().optional().nullable(),
+  xmin: z.number().optional().nullable(),
 });
 
 // Backend: AppBudgetUpsertResult — wire shape returned by UpsertAppBudgetCommand handler.
@@ -38,7 +38,7 @@ export const upsertAppBudgetRequestSchema = z.object({
 export const upsertAppBudgetResultSchema = z.object({
   id: z.string().uuid(),
   updatedAt: z.string().datetime({ offset: true }),
-  rowVersion: z.string(),
+  xmin: z.number(),
 });
 
 export type SpendBreakdown = z.infer<typeof spendBreakdownSchema>;


### PR DESCRIPTION
## Context

Follow-up to #2688. Investigation (root-cause analysis in #2690) proved the `byte[] RowVersion` + `.IsRowVersion()` → `bytea NOT NULL` optimistic-concurrency pattern is **broken on Postgres**: EF treats the column as store-generated and omits it from INSERT, but a plain `bytea` is never populated (no xmin/trigger/default) → `NULL` → **23502** not-null violation. Even made nullable (as ProviderCredential #2688 was, as a band-aid), the token stays NULL so concurrency is a permanent no-op.

Affected:
- **AlertChannel / AppBudget**: 23502 **active** (their integration tests were red) + genuine optimistic-concurrency requirements.
- **GameToolkit / ToolkitVersion**: 23502 **latent** — the known "toolkit RowVersion" seed failure (no real-PG test exercised the insert).

## Fix — convert to the working `xmin` pattern

Same approach LiveGameSession (#2097) and PlayRecord already use: map a `uint Xmin` to the Postgres `xmin` **system column** via `.HasColumnName("xmin").HasColumnType("xid").ValueGeneratedOnAddOrUpdate().IsConcurrencyToken()`, and drop the legacy `bytea` columns. INSERT now works (Postgres owns xmin) and stale-token detection raises `DbUpdateConcurrencyException` → 409 for real.

- Migration `20260706042217_RowVersionToXminSweep` **drops** the 4 bytea columns only (xmin is a system column — the scaffolded `AddColumn xmin` ops were removed, mirroring `20260614_LiveSessionRowVersionToXmin`).

## API-breaking (AlertChannel / AppBudget)

The concurrency token in DTOs/requests changes from a base64 `rowVersion` **string** to a numeric `xmin` (**uint / JSON number**):
- `GET .../alert-channels`, `GET .../budget`: response field `rowVersion` → `xmin`.
- `PUT` request body + response: `rowVersion` → `xmin`.

**Frontend updated** (7 files): Zod schemas (`z.string()` → `z.number()`), `SetBudgetDialog`, `CanaliDrawer` submit bodies, api-client docs. No `rowVersion` references remain for these flows. (GameToolkit/ToolkitVersion are internal — no API/FE change.)

## Verification

- **91/91** backend tests green for the refactored areas — AlertChannel/AppBudget integration tests went from **red (23502)** to green; toolkit no-regression.
- Frontend `tsc --noEmit` clean.

## Out of scope

ProviderCredential/PhotoBatchUpload keep their nullable band-aid (legitimate — their invariants are enforced elsewhere, e.g. `ux_provider_credentials_active_one`).

Closes #2690.

🤖 Generated with [Claude Code](https://claude.com/claude-code)