### PR TITLE
fix(frontend): #2715 risana CI frontend baseline (session/session-live)

### DIFF
--- a/apps/web/__tests__/session-live-chat-agent-g3-axe.test.tsx
+++ b/apps/web/__tests__/session-live-chat-agent-g3-axe.test.tsx
@@ -34,6 +34,7 @@ const labels = {
     visibilityShared: 'Shared',
     emptyMessage: 'No messages yet.',
     newMessagesToastAriaLabel: 'New messages — click to scroll',
+    attachAriaLabel: 'Attach image',
   },
 };
 

--- a/apps/web/src/components/features/session-live/PhotosTabContent.tsx
+++ b/apps/web/src/components/features/session-live/PhotosTabContent.tsx
@@ -63,18 +63,18 @@ function PhotoCard({
       {/* Hover overlay */}
       <div className="absolute inset-0 bg-foreground/0 group-hover:bg-foreground/30 transition-colors" />
       {/* Timestamp badge */}
-      <div className="absolute bottom-0 inset-x-0 bg-gradient-to-t from-black/60 to-transparent p-2">
-        <p className="text-white text-xs font-mono">{timeLabel}</p>
+      <div className="absolute bottom-0 inset-x-0 bg-gradient-to-t from-black/60 to-transparent p-2 text-white">
+        <p className="text-xs font-mono">{timeLabel}</p>
       </div>
       {/* Delete button */}
       <button
         type="button"
-        className="absolute top-1.5 right-1.5 h-7 w-7 rounded-full bg-foreground/40 hover:bg-destructive/80 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-all"
+        className="absolute top-1.5 right-1.5 h-7 w-7 rounded-full bg-foreground/40 hover:bg-destructive/80 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-all text-white"
         onClick={() => onDelete(photo.id)}
         aria-label={deleteAriaLabel}
         data-testid={`delete-photo-${photo.id}`}
       >
-        <Trash2 className="h-3.5 w-3.5 text-white" />
+        <Trash2 className="h-3.5 w-3.5" />
       </button>
     </div>
   );

--- a/apps/web/src/lib/api/__tests__/sessionsClient.crud.test.ts
+++ b/apps/web/src/lib/api/__tests__/sessionsClient.crud.test.ts
@@ -1,7 +1,10 @@
 /**
  * SessionsClient CRUD and Lifecycle Tests
  *
- * Tests for: getById, getHistory, start, pause, resume, end, complete, abandon
+ * Tests for: getById, getHistory, pause, resume, end, complete, abandon
+ *
+ * NB: `start` (POST /sessions) was removed in #2587 (dead funnel). The orphaned
+ * start tests were deleted in #2715; do not re-add them.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { createSessionsClient } from '../clients/sessionsClient';
@@ -106,52 +109,6 @@ describe('sessionsClient CRUD and lifecycle', () => {
 
       expect(result.sessions).toEqual([]);
       expect(result.total).toBe(0);
-    });
-  });
-
-  describe('start', () => {
-    it('should start a new session', async () => {
-      const mockSession = {
-        id: 'new-session',
-        gameId: 'game-1',
-        status: 'active',
-        players: [{ playerName: 'Player 1', playerOrder: 1 }],
-      };
-
-      vi.mocked(mockHttpClient.post).mockResolvedValueOnce(mockSession);
-
-      const result = await client.start({
-        gameId: 'game-1',
-        players: [{ playerName: 'Player 1', playerOrder: 1 }],
-      });
-
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        '/api/v1/sessions',
-        {
-          gameId: 'game-1',
-          players: [{ playerName: 'Player 1', playerOrder: 1 }],
-        },
-        expect.any(Object)
-      );
-      expect(result).toEqual(mockSession);
-    });
-
-    it('should start session with notes', async () => {
-      const mockSession = { id: 'session-with-notes', notes: 'Test notes' };
-
-      vi.mocked(mockHttpClient.post).mockResolvedValueOnce(mockSession);
-
-      await client.start({
-        gameId: 'game-1',
-        players: [{ playerName: 'Player 1', playerOrder: 1 }],
-        notes: 'Test notes',
-      });
-
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        '/api/v1/sessions',
-        expect.objectContaining({ notes: 'Test notes' }),
-        expect.any(Object)
-      );
     });
   });
 

--- a/apps/web/src/lib/api/clients/__tests__/gameNightsClient.live.test.ts
+++ b/apps/web/src/lib/api/clients/__tests__/gameNightsClient.live.test.ts
@@ -36,12 +36,14 @@ const LIVE = {
       playOrder: 1,
       status: 'InProgress',
       winnerId: null,
+      winnerName: null,
       startedAt: '2026-07-04T20:00:00Z',
       completedAt: null,
     },
   ],
   isViewerOrganizer: true,
   plannedLineup: [],
+  currentSessionRoster: [],
 };
 
 describe('gameNightsClient.getLive', () => {

--- a/apps/web/src/lib/api/clients/__tests__/sessionsClient.test.ts
+++ b/apps/web/src/lib/api/clients/__tests__/sessionsClient.test.ts
@@ -186,47 +186,6 @@ describe('SessionsClient - Issue #3026', () => {
     });
   });
 
-  describe('start', () => {
-    it('should start a new session', async () => {
-      vi.mocked(mockHttpClient.post).mockResolvedValue(mockSession);
-
-      const client = createSessionsClient({ httpClient: mockHttpClient });
-      const result = await client.start({
-        gameId: 'game-456',
-        players: [
-          { playerName: 'Alice', playerOrder: 1, color: 'red' },
-          { playerName: 'Bob', playerOrder: 2, color: 'blue' },
-        ],
-        notes: 'First game of the day',
-      });
-
-      expect(result).toEqual(mockSession);
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        '/api/v1/sessions',
-        expect.objectContaining({ gameId: 'game-456' }),
-        expect.any(Object)
-      );
-    });
-
-    it('should start session without optional fields', async () => {
-      vi.mocked(mockHttpClient.post).mockResolvedValue(mockSession);
-
-      const client = createSessionsClient({ httpClient: mockHttpClient });
-      await client.start({
-        gameId: 'game-456',
-        players: [{ playerName: 'Solo', playerOrder: 1 }],
-      });
-
-      expect(mockHttpClient.post).toHaveBeenCalledWith(
-        '/api/v1/sessions',
-        expect.objectContaining({
-          players: [{ playerName: 'Solo', playerOrder: 1 }],
-        }),
-        expect.any(Object)
-      );
-    });
-  });
-
   describe('Session Lifecycle', () => {
     describe('pause', () => {
       it('should pause an active session', async () => {
@@ -363,9 +322,7 @@ describe('SessionsClient - Issue #3026', () => {
         const result = await client.getState('session-123');
 
         expect(result).toEqual(mockState);
-        expect(mockHttpClient.get).toHaveBeenCalledWith(
-          '/api/v1/sessions/session-123/state'
-        );
+        expect(mockHttpClient.get).toHaveBeenCalledWith('/api/v1/sessions/session-123/state');
       });
     });
 
@@ -377,10 +334,9 @@ describe('SessionsClient - Issue #3026', () => {
         const stateJson = JSON.stringify({ turnNumber: 6 });
         await client.updateState('session-123', stateJson);
 
-        expect(mockHttpClient.patch).toHaveBeenCalledWith(
-          '/api/v1/sessions/session-123/state',
-          { stateJson }
-        );
+        expect(mockHttpClient.patch).toHaveBeenCalledWith('/api/v1/sessions/session-123/state', {
+          stateJson,
+        });
       });
     });
 


### PR DESCRIPTION
Closes #2715.

Risana i 5 cluster di fallimento CI frontend accumulati su `main-dev` (session / session-live). Emersi durante il merge di #2714 (che ha richiesto admin-bypass proprio per questo baseline rotto).

## Fix per cluster

| Cluster | Causa radice | Fix | Tipo |
|---|---|---|---|
| **Lint** `text-white` | L'esenzione di `local/no-hardcoded-color-utility` richiede il bg colorato nella **stessa** `className`; in `PhotosTabContent.tsx` il gradient/`bg-foreground` erano sull'elemento parent | Sposto `text-white` sul div gradient (:66) e sul button (:72); testo/icona ereditano via CSS inheritance / `currentColor` | componente |
| **sessionsClient** (11 fail) | `start`/`POST /sessions` rimosso in #2587: 4× `client.start is not a function` + 7× lifecycle disallineati per **cascade `mockResolvedValueOnce`** (i mock non consumati dai test `start` scivolano sui lifecycle; `vi.clearAllMocks` non svuota le once-impl) | Elimino i blocchi `describe('start')` orfani nei 2 file → ri-allinea i lifecycle | test-only |
| **axe** `chat-attach-button` | Il fixture del test axe ometteva `attachAriaLabel` (required nel tipo `LiveAgentChat`) → `aria-label={undefined}` → violazione `button-name` | Aggiungo `attachAriaLabel` al fixture (in prod sempre passato da `SessionLiveView` via i18n) | test-only |
| **gameNights.live** | Mock stale vs schema #2634 C4 (mancavano `winnerName` e `currentSessionRoster`) | Allineo il mock allo schema | test-only |
| **i18n** `sessionLive.*` | — | **Nessuna chiave mancante**: non-issue, già risolto | — |

## Verifica locale
- `eslint .` (completo): **0 errori** (106 warning pre-esistenti, non bloccanti)
- 4 file cluster: **47 test verdi** (erano 13 falliti); PhotosTabContent: **17 verdi** (nessuna regressione dal cambio className)
- Suite FE completa: **22198 passed**

## Fuori scope (osservazione)
`__tests__/bundle-size.test.ts` fallisce **solo in locale** perché il mio `.next` è un prod build su disco; in CI la shard `frontend-test` non riceve l'artifact di build → il test è skippato (`skipIf(!existsSync)`). Il baseline totale (`bundle-size-baseline.json`, 17.09MB) è però driftato dal 2026-06-11 e andrebbe ri-bumpato in un **PR dedicato** (come indicato nel file stesso) — non correlato a questo fix.