### PR TITLE
feat(mechanic-extractor): #526 ME-M1.4 ClaimsSection UI + E2E (PR-C, Tasks 8-11,13)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/ApproveMechanicClaimCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/ApproveMechanicClaimCommand.cs
@@ -11,7 +11,9 @@ namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands.MechanicExt
 /// <param name="AnalysisId">Parent aggregate id.</param>
 /// <param name="ClaimId">Claim id to approve.</param>
 /// <param name="ReviewerId">Admin user id from the validated session (never from the body).</param>
+/// <param name="Note">Optional free-form review note captured on approval (#526 AC-6, ≤ 2000 chars).</param>
 internal record ApproveMechanicClaimCommand(
     Guid AnalysisId,
     Guid ClaimId,
-    Guid ReviewerId) : ICommand<MechanicClaimDto>;
+    Guid ReviewerId,
+    string? Note = null) : ICommand<MechanicClaimDto>;

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/ApproveMechanicClaimCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/ApproveMechanicClaimCommandHandler.cs
@@ -73,7 +73,7 @@ internal sealed class ApproveMechanicClaimCommandHandler
 
         try
         {
-            analysis.ApproveClaim(request.ClaimId, request.ReviewerId, utcNow);
+            analysis.ApproveClaim(request.ClaimId, request.ReviewerId, utcNow, request.Note);
         }
         catch (InvalidMechanicAnalysisStateException ex)
         {
@@ -123,6 +123,7 @@ internal sealed class ApproveMechanicClaimCommandHandler
             ReviewedBy: claim.ReviewedBy,
             ReviewedAt: claim.ReviewedAt,
             RejectionNote: claim.RejectionNote,
+            ReviewNote: claim.ReviewNote,
             Citations: claim.Citations
                 .OrderBy(c => c.DisplayOrder)
                 .Select(c => new MechanicCitationDto(

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/ApproveMechanicClaimCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/ApproveMechanicClaimCommandHandler.cs
@@ -130,5 +130,6 @@ internal sealed class ApproveMechanicClaimCommandHandler
                     PdfPage: c.PdfPage,
                     Quote: c.Quote,
                     DisplayOrder: c.DisplayOrder))
-                .ToList());
+                .ToList(),
+            Validations: MechanicClaimValidations.DerivePass());
 }

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/ApproveMechanicClaimCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/ApproveMechanicClaimCommandValidator.cs
@@ -20,5 +20,9 @@ internal sealed class ApproveMechanicClaimCommandValidator
 
         RuleFor(c => c.ReviewerId)
             .NotEmpty().WithMessage("ReviewerId is required.");
+
+        RuleFor(c => c.Note)
+            .MaximumLength(2000).WithMessage("Note must be 2000 characters or fewer.")
+            .When(c => c.Note is not null);
     }
 }

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/BulkApproveMechanicClaimsCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/BulkApproveMechanicClaimsCommandHandler.cs
@@ -133,7 +133,8 @@ internal sealed class BulkApproveMechanicClaimsCommandHandler
                         PdfPage: citation.PdfPage,
                         Quote: citation.Quote,
                         DisplayOrder: citation.DisplayOrder))
-                    .ToList()))
+                    .ToList(),
+                Validations: MechanicClaimValidations.DerivePass()))
             .ToList();
 
         return new BulkApproveMechanicClaimsResponseDto(

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/BulkApproveMechanicClaimsCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/BulkApproveMechanicClaimsCommandHandler.cs
@@ -126,6 +126,7 @@ internal sealed class BulkApproveMechanicClaimsCommandHandler
                 ReviewedBy: c.ReviewedBy,
                 ReviewedAt: c.ReviewedAt,
                 RejectionNote: c.RejectionNote,
+                ReviewNote: c.ReviewNote,
                 Citations: c.Citations
                     .OrderBy(citation => citation.DisplayOrder)
                     .Select(citation => new MechanicCitationDto(

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/BulkApproveMechanicClaimsCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/BulkApproveMechanicClaimsCommandHandler.cs
@@ -1,8 +1,10 @@
+using System.Diagnostics;
 using Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Exceptions;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using Api.Middleware.Exceptions;
+using Api.Observability;
 using Api.SharedKernel.Application.Interfaces;
 using Api.SharedKernel.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
@@ -112,6 +114,8 @@ internal sealed class BulkApproveMechanicClaimsCommandHandler
             analysis.Id,
             skippedRejectedCount,
             request.ReviewerId);
+
+        MeepleAiMetrics.MechanicReviewBulkActions.Add(1, new TagList { { "action", "bulk_approve" } });
 
         var claims = analysis.Claims
             .OrderBy(c => c.Section)

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/BulkRejectMechanicClaimsCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/BulkRejectMechanicClaimsCommandHandler.cs
@@ -139,6 +139,7 @@ internal sealed class BulkRejectMechanicClaimsCommandHandler
                 ReviewedBy: c.ReviewedBy,
                 ReviewedAt: c.ReviewedAt,
                 RejectionNote: c.RejectionNote,
+                ReviewNote: c.ReviewNote,
                 Citations: c.Citations
                     .OrderBy(citation => citation.DisplayOrder)
                     .Select(citation => new MechanicCitationDto(

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/BulkRejectMechanicClaimsCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/BulkRejectMechanicClaimsCommandHandler.cs
@@ -146,7 +146,8 @@ internal sealed class BulkRejectMechanicClaimsCommandHandler
                         PdfPage: citation.PdfPage,
                         Quote: citation.Quote,
                         DisplayOrder: citation.DisplayOrder))
-                    .ToList()))
+                    .ToList(),
+                Validations: MechanicClaimValidations.DerivePass()))
             .ToList();
 
         return new BulkRejectMechanicClaimsResponseDto(

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/BulkRejectMechanicClaimsCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/BulkRejectMechanicClaimsCommandHandler.cs
@@ -1,8 +1,10 @@
+using System.Diagnostics;
 using Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Exceptions;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using Api.Middleware.Exceptions;
+using Api.Observability;
 using Api.SharedKernel.Application.Interfaces;
 using Api.SharedKernel.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
@@ -125,6 +127,8 @@ internal sealed class BulkRejectMechanicClaimsCommandHandler
             analysis.Id,
             skippedAlreadyRejectedCount,
             request.ReviewerId);
+
+        MeepleAiMetrics.MechanicReviewBulkActions.Add(1, new TagList { { "action", "bulk_reject" } });
 
         var claims = analysis.Claims
             .OrderBy(c => c.Section)

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/RejectMechanicClaimCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/RejectMechanicClaimCommandHandler.cs
@@ -114,6 +114,7 @@ internal sealed class RejectMechanicClaimCommandHandler
                     PdfPage: c.PdfPage,
                     Quote: c.Quote,
                     DisplayOrder: c.DisplayOrder))
-                .ToList());
+                .ToList(),
+            Validations: MechanicClaimValidations.DerivePass());
     }
 }

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/RejectMechanicClaimCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/RejectMechanicClaimCommandHandler.cs
@@ -107,6 +107,7 @@ internal sealed class RejectMechanicClaimCommandHandler
             ReviewedBy: claim.ReviewedBy,
             ReviewedAt: claim.ReviewedAt,
             RejectionNote: claim.RejectionNote,
+            ReviewNote: claim.ReviewNote,
             Citations: claim.Citations
                 .OrderBy(c => c.DisplayOrder)
                 .Select(c => new MechanicCitationDto(

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/DTOs/MechanicClaimDto.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/DTOs/MechanicClaimDto.cs
@@ -17,6 +17,7 @@ namespace Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
 /// <param name="ReviewedAt">UTC timestamp of the last review action, or <c>null</c>.</param>
 /// <param name="RejectionNote">Reason for rejection (set only when <see cref="Status"/> is Rejected).</param>
 /// <param name="Citations">Attribution citations (≥ 1 — ADR-051 T3).</param>
+/// <param name="Validations">T1–T4 guardrail badges (#526 AC-1). Derived, not persisted — see <see cref="MechanicClaimValidationDto"/>.</param>
 public sealed record MechanicClaimDto(
     Guid Id,
     Guid AnalysisId,
@@ -27,7 +28,8 @@ public sealed record MechanicClaimDto(
     Guid? ReviewedBy,
     DateTime? ReviewedAt,
     string? RejectionNote,
-    IReadOnlyList<MechanicCitationDto> Citations);
+    IReadOnlyList<MechanicCitationDto> Citations,
+    IReadOnlyList<MechanicClaimValidationDto> Validations);
 
 /// <summary>
 /// Read model for a single attribution <c>MechanicCitation</c>. Page + verbatim quote are the

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/DTOs/MechanicClaimDto.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/DTOs/MechanicClaimDto.cs
@@ -16,6 +16,7 @@ namespace Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
 /// <param name="ReviewedBy">Admin who last reviewed the claim, or <c>null</c> if untouched.</param>
 /// <param name="ReviewedAt">UTC timestamp of the last review action, or <c>null</c>.</param>
 /// <param name="RejectionNote">Reason for rejection (set only when <see cref="Status"/> is Rejected).</param>
+/// <param name="ReviewNote">Optional note captured on approval (#526 AC-6). Distinct from <see cref="RejectionNote"/>.</param>
 /// <param name="Citations">Attribution citations (≥ 1 — ADR-051 T3).</param>
 /// <param name="Validations">T1–T4 guardrail badges (#526 AC-1). Derived, not persisted — see <see cref="MechanicClaimValidationDto"/>.</param>
 public sealed record MechanicClaimDto(
@@ -28,6 +29,7 @@ public sealed record MechanicClaimDto(
     Guid? ReviewedBy,
     DateTime? ReviewedAt,
     string? RejectionNote,
+    string? ReviewNote,
     IReadOnlyList<MechanicCitationDto> Citations,
     IReadOnlyList<MechanicClaimValidationDto> Validations);
 

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/DTOs/MechanicClaimValidationDto.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/DTOs/MechanicClaimValidationDto.cs
@@ -1,0 +1,25 @@
+namespace Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
+
+/// <summary>
+/// Per-claim guardrail badge outcome (#526 AC-1). Rule ∈ {T1,T2,T3,T4}; Outcome ∈ {pass,fail,notRun}.
+/// </summary>
+/// <remarks>
+/// CORE ITERATION: values are DERIVED, not persisted. Every claim that reaches the review queue
+/// passed its section's guardrails by the pipeline pass-invariant (rejection sampling retries a
+/// section until its output satisfies T1–T4, else aborts to PartiallyExtracted/Rejected), so all
+/// persisted claims are surfaced as <c>pass</c>. FU-1 (#526 follow-up) replaces this with real
+/// per-claim outcomes + scores captured at pipeline time; the <c>fail</c>/<c>notRun</c> states and
+/// <see cref="Message"/> light up then. #527 snapshots this array into <c>mechanic_cards.content</c>.
+/// </remarks>
+public sealed record MechanicClaimValidationDto(string Rule, string Outcome, string? Message = null);
+
+/// <summary>Derivation of the AC-1 badge families for the core iteration.</summary>
+public static class MechanicClaimValidations
+{
+    /// <summary>Badge families, ordered T1→T4 (T3 = grounding + citation-present).</summary>
+    public static readonly IReadOnlyList<string> Families = new[] { "T1", "T2", "T3", "T4" };
+
+    /// <summary>Derived all-pass outcomes (see <see cref="MechanicClaimValidationDto"/> remarks).</summary>
+    public static IReadOnlyList<MechanicClaimValidationDto> DerivePass() =>
+        Families.Select(f => new MechanicClaimValidationDto(f, "pass")).ToList();
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/MechanicExtractor/GetMechanicAnalysisClaimsQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/MechanicExtractor/GetMechanicAnalysisClaimsQueryHandler.cs
@@ -60,6 +60,7 @@ internal sealed class GetMechanicAnalysisClaimsQueryHandler
                 ReviewedBy: c.ReviewedBy,
                 ReviewedAt: c.ReviewedAt,
                 RejectionNote: c.RejectionNote,
+                ReviewNote: c.ReviewNote,
                 Citations: c.Citations
                     .OrderBy(citation => citation.DisplayOrder)
                     .Select(citation => new MechanicCitationDto(

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/MechanicExtractor/GetMechanicAnalysisClaimsQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/MechanicExtractor/GetMechanicAnalysisClaimsQueryHandler.cs
@@ -67,7 +67,8 @@ internal sealed class GetMechanicAnalysisClaimsQueryHandler
                         PdfPage: citation.PdfPage,
                         Quote: citation.Quote,
                         DisplayOrder: citation.DisplayOrder))
-                    .ToList()))
+                    .ToList(),
+                Validations: MechanicClaimValidations.DerivePass()))
             .ToList();
     }
 }

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Aggregates/MechanicAnalysis.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Aggregates/MechanicAnalysis.cs
@@ -564,12 +564,13 @@ public sealed class MechanicAnalysis : AggregateRoot<Guid>
     }
 
     /// <summary>
-    /// Approves a single claim. Valid only while the analysis is InReview.
+    /// Approves a single claim, optionally capturing a review note (#526 AC-6).
+    /// Valid only while the analysis is InReview.
     /// </summary>
-    public void ApproveClaim(Guid claimId, Guid reviewerId, DateTime utcNow)
+    public void ApproveClaim(Guid claimId, Guid reviewerId, DateTime utcNow, string? note = null)
     {
         var claim = RequireClaimUnderReview(claimId, "approve claim");
-        claim.Approve(reviewerId, utcNow);
+        claim.Approve(reviewerId, utcNow, note);
     }
 
     /// <summary>

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Entities/MechanicClaim.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Entities/MechanicClaim.cs
@@ -48,6 +48,9 @@ public sealed class MechanicClaim : Entity<Guid>
     /// <summary>Reason the claim was rejected. Required when <see cref="Status"/> is Rejected.</summary>
     public string? RejectionNote { get; private set; }
 
+    /// <summary>Optional note captured on approval (#526 AC-6). Distinct from <see cref="RejectionNote"/>.</summary>
+    public string? ReviewNote { get; private set; }
+
     /// <summary>Attribution citations (minimum 1 — ADR-051 T3).</summary>
     public IReadOnlyList<MechanicCitation> Citations => _citations.AsReadOnly();
 
@@ -205,7 +208,8 @@ public sealed class MechanicClaim : Entity<Guid>
         Guid? reviewedBy,
         DateTime? reviewedAt,
         string? rejectionNote,
-        IEnumerable<MechanicCitation> citations)
+        IEnumerable<MechanicCitation> citations,
+        string? reviewNote = null)
     {
         ArgumentNullException.ThrowIfNull(citations);
 
@@ -220,6 +224,7 @@ public sealed class MechanicClaim : Entity<Guid>
             ReviewedBy = reviewedBy,
             ReviewedAt = reviewedAt,
             RejectionNote = rejectionNote,
+            ReviewNote = reviewNote,
             IsNew = false
         };
 
@@ -228,9 +233,10 @@ public sealed class MechanicClaim : Entity<Guid>
     }
 
     /// <summary>
-    /// Approves the claim. Idempotent: re-approving is a no-op.
+    /// Approves the claim, optionally capturing a review note (#526 AC-6). Idempotent:
+    /// re-approving is a no-op except for refreshing the note.
     /// </summary>
-    internal void Approve(Guid reviewerId, DateTime utcNow)
+    internal void Approve(Guid reviewerId, DateTime utcNow, string? note = null)
     {
         if (reviewerId == Guid.Empty)
         {
@@ -241,6 +247,7 @@ public sealed class MechanicClaim : Entity<Guid>
         ReviewedBy = reviewerId;
         ReviewedAt = utcNow;
         RejectionNote = null;
+        ReviewNote = string.IsNullOrWhiteSpace(note) ? null : note.Trim();
     }
 
     /// <summary>
@@ -262,6 +269,7 @@ public sealed class MechanicClaim : Entity<Guid>
         ReviewedBy = reviewerId;
         ReviewedAt = utcNow;
         RejectionNote = note.Trim();
+        ReviewNote = null;
     }
 
     /// <summary>
@@ -273,5 +281,6 @@ public sealed class MechanicClaim : Entity<Guid>
         ReviewedBy = null;
         ReviewedAt = null;
         RejectionNote = null;
+        ReviewNote = null;
     }
 }

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/MechanicAnalysisRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/MechanicAnalysisRepository.cs
@@ -335,7 +335,8 @@ internal sealed class MechanicAnalysisRepository : RepositoryBase, IMechanicAnal
             reviewedBy: entity.ReviewedBy,
             reviewedAt: entity.ReviewedAt,
             rejectionNote: entity.RejectionNote,
-            citations: citations);
+            citations: citations,
+            reviewNote: entity.ReviewNote);
     }
 
     private static MechanicCitation MapCitationToDomain(MechanicCitationEntity entity)
@@ -402,6 +403,7 @@ internal sealed class MechanicAnalysisRepository : RepositoryBase, IMechanicAnal
             ReviewedBy = claim.ReviewedBy,
             ReviewedAt = claim.ReviewedAt,
             RejectionNote = claim.RejectionNote,
+            ReviewNote = claim.ReviewNote,
             Citations = claim.Citations.Select(MapCitationToEntity).ToList()
         };
     }

--- a/apps/api/src/Api/Infrastructure/Configurations/SharedGameCatalog/MechanicClaimEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/Configurations/SharedGameCatalog/MechanicClaimEntityConfiguration.cs
@@ -51,6 +51,10 @@ internal sealed class MechanicClaimEntityConfiguration : IEntityTypeConfiguratio
             .HasColumnName("rejection_note")
             .HasMaxLength(2000);
 
+        builder.Property(c => c.ReviewNote)
+            .HasColumnName("review_note")
+            .HasMaxLength(2000);
+
         builder.HasIndex(c => c.AnalysisId).HasDatabaseName("ix_mechanic_claims_analysis_id");
         builder.HasIndex(c => new { c.AnalysisId, c.Section, c.DisplayOrder })
             .HasDatabaseName("ix_mechanic_claims_analysis_section_order");

--- a/apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/MechanicClaimEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/MechanicClaimEntity.cs
@@ -21,6 +21,9 @@ public class MechanicClaimEntity
     public DateTime? ReviewedAt { get; set; }
     public string? RejectionNote { get; set; }
 
+    /// <summary>Optional free-form note captured on APPROVE (#526 AC-6). Distinct from RejectionNote.</summary>
+    public string? ReviewNote { get; set; }
+
     // === Navigation ===
     public MechanicAnalysisEntity Analysis { get; set; } = default!;
     public ICollection<MechanicCitationEntity> Citations { get; set; } = new List<MechanicCitationEntity>();

--- a/apps/api/src/Api/Infrastructure/Migrations/20260709200055_AddMechanicClaimReviewNote.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260709200055_AddMechanicClaimReviewNote.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260709200055_AddMechanicClaimReviewNote")]
+    partial class AddMechanicClaimReviewNote
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260709200055_AddMechanicClaimReviewNote.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260709200055_AddMechanicClaimReviewNote.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddMechanicClaimReviewNote : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "review_note",
+                table: "mechanic_claims",
+                type: "character varying(2000)",
+                maxLength: 2000,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "review_note",
+                table: "mechanic_claims");
+        }
+    }
+}

--- a/apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.MechanicReview.cs
+++ b/apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.MechanicReview.cs
@@ -1,0 +1,13 @@
+using System.Diagnostics.Metrics;
+
+namespace Api.Observability;
+
+/// <summary>#526 ME-M1.4 admin-review observability (AC-7): bulk-action counter.</summary>
+internal static partial class MeepleAiMetrics
+{
+    /// <summary>Admin mechanic-review bulk actions, tagged {action=bulk_approve|bulk_reject}.</summary>
+    public static readonly Counter<long> MechanicReviewBulkActions =
+        Meter.CreateCounter<long>(
+            "mechanic_review_bulk_actions_total",
+            description: "Admin mechanic-review bulk actions by action.");
+}

--- a/apps/api/src/Api/Routing/AdminMechanicAnalysesEndpoints.cs
+++ b/apps/api/src/Api/Routing/AdminMechanicAnalysesEndpoints.cs
@@ -187,6 +187,7 @@ internal static class AdminMechanicAnalysesEndpoints
         group.MapPost("/{id:guid}/claims/{claimId:guid}/approve", async (
             Guid id,
             Guid claimId,
+            ApproveClaimRequest? request,
             HttpContext httpContext,
             IMediator mediator,
             CancellationToken ct) =>
@@ -194,7 +195,7 @@ internal static class AdminMechanicAnalysesEndpoints
             var session = (SessionStatusDto)httpContext.Items[nameof(SessionStatusDto)]!;
             var reviewerId = session!.Principal!.Subject.Id;
 
-            var command = new ApproveMechanicClaimCommand(id, claimId, reviewerId);
+            var command = new ApproveMechanicClaimCommand(id, claimId, reviewerId, request?.Note);
             var response = await mediator.Send(command, ct).ConfigureAwait(false);
 
             return Results.Ok(response);
@@ -203,7 +204,9 @@ internal static class AdminMechanicAnalysesEndpoints
         .WithSummary("Approve a single claim (ISSUE-584)")
         .WithDescription(
             "Transitions a single claim from Pending or Rejected to Approved. Idempotent on " +
-            "claims already Approved. Parent analysis must be InReview; otherwise 409.");
+            "claims already Approved. An optional review note (#526 AC-6, ≤ 2000 chars) is " +
+            "persisted alongside the approval; an empty body still approves. Parent analysis " +
+            "must be InReview; otherwise 409.");
 
         // POST /api/v1/admin/mechanic-analyses/{id}/claims/{claimId}/reject (ISSUE-584)
         // Per-claim reject with mandatory note (1–500 chars).
