### PR TITLE
feat(mechanic-extractor): #531 how-it-works game-comprehension landing

### DIFF
--- a/apps/web/src/app/(public)/how-it-works/game-comprehension/__tests__/page.test.tsx
+++ b/apps/web/src/app/(public)/how-it-works/game-comprehension/__tests__/page.test.tsx
@@ -1,0 +1,68 @@
+/** @vitest-environment jsdom */
+// apps/web/src/app/(public)/how-it-works/game-comprehension/__tests__/page.test.tsx
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import GameComprehensionPage from '../page';
+
+// Mirror the sibling how-it-works test: return the key as the string. The
+// second arg (interpolation values) is accepted but ignored so keys with
+// placeholders (e.g. demoPageLabel) still resolve to a stable string.
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => ({ t: (k: string) => k, locale: 'it' }),
+}));
+
+describe('GameComprehensionPage', () => {
+  it('renders a single h1', () => {
+    render(<GameComprehensionPage />);
+    const h1 = screen.getByRole('heading', { level: 1 });
+    expect(h1).toHaveTextContent('pages.gameComprehension.title');
+  });
+
+  it('renders the 4 trust-chain steps in order', () => {
+    render(<GameComprehensionPage />);
+    for (const key of ['pdf', 'read', 'review', 'card']) {
+      expect(
+        screen.getByRole('heading', { name: `pages.gameComprehension.chain.${key}.title` })
+      ).toBeInTheDocument();
+    }
+    // The steps are an ordered list (semantic sequence).
+    const items = screen.getByRole('list').querySelectorAll('li');
+    expect(items).toHaveLength(4);
+  });
+
+  it('renders the live citation demo badge (interactive [p.N])', () => {
+    render(<GameComprehensionPage />);
+    // MechanicCitationBadge renders a button with an Italian aria-label + p.7.
+    const badge = screen.getByRole('button', { name: /Citazione regolamento, pagina 7/ });
+    expect(badge).toHaveTextContent('p.7');
+  });
+
+  it('opens the illustrative citation panel when the badge is activated', () => {
+    render(<GameComprehensionPage />);
+    // testid: the illustrative demo panel is a plain container with no ARIA
+    // role/name (it is not a modal dialog), so getByRole cannot target it.
+    expect(screen.queryByTestId('game-comprehension-demo-panel')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /Citazione regolamento, pagina 7/ }));
+    expect(screen.getByTestId('game-comprehension-demo-panel')).toBeInTheDocument();
+  });
+
+  it('renders the primary CTA to /register', () => {
+    render(<GameComprehensionPage />);
+    const cta = screen.getByRole('link', { name: 'pages.gameComprehension.ctaPrimary' });
+    expect(cta).toHaveAttribute('href', '/register');
+  });
+
+  it('renders the secondary CTA back to /how-it-works', () => {
+    render(<GameComprehensionPage />);
+    const cta = screen.getByRole('link', { name: 'pages.gameComprehension.ctaSecondary' });
+    expect(cta).toHaveAttribute('href', '/how-it-works');
+  });
+
+  it('emits a LearningResource JSON-LD structured-data script', () => {
+    const { container } = render(<GameComprehensionPage />);
+    const script = container.querySelector('script[type="application/ld+json"]');
+    expect(script).toBeTruthy();
+    expect(script?.textContent).toContain('LearningResource');
+  });
+});

