### PR TITLE
release: staging — #2655 deploy-staging validate-job 503-tolerance fix

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1283,10 +1283,15 @@ jobs:
           # CF Access bypass headers reused for all curls in this step
           CF_HEADERS=(-H "CF-Access-Client-Id: ${CF_ACCESS_CLIENT_ID}" -H "CF-Access-Client-Secret: ${CF_ACCESS_CLIENT_SECRET}")
 
-          # Wait for API with structured health response (CF Access bypass)
+          # Wait for API with structured health response (CF Access bypass).
+          # #2655 — `curl -s` (NOT `-sf`): with `-f` curl discards the body and returns non-zero on
+          # a 503 Degraded response, so $HEALTH stayed empty and the loop timed out even though the
+          # API was up and serving. The critical-service gate below only requires postgres+redis
+          # Healthy, so a Degraded overall status (e.g. a non-critical slack_queue backlog) must not
+          # fail the deploy. Same fix as the in-container health wait earlier in this workflow.
           HEALTH=""
           for i in {1..30}; do
-            HEALTH=$(curl -sf "${CF_HEADERS[@]}" https://api.meepleai.app/health 2>/dev/null || true)
+            HEALTH=$(curl -s "${CF_HEADERS[@]}" https://api.meepleai.app/health 2>/dev/null || true)
             if [ -n "$HEALTH" ]; then
               echo "📋 Health response received"
               break
@@ -1363,11 +1368,14 @@ jobs:
             fi
           }
 
-          # Critical smoke tests (failure = deployment issue)
-          smoke_test "API Health" "https://meepleai.app/health" "200"
+          # Critical smoke tests (failure = deployment issue).
+          # #2655 — /health returns 503 when the overall status is Degraded (e.g. a non-critical
+          # slack_queue backlog); the API is still up and serving, so accept 200 OR 503 for the
+          # two /health reachability probes. A truly-down API yields 000/timeout, which still fails.
+          smoke_test "API Health" "https://meepleai.app/health" "200 503"
           smoke_test "Web Root" "https://meepleai.app" "200"
           smoke_test "API Game Catalog" "https://meepleai.app/api/v1/shared-games?pageNumber=1&pageSize=1" "200"
-          smoke_test "API Direct Health" "https://api.meepleai.app/health" "200"
+          smoke_test "API Direct Health" "https://api.meepleai.app/health" "200 503"
 
           # Health endpoint JSON validation
           echo "  Validating health response structure..."

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/TranslateGamebookSegmentQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/TranslateGamebookSegmentQueryHandler.cs
@@ -77,6 +77,8 @@ internal sealed class TranslateGamebookSegmentQueryHandler
         double? streamingLatencySec = null;
         long? promptTokens = null;
         long? completionTokens = null;
+        double? costUsd = null;          // #2752: captured from StreamChunk.Cost on the final chunk
+        string provider = "unknown";     // #2752: LLM provider that served the request
         int totalApplicableTerms = 0;
         int matchedTerms = 0;
 
@@ -166,6 +168,13 @@ internal sealed class TranslateGamebookSegmentQueryHandler
                         "gamebook.translate.cost campaign={CampaignId} paragraph={Paragraph} tokens_in={In} tokens_out={Out}",
                         query.CampaignId, query.ParagraphNumber, chunk.Usage.PromptTokens, chunk.Usage.CompletionTokens);
                 }
+                // #2752: cost + provider ride on StreamChunk.Cost (sibling of Usage), populated
+                // per-provider by OpenRouterLlmClient / DeepSeekLlmClient on the final chunk.
+                if (chunk.Cost is not null)
+                {
+                    costUsd = (double)chunk.Cost.TotalCost;
+                    provider = chunk.Cost.Provider;
+                }
             }
 
             var translatedIt = fullText.ToString().Trim();
@@ -235,18 +244,17 @@ internal sealed class TranslateGamebookSegmentQueryHandler
                 status = "cancelled";
             }
 
-            // Cost tracking via existing LlmCostUsdTotal (MeepleAiMetrics.LlmOperational, Issue #5480)
-            // is emitted by HybridLlmService per-request; gamebook-specific cost_eur deferred to a
-            // follow-up that derives cost from token counts + provider pricing (LlmUsage record does
-            // not currently carry CostUsd / Provider fields).
+            // #2752: gamebook-specific cost_eur is derived (USD x UsdToEurRate) inside the helper
+            // from StreamChunk.Cost, captured above. costUsd stays null when the provider does not
+            // report cost (or on a failed/cancelled stream) — the helper skips the EUR record then.
             MeepleAiMetrics.RecordGamebookTranslationRequest(
                 status: status,
                 latencyFullSeconds: stopwatch.Elapsed.TotalSeconds,
                 latencyStreamingSeconds: streamingLatencySec,
                 promptTokens: promptTokens,
                 completionTokens: completionTokens,
-                costUsd: null,
-                provider: "unknown");
+                costUsd: costUsd,
+                provider: provider);
 
             if (totalApplicableTerms > 0)
             {

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/TranslateGamebookTextQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/TranslateGamebookTextQueryHandler.cs
@@ -61,6 +61,8 @@ internal sealed class TranslateGamebookTextQueryHandler
         double? streamingLatencySec = null;
         long? promptTokens = null;
         long? completionTokens = null;
+        double? costUsd = null;          // #2752: captured from StreamChunk.Cost on the final chunk
+        string provider = "unknown";     // #2752: LLM provider that served the request
         int totalApplicableTerms = 0;
         int matchedTerms = 0;
 
@@ -112,6 +114,13 @@ internal sealed class TranslateGamebookTextQueryHandler
                         "gamebook.text.translate.cost campaign={CampaignId} tokens_in={In} tokens_out={Out}",
                         query.CampaignId, chunk.Usage.PromptTokens, chunk.Usage.CompletionTokens);
                 }
+                // #2752: cost + provider ride on StreamChunk.Cost (sibling of Usage), populated
+                // per-provider by OpenRouterLlmClient / DeepSeekLlmClient on the final chunk.
+                if (chunk.Cost is not null)
+                {
+                    costUsd = (double)chunk.Cost.TotalCost;
+                    provider = chunk.Cost.Provider;
+                }
             }
 
             var translatedIt = fullText.ToString().Trim();
@@ -157,14 +166,17 @@ internal sealed class TranslateGamebookTextQueryHandler
                 status = "cancelled";
             }
 
+            // #2752: cost_eur derived (USD x UsdToEurRate) inside the helper from StreamChunk.Cost,
+            // captured above. costUsd stays null when the provider does not report cost (or on a
+            // failed/cancelled stream) — the helper skips the EUR record then.
             MeepleAiMetrics.RecordGamebookTranslationRequest(
                 status: status,
                 latencyFullSeconds: stopwatch.Elapsed.TotalSeconds,
                 latencyStreamingSeconds: streamingLatencySec,
                 promptTokens: promptTokens,
                 completionTokens: completionTokens,
-                costUsd: null,
-                provider: "unknown",
+                costUsd: costUsd,
+                provider: provider,
                 sourceMethod: "manual");
 
             if (totalApplicableTerms > 0)

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Queries/TranslateGamebookSegmentQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Queries/TranslateGamebookSegmentQueryHandlerTests.cs
@@ -6,7 +6,9 @@ using Api.BoundedContexts.SessionTracking.Domain.Enums;
 using Api.BoundedContexts.SessionTracking.Domain.Repositories;
 using Api.BoundedContexts.SessionTracking.Domain.ValueObjects;
 using Api.BoundedContexts.SessionTracking.Infrastructure.Services;
