### PR TITLE
refactor(game-night): #2723 voting as ?tab=voting on the detail view (ADR-061)

### DIFF
--- a/apps/web/src/app/(authenticated)/game-nights/[id]/_components/GameNightDetailView.tsx
+++ b/apps/web/src/app/(authenticated)/game-nights/[id]/_components/GameNightDetailView.tsx
@@ -25,7 +25,7 @@ import { useEffect, useMemo } from 'react';
 
 import { Edit, Send, XCircle } from 'lucide-react';
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 
 import {
   GameNightCancelledBanner,
@@ -54,6 +54,7 @@ import { GameNightEditDrawer } from './GameNightEditDrawer';
 
 export function GameNightDetailView({ id }: { id: string }): React.JSX.Element {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const { t, locale } = useTranslation();
   const { toast } = useToast();
 
@@ -206,6 +207,12 @@ export function GameNightDetailView({ id }: { id: string }): React.JSX.Element {
   const isCancelled = event.status === 'Cancelled';
   const isCompleted = event.status === 'Completed';
   const isLive = event.status === 'Published';
+
+  // #2723: Published events surface a Dettagli|Votazione tab strip (ADR-061 tab-canonical),
+  // deep-linked via ?tab=voting. The voting tab shows only the VotingPanel; the details tab
+  // shows the RSVP / session / roster body.
+  const votingTabActive = isLive && searchParams.get('tab') === 'voting';
+  const showDetailsContent = !votingTabActive;
   const hasActiveSession = activeSessions.some(s => s.status === 'in_progress');
 
   const statusKey = event.status.toLowerCase() as 'draft' | 'published' | 'completed' | 'cancelled';
@@ -336,8 +343,41 @@ export function GameNightDetailView({ id }: { id: string }): React.JSX.Element {
       {/* Draft → preserve legacy planning layout. */}
       {isDraft && <GameNightPlanningLayout title={event.title} availableGames={availableGames} />}
 
-      {/* RSVP action bar — guests only, on Published events. */}
-      {isGuest && isLive && (
+      {/* Published tabs — Dettagli | Votazione (#2723, ADR-061, ?tab=voting deep-link). */}
+      {isLive && (
+        <nav
+          className="flex gap-1 border-b border-border"
+          aria-label={t('gameNightDetail.tabs.details')}
+        >
+          <Link
+            href={`/game-nights/${id}`}
+            aria-current={showDetailsContent ? 'page' : undefined}
+            data-testid="tab-details"
+            className={`px-4 py-2 text-sm font-semibold ${
+              showDetailsContent
+                ? 'border-b-2 border-primary text-foreground'
+                : 'text-muted-foreground'
+            }`}
+          >
+            {t('gameNightDetail.tabs.details')}
+          </Link>
+          <Link
+            href={`/game-nights/${id}?tab=voting`}
+            aria-current={votingTabActive ? 'page' : undefined}
+            data-testid="tab-voting"
+            className={`px-4 py-2 text-sm font-semibold ${
+              votingTabActive
+                ? 'border-b-2 border-primary text-foreground'
+                : 'text-muted-foreground'
+            }`}
+          >
+            {t('gameNightDetail.tabs.voting')}
+          </Link>
+        </nav>
+      )}
+
+      {/* RSVP action bar — guests only, on Published events (details tab). */}
+      {isGuest && isLive && showDetailsContent && (
         <GameNightRsvpActionBar
           labels={rsvpLabels}
           currentResponse={currentResponse}
@@ -346,13 +386,13 @@ export function GameNightDetailView({ id }: { id: string }): React.JSX.Element {
         />
       )}
 
-      {/* Candidate voting (approval model) — Issue #2700. Published events only. */}
-      {isLive && (
+      {/* Candidate voting (approval model) — Issue #2700 / #2723 voting tab. */}
+      {votingTabActive && (
         <VotingPanel gameNightId={id} isOrganizer={isHost} gameTitleById={gameTitleById} />
       )}
 
-      {/* Live / Completed: session flow sections under hero. */}
-      {(isLive || isCompleted) && (
+      {/* Live / Completed: session flow sections under hero (details tab). */}
+      {(isLive || isCompleted) && showDetailsContent && (
         <>
           <GameNightActions
             gameNightId={id}
@@ -365,8 +405,8 @@ export function GameNightDetailView({ id }: { id: string }): React.JSX.Element {
         </>
       )}
 
-      {/* Roster */}
-      {sortedRsvps.length > 0 && (
+      {/* Roster (details tab) */}
+      {sortedRsvps.length > 0 && showDetailsContent && (
         <section
           aria-label={t('gameNightDetail.participants.sectionTitle', {
             count: sortedRsvps.length,

--- a/apps/web/src/app/(authenticated)/game-nights/[id]/_components/__tests__/GameNightDetailView.editDrawer.test.tsx
+++ b/apps/web/src/app/(authenticated)/game-nights/[id]/_components/__tests__/GameNightDetailView.editDrawer.test.tsx
@@ -35,7 +35,10 @@ vi.mock('@/hooks/useToast', () => ({ useToast: () => ({ toast: vi.fn() }) }));
 vi.mock('@/hooks/useTranslation', () => ({
   useTranslation: () => ({ t: (k: string) => k, locale: 'it-IT' }),
 }));
-vi.mock('next/navigation', () => ({ useRouter: () => ({ push: vi.fn(), replace: vi.fn() }) }));
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  useSearchParams: () => ({ get: () => null }),
+}));
 
 // Stub heavy children so the test focuses on the view's edit wiring.
 vi.mock('@/components/game-night/planning/GameNightPlanningLayout', () => ({

--- a/apps/web/src/app/(authenticated)/game-nights/[id]/_components/__tests__/GameNightDetailView.votingTab.test.tsx
+++ b/apps/web/src/app/(authenticated)/game-nights/[id]/_components/__tests__/GameNightDetailView.votingTab.test.tsx
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { GameNightDetailView } from '../GameNightDetailView';
+
+const detailMock = vi.fn();
+const getTabMock = vi.fn<(key: string) => string | null>();
+
+vi.mock('@/hooks/queries/useGameNightDetail', () => ({
+  useGameNightDetail: () => detailMock(),
+}));
+vi.mock('@/hooks/queries/useCurrentUser', () => ({
+  useCurrentUser: () => ({ data: { id: 'org-1' } }),
+}));
+vi.mock('@/hooks/queries/useGameNights', () => ({
+  usePublishGameNight: () => ({ mutate: vi.fn(), isPending: false }),
+  useCancelGameNight: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+vi.mock('@/hooks/queries/useSharedGames', () => ({
+  useSharedGames: () => ({ data: { items: [] } }),
+}));
+vi.mock('@/stores/game-night', () => ({
+  useGameNightStore: () => ({
+    addPlayer: vi.fn(),
+    addGame: vi.fn(),
+    reset: vi.fn(),
+    activeSessions: [],
+  }),
+}));
+vi.mock('@/hooks/useToast', () => ({ useToast: () => ({ toast: vi.fn() }) }));
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => ({ t: (k: string) => k, locale: 'it-IT' }),
+}));
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  useSearchParams: () => ({ get: getTabMock }),
+}));
+
+vi.mock('@/components/features/game-night-detail', () => ({
+  GameNightDetailHero: () => <div data-testid="hero" />,
+  GameNightCancelledBanner: () => null,
+  GameNightRsvpActionBar: () => null,
+  GameNightRsvpRow: () => <div data-testid="rsvp-row" />,
+}));
+vi.mock('@/components/game-night/GameNightActions', () => ({
+  GameNightActions: () => <div data-testid="game-night-actions" />,
+}));
+vi.mock('@/components/game-night/GameNightSessionsList', () => ({
+  GameNightSessionsList: () => <div data-testid="sessions-list" />,
+}));
+vi.mock('@/components/game-night/GameNightDiaryPanel', () => ({
+  GameNightDiaryPanel: () => <div data-testid="diary-panel" />,
+}));
+vi.mock('@/components/game-night/planning/GameNightPlanningLayout', () => ({
+  GameNightPlanningLayout: () => null,
+}));
+vi.mock('../GameNightEditDrawer', () => ({ GameNightEditDrawer: () => null }));
+vi.mock('@/components/features/game-night-detail/voting/VotingPanel', () => ({
+  VotingPanel: () => <div data-testid="voting-panel" />,
+}));
+
+const publishedEvent = {
+  id: 'gn-1',
+  status: 'Published' as const,
+  organizerId: 'org-1',
+  organizerName: 'Marco',
+  title: 'Serata',
+  description: null,
+  scheduledAt: '2026-08-01T20:00:00.000Z',
+  location: null,
+  maxPlayers: null,
+  gameIds: [] as string[],
+  acceptedCount: 1,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getTabMock.mockReturnValue(null);
+  detailMock.mockReturnValue({
+    event: publishedEvent,
+    rsvps: [{ id: 'r1', userId: 'org-1', userName: 'Marco', status: 'Accepted' }],
+    actor: { actor: 'host' },
+    isLoading: false,
+    isError: false,
+    currentResponse: undefined,
+    pendingResponse: null,
+    submitRsvp: vi.fn(),
+    isSubmitting: false,
+  });
+});
+
+describe('GameNightDetailView — voting tab (#2723)', () => {
+  it('renders the Dettagli/Votazione tab strip on a Published event', () => {
+    render(<GameNightDetailView id="gn-1" />);
+    expect(screen.getByTestId('tab-details')).toHaveAttribute('href', '/game-nights/gn-1');
+    expect(screen.getByTestId('tab-voting')).toHaveAttribute(
+      'href',
+      '/game-nights/gn-1?tab=voting'
+    );
+  });
+
+  it('shows the details body (roster) and hides the voting panel by default', () => {
+    render(<GameNightDetailView id="gn-1" />);
+    expect(screen.getByTestId('rsvp-row')).toBeInTheDocument();
+    expect(screen.queryByTestId('voting-panel')).not.toBeInTheDocument();
+  });
+
+  it('shows the voting panel and hides the details body when ?tab=voting', () => {
+    getTabMock.mockImplementation(k => (k === 'tab' ? 'voting' : null));
+    render(<GameNightDetailView id="gn-1" />);
+    expect(screen.getByTestId('voting-panel')).toBeInTheDocument();
+    expect(screen.queryByTestId('rsvp-row')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('sessions-list')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
> Closes #2723 · Follow-up da #2700 (umbrella #2697)

Il detail Published espone ora un tab strip **Dettagli|Votazione** (ADR-061 tab-canonical), deep-link `?tab=voting`. Il tab Votazione mostra solo il `VotingPanel`; il tab Dettagli mantiene il body RSVP/session-flow/roster. Hero + host actions + edit drawer restano sopra i tab (sempre visibili). Gli status non-Published sono invariati (nessun tab strip).

## Tests
Tab strip con href corretti su evento Published; default → details body + voting nascosto; `?tab=voting` → voting panel + details nascosto. Sistemato anche il mock `next/navigation` del test edit-drawer (#2701) per fornire `useSearchParams`. Typecheck + lint puliti; **55 game-night FE test** verdi. FE-only; FE CI red = baseline documentato.

🤖 Generated with [Claude Code](https://claude.com/claude-code)