### PR TITLE
fix(web): restore guest access to /library-public (proxy prefix collision)

### DIFF
--- a/apps/web/src/lib/routing/route-matching.test.ts
+++ b/apps/web/src/lib/routing/route-matching.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import { matchesRoutePrefix } from './route-matching';
+
+describe('matchesRoutePrefix', () => {
+  const routes = ['/library', '/games', '/admin', '/chat'];
+
+  it('matches an exact route', () => {
+    expect(matchesRoutePrefix('/library', routes)).toBe(true);
+    expect(matchesRoutePrefix('/chat', routes)).toBe(true);
+  });
+
+  it('matches a sub-path of a route', () => {
+    expect(matchesRoutePrefix('/library/abc-123', routes)).toBe(true);
+    expect(matchesRoutePrefix('/games/xyz/faqs', routes)).toBe(true);
+  });
+
+  it('does NOT match a sibling path that only shares a prefix (regression: /library-public)', () => {
+    // Plain `'/library-public'.startsWith('/library')` returns true and wrongly
+    // redirected this public landing to /login. Boundary matching fixes it.
+    expect(matchesRoutePrefix('/library-public', routes)).toBe(false);
+  });
+
+  it('does NOT match other prefix-collision siblings', () => {
+    expect(matchesRoutePrefix('/gamespider', routes)).toBe(false);
+    expect(matchesRoutePrefix('/administrator', routes)).toBe(false);
+  });
+
+  it('does NOT match an unrelated public path', () => {
+    expect(matchesRoutePrefix('/faq', routes)).toBe(false);
+    expect(matchesRoutePrefix('/shared-games', routes)).toBe(false);
+  });
+
+  it('returns false for an empty routes list', () => {
+    expect(matchesRoutePrefix('/library', [])).toBe(false);
+  });
+});

--- a/apps/web/src/lib/routing/route-matching.ts
+++ b/apps/web/src/lib/routing/route-matching.ts
@@ -1,0 +1,15 @@
+/**
+ * Boundary-aware route prefix matching.
+ *
+ * A pathname matches a route only when it equals the route exactly or starts
+ * with `route + '/'`. This prevents prefix-collision bugs where an unrelated
+ * public path is caught by a protected prefix — e.g. `/library-public` being
+ * matched by the protected route `/library`, since plain
+ * `'/library-public'.startsWith('/library')` returns `true`.
+ *
+ * Used by the auth proxy to decide whether a request path is protected /
+ * admin-only, and to validate the post-login `from` redirect target.
+ */
+export function matchesRoutePrefix(pathname: string, routes: readonly string[]): boolean {
+  return routes.some(route => pathname === route || pathname.startsWith(`${route}/`));
+}

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -28,6 +28,7 @@
 import { NextResponse } from 'next/server';
 
 import * as metrics from '@/lib/metrics/session-cache-metrics';
+import { matchesRoutePrefix } from '@/lib/routing/route-matching';
 import { isAdminRole } from '@/lib/utils/roles';
 
 import type { NextRequest } from 'next/server';
@@ -454,9 +455,12 @@ export async function proxy(request: NextRequest) {
   const isAdminViewMode = isAdmin && viewModeCookie?.value !== 'user';
 
   // Check if the current route is protected or public auth route
-  const isProtectedRoute = PROTECTED_ROUTES.some(route => pathname.startsWith(route));
+  // Boundary-aware matching (matchesRoutePrefix): a route matches only on an
+  // exact hit or a `route + '/'` sub-path, so protected `/library` no longer
+  // swallows the public `/library-public` landing (plain startsWith did).
+  const isProtectedRoute = matchesRoutePrefix(pathname, PROTECTED_ROUTES);
   const isPublicAuthRoute = PUBLIC_AUTH_ROUTES.some(route => pathname === route);
-  const isAdminRoute = ADMIN_ONLY_ROUTES.some(route => pathname.startsWith(route));
+  const isAdminRoute = matchesRoutePrefix(pathname, ADMIN_ONLY_ROUTES);
   const isHomePage = pathname === '/';
 
   // Redirect unauthenticated users from protected routes to login
@@ -481,7 +485,7 @@ export async function proxy(request: NextRequest) {
     const fromParam = request.nextUrl.searchParams.get('from');
     const defaultDest = isAdminViewMode ? '/admin' : '/library';
     const redirectUrl =
-      fromParam && PROTECTED_ROUTES.some(route => fromParam.startsWith(route))
+      fromParam && matchesRoutePrefix(fromParam, PROTECTED_ROUTES)
         ? new URL(fromParam, request.url)
         : new URL(defaultDest, request.url);
     const response = NextResponse.redirect(redirectUrl);


### PR DESCRIPTION
## Bug — public `/library-public` redirected guests to `/login`

The auth proxy (`apps/web/src/proxy.ts`) decided route protection with:

```js
PROTECTED_ROUTES.some(route => pathname.startsWith(route))
```

`PROTECTED_ROUTES` includes `/library` (the post-login dashboard). Because `'/library-public'.startsWith('/library')` is `true`, the **public** community landing `(public)/library-public` — a fixture-only acquisition page with "Inizia gratis" / "Crea account gratis" CTAs aimed at anonymous visitors — was treated as the protected dashboard and redirected to `/login`. The page was unreachable by the very audience it targets.

Verified live: a guest hitting `/library-public` → `/login?from=%2Flibrary-public`, while `/faq` and `/shared-games` (other public routes) load fine.

## Fix

Extract a boundary-aware helper `matchesRoutePrefix(pathname, routes)` (`apps/web/src/lib/routing/route-matching.ts`): a path matches only on an exact hit or a `route + '/'` sub-path. Apply it to `PROTECTED_ROUTES`, `ADMIN_ONLY_ROUTES` and the post-login `from` validation. This fixes the whole prefix-collision class (`/library-public` vs `/library`, `/administrator` vs `/admin`, …), not just this one route.

`/library` and `/library/[gameId]` stay protected; `/library-public` becomes public.

## Test

6 unit tests in `route-matching.test.ts` (exact match, sub-path, `/library-public` regression, other siblings, unrelated public paths, empty list) — all green. Frontend typecheck passes.

## Discovered via

Happy-path testing program (Fase B), scenario **U2-14**.

## Note

The fix is server-side (proxy); a `meepleai-web` rebuild is needed for the running dev container to pick it up at runtime. Verified at unit + logic level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
