### PR TITLE
feat(mechanic-extractor): ME-FU-1 per-claim precision + section signal (#2807 #2808 #2811)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/DTOs/MechanicAnalysisStatusDto.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/DTOs/MechanicAnalysisStatusDto.cs
@@ -34,7 +34,13 @@ public sealed record MechanicAnalysisStatusDto(
     Guid? SuppressedBy,
     string? SuppressionReason,
     int ClaimsCount,
-    IReadOnlyList<MechanicSectionRunSummaryDto> SectionRuns);
+    IReadOnlyList<MechanicSectionRunSummaryDto> SectionRuns,
+    // #2807 (ME-FU-1): the "N/M sections produced claims" signal. SectionsWithClaims = number of
+    // distinct sections that yielded >=1 persisted claim; TotalSections = total expected (6).
+    // SectionsWithClaims < TotalSections means at least one section was dropped (e.g. failed the
+    // well_formed check across all retries) and is silently absent from the review queue.
+    int SectionsWithClaims,
+    int TotalSections);
 
 /// <summary>
 /// Per-section execution summary persisted in <c>mechanic_analysis_section_runs</c> (B6=C).

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/MechanicExtractor/GetMechanicAnalysisStatusQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/MechanicExtractor/GetMechanicAnalysisStatusQueryHandler.cs
@@ -46,6 +46,17 @@ internal sealed class GetMechanicAnalysisStatusQueryHandler
             .CountAsync(c => c.AnalysisId == request.AnalysisId, cancellationToken)
             .ConfigureAwait(false);
 
+        // #2807: distinct sections that produced >=1 claim, so the reviewer can see "N/6 sections
+        // produced claims" and notice a section silently dropped (e.g. never well_formed).
+        var sectionsWithClaims = await _dbContext.MechanicClaims
+            .AsNoTracking()
+            .IgnoreQueryFilters()
+            .Where(c => c.AnalysisId == request.AnalysisId)
+            .Select(c => c.Section)
+            .Distinct()
+            .CountAsync(cancellationToken)
+            .ConfigureAwait(false);
+
         var sectionRunEntities = await _dbContext.MechanicAnalysisSectionRuns
             .AsNoTracking()
             .Where(r => r.AnalysisId == request.AnalysisId)
@@ -80,7 +91,9 @@ internal sealed class GetMechanicAnalysisStatusQueryHandler
             SuppressedBy: analysis.SuppressedBy,
             SuppressionReason: analysis.SuppressionReason,
             ClaimsCount: claimsCount,
-            SectionRuns: sectionRuns);
+            SectionRuns: sectionRuns,
+            SectionsWithClaims: sectionsWithClaims,
+            TotalSections: Enum.GetValues<MechanicSection>().Length);
     }
 
     private static MechanicSectionRunSummaryDto MapSectionRun(MechanicAnalysisSectionRunEntity entity) =>

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/Guardrails/GroundingGuardrail.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/Guardrails/GroundingGuardrail.cs
@@ -23,18 +23,20 @@ internal sealed class GroundingGuardrail : IMechanicGuardrail
     public async Task<IReadOnlyList<MechanicValidationViolation>> EvaluateAsync(
         MechanicGuardrailContext context, CancellationToken cancellationToken)
     {
-        var (violations, _) = await EvaluateCoreAsync(context, cancellationToken).ConfigureAwait(false);
+        var (violations, _, _) = await EvaluateCoreAsync(context, cancellationToken).ConfigureAwait(false);
         return violations;
     }
 
     public async Task<MechanicGuardrailResult> EvaluateDetailedAsync(
         MechanicGuardrailContext context, CancellationToken cancellationToken)
     {
-        var (violations, minCosine) = await EvaluateCoreAsync(context, cancellationToken).ConfigureAwait(false);
-        return new MechanicGuardrailResult(violations, minCosine);
+        var (violations, minCosine, claimScores) = await EvaluateCoreAsync(context, cancellationToken).ConfigureAwait(false);
+        return new MechanicGuardrailResult(violations, minCosine,
+            claimScores.Count > 0 ? claimScores : null);
     }
 
