### PR TITLE
fix(ci): #2799 passa il CF Access service token allo smoke E2E staging

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1531,6 +1531,12 @@ jobs:
         env:
           STAGING_URL: https://meepleai.app
           CI: 'true'
+          # #2799: staging is behind Cloudflare Access (owner-only). Pass the
+          # service-token so Playwright reaches the real app instead of the CF
+          # Access sign-in page. Consumed by playwright.staging.config.ts →
+          # extraHTTPHeaders. Same secrets the curl smoke already uses above.
+          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
         run: |
           echo "🧪 Running E2E smoke tests against staging..."
           pnpm exec playwright test e2e/smoke.spec.ts \

--- a/apps/web/playwright.staging.config.ts
+++ b/apps/web/playwright.staging.config.ts
@@ -18,6 +18,20 @@ export default defineConfig({
 
   use: {
     baseURL: process.env.STAGING_URL || 'https://meepleai.app',
+    // #2799: all of staging is behind Cloudflare Access (owner-only). Without
+    // these service-token headers every navigation lands on the CF Access
+    // "Sign in" page instead of the app — smoke.spec.ts step 2 (email input)
+    // fails deterministically and the lenient steps silently pass against CF's
+    // page. Mirrors the CF_ACCESS_CLIENT_ID/SECRET bypass the curl smoke already
+    // uses in deploy-staging.yml (Post-deploy Validation). Conditional so local
+    // runs without the tokens don't send empty headers.
+    extraHTTPHeaders:
+      process.env.CF_ACCESS_CLIENT_ID && process.env.CF_ACCESS_CLIENT_SECRET
+        ? {
+            'CF-Access-Client-Id': process.env.CF_ACCESS_CLIENT_ID,
+            'CF-Access-Client-Secret': process.env.CF_ACCESS_CLIENT_SECRET,
+          }
+        : {},
     trace: 'on-first-retry',
     actionTimeout: 10_000,
     navigationTimeout: 30_000,


### PR DESCRIPTION
Closes #2799

## Sintomo
`Staging E2E Smoke Tests` falliva **deterministicamente** su `smoke.spec.ts:41 › Auth login form visibile` (`input[type=email]/[name=email]` not found, timeout 15s). Rerun a VPS caldo → ri-fallito (non timing).

## Root cause
Tutto `meepleai.app` è dietro **Cloudflare Access (owner-only)**. Il job Playwright `e2e-staging` (runner GitHub-hosted → `https://meepleai.app`) **non passava gli header CF Access service-token**, quindi ogni navigazione atterrava sulla pagina "Sign in ・ Cloudflare Access", non sull'app. Il curl-smoke (Post-deploy Validation) usa già `CF_ACCESS_CLIENT_ID/SECRET`; il job Playwright no.

Le asserzioni lasche degli step 1,3-8 (`body`/heading) passavano anche contro la pagina CF Access → mascheravano il problema; solo lo step 2 lo esponeva.

**Evidenza**: curl esterno `/`,`/login`,`/dashboard` → tutti CF Access; curl VPS `localhost:3000/login` → 200 con `input id="login-email" type="email"` (SSR app corretto).

## Fix
- `apps/web/playwright.staging.config.ts`: `extraHTTPHeaders` con `CF-Access-Client-Id/Secret` da env (condizionale).
- `.github/workflows/deploy-staging.yml`: passa `CF_ACCESS_CLIENT_ID/SECRET` (secret esistenti) allo step "Run Smoke Tests against Staging".

## Validazione
Sullo smoke del prossimo deploy `main-staging` (dove i secret CF esistono). Localmente non riproducibile (serve il token + staging live).

## Follow-up (separato)
`API_BASE` fallback a `localhost:8080` → i mock `page.route` non scattano sullo staging; step 3-8 testano dati reali con asserzioni solo-`body`. Da irrobustire in issue dedicata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)