### PR TITLE
feat(game-night): #2634 in-progress→completed close strip wiring (SI-3)

### DIFF
--- a/apps/web/e2e/game-night/finalize-close-strip.spec.ts
+++ b/apps/web/e2e/game-night/finalize-close-strip.spec.ts
@@ -1,0 +1,125 @@
+/**
+ * GameNight finalize → close-strip E2E (SI-3 #2634) — SKELETON (test.skip).
+ *
+ * Pins the end-to-end in-progress→completed close flow across the two surfaces the transition
+ * touches:
+ *   1. The night-live hub (/game-nights/{id}/live): the organizer, with every game done and none
+ *      live, clicks "Concludi serata" → POST /complete → the read model refetches Completed → the
+ *      LD-14 effect routes to /summary.
+ *   2. The gamebook play page (/library/{gameId}/play/{campaignId}): after finalize, the invalidated
+ *      spine read returns gameNightStatus:'Completed' → SerataSpineStrip renders "completata", no
+ *      live badge, and the SerataResumeButton is gone (no backward transition on the FE).
+ *
+ * Kept `test.skip` (skeleton) — enable once the finalize CTA + cross-surface invalidation land in a
+ * seeded/harnessed E2E environment. Uses page.context().route() (NOT page.route()) for Next.js
+ * server-side fetch interception.
+ */
+
+import { test, expect, type Page } from '@playwright/test';
+
+const API_BASE =
+  process.env.PLAYWRIGHT_API_BASE || process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8080';
+
+const NIGHT_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const GAME_ID = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+const CAMPAIGN_ID = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
+
+const MOCK_USER = {
+  user: {
+    id: 'user-organizer-001',
+    email: 'organizer@meepleai.dev',
+    displayName: 'Night Organizer',
+    role: 'User',
+    tier: 'premium',
+  },
+  expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+};
+
+// A night mid-play: every planned game terminal, nothing live, status InProgress → the finalize
+// CTA precondition. The organizer flag gates the CTA.
+const LIVE_IN_PROGRESS = {
+  id: NIGHT_ID,
+  title: 'Serata Eldoria',
+  status: 'InProgress',
+  isViewerOrganizer: true,
+  plannedLineup: [], // nothing left to start → nextGame === null
+  currentSessionRoster: [],
+  sessions: [
+    {
+      sessionId: '11111111-1111-4111-8111-111111111111',
+      gameId: GAME_ID,
+      gameTitle: 'Spirit Island',
+      playOrder: 1,
+      status: 'Completed',
+      winnerId: null,
+      winnerName: null,
+      startedAt: new Date(Date.now() - 3 * 60 * 60 * 1000).toISOString(),
+      completedAt: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+    },
+  ],
+};
+
+// Post-finalize spine: the owning GameNight is Completed with no live sitting → the strip pins the
+// terminal state and drops the resume affordance (no FE backward flip).
+const SPINE_COMPLETED = {
+  gameNightId: NIGHT_ID,
+  gameNightTitle: 'Serata Eldoria',
+  organizerId: MOCK_USER.user.id,
+  gameNightStatus: 'Completed',
+  totalSessions: 1,
+  completedSessions: 1,
+  hasLiveSession: false,
+  campaignStatus: 'Completed',
+};
+
+async function setupRoutes(page: Page) {
+  await page
+    .context()
+    .route(`${API_BASE}/api/v1/auth/session`, route =>
+      route.fulfill({ status: 200, json: MOCK_USER })
+    );
+  await page
+    .context()
+    .route(`${API_BASE}/api/v1/game-nights/${NIGHT_ID}/live`, route =>
+      route.fulfill({ status: 200, json: LIVE_IN_PROGRESS })
+    );
+  // The finalize call — the flow under test.
+  await page
+    .context()
+    .route(`${API_BASE}/api/v1/game-nights/${NIGHT_ID}/complete`, route =>
+      route.fulfill({ status: 200, json: { gameNightId: NIGHT_ID, sessionsCompleted: 1 } })
+    );
+  await page
+    .context()
+    .route(`${API_BASE}/api/v1/gamebook/campaigns/${CAMPAIGN_ID}/spine`, route =>
+      route.fulfill({ status: 200, json: SPINE_COMPLETED })
+    );
+}
+
+test.describe('GameNight finalize → close strip (SI-3 #2634)', () => {
+  test.skip('organizer concludes an in-progress night and is routed to the summary', async ({
+    page,
+  }) => {
+    await setupRoutes(page);
+    await page.goto(`/game-nights/${NIGHT_ID}/live`);
+
+    await page.getByRole('button', { name: /Concludi serata/i }).click();
+
+    // POST /complete → read model refetch → LD-14 routes to the summary.
+    await expect(page).toHaveURL(new RegExp(`/game-nights/${NIGHT_ID}/summary`));
+  });
+
+  test.skip('the gamebook Serata strip reflects the Completed night after finalize', async ({
+    page,
+  }) => {
+    await setupRoutes(page);
+    await page.goto(`/library/${GAME_ID}/play/${CAMPAIGN_ID}`);
+
+    const strip = page.getByTestId('serata-spine-strip');
+    await expect(strip).toBeVisible();
+    await expect(strip).toContainText('completata');
+    await expect(page.getByTestId('serata-live-badge')).toHaveCount(0);
+    // No backward transition on the FE — the resume affordance is gone once completed.
+    await expect(page.getByRole('button', { name: /Riprendi/i })).toHaveCount(0);
+  });
+});

