### PR TITLE
feat(game-night): #2721 summary per-session event counts

### DIFF
--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/GameNights/GameNightSummaryDto.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/GameNights/GameNightSummaryDto.cs
@@ -42,4 +42,5 @@ public sealed record GameNightGameRecapDto(
     GameNightSessionStatus Status,
     Guid? WinnerId,
     string? WinnerName,
-    int? DurationMinutes);
+    int? DurationMinutes,
+    int EventsCount);

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GameNightSummaryEventCounts.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GameNightSummaryEventCounts.cs
@@ -1,0 +1,25 @@
+using Api.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.GameManagement.Application.Queries.GameNights;
+
+/// <summary>
+/// Counts diary events per session for a game night — Issue #2721. A single GROUP BY over the
+/// SessionTracking session-events (cross-BC read, scoped by game-night id, soft-delete aware).
+/// </summary>
+internal static class GameNightSummaryEventCounts
+{
+    public static async Task<IReadOnlyDictionary<Guid, int>> BuildAsync(
+        MeepleAiDbContext db, Guid gameNightId, CancellationToken cancellationToken)
+    {
+        var counts = await db.SessionEvents
+            .AsNoTracking()
+            .Where(e => e.GameNightId == gameNightId && !e.IsDeleted)
+            .GroupBy(e => e.SessionId)
+            .Select(g => new { SessionId = g.Key, Count = g.Count() })
+            .ToDictionaryAsync(x => x.SessionId, x => x.Count, cancellationToken)
+            .ConfigureAwait(false);
+
+        return counts;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GameNightSummaryMapper.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GameNightSummaryMapper.cs
@@ -15,13 +15,15 @@ internal static class GameNightSummaryMapper
     public static GameNightSummaryDto Map(
         GameNightEvent night,
         Func<GameNightSession, string?> winnerName,
+        IReadOnlyDictionary<Guid, int> eventCountBySession,
         bool isViewerOrganizer)
     {
         var games = night.Sessions
             .OrderBy(s => s.PlayOrder)
             .Select(s => new GameNightGameRecapDto(
                 s.SessionId, s.GameId, s.GameTitle, s.PlayOrder, s.Status,
-                s.WinnerId, winnerName(s), DurationMinutes(s)))
+                s.WinnerId, winnerName(s), DurationMinutes(s),
+                eventCountBySession.TryGetValue(s.SessionId, out var count) ? count : 0))
             .ToList();
 
         var kpis = new GameNightSummaryKpisDto(

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GetGameNightSummaryByShareTokenQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GetGameNightSummaryByShareTokenQueryHandler.cs
@@ -35,7 +35,9 @@ internal sealed class GetGameNightSummaryByShareTokenQueryHandler
 
         var winnerName = await GameNightSummaryWinnerResolver
             .BuildAsync(_db, gameNight, cancellationToken).ConfigureAwait(false);
+        var eventCounts = await GameNightSummaryEventCounts
+            .BuildAsync(_db, gameNight.Id, cancellationToken).ConfigureAwait(false);
 
-        return GameNightSummaryMapper.Map(gameNight, winnerName, isViewerOrganizer: false);
+        return GameNightSummaryMapper.Map(gameNight, winnerName, eventCounts, isViewerOrganizer: false);
     }
 }

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GetGameNightSummaryQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GetGameNightSummaryQueryHandler.cs
@@ -40,7 +40,9 @@ internal sealed class GetGameNightSummaryQueryHandler
 
         var winnerName = await GameNightSummaryWinnerResolver
             .BuildAsync(_db, gameNight, cancellationToken).ConfigureAwait(false);
+        var eventCounts = await GameNightSummaryEventCounts
+            .BuildAsync(_db, gameNight.Id, cancellationToken).ConfigureAwait(false);
 
-        return GameNightSummaryMapper.Map(gameNight, winnerName, isOrganizer);
+        return GameNightSummaryMapper.Map(gameNight, winnerName, eventCounts, isOrganizer);
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/GameNights/GameNightSummaryMapperTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/GameNights/GameNightSummaryMapperTests.cs
@@ -32,22 +32,27 @@ public class GameNightSummaryMapperTests
             completedAt: Start.AddMinutes(durationMinutes));
     }
 
