### PR TITLE
fix(invitation): /accept-invite redeem link, real emailSent, last-writer-wins in approval

### DIFF
--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/Invitation/SendInvitationCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/Invitation/SendInvitationCommandHandler.cs
@@ -75,7 +75,10 @@ internal sealed class SendInvitationCommandHandler : ICommandHandler<SendInvitat
         await _invitationRepo.AddAsync(invitation, cancellationToken).ConfigureAwait(false);
         await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
-        // Send email (fire-and-forget pattern — log errors but don't fail the operation)
+        // Send email (fire-and-forget pattern — log errors but don't fail the operation).
+        // Track the real send outcome so the DTO's EmailSent reflects an SMTP failure instead of
+        // always reporting true (bug #D): the admin UI reports "invito inviato" off this flag.
+        var emailSent = true;
         try
         {
             await _emailService.SendInvitationEmailAsync(
@@ -89,10 +92,11 @@ internal sealed class SendInvitationCommandHandler : ICommandHandler<SendInvitat
         catch (Exception ex)
         {
             _logger.LogWarning(ex, "Failed to send invitation email to {Email}", DataMasking.MaskEmail(normalizedEmail));
+            emailSent = false;
         }
 #pragma warning restore CA1031
 
-        return MapToDto(invitation, rawToken);
+        return MapToDto(invitation, rawToken) with { EmailSent = emailSent };
     }
 
     internal static InvitationDto MapToDto(InvitationToken invitation, string? rawToken = null)

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/EventHandlers/AccessRequestApprovedEventHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/EventHandlers/AccessRequestApprovedEventHandler.cs
@@ -52,11 +52,15 @@ internal sealed class AccessRequestApprovedEventHandler : DomainEventHandlerBase
                     domainEvent.ApprovedByUserId),
                 cancellationToken).ConfigureAwait(false);
 
-            // Set correlation ID linking access request to invitation
+            // Set correlation ID linking access request to invitation.
+            // Partial update (happy-path #B): write ONLY invitation_id via a direct SQL UPDATE.
+            // A full UpdateAsync(aggregate) here reverted the approved status (last-writer-wins),
+            // and adding a reentrant SaveChanges tripped the ConcurrencyDetector inside the outbox
+            // processor's transaction. SetInvitationIdAsync executes immediately without either hazard.
             if (accessRequest is not null)
             {
-                accessRequest.SetInvitationId(invitationResult.Id);
-                await _repository.UpdateAsync(accessRequest, cancellationToken).ConfigureAwait(false);
+                await _repository.SetInvitationIdAsync(
+                    domainEvent.AccessRequestId, invitationResult.Id, cancellationToken).ConfigureAwait(false);
             }
         }
         catch (Exception ex)

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/EventHandlers/AccessRequestCreatedEventHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/EventHandlers/AccessRequestCreatedEventHandler.cs
@@ -4,7 +4,6 @@ using Api.Infrastructure;
 using Api.Infrastructure.Security;
 using Api.Services;
 using Api.SharedKernel.Application.EventHandlers;
-using Api.SharedKernel.Infrastructure.Persistence;
 using Microsoft.Extensions.Logging;
 
 namespace Api.BoundedContexts.Authentication.Application.EventHandlers;
