### PR TITLE
feat(game-night): #2702 summary MVP/KPI + share-token + archive (full-stack)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/GenerateGameNightShareTokenCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/GenerateGameNightShareTokenCommand.cs
@@ -1,0 +1,9 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.GameManagement.Application.Commands.GameNights;
+
+/// <summary>
+/// Organiser generates (or rotates) a public share token for the night's summary — Issue #2702.
+/// Returns the new token.
+/// </summary>
+internal record GenerateGameNightShareTokenCommand(Guid GameNightId, Guid UserId) : ICommand<string>;

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/GenerateGameNightShareTokenCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/GenerateGameNightShareTokenCommandHandler.cs
@@ -1,0 +1,42 @@
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Infrastructure.Persistence;
+
+namespace Api.BoundedContexts.GameManagement.Application.Commands.GameNights;
+
+/// <summary>
+/// Generates a summary share token. Organiser-only (#2349 ownership guard). Returns the token.
+/// </summary>
+internal sealed class GenerateGameNightShareTokenCommandHandler
+    : ICommandHandler<GenerateGameNightShareTokenCommand, string>
+{
+    private readonly IGameNightEventRepository _repository;
+    private readonly IUnitOfWork _unitOfWork;
+
+    public GenerateGameNightShareTokenCommandHandler(
+        IGameNightEventRepository repository, IUnitOfWork unitOfWork)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+    }
+
+    public async Task<string> Handle(
+        GenerateGameNightShareTokenCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var gameNight = await _repository.GetByIdAsync(command.GameNightId, cancellationToken).ConfigureAwait(false)
+            ?? throw new NotFoundException("GameNightEvent", command.GameNightId.ToString());
+
+        if (gameNight.OrganizerId != command.UserId)
+            throw new ForbiddenException("Only the organizer can share this game night's summary.");
+
+        var token = gameNight.GenerateShareToken();
+
+        await _repository.UpdateAsync(gameNight, cancellationToken).ConfigureAwait(false);
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        return token;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/RevokeGameNightShareTokenCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/RevokeGameNightShareTokenCommand.cs
@@ -1,0 +1,6 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.GameManagement.Application.Commands.GameNights;
+
+/// <summary>Organiser revokes the summary share token — Issue #2702.</summary>
+internal record RevokeGameNightShareTokenCommand(Guid GameNightId, Guid UserId) : ICommand;

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/RevokeGameNightShareTokenCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/RevokeGameNightShareTokenCommandHandler.cs
@@ -1,0 +1,37 @@
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Infrastructure.Persistence;
+
+namespace Api.BoundedContexts.GameManagement.Application.Commands.GameNights;
+
+/// <summary>Revokes the summary share token. Organiser-only.</summary>
+internal sealed class RevokeGameNightShareTokenCommandHandler
+    : ICommandHandler<RevokeGameNightShareTokenCommand>
+{
+    private readonly IGameNightEventRepository _repository;
+    private readonly IUnitOfWork _unitOfWork;
+
+    public RevokeGameNightShareTokenCommandHandler(
+        IGameNightEventRepository repository, IUnitOfWork unitOfWork)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+    }
+
+    public async Task Handle(RevokeGameNightShareTokenCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var gameNight = await _repository.GetByIdAsync(command.GameNightId, cancellationToken).ConfigureAwait(false)
+            ?? throw new NotFoundException("GameNightEvent", command.GameNightId.ToString());
+
+        if (gameNight.OrganizerId != command.UserId)
+            throw new ForbiddenException("Only the organizer can revoke this game night's share link.");
+
+        gameNight.RevokeShareToken();
+
+        await _repository.UpdateAsync(gameNight, cancellationToken).ConfigureAwait(false);
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/SetGameNightArchivedCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/SetGameNightArchivedCommand.cs
@@ -1,0 +1,9 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.GameManagement.Application.Commands.GameNights;
+
+/// <summary>
+/// Organiser archives (or restores) a finalised game night — Issue #2702.
+/// Archiving requires a Completed night; restoring is always allowed.
+/// </summary>
+internal record SetGameNightArchivedCommand(Guid GameNightId, Guid UserId, bool Archived) : ICommand;

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/SetGameNightArchivedCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/SetGameNightArchivedCommandHandler.cs
@@ -1,0 +1,42 @@
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Infrastructure.Persistence;
+
+namespace Api.BoundedContexts.GameManagement.Application.Commands.GameNights;
+
+/// <summary>
+/// Archives / restores a game night. Organiser-only. The aggregate rejects archiving a
+/// non-Completed night (Conflict).
+/// </summary>
+internal sealed class SetGameNightArchivedCommandHandler : ICommandHandler<SetGameNightArchivedCommand>
+{
+    private readonly IGameNightEventRepository _repository;
+    private readonly IUnitOfWork _unitOfWork;
+
+    public SetGameNightArchivedCommandHandler(
+        IGameNightEventRepository repository, IUnitOfWork unitOfWork)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+    }
+
+    public async Task Handle(SetGameNightArchivedCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var gameNight = await _repository.GetByIdAsync(command.GameNightId, cancellationToken).ConfigureAwait(false)
+            ?? throw new NotFoundException("GameNightEvent", command.GameNightId.ToString());
+
+        if (gameNight.OrganizerId != command.UserId)
+            throw new ForbiddenException("Only the organizer can archive this game night.");
+
+        if (command.Archived)
+            gameNight.Archive();
+        else
+            gameNight.Unarchive();
+
+        await _repository.UpdateAsync(gameNight, cancellationToken).ConfigureAwait(false);
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/GameNights/GameNightSummaryDto.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/GameNights/GameNightSummaryDto.cs
@@ -1,0 +1,45 @@
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+
+namespace Api.BoundedContexts.GameManagement.Application.DTOs.GameNights;
+
+/// <summary>
+/// Post-finalize summary of a game night — Issue #2702: header, computed MVP + KPIs, and a
+/// per-game recap. <c>ShareToken</c> is only populated for the organiser.
+/// </summary>
+public sealed record GameNightSummaryDto(
+    Guid Id,
+    string Title,
+    GameNightStatus Status,
+    DateTimeOffset ScheduledAt,
+    string? Location,
+    bool IsViewerOrganizer,
+    bool IsArchived,
+    bool IsShared,
+    string? ShareToken,
+    GameNightMvpDto? Mvp,
+    GameNightSummaryKpisDto Kpis,
+    IReadOnlyList<GameNightGameRecapDto> Games);
+
+/// <summary>The night's most valuable player: the winner name with the most session wins.</summary>
+public sealed record GameNightMvpDto(string PlayerName, int Wins);
+
+/// <summary>Aggregated night KPIs.</summary>
+public sealed record GameNightSummaryKpisDto(
+    int TotalGames,
+    int CompletedGames,
+    int TotalDurationMinutes,
+    int WinnersCount);
+
+/// <summary>Response for a generated summary share token — Issue #2702.</summary>
+public sealed record GameNightShareLinkDto(string ShareToken);
+
+/// <summary>Per-game recap row.</summary>
+public sealed record GameNightGameRecapDto(
+    Guid SessionId,
+    Guid GameId,
+    string GameTitle,
+    int PlayOrder,
+    GameNightSessionStatus Status,
+    Guid? WinnerId,
+    string? WinnerName,
+    int? DurationMinutes);

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GameNightSummaryMapper.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GameNightSummaryMapper.cs
@@ -1,0 +1,62 @@
+using Api.BoundedContexts.GameManagement.Application.DTOs.GameNights;
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+
+namespace Api.BoundedContexts.GameManagement.Application.Queries.GameNights;
+
+/// <summary>
+/// Projects a <see cref="GameNightEvent"/> aggregate into the <see cref="GameNightSummaryDto"/>
+/// read model — Issue #2702. Shared by the participant summary handler and the public
+/// share-token handler; the winner-name resolver is supplied by the caller (a cross-BC
+/// SessionTracking participant read).
+/// </summary>
+internal static class GameNightSummaryMapper
+{
+    public static GameNightSummaryDto Map(
+        GameNightEvent night,
+        Func<GameNightSession, string?> winnerName,
+        bool isViewerOrganizer)
+    {
+        var games = night.Sessions
+            .OrderBy(s => s.PlayOrder)
+            .Select(s => new GameNightGameRecapDto(
+                s.SessionId, s.GameId, s.GameTitle, s.PlayOrder, s.Status,
+                s.WinnerId, winnerName(s), DurationMinutes(s)))
+            .ToList();
+
+        var kpis = new GameNightSummaryKpisDto(
+            TotalGames: night.Sessions.Count,
+            CompletedGames: night.Sessions.Count(s => s.Status == GameNightSessionStatus.Completed),
+            TotalDurationMinutes: night.Sessions.Sum(s => DurationMinutes(s) ?? 0),
+            WinnersCount: night.Sessions.Count(s => s.WinnerId is not null));
+
+        // MVP = the winner name with the most session wins (ties resolved by first-seen order).
+        var mvp = night.Sessions
+            .Where(s => s.WinnerId is not null)
+            .Select(winnerName)
+            .Where(n => !string.IsNullOrEmpty(n))
+            .GroupBy(n => n!, StringComparer.Ordinal)
+            .Select(g => new GameNightMvpDto(g.Key, g.Count()))
+            .OrderByDescending(m => m.Wins)
+            .FirstOrDefault();
+
+        return new GameNightSummaryDto(
+            night.Id,
+            night.Title,
+            night.Status,
+            night.ScheduledAt,
+            night.Location,
+            isViewerOrganizer,
+            night.IsArchived,
+            night.IsShared,
+            isViewerOrganizer ? night.ShareToken : null,
+            mvp,
+            kpis,
+            games);
+    }
+
+    private static int? DurationMinutes(GameNightSession s) =>
+        s.StartedAt is { } start && s.CompletedAt is { } end && end > start
+            ? (int)Math.Round((end - start).TotalMinutes)
+            : null;
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GameNightSummaryWinnerResolver.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GameNightSummaryWinnerResolver.cs
@@ -1,0 +1,36 @@
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.GameManagement.Application.Queries.GameNights;
+
+/// <summary>
+/// Builds a per-session winner-name resolver from a cross-BC SessionTracking participant read,
+/// scoped to a night's sessions — Issue #2702 (shared by the summary + share-token handlers).
+/// A stray/foreign participant id fails closed to null rather than resolving a wrong name.
+/// </summary>
+internal static class GameNightSummaryWinnerResolver
+{
+    public static async Task<Func<GameNightSession, string?>> BuildAsync(
+        MeepleAiDbContext db, GameNightEvent night, CancellationToken cancellationToken)
+    {
+        var sessionIds = night.Sessions.Select(s => s.SessionId).ToList();
+        var participants = sessionIds.Count == 0
+            ? new List<ParticipantRef>()
+            : await db.SessionTrackingParticipants.AsNoTracking()
+                .Where(p => sessionIds.Contains(p.SessionId))
+                .Select(p => new ParticipantRef(p.Id, p.SessionId, p.DisplayName))
+                .ToListAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+        return session =>
+            session.WinnerId is { } winnerId
+                ? participants
+                    .Where(p => p.SessionId == session.SessionId && p.Id == winnerId)
+                    .Select(p => p.DisplayName)
+                    .FirstOrDefault()
+                : null;
+    }
+
+    private sealed record ParticipantRef(Guid Id, Guid SessionId, string DisplayName);
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GetGameNightSummaryByShareTokenQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GetGameNightSummaryByShareTokenQuery.cs
@@ -1,0 +1,11 @@
+using Api.BoundedContexts.GameManagement.Application.DTOs.GameNights;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.GameManagement.Application.Queries.GameNights;
+
+/// <summary>
+/// Public (anonymous) query for a shared game-night summary by its token — Issue #2702.
+/// Possession of the token is the authorisation; no user identity is consulted.
+/// </summary>
+internal record GetGameNightSummaryByShareTokenQuery(string ShareToken)
+    : IQuery<GameNightSummaryDto>;

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GetGameNightSummaryByShareTokenQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GetGameNightSummaryByShareTokenQueryHandler.cs
@@ -1,0 +1,41 @@
+using Api.BoundedContexts.GameManagement.Application.DTOs.GameNights;
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.Infrastructure;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.GameManagement.Application.Queries.GameNights;
+
+/// <summary>
+/// Handles the anonymous shared-summary read (#2702). The token is a cryptographic secret —
+/// possession authorises the read — so there is no participant/organiser check. A revoked or
+/// unknown token resolves to null → 404. The projected summary never re-exposes the token
+/// (<c>isViewerOrganizer: false</c>).
+/// </summary>
+internal sealed class GetGameNightSummaryByShareTokenQueryHandler
+    : IQueryHandler<GetGameNightSummaryByShareTokenQuery, GameNightSummaryDto>
+{
+    private readonly IGameNightEventRepository _repository;
+    private readonly MeepleAiDbContext _db;
+
+    public GetGameNightSummaryByShareTokenQueryHandler(
+        IGameNightEventRepository repository, MeepleAiDbContext db)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+    }
+
+    public async Task<GameNightSummaryDto> Handle(
+        GetGameNightSummaryByShareTokenQuery query, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var gameNight = await _repository.GetByShareTokenAsync(query.ShareToken, cancellationToken).ConfigureAwait(false)
+            ?? throw new NotFoundException("SharedGameNight", query.ShareToken);
+
+        var winnerName = await GameNightSummaryWinnerResolver
+            .BuildAsync(_db, gameNight, cancellationToken).ConfigureAwait(false);
+
+        return GameNightSummaryMapper.Map(gameNight, winnerName, isViewerOrganizer: false);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GetGameNightSummaryQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GetGameNightSummaryQuery.cs
@@ -1,0 +1,11 @@
+using Api.BoundedContexts.GameManagement.Application.DTOs.GameNights;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.GameManagement.Application.Queries.GameNights;
+
+/// <summary>
+/// Query for a game night's post-finalize summary — Issue #2702. Participant-scoped
+/// (organizer or invited); <see cref="CallerUserId"/> also drives organiser-only fields.
+/// </summary>
+internal record GetGameNightSummaryQuery(Guid GameNightId, Guid CallerUserId)
+    : IQuery<GameNightSummaryDto>;

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GetGameNightSummaryQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GetGameNightSummaryQueryHandler.cs
@@ -1,0 +1,46 @@
+using Api.BoundedContexts.GameManagement.Application.DTOs.GameNights;
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.Infrastructure;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Application.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.GameManagement.Application.Queries.GameNights;
+
+/// <summary>
+/// Handles <see cref="GetGameNightSummaryQuery"/>: participant-scoped read (#2698) that composes
+/// the MVP + KPI + per-game recap via <see cref="GameNightSummaryMapper"/>. Winner names come from
+/// a cross-BC SessionTracking participant read scoped to this night's sessions (parity with the
+/// live handler).
+/// </summary>
+internal sealed class GetGameNightSummaryQueryHandler
+    : IQueryHandler<GetGameNightSummaryQuery, GameNightSummaryDto>
+{
+    private readonly IGameNightEventRepository _repository;
+    private readonly MeepleAiDbContext _db;
+
+    public GetGameNightSummaryQueryHandler(IGameNightEventRepository repository, MeepleAiDbContext db)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+    }
+
+    public async Task<GameNightSummaryDto> Handle(
+        GetGameNightSummaryQuery query, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var gameNight = await _repository.GetByIdAsync(query.GameNightId, cancellationToken).ConfigureAwait(false)
+            ?? throw new NotFoundException("GameNightEvent", query.GameNightId.ToString());
+
+        var isOrganizer = gameNight.OrganizerId == query.CallerUserId;
+        var isParticipant = isOrganizer || gameNight.Rsvps.Any(r => r.UserId == query.CallerUserId);
+        if (!isParticipant)
+            throw new ForbiddenException("Only the organizer or an invited player can view the summary.");
+
+        var winnerName = await GameNightSummaryWinnerResolver
+            .BuildAsync(_db, gameNight, cancellationToken).ConfigureAwait(false);
+
+        return GameNightSummaryMapper.Map(gameNight, winnerName, isOrganizer);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Validators/GameNights/GameNightSummaryShareValidators.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Validators/GameNights/GameNightSummaryShareValidators.cs
@@ -1,0 +1,37 @@
+using Api.BoundedContexts.GameManagement.Application.Commands.GameNights;
+using FluentValidation;
+
+namespace Api.BoundedContexts.GameManagement.Application.Validators.GameNights;
+
+/// <summary>Validator for GenerateGameNightShareTokenCommand — Issue #2702.</summary>
+internal sealed class GenerateGameNightShareTokenCommandValidator
+    : AbstractValidator<GenerateGameNightShareTokenCommand>
+{
+    public GenerateGameNightShareTokenCommandValidator()
+    {
+        RuleFor(x => x.GameNightId).NotEmpty().WithMessage("Game night ID is required");
+        RuleFor(x => x.UserId).NotEmpty().WithMessage("User ID is required");
+    }
+}
+
+/// <summary>Validator for RevokeGameNightShareTokenCommand — Issue #2702.</summary>
+internal sealed class RevokeGameNightShareTokenCommandValidator
+    : AbstractValidator<RevokeGameNightShareTokenCommand>
+{
+    public RevokeGameNightShareTokenCommandValidator()
+    {
+        RuleFor(x => x.GameNightId).NotEmpty().WithMessage("Game night ID is required");
+        RuleFor(x => x.UserId).NotEmpty().WithMessage("User ID is required");
+    }
+}
+
+/// <summary>Validator for SetGameNightArchivedCommand — Issue #2702.</summary>
+internal sealed class SetGameNightArchivedCommandValidator
+    : AbstractValidator<SetGameNightArchivedCommand>
+{
+    public SetGameNightArchivedCommandValidator()
+    {
+        RuleFor(x => x.GameNightId).NotEmpty().WithMessage("Game night ID is required");
+        RuleFor(x => x.UserId).NotEmpty().WithMessage("User ID is required");
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/GameNightEvent/GameNightEvent.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/GameNightEvent/GameNightEvent.cs
@@ -464,6 +464,66 @@ internal sealed class GameNightEvent : AggregateRoot<Guid>
     /// <summary>Restores the resolved tie-break winner from persistence.</summary>
     internal void RestoreVotingWinner(Guid? winnerGameId) => VotingWinnerGameId = winnerGameId;
 
+    // ── Summary share-token + archive — Issue #2702 ──────────────────────────
+
+    /// <summary>URL-safe token that makes the night's summary publicly readable; null when unshared.</summary>
+    public string? ShareToken { get; private set; }
+
+    /// <summary>True while a share token is active.</summary>
+    public bool IsShared { get; private set; }
+
+    /// <summary>True once the organiser has archived a finalised night.</summary>
+    public bool IsArchived { get; private set; }
+
+    /// <summary>
+    /// Generates (or rotates) a URL-safe share token that makes the night's summary publicly
+    /// readable. Possession of the token authorises the anonymous read (#2702).
+    /// </summary>
+    public string GenerateShareToken()
+    {
+        ShareToken = Convert.ToBase64String(Guid.NewGuid().ToByteArray())
+            .Replace('/', '_')
+            .Replace('+', '-')
+            .TrimEnd('=');
+        IsShared = true;
+        UpdatedAt = DateTimeOffset.UtcNow;
+        return ShareToken;
+    }
+
+    /// <summary>Revokes the share token, disabling anonymous access to the summary.</summary>
+    public void RevokeShareToken()
+    {
+        ShareToken = null;
+        IsShared = false;
+        UpdatedAt = DateTimeOffset.UtcNow;
+    }
+
+    /// <summary>Archives a finalised (Completed) night. Idempotent.</summary>
+    public void Archive()
+    {
+        ThrowIfCorrupted();
+        if (Status != GameNightStatus.Completed)
+            throw new ConflictException("Only a completed game night can be archived");
+        IsArchived = true;
+        UpdatedAt = DateTimeOffset.UtcNow;
+    }
+
+    /// <summary>Restores an archived night to the active summary list. Idempotent.</summary>
+    public void Unarchive()
+    {
+        ThrowIfCorrupted();
+        IsArchived = false;
+        UpdatedAt = DateTimeOffset.UtcNow;
+    }
+
+    /// <summary>Restores the share-token + archive state from persistence.</summary>
+    internal void RestoreShareState(string? shareToken, bool isShared, bool isArchived)
+    {
+        ShareToken = shareToken;
+        IsShared = isShared;
+        IsArchived = isArchived;
+    }
+
     /// <summary>
     /// Marks that the 24-hour reminder has been sent.
     /// </summary>

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/GameNightEvent/IGameNightEventRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/GameNightEvent/IGameNightEventRepository.cs
@@ -61,4 +61,10 @@ internal interface IGameNightEventRepository : IRepository<GameNightEvent, Guid>
 
     /// <summary>Persists the organiser's resolved tie-break winner on the event row.</summary>
     Task SetVotingWinnerAsync(Guid eventId, Guid? winnerGameId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Finds a shared game night by its summary share token — Issue #2702. Returns null when the
+    /// token is unknown or sharing was revoked. Possession of the token is the authorisation.
+    /// </summary>
+    Task<GameNightEvent?> GetByShareTokenAsync(string shareToken, CancellationToken cancellationToken = default);
 }

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Persistence/GameNightEventRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Persistence/GameNightEventRepository.cs
@@ -199,6 +199,22 @@ internal class GameNightEventRepository : RepositoryBase, IGameNightEventReposit
         return entity != null ? MapToDomain(entity) : null;
     }
 
+    public async Task<GameNightEvent?> GetByShareTokenAsync(
+        string shareToken, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(shareToken);
+
+        var entity = await DbContext.GameNightEvents
+            .AsNoTracking()
+            .Include(e => e.Rsvps)
+            .Include(e => e.Sessions)
+            .Include(e => e.Votes)
+            .FirstOrDefaultAsync(e => e.ShareToken == shareToken && e.IsShared, cancellationToken)
+            .ConfigureAwait(false);
+
+        return entity != null ? MapToDomain(entity) : null;
+    }
+
     public async Task AddVoteAsync(GameNightVote vote, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(vote);
@@ -259,6 +275,9 @@ internal class GameNightEventRepository : RepositoryBase, IGameNightEventReposit
             CreatedAt = domain.CreatedAt,
             UpdatedAt = domain.UpdatedAt,
             VotingWinnerGameId = domain.VotingWinnerGameId,
+            ShareToken = domain.ShareToken,
+            IsShared = domain.IsShared,
+            IsArchived = domain.IsArchived,
             Xmin = domain.Xmin
         };
 
@@ -407,6 +426,7 @@ internal class GameNightEventRepository : RepositoryBase, IGameNightEventReposit
             .ToList();
         evt.RestoreVotes(votes);
         evt.RestoreVotingWinner(entity.VotingWinnerGameId);
+        evt.RestoreShareState(entity.ShareToken, entity.IsShared, entity.IsArchived);
 
         // Clear domain events from reconstruction
         evt.ClearDomainEvents();

--- a/apps/api/src/Api/Infrastructure/Entities/GameManagement/GameNightEventEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/GameManagement/GameNightEventEntity.cs
@@ -85,6 +85,17 @@ public class GameNightEventEntity
 
     public List<GameNightVoteEntity> Votes { get; set; } = [];
 
+    // Summary share-token + archive — Issue #2702
+    [Column("share_token")]
+    [MaxLength(50)]
+    public string? ShareToken { get; set; }
+
+    [Column("is_shared")]
+    public bool IsShared { get; set; }
+
+    [Column("is_archived")]
+    public bool IsArchived { get; set; }
+
     // Optimistic concurrency via PostgreSQL's xmin system column (Issue #2703, ADR-060).
     // Server-owned: Postgres assigns xmin = transaction-id-of-last-write per row.
     // The repository round-trips this value so the detached Update emits a

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/GameManagement/GameNightEventEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/GameManagement/GameNightEventEntityConfiguration.cs
@@ -37,6 +37,15 @@ internal class GameNightEventEntityConfiguration : IEntityTypeConfiguration<Game
         // Candidate voting (approval model) — Issue #2700
         builder.Property(e => e.VotingWinnerGameId).HasColumnName("voting_winner_game_id");
 
+        // Summary share-token + archive — Issue #2702
+        builder.Property(e => e.ShareToken).HasColumnName("share_token").HasMaxLength(50);
+        builder.Property(e => e.IsShared).HasColumnName("is_shared");
+        builder.Property(e => e.IsArchived).HasColumnName("is_archived");
+        builder.HasIndex(e => e.ShareToken)
+            .HasDatabaseName("IX_game_night_events_share_token")
+            .IsUnique()
+            .HasFilter("share_token IS NOT NULL");
+
         // Optimistic concurrency via PostgreSQL's xmin system column (Issue #2703, ADR-060).
         // Server-owned, collision-safe (xmin = unique transaction id per row UPDATE).
         // Mirrors game_night_playlists (#2306) — no bytea row_version, no trigger.

--- a/apps/api/src/Api/Infrastructure/Migrations/20260706162637_AddGameNightSummaryShareArchive.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260706162637_AddGameNightSummaryShareArchive.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260706162637_AddGameNightSummaryShareArchive")]
+    partial class AddGameNightSummaryShareArchive
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260706162637_AddGameNightSummaryShareArchive.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260706162637_AddGameNightSummaryShareArchive.cs
@@ -1,0 +1,62 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddGameNightSummaryShareArchive : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "is_archived",
+                table: "game_night_events",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "is_shared",
+                table: "game_night_events",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AddColumn<string>(
+                name: "share_token",
+                table: "game_night_events",
+                type: "character varying(50)",
+                maxLength: 50,
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_game_night_events_share_token",
+                table: "game_night_events",
+                column: "share_token",
+                unique: true,
+                filter: "share_token IS NOT NULL");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_game_night_events_share_token",
+                table: "game_night_events");
+
+            migrationBuilder.DropColumn(
+                name: "is_archived",
+                table: "game_night_events");
+
+            migrationBuilder.DropColumn(
+                name: "is_shared",
+                table: "game_night_events");
+
+            migrationBuilder.DropColumn(
+                name: "share_token",
+                table: "game_night_events");
+        }
+    }
+}

--- a/apps/api/src/Api/Routing/GameNightEndpoints.cs
+++ b/apps/api/src/Api/Routing/GameNightEndpoints.cs
@@ -299,6 +299,59 @@ internal static class GameNightEndpoints
             .WithSummary("Get the candidate-vote tally")
             .WithDescription("Returns per-candidate approval counts, leader(s), tie flag, resolved winner, and the caller's own approvals. Participant-scoped (organizer or RSVP'd player).");
 
+        // ── Summary + share-token + archive — Issue #2702 ───────────────────
+
+        gameNights.MapGet("/{id:guid}/summary", HandleGetGameNightSummary)
+            .RequireAuthenticatedUser()
+            .Produces<GameNightSummaryDto>(200)
+            .Produces(401)
+            .Produces(403)
+            .Produces(404)
+            .WithName("GetGameNightSummary")
+            .WithSummary("Get the game night summary")
+            .WithDescription("Returns the post-finalize summary (MVP + KPIs + per-game recap). Participant-scoped (organizer or RSVP'd player). The share token is only included for the organizer.");
+
+        gameNights.MapPost("/{id:guid}/share-token", HandleGenerateGameNightShareToken)
+            .RequireAuthenticatedUser()
+            .Produces<GameNightShareLinkDto>(201)
+            .Produces(401)
+            .Produces(403)
+            .Produces(404)
+            .WithName("GenerateGameNightShareToken")
+            .WithSummary("Share the game night summary")
+            .WithDescription("Organizer-only. Generates (or rotates) a public share token for the summary; returns the token.");
+
+        gameNights.MapDelete("/{id:guid}/share-token", HandleRevokeGameNightShareToken)
+            .RequireAuthenticatedUser()
+            .Produces(204)
+            .Produces(401)
+            .Produces(403)
+            .Produces(404)
+            .WithName("RevokeGameNightShareToken")
+            .WithSummary("Stop sharing the game night summary")
+            .WithDescription("Organizer-only. Revokes the public share token.");
+
+        gameNights.MapPost("/{id:guid}/archive", HandleSetGameNightArchived)
+            .RequireAuthenticatedUser()
+            .Produces(204)
+            .Produces(401)
+            .Produces(403)
+            .Produces(404)
+            .Produces(409)
+            .WithName("SetGameNightArchived")
+            .WithSummary("Archive or restore a game night")
+            .WithDescription("Organizer-only. Archives a completed night (409 if not completed) or restores an archived one.");
+
+        gameNights.MapGet("/shared/{token}/summary", HandleGetSharedGameNightSummary)
+            .AllowAnonymous()
+            .RequireRateLimiting("GameNightTokenRead")
+            .Produces<GameNightSummaryDto>(200)
+            .Produces(404)
+            .Produces(429)
+            .WithName("GetSharedGameNightSummary")
+            .WithSummary("Get a shared game night summary by token")
+            .WithDescription("Public endpoint to read a shared summary by its opaque token. Returns 404 when the token is unknown or sharing was revoked. Rate-limited per IP.");
+
         return group;
     }
 
@@ -454,6 +507,72 @@ internal static class GameNightEndpoints
         var userId = httpContext.User.GetUserId();
         var result = await mediator
             .Send(new GetGameNightVoteTallyQuery(id, userId), cancellationToken)
+            .ConfigureAwait(false);
+        return Results.Ok(result);
+    }
+
+    // ── Summary + share-token + archive — Issue #2702 ───────────────────────
+
+    private static async Task<IResult> HandleGetGameNightSummary(
+        Guid id,
+        [FromServices] IMediator mediator,
+        HttpContext httpContext,
+        CancellationToken cancellationToken)
+    {
+        var userId = httpContext.User.GetUserId();
+        var result = await mediator
+            .Send(new GetGameNightSummaryQuery(id, userId), cancellationToken)
+            .ConfigureAwait(false);
+        return Results.Ok(result);
+    }
+
+    private static async Task<IResult> HandleGenerateGameNightShareToken(
+        Guid id,
+        [FromServices] IMediator mediator,
+        HttpContext httpContext,
+        CancellationToken cancellationToken)
+    {
+        var userId = httpContext.User.GetUserId();
+        var token = await mediator
+            .Send(new GenerateGameNightShareTokenCommand(id, userId), cancellationToken)
+            .ConfigureAwait(false);
+        return Results.Created($"/api/v1/game-nights/shared/{token}/summary", new GameNightShareLinkDto(token));
+    }
+
+    private static async Task<IResult> HandleRevokeGameNightShareToken(
+        Guid id,
+        [FromServices] IMediator mediator,
+        HttpContext httpContext,
+        CancellationToken cancellationToken)
+    {
+        var userId = httpContext.User.GetUserId();
+        await mediator
+            .Send(new RevokeGameNightShareTokenCommand(id, userId), cancellationToken)
+            .ConfigureAwait(false);
+        return Results.NoContent();
+    }
+
+    private static async Task<IResult> HandleSetGameNightArchived(
+        Guid id,
+        [FromBody] SetGameNightArchivedRequest request,
+        [FromServices] IMediator mediator,
+        HttpContext httpContext,
+        CancellationToken cancellationToken)
+    {
+        var userId = httpContext.User.GetUserId();
+        await mediator
+            .Send(new SetGameNightArchivedCommand(id, userId, request.Archived), cancellationToken)
+            .ConfigureAwait(false);
+        return Results.NoContent();
+    }
+
+    private static async Task<IResult> HandleGetSharedGameNightSummary(
+        string token,
+        [FromServices] IMediator mediator,
+        CancellationToken cancellationToken)
+    {
+        var result = await mediator
+            .Send(new GetGameNightSummaryByShareTokenQuery(token), cancellationToken)
             .ConfigureAwait(false);
         return Results.Ok(result);
     }
@@ -768,6 +887,7 @@ internal static class GameNightEndpoints
     // Game Night Experience v2 request records
     private sealed record CastVoteRequest(Guid CandidateGameId);
     private sealed record ResolveVotingTieRequest(Guid WinningCandidateGameId);
+    private sealed record SetGameNightArchivedRequest(bool Archived);
     private sealed record StartGameNightSessionRequest(Guid GameId, string GameTitle);
     private sealed record AttachGamebookCampaignRequest(Guid CampaignId);
     private sealed record CompleteGameNightSessionRequest(Guid? WinnerId);

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/GameNights/GameNightSummaryMapperTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/GameNights/GameNightSummaryMapperTests.cs
@@ -1,0 +1,96 @@
+using Api.BoundedContexts.GameManagement.Application.Queries.GameNights;
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Application.GameNights;
+
+/// <summary>
+/// Unit tests for <see cref="GameNightSummaryMapper"/> — the MVP/KPI/recap aggregation (#2702).
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "GameManagement")]
+[Trait("Feature", "GameNightSummary")]
+public class GameNightSummaryMapperTests
+{
+    private static readonly DateTimeOffset Start = new(2026, 8, 1, 21, 0, 0, TimeSpan.Zero);
+
+    private static GameNightSession CompletedSession(
+        Guid eventId, int order, Guid gameId, string title, Guid? winnerId, int durationMinutes)
+    {
+        return GameNightSession.Reconstitute(
+            id: Guid.NewGuid(),
+            gameNightEventId: eventId,
+            sessionId: Guid.NewGuid(),
+            gameId: gameId,
+            gameTitle: title,
+            playOrder: order,
+            status: GameNightSessionStatus.Completed,
+            winnerId: winnerId,
+            startedAt: Start,
+            completedAt: Start.AddMinutes(durationMinutes));
+    }
+
+    [Fact]
+    public void Map_ComputesMvpKpisAndRecap()
+    {
+        var evt = GameNightEvent.Create(Guid.NewGuid(), "Serata", Start.AddDays(-1));
+        var davide = Guid.NewGuid();
+        var marco = Guid.NewGuid();
+        evt.RestoreSessions(new[]
+        {
+            CompletedSession(evt.Id, 1, Guid.NewGuid(), "Brass", davide, 120),
+            CompletedSession(evt.Id, 2, Guid.NewGuid(), "Spirit", davide, 60),
+            CompletedSession(evt.Id, 3, Guid.NewGuid(), "Azul", marco, 30),
+        });
+        var names = new Dictionary<Guid, string> { [davide] = "Davide", [marco] = "Marco" };
+        string? Resolver(GameNightSession s) => s.WinnerId is { } w ? names.GetValueOrDefault(w) : null;
+
+        var dto = GameNightSummaryMapper.Map(evt, Resolver, isViewerOrganizer: true);
+
+        dto.Mvp.Should().NotBeNull();
+        dto.Mvp!.PlayerName.Should().Be("Davide");
+        dto.Mvp.Wins.Should().Be(2);
+        dto.Kpis.TotalGames.Should().Be(3);
+        dto.Kpis.CompletedGames.Should().Be(3);
+        dto.Kpis.WinnersCount.Should().Be(3);
+        dto.Kpis.TotalDurationMinutes.Should().Be(210);
+        dto.Games.Should().HaveCount(3);
+        dto.Games[0].GameTitle.Should().Be("Brass");
+        dto.Games[0].WinnerName.Should().Be("Davide");
+        dto.Games[0].DurationMinutes.Should().Be(120);
+    }
+
+    [Fact]
+    public void Map_NoWinners_YieldsNullMvpAndZeroWinnersCount()
+    {
+        var evt = GameNightEvent.Create(Guid.NewGuid(), "Serata", Start.AddDays(-1));
+        evt.RestoreSessions(new[]
+        {
+            CompletedSession(evt.Id, 1, Guid.NewGuid(), "Brass", winnerId: null, 90),
+        });
+
+        var dto = GameNightSummaryMapper.Map(evt, _ => null, isViewerOrganizer: true);
+
+        dto.Mvp.Should().BeNull();
+        dto.Kpis.WinnersCount.Should().Be(0);
+        dto.Kpis.TotalDurationMinutes.Should().Be(90);
+    }
+
+    [Fact]
+    public void Map_NonOrganizer_OmitsShareTokenButKeepsSharedFlag()
+    {
+        var evt = GameNightEvent.Create(Guid.NewGuid(), "Serata", Start.AddDays(-1));
+        evt.Publish(new List<Guid>());
+        evt.Complete();
+        evt.GenerateShareToken();
+
+        var organizerView = GameNightSummaryMapper.Map(evt, _ => null, isViewerOrganizer: true);
+        var guestView = GameNightSummaryMapper.Map(evt, _ => null, isViewerOrganizer: false);
+
+        organizerView.ShareToken.Should().NotBeNull();
+        guestView.ShareToken.Should().BeNull();
+        guestView.IsShared.Should().BeTrue();
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/Entities/GameNightEventSummaryShareTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/Entities/GameNightEventSummaryShareTests.cs
@@ -1,0 +1,93 @@
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.Middleware.Exceptions;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Domain.Entities;
+
+/// <summary>
+/// Unit tests for the summary share-token + archive domain behaviour on
+/// <see cref="GameNightEvent"/> — Issue #2702.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "GameManagement")]
+[Trait("Feature", "GameNightSummary")]
+public class GameNightEventSummaryShareTests
+{
+    private static GameNightEvent CompletedNight()
+    {
+        var night = GameNightEvent.Create(Guid.NewGuid(), "Serata", DateTimeOffset.UtcNow.AddDays(1));
+        night.Publish(new List<Guid>());
+        night.Complete();
+        return night;
+    }
+
+    [Fact]
+    public void GenerateShareToken_SetsUrlSafeTokenAndSharedFlag()
+    {
+        var night = CompletedNight();
+
+        var token = night.GenerateShareToken();
+
+        token.Should().NotBeNullOrWhiteSpace();
+        token.Should().NotContain("/").And.NotContain("+").And.NotEndWith("=");
+        night.ShareToken.Should().Be(token);
+        night.IsShared.Should().BeTrue();
+    }
+
+    [Fact]
+    public void GenerateShareToken_IsIdempotentlyRotatable()
+    {
+        var night = CompletedNight();
+
+        var first = night.GenerateShareToken();
+        var second = night.GenerateShareToken();
+
+        second.Should().NotBe(first);
+        night.ShareToken.Should().Be(second);
+    }
+
+    [Fact]
+    public void RevokeShareToken_ClearsTokenAndSharedFlag()
+    {
+        var night = CompletedNight();
+        night.GenerateShareToken();
+
+        night.RevokeShareToken();
+
+        night.ShareToken.Should().BeNull();
+        night.IsShared.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Archive_OnCompletedNight_SetsArchivedFlag()
+    {
+        var night = CompletedNight();
+
+        night.Archive();
+
+        night.IsArchived.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Archive_OnNonCompletedNight_ThrowsConflict()
+    {
+        var night = GameNightEvent.Create(Guid.NewGuid(), "Serata", DateTimeOffset.UtcNow.AddDays(1));
+        night.Publish(new List<Guid>()); // Published, not Completed
+
+        var act = () => night.Archive();
+
+        act.Should().Throw<ConflictException>();
+    }
+
+    [Fact]
+    public void Unarchive_ClearsArchivedFlag()
+    {
+        var night = CompletedNight();
+        night.Archive();
+
+        night.Unarchive();
+
+        night.IsArchived.Should().BeFalse();
+    }
+}

--- a/apps/api/tests/Api.Tests/Integration/GameManagement/GameNightSummaryCommandTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/GameManagement/GameNightSummaryCommandTests.cs
@@ -1,0 +1,196 @@
+using System.Text.Json;
+using Api.BoundedContexts.GameManagement.Application.Commands.GameNights;
+using Api.BoundedContexts.GameManagement.Application.DTOs.GameNights;
+using Api.BoundedContexts.GameManagement.Application.Queries.GameNights;
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.BoundedContexts.GameManagement.Infrastructure.Persistence;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.GameManagement;
+using Api.Middleware.Exceptions;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.Integration.GameManagement;
+
+/// <summary>
+/// Handler-driven integration tests for the game-night summary + share-token + archive flow
+/// through the MediatR pipeline — Issue #2702 (summary aggregation, IDOR, share-token, archive).
+/// </summary>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "GameManagement")]
+[Trait("Issue", "2702")]
+public sealed class GameNightSummaryCommandTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private string _databaseName = null!;
+    private string _connectionString = null!;
+    private MeepleAiDbContext _dbContext = null!;
+    private IServiceProvider? _serviceProvider;
+
+    public GameNightSummaryCommandTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    private IServiceProvider Sp => _serviceProvider ?? throw new InvalidOperationException("SP not initialized");
+    private static CancellationToken Ct => TestContext.Current.CancellationToken;
+
+    public async ValueTask InitializeAsync()
+    {
+        _databaseName = $"gamenight_summary_{Guid.NewGuid():N}";
+        _connectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+        _dbContext = _fixture.CreateDbContext(_connectionString);
+        await _dbContext.Database.MigrateAsync(Ct);
+
+        var services = IntegrationServiceCollectionBuilder.CreateBase(_connectionString);
+        services.AddScoped<IGameNightEventRepository, GameNightEventRepository>();
+        _serviceProvider = services.BuildServiceProvider();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _dbContext.DisposeAsync();
+        if (_serviceProvider is IAsyncDisposable d) await d.DisposeAsync();
+        await _fixture.DropIsolatedDatabaseAsync(_databaseName);
+    }
+
+    private async Task<(Guid EventId, Guid Organizer, Guid Participant)> SeedAsync(string status = "Completed")
+    {
+        var eventId = Guid.NewGuid();
+        var organizer = Guid.NewGuid();
+        var participant = Guid.NewGuid();
+        var gameId = Guid.NewGuid();
+
+        _dbContext.GameNightEvents.Add(new GameNightEventEntity
+        {
+            Id = eventId,
+            OrganizerId = organizer,
+            Title = "Serata riepilogo",
+            ScheduledAt = DateTimeOffset.UtcNow.AddDays(-1),
+            GameIdsJson = JsonSerializer.Serialize(new List<Guid> { gameId }),
+            Status = status,
+            CreatedAt = DateTimeOffset.UtcNow,
+            Rsvps =
+            {
+                new GameNightRsvpEntity
+                {
+                    Id = Guid.NewGuid(), EventId = eventId, UserId = participant,
+                    Status = "Accepted", CreatedAt = DateTimeOffset.UtcNow
+                }
+            },
+            Sessions =
+            {
+                new GameNightSessionEntity
+                {
+                    Id = Guid.NewGuid(), GameNightEventId = eventId, SessionId = Guid.NewGuid(),
+                    GameId = gameId, GameTitle = "Brass", PlayOrder = 1, Status = "Completed",
+                    StartedAt = DateTimeOffset.UtcNow.AddHours(-3),
+                    CompletedAt = DateTimeOffset.UtcNow.AddHours(-1)
+                }
+            }
+        });
+        await _dbContext.SaveChangesAsync(Ct);
+        return (eventId, organizer, participant);
+    }
+
+    private async Task SendAsync(IRequest request)
+    {
+        using var scope = Sp.CreateScope();
+        await scope.ServiceProvider.GetRequiredService<IMediator>().Send(request, Ct);
+    }
+
+    private async Task<TResult> SendAsync<TResult>(IRequest<TResult> request)
+    {
+        using var scope = Sp.CreateScope();
+        return await scope.ServiceProvider.GetRequiredService<IMediator>().Send(request, Ct);
+    }
+
+    [Fact(DisplayName = "Participant reads the summary with KPIs")]
+    public async Task Summary_ByParticipant_ReturnsKpis()
+    {
+        var (eventId, _, participant) = await SeedAsync();
+
+        var summary = await SendAsync(new GetGameNightSummaryQuery(eventId, participant));
+
+        summary.Id.Should().Be(eventId);
+        summary.Kpis.TotalGames.Should().Be(1);
+        summary.Kpis.CompletedGames.Should().Be(1);
+        summary.IsViewerOrganizer.Should().BeFalse();
+        summary.ShareToken.Should().BeNull(); // organiser-only field
+    }
+
+    [Fact(DisplayName = "IDOR: a non-participant cannot read the summary (403)")]
+    public async Task Summary_ByNonParticipant_Throws403()
+    {
+        var (eventId, _, _) = await SeedAsync();
+
+        var act = async () => await SendAsync(new GetGameNightSummaryQuery(eventId, Guid.NewGuid()));
+
+        await act.Should().ThrowAsync<ForbiddenException>();
+    }
+
+    [Fact(DisplayName = "Organizer generates a share token; the shared summary is publicly readable")]
+    public async Task ShareToken_GeneratedByOrganizer_EnablesPublicRead()
+    {
+        var (eventId, organizer, _) = await SeedAsync();
+
+        var token = await SendAsync(new GenerateGameNightShareTokenCommand(eventId, organizer));
+        token.Should().NotBeNullOrWhiteSpace();
+
+        var shared = await SendAsync(new GetGameNightSummaryByShareTokenQuery(token));
+        shared.Id.Should().Be(eventId);
+        shared.ShareToken.Should().BeNull(); // the public view never re-exposes the token
+
+        // After revoke the token no longer resolves.
+        await SendAsync(new RevokeGameNightShareTokenCommand(eventId, organizer));
+        var act = async () => await SendAsync(new GetGameNightSummaryByShareTokenQuery(token));
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+
+    [Fact(DisplayName = "IDOR: a non-organizer cannot generate a share token (403)")]
+    public async Task ShareToken_ByNonOrganizer_Throws403()
+    {
+        var (eventId, _, participant) = await SeedAsync();
+
+        var act = async () => await SendAsync(new GenerateGameNightShareTokenCommand(eventId, participant));
+
+        await act.Should().ThrowAsync<ForbiddenException>();
+    }
+
+    [Fact(DisplayName = "Organizer archives a completed night; summary reflects it")]
+    public async Task Archive_CompletedNight_ReflectedInSummary()
+    {
+        var (eventId, organizer, _) = await SeedAsync();
+
+        await SendAsync(new SetGameNightArchivedCommand(eventId, organizer, Archived: true));
+
+        var summary = await SendAsync(new GetGameNightSummaryQuery(eventId, organizer));
+        summary.IsArchived.Should().BeTrue();
+    }
+
+    [Fact(DisplayName = "Archiving a non-completed night returns 409")]
+    public async Task Archive_NonCompletedNight_Throws409()
+    {
+        var (eventId, organizer, _) = await SeedAsync(status: "Published");
+
+        var act = async () => await SendAsync(new SetGameNightArchivedCommand(eventId, organizer, Archived: true));
+
+        await act.Should().ThrowAsync<ConflictException>();
+    }
+
+    [Fact(DisplayName = "IDOR: a non-organizer cannot archive (403)")]
+    public async Task Archive_ByNonOrganizer_Throws403()
+    {
+        var (eventId, _, participant) = await SeedAsync();
+
+        var act = async () => await SendAsync(new SetGameNightArchivedCommand(eventId, participant, Archived: true));
+
+        await act.Should().ThrowAsync<ForbiddenException>();
+    }
+}

--- a/apps/web/src/app/(authenticated)/game-nights/[id]/summary/_components/NightSummaryClientView.tsx
+++ b/apps/web/src/app/(authenticated)/game-nights/[id]/summary/_components/NightSummaryClientView.tsx
@@ -4,45 +4,14 @@ import { useCallback, useState } from 'react';
 
 import { useRouter } from 'next/navigation';
 
-import {
-  NightSummaryView,
-  type NightSummaryMVP,
-  type NightSummaryNight,
-} from '@/components/features/game-nights/summary';
-import type { PerGameRecapGame } from '@/components/features/game-nights/summary';
+import { NightSummaryView } from '@/components/features/game-nights/summary';
+import { toNightSummaryViewModel } from '@/components/features/game-nights/summary/night-summary-adapter';
 import {
   useGameNightSummary,
   useGenerateGameNightShareToken,
   useSetGameNightArchived,
 } from '@/hooks/queries/useGameNights';
 import { useTranslation } from '@/hooks/useTranslation';
-
-// ─── DTO → view-model adapter ───────────────────────────────────────────────
-// Deferred (need new subsystems, #2702 follow-up): per-game top-3 leaderboard scores,
-// per-session event counts, and the photo gallery. Those render empty for now.
-
-function formatDuration(minutes: number): string {
-  const h = Math.floor(minutes / 60);
-  const m = minutes % 60;
-  return h > 0 ? `${h}h ${m}m` : `${m}m`;
-}
-
-function initialsOf(name: string): string {
-  return name
-    .split(/\s+/)
-    .map(w => w.charAt(0))
-    .join('')
-    .slice(0, 2)
-    .toUpperCase();
-}
-
-function hueOf(name: string): number {
-  let hue = 0;
-  for (let i = 0; i < name.length; i++) {
-    hue = (hue * 31 + name.charCodeAt(i)) % 360;
-  }
-  return hue;
-}
 
 export interface NightSummaryClientViewProps {
   readonly nightId: string;
@@ -64,7 +33,8 @@ export function NightSummaryClientView({ nightId }: NightSummaryClientViewProps)
     generateShare.mutate(nightId, {
       onSuccess: ({ shareToken }) => {
         if (typeof window !== 'undefined' && navigator.clipboard) {
-          const url = `${window.location.origin}/game-nights/${nightId}/summary?share=${shareToken}`;
+          // Public share route resolves the night from the token alone.
+          const url = `${window.location.origin}/game-nights/shared/${shareToken}`;
           void navigator.clipboard.writeText(url).catch(() => undefined);
         }
         setShareSuccess({ visible: true, subline: t('gameNightDetail.summary.shareCopied') });
@@ -102,56 +72,7 @@ export function NightSummaryClientView({ nightId }: NightSummaryClientViewProps)
     );
   }
 
-  const dto = summaryQuery.data;
-  const durationUnknown = t('gameNightDetail.summary.durationUnknown');
-
-  const startTime = new Intl.DateTimeFormat(locale, { hour: '2-digit', minute: '2-digit' }).format(
-    new Date(dto.scheduledAt)
-  );
-  const night: NightSummaryNight = {
-    title: dto.title,
-    dateLine: new Intl.DateTimeFormat(locale, {
-      weekday: 'long',
-      day: 'numeric',
-      month: 'long',
-      year: 'numeric',
-    }).format(new Date(dto.scheduledAt)),
-    ...(dto.location ? { location: dto.location } : {}),
-    startedAt: startTime,
-    endedAt: '',
-    duration: formatDuration(dto.kpis.totalDurationMinutes),
-    nightCode: `#${dto.id.slice(0, 8).toUpperCase()}`,
-  };
-
-  const mvp: NightSummaryMVP | null = dto.mvp
-    ? {
-        id: dto.mvp.playerName,
-        name: dto.mvp.playerName,
-        initials: initialsOf(dto.mvp.playerName),
-        color: hueOf(dto.mvp.playerName),
-        achievements: t('gameNightDetail.summary.mvpWins', { wins: dto.mvp.wins }),
-      }
-    : null;
-
-  const games: PerGameRecapGame[] = dto.games.map(g => ({
-    id: g.sessionId,
-    sessionId: g.sessionId,
-    title: g.gameTitle,
-    order: g.playOrder,
-    duration: g.durationMinutes != null ? formatDuration(g.durationMinutes) : durationUnknown,
-    eventsCount: 0,
-    ...(g.winnerName
-      ? {
-          winner: {
-            id: g.winnerName,
-            name: g.winnerName,
-            initials: initialsOf(g.winnerName),
-            color: hueOf(g.winnerName),
-            score: 0,
-          },
-        }
-      : {}),
-  }));
+  const { night, mvp, games } = toNightSummaryViewModel(summaryQuery.data, { locale, t });
 
   return (
     <NightSummaryView
@@ -159,7 +80,7 @@ export function NightSummaryClientView({ nightId }: NightSummaryClientViewProps)
       mvp={mvp}
       games={games}
       eventsCount={0}
-      archived={dto.isArchived}
+      archived={summaryQuery.data.isArchived}
       shareSuccess={shareSuccess}
       onShare={handleShare}
       onArchive={handleArchive}

--- a/apps/web/src/app/(authenticated)/game-nights/[id]/summary/_components/NightSummaryClientView.tsx
+++ b/apps/web/src/app/(authenticated)/game-nights/[id]/summary/_components/NightSummaryClientView.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useState } from 'react';
 
 import { useRouter } from 'next/navigation';
 
@@ -8,156 +8,158 @@ import {
   NightSummaryView,
   type NightSummaryMVP,
   type NightSummaryNight,
-  type NightSummaryPhoto,
 } from '@/components/features/game-nights/summary';
 import type { PerGameRecapGame } from '@/components/features/game-nights/summary';
+import {
+  useGameNightSummary,
+  useGenerateGameNightShareToken,
+  useSetGameNightArchived,
+} from '@/hooks/queries/useGameNights';
+import { useTranslation } from '@/hooks/useTranslation';
 
-// ─── Fixture data (TODO: replace with backend hook `useGameNightSummary(id)`)
-// Continuità con mockup M mergiato nel PR #1250 — issue #487
-// ─────────────────────────────────────────────────────────────────────────
+// ─── DTO → view-model adapter ───────────────────────────────────────────────
+// Deferred (need new subsystems, #2702 follow-up): per-game top-3 leaderboard scores,
+// per-session event counts, and the photo gallery. Those render empty for now.
 
-const NIGHT: NightSummaryNight = {
-  title: 'Sabato boardgame con i Padovani',
-  dateLine: 'sabato 17 maggio 2026',
-  location: 'Casa Marco · Padova',
-  startedAt: '21:00',
-  endedAt: '03:15',
-  duration: '6h 15m',
-  nightCode: '#GN-042',
-};
+function formatDuration(minutes: number): string {
+  const h = Math.floor(minutes / 60);
+  const m = minutes % 60;
+  return h > 0 ? `${h}h ${m}m` : `${m}m`;
+}
 
-const MVP: NightSummaryMVP = {
-  id: 'p-davide',
-  name: 'Davide',
-  initials: 'DC',
-  color: 200,
-  achievements: '1 vittoria · 11 eventi diary · top scorer Brass',
-};
+function initialsOf(name: string): string {
+  return name
+    .split(/\s+/)
+    .map(w => w.charAt(0))
+    .join('')
+    .slice(0, 2)
+    .toUpperCase();
+}
 
-const GAMES: ReadonlyArray<PerGameRecapGame> = [
-  {
-    id: 'gs-brass-1',
-    sessionId: 's-brass-may17',
-    title: 'Brass: Birmingham',
-    emoji: '🏭',
-    cover: ['hsl(220 35% 28%)', 'hsl(28 60% 38%)'],
-    order: 1,
-    duration: '2h 45m',
-    eventsCount: 11,
-    winner: { id: 'p-davide', name: 'Davide', initials: 'DC', color: 200, score: 178 },
-    topScores: [
-      { id: 'p-marco', name: 'Marco', initials: 'MR', color: 262, score: 142 },
-      { id: 'p-giulia', name: 'Giulia', initials: 'GM', color: 10, score: 128 },
-    ],
-  },
-  {
-    id: 'gs-spirit-1',
-    sessionId: 's-spirit-may17',
-    title: 'Spirit Island',
-    emoji: '🌋',
-    cover: ['hsl(210 50% 30%)', 'hsl(150 50% 38%)'],
-    order: 2,
-    duration: '1h 50m',
-    eventsCount: 9,
-    coopMode: true,
-    coopOutcome: 'team coop vinto · round 5/6 · adversary England 1',
-  },
-  {
-    id: 'gs-wing-1',
-    sessionId: 's-wing-may17',
-    title: 'Wingspan',
-    emoji: '🦜',
-    cover: ['hsl(85 40% 45%)', 'hsl(35 60% 50%)'],
-    order: 3,
-    duration: '1h 25m',
-    eventsCount: 8,
-    winner: { id: 'p-giulia', name: 'Giulia', initials: 'GM', color: 10, score: 92 },
-    topScores: [
-      { id: 'p-sara', name: 'Sara', initials: 'ST', color: 320, score: 88 },
-      { id: 'p-aaron', name: 'Aaron', initials: 'AK', color: 140, score: 81 },
-    ],
-  },
-];
-
-const PHOTOS: ReadonlyArray<NightSummaryPhoto> = [
-  { id: 'ph-1', label: 'Setup Brass', gradient: ['hsl(220 35% 30%)', 'hsl(28 60% 40%)'] },
-  { id: 'ph-2', label: 'Davide vince', gradient: ['hsl(350 70% 55%)', 'hsl(28 60% 50%)'] },
-  { id: 'ph-3', label: 'Tabellone Spirit', gradient: ['hsl(210 50% 30%)', 'hsl(150 50% 40%)'] },
-  { id: 'ph-4', label: 'Foto di gruppo', gradient: ['hsl(262 50% 50%)', 'hsl(320 60% 55%)'] },
-  { id: 'ph-5', label: 'Tableau Wingspan', gradient: ['hsl(85 50% 50%)', 'hsl(35 60% 55%)'] },
-  { id: 'ph-6', label: 'Brindisi finale', gradient: ['hsl(38 80% 55%)', 'hsl(10 70% 50%)'] },
-];
-
-// ─── View component ─────────────────────────────────────────────────────
+function hueOf(name: string): number {
+  let hue = 0;
+  for (let i = 0; i < name.length; i++) {
+    hue = (hue * 31 + name.charCodeAt(i)) % 360;
+  }
+  return hue;
+}
 
 export interface NightSummaryClientViewProps {
   readonly nightId: string;
 }
 
-export function NightSummaryClientView({ nightId: _nightId }: NightSummaryClientViewProps) {
+export function NightSummaryClientView({ nightId }: NightSummaryClientViewProps) {
   const router = useRouter();
-  const [archived, setArchived] = useState(false);
-  const [shareSuccess, setShareSuccess] = useState<{
-    visible: boolean;
-    subline?: string;
-  }>({ visible: false });
-  const toastTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const { t, locale } = useTranslation();
 
-  // Cleanup pending toast timer on unmount to avoid setState on unmounted component
-  useEffect(() => {
-    return () => {
-      if (toastTimerRef.current) {
-        clearTimeout(toastTimerRef.current);
-      }
-    };
-  }, []);
+  const summaryQuery = useGameNightSummary(nightId);
+  const generateShare = useGenerateGameNightShareToken();
+  const setArchived = useSetGameNightArchived();
+
+  const [shareSuccess, setShareSuccess] = useState<{ visible: boolean; subline?: string }>({
+    visible: false,
+  });
 
   const handleShare = useCallback(() => {
-    const url = `meepleai.app/s/${_nightId.slice(0, 12)}`;
-    if (typeof navigator !== 'undefined' && navigator.clipboard) {
-      void navigator.clipboard.writeText(`https://${url}`).catch(() => undefined);
-    }
-    setShareSuccess({
-      visible: true,
-      subline: `${url} · sparisce in 3s`,
+    generateShare.mutate(nightId, {
+      onSuccess: ({ shareToken }) => {
+        if (typeof window !== 'undefined' && navigator.clipboard) {
+          const url = `${window.location.origin}/game-nights/${nightId}/summary?share=${shareToken}`;
+          void navigator.clipboard.writeText(url).catch(() => undefined);
+        }
+        setShareSuccess({ visible: true, subline: t('gameNightDetail.summary.shareCopied') });
+      },
     });
-    // Replace any previous pending timer so rapid re-shares don't race
-    if (toastTimerRef.current) {
-      clearTimeout(toastTimerRef.current);
-    }
-    toastTimerRef.current = setTimeout(() => {
-      setShareSuccess({ visible: false });
-      toastTimerRef.current = null;
-    }, 3000);
-  }, [_nightId]);
+  }, [generateShare, nightId, t]);
 
-  const handleArchive = useCallback(() => {
-    setArchived(true);
-  }, []);
-
-  const handleUnarchive = useCallback(() => {
-    setArchived(false);
-  }, []);
-
-  const handleGoToList = useCallback(() => {
-    router.push('/game-nights');
-  }, [router]);
-
+  const handleArchive = useCallback(
+    () => setArchived.mutate({ id: nightId, archived: true }),
+    [setArchived, nightId]
+  );
+  const handleUnarchive = useCallback(
+    () => setArchived.mutate({ id: nightId, archived: false }),
+    [setArchived, nightId]
+  );
+  const handleGoToList = useCallback(() => router.push('/game-nights'), [router]);
   const handleJumpToSession = useCallback(
-    (sessionId: string) => {
-      router.push(`/sessions/${sessionId}`);
-    },
+    (sessionId: string) => router.push(`/sessions/${sessionId}`),
     [router]
   );
 
+  if (summaryQuery.isLoading) {
+    return (
+      <div data-testid="summary-loading" className="p-8 text-center text-muted-foreground">
+        {t('gameNightDetail.summary.loading')}
+      </div>
+    );
+  }
+
+  if (summaryQuery.isError || !summaryQuery.data) {
+    return (
+      <div data-testid="summary-error" className="p-8 text-center text-muted-foreground">
+        {t('gameNightDetail.summary.error')}
+      </div>
+    );
+  }
+
+  const dto = summaryQuery.data;
+  const durationUnknown = t('gameNightDetail.summary.durationUnknown');
+
+  const startTime = new Intl.DateTimeFormat(locale, { hour: '2-digit', minute: '2-digit' }).format(
+    new Date(dto.scheduledAt)
+  );
+  const night: NightSummaryNight = {
+    title: dto.title,
+    dateLine: new Intl.DateTimeFormat(locale, {
+      weekday: 'long',
+      day: 'numeric',
+      month: 'long',
+      year: 'numeric',
+    }).format(new Date(dto.scheduledAt)),
+    ...(dto.location ? { location: dto.location } : {}),
+    startedAt: startTime,
+    endedAt: '',
+    duration: formatDuration(dto.kpis.totalDurationMinutes),
+    nightCode: `#${dto.id.slice(0, 8).toUpperCase()}`,
+  };
+
+  const mvp: NightSummaryMVP | null = dto.mvp
+    ? {
+        id: dto.mvp.playerName,
+        name: dto.mvp.playerName,
+        initials: initialsOf(dto.mvp.playerName),
+        color: hueOf(dto.mvp.playerName),
+        achievements: t('gameNightDetail.summary.mvpWins', { wins: dto.mvp.wins }),
+      }
+    : null;
+
+  const games: PerGameRecapGame[] = dto.games.map(g => ({
+    id: g.sessionId,
+    sessionId: g.sessionId,
+    title: g.gameTitle,
+    order: g.playOrder,
+    duration: g.durationMinutes != null ? formatDuration(g.durationMinutes) : durationUnknown,
+    eventsCount: 0,
+    ...(g.winnerName
+      ? {
+          winner: {
+            id: g.winnerName,
+            name: g.winnerName,
+            initials: initialsOf(g.winnerName),
+            color: hueOf(g.winnerName),
+            score: 0,
+          },
+        }
+      : {}),
+  }));
+
   return (
     <NightSummaryView
-      night={NIGHT}
-      mvp={MVP}
-      games={GAMES}
-      eventsCount={28}
-      photos={PHOTOS}
-      archived={archived}
+      night={night}
+      mvp={mvp}
+      games={games}
+      eventsCount={0}
+      archived={dto.isArchived}
       shareSuccess={shareSuccess}
       onShare={handleShare}
       onArchive={handleArchive}

--- a/apps/web/src/app/(authenticated)/game-nights/[id]/summary/_components/__tests__/NightSummaryClientView.test.tsx
+++ b/apps/web/src/app/(authenticated)/game-nights/[id]/summary/_components/__tests__/NightSummaryClientView.test.tsx
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { NightSummaryClientView } from '../NightSummaryClientView';
+
+const summaryMock = vi.fn();
+const generateMock = vi.fn();
+const archiveMock = vi.fn();
+
+vi.mock('@/hooks/queries/useGameNights', () => ({
+  useGameNightSummary: () => summaryMock(),
+  useGenerateGameNightShareToken: () => ({ mutate: generateMock }),
+  useSetGameNightArchived: () => ({ mutate: archiveMock }),
+}));
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => ({ t: (key: string) => key, locale: 'it-IT' }),
+}));
+
+vi.mock('next/navigation', () => ({ useRouter: () => ({ push: vi.fn() }) }));
+
+// Stub the heavy presentational view; capture the adapted props.
+vi.mock('@/components/features/game-nights/summary', () => ({
+  NightSummaryView: (props: {
+    night: { title: string };
+    mvp?: { name: string } | null;
+    games: unknown[];
+    archived?: boolean;
+    onShare?: () => void;
+    onArchive?: () => void;
+  }) => (
+    <div
+      data-testid="night-summary-view"
+      data-title={props.night.title}
+      data-mvp={props.mvp?.name ?? ''}
+      data-games={props.games.length}
+      data-archived={String(props.archived)}
+    >
+      <button type="button" data-testid="share-btn" onClick={props.onShare}>
+        share
+      </button>
+      <button type="button" data-testid="archive-btn" onClick={props.onArchive}>
+        archive
+      </button>
+    </div>
+  ),
+}));
+
+const dto = {
+  id: '11111111-1111-1111-1111-111111111111',
+  title: 'Serata Test',
+  status: 'Completed',
+  scheduledAt: '2026-08-01T20:00:00.000Z',
+  location: 'Casa',
+  isViewerOrganizer: true,
+  isArchived: false,
+  isShared: false,
+  shareToken: null as string | null,
+  mvp: { playerName: 'Davide', wins: 2 },
+  kpis: { totalGames: 2, completedGames: 2, totalDurationMinutes: 150, winnersCount: 2 },
+  games: [
+    {
+      sessionId: 's1',
+      gameId: 'g1',
+      gameTitle: 'Brass',
+      playOrder: 1,
+      status: 'Completed',
+      winnerId: null,
+      winnerName: 'Davide',
+      durationMinutes: 90,
+    },
+  ],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  summaryMock.mockReturnValue({ data: dto, isLoading: false, isError: false });
+});
+
+describe('NightSummaryClientView', () => {
+  it('renders the loading state', () => {
+    summaryMock.mockReturnValue({ data: undefined, isLoading: true, isError: false });
+    render(<NightSummaryClientView nightId="gn-1" />);
+    expect(screen.getByTestId('summary-loading')).toBeInTheDocument();
+  });
+
+  it('renders the error state', () => {
+    summaryMock.mockReturnValue({ data: undefined, isLoading: false, isError: true });
+    render(<NightSummaryClientView nightId="gn-1" />);
+    expect(screen.getByTestId('summary-error')).toBeInTheDocument();
+  });
+
+  it('adapts the summary DTO into the view props', () => {
+    render(<NightSummaryClientView nightId="gn-1" />);
+    const view = screen.getByTestId('night-summary-view');
+    expect(view).toHaveAttribute('data-title', 'Serata Test');
+    expect(view).toHaveAttribute('data-mvp', 'Davide');
+    expect(view).toHaveAttribute('data-games', '1');
+    expect(view).toHaveAttribute('data-archived', 'false');
+  });
+
+  it('generates a share token when sharing', async () => {
+    const user = userEvent.setup();
+    render(<NightSummaryClientView nightId="gn-1" />);
+    await user.click(screen.getByTestId('share-btn'));
+    expect(generateMock).toHaveBeenCalledWith('gn-1', expect.any(Object));
+  });
+
+  it('archives the night when archiving', async () => {
+    const user = userEvent.setup();
+    render(<NightSummaryClientView nightId="gn-1" />);
+    await user.click(screen.getByTestId('archive-btn'));
+    expect(archiveMock).toHaveBeenCalledWith({ id: 'gn-1', archived: true });
+  });
+});

--- a/apps/web/src/app/(public)/game-nights/shared/[token]/page.tsx
+++ b/apps/web/src/app/(public)/game-nights/shared/[token]/page.tsx
@@ -1,0 +1,20 @@
+/**
+ * Public Shared Game Night Summary Page (#2702).
+ *
+ * Public route for viewing a shared game-night summary via its share-link token.
+ * No authentication required — access is controlled by the token in the URL.
+ *
+ * Route: /game-nights/shared/{token}
+ */
+'use client';
+
+import { useParams } from 'next/navigation';
+
+import { SharedGameNightSummaryView } from '@/components/features/game-nights/summary/SharedGameNightSummaryView';
+
+export default function SharedGameNightSummaryPage() {
+  const params = useParams();
+  const token = typeof params?.token === 'string' ? params.token : '';
+
+  return <SharedGameNightSummaryView token={token} />;
+}

--- a/apps/web/src/components/features/game-nights/summary/SharedGameNightSummaryView.tsx
+++ b/apps/web/src/components/features/game-nights/summary/SharedGameNightSummaryView.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { useSharedGameNightSummary } from '@/hooks/queries/useGameNights';
+import { useTranslation } from '@/hooks/useTranslation';
+
+import { toNightSummaryViewModel } from './night-summary-adapter';
+import { NightSummaryView } from './NightSummaryView';
+
+export interface SharedGameNightSummaryViewProps {
+  readonly token: string;
+}
+
+/**
+ * Public, read-only game-night summary reached via a share token (#2702). Possession of the
+ * token authorises the read; no share/archive/navigation CTAs are exposed.
+ */
+export function SharedGameNightSummaryView({ token }: SharedGameNightSummaryViewProps) {
+  const { t, locale } = useTranslation();
+  const query = useSharedGameNightSummary(token);
+
+  if (query.isLoading) {
+    return (
+      <div data-testid="shared-summary-loading" className="p-8 text-center text-muted-foreground">
+        {t('gameNightDetail.summary.loading')}
+      </div>
+    );
+  }
+
+  if (query.isError || !query.data) {
+    return (
+      <div data-testid="shared-summary-error" className="p-8 text-center text-muted-foreground">
+        {t('gameNightDetail.summary.error')}
+      </div>
+    );
+  }
+
+  const { night, mvp, games } = toNightSummaryViewModel(query.data, { locale, t });
+
+  return (
+    <NightSummaryView
+      night={night}
+      mvp={mvp}
+      games={games}
+      eventsCount={0}
+      archived={query.data.isArchived}
+    />
+  );
+}

--- a/apps/web/src/components/features/game-nights/summary/__tests__/SharedGameNightSummaryView.test.tsx
+++ b/apps/web/src/components/features/game-nights/summary/__tests__/SharedGameNightSummaryView.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { SharedGameNightSummaryView } from '../SharedGameNightSummaryView';
+
+const sharedMock = vi.fn();
+
+vi.mock('@/hooks/queries/useGameNights', () => ({
+  useSharedGameNightSummary: () => sharedMock(),
+}));
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => ({ t: (key: string) => key, locale: 'it-IT' }),
+}));
+
+vi.mock('../NightSummaryView', () => ({
+  NightSummaryView: (props: {
+    night: { title: string };
+    onShare?: () => void;
+    onArchive?: () => void;
+  }) => (
+    <div
+      data-testid="night-summary-view"
+      data-title={props.night.title}
+      data-has-share={String(Boolean(props.onShare))}
+      data-has-archive={String(Boolean(props.onArchive))}
+    />
+  ),
+}));
+
+const dto = {
+  id: '11111111-1111-1111-1111-111111111111',
+  title: 'Serata Condivisa',
+  status: 'Completed',
+  scheduledAt: '2026-08-01T20:00:00.000Z',
+  location: null as string | null,
+  isViewerOrganizer: false,
+  isArchived: false,
+  isShared: true,
+  shareToken: null as string | null,
+  mvp: null as { playerName: string; wins: number } | null,
+  kpis: { totalGames: 1, completedGames: 1, totalDurationMinutes: 60, winnersCount: 0 },
+  games: [],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  sharedMock.mockReturnValue({ data: dto, isLoading: false, isError: false });
+});
+
+describe('SharedGameNightSummaryView', () => {
+  it('renders loading', () => {
+    sharedMock.mockReturnValue({ data: undefined, isLoading: true, isError: false });
+    render(<SharedGameNightSummaryView token="tok" />);
+    expect(screen.getByTestId('shared-summary-loading')).toBeInTheDocument();
+  });
+
+  it('renders error / not-found', () => {
+    sharedMock.mockReturnValue({ data: undefined, isLoading: false, isError: true });
+    render(<SharedGameNightSummaryView token="tok" />);
+    expect(screen.getByTestId('shared-summary-error')).toBeInTheDocument();
+  });
+
+  it('renders the summary read-only (no share/archive CTAs)', () => {
+    render(<SharedGameNightSummaryView token="tok" />);
+    const view = screen.getByTestId('night-summary-view');
+    expect(view).toHaveAttribute('data-title', 'Serata Condivisa');
+    expect(view).toHaveAttribute('data-has-share', 'false');
+    expect(view).toHaveAttribute('data-has-archive', 'false');
+  });
+});

--- a/apps/web/src/components/features/game-nights/summary/night-summary-adapter.ts
+++ b/apps/web/src/components/features/game-nights/summary/night-summary-adapter.ts
@@ -1,0 +1,102 @@
+import type { GameNightSummaryDto } from '@/lib/api/schemas/game-nights.schemas';
+
+import type { NightSummaryMVP, NightSummaryNight } from './NightSummaryView';
+import type { PerGameRecapGame } from './PerGameRecapRow';
+
+// Deferred (need new subsystems, #2702 follow-up): per-game top-3 leaderboard scores,
+// per-session event counts, and the photo gallery. Those render empty for now.
+
+export interface NightSummaryViewModel {
+  readonly night: NightSummaryNight;
+  readonly mvp: NightSummaryMVP | null;
+  readonly games: PerGameRecapGame[];
+}
+
+export interface NightSummaryAdapterOptions {
+  readonly locale: string;
+  readonly t: (key: string, vars?: Record<string, unknown>) => string;
+}
+
+function formatDuration(minutes: number): string {
+  const h = Math.floor(minutes / 60);
+  const m = minutes % 60;
+  return h > 0 ? `${h}h ${m}m` : `${m}m`;
+}
+
+function initialsOf(name: string): string {
+  return name
+    .split(/\s+/)
+    .map(w => w.charAt(0))
+    .join('')
+    .slice(0, 2)
+    .toUpperCase();
+}
+
+function hueOf(name: string): number {
+  let hue = 0;
+  for (let i = 0; i < name.length; i++) {
+    hue = (hue * 31 + name.charCodeAt(i)) % 360;
+  }
+  return hue;
+}
+
+/**
+ * Maps the backend {@link GameNightSummaryDto} into the props the presentational
+ * {@link NightSummaryView} expects (#2702). Shared by the authenticated and public views.
+ */
+export function toNightSummaryViewModel(
+  dto: GameNightSummaryDto,
+  { locale, t }: NightSummaryAdapterOptions
+): NightSummaryViewModel {
+  const scheduled = new Date(dto.scheduledAt);
+
+  const night: NightSummaryNight = {
+    title: dto.title,
+    dateLine: new Intl.DateTimeFormat(locale, {
+      weekday: 'long',
+      day: 'numeric',
+      month: 'long',
+      year: 'numeric',
+    }).format(scheduled),
+    ...(dto.location ? { location: dto.location } : {}),
+    startedAt: new Intl.DateTimeFormat(locale, { hour: '2-digit', minute: '2-digit' }).format(
+      scheduled
+    ),
+    endedAt: '',
+    duration: formatDuration(dto.kpis.totalDurationMinutes),
+    nightCode: `#${dto.id.slice(0, 8).toUpperCase()}`,
+  };
+
+  const mvp: NightSummaryMVP | null = dto.mvp
+    ? {
+        id: dto.mvp.playerName,
+        name: dto.mvp.playerName,
+        initials: initialsOf(dto.mvp.playerName),
+        color: hueOf(dto.mvp.playerName),
+        achievements: t('gameNightDetail.summary.mvpWins', { wins: dto.mvp.wins }),
+      }
+    : null;
+
+  const durationUnknown = t('gameNightDetail.summary.durationUnknown');
+  const games: PerGameRecapGame[] = dto.games.map(g => ({
+    id: g.sessionId,
+    sessionId: g.sessionId,
+    title: g.gameTitle,
+    order: g.playOrder,
+    duration: g.durationMinutes != null ? formatDuration(g.durationMinutes) : durationUnknown,
+    eventsCount: 0,
+    ...(g.winnerName
+      ? {
+          winner: {
+            id: g.winnerName,
+            name: g.winnerName,
+            initials: initialsOf(g.winnerName),
+            color: hueOf(g.winnerName),
+            score: 0,
+          },
+        }
+      : {}),
+  }));
+
+  return { night, mvp, games };
+}

--- a/apps/web/src/hooks/queries/useGameNights.ts
+++ b/apps/web/src/hooks/queries/useGameNights.ts
@@ -186,6 +186,15 @@ export function useGameNightSummary(id: string, options: { enabled?: boolean } =
   });
 }
 
