### PR TITLE
feat(observability): #2752 wire gamebook translation_cost_eur from StreamChunk.Cost

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/TranslateGamebookSegmentQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/TranslateGamebookSegmentQueryHandler.cs
@@ -77,6 +77,8 @@ internal sealed class TranslateGamebookSegmentQueryHandler
         double? streamingLatencySec = null;
         long? promptTokens = null;
         long? completionTokens = null;
+        double? costUsd = null;          // #2752: captured from StreamChunk.Cost on the final chunk
+        string provider = "unknown";     // #2752: LLM provider that served the request
         int totalApplicableTerms = 0;
         int matchedTerms = 0;
 
@@ -166,6 +168,13 @@ internal sealed class TranslateGamebookSegmentQueryHandler
                         "gamebook.translate.cost campaign={CampaignId} paragraph={Paragraph} tokens_in={In} tokens_out={Out}",
                         query.CampaignId, query.ParagraphNumber, chunk.Usage.PromptTokens, chunk.Usage.CompletionTokens);
                 }
+                // #2752: cost + provider ride on StreamChunk.Cost (sibling of Usage), populated
+                // per-provider by OpenRouterLlmClient / DeepSeekLlmClient on the final chunk.
+                if (chunk.Cost is not null)
+                {
+                    costUsd = (double)chunk.Cost.TotalCost;
+                    provider = chunk.Cost.Provider;
+                }
             }
 
             var translatedIt = fullText.ToString().Trim();
@@ -235,18 +244,17 @@ internal sealed class TranslateGamebookSegmentQueryHandler
                 status = "cancelled";
             }
 
-            // Cost tracking via existing LlmCostUsdTotal (MeepleAiMetrics.LlmOperational, Issue #5480)
-            // is emitted by HybridLlmService per-request; gamebook-specific cost_eur deferred to a
-            // follow-up that derives cost from token counts + provider pricing (LlmUsage record does
-            // not currently carry CostUsd / Provider fields).
+            // #2752: gamebook-specific cost_eur is derived (USD x UsdToEurRate) inside the helper
+            // from StreamChunk.Cost, captured above. costUsd stays null when the provider does not
+            // report cost (or on a failed/cancelled stream) — the helper skips the EUR record then.
             MeepleAiMetrics.RecordGamebookTranslationRequest(
                 status: status,
                 latencyFullSeconds: stopwatch.Elapsed.TotalSeconds,
                 latencyStreamingSeconds: streamingLatencySec,
                 promptTokens: promptTokens,
                 completionTokens: completionTokens,
-                costUsd: null,
-                provider: "unknown");
+                costUsd: costUsd,
+                provider: provider);
 
             if (totalApplicableTerms > 0)
             {

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/TranslateGamebookTextQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/TranslateGamebookTextQueryHandler.cs
@@ -61,6 +61,8 @@ internal sealed class TranslateGamebookTextQueryHandler
         double? streamingLatencySec = null;
         long? promptTokens = null;
         long? completionTokens = null;
+        double? costUsd = null;          // #2752: captured from StreamChunk.Cost on the final chunk
+        string provider = "unknown";     // #2752: LLM provider that served the request
         int totalApplicableTerms = 0;
         int matchedTerms = 0;
 
@@ -112,6 +114,13 @@ internal sealed class TranslateGamebookTextQueryHandler
                         "gamebook.text.translate.cost campaign={CampaignId} tokens_in={In} tokens_out={Out}",
                         query.CampaignId, chunk.Usage.PromptTokens, chunk.Usage.CompletionTokens);
                 }
+                // #2752: cost + provider ride on StreamChunk.Cost (sibling of Usage), populated
+                // per-provider by OpenRouterLlmClient / DeepSeekLlmClient on the final chunk.
+                if (chunk.Cost is not null)
+                {
+                    costUsd = (double)chunk.Cost.TotalCost;
+                    provider = chunk.Cost.Provider;
+                }
             }
 
             var translatedIt = fullText.ToString().Trim();
@@ -157,14 +166,17 @@ internal sealed class TranslateGamebookTextQueryHandler
                 status = "cancelled";
             }
 
