### PR TITLE
feat(gamebook): #2639 campaign close 3-way selector (SI-8)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/CloseGamebookCampaignCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/CloseGamebookCampaignCommand.cs
@@ -1,0 +1,17 @@
+using Api.BoundedContexts.SessionTracking.Application.DTOs;
+using Api.BoundedContexts.SessionTracking.Domain.Enums;
+using MediatR;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Commands;
+
+/// <summary>
+/// SI-8 (#2639): terminally closes a libro-game campaign from the play-evening-end
+/// 3-way selector. <c>Completa</c> → <see cref="GamebookCampaignOutcome.Completed"/>,
+/// <c>Abbandona</c> → <see cref="GamebookCampaignOutcome.Abandoned"/>. "Archivia"
+/// (resumable) does NOT dispatch this command — it just finalizes the evening's
+/// Session (SI-3) and leaves the campaign open. Only the owner can close.
+/// </summary>
+public sealed record CloseGamebookCampaignCommand(
+    Guid CampaignId,
+    Guid CallerUserId,
+    GamebookCampaignOutcome Outcome) : IRequest<GamebookCampaignDto>;

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/CloseGamebookCampaignCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/CloseGamebookCampaignCommandValidator.cs
@@ -1,0 +1,21 @@
+using FluentValidation;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Commands;
+
+public class CloseGamebookCampaignCommandValidator : AbstractValidator<CloseGamebookCampaignCommand>
+{
+    public CloseGamebookCampaignCommandValidator()
+    {
+        RuleFor(x => x.CampaignId)
+            .NotEmpty()
+            .WithMessage("CampaignId is required");
+
+        RuleFor(x => x.CallerUserId)
+            .NotEmpty()
+            .WithMessage("CallerUserId is required");
+
+        RuleFor(x => x.Outcome)
+            .IsInEnum()
+            .WithMessage("Outcome must be a valid terminal outcome (Completed or Abandoned)");
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/CloseGamebookCampaignHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/CloseGamebookCampaignHandler.cs
@@ -1,0 +1,37 @@
+using Api.BoundedContexts.SessionTracking.Application.DTOs;
+using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using MediatR;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Commands;
+
+/// <summary>
+/// SI-8 (#2639): terminally closes a gamebook campaign (Completa/Abbandona).
+/// Only the owner may close (IDOR guard → 403). Closing an already-closed campaign
+/// throws <see cref="ConflictException"/> (→ 409) via the aggregate's idempotency
+/// guard. Returns the updated campaign DTO with its new outcome.
+/// </summary>
+public class CloseGamebookCampaignHandler : IRequestHandler<CloseGamebookCampaignCommand, GamebookCampaignDto>
+{
+    private readonly IGamebookCampaignSessionRepository _repo;
+
+    public CloseGamebookCampaignHandler(IGamebookCampaignSessionRepository repo)
+    {
+        _repo = repo ?? throw new ArgumentNullException(nameof(repo));
+    }
+
+    public async Task<GamebookCampaignDto> Handle(CloseGamebookCampaignCommand cmd, CancellationToken cancellationToken)
+    {
+        var session = await _repo.GetByIdAsync(cmd.CampaignId, cancellationToken).ConfigureAwait(false)
+            ?? throw new NotFoundException($"Campaign {cmd.CampaignId} not found");
+
+        if (session.OwnerUserId != cmd.CallerUserId)
+            throw new ForbiddenException("Only owner can close campaign");
+
+        // Aggregate enforces the already-closed idempotency guard (→ ConflictException).
+        session.Close(cmd.Outcome, cmd.CallerUserId);
+        await _repo.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        return CreateGamebookCampaignHandler.MapToDto(session, progress: null);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/CreateGamebookCampaignHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/CreateGamebookCampaignHandler.cs
@@ -68,7 +68,9 @@ public class CreateGamebookCampaignHandler : IRequestHandler<CreateGamebookCampa
             history,
             lastReadAt,
             s.CreatedAt,
-            s.UpdatedAt);
+            s.UpdatedAt,
+            s.Outcome.HasValue ? (int)s.Outcome.Value : null,
+            s.CompletedAt);
     }
 
     private static int ParseParagraph(string location)

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/DTOs/GamebookCampaignDto.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/DTOs/GamebookCampaignDto.cs
@@ -6,6 +6,10 @@ namespace Api.BoundedContexts.SessionTracking.Application.DTOs;
 /// shared vs private campaigns without hardcoding <c>kind: Shared</c>. Issue #1405
 /// removed the legacy <c>GameId</c> alias after all FE consumers migrated to
 /// <see cref="GameRefId"/>.
+///
+/// SI-8 (#2639): <see cref="Outcome"/> (int form of <c>GamebookCampaignOutcome</c>,
+/// null = open/resumable) + <see cref="CompletedAt"/> expose the manual terminal
+/// close, so the FE can render "completata"/"abbandonata" and filter the resume set.
 /// </summary>
 public sealed record GamebookCampaignDto(
     Guid Id,
@@ -17,4 +21,6 @@ public sealed record GamebookCampaignDto(
     IReadOnlyList<int> History,
     DateTimeOffset LastReadAt,
     DateTimeOffset CreatedAt,
-    DateTimeOffset UpdatedAt);
+    DateTimeOffset UpdatedAt,
+    int? Outcome = null,
+    DateTimeOffset? CompletedAt = null);

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Entities/GamebookCampaignSession.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Entities/GamebookCampaignSession.cs
@@ -1,3 +1,5 @@
+using Api.BoundedContexts.SessionTracking.Domain.Enums;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Domain.ValueObjects;
 
 namespace Api.BoundedContexts.SessionTracking.Domain.Entities;
@@ -14,6 +16,17 @@ public sealed class GamebookCampaignSession
     public Guid? UpdatedBy { get; private set; }
     public bool IsDeleted { get; private set; }
     public DateTimeOffset? DeletedAt { get; private set; }
+
+    // SI-8 (#2639): manual terminal close ("Completa"/"Abbandona" in the play-evening
+    // 3-way selector). Per D4 (reuse-Session), the campaign does NOT duplicate the
+    // Session timestamp-trio; the play-evening lifecycle lives on Session/GameNight.
+    // These two nullable columns are the single "manual Complete flag": a null
+    // Outcome means the campaign is still open/resumable ("Archivia" leaves it null).
+    public GamebookCampaignOutcome? Outcome { get; private set; }
+    public DateTimeOffset? CompletedAt { get; private set; }
+
+    /// <summary>True once the campaign has been terminally closed (Completa/Abbandona).</summary>
+    public bool IsClosed => Outcome.HasValue;
 
     // EF parameterless constructor
     private GamebookCampaignSession() { }
@@ -66,5 +79,28 @@ public sealed class GamebookCampaignSession
         DeletedAt = DateTimeOffset.UtcNow;
         UpdatedAt = DeletedAt.Value;
         UpdatedBy = deletedBy;
+    }
+
+    /// <summary>
+    /// SI-8 (#2639): terminally closes the campaign with a manual outcome
+    /// (<see cref="GamebookCampaignOutcome.Completed"/> or
+    /// <see cref="GamebookCampaignOutcome.Abandoned"/>), stamping
+    /// <see cref="CompletedAt"/>. Idempotency guard: throws if already closed.
+    /// The campaign is NOT soft-deleted — it stays queryable so the resume picker
+    /// can list it under a "completed" section (it just filters it out of the
+    /// resumable set). "Archivia" (resumable) never calls this.
+    /// </summary>
+    /// <exception cref="ConflictException">Thrown when the campaign is already closed.</exception>
+    public void Close(GamebookCampaignOutcome outcome, Guid closedBy)
+    {
+        if (Outcome.HasValue)
+            throw new ConflictException(
+                $"Campaign {Id} is already closed (outcome={Outcome}). Cannot close again.");
+
+        var now = DateTimeOffset.UtcNow;
+        Outcome = outcome;
+        CompletedAt = now;
+        UpdatedAt = now;
+        UpdatedBy = closedBy;
     }
 }

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Enums/GamebookCampaignOutcome.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Enums/GamebookCampaignOutcome.cs
@@ -1,0 +1,18 @@
+namespace Api.BoundedContexts.SessionTracking.Domain.Enums;
+
+/// <summary>
+/// Terminal outcome of a libro-game campaign, set by the play-evening-end 3-way
+/// selector (issue #2639 SI-8). A <c>null</c> outcome means the campaign is still
+/// open/resumable ("Archivia" leaves it null); the two members are the terminal
+/// choices. There is no <c>None = 0</c> member on purpose — "open" is represented
+/// by the nullable column being NULL, so the resume picker can filter on
+/// <c>outcome IS NULL</c>.
+/// </summary>
+public enum GamebookCampaignOutcome
+{
+    /// <summary>"Completa" — the campaign was finished. Terminal.</summary>
+    Completed = 1,
+
+    /// <summary>"Abbandona" — the campaign was dropped. Terminal.</summary>
+    Abandoned = 2,
+}

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/SessionTracking/GamebookCampaignSessionEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/SessionTracking/GamebookCampaignSessionEntityConfiguration.cs
@@ -37,6 +37,13 @@ internal class GamebookCampaignSessionEntityConfiguration : IEntityTypeConfigura
         builder.Property(e => e.IsDeleted).HasColumnName("is_deleted").HasDefaultValue(false);
         builder.Property(e => e.DeletedAt).HasColumnName("deleted_at");
 
