### PR TITLE
fix(frontend): #2770 restore SSR — remove app-wide ssr:false BailoutToCSR (fixes flaky login E2E)

### DIFF
--- a/apps/web/e2e/smoke.spec.ts
+++ b/apps/web/e2e/smoke.spec.ts
@@ -40,16 +40,18 @@ test.describe('Smoke Test — 8 step pre-deploy', () => {
 
   test('2. Auth login form visibile', async ({ page }) => {
     await page.goto('/login', { waitUntil: 'domcontentloaded' });
-    // Il login form è client-only: nell'SSR /login rende il fallback <Suspense>
-    // (useSearchParams), quindi l'input email esiste SOLO dopo l'hydration del
-    // bundle client. Sul runner self-hosted (chromium headless, VPS con cap
-    // memoria 3G) l'hydration supera consistentemente gli 8s → falso negativo
-    // (il form è renderizzato e funzionante, verificato in un browser reale).
-    // Timeout ampio (30s) per assorbire l'hydration lenta senza rallentare il
-    // caso normale (l'expect passa appena l'elemento appare). NON mockare
-    // /auth/me qui: simulerebbe un utente loggato → redirect via da /login.
+    // #2770: il login form è ora SERVER-RENDERED. Prima l'intero body dell'app
+    // faceva BailoutToCSR — StatePreviewProvider era montato via
+    // `next/dynamic({ ssr: false })` in providers.tsx e avvolgeva ogni route,
+    // così l'input email compariva SOLO dopo l'hydration del bundle client
+    // (>30s sul runner headless con cap memoria 3G → falso negativo). Ora
+    // l'email input è nell'HTML iniziale (verificato via curl dell'SSR), quindi
+    // è presente già a `domcontentloaded`. Timeout ridotto a 15s: ampio per
+    // assorbire latenza VPS/rete sul singolo documento, ma abbastanza stretto
+    // da FALLIRE (invece di mascherare via hydration) se l'SSR regredisse.
+    // NON mockare /auth/me qui: simulerebbe un utente loggato → redirect da /login.
     await expect(page.locator('input[type="email"], input[name="email"]').first()).toBeVisible({
-      timeout: 30000,
+      timeout: 15000,
     });
   });
 

--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -766,7 +766,7 @@ export default [
                 "@/components/ui/state-preview/state-preview-provider",
               ],
               message:
-                "Use '@/components/ui/state-preview' barrel (which uses dynamic({ssr:false}) for tree-shake guarantee). Direct import of state-preview-provider bypasses dev-only isolation.",
+                "Use '@/components/ui/state-preview' barrel (NODE_ENV-gated loader: production gets a zero-cost pass-through that keeps SSR working, dev gets a dynamic import WITHOUT ssr:false — see #2770). Direct import of state-preview-provider bypasses that isolation and the tree-shake guarantee.",
             },
             {
               group: [

--- a/apps/web/src/components/ui/state-preview/__tests__/state-preview-loader.test.tsx
+++ b/apps/web/src/components/ui/state-preview/__tests__/state-preview-loader.test.tsx
@@ -1,0 +1,73 @@
+/**
+ * StatePreview loader — SSR regression tests (Issue #2770).
+ *
+ * The loader wraps `<AppContent>{children}</AppContent>` for the ENTIRE app
+ * (via providers.tsx). It previously mounted the provider with
+ * `next/dynamic({ ssr: false })`, which throws `BailoutToCSR` during server
+ * rendering and forced React to client-render the whole subtree — disabling
+ * SSR for every route. The staging login form only appeared after (heavy)
+ * client hydration, causing the flaky E2E "Auth login form visibile".
+ *
+ * These tests lock in the fix: in production the loader MUST render its
+ * children server-side (no ssr:false bailout). We assert this at the unit
+ * level with `renderToString` so the guarantee survives future refactors
+ * without needing a full `next build` + curl.
+ */
+
+import type { ComponentType, ReactNode } from 'react';
+
+import { renderToString } from 'react-dom/server';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { StatePreviewProviderProps } from '../state-preview-types';
+
+const CHILD_MARKER = 'ssr-child-marker-2770';
+
+/**
+ * Re-import the loader with a fresh module registry so the module-level
+ * `process.env.NODE_ENV` branch is re-evaluated under the stubbed env.
+ */
+async function loadProvider(): Promise<ComponentType<StatePreviewProviderProps>> {
+  vi.resetModules();
+  const mod = await import('../state-preview-loader');
+  return mod.StatePreviewProvider;
+}
+
+function Child(): ReactNode {
+  return <div data-testid="ssr-child">{CHILD_MARKER}</div>;
+}
+
+describe('StatePreviewProvider loader — SSR (Issue #2770)', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it('server-renders children in production (no ssr:false CSR bailout)', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    const StatePreviewProvider = await loadProvider();
+
+    const html = renderToString(
+      <StatePreviewProvider>
+        <Child />
+      </StatePreviewProvider>
+    );
+
+    // The child MUST be present in the server-rendered HTML. With the old
+    // `dynamic({ ssr: false })` loader this string was absent (bailout → null).
+    expect(html).toContain(CHILD_MARKER);
+  });
+
+  it('renders children (pass-through) so it never gates the app tree', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    const StatePreviewProvider = await loadProvider();
+
+    const html = renderToString(
+      <StatePreviewProvider>
+        <Child />
+      </StatePreviewProvider>
+    );
+
+    expect(html).toContain('data-testid="ssr-child"');
+  });
+});

