### PR TITLE
fix(game-night): #2703 xmin optimistic concurrency on game_night_events

### DIFF
--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/GameNightEvent/GameNightEvent.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/GameNightEvent/GameNightEvent.cs
@@ -46,6 +46,16 @@ internal sealed class GameNightEvent : AggregateRoot<Guid>
     public DateTimeOffset? UpdatedAt { get; private set; }
     public IReadOnlyList<GameNightRsvp> Rsvps => _rsvps.AsReadOnly();
 
+    // Optimistic concurrency via PostgreSQL's xmin system column (Issue #2703, ADR-060).
+    // Server-owned: Postgres assigns xmin on each write; EF reads it back so the
+    // repository can round-trip the value for detached Update scenarios.
+    public uint Xmin { get; private set; }
+
+    /// <summary>
+    /// Called by the repository mapper to restore the xmin token after loading from persistence.
+    /// </summary>
+    internal void SetXmin(uint xmin) => Xmin = xmin;
+
     /// <summary>
     /// Private constructor for EF Core.
     /// </summary>

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Persistence/GameNightEventRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Persistence/GameNightEventRepository.cs
@@ -212,7 +212,8 @@ internal class GameNightEventRepository : RepositoryBase, IGameNightEventReposit
             RsvpDeadline = domain.RsvpDeadline,
             RsvpClosedAt = domain.RsvpClosedAt,
             CreatedAt = domain.CreatedAt,
-            UpdatedAt = domain.UpdatedAt
+            UpdatedAt = domain.UpdatedAt,
+            Xmin = domain.Xmin
         };
 
         foreach (var rsvp in domain.Rsvps)
@@ -292,6 +293,10 @@ internal class GameNightEventRepository : RepositoryBase, IGameNightEventReposit
 
         var rsvpClosedAtProp = typeof(GameNightEvent).GetProperty(nameof(GameNightEvent.RsvpClosedAt));
         rsvpClosedAtProp?.SetValue(evt, entity.RsvpClosedAt);
+
+        // Restore the xmin concurrency token so the detached UpdateAsync emits the
+        // WHERE id = @id AND xmin = @original check (Issue #2703).
+        evt.SetXmin(entity.Xmin);
 
         // Restore RSVPs
         var rsvps = entity.Rsvps.Select(r => GameNightRsvp.Reconstitute(

--- a/apps/api/src/Api/Infrastructure/Entities/GameManagement/GameNightEventEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/GameManagement/GameNightEventEntity.cs
@@ -78,4 +78,10 @@ public class GameNightEventEntity
     public List<GameNightRsvpEntity> Rsvps { get; set; } = [];
 
     public List<GameNightSessionEntity> Sessions { get; set; } = [];
+
+    // Optimistic concurrency via PostgreSQL's xmin system column (Issue #2703, ADR-060).
+    // Server-owned: Postgres assigns xmin = transaction-id-of-last-write per row.
+    // The repository round-trips this value so the detached Update emits a
+    // WHERE id = @id AND xmin = @original concurrency check.
+    public uint Xmin { get; set; }
 }

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/GameManagement/GameNightEventEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/GameManagement/GameNightEventEntityConfiguration.cs
@@ -34,6 +34,15 @@ internal class GameNightEventEntityConfiguration : IEntityTypeConfiguration<Game
         builder.Property(e => e.CreatedAt).HasColumnName("created_at").IsRequired();
         builder.Property(e => e.UpdatedAt).HasColumnName("updated_at");
 
+        // Optimistic concurrency via PostgreSQL's xmin system column (Issue #2703, ADR-060).
+        // Server-owned, collision-safe (xmin = unique transaction id per row UPDATE).
+        // Mirrors game_night_playlists (#2306) — no bytea row_version, no trigger.
+        builder.Property(e => e.Xmin)
+            .HasColumnName("xmin")
+            .HasColumnType("xid")
+            .ValueGeneratedOnAddOrUpdate()
+            .IsConcurrencyToken();
+
         builder.HasIndex(e => new { e.OrganizerId, e.ScheduledAt })
             .HasDatabaseName("IX_game_night_events_organizer_scheduled");
 

--- a/apps/api/src/Api/Infrastructure/Migrations/20260706110840_AddGameNightEventXmin.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260706110840_AddGameNightEventXmin.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260706110840_AddGameNightEventXmin")]
+    partial class AddGameNightEventXmin
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260706110840_AddGameNightEventXmin.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260706110840_AddGameNightEventXmin.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddGameNightEventXmin : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // xmin is a PostgreSQL system column (transaction ID of the last update).
+            // It exists on every Postgres table by default and does NOT need to be created —
+            // the EF-scaffolded AddColumn<uint>("xmin", type: "xid") would fail at runtime.
+            // This migration carries only the EF model snapshot update so that EF can round-trip
+            // the value as an optimistic-concurrency token (ADR-060). Issue #2703.
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            // xmin is a PostgreSQL system column — nothing to drop.
+        }
+    }
+}