+        // SI-8 (#2639): manual terminal close. Nullable outcome (stored as the enum's
+        // int value) + completion timestamp. Null outcome = still open/resumable.
+        builder.Property(e => e.Outcome)
+            .HasColumnName("outcome")
+            .HasConversion<int?>();
+        builder.Property(e => e.CompletedAt).HasColumnName("completed_at");
+
         // A0.2 (#1320): index over (owner_user_id, game_ref_kind, game_ref_id, is_deleted) is
         // declared via raw SQL in the migration because composite indexes spanning both the
         // parent entity (owner_user_id, is_deleted) AND owned-type columns (game_ref_kind,

--- a/apps/api/src/Api/Infrastructure/Migrations/20260707121146_AddGamebookCampaignOutcome.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260707121146_AddGamebookCampaignOutcome.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260707121146_AddGamebookCampaignOutcome")]
+    partial class AddGamebookCampaignOutcome
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260707121146_AddGamebookCampaignOutcome.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260707121146_AddGamebookCampaignOutcome.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddGamebookCampaignOutcome : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "completed_at",
+                schema: "session_tracking",
+                table: "gamebook_campaign_sessions",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<int>(
+                name: "outcome",
+                schema: "session_tracking",
+                table: "gamebook_campaign_sessions",
+                type: "integer",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "completed_at",
+                schema: "session_tracking",
+                table: "gamebook_campaign_sessions");
+
+            migrationBuilder.DropColumn(
+                name: "outcome",
+                schema: "session_tracking",
+                table: "gamebook_campaign_sessions");
+        }
+    }
+}

--- a/apps/api/src/Api/Routing/GamebookCampaignEndpoints.cs
+++ b/apps/api/src/Api/Routing/GamebookCampaignEndpoints.cs
@@ -4,6 +4,7 @@ using Api.BoundedContexts.GameManagement.Application.Queries.GameNight;
 using Api.BoundedContexts.SessionTracking.Application.Commands;
 using Api.BoundedContexts.SessionTracking.Application.DTOs;
 using Api.BoundedContexts.SessionTracking.Application.Queries;
+using Api.BoundedContexts.SessionTracking.Domain.Enums;
 using Api.Extensions;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
@@ -25,6 +26,7 @@ internal static class GamebookCampaignEndpoints
         MapGetCampaignProgressEndpoint(group);
         MapUpdateProgressEndpoint(group);
         MapRenameCampaignEndpoint(group);
+        MapCloseCampaignEndpoint(group);
         MapDeleteCampaignEndpoint(group);
 
         return group;
@@ -266,6 +268,50 @@ internal static class GamebookCampaignEndpoints
         .WithOpenApi();
     }
 
