### PR TITLE
fix(security): #2655 session media/chat authz resolved server-side (CWE-639)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/ChatCommandHandlers.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/ChatCommandHandlers.cs
@@ -273,10 +273,14 @@ internal class AskSessionAgentCommandHandler : IRequestHandler<AskSessionAgentCo
 public class DeleteChatMessageCommandHandler : IRequestHandler<DeleteChatMessageCommand, Unit>
 {
     private readonly ISessionChatRepository _chatRepository;
+    private readonly ISessionRepository _sessionRepository;
 
-    public DeleteChatMessageCommandHandler(ISessionChatRepository chatRepository)
+    public DeleteChatMessageCommandHandler(
+        ISessionChatRepository chatRepository,
+        ISessionRepository sessionRepository)
     {
         _chatRepository = chatRepository;
+        _sessionRepository = sessionRepository;
     }
 
     public async Task<Unit> Handle(DeleteChatMessageCommand request, CancellationToken cancellationToken)
@@ -284,11 +288,19 @@ public class DeleteChatMessageCommandHandler : IRequestHandler<DeleteChatMessage
         var message = await _chatRepository.GetByIdAsync(request.MessageId, cancellationToken).ConfigureAwait(false)
             ?? throw new NotFoundException($"Message {request.MessageId} not found");
 
-        if (message.SenderId.HasValue && message.SenderId.Value != request.RequesterId)
-            throw new ForbiddenException("Only the message sender can delete it.");
-
         if (message.MessageType != SessionChatMessageType.Text)
             throw new InvalidOperationException("Only text messages can be deleted.");
+
+        // #2655 IDOR guard: resolve the sending participant server-side from the
+        // authenticated caller — never trust a client-supplied requester id. Only
+        // the user who owns the sending participant may delete the message.
+        var session = await _sessionRepository.GetByIdAsync(message.SessionId, cancellationToken).ConfigureAwait(false)
+            ?? throw new NotFoundException($"Session {message.SessionId} not found");
+        var sender = message.SenderId.HasValue
+            ? session.Participants.FirstOrDefault(p => p.Id == message.SenderId.Value)
+            : null;
+        if (sender is null || sender.UserId != request.RequesterUserId)
+            throw new ForbiddenException("Only the message sender can delete it.");
 
         message.SoftDelete();
         await _chatRepository.UpdateAsync(message, cancellationToken).ConfigureAwait(false);

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/ChatCommandValidators.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/ChatCommandValidators.cs
@@ -55,6 +55,6 @@ public class DeleteChatMessageCommandValidator : AbstractValidator<DeleteChatMes
     public DeleteChatMessageCommandValidator()
     {
         RuleFor(x => x.MessageId).NotEmpty();
-        RuleFor(x => x.RequesterId).NotEmpty();
+        RuleFor(x => x.RequesterUserId).NotEmpty();
     }
 }

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/ChatCommands.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/ChatCommands.cs
@@ -53,7 +53,9 @@ public record AskSessionAgentResult(
 /// <summary>
 /// Command to delete a chat message.
 /// </summary>
+/// <param name="MessageId">Message to soft-delete.</param>
+/// <param name="RequesterUserId">Authenticated caller — must own the participant that sent the message (#2655 IDOR guard). Never sourced from the client query string.</param>
 public record DeleteChatMessageCommand(
     Guid MessageId,
-    Guid RequesterId
+    Guid RequesterUserId
 ) : IRequest<Unit>;

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/MediaCommandHandlers.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/MediaCommandHandlers.cs
@@ -99,13 +99,16 @@ public class UpdateMediaCaptionCommandHandler : IRequestHandler<UpdateMediaCapti
 public class DeleteSessionMediaCommandHandler : IRequestHandler<DeleteSessionMediaCommand, Unit>
 {
     private readonly ISessionMediaRepository _mediaRepository;
+    private readonly ISessionRepository _sessionRepository;
     private readonly IMediator _mediator;
 
     public DeleteSessionMediaCommandHandler(
         ISessionMediaRepository mediaRepository,
+        ISessionRepository sessionRepository,
         IMediator mediator)
     {
         _mediaRepository = mediaRepository;
+        _sessionRepository = sessionRepository;
         _mediator = mediator;
     }
 
@@ -114,7 +117,13 @@ public class DeleteSessionMediaCommandHandler : IRequestHandler<DeleteSessionMed
         var media = await _mediaRepository.GetByIdAsync(request.MediaId, cancellationToken).ConfigureAwait(false)
             ?? throw new NotFoundException($"Media {request.MediaId} not found");
 
-        if (media.ParticipantId != request.ParticipantId)
+        // #2655 IDOR guard: resolve the owning participant server-side from the
+        // authenticated caller — never trust a client-supplied participant id.
+        // Only the user who owns the uploading participant may delete the media.
+        var session = await _sessionRepository.GetByIdAsync(media.SessionId, cancellationToken).ConfigureAwait(false)
+            ?? throw new NotFoundException($"Session {media.SessionId} not found");
+        var owner = session.Participants.FirstOrDefault(p => p.Id == media.ParticipantId);
+        if (owner is null || owner.UserId != request.RequesterUserId)
             throw new ForbiddenException("Only the media owner can delete it.");
 
         media.SoftDelete();
@@ -125,7 +134,7 @@ public class DeleteSessionMediaCommandHandler : IRequestHandler<DeleteSessionMed
         {
             SessionId = media.SessionId,
             MediaId = media.Id,
-            ParticipantId = request.ParticipantId,
+            ParticipantId = media.ParticipantId,
         }, cancellationToken).ConfigureAwait(false);
 
         return Unit.Value;

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/MediaCommandHandlers.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/MediaCommandHandlers.cs
@@ -71,10 +71,14 @@ public class UploadSessionMediaCommandHandler : IRequestHandler<UploadSessionMed
 public class UpdateMediaCaptionCommandHandler : IRequestHandler<UpdateMediaCaptionCommand, Unit>
 {
     private readonly ISessionMediaRepository _mediaRepository;
+    private readonly ISessionRepository _sessionRepository;
 
-    public UpdateMediaCaptionCommandHandler(ISessionMediaRepository mediaRepository)
+    public UpdateMediaCaptionCommandHandler(
+        ISessionMediaRepository mediaRepository,
+        ISessionRepository sessionRepository)
     {
         _mediaRepository = mediaRepository;
+        _sessionRepository = sessionRepository;
     }
 
     public async Task<Unit> Handle(UpdateMediaCaptionCommand request, CancellationToken cancellationToken)
@@ -82,7 +86,12 @@ public class UpdateMediaCaptionCommandHandler : IRequestHandler<UpdateMediaCapti
         var media = await _mediaRepository.GetByIdAsync(request.MediaId, cancellationToken).ConfigureAwait(false)
             ?? throw new NotFoundException($"Media {request.MediaId} not found");
 
-        if (media.ParticipantId != request.ParticipantId)
+        // #2655 IDOR guard: resolve the owning participant server-side from the
+        // authenticated caller — never trust a client-supplied participant id.
+        var session = await _sessionRepository.GetByIdAsync(media.SessionId, cancellationToken).ConfigureAwait(false)
+            ?? throw new NotFoundException($"Session {media.SessionId} not found");
+        var owner = session.Participants.FirstOrDefault(p => p.Id == media.ParticipantId);
+        if (owner is null || owner.UserId != request.RequesterUserId)
             throw new ForbiddenException("Only the media owner can update the caption.");
 
         media.UpdateCaption(request.Caption);

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/MediaCommandValidators.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/MediaCommandValidators.cs
@@ -26,7 +26,7 @@ public class UpdateMediaCaptionCommandValidator : AbstractValidator<UpdateMediaC
     public UpdateMediaCaptionCommandValidator()
     {
         RuleFor(x => x.MediaId).NotEmpty();
-        RuleFor(x => x.ParticipantId).NotEmpty();
+        RuleFor(x => x.RequesterUserId).NotEmpty();
         RuleFor(x => x.Caption).MaximumLength(500).When(x => x.Caption != null);
     }
 }

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/MediaCommandValidators.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/MediaCommandValidators.cs
@@ -36,6 +36,6 @@ public class DeleteSessionMediaCommandValidator : AbstractValidator<DeleteSessio
     public DeleteSessionMediaCommandValidator()
     {
         RuleFor(x => x.MediaId).NotEmpty();
-        RuleFor(x => x.ParticipantId).NotEmpty();
+        RuleFor(x => x.RequesterUserId).NotEmpty();
     }
 }

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/MediaCommands.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/MediaCommands.cs
@@ -24,9 +24,12 @@ public record UploadSessionMediaResult(Guid MediaId);
 /// <summary>
 /// Command to update media caption.
 /// </summary>
