### PR TITLE
fix(auth): #2806 password reset confirm accepts base64url tokens

### DIFF
--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/Validators/ResetPasswordCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/Validators/ResetPasswordCommandValidator.cs
@@ -12,11 +12,14 @@ internal sealed class ResetPasswordCommandValidator : AbstractValidator<ResetPas
 {
     public ResetPasswordCommandValidator()
     {
+        // Issue #2806: the reset token is a 32-byte secure random value encoded as
+        // base64url by PasswordResetService — NOT a GUID. Only presence is enforced
+        // here; existence, single-use and expiry are checked in
+        // PasswordResetService.ResetPasswordAsync. The previous .Must(BeValidGuid)
+        // rejected every real token (HTTP 422), breaking password reset for all users.
         RuleFor(x => x.Token)
             .NotEmpty()
-            .WithMessage("Reset token is required")
-            .Must(BeValidGuid)
-            .WithMessage("Reset token must be a valid GUID");
+            .WithMessage("Reset token is required");
 
         // I7 (auth security fixes): the new password must satisfy the
         // 12-char minimum enforced by PasswordHash.Create.
@@ -35,10 +38,5 @@ internal sealed class ResetPasswordCommandValidator : AbstractValidator<ResetPas
             .WithMessage("New password must contain at least one digit")
             .Matches(@"[^a-zA-Z0-9]")
             .WithMessage("New password must contain at least one special character");
-    }
-
-    private static bool BeValidGuid(string token)
-    {
-        return Guid.TryParse(token, out _);
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/Authentication/Application/Validators/ResetPasswordCommandValidatorTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Authentication/Application/Validators/ResetPasswordCommandValidatorTests.cs
@@ -31,6 +31,31 @@ public sealed class ResetPasswordCommandValidatorTests
         // Assert
         result.ShouldNotHaveAnyValidationErrors();
     }
+
+    // Issue #2806: the reset token is a 32-byte secure random value encoded as
+    // base64url by PasswordResetService (NOT a GUID). This is the exact shape of
+    // every real token. The previous .Must(BeValidGuid) rule rejected all of them,
+    // breaking password reset confirm for every user (HTTP 422). The validator MUST
+    // accept a base64url token.
+    [Theory]
+    [InlineData("R6fJNEsX7k4lr8hHxADcWB81K1EDyH0qbW7CNFJYEJU")]
+    [InlineData("abc123XYZ_-def456GHI789jklMNO012pqrSTU345vwx")]
+    public void Should_Pass_When_Token_Is_Base64Url_From_Service(string token)
+    {
+        // Arrange
+        var command = new ResetPasswordCommand
+        {
+            Token = token,
+            NewPassword = "NewUnusualPwd123!"
+        };
+
+        // Act
+        var result = _validator.TestValidate(command);
+
+        // Assert
+        result.ShouldNotHaveValidationErrorFor(x => x.Token);
+    }
+
     [Theory]
     [InlineData(null)]
     [InlineData("")]
@@ -52,28 +77,9 @@ public sealed class ResetPasswordCommandValidatorTests
             .WithErrorMessage("Reset token is required");
     }
 
-    [Theory]
-    [InlineData("not-a-guid")]
-    [InlineData("12345")]
-    [InlineData("invalid-token-format")]
-    [InlineData("00000000-0000-0000-0000-00000000000")]
-    public void Should_Fail_When_Token_Is_Not_A_Valid_Guid(string token)
-    {
-        // Arrange
-        var command = new ResetPasswordCommand
-        {
-            Token = token,
-            NewPassword = "NewUnusualPwd123!"
-        };
-
-        // Act
-        var result = _validator.TestValidate(command);
-
-        // Assert
-        result.ShouldHaveValidationErrorFor(x => x.Token)
-            .WithErrorMessage("Reset token must be a valid GUID");
-    }
-
+    // Issue #2806: a GUID is still a non-empty string, so it continues to pass.
+    // These document backward-compatibility, NOT a GUID requirement — the token
+    // is base64url in practice (see Should_Pass_When_Token_Is_Base64Url_From_Service).
     [Fact]
     public void Should_Pass_When_Token_Is_Valid_Guid_With_Hyphens()
     {
@@ -244,7 +250,7 @@ public sealed class ResetPasswordCommandValidatorTests
         // Arrange
         var command = new ResetPasswordCommand
         {
-            Token = "invalid-token",
+            Token = "",
             NewPassword = "weak"
         };
 


### PR DESCRIPTION
## Bug (P1) — Closes #2806

Password reset **confirm** returned **HTTP 422** for every real token, making the feature **completely unusable for all users**. Discovered via the happy-path testing program (Fase B, scenario **U1-06**).

## Root cause — token generator ↔ validator mismatch

- `PasswordResetService.cs:87-88` issues a 32-byte secure random value encoded as **base64url** (43 chars, e.g. `R6fJNEsX7k4lr8hHxADcWB81K1EDyH0qbW7CNFJYEJU`) — **not a GUID**.
- **Verify** (`GET /api/v1/auth/password-reset/verify`) only hashes + looks up the token in the DB → accepts it → the "set new password" form opens.
- **Confirm** (`PUT /api/v1/auth/password-reset/confirm`) runs `ResetPasswordCommand` through FluentValidation; `ResetPasswordCommandValidator` required `Guid.TryParse(token)` → **422** on every real token.

Introduced by #1449 ("FluentValidation for Authentication CQRS pipeline"): the validator assumed `token = GUID` and was only ever tested against `Guid.NewGuid().ToString()`, never against a token produced by the service.

## Fix

- Remove `.Must(BeValidGuid)` from `ResetPasswordCommandValidator` (presence still enforced via `.NotEmpty()`; existence / single-use / expiry are validated in `PasswordResetService.ResetPasswordAsync`).
- Add regression test `Should_Pass_When_Token_Is_Base64Url_From_Service` using two real base64url tokens.
- Drop `Should_Fail_When_Token_Is_Not_A_Valid_Guid` (it encoded the buggy requirement) and fix `Should_Fail_With_Multiple_Validation_Errors` to use an empty token (the old `"invalid-token"` is now legitimately valid).

## Test

`19/19 ResetPasswordCommandValidatorTests` pass. The new test fails on `main-dev` (reproduces the bug) and passes with the fix.

## Note

This bug is independent from the invitation-flow cluster in PR #2805. Concurrency issue #2804 is also separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