--- a/apps/web/src/app/(authenticated)/game-nights/[id]/live/_components/NightLiveClientView.tsx
+++ b/apps/web/src/app/(authenticated)/game-nights/[id]/live/_components/NightLiveClientView.tsx
@@ -22,6 +22,7 @@ import {
   NightLiveHub,
   WinnerPickerModal,
 } from '@/components/features/game-nights/live';
+import { useCompleteGameNight } from '@/hooks/queries/useSessionFlow';
 import {
   ConflictError,
   ForbiddenError,
@@ -91,6 +92,13 @@ export function NightLiveClientView({ nightId }: NightLiveClientViewProps) {
     [completeGame]
   );
 
+  // #2634 SI-3: the organizer concludes the WHOLE night (in-progress → completed) once every game
+  // is done and none is live. POST /complete (useCompleteGameNight) is the single finalize path; on
+  // success the read model refetches and the LD-14 effect below routes to /summary. Complementary
+  // to — and mutually exclusive with — the per-session start/Completa CTAs (this one is night-level,
+  // live-only CTAs are per-session).
+  const finalizeNight = useCompleteGameNight();
+
   // LD-14: a Completed night must not render a fake-live hub over stale data —
   // send the user to the summary they actually want. The effect fires only once
   // the read model confirms the terminal status.
@@ -159,6 +167,25 @@ export function NightLiveClientView({ nightId }: NightLiveClientViewProps) {
         : 'Impossibile completare la partita. Riprova.'
     : null;
 
+  // #2634 SI-3: the night-level finalize CTA. Gated on nightStatus==='InProgress' because POST
+  // /complete is InProgress-only (409 on a still-Published night not yet promoted by its first
+  // session). Also requires no live game (status!=='live') and nothing left to start (nextGame
+  // null) — so it never overlaps the per-session start CTA (needs nextGame) or Completa CTA
+  // (live-only). plannedGames>0 is a sanity floor (a night with a lineup).
+  const showFinalizeCta =
+    vm.isViewerOrganizer &&
+    vm.status !== 'live' &&
+    nextGame === null &&
+    vm.nightStatus === 'InProgress' &&
+    vm.plannedGames.length > 0;
+  const finalizeErrorMessage = finalizeNight.isError
+    ? finalizeNight.error instanceof ForbiddenError
+      ? 'Solo l’organizzatore può concludere la serata.'
+      : finalizeNight.error instanceof ConflictError
+        ? 'Non è possibile concludere ora.'
+        : 'Impossibile concludere la serata. Riprova.'
+    : null;
+
   // Slice C2 (panel D2): compose the diary here, keyed off the live sessionId→game lookup.
   // A pending/errored diary read yields empty arrays — the hub degrades to an empty diary
   // rather than blocking the live view (AC6).
@@ -211,6 +238,27 @@ export function NightLiveClientView({ nightId }: NightLiveClientViewProps) {
             className="flex items-center gap-2 rounded-full border border-entity-session/40 bg-entity-session px-5 py-2.5 font-display text-sm font-extrabold text-white shadow-lg transition hover:bg-entity-session/90 disabled:cursor-not-allowed disabled:opacity-60"
           >
             🏁 Completa partita
+          </button>
+        </div>
+      ) : null}
+
+      {showFinalizeCta ? (
+        <div className="fixed inset-x-0 bottom-0 z-40 flex flex-col items-center gap-2 p-4">
+          {finalizeErrorMessage ? (
+            <p
+              role="alert"
+              className="rounded-md border border-border bg-card px-3 py-1.5 font-mono text-xs font-semibold text-destructive shadow"
+            >
+              {finalizeErrorMessage}
+            </p>
+          ) : null}
+          <button
+            type="button"
+            onClick={() => finalizeNight.mutate(nightId)}
+            disabled={finalizeNight.isPending}
+            className="flex items-center gap-2 rounded-full border border-entity-event/40 bg-entity-event px-5 py-2.5 font-display text-sm font-extrabold text-white shadow-lg transition hover:bg-entity-event/90 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            🏁 Concludi serata
           </button>
         </div>
       ) : null}

--- a/apps/web/src/app/(authenticated)/game-nights/[id]/live/_components/__tests__/NightLiveClientView.test.tsx
+++ b/apps/web/src/app/(authenticated)/game-nights/[id]/live/_components/__tests__/NightLiveClientView.test.tsx
@@ -71,6 +71,22 @@ vi.mock('@/lib/game-nights/hooks/useCompleteGameNightSession', () => ({
   }),
 }));
 
