### PR TITLE
feat(mechanic-extractor): #528 public login-gated card page

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/DTOs/PublishedMechanicCardDto.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/DTOs/PublishedMechanicCardDto.cs
@@ -1,0 +1,37 @@
+namespace Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
+
+/// <summary>
+/// Public read projection of a published <see cref="Domain.Aggregates.MechanicCard"/> for the
+/// login-gated card page <c>/games/{id}/card</c> (#528 ME-M1.6). Built by deserializing the immutable
+/// <c>mechanic_cards.content</c> snapshot (<see cref="Domain.ValueObjects.MechanicCardContent"/>) and
+/// GROUPING the flat claim list into the 6 sections in enum order. Intentionally omits the admin-only
+/// guardrail validation telemetry (down-projected passed/failed is admin review nuance, not public).
+/// A suppressed / absent card never reaches here — the handler returns null → 404.
+/// </summary>
+public sealed record PublishedMechanicCardDto(
+    Guid CardId,
+    Guid SharedGameId,
+    string Title,
+    int Version,
+    DateTime PublishedAt,
+    string GameName,
+    string? Publisher,
+    string Language,
+    IReadOnlyList<PublishedMechanicCardSectionDto> Sections);
+
+/// <summary>One of the 6 mechanic sections (Summary/Mechanics/Victory/Resources/Phases/Faq).</summary>
+public sealed record PublishedMechanicCardSectionDto(
+    string Section,
+    IReadOnlyList<PublishedMechanicCardClaimDto> Claims);
+
+/// <summary>A single reviewed claim with its verbatim citations.</summary>
+public sealed record PublishedMechanicCardClaimDto(
+    Guid Id,
+    string Claim,
+    IReadOnlyList<PublishedMechanicCardCitationDto> Citations);
+
+/// <summary>A verbatim source citation: the origin PDF, its page, and the quoted text.</summary>
+public sealed record PublishedMechanicCardCitationDto(
+    Guid PdfId,
+    int PdfPage,
+    string Quote);

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/MechanicExtractor/GetPublishedMechanicCardByGameQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/MechanicExtractor/GetPublishedMechanicCardByGameQuery.cs
@@ -1,0 +1,12 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
+using MediatR;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Queries.MechanicExtractor;
+
+/// <summary>
+/// Reads the active (non-suppressed) published mechanic card for a game (#528 ME-M1.6). Returns null
+/// when the game has no published card or the card was suppressed/taken down — the endpoint maps null
+/// to 404 so a suppressed card disappears from the public page automatically.
+/// </summary>
+internal sealed record GetPublishedMechanicCardByGameQuery(Guid SharedGameId)
+    : IRequest<PublishedMechanicCardDto?>;

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/MechanicExtractor/GetPublishedMechanicCardByGameQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/MechanicExtractor/GetPublishedMechanicCardByGameQueryHandler.cs
@@ -1,0 +1,85 @@
+using System.Text.Json;
+using Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+using MediatR;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Queries.MechanicExtractor;
+
+/// <summary>
+/// Handler for <see cref="GetPublishedMechanicCardByGameQuery"/> (#528). Delegates the by-game lookup
+/// to <see cref="IMechanicCardRepository.GetActiveByGameAsync"/> (which honors the <c>!IsSuppressed</c>
+/// query filter, so takedowns return null), then deserializes the immutable content snapshot and groups
+/// the flat claim list into the 6 sections in enum order for the public card renderer.
+/// </summary>
+internal sealed class GetPublishedMechanicCardByGameQueryHandler
+    : IRequestHandler<GetPublishedMechanicCardByGameQuery, PublishedMechanicCardDto?>
+{
+    private readonly IMechanicCardRepository _cards;
+
+    public GetPublishedMechanicCardByGameQueryHandler(IMechanicCardRepository cards)
+    {
+        _cards = cards ?? throw new ArgumentNullException(nameof(cards));
+    }
+
+    public async Task<PublishedMechanicCardDto?> Handle(
+        GetPublishedMechanicCardByGameQuery request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var card = await _cards.GetActiveByGameAsync(request.SharedGameId, cancellationToken).ConfigureAwait(false);
+        if (card is null)
+        {
+            return null; // no card, or suppressed → 404
+        }
+
+        MechanicCardContent? content;
+        try
+        {
+            content = JsonSerializer.Deserialize<MechanicCardContent>(card.Content);
+        }
+        catch (JsonException)
+        {
+            content = null;
+        }
+
+        if (content is null)
+        {
+            return null;
+        }
+
+        // The persisted claims are a flat list carrying a `section` string; group them into the 6
+        // sections, ordered by the MechanicSection enum (Summary..Faq) then by each claim's ordinal.
+        var sections = content.Claims
+            .GroupBy(c => c.Section, StringComparer.Ordinal)
+            .OrderBy(g => SectionOrder(g.Key))
+            .Select(g => new PublishedMechanicCardSectionDto(
+                g.Key,
+                g.OrderBy(c => c.Ordinal)
+                    .Select(c => new PublishedMechanicCardClaimDto(
+                        c.Id,
+                        c.Claim,
+                        c.Citations
+                            .Select(cit => new PublishedMechanicCardCitationDto(cit.PdfId, cit.PdfPage, cit.Quote))
+                            .ToList()))
+                    .ToList()))
+            .ToList();
+
+        return new PublishedMechanicCardDto(
+            CardId: card.Id,
+            SharedGameId: card.SharedGameId,
+            Title: card.Title,
+            Version: card.Version,
+            PublishedAt: card.PublishedAt,
+            GameName: content.Metadata.SharedGameName,
+            Publisher: content.Metadata.Publisher,
+            Language: content.Metadata.Language,
+            Sections: sections);
+    }
+
+    // Unknown section names sort last (defensive; the snapshot only writes enum names).
+    private static int SectionOrder(string section) =>
+        Enum.TryParse<MechanicSection>(section, ignoreCase: false, out var parsed) ? (int)parsed : int.MaxValue;
+}

--- a/apps/api/src/Api/Routing/SharedGameCatalog/SharedGameCatalogUserEndpoints.cs
+++ b/apps/api/src/Api/Routing/SharedGameCatalog/SharedGameCatalogUserEndpoints.cs
@@ -1,5 +1,6 @@
 using Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
 using Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetGameDocumentsForUser;
+using Api.BoundedContexts.SharedGameCatalog.Application.Queries.MechanicExtractor;
 using Api.Middleware.Exceptions;
 using MediatR;
 
@@ -21,6 +22,25 @@ internal static class SharedGameCatalogUserEndpoints
             .Produces<IReadOnlyList<SharedGameDocumentDto>>()
             .Produces(StatusCodes.Status401Unauthorized)
             .Produces(StatusCodes.Status404NotFound);
