### PR TITLE
feat(gamebook): #2750 wire libro detail tabs + encounter entry + glossary look-up

### DIFF
--- a/apps/web/src/app/(authenticated)/library/[gameId]/play/[campaignId]/encounter/__tests__/content.test.tsx
+++ b/apps/web/src/app/(authenticated)/library/[gameId]/play/[campaignId]/encounter/__tests__/content.test.tsx
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, type RenderResult } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactElement, ReactNode } from 'react';
+import { IntlProvider } from 'react-intl';
+
+import itMessages from '@/locales/it.json';
+import { Content } from '../_content';
+
+// #2750 C11: verify the encounter orchestrator wires the cheatsheet's "Glossario"
+// affordance to the read-only GlossaryLookupModal. EncounterCheatsheetView and
+// GlossaryLookupModal are tested independently; here we test the _content wiring.
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock('@/lib/gamebook/hooks/useEncounterParse', () => ({
+  useEncounterParse: () => ({
+    status: 'idle',
+    data: null,
+    error: undefined,
+    mutate: vi.fn(),
+    reset: vi.fn(),
+  }),
+}));
+
+// The real GlossaryLookupModal (imported directly, not via the barrel) reads this.
+vi.mock('@/lib/gamebook/hooks/useGamebookGlossary', () => ({
+  useGamebookGlossary: () => ({ data: [], isLoading: false, isError: false }),
+}));
+
+// Replace EncounterCheatsheetView with a stub that surfaces the onOpenGlossary prop
+// as a clickable button, so the wiring (not the FSM) is under test.
+vi.mock('@/components/features/gamebook', async importOriginal => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    EncounterCheatsheetView: ({ onOpenGlossary }: { onOpenGlossary?: () => void }) => (
+      <button type="button" onClick={onOpenGlossary}>
+        stub-open-glossary
+      </button>
+    ),
+  };
+});
+
+function flatten(obj: Record<string, unknown>, prefix = ''): Record<string, string> {
+  return Object.keys(obj).reduce(
+    (acc, key) => {
+      const full = prefix ? `${prefix}.${key}` : key;
+      const value = obj[key];
+      if (value && typeof value === 'object') {
+        Object.assign(acc, flatten(value as Record<string, unknown>, full));
+      } else {
+        acc[full] = String(value);
+      }
+      return acc;
+    },
+    {} as Record<string, string>
+  );
+}
+const FLAT_IT = flatten(itMessages as Record<string, unknown>);
+
+function renderContent(ui: ReactElement): RenderResult {
+  function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <IntlProvider locale="it" messages={FLAT_IT} onError={() => {}}>
+        {children}
+      </IntlProvider>
+    );
+  }
+  return render(ui, { wrapper: Wrapper });
+}
+
+const PROPS = {
+  gameId: 'g1',
+  campaignId: 'c1',
+  photoId: 'p1',
+  paragraphNumber: 218,
+  gameBookId: 'b1',
+  fromLabel: '147',
+  excerpt: 'You face a sentinel.',
+};
+
+describe('encounter/_content — GlossaryLookupModal wiring (#2750 C11)', () => {
+  it('does not show the glossary modal initially', () => {
+    renderContent(<Content {...PROPS} />);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('opens the read-only glossary look-up when the cheatsheet glossary action fires', async () => {
+    renderContent(<Content {...PROPS} />);
+    const user = userEvent.setup();
+
+    await user.click(screen.getByRole('button', { name: 'stub-open-glossary' }));
+
+    const dialog = screen.getByRole('dialog', { name: 'Glossario' });
+    expect(dialog).toBeVisible();
+  });
+});

--- a/apps/web/src/app/(authenticated)/library/[gameId]/play/[campaignId]/encounter/_content.tsx
+++ b/apps/web/src/app/(authenticated)/library/[gameId]/play/[campaignId]/encounter/_content.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, type ReactElement } from 'react';
+import { useMemo, useState, type ReactElement } from 'react';
 
 import { useRouter } from 'next/navigation';
 
@@ -9,6 +9,7 @@ import {
   type EncounterCheatsheetLabels,
   type EncounterStoryContext,
 } from '@/components/features/gamebook';
+import { GlossaryLookupModal } from '@/components/features/gamebook/GlossaryLookupModal';
 import { useTranslation } from '@/hooks/useTranslation';
 import { deriveEncounterStatus, mapEncounterError } from '@/lib/gamebook/encounter-fsm';
 import { useEncounterParse } from '@/lib/gamebook/hooks/useEncounterParse';
@@ -39,6 +40,8 @@ export function Content({
   const { t } = useTranslation();
   const router = useRouter();
   const parse = useEncounterParse(campaignId, photoId);
+  // #2750 C11: read-only glossary look-up, opened from the cheatsheet's "Glossario".
+  const [glossaryOpen, setGlossaryOpen] = useState(false);
 
   const paragraphMarker = paragraphNumber > 0 ? `§${paragraphNumber}` : '';
 
@@ -93,7 +96,13 @@ export function Content({
         labels={labels}
         onParse={() => parse.mutate({ paragraphNumber, gameBookId })}
         onResolve={() => router.push(`/library/${gameId}/play/${campaignId}`)}
+        onOpenGlossary={() => setGlossaryOpen(true)}
         onCancel={() => parse.reset()}
+      />
+      <GlossaryLookupModal
+        campaignId={campaignId}
+        isOpen={glossaryOpen}
+        onClose={() => setGlossaryOpen(false)}
       />
     </main>
   );

--- a/apps/web/src/app/(authenticated)/library/[gameId]/play/[campaignId]/translate/_content.tsx
+++ b/apps/web/src/app/(authenticated)/library/[gameId]/play/[campaignId]/translate/_content.tsx
@@ -47,7 +47,7 @@ export function Content({
       {isManualMode ? (
         <ManualInputView campaignId={campaignId} gameRef={gameRef} />
       ) : (
-        <TranslateViewer campaignId={campaignId} gameRef={gameRef} />
+        <TranslateViewer campaignId={campaignId} gameId={gameId} gameRef={gameRef} />
       )}
     </main>
   );

--- a/apps/web/src/components/features/gamebook/GlossaryLookupModal.tsx
+++ b/apps/web/src/components/features/gamebook/GlossaryLookupModal.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+import { useEffect, type ReactElement } from 'react';
+
+import { useTranslation } from '@/hooks/useTranslation';
+import { useGamebookGlossary } from '@/lib/gamebook/hooks/useGamebookGlossary';
+
+export interface GlossaryLookupModalProps {
+  /** Campaign whose glossary is looked up. */
+  readonly campaignId: string;
+  /** Whether the modal is visible. */
+  readonly isOpen: boolean;
+  /** Called when the user dismisses the modal (Escape, scrim, close button). */
+  readonly onClose: () => void;
+}
+
+/**
+ * #2750 C11 — read-only glossary look-up.
+ *
+ * Lists the campaign's EN → IT glossary terms so a player can look them up in
+ * context (e.g. from the encounter cheatsheet's "Glossario" affordance). This is
+ * deliberately distinct from {@link GlossaryEditorModal}, which edits a single
+ * entry: the look-up is read-only and shows the whole glossary at once.
+ */
+export function GlossaryLookupModal({
+  campaignId,
+  isOpen,
+  onClose,
+}: GlossaryLookupModalProps): ReactElement | null {
+  const { t } = useTranslation();
+  const { data: entries, isLoading, isError } = useGamebookGlossary(campaignId);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  const isEmpty = !isLoading && !isError && (entries?.length ?? 0) === 0;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={t('gamebook.glossaryLookup.title')}
+      className="fixed inset-0 z-50 flex items-end justify-center sm:items-center"
+    >
+      <div
+        data-testid="glossary-lookup-scrim"
+        role="presentation"
+        onClick={onClose}
+        className="absolute inset-0 bg-[rgba(0,0,0,0.45)]"
+      />
+      <div className="relative z-10 flex max-h-[80vh] w-full max-w-md flex-col overflow-hidden rounded-t-2xl border border-border bg-card shadow-xl sm:rounded-2xl">
+        <header className="flex items-center justify-between gap-3 border-b border-border px-4 py-3">
+          <div className="flex flex-col">
+            <h2 className="text-base font-semibold text-foreground">
+              {t('gamebook.glossaryLookup.title')}
+            </h2>
+            <span className="text-xs text-muted-foreground">
+              {t('gamebook.glossaryLookup.subtitle')}
+            </span>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label={t('gamebook.glossaryLookup.close')}
+            className="rounded-md p-1.5 text-muted-foreground hover:bg-muted"
+          >
+            <span aria-hidden="true">✕</span>
+          </button>
+        </header>
+
+        <div className="overflow-y-auto px-4 py-3">
+          {isLoading && (
+            <p
+              className="text-sm text-muted-foreground"
+              role="status"
+              data-testid="glossary-lookup-loading"
+            >
+              {t('gamebook.glossaryLookup.loading')}
+            </p>
+          )}
+          {isError && (
+            <p
+              className="text-sm text-destructive"
+              role="alert"
+              data-testid="glossary-lookup-error"
+            >
+              {t('gamebook.glossaryLookup.error')}
+            </p>
+          )}
+          {isEmpty && (
+            <p className="text-sm text-muted-foreground" data-testid="glossary-lookup-empty">
+              {t('gamebook.glossaryLookup.empty')}
+            </p>
+          )}
+          {!isLoading && !isError && entries && entries.length > 0 && (
+            <ul className="divide-y divide-border" data-testid="glossary-lookup-list">
+              {entries.map(entry => (
+                <li key={entry.id} className="flex items-baseline gap-2 py-2">
+                  <span className="font-medium text-foreground">{entry.termEn}</span>
+                  <span aria-hidden="true" className="text-muted-foreground">
+                    →
+                  </span>
+                  <span className="text-foreground">{entry.termIt}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/features/gamebook/LibroGameDetailView.tsx
+++ b/apps/web/src/components/features/gamebook/LibroGameDetailView.tsx
@@ -19,12 +19,14 @@
 
 import { useState, type ReactElement } from 'react';
 
+import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 
 import { GameBookList } from '@/components/features/gamebook/GameBookList';
 import { NanolithCampaignCTA } from '@/components/features/gamebook/NanolithCampaignCTA';
 import type { LibraryGameDetail } from '@/hooks/queries/useLibrary';
 import type { GameBookDto } from '@/lib/api/gamebook';
+import { useChatPanelStore } from '@/lib/stores/chat-panel-store';
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -48,6 +50,7 @@ export function LibroGameDetailView({
   booksLoading,
 }: LibroGameDetailViewProps): ReactElement {
   const router = useRouter();
+  const openChat = useChatPanelStore(s => s.open);
   const [tab, setTab] = useState<TabId>('info');
 
   const playersLabel =
@@ -185,9 +188,33 @@ export function LibroGameDetailView({
           {tab === 'info' && (
             <InfoPanel detail={gameDetail} books={books} booksLoading={booksLoading} />
           )}
-          {tab === 'chat' && <PlaceholderPanel label="AI Chat" />}
-          {tab === 'toolbox' && <PlaceholderPanel label="Toolbox" />}
-          {tab === 'toolkit' && <PlaceholderPanel label="Toolkit" />}
+          {/* #2750 C1 — the 3 non-Info tabs wire to real surfaces (was a placeholder). */}
+          {tab === 'chat' && (
+            <ChatTabPanel
+              onOpen={() =>
+                openChat({
+                  id: gameDetail.gameId,
+                  name: gameDetail.gameTitle,
+                  pdfCount: gameDetail.chunkCount ?? 0,
+                  kbStatus: 'ready',
+                })
+              }
+            />
+          )}
+          {tab === 'toolbox' && (
+            <ToolLinkPanel
+              label="Toolbox"
+              href={`/library/${gameDetail.gameId}/toolbox`}
+              description="Mazzi, fasi e strumenti di sessione per questo gioco."
+            />
+          )}
+          {tab === 'toolkit' && (
+            <ToolLinkPanel
+              label="Toolkit"
+              href={`/library/${gameDetail.gameId}/toolkit`}
+              description="Suggerimenti AI e strumenti generati dalla knowledge base."
+            />
+          )}
         </section>
       </main>
     </div>
@@ -324,12 +351,46 @@ function InfoPanel({
   );
 }
 
-function PlaceholderPanel({ label }: { label: string }): ReactElement {
+// #2750 C1 — AI Chat tab: opens the global chat panel (chat-panel-store) preseeded
+// with this game's context, mirroring GamebookPlayShell's "Apri chat con agente".
+function ChatTabPanel({ onOpen }: { onOpen: () => void }): ReactElement {
   return (
     <div className="rounded-[14px] border border-dashed border-[rgba(180,130,80,0.32)] bg-card p-6 text-center">
-      <p className="text-[15px] text-[#5a4a38]">
-        Pannello <strong>{label}</strong> · in arrivo con la prossima iter.
+      <p className="mb-3 text-[15px] text-[#5a4a38]">
+        Chatta con l&rsquo;<strong>agente Tutor</strong> per Q&amp;A sulle regole, con citazioni
+        dalla knowledge base.
       </p>
+      <button
+        type="button"
+        onClick={onOpen}
+        className="inline-flex items-center gap-2 rounded-[10px] bg-[hsl(var(--c-agent))] px-4 py-2 font-quicksand text-sm font-semibold text-white hover:opacity-90"
+      >
+        <span aria-hidden="true">💬</span> Apri chat con l&rsquo;agente
+      </button>
+    </div>
+  );
+}
+
+// #2750 C1 — Toolbox/Toolkit tabs: link to the dedicated in-app sub-pages
+// (/library/[gameId]/toolbox|toolkit) that already exist.
+function ToolLinkPanel({
+  label,
+  href,
+  description,
+}: {
+  label: string;
+  href: string;
+  description: string;
+}): ReactElement {
+  return (
+    <div className="rounded-[14px] border border-dashed border-[rgba(180,130,80,0.32)] bg-card p-6 text-center">
+      <p className="mb-3 text-[15px] text-[#5a4a38]">{description}</p>
+      <Link
+        href={href}
+        className="inline-flex items-center gap-2 rounded-[10px] bg-[hsl(var(--c-game))] px-4 py-2 font-quicksand text-sm font-semibold text-white hover:opacity-90"
+      >
+        Apri {label}
+      </Link>
     </div>
   );
 }

--- a/apps/web/src/components/features/gamebook/TranslateViewer.tsx
+++ b/apps/web/src/components/features/gamebook/TranslateViewer.tsx
@@ -2,6 +2,8 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactElement } from 'react';
 
+import Link from 'next/link';
+
 import { AbortButton } from '@/components/features/gamebook/AbortButton';
 import { BookPicker } from '@/components/features/gamebook/BookPicker';
 import { EnterManualLink } from '@/components/features/gamebook/EnterManualLink';
@@ -29,6 +31,12 @@ import { getLangTier, type LangTier } from '@/lib/gamebook/lang-tier';
 
 export interface TranslateViewerProps {
   campaignId: string;
+  /**
+   * #2750 C9: the route `gameId`, threaded from the translate page so the viewer
+   * can build the encounter-cheatsheet link (`/library/[gameId]/…/encounter`).
+   * Optional: when absent (legacy test-seams / stories) the link is not rendered.
+   */
+  gameId?: string;
   /**
    * GameRef of the campaign being translated. Required so the viewer can
    * fetch the list of GameBooks (multi-book generalization, Phase E).
@@ -99,6 +107,7 @@ function effectiveTier(
 
 export function TranslateViewer({
   campaignId,
+  gameId,
   gameRef,
   _initialPhase,
   _initialArtifact,
@@ -489,6 +498,33 @@ export function TranslateViewer({
           error={sse.error}
         />
       )}
+
+      {/* #2750 C9 — encounter-cheatsheet entry point. Available once a segment is
+          translated: the encounter route needs photoId + target paragraph +
+          gameBookId, all resolved at this point. This is the only live surface
+          that carries those params (the play shell lacks photoId). */}
+      {gameId &&
+        artifact &&
+        activeSegment &&
+        effectiveBookId &&
+        phase === 'translated' &&
+        sse.isComplete && (
+          <div className="rounded-lg border border-[var(--c-game)]/20 bg-background p-4">
+            <Link
+              href={`/library/${gameId}/play/${campaignId}/encounter?${new URLSearchParams({
+                photoId: artifact.id,
+                to: String(activeSegment.paragraphNumber),
+                gameBookId: effectiveBookId,
+                from: String(activeSegment.paragraphNumber),
+              }).toString()}`}
+              data-testid="translate-open-encounter"
+              className="inline-flex items-center gap-2 text-sm font-medium text-[var(--c-game)] hover:underline"
+            >
+              <span aria-hidden="true">⚔️</span> Apri scheda incontro §
+              {activeSegment.paragraphNumber}
+            </Link>
+          </div>
+        )}
 
       <LangOverrideModal
         open={modalState.open}

--- a/apps/web/src/components/features/gamebook/__tests__/GlossaryLookupModal.test.tsx
+++ b/apps/web/src/components/features/gamebook/__tests__/GlossaryLookupModal.test.tsx
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, within, type RenderResult } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactElement, ReactNode } from 'react';
+import { IntlProvider } from 'react-intl';
+
+import itMessages from '@/locales/it.json';
+import type { GamebookGlossaryEntry } from '@/lib/api/gamebook-glossary';
+import { GlossaryLookupModal } from '../GlossaryLookupModal';
+
+// #2750 C11: the modal is a read-only look-up over useGamebookGlossary. Mock the
+// hook so no QueryClientProvider is needed and we control the list.
+const glossaryState = vi.hoisted(() => ({
+  data: undefined as GamebookGlossaryEntry[] | undefined,
+  isLoading: false,
+  isError: false,
+}));
+vi.mock('@/lib/gamebook/hooks/useGamebookGlossary', () => ({
+  useGamebookGlossary: () => glossaryState,
+}));
+
+function flatten(obj: Record<string, unknown>, prefix = ''): Record<string, string> {
+  return Object.keys(obj).reduce(
+    (acc, key) => {
+      const full = prefix ? `${prefix}.${key}` : key;
+      const value = obj[key];
+      if (value && typeof value === 'object') {
+        Object.assign(acc, flatten(value as Record<string, unknown>, full));
+      } else {
+        acc[full] = String(value);
+      }
+      return acc;
+    },
+    {} as Record<string, string>
+  );
+}
+const FLAT_IT = flatten(itMessages as Record<string, unknown>);
+
+function renderModal(ui: ReactElement): RenderResult {
+  function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <IntlProvider locale="it" messages={FLAT_IT} onError={() => {}}>
+        {children}
+      </IntlProvider>
+    );
+  }
+  return render(ui, { wrapper: Wrapper });
+}
+
+function makeEntry(overrides: Partial<GamebookGlossaryEntry> = {}): GamebookGlossaryEntry {
+  return {
+    id: 'e1',
+    termEn: 'Hive',
+    termIt: 'Alveare',
+    source: 'AutoBootstrap',
+    updatedAt: '2026-07-01T00:00:00Z',
+    contexts: [],
+    ...overrides,
+  };
+}
+
+describe('GlossaryLookupModal', () => {
+  beforeEach(() => {
+    glossaryState.data = undefined;
+    glossaryState.isLoading = false;
+    glossaryState.isError = false;
+  });
+
+  it('renders nothing when closed', () => {
+    const { container } = renderModal(
+      <GlossaryLookupModal campaignId="c1" isOpen={false} onClose={vi.fn()} />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('lists glossary terms EN→IT when open', () => {
+    glossaryState.data = [
+      makeEntry({ id: '1', termEn: 'Hive', termIt: 'Alveare' }),
+      makeEntry({ id: '2', termEn: 'Sword', termIt: 'Spada', source: 'Manual' }),
+    ];
+    renderModal(<GlossaryLookupModal campaignId="c1" isOpen onClose={vi.fn()} />);
+
+    const dialog = screen.getByRole('dialog');
+    expect(within(dialog).getByText('Hive')).toBeVisible();
+    expect(within(dialog).getByText('Alveare')).toBeVisible();
+    expect(within(dialog).getByText('Sword')).toBeVisible();
+    expect(within(dialog).getByText('Spada')).toBeVisible();
+  });
+
+  it('shows the empty state when the campaign has no glossary terms', () => {
+    glossaryState.data = [];
+    renderModal(<GlossaryLookupModal campaignId="c1" isOpen onClose={vi.fn()} />);
+    expect(screen.getByTestId('glossary-lookup-empty')).toBeVisible();
+  });
+
+  it('shows an error state when the glossary fetch fails', () => {
+    glossaryState.isError = true;
+    renderModal(<GlossaryLookupModal campaignId="c1" isOpen onClose={vi.fn()} />);
+    expect(screen.getByTestId('glossary-lookup-error')).toBeVisible();
+  });
+
+  it('calls onClose when the close button is clicked', async () => {
+    glossaryState.data = [];
+    const onClose = vi.fn();
+    renderModal(<GlossaryLookupModal campaignId="c1" isOpen onClose={onClose} />);
+    const user = userEvent.setup();
+
+    await user.click(screen.getByRole('button', { name: /chiudi/i }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/components/features/gamebook/__tests__/LibroGameDetailView.test.tsx
+++ b/apps/web/src/components/features/gamebook/__tests__/LibroGameDetailView.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, within, type RenderResult } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { axe, toHaveNoViolations } from 'jest-axe';
@@ -64,6 +64,13 @@ vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: vi.fn() }),
 }));
 
+// #2750 C1: the AI Chat tab opens the global chat panel via chat-panel-store.
+const mockOpenChat = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/stores/chat-panel-store', () => ({
+  useChatPanelStore: (selector: (s: { open: typeof mockOpenChat }) => unknown) =>
+    selector({ open: mockOpenChat }),
+}));
+
 vi.mock('@/components/features/gamebook/NanolithCampaignCTA', () => ({
   NanolithCampaignCTA: ({ gameId, gameTitle }: { gameId: string; gameTitle: string }) => (
     <div data-testid="mock-nanolith-cta">
@@ -110,6 +117,10 @@ function makeLibraryGameDetail(overrides: Partial<LibraryGameDetail> = {}): Libr
 // ─── Tests ──────────────────────────────────────────────────────────────────
 
 describe('LibroGameDetailView', () => {
+  beforeEach(() => {
+    mockOpenChat.mockClear();
+  });
+
   it('renders default tab "info" with InfoPanel', () => {
     const gameDetail = makeLibraryGameDetail();
     renderView(<LibroGameDetailView gameDetail={gameDetail} />);
@@ -179,31 +190,50 @@ describe('LibroGameDetailView', () => {
     expect(screen.getByLabelText('partite 5')).toBeVisible();
   });
 
-  it('switches tabs and shows placeholder text', async () => {
-    const gameDetail = makeLibraryGameDetail();
+  // #2750 C1: the 3 non-Info tabs are wired to real surfaces (no more "in arrivo" placeholder).
+
+  it('C1: AI Chat tab opens the global chat panel with the game context', async () => {
+    const gameDetail = makeLibraryGameDetail({
+      gameId: 'g1',
+      gameTitle: 'Nanolith',
+      chunkCount: 4,
+    });
     renderView(<LibroGameDetailView gameDetail={gameDetail} />);
     const user = userEvent.setup();
 
-    // Click AI Chat tab
     await user.click(screen.getByRole('tab', { name: 'AI Chat' }));
-    expect(screen.getByText(/Pannello/i)).toBeVisible();
-    // Verify placeholder panel is visible by checking both the label and complete text together
     const chatPanel = screen.getByRole('tabpanel');
-    expect(chatPanel).toHaveTextContent('Pannello');
-    expect(chatPanel).toHaveTextContent('AI Chat');
-    expect(chatPanel).toHaveTextContent(/in arrivo con la prossima iter/);
+    expect(chatPanel).not.toHaveTextContent(/in arrivo con la prossima iter/);
 
-    // Click Toolbox tab
+    await user.click(within(chatPanel).getByRole('button', { name: /chat/i }));
+    expect(mockOpenChat).toHaveBeenCalledTimes(1);
+    expect(mockOpenChat).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'g1', name: 'Nanolith' })
+    );
+  });
+
+  it('C1: Toolbox tab links to the game toolbox sub-page', async () => {
+    const gameDetail = makeLibraryGameDetail({ gameId: 'g1' });
+    renderView(<LibroGameDetailView gameDetail={gameDetail} />);
+    const user = userEvent.setup();
+
     await user.click(screen.getByRole('tab', { name: 'Toolbox' }));
-    const toolboxPanel = screen.getByRole('tabpanel');
-    expect(toolboxPanel).toHaveTextContent('Toolbox');
-    expect(toolboxPanel).toHaveTextContent(/in arrivo con la prossima iter/);
+    const panel = screen.getByRole('tabpanel');
+    expect(panel).not.toHaveTextContent(/in arrivo con la prossima iter/);
+    const link = within(panel).getByRole('link');
+    expect(link).toHaveAttribute('href', '/library/g1/toolbox');
+  });
 
-    // Click Toolkit tab
+  it('C1: Toolkit tab links to the game toolkit sub-page', async () => {
+    const gameDetail = makeLibraryGameDetail({ gameId: 'g1' });
+    renderView(<LibroGameDetailView gameDetail={gameDetail} />);
+    const user = userEvent.setup();
+
     await user.click(screen.getByRole('tab', { name: 'Toolkit' }));
-    const toolkitPanel = screen.getByRole('tabpanel');
-    expect(toolkitPanel).toHaveTextContent('Toolkit');
-    expect(toolkitPanel).toHaveTextContent(/in arrivo con la prossima iter/);
+    const panel = screen.getByRole('tabpanel');
+    expect(panel).not.toHaveTextContent(/in arrivo con la prossima iter/);
+    const link = within(panel).getByRole('link');
+    expect(link).toHaveAttribute('href', '/library/g1/toolkit');
   });
 
   it("KB badge variant: kbStatus='indexing'", () => {

--- a/apps/web/src/components/features/gamebook/__tests__/TranslateViewer.test.tsx
+++ b/apps/web/src/components/features/gamebook/__tests__/TranslateViewer.test.tsx
@@ -233,6 +233,36 @@ describe('TranslateViewer', () => {
     expect(screen.getByTestId('translate-viewer-error')).toHaveTextContent('stream_error');
   });
 
+  // #2750 C9 — encounter cheatsheet entry point. The encounter route needs
+  // photoId + target paragraph + gameBookId, all available once a segment is
+  // translated. This is the only live surface with those params.
+  it('#2750 C9: offers an encounter-cheatsheet link after a segment is translated', () => {
+    makeOneBookMock();
+    wrap(
+      <TranslateViewer
+        campaignId={CAMPAIGN_ID}
+        gameRef={GAME_REF}
+        gameId={GAME_ID}
+        _initialPhase="translated"
+        _initialArtifact={FAKE_ARTIFACT as never}
+        _initialActiveSegment={FAKE_ARTIFACT.segments[0] as never}
+        _initialSseState={{ isComplete: true, partialText: 'Ti svegli in una prigione.' }}
+      />
+    );
+
+    const link = screen.getByTestId('translate-open-encounter');
+    expect(link).toHaveAttribute(
+      'href',
+      `/library/${GAME_ID}/play/${CAMPAIGN_ID}/encounter?photoId=${ARTIFACT_ID}&to=1&gameBookId=${BOOK_STORY_ID}&from=1`
+    );
+  });
+
+  it('#2750 C9: does not offer the encounter link before a translation completes', () => {
+    makeOneBookMock();
+    wrap(<TranslateViewer campaignId={CAMPAIGN_ID} gameRef={GAME_REF} gameId={GAME_ID} />);
+    expect(screen.queryByTestId('translate-open-encounter')).not.toBeInTheDocument();
+  });
+
   it('shows error copy and disables camera when no narrative books exist (E3)', () => {
     vi.mocked(booksHook.useGameBooks).mockReturnValue({
       data: [],

--- a/apps/web/src/components/features/gamebook/index.ts
+++ b/apps/web/src/components/features/gamebook/index.ts
@@ -148,6 +148,10 @@ export type {
 export { GlossaryEditorModal } from '@/components/features/gamebook/GlossaryEditorModal';
 export type { GlossaryEditorModalProps } from '@/components/features/gamebook/GlossaryEditorModal';
 
+// #2750 C11 — read-only glossary look-up (distinct from the single-entry editor above)
+export { GlossaryLookupModal } from '@/components/features/gamebook/GlossaryLookupModal';
+export type { GlossaryLookupModalProps } from '@/components/features/gamebook/GlossaryLookupModal';
+
 // Issue #1484 — Encounter Book cheatsheet (parse-centric MVP, consumes BE #1520)
 export { EncounterCheatsheetView } from '@/components/features/gamebook/EncounterCheatsheetView';
 export type {

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -3673,6 +3673,14 @@
       "lore": "Lore",
       "setup": "Setup"
     },
+    "glossaryLookup": {
+      "title": "Glossary",
+      "subtitle": "Campaign terms (EN → IT)",
+      "close": "Close",
+      "loading": "Loading glossary…",
+      "error": "Failed to load the glossary. Retry.",
+      "empty": "No glossary terms yet. Terms are created during translation."
+    },
     "glossaryEditor": {
       "title": "Edit glossary entry",
       "termEnLabel": "Source term",

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -3726,6 +3726,14 @@
       "lore": "Ambientazione",
       "setup": "Setup"
     },
+    "glossaryLookup": {
+      "title": "Glossario",
+      "subtitle": "Termini della campagna (EN → IT)",
+      "close": "Chiudi",
+      "loading": "Caricamento del glossario…",
+      "error": "Errore nel caricamento del glossario. Riprova.",
+      "empty": "Nessun termine nel glossario. I termini vengono creati durante la traduzione."
+    },
     "glossaryEditor": {
       "title": "Modifica voce di glossario",
       "termEnLabel": "Termine originale",


### PR DESCRIPTION
## Summary

Closes the **actionable** residual gaps from the SP6 libro-game verification pass (issue #2750). A 5-agent verification workflow triaged the ~25 MEDIUM/LOW gaps against live `main-dev`: **20 resolved · 5 not-applicable · 3 unclear · 3 actionable**. This PR ships the 3 actionable — all centered on the built-but-unwired encounter/glossary sub-feature + the placeholder detail tabs.

## What changed

### C1 — libro detail tabs (`LibroGameDetailView.tsx`)
The **AI Chat / Toolbox / Toolkit** tabs rendered a `<PlaceholderPanel>` ("in arrivo con la prossima iter") — a real UX dead-end.
- **AI Chat** → opens the global chat panel via `useChatPanelStore(s => s.open)` preseeded with the game context (mirrors `GamebookPlayShell`).
- **Toolbox / Toolkit** → `<Link>` to the existing `/library/[gameId]/toolbox|toolkit` sub-pages.

### C9 — encounter entry point (`TranslateViewer.tsx` + `translate/_content.tsx`)
The encounter cheatsheet route (`#1484`) was fully built but had **zero live entry point** — it needs `photoId + to + gameBookId`, which only the translate flow carries (the play shell lacks `photoId`). Adds an **"Apri scheda incontro §N"** link after a segment is translated, built via `URLSearchParams` to exactly match `encounter/page.tsx`'s param contract. New optional `gameId` prop threaded from the route.

### C11 — glossary look-up (`GlossaryLookupModal.tsx` new + `encounter/_content.tsx`)
The encounter's "Glossario" button never appeared because `onOpenGlossary` was never passed, and no glossary **look-up** surface existed (only the single-entry `GlossaryEditorModal`). Adds a read-only **`GlossaryLookupModal`** (EN → IT list over the existing `useGamebookGlossary` hook) and wires `onOpenGlossary` in the encounter orchestrator. New i18n keys `gamebook.glossaryLookup.*` (it + en); exported from the gamebook barrel.

## Out of scope (the 3 "unclear" gaps — product/backend decisions)
- **C14** quota/payment is a documented visual-only MVP stub (pending a real billing endpoint).
- **E4** campaign setup drops the player roster (add-player disabled/visual — pending a backend decision to persist it).
- **E5** house-rule AgentMemory honoring is a backend RAG behavior with no dedicated live FE surface.

These are documented in the #2750 triage comment; not FE-actionable now.

## Tests

TDD throughout (RED→GREEN watched per feature). Typecheck exit 0, ESLint exit 0. **598 tests pass** in the gamebook + play-route area, 0 regressions. New/updated tests: `LibroGameDetailView.test.tsx` (C1), `TranslateViewer.test.tsx` (C9), `GlossaryLookupModal.test.tsx` (C11 component), `encounter/__tests__/content.test.tsx` (C11 wiring).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
