### PR TITLE
fix(game-night): #2720 reminder job persists SentAt via ExecuteUpdate

### DIFF
--- a/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Scheduling/GameNightReminderJob.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Scheduling/GameNightReminderJob.cs
@@ -2,6 +2,7 @@ using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
 using Api.BoundedContexts.GameManagement.Domain.Events;
 using Api.Infrastructure;
 using MediatR;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Quartz;
 
@@ -86,9 +87,17 @@ internal sealed class GameNightReminderJob : IJob
                         new GameNightReminder24hEvent(gameNight.Id, gameNight.Title, gameNight.ScheduledAt, gameNight.Location),
                         ct).ConfigureAwait(false);
 
-                    gameNight.MarkReminder24hSent();
-                    await _repository.UpdateAsync(gameNight, ct).ConfigureAwait(false);
-                    await _dbContext.SaveChangesAsync(ct).ConfigureAwait(false);
+                    // Persist the SentAt flag via a direct column UPDATE (#2720). The previous
+                    // detached UpdateAsync threw an EF identity conflict (the event was loaded
+                    // tracked by GetEventsNeedingReminderAsync) that the catch swallowed, leaving
+                    // the flag unwritten so every run re-sent the reminder. ExecuteUpdate bypasses
+                    // the change tracker + the xmin concurrency token.
+                    await _dbContext.GameNightEvents
+                        .Where(e => e.Id == gameNight.Id)
+                        .ExecuteUpdateAsync(
+                            s => s.SetProperty(e => e.Reminder24hSentAt, DateTimeOffset.UtcNow),
+                            ct)
+                        .ConfigureAwait(false);
 
                     reminder24hCount++;
                     _logger.LogInformation(
@@ -125,9 +134,13 @@ internal sealed class GameNightReminderJob : IJob
                         new GameNightReminder1hEvent(gameNight.Id, gameNight.Title, gameNight.ScheduledAt),
                         ct).ConfigureAwait(false);
 
