### PR TITLE
fix(security): #2655 GameSession lifecycle IDOR ownership guards

### DIFF
--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/AbandonGameSessionCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/AbandonGameSessionCommand.cs
@@ -8,5 +8,6 @@ namespace Api.BoundedContexts.GameManagement.Application.Commands;
 /// </summary>
 internal record AbandonGameSessionCommand(
     Guid SessionId,
+    Guid RequesterId,
     string? Reason = null
 ) : ICommand<GameSessionDto>;

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/AbandonGameSessionCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/AbandonGameSessionCommandHandler.cs
@@ -32,6 +32,12 @@ internal class AbandonGameSessionCommandHandler : ICommandHandler<AbandonGameSes
         var session = await _sessionRepository.GetByIdAsync(command.SessionId, cancellationToken)
 .ConfigureAwait(false) ?? throw new NotFoundException("GameSession", command.SessionId.ToString());
 
+        // #2655 IDOR guard: only the session creator may abandon it.
+        if (session.CreatedByUserId != command.RequesterId)
+        {
+            throw new ForbiddenException("Only the session creator can abandon this session.");
+        }
+
         // Abandon via domain method
         session.Abandon(command.Reason);
 

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/CompleteGameSessionCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/CompleteGameSessionCommand.cs
@@ -6,7 +6,11 @@ namespace Api.BoundedContexts.GameManagement.Application.Commands;
 /// <summary>
 /// Command to complete an active game session.
 /// </summary>
+/// <param name="SessionId">Session to complete.</param>
+/// <param name="RequesterId">Authenticated caller — must match the session creator (#2655 IDOR guard).</param>
+/// <param name="WinnerName">Optional winner name.</param>
 internal record CompleteGameSessionCommand(
     Guid SessionId,
+    Guid RequesterId,
     string? WinnerName = null
 ) : ICommand<GameSessionDto>;

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/CompleteGameSessionCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/CompleteGameSessionCommandHandler.cs
@@ -3,6 +3,7 @@ using Api.BoundedContexts.GameManagement.Application.DTOs;
 using Api.BoundedContexts.GameManagement.Application.Mappers;
 using Api.BoundedContexts.GameManagement.Domain.Entities;
 using Api.BoundedContexts.GameManagement.Domain.Repositories;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Application.Interfaces;
 using Api.SharedKernel.Infrastructure.Persistence;
 
@@ -30,6 +31,12 @@ internal class CompleteGameSessionCommandHandler : ICommandHandler<CompleteGameS
         // Load session
         var session = await _sessionRepository.GetByIdAsync(command.SessionId, cancellationToken)
 .ConfigureAwait(false) ?? throw new InvalidOperationException($"Session with ID {command.SessionId} not found");
+
+        // #2655 IDOR guard: only the session creator may complete it.
+        if (session.CreatedByUserId != command.RequesterId)
+        {
+            throw new ForbiddenException("Only the session creator can complete this session.");
+        }
 
         // Complete via domain method
         session.Complete(command.WinnerName);

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/CompleteGameSessionCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/CompleteGameSessionCommandHandler.cs
@@ -30,7 +30,7 @@ internal class CompleteGameSessionCommandHandler : ICommandHandler<CompleteGameS
         ArgumentNullException.ThrowIfNull(command);
         // Load session
         var session = await _sessionRepository.GetByIdAsync(command.SessionId, cancellationToken)
-.ConfigureAwait(false) ?? throw new InvalidOperationException($"Session with ID {command.SessionId} not found");
+.ConfigureAwait(false) ?? throw new NotFoundException("GameSession", command.SessionId.ToString());
 
         // #2655 IDOR guard: only the session creator may complete it.
         if (session.CreatedByUserId != command.RequesterId)

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/EndGameSessionCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/EndGameSessionCommand.cs
@@ -7,7 +7,11 @@ namespace Api.BoundedContexts.GameManagement.Application.Commands;
 /// Command to end (complete) a game session with optional winner.
 /// Business alias for CompleteGameSessionCommand.
 /// </summary>
+/// <param name="SessionId">Session to end.</param>
+/// <param name="RequesterId">Authenticated caller — must match the session creator (#2655 IDOR guard).</param>
+/// <param name="WinnerName">Optional winner name.</param>
 internal record EndGameSessionCommand(
     Guid SessionId,
+    Guid RequesterId,
     string? WinnerName = null
 ) : ICommand<GameSessionDto>;

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/EndGameSessionCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/EndGameSessionCommandHandler.cs
@@ -2,6 +2,7 @@ using Api.BoundedContexts.GameManagement.Application.Commands;
 using Api.BoundedContexts.GameManagement.Application.DTOs;
 using Api.BoundedContexts.GameManagement.Application.Mappers;
 using Api.BoundedContexts.GameManagement.Domain.Repositories;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Application.Interfaces;
 using Api.SharedKernel.Infrastructure.Persistence;
 
@@ -29,7 +30,13 @@ internal class EndGameSessionCommandHandler : ICommandHandler<EndGameSessionComm
         // Fetch session
         var session = await _sessionRepository.GetByIdAsync(command.SessionId, cancellationToken).ConfigureAwait(false);
         if (session == null)
-            throw new InvalidOperationException($"Session with ID {command.SessionId} not found");
+            throw new NotFoundException("GameSession", command.SessionId.ToString());
+
+        // #2655 IDOR guard: only the session creator may end it.
+        if (session.CreatedByUserId != command.RequesterId)
+        {
+            throw new ForbiddenException("Only the session creator can end this session.");
+        }
 
         // Complete (domain method validates state transition)
         session.Complete(command.WinnerName);

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/PauseGameSessionCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/PauseGameSessionCommand.cs
@@ -7,5 +7,6 @@ namespace Api.BoundedContexts.GameManagement.Application.Commands;
 /// Command to pause an active game session.
 /// </summary>
 internal record PauseGameSessionCommand(
-    Guid SessionId
+    Guid SessionId,
+    Guid RequesterId
 ) : ICommand<GameSessionDto>;

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/PauseGameSessionCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/PauseGameSessionCommandHandler.cs
@@ -2,6 +2,7 @@ using Api.BoundedContexts.GameManagement.Application.Commands;
 using Api.BoundedContexts.GameManagement.Application.DTOs;
 using Api.BoundedContexts.GameManagement.Application.Mappers;
 using Api.BoundedContexts.GameManagement.Domain.Repositories;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Application.Interfaces;
 using Api.SharedKernel.Infrastructure.Persistence;
 