--- a/apps/api/tests/Api.Tests/Integration/GameManagement/GameNightEventConcurrencyTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/GameManagement/GameNightEventConcurrencyTests.cs
@@ -1,0 +1,151 @@
+using Api.BoundedContexts.GameManagement.Infrastructure.Persistence;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.GameManagement;
+using Api.SharedKernel.Application.Services;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.Integration.GameManagement;
+
+/// <summary>
+/// Integration tests proving that <c>game_night_events</c> enforces optimistic concurrency
+/// via the PostgreSQL <c>xmin</c> system-column concurrency token — Issue #2703 (Umbrella #2697,
+/// spec §4a US-INT-3 failure-mode #3, ADR-060).
+///
+/// Unlike the sibling <see cref="GameNightPlaylistRowVersionConcurrencyTests"/> (which checks at
+/// the raw-entity level), these tests exercise the full <see cref="GameNightEventRepository"/>
+/// round-trip: the repository loads with <c>AsNoTracking()</c> and writes with a detached
+/// <c>.Update()</c> that re-maps a brand-new persistence entity. The xmin token must survive that
+/// round-trip (loaded in <c>MapToDomain</c>, written back in <c>MapToPersistence</c>) for the
+/// concurrency check to fire. Before #2703 the entity had no xmin token, so the detached UPDATE
+/// emitted <c>WHERE id = @id</c> only → last-write-wins → the second writer silently overwrote.
+/// </summary>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "GameManagement")]
+[Trait("Issue", "2703")]
+public sealed class GameNightEventConcurrencyTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private string _databaseName = null!;
+    private string _connectionString = null!;
+    private MeepleAiDbContext _dbContext = null!;
+
+    public GameNightEventConcurrencyTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    private static CancellationToken TestCancellationToken => TestContext.Current.CancellationToken;
+
+    public async ValueTask InitializeAsync()
+    {
+        _databaseName = $"gamenight_xmin_{Guid.NewGuid():N}";
+        _connectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+        _dbContext = _fixture.CreateDbContext(_connectionString);
+        await _dbContext.Database.MigrateAsync(TestCancellationToken);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _dbContext.DisposeAsync();
+        await _fixture.DropIsolatedDatabaseAsync(_databaseName);
+    }
+
+    private GameNightEventRepository CreateRepository(MeepleAiDbContext dbContext) =>
+        new(dbContext, Mock.Of<IDomainEventCollector>(), Mock.Of<ILogger<GameNightEventRepository>>());
+
+    private async Task<Guid> SeedEventAsync(string status = "Published")
+    {
+        var eventId = Guid.NewGuid();
+        _dbContext.GameNightEvents.Add(new GameNightEventEntity
+        {
+            Id = eventId,
+            OrganizerId = Guid.NewGuid(),
+            Title = "Original Title",
+            ScheduledAt = DateTimeOffset.UtcNow.AddDays(3),
+            GameIdsJson = "[]",
+            Status = status,
+            CreatedAt = DateTimeOffset.UtcNow,
+            UpdatedAt = DateTimeOffset.UtcNow
+        });
+        await _dbContext.SaveChangesAsync(TestCancellationToken);
+        return eventId;
+    }
+
+    /// <summary>
+    /// Two organisers load the same game night, both edit, the first commits (advancing the row's
+    /// xmin), then the second commits holding the stale token — EF must raise
+    /// <see cref="DbUpdateConcurrencyException"/> (0 rows affected). The global middleware maps this
+    /// to 409 with <c>X-Warning-Code: concurrent-edit</c>.
+    /// </summary>
+    [Fact(DisplayName = "Concurrent GameNightEvent updates via repository throw DbUpdateConcurrencyException via xmin")]
+    public async Task ConcurrentUpdates_ViaRepository_ThrowDbUpdateConcurrencyException()
+    {
+        // ── Arrange: seed one event, then load it from two independent contexts ──
+        var eventId = await SeedEventAsync();
+
+        await using var dbA = _fixture.CreateDbContext(_connectionString);
+        await using var dbB = _fixture.CreateDbContext(_connectionString);
+        var repoA = CreateRepository(dbA);
+        var repoB = CreateRepository(dbB);
+
+        var eventA = await repoA.GetByIdAsync(eventId, TestCancellationToken);
+        var eventB = await repoB.GetByIdAsync(eventId, TestCancellationToken);
+        eventA.Should().NotBeNull();
+        eventB.Should().NotBeNull();
+
+        // ── Act: A wins the race and commits first (xmin advances in Postgres) ──
+        eventA!.Update("Updated by A", null, eventA.ScheduledAt, null, null, null);
+        await repoA.UpdateAsync(eventA, TestCancellationToken);
+        await dbA.SaveChangesAsync(TestCancellationToken);
+
+        // B holds a stale xmin — its detached UPDATE must match 0 rows in Postgres.
+        eventB!.Update("Updated by B", null, eventB.ScheduledAt, null, null, null);
+        await repoB.UpdateAsync(eventB, TestCancellationToken);
+        Func<Task> act = async () => await dbB.SaveChangesAsync(TestCancellationToken);
+
+        // ── Assert ──────────────────────────────────────────────────────────────
+        await act.Should().ThrowAsync<DbUpdateConcurrencyException>(
+            "scope B holds a stale xmin after scope A committed — " +
+            "EF optimistic concurrency must reject the second save");
+    }
+
+    /// <summary>
+    /// Regression guard: a single load→edit→save round-trip through the repository must still
+    /// persist the change. Protects against the xmin migration accidentally turning the detached
+    /// update into a silent no-op (cfr. memory repo-updateasync-astracking-notracking).
+    /// </summary>
+    [Fact(DisplayName = "Single GameNightEvent update via repository persists the change")]
+    public async Task SingleUpdate_ViaRepository_PersistsChange()
+    {
+        // ── Arrange ─────────────────────────────────────────────────────────────
+        var eventId = await SeedEventAsync();
+
+        await using var dbWrite = _fixture.CreateDbContext(_connectionString);
+        var repo = CreateRepository(dbWrite);
+
+        var evt = await repo.GetByIdAsync(eventId, TestCancellationToken);
+        evt.Should().NotBeNull();
+
+        // ── Act ─────────────────────────────────────────────────────────────────
+        evt!.Update("Updated Title", "New description", evt.ScheduledAt, "New location", 8, null);
+        await repo.UpdateAsync(evt, TestCancellationToken);
+        await dbWrite.SaveChangesAsync(TestCancellationToken);
+
+        // ── Assert: reload from a fresh context and confirm the scalar change stuck ──
+        await using var dbVerify = _fixture.CreateDbContext(_connectionString);
+        var reloaded = await dbVerify.GameNightEvents
+            .AsNoTracking()
+            .FirstAsync(e => e.Id == eventId, TestCancellationToken);
+
+        reloaded.Title.Should().Be("Updated Title");
+        reloaded.Location.Should().Be("New location");
+        reloaded.MaxPlayers.Should().Be(8);
+    }
+}