+            // #2752: cost_eur derived (USD x UsdToEurRate) inside the helper from StreamChunk.Cost,
+            // captured above. costUsd stays null when the provider does not report cost (or on a
+            // failed/cancelled stream) — the helper skips the EUR record then.
             MeepleAiMetrics.RecordGamebookTranslationRequest(
                 status: status,
                 latencyFullSeconds: stopwatch.Elapsed.TotalSeconds,
                 latencyStreamingSeconds: streamingLatencySec,
                 promptTokens: promptTokens,
                 completionTokens: completionTokens,
-                costUsd: null,
-                provider: "unknown",
+                costUsd: costUsd,
+                provider: provider,
                 sourceMethod: "manual");
 
             if (totalApplicableTerms > 0)

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Queries/TranslateGamebookSegmentQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Queries/TranslateGamebookSegmentQueryHandlerTests.cs
@@ -6,7 +6,9 @@ using Api.BoundedContexts.SessionTracking.Domain.Enums;
 using Api.BoundedContexts.SessionTracking.Domain.Repositories;
 using Api.BoundedContexts.SessionTracking.Domain.ValueObjects;
 using Api.BoundedContexts.SessionTracking.Infrastructure.Services;
+using System.Diagnostics.Metrics;
 using Api.Models;
+using Api.Observability;
 using Api.Services;
 using Api.Services.LlmClients;
 using Api.SharedKernel.Domain.ValueObjects;
@@ -16,6 +18,7 @@ using Xunit;
 
 namespace Api.Tests.BoundedContexts.SessionTracking.Application.Queries;
 
+[Collection("GamebookMeter")] // #2752: serialize with GamebookTranslationMetricsTests — shared static gamebook Meter
 [Trait("Category", "Unit")]
 [Trait("BoundedContext", "SessionTracking")]
 public sealed class TranslateGamebookSegmentQueryHandlerTests
@@ -252,6 +255,48 @@ public sealed class TranslateGamebookSegmentQueryHandlerTests
         public Task<int> RemoveByTagAcrossReplicasAsync(string tag, CancellationToken ct = default) => Task.FromResult(0);
         public Task<HybridCacheStats> GetStatsAsync(CancellationToken ct = default)
             => Task.FromResult(new HybridCacheStats());
