### PR TITLE
fix(security): #2655 impersonation /end ownership guard (IDOR #9)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/ImpersonationEndCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Commands/ImpersonationEndCommandHandler.cs
@@ -1,4 +1,6 @@
 using Api.BoundedContexts.Authentication.Application.Commands;
+using Api.BoundedContexts.Authentication.Infrastructure.Persistence;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Application.Interfaces;
 using MediatR;
 using Microsoft.Extensions.Logging;
@@ -12,18 +14,29 @@ namespace Api.BoundedContexts.Administration.Application.Commands;
 /// Audit is written by <c>AuditLoggingBehavior</c> (the command is <c>[AuditableAction]</c>),
 /// replacing the legacy manual <c>IAuditLogRepository.AddAsync</c> call (issue #1534). The
 /// handler therefore no longer takes <c>IAuditLogRepository</c> or <c>IUnitOfWork</c>.
+///
+/// <para>Q3 Security (#2655, finding #9): this is a SELF-END endpoint — the acting admin ends
+/// their OWN impersonation. Before delegating to the (admin-privileged) generic revoke, the
+/// handler verifies ownership: the target session must (1) exist, (2) be an active impersonation
+/// and (3) have been started by the requesting admin (<c>ImpersonatedByUserId == RequestingUserId</c>).
+/// Without these guards any admin could revoke an arbitrary session id — force-logging-out any
+/// user, or killing another admin's impersonation (that is the superadmin-only <c>/revoke</c>
+/// kill-switch, <see cref="RevokeImpersonationCommandHandler"/>).</para>
 /// </summary>
 internal sealed class ImpersonationEndCommandHandler
     : ICommandHandler<ImpersonationEndCommand, bool>
 {
     private readonly IMediator _mediator;
+    private readonly ISessionRepository _sessionRepository;
     private readonly ILogger<ImpersonationEndCommandHandler> _logger;
 
     public ImpersonationEndCommandHandler(
         IMediator mediator,
+        ISessionRepository sessionRepository,
         ILogger<ImpersonationEndCommandHandler> logger)
     {
         _mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
+        _sessionRepository = sessionRepository ?? throw new ArgumentNullException(nameof(sessionRepository));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -33,6 +46,37 @@ internal sealed class ImpersonationEndCommandHandler
 
         _logger.LogWarning("SECURITY: admin {RequesterId} ending impersonation session {SessionId}",
             command.RequestingUserId, command.SessionId);
+
+        // Ownership guards (finding #9) — run BEFORE any state-changing delegation. Ordering keeps
+        // us from leaking the revoke-state of sessions the caller does not own: not-found → 404,
+        // non-impersonation or another admin's impersonation → 403, then idempotent already-revoked.
+        var session = await _sessionRepository.GetByIdAsync(command.SessionId, cancellationToken)
+            .ConfigureAwait(false);
+        if (session is null)
+        {
+            _logger.LogWarning("Impersonation end: session {SessionId} not found", command.SessionId);
+            throw new NotFoundException($"Session '{command.SessionId}' not found");
+        }
+        if (!session.IsImpersonation)
+        {
+            _logger.LogWarning(
+                "SECURITY: admin {RequesterId} attempted to end non-impersonation session {SessionId}",
+                command.RequestingUserId, command.SessionId);
+            throw new ForbiddenException("Session is not an impersonation session");
+        }
+        if (session.ImpersonatedByUserId != command.RequestingUserId)
+        {
+            _logger.LogWarning(
+                "SECURITY: admin {RequesterId} attempted to end impersonation session {SessionId} started by {OwnerId}",
+                command.RequestingUserId, command.SessionId, session.ImpersonatedByUserId);
+            throw new ForbiddenException("You can only end an impersonation session you started");
+        }
+        if (session.IsRevoked())
+        {
+            // Idempotent: the caller's own impersonation is already revoked — nothing to do.
+            _logger.LogInformation("Impersonation session {SessionId} already revoked", command.SessionId);
+            return true;
+        }
 
         // Revoke the session using the existing generic session-revoke command. RevokeSessionCommand
         // handles the not-found / already-revoked cases and returns a structured result.

--- a/apps/api/src/Api/Routing/Admin/AdminImpersonationEndpoints.cs
+++ b/apps/api/src/Api/Routing/Admin/AdminImpersonationEndpoints.cs
@@ -72,7 +72,9 @@ internal static class AdminImpersonationEndpoints
         .WithSummary("End an active impersonation session (admin)")
         .Produces(StatusCodes.Status200OK)
         .Produces(StatusCodes.Status400BadRequest)
-        .Produces(StatusCodes.Status401Unauthorized);
+        .Produces(StatusCodes.Status401Unauthorized)
+        .Produces(StatusCodes.Status403Forbidden)
+        .Produces(StatusCodes.Status404NotFound);
 
         // REVOKE — superadmin kill-switch for another admin's impersonation session.
         impersonationGroup.MapPost("/revoke", async (

--- a/apps/api/tests/Api.Tests/BoundedContexts/Administration/Application/Commands/ImpersonationEndCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Administration/Application/Commands/ImpersonationEndCommandHandlerTests.cs
@@ -1,0 +1,181 @@
+using Api.BoundedContexts.Administration.Application.Commands;
+using Api.BoundedContexts.Authentication.Application.Commands;
+using Api.BoundedContexts.Authentication.Domain.Entities;
+using Api.BoundedContexts.Authentication.Domain.ValueObjects;
+using Api.BoundedContexts.Authentication.Infrastructure.Persistence;
+using Api.Middleware.Exceptions;
+using Api.Tests.Constants;
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Time.Testing;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.Administration.Application.Commands;
+
+/// <summary>
+/// Unit tests for <see cref="ImpersonationEndCommandHandler"/> (SP5 Admin Security S2 — T4).
+///
+/// Q3 Security (#2655, finding #9): the self-end endpoint must NOT revoke an arbitrary session.
+/// It may only end a session that (1) is an active impersonation and (2) was started by the
+/// requesting admin (<c>ImpersonatedByUserId == RequestingUserId</c>). Any other target is
+/// rejected — a non-impersonation login session or another admin's impersonation cannot be
+/// terminated through this endpoint (the superadmin kill-switch <c>/revoke</c> handles those).
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+public class ImpersonationEndCommandHandlerTests
+{
+    private readonly Mock<IMediator> _mockMediator;
+    private readonly Mock<ISessionRepository> _mockSessionRepository;
+    private readonly FakeTimeProvider _timeProvider;
+    private readonly ImpersonationEndCommandHandler _handler;
+
+    public ImpersonationEndCommandHandlerTests()
+    {
+        _mockMediator = new Mock<IMediator>();
+        _mockSessionRepository = new Mock<ISessionRepository>();
+        _timeProvider = new FakeTimeProvider(DateTimeOffset.Parse("2026-07-07T12:00:00Z"));
+
+        _handler = new ImpersonationEndCommandHandler(
+            _mockMediator.Object,
+            _mockSessionRepository.Object,
+            Mock.Of<ILogger<ImpersonationEndCommandHandler>>());
+    }
+
+    [Fact]
+    public async Task Handle_HappyPath_SelfEnd_RevokesViaRevokeSessionCommand()
+    {
+        // Arrange — admin alice ends her OWN impersonation of bob.
+        var aliceId = Guid.NewGuid();   // acting admin == session.ImpersonatedByUserId
+        var bobId = Guid.NewGuid();     // subject == session.UserId
+        var sessionId = Guid.NewGuid();
+
+        var session = CreateImpersonationSession(sessionId, subjectId: bobId, actorId: aliceId);
+        _mockSessionRepository
+            .Setup(r => r.GetByIdAsync(sessionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(session);
+        _mockMediator
+            .Setup(m => m.Send(It.IsAny<RevokeSessionCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new RevokeSessionResponse(true, null));
+
+        // Act
+        var result = await _handler.Handle(
+            new ImpersonationEndCommand(sessionId, aliceId), CancellationToken.None);
+
+        // Assert
+        result.Should().BeTrue();
+        _mockMediator.Verify(m => m.Send(
+            It.Is<RevokeSessionCommand>(c => c.SessionId == sessionId && c.IsRequestingUserAdmin),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_SessionNotFound_ThrowsNotFound()
+    {
+        var aliceId = Guid.NewGuid();
+        var sessionId = Guid.NewGuid();
+        _mockSessionRepository
+            .Setup(r => r.GetByIdAsync(sessionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Session?)null);
+
+        var act = () => _handler.Handle(
+            new ImpersonationEndCommand(sessionId, aliceId), CancellationToken.None);
+
+        await act.Should().ThrowAsync<NotFoundException>();
+        _mockMediator.Verify(m => m.Send(It.IsAny<RevokeSessionCommand>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_SessionNotAnImpersonation_ThrowsForbidden()
+    {
+        // A regular login session (ImpersonatedByUserId == null) must not be terminable here,
+        // even by an admin — otherwise any admin can force-logout any user by session id.
+        var aliceId = Guid.NewGuid();
+        var sessionId = Guid.NewGuid();
+
+        var regular = new Session(
+            id: sessionId, userId: Guid.NewGuid(), token: SessionToken.Generate(), timeProvider: _timeProvider);
+        _mockSessionRepository
+            .Setup(r => r.GetByIdAsync(sessionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(regular);
+
+        var act = () => _handler.Handle(
+            new ImpersonationEndCommand(sessionId, aliceId), CancellationToken.None);
+
+        await act.Should().ThrowAsync<ForbiddenException>();
+        _mockMediator.Verify(m => m.Send(It.IsAny<RevokeSessionCommand>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_ImpersonationStartedByAnotherAdmin_ThrowsForbidden()
+    {
+        // CORE of finding #9: admin carol must not be able to end alice's impersonation session.
+        var aliceId = Guid.NewGuid();   // admin who started the impersonation
+        var carolId = Guid.NewGuid();   // a DIFFERENT admin issuing the request
+        var bobId = Guid.NewGuid();
+        var sessionId = Guid.NewGuid();
+
+        var session = CreateImpersonationSession(sessionId, subjectId: bobId, actorId: aliceId);
+        _mockSessionRepository
+            .Setup(r => r.GetByIdAsync(sessionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(session);
+
+        var act = () => _handler.Handle(
+            new ImpersonationEndCommand(sessionId, carolId), CancellationToken.None);
+
+        await act.Should().ThrowAsync<ForbiddenException>();
+        _mockMediator.Verify(m => m.Send(It.IsAny<RevokeSessionCommand>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_SessionAlreadyRevoked_ReturnsTrueIdempotent()
+    {
+        var aliceId = Guid.NewGuid();
+        var bobId = Guid.NewGuid();
+        var sessionId = Guid.NewGuid();
+
+        var session = CreateImpersonationSession(sessionId, subjectId: bobId, actorId: aliceId);
+        session.Revoke(_timeProvider, "already revoked");
+        _mockSessionRepository
+            .Setup(r => r.GetByIdAsync(sessionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(session);
+
+        var result = await _handler.Handle(
+            new ImpersonationEndCommand(sessionId, aliceId), CancellationToken.None);
+
+        result.Should().BeTrue("ending an already-revoked own impersonation is idempotent");
+        _mockMediator.Verify(m => m.Send(It.IsAny<RevokeSessionCommand>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_RevokeSessionFails_ReturnsFalse()
+    {
+        var aliceId = Guid.NewGuid();
+        var bobId = Guid.NewGuid();
+        var sessionId = Guid.NewGuid();
+
+        var session = CreateImpersonationSession(sessionId, subjectId: bobId, actorId: aliceId);
+        _mockSessionRepository
+            .Setup(r => r.GetByIdAsync(sessionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(session);
+        _mockMediator
+            .Setup(m => m.Send(It.IsAny<RevokeSessionCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new RevokeSessionResponse(false, "boom"));
+
+        var result = await _handler.Handle(
+            new ImpersonationEndCommand(sessionId, aliceId), CancellationToken.None);
+
+        result.Should().BeFalse();
+    }
+
+    private Session CreateImpersonationSession(Guid sessionId, Guid subjectId, Guid actorId)
+        => new(
+            id: sessionId,
+            userId: subjectId,
+            token: SessionToken.Generate(),
+            lifetime: TimeSpan.FromMinutes(15),
+            impersonatedByUserId: actorId,
+            impersonatedUntil: _timeProvider.GetUtcNow().UtcDateTime.AddMinutes(15),
+            timeProvider: _timeProvider);
+}


### PR DESCRIPTION
## Q3 Security #2655 — finding #9 (privilege escalation / IDOR, CWE-639)

`POST /api/v1/admin/impersonation/end` (RequireAdmin) delegated to `ImpersonationEndCommandHandler`, which called the generic `RevokeSessionCommand` with `IsRequestingUserAdmin: true` given **only a SessionId**. That let **any** admin:
- revoke **any** session by id → force-logout any user, and
- terminate **another admin's** impersonation session (which should be the superadmin-only `/revoke` kill-switch).

### Fix
Ownership guards in `ImpersonationEndCommandHandler`, run **before** any state-changing delegation:
1. session not found → `NotFoundException` (404)
2. not an impersonation (`!IsImpersonation`) → `ForbiddenException` (403)
3. started by another admin (`ImpersonatedByUserId != RequestingUserId`) → `ForbiddenException` (403)
4. already-revoked (own) → idempotent `true` (placed **after** the ownership checks, so it never leaks revoke-state of sessions the caller does not own)

The fix lives in the **command handler**, so it also covers the legacy duplicate registration of the same route in `AdminUserActivityDetailEndpoints.HandleEndImpersonation`, which delegates to the same `ImpersonationEndCommand`.

The sibling superadmin kill-switch `/revoke` (`RevokeImpersonationCommandHandler`) was already protected (server-side superadmin role check + `IsImpersonation` guard) — verified in review, not bypassable.

### Tests
6 new unit tests in `ImpersonationEndCommandHandlerTests` (happy self-end, not-found→404, non-impersonation→403, another-admin→403, already-revoked idempotent, revoke-fails→false). All green.

Adversarial review clean on the core fix. Two pre-existing, out-of-scope observations reported on #2655 (general admin `DELETE /admin/sessions/{id}` policy; the legacy `/impersonation/end` duplicate route registration — both already covered by the shared patched handler for the security aspect).

Refs #2655