-    private async Task<(IReadOnlyList<MechanicValidationViolation> Violations, double? MinCosine)> EvaluateCoreAsync(
+    private async Task<(IReadOnlyList<MechanicValidationViolation> Violations, double? MinCosine,
+        IReadOnlyDictionary<string, double> ClaimScores)> EvaluateCoreAsync(
         MechanicGuardrailContext context, CancellationToken cancellationToken)
     {
         var violations = new List<MechanicValidationViolation>();
@@ -78,6 +80,9 @@ internal sealed class GroundingGuardrail : IMechanicGuardrail
         });
 
         double? minCosine = null;
+        // #2811: per-claim cosine keyed by the claim object's JSONPath (min across that claim's
+        // citations), so each claim can surface its OWN grounding score instead of the section min.
+        var claimScores = new Dictionary<string, double>(StringComparer.Ordinal);
         foreach (var (claim, path, chunk) in targets)
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -87,6 +92,7 @@ internal sealed class GroundingGuardrail : IMechanicGuardrail
                 var b = await _embeddings.EmbedAsync(chunk.Content, cancellationToken).ConfigureAwait(false);
                 var cos = Cosine(a, b);
                 minCosine = minCosine is null ? cos : Math.Min(minCosine.Value, cos);
+                claimScores[path] = claimScores.TryGetValue(path, out var prior) ? Math.Min(prior, cos) : cos;
                 if (cos < context.Options.MinClaimGroundingSimilarity)
                 {
                     violations.Add(new MechanicValidationViolation(
@@ -110,7 +116,7 @@ internal sealed class GroundingGuardrail : IMechanicGuardrail
             }
         }
 
-        return (violations, minCosine);
+        return (violations, minCosine, claimScores);
     }
 
     private static MechanicSourceChunk? ResolveChunk(JsonElement citation, IReadOnlyList<MechanicSourceChunk> pool)

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/Guardrails/IMechanicGuardrail.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/Guardrails/IMechanicGuardrail.cs
@@ -22,10 +22,16 @@ public sealed record MechanicGuardrailContext(
     public int RetryCount { get; init; }
 }
 
-/// <summary>Detailed guardrail result: the violations plus an optional numeric score (T3b only).</summary>
+/// <summary>
+/// Detailed guardrail result: the violations plus an optional numeric score (T3b only).
+/// <paramref name="Score"/> is the section-wide min cosine (kept for telemetry); <paramref name="ClaimScores"/>
+/// (#2811) carries the PER-CLAIM cosine keyed by the claim object's JSONPath so each claim can render
+/// its own grounding score instead of the misleading section min. Null for non-T3b guardrails.
+/// </summary>
 public sealed record MechanicGuardrailResult(
     IReadOnlyList<MechanicValidationViolation> Violations,
-    double? Score = null);
+    double? Score = null,
+    IReadOnlyDictionary<string, double>? ClaimScores = null);
 
 /// <summary>
 /// One ADR-051 guardrail (T1 quote cap, T2 long-verbatim, T3 citation present/grounded,

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/IMechanicOutputValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/IMechanicOutputValidator.cs
@@ -52,7 +52,11 @@ public sealed record MechanicRuleOutcome(
     string? Message,
     string? Path,
     double? Score,
-    IReadOnlyList<MechanicValidationViolation> Violations);
+    IReadOnlyList<MechanicValidationViolation> Violations,
+    // #2811: per-claim grounding cosine keyed by the claim object's JSONPath (T3b only; null
+    // otherwise). CorrelateValidations attaches each claim's own score from here instead of the
+    // section-wide min carried by Score.
+    IReadOnlyDictionary<string, double>? ClaimScores = null);
 
 public sealed record MechanicValidationViolation(
     string Rule,

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/MechanicAnalysisExecutor.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/MechanicAnalysisExecutor.cs
@@ -289,8 +289,15 @@ internal sealed class MechanicAnalysisExecutor : IMechanicAnalysisExecutor
                     var hits = o.Violations.Any(v => MatchesAnchor(v.Path, claim.SourceAnchor));
                     outcome = hits ? MechanicClaimValidationOutcomes.Fail : MechanicClaimValidationOutcomes.Pass;
                 }
