### PR TITLE
fix(processing): #2693 startup grace window before auto-degrade

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/Services/ProcessingQueueMonitorService.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/Services/ProcessingQueueMonitorService.cs
@@ -21,17 +21,22 @@ internal sealed class ProcessingQueueMonitorService : BackgroundService
     private readonly IServiceScopeFactory _scopeFactory;
     private readonly ILogger<ProcessingQueueMonitorService> _logger;
     private readonly IConfiguration _configuration;
+    private readonly TimeProvider _timeProvider;
+    private readonly DateTimeOffset _serviceStartedAt;
 
     private static readonly TimeSpan InitialDelay = TimeSpan.FromSeconds(30);
 
     public ProcessingQueueMonitorService(
         IServiceScopeFactory scopeFactory,
         IConfiguration configuration,
-        ILogger<ProcessingQueueMonitorService> logger)
+        ILogger<ProcessingQueueMonitorService> logger,
+        TimeProvider? timeProvider = null)
     {
         _scopeFactory = scopeFactory ?? throw new ArgumentNullException(nameof(scopeFactory));
         _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _timeProvider = timeProvider ?? TimeProvider.System;
+        _serviceStartedAt = _timeProvider.GetUtcNow();
     }
 
     private TimeSpan CheckInterval =>
@@ -44,6 +49,14 @@ internal sealed class ProcessingQueueMonitorService : BackgroundService
     // warning fires first, but a merely-slow job is never degraded. #2689.
     private TimeSpan StuckJobRecoveryTimeout =>
         TimeSpan.FromMinutes(_configuration.GetValue("ProcessingQueueMonitor:StuckJobRecoveryTimeoutMinutes", 30));
+
+    // Startup grace window — auto-degrade is suppressed while the service is younger than
+    // this value, allowing StalePdfRecoveryService to complete its one-shot startup pass
+    // before the monitor starts degrading the same jobs. #2693.
+    private TimeSpan StartupGracePeriod =>
+        TimeSpan.FromMinutes(_configuration.GetValue("ProcessingQueueMonitor:StartupGracePeriodMinutes", 15));
+
+    private bool StartupGraceElapsed() => (_timeProvider.GetUtcNow() - _serviceStartedAt) >= StartupGracePeriod;
 
     private int QueueDepthThreshold =>
         _configuration.GetValue("ProcessingQueueMonitor:QueueDepthThreshold", 20);
@@ -112,6 +125,8 @@ internal sealed class ProcessingQueueMonitorService : BackgroundService
             .ToListAsync(ct)
             .ConfigureAwait(false);
 
