### PR TITLE
feat(game-nights): #2724 recap photo gallery

### DIFF
--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/DeleteGameNightPhotoCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/DeleteGameNightPhotoCommand.cs
@@ -1,0 +1,10 @@
+using System;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.GameManagement.Application.Commands.GameNights;
+
+/// <summary>
+/// Removes a photo from a GameNight recap gallery (#2724). Allowed for the uploader
+/// or the night's organizer.
+/// </summary>
+internal record DeleteGameNightPhotoCommand(Guid GameNightId, Guid PhotoId, Guid UserId) : ICommand;

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/DeleteGameNightPhotoCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/DeleteGameNightPhotoCommandHandler.cs
@@ -1,0 +1,81 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.Middleware.Exceptions;
+using Api.Services.Pdf;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.GameManagement.Application.Commands.GameNights;
+
+/// <summary>
+/// Handles removing a photo from a GameNight recap gallery (#2724). Allowed for the
+/// uploader or the night's organizer. Deletes the DB row then best-effort deletes the blob.
+/// </summary>
+internal sealed class DeleteGameNightPhotoCommandHandler : ICommandHandler<DeleteGameNightPhotoCommand>
+{
+    private readonly IGameNightEventRepository _eventRepository;
+    private readonly IGameNightPhotoRepository _photoRepository;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly IBlobStorageService _blobStorage;
+    private readonly ILogger<DeleteGameNightPhotoCommandHandler> _logger;
+
+    public DeleteGameNightPhotoCommandHandler(
+        IGameNightEventRepository eventRepository,
+        IGameNightPhotoRepository photoRepository,
+        IUnitOfWork unitOfWork,
+        IBlobStorageService blobStorage,
+        ILogger<DeleteGameNightPhotoCommandHandler> logger)
+    {
+        _eventRepository = eventRepository ?? throw new ArgumentNullException(nameof(eventRepository));
+        _photoRepository = photoRepository ?? throw new ArgumentNullException(nameof(photoRepository));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+        _blobStorage = blobStorage ?? throw new ArgumentNullException(nameof(blobStorage));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task Handle(DeleteGameNightPhotoCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var photo = await _photoRepository.GetByIdAsync(command.PhotoId, cancellationToken).ConfigureAwait(false);
+        if (photo is null || photo.GameNightId != command.GameNightId)
+            throw new NotFoundException("GameNightPhoto", command.PhotoId.ToString());
+
+        var night = await _eventRepository.GetByIdAsync(command.GameNightId, cancellationToken).ConfigureAwait(false)
+            ?? throw new NotFoundException("GameNight", command.GameNightId.ToString());
+
+        var canDelete = photo.UploadedByUserId == command.UserId || night.OrganizerId == command.UserId;
+        if (!canDelete)
+            throw new ForbiddenException("Only the uploader or the organizer can delete this photo.");
+
+        await _photoRepository.RemoveAsync(photo, cancellationToken).ConfigureAwait(false);
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        // Best-effort blob cleanup (orphan is harmless if this fails).
+        await TryDeleteBlobAsync(photo.BlobUrl, cancellationToken).ConfigureAwait(false);
+        if (photo.ThumbnailUrl is not null)
+            await TryDeleteBlobAsync(photo.ThumbnailUrl, cancellationToken).ConfigureAwait(false);
+    }
+
+    private async Task TryDeleteBlobAsync(string blobPath, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var fileName = Path.GetFileName(blobPath);
+            var underscoreIndex = fileName.IndexOf('_', StringComparison.Ordinal);
+            if (underscoreIndex <= 0) return;
+            var fileId = fileName[..underscoreIndex];
+            var folder = Path.GetFileName(Path.GetDirectoryName(blobPath) ?? string.Empty);
+            if (string.IsNullOrEmpty(folder)) return;
+            await _blobStorage.DeleteAsync(fileId, BlobCategory.GameNightPhoto, folder, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogWarning(ex, "Best-effort blob delete failed for {BlobPath}", blobPath);
+        }
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/UploadGameNightPhotoCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/UploadGameNightPhotoCommand.cs
@@ -1,0 +1,27 @@
+using System;
+using System.IO;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.GameManagement.Application.Commands.GameNights;
+
+/// <summary>
+/// Uploads a photo to a GameNight recap gallery (Issue #2724). Mirrors the
+/// PlayRecord photo flow but persists a standalone entity via its own tracked
+/// repository (the aggregate's detached Update cannot insert new children).
+/// </summary>
+internal record UploadGameNightPhotoCommand(
+    Guid GameNightId,
+    Guid UserId,
+    Stream FileStream,
+    long FileSizeBytes,
+    string MimeType,
+    bool ExtractScoreFromPhoto,
+    string? Caption
+) : ICommand<GameNightPhotoUploadResult>;
+
+internal record GameNightPhotoUploadResult(
+    Guid PhotoId,
+    string PhotoUrl,
+    string? ThumbnailUrl,
+    string? OcrText,
+    bool WasDeduplicated);

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/UploadGameNightPhotoCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/UploadGameNightPhotoCommandHandler.cs
@@ -1,0 +1,203 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Api.BoundedContexts.DocumentProcessing.Application.Services;
+using Api.BoundedContexts.GameManagement.Application.Services;
+using Api.BoundedContexts.GameManagement.Application.Validators;
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.Helpers;
+using Api.Infrastructure.Entities.GameManagement;
+using Api.Middleware.Exceptions;
+using Api.Services.Pdf;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Domain.Exceptions;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.GameManagement.Application.Commands.GameNights;
+
+/// <summary>
+/// Handles uploading a photo to a GameNight recap gallery. Flow: participant-guard →
+/// buffer → magic-byte validate → SHA256 dedup → StoreAsync → thumbnail (best-effort) →
+/// OCR (opt-in, best-effort) → persist standalone entity → SaveChanges → presign.
+/// Issue #2724 (mirrors PlayRecord photos, ADR-067).
+/// </summary>
+internal sealed class UploadGameNightPhotoCommandHandler
+    : ICommandHandler<UploadGameNightPhotoCommand, GameNightPhotoUploadResult>
+{
+    private readonly IGameNightEventRepository _eventRepository;
+    private readonly IGameNightPhotoRepository _photoRepository;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly IBlobStorageService _blobStorage;
+    private readonly IPhotoPreprocessor _photoPreprocessor;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<UploadGameNightPhotoCommandHandler> _logger;
+
+    public UploadGameNightPhotoCommandHandler(
+        IGameNightEventRepository eventRepository,
+        IGameNightPhotoRepository photoRepository,
+        IUnitOfWork unitOfWork,
+        IBlobStorageService blobStorage,
+        IPhotoPreprocessor photoPreprocessor,
+        TimeProvider timeProvider,
+        ILogger<UploadGameNightPhotoCommandHandler> logger)
+    {
+        _eventRepository = eventRepository ?? throw new ArgumentNullException(nameof(eventRepository));
+        _photoRepository = photoRepository ?? throw new ArgumentNullException(nameof(photoRepository));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+        _blobStorage = blobStorage ?? throw new ArgumentNullException(nameof(blobStorage));
+        _photoPreprocessor = photoPreprocessor ?? throw new ArgumentNullException(nameof(photoPreprocessor));
+        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<GameNightPhotoUploadResult> Handle(UploadGameNightPhotoCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var night = await _eventRepository.GetByIdAsync(command.GameNightId, cancellationToken).ConfigureAwait(false)
+            ?? throw new NotFoundException("GameNight", command.GameNightId.ToString());
+
+        // Participant guard (IDOR): only the organizer or a tagged/invited/accepted
+        // participant may contribute to a night's recap gallery.
+        var isParticipant = night.OrganizerId == command.UserId
+            || night.Rsvps.Any(r => r.UserId == command.UserId);
+        if (!isParticipant)
+            throw new ForbiddenException("You do not have permission to add photos to this game night.");
+
+        // Buffer the upload (needed for magic-byte, hash, thumbnail, OCR + re-reads).
+        byte[] bytes;
+        using (var buffer = new MemoryStream())
+        {
+            await command.FileStream.CopyToAsync(buffer, cancellationToken).ConfigureAwait(false);
+            bytes = buffer.ToArray();
+        }
+
+        using (var validateStream = new MemoryStream(bytes, writable: false))
+        {
+            var ok = await ImageFileValidator
+                .ValidateMagicBytesAsync(validateStream, command.MimeType).ConfigureAwait(false);
+            if (!ok)
+                throw new ValidationException("File content does not match its declared type.");
+        }
+
+        var sha = CryptographyHelper.ComputeSha256Hash(bytes);
+
+        // Idempotent re-upload: same (night, sha) → return existing.
+        var existing = await _photoRepository.GetBySha256Async(command.GameNightId, sha, cancellationToken).ConfigureAwait(false);
+        if (existing != null)
+        {
+            var existingUrl = await GameNightPhotoUrlResolver.ResolveAsync(_blobStorage, existing.BlobUrl, GameNightPhotoUrlResolver.DefaultExpirySeconds).ConfigureAwait(false);
+            var existingThumb = existing.ThumbnailUrl is null
+                ? null
+                : await GameNightPhotoUrlResolver.ResolveAsync(_blobStorage, existing.ThumbnailUrl, GameNightPhotoUrlResolver.DefaultExpirySeconds).ConfigureAwait(false);
+            return new GameNightPhotoUploadResult(existing.Id, existingUrl, existingThumb, existing.OcrText, WasDeduplicated: true);
+        }
+
+        var photoId = Guid.NewGuid();
+        var ext = string.Equals(command.MimeType, "image/png", StringComparison.OrdinalIgnoreCase) ? ".png"
+                : string.Equals(command.MimeType, "image/webp", StringComparison.OrdinalIgnoreCase) ? ".webp" : ".jpg";
+
+        // Use underscore separator so the URL resolver can extract fileId (substring before first '_').
+        var resourceKey = $"game-night-{night.Id:N}";
+        var fileName = $"{photoId:N}_{sha[..8]}{ext}";
+
+        BlobStorageResult stored;
+        using (var storeStream = new MemoryStream(bytes, writable: false))
+        {
+            stored = await _blobStorage.StoreAsync(storeStream, fileName, BlobCategory.GameNightPhoto, resourceKey, cancellationToken).ConfigureAwait(false);
+        }
+
+        if (!stored.Success || stored.FilePath is null)
+            throw new ValidationException(stored.ErrorMessage ?? "Failed to store the photo.");
+
+        // Thumbnail — best-effort.
+        string? thumbUrl = null;
+        try
+        {
+            using var thumbSource = new MemoryStream(bytes, writable: false);
+            using var thumb = await ImageThumbnailHelper.GenerateThumbnailAsync(thumbSource, cancellationToken).ConfigureAwait(false);
+            if (thumb != null)
+            {
+                var thumbFileName = $"{photoId:N}_thumb.jpg";
+                var thumbResult = await _blobStorage.StoreAsync(thumb, thumbFileName, BlobCategory.GameNightPhoto, resourceKey, cancellationToken).ConfigureAwait(false);
+                if (thumbResult.Success) thumbUrl = thumbResult.FilePath;
+            }
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogWarning(ex, "Thumbnail generation failed for game-night photo {PhotoId}", photoId);
+        }
+
+        // OCR — opt-in, best-effort (smoldocling).
+        string? ocrText = null;
+        double? ocrConfidence = null;
+        if (command.ExtractScoreFromPhoto)
+        {
+            try
+            {
+                var ocr = await _photoPreprocessor.PreprocessAsync(bytes, cancellationToken).ConfigureAwait(false);
+                ocrText = ocr.ExtractedText;
+                ocrConfidence = ocr.ConfidenceScore;
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                _logger.LogWarning(ex, "OCR failed for game-night photo {PhotoId}", photoId);
+            }
+        }
+
+        var entity = new GameNightPhotoEntity
+        {
+            Id = photoId,
+            GameNightId = night.Id,
+            BlobUrl = stored.FilePath,
+            ThumbnailUrl = thumbUrl,
+            FileSizeBytes = command.FileSizeBytes,
+            Sha256Hash = sha,
+            OcrText = ocrText,
+            OcrConfidence = ocrConfidence,
+            Caption = command.Caption,
+            UploadedByUserId = command.UserId,
+            UploadedAt = _timeProvider.GetUtcNow().UtcDateTime,
+        };
+
+        await _photoRepository.AddAsync(entity, cancellationToken).ConfigureAwait(false);
+        try
+        {
+            await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (DbUpdateException ex) when (ex.InnerException is Npgsql.PostgresException { SqlState: "23505" })
+        {
+            // Concurrent identical upload won the (GameNightId, Sha256Hash) unique-index race
+            // between our GetBySha256 check and this SaveChanges → treat as idempotent dedup
+            // rather than a 500 (lesson #2700). Return the row the winner persisted.
+            var winner = await _photoRepository.GetBySha256Async(command.GameNightId, sha, cancellationToken).ConfigureAwait(false);
+            if (winner != null)
+            {
+                var winUrl = await GameNightPhotoUrlResolver.ResolveAsync(_blobStorage, winner.BlobUrl, GameNightPhotoUrlResolver.DefaultExpirySeconds).ConfigureAwait(false);
+                var winThumb = winner.ThumbnailUrl is null
+                    ? null
+                    : await GameNightPhotoUrlResolver.ResolveAsync(_blobStorage, winner.ThumbnailUrl, GameNightPhotoUrlResolver.DefaultExpirySeconds).ConfigureAwait(false);
+                return new GameNightPhotoUploadResult(winner.Id, winUrl, winThumb, winner.OcrText, WasDeduplicated: true);
+            }
+            throw;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            // Surface orphaned blobs so they are reclaimable (store-then-save trade-off).
+            _logger.LogError(ex,
+                "Failed to persist game-night photo {PhotoId}; orphaned blobs may remain: photo={PhotoPath} thumb={ThumbPath}",
+                photoId, stored.FilePath, thumbUrl);
+            throw;
+        }
+
+        var url = await GameNightPhotoUrlResolver.ResolveAsync(_blobStorage, stored.FilePath, GameNightPhotoUrlResolver.DefaultExpirySeconds).ConfigureAwait(false);
+        var thumbPresigned = thumbUrl is null
+            ? null
+            : await GameNightPhotoUrlResolver.ResolveAsync(_blobStorage, thumbUrl, GameNightPhotoUrlResolver.DefaultExpirySeconds).ConfigureAwait(false);
+        return new GameNightPhotoUploadResult(photoId, url, thumbPresigned, ocrText, WasDeduplicated: false);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/UploadGameNightPhotoCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/UploadGameNightPhotoCommandHandler.cs
@@ -174,6 +174,15 @@ internal sealed class UploadGameNightPhotoCommandHandler
             // Concurrent identical upload won the (GameNightId, Sha256Hash) unique-index race
             // between our GetBySha256 check and this SaveChanges → treat as idempotent dedup
             // rather than a 500 (lesson #2700). Return the row the winner persisted.
+            // Our own store already happened (store-then-save), so best-effort delete our now-orphaned
+            // blobs and log them, mirroring the generic-exception path.
+            _logger.LogWarning(ex,
+                "Concurrent duplicate game-night photo upload for night {GameNightId} sha {Sha}; reclaiming orphaned blobs: photo={PhotoPath} thumb={ThumbPath}",
+                command.GameNightId, sha, stored.FilePath, thumbUrl);
+            await TryDeleteBlobAsync(stored.FilePath, cancellationToken).ConfigureAwait(false);
+            if (thumbUrl is not null)
+                await TryDeleteBlobAsync(thumbUrl, cancellationToken).ConfigureAwait(false);
+
             var winner = await _photoRepository.GetBySha256Async(command.GameNightId, sha, cancellationToken).ConfigureAwait(false);
             if (winner != null)
             {
@@ -199,5 +208,24 @@ internal sealed class UploadGameNightPhotoCommandHandler
             ? null
             : await GameNightPhotoUrlResolver.ResolveAsync(_blobStorage, thumbUrl, GameNightPhotoUrlResolver.DefaultExpirySeconds).ConfigureAwait(false);
         return new GameNightPhotoUploadResult(photoId, url, thumbPresigned, ocrText, WasDeduplicated: false);
+    }
+
+    /// <summary>Best-effort blob delete parsing fileId/folder from the stored path (orphan is harmless if it fails).</summary>
+    private async Task TryDeleteBlobAsync(string blobPath, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var fileName = Path.GetFileName(blobPath);
+            var underscoreIndex = fileName.IndexOf('_', StringComparison.Ordinal);
+            if (underscoreIndex <= 0) return;
+            var fileId = fileName[..underscoreIndex];
+            var folder = Path.GetFileName(Path.GetDirectoryName(blobPath) ?? string.Empty);
+            if (string.IsNullOrEmpty(folder)) return;
+            await _blobStorage.DeleteAsync(fileId, BlobCategory.GameNightPhoto, folder, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogWarning(ex, "Best-effort blob delete failed for {BlobPath}", blobPath);
+        }
     }
 }

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/GameNights/GameNightPhotoDto.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/GameNights/GameNightPhotoDto.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace Api.BoundedContexts.GameManagement.Application.DTOs.GameNights;
+
+/// <summary>
+/// A GameNight recap photo, with its blob URL already presigned for the caller.
+/// Issue #2724.
+/// </summary>
+public record GameNightPhotoDto(
+    Guid Id,
+    string PhotoUrl,
+    string? ThumbnailUrl,
+    string? Caption,
+    Guid UploadedByUserId,
+    DateTimeOffset UploadedAt);

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GetGameNightPhotosByShareTokenQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GetGameNightPhotosByShareTokenQuery.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using Api.BoundedContexts.GameManagement.Application.DTOs.GameNights;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.GameManagement.Application.Queries.GameNights;
+
+/// <summary>
+/// Anonymous shared-token read of a GameNight's recap photo gallery (#2724).
+/// The token is a cryptographic secret — possession authorises the read.
+/// </summary>
+internal record GetGameNightPhotosByShareTokenQuery(string ShareToken)
+    : IQuery<IReadOnlyList<GameNightPhotoDto>>;

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GetGameNightPhotosByShareTokenQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GetGameNightPhotosByShareTokenQueryHandler.cs
@@ -1,0 +1,46 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Api.BoundedContexts.GameManagement.Application.DTOs.GameNights;
+using Api.BoundedContexts.GameManagement.Application.Services;
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.Middleware.Exceptions;
+using Api.Services.Pdf;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.GameManagement.Application.Queries.GameNights;
+
+/// <summary>
+/// Handles the anonymous shared-gallery read (#2724). A revoked or unknown token
+/// resolves to null → 404. Mirrors <see cref="GetGameNightSummaryByShareTokenQueryHandler"/>.
+/// </summary>
+internal sealed class GetGameNightPhotosByShareTokenQueryHandler
+    : IQueryHandler<GetGameNightPhotosByShareTokenQuery, IReadOnlyList<GameNightPhotoDto>>
+{
+    private readonly IGameNightEventRepository _eventRepository;
+    private readonly IGameNightPhotoRepository _photoRepository;
+    private readonly IBlobStorageService _blobStorage;
+
+    public GetGameNightPhotosByShareTokenQueryHandler(
+        IGameNightEventRepository eventRepository,
+        IGameNightPhotoRepository photoRepository,
+        IBlobStorageService blobStorage)
+    {
+        _eventRepository = eventRepository ?? throw new ArgumentNullException(nameof(eventRepository));
+        _photoRepository = photoRepository ?? throw new ArgumentNullException(nameof(photoRepository));
+        _blobStorage = blobStorage ?? throw new ArgumentNullException(nameof(blobStorage));
+    }
+
+    public async Task<IReadOnlyList<GameNightPhotoDto>> Handle(
+        GetGameNightPhotosByShareTokenQuery query, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var night = await _eventRepository.GetByShareTokenAsync(query.ShareToken, cancellationToken).ConfigureAwait(false)
+            ?? throw new NotFoundException("SharedGameNight", query.ShareToken);
+
+        var photos = await _photoRepository.GetByGameNightIdAsync(night.Id, cancellationToken).ConfigureAwait(false);
+        return await GameNightPhotoProjection.ResolveAsync(_blobStorage, photos, cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GetGameNightPhotosQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GetGameNightPhotosQuery.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+using Api.BoundedContexts.GameManagement.Application.DTOs.GameNights;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.GameManagement.Application.Queries.GameNights;
+
+/// <summary>
+/// Participant-scoped read of a GameNight's recap photo gallery (#2724).
+/// </summary>
+internal record GetGameNightPhotosQuery(Guid GameNightId, Guid CallerUserId)
+    : IQuery<IReadOnlyList<GameNightPhotoDto>>;

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GetGameNightPhotosQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GetGameNightPhotosQueryHandler.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Api.BoundedContexts.GameManagement.Application.DTOs.GameNights;
+using Api.BoundedContexts.GameManagement.Application.Services;
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.Middleware.Exceptions;
+using Api.Services.Pdf;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.GameManagement.Application.Queries.GameNights;
+
+/// <summary>
+/// Handles <see cref="GetGameNightPhotosQuery"/>: participant-scoped gallery read (#2724).
+/// Only the organizer or a tagged/invited participant may view the photos.
+/// </summary>
+internal sealed class GetGameNightPhotosQueryHandler
+    : IQueryHandler<GetGameNightPhotosQuery, IReadOnlyList<GameNightPhotoDto>>
+{
+    private readonly IGameNightEventRepository _eventRepository;
+    private readonly IGameNightPhotoRepository _photoRepository;
+    private readonly IBlobStorageService _blobStorage;
+
+    public GetGameNightPhotosQueryHandler(
+        IGameNightEventRepository eventRepository,
+        IGameNightPhotoRepository photoRepository,
+        IBlobStorageService blobStorage)
+    {
+        _eventRepository = eventRepository ?? throw new ArgumentNullException(nameof(eventRepository));
+        _photoRepository = photoRepository ?? throw new ArgumentNullException(nameof(photoRepository));
+        _blobStorage = blobStorage ?? throw new ArgumentNullException(nameof(blobStorage));
+    }
+
+    public async Task<IReadOnlyList<GameNightPhotoDto>> Handle(
+        GetGameNightPhotosQuery query, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var night = await _eventRepository.GetByIdAsync(query.GameNightId, cancellationToken).ConfigureAwait(false)
+            ?? throw new NotFoundException("GameNight", query.GameNightId.ToString());
+
+        var isParticipant = night.OrganizerId == query.CallerUserId
+            || night.Rsvps.Any(r => r.UserId == query.CallerUserId);
+        if (!isParticipant)
+            throw new ForbiddenException("Only the organizer or an invited player can view the photos.");
+
+        var photos = await _photoRepository.GetByGameNightIdAsync(query.GameNightId, cancellationToken).ConfigureAwait(false);
+        return await GameNightPhotoProjection.ResolveAsync(_blobStorage, photos, cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Services/GameNightPhotoProjection.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Services/GameNightPhotoProjection.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Api.BoundedContexts.GameManagement.Application.DTOs.GameNights;
+using Api.Infrastructure.Entities.GameManagement;
+using Api.Services.Pdf;
+
+namespace Api.BoundedContexts.GameManagement.Application.Services;
+
+/// <summary>
+/// Projects stored GameNight photo entities into presigned <see cref="GameNightPhotoDto"/>s.
+/// Shared by the participant-scoped and shared-token gallery query handlers (#2724).
+/// </summary>
+internal static class GameNightPhotoProjection
+{
+    public static async Task<IReadOnlyList<GameNightPhotoDto>> ResolveAsync(
+        IBlobStorageService blobStorage,
+        IReadOnlyList<GameNightPhotoEntity> photos,
+        CancellationToken cancellationToken)
+    {
+        var result = new List<GameNightPhotoDto>(photos.Count);
+        foreach (var p in photos)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var url = await GameNightPhotoUrlResolver
+                .ResolveAsync(blobStorage, p.BlobUrl, GameNightPhotoUrlResolver.DefaultExpirySeconds)
+                .ConfigureAwait(false);
+            var thumb = p.ThumbnailUrl is null
+                ? null
+                : await GameNightPhotoUrlResolver
+                    .ResolveAsync(blobStorage, p.ThumbnailUrl, GameNightPhotoUrlResolver.DefaultExpirySeconds)
+                    .ConfigureAwait(false);
+            result.Add(new GameNightPhotoDto(
+                p.Id, url, thumb, p.Caption, p.UploadedByUserId, p.UploadedAt));
+        }
+
+        return result;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Services/GameNightPhotoUrlResolver.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Services/GameNightPhotoUrlResolver.cs
@@ -1,0 +1,46 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Api.Services.Pdf;
+
+namespace Api.BoundedContexts.GameManagement.Application.Services;
+
+/// <summary>
+/// Resolves a stored GameNight photo blob path to a presigned download URL.
+/// Shared by the upload command handler (write path) and the gallery query
+/// handlers (read path) so the FilePath→fileId/folder parsing lives in one place.
+/// Issue #2724. On local storage GetPresignedDownloadUrlAsync returns null → raw path.
+/// </summary>
+internal static class GameNightPhotoUrlResolver
+{
+    /// <summary>Default presigned URL TTL (1 hour), shared by all call-sites.</summary>
+    internal const int DefaultExpirySeconds = 3600;
+
+    public static async Task<string> ResolveAsync(
+        IBlobStorageService blobStorage,
+        string blobPath,
+        int expirySeconds)
+    {
+        var fileName = Path.GetFileName(blobPath);
+        if (string.IsNullOrEmpty(fileName))
+            return blobPath;
+
+        var underscoreIndex = fileName.IndexOf('_', StringComparison.Ordinal);
+        if (underscoreIndex <= 0)
+            return blobPath;
+
+        var fileId = fileName[..underscoreIndex];
+        var directory = Path.GetDirectoryName(blobPath);
+        if (string.IsNullOrEmpty(directory))
+            return blobPath;
+
+        var folder = Path.GetFileName(directory);
+        if (string.IsNullOrEmpty(folder))
+            return blobPath;
+
+        var signed = await blobStorage
+            .GetPresignedDownloadUrlAsync(fileId, BlobCategory.GameNightPhoto, folder, expirySeconds)
+            .ConfigureAwait(false);
+        return signed ?? blobPath;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Validators/GameNights/UploadGameNightPhotoCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Validators/GameNights/UploadGameNightPhotoCommandValidator.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Collections.Generic;
+using Api.BoundedContexts.GameManagement.Application.Commands.GameNights;
+using FluentValidation;
+
+namespace Api.BoundedContexts.GameManagement.Application.Validators.GameNights;
+
+internal sealed class UploadGameNightPhotoCommandValidator : AbstractValidator<UploadGameNightPhotoCommand>
+{
+    internal const long MaxFileSizeBytes = 5 * 1024 * 1024; // 5MB (mirrors PlayRecord photo cap)
+    private static readonly HashSet<string> AllowedMimeTypes =
+        new(StringComparer.OrdinalIgnoreCase) { "image/jpeg", "image/png", "image/webp" };
+
+    public UploadGameNightPhotoCommandValidator()
+    {
+        RuleFor(c => c.GameNightId).NotEmpty();
+        RuleFor(c => c.UserId).NotEmpty();
+        RuleFor(c => c.FileSizeBytes)
+            .GreaterThan(0).WithMessage("File cannot be empty")
+            .LessThanOrEqualTo(MaxFileSizeBytes).WithMessage("File cannot exceed 5MB");
+        RuleFor(c => c.MimeType)
+            .NotEmpty()
+            .Must(m => AllowedMimeTypes.Contains(m))
+            .WithMessage("Only JPEG, PNG, and WebP images are allowed");
+        RuleFor(c => c.Caption).MaximumLength(500).When(c => c.Caption != null);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/GameNightEvent/IGameNightPhotoRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/GameNightEvent/IGameNightPhotoRepository.cs
@@ -1,0 +1,25 @@
+using Api.Infrastructure.Entities.GameManagement;
+
+namespace Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+
+/// <summary>
+/// Repository for GameNight recap photos (Issue #2724). POCO-based and tracked:
+/// AddAsync/RemoveAsync enqueue on the change tracker without saving — the command
+/// handler drives the UnitOfWork.SaveChangesAsync. Kept separate from the
+/// GameNightEvent aggregate repository (detached full-remap Update cannot insert
+/// new PK-set children).
+/// </summary>
+internal interface IGameNightPhotoRepository
+{
+    Task AddAsync(GameNightPhotoEntity photo, CancellationToken cancellationToken = default);
+
+    Task RemoveAsync(GameNightPhotoEntity photo, CancellationToken cancellationToken = default);
+
+    Task<GameNightPhotoEntity?> GetByIdAsync(Guid photoId, CancellationToken cancellationToken = default);
+
+    /// <summary>Returns the existing photo with the same (gameNightId, sha256) for idempotent re-upload, else null.</summary>
+    Task<GameNightPhotoEntity?> GetBySha256Async(Guid gameNightId, string sha256, CancellationToken cancellationToken = default);
+
+    /// <summary>Lists a night's photos, oldest first.</summary>
+    Task<IReadOnlyList<GameNightPhotoEntity>> GetByGameNightIdAsync(Guid gameNightId, CancellationToken cancellationToken = default);
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/DependencyInjection/GameManagementServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/DependencyInjection/GameManagementServiceExtensions.cs
@@ -48,6 +48,7 @@ internal static class GameManagementServiceExtensions
         services.AddScoped<ISessionAttachmentRepository, SessionAttachmentRepository>(); // Issue #5360: Session photo attachments
         services.AddScoped<IGameNightPlaylistRepository, GameNightPlaylistRepository>(); // Issue #5582: Game Night Playlist
         services.AddScoped<IGameNightEventRepository, GameNightEventRepository>(); // Issue #42: Game Night Event
+        services.AddScoped<IGameNightPhotoRepository, GameNightPhotoRepository>(); // Issue #2724: Recap photo gallery
         services.AddScoped<IGameNightInvitationRepository, GameNightInvitationRepository>(); // Issue #607: Token-based public RSVP invitations
         services.AddScoped<IRuleDisputeRepository, RuleDisputeRepository>(); // Structured rule dispute persistence
         services.AddScoped<IGamePhaseTemplateRepository, GamePhaseTemplateRepository>(); // Game phase templates for session setup

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Persistence/GameNightPhotoRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Persistence/GameNightPhotoRepository.cs
@@ -1,0 +1,57 @@
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.GameManagement;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.GameManagement.Infrastructure.Persistence;
+
+/// <summary>
+/// Tracked EF Core repository for GameNight recap photos (Issue #2724).
+/// Does not call SaveChanges — the command handler owns the UnitOfWork boundary.
+/// </summary>
+internal sealed class GameNightPhotoRepository : IGameNightPhotoRepository
+{
+    private readonly MeepleAiDbContext _dbContext;
+
+    public GameNightPhotoRepository(MeepleAiDbContext dbContext)
+    {
+        _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+    }
+
+    public async Task AddAsync(GameNightPhotoEntity photo, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(photo);
+        await _dbContext.GameNightPhotos.AddAsync(photo, cancellationToken).ConfigureAwait(false);
+    }
+
+    public Task RemoveAsync(GameNightPhotoEntity photo, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(photo);
+        _dbContext.GameNightPhotos.Remove(photo);
+        return Task.CompletedTask;
+    }
+
+    public async Task<GameNightPhotoEntity?> GetByIdAsync(Guid photoId, CancellationToken cancellationToken = default)
+    {
+        return await _dbContext.GameNightPhotos
+            .FirstOrDefaultAsync(p => p.Id == photoId, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public async Task<GameNightPhotoEntity?> GetBySha256Async(Guid gameNightId, string sha256, CancellationToken cancellationToken = default)
+    {
+        return await _dbContext.GameNightPhotos
+            .FirstOrDefaultAsync(p => p.GameNightId == gameNightId && p.Sha256Hash == sha256, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public async Task<IReadOnlyList<GameNightPhotoEntity>> GetByGameNightIdAsync(Guid gameNightId, CancellationToken cancellationToken = default)
+    {
+        return await _dbContext.GameNightPhotos
+            .Where(p => p.GameNightId == gameNightId)
+            .OrderBy(p => p.UploadedAt)
+            .ThenBy(p => p.Id)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+}

--- a/apps/api/src/Api/Infrastructure/Entities/GameManagement/GameNightPhotoEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/GameManagement/GameNightPhotoEntity.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace Api.Infrastructure.Entities.GameManagement;
+
+/// <summary>
+/// Persistence POCO for a photo attached to a GameNight recap gallery.
+/// Standalone table (NOT an owned collection on the GameNightEvent aggregate):
+/// the aggregate repository persists via a detached full-remap Update which cannot
+/// insert new PK-set children (0-row UPDATE), so photos use their own tracked
+/// repository. Issue #2724.
+/// </summary>
+public class GameNightPhotoEntity
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public Guid GameNightId { get; set; }
+    public string BlobUrl { get; set; } = string.Empty;
+    public string? ThumbnailUrl { get; set; }
+    public long FileSizeBytes { get; set; }
+    public string Sha256Hash { get; set; } = string.Empty;
+    public string? OcrText { get; set; }
+    public double? OcrConfidence { get; set; }
+    public string? Caption { get; set; }
+    public Guid UploadedByUserId { get; set; }
+    public DateTime UploadedAt { get; set; }
+}

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/GameManagement/GameNightPhotoEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/GameManagement/GameNightPhotoEntityConfiguration.cs
@@ -1,0 +1,46 @@
+using Api.Infrastructure.Entities.GameManagement;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Api.Infrastructure.EntityConfigurations.GameManagement;
+
+/// <summary>
+/// EF Core configuration for GameNightPhotoEntity (Issue #2724).
+/// Standalone table with a cascade-delete FK to game_night_events, so photos are
+/// reclaimed when their night is hard-deleted.
+/// </summary>
+internal class GameNightPhotoEntityConfiguration : IEntityTypeConfiguration<GameNightPhotoEntity>
+{
+    public void Configure(EntityTypeBuilder<GameNightPhotoEntity> builder)
+    {
+        builder.ToTable("game_night_photos");
+        builder.HasKey(e => e.Id);
+
+        builder.Property(e => e.GameNightId).IsRequired();
+        builder.Property(e => e.BlobUrl).IsRequired().HasMaxLength(1024);
+        builder.Property(e => e.ThumbnailUrl).HasMaxLength(1024);
+        builder.Property(e => e.FileSizeBytes).IsRequired();
+        builder.Property(e => e.Sha256Hash).IsRequired().HasMaxLength(64);
+        builder.Property(e => e.OcrText);
+        builder.Property(e => e.OcrConfidence);
+        builder.Property(e => e.Caption).HasMaxLength(500);
+        builder.Property(e => e.UploadedByUserId).IsRequired();
+        builder.Property(e => e.UploadedAt).IsRequired();
+
+        // FK to game_night_events (cascade-delete: photos removed when the night is deleted).
+        // No navigation on the principal — photos are managed by their own repository.
+        builder.HasOne<GameNightEventEntity>()
+            .WithMany()
+            .HasForeignKey(e => e.GameNightId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        // Unique index: same image cannot be attached twice to the same night (dedup guard).
+        builder.HasIndex(e => new { e.GameNightId, e.Sha256Hash })
+            .IsUnique()
+            .HasDatabaseName("UX_game_night_photos_gamenight_sha256");
+
+        // Non-unique index for FK traversal / gallery listing.
+        builder.HasIndex(e => e.GameNightId)
+            .HasDatabaseName("IX_game_night_photos_GameNightId");
+    }
+}

--- a/apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs
+++ b/apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs
@@ -294,6 +294,7 @@ public class MeepleAiDbContext : DbContext
     public DbSet<GameNightRsvpEntity> GameNightRsvps => Set<GameNightRsvpEntity>(); // ISSUE-42: Game Night RSVP
     public DbSet<GameNightSessionEntity> GameNightSessions => Set<GameNightSessionEntity>(); // Game Night Sessions
     public DbSet<GameNightVoteEntity> GameNightVotes => Set<GameNightVoteEntity>(); // ISSUE-2700: Candidate voting
+    public DbSet<GameNightPhotoEntity> GameNightPhotos => Set<GameNightPhotoEntity>(); // ISSUE-2724: Recap photo gallery
     public DbSet<GameNightInvitationEntity> GameNightInvitations => Set<GameNightInvitationEntity>(); // ISSUE-607: Token-based public RSVP invitations
     public DbSet<RuleDisputeEntity> RuleDisputes => Set<RuleDisputeEntity>(); // Structured rule dispute persistence
     public DbSet<BoundedContexts.AgentMemory.Infrastructure.Entities.GameMemoryEntity> GameMemories => Set<BoundedContexts.AgentMemory.Infrastructure.Entities.GameMemoryEntity>(); // AgentMemory: per-game memory

--- a/apps/api/src/Api/Infrastructure/Migrations/20260706201135_AddGameNightPhotos.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260706201135_AddGameNightPhotos.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260706201135_AddGameNightPhotos")]
+    partial class AddGameNightPhotos
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260706201135_AddGameNightPhotos.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260706201135_AddGameNightPhotos.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddGameNightPhotos : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "game_night_photos",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    GameNightId = table.Column<Guid>(type: "uuid", nullable: false),
+                    BlobUrl = table.Column<string>(type: "character varying(1024)", maxLength: 1024, nullable: false),
+                    ThumbnailUrl = table.Column<string>(type: "character varying(1024)", maxLength: 1024, nullable: true),
+                    FileSizeBytes = table.Column<long>(type: "bigint", nullable: false),
+                    Sha256Hash = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: false),
+                    OcrText = table.Column<string>(type: "text", nullable: true),
+                    OcrConfidence = table.Column<double>(type: "double precision", nullable: true),
+                    Caption = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: true),
+                    UploadedByUserId = table.Column<Guid>(type: "uuid", nullable: false),
+                    UploadedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_game_night_photos", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_game_night_photos_game_night_events_GameNightId",
+                        column: x => x.GameNightId,
+                        principalTable: "game_night_events",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_game_night_photos_GameNightId",
+                table: "game_night_photos",
+                column: "GameNightId");
+
+            migrationBuilder.CreateIndex(
+                name: "UX_game_night_photos_gamenight_sha256",
+                table: "game_night_photos",
+                columns: new[] { "GameNightId", "Sha256Hash" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "game_night_photos");
+        }
+    }
+}

--- a/apps/api/src/Api/Routing/GameNightEndpoints.cs
+++ b/apps/api/src/Api/Routing/GameNightEndpoints.cs
@@ -352,6 +352,50 @@ internal static class GameNightEndpoints
             .WithSummary("Get a shared game night summary by token")
             .WithDescription("Public endpoint to read a shared summary by its opaque token. Returns 404 when the token is unknown or sharing was revoked. Rate-limited per IP.");
 
+        // ── Recap photo gallery — Issue #2724 ────────────────────────────────
+
+        gameNights.MapPost("/{id:guid}/photos", HandleUploadGameNightPhoto)
+            .RequireAuthenticatedUser()
+            .DisableAntiforgery()
+            .Produces<GameNightPhotoUploadResult>(201)
+            .Produces(400)
+            .Produces(401)
+            .Produces(403)
+            .Produces(404)
+            .WithName("UploadGameNightPhoto")
+            .WithSummary("Upload a photo to the game night recap gallery")
+            .WithDescription("Multipart upload (field 'file', optional 'caption', optional 'extractScoreFromPhoto'). Participant-scoped (organizer or RSVP'd player). Idempotent on identical bytes.");
+
+        gameNights.MapGet("/{id:guid}/photos", HandleGetGameNightPhotos)
+            .RequireAuthenticatedUser()
+            .Produces<IReadOnlyList<GameNightPhotoDto>>(200)
+            .Produces(401)
+            .Produces(403)
+            .Produces(404)
+            .WithName("GetGameNightPhotos")
+            .WithSummary("List the game night recap photos")
+            .WithDescription("Participant-scoped (organizer or RSVP'd player). URLs are presigned.");
+
+        gameNights.MapDelete("/{id:guid}/photos/{photoId:guid}", HandleDeleteGameNightPhoto)
+            .RequireAuthenticatedUser()
+            .Produces(204)
+            .Produces(401)
+            .Produces(403)
+            .Produces(404)
+            .WithName("DeleteGameNightPhoto")
+            .WithSummary("Delete a game night recap photo")
+            .WithDescription("Uploader- or organizer-only.");
+
+        gameNights.MapGet("/shared/{token}/photos", HandleGetSharedGameNightPhotos)
+            .AllowAnonymous()
+            .RequireRateLimiting("GameNightTokenRead")
+            .Produces<IReadOnlyList<GameNightPhotoDto>>(200)
+            .Produces(404)
+            .Produces(429)
+            .WithName("GetSharedGameNightPhotos")
+            .WithSummary("Get shared game night photos by token")
+            .WithDescription("Public endpoint to read a shared night's recap photos by its opaque token. Returns 404 when the token is unknown or sharing was revoked. Rate-limited per IP.");
+
         return group;
     }
 
@@ -522,6 +566,69 @@ internal static class GameNightEndpoints
         var userId = httpContext.User.GetUserId();
         var result = await mediator
             .Send(new GetGameNightSummaryQuery(id, userId), cancellationToken)
+            .ConfigureAwait(false);
+        return Results.Ok(result);
+    }
+
+    private static async Task<IResult> HandleUploadGameNightPhoto(
+        Guid id,
+        [FromServices] IMediator mediator,
+        HttpContext httpContext,
+        CancellationToken cancellationToken)
+    {
+        var form = await httpContext.Request.ReadFormAsync(cancellationToken).ConfigureAwait(false);
+        var file = form.Files.GetFile("file");
+        if (file is null || file.Length == 0)
+            return Results.BadRequest(new { error = "File is required" });
+
+        var extractScore = form.TryGetValue("extractScoreFromPhoto", out var raw)
+            && bool.TryParse(raw.ToString(), out var b) && b;
+        var caption = form.TryGetValue("caption", out var cap) ? cap.ToString() : null;
+
+        using var stream = file.OpenReadStream();
+        var command = new UploadGameNightPhotoCommand(
+            id, httpContext.User.GetUserId(), stream, file.Length, file.ContentType, extractScore, caption);
+
+        // Exceptions propagate to ApiExceptionHandlerMiddleware (ForbiddenException→403,
+        // NotFoundException→404, ValidationException→400).
+        var result = await mediator.Send(command, cancellationToken).ConfigureAwait(false);
+        return Results.Created($"/api/v1/game-nights/{id}/photos/{result.PhotoId}", result);
+    }
+
+    private static async Task<IResult> HandleGetGameNightPhotos(
+        Guid id,
+        [FromServices] IMediator mediator,
+        HttpContext httpContext,
+        CancellationToken cancellationToken)
+    {
+        var userId = httpContext.User.GetUserId();
+        var result = await mediator
+            .Send(new GetGameNightPhotosQuery(id, userId), cancellationToken)
+            .ConfigureAwait(false);
+        return Results.Ok(result);
+    }
+
+    private static async Task<IResult> HandleDeleteGameNightPhoto(
+        Guid id,
+        Guid photoId,
+        [FromServices] IMediator mediator,
+        HttpContext httpContext,
+        CancellationToken cancellationToken)
+    {
+        var userId = httpContext.User.GetUserId();
+        await mediator
+            .Send(new DeleteGameNightPhotoCommand(id, photoId, userId), cancellationToken)
+            .ConfigureAwait(false);
+        return Results.NoContent();
+    }
+
+    private static async Task<IResult> HandleGetSharedGameNightPhotos(
+        string token,
+        [FromServices] IMediator mediator,
+        CancellationToken cancellationToken)
+    {
+        var result = await mediator
+            .Send(new GetGameNightPhotosByShareTokenQuery(token), cancellationToken)
             .ConfigureAwait(false);
         return Results.Ok(result);
     }

--- a/apps/api/src/Api/Services/Pdf/IBlobStorageService.cs
+++ b/apps/api/src/Api/Services/Pdf/IBlobStorageService.cs
@@ -43,6 +43,10 @@ public enum BlobCategory
     /// <summary>Photos attached to a PlayRecord (scoreboard captures, party shots).
     /// Target prefix <c>play-record-photos/{playRecordId}/</c>.</summary>
     PlayRecordPhoto,
+
+    /// <summary>Photos attached to a GameNight (recap gallery: scoreboard captures, party shots).
+    /// Target prefix <c>game-night-photos/{gameNightId}/</c>. Issue #2724.</summary>
+    GameNightPhoto,
 }
 
 internal static class BlobCategoryExtensions
@@ -62,6 +66,7 @@ internal static class BlobCategoryExtensions
         BlobCategory.GamebookPhoto => "gamebook-photos",
         BlobCategory.PhotoBatch => "photo-batches",
         BlobCategory.PlayRecordPhoto => "play-record-photos",
+        BlobCategory.GameNightPhoto => "game-night-photos",
         _ => throw new ArgumentOutOfRangeException(nameof(category), category, null),
     };
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/GameNight/GameNightPhotoGalleryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/GameNight/GameNightPhotoGalleryHandlerTests.cs
@@ -1,0 +1,188 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Api.BoundedContexts.GameManagement.Application.Commands.GameNights;
+using Api.BoundedContexts.GameManagement.Application.Queries.GameNights;
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.Infrastructure.Entities.GameManagement;
+using Api.Middleware.Exceptions;
+using Api.Services.Pdf;
+using Api.SharedKernel.Infrastructure.Persistence;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Application.GameNight;
+
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "GameManagement")]
+[Trait("Issue", "2724")]
+public class GameNightPhotoGalleryHandlerTests
+{
+    private readonly Mock<IGameNightEventRepository> _events = new();
+    private readonly Mock<IGameNightPhotoRepository> _photos = new();
+    private readonly Mock<IBlobStorageService> _blob = new();
+
+    private static GameNightEvent NewNight(Guid organizer) =>
+        GameNightEvent.Create(organizer, "Serata", DateTimeOffset.UtcNow.AddDays(1));
+
+    private static GameNightPhotoEntity Photo(Guid nightId, Guid uploader) => new()
+    {
+        Id = Guid.NewGuid(),
+        GameNightId = nightId,
+        BlobUrl = "game-night-photos/abc/fid_12345678.png",
+        Caption = "Vittoria!",
+        UploadedByUserId = uploader,
+        UploadedAt = DateTime.UtcNow,
+    };
+
+    // ── GetGameNightPhotosQuery (participant-scoped) ─────────────────────────
+
+    [Fact]
+    public async Task GetPhotos_NonParticipant_ThrowsForbidden()
+    {
+        var night = NewNight(Guid.NewGuid());
+        _events.Setup(r => r.GetByIdAsync(night.Id, It.IsAny<CancellationToken>())).ReturnsAsync(night);
+        var sut = new GetGameNightPhotosQueryHandler(_events.Object, _photos.Object, _blob.Object);
+
+        var act = () => sut.Handle(new GetGameNightPhotosQuery(night.Id, Guid.NewGuid()), CancellationToken.None);
+
+        await act.Should().ThrowAsync<ForbiddenException>();
+    }
+
+    [Fact]
+    public async Task GetPhotos_MissingNight_ThrowsNotFound()
+    {
+        var id = Guid.NewGuid();
+        _events.Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>())).ReturnsAsync((GameNightEvent?)null);
+        var sut = new GetGameNightPhotosQueryHandler(_events.Object, _photos.Object, _blob.Object);
+
+        var act = () => sut.Handle(new GetGameNightPhotosQuery(id, Guid.NewGuid()), CancellationToken.None);
+
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+
+    [Fact]
+    public async Task GetPhotos_Organizer_ReturnsPresignedList()
+    {
+        var organizer = Guid.NewGuid();
+        var night = NewNight(organizer);
+        _events.Setup(r => r.GetByIdAsync(night.Id, It.IsAny<CancellationToken>())).ReturnsAsync(night);
+        _photos.Setup(p => p.GetByGameNightIdAsync(night.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<GameNightPhotoEntity> { Photo(night.Id, organizer) });
+        _blob.Setup(b => b.GetPresignedDownloadUrlAsync(It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<int?>()))
+            .ReturnsAsync("https://signed/url");
+        var sut = new GetGameNightPhotosQueryHandler(_events.Object, _photos.Object, _blob.Object);
+
+        var result = await sut.Handle(new GetGameNightPhotosQuery(night.Id, organizer), CancellationToken.None);
+
+        result.Should().HaveCount(1);
+        result[0].PhotoUrl.Should().Be("https://signed/url");
+        result[0].Caption.Should().Be("Vittoria!");
+    }
+
+    // ── GetGameNightPhotosByShareTokenQuery (anonymous) ──────────────────────
+
+    [Fact]
+    public async Task GetSharedPhotos_UnknownToken_ThrowsNotFound()
+    {
+        _events.Setup(r => r.GetByShareTokenAsync("nope", It.IsAny<CancellationToken>())).ReturnsAsync((GameNightEvent?)null);
+        var sut = new GetGameNightPhotosByShareTokenQueryHandler(_events.Object, _photos.Object, _blob.Object);
+
+        var act = () => sut.Handle(new GetGameNightPhotosByShareTokenQuery("nope"), CancellationToken.None);
+
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+
+    [Fact]
+    public async Task GetSharedPhotos_KnownToken_ReturnsList()
+    {
+        var night = NewNight(Guid.NewGuid());
+        _events.Setup(r => r.GetByShareTokenAsync("tok", It.IsAny<CancellationToken>())).ReturnsAsync(night);
+        _photos.Setup(p => p.GetByGameNightIdAsync(night.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<GameNightPhotoEntity> { Photo(night.Id, Guid.NewGuid()) });
+        _blob.Setup(b => b.GetPresignedDownloadUrlAsync(It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<int?>()))
+            .ReturnsAsync("https://signed/url");
+        var sut = new GetGameNightPhotosByShareTokenQueryHandler(_events.Object, _photos.Object, _blob.Object);
+
+        var result = await sut.Handle(new GetGameNightPhotosByShareTokenQuery("tok"), CancellationToken.None);
+
+        result.Should().HaveCount(1);
+    }
+
+    // ── DeleteGameNightPhotoCommand ──────────────────────────────────────────
+
+    private DeleteGameNightPhotoCommandHandler CreateDeleteSut() =>
+        new(_events.Object, _photos.Object, Mock.Of<IUnitOfWork>(), _blob.Object,
+            NullLogger<DeleteGameNightPhotoCommandHandler>.Instance);
+
+    [Fact]
+    public async Task Delete_MissingPhoto_ThrowsNotFound()
+    {
+        var id = Guid.NewGuid();
+        _photos.Setup(p => p.GetByIdAsync(id, It.IsAny<CancellationToken>())).ReturnsAsync((GameNightPhotoEntity?)null);
+
+        var act = () => CreateDeleteSut().Handle(new DeleteGameNightPhotoCommand(Guid.NewGuid(), id, Guid.NewGuid()), CancellationToken.None);
+
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+
+    [Fact]
+    public async Task Delete_PhotoOfDifferentNight_ThrowsNotFound()
+    {
+        var nightId = Guid.NewGuid();
+        var photo = Photo(Guid.NewGuid(), Guid.NewGuid()); // belongs to a different night
+        _photos.Setup(p => p.GetByIdAsync(photo.Id, It.IsAny<CancellationToken>())).ReturnsAsync(photo);
+
+        var act = () => CreateDeleteSut().Handle(new DeleteGameNightPhotoCommand(nightId, photo.Id, Guid.NewGuid()), CancellationToken.None);
+
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+
+    [Fact]
+    public async Task Delete_NonUploaderNonOrganizer_ThrowsForbidden()
+    {
+        var organizer = Guid.NewGuid();
+        var uploader = Guid.NewGuid();
+        var night = NewNight(organizer);
+        var photo = Photo(night.Id, uploader);
+        _photos.Setup(p => p.GetByIdAsync(photo.Id, It.IsAny<CancellationToken>())).ReturnsAsync(photo);
+        _events.Setup(r => r.GetByIdAsync(night.Id, It.IsAny<CancellationToken>())).ReturnsAsync(night);
+
+        var act = () => CreateDeleteSut().Handle(new DeleteGameNightPhotoCommand(night.Id, photo.Id, Guid.NewGuid()), CancellationToken.None);
+
+        await act.Should().ThrowAsync<ForbiddenException>();
+    }
+
+    [Fact]
+    public async Task Delete_ByUploader_Removes()
+    {
+        var organizer = Guid.NewGuid();
+        var uploader = Guid.NewGuid();
+        var night = NewNight(organizer);
+        var photo = Photo(night.Id, uploader);
+        _photos.Setup(p => p.GetByIdAsync(photo.Id, It.IsAny<CancellationToken>())).ReturnsAsync(photo);
+        _events.Setup(r => r.GetByIdAsync(night.Id, It.IsAny<CancellationToken>())).ReturnsAsync(night);
+
+        await CreateDeleteSut().Handle(new DeleteGameNightPhotoCommand(night.Id, photo.Id, uploader), CancellationToken.None);
+
+        _photos.Verify(p => p.RemoveAsync(photo, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Delete_ByOrganizer_Removes()
+    {
+        var organizer = Guid.NewGuid();
+        var uploader = Guid.NewGuid();
+        var night = NewNight(organizer);
+        var photo = Photo(night.Id, uploader);
+        _photos.Setup(p => p.GetByIdAsync(photo.Id, It.IsAny<CancellationToken>())).ReturnsAsync(photo);
+        _events.Setup(r => r.GetByIdAsync(night.Id, It.IsAny<CancellationToken>())).ReturnsAsync(night);
+
+        await CreateDeleteSut().Handle(new DeleteGameNightPhotoCommand(night.Id, photo.Id, organizer), CancellationToken.None);
+
+        _photos.Verify(p => p.RemoveAsync(photo, It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/GameNight/UploadGameNightPhotoCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/GameNight/UploadGameNightPhotoCommandHandlerTests.cs
@@ -1,0 +1,172 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Api.BoundedContexts.DocumentProcessing.Application.Services;
+using Api.BoundedContexts.DocumentProcessing.Domain.ValueObjects;
+using Api.BoundedContexts.GameManagement.Application.Commands.GameNights;
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.Infrastructure.Entities.GameManagement;
+using Api.Middleware.Exceptions;
+using Api.Services.Pdf;
+using Api.SharedKernel.Infrastructure.Persistence;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using ImageMagick;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Application.GameNight;
+
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "GameManagement")]
+[Trait("Issue", "2724")]
+public class UploadGameNightPhotoCommandHandlerTests
+{
+    private readonly Mock<IGameNightEventRepository> _events = new();
+    private readonly Mock<IGameNightPhotoRepository> _photos = new();
+    private readonly Mock<IUnitOfWork> _uow = new();
+    private readonly Mock<IBlobStorageService> _blob = new();
+    private readonly Mock<IPhotoPreprocessor> _ocr = new();
+
+    private UploadGameNightPhotoCommandHandler CreateSut() =>
+        new(_events.Object, _photos.Object, _uow.Object, _blob.Object, _ocr.Object,
+            TimeProvider.System, NullLogger<UploadGameNightPhotoCommandHandler>.Instance);
+
+    private static GameNightEvent NewNight(Guid organizer) =>
+        GameNightEvent.Create(organizer, "Serata", DateTimeOffset.UtcNow.AddDays(1));
+
+    private static byte[] MakePngBytes()
+    {
+        var ms = new MemoryStream();
+        using var img = new MagickImage(MagickColors.Black, 10, 10);
+        img.Format = MagickFormat.Png;
+        img.Write(ms);
+        return ms.ToArray();
+    }
+
+    private void StubStore() =>
+        _blob.Setup(b => b.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), BlobCategory.GameNightPhoto, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new BlobStorageResult(true, "fid", "game-night-photos/abc/fid_12345678.png", 100));
+
+    [Fact]
+    public async Task Handle_NonParticipant_ThrowsForbidden()
+    {
+        var night = NewNight(Guid.NewGuid());
+        var stranger = Guid.NewGuid();
+        _events.Setup(r => r.GetByIdAsync(night.Id, It.IsAny<CancellationToken>())).ReturnsAsync(night);
+
+        var png = MakePngBytes();
+        var act = () => CreateSut().Handle(
+            new UploadGameNightPhotoCommand(night.Id, stranger, new MemoryStream(png), png.Length, "image/png", false, null),
+            CancellationToken.None);
+
+        await act.Should().ThrowAsync<ForbiddenException>();
+        _blob.Verify(b => b.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_MissingNight_ThrowsNotFound()
+    {
+        var id = Guid.NewGuid();
+        _events.Setup(r => r.GetByIdAsync(id, It.IsAny<CancellationToken>())).ReturnsAsync((GameNightEvent?)null);
+
+        var png = MakePngBytes();
+        var act = () => CreateSut().Handle(
+            new UploadGameNightPhotoCommand(id, Guid.NewGuid(), new MemoryStream(png), png.Length, "image/png", false, null),
+            CancellationToken.None);
+
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+
+    [Fact]
+    public async Task Handle_Organizer_StoresPhotoAndSaves()
+    {
+        var organizer = Guid.NewGuid();
+        var night = NewNight(organizer);
+        _events.Setup(r => r.GetByIdAsync(night.Id, It.IsAny<CancellationToken>())).ReturnsAsync(night);
+        _photos.Setup(p => p.GetBySha256Async(night.Id, It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync((GameNightPhotoEntity?)null);
+        StubStore();
+        _blob.Setup(b => b.GetPresignedDownloadUrlAsync(It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<int?>()))
+            .ReturnsAsync("https://signed/url");
+
+        var png = MakePngBytes();
+        var result = await CreateSut().Handle(
+            new UploadGameNightPhotoCommand(night.Id, organizer, new MemoryStream(png), png.Length, "image/png", false, null),
+            CancellationToken.None);
+
+        result.PhotoId.Should().NotBeEmpty();
+        result.WasDeduplicated.Should().BeFalse();
+        _photos.Verify(p => p.AddAsync(It.Is<GameNightPhotoEntity>(e => e.GameNightId == night.Id && e.UploadedByUserId == organizer), It.IsAny<CancellationToken>()), Times.Once);
+        _uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+        _ocr.Verify(o => o.PreprocessAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_ExtractScore_RunsOcrAndStoresText()
+    {
+        var organizer = Guid.NewGuid();
+        var night = NewNight(organizer);
+        _events.Setup(r => r.GetByIdAsync(night.Id, It.IsAny<CancellationToken>())).ReturnsAsync(night);
+        _photos.Setup(p => p.GetBySha256Async(night.Id, It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync((GameNightPhotoEntity?)null);
+        StubStore();
+        _ocr.Setup(o => o.PreprocessAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PhotoPreprocessResult(Array.Empty<byte>(), "Alice 10 Bob 8", 0.93, PageOrientation.Portrait, false, Array.Empty<string>()));
+
+        var png = MakePngBytes();
+        var result = await CreateSut().Handle(
+            new UploadGameNightPhotoCommand(night.Id, organizer, new MemoryStream(png), png.Length, "image/png", true, null),
+            CancellationToken.None);
+
+        result.OcrText.Should().Be("Alice 10 Bob 8");
+        _photos.Verify(p => p.AddAsync(It.Is<GameNightPhotoEntity>(e => e.OcrText == "Alice 10 Bob 8"), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_DuplicateSha_ReturnsExistingWithoutStore()
+    {
+        var organizer = Guid.NewGuid();
+        var night = NewNight(organizer);
+        _events.Setup(r => r.GetByIdAsync(night.Id, It.IsAny<CancellationToken>())).ReturnsAsync(night);
+
+        var existing = new GameNightPhotoEntity
+        {
+            Id = Guid.NewGuid(),
+            GameNightId = night.Id,
+            BlobUrl = "game-night-photos/abc/existing_12345678.png",
+            Sha256Hash = "will-be-overwritten",
+            UploadedByUserId = organizer,
+            UploadedAt = DateTime.UtcNow,
+        };
+        _photos.Setup(p => p.GetBySha256Async(night.Id, It.IsAny<string>(), It.IsAny<CancellationToken>())).ReturnsAsync(existing);
+        _blob.Setup(b => b.GetPresignedDownloadUrlAsync(It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<int?>()))
+            .ReturnsAsync("https://signed/url");
+
+        var png = MakePngBytes();
+        var result = await CreateSut().Handle(
+            new UploadGameNightPhotoCommand(night.Id, organizer, new MemoryStream(png), png.Length, "image/png", false, null),
+            CancellationToken.None);
+
+        result.WasDeduplicated.Should().BeTrue();
+        result.PhotoId.Should().Be(existing.Id);
+        _blob.Verify(b => b.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        _photos.Verify(p => p.AddAsync(It.IsAny<GameNightPhotoEntity>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_BadMagicBytes_ThrowsValidation()
+    {
+        var organizer = Guid.NewGuid();
+        var night = NewNight(organizer);
+        _events.Setup(r => r.GetByIdAsync(night.Id, It.IsAny<CancellationToken>())).ReturnsAsync(night);
+
+        // Declared PNG but bytes are not a PNG → magic-byte validation fails.
+        var notAnImage = new byte[] { 0x00, 0x01, 0x02, 0x03, 0x04 };
+        var act = () => CreateSut().Handle(
+            new UploadGameNightPhotoCommand(night.Id, organizer, new MemoryStream(notAnImage), notAnImage.Length, "image/png", false, null),
+            CancellationToken.None);
+
+        await act.Should().ThrowAsync<Api.SharedKernel.Domain.Exceptions.ValidationException>();
+        _blob.Verify(b => b.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/GameNight/UploadGameNightPhotoCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/GameNight/UploadGameNightPhotoCommandHandlerTests.cs
@@ -11,8 +11,10 @@ using Api.Middleware.Exceptions;
 using Api.Services.Pdf;
 using Api.SharedKernel.Infrastructure.Persistence;
 using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
+using Npgsql;
 using ImageMagick;
 using Xunit;
 
@@ -151,6 +153,45 @@ public class UploadGameNightPhotoCommandHandlerTests
         result.PhotoId.Should().Be(existing.Id);
         _blob.Verify(b => b.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
         _photos.Verify(p => p.AddAsync(It.IsAny<GameNightPhotoEntity>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_ConcurrentUniqueViolation_ReturnsDedupAndReclaimsOrphanBlob()
+    {
+        var organizer = Guid.NewGuid();
+        var night = NewNight(organizer);
+        _events.Setup(r => r.GetByIdAsync(night.Id, It.IsAny<CancellationToken>())).ReturnsAsync(night);
+
+        var winner = new GameNightPhotoEntity
+        {
+            Id = Guid.NewGuid(),
+            GameNightId = night.Id,
+            BlobUrl = "game-night-photos/winner/win_00000000.png",
+            UploadedByUserId = organizer,
+            UploadedAt = DateTime.UtcNow,
+        };
+        // First check (pre-store) sees nothing; the in-catch re-query finds the winner.
+        _photos.SetupSequence(p => p.GetBySha256Async(night.Id, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((GameNightPhotoEntity?)null)
+            .ReturnsAsync(winner);
+        StubStore();
+        _blob.Setup(b => b.GetPresignedDownloadUrlAsync(It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<int?>()))
+            .ReturnsAsync("https://signed/url");
+
+        // The losing concurrent write hits the (GameNightId, Sha256Hash) unique index.
+        var pg = new PostgresException("duplicate key", "ERROR", "ERROR", "23505");
+        _uow.Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new DbUpdateException("save failed", pg));
+
+        var png = MakePngBytes();
+        var result = await CreateSut().Handle(
+            new UploadGameNightPhotoCommand(night.Id, organizer, new MemoryStream(png), png.Length, "image/png", false, null),
+            CancellationToken.None);
+
+        result.WasDeduplicated.Should().BeTrue();
+        result.PhotoId.Should().Be(winner.Id);
+        // Our now-orphaned blob (game-night-photos/abc/fid_...png from StubStore) is reclaimed.
+        _blob.Verify(b => b.DeleteAsync(It.IsAny<string>(), BlobCategory.GameNightPhoto, It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.AtLeastOnce);
     }
 
     [Fact]

--- a/apps/api/tests/Api.Tests/Integration/GameManagement/GameNightPhotoUploadTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/GameManagement/GameNightPhotoUploadTests.cs
@@ -1,0 +1,246 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Api.BoundedContexts.DocumentProcessing.Application.Services;
+using Api.BoundedContexts.DocumentProcessing.Domain.ValueObjects;
+using Api.BoundedContexts.GameManagement.Application.Commands.GameNights;
+using Api.BoundedContexts.GameManagement.Application.DTOs.GameNights;
+using Api.BoundedContexts.GameManagement.Application.Queries.GameNights;
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.BoundedContexts.GameManagement.Infrastructure.Persistence;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.GameManagement;
+using Api.Middleware.Exceptions;
+using Api.Services.Pdf;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using ImageMagick;
+using Xunit;
+
+namespace Api.Tests.Integration.GameManagement;
+
+/// <summary>
+/// Testcontainers round-trip for the GameNight recap photo gallery (#2724):
+/// participant upload → list, IDOR guards, SHA256 dedup (DB unique index),
+/// share-token gallery read, and delete. Validates the EF config + migration.
+/// </summary>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "GameManagement")]
+[Trait("Issue", "2724")]
+public sealed class GameNightPhotoUploadTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private string _connectionString = string.Empty;
+    private string _databaseName = string.Empty;
+    private MeepleAiDbContext _dbContext = null!;
+    private IServiceProvider? _serviceProvider;
+
+    public GameNightPhotoUploadTests(SharedTestcontainersFixture fixture) => _fixture = fixture;
+
+    private IServiceProvider Sp => _serviceProvider ?? throw new InvalidOperationException("SP not initialized");
+    private static CancellationToken Ct => TestContext.Current.CancellationToken;
+
+    private sealed class FakeBlobStorageService : IBlobStorageService
+    {
+        public Task<BlobStorageResult> StoreAsync(Stream stream, string fileName, BlobCategory category, string resourceKey, CancellationToken ct = default)
+        {
+            var fileId = Guid.NewGuid().ToString("N");
+            return Task.FromResult(new BlobStorageResult(true, fileId, $"{category.ToS3Folder()}/{resourceKey}/{fileId}_{fileName}", 100));
+        }
+
+        public Task<Stream?> RetrieveAsync(string fileId, BlobCategory category, string resourceKey, CancellationToken ct = default)
+            => Task.FromResult<Stream?>(null);
+        public Task<bool> DeleteAsync(string fileId, BlobCategory category, string resourceKey, CancellationToken ct = default)
+            => Task.FromResult(true);
+        public Task<bool> ExistsAsync(string fileId, BlobCategory category, string resourceKey, CancellationToken cancellationToken = default)
+            => Task.FromResult(false);
+        public string GetStoragePath(string fileId, BlobCategory category, string resourceKey, string fileName)
+            => $"{category.ToS3Folder()}/{resourceKey}/{fileId}_{fileName}";
+        public Task<string?> GetPresignedDownloadUrlAsync(string fileId, BlobCategory category, string resourceKey, int? expirySeconds = null)
+            => Task.FromResult<string?>(null);
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        _databaseName = $"gamenight_photo_{Guid.NewGuid():N}";
+        _connectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+
+        var services = IntegrationServiceCollectionBuilder.CreateBase(_connectionString);
+        services.AddScoped<IGameNightEventRepository, GameNightEventRepository>();
+        services.AddScoped<IGameNightPhotoRepository, GameNightPhotoRepository>();
+        services.AddScoped<IBlobStorageService, FakeBlobStorageService>();
+
+        var ocrMock = new Mock<IPhotoPreprocessor>();
+        ocrMock.Setup(o => o.PreprocessAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PhotoPreprocessResult(Array.Empty<byte>(), "Alice 10 Bob 8", 0.93, PageOrientation.Portrait, false, Array.Empty<string>()));
+        services.AddScoped<IPhotoPreprocessor>(_ => ocrMock.Object);
+
+        _serviceProvider = services.BuildServiceProvider();
+        _dbContext = Sp.GetRequiredService<MeepleAiDbContext>();
+        await _dbContext.Database.MigrateAsync(Ct);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _dbContext.DisposeAsync();
+        if (_serviceProvider is IAsyncDisposable d) await d.DisposeAsync();
+        await _fixture.DropIsolatedDatabaseAsync(_databaseName);
+    }
+
+    private async Task<(Guid EventId, Guid Organizer, Guid Participant)> SeedAsync(string? shareToken = null)
+    {
+        var eventId = Guid.NewGuid();
+        var organizer = Guid.NewGuid();
+        var participant = Guid.NewGuid();
+
+        _dbContext.GameNightEvents.Add(new GameNightEventEntity
+        {
+            Id = eventId,
+            OrganizerId = organizer,
+            Title = "Serata foto",
+            ScheduledAt = DateTimeOffset.UtcNow.AddDays(-1),
+            GameIdsJson = JsonSerializer.Serialize(new List<Guid> { Guid.NewGuid() }),
+            Status = "Completed",
+            CreatedAt = DateTimeOffset.UtcNow,
+            ShareToken = shareToken,
+            IsShared = shareToken != null,
+            Rsvps =
+            {
+                new GameNightRsvpEntity
+                {
+                    Id = Guid.NewGuid(), EventId = eventId, UserId = participant,
+                    Status = "Accepted", CreatedAt = DateTimeOffset.UtcNow
+                }
+            },
+        });
+        await _dbContext.SaveChangesAsync(Ct);
+        return (eventId, organizer, participant);
+    }
+
+    private static byte[] MakePngBytes()
+    {
+        using var image = new MagickImage(MagickColors.Black, 10, 10) { Format = MagickFormat.Png };
+        return image.ToByteArray();
+    }
+
+    private async Task<GameNightPhotoUploadResult> UploadAsync(Guid eventId, Guid userId, byte[] bytes, bool ocr = false, string? caption = null)
+    {
+        using var scope = Sp.CreateScope();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+        return await mediator.Send(
+            new UploadGameNightPhotoCommand(eventId, userId, new MemoryStream(bytes), bytes.Length, "image/png", ocr, caption), Ct);
+    }
+
+    [Fact]
+    public async Task Upload_ByParticipant_ThenListedForOrganizer()
+    {
+        var (eventId, organizer, participant) = await SeedAsync();
+
+        var result = await UploadAsync(eventId, participant, MakePngBytes(), caption: "Vittoria!");
+        result.WasDeduplicated.Should().BeFalse();
+
+        using var scope = Sp.CreateScope();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+        var photos = await mediator.Send(new GetGameNightPhotosQuery(eventId, organizer), Ct);
+
+        photos.Should().HaveCount(1);
+        photos[0].Caption.Should().Be("Vittoria!");
+        photos[0].UploadedByUserId.Should().Be(participant);
+    }
+
+    [Fact]
+    public async Task Upload_ByNonParticipant_ThrowsForbidden()
+    {
+        var (eventId, _, _) = await SeedAsync();
+        var stranger = Guid.NewGuid();
+
+        var act = () => UploadAsync(eventId, stranger, MakePngBytes());
+
+        await act.Should().ThrowAsync<ForbiddenException>();
+    }
+
+    [Fact]
+    public async Task List_ByNonParticipant_ThrowsForbidden()
+    {
+        var (eventId, organizer, _) = await SeedAsync();
+        await UploadAsync(eventId, organizer, MakePngBytes());
+
+        using var scope = Sp.CreateScope();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+        var act = () => mediator.Send(new GetGameNightPhotosQuery(eventId, Guid.NewGuid()), Ct);
+
+        await act.Should().ThrowAsync<ForbiddenException>();
+    }
+
+    [Fact]
+    public async Task Upload_SameBytesTwice_DeduplicatesToOneRow()
+    {
+        var (eventId, organizer, _) = await SeedAsync();
+        var bytes = MakePngBytes();
+
+        var first = await UploadAsync(eventId, organizer, bytes);
+        var second = await UploadAsync(eventId, organizer, bytes);
+
+        first.WasDeduplicated.Should().BeFalse();
+        second.WasDeduplicated.Should().BeTrue();
+        second.PhotoId.Should().Be(first.PhotoId);
+
+        var rows = await _dbContext.GameNightPhotos.Where(p => p.GameNightId == eventId).CountAsync(Ct);
+        rows.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task SharedPhotos_KnownToken_ReturnsList_UnknownToken_ThrowsNotFound()
+    {
+        var (eventId, organizer, _) = await SeedAsync(shareToken: "public-token");
+        await UploadAsync(eventId, organizer, MakePngBytes());
+
+        using var scope = Sp.CreateScope();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+        var shared = await mediator.Send(new GetGameNightPhotosByShareTokenQuery("public-token"), Ct);
+        shared.Should().HaveCount(1);
+
+        var act = () => mediator.Send(new GetGameNightPhotosByShareTokenQuery("nope"), Ct);
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+
+    [Fact]
+    public async Task Delete_ByUploader_RemovesRow()
+    {
+        var (eventId, _, participant) = await SeedAsync();
+        var uploaded = await UploadAsync(eventId, participant, MakePngBytes());
+
+        using var scope = Sp.CreateScope();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+        await mediator.Send(new DeleteGameNightPhotoCommand(eventId, uploaded.PhotoId, participant), Ct);
+
+        var rows = await _dbContext.GameNightPhotos.Where(p => p.GameNightId == eventId).CountAsync(Ct);
+        rows.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Delete_ByNonOwner_ThrowsForbidden()
+    {
+        var (eventId, _, participant) = await SeedAsync();
+        var uploaded = await UploadAsync(eventId, participant, MakePngBytes());
+        // A second participant who is neither the uploader nor the organizer.
+        var otherUser = Guid.NewGuid();
+
+        using var scope = Sp.CreateScope();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+        var act = () => mediator.Send(new DeleteGameNightPhotoCommand(eventId, uploaded.PhotoId, otherUser), Ct);
+
+        await act.Should().ThrowAsync<ForbiddenException>();
+    }
+}

--- a/apps/web/src/app/(authenticated)/game-nights/[id]/summary/_components/NightSummaryClientView.tsx
+++ b/apps/web/src/app/(authenticated)/game-nights/[id]/summary/_components/NightSummaryClientView.tsx
@@ -4,14 +4,20 @@ import { useCallback, useState } from 'react';
 
 import { useRouter } from 'next/navigation';
 
+import { GameNightPhotoGallery } from '@/components/features/game-nights/photos/GameNightPhotoGallery';
+import { GameNightPhotoUploadDialog } from '@/components/features/game-nights/photos/GameNightPhotoUploadDialog';
 import { NightSummaryView } from '@/components/features/game-nights/summary';
 import { toNightSummaryViewModel } from '@/components/features/game-nights/summary/night-summary-adapter';
+import { useCurrentUser } from '@/hooks/queries/useCurrentUser';
 import {
+  useDeleteGameNightPhoto,
+  useGameNightPhotos,
   useGameNightSummary,
   useGenerateGameNightShareToken,
   useSetGameNightArchived,
 } from '@/hooks/queries/useGameNights';
 import { useTranslation } from '@/hooks/useTranslation';
+import type { GameNightPhotoDto } from '@/lib/api/schemas/game-nights.schemas';
 
 export interface NightSummaryClientViewProps {
   readonly nightId: string;
@@ -22,12 +28,26 @@ export function NightSummaryClientView({ nightId }: NightSummaryClientViewProps)
   const { t, locale } = useTranslation();
 
   const summaryQuery = useGameNightSummary(nightId);
+  const photosQuery = useGameNightPhotos(nightId);
   const generateShare = useGenerateGameNightShareToken();
   const setArchived = useSetGameNightArchived();
+  const deletePhoto = useDeleteGameNightPhoto(nightId);
+  const { data: currentUser } = useCurrentUser();
 
   const [shareSuccess, setShareSuccess] = useState<{ visible: boolean; subline?: string }>({
     visible: false,
   });
+  const [uploadOpen, setUploadOpen] = useState(false);
+
+  const isViewerOrganizer = summaryQuery.data?.isViewerOrganizer ?? false;
+  const canDeletePhoto = useCallback(
+    (photo: GameNightPhotoDto) => isViewerOrganizer || photo.uploadedByUserId === currentUser?.id,
+    [isViewerOrganizer, currentUser?.id]
+  );
+  const handleDeletePhoto = useCallback(
+    (photoId: string) => deletePhoto.mutate(photoId),
+    [deletePhoto]
+  );
 
   const handleShare = useCallback(() => {
     generateShare.mutate(nightId, {
@@ -78,18 +98,33 @@ export function NightSummaryClientView({ nightId }: NightSummaryClientViewProps)
   });
 
   return (
-    <NightSummaryView
-      night={night}
-      mvp={mvp}
-      games={games}
-      eventsCount={eventsCount}
-      archived={summaryQuery.data.isArchived}
-      shareSuccess={shareSuccess}
-      onShare={handleShare}
-      onArchive={handleArchive}
-      onUnarchive={handleUnarchive}
-      onGoToList={handleGoToList}
-      onJumpToSession={handleJumpToSession}
-    />
+    <div className="flex flex-col gap-6">
+      <NightSummaryView
+        night={night}
+        mvp={mvp}
+        games={games}
+        eventsCount={eventsCount}
+        archived={summaryQuery.data.isArchived}
+        shareSuccess={shareSuccess}
+        onShare={handleShare}
+        onArchive={handleArchive}
+        onUnarchive={handleUnarchive}
+        onGoToList={handleGoToList}
+        onJumpToSession={handleJumpToSession}
+      />
+
+      <GameNightPhotoGallery
+        photos={photosQuery.data ?? []}
+        onAddPhoto={() => setUploadOpen(true)}
+        onDeletePhoto={handleDeletePhoto}
+        canDeletePhoto={canDeletePhoto}
+      />
+
+      <GameNightPhotoUploadDialog
+        gameNightId={nightId}
+        open={uploadOpen}
+        onClose={() => setUploadOpen(false)}
+      />
+    </div>
   );
 }

--- a/apps/web/src/app/(authenticated)/game-nights/[id]/summary/_components/__tests__/NightSummaryClientView.test.tsx
+++ b/apps/web/src/app/(authenticated)/game-nights/[id]/summary/_components/__tests__/NightSummaryClientView.test.tsx
@@ -12,6 +12,20 @@ vi.mock('@/hooks/queries/useGameNights', () => ({
   useGameNightSummary: () => summaryMock(),
   useGenerateGameNightShareToken: () => ({ mutate: generateMock }),
   useSetGameNightArchived: () => ({ mutate: archiveMock }),
+  useGameNightPhotos: () => ({ data: [] }),
+  useDeleteGameNightPhoto: () => ({ mutate: vi.fn() }),
+}));
+
+vi.mock('@/hooks/queries/useCurrentUser', () => ({
+  useCurrentUser: () => ({ data: { id: 'org-1' } }),
+}));
+
+// Stub the photo subsystem — its own tests cover it; keep this test on summary wiring.
+vi.mock('@/components/features/game-nights/photos/GameNightPhotoGallery', () => ({
+  GameNightPhotoGallery: () => <div data-testid="photo-gallery" />,
+}));
+vi.mock('@/components/features/game-nights/photos/GameNightPhotoUploadDialog', () => ({
+  GameNightPhotoUploadDialog: () => null,
 }));
 
 vi.mock('@/hooks/useTranslation', () => ({

--- a/apps/web/src/components/features/game-nights/photos/GameNightPhotoGallery.tsx
+++ b/apps/web/src/components/features/game-nights/photos/GameNightPhotoGallery.tsx
@@ -1,0 +1,181 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+
+import clsx from 'clsx';
+
+import { Dialog, DialogContent, DialogTitle } from '@/components/ui/overlays/dialog';
+import { useTranslation } from '@/hooks/useTranslation';
+import type { GameNightPhotoDto } from '@/lib/api/schemas/game-nights.schemas';
+
+export interface GameNightPhotoGalleryProps {
+  photos: readonly GameNightPhotoDto[];
+  /** When provided, renders an "Add photo" affordance. */
+  onAddPhoto?: () => void;
+  /** When provided, renders a per-photo delete affordance. */
+  onDeletePhoto?: (photoId: string) => void;
+  /** Gates the delete affordance per-photo (e.g. organizer or uploader). Defaults to all. */
+  canDeletePhoto?: (photo: GameNightPhotoDto) => boolean;
+  className?: string;
+}
+
+/**
+ * Recap photo gallery for a game night summary (#2724). Thumbnail grid + lightbox.
+ * Self-contained (i18n via useTranslation) so it drops into both the authenticated
+ * and the public shared summary views.
+ */
+export function GameNightPhotoGallery({
+  photos,
+  onAddPhoto,
+  onDeletePhoto,
+  canDeletePhoto,
+  className,
+}: GameNightPhotoGalleryProps): React.JSX.Element {
+  const { t } = useTranslation();
+  const [openIndex, setOpenIndex] = useState<number | null>(null);
+
+  const close = useCallback(() => setOpenIndex(null), []);
+  const prev = useCallback(
+    () => setOpenIndex(i => (i === null ? null : (i - 1 + photos.length) % photos.length)),
+    [photos.length]
+  );
+  const next = useCallback(
+    () => setOpenIndex(i => (i === null ? null : (i + 1) % photos.length)),
+    [photos.length]
+  );
+
+  const fallbackAlt = t('gameNightDetail.photos.photoAltFallback');
+  const active = openIndex !== null ? photos[openIndex] : null;
+
+  const addButton = onAddPhoto ? (
+    <button
+      type="button"
+      onClick={onAddPhoto}
+      className="rounded-md border border-border bg-card px-3 py-1.5 text-sm font-bold text-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+    >
+      + {t('gameNightDetail.photos.addCta')}
+    </button>
+  ) : null;
+
+  if (photos.length === 0) {
+    return (
+      <section
+        data-slot="game-night-photos"
+        data-empty="true"
+        className={clsx('flex flex-col gap-2', className)}
+      >
+        <div className="flex items-center justify-between">
+          <h2 className="font-display text-base font-extrabold text-foreground">
+            <span aria-hidden="true" className="mr-1.5">
+              📷
+            </span>
+            {t('gameNightDetail.photos.title')}
+          </h2>
+          {addButton}
+        </div>
+        <div
+          role="status"
+          className="flex flex-col items-center gap-2 rounded-lg border border-dashed border-border bg-card px-4 py-8 text-center"
+        >
+          <span aria-hidden="true" className="text-3xl">
+            📷
+          </span>
+          <p className="text-sm font-extrabold text-foreground">
+            {t('gameNightDetail.photos.emptyTitle')}
+          </p>
+          <p className="text-xs text-muted-foreground">
+            {t('gameNightDetail.photos.emptyDescription')}
+          </p>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section data-slot="game-night-photos" className={clsx('flex flex-col gap-2', className)}>
+      <div className="flex items-center justify-between">
+        <h2 className="font-display text-base font-extrabold text-foreground">
+          <span aria-hidden="true" className="mr-1.5">
+            📷
+          </span>
+          {t('gameNightDetail.photos.title')}
+        </h2>
+        {addButton}
+      </div>
+
+      <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+        {photos.map((p, i) => {
+          const alt = p.caption ?? fallbackAlt;
+          return (
+            <div key={p.id} className="group relative aspect-square">
+              <button
+                type="button"
+                onClick={() => setOpenIndex(i)}
+                aria-label={alt}
+                className="h-full w-full overflow-hidden rounded-md border border-border bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                {/* eslint-disable-next-line @next/next/no-img-element -- thumbnail tile */}
+                <img
+                  src={p.thumbnailUrl ?? p.photoUrl}
+                  alt=""
+                  aria-hidden="true"
+                  loading="lazy"
+                  className="h-full w-full object-cover transition-transform group-hover:scale-105"
+                />
+              </button>
+              {onDeletePhoto && (!canDeletePhoto || canDeletePhoto(p)) && (
+                <button
+                  type="button"
+                  onClick={() => onDeletePhoto(p.id)}
+                  aria-label={t('gameNightDetail.photos.deleteCta')}
+                  className="absolute right-1 top-1 hidden h-6 w-6 items-center justify-center rounded-full bg-background/80 text-sm font-bold text-foreground shadow group-hover:flex focus-visible:flex focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                >
+                  ×
+                </button>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      <Dialog open={active !== null} onOpenChange={o => !o && close()}>
+        <DialogContent className="max-w-3xl">
+          <DialogTitle className="sr-only">{active?.caption ?? fallbackAlt}</DialogTitle>
+          {active && (
+            <div className="flex flex-col gap-3">
+              {/* eslint-disable-next-line @next/next/no-img-element -- full-res lightbox */}
+              <img
+                src={active.photoUrl}
+                alt={active.caption ?? fallbackAlt}
+                className="max-h-[70vh] w-full rounded-md object-contain"
+              />
+              {active.caption && (
+                <p className="text-sm font-medium text-foreground">{active.caption}</p>
+              )}
+              {photos.length > 1 && (
+                <div className="flex justify-between">
+                  <button
+                    type="button"
+                    onClick={prev}
+                    aria-label={t('gameNightDetail.photos.prev')}
+                    className="rounded-md px-3 py-1.5 text-sm font-bold text-foreground hover:bg-muted"
+                  >
+                    ← {t('gameNightDetail.photos.prev')}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={next}
+                    aria-label={t('gameNightDetail.photos.next')}
+                    className="rounded-md px-3 py-1.5 text-sm font-bold text-foreground hover:bg-muted"
+                  >
+                    {t('gameNightDetail.photos.next')} →
+                  </button>
+                </div>
+              )}
+            </div>
+          )}
+        </DialogContent>
+      </Dialog>
+    </section>
+  );
+}

--- a/apps/web/src/components/features/game-nights/photos/GameNightPhotoUploadDialog.tsx
+++ b/apps/web/src/components/features/game-nights/photos/GameNightPhotoUploadDialog.tsx
@@ -1,0 +1,161 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+import { toast } from 'sonner';
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from '@/components/ui/overlays/dialog';
+import { Button } from '@/components/ui/primitives/button';
+import { useUploadGameNightPhoto } from '@/hooks/queries/useGameNights';
+import { useTranslation } from '@/hooks/useTranslation';
+
+const MAX_BYTES = 5 * 1024 * 1024; // 5MB (matches the BE cap)
+const ACCEPTED_MIME = ['image/jpeg', 'image/png', 'image/webp'];
+
+export interface GameNightPhotoUploadDialogProps {
+  gameNightId: string;
+  open: boolean;
+  onClose: () => void;
+}
+
+export function GameNightPhotoUploadDialog({
+  gameNightId,
+  open,
+  onClose,
+}: GameNightPhotoUploadDialogProps): React.JSX.Element {
+  const { t } = useTranslation();
+  const [file, setFile] = useState<File | null>(null);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [caption, setCaption] = useState('');
+  const [extractScore, setExtractScore] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const upload = useUploadGameNightPhoto(gameNightId);
+
+  // Object-URL preview with proper revocation (avoid per-render leaks).
+  useEffect(() => {
+    if (!file || typeof URL.createObjectURL !== 'function') {
+      setPreviewUrl(null);
+      return;
+    }
+    const url = URL.createObjectURL(file);
+    setPreviewUrl(url);
+    return () => URL.revokeObjectURL(url);
+  }, [file]);
+
+  const reset = useCallback(() => {
+    setFile(null);
+    setCaption('');
+    setExtractScore(false);
+    setError(null);
+  }, []);
+
+  const handleSelect = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      setError(null);
+      const selected = e.target.files?.[0] ?? null;
+      if (!selected) return;
+      if (!ACCEPTED_MIME.includes(selected.type)) {
+        setError(t('gameNightDetail.photos.badFormat'));
+        return;
+      }
+      if (selected.size > MAX_BYTES) {
+        setError(t('gameNightDetail.photos.tooLarge'));
+        return;
+      }
+      setFile(selected);
+    },
+    [t]
+  );
+
+  const handleUpload = useCallback(async () => {
+    if (!file) return;
+    setError(null);
+    try {
+      const res = await upload.mutateAsync({
+        file,
+        caption: caption || undefined,
+        extractScoreFromPhoto: extractScore || undefined,
+      });
+      if (res.wasDeduplicated) {
+        toast.info(t('gameNightDetail.photos.dedupToast'));
+      } else if (res.ocrText) {
+        toast.success(`${t('gameNightDetail.photos.ocrResultTitle')}: ${res.ocrText}`);
+      }
+      reset();
+      onClose();
+    } catch {
+      setError(t('gameNightDetail.photos.uploadError'));
+    }
+  }, [file, caption, extractScore, upload, t, reset, onClose]);
+
+  return (
+    <Dialog open={open} onOpenChange={o => !o && onClose()}>
+      <DialogContent>
+        <DialogTitle>{t('gameNightDetail.photos.dialogTitle')}</DialogTitle>
+        <DialogDescription>{t('gameNightDetail.photos.dialogDescription')}</DialogDescription>
+
+        <label className="block">
+          <span className="text-sm font-medium">{t('gameNightDetail.photos.selectLabel')}</span>
+          <input
+            type="file"
+            accept="image/jpeg,image/png,image/webp"
+            onChange={handleSelect}
+            aria-label={t('gameNightDetail.photos.selectLabel')}
+            className="mt-1 block w-full"
+          />
+        </label>
+
+        {previewUrl && (
+          // eslint-disable-next-line @next/next/no-img-element -- local object-URL preview
+          <img
+            src={previewUrl}
+            alt={t('gameNightDetail.photos.previewAlt')}
+            className="max-h-48 w-full rounded-md object-contain"
+          />
+        )}
+
+        <label className="block">
+          <span className="text-sm font-medium">{t('gameNightDetail.photos.captionLabel')}</span>
+          <input
+            type="text"
+            value={caption}
+            maxLength={500}
+            onChange={e => setCaption(e.target.value)}
+            placeholder={t('gameNightDetail.photos.captionPlaceholder')}
+            aria-label={t('gameNightDetail.photos.captionLabel')}
+            className="mt-1 block w-full rounded-md border border-border bg-card px-3 py-1.5 text-sm"
+          />
+        </label>
+
+        <label className="flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={extractScore}
+            onChange={e => setExtractScore(e.target.checked)}
+            aria-label={t('gameNightDetail.photos.extractScoreLabel')}
+          />
+          {t('gameNightDetail.photos.extractScoreLabel')}
+        </label>
+
+        {error && (
+          <p role="alert" className="text-sm text-destructive">
+            {error}
+          </p>
+        )}
+
+        <div className="flex justify-end gap-2 pt-2">
+          <Button onClick={handleUpload} disabled={!file || upload.isPending}>
+            {upload.isPending
+              ? t('gameNightDetail.photos.uploading')
+              : t('gameNightDetail.photos.uploadCta')}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/features/game-nights/photos/__tests__/GameNightPhotoGallery.test.tsx
+++ b/apps/web/src/components/features/game-nights/photos/__tests__/GameNightPhotoGallery.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+import type { GameNightPhotoDto } from '@/lib/api/schemas/game-nights.schemas';
+
+import { GameNightPhotoGallery } from '../GameNightPhotoGallery';
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => ({ t: (k: string) => k, locale: 'it-IT' }),
+}));
+
+const photos: GameNightPhotoDto[] = [
+  {
+    id: 'a',
+    photoUrl: 'http://x/a.webp',
+    thumbnailUrl: null,
+    caption: 'board',
+    uploadedByUserId: 'u1',
+    uploadedAt: '2026-06-20T09:00:00Z',
+  },
+  {
+    id: 'b',
+    photoUrl: 'http://x/b.webp',
+    thumbnailUrl: 'http://x/b-thumb.webp',
+    caption: null,
+    uploadedByUserId: 'u2',
+    uploadedAt: '2026-06-20T10:00:00Z',
+  },
+];
+
+describe('GameNightPhotoGallery', () => {
+  it('renders the empty state', () => {
+    render(<GameNightPhotoGallery photos={[]} />);
+    const section = screen.getByRole('status');
+    expect(section).toBeInTheDocument();
+    expect(screen.getByText('gameNightDetail.photos.emptyTitle')).toBeInTheDocument();
+  });
+
+  it('renders a tile per photo', () => {
+    render(<GameNightPhotoGallery photos={photos} />);
+    // Each tile is a button labelled by caption (or the fallback for the captionless one).
+    expect(screen.getByRole('button', { name: 'board' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'gameNightDetail.photos.photoAltFallback' })
+    ).toBeInTheDocument();
+  });
+
+  it('opens the lightbox on tile click', () => {
+    render(<GameNightPhotoGallery photos={photos} />);
+    fireEvent.click(screen.getByRole('button', { name: 'board' }));
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByAltText('board')).toBeInTheDocument();
+  });
+
+  it('shows an Add button that calls onAddPhoto', () => {
+    const onAddPhoto = vi.fn();
+    render(<GameNightPhotoGallery photos={photos} onAddPhoto={onAddPhoto} />);
+    fireEvent.click(screen.getByRole('button', { name: /gameNightDetail\.photos\.addCta/ }));
+    expect(onAddPhoto).toHaveBeenCalledOnce();
+  });
+
+  it('gates the delete affordance via canDeletePhoto and calls onDeletePhoto', () => {
+    const onDeletePhoto = vi.fn();
+    render(
+      <GameNightPhotoGallery
+        photos={photos}
+        onDeletePhoto={onDeletePhoto}
+        canDeletePhoto={p => p.uploadedByUserId === 'u1'}
+      />
+    );
+    const deleteButtons = screen.getAllByRole('button', {
+      name: 'gameNightDetail.photos.deleteCta',
+    });
+    // Only photo 'a' (uploadedByUserId u1) is deletable.
+    expect(deleteButtons).toHaveLength(1);
+    fireEvent.click(deleteButtons[0]);
+    expect(onDeletePhoto).toHaveBeenCalledWith('a');
+  });
+});

--- a/apps/web/src/components/features/game-nights/photos/__tests__/GameNightPhotoUploadDialog.test.tsx
+++ b/apps/web/src/components/features/game-nights/photos/__tests__/GameNightPhotoUploadDialog.test.tsx
@@ -1,0 +1,97 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { toast } from 'sonner';
+
+import { api } from '@/lib/api';
+
+import { GameNightPhotoUploadDialog } from '../GameNightPhotoUploadDialog';
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => ({ t: (key: string) => key, locale: 'it-IT' }),
+}));
+
+vi.mock('sonner', () => ({
+  toast: { info: vi.fn(), success: vi.fn(), error: vi.fn() },
+}));
+
+function wrap(node: ReactNode) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={client}>{node}</QueryClientProvider>;
+}
+
+describe('GameNightPhotoUploadDialog', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+  });
+
+  it('rejects files over 5MB', async () => {
+    render(wrap(<GameNightPhotoUploadDialog gameNightId="gn-1" open onClose={() => {}} />));
+    const big = new File([new Uint8Array(6 * 1024 * 1024)], 'big.jpg', { type: 'image/jpeg' });
+    fireEvent.change(screen.getByLabelText('gameNightDetail.photos.selectLabel'), {
+      target: { files: [big] },
+    });
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent('gameNightDetail.photos.tooLarge');
+  });
+
+  it('rejects an unsupported format', async () => {
+    render(wrap(<GameNightPhotoUploadDialog gameNightId="gn-1" open onClose={() => {}} />));
+    const gif = new File(['x'], 'anim.gif', { type: 'image/gif' });
+    fireEvent.change(screen.getByLabelText('gameNightDetail.photos.selectLabel'), {
+      target: { files: [gif] },
+    });
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent('gameNightDetail.photos.badFormat');
+  });
+
+  it('uploads a valid jpeg with the OCR flag and closes', async () => {
+    const spy = vi.spyOn(api.gameNights, 'uploadPhoto').mockResolvedValue({
+      photoId: '11111111-1111-1111-1111-111111111111',
+      photoUrl: 'u',
+      thumbnailUrl: null,
+      ocrText: '42',
+      wasDeduplicated: false,
+    });
+    const onClose = vi.fn();
+    render(wrap(<GameNightPhotoUploadDialog gameNightId="gn-1" open onClose={onClose} />));
+
+    const file = new File(['x'], 'ok.jpg', { type: 'image/jpeg' });
+    fireEvent.change(screen.getByLabelText('gameNightDetail.photos.selectLabel'), {
+      target: { files: [file] },
+    });
+    fireEvent.click(screen.getByLabelText('gameNightDetail.photos.extractScoreLabel'));
+    fireEvent.click(screen.getByRole('button', { name: 'gameNightDetail.photos.uploadCta' }));
+
+    await waitFor(() =>
+      expect(spy).toHaveBeenCalledWith(
+        'gn-1',
+        expect.any(File),
+        expect.objectContaining({ extractScoreFromPhoto: true })
+      )
+    );
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+
+  it('shows an info toast when the upload was deduplicated', async () => {
+    vi.spyOn(api.gameNights, 'uploadPhoto').mockResolvedValue({
+      photoId: '11111111-1111-1111-1111-111111111111',
+      photoUrl: 'u',
+      thumbnailUrl: null,
+      ocrText: null,
+      wasDeduplicated: true,
+    });
+    render(wrap(<GameNightPhotoUploadDialog gameNightId="gn-1" open onClose={() => {}} />));
+
+    const file = new File(['x'], 'dup.jpg', { type: 'image/jpeg' });
+    fireEvent.change(screen.getByLabelText('gameNightDetail.photos.selectLabel'), {
+      target: { files: [file] },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'gameNightDetail.photos.uploadCta' }));
+
+    await waitFor(() => expect(toast.info).toHaveBeenCalled());
+  });
+});

--- a/apps/web/src/components/features/game-nights/summary/SharedGameNightSummaryView.tsx
+++ b/apps/web/src/components/features/game-nights/summary/SharedGameNightSummaryView.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import { useSharedGameNightSummary } from '@/hooks/queries/useGameNights';
+import { useSharedGameNightPhotos, useSharedGameNightSummary } from '@/hooks/queries/useGameNights';
 import { useTranslation } from '@/hooks/useTranslation';
 
 import { toNightSummaryViewModel } from './night-summary-adapter';
 import { NightSummaryView } from './NightSummaryView';
+import { GameNightPhotoGallery } from '../photos/GameNightPhotoGallery';
 
 export interface SharedGameNightSummaryViewProps {
   readonly token: string;
@@ -17,6 +18,7 @@ export interface SharedGameNightSummaryViewProps {
 export function SharedGameNightSummaryView({ token }: SharedGameNightSummaryViewProps) {
   const { t, locale } = useTranslation();
   const query = useSharedGameNightSummary(token);
+  const photosQuery = useSharedGameNightPhotos(token);
 
   if (query.isLoading) {
     return (
@@ -37,12 +39,17 @@ export function SharedGameNightSummaryView({ token }: SharedGameNightSummaryView
   const { night, mvp, games, eventsCount } = toNightSummaryViewModel(query.data, { locale, t });
 
   return (
-    <NightSummaryView
-      night={night}
-      mvp={mvp}
-      games={games}
-      eventsCount={eventsCount}
-      archived={query.data.isArchived}
-    />
+    <div className="flex flex-col gap-6">
+      <NightSummaryView
+        night={night}
+        mvp={mvp}
+        games={games}
+        eventsCount={eventsCount}
+        archived={query.data.isArchived}
+      />
+      {(photosQuery.data?.length ?? 0) > 0 && (
+        <GameNightPhotoGallery photos={photosQuery.data ?? []} />
+      )}
+    </div>
   );
 }

--- a/apps/web/src/components/features/game-nights/summary/__tests__/SharedGameNightSummaryView.test.tsx
+++ b/apps/web/src/components/features/game-nights/summary/__tests__/SharedGameNightSummaryView.test.tsx
@@ -4,9 +4,15 @@ import { render, screen } from '@testing-library/react';
 import { SharedGameNightSummaryView } from '../SharedGameNightSummaryView';
 
 const sharedMock = vi.fn();
+const sharedPhotosMock = vi.fn();
 
 vi.mock('@/hooks/queries/useGameNights', () => ({
   useSharedGameNightSummary: () => sharedMock(),
+  useSharedGameNightPhotos: () => sharedPhotosMock(),
+}));
+
+vi.mock('../../photos/GameNightPhotoGallery', () => ({
+  GameNightPhotoGallery: () => <div data-testid="photo-gallery" />,
 }));
 
 vi.mock('@/hooks/useTranslation', () => ({
@@ -46,6 +52,7 @@ const dto = {
 beforeEach(() => {
   vi.clearAllMocks();
   sharedMock.mockReturnValue({ data: dto, isLoading: false, isError: false });
+  sharedPhotosMock.mockReturnValue({ data: [], isLoading: false, isError: false });
 });
 
 describe('SharedGameNightSummaryView', () => {

--- a/apps/web/src/hooks/queries/useGameNights.ts
+++ b/apps/web/src/hooks/queries/useGameNights.ts
@@ -23,6 +23,8 @@ export const gameNightKeys = {
   rsvps: (id: string) => [...gameNightKeys.all, id, 'rsvps'] as const,
   voteTally: (id: string) => [...gameNightKeys.all, id, 'vote-tally'] as const,
   summary: (id: string) => [...gameNightKeys.all, id, 'summary'] as const,
+  photos: (id: string) => [...gameNightKeys.all, id, 'photos'] as const,
+  sharedPhotos: (token: string) => [...gameNightKeys.all, 'shared', token, 'photos'] as const,
 };
 
 export function useUpcomingGameNights(
@@ -212,6 +214,50 @@ export function useSetGameNightArchived() {
       api.gameNights.setArchived(id, archived),
     onSuccess: (_data, { id }) => {
       queryClient.invalidateQueries({ queryKey: gameNightKeys.summary(id) });
+    },
+  });
+}
+
+// ── Recap photo gallery — Issue #2724 ────────────────────────────────────
+
+export function useGameNightPhotos(id: string, options: { enabled?: boolean } = {}) {
+  const { enabled = true } = options;
+  return useQuery({
+    queryKey: gameNightKeys.photos(id),
+    queryFn: () => api.gameNights.getPhotos(id),
+    enabled: enabled && !!id,
+  });
+}
+
+export function useSharedGameNightPhotos(token: string) {
+  return useQuery({
+    queryKey: gameNightKeys.sharedPhotos(token),
+    queryFn: () => api.gameNights.getSharedPhotos(token),
+    enabled: !!token,
+    retry: false,
+  });
+}
+
+export function useUploadGameNightPhoto(id: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (vars: { file: Blob; caption?: string; extractScoreFromPhoto?: boolean }) =>
+      api.gameNights.uploadPhoto(id, vars.file, {
+        caption: vars.caption,
+        extractScoreFromPhoto: vars.extractScoreFromPhoto,
+      }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: gameNightKeys.photos(id) });
+    },
+  });
+}
+
+export function useDeleteGameNightPhoto(id: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (photoId: string) => api.gameNights.deletePhoto(id, photoId),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: gameNightKeys.photos(id) });
     },
   });
 }

--- a/apps/web/src/lib/api/clients/gameNightsClient.ts
+++ b/apps/web/src/lib/api/clients/gameNightsClient.ts
@@ -11,6 +11,8 @@ import {
   GameNightDtoSchema,
   GameNightLiveDtoSchema,
   GameNightRsvpDtoSchema,
+  GameNightPhotoDtoSchema,
+  GameNightPhotoUploadResultSchema,
   GameNightShareLinkDtoSchema,
   GameNightSummaryDtoSchema,
   GameNightVoteTallyDtoSchema,
@@ -20,6 +22,8 @@ import {
   type CreateGameNightInput,
   type GameNightDto,
   type GameNightLiveDto,
+  type GameNightPhotoDto,
+  type GameNightPhotoUploadResult,
   type GameNightRsvpDto,
   type GameNightShareLinkDto,
   type GameNightSummaryDto,
@@ -67,6 +71,15 @@ export interface GameNightsClient {
   generateShareToken(gameNightId: string): Promise<GameNightShareLinkDto>;
   revokeShareToken(gameNightId: string): Promise<void>;
   setArchived(gameNightId: string, archived: boolean): Promise<void>;
+  // Issue #2724 — recap photo gallery
+  getPhotos(gameNightId: string): Promise<GameNightPhotoDto[]>;
+  getSharedPhotos(token: string): Promise<GameNightPhotoDto[]>;
+  uploadPhoto(
+    gameNightId: string,
+    file: Blob,
+    opts?: { caption?: string; extractScoreFromPhoto?: boolean }
+  ): Promise<GameNightPhotoUploadResult>;
+  deletePhoto(gameNightId: string, photoId: string): Promise<void>;
 }
 
 export function createGameNightsClient({
@@ -219,6 +232,44 @@ export function createGameNightsClient({
 
     async setArchived(gameNightId, archived) {
       await httpClient.post(`/api/v1/game-nights/${gameNightId}/archive`, { archived });
+    },
+
+    async getPhotos(gameNightId) {
+      const data = await httpClient.get<GameNightPhotoDto[]>(
+        `/api/v1/game-nights/${gameNightId}/photos`
+      );
+      return GameNightPhotoDtoSchema.array().parse(data);
+    },
+
+    async getSharedPhotos(token) {
+      const data = await httpClient.get<GameNightPhotoDto[]>(
+        `/api/v1/game-nights/shared/${token}/photos`
+      );
+      return GameNightPhotoDtoSchema.array().parse(data);
+    },
+
+    // Multipart upload — raw fetch (httpClient does not support FormData). Relative URL
+    // through the Next.js proxy avoids CORS; credentials carry the session cookie.
+    async uploadPhoto(gameNightId, file, opts = {}) {
+      const form = new FormData();
+      form.append('file', file, file instanceof File ? file.name : 'photo.jpg');
+      if (opts.extractScoreFromPhoto) form.append('extractScoreFromPhoto', 'true');
+      if (opts.caption) form.append('caption', opts.caption);
+
+      const res = await fetch(`/api/v1/game-nights/${gameNightId}/photos`, {
+        method: 'POST',
+        body: form,
+        credentials: 'include',
+      });
+      if (!res.ok) {
+        const error = await res.json().catch(() => ({ message: 'Failed to upload photo' }));
+        throw new Error(error.error || error.message || 'Failed to upload photo');
+      }
+      return GameNightPhotoUploadResultSchema.parse(await res.json());
+    },
+
+    async deletePhoto(gameNightId, photoId) {
+      await httpClient.delete(`/api/v1/game-nights/${gameNightId}/photos/${photoId}`);
     },
   };
 }

--- a/apps/web/src/lib/api/schemas/game-nights.schemas.ts
+++ b/apps/web/src/lib/api/schemas/game-nights.schemas.ts
@@ -285,3 +285,23 @@ export type GameNightSummaryDto = z.infer<typeof GameNightSummaryDtoSchema>;
 
 export const GameNightShareLinkDtoSchema = z.object({ shareToken: z.string() });
 export type GameNightShareLinkDto = z.infer<typeof GameNightShareLinkDtoSchema>;
+
+// Issue #2724 — recap photo gallery
+export const GameNightPhotoDtoSchema = z.object({
+  id: z.string().uuid(),
+  photoUrl: z.string(),
+  thumbnailUrl: z.string().nullable(),
+  caption: z.string().nullable(),
+  uploadedByUserId: z.string().uuid(),
+  uploadedAt: z.string(),
+});
+export type GameNightPhotoDto = z.infer<typeof GameNightPhotoDtoSchema>;
+
+export const GameNightPhotoUploadResultSchema = z.object({
+  photoId: z.string().uuid(),
+  photoUrl: z.string(),
+  thumbnailUrl: z.string().nullable(),
+  ocrText: z.string().nullable(),
+  wasDeduplicated: z.boolean(),
+});
+export type GameNightPhotoUploadResult = z.infer<typeof GameNightPhotoUploadResultSchema>;

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -3874,6 +3874,30 @@
       "durationUnknown": "—",
       "shareCopied": "Link copied to clipboard",
       "shareError": "Could not generate the share link."
+    },
+    "photos": {
+      "title": "Game night photos",
+      "addCta": "Add photo",
+      "emptyTitle": "No photos yet",
+      "emptyDescription": "Add shots from the night: scoreboards, lucky rolls, cheers.",
+      "photoAltFallback": "Game night photo",
+      "deleteCta": "Delete photo",
+      "prev": "Previous",
+      "next": "Next",
+      "dialogTitle": "Upload a photo",
+      "dialogDescription": "JPEG, PNG or WebP up to 5 MB.",
+      "selectLabel": "Choose an image",
+      "previewAlt": "Preview of the selected photo",
+      "captionLabel": "Caption (optional)",
+      "captionPlaceholder": "e.g. Davide's photo-finish win",
+      "extractScoreLabel": "Extract the score from the photo (OCR)",
+      "uploadCta": "Upload",
+      "uploading": "Uploading…",
+      "uploadError": "Could not upload the photo. Please try again.",
+      "dedupToast": "This photo is already in the gallery.",
+      "ocrResultTitle": "Detected text",
+      "badFormat": "Unsupported format. Use JPEG, PNG or WebP.",
+      "tooLarge": "The photo exceeds 5 MB."
     }
   },
   "gameNightsIndex": {

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -3927,6 +3927,30 @@
       "durationUnknown": "—",
       "shareCopied": "Link copiato negli appunti",
       "shareError": "Impossibile generare il link di condivisione."
+    },
+    "photos": {
+      "title": "Foto della serata",
+      "addCta": "Aggiungi foto",
+      "emptyTitle": "Ancora nessuna foto",
+      "emptyDescription": "Aggiungi gli scatti della serata: tabelloni, tiri fortunati, brindisi.",
+      "photoAltFallback": "Foto della serata",
+      "deleteCta": "Elimina foto",
+      "prev": "Precedente",
+      "next": "Successiva",
+      "dialogTitle": "Carica una foto",
+      "dialogDescription": "JPEG, PNG o WebP fino a 5 MB.",
+      "selectLabel": "Scegli un'immagine",
+      "previewAlt": "Anteprima della foto selezionata",
+      "captionLabel": "Didascalia (opzionale)",
+      "captionPlaceholder": "Es. La vittoria di Davide al fotofinish",
+      "extractScoreLabel": "Estrai il punteggio dalla foto (OCR)",
+      "uploadCta": "Carica",
+      "uploading": "Caricamento…",
+      "uploadError": "Impossibile caricare la foto. Riprova.",
+      "dedupToast": "Foto già presente nella galleria.",
+      "ocrResultTitle": "Testo rilevato",
+      "badFormat": "Formato non supportato. Usa JPEG, PNG o WebP.",
+      "tooLarge": "La foto supera i 5 MB."
     }
   },
   "gameNightsIndex": {


### PR DESCRIPTION
## Sommario
Chiude #2724 — sottosistema completo della **galleria foto** per il riepilogo GameNight, mirror del pattern PlayRecord photos.

## Backend
- `GameNightPhotoEntity` standalone + config + migration `AddGameNightPhotos` (repo **tracked**, NON il detached `Update` dell'aggregate — lezione #2700), con unique index `(game_night_id, sha256)`.
- **Upload** command/handler: participant-guard (organizer o RSVP → 403), magic-byte validation, dedup SHA256, `IBlobStorageService.StoreAsync`, thumbnail best-effort + OCR opt-in (`IPhotoPreprocessor`), URL presigned. Race dedup concorrente `23505` → idempotente (niente 500).
- **Query** galleria (participant-scoped + shared-token anonimo) + **delete** (uploader/organizer). Endpoint: `POST/GET/DELETE /{id}/photos` + `GET /shared/{token}/photos`.
- `BlobCategory.GameNightPhoto` (prefix `game-night-photos/`).

## Frontend
- `gameNightsClient`: `uploadPhoto` (multipart raw fetch) + `getPhotos`/`getSharedPhotos`/`deletePhoto`; hook React Query; schema zod.
- `GameNightPhotoGallery` (griglia + lightbox, delete per-foto con gating organizer/uploader) + `GameNightPhotoUploadDialog` (caption/preview/OCR), innestati nella summary autenticata e nella vista pubblica shared. i18n it/en.

## Test
- **BE**: 16 unit + 7 integration (Testcontainers round-trip: upload/list/IDOR-403/dedup/share-token/delete).
- **FE**: 17 (gallery, upload dialog, wiring summary + shared).
- IDOR cross-tenant coperto (lezione #2349).

## DoD
- [x] Participant-guard + IDOR test su tutti gli endpoint entity-scoped
- [x] Migration pulita (solo `CreateTable` + 2 indici)
- [x] typecheck + lint FE puliti; backend build 0 errori
- [x] Nessun file fuori scope toccato

🤖 Generated with [Claude Code](https://claude.com/claude-code)