+// #2634 SI-3: the night-level "Concludi serata" mutation (POST /complete via useCompleteGameNight).
+const finalizeNightMutateMock = vi.hoisted(() => vi.fn());
+const finalizeNightState = vi.hoisted(() => ({
+  isPending: false,
+  isError: false,
+  error: null as Error | null,
+}));
+vi.mock('@/hooks/queries/useSessionFlow', () => ({
+  useCompleteGameNight: () => ({
+    mutate: finalizeNightMutateMock,
+    isPending: finalizeNightState.isPending,
+    isError: finalizeNightState.isError,
+    error: finalizeNightState.error,
+  }),
+}));
+
 const pushMock = vi.fn();
 const replaceMock = vi.fn();
 vi.mock('next/navigation', () => ({
@@ -137,6 +153,9 @@ beforeEach(() => {
   completeState.isPending = false;
   completeState.isError = false;
   completeState.error = null;
+  finalizeNightState.isPending = false;
+  finalizeNightState.isError = false;
+  finalizeNightState.error = null;
   useNightLiveDiaryMock.mockReturnValue({ data: undefined });
 });
 
@@ -383,6 +402,144 @@ describe('NightLiveClientView — organizer Completa + winner picker (C4)', () =
       { winnerId: undefined },
       expect.objectContaining({ onSuccess: expect.any(Function) })
     );
+  });
+});
+
+describe('NightLiveClientView — night finalize (SI-3)', () => {
+  it('shows the "Concludi serata" CTA for the organizer of an InProgress night with no live game and no next game', () => {
+    mockQuery({
+      data: vm({
+        isViewerOrganizer: true,
+        status: 'transition',
+        nextGame: null,
+        nightStatus: 'InProgress',
+      }),
+    });
+    render(<NightLiveClientView nightId={NIGHT_ID} />);
+    expect(screen.getByRole('button', { name: /Concludi serata/i })).toBeInTheDocument();
+  });
+
+  it('does NOT show the finalize CTA for a non-organizer', () => {
+    mockQuery({
+      data: vm({
+        isViewerOrganizer: false,
+        status: 'transition',
+        nextGame: null,
+        nightStatus: 'InProgress',
+      }),
+    });
+    render(<NightLiveClientView nightId={NIGHT_ID} />);
+    expect(screen.queryByRole('button', { name: /Concludi serata/i })).toBeNull();
+  });
+
+  it('does NOT show the finalize CTA while a game is live (status==="live")', () => {
+    mockQuery({
+      data: vm({
+        isViewerOrganizer: true,
+        status: 'live',
+        nextGame: null,
+        nightStatus: 'InProgress',
+      }),
+    });
+    render(<NightLiveClientView nightId={NIGHT_ID} />);
+    expect(screen.queryByRole('button', { name: /Concludi serata/i })).toBeNull();
+  });
+
+  it('does NOT show the finalize CTA when a next game is still queued', () => {
+    mockQuery({
+      data: vm({
+        isViewerOrganizer: true,
+        status: 'transition',
+        nextGame: NEXT_GAME,
+        nightStatus: 'InProgress',
+      }),
+    });
+    render(<NightLiveClientView nightId={NIGHT_ID} />);
+    expect(screen.queryByRole('button', { name: /Concludi serata/i })).toBeNull();
+  });
+
+  it('does NOT show the finalize CTA for a Published night not yet promoted to InProgress', () => {
+    mockQuery({
+      data: vm({
+        isViewerOrganizer: true,
+        status: 'transition',
+        nextGame: null,
+        nightStatus: 'Published',
+      }),
+    });
+    render(<NightLiveClientView nightId={NIGHT_ID} />);
+    expect(screen.queryByRole('button', { name: /Concludi serata/i })).toBeNull();
+  });
+
+  it('does NOT show the finalize CTA for a Completed night (redirects to summary instead)', () => {
+    mockQuery({
+      data: vm({
+        isViewerOrganizer: true,
+        status: 'transition',
+        nextGame: null,
+        nightStatus: 'Completed',
+      }),
+    });
+    render(<NightLiveClientView nightId={NIGHT_ID} />);
+    expect(screen.queryByRole('button', { name: /Concludi serata/i })).toBeNull();
+  });
+
+  it('finalizes the night with its id on click', async () => {
+    mockQuery({
+      data: vm({
+        isViewerOrganizer: true,
+        status: 'transition',
+        nextGame: null,
+        nightStatus: 'InProgress',
+      }),
+    });
+    render(<NightLiveClientView nightId={NIGHT_ID} />);
+    await userEvent.click(screen.getByRole('button', { name: /Concludi serata/i }));
+    expect(finalizeNightMutateMock).toHaveBeenCalledWith(NIGHT_ID);
+  });
+
+  it('disables the finalize CTA while the mutation is pending', () => {
+    finalizeNightState.isPending = true;
+    mockQuery({
+      data: vm({
+        isViewerOrganizer: true,
+        status: 'transition',
+        nextGame: null,
+        nightStatus: 'InProgress',
+      }),
+    });
+    render(<NightLiveClientView nightId={NIGHT_ID} />);
+    expect(screen.getByRole('button', { name: /Concludi serata/i })).toBeDisabled();
+  });
+
+  it('surfaces a distinct 403 message when the finalize is forbidden', () => {
+    finalizeNightState.isError = true;
+    finalizeNightState.error = new ForbiddenError({ message: 'not organizer' });
+    mockQuery({
+      data: vm({
+        isViewerOrganizer: true,
+        status: 'transition',
+        nextGame: null,
+        nightStatus: 'InProgress',
+      }),
+    });
+    render(<NightLiveClientView nightId={NIGHT_ID} />);
+    expect(screen.getByText(/Solo l’organizzatore può concludere la serata/i)).toBeInTheDocument();
+  });
+
+  it('surfaces a distinct 409 message when the finalize conflicts', () => {
+    finalizeNightState.isError = true;
+    finalizeNightState.error = new ConflictError({ message: 'cannot complete now' });
+    mockQuery({
+      data: vm({
+        isViewerOrganizer: true,
+        status: 'transition',
+        nextGame: null,
+        nightStatus: 'InProgress',
+      }),
+    });
+    render(<NightLiveClientView nightId={NIGHT_ID} />);
+    expect(screen.getByText(/Non è possibile concludere ora/i)).toBeInTheDocument();
   });
 });
 

