### PR TITLE
feat(glossary): #2638 multi-context support for gamebook glossary entries (SI-7)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/BootstrapGamebookGlossaryCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/BootstrapGamebookGlossaryCommandHandler.cs
@@ -85,7 +85,8 @@ internal sealed class BootstrapGamebookGlossaryCommandHandler
     }
 
     private static GamebookGlossaryEntryDto MapToDto(GamebookGlossaryEntry e) => new(
-        e.Id, e.TermEn, e.TermIt, e.Source.ToString(), e.UpdatedAt);
+        e.Id, e.TermEn, e.TermIt, e.Source.ToString(), e.UpdatedAt,
+        e.Contexts.Select(c => new GlossaryContextDto(c.BookId, c.ParagraphRef, c.Definition)).ToList());
 
     private sealed record BootstrapResult(IReadOnlyList<BootstrapEntry> Entries);
     private sealed record BootstrapEntry(string En, string It);

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/UpsertGlossaryEntryCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/UpsertGlossaryEntryCommand.cs
@@ -8,4 +8,6 @@ public sealed record UpsertGlossaryEntryCommand(
     Guid EntryId,
     string TermEn,
     string TermIt,
-    Guid CallerUserId) : IRequest<GamebookGlossaryEntryDto>;
+    Guid CallerUserId,
+    // #2638 / SI-7: null = leave existing contexts unchanged; non-null = full-set replace.
+    IReadOnlyList<GlossaryContextDto>? Contexts = null) : IRequest<GamebookGlossaryEntryDto>;

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/UpsertGlossaryEntryCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/UpsertGlossaryEntryCommandHandler.cs
@@ -3,6 +3,7 @@ using Api.BoundedContexts.SessionTracking.Domain.Entities;
 using Api.BoundedContexts.SessionTracking.Domain.Enums;
 using Api.BoundedContexts.SessionTracking.Domain.Exceptions;
 using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using Api.BoundedContexts.SessionTracking.Domain.ValueObjects;
 using Api.Middleware.Exceptions;
 using MediatR;
 
@@ -48,7 +49,8 @@ internal sealed class UpsertGlossaryEntryCommandHandler
         if (existing is null)
         {
             entry = GamebookGlossaryEntry.Create(
-                cmd.CampaignId, cmd.TermEn, cmd.TermIt, GlossarySource.Manual, cmd.CallerUserId);
+                cmd.CampaignId, cmd.TermEn, cmd.TermIt, GlossarySource.Manual, cmd.CallerUserId,
+                contexts: cmd.Contexts?.Select(c => GlossaryContext.Create(c.BookId, c.ParagraphRef, c.Definition)));
             await _glossary.AddAsync(entry, cancellationToken).ConfigureAwait(false);
         }
         else
@@ -57,11 +59,22 @@ internal sealed class UpsertGlossaryEntryCommandHandler
                 throw new ConflictException("Entry does not belong to this campaign");
 
             existing.UpdateTermIt(cmd.TermIt, cmd.CallerUserId);
+
+            // #2638 / SI-7: null = leave existing contexts unchanged; non-null = full-set replace.
+            if (cmd.Contexts is not null)
+            {
+                existing.ReplaceContexts(
+                    cmd.Contexts.Select(c => GlossaryContext.Create(c.BookId, c.ParagraphRef, c.Definition)),
+                    cmd.CallerUserId);
+            }
+
             entry = existing;
         }
 
         await _glossary.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
-        return new GamebookGlossaryEntryDto(entry.Id, entry.TermEn, entry.TermIt, entry.Source.ToString(), entry.UpdatedAt);
+        return new GamebookGlossaryEntryDto(
+            entry.Id, entry.TermEn, entry.TermIt, entry.Source.ToString(), entry.UpdatedAt,
+            entry.Contexts.Select(c => new GlossaryContextDto(c.BookId, c.ParagraphRef, c.Definition)).ToList());
     }
 }

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/DTOs/GamebookGlossaryEntryDto.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/DTOs/GamebookGlossaryEntryDto.cs
@@ -5,4 +5,11 @@ public sealed record GamebookGlossaryEntryDto(
     string TermEn,
     string TermIt,
     string Source,
-    DateTimeOffset UpdatedAt);
+    DateTimeOffset UpdatedAt,
+    IReadOnlyList<GlossaryContextDto> Contexts);
+
+/// <summary>
+/// A single provenance context (book + optional paragraph ref + optional definition)
+/// for a glossary term. #2638 / SI-7. Serialized to camelCase by the API JSON options.
+/// </summary>
+public sealed record GlossaryContextDto(Guid BookId, string? ParagraphRef, string? Definition);

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/GetGamebookGlossaryQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/GetGamebookGlossaryQueryHandler.cs
@@ -31,7 +31,9 @@ internal sealed class GetGamebookGlossaryQueryHandler
         var entries = await _glossary.ListByCampaignAsync(query.CampaignId, cancellationToken).ConfigureAwait(false);
 
         return entries
-            .Select(e => new GamebookGlossaryEntryDto(e.Id, e.TermEn, e.TermIt, e.Source.ToString(), e.UpdatedAt))
+            .Select(e => new GamebookGlossaryEntryDto(
+                e.Id, e.TermEn, e.TermIt, e.Source.ToString(), e.UpdatedAt,
+                e.Contexts.Select(c => new GlossaryContextDto(c.BookId, c.ParagraphRef, c.Definition)).ToList()))
             .ToList()
             .AsReadOnly();
     }

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Entities/GamebookGlossaryEntry.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Entities/GamebookGlossaryEntry.cs
@@ -1,4 +1,8 @@
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using Api.BoundedContexts.SessionTracking.Domain.Enums;
+using Api.BoundedContexts.SessionTracking.Domain.ValueObjects;
 
 namespace Api.BoundedContexts.SessionTracking.Domain.Entities;
 
@@ -8,15 +12,41 @@ namespace Api.BoundedContexts.SessionTracking.Domain.Entities;
 /// Iter 1.B — Libro Game Nanolith dogfood demo.
 /// C6 (2026-05-19): <see cref="FirstSeenBookId"/> records the book where a term
 /// first appeared (nullable — may be unknown when bootstrapped or created manually).
