### PR TITLE
feat(game-night): #2722 summary per-game top-N leaderboard (by rank)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/GameNights/GameNightSummaryDto.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/GameNights/GameNightSummaryDto.cs
@@ -43,4 +43,8 @@ public sealed record GameNightGameRecapDto(
     Guid? WinnerId,
     string? WinnerName,
     int? DurationMinutes,
-    int EventsCount);
+    int EventsCount,
+    IReadOnlyList<GameNightRecapPlayerDto> TopPlayers);
+
+/// <summary>A player on a game's final leaderboard (top-N by final rank) — Issue #2722.</summary>
+public sealed record GameNightRecapPlayerDto(string PlayerName, int? Rank);

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GameNightSummaryLeaderboard.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GameNightSummaryLeaderboard.cs
@@ -1,0 +1,41 @@
+using Api.BoundedContexts.GameManagement.Application.DTOs.GameNights;
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.GameManagement.Application.Queries.GameNights;
+
+/// <summary>
+/// Builds a per-session top-N leaderboard (by <c>FinalRank</c>) from the cross-BC SessionTracking
+/// participants — Issue #2722. Rank is universal across the polymorphic scoring types
+/// (Points/BinaryWin/Objectives/Ranking), so a numeric score is intentionally omitted here.
+/// </summary>
+internal static class GameNightSummaryLeaderboard
+{
+    private const int TopN = 3;
+
+    public static async Task<IReadOnlyDictionary<Guid, IReadOnlyList<GameNightRecapPlayerDto>>> BuildAsync(
+        MeepleAiDbContext db, GameNightEvent night, CancellationToken cancellationToken)
+    {
+        var sessionIds = night.Sessions.Select(s => s.SessionId).ToList();
+        if (sessionIds.Count == 0)
+            return new Dictionary<Guid, IReadOnlyList<GameNightRecapPlayerDto>>();
+
+        var participants = await db.SessionTrackingParticipants
+            .AsNoTracking()
+            .Where(p => sessionIds.Contains(p.SessionId))
+            .Select(p => new { p.SessionId, p.DisplayName, p.FinalRank })
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return participants
+            .GroupBy(p => p.SessionId)
+            .ToDictionary(
+                group => group.Key,
+                group => (IReadOnlyList<GameNightRecapPlayerDto>)group
+                    .OrderBy(p => p.FinalRank ?? int.MaxValue)
+                    .Take(TopN)
+                    .Select(p => new GameNightRecapPlayerDto(p.DisplayName, p.FinalRank))
+                    .ToList());
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GameNightSummaryMapper.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GameNightSummaryMapper.cs
@@ -16,6 +16,7 @@ internal static class GameNightSummaryMapper
         GameNightEvent night,
         Func<GameNightSession, string?> winnerName,
         IReadOnlyDictionary<Guid, int> eventCountBySession,
+        IReadOnlyDictionary<Guid, IReadOnlyList<GameNightRecapPlayerDto>> topPlayersBySession,
         bool isViewerOrganizer)
     {
         var games = night.Sessions
@@ -23,7 +24,10 @@ internal static class GameNightSummaryMapper
             .Select(s => new GameNightGameRecapDto(
                 s.SessionId, s.GameId, s.GameTitle, s.PlayOrder, s.Status,
                 s.WinnerId, winnerName(s), DurationMinutes(s),
-                eventCountBySession.TryGetValue(s.SessionId, out var count) ? count : 0))
+                eventCountBySession.TryGetValue(s.SessionId, out var count) ? count : 0,
+                topPlayersBySession.TryGetValue(s.SessionId, out var top)
+                    ? top
+                    : Array.Empty<GameNightRecapPlayerDto>()))
             .ToList();
 
         var kpis = new GameNightSummaryKpisDto(

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GetGameNightSummaryByShareTokenQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GetGameNightSummaryByShareTokenQueryHandler.cs
@@ -37,7 +37,10 @@ internal sealed class GetGameNightSummaryByShareTokenQueryHandler
             .BuildAsync(_db, gameNight, cancellationToken).ConfigureAwait(false);
         var eventCounts = await GameNightSummaryEventCounts
             .BuildAsync(_db, gameNight.Id, cancellationToken).ConfigureAwait(false);
+        var leaderboard = await GameNightSummaryLeaderboard
+            .BuildAsync(_db, gameNight, cancellationToken).ConfigureAwait(false);
 
-        return GameNightSummaryMapper.Map(gameNight, winnerName, eventCounts, isViewerOrganizer: false);
+        return GameNightSummaryMapper.Map(
+            gameNight, winnerName, eventCounts, leaderboard, isViewerOrganizer: false);
     }
 }

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GetGameNightSummaryQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GetGameNightSummaryQueryHandler.cs
@@ -42,7 +42,9 @@ internal sealed class GetGameNightSummaryQueryHandler
             .BuildAsync(_db, gameNight, cancellationToken).ConfigureAwait(false);
         var eventCounts = await GameNightSummaryEventCounts
             .BuildAsync(_db, gameNight.Id, cancellationToken).ConfigureAwait(false);