--- a/apps/web/src/components/features/game-night-detail/GameNightDetailHero.tsx
+++ b/apps/web/src/components/features/game-night-detail/GameNightDetailHero.tsx
@@ -69,6 +69,8 @@ export interface GameNightDetailHeroProps {
 const GRADIENT_BY_STATUS: Record<GameNightStatus, string> = {
   Draft: 'bg-gradient-to-br from-entity-event/[0.16] to-entity-event/[0.02]',
   Published: 'bg-gradient-to-br from-entity-toolkit/[0.16] to-entity-toolkit/[0.02]',
+  // SI-3 #2634: a night mid-play — session/indigo accent (mirrors GameNightStatusBadge).
+  InProgress: 'bg-gradient-to-br from-entity-session/[0.16] to-entity-session/[0.02]',
   Completed: 'bg-muted',
   Cancelled: 'bg-gradient-to-br from-destructive/[0.14] to-destructive/[0.04]',
 };
@@ -76,6 +78,7 @@ const GRADIENT_BY_STATUS: Record<GameNightStatus, string> = {
 const ACCENT_TEXT_BY_STATUS: Record<GameNightStatus, string> = {
   Draft: 'text-entity-event',
   Published: 'text-entity-toolkit',
+  InProgress: 'text-entity-session',
   Completed: 'text-muted-foreground',
   Cancelled: 'text-destructive',
 };

--- a/apps/web/src/components/features/game-night-detail/GameNightStatusBadge.tsx
+++ b/apps/web/src/components/features/game-night-detail/GameNightStatusBadge.tsx
@@ -45,6 +45,12 @@ const STATUS_VISUALS: Record<GameNightStatus, StatusVisualConfig> = {
     showPulsingDot: true,
     icon: null,
   },
+  // SI-3 #2634: a night mid-play — session/indigo, live-pulsing (per this file's status legend).
+  InProgress: {
+    entityClass: 'bg-entity-session/14 text-entity-session border-entity-session/28',
+    showPulsingDot: true,
+    icon: null,
+  },
   Completed: {
     entityClass: 'bg-muted text-muted-foreground border-border',
     showPulsingDot: false,

--- a/apps/web/src/components/features/gamebook/__tests__/SerataSpineStrip.test.tsx
+++ b/apps/web/src/components/features/gamebook/__tests__/SerataSpineStrip.test.tsx
@@ -36,6 +36,14 @@ describe('SerataSpineStrip', () => {
     expect(screen.getByText('programmata')).toBeInTheDocument();
   });
 
+  it('renders "completata" and NO live badge for a Completed night (SI-3 — pure BE-state render, no FE backward flip)', () => {
+    render(
+      <SerataSpineStrip spine={{ ...base, gameNightStatus: 'Completed', hasLiveSession: false }} />
+    );
+    expect(screen.queryByTestId('serata-live-badge')).not.toBeInTheDocument();
+    expect(screen.getByText('completata')).toBeInTheDocument();
+  });
+
   it('renders the session pip with completed/total', () => {
     render(<SerataSpineStrip spine={{ ...base, totalSessions: 3, completedSessions: 2 }} />);
     expect(screen.getByText('2/3')).toBeInTheDocument();

--- a/apps/web/src/hooks/queries/__tests__/useSessionFlow.test.tsx
+++ b/apps/web/src/hooks/queries/__tests__/useSessionFlow.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * useCompleteGameNight cache-invalidation tests — SI-3 #2634.
+ *
+ * On a successful `/complete`, the hook must invalidate NOT ONLY the existing
+ * diary/detail/all keys, but ALSO (SI-3) the night-live read + the whole gamebook
+ * campaign family — so the cross-surface "Serata" spine strip on the gamebook play
+ * page reflects the in-progress→completed transition (the strip is keyed by
+ * campaignId, unknown at finalize time → the broad campaign-family invalidation).
+ */
+
+import { type ReactNode } from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { gameNightLiveKeys } from '@/lib/game-nights/hooks/useGameNightLive';
+import { gamebookCampaignKeys } from '@/lib/gamebook/hooks/useGamebookCampaign';
+
+import { gameNightKeys } from '../useGameNights';
+import { sessionFlowKeys, useCompleteGameNight } from '../useSessionFlow';
+
+const completeGameNightMock = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/api', () => ({
+  api: { sessionFlow: { completeGameNight: completeGameNightMock } },
+}));
+
+const GN = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+
+function setup() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const invalidateSpy = vi.spyOn(qc, 'invalidateQueries').mockResolvedValue(undefined);
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+  );
+  return { invalidateSpy, wrapper };
+}
+
+describe('useCompleteGameNight — cache invalidation (SI-3)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('calls the API with the game night id', async () => {
+    completeGameNightMock.mockResolvedValue(undefined);
+    const { wrapper } = setup();
+    const { result } = renderHook(() => useCompleteGameNight(), { wrapper });
+
+    result.current.mutate(GN);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(completeGameNightMock).toHaveBeenCalledWith(GN);
+  });
+
+  it('invalidates the diary/detail/all keys on success (existing contract preserved)', async () => {
+    completeGameNightMock.mockResolvedValue(undefined);
+    const { invalidateSpy, wrapper } = setup();
+    const { result } = renderHook(() => useCompleteGameNight(), { wrapper });
+
+    result.current.mutate(GN);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: sessionFlowKeys.gameNightDiary(GN) });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: gameNightKeys.detail(GN) });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: gameNightKeys.all });
+  });
+
+  it('ALSO invalidates the night-live read + the gamebook campaign family (SI-3 cross-surface)', async () => {
+    completeGameNightMock.mockResolvedValue(undefined);
+    const { invalidateSpy, wrapper } = setup();
+    const { result } = renderHook(() => useCompleteGameNight(), { wrapper });
+
+    result.current.mutate(GN);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: gameNightLiveKeys.detail(GN) });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: gamebookCampaignKeys.all });
+  });
+});

