### PR TITLE
fix(security): #2655 set ForwardedHeaders KnownNetworks for staging/prod (SEC-C3)

### DIFF
--- a/apps/api/src/Api/appsettings.Production.json
+++ b/apps/api/src/Api/appsettings.Production.json
@@ -29,6 +29,14 @@
     "EnableTags": true,
     "MaxTagsPerEntry": 10
   },
+  "ForwardedHeaders": {
+    "Comment": "SEC-C3 (#2655): trust only Docker-internal RFC1918 hops for X-Forwarded-For. cloudflared (edge) runs on the VPS host and forwards to the API via the published port, so the API's immediate peer is the Docker bridge gateway (an RFC1918 address auto-assigned by the daemon). Listing all private ranges guarantees the real gateway is trusted regardless of the daemon address pool; ForwardLimit=1 (base) honors only that single hop's XFF entry, so external X-Forwarded-For cannot be spoofed and per-user rate limiting keys on the real client IP.",
+    "KnownNetworks": [
+      "172.16.0.0/12",
+      "10.0.0.0/8",
+      "192.168.0.0/16"
+    ]
+  },
   "DomainEventOutbox": {
     "Comment": "Issue #1535 Phase B — OutboxOnly mode is the target steady state. Inline MediatR.Publish inside SaveChangesAsync is OFF; the DomainEventOutboxProcessor BackgroundService is the SOLE dispatcher. This closes the original #1535 race: a rolled-back outer transaction never causes side-effects to escape. Rollback path: flip back to Hybrid and redeploy — the Phase A behaviour resumes immediately (outbox rows continue to flow + inline Publish fires for all events).",
     "Mode": "OutboxOnly"

--- a/apps/api/src/Api/appsettings.Staging.json
+++ b/apps/api/src/Api/appsettings.Staging.json
@@ -29,6 +29,14 @@
     "EnableTags": true,
     "MaxTagsPerEntry": 10
   },
+  "ForwardedHeaders": {
+    "Comment": "SEC-C3 (#2655): trust only Docker-internal RFC1918 hops for X-Forwarded-For. cloudflared (edge) runs on the VPS host and forwards to the API via the published port, so the API's immediate peer is the Docker bridge gateway (an RFC1918 address auto-assigned by the daemon). Listing all private ranges guarantees the real gateway is trusted regardless of the daemon address pool; ForwardLimit=1 (base) honors only that single hop's XFF entry, so external X-Forwarded-For cannot be spoofed and per-user rate limiting keys on the real client IP.",
+    "KnownNetworks": [
+      "172.16.0.0/12",
+      "10.0.0.0/8",
+      "192.168.0.0/16"
+    ]
+  },
   "Staging": {
     "ContactEmail": "badsworm@gmail.com"
   },


### PR DESCRIPTION
## Security fix — SEC-C3 (X-Forwarded-For spoofing / rate-limit bypass)

Part of the #2655 Q3 Security Review remediation (infra config).

### Problem
Base `appsettings.json` ships `ForwardedHeaders` with empty `KnownProxies`/`KnownNetworks`. In non-Development environments `Program.cs:264-270` logs the SEC-C3 warning: with no trusted proxies configured, **every** proxy is trusted, so `X-Forwarded-For` can be spoofed and IP-based rate limiting bypassed.

### Fix
Set `ForwardedHeaders:KnownNetworks` in `appsettings.Staging.json` + `appsettings.Production.json` to the RFC1918 private ranges: `172.16.0.0/12`, `10.0.0.0/8`, `192.168.0.0/16`.

### Rationale (topology-verified)
- cloudflared (edge) runs on the **VPS host**, forwarding to the API via the published Docker port, so the API's immediate peer is the **Docker bridge gateway** — an RFC1918 address auto-assigned by the daemon (non-deterministic subnet).
- Covering all RFC1918 guarantees the real gateway is trusted **regardless of the daemon address pool**. A too-narrow subnet that missed the gateway would leave `RemoteIp = gateway` for every request and **collapse per-user rate limiting into one shared bucket** — this breadth avoids that functional trap.
- `ForwardLimit=1` (inherited from base) honors only that single hop's XFF entry, so external `X-Forwarded-For` cannot be spoofed and rate limiting keys on the **real client IP**.
- Safe: RFC1918 source IPs are only reachable inside the host's Docker network; external traffic terminates at cloudflared.

`UseForwardedHeaders()` is wired at `WebApplicationExtensions.cs:41` (gated on `ForwardedHeaders:Enabled=true` from base), so these values take effect. CIDR parsing via `Program.cs:224-243` (dual-path `IPNetwork.TryParse` + manual split).

### Config merge
Base `KnownNetworks` is `[]`; ASP.NET layered merge yields exactly the 3 override entries (no stale base). `ForwardLimit=1` is inherited unchanged.

### Verification
- Both files valid JSON; `KnownNetworks` resolves to the 3 CIDRs; `ForwardLimit` inherited = 1.
- Adversarial review (feature-dev:code-reviewer): all 5 checks SOUND (correctness, spoofing safety, array-merge, CIDR parsing, JSON).
- **Post-deploy check**: SEC-C3 startup warning no longer fires, and rate limiting keys on real client IPs.

Resolves the SEC-C3 finding from the #2655 Q3 Security Review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)