### PR TITLE
fix(session-tracking): #2734 AsTracking on mutating getters (NoTracking no-op cluster)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Persistence/GamebookCampaignSessionRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Persistence/GamebookCampaignSessionRepository.cs
@@ -11,8 +11,14 @@ internal sealed class GamebookCampaignSessionRepository : IGamebookCampaignSessi
 
     public GamebookCampaignSessionRepository(MeepleAiDbContext db) => _db = db;
 
+    // #2734: the DbContext default is QueryTrackingBehavior.NoTracking (PERF-06). This getter
+    // feeds RenameGamebookCampaignHandler (Rename()) and UpdateGamebookProgressHandler (Touch()),
+    // which mutate the returned aggregate and rely on SaveChangesAsync to persist it. Without
+    // .AsTracking() the entity is untracked and every scalar mutation is a silent no-op.
+    // Tracking a single FirstOrDefault entity is negligible and side-effect-free for the
+    // read-only callers (e.g. CampaignOwnershipGuard), which never mutate it.
     public Task<GamebookCampaignSession?> GetByIdAsync(Guid id, CancellationToken ct = default)
-        => _db.GamebookCampaignSessions.FirstOrDefaultAsync(x => x.Id == id, ct);
+        => _db.GamebookCampaignSessions.AsTracking().FirstOrDefaultAsync(x => x.Id == id, ct);
 
     public async Task<IReadOnlyList<GamebookCampaignSession>> ListByOwnerAsync(Guid ownerUserId, Guid? gameId, CancellationToken ct = default)
     {

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Persistence/GamebookCampaignSessionRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Persistence/GamebookCampaignSessionRepository.cs
@@ -12,11 +12,15 @@ internal sealed class GamebookCampaignSessionRepository : IGamebookCampaignSessi
     public GamebookCampaignSessionRepository(MeepleAiDbContext db) => _db = db;
 
     // #2734: the DbContext default is QueryTrackingBehavior.NoTracking (PERF-06). This getter
-    // feeds RenameGamebookCampaignHandler (Rename()) and UpdateGamebookProgressHandler (Touch()),
-    // which mutate the returned aggregate and rely on SaveChangesAsync to persist it. Without
-    // .AsTracking() the entity is untracked and every scalar mutation is a silent no-op.
-    // Tracking a single FirstOrDefault entity is negligible and side-effect-free for the
-    // read-only callers (e.g. CampaignOwnershipGuard), which never mutate it.
+    // feeds every write path on the campaign aggregate — RenameGamebookCampaignHandler (Rename),
+    // UpdateGamebookProgressHandler + TranslateGamebookSegmentQueryHandler (Touch), and
+    // DeleteGamebookCampaignHandler (SoftDelete) — which mutate the returned aggregate and rely on
+    // SaveChangesAsync to persist it. Without .AsTracking() the entity is untracked and every
+    // mutation is a silent no-op. The SoftDelete no-op is especially dangerous: HasQueryFilter
+    // (!IsDeleted) only hides the row once is_deleted actually flips, so a "deleted" campaign
+    // stays visible forever. Tracking a single FirstOrDefault entity is negligible and
+    // side-effect-free for the read-only callers (e.g. CampaignOwnershipGuard,
+    // GetGamebookCampaignHandler), which never mutate it.
     public Task<GamebookCampaignSession?> GetByIdAsync(Guid id, CancellationToken ct = default)
         => _db.GamebookCampaignSessions.AsTracking().FirstOrDefaultAsync(x => x.Id == id, ct);
 

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Persistence/ToolkitSessionStateRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Persistence/ToolkitSessionStateRepository.cs
@@ -23,7 +23,14 @@ internal sealed class ToolkitSessionStateRepository : RepositoryBase, IToolkitSe
         Guid toolkitId,
         CancellationToken cancellationToken = default)
     {
+        // #2734: the DbContext default is QueryTrackingBehavior.NoTracking (PERF-06). This getter
+        // feeds UpdateWidgetStateCommandHandler's update path, which mutates the returned entity via
+        // UpdateWidgetState() and relies on IUnitOfWork.SaveChangesAsync to persist it. Without
+        // .AsTracking() the entity is untracked and the mutation is a silent no-op (the AddAsync
+        // path is unaffected). Tracking a single FirstOrDefault entity is negligible and
+        // side-effect-free for the read-only GetToolkitSessionStateQueryHandler, which never mutates it.
         return await DbContext.ToolkitSessionStates
+            .AsTracking()
             .FirstOrDefaultAsync(s => s.SessionId == sessionId && s.ToolkitId == toolkitId, cancellationToken)
             .ConfigureAwait(false);
     }

