### PR TITLE
chore(infra): #2796 rimuovi n8n da staging (inutilizzato) + gate health check

### DIFF
--- a/apps/api/src/Api/Extensions/ObservabilityServiceExtensions.cs
+++ b/apps/api/src/Api/Extensions/ObservabilityServiceExtensions.cs
@@ -200,14 +200,25 @@ internal static class ObservabilityServiceExtensions
                 "shared-catalog-fts",
                 failureStatus: HealthStatus.Degraded,
                 tags: SharedCatalogTags)
-            .AddUrlGroup(
-                new Uri($"{n8nUrl}/healthz"),
-                name: "n8n",
-                tags: N8nTags)
             .AddCheck<Api.Infrastructure.HealthChecks.ConfigurationHealthCheck>(
                 "configuration",
                 failureStatus: HealthStatus.Degraded,
                 tags: ConfigurationTags);
+
+        // #2796: only health-check n8n when the WorkflowIntegration webhook client
+        // is actually enabled (mirrors N8nWebhookClientOptions.SectionName "N8n" +
+        // IsEnabled). Staging removed n8n entirely (disk); an unconditional probe
+        // would report permanent Unhealthy on the dashboard for a service we don't
+        // integrate with. String-indexer read avoids coupling to the WI context.
+        var n8nEnabled = string.Equals(
+            configuration["N8n:IsEnabled"], "true", StringComparison.OrdinalIgnoreCase);
+        if (n8nEnabled)
+        {
+            builder.AddUrlGroup(
+                new Uri($"{n8nUrl}/healthz"),
+                name: "n8n",
+                tags: N8nTags);
+        }
     }
 
     /// <summary>

--- a/infra/compose.staging.yml
+++ b/infra/compose.staging.yml
@@ -298,8 +298,12 @@ services:
   alertmanager:
     restart: always
 
-  n8n:
-    restart: always
+  # n8n removed from staging (#2796): the WorkflowIntegration webhook client is
+  # disabled by default (N8n:IsEnabled=false, never set true in staging), so no
+  # GameNight webhooks were ever firing. The 1.62GB image + always-on container
+  # were pure disk cost on the CAX21. Base compose still defines n8n under the
+  # `automation` profile for local dev; re-enable in staging by re-adding this
+  # block AND setting N8n:IsEnabled=true.
 
 # Traefik service definition removed (PR #738, post CF Tunnel cutover, T18 Phase 6).
 # Edge is now Cloudflare Tunnel (cloudflared on VPS). For rollback see


### PR DESCRIPTION
Closes #2796

## Contesto
n8n (`n8nio/n8n:1.114.4`, **1.62GB**) girava in staging ma **non era usato**: `N8nWebhookClientOptions.IsEnabled` è **`false` di default** e nessuna config staging lo attiva → `N8nWebhookClient.TriggerWorkflowAsync` fa early-return, i webhook GameNight (published/cancelled/rsvp) **non partivano già**. Nessun volume dati (niente persistito).

Container + immagine **già rimossi dal server** (disco 75%→72%, ~2GB). Questo PR rende la rimozione permanente e pulisce il monitoring.

## Modifiche
1. **`infra/compose.staging.yml`** — rimosso il blocco `n8n:` (restart: always) così `docker compose up` non lo ricrea. Base compose conserva n8n sotto profilo `automation` per dev locale.
2. **`ObservabilityServiceExtensions.cs`** — il health check `AddUrlGroup(http://n8n:5678/healthz, name: "n8n")` era **incondizionato**; con n8n rimosso segnalerebbe permanente Unhealthy sulla dashboard. Ora gated su `N8n:IsEnabled` (non monitorare un servizio con cui non ci si integra) — coerente col flag già usato dal webhook client. Lettura via string-indexer per non accoppiare Observability al context WorkflowIntegration.

## Impatto & test
- **Funzionale: zero** (integrazione già disabilitata di default).
- Test health endpoint (`HealthEndpointsIntegrationTests`, `GetInfrastructureHealthQueryHandlerTests`) sono **mock-based** → non toccati. `HealthCheckServiceExtensionsTests.Always_On_Checks` non elenca n8n. Nessun test asserisce la registrazione del check n8n.
- Riattivare in staging: ri-aggiungere il blocco compose **e** settare `N8n:IsEnabled=true`.

## Fuori scope
`compose.dev.yml` / `compose.prod.yml` (dev locale + prod = decisioni separate); rimozione del context WorkflowIntegration (resta, solo disabilitato via flag).

🤖 Generated with [Claude Code](https://claude.com/claude-code)