### PR TITLE
feat(game-night): #2700 candidate voting (approval model, full-stack)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/CastGameNightVoteCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/CastGameNightVoteCommand.cs
@@ -1,0 +1,12 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.GameManagement.Application.Commands.GameNights;
+
+/// <summary>
+/// Command to cast (approve) a vote for a candidate game on a game night — Issue #2700.
+/// Idempotent: re-approving an already-approved candidate is a no-op.
+/// </summary>
+internal record CastGameNightVoteCommand(
+    Guid GameNightId,
+    Guid VoterUserId,
+    Guid CandidateGameId) : ICommand;

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/CastGameNightVoteCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/CastGameNightVoteCommandHandler.cs
@@ -2,6 +2,7 @@ using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
 using Api.Middleware.Exceptions;
 using Api.SharedKernel.Application.Interfaces;
 using Api.SharedKernel.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
 
 namespace Api.BoundedContexts.GameManagement.Application.Commands.GameNights;
 
@@ -40,7 +41,18 @@ internal sealed class CastGameNightVoteCommandHandler : ICommandHandler<CastGame
         if (vote is null)
             return; // approval already recorded — idempotent
 
-        await _repository.AddVoteAsync(vote, cancellationToken).ConfigureAwait(false);
-        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            await _repository.AddVoteAsync(vote, cancellationToken).ConfigureAwait(false);
+            await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (DbUpdateException ex)
+            when (ex.InnerException is Npgsql.PostgresException { SqlState: "23505" })
+        {
+            // A concurrent request approved the same (voter, candidate) pair first and won the
+            // unique index (event, voter, candidate). Our in-memory idempotency guard could not
+            // see it (both requests loaded before either committed). Treat the duplicate INSERT
+            // rejection as the idempotent success it is.
+        }
     }
 }

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/CastGameNightVoteCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/CastGameNightVoteCommandHandler.cs
@@ -1,0 +1,46 @@
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Infrastructure.Persistence;
+
+namespace Api.BoundedContexts.GameManagement.Application.Commands.GameNights;
+
+/// <summary>
+/// Casts an approval vote for a candidate game — Issue #2700.
+/// The aggregate enforces the guards (Published, voting open, valid candidate, confirmed voter)
+/// and returns the new vote (or null for an idempotent re-approval). The vote is inserted via
+/// the tracked <see cref="IGameNightEventRepository.AddVoteAsync"/> path.
+/// </summary>
+internal sealed class CastGameNightVoteCommandHandler : ICommandHandler<CastGameNightVoteCommand>
+{
+    private readonly IGameNightEventRepository _repository;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly TimeProvider _timeProvider;
+
+    public CastGameNightVoteCommandHandler(
+        IGameNightEventRepository repository,
+        IUnitOfWork unitOfWork,
+        TimeProvider timeProvider)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+    }
+
+    public async Task Handle(CastGameNightVoteCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var gameNight = await _repository.GetByIdAsync(command.GameNightId, cancellationToken).ConfigureAwait(false)
+            ?? throw new NotFoundException("GameNightEvent", command.GameNightId.ToString());
+
+        var vote = gameNight.CastVote(
+            command.VoterUserId, command.CandidateGameId, _timeProvider.GetUtcNow());
+
+        if (vote is null)
+            return; // approval already recorded — idempotent
+
+        await _repository.AddVoteAsync(vote, cancellationToken).ConfigureAwait(false);
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/ResolveGameNightVotingTieCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/ResolveGameNightVotingTieCommand.cs
@@ -1,0 +1,12 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.GameManagement.Application.Commands.GameNights;
+
+/// <summary>
+/// Command for the organiser to resolve a voting tie after voting closes, choosing one of
+/// the tied leaders as the winner — Issue #2700.
+/// </summary>
+internal record ResolveGameNightVotingTieCommand(
+    Guid GameNightId,
+    Guid HostUserId,
+    Guid WinningCandidateGameId) : ICommand;

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/ResolveGameNightVotingTieCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/ResolveGameNightVotingTieCommandHandler.cs
@@ -1,0 +1,39 @@
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.GameManagement.Application.Commands.GameNights;
+
+/// <summary>
+/// Resolves a voting tie by persisting the organiser's chosen winner — Issue #2700.
+/// The aggregate enforces the guards (organiser-only, voting closed, an actual tie, valid
+/// choice); the resolved winner is written directly to the event row via
+/// <see cref="IGameNightEventRepository.SetVotingWinnerAsync"/>.
+/// </summary>
+internal sealed class ResolveGameNightVotingTieCommandHandler : ICommandHandler<ResolveGameNightVotingTieCommand>
+{
+    private readonly IGameNightEventRepository _repository;
+    private readonly TimeProvider _timeProvider;
+
+    public ResolveGameNightVotingTieCommandHandler(
+        IGameNightEventRepository repository,
+        TimeProvider timeProvider)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+    }
+
+    public async Task Handle(ResolveGameNightVotingTieCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var gameNight = await _repository.GetByIdAsync(command.GameNightId, cancellationToken).ConfigureAwait(false)
+            ?? throw new NotFoundException("GameNightEvent", command.GameNightId.ToString());
+
+        gameNight.ResolveVotingTie(
+            command.HostUserId, command.WinningCandidateGameId, _timeProvider.GetUtcNow());
+
+        await _repository.SetVotingWinnerAsync(
+            command.GameNightId, gameNight.VotingWinnerGameId, cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/RetractGameNightVoteCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/RetractGameNightVoteCommand.cs
@@ -1,0 +1,12 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.GameManagement.Application.Commands.GameNights;
+
+/// <summary>
+/// Command to retract a previously-cast approval vote for a candidate game — Issue #2700.
+/// Idempotent: retracting an absent vote is a no-op.
+/// </summary>
+internal record RetractGameNightVoteCommand(
+    Guid GameNightId,
+    Guid VoterUserId,
+    Guid CandidateGameId) : ICommand;

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/RetractGameNightVoteCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/RetractGameNightVoteCommandHandler.cs
@@ -1,0 +1,45 @@
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Infrastructure.Persistence;
+
+namespace Api.BoundedContexts.GameManagement.Application.Commands.GameNights;
+
+/// <summary>
+/// Retracts a previously-cast approval vote — Issue #2700. The aggregate enforces the
+/// voting-open guard and returns the removed vote (or null when absent). The vote is deleted
+/// via the tracked <see cref="IGameNightEventRepository.RemoveVoteAsync"/> path.
+/// </summary>
+internal sealed class RetractGameNightVoteCommandHandler : ICommandHandler<RetractGameNightVoteCommand>
+{
+    private readonly IGameNightEventRepository _repository;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly TimeProvider _timeProvider;
+
+    public RetractGameNightVoteCommandHandler(
+        IGameNightEventRepository repository,
+        IUnitOfWork unitOfWork,
+        TimeProvider timeProvider)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+    }
+
+    public async Task Handle(RetractGameNightVoteCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var gameNight = await _repository.GetByIdAsync(command.GameNightId, cancellationToken).ConfigureAwait(false)
+            ?? throw new NotFoundException("GameNightEvent", command.GameNightId.ToString());
+
+        var vote = gameNight.RetractVote(
+            command.VoterUserId, command.CandidateGameId, _timeProvider.GetUtcNow());
+
+        if (vote is null)
+            return; // nothing to retract — idempotent
+
+        await _repository.RemoveVoteAsync(vote.Id, cancellationToken).ConfigureAwait(false);
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/GameNights/GameNightVoteTallyDto.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/GameNights/GameNightVoteTallyDto.cs
@@ -1,0 +1,22 @@
+namespace Api.BoundedContexts.GameManagement.Application.DTOs.GameNights;
+
+/// <summary>
+/// Approval-vote tally for a game night's candidate games — Issue #2700.
+/// </summary>
+/// <param name="IsVotingClosed">True once voting has closed (ScheduledAt - 1h).</param>
+/// <param name="IsTie">True when more than one candidate shares the lead.</param>
+/// <param name="WinnerGameId">Resolved winner (organiser tie-break, else single leader, else null).</param>
+/// <param name="LeadingCandidateGameIds">Candidate(s) with the maximum vote count.</param>
+/// <param name="Candidates">Per-candidate counts with the caller's own approval flag.</param>
+public sealed record GameNightVoteTallyDto(
+    bool IsVotingClosed,
+    bool IsTie,
+    Guid? WinnerGameId,
+    IReadOnlyList<Guid> LeadingCandidateGameIds,
+    IReadOnlyList<GameNightCandidateTallyDto> Candidates);
+
+/// <summary>Per-candidate approval tally row.</summary>
+/// <param name="GameId">The candidate game.</param>
+/// <param name="VoteCount">Number of approval votes for this candidate.</param>
+/// <param name="VotedByMe">Whether the requesting user has approved this candidate.</param>
+public sealed record GameNightCandidateTallyDto(Guid GameId, int VoteCount, bool VotedByMe);

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GetGameNightVoteTallyQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GetGameNightVoteTallyQuery.cs
@@ -1,0 +1,12 @@
+using Api.BoundedContexts.GameManagement.Application.DTOs.GameNights;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.GameManagement.Application.Queries.GameNights;
+
+/// <summary>
+/// Query for the candidate-vote tally of a game night — Issue #2700.
+/// <see cref="CallerUserId"/> scopes the read to participants (organizer or invited) and
+/// drives the per-candidate <c>VotedByMe</c> flag.
+/// </summary>
+internal record GetGameNightVoteTallyQuery(Guid GameNightId, Guid CallerUserId)
+    : IQuery<GameNightVoteTallyDto>;

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GetGameNightVoteTallyQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GetGameNightVoteTallyQueryHandler.cs
@@ -1,0 +1,59 @@
+using Api.BoundedContexts.GameManagement.Application.DTOs.GameNights;
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.GameManagement.Application.Queries.GameNights;
+
+/// <summary>
+/// Returns the candidate-vote tally for a game night — Issue #2700.
+/// Participant-scoped (organizer or invited) per the IDOR guard shared with the detail read
+/// (#2698). The <c>VotedByMe</c> flag reflects the caller's own approvals.
+/// </summary>
+internal sealed class GetGameNightVoteTallyQueryHandler
+    : IQueryHandler<GetGameNightVoteTallyQuery, GameNightVoteTallyDto>
+{
+    private readonly IGameNightEventRepository _repository;
+    private readonly TimeProvider _timeProvider;
+
+    public GetGameNightVoteTallyQueryHandler(
+        IGameNightEventRepository repository,
+        TimeProvider timeProvider)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+    }
+
+    public async Task<GameNightVoteTallyDto> Handle(
+        GetGameNightVoteTallyQuery query, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var gameNight = await _repository.GetByIdAsync(query.GameNightId, cancellationToken).ConfigureAwait(false)
+            ?? throw new NotFoundException("GameNightEvent", query.GameNightId.ToString());
+
+        // #2698 IDOR: participant-scoped read (organizer or invited).
+        var isParticipant = gameNight.OrganizerId == query.CallerUserId
+            || gameNight.Rsvps.Any(r => r.UserId == query.CallerUserId);
+        if (!isParticipant)
+            throw new ForbiddenException("Only the organizer or an invited player can view the vote tally.");
+
+        var tally = gameNight.TallyVotes();
+
+        var myApprovals = gameNight.Votes
+            .Where(v => v.VoterUserId == query.CallerUserId)
+            .Select(v => v.CandidateGameId)
+            .ToHashSet();
+
+        var candidates = tally.CountsByCandidate
+            .Select(kv => new GameNightCandidateTallyDto(kv.Key, kv.Value, myApprovals.Contains(kv.Key)))
+            .ToList();
+
+        return new GameNightVoteTallyDto(
+            IsVotingClosed: gameNight.IsVotingClosed(_timeProvider.GetUtcNow()),
+            IsTie: tally.IsTie,
+            WinnerGameId: tally.WinnerGameId,
+            LeadingCandidateGameIds: tally.LeadingCandidateGameIds,
+            Candidates: candidates);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Validators/GameNights/CastGameNightVoteCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Validators/GameNights/CastGameNightVoteCommandValidator.cs
@@ -1,0 +1,15 @@
+using Api.BoundedContexts.GameManagement.Application.Commands.GameNights;
+using FluentValidation;
+
+namespace Api.BoundedContexts.GameManagement.Application.Validators.GameNights;
+
+/// <summary>Validator for CastGameNightVoteCommand — Issue #2700.</summary>
+internal sealed class CastGameNightVoteCommandValidator : AbstractValidator<CastGameNightVoteCommand>
+{
+    public CastGameNightVoteCommandValidator()
+    {
+        RuleFor(x => x.GameNightId).NotEmpty().WithMessage("Game night ID is required");
+        RuleFor(x => x.VoterUserId).NotEmpty().WithMessage("Voter user ID is required");
+        RuleFor(x => x.CandidateGameId).NotEmpty().WithMessage("Candidate game ID is required");
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Validators/GameNights/ResolveGameNightVotingTieCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Validators/GameNights/ResolveGameNightVotingTieCommandValidator.cs
@@ -1,0 +1,16 @@
+using Api.BoundedContexts.GameManagement.Application.Commands.GameNights;
+using FluentValidation;
+
+namespace Api.BoundedContexts.GameManagement.Application.Validators.GameNights;
+
+/// <summary>Validator for ResolveGameNightVotingTieCommand — Issue #2700.</summary>
+internal sealed class ResolveGameNightVotingTieCommandValidator
+    : AbstractValidator<ResolveGameNightVotingTieCommand>
+{
+    public ResolveGameNightVotingTieCommandValidator()
+    {
+        RuleFor(x => x.GameNightId).NotEmpty().WithMessage("Game night ID is required");
+        RuleFor(x => x.HostUserId).NotEmpty().WithMessage("Host user ID is required");
+        RuleFor(x => x.WinningCandidateGameId).NotEmpty().WithMessage("Winning candidate game ID is required");
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Validators/GameNights/RetractGameNightVoteCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Validators/GameNights/RetractGameNightVoteCommandValidator.cs
@@ -1,0 +1,15 @@
+using Api.BoundedContexts.GameManagement.Application.Commands.GameNights;
+using FluentValidation;
+
+namespace Api.BoundedContexts.GameManagement.Application.Validators.GameNights;
+
+/// <summary>Validator for RetractGameNightVoteCommand — Issue #2700.</summary>
+internal sealed class RetractGameNightVoteCommandValidator : AbstractValidator<RetractGameNightVoteCommand>
+{
+    public RetractGameNightVoteCommandValidator()
+    {
+        RuleFor(x => x.GameNightId).NotEmpty().WithMessage("Game night ID is required");
+        RuleFor(x => x.VoterUserId).NotEmpty().WithMessage("Voter user ID is required");
+        RuleFor(x => x.CandidateGameId).NotEmpty().WithMessage("Candidate game ID is required");
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/GameNightEvent/GameNightEvent.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/GameNightEvent/GameNightEvent.cs
@@ -1,6 +1,7 @@
 using Api.BoundedContexts.GameManagement.Domain.Enums;
 using Api.BoundedContexts.GameManagement.Domain.Events;
 using Api.BoundedContexts.GameManagement.Domain.Exceptions;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Domain.Entities;
 
 namespace Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
@@ -15,6 +16,7 @@ internal sealed class GameNightEvent : AggregateRoot<Guid>
 #pragma warning restore MA0049
 {
     private readonly List<GameNightRsvp> _rsvps = new();
+    private readonly List<GameNightVote> _votes = new();
 
     public Guid OrganizerId { get; private set; }
     public string Title { get; private set; }
@@ -45,6 +47,15 @@ internal sealed class GameNightEvent : AggregateRoot<Guid>
     public DateTimeOffset CreatedAt { get; private set; }
     public DateTimeOffset? UpdatedAt { get; private set; }
     public IReadOnlyList<GameNightRsvp> Rsvps => _rsvps.AsReadOnly();
+
+    // Candidate voting (approval model) — Issue #2700
+    public IReadOnlyList<GameNightVote> Votes => _votes.AsReadOnly();
+
+    /// <summary>
+    /// Organiser-chosen winner set when candidate voting closed on a tie (#2700).
+    /// Null when there is no tie or the tie has not been resolved.
+    /// </summary>
+    public Guid? VotingWinnerGameId { get; private set; }
 
     // Optimistic concurrency via PostgreSQL's xmin system column (Issue #2703, ADR-060).
     // Server-owned: Postgres assigns xmin on each write; EF reads it back so the
@@ -327,6 +338,127 @@ internal sealed class GameNightEvent : AggregateRoot<Guid>
     /// Returns true if the game night has reached its maximum player count.
     /// </summary>
     public bool IsFull => MaxPlayers.HasValue && AcceptedCount >= MaxPlayers.Value;
+
+    // ── Candidate voting (approval model) — Issue #2700 ──────────────────────
+
+    /// <summary>Voting on candidate games closes this long before <see cref="ScheduledAt"/>.</summary>
+    public static readonly TimeSpan VotingCloseLeadTime = TimeSpan.FromHours(1);
+
+    /// <summary>
+    /// True once candidate voting has closed for the night: at or after
+    /// <c>ScheduledAt - 1h</c> (lazy check, no scheduled job — ADR-074 Option C philosophy).
+    /// </summary>
+    public bool IsVotingClosed(DateTimeOffset now) => now >= ScheduledAt - VotingCloseLeadTime;
+
+    /// <summary>
+    /// Casts (approves) a vote for a candidate game. Approval model: a confirmed participant
+    /// may approve any subset of candidates, one vote each. Idempotent for a repeated
+    /// (voter, candidate) pair. Guards: Published status, voting open, valid candidate,
+    /// confirmed (Accepted RSVP) voter.
+    /// </summary>
+    /// <returns>The newly-created vote, or null when the approval already existed (idempotent no-op).</returns>
+    public GameNightVote? CastVote(Guid voterUserId, Guid candidateGameId, DateTimeOffset now)
+    {
+        ThrowIfCorrupted();
+
+        if (Status != GameNightStatus.Published)
+            throw new ConflictException("Voting is only open on published game nights");
+        if (IsVotingClosed(now))
+            throw new ConflictException("Voting has closed for this game night");
+        if (!GameIds.Contains(candidateGameId))
+            throw new NotFoundException("GameNightCandidate", candidateGameId.ToString());
+        if (!IsConfirmedParticipant(voterUserId))
+            throw new ForbiddenException("Only confirmed participants can vote on candidate games");
+
+        if (_votes.Any(v => v.VoterUserId == voterUserId && v.CandidateGameId == candidateGameId))
+            return null; // approval toggle: a repeated approval is a no-op
+
+        var vote = GameNightVote.Create(Id, voterUserId, candidateGameId);
+        _votes.Add(vote);
+        UpdatedAt = now;
+        return vote;
+    }
+
+    /// <summary>
+    /// Retracts a previously-cast approval vote. Idempotent when the vote is absent.
+    /// Guard: voting still open.
+    /// </summary>
+    /// <returns>The removed vote, or null when no matching approval existed (idempotent no-op).</returns>
+    public GameNightVote? RetractVote(Guid voterUserId, Guid candidateGameId, DateTimeOffset now)
+    {
+        ThrowIfCorrupted();
+
+        if (IsVotingClosed(now))
+            throw new ConflictException("Voting has closed for this game night");
+
+        var vote = _votes.FirstOrDefault(
+            v => v.VoterUserId == voterUserId && v.CandidateGameId == candidateGameId);
+        if (vote is null)
+            return null; // idempotent
+
+        _votes.Remove(vote);
+        UpdatedAt = now;
+        return vote;
+    }
+
+    /// <summary>
+    /// Organiser resolves a voting tie after voting has closed, choosing one of the tied
+    /// leaders as the winner. Guards: organiser-only, voting closed, an actual tie exists,
+    /// the chosen game is one of the tied leaders.
+    /// </summary>
+    public void ResolveVotingTie(Guid hostUserId, Guid winningCandidateGameId, DateTimeOffset now)
+    {
+        ThrowIfCorrupted();
+
+        if (hostUserId != OrganizerId)
+            throw new ForbiddenException("Only the organiser can resolve a voting tie");
+        if (!IsVotingClosed(now))
+            throw new ConflictException(
+                "Voting is still open; a tie can only be resolved after voting closes");
+
+        var tally = TallyVotes();
+        if (!tally.IsTie)
+            throw new ConflictException("There is no voting tie to resolve");
+        if (!tally.LeadingCandidateGameIds.Contains(winningCandidateGameId))
+            throw new ConflictException("The chosen game is not among the tied leaders");
+
+        VotingWinnerGameId = winningCandidateGameId;
+        UpdatedAt = now;
+    }
+
+    /// <summary>
+    /// Tallies approval votes per candidate game and derives the leader(s), tie flag, and
+    /// resolved winner (organiser tie-break if set, else the single leader, else null).
+    /// </summary>
+    public GameNightVoteTally TallyVotes()
+    {
+        var counts = GameIds.ToDictionary(
+            gameId => gameId,
+            gameId => _votes.Count(v => v.CandidateGameId == gameId));
+
+        var max = counts.Count == 0 ? 0 : counts.Values.Max();
+        var leaders = max == 0
+            ? new List<Guid>()
+            : counts.Where(kv => kv.Value == max).Select(kv => kv.Key).ToList();
+        var isTie = leaders.Count > 1;
+
+        var winner = VotingWinnerGameId ?? (leaders.Count == 1 ? leaders[0] : (Guid?)null);
+
+        return new GameNightVoteTally(counts, leaders, isTie, winner);
+    }
+
+    private bool IsConfirmedParticipant(Guid userId) =>
+        _rsvps.Any(r => r.UserId == userId && r.Status == RsvpStatus.Accepted);
+
+    /// <summary>Restores votes from persistence.</summary>
+    internal void RestoreVotes(IEnumerable<GameNightVote> votes)
+    {
+        _votes.Clear();
+        _votes.AddRange(votes);
+    }
+
+    /// <summary>Restores the resolved tie-break winner from persistence.</summary>
+    internal void RestoreVotingWinner(Guid? winnerGameId) => VotingWinnerGameId = winnerGameId;
 
     /// <summary>
     /// Marks that the 24-hour reminder has been sent.

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/GameNightEvent/GameNightEvent.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/GameNightEvent/GameNightEvent.cs
@@ -388,6 +388,10 @@ internal sealed class GameNightEvent : AggregateRoot<Guid>
     {
         ThrowIfCorrupted();
 
+        // IDOR: gate authorization before revealing any voting state (parity with #2698).
+        if (!IsConfirmedParticipant(voterUserId))
+            throw new ForbiddenException("Only confirmed participants can retract a vote");
+
         if (IsVotingClosed(now))
             throw new ConflictException("Voting has closed for this game night");
 

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/GameNightEvent/GameNightVote.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/GameNightEvent/GameNightVote.cs
@@ -1,0 +1,54 @@
+namespace Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+
+/// <summary>
+/// Entity representing a single approval vote for a candidate game on a game night.
+/// Owned by the <see cref="GameNightEvent"/> aggregate root — Issue #2700.
+///
+/// Approval model: a confirmed participant casts at most one vote per candidate game
+/// (uniqueness enforced by the aggregate + a DB unique index on
+/// (event, voter, candidate)).
+/// </summary>
+public sealed class GameNightVote
+{
+    public Guid Id { get; private set; }
+    public Guid EventId { get; private set; }
+    public Guid VoterUserId { get; private set; }
+    public Guid CandidateGameId { get; private set; }
+    public DateTimeOffset CreatedAt { get; private set; }
+
+#pragma warning disable CS8618
+    private GameNightVote() { } // EF Core
+#pragma warning restore CS8618
+
+    internal static GameNightVote Create(Guid eventId, Guid voterUserId, Guid candidateGameId)
+    {
+        if (eventId == Guid.Empty) throw new ArgumentException("EventId required", nameof(eventId));
+        if (voterUserId == Guid.Empty) throw new ArgumentException("VoterUserId required", nameof(voterUserId));
+        if (candidateGameId == Guid.Empty) throw new ArgumentException("CandidateGameId required", nameof(candidateGameId));
+
+        return new GameNightVote
+        {
+            Id = Guid.NewGuid(),
+            EventId = eventId,
+            VoterUserId = voterUserId,
+            CandidateGameId = candidateGameId,
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+    }
+
+    /// <summary>
+    /// Reconstitutes a vote from persistence data.
+    /// </summary>
+    internal static GameNightVote Reconstitute(
+        Guid id, Guid eventId, Guid voterUserId, Guid candidateGameId, DateTimeOffset createdAt)
+    {
+        return new GameNightVote
+        {
+            Id = id,
+            EventId = eventId,
+            VoterUserId = voterUserId,
+            CandidateGameId = candidateGameId,
+            CreatedAt = createdAt
+        };
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/GameNightEvent/GameNightVoteTally.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/GameNightEvent/GameNightVoteTally.cs
@@ -1,0 +1,18 @@
+namespace Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+
+/// <summary>
+/// Read-model result of tallying candidate-game approval votes on a game night — Issue #2700.
+///
+/// <para><see cref="CountsByCandidate"/> maps every candidate game id to its approval count
+/// (candidates with zero votes are present with a count of 0).</para>
+/// <para><see cref="LeadingCandidateGameIds"/> holds the candidate(s) with the maximum count
+/// (empty when no votes were cast). <see cref="IsTie"/> is true when more than one candidate
+/// shares the lead.</para>
+/// <para><see cref="WinnerGameId"/> is the resolved winner: an organiser tie-break decision if
+/// one was made, otherwise the single leader, otherwise null (no votes or unresolved tie).</para>
+/// </summary>
+public sealed record GameNightVoteTally(
+    IReadOnlyDictionary<Guid, int> CountsByCandidate,
+    IReadOnlyList<Guid> LeadingCandidateGameIds,
+    bool IsTie,
+    Guid? WinnerGameId);

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/GameNightEvent/IGameNightEventRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/GameNightEvent/IGameNightEventRepository.cs
@@ -46,4 +46,19 @@ internal interface IGameNightEventRepository : IRepository<GameNightEvent, Guid>
     /// the parent game night when a Session transitions to live mode.
     /// </remarks>
     Task<GameNightEvent?> FindByLinkedSessionIdAsync(Guid sessionId, CancellationToken cancellationToken = default);
+
+    // ── Candidate voting (approval model) — Issue #2700 ──────────────────────
+    // Votes are immutable append/remove children persisted with tracked Add/Remove.
+    // They deliberately bypass the aggregate's detached-Update full-remap: EF's
+    // Update() marks a brand-new PK-set child as Modified → 0-row UPDATE. Loading the
+    // event (which Includes Votes) still preserves existing votes across an event edit.
+
+    /// <summary>Inserts a single approval vote (tracked Add → INSERT).</summary>
+    Task AddVoteAsync(GameNightVote vote, CancellationToken cancellationToken = default);
+
+    /// <summary>Removes a single approval vote by its id (tracked delete). No-op when absent.</summary>
+    Task RemoveVoteAsync(Guid voteId, CancellationToken cancellationToken = default);
+
+    /// <summary>Persists the organiser's resolved tie-break winner on the event row.</summary>
+    Task SetVotingWinnerAsync(Guid eventId, Guid? winnerGameId, CancellationToken cancellationToken = default);
 }

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Persistence/GameNightEventRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Persistence/GameNightEventRepository.cs
@@ -58,6 +58,7 @@ internal class GameNightEventRepository : RepositoryBase, IGameNightEventReposit
             .AsNoTracking()
             .Include(e => e.Rsvps)
             .Include(e => e.Sessions)
+            .Include(e => e.Votes)
             .FirstOrDefaultAsync(e => e.Id == id, cancellationToken).ConfigureAwait(false);
 
         return entity != null ? MapToDomain(entity) : null;
@@ -69,6 +70,7 @@ internal class GameNightEventRepository : RepositoryBase, IGameNightEventReposit
             .AsNoTracking()
             .Include(e => e.Rsvps)
             .Include(e => e.Sessions)
+            .Include(e => e.Votes)
             .OrderByDescending(e => e.ScheduledAt)
             .ToListAsync(cancellationToken).ConfigureAwait(false);
 
@@ -81,6 +83,7 @@ internal class GameNightEventRepository : RepositoryBase, IGameNightEventReposit
             .AsNoTracking()
             .Include(e => e.Rsvps)
             .Include(e => e.Sessions)
+            .Include(e => e.Votes)
             .Where(e => e.Status == nameof(GameNightStatus.Published) && e.ScheduledAt > DateTimeOffset.UtcNow)
             .OrderBy(e => e.ScheduledAt)
             .Take(50)
@@ -105,6 +108,7 @@ internal class GameNightEventRepository : RepositoryBase, IGameNightEventReposit
             .AsNoTracking()
             .Include(e => e.Rsvps)
             .Include(e => e.Sessions)
+            .Include(e => e.Votes)
             .Where(e => e.Status == nameof(GameNightStatus.Completed)
                 || (e.Status == nameof(GameNightStatus.Published) && e.ScheduledAt < now))
             .OrderByDescending(e => e.ScheduledAt)
@@ -120,6 +124,7 @@ internal class GameNightEventRepository : RepositoryBase, IGameNightEventReposit
             .AsNoTracking()
             .Include(e => e.Rsvps)
             .Include(e => e.Sessions)
+            .Include(e => e.Votes)
             .Where(e => e.OrganizerId == userId || e.Rsvps.Any(r => r.UserId == userId))
             .OrderByDescending(e => e.ScheduledAt)
             .Take(50)
@@ -135,6 +140,7 @@ internal class GameNightEventRepository : RepositoryBase, IGameNightEventReposit
         var entities = await DbContext.GameNightEvents
             .Include(e => e.Rsvps)
             .Include(e => e.Sessions)
+            .Include(e => e.Votes)
             .Where(e => e.Status == nameof(GameNightStatus.Published) && e.ScheduledAt >= from && e.ScheduledAt <= to)
             .ToListAsync(cancellationToken).ConfigureAwait(false);
 
@@ -184,12 +190,51 @@ internal class GameNightEventRepository : RepositoryBase, IGameNightEventReposit
         var entity = await DbContext.GameNightEvents
             .Include(e => e.Rsvps)
             .Include(e => e.Sessions)
+            .Include(e => e.Votes)
             .FirstOrDefaultAsync(
                 e => e.Sessions.Any(s => s.SessionId == sessionId),
                 cancellationToken)
             .ConfigureAwait(false);
 
         return entity != null ? MapToDomain(entity) : null;
+    }
+
+    public async Task AddVoteAsync(GameNightVote vote, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(vote);
+
+        await DbContext.GameNightVotes.AddAsync(new GameNightVoteEntity
+        {
+            Id = vote.Id,
+            EventId = vote.EventId,
+            VoterUserId = vote.VoterUserId,
+            CandidateGameId = vote.CandidateGameId,
+            CreatedAt = vote.CreatedAt
+        }, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task RemoveVoteAsync(Guid voteId, CancellationToken cancellationToken = default)
+    {
+        var entity = await DbContext.GameNightVotes
+            .FirstOrDefaultAsync(v => v.Id == voteId, cancellationToken).ConfigureAwait(false);
+        if (entity != null)
+        {
+            DbContext.GameNightVotes.Remove(entity);
+        }
+    }
+
+    public async Task SetVotingWinnerAsync(
+        Guid eventId, Guid? winnerGameId, CancellationToken cancellationToken = default)
+    {
+        // Direct column write — bypasses the aggregate's detached full-remap (which would
+        // re-Modify every child) and the xmin concurrency token (tie resolution is a single
+        // organiser action, not a contended write).
+        await DbContext.GameNightEvents
+            .Where(e => e.Id == eventId)
+            .ExecuteUpdateAsync(
+                s => s.SetProperty(e => e.VotingWinnerGameId, winnerGameId),
+                cancellationToken)
+            .ConfigureAwait(false);
     }
 
     private static GameNightEventEntity MapToPersistence(GameNightEvent domain)
@@ -213,6 +258,7 @@ internal class GameNightEventRepository : RepositoryBase, IGameNightEventReposit
             RsvpClosedAt = domain.RsvpClosedAt,
             CreatedAt = domain.CreatedAt,
             UpdatedAt = domain.UpdatedAt,
+            VotingWinnerGameId = domain.VotingWinnerGameId,
             Xmin = domain.Xmin
         };
 
@@ -243,6 +289,18 @@ internal class GameNightEventRepository : RepositoryBase, IGameNightEventReposit
                 WinnerId = session.WinnerId,
                 StartedAt = session.StartedAt,
                 CompletedAt = session.CompletedAt
+            });
+        }
+
+        foreach (var vote in domain.Votes)
+        {
+            entity.Votes.Add(new GameNightVoteEntity
+            {
+                Id = vote.Id,
+                EventId = vote.EventId,
+                VoterUserId = vote.VoterUserId,
+                CandidateGameId = vote.CandidateGameId,
+                CreatedAt = vote.CreatedAt
             });
         }
 
@@ -337,6 +395,18 @@ internal class GameNightEventRepository : RepositoryBase, IGameNightEventReposit
 
             evt.RestoreSessions(sessions);
         }
+
+        // Restore candidate-game votes + resolved tie-break winner (#2700)
+        var votes = entity.Votes
+            .Select(v => GameNightVote.Reconstitute(
+                id: v.Id,
+                eventId: v.EventId,
+                voterUserId: v.VoterUserId,
+                candidateGameId: v.CandidateGameId,
+                createdAt: v.CreatedAt))
+            .ToList();
+        evt.RestoreVotes(votes);
+        evt.RestoreVotingWinner(entity.VotingWinnerGameId);
 
         // Clear domain events from reconstruction
         evt.ClearDomainEvents();

--- a/apps/api/src/Api/Infrastructure/Entities/GameManagement/GameNightEventEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/GameManagement/GameNightEventEntity.cs
@@ -79,6 +79,12 @@ public class GameNightEventEntity
 
     public List<GameNightSessionEntity> Sessions { get; set; } = [];
 
+    // Candidate voting (approval model) — Issue #2700
+    [Column("voting_winner_game_id")]
+    public Guid? VotingWinnerGameId { get; set; }
+
+    public List<GameNightVoteEntity> Votes { get; set; } = [];
+
     // Optimistic concurrency via PostgreSQL's xmin system column (Issue #2703, ADR-060).
     // Server-owned: Postgres assigns xmin = transaction-id-of-last-write per row.
     // The repository round-trips this value so the detached Update emits a

--- a/apps/api/src/Api/Infrastructure/Entities/GameManagement/GameNightVoteEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/GameManagement/GameNightVoteEntity.cs
@@ -1,0 +1,34 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Api.Infrastructure.Entities.GameManagement;
+
+/// <summary>
+/// EF Core persistence entity for a candidate-game approval vote on a game night.
+/// Issue #2700: GameNight candidate voting.
+/// </summary>
+[Table("game_night_votes")]
+public class GameNightVoteEntity
+{
+    [Key]
+    [Column("id")]
+    public Guid Id { get; set; }
+
+    [Required]
+    [Column("event_id")]
+    public Guid EventId { get; set; }
+
+    [Required]
+    [Column("voter_user_id")]
+    public Guid VoterUserId { get; set; }
+
+    [Required]
+    [Column("candidate_game_id")]
+    public Guid CandidateGameId { get; set; }
+
+    [Required]
+    [Column("created_at")]
+    public DateTimeOffset CreatedAt { get; set; }
+
+    public GameNightEventEntity Event { get; set; } = null!;
+}

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/GameManagement/GameNightEventEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/GameManagement/GameNightEventEntityConfiguration.cs
@@ -34,6 +34,9 @@ internal class GameNightEventEntityConfiguration : IEntityTypeConfiguration<Game
         builder.Property(e => e.CreatedAt).HasColumnName("created_at").IsRequired();
         builder.Property(e => e.UpdatedAt).HasColumnName("updated_at");
 
+        // Candidate voting (approval model) — Issue #2700
+        builder.Property(e => e.VotingWinnerGameId).HasColumnName("voting_winner_game_id");
+
         // Optimistic concurrency via PostgreSQL's xmin system column (Issue #2703, ADR-060).
         // Server-owned, collision-safe (xmin = unique transaction id per row UPDATE).
         // Mirrors game_night_playlists (#2306) — no bytea row_version, no trigger.
@@ -57,6 +60,11 @@ internal class GameNightEventEntityConfiguration : IEntityTypeConfiguration<Game
         builder.HasMany(e => e.Sessions)
             .WithOne(s => s.GameNightEvent)
             .HasForeignKey(s => s.GameNightEventId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasMany(e => e.Votes)
+            .WithOne(v => v.Event)
+            .HasForeignKey(v => v.EventId)
             .OnDelete(DeleteBehavior.Cascade);
     }
 }

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/GameManagement/GameNightVoteEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/GameManagement/GameNightVoteEntityConfiguration.cs
@@ -1,0 +1,33 @@
+using Api.Infrastructure.Entities.GameManagement;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Api.Infrastructure.EntityConfigurations.GameManagement;
+
+/// <summary>
+/// EF Core configuration for GameNightVoteEntity.
+/// Issue #2700: GameNight candidate voting (approval model).
+/// </summary>
+internal class GameNightVoteEntityConfiguration : IEntityTypeConfiguration<GameNightVoteEntity>
+{
+    public void Configure(EntityTypeBuilder<GameNightVoteEntity> builder)
+    {
+        builder.ToTable("game_night_votes");
+        builder.HasKey(v => v.Id);
+
+        builder.Property(v => v.Id).HasColumnName("id").ValueGeneratedOnAdd();
+        builder.Property(v => v.EventId).HasColumnName("event_id").IsRequired();
+        builder.Property(v => v.VoterUserId).HasColumnName("voter_user_id").IsRequired();
+        builder.Property(v => v.CandidateGameId).HasColumnName("candidate_game_id").IsRequired();
+        builder.Property(v => v.CreatedAt).HasColumnName("created_at").IsRequired();
+
+        // Approval uniqueness: one vote per (event, voter, candidate).
+        builder.HasIndex(v => new { v.EventId, v.VoterUserId, v.CandidateGameId })
+            .HasDatabaseName("IX_game_night_votes_event_voter_candidate")
+            .IsUnique();
+
+        // Tally lookups scan by candidate within an event.
+        builder.HasIndex(v => new { v.EventId, v.CandidateGameId })
+            .HasDatabaseName("IX_game_night_votes_event_candidate");
+    }
+}

--- a/apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs
+++ b/apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs
@@ -293,6 +293,7 @@ public class MeepleAiDbContext : DbContext
     public DbSet<GameNightEventEntity> GameNightEvents => Set<GameNightEventEntity>(); // ISSUE-42: Game Night Event
     public DbSet<GameNightRsvpEntity> GameNightRsvps => Set<GameNightRsvpEntity>(); // ISSUE-42: Game Night RSVP
     public DbSet<GameNightSessionEntity> GameNightSessions => Set<GameNightSessionEntity>(); // Game Night Sessions
+    public DbSet<GameNightVoteEntity> GameNightVotes => Set<GameNightVoteEntity>(); // ISSUE-2700: Candidate voting
     public DbSet<GameNightInvitationEntity> GameNightInvitations => Set<GameNightInvitationEntity>(); // ISSUE-607: Token-based public RSVP invitations
     public DbSet<RuleDisputeEntity> RuleDisputes => Set<RuleDisputeEntity>(); // Structured rule dispute persistence
     public DbSet<BoundedContexts.AgentMemory.Infrastructure.Entities.GameMemoryEntity> GameMemories => Set<BoundedContexts.AgentMemory.Infrastructure.Entities.GameMemoryEntity>(); // AgentMemory: per-game memory

--- a/apps/api/src/Api/Infrastructure/Migrations/20260706131414_AddGameNightVoting.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260706131414_AddGameNightVoting.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260706131414_AddGameNightVoting")]
+    partial class AddGameNightVoting
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260706131414_AddGameNightVoting.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260706131414_AddGameNightVoting.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddGameNightVoting : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "voting_winner_game_id",
+                table: "game_night_events",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "game_night_votes",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    event_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    voter_user_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    candidate_game_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_game_night_votes", x => x.id);
+                    table.ForeignKey(
+                        name: "FK_game_night_votes_game_night_events_event_id",
+                        column: x => x.event_id,
+                        principalTable: "game_night_events",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_game_night_votes_event_candidate",
+                table: "game_night_votes",
+                columns: new[] { "event_id", "candidate_game_id" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_game_night_votes_event_voter_candidate",
+                table: "game_night_votes",
+                columns: new[] { "event_id", "voter_user_id", "candidate_game_id" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "game_night_votes");
+
+            migrationBuilder.DropColumn(
+                name: "voting_winner_game_id",
+                table: "game_night_events");
+        }
+    }
+}

--- a/apps/api/src/Api/Routing/GameNightEndpoints.cs
+++ b/apps/api/src/Api/Routing/GameNightEndpoints.cs
@@ -253,6 +253,52 @@ internal static class GameNightEndpoints
             .WithSummary("Get game night diary timeline")
             .WithDescription("Retrieves the cross-game diary timeline with all session events for the game night. Participant-scoped (organizer or RSVP'd player).");
 
+        // ── Candidate voting (approval model) — Issue #2700 ─────────────────
+
+        gameNights.MapPost("/{id:guid}/votes", HandleCastGameNightVote)
+            .RequireAuthenticatedUser()
+            .Produces(204)
+            .Produces(400)
+            .Produces(401)
+            .Produces(403)
+            .Produces(404)
+            .Produces(409)
+            .WithName("CastGameNightVote")
+            .WithSummary("Approve a candidate game")
+            .WithDescription("Casts an approval vote for a candidate game. Confirmed participants only; voting closes 1h before the event. Idempotent for a repeated approval.");
+
+        gameNights.MapDelete("/{id:guid}/votes/{candidateGameId:guid}", HandleRetractGameNightVote)
+            .RequireAuthenticatedUser()
+            .Produces(204)
+            .Produces(401)
+            .Produces(404)
+            .Produces(409)
+            .WithName("RetractGameNightVote")
+            .WithSummary("Retract a candidate approval")
+            .WithDescription("Retracts a previously-cast approval vote. Idempotent when absent; voting must still be open.");
+
+        gameNights.MapPost("/{id:guid}/votes/resolve-tie", HandleResolveGameNightVotingTie)
+            .RequireAuthenticatedUser()
+            .Produces(204)
+            .Produces(400)
+            .Produces(401)
+            .Produces(403)
+            .Produces(404)
+            .Produces(409)
+            .WithName("ResolveGameNightVotingTie")
+            .WithSummary("Resolve a voting tie")
+            .WithDescription("Organiser chooses the winner among the tied leaders after voting closes.");
+
+        gameNights.MapGet("/{id:guid}/votes/tally", HandleGetGameNightVoteTally)
+            .RequireAuthenticatedUser()
+            .Produces<GameNightVoteTallyDto>(200)
+            .Produces(401)
+            .Produces(403)
+            .Produces(404)
+            .WithName("GetGameNightVoteTally")
+            .WithSummary("Get the candidate-vote tally")
+            .WithDescription("Returns per-candidate approval counts, leader(s), tie flag, resolved winner, and the caller's own approvals. Participant-scoped (organizer or RSVP'd player).");
+
         return group;
     }
 
@@ -356,6 +402,60 @@ internal static class GameNightEndpoints
         var command = new RespondToGameNightCommand(id, userId, rsvpStatus);
         await mediator.Send(command, cancellationToken).ConfigureAwait(false);
         return Results.NoContent();
+    }
+
+    // ── Candidate voting (approval model) — Issue #2700 ─────────────────────
+
+    private static async Task<IResult> HandleCastGameNightVote(
+        Guid id,
+        [FromBody] CastVoteRequest request,
+        [FromServices] IMediator mediator,
+        HttpContext httpContext,
+        CancellationToken cancellationToken)
+    {
+        var userId = httpContext.User.GetUserId();
+        var command = new CastGameNightVoteCommand(id, userId, request.CandidateGameId);
+        await mediator.Send(command, cancellationToken).ConfigureAwait(false);
+        return Results.NoContent();
+    }
+
+    private static async Task<IResult> HandleRetractGameNightVote(
+        Guid id,
+        Guid candidateGameId,
+        [FromServices] IMediator mediator,
+        HttpContext httpContext,
+        CancellationToken cancellationToken)
+    {
+        var userId = httpContext.User.GetUserId();
+        var command = new RetractGameNightVoteCommand(id, userId, candidateGameId);
+        await mediator.Send(command, cancellationToken).ConfigureAwait(false);
+        return Results.NoContent();
+    }
+
+    private static async Task<IResult> HandleResolveGameNightVotingTie(
+        Guid id,
+        [FromBody] ResolveVotingTieRequest request,
+        [FromServices] IMediator mediator,
+        HttpContext httpContext,
+        CancellationToken cancellationToken)
+    {
+        var userId = httpContext.User.GetUserId();
+        var command = new ResolveGameNightVotingTieCommand(id, userId, request.WinningCandidateGameId);
+        await mediator.Send(command, cancellationToken).ConfigureAwait(false);
+        return Results.NoContent();
+    }
+
+    private static async Task<IResult> HandleGetGameNightVoteTally(
+        Guid id,
+        [FromServices] IMediator mediator,
+        HttpContext httpContext,
+        CancellationToken cancellationToken)
+    {
+        var userId = httpContext.User.GetUserId();
+        var result = await mediator
+            .Send(new GetGameNightVoteTallyQuery(id, userId), cancellationToken)
+            .ConfigureAwait(false);
+        return Results.Ok(result);
     }
 
     private static async Task<IResult> HandleCreateGameNightInvitationByEmail(
@@ -666,6 +766,8 @@ internal static class GameNightEndpoints
         string? DisplayName = null);
 
     // Game Night Experience v2 request records
+    private sealed record CastVoteRequest(Guid CandidateGameId);
+    private sealed record ResolveVotingTieRequest(Guid WinningCandidateGameId);
     private sealed record StartGameNightSessionRequest(Guid GameId, string GameTitle);
     private sealed record AttachGamebookCampaignRequest(Guid CampaignId);
     private sealed record CompleteGameNightSessionRequest(Guid? WinnerId);

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/Entities/GameNightEventVotingTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/Entities/GameNightEventVotingTests.cs
@@ -136,6 +136,17 @@ public class GameNightEventVotingTests
     }
 
     [Fact]
+    public void RetractVote_ByNonParticipant_ThrowsForbidden()
+    {
+        // IDOR: a non-participant must not learn the event's voting state via retract.
+        var (evt, _, gameA, _, _) = BuildPublishedEventWithConfirmedVoter();
+
+        var act = () => evt.RetractVote(Guid.NewGuid(), gameA, Open);
+
+        act.Should().Throw<ForbiddenException>();
+    }
+
+    [Fact]
     public void RetractVote_RemovesVote_AndIsIdempotent()
     {
         var (evt, voter, gameA, _, _) = BuildPublishedEventWithConfirmedVoter();

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/Entities/GameNightEventVotingTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/Entities/GameNightEventVotingTests.cs
@@ -1,0 +1,236 @@
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.Middleware.Exceptions;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Domain.Entities;
+
+/// <summary>
+/// Unit tests for the candidate-game approval-voting domain behaviour on
+/// <see cref="GameNightEvent"/> — Issue #2700 (Umbrella #2697, spec §4a US-INT-3 step 4).
+///
+/// Model: each confirmed participant (Accepted RSVP) approves any subset of the event's
+/// candidate games (1 vote per candidate, toggle). Voting closes 1h before ScheduledAt
+/// (lazy check, ADR-074 Option C philosophy). On a tie at close, the organiser resolves it.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "GameManagement")]
+[Trait("Feature", "GameNightVoting")]
+public class GameNightEventVotingTests
+{
+    private static readonly DateTimeOffset ScheduledAt = new(2026, 8, 1, 20, 0, 0, TimeSpan.Zero);
+    private static readonly DateTimeOffset Open = ScheduledAt.AddHours(-3);   // > 1h before → open
+    private static readonly DateTimeOffset Closed = ScheduledAt.AddMinutes(-30); // < 1h before → closed
+
+    private static (GameNightEvent Evt, Guid Voter, Guid GameA, Guid GameB, Guid Organizer)
+        BuildPublishedEventWithConfirmedVoter()
+    {
+        var organizer = Guid.NewGuid();
+        var voter = Guid.NewGuid();
+        var gameA = Guid.NewGuid();
+        var gameB = Guid.NewGuid();
+        var evt = GameNightEvent.Create(
+            organizer, "Serata voti", ScheduledAt, gameIds: new List<Guid> { gameA, gameB });
+        evt.Publish(new List<Guid> { voter });
+        evt.GetRsvp(voter)!.Accept();
+        return (evt, voter, gameA, gameB, organizer);
+    }
+
+    [Fact]
+    public void CastVote_ByConfirmedParticipant_RecordsVote()
+    {
+        var (evt, voter, gameA, _, _) = BuildPublishedEventWithConfirmedVoter();
+
+        evt.CastVote(voter, gameA, Open);
+
+        evt.Votes.Should().ContainSingle(v => v.VoterUserId == voter && v.CandidateGameId == gameA);
+        evt.TallyVotes().CountsByCandidate[gameA].Should().Be(1);
+    }
+
+    [Fact]
+    public void CastVote_IsIdempotent_ForSameVoterAndCandidate()
+    {
+        var (evt, voter, gameA, _, _) = BuildPublishedEventWithConfirmedVoter();
+
+        evt.CastVote(voter, gameA, Open);
+        evt.CastVote(voter, gameA, Open);
+
+        evt.TallyVotes().CountsByCandidate[gameA].Should().Be(1);
+    }
+
+    [Fact]
+    public void CastVote_ApprovalAllowsMultipleCandidates()
+    {
+        var (evt, voter, gameA, gameB, _) = BuildPublishedEventWithConfirmedVoter();
+
+        evt.CastVote(voter, gameA, Open);
+        evt.CastVote(voter, gameB, Open);
+
+        var tally = evt.TallyVotes();
+        tally.CountsByCandidate[gameA].Should().Be(1);
+        tally.CountsByCandidate[gameB].Should().Be(1);
+    }
+
+    [Fact]
+    public void CastVote_ByNonConfirmedUser_ThrowsForbidden()
+    {
+        var (evt, _, gameA, _, _) = BuildPublishedEventWithConfirmedVoter();
+        var pendingUser = Guid.NewGuid();
+        evt.AddInvitees(new List<Guid> { pendingUser }); // Pending, not Accepted
+
+        var act = () => evt.CastVote(pendingUser, gameA, Open);
+
+        act.Should().Throw<ForbiddenException>();
+    }
+
+    [Fact]
+    public void CastVote_ByStranger_ThrowsForbidden()
+    {
+        var (evt, _, gameA, _, _) = BuildPublishedEventWithConfirmedVoter();
+
+        var act = () => evt.CastVote(Guid.NewGuid(), gameA, Open);
+
+        act.Should().Throw<ForbiddenException>();
+    }
+
+    [Fact]
+    public void CastVote_ForNonCandidateGame_ThrowsNotFound()
+    {
+        var (evt, voter, _, _, _) = BuildPublishedEventWithConfirmedVoter();
+
+        var act = () => evt.CastVote(voter, Guid.NewGuid(), Open);
+
+        act.Should().Throw<NotFoundException>();
+    }
+
+    [Fact]
+    public void CastVote_WhenVotingClosed_ThrowsConflict()
+    {
+        var (evt, voter, gameA, _, _) = BuildPublishedEventWithConfirmedVoter();
+
+        var act = () => evt.CastVote(voter, gameA, Closed);
+
+        act.Should().Throw<ConflictException>();
+    }
+
+    [Fact]
+    public void CastVote_WhenNotPublished_ThrowsConflict()
+    {
+        var organizer = Guid.NewGuid();
+        var gameA = Guid.NewGuid();
+        var evt = GameNightEvent.Create(organizer, "Bozza", ScheduledAt, gameIds: new List<Guid> { gameA });
+        // still Draft — no confirmed voters possible, but the status guard must fire first
+
+        var act = () => evt.CastVote(organizer, gameA, Open);
+
+        act.Should().Throw<ConflictException>();
+    }
+
+    [Fact]
+    public void IsVotingClosed_TrueWithinOneHour_FalseEarlier()
+    {
+        var (evt, _, _, _, _) = BuildPublishedEventWithConfirmedVoter();
+
+        evt.IsVotingClosed(Open).Should().BeFalse();
+        evt.IsVotingClosed(Closed).Should().BeTrue();
+    }
+
+    [Fact]
+    public void RetractVote_RemovesVote_AndIsIdempotent()
+    {
+        var (evt, voter, gameA, _, _) = BuildPublishedEventWithConfirmedVoter();
+        evt.CastVote(voter, gameA, Open);
+
+        evt.RetractVote(voter, gameA, Open);
+        evt.RetractVote(voter, gameA, Open); // idempotent
+
+        evt.Votes.Should().BeEmpty();
+        evt.TallyVotes().CountsByCandidate[gameA].Should().Be(0);
+    }
+
+    [Fact]
+    public void TallyVotes_SingleLeader_DerivesWinner_NoTie()
+    {
+        var (evt, voter, gameA, gameB, organizer) = BuildPublishedEventWithConfirmedVoter();
+        evt.AddInvitees(new List<Guid> { organizer });
+        evt.GetRsvp(organizer)!.Accept();
+
+        evt.CastVote(voter, gameA, Open);
+        evt.CastVote(organizer, gameA, Open); // gameA: 2, gameB: 0
+
+        var tally = evt.TallyVotes();
+        tally.IsTie.Should().BeFalse();
+        tally.LeadingCandidateGameIds.Should().ContainSingle().Which.Should().Be(gameA);
+        tally.WinnerGameId.Should().Be(gameA);
+    }
+
+    [Fact]
+    public void TallyVotes_EqualCandidates_IsTie_NoWinnerUntilResolved()
+    {
+        var (evt, voter, gameA, gameB, organizer) = BuildPublishedEventWithConfirmedVoter();
+        evt.AddInvitees(new List<Guid> { organizer });
+        evt.GetRsvp(organizer)!.Accept();
+
+        evt.CastVote(voter, gameA, Open);
+        evt.CastVote(organizer, gameB, Open); // gameA: 1, gameB: 1 → tie
+
+        var tally = evt.TallyVotes();
+        tally.IsTie.Should().BeTrue();
+        tally.LeadingCandidateGameIds.Should().BeEquivalentTo(new[] { gameA, gameB });
+        tally.WinnerGameId.Should().BeNull();
+    }
+
+    [Fact]
+    public void ResolveVotingTie_ByHost_AfterClose_SetsWinner()
+    {
+        var (evt, voter, gameA, gameB, organizer) = BuildPublishedEventWithConfirmedVoter();
+        evt.AddInvitees(new List<Guid> { organizer });
+        evt.GetRsvp(organizer)!.Accept();
+        evt.CastVote(voter, gameA, Open);
+        evt.CastVote(organizer, gameB, Open); // tie
+
+        evt.ResolveVotingTie(organizer, gameA, Closed);
+
+        evt.VotingWinnerGameId.Should().Be(gameA);
+        evt.TallyVotes().WinnerGameId.Should().Be(gameA);
+    }
+
+    [Fact]
+    public void ResolveVotingTie_ByNonHost_ThrowsForbidden()
+    {
+        var (evt, voter, gameA, gameB, organizer) = BuildPublishedEventWithConfirmedVoter();
+        evt.AddInvitees(new List<Guid> { organizer });
+        evt.GetRsvp(organizer)!.Accept();
+        evt.CastVote(voter, gameA, Open);
+        evt.CastVote(organizer, gameB, Open);
+
+        var act = () => evt.ResolveVotingTie(voter, gameA, Closed);
+
+        act.Should().Throw<ForbiddenException>();
+    }
+
+    [Fact]
+    public void ResolveVotingTie_WhenVotingStillOpen_ThrowsConflict()
+    {
+        var (evt, voter, gameA, gameB, organizer) = BuildPublishedEventWithConfirmedVoter();
+        evt.AddInvitees(new List<Guid> { organizer });
+        evt.GetRsvp(organizer)!.Accept();
+        evt.CastVote(voter, gameA, Open);
+        evt.CastVote(organizer, gameB, Open);
+
+        var act = () => evt.ResolveVotingTie(organizer, gameA, Open);
+
+        act.Should().Throw<ConflictException>();
+    }
+
+    [Fact]
+    public void ResolveVotingTie_WhenNoTie_ThrowsConflict()
+    {
+        var (evt, voter, gameA, _, organizer) = BuildPublishedEventWithConfirmedVoter();
+        evt.CastVote(voter, gameA, Open); // single leader, no tie
+
+        var act = () => evt.ResolveVotingTie(organizer, gameA, Closed);
+
+        act.Should().Throw<ConflictException>();
+    }
+}

--- a/apps/api/tests/Api.Tests/Integration/GameManagement/GameNightVotingCommandTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/GameManagement/GameNightVotingCommandTests.cs
@@ -1,0 +1,165 @@
+using System.Text.Json;
+using Api.BoundedContexts.GameManagement.Application.Commands.GameNights;
+using Api.BoundedContexts.GameManagement.Application.DTOs.GameNights;
+using Api.BoundedContexts.GameManagement.Application.Queries.GameNights;
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.BoundedContexts.GameManagement.Infrastructure.Persistence;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.GameManagement;
+using Api.Middleware.Exceptions;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.Integration.GameManagement;
+
+/// <summary>
+/// Handler-driven integration tests for candidate voting through the MediatR pipeline — Issue #2700.
+/// Exercises the real command/query flow (guards + persistence + IDOR) rather than fixture-only DTOs.
+/// Voting open/closed is controlled purely via ScheduledAt relative to real UtcNow (closes at -1h).
+/// </summary>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "GameManagement")]
+[Trait("Issue", "2700")]
+public sealed class GameNightVotingCommandTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private string _databaseName = null!;
+    private string _connectionString = null!;
+    private MeepleAiDbContext _dbContext = null!;
+    private IServiceProvider? _serviceProvider;
+
+    public GameNightVotingCommandTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    private IServiceProvider Sp => _serviceProvider ?? throw new InvalidOperationException("SP not initialized");
+    private static CancellationToken Ct => TestContext.Current.CancellationToken;
+
+    public async ValueTask InitializeAsync()
+    {
+        _databaseName = $"gamenight_vote_cmd_{Guid.NewGuid():N}";
+        _connectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+        _dbContext = _fixture.CreateDbContext(_connectionString);
+        await _dbContext.Database.MigrateAsync(Ct);
+
+        var services = IntegrationServiceCollectionBuilder.CreateBase(_connectionString);
+        services.AddScoped<IGameNightEventRepository, GameNightEventRepository>();
+        _serviceProvider = services.BuildServiceProvider();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _dbContext.DisposeAsync();
+        if (_serviceProvider is IAsyncDisposable d) await d.DisposeAsync();
+        await _fixture.DropIsolatedDatabaseAsync(_databaseName);
+    }
+
+    private async Task<(Guid EventId, Guid Organizer, Guid Voter, Guid GameA, Guid GameB)> SeedAsync(
+        DateTimeOffset scheduledAt)
+    {
+        var eventId = Guid.NewGuid();
+        var organizer = Guid.NewGuid();
+        var voter = Guid.NewGuid();
+        var gameA = Guid.NewGuid();
+        var gameB = Guid.NewGuid();
+
+        _dbContext.GameNightEvents.Add(new GameNightEventEntity
+        {
+            Id = eventId,
+            OrganizerId = organizer,
+            Title = "Voting Night",
+            ScheduledAt = scheduledAt,
+            GameIdsJson = JsonSerializer.Serialize(new List<Guid> { gameA, gameB }),
+            Status = "Published",
+            CreatedAt = DateTimeOffset.UtcNow,
+            Rsvps =
+            {
+                new GameNightRsvpEntity
+                {
+                    Id = Guid.NewGuid(), EventId = eventId, UserId = voter,
+                    Status = "Accepted", CreatedAt = DateTimeOffset.UtcNow
+                }
+            }
+        });
+        await _dbContext.SaveChangesAsync(Ct);
+        return (eventId, organizer, voter, gameA, gameB);
+    }
+
+    private async Task SendAsync(IRequest request)
+    {
+        using var scope = Sp.CreateScope();
+        await scope.ServiceProvider.GetRequiredService<IMediator>().Send(request, Ct);
+    }
+
+    private async Task<TResult> SendAsync<TResult>(IRequest<TResult> request)
+    {
+        using var scope = Sp.CreateScope();
+        return await scope.ServiceProvider.GetRequiredService<IMediator>().Send(request, Ct);
+    }
+
+    [Fact(DisplayName = "Confirmed participant casts a vote; tally reflects it with VotedByMe")]
+    public async Task Cast_ByConfirmedParticipant_ReflectedInTally()
+    {
+        var (eventId, _, voter, gameA, _) = await SeedAsync(DateTimeOffset.UtcNow.AddDays(2));
+
+        await SendAsync(new CastGameNightVoteCommand(eventId, voter, gameA));
+
+        var tally = await SendAsync(new GetGameNightVoteTallyQuery(eventId, voter));
+        tally.Candidates.Single(c => c.GameId == gameA).VoteCount.Should().Be(1);
+        tally.Candidates.Single(c => c.GameId == gameA).VotedByMe.Should().BeTrue();
+        tally.WinnerGameId.Should().Be(gameA);
+        tally.IsTie.Should().BeFalse();
+    }
+
+    [Fact(DisplayName = "IDOR: a non-confirmed user cannot cast a vote (403)")]
+    public async Task Cast_ByNonConfirmedUser_Throws403()
+    {
+        var (eventId, _, _, gameA, _) = await SeedAsync(DateTimeOffset.UtcNow.AddDays(2));
+        var stranger = Guid.NewGuid();
+
+        var act = async () => await SendAsync(new CastGameNightVoteCommand(eventId, stranger, gameA));
+
+        await act.Should().ThrowAsync<ForbiddenException>();
+    }
+
+    [Fact(DisplayName = "IDOR: a non-participant cannot read the vote tally (403)")]
+    public async Task Tally_ByNonParticipant_Throws403()
+    {
+        var (eventId, _, _, _, _) = await SeedAsync(DateTimeOffset.UtcNow.AddDays(2));
+        var stranger = Guid.NewGuid();
+
+        var act = async () => await SendAsync(new GetGameNightVoteTallyQuery(eventId, stranger));
+
+        await act.Should().ThrowAsync<ForbiddenException>();
+    }
+
+    [Fact(DisplayName = "Retract removes the vote from the tally")]
+    public async Task Retract_RemovesVote()
+    {
+        var (eventId, _, voter, gameA, _) = await SeedAsync(DateTimeOffset.UtcNow.AddDays(2));
+        await SendAsync(new CastGameNightVoteCommand(eventId, voter, gameA));
+
+        await SendAsync(new RetractGameNightVoteCommand(eventId, voter, gameA));
+
+        var tally = await SendAsync(new GetGameNightVoteTallyQuery(eventId, voter));
+        tally.Candidates.Single(c => c.GameId == gameA).VoteCount.Should().Be(0);
+    }
+
+    [Fact(DisplayName = "Casting after voting has closed returns 409")]
+    public async Task Cast_AfterClose_Throws409()
+    {
+        // ScheduledAt 30 minutes out → now is already past ScheduledAt - 1h → closed.
+        var (eventId, _, voter, gameA, _) = await SeedAsync(DateTimeOffset.UtcNow.AddMinutes(30));
+
+        var act = async () => await SendAsync(new CastGameNightVoteCommand(eventId, voter, gameA));
+
+        await act.Should().ThrowAsync<ConflictException>();
+    }
+}

--- a/apps/api/tests/Api.Tests/Integration/GameManagement/GameNightVotingCommandTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/GameManagement/GameNightVotingCommandTests.cs
@@ -140,6 +140,17 @@ public sealed class GameNightVotingCommandTests : IAsyncLifetime
         await act.Should().ThrowAsync<ForbiddenException>();
     }
 
+    [Fact(DisplayName = "IDOR: a non-participant cannot retract a vote (403)")]
+    public async Task Retract_ByNonParticipant_Throws403()
+    {
+        var (eventId, _, _, gameA, _) = await SeedAsync(DateTimeOffset.UtcNow.AddDays(2));
+        var stranger = Guid.NewGuid();
+
+        var act = async () => await SendAsync(new RetractGameNightVoteCommand(eventId, stranger, gameA));
+
+        await act.Should().ThrowAsync<ForbiddenException>();
+    }
+
     [Fact(DisplayName = "Retract removes the vote from the tally")]
     public async Task Retract_RemovesVote()
     {

--- a/apps/api/tests/Api.Tests/Integration/GameManagement/GameNightVotingRepositoryTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/GameManagement/GameNightVotingRepositoryTests.cs
@@ -1,0 +1,144 @@
+using System.Text.Json;
+using Api.BoundedContexts.GameManagement.Infrastructure.Persistence;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.GameManagement;
+using Api.SharedKernel.Application.Services;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.Integration.GameManagement;
+
+/// <summary>
+/// Integration tests proving the <see cref="GameNightEventRepository"/> round-trips candidate
+/// votes (Issue #2700) through the detached-Update full-remap, and that an unrelated update
+/// does NOT silently wipe votes (the queries feeding a mutation path must Include the Votes
+/// owned collection — same class of bug as the xmin round-trip in #2703).
+/// </summary>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "GameManagement")]
+[Trait("Issue", "2700")]
+public sealed class GameNightVotingRepositoryTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private string _databaseName = null!;
+    private string _connectionString = null!;
+    private MeepleAiDbContext _dbContext = null!;
+
+    public GameNightVotingRepositoryTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    private static CancellationToken Ct => TestContext.Current.CancellationToken;
+
+    public async ValueTask InitializeAsync()
+    {
+        _databaseName = $"gamenight_votes_{Guid.NewGuid():N}";
+        _connectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+        _dbContext = _fixture.CreateDbContext(_connectionString);
+        await _dbContext.Database.MigrateAsync(Ct);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _dbContext.DisposeAsync();
+        await _fixture.DropIsolatedDatabaseAsync(_databaseName);
+    }
+
+    private GameNightEventRepository Repo(MeepleAiDbContext db) =>
+        new(db, Mock.Of<IDomainEventCollector>(), Mock.Of<ILogger<GameNightEventRepository>>());
+
+    private async Task<(Guid EventId, Guid Voter, Guid GameA, Guid GameB)> SeedPublishedEventAsync()
+    {
+        var eventId = Guid.NewGuid();
+        var voter = Guid.NewGuid();
+        var gameA = Guid.NewGuid();
+        var gameB = Guid.NewGuid();
+
+        _dbContext.GameNightEvents.Add(new GameNightEventEntity
+        {
+            Id = eventId,
+            OrganizerId = Guid.NewGuid(),
+            Title = "Voting Night",
+            ScheduledAt = DateTimeOffset.UtcNow.AddDays(2),
+            GameIdsJson = JsonSerializer.Serialize(new List<Guid> { gameA, gameB }),
+            Status = "Published",
+            CreatedAt = DateTimeOffset.UtcNow,
+            Rsvps =
+            {
+                new GameNightRsvpEntity
+                {
+                    Id = Guid.NewGuid(),
+                    EventId = eventId,
+                    UserId = voter,
+                    Status = "Accepted",
+                    CreatedAt = DateTimeOffset.UtcNow
+                }
+            }
+        });
+        await _dbContext.SaveChangesAsync(Ct);
+        return (eventId, voter, gameA, gameB);
+    }
+
+    [Fact(DisplayName = "Cast votes round-trip through the repository and tally correctly")]
+    public async Task CastVotes_RoundTripThroughRepository()
+    {
+        var (eventId, voter, gameA, _) = await SeedPublishedEventAsync();
+
+        // Load (for the domain guards), cast a vote, persist via the tracked AddVote path.
+        await using (var dbWrite = _fixture.CreateDbContext(_connectionString))
+        {
+            var repo = Repo(dbWrite);
+            var evt = await repo.GetByIdAsync(eventId, Ct);
+            var vote = evt!.CastVote(voter, gameA, DateTimeOffset.UtcNow);
+            await repo.AddVoteAsync(vote!, Ct);
+            await dbWrite.SaveChangesAsync(Ct);
+        }
+
+        // Reload from a fresh context and assert the vote survived + tally is right.
+        await using var dbRead = _fixture.CreateDbContext(_connectionString);
+        var reloaded = await Repo(dbRead).GetByIdAsync(eventId, Ct);
+
+        reloaded!.Votes.Should().ContainSingle(v => v.VoterUserId == voter && v.CandidateGameId == gameA);
+        reloaded.TallyVotes().CountsByCandidate[gameA].Should().Be(1);
+    }
+
+    [Fact(DisplayName = "An unrelated update does NOT wipe previously-cast votes")]
+    public async Task UnrelatedUpdate_DoesNotWipeVotes()
+    {
+        var (eventId, voter, gameA, _) = await SeedPublishedEventAsync();
+
+        await using (var dbVote = _fixture.CreateDbContext(_connectionString))
+        {
+            var repo = Repo(dbVote);
+            var evt = await repo.GetByIdAsync(eventId, Ct);
+            var vote = evt!.CastVote(voter, gameA, DateTimeOffset.UtcNow);
+            await repo.AddVoteAsync(vote!, Ct);
+            await dbVote.SaveChangesAsync(Ct);
+        }
+
+        // Mutate an unrelated field (title) through the detached-Update path — which
+        // re-maps existing votes as Modified UPDATEs, so they must survive.
+        await using (var dbEdit = _fixture.CreateDbContext(_connectionString))
+        {
+            var repo = Repo(dbEdit);
+            var evt = await repo.GetByIdAsync(eventId, Ct);
+            evt!.Update("Renamed Night", evt.Description, evt.ScheduledAt, evt.Location, evt.MaxPlayers, null);
+            await repo.UpdateAsync(evt, Ct);
+            await dbEdit.SaveChangesAsync(Ct);
+        }
+
+        // The vote must still be there — GetByIdAsync includes Votes, so the remap preserves it.
+        await using var dbRead = _fixture.CreateDbContext(_connectionString);
+        var reloaded = await Repo(dbRead).GetByIdAsync(eventId, Ct);
+
+        reloaded!.Title.Should().Be("Renamed Night");
+        reloaded.Votes.Should().ContainSingle(v => v.CandidateGameId == gameA);
+    }
+}

--- a/apps/api/tests/Api.Tests/Integration/GameManagement/GameNightVotingRepositoryTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/GameManagement/GameNightVotingRepositoryTests.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
 using Api.BoundedContexts.GameManagement.Infrastructure.Persistence;
 using Api.Infrastructure;
 using Api.Infrastructure.Entities.GameManagement;
@@ -107,6 +108,29 @@ public sealed class GameNightVotingRepositoryTests : IAsyncLifetime
 
         reloaded!.Votes.Should().ContainSingle(v => v.VoterUserId == voter && v.CandidateGameId == gameA);
         reloaded.TallyVotes().CountsByCandidate[gameA].Should().Be(1);
+    }
+
+    [Fact(DisplayName = "Duplicate (event,voter,candidate) vote is rejected by the unique index")]
+    public async Task DuplicateVote_ViolatesUniqueIndex()
+    {
+        var (eventId, voter, gameA, _) = await SeedPublishedEventAsync();
+
+        await using var db = _fixture.CreateDbContext(_connectionString);
+        var repo = Repo(db);
+
+        var evt = await repo.GetByIdAsync(eventId, Ct);
+        var first = evt!.CastVote(voter, gameA, DateTimeOffset.UtcNow);
+        await repo.AddVoteAsync(first!, Ct);
+        await db.SaveChangesAsync(Ct);
+
+        // A distinct row (new id) for the same (event, voter, candidate) tuple must be rejected —
+        // this is the DB guard the CastVote handler relies on to convert a concurrent race into
+        // an idempotent success.
+        var duplicate = GameNightVote.Create(eventId, voter, gameA);
+        await repo.AddVoteAsync(duplicate, Ct);
+        Func<Task> act = async () => await db.SaveChangesAsync(Ct);
+
+        await act.Should().ThrowAsync<DbUpdateException>();
     }
 
     [Fact(DisplayName = "An unrelated update does NOT wipe previously-cast votes")]

--- a/apps/web/src/app/(authenticated)/game-nights/[id]/_components/GameNightDetailView.tsx
+++ b/apps/web/src/app/(authenticated)/game-nights/[id]/_components/GameNightDetailView.tsx
@@ -33,6 +33,7 @@ import {
   GameNightRsvpActionBar,
   GameNightRsvpRow,
 } from '@/components/features/game-night-detail';
+import { VotingPanel } from '@/components/features/game-night-detail/voting/VotingPanel';
 import { GameNightActions } from '@/components/game-night/GameNightActions';
 import { GameNightDiaryPanel } from '@/components/game-night/GameNightDiaryPanel';
 import { GameNightSessionsList } from '@/components/game-night/GameNightSessionsList';
@@ -63,9 +64,10 @@ export function GameNightDetailView({ id }: { id: string }): React.JSX.Element {
 
   const { event, rsvps, actor, isLoading, isError, currentResponse, pendingResponse } = detail;
 
-  // Catalog games only needed for Draft planning layout.
+  // Catalog games power the Draft planning layout and the Published voting-panel titles.
   const isDraft = event?.status === 'Draft';
-  const { data: catalogData } = useSharedGames(undefined, isDraft);
+  const needsCatalog = isDraft || event?.status === 'Published';
+  const { data: catalogData } = useSharedGames(undefined, needsCatalog);
 
   const { addPlayer, addGame, reset, activeSessions } = useGameNightStore();
 
@@ -236,6 +238,11 @@ export function GameNightDetailView({ id }: { id: string }): React.JSX.Element {
     maxPlayers: g.maxPlayers,
   }));
 
+  // Candidate-game titles for the voting panel (#2700).
+  const gameTitleById: Record<string, string> = Object.fromEntries(
+    (catalogData?.items ?? []).map(g => [g.id, g.title])
+  );
+
   const isHost = actor?.actor === 'host';
   const isGuest = actor?.actor === 'guest';
 
@@ -337,6 +344,11 @@ export function GameNightDetailView({ id }: { id: string }): React.JSX.Element {
           pendingResponse={pendingResponse}
           onSelect={handleRsvp}
         />
+      )}
+
+      {/* Candidate voting (approval model) — Issue #2700. Published events only. */}
+      {isLive && (
+        <VotingPanel gameNightId={id} isOrganizer={isHost} gameTitleById={gameTitleById} />
       )}
 
       {/* Live / Completed: session flow sections under hero. */}

--- a/apps/web/src/components/features/game-night-detail/voting/GameVoteCard.tsx
+++ b/apps/web/src/components/features/game-night-detail/voting/GameVoteCard.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import { Check, Trophy } from 'lucide-react';
+
+import { Button } from '@/components/ui/primitives/button';
+import { useTranslation } from '@/hooks/useTranslation';
+
+export interface GameVoteCardProps {
+  readonly gameId: string;
+  readonly title: string;
+  readonly voteCount: number;
+  readonly maxVoteCount: number;
+  readonly votedByMe: boolean;
+  readonly isLeader: boolean;
+  readonly isWinner: boolean;
+  readonly disabled: boolean;
+  readonly pending: boolean;
+  readonly onToggle: (gameId: string, votedByMe: boolean) => void;
+}
+
+/**
+ * A single candidate game in the approval-voting panel (#2700): title, an approval-count
+ * bar, a leader/winner badge and a toggle that casts or retracts the caller's approval.
+ */
+export function GameVoteCard({
+  gameId,
+  title,
+  voteCount,
+  maxVoteCount,
+  votedByMe,
+  isLeader,
+  isWinner,
+  disabled,
+  pending,
+  onToggle,
+}: GameVoteCardProps): React.JSX.Element {
+  const { t } = useTranslation();
+  const barPct = maxVoteCount > 0 ? Math.round((voteCount / maxVoteCount) * 100) : 0;
+
+  return (
+    <div
+      data-testid={`vote-card-${gameId}`}
+      className="rounded-lg border border-border bg-card p-4"
+    >
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <span className="font-medium text-foreground">{title}</span>
+          {isWinner ? (
+            <span
+              data-testid={`winner-badge-${gameId}`}
+              className="inline-flex items-center gap-1 rounded-full bg-entity-game px-2 py-0.5 text-xs font-semibold text-white"
+            >
+              <Trophy className="h-3 w-3" />
+              {t('gameNightDetail.voting.winnerBadge')}
+            </span>
+          ) : (
+            isLeader && (
+              <span
+                data-testid={`leader-badge-${gameId}`}
+                className="rounded-full bg-muted px-2 py-0.5 text-xs font-semibold text-muted-foreground"
+              >
+                {t('gameNightDetail.voting.leaderBadge')}
+              </span>
+            )
+          )}
+        </div>
+        <span className="text-sm text-muted-foreground" data-testid={`vote-count-${gameId}`}>
+          {t('gameNightDetail.voting.votesCount', { count: voteCount })}
+        </span>
+      </div>
+
+      <div className="mt-2 h-2 w-full overflow-hidden rounded-full bg-muted" aria-hidden>
+        <div
+          className="h-full rounded-full bg-entity-event transition-all"
+          style={{ width: `${barPct}%` }}
+        />
+      </div>
+
+      <div className="mt-3 flex justify-end">
+        <Button
+          type="button"
+          size="sm"
+          variant={votedByMe ? 'secondary' : 'default'}
+          disabled={disabled || pending}
+          onClick={() => onToggle(gameId, votedByMe)}
+          data-testid={`vote-toggle-${gameId}`}
+        >
+          {votedByMe && <Check className="mr-1 h-4 w-4" />}
+          {votedByMe ? t('gameNightDetail.voting.retract') : t('gameNightDetail.voting.vote')}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/features/game-night-detail/voting/VotingPanel.tsx
+++ b/apps/web/src/components/features/game-night-detail/voting/VotingPanel.tsx
@@ -1,0 +1,169 @@
+'use client';
+
+import { Skeleton } from '@/components/ui/feedback/skeleton';
+import {
+  useCastGameNightVote,
+  useGameNightVoteTally,
+  useResolveGameNightVotingTie,
+  useRetractGameNightVote,
+} from '@/hooks/queries/useGameNights';
+import { useToast } from '@/hooks/useToast';
+import { useTranslation } from '@/hooks/useTranslation';
+
+import { GameVoteCard } from './GameVoteCard';
+import { VotingTiedResolver } from './VotingTiedResolver';
+
+export interface VotingPanelProps {
+  readonly gameNightId: string;
+  readonly isOrganizer: boolean;
+  /** gameId → display title (from the shared-game catalog); falls back to a generic label. */
+  readonly gameTitleById?: Record<string, string>;
+}
+
+/**
+ * Candidate approval-voting panel for a game night (#2700). Confirmed participants approve
+ * candidate games; the organiser resolves a tie once voting closes. Renders the 4 canonical
+ * states: loading / empty (no candidates) / error / default.
+ */
+export function VotingPanel({
+  gameNightId,
+  isOrganizer,
+  gameTitleById = {},
+}: VotingPanelProps): React.JSX.Element {
+  const { t } = useTranslation();
+  const { toast } = useToast();
+
+  const tallyQuery = useGameNightVoteTally(gameNightId);
+  const castMutation = useCastGameNightVote();
+  const retractMutation = useRetractGameNightVote();
+  const resolveMutation = useResolveGameNightVotingTie();
+
+  const title = (gameId: string): string =>
+    gameTitleById[gameId] ?? t('gameNightDetail.voting.candidateFallback');
+
+  function onError(): void {
+    toast({
+      title: t('common.error'),
+      description: t('gameNightDetail.voting.actionError'),
+      variant: 'destructive',
+    });
+  }
+
+  function handleToggle(gameId: string, votedByMe: boolean): void {
+    const mutation = votedByMe ? retractMutation : castMutation;
+    mutation.mutate({ id: gameNightId, candidateGameId: gameId }, { onError });
+  }
+
+  function handleResolve(gameId: string): void {
+    resolveMutation.mutate({ id: gameNightId, winningCandidateGameId: gameId }, { onError });
+  }
+
+  return (
+    <section aria-labelledby="voting-heading" className="space-y-3" data-testid="voting-panel">
+      <div className="flex items-center justify-between">
+        <h2 id="voting-heading" className="font-display text-base font-extrabold text-foreground">
+          {t('gameNightDetail.voting.title')}
+        </h2>
+        {tallyQuery.data?.isVotingClosed && (
+          <span className="text-xs font-semibold uppercase text-muted-foreground">
+            {t('gameNightDetail.voting.votingClosed')}
+          </span>
+        )}
+      </div>
+
+      {tallyQuery.isLoading ? (
+        <div className="space-y-2" data-testid="voting-loading">
+          <Skeleton className="h-20 w-full" />
+          <Skeleton className="h-20 w-full" />
+        </div>
+      ) : tallyQuery.isError ? (
+        <p className="text-sm text-muted-foreground" data-testid="voting-error">
+          {t('gameNightDetail.voting.error')}
+        </p>
+      ) : !tallyQuery.data || tallyQuery.data.candidates.length === 0 ? (
+        <div className="rounded-lg border border-border p-6 text-center" data-testid="voting-empty">
+          <p className="font-medium text-foreground">{t('gameNightDetail.voting.empty.title')}</p>
+          <p className="mt-1 text-sm text-muted-foreground">
+            {t('gameNightDetail.voting.empty.body')}
+          </p>
+        </div>
+      ) : (
+        <VotingContent
+          data={tallyQuery.data}
+          gameNightId={gameNightId}
+          isOrganizer={isOrganizer}
+          title={title}
+          pendingCastId={
+            castMutation.isPending ? castMutation.variables?.candidateGameId : undefined
+          }
+          pendingRetractId={
+            retractMutation.isPending ? retractMutation.variables?.candidateGameId : undefined
+          }
+          resolving={resolveMutation.isPending}
+          onToggle={handleToggle}
+          onResolve={handleResolve}
+        />
+      )}
+    </section>
+  );
+}
+
+interface VotingContentProps {
+  readonly data: NonNullable<ReturnType<typeof useGameNightVoteTally>['data']>;
+  readonly gameNightId: string;
+  readonly isOrganizer: boolean;
+  readonly title: (gameId: string) => string;
+  readonly pendingCastId?: string;
+  readonly pendingRetractId?: string;
+  readonly resolving: boolean;
+  readonly onToggle: (gameId: string, votedByMe: boolean) => void;
+  readonly onResolve: (gameId: string) => void;
+}
+
+function VotingContent({
+  data,
+  isOrganizer,
+  title,
+  pendingCastId,
+  pendingRetractId,
+  resolving,
+  onToggle,
+  onResolve,
+}: VotingContentProps): React.JSX.Element {
+  const maxVoteCount = Math.max(0, ...data.candidates.map(c => c.voteCount));
+  const showResolver = isOrganizer && data.isTie && data.isVotingClosed;
+
+  return (
+    <>
+      <ul className="space-y-2">
+        {data.candidates.map(candidate => (
+          <li key={candidate.gameId}>
+            <GameVoteCard
+              gameId={candidate.gameId}
+              title={title(candidate.gameId)}
+              voteCount={candidate.voteCount}
+              maxVoteCount={maxVoteCount}
+              votedByMe={candidate.votedByMe}
+              isLeader={data.leadingCandidateGameIds.includes(candidate.gameId)}
+              isWinner={data.winnerGameId === candidate.gameId}
+              disabled={data.isVotingClosed}
+              pending={pendingCastId === candidate.gameId || pendingRetractId === candidate.gameId}
+              onToggle={onToggle}
+            />
+          </li>
+        ))}
+      </ul>
+
+      {showResolver && (
+        <VotingTiedResolver
+          tiedCandidates={data.leadingCandidateGameIds.map(gameId => ({
+            gameId,
+            title: title(gameId),
+          }))}
+          pending={resolving}
+          onResolve={onResolve}
+        />
+      )}
+    </>
+  );
+}

--- a/apps/web/src/components/features/game-night-detail/voting/VotingPanel.tsx
+++ b/apps/web/src/components/features/game-night-detail/voting/VotingPanel.tsx
@@ -131,7 +131,9 @@ function VotingContent({
   onResolve,
 }: VotingContentProps): React.JSX.Element {
   const maxVoteCount = Math.max(0, ...data.candidates.map(c => c.voteCount));
-  const showResolver = isOrganizer && data.isTie && data.isVotingClosed;
+  // Hide once a winner is resolved: a tie's vote counts stay equal, so `isTie` remains true
+  // even after resolution — `!winnerGameId` prevents the organiser from re-overriding.
+  const showResolver = isOrganizer && data.isTie && data.isVotingClosed && !data.winnerGameId;
 
   return (
     <>

--- a/apps/web/src/components/features/game-night-detail/voting/VotingTiedResolver.tsx
+++ b/apps/web/src/components/features/game-night-detail/voting/VotingTiedResolver.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { Button } from '@/components/ui/primitives/button';
+import { useTranslation } from '@/hooks/useTranslation';
+
+export interface VotingTiedResolverProps {
+  readonly tiedCandidates: ReadonlyArray<{ gameId: string; title: string }>;
+  readonly pending: boolean;
+  readonly onResolve: (gameId: string) => void;
+}
+
+/**
+ * Shown to the organiser when voting has closed on a tie (#2700). The host picks the
+ * winning game among the tied leaders (mockup Frame06 "pareggio — host sceglie a -1h").
+ */
+export function VotingTiedResolver({
+  tiedCandidates,
+  pending,
+  onResolve,
+}: VotingTiedResolverProps): React.JSX.Element {
+  const { t } = useTranslation();
+
+  return (
+    <div
+      data-testid="voting-tied-resolver"
+      className="rounded-lg border border-border-strong bg-muted/40 p-4"
+    >
+      <h4 className="font-display text-sm font-extrabold text-foreground">
+        {t('gameNightDetail.voting.tie.title')}
+      </h4>
+      <p className="mt-1 text-sm text-muted-foreground">{t('gameNightDetail.voting.tie.body')}</p>
+
+      <div className="mt-3 flex flex-wrap gap-2">
+        {tiedCandidates.map(candidate => (
+          <Button
+            key={candidate.gameId}
+            type="button"
+            size="sm"
+            variant="outline"
+            disabled={pending}
+            onClick={() => onResolve(candidate.gameId)}
+            data-testid={`resolve-tie-${candidate.gameId}`}
+          >
+            {t('gameNightDetail.voting.tie.resolve', { title: candidate.title })}
+          </Button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/features/game-night-detail/voting/__tests__/VotingPanel.test.tsx
+++ b/apps/web/src/components/features/game-night-detail/voting/__tests__/VotingPanel.test.tsx
@@ -153,6 +153,22 @@ describe('VotingPanel', () => {
     );
   });
 
+  it('hides the tie resolver once a winner has been resolved', () => {
+    tallyMock.mockReturnValue({
+      data: {
+        ...openTally,
+        isTie: true,
+        isVotingClosed: true,
+        winnerGameId: 'game-a',
+        leadingCandidateGameIds: ['game-a', 'game-b'],
+      },
+      isLoading: false,
+      isError: false,
+    });
+    renderPanel({ isOrganizer: true });
+    expect(screen.queryByTestId('voting-tied-resolver')).not.toBeInTheDocument();
+  });
+
   it('hides the tie resolver from non-organizers', () => {
     tallyMock.mockReturnValue({
       data: {

--- a/apps/web/src/components/features/game-night-detail/voting/__tests__/VotingPanel.test.tsx
+++ b/apps/web/src/components/features/game-night-detail/voting/__tests__/VotingPanel.test.tsx
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { VotingPanel } from '../VotingPanel';
+
+// ── Hook mocks ────────────────────────────────────────────────────────────────
+const tallyMock = vi.fn();
+const castMutateMock = vi.fn();
+const retractMutateMock = vi.fn();
+const resolveMutateMock = vi.fn();
+
+vi.mock('@/hooks/queries/useGameNights', () => ({
+  useGameNightVoteTally: () => tallyMock(),
+  useCastGameNightVote: () => ({ mutate: castMutateMock, isPending: false, variables: undefined }),
+  useRetractGameNightVote: () => ({
+    mutate: retractMutateMock,
+    isPending: false,
+    variables: undefined,
+  }),
+  useResolveGameNightVotingTie: () => ({
+    mutate: resolveMutateMock,
+    isPending: false,
+    variables: undefined,
+  }),
+}));
+
+vi.mock('@/hooks/useToast', () => ({ useToast: () => ({ toast: vi.fn() }) }));
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => ({ t: (key: string) => key, locale: 'it-IT' }),
+}));
+
+const titles = { 'game-a': 'Catan', 'game-b': 'Wingspan' };
+
+const openTally = {
+  isVotingClosed: false,
+  isTie: false,
+  winnerGameId: null as string | null,
+  leadingCandidateGameIds: ['game-a'],
+  candidates: [
+    { gameId: 'game-a', voteCount: 2, votedByMe: true },
+    { gameId: 'game-b', voteCount: 1, votedByMe: false },
+  ],
+};
+
+function renderPanel(overrides: { isOrganizer?: boolean } = {}) {
+  return render(
+    <VotingPanel
+      gameNightId="gn-1"
+      isOrganizer={overrides.isOrganizer ?? false}
+      gameTitleById={titles}
+    />
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  tallyMock.mockReturnValue({ data: openTally, isLoading: false, isError: false });
+});
+
+describe('VotingPanel', () => {
+  it('renders a vote card per candidate with resolved titles', () => {
+    renderPanel();
+    expect(screen.getByTestId('vote-card-game-a')).toBeInTheDocument();
+    expect(screen.getByTestId('vote-card-game-b')).toBeInTheDocument();
+    expect(screen.getByText('Catan')).toBeInTheDocument();
+    expect(screen.getByText('Wingspan')).toBeInTheDocument();
+  });
+
+  it('shows the leader badge on the leading candidate', () => {
+    renderPanel();
+    expect(screen.getByTestId('leader-badge-game-a')).toBeInTheDocument();
+    expect(screen.queryByTestId('leader-badge-game-b')).not.toBeInTheDocument();
+  });
+
+  it('casts an approval when toggling an un-voted candidate', async () => {
+    const user = userEvent.setup();
+    renderPanel();
+
+    await user.click(screen.getByTestId('vote-toggle-game-b'));
+
+    expect(castMutateMock).toHaveBeenCalledWith(
+      { id: 'gn-1', candidateGameId: 'game-b' },
+      expect.any(Object)
+    );
+    expect(retractMutateMock).not.toHaveBeenCalled();
+  });
+
+  it('retracts an approval when toggling an already-voted candidate', async () => {
+    const user = userEvent.setup();
+    renderPanel();
+
+    await user.click(screen.getByTestId('vote-toggle-game-a'));
+
+    expect(retractMutateMock).toHaveBeenCalledWith(
+      { id: 'gn-1', candidateGameId: 'game-a' },
+      expect.any(Object)
+    );
+    expect(castMutateMock).not.toHaveBeenCalled();
+  });
+
+  it('disables toggles once voting has closed', () => {
+    tallyMock.mockReturnValue({
+      data: { ...openTally, isVotingClosed: true },
+      isLoading: false,
+      isError: false,
+    });
+    renderPanel();
+    expect(screen.getByTestId('vote-toggle-game-a')).toBeDisabled();
+  });
+
+  it('renders the loading state', () => {
+    tallyMock.mockReturnValue({ data: undefined, isLoading: true, isError: false });
+    renderPanel();
+    expect(screen.getByTestId('voting-loading')).toBeInTheDocument();
+  });
+
+  it('renders the error state', () => {
+    tallyMock.mockReturnValue({ data: undefined, isLoading: false, isError: true });
+    renderPanel();
+    expect(screen.getByTestId('voting-error')).toBeInTheDocument();
+  });
+
+  it('renders the empty state when there are no candidates', () => {
+    tallyMock.mockReturnValue({
+      data: { ...openTally, candidates: [], leadingCandidateGameIds: [] },
+      isLoading: false,
+      isError: false,
+    });
+    renderPanel();
+    expect(screen.getByTestId('voting-empty')).toBeInTheDocument();
+  });
+
+  it('shows the tie resolver to the organizer once voting closes on a tie', async () => {
+    const user = userEvent.setup();
+    tallyMock.mockReturnValue({
+      data: {
+        ...openTally,
+        isTie: true,
+        isVotingClosed: true,
+        leadingCandidateGameIds: ['game-a', 'game-b'],
+      },
+      isLoading: false,
+      isError: false,
+    });
+    renderPanel({ isOrganizer: true });
+
+    expect(screen.getByTestId('voting-tied-resolver')).toBeInTheDocument();
+    await user.click(screen.getByTestId('resolve-tie-game-a'));
+    expect(resolveMutateMock).toHaveBeenCalledWith(
+      { id: 'gn-1', winningCandidateGameId: 'game-a' },
+      expect.any(Object)
+    );
+  });
+
+  it('hides the tie resolver from non-organizers', () => {
+    tallyMock.mockReturnValue({
+      data: {
+        ...openTally,
+        isTie: true,
+        isVotingClosed: true,
+        leadingCandidateGameIds: ['game-a', 'game-b'],
+      },
+      isLoading: false,
+      isError: false,
+    });
+    renderPanel({ isOrganizer: false });
+    expect(screen.queryByTestId('voting-tied-resolver')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/hooks/queries/useGameNights.ts
+++ b/apps/web/src/hooks/queries/useGameNights.ts
@@ -21,6 +21,7 @@ export const gameNightKeys = {
   mine: () => [...gameNightKeys.all, 'mine'] as const,
   detail: (id: string) => [...gameNightKeys.all, id] as const,
   rsvps: (id: string) => [...gameNightKeys.all, id, 'rsvps'] as const,
+  voteTally: (id: string) => [...gameNightKeys.all, id, 'vote-tally'] as const,
 };
 
 export function useUpcomingGameNights(
@@ -125,6 +126,50 @@ export function useRsvpGameNight() {
       queryClient.invalidateQueries({ queryKey: gameNightKeys.detail(id) });
       queryClient.invalidateQueries({ queryKey: gameNightKeys.rsvps(id) });
       queryClient.invalidateQueries({ queryKey: gameNightKeys.all });
+    },
+  });
+}
+
+// ── Candidate voting (approval model) — Issue #2700 ──────────────────────
+
+export function useGameNightVoteTally(id: string, options: { enabled?: boolean } = {}) {
+  const { enabled = true } = options;
+  return useQuery({
+    queryKey: gameNightKeys.voteTally(id),
+    queryFn: () => api.gameNights.getVoteTally(id),
+    enabled: enabled && !!id,
+  });
+}
+
+export function useCastGameNightVote() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, candidateGameId }: { id: string; candidateGameId: string }) =>
+      api.gameNights.castVote(id, candidateGameId),
+    onSuccess: (_data, { id }) => {
+      queryClient.invalidateQueries({ queryKey: gameNightKeys.voteTally(id) });
+    },
+  });
+}
+
+export function useRetractGameNightVote() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, candidateGameId }: { id: string; candidateGameId: string }) =>
+      api.gameNights.retractVote(id, candidateGameId),
+    onSuccess: (_data, { id }) => {
+      queryClient.invalidateQueries({ queryKey: gameNightKeys.voteTally(id) });
+    },
+  });
+}
+
+export function useResolveGameNightVotingTie() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, winningCandidateGameId }: { id: string; winningCandidateGameId: string }) =>
+      api.gameNights.resolveVotingTie(id, winningCandidateGameId),
+    onSuccess: (_data, { id }) => {
+      queryClient.invalidateQueries({ queryKey: gameNightKeys.voteTally(id) });
     },
   });
 }

