### PR TITLE
fix(proxy): #2784 resolve admin role under E2E auth bypass

### DIFF
--- a/apps/web/e2e/_helpers/seedAuthSession.ts
+++ b/apps/web/e2e/_helpers/seedAuthSession.ts
@@ -52,12 +52,16 @@ const FIXTURE_SESSION_TOKEN = 'playwright-fixture-session-token';
 
 export type AuthSessionRole = 'user' | 'admin';
 
-export async function seedAuthSession(
-  page: Page,
-  options: { role?: AuthSessionRole } = {}
-): Promise<void> {
-  const role = options.role ?? 'user';
-  await page.context().addCookies([
+/** Role names used by the mock-auth helpers (AdminHelper, AuthHelper, fixtures). */
+export type MockAuthRole = 'Admin' | 'Editor' | 'User';
+
+/**
+ * Builds the two cookies proxy.ts needs to resolve an authenticated session AND
+ * its role under the E2E auth bypass. `role` must already be lower-cased to match
+ * proxy.ts's isAdminRole() expectation.
+ */
+function buildBypassAuthCookies(role: string) {
+  return [
     {
       name: SESSION_COOKIE_NAME,
       value: FIXTURE_SESSION_TOKEN,
@@ -65,7 +69,7 @@ export async function seedAuthSession(
       path: '/',
       httpOnly: true,
       secure: false,
-      sameSite: 'Lax',
+      sameSite: 'Lax' as const,
     },
     {
       name: USER_ROLE_COOKIE,
@@ -74,9 +78,30 @@ export async function seedAuthSession(
       path: '/',
       httpOnly: false,
       secure: false,
-      sameSite: 'Lax',
+      sameSite: 'Lax' as const,
     },
-  ]);
+  ];
+}
+
+export async function seedAuthSession(
+  page: Page,
+  options: { role?: AuthSessionRole } = {}
+): Promise<void> {
+  const role = options.role ?? 'user';
+  await page.context().addCookies(buildBypassAuthCookies(role));
+}
+
+/**
+ * Seeds the session + role cookies for the PascalCase-role mock-auth helpers so
+ * navigating to /admin/** actually resolves the admin role under the E2E bypass
+ * (proxy.ts #2784), instead of the middleware falling back to 'user' and
+ * redirecting away. Call BEFORE the first page.goto in a mock-auth helper.
+ *
+ * The meepleai_user_role cookie is honored by proxy.ts ONLY while the bypass is
+ * engaged (dev/CI); production ignores it, so it cannot escalate privileges.
+ */
+export async function seedMockRoleCookies(page: Page, role: MockAuthRole): Promise<void> {
+  await page.context().addCookies(buildBypassAuthCookies(role.toLowerCase()));
 }
 
 /**

--- a/apps/web/e2e/fixtures/auth.ts
+++ b/apps/web/e2e/fixtures/auth.ts
@@ -1,5 +1,7 @@
 import { test as base, Page, Route } from '@playwright/test';
 
+import { seedMockRoleCookies } from '../_helpers/seedAuthSession';
+
 // Issue #841: Make API_BASE configurable via environment variables
 const API_BASE =
   process.env.PLAYWRIGHT_API_BASE || process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8080';
@@ -104,6 +106,10 @@ export async function setupMockAuth(
   role: 'Admin' | 'Editor' | 'User' = 'Admin',
   email: string = 'admin@meepleai.dev'
 ) {
+  // Seed cookies FIRST (before any route mocks / navigation) so proxy.ts can
+  // resolve the role under the E2E bypass and grant /admin access (#2784).
+  await seedMockRoleCookies(page, role);
+
   const userResponse = {
     user: {
       id: `${role.toLowerCase()}-test-id`,

--- a/apps/web/e2e/pages/helpers/AdminHelper.ts
+++ b/apps/web/e2e/pages/helpers/AdminHelper.ts
@@ -13,6 +13,8 @@
 
 import { Page } from '@playwright/test';
 
+import { seedMockRoleCookies } from '../../_helpers/seedAuthSession';
+
 const apiBase = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8080';
 
 export class AdminHelper {
@@ -24,6 +26,10 @@ export class AdminHelper {
    * Equivalent to loginAsAdmin() from fixtures/auth.ts
    */
   async setupAdminAuth(skipNavigation: boolean = false): Promise<void> {
+    // Seed cookies FIRST so proxy.ts resolves the admin role under the E2E bypass
+    // and grants /admin access (#2784), instead of falling back to 'user'.
+    await seedMockRoleCookies(this.page, 'Admin');
+
     // Setup authenticated admin session
     const adminUser = {
       id: 'admin-test-id',

--- a/apps/web/e2e/pages/helpers/AuthHelper.ts
+++ b/apps/web/e2e/pages/helpers/AuthHelper.ts
@@ -12,6 +12,8 @@
 
 import { Page } from '@playwright/test';
 
+import { seedMockRoleCookies } from '../../_helpers/seedAuthSession';
+
 const apiBase = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8080';
 
 export interface UserFixture {
@@ -169,9 +171,7 @@ export class AuthHelper {
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
-        body: JSON.stringify([
-          { id: 'game-1', title: 'Test Game', description: 'A test game' },
-        ]),
+        body: JSON.stringify([{ id: 'game-1', title: 'Test Game', description: 'A test game' }]),
       });
     });
 
@@ -516,6 +516,10 @@ export class AuthHelper {
    * Equivalent to setupMockAuth() from fixtures/auth.ts
    */
   async setupMockAuth(role: 'Admin' | 'Editor' | 'User' = 'Admin', email?: string): Promise<void> {
+    // Seed cookies FIRST so proxy.ts resolves the role under the E2E bypass and
+    // grants /admin access (#2784), instead of falling back to 'user'.
+    await seedMockRoleCookies(this.page, role);
+
     const user = {
       id: `${role.toLowerCase()}-test-id`,
       email: email || `${role.toLowerCase()}@example.com`,
@@ -616,7 +620,9 @@ export class AuthHelper {
   async setupRealSession(role: 'admin' | 'editor' | 'user'): Promise<void> {
     const success = await this.loginWithRealCredentials(role);
     if (!success) {
-      throw new Error(`Failed to login as ${role}. Make sure E2E test users exist in the database.`);
+      throw new Error(
+        `Failed to login as ${role}. Make sure E2E test users exist in the database.`
+      );
     }
   }
 }

--- a/apps/web/src/__tests__/proxy.test.ts
+++ b/apps/web/src/__tests__/proxy.test.ts
@@ -1,0 +1,133 @@
+/**
+ * proxy.ts middleware — admin-role resolution under the E2E auth bypass (#2784)
+ *
+ * After the v1 plaintext role-cookie sunset (2026-05-13), proxy.ts resolved the
+ * admin role only from the backend-validated session cache. Under the E2E auth
+ * bypass (PLAYWRIGHT_AUTH_BYPASS=true) the cache is never warmed, so the role
+ * fell back to 'user' and every admin E2E spec redirected away from /admin.
+ *
+ * These tests pin the fix: when the bypass is engaged, the role is resolved from
+ * the plaintext meepleai_user_role cookie seeded by the E2E auth helpers — AND
+ * that this bypass path is unreachable in production, so the cookie can never
+ * escalate a real user to admin.
+ */
+import { NextRequest } from 'next/server';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const ADMIN_URL = 'http://localhost/admin';
+
+function makeRequest(cookies: Record<string, string>): NextRequest {
+  const cookieHeader = Object.entries(cookies)
+    .map(([name, value]) => `${name}=${value}`)
+    .join('; ');
+  return new NextRequest(ADMIN_URL, {
+    headers: cookieHeader ? { cookie: cookieHeader } : {},
+  });
+}
+
+/** True when the middleware let the request continue (no redirect). */
+function wasAllowed(res: Response): boolean {
+  return res.headers.get('location') === null;
+}
+
+describe('proxy() admin-role resolution under the E2E auth bypass (#2784)', () => {
+  beforeEach(() => {
+    // Reset the module-level sessionValidationCache + cachedApiOrigin between tests.
+    vi.resetModules();
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  it('grants /admin when the bypass is engaged and the role cookie is admin', async () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    vi.stubEnv('PLAYWRIGHT_AUTH_BYPASS', 'true');
+    vi.stubEnv('NEXT_PUBLIC_VISUAL_TEST_FIXTURE_ENABLED', '');
+
+    const { proxy } = await import('@/proxy');
+    const res = await proxy(
+      makeRequest({ meepleai_session: 'fixture-token', meepleai_user_role: 'admin' })
+    );
+
+    expect(wasAllowed(res)).toBe(true);
+    expect(res.status).toBe(200);
+  });
+
+  it('redirects /admin away when the bypass is engaged but the role cookie is user', async () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    vi.stubEnv('PLAYWRIGHT_AUTH_BYPASS', 'true');
+    vi.stubEnv('NEXT_PUBLIC_VISUAL_TEST_FIXTURE_ENABLED', '');
+
+    const { proxy } = await import('@/proxy');
+    const res = await proxy(
+      makeRequest({ meepleai_session: 'fixture-token', meepleai_user_role: 'user' })
+    );
+
+    // Authenticated non-admin → redirected to home (not admin).
+    expect(res.headers.get('location')).toBe('http://localhost/');
+  });
+
+  it('redirects /admin away when the bypass is engaged but no role cookie is present', async () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    vi.stubEnv('PLAYWRIGHT_AUTH_BYPASS', 'true');
+    vi.stubEnv('NEXT_PUBLIC_VISUAL_TEST_FIXTURE_ENABLED', '');
+
+    const { proxy } = await import('@/proxy');
+    const res = await proxy(makeRequest({ meepleai_session: 'fixture-token' }));
+
+    // Never elevate by guessing: default role 'user' → redirected away.
+    expect(res.headers.get('location')).toBe('http://localhost/');
+  });
+
+  it('does NOT trust the role cookie in production — role is sourced only from /auth/me', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    // Bypass flag is set but MUST be ignored: production build, visual flag off.
+    vi.stubEnv('PLAYWRIGHT_AUTH_BYPASS', 'true');
+    vi.stubEnv('NEXT_PUBLIC_VISUAL_TEST_FIXTURE_ENABLED', '');
+    vi.stubEnv('API_BASE_URL', 'http://api:8080');
+
+    // /auth/me reports the real role as 'user'; the admin role COOKIE must not win.
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ user: { role: 'user' } }),
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const { proxy } = await import('@/proxy');
+    const res = await proxy(
+      makeRequest({ meepleai_session: 'real-token', meepleai_user_role: 'admin' })
+    );
+
+    // Cookie escalation blocked: authenticated non-admin → redirected away from /admin.
+    expect(res.headers.get('location')).toBe('http://localhost/');
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not engage the bypass without PLAYWRIGHT_AUTH_BYPASS even with an admin role cookie', async () => {
+    vi.stubEnv('NODE_ENV', 'development');
+    vi.stubEnv('PLAYWRIGHT_AUTH_BYPASS', '');
+    vi.stubEnv('NEXT_PUBLIC_VISUAL_TEST_FIXTURE_ENABLED', '');
+    vi.stubEnv('API_BASE_URL', 'http://api:8080');
+
+    // No bypass → real session validation runs; backend rejects the fixture token.
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      json: async () => ({}),
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const { proxy } = await import('@/proxy');
+    const res = await proxy(
+      makeRequest({ meepleai_session: 'fixture-token', meepleai_user_role: 'admin' })
+    );
+
+    // Unauthenticated on a protected route → redirected to /login (not admin).
+    expect(res.headers.get('location')).toContain('/login');
+  });
+});

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -418,7 +418,11 @@ export async function proxy(request: NextRequest) {
   // PLAYWRIGHT_AUTH_BYPASS is never set there.
   const isVisualTestBuild = process.env.NEXT_PUBLIC_VISUAL_TEST_FIXTURE_ENABLED === '1';
   const isAuthBypassAllowed = process.env.NODE_ENV !== 'production' || isVisualTestBuild;
-  if (isAuthBypassAllowed && process.env.PLAYWRIGHT_AUTH_BYPASS === 'true' && sessionCookieValue) {
+  const isAuthBypassEngaged =
+    isAuthBypassAllowed &&
+    process.env.PLAYWRIGHT_AUTH_BYPASS === 'true' &&
+    Boolean(sessionCookieValue);
+  if (isAuthBypassEngaged) {
     isAuthenticated = true;
   } else if (sessionCookieValue) {
     isAuthenticated = await isSessionCookieValid(request, sessionCookieValue);
@@ -437,6 +441,20 @@ export async function proxy(request: NextRequest) {
     const cachedRole = getCachedRole(sessionCookieValue);
     if (cachedRole) {
       userRole = cachedRole;
+    } else if (isAuthBypassEngaged) {
+      // E2E auth bypass: isSessionCookieValid was skipped above, so the
+      // session-validation cache is never warmed and getCachedRole() is null.
+      // Resolve the role from the plaintext meepleai_user_role cookie seeded by
+      // the E2E auth helpers instead. Unreachable in production: the bypass
+      // requires PLAYWRIGHT_AUTH_BYPASS (never set in prod) AND either
+      // NODE_ENV!=='production' or the visual-test flag (dead-code-eliminated in
+      // real prod builds), so a client-set role cookie can never escalate a real
+      // user. Restores admin E2E coverage after the v1 role-cookie sunset
+      // (2026-05-13). See issue #2784.
+      const bypassRole = request.cookies.get(USER_ROLE_COOKIE_V1)?.value;
+      if (bypassRole) {
+        userRole = bypassRole;
+      }
     } else if (Date.now() < USER_ROLE_COOKIE_V1_SUNSET) {
       const v1 = request.cookies.get(USER_ROLE_COOKIE_V1)?.value;
       if (v1) {


### PR DESCRIPTION
## Summary

Fixes the **root cause** of #2784. After the `meepleai_user_role` v1 cookie sunset (2026-05-13), `proxy.ts` resolved the admin role only from the backend-validated session cache — which the E2E auth bypass (`PLAYWRIGHT_AUTH_BYPASS=true`) never warms. So `userRole` fell back to `'user'`, `isAdmin` was `false`, and `/admin` redirected away → admin E2E specs hard-failed locally.

Chosen approach: the **proxy root-fix** (not the ~108-file graceful-skip), per design discussion — restores real local coverage with a small, security-safe change.

## Changes

**Production — `apps/web/src/proxy.ts`**
- Extract `isAuthBypassEngaged` (the exact pre-existing bypass gate, no behaviour change).
- When the bypass is engaged and the session-cache role is absent, resolve the role from the `meepleai_user_role` cookie again.
- **Security-safe**: the new branch is gated behind `isAuthBypassEngaged` (`PLAYWRIGHT_AUTH_BYPASS=true` **and** `NODE_ENV!=='production'` or the visual-test build flag). In a real deploy `NODE_ENV=production` (hardcoded in the Dockerfile), `PLAYWRIGHT_AUTH_BYPASS` is never set, and `NEXT_PUBLIC_VISUAL_TEST_FIXTURE_ENABLED` is inlined off — so the branch is unreachable and a client-set role cookie can never escalate a real user.

**Test — `apps/web/src/__tests__/proxy.test.ts` (new)**
- 5 unit tests: bypass+admin→allow, bypass+user→deny, bypass+no-role→deny (no elevation-by-default), **production+bypass-flag→cookie ignored** (real `/auth/me` used — the security boundary, asserts `fetch` was called), no-bypass→real validation → `/login`.

**Shared E2E helpers**
- `e2e/_helpers/seedAuthSession.ts`: new `seedMockRoleCookies(page, role)` + extracted `buildBypassAuthCookies` (DRY).
- `fixtures/auth.ts::setupMockAuth`, `AuthHelper.setupMockAuth`, `AdminHelper.setupAdminAuth` now seed the `meepleai_session` + `meepleai_user_role` cookies (threading the caller's role) so specs reach `/admin` under the bypass. `AuthHelper.mockAuthenticatedSession` + `seedAuthSession` already seeded them.

## Verification

- `vitest run src/__tests__/proxy.test.ts` → **5/5** (RED→GREEN confirmed on the fix, guards green pre-fix).
- `pnpm typecheck` → clean · `eslint` (changed files) → 0 errors.
- **E2E end-to-end** against a bypass dev server: `rbac-authorization` "Admin can access /admin{,/users,/analytics}" → **3/3 reach `/admin`**. (The 4th, `/admin/configuration`, fails only on a pre-existing stale route name — the app route is `/admin/config` — not an auth redirect.)
- Adversarial review (opus): the "unreachable in production" claim **confirmed** by inspecting the Dockerfile, all workflows, and `infra/`; no correctness / regression / test-quality findings.

## Scope & residual

Fixes every admin spec using the **shared** auth helpers (AdminHelper, AuthHelper, fixtures `setupMockAuth`/`loginAsAdmin`, `seedAuthSession`). Specs with **bespoke inline auth** (local `mockAdminAuth` / inline `/auth/me` mocks), **real-UI-login**, or **direct-navigate** still don't seed the role cookie — a mechanical follow-up (migrate to `seedMockRoleCookies`, or graceful-skip for the real-backend ones). #2784 stays open to track that residual.

Refs #2784

🤖 Generated with [Claude Code](https://claude.com/claude-code)