+export function useSharedGameNightSummary(token: string) {
+  return useQuery({
+    queryKey: [...gameNightKeys.all, 'shared', token] as const,
+    queryFn: () => api.gameNights.getSharedSummary(token),
+    enabled: !!token,
+    retry: false,
+  });
+}
+
 export function useGenerateGameNightShareToken() {
   const queryClient = useQueryClient();
   return useMutation({

--- a/apps/web/src/hooks/queries/useGameNights.ts
+++ b/apps/web/src/hooks/queries/useGameNights.ts
@@ -22,6 +22,7 @@ export const gameNightKeys = {
   detail: (id: string) => [...gameNightKeys.all, id] as const,
   rsvps: (id: string) => [...gameNightKeys.all, id, 'rsvps'] as const,
   voteTally: (id: string) => [...gameNightKeys.all, id, 'vote-tally'] as const,
+  summary: (id: string) => [...gameNightKeys.all, id, 'summary'] as const,
 };
 
 export function useUpcomingGameNights(
@@ -170,6 +171,38 @@ export function useResolveGameNightVotingTie() {
       api.gameNights.resolveVotingTie(id, winningCandidateGameId),
     onSuccess: (_data, { id }) => {
       queryClient.invalidateQueries({ queryKey: gameNightKeys.voteTally(id) });
+    },
+  });
+}
+
+// ── Summary + share-token + archive — Issue #2702 ────────────────────────
+
+export function useGameNightSummary(id: string, options: { enabled?: boolean } = {}) {
+  const { enabled = true } = options;
+  return useQuery({
+    queryKey: gameNightKeys.summary(id),
+    queryFn: () => api.gameNights.getSummary(id),
+    enabled: enabled && !!id,
+  });
+}
+
+export function useGenerateGameNightShareToken() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => api.gameNights.generateShareToken(id),
+    onSuccess: (_data, id) => {
+      queryClient.invalidateQueries({ queryKey: gameNightKeys.summary(id) });
+    },
+  });
+}
+
+export function useSetGameNightArchived() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, archived }: { id: string; archived: boolean }) =>
+      api.gameNights.setArchived(id, archived),
+    onSuccess: (_data, { id }) => {
+      queryClient.invalidateQueries({ queryKey: gameNightKeys.summary(id) });
     },
   });
 }

