### PR TITLE
perf(infra): #2794 CPU-only torch — slim reranker/embedding images (~6GB su ARM)

### DIFF
--- a/apps/embedding-service/Dockerfile
+++ b/apps/embedding-service/Dockerfile
@@ -20,6 +20,13 @@ COPY requirements.txt .
 # PyPI/pythonhosted occasionally times out on large packages (torch ~700MB).
 # Extend pip's 15s socket timeout and add resumable retries.
 ENV PIP_DEFAULT_TIMEOUT=300
+# Install CPU-only torch FIRST from the official PyTorch CPU index (#2794).
+# On aarch64 the default `pip install torch` bundles ~2.9GB of unused NVIDIA
+# CUDA libraries (nvidia_cublas/cudnn/nccl/...); this server is GPU-less and the
+# service runs DEVICE=cpu, so they are dead weight. Pre-installing the CPU wheel
+# leaves torch already satisfied, so the requirements install below never pulls
+# the CUDA variant (and requirements.txt stays unchanged for CI test jobs).
+RUN pip install --no-cache-dir --retries 5 torch==2.12.1 --index-url https://download.pytorch.org/whl/cpu
 RUN pip install --no-cache-dir --retries 5 -r requirements.txt
 
 # Pre-download the model so runtime container starts fast

--- a/apps/embedding-service/Dockerfile
+++ b/apps/embedding-service/Dockerfile
@@ -26,6 +26,7 @@ ENV PIP_DEFAULT_TIMEOUT=300
 # service runs DEVICE=cpu, so they are dead weight. Pre-installing the CPU wheel
 # leaves torch already satisfied, so the requirements install below never pulls
 # the CUDA variant (and requirements.txt stays unchanged for CI test jobs).
+# hadolint ignore=DL3013 -- torch IS pinned; hadolint misreads the --index-url value as an unpinned package
 RUN pip install --no-cache-dir --retries 5 torch==2.12.1 --index-url https://download.pytorch.org/whl/cpu
 RUN pip install --no-cache-dir --retries 5 -r requirements.txt
 

--- a/apps/embedding-service/Dockerfile
+++ b/apps/embedding-service/Dockerfile
@@ -26,7 +26,8 @@ ENV PIP_DEFAULT_TIMEOUT=300
 # service runs DEVICE=cpu, so they are dead weight. Pre-installing the CPU wheel
 # leaves torch already satisfied, so the requirements install below never pulls
 # the CUDA variant (and requirements.txt stays unchanged for CI test jobs).
-# hadolint ignore=DL3013 -- torch IS pinned; hadolint misreads the --index-url value as an unpinned package
+# torch IS pinned below; hadolint misreads the --index-url value as an unpinned positional package (DL3013 false positive)
+# hadolint ignore=DL3013
 RUN pip install --no-cache-dir --retries 5 torch==2.12.1 --index-url https://download.pytorch.org/whl/cpu
 RUN pip install --no-cache-dir --retries 5 -r requirements.txt
 

--- a/apps/reranker-service/Dockerfile
+++ b/apps/reranker-service/Dockerfile
@@ -26,7 +26,8 @@ COPY requirements.txt .
 # service runs DEVICE=cpu, so they are dead weight. Pre-installing the CPU wheel
 # leaves torch already satisfied, so the requirements install below never pulls
 # the CUDA variant (and requirements.txt stays unchanged for CI test jobs).
-# hadolint ignore=DL3013 -- torch IS pinned; hadolint misreads the --index-url value as an unpinned package
+# torch IS pinned below; hadolint misreads the --index-url value as an unpinned positional package (DL3013 false positive)
+# hadolint ignore=DL3013
 RUN pip install --no-cache-dir --retries 5 torch==2.12.1 --index-url https://download.pytorch.org/whl/cpu
 RUN pip install --no-cache-dir --retries 5 -r requirements.txt
 

--- a/apps/reranker-service/Dockerfile
+++ b/apps/reranker-service/Dockerfile
@@ -10,14 +10,28 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Python dependencies
+# Install Python dependencies into a virtual env for a clean copy into the
+# runtime stage (#2794). The previous `pip wheel` + copy-to-/wheels approach
+# left ~409MB of wheel files behind in the final image (they were installed but
+# never removed). The venv-copy pattern (mirrors embedding-service) carries only
+# the installed packages, no wheel artifacts.
+RUN python -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+ENV PIP_DEFAULT_TIMEOUT=300
+
 COPY requirements.txt .
