### PR TITLE
fix(rag): #2712 meaningful confidence + FE fixes unhide grounded chat answers

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/SearchQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/SearchQueryHandler.cs
@@ -138,37 +138,30 @@ internal class SearchQueryHandler : IQueryHandler<SearchQuery, List<SearchResult
         IReadOnlyList<Guid>? documentIds,
         CancellationToken cancellationToken)
     {
-        // Get candidate embeddings from repository (already filtered and ranked by pgvector)
-        var embeddings = await _embeddingRepository.SearchByVectorAsync(
-            gameId, queryVector, topK, minScore, documentIds, cancellationToken).ConfigureAwait(false);
-
-        if (embeddings == null)
-        {
-            _logger.LogWarning("Vector search returned null for gameId={GameId}", gameId);
-            embeddings = new List<Domain.Entities.Embedding>();
-        }
+        // Issue #2712: use SearchByVectorWithScoresAsync so each result carries the REAL cosine
+        // similarity computed by pgvector in SQL (1 - (vector <=> query)). The previous call
+        // (SearchByVectorAsync) returned placeholder vectors and forced a rank-based score
+        // (1.0 - index*0.05), which made the downstream confidence degenerate (always ≈0.53) and
+        // hid grounded answers behind the "Non sono certo" card.
+        var scoredEmbeddings = await _embeddingRepository.SearchByVectorWithScoresAsync(
+            gameId, queryVector, topK, minScore, documentIds, cancellationToken).ConfigureAwait(false)
+            ?? (IReadOnlyList<Domain.Entities.ScoredEmbedding>)Array.Empty<Domain.Entities.ScoredEmbedding>();
 
         _logger.LogInformation(
-            "Vector search returned {Count} embeddings for gameId={GameId}",
-            embeddings.Count, gameId);
+            "Vector search returned {Count} scored embeddings for gameId={GameId}",
+            scoredEmbeddings.Count, gameId);
 
-        // Convert embeddings to SearchResults directly
-        // Note: pgvector already scored and filtered results by minScore, so we use rank-based scoring
-        // This avoids recalculating cosine similarity with placeholder vectors (which would always be 0)
-        var results = embeddings.Select((embedding, index) =>
+        // Results come pre-ordered by pgvector (ORDER BY distance), so the list index is the rank.
+        var results = scoredEmbeddings.Select((scored, index) =>
         {
-            // Calculate a score based on rank (first result gets highest score, decays with rank)
-            // This preserves pgvector's ranking while providing a meaningful confidence value
-            var rankBasedScore = 1.0 - (index * 0.05); // First = 1.0, Second = 0.95, etc.
-            var clampedScore = Math.Max(minScore, Math.Min(1.0, rankBasedScore));
-            var confidence = new Confidence(clampedScore);
+            var cosine = Math.Clamp(scored.Score, 0.0, 1.0);
 
             return new Domain.Entities.SearchResult(
                 id: Guid.NewGuid(),
-                vectorDocumentId: embedding.VectorDocumentId,
-                textContent: embedding.TextContent,
-                pageNumber: embedding.PageNumber,
-                relevanceScore: confidence,
+                vectorDocumentId: scored.Embedding.VectorDocumentId,
+                textContent: scored.Embedding.TextContent,
+                pageNumber: scored.Embedding.PageNumber,
+                relevanceScore: new Confidence(cosine),
                 rank: index + 1,
                 searchMethod: "vector"
             );

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Services/VectorSearch/RrfFusionDomainService.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Services/VectorSearch/RrfFusionDomainService.cs
@@ -78,7 +78,11 @@ internal class RrfFusionDomainService
                 vectorDocumentId: item.Result.VectorDocumentId,
                 textContent: item.Result.TextContent,
                 pageNumber: item.Result.PageNumber,
-                relevanceScore: new Confidence(item.NormalizedScore),
+                // Issue #2712: preserve the original relevance signal (cosine similarity for vector
+                // results) as the RelevanceScore. RRF still drives the ORDER (OrderByDescending above),
+                // but the RelevanceScore must reflect semantic relevance — feeding the rank-based RRF
+                // score into confidence made it degenerate (always ≈0.53).
+                relevanceScore: item.Result.RelevanceScore,
                 rank: index + 1, // Rank assigned after sorting
                 searchMethod: "hybrid"
             ))

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/AskQuestionQueryHandlerSecurityTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/AskQuestionQueryHandlerSecurityTests.cs
@@ -79,6 +79,16 @@ public class AskQuestionQueryHandlerSecurityTests
                 It.IsAny<IReadOnlyList<Guid>?>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<Embedding>());