+                // #2811: attach THIS claim's own grounding cosine (keyed by its anchor) rather than
+                // the section-wide min carried on o.Score — pass claims no longer render a misleading
+                // sibling's low score; claims with no per-claim cosine get null.
+                var claimScore = o.ClaimScores is not null
+                    && o.ClaimScores.TryGetValue(claim.SourceAnchor, out var cs)
+                    ? cs
+                    : (double?)null;
                 perClaim.Add(new MechanicClaimValidation(o.Rule, outcome,
-                    string.Equals(outcome, MechanicClaimValidationOutcomes.Fail, StringComparison.Ordinal) ? o.Message : null, o.Score));
+                    string.Equals(outcome, MechanicClaimValidationOutcomes.Fail, StringComparison.Ordinal) ? o.Message : null, claimScore));
             }
             claim.AttachValidations(perClaim);
         }

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/MechanicOutputParser.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/MechanicOutputParser.cs
@@ -199,6 +199,13 @@ internal static class MechanicOutputParser
             yield break;
         }
 
+        // The primary anchors to the whole "$.victory" object; its guardrail violations land on
+        // "$.victory" or "$.victory.citations[n]", both of which prefix-match this anchor (shared
+        // citations belong to the primary). NOTE: because MatchesAnchor is a one-way prefix check,
+        // "$.victory" also prefix-covers the "$.victory.alternatives[i]" subtree. That is harmless
+        // today — no guardrail walks the alternatives strings, so no "$.victory.alternatives[i]"
+        // violation path is ever produced. If alternatives-level validation is ever added, give the
+        // primary a boundary-exact anchor (or tighten MatchesAnchor) so it stops covering them.
         yield return BuildClaim(
             claimId: primaryClaimId,
             analysisId: analysisId,
@@ -215,8 +222,13 @@ internal static class MechanicOutputParser
             yield break;
         }
 
+        var altIndex = -1;
         foreach (var alt in alternatives.EnumerateArray())
         {
+            // #2808: stamp the RAW array index so each alternative carries a stable
+            // per-claim anchor ($.victory.alternatives[i]) that a "$.victory" primary
+            // violation no longer prefix-matches — mirrors the $.mechanics[i] semantics.
+            altIndex++;
             if (alt.ValueKind != JsonValueKind.String)
             {
                 continue;
@@ -242,7 +254,7 @@ internal static class MechanicOutputParser
                 text: text!,
                 displayOrder: displayOrder++,
                 citations: altCitations,
-                sourceAnchor: "$.victory");
+                sourceAnchor: $"$.victory.alternatives[{altIndex}]");
         }
     }
 

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/MechanicOutputValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/MechanicOutputValidator.cs
@@ -60,7 +60,8 @@ internal sealed class MechanicOutputValidator : IMechanicOutputValidator
                 Message: first?.Message,
                 Path: first?.Path,
                 Score: detailed.Score,
-                Violations: violations));
+                Violations: violations,
+                ClaimScores: detailed.ClaimScores));
 
             if (violations.Count > 0)
             {

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/MechanicExtractor/Guardrails/GroundingGuardrailScoreTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/MechanicExtractor/Guardrails/GroundingGuardrailScoreTests.cs
@@ -20,6 +20,14 @@ public class GroundingGuardrailScoreTests
         public Task<float[]> EmbedAsync(string text, CancellationToken ct) => Task.FromResult(_vec);
     }
 
