### PR TITLE
release: promote main-dev → main-staging (infra disk cleanup #2795/#2797 + #526 ME-M1.4 + SSR fixes)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/ApproveMechanicClaimCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/ApproveMechanicClaimCommand.cs
@@ -11,7 +11,9 @@ namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands.MechanicExt
 /// <param name="AnalysisId">Parent aggregate id.</param>
 /// <param name="ClaimId">Claim id to approve.</param>
 /// <param name="ReviewerId">Admin user id from the validated session (never from the body).</param>
+/// <param name="Note">Optional free-form review note captured on approval (#526 AC-6, ≤ 2000 chars).</param>
 internal record ApproveMechanicClaimCommand(
     Guid AnalysisId,
     Guid ClaimId,
-    Guid ReviewerId) : ICommand<MechanicClaimDto>;
+    Guid ReviewerId,
+    string? Note = null) : ICommand<MechanicClaimDto>;

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/ApproveMechanicClaimCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/ApproveMechanicClaimCommandHandler.cs
@@ -73,7 +73,7 @@ internal sealed class ApproveMechanicClaimCommandHandler
 
         try
         {
-            analysis.ApproveClaim(request.ClaimId, request.ReviewerId, utcNow);
+            analysis.ApproveClaim(request.ClaimId, request.ReviewerId, utcNow, request.Note);
         }
         catch (InvalidMechanicAnalysisStateException ex)
         {
@@ -123,6 +123,7 @@ internal sealed class ApproveMechanicClaimCommandHandler
             ReviewedBy: claim.ReviewedBy,
             ReviewedAt: claim.ReviewedAt,
             RejectionNote: claim.RejectionNote,
+            ReviewNote: claim.ReviewNote,
             Citations: claim.Citations
                 .OrderBy(c => c.DisplayOrder)
                 .Select(c => new MechanicCitationDto(
@@ -130,5 +131,6 @@ internal sealed class ApproveMechanicClaimCommandHandler
                     PdfPage: c.PdfPage,
                     Quote: c.Quote,
                     DisplayOrder: c.DisplayOrder))
-                .ToList());
+                .ToList(),
+            Validations: MechanicClaimValidations.DerivePass());
 }

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/ApproveMechanicClaimCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/ApproveMechanicClaimCommandValidator.cs
@@ -20,5 +20,9 @@ internal sealed class ApproveMechanicClaimCommandValidator
 
         RuleFor(c => c.ReviewerId)
             .NotEmpty().WithMessage("ReviewerId is required.");
+
+        RuleFor(c => c.Note)
+            .MaximumLength(2000).WithMessage("Note must be 2000 characters or fewer.")
+            .When(c => c.Note is not null);
     }
 }

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/BulkApproveMechanicClaimsCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/BulkApproveMechanicClaimsCommandHandler.cs
@@ -1,8 +1,10 @@
+using System.Diagnostics;
 using Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Exceptions;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using Api.Middleware.Exceptions;
+using Api.Observability;
 using Api.SharedKernel.Application.Interfaces;
 using Api.SharedKernel.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
@@ -113,6 +115,8 @@ internal sealed class BulkApproveMechanicClaimsCommandHandler
             skippedRejectedCount,
             request.ReviewerId);
 
+        MeepleAiMetrics.MechanicReviewBulkActions.Add(1, new TagList { { "action", "bulk_approve" } });
+
         var claims = analysis.Claims
             .OrderBy(c => c.Section)
             .ThenBy(c => c.DisplayOrder)
@@ -126,6 +130,7 @@ internal sealed class BulkApproveMechanicClaimsCommandHandler
                 ReviewedBy: c.ReviewedBy,
                 ReviewedAt: c.ReviewedAt,
                 RejectionNote: c.RejectionNote,
+                ReviewNote: c.ReviewNote,
                 Citations: c.Citations
                     .OrderBy(citation => citation.DisplayOrder)
                     .Select(citation => new MechanicCitationDto(
@@ -133,7 +138,8 @@ internal sealed class BulkApproveMechanicClaimsCommandHandler
                         PdfPage: citation.PdfPage,
                         Quote: citation.Quote,
                         DisplayOrder: citation.DisplayOrder))
-                    .ToList()))
+                    .ToList(),
+                Validations: MechanicClaimValidations.DerivePass()))
             .ToList();
 
         return new BulkApproveMechanicClaimsResponseDto(

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/BulkRejectMechanicClaimsCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/BulkRejectMechanicClaimsCommandHandler.cs
@@ -1,8 +1,10 @@
+using System.Diagnostics;
 using Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Exceptions;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using Api.Middleware.Exceptions;
+using Api.Observability;
 using Api.SharedKernel.Application.Interfaces;
 using Api.SharedKernel.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
@@ -126,6 +128,8 @@ internal sealed class BulkRejectMechanicClaimsCommandHandler
             skippedAlreadyRejectedCount,
             request.ReviewerId);
 
+        MeepleAiMetrics.MechanicReviewBulkActions.Add(1, new TagList { { "action", "bulk_reject" } });
+
         var claims = analysis.Claims
             .OrderBy(c => c.Section)
             .ThenBy(c => c.DisplayOrder)
@@ -139,6 +143,7 @@ internal sealed class BulkRejectMechanicClaimsCommandHandler
                 ReviewedBy: c.ReviewedBy,
                 ReviewedAt: c.ReviewedAt,
                 RejectionNote: c.RejectionNote,
+                ReviewNote: c.ReviewNote,
                 Citations: c.Citations
                     .OrderBy(citation => citation.DisplayOrder)
                     .Select(citation => new MechanicCitationDto(
@@ -146,7 +151,8 @@ internal sealed class BulkRejectMechanicClaimsCommandHandler
                         PdfPage: citation.PdfPage,
                         Quote: citation.Quote,
                         DisplayOrder: citation.DisplayOrder))
-                    .ToList()))
+                    .ToList(),
+                Validations: MechanicClaimValidations.DerivePass()))
             .ToList();
 
         return new BulkRejectMechanicClaimsResponseDto(

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/PublishMechanicCardCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/PublishMechanicCardCommand.cs
@@ -1,0 +1,22 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands.MechanicExtractor;
+
+/// <summary>
+/// Publishes an approved (<c>Published</c>-lifecycle) <c>MechanicAnalysis</c> into a user-facing
+/// <c>MechanicCard</c> (ADR-051 / #527). Publishing is explicit and distinct from approving the
+/// analysis lifecycle (AD-2).
+/// </summary>
+/// <param name="AnalysisId">Analysis to publish. Must be Published and not already published.</param>
+/// <param name="Title">Optional admin title (5..200 chars). When null, a default is derived from the game name.</param>
+/// <param name="PreviousCardId">
+/// Optional id of a suppressed card being superseded (republish / AC-5). When set it MUST reference a
+/// suppressed card for this game; the new card gets <c>version = previous.version + 1</c>.
+/// </param>
+/// <param name="PublisherId">Admin user id, sourced from the validated session (never from the body).</param>
+internal record PublishMechanicCardCommand(
+    Guid AnalysisId,
+    string? Title,
+    Guid? PreviousCardId,
+    Guid PublisherId) : ICommand<PublishMechanicCardResponseDto>;

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/PublishMechanicCardCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/PublishMechanicCardCommandHandler.cs
@@ -1,0 +1,187 @@
+using System.Text.Json;
+
+using Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands.MechanicExtractor;
+
+/// <summary>
+/// Handler for <see cref="PublishMechanicCardCommand"/> (#527). Snapshots an approved analysis into a
+/// new <c>MechanicCard</c>, links the analysis (<c>PublishedCardId</c>), and writes an audit-log row —
+/// all in the same transaction (AC-4 atomicity). Conflicts F1–F5/F9 surface as
+/// <see cref="ConflictException"/> (409); a missing analysis is 404.
+/// </summary>
+internal sealed class PublishMechanicCardCommandHandler
+    : ICommandHandler<PublishMechanicCardCommand, PublishMechanicCardResponseDto>
+{
+    private readonly IMechanicAnalysisRepository _analysisRepository;
+    private readonly IMechanicCardRepository _cardRepository;
+    private readonly ISharedGameRepository _sharedGameRepository;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<PublishMechanicCardCommandHandler> _logger;
+
+    public PublishMechanicCardCommandHandler(
+        IMechanicAnalysisRepository analysisRepository,
+        IMechanicCardRepository cardRepository,
+        ISharedGameRepository sharedGameRepository,
+        IUnitOfWork unitOfWork,
+        TimeProvider timeProvider,
+        ILogger<PublishMechanicCardCommandHandler> logger)
+    {
+        _analysisRepository = analysisRepository ?? throw new ArgumentNullException(nameof(analysisRepository));
+        _cardRepository = cardRepository ?? throw new ArgumentNullException(nameof(cardRepository));
+        _sharedGameRepository = sharedGameRepository ?? throw new ArgumentNullException(nameof(sharedGameRepository));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<PublishMechanicCardResponseDto> Handle(
+        PublishMechanicCardCommand request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var analysis = await _analysisRepository
+            .GetByIdWithClaimsIgnoringFiltersAsync(request.AnalysisId, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (analysis is null)
+        {
+            throw new NotFoundException("MechanicAnalysis", request.AnalysisId.ToString());
+        }
+
+        // F1 — analysis must be in Published lifecycle state.
+        if (analysis.Status != MechanicAnalysisStatus.Published)
+        {
+            _logger.LogWarning(
+                "Publish rejected for analysis {AnalysisId}: status is {Status} (ConflictReason={ConflictReason}).",
+                analysis.Id, analysis.Status, "not_published");
+            throw new ConflictException(
+                $"Analysis must be in Published state. Current: {analysis.Status}. Approve it first.");
+        }
+
+        // F2 — analysis already published.
+        if (analysis.PublishedCardId is not null)
+        {
+            _logger.LogWarning(
+                "Publish rejected for analysis {AnalysisId}: already published as {CardId} (ConflictReason={ConflictReason}).",
+                analysis.Id, analysis.PublishedCardId, "already_published");
+            throw new ConflictException(
+                $"Already published as card {analysis.PublishedCardId}. To revise, suppress current and republish.");
+        }
+
+        var game = await _sharedGameRepository.GetByIdAsync(analysis.SharedGameId, cancellationToken).ConfigureAwait(false);
+        if (game is null)
+        {
+            throw new NotFoundException("SharedGame", analysis.SharedGameId.ToString());
+        }
+
+        MechanicCardAuditAction auditAction;
+        string? auditMetadata = null;
+
+        if (request.PreviousCardId is { } previousCardId)
+        {
+            // AC-5 republish: the superseded card must exist, belong to this game, and be suppressed (F9).
+            var previous = await _cardRepository.GetByIdIgnoringFiltersAsync(previousCardId, cancellationToken).ConfigureAwait(false);
+            if (previous is null || previous.SharedGameId != analysis.SharedGameId || !previous.IsSuppressed)
+            {
+                _logger.LogWarning(
+                    "Publish rejected: previous card {PreviousCardId} not found / wrong game / still active (ConflictReason={ConflictReason}).",
+                    previousCardId, "previous_not_suppressed");
+                throw new ConflictException("Previous card not found or still active. Suppress it first before republishing.");
+            }
+
+            auditAction = MechanicCardAuditAction.Revised;
+            auditMetadata = JsonSerializer.Serialize(new { previous_card_id = previousCardId });
+        }
+        else
+        {
+            // F3 — an active (non-suppressed) card already exists for this game.
+            var active = await _cardRepository.GetActiveByGameAsync(analysis.SharedGameId, cancellationToken).ConfigureAwait(false);
+            if (active is not null)
+            {
+                _logger.LogWarning(
+                    "Publish rejected: active card {ExistingCardId} exists for game {SharedGameId} (ConflictReason={ConflictReason}).",
+                    active.Id, analysis.SharedGameId, "race_active");
+                throw new ConflictException(
+                    $"Active card {active.Id} exists for this game. Suppress it before publishing a new version.");
+            }
+
+            auditAction = MechanicCardAuditAction.Published;
+        }
+
+        var version = await _cardRepository.GetMaxVersionForGameAsync(analysis.SharedGameId, cancellationToken).ConfigureAwait(false) + 1;
+        var utcNow = _timeProvider.GetUtcNow().UtcDateTime;
+
+        var gameContext = new MechanicCardGameContext
+        {
+            SharedGameId = analysis.SharedGameId,
+            SharedGameName = game.Title,
+            Publisher = game.Publishers.FirstOrDefault()?.Name,
+            Language = "en"
+        };
+
+        MechanicCard card;
+        try
+        {
+            card = MechanicCard.PublishFromAnalysis(analysis, request.Title, gameContext, request.PublisherId, version, utcNow);
+        }
+        catch (InvalidOperationException ex)
+        {
+            // Defense-in-depth aggregate invariants (should be caught above) → 409.
+            throw new ConflictException(ex.Message, ex);
+        }
+
+        analysis.MarkPublished(card.Id);
+
+        await _cardRepository.AddAsync(card, cancellationToken).ConfigureAwait(false);
+        _cardRepository.AddAuditLog(
+            MechanicCardAuditLog.Create(card.Id, auditAction, request.PublisherId, utcNow, auditMetadata));
+        _analysisRepository.Update(analysis);
+
+        try
+        {
+            await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (DbUpdateConcurrencyException ex)
+        {
+            // F5 — analysis edited concurrently (xmin mismatch).
+            _logger.LogWarning(ex,
+                "Optimistic concurrency publishing card for analysis {AnalysisId} (ConflictReason={ConflictReason}).",
+                analysis.Id, "stale_concurrency");
+            throw new ConflictException("Analysis was modified concurrently, refresh and retry.", ex);
+        }
+        catch (DbUpdateException ex)
+        {
+            // F4 — partial unique index (ux_mechanic_cards_active_per_game) lost the race.
+            _logger.LogWarning(ex,
+                "Unique index violation publishing card for game {SharedGameId} (ConflictReason={ConflictReason}).",
+                analysis.SharedGameId, "race_active");
+            throw new ConflictException("Card was published concurrently from another analysis. Refresh and review.", ex);
+        }
+
+        _logger.LogInformation(
+            "MechanicCard {CardId} published for game {SharedGameId} from analysis {AnalysisId} by admin {PublisherId} (version {Version}).",
+            card.Id, card.SharedGameId, analysis.Id, request.PublisherId, version);
+
+        return new PublishMechanicCardResponseDto(
+            CardId: card.Id,
+            SharedGameId: card.SharedGameId,
+            Version: card.Version,
+            PublishedAt: card.PublishedAt,
+            PublishedBy: card.PublishedBy,
+            Title: card.Title,
+            OriginAnalysisId: card.OriginAnalysisId,
+            PublicCardUrl: $"/games/{card.SharedGameId}/card");
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/PublishMechanicCardCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/PublishMechanicCardCommandValidator.cs
@@ -1,0 +1,29 @@
+using FluentValidation;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands.MechanicExtractor;
+
+/// <summary>
+/// FluentValidation rules for <see cref="PublishMechanicCardCommand"/>. State-machine invariants
+/// (analysis Published, not already published, active-card conflict) are enforced by the handler and
+/// surface as <c>ConflictException</c> (409).
+/// </summary>
+internal sealed class PublishMechanicCardCommandValidator
+    : AbstractValidator<PublishMechanicCardCommand>
+{
+    public PublishMechanicCardCommandValidator()
+    {
+        RuleFor(c => c.AnalysisId)
+            .NotEmpty().WithMessage("AnalysisId is required.");
+
+        RuleFor(c => c.PublisherId)
+            .NotEmpty().WithMessage("PublisherId is required.");
+
+        // Title cap is 200 (not 100) to allow expanded titles (spec AC-4).
+        When(c => c.Title is not null, () =>
+        {
+            RuleFor(c => c.Title)
+                .Must(t => t!.Trim().Length >= 5 && t.Trim().Length <= 200)
+                .WithMessage("Title must be at least 5 characters and at most 200 characters.");
+        });
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/RejectMechanicClaimCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/RejectMechanicClaimCommandHandler.cs
@@ -107,6 +107,7 @@ internal sealed class RejectMechanicClaimCommandHandler
             ReviewedBy: claim.ReviewedBy,
             ReviewedAt: claim.ReviewedAt,
             RejectionNote: claim.RejectionNote,
+            ReviewNote: claim.ReviewNote,
             Citations: claim.Citations
                 .OrderBy(c => c.DisplayOrder)
                 .Select(c => new MechanicCitationDto(
@@ -114,6 +115,7 @@ internal sealed class RejectMechanicClaimCommandHandler
                     PdfPage: c.PdfPage,
                     Quote: c.Quote,
                     DisplayOrder: c.DisplayOrder))
-                .ToList());
+                .ToList(),
+            Validations: MechanicClaimValidations.DerivePass());
     }
 }

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/DTOs/MechanicClaimDto.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/DTOs/MechanicClaimDto.cs
@@ -16,7 +16,9 @@ namespace Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
 /// <param name="ReviewedBy">Admin who last reviewed the claim, or <c>null</c> if untouched.</param>
 /// <param name="ReviewedAt">UTC timestamp of the last review action, or <c>null</c>.</param>
 /// <param name="RejectionNote">Reason for rejection (set only when <see cref="Status"/> is Rejected).</param>
+/// <param name="ReviewNote">Optional note captured on approval (#526 AC-6). Distinct from <see cref="RejectionNote"/>.</param>
 /// <param name="Citations">Attribution citations (≥ 1 — ADR-051 T3).</param>
+/// <param name="Validations">T1–T4 guardrail badges (#526 AC-1). Derived, not persisted — see <see cref="MechanicClaimValidationDto"/>.</param>
 public sealed record MechanicClaimDto(
     Guid Id,
     Guid AnalysisId,
@@ -27,7 +29,9 @@ public sealed record MechanicClaimDto(
     Guid? ReviewedBy,
     DateTime? ReviewedAt,
     string? RejectionNote,
-    IReadOnlyList<MechanicCitationDto> Citations);
+    string? ReviewNote,
+    IReadOnlyList<MechanicCitationDto> Citations,
+    IReadOnlyList<MechanicClaimValidationDto> Validations);
 
 /// <summary>
 /// Read model for a single attribution <c>MechanicCitation</c>. Page + verbatim quote are the

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/DTOs/MechanicClaimValidationDto.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/DTOs/MechanicClaimValidationDto.cs
@@ -1,0 +1,25 @@
+namespace Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
+
+/// <summary>
+/// Per-claim guardrail badge outcome (#526 AC-1). Rule ∈ {T1,T2,T3,T4}; Outcome ∈ {pass,fail,notRun}.
+/// </summary>
+/// <remarks>
+/// CORE ITERATION: values are DERIVED, not persisted. Every claim that reaches the review queue
+/// passed its section's guardrails by the pipeline pass-invariant (rejection sampling retries a
+/// section until its output satisfies T1–T4, else aborts to PartiallyExtracted/Rejected), so all
+/// persisted claims are surfaced as <c>pass</c>. FU-1 (#526 follow-up) replaces this with real
+/// per-claim outcomes + scores captured at pipeline time; the <c>fail</c>/<c>notRun</c> states and
+/// <see cref="Message"/> light up then. #527 snapshots this array into <c>mechanic_cards.content</c>.
+/// </remarks>
+public sealed record MechanicClaimValidationDto(string Rule, string Outcome, string? Message = null);
+
+/// <summary>Derivation of the AC-1 badge families for the core iteration.</summary>
+public static class MechanicClaimValidations
+{
+    /// <summary>Badge families, ordered T1→T4 (T3 = grounding + citation-present).</summary>
+    public static readonly IReadOnlyList<string> Families = new[] { "T1", "T2", "T3", "T4" };
+
+    /// <summary>Derived all-pass outcomes (see <see cref="MechanicClaimValidationDto"/> remarks).</summary>
+    public static IReadOnlyList<MechanicClaimValidationDto> DerivePass() =>
+        Families.Select(f => new MechanicClaimValidationDto(f, "pass")).ToList();
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/DTOs/PublishMechanicCardResponseDto.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/DTOs/PublishMechanicCardResponseDto.cs
@@ -1,0 +1,22 @@
+namespace Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
+
+/// <summary>
+/// Response for a successful card publication (#527, AC-6). Returned with HTTP 201 Created.
+/// </summary>
+/// <param name="CardId">Id of the newly created card.</param>
+/// <param name="SharedGameId">Game the card belongs to.</param>
+/// <param name="Version">Monotonic version for the game (AD-3).</param>
+/// <param name="PublishedAt">Publish timestamp.</param>
+/// <param name="PublishedBy">Admin who published.</param>
+/// <param name="Title">Resolved card title.</param>
+/// <param name="OriginAnalysisId">Source analysis id.</param>
+/// <param name="PublicCardUrl">Shape of the player-facing URL (#528, may not be live yet).</param>
+internal record PublishMechanicCardResponseDto(
+    Guid CardId,
+    Guid SharedGameId,
+    int Version,
+    DateTime PublishedAt,
+    Guid PublishedBy,
+    string Title,
+    Guid OriginAnalysisId,
+    string PublicCardUrl);

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/MechanicExtractor/GetMechanicAnalysisClaimsQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/MechanicExtractor/GetMechanicAnalysisClaimsQueryHandler.cs
@@ -60,6 +60,7 @@ internal sealed class GetMechanicAnalysisClaimsQueryHandler
                 ReviewedBy: c.ReviewedBy,
                 ReviewedAt: c.ReviewedAt,
                 RejectionNote: c.RejectionNote,
+                ReviewNote: c.ReviewNote,
                 Citations: c.Citations
                     .OrderBy(citation => citation.DisplayOrder)
                     .Select(citation => new MechanicCitationDto(
@@ -67,7 +68,8 @@ internal sealed class GetMechanicAnalysisClaimsQueryHandler
                         PdfPage: citation.PdfPage,
                         Quote: citation.Quote,
                         DisplayOrder: citation.DisplayOrder))
-                    .ToList()))
+                    .ToList(),
+                Validations: MechanicClaimValidations.DerivePass()))
             .ToList();
     }
 }

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Aggregates/MechanicAnalysis.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Aggregates/MechanicAnalysis.cs
@@ -611,12 +611,13 @@ public sealed class MechanicAnalysis : AggregateRoot<Guid>
     }
 
     /// <summary>
-    /// Approves a single claim. Valid only while the analysis is InReview.
+    /// Approves a single claim, optionally capturing a review note (#526 AC-6).
+    /// Valid only while the analysis is InReview.
     /// </summary>
-    public void ApproveClaim(Guid claimId, Guid reviewerId, DateTime utcNow)
+    public void ApproveClaim(Guid claimId, Guid reviewerId, DateTime utcNow, string? note = null)
     {
         var claim = RequireClaimUnderReview(claimId, "approve claim");
-        claim.Approve(reviewerId, utcNow);
+        claim.Approve(reviewerId, utcNow, note);
     }
 
     /// <summary>

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Aggregates/MechanicAnalysis.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Aggregates/MechanicAnalysis.cs
@@ -72,6 +72,13 @@ public sealed class MechanicAnalysis : AggregateRoot<Guid>
     public DateTime? ReviewedAt { get; private set; }
     public string? RejectionReason { get; private set; }
 
+    /// <summary>
+    /// FK to the <see cref="MechanicCard"/> this analysis was published into (#527). Null until an
+    /// admin explicitly publishes the (already Published-lifecycle) analysis. Enforces the "at most
+    /// one card per analysis" invariant (AD-3) and short-circuits duplicate publish attempts (F2).
+    /// </summary>
+    public Guid? PublishedCardId { get; private set; }
+
     // === LLM execution snapshot ===
 
     public int TotalTokensUsed { get; private set; }
@@ -263,7 +270,8 @@ public sealed class MechanicAnalysis : AggregateRoot<Guid>
         Guid? certifiedByUserId = null,
         string? certificationOverrideReason = null,
         Guid? lastMetricsId = null,
-        uint xminVersion = 0)
+        uint xminVersion = 0,
+        Guid? publishedCardId = null)
     {
         ArgumentNullException.ThrowIfNull(claims);
 
@@ -281,6 +289,7 @@ public sealed class MechanicAnalysis : AggregateRoot<Guid>
             ReviewedBy = reviewedBy,
             ReviewedAt = reviewedAt,
             RejectionReason = rejectionReason,
+            PublishedCardId = publishedCardId,
             TotalTokensUsed = totalTokensUsed,
             EstimatedCostUsd = estimatedCostUsd,
             ModelUsed = modelUsed,
@@ -416,6 +425,12 @@ public sealed class MechanicAnalysis : AggregateRoot<Guid>
     /// <summary>
     /// Approves the analysis and transitions it to Published. Requires every claim to be Approved.
     /// </summary>
+    /// <remarks>
+    /// <see cref="MechanicAnalysisStatus.Published"/> means the analysis <em>lifecycle</em> is frozen
+    /// and eligible for publication into a user-facing <see cref="MechanicCard"/>. It does NOT create
+    /// the card — publishing the card surface is a separate, explicit admin act (AD-2, #527), tracked
+    /// by <see cref="PublishedCardId"/>. Approving multiple analyses does not publish any of them.
+    /// </remarks>
     public void Approve(Guid reviewerId, DateTime utcNow)
     {
         if (reviewerId == Guid.Empty)
@@ -445,6 +460,38 @@ public sealed class MechanicAnalysis : AggregateRoot<Guid>
         ReviewedAt = utcNow;
 
         AddDomainEvent(new MechanicAnalysisStatusChangedEvent(Id, previous, Status, reviewerId, note: null));
+    }
+
+    /// <summary>
+    /// Links this analysis to the <see cref="MechanicCard"/> it was published into (#527). Sets the
+    /// <see cref="PublishedCardId"/> FK, enforcing the "publish once" invariant. Must be called by the
+    /// publish handler in the same transaction that inserts the card.
+    /// </summary>
+    /// <exception cref="InvalidMechanicAnalysisStateException">Thrown if the analysis is not Published.</exception>
+    /// <exception cref="InvalidOperationException">Thrown if the analysis already has a published card (F2).</exception>
+    public void MarkPublished(Guid cardId)
+    {
+        if (cardId == Guid.Empty)
+        {
+            throw new ArgumentException("CardId cannot be empty.", nameof(cardId));
+        }
+
+        if (Status != MechanicAnalysisStatus.Published)
+        {
+            throw new InvalidMechanicAnalysisStateException(
+                Id,
+                Status,
+                "mark published card",
+                MechanicAnalysisStatus.Published);
+        }
+
+        if (PublishedCardId is not null)
+        {
+            throw new InvalidOperationException(
+                $"MechanicAnalysis {Id} is already published as card {PublishedCardId}.");
+        }
+
+        PublishedCardId = cardId;
     }
 
     /// <summary>

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Aggregates/MechanicCard.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Aggregates/MechanicCard.cs
@@ -1,0 +1,270 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Events;
+using Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+using Api.SharedKernel.Domain.Entities;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+
+/// <summary>
+/// Aggregate root for a published mechanics card (ADR-051 #527). A card is an immutable, user-facing
+/// snapshot of an approved <see cref="MechanicAnalysis"/>, surfaced on <c>/games/{slug}/card</c>
+/// (#528, login-gated). Publishing is an explicit admin act, distinct from approving the analysis
+/// lifecycle (AD-2). A revision produces a new card version rather than mutating an existing one
+/// (AD-1 / AD-3); at most one non-suppressed card may exist per game (enforced by a partial unique
+/// index).
+/// </summary>
+public sealed class MechanicCard : AggregateRoot<Guid>
+{
+    // === Identity / lineage ===
+    public Guid SharedGameId { get; private set; }
+    public Guid OriginAnalysisId { get; private set; }
+    public MechanicCardOrigin Origin { get; private set; }
+
+    // === Content ===
+    public string Title { get; private set; } = string.Empty;
+
+    /// <summary>Immutable JSONB snapshot of the approved claims (see <see cref="MechanicCardContent"/>).</summary>
+    public string Content { get; private set; } = string.Empty;
+
+    /// <summary>Monotonic version per <see cref="SharedGameId"/> (AD-3), starts at 1.</summary>
+    public int Version { get; private set; }
+
+    // === Takedown (T5, #529) — orthogonal to lifecycle ===
+    public bool IsSuppressed { get; private set; }
+    public string? SuppressedReason { get; private set; }
+    public DateTime? SuppressedAt { get; private set; }
+    public Guid? SuppressedBy { get; private set; }
+
+    // === Player feedback (preparatory for #531) ===
+    public int ErrorReportsCount { get; private set; }
+    public decimal? FeedbackScore { get; private set; }
+
+    // === Publication audit ===
+    public DateTime PublishedAt { get; private set; }
+    public Guid PublishedBy { get; private set; }
+
+    // === Housekeeping ===
+    public DateTime CreatedAt { get; private set; }
+    public DateTime UpdatedAt { get; private set; }
+
+    /// <summary>Optimistic concurrency token (PostgreSQL <c>xmin</c>, ADR-060).</summary>
+    public uint XminVersion { get; private set; }
+
+    private const int MinTitleLength = 5;
+    private const int MaxTitleLength = 200;
+
+    /// <summary>EF Core / reconstitution constructor.</summary>
+    private MechanicCard() : base()
+    {
+    }
+
+    private MechanicCard(Guid id) : base(id)
+    {
+    }
+
+    /// <summary>
+    /// Promotes an approved <see cref="MechanicAnalysis"/> into a new mechanics card, capturing an
+    /// immutable snapshot of its claims (AD-1). The version is computed by the caller (monotonic per
+    /// game, AD-3) and passed in.
+    /// </summary>
+    /// <param name="analysis">The source analysis, with its claim + citation graph materialized.
+    /// Must be <see cref="MechanicAnalysisStatus.Published"/> and not already published.</param>
+    /// <param name="overrideTitle">Optional admin-supplied title (validated 5..200). When null, a
+    /// default is derived from the game name.</param>
+    /// <param name="gameContext">Cross-aggregate game metadata resolved by the handler.</param>
+    /// <param name="publisherId">The admin performing the publish (sourced from the session).</param>
+    /// <param name="version">Monotonic version for this game (≥1).</param>
+    /// <param name="utcNow">Publish timestamp; also the snapshot timestamp.</param>
+    public static MechanicCard PublishFromAnalysis(
+        MechanicAnalysis analysis,
+        string? overrideTitle,
+        MechanicCardGameContext gameContext,
+        Guid publisherId,
+        int version,
+        DateTime utcNow)
+    {
+        ArgumentNullException.ThrowIfNull(analysis);
+        ArgumentNullException.ThrowIfNull(gameContext);
+
+        if (publisherId == Guid.Empty)
+        {
+            throw new ArgumentException("PublisherId cannot be empty.", nameof(publisherId));
+        }
+
+        if (version < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(version), version, "Version must be >= 1.");
+        }
+
+        // Defense in depth: the handler already guards these, but the factory re-checks so the
+        // aggregate can never be constructed from a non-publishable analysis.
+        if (analysis.Status != MechanicAnalysisStatus.Published)
+        {
+            throw new InvalidOperationException(
+                $"Cannot publish MechanicAnalysis {analysis.Id}: status is {analysis.Status}, expected Published.");
+        }
+
+        if (analysis.PublishedCardId is not null)
+        {
+            throw new InvalidOperationException(
+                $"MechanicAnalysis {analysis.Id} is already published as card {analysis.PublishedCardId}.");
+        }
+
+        if (analysis.Claims.Count == 0)
+        {
+            throw new InvalidOperationException(
+                $"Cannot publish MechanicAnalysis {analysis.Id}: it has no claims.");
+        }
+
+        if (analysis.Claims.Any(c => c.Status != MechanicClaimStatus.Approved))
+        {
+            throw new InvalidOperationException(
+                $"Cannot publish MechanicAnalysis {analysis.Id}: not all claims are Approved.");
+        }
+
+        var title = ResolveTitle(overrideTitle, gameContext.SharedGameName);
+        var content = MechanicCardContent.FromAnalysis(analysis, gameContext, utcNow).ToJson();
+
+        var card = new MechanicCard(Guid.NewGuid())
+        {
+            SharedGameId = analysis.SharedGameId,
+            OriginAnalysisId = analysis.Id,
+            Origin = MechanicCardOrigin.AiReviewed,
+            Title = title,
+            Content = content,
+            Version = version,
+            IsSuppressed = false,
+            ErrorReportsCount = 0,
+            FeedbackScore = null,
+            PublishedAt = utcNow,
+            PublishedBy = publisherId,
+            CreatedAt = utcNow,
+            UpdatedAt = utcNow
+        };
+
+        card.AddDomainEvent(new MechanicCardPublishedEvent(
+            card.Id,
+            card.SharedGameId,
+            card.OriginAnalysisId,
+            publisherId,
+            version));
+
+        return card;
+    }
+
+    /// <summary>
+    /// Applies a takedown (suppress) on the card (T5 / #529). Idempotency: throws if already
+    /// suppressed so the caller can surface a 409 rather than silently no-op.
+    /// </summary>
+    public void Suppress(Guid actorId, string reason, DateTime utcNow)
+    {
+        if (actorId == Guid.Empty)
+        {
+            throw new ArgumentException("ActorId cannot be empty.", nameof(actorId));
+        }
+
+        if (string.IsNullOrWhiteSpace(reason) || reason.Trim().Length is < 20 or > 500)
+        {
+            throw new ArgumentException("Suppression reason must be 20..500 characters (legal evidence chain).", nameof(reason));
+        }
+
+        if (IsSuppressed)
+        {
+            throw new InvalidOperationException($"MechanicCard {Id} is already suppressed.");
+        }
+
+        IsSuppressed = true;
+        SuppressedReason = reason.Trim();
+        SuppressedAt = utcNow;
+        SuppressedBy = actorId;
+        UpdatedAt = utcNow;
+
+        AddDomainEvent(new MechanicCardSuppressedEvent(Id, SharedGameId, actorId, SuppressedReason));
+    }
+
+    /// <summary>Lifts a takedown, clearing suppression tracking. Throws if not suppressed.</summary>
+    public void Unsuppress(Guid actorId, DateTime utcNow)
+    {
+        if (actorId == Guid.Empty)
+        {
+            throw new ArgumentException("ActorId cannot be empty.", nameof(actorId));
+        }
+
+        if (!IsSuppressed)
+        {
+            throw new InvalidOperationException($"MechanicCard {Id} is not suppressed.");
+        }
+
+        IsSuppressed = false;
+        SuppressedReason = null;
+        SuppressedAt = null;
+        SuppressedBy = null;
+        UpdatedAt = utcNow;
+    }
+
+    /// <summary>Increments the player error-report counter (preparatory for #531 feedback).</summary>
+    public void MarkErrorReport(DateTime utcNow)
+    {
+        ErrorReportsCount += 1;
+        UpdatedAt = utcNow;
+    }
+
+    private static string ResolveTitle(string? overrideTitle, string sharedGameName)
+    {
+        if (!string.IsNullOrWhiteSpace(overrideTitle))
+        {
+            var trimmed = overrideTitle.Trim();
+            if (trimmed.Length is < MinTitleLength or > MaxTitleLength)
+            {
+                throw new ArgumentException(
+                    $"Title must be {MinTitleLength}..{MaxTitleLength} characters.", nameof(overrideTitle));
+            }
+
+            return trimmed;
+        }
+
+        var name = string.IsNullOrWhiteSpace(sharedGameName) ? "Untitled Game" : sharedGameName.Trim();
+        return $"{name} — Mechanics Card";
+    }
+
+    /// <summary>Rehydrates a card from persistence (no validation, no events).</summary>
+    public static MechanicCard Reconstitute(
+        Guid id,
+        Guid sharedGameId,
+        Guid originAnalysisId,
+        MechanicCardOrigin origin,
+        string title,
+        string content,
+        int version,
+        bool isSuppressed,
+        string? suppressedReason,
+        DateTime? suppressedAt,
+        Guid? suppressedBy,
+        int errorReportsCount,
+        decimal? feedbackScore,
+        DateTime publishedAt,
+        Guid publishedBy,
+        DateTime createdAt,
+        DateTime updatedAt,
+        uint xminVersion = 0) =>
+        new(id)
+        {
+            SharedGameId = sharedGameId,
+            OriginAnalysisId = originAnalysisId,
+            Origin = origin,
+            Title = title,
+            Content = content,
+            Version = version,
+            IsSuppressed = isSuppressed,
+            SuppressedReason = suppressedReason,
+            SuppressedAt = suppressedAt,
+            SuppressedBy = suppressedBy,
+            ErrorReportsCount = errorReportsCount,
+            FeedbackScore = feedbackScore,
+            PublishedAt = publishedAt,
+            PublishedBy = publishedBy,
+            CreatedAt = createdAt,
+            UpdatedAt = updatedAt,
+            XminVersion = xminVersion
+        };
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Entities/MechanicCardAuditLog.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Entities/MechanicCardAuditLog.cs
@@ -1,0 +1,72 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using Api.SharedKernel.Domain.Entities;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+
+/// <summary>
+/// Immutable audit-log entry for a <see cref="Aggregates.MechanicCard"/> lifecycle action
+/// (ADR-051 audit trail). Written by the command handler in the same transaction as the card
+/// mutation so there are never orphaned rows.
+/// </summary>
+public sealed class MechanicCardAuditLog : Entity<Guid>
+{
+    public Guid CardId { get; private set; }
+    public MechanicCardAuditAction Action { get; private set; }
+    public Guid ActorId { get; private set; }
+    public DateTime OccurredAt { get; private set; }
+
+    /// <summary>Optional JSONB metadata, e.g. <c>{ "reason": "...", "previous_card_id": "..." }</c>.</summary>
+    public string? Metadata { get; private set; }
+
+    /// <summary>EF Core / reconstitution constructor.</summary>
+    private MechanicCardAuditLog() : base()
+    {
+    }
+
+    private MechanicCardAuditLog(
+        Guid id,
+        Guid cardId,
+        MechanicCardAuditAction action,
+        Guid actorId,
+        DateTime occurredAt,
+        string? metadata)
+        : base(id)
+    {
+        CardId = cardId;
+        Action = action;
+        ActorId = actorId;
+        OccurredAt = occurredAt;
+        Metadata = metadata;
+    }
+
+    /// <summary>Creates a new audit-log entry.</summary>
+    public static MechanicCardAuditLog Create(
+        Guid cardId,
+        MechanicCardAuditAction action,
+        Guid actorId,
+        DateTime occurredAt,
+        string? metadata = null)
+    {
+        if (cardId == Guid.Empty)
+        {
+            throw new ArgumentException("CardId cannot be empty.", nameof(cardId));
+        }
+
+        if (actorId == Guid.Empty)
+        {
+            throw new ArgumentException("ActorId cannot be empty.", nameof(actorId));
+        }
+
+        return new MechanicCardAuditLog(Guid.NewGuid(), cardId, action, actorId, occurredAt, metadata);
+    }
+
+    /// <summary>Rehydrates from persistence (no validation).</summary>
+    public static MechanicCardAuditLog Reconstitute(
+        Guid id,
+        Guid cardId,
+        MechanicCardAuditAction action,
+        Guid actorId,
+        DateTime occurredAt,
+        string? metadata) =>
+        new(id, cardId, action, actorId, occurredAt, metadata);
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Entities/MechanicClaim.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Entities/MechanicClaim.cs
@@ -48,6 +48,9 @@ public sealed class MechanicClaim : Entity<Guid>
     /// <summary>Reason the claim was rejected. Required when <see cref="Status"/> is Rejected.</summary>
     public string? RejectionNote { get; private set; }
 
+    /// <summary>Optional note captured on approval (#526 AC-6). Distinct from <see cref="RejectionNote"/>.</summary>
+    public string? ReviewNote { get; private set; }
+
     /// <summary>Attribution citations (minimum 1 — ADR-051 T3).</summary>
     public IReadOnlyList<MechanicCitation> Citations => _citations.AsReadOnly();
 
@@ -205,7 +208,8 @@ public sealed class MechanicClaim : Entity<Guid>
         Guid? reviewedBy,
         DateTime? reviewedAt,
         string? rejectionNote,
-        IEnumerable<MechanicCitation> citations)
+        IEnumerable<MechanicCitation> citations,
+        string? reviewNote = null)
     {
         ArgumentNullException.ThrowIfNull(citations);
 
@@ -220,6 +224,7 @@ public sealed class MechanicClaim : Entity<Guid>
             ReviewedBy = reviewedBy,
             ReviewedAt = reviewedAt,
             RejectionNote = rejectionNote,
+            ReviewNote = reviewNote,
             IsNew = false
         };
 
@@ -228,9 +233,10 @@ public sealed class MechanicClaim : Entity<Guid>
     }
 
     /// <summary>
-    /// Approves the claim. Idempotent: re-approving is a no-op.
+    /// Approves the claim, optionally capturing a review note (#526 AC-6). Idempotent:
+    /// re-approving is a no-op except for refreshing the note.
     /// </summary>
-    internal void Approve(Guid reviewerId, DateTime utcNow)
+    internal void Approve(Guid reviewerId, DateTime utcNow, string? note = null)
     {
         if (reviewerId == Guid.Empty)
         {
@@ -241,6 +247,7 @@ public sealed class MechanicClaim : Entity<Guid>
         ReviewedBy = reviewerId;
         ReviewedAt = utcNow;
         RejectionNote = null;
+        ReviewNote = string.IsNullOrWhiteSpace(note) ? null : note.Trim();
     }
 
     /// <summary>
@@ -262,6 +269,7 @@ public sealed class MechanicClaim : Entity<Guid>
         ReviewedBy = reviewerId;
         ReviewedAt = utcNow;
         RejectionNote = note.Trim();
+        ReviewNote = null;
     }
 
     /// <summary>
@@ -273,5 +281,6 @@ public sealed class MechanicClaim : Entity<Guid>
         ReviewedBy = null;
         ReviewedAt = null;
         RejectionNote = null;
+        ReviewNote = null;
     }
 }

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Enums/MechanicCardAuditAction.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Enums/MechanicCardAuditAction.cs
@@ -1,0 +1,20 @@
+namespace Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+
+/// <summary>
+/// Audit action recorded in <c>mechanic_card_audit_log</c> for a <see cref="Aggregates.MechanicCard"/>
+/// lifecycle event (ADR-051 audit trail). Persisted as a lowercase string (DB CHECK constraint).
+/// </summary>
+public enum MechanicCardAuditAction
+{
+    /// <summary>Card first published from an approved analysis (#527).</summary>
+    Published = 0,
+
+    /// <summary>Card taken down (is_suppressed=true) — #529.</summary>
+    Suppressed = 1,
+
+    /// <summary>Card takedown lifted (is_suppressed=false) — #529.</summary>
+    Unsuppressed = 2,
+
+    /// <summary>A superseding card (version+1) was published to replace a suppressed predecessor.</summary>
+    Revised = 3
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Enums/MechanicCardOrigin.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Enums/MechanicCardOrigin.cs
@@ -1,0 +1,18 @@
+namespace Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+
+/// <summary>
+/// Provenance of a <see cref="Aggregates.MechanicCard"/> (ADR-051). Persisted as a lowercase
+/// snake_case string in the <c>mechanic_cards.origin</c> column (DB CHECK constraint enforces the
+/// same set).
+/// </summary>
+public enum MechanicCardOrigin
+{
+    /// <summary>Promoted from an AI-generated analysis that passed admin review (#526 → #527).</summary>
+    AiReviewed = 0,
+
+    /// <summary>Authored manually by an admin (no AI pipeline). Reserved for future manual entry.</summary>
+    Manual = 1,
+
+    /// <summary>Imported from an external certified source. Reserved for future B2B ingestion.</summary>
+    ImportedExternal = 2
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Events/MechanicCardPublishedEvent.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Events/MechanicCardPublishedEvent.cs
@@ -1,0 +1,36 @@
+using Api.SharedKernel.Domain.Events;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Domain.Events;
+
+/// <summary>
+/// Raised when a <see cref="Aggregates.MechanicCard"/> is published from an approved analysis (#527).
+/// Downstream consumers (e.g. RAG cache invalidation for the game, #528 player view cache) can
+/// subscribe. The publish audit-log row is written by the command handler in the same transaction,
+/// so this event is purely for cross-context reactions.
+/// </summary>
+internal sealed class MechanicCardPublishedEvent : DomainEventBase
+{
+    public Guid CardId { get; }
+
+    public Guid SharedGameId { get; }
+
+    public Guid OriginAnalysisId { get; }
+
+    public Guid PublisherId { get; }
+
+    public int Version { get; }
+
+    public MechanicCardPublishedEvent(
+        Guid cardId,
+        Guid sharedGameId,
+        Guid originAnalysisId,
+        Guid publisherId,
+        int version)
+    {
+        CardId = cardId;
+        SharedGameId = sharedGameId;
+        OriginAnalysisId = originAnalysisId;
+        PublisherId = publisherId;
+        Version = version;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Events/MechanicCardSuppressedEvent.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Events/MechanicCardSuppressedEvent.cs
@@ -1,0 +1,26 @@
+using Api.SharedKernel.Domain.Events;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Domain.Events;
+
+/// <summary>
+/// Raised when a <see cref="Aggregates.MechanicCard"/> is suppressed (takedown, #529). Consumed by
+/// downstream cache-invalidation handlers so the player-facing card view (#528) drops the card.
+/// </summary>
+internal sealed class MechanicCardSuppressedEvent : DomainEventBase
+{
+    public Guid CardId { get; }
+
+    public Guid SharedGameId { get; }
+
+    public Guid ActorId { get; }
+
+    public string Reason { get; }
+
+    public MechanicCardSuppressedEvent(Guid cardId, Guid sharedGameId, Guid actorId, string reason)
+    {
+        CardId = cardId;
+        SharedGameId = sharedGameId;
+        ActorId = actorId;
+        Reason = reason;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Repositories/IMechanicCardRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Repositories/IMechanicCardRepository.cs
@@ -1,0 +1,36 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+
+/// <summary>
+/// Repository for the <see cref="MechanicCard"/> aggregate (#527). All mutations are staged into the
+/// shared <c>DbContext</c> and committed by <c>IUnitOfWork.SaveChangesAsync</c> so the card, its audit
+/// row, and the analysis FK update commit atomically.
+/// </summary>
+public interface IMechanicCardRepository
+{
+    /// <summary>Stages a new card for insertion and collects its domain events for post-save dispatch.</summary>
+    Task AddAsync(MechanicCard card, CancellationToken cancellationToken = default);
+
+    /// <summary>Stages an append-only audit-log row (same transaction as the card mutation).</summary>
+    void AddAuditLog(MechanicCardAuditLog entry);
+
+    /// <summary>
+    /// Highest existing <c>version</c> for the game across ALL cards (suppressed or not) — the basis
+    /// for the monotonic-per-game version (AD-3). Returns 0 when the game has no cards yet.
+    /// </summary>
+    Task<int> GetMaxVersionForGameAsync(Guid sharedGameId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// The active (non-suppressed) card for the game, if any — used by the publish race pre-check (F3).
+    /// Honors the suppression query filter, so a suppressed card returns null.
+    /// </summary>
+    Task<MechanicCard?> GetActiveByGameAsync(Guid sharedGameId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Loads a card by id ignoring the suppression filter — used to validate <c>previousCardId</c> on
+    /// republish (AC-5), which must reference a suppressed card.
+    /// </summary>
+    Task<MechanicCard?> GetByIdIgnoringFiltersAsync(Guid cardId, CancellationToken cancellationToken = default);
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/ValueObjects/MechanicCardContent.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/ValueObjects/MechanicCardContent.cs
@@ -1,0 +1,182 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+
+/// <summary>
+/// Immutable snapshot of an approved <see cref="MechanicAnalysis"/> captured at publish time and
+/// stored verbatim in the <c>mechanic_cards.content</c> JSONB column (ADR-051 AD-1). The card never
+/// dereferences the live claim graph at render time — a revision produces a new card version instead.
+/// </summary>
+/// <remarks>
+/// <see cref="SchemaVersion"/> guards forward evolution of the JSONB shape. Serialized with
+/// snake_case keys via <c>[JsonPropertyName]</c> so the on-disk JSON matches the ADR-051 contract.
+/// </remarks>
+public sealed record MechanicCardContent
+{
+    /// <summary>Current on-disk JSONB schema version.</summary>
+    public const int CurrentSchemaVersion = 1;
+
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        // Keys are already snake_case via [JsonPropertyName]; keep output compact.
+        WriteIndented = false,
+        DefaultIgnoreCondition = JsonIgnoreCondition.Never
+    };
+
+    [JsonPropertyName("schema_version")]
+    public int SchemaVersion { get; init; } = CurrentSchemaVersion;
+
+    [JsonPropertyName("snapshot_at")]
+    public DateTime SnapshotAt { get; init; }
+
+    [JsonPropertyName("source_analysis_id")]
+    public Guid SourceAnalysisId { get; init; }
+
+    [JsonPropertyName("source_prompt_version")]
+    public string SourcePromptVersion { get; init; } = string.Empty;
+
+    [JsonPropertyName("claims")]
+    public IReadOnlyList<MechanicCardClaimSnapshot> Claims { get; init; } = Array.Empty<MechanicCardClaimSnapshot>();
+
+    [JsonPropertyName("metadata")]
+    public MechanicCardMetadata Metadata { get; init; } = new();
+
+    /// <summary>
+    /// Builds an immutable snapshot from an approved analysis and its game context. The analysis
+    /// MUST already carry the fully materialized claim + citation graph.
+    /// </summary>
+    public static MechanicCardContent FromAnalysis(
+        MechanicAnalysis analysis,
+        MechanicCardGameContext gameContext,
+        DateTime snapshotAt)
+    {
+        ArgumentNullException.ThrowIfNull(analysis);
+        ArgumentNullException.ThrowIfNull(gameContext);
+
+        var claims = analysis.Claims
+            .OrderBy(c => c.Section)
+            .ThenBy(c => c.DisplayOrder)
+            .Select(c => new MechanicCardClaimSnapshot
+            {
+                Id = c.Id,
+                Section = c.Section.ToString(),
+                Ordinal = c.DisplayOrder,
+                Claim = c.Text,
+                Citations = c.Citations
+                    .OrderBy(cit => cit.DisplayOrder)
+                    .Select(cit => new MechanicCardCitationSnapshot
+                    {
+                        // A MechanicAnalysis is scoped to a single source PDF, so every citation
+                        // shares the analysis PdfDocumentId (the citation entity carries only the page).
+                        PdfId = analysis.PdfDocumentId,
+                        PdfPage = cit.PdfPage,
+                        Quote = cit.Quote
+                    })
+                    .ToList(),
+                // Validation (T1-T4) outcomes are not yet persisted on the claim graph (wired by
+                // #526). Emitted as an empty array now; the schema_version guards future population.
+                Validations = Array.Empty<MechanicCardValidationSnapshot>()
+            })
+            .ToList();
+
+        return new MechanicCardContent
+        {
+            SchemaVersion = CurrentSchemaVersion,
+            SnapshotAt = snapshotAt,
+            SourceAnalysisId = analysis.Id,
+            SourcePromptVersion = analysis.PromptVersion,
+            Claims = claims,
+            Metadata = new MechanicCardMetadata
+            {
+                SharedGameId = gameContext.SharedGameId,
+                SharedGameName = gameContext.SharedGameName,
+                Publisher = gameContext.Publisher,
+                Language = gameContext.Language
+            }
+        };
+    }
+
+    /// <summary>Serializes the snapshot to the JSONB string persisted in <c>mechanic_cards.content</c>.</summary>
+    public string ToJson() => JsonSerializer.Serialize(this, SerializerOptions);
+}
+
+/// <summary>Per-claim snapshot inside <see cref="MechanicCardContent.Claims"/>.</summary>
+public sealed record MechanicCardClaimSnapshot
+{
+    [JsonPropertyName("id")]
+    public Guid Id { get; init; }
+
+    [JsonPropertyName("section")]
+    public string Section { get; init; } = string.Empty;
+
+    [JsonPropertyName("ordinal")]
+    public int Ordinal { get; init; }
+
+    [JsonPropertyName("claim")]
+    public string Claim { get; init; } = string.Empty;
+
+    [JsonPropertyName("citations")]
+    public IReadOnlyList<MechanicCardCitationSnapshot> Citations { get; init; } = Array.Empty<MechanicCardCitationSnapshot>();
+
+    [JsonPropertyName("validations")]
+    public IReadOnlyList<MechanicCardValidationSnapshot> Validations { get; init; } = Array.Empty<MechanicCardValidationSnapshot>();
+}
+
+/// <summary>Per-citation snapshot (source page + verbatim quote).</summary>
+public sealed record MechanicCardCitationSnapshot
+{
+    [JsonPropertyName("pdf_id")]
+    public Guid PdfId { get; init; }
+
+    [JsonPropertyName("pdf_page")]
+    public int PdfPage { get; init; }
+
+    [JsonPropertyName("quote")]
+    public string Quote { get; init; } = string.Empty;
+}
+
+/// <summary>T1-T4 guardrail outcome snapshot (reserved; populated when #526 wires validations).</summary>
+public sealed record MechanicCardValidationSnapshot
+{
+    [JsonPropertyName("rule")]
+    public string Rule { get; init; } = string.Empty;
+
+    [JsonPropertyName("passed")]
+    public bool Passed { get; init; }
+
+    [JsonPropertyName("score")]
+    public double? Score { get; init; }
+}
+
+/// <summary>Game-context metadata block of the snapshot.</summary>
+public sealed record MechanicCardMetadata
+{
+    [JsonPropertyName("shared_game_id")]
+    public Guid SharedGameId { get; init; }
+
+    [JsonPropertyName("shared_game_name")]
+    public string SharedGameName { get; init; } = string.Empty;
+
+    [JsonPropertyName("publisher")]
+    public string? Publisher { get; init; }
+
+    [JsonPropertyName("language")]
+    public string Language { get; init; } = "en";
+}
+
+/// <summary>
+/// Cross-aggregate game context resolved by the command handler (from SharedGame + translations)
+/// and passed to <see cref="MechanicCardContent.FromAnalysis"/> and
+/// <see cref="MechanicCard.PublishFromAnalysis"/>, since it is not available on the analysis itself.
+/// </summary>
+public sealed record MechanicCardGameContext
+{
+    public required Guid SharedGameId { get; init; }
+    public required string SharedGameName { get; init; }
+    public string? Publisher { get; init; }
+    public string Language { get; init; } = "en";
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs
@@ -53,6 +53,7 @@ internal static class SharedGameCatalogServiceExtensions
         services.AddScoped<IRulebookAnalysisRepository, RulebookAnalysisRepository>(); // Issue #2402 Sprint 3
         services.AddScoped<IMechanicDraftRepository, MechanicDraftRepository>(); // Mechanic Extractor: Variant C drafts
         services.AddScoped<IMechanicAnalysisRepository, MechanicAnalysisRepository>(); // Issue #523: M1.1 Mechanic Analysis persistence
+        services.AddScoped<IMechanicCardRepository, MechanicCardRepository>(); // #527: M1.5 Mechanic Card persistence
         services.AddScoped<IMechanicGoldenClaimRepository, MechanicGoldenClaimRepository>(); // ADR-051 Sprint 1 / Task 15: golden claims
         services.AddScoped<IMechanicGoldenBggTagRepository, MechanicGoldenBggTagRepository>(); // ADR-051 Sprint 1 / Task 15: BGG mechanic tags
         services.AddScoped<IMechanicAnalysisMetricsRepository, MechanicAnalysisMetricsRepository>(); // ADR-051 Sprint 1 / Task 15: metrics snapshots

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/MechanicAnalysisRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/MechanicAnalysisRepository.cs
@@ -318,7 +318,8 @@ internal sealed class MechanicAnalysisRepository : RepositoryBase, IMechanicAnal
             certifiedByUserId: entity.CertifiedByUserId,
             certificationOverrideReason: entity.CertificationOverrideReason,
             lastMetricsId: entity.LastMetricsId,
-            xminVersion: entity.Xmin);
+            xminVersion: entity.Xmin,
+            publishedCardId: entity.PublishedCardId);
     }
 
     private static MechanicClaim MapClaimToDomain(MechanicClaimEntity entity)
@@ -363,6 +364,7 @@ internal sealed class MechanicAnalysisRepository : RepositoryBase, IMechanicAnal
             ReviewedBy = analysis.ReviewedBy,
             ReviewedAt = analysis.ReviewedAt,
             RejectionReason = analysis.RejectionReason,
+            PublishedCardId = analysis.PublishedCardId,
             TotalTokensUsed = analysis.TotalTokensUsed,
             EstimatedCostUsd = analysis.EstimatedCostUsd,
             ModelUsed = analysis.ModelUsed,

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/MechanicAnalysisRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/MechanicAnalysisRepository.cs
@@ -336,7 +336,8 @@ internal sealed class MechanicAnalysisRepository : RepositoryBase, IMechanicAnal
             reviewedBy: entity.ReviewedBy,
             reviewedAt: entity.ReviewedAt,
             rejectionNote: entity.RejectionNote,
-            citations: citations);
+            citations: citations,
+            reviewNote: entity.ReviewNote);
     }
 
     private static MechanicCitation MapCitationToDomain(MechanicCitationEntity entity)
@@ -404,6 +405,7 @@ internal sealed class MechanicAnalysisRepository : RepositoryBase, IMechanicAnal
             ReviewedBy = claim.ReviewedBy,
             ReviewedAt = claim.ReviewedAt,
             RejectionNote = claim.RejectionNote,
+            ReviewNote = claim.ReviewNote,
             Citations = claim.Citations.Select(MapCitationToEntity).ToList()
         };
     }

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/MechanicCardRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/MechanicCardRepository.cs
@@ -1,0 +1,155 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.SharedKernel.Application.Services;
+using Api.SharedKernel.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Infrastructure.Repositories;
+
+/// <summary>
+/// Repository implementation for the <see cref="MechanicCard"/> aggregate (ADR-051 / #527).
+/// </summary>
+internal sealed class MechanicCardRepository : RepositoryBase, IMechanicCardRepository
+{
+    public MechanicCardRepository(MeepleAiDbContext dbContext, IDomainEventCollector eventCollector)
+        : base(dbContext, eventCollector)
+    {
+    }
+
+    public async Task AddAsync(MechanicCard card, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(card);
+
+        var entity = MapToEntity(card);
+        await DbContext.MechanicCards.AddAsync(entity, cancellationToken).ConfigureAwait(false);
+
+        CollectDomainEvents(card);
+    }
+
+    public void AddAuditLog(MechanicCardAuditLog entry)
+    {
+        ArgumentNullException.ThrowIfNull(entry);
+        DbContext.MechanicCardAuditLog.Add(MapAuditToEntity(entry));
+    }
+
+    public async Task<int> GetMaxVersionForGameAsync(Guid sharedGameId, CancellationToken cancellationToken = default)
+    {
+        // Version is monotonic across ALL cards for the game (suppressed or not), so ignore the filter.
+        var max = await DbContext.MechanicCards
+            .IgnoreQueryFilters()
+            .Where(c => c.SharedGameId == sharedGameId)
+            .Select(c => (int?)c.Version)
+            .MaxAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return max ?? 0;
+    }
+
+    public async Task<MechanicCard?> GetActiveByGameAsync(Guid sharedGameId, CancellationToken cancellationToken = default)
+    {
+        // Suppression query filter applies → only the active (non-suppressed) card is returned.
+        var entity = await DbContext.MechanicCards
+            .AsNoTracking()
+            .FirstOrDefaultAsync(c => c.SharedGameId == sharedGameId, cancellationToken)
+            .ConfigureAwait(false);
+
+        return entity is null ? null : MapToDomain(entity);
+    }
+
+    public async Task<MechanicCard?> GetByIdIgnoringFiltersAsync(Guid cardId, CancellationToken cancellationToken = default)
+    {
+        var entity = await DbContext.MechanicCards
+            .AsNoTracking()
+            .IgnoreQueryFilters()
+            .FirstOrDefaultAsync(c => c.Id == cardId, cancellationToken)
+            .ConfigureAwait(false);
+
+        return entity is null ? null : MapToDomain(entity);
+    }
+
+    // === Mapping ===
+
+    private static MechanicCardEntity MapToEntity(MechanicCard card) =>
+        new()
+        {
+            Id = card.Id,
+            SharedGameId = card.SharedGameId,
+            OriginAnalysisId = card.OriginAnalysisId,
+            Origin = OriginToDb(card.Origin),
+            Title = card.Title,
+            Content = card.Content,
+            Version = card.Version,
+            IsSuppressed = card.IsSuppressed,
+            SuppressedReason = card.SuppressedReason,
+            SuppressedAt = card.SuppressedAt,
+            SuppressedBy = card.SuppressedBy,
+            ErrorReportsCount = card.ErrorReportsCount,
+            FeedbackScore = card.FeedbackScore,
+            PublishedAt = card.PublishedAt,
+            PublishedBy = card.PublishedBy,
+            CreatedAt = card.CreatedAt,
+            UpdatedAt = card.UpdatedAt,
+            Xmin = card.XminVersion
+        };
+
+    private static MechanicCard MapToDomain(MechanicCardEntity entity) =>
+        MechanicCard.Reconstitute(
+            id: entity.Id,
+            sharedGameId: entity.SharedGameId,
+            originAnalysisId: entity.OriginAnalysisId,
+            origin: OriginFromDb(entity.Origin),
+            title: entity.Title,
+            content: entity.Content,
+            version: entity.Version,
+            isSuppressed: entity.IsSuppressed,
+            suppressedReason: entity.SuppressedReason,
+            suppressedAt: entity.SuppressedAt,
+            suppressedBy: entity.SuppressedBy,
+            errorReportsCount: entity.ErrorReportsCount,
+            feedbackScore: entity.FeedbackScore,
+            publishedAt: entity.PublishedAt,
+            publishedBy: entity.PublishedBy,
+            createdAt: entity.CreatedAt,
+            updatedAt: entity.UpdatedAt,
+            xminVersion: entity.Xmin);
+
+    private static MechanicCardAuditLogEntity MapAuditToEntity(MechanicCardAuditLog entry) =>
+        new()
+        {
+            Id = entry.Id,
+            CardId = entry.CardId,
+            Action = ActionToDb(entry.Action),
+            ActorId = entry.ActorId,
+            OccurredAt = entry.OccurredAt,
+            Metadata = entry.Metadata
+        };
+
+    private static string OriginToDb(MechanicCardOrigin origin) => origin switch
+    {
+        MechanicCardOrigin.AiReviewed => "ai_reviewed",
+        MechanicCardOrigin.Manual => "manual",
+        MechanicCardOrigin.ImportedExternal => "imported_external",
+        _ => throw new ArgumentOutOfRangeException(nameof(origin), origin, "Unknown MechanicCardOrigin.")
+    };
+
+    private static MechanicCardOrigin OriginFromDb(string origin) => origin switch
+    {
+        "ai_reviewed" => MechanicCardOrigin.AiReviewed,
+        "manual" => MechanicCardOrigin.Manual,
+        "imported_external" => MechanicCardOrigin.ImportedExternal,
+        _ => throw new ArgumentOutOfRangeException(nameof(origin), origin, "Unknown mechanic_cards.origin value.")
+    };
+
+    private static string ActionToDb(MechanicCardAuditAction action) => action switch
+    {
+        MechanicCardAuditAction.Published => "published",
+        MechanicCardAuditAction.Suppressed => "suppressed",
+        MechanicCardAuditAction.Unsuppressed => "unsuppressed",
+        MechanicCardAuditAction.Revised => "revised",
+        _ => throw new ArgumentOutOfRangeException(nameof(action), action, "Unknown MechanicCardAuditAction.")
+    };
+}

--- a/apps/api/src/Api/Extensions/ObservabilityServiceExtensions.cs
+++ b/apps/api/src/Api/Extensions/ObservabilityServiceExtensions.cs
@@ -200,14 +200,25 @@ internal static class ObservabilityServiceExtensions
                 "shared-catalog-fts",
                 failureStatus: HealthStatus.Degraded,
                 tags: SharedCatalogTags)
-            .AddUrlGroup(
-                new Uri($"{n8nUrl}/healthz"),
-                name: "n8n",
-                tags: N8nTags)
             .AddCheck<Api.Infrastructure.HealthChecks.ConfigurationHealthCheck>(
                 "configuration",
                 failureStatus: HealthStatus.Degraded,
                 tags: ConfigurationTags);
+
+        // #2796: only health-check n8n when the WorkflowIntegration webhook client
+        // is actually enabled (mirrors N8nWebhookClientOptions.SectionName "N8n" +
+        // IsEnabled). Staging removed n8n entirely (disk); an unconditional probe
+        // would report permanent Unhealthy on the dashboard for a service we don't
+        // integrate with. String-indexer read avoids coupling to the WI context.
+        var n8nEnabled = string.Equals(
+            configuration["N8n:IsEnabled"], "true", StringComparison.OrdinalIgnoreCase);
+        if (n8nEnabled)
+        {
+            builder.AddUrlGroup(
+                new Uri($"{n8nUrl}/healthz"),
+                name: "n8n",
+                tags: N8nTags);
+        }
     }
 
     /// <summary>

--- a/apps/api/src/Api/Infrastructure/Configurations/SharedGameCatalog/MechanicAnalysisEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/Configurations/SharedGameCatalog/MechanicAnalysisEntityConfiguration.cs
@@ -64,6 +64,11 @@ internal sealed class MechanicAnalysisEntityConfiguration : IEntityTypeConfigura
             .HasColumnName("rejection_reason")
             .HasMaxLength(2000);
 
+        // #527: soft reference to the published card (no DB FK — avoids the analysis↔card FK cycle
+        // and its insert-ordering hazard; integrity is guaranteed by the publish handler setting
+        // this to the just-created card id inside the same transaction).
+        builder.Property(a => a.PublishedCardId).HasColumnName("published_card_id");
+
         builder.Property(a => a.TotalTokensUsed).HasColumnName("total_tokens_used").HasDefaultValue(0).IsRequired();
 
         builder.Property(a => a.EstimatedCostUsd)

--- a/apps/api/src/Api/Infrastructure/Configurations/SharedGameCatalog/MechanicCardAuditLogEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/Configurations/SharedGameCatalog/MechanicCardAuditLogEntityConfiguration.cs
@@ -1,0 +1,34 @@
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Api.Infrastructure.Configurations.SharedGameCatalog;
+
+/// <summary>
+/// EF configuration for <see cref="MechanicCardAuditLogEntity"/> (ADR-051 audit trail, #527).
+/// Append-only; FK to the card configured on the <see cref="MechanicCardEntityConfiguration"/> side
+/// (ON DELETE CASCADE).
+/// </summary>
+internal sealed class MechanicCardAuditLogEntityConfiguration : IEntityTypeConfiguration<MechanicCardAuditLogEntity>
+{
+    public void Configure(EntityTypeBuilder<MechanicCardAuditLogEntity> builder)
+    {
+        builder.ToTable("mechanic_card_audit_log", t =>
+        {
+            t.HasCheckConstraint(
+                "ck_mechanic_card_audit_log_action",
+                "action IN ('published', 'suppressed', 'unsuppressed', 'revised')");
+        });
+
+        builder.HasKey(a => a.Id);
+
+        builder.Property(a => a.Id).HasColumnName("id").IsRequired();
+        builder.Property(a => a.CardId).HasColumnName("card_id").IsRequired();
+        builder.Property(a => a.Action).HasColumnName("action").HasMaxLength(32).IsRequired();
+        builder.Property(a => a.ActorId).HasColumnName("actor_id").IsRequired();
+        builder.Property(a => a.OccurredAt).HasColumnName("occurred_at").IsRequired();
+        builder.Property(a => a.Metadata).HasColumnName("metadata").HasColumnType("jsonb");
+
+        builder.HasIndex(a => a.CardId).HasDatabaseName("ix_mechanic_card_audit_log_card_id");
+    }
+}

--- a/apps/api/src/Api/Infrastructure/Configurations/SharedGameCatalog/MechanicCardEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/Configurations/SharedGameCatalog/MechanicCardEntityConfiguration.cs
@@ -1,0 +1,104 @@
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Api.Infrastructure.Configurations.SharedGameCatalog;
+
+/// <summary>
+/// EF configuration for <see cref="MechanicCardEntity"/> (ADR-051 / #527).
+/// </summary>
+/// <remarks>
+/// Enforces at DB level:
+/// - Partial unique index: at most one non-suppressed card per SharedGame (T5 / AC-1).
+/// - CHECK origin IN ('ai_reviewed','manual','imported_external'), version >= 1.
+/// - CHECK suppression completeness (suppressed rows carry actor + reason + timestamp).
+/// - Global query filter hides suppressed cards from player-facing queries.
+/// </remarks>
+internal sealed class MechanicCardEntityConfiguration : IEntityTypeConfiguration<MechanicCardEntity>
+{
+    public void Configure(EntityTypeBuilder<MechanicCardEntity> builder)
+    {
+        builder.ToTable("mechanic_cards", t =>
+        {
+            t.HasCheckConstraint(
+                "ck_mechanic_cards_origin",
+                "origin IN ('ai_reviewed', 'manual', 'imported_external')");
+
+            t.HasCheckConstraint(
+                "ck_mechanic_cards_version_positive",
+                "version >= 1");
+
+            t.HasCheckConstraint(
+                "ck_mechanic_cards_suppression_completeness",
+                "(is_suppressed = false AND suppressed_at IS NULL AND suppressed_by IS NULL AND suppressed_reason IS NULL) "
+                + "OR (is_suppressed = true AND suppressed_at IS NOT NULL AND suppressed_by IS NOT NULL AND suppressed_reason IS NOT NULL)");
+
+            t.HasCheckConstraint(
+                "ck_mechanic_cards_error_reports_non_negative",
+                "error_reports_count >= 0");
+        });
+
+        builder.HasKey(c => c.Id);
+
+        builder.Property(c => c.Id).HasColumnName("id").IsRequired();
+        builder.Property(c => c.SharedGameId).HasColumnName("shared_game_id").IsRequired();
+        builder.Property(c => c.OriginAnalysisId).HasColumnName("origin_analysis_id").IsRequired();
+        builder.Property(c => c.Origin).HasColumnName("origin").HasMaxLength(32).IsRequired();
+        builder.Property(c => c.Title).HasColumnName("title").HasMaxLength(200).IsRequired();
+
+        builder.Property(c => c.Content)
+            .HasColumnName("content")
+            .HasColumnType("jsonb")
+            .IsRequired();
+
+        builder.Property(c => c.Version).HasColumnName("version").HasDefaultValue(1).IsRequired();
+
+        builder.Property(c => c.IsSuppressed).HasColumnName("is_suppressed").HasDefaultValue(false).IsRequired();
+        builder.Property(c => c.SuppressedReason).HasColumnName("suppressed_reason").HasMaxLength(500);
+        builder.Property(c => c.SuppressedAt).HasColumnName("suppressed_at");
+        builder.Property(c => c.SuppressedBy).HasColumnName("suppressed_by");
+
+        builder.Property(c => c.ErrorReportsCount).HasColumnName("error_reports_count").HasDefaultValue(0).IsRequired();
+        builder.Property(c => c.FeedbackScore).HasColumnName("feedback_score").HasColumnType("numeric(4,2)");
+
+        builder.Property(c => c.PublishedAt).HasColumnName("published_at").IsRequired();
+        builder.Property(c => c.PublishedBy).HasColumnName("published_by").IsRequired();
+        builder.Property(c => c.CreatedAt).HasColumnName("created_at").IsRequired();
+        builder.Property(c => c.UpdatedAt).HasColumnName("updated_at").IsRequired();
+
+        builder.Property(c => c.Xmin)
+            .HasColumnName("xmin")
+            .HasColumnType("xid")
+            .ValueGeneratedOnAddOrUpdate()
+            .IsConcurrencyToken();
+
+        // === Indexes ===
+        // At most one active (non-suppressed) card per shared game (AC-1 / T5).
+        builder.HasIndex(c => c.SharedGameId)
+            .HasDatabaseName("ux_mechanic_cards_active_per_game")
+            .IsUnique()
+            .HasFilter("is_suppressed = false");
+
+        builder.HasIndex(c => c.OriginAnalysisId)
+            .HasDatabaseName("ix_mechanic_cards_origin_analysis_id");
+
+        // === FKs ===
+        builder.HasOne(c => c.SharedGame)
+            .WithMany()
+            .HasForeignKey(c => c.SharedGameId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasOne(c => c.OriginAnalysis)
+            .WithMany()
+            .HasForeignKey(c => c.OriginAnalysisId)
+            .OnDelete(DeleteBehavior.Restrict);
+
+        builder.HasMany(c => c.AuditLog)
+            .WithOne(a => a.Card)
+            .HasForeignKey(a => a.CardId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        // Player-facing default hides suppressed cards (admin ops use IgnoreQueryFilters).
+        builder.HasQueryFilter(c => !c.IsSuppressed);
+    }
+}

--- a/apps/api/src/Api/Infrastructure/Configurations/SharedGameCatalog/MechanicClaimEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/Configurations/SharedGameCatalog/MechanicClaimEntityConfiguration.cs
@@ -51,6 +51,10 @@ internal sealed class MechanicClaimEntityConfiguration : IEntityTypeConfiguratio
             .HasColumnName("rejection_note")
             .HasMaxLength(2000);
 
+        builder.Property(c => c.ReviewNote)
+            .HasColumnName("review_note")
+            .HasMaxLength(2000);
+
         builder.HasIndex(c => c.AnalysisId).HasDatabaseName("ix_mechanic_claims_analysis_id");
         builder.HasIndex(c => new { c.AnalysisId, c.Section, c.DisplayOrder })
             .HasDatabaseName("ix_mechanic_claims_analysis_section_order");

--- a/apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/MechanicAnalysisEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/MechanicAnalysisEntity.cs
@@ -23,6 +23,9 @@ public class MechanicAnalysisEntity
     public DateTime? ReviewedAt { get; set; }
     public string? RejectionReason { get; set; }
 
+    /// <summary>FK to the published <c>mechanic_cards</c> row (#527). Null until explicitly published.</summary>
+    public Guid? PublishedCardId { get; set; }
+
     // === LLM execution snapshot ===
     public int TotalTokensUsed { get; set; }
     public decimal EstimatedCostUsd { get; set; }

--- a/apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/MechanicCardAuditLogEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/MechanicCardAuditLogEntity.cs
@@ -1,0 +1,23 @@
+namespace Api.Infrastructure.Entities.SharedGameCatalog;
+
+/// <summary>
+/// Persistence entity for <see cref="Api.BoundedContexts.SharedGameCatalog.Domain.Entities.MechanicCardAuditLog"/>
+/// (ADR-051 audit trail, #527). Append-only.
+/// </summary>
+public class MechanicCardAuditLogEntity
+{
+    public Guid Id { get; set; }
+    public Guid CardId { get; set; }
+
+    /// <summary>Lowercase string: 'published' | 'suppressed' | 'unsuppressed' | 'revised' (DB CHECK).</summary>
+    public string Action { get; set; } = "published";
+
+    public Guid ActorId { get; set; }
+    public DateTime OccurredAt { get; set; }
+
+    /// <summary>Optional JSONB metadata (e.g. reason, previous_card_id).</summary>
+    public string? Metadata { get; set; }
+
+    // === Navigation ===
+    public MechanicCardEntity Card { get; set; } = default!;
+}

--- a/apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/MechanicCardEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/MechanicCardEntity.cs
@@ -1,0 +1,51 @@
+namespace Api.Infrastructure.Entities.SharedGameCatalog;
+
+/// <summary>
+/// Persistence entity for <see cref="Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates.MechanicCard"/>
+/// (ADR-051 / #527). Plain POCO — all invariants live in the domain aggregate.
+/// </summary>
+public class MechanicCardEntity
+{
+    public Guid Id { get; set; }
+
+    // === Identity / lineage ===
+    public Guid SharedGameId { get; set; }
+    public Guid OriginAnalysisId { get; set; }
+
+    /// <summary>Lowercase string: 'ai_reviewed' | 'manual' | 'imported_external' (DB CHECK).</summary>
+    public string Origin { get; set; } = "ai_reviewed";
+
+    // === Content ===
+    public string Title { get; set; } = string.Empty;
+
+    /// <summary>Immutable JSONB snapshot of the approved claims (AD-1).</summary>
+    public string Content { get; set; } = "{}";
+
+    public int Version { get; set; }
+
+    // === Takedown (T5) ===
+    public bool IsSuppressed { get; set; }
+    public string? SuppressedReason { get; set; }
+    public DateTime? SuppressedAt { get; set; }
+    public Guid? SuppressedBy { get; set; }
+
+    // === Player feedback (#531) ===
+    public int ErrorReportsCount { get; set; }
+    public decimal? FeedbackScore { get; set; }
+
+    // === Publication audit ===
+    public DateTime PublishedAt { get; set; }
+    public Guid PublishedBy { get; set; }
+
+    // === Housekeeping ===
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+
+    /// <summary>PostgreSQL system column <c>xmin</c> mapped as <see cref="uint"/> (xid) — concurrency token (ADR-060).</summary>
+    public uint Xmin { get; set; }
+
+    // === Navigation ===
+    public SharedGameEntity SharedGame { get; set; } = default!;
+    public MechanicAnalysisEntity OriginAnalysis { get; set; } = default!;
+    public ICollection<MechanicCardAuditLogEntity> AuditLog { get; set; } = new List<MechanicCardAuditLogEntity>();
+}

--- a/apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/MechanicClaimEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/MechanicClaimEntity.cs
@@ -21,6 +21,9 @@ public class MechanicClaimEntity
     public DateTime? ReviewedAt { get; set; }
     public string? RejectionNote { get; set; }
 
+    /// <summary>Optional free-form note captured on APPROVE (#526 AC-6). Distinct from RejectionNote.</summary>
+    public string? ReviewNote { get; set; }
+
     // === Navigation ===
     public MechanicAnalysisEntity Analysis { get; set; } = default!;
     public ICollection<MechanicCitationEntity> Citations { get; set; } = new List<MechanicCitationEntity>();

--- a/apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs
+++ b/apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs
@@ -208,6 +208,8 @@ public class MeepleAiDbContext : DbContext
     public DbSet<MechanicCitationEntity> MechanicCitations => Set<MechanicCitationEntity>(); // ISSUE-523: Child of MechanicClaim (ADR-051 T1 quote cap)
     public DbSet<MechanicStatusAuditEntity> MechanicStatusAudits => Set<MechanicStatusAuditEntity>(); // ISSUE-523: T6 audit trail for lifecycle transitions
     public DbSet<MechanicSuppressionAuditEntity> MechanicSuppressionAudits => Set<MechanicSuppressionAuditEntity>(); // ISSUE-523: T5 audit trail for suppressions
+    public DbSet<MechanicCardEntity> MechanicCards => Set<MechanicCardEntity>(); // #527: Mechanic Extractor M1.5 — published user-facing card
+    public DbSet<MechanicCardAuditLogEntity> MechanicCardAuditLog => Set<MechanicCardAuditLogEntity>(); // #527: card lifecycle audit trail
     public DbSet<MechanicAnalysisSectionRunEntity> MechanicAnalysisSectionRuns => Set<MechanicAnalysisSectionRunEntity>(); // ISSUE-524: M1.2 per-section provider/token tracking (B6=C)
     public DbSet<MechanicGoldenClaimEntity> MechanicGoldenClaims => Set<MechanicGoldenClaimEntity>(); // ADR-051 Sprint 1 / M2.0: golden-set claims
     public DbSet<MechanicGoldenBggTagEntity> MechanicGoldenBggTags => Set<MechanicGoldenBggTagEntity>(); // ADR-051 Sprint 1 / M2.0: BGG mechanic tags

--- a/apps/api/src/Api/Infrastructure/Migrations/20260709200055_AddMechanicClaimReviewNote.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260709200055_AddMechanicClaimReviewNote.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260709200055_AddMechanicClaimReviewNote")]
+    partial class AddMechanicClaimReviewNote
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -11959,10 +11962,6 @@ namespace Api.Infrastructure.Migrations
                         .HasColumnType("character varying(64)")
                         .HasColumnName("provider");
 
-                    b.Property<Guid?>("PublishedCardId")
-                        .HasColumnType("uuid")
-                        .HasColumnName("published_card_id");
-
                     b.Property<string>("RejectionReason")
                         .HasMaxLength(2000)
                         .HasColumnType("character varying(2000)")
@@ -12237,157 +12236,6 @@ namespace Api.Infrastructure.Migrations
                             t.HasCheckConstraint("ck_mechanic_section_runs_status_range", "status BETWEEN 0 AND 2");
 
                             t.HasCheckConstraint("ck_mechanic_section_runs_tokens_non_negative", "prompt_tokens >= 0 AND completion_tokens >= 0 AND total_tokens >= 0");
-                        });
-                });
-
-            modelBuilder.Entity("Api.Infrastructure.Entities.SharedGameCatalog.MechanicCardAuditLogEntity", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("uuid")
-                        .HasColumnName("id");
-
-                    b.Property<string>("Action")
-                        .IsRequired()
-                        .HasMaxLength(32)
-                        .HasColumnType("character varying(32)")
-                        .HasColumnName("action");
-
-                    b.Property<Guid>("ActorId")
-                        .HasColumnType("uuid")
-                        .HasColumnName("actor_id");
-
-                    b.Property<Guid>("CardId")
-                        .HasColumnType("uuid")
-                        .HasColumnName("card_id");
-
-                    b.Property<string>("Metadata")
-                        .HasColumnType("jsonb")
-                        .HasColumnName("metadata");
-
-                    b.Property<DateTime>("OccurredAt")
-                        .HasColumnType("timestamp with time zone")
-                        .HasColumnName("occurred_at");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("CardId")
-                        .HasDatabaseName("ix_mechanic_card_audit_log_card_id");
-
-                    b.ToTable("mechanic_card_audit_log", null, t =>
-                        {
-                            t.HasCheckConstraint("ck_mechanic_card_audit_log_action", "action IN ('published', 'suppressed', 'unsuppressed', 'revised')");
-                        });
-                });
-
-            modelBuilder.Entity("Api.Infrastructure.Entities.SharedGameCatalog.MechanicCardEntity", b =>
-                {
-                    b.Property<Guid>("Id")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("uuid")
-                        .HasColumnName("id");
-
-                    b.Property<string>("Content")
-                        .IsRequired()
-                        .HasColumnType("jsonb")
-                        .HasColumnName("content");
-
-                    b.Property<DateTime>("CreatedAt")
-                        .HasColumnType("timestamp with time zone")
-                        .HasColumnName("created_at");
-
-                    b.Property<int>("ErrorReportsCount")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("integer")
-                        .HasDefaultValue(0)
-                        .HasColumnName("error_reports_count");
-
-                    b.Property<decimal?>("FeedbackScore")
-                        .HasColumnType("numeric(4,2)")
-                        .HasColumnName("feedback_score");
-
-                    b.Property<bool>("IsSuppressed")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("boolean")
-                        .HasDefaultValue(false)
-                        .HasColumnName("is_suppressed");
-
-                    b.Property<string>("Origin")
-                        .IsRequired()
-                        .HasMaxLength(32)
-                        .HasColumnType("character varying(32)")
-                        .HasColumnName("origin");
-
-                    b.Property<Guid>("OriginAnalysisId")
-                        .HasColumnType("uuid")
-                        .HasColumnName("origin_analysis_id");
-
-                    b.Property<DateTime>("PublishedAt")
-                        .HasColumnType("timestamp with time zone")
-                        .HasColumnName("published_at");
-
-                    b.Property<Guid>("PublishedBy")
-                        .HasColumnType("uuid")
-                        .HasColumnName("published_by");
-
-                    b.Property<Guid>("SharedGameId")
-                        .HasColumnType("uuid")
-                        .HasColumnName("shared_game_id");
-
-                    b.Property<DateTime?>("SuppressedAt")
-                        .HasColumnType("timestamp with time zone")
-                        .HasColumnName("suppressed_at");
-
-                    b.Property<Guid?>("SuppressedBy")
-                        .HasColumnType("uuid")
-                        .HasColumnName("suppressed_by");
-
-                    b.Property<string>("SuppressedReason")
-                        .HasMaxLength(500)
-                        .HasColumnType("character varying(500)")
-                        .HasColumnName("suppressed_reason");
-
-                    b.Property<string>("Title")
-                        .IsRequired()
-                        .HasMaxLength(200)
-                        .HasColumnType("character varying(200)")
-                        .HasColumnName("title");
-
-                    b.Property<DateTime>("UpdatedAt")
-                        .HasColumnType("timestamp with time zone")
-                        .HasColumnName("updated_at");
-
-                    b.Property<int>("Version")
-                        .ValueGeneratedOnAdd()
-                        .HasColumnType("integer")
-                        .HasDefaultValue(1)
-                        .HasColumnName("version");
-
-                    b.Property<uint>("Xmin")
-                        .IsConcurrencyToken()
-                        .ValueGeneratedOnAddOrUpdate()
-                        .HasColumnType("xid")
-                        .HasColumnName("xmin");
-
-                    b.HasKey("Id");
-
-                    b.HasIndex("OriginAnalysisId")
-                        .HasDatabaseName("ix_mechanic_cards_origin_analysis_id");
-
-                    b.HasIndex("SharedGameId")
-                        .IsUnique()
-                        .HasDatabaseName("ux_mechanic_cards_active_per_game")
-                        .HasFilter("is_suppressed = false");
-
-                    b.ToTable("mechanic_cards", null, t =>
-                        {
-                            t.HasCheckConstraint("ck_mechanic_cards_error_reports_non_negative", "error_reports_count >= 0");
-
-                            t.HasCheckConstraint("ck_mechanic_cards_origin", "origin IN ('ai_reviewed', 'manual', 'imported_external')");
-
-                            t.HasCheckConstraint("ck_mechanic_cards_suppression_completeness", "(is_suppressed = false AND suppressed_at IS NULL AND suppressed_by IS NULL AND suppressed_reason IS NULL) OR (is_suppressed = true AND suppressed_at IS NOT NULL AND suppressed_by IS NOT NULL AND suppressed_reason IS NOT NULL)");
-
-                            t.HasCheckConstraint("ck_mechanic_cards_version_positive", "version >= 1");
                         });
                 });
 
@@ -18305,36 +18153,6 @@ namespace Api.Infrastructure.Migrations
                     b.Navigation("Analysis");
                 });
 
-            modelBuilder.Entity("Api.Infrastructure.Entities.SharedGameCatalog.MechanicCardAuditLogEntity", b =>
-                {
-                    b.HasOne("Api.Infrastructure.Entities.SharedGameCatalog.MechanicCardEntity", "Card")
-                        .WithMany("AuditLog")
-                        .HasForeignKey("CardId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.Navigation("Card");
-                });
-
-            modelBuilder.Entity("Api.Infrastructure.Entities.SharedGameCatalog.MechanicCardEntity", b =>
-                {
-                    b.HasOne("Api.Infrastructure.Entities.SharedGameCatalog.MechanicAnalysisEntity", "OriginAnalysis")
-                        .WithMany()
-                        .HasForeignKey("OriginAnalysisId")
-                        .OnDelete(DeleteBehavior.Restrict)
-                        .IsRequired();
-
-                    b.HasOne("Api.Infrastructure.Entities.SharedGameCatalog.SharedGameEntity", "SharedGame")
-                        .WithMany()
-                        .HasForeignKey("SharedGameId")
-                        .OnDelete(DeleteBehavior.Cascade)
-                        .IsRequired();
-
-                    b.Navigation("OriginAnalysis");
-
-                    b.Navigation("SharedGame");
-                });
-
             modelBuilder.Entity("Api.Infrastructure.Entities.SharedGameCatalog.MechanicCitationEntity", b =>
                 {
                     b.HasOne("Api.Infrastructure.Entities.TextChunkEntity", null)
@@ -19046,11 +18864,6 @@ namespace Api.Infrastructure.Migrations
                     b.Navigation("Claims");
 
                     b.Navigation("SectionRuns");
-                });
-
-            modelBuilder.Entity("Api.Infrastructure.Entities.SharedGameCatalog.MechanicCardEntity", b =>
-                {
-                    b.Navigation("AuditLog");
                 });
 
             modelBuilder.Entity("Api.Infrastructure.Entities.SharedGameCatalog.MechanicClaimEntity", b =>

--- a/apps/api/src/Api/Infrastructure/Migrations/20260709200055_AddMechanicClaimReviewNote.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260709200055_AddMechanicClaimReviewNote.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddMechanicClaimReviewNote : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "review_note",
+                table: "mechanic_claims",
+                type: "character varying(2000)",
+                maxLength: 2000,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "review_note",
+                table: "mechanic_claims");
+        }
+    }
+}

--- a/apps/api/src/Api/Infrastructure/Migrations/20260709224421_M1_5_MechanicCardsSchema.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260709224421_M1_5_MechanicCardsSchema.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260709224421_M1_5_MechanicCardsSchema")]
+    partial class M1_5_MechanicCardsSchema
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260709224421_M1_5_MechanicCardsSchema.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260709224421_M1_5_MechanicCardsSchema.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class M1_5_MechanicCardsSchema : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // Idempotent raw SQL (ADR-051 AC-1, pattern PR #517). Each statement is terminated with
+            // ';' so the deploy's idempotent psql path parses cleanly (#2766).
+            //
+            // NOTE: the `xmin` concurrency token maps to PostgreSQL's SYSTEM column of the same name,
+            // which every table already has — it is deliberately NOT declared here (declaring a user
+            // column named `xmin` would collide with the system column).
+
+            migrationBuilder.Sql(
+                "ALTER TABLE mechanic_analyses ADD COLUMN IF NOT EXISTS published_card_id uuid NULL;");
+
+            migrationBuilder.Sql(@"
+                CREATE TABLE IF NOT EXISTS mechanic_cards (
+                    id uuid NOT NULL,
+                    shared_game_id uuid NOT NULL,
+                    origin_analysis_id uuid NOT NULL,
+                    origin character varying(32) NOT NULL,
+                    title character varying(200) NOT NULL,
+                    content jsonb NOT NULL,
+                    version integer NOT NULL DEFAULT 1,
+                    is_suppressed boolean NOT NULL DEFAULT false,
+                    suppressed_reason character varying(500) NULL,
+                    suppressed_at timestamp with time zone NULL,
+                    suppressed_by uuid NULL,
+                    error_reports_count integer NOT NULL DEFAULT 0,
+                    feedback_score numeric(4,2) NULL,
+                    published_at timestamp with time zone NOT NULL,
+                    published_by uuid NOT NULL,
+                    created_at timestamp with time zone NOT NULL,
+                    updated_at timestamp with time zone NOT NULL,
+                    CONSTRAINT ""PK_mechanic_cards"" PRIMARY KEY (id),
+                    CONSTRAINT ck_mechanic_cards_error_reports_non_negative CHECK (error_reports_count >= 0),
+                    CONSTRAINT ck_mechanic_cards_origin CHECK (origin IN ('ai_reviewed', 'manual', 'imported_external')),
+                    CONSTRAINT ck_mechanic_cards_suppression_completeness CHECK ((is_suppressed = false AND suppressed_at IS NULL AND suppressed_by IS NULL AND suppressed_reason IS NULL) OR (is_suppressed = true AND suppressed_at IS NOT NULL AND suppressed_by IS NOT NULL AND suppressed_reason IS NOT NULL)),
+                    CONSTRAINT ck_mechanic_cards_version_positive CHECK (version >= 1),
+                    CONSTRAINT ""FK_mechanic_cards_mechanic_analyses_origin_analysis_id"" FOREIGN KEY (origin_analysis_id) REFERENCES mechanic_analyses (id) ON DELETE RESTRICT,
+                    CONSTRAINT ""FK_mechanic_cards_shared_games_shared_game_id"" FOREIGN KEY (shared_game_id) REFERENCES shared_games (id) ON DELETE CASCADE
+                );");
+
+            migrationBuilder.Sql(@"
+                CREATE TABLE IF NOT EXISTS mechanic_card_audit_log (
+                    id uuid NOT NULL,
+                    card_id uuid NOT NULL,
+                    action character varying(32) NOT NULL,
+                    actor_id uuid NOT NULL,
+                    occurred_at timestamp with time zone NOT NULL,
+                    metadata jsonb NULL,
+                    CONSTRAINT ""PK_mechanic_card_audit_log"" PRIMARY KEY (id),
+                    CONSTRAINT ck_mechanic_card_audit_log_action CHECK (action IN ('published', 'suppressed', 'unsuppressed', 'revised')),
+                    CONSTRAINT ""FK_mechanic_card_audit_log_mechanic_cards_card_id"" FOREIGN KEY (card_id) REFERENCES mechanic_cards (id) ON DELETE CASCADE
+                );");
+
+            migrationBuilder.Sql(
+                "CREATE INDEX IF NOT EXISTS ix_mechanic_card_audit_log_card_id ON mechanic_card_audit_log (card_id);");
+
+            migrationBuilder.Sql(
+                "CREATE INDEX IF NOT EXISTS ix_mechanic_cards_origin_analysis_id ON mechanic_cards (origin_analysis_id);");
+
+            migrationBuilder.Sql(
+                "CREATE UNIQUE INDEX IF NOT EXISTS ux_mechanic_cards_active_per_game ON mechanic_cards (shared_game_id) WHERE is_suppressed = false;");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("DROP TABLE IF EXISTS mechanic_card_audit_log;");
+            migrationBuilder.Sql("DROP TABLE IF EXISTS mechanic_cards;");
+            migrationBuilder.Sql("ALTER TABLE mechanic_analyses DROP COLUMN IF EXISTS published_card_id;");
+        }
+    }
+}

--- a/apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.MechanicReview.cs
+++ b/apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.MechanicReview.cs
@@ -1,0 +1,13 @@
+using System.Diagnostics.Metrics;
+
+namespace Api.Observability;
+
+/// <summary>#526 ME-M1.4 admin-review observability (AC-7): bulk-action counter.</summary>
+internal static partial class MeepleAiMetrics
+{
+    /// <summary>Admin mechanic-review bulk actions, tagged {action=bulk_approve|bulk_reject}.</summary>
+    public static readonly Counter<long> MechanicReviewBulkActions =
+        Meter.CreateCounter<long>(
+            "mechanic_review_bulk_actions_total",
+            description: "Admin mechanic-review bulk actions by action.");
+}

--- a/apps/api/src/Api/Routing/AdminMechanicAnalysesEndpoints.cs
+++ b/apps/api/src/Api/Routing/AdminMechanicAnalysesEndpoints.cs
@@ -211,6 +211,7 @@ internal static class AdminMechanicAnalysesEndpoints
         group.MapPost("/{id:guid}/claims/{claimId:guid}/approve", async (
             Guid id,
             Guid claimId,
+            ApproveClaimRequest? request,
             HttpContext httpContext,
             IMediator mediator,
             CancellationToken ct) =>
@@ -218,7 +219,7 @@ internal static class AdminMechanicAnalysesEndpoints
             var session = (SessionStatusDto)httpContext.Items[nameof(SessionStatusDto)]!;
             var reviewerId = session!.Principal!.Subject.Id;
 
-            var command = new ApproveMechanicClaimCommand(id, claimId, reviewerId);
+            var command = new ApproveMechanicClaimCommand(id, claimId, reviewerId, request?.Note);
             var response = await mediator.Send(command, ct).ConfigureAwait(false);
 
             return Results.Ok(response);
@@ -227,7 +228,9 @@ internal static class AdminMechanicAnalysesEndpoints
         .WithSummary("Approve a single claim (ISSUE-584)")
         .WithDescription(
             "Transitions a single claim from Pending or Rejected to Approved. Idempotent on " +
-            "claims already Approved. Parent analysis must be InReview; otherwise 409.");
+            "claims already Approved. An optional review note (#526 AC-6, ≤ 2000 chars) is " +
+            "persisted alongside the approval; an empty body still approves. Parent analysis " +
+            "must be InReview; otherwise 409.");
 
         // POST /api/v1/admin/mechanic-analyses/{id}/claims/{claimId}/reject (ISSUE-584)
         // Per-claim reject with mandatory note (1–500 chars).
@@ -372,6 +375,14 @@ internal sealed record SuppressMechanicAnalysisRequest(
 /// <param name="Note">Reviewer rejection note (1–500 chars). Mandatory — surfaces back
 /// in the claims viewer so the reviewer can act on it before re-approving.</param>
 internal sealed record RejectClaimRequest(string Note);
+
+/// <summary>
+/// Request body for <c>POST /admin/mechanic-analyses/{id}/claims/{claimId}/approve</c>
+/// (#526 AC-6). Optional — an empty body still approves the claim. The reviewer id is
+/// sourced from the validated session, never the body.
+/// </summary>
+/// <param name="Note">Optional free-form review note (≤ 2000 chars) persisted with the approval.</param>
+internal sealed record ApproveClaimRequest(string? Note);
 
 /// <summary>
 /// Request body for <c>POST /admin/mechanic-analyses/{id}/claims/bulk-reject</c> (#526).

--- a/apps/api/src/Api/Routing/AdminMechanicAnalysesEndpoints.cs
+++ b/apps/api/src/Api/Routing/AdminMechanicAnalysesEndpoints.cs
@@ -161,6 +161,30 @@ internal static class AdminMechanicAnalysesEndpoints
             "Transitions the aggregate from InReview to Published. All claims must be in " +
             "Approved status; otherwise the endpoint returns 409 with a breakdown.");
 
+        // POST /api/v1/admin/mechanic-analyses/{id}/publish (#527)
+        // Publishes a Published-lifecycle analysis into a user-facing mechanic_cards row.
+        group.MapPost("/{id:guid}/publish", async (
+            Guid id,
+            PublishMechanicCardRequest? body,
+            HttpContext httpContext,
+            IMediator mediator,
+            CancellationToken ct) =>
+        {
+            var session = (SessionStatusDto)httpContext.Items[nameof(SessionStatusDto)]!;
+            var publisherId = session!.Principal!.Subject.Id;
+
+            var command = new PublishMechanicCardCommand(id, body?.Title, body?.PreviousCardId, publisherId);
+            var response = await mediator.Send(command, ct).ConfigureAwait(false);
+
+            return Results.Created($"/api/v1/admin/mechanic-cards/{response.CardId}", response);
+        })
+        .WithName("AdminPublishMechanicCard")
+        .WithSummary("Publish an approved mechanic analysis into a user-facing card")
+        .WithDescription(
+            "Snapshots the approved claims into a new mechanic_cards row (version monotonic per game). " +
+            "The analysis must be Published and not already published; an active card for the game " +
+            "returns 409 unless a suppressed previousCardId is supplied (republish → new version).");
+
         // GET /api/v1/admin/mechanic-analyses/{id}/claims (ISSUE-584)
         // Lists every claim of the analysis with citations, ordered by section then display order.
         group.MapGet("/{id:guid}/claims", async (
@@ -356,3 +380,6 @@ internal sealed record RejectClaimRequest(string Note);
 /// <param name="ClaimIds">Explicit claim ids to reject (computed client-side, decision D3).</param>
 /// <param name="Reason">Shared rejection reason (1–500 chars) applied to every claim.</param>
 internal sealed record BulkRejectClaimsRequest(IReadOnlyList<Guid> ClaimIds, string Reason);
+
+/// <summary>Body for <c>POST /admin/mechanic-analyses/{id}/publish</c> (#527). Both fields optional.</summary>
+internal sealed record PublishMechanicCardRequest(string? Title, Guid? PreviousCardId);

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/ApproveMechanicClaimCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/ApproveMechanicClaimCommandHandlerTests.cs
@@ -1,0 +1,142 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Commands.MechanicExtractor;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Commands.MechanicExtractor;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public class ApproveMechanicClaimCommandHandlerTests
+{
+    private readonly Mock<IMechanicAnalysisRepository> _repositoryMock = new();
+    private readonly Mock<IUnitOfWork> _unitOfWorkMock = new();
+    private readonly Mock<ILogger<ApproveMechanicClaimCommandHandler>> _loggerMock = new();
+    private readonly ApproveMechanicClaimCommandHandler _handler;
+
+    public ApproveMechanicClaimCommandHandlerTests()
+    {
+        _handler = new ApproveMechanicClaimCommandHandler(
+            _repositoryMock.Object,
+            _unitOfWorkMock.Object,
+            TimeProvider.System,
+            _loggerMock.Object);
+    }
+
+    // Builds an InReview analysis with `claimCount` Pending claims.
+    private static MechanicAnalysis BuildInReviewAnalysis(int claimCount)
+    {
+        var analysis = MechanicAnalysis.Create(
+            sharedGameId: Guid.NewGuid(),
+            pdfDocumentId: Guid.NewGuid(),
+            promptVersion: "v1",
+            createdBy: Guid.NewGuid(),
+            createdAt: DateTime.UtcNow,
+            modelUsed: "test-model",
+            provider: "test-provider",
+            costCapUsd: 1.0m);
+
+        for (var i = 0; i < claimCount; i++)
+        {
+            var citation = MechanicCitation.Create(Guid.NewGuid(), pdfPage: 1, quote: "q", chunkId: null, displayOrder: 0);
+            var claim = MechanicClaim.Create(
+                analysis.Id, MechanicSection.Mechanics, $"claim {i}", displayOrder: i, new[] { citation });
+            analysis.AddClaim(claim);
+        }
+
+        analysis.SubmitForReview(Guid.NewGuid(), DateTime.UtcNow);
+        return analysis;
+    }
+
+    private void SetupRepo(MechanicAnalysis? analysis, Guid analysisId)
+    {
+        _repositoryMock
+            .Setup(r => r.GetByIdWithClaimsIgnoringFiltersAsync(analysisId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(analysis);
+    }
+
+    [Fact]
+    public async Task Handle_WithNote_StoresReviewNote()
+    {
+        var analysis = BuildInReviewAnalysis(1);
+        var claimId = analysis.Claims.Single().Id;
+        SetupRepo(analysis, analysis.Id);
+
+        var result = await _handler.Handle(
+            new ApproveMechanicClaimCommand(analysis.Id, claimId, Guid.NewGuid(), "looks good, matches p.4"),
+            CancellationToken.None);
+
+        result.Status.Should().Be(MechanicClaimStatus.Approved);
+        result.ReviewNote.Should().Be("looks good, matches p.4");
+        _repositoryMock.Verify(r => r.Update(analysis), Times.Once);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WithoutNote_LeavesReviewNoteNull()
+    {
+        var analysis = BuildInReviewAnalysis(1);
+        var claimId = analysis.Claims.Single().Id;
+        SetupRepo(analysis, analysis.Id);
+
+        var result = await _handler.Handle(
+            new ApproveMechanicClaimCommand(analysis.Id, claimId, Guid.NewGuid()),
+            CancellationToken.None);
+
+        result.Status.Should().Be(MechanicClaimStatus.Approved);
+        result.ReviewNote.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_AnalysisNotFound_Throws404()
+    {
+        var analysisId = Guid.NewGuid();
+        SetupRepo(null, analysisId);
+
+        var command = new ApproveMechanicClaimCommand(analysisId, Guid.NewGuid(), Guid.NewGuid());
+
+        await Assert.ThrowsAsync<NotFoundException>(() => _handler.Handle(command, CancellationToken.None));
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_AnalysisNotInReview_Throws409()
+    {
+        // Draft analysis (never SubmitForReview) — ApproveClaim guard fails.
+        var analysis = MechanicAnalysis.Create(
+            Guid.NewGuid(), Guid.NewGuid(), "v1", Guid.NewGuid(), DateTime.UtcNow, "m", "p", 1.0m);
+        var citation = MechanicCitation.Create(Guid.NewGuid(), 1, "q", null, 0);
+        var claim = MechanicClaim.Create(analysis.Id, MechanicSection.Mechanics, "c", 0, new[] { citation });
+        analysis.AddClaim(claim);
+        SetupRepo(analysis, analysis.Id);
+
+        var command = new ApproveMechanicClaimCommand(analysis.Id, claim.Id, Guid.NewGuid());
+
+        await Assert.ThrowsAsync<ConflictException>(() => _handler.Handle(command, CancellationToken.None));
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_ConcurrencyConflict_Throws409()
+    {
+        var analysis = BuildInReviewAnalysis(1);
+        var claimId = analysis.Claims.Single().Id;
+        SetupRepo(analysis, analysis.Id);
+        _unitOfWorkMock
+            .Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new DbUpdateConcurrencyException());
+
+        var command = new ApproveMechanicClaimCommand(analysis.Id, claimId, Guid.NewGuid());
+
+        await Assert.ThrowsAsync<ConflictException>(() => _handler.Handle(command, CancellationToken.None));
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/MechanicReviewMetricsTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/MechanicReviewMetricsTests.cs
@@ -1,0 +1,44 @@
+using System.Diagnostics.Metrics;
+using Api.Observability;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Commands.MechanicExtractor;
+
+/// <summary>
+/// #526 ME-M1.4 admin-review observability (AC-7): asserts
+/// <see cref="MeepleAiMetrics.MechanicReviewBulkActions"/> emits the expected {action} tag shape,
+/// captured via System.Diagnostics.Metrics MeterListener — same pattern as
+/// <c>MechanicValidatorMetricsTests</c> (#2494 / ME-M1.3 AC-7).
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public class MechanicReviewMetricsTests
+{
+    private const string Counter = "mechanic_review_bulk_actions_total";
+
+    [Fact]
+    public void MechanicReviewBulkActions_Emits_ActionTag()
+    {
+        var events = new List<string>();
+        using var listener = new MeterListener
+        {
+            InstrumentPublished = (instrument, l) =>
+            {
+                if (instrument.Meter.Name == MeepleAiMetrics.MeterName && instrument.Name == Counter)
+                    l.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((_, _, tags, _) =>
+        {
+            foreach (var tag in tags)
+                if (tag.Key == "action" && tag.Value is string a) events.Add(a);
+        });
+        listener.Start();
+
+        MeepleAiMetrics.MechanicReviewBulkActions.Add(1, new System.Diagnostics.TagList { { "action", "bulk_reject" } });
+
+        events.Should().ContainSingle().Which.Should().Be("bulk_reject");
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/DTOs/MechanicClaimValidationsTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/DTOs/MechanicClaimValidationsTests.cs
@@ -1,0 +1,20 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.DTOs;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public class MechanicClaimValidationsTests
+{
+    [Fact]
+    public void DerivePass_ReturnsFourPassBadges_T1ToT4()
+    {
+        var validations = MechanicClaimValidations.DerivePass();
+
+        validations.Select(v => v.Rule).Should().Equal("T1", "T2", "T3", "T4");
+        validations.Should().OnlyContain(v => v.Outcome == "pass" && v.Message == null);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Domain/Aggregates/MechanicCardTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Domain/Aggregates/MechanicCardTests.cs
@@ -1,0 +1,342 @@
+using System.Text.Json;
+
+using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Events;
+using Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+
+/// <summary>
+/// Unit tests for the <see cref="MechanicCard"/> aggregate (#527, M1.5): publish factory,
+/// snapshot immutability (AD-1), suppress/unsuppress (T5), and the
+/// <see cref="MechanicAnalysis.MarkPublished"/> publish-once invariant.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class MechanicCardTests
+{
+    private static readonly DateTime Now = new(2026, 07, 10, 12, 0, 0, DateTimeKind.Utc);
+
+    // ============================================================
+    // PublishFromAnalysis — happy path
+    // ============================================================
+
+    [Fact]
+    public void PublishFromAnalysis_WithApprovedAnalysis_ProducesCardV1()
+    {
+        var analysis = PublishedAnalysis();
+        var publisher = Guid.NewGuid();
+
+        var card = MechanicCard.PublishFromAnalysis(
+            analysis, overrideTitle: "Catan: Mechanics", GameContext("Catan"), publisher, version: 1, Now);
+
+        card.Id.Should().NotBe(Guid.Empty);
+        card.SharedGameId.Should().Be(analysis.SharedGameId);
+        card.OriginAnalysisId.Should().Be(analysis.Id);
+        card.Origin.Should().Be(MechanicCardOrigin.AiReviewed);
+        card.Title.Should().Be("Catan: Mechanics");
+        card.Version.Should().Be(1);
+        card.IsSuppressed.Should().BeFalse();
+        card.ErrorReportsCount.Should().Be(0);
+        card.PublishedBy.Should().Be(publisher);
+        card.PublishedAt.Should().Be(Now);
+    }
+
+    [Fact]
+    public void PublishFromAnalysis_WithoutTitle_UsesDefaultFromGameName()
+    {
+        var analysis = PublishedAnalysis();
+
+        var card = MechanicCard.PublishFromAnalysis(
+            analysis, overrideTitle: null, GameContext("7 Wonders"), Guid.NewGuid(), version: 1, Now);
+
+        card.Title.Should().Be("7 Wonders — Mechanics Card");
+    }
+
+    [Fact]
+    public void PublishFromAnalysis_RaisesMechanicCardPublishedEvent()
+    {
+        var analysis = PublishedAnalysis();
+
+        var card = MechanicCard.PublishFromAnalysis(
+            analysis, "Catan: Mechanics", GameContext("Catan"), Guid.NewGuid(), version: 1, Now);
+
+        card.DomainEvents.Should().ContainSingle(e => e is MechanicCardPublishedEvent);
+    }
+
+    [Fact]
+    public void PublishFromAnalysis_SnapshotsClaimsAndMetadataIntoContent()
+    {
+        var analysis = PublishedAnalysis();
+        // The handler resolves the game from analysis.SharedGameId, so the context mirrors it.
+        var gameContext = new MechanicCardGameContext
+        {
+            SharedGameId = analysis.SharedGameId,
+            SharedGameName = "Catan",
+            Publisher = "Kosmos",
+            Language = "it"
+        };
+
+        var card = MechanicCard.PublishFromAnalysis(
+            analysis, "Catan: Mechanics", gameContext, Guid.NewGuid(), 1, Now);
+
+        using var doc = JsonDocument.Parse(card.Content);
+        var root = doc.RootElement;
+
+        root.GetProperty("schema_version").GetInt32().Should().Be(1);
+        root.GetProperty("source_analysis_id").GetGuid().Should().Be(analysis.Id);
+        root.GetProperty("source_prompt_version").GetString().Should().Be("v1");
+
+        var claims = root.GetProperty("claims");
+        claims.GetArrayLength().Should().Be(1);
+        var claim = claims[0];
+        claim.GetProperty("claim").GetString().Should().Be("Draw phase");
+        claim.GetProperty("section").GetString().Should().Be("Mechanics");
+        claim.GetProperty("citations").GetArrayLength().Should().Be(1);
+        claim.GetProperty("citations")[0].GetProperty("pdf_id").GetGuid().Should().Be(analysis.PdfDocumentId);
+        claim.GetProperty("citations")[0].GetProperty("pdf_page").GetInt32().Should().Be(1);
+
+        var metadata = root.GetProperty("metadata");
+        metadata.GetProperty("shared_game_id").GetGuid().Should().Be(analysis.SharedGameId);
+        metadata.GetProperty("shared_game_name").GetString().Should().Be("Catan");
+        metadata.GetProperty("publisher").GetString().Should().Be("Kosmos");
+        metadata.GetProperty("language").GetString().Should().Be("it");
+    }
+
+    // ============================================================
+    // PublishFromAnalysis — preconditions
+    // ============================================================
+
+    [Fact]
+    public void PublishFromAnalysis_WithNonPublishedAnalysis_Throws()
+    {
+        var analysis = NewAnalysisWithClaim(); // Draft
+
+        var act = () => MechanicCard.PublishFromAnalysis(
+            analysis, null, GameContext("Catan"), Guid.NewGuid(), 1, Now);
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*Published*");
+    }
+
+    [Fact]
+    public void PublishFromAnalysis_WhenAnalysisAlreadyPublished_Throws()
+    {
+        var analysis = PublishedAnalysis();
+        analysis.MarkPublished(Guid.NewGuid());
+
+        var act = () => MechanicCard.PublishFromAnalysis(
+            analysis, null, GameContext("Catan"), Guid.NewGuid(), 1, Now);
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*already published*");
+    }
+
+    [Fact]
+    public void PublishFromAnalysis_WithEmptyPublisher_Throws()
+    {
+        var analysis = PublishedAnalysis();
+
+        var act = () => MechanicCard.PublishFromAnalysis(
+            analysis, null, GameContext("Catan"), Guid.Empty, 1, Now);
+
+        act.Should().Throw<ArgumentException>().WithMessage("*PublisherId*");
+    }
+
+    [Fact]
+    public void PublishFromAnalysis_WithVersionBelowOne_Throws()
+    {
+        var analysis = PublishedAnalysis();
+
+        var act = () => MechanicCard.PublishFromAnalysis(
+            analysis, null, GameContext("Catan"), Guid.NewGuid(), version: 0, Now);
+
+        act.Should().Throw<ArgumentOutOfRangeException>();
+    }
+
+    [Theory]
+    [InlineData("ABC")] // < 5
+    public void PublishFromAnalysis_WithTooShortTitle_Throws(string title)
+    {
+        var analysis = PublishedAnalysis();
+
+        var act = () => MechanicCard.PublishFromAnalysis(
+            analysis, title, GameContext("Catan"), Guid.NewGuid(), 1, Now);
+
+        act.Should().Throw<ArgumentException>().WithMessage("*Title*");
+    }
+
+    [Fact]
+    public void PublishFromAnalysis_WithTooLongTitle_Throws()
+    {
+        var analysis = PublishedAnalysis();
+
+        var act = () => MechanicCard.PublishFromAnalysis(
+            analysis, new string('x', 201), GameContext("Catan"), Guid.NewGuid(), 1, Now);
+
+        act.Should().Throw<ArgumentException>().WithMessage("*Title*");
+    }
+
+    // ============================================================
+    // Suppress / Unsuppress (T5)
+    // ============================================================
+
+    [Fact]
+    public void Suppress_MarksSuppressedAndRaisesEvent()
+    {
+        var card = NewCard();
+        var actor = Guid.NewGuid();
+
+        card.Suppress(actor, "Publisher DMCA takedown request received via legal.", Now);
+
+        card.IsSuppressed.Should().BeTrue();
+        card.SuppressedBy.Should().Be(actor);
+        card.SuppressedReason.Should().StartWith("Publisher DMCA");
+        card.DomainEvents.Should().ContainSingle(e => e is MechanicCardSuppressedEvent);
+    }
+
+    [Fact]
+    public void Suppress_WhenAlreadySuppressed_Throws()
+    {
+        var card = NewCard();
+        card.Suppress(Guid.NewGuid(), "Publisher DMCA takedown request received via legal.", Now);
+
+        var act = () => card.Suppress(Guid.NewGuid(), "Publisher DMCA takedown request received via legal.", Now);
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*already suppressed*");
+    }
+
+    [Theory]
+    [InlineData("short")] // < 20
+    public void Suppress_WithInvalidReasonLength_Throws(string reason)
+    {
+        var card = NewCard();
+
+        var act = () => card.Suppress(Guid.NewGuid(), reason, Now);
+
+        act.Should().Throw<ArgumentException>().WithMessage("*20..500*");
+    }
+
+    [Fact]
+    public void Unsuppress_ClearsSuppressionState()
+    {
+        var card = NewCard();
+        card.Suppress(Guid.NewGuid(), "Publisher DMCA takedown request received via legal.", Now);
+
+        card.Unsuppress(Guid.NewGuid(), Now);
+
+        card.IsSuppressed.Should().BeFalse();
+        card.SuppressedReason.Should().BeNull();
+        card.SuppressedAt.Should().BeNull();
+        card.SuppressedBy.Should().BeNull();
+    }
+
+    [Fact]
+    public void Unsuppress_WhenNotSuppressed_Throws()
+    {
+        var card = NewCard();
+
+        var act = () => card.Unsuppress(Guid.NewGuid(), Now);
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*not suppressed*");
+    }
+
+    [Fact]
+    public void MarkErrorReport_IncrementsCounter()
+    {
+        var card = NewCard();
+
+        card.MarkErrorReport(Now);
+        card.MarkErrorReport(Now);
+
+        card.ErrorReportsCount.Should().Be(2);
+    }
+
+    // ============================================================
+    // MechanicAnalysis.MarkPublished (publish-once invariant)
+    // ============================================================
+
+    [Fact]
+    public void MarkPublished_OnPublishedAnalysis_SetsPublishedCardId()
+    {
+        var analysis = PublishedAnalysis();
+        var cardId = Guid.NewGuid();
+
+        analysis.MarkPublished(cardId);
+
+        analysis.PublishedCardId.Should().Be(cardId);
+    }
+
+    [Fact]
+    public void MarkPublished_WhenAlreadyPublished_Throws()
+    {
+        var analysis = PublishedAnalysis();
+        analysis.MarkPublished(Guid.NewGuid());
+
+        var act = () => analysis.MarkPublished(Guid.NewGuid());
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*already published*");
+    }
+
+    [Fact]
+    public void MarkPublished_WithEmptyCardId_Throws()
+    {
+        var analysis = PublishedAnalysis();
+
+        var act = () => analysis.MarkPublished(Guid.Empty);
+
+        act.Should().Throw<ArgumentException>().WithMessage("*CardId*");
+    }
+
+    // ============================================================
+    // Helpers
+    // ============================================================
+
+    private static MechanicCardGameContext GameContext(string name, string? publisher = null, string language = "en") =>
+        new() { SharedGameId = Guid.NewGuid(), SharedGameName = name, Publisher = publisher, Language = language };
+
+    private static MechanicCard NewCard()
+    {
+        var analysis = PublishedAnalysis();
+        return MechanicCard.PublishFromAnalysis(
+            analysis, "Catan: Mechanics", GameContext("Catan"), Guid.NewGuid(), version: 1, Now);
+    }
+
+    private static MechanicAnalysis NewAnalysisWithClaim()
+    {
+        var analysis = MechanicAnalysis.Create(
+            sharedGameId: Guid.NewGuid(),
+            pdfDocumentId: Guid.NewGuid(),
+            promptVersion: "v1",
+            createdBy: Guid.NewGuid(),
+            createdAt: Now,
+            modelUsed: "deepseek-chat",
+            provider: "deepseek",
+            costCapUsd: 1m);
+
+        var claim = MechanicClaim.Create(
+            analysisId: analysis.Id,
+            section: MechanicSection.Mechanics,
+            text: "Draw phase",
+            displayOrder: 0,
+            citations: new[]
+            {
+                MechanicCitation.Create(analysis.Id, pdfPage: 1, quote: "Each turn draw one card.", chunkId: null, displayOrder: 0)
+            });
+
+        analysis.AddClaim(claim);
+        return analysis;
+    }
+
+    private static MechanicAnalysis PublishedAnalysis()
+    {
+        var analysis = NewAnalysisWithClaim();
+        var reviewer = Guid.NewGuid();
+        analysis.SubmitForReview(reviewer, Now);
+        analysis.ApproveClaim(analysis.Claims[0].Id, reviewer, Now);
+        analysis.Approve(reviewer, Now);
+        return analysis;
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/PublishMechanicCardEndpointIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/PublishMechanicCardEndpointIntegrationTests.cs
@@ -1,0 +1,255 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+using Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Services;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Infrastructure;
+
+/// <summary>
+/// Integration tests for <c>POST /admin/mechanic-analyses/{id}/publish</c> (#527, M1.5). Exercises
+/// the full stack against real PostgreSQL (which also validates that the idempotent
+/// <c>M1_5_MechanicCardsSchema</c> migration applies): happy path (card + audit + analysis FK persist
+/// atomically) and the two common conflicts (F1 not-Published, F2 already-published).
+/// </summary>
+/// <remarks>
+/// The two-analyses active-card race (F4) is structurally prevented for the AI-review path by the
+/// pre-existing analysis-level partial unique index (one Published, non-suppressed analysis per game),
+/// so it is not reachable via seeding; the card-level index remains as belt-and-braces defense.
+/// </remarks>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class PublishMechanicCardEndpointIntegrationTests : IAsyncLifetime
+{
+    private const string EndpointBase = "/api/v1/admin/mechanic-analyses";
+
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly string _testDbName;
+    private WebApplicationFactory<Program> _factory = null!;
+    private HttpClient _client = null!;
+    private string _adminSessionToken = null!;
+    private Mock<IBackgroundTaskService> _backgroundTaskMock = null!;
+
+    private static readonly Guid TestAdminId = Guid.NewGuid();
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new JsonStringEnumConverter() }
+    };
+
+    public PublishMechanicCardEndpointIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+        _testDbName = $"publish_mechanic_card_{Guid.NewGuid():N}";
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_testDbName);
+
+        _backgroundTaskMock = new Mock<IBackgroundTaskService>();
+        _backgroundTaskMock
+            .Setup(b => b.ExecuteWithCancellation(It.IsAny<string>(), It.IsAny<Func<CancellationToken, Task>>()));
+
+        _factory = IntegrationWebApplicationFactory
+            .Create(connectionString)
+            .WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureTestServices(services =>
+                {
+                    services.RemoveAll<IBackgroundTaskService>();
+                    services.AddSingleton<IBackgroundTaskService>(_backgroundTaskMock.Object);
+                });
+            });
+
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            await dbContext.Database.MigrateAsync();
+
+            var (_, token) = await TestSessionHelper.CreateAdminSessionAsync(dbContext, TestAdminId);
+            _adminSessionToken = token;
+        }
+
+        _client = _factory.CreateClient();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _client?.Dispose();
+        _factory?.Dispose();
+        await _fixture.DropIsolatedDatabaseAsync(_testDbName);
+    }
+
+    [Fact]
+    public async Task Publish_ApprovedAnalysis_Returns201AndPersistsCardAuditAndAnalysisFk()
+    {
+        var gameId = await SeedSharedGameAsync();
+        var analysisId = await SeedAnalysisAsync(gameId, status: 2, claimStatuses: new[] { 1 }); // Published + Approved claim
+
+        var response = await SendPublishAsync(analysisId, new { title = "Catan: Game Mechanics" });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        var dto = await response.Content.ReadFromJsonAsync<PublishMechanicCardResponseDto>(JsonOptions);
+        dto.Should().NotBeNull();
+        dto!.SharedGameId.Should().Be(gameId);
+        dto.OriginAnalysisId.Should().Be(analysisId);
+        dto.Version.Should().Be(1);
+        dto.Title.Should().Be("Catan: Game Mechanics");
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        var card = await db.MechanicCards.AsNoTracking().SingleAsync(c => c.Id == dto.CardId);
+        card.SharedGameId.Should().Be(gameId);
+        card.Origin.Should().Be("ai_reviewed");
+        card.Version.Should().Be(1);
+        card.IsSuppressed.Should().BeFalse();
+
+        // PostgreSQL reformats jsonb on storage, so parse rather than string-match.
+        using (var contentDoc = JsonDocument.Parse(card.Content))
+        {
+            var contentRoot = contentDoc.RootElement;
+            contentRoot.GetProperty("schema_version").GetInt32().Should().Be(1);
+            contentRoot.GetProperty("source_analysis_id").GetGuid().Should().Be(analysisId);
+            contentRoot.GetProperty("claims").GetArrayLength().Should().Be(1);
+        }
+
+        var audit = await db.MechanicCardAuditLog.AsNoTracking().Where(a => a.CardId == dto.CardId).ToListAsync();
+        audit.Should().ContainSingle(a => a.Action == "published" && a.ActorId == TestAdminId);
+
+        var analysis = await db.MechanicAnalyses.AsNoTracking().IgnoreQueryFilters().SingleAsync(a => a.Id == analysisId);
+        analysis.PublishedCardId.Should().Be(dto.CardId);
+    }
+
+    [Fact]
+    public async Task Publish_InReviewAnalysis_Returns409()
+    {
+        var gameId = await SeedSharedGameAsync();
+        var analysisId = await SeedAnalysisAsync(gameId, status: 1, claimStatuses: new[] { 1 }); // InReview
+
+        var response = await SendPublishAsync(analysisId, new { });
+
+        response.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    [Fact]
+    public async Task Publish_AlreadyPublishedAnalysis_Returns409()
+    {
+        var gameId = await SeedSharedGameAsync();
+        var analysisId = await SeedAnalysisAsync(gameId, status: 2, claimStatuses: new[] { 1 });
+
+        var first = await SendPublishAsync(analysisId, new { });
+        first.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        var second = await SendPublishAsync(analysisId, new { });
+        second.StatusCode.Should().Be(HttpStatusCode.Conflict);
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private async Task<HttpResponseMessage> SendPublishAsync(Guid analysisId, object body)
+    {
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Post,
+            $"{EndpointBase}/{analysisId}/publish",
+            _adminSessionToken,
+            body);
+        return await _client.SendAsync(request);
+    }
+
+    private async Task<Guid> SeedSharedGameAsync()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        var gameId = Guid.NewGuid();
+        dbContext.Set<SharedGameEntity>().Add(new SharedGameEntity
+        {
+            Id = gameId,
+            Title = $"Publish Test Game {Guid.NewGuid():N}",
+            Description = "Integration test rulebook",
+            MinPlayers = 2,
+            MaxPlayers = 4,
+            PlayingTimeMinutes = 90,
+            YearPublished = 2024,
+            MinAge = 12,
+            CreatedAt = DateTime.UtcNow,
+            CreatedBy = TestAdminId
+        });
+        await dbContext.SaveChangesAsync();
+        return gameId;
+    }
+
+    private async Task<Guid> SeedAnalysisAsync(Guid sharedGameId, int status, int[] claimStatuses)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        var analysisId = Guid.NewGuid();
+        var now = DateTime.UtcNow;
+
+        dbContext.Set<MechanicAnalysisEntity>().Add(new MechanicAnalysisEntity
+        {
+            Id = analysisId,
+            SharedGameId = sharedGameId,
+            PdfDocumentId = Guid.NewGuid(),
+            PromptVersion = "mechanic-extractor-v1",
+            Status = status,
+            CreatedBy = TestAdminId,
+            CreatedAt = now,
+            ReviewedBy = status is 1 or 2 ? TestAdminId : null,
+            ReviewedAt = status is 1 or 2 ? now : null,
+            TotalTokensUsed = 1234,
+            EstimatedCostUsd = 0.05m,
+            ModelUsed = "test-model",
+            Provider = "test-provider",
+            CostCapUsd = 1.00m
+        });
+
+        for (var i = 0; i < claimStatuses.Length; i++)
+        {
+            var claimId = Guid.NewGuid();
+            dbContext.Set<MechanicClaimEntity>().Add(new MechanicClaimEntity
+            {
+                Id = claimId,
+                AnalysisId = analysisId,
+                Section = i % 6,
+                Text = $"Claim {i}: synthetic mechanic description.",
+                DisplayOrder = i,
+                Status = claimStatuses[i],
+                ReviewedBy = claimStatuses[i] == 0 ? null : TestAdminId,
+                ReviewedAt = claimStatuses[i] == 0 ? null : now
+            });
+            dbContext.Set<MechanicCitationEntity>().Add(new MechanicCitationEntity
+            {
+                Id = Guid.NewGuid(),
+                ClaimId = claimId,
+                PdfPage = 1,
+                Quote = "Each turn draw one card.",
+                DisplayOrder = 0
+            });
+        }
+
+        await dbContext.SaveChangesAsync();
+        return analysisId;
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/MechanicAnalysisRepositoryIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/MechanicAnalysisRepositoryIntegrationTests.cs
@@ -437,6 +437,40 @@ public sealed class MechanicAnalysisRepositoryIntegrationTests : IAsyncLifetime
     }
 
     // ============================================================
+    // #526 AC-6: optional approve note round-trips to review_note
+    // ============================================================
+
+    [Fact]
+    public async Task ApprovedClaimWithNote_PersistsReviewNote_AcrossReload()
+    {
+        // Guards BLOCKER-2: MapClaimToEntity must copy ReviewNote. The Moq handler test and the
+        // API response both read the in-memory domain aggregate, so they pass even if the DB write
+        // drops the note. Only this Postgres round-trip catches it — Update() forces
+        // EntityState.Modified, so review_note is UPDATEd to NULL unless the write mapper is patched.
+        var sharedGameId = await SeedSharedGameAsync();
+        var analysis = BuildDraftAnalysisWithClaim(sharedGameId);
+        await _repository.AddAsync(analysis);
+        await _dbContext.SaveChangesAsync();
+        _dbContext.ChangeTracker.Clear();
+
+        var reloaded = await _repository.GetByIdWithClaimsAsync(analysis.Id);
+        reloaded.Should().NotBeNull();
+
+        var reviewer = Guid.NewGuid();
+        var now = DateTime.UtcNow;
+        reloaded!.SubmitForReview(reviewer, now);
+        var claimId = reloaded.Claims.Single().Id;
+        reloaded.ApproveClaim(claimId, reviewer, now, "verified against p.4");
+
+        _repository.Update(reloaded);
+        await _dbContext.SaveChangesAsync();
+        _dbContext.ChangeTracker.Clear();
+
+        var verify = await _repository.GetByIdWithClaimsAsync(analysis.Id);
+        verify!.Claims.Single(c => c.Id == claimId).ReviewNote.Should().Be("verified against p.4");
+    }
+
+    // ============================================================
     // Helpers
     // ============================================================
 

--- a/apps/embedding-service/Dockerfile
+++ b/apps/embedding-service/Dockerfile
@@ -20,6 +20,15 @@ COPY requirements.txt .
 # PyPI/pythonhosted occasionally times out on large packages (torch ~700MB).
 # Extend pip's 15s socket timeout and add resumable retries.
 ENV PIP_DEFAULT_TIMEOUT=300
+# Install CPU-only torch FIRST from the official PyTorch CPU index (#2794).
+# On aarch64 the default `pip install torch` bundles ~2.9GB of unused NVIDIA
+# CUDA libraries (nvidia_cublas/cudnn/nccl/...); this server is GPU-less and the
+# service runs DEVICE=cpu, so they are dead weight. Pre-installing the CPU wheel
+# leaves torch already satisfied, so the requirements install below never pulls
+# the CUDA variant (and requirements.txt stays unchanged for CI test jobs).
+# torch IS pinned below; hadolint misreads the --index-url value as an unpinned positional package (DL3013 false positive)
+# hadolint ignore=DL3013
+RUN pip install --no-cache-dir --retries 5 torch==2.12.1 --index-url https://download.pytorch.org/whl/cpu
 RUN pip install --no-cache-dir --retries 5 -r requirements.txt
 
 # Pre-download the model so runtime container starts fast

--- a/apps/reranker-service/Dockerfile
+++ b/apps/reranker-service/Dockerfile
@@ -10,14 +10,30 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Python dependencies
+# Install Python dependencies into a virtual env for a clean copy into the
+# runtime stage (#2794). The previous `pip wheel` + copy-to-/wheels approach
+# left ~409MB of wheel files behind in the final image (they were installed but
+# never removed). The venv-copy pattern (mirrors embedding-service) carries only
+# the installed packages, no wheel artifacts.
+RUN python -m venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+ENV PIP_DEFAULT_TIMEOUT=300
+
 COPY requirements.txt .
-RUN pip wheel --no-cache-dir --no-deps --wheel-dir /app/wheels -r requirements.txt
+# Install CPU-only torch FIRST from the official PyTorch CPU index (#2794).
+# On aarch64 the default `pip install torch` bundles ~2.9GB of unused NVIDIA
+# CUDA libraries (nvidia_cublas/cudnn/nccl/...); this server is GPU-less and the
+# service runs DEVICE=cpu, so they are dead weight. Pre-installing the CPU wheel
+# leaves torch already satisfied, so the requirements install below never pulls
+# the CUDA variant (and requirements.txt stays unchanged for CI test jobs).
+# torch IS pinned below; hadolint misreads the --index-url value as an unpinned positional package (DL3013 false positive)
+# hadolint ignore=DL3013
+RUN pip install --no-cache-dir --retries 5 torch==2.12.1 --index-url https://download.pytorch.org/whl/cpu
+RUN pip install --no-cache-dir --retries 5 -r requirements.txt
 
 # Pre-download ML model in builder to avoid cold-start delay
 ENV HF_HOME=/model-cache
-RUN pip install --no-cache-dir /app/wheels/* \
-    && python -c "from sentence_transformers import CrossEncoder; CrossEncoder('BAAI/bge-reranker-v2-m3')"
+RUN python -c "from sentence_transformers import CrossEncoder; CrossEncoder('BAAI/bge-reranker-v2-m3')"
 
 # Production stage
 FROM python:3.11-slim
@@ -32,12 +48,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy wheels from builder stage
-COPY --from=builder /app/wheels /wheels
-COPY --from=builder /app/requirements.txt .
-
-# Install dependencies from wheels (faster, no compilation)
-RUN pip install --no-cache-dir /wheels/*
+# Copy the virtual env with all installed packages (no build tools, no wheels)
+COPY --from=builder /opt/venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
 
 # Copy pre-downloaded model from builder
 COPY --from=builder --chown=reranker:reranker /model-cache /home/reranker/.cache/huggingface

--- a/apps/web/e2e/admin-mechanic-extractor-validation/load-existing-analysis.spec.ts
+++ b/apps/web/e2e/admin-mechanic-extractor-validation/load-existing-analysis.spec.ts
@@ -47,21 +47,31 @@ const CLAIM_TEXT =
   'Players score 1 point per completed road tile when the road is finished during the scoring phase.';
 
 const STATUS_PUBLISHED = 2; // MechanicAnalysisStatus.Published
+const STATUS_IN_REVIEW = 1; // MechanicAnalysisStatus.InReview
 const SECTION_MECHANICS = 1; // MECHANIC_SECTION_LABELS[1] = 'Mechanics'
 const RUN_STATUS_SUCCEEDED = 0;
 const CLAIM_STATUS_PENDING = 0; // MechanicClaimStatus.Pending
 
+const CLAIM_ID_SHORT_QUOTE = 'ffffffff-ffff-4fff-8fff-ffffffffffff';
+
 /**
  * In-memory state holder so we can mutate the analysis between tests if
  * needed. The status mock returns whatever's currently in `state.current`.
+ *
+ * `status` is parameterized (default `Published`) because the bulk-action
+ * `<Select>` in `ClaimsSection` only renders when
+ * `isClaimsActionable = status === InReview && !isSuppressed` — see
+ * `analyses/page.tsx:716-719`. The three original load-existing-analysis
+ * flows don't care about bulk actions and keep the `Published` default; the
+ * bulk-reject test below overrides it to `InReview`.
  */
-function buildStatusDto() {
+function buildStatusDto(status: number = STATUS_PUBLISHED) {
   return {
     id: ANALYSIS_ID,
     sharedGameId: SHARED_GAME_ID,
     pdfDocumentId: PDF_DOCUMENT_ID,
     promptVersion: 'v1.0.0',
-    status: STATUS_PUBLISHED,
+    status,
     rejectionReason: null,
     createdBy: ADMIN_USER_ID,
     createdAt: '2026-04-25T10:00:00Z',
@@ -80,7 +90,7 @@ function buildStatusDto() {
     suppressedAt: null,
     suppressedBy: null,
     suppressionReason: null,
-    claimsCount: 1,
+    claimsCount: 2,
     sectionRuns: [
       {
         section: SECTION_MECHANICS,
@@ -111,7 +121,7 @@ function buildListResponse() {
         pdfDocumentId: PDF_DOCUMENT_ID,
         promptVersion: 'v1.0.0',
         status: STATUS_PUBLISHED,
-        claimsCount: 1,
+        claimsCount: 2,
         totalTokensUsed: 4200,
         estimatedCostUsd: 0.42,
         certificationStatus: 1,
@@ -125,6 +135,18 @@ function buildListResponse() {
   };
 }
 
+/**
+ * Two claims: `CLAIM_ID` carries a citation quote >20 words (drives the
+ * "Reject all with quote >20 words" bulk action / `claimsWithLongQuote` in
+ * `ClaimsSection.tsx:59-61`), the second carries a short-quote citation so
+ * the bulk-reject computed-ids assertion is meaningful (only 1 of 2 claims
+ * targeted). Every claim MUST set `reviewNote` + `validations` — Task 5 made
+ * both fields non-optional on `MechanicClaimDtoSchema`
+ * (`mechanic-analyses.schemas.ts:255-256`); omitting them makes
+ * `HttpClient.validateResponse` throw `SchemaValidationError`, which flips
+ * `ClaimsSection` into its `claims-load-error` branch and breaks every test
+ * in this file (not just the new ones).
+ */
 function buildClaimsResponse() {
   return [
     {
@@ -137,11 +159,48 @@ function buildClaimsResponse() {
       reviewedBy: null,
       reviewedAt: null,
       rejectionNote: null,
+      reviewNote: null,
+      validations: [
+        { rule: 'T1', outcome: 'pass', message: null },
+        { rule: 'T2', outcome: 'pass', message: null },
+        { rule: 'T3', outcome: 'pass', message: null },
+        { rule: 'T4', outcome: 'pass', message: null },
+      ],
       citations: [
         {
           id: 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee',
+          // >20 words — qualifies for the "reject-long-quote" bulk action.
           pdfPage: 4,
-          quote: 'A completed road scores 1 point per tile during the scoring phase.',
+          quote:
+            'A completed road scores 1 point per tile during the scoring phase, ' +
+            'and every player who contributed a tile to that road shares in the points equally.',
+          displayOrder: 0,
+        },
+      ],
+    },
+    {
+      id: CLAIM_ID_SHORT_QUOTE,
+      analysisId: ANALYSIS_ID,
+      section: SECTION_MECHANICS,
+      text: 'Cities score 2 points per tile when completed.',
+      displayOrder: 1,
+      status: CLAIM_STATUS_PENDING,
+      reviewedBy: null,
+      reviewedAt: null,
+      rejectionNote: null,
+      reviewNote: null,
+      validations: [
+        { rule: 'T1', outcome: 'pass', message: null },
+        { rule: 'T2', outcome: 'pass', message: null },
+        { rule: 'T3', outcome: 'pass', message: null },
+        { rule: 'T4', outcome: 'pass', message: null },
+      ],
+      citations: [
+        {
+          id: 'aaaaaaaa-1111-4aaa-8aaa-111111111111',
+          pdfPage: 6,
+          // Short quote — does NOT qualify for the "reject-long-quote" bulk action.
+          quote: 'A completed city scores 2 points per tile.',
           displayOrder: 0,
         },
       ],
@@ -185,13 +244,19 @@ function buildAuthMeDto() {
  * Absolute-URL mocks (against `API_BASE`) silently miss those requests, which
  * is why earlier iterations of this spec hung on the "Verifica autorizzazioni…"
  * spinner: `RequireRole` polled `/api/v1/auth/me` and never got a response.
+ *
+ * `statusOverride` lets bulk-action tests flip the analysis into `InReview`
+ * (see {@link buildStatusDto}) so `ClaimsSection`'s `isClaimsActionable` gate
+ * renders the `bulk-action-select`; the three pre-existing hydration tests
+ * don't pass it and keep the `Published` default.
  */
-async function mockAnalysisRoutes(page: Page) {
+async function mockAnalysisRoutes(page: Page, statusOverride?: number) {
   const calls = {
     authMe: 0,
     list: 0,
     status: 0,
     claims: 0,
+    bulkReject: 0,
   };
 
   // Auth — RequireRole in the admin (dashboard) layout calls this on mount.
@@ -262,7 +327,7 @@ async function mockAnalysisRoutes(page: Page) {
           await route.fulfill({
             status: 200,
             contentType: 'application/json',
-            body: JSON.stringify(buildStatusDto()),
+            body: JSON.stringify(buildStatusDto(statusOverride)),
           });
           return;
         }
@@ -282,6 +347,31 @@ async function mockAnalysisRoutes(page: Page) {
             status: 200,
             contentType: 'application/json',
             body: JSON.stringify(buildClaimsResponse()),
+          });
+          return;
+        }
+        await route.continue();
+      }
+    );
+
+  // Bulk-reject endpoint (#526 ME-M1.4 AC-3/AC-9) — POST only; falls through
+  // to `route.continue()` for any other method so unrelated requests aren't
+  // swallowed.
+  await page
+    .context()
+    .route(
+      new RegExp(`/api/v1/admin/mechanic-analyses/${ANALYSIS_ID}/claims/bulk-reject$`),
+      async (route: Route) => {
+        if (route.request().method() === 'POST') {
+          calls.bulkReject += 1;
+          await route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({
+              rejectedCount: 1,
+              skippedAlreadyRejectedCount: 0,
+              claims: buildClaimsResponse(),
+            }),
           });
           return;
         }
@@ -412,5 +502,45 @@ test.describe('Admin · Mechanic Extractor · Load existing analysis', () => {
 
     await expect.poll(() => calls.status, { timeout: 5000 }).toBeGreaterThanOrEqual(1);
     await expect.poll(() => calls.claims, { timeout: 5000 }).toBeGreaterThanOrEqual(1);
+  });
+
+  // #526 ME-M1.4 AC-9 — bulk-reject + citation-open flows.
+  test('bulk-reject by quote length calls the endpoint with computed ids', async ({ page }) => {
+    await setAdminSessionCookies(page);
+    // Analysis must be InReview for `isClaimsActionable` to render the bulk
+    // <Select> (see `analyses/page.tsx:716-719` / `buildStatusDto` doc above).
+    const calls = await mockAnalysisRoutes(page, STATUS_IN_REVIEW);
+    await page.goto(`${ANALYSES_PATH}?analysisId=${ANALYSIS_ID}`);
+
+    await expect(page.getByTestId('claims-section')).toBeVisible();
+
+    // `bulk-action-select` is a Radix `<Select>` (SelectPrimitive.Root), NOT a
+    // native <select> — `.selectOption()` does not drive it. Open the
+    // listbox by clicking the trigger, then click the target option by its
+    // accessible role/name (rendered text includes the computed count, e.g.
+    // "Reject all with quote >20 words (1)" — match on the stable prefix).
+    await page.getByTestId('bulk-action-select').click();
+    await page.getByRole('option', { name: /Reject all with quote >20 words/ }).click();
+
+    await expect(page.getByTestId('bulk-action-count')).toContainText('1');
+    await page.getByTestId('bulk-action-confirm').click();
+
+    await expect.poll(() => calls.bulkReject, { timeout: 5000 }).toBeGreaterThanOrEqual(1);
+  });
+
+  test('clicking a citation opens the quote highlighter', async ({ page }) => {
+    await setAdminSessionCookies(page);
+    await mockAnalysisRoutes(page);
+    await page.goto(`${ANALYSES_PATH}?analysisId=${ANALYSIS_ID}`);
+
+    await expect(page.getByTestId('claims-section')).toBeVisible();
+
+    await page.getByTestId(`claim-citations-toggle-${CLAIM_ID}`).click();
+    await page
+      .getByTestId(/^claim-citation-open-/)
+      .first()
+      .click();
+
+    await expect(page.getByRole('dialog')).toBeVisible();
   });
 });

--- a/apps/web/e2e/smoke.spec.ts
+++ b/apps/web/e2e/smoke.spec.ts
@@ -40,16 +40,18 @@ test.describe('Smoke Test — 8 step pre-deploy', () => {
 
   test('2. Auth login form visibile', async ({ page }) => {
     await page.goto('/login', { waitUntil: 'domcontentloaded' });
-    // Il login form è client-only: nell'SSR /login rende il fallback <Suspense>
-    // (useSearchParams), quindi l'input email esiste SOLO dopo l'hydration del
-    // bundle client. Sul runner self-hosted (chromium headless, VPS con cap
-    // memoria 3G) l'hydration supera consistentemente gli 8s → falso negativo
-    // (il form è renderizzato e funzionante, verificato in un browser reale).
-    // Timeout ampio (30s) per assorbire l'hydration lenta senza rallentare il
-    // caso normale (l'expect passa appena l'elemento appare). NON mockare
-    // /auth/me qui: simulerebbe un utente loggato → redirect via da /login.
+    // #2770: il login form è ora SERVER-RENDERED. Prima l'intero body dell'app
+    // faceva BailoutToCSR — StatePreviewProvider era montato via
+    // `next/dynamic({ ssr: false })` in providers.tsx e avvolgeva ogni route,
+    // così l'input email compariva SOLO dopo l'hydration del bundle client
+    // (>30s sul runner headless con cap memoria 3G → falso negativo). Ora
+    // l'email input è nell'HTML iniziale (verificato via curl dell'SSR), quindi
+    // è presente già a `domcontentloaded`. Timeout ridotto a 15s: ampio per
+    // assorbire latenza VPS/rete sul singolo documento, ma abbastanza stretto
+    // da FALLIRE (invece di mascherare via hydration) se l'SSR regredisse.
+    // NON mockare /auth/me qui: simulerebbe un utente loggato → redirect da /login.
     await expect(page.locator('input[type="email"], input[name="email"]').first()).toBeVisible({
-      timeout: 30000,
+      timeout: 15000,
     });
   });
 

--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -766,7 +766,7 @@ export default [
                 "@/components/ui/state-preview/state-preview-provider",
               ],
               message:
-                "Use '@/components/ui/state-preview' barrel (which uses dynamic({ssr:false}) for tree-shake guarantee). Direct import of state-preview-provider bypasses dev-only isolation.",
+                "Use '@/components/ui/state-preview' barrel (NODE_ENV-gated loader: production gets a zero-cost pass-through that keeps SSR working, dev gets a dynamic import WITHOUT ssr:false — see #2770). Direct import of state-preview-provider bypasses that isolation and the tree-shake guarantee.",
             },
             {
               group: [

--- a/apps/web/src/__tests__/app/admin/knowledge-base/mechanic-extractor/review.test.tsx
+++ b/apps/web/src/__tests__/app/admin/knowledge-base/mechanic-extractor/review.test.tsx
@@ -62,7 +62,7 @@ describe('MechanicExtractorReviewPage', () => {
     expect(screen.getByText('2')).toBeInTheDocument(); // 2 mechanics
   });
 
-  it('renders copyright footer with Variant C text', async () => {
+  it('renders ADR-051 attribution footer and NOT the retired Variant-C copy', async () => {
     mockGetMechanicDraft.mockResolvedValue({
       gameTitle: 'Catan',
       summaryDraft: 'Trade and build',
@@ -80,9 +80,9 @@ describe('MechanicExtractorReviewPage', () => {
 
     render(<MechanicExtractorReviewPage />, { wrapper: Wrapper });
 
-    expect(await screen.findByText(/Variant C/)).toBeInTheDocument();
+    expect(await screen.findByText(/riformulata in parole originali/i)).toBeInTheDocument();
     expect(
-      screen.getByText(/L'AI non ha mai letto il testo del PDF originale/i)
-    ).toBeInTheDocument();
+      screen.queryByText(/non ha mai letto il testo del PDF originale/i)
+    ).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/app/(auth)/register/__tests__/_content.test.tsx
+++ b/apps/web/src/app/(auth)/register/__tests__/_content.test.tsx
@@ -25,11 +25,9 @@ vi.mock('@/hooks/useTranslation', () => ({
 
 const pushMock = vi.fn().mockResolvedValue(undefined);
 const refreshMock = vi.fn();
-const searchParamsMock = { get: vi.fn<(key: string) => string | null>() };
 
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: pushMock, refresh: refreshMock }),
-  useSearchParams: () => searchParamsMock,
 }));
 
 const { mockAuth } = vi.hoisted(() => ({
@@ -67,18 +65,12 @@ vi.mock('@/lib/analytics/flywheel-events', () => ({
 }));
 
 // Import AFTER mocks
-import { RegisterPageContent, RegisterFallback } from '../_content';
+import { RegisterPageContent } from '../_content';
 import { logger } from '@/lib/logger';
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-function setSearchParams(params: Record<string, string | null>) {
-  searchParamsMock.get.mockImplementation((key: string) =>
-    Object.prototype.hasOwnProperty.call(params, key) ? (params[key] ?? null) : null
-  );
-}
 
 function resolveMode(mode: { publicRegistrationEnabled: boolean; oauthEnabled?: boolean }) {
   getRegistrationModeMock.mockResolvedValue(mode);
@@ -86,13 +78,13 @@ function resolveMode(mode: { publicRegistrationEnabled: boolean; oauthEnabled?: 
 
 beforeEach(() => {
   vi.clearAllMocks();
-  setSearchParams({});
   // default: public registration with OAuth enabled
   resolveMode({ publicRegistrationEnabled: true, oauthEnabled: true });
 });
 
-async function renderAndWait(mode?: 'public' | 'invite-only') {
-  const result = render(<RegisterPageContent />);
+async function renderAndWait(mode?: 'public' | 'invite-only', props?: { oauthDisabled?: boolean }) {
+  // #2773: oauth_disabled now flows as a prop from the async page.tsx.
+  const result = render(<RegisterPageContent oauthDisabled={props?.oauthDisabled} />);
   // Wait for async mode fetch to settle (loading indicator disappears)
   if (mode === 'public') {
     await screen.findByTestId('register-form');
@@ -130,16 +122,15 @@ describe('RegisterPageContent (v2 AuthCard)', () => {
       expect(screen.getByText('auth.register.inviteOnlySubtitle')).toBeInTheDocument();
     });
 
-    it('shows inviteOauthDisabled alert when ?oauth_disabled=true', async () => {
-      setSearchParams({ oauth_disabled: 'true' });
-      await renderAndWait('invite-only');
+    it('shows inviteOauthDisabled alert when oauthDisabled prop is true', async () => {
+      await renderAndWait('invite-only', { oauthDisabled: true });
       const alerts = screen.getAllByRole('alert');
       expect(alerts.some(a => a.textContent?.includes('auth.register.inviteOauthDisabled'))).toBe(
         true
       );
     });
 
-    it('does not show inviteOauthDisabled alert when oauth_disabled is absent', async () => {
+    it('does not show inviteOauthDisabled alert when oauthDisabled prop is absent', async () => {
       await renderAndWait('invite-only');
       const alerts = screen.queryAllByRole('alert');
       expect(alerts.some(a => a.textContent?.includes('auth.register.inviteOauthDisabled'))).toBe(
@@ -272,12 +263,5 @@ describe('RegisterPageContent (v2 AuthCard)', () => {
         });
       }
     });
-  });
-});
-
-describe('RegisterFallback', () => {
-  it('renders loading message', () => {
-    render(<RegisterFallback />);
-    expect(screen.getByText('auth.register.loadingMessage')).toBeInTheDocument();
   });
 });

--- a/apps/web/src/app/(auth)/register/_content.tsx
+++ b/apps/web/src/app/(auth)/register/_content.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useEffect, useState } from 'react';
 
 import Link from 'next/link';
-import { useRouter, useSearchParams } from 'next/navigation';
+import { useRouter } from 'next/navigation';
 
 import { buildOAuthUrl } from '@/components/auth/oauth-url';
 import { RegisterForm, type RegisterSubmitPayload } from '@/components/auth/RegisterForm';
@@ -23,25 +23,23 @@ import { useApiClient } from '@/lib/api/context';
 type RegistrationMode = 'loading' | 'public' | 'invite-only';
 
 // ============================================================================
-// Fallback (Suspense boundary)
-// ============================================================================
-
-export function RegisterFallback() {
-  const { t } = useTranslation();
-  return (
-    <main className="min-h-dvh flex items-center justify-center bg-muted text-muted-foreground">
-      {t('auth.register.loadingMessage')}
-    </main>
-  );
-}
-
-// ============================================================================
 // Main content
 // ============================================================================
 
-export function RegisterPageContent() {
+/**
+ * #2773 — `oauthDisabled` arrives as a PROP from the async Server Component
+ * page.tsx (which reads searchParams). Reading it as a prop instead of via the
+ * `useSearchParams` client hook lets this component render server-side (SSR) —
+ * the form is in the initial HTML instead of behind a CSR bailout. Same pattern
+ * as `login/_content.tsx` (#2650).
+ */
+export interface RegisterPageContentProps {
+  /** `?oauth_disabled=true` marker (OAuth suppressed for invite-only). */
+  oauthDisabled?: boolean;
+}
+
+export function RegisterPageContent({ oauthDisabled = false }: RegisterPageContentProps) {
   const router = useRouter();
-  const searchParams = useSearchParams();
   const { t } = useTranslation();
   const { register } = useAuth();
   const api = useApiClient();
@@ -51,7 +49,6 @@ export function RegisterPageContent() {
   const [isAuthenticating, setIsAuthenticating] = useState(false);
   const [error, setError] = useState<string>('');
 
-  const oauthDisabled = searchParams?.get('oauth_disabled') === 'true';
   // Audit (#2168): register does NOT read ?from=. Post-registration redirect is
   // hardcoded to /verification-pending (line below in handleRegister). If a
   // ?from= param is ever introduced here, use assertSafeRelativeOrFallback from

--- a/apps/web/src/app/(auth)/register/page.tsx
+++ b/apps/web/src/app/(auth)/register/page.tsx
@@ -12,16 +12,22 @@
  *
  * Standalone registration page with AuthModal.
  * Uses AuthLayout wrapper for consistent auth page UX (Issue #2231).
+ *
+ * #2773: this Server Component reads searchParams (async in Next 16) and passes
+ * `oauth_disabled` down as a prop, so the client RegisterPageContent renders
+ * WITHOUT `useSearchParams` — the form is server-rendered (no CSR bailout, no
+ * <Suspense> fallback). Same props pattern as `login/page.tsx` (#2650 / #2771).
  */
 
-import { Suspense } from 'react';
+import { RegisterPageContent } from './_content';
 
-import { RegisterFallback, RegisterPageContent } from './_content';
+export default async function RegisterPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+}) {
+  const params = await searchParams;
+  const oauthDisabled = params.oauth_disabled === 'true';
 
-export default function RegisterPage() {
-  return (
-    <Suspense fallback={<RegisterFallback />}>
-      <RegisterPageContent />
-    </Suspense>
-  );
+  return <RegisterPageContent oauthDisabled={oauthDisabled} />;
 }

--- a/apps/web/src/app/(auth)/reset-password/__tests__/_content.test.tsx
+++ b/apps/web/src/app/(auth)/reset-password/__tests__/_content.test.tsx
@@ -18,7 +18,6 @@ const {
   mockRequestPasswordReset,
   mockConfirmPasswordReset,
   mockLogin,
-  mockSearchParamsGet,
   MockApiError,
 } = vi.hoisted(() => {
   // Minimal stand-in for the real ApiError class. The shared getErrorMessage
@@ -41,14 +40,12 @@ const {
     mockRequestPasswordReset: vi.fn(),
     mockConfirmPasswordReset: vi.fn(),
     mockLogin: vi.fn(),
-    mockSearchParamsGet: vi.fn<(key: string) => string | null>(),
     MockApiError,
   };
 });
 
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: mockPush }),
-  useSearchParams: () => ({ get: mockSearchParamsGet }),
 }));
 
 vi.mock('@/hooks/useTranslation', () => ({
@@ -80,9 +77,7 @@ beforeEach(() => {
   mockRequestPasswordReset.mockReset();
   mockConfirmPasswordReset.mockReset();
   mockLogin.mockReset();
-  mockSearchParamsGet.mockReset();
 
-  mockSearchParamsGet.mockReturnValue(null);
   // default: not authenticated (so the auth guard clears isCheckingAuth)
   mockGetMe.mockRejectedValue(new Error('401'));
 });
@@ -179,10 +174,8 @@ describe('ResetPasswordPageContent — request mode', () => {
 // ---------------------------------------------------------------------------
 
 describe('ResetPasswordPageContent — reset mode', () => {
-  beforeEach(() => {
-    mockSearchParamsGet.mockImplementation((key: string) => (key === 'token' ? 'tok-123' : null));
-  });
-
+  // #2773: reset mode is now driven by the `token` prop (from the async page.tsx),
+  // not by a mocked useSearchParams.
   it('shows the verifying state while the token is being checked', async () => {
     // Use mockImplementation (not mockResolvedValueOnce): the verify-token
     // effect re-fires on every render because the mocked useTranslation
@@ -190,7 +183,7 @@ describe('ResetPasswordPageContent — reset mode', () => {
     // A single-shot mock would be exhausted after the first render.
     mockVerifyResetToken.mockImplementation(() => new Promise(() => {}));
 
-    render(<ResetPasswordPageContent />);
+    render(<ResetPasswordPageContent token="tok-123" />);
 
     expect(
       await screen.findByRole('heading', { name: 'auth.resetPassword.verifyingTitle' })
@@ -200,7 +193,7 @@ describe('ResetPasswordPageContent — reset mode', () => {
   it('shows the invalid-link card when token verification fails', async () => {
     mockVerifyResetToken.mockRejectedValue(new Error('bad token'));
 
-    render(<ResetPasswordPageContent />);
+    render(<ResetPasswordPageContent token="tok-123" />);
 
     expect(
       await screen.findByRole('heading', { name: 'auth.resetPassword.invalidLinkTitle' })
@@ -213,7 +206,7 @@ describe('ResetPasswordPageContent — reset mode', () => {
   it('renders the new password form when token is valid', async () => {
     mockVerifyResetToken.mockResolvedValue(undefined);
 
-    render(<ResetPasswordPageContent />);
+    render(<ResetPasswordPageContent token="tok-123" />);
 
     expect(
       await screen.findByRole('heading', { name: 'auth.resetPassword.confirmTitle' })
@@ -227,7 +220,7 @@ describe('ResetPasswordPageContent — reset mode', () => {
     mockConfirmPasswordReset.mockResolvedValue({ message: 'ok' });
     mockLogin.mockRejectedValue(new Error('no auto-login'));
 
-    render(<ResetPasswordPageContent />);
+    render(<ResetPasswordPageContent token="tok-123" />);
 
     const pwd = await screen.findByLabelText('auth.resetPassword.passwordLabel');
     const confirm = screen.getByLabelText('auth.resetPassword.confirmPasswordLabel');
@@ -264,7 +257,7 @@ describe('ResetPasswordPageContent — reset mode', () => {
     mockVerifyResetToken.mockResolvedValue(undefined);
     mockConfirmPasswordReset.mockRejectedValue(new Error('Token expired'));
 
-    render(<ResetPasswordPageContent />);
+    render(<ResetPasswordPageContent token="tok-123" />);
 
     const pwd = await screen.findByLabelText('auth.resetPassword.passwordLabel');
     const confirm = screen.getByLabelText('auth.resetPassword.confirmPasswordLabel');

--- a/apps/web/src/app/(auth)/reset-password/_content.tsx
+++ b/apps/web/src/app/(auth)/reset-password/_content.tsx
@@ -15,7 +15,7 @@
 import { useEffect, useState, type FormEvent, type JSX } from 'react';
 
 import Link from 'next/link';
-import { useRouter, useSearchParams } from 'next/navigation';
+import { useRouter } from 'next/navigation';
 
 import { AuthCard } from '@/components/ui/auth-card';
 import { Btn } from '@/components/ui/btn';
@@ -60,30 +60,26 @@ function validatePassword(password: string): PasswordValidation {
 }
 
 // ---------------------------------------------------------------------------
-// Suspense fallback
-// ---------------------------------------------------------------------------
-
-export function ResetPasswordFallback(): JSX.Element {
-  const { t } = useTranslation();
-  return (
-    <main className="min-h-dvh flex items-center justify-center bg-muted text-muted-foreground">
-      <div className="animate-pulse" data-testid="reset-password-loading">
-        {t('auth.resetPassword.loadingTitle')}
-      </div>
-    </main>
-  );
-}
-
-// ---------------------------------------------------------------------------
 // Main content
 // ---------------------------------------------------------------------------
 
-export function ResetPasswordPageContent(): JSX.Element | null {
+/**
+ * #2773 — `token` arrives as a PROP from the async Server Component page.tsx
+ * (which reads searchParams). Reading it as a prop instead of via the
+ * `useSearchParams` client hook lets this component render server-side (SSR),
+ * dropping the CSR bailout. Same pattern as `login/_content.tsx` (#2650).
+ */
+export interface ResetPasswordPageContentProps {
+  /** `?token=` reset token. Reset mode when present, request mode otherwise. */
+  token?: string | null;
+}
+
+export function ResetPasswordPageContent({
+  token = null,
+}: ResetPasswordPageContentProps): JSX.Element | null {
   const router = useRouter();
-  const searchParams = useSearchParams();
   const { t } = useTranslation();
 
-  const token = searchParams?.get('token') ?? null;
   const mode: 'request' | 'reset' = token ? 'reset' : 'request';
   // Note (#2168): all redirect targets in this file are hardcoded (/chat, /, /reset-password).
   // Do NOT introduce ?from= here without using assertSafeRelativeOrFallback

--- a/apps/web/src/app/(auth)/reset-password/page.tsx
+++ b/apps/web/src/app/(auth)/reset-password/page.tsx
@@ -10,15 +10,15 @@
 /**
  * Password Reset Page (AUTH-04) — v2 migration (Task 13).
  *
- * Two-mode password reset flow wrapped in a Suspense boundary so that the
- * client-only `useSearchParams()` hook inside `_content.tsx` is allowed.
+ * #2773: async Server Component reads searchParams (async in Next 16) and passes
+ * `token` down as a prop, so the client _content renders WITHOUT
+ * `useSearchParams` — SSR'd, no CSR bailout. Same props pattern as
+ * `login/page.tsx` (#2650 / #2771).
  */
-
-import { Suspense } from 'react';
 
 import { Metadata } from 'next';
 
-import { ResetPasswordFallback, ResetPasswordPageContent } from './_content';
+import { ResetPasswordPageContent } from './_content';
 
 export const metadata: Metadata = {
   title: 'Reimposta password | MeepleAI',
@@ -26,10 +26,13 @@ export const metadata: Metadata = {
   robots: { index: false, follow: false },
 };
 
-export default function ResetPasswordPage() {
-  return (
-    <Suspense fallback={<ResetPasswordFallback />}>
-      <ResetPasswordPageContent />
-    </Suspense>
-  );
+export default async function ResetPasswordPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+}) {
+  const params = await searchParams;
+  const token = typeof params.token === 'string' ? params.token : undefined;
+
+  return <ResetPasswordPageContent token={token} />;
 }

--- a/apps/web/src/app/(auth)/setup-account/__tests__/_content.test.tsx
+++ b/apps/web/src/app/(auth)/setup-account/__tests__/_content.test.tsx
@@ -1,0 +1,69 @@
+/**
+ * Setup-account page (_content.tsx) smoke tests — #2773 props migration.
+ *
+ * Covers the refactored contract: the invitation `token` now flows as a PROP
+ * from the async page.tsx instead of via `useSearchParams`. Focused smoke tests
+ * for the prop wiring (missing-token branch + validation call), not full
+ * behavioural coverage of the activation flow.
+ */
+
+import { render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mocks (must be registered before component import)
+// ---------------------------------------------------------------------------
+
+const pushMock = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: pushMock }),
+}));
+
+// Passthrough AuthLayout so the smoke test does not depend on layout internals.
+vi.mock('@/components/layouts', () => ({
+  AuthLayout: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+// Import AFTER mocks
+import { SetupAccountContent } from '../_content';
+
+const originalFetch = global.fetch;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+});
+
+describe('SetupAccountContent — #2773 props contract', () => {
+  it('renders the missing-token branch when the token prop is absent (no validation call)', () => {
+    const fetchMock = vi.fn();
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    render(<SetupAccountContent token={null} />);
+
+    expect(screen.getByText(/Utilizza il link ricevuto/)).toBeInTheDocument();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('validates the invitation token supplied via the prop on mount', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ isValid: false, errorReason: 'invalid' }),
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    render(<SetupAccountContent token="inv-tok" />);
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalled();
+    });
+
+    const [url, options] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(String(url)).toContain('/api/v1/auth/validate-invitation');
+    expect(options.method).toBe('POST');
+    expect(String(options.body)).toContain('inv-tok');
+  });
+});

--- a/apps/web/src/app/(auth)/setup-account/_content.tsx
+++ b/apps/web/src/app/(auth)/setup-account/_content.tsx
@@ -14,7 +14,7 @@
 import { useEffect, useState, FormEvent } from 'react';
 
 import Link from 'next/link';
-import { useRouter, useSearchParams } from 'next/navigation';
+import { useRouter } from 'next/navigation';
 
 import { AuthLayout } from '@/components/layouts';
 import { Btn } from '@/components/ui/btn';
@@ -71,10 +71,19 @@ const getApiBase = (): string => {
 // Main Content Component
 // ──────────────────────────────────────────────
 
-export function SetupAccountContent() {
+/**
+ * #2773 — `token` arrives as a PROP from the async Server Component page.tsx
+ * (which reads searchParams). Reading it as a prop instead of via the
+ * `useSearchParams` client hook lets this component render server-side (SSR),
+ * dropping the CSR bailout. Same pattern as `login/_content.tsx` (#2650).
+ */
+export interface SetupAccountContentProps {
+  /** `?token=` invitation token. */
+  token?: string | null;
+}
+
+export function SetupAccountContent({ token = null }: SetupAccountContentProps) {
   const router = useRouter();
-  const searchParams = useSearchParams();
-  const token = searchParams?.get('token') ?? null;
 
   // Token validation state
   const [validationResult, setValidationResult] = useState<InvitationValidation | null>(null);
@@ -376,9 +385,7 @@ export function SetupAccountContent() {
           <div className="text-sm space-y-1">
             <div
               className={`flex items-center gap-2 ${
-                passwordValidation.minLength
-                  ? 'text-green-400'
-                  : 'text-muted-foreground'
+                passwordValidation.minLength ? 'text-green-400' : 'text-muted-foreground'
               }`}
             >
               <span aria-hidden="true">{passwordValidation.minLength ? '\u2713' : '\u25CB'}</span>
@@ -386,9 +393,7 @@ export function SetupAccountContent() {
             </div>
             <div
               className={`flex items-center gap-2 ${
-                passwordValidation.hasUppercase
-                  ? 'text-green-400'
-                  : 'text-muted-foreground'
+                passwordValidation.hasUppercase ? 'text-green-400' : 'text-muted-foreground'
               }`}
             >
               <span aria-hidden="true">
@@ -398,9 +403,7 @@ export function SetupAccountContent() {
             </div>
             <div
               className={`flex items-center gap-2 ${
-                passwordValidation.hasLowercase
-                  ? 'text-green-400'
-                  : 'text-muted-foreground'
+                passwordValidation.hasLowercase ? 'text-green-400' : 'text-muted-foreground'
               }`}
             >
               <span aria-hidden="true">
@@ -410,9 +413,7 @@ export function SetupAccountContent() {
             </div>
             <div
               className={`flex items-center gap-2 ${
-                passwordValidation.hasNumber
-                  ? 'text-green-400'
-                  : 'text-muted-foreground'
+                passwordValidation.hasNumber ? 'text-green-400' : 'text-muted-foreground'
               }`}
             >
               <span aria-hidden="true">{passwordValidation.hasNumber ? '\u2713' : '\u25CB'}</span>

--- a/apps/web/src/app/(auth)/setup-account/page.tsx
+++ b/apps/web/src/app/(auth)/setup-account/page.tsx
@@ -20,24 +20,20 @@
  * 4. On submit: activate account and redirect to onboarding or dashboard
  */
 
-import { Suspense } from 'react';
-
-import { AuthLayout } from '@/components/layouts';
-
 import { SetupAccountContent } from './_content';
 
-export default function SetupAccountPage() {
-  return (
-    <Suspense
-      fallback={
-        <AuthLayout title="Caricamento...">
-          <div className="text-center py-8">
-            <div className="animate-pulse text-muted-foreground">Caricamento...</div>
-          </div>
-        </AuthLayout>
-      }
-    >
-      <SetupAccountContent />
-    </Suspense>
-  );
+/**
+ * #2773: async Server Component reads searchParams (async in Next 16) and passes
+ * `token` down as a prop, so the client content renders WITHOUT `useSearchParams`
+ * — no CSR bailout. Same props pattern as `login/page.tsx` (#2650 / #2771).
+ */
+export default async function SetupAccountPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+}) {
+  const params = await searchParams;
+  const token = typeof params.token === 'string' ? params.token : undefined;
+
+  return <SetupAccountContent token={token} />;
 }

--- a/apps/web/src/app/(auth)/verification-pending/__tests__/_content.test.tsx
+++ b/apps/web/src/app/(auth)/verification-pending/__tests__/_content.test.tsx
@@ -33,11 +33,9 @@ vi.mock('@/hooks/useTranslation', () => ({
 }));
 
 const pushMock = vi.fn().mockResolvedValue(undefined);
-const searchParamsMock = { get: vi.fn<(key: string) => string | null>() };
 
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: pushMock }),
-  useSearchParams: () => searchParamsMock,
 }));
 
 // Controllable hook state
@@ -70,10 +68,15 @@ import { VerificationPendingContent } from '../_content';
 // Helpers
 // ---------------------------------------------------------------------------
 
+// #2773: ?email= now flows as the `emailParam` prop from the async page.tsx.
+// This helper stores the value; renderContent() forwards it to the component.
+let emailParamValue: string | null = null;
 function setSearchParams(params: Record<string, string | null>) {
-  searchParamsMock.get.mockImplementation((key: string) =>
-    Object.prototype.hasOwnProperty.call(params, key) ? (params[key] ?? null) : null
-  );
+  emailParamValue = params.email ?? null;
+}
+
+function renderContent() {
+  return render(<VerificationPendingContent emailParam={emailParamValue} />);
 }
 
 function setHookState(partial: Partial<typeof hookState>) {
@@ -97,7 +100,7 @@ describe('VerificationPendingContent (v2 AuthCard)', () => {
   describe('Email resolution', () => {
     it('renders with email from ?email query param', () => {
       setSearchParams({ email: 'user@example.com' });
-      render(<VerificationPendingContent />);
+      renderContent();
       // Card title rendered verbatim (t returns key)
       expect(
         screen.getByRole('heading', { name: 'auth.emailVerification.pending.title' })
@@ -108,20 +111,20 @@ describe('VerificationPendingContent (v2 AuthCard)', () => {
 
     it('persists query-param email into sessionStorage', () => {
       setSearchParams({ email: 'user@example.com' });
-      render(<VerificationPendingContent />);
+      renderContent();
       expect(sessionStorage.getItem('pendingVerificationEmail')).toBe('user@example.com');
     });
 
     it('falls back to sessionStorage when no query param', () => {
       sessionStorage.setItem('pendingVerificationEmail', 'stored@example.com');
       setSearchParams({});
-      render(<VerificationPendingContent />);
+      renderContent();
       expect(screen.getByText(/s\*\*\*d@example\.com/)).toBeInTheDocument();
     });
 
     it('renders no-email redirect CTA when neither source has email', () => {
       setSearchParams({});
-      render(<VerificationPendingContent />);
+      renderContent();
       expect(screen.getByText('auth.emailVerification.pending.noEmail')).toBeInTheDocument();
       const cta = screen.getByRole('button', {
         name: 'auth.emailVerification.pending.goToRegister',
@@ -131,7 +134,7 @@ describe('VerificationPendingContent (v2 AuthCard)', () => {
 
     it('no-email CTA navigates to /register on click', () => {
       setSearchParams({});
-      render(<VerificationPendingContent />);
+      renderContent();
       const cta = screen.getByRole('button', {
         name: 'auth.emailVerification.pending.goToRegister',
       });
@@ -147,7 +150,7 @@ describe('VerificationPendingContent (v2 AuthCard)', () => {
 
     it('calls resendVerificationEmail(email) when resend button clicked', () => {
       setSearchParams({ email: 'user@example.com' });
-      render(<VerificationPendingContent />);
+      renderContent();
       const button = getResendButton();
       fireEvent.click(button);
       expect(resendMock).toHaveBeenCalledWith('user@example.com');
@@ -156,14 +159,14 @@ describe('VerificationPendingContent (v2 AuthCard)', () => {
     it('disables resend button when cooldownSeconds > 0', () => {
       setSearchParams({ email: 'user@example.com' });
       setHookState({ cooldownSeconds: 30 });
-      render(<VerificationPendingContent />);
+      renderContent();
       expect(getResendButton()).toBeDisabled();
     });
 
     it('shows cooldown message when cooldownSeconds > 0', () => {
       setSearchParams({ email: 'user@example.com' });
       setHookState({ cooldownSeconds: 30 });
-      render(<VerificationPendingContent />);
+      renderContent();
       expect(
         screen.getByText(/auth\.emailVerification\.pending\.cooldownMessage/)
       ).toBeInTheDocument();
@@ -172,7 +175,7 @@ describe('VerificationPendingContent (v2 AuthCard)', () => {
     it('enables resend button when cooldownSeconds is 0 and not resending', () => {
       setSearchParams({ email: 'user@example.com' });
       setHookState({ cooldownSeconds: 0, isResending: false });
-      render(<VerificationPendingContent />);
+      renderContent();
       expect(getResendButton()).not.toBeDisabled();
     });
   });
@@ -181,7 +184,7 @@ describe('VerificationPendingContent (v2 AuthCard)', () => {
     it('renders error from hook in alert role', () => {
       setSearchParams({ email: 'user@example.com' });
       setHookState({ error: 'Failed to resend email' });
-      render(<VerificationPendingContent />);
+      renderContent();
       const alert = screen.getByRole('alert');
       expect(alert).toHaveTextContent('Failed to resend email');
     });

--- a/apps/web/src/app/(auth)/verification-pending/_content.tsx
+++ b/apps/web/src/app/(auth)/verification-pending/_content.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react';
 
 import { Mail, RefreshCw } from 'lucide-react';
-import { useRouter, useSearchParams } from 'next/navigation';
+import { useRouter } from 'next/navigation';
 
 import { AuthCard } from '@/components/ui/auth-card';
 import { Btn } from '@/components/ui/btn';
@@ -26,13 +26,23 @@ function maskEmail(email: string): string {
   return `${maskedLocal}@${domain}`;
 }
 
-export function VerificationPendingContent() {
+/**
+ * #2773 — `emailParam` arrives as a PROP from the async Server Component
+ * page.tsx (which reads searchParams). Reading it as a prop instead of via the
+ * `useSearchParams` client hook lets this component render server-side (SSR),
+ * dropping the CSR bailout. Same pattern as `login/_content.tsx` (#2650).
+ */
+export interface VerificationPendingContentProps {
+  /** `?email=` address; falls back to sessionStorage when absent. */
+  emailParam?: string | null;
+}
+
+export function VerificationPendingContent({ emailParam = null }: VerificationPendingContentProps) {
   const router = useRouter();
-  const searchParams = useSearchParams();
   const { t } = useTranslation();
 
   // Get email from query params or session storage
-  const emailFromParams = searchParams?.get('email') ?? null;
+  const emailFromParams = emailParam;
   const [email, setEmail] = useState<string | null>(null);
 
   const { isResending, error, cooldownSeconds, resendVerificationEmail, clearError } =

--- a/apps/web/src/app/(auth)/verification-pending/page.tsx
+++ b/apps/web/src/app/(auth)/verification-pending/page.tsx
@@ -16,20 +16,20 @@
  * Task 12 (auth-flow-v2 migration): uses v2 AuthCard primitive via _content.tsx.
  */
 
-import { Suspense } from 'react';
-
 import { VerificationPendingContent } from './_content';
 
-export default function VerificationPendingPage() {
-  return (
-    <Suspense
-      fallback={
-        <div className="flex min-h-dvh items-center justify-center bg-background">
-          <div className="animate-pulse text-muted-foreground text-sm">Loading...</div>
-        </div>
-      }
-    >
-      <VerificationPendingContent />
-    </Suspense>
-  );
+/**
+ * #2773: async Server Component reads searchParams (async in Next 16) and passes
+ * `email` down as a prop, so the client content renders WITHOUT `useSearchParams`
+ * — no CSR bailout. Same props pattern as `login/page.tsx` (#2650 / #2771).
+ */
+export default async function VerificationPendingPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+}) {
+  const params = await searchParams;
+  const email = typeof params.email === 'string' ? params.email : undefined;
+
+  return <VerificationPendingContent emailParam={email} />;
 }

--- a/apps/web/src/app/(auth)/verify-email/__tests__/_content.test.tsx
+++ b/apps/web/src/app/(auth)/verify-email/__tests__/_content.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * Verify-email page (_content.tsx) smoke tests — #2773 props migration.
+ *
+ * Covers the refactored contract: `token`/`emailParam` now flow as PROPS from
+ * the async page.tsx instead of via `useSearchParams`. These are focused smoke
+ * tests for the prop wiring, not full behavioural coverage of the hook.
+ */
+
+import { render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mocks (must be registered before component import)
+// ---------------------------------------------------------------------------
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+const pushMock = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: pushMock }),
+}));
+
+const verifyEmailMock = vi.fn();
+const resendMock = vi.fn().mockResolvedValue(undefined);
+const hookState = {
+  isLoading: false,
+  isResending: false,
+  error: null as string | null,
+  errorType: null as string | null,
+  isVerified: false,
+  cooldownSeconds: 0,
+};
+
+vi.mock('@/hooks/useEmailVerification', () => ({
+  useEmailVerification: () => ({
+    isLoading: hookState.isLoading,
+    isResending: hookState.isResending,
+    error: hookState.error,
+    errorType: hookState.errorType,
+    isVerified: hookState.isVerified,
+    cooldownSeconds: hookState.cooldownSeconds,
+    verifyEmail: verifyEmailMock,
+    resendVerificationEmail: resendMock,
+  }),
+}));
+
+// Import AFTER mocks
+import { VerifyEmailContent } from '../_content';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  sessionStorage.clear();
+  hookState.isLoading = false;
+  hookState.isResending = false;
+  hookState.error = null;
+  hookState.errorType = null;
+  hookState.isVerified = false;
+  hookState.cooldownSeconds = 0;
+});
+
+describe('VerifyEmailContent — #2773 props contract', () => {
+  it('renders the no-token branch when the token prop is absent and never verifies', () => {
+    render(<VerifyEmailContent token={null} emailParam={null} />);
+
+    expect(screen.getByTestId('verify-email-page')).toBeInTheDocument();
+    expect(verifyEmailMock).not.toHaveBeenCalled();
+  });
+
+  it('verifies the token supplied via the prop on mount', async () => {
+    render(<VerifyEmailContent token="tok-abc" emailParam="user@example.com" />);
+
+    await waitFor(() => {
+      expect(verifyEmailMock).toHaveBeenCalledWith('tok-abc');
+    });
+    expect(screen.getByTestId('verify-email-page')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/(auth)/verify-email/_content.tsx
+++ b/apps/web/src/app/(auth)/verify-email/_content.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState, useCallback } from 'react';
 
-import { useRouter, useSearchParams } from 'next/navigation';
+import { useRouter } from 'next/navigation';
 
 import { VerificationError } from '@/components/auth/VerificationError';
 import { VerificationSuccess } from '@/components/auth/VerificationSuccess';
@@ -10,13 +10,24 @@ import { AuthCard } from '@/components/ui/auth-card';
 import { useEmailVerification } from '@/hooks/useEmailVerification';
 import { useTranslation } from '@/hooks/useTranslation';
 
-export function VerifyEmailContent() {
+/**
+ * #2773 — `token`/`emailParam` arrive as PROPS from the async Server Component
+ * page.tsx (which reads searchParams). Reading them as props instead of via the
+ * `useSearchParams` client hook lets this component render server-side (SSR),
+ * dropping the CSR bailout. Same pattern as `login/_content.tsx` (#2650).
+ */
+export interface VerifyEmailContentProps {
+  /** `?token=` verification token. */
+  token?: string | null;
+  /** `?email=` address (for resend); falls back to sessionStorage when absent. */
+  emailParam?: string | null;
+}
+
+export function VerifyEmailContent({ token = null, emailParam = null }: VerifyEmailContentProps) {
   const router = useRouter();
-  const searchParams = useSearchParams();
   const { t } = useTranslation();
 
-  const token = searchParams?.get('token') ?? null;
-  const emailFromParams = searchParams?.get('email') ?? null;
+  const emailFromParams = emailParam;
 
   const {
     isLoading,

--- a/apps/web/src/app/(auth)/verify-email/page.tsx
+++ b/apps/web/src/app/(auth)/verify-email/page.tsx
@@ -14,11 +14,7 @@
  * User lands here after clicking the verification link in their email.
  */
 
-import { Suspense } from 'react';
-
 import { Metadata } from 'next';
-
-import { AuthCard } from '@/components/ui/auth-card';
 
 import { VerifyEmailContent } from './_content';
 
@@ -28,20 +24,19 @@ export const metadata: Metadata = {
   robots: { index: false, follow: false },
 };
 
-export default function VerifyEmailPage() {
-  return (
-    <Suspense
-      fallback={
-        <AuthCard title="Verifica email">
-          <div className="text-center py-8">
-            <div className="animate-pulse text-muted-foreground text-sm">
-              Verifica email in corso...
-            </div>
-          </div>
-        </AuthCard>
-      }
-    >
-      <VerifyEmailContent />
-    </Suspense>
-  );
+/**
+ * #2773: async Server Component reads searchParams (async in Next 16) and passes
+ * `token`/`email` down as props, so the client content renders WITHOUT
+ * `useSearchParams` — no CSR bailout. Same props pattern as `login/page.tsx`.
+ */
+export default async function VerifyEmailPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+}) {
+  const params = await searchParams;
+  const token = typeof params.token === 'string' ? params.token : undefined;
+  const email = typeof params.email === 'string' ? params.email : undefined;
+
+  return <VerifyEmailContent token={token} emailParam={email} />;
 }

--- a/apps/web/src/app/(auth)/welcome/__tests__/_content.test.tsx
+++ b/apps/web/src/app/(auth)/welcome/__tests__/_content.test.tsx
@@ -15,11 +15,9 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 // ---------------------------------------------------------------------------
 
 const pushMock = vi.fn().mockResolvedValue(undefined);
-const searchParamsMock = { get: vi.fn<(key: string) => string | null>() };
 
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: pushMock }),
-  useSearchParams: () => searchParamsMock,
 }));
 
 vi.mock('@/lib/logger', () => ({
@@ -34,16 +32,12 @@ import { logger } from '@/lib/logger';
 // Helpers
 // ---------------------------------------------------------------------------
 
-function setSearchParams(params: Record<string, string | null>) {
-  searchParamsMock.get.mockImplementation((key: string) =>
-    Object.prototype.hasOwnProperty.call(params, key) ? (params[key] ?? null) : null
-  );
-}
+// #2773: ?redirectTo= now flows as the `redirectToParam` prop from the async
+// page.tsx, not via a mocked useSearchParams.
 
 beforeEach(() => {
   vi.clearAllMocks();
   vi.useFakeTimers();
-  setSearchParams({});
 });
 
 afterEach(() => {
@@ -71,8 +65,6 @@ async function advancePastRedirect() {
 
 describe('WelcomeContent — auto redirect', () => {
   it('redirects to /library after 2000ms when no ?redirectTo= param', async () => {
-    setSearchParams({});
-
     await act(async () => {
       render(<WelcomeContent />);
     });
@@ -84,8 +76,6 @@ describe('WelcomeContent — auto redirect', () => {
   });
 
   it('redirects immediately when the "Vai alla Dashboard" button is clicked', async () => {
-    setSearchParams({});
-
     await act(async () => {
       render(<WelcomeContent />);
       // Flush the setMounted(true) useEffect so the component renders the button
@@ -106,10 +96,8 @@ describe('WelcomeContent — auto redirect', () => {
 
 describe('WelcomeContent — open redirect protection (#2168)', () => {
   it('falls back to /library when ?redirectTo= is external URL', async () => {
-    setSearchParams({ redirectTo: 'https://evil.com' });
-
     await act(async () => {
-      render(<WelcomeContent />);
+      render(<WelcomeContent redirectToParam="https://evil.com" />);
     });
 
     await advancePastRedirect();
@@ -127,10 +115,8 @@ describe('WelcomeContent — open redirect protection (#2168)', () => {
   });
 
   it('preserves valid relative ?redirectTo= path', async () => {
-    setSearchParams({ redirectTo: '/sessions/abc-123' });
-
     await act(async () => {
-      render(<WelcomeContent />);
+      render(<WelcomeContent redirectToParam="/sessions/abc-123" />);
     });
 
     await advancePastRedirect();
@@ -142,10 +128,8 @@ describe('WelcomeContent — open redirect protection (#2168)', () => {
   });
 
   it('logs unsafe ?redirectTo= attempt on initial render (before redirect)', async () => {
-    setSearchParams({ redirectTo: 'https://evil.com' });
-
     await act(async () => {
-      render(<WelcomeContent />);
+      render(<WelcomeContent redirectToParam="https://evil.com" />);
       // Flush microtasks so the warn useEffect commits, but do NOT advance
       // past the 2000ms redirect timer — push must not have been called yet
     });

--- a/apps/web/src/app/(auth)/welcome/_content.tsx
+++ b/apps/web/src/app/(auth)/welcome/_content.tsx
@@ -4,7 +4,7 @@
 import { useEffect, useState, useCallback } from 'react';
 
 import { PartyPopper, ArrowRight, Sparkles } from 'lucide-react';
-import { useRouter, useSearchParams } from 'next/navigation';
+import { useRouter } from 'next/navigation';
 
 import { Btn } from '@/components/ui/btn';
 import { logger } from '@/lib/logger';
@@ -26,10 +26,20 @@ export function WelcomeFallback() {
   );
 }
 
-export function WelcomeContent() {
+/**
+ * #2773 — `redirectToParam` arrives as a PROP from the async Server Component
+ * page.tsx (which reads searchParams). Reading it as a prop instead of via the
+ * `useSearchParams` client hook lets this component render server-side (SSR),
+ * dropping the CSR bailout. Same pattern as `login/_content.tsx` (#2650).
+ */
+export interface WelcomeContentProps {
+  /** `?redirectTo=` target. Sanitized against open-redirect below (#2168). */
+  redirectToParam?: string;
+}
+
+export function WelcomeContent({ redirectToParam }: WelcomeContentProps) {
   const router = useRouter();
-  const searchParams = useSearchParams();
-  const rawRedirectTo = searchParams?.get('redirectTo');
+  const rawRedirectTo = redirectToParam;
   // Audit (#2168): ?redirectTo= is user-controlled; guard against open-redirect
   // via assertSafeRelativeOrFallback before passing to router.push().
   const redirectTo = assertSafeRelativeOrFallback(rawRedirectTo, '/library');

--- a/apps/web/src/app/(auth)/welcome/page.tsx
+++ b/apps/web/src/app/(auth)/welcome/page.tsx
@@ -12,16 +12,21 @@
  *
  * Displays a welcome message after successful registration,
  * then automatically redirects to dashboard after 2 seconds.
+ *
+ * #2773: async Server Component reads searchParams (async in Next 16) and passes
+ * `redirectTo` down as a prop, so the client WelcomeContent renders WITHOUT
+ * `useSearchParams` — no CSR bailout. Same props pattern as `login/page.tsx`.
  */
 
-import { Suspense } from 'react';
+import { WelcomeContent } from './_content';
 
-import { WelcomeFallback, WelcomeContent } from './_content';
+export default async function WelcomePage({
+  searchParams,
+}: {
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+}) {
+  const params = await searchParams;
+  const redirectTo = typeof params.redirectTo === 'string' ? params.redirectTo : undefined;
 
-export default function WelcomePage() {
-  return (
-    <Suspense fallback={<WelcomeFallback />}>
-      <WelcomeContent />
-    </Suspense>
-  );
+  return <WelcomeContent redirectToParam={redirectTo} />;
 }

--- a/apps/web/src/app/admin/(dashboard)/knowledge-base/mechanic-extractor/analyses/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/knowledge-base/mechanic-extractor/analyses/page.tsx
@@ -712,6 +712,7 @@ export default function MechanicAnalysesPage() {
             {analysisId && status && status.claimsCount > 0 && (
               <ClaimsSection
                 analysisId={analysisId}
+                pdfDocumentId={status?.pdfDocumentId}
                 isClaimsActionable={
                   // Approve/Reject only allowed while parent is InReview (server-enforced).
                   status.status === MechanicAnalysisStatus.InReview && !status.isSuppressed

--- a/apps/web/src/app/admin/(dashboard)/knowledge-base/mechanic-extractor/review/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/knowledge-base/mechanic-extractor/review/page.tsx
@@ -17,6 +17,7 @@ import {
 } from 'lucide-react';
 import { useSearchParams } from 'next/navigation';
 
+import { MechanicAnalysisFooterAttribution } from '@/components/admin/mechanic-extractor/MechanicAnalysisFooterAttribution';
 import { EvaluateButton } from '@/components/admin/mechanic-extractor/validation/EvaluateButton';
 import { FeatureFlagGate } from '@/components/admin/mechanic-extractor/validation/FeatureFlagGate';
 import { MetricsCard } from '@/components/admin/mechanic-extractor/validation/MetricsCard';
@@ -268,21 +269,11 @@ function ReviewContent() {
         </ReviewCard>
       )}
 
-      {/* Copyright Footer */}
-      <div className="rounded-lg border border-green-200 bg-green-50/50 p-4 text-center text-xs text-green-800 dark:border-green-800 dark:bg-green-950/20 dark:text-green-300 print:border-green-400">
-        <strong>&copy; 2026 MeepleAI</strong> — Contenuto originale. Meccaniche di gioco descritte
-        indipendentemente.
-        <br />
-        <span className="opacity-70">
-          Generato con Variant C (human + AI assistant). L&apos;AI non ha mai letto il testo del PDF
-          originale.
-        </span>
-        {(draft.totalTokensUsed ?? 0) > 0 && (
-          <span className="ml-2 opacity-70">
-            | {draft.totalTokensUsed} tokens, ${(draft.estimatedCostUsd ?? 0).toFixed(4)}
-          </span>
-        )}
-      </div>
+      {/* Copyright Footer (ADR-051, #526 AC-5) */}
+      <MechanicAnalysisFooterAttribution
+        totalTokensUsed={draft.totalTokensUsed}
+        estimatedCostUsd={draft.estimatedCostUsd}
+      />
 
       {/* AI Comprehension Validation (feature-flagged — ADR-051 Sprint 1 / Task 37) */}
       <FeatureFlagGate>

--- a/apps/web/src/components/admin/mechanic-extractor/MechanicAnalysisFooterAttribution.tsx
+++ b/apps/web/src/components/admin/mechanic-extractor/MechanicAnalysisFooterAttribution.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+export interface MechanicAnalysisFooterAttributionProps {
+  readonly totalTokensUsed?: number;
+  readonly estimatedCostUsd?: number;
+}
+
+/**
+ * #526 AC-5 — ADR-051 canonical attribution footer. Shared between the admin review page and the
+ * public card (#528). Replaces the retired Variant-C attribution copy.
+ */
+export function MechanicAnalysisFooterAttribution({
+  totalTokensUsed,
+  estimatedCostUsd,
+}: MechanicAnalysisFooterAttributionProps): React.JSX.Element {
+  return (
+    <div className="rounded-lg border border-green-200 bg-green-50/50 p-4 text-center text-xs text-green-800 dark:border-green-800 dark:bg-green-950/20 dark:text-green-300 print:border-green-400">
+      <strong>&copy; 2026 MeepleAI</strong> — Contenuto originale.
+      <br />
+      <span className="opacity-70">
+        Analisi elaborata dall&apos;AI sul manuale del gioco. Ogni affermazione è riformulata in
+        parole originali e cita la pagina del regolamento. Copyright &copy; degli editori per il
+        testo originale del manuale.
+      </span>
+      {(totalTokensUsed ?? 0) > 0 && (
+        <span className="ml-2 opacity-70">
+          | {totalTokensUsed} tokens, ${(estimatedCostUsd ?? 0).toFixed(4)}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/admin/mechanic-extractor/__tests__/MechanicAnalysisFooterAttribution.test.tsx
+++ b/apps/web/src/components/admin/mechanic-extractor/__tests__/MechanicAnalysisFooterAttribution.test.tsx
@@ -1,0 +1,18 @@
+/** @vitest-environment jsdom */
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { MechanicAnalysisFooterAttribution } from '../MechanicAnalysisFooterAttribution';
+
+describe('MechanicAnalysisFooterAttribution', () => {
+  it('renders the ADR-051 attribution and NOT the forbidden Variant-C string', () => {
+    render(<MechanicAnalysisFooterAttribution totalTokensUsed={500} estimatedCostUsd={0.002} />);
+    expect(
+      screen.getByText(/riformulata in parole originali e cita la pagina/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/non ha mai letto il testo del PDF originale/i)
+    ).not.toBeInTheDocument();
+    expect(screen.getByText(/500 tokens/)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/admin/mechanic-extractor/claims/ApproveClaimDialog.tsx
+++ b/apps/web/src/components/admin/mechanic-extractor/claims/ApproveClaimDialog.tsx
@@ -1,0 +1,98 @@
+/* eslint-disable local/no-hardcoded-color-utility -- admin tools chrome: text-white / button color on style-prop colored bg or admin-decorative inline gradient. DS-13d admin scope (--admin-* decision deferred to DS-15). */
+'use client';
+
+import React, { useEffect, useState } from 'react';
+
+import { Loader2Icon } from 'lucide-react';
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/overlays/alert-dialog-primitives';
+import { APPROVE_CLAIM_NOTE_MAX_LENGTH } from '@/lib/api/schemas/mechanic-analyses.schemas';
+
+interface ApproveClaimDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: (note: string) => void;
+  isPending: boolean;
+  /** Short claim preview (first ~80 chars) used in the dialog description. */
+  claimPreview?: string;
+}
+
+/**
+ * Modal for approving a single mechanic claim with an OPTIONAL reviewer note
+ * (#526 ME-M1.4 AC-6). Unlike {@link RejectClaimDialog}, the note here is not
+ * required — the confirm action is always enabled.
+ */
+export function ApproveClaimDialog({
+  open,
+  onOpenChange,
+  onConfirm,
+  isPending,
+  claimPreview,
+}: ApproveClaimDialogProps): React.JSX.Element {
+  const [note, setNote] = useState('');
+
+  // Reset note when the dialog closes (Cancel or programmatic close).
+  useEffect(() => {
+    if (!open) setNote('');
+  }, [open]);
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Approve this claim?</AlertDialogTitle>
+          <AlertDialogDescription>
+            {claimPreview ? (
+              <span className="block italic">&ldquo;{claimPreview}&rdquo;</span>
+            ) : null}
+            <span className="mt-2 block">
+              Optionally add a reviewer note. The note is recorded with the claim and surfaced to
+              other reviewers.
+            </span>
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <div className="space-y-2">
+          <label className="block text-sm font-medium" htmlFor="approve-claim-note">
+            Reviewer note (optional, up to {APPROVE_CLAIM_NOTE_MAX_LENGTH} chars)
+          </label>
+          <textarea
+            id="approve-claim-note"
+            value={note}
+            onChange={e => setNote(e.target.value)}
+            placeholder="e.g. matches p.4…"
+            className="h-24 w-full resize-y rounded-md border border-border bg-card px-3 py-2 text-sm dark:border-zinc-700 dark:bg-zinc-900 focus:border-green-400 focus:outline-none focus:ring-1 focus:ring-green-400"
+            data-testid="approve-claim-note-input"
+            maxLength={APPROVE_CLAIM_NOTE_MAX_LENGTH}
+          />
+          <p className="text-xs text-muted-foreground">
+            {note.length} / {APPROVE_CLAIM_NOTE_MAX_LENGTH} characters
+          </p>
+        </div>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isPending}>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={e => {
+              e.preventDefault();
+              onConfirm(note.trim());
+            }}
+            disabled={isPending}
+            className="bg-green-600 hover:bg-green-700"
+            data-testid="approve-claim-confirm"
+          >
+            {isPending ? <Loader2Icon className="mr-1 h-4 w-4 animate-spin" /> : null}
+            Approve claim
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/apps/web/src/components/admin/mechanic-extractor/claims/BulkActionDialog.tsx
+++ b/apps/web/src/components/admin/mechanic-extractor/claims/BulkActionDialog.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import React from 'react';
+
+import { Loader2Icon } from 'lucide-react';
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/overlays/alert-dialog-primitives';
+
+interface BulkActionDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Confirmation dialog title, e.g. "Approve all pending claims?". */
+  title: string;
+  /** Predicted number of claims the action will affect. */
+  count: number;
+  onConfirm: () => void;
+  isPending: boolean;
+}
+
+/**
+ * Confirmation modal for bulk claim actions (#526 ME-M1.4 AC-3).
+ *
+ * Mirrors {@link RejectClaimDialog} but is generic over the bulk action
+ * (approve-pending / reject-long-quote / future additions), surfacing only
+ * the predicted affected-claim count for the reviewer to confirm.
+ */
+export function BulkActionDialog({
+  open,
+  onOpenChange,
+  title,
+  count,
+  onConfirm,
+  isPending,
+}: BulkActionDialogProps): React.JSX.Element {
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          <AlertDialogDescription>
+            This will affect <strong data-testid="bulk-action-count">{count}</strong> claim
+            {count === 1 ? '' : 's'}. This action cannot be undone.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isPending}>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={e => {
+              e.preventDefault();
+              if (count === 0) return;
+              onConfirm();
+            }}
+            disabled={count === 0 || isPending}
+            data-testid="bulk-action-confirm"
+          >
+            {isPending ? <Loader2Icon className="mr-1 h-4 w-4 animate-spin" /> : null}
+            Confirm
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/apps/web/src/components/admin/mechanic-extractor/claims/ClaimsSection.tsx
+++ b/apps/web/src/components/admin/mechanic-extractor/claims/ClaimsSection.tsx
@@ -9,6 +9,7 @@
  *   POST /admin/mechanic-analyses/{id}/claims/{claimId}/approve       → single
  *   POST /admin/mechanic-analyses/{id}/claims/{claimId}/reject        → single + note
  *   POST /admin/mechanic-analyses/{id}/claims/bulk-approve            → batch
+ *   POST /admin/mechanic-analyses/{id}/claims/bulk-reject             → batch + reason (#526 ME-M1.4 AC-3)
  *
  * Lifecycle invariant (AC-10): the parent analysis can only be promoted to
  * Published once **every** claim is Approved. The viewer surfaces totals so
@@ -20,7 +21,15 @@ import React, { useMemo, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { CheckIcon, ChevronDownIcon, ChevronRightIcon, Loader2Icon, XIcon } from 'lucide-react';
 
+import { PdfQuoteHighlighter } from '@/components/pdf/PdfQuoteHighlighter';
 import { Badge } from '@/components/ui/data-display/badge';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/overlays/select';
 import { Button } from '@/components/ui/primitives/button';
 import { createAdminClient } from '@/lib/api/clients/adminClient';
 import { HttpClient } from '@/lib/api/core/httpClient';
@@ -29,18 +38,70 @@ import {
   MECHANIC_SECTION_LABELS,
   MechanicClaimStatus,
   type MechanicClaimDto,
+  type MechanicClaimValidationDto,
 } from '@/lib/api/schemas/mechanic-analyses.schemas';
 
+import { ApproveClaimDialog } from './ApproveClaimDialog';
+import { BulkActionDialog } from './BulkActionDialog';
 import { RejectClaimDialog } from './RejectClaimDialog';
 
 const httpClient = new HttpClient();
 const adminClient = createAdminClient({ httpClient });
+
+/** Word threshold above which a citation quote is considered "long" (#526 ME-M1.4 AC-3, ADR-051 T1). */
+const LONG_QUOTE_WORDS = 20;
+
+function wordCount(s: string): number {
+  return s.trim().split(/\s+/).filter(Boolean).length;
+}
+
+/** Claims whose citations include at least one quote longer than {@link LONG_QUOTE_WORDS} words. */
+function claimsWithLongQuote(claims: MechanicClaimDto[]): MechanicClaimDto[] {
+  return claims.filter(c => c.citations.some(cit => wordCount(cit.quote) > LONG_QUOTE_WORDS));
+}
+
+type BulkActionKind = 'approve-pending' | 'reject-long-quote';
 
 const CLAIM_STATUS_BADGE_CLASS: Record<number, string> = {
   [MechanicClaimStatus.Pending]: 'bg-amber-100 text-amber-800 border-amber-300',
   [MechanicClaimStatus.Approved]: 'bg-green-100 text-green-800 border-green-300',
   [MechanicClaimStatus.Rejected]: 'bg-rose-100 text-rose-800 border-rose-300',
 };
+
+/** Per-rule (T1-T4) template validation badge styling (#526 ME-M1.4 AC-1). */
+const VALIDATION_BADGE_CLASS: Record<string, string> = {
+  pass: 'bg-green-100 text-green-800 border-green-300',
+  fail: 'bg-rose-100 text-rose-800 border-rose-300',
+  notRun: 'bg-slate-100 text-slate-600 border-slate-300',
+};
+
+/**
+ * Renders one Badge per template validation rule (T1-T4) with pass/fail/notRun
+ * styling. Exported for direct unit testing and reuse across claim rows.
+ */
+export function ValidationBadges({
+  validations,
+}: {
+  validations: MechanicClaimValidationDto[];
+}): React.JSX.Element | null {
+  if (!validations || validations.length === 0) return null;
+  return (
+    <span className="flex flex-wrap gap-1" data-testid="claim-validation-badges">
+      {validations.map(v => (
+        <Badge
+          key={v.rule}
+          variant="outline"
+          className={VALIDATION_BADGE_CLASS[v.outcome] ?? VALIDATION_BADGE_CLASS.notRun}
+          data-testid={`claim-validation-badge-${v.rule}`}
+          aria-label={`${v.rule} ${v.outcome}${v.message ? `: ${v.message}` : ''}`}
+          title={v.message ?? `${v.rule} ${v.outcome}`}
+        >
+          {v.outcome === 'pass' ? '✓' : v.outcome === 'fail' ? '✗' : '—'} {v.rule}
+        </Badge>
+      ))}
+    </span>
+  );
+}
 
 interface ClaimsSectionProps {
   analysisId: string;
@@ -49,19 +110,35 @@ interface ClaimsSectionProps {
    * Used for terminal states where claims are still useful read-only context.
    */
   isClaimsActionable?: boolean;
+  /**
+   * Source PDF id (#526 ME-M1.4 AC-2). When present, citation rows become
+   * clickable buttons that open {@link PdfQuoteHighlighter} at the cited
+   * page/quote; when absent, citations render as plain read-only text.
+   */
+  pdfDocumentId?: string;
+}
+
+interface CitationTarget {
+  documentId: string;
+  page: number;
+  quote: string;
 }
 
 export function ClaimsSection({
   analysisId,
   isClaimsActionable = true,
+  pdfDocumentId,
 }: ClaimsSectionProps): React.JSX.Element {
   const queryClient = useQueryClient();
   const [actionError, setActionError] = useState<string | null>(null);
   // Separate channel for success-with-skipped (amber) so we don't conflate it
   // with hard failures (rose) — spec-panel P1 fix.
   const [actionWarning, setActionWarning] = useState<string | null>(null);
+  const [approveTarget, setApproveTarget] = useState<MechanicClaimDto | null>(null);
   const [rejectTarget, setRejectTarget] = useState<MechanicClaimDto | null>(null);
   const [pendingClaimId, setPendingClaimId] = useState<string | null>(null);
+  const [citationTarget, setCitationTarget] = useState<CitationTarget | null>(null);
+  const [bulkAction, setBulkAction] = useState<BulkActionKind | null>(null);
 
   const claimsQuery = useQuery({
     queryKey: ['mechanic-analysis', analysisId, 'claims'],
@@ -107,11 +184,13 @@ export function ClaimsSection({
   };
 
   const approveMutation = useMutation({
-    mutationFn: (claimId: string) => adminClient.approveMechanicClaim(analysisId, claimId),
-    onMutate: claimId => setPendingClaimId(claimId),
+    mutationFn: ({ claimId, note }: { claimId: string; note?: string }) =>
+      adminClient.approveMechanicClaim(analysisId, claimId, note || undefined),
+    onMutate: ({ claimId }) => setPendingClaimId(claimId),
     onSuccess: () => {
       setActionError(null);
       setActionWarning(null);
+      setApproveTarget(null);
       invalidateClaimsAndStatus();
     },
     onError: (err: unknown) => {
@@ -155,7 +234,53 @@ export function ClaimsSection({
     onError: (err: unknown) => {
       setActionError(err instanceof Error ? err.message : 'Bulk approve failed');
     },
+    onSettled: () => setBulkAction(null),
   });
+
+  const bulkRejectMutation = useMutation({
+    mutationFn: (vars: { claimIds: string[]; reason: string }) =>
+      adminClient.bulkRejectMechanicClaims(analysisId, vars),
+    onSuccess: result => {
+      setActionError(null);
+      // Partial success: report skipped-already-rejected as a warning (amber), not error (rose).
+      if (result.skippedAlreadyRejectedCount > 0) {
+        setActionWarning(
+          `Bulk reject completed: ${result.rejectedCount} rejected, ` +
+            `${result.skippedAlreadyRejectedCount} already-rejected claim(s) skipped.`
+        );
+      } else {
+        setActionWarning(null);
+      }
+      invalidateClaimsAndStatus();
+    },
+    onError: (err: unknown) => {
+      setActionError(err instanceof Error ? err.message : 'Bulk reject failed');
+    },
+    onSettled: () => setBulkAction(null),
+  });
+
+  const pendingClaims = useMemo(
+    () => claims.filter(c => c.status === MechanicClaimStatus.Pending),
+    [claims]
+  );
+  const longQuoteClaims = useMemo(() => claimsWithLongQuote(claims), [claims]);
+
+  const bulkActionTargets = bulkAction === 'approve-pending' ? pendingClaims : longQuoteClaims;
+  const bulkActionTitle =
+    bulkAction === 'approve-pending'
+      ? 'Approve all pending claims?'
+      : 'Reject claims with quote >20 words?';
+
+  const handleBulkActionConfirm = () => {
+    if (bulkAction === 'approve-pending') {
+      bulkApproveMutation.mutate();
+    } else if (bulkAction === 'reject-long-quote') {
+      bulkRejectMutation.mutate({
+        claimIds: bulkActionTargets.map(c => c.id),
+        reason: 'Citazione supera 20 parole (ADR-051 T1) — rifiuto bulk.',
+      });
+    }
+  };
 
   if (claimsQuery.isLoading) {
     return (
@@ -195,7 +320,7 @@ export function ClaimsSection({
     );
   }
 
-  const canBulkApprove = isClaimsActionable && stats.pending > 0 && !bulkApproveMutation.isPending;
+  const isBulkActionPending = bulkApproveMutation.isPending || bulkRejectMutation.isPending;
 
   return (
     <div className="space-y-3" data-testid="claims-section">
@@ -218,20 +343,23 @@ export function ClaimsSection({
           )}
         </div>
         {isClaimsActionable && (
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => bulkApproveMutation.mutate()}
-            disabled={!canBulkApprove}
-            data-testid="bulk-approve-button"
+          <Select
+            value=""
+            onValueChange={value => setBulkAction(value as BulkActionKind)}
+            disabled={isBulkActionPending}
           >
-            {bulkApproveMutation.isPending ? (
-              <Loader2Icon className="mr-1 h-4 w-4 animate-spin" />
-            ) : (
-              <CheckIcon className="mr-1 h-4 w-4" />
-            )}
-            Bulk approve pending ({stats.pending})
-          </Button>
+            <SelectTrigger className="w-64" data-testid="bulk-action-select">
+              <SelectValue placeholder="Bulk action…" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="approve-pending" disabled={pendingClaims.length === 0}>
+                Approve all pending ({pendingClaims.length})
+              </SelectItem>
+              <SelectItem value="reject-long-quote" disabled={longQuoteClaims.length === 0}>
+                Reject all with quote &gt;20 words ({longQuoteClaims.length})
+              </SelectItem>
+            </SelectContent>
+          </Select>
         )}
       </div>
 
@@ -262,11 +390,26 @@ export function ClaimsSection({
             claims={sectionClaims}
             isActionable={isClaimsActionable}
             pendingClaimId={pendingClaimId}
-            onApprove={id => approveMutation.mutate(id)}
+            pdfDocumentId={pdfDocumentId}
+            onApprove={claim => setApproveTarget(claim)}
             onReject={claim => setRejectTarget(claim)}
+            onOpenCitation={setCitationTarget}
           />
         ))}
       </div>
+
+      <ApproveClaimDialog
+        open={!!approveTarget}
+        onOpenChange={open => {
+          if (!open) setApproveTarget(null);
+        }}
+        onConfirm={note => {
+          if (!approveTarget) return;
+          approveMutation.mutate({ claimId: approveTarget.id, note });
+        }}
+        isPending={approveMutation.isPending}
+        claimPreview={approveTarget ? truncate(approveTarget.text, 120) : undefined}
+      />
 
       <RejectClaimDialog
         open={!!rejectTarget}
@@ -280,6 +423,29 @@ export function ClaimsSection({
         isPending={rejectMutation.isPending}
         claimPreview={rejectTarget ? truncate(rejectTarget.text, 120) : undefined}
       />
+
+      <BulkActionDialog
+        open={!!bulkAction}
+        onOpenChange={open => {
+          if (!open) setBulkAction(null);
+        }}
+        title={bulkActionTitle}
+        count={bulkActionTargets.length}
+        onConfirm={handleBulkActionConfirm}
+        isPending={isBulkActionPending}
+      />
+
+      {citationTarget && (
+        <PdfQuoteHighlighter
+          open={!!citationTarget}
+          onOpenChange={open => {
+            if (!open) setCitationTarget(null);
+          }}
+          documentId={citationTarget.documentId}
+          page={citationTarget.page}
+          quote={citationTarget.quote}
+        />
+      )}
     </div>
   );
 }
@@ -289,8 +455,10 @@ interface SectionGroupProps {
   claims: MechanicClaimDto[];
   isActionable: boolean;
   pendingClaimId: string | null;
-  onApprove: (claimId: string) => void;
+  pdfDocumentId?: string;
+  onApprove: (claim: MechanicClaimDto) => void;
   onReject: (claim: MechanicClaimDto) => void;
+  onOpenCitation: (target: CitationTarget) => void;
 }
 
 function SectionGroup({
@@ -298,8 +466,10 @@ function SectionGroup({
   claims,
   isActionable,
   pendingClaimId,
+  pdfDocumentId,
   onApprove,
   onReject,
+  onOpenCitation,
 }: SectionGroupProps): React.JSX.Element {
   const [expanded, setExpanded] = useState(true);
   const label = MECHANIC_SECTION_LABELS[section] ?? `Section ${section}`;
@@ -335,8 +505,10 @@ function SectionGroup({
               claim={claim}
               isActionable={isActionable}
               isPending={pendingClaimId === claim.id}
-              onApprove={() => onApprove(claim.id)}
+              pdfDocumentId={pdfDocumentId}
+              onApprove={() => onApprove(claim)}
               onReject={() => onReject(claim)}
+              onOpenCitation={onOpenCitation}
             />
           ))}
         </ul>
@@ -349,8 +521,10 @@ interface ClaimRowProps {
   claim: MechanicClaimDto;
   isActionable: boolean;
   isPending: boolean;
+  pdfDocumentId?: string;
   onApprove: () => void;
   onReject: () => void;
+  onOpenCitation: (target: CitationTarget) => void;
 }
 
 /**
@@ -365,8 +539,10 @@ function ClaimRow({
   claim,
   isActionable,
   isPending,
+  pdfDocumentId,
   onApprove,
   onReject,
+  onOpenCitation,
 }: ClaimRowProps): React.JSX.Element {
   const [showCitations, setShowCitations] = useState(false);
   const [textExpanded, setTextExpanded] = useState(false);
@@ -405,8 +581,17 @@ function ClaimRow({
               <strong>Rejection:</strong> {claim.rejectionNote}
             </p>
           )}
+          {claim.reviewNote && (
+            <p
+              className="mt-1 rounded border border-green-200 bg-green-50 p-1 text-xs text-green-800 break-words"
+              data-testid={`claim-review-note-${claim.id}`}
+            >
+              <strong>Note:</strong> {claim.reviewNote}
+            </p>
+          )}
         </div>
         <div className="flex flex-shrink-0 flex-wrap items-center gap-2">
+          <ValidationBadges validations={claim.validations} />
           <Badge
             variant="outline"
             className={CLAIM_STATUS_BADGE_CLASS[status] ?? ''}
@@ -461,10 +646,28 @@ function ClaimRow({
             <ul className="mt-1 space-y-1 border-l-2 border-sky-200 pl-3 text-xs">
               {claim.citations.map(c => (
                 <li key={c.id} className="text-muted-foreground">
-                  <span className="font-medium text-foreground">
-                    p.{c.pdfPage}
-                  </span>{' '}
-                  — &ldquo;{c.quote}&rdquo;
+                  {pdfDocumentId ? (
+                    <button
+                      type="button"
+                      className="text-left hover:underline"
+                      onClick={() =>
+                        onOpenCitation({
+                          documentId: pdfDocumentId,
+                          page: c.pdfPage,
+                          quote: c.quote,
+                        })
+                      }
+                      data-testid={`claim-citation-open-${c.id}`}
+                    >
+                      <span className="font-medium text-foreground">p.{c.pdfPage}</span> — &ldquo;
+                      {c.quote}&rdquo;
+                    </button>
+                  ) : (
+                    <>
+                      <span className="font-medium text-foreground">p.{c.pdfPage}</span> — &ldquo;
+                      {c.quote}&rdquo;
+                    </>
+                  )}
                 </li>
               ))}
             </ul>

--- a/apps/web/src/components/admin/mechanic-extractor/claims/__tests__/ClaimsSection.approveNote.test.tsx
+++ b/apps/web/src/components/admin/mechanic-extractor/claims/__tests__/ClaimsSection.approveNote.test.tsx
@@ -1,0 +1,68 @@
+/** @vitest-environment jsdom */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+const mockGetClaims = vi.hoisted(() => vi.fn());
+const mockApprove = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/api/clients/adminClient', () => ({
+  createAdminClient: () => ({
+    getMechanicAnalysisClaims: mockGetClaims,
+    approveMechanicClaim: mockApprove,
+  }),
+}));
+const MockHttpClient = vi.hoisted(() => class MockHttpClient {});
+vi.mock('@/lib/api/core/httpClient', () => ({ HttpClient: MockHttpClient }));
+
+import { ClaimsSection } from '../ClaimsSection';
+
+const claim = {
+  id: 'd1',
+  analysisId: 'a',
+  section: 1,
+  text: 't',
+  displayOrder: 0,
+  status: 0,
+  reviewedBy: null,
+  reviewedAt: null,
+  rejectionNote: null,
+  reviewNote: null,
+  validations: [],
+  citations: [],
+};
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+
+describe('ClaimsSection approve with note', () => {
+  it('sends the optional note on approve', async () => {
+    mockGetClaims.mockResolvedValue([claim]);
+    mockApprove.mockResolvedValue({ ...claim, status: 1, reviewNote: 'matches p.4' });
+    render(<ClaimsSection analysisId="a" />, { wrapper: Wrapper });
+    fireEvent.click(await screen.findByTestId('claim-approve-d1'));
+    expect(screen.getByTestId('approve-claim-note-input')).toHaveAttribute('maxLength', '2000');
+    fireEvent.change(screen.getByTestId('approve-claim-note-input'), {
+      target: { value: 'matches p.4' },
+    });
+    fireEvent.click(screen.getByTestId('approve-claim-confirm'));
+    await waitFor(() => expect(mockApprove).toHaveBeenCalledWith('a', 'd1', 'matches p.4'));
+  });
+
+  it('allows confirming with no note (note is optional)', async () => {
+    mockGetClaims.mockResolvedValue([claim]);
+    mockApprove.mockResolvedValue({ ...claim, status: 1, reviewNote: null });
+    render(<ClaimsSection analysisId="a" />, { wrapper: Wrapper });
+    fireEvent.click(await screen.findByTestId('claim-approve-d1'));
+    expect(screen.getByTestId('approve-claim-confirm')).not.toBeDisabled();
+    fireEvent.click(screen.getByTestId('approve-claim-confirm'));
+    await waitFor(() => expect(mockApprove).toHaveBeenCalledWith('a', 'd1', undefined));
+  });
+
+  it('renders the reviewNote in a green block after refetch', async () => {
+    mockGetClaims.mockResolvedValue([{ ...claim, status: 1, reviewNote: 'matches p.4' }]);
+    render(<ClaimsSection analysisId="a" />, { wrapper: Wrapper });
+    expect(await screen.findByTestId('claim-review-note-d1')).toHaveTextContent('matches p.4');
+  });
+});

--- a/apps/web/src/components/admin/mechanic-extractor/claims/__tests__/ClaimsSection.badges.test.tsx
+++ b/apps/web/src/components/admin/mechanic-extractor/claims/__tests__/ClaimsSection.badges.test.tsx
@@ -1,0 +1,36 @@
+/** @vitest-environment jsdom */
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { ValidationBadges } from '../ClaimsSection';
+
+describe('ValidationBadges', () => {
+  it('renders one badge per rule with pass/fail/notRun styling + aria-label', () => {
+    render(
+      <ValidationBadges
+        validations={[
+          { rule: 'T1', outcome: 'pass', message: null },
+          { rule: 'T2', outcome: 'fail', message: 'too long' },
+          { rule: 'T3', outcome: 'notRun', message: null },
+        ]}
+      />
+    );
+    expect(screen.getByTestId('claim-validation-badge-T1')).toHaveAttribute(
+      'aria-label',
+      expect.stringMatching(/T1.*pass/i)
+    );
+    expect(screen.getByTestId('claim-validation-badge-T2')).toHaveAttribute(
+      'aria-label',
+      expect.stringMatching(/T2.*fail/i)
+    );
+    expect(screen.getByTestId('claim-validation-badge-T3')).toHaveAttribute(
+      'aria-label',
+      expect.stringMatching(/T3.*not/i)
+    );
+  });
+
+  it('returns null when validations is empty', () => {
+    const { container } = render(<ValidationBadges validations={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/apps/web/src/components/admin/mechanic-extractor/claims/__tests__/ClaimsSection.bulk.test.tsx
+++ b/apps/web/src/components/admin/mechanic-extractor/claims/__tests__/ClaimsSection.bulk.test.tsx
@@ -1,0 +1,113 @@
+/** @vitest-environment jsdom */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, fireEvent, within, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+const mockGetClaims = vi.hoisted(() => vi.fn());
+const mockBulkApprove = vi.hoisted(() => vi.fn());
+const mockBulkReject = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/api/clients/adminClient', () => ({
+  createAdminClient: () => ({
+    getMechanicAnalysisClaims: mockGetClaims,
+    bulkApproveMechanicClaims: mockBulkApprove,
+    bulkRejectMechanicClaims: mockBulkReject,
+  }),
+}));
+const MockHttpClient = vi.hoisted(() => class MockHttpClient {});
+vi.mock('@/lib/api/core/httpClient', () => ({ HttpClient: MockHttpClient }));
+
+import { ClaimsSection } from '../ClaimsSection';
+
+const longQuote = Array.from({ length: 25 }, (_, i) => `w${i}`).join(' ');
+const claims = [
+  {
+    id: 'd1',
+    analysisId: 'a',
+    section: 1,
+    text: 't1',
+    displayOrder: 0,
+    status: 0,
+    reviewedBy: null,
+    reviewedAt: null,
+    rejectionNote: null,
+    reviewNote: null,
+    validations: [],
+    citations: [{ id: 'c1', pdfPage: 1, quote: longQuote, displayOrder: 0 }],
+  },
+  {
+    id: 'd2',
+    analysisId: 'a',
+    section: 1,
+    text: 't2',
+    displayOrder: 1,
+    status: 0,
+    reviewedBy: null,
+    reviewedAt: null,
+    rejectionNote: null,
+    reviewNote: null,
+    validations: [],
+    citations: [{ id: 'c2', pdfPage: 1, quote: 'short quote', displayOrder: 0 }],
+  },
+];
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+
+describe('ClaimsSection bulk reject by quote length', () => {
+  it('rejects only the >20-word-quote claim after count-confirm', async () => {
+    mockGetClaims.mockResolvedValue(claims);
+    mockBulkReject.mockResolvedValue({ rejectedCount: 1, skippedAlreadyRejectedCount: 0, claims });
+    render(<ClaimsSection analysisId="a" />, { wrapper: Wrapper });
+
+    const select = await screen.findByTestId('bulk-action-select');
+    fireEvent.click(select);
+    const listbox = await screen.findByRole('listbox');
+    fireEvent.click(within(listbox).getByText(/Reject all with quote >20 words/));
+
+    expect(screen.getByTestId('bulk-action-count')).toHaveTextContent('1');
+    fireEvent.click(screen.getByTestId('bulk-action-confirm'));
+
+    await waitFor(() =>
+      expect(mockBulkReject).toHaveBeenCalledWith(
+        'a',
+        expect.objectContaining({ claimIds: ['d1'] })
+      )
+    );
+  });
+
+  it('shows amber warning when bulk-reject skips already-rejected claims', async () => {
+    mockGetClaims.mockResolvedValue(claims);
+    mockBulkReject.mockResolvedValue({
+      rejectedCount: 1,
+      skippedAlreadyRejectedCount: 1,
+      claims,
+    });
+    render(<ClaimsSection analysisId="a" />, { wrapper: Wrapper });
+
+    const select = await screen.findByTestId('bulk-action-select');
+    fireEvent.click(select);
+    const listbox = await screen.findByRole('listbox');
+    fireEvent.click(within(listbox).getByText(/Reject all with quote >20 words/));
+    fireEvent.click(screen.getByTestId('bulk-action-confirm'));
+
+    expect(await screen.findByTestId('claims-action-warning')).toHaveTextContent(/1/);
+  });
+
+  it('approve-pending option calls the existing bulk-approve mutation', async () => {
+    mockGetClaims.mockResolvedValue(claims);
+    mockBulkApprove.mockResolvedValue({ approvedCount: 2, skippedRejectedCount: 0, claims });
+    render(<ClaimsSection analysisId="a" />, { wrapper: Wrapper });
+
+    const select = await screen.findByTestId('bulk-action-select');
+    fireEvent.click(select);
+    const listbox = await screen.findByRole('listbox');
+    fireEvent.click(within(listbox).getByText(/Approve all pending/));
+
+    expect(screen.getByTestId('bulk-action-count')).toHaveTextContent('2');
+    fireEvent.click(screen.getByTestId('bulk-action-confirm'));
+
+    await waitFor(() => expect(mockBulkApprove).toHaveBeenCalledWith('a'));
+  });
+});

--- a/apps/web/src/components/admin/mechanic-extractor/claims/__tests__/ClaimsSection.citation.test.tsx
+++ b/apps/web/src/components/admin/mechanic-extractor/claims/__tests__/ClaimsSection.citation.test.tsx
@@ -1,0 +1,66 @@
+/** @vitest-environment jsdom */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+const mockGetClaims = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/api/clients/adminClient', () => ({
+  createAdminClient: () => ({ getMechanicAnalysisClaims: mockGetClaims }),
+}));
+const MockHttpClient = vi.hoisted(() => class MockHttpClient {});
+vi.mock('@/lib/api/core/httpClient', () => ({ HttpClient: MockHttpClient }));
+const mockHighlighter = vi.hoisted(() => vi.fn());
+vi.mock('@/components/pdf/PdfQuoteHighlighter', () => ({
+  PdfQuoteHighlighter: (props: Record<string, unknown>) => {
+    mockHighlighter(props);
+    return props.open ? <div data-testid="highlighter-open" /> : null;
+  },
+}));
+
+import { ClaimsSection } from '../ClaimsSection';
+
+const claim = {
+  id: 'dddddddd-dddd-4ddd-8ddd-dddddddddddd',
+  analysisId: 'a',
+  section: 1,
+  text: 't',
+  displayOrder: 0,
+  status: 0,
+  reviewedBy: null,
+  reviewedAt: null,
+  rejectionNote: null,
+  reviewNote: null,
+  validations: [],
+  citations: [{ id: 'c1', pdfPage: 4, quote: 'score one point', displayOrder: 0 }],
+};
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+
+describe('ClaimsSection citation viewer', () => {
+  it('opens PdfQuoteHighlighter with documentId/page/quote on citation click', async () => {
+    mockGetClaims.mockResolvedValue([claim]);
+    render(<ClaimsSection analysisId="a" pdfDocumentId="pdf-99" />, { wrapper: Wrapper });
+    // expand citations then click
+    fireEvent.click(await screen.findByTestId(`claim-citations-toggle-${claim.id}`));
+    fireEvent.click(screen.getByTestId('claim-citation-open-c1'));
+    expect(mockHighlighter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        documentId: 'pdf-99',
+        page: 4,
+        quote: 'score one point',
+        open: true,
+      })
+    );
+  });
+
+  it('renders citations as plain text (no button) when pdfDocumentId is absent', async () => {
+    mockGetClaims.mockResolvedValue([claim]);
+    render(<ClaimsSection analysisId="a" />, { wrapper: Wrapper });
+    fireEvent.click(await screen.findByTestId(`claim-citations-toggle-${claim.id}`));
+    expect(screen.queryByTestId('claim-citation-open-c1')).not.toBeInTheDocument();
+    expect(screen.getByText(/score one point/)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/pdf/PdfInlineViewer.tsx
+++ b/apps/web/src/components/pdf/PdfInlineViewer.tsx
@@ -22,6 +22,7 @@ import {
   useState,
   useEffect,
   useCallback,
+  useMemo,
   useRef,
   type ChangeEvent,
   type FormEvent,
@@ -34,6 +35,8 @@ import 'react-pdf/dist/Page/AnnotationLayer.css';
 import 'react-pdf/dist/Page/TextLayer.css';
 
 import { api } from '@/lib/api';
+
+import { makeQuoteTextRenderer } from './pdf-quote-highlight';
 
 // Worker setup — T0 spike confirmed idempotent (multi-module assignment safe).
 pdfjs.GlobalWorkerOptions.workerSrc = new URL(
@@ -55,6 +58,9 @@ export interface PdfInlineViewerProps {
   readonly defaultZoom?: 'fit-width' | number;
   readonly features?: PdfInlineViewerFeatures;
   readonly className?: string;
+  readonly renderTextLayer?: boolean;
+  readonly highlightQuote?: string;
+  readonly onQuoteMatch?: (found: boolean) => void;
 }
 
 type ZoomState = 'fit-width' | number;
@@ -69,6 +75,9 @@ export function PdfInlineViewer({
   defaultZoom = 'fit-width',
   features = {},
   className,
+  renderTextLayer = false,
+  highlightQuote,
+  onQuoteMatch,
 }: PdfInlineViewerProps): ReactElement {
   const [numPages, setNumPages] = useState<number>(0);
   const [currentPage, setCurrentPage] = useState<number>(initialPage);
@@ -81,6 +90,11 @@ export function PdfInlineViewer({
   const containerRef = useRef<HTMLDivElement>(null);
 
   const downloadUrl = api.pdf.getPdfDownloadUrl(documentId);
+
+  const quoteRenderer = useMemo(
+    () => (highlightQuote ? makeQuoteTextRenderer(highlightQuote) : null),
+    [highlightQuote]
+  );
 
   const onDocumentLoadSuccess = useCallback(({ numPages: n }: { numPages: number }) => {
     setNumPages(n);
@@ -291,7 +305,15 @@ export function PdfInlineViewer({
               pageNumber={currentPage}
               scale={scale}
               renderAnnotationLayer={false}
-              renderTextLayer={false}
+              renderTextLayer={renderTextLayer || !!highlightQuote}
+              customTextRenderer={
+                quoteRenderer ? ({ str }) => quoteRenderer.render({ str }) : undefined
+              }
+              onRenderTextLayerSuccess={
+                quoteRenderer && onQuoteMatch
+                  ? () => onQuoteMatch(quoteRenderer.matched())
+                  : undefined
+              }
             />
           </Document>
         )}

--- a/apps/web/src/components/pdf/PdfQuoteHighlighter.tsx
+++ b/apps/web/src/components/pdf/PdfQuoteHighlighter.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/overlays/dialog';
+
+import { PdfInlineViewer } from './PdfInlineViewer';
+
+export interface PdfQuoteHighlighterProps {
+  readonly open: boolean;
+  readonly onOpenChange: (open: boolean) => void;
+  readonly documentId: string;
+  readonly page: number;
+  readonly quote: string;
+}
+
+/**
+ * #526 AC-2 / #530 AD-1 — shared citation quote viewer. Opens the source PDF at `page`, highlights
+ * `quote` via PdfInlineViewer's text-layer search (Pattern A), and shows a page-level fallback
+ * banner when the quote can't be located automatically. Consumed by admin review (#526) and,
+ * later, #528 public card + #530 chat citations.
+ */
+export function PdfQuoteHighlighter({
+  open,
+  onOpenChange,
+  documentId,
+  page,
+  quote,
+}: PdfQuoteHighlighterProps): React.JSX.Element {
+  const [matched, setMatched] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    if (open) setMatched(null); // reset per open
+  }, [open, documentId, page, quote]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-4xl">
+        <DialogHeader>
+          <DialogTitle>Citazione — p.{page}</DialogTitle>
+        </DialogHeader>
+        {matched === false && (
+          <div
+            className="rounded-md border border-amber-300 bg-amber-50 p-2 text-xs text-amber-900"
+            role="status"
+            data-testid="pdf-quote-fallback"
+          >
+            Quote non individuabile automaticamente a p.{page}; verifica manualmente.
+          </div>
+        )}
+        <div className="max-h-[70vh] overflow-auto">
+          <PdfInlineViewer
+            documentId={documentId}
+            initialPage={page}
+            highlightQuote={quote}
+            onQuoteMatch={setMatched}
+            features={{ jumpToPage: true, zoom: true }}
+          />
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/pdf/__tests__/PdfQuoteHighlighter.test.tsx
+++ b/apps/web/src/components/pdf/__tests__/PdfQuoteHighlighter.test.tsx
@@ -1,0 +1,20 @@
+/** @vitest-environment jsdom */
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../PdfInlineViewer', () => ({
+  PdfInlineViewer: ({ onQuoteMatch }: { onQuoteMatch?: (f: boolean) => void }) => {
+    onQuoteMatch?.(false); // simulate "not found" → banner should show
+    return <div data-testid="pdf-inline-viewer" />;
+  },
+}));
+
+import { PdfQuoteHighlighter } from '../PdfQuoteHighlighter';
+
+describe('PdfQuoteHighlighter', () => {
+  it('shows the fallback banner when the quote is not matched', () => {
+    render(<PdfQuoteHighlighter open onOpenChange={() => {}} documentId="d1" page={4} quote="x" />);
+    expect(screen.getByTestId('pdf-inline-viewer')).toBeInTheDocument();
+    expect(screen.getByTestId('pdf-quote-fallback')).toHaveTextContent(/verifica manualmente/i);
+  });
+});

--- a/apps/web/src/components/pdf/__tests__/pdf-quote-highlight.test.ts
+++ b/apps/web/src/components/pdf/__tests__/pdf-quote-highlight.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeQuoteText, makeQuoteTextRenderer } from '../pdf-quote-highlight';
+
+describe('pdf-quote-highlight', () => {
+  it('normalizes whitespace, soft hyphens, case', () => {
+    expect(normalizeQuoteText('Score  1­point\nper  Road')).toBe('score 1point per road');
+  });
+
+  it('wraps text items contained in the quote and reports a match', () => {
+    const r = makeQuoteTextRenderer('players score one point per road');
+    expect(r.render({ str: 'score one point' })).toContain('<mark');
+    expect(r.render({ str: 'per road' })).toContain('<mark');
+    expect(r.matched()).toBe(true);
+  });
+
+  it('escapes HTML and does not wrap non-quote items', () => {
+    const r = makeQuoteTextRenderer('players score one point');
+    expect(r.render({ str: '<b>bonus</b>' })).toBe('&lt;b&gt;bonus&lt;/b&gt;');
+    expect(r.matched()).toBe(false);
+  });
+
+  it('ignores trivially short items to reduce false positives', () => {
+    const r = makeQuoteTextRenderer('a player scores one point');
+    expect(r.render({ str: 'a' })).toBe('a'); // len<=2 not wrapped
+  });
+});

--- a/apps/web/src/components/pdf/pdf-quote-highlight.ts
+++ b/apps/web/src/components/pdf/pdf-quote-highlight.ts
@@ -1,0 +1,37 @@
+/** Normalize for tolerant substring matching: lowercase, strip soft hyphens, collapse whitespace. */
+export function normalizeQuoteText(s: string): string {
+  return s.replace(/­/g, '').toLowerCase().replace(/\s+/g, ' ').trim();
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+/**
+ * Best-effort per-item highlighter for react-pdf `customTextRenderer` (AC-2 Pattern A).
+ * A text item is wrapped in <mark> when its normalized string (len>2) is a substring of the
+ * normalized quote. Imperfect for very common short items — the caller shows a fallback banner
+ * via `matched()`. FU could upgrade to contiguous-run matching or Pattern-B coordinates.
+ */
+export function makeQuoteTextRenderer(quote: string): {
+  render: (item: { str: string }) => string;
+  matched: () => boolean;
+} {
+  const normQuote = normalizeQuoteText(quote);
+  let didMatch = false;
+  return {
+    render: ({ str }) => {
+      const norm = normalizeQuoteText(str);
+      if (norm.length > 2 && normQuote.includes(norm)) {
+        didMatch = true;
+        return `<mark class="pdf-quote-highlight">${escapeHtml(str)}</mark>`;
+      }
+      return escapeHtml(str);
+    },
+    matched: () => didMatch,
+  };
+}

--- a/apps/web/src/components/ui/state-preview/__tests__/state-preview-loader.test.tsx
+++ b/apps/web/src/components/ui/state-preview/__tests__/state-preview-loader.test.tsx
@@ -1,0 +1,73 @@
+/**
+ * StatePreview loader — SSR regression tests (Issue #2770).
+ *
+ * The loader wraps `<AppContent>{children}</AppContent>` for the ENTIRE app
+ * (via providers.tsx). It previously mounted the provider with
+ * `next/dynamic({ ssr: false })`, which throws `BailoutToCSR` during server
+ * rendering and forced React to client-render the whole subtree — disabling
+ * SSR for every route. The staging login form only appeared after (heavy)
+ * client hydration, causing the flaky E2E "Auth login form visibile".
+ *
+ * These tests lock in the fix: in production the loader MUST render its
+ * children server-side (no ssr:false bailout). We assert this at the unit
+ * level with `renderToString` so the guarantee survives future refactors
+ * without needing a full `next build` + curl.
+ */
+
+import type { ComponentType, ReactNode } from 'react';
+
+import { renderToString } from 'react-dom/server';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { StatePreviewProviderProps } from '../state-preview-types';
+
+const CHILD_MARKER = 'ssr-child-marker-2770';
+
+/**
+ * Re-import the loader with a fresh module registry so the module-level
+ * `process.env.NODE_ENV` branch is re-evaluated under the stubbed env.
+ */
+async function loadProvider(): Promise<ComponentType<StatePreviewProviderProps>> {
+  vi.resetModules();
+  const mod = await import('../state-preview-loader');
+  return mod.StatePreviewProvider;
+}
+
+function Child(): ReactNode {
+  return <div data-testid="ssr-child">{CHILD_MARKER}</div>;
+}
+
+describe('StatePreviewProvider loader — SSR (Issue #2770)', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+  });
+
+  it('server-renders children in production (no ssr:false CSR bailout)', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    const StatePreviewProvider = await loadProvider();
+
+    const html = renderToString(
+      <StatePreviewProvider>
+        <Child />
+      </StatePreviewProvider>
+    );
+
+    // The child MUST be present in the server-rendered HTML. With the old
+    // `dynamic({ ssr: false })` loader this string was absent (bailout → null).
+    expect(html).toContain(CHILD_MARKER);
+  });
+
+  it('renders children (pass-through) so it never gates the app tree', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    const StatePreviewProvider = await loadProvider();
+
+    const html = renderToString(
+      <StatePreviewProvider>
+        <Child />
+      </StatePreviewProvider>
+    );
+
+    expect(html).toContain('data-testid="ssr-child"');
+  });
+});

--- a/apps/web/src/components/ui/state-preview/state-preview-loader.tsx
+++ b/apps/web/src/components/ui/state-preview/state-preview-loader.tsx
@@ -2,11 +2,30 @@
  * StatePreviewProvider dynamic loader — CANONICAL CONSUMER ENTRY POINT.
  *
  * Asse B WP5 T5 (Issue #1897). DEC-4 + CRIT-5: Next.js dead-code-elimination
- * combined with `dynamic({ssr:false, loading: () => null})` guarantees the
- * provider implementation is tree-shaken from production chunks (>99% strip).
+ * combined with a dev-only `next/dynamic` import guarantees the provider
+ * implementation is tree-shaken from production chunks (>99% strip).
  *
  * Verified via static analysis acceptance test in
  * `apps/web/__tests__/state-preview-tree-shake.test.ts`.
+ *
+ * ────────────────────────────────────────────────────────────────────────
+ * Issue #2770 — DO NOT pass `ssr: false` here.
+ *
+ * This provider wraps `<AppContent>{children}</AppContent>` for the ENTIRE
+ * app (providers.tsx). A `next/dynamic({ ssr: false })` component throws
+ * `BailoutToCSR` during server rendering; React then client-renders the whole
+ * subtree, so NO route emitted any body HTML server-side. The staging login
+ * form only appeared after heavy client hydration — the flaky E2E "Auth login
+ * form visibile" (the input exceeded the 30s timeout on the 3 GB headless VPS
+ * runner). Confirmed by curling the SSR HTML: it contained a single
+ * `BAILOUT_TO_CLIENT_SIDE_RENDERING` template and zero app content.
+ *
+ * Fix: StatePreview is a dev-only tool. In production we render children
+ * directly (a zero-cost pass-through) so SSR works for every route AND the
+ * provider impl tree-shakes out entirely (the dead `import()` below is
+ * eliminated once `process.env.NODE_ENV` is inlined). In development we load
+ * the real provider lazily WITHOUT `ssr: false`, so dev SSRs like production.
+ * ────────────────────────────────────────────────────────────────────────
  *
  * Consumers MUST import from the barrel `@/components/ui/state-preview`,
  * which re-exports this loader. Direct import of `state-preview-provider`
@@ -15,13 +34,33 @@
 
 'use client';
 
-import type { ComponentType } from 'react';
+import type { ComponentType, ReactNode } from 'react';
 
 import dynamic from 'next/dynamic';
 
 import type { StatePreviewProviderProps } from './state-preview-types';
 
-export const StatePreviewProvider: ComponentType<StatePreviewProviderProps> = dynamic(
-  () => import('./state-preview-provider').then(m => m.StatePreviewProvider),
-  { ssr: false, loading: () => null }
-);
+/**
+ * Production pass-through: renders children with no context wrapper. Safe
+ * because every consumer short-circuits in production — `useStatePreview`
+ * returns a fixed no-op and `StatePreviewToggle` renders null. Keeping this a
+ * plain synchronous component is what restores server-side rendering.
+ */
+function StatePreviewPassThrough({ children }: StatePreviewProviderProps): ReactNode {
+  return <>{children}</>;
+}
+
+/**
+ * Dev-only lazy provider. The `import()` lives in the dead branch of the
+ * build-time-constant ternary below, so production builds eliminate it and the
+ * heavy impl never reaches a client chunk. No `ssr: false` → the provider
+ * server-renders in dev (mirrors production), instead of bailing the app to
+ * client-side rendering.
+ */
+export const StatePreviewProvider: ComponentType<StatePreviewProviderProps> =
+  process.env.NODE_ENV === 'production'
+    ? StatePreviewPassThrough
+    : (dynamic(
+        () => import('./state-preview-provider').then(m => ({ default: m.StatePreviewProvider })),
+        { loading: () => null }
+      ) as ComponentType<StatePreviewProviderProps>);

--- a/apps/web/src/lib/api/clients/admin/adminContentClient.ts
+++ b/apps/web/src/lib/api/clients/admin/adminContentClient.ts
@@ -47,6 +47,7 @@ import {
 } from '../../schemas/entity-link.schemas';
 import {
   BulkApproveMechanicClaimsResponseDtoSchema,
+  BulkRejectMechanicClaimsResponseDtoSchema,
   MechanicAnalysisGenerationResponseDtoSchema,
   MechanicAnalysisLifecycleResponseDtoSchema,
   MechanicAnalysisListPageDtoSchema,
@@ -55,6 +56,8 @@ import {
   MechanicClaimsListSchema,
   MECHANIC_ANALYSES_ROUTES,
   type BulkApproveMechanicClaimsResponseDto,
+  type BulkRejectMechanicClaimsRequest,
+  type BulkRejectMechanicClaimsResponseDto,
   type GenerateMechanicAnalysisRequest,
   type MechanicAnalysisGenerationResponseDto,
   type MechanicAnalysisLifecycleResponseDto,
@@ -622,10 +625,14 @@ export function createAdminContentClient(http: HttpClient) {
       return result ?? [];
     },
 
-    async approveMechanicClaim(analysisId: string, claimId: string): Promise<MechanicClaimDto> {
+    async approveMechanicClaim(
+      analysisId: string,
+      claimId: string,
+      note?: string
+    ): Promise<MechanicClaimDto> {
       const result = await http.post(
         MECHANIC_ANALYSES_ROUTES.approveClaim(analysisId, claimId),
-        {},
+        note !== undefined ? { note } : {},
         MechanicClaimDtoSchema
       );
       if (!result) throw new Error('Failed to approve claim');
@@ -655,6 +662,19 @@ export function createAdminContentClient(http: HttpClient) {
         BulkApproveMechanicClaimsResponseDtoSchema
       );
       if (!result) throw new Error('Failed to bulk-approve claims');
+      return result;
+    },
+
+    async bulkRejectMechanicClaims(
+      analysisId: string,
+      request: BulkRejectMechanicClaimsRequest
+    ): Promise<BulkRejectMechanicClaimsResponseDto> {
+      const result = await http.post(
+        MECHANIC_ANALYSES_ROUTES.bulkRejectClaims(analysisId),
+        request,
+        BulkRejectMechanicClaimsResponseDtoSchema
+      );
+      if (!result) throw new Error('Failed to bulk-reject claims');
       return result;
     },
 

--- a/apps/web/src/lib/api/schemas/__tests__/mechanic-analyses.schemas.test.ts
+++ b/apps/web/src/lib/api/schemas/__tests__/mechanic-analyses.schemas.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import {
+  MechanicClaimDtoSchema,
+  BulkRejectMechanicClaimsResponseDtoSchema,
+} from '../mechanic-analyses.schemas';
+
+describe('mechanic-analyses schemas #526', () => {
+  it('parses validations[] + reviewNote on a claim', () => {
+    const parsed = MechanicClaimDtoSchema.parse({
+      id: '11111111-1111-4111-8111-111111111111',
+      analysisId: '22222222-2222-4222-8222-222222222222',
+      section: 1,
+      text: 't',
+      displayOrder: 0,
+      status: 0,
+      reviewedBy: null,
+      reviewedAt: null,
+      rejectionNote: null,
+      reviewNote: null,
+      citations: [],
+      validations: [{ rule: 'T1', outcome: 'pass', message: null }],
+    });
+    expect(parsed.validations[0].rule).toBe('T1');
+  });
+
+  it('parses bulk-reject response', () => {
+    const r = BulkRejectMechanicClaimsResponseDtoSchema.parse({
+      rejectedCount: 2,
+      skippedAlreadyRejectedCount: 0,
+      claims: [],
+    });
+    expect(r.rejectedCount).toBe(2);
+  });
+});

--- a/apps/web/src/lib/api/schemas/mechanic-analyses.schemas.ts
+++ b/apps/web/src/lib/api/schemas/mechanic-analyses.schemas.ts
@@ -233,6 +233,14 @@ export const MechanicCitationDtoSchema = z.object({
 });
 export type MechanicCitationDto = z.infer<typeof MechanicCitationDtoSchema>;
 
+/** Per-rule template validation outcome (#526 ME-M1.4). Currently always T1-T4, derived server-side. */
+export const MechanicClaimValidationDtoSchema = z.object({
+  rule: z.string(),
+  outcome: z.enum(['pass', 'fail', 'notRun']),
+  message: z.string().nullable().optional(),
+});
+export type MechanicClaimValidationDto = z.infer<typeof MechanicClaimValidationDtoSchema>;
+
 export const MechanicClaimDtoSchema = z.object({
   id: z.string().uuid(),
   analysisId: z.string().uuid(),
@@ -244,6 +252,8 @@ export const MechanicClaimDtoSchema = z.object({
   reviewedAt: z.string().nullable(),
   rejectionNote: z.string().nullable(),
   citations: z.array(MechanicCitationDtoSchema),
+  reviewNote: z.string().nullable(),
+  validations: z.array(MechanicClaimValidationDtoSchema),
 });
 export type MechanicClaimDto = z.infer<typeof MechanicClaimDtoSchema>;
 
@@ -288,6 +298,21 @@ export const BulkApproveMechanicClaimsResponseDtoSchema = z.object({
 export type BulkApproveMechanicClaimsResponseDto = z.infer<
   typeof BulkApproveMechanicClaimsResponseDtoSchema
 >;
+
+export const BulkRejectMechanicClaimsResponseDtoSchema = z.object({
+  rejectedCount: z.number().int(),
+  skippedAlreadyRejectedCount: z.number().int(),
+  claims: MechanicClaimsListSchema,
+});
+export type BulkRejectMechanicClaimsResponseDto = z.infer<
+  typeof BulkRejectMechanicClaimsResponseDtoSchema
+>;
+
+/** Body for `POST .../claims/bulk-reject` (#526). Reviewer id comes from the session. */
+export interface BulkRejectMechanicClaimsRequest {
+  claimIds: string[];
+  reason: string;
+}
 
 // ========== Request types ==========
 
@@ -350,6 +375,7 @@ export const MECHANIC_ANALYSES_ROUTES = {
   rejectClaim: (id: string, claimId: string) =>
     `/api/v1/admin/mechanic-analyses/${id}/claims/${claimId}/reject`,
   bulkApproveClaims: (id: string) => `/api/v1/admin/mechanic-analyses/${id}/claims/bulk-approve`,
+  bulkRejectClaims: (id: string) => `/api/v1/admin/mechanic-analyses/${id}/claims/bulk-reject`,
 } as const;
 
 export const MECHANIC_ANALYSES_PAGES = {

--- a/apps/web/src/lib/api/schemas/mechanic-analyses.schemas.ts
+++ b/apps/web/src/lib/api/schemas/mechanic-analyses.schemas.ts
@@ -343,6 +343,13 @@ export interface RejectMechanicClaimRequest {
 export const REJECT_CLAIM_NOTE_MIN_LENGTH = 1;
 export const REJECT_CLAIM_NOTE_MAX_LENGTH = 500;
 
+/**
+ * Local validation bound for the (optional) approve reviewer note. Mirrors
+ * `ApproveMechanicClaimCommandValidator.MaximumLength(2000)` and the
+ * `review_note` column (`varchar(2000)`).
+ */
+export const APPROVE_CLAIM_NOTE_MAX_LENGTH = 2000;
+
 // ========== Labels ==========
 
 export const MECHANIC_ANALYSIS_STATUS_LABELS: Record<number, string> = {

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -864,3 +864,12 @@
   max-width: 65ch;
   margin-inline: auto;
 }
+
+/* ============================================================================
+ * PdfInlineViewer — opt-in quote highlight (ME-M1.4 AC-2 base, #526)
+ * Marks text-layer spans matching a `highlightQuote` via customTextRenderer.
+ * ============================================================================ */
+
+.pdf-quote-highlight {
+  background-color: rgba(255, 235, 59, 0.4);
+}

--- a/docs/for-developers/audits/2026-07-09-todo-fixme-triage-q3.md
+++ b/docs/for-developers/audits/2026-07-09-todo-fixme-triage-q3.md
@@ -1,0 +1,57 @@
+# TODO/FIXME Triage — Q3 2026 gate
+
+> Quarterly cadence per umbrella **#564**. Gate date: 2026-07-01 (run 2026-07-09).
+> Previous run: 2026-05-22 interim (386 total). Baseline: 2026-04-26 (452 total).
+
+## Snapshot
+
+**Command**: `rg "TODO|FIXME" apps/ infra/ docs/` (excl. `node_modules`, `.next`, `dist`)
+
+**Total: 470 markers in 203 files** — under the 500 escalation threshold (§ umbrella "escalate if > 500").
+
+| Area | 2026-04-26 | 2026-05-22 | **2026-07-09** | Δ vs prev |
+|------|-----------:|-----------:|---------------:|:---------:|
+| **Total** | 452 | 386 | **470** | **+84** |
+| apps/web/e2e (aspirational stubs) | ~117 | 130 | 114 | −16 |
+| apps/web/src (frontend) | — | 151 | 142 | −9 |
+| apps/api/src (backend) | — | 5 | 5 | 0 |
+| apps/api/tests | — | 0 | 0 | 0 |
+| apps/orchestration-service | — | 1 | 1 | 0 |
+| infra/ | — | 6 | 6 | 0 |
+| docs/superpowers/specs (gap-analysis) | ~100 | 13 | 19 | +6 |
+| docs/ (non-specs) | ~50 | ~50 | **160** | **+110** |
+
+## Where the +84 came from
+
+Almost entirely **`docs/` non-specs (+110)**, offset by code cleanup (−25 across e2e + frontend src). The docs growth is **not code debt** — it is template/checklist content (e.g., the security-review template's `- [ ]` items, ADR/spec placeholders, operations runbook TODOs). These are documentation authoring artifacts, not actionable engineering debt, and are excluded from the "actionable" triage below.
+
+## Categorization of code markers
+
+### Backend src — 5, all tracked ✅
+- `GameToolkitRepository.cs:300-301` — architectural breadcrumb, tracked via **#1458** (`VersionSemver` producer).
+- `SessionTracking/README.md:231,253,254` — roadmap notes (GST-003 event emission, GST-005 UserLibrary integration).
+
+No untracked backend debt.
+
+### Frontend src — 142, dominated by tracked/aspirational
+- **`#807-followup` cluster (~55)** — `session-summary/*` (ConnectionBar 17, SessionKpiGrid 13, Confetti 7, …) + `gamebook/GameSearchCard` (5): all are `eslint-disable meepleai/no-inline-hsl-v2` rationale comments tracking the same DS follow-up (**#807** — entity color CSS vars need alpha-stop / multi-stop-gradient support before these inline HSL styles can be removed). **Tracked, valid-pending.**
+- **DS-17 mockup stubs** — `kb-detail/*`, other `features/*`: `TODO: implement per admin-mockups/…` / `extract props contract from mockup`. Tracked under the DS-17 umbrella **#2063**.
+- **e2e/spec stubs (114)** — epic-driven roadmap test stubs (e.g., `epic-4068-permission-flows.spec.ts`). Intentional/aspirational, not debt.
+
+### Net-new actionable (this cycle): 1 cluster → issue opened
+- **`useEntityActions.ts` (5)** — 5 entity quick-action handlers with placeholder navigation/fallback pending full UX (copy-code without toast, invite via navigation instead of modal, download/export/RSVP via `router.push`). Not broken (working fallback), but the intended UX is stubbed. → **opened #2776**.
+
+## Stale removal (this cycle): none
+
+No clearly-stale removable TODOs found. The `#807-followup` and DS-17 mockup markers are valid-pending (blocked on an upstream CSS-var feature and the DS-17 migration respectively); removing them would drop legitimate tracking. No PR-removal performed this gate.
+
+## Outcome
+
+| DoD item | Status |
+|----------|--------|
+| Run `rg` + diff vs previous | ✅ (470 vs 386, +84 — mostly docs template content) |
+| Net-new actionable → open issues | ✅ 1 issue (**#2776**, `useEntityActions` UX stubs) |
+| Stale TODOs → remove with PR | ✅ none this cycle (documented above) |
+| Update umbrella with snapshot + audit link | ✅ (this doc + umbrella comment) |
+
+**Escalation**: none (470 < 500). Next gate: **2026-10-01 (Q4)**.

--- a/docs/for-developers/security/2026-Q3-security-review.md
+++ b/docs/for-developers/security/2026-Q3-security-review.md
@@ -1,0 +1,377 @@
+# 🔒 Quarterly Security Review — Q3 2026
+
+> **Authored from**: `docs/for-developers/security/security-review-template.md` v2 (hardened post spec-panel review of #186)
+> **Issue**: #2655
+> **Status**: 🟢 Remediation complete — closeout report (draft at T0+8d, within SC-2 T0+14d deadline)
+
+**Review Period**: 2026-07-01 (T0) → 2026-09-30 (T0+90d)
+
+**Status timeline**:
+- T0 = 2026-07-01 (issue #2655 opened — Q3 quarter start)
+- T0+14d = 2026-07-15 (draft due — **ON TIME**: this draft authored 2026-07-09 = T0+8d)
+- T0+30d = 2026-07-31 (critical fix deadline — **already met**: all critical/high remediated 2026-07-07 = T0+6d)
+- T0+90d = 2026-09-30 (close deadline)
+
+### Execution note
+
+Unlike Q2 (which slipped ~3 weeks past T0+14d on doc blockers), Q3 remediation ran same-week: the review scan (7-auditor pass) surfaced **11 real authorization/SSRF findings**, all fixed and merged by 2026-07-07 (T0+6d), each via dedicated branch → TDD → adversarial code review → PR to `main-dev`. This report is the closeout artifact.
+
+---
+
+## 👥 RACI
+
+| Role | Person | Responsibility |
+|------|--------|----------------|
+| **Responsible** (executes) | `@DegrassiAaron` | Single-maintainer; runs scans, drafts report, coordinates fixes |
+| **Accountable** (owns outcome) | `@DegrassiAaron` | Sign-off |
+| **Consulted** | n/a (single-maintainer team) | — |
+| **Informed** | Future contributors via this doc | — |
+
+> ⚠️ **Single-maintainer context**: same person maintains the codebase and runs the review. Bus-factor mitigation: this report is the durable artifact; resume from §Action Items.
+
+---
+
+## Executive Summary
+
+**Overall Security Posture**: 🟢 **Good** — 0 critical, 0 high in dependencies; the sole open CodeQL "high" is test-code substring matching (false positive, dismissable). The material Q3 work was closing an **11-finding IDOR/SSRF cluster** that spanned 5 bounded contexts.
+
+### Snapshot at scan time (2026-07-07, frozen)
+
+| Source | Critical | High | Medium | Low | Total |
+|--------|----------|------|--------|-----|-------|
+| **Authorization audit (secrets-authz scan)** | 4 | 7 | 0 | 0 | **11** |
+| **CodeQL** | 0 | 2 | 4+ | — | **12** triaged |
+| **Backend deps (.NET)** | 0 | 0 | 1 (carried from Q2) | 0 | **1** |
+| **Frontend deps (pnpm)** | 0 | 0 | 5 | 3 | **8** |
+| **gitleaks (in-scope)** | 0 | 0 | 0 | 0 | **0** (not re-run this cycle; last clean Q2) |
+
+### State after remediation (2026-07-07)
+
+| Source | Critical | High | Medium | Low | Total | Δ |
+|--------|----------|------|--------|-----|-------|---|
+| **Authorization audit** | **0** | **0** | 0 | 0 | **0** | **−11** (all fixed + merged) |
+| **CodeQL** | 0 | **1** | 0 | — | **1** | **−11** (fixed/dismissed; 1 test-code FP remains, dismissable) |
+| **Backend deps (.NET)** | 0 | 0 | 1 | 0 | **1** | 0 (OTel — carried to §Action Items) |
+| **Frontend deps (pnpm)** | 0 | 0 | 5 | 3 | **8** | dev-only transitive; 0 runtime high/critical |
+
+### Key Findings
+
+1. **11 authorization/SSRF vulnerabilities** surfaced by the secrets-authz scan and **all remediated same-week** (see §1.6): 4 Critical GameSession IDOR (+ `/end` sibling), 2 High AgentMemory IDOR, 2 High CWE-639 query-string authz (+ `UpdateMediaCaption` sibling), 1 admin-impersonation `/end` IDOR, 2 SSRF (BggCoverDownloader, SlackWebhookClient). Identity is now 100% server-derived; SSRF paths reuse the shared `SsrfSafeHttpClient` (HTTPS-only + private-IP block, fail-closed).
+2. **12 CodeQL alerts triaged**: STEP 1–4 remediated (`safe-loader.ts` regex anchor #2742, `appsettings.json` empty password verified inert #2743, `ChannelDispatchHandler` MEDIUM cluster #2744) + 4 false positives dismissed with justification (enum values ≠ PII).
+3. **Sole open CodeQL "high"** (#652, `js/incomplete-url-substring-sanitization`) is in **test code** (`SharedGameDetailModal.test.tsx`) — a test asserting a URL substring, no production attack surface. Dismissable as FP.
+4. **Frontend deps clean of high/critical**: pnpm audit reports 8 vulns (3 low / 5 moderate), all **dev-only transitive** (playwright-lighthouse → sentry → @opentelemetry/core, etc.). No runtime exposure.
+5. **Adversarial review value**: on 3 of the 5 fix PRs, the adversarial code-review step surfaced a **sibling endpoint with the same hole** (the `/end` alias on GameSession, `UpdateMediaCaption`, the impersonation `/end` route) — fixed in the same PR. Fixing in the *handler* (not the route) covered duplicated/legacy routes automatically.
+
+### Next Quarter Priorities (Q4)
+
+1. Execute **P1.3 OpenTelemetry** coordinated upgrade (carried Q2→Q3→Q4; single Moderate GHSA-g94r-2vxg-569j).
+2. Execute **P1.4b Trivy** full-scope (image + fs + config scan + CI gate) — deferred Q2.
+3. **SBOM generation** cadence (deferred Q2 §2.3, Q3).
+4. **DAST baseline** (OWASP ZAP + Schemathesis) — deferred Q2 §5.
+5. Extract the cross-BC `SlackWebhookClient` SSRF guard into a SharedKernel primitive (pragmatic reuse of `SsrfSafeHttpClient` shipped in #2753; long-term consolidation).
+
+---
+
+## Continuity from Previous Quarter
+
+**Previous review**: [2026-Q2-security-review.md](./2026-Q2-security-review.md)
+
+**Q2 items carried forward** (Q2 §Continuity to Q3):
+
+| Item | Origin | Q3 disposition |
+|------|--------|----------------|
+| P1.1-B 2FA admin strict mode (post shadow-mode telemetry) | Q2 P1.1 | ⏳ Deferred to Q4 — shadow-mode adoption telemetry not yet confirmed ≥90% |
+| P1.3 OpenTelemetry coordinated upgrade | Q2 P1.3 | ⏳ Carried to Q4 — 1 Moderate, no exploit path, low priority |
+| P1.4b Trivy full scope | Q2 P1.4b | ⏳ Carried to Q4 (tooling install) |
+| SBOM generation | Q2 §2.3 | ⏳ Carried to Q4 |
+| DAST baseline | Q2 §5 | ⏳ Carried to Q4 |
+
+**Trend (rolling 3 quarters)**:
+
+| Metric | Q1 2026 | Q2 2026 | Q3 2026 | Direction |
+|--------|---------|---------|---------|-----------|
+| Critical findings (T0 snapshot) | TBD | 2 | 4 (authz IDOR) | ↑ then →0 same-week |
+| High findings (T0 snapshot) | TBD | 50 | 7 (authz) + 2 (CodeQL) | ↓ |
+| Critical carried forward (T0+90d) | TBD | 0 | 0 | → |
+| High carried forward | TBD | 0 | 0 (1 test-code FP dismissable) | → |
+| MTTR critical (days) | TBD | same-day | **6** (T0→fix) | ✅ ≤7 |
+
+> Note: the Q3 T0 critical count (4) is higher than Q2 (2), but these are *newly surfaced by a deeper authz-focused scan*, not a regression — and all closed within MTTR target.
+
+---
+
+## 0. Threat Model Refresh
+
+### 0.1 Attack Surface Inventory
+
+- [x] Public endpoints: OpenAPI at `/openapi/v1.json` (minimal API + MediatR/CQRS endpoints)
+- [x] Auth surfaces: cookie session, OAuth (Google/Discord/GitHub), 2FA TOTP, API keys, **admin impersonation** (this quarter's #9 finding)
+- [x] Data classification: PII (email, OAuth tokens), Secrets (hashes, API keys), Untrusted input (PDF uploads)
+- [x] Trust boundaries: browser → Cloudflare Tunnel → API → DB/Redis → AI sidecars; **outbound fetch** (BGG cover download, Slack webhook — this quarter's #10/#11 SSRF findings)
+- [x] Third-party integrations: BGG (freeze per ADR-059), OAuth providers, Slack webhook (admin-configured), embedding/reranker/PDF services
+
+### 0.2 STRIDE per Tier-1 BC (this quarter — authz focus)
+
+| BC | Spoofing | Tampering | Repudiation | Info Disclosure | DoS | Elevation |
+|----|----------|-----------|-------------|------------------|-----|-----------|
+| Authentication | ✅ | ✅ | ⚠️ | ✅ | ⚠️ | ✅ **impersonation `/end` IDOR fixed #2751** |
+| Administration | ✅ | ✅ | ✅ AuditLog | ✅ RBAC | ⚠️ | ✅ |
+| GameManagement (sessions) | ✅ | ✅ **ownership guard added #2746** | ⚠️ | ✅ | ⚠️ | ✅ **4 IDOR fixed** |
+| AgentMemory | ✅ | ✅ **group IDOR fixed #2747** | ⚠️ | ✅ | n/a | ✅ |
+| KnowledgeBase | n/a | ⚠️ prompt injection (RAG) | ⚠️ | ⚠️ | ❌ AI cost cap TBD | n/a |
+
+Legend: ✅ controlled · ⚠️ partial · ❌ gap
+
+### 0.3 Top Kill Chains (this quarter)
+
+#### Kill Chain 1: Cross-user session tampering (IDOR) — **CLOSED**
+- **Path**: authenticated user A guesses/enumerates session id owned by user B → `POST /sessions/{id}/complete|abandon|pause|resume|end` → mutates B's session state
+- **Preventive**: ownership guard in the command *handler* (`ForbiddenException` when `CreatedByUserId != requester`); not-found normalized to 404 (#2568)
+- **Validation test**: `Category=SecurityRegression` — TDD per fix PR #2746 (70/70 unit tests)
+
+#### Kill Chain 2: SSRF via admin-configured outbound fetch — **CLOSED**
+- **Path**: attacker-influenced `remoteImageUrl` (BGG cover) or admin-configured Slack webhook URL → server fetches internal/metadata endpoint (169.254.169.254, localhost services)
+- **Preventive**: `SsrfSafeHttpClient` validators — HTTPS-only + private-IP/loopback block, fail-closed — reused across both call sites (#2753)
+- **Validation test**: offline SSRF tests with IP literals (avoid DNS-flaky CI; RFC5737 `203.0.113.10` happy-path)
+
+### 0.4 Diff vs Q2 2026
+
+- **New attack surface reviewed**: outbound fetch paths (BGG cover downloader, Slack webhook) — previously unaudited for SSRF
+- **Reduced surface**: BGG user-side asset ban (ADR-059, #2123) removed browser→geekdo image fetches
+- **Deepened review**: this quarter's scan was authz-focused (IDOR across session/memory/media/chat/impersonation), surfacing findings prior CodeQL-only scans missed
+
+---
+
+## 1. CodeQL Security Scans
+
+### 1.1 Scan Results (current, 2026-07-09)
+
+**Open alerts**: **1 high + 2 warning** (queried live via `gh api code-scanning/alerts`).
+
+| Severity | Open now | Fixed this Q | Dismissed FP | Notes |
+|----------|----------|--------------|--------------|-------|
+| Critical | 0 | — | — | |
+| High | **1** | STEP 1 (#2742) | STEP 2 verified inert + 4 enum≠PII | The 1 open is test-code (see §1.2) |
+| Medium | 0 | STEP 3-4 (#2744) | | `ChannelDispatchHandler` cluster |
+| Warning | 2 | — | — | Informational |
+
+### 1.2 Sole open HIGH — triage (dismissable FP)
+
+- **Alert #652**: `js/incomplete-url-substring-sanitization`
+- **Location**: `apps/web/src/components/shared-games/__tests__/SharedGameDetailModal.test.tsx` (created 2026-05-22)
+- **Assessment**: **false positive** — the flagged substring URL check is inside a **test file** asserting a rendered link, not a production security control. No runtime attack surface.
+- **Action**: dismiss with justification `used-in-tests` (deferred to workshop; does not block posture).
+
+### 1.3 STEP 1–4 remediation (known CodeQL findings)
+
+| Step | Finding | Action | PR |
+|------|---------|--------|----|
+| 1 | 🟠 HIGH `js/regex/missing-regexp-anchor` — `safe-loader.ts:84` unanchored BGG-host substring regex (false beacon → false P1) | Replaced with hostname-parsed `isBlockedImageHost` (anchored). Real allowlist gate already safe. | **#2742 ✅** |
+| 2 | 🟠 HIGH `js/empty-password-in-configuration-file` — `appsettings.json:418` empty `Alerting:Email:Password` | Verified inert optional-auth placeholder (`Credentials=null` unless `Username` set). Documented; no secret committed. | **#2743 ✅** |
+| 3–4 | 🟡 MEDIUM `ChannelDispatchHandler` cluster (×4) | Remediated | **#2744 ✅** |
+| — | 4× false positives (enum values flagged as sensitive-info exposure — enum ≠ PII) | Dismissed with justification | operational |
+
+> Evidence: issue #2655 comments (2026-07-07 audit + remediation) + merged PRs.
+
+---
+
+## 1.6 Authorization & SSRF Remediation (headline Q3 work)
+
+> This section is the material Q3 outcome: 11 real findings from the secrets-authz scan, all fixed + merged 2026-07-07. Each PR: dedicated branch → TDD → adversarial code review → PR to `main-dev`.
+
+| # | Finding | Class (CWE) | Fix (handler-level) | PR | Status |
+|---|---------|-------------|---------------------|----|--------|
+| 1–4 | GameSession IDOR — `POST /sessions/{id}/complete\|abandon\|pause\|resume` mutable by any authenticated user | IDOR (CWE-639) | Ownership guard `ForbiddenException` when `CreatedByUserId != requester`; not-found → 404 | **#2746** (+ `/end` sibling surfaced by review) | ✅ merged |
+| 5–6 | AgentMemory group IDOR — read (#7) + preferences (#8) accessible cross-group | IDOR (CWE-639) | Server-derived group membership check | **#2747** | ✅ merged |
+| 7–8 | Media delete + chat delete — identity from query-string (client-controlled) | CWE-639 | Identity 100% server-derived; `ISessionRepository` resolves owning participant | **#2749** (+ `UpdateMediaCaption` sibling) | ✅ merged |
+| 9 | `POST /admin/impersonation/end` — any admin could revoke any session id (force-logout / kill another admin's impersonation) | IDOR / priv-esc (CWE-639) | Guard in `ImpersonationEndCommandHandler` (404/403/403/idempotent); handler-level fix covers duplicated legacy route; `/revoke` twin already protected | **#2751** | ✅ merged |
+| 10 | `BggCoverDownloader` fetched `remoteImageUrl` with no scheme/private-IP guard | SSRF (CWE-918) | Reuse `SsrfSafeHttpClient` (HTTPS-only + private-IP block, fail-closed) | **#2753** | ✅ merged |
+| 11 | `SlackWebhookClient` fetched admin-configured webhook URL with no guard | SSRF (CWE-918) | Reuse `SsrfSafeHttpClient` | **#2753** | ✅ merged |
+
+**Refuted during triage (documented, not fixed)**:
+- `N8nWebhookClient` — **not** SSRF: `BaseUrl` is deployment-config (not runtime-tainted); target is an intentional internal service (`localhost:5678`).
+- `DELETE /admin/sessions/{id}` — out of scope: general admin power, not an IDOR (admin role is authorized to delete any session by design).
+
+---
+
+## 2. Dependency & Supply Chain Security
+
+### 2.1 Backend Dependencies (.NET)
+
+**Not re-scanned this cycle** (dotnet restore + `--vulnerable` deferred). Carried from Q2: **1 Moderate** — `OpenTelemetry.Api 1.14.0` ([GHSA-g94r-2vxg-569j](https://github.com/advisories/GHSA-g94r-2vxg-569j)), transitive. Remediation = **P1.3 coordinated OTel upgrade**, carried Q2→Q3→Q4 (single Moderate, no exploit path).
+
+### 2.2 Frontend Dependencies (pnpm)
+
+**Scan Date**: 2026-07-09 · **Tool**: `pnpm audit --audit-level=moderate`
+
+**Total**: 8 vulnerabilities (3 low / 5 moderate / **0 high / 0 critical**).
+
+| Package | Severity | Path | Runtime/Dev |
+|---------|----------|------|-------------|
+| @opentelemetry/core (<2.8.0, W3C Baggage DoS) | Moderate | `playwright-lighthouse > lighthouse > @sentry/node > @opentelemetry/core` | **dev** |
+| (others — transitive) | low/moderate | dev tooling (lighthouse, playwright) | **dev** |
+
+**Runtime exposure**: **none** — all 8 are confined to dev/test tooling (Playwright, Lighthouse). No runtime path. No action required this quarter; will clear on the next dependency refresh.
+
+### 2.3 SBOM / 2.4 Provenance / IaC (deferred)
+
+⚠️ Still deferred (tooling not installed on maintainer workstation) — carried to Q4 as in Q2. Risk of deferral: low (observability, not remediation).
+
+### 2.5 GitHub Actions Audit
+
+- SHA-pinning gate (`validate-workflows.yml`) + `GITHUB_TOKEN` least-privilege — ✅ established Q2 (P1.2, PRs #782/#784), still enforced.
+- Dependabot — ✅ re-enabled Q2 (#767).
+
+---
+
+## 3. Security Best Practices Audit (Evidence-Based)
+
+> Q3 focus was the authorization audit (§1.6). Control table below reflects controls verified during the Q3 secrets-authz scan; unchanged rows inherit Q2 evidence.
+
+### 3.1 Authentication & Authorization
+
+| Control | Evidence Source | Last Verified | Status |
+|---------|----------------|---------------|--------|
+| Ownership guard on session mutations | `Category=SecurityRegression` tests (PR #2746) | 2026-07-07 | ✅ (fixed this Q) |
+| Identity server-derived (no client query-string authz) | PRs #2747/#2749 + tests | 2026-07-07 | ✅ (fixed this Q) |
+| Admin impersonation end/revoke authorized | `ImpersonationEndCommandHandler` guard + tests (#2751) | 2026-07-07 | ✅ (fixed this Q) |
+| RBAC on all admin endpoints | `RequireAdminSession()` middleware | 2026-05-06 (Q2) | ✅ |
+| Password hashing PBKDF2-SHA256 ≥210k | `PasswordHashingService.cs` | 2026-05-06 (Q2) | ✅ |
+| 2FA admin enforcement | shadow-mode (P1.1-A #780) | Q2 | ⚠️ strict mode pending (P1.1-B, Q4) |
+
+### 3.3 Input Sanitization & SSRF
+
+| Control | Evidence Source | Last Verified | Status |
+|---------|----------------|---------------|--------|
+| Outbound fetch SSRF guard (HTTPS-only + private-IP block, fail-closed) | `SsrfSafeHttpClient` reused in BggCoverDownloader + SlackWebhookClient (PR #2753) + offline IP-literal tests | 2026-07-07 | ✅ (added this Q) |
+| Parameterized queries only (EF Core) | grep `SqlRaw\|FromSqlRaw` sanctioned paths | 2026-05-06 (Q2) | ✅ |
+
+### 3.4 CORS & Security Headers
+
+Unchanged from Q2 (ADR-010 middleware): CSP, X-Frame-Options DENY, nosniff, HSTS, Referrer-Policy — all ✅ (verified via curl on the #2773 SSR standalone check, 2026-07-09).
+
+---
+
+## 6. Security Test Coverage — Regression Requirement
+
+> Per template v2 §6.3: every Critical/High fix this quarter has a regression test (fails pre-fix, passes post-fix, `Category=SecurityRegression`).
+
+| Finding cluster | Fix PR | Regression coverage |
+|-----------------|--------|---------------------|
+| GameSession IDOR (4 + `/end`) | #2746 | 70/70 unit tests; ownership-denied → `ForbiddenException`, cross-user → 403/404 |
+| AgentMemory group IDOR (2) | #2747 | cross-group access denied |
+| Query-string authz (2 + `UpdateMediaCaption`) | #2749 | server-derived identity; client-supplied id ignored |
+| Impersonation `/end` IDOR (#9) | #2751 | 404/403/403/idempotent matrix |
+| SSRF (BggCoverDownloader, SlackWebhookClient) | #2753 | offline IP-literal tests (private-IP blocked, HTTPS-only enforced, fail-closed) |
+
+All fixes followed TDD (test-first) with an adversarial code-review gate per PR.
+
+---
+
+## 9. Metrics & KPIs
+
+| Metric | This Q (Q3) | Last Q (Q2) | Target |
+|--------|-------------|-------------|--------|
+| Critical findings (T0) | 4 (authz IDOR) | 2 | 0 carried forward |
+| High findings (T0) | 7 (authz) + 2 (CodeQL) | 50 | ≤ last Q ✅ |
+| Critical carried forward (T0+90d) | 0 | 0 | 0 ✅ |
+| High carried forward | 0 (1 test-code FP dismissable) | 0 | ≤2 ✅ |
+| MTTR critical (days) | **6** | same-day | ≤7 ✅ |
+| Runtime dep high/critical | 0 | 0 (post-fix) | 0 ✅ |
+
+---
+
+## 10. Lessons Learned
+
+### What Went Well
+1. **Same-week remediation** — 11 findings surfaced and closed within T0+6d (MTTR critical = 6d, within ≤7 target). Draft on time (T0+8d) vs Q2's T0+35d slip.
+2. **Handler-level fixes covered duplicated/legacy routes** — fixing in the command handler (not the route binding) automatically protected sibling/alias endpoints (`/end`, `UpdateMediaCaption`, impersonation `/end`).
+3. **Adversarial code review surfaced siblings** — on 3/5 PRs the review found a same-pattern endpoint the scan missed; fixed in the same PR.
+4. **Shared SSRF primitive** — reusing `SsrfSafeHttpClient` across two call sites (fail-closed) avoided divergent guards.
+5. **Honest triage** — 2 candidate findings correctly *refuted* (`N8nWebhookClient` config-not-runtime; `DELETE /admin/sessions` general admin power) rather than force-fixed.
+
+### What Could Be Improved
+1. Backend dep scan (`dotnet list --vulnerable`) not re-run this cycle — relied on Q2 carry-forward.
+2. SBOM / IaC / DAST still deferred (4th consecutive quarter for some) — tooling install keeps slipping.
+3. Offline SSRF happy-path initially used a real hostname → DNS-flaky CI; corrected to RFC5737 literal.
+
+### Process Improvements for Q4
+1. Pre-install `syft`, `trivy` before T0+1d (make it a hard gate, not aspirational).
+2. Add a scheduled `dotnet list --vulnerable` job so backend deps are always fresh.
+3. Auto-dismiss test-code CodeQL FPs (like #652) via `used-in-tests` classification rule.
+
+---
+
+## 11. Action Items for Q4
+
+### High Priority
+- [ ] **P1.3** OpenTelemetry coordinated upgrade (GHSA-g94r-2vxg-569j) — Owner: @DegrassiAaron
+- [ ] **P1.4b** Trivy full scope (image + fs + config + CI gate) — Owner: @DegrassiAaron
+
+### Medium Priority
+- [ ] **P1.1-B** 2FA admin strict mode (after shadow-mode telemetry ≥90%)
+- [ ] SBOM generation cadence (backend + frontend + containers)
+- [ ] DAST baseline (OWASP ZAP + Schemathesis on staging)
+- [ ] Extract `SsrfSafeHttpClient` guard into SharedKernel primitive (cross-BC consolidation)
+
+### Continuous
+- [ ] Dismiss CodeQL #652 (test-code FP) with `used-in-tests` justification
+- [ ] Re-run gitleaks + `dotnet list --vulnerable` for a full T0-style snapshot next cycle
+
+---
+
+## 12. Sign-off
+
+| Role | Name | Date | Signature |
+|------|------|------|-----------|
+| Reviewer (Responsible) | @DegrassiAaron | _pending_ | _(PR for this report)_ |
+| Approver (Accountable) | @DegrassiAaron (single-maintainer self-sign) | _pending_ | _(PR for this report)_ |
+
+### Sign-off rationale
+
+Q3 material outcome: **11 authorization/SSRF findings fixed + merged** (4 Critical + 7 High), all within MTTR target (critical = 6d). CodeQL STEP 1–4 remediated; sole open high is a test-code FP. Runtime dependencies clean of high/critical. Deferred items (OTel, Trivy, SBOM, DAST, 2FA strict) carried to Q4 with documented rationale — none is a live exploit path.
+
+### Final posture
+
+- **Critical: 0** ✅
+- **High: 1** (test-code CodeQL FP #652, dismissable) — 0 in production code / dependencies
+- **Runtime dep high/critical: 0** ✅
+- All in-scope remediation complete; deferred work is observability/tooling, not exposure.
+
+---
+
+## Appendix A — Tools & Versions Used
+
+| Tool | Version | Purpose |
+|------|---------|---------|
+| CodeQL | (GitHub Actions managed) | SAST — queried live via `gh api` |
+| pnpm | 10.x | frontend dependency audit |
+| dotnet SDK | 9.x | (backend audit carried from Q2, not re-run) |
+| gitleaks | 8.30.1 | secret scanning (not re-run; last clean Q2) |
+| Trivy / syft / OWASP ZAP | n/a (deferred) | container / SBOM / DAST |
+
+## Appendix B — Success Criteria Tracking
+
+- **SC-1** (100% critical/high at T0 → fixed/mitigated/accepted by T0+90d): ✅ 11/11 fixed by T0+6d.
+- **SC-2** (report signed by T0+14d): ✅ on track — draft T0+8d.
+- **SC-3** (MTTR critical ≤7d, high ≤30d): ✅ critical = 6d.
+- **SC-4** (zero critical carried forward): ✅ 0.
+- **SC-5** (tier-1 BC review + ≥95% security test coverage): review ✅; coverage measurement carried to Q4.
+
+## Appendix C — References
+
+- [security-review-template.md](./security-review-template.md) — v2 template
+- [2026-Q2-security-review.md](./2026-Q2-security-review.md) — previous quarter
+- Issue #2655 — Q3 2026 Security Review (this review's origin)
+- PRs #2742 / #2743 / #2744 (CodeQL) · #2746 / #2747 / #2749 / #2751 / #2753 (authz + SSRF remediation)
+- [ADR-059](../../for-claude/architecture/adr/adr-059-catalog-seed-legal-posture.md) — BGG legal posture (image ban context)
+- [ADR-078](../../for-claude/architecture/adr/adr-078-auto-issue-noise-thresholds.md) — auto-issue noise thresholds (why findings triaged in-issue, not auto-filed)
+
+---
+
+**Next Review Due**: 2026-10-01 (Q4 2026)
+
+**This review history**:
+- 2026-07-07: remediation executed (11 findings fixed + merged, T0+6d)
+- 2026-07-09: closeout report authored (T0+8d, within SC-2)
+- _pending_: sign-off

--- a/docs/superpowers/plans/2026-07-08-issue-526-me-m14-admin-review-core.md
+++ b/docs/superpowers/plans/2026-07-08-issue-526-me-m14-admin-review-core.md
@@ -1,0 +1,1472 @@
+# #526 ME-M1.4 Admin Review UI (core iteration) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Complete the core of the Mechanic Extractor admin review UI (#526): T1–T4 guardrail badges (derived), a PDF citation quote-highlighter, bulk-reject-by-predicate, the ADR-051 footer swap, an approve-with-note MVP, one observability counter, a11y, and tests — plus a `validations[]` DTO contract that unblocks #527.
+
+**Architecture:** The backend already ships the bulk-reject endpoint + analysis lifecycle. This plan adds a derived `validations[]` field to the claim read-model, a nullable `review_note` column, one metric, and wires the frontend `ClaimsSection` (badges, citation viewer, bulk dropdown, approve-note) plus two new components (`PdfQuoteHighlighter`, `MechanicAnalysisFooterAttribution`). Real per-claim validation persistence (AC-1) and analysis-finalize reconciliation with #527 (AC-4) are OUT — deferred to follow-ups FU-1 / FU-2.
+
+**Tech Stack:** .NET 9 (Minimal APIs + MediatR + EF Core + FluentValidation), Next.js 16 (React 19, Zod, React Query, shadcn primitives), react-pdf@10.4.1 + pdfjs-dist@5.7.284, Vitest + Playwright + xUnit/Moq.
+
+**Design spec:** `docs/superpowers/specs/2026-07-08-issue-526-me-m14-admin-review-core-design.md`
+
+## Global Constraints
+
+- **Branch:** `feature/issue-526-me-m14-admin-review-ui` (parent `main-dev`). Push with `git push -u origin feature/issue-526-me-m14-admin-review-ui`.
+- **CQRS:** endpoints call only `IMediator.Send()`. Exceptions: `ConflictException`(409), `NotFoundException`(404) — never `InvalidOperationException`(500).
+- **EF:** explicit `HasColumnName("snake_case")` — no auto snake_case. LiveSession-style handlers `AddAsync`/`Update` MUST be followed by `SaveChangesAsync` (already the case in existing handlers).
+- **Admin FE conventions:** shadcn primitives from `@/components/ui/{primitives,data-display,overlays}/…` (NOT MeepleCard). Keep the file-level `/* eslint-disable local/no-hardcoded-color-utility … DS-13d admin scope */` header on admin files with amber/green/rose class maps — do NOT introduce `--admin-*` tokens. Pervasive `data-testid`. React Query keys `['mechanic-analysis', id, 'claims']`.
+- **Bulk-reject contract (already shipped BE):** `POST /api/v1/admin/mechanic-analyses/{id}/claims/bulk-reject`, body `{ claimIds: Guid[], reason: string }` (reason 1–500 chars), response `{ rejectedCount, skippedAlreadyRejectedCount, claims: MechanicClaimDto[] }`. 404 stale id / 409 not-InReview.
+- **ADR-051 footer string (canonical):** `"Analisi elaborata dall'AI sul manuale del gioco. Ogni affermazione è riformulata in parole originali e cita la pagina del regolamento. Copyright © degli editori per il testo originale del manuale."` The forbidden string to delete lives only at `apps/web/src/app/admin/(dashboard)/knowledge-base/mechanic-extractor/review/page.tsx:277` as entity-encoded `L&apos;AI non ha mai letto il testo del PDF originale.`
+- **Guardrail → badge families:** T1=QuoteCap, T2=RejectionSampling(long-verbatim), T3=Grounding+CitationPresence, T4=PageSubstring.
+- **Test commands:** BE `cd apps/api/src/Api && dotnet test --filter "FullyQualifiedName~<Name>"` (kill testhost first if locked). FE `cd apps/web && pnpm test <path>` / `pnpm typecheck` / `pnpm lint`. E2E `pnpm test:e2e <spec>`.
+
+---
+
+## File map
+
+**Create (backend)**
+- `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/DTOs/MechanicClaimValidationDto.cs` — validation badge DTO + `MechanicClaimValidations.DerivePass()` helper.
+- `apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.MechanicReview.cs` — `MechanicReviewBulkActions` counter.
+- Migration (generated) `…/Migrations/<ts>_AddMechanicClaimReviewNote.cs`.
+- `apps/api/tests/…/MechanicExtractor/MechanicReviewMetricsTests.cs`.
+
+**Modify (backend)**
+- `…/Application/DTOs/MechanicClaimDto.cs` — add `Validations` positional param.
+- `…/Application/Queries/MechanicExtractor/GetMechanicAnalysisClaimsQueryHandler.cs` + every other `new MechanicClaimDto(` site — emit `Validations`.
+- `…/Infrastructure/Entities/SharedGameCatalog/MechanicClaimEntity.cs` + `…/Infrastructure/Configurations/SharedGameCatalog/MechanicClaimEntityConfiguration.cs` — `ReviewNote` / `review_note`.
+- `…/Domain/Entities/MechanicClaim.cs` (`Approve` note) + `…/Domain/Aggregates/MechanicAnalysis.cs` (`ApproveClaim` note) + `…/Application/Commands/MechanicExtractor/ApproveMechanicClaimCommand.cs` + `…Handler.cs` + `…Validator.cs`.
+- `…/Application/Commands/MechanicExtractor/BulkRejectMechanicClaimsCommandHandler.cs` + `BulkApproveMechanicClaimsCommandHandler.cs` — metric increment.
+
+**Create (frontend)**
+- `apps/web/src/components/pdf/PdfQuoteHighlighter.tsx` + `__tests__/PdfQuoteHighlighter.test.tsx`.
+- `apps/web/src/components/pdf/pdf-quote-highlight.ts` — pure normalize/match helper + `__tests__`.
+- `apps/web/src/components/admin/mechanic-extractor/MechanicAnalysisFooterAttribution.tsx` + `__tests__`.
+- `apps/web/src/components/admin/mechanic-extractor/claims/BulkActionDialog.tsx` + `ApproveClaimDialog.tsx`.
+
+**Modify (frontend)**
+- `apps/web/src/lib/api/schemas/mechanic-analyses.schemas.ts` — `MechanicClaimValidationDtoSchema` + `validations` field + `bulkRejectClaims` route + `BulkRejectMechanicClaimsResponseDtoSchema` + `BulkRejectMechanicClaimsRequest`.
+- `apps/web/src/lib/api/clients/admin/adminContentClient.ts` — `bulkRejectMechanicClaims` + optional `note` on `approveMechanicClaim`.
+- `apps/web/src/components/pdf/PdfInlineViewer.tsx` — `renderTextLayer?` + `highlightQuote?` + `onQuoteMatch?` props.
+- `apps/web/src/components/admin/mechanic-extractor/claims/ClaimsSection.tsx` — badges, citation-click, bulk dropdown, approve-note, `pdfDocumentId` prop.
+- `apps/web/src/app/admin/(dashboard)/knowledge-base/mechanic-extractor/analyses/page.tsx` — pass `pdfDocumentId` to `ClaimsSection`.
+- `apps/web/src/app/admin/(dashboard)/knowledge-base/mechanic-extractor/review/page.tsx` — footer swap.
+- `apps/web/e2e/admin-mechanic-extractor-validation/load-existing-analysis.spec.ts` — bulk-reject + citation-open flows.
+
+---
+
+## Delivery — recommended PR split
+
+14 tasks / ~20 files spanning a DB migration + 5 backend handlers + a metric + FE schemas/client + two new PDF components + a heavily-modified `ClaimsSection` + E2E is too large for one reviewable PR (and mixes a migration with UI churn). Recommended **3 stacked PRs** onto `main-dev` (each independently green; later PRs branch off the prior):
+
+- **PR-A — backend contract + AC-6 + AC-7 (Tasks 1–4):** `validations[]` DTO, `review_note` migration, approve-note (incl. the endpoint + `MapClaimToEntity` persistence fixes), bulk-actions counter. Migration isolated; fast BE tests.
+- **PR-B — FE plumbing + PDF (Tasks 5–7, 12):** schemas/client, `pdf-quote-highlight` helper, `PdfQuoteHighlighter`, footer attribution swap. No `ClaimsSection` behavior change.
+- **PR-C — ClaimsSection UI + E2E (Tasks 8–11, 13):** badges, citation wire, bulk dropdown, approve-note dialog, E2E. Concentrates the risky UI diff + the E2E fixture update in one reviewable slice.
+
+Task 14 (full-suite verify + follow-up filing) runs at the end of PR-C. If the reviewer prefers a single PR, the task order already works as one branch — this split is a reviewability optimization, not a dependency requirement. **Confirm the delivery shape before execution.**
+
+---
+
+## Task 1: Backend — derived `validations[]` on `MechanicClaimDto`
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/DTOs/MechanicClaimValidationDto.cs`
+- Modify: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/DTOs/MechanicClaimDto.cs`
+- Modify: every `new MechanicClaimDto(` construction site (grep below)
+- Test: `apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/DTOs/MechanicClaimValidationsTests.cs` (create)
+
+**Interfaces:**
+- Produces: `record MechanicClaimValidationDto(string Rule, string Outcome, string? Message = null)`; `static IReadOnlyList<MechanicClaimValidationDto> MechanicClaimValidations.DerivePass()`; `MechanicClaimDto.Validations : IReadOnlyList<MechanicClaimValidationDto>` (last positional param).
+
+- [ ] **Step 1: Write the failing unit test** (pure — no DB) — `MechanicClaimValidationsTests.cs`. The handler wiring is verified by the build (every construction site must compile) + the E2E/existing tests; here we lock the derivation contract:
+
+```csharp
+using Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.DTOs;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public class MechanicClaimValidationsTests
+{
+    [Fact]
+    public void DerivePass_ReturnsFourPassBadges_T1ToT4()
+    {
+        var validations = MechanicClaimValidations.DerivePass();
+
+        validations.Select(v => v.Rule).Should().Equal("T1", "T2", "T3", "T4");
+        validations.Should().OnlyContain(v => v.Outcome == "pass" && v.Message == null);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/api/src/Api && dotnet test --filter "FullyQualifiedName~MechanicClaimValidationsTests" -v minimal`
+Expected: FAIL — `MechanicClaimValidations` / `MechanicClaimValidationDto` do not exist.
+
+- [ ] **Step 3: Create the DTO + derivation helper**
+
+`MechanicClaimValidationDto.cs`:
+```csharp
+namespace Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
+
+/// <summary>
+/// Per-claim guardrail badge outcome (#526 AC-1). Rule ∈ {T1,T2,T3,T4}; Outcome ∈ {pass,fail,notRun}.
+/// </summary>
+/// <remarks>
+/// CORE ITERATION: values are DERIVED, not persisted. Every claim that reaches the review queue
+/// passed its section's guardrails by the pipeline pass-invariant (rejection sampling retries a
+/// section until its output satisfies T1–T4, else aborts to PartiallyExtracted/Rejected), so all
+/// persisted claims are surfaced as <c>pass</c>. FU-1 (#526 follow-up) replaces this with real
+/// per-claim outcomes + scores captured at pipeline time; the <c>fail</c>/<c>notRun</c> states and
+/// <see cref="Message"/> light up then. #527 snapshots this array into <c>mechanic_cards.content</c>.
+/// </remarks>
+public sealed record MechanicClaimValidationDto(string Rule, string Outcome, string? Message = null);
+
+/// <summary>Derivation of the AC-1 badge families for the core iteration.</summary>
+public static class MechanicClaimValidations
+{
+    /// <summary>Badge families, ordered T1→T4 (T3 = grounding + citation-present).</summary>
+    public static readonly IReadOnlyList<string> Families = new[] { "T1", "T2", "T3", "T4" };
+
+    /// <summary>Derived all-pass outcomes (see <see cref="MechanicClaimValidationDto"/> remarks).</summary>
+    public static IReadOnlyList<MechanicClaimValidationDto> DerivePass() =>
+        Families.Select(f => new MechanicClaimValidationDto(f, "pass")).ToList();
+}
+```
+> Honesty note: `all-pass` is correct, not optimistic. A section that fails guardrails returns `Output: null` and aborts (`MechanicAnalysisPipeline.cs:96-100,261`); the `PartiallyExtracted` salvage keeps only passed sections (`MechanicAnalysisExecutor.cs:291-292`) — so every *persisted* claim passed T1–T4. And `MechanicGuardrailOptions` exposes **no per-guardrail enable flag**, so no family is ever `notRun` in core; the spec's `notRun`-for-disabled branch stays dormant until FU-1 records real outcomes.
+
+- [ ] **Step 4: Add `Validations` to `MechanicClaimDto`** — append as the last positional param (after `Citations`) in `MechanicClaimDto.cs`:
+
+```csharp
+public sealed record MechanicClaimDto(
+    Guid Id,
+    Guid AnalysisId,
+    MechanicSection Section,
+    string Text,
+    int DisplayOrder,
+    MechanicClaimStatus Status,
+    Guid? ReviewedBy,
+    DateTime? ReviewedAt,
+    string? RejectionNote,
+    IReadOnlyList<MechanicCitationDto> Citations,
+    IReadOnlyList<MechanicClaimValidationDto> Validations);
+```
+
+- [ ] **Step 5: Update every construction site.** There are **5** — but `ApproveMechanicClaimCommandHandler.ToDto` is target-typed (`=> new(`), so a `new MechanicClaimDto(` grep only finds 4. Enumerate all 5 explicitly:
+- `GetMechanicAnalysisClaimsQueryHandler.cs:53`
+- `ApproveMechanicClaimCommandHandler.cs:113` (target-typed `new(`)
+- `RejectMechanicClaimCommandHandler.cs:100`
+- `BulkApproveMechanicClaimsCommandHandler.cs:119`
+- `BulkRejectMechanicClaimsCommandHandler.cs:132`
+
+Cross-check with `cd apps/api/src/Api && grep -rn "MechanicClaimDto(" BoundedContexts` (no `new ` prefix) — and rely on `dotnet build` (Step 6) to catch any miss (a missing arg is a compile error). For each, add the final argument:
+```csharp
+                    .ToList(),
+            Validations: MechanicClaimValidations.DerivePass()));
+```
+(i.e. after the `Citations: … .ToList()` argument, add `Validations: MechanicClaimValidations.DerivePass()`.)
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `cd apps/api/src/Api && dotnet test --filter "FullyQualifiedName~MechanicClaimValidationsTests" -v minimal`
+Expected: PASS. Then `dotnet build` to confirm all `new MechanicClaimDto(` construction sites compile with the new `Validations` argument.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/DTOs/MechanicClaimValidationDto.cs \
+        apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/DTOs/MechanicClaimDto.cs \
+        "apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/MechanicExtractor/GetMechanicAnalysisClaimsQueryHandler.cs" \
+        "apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/"*Handler.cs \
+        apps/api/tests
+git commit -m "feat(mechanic-extractor): #526 derive T1-T4 validations[] on claim DTO (AC-1 contract)"
+```
+
+---
+
+## Task 2: Backend — `review_note` column (AC-6 storage)
+
+**Files:**
+- Modify: `apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/MechanicClaimEntity.cs`
+- Modify: `apps/api/src/Api/Infrastructure/Configurations/SharedGameCatalog/MechanicClaimEntityConfiguration.cs`
+- Create: migration `AddMechanicClaimReviewNote`
+
+**Interfaces:**
+- Produces: `MechanicClaimEntity.ReviewNote : string?` mapped to nullable `review_note character varying(2000)`.
+
+- [ ] **Step 1: Add the entity property** — after `RejectionNote` in `MechanicClaimEntity.cs`:
+
+```csharp
+    public string? RejectionNote { get; set; }
+
+    /// <summary>Optional free-form note captured on APPROVE (#526 AC-6). Distinct from RejectionNote.</summary>
+    public string? ReviewNote { get; set; }
+```
+
+- [ ] **Step 2: Map the column** — after the `RejectionNote` mapping block in `MechanicClaimEntityConfiguration.cs`:
+
+```csharp
+        builder.Property(c => c.RejectionNote)
+            .HasColumnName("rejection_note")
+            .HasMaxLength(2000);
+
+        builder.Property(c => c.ReviewNote)
+            .HasColumnName("review_note")
+            .HasMaxLength(2000);
+```
+
+- [ ] **Step 3: Generate the migration**
+
+Run: `cd apps/api/src/Api && dotnet ef migrations add AddMechanicClaimReviewNote`
+Expected: a new migration adding `review_note` (`character varying(2000)`, nullable) to `mechanic_claims`.
+
+- [ ] **Step 4: Review the migration SQL.** Open the generated `Up`/`Down`; confirm it is a single additive `AddColumn` (nullable, no default) and `DropColumn` on down. No other tables touched. (Idempotent-terminator lesson #2763: EF-generated `AddColumn` is safe; do not hand-edit.)
+
+- [ ] **Step 5: Apply + verify build**
+
+Run: `cd apps/api/src/Api && dotnet ef database update && dotnet build`
+Expected: migration applies; build succeeds.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/MechanicClaimEntity.cs \
+        apps/api/src/Api/Infrastructure/Configurations/SharedGameCatalog/MechanicClaimEntityConfiguration.cs \
+        apps/api/src/Api/Infrastructure/Migrations
+git commit -m "feat(mechanic-extractor): #526 add nullable review_note column (AC-6)"
+```
+> Migrations + the single `MeepleAiDbContextModelSnapshot.cs` live under `apps/api/src/Api/Infrastructure/Migrations/` (NOT `apps/api/src/Api/Migrations`). Confirm both the new migration file and the modified snapshot are staged.
+
+---
+
+## Task 3: Backend — thread optional approve note
+
+**Files:**
+- Modify: `…/Domain/Entities/MechanicClaim.cs` (`Approve`, `Reconstitute`, `ResetToPending`)
+- Modify: `…/Domain/Aggregates/MechanicAnalysis.cs` (`ApproveClaim`)
+- Modify: `…/Application/Commands/MechanicExtractor/ApproveMechanicClaimCommand.cs`, `…Handler.cs`, `…Validator.cs`
+- Modify: `…/Application/DTOs/MechanicClaimDto.cs` (add `ReviewNote`) + all construction sites
+- **Modify: `apps/api/src/Api/Routing/AdminMechanicAnalysesEndpoints.cs`** — the approve endpoint must bind the note from the body (BLOCKER-1)
+- **Modify: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/MechanicAnalysisRepository.cs`** — BOTH `MapClaimToDomain` (read) AND `MapClaimToEntity` (write) (BLOCKER-2)
+- Test: `apps/api/tests/…/MechanicExtractor/ApproveMechanicClaimCommandHandlerTests.cs` (Moq, fast) **and** an integration round-trip test in `MechanicAnalysisRepositoryIntegrationTests.cs` (Testcontainers) — the Moq test alone is INSUFFICIENT (it reads the in-memory domain object, so it stays green even if the DB write drops the note).
+
+**Interfaces:**
+- Consumes: `MechanicClaimValidations.DerivePass()` (Task 1).
+- Produces: `ApproveMechanicClaimCommand(Guid AnalysisId, Guid ClaimId, Guid ReviewerId, string? Note = null)`; `MechanicClaim.Approve(Guid, DateTime, string?)`; `MechanicClaim.Reconstitute(…, IEnumerable<MechanicCitation> citations, string? reviewNote = null)` (new param is **LAST**); `MechanicAnalysis.ApproveClaim(Guid, Guid, DateTime, string?)`; `MechanicClaimDto.ReviewNote : string?`; `record ApproveClaimRequest(string? Note)` (endpoint body).
+
+> ⚠️ **Two silent-persistence traps this task must close (both caught in plan review):**
+> 1. The approve **endpoint** currently binds no body (`AdminMechanicAnalysesEndpoints.cs:187-198` hard-codes `new ApproveMechanicClaimCommand(id, claimId, reviewerId)`), so the FE `{ note }` is discarded — mirror the reject endpoint's `RejectClaimRequest` binding.
+> 2. The repo **write** mapper `MapClaimToEntity` (`MechanicAnalysisRepository.cs:392-407`) copies `RejectionNote` but not `ReviewNote`; `Update()` forces `EntityState.Modified`, so `review_note` is UPDATEd to `null` unless the mapper is patched. The Moq handler test + the API response both come from the in-memory domain aggregate and will pass anyway — only the integration round-trip test (Step 9) catches this.
+
+- [ ] **Step 1: Write the failing Moq handler test** — in `ApproveMechanicClaimCommandHandlerTests.cs` (mirror the Moq/`BuildInReviewAnalysis` pattern from `BulkRejectMechanicClaimsCommandHandlerTests.cs`). NOTE: necessary but NOT sufficient — it verifies the domain thread, not persistence (Step 9 covers persistence):
+
+```csharp
+[Fact]
+public async Task Handle_WithNote_StoresReviewNote()
+{
+    var analysis = BuildInReviewAnalysis(1);
+    var claimId = analysis.Claims.Single().Id;
+    SetupRepo(analysis, analysis.Id);
+
+    var result = await _handler.Handle(
+        new ApproveMechanicClaimCommand(analysis.Id, claimId, Guid.NewGuid(), "looks good, matches p.4"),
+        CancellationToken.None);
+
+    result.Status.Should().Be(MechanicClaimStatus.Approved);
+    result.ReviewNote.Should().Be("looks good, matches p.4");
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd apps/api/src/Api && dotnet test --filter "FullyQualifiedName~ApproveMechanicClaimCommandHandlerTests.Handle_WithNote"`
+Expected: FAIL — `ApproveMechanicClaimCommand` has 3 params / `MechanicClaimDto` has no `ReviewNote`.
+
+- [ ] **Step 3: Entity** — change `MechanicClaim.Approve` (add `ReviewNote` property + note param):
+
+```csharp
+    /// <summary>Optional note captured on approval (#526 AC-6).</summary>
+    public string? ReviewNote { get; private set; }
+
+    internal void Approve(Guid reviewerId, DateTime utcNow, string? note = null)
+    {
+        if (reviewerId == Guid.Empty)
+        {
+            throw new ArgumentException("ReviewerId cannot be empty.", nameof(reviewerId));
+        }
+
+        Status = MechanicClaimStatus.Approved;
+        ReviewedBy = reviewerId;
+        ReviewedAt = utcNow;
+        RejectionNote = null;
+        ReviewNote = string.IsNullOrWhiteSpace(note) ? null : note.Trim();
+    }
+```
+In `ResetToPending`, add `ReviewNote = null;`. In `Reconstitute`, add `string? reviewNote = null` as the **LAST** parameter (after `IEnumerable<MechanicCitation> citations`) — placing it mid-list breaks the 6 named-arg callers (1 prod + 5 tests) and an optional-before-required `citations` is a CS1737 compile error. Assign `claim.ReviewNote = reviewNote;` (via the object initializer). Only the prod caller passes it (Step 7); the 5 test callers keep compiling because the param is optional-and-last.
+
+- [ ] **Step 4: Aggregate** — `MechanicAnalysis.ApproveClaim`:
+
+```csharp
+    public void ApproveClaim(Guid claimId, Guid reviewerId, DateTime utcNow, string? note = null)
+    {
+        var claim = RequireClaimUnderReview(claimId, "approve claim");
+        claim.Approve(reviewerId, utcNow, note);
+    }
+```
+
+- [ ] **Step 5: Command + validator + handler**
+
+Command (`ApproveMechanicClaimCommand.cs`):
+```csharp
+internal record ApproveMechanicClaimCommand(
+    Guid AnalysisId,
+    Guid ClaimId,
+    Guid ReviewerId,
+    string? Note = null) : ICommand<MechanicClaimDto>;
+```
+Validator (`ApproveMechanicClaimCommandValidator.cs`, after the ReviewerId rule):
+```csharp
+        RuleFor(c => c.Note)
+            .MaximumLength(2000).WithMessage("Note must be 2000 characters or fewer.")
+            .When(c => c.Note is not null);
+```
+Handler (`ApproveMechanicClaimCommandHandler.cs`, line ~76): `analysis.ApproveClaim(request.ClaimId, request.ReviewerId, utcNow, request.Note);` and in `ToDto` add `ReviewNote: claim.ReviewNote,` after `RejectionNote:`.
+
+- [ ] **Step 6: Bind the note at the endpoint (BLOCKER-1)** — in `AdminMechanicAnalysesEndpoints.cs`, the approve mapping (~line 187) currently takes no body. Add an optional body record + pass it (mirror the reject endpoint at ~line 210):
+
+```csharp
+// near the other request records at the bottom of the file:
+internal sealed record ApproveClaimRequest(string? Note);
+```
+```csharp
+// approve endpoint handler — add the body param + thread request?.Note:
+        group.MapPost("/{id:guid}/claims/{claimId:guid}/approve", async (
+            Guid id,
+            Guid claimId,
+            ApproveClaimRequest? request,          // NEW — optional so empty-body approve still works
+            HttpContext httpContext,
+            IMediator mediator,
+            CancellationToken ct) =>
+        {
+            var session = (SessionStatusDto)httpContext.Items[nameof(SessionStatusDto)]!;
+            var reviewerId = session!.Principal!.Subject.Id;
+            var command = new ApproveMechanicClaimCommand(id, claimId, reviewerId, request?.Note);
+            var response = await mediator.Send(command, ct).ConfigureAwait(false);
+            return Results.Ok(response);
+        }) // …existing .WithName/.WithSummary chain unchanged
+```
+
+- [ ] **Step 7: Repository read + WRITE mappers (BLOCKER-2)** — in `MechanicAnalysisRepository.cs`:
+  - `MapClaimToDomain` (~line 328): pass the column into `Reconstitute` — `reviewNote: entity.ReviewNote` (last arg).
+  - **`MapClaimToEntity` (~line 404): add `ReviewNote = claim.ReviewNote,`** next to `RejectionNote = claim.RejectionNote,`. Without this, `Update()` writes `review_note = NULL`.
+
+- [ ] **Step 8: DTO + all construction sites**
+
+Add `string? ReviewNote` to `MechanicClaimDto` (after `RejectionNote`). Then update **all 5** construction sites (named args, so order-independent) — the literal grep misses the target-typed one, so enumerate: `GetMechanicAnalysisClaimsQueryHandler.cs:53` (entity source → `c.ReviewNote`), `ApproveMechanicClaimCommandHandler.cs:113` (`new(` target-typed — already handled in Step 5's `ToDto`), `RejectMechanicClaimCommandHandler.cs:100`, `BulkApproveMechanicClaimsCommandHandler.cs:119`, `BulkRejectMechanicClaimsCommandHandler.cs:132` (all four project from the domain aggregate → `c.ReviewNote`). Add `ReviewNote: c.ReviewNote,` to each.
+
+- [ ] **Step 9: Write the failing integration round-trip test (persistence guard)** — in `MechanicAnalysisRepositoryIntegrationTests.cs` (Testcontainers). This is the test the Moq one cannot be: it reloads the aggregate from Postgres and asserts the column survived.
+
+```csharp
+[Fact]
+public async Task ApprovedClaimWithNote_PersistsReviewNote_AcrossReload()
+{
+    var analysis = BuildInReviewAnalysisWithClaim(); // reuse this file's seed helper
+    await _repository.AddAsync(analysis, CancellationToken.None);
+    await _unitOfWork.SaveChangesAsync(CancellationToken.None);
+
+    var claimId = analysis.Claims.Single().Id;
+    analysis.ApproveClaim(claimId, Guid.NewGuid(), DateTime.UtcNow, "verified against p.4");
+    _repository.Update(analysis);
+    await _unitOfWork.SaveChangesAsync(CancellationToken.None);
+
+    var reloaded = await _repository.GetByIdWithClaimsIgnoringFiltersAsync(analysis.Id, CancellationToken.None);
+    reloaded!.Claims.Single(c => c.Id == claimId).ReviewNote.Should().Be("verified against p.4");
+}
+```
+Run it and confirm it FAILS before Step 7's `MapClaimToEntity` fix (proves the trap), then PASSES after.
+
+- [ ] **Step 10: Run to verify all pass + build**
+
+Run: `cd apps/api/src/Api && dotnet test --filter "FullyQualifiedName~ApproveMechanicClaimCommandHandlerTests|FullyQualifiedName~MechanicAnalysisRepositoryIntegrationTests" && dotnet build`
+Expected: PASS + build OK (all construction sites + the 6 `Reconstitute` callers compile).
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add -A
+git commit -m "feat(mechanic-extractor): #526 thread + persist optional approve note to review_note (AC-6)"
+```
+
+---
+
+## Task 4: Backend — `mechanic_review_bulk_actions_total` counter (AC-7)
+
+**Files:**
+- Create: `apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.MechanicReview.cs`
+- Modify: `…/Commands/MechanicExtractor/BulkRejectMechanicClaimsCommandHandler.cs` + `BulkApproveMechanicClaimsCommandHandler.cs`
+- Create: `apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/MechanicReviewMetricsTests.cs`
+
+**Interfaces:**
+- Produces: `MeepleAiMetrics.MechanicReviewBulkActions` (`Counter<long>`), incremented `Add(1, TagList{{"action", "bulk_reject"|"bulk_approve"}})`.
+
+- [ ] **Step 1: Write the failing test** — mirror `MechanicValidatorMetricsTests` (name-filtered `MeterListener`, `ContainSingle`, Approach 1 / #2752):
+
+```csharp
+using System.Diagnostics.Metrics;
+using Api.Observability;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Commands.MechanicExtractor;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public class MechanicReviewMetricsTests
+{
+    private const string Counter = "mechanic_review_bulk_actions_total";
+
+    [Fact]
+    public void MechanicReviewBulkActions_Emits_ActionTag()
+    {
+        var events = new List<string>();
+        using var listener = new MeterListener
+        {
+            InstrumentPublished = (instrument, l) =>
+            {
+                if (instrument.Meter.Name == MeepleAiMetrics.MeterName && instrument.Name == Counter)
+                    l.EnableMeasurementEvents(instrument);
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((_, _, tags, _) =>
+        {
+            foreach (var tag in tags)
+                if (tag.Key == "action" && tag.Value is string a) events.Add(a);
+        });
+        listener.Start();
+
+        MeepleAiMetrics.MechanicReviewBulkActions.Add(1, new System.Diagnostics.TagList { { "action", "bulk_reject" } });
+
+        events.Should().ContainSingle().Which.Should().Be("bulk_reject");
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd apps/api/src/Api && dotnet test --filter "FullyQualifiedName~MechanicReviewMetricsTests"`
+Expected: FAIL — `MechanicReviewBulkActions` does not exist.
+
+- [ ] **Step 3: Declare the counter** — `MeepleAiMetrics.MechanicReview.cs`:
+
+```csharp
+using System.Diagnostics.Metrics;
+
+namespace Api.Observability;
+
+/// <summary>#526 ME-M1.4 admin-review observability (AC-7): bulk-action counter.</summary>
+internal static partial class MeepleAiMetrics
+{
+    /// <summary>Admin mechanic-review bulk actions, tagged {action=bulk_approve|bulk_reject}.</summary>
+    public static readonly Counter<long> MechanicReviewBulkActions =
+        Meter.CreateCounter<long>(
+            "mechanic_review_bulk_actions_total",
+            description: "Admin mechanic-review bulk actions by action.");
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cd apps/api/src/Api && dotnet test --filter "FullyQualifiedName~MechanicReviewMetricsTests"`
+Expected: PASS.
+
+- [ ] **Step 5: Increment in the handlers.** In `BulkRejectMechanicClaimsCommandHandler.Handle` (after the successful `SaveChangesAsync`/log region, before building the response) add:
+
+```csharp
+        MeepleAiMetrics.MechanicReviewBulkActions.Add(1, new System.Diagnostics.TagList { { "action", "bulk_reject" } });
+```
+Add `using System.Diagnostics;` and `using Api.Observability;` at the top. Do the same in `BulkApproveMechanicClaimsCommandHandler` with `{ "action", "bulk_approve" }`.
+
+- [ ] **Step 6: Build**
+
+Run: `cd apps/api/src/Api && dotnet build`
+Expected: succeeds.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/Api/Observability apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/BulkRejectMechanicClaimsCommandHandler.cs apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/BulkApproveMechanicClaimsCommandHandler.cs apps/api/tests
+git commit -m "feat(mechanic-extractor): #526 mechanic_review_bulk_actions_total counter (AC-7)"
+```
+
+---
+
+## Task 5: Frontend — schemas + client (validations, bulk-reject, approve note)
+
+**Files:**
+- Modify: `apps/web/src/lib/api/schemas/mechanic-analyses.schemas.ts`
+- Modify: `apps/web/src/lib/api/clients/admin/adminContentClient.ts`
+- Test: `apps/web/src/lib/api/schemas/__tests__/mechanic-analyses.schemas.test.ts` (create if absent)
+
+**Interfaces:**
+- Produces: `MechanicClaimValidationDtoSchema`; `MechanicClaimDto.validations` + `.reviewNote`; `MECHANIC_ANALYSES_ROUTES.bulkRejectClaims`; `BulkRejectMechanicClaimsResponseDtoSchema`/`Dto`; `BulkRejectMechanicClaimsRequest`; `adminClient.bulkRejectMechanicClaims(id, req)`; `adminClient.approveMechanicClaim(id, claimId, note?)`.
+
+- [ ] **Step 1: Write the failing schema test**
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { MechanicClaimDtoSchema, BulkRejectMechanicClaimsResponseDtoSchema } from '../mechanic-analyses.schemas';
+
+describe('mechanic-analyses schemas #526', () => {
+  it('parses validations[] + reviewNote on a claim', () => {
+    const parsed = MechanicClaimDtoSchema.parse({
+      id: '11111111-1111-4111-8111-111111111111',
+      analysisId: '22222222-2222-4222-8222-222222222222',
+      section: 1, text: 't', displayOrder: 0, status: 0,
+      reviewedBy: null, reviewedAt: null, rejectionNote: null, reviewNote: null,
+      citations: [],
+      validations: [{ rule: 'T1', outcome: 'pass', message: null }],
+    });
+    expect(parsed.validations[0].rule).toBe('T1');
+  });
+
+  it('parses bulk-reject response', () => {
+    const r = BulkRejectMechanicClaimsResponseDtoSchema.parse({
+      rejectedCount: 2, skippedAlreadyRejectedCount: 0, claims: [],
+    });
+    expect(r.rejectedCount).toBe(2);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd apps/web && pnpm test src/lib/api/schemas/__tests__/mechanic-analyses.schemas.test.ts`
+Expected: FAIL — `validations`/`reviewNote` unknown, `BulkRejectMechanicClaimsResponseDtoSchema` undefined.
+
+- [ ] **Step 3: Add the validation schema + fields.** After `MechanicCitationDtoSchema` (line 234) add:
+
+```ts
+export const MechanicClaimValidationDtoSchema = z.object({
+  rule: z.string(),
+  outcome: z.enum(['pass', 'fail', 'notRun']),
+  message: z.string().nullable().optional(),
+});
+export type MechanicClaimValidationDto = z.infer<typeof MechanicClaimValidationDtoSchema>;
+```
+In `MechanicClaimDtoSchema`, after `citations: z.array(MechanicCitationDtoSchema),` add:
+```ts
+  reviewNote: z.string().nullable(),
+  validations: z.array(MechanicClaimValidationDtoSchema),
+```
+
+- [ ] **Step 4: Add route + response + request.** After the `bulkApproveClaims` route entry:
+```ts
+  bulkRejectClaims: (id: string) => `/api/v1/admin/mechanic-analyses/${id}/claims/bulk-reject`,
+```
+After `BulkApproveMechanicClaimsResponseDto` type export:
+```ts
+export const BulkRejectMechanicClaimsResponseDtoSchema = z.object({
+  rejectedCount: z.number().int(),
+  skippedAlreadyRejectedCount: z.number().int(),
+  claims: MechanicClaimsListSchema,
+});
+export type BulkRejectMechanicClaimsResponseDto = z.infer<
+  typeof BulkRejectMechanicClaimsResponseDtoSchema
+>;
+
+/** Body for `POST .../claims/bulk-reject` (#526). Reviewer id comes from the session. */
+export interface BulkRejectMechanicClaimsRequest {
+  claimIds: string[];
+  reason: string;
+}
+```
+
+- [ ] **Step 5: Add client methods.** In `adminContentClient.ts` imports, add `BulkRejectMechanicClaimsResponseDtoSchema` (value) + `type BulkRejectMechanicClaimsResponseDto`, `type BulkRejectMechanicClaimsRequest` (preserve alpha order). After `bulkApproveMechanicClaims`:
+
+```ts
+    async bulkRejectMechanicClaims(
+      analysisId: string,
+      request: BulkRejectMechanicClaimsRequest
+    ): Promise<BulkRejectMechanicClaimsResponseDto> {
+      const result = await http.post(
+        MECHANIC_ANALYSES_ROUTES.bulkRejectClaims(analysisId),
+        request,
+        BulkRejectMechanicClaimsResponseDtoSchema
+      );
+      if (!result) throw new Error('Failed to bulk-reject claims');
+      return result;
+    },
+```
+Change `approveMechanicClaim` signature to `(analysisId: string, claimId: string, note?: string)` and its POST body from `{}` to `note !== undefined ? { note } : {}`.
+
+- [ ] **Step 6: Run to verify it passes + typecheck**
+
+Run: `cd apps/web && pnpm test src/lib/api/schemas/__tests__/mechanic-analyses.schemas.test.ts && pnpm typecheck`
+Expected: PASS + typecheck OK.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/src/lib/api/schemas/mechanic-analyses.schemas.ts apps/web/src/lib/api/clients/admin/adminContentClient.ts apps/web/src/lib/api/schemas/__tests__
+git commit -m "feat(mechanic-extractor): #526 FE schemas+client for validations, bulk-reject, approve note"
+```
+
+---
+
+## Task 6: Frontend — pure quote-highlight helper + PdfInlineViewer opt-in text layer
+
+**Files:**
+- Create: `apps/web/src/components/pdf/pdf-quote-highlight.ts` + `__tests__/pdf-quote-highlight.test.ts`
+- Modify: `apps/web/src/components/pdf/PdfInlineViewer.tsx`
+
+**Interfaces:**
+- Produces: `normalizeQuoteText(s: string): string`; `makeQuoteTextRenderer(quote: string): { render: (item: { str: string }) => string; matched: () => boolean }`; `PdfInlineViewer` props `renderTextLayer?: boolean`, `highlightQuote?: string`, `onQuoteMatch?: (found: boolean) => void`.
+
+- [ ] **Step 1: Write the failing helper test**
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { normalizeQuoteText, makeQuoteTextRenderer } from '../pdf-quote-highlight';
+
+describe('pdf-quote-highlight', () => {
+  it('normalizes whitespace, soft hyphens, case', () => {
+    expect(normalizeQuoteText('Score  1­point\nper  Road')).toBe('score 1point per road');
+  });
+
+  it('wraps text items contained in the quote and reports a match', () => {
+    const r = makeQuoteTextRenderer('players score one point per road');
+    expect(r.render({ str: 'score one point' })).toContain('<mark');
+    expect(r.render({ str: 'per road' })).toContain('<mark');
+    expect(r.matched()).toBe(true);
+  });
+
+  it('escapes HTML and does not wrap non-quote items', () => {
+    const r = makeQuoteTextRenderer('players score one point');
+    expect(r.render({ str: '<b>bonus</b>' })).toBe('&lt;b&gt;bonus&lt;/b&gt;');
+    expect(r.matched()).toBe(false);
+  });
+
+  it('ignores trivially short items to reduce false positives', () => {
+    const r = makeQuoteTextRenderer('a player scores one point');
+    expect(r.render({ str: 'a' })).toBe('a'); // len<=2 not wrapped
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd apps/web && pnpm test src/components/pdf/__tests__/pdf-quote-highlight.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the helper** — `pdf-quote-highlight.ts`:
+
+```ts
+/** Normalize for tolerant substring matching: lowercase, strip soft hyphens, collapse whitespace. */
+export function normalizeQuoteText(s: string): string {
+  return s
+    .replace(/­/g, '')
+    .toLowerCase()
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+/**
+ * Best-effort per-item highlighter for react-pdf `customTextRenderer` (AC-2 Pattern A).
+ * A text item is wrapped in <mark> when its normalized string (len>2) is a substring of the
+ * normalized quote. Imperfect for very common short items — the caller shows a fallback banner
+ * via `matched()`. FU could upgrade to contiguous-run matching or Pattern-B coordinates.
+ */
+export function makeQuoteTextRenderer(quote: string): {
+  render: (item: { str: string }) => string;
+  matched: () => boolean;
+} {
+  const normQuote = normalizeQuoteText(quote);
+  let didMatch = false;
+  return {
+    render: ({ str }) => {
+      const norm = normalizeQuoteText(str);
+      if (norm.length > 2 && normQuote.includes(norm)) {
+        didMatch = true;
+        return `<mark class="pdf-quote-highlight">${escapeHtml(str)}</mark>`;
+      }
+      return escapeHtml(str);
+    },
+    matched: () => didMatch,
+  };
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cd apps/web && pnpm test src/components/pdf/__tests__/pdf-quote-highlight.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Parameterize PdfInlineViewer.** Add to `PdfInlineViewerProps`:
+```ts
+  readonly renderTextLayer?: boolean;
+  readonly highlightQuote?: string;
+  readonly onQuoteMatch?: (found: boolean) => void;
+```
+Destructure them (with `renderTextLayer` default `false`). **Add `useMemo` to the existing React import** (`PdfInlineViewer.tsx:21` currently imports `useState, useEffect, useCallback, useRef` — not `useMemo`). Build the renderer:
+```tsx
+import { makeQuoteTextRenderer } from './pdf-quote-highlight';
+// … inside component:
+  const quoteRenderer = useMemo(
+    () => (highlightQuote ? makeQuoteTextRenderer(highlightQuote) : null),
+    [highlightQuote]
+  );
+```
+Change the `<Page>` (line ~290) to:
+```tsx
+            <Page
+              pageNumber={currentPage}
+              scale={scale}
+              renderAnnotationLayer={false}
+              renderTextLayer={renderTextLayer || !!highlightQuote}
+              customTextRenderer={quoteRenderer ? ({ str }) => quoteRenderer.render({ str }) : undefined}
+              onRenderTextLayerSuccess={
+                quoteRenderer && onQuoteMatch ? () => onQuoteMatch(quoteRenderer.matched()) : undefined
+              }
+            />
+```
+Add a highlight style (module-level or in `apps/web/src/app/globals.css`): `.pdf-quote-highlight { background-color: rgba(255, 235, 59, 0.4); }`.
+
+- [ ] **Step 6: Typecheck + existing viewer tests still green**
+
+Run: `cd apps/web && pnpm typecheck && pnpm test src/components/pdf`
+Expected: PASS (new props are optional; default behavior unchanged — `renderTextLayer` still off when not requested).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/src/components/pdf/pdf-quote-highlight.ts apps/web/src/components/pdf/__tests__/pdf-quote-highlight.test.ts apps/web/src/components/pdf/PdfInlineViewer.tsx apps/web/src/app/globals.css
+git commit -m "feat(pdf): #526 opt-in text-layer quote highlighting on PdfInlineViewer (AC-2 base)"
+```
+
+---
+
+## Task 7: Frontend — `<PdfQuoteHighlighter>` modal
+
+**Files:**
+- Create: `apps/web/src/components/pdf/PdfQuoteHighlighter.tsx`
+- Test: `apps/web/src/components/pdf/__tests__/PdfQuoteHighlighter.test.tsx`
+
+**Interfaces:**
+- Consumes: `PdfInlineViewer` (Task 6).
+- Produces: `<PdfQuoteHighlighter open onOpenChange documentId page quote />` (default export named `PdfQuoteHighlighter`). Renders a Dialog with the viewer at `page`, highlights `quote`, and shows a fallback banner when no match.
+
+- [ ] **Step 1: Write the failing test** (mock `PdfInlineViewer` to drive `onQuoteMatch`):
+
+```tsx
+/** @vitest-environment jsdom */
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../PdfInlineViewer', () => ({
+  PdfInlineViewer: ({ onQuoteMatch }: { onQuoteMatch?: (f: boolean) => void }) => {
+    onQuoteMatch?.(false); // simulate "not found" → banner should show
+    return <div data-testid="pdf-inline-viewer" />;
+  },
+}));
+
+import { PdfQuoteHighlighter } from '../PdfQuoteHighlighter';
+
+describe('PdfQuoteHighlighter', () => {
+  it('shows the fallback banner when the quote is not matched', () => {
+    render(
+      <PdfQuoteHighlighter open onOpenChange={() => {}} documentId="d1" page={4} quote="x" />
+    );
+    expect(screen.getByTestId('pdf-inline-viewer')).toBeInTheDocument();
+    expect(screen.getByTestId('pdf-quote-fallback')).toHaveTextContent(/verifica manualmente/i);
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd apps/web && pnpm test src/components/pdf/__tests__/PdfQuoteHighlighter.test.tsx`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement** — `PdfQuoteHighlighter.tsx`:
+
+```tsx
+'use client';
+
+import React, { useEffect, useState } from 'react';
+
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/overlays/dialog';
+
+import { PdfInlineViewer } from './PdfInlineViewer';
+
+export interface PdfQuoteHighlighterProps {
+  readonly open: boolean;
+  readonly onOpenChange: (open: boolean) => void;
+  readonly documentId: string;
+  readonly page: number;
+  readonly quote: string;
+}
+
+/**
+ * #526 AC-2 / #530 AD-1 — shared citation quote viewer. Opens the source PDF at `page`, highlights
+ * `quote` via PdfInlineViewer's text-layer search (Pattern A), and shows a page-level fallback
+ * banner when the quote can't be located automatically. Consumed by admin review (#526) and,
+ * later, #528 public card + #530 chat citations.
+ */
+export function PdfQuoteHighlighter({
+  open,
+  onOpenChange,
+  documentId,
+  page,
+  quote,
+}: PdfQuoteHighlighterProps): React.JSX.Element {
+  const [matched, setMatched] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    if (open) setMatched(null); // reset per open
+  }, [open, documentId, page, quote]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-4xl">
+        <DialogHeader>
+          <DialogTitle>Citazione — p.{page}</DialogTitle>
+        </DialogHeader>
+        {matched === false && (
+          <div
+            className="rounded-md border border-amber-300 bg-amber-50 p-2 text-xs text-amber-900"
+            role="status"
+            data-testid="pdf-quote-fallback"
+          >
+            Quote non individuabile automaticamente a p.{page}; verifica manualmente.
+          </div>
+        )}
+        <div className="max-h-[70vh] overflow-auto">
+          <PdfInlineViewer
+            documentId={documentId}
+            initialPage={page}
+            highlightQuote={quote}
+            onQuoteMatch={setMatched}
+            features={{ jumpToPage: true, zoom: true }}
+          />
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+```
+(If `@/components/ui/overlays/dialog` exports differ, mirror the imports used by an existing modal, e.g. `PdfViewerModal.tsx`.)
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cd apps/web && pnpm test src/components/pdf/__tests__/PdfQuoteHighlighter.test.tsx && pnpm typecheck`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/pdf/PdfQuoteHighlighter.tsx apps/web/src/components/pdf/__tests__/PdfQuoteHighlighter.test.tsx
+git commit -m "feat(pdf): #526 PdfQuoteHighlighter modal at components/pdf/ (AC-2, reconciles #530 AD-1)"
+```
+
+---
+
+## Task 8: Frontend — T1–T4 badges in ClaimsSection (AC-1 UI)
+
+**Files:**
+- Modify: `apps/web/src/components/admin/mechanic-extractor/claims/ClaimsSection.tsx`
+- Test: `apps/web/src/components/admin/mechanic-extractor/claims/__tests__/ClaimsSection.badges.test.tsx`
+
+**Interfaces:**
+- Consumes: `MechanicClaimDto.validations` (Task 5).
+- Produces: a `ValidationBadges` sub-component rendered in each `ClaimRow`, `data-testid="claim-validation-badge-<rule>-<claimId>"`, `aria-label` per badge.
+
+- [ ] **Step 1: Write the failing test** (mount `ClaimRow` via the exported `ClaimsSection` with a mocked client, or export `ValidationBadges` and test it directly — prefer exporting the small badge component). Add near the top of `ClaimsSection.tsx`: `export function ValidationBadges({ validations }: { validations: MechanicClaimValidationDto[] })`. Test:
+
+```tsx
+/** @vitest-environment jsdom */
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { ValidationBadges } from '../ClaimsSection';
+
+describe('ValidationBadges', () => {
+  it('renders one badge per rule with pass/fail/notRun styling + aria-label', () => {
+    render(
+      <ValidationBadges
+        validations={[
+          { rule: 'T1', outcome: 'pass', message: null },
+          { rule: 'T2', outcome: 'fail', message: 'too long' },
+          { rule: 'T3', outcome: 'notRun', message: null },
+        ]}
+      />
+    );
+    expect(screen.getByTestId('claim-validation-badge-T1')).toHaveAttribute('aria-label', expect.stringMatching(/T1.*pass/i));
+    expect(screen.getByTestId('claim-validation-badge-T2')).toHaveAttribute('aria-label', expect.stringMatching(/T2.*fail/i));
+    expect(screen.getByTestId('claim-validation-badge-T3')).toHaveAttribute('aria-label', expect.stringMatching(/T3.*not/i));
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd apps/web && pnpm test src/components/admin/mechanic-extractor/claims/__tests__/ClaimsSection.badges.test.tsx`
+Expected: FAIL — `ValidationBadges` not exported.
+
+- [ ] **Step 3: Implement `ValidationBadges`** in `ClaimsSection.tsx` (add the type import `MechanicClaimValidationDto` from the schemas module) and a color map:
+
+```tsx
+const VALIDATION_BADGE_CLASS: Record<string, string> = {
+  pass: 'bg-green-100 text-green-800 border-green-300',
+  fail: 'bg-rose-100 text-rose-800 border-rose-300',
+  notRun: 'bg-slate-100 text-slate-600 border-slate-300',
+};
+
+export function ValidationBadges({
+  validations,
+}: {
+  validations: MechanicClaimValidationDto[];
+}): React.JSX.Element | null {
+  if (!validations || validations.length === 0) return null;
+  return (
+    <span className="flex flex-wrap gap-1" data-testid="claim-validation-badges">
+      {validations.map(v => (
+        <Badge
+          key={v.rule}
+          variant="outline"
+          className={VALIDATION_BADGE_CLASS[v.outcome] ?? VALIDATION_BADGE_CLASS.notRun}
+          data-testid={`claim-validation-badge-${v.rule}`}
+          aria-label={`${v.rule} ${v.outcome}${v.message ? `: ${v.message}` : ''}`}
+          title={v.message ?? `${v.rule} ${v.outcome}`}
+        >
+          {v.outcome === 'pass' ? '✓' : v.outcome === 'fail' ? '✗' : '—'} {v.rule}
+        </Badge>
+      ))}
+    </span>
+  );
+}
+```
+Render `<ValidationBadges validations={claim.validations} />` inside `ClaimRow`, in the right-hand action cluster before the status `Badge` (around line 409).
+
+- [ ] **Step 4: Run to verify it passes + existing ClaimsSection tests green**
+
+Run: `cd apps/web && pnpm test src/components/admin/mechanic-extractor/claims && pnpm typecheck`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/admin/mechanic-extractor/claims/ClaimsSection.tsx apps/web/src/components/admin/mechanic-extractor/claims/__tests__/ClaimsSection.badges.test.tsx
+git commit -m "feat(mechanic-extractor): #526 T1-T4 validation badges in ClaimsSection (AC-1 UI)"
+```
+
+---
+
+## Task 9: Frontend — citation click → PdfQuoteHighlighter (AC-2 wire)
+
+**Files:**
+- Modify: `apps/web/src/components/admin/mechanic-extractor/claims/ClaimsSection.tsx` (add `pdfDocumentId` prop; citation rows become buttons)
+- Modify: `apps/web/src/app/admin/(dashboard)/knowledge-base/mechanic-extractor/analyses/page.tsx` (pass `pdfDocumentId={status.pdfDocumentId}`)
+- Test: `apps/web/src/components/admin/mechanic-extractor/claims/__tests__/ClaimsSection.citation.test.tsx`
+
+**Interfaces:**
+- Consumes: `PdfQuoteHighlighter` (Task 7).
+- Produces: `ClaimsSectionProps.pdfDocumentId?: string`; citation button `data-testid="claim-citation-open-<citationId>"`.
+
+- [ ] **Step 1: Write the failing test** — mock `PdfQuoteHighlighter`, mock `adminClient.getMechanicAnalysisClaims` to return one claim with a citation, click the citation, assert the highlighter opened with the right props.
+
+```tsx
+/** @vitest-environment jsdom */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+const mockGetClaims = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/api/clients/adminClient', () => ({
+  createAdminClient: () => ({ getMechanicAnalysisClaims: mockGetClaims }),
+}));
+class MockHttpClient {}
+vi.mock('@/lib/api/core/httpClient', () => ({ HttpClient: MockHttpClient }));
+const mockHighlighter = vi.hoisted(() => vi.fn());
+vi.mock('@/components/pdf/PdfQuoteHighlighter', () => ({
+  PdfQuoteHighlighter: (props: Record<string, unknown>) => {
+    mockHighlighter(props);
+    return props.open ? <div data-testid="highlighter-open" /> : null;
+  },
+}));
+
+import { ClaimsSection } from '../ClaimsSection';
+
+const claim = {
+  id: 'dddddddd-dddd-4ddd-8ddd-dddddddddddd', analysisId: 'a', section: 1, text: 't',
+  displayOrder: 0, status: 0, reviewedBy: null, reviewedAt: null, rejectionNote: null,
+  reviewNote: null, validations: [],
+  citations: [{ id: 'c1', pdfPage: 4, quote: 'score one point', displayOrder: 0 }],
+};
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+
+describe('ClaimsSection citation viewer', () => {
+  it('opens PdfQuoteHighlighter with documentId/page/quote on citation click', async () => {
+    mockGetClaims.mockResolvedValue([claim]);
+    render(<ClaimsSection analysisId="a" pdfDocumentId="pdf-99" />, { wrapper: Wrapper });
+    // expand citations then click
+    fireEvent.click(await screen.findByTestId(`claim-citations-toggle-${claim.id}`));
+    fireEvent.click(screen.getByTestId('claim-citation-open-c1'));
+    expect(mockHighlighter).toHaveBeenCalledWith(
+      expect.objectContaining({ documentId: 'pdf-99', page: 4, quote: 'score one point', open: true })
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd apps/web && pnpm test src/components/admin/mechanic-extractor/claims/__tests__/ClaimsSection.citation.test.tsx`
+Expected: FAIL — `pdfDocumentId` prop / citation button / highlighter wiring missing.
+
+- [ ] **Step 3: Implement.** Add `pdfDocumentId?: string` to `ClaimsSectionProps` and thread it to `SectionGroup` → `ClaimRow`. Add highlighter state in `ClaimsSection` (`const [citationTarget, setCitationTarget] = useState<{ documentId: string; page: number; quote: string } | null>(null)`), a callback `onOpenCitation`, and render `<PdfQuoteHighlighter open={!!citationTarget} onOpenChange={o => !o && setCitationTarget(null)} {...citationTarget} />` guarded by `citationTarget`. In `ClaimRow` citation `<li>` (line ~462), replace the static text with a button when `pdfDocumentId` is present:
+
+```tsx
+{claim.citations.map(c => (
+  <li key={c.id} className="text-muted-foreground">
+    {pdfDocumentId ? (
+      <button
+        type="button"
+        className="text-left hover:underline"
+        onClick={() => onOpenCitation({ documentId: pdfDocumentId, page: c.pdfPage, quote: c.quote })}
+        data-testid={`claim-citation-open-${c.id}`}
+      >
+        <span className="font-medium text-foreground">p.{c.pdfPage}</span> — &ldquo;{c.quote}&rdquo;
+      </button>
+    ) : (
+      <>
+        <span className="font-medium text-foreground">p.{c.pdfPage}</span> — &ldquo;{c.quote}&rdquo;
+      </>
+    )}
+  </li>
+))}
+```
+Thread `onOpenCitation` and `pdfDocumentId` down the `SectionGroup`/`ClaimRow` prop chain.
+
+- [ ] **Step 4: Pass `pdfDocumentId` from the parent.** In `analyses/page.tsx`, find where `<ClaimsSection analysisId=… isClaimsActionable=… />` renders and add `pdfDocumentId={status?.pdfDocumentId}` (the status query already carries `pdfDocumentId`).
+
+- [ ] **Step 5: Run to verify it passes + existing tests + typecheck**
+
+Run: `cd apps/web && pnpm test src/components/admin/mechanic-extractor/claims && pnpm typecheck`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/components/admin/mechanic-extractor/claims/ClaimsSection.tsx "apps/web/src/app/admin/(dashboard)/knowledge-base/mechanic-extractor/analyses/page.tsx" apps/web/src/components/admin/mechanic-extractor/claims/__tests__/ClaimsSection.citation.test.tsx
+git commit -m "feat(mechanic-extractor): #526 open PdfQuoteHighlighter from citation rows (AC-2 wire)"
+```
+
+---
+
+## Task 10: Frontend — bulk-action dropdown (AC-3)
+
+**Files:**
+- Create: `apps/web/src/components/admin/mechanic-extractor/claims/BulkActionDialog.tsx`
+- Modify: `apps/web/src/components/admin/mechanic-extractor/claims/ClaimsSection.tsx`
+- Test: `apps/web/src/components/admin/mechanic-extractor/claims/__tests__/ClaimsSection.bulk.test.tsx`
+
+**Interfaces:**
+- Consumes: `adminClient.bulkApproveMechanicClaims`, `adminClient.bulkRejectMechanicClaims` (Task 5).
+- Produces: a `Select`-driven bulk menu with options `approve-pending` + `reject-long-quote`; `BulkActionDialog` confirm showing the predicted count. `data-testid` `bulk-action-select`, `bulk-action-confirm`, `bulk-action-count`.
+
+- [ ] **Step 1: Write the failing test** — pick "reject all with quote >20 words", assert the confirm dialog shows the count and calls `bulkRejectMechanicClaims` with the computed ids.
+
+```tsx
+/** @vitest-environment jsdom */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+const mockGetClaims = vi.hoisted(() => vi.fn());
+const mockBulkReject = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/api/clients/adminClient', () => ({
+  createAdminClient: () => ({
+    getMechanicAnalysisClaims: mockGetClaims,
+    bulkApproveMechanicClaims: vi.fn(),
+    bulkRejectMechanicClaims: mockBulkReject,
+  }),
+}));
+class MockHttpClient {}
+vi.mock('@/lib/api/core/httpClient', () => ({ HttpClient: MockHttpClient }));
+
+import { ClaimsSection } from '../ClaimsSection';
+
+const longQuote = Array.from({ length: 25 }, (_, i) => `w${i}`).join(' ');
+const claims = [
+  { id: 'd1', analysisId: 'a', section: 1, text: 't1', displayOrder: 0, status: 0,
+    reviewedBy: null, reviewedAt: null, rejectionNote: null, reviewNote: null, validations: [],
+    citations: [{ id: 'c1', pdfPage: 1, quote: longQuote, displayOrder: 0 }] },
+  { id: 'd2', analysisId: 'a', section: 1, text: 't2', displayOrder: 1, status: 0,
+    reviewedBy: null, reviewedAt: null, rejectionNote: null, reviewNote: null, validations: [],
+    citations: [{ id: 'c2', pdfPage: 1, quote: 'short quote', displayOrder: 0 }] },
+];
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+
+describe('ClaimsSection bulk reject by quote length', () => {
+  it('rejects only the >20-word-quote claim after count-confirm', async () => {
+    mockGetClaims.mockResolvedValue(claims);
+    mockBulkReject.mockResolvedValue({ rejectedCount: 1, skippedAlreadyRejectedCount: 0, claims });
+    render(<ClaimsSection analysisId="a" />, { wrapper: Wrapper });
+
+    fireEvent.change(await screen.findByTestId('bulk-action-select'), {
+      target: { value: 'reject-long-quote' },
+    });
+    expect(screen.getByTestId('bulk-action-count')).toHaveTextContent('1');
+    fireEvent.click(screen.getByTestId('bulk-action-confirm'));
+
+    expect(mockBulkReject).toHaveBeenCalledWith('a', expect.objectContaining({ claimIds: ['d1'] }));
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd apps/web && pnpm test src/components/admin/mechanic-extractor/claims/__tests__/ClaimsSection.bulk.test.tsx`
+Expected: FAIL — bulk select / confirm not implemented.
+
+- [ ] **Step 3: Implement the predicate + dialog.** Add a pure predicate helper near the top of `ClaimsSection.tsx`:
+```tsx
+const LONG_QUOTE_WORDS = 20;
+function wordCount(s: string): number {
+  return s.trim().split(/\s+/).filter(Boolean).length;
+}
+function claimsWithLongQuote(claims: MechanicClaimDto[]): MechanicClaimDto[] {
+  return claims.filter(c => c.citations.some(cit => wordCount(cit.quote) > LONG_QUOTE_WORDS));
+}
+```
+Create `BulkActionDialog.tsx` (an `AlertDialog` mirroring `RejectClaimDialog`) with props `{ open, onOpenChange, title, count, onConfirm, isPending }` rendering `data-testid="bulk-action-count"` and `data-testid="bulk-action-confirm"`. In the `ClaimsSection` header (replace the single bulk-approve button, lines ~220–235) add a `Select` (`data-testid="bulk-action-select"`) with options `Approve all pending ({pending})` → value `approve-pending`, `Reject all with quote >20 words ({n})` → value `reject-long-quote`. On change, compute the target set and open `BulkActionDialog` with the count. On confirm:
+- `approve-pending` → `bulkApproveMutation.mutate()` (existing).
+- `reject-long-quote` → `bulkRejectMutation.mutate({ claimIds: targets.map(c => c.id), reason: 'Citazione supera 20 parole (ADR-051 T1) — rifiuto bulk.' })`.
+Add `bulkRejectMutation` (mirror `bulkApproveMutation`; on success set an amber warning if `skippedAlreadyRejectedCount > 0`, then `invalidateClaimsAndStatus()`).
+
+- [ ] **Step 4: Run to verify it passes + typecheck + existing tests**
+
+Run: `cd apps/web && pnpm test src/components/admin/mechanic-extractor/claims && pnpm typecheck`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/admin/mechanic-extractor/claims
+git commit -m "feat(mechanic-extractor): #526 bulk-action dropdown with reject-by-quote-length + count-confirm (AC-3)"
+```
+
+---
+
+## Task 11: Frontend — approve-with-note dialog (AC-6 UI)
+
+**Files:**
+- Create: `apps/web/src/components/admin/mechanic-extractor/claims/ApproveClaimDialog.tsx`
+- Modify: `apps/web/src/components/admin/mechanic-extractor/claims/ClaimsSection.tsx`
+- Test: `apps/web/src/components/admin/mechanic-extractor/claims/__tests__/ClaimsSection.approveNote.test.tsx`
+
+**Interfaces:**
+- Consumes: `adminClient.approveMechanicClaim(id, claimId, note?)` (Task 5).
+- Produces: an optional-note approve flow. `data-testid` `approve-claim-note-input`, `approve-claim-confirm`.
+
+- [ ] **Step 1: Write the failing test** — click Approve → dialog → type a note → confirm → assert `approveMechanicClaim('a','d1','matches p.4')`, and the reviewNote renders after refetch.
+
+```tsx
+/** @vitest-environment jsdom */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+const mockGetClaims = vi.hoisted(() => vi.fn());
+const mockApprove = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/api/clients/adminClient', () => ({
+  createAdminClient: () => ({ getMechanicAnalysisClaims: mockGetClaims, approveMechanicClaim: mockApprove }),
+}));
+class MockHttpClient {}
+vi.mock('@/lib/api/core/httpClient', () => ({ HttpClient: MockHttpClient }));
+
+import { ClaimsSection } from '../ClaimsSection';
+const claim = { id: 'd1', analysisId: 'a', section: 1, text: 't', displayOrder: 0, status: 0,
+  reviewedBy: null, reviewedAt: null, rejectionNote: null, reviewNote: null, validations: [], citations: [] };
+function Wrapper({ children }: { children: React.ReactNode }) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+}
+
+describe('ClaimsSection approve with note', () => {
+  it('sends the optional note on approve', async () => {
+    mockGetClaims.mockResolvedValue([claim]);
+    mockApprove.mockResolvedValue({ ...claim, status: 1, reviewNote: 'matches p.4' });
+    render(<ClaimsSection analysisId="a" />, { wrapper: Wrapper });
+    fireEvent.click(await screen.findByTestId('claim-approve-d1'));
+    fireEvent.change(screen.getByTestId('approve-claim-note-input'), { target: { value: 'matches p.4' } });
+    fireEvent.click(screen.getByTestId('approve-claim-confirm'));
+    expect(mockApprove).toHaveBeenCalledWith('a', 'd1', 'matches p.4');
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd apps/web && pnpm test src/components/admin/mechanic-extractor/claims/__tests__/ClaimsSection.approveNote.test.tsx`
+Expected: FAIL — approve now opens a dialog instead of firing immediately.
+
+- [ ] **Step 3: Implement.** Create `ApproveClaimDialog.tsx` (`AlertDialog`, optional textarea, `data-testid="approve-claim-note-input"` + `approve-claim-confirm`; note is optional so confirm is always enabled). In `ClaimsSection`, change the Approve button to set an `approveTarget` (like `rejectTarget`) instead of calling `approveMutation.mutate` directly; render `<ApproveClaimDialog … onConfirm={note => approveMutation.mutate({ claimId: approveTarget.id, note })} />`. Change `approveMutation` to accept `{ claimId, note }` and call `adminClient.approveMechanicClaim(analysisId, claimId, note || undefined)`. Render `claim.reviewNote` in `ClaimRow` (a small green note block mirroring the rejection-note block) when present.
+
+- [ ] **Step 4: Run to verify it passes + existing claims tests + typecheck**
+
+Run: `cd apps/web && pnpm test src/components/admin/mechanic-extractor/claims && pnpm typecheck`
+Expected: PASS. (Note: `ClaimsSection` ships with **zero** pre-existing unit tests — the only tests touching `claim-approve-*` are the ones this plan creates in Tasks 8–11, and Tasks 8/9/10 never click approve, so routing approve through a dialog here breaks nothing prior. No external test needs updating.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/admin/mechanic-extractor/claims
+git commit -m "feat(mechanic-extractor): #526 approve-with-note dialog (AC-6 UI)"
+```
+
+---
+
+## Task 12: Frontend — footer attribution swap (AC-5)
+
+**Files:**
+- Create: `apps/web/src/components/admin/mechanic-extractor/MechanicAnalysisFooterAttribution.tsx`
+- Modify: `apps/web/src/app/admin/(dashboard)/knowledge-base/mechanic-extractor/review/page.tsx`
+- Test: `apps/web/src/components/admin/mechanic-extractor/__tests__/MechanicAnalysisFooterAttribution.test.tsx`
+
+**Interfaces:**
+- Produces: `<MechanicAnalysisFooterAttribution totalTokensUsed? estimatedCostUsd? />` rendering the ADR-051 canonical string.
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+/** @vitest-environment jsdom */
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { MechanicAnalysisFooterAttribution } from '../MechanicAnalysisFooterAttribution';
+
+describe('MechanicAnalysisFooterAttribution', () => {
+  it('renders the ADR-051 attribution and NOT the forbidden Variant-C string', () => {
+    render(<MechanicAnalysisFooterAttribution totalTokensUsed={500} estimatedCostUsd={0.002} />);
+    expect(screen.getByText(/riformulata in parole originali e cita la pagina/i)).toBeInTheDocument();
+    expect(screen.queryByText(/non ha mai letto il testo del PDF originale/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/500 tokens/)).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd apps/web && pnpm test src/components/admin/mechanic-extractor/__tests__/MechanicAnalysisFooterAttribution.test.tsx`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the component** — `MechanicAnalysisFooterAttribution.tsx`:
+
+```tsx
+/* eslint-disable local/no-hardcoded-color-utility -- admin tools chrome. DS-13d admin scope. */
+import React from 'react';
+
+export interface MechanicAnalysisFooterAttributionProps {
+  readonly totalTokensUsed?: number;
+  readonly estimatedCostUsd?: number;
+}
+
+/**
+ * #526 AC-5 — ADR-051 canonical attribution footer. Shared between the admin review page and the
+ * public card (#528). Replaces the retired Variant-C "L'AI non ha mai letto…" copy.
+ */
+export function MechanicAnalysisFooterAttribution({
+  totalTokensUsed,
+  estimatedCostUsd,
+}: MechanicAnalysisFooterAttributionProps): React.JSX.Element {
+  return (
+    <div className="rounded-lg border border-green-200 bg-green-50/50 p-4 text-center text-xs text-green-800 dark:border-green-800 dark:bg-green-950/20 dark:text-green-300 print:border-green-400">
+      <strong>&copy; 2026 MeepleAI</strong> — Contenuto originale.
+      <br />
+      <span className="opacity-70">
+        Analisi elaborata dall&apos;AI sul manuale del gioco. Ogni affermazione è riformulata in
+        parole originali e cita la pagina del regolamento. Copyright &copy; degli editori per il
+        testo originale del manuale.
+      </span>
+      {(totalTokensUsed ?? 0) > 0 && (
+        <span className="ml-2 opacity-70">
+          | {totalTokensUsed} tokens, ${(estimatedCostUsd ?? 0).toFixed(4)}
+        </span>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Swap in `review/page.tsx`.** Add the import to the `@/components/admin/mechanic-extractor/…` cluster; replace the footer `<div>` block (lines 271–285, the `{/* Copyright Footer */}` comment + div) with:
+```tsx
+      {/* Copyright Footer (ADR-051, #526 AC-5) */}
+      <MechanicAnalysisFooterAttribution
+        totalTokensUsed={draft.totalTokensUsed}
+        estimatedCostUsd={draft.estimatedCostUsd}
+      />
+```
+
+- [ ] **Step 5: Update the stale review-page test.** The existing test `renders copyright footer with Variant C text` in `review.test.tsx` has **two** assertions inside the swapped-out footer: `/Variant C/` (line 83) AND `/L'AI non ha mai letto…/` (line 85). The new `MechanicAnalysisFooterAttribution` renders **neither** — updating only line 85 leaves line 83 red. Rewrite the whole test to assert the new attribution and drop `/Variant C/`:
+
+```tsx
+    expect(await screen.findByText(/riformulata in parole originali/i)).toBeInTheDocument();
+    expect(
+      screen.queryByText(/non ha mai letto il testo del PDF originale/i)
+    ).not.toBeInTheDocument();
+```
+
+- [ ] **Step 6: Verify the forbidden string is gone + tests pass.** The source uses the entity apostrophe `L&apos;AI` and wraps `…del PDF` / `originale.` across two lines, so a full-phrase grep never matches the page — use the short substring:
+
+```
+cd apps/web && grep -rn "non ha mai letto" src ; echo "hits above (expect 0)"
+pnpm test src/components/admin/mechanic-extractor/__tests__/MechanicAnalysisFooterAttribution.test.tsx
+pnpm test src/__tests__/app/admin/knowledge-base/mechanic-extractor/review.test.tsx
+```
+Expected: **0 grep hits**; both tests PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/src/components/admin/mechanic-extractor/MechanicAnalysisFooterAttribution.tsx apps/web/src/components/admin/mechanic-extractor/__tests__ "apps/web/src/app/admin/(dashboard)/knowledge-base/mechanic-extractor/review/page.tsx" apps/web/src/__tests__/app/admin/knowledge-base/mechanic-extractor/review.test.tsx
+git commit -m "feat(mechanic-extractor): #526 swap Variant-C footer for ADR-051 attribution (AC-5)"
+```
+
+---
+
+## Task 13: E2E — bulk-reject + citation-open flows (AC-9)
+
+**Files:**
+- Modify: `apps/web/e2e/admin-mechanic-extractor-validation/load-existing-analysis.spec.ts`
+
+**Interfaces:**
+- Consumes: all prior tasks (the running app).
+
+- [ ] **Step 1: Update the claims fixture (REQUIRED — Task 5 made `reviewNote` + `validations` non-optional) + add a bulk-reject mock.** `HttpClient.validateResponse` throws `SchemaValidationError` on a `safeParse` miss, so the existing `buildClaimsResponse()` (which omits both new fields) will make `getMechanicAnalysisClaims` throw → `ClaimsSection` renders `claims-load-error` and **all three existing E2E tests break** (deep-link / load-by-id / discovery). Every claim object in `buildClaimsResponse()` MUST add:
+```ts
+      reviewNote: null,
+      validations: [
+        { rule: 'T1', outcome: 'pass', message: null },
+        { rule: 'T2', outcome: 'pass', message: null },
+        { rule: 'T3', outcome: 'pass', message: null },
+        { rule: 'T4', outcome: 'pass', message: null },
+      ],
+```
+Then, in `mockAnalysisRoutes`, add `bulkReject: 0` to `calls`, extend `buildClaimsResponse()` to return two claims (`CLAIM_ID` with a >20-word quote + a second short-quote claim), flip the status builder to `InReview` (so the bulk `Select` renders — `isClaimsActionable = InReview && !suppressed`), and register:
+```ts
+  await page.context().route(
+    new RegExp(`/api/v1/admin/mechanic-analyses/${ANALYSIS_ID}/claims/bulk-reject$`),
+    async (route: Route) => {
+      if (route.request().method() === 'POST') {
+        calls.bulkReject += 1;
+        await route.fulfill({ status: 200, contentType: 'application/json',
+          body: JSON.stringify({ rejectedCount: 1, skippedAlreadyRejectedCount: 0, claims: buildClaimsResponse() }) });
+        return;
+      }
+      await route.continue();
+    });
+```
+(Analysis status must be `InReview` for the bulk UI to be actionable — add an `InReview` status builder or parameterize `buildStatusDto()`.)
+
+- [ ] **Step 2: Add the bulk-reject test** inside the `test.describe`:
+```ts
+  test('bulk-reject by quote length calls the endpoint with computed ids', async ({ page }) => {
+    await setAdminSessionCookies(page);
+    const calls = await mockAnalysisRoutes(page);
+    await page.goto(`${ANALYSES_PATH}?analysisId=${ANALYSIS_ID}`);
+
+    await expect(page.getByTestId('claims-section')).toBeVisible();
+    await page.getByTestId('bulk-action-select').selectOption('reject-long-quote');
+    await expect(page.getByTestId('bulk-action-count')).toContainText('1');
+    await page.getByTestId('bulk-action-confirm').click();
+
+    await expect.poll(() => calls.bulkReject, { timeout: 5000 }).toBeGreaterThanOrEqual(1);
+  });
+```
+
+- [ ] **Step 3: Add the citation-open test:**
+```ts
+  test('clicking a citation opens the quote highlighter', async ({ page }) => {
+    await setAdminSessionCookies(page);
+    await mockAnalysisRoutes(page);
+    await page.goto(`${ANALYSES_PATH}?analysisId=${ANALYSIS_ID}`);
+
+    await page.getByTestId(`claim-citations-toggle-${CLAIM_ID}`).click();
+    await page.getByTestId(/^claim-citation-open-/).first().click();
+    await expect(page.getByRole('dialog')).toBeVisible();
+  });
+```
+
+- [ ] **Step 4: Run the spec**
+
+Run: `cd apps/web && pnpm test:e2e admin-mechanic-extractor-validation/load-existing-analysis.spec.ts`
+Expected: PASS (requires `NEXT_PUBLIC_MECHANIC_VALIDATION_ENABLED=true` at server start). If the PDF highlighter cannot load a blob in E2E, assert only the dialog opening (as above) — do not assert on-page highlight in E2E.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/e2e/admin-mechanic-extractor-validation/load-existing-analysis.spec.ts
+git commit -m "test(mechanic-extractor): #526 E2E bulk-reject + citation-open flows (AC-9)"
+```
+
+---
+
+## Task 14: Full-suite verification + follow-up issues
+
+- [ ] **Step 1: Backend suite**
+
+Run: `cd apps/api/src/Api && dotnet test --filter "BoundedContext=SharedGameCatalog"`
+Expected: green; no growth over the known-flaky baseline.
+
+- [ ] **Step 2: Frontend quality gates**
+
+Run: `cd apps/web && pnpm typecheck && pnpm lint && pnpm test src/components/admin/mechanic-extractor src/components/pdf src/lib/api`
+Expected: green. Also run `pnpm lint:tokens` if any admin CSS changed (should be none beyond the allowed eslint-disable pattern).
+
+- [ ] **Step 3: File the two follow-up issues** (referenced by #526's DoD):
+  - **FU-1 — AC-1 real validation persistence**: persist per-claim guardrail outcomes + scores at pipeline time; flip `MechanicClaimValidations.DerivePass()` to persisted data; enable the *reject-all-failing-T2* predicate + T3 score display.
+  - **FU-2 — AC-4 analysis finalize**: reconcile analysis-level finalize with #527/ADR-051 (card creation belongs to #527 Publish); resolve the `FinalizeMechanicAnalysisCommand` name collision. Amend #526 AC-4/DoD "becomes mechanic_card".
+
+  Run (adjust body files as needed):
+  ```bash
+  gh issue create --repo meepleAi-app/meepleai-monorepo --title "[ME-M1.4 FU-1] Persist per-claim T1-T4 validation outcomes + scores" --label enhancement,area/backend,mechanic-extractor --body "Follow-up of #526. Replace the derived MechanicClaimValidations.DerivePass() with real per-claim guardrail outcomes captured at pipeline time (incl. T3 grounding score). Unblocks the reject-all-failing-T2 predicate + score display in the admin badges and #527 snapshot."
+  gh issue create --repo meepleAi-app/meepleai-monorepo --title "[ME-M1.4 FU-2] Analysis finalize + #527 publish reconciliation" --label enhancement,area/backend,mechanic-extractor --body "Follow-up of #526. Reconcile the analysis-level finalize with #527/ADR-051: card creation belongs to #527 Publish, not #526. Amend #526 AC-4/DoD 'becomes mechanic_card'. Resolve the FinalizeMechanicAnalysisCommand name collision with the legacy Variant-C draft flow."
+  ```
+
+- [ ] **Step 4: Update #526** — comment linking the delivered ACs + the two follow-ups; note the AC-1 (derived, FU-1) and AC-4 (deferred, FU-2) scope amendments so the DoD reflects delivered scope. Push the branch and open the PR to `main-dev` (see execution handoff).
+
+---
+
+## Manual verification checklist (before PR)
+
+- [ ] Admin can open a real analysis (`?analysisId=`), see 4 green T1–T4 badges per claim.
+- [ ] Clicking a citation opens the PDF at the right page; the quote highlights, or the amber fallback banner shows if not matched. **Verify admin PDF authorization**: `api.pdf.getPdfDownloadUrl(pdfDocumentId)` must resolve for an admin against a shared-game rulebook — if it 403s, file a small follow-up for an admin PDF-fetch route (not a #526 blocker for the rest).
+- [ ] Bulk "reject >20 words" shows the correct count and rejects only those claims.
+- [ ] Approve-with-note stores + displays the note (green block).
+- [ ] Review page footer shows the ADR-051 string; `grep "non ha mai letto"` → 0 hits.

--- a/docs/superpowers/specs/2026-07-08-issue-526-me-m14-admin-review-core-design.md
+++ b/docs/superpowers/specs/2026-07-08-issue-526-me-m14-admin-review-core-design.md
@@ -1,0 +1,139 @@
+# Design — #526 ME-M1.4 Admin Review UI (core iteration)
+
+- **Issue**: [#526](https://github.com/meepleAi-app/meepleai-monorepo/issues/526) `[ME-M1.4] Admin Review UI: per-claim approve/reject + citation viewer`
+- **Parent ADR**: [ADR-051 Mechanic Extractor IP Policy](../../for-claude/architecture/adr/adr-051-mechanic-extractor-ip-policy.md)
+- **Date**: 2026-07-08
+- **Status**: PROPOSED (design approved in brainstorming; awaiting spec review → writing-plans)
+- **Branch**: `feature/issue-526-me-m14-admin-review-ui` (parent `main-dev`)
+
+---
+
+## 1. Context
+
+`#526` is the admin per-claim review surface for the Mechanic Extractor pipeline. PR #592 already shipped ~50% of the feature. A structured recon of the current codebase (7-agent understand fan-out, 2026-07-08) surfaced that the repository is in several places **ahead of** the issue body, and that two acceptance criteria carry **cross-issue contradictions** that must not be resolved unilaterally inside this issue.
+
+### Already shipped (PR #592 — verify + close)
+- Route consumes `mechanic_analyses` (not the legacy `mechanic_drafts`). **NB the route is the single-file `.../mechanic-extractor/analyses/page.tsx` deep-linked via `?analysisId=` query param — NOT a `[id]` dynamic route** (the issue's AC-Done text is inaccurate on this).
+- Per-claim approve/reject + `RejectClaimDialog` (mandatory note, 1–500 chars).
+- `MechanicAnalysesListCard` discovery table; `ClaimsSection` grouped-by-section claim list; single "Bulk approve pending" button.
+- Backend **`POST /admin/mechanic-analyses/{id}/claims/bulk-reject`** already exists (command + validator + handler + tests) — only the frontend wiring is missing.
+- Analysis lifecycle already present: `submit-review` → `approve` (`InReview`→`Published`, **409 if any claim is not Approved**) → `suppress`.
+- One E2E: `apps/web/e2e/admin-mechanic-extractor-validation/load-existing-analysis.spec.ts`.
+
+### Ground-truth facts from recon (evidence-backed)
+- **Guardrail (T1–T4) outcomes are transient.** `MechanicValidationViolation` (`IMechanicOutputValidator.cs:33` = `record (string Rule, string Message, string? Path)`) is produced only during the pipeline to drive rejection-sampling retries (`MechanicAnalysisPipeline.cs:220,238`) and then discarded. There is **no persisted per-claim validation column, and no `MechanicValidationViolation` domain entity.** `MechanicClaim` fields are: `AnalysisId, Section, Text, DisplayOrder, Status, ReviewedBy, ReviewedAt, RejectionNote, Citations, IsNew` (`MechanicClaim.cs`).
+- **Corollary:** any claim reaching the review queue has, by construction, passed its section's enabled guardrails (rejection sampling retries the section until guardrails pass, or aborts the analysis to `PartiallyExtracted`/`Rejected`). So real per-claim T1–T4 data is largely degenerate (all-pass) — persisting it is low value; a **derived** signal captures nearly all of it.
+- **Guardrail → rule-family map:** T1 = `QuoteCapGuardrail`, T2 = `RejectionSamplingGuardrail` (long-verbatim), T3a = `CitationPresenceGuardrail`, T3b = `GroundingGuardrail`, T4 = `PageSubstringGuardrail`.
+- **Analysis status enum** (`MechanicAnalysisStatus`): `Draft(0), InReview(1), Published(2), Rejected(3), PartiallyExtracted(4)`. There is **no `Approved` and no `NeedsReview`** state — the issue body's AC-4 wording assumes states that do not exist.
+- **`mechanic_card` aggregate does not exist yet** (0 files). It is created by #527's explicit Publish, not by #526.
+- **PDF stack already exists:** `react-pdf@10.4.1` + `pdfjs-dist@5.7.284` (pinned), worker bundled locally. Reusable viewers live in `apps/web/src/components/pdf/` (`PdfInlineViewer` documented as the shared viewer, `PdfViewerModal` already renders the text layer). **No on-page quote highlighting exists anywhere.** No bounding-box / pixel-coordinate data exists for quotes (blocks "Pattern B").
+- **`ApproveMechanicClaimCommand`** = `record (AnalysisId, ClaimId, ReviewerId)` — **no note field**; the domain `MechanicClaim.Approve()` clears `RejectionNote`. Approve-with-note therefore needs a new note sink.
+
+---
+
+## 2. Scope (locked)
+
+### IN — this PR (core)
+| AC | Deliverable |
+|----|-------------|
+| AC-1 (contract only) | Extend `MechanicClaimDto` with `validations[]` (**derived**, not persisted) + render T1–T4 badges from it (green/red/gray). |
+| AC-2 | `<PdfQuoteHighlighter>` at `components/pdf/`, Pattern A (text-layer search) + page-level fallback; wired into `ClaimsSection` citation rows. |
+| AC-3 | "Bulk action" dropdown: *approve-all-pending* (existing) + *reject-all-quote>20-words* (client predicate → existing bulk-reject endpoint) + count-confirm dialog. |
+| AC-5 | `<MechanicAnalysisFooterAttribution>` (ADR-051 canonical string); remove forbidden Variant-C string; grep gate → 0 hits. |
+| AC-6 (MVP) | Approve-with-note (optional): adds one nullable `ReviewNote` column + extends approve command. |
+| AC-7 (light) | `mechanic_review_bulk_actions_total{action}` counter via `MeepleAiMetrics`; test isolated per the static-Meter pollution pitfall (#2752). |
+| AC-8 | a11y: badge `aria-label`s, PDF modal focus-trap, dark-mode highlight contrast. |
+| AC-9 | Tests (Vitest + backend handler + E2E extension). |
+
+### OUT — deferred to scoped follow-up issues
+- **FU-1 (AC-1 real):** persist per-claim guardrail outcomes + scores (e.g. T3 grounding score) at pipeline time; flip the derived `validations[]` to persisted; unblocks the *reject-all-failing-T2* predicate and T3 score display.
+- **FU-2 (AC-4):** analysis-level Finalize + state-machine reconciliation with #527/ADR-051. **Amend** the #526 AC-4/DoD line "*Finalize → becomes mechanic_card*" — card creation belongs to #527's explicit Publish (ADR-051 §7 requires deliberate publication; #527 AD-5). Resolve the `FinalizeMechanicAnalysisCommand` name collision (the existing command is the legacy Variant-C draft flow).
+
+---
+
+## 3. Locked decisions
+
+1. **Scope** = core-completable + 2 follow-ups (above).
+2. **`<PdfQuoteHighlighter>` path** = `apps/web/src/components/pdf/PdfQuoteHighlighter.tsx` (matches all existing PDF primitives). Reconcile #530's spec text (which names `components/citations/`) to this path.
+3. **AC-1 data** = **derived from the pass-invariant** in `GetMechanicAnalysisClaimsQueryHandler`, not persisted. Documented as derived in code + DTO XML doc. Real persistence = FU-1.
+4. **AC-4 (finalize)** = **not in this PR.** #526 does NOT create the `mechanic_card`.
+5. **AC-2 algorithm** = Pattern A (text-layer substring search) with page-level-highlight + banner fallback (pre-authorized by #526 F2 and #530). Component API is hybrid-shaped (accepts optional coordinates) so a future Pattern-B backend slots in without an API change. Admin context does not require antiLeak → text layer is rendered.
+6. **AC-6** = the single nullable `ReviewNote` column is the **only migration** in core (AC-1 validations are derived, no migration). *Open to trimming to "reject-note only, defer approve-note to FU-1" at the review gate if a zero-migration core is preferred.*
+
+---
+
+## 4. Design detail
+
+### 4.1 Backend
+
+**`MechanicClaimDto` + validations contract** — add:
+```
+public sealed record MechanicClaimValidationDto(
+    string Rule,        // "T1" | "T2" | "T3" | "T4"
+    string Outcome,     // "pass" | "fail" | "notRun"
+    string? Message);   // populated only on fail (from MechanicValidationViolation.Message)
+```
+`MechanicClaimDto.Validations : IReadOnlyList<MechanicClaimValidationDto>`. `GetMechanicAnalysisClaimsQueryHandler` derives one entry per badge family (T1, T2, T3 = grounding+citation-present, T4): `pass` for enabled guardrails (any persisted claim passed them), `notRun` for guardrails disabled in `MechanicGuardrailOptions`. Never emits `fail` in the derived path (a failing claim would not be in the queue) — the `fail`/`Message` path lights up only once FU-1 persists real outcomes. #527 snapshots this array into `mechanic_cards.content` (score fields arrive with FU-1).
+
+**Approve-with-note (AC-6)** — add nullable `ReviewNote` (snake_case `review_note`) to `MechanicClaim` + `MechanicClaimEntity` + config + additive migration; add optional `Note` to `ApproveMechanicClaimCommand` + domain `MechanicClaim.Approve(reviewerId, utcNow, note?)`. Reject-note flow is unchanged (already shipped).
+
+**No new endpoints.** `bulk-reject` exists. AC-7 adds a counter increment in the bulk-reject/bulk-approve handlers.
+
+### 4.2 Frontend
+
+**`<PdfQuoteHighlighter pdfUrl page quote onClose coordinates?/>`** (`components/pdf/`) — composes `PdfInlineViewer`, opens at `page`, renders the text layer, normalizes whitespace/soft-hyphenation, substring-matches `quote` against positioned spans, overlays `<mark>` (`rgba(255,235,59,0.4)`). On no-match: page-level highlight + banner *"Quote non individuabile automaticamente; verifica manualmente"*. WCAG AA ≥3:1 + text-only toggle. PDF URL resolved from the analysis `pdfDocumentId` (`MechanicCitationDto` carries only `{pdfPage, quote}`).
+
+**`ClaimsSection` changes:**
+- **Badges (AC-1):** 4 badges/claim from `claim.validations ?? []`; green(pass)/red(fail)/gray(notRun|absent); tooltip = `message` on fail; `aria-label` per badge. Gray fallback when field empty → real-data flip is a pure BE change.
+- **Citation rows (AC-2):** the plain-text `p.N — "quote"` becomes a button → opens `<PdfQuoteHighlighter>`.
+- **Bulk dropdown (AC-3):** replace the single button with a `Select`: *Approva tutti i pending* (existing `bulkApproveMechanicClaims`); *Rifiuta tutti con quote >20 parole* (client predicate on `citations[].quote` word count → compute `claimIds` → existing `bulk-reject`), with a confirm dialog showing the predicted count (`"Rifiuta 7 claim?"`). **No 5-second undo** (count-confirm is the guard; keeps the audit log clean). Add FE: route constant `bulkRejectClaims`, `BulkRejectMechanicClaimsResponseDtoSchema`, `bulkRejectMechanicClaims` client method.
+- **Approve-with-note (AC-6):** optional collapsible textarea on approve (reuse the `RejectClaimDialog` pattern).
+
+**`<MechanicAnalysisFooterAttribution>`** (shared, reused by #528) renders the ADR-051 string:
+> *"Analisi elaborata dall'AI sul manuale del gioco. Ogni affermazione è riformulata in parole originali e cita la pagina del regolamento. Copyright © degli editori per il testo originale del manuale."*
+
+Remove the forbidden *"L'AI non ha mai letto il testo del PDF originale."* from `review/page.tsx` (and any other hit). **DoD gate:** `grep "L'AI non ha mai letto" apps/web/src` → 0 hits.
+
+### 4.3 Conventions (match existing admin code)
+shadcn primitives (`@/components/ui/{primitives,data-display,overlays}/…`), **not** MeepleCard. Keep the file-level `eslint-disable local/no-hardcoded-color-utility` (DS-13d admin scope) with the existing amber/green/rose class maps — **do not** introduce `--admin-*` tokens (that is DS-15/16). React Query keys `['mechanic-analysis', id, 'claims']` etc. Pervasive `data-testid`. EF: `HasColumnName("review_note")` (no auto snake_case).
+
+---
+
+## 5. Testing (AC-9)
+
+- **Vitest (FE):** badge render matrix (green/red/gray × T1–T4 fixtures); `<PdfQuoteHighlighter>` not-found fallback banner; bulk dropdown predicate → count → confirm; footer swap (old string absent, new string present); approve-with-note optional path.
+- **Backend:** `GetMechanicAnalysisClaimsQueryHandler` asserts derived `validations[]` (pass for enabled, notRun for disabled); `ApproveMechanicClaimCommand` with/without note; AC-7 counter test isolated (distinctive tag or `[Collection]` disabling parallel, per #2752).
+- **E2E:** extend `load-existing-analysis.spec.ts` → bulk-reject-by-predicate flow + citation-open flow.
+
+---
+
+## 6. Follow-up issues to open
+
+- **FU-1 — AC-1 real validation persistence.** Persist per-claim guardrail outcomes + scores at pipeline time; flip derived `validations[]` → persisted; enable *reject-all-failing-T2* predicate + T3 score display.
+- **FU-2 — AC-4 finalize + state reconciliation.** Analysis-level Finalize reconciled with #527/ADR-051; amend the "becomes mechanic_card" AC (card = #527 Publish); resolve the `FinalizeMechanicAnalysisCommand` name collision.
+
+Both must be filed **before** closing #526, and #526's AC-4/AC-1-real items moved into them so #526's DoD reflects the actual delivered scope.
+
+---
+
+## 7. Risks / open items
+
+- **Quote text-layer match rate** on OCR'd/photo-batch PDFs is unknown; Pattern A may fall back to page-level highlight frequently. Acceptable (fallback is pre-blessed), but worth a quick spike on a seeded game (e.g. Catan) during implementation.
+- **Admin PDF fetch authorization:** confirm an admin can fetch an arbitrary shared-game rulebook PDF via `pdfDocumentId` (existing `api.pdf.getPdfDownloadUrl` or a new admin route). If a new route is needed, it is a small addition.
+- **`PartiallyExtracted` analyses** in the review UI: badges render fine (surviving claims passed); bulk actions operate on present claims. No special handling needed for core.
+- Branch currently tracks `origin/main-dev`; push with `git push -u origin feature/issue-526-me-m14-admin-review-ui` to retarget upstream.
+
+---
+
+## 8. Key references
+- `apps/web/src/app/admin/(dashboard)/knowledge-base/mechanic-extractor/analyses/page.tsx` — review route (`?analysisId=`).
+- `apps/web/src/components/admin/mechanic-extractor/claims/ClaimsSection.tsx` — primary FE surface.
+- `apps/web/src/components/admin/mechanic-extractor/claims/RejectClaimDialog.tsx` — reuse for approve-note.
+- `apps/web/src/lib/api/schemas/mechanic-analyses.schemas.ts` — Zod DTOs + routes.
+- `apps/web/src/lib/api/clients/admin/adminContentClient.ts` — admin client methods.
+- `apps/web/src/components/pdf/PdfInlineViewer.tsx` — base for `<PdfQuoteHighlighter>`.
+- `apps/api/src/Api/Routing/AdminMechanicAnalysesEndpoints.cs` — REST surface (bulk-reject at :258).
+- `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/DTOs/MechanicClaimDto.cs` — DTO to extend.
+- `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Entities/MechanicClaim.cs` — add `ReviewNote`.
+- `apps/api/.../Application/Services/MechanicExtractor/Guardrails/*` — T1–T4 rule families.
+- `docs/for-claude/architecture/adr/adr-051-mechanic-extractor-ip-policy.md` — footer string, T-constraints, status enum addendum.

--- a/infra/compose.staging.yml
+++ b/infra/compose.staging.yml
@@ -298,8 +298,12 @@ services:
   alertmanager:
     restart: always
 
-  n8n:
-    restart: always
+  # n8n removed from staging (#2796): the WorkflowIntegration webhook client is
+  # disabled by default (N8n:IsEnabled=false, never set true in staging), so no
+  # GameNight webhooks were ever firing. The 1.62GB image + always-on container
+  # were pure disk cost on the CAX21. Base compose still defines n8n under the
+  # `automation` profile for local dev; re-enable in staging by re-adding this
+  # block AND setting N8n:IsEnabled=true.
 
 # Traefik service definition removed (PR #738, post CF Tunnel cutover, T18 Phase 6).
 # Edge is now Cloudflare Tunnel (cloudflared on VPS). For rollback see


### PR DESCRIPTION
Promozione release `main-dev` → `main-staging` (10 commit).

## Infra / disco (focus di questa sessione)
- **#2795** — reranker/embedding: torch CPU-only (−2.9GB CUDA/img su ARM) + reranker venv refactor. **Trigger rebuild ARM path-filtered** su `apps/{reranker,embedding}-service/**` → validazione reale del build ARM che non era possibile in locale (host x86).
- **#2797** — rimozione n8n da staging (inutilizzato) + gate health check n8n su `N8n:IsEnabled`.

## Altri commit nel batch (già mergiati/reviewati su main-dev)
- #2779/#2780/#2781 — #526 ME-M1.4 admin review UI (BE contract + FE schemas/PDF highlighter + ClaimsSection/E2E)
- #2778 — #527 ME-M1.5 publish approved → mechanic_cards
- #2771/#2774 — fix SSR (restore + auth routes server-props)
- #2777 — #564 TODO/FIXME triage gate
- #2775 — #2655 Security Review closeout report

## Post-deploy checklist (verifica manuale)
- [ ] deploy-staging run verde (rebuild ML ARM incluso)
- [ ] healthcheck reranker (8003) + embedding (8000) verdi
- [ ] `nvidia_*` assenti da site-packages delle nuove immagini ML
- [ ] disco staging in calo (~65% atteso)

🤖 Generated with [Claude Code](https://claude.com/claude-code)