+/// #2638 / SI-7 (2026-07-07): <see cref="Contexts"/> persists ALL books/paragraphs
+/// where a term appears (multi-context), stored as a JSONB array. <see cref="FirstSeenBookId"/>
+/// is retained as the backward-compat pointer to the first context.
 /// </summary>
 public sealed class GamebookGlossaryEntry
 {
+    // Preserve non-ASCII paragraph markers (e.g. "§147") in the JSONB payload instead of escaping
+    // them. JSONB stores Unicode natively, so unescaped UTF-8 is simpler to query and read.
+    // UnsafeRelaxedJsonEscaping is safe here because the value is persisted to a JSONB column,
+    // not embedded into an HTML / JS context. Mirrors SessionBookProgress.
+    private static readonly JsonSerializerOptions ContextsSerializerOptions = new()
+    {
+        Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping,
+    };
+
     public Guid Id { get; private set; }
     public Guid CampaignId { get; private set; }
     public string TermEn { get; private set; } = default!;
     public string TermIt { get; private set; } = default!;
     public GlossarySource Source { get; private set; }
     public Guid? FirstSeenBookId { get; private set; }
+
+    /// <summary>
+    /// Raw JSONB payload of the multi-context list. Backed by the <c>contexts</c> column.
+    /// Prefer the <see cref="Contexts"/> projection for reads and the mutators
+    /// (<see cref="AddContext"/> / <see cref="RemoveContext"/> / <see cref="ReplaceContexts"/>)
+    /// for writes.
+    /// </summary>
+    public string ContextsJson { get; private set; } = "[]";
+
+    /// <summary>Deserialized view of <see cref="ContextsJson"/>. Not mapped (see config Ignore).</summary>
+    [JsonIgnore]
+    public IReadOnlyList<GlossaryContext> Contexts =>
+        JsonSerializer.Deserialize<List<GlossaryContext>>(ContextsJson) ?? new List<GlossaryContext>();
+
     public DateTimeOffset CreatedAt { get; private set; }
     public DateTimeOffset UpdatedAt { get; private set; }
     public Guid CreatedBy { get; private set; }
@@ -31,7 +61,8 @@ public sealed class GamebookGlossaryEntry
         string termIt,
         GlossarySource source,
         Guid createdBy,
-        Guid? firstSeenBookId = null)
+        Guid? firstSeenBookId = null,
+        IEnumerable<GlossaryContext>? contexts = null)
     {
         if (campaignId == Guid.Empty)
             throw new ArgumentException("campaignId required", nameof(campaignId));
@@ -44,6 +75,20 @@ public sealed class GamebookGlossaryEntry
         if (firstSeenBookId.HasValue && firstSeenBookId.Value == Guid.Empty)
             throw new ArgumentException("firstSeenBookId cannot be Guid.Empty when set", nameof(firstSeenBookId));
 
+        string contextsJson;
+        if (contexts is not null)
+        {
+            contextsJson = SerializeContexts(Dedup(contexts));
+        }
+        else if (firstSeenBookId.HasValue)
+        {
+            contextsJson = SerializeContexts(new[] { new GlossaryContext(firstSeenBookId.Value, null, null) });
+        }
+        else
+        {
+            contextsJson = "[]";
+        }
+
         var now = DateTimeOffset.UtcNow;
         return new GamebookGlossaryEntry
         {
@@ -53,6 +98,7 @@ public sealed class GamebookGlossaryEntry
             TermIt = termIt.Trim(),
             Source = source,
             FirstSeenBookId = firstSeenBookId,
+            ContextsJson = contextsJson,
             CreatedAt = now,
             UpdatedAt = now,
             CreatedBy = createdBy,
@@ -74,4 +120,81 @@ public sealed class GamebookGlossaryEntry
         UpdatedAt = DateTimeOffset.UtcNow;
         UpdatedBy = editedBy;
     }
+
+    /// <summary>
+    /// Adds a context if no context with the same <c>(BookId, ParagraphRef)</c>
+    /// (case-insensitive on ParagraphRef) already exists. Stamps the audit fields
+    /// only when a context is actually appended.
+    /// </summary>
+    public void AddContext(GlossaryContext ctx, Guid editedBy)
+    {
+        ArgumentNullException.ThrowIfNull(ctx);
+        if (editedBy == Guid.Empty)
+            throw new ArgumentException("editedBy required", nameof(editedBy));
+
+        var list = Contexts.ToList();
+        if (list.Any(c => SameKey(c, ctx)))
+            return;
+
+        list.Add(ctx);
+        ContextsJson = SerializeContexts(list);
+        Stamp(editedBy);
+    }
+
+    /// <summary>
+    /// Removes any context matching <c>(BookId, ParagraphRef)</c> (case-insensitive on
+    /// ParagraphRef). Stamps the audit fields only when at least one context is removed.
+    /// </summary>
+    public void RemoveContext(GlossaryContext ctx, Guid editedBy)
+    {
+        ArgumentNullException.ThrowIfNull(ctx);
+        if (editedBy == Guid.Empty)
+            throw new ArgumentException("editedBy required", nameof(editedBy));
+
+        var list = Contexts.ToList();
+        var removed = list.RemoveAll(c => SameKey(c, ctx));
+        if (removed == 0)
+            return;
+
+        ContextsJson = SerializeContexts(list);
+        Stamp(editedBy);
+    }
+
+    /// <summary>
+    /// Replaces the full context set (dedup by <c>(BookId, ParagraphRef)</c>,
+    /// case-insensitive on ParagraphRef) and stamps the audit fields.
+    /// </summary>
+    public void ReplaceContexts(IEnumerable<GlossaryContext> ctxs, Guid editedBy)
+    {
+        ArgumentNullException.ThrowIfNull(ctxs);
+        if (editedBy == Guid.Empty)
+            throw new ArgumentException("editedBy required", nameof(editedBy));
+
+        ContextsJson = SerializeContexts(Dedup(ctxs));
+        Stamp(editedBy);
+    }
+
+    private void Stamp(Guid editedBy)
+    {
+        UpdatedAt = DateTimeOffset.UtcNow;
+        UpdatedBy = editedBy;
+    }
+
+    private static bool SameKey(GlossaryContext a, GlossaryContext b)
+        => a.BookId == b.BookId
+           && string.Equals(a.ParagraphRef, b.ParagraphRef, StringComparison.OrdinalIgnoreCase);
+
+    private static List<GlossaryContext> Dedup(IEnumerable<GlossaryContext> ctxs)
+    {
+        var result = new List<GlossaryContext>();
+        foreach (var c in ctxs)
+        {
+            if (!result.Any(existing => SameKey(existing, c)))
+                result.Add(c);
+        }
+        return result;
+    }
+
+    private static string SerializeContexts(IEnumerable<GlossaryContext> ctxs)
+        => JsonSerializer.Serialize(ctxs, ContextsSerializerOptions);
 }

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/ValueObjects/GlossaryContext.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/ValueObjects/GlossaryContext.cs
@@ -1,0 +1,33 @@
+namespace Api.BoundedContexts.SessionTracking.Domain.ValueObjects;
+
+/// <summary>
+/// A single provenance context for a glossary term: the <see cref="BookId"/> and,
+/// optionally, the paragraph reference (<see cref="ParagraphRef"/>) where the term
+/// appears, plus an optional context-specific <see cref="Definition"/>.
+///
+/// Part of the multi-context glossary model (issue #2638 / SI-7): a term may appear
+/// in several books/paragraphs, each carrying its own optional definition. The old
+/// single-context pointer (<c>GamebookGlossaryEntry.FirstSeenBookId</c>) is retained
+/// for backward-compat and still marks the "first" context.
+///
+/// The positional constructor is public so System.Text.Json can round-trip the value
+/// from the JSONB payload; use <see cref="Create"/> for validated, normalized instances.
+/// </summary>
+public sealed record GlossaryContext(Guid BookId, string? ParagraphRef, string? Definition)
+{
+    /// <summary>
+    /// Creates a normalized context. Throws when <paramref name="bookId"/> is empty.
+    /// Whitespace-only <paramref name="paragraphRef"/> / <paramref name="definition"/>
+    /// are normalized to <c>null</c>; otherwise they are trimmed.
+    /// </summary>
+    public static GlossaryContext Create(Guid bookId, string? paragraphRef = null, string? definition = null)
+    {
+        if (bookId == Guid.Empty)
+            throw new ArgumentException("bookId required", nameof(bookId));
+
+        return new GlossaryContext(bookId, Normalize(paragraphRef), Normalize(definition));
+    }
+
+    private static string? Normalize(string? value)
+        => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+}

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Persistence/GamebookGlossaryRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Persistence/GamebookGlossaryRepository.cs
@@ -39,7 +39,11 @@ internal sealed class GamebookGlossaryRepository : IGamebookGlossaryRepository
     }
 
     public Task<GamebookGlossaryEntry?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