@@ -30,6 +31,12 @@ internal class PauseGameSessionCommandHandler : ICommandHandler<PauseGameSession
         var session = await _sessionRepository.GetByIdAsync(command.SessionId, cancellationToken).ConfigureAwait(false);
         if (session == null)
             throw new InvalidOperationException($"Session with ID {command.SessionId} not found");
+
+        // #2655 IDOR guard: only the session creator may pause it.
+        if (session.CreatedByUserId != command.RequesterId)
+        {
+            throw new ForbiddenException("Only the session creator can pause this session.");
+        }
 
         // Pause (domain method validates state transition)
         session.Pause();

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/PauseGameSessionCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/PauseGameSessionCommandHandler.cs
@@ -30,7 +30,7 @@ internal class PauseGameSessionCommandHandler : ICommandHandler<PauseGameSession
         // Fetch session
         var session = await _sessionRepository.GetByIdAsync(command.SessionId, cancellationToken).ConfigureAwait(false);
         if (session == null)
-            throw new InvalidOperationException($"Session with ID {command.SessionId} not found");
+            throw new NotFoundException("GameSession", command.SessionId.ToString());
 
         // #2655 IDOR guard: only the session creator may pause it.
         if (session.CreatedByUserId != command.RequesterId)

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/ResumeGameSessionCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/ResumeGameSessionCommand.cs
@@ -7,5 +7,6 @@ namespace Api.BoundedContexts.GameManagement.Application.Commands;
 /// Command to resume a paused game session.
 /// </summary>
 internal record ResumeGameSessionCommand(
-    Guid SessionId
+    Guid SessionId,
+    Guid RequesterId
 ) : ICommand<GameSessionDto>;

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/ResumeGameSessionCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/ResumeGameSessionCommandHandler.cs
@@ -32,6 +32,12 @@ internal class ResumeGameSessionCommandHandler : ICommandHandler<ResumeGameSessi
         if (session == null)
             throw new NotFoundException("GameSession", command.SessionId.ToString());
 
+        // #2655 IDOR guard: only the session creator may resume it.
+        if (session.CreatedByUserId != command.RequesterId)
+        {
+            throw new ForbiddenException("Only the session creator can resume this session.");
+        }
+
         // Resume (domain method validates state transition)
         session.Resume();
 

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Validators/GameSessionCommandValidators.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Validators/GameSessionCommandValidators.cs
@@ -13,6 +13,9 @@ internal sealed class PauseGameSessionCommandValidator : AbstractValidator<Pause
     {
         RuleFor(x => x.SessionId)
             .NotEmpty().WithMessage("Session ID is required");
+
+        RuleFor(x => x.RequesterId)
+            .NotEmpty().WithMessage("Requester ID is required");
     }
 }
 
@@ -26,6 +29,9 @@ internal sealed class ResumeGameSessionCommandValidator : AbstractValidator<Resu
     {
         RuleFor(x => x.SessionId)
             .NotEmpty().WithMessage("Session ID is required");
+
+        RuleFor(x => x.RequesterId)
+            .NotEmpty().WithMessage("Requester ID is required");
     }
 }
 

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Validators/GameSessionLifecycleCommandValidators.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Validators/GameSessionLifecycleCommandValidators.cs
@@ -54,6 +54,9 @@ internal sealed class EndGameSessionCommandValidator : AbstractValidator<EndGame
         RuleFor(x => x.SessionId)
             .NotEmpty().WithMessage("Session ID is required");
 
+        RuleFor(x => x.RequesterId)
+            .NotEmpty().WithMessage("Requester ID is required");
+
         RuleFor(x => x.WinnerName)
             .MaximumLength(200).WithMessage("Winner name must not exceed 200 characters")
             .When(x => x.WinnerName is not null);

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Validators/GameSessionLifecycleCommandValidators.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Validators/GameSessionLifecycleCommandValidators.cs
@@ -14,6 +14,9 @@ internal sealed class AbandonGameSessionCommandValidator : AbstractValidator<Aba
         RuleFor(x => x.SessionId)
             .NotEmpty().WithMessage("Session ID is required");
 
+        RuleFor(x => x.RequesterId)
+            .NotEmpty().WithMessage("Requester ID is required");
+
         RuleFor(x => x.Reason)
             .MaximumLength(500).WithMessage("Reason must not exceed 500 characters")
             .When(x => x.Reason is not null);
