### PR TITLE
fix(ci): #2816 dev-async smoke — avvia backend reale + pin desktop-chrome

### DIFF
--- a/.github/workflows/dev-async.yml
+++ b/.github/workflows/dev-async.yml
@@ -90,11 +90,105 @@ jobs:
     timeout-minutes: 15
     needs: changes
     if: needs.changes.outputs.frontend == 'true' || github.event_name == 'workflow_dispatch'
-    defaults:
-      run:
-        working-directory: apps/web
+    # #2816: the e2e/smoke-real-backend specs need a REAL API. Previously this
+    # job started no backend (→ ECONNREFUSED on localhost:8080) AND ran the folder
+    # across all 6 Playwright projects (~138 tests → 15min timeout). Mirror the
+    # ci.yml `e2e` (E2E - Critical Paths) backend stack + pin to desktop-chrome.
+    services:
+      postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_DB: meepleai_test
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres_test_password
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+      redis:
+        image: redis:7-alpine
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 6379:6379
     steps:
       - uses: actions/checkout@v6
+
+      # ===== Backend (real API for smoke-real-backend specs) =====
+      - name: Create CI secret files
+        run: |
+          mkdir -p infra/secrets
+          printf 'POSTGRES_USER=postgres\nPOSTGRES_PASSWORD=postgres_test_password\nPOSTGRES_DB=meepleai_test\n' > infra/secrets/database.secret
+          printf 'REDIS_PASSWORD=redis-ci-test\n' > infra/secrets/redis.secret
+          printf 'JWT_SECRET_KEY=ci-test-jwt-secret-key-minimum-32-chars-long\nJWT_ISSUER=meepleai-ci-test\nJWT_AUDIENCE=meepleai-ci-test\n' > infra/secrets/jwt.secret
+          printf 'ADMIN_EMAIL=admin@test.local\nADMIN_PASSWORD=CiTestPassword123!\nADMIN_DISPLAY_NAME=CI Admin\nINITIAL_ADMIN_EMAIL=admin@test.local\nINITIAL_ADMIN_DISPLAY_NAME=CI Admin\n' > infra/secrets/admin.secret
+          printf 'EMBEDDING_SERVICE_URL=http://localhost:8000\n' > infra/secrets/embedding-service.secret
+
+      - name: Setup Backend
+        uses: ./.github/actions/setup-backend
+        with:
+          dotnet-version: '9.0.x'
+          working-directory: apps/api
+          cache-version: ${{ vars.CACHE_VERSION || 'v1' }}
+
+      - name: Build API (Release)
+        working-directory: apps/api
+        run: dotnet build --no-restore --configuration Release
+
+      - name: Install EF Core tools
+        run: |
+          dotnet tool install --global dotnet-ef
+          echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
+
+      - name: Run database migrations
+        working-directory: apps/api/src/Api
+        run: dotnet ef database update --no-build --configuration Release
+        env:
+          POSTGRES_HOST: localhost
+          POSTGRES_PORT: "5432"
+          POSTGRES_DB: meepleai_test
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres_test_password
+
+      - name: Start Backend API
+        working-directory: apps/api/src/Api
+        run: |
+          dotnet run --no-build --configuration Release --no-launch-profile > /tmp/api.log 2>&1 &
+          echo $! > api.pid
+          echo "API started with PID $(cat api.pid)"
+        env:
+          ASPNETCORE_ENVIRONMENT: CI
+          ASPNETCORE_URLS: "http://localhost:8080"
+          POSTGRES_HOST: localhost
+          POSTGRES_PORT: "5432"
+          POSTGRES_DB: meepleai_test
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres_test_password
+          REDIS_URL: "localhost:6379"
+          OPENROUTER_API_KEY: "test-key-for-ci-placeholder"
+          LOCAL_EMBEDDING_URL: "http://localhost:8000"
+
+      - name: Wait for API health
+        timeout-minutes: 2
+        run: |
+          for i in {1..40}; do
+            if curl -sf http://localhost:8080/health/live > /dev/null 2>&1; then
+              echo "✅ API live after ~$((i*3))s"; exit 0
+            fi
+            if [ $((i % 5)) -eq 0 ] && [ -f apps/api/src/Api/api.pid ] && ! kill -0 "$(cat apps/api/src/Api/api.pid)" 2>/dev/null; then
+              echo "❌ API process died. Last 30 lines of log:"; tail -30 /tmp/api.log 2>/dev/null; exit 1
+            fi
+            sleep 3
+          done
+          echo "❌ API failed to start within 2 minutes"; tail -50 /tmp/api.log 2>/dev/null; exit 1
+
+      # ===== Frontend + smoke =====
       - uses: ./.github/actions/setup-frontend
         with:
           node-version: '20'
