### PR TITLE
fix(ci): #2655 deep-health + smoke tolerate 503 Degraded API

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1283,10 +1283,15 @@ jobs:
           # CF Access bypass headers reused for all curls in this step
           CF_HEADERS=(-H "CF-Access-Client-Id: ${CF_ACCESS_CLIENT_ID}" -H "CF-Access-Client-Secret: ${CF_ACCESS_CLIENT_SECRET}")
 
-          # Wait for API with structured health response (CF Access bypass)
+          # Wait for API with structured health response (CF Access bypass).
+          # #2655 — `curl -s` (NOT `-sf`): with `-f` curl discards the body and returns non-zero on
+          # a 503 Degraded response, so $HEALTH stayed empty and the loop timed out even though the
+          # API was up and serving. The critical-service gate below only requires postgres+redis
+          # Healthy, so a Degraded overall status (e.g. a non-critical slack_queue backlog) must not
+          # fail the deploy. Same fix as the in-container health wait earlier in this workflow.
           HEALTH=""
           for i in {1..30}; do
-            HEALTH=$(curl -sf "${CF_HEADERS[@]}" https://api.meepleai.app/health 2>/dev/null || true)
+            HEALTH=$(curl -s "${CF_HEADERS[@]}" https://api.meepleai.app/health 2>/dev/null || true)
             if [ -n "$HEALTH" ]; then
               echo "📋 Health response received"
               break
@@ -1363,11 +1368,14 @@ jobs:
             fi
           }
 
-          # Critical smoke tests (failure = deployment issue)
-          smoke_test "API Health" "https://meepleai.app/health" "200"
+          # Critical smoke tests (failure = deployment issue).
+          # #2655 — /health returns 503 when the overall status is Degraded (e.g. a non-critical
+          # slack_queue backlog); the API is still up and serving, so accept 200 OR 503 for the
+          # two /health reachability probes. A truly-down API yields 000/timeout, which still fails.
+          smoke_test "API Health" "https://meepleai.app/health" "200 503"
           smoke_test "Web Root" "https://meepleai.app" "200"
           smoke_test "API Game Catalog" "https://meepleai.app/api/v1/shared-games?pageNumber=1&pageSize=1" "200"
-          smoke_test "API Direct Health" "https://api.meepleai.app/health" "200"
+          smoke_test "API Direct Health" "https://api.meepleai.app/health" "200 503"
 
           # Health endpoint JSON validation
           echo "  Validating health response structure..."


### PR DESCRIPTION
## Q3 #2655 soak follow-up — validate job tolerates 503 Degraded

Discovered during the STEP 6 soak: after the deploy job (with the STEP 6 health-check) passed, the **Post-deploy Validation** job failed. Root cause confirmed live on the VPS: the staging API returns HTTP **503** when its overall status is **Degraded** — a non-critical `slack_queue` backlog (121 pending > threshold 100) while postgres+redis and all 21 other checks are Healthy. This is the same anti-pattern STEP 6 fixed, but in the `validate` job.

### Fixes (deploy-staging.yml, `validate` job)
1. **Deep Health Check** — `curl -sf` → `curl -s` on the `/health` wait loop. `-f` discarded the body and returned non-zero on 503, so `$HEALTH` stayed empty and the loop timed out ("API did not respond within 5 minutes") even though the API was up. The downstream gate only requires postgres+redis Healthy, so a Degraded overall must not fail the deploy.
2. **Smoke Tests** — the two `/health` reachability probes now accept `"200 503"` (were `"200"`). Web Root and API Game Catalog stay `"200"` (not /health, no Degraded state).

A truly-down API yields `000`/timeout, which is NOT in the allow-set, so a real outage still fails the deploy. The critical-service assertion (postgres+redis, parsed from the JSON body) is unchanged.

### Verification
YAML parses; `bash -n` clean on both edited steps; file is LF-clean (edits introduced no CRLF). Adversarial review: sound and complete — the two remaining `curl -sf` in Smoke Tests (`HEALTH_JSON`, `RT`) are genuinely non-blocking (degrade to warning/fallback), and the `grep -q "200 503"` has no false-match for any valid HTTP code.

This is the likely chronic cause of staging-deploy failures (memoria #2650/#1990). Refs #2655