### PR DESCRIPTION
> Closes #2703 · Umbrella #2697 (Tier 3) · Spec §4a US-INT-3 failure-mode #3 · ADR-060

## Gap

The `GameNightEvent` aggregate had **no optimistic concurrency**: `game_night_events` lacked an `xmin`/`RowVersion` token, and `GameNightEventRepository.UpdateAsync` issued a detached full-row `.Update()` with `WHERE id = @id` only. Concurrent host edits (or a host edit racing an RSVP-driven write) silently overwrote each other.

## Fix

Map the PostgreSQL `xmin` system column as an EF concurrency token, mirroring the proven `game_night_playlists` (#2306) / `play_records` (#2437) siblings:

- `uint Xmin` on `GameNightEventEntity` + Fluent config (`xid`, `ValueGeneratedOnAddOrUpdate`, `IsConcurrencyToken`).
- `uint Xmin` + `internal SetXmin()` on the `GameNightEvent` aggregate.
- `GameNightEventRepository` round-trips the token — `SetXmin` in `MapToDomain`, `Xmin` in `MapToPersistence` — so the detached `.Update()` emits `WHERE id = @id AND xmin = @original`.
- Empty EF migration (`xmin` is a Postgres system column; the scaffolded `AddColumn` would fail at runtime), carrying only the model-snapshot update.

### Why no handler-level catch

`DbUpdateConcurrencyException` propagates to the existing `ApiExceptionHandlerMiddleware`, which already maps it to **409 + `X-Warning-Code: concurrent-edit`** (richer than a handler-level `ConflictException`, and exactly what the #2701 edit-drawer reload-and-retry UX consumes). No handler change — matches the `GameNightPlaylist`/`PlayRecord` siblings.

## Tests (TDD, Testcontainers, repository round-trip)

`GameNightEventConcurrencyTests`:
- **Concurrency**: two independent contexts load the same event, first commits (xmin advances), second commits with a stale token → `DbUpdateConcurrencyException`. Watched RED first (no exception thrown pre-fix), then GREEN.
- **Regression guard**: a single load→edit→save round-trip still persists the scalar change (protects against a silent no-op).

Regression sweep: **406 GameNight unit + 104 GameNight integration = 510 tests, 0 failures.**

## Definition of Done

- [x] `xmin` concurrency on `game_night_events`
- [x] 409 on conflict (via middleware `concurrent_edit`)
- [x] EF migration
- [x] Concurrency + regression tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)