### PR TITLE
fix(frontend): #2773 SSR remaining (auth) routes via server-props pattern

### DIFF
--- a/apps/web/src/app/(auth)/register/__tests__/_content.test.tsx
+++ b/apps/web/src/app/(auth)/register/__tests__/_content.test.tsx
@@ -25,11 +25,9 @@ vi.mock('@/hooks/useTranslation', () => ({
 
 const pushMock = vi.fn().mockResolvedValue(undefined);
 const refreshMock = vi.fn();
-const searchParamsMock = { get: vi.fn<(key: string) => string | null>() };
 
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: pushMock, refresh: refreshMock }),
-  useSearchParams: () => searchParamsMock,
 }));
 
 const { mockAuth } = vi.hoisted(() => ({
@@ -67,18 +65,12 @@ vi.mock('@/lib/analytics/flywheel-events', () => ({
 }));
 
 // Import AFTER mocks
-import { RegisterPageContent, RegisterFallback } from '../_content';
+import { RegisterPageContent } from '../_content';
 import { logger } from '@/lib/logger';
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-function setSearchParams(params: Record<string, string | null>) {
-  searchParamsMock.get.mockImplementation((key: string) =>
-    Object.prototype.hasOwnProperty.call(params, key) ? (params[key] ?? null) : null
-  );
-}
 
 function resolveMode(mode: { publicRegistrationEnabled: boolean; oauthEnabled?: boolean }) {
   getRegistrationModeMock.mockResolvedValue(mode);
@@ -86,13 +78,13 @@ function resolveMode(mode: { publicRegistrationEnabled: boolean; oauthEnabled?: 
 
 beforeEach(() => {
   vi.clearAllMocks();
-  setSearchParams({});
   // default: public registration with OAuth enabled
   resolveMode({ publicRegistrationEnabled: true, oauthEnabled: true });
 });
 
-async function renderAndWait(mode?: 'public' | 'invite-only') {
-  const result = render(<RegisterPageContent />);
+async function renderAndWait(mode?: 'public' | 'invite-only', props?: { oauthDisabled?: boolean }) {
+  // #2773: oauth_disabled now flows as a prop from the async page.tsx.
+  const result = render(<RegisterPageContent oauthDisabled={props?.oauthDisabled} />);
   // Wait for async mode fetch to settle (loading indicator disappears)
   if (mode === 'public') {
     await screen.findByTestId('register-form');
@@ -130,16 +122,15 @@ describe('RegisterPageContent (v2 AuthCard)', () => {
       expect(screen.getByText('auth.register.inviteOnlySubtitle')).toBeInTheDocument();
     });
 
-    it('shows inviteOauthDisabled alert when ?oauth_disabled=true', async () => {
-      setSearchParams({ oauth_disabled: 'true' });
-      await renderAndWait('invite-only');
+    it('shows inviteOauthDisabled alert when oauthDisabled prop is true', async () => {
+      await renderAndWait('invite-only', { oauthDisabled: true });
       const alerts = screen.getAllByRole('alert');
       expect(alerts.some(a => a.textContent?.includes('auth.register.inviteOauthDisabled'))).toBe(
         true
       );
     });
 
-    it('does not show inviteOauthDisabled alert when oauth_disabled is absent', async () => {
+    it('does not show inviteOauthDisabled alert when oauthDisabled prop is absent', async () => {
       await renderAndWait('invite-only');
       const alerts = screen.queryAllByRole('alert');
       expect(alerts.some(a => a.textContent?.includes('auth.register.inviteOauthDisabled'))).toBe(
@@ -272,12 +263,5 @@ describe('RegisterPageContent (v2 AuthCard)', () => {
         });
       }
     });
-  });
-});
-
-describe('RegisterFallback', () => {
-  it('renders loading message', () => {
-    render(<RegisterFallback />);
-    expect(screen.getByText('auth.register.loadingMessage')).toBeInTheDocument();
   });
 });

--- a/apps/web/src/app/(auth)/register/_content.tsx
+++ b/apps/web/src/app/(auth)/register/_content.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useState } from 'react';
 
 import Link from 'next/link';
-import { useRouter, useSearchParams } from 'next/navigation';
+import { useRouter } from 'next/navigation';
 
 import { buildOAuthUrl } from '@/components/auth/oauth-url';
 import { RegisterForm, type RegisterSubmitPayload } from '@/components/auth/RegisterForm';
@@ -23,25 +23,23 @@ import { useApiClient } from '@/lib/api/context';
 type RegistrationMode = 'loading' | 'public' | 'invite-only';
 
 // ============================================================================
-// Fallback (Suspense boundary)
-// ============================================================================
-
-export function RegisterFallback() {
-  const { t } = useTranslation();
-  return (
-    <main className="min-h-dvh flex items-center justify-center bg-muted text-muted-foreground">
-      {t('auth.register.loadingMessage')}
-    </main>
-  );
-}
-
-// ============================================================================
 // Main content
 // ============================================================================
 
-export function RegisterPageContent() {
+/**
+ * #2773 — `oauthDisabled` arrives as a PROP from the async Server Component
+ * page.tsx (which reads searchParams). Reading it as a prop instead of via the
+ * `useSearchParams` client hook lets this component render server-side (SSR) —
+ * the form is in the initial HTML instead of behind a CSR bailout. Same pattern
+ * as `login/_content.tsx` (#2650).
+ */
+export interface RegisterPageContentProps {
+  /** `?oauth_disabled=true` marker (OAuth suppressed for invite-only). */
+  oauthDisabled?: boolean;
+}
+
+export function RegisterPageContent({ oauthDisabled = false }: RegisterPageContentProps) {
   const router = useRouter();
-  const searchParams = useSearchParams();
   const { t } = useTranslation();
   const { register } = useAuth();
   const api = useApiClient();
@@ -51,7 +49,6 @@ export function RegisterPageContent() {
   const [isAuthenticating, setIsAuthenticating] = useState(false);
   const [error, setError] = useState<string>('');
 
-  const oauthDisabled = searchParams?.get('oauth_disabled') === 'true';
   // Audit (#2168): register does NOT read ?from=. Post-registration redirect is
   // hardcoded to /verification-pending (line below in handleRegister). If a
   // ?from= param is ever introduced here, use assertSafeRelativeOrFallback from

--- a/apps/web/src/app/(auth)/register/page.tsx
+++ b/apps/web/src/app/(auth)/register/page.tsx
@@ -12,16 +12,22 @@
  *
  * Standalone registration page with AuthModal.
  * Uses AuthLayout wrapper for consistent auth page UX (Issue #2231).
+ *
+ * #2773: this Server Component reads searchParams (async in Next 16) and passes
+ * `oauth_disabled` down as a prop, so the client RegisterPageContent renders
+ * WITHOUT `useSearchParams` — the form is server-rendered (no CSR bailout, no
+ * <Suspense> fallback). Same props pattern as `login/page.tsx` (#2650 / #2771).
  */
 
-import { Suspense } from 'react';
+import { RegisterPageContent } from './_content';
 
-import { RegisterFallback, RegisterPageContent } from './_content';
+export default async function RegisterPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+}) {
+  const params = await searchParams;
+  const oauthDisabled = params.oauth_disabled === 'true';
 
-export default function RegisterPage() {
-  return (
-    <Suspense fallback={<RegisterFallback />}>
-      <RegisterPageContent />
-    </Suspense>
-  );
+  return <RegisterPageContent oauthDisabled={oauthDisabled} />;
 }

--- a/apps/web/src/app/(auth)/reset-password/__tests__/_content.test.tsx
+++ b/apps/web/src/app/(auth)/reset-password/__tests__/_content.test.tsx
@@ -18,7 +18,6 @@ const {
   mockRequestPasswordReset,
   mockConfirmPasswordReset,
   mockLogin,
-  mockSearchParamsGet,
   MockApiError,
 } = vi.hoisted(() => {
   // Minimal stand-in for the real ApiError class. The shared getErrorMessage
@@ -41,14 +40,12 @@ const {
     mockRequestPasswordReset: vi.fn(),
     mockConfirmPasswordReset: vi.fn(),
     mockLogin: vi.fn(),
-    mockSearchParamsGet: vi.fn<(key: string) => string | null>(),
     MockApiError,
   };
 });
 
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: mockPush }),
-  useSearchParams: () => ({ get: mockSearchParamsGet }),
 }));
 
 vi.mock('@/hooks/useTranslation', () => ({
@@ -80,9 +77,7 @@ beforeEach(() => {
   mockRequestPasswordReset.mockReset();
   mockConfirmPasswordReset.mockReset();
   mockLogin.mockReset();
-  mockSearchParamsGet.mockReset();
 
-  mockSearchParamsGet.mockReturnValue(null);
   // default: not authenticated (so the auth guard clears isCheckingAuth)
   mockGetMe.mockRejectedValue(new Error('401'));
 });
@@ -179,10 +174,8 @@ describe('ResetPasswordPageContent — request mode', () => {
 // ---------------------------------------------------------------------------
 
 describe('ResetPasswordPageContent — reset mode', () => {
-  beforeEach(() => {
-    mockSearchParamsGet.mockImplementation((key: string) => (key === 'token' ? 'tok-123' : null));
-  });
-
+  // #2773: reset mode is now driven by the `token` prop (from the async page.tsx),
+  // not by a mocked useSearchParams.
   it('shows the verifying state while the token is being checked', async () => {
     // Use mockImplementation (not mockResolvedValueOnce): the verify-token
     // effect re-fires on every render because the mocked useTranslation
@@ -190,7 +183,7 @@ describe('ResetPasswordPageContent — reset mode', () => {
     // A single-shot mock would be exhausted after the first render.
     mockVerifyResetToken.mockImplementation(() => new Promise(() => {}));
 
-    render(<ResetPasswordPageContent />);
+    render(<ResetPasswordPageContent token="tok-123" />);
 
     expect(
       await screen.findByRole('heading', { name: 'auth.resetPassword.verifyingTitle' })
@@ -200,7 +193,7 @@ describe('ResetPasswordPageContent — reset mode', () => {
   it('shows the invalid-link card when token verification fails', async () => {
     mockVerifyResetToken.mockRejectedValue(new Error('bad token'));
 
-    render(<ResetPasswordPageContent />);
+    render(<ResetPasswordPageContent token="tok-123" />);
 
     expect(
       await screen.findByRole('heading', { name: 'auth.resetPassword.invalidLinkTitle' })
@@ -213,7 +206,7 @@ describe('ResetPasswordPageContent — reset mode', () => {
   it('renders the new password form when token is valid', async () => {
     mockVerifyResetToken.mockResolvedValue(undefined);
 
-    render(<ResetPasswordPageContent />);
+    render(<ResetPasswordPageContent token="tok-123" />);
 
     expect(
       await screen.findByRole('heading', { name: 'auth.resetPassword.confirmTitle' })
@@ -227,7 +220,7 @@ describe('ResetPasswordPageContent — reset mode', () => {
     mockConfirmPasswordReset.mockResolvedValue({ message: 'ok' });
     mockLogin.mockRejectedValue(new Error('no auto-login'));
 
-    render(<ResetPasswordPageContent />);
+    render(<ResetPasswordPageContent token="tok-123" />);
 
     const pwd = await screen.findByLabelText('auth.resetPassword.passwordLabel');
     const confirm = screen.getByLabelText('auth.resetPassword.confirmPasswordLabel');
@@ -264,7 +257,7 @@ describe('ResetPasswordPageContent — reset mode', () => {
     mockVerifyResetToken.mockResolvedValue(undefined);
     mockConfirmPasswordReset.mockRejectedValue(new Error('Token expired'));
 
-    render(<ResetPasswordPageContent />);
+    render(<ResetPasswordPageContent token="tok-123" />);
 
     const pwd = await screen.findByLabelText('auth.resetPassword.passwordLabel');
     const confirm = screen.getByLabelText('auth.resetPassword.confirmPasswordLabel');

--- a/apps/web/src/app/(auth)/reset-password/_content.tsx
+++ b/apps/web/src/app/(auth)/reset-password/_content.tsx
@@ -15,7 +15,7 @@
 import { useEffect, useState, type FormEvent, type JSX } from 'react';
 
 import Link from 'next/link';
-import { useRouter, useSearchParams } from 'next/navigation';
+import { useRouter } from 'next/navigation';
 
 import { AuthCard } from '@/components/ui/auth-card';
 import { Btn } from '@/components/ui/btn';
@@ -60,30 +60,26 @@ function validatePassword(password: string): PasswordValidation {
 }
 
 // ---------------------------------------------------------------------------
-// Suspense fallback
-// ---------------------------------------------------------------------------
-
-export function ResetPasswordFallback(): JSX.Element {
-  const { t } = useTranslation();
-  return (
-    <main className="min-h-dvh flex items-center justify-center bg-muted text-muted-foreground">
-      <div className="animate-pulse" data-testid="reset-password-loading">
-        {t('auth.resetPassword.loadingTitle')}
-      </div>
-    </main>
-  );
-}
-
-// ---------------------------------------------------------------------------
 // Main content
 // ---------------------------------------------------------------------------
 
-export function ResetPasswordPageContent(): JSX.Element | null {
+/**
+ * #2773 — `token` arrives as a PROP from the async Server Component page.tsx
+ * (which reads searchParams). Reading it as a prop instead of via the
+ * `useSearchParams` client hook lets this component render server-side (SSR),
+ * dropping the CSR bailout. Same pattern as `login/_content.tsx` (#2650).
+ */
+export interface ResetPasswordPageContentProps {
+  /** `?token=` reset token. Reset mode when present, request mode otherwise. */
+  token?: string | null;
+}
+
+export function ResetPasswordPageContent({
+  token = null,
+}: ResetPasswordPageContentProps): JSX.Element | null {
   const router = useRouter();
-  const searchParams = useSearchParams();
   const { t } = useTranslation();
 
-  const token = searchParams?.get('token') ?? null;
   const mode: 'request' | 'reset' = token ? 'reset' : 'request';
   // Note (#2168): all redirect targets in this file are hardcoded (/chat, /, /reset-password).
   // Do NOT introduce ?from= here without using assertSafeRelativeOrFallback

--- a/apps/web/src/app/(auth)/reset-password/page.tsx
+++ b/apps/web/src/app/(auth)/reset-password/page.tsx
@@ -10,15 +10,15 @@
 /**
  * Password Reset Page (AUTH-04) — v2 migration (Task 13).
  *
- * Two-mode password reset flow wrapped in a Suspense boundary so that the
- * client-only `useSearchParams()` hook inside `_content.tsx` is allowed.
+ * #2773: async Server Component reads searchParams (async in Next 16) and passes
+ * `token` down as a prop, so the client _content renders WITHOUT
+ * `useSearchParams` — SSR'd, no CSR bailout. Same props pattern as
+ * `login/page.tsx` (#2650 / #2771).
  */
-
-import { Suspense } from 'react';
 
 import { Metadata } from 'next';
 
-import { ResetPasswordFallback, ResetPasswordPageContent } from './_content';
+import { ResetPasswordPageContent } from './_content';
 
 export const metadata: Metadata = {
   title: 'Reimposta password | MeepleAI',
@@ -26,10 +26,13 @@ export const metadata: Metadata = {
   robots: { index: false, follow: false },
 };
 
-export default function ResetPasswordPage() {
-  return (
-    <Suspense fallback={<ResetPasswordFallback />}>
-      <ResetPasswordPageContent />
-    </Suspense>
-  );
+export default async function ResetPasswordPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+}) {
+  const params = await searchParams;
+  const token = typeof params.token === 'string' ? params.token : undefined;
+
+  return <ResetPasswordPageContent token={token} />;
 }

--- a/apps/web/src/app/(auth)/setup-account/__tests__/_content.test.tsx
+++ b/apps/web/src/app/(auth)/setup-account/__tests__/_content.test.tsx
@@ -1,0 +1,69 @@
+/**
+ * Setup-account page (_content.tsx) smoke tests — #2773 props migration.
+ *
+ * Covers the refactored contract: the invitation `token` now flows as a PROP
+ * from the async page.tsx instead of via `useSearchParams`. Focused smoke tests
+ * for the prop wiring (missing-token branch + validation call), not full
+ * behavioural coverage of the activation flow.
+ */
+
+import { render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mocks (must be registered before component import)
+// ---------------------------------------------------------------------------
+
+const pushMock = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: pushMock }),
+}));
+
+// Passthrough AuthLayout so the smoke test does not depend on layout internals.
+vi.mock('@/components/layouts', () => ({
+  AuthLayout: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+// Import AFTER mocks
+import { SetupAccountContent } from '../_content';
+
+const originalFetch = global.fetch;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+});
+
+describe('SetupAccountContent — #2773 props contract', () => {
+  it('renders the missing-token branch when the token prop is absent (no validation call)', () => {
+    const fetchMock = vi.fn();
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    render(<SetupAccountContent token={null} />);
+
+    expect(screen.getByText(/Utilizza il link ricevuto/)).toBeInTheDocument();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('validates the invitation token supplied via the prop on mount', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ isValid: false, errorReason: 'invalid' }),
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    render(<SetupAccountContent token="inv-tok" />);
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalled();
+    });
+
+    const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(String(url)).toContain('/api/v1/auth/validate-invitation');
+    expect(options.method).toBe('POST');
+    expect(String(options.body)).toContain('inv-tok');
+  });
+});

--- a/apps/web/src/app/(auth)/setup-account/_content.tsx
+++ b/apps/web/src/app/(auth)/setup-account/_content.tsx
@@ -14,7 +14,7 @@
 import { useEffect, useState, FormEvent } from 'react';
 
 import Link from 'next/link';
-import { useRouter, useSearchParams } from 'next/navigation';
+import { useRouter } from 'next/navigation';
 
 import { AuthLayout } from '@/components/layouts';
 import { Btn } from '@/components/ui/btn';
@@ -71,10 +71,19 @@ const getApiBase = (): string => {
 // Main Content Component
 // ──────────────────────────────────────────────
 
-export function SetupAccountContent() {
+/**
+ * #2773 — `token` arrives as a PROP from the async Server Component page.tsx
+ * (which reads searchParams). Reading it as a prop instead of via the
+ * `useSearchParams` client hook lets this component render server-side (SSR),
+ * dropping the CSR bailout. Same pattern as `login/_content.tsx` (#2650).
+ */
+export interface SetupAccountContentProps {
+  /** `?token=` invitation token. */
+  token?: string | null;
+}
+
+export function SetupAccountContent({ token = null }: SetupAccountContentProps) {
   const router = useRouter();
-  const searchParams = useSearchParams();
-  const token = searchParams?.get('token') ?? null;
 
   // Token validation state
   const [validationResult, setValidationResult] = useState<InvitationValidation | null>(null);
@@ -376,9 +385,7 @@ export function SetupAccountContent() {
           <div className="text-sm space-y-1">
             <div
               className={`flex items-center gap-2 ${
-                passwordValidation.minLength
-                  ? 'text-green-400'
-                  : 'text-muted-foreground'
+                passwordValidation.minLength ? 'text-green-400' : 'text-muted-foreground'
               }`}
             >
               <span aria-hidden="true">{passwordValidation.minLength ? '\u2713' : '\u25CB'}</span>
@@ -386,9 +393,7 @@ export function SetupAccountContent() {
             </div>
             <div
               className={`flex items-center gap-2 ${
-                passwordValidation.hasUppercase
-                  ? 'text-green-400'
-                  : 'text-muted-foreground'
+                passwordValidation.hasUppercase ? 'text-green-400' : 'text-muted-foreground'
               }`}
             >
               <span aria-hidden="true">
@@ -398,9 +403,7 @@ export function SetupAccountContent() {
             </div>
             <div
               className={`flex items-center gap-2 ${
-                passwordValidation.hasLowercase
-                  ? 'text-green-400'
-                  : 'text-muted-foreground'
+                passwordValidation.hasLowercase ? 'text-green-400' : 'text-muted-foreground'
               }`}
             >
               <span aria-hidden="true">
@@ -410,9 +413,7 @@ export function SetupAccountContent() {
             </div>
             <div
               className={`flex items-center gap-2 ${
-                passwordValidation.hasNumber
-                  ? 'text-green-400'
-                  : 'text-muted-foreground'
+                passwordValidation.hasNumber ? 'text-green-400' : 'text-muted-foreground'
               }`}
             >
               <span aria-hidden="true">{passwordValidation.hasNumber ? '\u2713' : '\u25CB'}</span>

--- a/apps/web/src/app/(auth)/setup-account/page.tsx
+++ b/apps/web/src/app/(auth)/setup-account/page.tsx
@@ -20,24 +20,20 @@
  * 4. On submit: activate account and redirect to onboarding or dashboard
  */
 
-import { Suspense } from 'react';
-
-import { AuthLayout } from '@/components/layouts';
-
 import { SetupAccountContent } from './_content';
 
-export default function SetupAccountPage() {
-  return (
-    <Suspense
-      fallback={
-        <AuthLayout title="Caricamento...">
-          <div className="text-center py-8">
-            <div className="animate-pulse text-muted-foreground">Caricamento...</div>
-          </div>
-        </AuthLayout>
-      }
-    >
-      <SetupAccountContent />
-    </Suspense>
-  );
+/**
+ * #2773: async Server Component reads searchParams (async in Next 16) and passes
+ * `token` down as a prop, so the client content renders WITHOUT `useSearchParams`
+ * — no CSR bailout. Same props pattern as `login/page.tsx` (#2650 / #2771).
+ */
+export default async function SetupAccountPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+}) {
+  const params = await searchParams;
+  const token = typeof params.token === 'string' ? params.token : undefined;
+
+  return <SetupAccountContent token={token} />;
 }

--- a/apps/web/src/app/(auth)/verification-pending/__tests__/_content.test.tsx
+++ b/apps/web/src/app/(auth)/verification-pending/__tests__/_content.test.tsx
@@ -33,11 +33,9 @@ vi.mock('@/hooks/useTranslation', () => ({
 }));
 
 const pushMock = vi.fn().mockResolvedValue(undefined);
-const searchParamsMock = { get: vi.fn<(key: string) => string | null>() };
 
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: pushMock }),
-  useSearchParams: () => searchParamsMock,
 }));
 
 // Controllable hook state
@@ -70,10 +68,15 @@ import { VerificationPendingContent } from '../_content';
 // Helpers
 // ---------------------------------------------------------------------------
 
+// #2773: ?email= now flows as the `emailParam` prop from the async page.tsx.
+// This helper stores the value; renderContent() forwards it to the component.
+let emailParamValue: string | null = null;
 function setSearchParams(params: Record<string, string | null>) {
-  searchParamsMock.get.mockImplementation((key: string) =>
-    Object.prototype.hasOwnProperty.call(params, key) ? (params[key] ?? null) : null
-  );
+  emailParamValue = params.email ?? null;
+}
+
+function renderContent() {
+  return render(<VerificationPendingContent emailParam={emailParamValue} />);
 }
 
 function setHookState(partial: Partial<typeof hookState>) {
@@ -97,7 +100,7 @@ describe('VerificationPendingContent (v2 AuthCard)', () => {
   describe('Email resolution', () => {
     it('renders with email from ?email query param', () => {
       setSearchParams({ email: 'user@example.com' });
-      render(<VerificationPendingContent />);
+      renderContent();
       // Card title rendered verbatim (t returns key)
       expect(
         screen.getByRole('heading', { name: 'auth.emailVerification.pending.title' })
@@ -108,20 +111,20 @@ describe('VerificationPendingContent (v2 AuthCard)', () => {
 
     it('persists query-param email into sessionStorage', () => {
       setSearchParams({ email: 'user@example.com' });
-      render(<VerificationPendingContent />);
+      renderContent();
       expect(sessionStorage.getItem('pendingVerificationEmail')).toBe('user@example.com');
     });
 
     it('falls back to sessionStorage when no query param', () => {
       sessionStorage.setItem('pendingVerificationEmail', 'stored@example.com');
       setSearchParams({});
-      render(<VerificationPendingContent />);
+      renderContent();
       expect(screen.getByText(/s\*\*\*d@example\.com/)).toBeInTheDocument();
     });
 
     it('renders no-email redirect CTA when neither source has email', () => {
       setSearchParams({});
-      render(<VerificationPendingContent />);
+      renderContent();
       expect(screen.getByText('auth.emailVerification.pending.noEmail')).toBeInTheDocument();
       const cta = screen.getByRole('button', {
         name: 'auth.emailVerification.pending.goToRegister',
@@ -131,7 +134,7 @@ describe('VerificationPendingContent (v2 AuthCard)', () => {
 
     it('no-email CTA navigates to /register on click', () => {
       setSearchParams({});
-      render(<VerificationPendingContent />);
+      renderContent();
       const cta = screen.getByRole('button', {
         name: 'auth.emailVerification.pending.goToRegister',
       });
@@ -147,7 +150,7 @@ describe('VerificationPendingContent (v2 AuthCard)', () => {
 
     it('calls resendVerificationEmail(email) when resend button clicked', () => {
       setSearchParams({ email: 'user@example.com' });
-      render(<VerificationPendingContent />);
+      renderContent();
       const button = getResendButton();
       fireEvent.click(button);
       expect(resendMock).toHaveBeenCalledWith('user@example.com');
@@ -156,14 +159,14 @@ describe('VerificationPendingContent (v2 AuthCard)', () => {
     it('disables resend button when cooldownSeconds > 0', () => {
       setSearchParams({ email: 'user@example.com' });
       setHookState({ cooldownSeconds: 30 });
-      render(<VerificationPendingContent />);
+      renderContent();
       expect(getResendButton()).toBeDisabled();
     });
 
     it('shows cooldown message when cooldownSeconds > 0', () => {
       setSearchParams({ email: 'user@example.com' });
       setHookState({ cooldownSeconds: 30 });
-      render(<VerificationPendingContent />);
+      renderContent();
       expect(
         screen.getByText(/auth\.emailVerification\.pending\.cooldownMessage/)
       ).toBeInTheDocument();
@@ -172,7 +175,7 @@ describe('VerificationPendingContent (v2 AuthCard)', () => {
     it('enables resend button when cooldownSeconds is 0 and not resending', () => {
       setSearchParams({ email: 'user@example.com' });
       setHookState({ cooldownSeconds: 0, isResending: false });
-      render(<VerificationPendingContent />);
+      renderContent();
       expect(getResendButton()).not.toBeDisabled();
     });
   });
@@ -181,7 +184,7 @@ describe('VerificationPendingContent (v2 AuthCard)', () => {
     it('renders error from hook in alert role', () => {
       setSearchParams({ email: 'user@example.com' });
       setHookState({ error: 'Failed to resend email' });
-      render(<VerificationPendingContent />);
+      renderContent();
       const alert = screen.getByRole('alert');
       expect(alert).toHaveTextContent('Failed to resend email');
     });

--- a/apps/web/src/app/(auth)/verification-pending/_content.tsx
+++ b/apps/web/src/app/(auth)/verification-pending/_content.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react';
 
 import { Mail, RefreshCw } from 'lucide-react';
-import { useRouter, useSearchParams } from 'next/navigation';
+import { useRouter } from 'next/navigation';
 
 import { AuthCard } from '@/components/ui/auth-card';
 import { Btn } from '@/components/ui/btn';
@@ -26,13 +26,23 @@ function maskEmail(email: string): string {
   return `${maskedLocal}@${domain}`;
 }
 
-export function VerificationPendingContent() {
+/**
+ * #2773 — `emailParam` arrives as a PROP from the async Server Component
+ * page.tsx (which reads searchParams). Reading it as a prop instead of via the
+ * `useSearchParams` client hook lets this component render server-side (SSR),
+ * dropping the CSR bailout. Same pattern as `login/_content.tsx` (#2650).
+ */
+export interface VerificationPendingContentProps {
+  /** `?email=` address; falls back to sessionStorage when absent. */
+  emailParam?: string | null;
+}
+
+export function VerificationPendingContent({ emailParam = null }: VerificationPendingContentProps) {
   const router = useRouter();
-  const searchParams = useSearchParams();
   const { t } = useTranslation();
 
   // Get email from query params or session storage
-  const emailFromParams = searchParams?.get('email') ?? null;
+  const emailFromParams = emailParam;
   const [email, setEmail] = useState<string | null>(null);
 
   const { isResending, error, cooldownSeconds, resendVerificationEmail, clearError } =

--- a/apps/web/src/app/(auth)/verification-pending/page.tsx
+++ b/apps/web/src/app/(auth)/verification-pending/page.tsx
@@ -16,20 +16,20 @@
  * Task 12 (auth-flow-v2 migration): uses v2 AuthCard primitive via _content.tsx.
  */
 
-import { Suspense } from 'react';
-
 import { VerificationPendingContent } from './_content';
 
-export default function VerificationPendingPage() {
-  return (
-    <Suspense
-      fallback={
-        <div className="flex min-h-dvh items-center justify-center bg-background">
-          <div className="animate-pulse text-muted-foreground text-sm">Loading...</div>
-        </div>
-      }
-    >
-      <VerificationPendingContent />
-    </Suspense>
-  );
+/**
+ * #2773: async Server Component reads searchParams (async in Next 16) and passes
+ * `email` down as a prop, so the client content renders WITHOUT `useSearchParams`
+ * — no CSR bailout. Same props pattern as `login/page.tsx` (#2650 / #2771).
+ */
+export default async function VerificationPendingPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+}) {
+  const params = await searchParams;
+  const email = typeof params.email === 'string' ? params.email : undefined;
+
+  return <VerificationPendingContent emailParam={email} />;
 }

--- a/apps/web/src/app/(auth)/verify-email/__tests__/_content.test.tsx
+++ b/apps/web/src/app/(auth)/verify-email/__tests__/_content.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * Verify-email page (_content.tsx) smoke tests — #2773 props migration.
+ *
+ * Covers the refactored contract: `token`/`emailParam` now flow as PROPS from
+ * the async page.tsx instead of via `useSearchParams`. These are focused smoke
+ * tests for the prop wiring, not full behavioural coverage of the hook.
+ */
+
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mocks (must be registered before component import)
+// ---------------------------------------------------------------------------
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+const pushMock = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: pushMock }),
+}));
+
+const verifyEmailMock = vi.fn();
+const resendMock = vi.fn().mockResolvedValue(undefined);
+const hookState = {
+  isLoading: false,
+  isResending: false,
+  error: null as string | null,
+  errorType: null as string | null,
+  isVerified: false,
+  cooldownSeconds: 0,
+};
+
+vi.mock('@/hooks/useEmailVerification', () => ({
+  useEmailVerification: () => ({
+    isLoading: hookState.isLoading,
+    isResending: hookState.isResending,
+    error: hookState.error,
+    errorType: hookState.errorType,
+    isVerified: hookState.isVerified,
+    cooldownSeconds: hookState.cooldownSeconds,
+    verifyEmail: verifyEmailMock,
+    resendVerificationEmail: resendMock,
+  }),
+}));
+
+// Import AFTER mocks
+import { VerifyEmailContent } from '../_content';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  sessionStorage.clear();
+  hookState.isLoading = false;
+  hookState.isResending = false;
+  hookState.error = null;
+  hookState.errorType = null;
+  hookState.isVerified = false;
+  hookState.cooldownSeconds = 0;
+});
+
+describe('VerifyEmailContent — #2773 props contract', () => {
+  it('renders the no-token branch when the token prop is absent and never verifies', () => {
+    render(<VerifyEmailContent token={null} emailParam={null} />);
+
+    expect(screen.getByTestId('verify-email-page')).toBeInTheDocument();
+    expect(verifyEmailMock).not.toHaveBeenCalled();
+  });
+
+  it('verifies the token supplied via the prop on mount', async () => {
+    render(<VerifyEmailContent token="tok-abc" emailParam="user@example.com" />);
+
+    await waitFor(() => {
+      expect(verifyEmailMock).toHaveBeenCalledWith('tok-abc');
+    });
+    expect(screen.getByTestId('verify-email-page')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/(auth)/verify-email/_content.tsx
+++ b/apps/web/src/app/(auth)/verify-email/_content.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState, useCallback } from 'react';
 
-import { useRouter, useSearchParams } from 'next/navigation';
+import { useRouter } from 'next/navigation';
 
 import { VerificationError } from '@/components/auth/VerificationError';
 import { VerificationSuccess } from '@/components/auth/VerificationSuccess';
@@ -10,13 +10,24 @@ import { AuthCard } from '@/components/ui/auth-card';
 import { useEmailVerification } from '@/hooks/useEmailVerification';
 import { useTranslation } from '@/hooks/useTranslation';
 
-export function VerifyEmailContent() {
+/**
+ * #2773 — `token`/`emailParam` arrive as PROPS from the async Server Component
+ * page.tsx (which reads searchParams). Reading them as props instead of via the
+ * `useSearchParams` client hook lets this component render server-side (SSR),
+ * dropping the CSR bailout. Same pattern as `login/_content.tsx` (#2650).
+ */
+export interface VerifyEmailContentProps {
+  /** `?token=` verification token. */
+  token?: string | null;
+  /** `?email=` address (for resend); falls back to sessionStorage when absent. */
+  emailParam?: string | null;
+}
+
+export function VerifyEmailContent({ token = null, emailParam = null }: VerifyEmailContentProps) {
   const router = useRouter();
-  const searchParams = useSearchParams();
   const { t } = useTranslation();
 
-  const token = searchParams?.get('token') ?? null;
-  const emailFromParams = searchParams?.get('email') ?? null;
+  const emailFromParams = emailParam;
 
   const {
     isLoading,

--- a/apps/web/src/app/(auth)/verify-email/page.tsx
+++ b/apps/web/src/app/(auth)/verify-email/page.tsx
@@ -14,11 +14,7 @@
  * User lands here after clicking the verification link in their email.
  */
 
-import { Suspense } from 'react';
-
 import { Metadata } from 'next';
-
-import { AuthCard } from '@/components/ui/auth-card';
 
 import { VerifyEmailContent } from './_content';
 
@@ -28,20 +24,19 @@ export const metadata: Metadata = {
   robots: { index: false, follow: false },
 };
 
-export default function VerifyEmailPage() {
-  return (
-    <Suspense
-      fallback={
-        <AuthCard title="Verifica email">
-          <div className="text-center py-8">
-            <div className="animate-pulse text-muted-foreground text-sm">
-              Verifica email in corso...
-            </div>
-          </div>
-        </AuthCard>
-      }
-    >
-      <VerifyEmailContent />
-    </Suspense>
-  );
+/**
+ * #2773: async Server Component reads searchParams (async in Next 16) and passes
+ * `token`/`email` down as props, so the client content renders WITHOUT
+ * `useSearchParams` — no CSR bailout. Same props pattern as `login/page.tsx`.
+ */
+export default async function VerifyEmailPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+}) {
+  const params = await searchParams;
+  const token = typeof params.token === 'string' ? params.token : undefined;
+  const email = typeof params.email === 'string' ? params.email : undefined;
+
+  return <VerifyEmailContent token={token} emailParam={email} />;
 }

--- a/apps/web/src/app/(auth)/welcome/__tests__/_content.test.tsx
+++ b/apps/web/src/app/(auth)/welcome/__tests__/_content.test.tsx
@@ -15,11 +15,9 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 // ---------------------------------------------------------------------------
 
 const pushMock = vi.fn().mockResolvedValue(undefined);
-const searchParamsMock = { get: vi.fn<(key: string) => string | null>() };
 
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: pushMock }),
-  useSearchParams: () => searchParamsMock,
 }));
 
 vi.mock('@/lib/logger', () => ({
@@ -34,16 +32,12 @@ import { logger } from '@/lib/logger';
 // Helpers
 // ---------------------------------------------------------------------------
 
-function setSearchParams(params: Record<string, string | null>) {
-  searchParamsMock.get.mockImplementation((key: string) =>
-    Object.prototype.hasOwnProperty.call(params, key) ? (params[key] ?? null) : null
-  );
-}
+// #2773: ?redirectTo= now flows as the `redirectToParam` prop from the async
+// page.tsx, not via a mocked useSearchParams.
 
 beforeEach(() => {
   vi.clearAllMocks();
   vi.useFakeTimers();
-  setSearchParams({});
 });
 
 afterEach(() => {
@@ -71,8 +65,6 @@ async function advancePastRedirect() {
 
 describe('WelcomeContent — auto redirect', () => {
   it('redirects to /library after 2000ms when no ?redirectTo= param', async () => {
-    setSearchParams({});
-
     await act(async () => {
       render(<WelcomeContent />);
     });
@@ -84,8 +76,6 @@ describe('WelcomeContent — auto redirect', () => {
   });
 
   it('redirects immediately when the "Vai alla Dashboard" button is clicked', async () => {
-    setSearchParams({});
-
     await act(async () => {
       render(<WelcomeContent />);
       // Flush the setMounted(true) useEffect so the component renders the button
@@ -106,10 +96,8 @@ describe('WelcomeContent — auto redirect', () => {
 
 describe('WelcomeContent — open redirect protection (#2168)', () => {
   it('falls back to /library when ?redirectTo= is external URL', async () => {
-    setSearchParams({ redirectTo: 'https://evil.com' });
-
     await act(async () => {
-      render(<WelcomeContent />);
+      render(<WelcomeContent redirectToParam="https://evil.com" />);
     });
 
     await advancePastRedirect();
@@ -127,10 +115,8 @@ describe('WelcomeContent — open redirect protection (#2168)', () => {
   });
 
   it('preserves valid relative ?redirectTo= path', async () => {
-    setSearchParams({ redirectTo: '/sessions/abc-123' });
-
     await act(async () => {
-      render(<WelcomeContent />);
+      render(<WelcomeContent redirectToParam="/sessions/abc-123" />);
     });
 
     await advancePastRedirect();
@@ -142,10 +128,8 @@ describe('WelcomeContent — open redirect protection (#2168)', () => {
   });
 
   it('logs unsafe ?redirectTo= attempt on initial render (before redirect)', async () => {
-    setSearchParams({ redirectTo: 'https://evil.com' });
-
     await act(async () => {
-      render(<WelcomeContent />);
+      render(<WelcomeContent redirectToParam="https://evil.com" />);
       // Flush microtasks so the warn useEffect commits, but do NOT advance
       // past the 2000ms redirect timer — push must not have been called yet
     });

--- a/apps/web/src/app/(auth)/welcome/_content.tsx
+++ b/apps/web/src/app/(auth)/welcome/_content.tsx
@@ -4,7 +4,7 @@
 import { useEffect, useState, useCallback } from 'react';
 
 import { PartyPopper, ArrowRight, Sparkles } from 'lucide-react';
-import { useRouter, useSearchParams } from 'next/navigation';
+import { useRouter } from 'next/navigation';
 
 import { Btn } from '@/components/ui/btn';
 import { logger } from '@/lib/logger';
@@ -26,10 +26,20 @@ export function WelcomeFallback() {
   );
 }
 
-export function WelcomeContent() {
+/**
+ * #2773 — `redirectToParam` arrives as a PROP from the async Server Component
+ * page.tsx (which reads searchParams). Reading it as a prop instead of via the
+ * `useSearchParams` client hook lets this component render server-side (SSR),
+ * dropping the CSR bailout. Same pattern as `login/_content.tsx` (#2650).
+ */
+export interface WelcomeContentProps {
+  /** `?redirectTo=` target. Sanitized against open-redirect below (#2168). */
+  redirectToParam?: string;
+}
+
+export function WelcomeContent({ redirectToParam }: WelcomeContentProps) {
   const router = useRouter();
-  const searchParams = useSearchParams();
-  const rawRedirectTo = searchParams?.get('redirectTo');
+  const rawRedirectTo = redirectToParam;
   // Audit (#2168): ?redirectTo= is user-controlled; guard against open-redirect
   // via assertSafeRelativeOrFallback before passing to router.push().
   const redirectTo = assertSafeRelativeOrFallback(rawRedirectTo, '/library');

--- a/apps/web/src/app/(auth)/welcome/page.tsx
+++ b/apps/web/src/app/(auth)/welcome/page.tsx
@@ -12,16 +12,21 @@
  *
  * Displays a welcome message after successful registration,
  * then automatically redirects to dashboard after 2 seconds.
+ *
+ * #2773: async Server Component reads searchParams (async in Next 16) and passes
+ * `redirectTo` down as a prop, so the client WelcomeContent renders WITHOUT
+ * `useSearchParams` — no CSR bailout. Same props pattern as `login/page.tsx`.
  */
 
-import { Suspense } from 'react';
+import { WelcomeContent } from './_content';
 
-import { WelcomeFallback, WelcomeContent } from './_content';
+export default async function WelcomePage({
+  searchParams,
+}: {
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+}) {
+  const params = await searchParams;
+  const redirectTo = typeof params.redirectTo === 'string' ? params.redirectTo : undefined;
 
-export default function WelcomePage() {
-  return (
-    <Suspense fallback={<WelcomeFallback />}>
-      <WelcomeContent />
-    </Suspense>
-  );
+  return <WelcomeContent redirectToParam={redirectTo} />;
 }


### PR DESCRIPTION
## Summary

Follow-up di #2770 (PR #2771). Ora che il `BailoutToCSR` app-wide è stato rimosso, le route `(auth)` che leggevano ancora `useSearchParams()` in `_content.tsx` restavano fuori dall'SSR (`BAILOUT_TO_CLIENT_SIDE_RENDERING`). Questa PR applica alle **6 route rimanenti** lo stesso pattern server-props già shippato per `/login` in #2650/#2771: una `page.tsx` async (Server Component) legge `searchParams` (Promise in Next 16) e passa i valori come **props** al client `_content.tsx`, che così non usa più `useSearchParams`.

## Routes migrate

| Route | Param → prop |
|---|---|
| `/register` | `oauth_disabled` → `oauthDisabled` |
| `/reset-password` | `token` |
| `/welcome` | `redirectTo` → `redirectToParam` |
| `/verify-email` | `token` + `email` → `emailParam` |
| `/setup-account` | `token` |
| `/verification-pending` | `email` → `emailParam` |

Rimossi i `<Suspense>` + fallback ormai inutili (`RegisterFallback`, `ResetPasswordFallback`). `WelcomeFallback` è **mantenuto**: serve il `mounted` gate interno, non il boundary di searchParams.

## Acceptance criteria

- [x] Ogni `_content.tsx` non chiama più `useSearchParams()`; i param arrivano come props da una `page.tsx` async.
- [x] curl dell'HTML SSR (prod standalone, `node .next/standalone/server.js`): **0** `BAILOUT_TO_CLIENT_SIDE_RENDERING` su register/reset-password/welcome/verify-email/verification-pending (~30KB di markup server-rendered ciascuna).
- [x] Suite `_content.test.tsx` esistenti aggiornate (props-based) + 2 nuove smoke suite (verify-email, setup-account). **72/72 verdi.**
- [x] typecheck / lint (0 errori) / prettier clean; `pnpm build` verde.

## Nota (fuori scope)

`/setup-account` non è curl-verificabile da non autenticati perché il proxy (`apps/web/src/proxy.ts`) lo intercetta con una **collisione di prefisso pre-esistente**: `PROTECTED_ROUTES` contiene `/setup` e il match è `pathname.startsWith('/setup')` → cattura anche `/setup-account`, con redirect a `/login`. Non è toccato da questa PR (proxy non nel diff) ed è coerente con la issue che marcava setup-account come "static analysis" e non curl-confirmed. Il build classifica comunque la route come dynamic server-rendered; typecheck + smoke test confermano il wiring delle props. **Vale la pena aprire una issue separata** per la collisione `/setup` ↔ `/setup-account` (potenziale rottura del flusso di attivazione invito).

Refs #2773 #2650 #2771 #2770

🤖 Generated with [Claude Code](https://claude.com/claude-code)
