### PR TITLE
release: staging — #2655 fix AI-deploy disk-gate loop (structural)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -229,14 +229,18 @@ jobs:
             echo "📦 Selective deploy: api=$API, web=$WEB"
           fi
 
-          # Issue #1578 — AI service change detection. Same force-full triggers
-          # as api/web (workflow_dispatch / force / infra / initial push).
+          # Issue #1578 — AI service change detection.
+          # #2655 — INFRA is deliberately NOT a force trigger for AI (unlike api/web). The AI
+          # images (~10GB embedding + ~13GB reranker) do NOT depend on infra/** or the workflow
+          # file, so an infra/workflow-only change must not force a ~23GB re-pull that trips the
+          # AI_PULL_GATE on the 75GB staging VPS. AI is re-pulled only on an explicit operator
+          # deploy (workflow_dispatch / force_full_deploy), an initial push that can't diff, or an
+          # actual change to the service's own path (apps/{embedding,reranker,orchestration}-service).
           EMB="${{ steps.changes.outputs.embedding }}"
           RRK="${{ steps.changes.outputs.reranker }}"
           ORC="${{ steps.changes.outputs.orchestration }}"
           if [ "$EVENT" = "workflow_dispatch" ] \
             || [ "$FORCE" = "true" ] \
-            || [ "$INFRA" = "true" ] \
             || [ "$BEFORE" = "$ZEROS" ] \
             || [ -z "$BEFORE" ]; then
             EMB=true; RRK=true; ORC=true
@@ -1041,16 +1045,34 @@ jobs:
             RRK_CHANGED="${{ fromJSON(needs.detect-changes.outputs.ai_changed).reranker }}"
             ORC_CHANGED="${{ fromJSON(needs.detect-changes.outputs.ai_changed).orchestration }}"
 
-            # Pre-pull disk guard (issue #1578 / #1575). Pulling a ~5GB torch
-            # image while the old one is still referenced can fill the disk.
-            # Pre-prune, then require AI_PULL_GATE_GB free; otherwise ABORT
-            # (fail-safe) — never risk disk-full.
+            # Issue #1578 follow-up — free OLD AI images BEFORE the disk gate (disk-safe order).
+            # The old image stays referenced by the running container while the new one is pulled
+            # (transient peak ~old+new). Freeing the changed services' old images first (~10GB
+            # embedding + ~13GB reranker) lets the AI_PULL_GATE below see the REAL post-free
+            # headroom. #2655 — previously free_old_ai ran AFTER this gate, so on the 75GB VPS the
+            # gate saw only ~10GB free (old images still present) and aborted every AI deploy before
+            # the space could be reclaimed. Trade-off: ~30-60s AI downtime during the pull.
+            free_old_ai() {
+              local cont="$1"
+              local old_img
+              old_img=$(docker inspect "$cont" --format '{{.Image}}' 2>/dev/null || true)
+              docker rm -f "$cont" 2>/dev/null && echo "  - stopped + removed $cont" || true
+              if [ -n "$old_img" ]; then
+                docker rmi "$old_img" 2>/dev/null && echo "  - rmi $old_img" || echo "  - rmi $old_img skipped (in use elsewhere)"
+              fi
+            }
+
+            # Pre-pull disk guard (issue #1578 / #1575): free old AI images, prune, then require
+            # AI_PULL_GATE_GB free; otherwise ABORT (fail-safe) — never risk disk-full.
             AI_PULL_GATE_GB="${AI_PULL_GATE_GB:-15}"
             if [ "$EMB_CHANGED" = "true" ] || [ "$RRK_CHANGED" = "true" ] || [ "$ORC_CHANGED" = "true" ]; then
+              echo "🗑️ Freeing old AI images before disk gate (disk-safe ordering)..."
+              [ "$EMB_CHANGED" = "true" ] && free_old_ai meepleai-embedding
+              [ "$RRK_CHANGED" = "true" ] && free_old_ai meepleai-reranker
               echo "🧹 Pre-prune before AI image pull..."
               docker image prune -af --filter "until=24h" || true
               FREE_GB=$(df -BG / | awk 'NR==2 {gsub(/G/,"",$4); print $4}')
-              echo "💽 VPS disk: ${FREE_GB} GB free — AI pull gate ${AI_PULL_GATE_GB} GB"
+              echo "💽 VPS disk after free: ${FREE_GB} GB free — AI pull gate ${AI_PULL_GATE_GB} GB"
               if [ "$FREE_GB" -lt "$AI_PULL_GATE_GB" ]; then
                 echo "::error::Insufficient disk for AI image pull: ${FREE_GB} GB free < ${AI_PULL_GATE_GB} GB"
                 echo "🚫 Aborting AI deploy (fail-safe). Manual cleanup on the VPS:"
@@ -1077,33 +1099,7 @@ jobs:
               echo "📦 Web image updated"
             fi
 
-            # Issue #1578 follow-up — free-old-AI before pull (disk-safe order).
-            # The original "pull then recreate then prune" order leaves OLD AI
-            # images on disk during the new pull (transient peak ~old+new). On
-            # a VPS at 14 GB free this hit the AI_PULL_GATE_GB=15 fail-safe and
-            # blocked the deploy (run 26563212569). Re-ordering to:
-            #   stop+rm container → rmi old image → pull new → compose recreate
-            # frees ~5.3 GB (embedding) + ~2.1 GB (reranker) BEFORE the pull, so
-            # the transient peak does not need the full old+new headroom.
-            # Trade-off: ~30-60s extra AI downtime per service during the pull,
-            # acceptable on staging.
-            free_old_ai() {
-              local cont="$1"
-              local old_img
-              old_img=$(docker inspect "$cont" --format '{{.Image}}' 2>/dev/null || true)
-              docker rm -f "$cont" 2>/dev/null && echo "  - stopped + removed $cont" || true
-              if [ -n "$old_img" ]; then
-                docker rmi "$old_img" 2>/dev/null && echo "  - rmi $old_img" || echo "  - rmi $old_img skipped (in use elsewhere)"
-              fi
-            }
-            if [ "$EMB_CHANGED" = "true" ] || [ "$RRK_CHANGED" = "true" ]; then
-              echo "🗑️ Freeing old AI images before pull (disk-safe ordering)..."
-              [ "$EMB_CHANGED" = "true" ] && free_old_ai meepleai-embedding
-              [ "$RRK_CHANGED" = "true" ] && free_old_ai meepleai-reranker
-              echo "💽 Disk after free-old: $(df -BG / | awk 'NR==2 {gsub(/G/,"",$4); print $4}') GB free"
-            fi
-
-            # Issue #1578 — AI services. embedding/reranker are in the
+            # AI services. embedding/reranker are in the
             # ai-essential profile → pull + recreate. orchestration is
             # publish-only → pull ONLY (cached for a future activation).
             if [ "$EMB_CHANGED" = "true" ]; then

--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Queries/Gamebook/GetGamebookQuotaQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Queries/Gamebook/GetGamebookQuotaQuery.cs
@@ -1,0 +1,14 @@
+using MediatR;
+
+namespace Api.BoundedContexts.Administration.Application.Queries.Gamebook;
+
+/// <summary>
+/// #2750 (C14): reads the authenticated user's monthly gamebook paragraph-translation quota.
+/// Display-only (no enforcement/blocking).
+/// </summary>
+internal sealed record GetGamebookQuotaQuery(Guid UserId) : IRequest<GamebookQuotaDto>;
+
+/// <summary>
+/// Gamebook quota DTO matching the FE <c>QuotaInfo</c> shape: { used, total, resetDate, tier }.
+/// </summary>
+public sealed record GamebookQuotaDto(int Used, int Total, string ResetDate, string Tier);