+    private static void MapCloseCampaignEndpoint(RouteGroupBuilder group)
+    {
+        // SI-8 (#2639): terminal close from the play-evening-end 3-way selector.
+        // "Completa"/"Abbandona" POST here; "Archivia" (resumable) does not.
+        group.MapPost("/gamebook/campaigns/{id:guid}/close", async (
+            Guid id,
+            [FromBody] CloseGamebookCampaignRequest body,
+            IMediator mediator,
+            HttpContext context,
+            CancellationToken ct) =>
+        {
+            var (authenticated, session, error) = context.TryGetAuthenticatedUser();
+            if (!authenticated) return error!;
+
+            if (!TryGetUserId(context, session, out var userId))
+            {
+                return Results.Unauthorized();
+            }
+
+            if (!Enum.TryParse<GamebookCampaignOutcome>(body.Outcome, ignoreCase: true, out var outcome)
+                || !Enum.IsDefined(outcome))
+            {
+                return Results.BadRequest(new { error = "outcome must be 'Completed' or 'Abandoned'" });
+            }
+
+            var dto = await mediator.Send(
+                new CloseGamebookCampaignCommand(id, userId, outcome), ct
+            ).ConfigureAwait(false);
+
+            return Results.Ok(dto);
+        })
+        .RequireAuthenticatedUser()
+        .Produces<GamebookCampaignDto>(StatusCodes.Status200OK)
+        .Produces(StatusCodes.Status400BadRequest)
+        .Produces(StatusCodes.Status401Unauthorized)
+        .Produces(StatusCodes.Status403Forbidden)
+        .Produces(StatusCodes.Status404NotFound)
+        .Produces(StatusCodes.Status409Conflict)
+        .WithTags("Gamebook")
+        .WithSummary("Terminally close a gamebook campaign")
+        .WithDescription("Sets the manual terminal outcome (Completed/Abandoned) on the campaign (SI-8). Only the owner may close; a campaign already closed returns 409.")
+        .WithOpenApi();
+    }
+
     private static void MapDeleteCampaignEndpoint(RouteGroupBuilder group)
     {
         group.MapDelete("/gamebook/campaigns/{id:guid}", async (
@@ -327,3 +373,10 @@ public sealed record UpdateGamebookProgressRequest(Guid GameBookId, int CurrentP
 
 /// <summary>Request body for renaming a gamebook campaign.</summary>
 public sealed record RenameGamebookCampaignRequest(string Title);
+
+/// <summary>
+/// Request body for terminally closing a gamebook campaign (SI-8 #2639).
+/// <paramref name="Outcome"/> is the string form of <c>GamebookCampaignOutcome</c>
+/// ("Completed" or "Abandoned"); "Archivia" (resumable) does not call this endpoint.
+/// </summary>
+public sealed record CloseGamebookCampaignRequest(string Outcome);

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Commands/CloseGamebookCampaignHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Commands/CloseGamebookCampaignHandlerTests.cs
@@ -1,0 +1,117 @@
+using Api.BoundedContexts.SessionTracking.Application.Commands;
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+using Api.BoundedContexts.SessionTracking.Domain.Enums;
+using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Domain.ValueObjects;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SessionTracking.Application.Commands;
+
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SessionTracking")]
+public sealed class CloseGamebookCampaignHandlerTests
+{
+    private sealed class FakeRepo : IGamebookCampaignSessionRepository
+    {
+        public List<GamebookCampaignSession> Store { get; } = new();
+
+        public Task<GamebookCampaignSession?> GetByIdAsync(Guid id, CancellationToken ct = default)
+            => Task.FromResult(Store.FirstOrDefault(x => x.Id == id));
+
+        public Task<IReadOnlyList<GamebookCampaignSession>> ListByOwnerAsync(Guid o, Guid? g, CancellationToken ct = default)
+            => Task.FromResult<IReadOnlyList<GamebookCampaignSession>>(Store);
+
+        public Task AddAsync(GamebookCampaignSession s, CancellationToken ct = default)
+        {
+            Store.Add(s);
+            return Task.CompletedTask;
+        }
+
+        public int SaveCalls { get; private set; }
+
+        public Task SaveChangesAsync(CancellationToken ct = default)
+        {
+            SaveCalls++;
+            return Task.CompletedTask;
+        }
+    }
+
+    private static (FakeRepo repo, CloseGamebookCampaignHandler handler, GamebookCampaignSession session) BuildSut()
+    {
+        var repo = new FakeRepo();
+        var handler = new CloseGamebookCampaignHandler(repo);
+        var userId = Guid.NewGuid();
+        var session = GamebookCampaignSession.Create(GameRef.Shared(Guid.NewGuid()), userId, "Campagna Eldoria");
+        repo.Store.Add(session);
+        return (repo, handler, session);
+    }
+
+    [Fact]
+    public async Task Handle_Completed_SetsOutcomeAndSaves()
+    {
+        var (repo, handler, session) = BuildSut();
+        var cmd = new CloseGamebookCampaignCommand(session.Id, session.OwnerUserId, GamebookCampaignOutcome.Completed);
+
+        var dto = await handler.Handle(cmd, CancellationToken.None);
+
+        session.Outcome.Should().Be(GamebookCampaignOutcome.Completed);
+        session.IsClosed.Should().BeTrue();
+        dto.Outcome.Should().Be((int)GamebookCampaignOutcome.Completed);
+        dto.CompletedAt.Should().NotBeNull();
+        repo.SaveCalls.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Handle_Abandoned_SetsOutcome()
+    {
+        var (_, handler, session) = BuildSut();
+        var cmd = new CloseGamebookCampaignCommand(session.Id, session.OwnerUserId, GamebookCampaignOutcome.Abandoned);
+
+        var dto = await handler.Handle(cmd, CancellationToken.None);
+
+        dto.Outcome.Should().Be((int)GamebookCampaignOutcome.Abandoned);
+        session.Outcome.Should().Be(GamebookCampaignOutcome.Abandoned);
+    }
+
+    [Fact]
+    public async Task Handle_WhenSessionMissing_ThrowsNotFound()
+    {
+        var (_, handler, _) = BuildSut();
+        var cmd = new CloseGamebookCampaignCommand(Guid.NewGuid(), Guid.NewGuid(), GamebookCampaignOutcome.Completed);
+
+        var act = async () => await handler.Handle(cmd, CancellationToken.None);
+
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+
+    [Fact]
+    public async Task Handle_WhenCallerIsNotOwner_ThrowsForbidden()
+    {
+        // IDOR guard: a non-owner must not be able to close someone else's campaign.
+        var (repo, handler, session) = BuildSut();
+        var attacker = Guid.NewGuid();
+        var cmd = new CloseGamebookCampaignCommand(session.Id, attacker, GamebookCampaignOutcome.Abandoned);
+
+        var act = async () => await handler.Handle(cmd, CancellationToken.None);
+
+        await act.Should().ThrowAsync<ForbiddenException>();
+        session.IsClosed.Should().BeFalse();
+        repo.SaveCalls.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Handle_WhenAlreadyClosed_ThrowsConflict()
+    {
+        // Idempotency guard (409): a second close on an already-closed campaign fails.
+        var (_, handler, session) = BuildSut();
+        session.Close(GamebookCampaignOutcome.Completed, session.OwnerUserId);
+        var cmd = new CloseGamebookCampaignCommand(session.Id, session.OwnerUserId, GamebookCampaignOutcome.Abandoned);
+
+        var act = async () => await handler.Handle(cmd, CancellationToken.None);
+
+        await act.Should().ThrowAsync<ConflictException>();
+        session.Outcome.Should().Be(GamebookCampaignOutcome.Completed); // unchanged
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Domain/GamebookCampaignSessionTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Domain/GamebookCampaignSessionTests.cs
@@ -1,4 +1,6 @@
 using Api.BoundedContexts.SessionTracking.Domain.Entities;
+using Api.BoundedContexts.SessionTracking.Domain.Enums;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Domain.ValueObjects;
 using FluentAssertions;
 using Xunit;
@@ -81,5 +83,67 @@ public class GamebookCampaignSessionTests
 
         Assert.Equal(GameRefKind.Private, session.GameRef.Kind);
         Assert.Equal(privateId, session.GameRef.Id);
+    }
+
+    // ── SI-8 (#2639): manual campaign close (Completa / Abbandona terminal) ────
+
+    [Fact]
+    public void Create_LeavesCampaignOpen_NoOutcome()
+    {
+        var session = GamebookCampaignSession.Create(SharedRef(), OwnerId, "C1");
+
+        session.Outcome.Should().BeNull();
+        session.CompletedAt.Should().BeNull();
+        session.IsClosed.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Close_WithCompleted_SetsOutcomeCompletedAtAndAudit()
+    {
+        var session = GamebookCampaignSession.Create(SharedRef(), OwnerId, "C1");
+        var before = session.UpdatedAt;
+        Thread.Sleep(20);
+
+        session.Close(GamebookCampaignOutcome.Completed, closedBy: OwnerId);
+
+        session.Outcome.Should().Be(GamebookCampaignOutcome.Completed);
+        session.CompletedAt.Should().NotBeNull();
+        session.IsClosed.Should().BeTrue();
+        session.UpdatedAt.Should().BeAfter(before);
+        session.UpdatedBy.Should().Be(OwnerId);
+    }
+
+    [Fact]
+    public void Close_WithAbandoned_SetsOutcome()
+    {
+        var session = GamebookCampaignSession.Create(SharedRef(), OwnerId, "C1");
+
+        session.Close(GamebookCampaignOutcome.Abandoned, closedBy: OwnerId);
+
+        session.Outcome.Should().Be(GamebookCampaignOutcome.Abandoned);
+        session.IsClosed.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Close_WhenAlreadyClosed_ThrowsConflict()
+    {
+        var session = GamebookCampaignSession.Create(SharedRef(), OwnerId, "C1");
+        session.Close(GamebookCampaignOutcome.Completed, closedBy: OwnerId);
+
+        Action act = () => session.Close(GamebookCampaignOutcome.Abandoned, closedBy: OwnerId);
+
+        act.Should().Throw<ConflictException>();
+    }
+
+    [Fact]
+    public void Close_DoesNotSoftDelete()
+    {
+        // Archivia is the resumable default (no Close call); Completa/Abbandona are
+        // terminal but the campaign row is NOT soft-deleted — it stays queryable so
+        // the resume picker can list it under a "completed" section.
+        var session = GamebookCampaignSession.Create(SharedRef(), OwnerId, "C1");
+        session.Close(GamebookCampaignOutcome.Completed, closedBy: OwnerId);
+
+        session.IsDeleted.Should().BeFalse();
     }
 }

--- a/apps/web/src/app/(authenticated)/library/[gameId]/play/[campaignId]/_content.tsx
+++ b/apps/web/src/app/(authenticated)/library/[gameId]/play/[campaignId]/_content.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import { useCallback, useMemo, type ReactElement } from 'react';
+import { useCallback, useMemo, useState, type ReactElement } from 'react';
 
 import { useRouter } from 'next/navigation';
 
 import { GamebookPlayShell } from '@/components/features/gamebook';
+import { CampaignCloseSelector } from '@/components/features/gamebook/CampaignCloseSelector';
 import { ResumeBooksList } from '@/components/features/gamebook/ResumeBooksList';
 import {
   SerataResumeButton,
@@ -12,6 +13,7 @@ import {
 } from '@/components/features/gamebook/SerataResumeButton';
 import { SerataSpineStrip } from '@/components/features/gamebook/SerataSpineStrip';
 import { useCurrentUser } from '@/hooks/queries/useCurrentUser';
+import { useTranslation } from '@/hooks/useTranslation';
 import { GameRefKind, type GameRef } from '@/lib/api/gamebook';
 import { useCampaignProgress } from '@/lib/gamebook/hooks/useCampaignProgress';
 import {
@@ -27,6 +29,10 @@ export function Content({
   gameId: string;
 }): ReactElement {
   const router = useRouter();
+  const { t } = useTranslation();
+  // SI-8 (#2639): the play-evening-end 3-way close selector is revealed on demand
+  // (not always visible while reading) and only for an open campaign.
+  const [showClose, setShowClose] = useState(false);
   // Issue #1392: derive the GameRef discriminator from the campaign DTO so
   // private-game campaigns route correctly (the BE now emits gameRefKind).
   // Fallback to Shared + route gameId while the campaign is still loading.
@@ -79,6 +85,32 @@ export function Content({
               <SerataResumeButton gameNightId={spine.gameNightId} campaignId={campaignId} />
             </div>
           ) : null}
+        </div>
+      ) : null}
+      {/* SI-8 (#2639): campaign close. Shown only for a loaded, still-open campaign;
+          "Archivia" leaves it resumable, "Completa"/"Abbandona" close it terminally. */}
+      {campaign && campaign.outcome == null ? (
+        <div className="px-3 pt-2">
+          {showClose ? (
+            <CampaignCloseSelector
+              campaignId={campaignId}
+              campaignName={campaign.title}
+              onArchive={() => {
+                setShowClose(false);
+                router.refresh();
+              }}
+              onClosed={() => router.push('/library')}
+            />
+          ) : (
+            <button
+              type="button"
+              data-testid="campaign-close-open"
+              onClick={() => setShowClose(true)}
+              className="rounded-md border border-border px-3 py-2 text-sm font-medium text-muted-foreground hover:bg-muted"
+            >
+              {t('gamebook.campaignClose.heading')}
+            </button>
+          )}
         </div>
       ) : null}
       <ResumeBooksList progress={bookProgress} onResume={handleResume} />

--- a/apps/web/src/components/features/gamebook/CampaignCloseSelector.tsx
+++ b/apps/web/src/components/features/gamebook/CampaignCloseSelector.tsx
@@ -1,0 +1,161 @@
+/**
+ * CampaignCloseSelector — the play-evening-end 3-way close selector (issue #2639,
+ * SI-8). Reconciles the mockup's 4 outcome states to the ratified D2 model:
+ * three top-level choices, "defeat" being a dock-only branch (out of scope here).
+ *
+ *   • Completa (terminal)  → close the campaign as Completed.
+ *   • Archivia (resumable) → leave the campaign open; the evening's Session is
+ *                            finalized separately (SI-3). Fires `onArchive`.
+ *   • Abbandona (terminal) → close the campaign as Abandoned.
+ *
+ * Per D4 (reuse-Session), the play-evening lifecycle (Session.Finalize + the
+ * GameNight in-progress→completed transition) lives in SI-3; this component owns
+ * only the campaign-level terminal outcome. Completa/Abbandona POST to the SI-8
+ * close endpoint via `useCloseGamebookCampaign`; the caller composes the SI-3
+ * finalize where a live GameNight session exists.
+ *
+ * Design tokens only (no hardcoded neutral utilities; entity/semantic colors).
+ */
+
+'use client';
+
+import { useCallback, type ReactElement } from 'react';
+
+import { useTranslation } from '@/hooks/useTranslation';
+import { GamebookCampaignOutcome, type GamebookCampaign } from '@/lib/api/gamebook-campaigns';
+import { useCloseGamebookCampaign } from '@/lib/gamebook/hooks/useCloseGamebookCampaign';
+
+export interface CampaignCloseSelectorProps {
+  readonly campaignId: string;
+  readonly campaignName: string;
+  /** Fired when the user picks "Archivia" (resumable — no campaign close). */
+  readonly onArchive: () => void;
+  /** Fired after a successful terminal close (Completa/Abbandona). */
+  readonly onClosed?: (campaign: GamebookCampaign) => void;
+}
+
+export function CampaignCloseSelector({
+  campaignId,
+  campaignName,
+  onArchive,
+  onClosed,
+}: CampaignCloseSelectorProps): ReactElement {
+  const { t } = useTranslation();
+  const close = useCloseGamebookCampaign(campaignId);
+
+  const handleComplete = useCallback(() => {
+    close.mutate(GamebookCampaignOutcome.Completed, { onSuccess: onClosed });
+  }, [close, onClosed]);
+
+  const handleAbandon = useCallback(() => {
+    close.mutate(GamebookCampaignOutcome.Abandoned, { onSuccess: onClosed });
+  }, [close, onClosed]);
+
+  const busy = close.isPending;
+
+  return (
+    <section
+      data-slot="campaign-close-selector"
+      data-testid="campaign-close-selector"
+      aria-label={t('gamebook.campaignClose.heading')}
+      className="flex flex-col gap-3 rounded-lg border border-border bg-card p-4"
+    >
+      <div>
+        <h2 className="font-quicksand text-lg font-bold text-foreground">
+          {t('gamebook.campaignClose.heading')}
+        </h2>
+        <p className="mt-0.5 text-sm text-muted-foreground">
+          {t('gamebook.campaignClose.prompt', { campaign: campaignName })}
+        </p>
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <CloseChoice
+          testId="campaign-close-complete"
+          label={t('gamebook.campaignClose.complete')}
+          hint={t('gamebook.campaignClose.completeHint')}
+          tone="success"
+          disabled={busy}
+          onClick={handleComplete}
+        />
+        <CloseChoice
+          testId="campaign-close-archive"
+          label={t('gamebook.campaignClose.archive')}
+          hint={t('gamebook.campaignClose.archiveHint')}
+          tone="neutral"
+          disabled={busy}
+          onClick={onArchive}
+        />
+        <CloseChoice
+          testId="campaign-close-abandon"
+          label={t('gamebook.campaignClose.abandon')}
+          hint={t('gamebook.campaignClose.abandonHint')}
+          tone="danger"
+          disabled={busy}
+          onClick={handleAbandon}
+        />
+      </div>
+
+      {busy && (
+        <p
+          data-testid="campaign-close-pending"
+          className="text-sm text-muted-foreground"
+          aria-live="polite"
+        >
+          {t('gamebook.campaignClose.closing')}
+        </p>
+      )}
+
+      {close.isError && !busy && (
+        <div role="alert" data-testid="campaign-close-error" className="flex items-center gap-2">
+          <p className="text-sm text-[hsl(var(--c-danger))]">{t('gamebook.campaignClose.error')}</p>
+          <button
+            type="button"
+            onClick={() => close.reset()}
+            className="rounded-md border border-border px-2 py-1 text-sm font-medium text-foreground"
+          >
+            {t('gamebook.campaignClose.retry')}
+          </button>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function CloseChoice({
+  testId,
+  label,
+  hint,
+  tone,
+  disabled,
+  onClick,
+}: {
+  testId: string;
+  label: string;
+  hint: string;
+  tone: 'success' | 'neutral' | 'danger';
+  disabled: boolean;
+  onClick: () => void;
+}): ReactElement {
+  const toneClass =
+    tone === 'success'
+      ? 'border-[hsl(var(--c-success)/0.4)] hover:bg-[hsl(var(--c-success)/0.08)]'
+      : tone === 'danger'
+        ? 'border-[hsl(var(--c-danger)/0.4)] hover:bg-[hsl(var(--c-danger)/0.08)]'
+        : 'border-border hover:bg-muted';
+  return (
+    <button
+      type="button"
+      data-testid={testId}
+      disabled={disabled}
+      onClick={onClick}
+      className={
+        'flex flex-col items-start rounded-md border px-4 py-3 text-left transition-colors disabled:opacity-60 ' +
+        toneClass
+      }
+    >
+      <span className="font-quicksand font-semibold text-foreground">{label}</span>
+      <span className="mt-0.5 text-xs text-muted-foreground">{hint}</span>
+    </button>
+  );
+}

--- a/apps/web/src/components/features/gamebook/__tests__/CampaignCloseSelector.test.tsx
+++ b/apps/web/src/components/features/gamebook/__tests__/CampaignCloseSelector.test.tsx
@@ -1,0 +1,147 @@
+/**
+ * CampaignCloseSelector — tests for issue #2639 (SI-8): the play-evening-end
+ * 3-way close selector. Completa/Abbandona close the campaign (POST close);
+ * Archivia leaves it resumable (callback only, no close call).
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor, type RenderResult } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactElement, ReactNode } from 'react';
+import { IntlProvider } from 'react-intl';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import itMessages from '@/locales/it.json';
+import * as client from '@/lib/api/gamebook-campaigns';
+import { GamebookCampaignOutcome } from '@/lib/api/gamebook-campaigns';
+
+import { CampaignCloseSelector } from '../CampaignCloseSelector';
+
+vi.mock('@/lib/api/gamebook-campaigns', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/lib/api/gamebook-campaigns')>();
+  return { ...actual, closeCampaign: vi.fn() };
+});
+
+function flatten(obj: Record<string, unknown>, prefix = ''): Record<string, string> {
+  return Object.keys(obj).reduce(
+    (acc, key) => {
+      const full = prefix ? `${prefix}.${key}` : key;
+      const value = obj[key];
+      if (value && typeof value === 'object') {
+        Object.assign(acc, flatten(value as Record<string, unknown>, full));
+      } else {
+        acc[full] = String(value);
+      }
+      return acc;
+    },
+    {} as Record<string, string>
+  );
+}
+const FLAT_IT = flatten(itMessages as Record<string, unknown>);
+
+const CAMPAIGN_ID = '11111111-1111-4111-8111-111111111111';
+const closedCampaign = { id: CAMPAIGN_ID, title: 'Eldoria', outcome: 1 } as never;
+
+function renderSelector(ui: ReactElement): RenderResult {
+  const qc = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+  function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={qc}>
+        <IntlProvider locale="it" messages={FLAT_IT} onError={() => {}}>
+          {children}
+        </IntlProvider>
+      </QueryClientProvider>
+    );
+  }
+  return render(ui, { wrapper: Wrapper });
+}
+
+beforeEach(() => {
+  vi.mocked(client.closeCampaign).mockReset();
+});
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('CampaignCloseSelector', () => {
+  it('renders the 3-way selector (Completa / Archivia / Abbandona)', () => {
+    renderSelector(
+      <CampaignCloseSelector campaignId={CAMPAIGN_ID} campaignName="Eldoria" onArchive={() => {}} />
+    );
+    expect(screen.getByTestId('campaign-close-selector')).toBeInTheDocument();
+    expect(screen.getByTestId('campaign-close-complete')).toHaveTextContent('Completa');
+    expect(screen.getByTestId('campaign-close-archive')).toHaveTextContent('Archivia');
+    expect(screen.getByTestId('campaign-close-abandon')).toHaveTextContent('Abbandona');
+  });
+
+  it('Completa closes the campaign as Completed and fires onClosed', async () => {
+    vi.mocked(client.closeCampaign).mockResolvedValueOnce(closedCampaign);
+    const onClosed = vi.fn();
+    const user = userEvent.setup();
+    renderSelector(
+      <CampaignCloseSelector
+        campaignId={CAMPAIGN_ID}
+        campaignName="Eldoria"
+        onArchive={() => {}}
+        onClosed={onClosed}
+      />
+    );
+
+    await user.click(screen.getByTestId('campaign-close-complete'));
+
+    await waitFor(() =>
+      expect(client.closeCampaign).toHaveBeenCalledWith(
+        CAMPAIGN_ID,
+        GamebookCampaignOutcome.Completed
+      )
+    );
+    await waitFor(() => expect(onClosed).toHaveBeenCalledTimes(1));
+  });
+
+  it('Abbandona closes the campaign as Abandoned', async () => {
+    vi.mocked(client.closeCampaign).mockResolvedValueOnce(closedCampaign);
+    const user = userEvent.setup();
+    renderSelector(
+      <CampaignCloseSelector campaignId={CAMPAIGN_ID} campaignName="Eldoria" onArchive={() => {}} />
+    );
+
+    await user.click(screen.getByTestId('campaign-close-abandon'));
+
+    await waitFor(() =>
+      expect(client.closeCampaign).toHaveBeenCalledWith(
+        CAMPAIGN_ID,
+        GamebookCampaignOutcome.Abandoned
+      )
+    );
+  });
+
+  it('Archivia fires onArchive and does NOT close the campaign (resumable)', async () => {
+    const onArchive = vi.fn();
+    const user = userEvent.setup();
+    renderSelector(
+      <CampaignCloseSelector
+        campaignId={CAMPAIGN_ID}
+        campaignName="Eldoria"
+        onArchive={onArchive}
+      />
+    );
+
+    await user.click(screen.getByTestId('campaign-close-archive'));
+
+    expect(onArchive).toHaveBeenCalledTimes(1);
+    expect(client.closeCampaign).not.toHaveBeenCalled();
+  });
+
+  it('surfaces an error with a retry when the close fails', async () => {
+    vi.mocked(client.closeCampaign).mockRejectedValueOnce(new Error('boom'));
+    const user = userEvent.setup();
+    renderSelector(
+      <CampaignCloseSelector campaignId={CAMPAIGN_ID} campaignName="Eldoria" onArchive={() => {}} />
+    );
+
+    await user.click(screen.getByTestId('campaign-close-complete'));
+
+    await waitFor(() => expect(screen.getByTestId('campaign-close-error')).toBeInTheDocument());
+    expect(screen.getByRole('button', { name: /riprova/i })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/lib/api/gamebook-campaigns.ts
+++ b/apps/web/src/lib/api/gamebook-campaigns.ts
@@ -55,7 +55,26 @@ export const GamebookCampaignSchema = z.object({
   lastReadAt: z.string().datetime({ offset: true }),
   createdAt: z.string().datetime({ offset: true }),
   updatedAt: z.string().datetime({ offset: true }),
+  /**
+   * SI-8 (#2639): terminal close outcome. Mirrors backend `GamebookCampaignOutcome`
+   * (1 = Completed, 2 = Abandoned); `null` = still open/resumable ("Archivia").
+   * Optional for backward-compat with fixtures predating the field.
+   */
+  outcome: z.number().int().nullable().optional().default(null),
+  completedAt: z.string().datetime({ offset: true }).nullable().optional().default(null),
 });
+
+/**
+ * SI-8 (#2639): terminal outcome mirroring backend `GamebookCampaignOutcome`.
+ * "Archivia" (resumable) is NOT one of these — it never closes the campaign.
+ */
+export const GamebookCampaignOutcome = {
+  Completed: 1,
+  Abandoned: 2,
+} as const;
+
+export type GamebookCampaignOutcomeValue =
+  (typeof GamebookCampaignOutcome)[keyof typeof GamebookCampaignOutcome];
 
 export type GamebookCampaign = z.infer<typeof GamebookCampaignSchema>;
 
@@ -189,6 +208,26 @@ export async function renameCampaign(id: string, title: string): Promise<Gameboo
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ title }),
+    credentials: 'include',
+  });
+  return parseJson(res, GamebookCampaignSchema);
+}
+
+/**
+ * SI-8 (#2639): terminally close a campaign with a manual outcome
+ * (Completed / Abandoned). "Archivia" (resumable) does NOT call this — it just
+ * finalizes the evening's Session (SI-3) and leaves the campaign open.
+ * Owner-only (403 for others); a campaign already closed returns 409.
+ */
+export async function closeCampaign(
+  id: string,
+  outcome: GamebookCampaignOutcomeValue
+): Promise<GamebookCampaign> {
+  const outcomeName = outcome === GamebookCampaignOutcome.Completed ? 'Completed' : 'Abandoned';
+  const res = await fetch(`${API_BASE}/api/v1/gamebook/campaigns/${encodeURIComponent(id)}/close`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ outcome: outcomeName }),
     credentials: 'include',
   });
   return parseJson(res, GamebookCampaignSchema);

--- a/apps/web/src/lib/gamebook/hooks/__tests__/useCloseGamebookCampaign.test.tsx
+++ b/apps/web/src/lib/gamebook/hooks/__tests__/useCloseGamebookCampaign.test.tsx
@@ -1,0 +1,61 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import * as clientMod from '@/lib/api/gamebook-campaigns';
+import { GamebookCampaignOutcome } from '@/lib/api/gamebook-campaigns';
+
+import { useCloseGamebookCampaign } from '../useCloseGamebookCampaign';
+import { gamebookCampaignKeys } from '../useGamebookCampaign';
+
+vi.mock('@/lib/api/gamebook-campaigns', async importOriginal => {
+  const actual = await importOriginal<typeof import('@/lib/api/gamebook-campaigns')>();
+  return { ...actual, closeCampaign: vi.fn() };
+});
+
+const CAMPAIGN_ID = 'abc';
+const closed = { id: CAMPAIGN_ID, title: 'C1', outcome: 1 } as never;
+
+describe('useCloseGamebookCampaign', () => {
+  const wrapper =
+    (qc: QueryClient) =>
+    ({ children }: { children: ReactNode }) => (
+      <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+    );
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('calls closeCampaign with the outcome and primes the detail cache', async () => {
+    vi.mocked(clientMod.closeCampaign).mockResolvedValueOnce(closed);
+    const qc = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+
+    const { result } = renderHook(() => useCloseGamebookCampaign(CAMPAIGN_ID), {
+      wrapper: wrapper(qc),
+    });
+
+    result.current.mutate(GamebookCampaignOutcome.Completed);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(clientMod.closeCampaign).toHaveBeenCalledWith(
+      CAMPAIGN_ID,
+      GamebookCampaignOutcome.Completed
+    );
+    expect(qc.getQueryData(gamebookCampaignKeys.detail(CAMPAIGN_ID))).toEqual(closed);
+  });
+
+  it('surfaces the error on a failed close', async () => {
+    vi.mocked(clientMod.closeCampaign).mockRejectedValueOnce(new Error('409'));
+    const qc = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+
+    const { result } = renderHook(() => useCloseGamebookCampaign(CAMPAIGN_ID), {
+      wrapper: wrapper(qc),
+    });
+
+    result.current.mutate(GamebookCampaignOutcome.Abandoned);
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});

--- a/apps/web/src/lib/gamebook/hooks/useCloseGamebookCampaign.ts
+++ b/apps/web/src/lib/gamebook/hooks/useCloseGamebookCampaign.ts
@@ -1,0 +1,31 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import {
+  closeCampaign,
+  type GamebookCampaign,
+  type GamebookCampaignOutcomeValue,
+} from '@/lib/api/gamebook-campaigns';
+
+import { gamebookCampaignKeys } from './useGamebookCampaign';
+
+/**
+ * SI-8 (#2639): terminally close a gamebook campaign (Completa/Abbandona) from
+ * the play-evening-end 3-way selector. "Archivia" (resumable) does NOT use this
+ * hook — it leaves the campaign open.
+ *
+ * On success, primes the campaign detail cache with the returned (now-closed)
+ * DTO and invalidates the broad campaign family + this campaign's spine so the
+ * resume picker and the Serata strip reflect the terminal state (mirrors the
+ * SI-3 cross-surface invalidation contract).
+ */
+export function useCloseGamebookCampaign(campaignId: string) {
+  const qc = useQueryClient();
+  return useMutation<GamebookCampaign, Error, GamebookCampaignOutcomeValue>({
+    mutationFn: outcome => closeCampaign(campaignId, outcome),
+    onSuccess: data => {
+      qc.setQueryData(gamebookCampaignKeys.detail(campaignId), data);
+      qc.invalidateQueries({ queryKey: gamebookCampaignKeys.all });
+      qc.invalidateQueries({ queryKey: gamebookCampaignKeys.spine(campaignId) });
+    },
+  });
+}

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -3640,6 +3640,19 @@
         }
       }
     },
+    "campaignClose": {
+      "heading": "End the evening",
+      "prompt": "How do you want to close “{campaign}”?",
+      "complete": "Complete",
+      "completeHint": "You finished the book — close the campaign.",
+      "archive": "Archive",
+      "archiveHint": "Pause it: you can resume later.",
+      "abandon": "Abandon",
+      "abandonHint": "Close it for good without finishing.",
+      "closing": "Closing…",
+      "error": "Close failed. Try again.",
+      "retry": "Retry"
+    },
     "bookList": {
       "heading": "Books",
       "count": "{count, plural, one {# book} other {# books}}",

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -3693,6 +3693,19 @@
         }
       }
     },
+    "campaignClose": {
+      "heading": "Termina la serata",
+      "prompt": "Come vuoi chiudere «{campaign}»?",
+      "complete": "Completa",
+      "completeHint": "Hai finito il libro — chiudi la campagna.",
+      "archive": "Archivia",
+      "archiveHint": "Metti in pausa: potrai riprendere più tardi.",
+      "abandon": "Abbandona",
+      "abandonHint": "Chiudi definitivamente senza completarla.",
+      "closing": "Chiusura in corso…",
+      "error": "Chiusura fallita. Riprova.",
+      "retry": "Riprova"
+    },
     "bookList": {
       "heading": "Libri",
       "count": "{count, plural, one {# libro} other {# libri}}",


### PR DESCRIPTION
## Summary

Closes #2639 (SI-8, umbrella #2619 Thread B) — **closes the SP6 libro-game wave**. Adds the manual terminal close of a libro-game campaign from the play-evening-end **3-way selector** (Completa / Archivia / Abbandona), per the ratified **D4 = reuse-Session**.

## Design decision (Option A, chosen with the maintainer)
The spec self-contradicted: **§4 D4** allows "a manual `Complete` flag" and forbids only the "timestamp-**trio** migration"; **§5 line 113** says "no migration" flatly. Resolved as **Option A**: add **one nullable outcome column** (+ `CompletedAt`) + a small migration. §5's "no migration" is read as "no *timestamp-trio* migration" (not the `Session` trio). `Session.Finalize()` carries no outcome and Completa-vs-Abbandona is not derivable from Sessions, so the terminal choice must be persisted.

## Backend
- `GamebookCampaignOutcome` enum `{Completed=1, Abandoned=2}`; `null` = open/resumable ("Archivia").
- `GamebookCampaignSession.Close(outcome, closedBy)` + `IsClosed`; **idempotency guard** (`ConflictException` if already closed); no soft-delete side effect.
- Migration `AddGamebookCampaignOutcome`: 2 nullable columns (`outcome` int, `completed_at`) — **not** the Session timestamp trio.
- `CloseGamebookCampaignCommand` + Validator + Handler: **IDOR guard** (owner-only → **403**) before mutation, NotFound → **404**, already-closed → **409**.
- `POST /api/v1/gamebook/campaigns/{id}/close` `{outcome:'Completed'|'Abandoned'}`.
- `GamebookCampaignDto` exposes `Outcome` + `CompletedAt` (optional → back-compat).

## Frontend
- `closeCampaign` client + `useCloseGamebookCampaign` (invalidates detail/all/spine, mirroring the SI-3 cross-surface contract).
- `CampaignCloseSelector` (3-way): Completa→Completed, Abbandona→Abandoned, **Archivia→`onArchive` (resumable, NO close call)**; pending disables, error+retry via `close.reset()`.
- Wired into the play `_content.tsx` behind a **"Termina la serata"** toggle, shown only for an **open** campaign (`outcome == null`). i18n `gamebook.campaignClose.*` in it+en.

## Scope (deliberate)
- The play-evening lifecycle (`Session.Finalize` + GameNight in-progress→completed) is **SI-3** (already shipped #2634) — this PR does **not** re-implement it; "Archivia" leaves the campaign open and finalizing the evening's Session stays SI-3's job.
- The rich `SessionEndModal` (stats/highlights/ManaPips, 4 states) is **forward-refactor** (depends on a not-yet-existing `useLiveSessionStore`) — SI-8 ships the focused 3-way selector, not the full modal.

## Testing
- BE: domain `Close` (5) + handler IDOR/idempotency/404/success (5) + **60 SessionTracking** green; `dotnet build` 0 errors.
- FE: selector 3-outcome + error (5) + hook (2) + **660 gamebook** suite green; `pnpm typecheck` 0, ESLint 0.
- Note: the adversarial multi-agent review was blocked by transient API rate/session limits; local coverage exercises exactly its lenses (IDOR 403 + no-save, idempotency 409 + outcome unchanged, 3 outcomes + error path, i18n both catalogs, token compliance via lint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)