### PR TITLE
fix(game-night): #2698 participant-guard on detail + rsvps reads (IDOR)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GetGameNightByIdQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GetGameNightByIdQuery.cs
@@ -6,5 +6,7 @@ namespace Api.BoundedContexts.GameManagement.Application.Queries.GameNights;
 /// <summary>
 /// Query to get a game night by its ID.
 /// Issue #46: GameNight API endpoints.
+/// #2698: <see cref="CallerUserId"/> scopes the read to participants (organizer or invited),
+/// closing the cross-tenant IDOR on the detail read.
 /// </summary>
-internal record GetGameNightByIdQuery(Guid GameNightId) : IQuery<GameNightDto>;
+internal record GetGameNightByIdQuery(Guid GameNightId, Guid CallerUserId) : IQuery<GameNightDto>;

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GetGameNightByIdQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GetGameNightByIdQueryHandler.cs
@@ -33,6 +33,14 @@ internal sealed class GetGameNightByIdQueryHandler : IQueryHandler<GetGameNightB
         var gameNight = await _repository.GetByIdAsync(query.GameNightId, cancellationToken).ConfigureAwait(false)
             ?? throw new NotFoundException("GameNightEvent", query.GameNightId.ToString());
 
+        // #2698: participant-scoped read (organizer or invited) — closes the cross-tenant IDOR
+        // where any authenticated user could read another user's private game night. Mirrors the
+        // guard on GetGameNightLiveQueryHandler.
+        var isParticipant = gameNight.OrganizerId == query.CallerUserId
+            || gameNight.Rsvps.Any(r => r.UserId == query.CallerUserId);
+        if (!isParticipant)
+            throw new ForbiddenException("Only the organizer or an invited player can view this game night.");
+
         var organizerName = await GetUserDisplayNameAsync(gameNight.OrganizerId, cancellationToken).ConfigureAwait(false);
 
         return GameNightMapperHelper.MapToDto(gameNight, organizerName);

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GetGameNightRsvpsQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GetGameNightRsvpsQuery.cs
@@ -6,5 +6,7 @@ namespace Api.BoundedContexts.GameManagement.Application.Queries.GameNights;
 /// <summary>
 /// Query to get RSVPs for a game night.
 /// Issue #46: GameNight API endpoints.
+/// #2698: <see cref="CallerUserId"/> scopes the roster read to participants (organizer or invited),
+/// closing the cross-tenant IDOR on the RSVP roster.
 /// </summary>
-internal record GetGameNightRsvpsQuery(Guid GameNightId) : IQuery<IReadOnlyList<GameNightRsvpDto>>;
+internal record GetGameNightRsvpsQuery(Guid GameNightId, Guid CallerUserId) : IQuery<IReadOnlyList<GameNightRsvpDto>>;

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GetGameNightRsvpsQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GetGameNightRsvpsQueryHandler.cs
@@ -33,6 +33,13 @@ internal sealed class GetGameNightRsvpsQueryHandler : IQueryHandler<GetGameNight
         var gameNight = await _repository.GetByIdAsync(query.GameNightId, cancellationToken).ConfigureAwait(false)
             ?? throw new NotFoundException("GameNightEvent", query.GameNightId.ToString());
 
+        // #2698: participant-scoped read (organizer or invited) — closes the cross-tenant IDOR
+        // where any authenticated user could read another user's roster + member names.
+        var isParticipant = gameNight.OrganizerId == query.CallerUserId
+            || gameNight.Rsvps.Any(r => r.UserId == query.CallerUserId);
+        if (!isParticipant)
+            throw new ForbiddenException("Only the organizer or an invited player can view this game night's RSVPs.");
+
         var userIds = gameNight.Rsvps.Select(r => r.UserId).Distinct().ToList();
         var userNames = await GetUserDisplayNamesAsync(userIds, cancellationToken).ConfigureAwait(false);
 

--- a/apps/api/src/Api/Routing/GameNightEndpoints.cs
+++ b/apps/api/src/Api/Routing/GameNightEndpoints.cs
@@ -77,6 +77,7 @@ internal static class GameNightEndpoints
         gameNights.MapGet("/{id:guid}", HandleGetGameNightById)
             .RequireAuthenticatedUser()
             .Produces<GameNightDto>(200)
+            .Produces(403)
             .Produces(404)
             .Produces(401)
             .WithName("GetGameNightById")
@@ -137,6 +138,7 @@ internal static class GameNightEndpoints
         gameNights.MapGet("/{id:guid}/rsvps", HandleGetGameNightRsvps)
             .RequireAuthenticatedUser()
             .Produces<IReadOnlyList<GameNightRsvpDto>>(200)
+            .Produces(403)
             .Produces(404)
             .Produces(401)
             .WithName("GetGameNightRsvps")
