### PR TITLE
feat(agent): #2732 editable Settings tab via shared AgentConfigFields

### DIFF
--- a/apps/web/src/app/(authenticated)/agents/[id]/_components/AgentDetailView.tsx
+++ b/apps/web/src/app/(authenticated)/agents/[id]/_components/AgentDetailView.tsx
@@ -30,6 +30,7 @@ import { useMemo, useState, type ReactElement } from 'react';
 import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
 
+import { type AgentConfigFieldsValue } from '@/components/agent/config';
 import {
   AgentDangerZone,
   AgentHero,
@@ -244,28 +245,30 @@ function mapChatHistoryState(
 
 function mapSettingsState(
   query: ReturnType<typeof useAgentConfig>,
-  isReadOnly: boolean,
+  isArchived: boolean,
+  agentHasGameId: boolean,
   onRetry: () => void
 ): SettingsState {
   if (query.isLoading) return { kind: 'loading' };
   if (query.isError) return { kind: 'error', retry: onRetry };
 
   const config = query.data;
-  const resolvedConfig = {
-    strategy: config?.llmModel ?? 'llama-3.3-70b-free',
-    parameters: config
-      ? {
-          temperature: config.temperature,
-          maxTokens: config.maxTokens,
-          personality: config.personality,
-          detailLevel: config.detailLevel,
-          customInstructions: config.personalNotes,
-        }
-      : {},
-  };
+  const value: AgentConfigFieldsValue = config
+    ? {
+        llmModel: config.llmModel,
+        temperature: config.temperature,
+        maxTokens: config.maxTokens,
+        personality: config.personality,
+        detailLevel: config.detailLevel,
+        personalNotes: config.personalNotes ?? '',
+      }
+    : { ...DEFAULT_AGENT_CONFIG, personalNotes: '' };
 
-  if (isReadOnly) return { kind: 'read-only', config: resolvedConfig };
-  return { kind: 'editable', config: resolvedConfig };
+  // Archived agents and standalone agents (no game) are read-only: the per-game
+  // config cannot be edited/persisted for them.
+  if (isArchived) return { kind: 'read-only', value, readOnlyReason: 'archived' };
+  if (!agentHasGameId) return { kind: 'read-only', value, readOnlyReason: 'standalone' };
+  return { kind: 'editable', value };
 }
 
 // ─── Main orchestrator ───────────────────────────────────────────────────────
@@ -501,6 +504,8 @@ export function AgentDetailView({ agentId }: AgentDetailViewProps): ReactElement
     strategyLabel: t('pages.agentDetail.settings.strategyLabel'),
     parametersLabel: t('pages.agentDetail.settings.parametersLabel'),
     readOnlyBanner: t('pages.agentDetail.settings.readOnlyBanner'),
+    readOnlyStandalone: t('pages.agentDetail.settings.readOnlyStandalone'),
+    perGameNote: t('pages.agentDetail.settings.perGameNote'),
     saveCta: t('pages.agentDetail.settings.saveCta'),
     cancelCta: t('pages.agentDetail.settings.cancelCta'),
     saveSuccess: t('pages.agentDetail.settings.saveSuccess'),
@@ -529,8 +534,11 @@ export function AgentDetailView({ agentId }: AgentDetailViewProps): ReactElement
     threadsQueryGated.refetch()
   );
 
-  const settingsState: SettingsState = mapSettingsState(configQueryGated, isArchived, () =>
-    configQueryGated.refetch()
+  const settingsState: SettingsState = mapSettingsState(
+    configQueryGated,
+    isArchived,
+    safeAgent.gameId != null,
+    () => configQueryGated.refetch()
   );
 
   return (
@@ -660,29 +668,17 @@ export function AgentDetailView({ agentId }: AgentDetailViewProps): ReactElement
             <AgentSettingsForm
               state={settingsState}
               labels={settingsLabels}
-              onSave={() => {
+              onSave={value => {
                 if (updateConfig.isPending) return; // guard against double-fire
                 const gameId = agentQuery.data?.gameId;
-                // Config is per-game; a standalone agent (no real gameId) cannot
-                // be configured from this per-agent page.
+                // Editable state is only produced for agents with a game; guard
+                // defensively (config is per-game and can't persist without one).
                 if (!gameId) {
                   toast.error(settingsLabels.saveError);
                   return;
                 }
-                const current = configQueryGated.data;
-                // No custom config yet → persist defaults (mutation create path).
-                const request = current
-                  ? {
-                      llmModel: current.llmModel,
-                      temperature: current.temperature,
-                      maxTokens: current.maxTokens,
-                      personality: current.personality,
-                      detailLevel: current.detailLevel,
-                      personalNotes: current.personalNotes ?? null,
-                    }
-                  : { ...DEFAULT_AGENT_CONFIG, personalNotes: null };
                 updateConfig.mutate(
-                  { gameId, request },
+                  { gameId, request: { ...value, personalNotes: value.personalNotes || null } },
                   {
                     onSuccess: () => toast.success(settingsLabels.saveSuccess),
                     onError: () => toast.error(settingsLabels.saveError),

--- a/apps/web/src/app/(authenticated)/agents/[id]/_components/__tests__/AgentDetailView.test.tsx
+++ b/apps/web/src/app/(authenticated)/agents/[id]/_components/__tests__/AgentDetailView.test.tsx
@@ -222,6 +222,8 @@ const MESSAGES: Record<string, string> = {
   'pages.agentDetail.settings.strategyLabel': 'Strategia RAG',
   'pages.agentDetail.settings.parametersLabel': 'Parametri',
   'pages.agentDetail.settings.readOnlyBanner': 'Impostazioni in sola lettura.',
+  'pages.agentDetail.settings.readOnlyStandalone': 'Config solo per agenti con gioco.',
+  'pages.agentDetail.settings.perGameNote': 'Vale per tutti gli agenti del gioco.',
   'pages.agentDetail.settings.saveCta': 'Salva',
   'pages.agentDetail.settings.cancelCta': 'Annulla',
   'pages.agentDetail.settings.saveSuccess': 'Salvato.',
@@ -936,6 +938,84 @@ describe('AgentDetailView — FSM integration tests (Phase 0.5 contract, Wave C.
     expect(payload.request.personality).toBe('Amichevole');
     expect(payload.request.detailLevel).toBe('Normale');
     expect(payload.request.personalNotes).toBeNull();
+
+    assertKbDocsNeverCalledWithBadGameId();
+  });
+
+  // ─── Settings tab: editing a field persists the EDITED value (#2732) ───────
+  it('Settings tab editing a field and saving persists the edited value', () => {
+    useAgentSpy.mockImplementation(() => ({
+      data: makeAgent({ invocationCount: 5 }),
+      isLoading: false,
+      isError: false,
+      isSuccess: true,
+      refetch: vi.fn(),
+    }));
+    useAgentConfigSpy.mockImplementation(() => ({
+      ...configMockState,
+      data: {
+        llmModel: 'llama-3.3-70b-free',
+        temperature: 0.7,
+        maxTokens: 4096,
+        personality: 'Amichevole',
+        detailLevel: 'Normale',
+        personalNotes: 'note',
+      },
+      isSuccess: true,
+    }));
+
+    renderWithIntl(<AgentDetailView agentId={VALID_AGENT_ID} />);
+
+    act(() => {
+      fireEvent.click(document.querySelector('[data-tab-key="settings"]')!);
+    });
+    act(() => {
+      fireEvent.change(screen.getByLabelText(/Max Tokens/), { target: { value: '2048' } });
+    });
+    act(() => {
+      fireEvent.click(screen.getByRole('button', { name: 'Salva' }));
+    });
+
+    expect(updateConfigMutate).toHaveBeenCalledTimes(1);
+    const payload = updateConfigMutate.mock.calls[0][0] as {
+      gameId: string;
+      request: Record<string, unknown>;
+    };
+    expect(payload.gameId).toBe(VALID_GAME_ID);
+    expect(payload.request.maxTokens).toBe(2048);
+    expect(payload.request.personalNotes).toBe('note');
+
+    assertKbDocsNeverCalledWithBadGameId();
+  });
+
+  // ─── Settings tab: standalone agent (no game) is read-only (#2732) ──────────
+  it('Settings tab is read-only for a standalone agent (no gameId)', () => {
+    useAgentSpy.mockImplementation(() => ({
+      data: makeAgent({ invocationCount: 5, gameId: null, gameName: null }),
+      isLoading: false,
+      isError: false,
+      isSuccess: true,
+      refetch: vi.fn(),
+    }));
+    useAgentConfigSpy.mockImplementation(() => ({
+      ...configMockState,
+      data: null,
+      isSuccess: true,
+    }));
+
+    renderWithIntl(<AgentDetailView agentId={VALID_AGENT_ID} />);
+
+    act(() => {
+      fireEvent.click(document.querySelector('[data-tab-key="settings"]')!);
+    });
+
+    expect(
+      document.querySelector(
+        '[data-slot="agent-detail-settings-form"][data-settings-kind="read-only"]'
+      )
+    ).toBeInTheDocument();
+    expect(screen.getByText('Config solo per agenti con gioco.')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Salva' })).not.toBeInTheDocument();
 
     assertKbDocsNeverCalledWithBadGameId();
   });

--- a/apps/web/src/components/agent/config/AgentConfigFields.tsx
+++ b/apps/web/src/components/agent/config/AgentConfigFields.tsx
@@ -1,0 +1,193 @@
+/**
+ * AgentConfigFields — shared per-game AI config field group (Issue #2732).
+ *
+ * Controlled presentational component extracted verbatim from AgentConfigModal's
+ * inline fields so the /agents/[id] Settings tab and the library modal share one
+ * tested UI. No hooks, no data fetching. Emits partial patches via `onChange`.
+ */
+
+'use client';
+
+import type { ReactElement } from 'react';
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/overlays/select';
+import { Input } from '@/components/ui/primitives/input';
+import { Label } from '@/components/ui/primitives/label';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/primitives/radio-group';
+import { Slider } from '@/components/ui/primitives/slider';
+import { Textarea } from '@/components/ui/primitives/textarea';
+import {
+  MODEL_OPTIONS,
+  PERSONALITY_OPTIONS,
+  DETAIL_LEVEL_OPTIONS,
+  type AIModel,
+  type AgentPersonality,
+  type DetailLevel,
+} from '@/lib/api';
+
+export interface AgentConfigFieldsValue {
+  llmModel: AIModel;
+  temperature: number;
+  maxTokens: number;
+  personality: AgentPersonality;
+  detailLevel: DetailLevel;
+  /** Form-side value: empty string instead of null; consumers normalize to null. */
+  personalNotes: string;
+}
+
+export interface AgentConfigFieldsProps {
+  value: AgentConfigFieldsValue;
+  onChange: (patch: Partial<AgentConfigFieldsValue>) => void;
+  disabled?: boolean;
+}
+
+export function AgentConfigFields({
+  value,
+  onChange,
+  disabled = false,
+}: AgentConfigFieldsProps): ReactElement {
+  return (
+    <div className="space-y-6">
+      {/* Model Selection */}
+      <div className="space-y-2">
+        <Label htmlFor="model" className="text-base font-semibold">
+          🤖 Modello AI
+        </Label>
+        <Select
+          value={value.llmModel}
+          onValueChange={v => onChange({ llmModel: v as AIModel })}
+          disabled={disabled}
+        >
+          <SelectTrigger id="model">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {MODEL_OPTIONS.map(model => (
+              <SelectItem key={model.value} value={model.value}>
+                {model.label} ({model.costLevel}) {model.isDefault && '⭐'}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <p className="text-sm text-muted-foreground">
+          {MODEL_OPTIONS.find(m => m.value === value.llmModel)?.description}
+        </p>
+      </div>
+
+      {/* Temperature Slider */}
+      <div className="space-y-2">
+        <div className="flex items-center justify-between">
+          <Label htmlFor="temperature" className="text-base font-semibold">
+            ⚙️ Temperatura
+          </Label>
+          <span className="text-sm text-muted-foreground">{value.temperature.toFixed(2)}</span>
+        </div>
+        <Slider
+          id="temperature"
+          min={0}
+          max={2}
+          step={0.1}
+          value={[value.temperature]}
+          onValueChange={([v]) => onChange({ temperature: v })}
+          disabled={disabled}
+          className="w-full"
+        />
+        <div className="flex justify-between text-xs text-muted-foreground">
+          <span>0.0 (Preciso)</span>
+          <span>2.0 (Creativo)</span>
+        </div>
+      </div>
+
+      {/* Max Tokens Input */}
+      <div className="space-y-2">
+        <Label htmlFor="maxTokens" className="text-base font-semibold">
+          📏 Max Tokens
+        </Label>
+        <Input
+          id="maxTokens"
+          type="number"
+          min={512}
+          max={8192}
+          step={256}
+          value={value.maxTokens}
+          onChange={e => onChange({ maxTokens: Number(e.target.value) })}
+          disabled={disabled}
+        />
+        <p className="text-sm text-muted-foreground">Lunghezza massima della risposta (512-8192)</p>
+      </div>
+
+      {/* Personality Radio Buttons */}
+      <div className="space-y-2">
+        <Label className="text-base font-semibold">🎭 Personalità Agente</Label>
+        <RadioGroup
+          value={value.personality}
+          onValueChange={v => onChange({ personality: v as AgentPersonality })}
+          disabled={disabled}
+        >
+          {PERSONALITY_OPTIONS.map(option => (
+            <div key={option.value} className="flex items-center space-x-2">
+              <RadioGroupItem
+                value={option.value}
+                id={`personality-${option.value}`}
+                disabled={disabled}
+              />
+              <Label htmlFor={`personality-${option.value}`} className="font-normal cursor-pointer">
+                <span className="font-medium">{option.label}</span>
+                <span className="text-sm text-muted-foreground ml-2">({option.description})</span>
+              </Label>
+            </div>
+          ))}
+        </RadioGroup>
+      </div>
+
+      {/* Detail Level Radio Buttons */}
+      <div className="space-y-2">
+        <Label className="text-base font-semibold">📊 Livello Dettaglio</Label>
+        <RadioGroup
+          value={value.detailLevel}
+          onValueChange={v => onChange({ detailLevel: v as DetailLevel })}
+          disabled={disabled}
+        >
+          {DETAIL_LEVEL_OPTIONS.map(option => (
+            <div key={option.value} className="flex items-center space-x-2">
+              <RadioGroupItem
+                value={option.value}
+                id={`detail-${option.value}`}
+                disabled={disabled}
+              />
+              <Label htmlFor={`detail-${option.value}`} className="font-normal cursor-pointer">
+                <span className="font-medium">{option.label}</span>
+                <span className="text-sm text-muted-foreground ml-2">({option.description})</span>
+              </Label>
+            </div>
+          ))}
+        </RadioGroup>
+      </div>
+
+      {/* Personal Notes Textarea */}
+      <div className="space-y-2">
+        <Label htmlFor="instructions" className="text-base font-semibold">
+          📝 Note Personali
+        </Label>
+        <Textarea
+          id="instructions"
+          placeholder="Es: Spiega sempre le regole come se fossi principiante"
+          value={value.personalNotes}
+          onChange={e => onChange({ personalNotes: e.target.value })}
+          maxLength={1000}
+          rows={4}
+          disabled={disabled}
+        />
+        <div className="text-xs text-right text-muted-foreground">
+          {1000 - value.personalNotes.length} caratteri rimanenti
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/agent/config/__tests__/AgentConfigFields.test.tsx
+++ b/apps/web/src/components/agent/config/__tests__/AgentConfigFields.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * AgentConfigFields — shared per-game AI config field group (Issue #2732).
+ *
+ * Controlled presentational component reused by AgentConfigModal (library) and
+ * the /agents/[id] Settings tab. Tests cover: all six fields render, onChange
+ * emits the right patch for native inputs, and `disabled` propagates.
+ */
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+import { AgentConfigFields, type AgentConfigFieldsValue } from '../AgentConfigFields';
+
+const baseValue: AgentConfigFieldsValue = {
+  llmModel: 'llama-3.3-70b-free',
+  temperature: 0.7,
+  maxTokens: 4096,
+  personality: 'Amichevole',
+  detailLevel: 'Normale',
+  personalNotes: 'ciao',
+};
+
+describe('AgentConfigFields', () => {
+  it('renders all six config field groups', () => {
+    render(<AgentConfigFields value={baseValue} onChange={vi.fn()} />);
+
+    expect(screen.getByText(/Modello AI/)).toBeInTheDocument();
+    expect(screen.getByText(/Temperatura/)).toBeInTheDocument();
+    expect(screen.getByText(/Max Tokens/)).toBeInTheDocument();
+    expect(screen.getByText(/Personalità Agente/)).toBeInTheDocument();
+    expect(screen.getByText(/Livello Dettaglio/)).toBeInTheDocument();
+    expect(screen.getByText(/Note Personali/)).toBeInTheDocument();
+    expect(screen.getByDisplayValue('ciao')).toBeInTheDocument();
+  });
+
+  it('emits onChange patch when maxTokens changes', () => {
+    const onChange = vi.fn();
+    render(<AgentConfigFields value={baseValue} onChange={onChange} />);
+
+    fireEvent.change(screen.getByLabelText(/Max Tokens/), { target: { value: '2048' } });
+
+    expect(onChange).toHaveBeenCalledWith({ maxTokens: 2048 });
+  });
+
+  it('emits onChange patch when personalNotes changes', () => {
+    const onChange = vi.fn();
+    render(<AgentConfigFields value={baseValue} onChange={onChange} />);
+
+    fireEvent.change(screen.getByDisplayValue('ciao'), { target: { value: 'nuove note' } });
+
+    expect(onChange).toHaveBeenCalledWith({ personalNotes: 'nuove note' });
+  });
+
+  it('emits onChange patch when a personality radio is selected', () => {
+    const onChange = vi.fn();
+    render(<AgentConfigFields value={baseValue} onChange={onChange} />);
+
+    fireEvent.click(screen.getByRole('radio', { name: /Professionale/ }));
+
+    expect(onChange).toHaveBeenCalledWith({ personality: 'Professionale' });
+  });
+
+  it('emits onChange patch when a detailLevel radio is selected', () => {
+    const onChange = vi.fn();
+    render(<AgentConfigFields value={baseValue} onChange={onChange} />);
+
+    fireEvent.click(screen.getByRole('radio', { name: /Esaustivo/ }));
+
+    expect(onChange).toHaveBeenCalledWith({ detailLevel: 'Esaustivo' });
+  });
+
+  it('disables ALL controls when disabled (native inputs + radios)', () => {
+    render(<AgentConfigFields value={baseValue} onChange={vi.fn()} disabled />);
+
+    expect(screen.getByLabelText(/Max Tokens/)).toBeDisabled();
+    expect(screen.getByDisplayValue('ciao')).toBeDisabled();
+    expect(screen.getByRole('radio', { name: /Amichevole/ })).toBeDisabled();
+    expect(screen.getByRole('radio', { name: /Breve/ })).toBeDisabled();
+  });
+});

--- a/apps/web/src/components/agent/config/index.ts
+++ b/apps/web/src/components/agent/config/index.ts
@@ -18,6 +18,8 @@ export { TokenQuotaDisplay } from './TokenQuotaDisplay';
 export { SlotCards } from './SlotCards';
 export { ModelTierSelector } from './ModelTierSelector';
 export { CostPreview } from './CostPreview';
+export { AgentConfigFields } from './AgentConfigFields';
 
 export type { TypologySelectorProps } from './TypologySelector';
 export type { StrategySelectorProps } from './StrategySelector';
+export type { AgentConfigFieldsValue, AgentConfigFieldsProps } from './AgentConfigFields';

--- a/apps/web/src/components/features/agent-detail/AgentSettingsForm.tsx
+++ b/apps/web/src/components/features/agent-detail/AgentSettingsForm.tsx
@@ -1,40 +1,33 @@
 /**
- * AgentSettingsForm - v2 Wave C.2 (Issue #581)
+ * AgentSettingsForm - v2 Wave C.2 (Issue #581), editable via AgentConfigFields (Issue #2732).
  *
- * Mapped from `admin-mockups/design_files/sp4-agent-detail.jsx` (SettingsTab).
- * Spec: docs/superpowers/specs/2026-04-26-v2-design-migration.md (Phase 1+2)
- * Tracking: docs/frontend/v2-migration-matrix.md (Issue #581)
+ * The /agents/[id] Settings tab editor for the per-game AI agent config. Uses
+ * the shared `AgentConfigFields` (same UI as the library modal).
  *
- * Pure presentational component — no hooks, no i18n calls, no data fetching.
- * Variant-aware: archived agent → read-only (no Save CTA).
- *
- * 4-state discriminated union per Phase 0.5 contract sez. 4.3:
+ * 4-state discriminated union:
  *   - `loading`: shimmer skeleton
  *   - `error`: error message + retry button
- *   - `editable`: active agent — form fields + Save/Cancel buttons
- *   - `read-only`: archived agent — display-only + read-only banner (no Save)
+ *   - `editable`: active agent with a game — editable fields + per-game note + Save/Cancel
+ *   - `read-only`: archived OR standalone agent — disabled fields + reason banner (no Save)
  *
- * A11y: read-only banner has `role="status"` (informational).
- *
- * AC: T A V
+ * A11y: banners use `role="status"` (informational).
  */
 
 'use client';
 
-import type { ReactElement } from 'react';
+import { useEffect, useRef, useState, type ReactElement } from 'react';
 
 import clsx from 'clsx';
 
-export interface AgentConfig {
-  readonly strategy: string;
-  readonly parameters: Record<string, unknown>;
-}
+import { AgentConfigFields, type AgentConfigFieldsValue } from '@/components/agent/config';
 
 export interface AgentSettingsFormLabels {
   readonly title: string;
   readonly strategyLabel: string;
   readonly parametersLabel: string;
   readonly readOnlyBanner: string;
+  readonly readOnlyStandalone: string;
+  readonly perGameNote: string;
   readonly saveCta: string;
   readonly cancelCta: string;
   readonly saveSuccess: string;
@@ -45,20 +38,20 @@ export interface AgentSettingsFormLabels {
 }
 
 /**
- * Discriminated union per Phase 0.5 contract sez. 4.3.
- * - `editable`: active agent — can save changes
- * - `read-only`: archived agent — display only, no Save CTA
+ * Discriminated union.
+ * - `editable`: active agent with a game — can save changes
+ * - `read-only`: archived (reason='archived') or standalone (reason='standalone')
  */
 export type SettingsState =
   | { kind: 'loading' }
   | { kind: 'error'; retry: () => void }
-  | { kind: 'editable'; config: AgentConfig }
-  | { kind: 'read-only'; config: AgentConfig };
+  | { kind: 'editable'; value: AgentConfigFieldsValue }
+  | { kind: 'read-only'; value: AgentConfigFieldsValue; readOnlyReason: 'archived' | 'standalone' };
 
 export interface AgentSettingsFormProps {
   readonly state: SettingsState;
   readonly labels: AgentSettingsFormLabels;
-  readonly onSave: (config: AgentConfig) => void;
+  readonly onSave: (value: AgentConfigFieldsValue) => void;
   readonly onCancel: () => void;
   readonly className?: string;
 }
@@ -72,10 +65,8 @@ export function AgentSettingsForm(props: AgentSettingsFormProps): ReactElement {
       data-settings-kind={state.kind}
       className={clsx('flex flex-col gap-4', className)}
     >
-      {/* Section header */}
       <h3 className="font-display text-[15px] font-extrabold text-foreground">{labels.title}</h3>
 
-      {/* Loading state */}
       {state.kind === 'loading' ? (
         <div className="flex flex-col gap-4" aria-label={labels.loadingLabel} aria-busy="true">
           {[0, 1, 2].map(i => (
@@ -84,7 +75,6 @@ export function AgentSettingsForm(props: AgentSettingsFormProps): ReactElement {
         </div>
       ) : null}
 
-      {/* Error state */}
       {state.kind === 'error' ? (
         <div className="flex flex-col items-center gap-3 rounded-xl border border-rose-200 bg-rose-50 px-6 py-8 text-center dark:border-rose-900/40 dark:bg-rose-950/20">
           <span aria-hidden="true" className="text-2xl">
@@ -103,79 +93,117 @@ export function AgentSettingsForm(props: AgentSettingsFormProps): ReactElement {
         </div>
       ) : null}
 
-      {/* Read-only state (archived) */}
       {state.kind === 'read-only' ? (
-        <div className="flex flex-col gap-4">
-          <div
-            role="status"
-            className="flex items-center gap-2.5 rounded-xl border border-border bg-muted px-4 py-3"
-          >
-            <span aria-hidden="true" className="text-base">
-              🔒
-            </span>
-            <p className="font-display text-[12.5px] font-semibold text-muted-foreground">
-              {labels.readOnlyBanner}
-            </p>
-          </div>
-          <ConfigDisplay config={state.config} labels={labels} />
-        </div>
+        <ReadOnlyView value={state.value} reason={state.readOnlyReason} labels={labels} />
       ) : null}
 
-      {/* Editable state (active) */}
       {state.kind === 'editable' ? (
-        <div className="flex flex-col gap-5">
-          <div className="rounded-xl border border-border bg-card px-5 py-5 shadow-sm">
-            <ConfigDisplay config={state.config} labels={labels} />
-          </div>
-
-          {/* Action bar */}
-          <div className="flex items-center justify-end gap-3">
-            <button
-              type="button"
-              onClick={onCancel}
-              className="inline-flex items-center rounded-lg border border-border px-4 py-2.5 font-display text-[13px] font-bold text-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-            >
-              {labels.cancelCta}
-            </button>
-            <button
-              type="button"
-              onClick={() => onSave(state.config)}
-              className="inline-flex items-center gap-1.5 rounded-lg bg-violet-700 px-4 py-2.5 font-display text-[13px] font-extrabold text-white shadow-sm hover:bg-violet-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-700 focus-visible:ring-offset-2"
-            >
-              {labels.saveCta}
-            </button>
-          </div>
-        </div>
+        <EditableView value={state.value} labels={labels} onSave={onSave} onCancel={onCancel} />
       ) : null}
     </section>
   );
 }
 
-/** Internal pure helper — renders config fields. */
-function ConfigDisplay({
-  config,
+/** Read-only view: disabled fields + reason-specific banner. */
+function ReadOnlyView({
+  value,
+  reason,
   labels,
 }: {
-  config: AgentConfig;
+  value: AgentConfigFieldsValue;
+  reason: 'archived' | 'standalone';
   labels: AgentSettingsFormLabels;
 }): ReactElement {
+  const banner = reason === 'standalone' ? labels.readOnlyStandalone : labels.readOnlyBanner;
   return (
     <div className="flex flex-col gap-4">
-      <div>
-        <label className="mb-1.5 block font-display text-[12px] font-extrabold uppercase tracking-[0.06em] text-muted-foreground">
-          {labels.strategyLabel}
-        </label>
-        <p className="rounded-lg border border-border bg-muted/30 px-3.5 py-2.5 font-mono text-[13px] text-foreground">
-          {config.strategy}
+      <div
+        role="status"
+        className="flex items-center gap-2.5 rounded-xl border border-border bg-muted px-4 py-3"
+      >
+        <span aria-hidden="true" className="text-base">
+          🔒
+        </span>
+        <p className="font-display text-[12.5px] font-semibold text-muted-foreground">{banner}</p>
+      </div>
+      <div className="rounded-xl border border-border bg-card px-5 py-5 shadow-sm">
+        <AgentConfigFields value={value} onChange={() => {}} disabled />
+      </div>
+    </div>
+  );
+}
+
+/** Editable view: owns local edit state, resynced when the source config changes. */
+function EditableView({
+  value,
+  labels,
+  onSave,
+  onCancel,
+}: {
+  value: AgentConfigFieldsValue;
+  labels: AgentSettingsFormLabels;
+  onSave: (value: AgentConfigFieldsValue) => void;
+  onCancel: () => void;
+}): ReactElement {
+  const [edited, setEdited] = useState<AgentConfigFieldsValue>(value);
+  // True once the user has touched a field: guards against a background refetch
+  // (refetchOnWindowFocus) clobbering unsaved edits. Reset on save/cancel.
+  const dirtyRef = useRef(false);
+
+  // Resync when the loaded config content changes (e.g. after a refetch). Depend
+  // on the primitive fields — the `value` prop is a fresh object each render.
+  const { llmModel, temperature, maxTokens, personality, detailLevel, personalNotes } = value;
+  useEffect(() => {
+    if (dirtyRef.current) return; // preserve in-progress edits
+    setEdited({ llmModel, temperature, maxTokens, personality, detailLevel, personalNotes });
+  }, [llmModel, temperature, maxTokens, personality, detailLevel, personalNotes]);
+
+  return (
+    <div className="flex flex-col gap-5">
+      <div
+        role="status"
+        className="flex items-center gap-2.5 rounded-xl border border-border bg-muted px-4 py-3"
+      >
+        <span aria-hidden="true" className="text-base">
+          ℹ️
+        </span>
+        <p className="font-display text-[12.5px] font-semibold text-muted-foreground">
+          {labels.perGameNote}
         </p>
       </div>
-      <div>
-        <label className="mb-1.5 block font-display text-[12px] font-extrabold uppercase tracking-[0.06em] text-muted-foreground">
-          {labels.parametersLabel}
-        </label>
-        <pre className="overflow-x-auto rounded-lg border border-border bg-muted/30 px-3.5 py-2.5 font-mono text-[11px] text-foreground [white-space:pre-wrap]">
-          {JSON.stringify(config.parameters, null, 2)}
-        </pre>
+
+      <div className="rounded-xl border border-border bg-card px-5 py-5 shadow-sm">
+        <AgentConfigFields
+          value={edited}
+          onChange={patch => {
+            dirtyRef.current = true;
+            setEdited(prev => ({ ...prev, ...patch }));
+          }}
+        />
+      </div>
+
+      <div className="flex items-center justify-end gap-3">
+        <button
+          type="button"
+          onClick={() => {
+            dirtyRef.current = false;
+            setEdited(value);
+            onCancel();
+          }}
+          className="inline-flex items-center rounded-lg border border-border px-4 py-2.5 font-display text-[13px] font-bold text-foreground hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          {labels.cancelCta}
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            dirtyRef.current = false;
+            onSave(edited);
+          }}
+          className="inline-flex items-center gap-1.5 rounded-lg bg-violet-700 px-4 py-2.5 font-display text-[13px] font-extrabold text-white shadow-sm hover:bg-violet-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-700 focus-visible:ring-offset-2"
+        >
+          {labels.saveCta}
+        </button>
       </div>
     </div>
   );

--- a/apps/web/src/components/features/agent-detail/__tests__/AgentSettingsForm.test.tsx
+++ b/apps/web/src/components/features/agent-detail/__tests__/AgentSettingsForm.test.tsx
@@ -1,10 +1,12 @@
 /**
- * AgentSettingsForm unit tests — Wave C.2 Task 2
+ * AgentSettingsForm unit tests — editable via AgentConfigFields (Issue #2732).
  *
- * 6 tests: variant editable/read-only, loading, error, data-slot.
+ * The form evolves from display-only to a real editor: editable state renders
+ * the shared config fields + per-game note + Save/Cancel; read-only disables
+ * the fields and shows a reason-specific banner (archived vs standalone).
  */
 
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
 import { AgentSettingsForm } from '../AgentSettingsForm';
@@ -14,6 +16,8 @@ const LABELS = {
   strategyLabel: 'Strategia RAG',
   parametersLabel: 'Parametri strategia',
   readOnlyBanner: 'Le impostazioni sono in sola lettura per gli agenti archiviati.',
+  readOnlyStandalone: 'Configurazione disponibile solo per agenti associati a un gioco.',
+  perGameNote: 'Queste impostazioni valgono per tutti gli agenti di questo gioco.',
   saveCta: 'Salva impostazioni',
   cancelCta: 'Annulla',
   saveSuccess: 'Impostazioni salvate.',
@@ -23,16 +27,20 @@ const LABELS = {
   retryLabel: 'Riprova',
 };
 
-const SAMPLE_CONFIG = {
-  strategy: 'hybrid',
-  parameters: { topK: 5, threshold: 0.7 },
+const SAMPLE_VALUE = {
+  llmModel: 'llama-3.3-70b-free' as const,
+  temperature: 0.7,
+  maxTokens: 4096,
+  personality: 'Amichevole' as const,
+  detailLevel: 'Normale' as const,
+  personalNotes: 'note',
 };
 
 describe('AgentSettingsForm', () => {
   it('renders data-slot attribute', () => {
     render(
       <AgentSettingsForm
-        state={{ kind: 'editable', config: SAMPLE_CONFIG }}
+        state={{ kind: 'editable', value: SAMPLE_VALUE }}
         labels={LABELS}
         onSave={vi.fn()}
         onCancel={vi.fn()}
@@ -41,43 +49,67 @@ describe('AgentSettingsForm', () => {
     expect(document.querySelector('[data-slot="agent-detail-settings-form"]')).toBeTruthy();
   });
 
-  it('editable kind: renders save and cancel buttons', () => {
+  it('editable: renders the config fields, per-game note and Save/Cancel', () => {
     render(
       <AgentSettingsForm
-        state={{ kind: 'editable', config: SAMPLE_CONFIG }}
+        state={{ kind: 'editable', value: SAMPLE_VALUE }}
         labels={LABELS}
         onSave={vi.fn()}
         onCancel={vi.fn()}
       />
     );
+    expect(screen.getByLabelText(/Max Tokens/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Max Tokens/)).not.toBeDisabled();
+    expect(screen.getByText(/valgono per tutti gli agenti/i)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /salva impostazioni/i })).toBeInTheDocument();
   });
 
-  it('read-only kind: renders read-only banner (archived)', () => {
+  it('editable: Save emits the edited value', () => {
+    const onSave = vi.fn();
     render(
       <AgentSettingsForm
-        state={{ kind: 'read-only', config: SAMPLE_CONFIG }}
+        state={{ kind: 'editable', value: SAMPLE_VALUE }}
+        labels={LABELS}
+        onSave={onSave}
+        onCancel={vi.fn()}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText(/Max Tokens/), { target: { value: '2048' } });
+    fireEvent.click(screen.getByRole('button', { name: /salva impostazioni/i }));
+
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({ maxTokens: 2048, llmModel: 'llama-3.3-70b-free' })
+    );
+  });
+
+  it('read-only archived: banner + disabled fields + no Save button', () => {
+    render(
+      <AgentSettingsForm
+        state={{ kind: 'read-only', value: SAMPLE_VALUE, readOnlyReason: 'archived' }}
         labels={LABELS}
         onSave={vi.fn()}
         onCancel={vi.fn()}
       />
     );
     expect(screen.getByText(/sola lettura/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Max Tokens/)).toBeDisabled();
+    expect(screen.queryByRole('button', { name: /salva impostazioni/i })).not.toBeInTheDocument();
   });
 
-  it('read-only kind: save button is NOT rendered', () => {
+  it('read-only standalone: renders the standalone banner', () => {
     render(
       <AgentSettingsForm
-        state={{ kind: 'read-only', config: SAMPLE_CONFIG }}
+        state={{ kind: 'read-only', value: SAMPLE_VALUE, readOnlyReason: 'standalone' }}
         labels={LABELS}
         onSave={vi.fn()}
         onCancel={vi.fn()}
       />
     );
-    expect(screen.queryByRole('button', { name: /salva impostazioni/i })).not.toBeInTheDocument();
+    expect(screen.getByText(/solo per agenti associati a un gioco/i)).toBeInTheDocument();
   });
 
-  it('loading kind: no config content visible', () => {
+  it('loading kind: no Save button', () => {
     render(
       <AgentSettingsForm
         state={{ kind: 'loading' }}
@@ -100,5 +132,62 @@ describe('AgentSettingsForm', () => {
       />
     );
     expect(screen.getByRole('button', { name: /riprova/i })).toBeInTheDocument();
+  });
+
+  it('read-only: config fields including radios are disabled', () => {
+    render(
+      <AgentSettingsForm
+        state={{ kind: 'read-only', value: SAMPLE_VALUE, readOnlyReason: 'archived' }}
+        labels={LABELS}
+        onSave={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    );
+    expect(screen.getByLabelText(/Max Tokens/)).toBeDisabled();
+    expect(screen.getByRole('radio', { name: /Amichevole/ })).toBeDisabled();
+  });
+
+  it('editable: Cancel resets edits and calls onCancel', () => {
+    const onCancel = vi.fn();
+    render(
+      <AgentSettingsForm
+        state={{ kind: 'editable', value: SAMPLE_VALUE }}
+        labels={LABELS}
+        onSave={vi.fn()}
+        onCancel={onCancel}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText(/Max Tokens/), { target: { value: '2048' } });
+    fireEvent.click(screen.getByRole('button', { name: /annulla/i }));
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+    expect(screen.getByLabelText(/Max Tokens/)).toHaveValue(4096);
+  });
+
+  it('editable: preserves in-progress edits when the source value refetches', () => {
+    // Simulates refetchOnWindowFocus bringing different server data mid-edit:
+    // the local edit buffer must NOT be clobbered.
+    const { rerender } = render(
+      <AgentSettingsForm
+        state={{ kind: 'editable', value: SAMPLE_VALUE }}
+        labels={LABELS}
+        onSave={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText(/Max Tokens/), { target: { value: '2048' } });
+
+    rerender(
+      <AgentSettingsForm
+        state={{ kind: 'editable', value: { ...SAMPLE_VALUE, maxTokens: 8000 } }}
+        labels={LABELS}
+        onSave={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    );
+
+    expect(screen.getByLabelText(/Max Tokens/)).toHaveValue(2048);
   });
 });

--- a/apps/web/src/components/features/agent-detail/index.ts
+++ b/apps/web/src/components/features/agent-detail/index.ts
@@ -64,7 +64,6 @@ export {
   type AgentSettingsFormProps,
   type AgentSettingsFormLabels,
   type SettingsState,
-  type AgentConfig,
 } from '@/components/features/agent-detail/AgentSettingsForm';
 
 // AgentDangerZone — only renders when variant === 'active', returns null otherwise

--- a/apps/web/src/components/library/AgentConfigModal.tsx
+++ b/apps/web/src/components/library/AgentConfigModal.tsx
@@ -18,7 +18,7 @@ import { useState, useEffect } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { Loader2, Check, RotateCcw, MessageCircle, Bot } from 'lucide-react';
 
-import { TypologySelector, StrategySelector } from '@/components/agent/config';
+import { TypologySelector, StrategySelector, AgentConfigFields } from '@/components/agent/config';
 import { toast } from '@/components/layout/Toast';
 import {
   Dialog,
@@ -28,25 +28,10 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/overlays/dialog';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/overlays/select';
 import { Button } from '@/components/ui/primitives/button';
-import { Input } from '@/components/ui/primitives/input';
-import { Label } from '@/components/ui/primitives/label';
-import { RadioGroup, RadioGroupItem } from '@/components/ui/primitives/radio-group';
-import { Slider } from '@/components/ui/primitives/slider';
-import { Textarea } from '@/components/ui/primitives/textarea';
 import { useAgentConfig, useUpdateAgentConfig, agentConfigKeys } from '@/hooks/queries';
 import {
   api,
-  MODEL_OPTIONS,
-  PERSONALITY_OPTIONS,
-  DETAIL_LEVEL_OPTIONS,
   DEFAULT_AGENT_CONFIG,
   type AIModel,
   type AgentPersonality,
@@ -247,134 +232,17 @@ export function AgentConfigModal({ isOpen, onClose, gameId, gameTitle }: AgentCo
             </div>
           </div>
         ) : (
-          <div className="space-y-6">
-            {/* Model Selection */}
-            <div className="space-y-2">
-              <Label htmlFor="model" className="text-base font-semibold">
-                🤖 Modello AI
-              </Label>
-              <Select value={llmModel} onValueChange={value => setLlmModel(value as AIModel)}>
-                <SelectTrigger id="model">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  {MODEL_OPTIONS.map(model => (
-                    <SelectItem key={model.value} value={model.value}>
-                      {model.label} ({model.costLevel}) {model.isDefault && '⭐'}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-              <p className="text-sm text-muted-foreground">
-                {MODEL_OPTIONS.find(m => m.value === llmModel)?.description}
-              </p>
-            </div>
-
-            {/* Temperature Slider */}
-            <div className="space-y-2">
-              <div className="flex items-center justify-between">
-                <Label htmlFor="temperature" className="text-base font-semibold">
-                  ⚙️ Temperatura
-                </Label>
-                <span className="text-sm text-muted-foreground">{temperature.toFixed(2)}</span>
-              </div>
-              <Slider
-                id="temperature"
-                min={0}
-                max={2}
-                step={0.1}
-                value={[temperature]}
-                onValueChange={([value]) => setTemperature(value)}
-                className="w-full"
-              />
-              <div className="flex justify-between text-xs text-muted-foreground">
-                <span>0.0 (Preciso)</span>
-                <span>2.0 (Creativo)</span>
-              </div>
-            </div>
-
-            {/* Max Tokens Input */}
-            <div className="space-y-2">
-              <Label htmlFor="maxTokens" className="text-base font-semibold">
-                📏 Max Tokens
-              </Label>
-              <Input
-                id="maxTokens"
-                type="number"
-                min={512}
-                max={8192}
-                step={256}
-                value={maxTokens}
-                onChange={e => setMaxTokens(Number(e.target.value))}
-              />
-              <p className="text-sm text-muted-foreground">
-                Lunghezza massima della risposta (512-8192)
-              </p>
-            </div>
-
-            {/* Personality Radio Buttons */}
-            <div className="space-y-2">
-              <Label className="text-base font-semibold">🎭 Personalità Agente</Label>
-              <RadioGroup
-                value={personality}
-                onValueChange={v => setPersonality(v as AgentPersonality)}
-              >
-                {PERSONALITY_OPTIONS.map(option => (
-                  <div key={option.value} className="flex items-center space-x-2">
-                    <RadioGroupItem value={option.value} id={`personality-${option.value}`} />
-                    <Label
-                      htmlFor={`personality-${option.value}`}
-                      className="font-normal cursor-pointer"
-                    >
-                      <span className="font-medium">{option.label}</span>
-                      <span className="text-sm text-muted-foreground ml-2">
-                        ({option.description})
-                      </span>
-                    </Label>
-                  </div>
-                ))}
-              </RadioGroup>
-            </div>
-
-            {/* Detail Level Radio Buttons */}
-            <div className="space-y-2">
-              <Label className="text-base font-semibold">📊 Livello Dettaglio</Label>
-              <RadioGroup value={detailLevel} onValueChange={v => setDetailLevel(v as DetailLevel)}>
-                {DETAIL_LEVEL_OPTIONS.map(option => (
-                  <div key={option.value} className="flex items-center space-x-2">
-                    <RadioGroupItem value={option.value} id={`detail-${option.value}`} />
-                    <Label
-                      htmlFor={`detail-${option.value}`}
-                      className="font-normal cursor-pointer"
-                    >
-                      <span className="font-medium">{option.label}</span>
-                      <span className="text-sm text-muted-foreground ml-2">
-                        ({option.description})
-                      </span>
-                    </Label>
-                  </div>
-                ))}
-              </RadioGroup>
-            </div>
-
-            {/* Custom Instructions Textarea */}
-            <div className="space-y-2">
-              <Label htmlFor="instructions" className="text-base font-semibold">
-                📝 Note Personali
-              </Label>
-              <Textarea
-                id="instructions"
-                placeholder="Es: Spiega sempre le regole come se fossi principiante"
-                value={personalNotes}
-                onChange={e => setPersonalNotes(e.target.value)}
-                maxLength={1000}
-                rows={4}
-              />
-              <div className="text-xs text-right text-muted-foreground">
-                {1000 - personalNotes.length} caratteri rimanenti
-              </div>
-            </div>
-          </div>
+          <AgentConfigFields
+            value={{ llmModel, temperature, maxTokens, personality, detailLevel, personalNotes }}
+            onChange={patch => {
+              if (patch.llmModel !== undefined) setLlmModel(patch.llmModel);
+              if (patch.temperature !== undefined) setTemperature(patch.temperature);
+              if (patch.maxTokens !== undefined) setMaxTokens(patch.maxTokens);
+              if (patch.personality !== undefined) setPersonality(patch.personality);
+              if (patch.detailLevel !== undefined) setDetailLevel(patch.detailLevel);
+              if (patch.personalNotes !== undefined) setPersonalNotes(patch.personalNotes);
+            }}
+          />
         )}
 
         {mode === 'edit' && (

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -2733,6 +2733,8 @@
         "strategyLabel": "RAG Strategy",
         "parametersLabel": "Strategy parameters",
         "readOnlyBanner": "Settings are read-only for archived agents.",
+        "readOnlyStandalone": "Configuration is available only for agents linked to a game.",
+        "perGameNote": "These settings apply to every agent for this game.",
         "saveCta": "Save settings",
         "cancelCta": "Cancel",
         "saveSuccess": "Settings saved.",

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -2783,6 +2783,8 @@
         "strategyLabel": "Strategia RAG",
         "parametersLabel": "Parametri strategia",
         "readOnlyBanner": "Le impostazioni sono in sola lettura per gli agenti archiviati.",
+        "readOnlyStandalone": "Configurazione disponibile solo per agenti associati a un gioco.",
+        "perGameNote": "Queste impostazioni valgono per tutti gli agenti di questo gioco.",
         "saveCta": "Salva impostazioni",
         "cancelCta": "Annulla",
         "saveSuccess": "Impostazioni salvate.",

--- a/docs/superpowers/specs/2026-07-07-agent-settings-tab-editable-design.md
+++ b/docs/superpowers/specs/2026-07-07-agent-settings-tab-editable-design.md
@@ -1,0 +1,136 @@
+# Settings tab editabile via `AgentConfigFields` condiviso
+
+**Issue**: #2732 (follow-up di #2727 / PR #2731)
+**Data**: 2026-07-07
+**Tipo**: feature (frontend)
+
+## Contesto e problema
+
+Nel fix #2727 il tab **Settings** di `/agents/[id]` è stato cablato al salvataggio della config AI per-gioco (`useUpdateAgentConfig` → `PUT /api/v1/library/games/{gameId}/agent-config`). Tuttavia `AgentSettingsForm` è un componente **display-only**: il sotto-componente `ConfigDisplay` renderizza `strategy` e `parameters` come testo/JSON read-only, senza input editabili. Lo stato `editable` mostra gli stessi dati read-only più i bottoni Salva/Annulla, ma **l'utente non può modificare nulla**.
+
+Il form editabile completo esiste già in `AgentConfigModal` (library) — i 6 campi della config AI per-gioco, con la loro UI e le option dal contratto `agent-config.schemas`.
+
+## Obiettivo
+
+Rendere il tab Settings un **editor reale** della config AI per-gioco, riusando un componente di campi condiviso col modal — senza duplicare la UI.
+
+## Contratto config (invariato, da #2727)
+
+`AgentConfigDto` (UserLibrary, per-gioco):
+
+```ts
+{
+  llmModel: AIModel;            // enum: llama-3.3-70b-free | google-gemini-pro | deepseek-chat | llama-3.3-70b
+  temperature: number;         // 0.0–2.0
+  maxTokens: number;           // 512–8192 (UI); BE accetta 100–32000
+  personality: AgentPersonality;   // Amichevole | Professionale | Umoristico | Conciso | Dettagliato
+  detailLevel: DetailLevel;        // Breve | Normale | Dettagliato | Esaustivo
+  personalNotes: string | null;    // max 1000
+}
+```
+
+## Design
+
+### 1. Nuovo componente `AgentConfigFields` (condiviso, controllato)
+
+`apps/web/src/components/agent/config/AgentConfigFields.tsx` — presentational puro, controllato. Estrae *verbatim* i 6 campi oggi inline in `AgentConfigModal.tsx`:
+
+- **Modello**: `Select` su `MODEL_OPTIONS`
+- **Temperatura**: `Slider` 0–2 step 0.1
+- **Max Tokens**: `Input` number 512–8192
+- **Personalità**: `RadioGroup` su `PERSONALITY_OPTIONS`
+- **Livello dettaglio**: `RadioGroup` su `DETAIL_LEVEL_OPTIONS`
+- **Note personali**: `Textarea` maxLength 1000 + contatore
+
+Contratto:
+
+```ts
+export interface AgentConfigFieldsValue {
+  llmModel: AIModel;
+  temperature: number;
+  maxTokens: number;
+  personality: AgentPersonality;
+  detailLevel: DetailLevel;
+  personalNotes: string; // stringa vuota anziché null nel form; normalizzata a null in uscita dai consumer
+}
+
+export interface AgentConfigFieldsProps {
+  value: AgentConfigFieldsValue;
+  onChange: (patch: Partial<AgentConfigFieldsValue>) => void;
+  disabled?: boolean; // read-only / archived
+}
+```
+
+Nessun hook, nessun fetch. Usa `MODEL_OPTIONS`/`PERSONALITY_OPTIONS`/`DETAIL_LEVEL_OPTIONS`/tipi da `agent-config.schemas`. Ogni input disabilitato quando `disabled`.
+
+### 2. Refactor `AgentConfigModal`
+
+Sostituisce i campi inline (righe ~250–376) con `<AgentConfigFields value={{...}} onChange={patch => applica setter}} />`. Lo stato locale (`llmModel`, `temperature`, …), `handleSave`, `handleResetToDefault` restano invariati. **Comportamento identico** — i test esistenti (inclusi quelli #2727) sono il guardrail.
+
+### 3. `AgentSettingsForm` editabile
+
+Il componente del tab evolve da display-only a editor:
+
+- `SettingsState` porta il **value tipizzato**:
+  ```ts
+  type SettingsState =
+    | { kind: 'loading' }
+    | { kind: 'error'; retry: () => void }
+    | { kind: 'editable'; value: AgentConfigFieldsValue }
+    | { kind: 'read-only'; value: AgentConfigFieldsValue; readOnlyReason: 'archived' | 'standalone' };
+  ```
+- Il form possiede lo **stato di edit locale** (init da `value`; `useEffect` che risincronizza lo stato quando cambia il `value` in ingresso, es. dopo un refetch), monta `AgentConfigFields`.
+- `editable`: campi attivi + nota per-gioco + Salva/Annulla. **Salva** → `onSave(localValue)`; **Annulla** → reset a `value`.
+- `read-only`: `AgentConfigFields disabled` + banner (`role="status"`) con testo dipendente da `readOnlyReason` (archiviato vs standalone).
+- **Nota per-gioco** (stato editable): banner informativo "Queste impostazioni valgono per tutti gli agenti di questo gioco." (label i18n).
+
+Props: `onSave: (value: AgentConfigFieldsValue) => void` (era `(config: AgentConfig) => void`).
+
+### 4. Wiring in `AgentDetailView`
+
+- `mapSettingsState(query, variant, agentHasGameId, onRetry)`:
+  - loading/error invariati.
+  - Costruisce `value` da `configQueryGated.data` con fallback ai default (`DEFAULT_AGENT_CONFIG` + `personalNotes: ''`).
+  - `archived` → `{ kind: 'read-only', value, readOnlyReason: 'archived' }`.
+  - **standalone** (agente senza `gameId`) → `{ kind: 'read-only', value, readOnlyReason: 'standalone' }`.
+  - altrimenti → `{ kind: 'editable', value }`.
+- `onSave(value)` → guardia `isPending`; `gameId` presente per costruzione (editable solo con gameId); `updateConfig.mutate({ gameId, request: { ...value, personalNotes: value.personalNotes || null } }, { onSuccess: toast.success, onError: toast.error })`.
+
+Questo **estende** il wiring #2727: si salva il **value editato** dal form (non più la config caricata). La guardia default-create di #2727 non serve più (il form parte sempre dai default quando non c'è config → salva quei valori).
+
+## Nuove label i18n (`apps/web/src/locales/it.json` + `en.json`)
+
+- `pages.agentDetail.settings.perGameNote`
+- `pages.agentDetail.settings.readOnlyStandalone`
+
+(La chiave esistente `readOnlyBanner` resta per il caso archived.) Il tab passa le nuove label a `AgentSettingsForm` via il dizionario `settingsLabels` già costruito in `AgentDetailView`.
+
+## Edge case
+
+- **Standalone (no gameId)**: read-only con nota dedicata; salvataggio non possibile (config per-gioco).
+- **Config assente**: il form parte dai default; Salva crea la config con quei valori.
+- **Archived**: read-only (comportamento attuale preservato).
+
+## Testing (TDD)
+
+1. `AgentConfigFields.test.tsx`: render dei 6 input; `onChange` emette il patch corretto per ogni campo; `disabled` disabilita tutti gli input.
+2. `AgentConfigModal.test.tsx`: i test esistenti restano verdi (refactor non-regressivo); asserzione che il payload di Salva resti BE-aligned.
+3. `AgentSettingsForm.test.tsx`: stato editable mostra input; modificando un campo e premendo Salva, `onSave` riceve il value **modificato**; read-only disabilita gli input e mostra il banner corretto per reason.
+4. `AgentDetailView.test.tsx`: (a) in editable, modifica campo + Salva → `updateConfig.mutate` col value modificato + `personalNotes` normalizzato; (b) agente standalone → tab read-only reason=standalone; (c) archived → read-only reason=archived.
+
+## Fuori scope (YAGNI)
+
+- Nessun tocco alla config **per-agente** (`AgentDefinition`: strategy/prompts/tools) o al PATCH `/agents/{id}/configuration`.
+- Nessun refactor non correlato.
+- Editabilità dei campi restano i 6 della config per-gioco (nessun campo nuovo).
+
+## File impattati
+
+| File | Azione |
+|---|---|
+| `components/agent/config/AgentConfigFields.tsx` | **nuovo** |
+| `components/library/AgentConfigModal.tsx` | refactor → usa `AgentConfigFields` |
+| `components/features/agent-detail/AgentSettingsForm.tsx` | editabile + `AgentConfigFields` |
+| `app/(authenticated)/agents/[id]/_components/AgentDetailView.tsx` | `mapSettingsState` + `onSave` value editato |
+| `messages/it.json`, `messages/en.json` | 2 label nuove |
+| relativi `__tests__/` | test TDD |


### PR DESCRIPTION
## Sommario

Follow-up di #2727 (PR #2731). Rende il tab **Settings** di `/agents/[id]` un editor reale della config AI **per-gioco** (modello, temperatura, maxTokens, personalità, livello dettaglio, note), riusando un componente di campi condiviso col modal della library.

Spec: `docs/superpowers/specs/2026-07-07-agent-settings-tab-editable-design.md` (brainstorming → design → TDD).

## Cosa cambia

- **`AgentConfigFields`** (nuovo, controllato): i 6 campi config estratti da `AgentConfigModal`. `disabled` si propaga a **tutti** i controlli (inclusi i `RadioGroupItem`).
- **`AgentConfigModal`**: refactor → usa `AgentConfigFields` (−156 righe, comportamento invariato; guardrail = typecheck + test dei campi).
- **`AgentSettingsForm`**: da display-only a **editor**. Stato di edit locale con **dirty-guard** (un refetch da `refetchOnWindowFocus` non sovrascrive edit non salvati); nota informativa per-gioco; read-only con reason `archived` | `standalone`.
- **`AgentDetailView`**: `mapSettingsState` costruisce value tipizzato + reason (editable / archived / standalone); `onSave` persiste il **valore modificato** (`personalNotes` normalizzato a `null`).
- **i18n**: 2 label nuove (`it`/`en`) — `settings.perGameNote`, `settings.readOnlyStandalone`.

## Semantica

Config **per-gioco** (condivisa dagli agenti dello stesso gioco) + nota informativa. Agenti **standalone** (senza gioco) e **archiviati** → read-only.

## Qualità

- **TDD** RED→GREEN per ogni step.
- **Review avversariale** multi-agente (4 dimensioni, 10 agenti): 6 finding LOW, tutti risolti in-PR — `disabled` sui radio, preservazione degli edit su refetch, e copertura test (onChange dei radio, read-only disabled su tutti i controlli, Cancel).
- typecheck 0 · lint 0 · **1181 test** verdi nelle aree toccate (0 regressioni). Nuovi test: `AgentConfigFields` (6), `AgentSettingsForm` (10), `AgentDetailView` (+2: edit-persiste-valore-modificato, standalone read-only).

## DoD (#2732)

- [x] `AgentConfigFields` estratto e usato da entrambi i consumer
- [x] Tab Settings modifica e salva i valori editati
- [x] Nota per-gioco; standalone/archived read-only
- [x] Test TDD; nessuna regressione
- [ ] PR verso `main-dev` mergiata

🤖 Generated with [Claude Code](https://claude.com/claude-code)