+        var leaderboard = await GameNightSummaryLeaderboard
+            .BuildAsync(_db, gameNight, cancellationToken).ConfigureAwait(false);
 
-        return GameNightSummaryMapper.Map(gameNight, winnerName, eventCounts, isOrganizer);
+        return GameNightSummaryMapper.Map(gameNight, winnerName, eventCounts, leaderboard, isOrganizer);
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/GameNights/GameNightSummaryMapperTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/GameNights/GameNightSummaryMapperTests.cs
@@ -1,3 +1,4 @@
+using Api.BoundedContexts.GameManagement.Application.DTOs.GameNights;
 using Api.BoundedContexts.GameManagement.Application.Queries.GameNights;
 using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
 using Api.BoundedContexts.GameManagement.Domain.Enums;
@@ -35,6 +36,9 @@ public class GameNightSummaryMapperTests
     private static readonly IReadOnlyDictionary<Guid, int> NoEventCounts =
         new Dictionary<Guid, int>();
 
+    private static readonly IReadOnlyDictionary<Guid, IReadOnlyList<GameNightRecapPlayerDto>> NoTopPlayers =
+        new Dictionary<Guid, IReadOnlyList<GameNightRecapPlayerDto>>();
+
     [Fact]
     public void Map_ComputesMvpKpisAndRecap()
     {
@@ -51,8 +55,17 @@ public class GameNightSummaryMapperTests
         var names = new Dictionary<Guid, string> { [davide] = "Davide", [marco] = "Marco" };
         string? Resolver(GameNightSession s) => s.WinnerId is { } w ? names.GetValueOrDefault(w) : null;
         var eventCounts = new Dictionary<Guid, int> { [brass.SessionId] = 11 };
+        var topPlayers = new Dictionary<Guid, IReadOnlyList<GameNightRecapPlayerDto>>
+        {
+            [brass.SessionId] = new List<GameNightRecapPlayerDto>
+            {
+                new("Davide", 1),
+                new("Marco", 2),
+                new("Giulia", 3),
+            },
+        };
 
-        var dto = GameNightSummaryMapper.Map(evt, Resolver, eventCounts, isViewerOrganizer: true);
+        var dto = GameNightSummaryMapper.Map(evt, Resolver, eventCounts, topPlayers, isViewerOrganizer: true);
 
         dto.Mvp.Should().NotBeNull();
         dto.Mvp!.PlayerName.Should().Be("Davide");
@@ -66,7 +79,11 @@ public class GameNightSummaryMapperTests
         dto.Games[0].WinnerName.Should().Be("Davide");
         dto.Games[0].DurationMinutes.Should().Be(120);
         dto.Games[0].EventsCount.Should().Be(11);
+        dto.Games[0].TopPlayers.Should().HaveCount(3);
+        dto.Games[0].TopPlayers[0].PlayerName.Should().Be("Davide");
+        dto.Games[0].TopPlayers[0].Rank.Should().Be(1);
         dto.Games[1].EventsCount.Should().Be(0); // no events recorded for this session
+        dto.Games[1].TopPlayers.Should().BeEmpty();
     }
 
     [Fact]
@@ -78,7 +95,7 @@ public class GameNightSummaryMapperTests
             CompletedSession(evt.Id, 1, Guid.NewGuid(), "Brass", winnerId: null, 90),
         });
 
-        var dto = GameNightSummaryMapper.Map(evt, _ => null, NoEventCounts, isViewerOrganizer: true);
+        var dto = GameNightSummaryMapper.Map(evt, _ => null, NoEventCounts, NoTopPlayers, isViewerOrganizer: true);
 
         dto.Mvp.Should().BeNull();
         dto.Kpis.WinnersCount.Should().Be(0);