+    private sealed class KeyedEmbeddings : IEmbeddingService
+    {
+        private readonly IReadOnlyDictionary<string, float[]> _map;
+        public KeyedEmbeddings(IReadOnlyDictionary<string, float[]> map) => _map = map;
+        public Task<float[]> EmbedAsync(string text, CancellationToken ct) =>
+            Task.FromResult(_map.TryGetValue(text, out var v) ? v : new float[] { 0f, 0f });
+    }
+
     [Fact]
     public async Task EvaluateDetailedAsync_PopulatesScore_WithMinCosine_OnPass()
     {
@@ -40,5 +48,43 @@ public class GroundingGuardrailScoreTests
         result.Violations.Should().BeEmpty();
         result.Score.Should().NotBeNull();
         result.Score!.Value.Should().BeApproximately(1.0, 0.001);
+    }
+
+    [Fact]
+    public async Task EvaluateDetailedAsync_PopulatesPerClaimScores_KeyedByObjectPath()
+    {
+        // #2811: two mechanics claims — one well-grounded (cosine 1.0), one poorly (cosine 0.0).
+        // ClaimScores must carry EACH claim's own cosine keyed by its object path, so a well-grounded
+        // sibling no longer inherits the section-wide min.
+        var embeddings = new KeyedEmbeddings(new Dictionary<string, float[]>
+        {
+            ["well grounded claim"] = new[] { 1f, 0f },
+            ["cited chunk A"] = new[] { 1f, 0f }, // cosine(well, A) = 1.0
+            ["poorly grounded claim"] = new[] { 1f, 0f },
+            ["cited chunk B"] = new[] { 0f, 1f }, // cosine(poor, B) = 0.0
+        });
+        var guardrail = new GroundingGuardrail(embeddings);
+
+        var json = """
+        {"mechanics":[
+          {"description":"well grounded claim","citations":[{"pdf_page":1,"quote":"q","chunk_id":"11111111-1111-4111-8111-111111111111"}]},
+          {"description":"poorly grounded claim","citations":[{"pdf_page":2,"quote":"q","chunk_id":"22222222-2222-4222-8222-222222222222"}]}
+        ]}
+        """;
+        using var doc = JsonDocument.Parse(json);
+        var chunks = new[]
+        {
+            new MechanicSourceChunk(0, 1, Guid.Parse("11111111-1111-4111-8111-111111111111"), "cited chunk A"),
+            new MechanicSourceChunk(1, 2, Guid.Parse("22222222-2222-4222-8222-222222222222"), "cited chunk B"),
+        };
+        var ctx = new MechanicGuardrailContext(MechanicSection.Mechanics, doc.RootElement, chunks, 10,
+            new MechanicGuardrailOptions { MinClaimGroundingSimilarity = 0.5 });
+
+        var result = await guardrail.EvaluateDetailedAsync(ctx, CancellationToken.None);
+
+        result.ClaimScores.Should().NotBeNull();
+        result.ClaimScores!["$.mechanics[0]"].Should().BeApproximately(1.0, 0.001);
+        result.ClaimScores!["$.mechanics[1]"].Should().BeApproximately(0.0, 0.001);
+        result.Score!.Value.Should().BeApproximately(0.0, 0.001); // section min unchanged
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/MechanicAnalysisExecutorCorrelationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/MechanicAnalysisExecutorCorrelationTests.cs
@@ -32,7 +32,8 @@ public class MechanicAnalysisExecutorCorrelationTests
                 new MechanicRuleOutcome("T2", "fail", "long verbatim", "$.mechanics[1].description", null,
                     new[] { new MechanicValidationViolation("T2_long_verbatim", "long verbatim", "$.mechanics[1].description") }),
                 new MechanicRuleOutcome("T3a", "pass", null, null, null, Array.Empty<MechanicValidationViolation>()),
-                new MechanicRuleOutcome("T3b", "pass", null, null, 0.8, Array.Empty<MechanicValidationViolation>()),
+                new MechanicRuleOutcome("T3b", "pass", null, null, 0.8, Array.Empty<MechanicValidationViolation>(),
+                    new Dictionary<string, double> { ["$.mechanics[0]"] = 0.8, ["$.mechanics[1]"] = 0.8 }),
                 new MechanicRuleOutcome("T4", "pass", null, null, null, Array.Empty<MechanicValidationViolation>()),
             }
         };
@@ -88,12 +89,12 @@ public class MechanicAnalysisExecutorCorrelationTests
     }
 
     [Fact]