+    private static readonly IReadOnlyDictionary<Guid, int> NoEventCounts =
+        new Dictionary<Guid, int>();
+
     [Fact]
     public void Map_ComputesMvpKpisAndRecap()
     {
         var evt = GameNightEvent.Create(Guid.NewGuid(), "Serata", Start.AddDays(-1));
         var davide = Guid.NewGuid();
         var marco = Guid.NewGuid();
+        var brass = CompletedSession(evt.Id, 1, Guid.NewGuid(), "Brass", davide, 120);
         evt.RestoreSessions(new[]
         {
-            CompletedSession(evt.Id, 1, Guid.NewGuid(), "Brass", davide, 120),
+            brass,
             CompletedSession(evt.Id, 2, Guid.NewGuid(), "Spirit", davide, 60),
             CompletedSession(evt.Id, 3, Guid.NewGuid(), "Azul", marco, 30),
         });
         var names = new Dictionary<Guid, string> { [davide] = "Davide", [marco] = "Marco" };
         string? Resolver(GameNightSession s) => s.WinnerId is { } w ? names.GetValueOrDefault(w) : null;
+        var eventCounts = new Dictionary<Guid, int> { [brass.SessionId] = 11 };
 
-        var dto = GameNightSummaryMapper.Map(evt, Resolver, isViewerOrganizer: true);
+        var dto = GameNightSummaryMapper.Map(evt, Resolver, eventCounts, isViewerOrganizer: true);
 
         dto.Mvp.Should().NotBeNull();
         dto.Mvp!.PlayerName.Should().Be("Davide");
@@ -60,6 +65,8 @@ public class GameNightSummaryMapperTests
         dto.Games[0].GameTitle.Should().Be("Brass");
         dto.Games[0].WinnerName.Should().Be("Davide");
         dto.Games[0].DurationMinutes.Should().Be(120);
+        dto.Games[0].EventsCount.Should().Be(11);
+        dto.Games[1].EventsCount.Should().Be(0); // no events recorded for this session
     }
 
     [Fact]
@@ -71,7 +78,7 @@ public class GameNightSummaryMapperTests
             CompletedSession(evt.Id, 1, Guid.NewGuid(), "Brass", winnerId: null, 90),
         });
 
-        var dto = GameNightSummaryMapper.Map(evt, _ => null, isViewerOrganizer: true);
+        var dto = GameNightSummaryMapper.Map(evt, _ => null, NoEventCounts, isViewerOrganizer: true);
 
         dto.Mvp.Should().BeNull();
         dto.Kpis.WinnersCount.Should().Be(0);
@@ -86,8 +93,8 @@ public class GameNightSummaryMapperTests
         evt.Complete();
         evt.GenerateShareToken();
 
-        var organizerView = GameNightSummaryMapper.Map(evt, _ => null, isViewerOrganizer: true);
-        var guestView = GameNightSummaryMapper.Map(evt, _ => null, isViewerOrganizer: false);
+        var organizerView = GameNightSummaryMapper.Map(evt, _ => null, NoEventCounts, isViewerOrganizer: true);
+        var guestView = GameNightSummaryMapper.Map(evt, _ => null, NoEventCounts, isViewerOrganizer: false);
 
         organizerView.ShareToken.Should().NotBeNull();
         guestView.ShareToken.Should().BeNull();

--- a/apps/web/src/app/(authenticated)/game-nights/[id]/summary/_components/NightSummaryClientView.tsx
+++ b/apps/web/src/app/(authenticated)/game-nights/[id]/summary/_components/NightSummaryClientView.tsx
@@ -72,14 +72,17 @@ export function NightSummaryClientView({ nightId }: NightSummaryClientViewProps)
     );
   }
 
