### PR TITLE
fix(game-night): #2699 finalize accepts InProgress night (was 409 post-live)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/GameNightEvent/GameNightEvent.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/GameNightEvent/GameNightEvent.cs
@@ -497,13 +497,15 @@ internal sealed class GameNightEvent : AggregateRoot<Guid>
 
     /// <summary>
     /// Finalizes the game night, transitioning to Completed status.
-    /// All sessions must be finished (not in-progress).
+    /// Accepts both Published (finalized before any live session) and InProgress
+    /// (the production flow — invariant #15 promotes the night to InProgress when the
+    /// first Session goes live; #2699). All sessions must be finished (not in-progress).
     /// </summary>
     public void FinalizeNight()
     {
         ThrowIfCorrupted();
 
-        if (Status != GameNightStatus.Published)
+        if (Status != GameNightStatus.Published && Status != GameNightStatus.InProgress)
             throw new InvalidOperationException($"Cannot finalize a {Status} game night.");
         if (_sessions.Any(s => s.Status == GameNightSessionStatus.InProgress))
             throw new InvalidOperationException("Cannot finalize: a session is still in progress.");

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/Entities/GameNightEventSessionsTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/Entities/GameNightEventSessionsTests.cs
@@ -169,6 +169,26 @@ public class GameNightEventSessionsTests
     }
 
     [Fact]
+    public void FinalizeNight_WhenInProgressAfterFirstLiveSession_SetsCompleted()
+    {
+        // #2699: reproduces the PRODUCTION flow. Invariant #15 promotes the night
+        // Published -> InProgress when the first Session goes live (SessionStartedHandler
+        // -> HandleFirstSessionStarted). FinalizeNight must accept InProgress, not only
+        // Published, otherwise a real finalize after a live session throws -> 409.
+        var evt = CreatePublishedEvent();
+        var sessionId = Guid.NewGuid();
+        evt.AddSession(sessionId, evt.GameIds[0], "Catan");
+        evt.StartCurrentSession();
+        evt.HandleFirstSessionStarted(sessionId);   // #15: Published -> InProgress
+        Assert.Equal(GameNightStatus.InProgress, evt.Status);
+        evt.CompleteCurrentSession(Guid.NewGuid());
+
+        evt.FinalizeNight();
+
+        Assert.Equal(GameNightStatus.Completed, evt.Status);
+    }
+
+    [Fact]
     public void FinalizeNight_WithInProgressSession_Throws()
     {
         var evt = CreatePublishedEvent();


### PR DESCRIPTION
Closes #2699 · Parent umbrella #2697 (Tier 3) · companion #2342

## Bug

`GameNightEvent.FinalizeNight()` richiedeva `Status==Published`. Ma il flusso di **produzione** promuove la night `Published → InProgress` via invariante #15 (`SessionStartedHandler → HandleFirstSessionStarted`) quando la prima Session va live. Un finalize reale dopo una sessione live lanciava quindi `InvalidOperationException` → `ConflictException` **409**.

Il test esistente `FinalizeNight_SetsCompleted_WhenAllSessionsDone` **mascherava** il bug: chiama `StartCurrentSession()` senza `HandleFirstSessionStarted()`, lasciando la night `Published`.

## Fix

`FinalizeNight()` ora accetta `Published` **o** `InProgress` → `Completed`, mantenendo:
- il guard "nessuna sessione in corso" (il vero invariante di sicurezza),
- il rifiuto di `Draft/Cancelled/Completed/Corrupted`,
- `NightFinalizedEvent`.

Nessuna modifica all'handler (delega a `FinalizeNight()`). `CompleteAdHoc()` (non usato da alcun handler di produzione — solo test) resta invariato.

## TDD

- **RED**: nuovo test `FinalizeNight_WhenInProgressAfterFirstLiveSession_SetsCompleted` che replica la sequenza reale (AddSession → StartCurrentSession → **HandleFirstSessionStarted** → CompleteCurrentSession → FinalizeNight). Falliva con `InvalidOperationException: Cannot finalize a InProgress game night` (`GameNightEvent.cs:507`).
- **GREEN**: fix applicato → **49/49** test `GameNightEvent*` verdi (incluso `FinalizeNight_WithInProgressSession_Throws` che resta rosso→verde correttamente sul guard sessione).

## Note

Il fix è a livello di dominio con test che esercita la sequenza di produzione. Un integration test end-to-end (`create → publish → live → complete → finalize` via handler/HTTP) è un follow-up consigliato ma non necessario per chiudere il bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)