--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Queries/Gamebook/GetGamebookQuotaQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Queries/Gamebook/GetGamebookQuotaQueryHandler.cs
@@ -1,0 +1,33 @@
+using System.Globalization;
+using Api.SharedKernel.Services;
+using MediatR;
+
+namespace Api.BoundedContexts.Administration.Application.Queries.Gamebook;
+
+/// <summary>
+/// #2750 (C14): maps the tier-enforcement gamebook quota snapshot to the FE-facing
+/// <see cref="GamebookQuotaDto"/>. Thin handler — no domain logic.
+/// </summary>
+internal sealed class GetGamebookQuotaQueryHandler
+    : IRequestHandler<GetGamebookQuotaQuery, GamebookQuotaDto>
+{
+    private readonly ITierEnforcementService _tierService;
+
+    public GetGamebookQuotaQueryHandler(ITierEnforcementService tierService)
+        => _tierService = tierService ?? throw new ArgumentNullException(nameof(tierService));
+
+    public async Task<GamebookQuotaDto> Handle(
+        GetGamebookQuotaQuery request, CancellationToken cancellationToken)
+    {
+        var snapshot = await _tierService
+            .GetGamebookQuotaSnapshotAsync(request.UserId, cancellationToken)
+            .ConfigureAwait(false);
+
+        return new GamebookQuotaDto(
+            Used: snapshot.TranslationsThisMonth,
+            Total: snapshot.MaxTranslationsPerMonth,
+            ResetDate: snapshot.ResetDate.ToString(
+                "yyyy-MM-dd'T'HH:mm:ss.fff'Z'", CultureInfo.InvariantCulture),
+            Tier: snapshot.Tier);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/TranslateGamebookSegmentQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/TranslateGamebookSegmentQueryHandler.cs
@@ -14,6 +14,7 @@ using Api.Models;
 using Api.Observability;
 using Api.Services;
 using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Services;
 using Api.SharedKernel.Translation;
 using Microsoft.Extensions.Logging;
 
@@ -34,6 +35,7 @@ internal sealed class TranslateGamebookSegmentQueryHandler
     private readonly ICampaignOwnershipGuard _ownershipGuard;
     private readonly IHybridCacheService _cache;
     private readonly ILogger<TranslateGamebookSegmentQueryHandler> _logger;
+    private readonly ITierEnforcementService _tierService;
 
     public TranslateGamebookSegmentQueryHandler(
         IGamebookCampaignSessionRepository campaigns,
@@ -44,7 +46,8 @@ internal sealed class TranslateGamebookSegmentQueryHandler
         ILlmService llm,
         ICampaignOwnershipGuard ownershipGuard,
         IHybridCacheService cache,
-        ILogger<TranslateGamebookSegmentQueryHandler> logger)
+        ILogger<TranslateGamebookSegmentQueryHandler> logger,
+        ITierEnforcementService tierService)
     {
         ArgumentNullException.ThrowIfNull(campaigns);
         ArgumentNullException.ThrowIfNull(photos);
@@ -55,6 +58,7 @@ internal sealed class TranslateGamebookSegmentQueryHandler
         ArgumentNullException.ThrowIfNull(ownershipGuard);
         ArgumentNullException.ThrowIfNull(cache);
         ArgumentNullException.ThrowIfNull(logger);
+        ArgumentNullException.ThrowIfNull(tierService);
         _campaigns = campaigns;
         _photos = photos;
         _paragraphs = paragraphs;
@@ -64,6 +68,7 @@ internal sealed class TranslateGamebookSegmentQueryHandler
         _ownershipGuard = ownershipGuard;
         _cache = cache;
         _logger = logger;
+        _tierService = tierService;
     }
 
     public async IAsyncEnumerable<TranslateChunk> Handle(
@@ -260,6 +265,16 @@ internal sealed class TranslateGamebookSegmentQueryHandler
             {
                 var rate = (double)matchedTerms / totalApplicableTerms;
                 MeepleAiMetrics.RecordGamebookGlossaryConsistency(rate, HashCampaignId(query.CampaignId));
+            }
+
+            // #2750 (C14): count one successful paragraph translation toward the monthly quota.
+            // CancellationToken.None so a request whose SSE stream was aborted AFTER the
+            // translation completed still counts (mirrors the metrics emit above).
+            if (string.Equals(status, "success", StringComparison.Ordinal))
+            {
+                await _tierService
+                    .RecordUsageAsync(query.CallerUserId, TierAction.TranslateGamebookParagraph, CancellationToken.None)
+                    .ConfigureAwait(false);
             }
         }
     }

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/TranslateGamebookTextQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/TranslateGamebookTextQueryHandler.cs
@@ -10,6 +10,7 @@ using Api.Models;
 using Api.Observability;
 using Api.Services;
 using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Services;
 using Api.SharedKernel.Translation;
 using Microsoft.Extensions.Logging;
 
@@ -32,24 +33,28 @@ internal sealed class TranslateGamebookTextQueryHandler
     private readonly ILlmService _llm;
     private readonly ICampaignOwnershipGuard _ownershipGuard;
     private readonly ILogger<TranslateGamebookTextQueryHandler> _logger;
+    private readonly ITierEnforcementService _tierService;
 
     public TranslateGamebookTextQueryHandler(
         IGamebookCampaignSessionRepository campaigns,
         IGamebookGlossaryRepository glossary,
         ILlmService llm,
         ICampaignOwnershipGuard ownershipGuard,
-        ILogger<TranslateGamebookTextQueryHandler> logger)
+        ILogger<TranslateGamebookTextQueryHandler> logger,
+        ITierEnforcementService tierService)
     {
         ArgumentNullException.ThrowIfNull(campaigns);
         ArgumentNullException.ThrowIfNull(glossary);
         ArgumentNullException.ThrowIfNull(llm);
         ArgumentNullException.ThrowIfNull(ownershipGuard);
         ArgumentNullException.ThrowIfNull(logger);
+        ArgumentNullException.ThrowIfNull(tierService);
         _campaigns = campaigns;
         _glossary = glossary;
         _llm = llm;
         _ownershipGuard = ownershipGuard;
         _logger = logger;
+        _tierService = tierService;
     }
 
     public async IAsyncEnumerable<TranslateChunk> Handle(
@@ -183,6 +188,16 @@ internal sealed class TranslateGamebookTextQueryHandler
             {
                 var rate = (double)matchedTerms / totalApplicableTerms;
                 MeepleAiMetrics.RecordGamebookGlossaryConsistency(rate, HashCampaignId(query.CampaignId));
+            }
+
+            // #2750 (C14): count one successful paragraph translation toward the monthly quota.
+            // CancellationToken.None so a request whose SSE stream was aborted AFTER the
+            // translation completed still counts (mirrors the metrics emit above).
+            if (string.Equals(status, "success", StringComparison.Ordinal))
+            {
+                await _tierService
+                    .RecordUsageAsync(query.CallerUserId, TierAction.TranslateGamebookParagraph, CancellationToken.None)
+                    .ConfigureAwait(false);
             }
         }
     }

--- a/apps/api/src/Api/BoundedContexts/SystemConfiguration/Application/DTOs/TierDefinitionDto.cs
+++ b/apps/api/src/Api/BoundedContexts/SystemConfiguration/Application/DTOs/TierDefinitionDto.cs
@@ -42,7 +42,10 @@ public record TierLimitsDto(
     int MaxSessionPlayers,
     int MaxPhotosPerSession,
     bool SessionSaveEnabled,
-    int MaxCatalogProposalsPerWeek)
+    int MaxCatalogProposalsPerWeek,
+    // #2750 (C14): optional (defaults 0) so existing positional constructions keep compiling;
+    // FromValueObject/ToValueObject round-trip the real value so admin edits don't reset the quota.
+    int MaxGamebookTranslationsPerMonth = 0)
 {
     public static TierLimitsDto FromValueObject(TierLimits limits) => new(
         limits.MaxPrivateGames,
@@ -54,12 +57,14 @@ public record TierLimitsDto(
         limits.MaxSessionPlayers,
         limits.MaxPhotosPerSession,
         limits.SessionSaveEnabled,
-        limits.MaxCatalogProposalsPerWeek);
+        limits.MaxCatalogProposalsPerWeek,
+        limits.MaxGamebookTranslationsPerMonth);
 
     public TierLimits ToValueObject() => TierLimits.Create(
         MaxPrivateGames, MaxPdfUploadsPerMonth,
         MaxPdfSizeBytes, MaxAgents,
         MaxAgentQueriesPerDay, MaxSessionQueries,
         MaxSessionPlayers, MaxPhotosPerSession,
-        SessionSaveEnabled, MaxCatalogProposalsPerWeek);
+        SessionSaveEnabled, MaxCatalogProposalsPerWeek,
+        maxGamebookTranslationsPerMonth: MaxGamebookTranslationsPerMonth);
 }