--- a/apps/web/src/hooks/queries/useSessionFlow.ts
+++ b/apps/web/src/hooks/queries/useSessionFlow.ts
@@ -7,6 +7,8 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { api } from '@/lib/api';
 import type { DiaryQueryParams } from '@/lib/api/session-flow/types';
+import { gameNightLiveKeys } from '@/lib/game-nights/hooks/useGameNightLive';
+import { gamebookCampaignKeys } from '@/lib/gamebook/hooks/useGamebookCampaign';
 
 import { gameNightKeys } from './useGameNights';
 
@@ -71,8 +73,13 @@ export function useKbReadinessQuery(gameId: string) {
 // ─── Mutations ──────────────────────────────────────────────────────────────
 
 /**
- * Complete a game night — cascade-finalize all sessions.
- * Invalidates both session-flow diary and game-night detail queries.
+ * Complete a game night — cascade-finalize all sessions (in-progress → completed).
+ *
+ * Invalidates the session-flow diary + game-night list/detail queries AND (SI-3 #2634) the
+ * night-live read + the whole gamebook campaign family, so every surface reflecting the night's
+ * status refetches: the night-live hub strip AND the cross-surface "Serata" spine strip on the
+ * gamebook play page. The spine is keyed by campaignId (unknown at finalize time), hence the
+ * broad `gamebookCampaignKeys.all` family invalidation rather than a targeted key.
  */
 export function useCompleteGameNight() {
   const queryClient = useQueryClient();
@@ -83,6 +90,10 @@ export function useCompleteGameNight() {
       queryClient.invalidateQueries({ queryKey: sessionFlowKeys.gameNightDiary(gameNightId) });
       queryClient.invalidateQueries({ queryKey: gameNightKeys.detail(gameNightId) });
       queryClient.invalidateQueries({ queryKey: gameNightKeys.all });
+      // SI-3: the night-live read (the strip transitions in-progress → completed) …
+      queryClient.invalidateQueries({ queryKey: gameNightLiveKeys.detail(gameNightId) });
+      // … and every gamebook campaign/spine (cross-surface Serata strip refetch).
+      queryClient.invalidateQueries({ queryKey: gamebookCampaignKeys.all });
     },
   });
 }