--- a/apps/web/src/lib/api/clients/gameNightsClient.ts
+++ b/apps/web/src/lib/api/clients/gameNightsClient.ts
@@ -11,6 +11,7 @@ import {
   GameNightDtoSchema,
   GameNightLiveDtoSchema,
   GameNightRsvpDtoSchema,
+  GameNightVoteTallyDtoSchema,
   RegularDtoSchema,
   StartGameNightSessionResultSchema,
   type ConflictCheckDto,
@@ -18,6 +19,7 @@ import {
   type GameNightDto,
   type GameNightLiveDto,
   type GameNightRsvpDto,
+  type GameNightVoteTallyDto,
   type RegularDto,
   type RsvpStatus,
   type StartGameNightSessionResult,
@@ -50,6 +52,11 @@ export interface GameNightsClient {
   // Issue #950 W1-PR2 wizard hooks
   getRegulars(limit?: number): Promise<RegularDto[]>;
   checkConflict(at: string): Promise<ConflictCheckDto>;
+  // Issue #2700 — candidate voting (approval model)
+  getVoteTally(gameNightId: string): Promise<GameNightVoteTallyDto>;
+  castVote(gameNightId: string, candidateGameId: string): Promise<void>;
+  retractVote(gameNightId: string, candidateGameId: string): Promise<void>;
+  resolveVotingTie(gameNightId: string, winningCandidateGameId: string): Promise<void>;
 }
 
 export function createGameNightsClient({
@@ -151,6 +158,27 @@ export function createGameNightsClient({
         `/api/v1/game-nights/check-conflict?at=${encodeURIComponent(at)}`
       );
       return ConflictCheckDtoSchema.parse(data);
+    },
+
+    async getVoteTally(gameNightId) {
+      const data = await httpClient.get<GameNightVoteTallyDto>(
+        `/api/v1/game-nights/${gameNightId}/votes/tally`
+      );
+      return GameNightVoteTallyDtoSchema.parse(data);
+    },
+
+    async castVote(gameNightId, candidateGameId) {
+      await httpClient.post(`/api/v1/game-nights/${gameNightId}/votes`, { candidateGameId });
+    },
+
+    async retractVote(gameNightId, candidateGameId) {
+      await httpClient.delete(`/api/v1/game-nights/${gameNightId}/votes/${candidateGameId}`);
+    },
+
+    async resolveVotingTie(gameNightId, winningCandidateGameId) {
+      await httpClient.post(`/api/v1/game-nights/${gameNightId}/votes/resolve-tie`, {
+        winningCandidateGameId,
+      });
     },
   };
 }

--- a/apps/web/src/lib/api/schemas/game-nights.schemas.ts
+++ b/apps/web/src/lib/api/schemas/game-nights.schemas.ts
@@ -214,3 +214,23 @@ export const UpdateGameNightInputSchema = z.object({
   gameIds: z.array(z.string().uuid()).max(20).optional(),
 });
 export type UpdateGameNightInput = z.infer<typeof UpdateGameNightInputSchema>;
+
+// ──────────────────────────────────────────────────────────────────────
+// Issue #2700 — candidate voting (approval model)
+// ──────────────────────────────────────────────────────────────────────
+
+export const GameNightCandidateTallyDtoSchema = z.object({
+  gameId: z.string().uuid(),
+  voteCount: z.number().int().nonnegative(),
+  votedByMe: z.boolean(),
+});
+export type GameNightCandidateTallyDto = z.infer<typeof GameNightCandidateTallyDtoSchema>;
+
+export const GameNightVoteTallyDtoSchema = z.object({
+  isVotingClosed: z.boolean(),
+  isTie: z.boolean(),
+  winnerGameId: z.string().uuid().nullable(),
+  leadingCandidateGameIds: z.array(z.string().uuid()),
+  candidates: z.array(GameNightCandidateTallyDtoSchema),
+});
+export type GameNightVoteTallyDto = z.infer<typeof GameNightVoteTallyDtoSchema>;

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -3845,6 +3845,27 @@
       "submit": "Save changes",
       "savedToast": "Game night updated",
       "errorGeneric": "Could not update the game night."
+    },
+    "voting": {
+      "title": "Candidate voting",
+      "votingClosed": "Voting closed",
+      "vote": "Vote",
+      "retract": "Remove vote",
+      "leaderBadge": "Leading",
+      "winnerBadge": "Winner",
+      "candidateFallback": "Game",
+      "votesCount": "{count, plural, =0 {No votes} =1 {1 vote} other {# votes}}",
+      "actionError": "Could not record your vote. Please retry.",
+      "error": "Could not load the vote.",
+      "empty": {
+        "title": "No candidates",
+        "body": "There are no games to vote on for this night."
+      },
+      "tie": {
+        "title": "It's a tie!",
+        "body": "Choose the winning game among the tied candidates.",
+        "resolve": "Choose {title}"
+      }
     }
   },
   "gameNightsIndex": {

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -3898,6 +3898,27 @@
       "submit": "Salva modifiche",
       "savedToast": "Serata aggiornata",
       "errorGeneric": "Impossibile aggiornare la serata."
+    },
+    "voting": {
+      "title": "Votazione candidati",
+      "votingClosed": "Votazione chiusa",
+      "vote": "Vota",
+      "retract": "Rimuovi voto",
+      "leaderBadge": "In testa",
+      "winnerBadge": "Vincitore",
+      "candidateFallback": "Gioco",
+      "votesCount": "{count, plural, =0 {Nessun voto} =1 {1 voto} other {# voti}}",
+      "actionError": "Impossibile registrare il voto. Riprova.",
+      "error": "Impossibile caricare la votazione.",
+      "empty": {
+        "title": "Nessun candidato",
+        "body": "Non ci sono giochi tra cui votare per questa serata."
+      },
+      "tie": {
+        "title": "Pareggio!",
+        "body": "Scegli il gioco vincitore tra i candidati in parità.",
+        "resolve": "Scegli {title}"
+      }
     }
   },
   "gameNightsIndex": {


### PR DESCRIPTION
> Closes #2700 · Umbrella #2697 (Tier 3) · Spec §4a US-INT-3 step 4 · ADR-074 (closure philosophy)

## What

Candidate-game **approval voting** for a game night. Each confirmed participant (Accepted RSVP) approves any subset of the event's candidate games (1 vote per candidate, toggle). Voting **closes 1h before** `ScheduledAt` (lazy check). On a **tie** at close, the **organiser** resolves it.

_Design decisions confirmed with the maintainer: approval model + single full-stack PR (no authoritative mockup — the sp7 voting tab was deferred)._

## Backend

- **Domain** (`GameNightEvent`): `GameNightVote` owned entity + `GameNightVoteTally` record. `CastVote`/`RetractVote` (return the vote or null for an idempotent no-op) with guards (Published, voting open, valid candidate, confirmed voter → `Conflict`/`NotFound`/`Forbidden`); `ResolveVotingTie` (organiser-only, post-close, real tie, valid choice); `TallyVotes()`; `IsVotingClosed(now)`.
- **Persistence**: `game_night_votes` table (unique `(event,voter,candidate)`) + `voting_winner_game_id` column + migration. Votes are **append/remove immutables persisted via tracked `AddVoteAsync`/`RemoveVoteAsync`** — the aggregate's detached full-remap `Update()` marks a brand-new PK-set child `Modified` (→ 0-row UPDATE), so new votes bypass it. Votes are `Include`d on every event query so an unrelated event edit still preserves them (proven by an integration test).
- **Application + routing**: Cast/Retract/ResolveTie commands + validators + handlers; `GetGameNightVoteTallyQuery` (participant-scoped IDOR per #2698, `VotedByMe` flag). Endpoints: `POST`/`DELETE /{id}/votes`, `POST /{id}/votes/resolve-tie`, `GET /{id}/votes/tally`.

## Frontend

- Client + zod schema + hooks (`useGameNightVoteTally` + cast/retract/resolve mutations).
- `GameVoteCard` (approval bar + leader/winner badge + cast/retract toggle) · `VotingTiedResolver` (organiser picks the winner on a tie) · `VotingPanel` (4 canonical states: loading / empty / error / default). Mounted on the **Published** detail; the tie resolver is organiser-gated; candidate titles resolve from the shared-game catalog.
- i18n `gameNightDetail.voting` (it + en).

## 🔴 IDOR / DEC-A5

- Non-confirmed user cannot cast (→ **403** `Forbidden`, aggregate guard) — handler-driven integration test.
- Non-participant cannot read the tally (→ **403**) — integration test.
- DEC-A5 states: default / empty (no candidates) / loading / error (manual + unit-tested).

## Tests (TDD RED→GREEN)

- **Backend**: 16 domain (guards/tally/tie) + 2 repository integration (round-trip + no-wipe-on-edit) + 5 handler-driven MediatR integration (cast, IDOR cast 403, IDOR tally 403, retract, closed 409). **422 GameNight unit tests pass**, 0 regressions.
- **Frontend**: 10 `VotingPanel` tests (states, cast/retract toggle, leader badge, closed-disabled, tie resolver organiser-gated). Typecheck + lint clean; **57 game-night FE tests pass**.

## Definition of Done

- [x] Per-candidate approval voting with temporal closure (-1h)
- [x] Tally (counts + winner + tie) + tie resolver
- [x] FE voting panel + states
- [x] Cross-tenant (IDOR) tests + tally

## Notes / follow-ups

- Voting surfaces as a **section** on the Published detail (the detail view isn't tabbed yet; a full `?tab=voting` refactor per ADR-061 is deferred).
- FE CI checks may show pre-existing baseline-red (`sessionsClient(.crud)`, `gameNightsClient.live`, `PhotosTabContent` lint) unrelated to this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)