--- a/apps/web/src/app/(public)/how-it-works/game-comprehension/layout.tsx
+++ b/apps/web/src/app/(public)/how-it-works/game-comprehension/layout.tsx
@@ -1,0 +1,23 @@
+import type { Metadata } from 'next';
+
+const CANONICAL_URL = 'https://meepleai.com/how-it-works/game-comprehension';
+
+export const metadata: Metadata = {
+  title: 'Come MeepleAI comprende un gioco | MeepleAI',
+  description:
+    'Dal PDF del regolamento alla scheda con citazioni: scopri la catena di fiducia che rende ogni risposta di MeepleAI verificabile, pagina per pagina.',
+  robots: { index: true, follow: true },
+  alternates: { canonical: CANONICAL_URL },
+  openGraph: {
+    type: 'article',
+    title: 'Come MeepleAI comprende un gioco',
+    description:
+      'La catena di fiducia dietro ogni risposta: PDF ufficiale, riformulazione AI, revisione umana per-affermazione, scheda con citazione della pagina esatta.',
+    url: CANONICAL_URL,
+    siteName: 'MeepleAI',
+  },
+};
+
+export default function GameComprehensionLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/apps/web/src/app/(public)/how-it-works/game-comprehension/page.stories.tsx
+++ b/apps/web/src/app/(public)/how-it-works/game-comprehension/page.stories.tsx
@@ -1,0 +1,32 @@
+/**
+ * game-comprehension — ME-M2.2 (Issue #531), parent ADR-051.
+ *
+ * Public explainer for the AI game-comprehension trust chain (PDF → AI rewords →
+ * human reviews per-claim → cited card) with a live citation demo.
+ */
+
+import GameComprehensionPage from './page';
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta<typeof GameComprehensionPage> = {
+  title: 'Public / how-it-works / game-comprehension',
+  component: GameComprehensionPage,
+  parameters: {
+    layout: 'fullscreen',
+    nextjs: { appDirectory: true },
+    viewport: { defaultViewport: 'desktop' },
+    docs: {
+      description: {
+        component:
+          '#531 ME-M2.2. Public landing explaining the AI game-comprehension trust chain, with a hardcoded live citation demo (sample Catan claim + `[p.7]` badge).',
+      },
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof GameComprehensionPage>;
+
+export const Default: Story = {};

--- a/apps/web/src/app/(public)/how-it-works/game-comprehension/page.tsx
+++ b/apps/web/src/app/(public)/how-it-works/game-comprehension/page.tsx
@@ -1,0 +1,311 @@
+'use client';
+
+/**
+ * Public explainer — ME-M2.2 (Issue #531), parent ADR-051.
+ *
+ * `/how-it-works/game-comprehension` — a public marketing/explainer landing page
+ * describing the AI game-comprehension trust chain (PDF → AI rewords → human
+ * reviews per-claim → published card cites the exact page), with a live,
+ * keyboard-accessible citation demo.
+ *
+ * The live demo uses HARDCODED sample Catan data so the page renders even if no
+ * Catan card is published. It reuses the real {@link MechanicCitationBadge} from
+ * #530 for the inline `[p.N]` control, but shows a lightweight illustrative panel
+ * (the quote + page + "human-reviewed" badge) on activation rather than mounting
+ * the full pdfjs-backed {@link MechanicCitationPanel}, which needs a real PDF.
+ */
+
+import { useCallback, useState, type JSX } from 'react';
+
+import Link from 'next/link';
+
+import { MechanicCitationBadge } from '@/components/features/mechanic-card/MechanicCitationBadge';
+import { StructuredData, learningResourceSchema } from '@/components/legal/StructuredData';
+import { Btn } from '@/components/ui/btn';
+import { useTranslation } from '@/hooks/useTranslation';
+import type { PublishedMechanicCitationDto } from '@/lib/api/schemas/mechanic-card.schemas';
+
+const CANONICAL_URL = 'https://meepleai.com/how-it-works/game-comprehension';
+
+/** The four links in the provenance chain, in order. */
+const CHAIN_STEPS = ['pdf', 'read', 'review', 'card'] as const;
+type ChainStepKey = (typeof CHAIN_STEPS)[number];
+
+/** Line-icon per station. Presentational only — decorative (`aria-hidden`). */
+const CHAIN_ICON: Record<ChainStepKey, JSX.Element> = {
+  pdf: <PdfIcon />,
+  read: <ReadIcon />,
+  review: <ReviewIcon />,
+  card: <CardIcon />,
+};
+
+/**
+ * Hardcoded sample citation for the live demo. Not fetched — the landing must
+ * render even when no Catan card is published. The `pdfId` is a stable dummy
+ * UUID (the badge only needs `pdfPage` to be interactive).
+ */
+const DEMO_PDF_PAGE = 7;
+
+export default function GameComprehensionPage(): JSX.Element {
+  const { t } = useTranslation();
+  const [panelOpen, setPanelOpen] = useState(false);
+
+  const demoCitation: PublishedMechanicCitationDto = {
+    pdfId: '00000000-0000-4000-8000-000000000531',
+    pdfPage: DEMO_PDF_PAGE,
+    quote: t('pages.gameComprehension.demoQuote'),
+  };
+
+  const openPanel = useCallback(() => setPanelOpen(true), []);
+  const closePanel = useCallback(() => setPanelOpen(false), []);
+
+  return (
+    <main className="bg-background">
+      <StructuredData
+        data={learningResourceSchema({
+          name: t('pages.gameComprehension.metaTitle'),
+          description: t('pages.gameComprehension.metaDescription'),
+          url: CANONICAL_URL,
+        })}
+      />
+
+      {/* ── Hero ─────────────────────────────────────────────────────────── */}
+      <section
+        className="relative overflow-hidden px-4 py-20 md:py-28"
+        style={{
+          background:
+            'linear-gradient(160deg, hsl(var(--c-game) / 0.10), hsl(var(--c-document) / 0.06) 55%, transparent)',
+        }}
+      >
+        <div className="mx-auto max-w-3xl text-center">
+          <p className="mb-4 inline-flex items-center gap-2 rounded-full border border-entity-game/30 bg-entity-game/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-entity-game">
+            {t('pages.gameComprehension.eyebrow')}
+          </p>
+          <h1
+            className="m-0 text-balance text-4xl font-bold tracking-tight text-foreground md:text-6xl"
+            style={{ fontFamily: 'var(--f-display)' }}
+          >
+            {t('pages.gameComprehension.title')}
+          </h1>
+          <p className="mx-auto mt-6 max-w-2xl text-pretty text-lg leading-relaxed text-muted-foreground">
+            {t('pages.gameComprehension.subtitle')}
+          </p>
+        </div>
+      </section>
+
+      {/* ── Trust chain ──────────────────────────────────────────────────── */}
+      <section className="mx-auto max-w-6xl px-4 py-16 md:py-20">
+        <div className="mx-auto max-w-2xl text-center">
+          <h2 className="text-2xl font-bold text-foreground md:text-3xl">
+            {t('pages.gameComprehension.chainHeading')}
+          </h2>
+          <p className="mt-3 text-muted-foreground">
+            {t('pages.gameComprehension.chainSubheading')}
+          </p>
+        </div>
+
+        {/* The chain: a connecting "thread" (the provenance that never breaks)
+            runs behind the numbered stations. Vertical on mobile, horizontal on
+            large screens. The thread is decorative; the ordered list carries the
+            real sequence semantics. */}
+        <ol className="relative mt-14 grid grid-cols-1 gap-y-10 sm:grid-cols-2 lg:grid-cols-4 lg:gap-x-6">
+          {/* Horizontal thread (lg+): sits behind the numbered nodes. */}
+          <span
+            aria-hidden="true"
+            className="pointer-events-none absolute left-0 right-0 top-6 hidden h-px bg-gradient-to-r from-entity-game/10 via-entity-game/40 to-entity-game/10 lg:block"
+          />
+          {CHAIN_STEPS.map((key, idx) => (
+            <li
+              key={key}
+              className="relative flex break-inside-avoid flex-col items-center text-center lg:px-3"
+            >
+              {/* Numbered node — the anchor point on the thread. */}
+              <span className="relative z-10 flex h-12 w-12 items-center justify-center rounded-full border border-entity-game/30 bg-card text-lg font-bold text-entity-game shadow-sm">
+                <span className="sr-only">{`${idx + 1}. `}</span>
+                {idx + 1}
+              </span>
+              <span
+                className="mt-5 flex h-11 w-11 items-center justify-center text-entity-game"
+                aria-hidden="true"
+              >
+                {CHAIN_ICON[key]}
+              </span>
+              <span className="mt-3 text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+                {t(`pages.gameComprehension.chain.${key}.label`)}
+              </span>
+              <h3 className="mt-1 text-lg font-semibold text-foreground">
+                {t(`pages.gameComprehension.chain.${key}.title`)}
+              </h3>
+              <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+                {t(`pages.gameComprehension.chain.${key}.description`)}
+              </p>
+            </li>
+          ))}
+        </ol>
+      </section>
+
+      {/* ── Live citation demo ───────────────────────────────────────────── */}
+      <section className="border-y border-border bg-muted/40 px-4 py-16 md:py-20">
+        <div className="mx-auto max-w-3xl">
+          <div className="mx-auto max-w-2xl text-center">
+            <h2 className="text-2xl font-bold text-foreground md:text-3xl">
+              {t('pages.gameComprehension.demoHeading')}
+            </h2>
+            <p className="mt-3 text-muted-foreground">
+              {t('pages.gameComprehension.demoSubheading')}
+            </p>
+          </div>
+
+          {/* A representative snippet of a published card. */}
+          <figure className="mx-auto mt-10 max-w-xl rounded-2xl border border-border bg-card p-6 shadow-sm">
+            <figcaption className="flex flex-wrap items-center gap-2 border-b border-border pb-3">
+              <span className="text-sm font-semibold text-entity-game">
+                {t('pages.gameComprehension.demoGameName')}
+              </span>
+              <span className="text-xs uppercase tracking-wide text-muted-foreground">
+                {t('pages.gameComprehension.demoSectionLabel')}
+              </span>
+            </figcaption>
+
+            <p className="mt-4 text-base leading-relaxed text-foreground">
+              {t('pages.gameComprehension.demoClaim')}{' '}
+              <MechanicCitationBadge citation={demoCitation} onOpen={openPanel} />
+            </p>
+
+            {/* Lightweight illustrative panel (a mock of MechanicCitationPanel —
+                no real PDF). Toggled by the badge. Keyboard-dismissable. */}
+            {panelOpen && (
+              <div
+                className="mt-5 rounded-xl border border-entity-game/30 bg-entity-game/5 p-4"
+                data-testid="game-comprehension-demo-panel"
+              >
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <span className="inline-flex items-center rounded-md border border-entity-game/40 bg-entity-game/10 px-2 py-0.5 text-xs font-semibold text-entity-game">
+                    {t('pages.gameComprehension.demoReviewedBadge')}
+                  </span>
+                  <span className="text-xs uppercase tracking-wide text-muted-foreground">
+                    {t('pages.gameComprehension.demoPageLabel', { page: DEMO_PDF_PAGE })}
+                  </span>
+                </div>
+                <blockquote className="mt-3 border-l-2 border-entity-game/40 pl-3 text-sm italic leading-relaxed text-foreground">
+                  &ldquo;{t('pages.gameComprehension.demoQuote')}&rdquo;
+                </blockquote>
+                <p className="mt-3 text-xs text-muted-foreground">
+                  {t('pages.gameComprehension.demoDocumentName')}
+                </p>
+                <div className="mt-3 flex justify-end">
+                  <Btn variant="ghost" size="sm" onClick={closePanel}>
+                    {t('pages.gameComprehension.demoDismiss')}
+                  </Btn>
+                </div>
+              </div>
+            )}
+          </figure>
+
+          <p className="mx-auto mt-8 max-w-xl text-center text-sm leading-relaxed text-muted-foreground">
+            {t('pages.gameComprehension.trustNote')}
+          </p>
+        </div>
+      </section>
+
+      {/* ── CTA ──────────────────────────────────────────────────────────── */}
+      <section className="mx-auto max-w-3xl px-4 py-16 text-center md:py-24">
+        <h2 className="text-2xl font-bold text-foreground md:text-3xl">
+          {t('pages.gameComprehension.ctaHeading')}
+        </h2>
+        <p className="mx-auto mt-3 max-w-xl text-muted-foreground">
+          {t('pages.gameComprehension.ctaSubheading')}
+        </p>
+        <div className="mt-8 flex flex-col items-center justify-center gap-3 sm:flex-row">
+          <Btn variant="primary" entity="game" size="lg" asChild>
+            <Link href="/register">{t('pages.gameComprehension.ctaPrimary')}</Link>
+          </Btn>
+          <Btn variant="ghost" size="lg" asChild>
+            <Link href="/how-it-works">{t('pages.gameComprehension.ctaSecondary')}</Link>
+          </Btn>
+        </div>
+      </section>
+    </main>
+  );
+}
+
+/* ── Decorative line icons (aria-hidden, inherit currentColor) ───────────── */
+
+function PdfIcon(): JSX.Element {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      className="h-8 w-8"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M14 3v4a1 1 0 0 0 1 1h4M5 3h9l5 5v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2Z"
+      />
+      <path strokeLinecap="round" d="M8 13h8M8 17h5" />
+    </svg>
+  );
+}
+
+function ReadIcon(): JSX.Element {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      className="h-8 w-8"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M12 6c-2-1.5-4.5-1.5-7-1v12c2.5-.5 5-.5 7 1m0-13c2-1.5 4.5-1.5 7-1v12c-2.5-.5-5-.5-7 1m0-13v13"
+      />
+      <path strokeLinecap="round" strokeLinejoin="round" d="m16.5 15 1.5 1.5 3-3" />
+    </svg>
+  );
+}
+
+function ReviewIcon(): JSX.Element {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      className="h-8 w-8"
+    >
+      <circle cx="12" cy="8" r="3.5" strokeLinecap="round" strokeLinejoin="round" />
+      <path strokeLinecap="round" strokeLinejoin="round" d="M5 20a7 7 0 0 1 14 0" />
+      <path strokeLinecap="round" strokeLinejoin="round" d="m9.5 8 1.6 1.6L14 6.5" />
+    </svg>
+  );
+}
+
+function CardIcon(): JSX.Element {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      className="h-8 w-8"
+    >
+      <rect
+        x="3"
+        y="5"
+        width="18"
+        height="14"
+        rx="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path strokeLinecap="round" d="M7 10h6" />
+      <path strokeLinecap="round" strokeLinejoin="round" d="M15 14h2.5" opacity="0.7" />
+      <path strokeLinecap="round" d="M7 14h4" />
+    </svg>
+  );
+}