--- a/apps/web/src/lib/api/schemas/game-nights.schemas.ts
+++ b/apps/web/src/lib/api/schemas/game-nights.schemas.ts
@@ -5,7 +5,16 @@
 
 import { z } from 'zod';
 
-export const GameNightStatusSchema = z.enum(['Draft', 'Published', 'Cancelled', 'Completed']);
+// SI-3 #2634: `InProgress` mirrors the BE `GameNightStatus` enum (a Published night is promoted
+// to InProgress when its first session starts, event-driven via SessionStartedHandler). It MUST be
+// listed so the live/detail read of a night mid-play parses instead of failing the whole payload.
+export const GameNightStatusSchema = z.enum([
+  'Draft',
+  'Published',
+  'InProgress',
+  'Cancelled',
+  'Completed',
+]);
 export type GameNightStatus = z.infer<typeof GameNightStatusSchema>;
 
 export const RsvpStatusSchema = z.enum(['Pending', 'Accepted', 'Declined', 'Maybe']);

--- a/apps/web/src/lib/gamebook/hooks/useGamebookCampaign.ts
+++ b/apps/web/src/lib/gamebook/hooks/useGamebookCampaign.ts
@@ -8,6 +8,10 @@ import {
 } from '@/lib/api/gamebook-campaigns';
 
 export const gamebookCampaignKeys = {
+  // SI-3 #2634: broad family key so `invalidateQueries({ queryKey: gamebookCampaignKeys.all })`
+  // targets every campaign detail + spine at once — the finalize flow does not know the
+  // campaignId(s) of the night it completes, so it must invalidate the whole family.
+  all: ['gamebook', 'campaigns'] as const,
   detail: (id: string) => ['gamebook', 'campaigns', id] as const,
   spine: (id: string) => ['gamebook', 'campaigns', id, 'spine'] as const,
 };