--- a/apps/web/src/lib/api/clients/gameNightsClient.ts
+++ b/apps/web/src/lib/api/clients/gameNightsClient.ts
@@ -11,6 +11,8 @@ import {
   GameNightDtoSchema,
   GameNightLiveDtoSchema,
   GameNightRsvpDtoSchema,
+  GameNightShareLinkDtoSchema,
+  GameNightSummaryDtoSchema,
   GameNightVoteTallyDtoSchema,
   RegularDtoSchema,
   StartGameNightSessionResultSchema,
@@ -19,6 +21,8 @@ import {
   type GameNightDto,
   type GameNightLiveDto,
   type GameNightRsvpDto,
+  type GameNightShareLinkDto,
+  type GameNightSummaryDto,
   type GameNightVoteTallyDto,
   type RegularDto,
   type RsvpStatus,
@@ -57,6 +61,12 @@ export interface GameNightsClient {
   castVote(gameNightId: string, candidateGameId: string): Promise<void>;
   retractVote(gameNightId: string, candidateGameId: string): Promise<void>;
   resolveVotingTie(gameNightId: string, winningCandidateGameId: string): Promise<void>;
+  // Issue #2702 — summary + share-token + archive
+  getSummary(gameNightId: string): Promise<GameNightSummaryDto>;
+  getSharedSummary(token: string): Promise<GameNightSummaryDto>;
+  generateShareToken(gameNightId: string): Promise<GameNightShareLinkDto>;
+  revokeShareToken(gameNightId: string): Promise<void>;
+  setArchived(gameNightId: string, archived: boolean): Promise<void>;
 }
 
 export function createGameNightsClient({
@@ -179,6 +189,36 @@ export function createGameNightsClient({
       await httpClient.post(`/api/v1/game-nights/${gameNightId}/votes/resolve-tie`, {
         winningCandidateGameId,
       });
+    },
+
+    async getSummary(gameNightId) {
+      const data = await httpClient.get<GameNightSummaryDto>(
+        `/api/v1/game-nights/${gameNightId}/summary`
+      );
+      return GameNightSummaryDtoSchema.parse(data);
+    },
+
+    async getSharedSummary(token) {
+      const data = await httpClient.get<GameNightSummaryDto>(
+        `/api/v1/game-nights/shared/${token}/summary`
+      );
+      return GameNightSummaryDtoSchema.parse(data);
+    },
+
+    async generateShareToken(gameNightId) {
+      const data = await httpClient.post<GameNightShareLinkDto>(
+        `/api/v1/game-nights/${gameNightId}/share-token`,
+        {}
+      );
+      return GameNightShareLinkDtoSchema.parse(data);
+    },
+
+    async revokeShareToken(gameNightId) {
+      await httpClient.delete(`/api/v1/game-nights/${gameNightId}/share-token`);
+    },
+
+    async setArchived(gameNightId, archived) {
+      await httpClient.post(`/api/v1/game-nights/${gameNightId}/archive`, { archived });
     },
   };
 }

--- a/apps/web/src/lib/api/schemas/game-nights.schemas.ts
+++ b/apps/web/src/lib/api/schemas/game-nights.schemas.ts
@@ -234,3 +234,52 @@ export const GameNightVoteTallyDtoSchema = z.object({
   candidates: z.array(GameNightCandidateTallyDtoSchema),
 });
 export type GameNightVoteTallyDto = z.infer<typeof GameNightVoteTallyDtoSchema>;
+
+// ──────────────────────────────────────────────────────────────────────
+// Issue #2702 — summary (MVP/KPI) + share-token + archive
+// ──────────────────────────────────────────────────────────────────────
+
+export const GameNightMvpDtoSchema = z.object({
+  playerName: z.string(),
+  wins: z.number().int().nonnegative(),
+});
+export type GameNightMvpDto = z.infer<typeof GameNightMvpDtoSchema>;
+
+export const GameNightSummaryKpisDtoSchema = z.object({
+  totalGames: z.number().int().nonnegative(),
+  completedGames: z.number().int().nonnegative(),
+  totalDurationMinutes: z.number().int().nonnegative(),
+  winnersCount: z.number().int().nonnegative(),
+});
+export type GameNightSummaryKpisDto = z.infer<typeof GameNightSummaryKpisDtoSchema>;
+
+export const GameNightGameRecapDtoSchema = z.object({
+  sessionId: z.string().uuid(),
+  gameId: z.string().uuid(),
+  gameTitle: z.string(),
+  playOrder: z.number().int(),
+  status: z.string(),
+  winnerId: z.string().uuid().nullable(),
+  winnerName: z.string().nullable(),
+  durationMinutes: z.number().int().nullable(),
+});
+export type GameNightGameRecapDto = z.infer<typeof GameNightGameRecapDtoSchema>;
+
+export const GameNightSummaryDtoSchema = z.object({
+  id: z.string().uuid(),
+  title: z.string(),
+  status: z.string(),
+  scheduledAt: z.string(),
+  location: z.string().nullable(),
+  isViewerOrganizer: z.boolean(),
+  isArchived: z.boolean(),
+  isShared: z.boolean(),
+  shareToken: z.string().nullable(),
+  mvp: GameNightMvpDtoSchema.nullable(),
+  kpis: GameNightSummaryKpisDtoSchema,
+  games: z.array(GameNightGameRecapDtoSchema),
+});
+export type GameNightSummaryDto = z.infer<typeof GameNightSummaryDtoSchema>;
+
+export const GameNightShareLinkDtoSchema = z.object({ shareToken: z.string() });
+export type GameNightShareLinkDto = z.infer<typeof GameNightShareLinkDtoSchema>;

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -3866,6 +3866,14 @@
         "body": "Choose the winning game among the tied candidates.",
         "resolve": "Choose {title}"
       }
+    },
+    "summary": {
+      "loading": "Loading summary…",
+      "error": "Could not load the game night summary.",
+      "mvpWins": "{wins, plural, =1 {1 win} other {# wins}}",
+      "durationUnknown": "—",
+      "shareCopied": "Link copied to clipboard",
+      "shareError": "Could not generate the share link."
     }
   },
   "gameNightsIndex": {

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -3919,6 +3919,14 @@
         "body": "Scegli il gioco vincitore tra i candidati in parità.",
         "resolve": "Scegli {title}"
       }