--- a/apps/web/src/components/legal/StructuredData.tsx
+++ b/apps/web/src/components/legal/StructuredData.tsx
@@ -99,6 +99,43 @@ export function faqPageSchema(faqs: Array<{ question: string; answer: string }>)
 }
 
 /**
+ * Generate LearningResource schema for explainer / how-it-works pages.
+ *
+ * Emits a schema.org `LearningResource` (JSON-LD) so search engines can surface
+ * the page as educational content. `learningResourceType` describes the format
+ * (e.g. "explainer"); `inLanguage` mirrors the site's bilingual support.
+ */
+export function learningResourceSchema({
+  name,
+  description,
+  url,
+  learningResourceType = 'explainer',
+  inLanguage = ['it', 'en'],
+}: {
+  name: string;
+  description: string;
+  url: string;
+  learningResourceType?: string;
+  inLanguage?: string[];
+}) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'LearningResource',
+    name,
+    description,
+    url,
+    learningResourceType,
+    inLanguage,
+    provider: organizationSchema(),
+    isPartOf: {
+      '@type': 'WebSite',
+      name: 'MeepleAI',
+      url: 'https://meepleai.com',
+    },
+  };
+}
+
+/**
  * Generate BreadcrumbList schema
  */
 export function breadcrumbSchema(items: Array<{ name: string; url: string }>) {

--- a/apps/web/src/components/legal/__tests__/StructuredData.test.tsx
+++ b/apps/web/src/components/legal/__tests__/StructuredData.test.tsx
@@ -13,6 +13,7 @@ import {
   organizationSchema,
   breadcrumbSchema,
   faqPageSchema,
+  learningResourceSchema,
 } from '../StructuredData';
 
 describe('StructuredData', () => {
@@ -90,5 +91,34 @@ describe('faqPageSchema', () => {
     expect(schema['@type']).toBe('FAQPage');
     expect(schema.mainEntity).toHaveLength(1);
     expect(schema.mainEntity[0]['@type']).toBe('Question');
+  });
+});
+
+describe('learningResourceSchema', () => {
+  it('generates correct LearningResource schema with defaults', () => {
+    const schema = learningResourceSchema({
+      name: 'How MeepleAI understands a game',
+      description: 'The trust chain behind every answer.',
+      url: 'https://meepleai.com/how-it-works/game-comprehension',
+    });
+    expect(schema['@context']).toBe('https://schema.org');
+    expect(schema['@type']).toBe('LearningResource');
+    expect(schema.name).toBe('How MeepleAI understands a game');
+    expect(schema.url).toBe('https://meepleai.com/how-it-works/game-comprehension');
+    expect(schema.learningResourceType).toBe('explainer');
+    expect(schema.inLanguage).toEqual(['it', 'en']);
+    expect(schema.provider['@type']).toBe('Organization');
+  });
+
+  it('respects overridden learningResourceType and inLanguage', () => {
+    const schema = learningResourceSchema({
+      name: 'Guide',
+      description: 'Desc',
+      url: 'https://meepleai.com/x',
+      learningResourceType: 'guide',
+      inLanguage: ['en'],
+    });
+    expect(schema.learningResourceType).toBe('guide');
+    expect(schema.inLanguage).toEqual(['en']);
   });
 });

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -1109,6 +1109,53 @@
       "aboutCta": "Learn more about MeepleAI",
       "faqCta": "Browse the FAQ"
     },