### PR DESCRIPTION
## Contesto

Closes #2634 (SI-3 di #2619, Thread A; dep SI-1 #2632 già CLOSED). Wire FE della transizione GameNight in-progress→completed: chiudendo l'ultima Session live via "Completa", la strip Serata passa in-progress→completed, riflettendo la transizione BE **già shipped**. Design: [decomposition §5 SI-3](docs/for-developers/specs/2026-07-01-issue-2619-decomposition-design.md).

## Decisione di scope (open questions risolte)
- Endpoint **`/complete`** (`useCompleteGameNight`, single source già RQ-wired), NON `/finalize`.
- SI-3 = **solo** transizione Completa→completed + riflesso strip + invalidation. Il selettore 3-vie unificato è scope di **SI-8**; Abbandona (Cancel) / Archivia (resume) restano affordance pre-esistenti (non toccate).

## Cosa cambia
- `useCompleteGameNight.onSuccess` ora invalida anche `gameNightLiveKeys.detail(id)` + `gamebookCampaignKeys.all` → il live hub **e** la strip Serata (gamebook play page, keyed by campaignId) refetchano a Completed. Aggiunta `gamebookCampaignKeys.all`.
- `NightLiveClientView`: CTA night-level **"🏁 Concludi serata"** (organizer + non-live + nessun next game + `nightStatus === 'InProgress'`), wired a `/complete`, feedback distinto 403/409; l'effetto LD-14 esistente redirige a `/summary` a Completed.
- **Fix schema drift**: `GameNightStatusSchema` non includeva `InProgress` (valore enum BE 4, passato raw da `GetGameNightLiveQueryHandler`) → il payload `/live` di una serata InProgress falliva `.parse()`. Aggiunto `InProgress` allo schema + ai 2 consumer `Record<GameNightStatus>` esaustivi (badge, hero). Chiavi i18n già presenti.

## Test (verificati in modo indipendente)
- vitest area game-night: **341 pass** / 36 file (SI-3 trio + consumer schema + regressione widening `InProgress`).
- `useSessionFlow` invalidation contract (nuovo), `NightLiveClientView` SI-3 (10 test), `SerataSpineStrip` Completed guard, E2E skeleton (`test.skip`).
- `pnpm typecheck` exit 0 · lint file toccati clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)