@@ -348,6 +351,14 @@ internal sealed record SuppressMechanicAnalysisRequest(
 /// <param name="Note">Reviewer rejection note (1–500 chars). Mandatory — surfaces back
 /// in the claims viewer so the reviewer can act on it before re-approving.</param>
 internal sealed record RejectClaimRequest(string Note);
+
+/// <summary>
+/// Request body for <c>POST /admin/mechanic-analyses/{id}/claims/{claimId}/approve</c>
+/// (#526 AC-6). Optional — an empty body still approves the claim. The reviewer id is
+/// sourced from the validated session, never the body.
+/// </summary>
+/// <param name="Note">Optional free-form review note (≤ 2000 chars) persisted with the approval.</param>
+internal sealed record ApproveClaimRequest(string? Note);
 
 /// <summary>
 /// Request body for <c>POST /admin/mechanic-analyses/{id}/claims/bulk-reject</c> (#526).

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/ApproveMechanicClaimCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/ApproveMechanicClaimCommandHandlerTests.cs
@@ -1,0 +1,142 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Commands.MechanicExtractor;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Commands.MechanicExtractor;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public class ApproveMechanicClaimCommandHandlerTests
+{
+    private readonly Mock<IMechanicAnalysisRepository> _repositoryMock = new();
+    private readonly Mock<IUnitOfWork> _unitOfWorkMock = new();
+    private readonly Mock<ILogger<ApproveMechanicClaimCommandHandler>> _loggerMock = new();
+    private readonly ApproveMechanicClaimCommandHandler _handler;
+
+    public ApproveMechanicClaimCommandHandlerTests()
+    {
+        _handler = new ApproveMechanicClaimCommandHandler(
+            _repositoryMock.Object,
+            _unitOfWorkMock.Object,
+            TimeProvider.System,
+            _loggerMock.Object);
+    }
+
+    // Builds an InReview analysis with `claimCount` Pending claims.
+    private static MechanicAnalysis BuildInReviewAnalysis(int claimCount)
+    {
+        var analysis = MechanicAnalysis.Create(
+            sharedGameId: Guid.NewGuid(),
+            pdfDocumentId: Guid.NewGuid(),
+            promptVersion: "v1",
+            createdBy: Guid.NewGuid(),
+            createdAt: DateTime.UtcNow,
+            modelUsed: "test-model",
+            provider: "test-provider",
+            costCapUsd: 1.0m);
+
+        for (var i = 0; i < claimCount; i++)
+        {
+            var citation = MechanicCitation.Create(Guid.NewGuid(), pdfPage: 1, quote: "q", chunkId: null, displayOrder: 0);
+            var claim = MechanicClaim.Create(
+                analysis.Id, MechanicSection.Mechanics, $"claim {i}", displayOrder: i, new[] { citation });
+            analysis.AddClaim(claim);
+        }
+
+        analysis.SubmitForReview(Guid.NewGuid(), DateTime.UtcNow);
+        return analysis;
+    }
+
+    private void SetupRepo(MechanicAnalysis? analysis, Guid analysisId)
+    {
+        _repositoryMock
+            .Setup(r => r.GetByIdWithClaimsIgnoringFiltersAsync(analysisId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(analysis);
+    }
+
+    [Fact]
+    public async Task Handle_WithNote_StoresReviewNote()
+    {
+        var analysis = BuildInReviewAnalysis(1);
+        var claimId = analysis.Claims.Single().Id;
+        SetupRepo(analysis, analysis.Id);
+
+        var result = await _handler.Handle(
+            new ApproveMechanicClaimCommand(analysis.Id, claimId, Guid.NewGuid(), "looks good, matches p.4"),
+            CancellationToken.None);
+
+        result.Status.Should().Be(MechanicClaimStatus.Approved);
+        result.ReviewNote.Should().Be("looks good, matches p.4");
+        _repositoryMock.Verify(r => r.Update(analysis), Times.Once);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WithoutNote_LeavesReviewNoteNull()
+    {
+        var analysis = BuildInReviewAnalysis(1);
+        var claimId = analysis.Claims.Single().Id;
+        SetupRepo(analysis, analysis.Id);
+
+        var result = await _handler.Handle(
+            new ApproveMechanicClaimCommand(analysis.Id, claimId, Guid.NewGuid()),
+            CancellationToken.None);
+
+        result.Status.Should().Be(MechanicClaimStatus.Approved);
+        result.ReviewNote.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_AnalysisNotFound_Throws404()
+    {
+        var analysisId = Guid.NewGuid();
+        SetupRepo(null, analysisId);
+
+        var command = new ApproveMechanicClaimCommand(analysisId, Guid.NewGuid(), Guid.NewGuid());
+
+        await Assert.ThrowsAsync<NotFoundException>(() => _handler.Handle(command, CancellationToken.None));
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_AnalysisNotInReview_Throws409()
+    {
+        // Draft analysis (never SubmitForReview) — ApproveClaim guard fails.
+        var analysis = MechanicAnalysis.Create(
+            Guid.NewGuid(), Guid.NewGuid(), "v1", Guid.NewGuid(), DateTime.UtcNow, "m", "p", 1.0m);
+        var citation = MechanicCitation.Create(Guid.NewGuid(), 1, "q", null, 0);
+        var claim = MechanicClaim.Create(analysis.Id, MechanicSection.Mechanics, "c", 0, new[] { citation });
+        analysis.AddClaim(claim);
+        SetupRepo(analysis, analysis.Id);
+
+        var command = new ApproveMechanicClaimCommand(analysis.Id, claim.Id, Guid.NewGuid());
+
+        await Assert.ThrowsAsync<ConflictException>(() => _handler.Handle(command, CancellationToken.None));
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_ConcurrencyConflict_Throws409()
+    {
+        var analysis = BuildInReviewAnalysis(1);
+        var claimId = analysis.Claims.Single().Id;
+        SetupRepo(analysis, analysis.Id);
+        _unitOfWorkMock
+            .Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new DbUpdateConcurrencyException());
+
+        var command = new ApproveMechanicClaimCommand(analysis.Id, claimId, Guid.NewGuid());
+
+        await Assert.ThrowsAsync<ConflictException>(() => _handler.Handle(command, CancellationToken.None));
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/MechanicReviewMetricsTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/MechanicReviewMetricsTests.cs
@@ -1,0 +1,44 @@
+using System.Diagnostics.Metrics;
+using Api.Observability;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Commands.MechanicExtractor;
+
+/// <summary>
+/// #526 ME-M1.4 admin-review observability (AC-7): asserts
+/// <see cref="MeepleAiMetrics.MechanicReviewBulkActions"/> emits the expected {action} tag shape,
+/// captured via System.Diagnostics.Metrics MeterListener — same pattern as
+/// <c>MechanicValidatorMetricsTests</c> (#2494 / ME-M1.3 AC-7).
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public class MechanicReviewMetricsTests
+{
+    private const string Counter = "mechanic_review_bulk_actions_total";
+
+    [Fact]
+    public void MechanicReviewBulkActions_Emits_ActionTag()
+    {
+        var events = new List<string>();
+        using var listener = new MeterListener
+        {
+            InstrumentPublished = (instrument, l) =>
+            {
+                if (instrument.Meter.Name == MeepleAiMetrics.MeterName && instrument.Name == Counter)
+                    l.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((_, _, tags, _) =>
+        {
+            foreach (var tag in tags)
+                if (tag.Key == "action" && tag.Value is string a) events.Add(a);
+        });
+        listener.Start();
+
+        MeepleAiMetrics.MechanicReviewBulkActions.Add(1, new System.Diagnostics.TagList { { "action", "bulk_reject" } });
+
+        events.Should().ContainSingle().Which.Should().Be("bulk_reject");
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/DTOs/MechanicClaimValidationsTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/DTOs/MechanicClaimValidationsTests.cs
@@ -1,0 +1,20 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.DTOs;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public class MechanicClaimValidationsTests
+{
+    [Fact]
+    public void DerivePass_ReturnsFourPassBadges_T1ToT4()
+    {
+        var validations = MechanicClaimValidations.DerivePass();
+
+        validations.Select(v => v.Rule).Should().Equal("T1", "T2", "T3", "T4");
+        validations.Should().OnlyContain(v => v.Outcome == "pass" && v.Message == null);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/MechanicAnalysisRepositoryIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/MechanicAnalysisRepositoryIntegrationTests.cs
@@ -437,6 +437,40 @@ public sealed class MechanicAnalysisRepositoryIntegrationTests : IAsyncLifetime
     }
 
     // ============================================================
+    // #526 AC-6: optional approve note round-trips to review_note
+    // ============================================================
+
+    [Fact]
+    public async Task ApprovedClaimWithNote_PersistsReviewNote_AcrossReload()
+    {
+        // Guards BLOCKER-2: MapClaimToEntity must copy ReviewNote. The Moq handler test and the
+        // API response both read the in-memory domain aggregate, so they pass even if the DB write
+        // drops the note. Only this Postgres round-trip catches it — Update() forces
+        // EntityState.Modified, so review_note is UPDATEd to NULL unless the write mapper is patched.
+        var sharedGameId = await SeedSharedGameAsync();
+        var analysis = BuildDraftAnalysisWithClaim(sharedGameId);
+        await _repository.AddAsync(analysis);
+        await _dbContext.SaveChangesAsync();
+        _dbContext.ChangeTracker.Clear();
+
+        var reloaded = await _repository.GetByIdWithClaimsAsync(analysis.Id);
+        reloaded.Should().NotBeNull();
+
+        var reviewer = Guid.NewGuid();
+        var now = DateTime.UtcNow;
+        reloaded!.SubmitForReview(reviewer, now);
+        var claimId = reloaded.Claims.Single().Id;
+        reloaded.ApproveClaim(claimId, reviewer, now, "verified against p.4");
+
+        _repository.Update(reloaded);
+        await _dbContext.SaveChangesAsync();
+        _dbContext.ChangeTracker.Clear();
+
+        var verify = await _repository.GetByIdWithClaimsAsync(analysis.Id);
+        verify!.Claims.Single(c => c.Id == claimId).ReviewNote.Should().Be("verified against p.4");
+    }
+
+    // ============================================================
     // Helpers
     // ============================================================
 

--- a/apps/web/e2e/admin-mechanic-extractor-validation/load-existing-analysis.spec.ts
+++ b/apps/web/e2e/admin-mechanic-extractor-validation/load-existing-analysis.spec.ts
@@ -47,21 +47,31 @@ const CLAIM_TEXT =
   'Players score 1 point per completed road tile when the road is finished during the scoring phase.';
 
 const STATUS_PUBLISHED = 2; // MechanicAnalysisStatus.Published
+const STATUS_IN_REVIEW = 1; // MechanicAnalysisStatus.InReview
 const SECTION_MECHANICS = 1; // MECHANIC_SECTION_LABELS[1] = 'Mechanics'
 const RUN_STATUS_SUCCEEDED = 0;
 const CLAIM_STATUS_PENDING = 0; // MechanicClaimStatus.Pending
 
+const CLAIM_ID_SHORT_QUOTE = 'ffffffff-ffff-4fff-8fff-ffffffffffff';
+
 /**
  * In-memory state holder so we can mutate the analysis between tests if
  * needed. The status mock returns whatever's currently in `state.current`.
+ *
+ * `status` is parameterized (default `Published`) because the bulk-action
+ * `<Select>` in `ClaimsSection` only renders when
+ * `isClaimsActionable = status === InReview && !isSuppressed` — see
+ * `analyses/page.tsx:716-719`. The three original load-existing-analysis
+ * flows don't care about bulk actions and keep the `Published` default; the
+ * bulk-reject test below overrides it to `InReview`.
  */
-function buildStatusDto() {
+function buildStatusDto(status: number = STATUS_PUBLISHED) {
   return {
     id: ANALYSIS_ID,
     sharedGameId: SHARED_GAME_ID,
     pdfDocumentId: PDF_DOCUMENT_ID,
     promptVersion: 'v1.0.0',
-    status: STATUS_PUBLISHED,
+    status,
     rejectionReason: null,
     createdBy: ADMIN_USER_ID,
     createdAt: '2026-04-25T10:00:00Z',
@@ -80,7 +90,7 @@ function buildStatusDto() {
     suppressedAt: null,
     suppressedBy: null,
     suppressionReason: null,
-    claimsCount: 1,
+    claimsCount: 2,
     sectionRuns: [
       {
         section: SECTION_MECHANICS,
@@ -111,7 +121,7 @@ function buildListResponse() {
         pdfDocumentId: PDF_DOCUMENT_ID,
         promptVersion: 'v1.0.0',
         status: STATUS_PUBLISHED,
-        claimsCount: 1,
+        claimsCount: 2,
         totalTokensUsed: 4200,
         estimatedCostUsd: 0.42,
         certificationStatus: 1,
@@ -125,6 +135,18 @@ function buildListResponse() {
   };
 }
 
+/**
+ * Two claims: `CLAIM_ID` carries a citation quote >20 words (drives the
+ * "Reject all with quote >20 words" bulk action / `claimsWithLongQuote` in
+ * `ClaimsSection.tsx:59-61`), the second carries a short-quote citation so
+ * the bulk-reject computed-ids assertion is meaningful (only 1 of 2 claims
+ * targeted). Every claim MUST set `reviewNote` + `validations` — Task 5 made
+ * both fields non-optional on `MechanicClaimDtoSchema`
+ * (`mechanic-analyses.schemas.ts:255-256`); omitting them makes
+ * `HttpClient.validateResponse` throw `SchemaValidationError`, which flips
+ * `ClaimsSection` into its `claims-load-error` branch and breaks every test
+ * in this file (not just the new ones).
+ */
 function buildClaimsResponse() {
   return [
     {
@@ -137,11 +159,48 @@ function buildClaimsResponse() {
       reviewedBy: null,
       reviewedAt: null,
       rejectionNote: null,
+      reviewNote: null,
+      validations: [
+        { rule: 'T1', outcome: 'pass', message: null },
+        { rule: 'T2', outcome: 'pass', message: null },
+        { rule: 'T3', outcome: 'pass', message: null },
+        { rule: 'T4', outcome: 'pass', message: null },
+      ],
       citations: [
         {
           id: 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee',
+          // >20 words — qualifies for the "reject-long-quote" bulk action.
           pdfPage: 4,
-          quote: 'A completed road scores 1 point per tile during the scoring phase.',
+          quote:
+            'A completed road scores 1 point per tile during the scoring phase, ' +
+            'and every player who contributed a tile to that road shares in the points equally.',
+          displayOrder: 0,
+        },
+      ],
+    },
+    {
+      id: CLAIM_ID_SHORT_QUOTE,
+      analysisId: ANALYSIS_ID,
+      section: SECTION_MECHANICS,
+      text: 'Cities score 2 points per tile when completed.',
+      displayOrder: 1,
+      status: CLAIM_STATUS_PENDING,
+      reviewedBy: null,
+      reviewedAt: null,
+      rejectionNote: null,
+      reviewNote: null,
+      validations: [
+        { rule: 'T1', outcome: 'pass', message: null },
+        { rule: 'T2', outcome: 'pass', message: null },
+        { rule: 'T3', outcome: 'pass', message: null },
+        { rule: 'T4', outcome: 'pass', message: null },
+      ],
+      citations: [
+        {
+          id: 'aaaaaaaa-1111-4aaa-8aaa-111111111111',
+          pdfPage: 6,
+          // Short quote — does NOT qualify for the "reject-long-quote" bulk action.
+          quote: 'A completed city scores 2 points per tile.',
           displayOrder: 0,
         },
       ],
@@ -185,13 +244,19 @@ function buildAuthMeDto() {
  * Absolute-URL mocks (against `API_BASE`) silently miss those requests, which
  * is why earlier iterations of this spec hung on the "Verifica autorizzazioni…"
  * spinner: `RequireRole` polled `/api/v1/auth/me` and never got a response.
+ *
+ * `statusOverride` lets bulk-action tests flip the analysis into `InReview`
+ * (see {@link buildStatusDto}) so `ClaimsSection`'s `isClaimsActionable` gate
+ * renders the `bulk-action-select`; the three pre-existing hydration tests
+ * don't pass it and keep the `Published` default.
  */
-async function mockAnalysisRoutes(page: Page) {
+async function mockAnalysisRoutes(page: Page, statusOverride?: number) {
   const calls = {
     authMe: 0,
     list: 0,
     status: 0,
     claims: 0,
+    bulkReject: 0,
   };
 
   // Auth — RequireRole in the admin (dashboard) layout calls this on mount.
@@ -262,7 +327,7 @@ async function mockAnalysisRoutes(page: Page) {
           await route.fulfill({
             status: 200,
             contentType: 'application/json',
-            body: JSON.stringify(buildStatusDto()),
+            body: JSON.stringify(buildStatusDto(statusOverride)),
           });
           return;
         }
@@ -282,6 +347,31 @@ async function mockAnalysisRoutes(page: Page) {
             status: 200,
             contentType: 'application/json',
             body: JSON.stringify(buildClaimsResponse()),
+          });
+          return;
+        }
+        await route.continue();
+      }
+    );
+
+  // Bulk-reject endpoint (#526 ME-M1.4 AC-3/AC-9) — POST only; falls through
+  // to `route.continue()` for any other method so unrelated requests aren't
+  // swallowed.
+  await page
+    .context()
+    .route(
+      new RegExp(`/api/v1/admin/mechanic-analyses/${ANALYSIS_ID}/claims/bulk-reject$`),
+      async (route: Route) => {
+        if (route.request().method() === 'POST') {
+          calls.bulkReject += 1;
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({
+              rejectedCount: 1,
+              skippedAlreadyRejectedCount: 0,
+              claims: buildClaimsResponse(),
+            }),
           });
           return;
         }
@@ -412,5 +502,45 @@ test.describe('Admin · Mechanic Extractor · Load existing analysis', () => {
 
     await expect.poll(() => calls.status, { timeout: 5000 }).toBeGreaterThanOrEqual(1);
     await expect.poll(() => calls.claims, { timeout: 5000 }).toBeGreaterThanOrEqual(1);
+  });
+
+  // #526 ME-M1.4 AC-9 — bulk-reject + citation-open flows.
+  test('bulk-reject by quote length calls the endpoint with computed ids', async ({ page }) => {
+    await setAdminSessionCookies(page);
+    // Analysis must be InReview for `isClaimsActionable` to render the bulk
+    // <Select> (see `analyses/page.tsx:716-719` / `buildStatusDto` doc above).
+    const calls = await mockAnalysisRoutes(page, STATUS_IN_REVIEW);
+    await page.goto(`${ANALYSES_PATH}?analysisId=${ANALYSIS_ID}`);
+
+    await expect(page.getByTestId('claims-section')).toBeVisible();
+
+    // `bulk-action-select` is a Radix `<Select>` (SelectPrimitive.Root), NOT a
+    // native <select> — `.selectOption()` does not drive it. Open the
+    // listbox by clicking the trigger, then click the target option by its
+    // accessible role/name (rendered text includes the computed count, e.g.
+    // "Reject all with quote >20 words (1)" — match on the stable prefix).
+    await page.getByTestId('bulk-action-select').click();
+    await page.getByRole('option', { name: /Reject all with quote >20 words/ }).click();
+
+    await expect(page.getByTestId('bulk-action-count')).toContainText('1');
+    await page.getByTestId('bulk-action-confirm').click();
+
+    await expect.poll(() => calls.bulkReject, { timeout: 5000 }).toBeGreaterThanOrEqual(1);
+  });
+
+  test('clicking a citation opens the quote highlighter', async ({ page }) => {
+    await setAdminSessionCookies(page);
+    await mockAnalysisRoutes(page);
+    await page.goto(`${ANALYSES_PATH}?analysisId=${ANALYSIS_ID}`);
+
+    await expect(page.getByTestId('claims-section')).toBeVisible();
+
+    await page.getByTestId(`claim-citations-toggle-${CLAIM_ID}`).click();
+    await page
+      .getByTestId(/^claim-citation-open-/)
+      .first()
+      .click();
+
+    await expect(page.getByRole('dialog')).toBeVisible();
   });
 });

--- a/apps/web/src/__tests__/app/admin/knowledge-base/mechanic-extractor/review.test.tsx
+++ b/apps/web/src/__tests__/app/admin/knowledge-base/mechanic-extractor/review.test.tsx
@@ -62,7 +62,7 @@ describe('MechanicExtractorReviewPage', () => {
     expect(screen.getByText('2')).toBeInTheDocument(); // 2 mechanics
   });
 
-  it('renders copyright footer with Variant C text', async () => {
+  it('renders ADR-051 attribution footer and NOT the retired Variant-C copy', async () => {
     mockGetMechanicDraft.mockResolvedValue({
       gameTitle: 'Catan',
       summaryDraft: 'Trade and build',
@@ -80,9 +80,9 @@ describe('MechanicExtractorReviewPage', () => {
 
     render(<MechanicExtractorReviewPage />, { wrapper: Wrapper });
 
-    expect(await screen.findByText(/Variant C/)).toBeInTheDocument();
+    expect(await screen.findByText(/riformulata in parole originali/i)).toBeInTheDocument();
     expect(
-      screen.getByText(/L'AI non ha mai letto il testo del PDF originale/i)
-    ).toBeInTheDocument();
+      screen.queryByText(/non ha mai letto il testo del PDF originale/i)
+    ).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/app/admin/(dashboard)/knowledge-base/mechanic-extractor/analyses/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/knowledge-base/mechanic-extractor/analyses/page.tsx
@@ -712,6 +712,7 @@ export default function MechanicAnalysesPage() {
             {analysisId && status && status.claimsCount > 0 && (
               <ClaimsSection
                 analysisId={analysisId}
+                pdfDocumentId={status?.pdfDocumentId}
                 isClaimsActionable={
                   // Approve/Reject only allowed while parent is InReview (server-enforced).
                   status.status === MechanicAnalysisStatus.InReview && !status.isSuppressed

--- a/apps/web/src/app/admin/(dashboard)/knowledge-base/mechanic-extractor/review/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/knowledge-base/mechanic-extractor/review/page.tsx
@@ -17,6 +17,7 @@ import {
 } from 'lucide-react';
 import { useSearchParams } from 'next/navigation';
 
+import { MechanicAnalysisFooterAttribution } from '@/components/admin/mechanic-extractor/MechanicAnalysisFooterAttribution';
 import { EvaluateButton } from '@/components/admin/mechanic-extractor/validation/EvaluateButton';
 import { FeatureFlagGate } from '@/components/admin/mechanic-extractor/validation/FeatureFlagGate';
 import { MetricsCard } from '@/components/admin/mechanic-extractor/validation/MetricsCard';
@@ -268,21 +269,11 @@ function ReviewContent() {
         </ReviewCard>
       )}
 
-      {/* Copyright Footer */}
-      <div className="rounded-lg border border-green-200 bg-green-50/50 p-4 text-center text-xs text-green-800 dark:border-green-800 dark:bg-green-950/20 dark:text-green-300 print:border-green-400">
-        <strong>&copy; 2026 MeepleAI</strong> — Contenuto originale. Meccaniche di gioco descritte
-        indipendentemente.
-        <br />
-        <span className="opacity-70">
-          Generato con Variant C (human + AI assistant). L&apos;AI non ha mai letto il testo del PDF
-          originale.
-        </span>
-        {(draft.totalTokensUsed ?? 0) > 0 && (
-          <span className="ml-2 opacity-70">
-            | {draft.totalTokensUsed} tokens, ${(draft.estimatedCostUsd ?? 0).toFixed(4)}
-          </span>
-        )}
-      </div>
+      {/* Copyright Footer (ADR-051, #526 AC-5) */}
+      <MechanicAnalysisFooterAttribution
+        totalTokensUsed={draft.totalTokensUsed}
+        estimatedCostUsd={draft.estimatedCostUsd}
+      />
 
       {/* AI Comprehension Validation (feature-flagged — ADR-051 Sprint 1 / Task 37) */}
       <FeatureFlagGate>

--- a/apps/web/src/components/admin/mechanic-extractor/MechanicAnalysisFooterAttribution.tsx
+++ b/apps/web/src/components/admin/mechanic-extractor/MechanicAnalysisFooterAttribution.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+export interface MechanicAnalysisFooterAttributionProps {
+  readonly totalTokensUsed?: number;
+  readonly estimatedCostUsd?: number;
+}
+
+/**
+ * #526 AC-5 — ADR-051 canonical attribution footer. Shared between the admin review page and the
+ * public card (#528). Replaces the retired Variant-C attribution copy.
+ */
+export function MechanicAnalysisFooterAttribution({
+  totalTokensUsed,
+  estimatedCostUsd,
+}: MechanicAnalysisFooterAttributionProps): React.JSX.Element {
+  return (
+    <div className="rounded-lg border border-green-200 bg-green-50/50 p-4 text-center text-xs text-green-800 dark:border-green-800 dark:bg-green-950/20 dark:text-green-300 print:border-green-400">
+      <strong>&copy; 2026 MeepleAI</strong> — Contenuto originale.
+      <br />
+      <span className="opacity-70">
+        Analisi elaborata dall&apos;AI sul manuale del gioco. Ogni affermazione è riformulata in
+        parole originali e cita la pagina del regolamento. Copyright &copy; degli editori per il
+        testo originale del manuale.
+      </span>
+      {(totalTokensUsed ?? 0) > 0 && (
+        <span className="ml-2 opacity-70">
+          | {totalTokensUsed} tokens, ${(estimatedCostUsd ?? 0).toFixed(4)}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/admin/mechanic-extractor/__tests__/MechanicAnalysisFooterAttribution.test.tsx
+++ b/apps/web/src/components/admin/mechanic-extractor/__tests__/MechanicAnalysisFooterAttribution.test.tsx
@@ -1,0 +1,18 @@
+/** @vitest-environment jsdom */
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { MechanicAnalysisFooterAttribution } from '../MechanicAnalysisFooterAttribution';
+
+describe('MechanicAnalysisFooterAttribution', () => {
+  it('renders the ADR-051 attribution and NOT the forbidden Variant-C string', () => {
+    render(<MechanicAnalysisFooterAttribution totalTokensUsed={500} estimatedCostUsd={0.002} />);
+    expect(
+      screen.getByText(/riformulata in parole originali e cita la pagina/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/non ha mai letto il testo del PDF originale/i)
+    ).not.toBeInTheDocument();
+    expect(screen.getByText(/500 tokens/)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/admin/mechanic-extractor/claims/ApproveClaimDialog.tsx
+++ b/apps/web/src/components/admin/mechanic-extractor/claims/ApproveClaimDialog.tsx
@@ -15,8 +15,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/components/ui/overlays/alert-dialog-primitives';
-
-const APPROVE_CLAIM_NOTE_MAX_LENGTH = 500;
+import { APPROVE_CLAIM_NOTE_MAX_LENGTH } from '@/lib/api/schemas/mechanic-analyses.schemas';
 
 interface ApproveClaimDialogProps {
   open: boolean;

--- a/apps/web/src/components/admin/mechanic-extractor/claims/ApproveClaimDialog.tsx
+++ b/apps/web/src/components/admin/mechanic-extractor/claims/ApproveClaimDialog.tsx
@@ -1,0 +1,99 @@
+/* eslint-disable local/no-hardcoded-color-utility -- admin tools chrome: text-white / button color on style-prop colored bg or admin-decorative inline gradient. DS-13d admin scope (--admin-* decision deferred to DS-15). */
+'use client';
+
+import React, { useEffect, useState } from 'react';
+
+import { Loader2Icon } from 'lucide-react';
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/overlays/alert-dialog-primitives';
+
+const APPROVE_CLAIM_NOTE_MAX_LENGTH = 500;
+
+interface ApproveClaimDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: (note: string) => void;
+  isPending: boolean;
+  /** Short claim preview (first ~80 chars) used in the dialog description. */
+  claimPreview?: string;
+}
+
+/**
+ * Modal for approving a single mechanic claim with an OPTIONAL reviewer note
+ * (#526 ME-M1.4 AC-6). Unlike {@link RejectClaimDialog}, the note here is not
+ * required — the confirm action is always enabled.
+ */
+export function ApproveClaimDialog({
+  open,
+  onOpenChange,
+  onConfirm,
+  isPending,
+  claimPreview,
+}: ApproveClaimDialogProps): React.JSX.Element {
+  const [note, setNote] = useState('');
+
+  // Reset note when the dialog closes (Cancel or programmatic close).
+  useEffect(() => {
+    if (!open) setNote('');
+  }, [open]);
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Approve this claim?</AlertDialogTitle>
+          <AlertDialogDescription>
+            {claimPreview ? (
+              <span className="block italic">&ldquo;{claimPreview}&rdquo;</span>
+            ) : null}
+            <span className="mt-2 block">
+              Optionally add a reviewer note. The note is recorded with the claim and surfaced to
+              other reviewers.
+            </span>
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <div className="space-y-2">
+          <label className="block text-sm font-medium" htmlFor="approve-claim-note">
+            Reviewer note (optional, up to {APPROVE_CLAIM_NOTE_MAX_LENGTH} chars)
+          </label>
+          <textarea
+            id="approve-claim-note"
+            value={note}
+            onChange={e => setNote(e.target.value)}
+            placeholder="e.g. matches p.4…"
+            className="h-24 w-full resize-y rounded-md border border-border bg-card px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-900 focus:border-green-400 focus:outline-none focus:ring-1 focus:ring-green-400"
+            data-testid="approve-claim-note-input"
+            maxLength={APPROVE_CLAIM_NOTE_MAX_LENGTH}
+          />
+          <p className="text-xs text-muted-foreground">
+            {note.length} / {APPROVE_CLAIM_NOTE_MAX_LENGTH} characters
+          </p>
+        </div>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isPending}>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={e => {
+              e.preventDefault();
+              onConfirm(note.trim());
+            }}
+            disabled={isPending}
+            className="bg-green-600 hover:bg-green-700"
+            data-testid="approve-claim-confirm"
+          >
+            {isPending ? <Loader2Icon className="mr-1 h-4 w-4 animate-spin" /> : null}
+            Approve claim
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/apps/web/src/components/admin/mechanic-extractor/claims/BulkActionDialog.tsx
+++ b/apps/web/src/components/admin/mechanic-extractor/claims/BulkActionDialog.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import React from 'react';
+
+import { Loader2Icon } from 'lucide-react';
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/overlays/alert-dialog-primitives';
+
+interface BulkActionDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Confirmation dialog title, e.g. "Approve all pending claims?". */
+  title: string;
+  /** Predicted number of claims the action will affect. */
+  count: number;
+  onConfirm: () => void;
+  isPending: boolean;
+}
+
+/**
+ * Confirmation modal for bulk claim actions (#526 ME-M1.4 AC-3).
+ *
+ * Mirrors {@link RejectClaimDialog} but is generic over the bulk action
+ * (approve-pending / reject-long-quote / future additions), surfacing only
+ * the predicted affected-claim count for the reviewer to confirm.
+ */
+export function BulkActionDialog({
+  open,
+  onOpenChange,
+  title,
+  count,
+  onConfirm,
+  isPending,
+}: BulkActionDialogProps): React.JSX.Element {
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          <AlertDialogDescription>
+            This will affect <strong data-testid="bulk-action-count">{count}</strong> claim
+            {count === 1 ? '' : 's'}. This action cannot be undone.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isPending}>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={e => {
+              e.preventDefault();
+              if (count === 0) return;
+              onConfirm();
+            }}
+            disabled={count === 0 || isPending}
+            data-testid="bulk-action-confirm"
+          >
+            {isPending ? <Loader2Icon className="mr-1 h-4 w-4 animate-spin" /> : null}
+            Confirm
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/apps/web/src/components/admin/mechanic-extractor/claims/ClaimsSection.tsx
+++ b/apps/web/src/components/admin/mechanic-extractor/claims/ClaimsSection.tsx
@@ -9,6 +9,7 @@
  *   POST /admin/mechanic-analyses/{id}/claims/{claimId}/approve       → single
  *   POST /admin/mechanic-analyses/{id}/claims/{claimId}/reject        → single + note
  *   POST /admin/mechanic-analyses/{id}/claims/bulk-approve            → batch
+ *   POST /admin/mechanic-analyses/{id}/claims/bulk-reject             → batch + reason (#526 ME-M1.4 AC-3)
  *
  * Lifecycle invariant (AC-10): the parent analysis can only be promoted to
  * Published once **every** claim is Approved. The viewer surfaces totals so
@@ -22,6 +23,13 @@ import { CheckIcon, ChevronDownIcon, ChevronRightIcon, Loader2Icon, XIcon } from
 
 import { PdfQuoteHighlighter } from '@/components/pdf/PdfQuoteHighlighter';
 import { Badge } from '@/components/ui/data-display/badge';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/overlays/select';
 import { Button } from '@/components/ui/primitives/button';
 import { createAdminClient } from '@/lib/api/clients/adminClient';
 import { HttpClient } from '@/lib/api/core/httpClient';
@@ -33,10 +41,25 @@ import {
   type MechanicClaimValidationDto,
 } from '@/lib/api/schemas/mechanic-analyses.schemas';
 
+import { BulkActionDialog } from './BulkActionDialog';
 import { RejectClaimDialog } from './RejectClaimDialog';
 
 const httpClient = new HttpClient();
 const adminClient = createAdminClient({ httpClient });
+
+/** Word threshold above which a citation quote is considered "long" (#526 ME-M1.4 AC-3, ADR-051 T1). */
+const LONG_QUOTE_WORDS = 20;
+
+function wordCount(s: string): number {
+  return s.trim().split(/\s+/).filter(Boolean).length;
+}
+
+/** Claims whose citations include at least one quote longer than {@link LONG_QUOTE_WORDS} words. */
+function claimsWithLongQuote(claims: MechanicClaimDto[]): MechanicClaimDto[] {
+  return claims.filter(c => c.citations.some(cit => wordCount(cit.quote) > LONG_QUOTE_WORDS));
+}
+
+type BulkActionKind = 'approve-pending' | 'reject-long-quote';
 
 const CLAIM_STATUS_BADGE_CLASS: Record<number, string> = {
   [MechanicClaimStatus.Pending]: 'bg-amber-100 text-amber-800 border-amber-300',
@@ -113,6 +136,7 @@ export function ClaimsSection({
   const [rejectTarget, setRejectTarget] = useState<MechanicClaimDto | null>(null);
   const [pendingClaimId, setPendingClaimId] = useState<string | null>(null);
   const [citationTarget, setCitationTarget] = useState<CitationTarget | null>(null);
+  const [bulkAction, setBulkAction] = useState<BulkActionKind | null>(null);
 
   const claimsQuery = useQuery({
     queryKey: ['mechanic-analysis', analysisId, 'claims'],
@@ -206,7 +230,53 @@ export function ClaimsSection({
     onError: (err: unknown) => {
       setActionError(err instanceof Error ? err.message : 'Bulk approve failed');
     },
+    onSettled: () => setBulkAction(null),
   });
+
+  const bulkRejectMutation = useMutation({
+    mutationFn: (vars: { claimIds: string[]; reason: string }) =>
+      adminClient.bulkRejectMechanicClaims(analysisId, vars),
+    onSuccess: result => {
+      setActionError(null);
+      // Partial success: report skipped-already-rejected as a warning (amber), not error (rose).
+      if (result.skippedAlreadyRejectedCount > 0) {
+        setActionWarning(
+          `Bulk reject completed: ${result.rejectedCount} rejected, ` +
+            `${result.skippedAlreadyRejectedCount} already-rejected claim(s) skipped.`
+        );
+      } else {
+        setActionWarning(null);
+      }
+      invalidateClaimsAndStatus();
+    },
+    onError: (err: unknown) => {
+      setActionError(err instanceof Error ? err.message : 'Bulk reject failed');
+    },
+    onSettled: () => setBulkAction(null),
+  });
+
+  const pendingClaims = useMemo(
+    () => claims.filter(c => c.status === MechanicClaimStatus.Pending),
+    [claims]
+  );
+  const longQuoteClaims = useMemo(() => claimsWithLongQuote(claims), [claims]);
+
+  const bulkActionTargets = bulkAction === 'approve-pending' ? pendingClaims : longQuoteClaims;
+  const bulkActionTitle =
+    bulkAction === 'approve-pending'
+      ? 'Approve all pending claims?'
+      : 'Reject claims with quote >20 words?';
+
+  const handleBulkActionConfirm = () => {
+    if (bulkAction === 'approve-pending') {
+      bulkApproveMutation.mutate();
+    } else if (bulkAction === 'reject-long-quote') {
+      bulkRejectMutation.mutate({
+        claimIds: bulkActionTargets.map(c => c.id),
+        reason: 'Citazione supera 20 parole (ADR-051 T1) — rifiuto bulk.',
+      });
+    }
+  };
 
   if (claimsQuery.isLoading) {
     return (
@@ -246,7 +316,7 @@ export function ClaimsSection({
     );
   }
 
-  const canBulkApprove = isClaimsActionable && stats.pending > 0 && !bulkApproveMutation.isPending;
+  const isBulkActionPending = bulkApproveMutation.isPending || bulkRejectMutation.isPending;
 
   return (
     <div className="space-y-3" data-testid="claims-section">
@@ -269,20 +339,23 @@ export function ClaimsSection({
           )}
         </div>
         {isClaimsActionable && (
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => bulkApproveMutation.mutate()}
-            disabled={!canBulkApprove}
-            data-testid="bulk-approve-button"
+          <Select
+            value=""
+            onValueChange={value => setBulkAction(value as BulkActionKind)}
+            disabled={isBulkActionPending}
           >
-            {bulkApproveMutation.isPending ? (
-              <Loader2Icon className="mr-1 h-4 w-4 animate-spin" />
-            ) : (
-              <CheckIcon className="mr-1 h-4 w-4" />
-            )}
-            Bulk approve pending ({stats.pending})
-          </Button>
+            <SelectTrigger className="w-64" data-testid="bulk-action-select">
+              <SelectValue placeholder="Bulk action…" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="approve-pending" disabled={pendingClaims.length === 0}>
+                Approve all pending ({pendingClaims.length})
+              </SelectItem>
+              <SelectItem value="reject-long-quote" disabled={longQuoteClaims.length === 0}>
+                Reject all with quote &gt;20 words ({longQuoteClaims.length})
+              </SelectItem>
+            </SelectContent>
+          </Select>
         )}
       </div>
 
@@ -332,6 +405,17 @@ export function ClaimsSection({
         }}
         isPending={rejectMutation.isPending}
         claimPreview={rejectTarget ? truncate(rejectTarget.text, 120) : undefined}
+      />
+
+      <BulkActionDialog
+        open={!!bulkAction}
+        onOpenChange={open => {
+          if (!open) setBulkAction(null);
+        }}
+        title={bulkActionTitle}
+        count={bulkActionTargets.length}
+        onConfirm={handleBulkActionConfirm}
+        isPending={isBulkActionPending}
       />
 
       {citationTarget && (

--- a/apps/web/src/components/admin/mechanic-extractor/claims/ClaimsSection.tsx
+++ b/apps/web/src/components/admin/mechanic-extractor/claims/ClaimsSection.tsx
@@ -20,6 +20,7 @@ import React, { useMemo, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { CheckIcon, ChevronDownIcon, ChevronRightIcon, Loader2Icon, XIcon } from 'lucide-react';
 
+import { PdfQuoteHighlighter } from '@/components/pdf/PdfQuoteHighlighter';
 import { Badge } from '@/components/ui/data-display/badge';
 import { Button } from '@/components/ui/primitives/button';
 import { createAdminClient } from '@/lib/api/clients/adminClient';
@@ -85,11 +86,24 @@ interface ClaimsSectionProps {
    * Used for terminal states where claims are still useful read-only context.
    */
   isClaimsActionable?: boolean;
+  /**
+   * Source PDF id (#526 ME-M1.4 AC-2). When present, citation rows become
+   * clickable buttons that open {@link PdfQuoteHighlighter} at the cited
+   * page/quote; when absent, citations render as plain read-only text.
+   */
+  pdfDocumentId?: string;
+}
+
+interface CitationTarget {
+  documentId: string;
+  page: number;
+  quote: string;
 }
 
 export function ClaimsSection({
   analysisId,
   isClaimsActionable = true,
+  pdfDocumentId,
 }: ClaimsSectionProps): React.JSX.Element {
   const queryClient = useQueryClient();
   const [actionError, setActionError] = useState<string | null>(null);
@@ -98,6 +112,7 @@ export function ClaimsSection({
   const [actionWarning, setActionWarning] = useState<string | null>(null);
   const [rejectTarget, setRejectTarget] = useState<MechanicClaimDto | null>(null);
   const [pendingClaimId, setPendingClaimId] = useState<string | null>(null);
+  const [citationTarget, setCitationTarget] = useState<CitationTarget | null>(null);
 
   const claimsQuery = useQuery({
     queryKey: ['mechanic-analysis', analysisId, 'claims'],
@@ -298,8 +313,10 @@ export function ClaimsSection({
             claims={sectionClaims}
             isActionable={isClaimsActionable}
             pendingClaimId={pendingClaimId}
+            pdfDocumentId={pdfDocumentId}
             onApprove={id => approveMutation.mutate(id)}
             onReject={claim => setRejectTarget(claim)}
+            onOpenCitation={setCitationTarget}
           />
         ))}
       </div>
@@ -316,6 +333,18 @@ export function ClaimsSection({
         isPending={rejectMutation.isPending}
         claimPreview={rejectTarget ? truncate(rejectTarget.text, 120) : undefined}
       />
+
+      {citationTarget && (
+        <PdfQuoteHighlighter
+          open={!!citationTarget}
+          onOpenChange={open => {
+            if (!open) setCitationTarget(null);
+          }}
+          documentId={citationTarget.documentId}
+          page={citationTarget.page}
+          quote={citationTarget.quote}
+        />
+      )}
     </div>
   );
 }
@@ -325,8 +354,10 @@ interface SectionGroupProps {
   claims: MechanicClaimDto[];
   isActionable: boolean;
   pendingClaimId: string | null;
+  pdfDocumentId?: string;
   onApprove: (claimId: string) => void;
   onReject: (claim: MechanicClaimDto) => void;
+  onOpenCitation: (target: CitationTarget) => void;
 }
 
 function SectionGroup({
@@ -334,8 +365,10 @@ function SectionGroup({
   claims,
   isActionable,
   pendingClaimId,
+  pdfDocumentId,
   onApprove,
   onReject,
+  onOpenCitation,
 }: SectionGroupProps): React.JSX.Element {
   const [expanded, setExpanded] = useState(true);
   const label = MECHANIC_SECTION_LABELS[section] ?? `Section ${section}`;
@@ -371,8 +404,10 @@ function SectionGroup({
               claim={claim}
               isActionable={isActionable}
               isPending={pendingClaimId === claim.id}
+              pdfDocumentId={pdfDocumentId}
               onApprove={() => onApprove(claim.id)}
               onReject={() => onReject(claim)}
+              onOpenCitation={onOpenCitation}
             />
           ))}
         </ul>
@@ -385,8 +420,10 @@ interface ClaimRowProps {
   claim: MechanicClaimDto;
   isActionable: boolean;
   isPending: boolean;
+  pdfDocumentId?: string;
   onApprove: () => void;
   onReject: () => void;
+  onOpenCitation: (target: CitationTarget) => void;
 }
 
 /**
@@ -401,8 +438,10 @@ function ClaimRow({
   claim,
   isActionable,
   isPending,
+  pdfDocumentId,
   onApprove,
   onReject,
+  onOpenCitation,
 }: ClaimRowProps): React.JSX.Element {
   const [showCitations, setShowCitations] = useState(false);
   const [textExpanded, setTextExpanded] = useState(false);
@@ -498,8 +537,28 @@ function ClaimRow({
             <ul className="mt-1 space-y-1 border-l-2 border-sky-200 pl-3 text-xs">
               {claim.citations.map(c => (
                 <li key={c.id} className="text-muted-foreground">
-                  <span className="font-medium text-foreground">p.{c.pdfPage}</span> — &ldquo;
-                  {c.quote}&rdquo;
+                  {pdfDocumentId ? (
+                    <button
+                      type="button"
+                      className="text-left hover:underline"
+                      onClick={() =>
+                        onOpenCitation({
+                          documentId: pdfDocumentId,
+                          page: c.pdfPage,
+                          quote: c.quote,
+                        })
+                      }
+                      data-testid={`claim-citation-open-${c.id}`}
+                    >
+                      <span className="font-medium text-foreground">p.{c.pdfPage}</span> — &ldquo;
+                      {c.quote}&rdquo;
+                    </button>
+                  ) : (
+                    <>
+                      <span className="font-medium text-foreground">p.{c.pdfPage}</span> — &ldquo;
+                      {c.quote}&rdquo;
+                    </>
+                  )}
                 </li>
               ))}
             </ul>

--- a/apps/web/src/components/admin/mechanic-extractor/claims/ClaimsSection.tsx
+++ b/apps/web/src/components/admin/mechanic-extractor/claims/ClaimsSection.tsx
@@ -29,6 +29,7 @@ import {
   MECHANIC_SECTION_LABELS,
   MechanicClaimStatus,
   type MechanicClaimDto,
+  type MechanicClaimValidationDto,
 } from '@/lib/api/schemas/mechanic-analyses.schemas';
 
 import { RejectClaimDialog } from './RejectClaimDialog';
@@ -41,6 +42,41 @@ const CLAIM_STATUS_BADGE_CLASS: Record<number, string> = {
   [MechanicClaimStatus.Approved]: 'bg-green-100 text-green-800 border-green-300',
   [MechanicClaimStatus.Rejected]: 'bg-rose-100 text-rose-800 border-rose-300',
 };
+
+/** Per-rule (T1-T4) template validation badge styling (#526 ME-M1.4 AC-1). */
+const VALIDATION_BADGE_CLASS: Record<string, string> = {
+  pass: 'bg-green-100 text-green-800 border-green-300',
+  fail: 'bg-rose-100 text-rose-800 border-rose-300',
+  notRun: 'bg-slate-100 text-slate-600 border-slate-300',
+};
+
+/**
+ * Renders one Badge per template validation rule (T1-T4) with pass/fail/notRun
+ * styling. Exported for direct unit testing and reuse across claim rows.
+ */
+export function ValidationBadges({
+  validations,
+}: {
+  validations: MechanicClaimValidationDto[];
+}): React.JSX.Element | null {
+  if (!validations || validations.length === 0) return null;
+  return (
+    <span className="flex flex-wrap gap-1" data-testid="claim-validation-badges">
+      {validations.map(v => (
+        <Badge
+          key={v.rule}
+          variant="outline"
+          className={VALIDATION_BADGE_CLASS[v.outcome] ?? VALIDATION_BADGE_CLASS.notRun}
+          data-testid={`claim-validation-badge-${v.rule}`}
+          aria-label={`${v.rule} ${v.outcome}${v.message ? `: ${v.message}` : ''}`}
+          title={v.message ?? `${v.rule} ${v.outcome}`}
+        >
+          {v.outcome === 'pass' ? '✓' : v.outcome === 'fail' ? '✗' : '—'} {v.rule}
+        </Badge>
+      ))}
+    </span>
+  );
+}
 
 interface ClaimsSectionProps {
   analysisId: string;
@@ -407,6 +443,7 @@ function ClaimRow({
           )}
         </div>
         <div className="flex flex-shrink-0 flex-wrap items-center gap-2">
+          <ValidationBadges validations={claim.validations} />
           <Badge
             variant="outline"
             className={CLAIM_STATUS_BADGE_CLASS[status] ?? ''}
@@ -461,10 +498,8 @@ function ClaimRow({
             <ul className="mt-1 space-y-1 border-l-2 border-sky-200 pl-3 text-xs">
               {claim.citations.map(c => (
                 <li key={c.id} className="text-muted-foreground">
-                  <span className="font-medium text-foreground">
-                    p.{c.pdfPage}
-                  </span>{' '}
-                  — &ldquo;{c.quote}&rdquo;
+                  <span className="font-medium text-foreground">p.{c.pdfPage}</span> — &ldquo;
+                  {c.quote}&rdquo;
                 </li>
               ))}
             </ul>

--- a/apps/web/src/components/admin/mechanic-extractor/claims/ClaimsSection.tsx
+++ b/apps/web/src/components/admin/mechanic-extractor/claims/ClaimsSection.tsx
@@ -41,6 +41,7 @@ import {
   type MechanicClaimValidationDto,
 } from '@/lib/api/schemas/mechanic-analyses.schemas';
 
+import { ApproveClaimDialog } from './ApproveClaimDialog';
 import { BulkActionDialog } from './BulkActionDialog';
 import { RejectClaimDialog } from './RejectClaimDialog';
 
@@ -133,6 +134,7 @@ export function ClaimsSection({
   // Separate channel for success-with-skipped (amber) so we don't conflate it
   // with hard failures (rose) — spec-panel P1 fix.
   const [actionWarning, setActionWarning] = useState<string | null>(null);
+  const [approveTarget, setApproveTarget] = useState<MechanicClaimDto | null>(null);
   const [rejectTarget, setRejectTarget] = useState<MechanicClaimDto | null>(null);
   const [pendingClaimId, setPendingClaimId] = useState<string | null>(null);
   const [citationTarget, setCitationTarget] = useState<CitationTarget | null>(null);
@@ -182,11 +184,13 @@ export function ClaimsSection({
   };
 
   const approveMutation = useMutation({
-    mutationFn: (claimId: string) => adminClient.approveMechanicClaim(analysisId, claimId),
-    onMutate: claimId => setPendingClaimId(claimId),
+    mutationFn: ({ claimId, note }: { claimId: string; note?: string }) =>
+      adminClient.approveMechanicClaim(analysisId, claimId, note || undefined),
+    onMutate: ({ claimId }) => setPendingClaimId(claimId),
     onSuccess: () => {
       setActionError(null);
       setActionWarning(null);
+      setApproveTarget(null);
       invalidateClaimsAndStatus();
     },
     onError: (err: unknown) => {
@@ -387,12 +391,25 @@ export function ClaimsSection({
             isActionable={isClaimsActionable}
             pendingClaimId={pendingClaimId}
             pdfDocumentId={pdfDocumentId}
-            onApprove={id => approveMutation.mutate(id)}
+            onApprove={claim => setApproveTarget(claim)}
             onReject={claim => setRejectTarget(claim)}
             onOpenCitation={setCitationTarget}
           />
         ))}
       </div>
+
+      <ApproveClaimDialog
+        open={!!approveTarget}
+        onOpenChange={open => {
+          if (!open) setApproveTarget(null);
+        }}
+        onConfirm={note => {
+          if (!approveTarget) return;
+          approveMutation.mutate({ claimId: approveTarget.id, note });
+        }}
+        isPending={approveMutation.isPending}
+        claimPreview={approveTarget ? truncate(approveTarget.text, 120) : undefined}
+      />
 
       <RejectClaimDialog
         open={!!rejectTarget}
@@ -439,7 +456,7 @@ interface SectionGroupProps {
   isActionable: boolean;
   pendingClaimId: string | null;
   pdfDocumentId?: string;
-  onApprove: (claimId: string) => void;
+  onApprove: (claim: MechanicClaimDto) => void;
   onReject: (claim: MechanicClaimDto) => void;
   onOpenCitation: (target: CitationTarget) => void;
 }
@@ -489,7 +506,7 @@ function SectionGroup({
               isActionable={isActionable}
               isPending={pendingClaimId === claim.id}
               pdfDocumentId={pdfDocumentId}
-              onApprove={() => onApprove(claim.id)}
+              onApprove={() => onApprove(claim)}
               onReject={() => onReject(claim)}
               onOpenCitation={onOpenCitation}
             />
@@ -562,6 +579,14 @@ function ClaimRow({
               data-testid={`claim-rejection-note-${claim.id}`}
             >
               <strong>Rejection:</strong> {claim.rejectionNote}
+            </p>
+          )}
+          {claim.reviewNote && (
+            <p
+              className="mt-1 rounded border border-green-200 bg-green-50 p-1 text-xs text-green-800 break-words"
+              data-testid={`claim-review-note-${claim.id}`}
+            >
+              <strong>Note:</strong> {claim.reviewNote}
             </p>
           )}
         </div>

--- a/apps/web/src/components/admin/mechanic-extractor/claims/__tests__/ClaimsSection.approveNote.test.tsx
+++ b/apps/web/src/components/admin/mechanic-extractor/claims/__tests__/ClaimsSection.approveNote.test.tsx
@@ -1,0 +1,67 @@
+/** @vitest-environment jsdom */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+const mockGetClaims = vi.hoisted(() => vi.fn());
+const mockApprove = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/api/clients/adminClient', () => ({
+  createAdminClient: () => ({
+    getMechanicAnalysisClaims: mockGetClaims,
+    approveMechanicClaim: mockApprove,
+  }),
+}));
+const MockHttpClient = vi.hoisted(() => class MockHttpClient {});
+vi.mock('@/lib/api/core/httpClient', () => ({ HttpClient: MockHttpClient }));
+
+import { ClaimsSection } from '../ClaimsSection';
+
+const claim = {
+  id: 'd1',
+  analysisId: 'a',
+  section: 1,
+  text: 't',
+  displayOrder: 0,
+  status: 0,
+  reviewedBy: null,
+  reviewedAt: null,
+  rejectionNote: null,
+  reviewNote: null,
+  validations: [],
+  citations: [],
+};
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+
+describe('ClaimsSection approve with note', () => {
+  it('sends the optional note on approve', async () => {
+    mockGetClaims.mockResolvedValue([claim]);
+    mockApprove.mockResolvedValue({ ...claim, status: 1, reviewNote: 'matches p.4' });
+    render(<ClaimsSection analysisId="a" />, { wrapper: Wrapper });
+    fireEvent.click(await screen.findByTestId('claim-approve-d1'));
+    fireEvent.change(screen.getByTestId('approve-claim-note-input'), {
+      target: { value: 'matches p.4' },
+    });
+    fireEvent.click(screen.getByTestId('approve-claim-confirm'));
+    await waitFor(() => expect(mockApprove).toHaveBeenCalledWith('a', 'd1', 'matches p.4'));
+  });
+
+  it('allows confirming with no note (note is optional)', async () => {
+    mockGetClaims.mockResolvedValue([claim]);
+    mockApprove.mockResolvedValue({ ...claim, status: 1, reviewNote: null });
+    render(<ClaimsSection analysisId="a" />, { wrapper: Wrapper });
+    fireEvent.click(await screen.findByTestId('claim-approve-d1'));
+    expect(screen.getByTestId('approve-claim-confirm')).not.toBeDisabled();
+    fireEvent.click(screen.getByTestId('approve-claim-confirm'));
+    await waitFor(() => expect(mockApprove).toHaveBeenCalledWith('a', 'd1', undefined));
+  });
+
+  it('renders the reviewNote in a green block after refetch', async () => {
+    mockGetClaims.mockResolvedValue([{ ...claim, status: 1, reviewNote: 'matches p.4' }]);
+    render(<ClaimsSection analysisId="a" />, { wrapper: Wrapper });
+    expect(await screen.findByTestId('claim-review-note-d1')).toHaveTextContent('matches p.4');
+  });
+});

--- a/apps/web/src/components/admin/mechanic-extractor/claims/__tests__/ClaimsSection.approveNote.test.tsx
+++ b/apps/web/src/components/admin/mechanic-extractor/claims/__tests__/ClaimsSection.approveNote.test.tsx
@@ -42,6 +42,7 @@ describe('ClaimsSection approve with note', () => {
     mockApprove.mockResolvedValue({ ...claim, status: 1, reviewNote: 'matches p.4' });
     render(<ClaimsSection analysisId="a" />, { wrapper: Wrapper });
     fireEvent.click(await screen.findByTestId('claim-approve-d1'));
+    expect(screen.getByTestId('approve-claim-note-input')).toHaveAttribute('maxLength', '2000');
     fireEvent.change(screen.getByTestId('approve-claim-note-input'), {
       target: { value: 'matches p.4' },
     });

--- a/apps/web/src/components/admin/mechanic-extractor/claims/__tests__/ClaimsSection.badges.test.tsx
+++ b/apps/web/src/components/admin/mechanic-extractor/claims/__tests__/ClaimsSection.badges.test.tsx
@@ -1,0 +1,36 @@
+/** @vitest-environment jsdom */
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { ValidationBadges } from '../ClaimsSection';
+
+describe('ValidationBadges', () => {
+  it('renders one badge per rule with pass/fail/notRun styling + aria-label', () => {
+    render(
+      <ValidationBadges
+        validations={[
+          { rule: 'T1', outcome: 'pass', message: null },
+          { rule: 'T2', outcome: 'fail', message: 'too long' },
+          { rule: 'T3', outcome: 'notRun', message: null },
+        ]}
+      />
+    );
+    expect(screen.getByTestId('claim-validation-badge-T1')).toHaveAttribute(
+      'aria-label',
+      expect.stringMatching(/T1.*pass/i)
+    );
+    expect(screen.getByTestId('claim-validation-badge-T2')).toHaveAttribute(
+      'aria-label',
+      expect.stringMatching(/T2.*fail/i)
+    );
+    expect(screen.getByTestId('claim-validation-badge-T3')).toHaveAttribute(
+      'aria-label',
+      expect.stringMatching(/T3.*not/i)
+    );
+  });
+
+  it('returns null when validations is empty', () => {
+    const { container } = render(<ValidationBadges validations={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/apps/web/src/components/admin/mechanic-extractor/claims/__tests__/ClaimsSection.bulk.test.tsx
+++ b/apps/web/src/components/admin/mechanic-extractor/claims/__tests__/ClaimsSection.bulk.test.tsx
@@ -1,0 +1,113 @@
+/** @vitest-environment jsdom */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, fireEvent, within, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+const mockGetClaims = vi.hoisted(() => vi.fn());
+const mockBulkApprove = vi.hoisted(() => vi.fn());
+const mockBulkReject = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/api/clients/adminClient', () => ({
+  createAdminClient: () => ({
+    getMechanicAnalysisClaims: mockGetClaims,
+    bulkApproveMechanicClaims: mockBulkApprove,
+    bulkRejectMechanicClaims: mockBulkReject,
+  }),
+}));
+const MockHttpClient = vi.hoisted(() => class MockHttpClient {});
+vi.mock('@/lib/api/core/httpClient', () => ({ HttpClient: MockHttpClient }));
+
+import { ClaimsSection } from '../ClaimsSection';
+
+const longQuote = Array.from({ length: 25 }, (_, i) => `w${i}`).join(' ');
+const claims = [
+  {
+    id: 'd1',
+    analysisId: 'a',
+    section: 1,
+    text: 't1',
+    displayOrder: 0,
+    status: 0,
+    reviewedBy: null,
+    reviewedAt: null,
+    rejectionNote: null,
+    reviewNote: null,
+    validations: [],
+    citations: [{ id: 'c1', pdfPage: 1, quote: longQuote, displayOrder: 0 }],
+  },
+  {
+    id: 'd2',
+    analysisId: 'a',
+    section: 1,
+    text: 't2',
+    displayOrder: 1,
+    status: 0,
+    reviewedBy: null,
+    reviewedAt: null,
+    rejectionNote: null,
+    reviewNote: null,
+    validations: [],
+    citations: [{ id: 'c2', pdfPage: 1, quote: 'short quote', displayOrder: 0 }],
+  },
+];
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+
+describe('ClaimsSection bulk reject by quote length', () => {
+  it('rejects only the >20-word-quote claim after count-confirm', async () => {
+    mockGetClaims.mockResolvedValue(claims);
+    mockBulkReject.mockResolvedValue({ rejectedCount: 1, skippedAlreadyRejectedCount: 0, claims });
+    render(<ClaimsSection analysisId="a" />, { wrapper: Wrapper });
+
+    const select = await screen.findByTestId('bulk-action-select');
+    fireEvent.click(select);
+    const listbox = await screen.findByRole('listbox');
+    fireEvent.click(within(listbox).getByText(/Reject all with quote >20 words/));
+
+    expect(screen.getByTestId('bulk-action-count')).toHaveTextContent('1');
+    fireEvent.click(screen.getByTestId('bulk-action-confirm'));
+
+    await waitFor(() =>
+      expect(mockBulkReject).toHaveBeenCalledWith(
+        'a',
+        expect.objectContaining({ claimIds: ['d1'] })
+      )
+    );
+  });
+
+  it('shows amber warning when bulk-reject skips already-rejected claims', async () => {
+    mockGetClaims.mockResolvedValue(claims);
+    mockBulkReject.mockResolvedValue({
+      rejectedCount: 1,
+      skippedAlreadyRejectedCount: 1,
+      claims,
+    });
+    render(<ClaimsSection analysisId="a" />, { wrapper: Wrapper });
+
+    const select = await screen.findByTestId('bulk-action-select');
+    fireEvent.click(select);
+    const listbox = await screen.findByRole('listbox');
+    fireEvent.click(within(listbox).getByText(/Reject all with quote >20 words/));
+    fireEvent.click(screen.getByTestId('bulk-action-confirm'));
+
+    expect(await screen.findByTestId('claims-action-warning')).toHaveTextContent(/1/);
+  });
+
+  it('approve-pending option calls the existing bulk-approve mutation', async () => {
+    mockGetClaims.mockResolvedValue(claims);
+    mockBulkApprove.mockResolvedValue({ approvedCount: 2, skippedRejectedCount: 0, claims });
+    render(<ClaimsSection analysisId="a" />, { wrapper: Wrapper });
+
+    const select = await screen.findByTestId('bulk-action-select');
+    fireEvent.click(select);
+    const listbox = await screen.findByRole('listbox');
+    fireEvent.click(within(listbox).getByText(/Approve all pending/));
+
+    expect(screen.getByTestId('bulk-action-count')).toHaveTextContent('2');
+    fireEvent.click(screen.getByTestId('bulk-action-confirm'));
+
+    await waitFor(() => expect(mockBulkApprove).toHaveBeenCalledWith('a'));
+  });
+});

--- a/apps/web/src/components/admin/mechanic-extractor/claims/__tests__/ClaimsSection.citation.test.tsx
+++ b/apps/web/src/components/admin/mechanic-extractor/claims/__tests__/ClaimsSection.citation.test.tsx
@@ -1,0 +1,66 @@
+/** @vitest-environment jsdom */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+const mockGetClaims = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/api/clients/adminClient', () => ({
+  createAdminClient: () => ({ getMechanicAnalysisClaims: mockGetClaims }),
+}));
+const MockHttpClient = vi.hoisted(() => class MockHttpClient {});
+vi.mock('@/lib/api/core/httpClient', () => ({ HttpClient: MockHttpClient }));
+const mockHighlighter = vi.hoisted(() => vi.fn());
+vi.mock('@/components/pdf/PdfQuoteHighlighter', () => ({
+  PdfQuoteHighlighter: (props: Record<string, unknown>) => {
+    mockHighlighter(props);
+    return props.open ? <div data-testid="highlighter-open" /> : null;
+  },
+}));
+
+import { ClaimsSection } from '../ClaimsSection';
+
+const claim = {
+  id: 'dddddddd-dddd-4ddd-8ddd-dddddddddddd',
+  analysisId: 'a',
+  section: 1,
+  text: 't',
+  displayOrder: 0,
+  status: 0,
+  reviewedBy: null,
+  reviewedAt: null,
+  rejectionNote: null,
+  reviewNote: null,
+  validations: [],
+  citations: [{ id: 'c1', pdfPage: 4, quote: 'score one point', displayOrder: 0 }],
+};
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+
+describe('ClaimsSection citation viewer', () => {
+  it('opens PdfQuoteHighlighter with documentId/page/quote on citation click', async () => {
+    mockGetClaims.mockResolvedValue([claim]);
+    render(<ClaimsSection analysisId="a" pdfDocumentId="pdf-99" />, { wrapper: Wrapper });
+    // expand citations then click
+    fireEvent.click(await screen.findByTestId(`claim-citations-toggle-${claim.id}`));
+    fireEvent.click(screen.getByTestId('claim-citation-open-c1'));
+    expect(mockHighlighter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        documentId: 'pdf-99',
+        page: 4,
+        quote: 'score one point',
+        open: true,
+      })
+    );
+  });
+
+  it('renders citations as plain text (no button) when pdfDocumentId is absent', async () => {
+    mockGetClaims.mockResolvedValue([claim]);
+    render(<ClaimsSection analysisId="a" />, { wrapper: Wrapper });
+    fireEvent.click(await screen.findByTestId(`claim-citations-toggle-${claim.id}`));
+    expect(screen.queryByTestId('claim-citation-open-c1')).not.toBeInTheDocument();
+    expect(screen.getByText(/score one point/)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/pdf/PdfInlineViewer.tsx
+++ b/apps/web/src/components/pdf/PdfInlineViewer.tsx
@@ -22,6 +22,7 @@ import {
   useState,
   useEffect,
   useCallback,
+  useMemo,
   useRef,
   type ChangeEvent,
   type FormEvent,
@@ -34,6 +35,8 @@ import 'react-pdf/dist/Page/AnnotationLayer.css';
 import 'react-pdf/dist/Page/TextLayer.css';
 
 import { api } from '@/lib/api';
+
+import { makeQuoteTextRenderer } from './pdf-quote-highlight';
 
 // Worker setup — T0 spike confirmed idempotent (multi-module assignment safe).
 pdfjs.GlobalWorkerOptions.workerSrc = new URL(
@@ -55,6 +58,9 @@ export interface PdfInlineViewerProps {
   readonly defaultZoom?: 'fit-width' | number;
   readonly features?: PdfInlineViewerFeatures;
   readonly className?: string;
+  readonly renderTextLayer?: boolean;
+  readonly highlightQuote?: string;
+  readonly onQuoteMatch?: (found: boolean) => void;
 }
 
 type ZoomState = 'fit-width' | number;
@@ -69,6 +75,9 @@ export function PdfInlineViewer({
   defaultZoom = 'fit-width',
   features = {},
   className,
+  renderTextLayer = false,
+  highlightQuote,
+  onQuoteMatch,
 }: PdfInlineViewerProps): ReactElement {
   const [numPages, setNumPages] = useState<number>(0);
   const [currentPage, setCurrentPage] = useState<number>(initialPage);
@@ -81,6 +90,11 @@ export function PdfInlineViewer({
   const containerRef = useRef<HTMLDivElement>(null);
 
   const downloadUrl = api.pdf.getPdfDownloadUrl(documentId);
+
+  const quoteRenderer = useMemo(
+    () => (highlightQuote ? makeQuoteTextRenderer(highlightQuote) : null),
+    [highlightQuote]
+  );
 
   const onDocumentLoadSuccess = useCallback(({ numPages: n }: { numPages: number }) => {
     setNumPages(n);
@@ -291,7 +305,15 @@ export function PdfInlineViewer({
               pageNumber={currentPage}
               scale={scale}
               renderAnnotationLayer={false}
-              renderTextLayer={false}
+              renderTextLayer={renderTextLayer || !!highlightQuote}
+              customTextRenderer={
+                quoteRenderer ? ({ str }) => quoteRenderer.render({ str }) : undefined
+              }
+              onRenderTextLayerSuccess={
+                quoteRenderer && onQuoteMatch
+                  ? () => onQuoteMatch(quoteRenderer.matched())
+                  : undefined
+              }
             />
           </Document>
         )}

--- a/apps/web/src/components/pdf/PdfQuoteHighlighter.tsx
+++ b/apps/web/src/components/pdf/PdfQuoteHighlighter.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/overlays/dialog';
+
+import { PdfInlineViewer } from './PdfInlineViewer';
+
+export interface PdfQuoteHighlighterProps {
+  readonly open: boolean;
+  readonly onOpenChange: (open: boolean) => void;
+  readonly documentId: string;
+  readonly page: number;
+  readonly quote: string;
+}
+
+/**
+ * #526 AC-2 / #530 AD-1 — shared citation quote viewer. Opens the source PDF at `page`, highlights
+ * `quote` via PdfInlineViewer's text-layer search (Pattern A), and shows a page-level fallback
+ * banner when the quote can't be located automatically. Consumed by admin review (#526) and,
+ * later, #528 public card + #530 chat citations.
+ */
+export function PdfQuoteHighlighter({
+  open,
+  onOpenChange,
+  documentId,
+  page,
+  quote,
+}: PdfQuoteHighlighterProps): React.JSX.Element {
+  const [matched, setMatched] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    if (open) setMatched(null); // reset per open
+  }, [open, documentId, page, quote]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-4xl">
+        <DialogHeader>
+          <DialogTitle>Citazione — p.{page}</DialogTitle>
+        </DialogHeader>
+        {matched === false && (
+          <div
+            className="rounded-md border border-amber-300 bg-amber-50 p-2 text-xs text-amber-900"
+            role="status"
+            data-testid="pdf-quote-fallback"
+          >
+            Quote non individuabile automaticamente a p.{page}; verifica manualmente.
+          </div>
+        )}
+        <div className="max-h-[70vh] overflow-auto">
+          <PdfInlineViewer
+            documentId={documentId}
+            initialPage={page}
+            highlightQuote={quote}
+            onQuoteMatch={setMatched}
+            features={{ jumpToPage: true, zoom: true }}
+          />
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/pdf/__tests__/PdfQuoteHighlighter.test.tsx
+++ b/apps/web/src/components/pdf/__tests__/PdfQuoteHighlighter.test.tsx
@@ -1,0 +1,20 @@
+/** @vitest-environment jsdom */
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../PdfInlineViewer', () => ({
+  PdfInlineViewer: ({ onQuoteMatch }: { onQuoteMatch?: (f: boolean) => void }) => {
+    onQuoteMatch?.(false); // simulate "not found" → banner should show
+    return <div data-testid="pdf-inline-viewer" />;
+  },
+}));
+
+import { PdfQuoteHighlighter } from '../PdfQuoteHighlighter';
+
+describe('PdfQuoteHighlighter', () => {
+  it('shows the fallback banner when the quote is not matched', () => {
+    render(<PdfQuoteHighlighter open onOpenChange={() => {}} documentId="d1" page={4} quote="x" />);
+    expect(screen.getByTestId('pdf-inline-viewer')).toBeInTheDocument();
+    expect(screen.getByTestId('pdf-quote-fallback')).toHaveTextContent(/verifica manualmente/i);
+  });
+});

--- a/apps/web/src/components/pdf/__tests__/pdf-quote-highlight.test.ts
+++ b/apps/web/src/components/pdf/__tests__/pdf-quote-highlight.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeQuoteText, makeQuoteTextRenderer } from '../pdf-quote-highlight';
+
+describe('pdf-quote-highlight', () => {
+  it('normalizes whitespace, soft hyphens, case', () => {
+    expect(normalizeQuoteText('Score  1­point\nper  Road')).toBe('score 1point per road');
+  });
+
+  it('wraps text items contained in the quote and reports a match', () => {
+    const r = makeQuoteTextRenderer('players score one point per road');
+    expect(r.render({ str: 'score one point' })).toContain('<mark');
+    expect(r.render({ str: 'per road' })).toContain('<mark');
+    expect(r.matched()).toBe(true);
+  });
+
+  it('escapes HTML and does not wrap non-quote items', () => {
+    const r = makeQuoteTextRenderer('players score one point');
+    expect(r.render({ str: '<b>bonus</b>' })).toBe('&lt;b&gt;bonus&lt;/b&gt;');
+    expect(r.matched()).toBe(false);
+  });
+
+  it('ignores trivially short items to reduce false positives', () => {
+    const r = makeQuoteTextRenderer('a player scores one point');
+    expect(r.render({ str: 'a' })).toBe('a'); // len<=2 not wrapped
+  });
+});

--- a/apps/web/src/components/pdf/pdf-quote-highlight.ts
+++ b/apps/web/src/components/pdf/pdf-quote-highlight.ts
@@ -1,0 +1,37 @@
+/** Normalize for tolerant substring matching: lowercase, strip soft hyphens, collapse whitespace. */
+export function normalizeQuoteText(s: string): string {
+  return s.replace(/­/g, '').toLowerCase().replace(/\s+/g, ' ').trim();
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+/**
+ * Best-effort per-item highlighter for react-pdf `customTextRenderer` (AC-2 Pattern A).
+ * A text item is wrapped in <mark> when its normalized string (len>2) is a substring of the
+ * normalized quote. Imperfect for very common short items — the caller shows a fallback banner
+ * via `matched()`. FU could upgrade to contiguous-run matching or Pattern-B coordinates.
+ */
+export function makeQuoteTextRenderer(quote: string): {
+  render: (item: { str: string }) => string;
+  matched: () => boolean;
+} {
+  const normQuote = normalizeQuoteText(quote);
+  let didMatch = false;
+  return {
+    render: ({ str }) => {
+      const norm = normalizeQuoteText(str);
+      if (norm.length > 2 && normQuote.includes(norm)) {
+        didMatch = true;
+        return `<mark class="pdf-quote-highlight">${escapeHtml(str)}</mark>`;
+      }
+      return escapeHtml(str);
+    },
+    matched: () => didMatch,
+  };
+}

--- a/apps/web/src/lib/api/clients/admin/adminContentClient.ts
+++ b/apps/web/src/lib/api/clients/admin/adminContentClient.ts
@@ -47,6 +47,7 @@ import {
 } from '../../schemas/entity-link.schemas';
 import {
   BulkApproveMechanicClaimsResponseDtoSchema,
+  BulkRejectMechanicClaimsResponseDtoSchema,
   MechanicAnalysisGenerationResponseDtoSchema,
   MechanicAnalysisLifecycleResponseDtoSchema,
   MechanicAnalysisListPageDtoSchema,
@@ -55,6 +56,8 @@ import {
   MechanicClaimsListSchema,
   MECHANIC_ANALYSES_ROUTES,
   type BulkApproveMechanicClaimsResponseDto,
+  type BulkRejectMechanicClaimsRequest,
+  type BulkRejectMechanicClaimsResponseDto,
   type GenerateMechanicAnalysisRequest,
   type MechanicAnalysisGenerationResponseDto,
   type MechanicAnalysisLifecycleResponseDto,
@@ -622,10 +625,14 @@ export function createAdminContentClient(http: HttpClient) {
       return result ?? [];
     },
 
-    async approveMechanicClaim(analysisId: string, claimId: string): Promise<MechanicClaimDto> {
+    async approveMechanicClaim(
+      analysisId: string,
+      claimId: string,
+      note?: string
+    ): Promise<MechanicClaimDto> {
       const result = await http.post(
         MECHANIC_ANALYSES_ROUTES.approveClaim(analysisId, claimId),
-        {},
+        note !== undefined ? { note } : {},
         MechanicClaimDtoSchema
       );
       if (!result) throw new Error('Failed to approve claim');
@@ -655,6 +662,19 @@ export function createAdminContentClient(http: HttpClient) {
         BulkApproveMechanicClaimsResponseDtoSchema
       );
       if (!result) throw new Error('Failed to bulk-approve claims');
+      return result;
+    },
+
+    async bulkRejectMechanicClaims(
+      analysisId: string,
+      request: BulkRejectMechanicClaimsRequest
+    ): Promise<BulkRejectMechanicClaimsResponseDto> {
+      const result = await http.post(
+        MECHANIC_ANALYSES_ROUTES.bulkRejectClaims(analysisId),
+        request,
+        BulkRejectMechanicClaimsResponseDtoSchema
+      );
+      if (!result) throw new Error('Failed to bulk-reject claims');
       return result;
     },
 

--- a/apps/web/src/lib/api/schemas/__tests__/mechanic-analyses.schemas.test.ts
+++ b/apps/web/src/lib/api/schemas/__tests__/mechanic-analyses.schemas.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import {
+  MechanicClaimDtoSchema,
+  BulkRejectMechanicClaimsResponseDtoSchema,
+} from '../mechanic-analyses.schemas';
+
+describe('mechanic-analyses schemas #526', () => {
+  it('parses validations[] + reviewNote on a claim', () => {
+    const parsed = MechanicClaimDtoSchema.parse({
+      id: '11111111-1111-4111-8111-111111111111',
+      analysisId: '22222222-2222-4222-8222-222222222222',
+      section: 1,
+      text: 't',
+      displayOrder: 0,
+      status: 0,
+      reviewedBy: null,
+      reviewedAt: null,
+      rejectionNote: null,
+      reviewNote: null,
+      citations: [],
+      validations: [{ rule: 'T1', outcome: 'pass', message: null }],
+    });
+    expect(parsed.validations[0].rule).toBe('T1');
+  });
+
+  it('parses bulk-reject response', () => {
+    const r = BulkRejectMechanicClaimsResponseDtoSchema.parse({
+      rejectedCount: 2,
+      skippedAlreadyRejectedCount: 0,
+      claims: [],
+    });
+    expect(r.rejectedCount).toBe(2);
+  });
+});

--- a/apps/web/src/lib/api/schemas/mechanic-analyses.schemas.ts
+++ b/apps/web/src/lib/api/schemas/mechanic-analyses.schemas.ts
@@ -233,6 +233,14 @@ export const MechanicCitationDtoSchema = z.object({
 });
 export type MechanicCitationDto = z.infer<typeof MechanicCitationDtoSchema>;
 
+/** Per-rule template validation outcome (#526 ME-M1.4). Currently always T1-T4, derived server-side. */
+export const MechanicClaimValidationDtoSchema = z.object({
+  rule: z.string(),
+  outcome: z.enum(['pass', 'fail', 'notRun']),
+  message: z.string().nullable().optional(),
+});
+export type MechanicClaimValidationDto = z.infer<typeof MechanicClaimValidationDtoSchema>;
+
 export const MechanicClaimDtoSchema = z.object({
   id: z.string().uuid(),
   analysisId: z.string().uuid(),
@@ -244,6 +252,8 @@ export const MechanicClaimDtoSchema = z.object({
   reviewedAt: z.string().nullable(),
   rejectionNote: z.string().nullable(),
   citations: z.array(MechanicCitationDtoSchema),
+  reviewNote: z.string().nullable(),
+  validations: z.array(MechanicClaimValidationDtoSchema),
 });
 export type MechanicClaimDto = z.infer<typeof MechanicClaimDtoSchema>;
 
@@ -288,6 +298,21 @@ export const BulkApproveMechanicClaimsResponseDtoSchema = z.object({
 export type BulkApproveMechanicClaimsResponseDto = z.infer<
   typeof BulkApproveMechanicClaimsResponseDtoSchema
 >;
+
+export const BulkRejectMechanicClaimsResponseDtoSchema = z.object({
+  rejectedCount: z.number().int(),
+  skippedAlreadyRejectedCount: z.number().int(),
+  claims: MechanicClaimsListSchema,
+});
+export type BulkRejectMechanicClaimsResponseDto = z.infer<
+  typeof BulkRejectMechanicClaimsResponseDtoSchema
+>;
+
+/** Body for `POST .../claims/bulk-reject` (#526). Reviewer id comes from the session. */
+export interface BulkRejectMechanicClaimsRequest {
+  claimIds: string[];
+  reason: string;
+}
 
 // ========== Request types ==========
 
@@ -350,6 +375,7 @@ export const MECHANIC_ANALYSES_ROUTES = {
   rejectClaim: (id: string, claimId: string) =>
     `/api/v1/admin/mechanic-analyses/${id}/claims/${claimId}/reject`,
   bulkApproveClaims: (id: string) => `/api/v1/admin/mechanic-analyses/${id}/claims/bulk-approve`,
+  bulkRejectClaims: (id: string) => `/api/v1/admin/mechanic-analyses/${id}/claims/bulk-reject`,
 } as const;
 
 export const MECHANIC_ANALYSES_PAGES = {

--- a/apps/web/src/lib/api/schemas/mechanic-analyses.schemas.ts
+++ b/apps/web/src/lib/api/schemas/mechanic-analyses.schemas.ts
@@ -343,6 +343,13 @@ export interface RejectMechanicClaimRequest {
 export const REJECT_CLAIM_NOTE_MIN_LENGTH = 1;
 export const REJECT_CLAIM_NOTE_MAX_LENGTH = 500;
 
+/**
+ * Local validation bound for the (optional) approve reviewer note. Mirrors
+ * `ApproveMechanicClaimCommandValidator.MaximumLength(2000)` and the
+ * `review_note` column (`varchar(2000)`).
+ */
+export const APPROVE_CLAIM_NOTE_MAX_LENGTH = 2000;
+
 // ========== Labels ==========
 
 export const MECHANIC_ANALYSIS_STATUS_LABELS: Record<number, string> = {

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -864,3 +864,12 @@
   max-width: 65ch;
   margin-inline: auto;
 }
+
+/* ============================================================================
+ * PdfInlineViewer — opt-in quote highlight (ME-M1.4 AC-2 base, #526)
+ * Marks text-layer spans matching a `highlightQuote` via customTextRenderer.
+ * ============================================================================ */
+
+.pdf-quote-highlight {
+  background-color: rgba(255, 235, 59, 0.4);
+}

--- a/docs/superpowers/plans/2026-07-08-issue-526-me-m14-admin-review-core.md
+++ b/docs/superpowers/plans/2026-07-08-issue-526-me-m14-admin-review-core.md
@@ -1,0 +1,1380 @@
+# #526 ME-M1.4 Admin Review UI (core iteration) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Complete the core of the Mechanic Extractor admin review UI (#526): T1–T4 guardrail badges (derived), a PDF citation quote-highlighter, bulk-reject-by-predicate, the ADR-051 footer swap, an approve-with-note MVP, one observability counter, a11y, and tests — plus a `validations[]` DTO contract that unblocks #527.
+
+**Architecture:** The backend already ships the bulk-reject endpoint + analysis lifecycle. This plan adds a derived `validations[]` field to the claim read-model, a nullable `review_note` column, one metric, and wires the frontend `ClaimsSection` (badges, citation viewer, bulk dropdown, approve-note) plus two new components (`PdfQuoteHighlighter`, `MechanicAnalysisFooterAttribution`). Real per-claim validation persistence (AC-1) and analysis-finalize reconciliation with #527 (AC-4) are OUT — deferred to follow-ups FU-1 / FU-2.
+
+**Tech Stack:** .NET 9 (Minimal APIs + MediatR + EF Core + FluentValidation), Next.js 16 (React 19, Zod, React Query, shadcn primitives), react-pdf@10.4.1 + pdfjs-dist@5.7.284, Vitest + Playwright + xUnit/Moq.
+
+**Design spec:** `docs/superpowers/specs/2026-07-08-issue-526-me-m14-admin-review-core-design.md`
+
+## Global Constraints
+
+- **Branch:** `feature/issue-526-me-m14-admin-review-ui` (parent `main-dev`). Push with `git push -u origin feature/issue-526-me-m14-admin-review-ui`.
+- **CQRS:** endpoints call only `IMediator.Send()`. Exceptions: `ConflictException`(409), `NotFoundException`(404) — never `InvalidOperationException`(500).
+- **EF:** explicit `HasColumnName("snake_case")` — no auto snake_case. LiveSession-style handlers `AddAsync`/`Update` MUST be followed by `SaveChangesAsync` (already the case in existing handlers).
+- **Admin FE conventions:** shadcn primitives from `@/components/ui/{primitives,data-display,overlays}/…` (NOT MeepleCard). Keep the file-level `/* eslint-disable local/no-hardcoded-color-utility … DS-13d admin scope */` header on admin files with amber/green/rose class maps — do NOT introduce `--admin-*` tokens. Pervasive `data-testid`. React Query keys `['mechanic-analysis', id, 'claims']`.
+- **Bulk-reject contract (already shipped BE):** `POST /api/v1/admin/mechanic-analyses/{id}/claims/bulk-reject`, body `{ claimIds: Guid[], reason: string }` (reason 1–500 chars), response `{ rejectedCount, skippedAlreadyRejectedCount, claims: MechanicClaimDto[] }`. 404 stale id / 409 not-InReview.
+- **ADR-051 footer string (canonical):** `"Analisi elaborata dall'AI sul manuale del gioco. Ogni affermazione è riformulata in parole originali e cita la pagina del regolamento. Copyright © degli editori per il testo originale del manuale."` The forbidden string to delete lives only at `apps/web/src/app/admin/(dashboard)/knowledge-base/mechanic-extractor/review/page.tsx:277` as entity-encoded `L&apos;AI non ha mai letto il testo del PDF originale.`
+- **Guardrail → badge families:** T1=QuoteCap, T2=RejectionSampling(long-verbatim), T3=Grounding+CitationPresence, T4=PageSubstring.
+- **Test commands:** BE `cd apps/api/src/Api && dotnet test --filter "FullyQualifiedName~<Name>"` (kill testhost first if locked). FE `cd apps/web && pnpm test <path>` / `pnpm typecheck` / `pnpm lint`. E2E `pnpm test:e2e <spec>`.
+
+---
+
+## File map
+
+**Create (backend)**
+- `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/DTOs/MechanicClaimValidationDto.cs` — validation badge DTO + `MechanicClaimValidations.DerivePass()` helper.
+- `apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.MechanicReview.cs` — `MechanicReviewBulkActions` counter.
+- Migration (generated) `…/Migrations/<ts>_AddMechanicClaimReviewNote.cs`.
+- `apps/api/tests/…/MechanicExtractor/MechanicReviewMetricsTests.cs`.
+
+**Modify (backend)**
+- `…/Application/DTOs/MechanicClaimDto.cs` — add `Validations` positional param.
+- `…/Application/Queries/MechanicExtractor/GetMechanicAnalysisClaimsQueryHandler.cs` + every other `new MechanicClaimDto(` site — emit `Validations`.
+- `…/Infrastructure/Entities/SharedGameCatalog/MechanicClaimEntity.cs` + `…/Infrastructure/Configurations/SharedGameCatalog/MechanicClaimEntityConfiguration.cs` — `ReviewNote` / `review_note`.
+- `…/Domain/Entities/MechanicClaim.cs` (`Approve` note) + `…/Domain/Aggregates/MechanicAnalysis.cs` (`ApproveClaim` note) + `…/Application/Commands/MechanicExtractor/ApproveMechanicClaimCommand.cs` + `…Handler.cs` + `…Validator.cs`.
+- `…/Application/Commands/MechanicExtractor/BulkRejectMechanicClaimsCommandHandler.cs` + `BulkApproveMechanicClaimsCommandHandler.cs` — metric increment.
+
+**Create (frontend)**
+- `apps/web/src/components/pdf/PdfQuoteHighlighter.tsx` + `__tests__/PdfQuoteHighlighter.test.tsx`.
+- `apps/web/src/components/pdf/pdf-quote-highlight.ts` — pure normalize/match helper + `__tests__`.
+- `apps/web/src/components/admin/mechanic-extractor/MechanicAnalysisFooterAttribution.tsx` + `__tests__`.
+- `apps/web/src/components/admin/mechanic-extractor/claims/BulkActionDialog.tsx` + `ApproveClaimDialog.tsx`.
+
+**Modify (frontend)**
+- `apps/web/src/lib/api/schemas/mechanic-analyses.schemas.ts` — `MechanicClaimValidationDtoSchema` + `validations` field + `bulkRejectClaims` route + `BulkRejectMechanicClaimsResponseDtoSchema` + `BulkRejectMechanicClaimsRequest`.
+- `apps/web/src/lib/api/clients/admin/adminContentClient.ts` — `bulkRejectMechanicClaims` + optional `note` on `approveMechanicClaim`.
+- `apps/web/src/components/pdf/PdfInlineViewer.tsx` — `renderTextLayer?` + `highlightQuote?` + `onQuoteMatch?` props.
+- `apps/web/src/components/admin/mechanic-extractor/claims/ClaimsSection.tsx` — badges, citation-click, bulk dropdown, approve-note, `pdfDocumentId` prop.
+- `apps/web/src/app/admin/(dashboard)/knowledge-base/mechanic-extractor/analyses/page.tsx` — pass `pdfDocumentId` to `ClaimsSection`.
+- `apps/web/src/app/admin/(dashboard)/knowledge-base/mechanic-extractor/review/page.tsx` — footer swap.
+- `apps/web/e2e/admin-mechanic-extractor-validation/load-existing-analysis.spec.ts` — bulk-reject + citation-open flows.
+
+---
+
+## Task 1: Backend — derived `validations[]` on `MechanicClaimDto`
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/DTOs/MechanicClaimValidationDto.cs`
+- Modify: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/DTOs/MechanicClaimDto.cs`
+- Modify: every `new MechanicClaimDto(` construction site (grep below)
+- Test: `apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/DTOs/MechanicClaimValidationsTests.cs` (create)
+
+**Interfaces:**
+- Produces: `record MechanicClaimValidationDto(string Rule, string Outcome, string? Message = null)`; `static IReadOnlyList<MechanicClaimValidationDto> MechanicClaimValidations.DerivePass()`; `MechanicClaimDto.Validations : IReadOnlyList<MechanicClaimValidationDto>` (last positional param).
+
+- [ ] **Step 1: Write the failing unit test** (pure — no DB) — `MechanicClaimValidationsTests.cs`. The handler wiring is verified by the build (every construction site must compile) + the E2E/existing tests; here we lock the derivation contract:
+
+```csharp
+using Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.DTOs;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public class MechanicClaimValidationsTests
+{
+    [Fact]
+    public void DerivePass_ReturnsFourPassBadges_T1ToT4()
+    {
+        var validations = MechanicClaimValidations.DerivePass();
+
+        validations.Select(v => v.Rule).Should().Equal("T1", "T2", "T3", "T4");
+        validations.Should().OnlyContain(v => v.Outcome == "pass" && v.Message == null);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/api/src/Api && dotnet test --filter "FullyQualifiedName~MechanicClaimValidationsTests" -v minimal`
+Expected: FAIL — `MechanicClaimValidations` / `MechanicClaimValidationDto` do not exist.
+
+- [ ] **Step 3: Create the DTO + derivation helper**
+
+`MechanicClaimValidationDto.cs`:
+```csharp
+namespace Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
+
+/// <summary>
+/// Per-claim guardrail badge outcome (#526 AC-1). Rule ∈ {T1,T2,T3,T4}; Outcome ∈ {pass,fail,notRun}.
+/// </summary>
+/// <remarks>
+/// CORE ITERATION: values are DERIVED, not persisted. Every claim that reaches the review queue
+/// passed its section's guardrails by the pipeline pass-invariant (rejection sampling retries a
+/// section until its output satisfies T1–T4, else aborts to PartiallyExtracted/Rejected), so all
+/// persisted claims are surfaced as <c>pass</c>. FU-1 (#526 follow-up) replaces this with real
+/// per-claim outcomes + scores captured at pipeline time; the <c>fail</c>/<c>notRun</c> states and
+/// <see cref="Message"/> light up then. #527 snapshots this array into <c>mechanic_cards.content</c>.
+/// </remarks>
+public sealed record MechanicClaimValidationDto(string Rule, string Outcome, string? Message = null);
+
+/// <summary>Derivation of the AC-1 badge families for the core iteration.</summary>
+public static class MechanicClaimValidations
+{
+    /// <summary>Badge families, ordered T1→T4 (T3 = grounding + citation-present).</summary>
+    public static readonly IReadOnlyList<string> Families = new[] { "T1", "T2", "T3", "T4" };
+
+    /// <summary>Derived all-pass outcomes (see <see cref="MechanicClaimValidationDto"/> remarks).</summary>
+    public static IReadOnlyList<MechanicClaimValidationDto> DerivePass() =>
+        Families.Select(f => new MechanicClaimValidationDto(f, "pass")).ToList();
+}
+```
+
+- [ ] **Step 4: Add `Validations` to `MechanicClaimDto`** — append as the last positional param (after `Citations`) in `MechanicClaimDto.cs`:
+
+```csharp
+public sealed record MechanicClaimDto(
+    Guid Id,
+    Guid AnalysisId,
+    MechanicSection Section,
+    string Text,
+    int DisplayOrder,
+    MechanicClaimStatus Status,
+    Guid? ReviewedBy,
+    DateTime? ReviewedAt,
+    string? RejectionNote,
+    IReadOnlyList<MechanicCitationDto> Citations,
+    IReadOnlyList<MechanicClaimValidationDto> Validations);
+```
+
+- [ ] **Step 5: Update every construction site.** Find them:
+
+Run: `cd apps/api/src/Api && grep -rn "new MechanicClaimDto(" .`
+For each site (GetMechanicAnalysisClaimsQueryHandler, ApproveMechanicClaimCommandHandler.ToDto, RejectMechanicClaimCommandHandler, BulkApproveMechanicClaimsCommandHandler, BulkRejectMechanicClaimsCommandHandler), add the final argument:
+```csharp
+                    .ToList(),
+            Validations: MechanicClaimValidations.DerivePass()));
+```
+(i.e. after the `Citations: … .ToList()` argument, add `Validations: MechanicClaimValidations.DerivePass()`.)
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `cd apps/api/src/Api && dotnet test --filter "FullyQualifiedName~MechanicClaimValidationsTests" -v minimal`
+Expected: PASS. Then `dotnet build` to confirm all `new MechanicClaimDto(` construction sites compile with the new `Validations` argument.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/DTOs/MechanicClaimValidationDto.cs \
+        apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/DTOs/MechanicClaimDto.cs \
+        "apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/MechanicExtractor/GetMechanicAnalysisClaimsQueryHandler.cs" \
+        "apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/"*Handler.cs \
+        apps/api/tests
+git commit -m "feat(mechanic-extractor): #526 derive T1-T4 validations[] on claim DTO (AC-1 contract)"
+```
+
+---
+
+## Task 2: Backend — `review_note` column (AC-6 storage)
+
+**Files:**
+- Modify: `apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/MechanicClaimEntity.cs`
+- Modify: `apps/api/src/Api/Infrastructure/Configurations/SharedGameCatalog/MechanicClaimEntityConfiguration.cs`
+- Create: migration `AddMechanicClaimReviewNote`
+
+**Interfaces:**
+- Produces: `MechanicClaimEntity.ReviewNote : string?` mapped to nullable `review_note character varying(2000)`.
+
+- [ ] **Step 1: Add the entity property** — after `RejectionNote` in `MechanicClaimEntity.cs`:
+
+```csharp
+    public string? RejectionNote { get; set; }
+
+    /// <summary>Optional free-form note captured on APPROVE (#526 AC-6). Distinct from RejectionNote.</summary>
+    public string? ReviewNote { get; set; }
+```
+
+- [ ] **Step 2: Map the column** — after the `RejectionNote` mapping block in `MechanicClaimEntityConfiguration.cs`:
+
+```csharp
+        builder.Property(c => c.RejectionNote)
+            .HasColumnName("rejection_note")
+            .HasMaxLength(2000);
+
+        builder.Property(c => c.ReviewNote)
+            .HasColumnName("review_note")
+            .HasMaxLength(2000);
+```
+
+- [ ] **Step 3: Generate the migration**
+
+Run: `cd apps/api/src/Api && dotnet ef migrations add AddMechanicClaimReviewNote`
+Expected: a new migration adding `review_note` (`character varying(2000)`, nullable) to `mechanic_claims`.
+
+- [ ] **Step 4: Review the migration SQL.** Open the generated `Up`/`Down`; confirm it is a single additive `AddColumn` (nullable, no default) and `DropColumn` on down. No other tables touched. (Idempotent-terminator lesson #2763: EF-generated `AddColumn` is safe; do not hand-edit.)
+
+- [ ] **Step 5: Apply + verify build**
+
+Run: `cd apps/api/src/Api && dotnet ef database update && dotnet build`
+Expected: migration applies; build succeeds.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/MechanicClaimEntity.cs \
+        apps/api/src/Api/Infrastructure/Configurations/SharedGameCatalog/MechanicClaimEntityConfiguration.cs \
+        apps/api/src/Api/Migrations
+git commit -m "feat(mechanic-extractor): #526 add nullable review_note column (AC-6)"
+```
+
+---
+
+## Task 3: Backend — thread optional approve note
+
+**Files:**
+- Modify: `…/Domain/Entities/MechanicClaim.cs` (`Approve`)
+- Modify: `…/Domain/Aggregates/MechanicAnalysis.cs` (`ApproveClaim`)
+- Modify: `…/Application/Commands/MechanicExtractor/ApproveMechanicClaimCommand.cs`, `…Handler.cs`, `…Validator.cs`
+- Modify: `…/Application/DTOs/MechanicClaimDto.cs` (add `ReviewNote`) + all construction sites
+- Test: `apps/api/tests/…/MechanicExtractor/ApproveMechanicClaimCommandHandlerTests.cs`
+
+**Interfaces:**
+- Consumes: `MechanicClaimValidations.DerivePass()` (Task 1).
+- Produces: `ApproveMechanicClaimCommand(Guid AnalysisId, Guid ClaimId, Guid ReviewerId, string? Note = null)`; `MechanicClaim.Approve(Guid, DateTime, string?)`; `MechanicAnalysis.ApproveClaim(Guid, Guid, DateTime, string?)`; `MechanicClaimDto.ReviewNote : string?`.
+
+- [ ] **Step 1: Write the failing domain test** — in `ApproveMechanicClaimCommandHandlerTests.cs` (mirror the Moq/`BuildInReviewAnalysis` pattern from `BulkRejectMechanicClaimsCommandHandlerTests.cs`):
+
+```csharp
+[Fact]
+public async Task Handle_WithNote_StoresReviewNote()
+{
+    var analysis = BuildInReviewAnalysis(1);
+    var claimId = analysis.Claims.Single().Id;
+    SetupRepo(analysis, analysis.Id);
+
+    var result = await _handler.Handle(
+        new ApproveMechanicClaimCommand(analysis.Id, claimId, Guid.NewGuid(), "looks good, matches p.4"),
+        CancellationToken.None);
+
+    result.Status.Should().Be(MechanicClaimStatus.Approved);
+    result.ReviewNote.Should().Be("looks good, matches p.4");
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd apps/api/src/Api && dotnet test --filter "FullyQualifiedName~ApproveMechanicClaimCommandHandlerTests.Handle_WithNote"`
+Expected: FAIL — `ApproveMechanicClaimCommand` has 3 params / `MechanicClaimDto` has no `ReviewNote`.
+
+- [ ] **Step 3: Entity** — change `MechanicClaim.Approve` (add `ReviewNote` property + note param):
+
+```csharp
+    /// <summary>Optional note captured on approval (#526 AC-6).</summary>
+    public string? ReviewNote { get; private set; }
+
+    internal void Approve(Guid reviewerId, DateTime utcNow, string? note = null)
+    {
+        if (reviewerId == Guid.Empty)
+        {
+            throw new ArgumentException("ReviewerId cannot be empty.", nameof(reviewerId));
+        }
+
+        Status = MechanicClaimStatus.Approved;
+        ReviewedBy = reviewerId;
+        ReviewedAt = utcNow;
+        RejectionNote = null;
+        ReviewNote = string.IsNullOrWhiteSpace(note) ? null : note.Trim();
+    }
+```
+Also add `ReviewNote` to `Reconstitute` (new param + assignment) and set `ReviewNote = null` in `ResetToPending`. Update the `Reconstitute` call site in the repository's `MapToDomain` (grep `Reconstitute(` in `MechanicAnalysisRepository`).
+
+- [ ] **Step 4: Aggregate** — `MechanicAnalysis.ApproveClaim`:
+
+```csharp
+    public void ApproveClaim(Guid claimId, Guid reviewerId, DateTime utcNow, string? note = null)
+    {
+        var claim = RequireClaimUnderReview(claimId, "approve claim");
+        claim.Approve(reviewerId, utcNow, note);
+    }
+```
+
+- [ ] **Step 5: Command + validator + handler**
+
+Command (`ApproveMechanicClaimCommand.cs`):
+```csharp
+internal record ApproveMechanicClaimCommand(
+    Guid AnalysisId,
+    Guid ClaimId,
+    Guid ReviewerId,
+    string? Note = null) : ICommand<MechanicClaimDto>;
+```
+Validator (`ApproveMechanicClaimCommandValidator.cs`, after the ReviewerId rule):
+```csharp
+        RuleFor(c => c.Note)
+            .MaximumLength(2000).WithMessage("Note must be 2000 characters or fewer.")
+            .When(c => c.Note is not null);
+```
+Handler (`ApproveMechanicClaimCommandHandler.cs`, line ~76): `analysis.ApproveClaim(request.ClaimId, request.ReviewerId, utcNow, request.Note);` and in `ToDto` add `ReviewNote: claim.ReviewNote,` after `RejectionNote:`.
+
+- [ ] **Step 6: DTO + entity mapping + all construction sites**
+
+Add `string? ReviewNote` to `MechanicClaimDto` (after `RejectionNote`); in `GetMechanicAnalysisClaimsQueryHandler` projection add `ReviewNote: c.ReviewNote,` (the query reads the `MechanicClaimEntity`, so `c.ReviewNote` resolves after Task 2); repeat for the Reject/BulkApprove/BulkReject projection sites (add `ReviewNote: c.ReviewNote,`). Confirm the entity→domain map (`MechanicClaimEntityConfiguration` already maps the column; the repository `Reconstitute` call must pass `entity.ReviewNote`).
+
+- [ ] **Step 7: Run to verify it passes + build**
+
+Run: `cd apps/api/src/Api && dotnet test --filter "FullyQualifiedName~ApproveMechanicClaimCommandHandlerTests" && dotnet build`
+Expected: PASS + build OK (all `new MechanicClaimDto(` sites compile with `ReviewNote`).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add -A
+git commit -m "feat(mechanic-extractor): #526 thread optional approve note through to review_note (AC-6)"
+```
+
+---
+
+## Task 4: Backend — `mechanic_review_bulk_actions_total` counter (AC-7)
+
+**Files:**
+- Create: `apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.MechanicReview.cs`
+- Modify: `…/Commands/MechanicExtractor/BulkRejectMechanicClaimsCommandHandler.cs` + `BulkApproveMechanicClaimsCommandHandler.cs`
+- Create: `apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/MechanicReviewMetricsTests.cs`
+
+**Interfaces:**
+- Produces: `MeepleAiMetrics.MechanicReviewBulkActions` (`Counter<long>`), incremented `Add(1, TagList{{"action", "bulk_reject"|"bulk_approve"}})`.
+
+- [ ] **Step 1: Write the failing test** — mirror `MechanicValidatorMetricsTests` (name-filtered `MeterListener`, `ContainSingle`, Approach 1 / #2752):
+
+```csharp
+using System.Diagnostics.Metrics;
+using Api.Observability;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Commands.MechanicExtractor;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public class MechanicReviewMetricsTests
+{
+    private const string Counter = "mechanic_review_bulk_actions_total";
+
+    [Fact]
+    public void MechanicReviewBulkActions_Emits_ActionTag()
+    {
+        var events = new List<string>();
+        using var listener = new MeterListener
+        {
+            InstrumentPublished = (instrument, l) =>
+            {
+                if (instrument.Meter.Name == MeepleAiMetrics.MeterName && instrument.Name == Counter)
+                    l.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((_, _, tags, _) =>
+        {
+            foreach (var tag in tags)
+                if (tag.Key == "action" && tag.Value is string a) events.Add(a);
+        });
+        listener.Start();
+
+        MeepleAiMetrics.MechanicReviewBulkActions.Add(1, new System.Diagnostics.TagList { { "action", "bulk_reject" } });
+
+        events.Should().ContainSingle().Which.Should().Be("bulk_reject");
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd apps/api/src/Api && dotnet test --filter "FullyQualifiedName~MechanicReviewMetricsTests"`
+Expected: FAIL — `MechanicReviewBulkActions` does not exist.
+
+- [ ] **Step 3: Declare the counter** — `MeepleAiMetrics.MechanicReview.cs`:
+
+```csharp
+using System.Diagnostics.Metrics;
+
+namespace Api.Observability;
+
+/// <summary>#526 ME-M1.4 admin-review observability (AC-7): bulk-action counter.</summary>
+internal static partial class MeepleAiMetrics
+{
+    /// <summary>Admin mechanic-review bulk actions, tagged {action=bulk_approve|bulk_reject}.</summary>
+    public static readonly Counter<long> MechanicReviewBulkActions =
+        Meter.CreateCounter<long>(
+            "mechanic_review_bulk_actions_total",
+            description: "Admin mechanic-review bulk actions by action.");
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cd apps/api/src/Api && dotnet test --filter "FullyQualifiedName~MechanicReviewMetricsTests"`
+Expected: PASS.
+
+- [ ] **Step 5: Increment in the handlers.** In `BulkRejectMechanicClaimsCommandHandler.Handle` (after the successful `SaveChangesAsync`/log region, before building the response) add:
+
+```csharp
+        MeepleAiMetrics.MechanicReviewBulkActions.Add(1, new System.Diagnostics.TagList { { "action", "bulk_reject" } });
+```
+Add `using System.Diagnostics;` and `using Api.Observability;` at the top. Do the same in `BulkApproveMechanicClaimsCommandHandler` with `{ "action", "bulk_approve" }`.
+
+- [ ] **Step 6: Build**
+
+Run: `cd apps/api/src/Api && dotnet build`
+Expected: succeeds.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/Api/Observability apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/BulkRejectMechanicClaimsCommandHandler.cs apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/BulkApproveMechanicClaimsCommandHandler.cs apps/api/tests
+git commit -m "feat(mechanic-extractor): #526 mechanic_review_bulk_actions_total counter (AC-7)"
+```
+
+---
+
+## Task 5: Frontend — schemas + client (validations, bulk-reject, approve note)
+
+**Files:**
+- Modify: `apps/web/src/lib/api/schemas/mechanic-analyses.schemas.ts`
+- Modify: `apps/web/src/lib/api/clients/admin/adminContentClient.ts`
+- Test: `apps/web/src/lib/api/schemas/__tests__/mechanic-analyses.schemas.test.ts` (create if absent)
+
+**Interfaces:**
+- Produces: `MechanicClaimValidationDtoSchema`; `MechanicClaimDto.validations` + `.reviewNote`; `MECHANIC_ANALYSES_ROUTES.bulkRejectClaims`; `BulkRejectMechanicClaimsResponseDtoSchema`/`Dto`; `BulkRejectMechanicClaimsRequest`; `adminClient.bulkRejectMechanicClaims(id, req)`; `adminClient.approveMechanicClaim(id, claimId, note?)`.
+
+- [ ] **Step 1: Write the failing schema test**
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { MechanicClaimDtoSchema, BulkRejectMechanicClaimsResponseDtoSchema } from '../mechanic-analyses.schemas';
+
+describe('mechanic-analyses schemas #526', () => {
+  it('parses validations[] + reviewNote on a claim', () => {
+    const parsed = MechanicClaimDtoSchema.parse({
+      id: '11111111-1111-4111-8111-111111111111',
+      analysisId: '22222222-2222-4222-8222-222222222222',
+      section: 1, text: 't', displayOrder: 0, status: 0,
+      reviewedBy: null, reviewedAt: null, rejectionNote: null, reviewNote: null,
+      citations: [],
+      validations: [{ rule: 'T1', outcome: 'pass', message: null }],
+    });
+    expect(parsed.validations[0].rule).toBe('T1');
+  });
+
+  it('parses bulk-reject response', () => {
+    const r = BulkRejectMechanicClaimsResponseDtoSchema.parse({
+      rejectedCount: 2, skippedAlreadyRejectedCount: 0, claims: [],
+    });
+    expect(r.rejectedCount).toBe(2);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd apps/web && pnpm test src/lib/api/schemas/__tests__/mechanic-analyses.schemas.test.ts`
+Expected: FAIL — `validations`/`reviewNote` unknown, `BulkRejectMechanicClaimsResponseDtoSchema` undefined.
+
+- [ ] **Step 3: Add the validation schema + fields.** After `MechanicCitationDtoSchema` (line 234) add:
+
+```ts
+export const MechanicClaimValidationDtoSchema = z.object({
+  rule: z.string(),
+  outcome: z.enum(['pass', 'fail', 'notRun']),
+  message: z.string().nullable().optional(),
+});
+export type MechanicClaimValidationDto = z.infer<typeof MechanicClaimValidationDtoSchema>;
+```
+In `MechanicClaimDtoSchema`, after `citations: z.array(MechanicCitationDtoSchema),` add:
+```ts
+  reviewNote: z.string().nullable(),
+  validations: z.array(MechanicClaimValidationDtoSchema),
+```
+
+- [ ] **Step 4: Add route + response + request.** After the `bulkApproveClaims` route entry:
+```ts
+  bulkRejectClaims: (id: string) => `/api/v1/admin/mechanic-analyses/${id}/claims/bulk-reject`,
+```
+After `BulkApproveMechanicClaimsResponseDto` type export:
+```ts
+export const BulkRejectMechanicClaimsResponseDtoSchema = z.object({
+  rejectedCount: z.number().int(),
+  skippedAlreadyRejectedCount: z.number().int(),
+  claims: MechanicClaimsListSchema,
+});
+export type BulkRejectMechanicClaimsResponseDto = z.infer<
+  typeof BulkRejectMechanicClaimsResponseDtoSchema
+>;
+
+/** Body for `POST .../claims/bulk-reject` (#526). Reviewer id comes from the session. */
+export interface BulkRejectMechanicClaimsRequest {
+  claimIds: string[];
+  reason: string;
+}
+```
+
+- [ ] **Step 5: Add client methods.** In `adminContentClient.ts` imports, add `BulkRejectMechanicClaimsResponseDtoSchema` (value) + `type BulkRejectMechanicClaimsResponseDto`, `type BulkRejectMechanicClaimsRequest` (preserve alpha order). After `bulkApproveMechanicClaims`:
+
+```ts
+    async bulkRejectMechanicClaims(
+      analysisId: string,
+      request: BulkRejectMechanicClaimsRequest
+    ): Promise<BulkRejectMechanicClaimsResponseDto> {
+      const result = await http.post(
+        MECHANIC_ANALYSES_ROUTES.bulkRejectClaims(analysisId),
+        request,
+        BulkRejectMechanicClaimsResponseDtoSchema
+      );
+      if (!result) throw new Error('Failed to bulk-reject claims');
+      return result;
+    },
+```
+Change `approveMechanicClaim` signature to `(analysisId: string, claimId: string, note?: string)` and its POST body from `{}` to `note !== undefined ? { note } : {}`.
+
+- [ ] **Step 6: Run to verify it passes + typecheck**
+
+Run: `cd apps/web && pnpm test src/lib/api/schemas/__tests__/mechanic-analyses.schemas.test.ts && pnpm typecheck`
+Expected: PASS + typecheck OK.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/src/lib/api/schemas/mechanic-analyses.schemas.ts apps/web/src/lib/api/clients/admin/adminContentClient.ts apps/web/src/lib/api/schemas/__tests__
+git commit -m "feat(mechanic-extractor): #526 FE schemas+client for validations, bulk-reject, approve note"
+```
+
+---
+
+## Task 6: Frontend — pure quote-highlight helper + PdfInlineViewer opt-in text layer
+
+**Files:**
+- Create: `apps/web/src/components/pdf/pdf-quote-highlight.ts` + `__tests__/pdf-quote-highlight.test.ts`
+- Modify: `apps/web/src/components/pdf/PdfInlineViewer.tsx`
+
+**Interfaces:**
+- Produces: `normalizeQuoteText(s: string): string`; `makeQuoteTextRenderer(quote: string): { render: (item: { str: string }) => string; matched: () => boolean }`; `PdfInlineViewer` props `renderTextLayer?: boolean`, `highlightQuote?: string`, `onQuoteMatch?: (found: boolean) => void`.
+
+- [ ] **Step 1: Write the failing helper test**
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { normalizeQuoteText, makeQuoteTextRenderer } from '../pdf-quote-highlight';
+
+describe('pdf-quote-highlight', () => {
+  it('normalizes whitespace, soft hyphens, case', () => {
+    expect(normalizeQuoteText('Score  1­point\nper  Road')).toBe('score 1point per road');
+  });
+
+  it('wraps text items contained in the quote and reports a match', () => {
+    const r = makeQuoteTextRenderer('players score one point per road');
+    expect(r.render({ str: 'score one point' })).toContain('<mark');
+    expect(r.render({ str: 'per road' })).toContain('<mark');
+    expect(r.matched()).toBe(true);
+  });
+
+  it('escapes HTML and does not wrap non-quote items', () => {
+    const r = makeQuoteTextRenderer('players score one point');
+    expect(r.render({ str: '<b>bonus</b>' })).toBe('&lt;b&gt;bonus&lt;/b&gt;');
+    expect(r.matched()).toBe(false);
+  });
+
+  it('ignores trivially short items to reduce false positives', () => {
+    const r = makeQuoteTextRenderer('a player scores one point');
+    expect(r.render({ str: 'a' })).toBe('a'); // len<=2 not wrapped
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd apps/web && pnpm test src/components/pdf/__tests__/pdf-quote-highlight.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the helper** — `pdf-quote-highlight.ts`:
+
+```ts
+/** Normalize for tolerant substring matching: lowercase, strip soft hyphens, collapse whitespace. */
+export function normalizeQuoteText(s: string): string {
+  return s
+    .replace(/­/g, '')
+    .toLowerCase()
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+/**
+ * Best-effort per-item highlighter for react-pdf `customTextRenderer` (AC-2 Pattern A).
+ * A text item is wrapped in <mark> when its normalized string (len>2) is a substring of the
+ * normalized quote. Imperfect for very common short items — the caller shows a fallback banner
+ * via `matched()`. FU could upgrade to contiguous-run matching or Pattern-B coordinates.
+ */
+export function makeQuoteTextRenderer(quote: string): {
+  render: (item: { str: string }) => string;
+  matched: () => boolean;
+} {
+  const normQuote = normalizeQuoteText(quote);
+  let didMatch = false;
+  return {
+    render: ({ str }) => {
+      const norm = normalizeQuoteText(str);
+      if (norm.length > 2 && normQuote.includes(norm)) {
+        didMatch = true;
+        return `<mark class="pdf-quote-highlight">${escapeHtml(str)}</mark>`;
+      }
+      return escapeHtml(str);
+    },
+    matched: () => didMatch,
+  };
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cd apps/web && pnpm test src/components/pdf/__tests__/pdf-quote-highlight.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Parameterize PdfInlineViewer.** Add to `PdfInlineViewerProps`:
+```ts
+  readonly renderTextLayer?: boolean;
+  readonly highlightQuote?: string;
+  readonly onQuoteMatch?: (found: boolean) => void;
+```
+Destructure them (with `renderTextLayer` default `false`). Build the renderer + effect:
+```tsx
+import { makeQuoteTextRenderer } from './pdf-quote-highlight';
+// … inside component:
+  const quoteRenderer = useMemo(
+    () => (highlightQuote ? makeQuoteTextRenderer(highlightQuote) : null),
+    [highlightQuote]
+  );
+```
+Change the `<Page>` (line ~290) to:
+```tsx
+            <Page
+              pageNumber={currentPage}
+              scale={scale}
+              renderAnnotationLayer={false}
+              renderTextLayer={renderTextLayer || !!highlightQuote}
+              customTextRenderer={quoteRenderer ? ({ str }) => quoteRenderer.render({ str }) : undefined}
+              onRenderTextLayerSuccess={
+                quoteRenderer && onQuoteMatch ? () => onQuoteMatch(quoteRenderer.matched()) : undefined
+              }
+            />
+```
+Add a highlight style (module-level or in `apps/web/src/app/globals.css`): `.pdf-quote-highlight { background-color: rgba(255, 235, 59, 0.4); }`.
+
+- [ ] **Step 6: Typecheck + existing viewer tests still green**
+
+Run: `cd apps/web && pnpm typecheck && pnpm test src/components/pdf`
+Expected: PASS (new props are optional; default behavior unchanged — `renderTextLayer` still off when not requested).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/src/components/pdf/pdf-quote-highlight.ts apps/web/src/components/pdf/__tests__/pdf-quote-highlight.test.ts apps/web/src/components/pdf/PdfInlineViewer.tsx apps/web/src/app/globals.css
+git commit -m "feat(pdf): #526 opt-in text-layer quote highlighting on PdfInlineViewer (AC-2 base)"
+```
+
+---
+
+## Task 7: Frontend — `<PdfQuoteHighlighter>` modal
+
+**Files:**
+- Create: `apps/web/src/components/pdf/PdfQuoteHighlighter.tsx`
+- Test: `apps/web/src/components/pdf/__tests__/PdfQuoteHighlighter.test.tsx`
+
+**Interfaces:**
+- Consumes: `PdfInlineViewer` (Task 6).
+- Produces: `<PdfQuoteHighlighter open onOpenChange documentId page quote />` (default export named `PdfQuoteHighlighter`). Renders a Dialog with the viewer at `page`, highlights `quote`, and shows a fallback banner when no match.
+
+- [ ] **Step 1: Write the failing test** (mock `PdfInlineViewer` to drive `onQuoteMatch`):
+
+```tsx
+/** @vitest-environment jsdom */
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../PdfInlineViewer', () => ({
+  PdfInlineViewer: ({ onQuoteMatch }: { onQuoteMatch?: (f: boolean) => void }) => {
+    onQuoteMatch?.(false); // simulate "not found" → banner should show
+    return <div data-testid="pdf-inline-viewer" />;
+  },
+}));
+
+import { PdfQuoteHighlighter } from '../PdfQuoteHighlighter';
+
+describe('PdfQuoteHighlighter', () => {
+  it('shows the fallback banner when the quote is not matched', () => {
+    render(
+      <PdfQuoteHighlighter open onOpenChange={() => {}} documentId="d1" page={4} quote="x" />
+    );
+    expect(screen.getByTestId('pdf-inline-viewer')).toBeInTheDocument();
+    expect(screen.getByTestId('pdf-quote-fallback')).toHaveTextContent(/verifica manualmente/i);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd apps/web && pnpm test src/components/pdf/__tests__/PdfQuoteHighlighter.test.tsx`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement** — `PdfQuoteHighlighter.tsx`:
+
+```tsx
+'use client';
+
+import React, { useEffect, useState } from 'react';
+
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/overlays/dialog';
+
+import { PdfInlineViewer } from './PdfInlineViewer';
+
+export interface PdfQuoteHighlighterProps {
+  readonly open: boolean;
+  readonly onOpenChange: (open: boolean) => void;
+  readonly documentId: string;
+  readonly page: number;
+  readonly quote: string;
+}
+
+/**
+ * #526 AC-2 / #530 AD-1 — shared citation quote viewer. Opens the source PDF at `page`, highlights
+ * `quote` via PdfInlineViewer's text-layer search (Pattern A), and shows a page-level fallback
+ * banner when the quote can't be located automatically. Consumed by admin review (#526) and,
+ * later, #528 public card + #530 chat citations.
+ */
+export function PdfQuoteHighlighter({
+  open,
+  onOpenChange,
+  documentId,
+  page,
+  quote,
+}: PdfQuoteHighlighterProps): React.JSX.Element {
+  const [matched, setMatched] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    if (open) setMatched(null); // reset per open
+  }, [open, documentId, page, quote]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-4xl">
+        <DialogHeader>
+          <DialogTitle>Citazione — p.{page}</DialogTitle>
+        </DialogHeader>
+        {matched === false && (
+          <div
+            className="rounded-md border border-amber-300 bg-amber-50 p-2 text-xs text-amber-900"
+            role="status"
+            data-testid="pdf-quote-fallback"
+          >
+            Quote non individuabile automaticamente a p.{page}; verifica manualmente.
+          </div>
+        )}
+        <div className="max-h-[70vh] overflow-auto">
+          <PdfInlineViewer
+            documentId={documentId}
+            initialPage={page}
+            highlightQuote={quote}
+            onQuoteMatch={setMatched}
+            features={{ jumpToPage: true, zoom: true }}
+          />
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+```
+(If `@/components/ui/overlays/dialog` exports differ, mirror the imports used by an existing modal, e.g. `PdfViewerModal.tsx`.)
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cd apps/web && pnpm test src/components/pdf/__tests__/PdfQuoteHighlighter.test.tsx && pnpm typecheck`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/pdf/PdfQuoteHighlighter.tsx apps/web/src/components/pdf/__tests__/PdfQuoteHighlighter.test.tsx
+git commit -m "feat(pdf): #526 PdfQuoteHighlighter modal at components/pdf/ (AC-2, reconciles #530 AD-1)"
+```
+
+---
+
+## Task 8: Frontend — T1–T4 badges in ClaimsSection (AC-1 UI)
+
+**Files:**
+- Modify: `apps/web/src/components/admin/mechanic-extractor/claims/ClaimsSection.tsx`
+- Test: `apps/web/src/components/admin/mechanic-extractor/claims/__tests__/ClaimsSection.badges.test.tsx`
+
+**Interfaces:**
+- Consumes: `MechanicClaimDto.validations` (Task 5).
+- Produces: a `ValidationBadges` sub-component rendered in each `ClaimRow`, `data-testid="claim-validation-badge-<rule>-<claimId>"`, `aria-label` per badge.
+
+- [ ] **Step 1: Write the failing test** (mount `ClaimRow` via the exported `ClaimsSection` with a mocked client, or export `ValidationBadges` and test it directly — prefer exporting the small badge component). Add near the top of `ClaimsSection.tsx`: `export function ValidationBadges({ validations }: { validations: MechanicClaimValidationDto[] })`. Test:
+
+```tsx
+/** @vitest-environment jsdom */
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { ValidationBadges } from '../ClaimsSection';
+
+describe('ValidationBadges', () => {
+  it('renders one badge per rule with pass/fail/notRun styling + aria-label', () => {
+    render(
+      <ValidationBadges
+        validations={[
+          { rule: 'T1', outcome: 'pass', message: null },
+          { rule: 'T2', outcome: 'fail', message: 'too long' },
+          { rule: 'T3', outcome: 'notRun', message: null },
+        ]}
+      />
+    );
+    expect(screen.getByTestId('claim-validation-badge-T1')).toHaveAttribute('aria-label', expect.stringMatching(/T1.*pass/i));
+    expect(screen.getByTestId('claim-validation-badge-T2')).toHaveAttribute('aria-label', expect.stringMatching(/T2.*fail/i));
+    expect(screen.getByTestId('claim-validation-badge-T3')).toHaveAttribute('aria-label', expect.stringMatching(/T3.*not/i));
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd apps/web && pnpm test src/components/admin/mechanic-extractor/claims/__tests__/ClaimsSection.badges.test.tsx`
+Expected: FAIL — `ValidationBadges` not exported.
+
+- [ ] **Step 3: Implement `ValidationBadges`** in `ClaimsSection.tsx` (add the type import `MechanicClaimValidationDto` from the schemas module) and a color map:
+
+```tsx
+const VALIDATION_BADGE_CLASS: Record<string, string> = {
+  pass: 'bg-green-100 text-green-800 border-green-300',
+  fail: 'bg-rose-100 text-rose-800 border-rose-300',
+  notRun: 'bg-slate-100 text-slate-600 border-slate-300',
+};
+
+export function ValidationBadges({
+  validations,
+}: {
+  validations: MechanicClaimValidationDto[];
+}): React.JSX.Element | null {
+  if (!validations || validations.length === 0) return null;
+  return (
+    <span className="flex flex-wrap gap-1" data-testid="claim-validation-badges">
+      {validations.map(v => (
+        <Badge
+          key={v.rule}
+          variant="outline"
+          className={VALIDATION_BADGE_CLASS[v.outcome] ?? VALIDATION_BADGE_CLASS.notRun}
+          data-testid={`claim-validation-badge-${v.rule}`}
+          aria-label={`${v.rule} ${v.outcome}${v.message ? `: ${v.message}` : ''}`}
+          title={v.message ?? `${v.rule} ${v.outcome}`}
+        >
+          {v.outcome === 'pass' ? '✓' : v.outcome === 'fail' ? '✗' : '—'} {v.rule}
+        </Badge>
+      ))}
+    </span>
+  );
+}
+```
+Render `<ValidationBadges validations={claim.validations} />` inside `ClaimRow`, in the right-hand action cluster before the status `Badge` (around line 409).
+
+- [ ] **Step 4: Run to verify it passes + existing ClaimsSection tests green**
+
+Run: `cd apps/web && pnpm test src/components/admin/mechanic-extractor/claims && pnpm typecheck`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/admin/mechanic-extractor/claims/ClaimsSection.tsx apps/web/src/components/admin/mechanic-extractor/claims/__tests__/ClaimsSection.badges.test.tsx
+git commit -m "feat(mechanic-extractor): #526 T1-T4 validation badges in ClaimsSection (AC-1 UI)"
+```
+
+---
+
+## Task 9: Frontend — citation click → PdfQuoteHighlighter (AC-2 wire)
+
+**Files:**
+- Modify: `apps/web/src/components/admin/mechanic-extractor/claims/ClaimsSection.tsx` (add `pdfDocumentId` prop; citation rows become buttons)
+- Modify: `apps/web/src/app/admin/(dashboard)/knowledge-base/mechanic-extractor/analyses/page.tsx` (pass `pdfDocumentId={status.pdfDocumentId}`)
+- Test: `apps/web/src/components/admin/mechanic-extractor/claims/__tests__/ClaimsSection.citation.test.tsx`
+
+**Interfaces:**
+- Consumes: `PdfQuoteHighlighter` (Task 7).
+- Produces: `ClaimsSectionProps.pdfDocumentId?: string`; citation button `data-testid="claim-citation-open-<citationId>"`.
+
+- [ ] **Step 1: Write the failing test** — mock `PdfQuoteHighlighter`, mock `adminClient.getMechanicAnalysisClaims` to return one claim with a citation, click the citation, assert the highlighter opened with the right props.
+
+```tsx
+/** @vitest-environment jsdom */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+const mockGetClaims = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/api/clients/adminClient', () => ({
+  createAdminClient: () => ({ getMechanicAnalysisClaims: mockGetClaims }),
+}));
+class MockHttpClient {}
+vi.mock('@/lib/api/core/httpClient', () => ({ HttpClient: MockHttpClient }));
+const mockHighlighter = vi.hoisted(() => vi.fn());
+vi.mock('@/components/pdf/PdfQuoteHighlighter', () => ({
+  PdfQuoteHighlighter: (props: Record<string, unknown>) => {
+    mockHighlighter(props);
+    return props.open ? <div data-testid="highlighter-open" /> : null;
+  },
+}));
+
+import { ClaimsSection } from '../ClaimsSection';
+
+const claim = {
+  id: 'dddddddd-dddd-4ddd-8ddd-dddddddddddd', analysisId: 'a', section: 1, text: 't',
+  displayOrder: 0, status: 0, reviewedBy: null, reviewedAt: null, rejectionNote: null,
+  reviewNote: null, validations: [],
+  citations: [{ id: 'c1', pdfPage: 4, quote: 'score one point', displayOrder: 0 }],
+};
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+
+describe('ClaimsSection citation viewer', () => {
+  it('opens PdfQuoteHighlighter with documentId/page/quote on citation click', async () => {
+    mockGetClaims.mockResolvedValue([claim]);
+    render(<ClaimsSection analysisId="a" pdfDocumentId="pdf-99" />, { wrapper: Wrapper });
+    // expand citations then click
+    fireEvent.click(await screen.findByTestId(`claim-citations-toggle-${claim.id}`));
+    fireEvent.click(screen.getByTestId('claim-citation-open-c1'));
+    expect(mockHighlighter).toHaveBeenCalledWith(
+      expect.objectContaining({ documentId: 'pdf-99', page: 4, quote: 'score one point', open: true })
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd apps/web && pnpm test src/components/admin/mechanic-extractor/claims/__tests__/ClaimsSection.citation.test.tsx`
+Expected: FAIL — `pdfDocumentId` prop / citation button / highlighter wiring missing.
+
+- [ ] **Step 3: Implement.** Add `pdfDocumentId?: string` to `ClaimsSectionProps` and thread it to `SectionGroup` → `ClaimRow`. Add highlighter state in `ClaimsSection` (`const [citationTarget, setCitationTarget] = useState<{ documentId: string; page: number; quote: string } | null>(null)`), a callback `onOpenCitation`, and render `<PdfQuoteHighlighter open={!!citationTarget} onOpenChange={o => !o && setCitationTarget(null)} {...citationTarget} />` guarded by `citationTarget`. In `ClaimRow` citation `<li>` (line ~462), replace the static text with a button when `pdfDocumentId` is present:
+
+```tsx
+{claim.citations.map(c => (
+  <li key={c.id} className="text-muted-foreground">
+    {pdfDocumentId ? (
+      <button
+        type="button"
+        className="text-left hover:underline"
+        onClick={() => onOpenCitation({ documentId: pdfDocumentId, page: c.pdfPage, quote: c.quote })}
+        data-testid={`claim-citation-open-${c.id}`}
+      >
+        <span className="font-medium text-foreground">p.{c.pdfPage}</span> — &ldquo;{c.quote}&rdquo;
+      </button>
+    ) : (
+      <>
+        <span className="font-medium text-foreground">p.{c.pdfPage}</span> — &ldquo;{c.quote}&rdquo;
+      </>
+    )}
+  </li>
+))}
+```
+Thread `onOpenCitation` and `pdfDocumentId` down the `SectionGroup`/`ClaimRow` prop chain.
+
+- [ ] **Step 4: Pass `pdfDocumentId` from the parent.** In `analyses/page.tsx`, find where `<ClaimsSection analysisId=… isClaimsActionable=… />` renders and add `pdfDocumentId={status?.pdfDocumentId}` (the status query already carries `pdfDocumentId`).
+
+- [ ] **Step 5: Run to verify it passes + existing tests + typecheck**
+
+Run: `cd apps/web && pnpm test src/components/admin/mechanic-extractor/claims && pnpm typecheck`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/components/admin/mechanic-extractor/claims/ClaimsSection.tsx "apps/web/src/app/admin/(dashboard)/knowledge-base/mechanic-extractor/analyses/page.tsx" apps/web/src/components/admin/mechanic-extractor/claims/__tests__/ClaimsSection.citation.test.tsx
+git commit -m "feat(mechanic-extractor): #526 open PdfQuoteHighlighter from citation rows (AC-2 wire)"
+```
+
+---
+
+## Task 10: Frontend — bulk-action dropdown (AC-3)
+
+**Files:**
+- Create: `apps/web/src/components/admin/mechanic-extractor/claims/BulkActionDialog.tsx`
+- Modify: `apps/web/src/components/admin/mechanic-extractor/claims/ClaimsSection.tsx`
+- Test: `apps/web/src/components/admin/mechanic-extractor/claims/__tests__/ClaimsSection.bulk.test.tsx`
+
+**Interfaces:**
+- Consumes: `adminClient.bulkApproveMechanicClaims`, `adminClient.bulkRejectMechanicClaims` (Task 5).
+- Produces: a `Select`-driven bulk menu with options `approve-pending` + `reject-long-quote`; `BulkActionDialog` confirm showing the predicted count. `data-testid` `bulk-action-select`, `bulk-action-confirm`, `bulk-action-count`.
+
+- [ ] **Step 1: Write the failing test** — pick "reject all with quote >20 words", assert the confirm dialog shows the count and calls `bulkRejectMechanicClaims` with the computed ids.
+
+```tsx
+/** @vitest-environment jsdom */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+const mockGetClaims = vi.hoisted(() => vi.fn());
+const mockBulkReject = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/api/clients/adminClient', () => ({
+  createAdminClient: () => ({
+    getMechanicAnalysisClaims: mockGetClaims,
+    bulkApproveMechanicClaims: vi.fn(),
+    bulkRejectMechanicClaims: mockBulkReject,
+  }),
+}));
+class MockHttpClient {}
+vi.mock('@/lib/api/core/httpClient', () => ({ HttpClient: MockHttpClient }));
+
+import { ClaimsSection } from '../ClaimsSection';
+
+const longQuote = Array.from({ length: 25 }, (_, i) => `w${i}`).join(' ');
+const claims = [
+  { id: 'd1', analysisId: 'a', section: 1, text: 't1', displayOrder: 0, status: 0,
+    reviewedBy: null, reviewedAt: null, rejectionNote: null, reviewNote: null, validations: [],
+    citations: [{ id: 'c1', pdfPage: 1, quote: longQuote, displayOrder: 0 }] },
+  { id: 'd2', analysisId: 'a', section: 1, text: 't2', displayOrder: 1, status: 0,
+    reviewedBy: null, reviewedAt: null, rejectionNote: null, reviewNote: null, validations: [],
+    citations: [{ id: 'c2', pdfPage: 1, quote: 'short quote', displayOrder: 0 }] },
+];
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+
+describe('ClaimsSection bulk reject by quote length', () => {
+  it('rejects only the >20-word-quote claim after count-confirm', async () => {
+    mockGetClaims.mockResolvedValue(claims);
+    mockBulkReject.mockResolvedValue({ rejectedCount: 1, skippedAlreadyRejectedCount: 0, claims });
+    render(<ClaimsSection analysisId="a" />, { wrapper: Wrapper });
+
+    fireEvent.change(await screen.findByTestId('bulk-action-select'), {
+      target: { value: 'reject-long-quote' },
+    });
+    expect(screen.getByTestId('bulk-action-count')).toHaveTextContent('1');
+    fireEvent.click(screen.getByTestId('bulk-action-confirm'));
+
+    expect(mockBulkReject).toHaveBeenCalledWith('a', expect.objectContaining({ claimIds: ['d1'] }));
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd apps/web && pnpm test src/components/admin/mechanic-extractor/claims/__tests__/ClaimsSection.bulk.test.tsx`
+Expected: FAIL — bulk select / confirm not implemented.
+
+- [ ] **Step 3: Implement the predicate + dialog.** Add a pure predicate helper near the top of `ClaimsSection.tsx`:
+```tsx
+const LONG_QUOTE_WORDS = 20;
+function wordCount(s: string): number {
+  return s.trim().split(/\s+/).filter(Boolean).length;
+}
+function claimsWithLongQuote(claims: MechanicClaimDto[]): MechanicClaimDto[] {
+  return claims.filter(c => c.citations.some(cit => wordCount(cit.quote) > LONG_QUOTE_WORDS));
+}
+```
+Create `BulkActionDialog.tsx` (an `AlertDialog` mirroring `RejectClaimDialog`) with props `{ open, onOpenChange, title, count, onConfirm, isPending }` rendering `data-testid="bulk-action-count"` and `data-testid="bulk-action-confirm"`. In the `ClaimsSection` header (replace the single bulk-approve button, lines ~220–235) add a `Select` (`data-testid="bulk-action-select"`) with options `Approve all pending ({pending})` → value `approve-pending`, `Reject all with quote >20 words ({n})` → value `reject-long-quote`. On change, compute the target set and open `BulkActionDialog` with the count. On confirm:
+- `approve-pending` → `bulkApproveMutation.mutate()` (existing).
+- `reject-long-quote` → `bulkRejectMutation.mutate({ claimIds: targets.map(c => c.id), reason: 'Citazione supera 20 parole (ADR-051 T1) — rifiuto bulk.' })`.
+Add `bulkRejectMutation` (mirror `bulkApproveMutation`; on success set an amber warning if `skippedAlreadyRejectedCount > 0`, then `invalidateClaimsAndStatus()`).
+
+- [ ] **Step 4: Run to verify it passes + typecheck + existing tests**
+
+Run: `cd apps/web && pnpm test src/components/admin/mechanic-extractor/claims && pnpm typecheck`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/admin/mechanic-extractor/claims
+git commit -m "feat(mechanic-extractor): #526 bulk-action dropdown with reject-by-quote-length + count-confirm (AC-3)"
+```
+
+---
+
+## Task 11: Frontend — approve-with-note dialog (AC-6 UI)
+
+**Files:**
+- Create: `apps/web/src/components/admin/mechanic-extractor/claims/ApproveClaimDialog.tsx`
+- Modify: `apps/web/src/components/admin/mechanic-extractor/claims/ClaimsSection.tsx`
+- Test: `apps/web/src/components/admin/mechanic-extractor/claims/__tests__/ClaimsSection.approveNote.test.tsx`
+
+**Interfaces:**
+- Consumes: `adminClient.approveMechanicClaim(id, claimId, note?)` (Task 5).
+- Produces: an optional-note approve flow. `data-testid` `approve-claim-note-input`, `approve-claim-confirm`.
+
+- [ ] **Step 1: Write the failing test** — click Approve → dialog → type a note → confirm → assert `approveMechanicClaim('a','d1','matches p.4')`, and the reviewNote renders after refetch.
+
+```tsx
+/** @vitest-environment jsdom */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+const mockGetClaims = vi.hoisted(() => vi.fn());
+const mockApprove = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/api/clients/adminClient', () => ({
+  createAdminClient: () => ({ getMechanicAnalysisClaims: mockGetClaims, approveMechanicClaim: mockApprove }),
+}));
+class MockHttpClient {}
+vi.mock('@/lib/api/core/httpClient', () => ({ HttpClient: MockHttpClient }));
+
+import { ClaimsSection } from '../ClaimsSection';
+const claim = { id: 'd1', analysisId: 'a', section: 1, text: 't', displayOrder: 0, status: 0,
+  reviewedBy: null, reviewedAt: null, rejectionNote: null, reviewNote: null, validations: [], citations: [] };
+function Wrapper({ children }: { children: React.ReactNode }) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+
+describe('ClaimsSection approve with note', () => {
+  it('sends the optional note on approve', async () => {
+    mockGetClaims.mockResolvedValue([claim]);
+    mockApprove.mockResolvedValue({ ...claim, status: 1, reviewNote: 'matches p.4' });
+    render(<ClaimsSection analysisId="a" />, { wrapper: Wrapper });
+    fireEvent.click(await screen.findByTestId('claim-approve-d1'));
+    fireEvent.change(screen.getByTestId('approve-claim-note-input'), { target: { value: 'matches p.4' } });
+    fireEvent.click(screen.getByTestId('approve-claim-confirm'));
+    expect(mockApprove).toHaveBeenCalledWith('a', 'd1', 'matches p.4');
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd apps/web && pnpm test src/components/admin/mechanic-extractor/claims/__tests__/ClaimsSection.approveNote.test.tsx`
+Expected: FAIL — approve now opens a dialog instead of firing immediately.
+
+- [ ] **Step 3: Implement.** Create `ApproveClaimDialog.tsx` (`AlertDialog`, optional textarea, `data-testid="approve-claim-note-input"` + `approve-claim-confirm`; note is optional so confirm is always enabled). In `ClaimsSection`, change the Approve button to set an `approveTarget` (like `rejectTarget`) instead of calling `approveMutation.mutate` directly; render `<ApproveClaimDialog … onConfirm={note => approveMutation.mutate({ claimId: approveTarget.id, note })} />`. Change `approveMutation` to accept `{ claimId, note }` and call `adminClient.approveMechanicClaim(analysisId, claimId, note || undefined)`. Render `claim.reviewNote` in `ClaimRow` (a small green note block mirroring the rejection-note block) when present.
+
+- [ ] **Step 4: Run to verify it passes + existing claims tests + typecheck**
+
+Run: `cd apps/web && pnpm test src/components/admin/mechanic-extractor/claims && pnpm typecheck`
+Expected: PASS. (Note: existing tests that click `claim-approve-<id>` and expect immediate approval must be updated to go through the dialog — update them in this step.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/admin/mechanic-extractor/claims
+git commit -m "feat(mechanic-extractor): #526 approve-with-note dialog (AC-6 UI)"
+```
+
+---
+
+## Task 12: Frontend — footer attribution swap (AC-5)
+
+**Files:**
+- Create: `apps/web/src/components/admin/mechanic-extractor/MechanicAnalysisFooterAttribution.tsx`
+- Modify: `apps/web/src/app/admin/(dashboard)/knowledge-base/mechanic-extractor/review/page.tsx`
+- Test: `apps/web/src/components/admin/mechanic-extractor/__tests__/MechanicAnalysisFooterAttribution.test.tsx`
+
+**Interfaces:**
+- Produces: `<MechanicAnalysisFooterAttribution totalTokensUsed? estimatedCostUsd? />` rendering the ADR-051 canonical string.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+/** @vitest-environment jsdom */
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { MechanicAnalysisFooterAttribution } from '../MechanicAnalysisFooterAttribution';
+
+describe('MechanicAnalysisFooterAttribution', () => {
+  it('renders the ADR-051 attribution and NOT the forbidden Variant-C string', () => {
+    render(<MechanicAnalysisFooterAttribution totalTokensUsed={500} estimatedCostUsd={0.002} />);
+    expect(screen.getByText(/riformulata in parole originali e cita la pagina/i)).toBeInTheDocument();
+    expect(screen.queryByText(/non ha mai letto il testo del PDF originale/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/500 tokens/)).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd apps/web && pnpm test src/components/admin/mechanic-extractor/__tests__/MechanicAnalysisFooterAttribution.test.tsx`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the component** — `MechanicAnalysisFooterAttribution.tsx`:
+
+```tsx
+/* eslint-disable local/no-hardcoded-color-utility -- admin tools chrome. DS-13d admin scope. */
+import React from 'react';
+
+export interface MechanicAnalysisFooterAttributionProps {
+  readonly totalTokensUsed?: number;
+  readonly estimatedCostUsd?: number;
+}
+
+/**
+ * #526 AC-5 — ADR-051 canonical attribution footer. Shared between the admin review page and the
+ * public card (#528). Replaces the retired Variant-C "L'AI non ha mai letto…" copy.
+ */
+export function MechanicAnalysisFooterAttribution({
+  totalTokensUsed,
+  estimatedCostUsd,
+}: MechanicAnalysisFooterAttributionProps): React.JSX.Element {
+  return (
+    <div className="rounded-lg border border-green-200 bg-green-50/50 p-4 text-center text-xs text-green-800 dark:border-green-800 dark:bg-green-950/20 dark:text-green-300 print:border-green-400">
+      <strong>&copy; 2026 MeepleAI</strong> — Contenuto originale.
+      <br />
+      <span className="opacity-70">
+        Analisi elaborata dall&apos;AI sul manuale del gioco. Ogni affermazione è riformulata in
+        parole originali e cita la pagina del regolamento. Copyright &copy; degli editori per il
+        testo originale del manuale.
+      </span>
+      {(totalTokensUsed ?? 0) > 0 && (
+        <span className="ml-2 opacity-70">
+          | {totalTokensUsed} tokens, ${(estimatedCostUsd ?? 0).toFixed(4)}
+        </span>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Swap in `review/page.tsx`.** Add the import to the `@/components/admin/mechanic-extractor/…` cluster; replace the footer `<div>` block (lines 271–285, the `{/* Copyright Footer */}` comment + div) with:
+```tsx
+      {/* Copyright Footer (ADR-051, #526 AC-5) */}
+      <MechanicAnalysisFooterAttribution
+        totalTokensUsed={draft.totalTokensUsed}
+        estimatedCostUsd={draft.estimatedCostUsd}
+      />
+```
+
+- [ ] **Step 5: Verify the forbidden string is gone + existing page test passes**
+
+Run:
+```
+cd apps/web && grep -rn "non ha mai letto il testo del PDF originale" src ; echo "hits above (expect 0)"
+pnpm test src/components/admin/mechanic-extractor/__tests__/MechanicAnalysisFooterAttribution.test.tsx
+pnpm test src/__tests__/app/admin/knowledge-base/mechanic-extractor/review.test.tsx
+```
+Expected: **0 grep hits**; both tests PASS. NB the existing `review.test.tsx:85` asserts `/L'AI non ha mai letto…/` — that assertion is now stale and MUST be updated in this step to assert the new attribution text (`/riformulata in parole originali/i`) instead. Update it.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/components/admin/mechanic-extractor/MechanicAnalysisFooterAttribution.tsx apps/web/src/components/admin/mechanic-extractor/__tests__ "apps/web/src/app/admin/(dashboard)/knowledge-base/mechanic-extractor/review/page.tsx" apps/web/src/__tests__/app/admin/knowledge-base/mechanic-extractor/review.test.tsx
+git commit -m "feat(mechanic-extractor): #526 swap Variant-C footer for ADR-051 attribution (AC-5)"
+```
+
+---
+
+## Task 13: E2E — bulk-reject + citation-open flows (AC-9)
+
+**Files:**
+- Modify: `apps/web/e2e/admin-mechanic-extractor-validation/load-existing-analysis.spec.ts`
+
+**Interfaces:**
+- Consumes: all prior tasks (the running app).
+
+- [ ] **Step 1: Add a claims fixture with two claims (one long-quote) + a bulk-reject route mock.** In `mockAnalysisRoutes`, add `bulkReject: 0` to `calls`, extend `buildClaimsResponse()` to return two claims (`CLAIM_ID` with a >20-word quote + a second short-quote claim), and register:
+```ts
+  await page.context().route(
+    new RegExp(`/api/v1/admin/mechanic-analyses/${ANALYSIS_ID}/claims/bulk-reject$`),
+    async (route: Route) => {
+      if (route.request().method() === 'POST') {
+        calls.bulkReject += 1;
+        await route.fulfill({ status: 200, contentType: 'application/json',
+          body: JSON.stringify({ rejectedCount: 1, skippedAlreadyRejectedCount: 0, claims: buildClaimsResponse() }) });
+        return;
+      }
+      await route.continue();
+    });
+```
+(Analysis status must be `InReview` for the bulk UI to be actionable — add an `InReview` status builder or parameterize `buildStatusDto()`.)
+
+- [ ] **Step 2: Add the bulk-reject test** inside the `test.describe`:
+```ts
+  test('bulk-reject by quote length calls the endpoint with computed ids', async ({ page }) => {
+    await setAdminSessionCookies(page);
+    const calls = await mockAnalysisRoutes(page);
+    await page.goto(`${ANALYSES_PATH}?analysisId=${ANALYSIS_ID}`);
+
+    await expect(page.getByTestId('claims-section')).toBeVisible();
+    await page.getByTestId('bulk-action-select').selectOption('reject-long-quote');
+    await expect(page.getByTestId('bulk-action-count')).toContainText('1');
+    await page.getByTestId('bulk-action-confirm').click();
+
+    await expect.poll(() => calls.bulkReject, { timeout: 5000 }).toBeGreaterThanOrEqual(1);
+  });
+```
+
+- [ ] **Step 3: Add the citation-open test:**
+```ts
+  test('clicking a citation opens the quote highlighter', async ({ page }) => {
+    await setAdminSessionCookies(page);
+    await mockAnalysisRoutes(page);
+    await page.goto(`${ANALYSES_PATH}?analysisId=${ANALYSIS_ID}`);
+
+    await page.getByTestId(`claim-citations-toggle-${CLAIM_ID}`).click();
+    await page.getByTestId(/^claim-citation-open-/).first().click();
+    await expect(page.getByRole('dialog')).toBeVisible();
+  });
+```
+
+- [ ] **Step 4: Run the spec**
+
+Run: `cd apps/web && pnpm test:e2e admin-mechanic-extractor-validation/load-existing-analysis.spec.ts`
+Expected: PASS (requires `NEXT_PUBLIC_MECHANIC_VALIDATION_ENABLED=true` at server start). If the PDF highlighter cannot load a blob in E2E, assert only the dialog opening (as above) — do not assert on-page highlight in E2E.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/e2e/admin-mechanic-extractor-validation/load-existing-analysis.spec.ts
+git commit -m "test(mechanic-extractor): #526 E2E bulk-reject + citation-open flows (AC-9)"
+```
+
+---
+
+## Task 14: Full-suite verification + follow-up issues
+
+- [ ] **Step 1: Backend suite**
+
+Run: `cd apps/api/src/Api && dotnet test --filter "BoundedContext=SharedGameCatalog"`
+Expected: green; no growth over the known-flaky baseline.
+
+- [ ] **Step 2: Frontend quality gates**
+
+Run: `cd apps/web && pnpm typecheck && pnpm lint && pnpm test src/components/admin/mechanic-extractor src/components/pdf src/lib/api`
+Expected: green. Also run `pnpm lint:tokens` if any admin CSS changed (should be none beyond the allowed eslint-disable pattern).
+
+- [ ] **Step 3: File the two follow-up issues** (referenced by #526's DoD):
+  - **FU-1 — AC-1 real validation persistence**: persist per-claim guardrail outcomes + scores at pipeline time; flip `MechanicClaimValidations.DerivePass()` to persisted data; enable the *reject-all-failing-T2* predicate + T3 score display.
+  - **FU-2 — AC-4 analysis finalize**: reconcile analysis-level finalize with #527/ADR-051 (card creation belongs to #527 Publish); resolve the `FinalizeMechanicAnalysisCommand` name collision. Amend #526 AC-4/DoD "becomes mechanic_card".
+
+  Run (adjust body files as needed):
+  ```bash
+  gh issue create --repo meepleAi-app/meepleai-monorepo --title "[ME-M1.4 FU-1] Persist per-claim T1-T4 validation outcomes + scores" --label enhancement,area/backend,mechanic-extractor --body "Follow-up of #526. Replace the derived MechanicClaimValidations.DerivePass() with real per-claim guardrail outcomes captured at pipeline time (incl. T3 grounding score). Unblocks the reject-all-failing-T2 predicate + score display in the admin badges and #527 snapshot."
+  gh issue create --repo meepleAi-app/meepleai-monorepo --title "[ME-M1.4 FU-2] Analysis finalize + #527 publish reconciliation" --label enhancement,area/backend,mechanic-extractor --body "Follow-up of #526. Reconcile the analysis-level finalize with #527/ADR-051: card creation belongs to #527 Publish, not #526. Amend #526 AC-4/DoD 'becomes mechanic_card'. Resolve the FinalizeMechanicAnalysisCommand name collision with the legacy Variant-C draft flow."
+  ```
+
+- [ ] **Step 4: Update #526** — comment linking the delivered ACs + the two follow-ups; note the AC-1 (derived, FU-1) and AC-4 (deferred, FU-2) scope amendments so the DoD reflects delivered scope. Push the branch and open the PR to `main-dev` (see execution handoff).
+
+---
+
+## Manual verification checklist (before PR)
+
+- [ ] Admin can open a real analysis (`?analysisId=`), see 4 green T1–T4 badges per claim.
+- [ ] Clicking a citation opens the PDF at the right page; the quote highlights, or the amber fallback banner shows if not matched. **Verify admin PDF authorization**: `api.pdf.getPdfDownloadUrl(pdfDocumentId)` must resolve for an admin against a shared-game rulebook — if it 403s, file a small follow-up for an admin PDF-fetch route (not a #526 blocker for the rest).
+- [ ] Bulk "reject >20 words" shows the correct count and rejects only those claims.
+- [ ] Approve-with-note stores + displays the note (green block).
+- [ ] Review page footer shows the ADR-051 string; `grep "non ha mai letto"` → 0 hits.

--- a/docs/superpowers/plans/2026-07-08-issue-526-me-m14-admin-review-core.md
+++ b/docs/superpowers/plans/2026-07-08-issue-526-me-m14-admin-review-core.md
@@ -55,6 +55,18 @@
 
 ---
 
+## Delivery — recommended PR split
+
+14 tasks / ~20 files spanning a DB migration + 5 backend handlers + a metric + FE schemas/client + two new PDF components + a heavily-modified `ClaimsSection` + E2E is too large for one reviewable PR (and mixes a migration with UI churn). Recommended **3 stacked PRs** onto `main-dev` (each independently green; later PRs branch off the prior):
+
+- **PR-A — backend contract + AC-6 + AC-7 (Tasks 1–4):** `validations[]` DTO, `review_note` migration, approve-note (incl. the endpoint + `MapClaimToEntity` persistence fixes), bulk-actions counter. Migration isolated; fast BE tests.
+- **PR-B — FE plumbing + PDF (Tasks 5–7, 12):** schemas/client, `pdf-quote-highlight` helper, `PdfQuoteHighlighter`, footer attribution swap. No `ClaimsSection` behavior change.
+- **PR-C — ClaimsSection UI + E2E (Tasks 8–11, 13):** badges, citation wire, bulk dropdown, approve-note dialog, E2E. Concentrates the risky UI diff + the E2E fixture update in one reviewable slice.
+
+Task 14 (full-suite verify + follow-up filing) runs at the end of PR-C. If the reviewer prefers a single PR, the task order already works as one branch — this split is a reviewability optimization, not a dependency requirement. **Confirm the delivery shape before execution.**
+
+---
+
 ## Task 1: Backend — derived `validations[]` on `MechanicClaimDto`
 
 **Files:**
@@ -126,6 +138,7 @@ public static class MechanicClaimValidations
         Families.Select(f => new MechanicClaimValidationDto(f, "pass")).ToList();
 }
 ```
+> Honesty note: `all-pass` is correct, not optimistic. A section that fails guardrails returns `Output: null` and aborts (`MechanicAnalysisPipeline.cs:96-100,261`); the `PartiallyExtracted` salvage keeps only passed sections (`MechanicAnalysisExecutor.cs:291-292`) — so every *persisted* claim passed T1–T4. And `MechanicGuardrailOptions` exposes **no per-guardrail enable flag**, so no family is ever `notRun` in core; the spec's `notRun`-for-disabled branch stays dormant until FU-1 records real outcomes.
 
 - [ ] **Step 4: Add `Validations` to `MechanicClaimDto`** — append as the last positional param (after `Citations`) in `MechanicClaimDto.cs`:
 
@@ -144,10 +157,14 @@ public sealed record MechanicClaimDto(
     IReadOnlyList<MechanicClaimValidationDto> Validations);
 ```
 
-- [ ] **Step 5: Update every construction site.** Find them:
+- [ ] **Step 5: Update every construction site.** There are **5** — but `ApproveMechanicClaimCommandHandler.ToDto` is target-typed (`=> new(`), so a `new MechanicClaimDto(` grep only finds 4. Enumerate all 5 explicitly:
+- `GetMechanicAnalysisClaimsQueryHandler.cs:53`
+- `ApproveMechanicClaimCommandHandler.cs:113` (target-typed `new(`)
+- `RejectMechanicClaimCommandHandler.cs:100`
+- `BulkApproveMechanicClaimsCommandHandler.cs:119`
+- `BulkRejectMechanicClaimsCommandHandler.cs:132`
 
-Run: `cd apps/api/src/Api && grep -rn "new MechanicClaimDto(" .`
-For each site (GetMechanicAnalysisClaimsQueryHandler, ApproveMechanicClaimCommandHandler.ToDto, RejectMechanicClaimCommandHandler, BulkApproveMechanicClaimsCommandHandler, BulkRejectMechanicClaimsCommandHandler), add the final argument:
+Cross-check with `cd apps/api/src/Api && grep -rn "MechanicClaimDto(" BoundedContexts` (no `new ` prefix) — and rely on `dotnet build` (Step 6) to catch any miss (a missing arg is a compile error). For each, add the final argument:
 ```csharp
                     .ToList(),
             Validations: MechanicClaimValidations.DerivePass()));
@@ -220,26 +237,33 @@ Expected: migration applies; build succeeds.
 ```bash
 git add apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/MechanicClaimEntity.cs \
         apps/api/src/Api/Infrastructure/Configurations/SharedGameCatalog/MechanicClaimEntityConfiguration.cs \
-        apps/api/src/Api/Migrations
+        apps/api/src/Api/Infrastructure/Migrations
 git commit -m "feat(mechanic-extractor): #526 add nullable review_note column (AC-6)"
 ```
+> Migrations + the single `MeepleAiDbContextModelSnapshot.cs` live under `apps/api/src/Api/Infrastructure/Migrations/` (NOT `apps/api/src/Api/Migrations`). Confirm both the new migration file and the modified snapshot are staged.
 
 ---
 
 ## Task 3: Backend — thread optional approve note
 
 **Files:**
-- Modify: `…/Domain/Entities/MechanicClaim.cs` (`Approve`)
+- Modify: `…/Domain/Entities/MechanicClaim.cs` (`Approve`, `Reconstitute`, `ResetToPending`)
 - Modify: `…/Domain/Aggregates/MechanicAnalysis.cs` (`ApproveClaim`)
 - Modify: `…/Application/Commands/MechanicExtractor/ApproveMechanicClaimCommand.cs`, `…Handler.cs`, `…Validator.cs`
 - Modify: `…/Application/DTOs/MechanicClaimDto.cs` (add `ReviewNote`) + all construction sites
-- Test: `apps/api/tests/…/MechanicExtractor/ApproveMechanicClaimCommandHandlerTests.cs`
+- **Modify: `apps/api/src/Api/Routing/AdminMechanicAnalysesEndpoints.cs`** — the approve endpoint must bind the note from the body (BLOCKER-1)
+- **Modify: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/MechanicAnalysisRepository.cs`** — BOTH `MapClaimToDomain` (read) AND `MapClaimToEntity` (write) (BLOCKER-2)
+- Test: `apps/api/tests/…/MechanicExtractor/ApproveMechanicClaimCommandHandlerTests.cs` (Moq, fast) **and** an integration round-trip test in `MechanicAnalysisRepositoryIntegrationTests.cs` (Testcontainers) — the Moq test alone is INSUFFICIENT (it reads the in-memory domain object, so it stays green even if the DB write drops the note).
 
 **Interfaces:**
 - Consumes: `MechanicClaimValidations.DerivePass()` (Task 1).
-- Produces: `ApproveMechanicClaimCommand(Guid AnalysisId, Guid ClaimId, Guid ReviewerId, string? Note = null)`; `MechanicClaim.Approve(Guid, DateTime, string?)`; `MechanicAnalysis.ApproveClaim(Guid, Guid, DateTime, string?)`; `MechanicClaimDto.ReviewNote : string?`.
+- Produces: `ApproveMechanicClaimCommand(Guid AnalysisId, Guid ClaimId, Guid ReviewerId, string? Note = null)`; `MechanicClaim.Approve(Guid, DateTime, string?)`; `MechanicClaim.Reconstitute(…, IEnumerable<MechanicCitation> citations, string? reviewNote = null)` (new param is **LAST**); `MechanicAnalysis.ApproveClaim(Guid, Guid, DateTime, string?)`; `MechanicClaimDto.ReviewNote : string?`; `record ApproveClaimRequest(string? Note)` (endpoint body).
 
-- [ ] **Step 1: Write the failing domain test** — in `ApproveMechanicClaimCommandHandlerTests.cs` (mirror the Moq/`BuildInReviewAnalysis` pattern from `BulkRejectMechanicClaimsCommandHandlerTests.cs`):
+> ⚠️ **Two silent-persistence traps this task must close (both caught in plan review):**
+> 1. The approve **endpoint** currently binds no body (`AdminMechanicAnalysesEndpoints.cs:187-198` hard-codes `new ApproveMechanicClaimCommand(id, claimId, reviewerId)`), so the FE `{ note }` is discarded — mirror the reject endpoint's `RejectClaimRequest` binding.
+> 2. The repo **write** mapper `MapClaimToEntity` (`MechanicAnalysisRepository.cs:392-407`) copies `RejectionNote` but not `ReviewNote`; `Update()` forces `EntityState.Modified`, so `review_note` is UPDATEd to `null` unless the mapper is patched. The Moq handler test + the API response both come from the in-memory domain aggregate and will pass anyway — only the integration round-trip test (Step 9) catches this.
+
+- [ ] **Step 1: Write the failing Moq handler test** — in `ApproveMechanicClaimCommandHandlerTests.cs` (mirror the Moq/`BuildInReviewAnalysis` pattern from `BulkRejectMechanicClaimsCommandHandlerTests.cs`). NOTE: necessary but NOT sufficient — it verifies the domain thread, not persistence (Step 9 covers persistence):
 
 ```csharp
 [Fact]
@@ -283,7 +307,7 @@ Expected: FAIL — `ApproveMechanicClaimCommand` has 3 params / `MechanicClaimDt
         ReviewNote = string.IsNullOrWhiteSpace(note) ? null : note.Trim();
     }
 ```
-Also add `ReviewNote` to `Reconstitute` (new param + assignment) and set `ReviewNote = null` in `ResetToPending`. Update the `Reconstitute` call site in the repository's `MapToDomain` (grep `Reconstitute(` in `MechanicAnalysisRepository`).
+In `ResetToPending`, add `ReviewNote = null;`. In `Reconstitute`, add `string? reviewNote = null` as the **LAST** parameter (after `IEnumerable<MechanicCitation> citations`) — placing it mid-list breaks the 6 named-arg callers (1 prod + 5 tests) and an optional-before-required `citations` is a CS1737 compile error. Assign `claim.ReviewNote = reviewNote;` (via the object initializer). Only the prod caller passes it (Step 7); the 5 test callers keep compiling because the param is optional-and-last.
 
 - [ ] **Step 4: Aggregate** — `MechanicAnalysis.ApproveClaim`:
 
@@ -313,20 +337,69 @@ Validator (`ApproveMechanicClaimCommandValidator.cs`, after the ReviewerId rule)
 ```
 Handler (`ApproveMechanicClaimCommandHandler.cs`, line ~76): `analysis.ApproveClaim(request.ClaimId, request.ReviewerId, utcNow, request.Note);` and in `ToDto` add `ReviewNote: claim.ReviewNote,` after `RejectionNote:`.
 
-- [ ] **Step 6: DTO + entity mapping + all construction sites**
+- [ ] **Step 6: Bind the note at the endpoint (BLOCKER-1)** — in `AdminMechanicAnalysesEndpoints.cs`, the approve mapping (~line 187) currently takes no body. Add an optional body record + pass it (mirror the reject endpoint at ~line 210):
 
-Add `string? ReviewNote` to `MechanicClaimDto` (after `RejectionNote`); in `GetMechanicAnalysisClaimsQueryHandler` projection add `ReviewNote: c.ReviewNote,` (the query reads the `MechanicClaimEntity`, so `c.ReviewNote` resolves after Task 2); repeat for the Reject/BulkApprove/BulkReject projection sites (add `ReviewNote: c.ReviewNote,`). Confirm the entity→domain map (`MechanicClaimEntityConfiguration` already maps the column; the repository `Reconstitute` call must pass `entity.ReviewNote`).
+```csharp
+// near the other request records at the bottom of the file:
+internal sealed record ApproveClaimRequest(string? Note);
+```
+```csharp
+// approve endpoint handler — add the body param + thread request?.Note:
+        group.MapPost("/{id:guid}/claims/{claimId:guid}/approve", async (
+            Guid id,
+            Guid claimId,
+            ApproveClaimRequest? request,          // NEW — optional so empty-body approve still works
+            HttpContext httpContext,
+            IMediator mediator,
+            CancellationToken ct) =>
+        {
+            var session = (SessionStatusDto)httpContext.Items[nameof(SessionStatusDto)]!;
+            var reviewerId = session!.Principal!.Subject.Id;
+            var command = new ApproveMechanicClaimCommand(id, claimId, reviewerId, request?.Note);
+            var response = await mediator.Send(command, ct).ConfigureAwait(false);
+            return Results.Ok(response);
+        }) // …existing .WithName/.WithSummary chain unchanged
+```
 
-- [ ] **Step 7: Run to verify it passes + build**
+- [ ] **Step 7: Repository read + WRITE mappers (BLOCKER-2)** — in `MechanicAnalysisRepository.cs`:
+  - `MapClaimToDomain` (~line 328): pass the column into `Reconstitute` — `reviewNote: entity.ReviewNote` (last arg).
+  - **`MapClaimToEntity` (~line 404): add `ReviewNote = claim.ReviewNote,`** next to `RejectionNote = claim.RejectionNote,`. Without this, `Update()` writes `review_note = NULL`.
 
-Run: `cd apps/api/src/Api && dotnet test --filter "FullyQualifiedName~ApproveMechanicClaimCommandHandlerTests" && dotnet build`
-Expected: PASS + build OK (all `new MechanicClaimDto(` sites compile with `ReviewNote`).
+- [ ] **Step 8: DTO + all construction sites**
 
-- [ ] **Step 8: Commit**
+Add `string? ReviewNote` to `MechanicClaimDto` (after `RejectionNote`). Then update **all 5** construction sites (named args, so order-independent) — the literal grep misses the target-typed one, so enumerate: `GetMechanicAnalysisClaimsQueryHandler.cs:53` (entity source → `c.ReviewNote`), `ApproveMechanicClaimCommandHandler.cs:113` (`new(` target-typed — already handled in Step 5's `ToDto`), `RejectMechanicClaimCommandHandler.cs:100`, `BulkApproveMechanicClaimsCommandHandler.cs:119`, `BulkRejectMechanicClaimsCommandHandler.cs:132` (all four project from the domain aggregate → `c.ReviewNote`). Add `ReviewNote: c.ReviewNote,` to each.
+
+- [ ] **Step 9: Write the failing integration round-trip test (persistence guard)** — in `MechanicAnalysisRepositoryIntegrationTests.cs` (Testcontainers). This is the test the Moq one cannot be: it reloads the aggregate from Postgres and asserts the column survived.
+
+```csharp
+[Fact]
+public async Task ApprovedClaimWithNote_PersistsReviewNote_AcrossReload()
+{
+    var analysis = BuildInReviewAnalysisWithClaim(); // reuse this file's seed helper
+    await _repository.AddAsync(analysis, CancellationToken.None);
+    await _unitOfWork.SaveChangesAsync(CancellationToken.None);
+
+    var claimId = analysis.Claims.Single().Id;
+    analysis.ApproveClaim(claimId, Guid.NewGuid(), DateTime.UtcNow, "verified against p.4");
+    _repository.Update(analysis);
+    await _unitOfWork.SaveChangesAsync(CancellationToken.None);
+
+    var reloaded = await _repository.GetByIdWithClaimsIgnoringFiltersAsync(analysis.Id, CancellationToken.None);
+    reloaded!.Claims.Single(c => c.Id == claimId).ReviewNote.Should().Be("verified against p.4");
+}
+```
+Run it and confirm it FAILS before Step 7's `MapClaimToEntity` fix (proves the trap), then PASSES after.
+
+- [ ] **Step 10: Run to verify all pass + build**
+
+Run: `cd apps/api/src/Api && dotnet test --filter "FullyQualifiedName~ApproveMechanicClaimCommandHandlerTests|FullyQualifiedName~MechanicAnalysisRepositoryIntegrationTests" && dotnet build`
+Expected: PASS + build OK (all construction sites + the 6 `Reconstitute` callers compile).
+
+- [ ] **Step 11: Commit**
 
 ```bash
 git add -A
-git commit -m "feat(mechanic-extractor): #526 thread optional approve note through to review_note (AC-6)"
+git commit -m "feat(mechanic-extractor): #526 thread + persist optional approve note to review_note (AC-6)"
 ```
 
 ---
@@ -346,6 +419,7 @@ git commit -m "feat(mechanic-extractor): #526 thread optional approve note throu
 ```csharp
 using System.Diagnostics.Metrics;
 using Api.Observability;
+using Api.Tests.Constants;
 using FluentAssertions;
 using Xunit;
 
@@ -647,7 +721,7 @@ Expected: PASS.
   readonly highlightQuote?: string;
   readonly onQuoteMatch?: (found: boolean) => void;
 ```
-Destructure them (with `renderTextLayer` default `false`). Build the renderer + effect:
+Destructure them (with `renderTextLayer` default `false`). **Add `useMemo` to the existing React import** (`PdfInlineViewer.tsx:21` currently imports `useState, useEffect, useCallback, useRef` — not `useMemo`). Build the renderer:
 ```tsx
 import { makeQuoteTextRenderer } from './pdf-quote-highlight';
 // … inside component:
@@ -1168,7 +1242,7 @@ Expected: FAIL — approve now opens a dialog instead of firing immediately.
 - [ ] **Step 4: Run to verify it passes + existing claims tests + typecheck**
 
 Run: `cd apps/web && pnpm test src/components/admin/mechanic-extractor/claims && pnpm typecheck`
-Expected: PASS. (Note: existing tests that click `claim-approve-<id>` and expect immediate approval must be updated to go through the dialog — update them in this step.)
+Expected: PASS. (Note: `ClaimsSection` ships with **zero** pre-existing unit tests — the only tests touching `claim-approve-*` are the ones this plan creates in Tasks 8–11, and Tasks 8/9/10 never click approve, so routing approve through a dialog here breaks nothing prior. No external test needs updating.)
 
 - [ ] **Step 5: Commit**
 
@@ -1259,17 +1333,25 @@ export function MechanicAnalysisFooterAttribution({
       />
 ```
 
-- [ ] **Step 5: Verify the forbidden string is gone + existing page test passes**
+- [ ] **Step 5: Update the stale review-page test.** The existing test `renders copyright footer with Variant C text` in `review.test.tsx` has **two** assertions inside the swapped-out footer: `/Variant C/` (line 83) AND `/L'AI non ha mai letto…/` (line 85). The new `MechanicAnalysisFooterAttribution` renders **neither** — updating only line 85 leaves line 83 red. Rewrite the whole test to assert the new attribution and drop `/Variant C/`:
 
-Run:
+```tsx
+    expect(await screen.findByText(/riformulata in parole originali/i)).toBeInTheDocument();
+    expect(
+      screen.queryByText(/non ha mai letto il testo del PDF originale/i)
+    ).not.toBeInTheDocument();
 ```
-cd apps/web && grep -rn "non ha mai letto il testo del PDF originale" src ; echo "hits above (expect 0)"
+
+- [ ] **Step 6: Verify the forbidden string is gone + tests pass.** The source uses the entity apostrophe `L&apos;AI` and wraps `…del PDF` / `originale.` across two lines, so a full-phrase grep never matches the page — use the short substring:
+
+```
+cd apps/web && grep -rn "non ha mai letto" src ; echo "hits above (expect 0)"
 pnpm test src/components/admin/mechanic-extractor/__tests__/MechanicAnalysisFooterAttribution.test.tsx
 pnpm test src/__tests__/app/admin/knowledge-base/mechanic-extractor/review.test.tsx
 ```
-Expected: **0 grep hits**; both tests PASS. NB the existing `review.test.tsx:85` asserts `/L'AI non ha mai letto…/` — that assertion is now stale and MUST be updated in this step to assert the new attribution text (`/riformulata in parole originali/i`) instead. Update it.
+Expected: **0 grep hits**; both tests PASS.
 
-- [ ] **Step 6: Commit**
+- [ ] **Step 7: Commit**
 
 ```bash
 git add apps/web/src/components/admin/mechanic-extractor/MechanicAnalysisFooterAttribution.tsx apps/web/src/components/admin/mechanic-extractor/__tests__ "apps/web/src/app/admin/(dashboard)/knowledge-base/mechanic-extractor/review/page.tsx" apps/web/src/__tests__/app/admin/knowledge-base/mechanic-extractor/review.test.tsx
@@ -1286,7 +1368,17 @@ git commit -m "feat(mechanic-extractor): #526 swap Variant-C footer for ADR-051 
 **Interfaces:**
 - Consumes: all prior tasks (the running app).
 
-- [ ] **Step 1: Add a claims fixture with two claims (one long-quote) + a bulk-reject route mock.** In `mockAnalysisRoutes`, add `bulkReject: 0` to `calls`, extend `buildClaimsResponse()` to return two claims (`CLAIM_ID` with a >20-word quote + a second short-quote claim), and register:
+- [ ] **Step 1: Update the claims fixture (REQUIRED — Task 5 made `reviewNote` + `validations` non-optional) + add a bulk-reject mock.** `HttpClient.validateResponse` throws `SchemaValidationError` on a `safeParse` miss, so the existing `buildClaimsResponse()` (which omits both new fields) will make `getMechanicAnalysisClaims` throw → `ClaimsSection` renders `claims-load-error` and **all three existing E2E tests break** (deep-link / load-by-id / discovery). Every claim object in `buildClaimsResponse()` MUST add:
+```ts
+      reviewNote: null,
+      validations: [
+        { rule: 'T1', outcome: 'pass', message: null },
+        { rule: 'T2', outcome: 'pass', message: null },
+        { rule: 'T3', outcome: 'pass', message: null },
+        { rule: 'T4', outcome: 'pass', message: null },
+      ],
+```
+Then, in `mockAnalysisRoutes`, add `bulkReject: 0` to `calls`, extend `buildClaimsResponse()` to return two claims (`CLAIM_ID` with a >20-word quote + a second short-quote claim), flip the status builder to `InReview` (so the bulk `Select` renders — `isClaimsActionable = InReview && !suppressed`), and register:
 ```ts
   await page.context().route(
     new RegExp(`/api/v1/admin/mechanic-analyses/${ANALYSIS_ID}/claims/bulk-reject$`),

--- a/docs/superpowers/specs/2026-07-08-issue-526-me-m14-admin-review-core-design.md
+++ b/docs/superpowers/specs/2026-07-08-issue-526-me-m14-admin-review-core-design.md
@@ -1,0 +1,139 @@
+# Design — #526 ME-M1.4 Admin Review UI (core iteration)
+
+- **Issue**: [#526](https://github.com/meepleAi-app/meepleai-monorepo/issues/526) `[ME-M1.4] Admin Review UI: per-claim approve/reject + citation viewer`
+- **Parent ADR**: [ADR-051 Mechanic Extractor IP Policy](../../for-claude/architecture/adr/adr-051-mechanic-extractor-ip-policy.md)
+- **Date**: 2026-07-08
+- **Status**: PROPOSED (design approved in brainstorming; awaiting spec review → writing-plans)
+- **Branch**: `feature/issue-526-me-m14-admin-review-ui` (parent `main-dev`)
+
+---
+
+## 1. Context
+
+`#526` is the admin per-claim review surface for the Mechanic Extractor pipeline. PR #592 already shipped ~50% of the feature. A structured recon of the current codebase (7-agent understand fan-out, 2026-07-08) surfaced that the repository is in several places **ahead of** the issue body, and that two acceptance criteria carry **cross-issue contradictions** that must not be resolved unilaterally inside this issue.
+
+### Already shipped (PR #592 — verify + close)
+- Route consumes `mechanic_analyses` (not the legacy `mechanic_drafts`). **NB the route is the single-file `.../mechanic-extractor/analyses/page.tsx` deep-linked via `?analysisId=` query param — NOT a `[id]` dynamic route** (the issue's AC-Done text is inaccurate on this).
+- Per-claim approve/reject + `RejectClaimDialog` (mandatory note, 1–500 chars).
+- `MechanicAnalysesListCard` discovery table; `ClaimsSection` grouped-by-section claim list; single "Bulk approve pending" button.
+- Backend **`POST /admin/mechanic-analyses/{id}/claims/bulk-reject`** already exists (command + validator + handler + tests) — only the frontend wiring is missing.
+- Analysis lifecycle already present: `submit-review` → `approve` (`InReview`→`Published`, **409 if any claim is not Approved**) → `suppress`.
+- One E2E: `apps/web/e2e/admin-mechanic-extractor-validation/load-existing-analysis.spec.ts`.
+
+### Ground-truth facts from recon (evidence-backed)
+- **Guardrail (T1–T4) outcomes are transient.** `MechanicValidationViolation` (`IMechanicOutputValidator.cs:33` = `record (string Rule, string Message, string? Path)`) is produced only during the pipeline to drive rejection-sampling retries (`MechanicAnalysisPipeline.cs:220,238`) and then discarded. There is **no persisted per-claim validation column, and no `MechanicValidationViolation` domain entity.** `MechanicClaim` fields are: `AnalysisId, Section, Text, DisplayOrder, Status, ReviewedBy, ReviewedAt, RejectionNote, Citations, IsNew` (`MechanicClaim.cs`).
+- **Corollary:** any claim reaching the review queue has, by construction, passed its section's enabled guardrails (rejection sampling retries the section until guardrails pass, or aborts the analysis to `PartiallyExtracted`/`Rejected`). So real per-claim T1–T4 data is largely degenerate (all-pass) — persisting it is low value; a **derived** signal captures nearly all of it.
+- **Guardrail → rule-family map:** T1 = `QuoteCapGuardrail`, T2 = `RejectionSamplingGuardrail` (long-verbatim), T3a = `CitationPresenceGuardrail`, T3b = `GroundingGuardrail`, T4 = `PageSubstringGuardrail`.
+- **Analysis status enum** (`MechanicAnalysisStatus`): `Draft(0), InReview(1), Published(2), Rejected(3), PartiallyExtracted(4)`. There is **no `Approved` and no `NeedsReview`** state — the issue body's AC-4 wording assumes states that do not exist.
+- **`mechanic_card` aggregate does not exist yet** (0 files). It is created by #527's explicit Publish, not by #526.
+- **PDF stack already exists:** `react-pdf@10.4.1` + `pdfjs-dist@5.7.284` (pinned), worker bundled locally. Reusable viewers live in `apps/web/src/components/pdf/` (`PdfInlineViewer` documented as the shared viewer, `PdfViewerModal` already renders the text layer). **No on-page quote highlighting exists anywhere.** No bounding-box / pixel-coordinate data exists for quotes (blocks "Pattern B").
+- **`ApproveMechanicClaimCommand`** = `record (AnalysisId, ClaimId, ReviewerId)` — **no note field**; the domain `MechanicClaim.Approve()` clears `RejectionNote`. Approve-with-note therefore needs a new note sink.
+
+---
+
+## 2. Scope (locked)
+
+### IN — this PR (core)
+| AC | Deliverable |
+|----|-------------|
+| AC-1 (contract only) | Extend `MechanicClaimDto` with `validations[]` (**derived**, not persisted) + render T1–T4 badges from it (green/red/gray). |
+| AC-2 | `<PdfQuoteHighlighter>` at `components/pdf/`, Pattern A (text-layer search) + page-level fallback; wired into `ClaimsSection` citation rows. |
+| AC-3 | "Bulk action" dropdown: *approve-all-pending* (existing) + *reject-all-quote>20-words* (client predicate → existing bulk-reject endpoint) + count-confirm dialog. |
+| AC-5 | `<MechanicAnalysisFooterAttribution>` (ADR-051 canonical string); remove forbidden Variant-C string; grep gate → 0 hits. |
+| AC-6 (MVP) | Approve-with-note (optional): adds one nullable `ReviewNote` column + extends approve command. |
+| AC-7 (light) | `mechanic_review_bulk_actions_total{action}` counter via `MeepleAiMetrics`; test isolated per the static-Meter pollution pitfall (#2752). |
+| AC-8 | a11y: badge `aria-label`s, PDF modal focus-trap, dark-mode highlight contrast. |
+| AC-9 | Tests (Vitest + backend handler + E2E extension). |
+
+### OUT — deferred to scoped follow-up issues
+- **FU-1 (AC-1 real):** persist per-claim guardrail outcomes + scores (e.g. T3 grounding score) at pipeline time; flip the derived `validations[]` to persisted; unblocks the *reject-all-failing-T2* predicate and T3 score display.
+- **FU-2 (AC-4):** analysis-level Finalize + state-machine reconciliation with #527/ADR-051. **Amend** the #526 AC-4/DoD line "*Finalize → becomes mechanic_card*" — card creation belongs to #527's explicit Publish (ADR-051 §7 requires deliberate publication; #527 AD-5). Resolve the `FinalizeMechanicAnalysisCommand` name collision (the existing command is the legacy Variant-C draft flow).
+
+---
+
+## 3. Locked decisions
+
+1. **Scope** = core-completable + 2 follow-ups (above).
+2. **`<PdfQuoteHighlighter>` path** = `apps/web/src/components/pdf/PdfQuoteHighlighter.tsx` (matches all existing PDF primitives). Reconcile #530's spec text (which names `components/citations/`) to this path.
+3. **AC-1 data** = **derived from the pass-invariant** in `GetMechanicAnalysisClaimsQueryHandler`, not persisted. Documented as derived in code + DTO XML doc. Real persistence = FU-1.
+4. **AC-4 (finalize)** = **not in this PR.** #526 does NOT create the `mechanic_card`.
+5. **AC-2 algorithm** = Pattern A (text-layer substring search) with page-level-highlight + banner fallback (pre-authorized by #526 F2 and #530). Component API is hybrid-shaped (accepts optional coordinates) so a future Pattern-B backend slots in without an API change. Admin context does not require antiLeak → text layer is rendered.
+6. **AC-6** = the single nullable `ReviewNote` column is the **only migration** in core (AC-1 validations are derived, no migration). *Open to trimming to "reject-note only, defer approve-note to FU-1" at the review gate if a zero-migration core is preferred.*
+
+---
+
+## 4. Design detail
+
+### 4.1 Backend
+
+**`MechanicClaimDto` + validations contract** — add:
+```
+public sealed record MechanicClaimValidationDto(
+    string Rule,        // "T1" | "T2" | "T3" | "T4"
+    string Outcome,     // "pass" | "fail" | "notRun"
+    string? Message);   // populated only on fail (from MechanicValidationViolation.Message)
+```
+`MechanicClaimDto.Validations : IReadOnlyList<MechanicClaimValidationDto>`. `GetMechanicAnalysisClaimsQueryHandler` derives one entry per badge family (T1, T2, T3 = grounding+citation-present, T4): `pass` for enabled guardrails (any persisted claim passed them), `notRun` for guardrails disabled in `MechanicGuardrailOptions`. Never emits `fail` in the derived path (a failing claim would not be in the queue) — the `fail`/`Message` path lights up only once FU-1 persists real outcomes. #527 snapshots this array into `mechanic_cards.content` (score fields arrive with FU-1).
+
+**Approve-with-note (AC-6)** — add nullable `ReviewNote` (snake_case `review_note`) to `MechanicClaim` + `MechanicClaimEntity` + config + additive migration; add optional `Note` to `ApproveMechanicClaimCommand` + domain `MechanicClaim.Approve(reviewerId, utcNow, note?)`. Reject-note flow is unchanged (already shipped).
+
+**No new endpoints.** `bulk-reject` exists. AC-7 adds a counter increment in the bulk-reject/bulk-approve handlers.
+
+### 4.2 Frontend
+
+**`<PdfQuoteHighlighter pdfUrl page quote onClose coordinates?/>`** (`components/pdf/`) — composes `PdfInlineViewer`, opens at `page`, renders the text layer, normalizes whitespace/soft-hyphenation, substring-matches `quote` against positioned spans, overlays `<mark>` (`rgba(255,235,59,0.4)`). On no-match: page-level highlight + banner *"Quote non individuabile automaticamente; verifica manualmente"*. WCAG AA ≥3:1 + text-only toggle. PDF URL resolved from the analysis `pdfDocumentId` (`MechanicCitationDto` carries only `{pdfPage, quote}`).
+
+**`ClaimsSection` changes:**
+- **Badges (AC-1):** 4 badges/claim from `claim.validations ?? []`; green(pass)/red(fail)/gray(notRun|absent); tooltip = `message` on fail; `aria-label` per badge. Gray fallback when field empty → real-data flip is a pure BE change.
+- **Citation rows (AC-2):** the plain-text `p.N — "quote"` becomes a button → opens `<PdfQuoteHighlighter>`.
+- **Bulk dropdown (AC-3):** replace the single button with a `Select`: *Approva tutti i pending* (existing `bulkApproveMechanicClaims`); *Rifiuta tutti con quote >20 parole* (client predicate on `citations[].quote` word count → compute `claimIds` → existing `bulk-reject`), with a confirm dialog showing the predicted count (`"Rifiuta 7 claim?"`). **No 5-second undo** (count-confirm is the guard; keeps the audit log clean). Add FE: route constant `bulkRejectClaims`, `BulkRejectMechanicClaimsResponseDtoSchema`, `bulkRejectMechanicClaims` client method.
+- **Approve-with-note (AC-6):** optional collapsible textarea on approve (reuse the `RejectClaimDialog` pattern).
+
+**`<MechanicAnalysisFooterAttribution>`** (shared, reused by #528) renders the ADR-051 string:
+> *"Analisi elaborata dall'AI sul manuale del gioco. Ogni affermazione è riformulata in parole originali e cita la pagina del regolamento. Copyright © degli editori per il testo originale del manuale."*
+
+Remove the forbidden *"L'AI non ha mai letto il testo del PDF originale."* from `review/page.tsx` (and any other hit). **DoD gate:** `grep "L'AI non ha mai letto" apps/web/src` → 0 hits.
+
+### 4.3 Conventions (match existing admin code)
+shadcn primitives (`@/components/ui/{primitives,data-display,overlays}/…`), **not** MeepleCard. Keep the file-level `eslint-disable local/no-hardcoded-color-utility` (DS-13d admin scope) with the existing amber/green/rose class maps — **do not** introduce `--admin-*` tokens (that is DS-15/16). React Query keys `['mechanic-analysis', id, 'claims']` etc. Pervasive `data-testid`. EF: `HasColumnName("review_note")` (no auto snake_case).
+
+---
+
+## 5. Testing (AC-9)
+
+- **Vitest (FE):** badge render matrix (green/red/gray × T1–T4 fixtures); `<PdfQuoteHighlighter>` not-found fallback banner; bulk dropdown predicate → count → confirm; footer swap (old string absent, new string present); approve-with-note optional path.
+- **Backend:** `GetMechanicAnalysisClaimsQueryHandler` asserts derived `validations[]` (pass for enabled, notRun for disabled); `ApproveMechanicClaimCommand` with/without note; AC-7 counter test isolated (distinctive tag or `[Collection]` disabling parallel, per #2752).
+- **E2E:** extend `load-existing-analysis.spec.ts` → bulk-reject-by-predicate flow + citation-open flow.
+
+---
+
+## 6. Follow-up issues to open
+
+- **FU-1 — AC-1 real validation persistence.** Persist per-claim guardrail outcomes + scores at pipeline time; flip derived `validations[]` → persisted; enable *reject-all-failing-T2* predicate + T3 score display.
+- **FU-2 — AC-4 finalize + state reconciliation.** Analysis-level Finalize reconciled with #527/ADR-051; amend the "becomes mechanic_card" AC (card = #527 Publish); resolve the `FinalizeMechanicAnalysisCommand` name collision.
+
+Both must be filed **before** closing #526, and #526's AC-4/AC-1-real items moved into them so #526's DoD reflects the actual delivered scope.
+
+---
+
+## 7. Risks / open items
+
+- **Quote text-layer match rate** on OCR'd/photo-batch PDFs is unknown; Pattern A may fall back to page-level highlight frequently. Acceptable (fallback is pre-blessed), but worth a quick spike on a seeded game (e.g. Catan) during implementation.
+- **Admin PDF fetch authorization:** confirm an admin can fetch an arbitrary shared-game rulebook PDF via `pdfDocumentId` (existing `api.pdf.getPdfDownloadUrl` or a new admin route). If a new route is needed, it is a small addition.
+- **`PartiallyExtracted` analyses** in the review UI: badges render fine (surviving claims passed); bulk actions operate on present claims. No special handling needed for core.
+- Branch currently tracks `origin/main-dev`; push with `git push -u origin feature/issue-526-me-m14-admin-review-ui` to retarget upstream.
+
+---
+
+## 8. Key references
+- `apps/web/src/app/admin/(dashboard)/knowledge-base/mechanic-extractor/analyses/page.tsx` — review route (`?analysisId=`).
+- `apps/web/src/components/admin/mechanic-extractor/claims/ClaimsSection.tsx` — primary FE surface.
+- `apps/web/src/components/admin/mechanic-extractor/claims/RejectClaimDialog.tsx` — reuse for approve-note.
+- `apps/web/src/lib/api/schemas/mechanic-analyses.schemas.ts` — Zod DTOs + routes.
+- `apps/web/src/lib/api/clients/admin/adminContentClient.ts` — admin client methods.
+- `apps/web/src/components/pdf/PdfInlineViewer.tsx` — base for `<PdfQuoteHighlighter>`.
+- `apps/api/src/Api/Routing/AdminMechanicAnalysesEndpoints.cs` — REST surface (bulk-reject at :258).
+- `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/DTOs/MechanicClaimDto.cs` — DTO to extend.
+- `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Entities/MechanicClaim.cs` — add `ReviewNote`.
+- `apps/api/.../Application/Services/MechanicExtractor/Guardrails/*` — T1–T4 rule families.
+- `docs/for-claude/architecture/adr/adr-051-mechanic-extractor-ip-policy.md` — footer string, T-constraints, status enum addendum.


### PR DESCRIPTION
## PR-C — ClaimsSection UI + E2E (Tasks 8–11, 13)

Part of **#526** (ME-M1.4). **Third of 3 stacked PRs** — completes the slice.
Stack: PR-A → main-dev · PR-B → PR-A · **PR-C (this) → PR-B**.
⚠️ **Base is `feature/issue-526-me-m14-pr-b-fe-pdf`** (stacked). Re-targets to `main-dev` as the stack merges.

### What
Wires the review UI in `ClaimsSection.tsx` (+ E2E):
- **T8 — T1–T4 validation badges (AC-1 UI):** `ValidationBadges` per claim (pass/fail/notRun color map, per-badge `data-testid` + `aria-label`).
- **T9 — citation → PdfQuoteHighlighter (AC-2 wire):** citation rows become buttons that open the highlighter at the citation's page+quote; `pdfDocumentId` threaded from the analyses page; plain-text fallback when absent.
- **T10 — bulk-action dropdown (AC-3):** a Radix `Select` with `approve-all-pending` + `reject-all-with-quote > 20 words` (strict predicate), a count-confirm `BulkActionDialog`, and `bulkRejectMutation` (skipped-warning + query invalidation). Existing bulk-approve preserved (regression-tested).
- **T11 — approve-with-note dialog (AC-6 UI):** Approve routes through an `ApproveClaimDialog` (optional note, confirm always enabled); `reviewNote` rendered as a green block. **Review-fix:** the note cap was aligned FE↔BE to **2000** via a shared schema constant (was a stray 500 copied from the reject bound).
- **T13 — E2E bulk-reject + citation-open (AC-9):** fixture updated to carry the now-required `validations`/`reviewNote` (prevents the schema-validation break of the 3 pre-existing tests); Radix `Select` driven by click (not `selectOption`).

### Testing
- 10/10 `ClaimsSection` unit tests (badges/citation/bulk/approve-note) green; FE **typecheck 0 · lint 0 · 1671 tests / 0 fail**.
- **Known pre-existing (NOT this PR):** the E2E spec hard-fails locally due to the repo-wide `PLAYWRIGHT_AUTH_BYPASS` + `USER_ROLE_COOKIE_V1` sunset (2026-05-13); the 3 pre-existing tests fail identically. Spec is structurally verified (fixture schema-matched, Radix-click); it runs in CI via the real backend session. Follow-up filed.

### Scope amendments (#526 DoD)
- **AC-1** shipped as **derived** all-pass; real per-claim persistence → **FU-1** (filed).
- **AC-4** analysis-finalize / #527 reconciliation → **FU-2** (filed).

### Review
All tasks individually spec+quality reviewed; the T11 note-cap Important finding was fixed + re-reviewed (closed). Final whole-branch review: **ready to merge**, all remaining findings deferred to FU-1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