+/// <param name="MediaId">Media whose caption to update.</param>
+/// <param name="RequesterUserId">Authenticated caller — must own the participant that uploaded the media (#2655 IDOR guard). Set server-side; any client-supplied value is overridden.</param>
+/// <param name="Caption">New caption text.</param>
 public record UpdateMediaCaptionCommand(
     Guid MediaId,
-    Guid ParticipantId,
+    Guid RequesterUserId,
     string? Caption
 ) : IRequest<Unit>;
 

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/MediaCommands.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/MediaCommands.cs
@@ -33,8 +33,10 @@ public record UpdateMediaCaptionCommand(
 /// <summary>
 /// Command to delete media from a session.
 /// </summary>
+/// <param name="MediaId">Media to soft-delete.</param>
+/// <param name="RequesterUserId">Authenticated caller — must own the participant that uploaded the media (#2655 IDOR guard). Never sourced from the client query string.</param>
 public record DeleteSessionMediaCommand(
     Guid MediaId,
-    Guid ParticipantId
+    Guid RequesterUserId
 ) : IRequest<Unit>;
 

--- a/apps/api/src/Api/Routing/SessionTracking/SessionPlayerActionsEndpoints.cs
+++ b/apps/api/src/Api/Routing/SessionTracking/SessionPlayerActionsEndpoints.cs
@@ -516,15 +516,22 @@ internal static class SessionPlayerActionsEndpoints
 
     private static void MapDeleteSessionMediaEndpoint(RouteGroupBuilder group)
     {
-        // Note: participantId comes from query string. Future auth refactor should extract from HttpContext.User.
+        // #2655: the deleting participant is resolved server-side from the
+        // authenticated user — no longer trusted from the client query string.
         group.MapDelete("/game-sessions/{sessionId:guid}/media/{mediaId:guid}", async (
             Guid sessionId,
             Guid mediaId,
-            Guid participantId,
+            HttpContext httpContext,
             IMediator mediator,
             CancellationToken ct) =>
         {
-            var command = new DeleteSessionMediaCommand(mediaId, participantId);
+            var userId = httpContext.User.GetUserId();
+            if (userId == Guid.Empty)
+            {
+                return Results.Unauthorized();
+            }
+
+            var command = new DeleteSessionMediaCommand(mediaId, userId);
             await mediator.Send(command, ct).ConfigureAwait(false);
             return Results.NoContent();
         })
@@ -643,15 +650,22 @@ internal static class SessionPlayerActionsEndpoints
 
     private static void MapDeleteChatMessageEndpoint(RouteGroupBuilder group)
     {
-        // Note: requesterId comes from query string. Future auth refactor should extract from HttpContext.User.
+        // #2655: the requesting sender is resolved server-side from the
+        // authenticated user — no longer trusted from the client query string.
         group.MapDelete("/game-sessions/{sessionId:guid}/chat/{messageId:guid}", async (
             Guid sessionId,
             Guid messageId,
-            Guid requesterId,
+            HttpContext httpContext,
             IMediator mediator,
             CancellationToken ct) =>
         {
-            var command = new DeleteChatMessageCommand(messageId, requesterId);
+            var userId = httpContext.User.GetUserId();
+            if (userId == Guid.Empty)
+            {
+                return Results.Unauthorized();
+            }
+
+            var command = new DeleteChatMessageCommand(messageId, userId);
             await mediator.Send(command, ct).ConfigureAwait(false);
             return Results.NoContent();
         })

--- a/apps/api/src/Api/Routing/SessionTracking/SessionPlayerActionsEndpoints.cs
+++ b/apps/api/src/Api/Routing/SessionTracking/SessionPlayerActionsEndpoints.cs
@@ -492,6 +492,7 @@ internal static class SessionPlayerActionsEndpoints
             Guid sessionId,
             Guid mediaId,
             UpdateMediaCaptionCommand command,
+            HttpContext httpContext,
             IMediator mediator,
             CancellationToken ct) =>
         {
@@ -500,7 +501,15 @@ internal static class SessionPlayerActionsEndpoints
                 return Results.BadRequest(new { error = "Media ID mismatch" });
             }
 
-            await mediator.Send(command, ct).ConfigureAwait(false);
+            // #2655: the owning participant is resolved server-side from the
+            // authenticated user; any client-supplied RequesterUserId is overridden.
+            var userId = httpContext.User.GetUserId();
+            if (userId == Guid.Empty)
+            {
+                return Results.Unauthorized();
+            }
+
+            await mediator.Send(command with { RequesterUserId = userId }, ct).ConfigureAwait(false);
             return Results.NoContent();
         })
         .RequireAuthenticatedUser()

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Handlers/ChatCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Handlers/ChatCommandHandlerTests.cs
@@ -281,25 +281,49 @@ public class AskSessionAgentCommandHandlerTests
 public class DeleteChatMessageCommandHandlerTests
 {
     private readonly Mock<ISessionChatRepository> _mockChatRepo;
+    private readonly Mock<ISessionRepository> _mockSessionRepo;
     private readonly DeleteChatMessageCommandHandler _handler;
 
     public DeleteChatMessageCommandHandlerTests()
     {
         _mockChatRepo = new Mock<ISessionChatRepository>();
-        _handler = new DeleteChatMessageCommandHandler(_mockChatRepo.Object);
+        _mockSessionRepo = new Mock<ISessionRepository>();
+        _handler = new DeleteChatMessageCommandHandler(_mockChatRepo.Object, _mockSessionRepo.Object);
+    }
+
+    private static Session CreateSessionWithParticipant(Guid sessionId, Guid participantId, Guid? ownerUserId)
+    {
+        var session = Session.Create(
+            userId: Guid.NewGuid(),
+            gameId: Guid.NewGuid(),
+            sessionType: SessionType.GameSpecific);
+
+        typeof(Session).GetProperty("Id")!.SetValue(session, sessionId);
+
+        var participant = new Participant { Id = participantId, SessionId = sessionId, UserId = ownerUserId };
+        var participantsField = typeof(Session).GetField("_participants",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        var list = (List<Participant>)participantsField!.GetValue(session)!;
+        list.Add(participant);
+
+        return session;
     }
 
     [Fact]
-    public async Task Handle_ValidCommand_SoftDeletesTextMessage()
+    public async Task Handle_SenderDeletes_SoftDeletesTextMessage()
     {
-        // Arrange
-        var senderId = Guid.NewGuid();
-        var message = SessionChatMessage.CreateTextMessage(Guid.NewGuid(), senderId, "Hello", 1);
+        // Arrange — the authenticated user owns the participant that sent the message.
+        var sessionId = Guid.NewGuid();
+        var senderParticipantId = Guid.NewGuid();
+        var ownerUserId = Guid.NewGuid();
+        var message = SessionChatMessage.CreateTextMessage(sessionId, senderParticipantId, "Hello", 1);
 
         _mockChatRepo.Setup(r => r.GetByIdAsync(message.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(message);
+        _mockSessionRepo.Setup(r => r.GetByIdAsync(sessionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateSessionWithParticipant(sessionId, senderParticipantId, ownerUserId));
 
-        var command = new DeleteChatMessageCommand(message.Id, senderId);
+        var command = new DeleteChatMessageCommand(message.Id, ownerUserId);
 
         // Act
         await _handler.Handle(command, TestContext.Current.CancellationToken);
@@ -324,15 +348,23 @@ public class DeleteChatMessageCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_DifferentSender_ThrowsForbiddenException()
+    public async Task Handle_DifferentUser_ThrowsForbiddenException()
     {
-        var senderId = Guid.NewGuid();
-        var message = SessionChatMessage.CreateTextMessage(Guid.NewGuid(), senderId, "Hello", 1);
+        // Arrange — #2655 IDOR fix: a user who does NOT own the sending participant
+        // cannot delete the message, even by forging a requester id (now resolved
+        // server-side from the authenticated caller).
+        var sessionId = Guid.NewGuid();
+        var senderParticipantId = Guid.NewGuid();
+        var ownerUserId = Guid.NewGuid();
+        var attackerUserId = Guid.NewGuid();
+        var message = SessionChatMessage.CreateTextMessage(sessionId, senderParticipantId, "Hello", 1);
 
         _mockChatRepo.Setup(r => r.GetByIdAsync(message.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(message);
+        _mockSessionRepo.Setup(r => r.GetByIdAsync(sessionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateSessionWithParticipant(sessionId, senderParticipantId, ownerUserId));
 
-        var command = new DeleteChatMessageCommand(message.Id, Guid.NewGuid());
+        var command = new DeleteChatMessageCommand(message.Id, attackerUserId);
 
         var act6 = () => _handler.Handle(command, TestContext.Current.CancellationToken);
         await act6.Should().ThrowAsync<ForbiddenException>();
@@ -343,16 +375,15 @@ public class DeleteChatMessageCommandHandlerTests
     [Fact]
     public async Task Handle_SystemEventMessage_ThrowsInvalidOperationException()
     {
+        // Non-text messages are rejected by the type check, which runs before the
+        // ownership resolution — so no session lookup is needed here.
         var message = SessionChatMessage.CreateSystemEvent(Guid.NewGuid(), "event", 1);
 
         _mockChatRepo.Setup(r => r.GetByIdAsync(message.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(message);
 
-        // System messages have no sender, so requesterId won't match but the type check comes first
         var command = new DeleteChatMessageCommand(message.Id, Guid.NewGuid());
 
-        // SenderId is null for system events, so ForbiddenException won't fire (null != requesterId is false with HasValue check)
-        // Instead, it reaches the MessageType check
         var act7 = () => _handler.Handle(command, TestContext.Current.CancellationToken);
         await act7.Should().ThrowAsync<InvalidOperationException>();
     }

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Handlers/MediaCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Handlers/MediaCommandHandlerTests.cs
@@ -191,28 +191,53 @@ public class UpdateMediaCaptionCommandHandlerTests
 public class DeleteSessionMediaCommandHandlerTests
 {
     private readonly Mock<ISessionMediaRepository> _mockMediaRepo;
+    private readonly Mock<ISessionRepository> _mockSessionRepo;
     private readonly Mock<IMediator> _mockMediator;
     private readonly DeleteSessionMediaCommandHandler _handler;
 
     public DeleteSessionMediaCommandHandlerTests()
     {
         _mockMediaRepo = new Mock<ISessionMediaRepository>();
+        _mockSessionRepo = new Mock<ISessionRepository>();
         _mockMediator = new Mock<IMediator>();
-        _handler = new DeleteSessionMediaCommandHandler(_mockMediaRepo.Object, _mockMediator.Object);
+        _handler = new DeleteSessionMediaCommandHandler(
+            _mockMediaRepo.Object, _mockSessionRepo.Object, _mockMediator.Object);
+    }
+
+    private static Session CreateSessionWithParticipant(Guid sessionId, Guid participantId, Guid? ownerUserId)
+    {
+        var session = Session.Create(
+            userId: Guid.NewGuid(),
+            gameId: Guid.NewGuid(),
+            sessionType: SessionType.GameSpecific);
+
+        typeof(Session).GetProperty("Id")!.SetValue(session, sessionId);
+
+        var participant = new Participant { Id = participantId, SessionId = sessionId, UserId = ownerUserId };
+        var participantsField = typeof(Session).GetField("_participants",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        var list = (List<Participant>)participantsField!.GetValue(session)!;
+        list.Add(participant);
+
+        return session;
     }
 
     [Fact]
-    public async Task Handle_ValidCommand_SoftDeletesAndPublishesEvent()
+    public async Task Handle_OwnerDeletes_SoftDeletesAndPublishesEvent()
     {
-        // Arrange
+        // Arrange — the authenticated user owns the participant that uploaded the media.
+        var sessionId = Guid.NewGuid();
         var participantId = Guid.NewGuid();
+        var ownerUserId = Guid.NewGuid();
         var media = SessionMedia.Create(
-            Guid.NewGuid(), participantId, "f", "f.jpg", "image/jpeg", 100, SessionMediaType.Photo);
+            sessionId, participantId, "f", "f.jpg", "image/jpeg", 100, SessionMediaType.Photo);
 
         _mockMediaRepo.Setup(r => r.GetByIdAsync(media.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(media);
+        _mockSessionRepo.Setup(r => r.GetByIdAsync(sessionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateSessionWithParticipant(sessionId, participantId, ownerUserId));
 
-        var command = new DeleteSessionMediaCommand(media.Id, participantId);
+        var command = new DeleteSessionMediaCommand(media.Id, ownerUserId);
 
         // Act
         await _handler.Handle(command, TestContext.Current.CancellationToken);
@@ -238,16 +263,24 @@ public class DeleteSessionMediaCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_DifferentParticipant_ThrowsForbiddenException()
+    public async Task Handle_DifferentUser_ThrowsForbiddenException()
     {
+        // Arrange — #2655 IDOR fix: a user who does NOT own the media's participant
+        // cannot delete it, even by passing a forged participant id (the id is now
+        // resolved server-side from the authenticated caller).
+        var sessionId = Guid.NewGuid();
         var participantId = Guid.NewGuid();
+        var ownerUserId = Guid.NewGuid();
+        var attackerUserId = Guid.NewGuid();
         var media = SessionMedia.Create(
-            Guid.NewGuid(), participantId, "f", "f.jpg", "image/jpeg", 100, SessionMediaType.Photo);
+            sessionId, participantId, "f", "f.jpg", "image/jpeg", 100, SessionMediaType.Photo);
 
         _mockMediaRepo.Setup(r => r.GetByIdAsync(media.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(media);
+        _mockSessionRepo.Setup(r => r.GetByIdAsync(sessionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateSessionWithParticipant(sessionId, participantId, ownerUserId));
 
-        var command = new DeleteSessionMediaCommand(media.Id, Guid.NewGuid());
+        var command = new DeleteSessionMediaCommand(media.Id, attackerUserId);
 
         var act6 = () => _handler.Handle(command, TestContext.Current.CancellationToken);
         await act6.Should().ThrowAsync<ForbiddenException>();

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Handlers/MediaCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Handlers/MediaCommandHandlerTests.cs
@@ -124,26 +124,50 @@ public class UploadSessionMediaCommandHandlerTests
 public class UpdateMediaCaptionCommandHandlerTests
 {
     private readonly Mock<ISessionMediaRepository> _mockMediaRepo;
+    private readonly Mock<ISessionRepository> _mockSessionRepo;
     private readonly UpdateMediaCaptionCommandHandler _handler;
 
     public UpdateMediaCaptionCommandHandlerTests()
     {
         _mockMediaRepo = new Mock<ISessionMediaRepository>();
-        _handler = new UpdateMediaCaptionCommandHandler(_mockMediaRepo.Object);
+        _mockSessionRepo = new Mock<ISessionRepository>();
+        _handler = new UpdateMediaCaptionCommandHandler(_mockMediaRepo.Object, _mockSessionRepo.Object);
+    }
+
+    private static Session CreateSessionWithParticipant(Guid sessionId, Guid participantId, Guid? ownerUserId)
+    {
+        var session = Session.Create(
+            userId: Guid.NewGuid(),
+            gameId: Guid.NewGuid(),
+            sessionType: SessionType.GameSpecific);
+
+        typeof(Session).GetProperty("Id")!.SetValue(session, sessionId);
+
+        var participant = new Participant { Id = participantId, SessionId = sessionId, UserId = ownerUserId };
+        var participantsField = typeof(Session).GetField("_participants",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        var list = (List<Participant>)participantsField!.GetValue(session)!;
+        list.Add(participant);
+
+        return session;
     }
 
     [Fact]
-    public async Task Handle_ValidCommand_UpdatesCaptionAndSaves()
+    public async Task Handle_OwnerUpdates_UpdatesCaptionAndSaves()
     {
-        // Arrange
+        // Arrange — the authenticated user owns the participant that uploaded the media.
+        var sessionId = Guid.NewGuid();
         var participantId = Guid.NewGuid();
+        var ownerUserId = Guid.NewGuid();
         var media = SessionMedia.Create(
-            Guid.NewGuid(), participantId, "f", "f.jpg", "image/jpeg", 100, SessionMediaType.Photo, "old");
+            sessionId, participantId, "f", "f.jpg", "image/jpeg", 100, SessionMediaType.Photo, "old");
 
         _mockMediaRepo.Setup(r => r.GetByIdAsync(media.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(media);
+        _mockSessionRepo.Setup(r => r.GetByIdAsync(sessionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateSessionWithParticipant(sessionId, participantId, ownerUserId));
 
-        var command = new UpdateMediaCaptionCommand(media.Id, participantId, "new caption");
+        var command = new UpdateMediaCaptionCommand(media.Id, ownerUserId, "new caption");
 
         // Act
         await _handler.Handle(command, TestContext.Current.CancellationToken);
@@ -168,16 +192,23 @@ public class UpdateMediaCaptionCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_DifferentParticipant_ThrowsForbiddenException()
+    public async Task Handle_DifferentUser_ThrowsForbiddenException()
     {
+        // Arrange — #2655 IDOR fix: a user who does NOT own the media's participant
+        // cannot edit its caption, even by forging a participant id.
+        var sessionId = Guid.NewGuid();
         var participantId = Guid.NewGuid();
+        var ownerUserId = Guid.NewGuid();
+        var attackerUserId = Guid.NewGuid();
         var media = SessionMedia.Create(
-            Guid.NewGuid(), participantId, "f", "f.jpg", "image/jpeg", 100, SessionMediaType.Photo);
+            sessionId, participantId, "f", "f.jpg", "image/jpeg", 100, SessionMediaType.Photo);
 
         _mockMediaRepo.Setup(r => r.GetByIdAsync(media.Id, It.IsAny<CancellationToken>()))
             .ReturnsAsync(media);
+        _mockSessionRepo.Setup(r => r.GetByIdAsync(sessionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateSessionWithParticipant(sessionId, participantId, ownerUserId));
 
-        var command = new UpdateMediaCaptionCommand(media.Id, Guid.NewGuid(), "hacked caption");
+        var command = new UpdateMediaCaptionCommand(media.Id, attackerUserId, "hacked caption");
 
         var act4 = () => _handler.Handle(command, TestContext.Current.CancellationToken);
         await act4.Should().ThrowAsync<ForbiddenException>();

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Validators/ChatCommandValidatorTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Validators/ChatCommandValidatorTests.cs
@@ -124,7 +124,7 @@ public class DeleteChatMessageCommandValidatorTests
     }
 
     [Fact]
-    public void Validate_EmptyRequesterId_ShouldFail()
+    public void Validate_EmptyRequesterUserId_ShouldFail()
     {
         var cmd = new DeleteChatMessageCommand(Guid.NewGuid(), Guid.Empty);
         var result = _validator.Validate(cmd);

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Validators/MediaCommandValidatorTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Validators/MediaCommandValidatorTests.cs
@@ -207,7 +207,7 @@ public class DeleteSessionMediaCommandValidatorTests
     }
 
     [Fact]
-    public void Validate_EmptyParticipantId_ShouldFail()
+    public void Validate_EmptyRequesterUserId_ShouldFail()
     {
         var cmd = new DeleteSessionMediaCommand(Guid.NewGuid(), Guid.Empty);
         var result = _validator.Validate(cmd);

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Validators/MediaCommandValidatorTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Validators/MediaCommandValidatorTests.cs
@@ -168,7 +168,7 @@ public class UpdateMediaCaptionCommandValidatorTests
     }
 
     [Fact]
-    public void Validate_EmptyParticipantId_ShouldFail()
+    public void Validate_EmptyRequesterUserId_ShouldFail()
     {
         var cmd = new UpdateMediaCaptionCommand(Guid.NewGuid(), Guid.Empty, "Caption");
         var result = _validator.Validate(cmd);


### PR DESCRIPTION
## Security fix — CWE-639 (query-string authorization bypass)

Part of the #2655 Q3 Security Review remediation. STEP 5 confirmed 2 High findings (#5/#6).

### Problem
`DELETE /game-sessions/{id}/media/{mediaId}` and `.../chat/{messageId}` took the **authorizing identity** (`participantId` / `requesterId`) straight from the **client query string**. The handlers checked ownership against that value, so an attacker could pass the victim's participant/sender id and delete another user's media or chat message.

### Fix — identity resolved server-side
- Endpoints extract `httpContext.User.GetUserId()` (401 when empty) and pass it as `RequesterUserId`; the query-string params are removed.
- Commands renamed `ParticipantId`/`RequesterId` → `RequesterUserId` (a **user** id).
- Handlers inject `ISessionRepository`, resolve the owning/sending participant from the media/message `SessionId`, and throw `ForbiddenException` unless that participant's `UserId == RequesterUserId`. Chat keeps the "text only" type check **first** (system/agent messages still 400 before the ownership resolution — no null deref).
- Validators require `RequesterUserId NotEmpty`.

### Sibling gap also closed (found by review)
`PUT /game-sessions/{id}/media/{mediaId}/caption` (`UpdateMediaCaption`) shared the identical CWE-639 pattern (ownership checked against a client-supplied `ParticipantId` from the body). Fixed the same way: the endpoint overrides the field server-side (`command with { RequesterUserId = userId }`) and the handler resolves the owner via the session. This prevents caption-tampering on another user's media.

### Notes
- Guest-owned entries (participant `UserId` null) are denied to authenticated users (`null != realGuid` → 403) — acceptable.
- The media deleted-event now sources `ParticipantId` from `media.ParticipantId` (semantically identical to the pre-fix success path).
- `ISessionRepository` is already DI-registered (used by sibling handlers); no new registration needed. No integration/E2E test hits these endpoints with the removed query param.

### Testing (TDD)
RED tests: a different authenticated user is denied even with a forged id; the owner succeeds; not-found + non-text cases preserved. **34/34** media/chat authz unit tests green.

Adversarial review (feature-dev:code-reviewer) on the DELETE fix: all 5 points SOUND, IDOR 100% server-derived; it surfaced the caption sibling (fixed here).

Refs #2655.

🤖 Generated with [Claude Code](https://claude.com/claude-code)