### PR TITLE
fix(migration): #2763 add ; terminator for idempotent script

### DIFF
--- a/apps/api/src/Api/Infrastructure/Migrations/20260707190653_AddGamebookTranslationsLimit.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260707190653_AddGamebookTranslationsLimit.cs
@@ -20,10 +20,14 @@ namespace Api.Infrastructure.Migrations
             // Issue #2750 (C14): the tier seeder is idempotent (it skips already-seeded rows),
             // so existing premium/unlimited definitions must be corrected explicitly. The free
             // tier stays at the column default (50).
+            // #2655 — the trailing ';' is REQUIRED: EF's idempotent migration script wraps each
+            // Sql() statement in `DO $EF$ BEGIN IF NOT EXISTS(...) THEN <sql> END IF; END $EF$`.
+            // Without the terminator the block becomes `<UPDATE> END IF` → "syntax error at or
+            // near END" under psql (the staging deploy applies the idempotent script).
             migrationBuilder.Sql(
-                "UPDATE tier_definitions SET max_gamebook_translations_per_month = 500 WHERE name = 'premium'");
+                "UPDATE tier_definitions SET max_gamebook_translations_per_month = 500 WHERE name = 'premium';");
             migrationBuilder.Sql(
-                "UPDATE tier_definitions SET max_gamebook_translations_per_month = 2147483647 WHERE name = 'unlimited'");
+                "UPDATE tier_definitions SET max_gamebook_translations_per_month = 2147483647 WHERE name = 'unlimited';");
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
## #2655 soak follow-up — fix migration that breaks the idempotent script

Discovered during the staging deploy soak: the "Apply migrations" step fails with
`psql:/tmp/migrations.sql:11205: ERROR: syntax error at or near "END" (LINE 5: END IF;)`.

### Root cause
The staging deploy applies EF Core's **idempotent** migration script via `psql -v ON_ERROR_STOP=1`, which wraps every `migrationBuilder.Sql()` statement in `DO $EF$ BEGIN IF NOT EXISTS(...) THEN <sql> END IF; END $EF$;`. Migration `20260707190653_AddGamebookTranslationsLimit`'s two `Sql("UPDATE tier_definitions SET ... WHERE name = 'premium'")` calls had **no trailing `;`**, producing `UPDATE ... 'premium'\n END IF;` — invalid PL/pgSQL. This is invisible on the `dotnet ef database update` path (raw SQL, no wrapper) but aborts the deploy on the idempotent `psql` path.

### Fix
Added `;` to both `Sql()` strings. Identical executed SQL; only the PL/pgSQL statement terminator. Verified by regenerating the idempotent script (`dotnet ef migrations script --idempotent`) and scanning ALL blocks — **zero remaining statements without a `;` before `END IF`**. Adversarial review spot-checked all 10 migrations using `Sql()` — every other one already terminates correctly (no latent twins).

Safe to edit: the migration was never applied to staging (deploy failed) or prod; EF tracks only MigrationId (no content checksum), so dev DBs that applied it via the direct path are already in the correct end state.

Note (informational, not in this PR): there is no analyzer catching a missing `;` in `migrationBuilder.Sql()` — a systemic gap worth a future lightweight Roslyn rule.

Refs #2655 #2763