### PR TITLE
fix(security): #2655 anchor BGG host detection in image safe-loader

### DIFF
--- a/apps/web/src/lib/games/__tests__/cover-utils.test.ts
+++ b/apps/web/src/lib/games/__tests__/cover-utils.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect } from 'vitest';
 
-import { extractInitials, hashToHue, shouldUsePlaceholder } from '../cover-utils';
+import {
+  extractInitials,
+  hashToHue,
+  isBlockedImageHost,
+  shouldUsePlaceholder,
+} from '../cover-utils';
 
 describe('shouldUsePlaceholder', () => {
   it.each([
@@ -46,6 +51,45 @@ describe('shouldUsePlaceholder', () => {
   it('returns false for arbitrary first-party HTTPS hosts', () => {
     expect(shouldUsePlaceholder('https://meepleai.app/static/foo.png')).toBe(false);
     expect(shouldUsePlaceholder('https://cdn.wikimedia.org/foo.jpg')).toBe(false);
+  });
+});
+
+describe('isBlockedImageHost (#2655 — hostname-anchored BGG detection)', () => {
+  it('returns true only for a parsed hostname that is a blocked BGG image CDN', () => {
+    expect(isBlockedImageHost('https://cf.geekdo-images.com/foo.jpg')).toBe(true);
+    expect(isBlockedImageHost('https://images.geekdo.com/foo.png')).toBe(true);
+    expect(isBlockedImageHost('https://geekdo-images.com/foo.png')).toBe(true);
+  });
+
+  it('returns true for subdomains of blocked hosts', () => {
+    expect(isBlockedImageHost('https://eu.cf.geekdo-images.com/foo.png')).toBe(true);
+  });
+
+  it.each([null, undefined, '', '   '])('returns false for missing input %p', input => {
+    expect(isBlockedImageHost(input)).toBe(false);
+  });
+
+  it('returns false for unparseable src even when it contains a BGG host substring', () => {
+    // Regression for the js/regex/missing-regexp-anchor finding: the old
+    // unanchored `/…geekdo-images\.com…/.test(src)` matched a raw substring, so
+    // a garbage/unparseable src that merely CONTAINS a BGG host token was
+    // mis-detected. A parsed hostname check rejects it (no real BGG request).
+    expect(isBlockedImageHost('not-a-real-url-boardgamegeek.com-marketing')).toBe(false);
+    expect(isBlockedImageHost('cf.geekdo-images.com.evil.example/pic.jpg')).toBe(false);
+  });
+
+  it('returns false when a BGG token appears only in the path/query of a non-BGG host', () => {
+    // Attacker-style URL whose real hostname is benign but whose path embeds a
+    // BGG token. Substring matching would flag it; hostname matching must not.
+    expect(
+      isBlockedImageHost('https://evil.example/redirect?to=cf.geekdo-images.com%2Fx.jpg')
+    ).toBe(false);
+  });
+
+  it('returns false for first-party and data/relative sources', () => {
+    expect(isBlockedImageHost('https://covers.meepleai.app/abc/cover.webp')).toBe(false);
+    expect(isBlockedImageHost('data:image/png;base64,iVBORw0KGgo=')).toBe(false);
+    expect(isBlockedImageHost('/uploads/covers/abc.webp')).toBe(false);
   });
 });
 

--- a/apps/web/src/lib/games/cover-utils.ts
+++ b/apps/web/src/lib/games/cover-utils.ts
@@ -33,6 +33,53 @@ const BLOCKED_IMAGE_HOSTS: readonly string[] = [
 ];
 
 /**
+ * Parses `imageUrl` and returns its lowercased hostname, or `null` when the
+ * input is missing, a data/relative URL, or fails to parse. Centralises the
+ * URL-parsing rules so every BGG-host decision uses the same anchored,
+ * hostname-based comparison instead of ad-hoc substring matching.
+ *
+ * SSR-safe: does not rely on `window.location` or other browser globals.
+ */
+function parseImageHost(imageUrl: string | null | undefined): string | null {
+  if (!imageUrl) return null;
+
+  const trimmed = imageUrl.trim();
+  if (!trimmed) return null;
+
+  // Data URLs and same-origin relative paths carry no third-party host.
+  if (trimmed.startsWith('data:') || trimmed.startsWith('/')) return null;
+
+  try {
+    return new URL(trimmed).hostname.toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Returns true when `host` is a blocked BGG image CDN, matching either the
+ * exact host or any subdomain of it. Anchored comparison — no substring match.
+ */
+function isBggImageHostname(host: string): boolean {
+  return BLOCKED_IMAGE_HOSTS.some(blocked => host === blocked || host.endsWith(`.${blocked}`));
+}
+
+/**
+ * Returns true only when `imageUrl` parses to a hostname that is a blocked BGG
+ * image CDN (issue #2655). Unlike {@link shouldUsePlaceholder}, it returns
+ * `false` for the null / empty / unparseable / relative cases — those are
+ * missing-data states, not ToS violations. Use this to decide whether a real
+ * BGG asset request was attempted (e.g. before firing the SLO=0 beacon), so a
+ * garbage src that merely *contains* a BGG token is not mis-counted.
+ *
+ * SSR-safe.
+ */
+export function isBlockedImageHost(imageUrl: string | null | undefined): boolean {
+  const host = parseImageHost(imageUrl);
+  return host !== null && isBggImageHostname(host);
+}
+
+/**
  * Returns true when the given image URL should be treated as missing and the
  * caller should render the placeholder instead.
  *
@@ -52,14 +99,11 @@ export function shouldUsePlaceholder(imageUrl: string | null | undefined): boole
   // Data URLs and same-origin relative paths are always allowed.
   if (trimmed.startsWith('data:') || trimmed.startsWith('/')) return false;
 
-  let host: string;
-  try {
-    host = new URL(trimmed).hostname.toLowerCase();
-  } catch {
-    return true;
-  }
+  const host = parseImageHost(trimmed);
+  // A non-parseable URL has no host we can vet → fall back to the placeholder.
+  if (host === null) return true;
 
-  return BLOCKED_IMAGE_HOSTS.some(blocked => host === blocked || host.endsWith(`.${blocked}`));
+  return isBggImageHostname(host);
 }
 
 /**

--- a/apps/web/src/lib/images/__tests__/safe-loader.test.ts
+++ b/apps/web/src/lib/images/__tests__/safe-loader.test.ts
@@ -85,6 +85,36 @@ describe('safeImageLoader (#2123)', () => {
     expect(beacon).not.toHaveBeenCalled();
   });
 
+  it('does NOT fire the beacon for an unparseable src that only contains a BGG host substring (#2655)', () => {
+    // Regression for js/regex/missing-regexp-anchor: the old unanchored regex
+    // matched a raw substring, so a garbage src merely CONTAINING a BGG token
+    // fired a false BGG-attempt beacon and inflated the SLO=0 metric (false P1).
+    // The src is still redirected to the placeholder (no BGG request), but the
+    // beacon must stay silent because there is no real BGG host involved.
+    const beacon = vi.fn(() => true);
+    // @ts-expect-error — overriding for the test
+    navigator.sendBeacon = beacon;
+
+    const url = safeImageLoader({
+      src: 'not-a-real-url-boardgamegeek.com-marketing',
+      width: 100,
+    });
+
+    expect(url).toBe('/placeholder.svg');
+    expect(beacon).not.toHaveBeenCalled();
+  });
+
+  it('fires the beacon for a subdomain of a blocked BGG host (#2655)', () => {
+    const beacon = vi.fn(() => true);
+    // @ts-expect-error — overriding for the test
+    navigator.sendBeacon = beacon;
+
+    safeImageLoader({ src: 'https://eu.cf.geekdo-images.com/y.jpg', width: 100 });
+
+    expect(beacon).toHaveBeenCalledTimes(1);
+    expect(beacon.mock.calls[0][0]).toBe('/api/metrics/bgg-attempt');
+  });
+
   it('truncates oversized src to 512 chars + ellipsis before fire-and-forget beacon', () => {
     // Mitigates code-review followup #3: the beacon payload must not carry
     // multi-KB src strings over the wire even before the backend truncates.

--- a/apps/web/src/lib/images/safe-loader.ts
+++ b/apps/web/src/lib/images/safe-loader.ts
@@ -23,7 +23,7 @@
  *   ADR : docs/for-claude/architecture/adr/adr-059-catalog-seed-legal-posture.md §5
  */
 
-import { shouldUsePlaceholder } from '@/lib/games/cover-utils';
+import { isBlockedImageHost, shouldUsePlaceholder } from '@/lib/games/cover-utils';
 
 interface LoaderArgs {
   src: string;
@@ -79,12 +79,11 @@ export default function safeImageLoader({ src, width, quality }: LoaderArgs): st
     // Only fire the beacon for hosts in the BGG block list — not for the
     // null / empty / unparseable cases that `shouldUsePlaceholder` also
     // returns true for (those are not ToS issues, just missing-data states).
-    if (
-      src &&
-      /(cf\.geekdo-images\.com|geekdo-images\.com|images\.geekdo\.com|boardgamegeek\.com)/i.test(
-        src
-      )
-    ) {
+    //
+    // `isBlockedImageHost` parses the URL and compares the hostname exactly
+    // (issue #2655) — replacing an unanchored substring regex that mis-flagged
+    // any src merely *containing* a BGG token (js/regex/missing-regexp-anchor).
+    if (isBlockedImageHost(src)) {
       reportBggAttempt(src);
     }
     return PLACEHOLDER_PATH;


### PR DESCRIPTION
## Security fix — CodeQL `js/regex/missing-regexp-anchor` (alert #661)

Part of the #2655 Q3 Security Review remediation (HIGH-priority finding).

### Problem
`safeImageLoader` decided whether to fire the `meepleai_bgg_url_attempted_render_total` beacon (SLO=0) with an **unanchored substring regex** at `safe-loader.ts:84`:

```ts
/(cf\.geekdo-images\.com|geekdo-images\.com|images\.geekdo\.com|boardgamegeek\.com)/i.test(src)
```

A raw substring match flags any `src` that merely *contains* a BGG token — e.g. a garbage/unparseable `"…-boardgamegeek.com-…"` string, or a BGG token embedded in the path/query of a benign host. Those fired **false BGG-attempt beacons**, turning an SLO=0 metric into false P1 alerts. CodeQL flags the pattern as `js/regex/missing-regexp-anchor` because such a regex can match anywhere.

### Fix
Replace the regex with a **hostname-parsed** check, consistent with the real placeholder gate (`shouldUsePlaceholder`, which was already hostname-anchored):

- Extract `parseImageHost` + `isBggImageHostname` in `cover-utils.ts`; reuse them from `shouldUsePlaceholder` (**no behavior change** there).
- Add exported `isBlockedImageHost(url)`: `true` only when the parsed hostname is a blocked BGG CDN (exact or subdomain); `false` for null/empty/relative/unparseable and for BGG tokens appearing only in path/query of a benign host.
- Rewire the safe-loader beacon to `isBlockedImageHost`.

### Notes
- The **real** allowlist/placeholder gate (`shouldUsePlaceholder`) and the network-plane `next.config.js` allowlist were already correct and are unaffected — this only fixes the metric-beacon detection.
- Dropping `boardgamegeek.com` from the beacon set is **not** a coverage loss: `shouldUsePlaceholder` returns `false` for `boardgamegeek.com` hostnames, so that clause was unreachable at runtime.

### Testing (TDD)
RED tests demonstrate the substring false-positive before the fix; all pass after.
- `apps/web/src/lib/games/__tests__/cover-utils.test.ts` — `isBlockedImageHost` cases (exact/subdomain/unparseable/path-embedded/lookalike).
- `apps/web/src/lib/images/__tests__/safe-loader.test.ts` — no beacon for unparseable substring src; beacon still fires for real BGG subdomain.
- `pnpm lint:bgg` clean · typecheck clean · 48/48 tests pass.
- Adversarial review (feature-dev:code-reviewer): 0 issues ≥80% confidence; URL edge cases (uppercase/port/userinfo/trailing-dot) verified.

Closes CodeQL alert #661.

🤖 Generated with [Claude Code](https://claude.com/claude-code)