+using System.Diagnostics.Metrics;
 using Api.Models;
+using Api.Observability;
 using Api.Services;
 using Api.Services.LlmClients;
 using Api.SharedKernel.Domain.ValueObjects;
@@ -16,6 +18,7 @@ using Xunit;
 
 namespace Api.Tests.BoundedContexts.SessionTracking.Application.Queries;
 
+[Collection("GamebookMeter")] // #2752: serialize with GamebookTranslationMetricsTests — shared static gamebook Meter
 [Trait("Category", "Unit")]
 [Trait("BoundedContext", "SessionTracking")]
 public sealed class TranslateGamebookSegmentQueryHandlerTests
@@ -252,6 +255,48 @@ public sealed class TranslateGamebookSegmentQueryHandlerTests
         public Task<int> RemoveByTagAcrossReplicasAsync(string tag, CancellationToken ct = default) => Task.FromResult(0);
         public Task<HybridCacheStats> GetStatsAsync(CancellationToken ct = default)
             => Task.FromResult(new HybridCacheStats());
+    }
+
+    /// <summary>
+    /// #2752: Fake LLM whose final chunk carries BOTH Usage and Cost, mirroring what
+    /// OpenRouterLlmClient / DeepSeekLlmClient emit. Drives the translation_cost_eur wiring.
+    /// </summary>
+    private sealed class CostReportingFakeLlmService : ILlmService
+    {
+        private readonly LlmCost _cost;
+        public CostReportingFakeLlmService(LlmCost cost) => _cost = cost;
+
+        public async IAsyncEnumerable<StreamChunk> GenerateCompletionStreamAsync(
+            string systemPrompt,
+            string userPrompt,
+            RequestSource source = RequestSource.Manual,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct = default)
+        {
+            yield return new StreamChunk("L'Alveare si risveglia.", IsFinal: false);
+            await Task.Yield();
+            yield return new StreamChunk(null, Usage: new LlmUsage(50, 10, 60), Cost: _cost, IsFinal: true);
+        }
+
+        public Task<LlmCompletionResult> GenerateCompletionAsync(string s, string u, RequestSource r = RequestSource.Manual, CancellationToken ct = default)
+            => Task.FromResult(LlmCompletionResult.CreateSuccess(string.Empty));
+
+        public Task<T?> GenerateJsonAsync<T>(string s, string u, RequestSource r = RequestSource.Manual, CancellationToken ct = default) where T : class
+            => Task.FromResult<T?>(null);
+
+        public Task<LlmCompletionResult> GenerateMultimodalCompletionAsync(IReadOnlyList<LlmMessage> messages, RequestSource source = RequestSource.Manual, CancellationToken ct = default)
+            => Task.FromResult(LlmCompletionResult.CreateSuccess(string.Empty));
+
+        public async IAsyncEnumerable<StreamChunk> GenerateMultimodalCompletionStreamAsync(
+            IReadOnlyList<LlmMessage> messages,
+            RequestSource source = RequestSource.Manual,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct = default)
+        {
+            yield return new StreamChunk(null, IsFinal: true);
+            await Task.CompletedTask;
+        }
+
+        public Task<LlmCompletionResult> GenerateCompletionWithModelAsync(string explicitModel, string systemPrompt, string userPrompt, RequestSource source = RequestSource.Manual, int? maxTokens = null, CancellationToken ct = default)
+            => Task.FromResult(LlmCompletionResult.CreateSuccess(string.Empty));
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────────
@@ -542,5 +587,129 @@ public sealed class TranslateGamebookSegmentQueryHandlerTests
         finalChunk.DetectedSourceLang.Should().BeNull(
             "no lang was detected — audit field must remain null");
         finalChunk.LangDetectionConfidence.Should().BeNull();
+    }
+
+    // ── #2752: translation_cost_eur wiring from StreamChunk.Cost ────────────────
+
+    [Fact]
+    public async Task Handle_FinalChunkCarriesCost_RecordsTranslationCostEur()
+    {
+        // Arrange
+        var campaignRepo = new FakeCampaignRepo();
+        var artifactRepo = new FakeArtifactRepo();
+        var paragraphRepo = new FakeParagraphRepo();
+        var glossaryRepo = new FakeGlossaryRepo();
+        var progressRepo = new FakeProgressRepo();
+
+        var ownerId = Guid.NewGuid();
+        var campaign = GamebookCampaignSession.Create(GameRef.Shared(Guid.NewGuid()), ownerId, "Cost Campaign");
+        campaignRepo.Store.Add(campaign);
+        var bookId = Guid.NewGuid();
+
+        var artifact = GamebookPhotoArtifact.Create(campaign.Id, bookId, $"gamebook-photos/{campaign.Id}/photo-cost");
+        artifact.RecordSegments(
+            new[] { GamebookSegment.Create(47, "The Hive awakens.", null) },
+            "The Hive awakens.");
+        artifactRepo.Store.Add(artifact);
+
+        // TotalCost = 0.0005 USD, distinctive provider isolates this test from concurrent meter emitters.
+        var cost = new LlmCost { InputCost = 0.0003m, OutputCost = 0.0002m, ModelId = "deepseek-chat", Provider = "test-seg-provider" };
+        var handler = BuildHandler(
+            campaignRepo, artifactRepo, paragraphRepo, glossaryRepo, progressRepo,
+            llm: new CostReportingFakeLlmService(cost));
+
+        var query = new TranslateGamebookSegmentQuery(campaign.Id, artifact.Id, 47, ownerId, bookId);
+
+        // Act
+        using var capture = new CostEurCapture();
+        await foreach (var _ in handler.Handle(query, CancellationToken.None)) { }
+
+        // Assert — cost_eur = TotalCost x UsdToEurRate, tagged with the chunk's provider
+        var recorded = capture.ForProvider("test-seg-provider");
+        recorded.Should().NotBeNull("StreamChunk.Cost carries a positive cost → translation_cost_eur must be recorded");
+        recorded!.Value.Value.Should().BeApproximately(0.0005 * MeepleAiMetrics.UsdToEurRate, 1e-9);
+    }
+
+    [Fact]
+    public async Task Handle_FinalChunkWithoutCost_DoesNotRecordCostEur()
+    {
+        // Arrange — default FakeLlmService yields a final chunk with Usage but no Cost.
+        var campaignRepo = new FakeCampaignRepo();
+        var artifactRepo = new FakeArtifactRepo();
+        var paragraphRepo = new FakeParagraphRepo();
+        var glossaryRepo = new FakeGlossaryRepo();
+        var progressRepo = new FakeProgressRepo();
+
+        var ownerId = Guid.NewGuid();
+        var campaign = GamebookCampaignSession.Create(GameRef.Shared(Guid.NewGuid()), ownerId, "No-Cost Campaign");
+        campaignRepo.Store.Add(campaign);
+        var bookId = Guid.NewGuid();
+
+        var artifact = GamebookPhotoArtifact.Create(campaign.Id, bookId, $"gamebook-photos/{campaign.Id}/photo-nocost");
+        artifact.RecordSegments(
+            new[] { GamebookSegment.Create(47, "The Hive awakens.", null) },
+            "The Hive awakens.");
+        artifactRepo.Store.Add(artifact);
+
+        var handler = BuildHandler(campaignRepo, artifactRepo, paragraphRepo, glossaryRepo, progressRepo);
+        var query = new TranslateGamebookSegmentQuery(campaign.Id, artifact.Id, 47, ownerId, bookId);
+
+        // Act
+        using var capture = new CostEurCapture();
+        await foreach (var _ in handler.Handle(query, CancellationToken.None)) { }
+
+        // Assert — no cost means no EUR record (provider stays "unknown", helper skips the emit)
+        capture.ForProvider("unknown").Should().BeNull("null Cost → handler must not record translation_cost_eur");
+    }
+
+    /// <summary>
+    /// #2752: captures meepleai.gamebook.translation_cost_eur measurements, keyed by provider tag,
+    /// so assertions filter to this test's distinctive provider and stay robust under parallel test runs.
+    /// </summary>
+    private sealed class CostEurCapture : IDisposable
+    {
+        private const string CostName = "meepleai.gamebook.translation_cost_eur";
+        private readonly MeterListener _listener;
+        private readonly List<(double Value, string? Provider)> _captured = new();
+        private readonly object _gate = new();
+
+        public CostEurCapture()
+        {
+            _listener = new MeterListener
+            {
+                InstrumentPublished = (instrument, l) =>
+                {
+                    if (instrument.Meter.Name == MeepleAiMetrics.MeterName && instrument.Name == CostName)
+                        l.EnableMeasurementEvents(instrument);
+                }
+            };
+            _listener.SetMeasurementEventCallback<double>((instrument, value, tags, _) =>
+            {
+                string? provider = null;
+                foreach (var tag in tags)
+                {
+                    if (tag.Key == "provider")
+                        provider = tag.Value as string;
+                }
+                lock (_gate)
+                {
+                    _captured.Add((value, provider));
+                }
+            });
+            _listener.Start();
+        }
+
+        public (double Value, string? Provider)? ForProvider(string provider)
+        {
+            lock (_gate)
+            {
+                return _captured
+                    .Where(m => string.Equals(m.Provider, provider, StringComparison.Ordinal))
+                    .Select(m => ((double Value, string? Provider)?)m)
+                    .LastOrDefault();
+            }
+        }
+
+        public void Dispose() => _listener.Dispose();
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Queries/TranslateGamebookTextQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Queries/TranslateGamebookTextQueryHandlerTests.cs
@@ -4,7 +4,9 @@ using Api.BoundedContexts.SessionTracking.Application.Services;
 using Api.BoundedContexts.SessionTracking.Domain.Entities;
 using Api.BoundedContexts.SessionTracking.Domain.Enums;
 using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using System.Diagnostics.Metrics;
 using Api.Middleware.Exceptions;
+using Api.Observability;
 using Api.Services;
 using Api.Services.LlmClients;
 using Api.SharedKernel.Domain.ValueObjects;
@@ -14,6 +16,7 @@ using Xunit;
 
 namespace Api.Tests.BoundedContexts.SessionTracking.Application.Queries;
 
+[Collection("GamebookMeter")] // #2752: serialize with GamebookTranslationMetricsTests — shared static gamebook Meter
 [Trait("Category", "Unit")]
 [Trait("BoundedContext", "SessionTracking")]
 public sealed class TranslateGamebookTextQueryHandlerTests
@@ -92,6 +95,48 @@ public sealed class TranslateGamebookTextQueryHandlerTests
                 await Task.Yield();
             }
             yield return new StreamChunk(null, IsFinal: true, Usage: new LlmUsage(10, 5, 15));
