### PR TITLE
fix(agent): #2727 config save contract + settings tab persist + tutor redirect

### DIFF
--- a/apps/web/src/app/(authenticated)/agents/[id]/_components/AgentDetailView.tsx
+++ b/apps/web/src/app/(authenticated)/agents/[id]/_components/AgentDetailView.tsx
@@ -49,8 +49,9 @@ import {
   type SettingsState,
 } from '@/components/features/agent-detail';
 import { DetailPageContainer } from '@/components/layout/PageContainer';
+import { toast } from '@/components/layout/Toast';
 import { useAgent } from '@/hooks/queries/useAgent';
-import { useAgentConfig } from '@/hooks/queries/useAgentConfig';
+import { useAgentConfig, useUpdateAgentConfig } from '@/hooks/queries/useAgentConfig';
 import { useAgentKbDocs, useAgentThreads } from '@/hooks/queries/useAgentData';
 import { useTranslation } from '@/hooks/useTranslation';
 import { deriveAgentDetailUiState } from '@/lib/agents/agent-detail-state';
@@ -59,6 +60,7 @@ import {
   IS_VISUAL_TEST_BUILD,
   tryLoadVisualTestFixture,
 } from '@/lib/agents/agent-detail-visual-test-fixture';
+import { DEFAULT_AGENT_CONFIG } from '@/lib/api/schemas/agent-config.schemas';
 
 // ─── State override hatch (dev / visual-test only) ─────────────────────────
 
@@ -250,14 +252,14 @@ function mapSettingsState(
 
   const config = query.data;
   const resolvedConfig = {
-    strategy: config?.modelType ?? 'llama-3.3-70b-free',
+    strategy: config?.llmModel ?? 'llama-3.3-70b-free',
     parameters: config
       ? {
           temperature: config.temperature,
           maxTokens: config.maxTokens,
           personality: config.personality,
           detailLevel: config.detailLevel,
-          customInstructions: config.customInstructions,
+          customInstructions: config.personalNotes,
         }
       : {},
   };
@@ -374,6 +376,11 @@ export function AgentDetailView({ agentId }: AgentDetailViewProps): ReactElement
     gameIdForConfig || (agentId ?? ''), // fallback to agentId if no gameId
     configEnabled
   );