@@ -583,9 +585,11 @@ internal static class GameNightEndpoints
     private static async Task<IResult> HandleGetGameNightById(
         Guid id,
         [FromServices] IMediator mediator,
+        HttpContext httpContext,
         CancellationToken cancellationToken)
     {
-        var result = await mediator.Send(new GetGameNightByIdQuery(id), cancellationToken).ConfigureAwait(false);
+        var userId = httpContext.User.GetUserId();
+        var result = await mediator.Send(new GetGameNightByIdQuery(id, userId), cancellationToken).ConfigureAwait(false);
         return Results.Ok(result);
     }
 
@@ -603,9 +607,11 @@ internal static class GameNightEndpoints
     private static async Task<IResult> HandleGetGameNightRsvps(
         Guid id,
         [FromServices] IMediator mediator,
+        HttpContext httpContext,
         CancellationToken cancellationToken)
     {
-        var result = await mediator.Send(new GetGameNightRsvpsQuery(id), cancellationToken).ConfigureAwait(false);
+        var userId = httpContext.User.GetUserId();
+        var result = await mediator.Send(new GetGameNightRsvpsQuery(id, userId), cancellationToken).ConfigureAwait(false);
         return Results.Ok(result);
     }
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/GameNight/GetGameNightByIdQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/GameNight/GetGameNightByIdQueryHandlerTests.cs
@@ -1,0 +1,100 @@
+using Api.BoundedContexts.GameManagement.Application.Queries.GameNights;
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.Infrastructure;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Application.Services;
+using Api.Tests.Constants;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Application.GameNight;
+
+/// <summary>
+/// #2698: the detail read must be participant-scoped (organizer or invited), closing the
+/// cross-tenant IDOR where any authenticated user could read another user's private game night.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "GameManagement")]
+public class GetGameNightByIdQueryHandlerTests : IDisposable
+{
+    private readonly Mock<IGameNightEventRepository> _repo = new();
+    private readonly MeepleAiDbContext _db;
+    private readonly GetGameNightByIdQueryHandler _handler;
+
+    public GetGameNightByIdQueryHandlerTests()
+    {
+        var options = new DbContextOptionsBuilder<MeepleAiDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        _db = new MeepleAiDbContext(
+            options, new Mock<IMediator>().Object, new Mock<IDomainEventCollector>().Object);
+        _handler = new GetGameNightByIdQueryHandler(_repo.Object, _db);
+    }
+
+    public void Dispose()
+    {
+        _db.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    private GameNightEvent PublishedEventWith(Guid organizerId, params Guid[] invitedUserIds)
+    {
+        var evt = GameNightEvent.Create(
+            organizerId, "Serata privata", DateTimeOffset.UtcNow.AddHours(1), gameIds: [Guid.NewGuid()]);
+        evt.Publish(invitedUserIds.ToList());
+        _repo.Setup(r => r.GetByIdAsync(evt.Id, It.IsAny<CancellationToken>())).ReturnsAsync(evt);
+        return evt;
+    }
+
+    [Fact]
+    public async Task Handle_NonParticipant_ThrowsForbidden()
+    {
+        // The core IDOR: a random authenticated user must NOT read another user's private night.
+        var evt = PublishedEventWith(Guid.NewGuid());
+
+        var act = () => _handler.Handle(
+            new GetGameNightByIdQuery(evt.Id, Guid.NewGuid()), TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<ForbiddenException>();
+    }
+
+    [Fact]
+    public async Task Handle_Organizer_ReturnsDto()
+    {
+        var organizerId = Guid.NewGuid();
+        var evt = PublishedEventWith(organizerId);
+
+        var result = await _handler.Handle(
+            new GetGameNightByIdQuery(evt.Id, organizerId), TestContext.Current.CancellationToken);
+
+        result.Id.Should().Be(evt.Id);
+    }
+
+    [Fact]
+    public async Task Handle_InvitedUser_ReturnsDto()
+    {
+        // Invitees get a Pending RSVP on Publish, so they can read the detail to respond.
+        var invitedUserId = Guid.NewGuid();
+        var evt = PublishedEventWith(Guid.NewGuid(), invitedUserId);
+
+        var result = await _handler.Handle(
+            new GetGameNightByIdQuery(evt.Id, invitedUserId), TestContext.Current.CancellationToken);
+
+        result.Id.Should().Be(evt.Id);
+    }
+
+    [Fact]
+    public async Task Handle_NotFound_ThrowsNotFound()
+    {
+        _repo.Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((GameNightEvent?)null);
+
+        var act = () => _handler.Handle(
+            new GetGameNightByIdQuery(Guid.NewGuid(), Guid.NewGuid()), TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/GameNight/GetGameNightRsvpsQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/GameNight/GetGameNightRsvpsQueryHandlerTests.cs
@@ -1,0 +1,87 @@
+using Api.BoundedContexts.GameManagement.Application.Queries.GameNights;
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.Infrastructure;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Application.Services;
+using Api.Tests.Constants;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Application.GameNight;
+
+/// <summary>
+/// #2698: the RSVP roster read must be participant-scoped (organizer or invited), closing the
+/// cross-tenant IDOR where any authenticated user could read another user's roster + names.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "GameManagement")]
+public class GetGameNightRsvpsQueryHandlerTests : IDisposable
+{
+    private readonly Mock<IGameNightEventRepository> _repo = new();
+    private readonly MeepleAiDbContext _db;
+    private readonly GetGameNightRsvpsQueryHandler _handler;
+
+    public GetGameNightRsvpsQueryHandlerTests()
+    {
+        var options = new DbContextOptionsBuilder<MeepleAiDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        _db = new MeepleAiDbContext(
+            options, new Mock<IMediator>().Object, new Mock<IDomainEventCollector>().Object);
+        _handler = new GetGameNightRsvpsQueryHandler(_repo.Object, _db);
+    }
+
+    public void Dispose()
+    {
+        _db.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    private GameNightEvent PublishedEventWith(Guid organizerId, params Guid[] invitedUserIds)
+    {
+        var evt = GameNightEvent.Create(
+            organizerId, "Serata privata", DateTimeOffset.UtcNow.AddHours(1), gameIds: [Guid.NewGuid()]);
+        evt.Publish(invitedUserIds.ToList());
+        _repo.Setup(r => r.GetByIdAsync(evt.Id, It.IsAny<CancellationToken>())).ReturnsAsync(evt);
+        return evt;
+    }
+
+    [Fact]
+    public async Task Handle_NonParticipant_ThrowsForbidden()
+    {
+        // The core IDOR: a random authenticated user must NOT read another user's roster.
+        var evt = PublishedEventWith(Guid.NewGuid(), Guid.NewGuid());
+
+        var act = () => _handler.Handle(
+            new GetGameNightRsvpsQuery(evt.Id, Guid.NewGuid()), TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<ForbiddenException>();
+    }
+
+    [Fact]
+    public async Task Handle_Organizer_ReturnsRoster()
+    {
+        var organizerId = Guid.NewGuid();
+        var evt = PublishedEventWith(organizerId, Guid.NewGuid());
+
+        var result = await _handler.Handle(
+            new GetGameNightRsvpsQuery(evt.Id, organizerId), TestContext.Current.CancellationToken);
+
+        result.Should().ContainSingle();
+    }
+
+    [Fact]
+    public async Task Handle_InvitedUser_ReturnsRoster()
+    {
+        var invitedUserId = Guid.NewGuid();
+        var evt = PublishedEventWith(Guid.NewGuid(), invitedUserId);
+
+        var result = await _handler.Handle(
+            new GetGameNightRsvpsQuery(evt.Id, invitedUserId), TestContext.Current.CancellationToken);
+
+        result.Should().ContainSingle();
+    }
+}


### PR DESCRIPTION
Closes #2698 · Parent umbrella #2697 (Tier 3) · companion #2342 · lezione #2349

## Vulnerabilità (P1 · IDOR live)

`GET /game-nights/{id}` e `GET /game-nights/{id}/rsvps` non passavano il caller `UserId`: **qualunque utente autenticato** poteva leggere il dettaglio di una game night privata altrui (location, roster) e l'intero roster RSVP con i nomi dei membri, manipolando l'id in URL. Le mutazioni erano già guardate (`OrganizerId==UserId`) e il live read era participant-scoped — solo questi due GET erano esposti.

## Fix

- `CallerUserId` aggiunto a `GetGameNightByIdQuery` + `GetGameNightRsvpsQuery`; gli endpoint lo wirano da `httpContext.User.GetUserId()`.
- Gli handler rifiutano i non-participant (`organizer || Rsvps.Any(r => r.UserId == caller)`) con `ForbiddenException`, **replicando il guard già esistente** in `GetGameNightLiveQueryHandler`.
- Gli **invitati mantengono l'accesso**: `Publish`/`AddInvitees`/`PreInvite` creano un `Rsvp` Pending, quindi il flusso RSVP non si rompe. Gli invitati via email (guest) usano il path token `/invitations/{token}`, non impattato.
- `.Produces(403)` su entrambi i mapping GET.

## TDD

- **RED**: i due `Handle_NonParticipant_ThrowsForbidden` fallivano (l'handler ritornava i dati → IDOR dimostrato).
- **GREEN**: 7/7 nuovi test handler + **533/533** suite `GameNight` completa, zero regressioni.

## Nota di design (divergenza consapevole)

`GetGameNightByIdQuery` era documentato in `GetGameNightLiveQuery.cs` come deliberatamente **"lean" (non-guardato)**. Questa PR chiude quella scelta trattando detail + roster come dati privati di eventi privati (lezione #2349). Se il maintainer preferisce mantenere il detail leggibile agli autenticati, il guard sul solo `/{id}` è isolabile — ma il roster `/rsvps` resta un IDOR netto da chiudere in ogni caso.

🤖 Generated with [Claude Code](https://claude.com/claude-code)