+        }
+
+        public Task<LlmCompletionResult> GenerateCompletionAsync(string s, string u, RequestSource r = RequestSource.Manual, CancellationToken ct = default)
+            => Task.FromResult(LlmCompletionResult.CreateSuccess(string.Empty));
+
+        public Task<T?> GenerateJsonAsync<T>(string s, string u, RequestSource r = RequestSource.Manual, CancellationToken ct = default) where T : class
+            => Task.FromResult<T?>(null);
+
+        public Task<LlmCompletionResult> GenerateMultimodalCompletionAsync(IReadOnlyList<LlmMessage> messages, RequestSource source = RequestSource.Manual, CancellationToken ct = default)
+            => Task.FromResult(LlmCompletionResult.CreateSuccess(string.Empty));
+
+        public async IAsyncEnumerable<StreamChunk> GenerateMultimodalCompletionStreamAsync(
+            IReadOnlyList<LlmMessage> messages,
+            RequestSource source = RequestSource.Manual,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct = default)
+        {
+            yield return new StreamChunk(null, IsFinal: true);
+            await Task.CompletedTask;
+        }
+
+        public Task<LlmCompletionResult> GenerateCompletionWithModelAsync(string explicitModel, string systemPrompt, string userPrompt, RequestSource source = RequestSource.Manual, int? maxTokens = null, CancellationToken ct = default)
+            => Task.FromResult(LlmCompletionResult.CreateSuccess(string.Empty));
+    }
+
+    /// <summary>
+    /// #2752: Fake LLM whose final chunk carries BOTH Usage and Cost, mirroring what
+    /// OpenRouterLlmClient / DeepSeekLlmClient emit. Drives the translation_cost_eur wiring.
+    /// </summary>
+    private sealed class CostReportingFakeLlmService : ILlmService
+    {
+        private readonly LlmCost _cost;
+        public CostReportingFakeLlmService(LlmCost cost) => _cost = cost;
+
+        public async IAsyncEnumerable<StreamChunk> GenerateCompletionStreamAsync(
+            string systemPrompt,
+            string userPrompt,
+            RequestSource source = RequestSource.Manual,
+            [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken ct = default)
+        {
+            yield return new StreamChunk("Ciao mondo.", IsFinal: false);
+            await Task.Yield();
+            yield return new StreamChunk(null, Usage: new LlmUsage(10, 5, 15), Cost: _cost, IsFinal: true);
         }
 
         public Task<LlmCompletionResult> GenerateCompletionAsync(string s, string u, RequestSource r = RequestSource.Manual, CancellationToken ct = default)
@@ -325,6 +370,94 @@ public sealed class TranslateGamebookTextQueryHandlerTests
             "lowercase 'fr' must normalize to 'FR' → 'French' in prompt");
         chunks.Last().DetectedSourceLang.Should().Be("FR",
             "final chunk must echo normalized uppercase source lang code");
+    }
+
+    // ── #2752: translation_cost_eur wiring from StreamChunk.Cost ────────────────
+
+    [Fact]
+    public async Task Handle_FinalChunkCarriesCost_RecordsTranslationCostEur()
+    {
+        var (campaigns, glossary) = BuildRepos();
+        var campaign = campaigns.Store[0];
+
+        // TotalCost = 0.0005 USD, distinctive provider isolates this test from concurrent meter emitters.
+        var cost = new LlmCost { InputCost = 0.0003m, OutputCost = 0.0002m, ModelId = "deepseek-chat", Provider = "test-text-provider" };
+        var handler = BuildHandler(campaigns, glossary, llm: new CostReportingFakeLlmService(cost));
+        var query = new TranslateGamebookTextQuery(campaign.Id, "Hello world.", "EN", "IT", GameBookId, UserId);
+
+        using var capture = new CostEurCapture();
+        await foreach (var _ in handler.Handle(query, CancellationToken.None)) { }
+
+        var recorded = capture.ForProvider("test-text-provider");
+        recorded.Should().NotBeNull("StreamChunk.Cost carries a positive cost → translation_cost_eur must be recorded");
+        recorded!.Value.Value.Should().BeApproximately(0.0005 * MeepleAiMetrics.UsdToEurRate, 1e-9);
+    }
+
+    [Fact]
+    public async Task Handle_FinalChunkWithoutCost_DoesNotRecordCostEur()
+    {
+        var (campaigns, glossary) = BuildRepos();
+        var campaign = campaigns.Store[0];
+
+        // Default FakeLlmService yields a final chunk with Usage but no Cost.
+        var handler = BuildHandler(campaigns, glossary);
+        var query = new TranslateGamebookTextQuery(campaign.Id, "Hello world.", "EN", "IT", GameBookId, UserId);
+
+        using var capture = new CostEurCapture();
+        await foreach (var _ in handler.Handle(query, CancellationToken.None)) { }
+
+        capture.ForProvider("unknown").Should().BeNull("null Cost → handler must not record translation_cost_eur");
+    }
+
+    /// <summary>
+    /// #2752: captures meepleai.gamebook.translation_cost_eur measurements, keyed by provider tag,
+    /// so assertions filter to this test's distinctive provider and stay robust under parallel test runs.
+    /// </summary>
+    private sealed class CostEurCapture : IDisposable
+    {
+        private const string CostName = "meepleai.gamebook.translation_cost_eur";
+        private readonly MeterListener _listener;
+        private readonly List<(double Value, string? Provider)> _captured = new();
+        private readonly object _gate = new();
+
+        public CostEurCapture()
+        {
+            _listener = new MeterListener
+            {
+                InstrumentPublished = (instrument, l) =>
+                {
+                    if (instrument.Meter.Name == MeepleAiMetrics.MeterName && instrument.Name == CostName)
+                        l.EnableMeasurementEvents(instrument);
+                }
+            };
+            _listener.SetMeasurementEventCallback<double>((instrument, value, tags, _) =>
+            {
+                string? provider = null;
+                foreach (var tag in tags)
+                {
+                    if (tag.Key == "provider")
+                        provider = tag.Value as string;
+                }
+                lock (_gate)
+                {
+                    _captured.Add((value, provider));
+                }
+            });
+            _listener.Start();
+        }
+
+        public (double Value, string? Provider)? ForProvider(string provider)
+        {
+            lock (_gate)
+            {
+                return _captured
+                    .Where(m => string.Equals(m.Provider, provider, StringComparison.Ordinal))
+                    .Select(m => ((double Value, string? Provider)?)m)
+                    .LastOrDefault();
+            }
+        }
+
+        public void Dispose() => _listener.Dispose();
     }
 
     // ── Additional tracking fake ──────────────────────────────────────────────