+    }
+
+    /// <summary>
+    /// #2752: Fake LLM whose final chunk carries BOTH Usage and Cost, mirroring what
+    /// OpenRouterLlmClient / DeepSeekLlmClient emit. Drives the translation_cost_eur wiring.
+    /// </summary>
+    private sealed class CostReportingFakeLlmService : ILlmService
+    {
+        private readonly LlmCost _cost;
+        public CostReportingFakeLlmService(LlmCost cost) => _cost = cost;
+
+        public async IAsyncEnumerable<StreamChunk> GenerateCompletionStreamAsync(
+            string systemPrompt,
+            string userPrompt,
+            RequestSource source = RequestSource.Manual,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct = default)
+        {
+            yield return new StreamChunk("L'Alveare si risveglia.", IsFinal: false);
+            await Task.Yield();
+            yield return new StreamChunk(null, Usage: new LlmUsage(50, 10, 60), Cost: _cost, IsFinal: true);
+        }
+
+        public Task<LlmCompletionResult> GenerateCompletionAsync(string s, string u, RequestSource r = RequestSource.Manual, CancellationToken ct = default)
+            => Task.FromResult(LlmCompletionResult.CreateSuccess(string.Empty));
+
+        public Task<T?> GenerateJsonAsync<T>(string s, string u, RequestSource r = RequestSource.Manual, CancellationToken ct = default) where T : class
+            => Task.FromResult<T?>(null);
+
+        public Task<LlmCompletionResult> GenerateMultimodalCompletionAsync(IReadOnlyList<LlmMessage> messages, RequestSource source = RequestSource.Manual, CancellationToken ct = default)
+            => Task.FromResult(LlmCompletionResult.CreateSuccess(string.Empty));
+
+        public async IAsyncEnumerable<StreamChunk> GenerateMultimodalCompletionStreamAsync(
+            IReadOnlyList<LlmMessage> messages,
+            RequestSource source = RequestSource.Manual,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct = default)
+        {
+            yield return new StreamChunk(null, IsFinal: true);
+            await Task.CompletedTask;
+        }
+
+        public Task<LlmCompletionResult> GenerateCompletionWithModelAsync(string explicitModel, string systemPrompt, string userPrompt, RequestSource source = RequestSource.Manual, int? maxTokens = null, CancellationToken ct = default)
+            => Task.FromResult(LlmCompletionResult.CreateSuccess(string.Empty));
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────────
@@ -542,5 +587,129 @@ public sealed class TranslateGamebookSegmentQueryHandlerTests
         finalChunk.DetectedSourceLang.Should().BeNull(
             "no lang was detected — audit field must remain null");
         finalChunk.LangDetectionConfidence.Should().BeNull();
+    }
+
+    // ── #2752: translation_cost_eur wiring from StreamChunk.Cost ────────────────
+
+    [Fact]
+    public async Task Handle_FinalChunkCarriesCost_RecordsTranslationCostEur()
+    {
+        // Arrange
+        var campaignRepo = new FakeCampaignRepo();
+        var artifactRepo = new FakeArtifactRepo();
+        var paragraphRepo = new FakeParagraphRepo();
+        var glossaryRepo = new FakeGlossaryRepo();
+        var progressRepo = new FakeProgressRepo();
+
+        var ownerId = Guid.NewGuid();
+        var campaign = GamebookCampaignSession.Create(GameRef.Shared(Guid.NewGuid()), ownerId, "Cost Campaign");
+        campaignRepo.Store.Add(campaign);
+        var bookId = Guid.NewGuid();
+
+        var artifact = GamebookPhotoArtifact.Create(campaign.Id, bookId, $"gamebook-photos/{campaign.Id}/photo-cost");
+        artifact.RecordSegments(
+            new[] { GamebookSegment.Create(47, "The Hive awakens.", null) },
+            "The Hive awakens.");
+        artifactRepo.Store.Add(artifact);
+
+        // TotalCost = 0.0005 USD, distinctive provider isolates this test from concurrent meter emitters.
+        var cost = new LlmCost { InputCost = 0.0003m, OutputCost = 0.0002m, ModelId = "deepseek-chat", Provider = "test-seg-provider" };
+        var handler = BuildHandler(
+            campaignRepo, artifactRepo, paragraphRepo, glossaryRepo, progressRepo,
+            llm: new CostReportingFakeLlmService(cost));
+
+        var query = new TranslateGamebookSegmentQuery(campaign.Id, artifact.Id, 47, ownerId, bookId);
+
+        // Act
+        using var capture = new CostEurCapture();
+        await foreach (var _ in handler.Handle(query, CancellationToken.None)) { }
+
+        // Assert — cost_eur = TotalCost x UsdToEurRate, tagged with the chunk's provider
+        var recorded = capture.ForProvider("test-seg-provider");
+        recorded.Should().NotBeNull("StreamChunk.Cost carries a positive cost → translation_cost_eur must be recorded");
+        recorded!.Value.Value.Should().BeApproximately(0.0005 * MeepleAiMetrics.UsdToEurRate, 1e-9);
+    }
+
+    [Fact]
+    public async Task Handle_FinalChunkWithoutCost_DoesNotRecordCostEur()
+    {
+        // Arrange — default FakeLlmService yields a final chunk with Usage but no Cost.
+        var campaignRepo = new FakeCampaignRepo();
+        var artifactRepo = new FakeArtifactRepo();
+        var paragraphRepo = new FakeParagraphRepo();
+        var glossaryRepo = new FakeGlossaryRepo();
+        var progressRepo = new FakeProgressRepo();
+
+        var ownerId = Guid.NewGuid();
+        var campaign = GamebookCampaignSession.Create(GameRef.Shared(Guid.NewGuid()), ownerId, "No-Cost Campaign");
+        campaignRepo.Store.Add(campaign);
+        var bookId = Guid.NewGuid();
+
+        var artifact = GamebookPhotoArtifact.Create(campaign.Id, bookId, $"gamebook-photos/{campaign.Id}/photo-nocost");
+        artifact.RecordSegments(
+            new[] { GamebookSegment.Create(47, "The Hive awakens.", null) },
+            "The Hive awakens.");
+        artifactRepo.Store.Add(artifact);
+
+        var handler = BuildHandler(campaignRepo, artifactRepo, paragraphRepo, glossaryRepo, progressRepo);
+        var query = new TranslateGamebookSegmentQuery(campaign.Id, artifact.Id, 47, ownerId, bookId);
+
+        // Act
+        using var capture = new CostEurCapture();
+        await foreach (var _ in handler.Handle(query, CancellationToken.None)) { }
+
+        // Assert — no cost means no EUR record (provider stays "unknown", helper skips the emit)
+        capture.ForProvider("unknown").Should().BeNull("null Cost → handler must not record translation_cost_eur");
+    }
+
+    /// <summary>
+    /// #2752: captures meepleai.gamebook.translation_cost_eur measurements, keyed by provider tag,
+    /// so assertions filter to this test's distinctive provider and stay robust under parallel test runs.
+    /// </summary>
+    private sealed class CostEurCapture : IDisposable
+    {
+        private const string CostName = "meepleai.gamebook.translation_cost_eur";
+        private readonly MeterListener _listener;
+        private readonly List<(double Value, string? Provider)> _captured = new();
+        private readonly object _gate = new();
+
+        public CostEurCapture()
+        {
+            _listener = new MeterListener
+            {
+                InstrumentPublished = (instrument, l) =>
+                {
+                    if (instrument.Meter.Name == MeepleAiMetrics.MeterName && instrument.Name == CostName)
+                        l.EnableMeasurementEvents(instrument);
+                }
+            };
+            _listener.SetMeasurementEventCallback<double>((instrument, value, tags, _) =>
+            {
+                string? provider = null;
+                foreach (var tag in tags)
+                {
+                    if (tag.Key == "provider")
+                        provider = tag.Value as string;
+                }
+                lock (_gate)
+                {
+                    _captured.Add((value, provider));
+                }
+            });
+            _listener.Start();
+        }
+
+        public (double Value, string? Provider)? ForProvider(string provider)
+        {
+            lock (_gate)
+            {
+                return _captured
+                    .Where(m => string.Equals(m.Provider, provider, StringComparison.Ordinal))
+                    .Select(m => ((double Value, string? Provider)?)m)
+                    .LastOrDefault();
+            }
+        }
+
+        public void Dispose() => _listener.Dispose();
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Queries/TranslateGamebookTextQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Queries/TranslateGamebookTextQueryHandlerTests.cs
@@ -4,7 +4,9 @@ using Api.BoundedContexts.SessionTracking.Application.Services;
 using Api.BoundedContexts.SessionTracking.Domain.Entities;
 using Api.BoundedContexts.SessionTracking.Domain.Enums;
 using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using System.Diagnostics.Metrics;
 using Api.Middleware.Exceptions;
+using Api.Observability;
 using Api.Services;
 using Api.Services.LlmClients;
 using Api.SharedKernel.Domain.ValueObjects;
@@ -14,6 +16,7 @@ using Xunit;
 
 namespace Api.Tests.BoundedContexts.SessionTracking.Application.Queries;
 
+[Collection("GamebookMeter")] // #2752: serialize with GamebookTranslationMetricsTests — shared static gamebook Meter
 [Trait("Category", "Unit")]
 [Trait("BoundedContext", "SessionTracking")]
 public sealed class TranslateGamebookTextQueryHandlerTests
@@ -92,6 +95,48 @@ public sealed class TranslateGamebookTextQueryHandlerTests
                 await Task.Yield();
             }
             yield return new StreamChunk(null, IsFinal: true, Usage: new LlmUsage(10, 5, 15));
