### PR TITLE
feat(mechanic-card): #527 ME-M1.5 publish approved analysis to mechanic_cards

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/PublishMechanicCardCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/PublishMechanicCardCommand.cs
@@ -1,0 +1,22 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands.MechanicExtractor;
+
+/// <summary>
+/// Publishes an approved (<c>Published</c>-lifecycle) <c>MechanicAnalysis</c> into a user-facing
+/// <c>MechanicCard</c> (ADR-051 / #527). Publishing is explicit and distinct from approving the
+/// analysis lifecycle (AD-2).
+/// </summary>
+/// <param name="AnalysisId">Analysis to publish. Must be Published and not already published.</param>
+/// <param name="Title">Optional admin title (5..200 chars). When null, a default is derived from the game name.</param>
+/// <param name="PreviousCardId">
+/// Optional id of a suppressed card being superseded (republish / AC-5). When set it MUST reference a
+/// suppressed card for this game; the new card gets <c>version = previous.version + 1</c>.
+/// </param>
+/// <param name="PublisherId">Admin user id, sourced from the validated session (never from the body).</param>
+internal record PublishMechanicCardCommand(
+    Guid AnalysisId,
+    string? Title,
+    Guid? PreviousCardId,
+    Guid PublisherId) : ICommand<PublishMechanicCardResponseDto>;

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/PublishMechanicCardCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/PublishMechanicCardCommandHandler.cs
@@ -1,0 +1,187 @@
+using System.Text.Json;
+
+using Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands.MechanicExtractor;
+
+/// <summary>
+/// Handler for <see cref="PublishMechanicCardCommand"/> (#527). Snapshots an approved analysis into a
+/// new <c>MechanicCard</c>, links the analysis (<c>PublishedCardId</c>), and writes an audit-log row —
+/// all in the same transaction (AC-4 atomicity). Conflicts F1–F5/F9 surface as
+/// <see cref="ConflictException"/> (409); a missing analysis is 404.
+/// </summary>
+internal sealed class PublishMechanicCardCommandHandler
+    : ICommandHandler<PublishMechanicCardCommand, PublishMechanicCardResponseDto>
+{
+    private readonly IMechanicAnalysisRepository _analysisRepository;
+    private readonly IMechanicCardRepository _cardRepository;
+    private readonly ISharedGameRepository _sharedGameRepository;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<PublishMechanicCardCommandHandler> _logger;
+
+    public PublishMechanicCardCommandHandler(
+        IMechanicAnalysisRepository analysisRepository,
+        IMechanicCardRepository cardRepository,
+        ISharedGameRepository sharedGameRepository,
+        IUnitOfWork unitOfWork,
+        TimeProvider timeProvider,
+        ILogger<PublishMechanicCardCommandHandler> logger)
+    {
+        _analysisRepository = analysisRepository ?? throw new ArgumentNullException(nameof(analysisRepository));
+        _cardRepository = cardRepository ?? throw new ArgumentNullException(nameof(cardRepository));
+        _sharedGameRepository = sharedGameRepository ?? throw new ArgumentNullException(nameof(sharedGameRepository));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<PublishMechanicCardResponseDto> Handle(
+        PublishMechanicCardCommand request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var analysis = await _analysisRepository
+            .GetByIdWithClaimsIgnoringFiltersAsync(request.AnalysisId, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (analysis is null)
+        {
+            throw new NotFoundException("MechanicAnalysis", request.AnalysisId.ToString());
+        }
+
+        // F1 — analysis must be in Published lifecycle state.
+        if (analysis.Status != MechanicAnalysisStatus.Published)
+        {
+            _logger.LogWarning(
+                "Publish rejected for analysis {AnalysisId}: status is {Status} (ConflictReason={ConflictReason}).",
+                analysis.Id, analysis.Status, "not_published");
+            throw new ConflictException(
+                $"Analysis must be in Published state. Current: {analysis.Status}. Approve it first.");
+        }
+
+        // F2 — analysis already published.
+        if (analysis.PublishedCardId is not null)
+        {
+            _logger.LogWarning(
+                "Publish rejected for analysis {AnalysisId}: already published as {CardId} (ConflictReason={ConflictReason}).",
+                analysis.Id, analysis.PublishedCardId, "already_published");
+            throw new ConflictException(
+                $"Already published as card {analysis.PublishedCardId}. To revise, suppress current and republish.");
+        }
+
+        var game = await _sharedGameRepository.GetByIdAsync(analysis.SharedGameId, cancellationToken).ConfigureAwait(false);
+        if (game is null)
+        {
+            throw new NotFoundException("SharedGame", analysis.SharedGameId.ToString());
+        }
+
+        MechanicCardAuditAction auditAction;
+        string? auditMetadata = null;
+
+        if (request.PreviousCardId is { } previousCardId)
+        {
+            // AC-5 republish: the superseded card must exist, belong to this game, and be suppressed (F9).
+            var previous = await _cardRepository.GetByIdIgnoringFiltersAsync(previousCardId, cancellationToken).ConfigureAwait(false);
+            if (previous is null || previous.SharedGameId != analysis.SharedGameId || !previous.IsSuppressed)
+            {
+                _logger.LogWarning(
+                    "Publish rejected: previous card {PreviousCardId} not found / wrong game / still active (ConflictReason={ConflictReason}).",
+                    previousCardId, "previous_not_suppressed");
+                throw new ConflictException("Previous card not found or still active. Suppress it first before republishing.");
+            }
+
+            auditAction = MechanicCardAuditAction.Revised;
+            auditMetadata = JsonSerializer.Serialize(new { previous_card_id = previousCardId });
+        }
+        else
+        {
+            // F3 — an active (non-suppressed) card already exists for this game.
+            var active = await _cardRepository.GetActiveByGameAsync(analysis.SharedGameId, cancellationToken).ConfigureAwait(false);
+            if (active is not null)
+            {
+                _logger.LogWarning(
+                    "Publish rejected: active card {ExistingCardId} exists for game {SharedGameId} (ConflictReason={ConflictReason}).",
+                    active.Id, analysis.SharedGameId, "race_active");
+                throw new ConflictException(
+                    $"Active card {active.Id} exists for this game. Suppress it before publishing a new version.");
+            }
+
+            auditAction = MechanicCardAuditAction.Published;
+        }
+
+        var version = await _cardRepository.GetMaxVersionForGameAsync(analysis.SharedGameId, cancellationToken).ConfigureAwait(false) + 1;
+        var utcNow = _timeProvider.GetUtcNow().UtcDateTime;
+
+        var gameContext = new MechanicCardGameContext
+        {
+            SharedGameId = analysis.SharedGameId,
+            SharedGameName = game.Title,
+            Publisher = game.Publishers.FirstOrDefault()?.Name,
+            Language = "en"
+        };
+
+        MechanicCard card;
+        try
+        {
+            card = MechanicCard.PublishFromAnalysis(analysis, request.Title, gameContext, request.PublisherId, version, utcNow);
+        }
+        catch (InvalidOperationException ex)
+        {
+            // Defense-in-depth aggregate invariants (should be caught above) → 409.
+            throw new ConflictException(ex.Message, ex);
+        }
+
+        analysis.MarkPublished(card.Id);
+
+        await _cardRepository.AddAsync(card, cancellationToken).ConfigureAwait(false);
+        _cardRepository.AddAuditLog(
+            MechanicCardAuditLog.Create(card.Id, auditAction, request.PublisherId, utcNow, auditMetadata));
+        _analysisRepository.Update(analysis);
+
+        try
+        {
+            await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (DbUpdateConcurrencyException ex)
+        {
+            // F5 — analysis edited concurrently (xmin mismatch).
+            _logger.LogWarning(ex,
+                "Optimistic concurrency publishing card for analysis {AnalysisId} (ConflictReason={ConflictReason}).",
+                analysis.Id, "stale_concurrency");
+            throw new ConflictException("Analysis was modified concurrently, refresh and retry.", ex);
+        }
+        catch (DbUpdateException ex)
+        {
+            // F4 — partial unique index (ux_mechanic_cards_active_per_game) lost the race.
+            _logger.LogWarning(ex,
+                "Unique index violation publishing card for game {SharedGameId} (ConflictReason={ConflictReason}).",
+                analysis.SharedGameId, "race_active");
+            throw new ConflictException("Card was published concurrently from another analysis. Refresh and review.", ex);
+        }
+
+        _logger.LogInformation(
+            "MechanicCard {CardId} published for game {SharedGameId} from analysis {AnalysisId} by admin {PublisherId} (version {Version}).",
+            card.Id, card.SharedGameId, analysis.Id, request.PublisherId, version);
+
+        return new PublishMechanicCardResponseDto(
+            CardId: card.Id,
+            SharedGameId: card.SharedGameId,
+            Version: card.Version,
+            PublishedAt: card.PublishedAt,
+            PublishedBy: card.PublishedBy,
+            Title: card.Title,
+            OriginAnalysisId: card.OriginAnalysisId,
+            PublicCardUrl: $"/games/{card.SharedGameId}/card");
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/PublishMechanicCardCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/PublishMechanicCardCommandValidator.cs
@@ -1,0 +1,29 @@
+using FluentValidation;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands.MechanicExtractor;
+
+/// <summary>
+/// FluentValidation rules for <see cref="PublishMechanicCardCommand"/>. State-machine invariants
+/// (analysis Published, not already published, active-card conflict) are enforced by the handler and
+/// surface as <c>ConflictException</c> (409).
+/// </summary>
+internal sealed class PublishMechanicCardCommandValidator
+    : AbstractValidator<PublishMechanicCardCommand>
+{
+    public PublishMechanicCardCommandValidator()
+    {
+        RuleFor(c => c.AnalysisId)
+            .NotEmpty().WithMessage("AnalysisId is required.");
+
+        RuleFor(c => c.PublisherId)
+            .NotEmpty().WithMessage("PublisherId is required.");
+
+        // Title cap is 200 (not 100) to allow expanded titles (spec AC-4).
+        When(c => c.Title is not null, () =>
+        {
+            RuleFor(c => c.Title)
+                .Must(t => t!.Trim().Length >= 5 && t.Trim().Length <= 200)
+                .WithMessage("Title must be at least 5 characters and at most 200 characters.");
+        });
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/DTOs/PublishMechanicCardResponseDto.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/DTOs/PublishMechanicCardResponseDto.cs
@@ -1,0 +1,22 @@
+namespace Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
+
+/// <summary>
+/// Response for a successful card publication (#527, AC-6). Returned with HTTP 201 Created.
+/// </summary>
+/// <param name="CardId">Id of the newly created card.</param>
+/// <param name="SharedGameId">Game the card belongs to.</param>
+/// <param name="Version">Monotonic version for the game (AD-3).</param>
+/// <param name="PublishedAt">Publish timestamp.</param>
+/// <param name="PublishedBy">Admin who published.</param>
+/// <param name="Title">Resolved card title.</param>
+/// <param name="OriginAnalysisId">Source analysis id.</param>
+/// <param name="PublicCardUrl">Shape of the player-facing URL (#528, may not be live yet).</param>
+internal record PublishMechanicCardResponseDto(
+    Guid CardId,
+    Guid SharedGameId,
+    int Version,
+    DateTime PublishedAt,
+    Guid PublishedBy,
+    string Title,
+    Guid OriginAnalysisId,
+    string PublicCardUrl);

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Aggregates/MechanicAnalysis.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Aggregates/MechanicAnalysis.cs
@@ -72,6 +72,13 @@ public sealed class MechanicAnalysis : AggregateRoot<Guid>
     public DateTime? ReviewedAt { get; private set; }
     public string? RejectionReason { get; private set; }
 
+    /// <summary>
+    /// FK to the <see cref="MechanicCard"/> this analysis was published into (#527). Null until an
+    /// admin explicitly publishes the (already Published-lifecycle) analysis. Enforces the "at most
+    /// one card per analysis" invariant (AD-3) and short-circuits duplicate publish attempts (F2).
+    /// </summary>
+    public Guid? PublishedCardId { get; private set; }
+
     // === LLM execution snapshot ===
 
     public int TotalTokensUsed { get; private set; }
@@ -263,7 +270,8 @@ public sealed class MechanicAnalysis : AggregateRoot<Guid>
         Guid? certifiedByUserId = null,
         string? certificationOverrideReason = null,
         Guid? lastMetricsId = null,
-        uint xminVersion = 0)
+        uint xminVersion = 0,
+        Guid? publishedCardId = null)
     {
         ArgumentNullException.ThrowIfNull(claims);
 
@@ -281,6 +289,7 @@ public sealed class MechanicAnalysis : AggregateRoot<Guid>
             ReviewedBy = reviewedBy,
             ReviewedAt = reviewedAt,
             RejectionReason = rejectionReason,
+            PublishedCardId = publishedCardId,
             TotalTokensUsed = totalTokensUsed,
             EstimatedCostUsd = estimatedCostUsd,
             ModelUsed = modelUsed,
@@ -416,6 +425,12 @@ public sealed class MechanicAnalysis : AggregateRoot<Guid>
     /// <summary>
     /// Approves the analysis and transitions it to Published. Requires every claim to be Approved.
     /// </summary>
+    /// <remarks>
+    /// <see cref="MechanicAnalysisStatus.Published"/> means the analysis <em>lifecycle</em> is frozen
+    /// and eligible for publication into a user-facing <see cref="MechanicCard"/>. It does NOT create
+    /// the card — publishing the card surface is a separate, explicit admin act (AD-2, #527), tracked
+    /// by <see cref="PublishedCardId"/>. Approving multiple analyses does not publish any of them.
+    /// </remarks>
     public void Approve(Guid reviewerId, DateTime utcNow)
     {
         if (reviewerId == Guid.Empty)
@@ -445,6 +460,38 @@ public sealed class MechanicAnalysis : AggregateRoot<Guid>
         ReviewedAt = utcNow;
 
         AddDomainEvent(new MechanicAnalysisStatusChangedEvent(Id, previous, Status, reviewerId, note: null));
+    }
+
+    /// <summary>
+    /// Links this analysis to the <see cref="MechanicCard"/> it was published into (#527). Sets the
+    /// <see cref="PublishedCardId"/> FK, enforcing the "publish once" invariant. Must be called by the
+    /// publish handler in the same transaction that inserts the card.
+    /// </summary>
+    /// <exception cref="InvalidMechanicAnalysisStateException">Thrown if the analysis is not Published.</exception>
+    /// <exception cref="InvalidOperationException">Thrown if the analysis already has a published card (F2).</exception>
+    public void MarkPublished(Guid cardId)
+    {
+        if (cardId == Guid.Empty)
+        {
+            throw new ArgumentException("CardId cannot be empty.", nameof(cardId));
+        }
+
+        if (Status != MechanicAnalysisStatus.Published)
+        {
+            throw new InvalidMechanicAnalysisStateException(
+                Id,
+                Status,
+                "mark published card",
+                MechanicAnalysisStatus.Published);
+        }
+
+        if (PublishedCardId is not null)
+        {
+            throw new InvalidOperationException(
+                $"MechanicAnalysis {Id} is already published as card {PublishedCardId}.");
+        }
+
+        PublishedCardId = cardId;
     }
 
     /// <summary>

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Aggregates/MechanicCard.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Aggregates/MechanicCard.cs
@@ -1,0 +1,270 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Events;
+using Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+using Api.SharedKernel.Domain.Entities;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+
+/// <summary>
+/// Aggregate root for a published mechanics card (ADR-051 #527). A card is an immutable, user-facing
+/// snapshot of an approved <see cref="MechanicAnalysis"/>, surfaced on <c>/games/{slug}/card</c>
+/// (#528, login-gated). Publishing is an explicit admin act, distinct from approving the analysis
+/// lifecycle (AD-2). A revision produces a new card version rather than mutating an existing one
+/// (AD-1 / AD-3); at most one non-suppressed card may exist per game (enforced by a partial unique
+/// index).
+/// </summary>
+public sealed class MechanicCard : AggregateRoot<Guid>
+{
+    // === Identity / lineage ===
+    public Guid SharedGameId { get; private set; }
+    public Guid OriginAnalysisId { get; private set; }
+    public MechanicCardOrigin Origin { get; private set; }
+
+    // === Content ===
+    public string Title { get; private set; } = string.Empty;
+
+    /// <summary>Immutable JSONB snapshot of the approved claims (see <see cref="MechanicCardContent"/>).</summary>
+    public string Content { get; private set; } = string.Empty;
+
+    /// <summary>Monotonic version per <see cref="SharedGameId"/> (AD-3), starts at 1.</summary>
+    public int Version { get; private set; }
+
+    // === Takedown (T5, #529) — orthogonal to lifecycle ===
+    public bool IsSuppressed { get; private set; }
+    public string? SuppressedReason { get; private set; }
+    public DateTime? SuppressedAt { get; private set; }
+    public Guid? SuppressedBy { get; private set; }
+
+    // === Player feedback (preparatory for #531) ===
+    public int ErrorReportsCount { get; private set; }
+    public decimal? FeedbackScore { get; private set; }
+
+    // === Publication audit ===
+    public DateTime PublishedAt { get; private set; }
+    public Guid PublishedBy { get; private set; }
+
+    // === Housekeeping ===
+    public DateTime CreatedAt { get; private set; }
+    public DateTime UpdatedAt { get; private set; }
+
+    /// <summary>Optimistic concurrency token (PostgreSQL <c>xmin</c>, ADR-060).</summary>
+    public uint XminVersion { get; private set; }
+
+    private const int MinTitleLength = 5;
+    private const int MaxTitleLength = 200;
+
+    /// <summary>EF Core / reconstitution constructor.</summary>
+    private MechanicCard() : base()
+    {
+    }
+
+    private MechanicCard(Guid id) : base(id)
+    {
+    }
+
+    /// <summary>
+    /// Promotes an approved <see cref="MechanicAnalysis"/> into a new mechanics card, capturing an
+    /// immutable snapshot of its claims (AD-1). The version is computed by the caller (monotonic per
+    /// game, AD-3) and passed in.
+    /// </summary>
+    /// <param name="analysis">The source analysis, with its claim + citation graph materialized.
+    /// Must be <see cref="MechanicAnalysisStatus.Published"/> and not already published.</param>
+    /// <param name="overrideTitle">Optional admin-supplied title (validated 5..200). When null, a
+    /// default is derived from the game name.</param>
+    /// <param name="gameContext">Cross-aggregate game metadata resolved by the handler.</param>
+    /// <param name="publisherId">The admin performing the publish (sourced from the session).</param>
+    /// <param name="version">Monotonic version for this game (≥1).</param>
+    /// <param name="utcNow">Publish timestamp; also the snapshot timestamp.</param>
+    public static MechanicCard PublishFromAnalysis(
+        MechanicAnalysis analysis,
+        string? overrideTitle,
+        MechanicCardGameContext gameContext,
+        Guid publisherId,
+        int version,
+        DateTime utcNow)
+    {
+        ArgumentNullException.ThrowIfNull(analysis);
+        ArgumentNullException.ThrowIfNull(gameContext);
+
+        if (publisherId == Guid.Empty)
+        {
+            throw new ArgumentException("PublisherId cannot be empty.", nameof(publisherId));
+        }
+
+        if (version < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(version), version, "Version must be >= 1.");
+        }
+
+        // Defense in depth: the handler already guards these, but the factory re-checks so the
+        // aggregate can never be constructed from a non-publishable analysis.
+        if (analysis.Status != MechanicAnalysisStatus.Published)
+        {
+            throw new InvalidOperationException(
+                $"Cannot publish MechanicAnalysis {analysis.Id}: status is {analysis.Status}, expected Published.");
+        }
+
+        if (analysis.PublishedCardId is not null)
+        {
+            throw new InvalidOperationException(
+                $"MechanicAnalysis {analysis.Id} is already published as card {analysis.PublishedCardId}.");
+        }
+
+        if (analysis.Claims.Count == 0)
+        {
+            throw new InvalidOperationException(
+                $"Cannot publish MechanicAnalysis {analysis.Id}: it has no claims.");
+        }
+
+        if (analysis.Claims.Any(c => c.Status != MechanicClaimStatus.Approved))
+        {
+            throw new InvalidOperationException(
+                $"Cannot publish MechanicAnalysis {analysis.Id}: not all claims are Approved.");
+        }
+
+        var title = ResolveTitle(overrideTitle, gameContext.SharedGameName);
+        var content = MechanicCardContent.FromAnalysis(analysis, gameContext, utcNow).ToJson();
+
+        var card = new MechanicCard(Guid.NewGuid())
+        {
+            SharedGameId = analysis.SharedGameId,
+            OriginAnalysisId = analysis.Id,
+            Origin = MechanicCardOrigin.AiReviewed,
+            Title = title,
+            Content = content,
+            Version = version,
+            IsSuppressed = false,
+            ErrorReportsCount = 0,
+            FeedbackScore = null,
+            PublishedAt = utcNow,
+            PublishedBy = publisherId,
+            CreatedAt = utcNow,
+            UpdatedAt = utcNow
+        };
+
+        card.AddDomainEvent(new MechanicCardPublishedEvent(
+            card.Id,
+            card.SharedGameId,
+            card.OriginAnalysisId,
+            publisherId,
+            version));
+
+        return card;
+    }
+
+    /// <summary>
+    /// Applies a takedown (suppress) on the card (T5 / #529). Idempotency: throws if already
+    /// suppressed so the caller can surface a 409 rather than silently no-op.
+    /// </summary>
+    public void Suppress(Guid actorId, string reason, DateTime utcNow)
+    {
+        if (actorId == Guid.Empty)
+        {
+            throw new ArgumentException("ActorId cannot be empty.", nameof(actorId));
+        }
+
+        if (string.IsNullOrWhiteSpace(reason) || reason.Trim().Length is < 20 or > 500)
+        {
+            throw new ArgumentException("Suppression reason must be 20..500 characters (legal evidence chain).", nameof(reason));
+        }
+
+        if (IsSuppressed)
+        {
+            throw new InvalidOperationException($"MechanicCard {Id} is already suppressed.");
+        }
+
+        IsSuppressed = true;
+        SuppressedReason = reason.Trim();
+        SuppressedAt = utcNow;
+        SuppressedBy = actorId;
+        UpdatedAt = utcNow;
+
+        AddDomainEvent(new MechanicCardSuppressedEvent(Id, SharedGameId, actorId, SuppressedReason));
+    }
+
+    /// <summary>Lifts a takedown, clearing suppression tracking. Throws if not suppressed.</summary>
+    public void Unsuppress(Guid actorId, DateTime utcNow)
+    {
+        if (actorId == Guid.Empty)
+        {
+            throw new ArgumentException("ActorId cannot be empty.", nameof(actorId));
+        }
+
+        if (!IsSuppressed)
+        {
+            throw new InvalidOperationException($"MechanicCard {Id} is not suppressed.");
+        }
+
+        IsSuppressed = false;
+        SuppressedReason = null;
+        SuppressedAt = null;
+        SuppressedBy = null;
+        UpdatedAt = utcNow;
+    }
+
+    /// <summary>Increments the player error-report counter (preparatory for #531 feedback).</summary>
+    public void MarkErrorReport(DateTime utcNow)
+    {
+        ErrorReportsCount += 1;
+        UpdatedAt = utcNow;
+    }
+
+    private static string ResolveTitle(string? overrideTitle, string sharedGameName)
+    {
+        if (!string.IsNullOrWhiteSpace(overrideTitle))
+        {
+            var trimmed = overrideTitle.Trim();
+            if (trimmed.Length is < MinTitleLength or > MaxTitleLength)
+            {
+                throw new ArgumentException(
+                    $"Title must be {MinTitleLength}..{MaxTitleLength} characters.", nameof(overrideTitle));
+            }
+
+            return trimmed;
+        }
+
+        var name = string.IsNullOrWhiteSpace(sharedGameName) ? "Untitled Game" : sharedGameName.Trim();
+        return $"{name} — Mechanics Card";
+    }
+
+    /// <summary>Rehydrates a card from persistence (no validation, no events).</summary>
+    public static MechanicCard Reconstitute(
+        Guid id,
+        Guid sharedGameId,
+        Guid originAnalysisId,
+        MechanicCardOrigin origin,
+        string title,
+        string content,
+        int version,
+        bool isSuppressed,
+        string? suppressedReason,
+        DateTime? suppressedAt,
+        Guid? suppressedBy,
+        int errorReportsCount,
+        decimal? feedbackScore,
+        DateTime publishedAt,
+        Guid publishedBy,
+        DateTime createdAt,
+        DateTime updatedAt,
+        uint xminVersion = 0) =>
+        new(id)
+        {
+            SharedGameId = sharedGameId,
+            OriginAnalysisId = originAnalysisId,
+            Origin = origin,
+            Title = title,
+            Content = content,
+            Version = version,
+            IsSuppressed = isSuppressed,
+            SuppressedReason = suppressedReason,
+            SuppressedAt = suppressedAt,
+            SuppressedBy = suppressedBy,
+            ErrorReportsCount = errorReportsCount,
+            FeedbackScore = feedbackScore,
+            PublishedAt = publishedAt,
+            PublishedBy = publishedBy,
+            CreatedAt = createdAt,
+            UpdatedAt = updatedAt,
+            XminVersion = xminVersion
+        };
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Entities/MechanicCardAuditLog.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Entities/MechanicCardAuditLog.cs
@@ -1,0 +1,72 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using Api.SharedKernel.Domain.Entities;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+
+/// <summary>
+/// Immutable audit-log entry for a <see cref="Aggregates.MechanicCard"/> lifecycle action
+/// (ADR-051 audit trail). Written by the command handler in the same transaction as the card
+/// mutation so there are never orphaned rows.
+/// </summary>
+public sealed class MechanicCardAuditLog : Entity<Guid>
+{
+    public Guid CardId { get; private set; }
+    public MechanicCardAuditAction Action { get; private set; }
+    public Guid ActorId { get; private set; }
+    public DateTime OccurredAt { get; private set; }
+
+    /// <summary>Optional JSONB metadata, e.g. <c>{ "reason": "...", "previous_card_id": "..." }</c>.</summary>
+    public string? Metadata { get; private set; }
+
+    /// <summary>EF Core / reconstitution constructor.</summary>
+    private MechanicCardAuditLog() : base()
+    {
+    }
+
+    private MechanicCardAuditLog(
+        Guid id,
+        Guid cardId,
+        MechanicCardAuditAction action,
+        Guid actorId,
+        DateTime occurredAt,
+        string? metadata)
+        : base(id)
+    {
+        CardId = cardId;
+        Action = action;
+        ActorId = actorId;
+        OccurredAt = occurredAt;
+        Metadata = metadata;
+    }
+
+    /// <summary>Creates a new audit-log entry.</summary>
+    public static MechanicCardAuditLog Create(
+        Guid cardId,
+        MechanicCardAuditAction action,
+        Guid actorId,
+        DateTime occurredAt,
+        string? metadata = null)
+    {
+        if (cardId == Guid.Empty)
+        {
+            throw new ArgumentException("CardId cannot be empty.", nameof(cardId));
+        }
+
+        if (actorId == Guid.Empty)
+        {
+            throw new ArgumentException("ActorId cannot be empty.", nameof(actorId));
+        }
+
+        return new MechanicCardAuditLog(Guid.NewGuid(), cardId, action, actorId, occurredAt, metadata);
+    }
+
+    /// <summary>Rehydrates from persistence (no validation).</summary>
+    public static MechanicCardAuditLog Reconstitute(
+        Guid id,
+        Guid cardId,
+        MechanicCardAuditAction action,
+        Guid actorId,
+        DateTime occurredAt,
+        string? metadata) =>
+        new(id, cardId, action, actorId, occurredAt, metadata);
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Enums/MechanicCardAuditAction.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Enums/MechanicCardAuditAction.cs
@@ -1,0 +1,20 @@
+namespace Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+
+/// <summary>
+/// Audit action recorded in <c>mechanic_card_audit_log</c> for a <see cref="Aggregates.MechanicCard"/>
+/// lifecycle event (ADR-051 audit trail). Persisted as a lowercase string (DB CHECK constraint).
+/// </summary>
+public enum MechanicCardAuditAction
+{
+    /// <summary>Card first published from an approved analysis (#527).</summary>
+    Published = 0,
+
+    /// <summary>Card taken down (is_suppressed=true) — #529.</summary>
+    Suppressed = 1,
+
+    /// <summary>Card takedown lifted (is_suppressed=false) — #529.</summary>
+    Unsuppressed = 2,
+
+    /// <summary>A superseding card (version+1) was published to replace a suppressed predecessor.</summary>
+    Revised = 3
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Enums/MechanicCardOrigin.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Enums/MechanicCardOrigin.cs
@@ -1,0 +1,18 @@
+namespace Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+
+/// <summary>
+/// Provenance of a <see cref="Aggregates.MechanicCard"/> (ADR-051). Persisted as a lowercase
+/// snake_case string in the <c>mechanic_cards.origin</c> column (DB CHECK constraint enforces the
+/// same set).
+/// </summary>
+public enum MechanicCardOrigin
+{
+    /// <summary>Promoted from an AI-generated analysis that passed admin review (#526 → #527).</summary>
+    AiReviewed = 0,
+
+    /// <summary>Authored manually by an admin (no AI pipeline). Reserved for future manual entry.</summary>
+    Manual = 1,
+
+    /// <summary>Imported from an external certified source. Reserved for future B2B ingestion.</summary>
+    ImportedExternal = 2
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Events/MechanicCardPublishedEvent.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Events/MechanicCardPublishedEvent.cs
@@ -1,0 +1,36 @@
+using Api.SharedKernel.Domain.Events;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Domain.Events;
+
+/// <summary>
+/// Raised when a <see cref="Aggregates.MechanicCard"/> is published from an approved analysis (#527).
+/// Downstream consumers (e.g. RAG cache invalidation for the game, #528 player view cache) can
+/// subscribe. The publish audit-log row is written by the command handler in the same transaction,
+/// so this event is purely for cross-context reactions.
+/// </summary>
+internal sealed class MechanicCardPublishedEvent : DomainEventBase
+{
+    public Guid CardId { get; }
+
+    public Guid SharedGameId { get; }
+
+    public Guid OriginAnalysisId { get; }
+
+    public Guid PublisherId { get; }
+
+    public int Version { get; }
+
+    public MechanicCardPublishedEvent(
+        Guid cardId,
+        Guid sharedGameId,
+        Guid originAnalysisId,
+        Guid publisherId,
+        int version)
+    {
+        CardId = cardId;
+        SharedGameId = sharedGameId;
+        OriginAnalysisId = originAnalysisId;
+        PublisherId = publisherId;
+        Version = version;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Events/MechanicCardSuppressedEvent.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Events/MechanicCardSuppressedEvent.cs
@@ -1,0 +1,26 @@
+using Api.SharedKernel.Domain.Events;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Domain.Events;
+
+/// <summary>
+/// Raised when a <see cref="Aggregates.MechanicCard"/> is suppressed (takedown, #529). Consumed by
+/// downstream cache-invalidation handlers so the player-facing card view (#528) drops the card.
+/// </summary>
+internal sealed class MechanicCardSuppressedEvent : DomainEventBase
+{
+    public Guid CardId { get; }
+
+    public Guid SharedGameId { get; }
+
+    public Guid ActorId { get; }
+
+    public string Reason { get; }
+
+    public MechanicCardSuppressedEvent(Guid cardId, Guid sharedGameId, Guid actorId, string reason)
+    {
+        CardId = cardId;
+        SharedGameId = sharedGameId;
+        ActorId = actorId;
+        Reason = reason;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Repositories/IMechanicCardRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Repositories/IMechanicCardRepository.cs
@@ -1,0 +1,36 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+
+/// <summary>
+/// Repository for the <see cref="MechanicCard"/> aggregate (#527). All mutations are staged into the
+/// shared <c>DbContext</c> and committed by <c>IUnitOfWork.SaveChangesAsync</c> so the card, its audit
+/// row, and the analysis FK update commit atomically.
+/// </summary>
+public interface IMechanicCardRepository
+{
+    /// <summary>Stages a new card for insertion and collects its domain events for post-save dispatch.</summary>
+    Task AddAsync(MechanicCard card, CancellationToken cancellationToken = default);
+
+    /// <summary>Stages an append-only audit-log row (same transaction as the card mutation).</summary>
+    void AddAuditLog(MechanicCardAuditLog entry);
+
+    /// <summary>
+    /// Highest existing <c>version</c> for the game across ALL cards (suppressed or not) — the basis
+    /// for the monotonic-per-game version (AD-3). Returns 0 when the game has no cards yet.
+    /// </summary>
+    Task<int> GetMaxVersionForGameAsync(Guid sharedGameId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// The active (non-suppressed) card for the game, if any — used by the publish race pre-check (F3).
+    /// Honors the suppression query filter, so a suppressed card returns null.
+    /// </summary>
+    Task<MechanicCard?> GetActiveByGameAsync(Guid sharedGameId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Loads a card by id ignoring the suppression filter — used to validate <c>previousCardId</c> on
+    /// republish (AC-5), which must reference a suppressed card.
+    /// </summary>
+    Task<MechanicCard?> GetByIdIgnoringFiltersAsync(Guid cardId, CancellationToken cancellationToken = default);
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/ValueObjects/MechanicCardContent.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/ValueObjects/MechanicCardContent.cs
@@ -1,0 +1,182 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+
+/// <summary>
+/// Immutable snapshot of an approved <see cref="MechanicAnalysis"/> captured at publish time and
+/// stored verbatim in the <c>mechanic_cards.content</c> JSONB column (ADR-051 AD-1). The card never
+/// dereferences the live claim graph at render time — a revision produces a new card version instead.
+/// </summary>
+/// <remarks>
+/// <see cref="SchemaVersion"/> guards forward evolution of the JSONB shape. Serialized with
+/// snake_case keys via <c>[JsonPropertyName]</c> so the on-disk JSON matches the ADR-051 contract.
+/// </remarks>
+public sealed record MechanicCardContent
+{
+    /// <summary>Current on-disk JSONB schema version.</summary>
+    public const int CurrentSchemaVersion = 1;
+
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        // Keys are already snake_case via [JsonPropertyName]; keep output compact.
+        WriteIndented = false,
+        DefaultIgnoreCondition = JsonIgnoreCondition.Never
+    };
+
+    [JsonPropertyName("schema_version")]
+    public int SchemaVersion { get; init; } = CurrentSchemaVersion;
+
+    [JsonPropertyName("snapshot_at")]
+    public DateTime SnapshotAt { get; init; }
+
+    [JsonPropertyName("source_analysis_id")]
+    public Guid SourceAnalysisId { get; init; }
+
+    [JsonPropertyName("source_prompt_version")]
+    public string SourcePromptVersion { get; init; } = string.Empty;
+
+    [JsonPropertyName("claims")]
+    public IReadOnlyList<MechanicCardClaimSnapshot> Claims { get; init; } = Array.Empty<MechanicCardClaimSnapshot>();
+
+    [JsonPropertyName("metadata")]
+    public MechanicCardMetadata Metadata { get; init; } = new();
+
+    /// <summary>
+    /// Builds an immutable snapshot from an approved analysis and its game context. The analysis
+    /// MUST already carry the fully materialized claim + citation graph.
+    /// </summary>
+    public static MechanicCardContent FromAnalysis(
+        MechanicAnalysis analysis,
+        MechanicCardGameContext gameContext,
+        DateTime snapshotAt)
+    {
+        ArgumentNullException.ThrowIfNull(analysis);
+        ArgumentNullException.ThrowIfNull(gameContext);
+
+        var claims = analysis.Claims
+            .OrderBy(c => c.Section)
+            .ThenBy(c => c.DisplayOrder)
+            .Select(c => new MechanicCardClaimSnapshot
+            {
+                Id = c.Id,
+                Section = c.Section.ToString(),
+                Ordinal = c.DisplayOrder,
+                Claim = c.Text,
+                Citations = c.Citations
+                    .OrderBy(cit => cit.DisplayOrder)
+                    .Select(cit => new MechanicCardCitationSnapshot
+                    {
+                        // A MechanicAnalysis is scoped to a single source PDF, so every citation
+                        // shares the analysis PdfDocumentId (the citation entity carries only the page).
+                        PdfId = analysis.PdfDocumentId,
+                        PdfPage = cit.PdfPage,
+                        Quote = cit.Quote
+                    })
+                    .ToList(),
+                // Validation (T1-T4) outcomes are not yet persisted on the claim graph (wired by
+                // #526). Emitted as an empty array now; the schema_version guards future population.
+                Validations = Array.Empty<MechanicCardValidationSnapshot>()
+            })
+            .ToList();
+
+        return new MechanicCardContent
+        {
+            SchemaVersion = CurrentSchemaVersion,
+            SnapshotAt = snapshotAt,
+            SourceAnalysisId = analysis.Id,
+            SourcePromptVersion = analysis.PromptVersion,
+            Claims = claims,
+            Metadata = new MechanicCardMetadata
+            {
+                SharedGameId = gameContext.SharedGameId,
+                SharedGameName = gameContext.SharedGameName,
+                Publisher = gameContext.Publisher,
+                Language = gameContext.Language
+            }
+        };
+    }
+
+    /// <summary>Serializes the snapshot to the JSONB string persisted in <c>mechanic_cards.content</c>.</summary>
+    public string ToJson() => JsonSerializer.Serialize(this, SerializerOptions);
+}
+
+/// <summary>Per-claim snapshot inside <see cref="MechanicCardContent.Claims"/>.</summary>
+public sealed record MechanicCardClaimSnapshot
+{
+    [JsonPropertyName("id")]
+    public Guid Id { get; init; }
+
+    [JsonPropertyName("section")]
+    public string Section { get; init; } = string.Empty;
+
+    [JsonPropertyName("ordinal")]
+    public int Ordinal { get; init; }
+
+    [JsonPropertyName("claim")]
+    public string Claim { get; init; } = string.Empty;
+
+    [JsonPropertyName("citations")]
+    public IReadOnlyList<MechanicCardCitationSnapshot> Citations { get; init; } = Array.Empty<MechanicCardCitationSnapshot>();
+
+    [JsonPropertyName("validations")]
+    public IReadOnlyList<MechanicCardValidationSnapshot> Validations { get; init; } = Array.Empty<MechanicCardValidationSnapshot>();
+}
+
+/// <summary>Per-citation snapshot (source page + verbatim quote).</summary>
+public sealed record MechanicCardCitationSnapshot
+{
+    [JsonPropertyName("pdf_id")]
+    public Guid PdfId { get; init; }
+
+    [JsonPropertyName("pdf_page")]
+    public int PdfPage { get; init; }
+
+    [JsonPropertyName("quote")]
+    public string Quote { get; init; } = string.Empty;
+}
+
+/// <summary>T1-T4 guardrail outcome snapshot (reserved; populated when #526 wires validations).</summary>
+public sealed record MechanicCardValidationSnapshot
+{
+    [JsonPropertyName("rule")]
+    public string Rule { get; init; } = string.Empty;
+
+    [JsonPropertyName("passed")]
+    public bool Passed { get; init; }
+
+    [JsonPropertyName("score")]
+    public double? Score { get; init; }
+}
+
+/// <summary>Game-context metadata block of the snapshot.</summary>
+public sealed record MechanicCardMetadata
+{
+    [JsonPropertyName("shared_game_id")]
+    public Guid SharedGameId { get; init; }
+
+    [JsonPropertyName("shared_game_name")]
+    public string SharedGameName { get; init; } = string.Empty;
+
+    [JsonPropertyName("publisher")]
+    public string? Publisher { get; init; }
+
+    [JsonPropertyName("language")]
+    public string Language { get; init; } = "en";
+}
+
+/// <summary>
+/// Cross-aggregate game context resolved by the command handler (from SharedGame + translations)
+/// and passed to <see cref="MechanicCardContent.FromAnalysis"/> and
+/// <see cref="MechanicCard.PublishFromAnalysis"/>, since it is not available on the analysis itself.
+/// </summary>
+public sealed record MechanicCardGameContext
+{
+    public required Guid SharedGameId { get; init; }
+    public required string SharedGameName { get; init; }
+    public string? Publisher { get; init; }
+    public string Language { get; init; } = "en";
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs
@@ -53,6 +53,7 @@ internal static class SharedGameCatalogServiceExtensions
         services.AddScoped<IRulebookAnalysisRepository, RulebookAnalysisRepository>(); // Issue #2402 Sprint 3
         services.AddScoped<IMechanicDraftRepository, MechanicDraftRepository>(); // Mechanic Extractor: Variant C drafts
         services.AddScoped<IMechanicAnalysisRepository, MechanicAnalysisRepository>(); // Issue #523: M1.1 Mechanic Analysis persistence
+        services.AddScoped<IMechanicCardRepository, MechanicCardRepository>(); // #527: M1.5 Mechanic Card persistence
         services.AddScoped<IMechanicGoldenClaimRepository, MechanicGoldenClaimRepository>(); // ADR-051 Sprint 1 / Task 15: golden claims
         services.AddScoped<IMechanicGoldenBggTagRepository, MechanicGoldenBggTagRepository>(); // ADR-051 Sprint 1 / Task 15: BGG mechanic tags
         services.AddScoped<IMechanicAnalysisMetricsRepository, MechanicAnalysisMetricsRepository>(); // ADR-051 Sprint 1 / Task 15: metrics snapshots

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/MechanicAnalysisRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/MechanicAnalysisRepository.cs
@@ -318,7 +318,8 @@ internal sealed class MechanicAnalysisRepository : RepositoryBase, IMechanicAnal
             certifiedByUserId: entity.CertifiedByUserId,
             certificationOverrideReason: entity.CertificationOverrideReason,
             lastMetricsId: entity.LastMetricsId,
-            xminVersion: entity.Xmin);
+            xminVersion: entity.Xmin,
+            publishedCardId: entity.PublishedCardId);
     }
 
     private static MechanicClaim MapClaimToDomain(MechanicClaimEntity entity)
@@ -363,6 +364,7 @@ internal sealed class MechanicAnalysisRepository : RepositoryBase, IMechanicAnal
             ReviewedBy = analysis.ReviewedBy,
             ReviewedAt = analysis.ReviewedAt,
             RejectionReason = analysis.RejectionReason,
+            PublishedCardId = analysis.PublishedCardId,
             TotalTokensUsed = analysis.TotalTokensUsed,
             EstimatedCostUsd = analysis.EstimatedCostUsd,
             ModelUsed = analysis.ModelUsed,

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/MechanicCardRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/MechanicCardRepository.cs
@@ -1,0 +1,155 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.SharedKernel.Application.Services;
+using Api.SharedKernel.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Infrastructure.Repositories;
+
+/// <summary>
+/// Repository implementation for the <see cref="MechanicCard"/> aggregate (ADR-051 / #527).
+/// </summary>
+internal sealed class MechanicCardRepository : RepositoryBase, IMechanicCardRepository
+{
+    public MechanicCardRepository(MeepleAiDbContext dbContext, IDomainEventCollector eventCollector)
+        : base(dbContext, eventCollector)
+    {
+    }
+
+    public async Task AddAsync(MechanicCard card, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(card);
+
+        var entity = MapToEntity(card);
+        await DbContext.MechanicCards.AddAsync(entity, cancellationToken).ConfigureAwait(false);
+
+        CollectDomainEvents(card);
+    }
+
+    public void AddAuditLog(MechanicCardAuditLog entry)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+        DbContext.MechanicCardAuditLog.Add(MapAuditToEntity(entry));
+    }
+
+    public async Task<int> GetMaxVersionForGameAsync(Guid sharedGameId, CancellationToken cancellationToken = default)
+    {
+        // Version is monotonic across ALL cards for the game (suppressed or not), so ignore the filter.
+        var max = await DbContext.MechanicCards
+            .IgnoreQueryFilters()
+            .Where(c => c.SharedGameId == sharedGameId)
+            .Select(c => (int?)c.Version)
+            .MaxAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return max ?? 0;
+    }
+
+    public async Task<MechanicCard?> GetActiveByGameAsync(Guid sharedGameId, CancellationToken cancellationToken = default)
+    {
+        // Suppression query filter applies → only the active (non-suppressed) card is returned.
+        var entity = await DbContext.MechanicCards
+            .AsNoTracking()
+            .FirstOrDefaultAsync(c => c.SharedGameId == sharedGameId, cancellationToken)
+            .ConfigureAwait(false);
+
+        return entity is null ? null : MapToDomain(entity);
+    }
+
+    public async Task<MechanicCard?> GetByIdIgnoringFiltersAsync(Guid cardId, CancellationToken cancellationToken = default)
+    {
+        var entity = await DbContext.MechanicCards
+            .AsNoTracking()
+            .IgnoreQueryFilters()
+            .FirstOrDefaultAsync(c => c.Id == cardId, cancellationToken)
+            .ConfigureAwait(false);
+
+        return entity is null ? null : MapToDomain(entity);
+    }
+
+    // === Mapping ===
+
+    private static MechanicCardEntity MapToEntity(MechanicCard card) =>
+        new()
+        {
+            Id = card.Id,
+            SharedGameId = card.SharedGameId,
+            OriginAnalysisId = card.OriginAnalysisId,
+            Origin = OriginToDb(card.Origin),
+            Title = card.Title,
+            Content = card.Content,
+            Version = card.Version,
+            IsSuppressed = card.IsSuppressed,
+            SuppressedReason = card.SuppressedReason,
+            SuppressedAt = card.SuppressedAt,
+            SuppressedBy = card.SuppressedBy,
+            ErrorReportsCount = card.ErrorReportsCount,
+            FeedbackScore = card.FeedbackScore,
+            PublishedAt = card.PublishedAt,
+            PublishedBy = card.PublishedBy,
+            CreatedAt = card.CreatedAt,
+            UpdatedAt = card.UpdatedAt,
+            Xmin = card.XminVersion
+        };
+
+    private static MechanicCard MapToDomain(MechanicCardEntity entity) =>
+        MechanicCard.Reconstitute(
+            id: entity.Id,
+            sharedGameId: entity.SharedGameId,
+            originAnalysisId: entity.OriginAnalysisId,
+            origin: OriginFromDb(entity.Origin),
+            title: entity.Title,
+            content: entity.Content,
+            version: entity.Version,
+            isSuppressed: entity.IsSuppressed,
+            suppressedReason: entity.SuppressedReason,
+            suppressedAt: entity.SuppressedAt,
+            suppressedBy: entity.SuppressedBy,
+            errorReportsCount: entity.ErrorReportsCount,
+            feedbackScore: entity.FeedbackScore,
+            publishedAt: entity.PublishedAt,
+            publishedBy: entity.PublishedBy,
+            createdAt: entity.CreatedAt,
+            updatedAt: entity.UpdatedAt,
+            xminVersion: entity.Xmin);
+
+    private static MechanicCardAuditLogEntity MapAuditToEntity(MechanicCardAuditLog entry) =>
+        new()
+        {
+            Id = entry.Id,
+            CardId = entry.CardId,
+            Action = ActionToDb(entry.Action),
+            ActorId = entry.ActorId,
+            OccurredAt = entry.OccurredAt,
+            Metadata = entry.Metadata
+        };
+
+    private static string OriginToDb(MechanicCardOrigin origin) => origin switch
+    {
+        MechanicCardOrigin.AiReviewed => "ai_reviewed",
+        MechanicCardOrigin.Manual => "manual",
+        MechanicCardOrigin.ImportedExternal => "imported_external",
+        _ => throw new ArgumentOutOfRangeException(nameof(origin), origin, "Unknown MechanicCardOrigin.")
+    };
+
+    private static MechanicCardOrigin OriginFromDb(string origin) => origin switch
+    {
+        "ai_reviewed" => MechanicCardOrigin.AiReviewed,
+        "manual" => MechanicCardOrigin.Manual,
+        "imported_external" => MechanicCardOrigin.ImportedExternal,
+        _ => throw new ArgumentOutOfRangeException(nameof(origin), origin, "Unknown mechanic_cards.origin value.")
+    };
+
+    private static string ActionToDb(MechanicCardAuditAction action) => action switch
+    {
+        MechanicCardAuditAction.Published => "published",
+        MechanicCardAuditAction.Suppressed => "suppressed",
+        MechanicCardAuditAction.Unsuppressed => "unsuppressed",
+        MechanicCardAuditAction.Revised => "revised",
+        _ => throw new ArgumentOutOfRangeException(nameof(action), action, "Unknown MechanicCardAuditAction.")
+    };
+}

--- a/apps/api/src/Api/Infrastructure/Configurations/SharedGameCatalog/MechanicAnalysisEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/Configurations/SharedGameCatalog/MechanicAnalysisEntityConfiguration.cs
@@ -64,6 +64,11 @@ internal sealed class MechanicAnalysisEntityConfiguration : IEntityTypeConfigura
             .HasColumnName("rejection_reason")
             .HasMaxLength(2000);
 
+        // #527: soft reference to the published card (no DB FK — avoids the analysis↔card FK cycle
+        // and its insert-ordering hazard; integrity is guaranteed by the publish handler setting
+        // this to the just-created card id inside the same transaction).
+        builder.Property(a => a.PublishedCardId).HasColumnName("published_card_id");
+
         builder.Property(a => a.TotalTokensUsed).HasColumnName("total_tokens_used").HasDefaultValue(0).IsRequired();
 
         builder.Property(a => a.EstimatedCostUsd)

--- a/apps/api/src/Api/Infrastructure/Configurations/SharedGameCatalog/MechanicCardAuditLogEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/Configurations/SharedGameCatalog/MechanicCardAuditLogEntityConfiguration.cs
@@ -1,0 +1,34 @@
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Api.Infrastructure.Configurations.SharedGameCatalog;
+
+/// <summary>
+/// EF configuration for <see cref="MechanicCardAuditLogEntity"/> (ADR-051 audit trail, #527).
+/// Append-only; FK to the card configured on the <see cref="MechanicCardEntityConfiguration"/> side
+/// (ON DELETE CASCADE).
+/// </summary>
+internal sealed class MechanicCardAuditLogEntityConfiguration : IEntityTypeConfiguration<MechanicCardAuditLogEntity>
+{
+    public void Configure(EntityTypeBuilder<MechanicCardAuditLogEntity> builder)
+    {
+        builder.ToTable("mechanic_card_audit_log", t =>
+        {
+            t.HasCheckConstraint(
+                "ck_mechanic_card_audit_log_action",
+                "action IN ('published', 'suppressed', 'unsuppressed', 'revised')");
+        });
+
+        builder.HasKey(a => a.Id);
+
+        builder.Property(a => a.Id).HasColumnName("id").IsRequired();
+        builder.Property(a => a.CardId).HasColumnName("card_id").IsRequired();
+        builder.Property(a => a.Action).HasColumnName("action").HasMaxLength(32).IsRequired();
+        builder.Property(a => a.ActorId).HasColumnName("actor_id").IsRequired();
+        builder.Property(a => a.OccurredAt).HasColumnName("occurred_at").IsRequired();
+        builder.Property(a => a.Metadata).HasColumnName("metadata").HasColumnType("jsonb");
+
+        builder.HasIndex(a => a.CardId).HasDatabaseName("ix_mechanic_card_audit_log_card_id");
+    }
+}

--- a/apps/api/src/Api/Infrastructure/Configurations/SharedGameCatalog/MechanicCardEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/Configurations/SharedGameCatalog/MechanicCardEntityConfiguration.cs
@@ -1,0 +1,104 @@
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Api.Infrastructure.Configurations.SharedGameCatalog;
+
+/// <summary>
+/// EF configuration for <see cref="MechanicCardEntity"/> (ADR-051 / #527).
+/// </summary>
+/// <remarks>
+/// Enforces at DB level:
+/// - Partial unique index: at most one non-suppressed card per SharedGame (T5 / AC-1).
+/// - CHECK origin IN ('ai_reviewed','manual','imported_external'), version >= 1.
+/// - CHECK suppression completeness (suppressed rows carry actor + reason + timestamp).
+/// - Global query filter hides suppressed cards from player-facing queries.
+/// </remarks>
+internal sealed class MechanicCardEntityConfiguration : IEntityTypeConfiguration<MechanicCardEntity>
+{
+    public void Configure(EntityTypeBuilder<MechanicCardEntity> builder)
+    {
+        builder.ToTable("mechanic_cards", t =>
+        {
+            t.HasCheckConstraint(
+                "ck_mechanic_cards_origin",
+                "origin IN ('ai_reviewed', 'manual', 'imported_external')");
+
+            t.HasCheckConstraint(
+                "ck_mechanic_cards_version_positive",
+                "version >= 1");
+
+            t.HasCheckConstraint(
+                "ck_mechanic_cards_suppression_completeness",
+                "(is_suppressed = false AND suppressed_at IS NULL AND suppressed_by IS NULL AND suppressed_reason IS NULL) "
+                + "OR (is_suppressed = true AND suppressed_at IS NOT NULL AND suppressed_by IS NOT NULL AND suppressed_reason IS NOT NULL)");
+
+            t.HasCheckConstraint(
+                "ck_mechanic_cards_error_reports_non_negative",
+                "error_reports_count >= 0");
+        });
+
+        builder.HasKey(c => c.Id);
+
+        builder.Property(c => c.Id).HasColumnName("id").IsRequired();
+        builder.Property(c => c.SharedGameId).HasColumnName("shared_game_id").IsRequired();
+        builder.Property(c => c.OriginAnalysisId).HasColumnName("origin_analysis_id").IsRequired();
+        builder.Property(c => c.Origin).HasColumnName("origin").HasMaxLength(32).IsRequired();
+        builder.Property(c => c.Title).HasColumnName("title").HasMaxLength(200).IsRequired();
+
+        builder.Property(c => c.Content)
+            .HasColumnName("content")
+            .HasColumnType("jsonb")
+            .IsRequired();
+
+        builder.Property(c => c.Version).HasColumnName("version").HasDefaultValue(1).IsRequired();
+
+        builder.Property(c => c.IsSuppressed).HasColumnName("is_suppressed").HasDefaultValue(false).IsRequired();
+        builder.Property(c => c.SuppressedReason).HasColumnName("suppressed_reason").HasMaxLength(500);
+        builder.Property(c => c.SuppressedAt).HasColumnName("suppressed_at");
+        builder.Property(c => c.SuppressedBy).HasColumnName("suppressed_by");
+
+        builder.Property(c => c.ErrorReportsCount).HasColumnName("error_reports_count").HasDefaultValue(0).IsRequired();
+        builder.Property(c => c.FeedbackScore).HasColumnName("feedback_score").HasColumnType("numeric(4,2)");
+
+        builder.Property(c => c.PublishedAt).HasColumnName("published_at").IsRequired();
+        builder.Property(c => c.PublishedBy).HasColumnName("published_by").IsRequired();
+        builder.Property(c => c.CreatedAt).HasColumnName("created_at").IsRequired();
+        builder.Property(c => c.UpdatedAt).HasColumnName("updated_at").IsRequired();
+
+        builder.Property(c => c.Xmin)
+            .HasColumnName("xmin")
+            .HasColumnType("xid")
+            .ValueGeneratedOnAddOrUpdate()
+            .IsConcurrencyToken();
+
+        // === Indexes ===
+        // At most one active (non-suppressed) card per shared game (AC-1 / T5).
+        builder.HasIndex(c => c.SharedGameId)
+            .HasDatabaseName("ux_mechanic_cards_active_per_game")
+            .IsUnique()
+            .HasFilter("is_suppressed = false");
+
+        builder.HasIndex(c => c.OriginAnalysisId)
+            .HasDatabaseName("ix_mechanic_cards_origin_analysis_id");
+
+        // === FKs ===
+        builder.HasOne(c => c.SharedGame)
+            .WithMany()
+            .HasForeignKey(c => c.SharedGameId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasOne(c => c.OriginAnalysis)
+            .WithMany()
+            .HasForeignKey(c => c.OriginAnalysisId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasMany(c => c.AuditLog)
+            .WithOne(a => a.Card)
+            .HasForeignKey(a => a.CardId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        // Player-facing default hides suppressed cards (admin ops use IgnoreQueryFilters).
+        builder.HasQueryFilter(c => !c.IsSuppressed);
+    }
+}

--- a/apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/MechanicAnalysisEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/MechanicAnalysisEntity.cs
@@ -23,6 +23,9 @@ public class MechanicAnalysisEntity
     public DateTime? ReviewedAt { get; set; }
     public string? RejectionReason { get; set; }
 
+    /// <summary>FK to the published <c>mechanic_cards</c> row (#527). Null until explicitly published.</summary>
+    public Guid? PublishedCardId { get; set; }
+
     // === LLM execution snapshot ===
     public int TotalTokensUsed { get; set; }
     public decimal EstimatedCostUsd { get; set; }

--- a/apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/MechanicCardAuditLogEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/MechanicCardAuditLogEntity.cs
@@ -1,0 +1,23 @@
+namespace Api.Infrastructure.Entities.SharedGameCatalog;
+
+/// <summary>
+/// Persistence entity for <see cref="Api.BoundedContexts.SharedGameCatalog.Domain.Entities.MechanicCardAuditLog"/>
+/// (ADR-051 audit trail, #527). Append-only.
+/// </summary>
+public class MechanicCardAuditLogEntity
+{
+    public Guid Id { get; set; }
+    public Guid CardId { get; set; }
+
+    /// <summary>Lowercase string: 'published' | 'suppressed' | 'unsuppressed' | 'revised' (DB CHECK).</summary>
+    public string Action { get; set; } = "published";
+
+    public Guid ActorId { get; set; }
+    public DateTime OccurredAt { get; set; }
+
+    /// <summary>Optional JSONB metadata (e.g. reason, previous_card_id).</summary>
+    public string? Metadata { get; set; }
+
+    // === Navigation ===
+    public MechanicCardEntity Card { get; set; } = default!;
+}

--- a/apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/MechanicCardEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/MechanicCardEntity.cs
@@ -1,0 +1,51 @@
+namespace Api.Infrastructure.Entities.SharedGameCatalog;
+
+/// <summary>
+/// Persistence entity for <see cref="Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates.MechanicCard"/>
+/// (ADR-051 / #527). Plain POCO — all invariants live in the domain aggregate.
+/// </summary>
+public class MechanicCardEntity
+{
+    public Guid Id { get; set; }
+
+    // === Identity / lineage ===
+    public Guid SharedGameId { get; set; }
+    public Guid OriginAnalysisId { get; set; }
+
+    /// <summary>Lowercase string: 'ai_reviewed' | 'manual' | 'imported_external' (DB CHECK).</summary>
+    public string Origin { get; set; } = "ai_reviewed";
+
+    // === Content ===
+    public string Title { get; set; } = string.Empty;
+
+    /// <summary>Immutable JSONB snapshot of the approved claims (AD-1).</summary>
+    public string Content { get; set; } = "{}";
+
+    public int Version { get; set; }
+
+    // === Takedown (T5) ===
+    public bool IsSuppressed { get; set; }
+    public string? SuppressedReason { get; set; }
+    public DateTime? SuppressedAt { get; set; }
+    public Guid? SuppressedBy { get; set; }
+
+    // === Player feedback (#531) ===
+    public int ErrorReportsCount { get; set; }
+    public decimal? FeedbackScore { get; set; }
+
+    // === Publication audit ===
+    public DateTime PublishedAt { get; set; }
+    public Guid PublishedBy { get; set; }
+
+    // === Housekeeping ===
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+
+    /// <summary>PostgreSQL system column <c>xmin</c> mapped as <see cref="uint"/> (xid) — concurrency token (ADR-060).</summary>
+    public uint Xmin { get; set; }
+
+    // === Navigation ===
+    public SharedGameEntity SharedGame { get; set; } = default!;
+    public MechanicAnalysisEntity OriginAnalysis { get; set; } = default!;
+    public ICollection<MechanicCardAuditLogEntity> AuditLog { get; set; } = new List<MechanicCardAuditLogEntity>();
+}

--- a/apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs
+++ b/apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs
@@ -208,6 +208,8 @@ public class MeepleAiDbContext : DbContext
     public DbSet<MechanicCitationEntity> MechanicCitations => Set<MechanicCitationEntity>(); // ISSUE-523: Child of MechanicClaim (ADR-051 T1 quote cap)
     public DbSet<MechanicStatusAuditEntity> MechanicStatusAudits => Set<MechanicStatusAuditEntity>(); // ISSUE-523: T6 audit trail for lifecycle transitions
     public DbSet<MechanicSuppressionAuditEntity> MechanicSuppressionAudits => Set<MechanicSuppressionAuditEntity>(); // ISSUE-523: T5 audit trail for suppressions
+    public DbSet<MechanicCardEntity> MechanicCards => Set<MechanicCardEntity>(); // #527: Mechanic Extractor M1.5 — published user-facing card
+    public DbSet<MechanicCardAuditLogEntity> MechanicCardAuditLog => Set<MechanicCardAuditLogEntity>(); // #527: card lifecycle audit trail
     public DbSet<MechanicAnalysisSectionRunEntity> MechanicAnalysisSectionRuns => Set<MechanicAnalysisSectionRunEntity>(); // ISSUE-524: M1.2 per-section provider/token tracking (B6=C)
     public DbSet<MechanicGoldenClaimEntity> MechanicGoldenClaims => Set<MechanicGoldenClaimEntity>(); // ADR-051 Sprint 1 / M2.0: golden-set claims
     public DbSet<MechanicGoldenBggTagEntity> MechanicGoldenBggTags => Set<MechanicGoldenBggTagEntity>(); // ADR-051 Sprint 1 / M2.0: BGG mechanic tags

--- a/apps/api/src/Api/Infrastructure/Migrations/20260709224421_M1_5_MechanicCardsSchema.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260709224421_M1_5_MechanicCardsSchema.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260709224421_M1_5_MechanicCardsSchema")]
+    partial class M1_5_MechanicCardsSchema
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260709224421_M1_5_MechanicCardsSchema.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260709224421_M1_5_MechanicCardsSchema.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class M1_5_MechanicCardsSchema : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // Idempotent raw SQL (ADR-051 AC-1, pattern PR #517). Each statement is terminated with
+            // ';' so the deploy's idempotent psql path parses cleanly (#2766).
+            //
+            // NOTE: the `xmin` concurrency token maps to PostgreSQL's SYSTEM column of the same name,
+            // which every table already has — it is deliberately NOT declared here (declaring a user
+            // column named `xmin` would collide with the system column).
+
+            migrationBuilder.Sql(
+                "ALTER TABLE mechanic_analyses ADD COLUMN IF NOT EXISTS published_card_id uuid NULL;");
+
+            migrationBuilder.Sql(@"
+                CREATE TABLE IF NOT EXISTS mechanic_cards (
+                    id uuid NOT NULL,
+                    shared_game_id uuid NOT NULL,
+                    origin_analysis_id uuid NOT NULL,
+                    origin character varying(32) NOT NULL,
+                    title character varying(200) NOT NULL,
+                    content jsonb NOT NULL,
+                    version integer NOT NULL DEFAULT 1,
+                    is_suppressed boolean NOT NULL DEFAULT false,
+                    suppressed_reason character varying(500) NULL,
+                    suppressed_at timestamp with time zone NULL,
+                    suppressed_by uuid NULL,
+                    error_reports_count integer NOT NULL DEFAULT 0,
+                    feedback_score numeric(4,2) NULL,
+                    published_at timestamp with time zone NOT NULL,
+                    published_by uuid NOT NULL,
+                    created_at timestamp with time zone NOT NULL,
+                    updated_at timestamp with time zone NOT NULL,
+                    CONSTRAINT ""PK_mechanic_cards"" PRIMARY KEY (id),
+                    CONSTRAINT ck_mechanic_cards_error_reports_non_negative CHECK (error_reports_count >= 0),
+                    CONSTRAINT ck_mechanic_cards_origin CHECK (origin IN ('ai_reviewed', 'manual', 'imported_external')),
+                    CONSTRAINT ck_mechanic_cards_suppression_completeness CHECK ((is_suppressed = false AND suppressed_at IS NULL AND suppressed_by IS NULL AND suppressed_reason IS NULL) OR (is_suppressed = true AND suppressed_at IS NOT NULL AND suppressed_by IS NOT NULL AND suppressed_reason IS NOT NULL)),
+                    CONSTRAINT ck_mechanic_cards_version_positive CHECK (version >= 1),
+                    CONSTRAINT ""FK_mechanic_cards_mechanic_analyses_origin_analysis_id"" FOREIGN KEY (origin_analysis_id) REFERENCES mechanic_analyses (id) ON DELETE RESTRICT,
+                    CONSTRAINT ""FK_mechanic_cards_shared_games_shared_game_id"" FOREIGN KEY (shared_game_id) REFERENCES shared_games (id) ON DELETE CASCADE
+                );");
+
+            migrationBuilder.Sql(@"
+                CREATE TABLE IF NOT EXISTS mechanic_card_audit_log (
+                    id uuid NOT NULL,
+                    card_id uuid NOT NULL,
+                    action character varying(32) NOT NULL,
+                    actor_id uuid NOT NULL,
+                    occurred_at timestamp with time zone NOT NULL,
+                    metadata jsonb NULL,
+                    CONSTRAINT ""PK_mechanic_card_audit_log"" PRIMARY KEY (id),
+                    CONSTRAINT ck_mechanic_card_audit_log_action CHECK (action IN ('published', 'suppressed', 'unsuppressed', 'revised')),
+                    CONSTRAINT ""FK_mechanic_card_audit_log_mechanic_cards_card_id"" FOREIGN KEY (card_id) REFERENCES mechanic_cards (id) ON DELETE CASCADE
+                );");
+
+            migrationBuilder.Sql(
+                "CREATE INDEX IF NOT EXISTS ix_mechanic_card_audit_log_card_id ON mechanic_card_audit_log (card_id);");
+
+            migrationBuilder.Sql(
+                "CREATE INDEX IF NOT EXISTS ix_mechanic_cards_origin_analysis_id ON mechanic_cards (origin_analysis_id);");
+
+            migrationBuilder.Sql(
+                "CREATE UNIQUE INDEX IF NOT EXISTS ux_mechanic_cards_active_per_game ON mechanic_cards (shared_game_id) WHERE is_suppressed = false;");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("DROP TABLE IF EXISTS mechanic_card_audit_log;");
+            migrationBuilder.Sql("DROP TABLE IF EXISTS mechanic_cards;");
+            migrationBuilder.Sql("ALTER TABLE mechanic_analyses DROP COLUMN IF EXISTS published_card_id;");
+        }
+    }
+}

--- a/apps/api/src/Api/Routing/AdminMechanicAnalysesEndpoints.cs
+++ b/apps/api/src/Api/Routing/AdminMechanicAnalysesEndpoints.cs
@@ -161,6 +161,30 @@ internal static class AdminMechanicAnalysesEndpoints
             "Transitions the aggregate from InReview to Published. All claims must be in " +
             "Approved status; otherwise the endpoint returns 409 with a breakdown.");
 
+        // POST /api/v1/admin/mechanic-analyses/{id}/publish (#527)
+        // Publishes a Published-lifecycle analysis into a user-facing mechanic_cards row.
+        group.MapPost("/{id:guid}/publish", async (
+            Guid id,
+            PublishMechanicCardRequest? body,
+            HttpContext httpContext,
+            IMediator mediator,
+            CancellationToken ct) =>
+        {
+            var session = (SessionStatusDto)httpContext.Items[nameof(SessionStatusDto)]!;
+            var publisherId = session!.Principal!.Subject.Id;
+
+            var command = new PublishMechanicCardCommand(id, body?.Title, body?.PreviousCardId, publisherId);
+            var response = await mediator.Send(command, ct).ConfigureAwait(false);
+
+            return Results.Created($"/api/v1/admin/mechanic-cards/{response.CardId}", response);
+        })
+        .WithName("AdminPublishMechanicCard")
+        .WithSummary("Publish an approved mechanic analysis into a user-facing card")
+        .WithDescription(
+            "Snapshots the approved claims into a new mechanic_cards row (version monotonic per game). " +
+            "The analysis must be Published and not already published; an active card for the game " +
+            "returns 409 unless a suppressed previousCardId is supplied (republish → new version).");
+
         // GET /api/v1/admin/mechanic-analyses/{id}/claims (ISSUE-584)
         // Lists every claim of the analysis with citations, ordered by section then display order.
         group.MapGet("/{id:guid}/claims", async (
@@ -356,3 +380,6 @@ internal sealed record RejectClaimRequest(string Note);
 /// <param name="ClaimIds">Explicit claim ids to reject (computed client-side, decision D3).</param>
 /// <param name="Reason">Shared rejection reason (1–500 chars) applied to every claim.</param>
 internal sealed record BulkRejectClaimsRequest(IReadOnlyList<Guid> ClaimIds, string Reason);
+
+/// <summary>Body for <c>POST /admin/mechanic-analyses/{id}/publish</c> (#527). Both fields optional.</summary>
+internal sealed record PublishMechanicCardRequest(string? Title, Guid? PreviousCardId);

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Domain/Aggregates/MechanicCardTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Domain/Aggregates/MechanicCardTests.cs
@@ -1,0 +1,342 @@
+using System.Text.Json;
+
+using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Events;
+using Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+
+/// <summary>
+/// Unit tests for the <see cref="MechanicCard"/> aggregate (#527, M1.5): publish factory,
+/// snapshot immutability (AD-1), suppress/unsuppress (T5), and the
+/// <see cref="MechanicAnalysis.MarkPublished"/> publish-once invariant.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class MechanicCardTests
+{
+    private static readonly DateTime Now = new(2026, 07, 10, 12, 0, 0, DateTimeKind.Utc);
+
+    // ============================================================
+    // PublishFromAnalysis — happy path
+    // ============================================================
+
+    [Fact]
+    public void PublishFromAnalysis_WithApprovedAnalysis_ProducesCardV1()
+    {
+        var analysis = PublishedAnalysis();
+        var publisher = Guid.NewGuid();
+
+        var card = MechanicCard.PublishFromAnalysis(
+            analysis, overrideTitle: "Catan: Mechanics", GameContext("Catan"), publisher, version: 1, Now);
+
+        card.Id.Should().NotBe(Guid.Empty);
+        card.SharedGameId.Should().Be(analysis.SharedGameId);
+        card.OriginAnalysisId.Should().Be(analysis.Id);
+        card.Origin.Should().Be(MechanicCardOrigin.AiReviewed);
+        card.Title.Should().Be("Catan: Mechanics");
+        card.Version.Should().Be(1);
+        card.IsSuppressed.Should().BeFalse();
+        card.ErrorReportsCount.Should().Be(0);
+        card.PublishedBy.Should().Be(publisher);
+        card.PublishedAt.Should().Be(Now);
+    }
+
+    [Fact]
+    public void PublishFromAnalysis_WithoutTitle_UsesDefaultFromGameName()
+    {
+        var analysis = PublishedAnalysis();
+
+        var card = MechanicCard.PublishFromAnalysis(
+            analysis, overrideTitle: null, GameContext("7 Wonders"), Guid.NewGuid(), version: 1, Now);
+
+        card.Title.Should().Be("7 Wonders — Mechanics Card");
+    }
+
+    [Fact]
+    public void PublishFromAnalysis_RaisesMechanicCardPublishedEvent()
+    {
+        var analysis = PublishedAnalysis();
+
+        var card = MechanicCard.PublishFromAnalysis(
+            analysis, "Catan: Mechanics", GameContext("Catan"), Guid.NewGuid(), version: 1, Now);
+
+        card.DomainEvents.Should().ContainSingle(e => e is MechanicCardPublishedEvent);
+    }
+
+    [Fact]
+    public void PublishFromAnalysis_SnapshotsClaimsAndMetadataIntoContent()
+    {
+        var analysis = PublishedAnalysis();
+        // The handler resolves the game from analysis.SharedGameId, so the context mirrors it.
+        var gameContext = new MechanicCardGameContext
+        {
+            SharedGameId = analysis.SharedGameId,
+            SharedGameName = "Catan",
+            Publisher = "Kosmos",
+            Language = "it"
+        };
+
+        var card = MechanicCard.PublishFromAnalysis(
+            analysis, "Catan: Mechanics", gameContext, Guid.NewGuid(), 1, Now);
+
+        using var doc = JsonDocument.Parse(card.Content);
+        var root = doc.RootElement;
+
+        root.GetProperty("schema_version").GetInt32().Should().Be(1);
+        root.GetProperty("source_analysis_id").GetGuid().Should().Be(analysis.Id);
+        root.GetProperty("source_prompt_version").GetString().Should().Be("v1");
+
+        var claims = root.GetProperty("claims");
+        claims.GetArrayLength().Should().Be(1);
+        var claim = claims[0];
+        claim.GetProperty("claim").GetString().Should().Be("Draw phase");
+        claim.GetProperty("section").GetString().Should().Be("Mechanics");
+        claim.GetProperty("citations").GetArrayLength().Should().Be(1);
+        claim.GetProperty("citations")[0].GetProperty("pdf_id").GetGuid().Should().Be(analysis.PdfDocumentId);
+        claim.GetProperty("citations")[0].GetProperty("pdf_page").GetInt32().Should().Be(1);
+
+        var metadata = root.GetProperty("metadata");
+        metadata.GetProperty("shared_game_id").GetGuid().Should().Be(analysis.SharedGameId);
+        metadata.GetProperty("shared_game_name").GetString().Should().Be("Catan");
+        metadata.GetProperty("publisher").GetString().Should().Be("Kosmos");
+        metadata.GetProperty("language").GetString().Should().Be("it");
+    }
+
+    // ============================================================
+    // PublishFromAnalysis — preconditions
+    // ============================================================
+
+    [Fact]
+    public void PublishFromAnalysis_WithNonPublishedAnalysis_Throws()
+    {
+        var analysis = NewAnalysisWithClaim(); // Draft
+
+        var act = () => MechanicCard.PublishFromAnalysis(
+            analysis, null, GameContext("Catan"), Guid.NewGuid(), 1, Now);
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*Published*");
+    }
+
+    [Fact]
+    public void PublishFromAnalysis_WhenAnalysisAlreadyPublished_Throws()
+    {
+        var analysis = PublishedAnalysis();
+        analysis.MarkPublished(Guid.NewGuid());
+
+        var act = () => MechanicCard.PublishFromAnalysis(
+            analysis, null, GameContext("Catan"), Guid.NewGuid(), 1, Now);
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*already published*");
+    }
+
+    [Fact]
+    public void PublishFromAnalysis_WithEmptyPublisher_Throws()
+    {
+        var analysis = PublishedAnalysis();
+
+        var act = () => MechanicCard.PublishFromAnalysis(
+            analysis, null, GameContext("Catan"), Guid.Empty, 1, Now);
+
+        act.Should().Throw<ArgumentException>().WithMessage("*PublisherId*");
+    }
+
+    [Fact]
+    public void PublishFromAnalysis_WithVersionBelowOne_Throws()
+    {
+        var analysis = PublishedAnalysis();
+
+        var act = () => MechanicCard.PublishFromAnalysis(
+            analysis, null, GameContext("Catan"), Guid.NewGuid(), version: 0, Now);
+
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Theory]
+    [InlineData("ABC")] // < 5
+    public void PublishFromAnalysis_WithTooShortTitle_Throws(string title)
+    {
+        var analysis = PublishedAnalysis();
+
+        var act = () => MechanicCard.PublishFromAnalysis(
+            analysis, title, GameContext("Catan"), Guid.NewGuid(), 1, Now);
+
+        act.Should().Throw<ArgumentException>().WithMessage("*Title*");
+    }
+
+    [Fact]
+    public void PublishFromAnalysis_WithTooLongTitle_Throws()
+    {
+        var analysis = PublishedAnalysis();
+
+        var act = () => MechanicCard.PublishFromAnalysis(
+            analysis, new string('x', 201), GameContext("Catan"), Guid.NewGuid(), 1, Now);
+
+        act.Should().Throw<ArgumentException>().WithMessage("*Title*");
+    }
+
+    // ============================================================
+    // Suppress / Unsuppress (T5)
+    // ============================================================
+
+    [Fact]
+    public void Suppress_MarksSuppressedAndRaisesEvent()
+    {
+        var card = NewCard();
+        var actor = Guid.NewGuid();
+
+        card.Suppress(actor, "Publisher DMCA takedown request received via legal.", Now);
+
+        card.IsSuppressed.Should().BeTrue();
+        card.SuppressedBy.Should().Be(actor);
+        card.SuppressedReason.Should().StartWith("Publisher DMCA");
+        card.DomainEvents.Should().ContainSingle(e => e is MechanicCardSuppressedEvent);
+    }
+
+    [Fact]
+    public void Suppress_WhenAlreadySuppressed_Throws()
+    {
+        var card = NewCard();
+        card.Suppress(Guid.NewGuid(), "Publisher DMCA takedown request received via legal.", Now);
+
+        var act = () => card.Suppress(Guid.NewGuid(), "Publisher DMCA takedown request received via legal.", Now);
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*already suppressed*");
+    }
+
+    [Theory]
+    [InlineData("short")] // < 20
+    public void Suppress_WithInvalidReasonLength_Throws(string reason)
+    {
+        var card = NewCard();
+
+        var act = () => card.Suppress(Guid.NewGuid(), reason, Now);
+
+        act.Should().Throw<ArgumentException>().WithMessage("*20..500*");
+    }
+
+    [Fact]
+    public void Unsuppress_ClearsSuppressionState()
+    {
+        var card = NewCard();
+        card.Suppress(Guid.NewGuid(), "Publisher DMCA takedown request received via legal.", Now);
+
+        card.Unsuppress(Guid.NewGuid(), Now);
+
+        card.IsSuppressed.Should().BeFalse();
+        card.SuppressedReason.Should().BeNull();
+        card.SuppressedAt.Should().BeNull();
+        card.SuppressedBy.Should().BeNull();
+    }
+
+    [Fact]
+    public void Unsuppress_WhenNotSuppressed_Throws()
+    {
+        var card = NewCard();
+
+        var act = () => card.Unsuppress(Guid.NewGuid(), Now);
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*not suppressed*");
+    }
+
+    [Fact]
+    public void MarkErrorReport_IncrementsCounter()
+    {
+        var card = NewCard();
+
+        card.MarkErrorReport(Now);
+        card.MarkErrorReport(Now);
+
+        card.ErrorReportsCount.Should().Be(2);
+    }
+
+    // ============================================================
+    // MechanicAnalysis.MarkPublished (publish-once invariant)
+    // ============================================================
+
+    [Fact]
+    public void MarkPublished_OnPublishedAnalysis_SetsPublishedCardId()
+    {
+        var analysis = PublishedAnalysis();
+        var cardId = Guid.NewGuid();
+
+        analysis.MarkPublished(cardId);
+
+        analysis.PublishedCardId.Should().Be(cardId);
+    }
+
+    [Fact]
+    public void MarkPublished_WhenAlreadyPublished_Throws()
+    {
+        var analysis = PublishedAnalysis();
+        analysis.MarkPublished(Guid.NewGuid());
+
+        var act = () => analysis.MarkPublished(Guid.NewGuid());
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*already published*");
+    }
+
+    [Fact]
+    public void MarkPublished_WithEmptyCardId_Throws()
+    {
+        var analysis = PublishedAnalysis();
+
+        var act = () => analysis.MarkPublished(Guid.Empty);
+
+        act.Should().Throw<ArgumentException>().WithMessage("*CardId*");
+    }
+
+    // ============================================================
+    // Helpers
+    // ============================================================
+
+    private static MechanicCardGameContext GameContext(string name, string? publisher = null, string language = "en") =>
+        new() { SharedGameId = Guid.NewGuid(), SharedGameName = name, Publisher = publisher, Language = language };
+
+    private static MechanicCard NewCard()
+    {
+        var analysis = PublishedAnalysis();
+        return MechanicCard.PublishFromAnalysis(
+            analysis, "Catan: Mechanics", GameContext("Catan"), Guid.NewGuid(), version: 1, Now);
+    }
+
+    private static MechanicAnalysis NewAnalysisWithClaim()
+    {
+        var analysis = MechanicAnalysis.Create(
+            sharedGameId: Guid.NewGuid(),
+            pdfDocumentId: Guid.NewGuid(),
+            promptVersion: "v1",
+            createdBy: Guid.NewGuid(),
+            createdAt: Now,
+            modelUsed: "deepseek-chat",
+            provider: "deepseek",
+            costCapUsd: 1m);
+
+        var claim = MechanicClaim.Create(
+            analysisId: analysis.Id,
+            section: MechanicSection.Mechanics,
+            text: "Draw phase",
+            displayOrder: 0,
+            citations: new[]
+            {
+                MechanicCitation.Create(analysis.Id, pdfPage: 1, quote: "Each turn draw one card.", chunkId: null, displayOrder: 0)
+            });
+
+        analysis.AddClaim(claim);
+        return analysis;
+    }
+
+    private static MechanicAnalysis PublishedAnalysis()
+    {
+        var analysis = NewAnalysisWithClaim();
+        var reviewer = Guid.NewGuid();
+        analysis.SubmitForReview(reviewer, Now);
+        analysis.ApproveClaim(analysis.Claims[0].Id, reviewer, Now);
+        analysis.Approve(reviewer, Now);
+        return analysis;
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/PublishMechanicCardEndpointIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/PublishMechanicCardEndpointIntegrationTests.cs
@@ -1,0 +1,255 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+using Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Services;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Infrastructure;
+
+/// <summary>
+/// Integration tests for <c>POST /admin/mechanic-analyses/{id}/publish</c> (#527, M1.5). Exercises
+/// the full stack against real PostgreSQL (which also validates that the idempotent
+/// <c>M1_5_MechanicCardsSchema</c> migration applies): happy path (card + audit + analysis FK persist
+/// atomically) and the two common conflicts (F1 not-Published, F2 already-published).
+/// </summary>
+/// <remarks>
+/// The two-analyses active-card race (F4) is structurally prevented for the AI-review path by the
+/// pre-existing analysis-level partial unique index (one Published, non-suppressed analysis per game),
+/// so it is not reachable via seeding; the card-level index remains as belt-and-braces defense.
+/// </remarks>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class PublishMechanicCardEndpointIntegrationTests : IAsyncLifetime
+{
+    private const string EndpointBase = "/api/v1/admin/mechanic-analyses";
+
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly string _testDbName;
+    private WebApplicationFactory<Program> _factory = null!;
+    private HttpClient _client = null!;
+    private string _adminSessionToken = null!;
+    private Mock<IBackgroundTaskService> _backgroundTaskMock = null!;
+
+    private static readonly Guid TestAdminId = Guid.NewGuid();
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new JsonStringEnumConverter() }
+    };
+
+    public PublishMechanicCardEndpointIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+        _testDbName = $"publish_mechanic_card_{Guid.NewGuid():N}";
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_testDbName);
+
+        _backgroundTaskMock = new Mock<IBackgroundTaskService>();
+        _backgroundTaskMock
+            .Setup(b => b.ExecuteWithCancellation(It.IsAny<string>(), It.IsAny<Func<CancellationToken, Task>>()));
+
+        _factory = IntegrationWebApplicationFactory
+            .Create(connectionString)
+            .WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureTestServices(services =>
+                {
+                    services.RemoveAll<IBackgroundTaskService>();
+                    services.AddSingleton<IBackgroundTaskService>(_backgroundTaskMock.Object);
+                });
+            });
+
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            await dbContext.Database.MigrateAsync();
+
+            var (_, token) = await TestSessionHelper.CreateAdminSessionAsync(dbContext, TestAdminId);
+            _adminSessionToken = token;
+        }
+
+        _client = _factory.CreateClient();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _client?.Dispose();
+        _factory?.Dispose();
+        await _fixture.DropIsolatedDatabaseAsync(_testDbName);
+    }
+
+    [Fact]
+    public async Task Publish_ApprovedAnalysis_Returns201AndPersistsCardAuditAndAnalysisFk()
+    {
+        var gameId = await SeedSharedGameAsync();
+        var analysisId = await SeedAnalysisAsync(gameId, status: 2, claimStatuses: new[] { 1 }); // Published + Approved claim
+
+        var response = await SendPublishAsync(analysisId, new { title = "Catan: Game Mechanics" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        var dto = await response.Content.ReadFromJsonAsync<PublishMechanicCardResponseDto>(JsonOptions);
+        dto.Should().NotBeNull();
+        dto!.SharedGameId.Should().Be(gameId);
+        dto.OriginAnalysisId.Should().Be(analysisId);
+        dto.Version.Should().Be(1);
+        dto.Title.Should().Be("Catan: Game Mechanics");
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        var card = await db.MechanicCards.AsNoTracking().SingleAsync(c => c.Id == dto.CardId);
+        card.SharedGameId.Should().Be(gameId);
+        card.Origin.Should().Be("ai_reviewed");
+        card.Version.Should().Be(1);
+        card.IsSuppressed.Should().BeFalse();
+
+        // PostgreSQL reformats jsonb on storage, so parse rather than string-match.
+        using (var contentDoc = JsonDocument.Parse(card.Content))
+        {
+            var contentRoot = contentDoc.RootElement;
+            contentRoot.GetProperty("schema_version").GetInt32().Should().Be(1);
+            contentRoot.GetProperty("source_analysis_id").GetGuid().Should().Be(analysisId);
+            contentRoot.GetProperty("claims").GetArrayLength().Should().Be(1);
+        }
+
+        var audit = await db.MechanicCardAuditLog.AsNoTracking().Where(a => a.CardId == dto.CardId).ToListAsync();
+        audit.Should().ContainSingle(a => a.Action == "published" && a.ActorId == TestAdminId);
+
+        var analysis = await db.MechanicAnalyses.AsNoTracking().IgnoreQueryFilters().SingleAsync(a => a.Id == analysisId);
+        analysis.PublishedCardId.Should().Be(dto.CardId);
+    }
+
+    [Fact]
+    public async Task Publish_InReviewAnalysis_Returns409()
+    {
+        var gameId = await SeedSharedGameAsync();
+        var analysisId = await SeedAnalysisAsync(gameId, status: 1, claimStatuses: new[] { 1 }); // InReview
+
+        var response = await SendPublishAsync(analysisId, new { });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    [Fact]
+    public async Task Publish_AlreadyPublishedAnalysis_Returns409()
+    {
+        var gameId = await SeedSharedGameAsync();
+        var analysisId = await SeedAnalysisAsync(gameId, status: 2, claimStatuses: new[] { 1 });
+
+        var first = await SendPublishAsync(analysisId, new { });
+        first.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var second = await SendPublishAsync(analysisId, new { });
+        second.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private async Task<HttpResponseMessage> SendPublishAsync(Guid analysisId, object body)
+    {
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Post,
+            $"{EndpointBase}/{analysisId}/publish",
+            _adminSessionToken,
+            body);
+        return await _client.SendAsync(request);
+    }
+
+    private async Task<Guid> SeedSharedGameAsync()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        var gameId = Guid.NewGuid();
+        dbContext.Set<SharedGameEntity>().Add(new SharedGameEntity
+        {
+            Id = gameId,
+            Title = $"Publish Test Game {Guid.NewGuid():N}",
+            Description = "Integration test rulebook",
+            MinPlayers = 2,
+            MaxPlayers = 4,
+            PlayingTimeMinutes = 90,
+            YearPublished = 2024,
+            MinAge = 12,
+            CreatedAt = DateTime.UtcNow,
+            CreatedBy = TestAdminId
+        });
+        await dbContext.SaveChangesAsync();
+        return gameId;
+    }
+
+    private async Task<Guid> SeedAnalysisAsync(Guid sharedGameId, int status, int[] claimStatuses)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        var analysisId = Guid.NewGuid();
+        var now = DateTime.UtcNow;
+
+        dbContext.Set<MechanicAnalysisEntity>().Add(new MechanicAnalysisEntity
+        {
+            Id = analysisId,
+            SharedGameId = sharedGameId,
+            PdfDocumentId = Guid.NewGuid(),
+            PromptVersion = "mechanic-extractor-v1",
+            Status = status,
+            CreatedBy = TestAdminId,
+            CreatedAt = now,
+            ReviewedBy = status is 1 or 2 ? TestAdminId : null,
+            ReviewedAt = status is 1 or 2 ? now : null,
+            TotalTokensUsed = 1234,
+            EstimatedCostUsd = 0.05m,
+            ModelUsed = "test-model",
+            Provider = "test-provider",
+            CostCapUsd = 1.00m
+        });
+
+        for (var i = 0; i < claimStatuses.Length; i++)
+        {
+            var claimId = Guid.NewGuid();
+            dbContext.Set<MechanicClaimEntity>().Add(new MechanicClaimEntity
+            {
+                Id = claimId,
+                AnalysisId = analysisId,
+                Section = i % 6,
+                Text = $"Claim {i}: synthetic mechanic description.",
+                DisplayOrder = i,
+                Status = claimStatuses[i],
+                ReviewedBy = claimStatuses[i] == 0 ? null : TestAdminId,
+                ReviewedAt = claimStatuses[i] == 0 ? null : now
+            });
+            dbContext.Set<MechanicCitationEntity>().Add(new MechanicCitationEntity
+            {
+                Id = Guid.NewGuid(),
+                ClaimId = claimId,
+                PdfPage = 1,
+                Quote = "Each turn draw one card.",
+                DisplayOrder = 0
+            });
+        }
+
+        await dbContext.SaveChangesAsync();
+        return analysisId;
+    }
+}


### PR DESCRIPTION
## Summary

Implementa **ME-M1.5 (#527)**: promuove una `MechanicAnalysis` in stato `Published` in una nuova card user-facing (`mechanic_cards`), snapshot immutabile dei claim approvati (ADR-051 AD-1). Pubblicare è un atto esplicito distinto dall'approvare il lifecycle (AD-2, Opzione A dello state machine — nessuna modifica all'enum). Successore naturale di #526.

Endpoint: `POST /api/v1/admin/mechanic-analyses/{id}/publish` → **201 Created** + `Location`.

## Cosa contiene (5 slice, commit incrementali)

1. **Domain** — aggregate `MechanicCard` (factory `PublishFromAnalysis`, `Suppress`/`Unsuppress` T5, `MarkErrorReport`), snapshot JSONB immutabile `MechanicCardContent`, `MechanicCardAuditLog`, enum `MechanicCardOrigin`/`AuditAction`, eventi `MechanicCardPublished`/`Suppressed`. `MechanicAnalysis` guadagna `PublishedCardId` + `MarkPublished` (publish-once, F2).
2. **Persistence + migration** — entity POCO + config EF (partial unique index `ux_mechanic_cards_active_per_game`, CHECK, xmin `xid`, query filter suppression). Migration **idempotente** `M1_5_MechanicCardsSchema` (IF NOT EXISTS; #2766). `published_card_id` come colonna soft-ref (no FK, evita ciclo analysis↔card).
3. **Repository + DI** — `IMechanicCardRepository` + impl (AddAsync, AddAuditLog, GetMaxVersionForGame, GetActiveByGame, GetByIdIgnoringFilters).
4. **Application + endpoint** — `PublishMechanicCardCommand` + Validator + Handler (game-context via `ISharedGameRepository`, card+audit+analysis-FK atomici in un `IUnitOfWork`, F1-F5/F9, structured logging con `ConflictReason` per AC-7) + response DTO + endpoint.
5. **Test** — 3 integration (Testcontainers, valida che la migration applichi: happy path + F1 + F2) + 19 unit (aggregate: factory, snapshot, suppress, MarkPublished, precondizioni).

## Verifica

- ✅ Build verde (Api + test) su tutte le 5 slice.
- ✅ **19 unit + 3 integration test verdi.** L'integration happy-path valida end-to-end: migration applica su Postgres reale, card + audit + `analysis.published_card_id` persistiti atomicamente, snapshot JSONB corretto.
- ✅ typecheck/pre-commit hook verdi a ogni commit.

## Insight di design (F4 race)

Lo scenario F4 della spec ("due analisi Published stesso game pubblicate concorrentemente") è **struttura-prevenuto** per il path AI-review dall'indice unico **analysis-level** pre-esistente (`ux_mechanic_analyses_published_per_game`: una sola analisi Published+non-suppressed per game). L'indice unico **card-level** resta come defense-in-depth belt-and-braces (rilevante per il path republish AC-5). L'handler gestisce comunque F4/F5 via `DbUpdateException`/`DbUpdateConcurrencyException` → 409.

## Note (differito, con rationale onesto)

- **Prometheus counters (AC-7)**: la parte *structured logging* di AC-7 è implementata (LogInformation/LogWarning con `{AnalysisId, CardId, SharedGameId, PublisherId, Version, ConflictReason}`). I counter Prometheus dedicati (`mechanic_card_published_total`, ecc.) sono un follow-up leggero.
- **Roadmap doc**: `docs/roadmap/mechanic-extractor-ai-first-issues.md` (citato nel DoD) non è più presente nel repo — skip.
- **Dipendenza #526**: il backend è indipendente e testato con fixture; il flusso E2E via UI di review (#526, OPEN) chiude il cerchio quando mergiato.

Refs #527 #524 #525 #526

🤖 Generated with [Claude Code](https://claude.com/claude-code)
