### PR TITLE
fix(ci): #2816 dev-async smoke — fix doppio-dash + build API piu veloce

### DIFF
--- a/.github/workflows/dev-async.yml
+++ b/.github/workflows/dev-async.yml
@@ -139,7 +139,9 @@ jobs:
 
       - name: Build API (Release)
         working-directory: apps/api
-        run: dotnet build --no-restore --configuration Release
+        # Build only the API project (not the whole solution incl. test projects)
+        # to stay inside the 15min SLO — the full solution build was ~6min. #2816
+        run: dotnet build src/Api --no-restore --configuration Release
 
       - name: Install EF Core tools
         run: |
@@ -219,8 +221,15 @@ jobs:
         # #2816: pin to a single project — the folder was running across all 6
         # Playwright projects (~138 tests) and timing out. desktop-chrome matches
         # the ci.yml `e2e` job convention.
+        #
+        # Call playwright directly via `pnpm exec` (NOT `pnpm test:e2e -- …`):
+        # the test:e2e script is `dotenv -e .env.test -- playwright test`, and
+        # `pnpm run … -- <args>` appends a SECOND `--`, so playwright received
+        # `-- --project=… folder` → `--project` was parsed as a positional file
+        # filter (ignored) and all 6 projects ran anyway. `pnpm exec dotenv …`
+        # forwards `--project` as a real option.
         working-directory: apps/web
         env:
           PLAYWRIGHT_AUTH_BYPASS: 'true'
           CI: 'true'
-        run: pnpm test:e2e -- --project=desktop-chrome e2e/smoke-real-backend/
+        run: pnpm exec dotenv -e .env.test -- playwright test --project=desktop-chrome e2e/smoke-real-backend/


### PR DESCRIPTION
Follow-up di #2817. `--project=desktop-chrome` non veniva applicato: `pnpm test:e2e -- --project=… folder` espande a `dotenv … -- playwright test -- --project=… folder` (pnpm inserisce un **secondo** `--`) → Playwright trattava `--project` come filtro file posizionale → giravano tutti i 6 progetti (chromium+firefox+webkit) → ~138 test → timeout 15min (confermato: orphan webkit/WPEWebProcess nel run 29151245941).

## Fix
- Playwright diretto: `pnpm exec dotenv -e .env.test -- playwright test --project=desktop-chrome e2e/smoke-real-backend/`. **Verificato in locale: Total 23 test, tutti `[desktop-chrome]`** (era 138 su 6 progetti).
- Build solo `src/Api` (non l'intera solution coi test project) — il build pieno era ~6min20s.

Lo stack backend di #2817 funziona (API live ~21s, migrazioni ok, Next buildato). Job non-blocking.