+        }
+
+        public Task<LlmCompletionResult> GenerateCompletionAsync(string s, string u, RequestSource r = RequestSource.Manual, CancellationToken ct = default)
+            => Task.FromResult(LlmCompletionResult.CreateSuccess(string.Empty));
+
+        public Task<T?> GenerateJsonAsync<T>(string s, string u, RequestSource r = RequestSource.Manual, CancellationToken ct = default) where T : class
+            => Task.FromResult<T?>(null);
+
+        public Task<LlmCompletionResult> GenerateMultimodalCompletionAsync(IReadOnlyList<LlmMessage> messages, RequestSource source = RequestSource.Manual, CancellationToken ct = default)
+            => Task.FromResult(LlmCompletionResult.CreateSuccess(string.Empty));
+
+        public async IAsyncEnumerable<StreamChunk> GenerateMultimodalCompletionStreamAsync(
+            IReadOnlyList<LlmMessage> messages,
+            RequestSource source = RequestSource.Manual,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct = default)
+        {
+            yield return new StreamChunk(null, IsFinal: true);
+            await Task.CompletedTask;
+        }
+
+        public Task<LlmCompletionResult> GenerateCompletionWithModelAsync(string explicitModel, string systemPrompt, string userPrompt, RequestSource source = RequestSource.Manual, int? maxTokens = null, CancellationToken ct = default)
+            => Task.FromResult(LlmCompletionResult.CreateSuccess(string.Empty));
+    }
+
+    /// <summary>
+    /// #2752: Fake LLM whose final chunk carries BOTH Usage and Cost, mirroring what
+    /// OpenRouterLlmClient / DeepSeekLlmClient emit. Drives the translation_cost_eur wiring.
+    /// </summary>
+    private sealed class CostReportingFakeLlmService : ILlmService
+    {
+        private readonly LlmCost _cost;
+        public CostReportingFakeLlmService(LlmCost cost) => _cost = cost;
+
+        public async IAsyncEnumerable<StreamChunk> GenerateCompletionStreamAsync(
+            string systemPrompt,
+            string userPrompt,
+            RequestSource source = RequestSource.Manual,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct = default)
+        {
+            yield return new StreamChunk("Ciao mondo.", IsFinal: false);
+            await Task.Yield();
+            yield return new StreamChunk(null, Usage: new LlmUsage(10, 5, 15), Cost: _cost, IsFinal: true);
         }
 
         public Task<LlmCompletionResult> GenerateCompletionAsync(string s, string u, RequestSource r = RequestSource.Manual, CancellationToken ct = default)
@@ -325,6 +370,94 @@ public sealed class TranslateGamebookTextQueryHandlerTests
             "lowercase 'fr' must normalize to 'FR' → 'French' in prompt");
         chunks.Last().DetectedSourceLang.Should().Be("FR",
             "final chunk must echo normalized uppercase source lang code");