-        => _db.GamebookGlossaryEntries.FirstOrDefaultAsync(x => x.Id == id, cancellationToken);
+        // #2638 / PERF-06: the upsert handler mutates the returned entity (UpdateTermIt /
+        // ReplaceContexts) and expects SaveChanges to persist it. Under the global
+        // QueryTrackingBehavior.NoTracking default the mutation would be a silent no-op
+        // (same class as #2660), so this getter must load .AsTracking().
+        => _db.GamebookGlossaryEntries.AsTracking().FirstOrDefaultAsync(x => x.Id == id, cancellationToken);
 
     public async Task AddRangeAsync(IEnumerable<GamebookGlossaryEntry> entries, CancellationToken cancellationToken = default)
     {

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/SessionTracking/GamebookGlossaryEntryEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/SessionTracking/GamebookGlossaryEntryEntityConfiguration.cs
@@ -24,6 +24,9 @@ internal class GamebookGlossaryEntryEntityConfiguration : IEntityTypeConfigurati
         builder.Property(e => e.TermIt).HasColumnName("term_it").HasMaxLength(200).IsRequired();
         builder.Property(e => e.Source).HasColumnName("source").IsRequired();
         builder.Property(e => e.FirstSeenBookId).HasColumnName("first_seen_book_id");
+        // #2638 / SI-7: multi-context list persisted as a JSONB array (default "[]").
+        builder.Property(e => e.ContextsJson).HasColumnName("contexts").HasColumnType("jsonb").IsRequired().HasDefaultValue("[]");
+        builder.Ignore(e => e.Contexts);
         builder.Property(e => e.CreatedAt).HasColumnName("created_at").IsRequired();
         builder.Property(e => e.UpdatedAt).HasColumnName("updated_at").IsRequired();
         builder.Property(e => e.CreatedBy).HasColumnName("created_by").IsRequired();

--- a/apps/api/src/Api/Infrastructure/Migrations/20260707063209_AddGlossaryContexts.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260707063209_AddGlossaryContexts.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260707063209_AddGlossaryContexts")]
+    partial class AddGlossaryContexts
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260707063209_AddGlossaryContexts.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260707063209_AddGlossaryContexts.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddGlossaryContexts : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "contexts",
+                schema: "session_tracking",
+                table: "gamebook_glossary_entries",
+                type: "jsonb",
+                nullable: false,
+                defaultValue: "[]");
+
+            // #2638 / SI-7: backfill the multi-context list from the legacy single-context
+            // pointer. Keys are PascalCase to match System.Text.Json default serialization
+            // (the C# GlossaryContext record round-trips {BookId, ParagraphRef, Definition}).
+            // Rows with no first_seen_book_id keep the "[]" default.
+            migrationBuilder.Sql(
+                "UPDATE session_tracking.gamebook_glossary_entries " +
+                "SET contexts = jsonb_build_array(jsonb_build_object(" +
+                "'BookId', first_seen_book_id::text, 'ParagraphRef', NULL, 'Definition', NULL)) " +
+                "WHERE first_seen_book_id IS NOT NULL;");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "contexts",
+                schema: "session_tracking",
+                table: "gamebook_glossary_entries");
+        }
+    }
+}

--- a/apps/api/src/Api/Routing/GamebookPhotoEndpoints.cs
+++ b/apps/api/src/Api/Routing/GamebookPhotoEndpoints.cs
@@ -490,7 +490,7 @@ internal static class GamebookPhotoEndpoints
                 return Results.BadRequest(new { error = "termIt is required" });
 
             var dto = await mediator.Send(
-                new UpsertGlossaryEntryCommand(campaignId, entryId, body.TermEn, body.TermIt, userId),
+                new UpsertGlossaryEntryCommand(campaignId, entryId, body.TermEn, body.TermIt, userId, body.Contexts),
                 ct).ConfigureAwait(false);
 
             return Results.Ok(dto);
@@ -607,4 +607,11 @@ internal static class GamebookPhotoEndpoints
 }
 
 /// <summary>Request body for upserting a glossary entry.</summary>
-public sealed record UpsertGlossaryEntryRequest(string TermEn, string TermIt);
+/// <remarks>
+/// #2638 / SI-7: <c>Contexts</c> is optional — null leaves existing contexts unchanged,
+/// non-null replaces the full set (dedup by book + paragraph ref).
+/// </remarks>
+public sealed record UpsertGlossaryEntryRequest(
+    string TermEn,
+    string TermIt,
+    IReadOnlyList<GlossaryContextDto>? Contexts = null);

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Commands/UpsertGlossaryEntryCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Commands/UpsertGlossaryEntryCommandHandlerTests.cs
@@ -1,4 +1,5 @@
 using Api.BoundedContexts.SessionTracking.Application.Commands;
+using Api.BoundedContexts.SessionTracking.Application.DTOs;
 using Api.BoundedContexts.SessionTracking.Domain.Entities;
 using Api.BoundedContexts.SessionTracking.Domain.Enums;
 using Api.BoundedContexts.SessionTracking.Domain.Exceptions;
@@ -143,5 +144,101 @@ public sealed class UpsertGlossaryEntryCommandHandlerTests
 
         // Assert
         await act.Should().ThrowAsync<GlossaryTermCollisionException>();
