### PR TITLE
feat(mechanic-extractor): #529 takedown page + policy + card link

### DIFF
--- a/apps/web/src/app/(public)/legal/takedown/__tests__/page.test.tsx
+++ b/apps/web/src/app/(public)/legal/takedown/__tests__/page.test.tsx
@@ -1,0 +1,45 @@
+/** @vitest-environment jsdom */
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import TakedownPage, { metadata } from '../page';
+
+// The page renders LegalPageLayout, which is a client component that supplies
+// its own LegalLocaleProvider (+ IntlProvider) — no extra wrapper needed here.
+describe('TakedownPage', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('exposes SEO metadata (title + canonical)', () => {
+    expect(metadata.title).toMatch(/takedown/i);
+    expect(metadata.alternates?.canonical).toBe('https://meepleai.com/legal/takedown');
+  });
+
+  it('renders the takedown heading and policy section titles (default IT locale)', () => {
+    render(<TakedownPage />);
+
+    // Page heading uses the pageKey testid from LegalPageLayout.
+    expect(screen.getByTestId('takedown-heading')).toBeInTheDocument();
+
+    // Default locale is IT — the first section title comes from legal.takedown.sections.overview.
+    // Accordion header + table-of-contents link both render the title, so use getAllByText.
+    expect(screen.getAllByText(/Panoramica/i).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Contatti/i).length).toBeGreaterThan(0);
+  });
+
+  it('mounts the takedown request form in the footer slot', () => {
+    const { container } = render(<TakedownPage />);
+    expect(container.querySelector('[data-slot="takedown-request-form"]')).not.toBeNull();
+    // Direct mailto link is always present.
+    const mailLink = screen.getByRole('link', { name: 'takedown@meepleai.app' });
+    expect(mailLink).toHaveAttribute('href', 'mailto:takedown@meepleai.app');
+  });
+
+  it('links back to the terms page', () => {
+    render(<TakedownPage />);
+    // prevLink → /terms
+    const termsLink = screen.getAllByRole('link').find(a => a.getAttribute('href') === '/terms');
+    expect(termsLink).toBeTruthy();
+  });
+});

--- a/apps/web/src/app/(public)/legal/takedown/page.tsx
+++ b/apps/web/src/app/(public)/legal/takedown/page.tsx
@@ -1,0 +1,58 @@
+/**
+ * Takedown Request Page — /legal/takedown (ME-M1.7, Issue #529).
+ *
+ * Public (NOT login-gated) policy page describing how to file a copyright
+ * takedown request for a published mechanic card, plus a functional template
+ * form that composes a pre-filled email to `takedown@meepleai.app` (ADR-051 §
+ * "Follow-up obbligatori"). No backend intake endpoint exists — the form is a
+ * client-side mailto/copy template, mounted in LegalPageLayout's `footerSlot`.
+ *
+ * Mirrors the established legal-page pattern (see `terms/page.tsx`): shared
+ * `LegalPageLayout`, i18n-driven `legal.takedown.*` content, IT/EN toggle, and
+ * JSON-LD structured data.
+ */
+
+import { LegalPageLayout, TakedownRequestForm } from '@/components/legal';
+
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Takedown Request | MeepleAI',
+  description:
+    'Report content on MeepleAI that you believe infringes your copyright. Includes a template request form and our response commitments.',
+  openGraph: {
+    title: 'Takedown Request | MeepleAI',
+    description:
+      'Report content on MeepleAI that you believe infringes your copyright, and learn how we handle takedown requests.',
+    url: 'https://meepleai.com/legal/takedown',
+    type: 'website',
+  },
+  alternates: {
+    canonical: 'https://meepleai.com/legal/takedown',
+  },
+};
+
+const TAKEDOWN_SECTIONS = [
+  'overview',
+  'whoCanFile',
+  'whatToInclude',
+  'howWeRespond',
+  'contact',
+] as const;
+
+export default function TakedownPage() {
+  return (
+    <LegalPageLayout
+      pageKey="takedown"
+      sections={TAKEDOWN_SECTIONS}
+      defaultOpenSection="overview"
+      lastUpdated={new Date('2026-07-11')}
+      prevLink={{
+        href: '/terms',
+        labelIt: 'Termini e Condizioni',
+        labelEn: 'Terms and Conditions',
+      }}
+      footerSlot={<TakedownRequestForm />}
+    />
+  );
+}

--- a/apps/web/src/components/features/mechanic-card/MechanicCardView.tsx
+++ b/apps/web/src/components/features/mechanic-card/MechanicCardView.tsx
@@ -41,6 +41,7 @@ import type {
 import { MECHANIC_SECTION_LABELS, MechanicSection } from '@/lib/api/schemas/mechanic-card.schemas';
 
 const HOW_IT_WORKS_HREF = '/how-it-works/game-comprehension';
+const TAKEDOWN_HREF = '/legal/takedown';
 
 /**
  * Resolve a human label for a section. The parsed DTO carries the numeric enum
@@ -317,9 +318,21 @@ export function MechanicCardView({ gameId }: MechanicCardViewProps): ReactElemen
           </div>
         )}
 
-        {/* Footer attribution (shared, ADR-051 — #529 will later swap the copy) */}
+        {/* Footer attribution (shared, ADR-051) + public takedown link (#529).
+            The takedown link is card-only — the shared attribution component is
+            reused on the admin review page, which must NOT show it. */}
         <footer data-slot="mechanic-card-footer">
           <MechanicAnalysisFooterAttribution />
+          <p className="mt-2 text-center text-xs text-muted-foreground print:hidden">
+            <Link
+              href={TAKEDOWN_HREF}
+              data-slot="mechanic-card-takedown-link"
+              data-testid="mechanic-card-takedown-link"
+              className="underline hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              Report a copyright concern
+            </Link>
+          </p>
         </footer>
       </article>
 