@@ -107,22 +201,26 @@ jobs:
           working-directory: apps/web
           cache-version: ${{ vars.CACHE_VERSION || 'v1' }}
 
+      - name: Setup test env
+        working-directory: apps/web
+        run: cp .env.test.example .env.test
+
       - name: Build Next.js (required by Playwright webServer `next start`)
-        # playwright.config.ts (L561-564) selects `next start` when CI=true to
-        # avoid dev-server crashes under sustained load (Issue #2007). That
-        # requires a prior production build; without it the webServer aborts
-        # with "Could not find a production build in the '.next' directory".
+        # playwright.config.ts selects `next start` when CI=true (Issue #2007),
+        # which needs a prior production build. NEXT_PUBLIC_API_BASE is inlined at
+        # build time so the web reaches the API started above on localhost:8080.
+        working-directory: apps/web
         run: pnpm build
         env:
           NEXT_TELEMETRY_DISABLED: '1'
+          NEXT_PUBLIC_API_BASE: http://localhost:8080
 
-      - name: Run smoke specs only
-        # Use the dedicated smoke-real-backend folder (3 specs covering the
-        # game-night flow). The `@smoke` Playwright tag is documented in
-        # e2e/helpers/test-tags.ts but only one spec currently carries it
-        # (playwright-patterns-demo.spec.ts), so a tag-based --grep would
-        # silently match a single demo file. The folder-based filter is
-        # explicit and matches the specs the nightly run already exercises.
+      - name: Run smoke specs (desktop-chrome only)
+        # #2816: pin to a single project — the folder was running across all 6
+        # Playwright projects (~138 tests) and timing out. desktop-chrome matches
+        # the ci.yml `e2e` job convention.
+        working-directory: apps/web
         env:
           PLAYWRIGHT_AUTH_BYPASS: 'true'
-        run: pnpm test:e2e -- e2e/smoke-real-backend/
+          CI: 'true'
+        run: pnpm test:e2e -- --project=desktop-chrome e2e/smoke-real-backend/


### PR DESCRIPTION
Closes #2816

## Problema
Il job `frontend-e2e-smoke` (`dev-async.yml`, "Frontend E2E Smoke (Playwright subset)") era rotto da sempre:
1. **No `--project`** → `pnpm test:e2e -- e2e/smoke-real-backend/` girava le ~14 spec su tutti i 6 progetti Playwright (~138 test) → **timeout 15min**.
2. **Nessun backend avviato** → le spec `smoke-real-backend` (API reale richiesta) fallivano con `ECONNREFUSED` su `localhost:8080`.

## Fix
Replicato lo stack backend del job `e2e` di `ci.yml`:
- `services:` postgres (pgvector) + redis
- CI secret files (database/redis/jwt/admin/embedding)
- `setup-backend` + `dotnet build` inline + `dotnet ef database update` + `dotnet run` + wait-for-health
- build FE con `NEXT_PUBLIC_API_BASE=http://localhost:8080` (la webServer `next start` raggiunge l'API)
- `--project=desktop-chrome` (138 → ~23 test)

## Scope & validazione
- Job **non-blocking** (async post-merge main-dev, non gatekeeper dei merge).
- **Non correlato** allo staging smoke `smoke.spec.ts` (#2802/#2803, già validato 8/8) — scoperto durante quel lavoro.
- ⚠️ **Non validabile in locale** (serve lo stack backend + ambiente CI). La validazione è il primo run del workflow. Possibili punti da iterare: seed data per le spec game-night, meccanica `PLAYWRIGHT_AUTH_BYPASS` col backend reale, SLO 15min. Essendo non-blocking, un eventuale rosso è iterabile senza impatto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)