@@ -30,6 +33,9 @@ internal sealed class CompleteGameSessionCommandValidator : AbstractValidator<Co
     {
         RuleFor(x => x.SessionId)
             .NotEmpty().WithMessage("Session ID is required");
+
+        RuleFor(x => x.RequesterId)
+            .NotEmpty().WithMessage("Requester ID is required");
 
         RuleFor(x => x.WinnerName)
             .MaximumLength(200).WithMessage("Winner name must not exceed 200 characters")

--- a/apps/api/src/Api/Routing/GameEndpoints.cs
+++ b/apps/api/src/Api/Routing/GameEndpoints.cs
@@ -526,11 +526,19 @@ internal static class GameEndpoints
     private static async Task<IResult> HandleEndSession(
         Guid id,
         CompleteSessionRequest? request,
+        HttpContext httpContext,
         IMediator mediator,
                 CancellationToken ct)
     {
+        var userId = httpContext.User.GetUserId();
+        if (userId == Guid.Empty)
+        {
+            return Results.Unauthorized();
+        }
+
         var command = new EndGameSessionCommand(
             SessionId: id,
+            RequesterId: userId,
             WinnerName: request?.WinnerName
         );
 

--- a/apps/api/src/Api/Routing/GameEndpoints.cs
+++ b/apps/api/src/Api/Routing/GameEndpoints.cs
@@ -445,11 +445,19 @@ internal static class GameEndpoints
     private static async Task<IResult> HandleCompleteSession(
         Guid id,
         CompleteSessionRequest? request,
+        HttpContext httpContext,
         IMediator mediator,
                 CancellationToken ct)
     {
+        var userId = httpContext.User.GetUserId();
+        if (userId == Guid.Empty)
+        {
+            return Results.Unauthorized();
+        }
+
         var command = new CompleteGameSessionCommand(
             SessionId: id,
+            RequesterId: userId,
             WinnerName: request?.WinnerName
         );
 
@@ -459,11 +467,19 @@ internal static class GameEndpoints
 
     private static async Task<IResult> HandleAbandonSession(
         Guid id,
+        HttpContext httpContext,
         IMediator mediator,
                 CancellationToken ct)
     {
+        var userId = httpContext.User.GetUserId();
+        if (userId == Guid.Empty)
+        {
+            return Results.Unauthorized();
+        }
+
         var command = new AbandonGameSessionCommand(
             SessionId: id,
+            RequesterId: userId,
             Reason: null
         );
 
@@ -473,10 +489,17 @@ internal static class GameEndpoints
 
     private static async Task<IResult> HandlePauseSession(
         Guid id,
+        HttpContext httpContext,
         IMediator mediator,
                 CancellationToken ct)
     {
-        var command = new PauseGameSessionCommand(SessionId: id);
+        var userId = httpContext.User.GetUserId();
+        if (userId == Guid.Empty)
+        {
+            return Results.Unauthorized();
+        }
+
+        var command = new PauseGameSessionCommand(SessionId: id, RequesterId: userId);
         var result = await mediator.Send(command, ct).ConfigureAwait(false);
 
         return Results.Ok(result);
@@ -484,10 +507,17 @@ internal static class GameEndpoints
 
     private static async Task<IResult> HandleResumeSession(
         Guid id,
+        HttpContext httpContext,
         IMediator mediator,
                 CancellationToken ct)
     {
-        var command = new ResumeGameSessionCommand(SessionId: id);
+        var userId = httpContext.User.GetUserId();
+        if (userId == Guid.Empty)
+        {
+            return Results.Unauthorized();
+        }
+
+        var command = new ResumeGameSessionCommand(SessionId: id, RequesterId: userId);
         var result = await mediator.Send(command, ct).ConfigureAwait(false);
 
         return Results.Ok(result);

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/AbandonGameSessionCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/AbandonGameSessionCommandHandlerTests.cs
@@ -47,6 +47,7 @@ public class AbandonGameSessionCommandHandlerTests
 
         var command = new AbandonGameSessionCommand(
             SessionId: sessionId,
+            RequesterId: GameSessionBuilder.DefaultCreatedByUserId,
             Reason: "Players had to leave");
 
         // Act
@@ -82,6 +83,7 @@ public class AbandonGameSessionCommandHandlerTests
 
         var command = new AbandonGameSessionCommand(
             SessionId: sessionId,
+            RequesterId: GameSessionBuilder.DefaultCreatedByUserId,
             Reason: "Emergency came up");
 
         // Act
@@ -108,6 +110,7 @@ public class AbandonGameSessionCommandHandlerTests
 
         var command = new AbandonGameSessionCommand(
             SessionId: sessionId,
+            RequesterId: GameSessionBuilder.DefaultCreatedByUserId,
             Reason: null);
 
         // Act
@@ -136,6 +139,7 @@ public class AbandonGameSessionCommandHandlerTests
 
         var command = new AbandonGameSessionCommand(
             SessionId: sessionId,
+            RequesterId: GameSessionBuilder.DefaultCreatedByUserId,
             Reason: "Power outage");
 
         // Act
@@ -165,6 +169,7 @@ public class AbandonGameSessionCommandHandlerTests
 
         var command = new AbandonGameSessionCommand(
             SessionId: sessionId,
+            RequesterId: GameSessionBuilder.DefaultCreatedByUserId,
             Reason: "Never resumed");
 
         // Act
@@ -189,6 +194,7 @@ public class AbandonGameSessionCommandHandlerTests
 
         var command = new AbandonGameSessionCommand(
             SessionId: sessionId,
+            RequesterId: GameSessionBuilder.DefaultCreatedByUserId,
             Reason: "Not enough players showed up");
 
         // Act
@@ -216,6 +222,7 @@ public class AbandonGameSessionCommandHandlerTests
 
         var command = new AbandonGameSessionCommand(
             SessionId: sessionId,
+            RequesterId: GameSessionBuilder.DefaultCreatedByUserId,
             Reason: "Game took too long");
 
         // Act
@@ -237,6 +244,7 @@ public class AbandonGameSessionCommandHandlerTests
 
         var command = new AbandonGameSessionCommand(
             SessionId: sessionId,
+            RequesterId: GameSessionBuilder.DefaultCreatedByUserId,
             Reason: "Test");
 
         // Act & Assert
@@ -268,6 +276,7 @@ public class AbandonGameSessionCommandHandlerTests
 
         var command = new AbandonGameSessionCommand(
             SessionId: sessionId,
+            RequesterId: GameSessionBuilder.DefaultCreatedByUserId,
             Reason: "Too late");
 
         // Act & Assert
@@ -296,6 +305,7 @@ public class AbandonGameSessionCommandHandlerTests
 
         var command = new AbandonGameSessionCommand(
             SessionId: sessionId,
+            RequesterId: GameSessionBuilder.DefaultCreatedByUserId,
             Reason: "Second reason");
 
         // Act & Assert
@@ -322,6 +332,7 @@ public class AbandonGameSessionCommandHandlerTests
 
         var command = new AbandonGameSessionCommand(
             SessionId: sessionId,
+            RequesterId: GameSessionBuilder.DefaultCreatedByUserId,
             Reason: "");
 
         // Act
@@ -353,6 +364,7 @@ public class AbandonGameSessionCommandHandlerTests
 
         var command = new AbandonGameSessionCommand(
             SessionId: sessionId,
+            RequesterId: GameSessionBuilder.DefaultCreatedByUserId,
             Reason: "Test abandon");
 
         // Act
@@ -385,6 +397,7 @@ public class AbandonGameSessionCommandHandlerTests
 
         var command = new AbandonGameSessionCommand(
             SessionId: sessionId,
+            RequesterId: GameSessionBuilder.DefaultCreatedByUserId,
             Reason: "Test");
 
         // Act
@@ -413,6 +426,7 @@ public class AbandonGameSessionCommandHandlerTests
 
         var command = new AbandonGameSessionCommand(
             SessionId: sessionId,
+            RequesterId: GameSessionBuilder.DefaultCreatedByUserId,
             Reason: "Test");
 
         using var cts = new CancellationTokenSource();
@@ -431,6 +445,34 @@ public class AbandonGameSessionCommandHandlerTests
         _unitOfWorkMock.Verify(
             u => u.SaveChangesAsync(cancellationToken),
             Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WhenRequesterIsNotOwner_ThrowsForbiddenException()
+    {
+        // Arrange — #2655 IDOR fix: only the session creator may abandon it.
+        var sessionId = Guid.NewGuid();
+        var session = new GameSessionBuilder()
+            .WithId(sessionId)
+            .WithCreatedByUserId(GameSessionBuilder.DefaultCreatedByUserId)
+            .ThatIsStarted()
+            .Build();
+
+        _sessionRepositoryMock
+            .Setup(r => r.GetByIdAsync(sessionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(session);
+
+        var command = new AbandonGameSessionCommand(
+            SessionId: sessionId,
+            RequesterId: Guid.NewGuid(), // attacker, not the owner
+            Reason: "malicious abandon");
+
+        // Act & Assert
+        var act = () => _handler.Handle(command, TestContext.Current.CancellationToken);
+        await act.Should().ThrowAsync<ForbiddenException>();
+
+        _sessionRepositoryMock.Verify(r => r.UpdateAsync(It.IsAny<GameSession>(), It.IsAny<CancellationToken>()), Times.Never);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
     }
 }
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/CompleteGameSessionCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/CompleteGameSessionCommandHandlerTests.cs
@@ -3,6 +3,7 @@ using Api.BoundedContexts.GameManagement.Application.Queries;
 using Api.BoundedContexts.GameManagement.Domain.Entities;
 using Api.BoundedContexts.GameManagement.Domain.Repositories;
 using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Infrastructure.Persistence;
 using Moq;
 using Xunit;
@@ -17,6 +18,8 @@ namespace Api.Tests.BoundedContexts.GameManagement.Application.Handlers;
 [Trait("Category", TestCategories.Unit)]
 public class CompleteGameSessionCommandHandlerTests
 {
+    private static readonly Guid OwnerId = Guid.NewGuid();
+
     private readonly Mock<IGameSessionRepository> _sessionRepositoryMock;
     private readonly Mock<IUnitOfWork> _unitOfWorkMock;
     private readonly CompleteGameSessionCommandHandler _handler;
@@ -37,7 +40,7 @@ public class CompleteGameSessionCommandHandlerTests
         var gameId = Guid.NewGuid();
         var session = CreateActiveSession(gameId);
         session.Start();
-        var command = new CompleteGameSessionCommand(session.Id, "Player 1");
+        var command = new CompleteGameSessionCommand(session.Id, OwnerId, "Player 1");
 
         _sessionRepositoryMock
             .Setup(r => r.GetByIdAsync(session.Id, It.IsAny<CancellationToken>()))
@@ -63,7 +66,7 @@ public class CompleteGameSessionCommandHandlerTests
         var gameId = Guid.NewGuid();
         var session = CreateActiveSession(gameId);
         session.Start();
-        var command = new CompleteGameSessionCommand(session.Id);
+        var command = new CompleteGameSessionCommand(session.Id, OwnerId);
 
         _sessionRepositoryMock
             .Setup(r => r.GetByIdAsync(session.Id, It.IsAny<CancellationToken>()))
@@ -83,7 +86,7 @@ public class CompleteGameSessionCommandHandlerTests
     {
         // Arrange
         var sessionId = Guid.NewGuid();
-        var command = new CompleteGameSessionCommand(sessionId, "Player 1");
+        var command = new CompleteGameSessionCommand(sessionId, OwnerId, "Player 1");
 
         _sessionRepositoryMock
             .Setup(r => r.GetByIdAsync(sessionId, It.IsAny<CancellationToken>()))
@@ -105,7 +108,7 @@ public class CompleteGameSessionCommandHandlerTests
         var gameId = Guid.NewGuid();
         var session = CreateActiveSession(gameId);
         session.Start();
-        var command = new CompleteGameSessionCommand(session.Id, "Winner");
+        var command = new CompleteGameSessionCommand(session.Id, OwnerId, "Winner");
 
         using var cts = new CancellationTokenSource();
         var token = cts.Token;
@@ -132,7 +135,52 @@ public class CompleteGameSessionCommandHandlerTests
         await act.Should().ThrowAsync<ArgumentNullException>();
     }
 
-    private static GameSession CreateActiveSession(Guid gameId)
+    [Fact]
+    public async Task Handle_WhenRequesterIsNotOwner_ThrowsForbiddenException()
+    {
+        // Arrange — #2655 IDOR fix: only the session creator may complete it.
+        var gameId = Guid.NewGuid();
+        var session = CreateActiveSession(gameId, ownerId: OwnerId);
+        session.Start();
+        var attacker = Guid.NewGuid();
+        var command = new CompleteGameSessionCommand(session.Id, attacker, "Player 1");
+
+        _sessionRepositoryMock
+            .Setup(r => r.GetByIdAsync(session.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(session);
+
+        // Act & Assert
+        var act = () => _handler.Handle(command, TestContext.Current.CancellationToken);
+        await act.Should().ThrowAsync<ForbiddenException>();
+
+        _sessionRepositoryMock.Verify(r => r.UpdateAsync(It.IsAny<GameSession>(), It.IsAny<CancellationToken>()), Times.Never);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_WhenSessionHasNoOwner_ThrowsForbiddenException()
+    {
+        // Arrange — a session with no recorded creator is not completable by anyone
+        // via this endpoint (safe default, consistent with CreatePauseSnapshot).
+        var gameId = Guid.NewGuid();
+        var ownerlessSession = new GameSession(
+            id: Guid.NewGuid(),
+            gameId: gameId,
+            players: new List<SessionPlayer> { new("Player 1", 1, "Red"), new("Player 2", 2, "Blue") },
+            createdByUserId: null);
+        ownerlessSession.Start();
+        var command = new CompleteGameSessionCommand(ownerlessSession.Id, OwnerId, "Player 1");
+
+        _sessionRepositoryMock
+            .Setup(r => r.GetByIdAsync(ownerlessSession.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ownerlessSession);
+
+        // Act & Assert
+        var act = () => _handler.Handle(command, TestContext.Current.CancellationToken);
+        await act.Should().ThrowAsync<ForbiddenException>();
+    }
+
+    private static GameSession CreateActiveSession(Guid gameId, Guid? ownerId = null)
     {
         var players = new List<SessionPlayer>
         {
@@ -143,7 +191,8 @@ public class CompleteGameSessionCommandHandlerTests
         return new GameSession(
             id: Guid.NewGuid(),
             gameId: gameId,
-            players: players
+            players: players,
+            createdByUserId: ownerId ?? OwnerId
         );
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/CompleteGameSessionCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/CompleteGameSessionCommandHandlerTests.cs
@@ -82,7 +82,7 @@ public class CompleteGameSessionCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_WithNonExistentSession_ThrowsInvalidOperationException()
+    public async Task Handle_WithNonExistentSession_ThrowsNotFoundException()
     {
         // Arrange
         var sessionId = Guid.NewGuid();
@@ -92,10 +92,10 @@ public class CompleteGameSessionCommandHandlerTests
             .Setup(r => r.GetByIdAsync(sessionId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((GameSession?)null);
 
-        // Act & Assert
+        // Act & Assert — #2568: missing resource must be 404 (NotFoundException), not 500.
         var act =
             () => _handler.Handle(command, TestContext.Current.CancellationToken);
-        var exception = (await act.Should().ThrowAsync<InvalidOperationException>()).Which;
+        var exception = (await act.Should().ThrowAsync<NotFoundException>()).Which;
 
         exception.Message.Should().Contain(sessionId.ToString());
         _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/EndGameSessionCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/EndGameSessionCommandHandlerTests.cs
@@ -2,6 +2,7 @@ using Api.BoundedContexts.GameManagement.Application.Commands;
 using Api.BoundedContexts.GameManagement.Application.Queries;
 using Api.BoundedContexts.GameManagement.Domain.Entities;
 using Api.BoundedContexts.GameManagement.Domain.Repositories;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Infrastructure.Persistence;
 using Api.Tests.BoundedContexts.GameManagement.TestHelpers;
 using Moq;
@@ -47,6 +48,7 @@ public class EndGameSessionCommandHandlerTests
 
         var command = new EndGameSessionCommand(
             SessionId: sessionId,
+            RequesterId: GameSessionBuilder.DefaultCreatedByUserId,
             WinnerName: "Alice");
 
         // Act
@@ -88,6 +90,7 @@ public class EndGameSessionCommandHandlerTests
 
         var command = new EndGameSessionCommand(
             SessionId: sessionId,
+            RequesterId: GameSessionBuilder.DefaultCreatedByUserId,
             WinnerName: null);
 
         // Act
@@ -117,6 +120,7 @@ public class EndGameSessionCommandHandlerTests
 
         var command = new EndGameSessionCommand(
             SessionId: sessionId,
+            RequesterId: GameSessionBuilder.DefaultCreatedByUserId,
             WinnerName: "Charlie");
 
         // Act
@@ -146,6 +150,7 @@ public class EndGameSessionCommandHandlerTests
 
         var command = new EndGameSessionCommand(
             SessionId: sessionId,
+            RequesterId: GameSessionBuilder.DefaultCreatedByUserId,
             WinnerName: "Player 1");
 
         // Act
@@ -157,7 +162,7 @@ public class EndGameSessionCommandHandlerTests
         (result.CompletedAt >= result.StartedAt).Should().BeTrue(); // EndedAt should be after StartedAt
     }
     [Fact]
-    public async Task Handle_NonExistentSession_ThrowsInvalidOperationException()
+    public async Task Handle_NonExistentSession_ThrowsNotFoundException()
     {
         // Arrange
         var sessionId = Guid.NewGuid();
@@ -168,19 +173,49 @@ public class EndGameSessionCommandHandlerTests
 
         var command = new EndGameSessionCommand(
             SessionId: sessionId,
+            RequesterId: GameSessionBuilder.DefaultCreatedByUserId,
             WinnerName: "Player 1");
 
-        // Act & Assert
+        // Act & Assert — #2568: missing resource must be 404 (NotFoundException), not 500.
         var act =
             () => _handler.Handle(command, TestContext.Current.CancellationToken);
-        var exception = (await act.Should().ThrowAsync<InvalidOperationException>()).Which;
+        var exception = (await act.Should().ThrowAsync<NotFoundException>()).Which;
 
-        exception.Message.Should().ContainEquivalentOf($"Session with ID {sessionId} not found");
+        exception.Message.Should().ContainEquivalentOf(sessionId.ToString());
 
         // Verify update was NOT called
         _sessionRepositoryMock.Verify(
             r => r.UpdateAsync(It.IsAny<GameSession>(), It.IsAny<CancellationToken>()),
             Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_WhenRequesterIsNotOwner_ThrowsForbiddenException()
+    {
+        // Arrange — #2655 IDOR fix: only the session creator may end it.
+        var sessionId = Guid.NewGuid();
+        var session = new GameSessionBuilder()
+            .WithId(sessionId)
+            .WithCreatedByUserId(GameSessionBuilder.DefaultCreatedByUserId)
+            .WithPlayers("Alice", "Bob")
+            .ThatIsStarted()
+            .Build();
+
+        _sessionRepositoryMock
+            .Setup(r => r.GetByIdAsync(sessionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(session);
+
+        var command = new EndGameSessionCommand(
+            SessionId: sessionId,
+            RequesterId: Guid.NewGuid(), // attacker, not the owner
+            WinnerName: "Alice");
+
+        // Act & Assert
+        var act = () => _handler.Handle(command, TestContext.Current.CancellationToken);
+        await act.Should().ThrowAsync<ForbiddenException>();
+
+        _sessionRepositoryMock.Verify(r => r.UpdateAsync(It.IsAny<GameSession>(), It.IsAny<CancellationToken>()), Times.Never);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
     }
     [Fact]
     public async Task Handle_WithCancellationToken_PassesToRepositories()
@@ -199,6 +234,7 @@ public class EndGameSessionCommandHandlerTests
 
         var command = new EndGameSessionCommand(
             SessionId: sessionId,
+            RequesterId: GameSessionBuilder.DefaultCreatedByUserId,
             WinnerName: "Player 1");
 
         using var cts = new CancellationTokenSource();
@@ -237,6 +273,7 @@ public class EndGameSessionCommandHandlerTests
 
         var command = new EndGameSessionCommand(
             SessionId: sessionId,
+            RequesterId: GameSessionBuilder.DefaultCreatedByUserId,
             WinnerName: "Player 1");
 
         // Act
@@ -263,6 +300,7 @@ public class EndGameSessionCommandHandlerTests
 
         var command = new EndGameSessionCommand(
             SessionId: sessionId,
+            RequesterId: GameSessionBuilder.DefaultCreatedByUserId,
             WinnerName: "Bob");
 
         // Act

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/PauseGameSessionCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/PauseGameSessionCommandHandlerTests.cs
@@ -140,7 +140,7 @@ public class PauseGameSessionCommandHandlerTests
         result.Notes.Should().Contain("Game is going well!");
     }
     [Fact]
-    public async Task Handle_NonExistentSession_ThrowsInvalidOperationException()
+    public async Task Handle_NonExistentSession_ThrowsNotFoundException()
     {
         // Arrange
         var sessionId = Guid.NewGuid();
@@ -151,12 +151,12 @@ public class PauseGameSessionCommandHandlerTests
 
         var command = new PauseGameSessionCommand(SessionId: sessionId, RequesterId: GameSessionBuilder.DefaultCreatedByUserId);
 
-        // Act & Assert
+        // Act & Assert — #2568: missing resource must be 404 (NotFoundException), not 500.
         var act =
             () => _handler.Handle(command, TestContext.Current.CancellationToken);
-        var exception = (await act.Should().ThrowAsync<InvalidOperationException>()).Which;
+        var exception = (await act.Should().ThrowAsync<NotFoundException>()).Which;
 
-        exception.Message.Should().ContainEquivalentOf($"Session with ID {sessionId} not found");
+        exception.Message.Should().ContainEquivalentOf(sessionId.ToString());
 
         // Verify save was NOT called
         _unitOfWorkMock.Verify(

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/PauseGameSessionCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/PauseGameSessionCommandHandlerTests.cs
@@ -2,6 +2,7 @@ using Api.BoundedContexts.GameManagement.Application.Commands;
 using Api.BoundedContexts.GameManagement.Application.Queries;
 using Api.BoundedContexts.GameManagement.Domain.Entities;
 using Api.BoundedContexts.GameManagement.Domain.Repositories;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Infrastructure.Persistence;
 using Api.Tests.BoundedContexts.GameManagement.TestHelpers;
 using Moq;
@@ -44,7 +45,7 @@ public class PauseGameSessionCommandHandlerTests
             .Setup(r => r.GetByIdAsync(sessionId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(session);
 
-        var command = new PauseGameSessionCommand(SessionId: sessionId);
+        var command = new PauseGameSessionCommand(SessionId: sessionId, RequesterId: GameSessionBuilder.DefaultCreatedByUserId);
 
         // Act
         var result = await _handler.Handle(command, TestContext.Current.CancellationToken);
@@ -77,7 +78,7 @@ public class PauseGameSessionCommandHandlerTests
             .Setup(r => r.GetByIdAsync(sessionId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(session);
 
-        var command = new PauseGameSessionCommand(SessionId: sessionId);
+        var command = new PauseGameSessionCommand(SessionId: sessionId, RequesterId: GameSessionBuilder.DefaultCreatedByUserId);
 
         // Act
         var result = await _handler.Handle(command, TestContext.Current.CancellationToken);
@@ -104,7 +105,7 @@ public class PauseGameSessionCommandHandlerTests
             .Setup(r => r.GetByIdAsync(sessionId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(session);
 
-        var command = new PauseGameSessionCommand(SessionId: sessionId);
+        var command = new PauseGameSessionCommand(SessionId: sessionId, RequesterId: GameSessionBuilder.DefaultCreatedByUserId);
 
         // Act
         var result = await _handler.Handle(command, TestContext.Current.CancellationToken);
@@ -129,7 +130,7 @@ public class PauseGameSessionCommandHandlerTests
             .Setup(r => r.GetByIdAsync(sessionId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(session);
 
-        var command = new PauseGameSessionCommand(SessionId: sessionId);
+        var command = new PauseGameSessionCommand(SessionId: sessionId, RequesterId: GameSessionBuilder.DefaultCreatedByUserId);
 
         // Act
         var result = await _handler.Handle(command, TestContext.Current.CancellationToken);
@@ -148,7 +149,7 @@ public class PauseGameSessionCommandHandlerTests
             .Setup(r => r.GetByIdAsync(sessionId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((GameSession?)null);
 
-        var command = new PauseGameSessionCommand(SessionId: sessionId);
+        var command = new PauseGameSessionCommand(SessionId: sessionId, RequesterId: GameSessionBuilder.DefaultCreatedByUserId);
 
         // Act & Assert
         var act =
@@ -176,7 +177,7 @@ public class PauseGameSessionCommandHandlerTests
             .Setup(r => r.GetByIdAsync(sessionId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(session);
 
-        var command = new PauseGameSessionCommand(SessionId: sessionId);
+        var command = new PauseGameSessionCommand(SessionId: sessionId, RequesterId: GameSessionBuilder.DefaultCreatedByUserId);
 
         // Act & Assert
         var act =
@@ -205,7 +206,7 @@ public class PauseGameSessionCommandHandlerTests
             .Setup(r => r.GetByIdAsync(sessionId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(session);
 
-        var command = new PauseGameSessionCommand(SessionId: sessionId);
+        var command = new PauseGameSessionCommand(SessionId: sessionId, RequesterId: GameSessionBuilder.DefaultCreatedByUserId);
 
         // Act & Assert
         var act =
@@ -232,7 +233,7 @@ public class PauseGameSessionCommandHandlerTests
             .Setup(r => r.GetByIdAsync(sessionId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(session);
 
-        var command = new PauseGameSessionCommand(SessionId: sessionId);
+        var command = new PauseGameSessionCommand(SessionId: sessionId, RequesterId: GameSessionBuilder.DefaultCreatedByUserId);
 
         // Act & Assert
         var act =
@@ -260,7 +261,7 @@ public class PauseGameSessionCommandHandlerTests
             .Setup(r => r.GetByIdAsync(sessionId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(session);
 
-        var command = new PauseGameSessionCommand(SessionId: sessionId);
+        var command = new PauseGameSessionCommand(SessionId: sessionId, RequesterId: GameSessionBuilder.DefaultCreatedByUserId);
 
         // Act
         var result = await _handler.Handle(command, TestContext.Current.CancellationToken);
@@ -287,7 +288,7 @@ public class PauseGameSessionCommandHandlerTests
             .Setup(r => r.GetByIdAsync(sessionId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(session);
 
-        var command = new PauseGameSessionCommand(SessionId: sessionId);
+        var command = new PauseGameSessionCommand(SessionId: sessionId, RequesterId: GameSessionBuilder.DefaultCreatedByUserId);
 
         using var cts = new CancellationTokenSource();
         var cancellationToken = cts.Token;
@@ -305,6 +306,31 @@ public class PauseGameSessionCommandHandlerTests
         _unitOfWorkMock.Verify(
             u => u.SaveChangesAsync(cancellationToken),
             Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WhenRequesterIsNotOwner_ThrowsForbiddenException()
+    {
+        // Arrange — #2655 IDOR fix: only the session creator may pause it.
+        var sessionId = Guid.NewGuid();
+        var session = new GameSessionBuilder()
+            .WithId(sessionId)
+            .WithCreatedByUserId(GameSessionBuilder.DefaultCreatedByUserId)
+            .ThatIsStarted()
+            .Build();
+
+        _sessionRepositoryMock
+            .Setup(r => r.GetByIdAsync(sessionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(session);
+
+        var command = new PauseGameSessionCommand(SessionId: sessionId, RequesterId: Guid.NewGuid());
+
+        // Act & Assert
+        var act = () => _handler.Handle(command, TestContext.Current.CancellationToken);
+        await act.Should().ThrowAsync<ForbiddenException>();
+
+        _sessionRepositoryMock.Verify(r => r.UpdateAsync(It.IsAny<GameSession>(), It.IsAny<CancellationToken>()), Times.Never);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
     }
 }
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/ResumeGameSessionCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/ResumeGameSessionCommandHandlerTests.cs
@@ -48,7 +48,7 @@ public class ResumeGameSessionCommandHandlerTests
             .Setup(r => r.GetByIdAsync(sessionId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(session);
 
-        var command = new ResumeGameSessionCommand(SessionId: sessionId);
+        var command = new ResumeGameSessionCommand(SessionId: sessionId, RequesterId: GameSessionBuilder.DefaultCreatedByUserId);
 
         // Act
         var result = await _handler.Handle(command, TestContext.Current.CancellationToken);
@@ -83,7 +83,7 @@ public class ResumeGameSessionCommandHandlerTests
             .Setup(r => r.GetByIdAsync(sessionId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(session);
 
-        var command = new ResumeGameSessionCommand(SessionId: sessionId);
+        var command = new ResumeGameSessionCommand(SessionId: sessionId, RequesterId: GameSessionBuilder.DefaultCreatedByUserId);
 
         // Act
         var result = await _handler.Handle(command, TestContext.Current.CancellationToken);
@@ -112,7 +112,7 @@ public class ResumeGameSessionCommandHandlerTests
             .Setup(r => r.GetByIdAsync(sessionId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(session);
 
-        var command = new ResumeGameSessionCommand(SessionId: sessionId);
+        var command = new ResumeGameSessionCommand(SessionId: sessionId, RequesterId: GameSessionBuilder.DefaultCreatedByUserId);
 
         // Act
         var result = await _handler.Handle(command, TestContext.Current.CancellationToken);
@@ -139,7 +139,7 @@ public class ResumeGameSessionCommandHandlerTests
             .Setup(r => r.GetByIdAsync(sessionId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(session);
 
-        var command = new ResumeGameSessionCommand(SessionId: sessionId);
+        var command = new ResumeGameSessionCommand(SessionId: sessionId, RequesterId: GameSessionBuilder.DefaultCreatedByUserId);
 
         // Act
         var result = await _handler.Handle(command, TestContext.Current.CancellationToken);
@@ -170,7 +170,7 @@ public class ResumeGameSessionCommandHandlerTests
             .Setup(r => r.GetByIdAsync(sessionId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(session);
 
-        var command = new ResumeGameSessionCommand(SessionId: sessionId);
+        var command = new ResumeGameSessionCommand(SessionId: sessionId, RequesterId: GameSessionBuilder.DefaultCreatedByUserId);
 
         // Act - Resume from second pause
         var result = await _handler.Handle(command, TestContext.Current.CancellationToken);
@@ -188,7 +188,7 @@ public class ResumeGameSessionCommandHandlerTests
             .Setup(r => r.GetByIdAsync(sessionId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((GameSession?)null);
 
-        var command = new ResumeGameSessionCommand(SessionId: sessionId);
+        var command = new ResumeGameSessionCommand(SessionId: sessionId, RequesterId: GameSessionBuilder.DefaultCreatedByUserId);
 
         // Act & Assert
         var act =
@@ -216,7 +216,7 @@ public class ResumeGameSessionCommandHandlerTests
             .Setup(r => r.GetByIdAsync(sessionId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(session);
 
-        var command = new ResumeGameSessionCommand(SessionId: sessionId);
+        var command = new ResumeGameSessionCommand(SessionId: sessionId, RequesterId: GameSessionBuilder.DefaultCreatedByUserId);
 
         // Act & Assert
         var act =
@@ -245,7 +245,7 @@ public class ResumeGameSessionCommandHandlerTests
             .Setup(r => r.GetByIdAsync(sessionId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(session);
 
-        var command = new ResumeGameSessionCommand(SessionId: sessionId);
+        var command = new ResumeGameSessionCommand(SessionId: sessionId, RequesterId: GameSessionBuilder.DefaultCreatedByUserId);
 
         // Act & Assert
         var act =
@@ -269,7 +269,7 @@ public class ResumeGameSessionCommandHandlerTests
             .Setup(r => r.GetByIdAsync(sessionId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(session);
 
-        var command = new ResumeGameSessionCommand(SessionId: sessionId);
+        var command = new ResumeGameSessionCommand(SessionId: sessionId, RequesterId: GameSessionBuilder.DefaultCreatedByUserId);
 
         // Act & Assert
         var act =
@@ -299,7 +299,7 @@ public class ResumeGameSessionCommandHandlerTests
             .Setup(r => r.GetByIdAsync(sessionId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(session);
 
-        var command = new ResumeGameSessionCommand(SessionId: sessionId);
+        var command = new ResumeGameSessionCommand(SessionId: sessionId, RequesterId: GameSessionBuilder.DefaultCreatedByUserId);
 
         // Act
         var result = await _handler.Handle(command, TestContext.Current.CancellationToken);
@@ -328,7 +328,7 @@ public class ResumeGameSessionCommandHandlerTests
             .Setup(r => r.GetByIdAsync(sessionId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(session);
 
-        var command = new ResumeGameSessionCommand(SessionId: sessionId);
+        var command = new ResumeGameSessionCommand(SessionId: sessionId, RequesterId: GameSessionBuilder.DefaultCreatedByUserId);
 
         using var cts = new CancellationTokenSource();
         var cancellationToken = cts.Token;
@@ -346,6 +346,32 @@ public class ResumeGameSessionCommandHandlerTests
         _unitOfWorkMock.Verify(
             u => u.SaveChangesAsync(cancellationToken),
             Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WhenRequesterIsNotOwner_ThrowsForbiddenException()
+    {
+        // Arrange — #2655 IDOR fix: only the session creator may resume it.
+        var sessionId = Guid.NewGuid();
+        var session = new GameSessionBuilder()
+            .WithId(sessionId)
+            .WithCreatedByUserId(GameSessionBuilder.DefaultCreatedByUserId)
+            .ThatIsStarted()
+            .Build();
+        session.Pause();
+
+        _sessionRepositoryMock
+            .Setup(r => r.GetByIdAsync(sessionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(session);
+
+        var command = new ResumeGameSessionCommand(SessionId: sessionId, RequesterId: Guid.NewGuid());
+
+        // Act & Assert
+        var act = () => _handler.Handle(command, TestContext.Current.CancellationToken);
+        await act.Should().ThrowAsync<ForbiddenException>();
+
+        _sessionRepositoryMock.Verify(r => r.UpdateAsync(It.IsAny<GameSession>(), It.IsAny<CancellationToken>()), Times.Never);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
     }
 }
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/TestHelpers/GameSessionBuilder.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/TestHelpers/GameSessionBuilder.cs
@@ -8,8 +8,15 @@ namespace Api.Tests.BoundedContexts.GameManagement.TestHelpers;
 /// </summary>
 internal class GameSessionBuilder
 {
+    /// <summary>
+    /// Default session creator id. Tests asserting ownership (#2655 IDOR guards)
+    /// can pass this as the command RequesterId to match the built session.
+    /// </summary>
+    public static readonly Guid DefaultCreatedByUserId = Guid.Parse("11111111-1111-1111-1111-111111111111");
+
     private Guid _id = Guid.NewGuid();
     private Guid _gameId = Guid.NewGuid();
+    private Guid? _createdByUserId = DefaultCreatedByUserId;
     private List<SessionPlayer> _players = new()
     {
         new SessionPlayer("Player 1", 1),
@@ -25,6 +32,13 @@ internal class GameSessionBuilder
     public GameSessionBuilder WithId(Guid id)
     {
         _id = id;
+        return this;
+    }
+
+    /// <summary>Sets the session creator id (null = ownerless session).</summary>
+    public GameSessionBuilder WithCreatedByUserId(Guid? createdByUserId)
+    {
+        _createdByUserId = createdByUserId;
         return this;
     }
 
@@ -140,7 +154,7 @@ internal class GameSessionBuilder
     /// </summary>
     public GameSession Build()
     {
-        var session = new GameSession(_id, _gameId, _players);
+        var session = new GameSession(_id, _gameId, _players, _createdByUserId);
 
         if (_notes != null)
         {


### PR DESCRIPTION
## Security fix — 4 Critical IDOR (STEP 5 secrets-authz scan)

Part of the #2655 Q3 Security Review remediation. The STEP 5 authz scan confirmed 4 Critical IDOR vulnerabilities (independently re-verified).

### Problem
`POST /sessions/{id}/complete|abandon|pause|resume|end` (GameEndpoints.cs) were gated only by `.RequireSession()` (authentication). The handlers did `GetByIdAsync` + mutate with **no ownership check**, and the commands carried **no requester identity** — so any authenticated user could complete/abandon/pause/resume/end **any** GameSession by guessing its id (integrity IDOR on a per-user resource).

> The GameSession create funnel (`POST /sessions`) was removed in #2587, but these lifecycle endpoints remain registered → still an active attack surface.

### Fix
Follows the existing GameSession ownership pattern (`CreatePauseSnapshotCommand.cs:93`, `SubmitRuleDisputeCommand.cs:130`):
- Add `Guid RequesterId` to the 5 commands (+ FluentValidation `NotEmpty`).
- Endpoints extract `httpContext.User.GetUserId()` (401 when empty) and pass it.
- Handlers throw `ForbiddenException` (403) when `session.CreatedByUserId != command.RequesterId`, placed **after** the not-found check. Ownerless sessions (null `CreatedByUserId`) are denied by construction (safe default).

**The 5th endpoint `POST /sessions/{id}/end`** (`EndGameSessionCommand`, a business alias for Complete) was surfaced by adversarial review — it had the identical unguarded IDOR and is fixed here too.

### Also (review Important, pitfall #2568)
`Complete`/`Pause`/`End` handlers threw `InvalidOperationException` (HTTP 500) for a missing session; normalized to `NotFoundException` (HTTP 404), matching the `Abandon`/`Resume` siblings.

### Saga safety
Unaffected — the internal correlate saga completes sessions via `GameSession.MarkCorrelatedComplete()` (a domain method), not these command handlers (verified: the 5 commands are only sent from GameEndpoints.cs).

### Testing (TDD)
- RED tests per handler: non-owner → `ForbiddenException` (no persistence) + null-owner case.
- Existing tests updated to own their sessions via new `GameSessionBuilder.WithCreatedByUserId` (default owner).
- **70/70** GameSession handler unit tests green.
- Adversarial review (feature-dev:code-reviewer): found the `/end` gap (now fixed) + the not-found inconsistency (now fixed); all other verification points sound.

Refs #2655.

🤖 Generated with [Claude Code](https://claude.com/claude-code)