+        var graceElapsed = StartupGraceElapsed();
+
         foreach (var job in stuckJobs)
         {
             var stuckMinutes = (DateTimeOffset.UtcNow - job.StartedAt!.Value).TotalMinutes;
@@ -131,8 +146,18 @@ internal sealed class ProcessingQueueMonitorService : BackgroundService
             // Past recovery threshold → auto-degrade via command (Issue #2689).
             // Degrade-only: the monitor sends the command; all state mutation lives in
             // DegradeStuckJobCommandHandler. Does NOT re-queue (that was reverted in #2686).
+            // Gated behind startup grace (Issue #2693): suppressed while the service is younger
+            // than StartupGracePeriod to avoid racing StalePdfRecoveryService on first cycle.
             if (stuckMinutes >= StuckJobRecoveryTimeout.TotalMinutes)
             {
+                if (!graceElapsed)
+                {
+                    _logger.LogDebug(
+                        "Skipping auto-degrade for job {JobId} (stuck {Minutes:F1} min): startup grace period has not elapsed (Issue #2693)",
+                        job.Id, stuckMinutes);
+                    continue;
+                }
+
                 var result = await mediator.Send(new DegradeStuckJobCommand(job.Id, stuckMinutes), ct).ConfigureAwait(false);
                 if (result.Degraded)
                 {

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Infrastructure/Services/ProcessingQueueMonitorServiceTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Infrastructure/Services/ProcessingQueueMonitorServiceTests.cs
@@ -12,6 +12,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
 using Moq;
 using Xunit;
 
@@ -23,6 +24,8 @@ namespace Api.Tests.BoundedContexts.DocumentProcessing.Infrastructure.Services;
 /// Issue #2689: Validates that the monitor sends <see cref="DegradeStuckJobCommand"/>
 /// when a job is stuck past the recovery threshold (default 30 min), and does NOT send it
 /// when the job is only past the alert threshold (10 min) but below the recovery threshold.
+/// Issue #2693: Validates that auto-degrade is suppressed within the startup grace period
+/// (default 15 min) to avoid racing StalePdfRecoveryService on the first monitor cycle.
 /// </summary>
 [Trait("Category", TestCategories.Unit)]
 [Trait("BoundedContext", "DocumentProcessing")]
@@ -154,16 +157,23 @@ public sealed class ProcessingQueueMonitorServiceTests
         return jobId;
     }
 
-    private static ProcessingQueueMonitorService BuildMonitor(IServiceScopeFactory scopeFactory)
+    /// <summary>
+    /// Builds a <see cref="ProcessingQueueMonitorService"/> using empty configuration
+    /// (all thresholds default: StuckJobTimeout=10min, StuckJobRecoveryTimeout=30min,
+    /// StartupGracePeriodMinutes=15min) and an optional <paramref name="timeProvider"/>.
+    /// The <paramref name="timeProvider"/> clock is sampled in the constructor to capture
+    /// <c>_serviceStartedAt</c>, so advance it AFTER this call to simulate elapsed time.
+    /// </summary>
+    private static ProcessingQueueMonitorService BuildMonitor(
+        IServiceScopeFactory scopeFactory,
+        TimeProvider? timeProvider = null)
     {
-        // Empty configuration → all thresholds use their defaults:
-        //   StuckJobTimeout          = 10 min
-        //   StuckJobRecoveryTimeout  = 30 min
         var configuration = new ConfigurationBuilder().Build();
         return new ProcessingQueueMonitorService(
             scopeFactory,
             configuration,
-            NullLogger<ProcessingQueueMonitorService>.Instance);
+            NullLogger<ProcessingQueueMonitorService>.Instance,
+            timeProvider);
     }
 
     // ──────────────────────────────────────────────────────────────────
@@ -179,7 +189,12 @@ public sealed class ProcessingQueueMonitorServiceTests
         var jobId = await SeedStuckJobAsync(dbName, startedAt);
 
         var (scopeFactory, mediatorMock, _) = BuildScopeFactory(dbName);
-        var monitor = BuildMonitor(scopeFactory);
+
+        // Construct first (captures _serviceStartedAt = T), then advance past the 15-min
+        // startup grace window so the degrade gate is open (Issue #2693 regression fix).
+        var tp = new FakeTimeProvider(DateTimeOffset.UtcNow);
+        var monitor = BuildMonitor(scopeFactory, tp);
+        tp.Advance(TimeSpan.FromMinutes(31));
 
         // Act — call the internal method directly, bypassing the 2-minute loop delay
         await monitor.RunChecksAsync(CancellationToken.None);
@@ -206,7 +221,12 @@ public sealed class ProcessingQueueMonitorServiceTests
         await SeedStuckJobAsync(dbName, startedAt);
 
         var (scopeFactory, mediatorMock, streamMock) = BuildScopeFactory(dbName);
-        var monitor = BuildMonitor(scopeFactory);
+
+        // Construct first (captures _serviceStartedAt = T), then advance past the 15-min
+        // startup grace window so the degrade gate is open (Issue #2693 regression fix).
+        var tp = new FakeTimeProvider(DateTimeOffset.UtcNow);
+        var monitor = BuildMonitor(scopeFactory, tp);
+        tp.Advance(TimeSpan.FromMinutes(31));
 
         // Act
         await monitor.RunChecksAsync(CancellationToken.None);
@@ -222,5 +242,76 @@ public sealed class ProcessingQueueMonitorServiceTests
         mediatorMock.Verify(
             m => m.Send(It.IsAny<DegradeStuckJobCommand>(), It.IsAny<CancellationToken>()),
             Times.Never);
+    }
+
+    // ──────────────────────────────────────────────────────────────────
+    // Grace-period test A: within grace → SSE alert fires but NO degrade
+    // Issue #2693
+    // ──────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task CheckStuckJobs_WithinStartupGracePeriod_PublishesAlertButDoesNotDegrade()
+    {
+        // Arrange: job started 40 min ago (past both the 10-min alert and 30-min recovery
+        // thresholds), but the service is brand-new — grace not yet elapsed.
+        var dbName = $"monitor_grace_suppress_{Guid.NewGuid():N}";
+        var startedAt = DateTimeOffset.UtcNow.AddMinutes(-40);
+        var jobId = await SeedStuckJobAsync(dbName, startedAt);
+
+        var (scopeFactory, mediatorMock, streamMock) = BuildScopeFactory(dbName);
+
+        // FakeTimeProvider is NOT advanced after construction:
+        // elapsed = 0 min < 15 min default grace → degrade suppressed.
+        var tp = new FakeTimeProvider(DateTimeOffset.UtcNow);
+        var monitor = BuildMonitor(scopeFactory, tp);
+        // No tp.Advance() — service just started.
+
+        // Act
+        await monitor.RunChecksAsync(CancellationToken.None);
+
+        // Assert: SSE alert still fires (stuck detection is unaffected by grace)
+        streamMock.Verify(
+            s => s.PublishQueueEventAsync(
+                It.Is<QueueStreamEvent>(e => e.Type == QueueStreamEventType.AlertDocumentStuck),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        // Assert: degrade suppressed — grace not yet elapsed
+        mediatorMock.Verify(
+            m => m.Send(It.IsAny<DegradeStuckJobCommand>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    // ──────────────────────────────────────────────────────────────────
+    // Grace-period test B: after grace → degrade fires
+    // Issue #2693
+    // ──────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task CheckStuckJobs_AfterStartupGracePeriod_SendsDegradeCommand()
+    {
+        // Arrange: job started 40 min ago (> 30-min recovery threshold)
+        // and the service clock is advanced beyond the 15-min grace window.
+        var dbName = $"monitor_grace_degrade_{Guid.NewGuid():N}";
+        var startedAt = DateTimeOffset.UtcNow.AddMinutes(-40);
+        var jobId = await SeedStuckJobAsync(dbName, startedAt);
+
+        var (scopeFactory, mediatorMock, _) = BuildScopeFactory(dbName);
+
+        // Construct first (captures _serviceStartedAt = T), then advance 16 min
+        // (> 15 min default grace) so the degrade gate opens.
+        var tp = new FakeTimeProvider(DateTimeOffset.UtcNow);
+        var monitor = BuildMonitor(scopeFactory, tp);
+        tp.Advance(TimeSpan.FromMinutes(16));
+
+        // Act
+        await monitor.RunChecksAsync(CancellationToken.None);
+
+        // Assert: degrade fires once with correct job id and stuck minutes
+        mediatorMock.Verify(
+            m => m.Send(
+                It.Is<DegradeStuckJobCommand>(c => c.JobId == jobId && c.StuckMinutes >= 30),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 }


### PR DESCRIPTION
## Issue #2693 (follow-up di #2689)

La review whole-branch di #2689 (PR #2692) aveva rilevato una **startup race**: al boot, `ProcessingQueueMonitorService` (auto-degrade oltre 30 min, misurato su `job.StartedAt` assoluto) degradava i PDF stale al **primo** ciclo, in competizione con `StalePdfRecoveryService` (recovery one-shot allo startup) sugli stessi PDF. Il monitor (veloce, marca `Failed`) generalmente vinceva e poteva degradare un PDF che StalePdfRecovery stava — potenzialmente con successo — recuperando.

## Design (scelto dopo valutazione di 3 approcci)

**Startup grace period** — il monitor traccia il proprio istante di avvio (`_serviceStartedAt`, catturato nel costruttore via `TimeProvider` iniettato) e **non degrada** finché non è trascorsa una finestra di grazia configurabile (default 15 min, `ProcessingQueueMonitor:StartupGracePeriodMinutes`). L'**alert SSE dei 10 min resta immediato** — solo `DegradeStuckJobCommand` è differito. Dopo la finestra, il monitor degrada esattamente gli orfani che StalePdfRecovery non è riuscito a recuperare.

Approcci scartati (motivati nel design):
- **skip-recently-reset**: fatalmente rotto — `ResetToPendingAsync` non scrive mai `UpdatedAt`, quindi il segnale non scatta; `state==Pending` dura una frazione di secondo prima del claim.
- **signal-completion**: reintroduce l'accoppiamento cross-service che #2686 ha rimosso; disabilita *tutto* il degrade per l'intero batch unbounded; non-persistente nel crash-loop.

## Cosa cambia

- `ProcessingQueueMonitorService`: 4° ctor param `TimeProvider? timeProvider = null` (`?? TimeProvider.System`, auto-risolto da DI), `_serviceStartedAt` catturato nel costruttore, config `StartupGracePeriod` (default 15 min), helper `StartupGraceElapsed()`, e AND del gate di degrade con `graceElapsed` + `LogDebug` sul deferral.
- **Degrade-only, nessuna mutazione DB / re-queue** — la modifica **ritarda soltanto** un `mediator.Send` esistente (non reintroduce nulla di #2686).
- Clock misto intenzionale: la grace usa `TimeProvider`; staleness/stuck-minutes restano su `DateTimeOffset.UtcNow`.

## Test

- 2 nuovi test grace (within-grace → alert ma no degrade; after-grace → degrade) via `FakeTimeProvider`.
- I 2 test behavior esistenti aggiornati (advance 31 min) — assertion invariate, attribuibili alla recovery-threshold.
- I 3 ctor-guard test invariati (4° param opzionale).
- **7/7** monitor class · **401/401** DocumentProcessing Unit · 0 regressioni.

## Limite noto (documentato)

È una **mitigazione, non una prova**: `StalePdfRecoveryService` è signal-less con runtime unbounded, quindi un backlog grande può superare qualsiasi finestra fissa — la race residua è più stretta di oggi e resta coperta dal self-heal esistente (`DegradeStuckJobCommandHandler` skip Ready/Failed + xmin swallow + `RetryFailedPdfsJob`). Il crash-loop resetta la grace ad ogni boot (l'alert SSE scatta comunque; il retry Quartz è indipendente). La divergenza job/PDF resta invariata (l'handler protegge il PDF; marcare `Failed` un job-row abbandonato è cleanup corretto).

Closes #2693

🤖 Generated with [Claude Code](https://claude.com/claude-code)