+    },
+    "summary": {
+      "loading": "Caricamento riepilogo…",
+      "error": "Impossibile caricare il riepilogo della serata.",
+      "mvpWins": "{wins, plural, =1 {1 vittoria} other {# vittorie}}",
+      "durationUnknown": "—",
+      "shareCopied": "Link copiato negli appunti",
+      "shareError": "Impossibile generare il link di condivisione."
     }
   },
   "gameNightsIndex": {


### PR DESCRIPTION
> Closes #2702 · Umbrella #2697 (Tier 3, final gap) · Spec §4a US-INT-3f · Mockup sp7-game-night-summary · depends on #2699 (finalize)

## What

The post-finalize game-night **summary** with aggregated MVP + KPIs, a public **share-token**, and **archive**. _Scope confirmed with the maintainer: full DoD in one PR; per-game top-3 scores + photo gallery deferred (need SessionTracking scoring + a game-night photo subsystem that don't exist yet)._

## Backend

- **Summary** — `GetGameNightSummaryQuery` + handler (participant-scoped IDOR per #2698) composes MVP + KPIs + per-game recap via `GameNightSummaryMapper`. Winner names resolve through a cross-BC SessionTracking participant read (`GameNightSummaryWinnerResolver`, parity with the live handler). MVP = the winner name with the most session wins; KPIs = total/completed games, total duration (session timestamps), winners count. `ShareToken` is projected **only** for the organiser.
- **Share-token** (mirrors PlayRecord #2437) — aggregate `ShareToken`/`IsShared` + `GenerateShareToken()`/`RevokeShareToken()`; Generate/Revoke commands (organiser-only, #2349 ownership guard); the public `GetGameNightSummaryByShareTokenQuery` is **AllowAnonymous** — possession of the token is the authorisation, a revoked/unknown token → 404, and the public projection never re-exposes the token. `share_token` (unique filtered index) + `is_shared` columns.
- **Archive** — aggregate `IsArchived` + `Archive()` (Completed-only → **409** otherwise) / `Unarchive()`; `SetGameNightArchivedCommand` (organiser-only). `is_archived` column.
- **Endpoints**: `GET /{id}/summary`, `POST`/`DELETE /{id}/share-token`, `POST /{id}/archive`, `GET /shared/{token}/summary` (anonymous, rate-limited).

## Frontend

- Client + zod schema + hooks (`useGameNightSummary` + generate-share / set-archived mutations).
- `NightSummaryClientView` — the existing Screen M view was **fixture-only**; now fetches via `useGameNightSummary(id)`, renders loading / error, and adapts the DTO → the view props (title, date, MVP, KPIs→duration, per-game recap with winner + duration). Share CTA generates a token + copies the link; archive CTA calls the command. i18n `gameNightDetail.summary` (it + en).

## 🔴 IDOR / DEC-A5

- Non-participant cannot read the summary (**403**); non-organiser cannot generate a share token or archive (**403**) — handler-driven tests. Share-token read validates the target via the token→night binding (#2349): only the organiser can mint a token, and it resolves to exactly that night.
- States: default / empty (no sessions → zero KPIs) / loading / error.

## Tests (TDD RED→GREEN)

- **Backend**: 6 domain (share-token/archive guards) + 3 mapper (MVP/KPI/recap, organiser-only token) + 7 handler-driven integration (summary read, IDOR 403, share generate/public-read/revoke-404, non-organiser 403, archive completed/409/403). **432 GameNight unit tests pass**, 0 regressions.
- **Frontend**: 5 `NightSummaryClientView` tests (states, DTO→props adapter, share, archive). Typecheck + lint clean; **52 game-night FE + 50 summary component tests pass**.

## Definition of Done

- [x] Summary aggregation (MVP + KPIs + per-game recap), participant-scoped
- [x] Signed share-token (generate/revoke + anonymous read) with ownership validation
- [x] Archive (flag + command)
- [x] FE summary page wired + share/archive CTAs
- [x] Cross-tenant (IDOR) tests

## Follow-ups

Per-game top-3 leaderboard scores (SessionTracking scoring integration), per-session event counts, photo gallery, and a dedicated public share page (`?share=token`) — deferred; the CTAs + BE token are in place. FE CI red is documented baseline (sessionsClient / gameNightsClient.live / PhotosTabContent), unrelated to this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)