+    "gameComprehension": {
+      "metaTitle": "How MeepleAI understands a game | MeepleAI",
+      "metaDescription": "From the rulebook PDF to a card with citations: see the trust chain that makes every MeepleAI answer verifiable, page by page.",
+      "eyebrow": "The trust chain",
+      "title": "Every answer traces back to the rulebook.",
+      "subtitle": "MeepleAI reads the official manual, rewords each mechanic in its own words, and cites the exact page. No invented rules — only what's written, with the source attached.",
+      "chainHeading": "From PDF to a cited card",
+      "chainSubheading": "Four steps, one thread running through them: the source is never lost.",
+      "chain": {
+        "pdf": {
+          "label": "Source",
+          "title": "The rulebook PDF",
+          "description": "It all starts with the game's official manual. It is our single source of truth: MeepleAI never adds anything that isn't in the document."
+        },
+        "read": {
+          "label": "AI reads",
+          "title": "The AI reads and rewords",
+          "description": "The AI reads the manual and rewrites each mechanic in its own words, keeping the link back to the exact spot it came from."
+        },
+        "review": {
+          "label": "Human review",
+          "title": "A reviewer approves",
+          "description": "A person reviews every claim, one by one. Only approved rules make it onto the published card."
+        },
+        "card": {
+          "label": "Final card",
+          "title": "The card with citations",
+          "description": "The published card cites the precise rulebook page for every claim. One click and you see where it came from."
+        }
+      },
+      "demoHeading": "Try it: hover the citation",
+      "demoSubheading": "Here's a Catan mechanic as it would appear on the card. Hover or press Enter on the reference to see the source.",
+      "demoGameName": "Catan",
+      "demoSectionLabel": "Mechanics",
+      "demoClaim": "Players gather resources by rolling dice at the start of each turn.",
+      "demoQuote": "At the beginning of their turn, the active player rolls both dice. The total indicates which terrain hexes produce resources this turn.",
+      "demoDocumentName": "Catan Rulebook",
+      "demoPanelHeading": "Citation source",
+      "demoReviewedBadge": "AI-generated, human-reviewed",
+      "demoPageLabel": "page {page}",
+      "demoDismiss": "Dismiss",
+      "trustNote": "Every card is AI-generated and human-reviewed. It's that combination — not the AI alone — that makes each citation trustworthy.",
+      "ctaHeading": "Ready to trust the rules?",
+      "ctaSubheading": "Upload your game's rulebook and get answers with the source attached.",
+      "ctaPrimary": "Try it with your game",
+      "ctaSecondary": "See how it works overall"
+    },
     "blog": {
       "title": "Blog",
       "description": "News, guides, and insights on the world of board games",

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -1156,6 +1156,53 @@
       "aboutCta": "Scopri di più su MeepleAI",
       "faqCta": "Consulta le FAQ"
     },