+    }
+
+    // ── #2752: translation_cost_eur wiring from StreamChunk.Cost ────────────────
+
+    [Fact]
+    public async Task Handle_FinalChunkCarriesCost_RecordsTranslationCostEur()
+    {
+        var (campaigns, glossary) = BuildRepos();
+        var campaign = campaigns.Store[0];
+
+        // TotalCost = 0.0005 USD, distinctive provider isolates this test from concurrent meter emitters.
+        var cost = new LlmCost { InputCost = 0.0003m, OutputCost = 0.0002m, ModelId = "deepseek-chat", Provider = "test-text-provider" };
+        var handler = BuildHandler(campaigns, glossary, llm: new CostReportingFakeLlmService(cost));
+        var query = new TranslateGamebookTextQuery(campaign.Id, "Hello world.", "EN", "IT", GameBookId, UserId);
+
+        using var capture = new CostEurCapture();
+        await foreach (var _ in handler.Handle(query, CancellationToken.None)) { }
+
+        var recorded = capture.ForProvider("test-text-provider");
+        recorded.Should().NotBeNull("StreamChunk.Cost carries a positive cost → translation_cost_eur must be recorded");
+        recorded!.Value.Value.Should().BeApproximately(0.0005 * MeepleAiMetrics.UsdToEurRate, 1e-9);
+    }
+
+    [Fact]
+    public async Task Handle_FinalChunkWithoutCost_DoesNotRecordCostEur()
+    {
+        var (campaigns, glossary) = BuildRepos();
+        var campaign = campaigns.Store[0];
+
+        // Default FakeLlmService yields a final chunk with Usage but no Cost.
+        var handler = BuildHandler(campaigns, glossary);
+        var query = new TranslateGamebookTextQuery(campaign.Id, "Hello world.", "EN", "IT", GameBookId, UserId);
+
+        using var capture = new CostEurCapture();
+        await foreach (var _ in handler.Handle(query, CancellationToken.None)) { }
+
+        capture.ForProvider("unknown").Should().BeNull("null Cost → handler must not record translation_cost_eur");
+    }
+
+    /// <summary>
+    /// #2752: captures meepleai.gamebook.translation_cost_eur measurements, keyed by provider tag,
+    /// so assertions filter to this test's distinctive provider and stay robust under parallel test runs.
+    /// </summary>
+    private sealed class CostEurCapture : IDisposable
+    {
+        private const string CostName = "meepleai.gamebook.translation_cost_eur";
+        private readonly MeterListener _listener;
+        private readonly List<(double Value, string? Provider)> _captured = new();
+        private readonly object _gate = new();
+
+        public CostEurCapture()
+        {
+            _listener = new MeterListener
+            {
+                InstrumentPublished = (instrument, l) =>
+                {
+                    if (instrument.Meter.Name == MeepleAiMetrics.MeterName && instrument.Name == CostName)
+                        l.EnableMeasurementEvents(instrument);
+                }
+            };
+            _listener.SetMeasurementEventCallback<double>((instrument, value, tags, _) =>
+            {
+                string? provider = null;
+                foreach (var tag in tags)
+                {
+                    if (tag.Key == "provider")
+                        provider = tag.Value as string;
+                }
+                lock (_gate)
+                {
+                    _captured.Add((value, provider));
+                }
+            });
+            _listener.Start();
+        }
+
+        public (double Value, string? Provider)? ForProvider(string provider)
+        {
+            lock (_gate)
+            {
+                return _captured
+                    .Where(m => string.Equals(m.Provider, provider, StringComparison.Ordinal))
+                    .Select(m => ((double Value, string? Provider)?)m)
+                    .LastOrDefault();
+            }
+        }
+
+        public void Dispose() => _listener.Dispose();
     }
 
     // ── Additional tracking fake ──────────────────────────────────────────────