-    public void Correlate_VictorySection_FailPropagatesToAllSharedAnchorClaims()
+    public void Correlate_VictorySection_PrimaryFail_DoesNotTaintAlternatives()
     {
-        // Victory primary + alternatives all share the anchor "$.victory" (MechanicOutputParser
-        // ParseVictory), so per the D4 documented approximation a Victory guardrail failure
-        // attributes to every Victory claim sharing that anchor — there is no per-alternative
-        // sub-anchor to disambiguate against.
+        // #2808: the primary anchors to "$.victory" and each alternative to
+        // "$.victory.alternatives[i]", so a "$.victory" violation (about the primary)
+        // matches the primary exactly but NOT the alternative sub-anchors — the D4
+        // broadcast approximation is replaced with per-claim precision.
         var json = """
         {"victory":{
           "primary":"Score the most points",
@@ -105,7 +106,8 @@ public class MechanicAnalysisExecutorCorrelationTests
             new Dictionary<MechanicSection, string> { [MechanicSection.Victory] = json }).ToList();
 
         claims.Should().HaveCount(2);
-        claims.Should().OnlyContain(c => c.SourceAnchor == "$.victory");
+        claims[0].SourceAnchor.Should().Be("$.victory");
+        claims[1].SourceAnchor.Should().Be("$.victory.alternatives[0]");
 
         var outcomes = new Dictionary<MechanicSection, IReadOnlyList<MechanicRuleOutcome>>
         {
@@ -118,6 +120,73 @@ public class MechanicAnalysisExecutorCorrelationTests
 
         MechanicAnalysisExecutor.CorrelateValidations(claims, outcomes);
 
-        claims.Should().OnlyContain(c => c.Validations.Single(v => v.Rule == "T3a").Outcome == "fail");
+        claims[0].Validations.Single(v => v.Rule == "T3a").Outcome.Should().Be("fail"); // primary
+        claims[1].Validations.Single(v => v.Rule == "T3a").Outcome.Should().Be("pass"); // alternative untainted
+    }
+
+    [Fact]
+    public void Correlate_T3b_AttachesPerClaimCosine_NotSectionMin()
+    {
+        // #2811: a well-grounded claim must render ITS OWN cosine, not the section-wide min
+        // captured from a different, poorly-grounded sibling.
+        var json = """
+        {"mechanics":[
+          {"description":"well grounded","citations":[{"pdf_page":1,"quote":"q"}]},
+          {"description":"poorly grounded","citations":[{"pdf_page":2,"quote":"q"}]}
+        ]}
+        """;
+        var claims = MechanicOutputParser.Parse(Guid.NewGuid(),
+            new Dictionary<MechanicSection, string> { [MechanicSection.Mechanics] = json }).ToList();
+
+        var claimScores = new Dictionary<string, double>
+        {
+            ["$.mechanics[0]"] = 0.90,
+            ["$.mechanics[1]"] = 0.30,
+        };
+        var outcomes = new Dictionary<MechanicSection, IReadOnlyList<MechanicRuleOutcome>>
+        {
+            [MechanicSection.Mechanics] = new[]
+            {
+                new MechanicRuleOutcome("T3b", "fail", "below threshold", "$.mechanics[1]", 0.30,
+                    new[] { new MechanicValidationViolation("T3_grounding", "below threshold", "$.mechanics[1]") },
+                    claimScores),
+            }
+        };
+
+        MechanicAnalysisExecutor.CorrelateValidations(claims, outcomes);
+
+        var c0 = claims[0].Validations.Single(v => v.Rule == "T3b");
+        c0.Outcome.Should().Be("pass");
+        c0.Score.Should().Be(0.90); // its own — NOT the section-min 0.30
+
+        var c1 = claims[1].Validations.Single(v => v.Rule == "T3b");
+        c1.Outcome.Should().Be("fail");
+        c1.Score.Should().Be(0.30);
+    }
+
+    [Fact]
+    public void Correlate_T3b_NoPerClaimScore_YieldsNull_NotSectionMin()
+    {
+        // #2811: when a claim has no per-claim cosine (e.g. no citations graded), its T3b score
+        // is null rather than the misleading section-min carried on the outcome.
+        var json = """
+        {"mechanics":[{"description":"ungraded","citations":[{"pdf_page":1,"quote":"q"}]}]}
+        """;
+        var claims = MechanicOutputParser.Parse(Guid.NewGuid(),
+            new Dictionary<MechanicSection, string> { [MechanicSection.Mechanics] = json }).ToList();
+
+        var outcomes = new Dictionary<MechanicSection, IReadOnlyList<MechanicRuleOutcome>>
+        {
+            [MechanicSection.Mechanics] = new[]
+            {
+                // Score (section-min) present but ClaimScores has no entry for $.mechanics[0].
+                new MechanicRuleOutcome("T3b", "pass", null, null, 0.42, Array.Empty<MechanicValidationViolation>(),
+                    new Dictionary<string, double>()),
+            }
+        };
+
+        MechanicAnalysisExecutor.CorrelateValidations(claims, outcomes);
+
+        claims[0].Validations.Single(v => v.Rule == "T3b").Score.Should().BeNull();
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/MechanicOutputParserAnchorTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/MechanicOutputParserAnchorTests.cs
@@ -30,10 +30,33 @@ public class MechanicOutputParserAnchorTests
     }
 
     [Fact]
-    public void Parse_Victory_AnchorsPrimaryAndAlternatives_ToVictoryObject()
+    public void Parse_Victory_AnchorsPrimaryToVictory_AndAlternativesToRawSubIndex()
     {
+        // #2808: the primary anchors to $.victory; each alternative gets its own
+        // $.victory.alternatives[i] sub-anchor (raw array index) so a $.victory
+        // guardrail violation about the primary no longer broadcasts to alternatives.
         var json = """
-        {"victory":{"primary":"most points wins","alternatives":["instant win on 10 gems"],
+        {"victory":{"primary":"most points wins",
+          "alternatives":["instant win on 10 gems","control all regions"],
+          "citations":[{"pdf_page":5,"quote":"points win"}]}}
+        """;
+        var outputs = new Dictionary<MechanicSection, string> { [MechanicSection.Victory] = json };
+
+        var claims = MechanicOutputParser.Parse(Guid.NewGuid(), outputs);
+
+        claims.Should().HaveCount(3);
+        claims[0].SourceAnchor.Should().Be("$.victory"); // primary
+        claims[1].SourceAnchor.Should().Be("$.victory.alternatives[0]");
+        claims[2].SourceAnchor.Should().Be("$.victory.alternatives[1]");
+    }
+
+    [Fact]
+    public void Parse_Victory_StampsRawAlternativeIndex_EvenWhenEarlierAlternativesDropped()
+    {
+        // alternatives[0] is blank → dropped; alternatives[1] emitted. Its anchor must be
+        // the raw array index $.victory.alternatives[1], mirroring $.mechanics[i] semantics.
+        var json = """
+        {"victory":{"primary":"most points wins","alternatives":["","control all regions"],
           "citations":[{"pdf_page":5,"quote":"points win"}]}}
         """;
         var outputs = new Dictionary<MechanicSection, string> { [MechanicSection.Victory] = json };
@@ -41,6 +64,7 @@ public class MechanicOutputParserAnchorTests
         var claims = MechanicOutputParser.Parse(Guid.NewGuid(), outputs);
 
         claims.Should().HaveCount(2);
-        claims.Should().OnlyContain(c => c.SourceAnchor == "$.victory");
+        claims[0].SourceAnchor.Should().Be("$.victory"); // primary
+        claims[1].SourceAnchor.Should().Be("$.victory.alternatives[1]"); // raw index, not compacted
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/MechanicAnalysisEndpointsIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/MechanicAnalysisEndpointsIntegrationTests.cs
@@ -396,6 +396,9 @@ public sealed class MechanicAnalysisEndpointsIntegrationTests : IAsyncLifetime
         dto.IsSuppressed.Should().BeFalse();
         // Background executor is mocked → no section runs recorded yet.
         dto.SectionRuns.Should().BeEmpty();
+        // #2807: N/M sections-with-claims signal — no claims produced yet → 0 of 6.
+        dto.SectionsWithClaims.Should().Be(0);
+        dto.TotalSections.Should().Be(6);
     }
 
     [Fact]

--- a/apps/api/tests/Api.Tests/Integration/SharedGameCatalog/GetMechanicAnalysisStatusSectionSignalIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/SharedGameCatalog/GetMechanicAnalysisStatusSectionSignalIntegrationTests.cs
@@ -1,0 +1,137 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Queries.MechanicExtractor;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Api.Tests.Integration.SharedGameCatalog;
+
+/// <summary>
+/// #2807 (ME-FU-1): the mechanic-analysis status query surfaces an "N/M sections produced claims"
+/// signal (SectionsWithClaims / TotalSections) so a section that was silently dropped — e.g. failed
+/// the well_formed check across all retries and never reached the review queue — is visible to the
+/// reviewer as N &lt; M. Computed at query time from the persisted claims; no schema change.
+/// </summary>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class GetMechanicAnalysisStatusSectionSignalIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private string _databaseName = null!;
+    private string _connectionString = null!;
+    private MeepleAiDbContext _dbContext = null!;
+
+    private static readonly Guid TestAdminId = Guid.NewGuid();
+
+    public GetMechanicAnalysisStatusSectionSignalIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        _databaseName = $"status_section_signal_{Guid.NewGuid():N}";
+        _connectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+        _dbContext = _fixture.CreateDbContext(_connectionString);
+        await _dbContext.Database.MigrateAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _dbContext.DisposeAsync();
+        await _fixture.DropIsolatedDatabaseAsync(_databaseName);
+    }
+
+    [Fact(DisplayName = "Status query counts DISTINCT sections-with-claims out of 6 total")]
+    public async Task Handle_ReportsDistinctSectionsWithClaims_OutOfSixTotal()
+    {
+        var analysisId = await SeedAnalysisAsync();
+        // Claims across 3 DISTINCT sections (Summary=0, Mechanics=1, Resources=3); Mechanics twice
+        // to prove we count distinct sections, not raw claims.
+        AddClaim(analysisId, section: 0, order: 0);
+        AddClaim(analysisId, section: 1, order: 1);
+        AddClaim(analysisId, section: 1, order: 2);
+        AddClaim(analysisId, section: 3, order: 3);
+        await _dbContext.SaveChangesAsync();
+
+        var handler = new GetMechanicAnalysisStatusQueryHandler(_dbContext);
+        var dto = await handler.Handle(new GetMechanicAnalysisStatusQuery(analysisId), CancellationToken.None);
+
+        dto.Should().NotBeNull();
+        dto!.ClaimsCount.Should().Be(4);
+        dto.SectionsWithClaims.Should().Be(3); // sections 0,1,3 — Victory/Phases/Faq dropped
+        dto.TotalSections.Should().Be(6);
+    }
+
+    [Fact(DisplayName = "Status query reports 0/6 when no section produced claims")]
+    public async Task Handle_ReportsZeroSectionsWithClaims_WhenNoClaims()
+    {
+        var analysisId = await SeedAnalysisAsync();
+        await _dbContext.SaveChangesAsync();
+
+        var handler = new GetMechanicAnalysisStatusQueryHandler(_dbContext);
+        var dto = await handler.Handle(new GetMechanicAnalysisStatusQuery(analysisId), CancellationToken.None);
+
+        dto.Should().NotBeNull();
+        dto!.SectionsWithClaims.Should().Be(0);
+        dto.TotalSections.Should().Be(6);
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private void AddClaim(Guid analysisId, int section, int order) =>
+        _dbContext.MechanicClaims.Add(new MechanicClaimEntity
+        {
+            Id = Guid.NewGuid(),
+            AnalysisId = analysisId,
+            Section = section,
+            Text = $"claim s{section} o{order}",
+            DisplayOrder = order,
+            Status = 0
+        });
+
+    private async Task<Guid> SeedAnalysisAsync()
+    {
+        var sharedGameId = Guid.NewGuid();
+        _dbContext.SharedGames.Add(new SharedGameEntity
+        {
+            Id = sharedGameId,
+            Title = "Status Section Signal Test Game",
+            Description = "Integration test game",
+            ImageUrl = string.Empty,
+            ThumbnailUrl = string.Empty,
+            YearPublished = 2024,
+            MinPlayers = 2,
+            MaxPlayers = 4,
+            PlayingTimeMinutes = 60,
+            MinAge = 10,
+            Status = 1,
+            CreatedBy = TestAdminId,
+            CreatedAt = DateTime.UtcNow
+        });
+
+        var analysisId = Guid.NewGuid();
+        _dbContext.MechanicAnalyses.Add(new MechanicAnalysisEntity
+        {
+            Id = analysisId,
+            SharedGameId = sharedGameId,
+            PdfDocumentId = Guid.NewGuid(),
+            PromptVersion = "mechanic-extractor-v1",
+            Status = 0,
+            CreatedBy = TestAdminId,
+            CreatedAt = DateTime.UtcNow,
+            TotalTokensUsed = 0,
+            EstimatedCostUsd = 0m,
+            ModelUsed = "test-model",
+            Provider = "test-provider",
+            CostCapUsd = 1.00m
+        });
+
+        await _dbContext.SaveChangesAsync();
+        return analysisId;
+    }
+}


### PR DESCRIPTION
## Summary

Three low-risk **ME-FU-1** follow-ups deferred from #2782 (per-claim validation), all in the Mechanic Extractor (`SharedGameCatalog`). **No schema change.**

## #2808 — Victory guardrail correlation is now per-claim precise
`MechanicOutputParser.ParseVictory` stamped **both** the primary and every alternative victory claim with `SourceAnchor = "$.victory"`, so a single `$.victory` guardrail violation (about the primary / shared citations) broadcast to every victory claim via `MatchesAnchor` prefix-matching (D4 documented approximation). Alternatives now get `$.victory.alternatives[i]` (**raw array index**, mirroring `$.mechanics[i]`), so a `$.victory` violation matches the primary exactly but not the alternative sub-anchors.

## #2811 — T3b claim score is the per-claim cosine, not the section-wide min
`GroundingGuardrail` captured a single section-wide `minCosine`; `CorrelateValidations` attached it (`o.Score`) to **every** claim's T3b outcome — so a well-grounded claim (cosine 0.90, pass) could render *"T3b pass, score 0.30"* (the min from a different, failing claim). The guardrail now also returns a **per-path cosine map** (`ClaimScores`, min per path) plumbed through `MechanicGuardrailResult` → `MechanicRuleOutcome`; `CorrelateValidations` attaches each claim's own cosine keyed by `SourceAnchor` (or `null` when the claim wasn't graded — e.g. victory alternatives, which are strings and never grounded). **No functional impact** — all gating keys off `Outcome`, never `Score`.

## #2807 — "N/M sections produced claims" signal
`GET /api/v1/admin/mechanic-analyses/{id}/status` now returns `SectionsWithClaims` (distinct sections with ≥1 persisted claim) + `TotalSections` (`Enum.GetValues<MechanicSection>().Length` = 6), computed at query time from persisted claims (**no schema change**). `SectionsWithClaims < TotalSections` means a section was silently dropped (e.g. failed `well_formed` across all retries) and is absent from the review queue. Additive/non-breaking DTO field; FE can render "N/6" as a warning.

## Verification
- **364 Mechanic unit tests green** — no regressions from the record (`MechanicRuleOutcome`/`MechanicGuardrailResult`/DTO) / executor / parser changes.
- New/updated tests: parser-anchor (victory sub-index + raw-index-on-drop), correlation (primary-fail-doesn't-taint-alternatives, per-claim-cosine-not-section-min, ungraded→null), grounding (per-path `ClaimScores`), status handler + endpoint (N/M distinct-vs-raw, 0/6, HTTP round-trip). RED→GREEN observed for #2808/#2811.
- **Adversarial opus review**: 0 CRITICAL/HIGH; confirmed the map-key/`SourceAnchor` alignment, the alternatives-null-score is correct by design, and the positional-record append is safe. One LOW latent note on `MatchesAnchor` prefix asymmetry (dead code today) documented with a defensive comment.

Closes #2807
Closes #2808
Closes #2811

🤖 Generated with [Claude Code](https://claude.com/claude-code)