-                    gameNight.MarkReminder1hSent();
-                    await _repository.UpdateAsync(gameNight, ct).ConfigureAwait(false);
-                    await _dbContext.SaveChangesAsync(ct).ConfigureAwait(false);
+                    // Direct column UPDATE — see the 24h branch (#2720).
+                    await _dbContext.GameNightEvents
+                        .Where(e => e.Id == gameNight.Id)
+                        .ExecuteUpdateAsync(
+                            s => s.SetProperty(e => e.Reminder1hSentAt, DateTimeOffset.UtcNow),
+                            ct)
+                        .ConfigureAwait(false);
 
                     reminder1hCount++;
                     _logger.LogInformation(

--- a/apps/api/tests/Api.Tests/Integration/GameManagement/GameNightReminderJobReliabilityTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/GameManagement/GameNightReminderJobReliabilityTests.cs
@@ -1,0 +1,113 @@
+using Api.BoundedContexts.GameManagement.Domain.Events;
+using Api.BoundedContexts.GameManagement.Infrastructure.Persistence;
+using Api.BoundedContexts.GameManagement.Infrastructure.Scheduling;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.GameManagement;
+using Api.SharedKernel.Application.Services;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Quartz;
+using Xunit;
+
+namespace Api.Tests.Integration.GameManagement;
+
+/// <summary>
+/// Reliability tests for <see cref="GameNightReminderJob"/> — Issue #2720. Proves the reminder
+/// flag is durably persisted so a subsequent job run (fresh scope, as in production) does NOT
+/// re-publish the reminder. Before the fix, the job loaded the event tracked and persisted the
+/// flag via the detached <c>UpdateAsync</c>, which threw an EF identity conflict (a second
+/// instance of the same key) — swallowed by the per-event catch — so the flag was never written
+/// and every run re-sent the reminder.
+/// </summary>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "GameManagement")]
+[Trait("Issue", "2720")]
+public sealed class GameNightReminderJobReliabilityTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private string _databaseName = null!;
+    private string _connectionString = null!;
+    private MeepleAiDbContext _dbContext = null!;
+
+    public GameNightReminderJobReliabilityTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    private static CancellationToken Ct => TestContext.Current.CancellationToken;
+
+    public async ValueTask InitializeAsync()
+    {
+        _databaseName = $"reminder_job_{Guid.NewGuid():N}";
+        _connectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+        _dbContext = _fixture.CreateDbContext(_connectionString);
+        await _dbContext.Database.MigrateAsync(Ct);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _dbContext.DisposeAsync();
+        await _fixture.DropIsolatedDatabaseAsync(_databaseName);
+    }
+
+    private static IJobExecutionContext JobContext()
+    {
+        var ctx = new Mock<IJobExecutionContext>();
+        ctx.SetupAllProperties();
+        ctx.Setup(c => c.CancellationToken).Returns(CancellationToken.None);
+        ctx.Setup(c => c.FireTimeUtc).Returns(DateTimeOffset.UtcNow);
+        return ctx.Object;
+    }
+
+    private async Task RunJobInFreshScopeAsync(IMediator mediator)
+    {
+        await using var db = _fixture.CreateDbContext(_connectionString);
+        var repo = new GameNightEventRepository(
+            db, Mock.Of<IDomainEventCollector>(), NullLogger<GameNightEventRepository>.Instance);
+        var job = new GameNightReminderJob(repo, mediator, db, NullLogger<GameNightReminderJob>.Instance);
+        await job.Execute(JobContext());
+    }
+
+    [Fact(DisplayName = "Reminder is marked once and not re-published on a subsequent run")]
+    public async Task Execute_MarksReminder_AndDoesNotRepublish()
+    {
+        // Seed a Published event whose ScheduledAt sits in the 24h reminder window.
+        var eventId = Guid.NewGuid();
+        _dbContext.GameNightEvents.Add(new GameNightEventEntity
+        {
+            Id = eventId,
+            OrganizerId = Guid.NewGuid(),
+            Title = "Serata promemoria",
+            ScheduledAt = DateTimeOffset.UtcNow.AddHours(24),
+            GameIdsJson = "[]",
+            Status = "Published",
+            CreatedAt = DateTimeOffset.UtcNow,
+        });
+        await _dbContext.SaveChangesAsync(Ct);
+
+        var mediator = new Mock<IMediator>();
+        mediator
+            .Setup(m => m.Publish(It.IsAny<GameNightReminder24hEvent>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        // Two independent job runs (each with a fresh DbContext scope, as in production).
+        await RunJobInFreshScopeAsync(mediator.Object);
+        await RunJobInFreshScopeAsync(mediator.Object);
+
+        // The reminder must have been published exactly once...
+        mediator.Verify(
+            m => m.Publish(It.IsAny<GameNightReminder24hEvent>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        // ...and the SentAt flag durably persisted (so the second run skipped it).
+        await using var verify = _fixture.CreateDbContext(_connectionString);
+        var row = await verify.GameNightEvents.AsNoTracking().FirstAsync(e => e.Id == eventId, Ct);
+        row.Reminder24hSentAt.Should().NotBeNull();
+    }
+}


### PR DESCRIPTION
> Closes #2720 · Follow-up da umbrella #2697 (review #2703)

## Bug
`GameNightReminderJob` caricava l'evento **tracked** (`GetEventsNeedingReminderAsync`), poi pubblicava il reminder e persisteva il flag `Reminder*SentAt` via il detached `UpdateAsync` — che ri-mappa una **nuova entity con lo stesso key** → EF **identity conflict** ("another instance with the same key is already being tracked"). Il `catch (Exception)` per-evento lo ingoiava → flag mai scritto → **ogni run (15m) ri-pubblicava il reminder** (email duplicate). Con l'xmin (#2703) attivo, una scrittura concorrente sarebbe stata ingoiata allo stesso modo.

Il job era **senza test**.

## Fix
Persistere il flag con un `ExecuteUpdateAsync` diretto sulla colonna — bypassa il change tracker (niente identity conflict) e il token xmin. Ordine publish→mark mantenuto (at-least-once; `ExecuteUpdate` è un singolo UPDATE atomico che di fatto non fallisce).

**Tradeoff**: `ExecuteUpdate` bypassa l'`AuditingSaveChangesInterceptor` — il flag reminder-sent (system flag di background, non azione utente) non viene più audited. Accettabile.

## Test (TDD RED→GREEN, Testcontainers)
`GameNightReminderJobReliabilityTests`: due run del job con **DbContext fresco per run** (come in produzione, scope-per-execution) su un evento nella finestra 24h → il reminder è pubblicato **esattamente una volta** e il flag `Reminder24hSentAt` è persistito. RED prima (pubblicato 2×, flag null) → GREEN.

Backend-only (i check FE skippano).

🤖 Generated with [Claude Code](https://claude.com/claude-code)