--- a/apps/api/tests/Api.Tests/Observability/GamebookTranslationMetricsTests.cs
+++ b/apps/api/tests/Api.Tests/Observability/GamebookTranslationMetricsTests.cs
@@ -14,6 +14,18 @@ namespace Api.Tests.Observability;
 /// Prometheus alert rules and Grafana dashboards) and that record helpers emit
 /// values with the documented label set.
 /// </summary>
+/// <summary>
+/// #2752: the gamebook meter (meepleai.gamebook.*) is a process-wide static Meter. Tests that
+/// assert exact values via a global MeterListener + FindLast are polluted by ANY concurrent emitter
+/// (the translate handler tests now emit translation_cost_eur / latency / token). This collection
+/// serializes all direct + indirect gamebook-meter emitters so their assertions stay deterministic.
+/// </summary>
+[CollectionDefinition("GamebookMeter", DisableParallelization = true)]
+public sealed class GamebookMeterCollection
+{
+}
+
+[Collection("GamebookMeter")]
 [Trait("Category", TestCategories.Unit)]
 [Trait("Area", "Observability")]
 [Trait("BoundedContext", "SessionTracking")]


### PR DESCRIPTION
## Summary

Closes #2752 (follow-up to #833). Wires the `meepleai.gamebook.translation_cost_eur` Prometheus counter, which #833's follow-up left recording `null`/`"unknown"`.

## Root finding

#833 deferred this with the rationale *"LlmUsage record does not currently carry CostUsd / Provider fields"*. That premise looked at the wrong field: cost + provider are already available to both handlers via **`StreamChunk.Cost`** (a sibling of `StreamChunk.Usage`), which carries `TotalCost` (USD) + `Provider`, populated on the final chunk by `OpenRouterLlmClient` (`:747`) and `DeepSeekLlmClient` (`:712`) and passed through unchanged by `HybridLlmService` (`:284`). No LLM-contract change and no per-provider price table are needed.

## What changed

- **`TranslateGamebookSegmentQueryHandler`** (OCR/photo, `source_method=ocr`) + **`TranslateGamebookTextQueryHandler`** (manual text, `source_method=manual`): capture `chunk.Cost` in the final-chunk branch and thread `costUsd = (double)chunk.Cost.TotalCost` + `provider = chunk.Cost.Provider` into `RecordGamebookTranslationRequest`. The helper already derives EUR (`USD × UsdToEurRate = 0.92`) and guards null/zero cost. Stale deferral comments updated.
- **Tests** (TDD): positive (final chunk carries `Cost` → `cost_eur = TotalCost × 0.92` tagged with provider) + negative guard (null `Cost` → no record) for both handlers.
- **`GamebookTranslationMetricsTests`**: serialized the gamebook-meter test classes into a non-parallel `[Collection("GamebookMeter")]`. The metrics assertions read a process-wide static `Meter` via a global `MeterListener`/`FindLast`; the new cost-emitting handler tests polluted them under parallel runs.

## Edge cases

- Final chunk without `Cost` (provider that doesn't report it, or failed/cancelled stream) → `costUsd` stays null → helper skips the EUR record. `provider` stays `"unknown"` (irrelevant with no cost).
- Zero-cost (free-tier model) → helper `> 0` guard → no record.

## Out of scope

Runtime FX provider (`IExchangeRateProvider`) — fixed `0.92` retained per #833. Bulkhead policy — still deferred pending post-launch traffic baseline.

## Tests

41/41 green in the affected area (both handlers + metrics + photo OCR + LLM operational). RED→GREEN followed per handler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
