### PR TITLE
fix(security): #2655 SSRF guards on BGG cover + Slack webhook (#10 #11)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/Administration/Infrastructure/External/SlackWebhookClient.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Infrastructure/External/SlackWebhookClient.cs
@@ -1,4 +1,5 @@
 using System.Net.Http.Json;
+using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
 using Api.Helpers;
 
 namespace Api.BoundedContexts.Administration.Infrastructure.External;
@@ -43,6 +44,21 @@ internal sealed class SlackWebhookClient : ISlackWebhookClient
         if (!Uri.TryCreate(webhookUrl, UriKind.Absolute, out var uri))
         {
             return new SlackSendResult(false, "Webhook URL is not a valid absolute URI.");
+        }
+
+        // SSRF guard (#2655 finding #11): a compromised/misconfigured webhook URL must not be able
+        // to reach internal services or the cloud metadata endpoint. Only HTTPS URLs resolving to
+        // public IPs are allowed. The response message stays generic (no resolved IP) and the URL is
+        // never logged (it embeds the webhook secret).
+        try
+        {
+            SsrfSafeHttpClient.ValidateUrlScheme(webhookUrl);
+            await SsrfSafeHttpClient.ValidateResolvedIpAsync(webhookUrl, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is ArgumentException or InvalidOperationException)
+        {
+            _logger.LogWarning(ex, "Slack webhook blocked by SSRF guard");
+            return new SlackSendResult(false, "Webhook URL is not allowed (must be HTTPS to a public host).");
         }
 
         var payload = BuildPayload(message);

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/BggCoverDownloader.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/BggCoverDownloader.cs
@@ -1,3 +1,4 @@
+using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
 using Api.Services.Pdf;
 using Microsoft.Extensions.Logging;
 
@@ -26,6 +27,23 @@ internal sealed class BggCoverDownloader : IBggCoverDownloader
     {
         if (string.IsNullOrWhiteSpace(remoteImageUrl))
         {
+            return null;
+        }
+
+        // SSRF guard (#2655 finding #10): only fetch HTTPS URLs that resolve to public IPs.
+        // Reuses the SharedGameCatalog SsrfSafeHttpClient validators (same bounded context). Fails
+        // closed — an invalid scheme or a private/reserved target aborts the download (returns null).
+        try
+        {
+            SsrfSafeHttpClient.ValidateUrlScheme(remoteImageUrl);
+            await SsrfSafeHttpClient.ValidateResolvedIpAsync(remoteImageUrl, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is ArgumentException or InvalidOperationException)
+        {
+            _logger.LogWarning(
+                ex,
+                "BGG cover download blocked by SSRF guard: BggId={BggId}, Url={Url}",
+                bggId, remoteImageUrl);
             return null;
         }
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/Administration/Infrastructure/External/SlackWebhookClientTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Administration/Infrastructure/External/SlackWebhookClientTests.cs
@@ -19,6 +19,11 @@ namespace Api.Tests.BoundedContexts.Administration.Infrastructure.External;
 [Trait("Issue", "1840")]
 public class SlackWebhookClientTests
 {
+    // A public, non-private IP literal (RFC 5737 TEST-NET-3). Using an IP literal keeps the SSRF
+    // guard's DNS resolution offline/deterministic in unit tests (Dns.GetHostAddressesAsync on a
+    // literal returns it without a DNS query), while still passing the private-IP check.
+    private const string PublicWebhookUrl = "https://203.0.113.10/services/T1/B1/abc";
+
     private static SlackWebhookClient CreateClient(Mock<HttpMessageHandler> handler)
     {
         var httpClient = new HttpClient(handler.Object);
@@ -46,7 +51,7 @@ public class SlackWebhookClientTests
         var client = CreateClient(handler);
 
         var result = await client.SendAsync(
-            "https://hooks.slack.com/services/T1/B1/abc",
+            PublicWebhookUrl,
             new SlackMessage("Hello"),
             CancellationToken.None);
 
@@ -61,7 +66,7 @@ public class SlackWebhookClientTests
         var client = CreateClient(handler);
 
         var result = await client.SendAsync(
-            "https://hooks.slack.com/services/T1/B1/expired",
+            PublicWebhookUrl,
             new SlackMessage("Hello", Severity: "warning"),
             CancellationToken.None);
 
@@ -83,7 +88,7 @@ public class SlackWebhookClientTests
         var client = CreateClient(handler);
 
         var result = await client.SendAsync(
-            "https://hooks.slack.com/services/T1/B1/ok",
+            PublicWebhookUrl,
             new SlackMessage("Hello"),
             CancellationToken.None);
 
@@ -136,7 +141,7 @@ public class SlackWebhookClientTests
         var client = CreateClient(handler);
 
         var result = await client.TestConnectionAsync(
-            "https://hooks.slack.com/services/T1/B1/probe",
+            PublicWebhookUrl,
             CancellationToken.None);
 
         result.Success.Should().BeTrue();
@@ -151,11 +156,44 @@ public class SlackWebhookClientTests
         var client = CreateClient(handler);
 
         var result = await client.TestConnectionAsync(
-            "https://hooks.slack.com/services/T1/B1/missing",
+            PublicWebhookUrl,
             CancellationToken.None);
 
         result.Success.Should().BeFalse();
         result.Message.Should().NotBeNullOrEmpty();
         result.StatusCode.Should().Be(404);
+    }
+
+    // ---- SSRF guard (#2655 finding #11) ----
+
+    [Theory]
+    [InlineData("http://203.0.113.10/services/T1/B1/abc")]  // non-HTTPS scheme
+    [InlineData("ftp://203.0.113.10/services/T1/B1/abc")]    // non-HTTP scheme
+    public async Task SendAsync_NonHttpsUrl_BlockedWithoutPosting(string webhookUrl)
+    {
+        var handler = HandlerReturning(HttpStatusCode.OK, "ok");
+        var client = CreateClient(handler);
+
+        var result = await client.SendAsync(webhookUrl, new SlackMessage("Hello"), CancellationToken.None);
+
+        result.Success.Should().BeFalse("a non-HTTPS webhook URL must be blocked by the SSRF guard");
+        handler.Protected().Verify(
+            "SendAsync", Times.Never(), ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>());
+    }
+
+    [Theory]
+    [InlineData("https://127.0.0.1/services/T1/B1/abc")]     // loopback
+    [InlineData("https://169.254.169.254/latest")]           // cloud metadata endpoint
+    [InlineData("https://10.0.0.5/services/T1/B1/abc")]      // RFC 1918 private
+    public async Task SendAsync_PrivateOrReservedIp_BlockedWithoutPosting(string webhookUrl)
+    {
+        var handler = HandlerReturning(HttpStatusCode.OK, "ok");
+        var client = CreateClient(handler);
+
+        var result = await client.SendAsync(webhookUrl, new SlackMessage("Hello"), CancellationToken.None);
+
+        result.Success.Should().BeFalse("a webhook URL resolving to a private/reserved IP must be blocked by the SSRF guard");
+        handler.Protected().Verify(
+            "SendAsync", Times.Never(), ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>());
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/BggCoverDownloaderTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/BggCoverDownloaderTests.cs
@@ -14,6 +14,11 @@ public sealed class BggCoverDownloaderTests
     private readonly Mock<IBlobStorageService> _blobMock = new();
     private readonly Mock<ILogger<BggCoverDownloader>> _loggerMock = new();
 
+    // A public, non-private IP literal (RFC 5737 TEST-NET-3). Using an IP literal keeps the SSRF
+    // guard's DNS resolution offline/deterministic in unit tests (Dns.GetHostAddressesAsync on a
+    // literal returns it without a DNS query), while still passing the private-IP check.
+    private const string PublicHttpsUrl = "https://203.0.113.10/abc.jpg";
+
     [Fact]
     public async Task DownloadAndUploadAsync_OnSuccess_ReturnsR2Key()
     {
@@ -30,7 +35,7 @@ public sealed class BggCoverDownloaderTests
         var sut = new BggCoverDownloader(httpClient, _blobMock.Object, _loggerMock.Object);
 
         // Act
-        var result = await sut.DownloadAndUploadAsync(13, "https://cf.geekdo-images.com/abc.jpg", CancellationToken.None);
+        var result = await sut.DownloadAndUploadAsync(13, PublicHttpsUrl, CancellationToken.None);
 
         // Assert
         result.Should().Be("bgg-cover-13");
@@ -44,7 +49,7 @@ public sealed class BggCoverDownloaderTests
         var sut = new BggCoverDownloader(httpClient, _blobMock.Object, _loggerMock.Object);
 
         // Act
-        var result = await sut.DownloadAndUploadAsync(13, "https://cf.geekdo-images.com/missing.jpg", CancellationToken.None);
+        var result = await sut.DownloadAndUploadAsync(13, PublicHttpsUrl, CancellationToken.None);
 
         // Assert
         result.Should().BeNull();
@@ -65,13 +70,47 @@ public sealed class BggCoverDownloaderTests
         var sut = new BggCoverDownloader(httpClient, _blobMock.Object, _loggerMock.Object);
 
         // Act
-        var result = await sut.DownloadAndUploadAsync(13, "https://cf.geekdo-images.com/abc.jpg", CancellationToken.None);
+        var result = await sut.DownloadAndUploadAsync(13, PublicHttpsUrl, CancellationToken.None);
 
         // Assert
         result.Should().BeNull();
     }
 
+    // ---- SSRF guard (#2655 finding #10) ----
+
+    [Theory]
+    [InlineData("http://203.0.113.10/abc.jpg")]      // non-HTTPS scheme
+    [InlineData("ftp://203.0.113.10/abc.jpg")]        // non-HTTP scheme
+    public async Task DownloadAndUploadAsync_NonHttpsUrl_BlockedWithoutFetching(string url)
+    {
+        var handler = TrackingHandler(HttpStatusCode.OK, new byte[] { 0x01 });
+        var sut = new BggCoverDownloader(new HttpClient(handler.Object), _blobMock.Object, _loggerMock.Object);
+
+        var result = await sut.DownloadAndUploadAsync(13, url, CancellationToken.None);
+
+        result.Should().BeNull("a non-HTTPS URL must be blocked by the SSRF guard");
+        VerifyNoHttpCall(handler);
+    }
+
+    [Theory]
+    [InlineData("https://127.0.0.1/abc.jpg")]         // loopback
+    [InlineData("https://169.254.169.254/latest")]    // cloud metadata endpoint
+    [InlineData("https://10.0.0.5/abc.jpg")]          // RFC 1918 private
+    public async Task DownloadAndUploadAsync_PrivateOrReservedIp_BlockedWithoutFetching(string url)
+    {
+        var handler = TrackingHandler(HttpStatusCode.OK, new byte[] { 0x01 });
+        var sut = new BggCoverDownloader(new HttpClient(handler.Object), _blobMock.Object, _loggerMock.Object);
+
+        var result = await sut.DownloadAndUploadAsync(13, url, CancellationToken.None);
+
+        result.Should().BeNull("a URL resolving to a private/reserved IP must be blocked by the SSRF guard");
+        VerifyNoHttpCall(handler);
+    }
+
     private static HttpClient BuildHttpClient(HttpStatusCode statusCode, byte[]? content = null)
+        => new(TrackingHandler(statusCode, content).Object);
+
+    private static Mock<HttpMessageHandler> TrackingHandler(HttpStatusCode statusCode, byte[]? content = null)
     {
         var handler = new Mock<HttpMessageHandler>();
         handler.Protected()
@@ -84,6 +123,13 @@ public sealed class BggCoverDownloaderTests
                 StatusCode = statusCode,
                 Content = content is null ? null : new ByteArrayContent(content)
             });
-        return new HttpClient(handler.Object);
+        return handler;
     }
+
+    private static void VerifyNoHttpCall(Mock<HttpMessageHandler> handler)
+        => handler.Protected().Verify(
+            "SendAsync",
+            Times.Never(),
+            ItExpr.IsAny<HttpRequestMessage>(),
+            ItExpr.IsAny<CancellationToken>());
 }


### PR DESCRIPTION
## Q3 Security #2655 — findings #10 and #11 (SSRF)

Two outbound-HTTP paths fetched a caller/admin-influenced URL without an SSRF guard:

- **#10** `BggCoverDownloader.DownloadAndUploadAsync` → `HttpClient.GetAsync(remoteImageUrl)` with no scheme/IP validation.
- **#11** `SlackWebhookClient.SendAsync` → validated only that the URL is an absolute URI; did not block `169.254.169.254` (cloud metadata), localhost, or RFC1918 private ranges.

### Fix
Both call sites now route through the existing `SsrfSafeHttpClient` validators **before** the outbound request:
- `ValidateUrlScheme` (HTTPS-only)
- `ValidateResolvedIpAsync` (blocks loopback / link-local / RFC1918 / cloud-metadata)

Fail-closed: a blocked URL aborts the request (`return null` / `SlackSendResult(false, …)`). The catch filters only `ArgumentException`/`InvalidOperationException`, so cancellation still propagates. `SlackWebhookClient` returns a generic message (no resolved IP) and never logs the webhook URL (it embeds a secret). TOCTOU/DNS-rebinding window is at exact parity with the existing `DownloadPdfAsync`.

### Tests
- 10 new blocking tests (non-HTTPS scheme + loopback/metadata/RFC1918) that assert the HTTP handler is **never** called (`Times.Never`) — proving a real gate, not a downstream-null.
- Existing happy-path tests updated to RFC 5737 IP literals (`203.0.113.10`) so the guard's DNS resolution stays offline-deterministic in unit tests. 22/22 green.

Adversarial review: fix SOUND (guard-before-HTTP, fail-closed, exception propagation, info-disclosure all correct). Two out-of-scope observations reported on #2655: (a) cross-context reuse of `SsrfSafeHttpClient` (the task required routing via it; SharedKernel extraction is a follow-up); (b) `N8nWebhookClient` was evaluated and **refuted** — its `BaseUrl` is deployment `IOptions` config (not runtime/admin input) and targets an intentional internal service (`localhost:5678`), so the guard would break it and there is no runtime SSRF vector.

Refs #2655