### PR TITLE
fix(web): restore /library/wishlist and /library/private standalone routes

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -226,8 +226,14 @@ const nextConfig = {
       // sub-route redirects above (they map specific tab paths) but do not
       // add a catch-all here — rely on the explicit list to avoid the
       // aiChat regression that motivated #1004.
-      { source: '/library/wishlist', destination: '/library?tab=wishlist', permanent: true },
-      { source: '/library/private', destination: '/library?tab=private', permanent: true },
+      // Happy-path testing (2026-07-11): removed the legacy `/library/wishlist`
+      // → `?tab=wishlist` and `/library/private` → `?tab=private` redirects. Those
+      // hub tabs were retired (see `library/_content.tsx`) but the redirects
+      // survived and — since Next redirects take precedence over page routing —
+      // shadowed the standalone pages `library/wishlist/page.tsx` ("My Wishlist")
+      // and `library/private/page.tsx` (PrivateGamesClient), leaving both routes
+      // unreachable (they landed on the hub "Tutti" tab). Those pages are the
+      // canonical destinations and nav links (`contextual-tabs.ts`) point to them.
       { source: '/library/proposals', destination: '/discover?tab=proposals', permanent: true },
       { source: '/library/propose', destination: '/discover/propose', permanent: true },
 


### PR DESCRIPTION
## Problema

Due redirect legacy in `next.config.js` rendevano irraggiungibili le pagine standalone della libreria, scoperti durante happy-path browser testing (finding #I, scenari U3-03/U3-06):

- `/library/wishlist` → `/library?tab=wishlist`
- `/library/private` → `/library?tab=private`

I tab `?tab=wishlist` / `?tab=private` del library hub sono stati **ritirati** (`library/_content.tsx:8-10` dichiara *"Wishlist remains reachable as a standalone route at /library/wishlist"*) ma i redirect sono sopravvissuti. Poiché i redirect Next.js hanno precedenza sul routing app-router, le pagine standalone `wishlist/page.tsx` ("My Wishlist" + AddToWishlistDialog + griglia) e `private/page.tsx` (PrivateGamesClient) erano **oscurate**: navigando ci si atterrava sul hub, tab "Tutti", senza superficie wishlist/private.

## Impatto

- Wishlist e private games **irraggiungibili** dalle route canoniche.
- Link nav rotto: `contextual-tabs.ts:14` punta a `/library/wishlist`.
- Contraddice e2e esistenti: `gap-analysis-critical.spec.ts:133` (`toHaveURL('/library/wishlist')`), `library/wishlist.spec.ts`.
- `permanent: true` (301) → i browser cacheano il redirect.

## Fix

Rimossi i due redirect legacy. **Verificato in locale** (rebuild web production `node server.js`): `/library/wishlist` → pagina "My Wishlist" (empty-state + Add to Wishlist); `/library/private` → PrivateGamesClient ("La tua collezione" + Aggiungi Gioco).

## Note

- Sotto-route (`/library/private/add`, `/library/private/[id]`) non impattate (redirect su match esatto).
- Righe adiacenti `/library/proposals`, `/library/propose` (destinazione `/discover`) invariate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