@@ -13,19 +12,16 @@ internal sealed class AccessRequestCreatedEventHandler : DomainEventHandlerBase<
 {
     private readonly IAlertingService _alertingService;
     private readonly IAccessRequestRepository _repository;
-    private readonly IUnitOfWork _unitOfWork;
 
     public AccessRequestCreatedEventHandler(
         MeepleAiDbContext dbContext,
         IAlertingService alertingService,
         IAccessRequestRepository repository,
-        IUnitOfWork unitOfWork,
         ILogger<AccessRequestCreatedEventHandler> logger)
         : base(dbContext, logger)
     {
         _alertingService = alertingService;
         _repository = repository;
-        _unitOfWork = unitOfWork;
     }
 
     protected override async Task HandleEventAsync(
@@ -90,9 +86,12 @@ internal sealed class AccessRequestCreatedEventHandler : DomainEventHandlerBase<
         // may resend the Slack alert on the retry — accepted trade-off vs the alternative
         // where a DB failure after a successful Slack send silently swallows the guard,
         // which would have the same effect plus no operator signal.
-        accessRequest.MarkNotified(domainEvent.EventId);
-        await _repository.UpdateAsync(accessRequest, cancellationToken).ConfigureAwait(false);
-        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        // Partial update (happy-path #B): persist ONLY last_notified_event_id via a direct SQL
+        // UPDATE. The previous MarkNotified + full UpdateAsync(aggregate) + SaveChanges reverted a
+        // concurrently-committed approval (last-writer-wins) — the handler's read can predate the
+        // approval, so writing the whole aggregate back clobbered the Approved status.
+        await _repository.MarkNotifiedAsync(
+            domainEvent.AccessRequestId, domainEvent.EventId, cancellationToken).ConfigureAwait(false);
     }
 
     protected override Guid? GetUserId(AccessRequestCreatedEvent domainEvent)

--- a/apps/api/src/Api/BoundedContexts/Authentication/Domain/Repositories/IAccessRequestRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Domain/Repositories/IAccessRequestRepository.cs
@@ -12,4 +12,21 @@ internal interface IAccessRequestRepository : IRepository<AccessRequest, Guid>
         CancellationToken cancellationToken = default);
     Task<int> CountByStatusAsync(AccessRequestStatus status, CancellationToken cancellationToken = default);
     Task<int> CountAllAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Partial update: persists ONLY <c>InvitationId</c> via a direct SQL UPDATE.
+    /// Used by <c>AccessRequestApprovedEventHandler</c> during async outbox dispatch so it does
+    /// NOT rewrite the whole aggregate — a full <see cref="IRepository{T,TKey}.UpdateAsync"/> would
+    /// clobber a concurrently-committed status change (last-writer-wins, happy-path #B 2026-07-10).
+    /// Executes immediately (no <c>SaveChangesAsync</c>), so it never reenters the event dispatcher.
+    /// </summary>
+    Task SetInvitationIdAsync(Guid id, Guid invitationId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Partial update: persists ONLY <c>LastNotifiedEventId</c> (Slack-alert idempotency guard,
+    /// #1940) via a direct SQL UPDATE. Same rationale as <see cref="SetInvitationIdAsync"/> — the
+    /// Created-event handler must not rewrite the rest of the aggregate (which would revert an
+    /// approval that landed between the handler's read and its write).
+    /// </summary>
+    Task MarkNotifiedAsync(Guid id, Guid eventId, CancellationToken cancellationToken = default);
 }

--- a/apps/api/src/Api/BoundedContexts/Authentication/Infrastructure/Repositories/AccessRequestRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Infrastructure/Repositories/AccessRequestRepository.cs
@@ -125,6 +125,26 @@ internal sealed class AccessRequestRepository : RepositoryBase, IAccessRequestRe
             .ConfigureAwait(false);
     }
 
