### PR TITLE
release: promote main-dev → main-staging (#2800 CF Access smoke fix)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1531,6 +1531,12 @@ jobs:
         env:
           STAGING_URL: https://meepleai.app
           CI: 'true'
+          # #2799: staging is behind Cloudflare Access (owner-only). Pass the
+          # service-token so Playwright reaches the real app instead of the CF
+          # Access sign-in page. Consumed by playwright.staging.config.ts →
+          # extraHTTPHeaders. Same secrets the curl smoke already uses above.
+          CF_ACCESS_CLIENT_ID: ${{ secrets.CF_ACCESS_CLIENT_ID }}
+          CF_ACCESS_CLIENT_SECRET: ${{ secrets.CF_ACCESS_CLIENT_SECRET }}
         run: |
           echo "🧪 Running E2E smoke tests against staging..."
           pnpm exec playwright test e2e/smoke.spec.ts \

--- a/apps/web/playwright.staging.config.ts
+++ b/apps/web/playwright.staging.config.ts
@@ -18,6 +18,20 @@ export default defineConfig({
 
   use: {
     baseURL: process.env.STAGING_URL || 'https://meepleai.app',
+    // #2799: all of staging is behind Cloudflare Access (owner-only). Without
+    // these service-token headers every navigation lands on the CF Access
+    // "Sign in" page instead of the app — smoke.spec.ts step 2 (email input)
+    // fails deterministically and the lenient steps silently pass against CF's
+    // page. Mirrors the CF_ACCESS_CLIENT_ID/SECRET bypass the curl smoke already
+    // uses in deploy-staging.yml (Post-deploy Validation). Conditional so local
+    // runs without the tokens don't send empty headers.
+    extraHTTPHeaders:
+      process.env.CF_ACCESS_CLIENT_ID && process.env.CF_ACCESS_CLIENT_SECRET
+        ? {
+            'CF-Access-Client-Id': process.env.CF_ACCESS_CLIENT_ID,
+            'CF-Access-Client-Secret': process.env.CF_ACCESS_CLIENT_SECRET,
+          }
+        : {},
     trace: 'on-first-retry',
     actionTimeout: 10_000,
     navigationTimeout: 30_000,


### PR DESCRIPTION
Promozione release `main-dev` → `main-staging` — **1 commit isolato**.

## Contenuto
- **#2800** (#2799) — passa il CF Access service-token allo smoke E2E Playwright: `extraHTTPHeaders` in `playwright.staging.config.ts` + env `CF_ACCESS_CLIENT_ID/SECRET` sul job `Staging E2E Smoke Tests`.

## Scopo
Validare il fix: al deploy, lo step `smoke.spec.ts › 2. Auth login form visibile` deve diventare **verde** (Playwright ora attraversa CF Access e raggiunge la login reale con l'email input SSR, invece della sign-in di Cloudflare).

## Post-deploy checklist
- [ ] deploy-staging verde
- [ ] `Staging E2E Smoke Tests` → step 2 "Auth login form visibile" PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)