+
+        // Get the active published mechanic card for a game (#528 ME-M1.6, login-gated).
+        group.MapGet("/games/{gameId:guid}/card", HandleGetPublishedMechanicCard)
+            .RequireAuthorization()
+            .WithName("GetPublishedMechanicCard")
+            .WithSummary("Get the published mechanic card for a game (Authenticated)")
+            .WithDescription("Returns the active (non-suppressed) published mechanic card for a game. 404 when no card is published or the card was suppressed/taken down.")
+            .Produces<PublishedMechanicCardDto>()
+            .Produces(StatusCodes.Status401Unauthorized)
+            .Produces(StatusCodes.Status404NotFound);
+    }
+
+    private static async Task<IResult> HandleGetPublishedMechanicCard(
+        Guid gameId,
+        IMediator mediator,
+        CancellationToken ct)
+    {
+        var result = await mediator.Send(new GetPublishedMechanicCardByGameQuery(gameId), ct).ConfigureAwait(false);
+        return result is null ? Results.NotFound() : Results.Ok(result);
     }
 
     private static async Task<IResult> HandleGetGameDocumentsForUser(

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Queries/MechanicExtractor/GetPublishedMechanicCardByGameQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Queries/MechanicExtractor/GetPublishedMechanicCardByGameQueryHandlerTests.cs
@@ -1,0 +1,110 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Queries.MechanicExtractor;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Queries.MechanicExtractor;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public class GetPublishedMechanicCardByGameQueryHandlerTests
+{
+    private static MechanicCard BuildCard(Guid gameId, string contentJson, bool suppressed = false) =>
+        MechanicCard.Reconstitute(
+            id: Guid.NewGuid(),
+            sharedGameId: gameId,
+            originAnalysisId: Guid.NewGuid(),
+            origin: MechanicCardOrigin.AiReviewed,
+            title: "Catan — Comprehension Card",
+            content: contentJson,
+            version: 3,
+            isSuppressed: suppressed,
+            suppressedReason: suppressed ? "test" : null,
+            suppressedAt: suppressed ? DateTime.UtcNow : null,
+            suppressedBy: suppressed ? Guid.NewGuid() : null,
+            errorReportsCount: 0,
+            feedbackScore: null,
+            publishedAt: new DateTime(2026, 5, 1, 0, 0, 0, DateTimeKind.Utc),
+            publishedBy: Guid.NewGuid(),
+            createdAt: DateTime.UtcNow,
+            updatedAt: DateTime.UtcNow);
+
+    private static string ContentWithMixedSections(Guid gameId, Guid pdfId)
+    {
+        // Sections deliberately OUT of enum order and ordinals shuffled within a section,
+        // to prove the handler groups + orders by MechanicSection enum then by ordinal.
+        var content = new MechanicCardContent
+        {
+            SnapshotAt = DateTime.UtcNow,
+            SourceAnalysisId = Guid.NewGuid(),
+            SourcePromptVersion = "mechanic-extractor-v1",
+            Metadata = new MechanicCardMetadata
+            {
+                SharedGameId = gameId,
+                SharedGameName = "Catan",
+                Publisher = "Kosmos",
+                Language = "en"
+            },
+            Claims = new[]
+            {
+                new MechanicCardClaimSnapshot { Id = Guid.NewGuid(), Section = "Faq", Ordinal = 0, Claim = "faq claim",
+                    Citations = new[] { new MechanicCardCitationSnapshot { PdfId = pdfId, PdfPage = 12, Quote = "faq quote" } } },
+                new MechanicCardClaimSnapshot { Id = Guid.NewGuid(), Section = "Summary", Ordinal = 1, Claim = "summary second",
+                    Citations = Array.Empty<MechanicCardCitationSnapshot>() },
+                new MechanicCardClaimSnapshot { Id = Guid.NewGuid(), Section = "Summary", Ordinal = 0, Claim = "summary first",
+                    Citations = new[] { new MechanicCardCitationSnapshot { PdfId = pdfId, PdfPage = 1, Quote = "summary quote" } } },
+                new MechanicCardClaimSnapshot { Id = Guid.NewGuid(), Section = "Mechanics", Ordinal = 0, Claim = "mechanics claim",
+                    Citations = Array.Empty<MechanicCardCitationSnapshot>() },
+            }
+        };
+        return content.ToJson();
+    }
+
+    [Fact]
+    public async Task Handle_GroupsClaimsBySection_InEnumOrder_AndOrdinalWithinSection()
+    {
+        var gameId = Guid.NewGuid();
+        var pdfId = Guid.NewGuid();
+        var card = BuildCard(gameId, ContentWithMixedSections(gameId, pdfId));
+
+        var repo = new Mock<IMechanicCardRepository>();
+        repo.Setup(r => r.GetActiveByGameAsync(gameId, It.IsAny<CancellationToken>())).ReturnsAsync(card);
+
+        var handler = new GetPublishedMechanicCardByGameQueryHandler(repo.Object);
+        var dto = await handler.Handle(new GetPublishedMechanicCardByGameQuery(gameId), CancellationToken.None);
+
+        dto.Should().NotBeNull();
+        dto!.GameName.Should().Be("Catan");
+        dto.Publisher.Should().Be("Kosmos");
+        dto.Language.Should().Be("en");
+        dto.Version.Should().Be(3);
+
+        // Grouped into 3 sections, ordered by MechanicSection enum: Summary(0), Mechanics(1), Faq(5).
+        dto.Sections.Select(s => s.Section).Should().Equal("Summary", "Mechanics", "Faq");
+        // Summary claims ordered by ordinal (0 before 1), NOT input order.
+        dto.Sections[0].Claims.Select(c => c.Claim).Should().Equal("summary first", "summary second");
+        // Citations projected through.
+        dto.Sections[0].Claims[0].Citations.Should().ContainSingle();
+        dto.Sections[0].Claims[0].Citations[0].PdfPage.Should().Be(1);
+        dto.Sections[2].Claims[0].Citations[0].PdfId.Should().Be(pdfId);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsNull_WhenNoActiveCard()
+    {
+        var gameId = Guid.NewGuid();
+        var repo = new Mock<IMechanicCardRepository>();
+        // GetActiveByGameAsync honors the !IsSuppressed filter → suppressed/absent both surface as null.
+        repo.Setup(r => r.GetActiveByGameAsync(gameId, It.IsAny<CancellationToken>())).ReturnsAsync((MechanicCard?)null);
+
+        var handler = new GetPublishedMechanicCardByGameQueryHandler(repo.Object);
+        var dto = await handler.Handle(new GetPublishedMechanicCardByGameQuery(gameId), CancellationToken.None);
+
+        dto.Should().BeNull();
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/PublishedMechanicCardEndpointIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/PublishedMechanicCardEndpointIntegrationTests.cs
@@ -1,0 +1,223 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+using Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
+using Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Infrastructure;
+
+/// <summary>
+/// Integration tests for <c>GET /api/v1/games/{gameId}/card</c> (#528, ME-M1.6) — the login-gated
+/// public read of a published mechanic card. Exercises the full stack against real PostgreSQL: the
+/// content JSONB round-trip + grouping, the suppression query filter (takedown → 404), the no-card
+/// 404, and the authentication gate (401 without a session).
+/// </summary>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class PublishedMechanicCardEndpointIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly string _testDbName;
+    private WebApplicationFactory<Program> _factory = null!;
+    private HttpClient _client = null!;
+    private string _userSessionToken = null!;
+
+    private static readonly Guid TestUserId = Guid.NewGuid();
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        Converters = { new JsonStringEnumConverter() }
+    };
+
+    public PublishedMechanicCardEndpointIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+        _testDbName = $"published_mechanic_card_{Guid.NewGuid():N}";
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_testDbName);
+        _factory = IntegrationWebApplicationFactory.Create(connectionString);
+
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            await dbContext.Database.MigrateAsync();
+            var (_, token) = await TestSessionHelper.CreateUserSessionAsync(dbContext, TestUserId);
+            _userSessionToken = token;
+        }
+
+        _client = _factory.CreateClient();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _client?.Dispose();
+        if (_factory is not null)
+        {
+            await _factory.DisposeAsync();
+        }
+        await _fixture.DropIsolatedDatabaseAsync(_testDbName);
+    }
+
+    [Fact]
+    public async Task GetCard_ForPublishedActiveCard_Returns200WithGroupedSections()
+    {
+        var gameId = await SeedGameWithCardAsync(suppressed: false);
+
+        var response = await SendGetCardAsync(gameId, authenticated: true);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var dto = await response.Content.ReadFromJsonAsync<PublishedMechanicCardDto>(JsonOptions);
+        dto.Should().NotBeNull();
+        dto!.GameName.Should().Be("Catan");
+        dto.Publisher.Should().Be("Kosmos");
+        // Sections grouped + ordered by enum: Summary then Mechanics.
+        dto.Sections.Select(s => s.Section).Should().Equal("Summary", "Mechanics");
+        dto.Sections[0].Claims[0].Citations[0].PdfPage.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task GetCard_ForSuppressedCard_Returns404()
+    {
+        var gameId = await SeedGameWithCardAsync(suppressed: true);
+
+        var response = await SendGetCardAsync(gameId, authenticated: true);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task GetCard_ForGameWithNoCard_Returns404()
+    {
+        var response = await SendGetCardAsync(Guid.NewGuid(), authenticated: true);
+
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task GetCard_WithoutSession_Returns401()
+    {
+        var gameId = await SeedGameWithCardAsync(suppressed: false);
+
+        var response = await SendGetCardAsync(gameId, authenticated: false);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private async Task<HttpResponseMessage> SendGetCardAsync(Guid gameId, bool authenticated)
+    {
+        if (authenticated)
+        {
+            var request = TestSessionHelper.CreateAuthenticatedRequest(
+                HttpMethod.Get, $"/api/v1/games/{gameId}/card", _userSessionToken);
+            return await _client.SendAsync(request);
+        }
+
+        return await _client.GetAsync($"/api/v1/games/{gameId}/card");
+    }
+
+    private async Task<Guid> SeedGameWithCardAsync(bool suppressed)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        var gameId = Guid.NewGuid();
+        db.SharedGames.Add(new SharedGameEntity
+        {
+            Id = gameId,
+            Title = "Catan",
+            Description = "Integration test game",
+            ImageUrl = string.Empty,
+            ThumbnailUrl = string.Empty,
+            YearPublished = 1995,
+            MinPlayers = 3,
+            MaxPlayers = 4,
+            PlayingTimeMinutes = 90,
+            MinAge = 10,
+            Status = 1,
+            CreatedBy = TestUserId,
+            CreatedAt = DateTime.UtcNow
+        });
+
+        var analysisId = Guid.NewGuid();
+        var pdfId = Guid.NewGuid();
+        db.MechanicAnalyses.Add(new MechanicAnalysisEntity
+        {
+            Id = analysisId,
+            SharedGameId = gameId,
+            PdfDocumentId = pdfId,
+            PromptVersion = "mechanic-extractor-v1",
+            Status = (int)Api.BoundedContexts.SharedGameCatalog.Domain.Enums.MechanicAnalysisStatus.Published,
+            CreatedBy = TestUserId,
+            CreatedAt = DateTime.UtcNow,
+            TotalTokensUsed = 0,
+            EstimatedCostUsd = 0m,
+            ModelUsed = "test-model",
+            Provider = "test-provider",
+            CostCapUsd = 1.00m
+        });
+
+        var content = new MechanicCardContent
+        {
+            SnapshotAt = DateTime.UtcNow,
+            SourceAnalysisId = analysisId,
+            SourcePromptVersion = "mechanic-extractor-v1",
+            Metadata = new MechanicCardMetadata
+            {
+                SharedGameId = gameId,
+                SharedGameName = "Catan",
+                Publisher = "Kosmos",
+                Language = "en"
+            },
+            Claims = new[]
+            {
+                new MechanicCardClaimSnapshot { Id = Guid.NewGuid(), Section = "Mechanics", Ordinal = 0, Claim = "Roll and produce resources.",
+                    Citations = Array.Empty<MechanicCardCitationSnapshot>() },
+                new MechanicCardClaimSnapshot { Id = Guid.NewGuid(), Section = "Summary", Ordinal = 0, Claim = "Build settlements to 10 VP.",
+                    Citations = new[] { new MechanicCardCitationSnapshot { PdfId = pdfId, PdfPage = 1, Quote = "first to 10 points wins" } } },
+            }
+        };
+
+        db.Set<MechanicCardEntity>().Add(new MechanicCardEntity
+        {
+            Id = Guid.NewGuid(),
+            SharedGameId = gameId,
+            OriginAnalysisId = analysisId,
+            Origin = "ai_reviewed",
+            Title = "Catan — Comprehension Card",
+            Content = content.ToJson(),
+            Version = 1,
+            IsSuppressed = suppressed,
+            SuppressedReason = suppressed ? "takedown request" : null,
+            SuppressedAt = suppressed ? DateTime.UtcNow : null,
+            SuppressedBy = suppressed ? TestUserId : null,
+            ErrorReportsCount = 0,
+            FeedbackScore = null,
+            PublishedAt = DateTime.UtcNow,
+            PublishedBy = TestUserId,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        });
+
+        await db.SaveChangesAsync();
+        return gameId;
+    }
+}

--- a/apps/web/e2e/mechanic-card-public.spec.ts
+++ b/apps/web/e2e/mechanic-card-public.spec.ts
@@ -1,0 +1,128 @@
+/**
+ * E2E — public, login-gated mechanic card (ME-M1.6, Issue #528).
+ *
+ * `/games/[id]/card` is an `(authenticated)` route gated by proxy.ts. Under
+ * PLAYWRIGHT_AUTH_BYPASS we must seed the session + role cookies
+ * (`seedMockRoleCookies`) so the proxy resolves the user instead of 307→/login,
+ * plus mock `/auth/me` + `/session/status` so AuthProvider doesn't hang on the
+ * "Verifica autorizzazioni…" spinner (real backend is unreachable in this run).
+ *
+ * The card endpoint `GET /api/v1/games/{gameId}/card` is mocked via
+ * `page.context().route(...)` (NOT `page.route` — project convention: the
+ * context route matches with/without the query string and before redirects).
+ *
+ * Two scenarios:
+ *   1. 200 → assert the section labels + a `[p.N]` citation badge render.
+ *   2. 404 → assert the not-found UI (Next's notFound() boundary).
+ */
+import { test, expect, type Route } from '@playwright/test';
+
+import { mockAuthEndpoints, seedMockRoleCookies } from './_helpers/seedAuthSession';
+import { seedCookieConsent } from './_helpers/seedCookieConsent';
+
+// Deterministic sharedGameId used as the route param.
+const GAME_ID = '00000000-0000-4000-8000-000000000528';
+
+const SAMPLE_CARD = {
+  cardId: '11111111-1111-4111-8111-111111111111',
+  sharedGameId: GAME_ID,
+  title: 'Catan — Mechanics',
+  version: 3,
+  publishedAt: '2026-05-01T00:00:00Z',
+  gameName: 'Catan',
+  publisher: 'Kosmos',
+  language: 'en',
+  sections: [
+    {
+      section: 'Summary',
+      claims: [
+        {
+          id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+          claim: 'Players collect resources to build settlements and cities.',
+          citations: [
+            {
+              pdfId: 'ffffffff-ffff-4fff-8fff-ffffffffffff',
+              pdfPage: 2,
+              quote: 'gather resources',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      section: 'Faq',
+      claims: [
+        {
+          id: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+          claim: 'You may only trade on your own turn.',
+          citations: [
+            {
+              pdfId: 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee',
+              pdfPage: 12,
+              quote: 'only on your own turn',
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+async function seedAuth(page: import('@playwright/test').Page): Promise<void> {
+  await seedMockRoleCookies(page, 'User');
+  await seedCookieConsent(page);
+  await mockAuthEndpoints(page);
+}
+
+test.describe('Public mechanic card — /games/[id]/card', () => {
+  test('renders sections + citation badge for a published card (200)', async ({ page }) => {
+    await seedAuth(page);
+
+    await page.context().route(/\/api\/v1\/games\/[^/]+\/card(\?.*)?$/, async (route: Route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(SAMPLE_CARD),
+      });
+    });
+
+    await page.goto(`/games/${GAME_ID}/card`, { waitUntil: 'domcontentloaded' });
+
+    // Card root + title
+    await expect(page.locator('[data-slot="mechanic-card"]')).toBeVisible();
+    await expect(page.getByTestId('mechanic-card-title')).toHaveText('Catan');
+
+    // Section labels present (Faq → FAQ)
+    await expect(page.getByRole('heading', { name: 'Summary' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'FAQ' })).toBeVisible();
+
+    // A claim from each section
+    await expect(
+      page.getByText('Players collect resources to build settlements and cities.')
+    ).toBeVisible();
+
+    // A [p.N] citation badge
+    await expect(
+      page.getByTestId('mechanic-card-citation-eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee-12')
+    ).toHaveText('p.12');
+  });
+
+  test('renders the not-found UI when the card is gone (404)', async ({ page }) => {
+    await seedAuth(page);
+
+    await page.context().route(/\/api\/v1\/games\/[^/]+\/card(\?.*)?$/, async (route: Route) => {
+      await route.fulfill({
+        status: 404,
+        contentType: 'application/json',
+        body: JSON.stringify({ error: 'NOT_FOUND' }),
+      });
+    });
+
+    await page.goto(`/games/${GAME_ID}/card`, { waitUntil: 'domcontentloaded' });
+
+    // The card content must NOT render; Next's notFound() boundary takes over.
+    await expect(page.getByTestId('mechanic-card-title')).toHaveCount(0);
+    // The default Next not-found surface shows a 404 signal.
+    await expect(page.getByText(/not found|404|non trovat/i).first()).toBeVisible();
+  });
+});

--- a/apps/web/src/app/(authenticated)/games/[id]/card/page.tsx
+++ b/apps/web/src/app/(authenticated)/games/[id]/card/page.tsx
@@ -1,0 +1,30 @@
+/**
+ * Public Mechanic Card Page — /games/[id]/card (ME-M1.6, Issue #528).
+ *
+ * Thin shell: normalizes `params.id` (the sharedGameId) to `string | null` at
+ * the page boundary and delegates all rendering to `MechanicCardView`.
+ *
+ * `[id]` IS the sharedGameId — matches the `(authenticated)/games/[id]` group
+ * and the backend `PublicCardUrl` (`/games/{sharedGameId}/card`). The route is
+ * login-gated by `proxy.ts` (`/games` is a PROTECTED_ROUTE); the view calls
+ * `notFound()` when the card endpoint returns 404 (no published card, or the
+ * card was suppressed/taken down).
+ *
+ * Normalization mirrors `(authenticated)/games/[id]/page.tsx`:
+ *   const gameId = typeof rawId === 'string' && rawId.length > 0 ? rawId : null;
+ * NEVER pass `String(rawId)` or `rawId ?? ''` (leads to the 'undefined' string).
+ */
+
+'use client';
+
+import { useParams } from 'next/navigation';
+
+import { MechanicCardView } from '@/components/features/mechanic-card';
+
+export default function MechanicCardPage() {
+  const params = useParams<{ id: string }>();
+  const rawId = params?.id;
+  const gameId = typeof rawId === 'string' && rawId.length > 0 ? rawId : null;
+
+  return <MechanicCardView gameId={gameId} />;
+}

--- a/apps/web/src/components/features/mechanic-card/MechanicCardView.tsx
+++ b/apps/web/src/components/features/mechanic-card/MechanicCardView.tsx
@@ -1,0 +1,346 @@
+'use client';
+
+/**
+ * MechanicCardView — public, login-gated mechanic card (ME-M1.6, Issue #528).
+ *
+ * Renders the published `PublishedMechanicCardDto` returned by
+ * `GET /api/v1/games/{sharedGameId}/card`:
+ *   - Header: game name + "AI-generated, human-reviewed" badge linking to the
+ *     game-comprehension explainer (#531, forward reference — landing not built yet).
+ *   - The present sections (Summary | Mechanics | Victory | Resources | Phases | FAQ),
+ *     already grouped + ordered by the backend, each with its reworded claims.
+ *   - Each claim: reworded text + inline `[p.N]` citation badges that open the
+ *     shared {@link PdfQuoteHighlighter} at the cited page/quote.
+ *   - Footer: the shared ADR-051 attribution ({@link MechanicAnalysisFooterAttribution}).
+ *
+ * Designed as a rulebook reference card a player can print at the table:
+ * mobile-first single column, `print:` utilities strip chrome, semantic tokens
+ * keep it legible on the default light (cream) theme AND on paper.
+ *
+ * On a 404 (no published card, or suppressed/taken down) the hook returns
+ * `data === null`; this component calls Next's `notFound()`.
+ *
+ * NOTE: guardrail validation badges (T1–T4) are admin-only telemetry and are
+ * deliberately NOT rendered here — they are not part of the public DTO.
+ */
+
+import { useState, type ReactElement } from 'react';
+
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+
+import { MechanicAnalysisFooterAttribution } from '@/components/admin/mechanic-extractor/MechanicAnalysisFooterAttribution';
+import { PdfQuoteHighlighter } from '@/components/pdf/PdfQuoteHighlighter';
+import { Badge } from '@/components/ui/data-display/badge';
+import { useMechanicCard } from '@/hooks/queries/useMechanicCard';
+import type {
+  PublishedMechanicCardDto,
+  PublishedMechanicCitationDto,
+  PublishedMechanicSectionDto,
+} from '@/lib/api/schemas/mechanic-card.schemas';
+import { MECHANIC_SECTION_LABELS, MechanicSection } from '@/lib/api/schemas/mechanic-card.schemas';
+
+const HOW_IT_WORKS_HREF = '/how-it-works/game-comprehension';
+
+/**
+ * Resolve a human label for a section. The parsed DTO carries the numeric enum
+ * value, but stay tolerant of the raw PascalCase name too (backend serializer
+ * emits `"Faq"` etc.) so the label is never a bare `Section 5`.
+ */
+function sectionLabel(section: PublishedMechanicSectionDto['section']): string {
+  if (typeof section === 'number') {
+    return MECHANIC_SECTION_LABELS[section] ?? `Section ${section}`;
+  }
+  const numeric = MechanicSection[section as keyof typeof MechanicSection];
+  if (numeric !== undefined) return MECHANIC_SECTION_LABELS[numeric] ?? String(section);
+  return String(section);
+}
+
+export interface MechanicCardViewProps {
+  /**
+   * SharedGame id from the route param, normalized at the page boundary.
+   * MUST be `string | null` — never `undefined` or the string `'undefined'`.
+   */
+  readonly gameId: string | null;
+}
+
+interface CitationTarget {
+  readonly documentId: string;
+  readonly page: number;
+  readonly quote: string;
+}
+
+// ─── Shells ──────────────────────────────────────────────────────────────────
+
+function CardShell({ children }: { children: React.ReactNode }): ReactElement {
+  return (
+    <main
+      data-slot="mechanic-card"
+      className="mx-auto w-full max-w-[900px] px-4 py-8 print:px-0 print:py-0 sm:px-6 sm:py-12"
+    >
+      {children}
+    </main>
+  );
+}
+
+function LoadingShell(): ReactElement {
+  return (
+    <CardShell>
+      <div
+        data-slot="mechanic-card-loading"
+        data-testid="mechanic-card-loading"
+        aria-busy="true"
+        className="flex flex-col gap-6"
+      >
+        <div className="h-10 w-2/3 animate-pulse rounded-lg bg-muted" />
+        <div className="h-6 w-40 animate-pulse rounded-full bg-muted" />
+        <div className="mt-4 h-32 w-full animate-pulse rounded-2xl bg-muted" />
+        <div className="h-32 w-full animate-pulse rounded-2xl bg-muted" />
+      </div>
+    </CardShell>
+  );
+}
+
+function ErrorShell({ onRetry }: { onRetry: () => void }): ReactElement {
+  return (
+    <CardShell>
+      <div
+        data-slot="mechanic-card-error"
+        className="flex min-h-[40vh] flex-col items-center justify-center gap-4 text-center"
+      >
+        <span aria-hidden="true" className="text-4xl">
+          ⚠️
+        </span>
+        <h1 className="font-display text-xl font-extrabold text-foreground">
+          Couldn&apos;t load this card
+        </h1>
+        <p className="max-w-sm text-sm text-muted-foreground">
+          Something went wrong while loading the card. Please try again.
+        </p>
+        <button
+          type="button"
+          onClick={onRetry}
+          data-slot="mechanic-card-error-retry"
+          data-testid="mechanic-card-error-retry"
+          className="rounded-md border border-border bg-transparent px-4 py-2 font-display text-sm font-bold text-foreground transition-colors hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          Retry
+        </button>
+      </div>
+    </CardShell>
+  );
+}
+
+// ─── Presentational pieces ───────────────────────────────────────────────────
+
+/**
+ * A single `[p.N]` citation. When it can open the source PDF it renders as a
+ * button that opens the shared viewer; otherwise (defensive, should not happen
+ * for a published card) it degrades to a static badge.
+ */
+function CitationBadge({
+  citation,
+  onOpen,
+}: {
+  citation: PublishedMechanicCitationDto;
+  onOpen: (target: CitationTarget) => void;
+}): ReactElement {
+  const label = `p.${citation.pdfPage}`;
+  return (
+    <button
+      type="button"
+      data-slot="mechanic-card-citation"
+      data-testid={`mechanic-card-citation-${citation.pdfId}-${citation.pdfPage}`}
+      onClick={() =>
+        onOpen({ documentId: citation.pdfId, page: citation.pdfPage, quote: citation.quote })
+      }
+      title={`“${citation.quote}”`}
+      aria-label={`Open source rulebook at page ${citation.pdfPage}`}
+      className="inline-flex items-center rounded-md border border-entity-game/40 bg-entity-game/10 px-1.5 py-0.5 align-middle text-[11px] font-semibold text-entity-game transition-colors hover:bg-entity-game/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring print:border-border print:bg-transparent print:text-foreground"
+    >
+      {label}
+    </button>
+  );
+}
+
+function ClaimItem({
+  claim,
+  onOpenCitation,
+}: {
+  claim: PublishedMechanicCardDto['sections'][number]['claims'][number];
+  onOpenCitation: (target: CitationTarget) => void;
+}): ReactElement {
+  return (
+    <li
+      data-slot="mechanic-card-claim"
+      data-testid={`mechanic-card-claim-${claim.id}`}
+      className="flex flex-col gap-1.5 border-t border-border/60 py-3 first:border-t-0 first:pt-0"
+    >
+      <p className="text-[15px] leading-relaxed text-foreground">{claim.claim}</p>
+      {claim.citations.length > 0 && (
+        <div className="flex flex-wrap items-center gap-1.5">
+          <span className="sr-only">Sources:</span>
+          {claim.citations.map(citation => (
+            <CitationBadge
+              key={`${citation.pdfId}-${citation.pdfPage}`}
+              citation={citation}
+              onOpen={onOpenCitation}
+            />
+          ))}
+        </div>
+      )}
+    </li>
+  );
+}
+
+function SectionBlock({
+  section,
+  index,
+  onOpenCitation,
+}: {
+  section: PublishedMechanicSectionDto;
+  index: number;
+  onOpenCitation: (target: CitationTarget) => void;
+}): ReactElement {
+  const label = sectionLabel(section.section);
+  return (
+    <section
+      data-slot="mechanic-card-section"
+      data-testid={`mechanic-card-section-${section.section}`}
+      className="break-inside-avoid rounded-2xl border border-border bg-card p-5 sm:p-6 print:rounded-none print:border-x-0 print:border-t-0 print:p-0 print:pt-4"
+      aria-labelledby={`mechanic-card-section-heading-${section.section}`}
+    >
+      <div className="mb-3 flex items-baseline gap-3 border-b border-border/60 pb-2">
+        {/* Sections ARE an ordered sequence (Summary→…→FAQ), so a rulebook-style
+            chapter numeral encodes real order rather than decorating. */}
+        <span
+          aria-hidden="true"
+          className="font-display text-sm font-bold tabular-nums text-entity-game"
+        >
+          {String(index + 1).padStart(2, '0')}
+        </span>
+        <h2
+          id={`mechanic-card-section-heading-${section.section}`}
+          className="font-display text-lg font-extrabold tracking-tight text-foreground"
+        >
+          {label}
+        </h2>
+      </div>
+      <ul className="flex flex-col">
+        {section.claims.map(claim => (
+          <ClaimItem key={claim.id} claim={claim} onOpenCitation={onOpenCitation} />
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+// ─── Main view ───────────────────────────────────────────────────────────────
+
+export function MechanicCardView({ gameId }: MechanicCardViewProps): ReactElement {
+  const { data, isLoading, isError, refetch } = useMechanicCard(gameId);
+  const [citationTarget, setCitationTarget] = useState<CitationTarget | null>(null);
+
+  if (isLoading) {
+    return <LoadingShell />;
+  }
+
+  if (isError) {
+    return <ErrorShell onRetry={() => void refetch()} />;
+  }
+
+  // `data === null` → backend 404 (no published card OR suppressed/taken down).
+  if (data == null) {
+    notFound();
+  }
+
+  const card = data;
+  const publishedDate = formatPublishedDate(card.publishedAt);
+
+  return (
+    <CardShell>
+      <article className="flex flex-col gap-6">
+        {/* Header */}
+        <header data-slot="mechanic-card-header" className="flex flex-col gap-3">
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge
+              variant="outline"
+              data-slot="mechanic-card-ai-badge"
+              className="border-entity-game/40 bg-entity-game/10 text-entity-game print:border-border print:bg-transparent print:text-foreground"
+            >
+              <Link
+                href={HOW_IT_WORKS_HREF}
+                className="focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                AI-generated, human-reviewed
+              </Link>
+            </Badge>
+            <span className="text-xs uppercase tracking-wide text-muted-foreground">
+              {card.language}
+            </span>
+          </div>
+
+          <h1
+            data-testid="mechanic-card-title"
+            className="font-display text-3xl font-extrabold leading-tight tracking-tight text-foreground sm:text-4xl"
+          >
+            {card.gameName}
+          </h1>
+
+          <p className="text-sm text-muted-foreground">
+            {card.title}
+            {card.publisher ? ` · ${card.publisher}` : ''}
+            {' · '}
+            <span className="whitespace-nowrap">v{card.version}</span>
+            {publishedDate ? ` · ${publishedDate}` : ''}
+          </p>
+        </header>
+
+        {/* Sections */}
+        {card.sections.length === 0 ? (
+          <p
+            data-slot="mechanic-card-empty"
+            className="rounded-2xl border border-border bg-muted p-6 text-center text-sm text-muted-foreground"
+          >
+            This card doesn&apos;t have any content yet.
+          </p>
+        ) : (
+          <div className="flex flex-col gap-4 print:gap-0">
+            {card.sections.map((section, index) => (
+              <SectionBlock
+                key={String(section.section)}
+                section={section}
+                index={index}
+                onOpenCitation={setCitationTarget}
+              />
+            ))}
+          </div>
+        )}
+
+        {/* Footer attribution (shared, ADR-051 — #529 will later swap the copy) */}
+        <footer data-slot="mechanic-card-footer">
+          <MechanicAnalysisFooterAttribution />
+        </footer>
+      </article>
+
+      {citationTarget && (
+        <PdfQuoteHighlighter
+          open={!!citationTarget}
+          onOpenChange={open => {
+            if (!open) setCitationTarget(null);
+          }}
+          documentId={citationTarget.documentId}
+          page={citationTarget.page}
+          quote={citationTarget.quote}
+        />
+      )}
+    </CardShell>
+  );
+}
+
+/** Format an ISO date as a short, locale-independent published date. */
+function formatPublishedDate(iso: string): string | null {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: 'numeric' });
+}

--- a/apps/web/src/components/features/mechanic-card/__tests__/MechanicCardView.test.tsx
+++ b/apps/web/src/components/features/mechanic-card/__tests__/MechanicCardView.test.tsx
@@ -1,0 +1,179 @@
+/** @vitest-environment jsdom */
+import { render, screen, fireEvent } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  MechanicSection,
+  type PublishedMechanicCardDto,
+} from '@/lib/api/schemas/mechanic-card.schemas';
+
+// ─── Mock the shared PDF citation viewer (mirrors ClaimsSection.citation.test) ──
+const mockHighlighter = vi.hoisted(() => vi.fn());
+vi.mock('@/components/pdf/PdfQuoteHighlighter', () => ({
+  PdfQuoteHighlighter: (props: Record<string, unknown>) => {
+    mockHighlighter(props);
+    return props.open ? <div data-testid="highlighter-open" /> : null;
+  },
+}));
+
+// ─── Mock the data hook ────────────────────────────────────────────────────────
+type MockCardReturn = {
+  data?: PublishedMechanicCardDto | null;
+  isLoading: boolean;
+  isError: boolean;
+  refetch: ReturnType<typeof vi.fn>;
+};
+const cardMockState: MockCardReturn = {
+  data: undefined,
+  isLoading: false,
+  isError: false,
+  refetch: vi.fn(),
+};
+vi.mock('@/hooks/queries/useMechanicCard', () => ({
+  useMechanicCard: () => cardMockState,
+}));
+
+// ─── notFound spy (called on data === null) ────────────────────────────────────
+const notFoundSpy = vi.hoisted(() => vi.fn());
+vi.mock('next/navigation', () => ({
+  notFound: () => {
+    notFoundSpy();
+    // Throw like the real notFound() so control flow stops.
+    throw new Error('NEXT_NOT_FOUND');
+  },
+}));
+
+import { MechanicCardView } from '../MechanicCardView';
+
+const SAMPLE_CARD: PublishedMechanicCardDto = {
+  cardId: '11111111-1111-4111-8111-111111111111',
+  sharedGameId: '22222222-2222-4222-8222-222222222222',
+  title: 'Catan — Mechanics',
+  version: 3,
+  publishedAt: '2026-05-01T00:00:00Z',
+  gameName: 'Catan',
+  publisher: 'Kosmos',
+  language: 'en',
+  sections: [
+    {
+      // Parsed DTO carries the numeric enum (zod preprocesses the "Summary" string).
+      section: MechanicSection.Summary,
+      claims: [
+        {
+          id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+          claim: 'Players collect resources to build settlements.',
+          citations: [
+            {
+              pdfId: 'ffffffff-ffff-4fff-8fff-ffffffffffff',
+              pdfPage: 2,
+              quote: 'gather resources',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      // Faq enum member must display as "FAQ".
+      section: MechanicSection.Faq,
+      claims: [
+        {
+          id: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+          claim: 'Can you trade on another player’s turn? No.',
+          citations: [
+            {
+              pdfId: 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee',
+              pdfPage: 12,
+              quote: 'only on your own turn',
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+describe('MechanicCardView', () => {
+  beforeEach(() => {
+    cardMockState.data = undefined;
+    cardMockState.isLoading = false;
+    cardMockState.isError = false;
+    cardMockState.refetch = vi.fn();
+    mockHighlighter.mockClear();
+    notFoundSpy.mockClear();
+  });
+
+  it('renders game name, section labels (Faq → FAQ) and claims', () => {
+    cardMockState.data = SAMPLE_CARD;
+    render(<MechanicCardView gameId={SAMPLE_CARD.sharedGameId} />);
+
+    expect(screen.getByTestId('mechanic-card-title')).toHaveTextContent('Catan');
+    // Summary section label
+    expect(screen.getByText('Summary')).toBeInTheDocument();
+    // Faq enum member displayed as "FAQ"
+    expect(screen.getByText('FAQ')).toBeInTheDocument();
+    // Claims text present
+    expect(screen.getByText('Players collect resources to build settlements.')).toBeInTheDocument();
+    expect(screen.getByText(/Can you trade on another player/)).toBeInTheDocument();
+    // Attribution footer present
+    expect(screen.getByText(/MeepleAI/)).toBeInTheDocument();
+    // "AI-generated, human-reviewed" badge links to the explainer
+    const badgeLink = screen.getByRole('link', { name: /AI-generated, human-reviewed/ });
+    expect(badgeLink).toHaveAttribute('href', '/how-it-works/game-comprehension');
+  });
+
+  it('renders a [p.N] citation badge per citation', () => {
+    cardMockState.data = SAMPLE_CARD;
+    render(<MechanicCardView gameId={SAMPLE_CARD.sharedGameId} />);
+
+    expect(
+      screen.getByTestId('mechanic-card-citation-ffffffff-ffff-4fff-8fff-ffffffffffff-2')
+    ).toHaveTextContent('p.2');
+    expect(
+      screen.getByTestId('mechanic-card-citation-eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee-12')
+    ).toHaveTextContent('p.12');
+  });
+
+  it('opens PdfQuoteHighlighter with documentId/page/quote when a citation is clicked', () => {
+    cardMockState.data = SAMPLE_CARD;
+    render(<MechanicCardView gameId={SAMPLE_CARD.sharedGameId} />);
+
+    // Before any click, the viewer is not open.
+    expect(mockHighlighter).not.toHaveBeenCalledWith(expect.objectContaining({ open: true }));
+
+    fireEvent.click(
+      screen.getByTestId('mechanic-card-citation-eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee-12')
+    );
+
+    expect(mockHighlighter).toHaveBeenCalledWith(
+      expect.objectContaining({
+        documentId: 'eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee',
+        page: 12,
+        quote: 'only on your own turn',
+        open: true,
+      })
+    );
+    expect(screen.getByTestId('highlighter-open')).toBeInTheDocument();
+  });
+
+  it('shows a loading shell while fetching', () => {
+    cardMockState.isLoading = true;
+    render(<MechanicCardView gameId={SAMPLE_CARD.sharedGameId} />);
+    expect(screen.getByTestId('mechanic-card-loading')).toBeInTheDocument();
+  });
+
+  it('shows an error shell with a retry action on error', () => {
+    cardMockState.isError = true;
+    render(<MechanicCardView gameId={SAMPLE_CARD.sharedGameId} />);
+    fireEvent.click(screen.getByTestId('mechanic-card-error-retry'));
+    expect(cardMockState.refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls notFound() when the card is null (404 / suppressed)', () => {
+    cardMockState.data = null;
+    // notFound() throws (mimicking Next) — the render throws too.
+    expect(() => render(<MechanicCardView gameId={SAMPLE_CARD.sharedGameId} />)).toThrow(
+      'NEXT_NOT_FOUND'
+    );
+    expect(notFoundSpy).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/features/mechanic-card/index.ts
+++ b/apps/web/src/components/features/mechanic-card/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Public mechanic card (ME-M1.6, Issue #528) component family barrel.
+ *
+ * Lets the `/games/[id]/card` route shell import from
+ * `@/components/features/mechanic-card` without deep paths.
+ */
+
+export { MechanicCardView } from '@/components/features/mechanic-card/MechanicCardView';
+export type { MechanicCardViewProps } from '@/components/features/mechanic-card/MechanicCardView';

--- a/apps/web/src/hooks/queries/useMechanicCard.ts
+++ b/apps/web/src/hooks/queries/useMechanicCard.ts
@@ -1,0 +1,45 @@
+/**
+ * useMechanicCard — React Query hook for the public, login-gated mechanic card
+ * (ME-M1.6, Issue #528).
+ *
+ * Wraps `api.sharedGames.getPublishedMechanicCard(gameId)`:
+ *   - `data === undefined` while loading / before enabled
+ *   - `data === null` → backend returned 404 (no published card OR suppressed/
+ *     taken down). The view translates this to Next's `notFound()`.
+ *   - `data` populated → the published card DTO
+ *   - `isError` → genuine failure (5xx / network / schema) — distinct from 404
+ *
+ * `gameId` is the sharedGameId (matches the `/games/{sharedGameId}/card` route).
+ */
+
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+
+import { api } from '@/lib/api';
+import type { PublishedMechanicCardDto } from '@/lib/api/schemas/mechanic-card.schemas';
+
+/** Query key factory for the public mechanic card. */
+export const mechanicCardKeys = {
+  all: ['mechanicCard'] as const,
+  detail: (gameId: string) => [...mechanicCardKeys.all, 'detail', gameId] as const,
+};
+
+/**
+ * Fetch the published mechanic card for a game.
+ *
+ * @param gameId SharedGame UUID (or null when the route param is not yet ready)
+ * @param options.enabled Extra gate on top of the internal `!!gameId` guard
+ */
+export function useMechanicCard(
+  gameId: string | null,
+  options: { enabled?: boolean } = {}
+): UseQueryResult<PublishedMechanicCardDto | null, Error> {
+  const { enabled = true } = options;
+  const safeId = gameId ?? '';
+  return useQuery({
+    queryKey: mechanicCardKeys.detail(safeId),
+    queryFn: () => api.sharedGames.getPublishedMechanicCard(safeId),
+    enabled: enabled && !!gameId,
+    // A published card changes only on republish; safe to cache for a while.
+    staleTime: 10 * 60 * 1000,
+  });
+}

--- a/apps/web/src/lib/api/clients/sharedGamesClient.ts
+++ b/apps/web/src/lib/api/clients/sharedGamesClient.ts
@@ -7,6 +7,7 @@
 
 import { z } from 'zod';
 
+import { isNotFoundError } from '../core/errors';
 import { type HttpClient, downloadFile, getApiBase } from '../core/httpClient';
 import {
   agentDefinitionDtoSchema,
@@ -14,6 +15,11 @@ import {
   type AgentDefinitionDto,
   type KbCardDto,
 } from '../schemas/agent-definitions.schemas';
+import {
+  MECHANIC_CARD_ROUTES,
+  PublishedMechanicCardDtoSchema,
+  type PublishedMechanicCardDto,
+} from '../schemas/mechanic-card.schemas';
 import { GameRagReadinessSchema, type GameRagReadiness } from '../schemas/rag-setup.schemas';
 import {
   SeedingGameListSchema,
@@ -1099,6 +1105,41 @@ export function createSharedGamesClient({ httpClient }: CreateSharedGamesClientP
         z.array(RulebookAnalysisDtoSchema)
       );
       return result ?? [];
+    },
+
+    // ========== Public Mechanic Card (ME-M1.6, Issue #528) ==========
+
+    /**
+     * Get the published, login-gated mechanic card for a game (AUTHENTICATED).
+     * GET /api/v1/games/{gameId}/card — `gameId` is the sharedGameId.
+     *
+     * Returns `null` when the backend responds 404 (no published card, or the
+     * card was suppressed/taken down) so the caller can render `notFound()`.
+     * All other failures (5xx / network / schema) propagate so the caller can
+     * distinguish "gone" from "broken".
+     *
+     * @param gameId - SharedGame UUID
+     * @returns The published card, or null when 404
+     */
+    async getPublishedMechanicCard(gameId: string): Promise<PublishedMechanicCardDto | null> {
+      if (
+        !gameId ||
+        !/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(gameId)
+      ) {
+        return null;
+      }
+      try {
+        return await httpClient.get(
+          MECHANIC_CARD_ROUTES.card(gameId),
+          PublishedMechanicCardDtoSchema
+        );
+      } catch (error) {
+        // 404 = no published card OR suppressed/taken down → caller calls notFound().
+        if (isNotFoundError(error)) {
+          return null;
+        }
+        throw error;
+      }
     },
 
     // ========== Admin PDF Upload (Issue #4922 + #4926) ==========

--- a/apps/web/src/lib/api/schemas/mechanic-card.schemas.ts
+++ b/apps/web/src/lib/api/schemas/mechanic-card.schemas.ts
@@ -1,0 +1,95 @@
+/**
+ * Public Mechanic Card schemas (ME-M1.6, Issue #528).
+ *
+ * Backend endpoint (locked contract, already implemented):
+ *   GET /api/v1/games/{gameId:guid}/card   → authenticated (any logged-in user)
+ *
+ * Responses:
+ *   200 → `PublishedMechanicCardDto` (this schema)
+ *   404 → no published card OR the card was suppressed/taken down (→ notFound())
+ *   401 → unauthenticated (proxy redirects to /login before this; handled defensively)
+ *
+ * Sections arrive already grouped and ordered by the backend; each claim is
+ * already ordered by its ordinal. The section discriminator reuses the same
+ * `Faq → "FAQ"` labelling as `mechanic-analyses.schemas.ts` via
+ * {@link MECHANIC_SECTION_LABELS} / {@link MechanicSectionSchema}.
+ */
+import { z } from 'zod';
+
+import { MechanicSectionSchema } from './mechanic-analyses.schemas';
+
+// Re-export for convenience so card consumers can import both from one module.
+export {
+  MECHANIC_SECTION_LABELS,
+  MechanicSection,
+  MechanicSectionSchema,
+} from './mechanic-analyses.schemas';
+export type { MechanicSectionValue } from './mechanic-analyses.schemas';
+
+// ========== Nested DTOs ==========
+
+/**
+ * A single verbatim quote from the source rulebook backing a claim.
+ * `pdfId` + `pdfPage` + `quote` are the exact props the shared
+ * `PdfQuoteHighlighter` needs (documentId / page / quote).
+ */
+export const PublishedMechanicCitationDtoSchema = z.object({
+  pdfId: z.string().uuid(),
+  pdfPage: z.number().int(),
+  quote: z.string(),
+});
+export type PublishedMechanicCitationDto = z.infer<typeof PublishedMechanicCitationDtoSchema>;
+
+/** A reworded claim plus the citations that ground it. */
+export const PublishedMechanicClaimDtoSchema = z.object({
+  id: z.string().uuid(),
+  claim: z.string(),
+  citations: z.array(PublishedMechanicCitationDtoSchema),
+});
+export type PublishedMechanicClaimDto = z.infer<typeof PublishedMechanicClaimDtoSchema>;
+
+/**
+ * One card section (Summary | Mechanics | Victory | Resources | Phases | Faq).
+ * `section` tolerates both the PascalCase string name (backend
+ * `JsonStringEnumConverter` output) and the numeric enum via
+ * {@link MechanicSectionSchema}. Label via {@link MECHANIC_SECTION_LABELS}
+ * (maps `Faq → "FAQ"`).
+ */
+export const PublishedMechanicSectionDtoSchema = z.object({
+  section: MechanicSectionSchema,
+  claims: z.array(PublishedMechanicClaimDtoSchema),
+});
+export type PublishedMechanicSectionDto = z.infer<typeof PublishedMechanicSectionDtoSchema>;
+
+// ========== Root DTO ==========
+
+export const PublishedMechanicCardDtoSchema = z.object({
+  cardId: z.string().uuid(),
+  sharedGameId: z.string().uuid(),
+  title: z.string(),
+  version: z.number().int(),
+  publishedAt: z.string(),
+  gameName: z.string(),
+  publisher: z.string().nullable(),
+  language: z.string(),
+  sections: z.array(PublishedMechanicSectionDtoSchema),
+});
+export type PublishedMechanicCardDto = z.infer<typeof PublishedMechanicCardDtoSchema>;
+
+// ========== Parser ==========
+
+/**
+ * Strict parser for the public card DTO. Throws on shape mismatch (mirrors the
+ * `httpClient` zod-validate path). Use in client methods / tests that receive a
+ * raw JSON object.
+ */
+export function parsePublishedMechanicCard(data: unknown): PublishedMechanicCardDto {
+  return PublishedMechanicCardDtoSchema.parse(data);
+}
+
+// ========== Routes ==========
+
+export const MECHANIC_CARD_ROUTES = {
+  /** Public, login-gated card endpoint (`gameId` is the sharedGameId). */
+  card: (gameId: string) => `/api/v1/games/${gameId}/card`,
+} as const;


### PR DESCRIPTION
## Summary

**ME-M1.6** — the public, login-gated mechanic card page `/games/[id]/card`. This is the **first reader** of the published `mechanic_cards.content` snapshot (write-only since #527), and the **root of the M1→M3 critical path** (unblocks #529/#530/#531/#533→#534→#535).

## Backend

- New **authenticated (non-admin)** read `GET /api/v1/games/{gameId:guid}/card` (`.RequireAuthorization()`, mirrors the sibling `GetSharedGameDocumentsForUser`).
- `GetPublishedMechanicCardByGameQuery` → handler → `IMechanicCardRepository.GetActiveByGameAsync` (**honors the `!IsSuppressed` query filter, so a takedown 404s automatically**; the per-game active-unique index makes the lookup unambiguous) → deserializes the immutable `MechanicCardContent` snapshot and **groups the flat claim list into the 6 sections in enum order** (Summary..Faq), each claim ordered by ordinal.
- `PublishedMechanicCardDto` — public projection; intentionally **omits admin-only guardrail validation telemetry**. Citations expose `pdfId`/`pdfPage`/`quote`.
- Returns **404** when there is no active card.

## Frontend

- Route `(authenticated)/games/[id]/card/page.tsx` — thin shell (`[id]` = sharedGameId, matches the emitted `PublicCardUrl` + existing `/games/[id]` routes; login-gated by the `/games` proxy gate).
- `MechanicCardView` (`components/features/mechanic-card/`) — header (game name + "AI-generated, human-reviewed" badge → `/how-it-works/game-comprehension`, #531 forward ref), the present sections with rulebook chapter numerals, each claim's reworded text + inline `[p.N]` citation badges wired to the **shared `PdfQuoteHighlighter`** viewer, and the **shared `MechanicAnalysisFooterAttribution`** footer. Mobile-first, `print:`-friendly, semantic tokens only. `data === null` (404 / suppressed) → `notFound()`.
- Public read client `getPublishedMechanicCard` (404 → null) + `useMechanicCard` hook + zod schema.

## Slug decision
`SharedGameEntity` has no slug column. `[id]` **is** the sharedGameId — consistent with every existing `/games/[id]/*` route, the `/api/v1/shared-games/{id:guid}` contract, and the publish handler's emitted `PublicCardUrl`. **No migration / backfill.** (A human-readable slug is a larger, separate change if product wants it.)

## Verification
- **BE**: handler unit test (section grouping in enum order + ordinal-within-section + suppressed/absent → null) **2/2**; endpoint integration test (Testcontainers) — 200 with real JSONB round-trip, **404 suppressed** (takedown), 404 no-card, 401 no-session — **4/4**.
- **FE**: `pnpm typecheck` clean · `eslint` clean · Vitest `MechanicCardView` **6/6** (labels incl. `Faq→FAQ`, citation-click opens the viewer with the right props, loading/error/notFound). Playwright E2E spec (200 sections + citation, 404 not-found) added; compiles/typechecks (not run — needs a dev server).
- FE implemented by a subagent against the locked DTO contract; reviewed here (PdfQuoteHighlighter props verified, 404 handling verified).

## Scope notes
- The rich citation tooltip/side-panel + copy-as-quote is **#530** (depends on this); this ships the basic clickable citation → viewer.
- The badge's `/how-it-works/game-comprehension` target is **#531** (not built yet — intended forward link).

Closes #528

🤖 Generated with [Claude Code](https://claude.com/claude-code)