+    "gameComprehension": {
+      "metaTitle": "Come MeepleAI comprende un gioco | MeepleAI",
+      "metaDescription": "Dal PDF del regolamento alla scheda con citazioni: scopri la catena di fiducia che rende ogni risposta di MeepleAI verificabile, pagina per pagina.",
+      "eyebrow": "La catena di fiducia",
+      "title": "Ogni risposta risale al regolamento.",
+      "subtitle": "MeepleAI legge il manuale ufficiale, riformula ogni meccanica con le sue parole e cita la pagina esatta. Nessuna regola inventata: solo ciò che c'è scritto, con la fonte allegata.",
+      "chainHeading": "Dal PDF alla scheda citata",
+      "chainSubheading": "Quattro passaggi, un solo filo conduttore: la fonte non si perde mai.",
+      "chain": {
+        "pdf": {
+          "label": "Fonte",
+          "title": "Il regolamento in PDF",
+          "description": "Tutto parte dal manuale ufficiale del gioco. È la nostra unica fonte di verità: MeepleAI non aggiunge nulla che non sia nel documento."
+        },
+        "read": {
+          "label": "Lettura AI",
+          "title": "L'AI legge e riformula",
+          "description": "L'AI legge il manuale e riscrive ogni meccanica con parole proprie, mantenendo il legame con il punto esatto da cui l'ha estratta."
+        },
+        "review": {
+          "label": "Revisione umana",
+          "title": "Un revisore approva",
+          "description": "Una persona rivede ogni affermazione, una per una. Solo le regole approvate finiscono sulla scheda pubblicata."
+        },
+        "card": {
+          "label": "Scheda finale",
+          "title": "La scheda con citazioni",
+          "description": "La scheda pubblicata cita la pagina precisa del regolamento per ogni affermazione. Un clic e vedi da dove arriva."
+        }
+      },
+      "demoHeading": "Provala: passa sopra la citazione",
+      "demoSubheading": "Ecco una meccanica di Catan come apparirebbe sulla scheda. Passa il mouse o usa il tasto Invio sul riferimento per vedere la fonte.",
+      "demoGameName": "Catan",
+      "demoSectionLabel": "Meccaniche",
+      "demoClaim": "I giocatori raccolgono risorse tirando i dadi all'inizio di ogni turno.",
+      "demoQuote": "All'inizio del suo turno, il giocatore di turno tira entrambi i dadi. La somma indica quali caselle terreno producono risorse in questo turno.",
+      "demoDocumentName": "Regolamento di Catan",
+      "demoPanelHeading": "Fonte della citazione",
+      "demoReviewedBadge": "Generata da AI, revisionata da una persona",
+      "demoPageLabel": "pagina {page}",
+      "demoDismiss": "Chiudi",
+      "trustNote": "Ogni scheda è generata dall'AI e revisionata da una persona. È questa combinazione — non l'AI da sola — a rendere ogni citazione affidabile.",
+      "ctaHeading": "Pronto a fidarti delle regole?",
+      "ctaSubheading": "Carica il regolamento del tuo gioco e ottieni risposte con la fonte allegata.",
+      "ctaPrimary": "Prova con il tuo gioco",
+      "ctaSecondary": "Come funziona in generale"
+    },
     "blog": {
       "title": "Blog",
       "subtitle": "Novità, guide e approfondimenti",


### PR DESCRIPTION
ME-M2.2. Public explainer landing **/how-it-works/game-comprehension** showing the AI game-comprehension trust chain (linked from the card's "AI-generated, human-reviewed" badge, #528).

- Sub-route under the existing `(public)/how-it-works` group (server layout + metadata, client page i18n IT/EN).
- **Trust chain** as a semantic `<ol>`, 4 steps: PDF → AI reads → Admin review → Card with citations (numbered nodes on a provenance thread, responsive).
- **Live citation demo**: hardcoded sample Catan claim + the reused `MechanicCitationBadge` (#530, tooltip + keyboard); on activation shows a lightweight illustrative panel — NOT the pdfjs panel, so it renders with no published card.
- CTA "Prova con il tuo gioco" → /register.
- **SEO**: metadata + `LearningResource` JSON-LD (new `learningResourceSchema` builder). **WCAG AA** (single h1, list semantics, aria-hidden SVGs, semantic tokens).

Verified: typecheck clean, eslint 0, **vitest 16/16**.

Closes #531