-  const { night, mvp, games } = toNightSummaryViewModel(summaryQuery.data, { locale, t });
+  const { night, mvp, games, eventsCount } = toNightSummaryViewModel(summaryQuery.data, {
+    locale,
+    t,
+  });
 
   return (
     <NightSummaryView
       night={night}
       mvp={mvp}
       games={games}
-      eventsCount={0}
+      eventsCount={eventsCount}
       archived={summaryQuery.data.isArchived}
       shareSuccess={shareSuccess}
       onShare={handleShare}

--- a/apps/web/src/app/(authenticated)/game-nights/[id]/summary/_components/__tests__/NightSummaryClientView.test.tsx
+++ b/apps/web/src/app/(authenticated)/game-nights/[id]/summary/_components/__tests__/NightSummaryClientView.test.tsx
@@ -69,6 +69,7 @@ const dto = {
       winnerId: null,
       winnerName: 'Davide',
       durationMinutes: 90,
+      eventsCount: 8,
     },
   ],
 };

--- a/apps/web/src/components/features/game-nights/summary/SharedGameNightSummaryView.tsx
+++ b/apps/web/src/components/features/game-nights/summary/SharedGameNightSummaryView.tsx
@@ -34,14 +34,14 @@ export function SharedGameNightSummaryView({ token }: SharedGameNightSummaryView
     );
   }
 
-  const { night, mvp, games } = toNightSummaryViewModel(query.data, { locale, t });
+  const { night, mvp, games, eventsCount } = toNightSummaryViewModel(query.data, { locale, t });
 
   return (
     <NightSummaryView
       night={night}
       mvp={mvp}
       games={games}
-      eventsCount={0}
+      eventsCount={eventsCount}
       archived={query.data.isArchived}
     />
   );

--- a/apps/web/src/components/features/game-nights/summary/night-summary-adapter.ts
+++ b/apps/web/src/components/features/game-nights/summary/night-summary-adapter.ts
@@ -10,6 +10,7 @@ export interface NightSummaryViewModel {
   readonly night: NightSummaryNight;
   readonly mvp: NightSummaryMVP | null;
   readonly games: PerGameRecapGame[];
+  readonly eventsCount: number;
 }
 
 export interface NightSummaryAdapterOptions {
@@ -84,7 +85,7 @@ export function toNightSummaryViewModel(
     title: g.gameTitle,
     order: g.playOrder,
     duration: g.durationMinutes != null ? formatDuration(g.durationMinutes) : durationUnknown,
-    eventsCount: 0,
+    eventsCount: g.eventsCount,
     ...(g.winnerName
       ? {
           winner: {
@@ -98,5 +99,7 @@ export function toNightSummaryViewModel(
       : {}),
   }));
 
-  return { night, mvp, games };
+  const eventsCount = dto.games.reduce((sum, g) => sum + g.eventsCount, 0);
+
+  return { night, mvp, games, eventsCount };
 }

--- a/apps/web/src/lib/api/schemas/game-nights.schemas.ts
+++ b/apps/web/src/lib/api/schemas/game-nights.schemas.ts
@@ -262,6 +262,7 @@ export const GameNightGameRecapDtoSchema = z.object({
   winnerId: z.string().uuid().nullable(),
   winnerName: z.string().nullable(),
   durationMinutes: z.number().int().nullable(),
+  eventsCount: z.number().int().nonnegative(),
 });
 export type GameNightGameRecapDto = z.infer<typeof GameNightGameRecapDtoSchema>;
 


### PR DESCRIPTION
> Closes #2721 · Follow-up da #2702 (umbrella #2697)

Il per-game recap del summary ora porta il conteggio reale di eventi diary per sessione (prima era 0).

## BE
`GameNightSummaryEventCounts.BuildAsync` — singola GROUP BY sui session-events di SessionTracking scoped per game-night id (soft-delete aware, cross-BC read come il winner resolver). Entrambi gli handler summary (participant + share-token) costruiscono i conteggi e li passano a `GameNightSummaryMapper.Map` → popola `EventsCount` per riga recap.

## FE
`eventsCount` sullo schema zod recap; l'adapter lo mappa per gioco e lo somma nel KPI `eventsCount` a livello serata.

## Tests
Mapper unit test asserisce `EventsCount` per sessione (11 per la sessione conteggiata, 0 per una senza); gli integration test summary esercitano la GROUP BY end-to-end. **10 BE summary + 58 FE summary** verdi; typecheck + lint puliti. FE CI red = baseline documentato.

🤖 Generated with [Claude Code](https://claude.com/claude-code)