### PR TITLE
fix(security): #2655 AgentMemory group IDOR membership guards

### DIFF
--- a/apps/api/src/Api/BoundedContexts/AgentMemory/Application/Commands/UpdateGroupPreferencesCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/AgentMemory/Application/Commands/UpdateGroupPreferencesCommand.cs
@@ -5,8 +5,14 @@ namespace Api.BoundedContexts.AgentMemory.Application.Commands;
 /// <summary>
 /// Command to update a group's gaming preferences.
 /// </summary>
+/// <param name="GroupId">Group whose preferences to update.</param>
+/// <param name="RequesterId">Authenticated caller — must be the creator or a member (#2655 IDOR guard).</param>
+/// <param name="MaxDuration">Preferred maximum session duration, if any.</param>
+/// <param name="PreferredComplexity">Preferred game complexity (Light/Medium/Heavy), if any.</param>
+/// <param name="CustomNotes">Free-form group preference notes, if any.</param>
 internal record UpdateGroupPreferencesCommand(
     Guid GroupId,
+    Guid RequesterId,
     TimeSpan? MaxDuration,
     string? PreferredComplexity,
     string? CustomNotes

--- a/apps/api/src/Api/BoundedContexts/AgentMemory/Application/Commands/UpdateGroupPreferencesCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/AgentMemory/Application/Commands/UpdateGroupPreferencesCommandHandler.cs
@@ -46,6 +46,12 @@ internal sealed class UpdateGroupPreferencesCommandHandler : ICommandHandler<Upd
         var group = await _groupRepo.GetByIdAsync(command.GroupId, cancellationToken).ConfigureAwait(false)
             ?? throw new NotFoundException($"Group memory {command.GroupId} not found");
 
+        // #2655 IDOR guard: only the creator or a member may change preferences.
+        if (!group.IsMemberOrCreator(command.RequesterId))
+        {
+            throw new ForbiddenException("Only a group member can update its preferences.");
+        }
+
         PreferredComplexity? complexity = command.PreferredComplexity != null
             ? Enum.Parse<PreferredComplexity>(command.PreferredComplexity, ignoreCase: true)
             : null;

--- a/apps/api/src/Api/BoundedContexts/AgentMemory/Application/Queries/GetGroupMemoryQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/AgentMemory/Application/Queries/GetGroupMemoryQuery.cs
@@ -6,4 +6,6 @@ namespace Api.BoundedContexts.AgentMemory.Application.Queries;
 /// <summary>
 /// Query to retrieve a group's memory by group ID.
 /// </summary>
-internal record GetGroupMemoryQuery(Guid GroupId) : IQuery<GroupMemoryDto?>;
+/// <param name="GroupId">Group to read.</param>
+/// <param name="RequesterId">Authenticated caller — must be the creator or a member (#2655 IDOR guard).</param>
+internal record GetGroupMemoryQuery(Guid GroupId, Guid RequesterId) : IQuery<GroupMemoryDto?>;

--- a/apps/api/src/Api/BoundedContexts/AgentMemory/Application/Queries/GetGroupMemoryQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/AgentMemory/Application/Queries/GetGroupMemoryQueryHandler.cs
@@ -26,7 +26,14 @@ internal sealed class GetGroupMemoryQueryHandler : IQueryHandler<GetGroupMemoryQ
             .GetByIdAsync(query.GroupId, cancellationToken)
             .ConfigureAwait(false);
 
-        return group != null ? MapToDto(group) : null;
+        // #2655 IDOR guard: only the creator or a member may read the group.
+        // Returning null for non-members also hides the group's existence (404).
+        if (group is null || !group.IsMemberOrCreator(query.RequesterId))
+        {
+            return null;
+        }
+
+        return MapToDto(group);
     }
 
     private static GroupMemoryDto MapToDto(GroupMemory group) => new(

--- a/apps/api/src/Api/BoundedContexts/AgentMemory/Application/Validators/UpdateGroupPreferencesCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/AgentMemory/Application/Validators/UpdateGroupPreferencesCommandValidator.cs
@@ -16,6 +16,10 @@ internal sealed class UpdateGroupPreferencesCommandValidator : AbstractValidator
             .NotEmpty()
             .WithMessage("Group ID is required");
 
+        RuleFor(x => x.RequesterId)
+            .NotEmpty()
+            .WithMessage("Requester ID is required");
+
         RuleFor(x => x.PreferredComplexity)
             .Must(c => c == null || ValidComplexities.Contains(c, StringComparer.OrdinalIgnoreCase))
             .WithMessage("Preferred complexity must be Light, Medium, or Heavy");

--- a/apps/api/src/Api/BoundedContexts/AgentMemory/Domain/Entities/GroupMemory.cs
+++ b/apps/api/src/Api/BoundedContexts/AgentMemory/Domain/Entities/GroupMemory.cs
@@ -66,6 +66,16 @@ internal sealed class GroupMemory : AggregateRoot<Guid>
         });
     }
 