-RUN pip wheel --no-cache-dir --no-deps --wheel-dir /app/wheels -r requirements.txt
+# Install CPU-only torch FIRST from the official PyTorch CPU index (#2794).
+# On aarch64 the default `pip install torch` bundles ~2.9GB of unused NVIDIA
+# CUDA libraries (nvidia_cublas/cudnn/nccl/...); this server is GPU-less and the
+# service runs DEVICE=cpu, so they are dead weight. Pre-installing the CPU wheel
+# leaves torch already satisfied, so the requirements install below never pulls
+# the CUDA variant (and requirements.txt stays unchanged for CI test jobs).
+RUN pip install --no-cache-dir --retries 5 torch --index-url https://download.pytorch.org/whl/cpu
+RUN pip install --no-cache-dir --retries 5 -r requirements.txt
 
 # Pre-download ML model in builder to avoid cold-start delay
 ENV HF_HOME=/model-cache
-RUN pip install --no-cache-dir /app/wheels/* \
-    && python -c "from sentence_transformers import CrossEncoder; CrossEncoder('BAAI/bge-reranker-v2-m3')"
+RUN python -c "from sentence_transformers import CrossEncoder; CrossEncoder('BAAI/bge-reranker-v2-m3')"
 
 # Production stage
 FROM python:3.11-slim
@@ -32,12 +46,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy wheels from builder stage
-COPY --from=builder /app/wheels /wheels
-COPY --from=builder /app/requirements.txt .
-
-# Install dependencies from wheels (faster, no compilation)
-RUN pip install --no-cache-dir /wheels/*
+# Copy the virtual env with all installed packages (no build tools, no wheels)
+COPY --from=builder /opt/venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
 
 # Copy pre-downloaded model from builder
 COPY --from=builder --chown=reranker:reranker /model-cache /home/reranker/.cache/huggingface

--- a/apps/reranker-service/Dockerfile
+++ b/apps/reranker-service/Dockerfile
@@ -26,7 +26,8 @@ COPY requirements.txt .
 # service runs DEVICE=cpu, so they are dead weight. Pre-installing the CPU wheel
 # leaves torch already satisfied, so the requirements install below never pulls
 # the CUDA variant (and requirements.txt stays unchanged for CI test jobs).
-RUN pip install --no-cache-dir --retries 5 torch --index-url https://download.pytorch.org/whl/cpu
+# hadolint ignore=DL3013 -- torch IS pinned; hadolint misreads the --index-url value as an unpinned package
+RUN pip install --no-cache-dir --retries 5 torch==2.12.1 --index-url https://download.pytorch.org/whl/cpu
 RUN pip install --no-cache-dir --retries 5 -r requirements.txt
 
 # Pre-download ML model in builder to avoid cold-start delay


### PR DESCRIPTION
Closes #2794

## Problema
Staging (Hetzner CAX21 **ARM64, GPU-less**) all'82% disco. Le immagini `reranker-service` (13.1GB) e `embedding-service` (10.4GB) dominano l'occupazione Docker.

`docker exec ... du` sulle immagini live ha mostrato che **ognuna trascina ~2.9GB di librerie CUDA NVIDIA** (`nvidia_cublas`, `nvidia_cudnn_cu13`, `nvidia_nccl_cu13`, `cufft`, `cusparse`, `cusolver`, …): il default `pip install torch` su aarch64 bundle-a le wheel CUDA. I servizi girano `DEVICE=cpu` su una macchina **senza GPU** → peso morto mai caricato. Il reranker in più lasciava **409MB di `/wheels`** nell'immagine finale (installati ma mai cancellati).

## Fix
1. **Torch CPU-only** dall'indice ufficiale PyTorch (`--index-url https://download.pytorch.org/whl/cpu`) pre-installato **prima** delle requirements → torch risulta già soddisfatto, `pip install -r requirements.txt` non ritira più la variante CUDA. `requirements.txt` **invariato** → i job di test CI non cambiano.
2. **Reranker → pattern venv-copy** (come embedding) → niente `/wheels` residui nell'immagine finale.

## Risparmio atteso
| Immagine | Prima | Dopo | Δ |
|---|---|---|---|
| reranker-service | 13.1GB | ~9.7GB | −2.9GB CUDA −0.4GB wheels |
| embedding-service | 10.4GB | ~7.5GB | −2.9GB CUDA |

**~6GB netti** dopo redeploy + prune delle immagini superate.

## Rischio
Basso: `DEVICE=cpu` già in uso, le lib CUDA non vengono mai caricate → inference invariata.

## Validazione
⚠️ **Non buildato in locale** (host x86/Windows non builda immagini ARM). La validazione reale è il **rebuild ARM path-filtered** su `apps/{reranker,embedding}-service/**` al prossimo deploy `main-staging`, oppure un `workflow_dispatch` di `deploy-staging.yml` (skip_tests) su questo branch. Verificare healthcheck verdi (`/health` 8003/8000) prima del merge staging.

## Fuori scope
Externalizzare i modelli baked (bge-reranker-v2-m3 ~2.3GB, e5-base ~1.1GB) su volume — reintroduce cold-start, decisione separata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)