### PR TITLE
release: staging — #2655 migration idempotent-terminator fix

### DIFF
--- a/apps/api/src/Api/Infrastructure/Migrations/20260707190653_AddGamebookTranslationsLimit.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260707190653_AddGamebookTranslationsLimit.cs
@@ -20,10 +20,14 @@ namespace Api.Infrastructure.Migrations
             // Issue #2750 (C14): the tier seeder is idempotent (it skips already-seeded rows),
             // so existing premium/unlimited definitions must be corrected explicitly. The free
             // tier stays at the column default (50).
+            // #2655 — the trailing ';' is REQUIRED: EF's idempotent migration script wraps each
+            // Sql() statement in `DO $EF$ BEGIN IF NOT EXISTS(...) THEN <sql> END IF; END $EF$`.
+            // Without the terminator the block becomes `<UPDATE> END IF` → "syntax error at or
+            // near END" under psql (the staging deploy applies the idempotent script).
             migrationBuilder.Sql(
-                "UPDATE tier_definitions SET max_gamebook_translations_per_month = 500 WHERE name = 'premium'");
+                "UPDATE tier_definitions SET max_gamebook_translations_per_month = 500 WHERE name = 'premium';");
             migrationBuilder.Sql(
-                "UPDATE tier_definitions SET max_gamebook_translations_per_month = 2147483647 WHERE name = 'unlimited'");
+                "UPDATE tier_definitions SET max_gamebook_translations_per_month = 2147483647 WHERE name = 'unlimited';");
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
## Release main-dev → main-staging (auto-deploy on merge)

Fourth #2655 staging promotion. Carries the migration fix (#2766) that unblocks the "Apply migrations" step (idempotent-script `;` terminator). With all prior fixes in place (STEP 6 health-wait, Deep Health Check 503-tolerance, disk-gate loop), this deploy should finally go green end-to-end except the known-flaky E2E login smoke.

### Delta (1 commit, no AI-service changes)
- `#2766` fix(migration): add ; terminator for idempotent script

### Expected
- Apply migrations: SUCCESS (the `;` fixes the `DO $EF$ ... END IF` PL/pgSQL block)
- Deploy via SSH: disk-gate does not fire (Fix A, no AI pull) + STEP 6 health-wait
- Post-deploy Validation: SUCCESS (503-tolerant Deep Health Check)
- E2E "Auth login form visible" may still be flaky (#2659) — orthogonal

Refs #2655