+
+  // BUG E (#2727): Settings tab Save persists the per-game agent config.
+  // NOTE: AgentSettingsForm is currently display-only (no editable inputs), so
+  // this round-trips the loaded config; field editability is a follow-up.
+  const updateConfig = useUpdateAgentConfig();
 
   // ── Shell renders (FSM cells 1, 2, 3, 4) ──────────────────────────────────
   if (effectiveKind === 'loading') {
@@ -654,7 +661,33 @@ export function AgentDetailView({ agentId }: AgentDetailViewProps): ReactElement
               state={settingsState}
               labels={settingsLabels}
               onSave={() => {
-                /* mutations handled by child */
+                if (updateConfig.isPending) return; // guard against double-fire
+                const gameId = agentQuery.data?.gameId;
+                // Config is per-game; a standalone agent (no real gameId) cannot
+                // be configured from this per-agent page.
+                if (!gameId) {
+                  toast.error(settingsLabels.saveError);
+                  return;
+                }
+                const current = configQueryGated.data;
+                // No custom config yet → persist defaults (mutation create path).
+                const request = current
+                  ? {
+                      llmModel: current.llmModel,
+                      temperature: current.temperature,
+                      maxTokens: current.maxTokens,
+                      personality: current.personality,
+                      detailLevel: current.detailLevel,
+                      personalNotes: current.personalNotes ?? null,
+                    }
+                  : { ...DEFAULT_AGENT_CONFIG, personalNotes: null };
+                updateConfig.mutate(
+                  { gameId, request },
+                  {
+                    onSuccess: () => toast.success(settingsLabels.saveSuccess),
+                    onError: () => toast.error(settingsLabels.saveError),
+                  }
+                );
               }}
               onCancel={() => {
                 /* no-op: form handles internally */

--- a/apps/web/src/app/(authenticated)/agents/[id]/_components/__tests__/AgentDetailView.test.tsx
+++ b/apps/web/src/app/(authenticated)/agents/[id]/_components/__tests__/AgentDetailView.test.tsx
@@ -128,9 +128,25 @@ const configMockState: MockConfigReturn = {
 };
 
 const useAgentConfigSpy = vi.fn<[string, boolean?], MockConfigReturn>();
+// BUG E (#2727): Settings tab Save must wire the update-config mutation.
+const updateConfigMutate = vi.fn();
 
 vi.mock('@/hooks/queries/useAgentConfig', () => ({
   useAgentConfig: (gameId: string, enabled?: boolean) => useAgentConfigSpy(gameId, enabled),
+  useUpdateAgentConfig: () => ({ mutate: updateConfigMutate, isPending: false }),
+}));
+
+// ─── Toast mock (BUG E #2727) ─────────────────────────────────────────────────
+
+const toastSuccess = vi.fn();
+const toastError = vi.fn();
+
+vi.mock('@/components/layout/Toast', () => ({
+  toast: {
+    success: (...args: unknown[]) => toastSuccess(...args),
+    error: (...args: unknown[]) => toastError(...args),
+    info: vi.fn(),
+  },
 }));
 
 // ─── Visual fixture mock ──────────────────────────────────────────────────────
@@ -318,6 +334,9 @@ function resetAll() {
   configMockState.refetch = vi.fn();
   useAgentConfigSpy.mockReset();
   useAgentConfigSpy.mockImplementation(() => ({ ...configMockState }));
+  updateConfigMutate.mockClear();
+  toastSuccess.mockClear();
+  toastError.mockClear();
 
   mockIsVisualTestBuild = false;
   mockFixtureData = null;
@@ -824,6 +843,99 @@ describe('AgentDetailView — FSM integration tests (Phase 0.5 contract, Wave C.
     expect(
       document.querySelector('[data-slot="agent-detail-settings-form"][data-settings-kind="error"]')
     ).toBeInTheDocument();
+
+    assertKbDocsNeverCalledWithBadGameId();
+  });
+
+  // ─── Settings tab: Save persists config (BUG E #2727) ──────────────────────
+  it('Settings tab Save wires the update-config mutation with per-game payload', () => {
+    useAgentSpy.mockImplementation(() => ({
+      data: makeAgent({ invocationCount: 5 }), // active + gameId → editable variant
+      isLoading: false,
+      isError: false,
+      isSuccess: true,
+      refetch: vi.fn(),
+    }));
+    useAgentConfigSpy.mockImplementation(() => ({
+      ...configMockState,
+      data: {
+        llmModel: 'llama-3.3-70b-free',
+        temperature: 0.7,
+        maxTokens: 4096,
+        personality: 'Amichevole',
+        detailLevel: 'Normale',
+        personalNotes: 'note personali',
+      },
+      isSuccess: true,
+    }));
+
+    renderWithIntl(<AgentDetailView agentId={VALID_AGENT_ID} />);
+
+    act(() => {
+      fireEvent.click(document.querySelector('[data-tab-key="settings"]')!);
+    });
+
+    const saveBtn = screen.getByRole('button', { name: 'Salva' });
+    act(() => {
+      fireEvent.click(saveBtn);
+    });
+
+    expect(updateConfigMutate).toHaveBeenCalledTimes(1);
+    expect(updateConfigMutate.mock.calls[0][0]).toEqual({
+      gameId: VALID_GAME_ID,
+      request: {
+        llmModel: 'llama-3.3-70b-free',
+        temperature: 0.7,
+        maxTokens: 4096,
+        personality: 'Amichevole',
+        detailLevel: 'Normale',
+        personalNotes: 'note personali',
+      },
+    });
+
+    assertKbDocsNeverCalledWithBadGameId();
+  });
+
+  // ─── Settings tab: Save on unconfigured active agent persists defaults ─────
+  it('Settings tab Save on an unconfigured active agent persists defaults, no error toast', () => {
+    // BUG E follow-up (#2727 review): an active agent with no saved config
+    // (getAgentConfig → null) must create the config from defaults on Save,
+    // NOT show a misleading "save error" toast.
+    useAgentSpy.mockImplementation(() => ({
+      data: makeAgent({ invocationCount: 5 }), // active + gameId
+      isLoading: false,
+      isError: false,
+      isSuccess: true,
+      refetch: vi.fn(),
+    }));
+    useAgentConfigSpy.mockImplementation(() => ({
+      ...configMockState,
+      data: null, // no custom config saved yet
+      isSuccess: true,
+    }));
+
+    renderWithIntl(<AgentDetailView agentId={VALID_AGENT_ID} />);
+
+    act(() => {
+      fireEvent.click(document.querySelector('[data-tab-key="settings"]')!);
+    });
+
+    const saveBtn = screen.getByRole('button', { name: 'Salva' });
+    act(() => {
+      fireEvent.click(saveBtn);
+    });
+
+    expect(toastError).not.toHaveBeenCalled();
+    expect(updateConfigMutate).toHaveBeenCalledTimes(1);
+    const payload = updateConfigMutate.mock.calls[0][0] as {
+      gameId: string;
+      request: Record<string, unknown>;
+    };
+    expect(payload.gameId).toBe(VALID_GAME_ID);
+    expect(payload.request.llmModel).toBe('llama-3.3-70b-free');
+    expect(payload.request.personality).toBe('Amichevole');
+    expect(payload.request.detailLevel).toBe('Normale');
+    expect(payload.request.personalNotes).toBeNull();
 
     assertKbDocsNeverCalledWithBadGameId();
   });

--- a/apps/web/src/components/library/AgentConfigModal.stories.tsx
+++ b/apps/web/src/components/library/AgentConfigModal.stories.tsx
@@ -26,7 +26,7 @@ const createMockQueryClient = (hasConfig = true) => {
   if (hasConfig) {
     queryClient.setQueryData(['agent-config', 'game-123'], {
       ...DEFAULT_AGENT_CONFIG,
-      customInstructions: 'Spiega sempre le regole come se fossi principiante',
+      personalNotes: 'Spiega sempre le regole come se fossi principiante',
     });
   }
 
@@ -72,7 +72,7 @@ export const Default: Story = {
     onClose: fn(),
   },
   decorators: [
-    (Story) => (
+    Story => (
       <QueryClientProvider client={createMockQueryClient(true)}>
         <Story />
       </QueryClientProvider>
@@ -88,7 +88,7 @@ export const NoExistingConfig: Story = {
     onClose: fn(),
   },
   decorators: [
-    (Story) => (
+    Story => (
       <QueryClientProvider client={createMockQueryClient(false)}>
         <Story />
       </QueryClientProvider>
@@ -104,7 +104,7 @@ export const LoadingConfig: Story = {
     onClose: fn(),
   },
   decorators: [
-    (Story) => {
+    Story => {
       const loadingClient = new QueryClient({
         defaultOptions: {
           queries: { retry: false, staleTime: Infinity },
@@ -128,7 +128,7 @@ export const ModelDropdownOpen: Story = {
     ...Default.args,
   },
   decorators: [
-    (Story) => (
+    Story => (
       <QueryClientProvider client={createMockQueryClient(true)}>
         <Story />
       </QueryClientProvider>
@@ -151,7 +151,7 @@ export const TemperatureHigh: Story = {
     ...Default.args,
   },
   decorators: [
-    (Story) => {
+    Story => {
       const client = createMockQueryClient(true);
       client.setQueryData(['agent-config', 'game-123'], {
         ...DEFAULT_AGENT_CONFIG,
@@ -171,7 +171,7 @@ export const TemperatureLow: Story = {
     ...Default.args,
   },
   decorators: [
-    (Story) => {
+    Story => {
       const client = createMockQueryClient(true);
       client.setQueryData(['agent-config', 'game-123'], {
         ...DEFAULT_AGENT_CONFIG,
@@ -195,11 +195,11 @@ export const PersonalityFriendly: Story = {
     ...Default.args,
   },
   decorators: [
-    (Story) => {
+    Story => {
       const client = createMockQueryClient(true);
       client.setQueryData(['agent-config', 'game-123'], {
         ...DEFAULT_AGENT_CONFIG,
-        personality: 'friendly',
+        personality: 'Amichevole',
       });
       return (
         <QueryClientProvider client={client}>
@@ -215,11 +215,11 @@ export const PersonalityProfessional: Story = {
     ...Default.args,
   },
   decorators: [
-    (Story) => {
+    Story => {
       const client = createMockQueryClient(true);
       client.setQueryData(['agent-config', 'game-123'], {
         ...DEFAULT_AGENT_CONFIG,
-        personality: 'professional',
+        personality: 'Professionale',
       });
       return (
         <QueryClientProvider client={client}>
@@ -235,11 +235,11 @@ export const PersonalityEnthusiastic: Story = {
     ...Default.args,
   },
   decorators: [
-    (Story) => {
+    Story => {
       const client = createMockQueryClient(true);
       client.setQueryData(['agent-config', 'game-123'], {
         ...DEFAULT_AGENT_CONFIG,
-        personality: 'enthusiastic',
+        personality: 'Umoristico',
       });
       return (
         <QueryClientProvider client={client}>
@@ -259,11 +259,11 @@ export const DetailBrief: Story = {
     ...Default.args,
   },
   decorators: [
-    (Story) => {
+    Story => {
       const client = createMockQueryClient(true);
       client.setQueryData(['agent-config', 'game-123'], {
         ...DEFAULT_AGENT_CONFIG,
-        detailLevel: 'brief',
+        detailLevel: 'Breve',
       });
       return (
         <QueryClientProvider client={client}>
@@ -279,11 +279,11 @@ export const DetailDetailed: Story = {
     ...Default.args,
   },
   decorators: [
-    (Story) => {
+    Story => {
       const client = createMockQueryClient(true);
       client.setQueryData(['agent-config', 'game-123'], {
         ...DEFAULT_AGENT_CONFIG,
-        detailLevel: 'detailed',
+        detailLevel: 'Dettagliato',
       });
       return (
         <QueryClientProvider client={client}>
@@ -303,11 +303,11 @@ export const WithCustomInstructions: Story = {
     ...Default.args,
   },
   decorators: [
-    (Story) => {
+    Story => {
       const client = createMockQueryClient(true);
       client.setQueryData(['agent-config', 'game-123'], {
         ...DEFAULT_AGENT_CONFIG,
-        customInstructions:
+        personalNotes:
           'Spiega sempre le regole come se fossi principiante. Usa esempi pratici per chiarire concetti complessi.',
       });
       return (
@@ -324,11 +324,11 @@ export const CustomInstructionsNearLimit: Story = {
     ...Default.args,
   },
   decorators: [
-    (Story) => {
+    Story => {
       const client = createMockQueryClient(true);
       client.setQueryData(['agent-config', 'game-123'], {
         ...DEFAULT_AGENT_CONFIG,
-        customInstructions: 'A'.repeat(950), // 950 chars, 50 remaining
+        personalNotes: 'A'.repeat(950), // 950 chars, 50 remaining
       });
       return (
         <QueryClientProvider client={client}>
@@ -348,7 +348,7 @@ export const HoverResetButton: Story = {
     ...Default.args,
   },
   decorators: [
-    (Story) => (
+    Story => (
       <QueryClientProvider client={createMockQueryClient(true)}>
         <Story />
       </QueryClientProvider>
@@ -367,7 +367,7 @@ export const HoverTestButton: Story = {
     ...Default.args,
   },
   decorators: [
-    (Story) => (
+    Story => (
       <QueryClientProvider client={createMockQueryClient(true)}>
         <Story />
       </QueryClientProvider>
@@ -386,7 +386,7 @@ export const HoverSaveButton: Story = {
     ...Default.args,
   },
   decorators: [
-    (Story) => (
+    Story => (
       <QueryClientProvider client={createMockQueryClient(true)}>
         <Story />
       </QueryClientProvider>
@@ -409,7 +409,7 @@ export const Mobile: Story = {
     ...Default.args,
   },
   decorators: [
-    (Story) => (
+    Story => (
       <QueryClientProvider client={createMockQueryClient(true)}>
         <Story />
       </QueryClientProvider>
@@ -430,7 +430,7 @@ export const Tablet: Story = {
     ...Default.args,
   },
   decorators: [
-    (Story) => (
+    Story => (
       <QueryClientProvider client={createMockQueryClient(true)}>
         <Story />
       </QueryClientProvider>
@@ -451,7 +451,7 @@ export const Desktop: Story = {
     ...Default.args,
   },
   decorators: [
-    (Story) => (
+    Story => (
       <QueryClientProvider client={createMockQueryClient(true)}>
         <Story />
       </QueryClientProvider>

--- a/apps/web/src/components/library/AgentConfigModal.tsx
+++ b/apps/web/src/components/library/AgentConfigModal.tsx
@@ -81,43 +81,43 @@ export function AgentConfigModal({ isOpen, onClose, gameId, gameTitle }: AgentCo
   }, [isOpen, configLoading, currentConfig]);
 
   // Form state
-  const [modelType, setModelType] = useState<AIModel>(DEFAULT_AGENT_CONFIG.modelType);
+  const [llmModel, setLlmModel] = useState<AIModel>(DEFAULT_AGENT_CONFIG.llmModel);
   const [temperature, setTemperature] = useState(DEFAULT_AGENT_CONFIG.temperature);
   const [maxTokens, setMaxTokens] = useState(DEFAULT_AGENT_CONFIG.maxTokens);
   const [personality, setPersonality] = useState<AgentPersonality>(
     DEFAULT_AGENT_CONFIG.personality
   );
   const [detailLevel, setDetailLevel] = useState<DetailLevel>(DEFAULT_AGENT_CONFIG.detailLevel);
-  const [customInstructions, setCustomInstructions] = useState('');
+  const [personalNotes, setPersonalNotes] = useState('');
 
   // Load current config when modal opens
   useEffect(() => {
     if (isOpen && currentConfig) {
-      setModelType(currentConfig.modelType);
+      setLlmModel(currentConfig.llmModel);
       setTemperature(currentConfig.temperature);
       setMaxTokens(currentConfig.maxTokens);
       setPersonality(currentConfig.personality);
       setDetailLevel(currentConfig.detailLevel);
-      setCustomInstructions(currentConfig.customInstructions || '');
+      setPersonalNotes(currentConfig.personalNotes || '');
     } else if (isOpen && !currentConfig) {
       // Reset to defaults if no config exists (inline to avoid dependency)
-      setModelType(DEFAULT_AGENT_CONFIG.modelType);
+      setLlmModel(DEFAULT_AGENT_CONFIG.llmModel);
       setTemperature(DEFAULT_AGENT_CONFIG.temperature);
       setMaxTokens(DEFAULT_AGENT_CONFIG.maxTokens);
       setPersonality(DEFAULT_AGENT_CONFIG.personality);
       setDetailLevel(DEFAULT_AGENT_CONFIG.detailLevel);
-      setCustomInstructions('');
+      setPersonalNotes('');
     }
   }, [isOpen, currentConfig]);
 
   const handleSave = async () => {
     const request: UpdateAgentConfigRequest = {
-      modelType,
+      llmModel,
       temperature,
       maxTokens,
       personality,
       detailLevel,
-      customInstructions: customInstructions || null,
+      personalNotes: personalNotes || null,
     };
 
     try {
@@ -134,12 +134,12 @@ export function AgentConfigModal({ isOpen, onClose, gameId, gameTitle }: AgentCo
   };
 
   const handleResetToDefault = () => {
-    setModelType(DEFAULT_AGENT_CONFIG.modelType);
+    setLlmModel(DEFAULT_AGENT_CONFIG.llmModel);
     setTemperature(DEFAULT_AGENT_CONFIG.temperature);
     setMaxTokens(DEFAULT_AGENT_CONFIG.maxTokens);
     setPersonality(DEFAULT_AGENT_CONFIG.personality);
     setDetailLevel(DEFAULT_AGENT_CONFIG.detailLevel);
-    setCustomInstructions('');
+    setPersonalNotes('');
     toast.info('Configurazione ripristinata ai valori predefiniti');
   };
 
@@ -253,7 +253,7 @@ export function AgentConfigModal({ isOpen, onClose, gameId, gameTitle }: AgentCo
               <Label htmlFor="model" className="text-base font-semibold">
                 🤖 Modello AI
               </Label>
-              <Select value={modelType} onValueChange={value => setModelType(value as AIModel)}>
+              <Select value={llmModel} onValueChange={value => setLlmModel(value as AIModel)}>
                 <SelectTrigger id="model">
                   <SelectValue />
                 </SelectTrigger>
@@ -266,7 +266,7 @@ export function AgentConfigModal({ isOpen, onClose, gameId, gameTitle }: AgentCo
                 </SelectContent>
               </Select>
               <p className="text-sm text-muted-foreground">
-                {MODEL_OPTIONS.find(m => m.value === modelType)?.description}
+                {MODEL_OPTIONS.find(m => m.value === llmModel)?.description}
               </p>
             </div>
 
@@ -365,13 +365,13 @@ export function AgentConfigModal({ isOpen, onClose, gameId, gameTitle }: AgentCo
               <Textarea
                 id="instructions"
                 placeholder="Es: Spiega sempre le regole come se fossi principiante"
-                value={customInstructions}
-                onChange={e => setCustomInstructions(e.target.value)}
+                value={personalNotes}
+                onChange={e => setPersonalNotes(e.target.value)}
                 maxLength={1000}
                 rows={4}
               />
               <div className="text-xs text-right text-muted-foreground">
-                {1000 - customInstructions.length} caratteri rimanenti
+                {1000 - personalNotes.length} caratteri rimanenti
               </div>
             </div>
           </div>

--- a/apps/web/src/components/library/MeepleLibraryGameCard.tsx
+++ b/apps/web/src/components/library/MeepleLibraryGameCard.tsx
@@ -128,7 +128,7 @@ export function MeepleLibraryGameCard({
   // Fetch agent configuration status
   const { data: agentConfig } = useAgentConfig(game.gameId, true);
   const agentConfigured = agentConfig !== null;
-  const agentModel = agentConfig?.modelType || 'default';
+  const agentModel = agentConfig?.llmModel || 'default';
 
   const toggleFavoriteMutation = useToggleLibraryFavorite();
 

--- a/apps/web/src/components/library/OwnershipConfirmationDialog.tsx
+++ b/apps/web/src/components/library/OwnershipConfirmationDialog.tsx
@@ -56,7 +56,11 @@ export function OwnershipConfirmationDialog({
     try {
       const result = await api.agents.quickCreateTutor(gameId, sharedGameId);
       onOpenChange(false);
-      router.push(`/chat/${result.chatThreadId}`);
+      // BUG B (#2727): the BE returns a placeholder chatThreadId (Guid.NewGuid,
+      // never persisted — chat-thread BC integration deferred), so navigating to
+      // /chat/{chatThreadId} lands on a non-existent thread. Send the user to the
+      // agent that was actually created instead.
+      router.push(`/agents/${result.agentId}`);
     } catch (error) {
       toast.error(error instanceof Error ? error.message : 'Impossibile creare il tutor. Riprova.');
     } finally {

--- a/apps/web/src/components/library/__tests__/OwnershipConfirmationDialog.test.tsx
+++ b/apps/web/src/components/library/__tests__/OwnershipConfirmationDialog.test.tsx
@@ -104,7 +104,10 @@ describe('OwnershipConfirmationDialog', () => {
     expect(screen.queryByRole('button', { name: /Crea Tutor veloce/i })).not.toBeInTheDocument();
   });
 
-  it('quick-create calls API and navigates to chat thread', async () => {
+  it('quick-create calls API and navigates to the created agent page', async () => {
+    // BUG B (#2727): the BE returns a placeholder chatThreadId (Guid.NewGuid,
+    // never persisted), so redirecting to /chat/{chatThreadId} lands on a dead
+    // thread. Redirect to the created agent's detail page instead.
     const user = userEvent.setup();
     render(
       <OwnershipConfirmationDialog
@@ -119,8 +122,9 @@ describe('OwnershipConfirmationDialog', () => {
 
     await waitFor(() => {
       expect(mockQuickCreateTutor).toHaveBeenCalledWith('game-1', 'shared-1');
-      expect(mockPush).toHaveBeenCalledWith('/chat/thread-1');
+      expect(mockPush).toHaveBeenCalledWith('/agents/agent-1');
     });
+    expect(mockPush).not.toHaveBeenCalledWith('/chat/thread-1');
   });
 
   it('Personalizza navigates to agent creation wizard', async () => {

--- a/apps/web/src/hooks/queries/useAgentConfig.ts
+++ b/apps/web/src/hooks/queries/useAgentConfig.ts
@@ -6,13 +6,15 @@
  * Provides caching and mutations for per-game agent customization.
  */
 
-import { useQuery, useMutation, useQueryClient, UseQueryResult, UseMutationResult } from '@tanstack/react-query';
-
 import {
-  api,
-  type AgentConfigDto,
-  type UpdateAgentConfigRequest,
-} from '@/lib/api';
+  useQuery,
+  useMutation,
+  useQueryClient,
+  UseQueryResult,
+  UseMutationResult,
+} from '@tanstack/react-query';
+
+import { api, type AgentConfigDto, type UpdateAgentConfigRequest } from '@/lib/api';
 
 /**
  * Query key factory for agent configuration queries
@@ -81,26 +83,14 @@ export function useUpdateAgentConfig(): UseMutationResult<
         agentConfigKeys.byGame(gameId)
       );
 
-      // Optimistically update cache
-      queryClient.setQueryData<AgentConfigDto>(agentConfigKeys.byGame(gameId), (old) => {
+      // Optimistically update cache. The BE config DTO (UserLibrary) is a flat
+      // record with no id/userId/gameId/timestamps, so the request payload IS
+      // the optimistic config shape.
+      queryClient.setQueryData<AgentConfigDto>(agentConfigKeys.byGame(gameId), old => {
         if (!old) {
-          // If no config exists, create optimistic one
-          const optimisticConfig: AgentConfigDto = {
-            id: 'temp-id',
-            userId: 'temp-user',
-            gameId,
-            ...request,
-            createdAt: new Date().toISOString(),
-            updatedAt: new Date().toISOString(),
-          };
-          return optimisticConfig;
+          return { ...request };
         }
-        // Update existing config
-        return {
-          ...old,
-          ...request,
-          updatedAt: new Date().toISOString(),
-        };
+        return { ...old, ...request };
       });
 
       return { previousConfig };

--- a/apps/web/src/lib/api/clients/__tests__/libraryClient.test.ts
+++ b/apps/web/src/lib/api/clients/__tests__/libraryClient.test.ts
@@ -333,12 +333,14 @@ describe('LibraryClient - Issue #3026', () => {
   });
 
   describe('Agent Configuration', () => {
+    // BE UserLibrary AgentConfigDto shape (flat, no id/userId/gameId/timestamps).
     const mockAgentConfig = {
-      id: 'config-123',
-      gameId: 'game-456',
-      agentDefinitionId: 'strategy',
-      modelName: 'gpt-4',
-      costEstimate: 0.05,
+      llmModel: 'llama-3.3-70b-free',
+      temperature: 0.7,
+      maxTokens: 4096,
+      personality: 'Amichevole',
+      detailLevel: 'Normale',
+      personalNotes: null,
     };
 
     describe('getAgentConfig', () => {
@@ -366,23 +368,57 @@ describe('LibraryClient - Issue #3026', () => {
     });
 
     describe('updateAgentConfig', () => {
-      it('should update agent configuration', async () => {
-        const updatedConfig = { ...mockAgentConfig, modelName: 'gpt-4-turbo' };
-        vi.mocked(mockHttpClient.put).mockResolvedValue(updatedConfig);
+      it('sends the BE-aligned request and returns the persisted customAgentConfig', async () => {
+        const persisted = {
+          llmModel: 'llama-3.3-70b',
+          temperature: 0.5,
+          maxTokens: 2048,
+          personality: 'Professionale',
+          detailLevel: 'Esaustivo',
+          personalNotes: 'gioco in coppia',
+        };
+        // BE PUT returns the full UserLibraryEntryDto with the config nested.
+        vi.mocked(mockHttpClient.put).mockResolvedValue({
+          id: 'entry-1',
+          customAgentConfig: persisted,
+        });
 
         const client = createLibraryClient({ httpClient: mockHttpClient });
-        const result = await client.updateAgentConfig('game-456', { modelName: 'gpt-4-turbo' });
+        const result = await client.updateAgentConfig('game-456', {
+          llmModel: 'llama-3.3-70b',
+          temperature: 0.5,
+          maxTokens: 2048,
+          personality: 'Professionale',
+          detailLevel: 'Esaustivo',
+          personalNotes: 'gioco in coppia',
+        });
 
-        expect(result.modelName).toBe('gpt-4-turbo');
+        expect(result).toEqual(persisted);
+        expect(mockHttpClient.put).toHaveBeenCalledWith(
+          '/api/v1/library/games/game-456/agent-config',
+          expect.objectContaining({
+            llmModel: 'llama-3.3-70b',
+            personality: 'Professionale',
+            detailLevel: 'Esaustivo',
+            personalNotes: 'gioco in coppia',
+          }),
+          expect.any(Object)
+        );
       });
 
-      it('should throw error when update fails', async () => {
-        vi.mocked(mockHttpClient.put).mockResolvedValue(null);
+      it('throws when the entry has no customAgentConfig', async () => {
+        vi.mocked(mockHttpClient.put).mockResolvedValue({ id: 'entry-1' });
 
         const client = createLibraryClient({ httpClient: mockHttpClient });
 
         await expect(
-          client.updateAgentConfig('game-456', { modelName: 'invalid' })
+          client.updateAgentConfig('game-456', {
+            llmModel: 'llama-3.3-70b',
+            temperature: 0.5,
+            maxTokens: 2048,
+            personality: 'Professionale',
+            detailLevel: 'Esaustivo',
+          })
         ).rejects.toThrow('Failed to update agent configuration');
       });
     });

--- a/apps/web/src/lib/api/clients/agentsClient.ts
+++ b/apps/web/src/lib/api/clients/agentsClient.ts
@@ -692,10 +692,11 @@ export function createAgentsClient({ httpClient }: CreateAgentsClientParams) {
     /**
      * Quick-create a tutor agent for a game after ownership declaration.
      * Uses pre-existing KB cards to instantly set up a chat-ready agent.
-     * POST /api/v1/agents/quick-create
+     * POST /api/v1/agents/quick-create (QuickCreateAgentCommand).
      * @param gameId - Game UUID
      * @param sharedGameId - Optional shared game UUID for catalog-linked games
-     * @todo BACKEND MISSING: No route registered for POST /api/v1/agents/quick-create. Throws on null response. See: endpoint audit 2026-04-15
+     * @remarks The response `chatThreadId` is a backend placeholder (chat-thread
+     * BC integration deferred) — do NOT navigate to it. Use `agentId` instead.
      */
     async quickCreateTutor(gameId: string, sharedGameId?: string): Promise<QuickCreateResult> {
       const body: { gameId: string; sharedGameId?: string } = { gameId };

--- a/apps/web/src/lib/api/clients/libraryClient.ts
+++ b/apps/web/src/lib/api/clients/libraryClient.ts
@@ -13,8 +13,10 @@ import { z } from 'zod';
 
 import {
   AgentConfigDtoSchema,
+  UpdateAgentConfigResponseSchema,
   type AgentConfigDto,
   type UpdateAgentConfigRequest,
+  type UpdateAgentConfigResponse,
 } from '../schemas/agent-config.schemas';
 import {
   EntityLinkDtoSchema,
@@ -433,7 +435,11 @@ export function createLibraryClient({ httpClient }: CreateLibraryClientParams): 
      */
     async createGameAgent(
       gameId: string,
-      request: { agentDefinitionId: string; strategyName: string; strategyParameters?: string | null }
+      request: {
+        agentDefinitionId: string;
+        strategyName: string;
+        strategyParameters?: string | null;
+      }
     ): Promise<unknown> {
       return httpClient.post<unknown>(`/api/v1/library/games/${gameId}/agent`, request);
     },
@@ -493,15 +499,17 @@ export function createLibraryClient({ httpClient }: CreateLibraryClientParams): 
       gameId: string,
       request: UpdateAgentConfigRequest
     ): Promise<AgentConfigDto> {
-      const data = await httpClient.put<AgentConfigDto>(
+      // PUT returns the full UserLibraryEntryDto; the persisted config lives in
+      // its `customAgentConfig` field (ConfigureGameAgentCommandHandler).
+      const entry = await httpClient.put<UpdateAgentConfigResponse>(
         `/api/v1/library/games/${gameId}/agent-config`,
         request,
-        AgentConfigDtoSchema
+        UpdateAgentConfigResponseSchema
       );
-      if (!data) {
+      if (!entry?.customAgentConfig) {
         throw new Error('Failed to update agent configuration');
       }
-      return data;
+      return entry.customAgentConfig;
     },
 
     /**

--- a/apps/web/src/lib/api/schemas/__tests__/agent-config.schemas.test.ts
+++ b/apps/web/src/lib/api/schemas/__tests__/agent-config.schemas.test.ts
@@ -1,0 +1,75 @@
+/**
+ * agent-config.schemas — BE-aligned contract tests (Issue #2727, BUG A)
+ *
+ * The PUT /api/v1/library/games/{gameId}/agent-config endpoint binds
+ * `AgentConfigDto(string LlmModel, double Temperature, int MaxTokens,
+ * string Personality, string DetailLevel, string? PersonalNotes)` and its
+ * FluentValidation validator only accepts the canonical Italian personality /
+ * detail-level values. The FE contract must match the BE, otherwise the save
+ * fails with HTTP 400/500 (see ConfigureGameAgentCommandValidator).
+ */
+import { describe, it, expect } from 'vitest';
+
+import {
+  UpdateAgentConfigRequestSchema,
+  AgentConfigDtoSchema,
+  DEFAULT_AGENT_CONFIG,
+} from '../agent-config.schemas';
+
+describe('agent-config.schemas — BE-aligned contract (#2727 BUG A)', () => {
+  it('request uses BE field names (llmModel, personalNotes)', () => {
+    const parsed = UpdateAgentConfigRequestSchema.parse({
+      llmModel: 'llama-3.3-70b-free',
+      temperature: 0.7,
+      maxTokens: 4096,
+      personality: 'Amichevole',
+      detailLevel: 'Normale',
+      personalNotes: 'gioco spesso in 4',
+    });
+
+    expect(parsed.llmModel).toBe('llama-3.3-70b-free');
+    expect(parsed.personalNotes).toBe('gioco spesso in 4');
+  });
+
+  it('personality/detailLevel accept BE canonical values and reject legacy English', () => {
+    expect(() =>
+      UpdateAgentConfigRequestSchema.parse({
+        llmModel: 'llama-3.3-70b-free',
+        temperature: 0.7,
+        maxTokens: 4096,
+        personality: 'Professionale',
+        detailLevel: 'Esaustivo',
+      })
+    ).not.toThrow();
+
+    expect(() =>
+      UpdateAgentConfigRequestSchema.parse({
+        llmModel: 'llama-3.3-70b-free',
+        temperature: 0.7,
+        maxTokens: 4096,
+        personality: 'friendly',
+        detailLevel: 'normal',
+      })
+    ).toThrow();
+  });
+
+  it('response mirrors BE AgentConfigDto shape (no id/userId/gameId/createdAt)', () => {
+    const parsed = AgentConfigDtoSchema.parse({
+      llmModel: 'google-gemini-pro',
+      temperature: 0.5,
+      maxTokens: 2048,
+      personality: 'Conciso',
+      detailLevel: 'Breve',
+      personalNotes: null,
+    });
+
+    expect(parsed.llmModel).toBe('google-gemini-pro');
+    expect(parsed.personality).toBe('Conciso');
+  });
+
+  it('DEFAULT_AGENT_CONFIG uses BE-aligned defaults', () => {
+    expect(DEFAULT_AGENT_CONFIG.llmModel).toBeDefined();
+    expect(DEFAULT_AGENT_CONFIG.personality).toBe('Amichevole');
+    expect(DEFAULT_AGENT_CONFIG.detailLevel).toBe('Normale');
+  });
+});

--- a/apps/web/src/lib/api/schemas/agent-config.schemas.ts
+++ b/apps/web/src/lib/api/schemas/agent-config.schemas.ts
@@ -22,68 +22,95 @@ export type AIModel = z.infer<typeof AIModelSchema>;
 
 /**
  * Agent Personality Types
+ *
+ * Canonical values are the Italian labels enforced by the backend
+ * ConfigureGameAgentCommandValidator (`ValidPersonalities`). The FE contract
+ * mirrors the BE exactly — sending legacy English values yields HTTP 400.
  */
 export const AgentPersonalitySchema = z.enum([
-  'formal', // Professional tone, detailed responses
-  'friendly', // Casual tone, practical examples
-  'expert', // Technical tone, advanced references
+  'Amichevole', // Casual tone, practical examples
+  'Professionale', // Professional, formal tone
+  'Umoristico', // Light, witty tone
+  'Conciso', // Short, direct answers
+  'Dettagliato', // In-depth, complete answers
 ]);
 
 export type AgentPersonality = z.infer<typeof AgentPersonalitySchema>;
 
 /**
  * Response Detail Level
+ *
+ * Canonical values are the Italian labels enforced by the backend
+ * ConfigureGameAgentCommandValidator (`ValidDetailLevels`).
  */
 export const DetailLevelSchema = z.enum([
-  'brief', // Short responses (1-2 sentences)
-  'normal', // Balanced responses (2-4 sentences)
-  'detailed', // Complete responses with examples
+  'Breve', // Short responses (1-2 sentences)
+  'Normale', // Balanced responses (2-4 sentences)
+  'Dettagliato', // Complete responses with examples
+  'Esaustivo', // Very thorough responses
 ]);
 
 export type DetailLevel = z.infer<typeof DetailLevelSchema>;
 
 /**
  * Agent Configuration Request (User -> Backend)
+ *
+ * Field names mirror the backend `AgentConfigDto` record
+ * (LlmModel / PersonalNotes) — camelCased on the wire.
  */
 export const UpdateAgentConfigRequestSchema = z.object({
-  modelType: AIModelSchema.default('llama-3.3-70b-free'),
+  llmModel: AIModelSchema.default('llama-3.3-70b-free'),
   temperature: z.number().min(0).max(2).default(0.7),
   maxTokens: z.number().min(512).max(8192).default(4096),
-  personality: AgentPersonalitySchema.default('friendly'),
-  detailLevel: DetailLevelSchema.default('normal'),
-  customInstructions: z.string().max(1000).nullable().optional(),
+  personality: AgentPersonalitySchema.default('Amichevole'),
+  detailLevel: DetailLevelSchema.default('Normale'),
+  personalNotes: z.string().max(1000).nullable().optional(),
 });
 
 export type UpdateAgentConfigRequest = z.infer<typeof UpdateAgentConfigRequestSchema>;
 
 /**
  * Agent Configuration Response (Backend -> User)
+ *
+ * Mirrors the backend `AgentConfigDto` (UserLibrary bounded context): a flat
+ * config record with no id/userId/gameId/timestamps. Returned by
+ * GET /api/v1/library/games/{gameId}/agent-config (null when unconfigured).
  */
 export const AgentConfigDtoSchema = z.object({
-  id: z.string().uuid(),
-  userId: z.string().uuid(),
-  gameId: z.string().uuid(),
-  modelType: AIModelSchema,
+  llmModel: AIModelSchema,
   temperature: z.number(),
   maxTokens: z.number(),
   personality: AgentPersonalitySchema,
   detailLevel: DetailLevelSchema,
-  customInstructions: z.string().nullable().optional(),
-  createdAt: z.string().datetime({ offset: true }),
-  updatedAt: z.string().datetime({ offset: true }).nullable().optional(),
+  personalNotes: z.string().nullable().optional(),
 });
 
 export type AgentConfigDto = z.infer<typeof AgentConfigDtoSchema>;
 
 /**
+ * Response wrapper for PUT /api/v1/library/games/{gameId}/agent-config.
+ *
+ * The backend endpoint returns the full UserLibraryEntryDto after configuring
+ * the agent; only its `customAgentConfig` field carries the persisted config.
+ * `.passthrough()` tolerates the remaining entry fields we don't consume here.
+ */
+export const UpdateAgentConfigResponseSchema = z
+  .object({
+    customAgentConfig: AgentConfigDtoSchema.nullable().optional(),
+  })
+  .passthrough();
+
+export type UpdateAgentConfigResponse = z.infer<typeof UpdateAgentConfigResponseSchema>;
+
+/**
  * Default Agent Configuration (fallback values)
  */
-export const DEFAULT_AGENT_CONFIG: Omit<UpdateAgentConfigRequest, 'customInstructions'> = {
-  modelType: 'llama-3.3-70b-free',
+export const DEFAULT_AGENT_CONFIG: Omit<UpdateAgentConfigRequest, 'personalNotes'> = {
+  llmModel: 'llama-3.3-70b-free',
   temperature: 0.7,
   maxTokens: 4096,
-  personality: 'friendly',
-  detailLevel: 'normal',
+  personality: 'Amichevole',
+  detailLevel: 'Normale',
 };
 
 /**
@@ -179,19 +206,29 @@ export interface PersonalityInfo {
 
 export const PERSONALITY_OPTIONS: PersonalityInfo[] = [
   {
-    value: 'formal',
-    label: 'Formale',
-    description: 'Tono professionale, risposte dettagliate',
-  },
-  {
-    value: 'friendly',
+    value: 'Amichevole',
     label: 'Amichevole',
     description: 'Tono casual, esempi pratici',
   },
   {
-    value: 'expert',
-    label: 'Esperto',
-    description: 'Tono tecnico, riferimenti avanzati',
+    value: 'Professionale',
+    label: 'Professionale',
+    description: 'Tono professionale e formale',
+  },
+  {
+    value: 'Umoristico',
+    label: 'Umoristico',
+    description: 'Tono leggero e spiritoso',
+  },
+  {
+    value: 'Conciso',
+    label: 'Conciso',
+    description: 'Risposte brevi e dirette',
+  },
+  {
+    value: 'Dettagliato',
+    label: 'Dettagliato',
+    description: 'Risposte approfondite e complete',
   },
 ];
 
@@ -206,18 +243,23 @@ export interface DetailLevelInfo {
 
 export const DETAIL_LEVEL_OPTIONS: DetailLevelInfo[] = [
   {
-    value: 'brief',
-    label: 'Sintetico',
+    value: 'Breve',
+    label: 'Breve',
     description: 'Risposte brevi (1-2 frasi)',
   },
   {
-    value: 'normal',
+    value: 'Normale',
     label: 'Normale',
     description: 'Risposte equilibrate (2-4 frasi)',
   },
   {
-    value: 'detailed',
+    value: 'Dettagliato',
     label: 'Dettagliato',
     description: 'Risposte complete con esempi',
+  },
+  {
+    value: 'Esaustivo',
+    label: 'Esaustivo',
+    description: 'Risposte molto approfondite',
   },
 ];


### PR DESCRIPTION
## Sommario

Fix di 3 bug 🔴 sulla pagina agente e sull'entità agente (issue #2727), emersi da un audit completo (`/sc:spec-panel`). Sintomo utente: "errore su creazione/config agente".

## Bug risolti

### 🔴 A — Salvataggio config agente → HTTP 400/500
Contratto FE↔BE completamente disallineato sul `PUT /api/v1/library/games/{gameId}/agent-config`:
- FE inviava `modelType`/`customInstructions` + enum inglesi (`friendly`/`brief`); il BE bind-a `AgentConfigDto(string LlmModel, …, string? PersonalNotes)` e il validator (`ConfigureGameAgentCommandValidator`) accetta solo i valori canonici italiani (`Amichevole/Professionale/Umoristico/Conciso/Dettagliato`, `Breve/Normale/Dettagliato/Esaustivo`).
- La response del PUT è un `UserLibraryEntryDto` (config annidata in `customAgentConfig`), non un `AgentConfigDto` → ZodError anche con 200.

**Fix (direzione: allinea FE→BE)**: rinominati i campi (`llmModel`/`personalNotes`), adottati gli enum canonici BE 1:1, e il client ora estrae `customAgentConfig` dalla response.

### 🔴 E — Tab Settings di `/agents/[id]`: salvataggio no-op
`onSave` era `() => {}`. Ora cablato a `useUpdateAgentConfig` con gating per-gioco, creazione-da-default al primo salvataggio, guardia anti doppio-fire e feedback toast.
> Nota: `AgentSettingsForm` resta display-only (nessun input editabile) — l'editabilità dei campi è un follow-up dedicato; questo fix rende il salvataggio funzionante e onesto.

### 🔴 B — "Crea Tutor" → redirect a chat inesistente
`OwnershipConfirmationDialog` reindirizzava a `/chat/{chatThreadId}`, ma il BE ritorna un `chatThreadId` placeholder (`Guid.NewGuid`, mai persistito). Ora reindirizza a `/agents/{agentId}` (l'agente creato realmente).

## Falsi allarmi esclusi dall'audit
- Casing SSE PascalCase (gestito da `SseJsonOptions` camelCase).
- "Endpoint backend mancanti" (esistono, con path diversi; commenti `@todo` stale corretti).

## Test (TDD)
- `agent-config.schemas.test.ts` — contratto request/response BE-aligned.
- `libraryClient.test.ts` — `updateAgentConfig` estrae `customAgentConfig`.
- `OwnershipConfirmationDialog.test.tsx` — redirect a `/agents/{agentId}`.
- `AgentDetailView.test.tsx` — salvataggio cablato (config presente + config assente/default).

**Verifica**: typecheck exit 0 · ESLint clean · 878 test verdi nelle aree toccate (0 regressioni). Review avversariale multi-agente (4 dimensioni): 2 finding LOW, entrambi risolti in-PR.

## DoD
- [x] A: config salvabile senza 400/500, campi + enum allineati, response validata
- [x] E: tab Settings persiste con feedback (gating per-gioco)
- [x] B: "Crea Tutor" non porta più a chat inesistente
- [x] Nessuna regressione (typecheck/lint/test verdi)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
