### PR TITLE
chore(frontend): #2718 rebump bundle-size-baseline to fresh prod build

### DIFF
--- a/apps/web/bundle-size-baseline.json
+++ b/apps/web/bundle-size-baseline.json
@@ -1,6 +1,6 @@
 {
-  "description": "Baseline JS bundle size for prod build (no mock). Update manually in dedicated PRs. F5 #1823 Wave 3 follow-up rebump 2026-06-11: previous 2026-06-03 baseline (14,730,000) drifted ~+2.3MB across ~8 days of unaccounted FE deliveries (Asse A/B/C/D waves, DS-17 phase 2.5/3/C-1, SP3/SP4/SP6/SP7 Storybook expansion, M13 admin wikidata-dead-letters page). Re-anchored to fresh prod-build measurement + bumped tolerance to 50KB to absorb minor day-to-day churn until the next intentional rebump PR.",
-  "updatedAt": "2026-06-11",
-  "totalBytes": 17088259,
+  "description": "Baseline JS bundle size for prod build (no mock). Update manually in dedicated PRs. #2718 rebump 2026-07-06: previous 2026-06-11 baseline (17,088,259) drifted ~+61KB across ~25 days of unaccounted FE deliveries (Asse A-D session-live G-slices, DS-17 phase 2.5/3/C, SP5 waves), exceeding baseline+tolerance by ~10KB. Re-anchored to fresh prod-build measurement (pnpm build default config; sum of top-level .js in .next/static/chunks = 420 files, matching bundle-size.test.ts); tolerance kept at 50KB.",
+  "updatedAt": "2026-07-06",
+  "totalBytes": 17149683,
   "toleranceBytes": 51200
 }


### PR DESCRIPTION
Closes #2718.

Ri-anchora `apps/web/bundle-size-baseline.json` a una misura fresh prod-build. Il baseline precedente (`17,088,259`, 2026-06-11) era superato di ~10KB.

## Misura (test-exact)
`pnpm build` (config default, `NEXT_PUBLIC_API_BASE=http://localhost:8080`, no fixture flag) → somma dei `.js` nel **livello top** di `.next/static/chunks` (420 file), esattamente come `bundle-size.test.ts`:

| | valore |
|---|---|
| baseline precedente | 17,088,259 (max 17,139,459) |
| **nuovo** totalBytes | **17,149,683** |
| toleranceBytes | 51,200 (invariato) → nuovo max 17,200,883 |

Drift reale **~+61KB** in ~25 giorni (Asse A–D session-live, DS-17, SP5). La stima iniziale "+800KB" era errata: derivava da `du -sb` **ricorsivo** (include `.map` + sottodir), mentre il test conta solo i `.js` top-level.

## Verifica
- `bundle-size.test.ts`: **verde** in locale con `.next` fresco.
- Nessun impatto CI: il test è comunque skippato nella shard `frontend-test` (no build-artifact); questo PR mantiene solo il baseline accurato per gli sviluppatori.

Follow-up da #2715.