--- a/apps/web/src/components/ui/state-preview/state-preview-loader.tsx
+++ b/apps/web/src/components/ui/state-preview/state-preview-loader.tsx
@@ -2,11 +2,30 @@
  * StatePreviewProvider dynamic loader — CANONICAL CONSUMER ENTRY POINT.
  *
  * Asse B WP5 T5 (Issue #1897). DEC-4 + CRIT-5: Next.js dead-code-elimination
- * combined with `dynamic({ssr:false, loading: () => null})` guarantees the
- * provider implementation is tree-shaken from production chunks (>99% strip).
+ * combined with a dev-only `next/dynamic` import guarantees the provider
+ * implementation is tree-shaken from production chunks (>99% strip).
  *
  * Verified via static analysis acceptance test in
  * `apps/web/__tests__/state-preview-tree-shake.test.ts`.
+ *
+ * ────────────────────────────────────────────────────────────────────────
+ * Issue #2770 — DO NOT pass `ssr: false` here.
+ *
+ * This provider wraps `<AppContent>{children}</AppContent>` for the ENTIRE
+ * app (providers.tsx). A `next/dynamic({ ssr: false })` component throws
+ * `BailoutToCSR` during server rendering; React then client-renders the whole
+ * subtree, so NO route emitted any body HTML server-side. The staging login
+ * form only appeared after heavy client hydration — the flaky E2E "Auth login
+ * form visibile" (the input exceeded the 30s timeout on the 3 GB headless VPS
+ * runner). Confirmed by curling the SSR HTML: it contained a single
+ * `BAILOUT_TO_CLIENT_SIDE_RENDERING` template and zero app content.
+ *
+ * Fix: StatePreview is a dev-only tool. In production we render children
+ * directly (a zero-cost pass-through) so SSR works for every route AND the
+ * provider impl tree-shakes out entirely (the dead `import()` below is
+ * eliminated once `process.env.NODE_ENV` is inlined). In development we load
+ * the real provider lazily WITHOUT `ssr: false`, so dev SSRs like production.
+ * ────────────────────────────────────────────────────────────────────────
  *
  * Consumers MUST import from the barrel `@/components/ui/state-preview`,
  * which re-exports this loader. Direct import of `state-preview-provider`
@@ -15,13 +34,33 @@
 
 'use client';
 
-import type { ComponentType } from 'react';
+import type { ComponentType, ReactNode } from 'react';
 
 import dynamic from 'next/dynamic';
 
 import type { StatePreviewProviderProps } from './state-preview-types';
 
-export const StatePreviewProvider: ComponentType<StatePreviewProviderProps> = dynamic(
-  () => import('./state-preview-provider').then(m => m.StatePreviewProvider),
-  { ssr: false, loading: () => null }
-);
+/**
+ * Production pass-through: renders children with no context wrapper. Safe
+ * because every consumer short-circuits in production — `useStatePreview`
+ * returns a fixed no-op and `StatePreviewToggle` renders null. Keeping this a
+ * plain synchronous component is what restores server-side rendering.
+ */
+function StatePreviewPassThrough({ children }: StatePreviewProviderProps): ReactNode {
+  return <>{children}</>;
+}
+
+/**
+ * Dev-only lazy provider. The `import()` lives in the dead branch of the
+ * build-time-constant ternary below, so production builds eliminate it and the
+ * heavy impl never reaches a client chunk. No `ssr: false` → the provider
+ * server-renders in dev (mirrors production), instead of bailing the app to
+ * client-side rendering.
+ */
+export const StatePreviewProvider: ComponentType<StatePreviewProviderProps> =
+  process.env.NODE_ENV === 'production'
+    ? StatePreviewPassThrough
+    : (dynamic(
+        () => import('./state-preview-provider').then(m => ({ default: m.StatePreviewProvider })),
+        { loading: () => null }
+      ) as ComponentType<StatePreviewProviderProps>);


