### PR TITLE
feat(gamebook): #2637 GameBook 1..N book-manager in detail + glossary (SI-6)

### DIFF
--- a/apps/web/src/app/(authenticated)/library/[gameId]/__tests__/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/library/[gameId]/__tests__/page.test.tsx
@@ -33,6 +33,12 @@ vi.mock('@/hooks/queries/useLibrary', () => ({
   useLibraryGameDetail: mockUseLibraryGameDetail,
 }));
 
+// SI-6 (#2637): the page now fetches the game's GameBooks; stub the hook so the
+// branching-logic tests don't fire a real network request.
+vi.mock('@/hooks/useGameBooks', () => ({
+  useGameBooks: vi.fn(() => ({ data: [], isLoading: false })),
+}));
+
 vi.mock('@/lib/visual-test/state-override', () => ({
   useStateOverride: mockUseStateOverride,
 }));

--- a/apps/web/src/app/(authenticated)/library/[gameId]/page.tsx
+++ b/apps/web/src/app/(authenticated)/library/[gameId]/page.tsx
@@ -32,6 +32,8 @@ import { GameTableSkeleton } from '@/components/library/game-table';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/feedback/alert';
 import { Button } from '@/components/ui/primitives/button';
 import { useLibraryGameDetail } from '@/hooks/queries/useLibrary';
+import { useGameBooks } from '@/hooks/useGameBooks';
+import { GameRefKind } from '@/lib/api/gamebook';
 import { tryLoadVisualTestFixture } from '@/lib/games/game-detail-visual-test-fixture';
 import { isLibroGame } from '@/lib/games/is-libro-game';
 import { useStateOverride } from '@/lib/visual-test/state-override';
@@ -63,6 +65,14 @@ export default function LibraryGameDetailPage() {
     isLoading,
     error,
   } = useLibraryGameDetail(gameId, stateOverride === null);
+
+  // SI-6 (#2637): the game's 1..N GameBooks, surfaced in the libro-game detail
+  // view. Fetched here (page owns data) and passed down. Shared GameRef — the
+  // seeded community books live on the SharedGame; the endpoint returns []
+  // for games without books, so this is inert for non-libro titles.
+  const { data: gameBooks, isLoading: gameBooksLoading } = useGameBooks(
+    gameId ? { id: gameId, kind: GameRefKind.Shared } : null
+  );
 
   // S4 — parse `?tab=` query param to open a specific tab (deep-link support)
   const tabParam = searchParams?.get('tab');
