### PR TITLE
test(session): #2660 assert UpdateAsync persists FinalizedAt + Status columns

### DIFF
--- a/apps/api/tests/Api.Tests/Integration/SessionTracking/SessionRepositoryUpdatePersistenceTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/SessionTracking/SessionRepositoryUpdatePersistenceTests.cs
@@ -87,4 +87,44 @@ public sealed class SessionRepositoryUpdatePersistenceTests : IAsyncLifetime
                 "UpdateAsync must persist the StartedAt scalar set by OpenLiveMode (#2660 — .AsTracking() under the NoTracking default)");
         }
     }
+
+    [Fact(DisplayName = "#2660: UpdateAsync persists Session.FinalizedAt + Status (Finalize) to the scalar columns")]
+    public async Task UpdateAsync_PersistsFinalizedAt()
+    {
+        Guid sessionId;
+        await using (var scope = _factory.Services.CreateAsyncScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            var repo = scope.ServiceProvider.GetRequiredService<ISessionRepository>();
+            var uow = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+
+            var (userId, _) = await TestSessionHelper.CreateUserSessionAsync(db);
+            var gameId = await TestSessionHelper.SeedSharedGameAsync(db, title: "Finalize-Persist Game");
+            var session = Session.Create(userId, gameId, SessionType.Generic);
+            await repo.AddAsync(session, CancellationToken.None);
+            await uow.SaveChangesAsync(CancellationToken.None);
+            sessionId = session.Id;
+        }
+
+        await using (var scope = _factory.Services.CreateAsyncScope())
+        {
+            var repo = scope.ServiceProvider.GetRequiredService<ISessionRepository>();
+            var uow = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+
+            var session = await repo.GetByIdAsync(sessionId, CancellationToken.None);
+            session!.Finalize();
+            await repo.UpdateAsync(session, CancellationToken.None);
+            await uow.SaveChangesAsync(CancellationToken.None);
+        }
+
+        await using (var scope = _factory.Services.CreateAsyncScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            var entity = await db.SessionTrackingSessions.AsNoTracking().FirstAsync(s => s.Id == sessionId);
+            entity.FinalizedAt.Should().NotBeNull(
+                "UpdateAsync must persist the FinalizedAt scalar set by Finalize (#2660 — same untracked no-op class as StartedAt)");
+            entity.Status.Should().Be("Finalized",
+                "UpdateAsync must persist the Status scalar set by Finalize (#2660 — .AsTracking() under the NoTracking default)");
+        }
+    }
 }


### PR DESCRIPTION
## Contesto

Closes #2660.

Investigazione: il fix della root cause (`.AsTracking()` su `SessionRepository.UpdateAsync` sotto il default globale `QueryTrackingBehavior.NoTracking` — PERF-06) è **già mergiato** su `main-dev` (commit `03b4dd3ce`, insieme a #2633) con il test di regressione `UpdateAsync_PersistsStartedAt`. L'issue richiedeva esplicitamente anche la variante `FinalizedAt`; questa PR la aggiunge, chiudendo #2660.

## Cosa cambia

- Aggiunge `UpdateAsync_PersistsFinalizedAt` a `SessionRepositoryUpdatePersistenceTests` (bounded context SessionTracking, Testcontainers).
- Il test: `Session.Create` → `SaveChanges` → (nuovo scope) `GetByIdAsync` → `Finalize()` → `UpdateAsync` → `SaveChanges` → (nuovo scope) re-read `AsNoTracking` e asserisce `finalized_at NOT NULL` **e** `status == "Finalized"`.
- Sorveglia la stessa classe di bug "untracked no-op" già coperta per `StartedAt`: `FinalizedAt` (riga 133) e `Status` (riga 131) sono assegnati sulla stessa entità `existing` caricata `.AsTracking()` (riga 122). Nel test l'unico percorso di persistenza è `UpdateAsync`, quindi il test è non-vacuo.

## Test

- `dotnet test --filter "FullyQualifiedName~SessionRepositoryUpdatePersistenceTests"` → **2 passed, 0 failed** (StartedAt + nuovo FinalizedAt).

## Follow-up (fuori scope)

L'investigazione ha rilevato un **cluster gemello** di no-op silenziosi ancora live su `main-dev` negli handler SessionTracking fratelli (Rename gamebook campaign, Update gamebook progress/Touch, Update widget state) — stessa classe di `.AsTracking()` mancante. Il caso Glossary è coperto dalla PR di #2638. Apro issue di follow-up dedicata per il resto del cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)