### PR DESCRIPTION
## Summary

Resolves **root cause A** of #2770 — the flaky staging E2E `smoke.spec.ts › 2. Auth login form visibile` — at its true source.

### Root cause (found by curling the SSR HTML)

The `/login` form was never server-rendered. The `#2650` bisection looked inside the `/login` route, but the culprit lives **above the whole app** in `providers.tsx`:

`StatePreviewProvider` (a dev-only tool) was mounted via `next/dynamic(() => import(...), { ssr: false, loading: () => null })` and wraps `<AppContent>{children}</AppContent>` — i.e. **every route**. In Next.js 16, an `ssr:false` dynamic component throws `BailoutToCSR` during SSR, so React client-renders the whole subtree. **No route emitted body HTML server-side.** The login form only appeared after heavy client hydration (>30 s on the 3 GB headless VPS runner) → flaky.

Ground-truth evidence — the SSR HTML of `/login` contained a single:
```html
<template data-dgst="BAILOUT_TO_CLIENT_SIDE_RENDERING"
  data-msg="... Bail out to client-side rendering: next/dynamic" ...>
```
and **zero** app body content (not even the `main-content` landmark). `/` and every other route bailed the same way.

This explains why all the #2650 attempts (props, `window.location`, `force-dynamic`, bare client child, server layout) failed: none touched the global `StatePreviewProvider`, which sits above `/login` in the tree.

### Fix

`state-preview-loader.tsx` — gate the loader on `NODE_ENV`:
- **Production** → render children directly (a zero-cost pass-through). Safe because every StatePreview consumer already no-ops in prod (`useStatePreview` returns a fixed no-op; `StatePreviewToggle` renders null). This restores SSR for every route **and** keeps the DEC-4 tree-shake guarantee (the dead `import()` in the ternary's dead branch is eliminated once `NODE_ENV` is inlined).
- **Dev/test** → load the real provider lazily **without** `ssr: false`, so dev SSRs like prod and the dev tool still works.

## Verification

| Check | Result |
|---|---|
| Prod **standalone** build (`node .next/standalone/server.js`, the exact staging artifact) — curl `/login` | ✅ email input + `login-form` + `main-content` in SSR HTML, **0** `BailoutToCSR` |
| `pnpm build` | ✅ 157 static pages, 0 errors |
| Tree-shake guarantee (`state-preview-tree-shake.test.ts`) | ✅ 2/2 (impl not in entry chunks) |
| New `renderToString` regression test | ✅ red → green |
| typecheck / eslint / prettier | ✅ clean |
| state-preview (15) + auth/login (25) unit tests | ✅ green |
| Adversarial code review | ✅ no critical/high; 1 stale lint message fixed |

## Files
- `state-preview-loader.tsx` — the fix (NODE_ENV-gated loader, no `ssr:false`)
- `__tests__/state-preview-loader.test.tsx` — new SSR regression test
- `e2e/smoke.spec.ts` — updated comment; timeout `30s → 15s` (the input is now in the initial HTML, so a tighter timeout **fails fast** on an SSR regression instead of masking it via slow hydration)
- `eslint.config.mjs` — refresh the `no-restricted-imports` message (no longer references `ssr:false`)

## Notes / out of scope
- `/register`, `/reset-password`, `/welcome`, `/verify-email` still client-render via **their own** `useSearchParams` (pre-existing — merely *unmasked* by removing the global bailout; **no regression**). Each would SSR with the #2650 props pattern — a good follow-up but not required by #2770.
- **Root cause B** (`api.meepleai.app` 502) is **infra-only** and being tracked separately: cloudflared is a **VPS-native process** (not a container), so the issue's "route via the docker network (`meepleai-api:8080`)" suggestion is **not viable** as-is, and the tunnel ingress (`originService=http://localhost:8080`) lives in the **Cloudflare dashboard, not the repo**. The 502 was the host **docker-proxy dying** under resource pressure. Any fix (containerize cloudflared, or resource headroom) needs a staging deploy to validate — a follow-up issue captures the corrected analysis.

Refs #2770 #2659 #2650