--- a/apps/web/src/components/features/mechanic-card/__tests__/MechanicCardView.test.tsx
+++ b/apps/web/src/components/features/mechanic-card/__tests__/MechanicCardView.test.tsx
@@ -121,6 +121,15 @@ describe('MechanicCardView', () => {
     expect(badgeLink).toHaveAttribute('href', '/how-it-works/game-comprehension');
   });
 
+  it('renders a public takedown link in the card footer (#529)', () => {
+    cardMockState.data = SAMPLE_CARD;
+    render(<MechanicCardView gameId={SAMPLE_CARD.sharedGameId} />);
+
+    const takedownLink = screen.getByTestId('mechanic-card-takedown-link');
+    expect(takedownLink).toHaveAttribute('href', '/legal/takedown');
+    expect(takedownLink).toHaveTextContent(/copyright/i);
+  });
+
   it('renders a [p.N] citation badge per citation', () => {
     cardMockState.data = SAMPLE_CARD;
     render(<MechanicCardView gameId={SAMPLE_CARD.sharedGameId} />);

--- a/apps/web/src/components/legal/LegalPageLayout.tsx
+++ b/apps/web/src/components/legal/LegalPageLayout.tsx
@@ -33,7 +33,7 @@ import { LegalLocaleProvider, LegalLocaleToggle } from './LegalLocaleToggle';
 import { LegalMarkdown } from './LegalMarkdown';
 import { StructuredData, legalPageSchema, breadcrumbSchema } from './StructuredData';
 
-type LegalPageKey = 'privacy' | 'terms' | 'cookies';
+type LegalPageKey = 'privacy' | 'terms' | 'cookies' | 'takedown';
 
 interface FooterNavLink {
   href: string;
@@ -66,6 +66,7 @@ const PAGE_PATHS: Record<LegalPageKey, string> = {
   privacy: '/privacy',
   terms: '/terms',
   cookies: '/cookies',
+  takedown: '/legal/takedown',
 };
 
 function LegalPageContent({

--- a/apps/web/src/components/legal/TakedownRequestForm.tsx
+++ b/apps/web/src/components/legal/TakedownRequestForm.tsx
@@ -1,0 +1,357 @@
+/**
+ * TakedownRequestForm — public "template takedown request" form (ADR-051, Issue #529).
+ *
+ * There is NO backend endpoint for takedown requests and no email-alias intake
+ * pipeline. This form is a functional TEMPLATE: it validates the required fields
+ * client-side, then either opens a `mailto:takedown@meepleai.app` link with a
+ * structured, pre-filled subject + body, or copies that same request text to the
+ * clipboard. No data leaves the browser.
+ *
+ * Rendered inside {@link LegalPageLayout}'s `footerSlot`, so it lives within the
+ * `LegalLocaleProvider` and can use both `useLegalLocale()` (IT/EN toggle) and
+ * `useTranslation()` (`t()`).
+ */
+
+'use client';
+
+import { useId, useMemo, useState, type FormEvent } from 'react';
+
+import { useLegalLocale } from '@/components/legal/LegalLocaleToggle';
+import { Button } from '@/components/ui/primitives/button';
+import { Checkbox } from '@/components/ui/primitives/checkbox';
+import { Input } from '@/components/ui/primitives/input';
+import { Label } from '@/components/ui/primitives/label';
+import { Textarea } from '@/components/ui/primitives/textarea';
+import { useTranslation } from '@/hooks/useTranslation';
+
+export const TAKEDOWN_EMAIL = 'takedown@meepleai.app';
+
+interface TakedownFields {
+  name: string;
+  email: string;
+  work: string;
+  cardUrl: string;
+  description: string;
+  confirmed: boolean;
+}
+
+type FieldKey = keyof Omit<TakedownFields, 'confirmed'>;
+
+const EMPTY_FIELDS: TakedownFields = {
+  name: '',
+  email: '',
+  work: '',
+  cardUrl: '',
+  description: '',
+  confirmed: false,
+};
+
+// Simple, permissive email shape check — the browser + backend do the real work.
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+interface ValidationErrors {
+  name?: string;
+  email?: string;
+  work?: string;
+  cardUrl?: string;
+  description?: string;
+  confirmed?: string;
+}
+
+/**
+ * Build the structured request body text from the form fields. Shared by both
+ * the mailto link and the "copy to clipboard" action so they stay identical.
+ */
+export function buildTakedownBody(
+  fields: TakedownFields,
+  labels: {
+    name: string;
+    email: string;
+    work: string;
+    cardUrl: string;
+    description: string;
+    confirm: string;
+  }
+): string {
+  return [
+    `${labels.name}: ${fields.name}`,
+    `${labels.email}: ${fields.email}`,
+    `${labels.work}: ${fields.work}`,
+    `${labels.cardUrl}: ${fields.cardUrl}`,
+    '',
+    `${labels.description}:`,
+    fields.description,
+    '',
+    labels.confirm,
+  ].join('\n');
+}
+
+export function TakedownRequestForm() {
+  const { t } = useTranslation();
+  const { locale } = useLegalLocale();
+  const baseId = useId();
+
+  const [fields, setFields] = useState<TakedownFields>(EMPTY_FIELDS);
+  const [errors, setErrors] = useState<ValidationErrors>({});
+  const [submitted, setSubmitted] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  // Field label strings, resolved once per render (also embedded in the email body).
+  const labels = useMemo(
+    () => ({
+      name: t('legal.takedown.form.nameLabel'),
+      email: t('legal.takedown.form.emailLabel'),
+      work: t('legal.takedown.form.workLabel'),
+      cardUrl: t('legal.takedown.form.cardUrlLabel'),
+      description: t('legal.takedown.form.descriptionLabel'),
+      confirm: t('legal.takedown.form.confirmLabel'),
+    }),
+    [t]
+  );
+
+  function validate(current: TakedownFields): ValidationErrors {
+    const next: ValidationErrors = {};
+    const requiredMsg = t('legal.takedown.form.requiredError');
+
+    if (!current.name.trim()) next.name = requiredMsg;
+
+    if (!current.email.trim()) {
+      next.email = requiredMsg;
+    } else if (!EMAIL_RE.test(current.email.trim())) {
+      next.email = t('legal.takedown.form.emailInvalidError');
+    }
+
+    if (!current.work.trim()) next.work = requiredMsg;
+    if (!current.cardUrl.trim()) next.cardUrl = requiredMsg;
+    if (!current.description.trim()) next.description = requiredMsg;
+    if (!current.confirmed) next.confirmed = t('legal.takedown.form.confirmError');
+
+    return next;
+  }
+
+  function setField(key: keyof TakedownFields, value: string | boolean) {
+    setCopied(false);
+    setFields(prev => {
+      const next = { ...prev, [key]: value };
+      // Re-validate incrementally only after the first submit attempt so we
+      // don't shout at the user before they've tried anything.
+      if (submitted) setErrors(validate(next));
+      return next;
+    });
+  }
+
+  function buildRequest(): { subject: string; body: string } {
+    const subject = t('legal.takedown.form.mailSubject', {
+      work: fields.work.trim() || '—',
+    });
+    const body = buildTakedownBody(fields, labels);
+    return { subject, body };
+  }
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setSubmitted(true);
+    const nextErrors = validate(fields);
+    setErrors(nextErrors);
+    if (Object.keys(nextErrors).length > 0) return;
+
+    const { subject, body } = buildRequest();
+    const mailto = `mailto:${TAKEDOWN_EMAIL}?subject=${encodeURIComponent(
+      subject
+    )}&body=${encodeURIComponent(body)}`;
+    // Trigger the user's mail client.
+    window.location.href = mailto;
+  }
+
+  async function handleCopy() {
+    setSubmitted(true);
+    const nextErrors = validate(fields);
+    setErrors(nextErrors);
+    if (Object.keys(nextErrors).length > 0) return;
+
+    const { subject, body } = buildRequest();
+    const text = `${subject}\n\n${body}`;
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+    } catch {
+      // Clipboard unavailable (e.g. insecure context) — silently no-op; the
+      // mailto path still works. We deliberately avoid a disruptive alert.
+      setCopied(false);
+    }
+  }
+
+  const hasErrors = submitted && Object.keys(errors).length > 0;
+
+  const textInputFields: Array<{
+    key: FieldKey;
+    type: 'text' | 'email' | 'url';
+    autoComplete?: string;
+  }> = [
+    { key: 'name', type: 'text', autoComplete: 'name' },
+    { key: 'email', type: 'email', autoComplete: 'email' },
+    { key: 'work', type: 'text' },
+    { key: 'cardUrl', type: 'url' },
+  ];
+
+  const labelFor: Record<FieldKey, string> = {
+    name: t('legal.takedown.form.nameLabel'),
+    email: t('legal.takedown.form.emailLabel'),
+    work: t('legal.takedown.form.workLabel'),
+    cardUrl: t('legal.takedown.form.cardUrlLabel'),
+    description: t('legal.takedown.form.descriptionLabel'),
+  };
+  const placeholderFor: Record<FieldKey, string> = {
+    name: t('legal.takedown.form.namePlaceholder'),
+    email: t('legal.takedown.form.emailPlaceholder'),
+    work: t('legal.takedown.form.workPlaceholder'),
+    cardUrl: t('legal.takedown.form.cardUrlPlaceholder'),
+    description: t('legal.takedown.form.descriptionPlaceholder'),
+  };
+
+  return (
+    <form
+      noValidate
+      onSubmit={handleSubmit}
+      data-slot="takedown-request-form"
+      aria-label={t('legal.takedown.form.heading')}
+      className="mx-auto mt-6 w-full max-w-2xl rounded-2xl border border-border bg-card p-6 text-left"
+    >
+      <h2 className="text-lg font-semibold text-foreground">{t('legal.takedown.form.heading')}</h2>
+      <p className="mt-1 text-sm text-muted-foreground">{t('legal.takedown.form.intro')}</p>
+
+      {hasErrors && (
+        <p
+          role="alert"
+          data-testid="takedown-error-summary"
+          className="mt-4 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+        >
+          {t('legal.takedown.form.errorSummary')}
+        </p>
+      )}
+
+      <div className="mt-4 flex flex-col gap-4">
+        {textInputFields.map(({ key, type, autoComplete }) => {
+          const fieldId = `${baseId}-${key}`;
+          const errorId = `${fieldId}-error`;
+          const error = errors[key];
+          return (
+            <div key={key} className="flex flex-col gap-1.5">
+              <Label htmlFor={fieldId}>
+                {labelFor[key]}
+                <span aria-hidden="true" className="ml-0.5 text-destructive">
+                  *
+                </span>
+              </Label>
+              <Input
+                id={fieldId}
+                type={type}
+                value={fields[key]}
+                onChange={e => setField(key, e.target.value)}
+                placeholder={placeholderFor[key]}
+                autoComplete={autoComplete}
+                required
+                aria-required="true"
+                aria-invalid={error ? 'true' : undefined}
+                aria-describedby={error ? errorId : undefined}
+              />
+              {error && (
+                <p id={errorId} role="alert" className="text-sm text-destructive">
+                  {error}
+                </p>
+              )}
+            </div>
+          );
+        })}
+
+        {/* Description (textarea) */}
+        {(() => {
+          const fieldId = `${baseId}-description`;
+          const errorId = `${fieldId}-error`;
+          const error = errors.description;
+          return (
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor={fieldId}>
+                {labelFor.description}
+                <span aria-hidden="true" className="ml-0.5 text-destructive">
+                  *
+                </span>
+              </Label>
+              <Textarea
+                id={fieldId}
+                rows={4}
+                value={fields.description}
+                onChange={e => setField('description', e.target.value)}
+                placeholder={placeholderFor.description}
+                required
+                aria-required="true"
+                aria-invalid={error ? 'true' : undefined}
+                aria-describedby={error ? errorId : undefined}
+              />
+              {error && (
+                <p id={errorId} role="alert" className="text-sm text-destructive">
+                  {error}
+                </p>
+              )}
+            </div>
+          );
+        })()}
+
+        {/* Good-faith + accuracy confirmation */}
+        {(() => {
+          const fieldId = `${baseId}-confirm`;
+          const errorId = `${fieldId}-error`;
+          const error = errors.confirmed;
+          return (
+            <div className="flex flex-col gap-1.5">
+              <div className="flex items-start gap-2">
+                <Checkbox
+                  id={fieldId}
+                  checked={fields.confirmed}
+                  onCheckedChange={checked => setField('confirmed', checked === true)}
+                  aria-required="true"
+                  aria-invalid={error ? 'true' : undefined}
+                  aria-describedby={error ? errorId : undefined}
+                  className="mt-0.5"
+                />
+                <Label htmlFor={fieldId} className="text-sm font-normal text-muted-foreground">
+                  {t('legal.takedown.form.confirmLabel')}
+                </Label>
+              </div>
+              {error && (
+                <p id={errorId} role="alert" className="text-sm text-destructive">
+                  {error}
+                </p>
+              )}
+            </div>
+          );
+        })()}
+      </div>
+
+      <div className="mt-6 flex flex-col gap-3 sm:flex-row">
+        <Button type="submit" data-testid="takedown-submit">
+          {t('legal.takedown.form.submit')}
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          onClick={handleCopy}
+          data-testid="takedown-copy"
+          aria-live="polite"
+        >
+          {copied ? t('legal.takedown.form.copied') : t('legal.takedown.form.copy')}
+        </Button>
+      </div>
+
+      <p className="mt-4 text-xs text-muted-foreground">
+        {locale === 'it' ? 'Invia a: ' : 'Send to: '}
+        <a
+          href={`mailto:${TAKEDOWN_EMAIL}`}
+          className="underline hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          {TAKEDOWN_EMAIL}
+        </a>
+      </p>
+    </form>
+  );
+}

--- a/apps/web/src/components/legal/__tests__/TakedownRequestForm.test.tsx
+++ b/apps/web/src/components/legal/__tests__/TakedownRequestForm.test.tsx
@@ -1,0 +1,222 @@
+/** @vitest-environment jsdom */
+import { render, screen, fireEvent, waitFor, type RenderResult } from '@testing-library/react';
+import type { ReactElement } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { LegalLocaleProvider } from '@/components/legal/LegalLocaleToggle';
+
+import { TakedownRequestForm, TAKEDOWN_EMAIL, buildTakedownBody } from '../TakedownRequestForm';
+
+// The form is mounted inside LegalLocaleProvider in production (LegalPageLayout
+// footerSlot), which supplies both the IT/EN locale context and the IntlProvider.
+function renderForm(ui: ReactElement): RenderResult {
+  return render(<LegalLocaleProvider>{ui}</LegalLocaleProvider>);
+}
+
+function fillTextField(label: RegExp, value: string) {
+  fireEvent.change(screen.getByLabelText(label), { target: { value } });
+}
+
+const VALID = {
+  name: 'Jane Doe',
+  email: 'jane@example.com',
+  work: 'Catan Rulebook',
+  cardUrl: 'https://meepleai.com/games/abc/card',
+  description: 'Reproduces protected text verbatim.',
+};
+
+/** Fill every required field + confirm checkbox with valid values. */
+function fillAllValid() {
+  fillTextField(/full name/i, VALID.name);
+  fillTextField(/email/i, VALID.email);
+  fillTextField(/copyrighted work/i, VALID.work);
+  fillTextField(/url of the card/i, VALID.cardUrl);
+  fillTextField(/description of the problem/i, VALID.description);
+  fireEvent.click(screen.getByRole('checkbox'));
+}
+
+describe('TakedownRequestForm', () => {
+  const originalLocation = window.location;
+  const originalClipboard = navigator.clipboard;
+
+  beforeEach(() => {
+    // Force EN so the label regexes above match (default locale is IT).
+    window.localStorage.setItem('meepleai-legal-locale', 'en');
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    window.localStorage.clear();
+    // Restore the objects we replaced per-test.
+    Object.defineProperty(window, 'location', {
+      value: originalLocation,
+      configurable: true,
+      writable: true,
+    });
+    Object.defineProperty(navigator, 'clipboard', {
+      value: originalClipboard,
+      configurable: true,
+    });
+  });
+
+  /** Replace window.location so `location.href = mailto` is observable, not a real nav. */
+  function stubLocation(): { current: string } {
+    const ref = { current: '' };
+    delete (window as unknown as { location?: unknown }).location;
+    (window as unknown as { location: { href: string } }).location = {
+      get href() {
+        return ref.current;
+      },
+      set href(v: string) {
+        ref.current = v;
+      },
+    };
+    return ref;
+  }
+
+  it('renders all required fields and both action buttons', async () => {
+    renderForm(<TakedownRequestForm />);
+    // Wait for the locale to sync to EN (useEffect on mount).
+    await screen.findByRole('button', { name: /open pre-filled email/i });
+
+    expect(screen.getByLabelText(/full name/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/copyrighted work/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/url of the card/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/description of the problem/i)).toBeInTheDocument();
+    expect(screen.getByRole('checkbox')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /open pre-filled email/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /copy request to clipboard/i })).toBeInTheDocument();
+  });
+
+  it('blocks submit and shows errors when required fields are empty', async () => {
+    renderForm(<TakedownRequestForm />);
+    await screen.findByRole('button', { name: /open pre-filled email/i });
+
+    const loc = stubLocation();
+    fireEvent.click(screen.getByTestId('takedown-submit'));
+
+    // Error summary announced
+    expect(await screen.findByTestId('takedown-error-summary')).toBeInTheDocument();
+    // One inline error per required text field + confirmation → multiple alerts
+    const alerts = screen.getAllByRole('alert');
+    expect(alerts.length).toBeGreaterThan(1);
+    // Never navigated to a mailto because validation failed
+    expect(loc.current).toBe('');
+  });
+
+  it('marks invalid email with an aria-invalid state and a specific error', async () => {
+    renderForm(<TakedownRequestForm />);
+    await screen.findByRole('button', { name: /open pre-filled email/i });
+
+    fillTextField(/full name/i, VALID.name);
+    fillTextField(/email/i, 'not-an-email');
+    fillTextField(/copyrighted work/i, VALID.work);
+    fillTextField(/url of the card/i, VALID.cardUrl);
+    fillTextField(/description of the problem/i, VALID.description);
+    fireEvent.click(screen.getByRole('checkbox'));
+
+    stubLocation();
+    fireEvent.click(screen.getByTestId('takedown-submit'));
+
+    const emailInput = screen.getByLabelText(/email/i);
+    await waitFor(() => expect(emailInput).toHaveAttribute('aria-invalid', 'true'));
+    expect(screen.getByText(/valid email address/i)).toBeInTheDocument();
+  });
+
+  it('opens a pre-filled mailto with the field values when valid', async () => {
+    renderForm(<TakedownRequestForm />);
+    await screen.findByRole('button', { name: /open pre-filled email/i });
+
+    const loc = stubLocation();
+    fillAllValid();
+    fireEvent.click(screen.getByTestId('takedown-submit'));
+
+    expect(loc.current).toContain(`mailto:${TAKEDOWN_EMAIL}`);
+    const decoded = decodeURIComponent(loc.current);
+    // Subject carries the work title
+    expect(decoded).toContain('Takedown request — Catan Rulebook');
+    // Body carries the reporter details
+    expect(decoded).toContain(VALID.name);
+    expect(decoded).toContain(VALID.email);
+    expect(decoded).toContain(VALID.cardUrl);
+    expect(decoded).toContain(VALID.description);
+  });
+
+  it('copies the structured request to the clipboard when valid', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    });
+
+    renderForm(<TakedownRequestForm />);
+    await screen.findByRole('button', { name: /copy request to clipboard/i });
+
+    fillAllValid();
+    fireEvent.click(screen.getByTestId('takedown-copy'));
+
+    await waitFor(() => expect(writeText).toHaveBeenCalledTimes(1));
+    const copiedText = writeText.mock.calls[0][0] as string;
+    expect(copiedText).toContain('Takedown request — Catan Rulebook');
+    expect(copiedText).toContain(VALID.name);
+    expect(copiedText).toContain(VALID.cardUrl);
+    // Button flips to the "Copied!" confirmation state
+    expect(await screen.findByRole('button', { name: /copied/i })).toBeInTheDocument();
+  });
+
+  it('does not copy when validation fails', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    });
+
+    renderForm(<TakedownRequestForm />);
+    await screen.findByRole('button', { name: /copy request to clipboard/i });
+
+    fireEvent.click(screen.getByTestId('takedown-copy'));
+
+    expect(await screen.findByTestId('takedown-error-summary')).toBeInTheDocument();
+    expect(writeText).not.toHaveBeenCalled();
+  });
+
+  it('renders a direct mailto link to takedown@meepleai.app', async () => {
+    renderForm(<TakedownRequestForm />);
+    await screen.findByRole('button', { name: /open pre-filled email/i });
+
+    const mailLink = screen.getByRole('link', { name: TAKEDOWN_EMAIL });
+    expect(mailLink).toHaveAttribute('href', `mailto:${TAKEDOWN_EMAIL}`);
+  });
+});
+
+describe('buildTakedownBody', () => {
+  it('lays out all fields plus the good-faith statement in order', () => {
+    const body = buildTakedownBody(
+      {
+        name: 'Jane',
+        email: 'jane@example.com',
+        work: 'Catan',
+        cardUrl: 'https://x/card',
+        description: 'text copied',
+        confirmed: true,
+      },
+      {
+        name: 'Name',
+        email: 'Email',
+        work: 'Work',
+        cardUrl: 'Card URL',
+        description: 'Description',
+        confirm: 'I confirm.',
+      }
+    );
+
+    expect(body).toContain('Name: Jane');
+    expect(body).toContain('Email: jane@example.com');
+    expect(body).toContain('Work: Catan');
+    expect(body).toContain('Card URL: https://x/card');
+    expect(body).toContain('Description:');
+    expect(body).toContain('text copied');
+    expect(body.trimEnd().endsWith('I confirm.')).toBe(true);
+  });
+});