--- a/apps/api/src/Api/BoundedContexts/SystemConfiguration/Domain/ValueObjects/TierLimits.cs
+++ b/apps/api/src/Api/BoundedContexts/SystemConfiguration/Domain/ValueObjects/TierLimits.cs
@@ -23,6 +23,13 @@ public record TierLimits
     /// </summary>
     public bool RaptorRebuildEnabled { get; init; }
 
+    /// <summary>
+    /// Max gamebook (libro-game) paragraph translations per month. Backs a display-only
+    /// quota widget (no enforcement/blocking). Issue #2750 (C14).
+    /// Free = 50, Premium = 500, Unlimited = int.MaxValue.
+    /// </summary>
+    public int MaxGamebookTranslationsPerMonth { get; init; }
+
     private TierLimits() { }
 
     public static TierLimits Create(
@@ -31,7 +38,8 @@ public record TierLimits
         int maxAgentQueriesPerDay, int maxSessionQueries,
         int maxSessionPlayers, int maxPhotosPerSession,
         bool sessionSaveEnabled, int maxCatalogProposalsPerWeek,
-        bool raptorRebuildEnabled = false)
+        bool raptorRebuildEnabled = false,
+        int maxGamebookTranslationsPerMonth = 0)
     {
         if (maxPrivateGames < 0)
             throw new ArgumentException("Cannot be negative", nameof(maxPrivateGames));
@@ -51,6 +59,8 @@ public record TierLimits
             throw new ArgumentException("Cannot be negative", nameof(maxPhotosPerSession));
         if (maxCatalogProposalsPerWeek < 0)
             throw new ArgumentException("Cannot be negative", nameof(maxCatalogProposalsPerWeek));
+        if (maxGamebookTranslationsPerMonth < 0)
+            throw new ArgumentException("Cannot be negative", nameof(maxGamebookTranslationsPerMonth));
 
         return new TierLimits
         {
@@ -64,7 +74,8 @@ public record TierLimits
             MaxPhotosPerSession = maxPhotosPerSession,
             SessionSaveEnabled = sessionSaveEnabled,
             MaxCatalogProposalsPerWeek = maxCatalogProposalsPerWeek,
-            RaptorRebuildEnabled = raptorRebuildEnabled
+            RaptorRebuildEnabled = raptorRebuildEnabled,
+            MaxGamebookTranslationsPerMonth = maxGamebookTranslationsPerMonth
         };
     }
 
@@ -72,13 +83,16 @@ public record TierLimits
     public static TierLimits Unlimited => Create(
         int.MaxValue, int.MaxValue, 500L * 1024 * 1024,
         int.MaxValue, int.MaxValue, int.MaxValue,
-        12, int.MaxValue, true, int.MaxValue, raptorRebuildEnabled: true);
+        12, int.MaxValue, true, int.MaxValue, raptorRebuildEnabled: true,
+        maxGamebookTranslationsPerMonth: int.MaxValue);
 
     /// <summary>Free tier defaults.</summary>
     public static TierLimits FreeTier => Create(
-        3, 3, 50L * 1024 * 1024, 1, 20, 30, 6, 5, false, 1, raptorRebuildEnabled: false);
+        3, 3, 50L * 1024 * 1024, 1, 20, 30, 6, 5, false, 1, raptorRebuildEnabled: false,
+        maxGamebookTranslationsPerMonth: 50);
 
     /// <summary>Premium tier defaults.</summary>
     public static TierLimits PremiumTier => Create(
-        15, 15, 200L * 1024 * 1024, 10, 200, 150, 12, 20, true, 5, raptorRebuildEnabled: true);
+        15, 15, 200L * 1024 * 1024, 10, 200, 150, 12, 20, true, 5, raptorRebuildEnabled: true,
+        maxGamebookTranslationsPerMonth: 500);
 }

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/SystemConfiguration/TierDefinitionConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/SystemConfiguration/TierDefinitionConfiguration.cs
@@ -64,6 +64,9 @@ internal class TierDefinitionConfiguration : IEntityTypeConfiguration<TierDefini
                 .HasColumnName("session_save_enabled");
             limits.Property(l => l.MaxCatalogProposalsPerWeek)
                 .HasColumnName("max_catalog_proposals_per_week");
+            // Issue #2750 (C14): monthly gamebook translation quota (display-only).
+            limits.Property(l => l.MaxGamebookTranslationsPerMonth)
+                .HasColumnName("max_gamebook_translations_per_month");
         });
 
         // Unique index on name

--- a/apps/api/src/Api/Infrastructure/Migrations/20260707190653_AddGamebookTranslationsLimit.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260707190653_AddGamebookTranslationsLimit.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260707190653_AddGamebookTranslationsLimit")]
+    partial class AddGamebookTranslationsLimit
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260707190653_AddGamebookTranslationsLimit.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260707190653_AddGamebookTranslationsLimit.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddGamebookTranslationsLimit : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "max_gamebook_translations_per_month",
+                table: "tier_definitions",
+                type: "integer",
+                nullable: false,
+                defaultValue: 50);
+
+            // Issue #2750 (C14): the tier seeder is idempotent (it skips already-seeded rows),
+            // so existing premium/unlimited definitions must be corrected explicitly. The free
+            // tier stays at the column default (50).
+            migrationBuilder.Sql(
+                "UPDATE tier_definitions SET max_gamebook_translations_per_month = 500 WHERE name = 'premium'");
+            migrationBuilder.Sql(
+                "UPDATE tier_definitions SET max_gamebook_translations_per_month = 2147483647 WHERE name = 'unlimited'");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "max_gamebook_translations_per_month",
+                table: "tier_definitions");
+        }
+    }
+}

--- a/apps/api/src/Api/Routing/UserUsageEndpoints.cs
+++ b/apps/api/src/Api/Routing/UserUsageEndpoints.cs
@@ -1,3 +1,4 @@
+using Api.BoundedContexts.Administration.Application.Queries.Gamebook;
 using Api.BoundedContexts.Administration.Application.Queries.Usage;
 using Api.BoundedContexts.Authentication.Application.DTOs;
 using Api.Extensions;
@@ -49,6 +50,28 @@ internal static class UserUsageEndpoints
 - Session save enabled flag
 - Catalog proposals this week vs. max")
         .Produces<UsageSnapshot>(200)
+        .Produces(401);
+
+        // #2750 (C14): monthly gamebook paragraph-translation quota (display-only).
+        group.MapGet("/users/me/quota", async (
+            HttpContext context,
+            IMediator mediator,
+            CancellationToken ct) =>
+        {
+            var session = (SessionStatusDto)context.Items[nameof(SessionStatusDto)]!;
+            var userId = session!.Principal!.Subject.Id;
+
+            var query = new GetGamebookQuotaQuery(userId);
+            var quota = await mediator.Send(query, ct).ConfigureAwait(false);
+
+            return Results.Ok(quota);
+        })
+        .RequireSession()
+        .RequireAuthorization()
+        .WithName("GetMyGamebookQuota")
+        .WithTags("User", "Gamebook", "Quota")
+        .WithSummary("Get monthly gamebook paragraph-translation quota for authenticated user")
+        .Produces<GamebookQuotaDto>(200)
         .Produces(401);
 
         return group;

--- a/apps/api/src/Api/SharedKernel/Services/ITierEnforcementService.cs
+++ b/apps/api/src/Api/SharedKernel/Services/ITierEnforcementService.cs
@@ -19,6 +19,12 @@ public interface ITierEnforcementService
 
     /// <summary>Gets a snapshot of current usage for a user.</summary>
     Task<UsageSnapshot> GetUsageAsync(Guid userId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets the monthly gamebook paragraph-translation quota snapshot for display (no enforcement).
+    /// Issue #2750 (C14).
+    /// </summary>
+    Task<GamebookQuotaSnapshot> GetGamebookQuotaSnapshotAsync(Guid userId, CancellationToken ct = default);
 }
 
 /// <summary>
@@ -39,7 +45,13 @@ public enum TierAction
     /// Free-tier users are blocked (returns false from CanPerformAsync).
     /// Issue #903: SG2 — KB lifecycle smoke tests.
     /// </summary>
-    RaptorRebuild
+    RaptorRebuild,
+
+    /// <summary>
+    /// Translate one gamebook (libro-game) paragraph. Monthly per-user counter backing
+    /// a display-only quota widget (no enforcement/blocking). Issue #2750 (C14).
+    /// </summary>
+    TranslateGamebookParagraph
 }
 
 /// <summary>