--- a/apps/api/tests/Api.Tests/Observability/GamebookTranslationMetricsTests.cs
+++ b/apps/api/tests/Api.Tests/Observability/GamebookTranslationMetricsTests.cs
@@ -14,6 +14,18 @@ namespace Api.Tests.Observability;
 /// Prometheus alert rules and Grafana dashboards) and that record helpers emit
 /// values with the documented label set.
 /// </summary>
+/// <summary>
+/// #2752: the gamebook meter (meepleai.gamebook.*) is a process-wide static Meter. Tests that
+/// assert exact values via a global MeterListener + FindLast are polluted by ANY concurrent emitter
+/// (the translate handler tests now emit translation_cost_eur / latency / token). This collection
+/// serializes all direct + indirect gamebook-meter emitters so their assertions stay deterministic.
+/// </summary>
+[CollectionDefinition("GamebookMeter", DisableParallelization = true)]
+public sealed class GamebookMeterCollection
+{
+}
+
+[Collection("GamebookMeter")]
 [Trait("Category", TestCategories.Unit)]
 [Trait("Area", "Observability")]
 [Trait("BoundedContext", "SessionTracking")]

--- a/apps/web/src/app/(authenticated)/library/[gameId]/play/[campaignId]/encounter/__tests__/content.test.tsx
+++ b/apps/web/src/app/(authenticated)/library/[gameId]/play/[campaignId]/encounter/__tests__/content.test.tsx
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, type RenderResult } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactElement, ReactNode } from 'react';
+import { IntlProvider } from 'react-intl';
+
+import itMessages from '@/locales/it.json';
+import { Content } from '../_content';
+
+// #2750 C11: verify the encounter orchestrator wires the cheatsheet's "Glossario"
+// affordance to the read-only GlossaryLookupModal. EncounterCheatsheetView and
+// GlossaryLookupModal are tested independently; here we test the _content wiring.
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock('@/lib/gamebook/hooks/useEncounterParse', () => ({
+  useEncounterParse: () => ({
+    status: 'idle',
+    data: null,
+    error: undefined,
+    mutate: vi.fn(),
+    reset: vi.fn(),
+  }),
+}));
+
+// The real GlossaryLookupModal (imported directly, not via the barrel) reads this.
+vi.mock('@/lib/gamebook/hooks/useGamebookGlossary', () => ({
+  useGamebookGlossary: () => ({ data: [], isLoading: false, isError: false }),
+}));
+
+// Replace EncounterCheatsheetView with a stub that surfaces the onOpenGlossary prop
+// as a clickable button, so the wiring (not the FSM) is under test.
+vi.mock('@/components/features/gamebook', async importOriginal => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...actual,
+    EncounterCheatsheetView: ({ onOpenGlossary }: { onOpenGlossary?: () => void }) => (
+      <button type="button" onClick={onOpenGlossary}>
+        stub-open-glossary
+      </button>
+    ),
+  };
+});
+
+function flatten(obj: Record<string, unknown>, prefix = ''): Record<string, string> {
+  return Object.keys(obj).reduce(
+    (acc, key) => {
+      const full = prefix ? `${prefix}.${key}` : key;
+      const value = obj[key];
+      if (value && typeof value === 'object') {
+        Object.assign(acc, flatten(value as Record<string, unknown>, full));
+      } else {
+        acc[full] = String(value);
+      }
+      return acc;
+    },
+    {} as Record<string, string>
+  );
+}
+const FLAT_IT = flatten(itMessages as Record<string, unknown>);
+
+function renderContent(ui: ReactElement): RenderResult {
+  function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <IntlProvider locale="it" messages={FLAT_IT} onError={() => {}}>
+        {children}
+      </IntlProvider>
+    );
+  }
+  return render(ui, { wrapper: Wrapper });
+}
+
+const PROPS = {
+  gameId: 'g1',
+  campaignId: 'c1',
+  photoId: 'p1',
+  paragraphNumber: 218,
+  gameBookId: 'b1',
+  fromLabel: '147',
+  excerpt: 'You face a sentinel.',
+};
+
+describe('encounter/_content — GlossaryLookupModal wiring (#2750 C11)', () => {
+  it('does not show the glossary modal initially', () => {
+    renderContent(<Content {...PROPS} />);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('opens the read-only glossary look-up when the cheatsheet glossary action fires', async () => {
+    renderContent(<Content {...PROPS} />);
+    const user = userEvent.setup();
+
+    await user.click(screen.getByRole('button', { name: 'stub-open-glossary' }));
+
+    const dialog = screen.getByRole('dialog', { name: 'Glossario' });
+    expect(dialog).toBeVisible();
+  });
+});

--- a/apps/web/src/app/(authenticated)/library/[gameId]/play/[campaignId]/encounter/_content.tsx
+++ b/apps/web/src/app/(authenticated)/library/[gameId]/play/[campaignId]/encounter/_content.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useMemo, type ReactElement } from 'react';
+import { useMemo, useState, type ReactElement } from 'react';
 
 import { useRouter } from 'next/navigation';
 
@@ -9,6 +9,7 @@ import {
   type EncounterCheatsheetLabels,
   type EncounterStoryContext,
 } from '@/components/features/gamebook';
+import { GlossaryLookupModal } from '@/components/features/gamebook/GlossaryLookupModal';
 import { useTranslation } from '@/hooks/useTranslation';
 import { deriveEncounterStatus, mapEncounterError } from '@/lib/gamebook/encounter-fsm';
 import { useEncounterParse } from '@/lib/gamebook/hooks/useEncounterParse';
@@ -39,6 +40,8 @@ export function Content({
   const { t } = useTranslation();
   const router = useRouter();
   const parse = useEncounterParse(campaignId, photoId);
+  // #2750 C11: read-only glossary look-up, opened from the cheatsheet's "Glossario".
+  const [glossaryOpen, setGlossaryOpen] = useState(false);
 
   const paragraphMarker = paragraphNumber > 0 ? `§${paragraphNumber}` : '';
 
@@ -93,7 +96,13 @@ export function Content({
         labels={labels}
         onParse={() => parse.mutate({ paragraphNumber, gameBookId })}
         onResolve={() => router.push(`/library/${gameId}/play/${campaignId}`)}
+        onOpenGlossary={() => setGlossaryOpen(true)}
         onCancel={() => parse.reset()}
+      />
+      <GlossaryLookupModal
+        campaignId={campaignId}
+        isOpen={glossaryOpen}
+        onClose={() => setGlossaryOpen(false)}
       />
     </main>
   );

--- a/apps/web/src/app/(authenticated)/library/[gameId]/play/[campaignId]/translate/_content.tsx
+++ b/apps/web/src/app/(authenticated)/library/[gameId]/play/[campaignId]/translate/_content.tsx
@@ -47,7 +47,7 @@ export function Content({
       {isManualMode ? (
         <ManualInputView campaignId={campaignId} gameRef={gameRef} />
       ) : (
-        <TranslateViewer campaignId={campaignId} gameRef={gameRef} />
+        <TranslateViewer campaignId={campaignId} gameId={gameId} gameRef={gameRef} />
       )}
     </main>
   );

--- a/apps/web/src/components/features/gamebook/GlossaryLookupModal.tsx
+++ b/apps/web/src/components/features/gamebook/GlossaryLookupModal.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+import { useEffect, type ReactElement } from 'react';
+
+import { useTranslation } from '@/hooks/useTranslation';
+import { useGamebookGlossary } from '@/lib/gamebook/hooks/useGamebookGlossary';
+
+export interface GlossaryLookupModalProps {
+  /** Campaign whose glossary is looked up. */
+  readonly campaignId: string;
+  /** Whether the modal is visible. */
+  readonly isOpen: boolean;
+  /** Called when the user dismisses the modal (Escape, scrim, close button). */
+  readonly onClose: () => void;
+}
+
+/**
+ * #2750 C11 — read-only glossary look-up.
+ *
+ * Lists the campaign's EN → IT glossary terms so a player can look them up in
+ * context (e.g. from the encounter cheatsheet's "Glossario" affordance). This is
+ * deliberately distinct from {@link GlossaryEditorModal}, which edits a single
+ * entry: the look-up is read-only and shows the whole glossary at once.
+ */
+export function GlossaryLookupModal({
+  campaignId,
+  isOpen,
+  onClose,
+}: GlossaryLookupModalProps): ReactElement | null {
+  const { t } = useTranslation();
+  const { data: entries, isLoading, isError } = useGamebookGlossary(campaignId);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  const isEmpty = !isLoading && !isError && (entries?.length ?? 0) === 0;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={t('gamebook.glossaryLookup.title')}
+      className="fixed inset-0 z-50 flex items-end justify-center sm:items-center"
+    >
+      <div
+        data-testid="glossary-lookup-scrim"
+        role="presentation"
+        onClick={onClose}
+        className="absolute inset-0 bg-[rgba(0,0,0,0.45)]"
+      />
+      <div className="relative z-10 flex max-h-[80vh] w-full max-w-md flex-col overflow-hidden rounded-t-2xl border border-border bg-card shadow-xl sm:rounded-2xl">
+        <header className="flex items-center justify-between gap-3 border-b border-border px-4 py-3">
+          <div className="flex flex-col">
+            <h2 className="text-base font-semibold text-foreground">
+              {t('gamebook.glossaryLookup.title')}
+            </h2>
+            <span className="text-xs text-muted-foreground">
+              {t('gamebook.glossaryLookup.subtitle')}
+            </span>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label={t('gamebook.glossaryLookup.close')}
+            className="rounded-md p-1.5 text-muted-foreground hover:bg-muted"
+          >
+            <span aria-hidden="true">✕</span>
+          </button>
+        </header>
+
+        <div className="overflow-y-auto px-4 py-3">
+          {isLoading && (
+            <p
+              className="text-sm text-muted-foreground"
+              role="status"
+              data-testid="glossary-lookup-loading"
+            >
+              {t('gamebook.glossaryLookup.loading')}
+            </p>
+          )}
+          {isError && (
+            <p
+              className="text-sm text-destructive"
+              role="alert"
+              data-testid="glossary-lookup-error"
+            >
+              {t('gamebook.glossaryLookup.error')}
+            </p>
+          )}
+          {isEmpty && (
+            <p className="text-sm text-muted-foreground" data-testid="glossary-lookup-empty">
+              {t('gamebook.glossaryLookup.empty')}
+            </p>
+          )}
+          {!isLoading && !isError && entries && entries.length > 0 && (
+            <ul className="divide-y divide-border" data-testid="glossary-lookup-list">
+              {entries.map(entry => (
+                <li key={entry.id} className="flex items-baseline gap-2 py-2">
+                  <span className="font-medium text-foreground">{entry.termEn}</span>
+                  <span aria-hidden="true" className="text-muted-foreground">
+                    →
+                  </span>
+                  <span className="text-foreground">{entry.termIt}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/features/gamebook/LibroGameDetailView.tsx
+++ b/apps/web/src/components/features/gamebook/LibroGameDetailView.tsx
@@ -19,12 +19,14 @@
 
 import { useState, type ReactElement } from 'react';
 
+import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 
 import { GameBookList } from '@/components/features/gamebook/GameBookList';
 import { NanolithCampaignCTA } from '@/components/features/gamebook/NanolithCampaignCTA';
 import type { LibraryGameDetail } from '@/hooks/queries/useLibrary';
 import type { GameBookDto } from '@/lib/api/gamebook';
+import { useChatPanelStore } from '@/lib/stores/chat-panel-store';
 
 // ─── Types ──────────────────────────────────────────────────────────────────
 
@@ -48,6 +50,7 @@ export function LibroGameDetailView({
   booksLoading,
 }: LibroGameDetailViewProps): ReactElement {
   const router = useRouter();
+  const openChat = useChatPanelStore(s => s.open);
   const [tab, setTab] = useState<TabId>('info');
 
   const playersLabel =
@@ -185,9 +188,33 @@ export function LibroGameDetailView({
           {tab === 'info' && (
             <InfoPanel detail={gameDetail} books={books} booksLoading={booksLoading} />
           )}
-          {tab === 'chat' && <PlaceholderPanel label="AI Chat" />}
-          {tab === 'toolbox' && <PlaceholderPanel label="Toolbox" />}
-          {tab === 'toolkit' && <PlaceholderPanel label="Toolkit" />}
+          {/* #2750 C1 — the 3 non-Info tabs wire to real surfaces (was a placeholder). */}
+          {tab === 'chat' && (
+            <ChatTabPanel
+              onOpen={() =>
+                openChat({
+                  id: gameDetail.gameId,
+                  name: gameDetail.gameTitle,
+                  pdfCount: gameDetail.chunkCount ?? 0,
+                  kbStatus: 'ready',
+                })
+              }
+            />
+          )}
+          {tab === 'toolbox' && (
+            <ToolLinkPanel
+              label="Toolbox"
+              href={`/library/${gameDetail.gameId}/toolbox`}
+              description="Mazzi, fasi e strumenti di sessione per questo gioco."
+            />
+          )}
+          {tab === 'toolkit' && (
+            <ToolLinkPanel
+              label="Toolkit"
+              href={`/library/${gameDetail.gameId}/toolkit`}
+              description="Suggerimenti AI e strumenti generati dalla knowledge base."
+            />
+          )}
         </section>
       </main>
     </div>
@@ -324,12 +351,46 @@ function InfoPanel({
   );
 }
 
-function PlaceholderPanel({ label }: { label: string }): ReactElement {
+// #2750 C1 — AI Chat tab: opens the global chat panel (chat-panel-store) preseeded
+// with this game's context, mirroring GamebookPlayShell's "Apri chat con agente".
+function ChatTabPanel({ onOpen }: { onOpen: () => void }): ReactElement {
   return (
     <div className="rounded-[14px] border border-dashed border-[rgba(180,130,80,0.32)] bg-card p-6 text-center">
-      <p className="text-[15px] text-[#5a4a38]">
-        Pannello <strong>{label}</strong> · in arrivo con la prossima iter.
+      <p className="mb-3 text-[15px] text-[#5a4a38]">
+        Chatta con l&rsquo;<strong>agente Tutor</strong> per Q&amp;A sulle regole, con citazioni
+        dalla knowledge base.
       </p>
+      <button
+        type="button"
+        onClick={onOpen}
+        className="inline-flex items-center gap-2 rounded-[10px] bg-[hsl(var(--c-agent))] px-4 py-2 font-quicksand text-sm font-semibold text-white hover:opacity-90"
+      >
+        <span aria-hidden="true">💬</span> Apri chat con l&rsquo;agente
+      </button>
+    </div>
+  );
+}
+
+// #2750 C1 — Toolbox/Toolkit tabs: link to the dedicated in-app sub-pages
+// (/library/[gameId]/toolbox|toolkit) that already exist.
+function ToolLinkPanel({
+  label,
+  href,
+  description,
+}: {
+  label: string;
+  href: string;
+  description: string;
+}): ReactElement {
+  return (
+    <div className="rounded-[14px] border border-dashed border-[rgba(180,130,80,0.32)] bg-card p-6 text-center">
+      <p className="mb-3 text-[15px] text-[#5a4a38]">{description}</p>
+      <Link
+        href={href}
+        className="inline-flex items-center gap-2 rounded-[10px] bg-[hsl(var(--c-game))] px-4 py-2 font-quicksand text-sm font-semibold text-white hover:opacity-90"
+      >
+        Apri {label}
+      </Link>
     </div>
   );
 }

--- a/apps/web/src/components/features/gamebook/TranslateViewer.tsx
+++ b/apps/web/src/components/features/gamebook/TranslateViewer.tsx
@@ -2,6 +2,8 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactElement } from 'react';
 
+import Link from 'next/link';
+
 import { AbortButton } from '@/components/features/gamebook/AbortButton';
 import { BookPicker } from '@/components/features/gamebook/BookPicker';
 import { EnterManualLink } from '@/components/features/gamebook/EnterManualLink';
@@ -29,6 +31,12 @@ import { getLangTier, type LangTier } from '@/lib/gamebook/lang-tier';
 
 export interface TranslateViewerProps {
   campaignId: string;
+  /**
+   * #2750 C9: the route `gameId`, threaded from the translate page so the viewer
+   * can build the encounter-cheatsheet link (`/library/[gameId]/…/encounter`).
+   * Optional: when absent (legacy test-seams / stories) the link is not rendered.
+   */
+  gameId?: string;
   /**
    * GameRef of the campaign being translated. Required so the viewer can
    * fetch the list of GameBooks (multi-book generalization, Phase E).
@@ -99,6 +107,7 @@ function effectiveTier(
 
 export function TranslateViewer({
   campaignId,
+  gameId,
   gameRef,
   _initialPhase,
   _initialArtifact,
@@ -489,6 +498,33 @@ export function TranslateViewer({
           error={sse.error}
         />
       )}
+
+      {/* #2750 C9 — encounter-cheatsheet entry point. Available once a segment is
+          translated: the encounter route needs photoId + target paragraph +
+          gameBookId, all resolved at this point. This is the only live surface
+          that carries those params (the play shell lacks photoId). */}
+      {gameId &&
+        artifact &&
+        activeSegment &&
+        effectiveBookId &&
+        phase === 'translated' &&
+        sse.isComplete && (
+          <div className="rounded-lg border border-[var(--c-game)]/20 bg-background p-4">
+            <Link
+              href={`/library/${gameId}/play/${campaignId}/encounter?${new URLSearchParams({
+                photoId: artifact.id,
+                to: String(activeSegment.paragraphNumber),
+                gameBookId: effectiveBookId,
+                from: String(activeSegment.paragraphNumber),
+              }).toString()}`}
+              data-testid="translate-open-encounter"
+              className="inline-flex items-center gap-2 text-sm font-medium text-[var(--c-game)] hover:underline"
+            >
+              <span aria-hidden="true">⚔️</span> Apri scheda incontro §
+              {activeSegment.paragraphNumber}
+            </Link>
+          </div>
+        )}
 
       <LangOverrideModal
         open={modalState.open}

--- a/apps/web/src/components/features/gamebook/__tests__/GlossaryLookupModal.test.tsx
+++ b/apps/web/src/components/features/gamebook/__tests__/GlossaryLookupModal.test.tsx
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, within, type RenderResult } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactElement, ReactNode } from 'react';
+import { IntlProvider } from 'react-intl';
+
+import itMessages from '@/locales/it.json';
+import type { GamebookGlossaryEntry } from '@/lib/api/gamebook-glossary';
+import { GlossaryLookupModal } from '../GlossaryLookupModal';
+
+// #2750 C11: the modal is a read-only look-up over useGamebookGlossary. Mock the
+// hook so no QueryClientProvider is needed and we control the list.
+const glossaryState = vi.hoisted(() => ({
+  data: undefined as GamebookGlossaryEntry[] | undefined,
+  isLoading: false,
+  isError: false,
+}));
+vi.mock('@/lib/gamebook/hooks/useGamebookGlossary', () => ({
+  useGamebookGlossary: () => glossaryState,
+}));
+
+function flatten(obj: Record<string, unknown>, prefix = ''): Record<string, string> {
+  return Object.keys(obj).reduce(
+    (acc, key) => {
+      const full = prefix ? `${prefix}.${key}` : key;
+      const value = obj[key];
+      if (value && typeof value === 'object') {
+        Object.assign(acc, flatten(value as Record<string, unknown>, full));
+      } else {
+        acc[full] = String(value);
+      }
+      return acc;
+    },
+    {} as Record<string, string>
+  );
+}
+const FLAT_IT = flatten(itMessages as Record<string, unknown>);
+
+function renderModal(ui: ReactElement): RenderResult {
+  function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <IntlProvider locale="it" messages={FLAT_IT} onError={() => {}}>
+        {children}
+      </IntlProvider>
+    );
+  }
+  return render(ui, { wrapper: Wrapper });
+}
+
+function makeEntry(overrides: Partial<GamebookGlossaryEntry> = {}): GamebookGlossaryEntry {
+  return {
+    id: 'e1',
+    termEn: 'Hive',
+    termIt: 'Alveare',
+    source: 'AutoBootstrap',
+    updatedAt: '2026-07-01T00:00:00Z',
+    contexts: [],
+    ...overrides,
+  };
+}
+
+describe('GlossaryLookupModal', () => {
+  beforeEach(() => {
+    glossaryState.data = undefined;
+    glossaryState.isLoading = false;
+    glossaryState.isError = false;
+  });
+
+  it('renders nothing when closed', () => {
+    const { container } = renderModal(
+      <GlossaryLookupModal campaignId="c1" isOpen={false} onClose={vi.fn()} />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('lists glossary terms EN→IT when open', () => {
+    glossaryState.data = [
+      makeEntry({ id: '1', termEn: 'Hive', termIt: 'Alveare' }),
+      makeEntry({ id: '2', termEn: 'Sword', termIt: 'Spada', source: 'Manual' }),
+    ];
+    renderModal(<GlossaryLookupModal campaignId="c1" isOpen onClose={vi.fn()} />);
+
+    const dialog = screen.getByRole('dialog');
+    expect(within(dialog).getByText('Hive')).toBeVisible();
+    expect(within(dialog).getByText('Alveare')).toBeVisible();
+    expect(within(dialog).getByText('Sword')).toBeVisible();
+    expect(within(dialog).getByText('Spada')).toBeVisible();
+  });
+
+  it('shows the empty state when the campaign has no glossary terms', () => {
+    glossaryState.data = [];
+    renderModal(<GlossaryLookupModal campaignId="c1" isOpen onClose={vi.fn()} />);
+    expect(screen.getByTestId('glossary-lookup-empty')).toBeVisible();
+  });
+
+  it('shows an error state when the glossary fetch fails', () => {
+    glossaryState.isError = true;
+    renderModal(<GlossaryLookupModal campaignId="c1" isOpen onClose={vi.fn()} />);
+    expect(screen.getByTestId('glossary-lookup-error')).toBeVisible();
+  });
+
+  it('calls onClose when the close button is clicked', async () => {
+    glossaryState.data = [];
+    const onClose = vi.fn();
+    renderModal(<GlossaryLookupModal campaignId="c1" isOpen onClose={onClose} />);
+    const user = userEvent.setup();
+
+    await user.click(screen.getByRole('button', { name: /chiudi/i }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/components/features/gamebook/__tests__/LibroGameDetailView.test.tsx
+++ b/apps/web/src/components/features/gamebook/__tests__/LibroGameDetailView.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, within, type RenderResult } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { axe, toHaveNoViolations } from 'jest-axe';
@@ -64,6 +64,13 @@ vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: vi.fn() }),
 }));
 
+// #2750 C1: the AI Chat tab opens the global chat panel via chat-panel-store.
+const mockOpenChat = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/stores/chat-panel-store', () => ({
+  useChatPanelStore: (selector: (s: { open: typeof mockOpenChat }) => unknown) =>
+    selector({ open: mockOpenChat }),
+}));
+
 vi.mock('@/components/features/gamebook/NanolithCampaignCTA', () => ({
   NanolithCampaignCTA: ({ gameId, gameTitle }: { gameId: string; gameTitle: string }) => (
     <div data-testid="mock-nanolith-cta">
@@ -110,6 +117,10 @@ function makeLibraryGameDetail(overrides: Partial<LibraryGameDetail> = {}): Libr
 // ─── Tests ──────────────────────────────────────────────────────────────────
 
 describe('LibroGameDetailView', () => {
+  beforeEach(() => {
+    mockOpenChat.mockClear();
+  });
+
   it('renders default tab "info" with InfoPanel', () => {
     const gameDetail = makeLibraryGameDetail();
     renderView(<LibroGameDetailView gameDetail={gameDetail} />);
@@ -179,31 +190,50 @@ describe('LibroGameDetailView', () => {
     expect(screen.getByLabelText('partite 5')).toBeVisible();
   });
 
-  it('switches tabs and shows placeholder text', async () => {
-    const gameDetail = makeLibraryGameDetail();
+  // #2750 C1: the 3 non-Info tabs are wired to real surfaces (no more "in arrivo" placeholder).
+
+  it('C1: AI Chat tab opens the global chat panel with the game context', async () => {
+    const gameDetail = makeLibraryGameDetail({
+      gameId: 'g1',
+      gameTitle: 'Nanolith',
+      chunkCount: 4,
+    });
     renderView(<LibroGameDetailView gameDetail={gameDetail} />);
     const user = userEvent.setup();
 
-    // Click AI Chat tab
     await user.click(screen.getByRole('tab', { name: 'AI Chat' }));
-    expect(screen.getByText(/Pannello/i)).toBeVisible();
-    // Verify placeholder panel is visible by checking both the label and complete text together
     const chatPanel = screen.getByRole('tabpanel');
-    expect(chatPanel).toHaveTextContent('Pannello');
-    expect(chatPanel).toHaveTextContent('AI Chat');
-    expect(chatPanel).toHaveTextContent(/in arrivo con la prossima iter/);
+    expect(chatPanel).not.toHaveTextContent(/in arrivo con la prossima iter/);
 
-    // Click Toolbox tab
+    await user.click(within(chatPanel).getByRole('button', { name: /chat/i }));
+    expect(mockOpenChat).toHaveBeenCalledTimes(1);
+    expect(mockOpenChat).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'g1', name: 'Nanolith' })
+    );
+  });
+
+  it('C1: Toolbox tab links to the game toolbox sub-page', async () => {
+    const gameDetail = makeLibraryGameDetail({ gameId: 'g1' });
+    renderView(<LibroGameDetailView gameDetail={gameDetail} />);
+    const user = userEvent.setup();
+
     await user.click(screen.getByRole('tab', { name: 'Toolbox' }));
-    const toolboxPanel = screen.getByRole('tabpanel');
-    expect(toolboxPanel).toHaveTextContent('Toolbox');
-    expect(toolboxPanel).toHaveTextContent(/in arrivo con la prossima iter/);
+    const panel = screen.getByRole('tabpanel');
+    expect(panel).not.toHaveTextContent(/in arrivo con la prossima iter/);
+    const link = within(panel).getByRole('link');
+    expect(link).toHaveAttribute('href', '/library/g1/toolbox');
+  });
 
-    // Click Toolkit tab
+  it('C1: Toolkit tab links to the game toolkit sub-page', async () => {
+    const gameDetail = makeLibraryGameDetail({ gameId: 'g1' });
+    renderView(<LibroGameDetailView gameDetail={gameDetail} />);
+    const user = userEvent.setup();
+
     await user.click(screen.getByRole('tab', { name: 'Toolkit' }));
-    const toolkitPanel = screen.getByRole('tabpanel');
-    expect(toolkitPanel).toHaveTextContent('Toolkit');
-    expect(toolkitPanel).toHaveTextContent(/in arrivo con la prossima iter/);
+    const panel = screen.getByRole('tabpanel');
+    expect(panel).not.toHaveTextContent(/in arrivo con la prossima iter/);
+    const link = within(panel).getByRole('link');
+    expect(link).toHaveAttribute('href', '/library/g1/toolkit');
   });
 
   it("KB badge variant: kbStatus='indexing'", () => {

--- a/apps/web/src/components/features/gamebook/__tests__/TranslateViewer.test.tsx
+++ b/apps/web/src/components/features/gamebook/__tests__/TranslateViewer.test.tsx
@@ -233,6 +233,36 @@ describe('TranslateViewer', () => {
     expect(screen.getByTestId('translate-viewer-error')).toHaveTextContent('stream_error');
   });
 
+  // #2750 C9 — encounter cheatsheet entry point. The encounter route needs
+  // photoId + target paragraph + gameBookId, all available once a segment is
+  // translated. This is the only live surface with those params.
+  it('#2750 C9: offers an encounter-cheatsheet link after a segment is translated', () => {
+    makeOneBookMock();
+    wrap(
+      <TranslateViewer
+        campaignId={CAMPAIGN_ID}
+        gameRef={GAME_REF}
+        gameId={GAME_ID}
+        _initialPhase="translated"
+        _initialArtifact={FAKE_ARTIFACT as never}
+        _initialActiveSegment={FAKE_ARTIFACT.segments[0] as never}
+        _initialSseState={{ isComplete: true, partialText: 'Ti svegli in una prigione.' }}
+      />
+    );
+
+    const link = screen.getByTestId('translate-open-encounter');
+    expect(link).toHaveAttribute(
+      'href',
+      `/library/${GAME_ID}/play/${CAMPAIGN_ID}/encounter?photoId=${ARTIFACT_ID}&to=1&gameBookId=${BOOK_STORY_ID}&from=1`
+    );
+  });
+
+  it('#2750 C9: does not offer the encounter link before a translation completes', () => {
+    makeOneBookMock();
+    wrap(<TranslateViewer campaignId={CAMPAIGN_ID} gameRef={GAME_REF} gameId={GAME_ID} />);
+    expect(screen.queryByTestId('translate-open-encounter')).not.toBeInTheDocument();
+  });
+
   it('shows error copy and disables camera when no narrative books exist (E3)', () => {
     vi.mocked(booksHook.useGameBooks).mockReturnValue({
       data: [],

--- a/apps/web/src/components/features/gamebook/index.ts
+++ b/apps/web/src/components/features/gamebook/index.ts
@@ -148,6 +148,10 @@ export type {
 export { GlossaryEditorModal } from '@/components/features/gamebook/GlossaryEditorModal';
 export type { GlossaryEditorModalProps } from '@/components/features/gamebook/GlossaryEditorModal';
 
+// #2750 C11 — read-only glossary look-up (distinct from the single-entry editor above)
+export { GlossaryLookupModal } from '@/components/features/gamebook/GlossaryLookupModal';
+export type { GlossaryLookupModalProps } from '@/components/features/gamebook/GlossaryLookupModal';
+
 // Issue #1484 — Encounter Book cheatsheet (parse-centric MVP, consumes BE #1520)
 export { EncounterCheatsheetView } from '@/components/features/gamebook/EncounterCheatsheetView';
 export type {

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -3673,6 +3673,14 @@
       "lore": "Lore",
       "setup": "Setup"
     },
+    "glossaryLookup": {
+      "title": "Glossary",
+      "subtitle": "Campaign terms (EN → IT)",
+      "close": "Close",
+      "loading": "Loading glossary…",
+      "error": "Failed to load the glossary. Retry.",
+      "empty": "No glossary terms yet. Terms are created during translation."
+    },
     "glossaryEditor": {
       "title": "Edit glossary entry",
       "termEnLabel": "Source term",

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -3726,6 +3726,14 @@
       "lore": "Ambientazione",
       "setup": "Setup"
     },
+    "glossaryLookup": {
+      "title": "Glossario",
+      "subtitle": "Termini della campagna (EN → IT)",
+      "close": "Chiudi",
+      "loading": "Caricamento del glossario…",
+      "error": "Errore nel caricamento del glossario. Riprova.",
+      "empty": "Nessun termine nel glossario. I termini vengono creati durante la traduzione."
+    },
     "glossaryEditor": {
       "title": "Modifica voce di glossario",
       "termEnLabel": "Termine originale",


### PR DESCRIPTION
## Release main-dev → main-staging (auto-deploy on merge)

Second staging promotion for #2655. The prior deploy (#2756) validated the STEP 6 in-container health-check but its **Post-deploy Validation** job failed because the Deep Health Check + two /health smoke probes did not tolerate a 503 Degraded API (non-critical `slack_queue` backlog). This release carries the fix (#2760).

### Delta (3 commits, no AI-service changes → no disk-gate risk)
- `#2760` fix(ci): deep-health + smoke tolerate 503 Degraded API
- `#2758` feat(gamebook): wire libro detail tabs, encounter entry, glossary look-up
- `#2754` feat(observability): gamebook translation_cost_eur from StreamChunk.Cost

### Expected
Deploy job (STEP 6 health-wait) passes as before; the validate job now accepts a 503 Degraded response for reachability while still gating on postgres+redis Healthy. A genuine outage (000/timeout) still fails.

Refs #2655