+    /// <summary>
+    /// Returns true when <paramref name="userId"/> is the group creator or a
+    /// registered member. Used to authorize read/mutate access to the group
+    /// (#2655 IDOR guard). The creator is normally also added as a member, but
+    /// the explicit CreatorId check keeps this robust for legacy rows.
+    /// </summary>
+    public bool IsMemberOrCreator(Guid userId) =>
+        userId != Guid.Empty
+        && (CreatorId == userId || _members.Any(m => m.UserId == userId));
+
     public void UpdatePreferences(GroupPreferences preferences)
     {
         Preferences = preferences ?? throw new ArgumentNullException(nameof(preferences));

--- a/apps/api/src/Api/Routing/AgentMemoryEndpoints.cs
+++ b/apps/api/src/Api/Routing/AgentMemoryEndpoints.cs
@@ -152,9 +152,16 @@ internal static class AgentMemoryEndpoints
     private static async Task<IResult> HandleGetGroup(
         Guid groupId,
         [FromServices] IMediator mediator,
+        HttpContext httpContext,
         CancellationToken cancellationToken)
     {
-        var result = await mediator.Send(new GetGroupMemoryQuery(groupId), cancellationToken).ConfigureAwait(false);
+        var userId = httpContext.User.GetUserId();
+        if (userId == Guid.Empty)
+        {
+            return Results.Unauthorized();
+        }
+
+        var result = await mediator.Send(new GetGroupMemoryQuery(groupId, userId), cancellationToken).ConfigureAwait(false);
         return result is null ? Results.NotFound() : Results.Ok(result);
     }
 
@@ -162,10 +169,17 @@ internal static class AgentMemoryEndpoints
         Guid groupId,
         [FromBody] UpdatePreferencesRequest request,
         [FromServices] IMediator mediator,
+        HttpContext httpContext,
         CancellationToken cancellationToken)
     {
+        var userId = httpContext.User.GetUserId();
+        if (userId == Guid.Empty)
+        {
+            return Results.Unauthorized();
+        }
+
         var command = new UpdateGroupPreferencesCommand(
-            groupId, request.MaxDuration, request.PreferredComplexity, request.CustomNotes);
+            groupId, userId, request.MaxDuration, request.PreferredComplexity, request.CustomNotes);
 
         await mediator.Send(command, cancellationToken).ConfigureAwait(false);
         return Results.NoContent();