@@ -142,7 +152,13 @@ export default function LibraryGameDetailPage() {
   // Non-libro-game titles keep the legacy GameDetailDesktop until B2/B3.
   const renderLibroView = isLibroGame({ gameTitle: effectiveDetail.gameTitle });
   if (renderLibroView) {
-    return <LibroGameDetailView gameDetail={effectiveDetail} />;
+    return (
+      <LibroGameDetailView
+        gameDetail={effectiveDetail}
+        books={gameBooks ?? []}
+        booksLoading={gameBooksLoading}
+      />
+    );
   }
 
   return (

--- a/apps/web/src/components/features/gamebook/BookPicker.tsx
+++ b/apps/web/src/components/features/gamebook/BookPicker.tsx
@@ -12,9 +12,9 @@
  *   - On click, fire `onChange(bookId)`.
  *
  * The `roles` field on each option carries the GameBookRole bitflag (Tutorial=1,
- * Setup=2, Narrative=4, Encounter=8, RulesReference=16). Callers typically
- * filter the full book list by role BEFORE passing it in (e.g. only Narrative
- * books for a photo-translate flow).
+ * RulesReference=2, Narrative=4, Encounter=8, Lore=16, Setup=32). Callers
+ * typically filter the full book list by role BEFORE passing it in (e.g. only
+ * Narrative books for a photo-translate flow).
  */
 
 import { type FC } from 'react';

--- a/apps/web/src/components/features/gamebook/GameBookList.tsx
+++ b/apps/web/src/components/features/gamebook/GameBookList.tsx
@@ -1,0 +1,141 @@
+/**
+ * GameBookList — the 1..N GameBook "book-manager" surface (issue #2637, SI-6).
+ *
+ * Renders the real `GameBook` aggregate for a game (community books have
+ * `ownerUserId = null`; personal books carry an owner) instead of the retired
+ * hardcoded "Press Start + Rules" 2-PDF model. One row per book showing the
+ * editable DisplayName, its role badges (decoded from the `roles` bitflag),
+ * whether it is a community or personal book, and its KB/physical status.
+ *
+ * Presentational: the caller owns the fetch (`useGameBooks`) and passes the
+ * result down, so the component stays trivially testable and reusable across
+ * the detail / (future) onboarding / glossary surfaces. Graceful loading,
+ * empty and all-physical states per the demo FIX-2 requirements.
+ *
+ * Spec: `docs/for-developers/specs/2026-07-01-issue-2619-decomposition-design.md` §5 SI-6.
+ */
+
+'use client';
+
+import { type ReactElement } from 'react';
+
+import { useTranslation } from '@/hooks/useTranslation';
+import { rolesToNames, type GameBookDto, type GameBookRoleName } from '@/lib/api/gamebook';
+
+export interface GameBookListProps {
+  /** The books to render — already fetched by the caller via `useGameBooks`. */
+  readonly books: readonly GameBookDto[];
+  /** Show the loading skeleton while the caller's query is in flight. */
+  readonly isLoading?: boolean;
+}
+
+function roleLabelKey(name: GameBookRoleName): string {
+  return `gamebook.bookRole.${name.charAt(0).toLowerCase()}${name.slice(1)}`;
+}
+
+export function GameBookList({ books, isLoading = false }: GameBookListProps): ReactElement {
+  const { t } = useTranslation();
+
+  if (isLoading) {
+    return (
+      <div data-testid="game-book-list-loading" aria-busy="true" className="flex flex-col gap-2">
+        <span className="sr-only">{t('gamebook.bookList.loading')}</span>
+        {[0, 1].map(i => (
+          <div
+            key={i}
+            aria-hidden="true"
+            className="h-16 animate-pulse rounded-md border border-border bg-muted"
+          />
+        ))}
+      </div>
+    );
+  }
+
+  if (books.length === 0) {
+    return (
+      <p data-testid="game-book-list-empty" className="text-sm text-muted-foreground">
+        {t('gamebook.bookList.empty')}
+      </p>
+    );
+  }
+
+  const indexedCount = books.filter(b => b.kbSourceDocId !== null).length;
+
+  return (
+    <div className="flex flex-col gap-2">
+      <p data-testid="game-book-list-summary" className="text-xs font-medium text-muted-foreground">
+        <span>{t('gamebook.bookList.count', { count: books.length })}</span>
+        {indexedCount > 0 && (
+          <span> · {t('gamebook.bookList.indexed', { count: indexedCount })}</span>
+        )}
+      </p>
+
+      <ul
+        data-testid="game-book-list"
+        aria-label={t('gamebook.bookList.heading')}
+        className="flex flex-col gap-2"
+      >
+        {books.map(book => (
+          <li
+            key={book.id}
+            data-testid={`game-book-list-row-${book.id}`}
+            className="flex flex-col gap-1.5 rounded-md border border-border bg-card p-3"
+          >
+            <div className="flex items-center justify-between gap-2">
+              <span className="font-medium text-foreground">{book.displayName}</span>
+              <OriginBadge ownerUserId={book.ownerUserId} />
+            </div>
+
+            <div className="flex flex-wrap items-center gap-1.5">
+              {rolesToNames(book.roles).map(name => (
+                <span
+                  key={name}
+                  data-slot="game-book-role"
+                  className="inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground"
+                >
+                  {t(roleLabelKey(name))}
+                </span>
+              ))}
+              <StatusBadge book={book} />
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function OriginBadge({ ownerUserId }: { ownerUserId: string | null }): ReactElement {
+  const { t } = useTranslation();
+  const isCommunity = ownerUserId === null;
+  return (
+    <span
+      data-slot="game-book-origin"
+      className={
+        'inline-flex shrink-0 items-center rounded-full px-2 py-0.5 text-xs font-medium ' +
+        (isCommunity
+          ? 'bg-[hsl(var(--c-kb)/0.12)] text-[hsl(var(--c-kb))]'
+          : 'bg-[hsl(var(--c-player)/0.12)] text-[hsl(var(--c-player))]')
+      }
+    >
+      {isCommunity ? t('gamebook.bookList.originCommunity') : t('gamebook.bookList.originPersonal')}
+    </span>
+  );
+}
+
+function StatusBadge({ book }: { book: GameBookDto }): ReactElement {
+  const { t } = useTranslation();
+  const label = book.physicalOnly
+    ? t('gamebook.bookList.statusPhysical')
+    : book.kbSourceDocId !== null
+      ? t('gamebook.bookList.statusIndexed')
+      : t('gamebook.bookList.statusNotIndexed');
+  return (
+    <span
+      data-slot="game-book-status"
+      className="inline-flex items-center rounded-full border border-border px-2 py-0.5 text-xs font-medium text-muted-foreground"
+    >
+      {label}
+    </span>
+  );
+}

--- a/apps/web/src/components/features/gamebook/GlossaryEditorModal.tsx
+++ b/apps/web/src/components/features/gamebook/GlossaryEditorModal.tsx
@@ -40,6 +40,12 @@ export interface GlossaryEditorModalProps {
   readonly onClose: () => void;
   /** Called after a successful PUT — parent decides whether to also close. */
   readonly onSaved?: (saved: GamebookGlossaryEntry) => void;
+  /**
+   * The game's GameBooks (SI-6 #2637), used to resolve each context's
+   * `bookId` to its human `displayName` instead of showing the raw UUID.
+   * When a context's book is absent the row falls back to the id.
+   */
+  readonly books?: readonly { readonly id: string; readonly displayName: string }[];
   /** Force layout for visual tests; auto-derived from viewport otherwise. */
   readonly forceLayout?: 'mobile' | 'desktop';
   /**
@@ -139,10 +145,12 @@ export function GlossaryEditorModal({
   onClose,
   onSaved,
   forceLayout,
+  books,
   _initialState,
 }: GlossaryEditorModalProps): ReactElement | null {
   const { t } = useTranslation();
   const upsert = useUpsertGlossary(campaignId);
+  const bookNameById = new Map((books ?? []).map(b => [b.id, b.displayName]));
   const titleId = useId();
   const inputRef = useRef<HTMLInputElement | null>(null);
   const [state, dispatch] = useReducer(modalReducer, entry, e => {
@@ -275,7 +283,7 @@ export function GlossaryEditorModal({
                     data-slot="glossary-context-book"
                     className="inline-flex w-fit items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground"
                   >
-                    📖 {ctx.bookId}
+                    📖 {bookNameById.get(ctx.bookId) ?? ctx.bookId}
                   </span>
                   <p className="text-sm text-foreground">
                     {ctx.definition ?? (

--- a/apps/web/src/components/features/gamebook/LibroGameDetailView.tsx
+++ b/apps/web/src/components/features/gamebook/LibroGameDetailView.tsx
@@ -21,8 +21,10 @@ import { useState, type ReactElement } from 'react';
 
 import { useRouter } from 'next/navigation';
 
+import { GameBookList } from '@/components/features/gamebook/GameBookList';
 import { NanolithCampaignCTA } from '@/components/features/gamebook/NanolithCampaignCTA';
 import type { LibraryGameDetail } from '@/hooks/queries/useLibrary';
+import type { GameBookDto } from '@/lib/api/gamebook';
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -30,11 +32,21 @@ type TabId = 'info' | 'chat' | 'toolbox' | 'toolkit';
 
 export interface LibroGameDetailViewProps {
   readonly gameDetail: LibraryGameDetail;
+  /**
+   * The game's 1..N GameBooks (SI-6). Fetched by the page via `useGameBooks`
+   * and threaded down so this presentational view stays provider-free.
+   */
+  readonly books?: readonly GameBookDto[];
+  readonly booksLoading?: boolean;
 }
 
 // ─── Component ──────────────────────────────────────────────────────────────
 
-export function LibroGameDetailView({ gameDetail }: LibroGameDetailViewProps): ReactElement {
+export function LibroGameDetailView({
+  gameDetail,
+  books,
+  booksLoading,
+}: LibroGameDetailViewProps): ReactElement {
   const router = useRouter();
   const [tab, setTab] = useState<TabId>('info');
 
@@ -170,7 +182,9 @@ export function LibroGameDetailView({ gameDetail }: LibroGameDetailViewProps): R
           aria-labelledby={`tab-${tab}`}
           className="py-4"
         >
-          {tab === 'info' && <InfoPanel detail={gameDetail} />}
+          {tab === 'info' && (
+            <InfoPanel detail={gameDetail} books={books} booksLoading={booksLoading} />
+          )}
           {tab === 'chat' && <PlaceholderPanel label="AI Chat" />}
           {tab === 'toolbox' && <PlaceholderPanel label="Toolbox" />}
           {tab === 'toolkit' && <PlaceholderPanel label="Toolkit" />}
@@ -256,7 +270,15 @@ function TabButton({
   );
 }
 
-function InfoPanel({ detail }: { detail: LibraryGameDetail }): ReactElement {
+function InfoPanel({
+  detail,
+  books,
+  booksLoading,
+}: {
+  detail: LibraryGameDetail;
+  books?: readonly GameBookDto[];
+  booksLoading?: boolean;
+}): ReactElement {
   return (
     <div className="grid gap-4">
       <div>
@@ -267,6 +289,15 @@ function InfoPanel({ detail }: { detail: LibraryGameDetail }): ReactElement {
           {detail.description ??
             `${detail.gameTitle} — campagna libro game. Avvia la modalità per setup tutorial, Q&A regole e traduzione storybook.`}
         </p>
+      </div>
+
+      {/* Libri — 1..N GameBook aggregate (SI-6 #2637); replaces the retired
+          hardcoded "Press Start + Rules" 2-PDF model. */}
+      <div>
+        <h2 className="mb-2 font-quicksand text-[15px] font-bold uppercase tracking-wide text-[#9a8870]">
+          Libri
+        </h2>
+        <GameBookList books={books ?? []} isLoading={booksLoading} />
       </div>
 
       {/* KB status row */}

--- a/apps/web/src/components/features/gamebook/__tests__/GameBookList.test.tsx
+++ b/apps/web/src/components/features/gamebook/__tests__/GameBookList.test.tsx
@@ -1,0 +1,173 @@
+/**
+ * GameBookList — tests for issue #2637 (SI-6): the 1..N book-manager surface.
+ *
+ * Renders the shipped `GameBook` aggregate (community `ownerUserId=null` +
+ * personal) with role/origin/status badges, replacing the hardcoded
+ * "Press Start + Rules" 2-PDF model. Covers loading / empty / list states.
+ */
+
+import { render, screen, within, type RenderResult } from '@testing-library/react';
+import { axe } from 'jest-axe';
+import type { ReactElement, ReactNode } from 'react';
+import { IntlProvider } from 'react-intl';
+import { describe, expect, it } from 'vitest';
+
+import enMessages from '@/locales/en.json';
+import itMessages from '@/locales/it.json';
+import { GameBookRole, type GameBookDto } from '@/lib/api/gamebook';
+
+import { GameBookList } from '../GameBookList';
+
+// react-intl wants dot-notation flat keys; the locale catalogue is nested.
+function flatten(obj: Record<string, unknown>, prefix = ''): Record<string, string> {
+  return Object.keys(obj).reduce(
+    (acc, key) => {
+      const full = prefix ? `${prefix}.${key}` : key;
+      const value = obj[key];
+      if (value && typeof value === 'object') {
+        Object.assign(acc, flatten(value as Record<string, unknown>, full));
+      } else {
+        acc[full] = String(value);
+      }
+      return acc;
+    },
+    {} as Record<string, string>
+  );
+}
+
+const FLAT_IT = flatten(itMessages as Record<string, unknown>);
+const FLAT_EN = flatten(enMessages as Record<string, unknown>);
+
+function renderList(ui: ReactElement, locale: 'it' | 'en' = 'it'): RenderResult {
+  const messages = locale === 'it' ? FLAT_IT : FLAT_EN;
+  function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <IntlProvider locale={locale} messages={messages} onError={() => {}}>
+        {children}
+      </IntlProvider>
+    );
+  }
+  return render(ui, { wrapper: Wrapper });
+}
+
+let seq = 0;
+function makeBook(overrides: Partial<GameBookDto> = {}): GameBookDto {
+  seq += 1;
+  return {
+    id: overrides.id ?? `book-${seq}`,
+    gameRefId: 'game-1',
+    gameRefKind: 0,
+    ownerUserId: null,
+    displayName: `Book ${seq}`,
+    roles: GameBookRole.RulesReference,
+    paragraphScheme: 0,
+    language: 'it',
+    sequentialRead: false,
+    kbSourceDocId: 'kb-1',
+    physicalOnly: false,
+    createdAt: '2026-07-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('GameBookList', () => {
+  it('renders the loading skeleton while the caller query is in flight', () => {
+    renderList(<GameBookList books={[]} isLoading />);
+    expect(screen.getByTestId('game-book-list-loading')).toHaveAttribute('aria-busy', 'true');
+    expect(screen.queryByTestId('game-book-list')).not.toBeInTheDocument();
+  });
+
+  it('renders the empty state when the game has no books', () => {
+    renderList(<GameBookList books={[]} />);
+    expect(screen.getByTestId('game-book-list-empty')).toBeInTheDocument();
+    expect(screen.queryByTestId('game-book-list')).not.toBeInTheDocument();
+  });
+
+  it('renders one row per book with its displayName (1..N, not the fixed 2-PDF model)', () => {
+    const books = [
+      makeBook({ id: 'a', displayName: 'Manuale Base' }),
+      makeBook({ id: 'b', displayName: 'Storybook' }),
+      makeBook({ id: 'c', displayName: 'Encounter Book' }),
+    ];
+    renderList(<GameBookList books={books} />);
+    const list = screen.getByTestId('game-book-list');
+    expect(within(list).getAllByRole('listitem')).toHaveLength(3);
+    expect(screen.getByText('Manuale Base')).toBeInTheDocument();
+    expect(screen.getByText('Storybook')).toBeInTheDocument();
+    expect(screen.getByText('Encounter Book')).toBeInTheDocument();
+  });
+
+  it('decodes role badges from the roles bitflag using the backend-parity enum', () => {
+    // RulesReference is BE value 2; the pre-fix FE enum mislabeled 2 as "Setup".
+    const book = makeBook({ id: 'r', roles: GameBookRole.RulesReference });
+    renderList(<GameBookList books={[book]} />);
+    const row = screen.getByTestId('game-book-list-row-r');
+    expect(within(row).getByText('Regole')).toBeInTheDocument();
+    expect(within(row).queryByText('Setup')).not.toBeInTheDocument();
+  });
+
+  it('renders multiple role badges for a composite bitflag', () => {
+    const book = makeBook({
+      id: 'multi',
+      roles: GameBookRole.Tutorial | GameBookRole.Setup,
+    });
+    renderList(<GameBookList books={[book]} />);
+    const row = screen.getByTestId('game-book-list-row-multi');
+    expect(within(row).getByText('Tutorial')).toBeInTheDocument();
+    expect(within(row).getByText('Setup')).toBeInTheDocument();
+  });
+
+  it('distinguishes community (ownerUserId=null) from personal books', () => {
+    const books = [
+      makeBook({ id: 'community', ownerUserId: null }),
+      makeBook({ id: 'personal', ownerUserId: 'user-9' }),
+    ];
+    renderList(<GameBookList books={books} />);
+    expect(
+      within(screen.getByTestId('game-book-list-row-community')).getByText('Community')
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId('game-book-list-row-personal')).getByText('Personale')
+    ).toBeInTheDocument();
+  });
+
+  it('surfaces physical-only, indexed and not-yet-indexed status per book', () => {
+    const books = [
+      makeBook({ id: 'indexed', physicalOnly: false, kbSourceDocId: 'kb-9' }),
+      makeBook({ id: 'physical', physicalOnly: true, kbSourceDocId: null }),
+      // digital book whose PDF has not been indexed yet (or failed): the
+      // reachable third status branch — reflects an aggregate state, not a
+      // hardcoded page count.
+      makeBook({ id: 'notidx', physicalOnly: false, kbSourceDocId: null }),
+    ];
+    renderList(<GameBookList books={books} />);
+    expect(
+      within(screen.getByTestId('game-book-list-row-indexed')).getByText('Indicizzato')
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId('game-book-list-row-physical')).getByText('Solo fisico')
+    ).toBeInTheDocument();
+    expect(
+      within(screen.getByTestId('game-book-list-row-notidx')).getByText('Non indicizzato')
+    ).toBeInTheDocument();
+  });
+
+  it('renders a generic count summary (no hardcoded page count)', () => {
+    const books = [
+      makeBook({ id: 'x1', kbSourceDocId: 'kb-1' }),
+      makeBook({ id: 'x2', kbSourceDocId: null, physicalOnly: true }),
+    ];
+    renderList(<GameBookList books={books} />);
+    const summary = screen.getByTestId('game-book-list-summary');
+    expect(summary).toHaveTextContent('2 libri');
+    expect(summary).toHaveTextContent('1 indicizzato');
+    expect(summary.textContent).not.toMatch(/24 pag/i);
+  });
+
+  it('has no axe violations in the list state', async () => {
+    const { container } = renderList(
+      <GameBookList books={[makeBook({ id: 'ax', displayName: 'Ax Book' })]} />
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/apps/web/src/components/features/gamebook/__tests__/GlossaryEditorModal.test.tsx
+++ b/apps/web/src/components/features/gamebook/__tests__/GlossaryEditorModal.test.tsx
@@ -658,6 +658,43 @@ describe('#2638 SI-7 — multi-context render', () => {
   });
 });
 
+describe('#2637 SI-6 — context bookId → GameBook displayName resolution', () => {
+  it('renders the GameBook displayName instead of the raw bookId when books are provided', () => {
+    renderModal(
+      <GlossaryEditorModal
+        campaignId={CAMPAIGN_ID}
+        entry={ENTRY_WITH_CONTEXTS}
+        onClose={() => {}}
+        books={[
+          { id: BOOK_A, displayName: 'Manuale Base' },
+          { id: BOOK_B, displayName: 'Storybook' },
+        ]}
+      />
+    );
+
+    const rows = screen.getAllByTestId('glossary-context-row');
+    expect(rows[0]).toHaveTextContent('Manuale Base');
+    expect(rows[0]).not.toHaveTextContent(BOOK_A);
+    expect(rows[1]).toHaveTextContent('Storybook');
+    expect(rows[1]).not.toHaveTextContent(BOOK_B);
+  });
+
+  it('falls back to the raw bookId when a context book is missing from the list', () => {
+    renderModal(
+      <GlossaryEditorModal
+        campaignId={CAMPAIGN_ID}
+        entry={ENTRY_WITH_CONTEXTS}
+        onClose={() => {}}
+        books={[{ id: BOOK_A, displayName: 'Manuale Base' }]}
+      />
+    );
+
+    const rows = screen.getAllByTestId('glossary-context-row');
+    expect(rows[0]).toHaveTextContent('Manuale Base');
+    expect(rows[1]).toHaveTextContent(BOOK_B);
+  });
+});
+
 // ---------------------------------------------------------------------------
 // AC-4 — Submit error + retry
 // ---------------------------------------------------------------------------

--- a/apps/web/src/components/features/gamebook/__tests__/LibroGameDetailView.test.tsx
+++ b/apps/web/src/components/features/gamebook/__tests__/LibroGameDetailView.test.tsx
@@ -1,12 +1,64 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within, type RenderResult } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { axe, toHaveNoViolations } from 'jest-axe';
+import type { ReactElement, ReactNode } from 'react';
+import { IntlProvider } from 'react-intl';
 
+import itMessages from '@/locales/it.json';
 import type { LibraryGameDetail } from '@/hooks/queries/useLibrary';
+import { GameBookRole, type GameBookDto } from '@/lib/api/gamebook';
 import { LibroGameDetailView } from '../LibroGameDetailView';
 
 expect.extend(toHaveNoViolations);
+
+// GameBookList (mounted in the info tab) consumes `useTranslation`, so the view
+// must render under an IntlProvider. Flatten the nested catalogue for react-intl.
+function flatten(obj: Record<string, unknown>, prefix = ''): Record<string, string> {
+  return Object.keys(obj).reduce(
+    (acc, key) => {
+      const full = prefix ? `${prefix}.${key}` : key;
+      const value = obj[key];
+      if (value && typeof value === 'object') {
+        Object.assign(acc, flatten(value as Record<string, unknown>, full));
+      } else {
+        acc[full] = String(value);
+      }
+      return acc;
+    },
+    {} as Record<string, string>
+  );
+}
+const FLAT_IT = flatten(itMessages as Record<string, unknown>);
+
+function renderView(ui: ReactElement): RenderResult {
+  function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <IntlProvider locale="it" messages={FLAT_IT} onError={() => {}}>
+        {children}
+      </IntlProvider>
+    );
+  }
+  return render(ui, { wrapper: Wrapper });
+}
+
+function makeGameBook(overrides: Partial<GameBookDto> = {}): GameBookDto {
+  return {
+    id: 'gb-1',
+    gameRefId: 'g1',
+    gameRefKind: 0,
+    ownerUserId: null,
+    displayName: 'Manuale Base',
+    roles: GameBookRole.RulesReference,
+    paragraphScheme: 0,
+    language: 'it',
+    sequentialRead: false,
+    kbSourceDocId: 'kb-1',
+    physicalOnly: false,
+    createdAt: '2026-07-01T00:00:00Z',
+    ...overrides,
+  };
+}
 
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: vi.fn() }),
@@ -60,11 +112,32 @@ function makeLibraryGameDetail(overrides: Partial<LibraryGameDetail> = {}): Libr
 describe('LibroGameDetailView', () => {
   it('renders default tab "info" with InfoPanel', () => {
     const gameDetail = makeLibraryGameDetail();
-    render(<LibroGameDetailView gameDetail={gameDetail} />);
+    renderView(<LibroGameDetailView gameDetail={gameDetail} />);
 
     expect(screen.getByText('Descrizione')).toBeVisible();
     expect(screen.getByText('Test description')).toBeVisible();
     expect(screen.getByText('Knowledge base')).toBeVisible();
+  });
+
+  it('SI-6: renders the 1..N GameBook list in the info tab', () => {
+    const gameDetail = makeLibraryGameDetail();
+    const books = [
+      makeGameBook({ id: 'a', displayName: 'Manuale Base' }),
+      makeGameBook({ id: 'b', displayName: 'Storybook', roles: GameBookRole.Narrative }),
+    ];
+    renderView(<LibroGameDetailView gameDetail={gameDetail} books={books} />);
+
+    expect(screen.getByRole('heading', { name: 'Libri' })).toBeVisible();
+    const list = screen.getByTestId('game-book-list');
+    expect(within(list).getByText('Manuale Base')).toBeVisible();
+    expect(within(list).getByText('Storybook')).toBeVisible();
+  });
+
+  it('SI-6: shows the graceful empty state when the game has no books', () => {
+    const gameDetail = makeLibraryGameDetail();
+    renderView(<LibroGameDetailView gameDetail={gameDetail} books={[]} />);
+
+    expect(screen.getByTestId('game-book-list-empty')).toBeVisible();
   });
 
   it('renders all 4 MetaStat cells with formatted values', () => {
@@ -75,7 +148,7 @@ describe('LibroGameDetailView', () => {
       averageRating: 7.5,
       gameYearPublished: 2024,
     });
-    render(<LibroGameDetailView gameDetail={gameDetail} />);
+    renderView(<LibroGameDetailView gameDetail={gameDetail} />);
 
     expect(screen.getByText('2–4')).toBeVisible();
     expect(screen.getByText('1–2h')).toBeVisible();
@@ -97,7 +170,7 @@ describe('LibroGameDetailView', () => {
       hasRagAccess: true,
       timesPlayed: 2,
     });
-    render(<LibroGameDetailView gameDetail={gameDetail} />);
+    renderView(<LibroGameDetailView gameDetail={gameDetail} />);
 
     expect(screen.getByLabelText('KB 3')).toBeVisible();
     expect(screen.getByLabelText('chat 0')).toBeVisible();
@@ -108,7 +181,7 @@ describe('LibroGameDetailView', () => {
 
   it('switches tabs and shows placeholder text', async () => {
     const gameDetail = makeLibraryGameDetail();
-    render(<LibroGameDetailView gameDetail={gameDetail} />);
+    renderView(<LibroGameDetailView gameDetail={gameDetail} />);
     const user = userEvent.setup();
 
     // Click AI Chat tab
@@ -135,7 +208,7 @@ describe('LibroGameDetailView', () => {
 
   it("KB badge variant: kbStatus='indexing'", () => {
     const gameDetail = makeLibraryGameDetail({ kbStatus: 'indexing' });
-    render(<LibroGameDetailView gameDetail={gameDetail} />);
+    renderView(<LibroGameDetailView gameDetail={gameDetail} />);
 
     expect(screen.getByText('Indicizzazione in corso…')).toBeVisible();
     expect(screen.getByText(/pipeline OCR\/embedding/)).toBeVisible();
@@ -143,7 +216,7 @@ describe('LibroGameDetailView', () => {
 
   it("KB badge variant: kbStatus='error'", () => {
     const gameDetail = makeLibraryGameDetail({ kbStatus: 'error' });
-    render(<LibroGameDetailView gameDetail={gameDetail} />);
+    renderView(<LibroGameDetailView gameDetail={gameDetail} />);
 
     // The source uses smart quote in "l'indicizzazione" — use regex to match
     expect(screen.getByText(/Errore durante l.indicizzazione/)).toBeVisible();
@@ -152,7 +225,7 @@ describe('LibroGameDetailView', () => {
 
   it('jest-axe smoke — no a11y violations on default render', async () => {
     const gameDetail = makeLibraryGameDetail();
-    const { container } = render(<LibroGameDetailView gameDetail={gameDetail} />);
+    const { container } = renderView(<LibroGameDetailView gameDetail={gameDetail} />);
 
     // T12: heading-order rule re-enabled — all consumers now pass headingLevel prop
     const results = await axe(container);

--- a/apps/web/src/components/library/game-table/__tests__/GameTablePage.test.tsx
+++ b/apps/web/src/components/library/game-table/__tests__/GameTablePage.test.tsx
@@ -20,6 +20,7 @@ const mocks = vi.hoisted(() => ({
   useRouter: vi.fn(() => ({ push: vi.fn(), replace: vi.fn() })),
   useSearchParams: vi.fn(() => new URLSearchParams()),
   useLibraryGameDetail: vi.fn(),
+  useGameBooks: vi.fn(() => ({ data: [], isLoading: false })),
 }));
 
 vi.mock('next/navigation', () => ({
@@ -35,6 +36,12 @@ vi.mock('@/hooks/queries/useLibrary', () => ({
     lists: () => ['library', 'list'],
     gameDetail: (id: string) => ['library', 'detail', id],
   },
+}));
+
+// SI-6 (#2637): the page now calls useGameBooks (useQuery); this suite renders
+// the page without a QueryClientProvider, so stub the hook.
+vi.mock('@/hooks/useGameBooks', () => ({
+  useGameBooks: mocks.useGameBooks,
 }));
 
 // Stub the heavy child components so this test focuses on page routing only

--- a/apps/web/src/lib/api/__tests__/gamebook.test.ts
+++ b/apps/web/src/lib/api/__tests__/gamebook.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+
+import { GameBookRole, hasRole, rolesToNames, GAME_BOOK_ROLE_ORDER } from '../gamebook';
+
+/**
+ * SI-6 (#2637): the FE `GameBookRole` bitflag must mirror the backend
+ * `[Flags] enum GameBookRole` (GameManagement BC) exactly, otherwise the
+ * book-manager mislabels roles decoded from the `roles` int on the wire.
+ *
+ * Backend source of truth (GameBookRole.cs):
+ *   None=0, Tutorial=1, RulesReference=2, Narrative=4, Encounter=8, Lore=16, Setup=32
+ */
+describe('GameBookRole enum — parity with backend [Flags] enum GameBookRole', () => {
+  it('mirrors the backend bitflag values exactly', () => {
+    expect(GameBookRole.Tutorial).toBe(1);
+    expect(GameBookRole.RulesReference).toBe(2);
+    expect(GameBookRole.Narrative).toBe(4);
+    expect(GameBookRole.Encounter).toBe(8);
+    expect(GameBookRole.Lore).toBe(16);
+    expect(GameBookRole.Setup).toBe(32);
+  });
+
+  it('exposes exactly the six backend roles', () => {
+    expect(Object.keys(GameBookRole).sort()).toEqual(
+      ['Encounter', 'Lore', 'Narrative', 'RulesReference', 'Setup', 'Tutorial'].sort()
+    );
+  });
+});
+
+describe('hasRole', () => {
+  it('detects each role present in a composite bitflag', () => {
+    const roles = GameBookRole.Tutorial | GameBookRole.Setup; // 1 | 32 = 33
+    expect(hasRole(roles, GameBookRole.Tutorial)).toBe(true);
+    expect(hasRole(roles, GameBookRole.Setup)).toBe(true);
+    expect(hasRole(roles, GameBookRole.RulesReference)).toBe(false);
+  });
+
+  it('returns false against None (0)', () => {
+    expect(hasRole(0, GameBookRole.Narrative)).toBe(false);
+  });
+});
+
+describe('rolesToNames', () => {
+  it('returns present role names in canonical display order', () => {
+    const roles = GameBookRole.Narrative | GameBookRole.Tutorial; // 4 | 1
+    expect(rolesToNames(roles)).toEqual(['Tutorial', 'Narrative']);
+  });
+
+  it('returns an empty array for None (0)', () => {
+    expect(rolesToNames(0)).toEqual([]);
+  });
+
+  it('returns all six names for the full bitmask, in order', () => {
+    const all =
+      GameBookRole.Tutorial |
+      GameBookRole.Setup |
+      GameBookRole.RulesReference |
+      GameBookRole.Narrative |
+      GameBookRole.Encounter |
+      GameBookRole.Lore;
+    expect(rolesToNames(all)).toEqual([...GAME_BOOK_ROLE_ORDER]);
+  });
+});

--- a/apps/web/src/lib/api/gamebook.ts
+++ b/apps/web/src/lib/api/gamebook.ts
@@ -39,8 +39,9 @@ export interface GameRef {
 /**
  * GameBook DTO mirroring `Api.BoundedContexts.GameManagement.Application.DTOs.GameBookDto`.
  *
- * `roles` encodes a GameBookRole bitflag: Tutorial=1, Setup=2, Narrative=4,
- * Encounter=8, RulesReference=16. Use bitwise AND to filter by role.
+ * `roles` encodes a GameBookRole bitflag: Tutorial=1, RulesReference=2,
+ * Narrative=4, Encounter=8, Lore=16, Setup=32. Use bitwise AND to filter by
+ * role (see `hasRole` / `rolesToNames`).
  *
  * `paragraphScheme`: 0=None, 1=ParagraphNumber, 2=Section.
  */
@@ -64,21 +65,50 @@ export type GameBookDto = z.infer<typeof GameBookDtoSchema>;
 const ListGameBooksResponseSchema = z.array(GameBookDtoSchema);
 
 /**
- * GameBookRole bitflag values (matches backend `[Flags] enum GameBookRole`).
+ * GameBookRole bitflag values — mirrors backend `[Flags] enum GameBookRole`
+ * (GameManagement BC) exactly:
+ *   None=0, Tutorial=1, RulesReference=2, Narrative=4, Encounter=8, Lore=16, Setup=32
+ *
+ * Kept in lock-step by `src/lib/api/__tests__/gamebook.test.ts`. Divergence
+ * mislabels the `roles` int decoded from the wire (issue #2637 SI-6).
  */
 export const GameBookRole = {
   Tutorial: 1,
-  Setup: 2,
+  RulesReference: 2,
   Narrative: 4,
   Encounter: 8,
-  RulesReference: 16,
+  Lore: 16,
+  Setup: 32,
 } as const;
+
+export type GameBookRoleName = keyof typeof GameBookRole;
+
+/**
+ * Canonical display order for the role badges rendered by the book-manager.
+ * Reading-flow order: onboarding roles first, then reference/story material.
+ */
+export const GAME_BOOK_ROLE_ORDER = [
+  'Tutorial',
+  'Setup',
+  'RulesReference',
+  'Narrative',
+  'Encounter',
+  'Lore',
+] as const satisfies readonly GameBookRoleName[];
 
 /**
  * Returns true if the supplied bitflag includes the given role.
  */
 export function hasRole(roles: number, role: number): boolean {
   return (roles & role) !== 0;
+}
+
+/**
+ * Decodes a `roles` bitflag into the list of present role names, in canonical
+ * display order (`GAME_BOOK_ROLE_ORDER`). Empty array for `None` (0).
+ */
+export function rolesToNames(roles: number): GameBookRoleName[] {
+  return GAME_BOOK_ROLE_ORDER.filter(name => hasRole(roles, GameBookRole[name]));
 }
 
 /**

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -3640,6 +3640,26 @@
         }
       }
     },
+    "bookList": {
+      "heading": "Books",
+      "count": "{count, plural, one {# book} other {# books}}",
+      "indexed": "{count, plural, one {# indexed} other {# indexed}}",
+      "empty": "No books available for this game yet.",
+      "loading": "Loading books…",
+      "originCommunity": "Community",
+      "originPersonal": "Personal",
+      "statusIndexed": "Indexed",
+      "statusPhysical": "Physical only",
+      "statusNotIndexed": "Not indexed"
+    },
+    "bookRole": {
+      "tutorial": "Tutorial",
+      "rulesReference": "Rules",
+      "narrative": "Story",
+      "encounter": "Encounters",
+      "lore": "Lore",
+      "setup": "Setup"
+    },
     "glossaryEditor": {
       "title": "Edit glossary entry",
       "termEnLabel": "Source term",

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -3693,6 +3693,26 @@
         }
       }
     },
+    "bookList": {
+      "heading": "Libri",
+      "count": "{count, plural, one {# libro} other {# libri}}",
+      "indexed": "{count, plural, one {# indicizzato} other {# indicizzati}}",
+      "empty": "Nessun libro disponibile per questo gioco.",
+      "loading": "Caricamento libri…",
+      "originCommunity": "Community",
+      "originPersonal": "Personale",
+      "statusIndexed": "Indicizzato",
+      "statusPhysical": "Solo fisico",
+      "statusNotIndexed": "Non indicizzato"
+    },
+    "bookRole": {
+      "tutorial": "Tutorial",
+      "rulesReference": "Regole",
+      "narrative": "Storia",
+      "encounter": "Incontri",
+      "lore": "Ambientazione",
+      "setup": "Setup"
+    },
     "glossaryEditor": {
       "title": "Modifica voce di glossario",
       "termEnLabel": "Termine originale",


### PR DESCRIPTION
## Summary

Closes #2637 (SI-6, umbrella #2619 Thread B). Surfaces the **shipped `GameBook` aggregate** (community `OwnerUserId=null` + personal) in the libro-game production surfaces, replacing the retired hardcoded **"Press Start + Rules" / "24 pagine"** 2-PDF model (demo FIX-2).

## What changed
- **`GameBookList`** (new) — presentational 1..N book-manager: displayName, role badges, community/personal origin, indexed/physical/not-indexed status, generic count summary; graceful loading + empty states; axe-clean.
- **`LibroGameDetailView`** info tab now renders `GameBookList`; the page (`library/[gameId]`) fetches via `useGameBooks` (Shared `GameRef`) and threads `books`/`booksLoading` down (view stays provider-free, consistent with its presentational character).
- **`GlossaryEditorModal`** — resolves each context `bookId` → GameBook `displayName` via a new optional `books` prop (fallback to the raw id when a book isn't in the list).
- **`GameBookRole` enum fix** — the FE bitflag had desynced from the backend (`RulesReference`, `Lore`, `Setup` mislabeled). Now byte-for-byte parity (`Tutorial=1, RulesReference=2, Narrative=4, Encounter=8, Lore=16, Setup=32`), guarded by a parity test. Added `rolesToNames` helper. Existing consumers only used `Narrative` (=4, unchanged) → no behavioural regression.
- i18n keys added to **both** `it.json` + `en.json` (`gamebook.bookList.*`, `gamebook.bookRole.*`).

## Scope decisions (grounded in the spec: SI-6 = deps-none, effort-L, FE-only)
- **Onboarding book-display deferred**: the only onboarding surface that shows books is a Storybook mock ("Template K", no real component); the real book-upload flow is XL with a prereq-stepper dependency → out of SI-6. `GameBookList` is reusable for it when built.
- **Residual "Press Start"/"24 pagine" literals** live exclusively in Storybook mockup-pilot fixtures + `admin-mockups/*.html` (DS-17 design track #2063), **not** production code → left untouched (editing them belongs to DS-17 and would risk the mockup-drift gates).
- **Known limitation** (revisit-later, not in SI-6 scope): the detail fetch hardcodes `GameRefKind.Shared`. Community books live on the SharedGame ref, so the current demo path resolves correctly; personal books on private games (`kind=Private`) are the deferred XL feature. Documented inline at `page.tsx`.

## Testing
- `gamebook.test.ts` — enum backend-parity, `hasRole`, `rolesToNames`.
- `GameBookList.test.tsx` — loading / empty / 1..N render / role decoding / community-vs-personal / **3 status branches** / generic count summary / axe.
- `LibroGameDetailView.test.tsx` — books section render + graceful empty (harness wrapped in `IntlProvider`).
- `GlossaryEditorModal.test.tsx` — displayName resolution + raw-id fallback.
- Full `gamebook` feature suite green (581 pass), `pnpm typecheck` 0, ESLint 0 errors.
- Adversarial multi-lens review (correctness / scope-vs-AC / conventions): 4 findings, 3 dismissed on verification (documented over-fetch, deferred Shared-kind, file-consistent hardcoded heading), 1 nit addressed (added the not-indexed status-branch test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)