@@ -54,4 +66,14 @@ public record UsageSnapshot(
     int PhotosThisSession, int PhotosThisSessionMax,
     bool SessionSaveEnabled,
     int CatalogProposalsThisWeek, int CatalogProposalsThisWeekMax
+);
+
+/// <summary>
+/// Monthly gamebook paragraph-translation quota snapshot (display-only). Issue #2750 (C14).
+/// </summary>
+public record GamebookQuotaSnapshot(
+    int TranslationsThisMonth,
+    int MaxTranslationsPerMonth,
+    DateTime ResetDate,
+    string Tier
 );

--- a/apps/api/src/Api/SharedKernel/Services/TierEnforcementService.cs
+++ b/apps/api/src/Api/SharedKernel/Services/TierEnforcementService.cs
@@ -144,6 +144,47 @@ internal sealed class TierEnforcementService : ITierEnforcementService
         );
     }
 
+    public async Task<GamebookQuotaSnapshot> GetGamebookQuotaSnapshotAsync(Guid userId, CancellationToken ct = default)
+    {
+        // Issue #2750 (C14): display-only monthly gamebook translation quota.
+        var user = await _dbContext.Users
+            .AsNoTracking()
+            .FirstOrDefaultAsync(u => u.Id == userId, ct)
+            .ConfigureAwait(false);
+
+        string tier;
+        if (user is null)
+        {
+            tier = "free";
+        }
+        else if (string.Equals(user.Role, "superadmin", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(user.Role, "admin", StringComparison.OrdinalIgnoreCase)
+            || string.Equals(user.Role, "editor", StringComparison.OrdinalIgnoreCase))
+        {
+            // Unlimited tier surfaces as "premium" for the FE quota-widget enum.
+            tier = "premium";
+        }
+        else
+        {
+            // FE QuotaInfo.tier is a binary enum ('free' | 'premium'); collapse any paid tier
+            // (normal/pro/premium/enterprise) or contributor to "premium" so the Zod parse holds.
+            var resolved = user.IsContributor ? "premium" : (user.Tier ?? "free");
+            tier = string.Equals(resolved, "free", StringComparison.OrdinalIgnoreCase) ? "free" : "premium";
+        }
+
+        var limits = await GetLimitsAsync(userId, ct).ConfigureAwait(false);
+        var used = await GetRedisCounterAsync(userId, TierAction.TranslateGamebookParagraph).ConfigureAwait(false);
+
+        var now = DateTime.UtcNow;
+        var resetDate = new DateTime(now.Year, now.Month, 1, 0, 0, 0, DateTimeKind.Utc).AddMonths(1);
+
+        return new GamebookQuotaSnapshot(
+            TranslationsThisMonth: used,
+            MaxTranslationsPerMonth: limits.MaxGamebookTranslationsPerMonth,
+            ResetDate: resetDate,
+            Tier: tier);
+    }
+
     // ─── Private helpers ──────────────────────────────────────────────────
 
     private async Task<TierDefinition?> GetTierDefinitionAsync(string tierName, CancellationToken ct)
@@ -196,7 +237,7 @@ internal sealed class TierEnforcementService : ITierEnforcementService
         TierAction.AgentQuery or TierAction.SessionAgentQuery
             => DateTime.UtcNow.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
 
-        TierAction.UploadPdf
+        TierAction.UploadPdf or TierAction.TranslateGamebookParagraph
             => DateTime.UtcNow.ToString("yyyy-MM", CultureInfo.InvariantCulture),
 
         TierAction.ProposeToSharedCatalog
@@ -222,7 +263,7 @@ internal sealed class TierEnforcementService : ITierEnforcementService
         TierAction.AgentQuery or TierAction.SessionAgentQuery or TierAction.UploadSessionPhoto
             => DailyTtl,
 
-        TierAction.UploadPdf
+        TierAction.UploadPdf or TierAction.TranslateGamebookParagraph
             => MonthlyTtl,
 
         TierAction.ProposeToSharedCatalog
@@ -242,6 +283,7 @@ internal sealed class TierEnforcementService : ITierEnforcementService
         TierAction.ProposeToSharedCatalog => limits.MaxCatalogProposalsPerWeek,
         // RaptorRebuild is handled separately as a boolean gate — this path is never reached.
         TierAction.RaptorRebuild => int.MaxValue,
+        TierAction.TranslateGamebookParagraph => limits.MaxGamebookTranslationsPerMonth,
         _ => int.MaxValue
     };
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/Administration/Application/Queries/Gamebook/GetGamebookQuotaQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Administration/Application/Queries/Gamebook/GetGamebookQuotaQueryHandlerTests.cs
@@ -1,0 +1,46 @@
+using Api.BoundedContexts.Administration.Application.Queries.Gamebook;
+using Api.SharedKernel.Services;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.Administration.Application.Queries.Gamebook;
+
+/// <summary>#2750 (C14): maps the tier gamebook quota snapshot to the FE-facing DTO.</summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "Administration")]
+public class GetGamebookQuotaQueryHandlerTests
+{
+    [Fact]
+    public async Task Handle_MapsSnapshotToDto_WithIsoResetDate()
+    {
+        var userId = Guid.NewGuid();
+        var reset = new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc);
+        var tierService = new Mock<ITierEnforcementService>();
+        tierService
+            .Setup(s => s.GetGamebookQuotaSnapshotAsync(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GamebookQuotaSnapshot(
+                TranslationsThisMonth: 12,
+                MaxTranslationsPerMonth: 50,
+                ResetDate: reset,
+                Tier: "free"));
+
+        var handler = new GetGamebookQuotaQueryHandler(tierService.Object);
+
+        var dto = await handler.Handle(new GetGamebookQuotaQuery(userId), CancellationToken.None);
+
+        dto.Used.Should().Be(12);
+        dto.Total.Should().Be(50);
+        dto.Tier.Should().Be("free");
+        // FE QuotaInfo.resetDate is a Zod z.string().datetime() — must be ISO-8601 UTC with millis.
+        dto.ResetDate.Should().Be("2026-08-01T00:00:00.000Z");
+    }
+
+    [Fact]
+    public void Constructor_NullService_Throws()
+    {
+        var act = () => new GetGamebookQuotaQueryHandler(null!);
+        act.Should().Throw<ArgumentNullException>();
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentMemoryContextTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Commands/ChatWithSessionAgentMemoryContextTests.cs
@@ -1,0 +1,274 @@
+using System.Collections.Generic;
+using Api.BoundedContexts.Administration.Application.Services;
+using Api.BoundedContexts.GameManagement.Application.Services;
+using Api.BoundedContexts.GameManagement.Domain.Entities;
+using Api.BoundedContexts.GameManagement.Domain.Repositories;
+using Api.BoundedContexts.KnowledgeBase.Application.Commands;
+using Api.BoundedContexts.KnowledgeBase.Application.Models;
+using Api.BoundedContexts.KnowledgeBase.Application.Services;
+using Api.BoundedContexts.KnowledgeBase.Domain.Enums;
+using Api.BoundedContexts.KnowledgeBase.Domain.Entities;
+using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
+using Api.BoundedContexts.KnowledgeBase.Domain.Services;
+using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
+using Api.Models;
+using Api.Services;
+using Api.SharedKernel.Application;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Domain.ValueObjects;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+// Disambiguate UserTier from two namespaces
+using SharedUserTier = Api.SharedKernel.Domain.ValueObjects.UserTier;
+
+namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Commands;
+
+/// <summary>
+/// Issue #2750 gap E5 — proving test for Path 2 (session-agent streaming chat) house-rule injection.
+/// The existing session-agent handler tests stub <see cref="IAgentMemoryContextBuilder"/> to return null;
+/// this class proves the OTHER branch: when the builder returns a non-null house-rule context, the handler
+/// appends it under a "## Agent Memory Context" heading and forwards the enriched system prompt to the LLM.
+/// Mirrors the Path-1 proof pattern in AskQuestionQueryHandlerPhase2Tests (Handle_WhenHouseRuleMatched_...).
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "KnowledgeBase")]
+public class ChatWithSessionAgentMemoryContextTests
+{
+    [Fact]
+    public async Task Chat_WhenAgentMemoryContextReturned_InjectsHouseRulesIntoSystemPrompt()
+    {
+        // Arrange — builder yields a non-null house-rule context (Path 2 non-null branch)
+        const string memoryContext = "House Rules for this game:\n- \"No trading on turn 1\" (from player)";
+
+        string? capturedSystemPrompt = null;
+        var handler = BuildHandler(
+            memoryContext: memoryContext,
+            captureSystemPrompt: sys => capturedSystemPrompt = sys);
+
+        var command = BuildCommand();
+
+        // Act — drain the stream to completion so the LLM call is issued
+        await foreach (var _ in handler.Handle(command, CancellationToken.None)) { }
+
+        // Assert — enriched system prompt reached the LLM
+        capturedSystemPrompt.Should().NotBeNull("the LLM must be invoked with a system prompt");
+        capturedSystemPrompt.Should().Contain("## Agent Memory Context",
+            "the handler wraps the injected memory under this heading");
+        capturedSystemPrompt.Should().Contain("No trading on turn 1",
+            "the house-rule text must be present in the enriched system prompt");
+        capturedSystemPrompt.Should().Contain("(from player)");
+    }
+
+    [Fact]
+    public async Task Chat_WhenNoAgentMemoryContext_DoesNotInjectMemoryHeading()
+    {
+        // Arrange — builder yields null (nothing to inject); baseline / negative control
+        string? capturedSystemPrompt = null;
+        var handler = BuildHandler(
+            memoryContext: null,
+            captureSystemPrompt: sys => capturedSystemPrompt = sys);
+
+        var command = BuildCommand();
+
+        // Act
+        await foreach (var _ in handler.Handle(command, CancellationToken.None)) { }
+
+        // Assert
+        capturedSystemPrompt.Should().NotBeNull();
+        capturedSystemPrompt.Should().NotContain("## Agent Memory Context",
+            "no memory context means the heading must not be appended");
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private static ChatWithSessionAgentCommand BuildCommand() =>
+        new ChatWithSessionAgentCommand(
+            AgentSessionId: Guid.NewGuid(),
+            UserQuestion: "What are the rules?",
+            UserId: Guid.NewGuid());
+
+    /// <summary>
+    /// Constructs a fully-wired handler with minimal happy-path mocks, overriding the agent-memory
+    /// builder to return <paramref name="memoryContext"/> and capturing the system prompt forwarded
+    /// to the LLM. Harness mirrors ChatSessionAgentBroadcastTests.BuildHandler.
+    /// </summary>
+    private static ChatWithSessionAgentCommandHandler BuildHandler(
+        string? memoryContext,
+        Action<string> captureSystemPrompt)
+    {
+        // --- AgentSession repo ---
+        var playerId = Guid.NewGuid();
+        var initialState = GameState.Create(
+            currentTurn: 1,
+            activePlayer: playerId,
+            playerScores: new Dictionary<Guid, decimal> { [playerId] = 0 },
+            gamePhase: "Setup",
+            lastAction: "Game started");
+
+        var agentSession = new AgentSession(
+            id: Guid.NewGuid(),
+            agentDefinitionId: Guid.NewGuid(),
+            gameSessionId: Guid.NewGuid(),
+            userId: Guid.NewGuid(),
+            gameId: Guid.NewGuid(),
+            initialState: initialState);
+
+        var sessionRepo = new Mock<IAgentSessionRepository>();
+        sessionRepo
+            .Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(agentSession);
+
+        // --- AgentDefinition repo ---
+        var definition = AgentDefinition.Create(
+            name: "tutor",
+            description: "Test agent",
+            type: AgentType.Custom("tutor", "Tutor"),
+            config: AgentDefinitionConfig.Default());
+
+        var definitionRepo = new Mock<IAgentDefinitionRepository>();
+        definitionRepo
+            .Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(definition);
+
+        // --- Game core data ---
+        var gameCoreData = new Mock<IGameCoreDataProvider>();
+        gameCoreData
+            .Setup(g => g.GetCoreDataAsync(It.IsAny<GameRef>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((GameCoreData?)null);  // null → "Unknown Game" title
+
+        // --- ChatThread repo: return null to trigger auto-create path ---
+        var chatThreadRepo = new Mock<IChatThreadRepository>();
+        chatThreadRepo
+            .Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ChatThread?)null);
+        chatThreadRepo
+            .Setup(r => r.AddAsync(It.IsAny<ChatThread>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        chatThreadRepo
+            .Setup(r => r.UpdateAsync(It.IsAny<ChatThread>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        // --- LiveSession repo: null → no live-session context, groupId == null ---
+        var liveSessionRepo = new Mock<ILiveSessionRepository>();
+        liveSessionRepo
+            .Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((LiveGameSession?)null);
+
+        // --- UoW ---
+        var unitOfWork = new Mock<IUnitOfWork>();
+        unitOfWork
+            .Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        // --- RAG prompt assembly ---
+        var assembled = new AssembledPrompt(
+            SystemPrompt: "You are a helpful assistant.",
+            UserPrompt: "What are the rules?",
+            Citations: new List<ChunkCitation>(),
+            EstimatedTokens: 100);
+
+        var ragPromptService = new Mock<IRagPromptAssemblyService>();
+        ragPromptService
+            .Setup(r => r.AssemblePromptAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<GameState?>(),
+                It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<ChatThread?>(),
+                It.IsAny<SharedUserTier?>(), It.IsAny<string>(), It.IsAny<CancellationToken>(),
+                It.IsAny<IRagDebugEventCollector?>(), It.IsAny<RetrievalProfile?>()))
+            .ReturnsAsync(assembled);
+
+        // --- Copyright tier resolver → returns citations as-is (empty) ---
+        var tierResolver = new Mock<ICopyrightTierResolver>();
+        tierResolver
+            .Setup(r => r.ResolveAsync(
+                It.IsAny<IReadOnlyList<ChunkCitation>>(),
+                It.IsAny<Guid>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ChunkCitation>());
+
+        // --- Agent memory context builder → returns the context under test ---
+        var memoryBuilder = new Mock<IAgentMemoryContextBuilder>();
+        memoryBuilder
+            .Setup(b => b.BuildContextAsync(
+                It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<Guid?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(memoryContext);
+
+        // --- LLM service: capture the forwarded system prompt, emit a token + final chunk ---
+        var llmService = new Mock<ILlmService>();
+        llmService
+            .Setup(l => l.GenerateCompletionStreamAsync(
+                It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<RequestSource>(), It.IsAny<CancellationToken>()))
+            .Callback<string, string, RequestSource, CancellationToken>((sys, _, _, _) => captureSystemPrompt(sys))
+            .Returns(CreateLlmStream("Hello world"));
+
+        // --- Budget service ---
+        var budgetService = new Mock<IUserBudgetService>();
+        budgetService
+            .Setup(b => b.HasBudgetForQueryAsync(
+                It.IsAny<Guid>(), It.IsAny<decimal>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        // --- Circuit breaker ---
+        var registry = new Mock<ICircuitBreakerRegistry>();
+        registry
+            .Setup(r => r.GetMonitoringStatus())
+            .Returns(new Dictionary<string, (string, string)>());
+
+        // --- ServiceScopeFactory (fire-and-forget chunk usage increment only) ---
+        var scopeFactory = new Mock<IServiceScopeFactory>();
+
+        // --- Copyright leak guard (no leak) ---
+        var noLeak = new CopyrightLeakResult(HasLeak: false, Matches: Array.Empty<LeakMatch>());
+        var leakGuard = new Mock<ICopyrightLeakGuard>();
+        leakGuard
+            .Setup(g => g.ScanAsync(
+                It.IsAny<string>(), It.IsAny<IReadOnlyList<ChunkCitation>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(noLeak);
+
+        var fallbackProvider = new Mock<ICopyrightFallbackMessageProvider>();
+
+        // --- Live session stream gateway (unused: no live session) ---
+        var gateway = new Mock<ILiveSessionStreamGateway>();
+
+        return new ChatWithSessionAgentCommandHandler(
+            sessionRepository: sessionRepo.Object,
+            definitionRepository: definitionRepo.Object,
+            chatThreadRepository: chatThreadRepo.Object,
+            gameCoreData: gameCoreData.Object,
+            liveSessionRepository: liveSessionRepo.Object,
+            unitOfWork: unitOfWork.Object,
+            ragPromptService: ragPromptService.Object,
+            copyrightTierResolver: tierResolver.Object,
+            agentMemoryContextBuilder: memoryBuilder.Object,
+            llmService: llmService.Object,
+            userBudgetService: budgetService.Object,
+            circuitBreakerRegistry: registry.Object,
+            scopeFactory: scopeFactory.Object,
+            logger: NullLogger<ChatWithSessionAgentCommandHandler>.Instance,
+            copyrightLeakGuard: leakGuard.Object,
+            fallbackMessageProvider: fallbackProvider.Object,
+            copyrightOptions: Options.Create(new CopyrightLeakGuardOptions()),
+            liveSessionStreamGateway: gateway.Object);
+    }
+
+    private static async IAsyncEnumerable<StreamChunk> CreateLlmStream(string content)
+    {
+        await Task.Yield();
+        yield return new StreamChunk(Content: content);
+        yield return new StreamChunk(
+            Content: null,
+            Usage: new LlmUsage(10, 5, 15),
+            IsFinal: true);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/AgentMemoryContextBuilderTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/AgentMemoryContextBuilderTests.cs
@@ -1,0 +1,183 @@
+using Api.BoundedContexts.AgentMemory.Domain.Entities;
+using Api.BoundedContexts.AgentMemory.Domain.Enums;
+using Api.BoundedContexts.AgentMemory.Domain.Repositories;
+using Api.BoundedContexts.KnowledgeBase.Application.Services;
+using Api.Infrastructure.Entities;
+using Api.Services;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Services;
+
+/// <summary>
+/// Issue #2750 gap E5 — proving tests for <see cref="AgentMemoryContextBuilder"/>, the cross-context
+/// read-only service that formats AgentMemory (house rules, notes, group preferences) for injection
+/// into the session-agent system prompt. This class previously had ZERO test coverage even though the
+/// behavior ships in production (Path 2, session-agent streaming chat).
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "KnowledgeBase")]
+public class AgentMemoryContextBuilderTests
+{
+    private readonly Mock<IGameMemoryRepository> _mockGameMemoryRepository = new();
+    private readonly Mock<IGroupMemoryRepository> _mockGroupMemoryRepository = new();
+    private readonly Mock<IFeatureFlagService> _mockFeatureFlagService = new();
+
+    private AgentMemoryContextBuilder BuildSut() =>
+        new(
+            _mockGameMemoryRepository.Object,
+            _mockGroupMemoryRepository.Object,
+            _mockFeatureFlagService.Object,
+            NullLogger<AgentMemoryContextBuilder>.Instance);
+
+    private void EnableFeatureFlag() =>
+        _mockFeatureFlagService
+            .Setup(f => f.IsEnabledAsync(It.IsAny<string>(), It.IsAny<UserRole?>()))
+            .ReturnsAsync(true);
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Test 1: house rule present + flag enabled → formatted context is returned
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task BuildContextAsync_WithUserAddedHouseRule_ReturnsFormattedHouseRuleContext()
+    {
+        // Arrange
+        var gameId = Guid.NewGuid();
+        var ownerId = Guid.NewGuid();
+        const string ruleDescription = "No trading on turn 1";
+
+        var gameMemory = GameMemory.Create(gameId, ownerId);
+        gameMemory.AddHouseRule(ruleDescription, HouseRuleSource.UserAdded);
+
+        EnableFeatureFlag();
+        _mockGameMemoryRepository
+            .Setup(r => r.GetByGameAndOwnerAsync(gameId, ownerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(gameMemory);
+
+        var sut = BuildSut();
+
+        // Act
+        var context = await sut.BuildContextAsync(gameId, ownerId, groupId: null, TestContext.Current.CancellationToken);
+
+        // Assert
+        context.Should().NotBeNull();
+        context.Should().Contain("House Rules for this game:");
+        context.Should().Contain(ruleDescription);
+        context.Should().Contain("(from player)", "UserAdded house rules render the 'from player' source label");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Test 2: feature flag disabled → returns null and repository is never queried
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task BuildContextAsync_WhenFeatureFlagDisabled_ReturnsNullWithoutQueryingRepository()
+    {
+        // Arrange
+        var gameId = Guid.NewGuid();
+        var ownerId = Guid.NewGuid();
+
+        _mockFeatureFlagService
+            .Setup(f => f.IsEnabledAsync(It.IsAny<string>(), It.IsAny<UserRole?>()))
+            .ReturnsAsync(false);
+
+        var sut = BuildSut();
+
+        // Act
+        var context = await sut.BuildContextAsync(gameId, ownerId, groupId: null, TestContext.Current.CancellationToken);
+
+        // Assert
+        context.Should().BeNull();
+        _mockGameMemoryRepository.Verify(
+            r => r.GetByGameAndOwnerAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+            Times.Never,
+            "the feature flag gate must short-circuit before any repository access");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Test 3: game memory exists but has no house rules and no notes → returns null
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task BuildContextAsync_WithEmptyGameMemory_ReturnsNull()
+    {
+        // Arrange
+        var gameId = Guid.NewGuid();
+        var ownerId = Guid.NewGuid();
+
+        var emptyGameMemory = GameMemory.Create(gameId, ownerId); // no rules, no notes
+
+        EnableFeatureFlag();
+        _mockGameMemoryRepository
+            .Setup(r => r.GetByGameAndOwnerAsync(gameId, ownerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(emptyGameMemory);
+
+        var sut = BuildSut();
+
+        // Act
+        var context = await sut.BuildContextAsync(gameId, ownerId, groupId: null, TestContext.Current.CancellationToken);
+
+        // Assert
+        context.Should().BeNull("no house rules and no notes means there is nothing to inject");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Test 4: notes present + flag enabled → notes section is rendered
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task BuildContextAsync_WithNotes_ReturnsFormattedNotesContext()
+    {
+        // Arrange
+        var gameId = Guid.NewGuid();
+        var ownerId = Guid.NewGuid();
+        const string noteContent = "We always play with the expansion";
+
+        var gameMemory = GameMemory.Create(gameId, ownerId);
+        gameMemory.AddNote(noteContent, addedByUserId: ownerId);
+
+        EnableFeatureFlag();
+        _mockGameMemoryRepository
+            .Setup(r => r.GetByGameAndOwnerAsync(gameId, ownerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(gameMemory);
+
+        var sut = BuildSut();
+
+        // Act
+        var context = await sut.BuildContextAsync(gameId, ownerId, groupId: null, TestContext.Current.CancellationToken);
+
+        // Assert
+        context.Should().NotBeNull();
+        context.Should().Contain("Notes:");
+        context.Should().Contain(noteContent);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Test 5: no game memory at all → returns null (graceful "nothing to inject")
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task BuildContextAsync_WhenNoGameMemory_ReturnsNull()
+    {
+        // Arrange
+        var gameId = Guid.NewGuid();
+        var ownerId = Guid.NewGuid();
+
+        EnableFeatureFlag();
+        _mockGameMemoryRepository
+            .Setup(r => r.GetByGameAndOwnerAsync(gameId, ownerId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((GameMemory?)null);
+
+        var sut = BuildSut();
+
+        // Act
+        var context = await sut.BuildContextAsync(gameId, ownerId, groupId: null, TestContext.Current.CancellationToken);
+
+        // Assert
+        context.Should().BeNull();
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Queries/TranslateGamebookSegmentQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Queries/TranslateGamebookSegmentQueryHandlerTests.cs
@@ -9,6 +9,8 @@ using Api.BoundedContexts.SessionTracking.Infrastructure.Services;
 using System.Diagnostics.Metrics;
 using Api.Models;
 using Api.Observability;
+using Api.SharedKernel.Services;
+using Moq;
 using Api.Services;
 using Api.Services.LlmClients;
 using Api.SharedKernel.Domain.ValueObjects;
@@ -309,7 +311,8 @@ public sealed class TranslateGamebookSegmentQueryHandlerTests
         FakeProgressRepo progressRepo,
         ILlmService? llm = null,
         ICampaignOwnershipGuard? ownershipGuard = null,
-        IHybridCacheService? cache = null) =>
+        IHybridCacheService? cache = null,
+        ITierEnforcementService? tierService = null) =>
         new(
             campaignRepo,
             artifactRepo,
@@ -319,9 +322,81 @@ public sealed class TranslateGamebookSegmentQueryHandlerTests
             llm ?? new FakeLlmService(),
             ownershipGuard ?? new AlwaysOwnedGuard(),
             cache ?? new FakeHybridCache(),
-            NullLogger<TranslateGamebookSegmentQueryHandler>.Instance);
+            NullLogger<TranslateGamebookSegmentQueryHandler>.Instance,
+            tierService ?? new Mock<ITierEnforcementService>().Object);
 
     // ── Tests ─────────────────────────────────────────────────────────────────
+
+    // #2750 (C14): a successful paragraph translation counts toward the monthly quota;
+    // a failed one does not.
+    [Fact]
+    public async Task Handle_OnSuccess_RecordsGamebookTranslationQuotaUsage()
+    {
+        var campaignRepo = new FakeCampaignRepo();
+        var artifactRepo = new FakeArtifactRepo();
+        var paragraphRepo = new FakeParagraphRepo();
+        var glossaryRepo = new FakeGlossaryRepo();
+        var progressRepo = new FakeProgressRepo();
+
+        var ownerId = Guid.NewGuid();
+        var campaign = GamebookCampaignSession.Create(GameRef.Shared(Guid.NewGuid()), ownerId, "Quota Campaign");
+        campaignRepo.Store.Add(campaign);
+        var bookId = Guid.NewGuid();
+        var artifact = GamebookPhotoArtifact.Create(campaign.Id, bookId, $"gamebook-photos/{campaign.Id}/photo-quota");
+        artifact.RecordSegments(
+            new[] { GamebookSegment.Create(47, "The Hive awakens.", null) }, "The Hive awakens.");
+        artifactRepo.Store.Add(artifact);
+
+        var tierService = new Mock<ITierEnforcementService>();
+        var handler = BuildHandler(
+            campaignRepo, artifactRepo, paragraphRepo, glossaryRepo, progressRepo,
+            tierService: tierService.Object);
+        var query = new TranslateGamebookSegmentQuery(campaign.Id, artifact.Id, 47, ownerId, bookId);
+
+        await foreach (var _ in handler.Handle(query, CancellationToken.None)) { }
+
+        tierService.Verify(
+            s => s.RecordUsageAsync(ownerId, TierAction.TranslateGamebookParagraph, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_OnFailure_DoesNotRecordGamebookTranslationQuotaUsage()
+    {
+        // Ownership guard throws → the translation never succeeds → no quota increment.
+        var campaignRepo = new FakeCampaignRepo();
+        var artifactRepo = new FakeArtifactRepo();
+        var paragraphRepo = new FakeParagraphRepo();
+        var glossaryRepo = new FakeGlossaryRepo();
+        var progressRepo = new FakeProgressRepo();
+
+        var ownerId = Guid.NewGuid();
+        var campaign = GamebookCampaignSession.Create(GameRef.Shared(Guid.NewGuid()), ownerId, "Quota Fail Campaign");
+        campaignRepo.Store.Add(campaign);
+        var bookId = Guid.NewGuid();
+
+        var tierService = new Mock<ITierEnforcementService>();
+        var handler = BuildHandler(
+            campaignRepo, artifactRepo, paragraphRepo, glossaryRepo, progressRepo,
+            ownershipGuard: new ThrowingOwnershipGuard(),
+            tierService: tierService.Object);
+        var query = new TranslateGamebookSegmentQuery(campaign.Id, Guid.NewGuid(), 47, ownerId, bookId);
+
+        await Assert.ThrowsAnyAsync<Exception>(async () =>
+        {
+            await foreach (var _ in handler.Handle(query, CancellationToken.None)) { }
+        });
+
+        tierService.Verify(
+            s => s.RecordUsageAsync(It.IsAny<Guid>(), It.IsAny<TierAction>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    private sealed class ThrowingOwnershipGuard : ICampaignOwnershipGuard
+    {
+        public Task AssertOwnedByAsync(Guid campaignId, Guid userId, CancellationToken cancellationToken)
+            => throw new UnauthorizedAccessException("not owner");
+    }
 
     [Fact]
     public async Task Handle_StreamsAndPersistsTranslation()

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Queries/TranslateGamebookTextQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Queries/TranslateGamebookTextQueryHandlerTests.cs
@@ -7,6 +7,8 @@ using Api.BoundedContexts.SessionTracking.Domain.Repositories;
 using System.Diagnostics.Metrics;
 using Api.Middleware.Exceptions;
 using Api.Observability;
+using Api.SharedKernel.Services;
+using Moq;
 using Api.Services;
 using Api.Services.LlmClients;
 using Api.SharedKernel.Domain.ValueObjects;
@@ -195,13 +197,15 @@ public sealed class TranslateGamebookTextQueryHandlerTests
         FakeCampaignRepo campaignRepo,
         FakeGlossaryRepo glossaryRepo,
         ILlmService? llm = null,
-        ICampaignOwnershipGuard? guard = null) =>
+        ICampaignOwnershipGuard? guard = null,
+        ITierEnforcementService? tierService = null) =>
         new(
             campaignRepo,
             glossaryRepo,
             llm ?? new FakeLlmService(),
             guard ?? new AlwaysOwnedGuard(),
-            NullLogger<TranslateGamebookTextQueryHandler>.Instance);
+            NullLogger<TranslateGamebookTextQueryHandler>.Instance,
+            tierService ?? new Mock<ITierEnforcementService>().Object);
 
     private static (FakeCampaignRepo campaigns, FakeGlossaryRepo glossary)
         BuildRepos()
@@ -216,6 +220,41 @@ public sealed class TranslateGamebookTextQueryHandlerTests
     }
 
     // ── Tests ─────────────────────────────────────────────────────────────────
+
+    // #2750 (C14): a successful paragraph translation counts toward the monthly quota;
+    // a failed one does not.
+    [Fact]
+    public async Task Handle_OnSuccess_RecordsGamebookTranslationQuotaUsage()
+    {
+        var (campaigns, glossary) = BuildRepos();
+        var campaign = campaigns.Store[0];
+        var tierService = new Mock<ITierEnforcementService>();
+        var handler = BuildHandler(campaigns, glossary, tierService: tierService.Object);
+        var query = new TranslateGamebookTextQuery(campaign.Id, "Hello.", "EN", "IT", GameBookId, UserId);
+
+        await foreach (var _ in handler.Handle(query, CancellationToken.None)) { }
+
+        tierService.Verify(
+            s => s.RecordUsageAsync(UserId, TierAction.TranslateGamebookParagraph, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_OnFailure_DoesNotRecordGamebookTranslationQuotaUsage()
+    {
+        var (campaigns, glossary) = BuildRepos();
+        var tierService = new Mock<ITierEnforcementService>();
+        var handler = BuildHandler(campaigns, glossary, guard: new AlwaysDeniedGuard(), tierService: tierService.Object);
+
+        await Assert.ThrowsAsync<ForbiddenException>(async () =>
+        {
+            await foreach (var _ in handler.Handle(DefaultQuery(), CancellationToken.None)) { }
+        });
+
+        tierService.Verify(
+            s => s.RecordUsageAsync(It.IsAny<Guid>(), It.IsAny<TierAction>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
 
     [Fact]
     public async Task Handle_OwnershipDenied_ThrowsForbidden()
@@ -328,7 +367,8 @@ public sealed class TranslateGamebookTextQueryHandlerTests
             glossary,
             new FakeLlmService(),
             new AlwaysOwnedGuard(),
-            NullLogger<TranslateGamebookTextQueryHandler>.Instance);
+            NullLogger<TranslateGamebookTextQueryHandler>.Instance,
+            new Mock<ITierEnforcementService>().Object);
 
         await foreach (var _ in handler.Handle(
             new TranslateGamebookTextQuery(campaign.Id, "Hello.", "EN", "IT", GameBookId, UserId),

--- a/apps/web/src/hooks/queries/__tests__/useGamebooks.test.tsx
+++ b/apps/web/src/hooks/queries/__tests__/useGamebooks.test.tsx
@@ -8,8 +8,8 @@
  *   - Stable queryKey contract (gamebookKeys)
  *   - useGamebooks fetches via `fetchUserGamebooks` and surfaces the response
  *   - useGamebooks propagates fetch errors to the query state
- *   - useQuotaInfo still returns canonical fixture data (Gate B carryover —
- *     backend GET /api/v1/users/me/quota deferred to follow-up)
+ *   - useQuotaInfo fetches via `fetchUserQuota` (#2750 C14 — GET /api/v1/users/me/quota)
+ *     and propagates errors to the query state
  */
 
 import { type ReactNode } from 'react';
@@ -18,13 +18,19 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-import { gamebookIndexFixtures, type GamebookCardData } from '@/lib/gamebook-index';
+import { gamebookIndexFixtures, type GamebookCardData, type QuotaInfo } from '@/lib/gamebook-index';
 
 const fetchUserGamebooksMock =
   vi.fn<(signal?: AbortSignal) => Promise<readonly GamebookCardData[]>>();
 
 vi.mock('@/lib/api/gamebooks-list', () => ({
   fetchUserGamebooks: (signal?: AbortSignal) => fetchUserGamebooksMock(signal),
+}));
+
+const fetchUserQuotaMock = vi.fn<(signal?: AbortSignal) => Promise<QuotaInfo>>();
+
+vi.mock('@/lib/api/gamebook-quota', () => ({
+  fetchUserQuota: (signal?: AbortSignal) => fetchUserQuotaMock(signal),
 }));
 
 import { gamebookKeys, useGamebooks, useQuotaInfo } from '../useGamebooks';
@@ -40,6 +46,7 @@ function createWrapper() {
 
 beforeEach(() => {
   fetchUserGamebooksMock.mockReset();
+  fetchUserQuotaMock.mockReset();
 });
 
 describe('gamebookKeys', () => {
@@ -91,21 +98,43 @@ describe('useGamebooks', () => {
 });
 
 describe('useQuotaInfo', () => {
-  it('returns canonical fixture quota on success', async () => {
+  it('returns the quota resolved by fetchUserQuota', async () => {
+    fetchUserQuotaMock.mockResolvedValue(gamebookIndexFixtures.default.quota);
+
     const { result } = renderHook(() => useQuotaInfo(), { wrapper: createWrapper() });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
+    expect(fetchUserQuotaMock).toHaveBeenCalledTimes(1);
     expect(result.current.data).toEqual(gamebookIndexFixtures.default.quota);
   });
 
-  it('exposes default quota 12/50 for free tier', async () => {
+  it('surfaces the real per-user quota from the endpoint', async () => {
+    const real: QuotaInfo = {
+      used: 3,
+      total: 50,
+      resetDate: '2026-08-01T00:00:00.000Z',
+      tier: 'free',
+    };
+    fetchUserQuotaMock.mockResolvedValue(real);
+
     const { result } = renderHook(() => useQuotaInfo(), { wrapper: createWrapper() });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(result.current.data?.used).toBe(12);
+    expect(result.current.data?.used).toBe(3);
     expect(result.current.data?.total).toBe(50);
     expect(result.current.data?.tier).toBe('free');
+  });
+
+  it('exposes the fetch error to the query state', async () => {
+    const failure = new Error('Quota API error 401: unauthorized');
+    fetchUserQuotaMock.mockRejectedValue(failure);
+
+    const { result } = renderHook(() => useQuotaInfo(), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(result.current.error).toBe(failure);
   });
 });

--- a/apps/web/src/hooks/queries/useGamebooks.ts
+++ b/apps/web/src/hooks/queries/useGamebooks.ts
@@ -3,10 +3,7 @@
  *
  * Issue #869 status:
  *   - `useGamebooks`  → wired to `GET /api/v1/gamebooks` (real data)
- *   - `useQuotaInfo`  → STILL STUB pending follow-up (`GET /api/v1/users/me/quota`
- *                       not yet exposed). The stub returns canonical fixture
- *                       data so the orchestrator FSM keeps rendering correctly
- *                       until the quota endpoint lands.
+ *   - `useQuotaInfo`  → wired to `GET /api/v1/users/me/quota` (real data, #2750 C14)
  *
  * Used by:
  *   - `apps/web/src/app/(authenticated)/gamebook/_components/GamebookIndexView.tsx`
@@ -16,8 +13,9 @@
 
 import { useQuery, type UseQueryResult } from '@tanstack/react-query';
 
+import { fetchUserQuota } from '@/lib/api/gamebook-quota';
 import { fetchUserGamebooks } from '@/lib/api/gamebooks-list';
-import { gamebookIndexFixtures, type GamebookCardData, type QuotaInfo } from '@/lib/gamebook-index';
+import { type GamebookCardData, type QuotaInfo } from '@/lib/gamebook-index';
 
 /**
  * Stable query keys for the gamebook index hooks.
@@ -50,21 +48,19 @@ export function useGamebooks(): UseQueryResult<readonly GamebookCardData[], Erro
 }
 
 /**
- * Hook to fetch the current user's translation quota.
+ * Hook to fetch the current user's monthly gamebook translation quota.
  *
- * v1 carryover: returns the canonical fixture data via `gamebookIndexFixtures.default`.
- * The backend `GET /api/v1/users/me/quota` endpoint is NOT exposed; integration
- * deferred to a follow-up (issue #869b — split from #869 to keep PR small).
+ * #2750 (C14): wired to `GET /api/v1/users/me/quota` via `fetchUserQuota` (was a
+ * fixture stub). Returns the real per-user "paragraphs translated this month"
+ * count vs the monthly free-tier limit; 401 surfaces as an error the
+ * orchestrator's `error` FSM cell renders.
  *
  * @returns UseQueryResult with the QuotaInfo object.
  */
 export function useQuotaInfo(): UseQueryResult<QuotaInfo, Error> {
   return useQuery({
     queryKey: gamebookKeys.quota(),
-    queryFn: async (): Promise<QuotaInfo> => {
-      // v1 carryover stub — return canonical fixture data.
-      return gamebookIndexFixtures.default.quota;
-    },
+    queryFn: ({ signal }) => fetchUserQuota(signal),
     staleTime: 60_000,
   });
 }

--- a/apps/web/src/lib/api/gamebook-quota.ts
+++ b/apps/web/src/lib/api/gamebook-quota.ts
@@ -1,0 +1,35 @@
+/**
+ * Gamebook quota API client (#2750 C14, follow-up to #869b).
+ *
+ * Endpoint: GET /api/v1/users/me/quota
+ *
+ * Returns the authenticated user's monthly gamebook paragraph-translation quota
+ * (display-only, no enforcement). Replaces the v1 carryover fixture stub in
+ * `useQuotaInfo` (`gamebookIndexFixtures.default.quota`).
+ *
+ * Backend handler: `GetGamebookQuotaQueryHandler` (Administration BC).
+ */
+
+import { quotaInfoSchema, type QuotaInfo } from '@/lib/gamebook-index/schemas';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8080';
+
+export async function fetchUserQuota(signal?: AbortSignal): Promise<QuotaInfo> {
+  const res = await fetch(`${API_BASE}/api/v1/users/me/quota`, {
+    credentials: 'include',
+    signal,
+  });
+
+  if (!res.ok) {
+    let detail = '';
+    try {
+      detail = await res.text();
+    } catch {
+      /* ignore body read failure */
+    }
+    throw new Error(`Quota API error ${res.status}: ${detail || res.statusText}`);
+  }
+
+  const raw = (await res.json()) as unknown;
+  return quotaInfoSchema.parse(raw);
+}


### PR DESCRIPTION
## Release main-dev → main-staging (auto-deploy on merge)

Third #2655 staging promotion. Carries the **structural fix for the disk-gate loop** (#2764) that has been blocking every AI deploy on the 75GB VPS.

### Delta (3 commits, no AI-service path changes)
- `#2764` fix(ci): break staging AI-deploy disk-gate loop (order+infra)
- `#2763` feat(gamebook): C14 monthly translation quota metering (display-only)
- `#2762` test(agent-memory): prove house-rule injection into RAG prompts

### Expected (validates the disk-gate fix)
With Fix A, this workflow/frontend change no longer forces a ~23GB AI re-pull, so the deploy should pass the disk-gate **without manual VPS cleanup** (previously it aborted at `10 GB free < 15 GB`). Deploy job + Post-deploy Validation (503-tolerant Deep Health Check, #2760) should be green. The E2E "Auth login form visible" smoke may still be flaky (hydration on VPS headless, #2659) — orthogonal to these fixes.

Refs #2655