--- a/apps/api/tests/Api.Tests/BoundedContexts/AgentMemory/Application/Handlers/GetGroupMemoryQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/AgentMemory/Application/Handlers/GetGroupMemoryQueryHandlerTests.cs
@@ -32,7 +32,7 @@ public class GetGroupMemoryQueryHandlerTests
             .Setup(r => r.GetByIdAsync(groupId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(group);
 
-        var query = new GetGroupMemoryQuery(groupId);
+        var query = new GetGroupMemoryQuery(groupId, creatorId);
 
         // Act
         var result = await _handler.Handle(query, CancellationToken.None);
@@ -44,6 +44,53 @@ public class GetGroupMemoryQueryHandlerTests
     }
 
     [Fact]
+    public async Task Handle_RequesterIsMemberNotCreator_ReturnsMappedDto()
+    {
+        // Arrange — a plain member (not the creator) may read the group.
+        var groupId = Guid.NewGuid();
+        var creatorId = Guid.NewGuid();
+        var memberId = Guid.NewGuid();
+        var group = GroupMemory.Create(creatorId, "Weekend Warriors");
+        group.AddMember(creatorId);
+        group.AddMember(memberId);
+
+        _groupRepoMock
+            .Setup(r => r.GetByIdAsync(groupId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(group);
+
+        var query = new GetGroupMemoryQuery(groupId, memberId);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public async Task Handle_RequesterNotMember_ReturnsNull()
+    {
+        // Arrange — #2655 IDOR fix: a non-member must not read another group's
+        // memory. Returning null (→ 404) also hides the group's existence.
+        var groupId = Guid.NewGuid();
+        var creatorId = Guid.NewGuid();
+        var group = GroupMemory.Create(creatorId, "Weekend Warriors");
+        group.AddMember(creatorId);
+
+        _groupRepoMock
+            .Setup(r => r.GetByIdAsync(groupId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(group);
+
+        var query = new GetGroupMemoryQuery(groupId, Guid.NewGuid()); // outsider
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        Assert.Null(result);
+    }
+
+    [Fact]
     public async Task Handle_GroupNotFound_ReturnsNull()
     {
         // Arrange
@@ -52,7 +99,7 @@ public class GetGroupMemoryQueryHandlerTests
             .Setup(r => r.GetByIdAsync(groupId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((GroupMemory?)null);
 
-        var query = new GetGroupMemoryQuery(groupId);
+        var query = new GetGroupMemoryQuery(groupId, Guid.NewGuid());
 
         // Act
         var result = await _handler.Handle(query, CancellationToken.None);

--- a/apps/api/tests/Api.Tests/BoundedContexts/AgentMemory/Application/Handlers/UpdateGroupPreferencesCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/AgentMemory/Application/Handlers/UpdateGroupPreferencesCommandHandlerTests.cs
@@ -40,7 +40,9 @@ public class UpdateGroupPreferencesCommandHandlerTests
     {
         // Arrange
         var groupId = Guid.NewGuid();
-        var group = GroupMemory.Create(Guid.NewGuid(), "Game Night Crew");
+        var creatorId = Guid.NewGuid();
+        var group = GroupMemory.Create(creatorId, "Game Night Crew");
+        group.AddMember(creatorId);
 
         _groupRepoMock
             .Setup(r => r.GetByIdAsync(groupId, It.IsAny<CancellationToken>()))
@@ -48,6 +50,7 @@ public class UpdateGroupPreferencesCommandHandlerTests
 
         var command = new UpdateGroupPreferencesCommand(
             groupId,
+            creatorId,
             TimeSpan.FromMinutes(90),
             "Medium",
             "We prefer cooperative games");
@@ -61,6 +64,30 @@ public class UpdateGroupPreferencesCommandHandlerTests
     }
 
     [Fact]
+    public async Task Handle_RequesterNotMember_ThrowsForbiddenException()
+    {
+        // Arrange — #2655 IDOR fix: a non-member must not modify a group's prefs.
+        var groupId = Guid.NewGuid();
+        var creatorId = Guid.NewGuid();
+        var group = GroupMemory.Create(creatorId, "Game Night Crew");
+        group.AddMember(creatorId);
+
+        _groupRepoMock
+            .Setup(r => r.GetByIdAsync(groupId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(group);
+
+        var command = new UpdateGroupPreferencesCommand(
+            groupId, Guid.NewGuid(), TimeSpan.FromMinutes(90), "Medium", null); // outsider
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ForbiddenException>(
+            () => _handler.Handle(command, CancellationToken.None));
+
+        _groupRepoMock.Verify(r => r.UpdateAsync(It.IsAny<GroupMemory>(), It.IsAny<CancellationToken>()), Times.Never);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
     public async Task Handle_GroupNotFound_ThrowsNotFoundException()
     {
         // Arrange
@@ -69,7 +96,7 @@ public class UpdateGroupPreferencesCommandHandlerTests
             .Setup(r => r.GetByIdAsync(groupId, It.IsAny<CancellationToken>()))
             .ReturnsAsync((GroupMemory?)null);
 
-        var command = new UpdateGroupPreferencesCommand(groupId, null, null, null);
+        var command = new UpdateGroupPreferencesCommand(groupId, Guid.NewGuid(), null, null, null);
 
         // Act & Assert
         await Assert.ThrowsAsync<NotFoundException>(
@@ -84,7 +111,7 @@ public class UpdateGroupPreferencesCommandHandlerTests
             .Setup(f => f.IsEnabledAsync("Features:AgentMemory.Enabled", null))
             .ReturnsAsync(false);
 
-        var command = new UpdateGroupPreferencesCommand(Guid.NewGuid(), null, null, null);
+        var command = new UpdateGroupPreferencesCommand(Guid.NewGuid(), Guid.NewGuid(), null, null, null);
 
         // Act & Assert
         await Assert.ThrowsAsync<ConflictException>(


### PR DESCRIPTION
## Security fix — 2 High IDOR (STEP 5 secrets-authz scan)

Part of the #2655 Q3 Security Review remediation.

### Problem
`GET /agent-memory/groups/{groupId}` and `PUT /agent-memory/groups/{groupId}/preferences` were gated only by `.RequireAuthenticatedUser()`; the handlers fetched the group by id with **no membership check**. Any authenticated user could:
- **read** any group's memory (members, preferences, stats) by id, and
- **modify** any group's preferences by id.

### Fix
- Add `GroupMemory.IsMemberOrCreator(userId)` domain method (creator or a registered member; `Guid.Empty` never matches; guest members with null `UserId` never match a real caller via lifted equality).
- Add `RequesterId` to `GetGroupMemoryQuery` + `UpdateGroupPreferencesCommand` (+ FluentValidation `NotEmpty` on the command).
- Endpoints extract `httpContext.User.GetUserId()` (401 when empty) and pass it.
- Read handler returns `null` (→ 404, **hides existence**) for non-members; the preferences handler throws `ForbiddenException` (403) for non-members (existence already confirmed → not-found is thrown first).

Coverage: the routing layer exposes exactly 3 group endpoints — `POST /groups` (create your own, no IDOR) + the 2 fixed here. No add-member/delete/stats group endpoints exist, so this covers 100% of the group surface.

### Testing (TDD)
RED tests: non-member read → null; non-member update → `ForbiddenException`; member-but-not-creator read → allowed. Existing tests updated to authorize the caller. **8/8** unit tests green.

Adversarial review (feature-dev:code-reviewer): all 5 verification points SOUND, no critical/important issues; confirmed nullable-`UserId` guest members can't be matched and the guard ordering is correct.

Refs #2655.

🤖 Generated with [Claude Code](https://claude.com/claude-code)