### PR TITLE
fix(rag): #2705 restore pgvector semantic search in session-agent chat

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/RagPromptAssemblyService.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/RagPromptAssemblyService.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using Api.BoundedContexts.KnowledgeBase.Application.Models;
 using Api.BoundedContexts.KnowledgeBase.Domain.Entities;
 using Api.BoundedContexts.KnowledgeBase.Domain.Enums;
+using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
 using Api.BoundedContexts.KnowledgeBase.Domain.Services.Enhancements;
 using Api.BoundedContexts.KnowledgeBase.Domain.Services.Reranking;
 using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
@@ -25,6 +26,7 @@ namespace Api.BoundedContexts.KnowledgeBase.Application.Services;
 internal sealed class RagPromptAssemblyService : IRagPromptAssemblyService
 {
     private readonly IEmbeddingService _embeddingService;
+    private readonly IEmbeddingRepository _embeddingRepository;
     private readonly ICrossEncoderReranker _reranker;
     private readonly ILlmService _llmService;
     private readonly ITextChunkSearchService _textSearch;
@@ -63,6 +65,7 @@ internal sealed class RagPromptAssemblyService : IRagPromptAssemblyService
 
     public RagPromptAssemblyService(
         IEmbeddingService embeddingService,
+        IEmbeddingRepository embeddingRepository,
         ICrossEncoderReranker reranker,
         ILlmService llmService,
         ITextChunkSearchService textSearch,
@@ -75,6 +78,7 @@ internal sealed class RagPromptAssemblyService : IRagPromptAssemblyService
         ILogger<RagPromptAssemblyService> logger)
     {
         _embeddingService = embeddingService ?? throw new ArgumentNullException(nameof(embeddingService));
+        _embeddingRepository = embeddingRepository ?? throw new ArgumentNullException(nameof(embeddingRepository));
         _reranker = reranker ?? throw new ArgumentNullException(nameof(reranker));
         _llmService = llmService ?? throw new ArgumentNullException(nameof(llmService));
         _textSearch = textSearch ?? throw new ArgumentNullException(nameof(textSearch));
@@ -246,9 +250,14 @@ internal sealed class RagPromptAssemblyService : IRagPromptAssemblyService
                 queries = await ExpandQueryAsync(userQuestion, ct).ConfigureAwait(false);
             }
 
-            // Step 2: Generate embeddings for all queries
+            // Step 2: Generate query embeddings and run pgvector semantic search.
+            // Issue #2705: this branch was dropped in commit 5d00be387 (#504), which left the
+            // retrieval FTS-only. FTS-only RRF scores are capped at NormalizeRrfScore(1/61) ≈ 0.49,
+            // below the 0.55 MinScore, so filteredChunks was ALWAYS empty and the agent answered
+            // "non sono certo" regardless of the question. Restoring the semantic branch feeds real
+            // cosine similarities (multilingual-e5, cross-lingual) into the fusion via Math.Max, so
+            // relevant chunks clear MinScore again.
             var allChunks = new List<SearchResultItem>();
-            // Embeddings are still generated for potential future use.
             foreach (var query in queries)
             {
                 var embeddingResult = await _embeddingService.GenerateEmbeddingAsync(query, ct).ConfigureAwait(false);
@@ -259,10 +268,29 @@ internal sealed class RagPromptAssemblyService : IRagPromptAssemblyService
                         _logger.LogWarning("Embedding generation failed for primary query: {Error}", embeddingResult.ErrorMessage);
                         return (string.Empty, citations);
                     }
+
+                    continue;
+                }
+
+                var queryVector = new Vector(embeddingResult.Embeddings[0]);
+                var scoredEmbeddings = await _embeddingRepository
+                    .SearchByVectorWithScoresAsync(gameId, queryVector, profile.TopK, profile.MinScore, documentIds: null, ct)
+                    .ConfigureAwait(false);
+
+                foreach (var scored in scoredEmbeddings)
+                {
+                    allChunks.Add(new SearchResultItem
+                    {
+                        Score = (float)scored.Score,
+                        Text = scored.Embedding.TextContent,
+                        PdfId = scored.Embedding.VectorDocumentId.ToString(),
+                        Page = scored.Embedding.PageNumber,
+                        ChunkIndex = scored.Embedding.ChunkIndex
+                    });
                 }
             }
 