+    public async Task SetInvitationIdAsync(Guid id, Guid invitationId, CancellationToken cancellationToken = default)
+    {
+        // Direct SQL UPDATE of a single column: does NOT load the aggregate, does NOT touch the
+        // ChangeTracker, and does NOT require SaveChangesAsync. This avoids the full-aggregate
+        // overwrite (last-writer-wins, #B 2026-07-10) that reverted an approved status when a
+        // stale aggregate snapshot was written back during async outbox dispatch.
+        await DbContext.AccessRequests
+            .Where(e => e.Id == id)
+            .ExecuteUpdateAsync(s => s.SetProperty(e => e.InvitationId, invitationId), cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public async Task MarkNotifiedAsync(Guid id, Guid eventId, CancellationToken cancellationToken = default)
+    {
+        await DbContext.AccessRequests
+            .Where(e => e.Id == id)
+            .ExecuteUpdateAsync(s => s.SetProperty(e => e.LastNotifiedEventId, eventId), cancellationToken)
+            .ConfigureAwait(false);
+    }
+
     /// <summary>
     /// Maps infrastructure entity to domain aggregate.
     /// Uses internal factory + RestoreState method (no reflection).

--- a/apps/api/src/Api/Services/Email/EmailService.Auth.cs
+++ b/apps/api/src/Api/Services/Email/EmailService.Auth.cs
@@ -312,9 +312,13 @@ internal partial class EmailService
     }
 
     // ISSUE-124: Invitation system emails
-    // Issue #1629: refactored to route through IEmailSender (Resend/SMTP) and
-    // fixed redeem link from /accept-invite?token=… to /invites/{token} so it
-    // matches the actual Next.js route at apps/web/src/app/(public)/invites/[token].
+    // Issue #1629: refactored to route through IEmailSender (Resend/SMTP).
+    // Redeem link: the base-invitation flow (token only, no pending user) is redeemed at
+    // /accept-invite?token= → POST /auth/accept-invitation, which creates the user from
+    // token+password (AcceptInvitationCommandHandler). NOTE: #1629 mistakenly repointed this
+    // to /invites/{token}, which is the game-night RSVP landing (game_night_invitations) and
+    // 404s for invitation tokens; restored to /accept-invite here. (The enhanced/provisioned
+    // flow with a pending user uses /setup-account?token= — see the overload below.)
     public async Task SendInvitationEmailAsync(
         string toEmail,
         string role,
@@ -324,7 +328,7 @@ internal partial class EmailService
     {
         try
         {
-            var inviteLink = $"{_frontendBaseUrl}/invites/{Uri.EscapeDataString(token)}";
+            var inviteLink = $"{_frontendBaseUrl}/accept-invite?token={Uri.EscapeDataString(token)}";
             var subject = "You've been invited to MeepleAI";
             var body = BuildInvitationEmailBody(role, inviteLink, invitedByName);
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/Authentication/Commands/Invitation/SendInvitationCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Authentication/Commands/Invitation/SendInvitationCommandHandlerTests.cs
@@ -1,0 +1,98 @@
+using Api.BoundedContexts.Authentication.Application.Commands.Invitation;
+using Api.BoundedContexts.Authentication.Domain.Entities;
+using Api.BoundedContexts.Authentication.Domain.Repositories;
+using Api.BoundedContexts.Authentication.Domain.ValueObjects;
+using Api.BoundedContexts.Authentication.Infrastructure.Persistence;
+using Api.Services;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.Authentication.Commands.Invitation;
+
+/// <summary>
+/// Unit tests for SendInvitationCommandHandler.
+/// Bug #D (happy-path testing 2026-07-10): the DTO's EmailSent flag must reflect the real SMTP
+/// outcome instead of always reporting true — the admin "Invite User" UI reports "invito inviato"
+/// off this flag, so a silent SMTP failure previously showed a false success.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "Authentication")]
+public sealed class SendInvitationCommandHandlerTests
+{
+    private readonly Mock<IInvitationTokenRepository> _invitationRepo = new();
+    private readonly Mock<IUserRepository> _userRepo = new();
+    private readonly Mock<IUnitOfWork> _unitOfWork = new();
+    private readonly Mock<IEmailService> _emailService = new();
+    private readonly Mock<ILogger<SendInvitationCommandHandler>> _logger = new();
+    private readonly SendInvitationCommandHandler _handler;
+
+    public SendInvitationCommandHandlerTests()
+    {
+        // No pending invitation, no existing user → the happy-path branch that reaches email send.
+        _invitationRepo
+            .Setup(r => r.GetPendingByEmailAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((InvitationToken?)null);
+        _invitationRepo
+            .Setup(r => r.AddAsync(It.IsAny<InvitationToken>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _userRepo
+            .Setup(r => r.ExistsByEmailAsync(It.IsAny<Email>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        _unitOfWork
+            .Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        _handler = new SendInvitationCommandHandler(
+            _invitationRepo.Object,
+            _userRepo.Object,
+            _unitOfWork.Object,
+            _emailService.Object,
+            _logger.Object);
+    }
+
+    private static SendInvitationCommand ValidCommand() =>
+        new("newuser@example.com", "User", Guid.NewGuid());
+
+    [Fact]
+    public async Task Handle_WhenEmailSendSucceeds_ReturnsEmailSentTrue()
+    {
+        // Arrange
+        _emailService
+            .Setup(e => e.SendInvitationEmailAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        // Act
+        var result = await _handler.Handle(ValidCommand(), CancellationToken.None);
+
+        // Assert
+        result.EmailSent.Should().BeTrue();
+        _unitOfWork.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WhenEmailSendFails_ReturnsEmailSentFalse_ButStillPersistsInvitation()
+    {
+        // Arrange — an SMTP transport failure surfaces as InvalidOperationException from EmailService.
+        _emailService
+            .Setup(e => e.SendInvitationEmailAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("Failed to send invitation email"));
+
+        // Act
+        var result = await _handler.Handle(ValidCommand(), CancellationToken.None);
+
+        // Assert — the invitation is still saved (fire-and-forget), but EmailSent MUST be false
+        // so the caller can surface the delivery failure instead of a false positive.
+        result.EmailSent.Should().BeFalse();
+        _invitationRepo.Verify(
+            r => r.AddAsync(It.IsAny<InvitationToken>(), It.IsAny<CancellationToken>()), Times.Once);
+        _unitOfWork.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/apps/api/tests/Api.Tests/Integration/Authentication/AccessRequestApprovalIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/Authentication/AccessRequestApprovalIntegrationTests.cs
@@ -1,0 +1,212 @@
+using Api.BoundedContexts.Authentication.Application.Commands.AccessRequest;
+using Api.BoundedContexts.Authentication.Domain.Entities;
+using Api.BoundedContexts.Authentication.Domain.Events;
+using Api.BoundedContexts.Authentication.Domain.Repositories;
+using Api.BoundedContexts.Authentication.Infrastructure.Persistence;
+using Api.BoundedContexts.Authentication.Infrastructure.Repositories;
+using Api.Infrastructure;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Time.Testing;
+using Npgsql;
+using Xunit;
+
+namespace Api.Tests.Integration.Authentication;
+
+/// <summary>
+/// Integration tests isolating the access-request APPROVAL flow (happy-path testing 2026-07-10, #B).
+/// Repro target: after approving, access_requests.status must become "Approved" and invitation_id
+/// must be populated — observed in the running app to stay Pending/null while a token IS created.
+/// This test isolates the COMMAND (no outbox processor running) to determine whether the command
+/// itself persists the Approved status.
+/// </summary>
+[Collection("Integration-GroupB")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("Dependency", "PostgreSQL")]
+[Trait("BoundedContext", "Authentication")]
+public sealed class AccessRequestApprovalIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private string _databaseName = string.Empty;
+    private MeepleAiDbContext _dbContext = null!;
+    private IServiceProvider _serviceProvider = null!;
+    private static CancellationToken Ct => TestContext.Current.CancellationToken;
+
+    private static readonly Guid AdminUserId = new("a0000000-0000-0000-0000-000000000001");
+
+    public AccessRequestApprovalIntegrationTests(SharedTestcontainersFixture fixture) => _fixture = fixture;
+
+    public async ValueTask InitializeAsync()
+    {
+        _databaseName = $"test_access_approval_{Guid.NewGuid():N}";
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+
+        var enforced = new NpgsqlConnectionStringBuilder(connectionString)
+        {
+            SslMode = SslMode.Disable,
+            KeepAlive = 30,
+            Pooling = false,
+            Timeout = 15,
+            CommandTimeout = 30
+        };
+
+        var services = IntegrationServiceCollectionBuilder.CreateBase(enforced.ConnectionString);
+        services.AddSingleton<TimeProvider>(new FakeTimeProvider(DateTimeOffset.UtcNow));
+        services.AddScoped<IUserRepository, UserRepository>();
+        services.AddScoped<ISessionRepository, SessionRepository>();
+        services.AddScoped<IInvitationTokenRepository, InvitationTokenRepository>();
+        services.AddScoped<IAccessRequestRepository, AccessRequestRepository>();
+
+        _serviceProvider = services.BuildServiceProvider();
+        _dbContext = _serviceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        await TestMigrationHelper.MigrateWithRetryAsync(_dbContext, Ct);
+
+        // Seed admin (approver)
+        var userRepo = _serviceProvider.GetRequiredService<IUserRepository>();
+        var uow = _serviceProvider.GetRequiredService<IUnitOfWork>();
+        var admin = new Api.BoundedContexts.Authentication.Domain.Entities.User(
+            AdminUserId,
+            new Api.BoundedContexts.Authentication.Domain.ValueObjects.Email("admin@test.meepleai.dev"),
+            "Test Admin",
+            Api.BoundedContexts.Authentication.Domain.ValueObjects.PasswordHash.Create("AdminUnusualPwd123!"),
+            Api.SharedKernel.Domain.ValueObjects.Role.Admin);
+        await userRepo.AddAsync(admin, Ct);
+        await uow.SaveChangesAsync(Ct);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _dbContext.DisposeAsync();
+        if (_serviceProvider is IAsyncDisposable d) await d.DisposeAsync();
+        if (!string.IsNullOrEmpty(_databaseName))
+        {
+            try { await _fixture.DropIsolatedDatabaseAsync(_databaseName); } catch { /* best-effort */ }
+        }
+    }
+
+    [Fact]
+    public async Task Approve_CommandAlone_PersistsApprovedStatus()
+    {
+        // Arrange — a pending access request committed to the DB.
+        var repo = _serviceProvider.GetRequiredService<IAccessRequestRepository>();
+        var uow = _serviceProvider.GetRequiredService<IUnitOfWork>();
+        var mediator = _serviceProvider.GetRequiredService<IMediator>();
+
+        var request = AccessRequest.Create("approve-iso@test.dev");
+        var requestId = request.Id;
+        await repo.AddAsync(request, Ct);
+        await uow.SaveChangesAsync(Ct);
+
+        // Act — approve via the command. OutboxOnly + no processor registered here, so the
+        // AccessRequestApprovedEvent handler does NOT fire. This isolates the command's own persistence.
+        await mediator.Send(new ApproveAccessRequestCommand(requestId, AdminUserId), Ct);
+
+        // Assert — read the committed row directly (fresh, no tracking).
+        _dbContext.ChangeTracker.Clear();
+        var committed = await _dbContext.AccessRequests.AsNoTracking()
+            .FirstAsync(e => e.Id == requestId, Ct);
+        committed.Status.Should().Be("Approved",
+            "the approve command must persist the Approved status independently of the event handler");
+        committed.ReviewedBy.Should().Be(AdminUserId);
+    }
+
+    [Fact]
+    public async Task Approve_ThenDispatchEventInSeparateScope_KeepsApprovedAndCorrelatesInvitation()
+    {
+        // Arrange
+        var repo = _serviceProvider.GetRequiredService<IAccessRequestRepository>();
+        var uow = _serviceProvider.GetRequiredService<IUnitOfWork>();
+        var mediator = _serviceProvider.GetRequiredService<IMediator>();
+
+        var request = AccessRequest.Create("approve-e2e@test.dev");
+        var requestId = request.Id;
+        var email = request.Email;
+        await repo.AddAsync(request, Ct);
+        await uow.SaveChangesAsync(Ct);
+
+        // 1. Approve via command — commits Approved status + enqueues the outbox event.
+        await mediator.Send(new ApproveAccessRequestCommand(requestId, AdminUserId), Ct);
+
+        // 2. Reproduce the DomainEventOutboxProcessor: it dispatches the event in a SEPARATE
+        //    scope (its own DbContext) and calls SaveChanges after the handler runs (line 230).
+        using (var procScope = _serviceProvider.CreateScope())
+        {
+            var procMediator = procScope.ServiceProvider.GetRequiredService<IMediator>();
+            var procDb = procScope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            await procMediator.Publish(new AccessRequestApprovedEvent(requestId, email, AdminUserId), Ct);
+            await procDb.SaveChangesAsync(Ct);
+        }
+
+        // 3. Assert final persisted state (fresh read).
+        _dbContext.ChangeTracker.Clear();
+        var final = await _dbContext.AccessRequests.AsNoTracking().FirstAsync(e => e.Id == requestId, Ct);
+        final.Status.Should().Be("Approved",
+            "status must remain Approved after the async event handler runs");
+        final.InvitationId.Should().NotBeNull(
+            "the event handler must persist the invitation correlation id (idempotency guard #1940)");
+    }
+
+    [Fact]
+    public async Task MarkNotified_PartialUpdate_DoesNotClobberApprovedStatus()
+    {
+        // Arrange — a pending request, then approved.
+        var repo = _serviceProvider.GetRequiredService<IAccessRequestRepository>();
+        var uow = _serviceProvider.GetRequiredService<IUnitOfWork>();
+        var mediator = _serviceProvider.GetRequiredService<IMediator>();
+
+        var request = AccessRequest.Create("guard@test.dev");
+        var id = request.Id;
+        await repo.AddAsync(request, Ct);
+        await uow.SaveChangesAsync(Ct);
+        await mediator.Send(new ApproveAccessRequestCommand(id, AdminUserId), Ct);
+
+        // Act — the Created-event notification guard persists AFTER the approval. The partial
+        // update (#B fix) writes only last_notified_event_id via direct SQL.
+        var eventId = Guid.NewGuid();
+        await repo.MarkNotifiedAsync(id, eventId, Ct);
+
+        // Assert — approval survives, guard persisted.
+        _dbContext.ChangeTracker.Clear();
+        var final = await _dbContext.AccessRequests.AsNoTracking().FirstAsync(e => e.Id == id, Ct);
+        final.Status.Should().Be("Approved",
+            "the notification-guard partial update must not clobber a concurrent approval (#B fix)");
+        final.LastNotifiedEventId.Should().Be(eventId);
+    }
+
+    [Fact]
+    public async Task SetInvitationId_PartialUpdate_DoesNotClobberApprovedStatus()
+    {
+        // Arrange
+        var repo = _serviceProvider.GetRequiredService<IAccessRequestRepository>();
+        var invRepo = _serviceProvider.GetRequiredService<IInvitationTokenRepository>();
+        var uow = _serviceProvider.GetRequiredService<IUnitOfWork>();
+        var mediator = _serviceProvider.GetRequiredService<IMediator>();
+
+        var request = AccessRequest.Create("corr@test.dev");
+        var id = request.Id;
+        await repo.AddAsync(request, Ct);
+        await uow.SaveChangesAsync(Ct);
+        await mediator.Send(new ApproveAccessRequestCommand(id, AdminUserId), Ct);
+
+        // A real invitation token must exist — FK access_requests.invitation_id → invitation_tokens.id.
+        var token = InvitationToken.Create("corr@test.dev", "User", "test-token-hash", AdminUserId);
+        await invRepo.AddAsync(token, Ct);
+        await uow.SaveChangesAsync(Ct);
+        var invitationId = token.Id;
+
+        // Act — the Approved-event handler correlates the invitation via the partial update.
+        await repo.SetInvitationIdAsync(id, invitationId, Ct);
+
+        // Assert — approval survives, correlation persisted (idempotency guard #1940 now works).
+        _dbContext.ChangeTracker.Clear();
+        var final = await _dbContext.AccessRequests.AsNoTracking().FirstAsync(e => e.Id == id, Ct);
+        final.Status.Should().Be("Approved");
+        final.InvitationId.Should().Be(invitationId);
+    }
+}

--- a/apps/api/tests/Api.Tests/Services/Email/EmailServiceInvitationLinkTests.cs
+++ b/apps/api/tests/Api.Tests/Services/Email/EmailServiceInvitationLinkTests.cs
@@ -70,11 +70,14 @@ public sealed class EmailServiceInvitationLinkTests
     }
 
     [Fact]
-    public async Task SendInvitationEmailAsync_RedeemLinkUsesInvitesPath()
+    public async Task SendInvitationEmailAsync_RedeemLinkUsesAcceptInvitePath()
     {
-        // Arrange — Issue #1629 collateral fix: link path was /accept-invite (query string token)
-        // but the actual Next.js route is /invites/[token]. Without this fix the link in
-        // delivered emails returned 404.
+        // Arrange — the base-invitation redeem flow lives at /accept-invite?token= →
+        // POST /auth/accept-invitation (AcceptInvitationCommandHandler creates the user from
+        // token+password; no pending user needed). Issue #1629 wrongly repointed this link at
+        // /invites/{token}, which is the game-night RSVP landing (game_night_invitations) and
+        // returns "Invito non trovato" for invitation tokens. The base flow has no pending user,
+        // so /setup-account (activate-account) is NOT its redeem either — /accept-invite is.
         EmailRequest? captured = null;
         _sender
             .Setup(s => s.SendAsync(It.IsAny<EmailRequest>(), It.IsAny<CancellationToken>()))
@@ -94,11 +97,11 @@ public sealed class EmailServiceInvitationLinkTests
         // Assert
         captured.Should().NotBeNull();
         captured!.HtmlBody.Should().Contain(
-            $"{FrontendBaseUrl}/invites/abc123",
-            "the redeem URL must point to the /invites/{token} path that exists in apps/web/src/app/(public)/invites/[token].");
+            $"{FrontendBaseUrl}/accept-invite?token=abc123",
+            "the redeem URL must point to /accept-invite?token= (apps/web/src/app/(public)/accept-invite) which calls POST /auth/accept-invitation.");
         captured.HtmlBody.Should().NotContain(
-            "/accept-invite?token=",
-            "the legacy /accept-invite?token= URL is a 404 — must be removed in this PR.");
+            "/invites/abc123",
+            "/invites/{token} is the game-night RSVP landing, not the user-invitation redeem — it 404s for invitation tokens.");
     }
 
     [Fact]


### PR DESCRIPTION
Fixes a cluster of real bugs on the user-invitation flow, found during happy-path browser testing (2026-07-10). The admin "Invite User" flow and the access-request approval flow were producing invitations/approvals that didn't work end-to-end.

## Fixes

### #C — invite email pointed at the wrong route ✅ verified e2e
`EmailService.Auth.cs` base overload built the redeem link as `{base}/invites/{token}`, but `/invites/[token]` is the game-night RSVP landing (`game_night_invitations`) → "Invito non trovato". Restored to `{base}/accept-invite?token=` → `POST /auth/accept-invitation` (creates the user from token+password), the canonical redeem for the base flow already used by `InviteUserDialog`. Issue #1629 had repointed it by mistake.
**Verified end-to-end** (mailpit): real invite → email with `/accept-invite?token=` → account created **Active** + login + onboarding.

### #D — `emailSent: true` false positive ✅ unit-tested
`SendInvitationCommandHandler` swallowed SMTP failures but always returned `emailSent: true`. Now tracks the real outcome via `… with { EmailSent }` (as the enhanced ProvisionAndInvite handler already did).

### #B — last-writer-wins in access-request approval ✅ 4 integration tests
Approving an access request left `access_requests.status = Pending` + `invitation_id = NULL` while a token was created. Root cause: the async outbox event handlers (`AccessRequestCreatedEventHandler` for the Slack guard, `AccessRequestApprovedEventHandler` for the invitation id) rewrote the **whole aggregate** via `UpdateAsync` just to persist one field → a stale snapshot clobbered the just-committed status (last-writer-wins).
Fix: targeted partial-update repository methods (`MarkNotifiedAsync` / `SetInvitationIdAsync`) issuing a single-column `ExecuteUpdateAsync` — no aggregate load, no ChangeTracker, no SaveChanges (hence no reentrant dispatch). Both handlers use these instead of full `UpdateAsync`.
`AccessRequestApprovalIntegrationTests` (Testcontainers): 4 passed.

### #E — `/setup-account` "not_found" — NOT a bug
Documented for completeness: that route is the *enhanced* (pending-user) redeem; the base flow redeems on `/accept-invite`. No code change.

## Known limitation (tracked separately)

The e2e verification of #B surfaced a **separate, preexisting DbContext-concurrency problem** in the dev Docker environment (ConcurrencyDetector on request-access + approve status not committed), NOT caused by this PR and not reproducible in the integration tests. Tracked in #2804. The last-writer-wins fix here is verified independently (partial-update fields persist correctly: `invitation_id` + `last_notified_event_id`).

## Tests
- `SendInvitationCommandHandlerTests` (emailSent true/false)
- `EmailServiceInvitationLinkTests` (inverted: link = /accept-invite)
- `AccessRequestApprovalIntegrationTests` (command persists status; full flow; both partial updates preserve a concurrent approval)
- Regression: 191 invitation/email/access-request unit tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)