+        // Issue #2712: PerformVectorSearchAsync now calls SearchByVectorWithScoresAsync.
+        mockEmbeddingRepo
+            .Setup(r => r.SearchByVectorWithScoresAsync(
+                It.IsAny<Guid>(),
+                It.IsAny<Vector>(),
+                It.IsAny<int>(),
+                It.IsAny<double>(),
+                It.IsAny<IReadOnlyList<Guid>?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyList<ScoredEmbedding>)new List<ScoredEmbedding>());
 
         // Setup VectorSearchDomainService
         mockVectorSearchService

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/StreamQaQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/StreamQaQueryHandlerTests.cs
@@ -598,6 +598,10 @@ public class StreamQaQueryHandlerTests
         _embeddingRepositoryMock
             .Setup(x => x.SearchByVectorAsync(It.IsAny<Guid>(), It.IsAny<Vector>(), It.IsAny<int>(), It.IsAny<double>(), It.IsAny<IReadOnlyList<Guid>?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<Embedding> { embedding });
+        // Issue #2712: PerformVectorSearchAsync now calls SearchByVectorWithScoresAsync (real cosine score).
+        _embeddingRepositoryMock
+            .Setup(x => x.SearchByVectorWithScoresAsync(It.IsAny<Guid>(), It.IsAny<Vector>(), It.IsAny<int>(), It.IsAny<double>(), It.IsAny<IReadOnlyList<Guid>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ScoredEmbedding> { new ScoredEmbedding(embedding, 0.55) });
 
         // Low relevance score (0.55)
         var lowScoreResult = new DomainSearchResult(
@@ -710,6 +714,10 @@ public class StreamQaQueryHandlerTests
         _embeddingRepositoryMock
             .Setup(x => x.SearchByVectorAsync(It.IsAny<Guid>(), It.IsAny<Vector>(), It.IsAny<int>(), It.IsAny<double>(), It.IsAny<IReadOnlyList<Guid>?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(embeddings);
+        // Issue #2712: PerformVectorSearchAsync now calls SearchByVectorWithScoresAsync (real cosine score).
+        _embeddingRepositoryMock
+            .Setup(x => x.SearchByVectorWithScoresAsync(It.IsAny<Guid>(), It.IsAny<Vector>(), It.IsAny<int>(), It.IsAny<double>(), It.IsAny<IReadOnlyList<Guid>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(embeddings.Select((e, i) => new ScoredEmbedding(e, 0.95 - i * 0.03)).ToList());
 
         _vectorSearchServiceMock
             .Setup(x => x.Search(It.IsAny<Vector>(), It.IsAny<List<Embedding>>(), It.IsAny<int>(), It.IsAny<double>()))
@@ -947,6 +955,10 @@ public class StreamQaQueryHandlerTests
         _embeddingRepositoryMock
             .Setup(x => x.SearchByVectorAsync(It.IsAny<Guid>(), It.IsAny<Vector>(), It.IsAny<int>(), It.IsAny<double>(), It.IsAny<IReadOnlyList<Guid>?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<Embedding> { embedding });
+        // Issue #2712: PerformVectorSearchAsync now calls SearchByVectorWithScoresAsync (real cosine score).
+        _embeddingRepositoryMock
+            .Setup(x => x.SearchByVectorWithScoresAsync(It.IsAny<Guid>(), It.IsAny<Vector>(), It.IsAny<int>(), It.IsAny<double>(), It.IsAny<IReadOnlyList<Guid>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ScoredEmbedding> { new ScoredEmbedding(embedding, 0.85) });
 
         // Setup vector search domain service to return results
         var vectorSearchResult = new DomainSearchResult(

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/AskQuestionQueryHandlerIntentRoutingTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/AskQuestionQueryHandlerIntentRoutingTests.cs
@@ -147,6 +147,12 @@ public sealed class AskQuestionQueryHandlerIntentRoutingTests
                 It.IsAny<Guid>(), It.IsAny<Vector>(), It.IsAny<int>(),
                 It.IsAny<double>(), It.IsAny<IReadOnlyList<Guid>?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<Embedding>());
+        // Issue #2712: PerformVectorSearchAsync now calls SearchByVectorWithScoresAsync.
+        embeddingRepoMock
+            .Setup(r => r.SearchByVectorWithScoresAsync(
+                It.IsAny<Guid>(), It.IsAny<Vector>(), It.IsAny<int>(),
+                It.IsAny<double>(), It.IsAny<IReadOnlyList<Guid>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyList<ScoredEmbedding>)new List<ScoredEmbedding>());
 
         var searchEmbeddingServiceMock = new Mock<IEmbeddingService>();
         searchEmbeddingServiceMock

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/AskQuestionQueryHandlerPhase2Tests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/AskQuestionQueryHandlerPhase2Tests.cs
@@ -64,6 +64,10 @@ public class AskQuestionQueryHandlerPhase2Tests
         mockEmbeddingRepo
             .Setup(r => r.SearchByVectorAsync(It.IsAny<Guid>(), It.IsAny<Vector>(), It.IsAny<int>(), It.IsAny<double>(), It.IsAny<IReadOnlyList<Guid>?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<Embedding>());
+        // Issue #2712: PerformVectorSearchAsync now calls SearchByVectorWithScoresAsync.
+        mockEmbeddingRepo
+            .Setup(r => r.SearchByVectorWithScoresAsync(It.IsAny<Guid>(), It.IsAny<Vector>(), It.IsAny<int>(), It.IsAny<double>(), It.IsAny<IReadOnlyList<Guid>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyList<ScoredEmbedding>)new List<ScoredEmbedding>());
 
         mockVectorSearchService
             .Setup(v => v.ValidateSearchParameters(It.IsAny<int>(), It.IsAny<double>()))

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/SearchQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/SearchQueryHandlerTests.cs
@@ -33,7 +33,7 @@ public sealed class SearchQueryHandlerTests
     /// <summary>
     /// Issue #563 — happy path: caller supplies a pre-computed query vector,
     /// so the handler MUST NOT invoke <see cref="IEmbeddingService.GenerateEmbeddingAsync(string, string, CancellationToken)"/>,
-    /// and the supplied vector MUST flow through to <see cref="IEmbeddingRepository.SearchByVectorAsync"/>.
+    /// and the supplied vector MUST flow through to <see cref="IEmbeddingRepository.SearchByVectorWithScoresAsync"/>.
     /// </summary>
     [Fact]
     public async Task Handle_WithPrecomputedQueryVector_SkipsEmbeddingService()
@@ -57,6 +57,19 @@ public sealed class SearchQueryHandlerTests
             .Callback<Guid, Vector, int, double, IReadOnlyList<Guid>?, CancellationToken>(
                 (_, vector, _, _, _, _) => capturedVectors.Add(vector))
             .ReturnsAsync(new List<Embedding>());
+        // Issue #2712: PerformVectorSearchAsync now calls SearchByVectorWithScoresAsync,
+        // so capture the query vector here (this is the method actually invoked).
+        embeddingRepositoryMock
+            .Setup(r => r.SearchByVectorWithScoresAsync(
+                It.IsAny<Guid>(),
+                It.IsAny<Vector>(),
+                It.IsAny<int>(),
+                It.IsAny<double>(),
+                It.IsAny<IReadOnlyList<Guid>?>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<Guid, Vector, int, double, IReadOnlyList<Guid>?, CancellationToken>(
+                (_, vector, _, _, _, _) => capturedVectors.Add(vector))
+            .ReturnsAsync((IReadOnlyList<ScoredEmbedding>)new List<ScoredEmbedding>());
 
         var ragAccessMock = new Mock<IRagAccessService>();
         // No UserId on query → access check is skipped, no setup needed.
@@ -124,6 +137,19 @@ public sealed class SearchQueryHandlerTests
             .Callback<Guid, Vector, int, double, IReadOnlyList<Guid>?, CancellationToken>(
                 (_, vector, _, _, _, _) => capturedVectors.Add(vector))
             .ReturnsAsync(new List<Embedding>());
+        // Issue #2712: PerformVectorSearchAsync now calls SearchByVectorWithScoresAsync,
+        // so capture the generated query vector here (this is the method actually invoked).
+        embeddingRepositoryMock
+            .Setup(r => r.SearchByVectorWithScoresAsync(
+                It.IsAny<Guid>(),
+                It.IsAny<Vector>(),
+                It.IsAny<int>(),
+                It.IsAny<double>(),
+                It.IsAny<IReadOnlyList<Guid>?>(),
+                It.IsAny<CancellationToken>()))
+            .Callback<Guid, Vector, int, double, IReadOnlyList<Guid>?, CancellationToken>(
+                (_, vector, _, _, _, _) => capturedVectors.Add(vector))
+            .ReturnsAsync((IReadOnlyList<ScoredEmbedding>)new List<ScoredEmbedding>());
 
         var ragAccessMock = new Mock<IRagAccessService>();
 
@@ -181,6 +207,16 @@ public sealed class SearchQueryHandlerTests
                 It.IsAny<IReadOnlyList<Guid>?>(),
                 It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<Embedding>());
+        // Issue #2712: PerformVectorSearchAsync now calls SearchByVectorWithScoresAsync.
+        embeddingRepositoryMock
+            .Setup(r => r.SearchByVectorWithScoresAsync(
+                It.IsAny<Guid>(),
+                It.IsAny<Vector>(),
+                It.IsAny<int>(),
+                It.IsAny<double>(),
+                It.IsAny<IReadOnlyList<Guid>?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyList<ScoredEmbedding>)new List<ScoredEmbedding>());
 
         var ragAccessMock = new Mock<IRagAccessService>();
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Domain/Services/VectorSearch/RrfFusionDomainServiceTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Domain/Services/VectorSearch/RrfFusionDomainServiceTests.cs
@@ -52,6 +52,34 @@ public sealed class RrfFusionDomainServiceTests
     }
 
     [Fact]
+    public void FuseResults_PreservesRealRelevanceScore_NotRankBasedRrf()
+    {
+        // Issue #2712: the fused RelevanceScore must reflect the SOURCE result's real relevance
+        // (cosine similarity for vector results), NOT the rank-based RRF score. The RRF score for a
+        // single rank-1 result is NormalizeRrfScore(1/61) = 30/61 ≈ 0.4918; feeding that into
+        // confidence made it degenerate (~0.53). The real cosine (0.87) must be preserved.
+        var docId = Guid.NewGuid();
+        var vectorResults = new List<SearchResult>
+        {
+            new SearchResult(
+                id: Guid.NewGuid(),
+                vectorDocumentId: docId,
+                textContent: "Relevant chunk",
+                pageNumber: 1,
+                relevanceScore: new Confidence(0.87),
+                rank: 1,
+                searchMethod: "vector"),
+        };
+        var keywordResults = new List<SearchResult>();
+
+        var result = _service.FuseResults(vectorResults, keywordResults);
+
+        result.Should().HaveCount(1);
+        result.First().RelevanceScore.Value.Should().BeApproximately(0.87, 0.0001,
+            "the real cosine must survive fusion, not be overwritten by the ~0.49 rank-based RRF score");
+    }
+
+    [Fact]
     public void FuseResults_WithOverlappingDocuments_CombinesScores()
     {
         // Arrange

--- a/apps/web/src/hooks/queries/__tests__/useGameChat.test.tsx
+++ b/apps/web/src/hooks/queries/__tests__/useGameChat.test.tsx
@@ -69,16 +69,34 @@ describe('useGameChat', () => {
     expect(result.current.messages[1].isLowQuality).toBe(false);
   });
 
-  it('derives isLowQuality=true when confidence < 0.70', async () => {
+  it('derives isLowQuality=true when confidence < 0.70 AND no citations', async () => {
     const lowConfEvents = [
       { type: 7, data: 'Non sono certo.' },
-      { type: 4, data: { confidence: 0.42, Citations: [sampleCitation] } },
+      { type: 4, data: { confidence: 0.42, Citations: [] } },
     ];
     vi.mocked(qaStream).mockReturnValueOnce(mockStream(lowConfEvents) as any);
     const { result } = renderHook(() => useGameChat('wingspan'));
-    await act(async () => { await result.current.ask('edge?'); });
+    await act(async () => {
+      await result.current.ask('edge?');
+    });
     expect(result.current.messages[1].isLowQuality).toBe(true);
     expect(result.current.messages[1].outOfContext).toBe(false);
+  });
+
+  it('does NOT mark isLowQuality when citations are present even if confidence < 0.70 (Issue #2712)', async () => {
+    // A grounded answer with valid citations must be shown, not hidden behind the "Non sono certo" card.
+    const groundedLowConf = [
+      { type: 7, data: 'Il punteggio si calcola contando le carte agente rimaste.' },
+      { type: 4, data: { confidence: 0.53, Citations: [sampleCitation] } },
+    ];
+    vi.mocked(qaStream).mockReturnValueOnce(mockStream(groundedLowConf) as any);
+    const { result } = renderHook(() => useGameChat('wingspan'));
+    await act(async () => {
+      await result.current.ask('come si calcola il punteggio?');
+    });
+    expect(result.current.messages[1].isLowQuality).toBe(false);
+    expect(result.current.messages[1].content).toContain('Il punteggio si calcola');
+    expect(result.current.messages[1].citations).toHaveLength(1);
   });
 
   it('derives outOfContext=true when no citations + confidence < 0.30', async () => {
@@ -88,7 +106,9 @@ describe('useGameChat', () => {
     ];
     vi.mocked(qaStream).mockReturnValueOnce(mockStream(oocEvents) as any);
     const { result } = renderHook(() => useGameChat('wingspan'));
-    await act(async () => { await result.current.ask('tg?'); });
+    await act(async () => {
+      await result.current.ask('tg?');
+    });
     expect(result.current.messages[1].outOfContext).toBe(true);
     expect(result.current.messages[1].citations).toBeUndefined();
   });
@@ -96,16 +116,22 @@ describe('useGameChat', () => {
   it('isLoading transitions correctly during ask', async () => {
     let releaseStream: () => void = () => {};
     const slowStream = async function* () {
-      await new Promise<void>(r => { releaseStream = r; });
+      await new Promise<void>(r => {
+        releaseStream = r;
+      });
       yield happyEvents[2];
     };
     vi.mocked(qaStream).mockReturnValueOnce(slowStream() as any);
     const { result } = renderHook(() => useGameChat('wingspan'));
 
-    act(() => { void result.current.ask('q'); });
+    act(() => {
+      void result.current.ask('q');
+    });
     await waitFor(() => expect(result.current.isLoading).toBe(true));
 
-    await act(async () => { releaseStream(); });
+    await act(async () => {
+      releaseStream();
+    });
     await waitFor(() => expect(result.current.isLoading).toBe(false));
   });
 
@@ -117,23 +143,33 @@ describe('useGameChat', () => {
     vi.mocked(qaStream).mockReturnValueOnce(errorStream() as any);
     const { result } = renderHook(() => useGameChat('wingspan'));
     await act(async () => {
-      try { await result.current.ask('q'); } catch { /* expected */ }
+      try {
+        await result.current.ask('q');
+      } catch {
+        /* expected */
+      }
     });
     await waitFor(() => expect(result.current.isError).toBe(true));
   });
 
   it('switchAgent updates currentAgent', () => {
     const { result } = renderHook(() => useGameChat('wingspan'));
-    act(() => { result.current.switchAgent('arbitro'); });
+    act(() => {
+      result.current.switchAgent('arbitro');
+    });
     expect(result.current.currentAgent).toBe('arbitro');
   });
 
   it('switchAgent does NOT clear message history', async () => {
     vi.mocked(qaStream).mockReturnValueOnce(mockStream(happyEvents) as any);
     const { result } = renderHook(() => useGameChat('wingspan'));
-    await act(async () => { await result.current.ask('q'); });
+    await act(async () => {
+      await result.current.ask('q');
+    });
     expect(result.current.messages).toHaveLength(2);
-    act(() => { result.current.switchAgent('arbitro'); });
+    act(() => {
+      result.current.switchAgent('arbitro');
+    });
     expect(result.current.messages).toHaveLength(2);
   });
 
@@ -219,11 +255,15 @@ describe('useGameChat', () => {
     const { result } = renderHook(() => useGameChat('wingspan'));
     await waitFor(() => expect(result.current.chatThreadId).toBe('thread-existing'));
 
-    await act(async () => { await result.current.ask('new question'); });
+    await act(async () => {
+      await result.current.ask('new question');
+    });
 
-    expect(qaStream).toHaveBeenCalledWith(expect.objectContaining({
-      chatId: 'thread-existing',
-    }));
+    expect(qaStream).toHaveBeenCalledWith(
+      expect.objectContaining({
+        chatId: 'thread-existing',
+      })
+    );
   });
 
   it('preserves messages across remount (audit trigger A)', async () => {

--- a/apps/web/src/hooks/queries/__tests__/useGameChat.test.tsx
+++ b/apps/web/src/hooks/queries/__tests__/useGameChat.test.tsx
@@ -99,6 +99,25 @@ describe('useGameChat', () => {
     expect(result.current.messages[1].citations).toHaveLength(1);
   });
 
+  it('accumulates answer text from { token } event shape (Issue #2712)', async () => {
+    // Production SSE sends type-7 events as { token: "..." } (chatClient.qaStream yields raw
+    // event.data), NOT plain strings. The hook must accumulate that shape or the bubble is empty.
+    const tokenObjectEvents = [
+      { type: 7, data: { token: 'Il punteggio ' } },
+      { type: 7, data: { token: 'si calcola alla fine della partita.' } },
+      { type: 4, data: { confidence: 0.79, Citations: [sampleCitation] } },
+    ];
+    vi.mocked(qaStream).mockReturnValueOnce(mockStream(tokenObjectEvents) as any);
+    const { result } = renderHook(() => useGameChat('wingspan'));
+    await act(async () => {
+      await result.current.ask('come si calcola il punteggio?');
+    });
+    expect(result.current.messages[1].content).toBe(
+      'Il punteggio si calcola alla fine della partita.'
+    );
+    expect(result.current.messages[1].isLowQuality).toBe(false);
+  });
+
   it('derives outOfContext=true when no citations + confidence < 0.30', async () => {
     const oocEvents = [
       { type: 7, data: 'Non ho informazioni.' },

--- a/apps/web/src/hooks/queries/useGameChat.ts
+++ b/apps/web/src/hooks/queries/useGameChat.ts
@@ -162,12 +162,13 @@ export function useGameChat(gameId: string, initialAgent: AgentKind = 'tutor'): 
             const tokenData = event.data;
             if (typeof tokenData === 'string') {
               answerBuffer += tokenData;
-            } else if (
-              typeof tokenData === 'object' &&
-              tokenData !== null &&
-              'content' in tokenData
-            ) {
-              answerBuffer += String((tokenData as { content?: unknown }).content ?? '');
+            } else if (typeof tokenData === 'object' && tokenData !== null) {
+              // Issue #2712: the SSE token event (type 7) carries { token: "..." } — see
+              // chatClient.qaStream, which yields the raw event.data. The previous code only
+              // handled { content }, so the answer text was NEVER accumulated (empty bubble).
+              // Support both shapes (token first) plus the plain-string form used in tests.
+              const obj = tokenData as { token?: unknown; content?: unknown };
+              answerBuffer += String(obj.token ?? obj.content ?? '');
             }
           } else if (event.type === COMPLETE_EVENT_TYPE) {
             const payload = event.data as StreamingCompletePayload;

--- a/apps/web/src/hooks/queries/useGameChat.ts
+++ b/apps/web/src/hooks/queries/useGameChat.ts
@@ -173,7 +173,14 @@ export function useGameChat(gameId: string, initialAgent: AgentKind = 'tutor'): 
             const payload = event.data as StreamingCompletePayload;
             const confidence = payload.confidence ?? undefined;
             const citations = payload.Citations ?? payload.citations ?? [];
-            const isLowQuality = confidence !== undefined && confidence < LOW_QUALITY_THRESHOLD;
+            // Issue #2712: a grounded answer (valid citations) must NOT be degraded to the
+            // "Non sono certo" card. The numeric confidence is currently compressed (rank-based),
+            // so gating solely on it hid correct answers. Treat low-quality only when the RAG
+            // found NO context (no citations) AND confidence is below threshold.
+            const isLowQuality =
+              citations.length === 0 &&
+              confidence !== undefined &&
+              confidence < LOW_QUALITY_THRESHOLD;
             const outOfContext =
               citations.length === 0 &&
               (confidence === undefined || confidence < OUT_OF_CONTEXT_THRESHOLD);


### PR DESCRIPTION
## Sintomo
La chat con agente AI (`/library/[id]?tab=aiChat`) mostrava **"⚠️ Non sono certo"** con **risposta vuota** per ogni domanda, anche quando il RAG recuperava i chunk giusti e l'LLM rispondeva correttamente.

## Root cause — tre difetti a valle del retrieval
Il retrieval funzionava (5 citazioni, risposta grounded verificata via fetch diretta), ma:

1. **Confidence degenere (BE)** — sempre `≈0.5312` a prescindere dalla domanda:
   - `SearchQueryHandler.PerformVectorSearchAsync` usava `SearchByVectorAsync` (vettori placeholder) e uno score **rank-based** `1.0 - index*0.05`, scartando il coseno pgvector.
   - `RrfFusionDomainService` sovrascriveva il `RelevanceScore` con lo score RRF rank-based (`30/(60+rank) ≈ 0.49`).
   - `CalculateSearchConfidence` mediava quei valori → sempre `≈0.4826` → overall `≈0.5312`.
2. **Gate FE troppo aggressivo** — `useGameChat` marcava `isLowQuality = confidence < 0.7`; siccome la confidence non superava mai 0.53, **ogni** risposta era degradata alla card "Non sono certo" (`GameChatTab:204` nasconde il testo).
3. **Parsing token rotto (FE)** — gli eventi token (type 7) dello stream arrivano come `{ token: "..." }`, ma `useGameChat` gestiva solo `string` / `{ content }` → il testo **non veniva mai accumulato** (bolla vuota). I test lo mascheravano mockando i token come stringhe.

## Fix
- **BE-1**: `PerformVectorSearchAsync` usa `SearchByVectorWithScoresAsync` → `RelevanceScore` è il coseno reale (già calcolato da pgvector in SQL).
- **BE-2**: `RrfFusionDomainService` preserva il `RelevanceScore` sorgente (coseno); l'RRF resta solo per l'ordinamento.
- **FE gate**: `isLowQuality` solo quando NON ci sono citazioni (contesto vuoto). Una risposta grounded con citazioni valide è sempre mostrata.
- **FE token**: `useGameChat` accumula il formato `{ token }` (con fallback su `{ content }` e stringa).

## Verifica end-to-end (locale, snapshot staging)
Rebuild immagini API+Web con i fix, stessa domanda della schermata originale:
- Confidence: `0.5312` (costante) → **0.79 / 0.80** (variabile, riflette il coseno).
- Chat: card "Non sono certo" + bolla vuota → **risposta grounded completa** con badge confidence accurato.

## Test
131 test BE + 92 FE verdi (nuovi test: coseno preservato nella fusione, gate FE con/senza citazioni, parsing `{ token }`). 0 regressioni.

## Nota
Follow-up dei fix #2705 (retrieval chat sessione) e #2708 (reranking qa/stream): corretti in sé, ma la **causa reale** del sintomo visibile era questo disallineamento confidence↔soglia + il parsing token rotto.

Closes #2712

🤖 Generated with [Claude Code](https://claude.com/claude-code)