-            // Step 2b: Hybrid search — PostgreSQL FTS + RRF fusion (graceful degradation)
+            // Step 2b: Hybrid search — semantic vector chunks + PostgreSQL FTS + RRF fusion (graceful degradation)
             allChunks = await TryHybridSearchAsync(userQuestion, gameId, allChunks, profile, ct).ConfigureAwait(false);
 
             // Deduplicate by PdfId+ChunkIndex, keep highest score

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/RagPromptAssemblyServiceFallbackMetricsTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/RagPromptAssemblyServiceFallbackMetricsTests.cs
@@ -3,6 +3,7 @@ using Api.BoundedContexts.KnowledgeBase.Application.Models;
 using Api.BoundedContexts.KnowledgeBase.Application.Services;
 using Api.BoundedContexts.KnowledgeBase.Domain.Entities;
 using Api.BoundedContexts.KnowledgeBase.Domain.Enums;
+using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
 using Api.BoundedContexts.KnowledgeBase.Domain.Services.Enhancements;
 using Api.BoundedContexts.KnowledgeBase.Domain.Services.Reranking;
 using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
@@ -36,6 +37,7 @@ public class RagPromptAssemblyServiceFallbackMetricsTests
     private const string CounterName = "meepleai.rag.retrieval.fallbacks";
 
     private readonly Mock<IEmbeddingService> _embeddingMock = new();
+    private readonly Mock<IEmbeddingRepository> _embeddingRepositoryMock = new();
     private readonly Mock<ICrossEncoderReranker> _rerankerMock = new();
     private readonly Mock<ILlmService> _llmMock = new();
     private readonly Mock<ITextChunkSearchService> _textSearchMock = new();
