### PR TITLE
fix(security): #2655 remove empty SMTP credentials from appsettings.json

### DIFF
--- a/apps/api/src/Api/appsettings.json
+++ b/apps/api/src/Api/appsettings.json
@@ -413,9 +413,7 @@
       "To": [
         "ops@meepleai.dev"
       ],
-      "UseTls": true,
-      "Username": "",
-      "Password": ""
+      "UseTls": true
     },
     "Slack": {
       "Enabled": true,


### PR DESCRIPTION
## Security fix — CodeQL `js/empty-password-in-configuration-file` (alert #543)

Part of the #2655 Q3 Security Review remediation (HIGH-priority finding).

### Problem
`appsettings.json:418` committed an empty `Alerting:Email:Password` (with an empty `Username` too). CodeQL flags empty passwords in config as a potential no-auth default.

### Verification — inert optional-auth placeholder, not a real credential
- `EmailConfiguration.Username`/`.Password` are `string?` → they bind to `null` when the keys are **absent** (identical to the previous empty string).
- `EmailAlertChannel` only constructs `NetworkCredential` when `Username` is non-empty (`EmailAlertChannel.cs:53-55`); with the empty/absent username it passes `Credentials = null`, so the password was **never used** for auth.
- No `Alerting__Email__Password` env override is configured anywhere in the repo (the `SMTP_PASSWORD` secret feeds the separate `EmailService`, a different config path).
- No test depends on the empty value (`SlackAlertChannelRoutingTests` builds the config in-code).

### Fix
Remove the empty `Username`/`Password` keys so optional SMTP auth is expressed by **absence**, not an empty-credential default. If authenticated SMTP is ever needed for alert email, inject `Alerting__Email__Username` / `Alerting__Email__Password` at runtime (env var / secrets store).

**Behavior unchanged**: `NetworkCredential` treats `null` and `""` passwords identically, and the username gate is unaffected.

### Testing
- JSON validated; `Alerting.Email` keys now: `Enabled, SmtpHost, SmtpPort, From, To, UseTls`.
- Config-file change (TDD config exception); behavior-parity proven by code trace above.

Closes CodeQL alert #543.

🤖 Generated with [Claude Code](https://claude.com/claude-code)