--- a/apps/web/src/components/legal/__tests__/i18n-legal-keys.test.ts
+++ b/apps/web/src/components/legal/__tests__/i18n-legal-keys.test.ts
@@ -60,6 +60,9 @@ const COOKIE_SECTIONS = [
   'policyUpdates',
 ];
 
+// #529 ME-M1.7 — takedown policy page sections
+const TAKEDOWN_SECTIONS = ['overview', 'whoCanFile', 'whatToInclude', 'howWeRespond', 'contact'];
+
 type LegalSections = Record<string, { title: string; content: string }>;
 
 describe('Legal i18n key validation', () => {
@@ -132,6 +135,69 @@ describe('Legal i18n key validation', () => {
     });
   });
 
+  describe('Takedown page sections', () => {
+    const itSections = (
+      itMessages as Record<string, unknown> & { legal: { takedown: { sections: LegalSections } } }
+    ).legal.takedown.sections;
+    const enSections = (
+      enMessages as Record<string, unknown> & { legal: { takedown: { sections: LegalSections } } }
+    ).legal.takedown.sections;
+
+    it.each(TAKEDOWN_SECTIONS)('IT: takedown section "%s" exists with title and content', key => {
+      const section = itSections[key];
+      expect(section).toBeDefined();
+      expect(section?.title).toBeTruthy();
+      expect(section?.content).toBeTruthy();
+    });
+
+    it.each(TAKEDOWN_SECTIONS)('EN: takedown section "%s" exists with title and content', key => {
+      const section = enSections[key];
+      expect(section).toBeDefined();
+      expect(section?.title).toBeTruthy();
+      expect(section?.content).toBeTruthy();
+    });
+  });
+
+  describe('Takedown form keys', () => {
+    const FORM_KEYS = [
+      'heading',
+      'intro',
+      'nameLabel',
+      'emailLabel',
+      'workLabel',
+      'cardUrlLabel',
+      'descriptionLabel',
+      'confirmLabel',
+      'submit',
+      'copy',
+      'copied',
+      'requiredError',
+      'emailInvalidError',
+      'confirmError',
+      'errorSummary',
+      'mailSubject',
+    ];
+
+    const itForm = (
+      itMessages as Record<string, unknown> & {
+        legal: { takedown: { form: Record<string, string> } };
+      }
+    ).legal.takedown.form;
+    const enForm = (
+      enMessages as Record<string, unknown> & {
+        legal: { takedown: { form: Record<string, string> } };
+      }
+    ).legal.takedown.form;
+
+    it.each(FORM_KEYS)('IT: takedown form key "%s" exists', key => {
+      expect(itForm[key]).toBeTruthy();
+    });
+
+    it.each(FORM_KEYS)('EN: takedown form key "%s" exists', key => {
+      expect(enForm[key]).toBeTruthy();
+    });
+  });
+
   describe('Common legal keys', () => {
     it('IT: has tableOfContents key', () => {
       expect(
@@ -163,7 +229,7 @@ describe('Legal i18n key validation', () => {
   });
 
   describe('Page metadata keys', () => {
-    const pages = ['privacy', 'terms', 'cookies'] as const;
+    const pages = ['privacy', 'terms', 'cookies', 'takedown'] as const;
 
     it.each(pages)('IT: "%s" has title and description', page => {
       const legal = (

--- a/apps/web/src/components/legal/index.ts
+++ b/apps/web/src/components/legal/index.ts
@@ -1,5 +1,6 @@
 export { LegalPageLayout } from './LegalPageLayout';
 export { LegalMarkdown } from './LegalMarkdown';
+export { TakedownRequestForm, TAKEDOWN_EMAIL, buildTakedownBody } from './TakedownRequestForm';
 export { LegalLocaleToggle, LegalLocaleProvider, useLegalLocale } from './LegalLocaleToggle';
 export { CookieConsentBanner, useCookieConsent } from './CookieConsentBanner';
 export type { CookieConsent } from './CookieConsentBanner';

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -803,6 +803,55 @@
         }
       }
     },
+    "takedown": {
+      "title": "Takedown Request",
+      "description": "How to report content you believe infringes your copyright, and how we handle the request.",
+      "sections": {
+        "overview": {
+          "title": "1. Overview",
+          "content": "MeepleAI respects copyright. Published mechanic cards are AI-generated analyses of game rulebooks: every claim is reworded in original language and cites the rulebook page. Copyright in the original manual text remains with the publishers.\n\nIf you believe a published card reproduces your protected material beyond what is permitted, you can request its removal or suppression through this page. Every request is reviewed by a person; this is not an automated process."
+        },
+        "whoCanFile": {
+          "title": "2. Who can file a request",
+          "content": "A takedown request may be filed by the copyright owner (for example the publisher or the author of the rulebook) or by a representative authorized to act on their behalf.\n\nSo we can verify and reach you, provide your full name, a valid email address, and — if acting on behalf of a third party — the party you represent."
+        },
+        "whatToInclude": {
+          "title": "3. What to include",
+          "content": "To let us handle the request quickly, please include:\n\n- The protected work involved (rulebook or manual title).\n- The exact URL of the card in question (the `/games/{id}/card` page).\n- A description of which content you believe is infringing and why.\n- A good-faith statement that the disputed use is not authorized by the copyright owner, its agent, or the law.\n- Confirmation that the information you provide is accurate.\n\nThe form below assembles these elements into a pre-filled email automatically."
+        },
+        "howWeRespond": {
+          "title": "4. How we respond",
+          "content": "We acknowledge receipt of your request within **3 business days**. We assess the report and, where upheld, suppress or remove the affected card within **10 business days** of receipt.\n\nA suppressed card is no longer publicly accessible. We will update you by email on the outcome, and may ask for additional information if needed to complete the review."
+        },
+        "contact": {
+          "title": "5. Contact",
+          "content": "Takedown requests should be sent to: **takedown@meepleai.app**\n\nYou can use the form at the bottom of this page to compose a pre-filled email, or write directly to that address including the information listed above."
+        }
+      },
+      "form": {
+        "heading": "Takedown request form",
+        "intro": "Fill in the fields to generate a pre-filled email to takedown@meepleai.app. No data is sent to our servers from this page.",
+        "nameLabel": "Full name",
+        "namePlaceholder": "Jane Doe",
+        "emailLabel": "Email",
+        "emailPlaceholder": "you@example.com",
+        "workLabel": "Copyrighted work / rulebook title",
+        "workPlaceholder": "e.g. Catan — Base game rulebook",
+        "cardUrlLabel": "URL of the card in question",
+        "cardUrlPlaceholder": "https://meepleai.com/games/.../card",
+        "descriptionLabel": "Description of the problem",
+        "descriptionPlaceholder": "Describe which content you believe infringes your copyright and why.",
+        "confirmLabel": "I state in good faith that the disputed use is not authorized and that the information I have provided is accurate.",
+        "submit": "Open pre-filled email",
+        "copy": "Copy request to clipboard",
+        "copied": "Copied!",
+        "requiredError": "This field is required.",
+        "emailInvalidError": "Enter a valid email address.",
+        "confirmError": "You must confirm the statement to proceed.",
+        "errorSummary": "Please fix the highlighted fields before proceeding.",
+        "mailSubject": "Takedown request — {work}"
+      }
+    },
     "privacy": {
       "title": "Privacy Policy",
       "description": "How we collect, use, and protect your personal data",

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -902,6 +902,55 @@
         }
       }
     },
+    "takedown": {
+      "title": "Richiesta di rimozione (Takedown)",
+      "description": "Come segnalare un contenuto che ritieni violi il tuo diritto d'autore e come gestiamo la richiesta.",
+      "sections": {
+        "overview": {
+          "title": "1. Panoramica",
+          "content": "MeepleAI rispetta il diritto d'autore. Le schede meccaniche pubblicate sono analisi generate dall'AI a partire dai manuali di gioco: ogni affermazione è riformulata in parole originali e cita la pagina del regolamento. Il copyright del testo originale del manuale resta degli editori.\n\nSe ritieni che una scheda pubblicata riproduca il tuo materiale protetto oltre quanto consentito, puoi chiederne la rimozione o la sospensione tramite questa pagina. La richiesta viene esaminata da una persona; non è un processo automatico."
+        },
+        "whoCanFile": {
+          "title": "2. Chi può inviare una richiesta",
+          "content": "Può inviare una richiesta di rimozione il titolare del diritto d'autore (ad esempio l'editore o l'autore del regolamento) oppure un suo rappresentante autorizzato ad agire per suo conto.\n\nPer permetterci di verificare e ricontattarti, indica il tuo nome completo, un indirizzo email valido e, se agisci per conto di terzi, il soggetto che rappresenti."
+        },
+        "whatToInclude": {
+          "title": "3. Cosa includere nella richiesta",
+          "content": "Per gestire la richiesta rapidamente, includi:\n\n- L'opera protetta interessata (titolo del regolamento o del manuale).\n- L'URL esatto della scheda contestata (la pagina `/games/{id}/card`).\n- Una descrizione di quale contenuto ritieni problematico e perché.\n- Una dichiarazione in buona fede che l'uso contestato non è autorizzato dal titolare del diritto, dal suo rappresentante o dalla legge.\n- La conferma che le informazioni fornite sono accurate.\n\nIl modulo qui sotto compone automaticamente questi elementi in una email precompilata."
+        },
+        "howWeRespond": {
+          "title": "4. Come rispondiamo",
+          "content": "Confermiamo la ricezione della tua richiesta entro **3 giorni lavorativi**. Valutiamo la segnalazione e, quando accolta, sospendiamo o rimuoviamo la scheda interessata entro **10 giorni lavorativi** dalla ricezione.\n\nUna scheda sospesa non è più accessibile pubblicamente. Ti aggiorneremo via email sull'esito. Possiamo chiederti informazioni aggiuntive se necessarie per completare la verifica."
+        },
+        "contact": {
+          "title": "5. Contatti",
+          "content": "Le richieste di rimozione vanno inviate a: **takedown@meepleai.app**\n\nPuoi usare il modulo in fondo a questa pagina per comporre una email precompilata, oppure scrivere direttamente all'indirizzo indicando le informazioni elencate sopra."
+        }
+      },
+      "form": {
+        "heading": "Modulo di richiesta di rimozione",
+        "intro": "Compila i campi per generare una email precompilata verso takedown@meepleai.app. Nessun dato viene inviato ai nostri server da questa pagina.",
+        "nameLabel": "Nome completo",
+        "namePlaceholder": "Mario Rossi",
+        "emailLabel": "Email",
+        "emailPlaceholder": "tu@esempio.com",
+        "workLabel": "Opera protetta / titolo del regolamento",
+        "workPlaceholder": "Es. Catan — Regolamento base",
+        "cardUrlLabel": "URL della scheda contestata",
+        "cardUrlPlaceholder": "https://meepleai.com/games/.../card",
+        "descriptionLabel": "Descrizione del problema",
+        "descriptionPlaceholder": "Descrivi quale contenuto ritieni violi il tuo diritto d'autore e perché.",
+        "confirmLabel": "Dichiaro in buona fede che l'uso contestato non è autorizzato e che le informazioni fornite sono accurate.",
+        "submit": "Apri email precompilata",
+        "copy": "Copia richiesta negli appunti",
+        "copied": "Copiato!",
+        "requiredError": "Questo campo è obbligatorio.",
+        "emailInvalidError": "Inserisci un indirizzo email valido.",
+        "confirmError": "Devi confermare la dichiarazione per procedere.",
+        "errorSummary": "Correggi i campi evidenziati prima di procedere.",
+        "mailSubject": "Richiesta di rimozione — {work}"
+      }
+    },
     "privacy": {
       "title": "Informativa sulla Privacy",
       "description": "Come raccogliamo, utilizziamo e proteggiamo i tuoi dati personali",

--- a/docs/legal/takedown-policy.md
+++ b/docs/legal/takedown-policy.md
@@ -1,0 +1,94 @@
+# Takedown Policy — Mechanic Comprehension Cards
+
+**Owner:** MeepleAI Trust & Legal
+**Parent ADR:** [ADR-051 — Mechanic Extractor IP Policy](../for-claude/architecture/adr/adr-051-mechanic-extractor-ip-policy.md)
+**Related issues:** #528 (public card), #529 (this policy + `/legal/takedown`)
+**Status:** Active
+
+---
+
+## 1. Scopo e ambito
+
+MeepleAI pubblica **comprehension card** dei giochi da tavolo: sintesi delle meccaniche
+**riformulate in parole originali dall'AI** a partire dal manuale, con citazione della pagina del
+regolamento (ADR-051). Il testo originale del manuale resta **copyright dell'editore**.
+
+Questa policy descrive come chiunque — in particolare editori e detentori di diritti — può
+richiedere la rimozione (takedown) di una card, e come MeepleAI la gestisce internamente. Copre le
+`mechanic_cards` pubblicate visibili su `/games/{id}/card`. Non copre contenuti caricati dagli
+utenti (regolati dai Terms of Service) né PDF sorgente (mai ripubblicati).
+
+## 2. Chi può presentare una richiesta
+
+- Il detentore dei diritti d'autore sul manuale o un suo rappresentante autorizzato.
+- Chiunque segnali un contenuto che ritiene violi diritti di terzi o sia inaccurato in modo lesivo.
+
+Non è richiesto un account MeepleAI: la pagina `/legal/takedown` è **pubblica** (route group
+`(public)`, non login-gated).
+
+## 3. Canali
+
+| Canale | Uso |
+|---|---|
+| Form pubblico **`/legal/takedown`** | Percorso primario; genera una richiesta strutturata precompilata. |
+| Email **`takedown@meepleai.app`** | Canale diretto / destinatario del form. |
+
+> **Nota infra (fuori scope #529):** l'alias `takedown@meepleai.app` va configurato come task
+> infrastrutturale separato prima del go-live pubblico. Fino ad allora il form indirizza comunque a
+> tale alias via `mailto:`.
+
+## 4. Cosa deve contenere una richiesta
+
+La richiesta (template del form) deve includere:
+
+1. **Identità e contatto** del richiedente (nome, email, ruolo/rappresentanza).
+2. **Opera protetta** identificata (titolo del gioco/manuale, editore, edizione).
+3. **URL della card** contestata (`/games/{id}/card`).
+4. **Descrizione** del problema (violazione di copyright, inaccuratezza lesiva, altro).
+5. **Dichiarazione di buona fede** e di **accuratezza** delle informazioni fornite.
+
+## 5. Processo interno
+
+```
+Richiesta (form/email)
+  → Triage Trust & Legal (registrazione, verifica completezza)
+    → Valutazione (fondatezza, ambito, opera identificata)
+      → Azione:
+          ├─ Fondata / precauzionale → SUPPRESS card
+          │     (is_suppressed=true, suppressed_reason, suppressed_at/by)
+          │     → card sparisce dal pubblico (404) automaticamente
+          ├─ Infondata → risposta motivata, nessuna rimozione
+          └─ Incompleta → richiesta di integrazione al mittente
+    → Audit log + risposta al richiedente
+```
+
+**Meccanismo tecnico di rimozione.** La soppressione imposta `is_suppressed=true` sull'aggregato
+`MechanicCard`. Il filtro globale EF (`HasQueryFilter(!IsSuppressed)`) e la query pubblica
+`GetActiveByGameAsync` fanno sì che la card soppressa **non sia più leggibile pubblicamente** —
+`GET /api/v1/games/{gameId}/card` restituisce **404** e la pagina rende `notFound()` (verificato in
+#528, test `PublishedMechanicCardEndpointIntegrationTests`). Ogni soppressione è tracciata (audit
+log + colonne `suppressed_*`).
+
+**Ruoli.** Triage e decisione: Trust & Legal. Esecuzione tecnica della soppressione: admin
+autorizzato (surface admin). Nessuna azione automatica di rimozione da questa policy (l'auto-
+suppression da feedback utente è separata — vedi #534).
+
+## 6. SLA
+
+| Fase | Target |
+|---|---|
+| **Presa in carico** (acknowledge al richiedente) | ≤ **3 giorni lavorativi** dalla ricezione |
+| **Risoluzione** (rimozione o risposta motivata) | ≤ **10 giorni lavorativi** dalla presa in carico |
+| Casi di rischio evidente | Soppressione **precauzionale immediata**, valutazione a seguire |
+
+## 7. Ripristino e controversie
+
+Se una richiesta viene ritenuta infondata dopo una soppressione precauzionale, o l'editore ritira la
+richiesta, la card può essere ripristinata ripubblicando l'analisi (nuova versione). Le controversie
+sono gestite via `takedown@meepleai.app`. Rimane impregiudicato ogni diritto di legge delle parti.
+
+## 8. Fuori scope
+
+- Setup dell'alias email `takedown@meepleai.app` (task infrastrutturale).
+- Review dei Terms of Service con IP legal counsel (gate M2, ADR-051).
+- Auto-suppression da feedback utente (#534, tracciata separatamente).


### PR DESCRIPTION
ME-M1.7 — public takedown channel + policy. The Variant-C footer copy was already retired in #526 (shared `MechanicAnalysisFooterAttribution` carries the ADR-051 attribution), so this completes the remaining scope.

- Public **/legal/takedown** page (route group `(public)`, not login-gated) on the shared `LegalPageLayout` (5 i18n sections IT/EN + SEO + JSON-LD like /terms). SLA per ADR-051: acknowledge ≤3 business days, resolve/suppress ≤10.
- **TakedownRequestForm** — functional template (no backend / email-alias is separate infra): validated fields + good-faith confirmation → pre-filled `mailto:takedown@meepleai.app` (or copy). Accessible, semantic tokens.
- Public card footer: **"Report a copyright concern"** link → /legal/takedown (below the shared attribution; admin review unaffected).
- **docs/legal/takedown-policy.md** — internal process + SLA; a takedown sets `is_suppressed=true` → the #528 public read 404s automatically.

Verified: typecheck clean, eslint 0, **vitest 187/187** (IT/EN legal-key parity + form validation/mailto/copy).

Out of scope (per issue): `takedown@` email alias (infra), ToS IP-counsel review.

Closes #529