--- a/apps/api/tests/Api.Tests/Integration/SessionTracking/SessionTrackingNoTrackingPersistenceTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/SessionTracking/SessionTrackingNoTrackingPersistenceTests.cs
@@ -1,0 +1,167 @@
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using Api.Infrastructure;
+using Api.SharedKernel.Domain.ValueObjects;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.Integration.SessionTracking;
+
+/// <summary>
+/// Regression for #2734: the sibling NoTracking silent no-op cluster surfaced while
+/// investigating #2660. The DbContext defaults to <c>QueryTrackingBehavior.NoTracking</c>
+/// (PERF-06), so a repository getter that loads an entity, hands it to a handler that mutates
+/// it via a domain method, and then calls <c>SaveChangesAsync</c> persists NOTHING unless the
+/// getter opts back into tracking with <c>.AsTracking()</c> — the mutation is a silent no-op.
+///
+/// Two getters were affected (verified):
+///  - <see cref="IGamebookCampaignSessionRepository.GetByIdAsync"/> → Rename() / Touch()
+///  - <see cref="IToolkitSessionStateRepository.GetBySessionAsync"/> → UpdateWidgetState() (update path)
+///
+/// Existing Category=Unit tests missed this because they mock the repository and never exercise
+/// the real EF NoTracking pipeline.
+/// </summary>
+[Collection("Integration-GroupD")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "SessionTracking")]
+[Trait("Issue", "2734")]
+public sealed class SessionTrackingNoTrackingPersistenceTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly string _databaseName = $"session_tracking_notracking_{Guid.NewGuid():N}";
+    private WebApplicationFactory<Program> _factory = null!;
+
+    public SessionTrackingNoTrackingPersistenceTests(SharedTestcontainersFixture fixture) => _fixture = fixture;
+
+    public async ValueTask InitializeAsync()
+    {
+        var conn = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+        await TestcontainersWaitHelpers.WaitForPostgresReadyAsync(conn);
+        _factory = IntegrationWebApplicationFactory.Create(conn);
+        using var scope = _factory.Services.CreateScope();
+        await scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>().Database.MigrateAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_factory != null) await _factory.DisposeAsync();
+        await _fixture.DropIsolatedDatabaseAsync(_databaseName);
+    }
+
+    [Fact(DisplayName = "#2734: GamebookCampaignSession.Rename persists the Title scalar through the getter")]
+    public async Task RenameGamebookCampaign_PersistsTitle()
+    {
+        Guid campaignId;
+        Guid ownerId;
+        await using (var scope = _factory.Services.CreateAsyncScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            var repo = scope.ServiceProvider.GetRequiredService<IGamebookCampaignSessionRepository>();
+
+            (ownerId, _) = await TestSessionHelper.CreateUserSessionAsync(db);
+            var session = GamebookCampaignSession.Create(GameRef.Shared(Guid.NewGuid()), ownerId, "Original Title");
+            await repo.AddAsync(session, CancellationToken.None);
+            await repo.SaveChangesAsync(CancellationToken.None);
+            campaignId = session.Id;
+        }
+
+        // Replicates RenameGamebookCampaignHandler: load via getter, mutate via domain method, save.
+        await using (var scope = _factory.Services.CreateAsyncScope())
+        {
+            var repo = scope.ServiceProvider.GetRequiredService<IGamebookCampaignSessionRepository>();
+
+            var session = await repo.GetByIdAsync(campaignId, CancellationToken.None);
+            session!.Rename("Renamed Title", ownerId);
+            await repo.SaveChangesAsync(CancellationToken.None);
+        }
+
+        await using (var scope = _factory.Services.CreateAsyncScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            var entity = await db.GamebookCampaignSessions.AsNoTracking().FirstAsync(x => x.Id == campaignId);
+            entity.Title.Should().Be("Renamed Title",
+                "GetByIdAsync must load .AsTracking() so Rename() is persisted (#2734 — NoTracking silent no-op)");
+        }
+    }
+
+    [Fact(DisplayName = "#2734: GamebookCampaignSession.Touch persists the UpdatedBy scalar through the getter")]
+    public async Task TouchGamebookCampaign_PersistsUpdatedBy()
+    {
+        Guid campaignId;
+        Guid ownerId;
+        await using (var scope = _factory.Services.CreateAsyncScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            var repo = scope.ServiceProvider.GetRequiredService<IGamebookCampaignSessionRepository>();
+
+            (ownerId, _) = await TestSessionHelper.CreateUserSessionAsync(db);
+            var session = GamebookCampaignSession.Create(GameRef.Shared(Guid.NewGuid()), ownerId, "Progress Campaign");
+            await repo.AddAsync(session, CancellationToken.None);
+            await repo.SaveChangesAsync(CancellationToken.None);
+            campaignId = session.Id;
+        }
+
+        // Replicates UpdateGamebookProgressHandler's parent-session Touch(): load, mutate, save.
+        await using (var scope = _factory.Services.CreateAsyncScope())
+        {
+            var repo = scope.ServiceProvider.GetRequiredService<IGamebookCampaignSessionRepository>();
+
+            var session = await repo.GetByIdAsync(campaignId, CancellationToken.None);
+            session!.Touch(ownerId);
+            await repo.SaveChangesAsync(CancellationToken.None);
+        }
+
+        await using (var scope = _factory.Services.CreateAsyncScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            var entity = await db.GamebookCampaignSessions.AsNoTracking().FirstAsync(x => x.Id == campaignId);
+            entity.UpdatedBy.Should().Be(ownerId,
+                "GetByIdAsync must load .AsTracking() so Touch() is persisted (#2734 — NoTracking silent no-op)");
+        }
+    }
+
+    [Fact(DisplayName = "#2734: ToolkitSessionState.UpdateWidgetState persists the widget state (update path) through the getter")]
+    public async Task UpdateWidgetState_PersistsWidgetStates()
+    {
+        var sessionId = Guid.NewGuid();
+        var toolkitId = Guid.NewGuid();
+
+        await using (var scope = _factory.Services.CreateAsyncScope())
+        {
+            var repo = scope.ServiceProvider.GetRequiredService<IToolkitSessionStateRepository>();
+            var uow = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+
+            var state = ToolkitSessionState.Create(sessionId, toolkitId);
+            await repo.AddAsync(state, CancellationToken.None);
+            await uow.SaveChangesAsync(CancellationToken.None);
+        }
+
+        // Replicates UpdateWidgetStateCommandHandler's update path (state already exists):
+        // load via getter, mutate via domain method, save via unit of work.
+        await using (var scope = _factory.Services.CreateAsyncScope())
+        {
+            var repo = scope.ServiceProvider.GetRequiredService<IToolkitSessionStateRepository>();
+            var uow = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+
+            var state = await repo.GetBySessionAsync(sessionId, toolkitId, CancellationToken.None);
+            state!.UpdateWidgetState("TurnManager", "{\"turn\":3}");
+            await uow.SaveChangesAsync(CancellationToken.None);
+        }
+
+        await using (var scope = _factory.Services.CreateAsyncScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            var entity = await db.ToolkitSessionStates.AsNoTracking().FirstAsync(x => x.SessionId == sessionId && x.ToolkitId == toolkitId);
+            entity.WidgetStates.Should().ContainKey("TurnManager",
+                "GetBySessionAsync must load .AsTracking() so UpdateWidgetState() is persisted on the update path (#2734 — NoTracking silent no-op)");
+            entity.WidgetStates["TurnManager"].Should().Be("{\"turn\":3}");
+        }
+    }
+}