@@ -93,8 +110,8 @@ public class GameNightSummaryMapperTests
         evt.Complete();
         evt.GenerateShareToken();
 
-        var organizerView = GameNightSummaryMapper.Map(evt, _ => null, NoEventCounts, isViewerOrganizer: true);
-        var guestView = GameNightSummaryMapper.Map(evt, _ => null, NoEventCounts, isViewerOrganizer: false);
+        var organizerView = GameNightSummaryMapper.Map(evt, _ => null, NoEventCounts, NoTopPlayers, isViewerOrganizer: true);
+        var guestView = GameNightSummaryMapper.Map(evt, _ => null, NoEventCounts, NoTopPlayers, isViewerOrganizer: false);
 
         organizerView.ShareToken.Should().NotBeNull();
         guestView.ShareToken.Should().BeNull();

--- a/apps/web/src/app/(authenticated)/game-nights/[id]/summary/_components/__tests__/NightSummaryClientView.test.tsx
+++ b/apps/web/src/app/(authenticated)/game-nights/[id]/summary/_components/__tests__/NightSummaryClientView.test.tsx
@@ -70,6 +70,10 @@ const dto = {
       winnerName: 'Davide',
       durationMinutes: 90,
       eventsCount: 8,
+      topPlayers: [
+        { playerName: 'Davide', rank: 1 },
+        { playerName: 'Marco', rank: 2 },
+      ],
     },
   ],
 };

--- a/apps/web/src/components/features/game-nights/summary/night-summary-adapter.ts
+++ b/apps/web/src/components/features/game-nights/summary/night-summary-adapter.ts
@@ -86,6 +86,16 @@ export function toNightSummaryViewModel(
     order: g.playOrder,
     duration: g.durationMinutes != null ? formatDuration(g.durationMinutes) : durationUnknown,
     eventsCount: g.eventsCount,
+    // Runner-ups (top-3 by final rank, excluding the winner). Score is omitted — rank is
+    // universal across the polymorphic scoring types (#2722).
+    topScores: g.topPlayers
+      .filter(p => p.playerName !== g.winnerName)
+      .map(p => ({
+        id: `${g.sessionId}:${p.playerName}`,
+        name: p.playerName,
+        initials: initialsOf(p.playerName),
+        color: hueOf(p.playerName),
+      })),
     ...(g.winnerName
       ? {
           winner: {

--- a/apps/web/src/lib/api/schemas/game-nights.schemas.ts
+++ b/apps/web/src/lib/api/schemas/game-nights.schemas.ts
@@ -263,6 +263,7 @@ export const GameNightGameRecapDtoSchema = z.object({
   winnerName: z.string().nullable(),
   durationMinutes: z.number().int().nullable(),
   eventsCount: z.number().int().nonnegative(),
+  topPlayers: z.array(z.object({ playerName: z.string(), rank: z.number().int().nullable() })),
 });
 export type GameNightGameRecapDto = z.infer<typeof GameNightGameRecapDtoSchema>;
 


### PR DESCRIPTION
> Closes #2722 · Follow-up da #2702 (umbrella #2697)

Il per-game recap del summary porta ora una top-3 leaderboard → mostra i runner-up, non solo il vincitore.

## BE
`GameNightSummaryLeaderboard.BuildAsync` legge i partecipanti SessionTracking (DisplayName + FinalRank), raggruppa per sessione, top-3 per `FinalRank`. Il **rank è universale** tra i tipi di scoring polimorfici (Points/BinaryWin/Objectives/Ranking), quindi lo score numerico è volutamente omesso. Entrambi gli handler summary lo passano al mapper → `TopPlayers` per riga recap.

## FE
`topPlayers` sullo schema recap; l'adapter mappa i runner-up (escluso il vincitore) in `topScores`.

## Tests
Mapper unit test asserisce `TopPlayers` (ordinati, rank) + vuoto per sessione senza rank. **10 BE summary + 58 FE summary** verdi; typecheck + lint puliti. FE CI red = baseline documentato.

**Nota**: gli score numerici per-player (polimorfici asse-D) restano fuori scope — la leaderboard è rank-based; un follow-up può esporre gli score per i giochi Points.

🤖 Generated with [Claude Code](https://claude.com/claude-code)