+    }
+
+    // -------------------------------------------------------------------------
+    // #2638 / SI-7 — multi-context upsert
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    [Trait("Issue", "2638")]
+    public async Task Handle_WithContexts_ReplacesAndReturnsThemInDto()
+    {
+        // Arrange — existing entry seeded with a single (legacy) context.
+        var legacyBook = Guid.NewGuid();
+        var editing = GamebookGlossaryEntry.Create(
+            CampaignId, "Voidstone", "Pietra del Vuoto", GlossarySource.Manual, OwnerId,
+            firstSeenBookId: legacyBook);
+        _glossaryMock
+            .Setup(r => r.GetByIdAsync(editing.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(editing);
+        _glossaryMock
+            .Setup(r => r.GetByTermItAsync(CampaignId, "Pietra del Vuoto", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((GamebookGlossaryEntry?)null);
+
+        var bookA = Guid.NewGuid();
+        var bookB = Guid.NewGuid();
+        var cmd = new UpsertGlossaryEntryCommand(
+            CampaignId, editing.Id, "Voidstone", "Pietra del Vuoto", OwnerId,
+            Contexts: new List<GlossaryContextDto>
+            {
+                new(bookA, "§147", null),
+                new(bookB, "§63", "definizione contestuale"),
+            });
+
+        // Act
+        var dto = await _handler.Handle(cmd, CancellationToken.None);
+
+        // Assert — full-set replace; legacy context gone, both new ones present in the DTO.
+        dto.Contexts.Should().HaveCount(2);
+        dto.Contexts.Should().NotContain(c => c.BookId == legacyBook);
+        dto.Contexts.Should().ContainSingle(c => c.BookId == bookA && c.ParagraphRef == "§147" && c.Definition == null);
+        dto.Contexts.Should().ContainSingle(c =>
+            c.BookId == bookB && c.ParagraphRef == "§63" && c.Definition == "definizione contestuale");
+        _glossaryMock.Verify(r => r.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    [Trait("Issue", "2638")]
+    public async Task Handle_WithoutContexts_LeavesExistingUnchanged()
+    {
+        // Arrange — existing entry with a single seeded context; command carries no contexts.
+        var legacyBook = Guid.NewGuid();
+        var editing = GamebookGlossaryEntry.Create(
+            CampaignId, "Voidstone", "Pietra del Vuoto", GlossarySource.Manual, OwnerId,
+            firstSeenBookId: legacyBook);
+        _glossaryMock
+            .Setup(r => r.GetByIdAsync(editing.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(editing);
+        _glossaryMock
+            .Setup(r => r.GetByTermItAsync(CampaignId, "Pietra del Vuoto rev", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((GamebookGlossaryEntry?)null);
+
+        var cmd = new UpsertGlossaryEntryCommand(
+            CampaignId, editing.Id, "Voidstone", "Pietra del Vuoto rev", OwnerId,
+            Contexts: null);
+
+        // Act
+        var dto = await _handler.Handle(cmd, CancellationToken.None);
+
+        // Assert — termIt updated, but the pre-existing context is untouched.
+        dto.TermIt.Should().Be("Pietra del Vuoto rev");
+        dto.Contexts.Should().ContainSingle(c => c.BookId == legacyBook);
+    }
+
+    [Fact]
+    [Trait("Issue", "2638")]
+    public async Task Handle_CreateWithContexts_PersistsThemOnNewEntry()
+    {
+        // Arrange — no existing entry (create branch).
+        _glossaryMock
+            .Setup(r => r.GetByIdAsync(EntryId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((GamebookGlossaryEntry?)null);
+        _glossaryMock
+            .Setup(r => r.GetByTermItAsync(CampaignId, "Spada", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((GamebookGlossaryEntry?)null);
+
+        var bookA = Guid.NewGuid();
+        var cmd = new UpsertGlossaryEntryCommand(
+            CampaignId, EntryId, "Sword", "Spada", OwnerId,
+            Contexts: new List<GlossaryContextDto> { new(bookA, "§12", null) });
+
+        // Act
+        var dto = await _handler.Handle(cmd, CancellationToken.None);
+
+        // Assert
+        dto.TermEn.Should().Be("Sword");
+        dto.Contexts.Should().ContainSingle(c => c.BookId == bookA && c.ParagraphRef == "§12");
+        _glossaryMock.Verify(r => r.AddAsync(It.IsAny<GamebookGlossaryEntry>(), It.IsAny<CancellationToken>()), Times.Once);
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Queries/GetGamebookGlossaryQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Queries/GetGamebookGlossaryQueryHandlerTests.cs
@@ -1,0 +1,57 @@
+using Api.BoundedContexts.SessionTracking.Application.Queries;
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+using Api.BoundedContexts.SessionTracking.Domain.Enums;
+using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using Api.BoundedContexts.SessionTracking.Domain.ValueObjects;
+using Api.SharedKernel.Domain.ValueObjects;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SessionTracking.Application.Queries;
+
+/// <summary>
+/// #2638 / SI-7: <see cref="GetGamebookGlossaryQueryHandler"/> must project each
+/// entry's multi-context list into the DTO.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SessionTracking")]
+[Trait("Issue", "2638")]
+public sealed class GetGamebookGlossaryQueryHandlerTests
+{
+    private static readonly Guid CampaignId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+    private static readonly Guid OwnerId = Guid.Parse("22222222-2222-2222-2222-222222222222");
+
+    [Fact]
+    public async Task Handle_ProjectsContextsIntoDto()
+    {
+        var campaign = GamebookCampaignSession.Create(GameRef.Shared(Guid.NewGuid()), OwnerId, "Test campaign");
+        var campaigns = new Mock<IGamebookCampaignSessionRepository>();
+        campaigns.Setup(r => r.GetByIdAsync(CampaignId, It.IsAny<CancellationToken>())).ReturnsAsync(campaign);
+
+        var bookA = Guid.NewGuid();
+        var bookB = Guid.NewGuid();
+        var entry = GamebookGlossaryEntry.Create(
+            CampaignId, "sentinel", "soldato", GlossarySource.Manual, OwnerId,
+            contexts: new[]
+            {
+                GlossaryContext.Create(bookA, "§147", null),
+                GlossaryContext.Create(bookB, "§63", "definizione"),
+            });
+
+        var glossary = new Mock<IGamebookGlossaryRepository>();
+        glossary.Setup(r => r.ListByCampaignAsync(CampaignId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { entry });
+
+        var handler = new GetGamebookGlossaryQueryHandler(campaigns.Object, glossary.Object);
+
+        var result = await handler.Handle(new GetGamebookGlossaryQuery(CampaignId, OwnerId), CancellationToken.None);
+
+        result.Should().ContainSingle();
+        var dto = result[0];
+        dto.Contexts.Should().HaveCount(2);
+        dto.Contexts.Should().ContainSingle(c => c.BookId == bookA && c.ParagraphRef == "§147" && c.Definition == null);
+        dto.Contexts.Should().ContainSingle(c => c.BookId == bookB && c.ParagraphRef == "§63" && c.Definition == "definizione");
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Domain/GamebookGlossaryEntryTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Domain/GamebookGlossaryEntryTests.cs
@@ -1,5 +1,6 @@
 using Api.BoundedContexts.SessionTracking.Domain.Entities;
 using Api.BoundedContexts.SessionTracking.Domain.Enums;
+using Api.BoundedContexts.SessionTracking.Domain.ValueObjects;
 using FluentAssertions;
 using Xunit;
 
@@ -83,5 +84,160 @@ public class GamebookGlossaryEntryTests
 
         act.Should().Throw<ArgumentException>()
             .WithParameterName("firstSeenBookId");
+    }
+
+    // -------------------------------------------------------------------------
+    // #2638 / SI-7 — multi-context support
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public void Create_WithFirstSeenBookId_SeedsSingleContext()
+    {
+        var bookId = Guid.NewGuid();
+
+        var entry = GamebookGlossaryEntry.Create(
+            CampaignId, "Voidstone", "Pietra del Vuoto",
+            GlossarySource.AutoBootstrap, UserId,
+            firstSeenBookId: bookId);
+
+        entry.Contexts.Should().ContainSingle();
+        entry.Contexts[0].BookId.Should().Be(bookId);
+        entry.Contexts[0].ParagraphRef.Should().BeNull();
+        entry.Contexts[0].Definition.Should().BeNull();
+    }
+
+    [Fact]
+    public void Create_WithoutFirstSeenBookId_HasEmptyContexts()
+    {
+        var entry = GamebookGlossaryEntry.Create(
+            CampaignId, "Goblin", "Goblin", GlossarySource.AutoBootstrap, UserId);
+
+        entry.Contexts.Should().BeEmpty();
+        entry.ContextsJson.Should().Be("[]");
+    }
+
+    [Fact]
+    public void Create_WithExplicitContexts_PersistsAll()
+    {
+        var bookA = Guid.NewGuid();
+        var bookB = Guid.NewGuid();
+        var contexts = new[]
+        {
+            GlossaryContext.Create(bookA, "§147", null),
+            GlossaryContext.Create(bookB, "§63", "punto di osservazione strategica"),
+        };
+
+        var entry = GamebookGlossaryEntry.Create(
+            CampaignId, "sentinel", "soldato di guardia", GlossarySource.Manual, UserId,
+            contexts: contexts);
+
+        entry.Contexts.Should().HaveCount(2);
+        entry.Contexts.Should().ContainSingle(c => c.BookId == bookA && c.ParagraphRef == "§147" && c.Definition == null);
+        entry.Contexts.Should().ContainSingle(c =>
+            c.BookId == bookB && c.ParagraphRef == "§63" && c.Definition == "punto di osservazione strategica");
+    }
+
+    [Fact]
+    public void Create_WithExplicitContexts_TakesPrecedenceOverFirstSeenBookId()
+    {
+        var explicitBook = Guid.NewGuid();
+        var firstSeen = Guid.NewGuid();
+
+        var entry = GamebookGlossaryEntry.Create(
+            CampaignId, "sentinel", "soldato di guardia", GlossarySource.Manual, UserId,
+            firstSeenBookId: firstSeen,
+            contexts: new[] { GlossaryContext.Create(explicitBook, null, null) });
+
+        entry.Contexts.Should().ContainSingle();
+        entry.Contexts[0].BookId.Should().Be(explicitBook);
+        entry.FirstSeenBookId.Should().Be(firstSeen); // pointer retained
+    }
+
+    [Fact]
+    public void AddContext_DedupsByBookAndParagraph()
+    {
+        var bookA = Guid.NewGuid();
+        var entry = GamebookGlossaryEntry.Create(
+            CampaignId, "sentinel", "soldato", GlossarySource.Manual, UserId,
+            contexts: new[] { GlossaryContext.Create(bookA, "§147", null) });
+
+        // Same (book, paragraph) with different casing on the ref → deduped, no-op.
+        entry.AddContext(GlossaryContext.Create(bookA, "§147", "a redefinition"), EditorId);
+        entry.Contexts.Should().ContainSingle();
+
+        // Distinct paragraph on the same book → appended.
+        entry.AddContext(GlossaryContext.Create(bookA, "§200", null), EditorId);
+        entry.Contexts.Should().HaveCount(2);
+        entry.UpdatedBy.Should().Be(EditorId);
+    }
+
+    [Fact]
+    public void RemoveContext_RemovesMatchingKey()
+    {
+        var bookA = Guid.NewGuid();
+        var bookB = Guid.NewGuid();
+        var entry = GamebookGlossaryEntry.Create(
+            CampaignId, "sentinel", "soldato", GlossarySource.Manual, UserId,
+            contexts: new[]
+            {
+                GlossaryContext.Create(bookA, "§147", null),
+                GlossaryContext.Create(bookB, "§63", null),
+            });
+
+        entry.RemoveContext(GlossaryContext.Create(bookA, "§147", null), EditorId);
+
+        entry.Contexts.Should().ContainSingle(c => c.BookId == bookB);
+        entry.UpdatedBy.Should().Be(EditorId);
+    }
+
+    [Fact]
+    public void ReplaceContexts_ReplacesAllAndDedups()
+    {
+        var bookA = Guid.NewGuid();
+        var bookB = Guid.NewGuid();
+        var entry = GamebookGlossaryEntry.Create(
+            CampaignId, "sentinel", "soldato", GlossarySource.Manual, UserId,
+            contexts: new[] { GlossaryContext.Create(bookA, "§1", null) });
+
+        // Replacement set includes a duplicate (bookB/§9 twice, one lower-cased ref).
+        entry.ReplaceContexts(
+            new[]
+            {
+                GlossaryContext.Create(bookB, "§9", null),
+                GlossaryContext.Create(bookB, "§9", "dup should be dropped"),
+                GlossaryContext.Create(bookA, "§5", null),
+            },
+            EditorId);
+
+        entry.Contexts.Should().HaveCount(2);
+        entry.Contexts.Should().NotContain(c => c.ParagraphRef == "§1"); // old set fully replaced
+        entry.Contexts.Should().ContainSingle(c => c.BookId == bookB && c.ParagraphRef == "§9");
+        entry.UpdatedBy.Should().Be(EditorId);
+    }
+
+    [Fact]
+    public void Contexts_RoundTripThroughJson()
+    {
+        var bookA = Guid.NewGuid();
+        var bookB = Guid.NewGuid();
+        var entry = GamebookGlossaryEntry.Create(
+            CampaignId, "sentinel", "soldato", GlossarySource.Manual, UserId,
+            contexts: new[]
+            {
+                GlossaryContext.Create(bookA, "§147", "def uno"),
+                GlossaryContext.Create(bookB, "§63", null),
+            });
+
+        // Non-ASCII paragraph markers must survive the JSONB payload unescaped.
+        entry.ContextsJson.Should().Contain("§147");
+
+        // Re-deserialize the raw JSON exactly as EF does on read.
+        var roundTripped = System.Text.Json.JsonSerializer
+            .Deserialize<List<GlossaryContext>>(entry.ContextsJson);
+
+        roundTripped.Should().NotBeNull();
+        roundTripped!.Should().HaveCount(2);
+        roundTripped.Should().ContainSingle(c => c.BookId == bookA && c.ParagraphRef == "§147" && c.Definition == "def uno");
+        roundTripped.Should().ContainSingle(c => c.BookId == bookB && c.ParagraphRef == "§63" && c.Definition == null);
     }
 }

--- a/apps/api/tests/Api.Tests/Integration/SessionTracking/GamebookGlossaryContextsPersistenceTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/SessionTracking/GamebookGlossaryContextsPersistenceTests.cs
@@ -1,0 +1,141 @@
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+using Api.BoundedContexts.SessionTracking.Domain.Enums;
+using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using Api.BoundedContexts.SessionTracking.Domain.ValueObjects;
+using Api.Infrastructure;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.Integration.SessionTracking;
+
+/// <summary>
+/// #2638 / SI-7: persistence coverage for the multi-context glossary model.
+///
+/// Test A proves the <c>contexts</c> JSONB column round-trips a multi-element list
+/// through the real EF pipeline. Test B proves the upsert-update path actually
+/// persists a <see cref="GamebookGlossaryEntry.ReplaceContexts"/> mutation — which
+/// only works because <see cref="IGamebookGlossaryRepository.GetByIdAsync"/> loads
+/// <c>.AsTracking()</c> under the global NoTracking default (same class as #2660).
+/// </summary>
+[Collection("Integration-GroupD")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "SessionTracking")]
+[Trait("Issue", "2638")]
+public sealed class GamebookGlossaryContextsPersistenceTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly string _databaseName = $"glossary_contexts_persist_{Guid.NewGuid():N}";
+    private WebApplicationFactory<Program> _factory = null!;
+
+    private static readonly Guid CampaignId = Guid.Parse("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static readonly Guid CreatedBy = Guid.Parse("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+
+    public GamebookGlossaryContextsPersistenceTests(SharedTestcontainersFixture fixture) => _fixture = fixture;
+
+    public async ValueTask InitializeAsync()
+    {
+        var conn = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+        await TestcontainersWaitHelpers.WaitForPostgresReadyAsync(conn);
+        _factory = IntegrationWebApplicationFactory.Create(conn);
+        using var scope = _factory.Services.CreateScope();
+        await scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>().Database.MigrateAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_factory != null) await _factory.DisposeAsync();
+        await _fixture.DropIsolatedDatabaseAsync(_databaseName);
+    }
+
+    [Fact(DisplayName = "#2638 Test A: contexts JSONB round-trips a multi-element list on create")]
+    public async Task Create_WithTwoContexts_RoundTripsThroughJsonb()
+    {
+        var bookA = Guid.NewGuid();
+        var bookB = Guid.NewGuid();
+        Guid entryId;
+
+        await using (var scope = _factory.Services.CreateAsyncScope())
+        {
+            var repo = scope.ServiceProvider.GetRequiredService<IGamebookGlossaryRepository>();
+            var entry = GamebookGlossaryEntry.Create(
+                CampaignId, "sentinel", "soldato di guardia", GlossarySource.Manual, CreatedBy,
+                contexts: new[]
+                {
+                    GlossaryContext.Create(bookA, "§147", null),
+                    GlossaryContext.Create(bookB, "§63", "punto di osservazione strategica"),
+                });
+            await repo.AddAsync(entry, CancellationToken.None);
+            await repo.SaveChangesAsync(CancellationToken.None);
+            entryId = entry.Id;
+        }
+
+        await using (var scope = _factory.Services.CreateAsyncScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            var reread = await db.GamebookGlossaryEntries.AsNoTracking().FirstAsync(e => e.Id == entryId);
+
+            reread.Contexts.Should().HaveCount(2);
+            reread.Contexts.Should().ContainSingle(c =>
+                c.BookId == bookA && c.ParagraphRef == "§147" && c.Definition == null);
+            reread.Contexts.Should().ContainSingle(c =>
+                c.BookId == bookB && c.ParagraphRef == "§63" && c.Definition == "punto di osservazione strategica");
+        }
+    }
+
+    [Fact(DisplayName = "#2638 Test B: ReplaceContexts persists through the .AsTracking() getter")]
+    public async Task Upsert_ReplaceContexts_PersistsViaTrackingGetter()
+    {
+        var legacyBook = Guid.NewGuid();
+        var bookA = Guid.NewGuid();
+        var bookB = Guid.NewGuid();
+        Guid entryId;
+
+        // Seed with a single (legacy) context.
+        await using (var scope = _factory.Services.CreateAsyncScope())
+        {
+            var repo = scope.ServiceProvider.GetRequiredService<IGamebookGlossaryRepository>();
+            var entry = GamebookGlossaryEntry.Create(
+                CampaignId, "Voidstone", "Pietra del Vuoto", GlossarySource.Manual, CreatedBy,
+                firstSeenBookId: legacyBook);
+            await repo.AddAsync(entry, CancellationToken.None);
+            await repo.SaveChangesAsync(CancellationToken.None);
+            entryId = entry.Id;
+        }
+
+        // Load via the repo getter (must be .AsTracking()), replace the full set, save.
+        await using (var scope = _factory.Services.CreateAsyncScope())
+        {
+            var repo = scope.ServiceProvider.GetRequiredService<IGamebookGlossaryRepository>();
+            var loaded = await repo.GetByIdAsync(entryId, CancellationToken.None);
+            loaded.Should().NotBeNull();
+            loaded!.ReplaceContexts(
+                new[]
+                {
+                    GlossaryContext.Create(bookA, "§1", null),
+                    GlossaryContext.Create(bookB, "§2", "def"),
+                },
+                CreatedBy);
+            await repo.SaveChangesAsync(CancellationToken.None);
+        }
+
+        // Fresh read confirms the mutation persisted (would be the legacy single context if
+        // GetByIdAsync had not tracked the entity — silent no-op under NoTracking).
+        await using (var scope = _factory.Services.CreateAsyncScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            var reread = await db.GamebookGlossaryEntries.AsNoTracking().FirstAsync(e => e.Id == entryId);
+
+            reread.Contexts.Should().HaveCount(2,
+                "ReplaceContexts must persist through SaveChanges — requires .AsTracking() on the getter (#2638)");
+            reread.Contexts.Should().NotContain(c => c.BookId == legacyBook);
+            reread.Contexts.Should().ContainSingle(c => c.BookId == bookA && c.ParagraphRef == "§1");
+            reread.Contexts.Should().ContainSingle(c => c.BookId == bookB && c.ParagraphRef == "§2" && c.Definition == "def");
+        }
+    }
+}

--- a/apps/web/src/__tests__/fixtures/mockup-pilots/librogame/librogame-glossary-editor.ts
+++ b/apps/web/src/__tests__/fixtures/mockup-pilots/librogame/librogame-glossary-editor.ts
@@ -62,6 +62,15 @@ export const MOCK_GLOSSARY_ENTRY_GE: GamebookGlossaryEntry = {
   termIt: 'soldato di guardia',
   source: 'AutoBootstrap',
   updatedAt: '2026-06-22T20:00:00Z',
+  // #2638 / SI-7: two provenance contexts mirroring the variant-expansion mockup.
+  contexts: [
+    { bookId: '11111111-1111-4111-8111-111111111111', paragraphRef: '§147', definition: null },
+    {
+      bookId: '22222222-2222-4222-8222-222222222222',
+      paragraphRef: '§63',
+      definition: 'punto di osservazione strategica',
+    },
+  ],
 };
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/__tests__/mocks/handlers/gamebook-glossary.handlers.ts
+++ b/apps/web/src/__tests__/mocks/handlers/gamebook-glossary.handlers.ts
@@ -52,6 +52,8 @@ const echoResponder: UpsertResponder = ({ entryId, body }) =>
     termIt: body.termIt,
     source: 'Manual',
     updatedAt: new Date('2026-05-19T10:00:00Z').toISOString(),
+    // #2638 / SI-7: entries carry a (possibly empty) contexts array.
+    contexts: [],
   });
 
 let activeUpsertResponder: UpsertResponder = echoResponder;
@@ -74,14 +76,12 @@ export function resetGlossaryResponder(): void {
 // ---------------------------------------------------------------------------
 
 export const gamebookGlossaryHandlers = [
-  http.get(
-    `${API_BASE}/api/v1/gamebook/campaigns/:campaignId/glossary`,
-    () => HttpResponse.json([])
+  http.get(`${API_BASE}/api/v1/gamebook/campaigns/:campaignId/glossary`, () =>
+    HttpResponse.json([])
   ),
 
-  http.post(
-    `${API_BASE}/api/v1/gamebook/campaigns/:campaignId/glossary/bootstrap`,
-    () => HttpResponse.json([])
+  http.post(`${API_BASE}/api/v1/gamebook/campaigns/:campaignId/glossary/bootstrap`, () =>
+    HttpResponse.json([])
   ),
 
   http.put(

--- a/apps/web/src/components/features/gamebook/GlossaryEditorModal.tsx
+++ b/apps/web/src/components/features/gamebook/GlossaryEditorModal.tsx
@@ -254,6 +254,47 @@ export function GlossaryEditorModal({
           </p>
         )}
 
+        {/* #2638 / SI-7: read-only multi-context list. Rendered only when the entry
+            carries provenance contexts (per-variant editing is a follow-up). */}
+        {entry.contexts.length > 0 && (
+          <section
+            data-slot="glossary-editor-contexts"
+            aria-label={t('gamebook.glossaryEditor.contexts.heading')}
+          >
+            <h3 className="text-sm font-semibold text-foreground">
+              {t('gamebook.glossaryEditor.contexts.heading')}
+            </h3>
+            <ul className="divide-y divide-border border-t border-border">
+              {entry.contexts.map((ctx, i) => (
+                <li
+                  key={`${ctx.bookId}-${ctx.paragraphRef ?? i}`}
+                  data-testid="glossary-context-row"
+                  className="flex flex-col gap-1 py-2"
+                >
+                  <span
+                    data-slot="glossary-context-book"
+                    className="inline-flex w-fit items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground"
+                  >
+                    📖 {ctx.bookId}
+                  </span>
+                  <p className="text-sm text-foreground">
+                    {ctx.definition ?? (
+                      <span className="italic text-muted-foreground">
+                        {t('gamebook.glossaryEditor.contexts.usaBase')}
+                      </span>
+                    )}
+                  </p>
+                  {ctx.paragraphRef && (
+                    <span className="text-xs text-muted-foreground">
+                      {t('gamebook.glossaryEditor.contexts.firstSeen', { ref: ctx.paragraphRef })}
+                    </span>
+                  )}
+                </li>
+              ))}
+            </ul>
+          </section>
+        )}
+
         {state.status === 'error' && (
           <div role="alert" data-testid="glossary-editor-error">
             <p>{t('gamebook.glossaryEditor.error.saveFailed')}</p>

--- a/apps/web/src/components/features/gamebook/__tests__/GlossaryEditorModal.test.tsx
+++ b/apps/web/src/components/features/gamebook/__tests__/GlossaryEditorModal.test.tsx
@@ -36,16 +36,19 @@ import { GlossaryEditorModal } from '../GlossaryEditorModal';
 
 // react-intl wants dot-notation flat keys; the locale catalogue is nested.
 function flatten(obj: Record<string, unknown>, prefix = ''): Record<string, string> {
-  return Object.keys(obj).reduce((acc, key) => {
-    const full = prefix ? `${prefix}.${key}` : key;
-    const value = obj[key];
-    if (value && typeof value === 'object') {
-      Object.assign(acc, flatten(value as Record<string, unknown>, full));
-    } else {
-      acc[full] = String(value);
-    }
-    return acc;
-  }, {} as Record<string, string>);
+  return Object.keys(obj).reduce(
+    (acc, key) => {
+      const full = prefix ? `${prefix}.${key}` : key;
+      const value = obj[key];
+      if (value && typeof value === 'object') {
+        Object.assign(acc, flatten(value as Record<string, unknown>, full));
+      } else {
+        acc[full] = String(value);
+      }
+      return acc;
+    },
+    {} as Record<string, string>
+  );
 }
 
 const FLAT_EN = flatten(enMessages as Record<string, unknown>);
@@ -93,6 +96,18 @@ const ENTRY: GamebookGlossaryEntry = {
   termIt: 'Pietra del Vuoto',
   source: 'AutoBootstrap',
   updatedAt: '2026-05-01T12:00:00Z',
+  contexts: [],
+};
+
+// #2638 / SI-7 — entry carrying two provenance contexts (one without a definition).
+const BOOK_A = '11111111-1111-4111-8111-111111111111';
+const BOOK_B = '22222222-2222-4222-8222-222222222222';
+const ENTRY_WITH_CONTEXTS: GamebookGlossaryEntry = {
+  ...ENTRY,
+  contexts: [
+    { bookId: BOOK_A, paragraphRef: '§147', definition: null },
+    { bookId: BOOK_B, paragraphRef: '§63', definition: 'punto di osservazione strategica' },
+  ],
 };
 
 beforeEach(() => {
@@ -110,13 +125,7 @@ afterEach(() => {
 
 describe('AC-1 — Pristine mount', () => {
   it('mounts with EN locked, IT prefilled, Salva button disabled', () => {
-    renderModal(
-      <GlossaryEditorModal
-        campaignId={CAMPAIGN_ID}
-        entry={ENTRY}
-        onClose={() => {}}
-      />
-    );
+    renderModal(<GlossaryEditorModal campaignId={CAMPAIGN_ID} entry={ENTRY} onClose={() => {}} />);
 
     // EN rendered as locked / read-only text (not in an editable input).
     expect(screen.getByText('Voidstone')).toBeInTheDocument();
@@ -138,13 +147,7 @@ describe('AC-1 — Pristine mount', () => {
 describe('AC-2 — Dirty edit + diff hint', () => {
   it('enables Salva and renders the diff hint with the previous value struck through', async () => {
     const user = userEvent.setup();
-    renderModal(
-      <GlossaryEditorModal
-        campaignId={CAMPAIGN_ID}
-        entry={ENTRY}
-        onClose={() => {}}
-      />
-    );
+    renderModal(<GlossaryEditorModal campaignId={CAMPAIGN_ID} entry={ENTRY} onClose={() => {}} />);
 
     const itInput = screen.getByRole('textbox', { name: /italian translation/i });
     await user.clear(itInput);
@@ -279,13 +282,7 @@ describe('AC-3b — Dismiss flows', () => {
 
 describe('AC-8 — Accessibility', () => {
   it('exposes role="dialog" + aria-modal + aria-labelledby pointing to the header', () => {
-    renderModal(
-      <GlossaryEditorModal
-        campaignId={CAMPAIGN_ID}
-        entry={ENTRY}
-        onClose={() => {}}
-      />
-    );
+    renderModal(<GlossaryEditorModal campaignId={CAMPAIGN_ID} entry={ENTRY} onClose={() => {}} />);
 
     const dialog = screen.getByRole('dialog');
     expect(dialog).toHaveAttribute('aria-modal', 'true');
@@ -298,13 +295,7 @@ describe('AC-8 — Accessibility', () => {
   });
 
   it('moves focus to the IT input on mount (not the close button)', async () => {
-    renderModal(
-      <GlossaryEditorModal
-        campaignId={CAMPAIGN_ID}
-        entry={ENTRY}
-        onClose={() => {}}
-      />
-    );
+    renderModal(<GlossaryEditorModal campaignId={CAMPAIGN_ID} entry={ENTRY} onClose={() => {}} />);
 
     const itInput = screen.getByRole('textbox', { name: /italian translation/i });
     await waitFor(() => {
@@ -479,13 +470,7 @@ describe('#1312 AC-5 — [Change translation] returns focus to input without res
       )
     );
 
-    renderModal(
-      <GlossaryEditorModal
-        campaignId={CAMPAIGN_ID}
-        entry={ENTRY}
-        onClose={() => {}}
-      />
-    );
+    renderModal(<GlossaryEditorModal campaignId={CAMPAIGN_ID} entry={ENTRY} onClose={() => {}} />);
 
     const itInput = screen.getByRole('textbox', { name: /italian translation/i });
     await user.clear(itInput);
@@ -620,14 +605,9 @@ describe('#1312 AC-7 — axe finds zero violations on collision states', () => {
 
 describe('AC-9 — i18n integration', () => {
   it('renders Italian labels when locale is "it" and preserves the entity literals', () => {
-    renderModal(
-      <GlossaryEditorModal
-        campaignId={CAMPAIGN_ID}
-        entry={ENTRY}
-        onClose={() => {}}
-      />,
-      { locale: 'it' }
-    );
+    renderModal(<GlossaryEditorModal campaignId={CAMPAIGN_ID} entry={ENTRY} onClose={() => {}} />, {
+      locale: 'it',
+    });
 
     // Italian dialog title from the it.json catalogue (not the en fallback).
     expect(screen.getByText('Modifica voce di glossario')).toBeInTheDocument();
@@ -637,9 +617,44 @@ describe('AC-9 — i18n integration', () => {
 
     // Entity literals are injected via props, not translated.
     expect(screen.getByText('Voidstone')).toBeInTheDocument();
-    expect(
-      screen.getByRole('textbox', { name: /traduzione italiana/i })
-    ).toHaveValue('Pietra del Vuoto');
+    expect(screen.getByRole('textbox', { name: /traduzione italiana/i })).toHaveValue(
+      'Pietra del Vuoto'
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// #2638 / SI-7 — multi-context read-only render
+// ---------------------------------------------------------------------------
+
+describe('#2638 SI-7 — multi-context render', () => {
+  it('renders one row per context with book badge, base fallback, and firstSeen ref', () => {
+    renderModal(
+      <GlossaryEditorModal
+        campaignId={CAMPAIGN_ID}
+        entry={ENTRY_WITH_CONTEXTS}
+        onClose={() => {}}
+      />
+    );
+
+    const rows = screen.getAllByTestId('glossary-context-row');
+    expect(rows).toHaveLength(2);
+
+    // First context: book badge (bookId), null definition → "uses base", firstSeen ref.
+    expect(rows[0]).toHaveTextContent(BOOK_A);
+    expect(rows[0]).toHaveTextContent(/uses base/i);
+    expect(rows[0]).toHaveTextContent('§147');
+
+    // Second context: concrete definition rendered literally + its own ref.
+    expect(rows[1]).toHaveTextContent(BOOK_B);
+    expect(rows[1]).toHaveTextContent('punto di osservazione strategica');
+    expect(rows[1]).toHaveTextContent('§63');
+  });
+
+  it('does NOT render the contexts section when the entry has no contexts', () => {
+    renderModal(<GlossaryEditorModal campaignId={CAMPAIGN_ID} entry={ENTRY} onClose={() => {}} />);
+
+    expect(screen.queryByTestId('glossary-context-row')).not.toBeInTheDocument();
   });
 });
 

--- a/apps/web/src/lib/api/__tests__/gamebook-glossary.test.ts
+++ b/apps/web/src/lib/api/__tests__/gamebook-glossary.test.ts
@@ -36,6 +36,35 @@ describe('GamebookGlossaryEntrySchema', () => {
   it('rejects unknown source', () => {
     expect(() => GamebookGlossaryEntrySchema.parse({ ...validEntry, source: 'Unknown' })).toThrow();
   });
+
+  // #2638 / SI-7 — contexts uses .default([]) so legacy payloads still parse.
+  it('defaults contexts to [] when the field is absent', () => {
+    const result = GamebookGlossaryEntrySchema.parse(validEntry);
+    expect(result.contexts).toEqual([]);
+  });
+
+  it('parses an entry WITH a populated contexts array', () => {
+    const result = GamebookGlossaryEntrySchema.parse({
+      ...validEntry,
+      contexts: [
+        { bookId: '11111111-1111-4111-8111-111111111111', paragraphRef: '§147', definition: null },
+        { bookId: '22222222-2222-4222-8222-222222222222', paragraphRef: null, definition: 'def' },
+      ],
+    });
+    expect(result.contexts).toHaveLength(2);
+    expect(result.contexts[0].bookId).toBe('11111111-1111-4111-8111-111111111111');
+    expect(result.contexts[0].paragraphRef).toBe('§147');
+    expect(result.contexts[1].definition).toBe('def');
+  });
+
+  it('rejects a context with a non-uuid bookId', () => {
+    expect(() =>
+      GamebookGlossaryEntrySchema.parse({
+        ...validEntry,
+        contexts: [{ bookId: 'not-a-uuid', paragraphRef: null, definition: null }],
+      })
+    ).toThrow();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/lib/api/gamebook-glossary.ts
+++ b/apps/web/src/lib/api/gamebook-glossary.ts
@@ -23,12 +23,28 @@ async function ensureOk(res: Response, ctx: string): Promise<Response> {
 // Schema
 // ---------------------------------------------------------------------------
 
+/**
+ * A single provenance context for a glossary term (issue #2638 / SI-7): the book
+ * (and optionally the paragraph ref) where the term appears, plus an optional
+ * context-specific definition. Read from the DTO's camelCase fields.
+ */
+export const GlossaryContextSchema = z.object({
+  bookId: z.string().uuid(),
+  paragraphRef: z.string().nullable().optional(),
+  definition: z.string().nullable().optional(),
+});
+
+export type GlossaryContext = z.infer<typeof GlossaryContextSchema>;
+
 export const GamebookGlossaryEntrySchema = z.object({
   id: z.string().uuid(),
   termEn: z.string().min(1),
   termIt: z.string().min(1),
   source: z.enum(['AutoBootstrap', 'Manual']),
   updatedAt: z.string(),
+  // #2638 / SI-7: `.default([])` (NOT required) — fixtures, MSW handlers, and the
+  // not-yet-deployed backend may return entries without a `contexts` field.
+  contexts: z.array(GlossaryContextSchema).default([]),
 });
 
 export type GamebookGlossaryEntry = z.infer<typeof GamebookGlossaryEntrySchema>;

--- a/apps/web/src/lib/gamebook/hooks/__tests__/useGamebookGlossary.test.tsx
+++ b/apps/web/src/lib/gamebook/hooks/__tests__/useGamebookGlossary.test.tsx
@@ -22,6 +22,7 @@ const fakeEntry: glossaryApi.GamebookGlossaryEntry = {
   termIt: 'Drago',
   source: 'AutoBootstrap',
   updatedAt: '2026-05-07T10:00:00Z',
+  contexts: [],
 };
 
 function makeWrapper(qc: QueryClient) {

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -3654,6 +3654,12 @@
         "overwrite": "Overwrite",
         "changeTranslation": "Change translation",
         "sidePanelLabel": "Conflicting entry"
+      },
+      "contexts": {
+        "heading": "Appears in",
+        "usaBase": "uses base",
+        "firstSeen": "See original paragraph {ref}",
+        "deleteVariant": "Delete variant {book}"
       }
     },
     "encounter": {

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -3707,6 +3707,12 @@
         "overwrite": "Sovrascrivi",
         "changeTranslation": "Cambia traduzione",
         "sidePanelLabel": "Voce in conflitto"
+      },
+      "contexts": {
+        "heading": "Appare in",
+        "usaBase": "usa base",
+        "firstSeen": "Vedi paragrafo originale {ref}",
+        "deleteVariant": "Elimina variante {book}"
       }
     },
     "encounter": {


### PR DESCRIPTION
## Contesto

Closes #2638 (SI-7 di #2619, Thread B). Le voci di glossario (`GamebookGlossaryEntry`, BC **SessionTracking**) passano dal single-context `FirstSeenBookId` a una lista `Contexts[]`, e l'editor le rende. Il verbo DELETE era già shipped (#2627). Design: [decomposition §5 SI-7](docs/for-developers/specs/2026-07-01-issue-2619-decomposition-design.md).

## Decisioni (open questions del design risolte)
- **KEEP** `FirstSeenBookId` (backward-compat, resta il pointer "primo contesto").
- **Scope MVP**: render read-only dei contexts + persist via upsert `contexts[]` (full-set replace). Editing per-variante (add/delete UI) → follow-up.
- Dedup per `(BookId, ParagraphRef)` case-insensitive.
- Bootstrap seeda contexts vuoti.

## Backend
- Nuovo VO `GlossaryContext(BookId, ParagraphRef?, Definition?)` + factory validante.
- `GamebookGlossaryEntry`: stato jsonb `ContextsJson` + `[JsonIgnore] Contexts` (idiom di `SessionBookProgress`) + `Create(contexts)`/`AddContext`/`RemoveContext`/`ReplaceContexts`.
- **Migration `AddGlossaryContexts`**: `contexts jsonb NOT NULL default '[]'` + backfill dati da `first_seen_book_id` (chiavi PascalCase per System.Text.Json).
- Contexts propagati su DTO (+`GlossaryContextDto`), query, upsert command/handler (`Contexts` opzionale = replace), bootstrap handler, endpoint request.
- **Fix PERF-06**: `GamebookGlossaryRepository.GetByIdAsync` ora `.AsTracking()` — sotto il default NoTracking la mutazione dell'upsert era un no-op silenzioso (stessa classe di #2660; questo copre il caso Glossary del cluster #2734).

## Frontend
- zod schema esteso con `contexts` (`.default([])` per back-compat), `GlossaryEditorModal` rende una sezione varianti read-only, i18n it/en (key-parity), fixtures/handlers MSW aggiornati.

## Test (verificati in modo indipendente)
- **BE**: 18 pass sul filtro `~GamebookGlossary` (domain + integration Testcontainers: jsonb round-trip + prova persistenza `.AsTracking()` + query) + upsert/bootstrap handler units. BE build 0 errori.
- **FE**: 37 pass (GlossaryEditorModal + schema parse con/senza contexts + hook). `pnpm typecheck` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)