--- a/apps/api/tests/Api.Tests/Integration/SessionTracking/SessionTrackingNoTrackingPersistenceTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/SessionTracking/SessionTrackingNoTrackingPersistenceTests.cs
@@ -127,6 +127,47 @@ public sealed class SessionTrackingNoTrackingPersistenceTests : IAsyncLifetime
         }
     }
 
+    [Fact(DisplayName = "#2734: GamebookCampaignSession.SoftDelete persists IsDeleted through the getter (data-integrity: HasQueryFilter)")]
+    public async Task SoftDeleteGamebookCampaign_PersistsIsDeleted()
+    {
+        Guid campaignId;
+        Guid ownerId;
+        await using (var scope = _factory.Services.CreateAsyncScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            var repo = scope.ServiceProvider.GetRequiredService<IGamebookCampaignSessionRepository>();
+
+            (ownerId, _) = await TestSessionHelper.CreateUserSessionAsync(db);
+            var session = GamebookCampaignSession.Create(GameRef.Shared(Guid.NewGuid()), ownerId, "Doomed Campaign");
+            await repo.AddAsync(session, CancellationToken.None);
+            await repo.SaveChangesAsync(CancellationToken.None);
+            campaignId = session.Id;
+        }
+
+        // Replicates DeleteGamebookCampaignHandler: load via getter, SoftDelete(), save.
+        await using (var scope = _factory.Services.CreateAsyncScope())
+        {
+            var repo = scope.ServiceProvider.GetRequiredService<IGamebookCampaignSessionRepository>();
+
+            var session = await repo.GetByIdAsync(campaignId, CancellationToken.None);
+            session!.SoftDelete(ownerId);
+            await repo.SaveChangesAsync(CancellationToken.None);
+        }
+
+        await using (var scope = _factory.Services.CreateAsyncScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            // IgnoreQueryFilters(): the global HasQueryFilter(e => !e.IsDeleted) would otherwise
+            // hide the row. Assert the column actually flipped — a NoTracking no-op would leave
+            // is_deleted=false, leaving the "deleted" campaign visible forever (data-integrity bug).
+            var entity = await db.GamebookCampaignSessions.IgnoreQueryFilters().AsNoTracking()
+                .FirstAsync(x => x.Id == campaignId);
+            entity.IsDeleted.Should().BeTrue(
+                "GetByIdAsync must load .AsTracking() so SoftDelete() flips is_deleted (#2734 — HasQueryFilter makes this a data-integrity bug)");
+            entity.DeletedAt.Should().NotBeNull();
+        }
+    }
+
     [Fact(DisplayName = "#2734: ToolkitSessionState.UpdateWidgetState persists the widget state (update path) through the getter")]
     public async Task UpdateWidgetState_PersistsWidgetStates()
     {


### PR DESCRIPTION
Closes #2734

## Root cause (verified in code)

The DbContext defaults to `QueryTrackingBehavior.NoTracking` (PERF-06, `InfrastructureServiceExtensions.cs:178`). Two SessionTracking getters loaded entities **untracked** that handlers then mutated via domain methods before calling `SaveChangesAsync` — making the mutation a **silent no-op** (same class as #2660):

| Getter | Handler / mutation | Effect |
|---|---|---|
| `GamebookCampaignSessionRepository.GetByIdAsync` | `RenameGamebookCampaignHandler` (`Rename()`) + `UpdateGamebookProgressHandler` (`Touch()`) | rename / progress-touch not persisted |
| `ToolkitSessionStateRepository.GetBySessionAsync` | `UpdateWidgetStateCommandHandler` (`UpdateWidgetState()`) | widget-state update not persisted (the `AddAsync` path was already fine) |

## Fix

Add `.AsTracking()` to both getters. Verified all callers first: both getters are also consumed by read-only paths (`CampaignOwnershipGuard`, `GetToolkitSessionStateQueryHandler`) where tracking a single `FirstOrDefault` entity is negligible and side-effect-free (the entity is never mutated there). This mirrors the precedent set by #2660 and the sibling glossary fix in #2638.

**Boundary with #2638**: this PR does **not** touch `GamebookGlossaryRepository` — that getter is fixed by the #2638 (glossary multi-context) PR, as noted in the issue. No file overlap.

## Tests

`Category=Unit` tests missed this because they mock the repository and never exercise the real EF NoTracking pipeline. Added an EF-real integration test (Testcontainers Postgres, 3-scope seed→mutate→assert on the persisted scalar/JSONB columns), one per affected path:

- `RenameGamebookCampaign_PersistsTitle`
- `TouchGamebookCampaign_PersistsUpdatedBy`
- `UpdateWidgetState_PersistsWidgetStates`

Verified RED before the fix (Title stale / UpdatedBy null / WidgetStates empty), GREEN after.

## Verification

- 3 new #2734 tests: RED → GREEN ✅
- Related callers (guard / handlers / toolkit): 16/16 ✅ (no logic regression)
- The 20 unrelated integration failures in the full-context run were Postgres connection exhaustion from parallel Testcontainers locally (setup `InitializeAsync`) — confirmed by running `SetTurnOrderCommandTests` in isolation (3/3 pass), not related to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)