@@ -64,12 +66,19 @@ public class RagPromptAssemblyServiceFallbackMetricsTests
         _ragEnhancementMock
             .Setup(r => r.GetActiveEnhancementsAsync(It.IsAny<UserTier>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(RagEnhancement.None);
+
+        _embeddingRepositoryMock
+            .Setup(r => r.SearchByVectorWithScoresAsync(
+                It.IsAny<Guid>(), It.IsAny<Vector>(), It.IsAny<int>(), It.IsAny<double>(),
+                It.IsAny<IReadOnlyList<Guid>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<ScoredEmbedding>());
     }
 
     private RagPromptAssemblyService CreateService()
     {
         return new RagPromptAssemblyService(
             _embeddingMock.Object,
+            _embeddingRepositoryMock.Object,
             _rerankerMock.Object,
             _llmMock.Object,
             _textSearchMock.Object,

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/RagPromptAssemblyServiceInlineCitationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/RagPromptAssemblyServiceInlineCitationTests.cs
@@ -1,6 +1,8 @@
 using Api.BoundedContexts.KnowledgeBase.Application.Models;
 using Api.BoundedContexts.KnowledgeBase.Application.Services;
+using Api.BoundedContexts.KnowledgeBase.Domain.Entities;
 using Api.BoundedContexts.KnowledgeBase.Domain.Enums;
+using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
 using Api.BoundedContexts.KnowledgeBase.Domain.Services.Enhancements;
 using Api.BoundedContexts.KnowledgeBase.Domain.Services.Reranking;
 using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
@@ -26,6 +28,7 @@ namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Services;
 public class RagPromptAssemblyServiceInlineCitationTests
 {
     private readonly Mock<IEmbeddingService> _embeddingMock = new();
+    private readonly Mock<IEmbeddingRepository> _embeddingRepositoryMock = new();
     private readonly Mock<ICrossEncoderReranker> _rerankerMock = new();
     private readonly Mock<ILlmService> _llmMock = new();
     private readonly Mock<ITextChunkSearchService> _textSearchMock = new();
@@ -37,10 +40,20 @@ public class RagPromptAssemblyServiceInlineCitationTests
     private readonly Mock<IGraphRetrievalService> _graphRetrievalMock = new();
     private readonly Mock<ILogger<RagPromptAssemblyService>> _loggerMock = new();
 
+    public RagPromptAssemblyServiceInlineCitationTests()
+    {
+        _embeddingRepositoryMock
+            .Setup(r => r.SearchByVectorWithScoresAsync(
+                It.IsAny<Guid>(), It.IsAny<Vector>(), It.IsAny<int>(), It.IsAny<double>(),
+                It.IsAny<IReadOnlyList<Guid>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<ScoredEmbedding>());
+    }
+
     private RagPromptAssemblyService CreateService()
     {
         return new RagPromptAssemblyService(
             _embeddingMock.Object,
+            _embeddingRepositoryMock.Object,
             _rerankerMock.Object,
             _llmMock.Object,
             _textSearchMock.Object,

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/RagPromptAssemblyServiceRetrievalEmptyMetricsTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/RagPromptAssemblyServiceRetrievalEmptyMetricsTests.cs
@@ -1,7 +1,9 @@
 using System.Diagnostics.Metrics;
 using Api.BoundedContexts.KnowledgeBase.Application.Models;
 using Api.BoundedContexts.KnowledgeBase.Application.Services;
+using Api.BoundedContexts.KnowledgeBase.Domain.Entities;
 using Api.BoundedContexts.KnowledgeBase.Domain.Enums;
+using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
 using Api.BoundedContexts.KnowledgeBase.Domain.Services.Enhancements;
 using Api.BoundedContexts.KnowledgeBase.Domain.Services.Reranking;
 using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
@@ -40,6 +42,7 @@ public class RagPromptAssemblyServiceRetrievalEmptyMetricsTests
     private const string CounterName = "meepleai.rag.retrieval_empty";
 
     private readonly Mock<IEmbeddingService> _embeddingMock = new();
+    private readonly Mock<IEmbeddingRepository> _embeddingRepositoryMock = new();
     private readonly Mock<ICrossEncoderReranker> _rerankerMock = new();
     private readonly Mock<ILlmService> _llmMock = new();
     private readonly Mock<ITextChunkSearchService> _textSearchMock = new();
@@ -69,6 +72,12 @@ public class RagPromptAssemblyServiceRetrievalEmptyMetricsTests
             .Setup(r => r.GetActiveEnhancementsAsync(It.IsAny<UserTier>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(RagEnhancement.None);
 
+        _embeddingRepositoryMock
+            .Setup(r => r.SearchByVectorWithScoresAsync(
+                It.IsAny<Guid>(), It.IsAny<Vector>(), It.IsAny<int>(), It.IsAny<double>(),
+                It.IsAny<IReadOnlyList<Guid>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<ScoredEmbedding>());
+
         SetupSuccessfulEmbedding();
     }
 
@@ -76,6 +85,7 @@ public class RagPromptAssemblyServiceRetrievalEmptyMetricsTests
     {
         return new RagPromptAssemblyService(
             _embeddingMock.Object,
+            _embeddingRepositoryMock.Object,
             _rerankerMock.Object,
             _llmMock.Object,
             _textSearchMock.Object,

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/RagPromptAssemblyServiceTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/RagPromptAssemblyServiceTests.cs
@@ -2,7 +2,9 @@ using Api.BoundedContexts.KnowledgeBase.Application.Models;
 using Api.BoundedContexts.KnowledgeBase.Application.Services;
 using Api.BoundedContexts.KnowledgeBase.Domain.Entities;
 using Api.BoundedContexts.KnowledgeBase.Domain.Enums;
+using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
 using Api.BoundedContexts.KnowledgeBase.Domain.Services.Enhancements;
+using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
 using Api.BoundedContexts.KnowledgeBase.Domain.Services.Reranking;
 using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
 using Api.Models;
@@ -23,6 +25,7 @@ namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Services;
 public class RagPromptAssemblyServiceTests
 {
     private readonly Mock<IEmbeddingService> _embeddingMock;
+    private readonly Mock<IEmbeddingRepository> _embeddingRepositoryMock;
     private readonly Mock<ICrossEncoderReranker> _rerankerMock;
     private readonly Mock<ILlmService> _llmMock;
     private readonly Mock<ITextChunkSearchService> _textSearchMock;
@@ -40,6 +43,7 @@ public class RagPromptAssemblyServiceTests
     public RagPromptAssemblyServiceTests()
     {
         _embeddingMock = new Mock<IEmbeddingService>();
+        _embeddingRepositoryMock = new Mock<IEmbeddingRepository>();
         _rerankerMock = new Mock<ICrossEncoderReranker>();
         _llmMock = new Mock<ILlmService>();
         _textSearchMock = new Mock<ITextChunkSearchService>();
@@ -66,12 +70,20 @@ public class RagPromptAssemblyServiceTests
         _ragEnhancementMock
             .Setup(r => r.GetActiveEnhancementsAsync(It.IsAny<UserTier>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(RagEnhancement.None);
+
+        // Default: pgvector semantic search returns no chunks (scenario-specific tests override this)
+        _embeddingRepositoryMock
+            .Setup(r => r.SearchByVectorWithScoresAsync(
+                It.IsAny<Guid>(), It.IsAny<Vector>(), It.IsAny<int>(), It.IsAny<double>(),
+                It.IsAny<IReadOnlyList<Guid>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<ScoredEmbedding>());
     }
 
     private RagPromptAssemblyService CreateService()
     {
         return new RagPromptAssemblyService(
             _embeddingMock.Object,
+            _embeddingRepositoryMock.Object,
             _rerankerMock.Object,
             _llmMock.Object,
             _textSearchMock.Object,
@@ -121,6 +133,27 @@ public class RagPromptAssemblyServiceTests
             });
     }
 
+    private void SetupVectorSearchResults(params (string text, int chunkIndex, double score)[] items)
+    {
+        var scored = items
+            .Select(i => new ScoredEmbedding(
+                new Embedding(
+                    Guid.NewGuid(),
+                    Guid.NewGuid(),
+                    i.text,
+                    new Vector(TestEmbedding),
+                    "test-model",
+                    i.chunkIndex,
+                    pageNumber: 1),
+                i.score))
+            .ToList();
+        _embeddingRepositoryMock
+            .Setup(r => r.SearchByVectorWithScoresAsync(
+                It.IsAny<Guid>(), It.IsAny<Vector>(), It.IsAny<int>(), It.IsAny<double>(),
+                It.IsAny<IReadOnlyList<Guid>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(scored);
+    }
+
     private static SearchResultItem CreateChunk(string pdfId, int chunkIndex, float score, string text = "Rule text", int page = 1)
     {
         return new SearchResultItem
@@ -132,6 +165,37 @@ public class RagPromptAssemblyServiceTests
             ChunkIndex = chunkIndex
         };
     }
+
+    #region AssemblePromptAsync - Vector semantic retrieval (regression #2705)
+
+    [Fact]
+    public async Task AssemblePrompt_WithRelevantVectorChunks_ProducesGroundedContext()
+    {
+        // Regression #2705: commit 5d00be387 removed the pgvector semantic search from
+        // RetrieveRagContextAsync, leaving FTS-only RRF scores capped at ~0.49 < MinScore 0.55.
+        // The RAG context was therefore ALWAYS empty, so the agent answered "non sono certo"
+        // regardless of the question. With the vector branch restored, chunks whose cosine
+        // similarity clears MinScore (0.55) must produce a grounded, non-empty context.
+        SetupSuccessfulEmbedding();
+        SetupVectorSearchResults(
+            ("Pawns move forward one square.", 0, 0.85),
+            ("Pawns can capture diagonally.", 1, 0.82));
+        SetupTextSearchResults(); // no FTS matches — semantic branch alone must ground the answer
+        SetupRerankerPassthrough();
+        var service = CreateService();
+
+        // Act
+        var result = await service.AssemblePromptAsync(
+            "tutor", "Chess", null, "How do pawns move?",
+            TestGameId, null, null, "it", CancellationToken.None);
+
+        // Assert — semantic chunks above threshold produce grounded context
+        result.Citations.Should().NotBeEmpty();
+        result.SystemPrompt.Should().NotContain("No game documentation is currently available");
+        result.SystemPrompt.Should().Contain("Pawns move forward");
+    }
+
+    #endregion
 
     #region AssemblePromptAsync - With Chunks (FTS-only post pgvector migration)
 
@@ -728,17 +792,27 @@ public class RagPromptAssemblyServiceTests
     public void Constructor_NullEmbeddingService_ThrowsArgumentNullException()
     {
         var act = () => new RagPromptAssemblyService(
-            null!, _rerankerMock.Object, _llmMock.Object, _textSearchMock.Object, _expansionResolverMock.Object,
+            null!, _embeddingRepositoryMock.Object, _rerankerMock.Object, _llmMock.Object, _textSearchMock.Object, _expansionResolverMock.Object,
             _ragEnhancementMock.Object, _complexityClassifierMock.Object, _relevanceEvaluatorMock.Object, _queryExpanderMock.Object, _graphRetrievalMock.Object, _loggerMock.Object);
 
         act.Should().Throw<ArgumentNullException>().WithParameterName("embeddingService");
     }
 
     [Fact]
+    public void Constructor_NullEmbeddingRepository_ThrowsArgumentNullException()
+    {
+        var act = () => new RagPromptAssemblyService(
+            _embeddingMock.Object, null!, _rerankerMock.Object, _llmMock.Object, _textSearchMock.Object, _expansionResolverMock.Object,
+            _ragEnhancementMock.Object, _complexityClassifierMock.Object, _relevanceEvaluatorMock.Object, _queryExpanderMock.Object, _graphRetrievalMock.Object, _loggerMock.Object);
+
+        act.Should().Throw<ArgumentNullException>().WithParameterName("embeddingRepository");
+    }
+
+    [Fact]
     public void Constructor_NullReranker_ThrowsArgumentNullException()
     {
         var act = () => new RagPromptAssemblyService(
-            _embeddingMock.Object, null!, _llmMock.Object, _textSearchMock.Object, _expansionResolverMock.Object,
+            _embeddingMock.Object, _embeddingRepositoryMock.Object, null!, _llmMock.Object, _textSearchMock.Object, _expansionResolverMock.Object,
             _ragEnhancementMock.Object, _complexityClassifierMock.Object, _relevanceEvaluatorMock.Object, _queryExpanderMock.Object, _graphRetrievalMock.Object, _loggerMock.Object);
 
         act.Should().Throw<ArgumentNullException>().WithParameterName("reranker");
@@ -748,7 +822,7 @@ public class RagPromptAssemblyServiceTests
     public void Constructor_NullLlmService_ThrowsArgumentNullException()
     {
         var act = () => new RagPromptAssemblyService(
-            _embeddingMock.Object, _rerankerMock.Object, null!, _textSearchMock.Object, _expansionResolverMock.Object,
+            _embeddingMock.Object, _embeddingRepositoryMock.Object, _rerankerMock.Object, null!, _textSearchMock.Object, _expansionResolverMock.Object,
             _ragEnhancementMock.Object, _complexityClassifierMock.Object, _relevanceEvaluatorMock.Object, _queryExpanderMock.Object, _graphRetrievalMock.Object, _loggerMock.Object);
 
         act.Should().Throw<ArgumentNullException>().WithParameterName("llmService");
@@ -758,7 +832,7 @@ public class RagPromptAssemblyServiceTests
     public void Constructor_NullTextSearchService_ThrowsArgumentNullException()
     {
         var act = () => new RagPromptAssemblyService(
-            _embeddingMock.Object, _rerankerMock.Object, _llmMock.Object, null!, _expansionResolverMock.Object,
+            _embeddingMock.Object, _embeddingRepositoryMock.Object, _rerankerMock.Object, _llmMock.Object, null!, _expansionResolverMock.Object,
             _ragEnhancementMock.Object, _complexityClassifierMock.Object, _relevanceEvaluatorMock.Object, _queryExpanderMock.Object, _graphRetrievalMock.Object, _loggerMock.Object);
 
         act.Should().Throw<ArgumentNullException>().WithParameterName("textSearch");
@@ -768,7 +842,7 @@ public class RagPromptAssemblyServiceTests
     public void Constructor_NullExpansionResolver_ThrowsArgumentNullException()
     {
         var act = () => new RagPromptAssemblyService(
-            _embeddingMock.Object, _rerankerMock.Object, _llmMock.Object, _textSearchMock.Object, null!,
+            _embeddingMock.Object, _embeddingRepositoryMock.Object, _rerankerMock.Object, _llmMock.Object, _textSearchMock.Object, null!,
             _ragEnhancementMock.Object, _complexityClassifierMock.Object, _relevanceEvaluatorMock.Object, _queryExpanderMock.Object, _graphRetrievalMock.Object, _loggerMock.Object);
 
         act.Should().Throw<ArgumentNullException>().WithParameterName("expansionResolver");
@@ -778,7 +852,7 @@ public class RagPromptAssemblyServiceTests
     public void Constructor_NullRagEnhancementService_ThrowsArgumentNullException()
     {
         var act = () => new RagPromptAssemblyService(
-            _embeddingMock.Object, _rerankerMock.Object, _llmMock.Object, _textSearchMock.Object, _expansionResolverMock.Object,
+            _embeddingMock.Object, _embeddingRepositoryMock.Object, _rerankerMock.Object, _llmMock.Object, _textSearchMock.Object, _expansionResolverMock.Object,
             null!, _complexityClassifierMock.Object, _relevanceEvaluatorMock.Object, _queryExpanderMock.Object, _graphRetrievalMock.Object, _loggerMock.Object);
 
         act.Should().Throw<ArgumentNullException>().WithParameterName("ragEnhancementService");
@@ -788,7 +862,7 @@ public class RagPromptAssemblyServiceTests
     public void Constructor_NullComplexityClassifier_ThrowsArgumentNullException()
     {
         var act = () => new RagPromptAssemblyService(
-            _embeddingMock.Object, _rerankerMock.Object, _llmMock.Object, _textSearchMock.Object, _expansionResolverMock.Object,
+            _embeddingMock.Object, _embeddingRepositoryMock.Object, _rerankerMock.Object, _llmMock.Object, _textSearchMock.Object, _expansionResolverMock.Object,
             _ragEnhancementMock.Object, null!, _relevanceEvaluatorMock.Object, _queryExpanderMock.Object, _graphRetrievalMock.Object, _loggerMock.Object);
 
         act.Should().Throw<ArgumentNullException>().WithParameterName("complexityClassifier");
@@ -798,7 +872,7 @@ public class RagPromptAssemblyServiceTests
     public void Constructor_NullRelevanceEvaluator_ThrowsArgumentNullException()
     {
         var act = () => new RagPromptAssemblyService(
-            _embeddingMock.Object, _rerankerMock.Object, _llmMock.Object, _textSearchMock.Object, _expansionResolverMock.Object,
+            _embeddingMock.Object, _embeddingRepositoryMock.Object, _rerankerMock.Object, _llmMock.Object, _textSearchMock.Object, _expansionResolverMock.Object,
             _ragEnhancementMock.Object, _complexityClassifierMock.Object, null!, _queryExpanderMock.Object, _graphRetrievalMock.Object, _loggerMock.Object);
 
         act.Should().Throw<ArgumentNullException>().WithParameterName("relevanceEvaluator");
@@ -808,7 +882,7 @@ public class RagPromptAssemblyServiceTests
     public void Constructor_NullQueryExpander_ThrowsArgumentNullException()
     {
         var act = () => new RagPromptAssemblyService(
-            _embeddingMock.Object, _rerankerMock.Object, _llmMock.Object, _textSearchMock.Object, _expansionResolverMock.Object,
+            _embeddingMock.Object, _embeddingRepositoryMock.Object, _rerankerMock.Object, _llmMock.Object, _textSearchMock.Object, _expansionResolverMock.Object,
             _ragEnhancementMock.Object, _complexityClassifierMock.Object, _relevanceEvaluatorMock.Object, null!, _graphRetrievalMock.Object, _loggerMock.Object);
 
         act.Should().Throw<ArgumentNullException>().WithParameterName("queryExpander");
@@ -818,7 +892,7 @@ public class RagPromptAssemblyServiceTests
     public void Constructor_NullGraphRetrievalService_ThrowsArgumentNullException()
     {
         var act = () => new RagPromptAssemblyService(
-            _embeddingMock.Object, _rerankerMock.Object, _llmMock.Object, _textSearchMock.Object, _expansionResolverMock.Object,
+            _embeddingMock.Object, _embeddingRepositoryMock.Object, _rerankerMock.Object, _llmMock.Object, _textSearchMock.Object, _expansionResolverMock.Object,
             _ragEnhancementMock.Object, _complexityClassifierMock.Object, _relevanceEvaluatorMock.Object, _queryExpanderMock.Object, null!, _loggerMock.Object);
 
         act.Should().Throw<ArgumentNullException>().WithParameterName("graphRetrievalService");
@@ -828,7 +902,7 @@ public class RagPromptAssemblyServiceTests
     public void Constructor_NullLogger_ThrowsArgumentNullException()
     {
         var act = () => new RagPromptAssemblyService(
-            _embeddingMock.Object, _rerankerMock.Object, _llmMock.Object, _textSearchMock.Object, _expansionResolverMock.Object,
+            _embeddingMock.Object, _embeddingRepositoryMock.Object, _rerankerMock.Object, _llmMock.Object, _textSearchMock.Object, _expansionResolverMock.Object,
             _ragEnhancementMock.Object, _complexityClassifierMock.Object, _relevanceEvaluatorMock.Object, _queryExpanderMock.Object, _graphRetrievalMock.Object, null!);
 
         act.Should().Throw<ArgumentNullException>().WithParameterName("logger");

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Unit/RagPromptAssemblyEnhancementsTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Unit/RagPromptAssemblyEnhancementsTests.cs
@@ -1,5 +1,7 @@
 using Api.BoundedContexts.KnowledgeBase.Application.Services;
+using Api.BoundedContexts.KnowledgeBase.Domain.Entities;
 using Api.BoundedContexts.KnowledgeBase.Domain.Enums;
+using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
 using Api.BoundedContexts.KnowledgeBase.Domain.Services.Enhancements;
 using Api.BoundedContexts.KnowledgeBase.Domain.Services.Reranking;
 using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
@@ -20,6 +22,7 @@ namespace Api.Tests.BoundedContexts.KnowledgeBase.Unit;
 public class RagPromptAssemblyEnhancementsTests
 {
     private readonly Mock<IEmbeddingService> _embeddingMock;
+    private readonly Mock<IEmbeddingRepository> _embeddingRepositoryMock;
     private readonly Mock<ICrossEncoderReranker> _rerankerMock;
     private readonly Mock<ILlmService> _llmMock;
     private readonly Mock<ITextChunkSearchService> _textSearchMock;
@@ -37,6 +40,7 @@ public class RagPromptAssemblyEnhancementsTests
     public RagPromptAssemblyEnhancementsTests()
     {
         _embeddingMock = new Mock<IEmbeddingService>();
+        _embeddingRepositoryMock = new Mock<IEmbeddingRepository>();
         _rerankerMock = new Mock<ICrossEncoderReranker>();
         _llmMock = new Mock<ILlmService>();
         _textSearchMock = new Mock<ITextChunkSearchService>();
@@ -70,12 +74,20 @@ public class RagPromptAssemblyEnhancementsTests
                 It.IsAny<Guid>(), It.IsAny<string>(), It.IsAny<int>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<TextChunkMatch>());
+
+        // Default: empty vector search (no embedding matches)
+        _embeddingRepositoryMock
+            .Setup(r => r.SearchByVectorWithScoresAsync(
+                It.IsAny<Guid>(), It.IsAny<Vector>(), It.IsAny<int>(), It.IsAny<double>(),
+                It.IsAny<IReadOnlyList<Guid>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<ScoredEmbedding>());
     }
 
     private RagPromptAssemblyService CreateService()
     {
         return new RagPromptAssemblyService(
             _embeddingMock.Object,
+            _embeddingRepositoryMock.Object,
             _rerankerMock.Object,
             _llmMock.Object,
             _textSearchMock.Object,


### PR DESCRIPTION
## Problema
Un agente con Knowledge Base rispondeva **"non sono certo"** a **qualsiasi** domanda. La diagnosi ha isolato **due percorsi di chat distinti**:

| Percorso | Handler | Retrieval | Stato |
|---|---|---|---|
| Pagina del gioco (`/agents/qa/stream`) | `StreamQaQueryHandler` → `SearchQueryHandler` | pgvector semantico (e5) | ✅ funziona |
| **Sessione live** | `ChatWithSessionAgentCommandHandler` → `RagPromptAssemblyService` | vector **disattivato**, solo FTS | ❌ **rotto** |

Questo PR corregge il percorso **rotto** (usato anche da `StreamDebugQaQueryHandler` e `CrossGameStreamQaQueryHandler`).

## Root cause
Il commit `5d00be387` (#504, mega-commit non correlato) ha rimosso il ramo di ricerca semantica pgvector da `RagPromptAssemblyService.RetrieveRagContextAsync`: gli embedding venivano generati ma **scartati** (`"for potential future use"`), lasciando il retrieval **FTS-only**. Gli score RRF FTS-only sono limitati a `NormalizeRrfScore(1/61) ≈ 0.49`, sotto `MinScore = 0.55` → `filteredChunks` **sempre vuoto** → l'LLM riceve l'istruzione di fallback → "non sono certo", a prescindere dalla domanda.

Aggravante: l'indice FTS è `to_tsvector('english', …)`, quindi le query **italiane** matchano **0 righe** (verificato sul DB locale). App italiana → percorso sistematicamente rotto.

I test unit `AssemblePrompt_WithChunks_FtsOnlyScoresBelowThreshold_*` **asserivano il bug come comportamento voluto**, mascherando la regressione (suite verde).

## Fix
Ripristinato il ramo pgvector: iniettata `IEmbeddingRepository`, eseguito `SearchByVectorWithScoresAsync` per ogni query espansa, coseno reale fuso nella RRF via `Math.Max`. `multilingual-e5` è cross-lingua → le domande italiane recuperano i chunk del regolamento inglese e superano `MinScore`.

## Test
- Nuovo test `AssemblePrompt_WithRelevantVectorChunks_ProducesGroundedContext` (grounding ripristinato) + null-check della nuova dipendenza.
- I test "empty context" esistenti restano validi (vector mock vuoto → FTS-only → filtrato).
- **2292 test unit KnowledgeBase verdi**, 0 regressioni.

## Verifica empirica (DB locale, snapshot staging)
- FTS italiano su Codenames: 0 match. RRF FTS-only max ≈ 0.49 < 0.55.
- pgvector e5: coseno 0.85 (rilevante) vs 0.74 (irrilevante) → chunk consegnati.

## Follow-up (fuori scope)
Reranking cross-encoder su `/agents/qa/stream` + `/agents/qa` (migliora la **precisione** senza alzare la soglia) — tracciato separatamente: quei percorsi non chiamano `ICrossEncoderReranker`, che invece è già attivo in `RagPromptAssemblyService`.

Closes #2705

🤖 Generated with [Claude Code](https://claude.com/claude-code)
