### PR TITLE
feat(mechanic-extractor): #533 per-claim card feedback + report modal

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/SubmitMechanicCardFeedbackCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/SubmitMechanicCardFeedbackCommand.cs
@@ -1,0 +1,35 @@
+using MediatR;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands.MechanicExtractor;
+
+/// <summary>
+/// Records a user's 👍/👎 feedback on a single claim of a published mechanic card (#533 ME-M3.1).
+/// Idempotent per (card, user, claim): a re-submission UPDATES the existing row instead of duplicating.
+/// </summary>
+internal sealed record SubmitMechanicCardFeedbackCommand(
+    Guid CardId,
+    Guid UserId,
+    Guid ClaimId,
+    bool IsPositive,
+    string? ErrorType,
+    string? Description,
+    string? SuggestedCitation) : IRequest<SubmitMechanicCardFeedbackResult>;
+
+/// <summary>Outcome of a feedback submission, mapped to an HTTP status by the endpoint.</summary>
+public enum SubmitFeedbackOutcome
+{
+    /// <summary>A new feedback row was created (201).</summary>
+    Created,
+
+    /// <summary>An existing feedback row was updated in place (200) — idempotent change.</summary>
+    Updated,
+
+    /// <summary>No active (non-suppressed) card with that id exists (404).</summary>
+    CardNotFound,
+
+    /// <summary>The user hit the per-day feedback cap (429).</summary>
+    RateLimited
+}
+
+/// <summary>Result of <see cref="SubmitMechanicCardFeedbackCommand"/>.</summary>
+public sealed record SubmitMechanicCardFeedbackResult(SubmitFeedbackOutcome Outcome);

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/SubmitMechanicCardFeedbackCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/SubmitMechanicCardFeedbackCommandHandler.cs
@@ -1,0 +1,89 @@
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands.MechanicExtractor;
+
+/// <summary>
+/// Handler for <see cref="SubmitMechanicCardFeedbackCommand"/> (#533). Records feedback idempotently
+/// per (card, user, claim) and enforces a per-user-per-day cap. Card-counter/auto-suppression logic
+/// lives in #534, which aggregates these rows — this handler only persists the raw feedback.
+/// </summary>
+internal sealed class SubmitMechanicCardFeedbackCommandHandler
+    : IRequestHandler<SubmitMechanicCardFeedbackCommand, SubmitMechanicCardFeedbackResult>
+{
+    /// <summary>Max NEW feedback rows a user may create per rolling 24h (#533 AC). Updates are unlimited.</summary>
+    internal const int MaxNewFeedbackPerDay = 10;
+
+    private readonly MeepleAiDbContext _dbContext;
+
+    public SubmitMechanicCardFeedbackCommandHandler(MeepleAiDbContext dbContext)
+    {
+        _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+    }
+
+    public async Task<SubmitMechanicCardFeedbackResult> Handle(
+        SubmitMechanicCardFeedbackCommand request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        // Suppression query filter applies → feedback on a suppressed/absent card is a 404.
+        var cardExists = await _dbContext.MechanicCards
+            .AnyAsync(c => c.Id == request.CardId, cancellationToken)
+            .ConfigureAwait(false);
+        if (!cardExists)
+        {
+            return new SubmitMechanicCardFeedbackResult(SubmitFeedbackOutcome.CardNotFound);
+        }
+
+        // AsTracking is required because the DbContext defaults to NoTracking (PERF-06): without it
+        // the mutate-then-SaveChanges below is a silent no-op.
+        var existing = await _dbContext.MechanicCardFeedback
+            .AsTracking()
+            .FirstOrDefaultAsync(
+                f => f.CardId == request.CardId && f.UserId == request.UserId && f.ClaimId == request.ClaimId,
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        var now = DateTime.UtcNow;
+
+        if (existing is not null)
+        {
+            // Idempotent change — update in place, does NOT count against the daily cap.
+            existing.IsPositive = request.IsPositive;
+            existing.ErrorType = request.IsPositive ? null : request.ErrorType;
+            existing.Description = request.Description;
+            existing.SuggestedCitation = request.SuggestedCitation;
+            existing.UpdatedAt = now;
+            await _dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            return new SubmitMechanicCardFeedbackResult(SubmitFeedbackOutcome.Updated);
+        }
+
+        var since = now.AddDays(-1);
+        var recentCount = await _dbContext.MechanicCardFeedback
+            .CountAsync(f => f.UserId == request.UserId && f.CreatedAt >= since, cancellationToken)
+            .ConfigureAwait(false);
+        if (recentCount >= MaxNewFeedbackPerDay)
+        {
+            return new SubmitMechanicCardFeedbackResult(SubmitFeedbackOutcome.RateLimited);
+        }
+
+        _dbContext.MechanicCardFeedback.Add(new MechanicCardFeedbackEntity
+        {
+            Id = Guid.NewGuid(),
+            CardId = request.CardId,
+            UserId = request.UserId,
+            ClaimId = request.ClaimId,
+            IsPositive = request.IsPositive,
+            ErrorType = request.IsPositive ? null : request.ErrorType,
+            Description = request.Description,
+            SuggestedCitation = request.SuggestedCitation,
+            CreatedAt = now,
+            UpdatedAt = now
+        });
+        await _dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        return new SubmitMechanicCardFeedbackResult(SubmitFeedbackOutcome.Created);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/SubmitMechanicCardFeedbackCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/SubmitMechanicCardFeedbackCommandValidator.cs
@@ -1,0 +1,36 @@
+using FluentValidation;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands.MechanicExtractor;
+
+/// <summary>Validates <see cref="SubmitMechanicCardFeedbackCommand"/> (#533).</summary>
+internal sealed class SubmitMechanicCardFeedbackCommandValidator
+    : AbstractValidator<SubmitMechanicCardFeedbackCommand>
+{
+    private static readonly string[] AllowedErrorTypes = { "factual", "ambiguous", "contradicts_rule" };
+
+    public SubmitMechanicCardFeedbackCommandValidator()
+    {
+        RuleFor(x => x.CardId).NotEmpty();
+        RuleFor(x => x.UserId).NotEmpty();
+        RuleFor(x => x.ClaimId).NotEmpty();
+
+        // ErrorType only applies to a 👎 and, when present, must be a known category
+        // (mirrors the DB CHECK). A 👍 must not carry an error type.
+        When(x => x.IsPositive, () =>
+        {
+            RuleFor(x => x.ErrorType)
+                .Null()
+                .WithMessage("A positive feedback must not carry an error type.");
+        });
+
+        When(x => !string.IsNullOrWhiteSpace(x.ErrorType), () =>
+        {
+            RuleFor(x => x.ErrorType!)
+                .Must(t => AllowedErrorTypes.Contains(t, StringComparer.Ordinal))
+                .WithMessage("ErrorType must be one of: factual, ambiguous, contradicts_rule.");
+        });
+
+        RuleFor(x => x.Description).MaximumLength(2000);
+        RuleFor(x => x.SuggestedCitation).MaximumLength(1000);
+    }
+}

--- a/apps/api/src/Api/Infrastructure/Configurations/SharedGameCatalog/MechanicCardFeedbackEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/Configurations/SharedGameCatalog/MechanicCardFeedbackEntityConfiguration.cs
@@ -1,0 +1,53 @@
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Api.Infrastructure.Configurations.SharedGameCatalog;
+
+/// <summary>
+/// EF configuration for <see cref="MechanicCardFeedbackEntity"/> (ADR-051 / #533 ME-M3.1).
+/// </summary>
+/// <remarks>
+/// Enforces at DB level:
+/// - Unique (card_id, user_id, claim_id): one feedback per user per claim → idempotent submit.
+/// - CHECK error_type IN ('factual','ambiguous','contradicts_rule') OR NULL.
+/// - Index (user_id, created_at) backs the per-user-per-day rate limit (#533 AC) and #534 aggregation.
+/// - FK card_id → mechanic_cards ON DELETE CASCADE (feedback dies with its card).
+/// </remarks>
+internal sealed class MechanicCardFeedbackEntityConfiguration : IEntityTypeConfiguration<MechanicCardFeedbackEntity>
+{
+    public void Configure(EntityTypeBuilder<MechanicCardFeedbackEntity> builder)
+    {
+        builder.ToTable("mechanic_card_feedback", t =>
+        {
+            t.HasCheckConstraint(
+                "ck_mechanic_card_feedback_error_type",
+                "error_type IS NULL OR error_type IN ('factual', 'ambiguous', 'contradicts_rule')");
+        });
+
+        builder.HasKey(f => f.Id);
+
+        builder.Property(f => f.Id).HasColumnName("id").IsRequired();
+        builder.Property(f => f.CardId).HasColumnName("card_id").IsRequired();
+        builder.Property(f => f.UserId).HasColumnName("user_id").IsRequired();
+        builder.Property(f => f.ClaimId).HasColumnName("claim_id").IsRequired();
+        builder.Property(f => f.IsPositive).HasColumnName("is_positive").IsRequired();
+        builder.Property(f => f.ErrorType).HasColumnName("error_type").HasMaxLength(32);
+        builder.Property(f => f.Description).HasColumnName("description").HasMaxLength(2000);
+        builder.Property(f => f.SuggestedCitation).HasColumnName("suggested_citation").HasMaxLength(1000);
+        builder.Property(f => f.CreatedAt).HasColumnName("created_at").IsRequired();
+        builder.Property(f => f.UpdatedAt).HasColumnName("updated_at").IsRequired();
+
+        builder.HasIndex(f => new { f.CardId, f.UserId, f.ClaimId })
+            .IsUnique()
+            .HasDatabaseName("ux_mechanic_card_feedback_card_user_claim");
+
+        builder.HasIndex(f => new { f.UserId, f.CreatedAt })
+            .HasDatabaseName("ix_mechanic_card_feedback_user_created");
+
+        builder.HasOne(f => f.Card)
+            .WithMany()
+            .HasForeignKey(f => f.CardId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/MechanicCardFeedbackEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/MechanicCardFeedbackEntity.cs
@@ -1,0 +1,38 @@
+namespace Api.Infrastructure.Entities.SharedGameCatalog;
+
+/// <summary>
+/// Per-user, per-claim feedback on a published mechanic card (#533 ME-M3.1). A user has AT MOST one
+/// feedback row per (card, claim) — the unique index makes submission idempotent (a user can CHANGE
+/// their feedback but never duplicate it). Downstream auto-suppression (#534) aggregates these rows.
+/// </summary>
+public class MechanicCardFeedbackEntity
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    /// <summary>FK → mechanic_cards.id (the card being rated).</summary>
+    public Guid CardId { get; set; }
+
+    /// <summary>The authenticated user who submitted the feedback.</summary>
+    public Guid UserId { get; set; }
+
+    /// <summary>The specific claim within the card the feedback targets.</summary>
+    public Guid ClaimId { get; set; }
+
+    /// <summary>Thumbs up (true) / thumbs down (false).</summary>
+    public bool IsPositive { get; set; }
+
+    /// <summary>Error category, only meaningful for a 👎: 'factual' | 'ambiguous' | 'contradicts_rule'. Null for 👍.</summary>
+    public string? ErrorType { get; set; }
+
+    /// <summary>Optional free-text description of the reported problem.</summary>
+    public string? Description { get; set; }
+
+    /// <summary>Optional citation to the correct rule the user believes applies.</summary>
+    public string? SuggestedCitation { get; set; }
+
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+
+    // === Navigation ===
+    public MechanicCardEntity Card { get; set; } = default!;
+}

--- a/apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs
+++ b/apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs
@@ -210,6 +210,7 @@ public class MeepleAiDbContext : DbContext
     public DbSet<MechanicSuppressionAuditEntity> MechanicSuppressionAudits => Set<MechanicSuppressionAuditEntity>(); // ISSUE-523: T5 audit trail for suppressions
     public DbSet<MechanicCardEntity> MechanicCards => Set<MechanicCardEntity>(); // #527: Mechanic Extractor M1.5 — published user-facing card
     public DbSet<MechanicCardAuditLogEntity> MechanicCardAuditLog => Set<MechanicCardAuditLogEntity>(); // #527: card lifecycle audit trail
+    public DbSet<MechanicCardFeedbackEntity> MechanicCardFeedback => Set<MechanicCardFeedbackEntity>(); // #533: per-user per-claim card feedback
     public DbSet<MechanicAnalysisSectionRunEntity> MechanicAnalysisSectionRuns => Set<MechanicAnalysisSectionRunEntity>(); // ISSUE-524: M1.2 per-section provider/token tracking (B6=C)
     public DbSet<MechanicGoldenClaimEntity> MechanicGoldenClaims => Set<MechanicGoldenClaimEntity>(); // ADR-051 Sprint 1 / M2.0: golden-set claims
     public DbSet<MechanicGoldenBggTagEntity> MechanicGoldenBggTags => Set<MechanicGoldenBggTagEntity>(); // ADR-051 Sprint 1 / M2.0: BGG mechanic tags

--- a/apps/api/src/Api/Infrastructure/Migrations/20260711223854_AddMechanicCardFeedback.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260711223854_AddMechanicCardFeedback.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260711223854_AddMechanicCardFeedback")]
+    partial class AddMechanicCardFeedback
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260711223854_AddMechanicCardFeedback.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260711223854_AddMechanicCardFeedback.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddMechanicCardFeedback : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "mechanic_card_feedback",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    card_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    user_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    claim_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    is_positive = table.Column<bool>(type: "boolean", nullable: false),
+                    error_type = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: true),
+                    description = table.Column<string>(type: "character varying(2000)", maxLength: 2000, nullable: true),
+                    suggested_citation = table.Column<string>(type: "character varying(1000)", maxLength: 1000, nullable: true),
+                    created_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    updated_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_mechanic_card_feedback", x => x.id);
+                    table.CheckConstraint("ck_mechanic_card_feedback_error_type", "error_type IS NULL OR error_type IN ('factual', 'ambiguous', 'contradicts_rule')");
+                    table.ForeignKey(
+                        name: "FK_mechanic_card_feedback_mechanic_cards_card_id",
+                        column: x => x.card_id,
+                        principalTable: "mechanic_cards",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_mechanic_card_feedback_user_created",
+                table: "mechanic_card_feedback",
+                columns: new[] { "user_id", "created_at" });
+
+            migrationBuilder.CreateIndex(
+                name: "ux_mechanic_card_feedback_card_user_claim",
+                table: "mechanic_card_feedback",
+                columns: new[] { "card_id", "user_id", "claim_id" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "mechanic_card_feedback");
+        }
+    }
+}

--- a/apps/api/src/Api/Routing/SharedGameCatalog/SharedGameCatalogRequestDtos.cs
+++ b/apps/api/src/Api/Routing/SharedGameCatalog/SharedGameCatalogRequestDtos.cs
@@ -12,6 +12,17 @@ namespace Api.Routing;
 // ========================================
 
 /// <summary>
+/// Request body for <c>POST /mechanic-cards/{cardId}/feedback</c> (#533 ME-M3.1). The card id comes
+/// from the route and the user id from the session, so the body only carries the claim + verdict.
+/// </summary>
+internal record SubmitMechanicCardFeedbackRequest(
+    Guid ClaimId,
+    bool IsPositive,
+    string? ErrorType,
+    string? Description,
+    string? SuggestedCitation);
+
+/// <summary>
 /// Request DTO for creating a shared game.
 /// </summary>
 internal record CreateSharedGameRequest(

--- a/apps/api/src/Api/Routing/SharedGameCatalog/SharedGameCatalogUserEndpoints.cs
+++ b/apps/api/src/Api/Routing/SharedGameCatalog/SharedGameCatalogUserEndpoints.cs
@@ -1,3 +1,4 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Commands.MechanicExtractor;
 using Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
 using Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetGameDocumentsForUser;
 using Api.BoundedContexts.SharedGameCatalog.Application.Queries.MechanicExtractor;
@@ -32,6 +33,47 @@ internal static class SharedGameCatalogUserEndpoints
             .Produces<PublishedMechanicCardDto>()
             .Produces(StatusCodes.Status401Unauthorized)
             .Produces(StatusCodes.Status404NotFound);
+
+        // Submit 👍/👎 feedback on a single claim of a published card (#533 ME-M3.1).
+        group.MapPost("/mechanic-cards/{cardId:guid}/feedback", HandleSubmitCardFeedback)
+            .RequireAuthorization()
+            .WithName("SubmitMechanicCardFeedback")
+            .WithSummary("Submit feedback on a mechanic card claim (Authenticated)")
+            .WithDescription("Records the user's up/down feedback on a claim. Idempotent per (card, user, claim). 201 on create, 200 on update, 404 when the card is missing/suppressed, 429 when the per-day cap is hit.")
+            .Produces(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status201Created)
+            .Produces(StatusCodes.Status401Unauthorized)
+            .Produces(StatusCodes.Status404NotFound)
+            .Produces(StatusCodes.Status429TooManyRequests);
+    }
+
+    private static async Task<IResult> HandleSubmitCardFeedback(
+        Guid cardId,
+        SubmitMechanicCardFeedbackRequest body,
+        IMediator mediator,
+        HttpContext context,
+        CancellationToken ct)
+    {
+        var userIdClaim = context.User.FindFirst("user_id")?.Value
+            ?? context.User.FindFirst(System.Security.Claims.ClaimTypes.NameIdentifier)?.Value;
+
+        if (!Guid.TryParse(userIdClaim, out var userId))
+        {
+            return Results.Unauthorized();
+        }
+
+        var command = new SubmitMechanicCardFeedbackCommand(
+            cardId, userId, body.ClaimId, body.IsPositive, body.ErrorType, body.Description, body.SuggestedCitation);
+        var result = await mediator.Send(command, ct).ConfigureAwait(false);
+
+        return result.Outcome switch
+        {
+            SubmitFeedbackOutcome.Created => Results.StatusCode(StatusCodes.Status201Created),
+            SubmitFeedbackOutcome.Updated => Results.Ok(),
+            SubmitFeedbackOutcome.CardNotFound => Results.NotFound(),
+            SubmitFeedbackOutcome.RateLimited => Results.StatusCode(StatusCodes.Status429TooManyRequests),
+            _ => Results.StatusCode(StatusCodes.Status500InternalServerError)
+        };
     }
 
     private static async Task<IResult> HandleGetPublishedMechanicCard(

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/SubmitMechanicCardFeedbackEndpointIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/SubmitMechanicCardFeedbackEndpointIntegrationTests.cs
@@ -1,0 +1,234 @@
+using System.Net;
+using System.Net.Http.Json;
+
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Infrastructure;
+
+/// <summary>
+/// Integration tests for <c>POST /api/v1/mechanic-cards/{cardId}/feedback</c> (#533 ME-M3.1) against
+/// real PostgreSQL: create (201), idempotent change (200, no duplicate), per-day cap (429), missing
+/// card (404), and the authentication gate (401).
+/// </summary>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class SubmitMechanicCardFeedbackEndpointIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly string _testDbName;
+    private WebApplicationFactory<Program> _factory = null!;
+    private HttpClient _client = null!;
+    private string _userSessionToken = null!;
+    private Guid _userId;
+
+    public SubmitMechanicCardFeedbackEndpointIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+        _testDbName = $"submit_card_feedback_{Guid.NewGuid():N}";
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_testDbName);
+        _factory = IntegrationWebApplicationFactory.Create(connectionString);
+
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            await dbContext.Database.MigrateAsync();
+            var (userId, token) = await TestSessionHelper.CreateUserSessionAsync(dbContext, Guid.NewGuid());
+            _userId = userId;
+            _userSessionToken = token;
+        }
+
+        _client = _factory.CreateClient();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _client?.Dispose();
+        if (_factory is not null)
+        {
+            await _factory.DisposeAsync();
+        }
+        await _fixture.DropIsolatedDatabaseAsync(_testDbName);
+    }
+
+    private sealed record FeedbackBody(Guid ClaimId, bool IsPositive, string? ErrorType, string? Description, string? SuggestedCitation);
+
+    private async Task<HttpResponseMessage> PostFeedbackAsync(Guid cardId, FeedbackBody body, bool authenticated)
+    {
+        if (!authenticated)
+        {
+            return await _client.PostAsJsonAsync($"/api/v1/mechanic-cards/{cardId}/feedback", body);
+        }
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Post, $"/api/v1/mechanic-cards/{cardId}/feedback", _userSessionToken);
+        request.Content = JsonContent.Create(body);
+        return await _client.SendAsync(request);
+    }
+
+    [Fact]
+    public async Task Submit_NewPositiveFeedback_Returns201_AndPersists()
+    {
+        var cardId = await SeedCardAsync();
+        var claimId = Guid.NewGuid();
+
+        var response = await PostFeedbackAsync(cardId, new FeedbackBody(claimId, true, null, null, null), authenticated: true);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created);
+        (await CountFeedbackAsync(cardId)).Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Submit_SameClaimTwice_Returns200_AndDoesNotDuplicate()
+    {
+        var cardId = await SeedCardAsync();
+        var claimId = Guid.NewGuid();
+
+        var first = await PostFeedbackAsync(cardId, new FeedbackBody(claimId, true, null, null, null), authenticated: true);
+        first.StatusCode.Should().Be(HttpStatusCode.Created);
+
+        // Change 👍 → 👎 with an error report: same (card,user,claim) → UPDATE, not a new row.
+        var second = await PostFeedbackAsync(cardId,
+            new FeedbackBody(claimId, false, "factual", "Wrong rule", null), authenticated: true);
+
+        second.StatusCode.Should().Be(HttpStatusCode.OK);
+        (await CountFeedbackAsync(cardId)).Should().Be(1);
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var row = await db.MechanicCardFeedback.AsNoTracking().SingleAsync(f => f.CardId == cardId);
+        row.IsPositive.Should().BeFalse();
+        row.ErrorType.Should().Be("factual");
+    }
+
+    [Fact]
+    public async Task Submit_ExceedingDailyCap_Returns429()
+    {
+        var cardId = await SeedCardAsync();
+
+        // Seed 10 feedback rows today for this user (same card, distinct claims → unique-index safe).
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            for (var i = 0; i < 10; i++)
+            {
+                db.MechanicCardFeedback.Add(new MechanicCardFeedbackEntity
+                {
+                    Id = Guid.NewGuid(),
+                    CardId = cardId,
+                    UserId = _userId,
+                    ClaimId = Guid.NewGuid(),
+                    IsPositive = true,
+                    CreatedAt = DateTime.UtcNow,
+                    UpdatedAt = DateTime.UtcNow
+                });
+            }
+            await db.SaveChangesAsync();
+        }
+
+        // The 11th NEW feedback (a fresh claim) is over the cap.
+        var response = await PostFeedbackAsync(cardId, new FeedbackBody(Guid.NewGuid(), true, null, null, null), authenticated: true);
+
+        response.StatusCode.Should().Be(HttpStatusCode.TooManyRequests);
+    }
+
+    [Fact]
+    public async Task Submit_ForMissingCard_Returns404()
+    {
+        var response = await PostFeedbackAsync(Guid.NewGuid(), new FeedbackBody(Guid.NewGuid(), true, null, null, null), authenticated: true);
+        response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Submit_WithoutSession_Returns401()
+    {
+        var cardId = await SeedCardAsync();
+        var response = await PostFeedbackAsync(cardId, new FeedbackBody(Guid.NewGuid(), true, null, null, null), authenticated: false);
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private async Task<int> CountFeedbackAsync(Guid cardId)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        return await db.MechanicCardFeedback.AsNoTracking().CountAsync(f => f.CardId == cardId);
+    }
+
+    private async Task<Guid> SeedCardAsync()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        var gameId = Guid.NewGuid();
+        db.SharedGames.Add(new SharedGameEntity
+        {
+            Id = gameId,
+            Title = "Catan",
+            Description = "Integration test game",
+            ImageUrl = string.Empty,
+            ThumbnailUrl = string.Empty,
+            YearPublished = 1995,
+            MinPlayers = 3,
+            MaxPlayers = 4,
+            PlayingTimeMinutes = 90,
+            MinAge = 10,
+            Status = 1,
+            CreatedBy = _userId,
+            CreatedAt = DateTime.UtcNow
+        });
+
+        var analysisId = Guid.NewGuid();
+        db.MechanicAnalyses.Add(new MechanicAnalysisEntity
+        {
+            Id = analysisId,
+            SharedGameId = gameId,
+            PdfDocumentId = Guid.NewGuid(),
+            PromptVersion = "mechanic-extractor-v1",
+            Status = (int)Api.BoundedContexts.SharedGameCatalog.Domain.Enums.MechanicAnalysisStatus.Published,
+            CreatedBy = _userId,
+            CreatedAt = DateTime.UtcNow,
+            TotalTokensUsed = 0,
+            EstimatedCostUsd = 0m,
+            ModelUsed = "test-model",
+            Provider = "test-provider",
+            CostCapUsd = 1.00m
+        });
+
+        var cardId = Guid.NewGuid();
+        db.Set<MechanicCardEntity>().Add(new MechanicCardEntity
+        {
+            Id = cardId,
+            SharedGameId = gameId,
+            OriginAnalysisId = analysisId,
+            Origin = "ai_reviewed",
+            Title = "Catan — Comprehension Card",
+            Content = "{}",
+            Version = 1,
+            IsSuppressed = false,
+            ErrorReportsCount = 0,
+            FeedbackScore = null,
+            PublishedAt = DateTime.UtcNow,
+            PublishedBy = _userId,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        });
+
+        await db.SaveChangesAsync();
+        return cardId;
+    }
+}

--- a/apps/web/e2e/mechanic-card-public.spec.ts
+++ b/apps/web/e2e/mechanic-card-public.spec.ts
@@ -128,4 +128,65 @@ test.describe('Public mechanic card — /games/[id]/card', () => {
     // The default Next not-found surface shows a 404 signal.
     await expect(page.getByText(/not found|404|non trovat/i).first()).toBeVisible();
   });
+
+  // ─── Per-claim feedback (ME-M3.1, #533) ───────────────────────────────────────
+  test('👍 posts a positive vote and shows the thanks state; 👎 posts an error report', async ({
+    page,
+  }) => {
+    await seedAuth(page);
+
+    const CLAIM_UP = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+    const CLAIM_DOWN = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+
+    await page.context().route(/\/api\/v1\/games\/[^/]+\/card(\?.*)?$/, async (route: Route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(SAMPLE_CARD),
+      });
+    });
+
+    // Capture the feedback POST bodies. 201 = created.
+    const feedbackBodies: unknown[] = [];
+    await page
+      .context()
+      .route(/\/api\/v1\/mechanic-cards\/[^/]+\/feedback(\?.*)?$/, async (route: Route) => {
+        feedbackBodies.push(route.request().postDataJSON());
+        await route.fulfill({ status: 201, contentType: 'application/json', body: '{}' });
+      });
+
+    await page.goto(`/games/${GAME_ID}/card`, { waitUntil: 'domcontentloaded' });
+    await expect(page.getByTestId('mechanic-card-title')).toHaveText('Catan');
+
+    // 👍 on the first claim → immediate positive vote.
+    await page.getByTestId(`mechanic-card-thumb-up-${CLAIM_UP}`).click();
+    await expect(page.getByTestId(`mechanic-card-feedback-thanks-${CLAIM_UP}`)).toBeVisible();
+    await expect(page.getByTestId(`mechanic-card-thumb-up-${CLAIM_UP}`)).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    );
+    expect(feedbackBodies.at(-1)).toMatchObject({
+      claimId: CLAIM_UP,
+      isPositive: true,
+      errorType: null,
+    });
+
+    // 👎 on the second claim → open the modal, fill it, submit.
+    await page.getByTestId(`mechanic-card-thumb-down-${CLAIM_DOWN}`).click();
+    await expect(page.getByTestId('mechanic-card-report-dialog')).toBeVisible();
+    await page
+      .getByTestId('mechanic-card-report-description')
+      .fill('This contradicts the trading rules.');
+    await page.getByTestId('mechanic-card-report-submit').click();
+
+    // Modal closes + the claim shows the "report received" thanks state.
+    await expect(page.getByTestId('mechanic-card-report-dialog')).toHaveCount(0);
+    await expect(page.getByTestId(`mechanic-card-feedback-thanks-${CLAIM_DOWN}`)).toBeVisible();
+    expect(feedbackBodies.at(-1)).toMatchObject({
+      claimId: CLAIM_DOWN,
+      isPositive: false,
+      errorType: 'factual',
+      description: 'This contradicts the trading rules.',
+    });
+  });
 });

--- a/apps/web/src/components/features/mechanic-card/ClaimFeedbackControls.tsx
+++ b/apps/web/src/components/features/mechanic-card/ClaimFeedbackControls.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+/**
+ * ClaimFeedbackControls — the per-claim 👍 / 👎 feedback row (ME-M3.1, Issue #533).
+ *
+ * Additive under each claim on the public mechanic card. Two labelled, keyboard-
+ * operable buttons:
+ *   - 👍 "Helpful"  → submits a positive vote immediately (parent owns the mutation).
+ *   - 👎 "Report a problem" → asks the parent to open the report-error modal.
+ *
+ * The current vote (`'up' | 'down' | undefined`) is owned by the parent
+ * (MechanicCardView keeps a single card-scoped claimId→vote map). This component
+ * is purely presentational + dispatches intents; it renders a subtle confirmation
+ * once a vote is recorded and reflects the active state on the pressed button.
+ *
+ * The whole row is `print:hidden` — a printed reference card shouldn't show
+ * interactive controls.
+ */
+
+import { type ReactElement } from 'react';
+
+import { ThumbsDown, ThumbsUp } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+
+export type ClaimVote = 'up' | 'down';
+
+export interface ClaimFeedbackControlsProps {
+  /** The claim this row belongs to (used for stable test ids + labels). */
+  readonly claimId: string;
+  /** The current recorded vote for this claim, if any. */
+  readonly vote: ClaimVote | undefined;
+  /** True while a submission for THIS claim is in flight — disables the buttons. */
+  readonly isPending: boolean;
+  /** Record a 👍 (submit immediately). */
+  readonly onThumbUp: () => void;
+  /** Request the report-error modal for a 👎. */
+  readonly onThumbDown: () => void;
+}
+
+export function ClaimFeedbackControls({
+  claimId,
+  vote,
+  isPending,
+  onThumbUp,
+  onThumbDown,
+}: ClaimFeedbackControlsProps): ReactElement {
+  const upActive = vote === 'up';
+  const downActive = vote === 'down';
+
+  return (
+    <div
+      data-slot="mechanic-card-claim-feedback"
+      className="mt-1 flex items-center gap-2 print:hidden"
+    >
+      <span className="sr-only">Was this claim helpful?</span>
+
+      <button
+        type="button"
+        onClick={onThumbUp}
+        disabled={isPending}
+        aria-pressed={upActive}
+        aria-label="Helpful"
+        data-testid={`mechanic-card-thumb-up-${claimId}`}
+        className={cn(
+          'inline-flex h-8 w-8 items-center justify-center rounded-full border transition-colors',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+          'disabled:cursor-not-allowed disabled:opacity-50',
+          upActive
+            ? 'border-entity-game/40 bg-entity-game/15 text-entity-game'
+            : 'border-border bg-transparent text-muted-foreground hover:bg-muted hover:text-foreground'
+        )}
+      >
+        <ThumbsUp className="h-4 w-4" aria-hidden="true" />
+      </button>
+
+      <button
+        type="button"
+        onClick={onThumbDown}
+        disabled={isPending}
+        aria-pressed={downActive}
+        aria-label="Report a problem"
+        data-testid={`mechanic-card-thumb-down-${claimId}`}
+        className={cn(
+          'inline-flex h-8 w-8 items-center justify-center rounded-full border transition-colors',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+          'disabled:cursor-not-allowed disabled:opacity-50',
+          downActive
+            ? 'border-destructive/40 bg-destructive/10 text-destructive'
+            : 'border-border bg-transparent text-muted-foreground hover:bg-muted hover:text-foreground'
+        )}
+      >
+        <ThumbsDown className="h-4 w-4" aria-hidden="true" />
+      </button>
+
+      {/* Confirmation copy — announced politely once a vote lands. */}
+      {vote !== undefined && (
+        <span
+          role="status"
+          data-testid={`mechanic-card-feedback-thanks-${claimId}`}
+          className="text-xs font-medium text-muted-foreground"
+        >
+          {upActive ? 'Thanks!' : 'Thanks — report received'}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/features/mechanic-card/MechanicCardView.tsx
+++ b/apps/web/src/components/features/mechanic-card/MechanicCardView.tsx
@@ -28,10 +28,13 @@ import { useState, type ReactElement } from 'react';
 
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
+import { toast } from 'sonner';
 
 import { MechanicAnalysisFooterAttribution } from '@/components/admin/mechanic-extractor/MechanicAnalysisFooterAttribution';
 import { Badge } from '@/components/ui/data-display/badge';
+import { useSubmitMechanicCardFeedback } from '@/hooks/mutations/useSubmitMechanicCardFeedback';
 import { useMechanicCard } from '@/hooks/queries/useMechanicCard';
+import { NotFoundError, RateLimitError } from '@/lib/api';
 import { MECHANIC_SECTION_LABELS, MechanicSection } from '@/lib/api/schemas/mechanic-card.schemas';
 import type {
   PublishedMechanicCardDto,
@@ -39,8 +42,10 @@ import type {
   PublishedMechanicSectionDto,
 } from '@/lib/api/schemas/mechanic-card.schemas';
 
+import { ClaimFeedbackControls, type ClaimVote } from './ClaimFeedbackControls';
 import { MechanicCitationBadge } from './MechanicCitationBadge';
 import { MechanicCitationPanel } from './MechanicCitationPanel';
+import { ReportErrorDialog, type ReportErrorSubmission } from './ReportErrorDialog';
 
 const HOW_IT_WORKS_HREF = '/how-it-works/game-comprehension';
 const TAKEDOWN_HREF = '/legal/takedown';
@@ -128,14 +133,31 @@ function ErrorShell({ onRetry }: { onRetry: () => void }): ReactElement {
   );
 }
 
+// ─── Feedback wiring (ME-M3.1, #533) ─────────────────────────────────────────
+
+/**
+ * The per-claim feedback surface, threaded from the card view down to each claim.
+ * Kept as one object so `SectionBlock` doesn't have to prop-drill five callbacks.
+ */
+interface ClaimFeedbackApi {
+  /** Current vote per claim id (`undefined` = not yet voted this session). */
+  readonly votes: Readonly<Record<string, ClaimVote>>;
+  /** The claim id whose submission is currently in flight, if any. */
+  readonly pendingClaimId: string | null;
+  readonly onThumbUp: (claimId: string) => void;
+  readonly onThumbDown: (claimId: string) => void;
+}
+
 // ─── Presentational pieces ───────────────────────────────────────────────────
 
 function ClaimItem({
   claim,
   onOpenCitation,
+  feedback,
 }: {
   claim: PublishedMechanicCardDto['sections'][number]['claims'][number];
   onOpenCitation: (citation: PublishedMechanicCitationDto) => void;
+  feedback: ClaimFeedbackApi;
 }): ReactElement {
   return (
     <li
@@ -156,6 +178,13 @@ function ClaimItem({
           ))}
         </div>
       )}
+      <ClaimFeedbackControls
+        claimId={claim.id}
+        vote={feedback.votes[claim.id]}
+        isPending={feedback.pendingClaimId === claim.id}
+        onThumbUp={() => feedback.onThumbUp(claim.id)}
+        onThumbDown={() => feedback.onThumbDown(claim.id)}
+      />
     </li>
   );
 }
@@ -164,10 +193,12 @@ function SectionBlock({
   section,
   index,
   onOpenCitation,
+  feedback,
 }: {
   section: PublishedMechanicSectionDto;
   index: number;
   onOpenCitation: (citation: PublishedMechanicCitationDto) => void;
+  feedback: ClaimFeedbackApi;
 }): ReactElement {
   const label = sectionLabel(section.section);
   return (
@@ -195,7 +226,12 @@ function SectionBlock({
       </div>
       <ul className="flex flex-col">
         {section.claims.map(claim => (
-          <ClaimItem key={claim.id} claim={claim} onOpenCitation={onOpenCitation} />
+          <ClaimItem
+            key={claim.id}
+            claim={claim}
+            onOpenCitation={onOpenCitation}
+            feedback={feedback}
+          />
         ))}
       </ul>
     </section>
@@ -210,9 +246,99 @@ export function MechanicCardView({ gameId }: MechanicCardViewProps): ReactElemen
   const [activeCitation, setActiveCitation] = useState<PublishedMechanicCitationDto | null>(null);
   const [panelOpen, setPanelOpen] = useState(false);
 
+  // ── Per-claim feedback state (ME-M3.1, #533) ──────────────────────────────
+  // A single card-scoped map: claimId → recorded vote this session. No global store.
+  const [votes, setVotes] = useState<Record<string, ClaimVote>>({});
+  // Which claim currently has a submission in flight (disables just that row).
+  const [pendingClaimId, setPendingClaimId] = useState<string | null>(null);
+  // Which claim's "Report error" modal is open (null = closed).
+  const [reportClaimId, setReportClaimId] = useState<string | null>(null);
+  const submitFeedback = useSubmitMechanicCardFeedback();
+
   const openCitation = (citation: PublishedMechanicCitationDto): void => {
     setActiveCitation(citation);
     setPanelOpen(true);
+  };
+
+  // Map a failed feedback submission to a user-facing toast. Returns nothing —
+  // callers decide whether to mark the vote as recorded (they do NOT on failure).
+  const notifyFeedbackError = (error: unknown): void => {
+    if (error instanceof RateLimitError) {
+      toast.error('You’ve reached today’s report limit. Please try again tomorrow.');
+      return;
+    }
+    if (error instanceof NotFoundError) {
+      toast.error('This card is no longer available.');
+      return;
+    }
+    toast.error('Something went wrong. Please try again.');
+  };
+
+  // 👍 — submit a positive vote immediately (errorType MUST be null).
+  const handleThumbUp = (claimId: string): void => {
+    // `data` is non-null past the guards below, but this closure is created before
+    // them at first render; the button only mounts once `card` exists, so read it
+    // defensively.
+    const cardId = data?.cardId;
+    if (!cardId || pendingClaimId !== null) return;
+    setPendingClaimId(claimId);
+    submitFeedback.mutate(
+      {
+        cardId,
+        body: {
+          claimId,
+          isPositive: true,
+          errorType: null,
+          description: null,
+          suggestedCitation: null,
+        },
+      },
+      {
+        onSuccess: () => setVotes(prev => ({ ...prev, [claimId]: 'up' })),
+        onError: notifyFeedbackError,
+        onSettled: () => setPendingClaimId(null),
+      }
+    );
+  };
+
+  // 👎 — open the report-error modal for this claim (submission happens on modal submit).
+  const handleThumbDown = (claimId: string): void => {
+    setReportClaimId(claimId);
+  };
+
+  // Modal submit → post the negative feedback with the collected type/description.
+  const handleReportSubmit = async (submission: ReportErrorSubmission): Promise<void> => {
+    const cardId = data?.cardId;
+    if (!cardId || reportClaimId === null) return;
+    const claimId = reportClaimId;
+    setPendingClaimId(claimId);
+    try {
+      await submitFeedback.mutateAsync({
+        cardId,
+        body: {
+          claimId,
+          isPositive: false,
+          errorType: submission.errorType,
+          description: submission.description,
+          suggestedCitation: submission.suggestedCitation,
+        },
+      });
+      // Success → mark the vote + close the modal.
+      setVotes(prev => ({ ...prev, [claimId]: 'down' }));
+      setReportClaimId(null);
+    } catch (error) {
+      // Keep the modal open so the user can retry; do NOT mark as submitted.
+      notifyFeedbackError(error);
+    } finally {
+      setPendingClaimId(null);
+    }
+  };
+
+  const feedback: ClaimFeedbackApi = {
+    votes,
+    pendingClaimId,
+    onThumbUp: handleThumbUp,
+    onThumbDown: handleThumbDown,
   };
 
   if (isLoading) {
@@ -286,6 +412,7 @@ export function MechanicCardView({ gameId }: MechanicCardViewProps): ReactElemen
                 section={section}
                 index={index}
                 onOpenCitation={openCitation}
+                feedback={feedback}
               />
             ))}
           </div>
@@ -316,6 +443,14 @@ export function MechanicCardView({ gameId }: MechanicCardViewProps): ReactElemen
         card={card}
         isOpen={panelOpen}
         onClose={() => setPanelOpen(false)}
+      />
+
+      {/* One report-error modal drives every 👎; the target claim is `reportClaimId`. */}
+      <ReportErrorDialog
+        open={reportClaimId !== null}
+        onClose={() => setReportClaimId(null)}
+        onSubmit={handleReportSubmit}
+        isSubmitting={pendingClaimId !== null && pendingClaimId === reportClaimId}
       />
     </CardShell>
   );

--- a/apps/web/src/components/features/mechanic-card/ReportErrorDialog.tsx
+++ b/apps/web/src/components/features/mechanic-card/ReportErrorDialog.tsx
@@ -1,0 +1,180 @@
+'use client';
+
+/**
+ * ReportErrorDialog — the "Report error" modal opened by a 👎 on a claim
+ * (ME-M3.1, Issue #533).
+ *
+ * Collects the required error **type** (factual | ambiguous | contradicts_rule),
+ * an optional free-text **description**, and an optional **suggested citation**
+ * ("citation to the correct rule"), then posts a 👎 feedback payload.
+ *
+ * The dialog is a controlled component: the parent owns `open` + the target
+ * `claimId`, and the parent runs the actual mutation via `onSubmit`. On a failed
+ * submit the parent keeps `open` true so the user can retry (see MechanicCardView);
+ * on success the parent closes it. Focus-trap + Esc + labelled controls come from
+ * the shared Radix Dialog primitive.
+ */
+
+import { useEffect, useState, type ReactElement } from 'react';
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/overlays/dialog';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/overlays/select';
+import { Button } from '@/components/ui/primitives/button';
+import { Input } from '@/components/ui/primitives/input';
+import { Label } from '@/components/ui/primitives/label';
+import { Textarea } from '@/components/ui/primitives/textarea';
+import {
+  MECHANIC_CARD_ERROR_TYPES,
+  MECHANIC_CARD_ERROR_TYPE_LABELS,
+  type MechanicCardErrorType,
+} from '@/lib/api/schemas/mechanic-card-feedback.schemas';
+
+export interface ReportErrorSubmission {
+  errorType: MechanicCardErrorType;
+  description: string | null;
+  suggestedCitation: string | null;
+}
+
+export interface ReportErrorDialogProps {
+  /** Whether the dialog is open (parent-controlled). */
+  readonly open: boolean;
+  /** Called when the dialog requests to close (Esc, overlay, ✕, or Cancel). */
+  readonly onClose: () => void;
+  /** Runs the 👎 submission. Resolves on success (parent then closes the dialog). */
+  readonly onSubmit: (submission: ReportErrorSubmission) => Promise<void>;
+  /** True while the submit mutation is in flight — disables the controls. */
+  readonly isSubmitting: boolean;
+}
+
+const DEFAULT_ERROR_TYPE: MechanicCardErrorType = 'factual';
+
+export function ReportErrorDialog({
+  open,
+  onClose,
+  onSubmit,
+  isSubmitting,
+}: ReportErrorDialogProps): ReactElement {
+  const [errorType, setErrorType] = useState<MechanicCardErrorType>(DEFAULT_ERROR_TYPE);
+  const [description, setDescription] = useState('');
+  const [suggestedCitation, setSuggestedCitation] = useState('');
+
+  // Reset the form whenever the dialog (re)opens so a previous claim's text never
+  // bleeds into the next report.
+  useEffect(() => {
+    if (open) {
+      setErrorType(DEFAULT_ERROR_TYPE);
+      setDescription('');
+      setSuggestedCitation('');
+    }
+  }, [open]);
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>): void => {
+    event.preventDefault();
+    void onSubmit({
+      errorType,
+      description: description.trim() === '' ? null : description.trim(),
+      suggestedCitation: suggestedCitation.trim() === '' ? null : suggestedCitation.trim(),
+    });
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={next => !next && onClose()}>
+      <DialogContent
+        data-slot="mechanic-card-report-dialog"
+        data-testid="mechanic-card-report-dialog"
+        className="max-w-md"
+      >
+        <DialogHeader>
+          <DialogTitle className="font-display text-lg font-extrabold text-foreground">
+            Report an error
+          </DialogTitle>
+          <DialogDescription>
+            Tell us what looks wrong with this claim. Your report helps us correct the card.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="mechanic-card-report-type">Type of problem</Label>
+            <Select
+              value={errorType}
+              onValueChange={value => setErrorType(value as MechanicCardErrorType)}
+              disabled={isSubmitting}
+            >
+              <SelectTrigger
+                id="mechanic-card-report-type"
+                data-testid="mechanic-card-report-type"
+                aria-label="Type of problem"
+              >
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {MECHANIC_CARD_ERROR_TYPES.map(type => (
+                  <SelectItem key={type} value={type}>
+                    {MECHANIC_CARD_ERROR_TYPE_LABELS[type]}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="mechanic-card-report-description">Description</Label>
+            <Textarea
+              id="mechanic-card-report-description"
+              data-testid="mechanic-card-report-description"
+              value={description}
+              onChange={event => setDescription(event.target.value)}
+              disabled={isSubmitting}
+              rows={4}
+              placeholder="What's wrong, and what should it say instead?"
+            />
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="mechanic-card-report-citation">
+              Citation to the correct rule{' '}
+              <span className="font-normal text-muted-foreground">(optional)</span>
+            </Label>
+            <Input
+              id="mechanic-card-report-citation"
+              data-testid="mechanic-card-report-citation"
+              value={suggestedCitation}
+              onChange={event => setSuggestedCitation(event.target.value)}
+              disabled={isSubmitting}
+              placeholder="e.g. Rulebook p. 12, “Trading”"
+            />
+          </div>
+
+          <DialogFooter className="gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={onClose}
+              disabled={isSubmitting}
+              data-testid="mechanic-card-report-cancel"
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isSubmitting} data-testid="mechanic-card-report-submit">
+              {isSubmitting ? 'Sending…' : 'Send report'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/features/mechanic-card/__tests__/MechanicCardView.test.tsx
+++ b/apps/web/src/components/features/mechanic-card/__tests__/MechanicCardView.test.tsx
@@ -1,7 +1,8 @@
 /** @vitest-environment jsdom */
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { NotFoundError, RateLimitError } from '@/lib/api';
 import {
   MechanicSection,
   type PublishedMechanicCardDto,
@@ -37,6 +38,26 @@ const cardMockState: MockCardReturn = {
 };
 vi.mock('@/hooks/queries/useMechanicCard', () => ({
   useMechanicCard: () => cardMockState,
+}));
+
+// ─── Mock the feedback mutation hook (#533) ────────────────────────────────────
+// `mutate` (👍) resolves via onSuccess; `mutateAsync` (👎) resolves/rejects.
+// Tests swap the implementation to exercise 200/429 paths.
+const feedbackMutate = vi.hoisted(() => vi.fn());
+const feedbackMutateAsync = vi.hoisted(() => vi.fn());
+vi.mock('@/hooks/mutations/useSubmitMechanicCardFeedback', () => ({
+  useSubmitMechanicCardFeedback: () => ({
+    mutate: feedbackMutate,
+    mutateAsync: feedbackMutateAsync,
+    isPending: false,
+  }),
+}));
+
+// ─── Mock sonner toasts ────────────────────────────────────────────────────────
+const toastError = vi.hoisted(() => vi.fn());
+const toastSuccess = vi.hoisted(() => vi.fn());
+vi.mock('sonner', () => ({
+  toast: { error: toastError, success: toastSuccess },
 }));
 
 // ─── notFound spy (called on data === null) ────────────────────────────────────
@@ -109,6 +130,10 @@ describe('MechanicCardView', () => {
     cardMockState.refetch = vi.fn();
     mockPanel.mockClear();
     notFoundSpy.mockClear();
+    feedbackMutate.mockReset();
+    feedbackMutateAsync.mockReset();
+    toastError.mockReset();
+    toastSuccess.mockReset();
   });
 
   it('renders game name, section labels (Faq → FAQ) and claims', () => {
@@ -202,5 +227,138 @@ describe('MechanicCardView', () => {
       'NEXT_NOT_FOUND'
     );
     expect(notFoundSpy).toHaveBeenCalled();
+  });
+
+  // ─── Per-claim feedback (ME-M3.1, #533) ──────────────────────────────────────
+  describe('per-claim feedback', () => {
+    const CLAIM_UP = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+
+    it('👍 posts isPositive:true (errorType null) and shows the thanks state', () => {
+      // The 👍 path uses mutate(vars, { onSuccess }) — invoke onSuccess to simulate 201/200.
+      feedbackMutate.mockImplementation(
+        (_vars: unknown, opts?: { onSuccess?: () => void; onSettled?: () => void }) => {
+          opts?.onSuccess?.();
+          opts?.onSettled?.();
+        }
+      );
+      cardMockState.data = SAMPLE_CARD;
+      render(<MechanicCardView gameId={SAMPLE_CARD.sharedGameId} />);
+
+      fireEvent.click(screen.getByTestId(`mechanic-card-thumb-up-${CLAIM_UP}`));
+
+      expect(feedbackMutate).toHaveBeenCalledWith(
+        {
+          cardId: SAMPLE_CARD.cardId,
+          body: {
+            claimId: CLAIM_UP,
+            isPositive: true,
+            errorType: null,
+            description: null,
+            suggestedCitation: null,
+          },
+        },
+        expect.any(Object)
+      );
+
+      // The thumb-up button reflects the active vote + a "thanks" confirmation shows.
+      expect(screen.getByTestId(`mechanic-card-thumb-up-${CLAIM_UP}`)).toHaveAttribute(
+        'aria-pressed',
+        'true'
+      );
+      expect(screen.getByTestId(`mechanic-card-feedback-thanks-${CLAIM_UP}`)).toHaveTextContent(
+        /thanks/i
+      );
+    });
+
+    it('👎 opens the report modal and submitting posts the negative payload', async () => {
+      feedbackMutateAsync.mockResolvedValue(undefined);
+      cardMockState.data = SAMPLE_CARD;
+      render(<MechanicCardView gameId={SAMPLE_CARD.sharedGameId} />);
+
+      // Modal is closed initially.
+      expect(screen.queryByTestId('mechanic-card-report-dialog')).not.toBeInTheDocument();
+
+      fireEvent.click(screen.getByTestId(`mechanic-card-thumb-down-${CLAIM_UP}`));
+
+      // Modal opens (focus-trapped Radix dialog).
+      expect(await screen.findByTestId('mechanic-card-report-dialog')).toBeInTheDocument();
+
+      // Fill the description (type defaults to 'factual') and submit.
+      fireEvent.change(screen.getByTestId('mechanic-card-report-description'), {
+        target: { value: 'Wrong page.' },
+      });
+      fireEvent.click(screen.getByTestId('mechanic-card-report-submit'));
+
+      await waitFor(() =>
+        expect(feedbackMutateAsync).toHaveBeenCalledWith({
+          cardId: SAMPLE_CARD.cardId,
+          body: {
+            claimId: CLAIM_UP,
+            isPositive: false,
+            errorType: 'factual',
+            description: 'Wrong page.',
+            suggestedCitation: null,
+          },
+        })
+      );
+
+      // On success: modal closes + the claim shows the "report received" thanks state.
+      await waitFor(() =>
+        expect(screen.queryByTestId('mechanic-card-report-dialog')).not.toBeInTheDocument()
+      );
+      expect(screen.getByTestId(`mechanic-card-thumb-down-${CLAIM_UP}`)).toHaveAttribute(
+        'aria-pressed',
+        'true'
+      );
+      expect(screen.getByTestId(`mechanic-card-feedback-thanks-${CLAIM_UP}`)).toHaveTextContent(
+        /report received/i
+      );
+    });
+
+    it('👍 on 429 shows the limit toast and does NOT mark the claim submitted', () => {
+      feedbackMutate.mockImplementation(
+        (_vars: unknown, opts?: { onError?: (e: unknown) => void; onSettled?: () => void }) => {
+          opts?.onError?.(new RateLimitError({ message: 'rate limited', endpoint: '/feedback' }));
+          opts?.onSettled?.();
+        }
+      );
+      cardMockState.data = SAMPLE_CARD;
+      render(<MechanicCardView gameId={SAMPLE_CARD.sharedGameId} />);
+
+      fireEvent.click(screen.getByTestId(`mechanic-card-thumb-up-${CLAIM_UP}`));
+
+      // Limit toast shown.
+      expect(toastError).toHaveBeenCalledWith(expect.stringMatching(/limit/i));
+      // NOT marked as voted → no thanks state, button not pressed.
+      expect(
+        screen.queryByTestId(`mechanic-card-feedback-thanks-${CLAIM_UP}`)
+      ).not.toBeInTheDocument();
+      expect(screen.getByTestId(`mechanic-card-thumb-up-${CLAIM_UP}`)).toHaveAttribute(
+        'aria-pressed',
+        'false'
+      );
+    });
+
+    it('👎 submit failure keeps the modal open and toasts (404 → card gone)', async () => {
+      feedbackMutateAsync.mockRejectedValue(
+        new NotFoundError({ message: 'gone', endpoint: '/feedback' })
+      );
+      cardMockState.data = SAMPLE_CARD;
+      render(<MechanicCardView gameId={SAMPLE_CARD.sharedGameId} />);
+
+      fireEvent.click(screen.getByTestId(`mechanic-card-thumb-down-${CLAIM_UP}`));
+      expect(await screen.findByTestId('mechanic-card-report-dialog')).toBeInTheDocument();
+
+      fireEvent.click(screen.getByTestId('mechanic-card-report-submit'));
+
+      await waitFor(() =>
+        expect(toastError).toHaveBeenCalledWith(expect.stringMatching(/no longer available/i))
+      );
+      // Modal stays open so the user can retry.
+      expect(screen.getByTestId('mechanic-card-report-dialog')).toBeInTheDocument();
+      expect(
+        screen.queryByTestId(`mechanic-card-feedback-thanks-${CLAIM_UP}`)
+      ).not.toBeInTheDocument();
+    });
   });
 });

--- a/apps/web/src/components/features/mechanic-card/index.ts
+++ b/apps/web/src/components/features/mechanic-card/index.ts
@@ -13,3 +13,15 @@ export type { MechanicCitationBadgeProps } from '@/components/features/mechanic-
 
 export { MechanicCitationPanel } from '@/components/features/mechanic-card/MechanicCitationPanel';
 export type { MechanicCitationPanelProps } from '@/components/features/mechanic-card/MechanicCitationPanel';
+
+export { ClaimFeedbackControls } from '@/components/features/mechanic-card/ClaimFeedbackControls';
+export type {
+  ClaimFeedbackControlsProps,
+  ClaimVote,
+} from '@/components/features/mechanic-card/ClaimFeedbackControls';
+
+export { ReportErrorDialog } from '@/components/features/mechanic-card/ReportErrorDialog';
+export type {
+  ReportErrorDialogProps,
+  ReportErrorSubmission,
+} from '@/components/features/mechanic-card/ReportErrorDialog';

--- a/apps/web/src/hooks/mutations/__tests__/useSubmitMechanicCardFeedback.test.tsx
+++ b/apps/web/src/hooks/mutations/__tests__/useSubmitMechanicCardFeedback.test.tsx
@@ -1,0 +1,145 @@
+/** @vitest-environment jsdom */
+import type { JSX, ReactNode } from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { api, NotFoundError, RateLimitError } from '@/lib/api';
+
+import { useSubmitMechanicCardFeedback } from '../useSubmitMechanicCardFeedback';
+
+function makeWrapper(qc: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }): JSX.Element {
+    return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+  };
+}
+
+const CARD_ID = '11111111-1111-4111-8111-111111111111';
+const CLAIM_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+
+describe('useSubmitMechanicCardFeedback (ME-M3.1 #533)', () => {
+  it('posts a positive vote (errorType null) via the client', async () => {
+    const spy = vi
+      .spyOn(api.sharedGames, 'submitMechanicCardFeedback')
+      .mockResolvedValue(undefined);
+    const qc = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    const { result } = renderHook(() => useSubmitMechanicCardFeedback(), {
+      wrapper: makeWrapper(qc),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        cardId: CARD_ID,
+        body: {
+          claimId: CLAIM_ID,
+          isPositive: true,
+          errorType: null,
+          description: null,
+          suggestedCitation: null,
+        },
+      });
+    });
+
+    expect(spy).toHaveBeenCalledWith(CARD_ID, {
+      claimId: CLAIM_ID,
+      isPositive: true,
+      errorType: null,
+      description: null,
+      suggestedCitation: null,
+    });
+    spy.mockRestore();
+  });
+
+  it('posts a negative report with type + description', async () => {
+    const spy = vi
+      .spyOn(api.sharedGames, 'submitMechanicCardFeedback')
+      .mockResolvedValue(undefined);
+    const qc = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    const { result } = renderHook(() => useSubmitMechanicCardFeedback(), {
+      wrapper: makeWrapper(qc),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        cardId: CARD_ID,
+        body: {
+          claimId: CLAIM_ID,
+          isPositive: false,
+          errorType: 'factual',
+          description: 'This is wrong.',
+          suggestedCitation: 'p. 12',
+        },
+      });
+    });
+
+    expect(spy).toHaveBeenCalledWith(CARD_ID, {
+      claimId: CLAIM_ID,
+      isPositive: false,
+      errorType: 'factual',
+      description: 'This is wrong.',
+      suggestedCitation: 'p. 12',
+    });
+    spy.mockRestore();
+  });
+
+  it('surfaces a RateLimitError (429) on the mutation', async () => {
+    const spy = vi
+      .spyOn(api.sharedGames, 'submitMechanicCardFeedback')
+      .mockRejectedValue(new RateLimitError({ message: 'rate limited', endpoint: '/feedback' }));
+    const qc = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    const { result } = renderHook(() => useSubmitMechanicCardFeedback(), {
+      wrapper: makeWrapper(qc),
+    });
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync({
+          cardId: CARD_ID,
+          body: {
+            claimId: CLAIM_ID,
+            isPositive: true,
+            errorType: null,
+            description: null,
+            suggestedCitation: null,
+          },
+        });
+      } catch {
+        /* expected */
+      }
+    });
+
+    await waitFor(() => expect(result.current.error).toBeInstanceOf(RateLimitError));
+    spy.mockRestore();
+  });
+
+  it('surfaces a NotFoundError (404) on the mutation', async () => {
+    const spy = vi
+      .spyOn(api.sharedGames, 'submitMechanicCardFeedback')
+      .mockRejectedValue(new NotFoundError({ message: 'gone', endpoint: '/feedback' }));
+    const qc = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    const { result } = renderHook(() => useSubmitMechanicCardFeedback(), {
+      wrapper: makeWrapper(qc),
+    });
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync({
+          cardId: CARD_ID,
+          body: {
+            claimId: CLAIM_ID,
+            isPositive: true,
+            errorType: null,
+            description: null,
+            suggestedCitation: null,
+          },
+        });
+      } catch {
+        /* expected */
+      }
+    });
+
+    await waitFor(() => expect(result.current.error).toBeInstanceOf(NotFoundError));
+    spy.mockRestore();
+  });
+});

--- a/apps/web/src/hooks/mutations/useSubmitMechanicCardFeedback.ts
+++ b/apps/web/src/hooks/mutations/useSubmitMechanicCardFeedback.ts
@@ -1,0 +1,35 @@
+/**
+ * useSubmitMechanicCardFeedback — mutation for per-claim 👍/👎 feedback on a
+ * published mechanic card (ME-M3.1, Issue #533).
+ *
+ * Wraps `api.sharedGames.submitMechanicCardFeedback(cardId, body)`:
+ *   - resolves on 201 (created) / 200 (updated — idempotent vote change)
+ *   - rejects with a typed `ApiError` on 404 / 429 / 401 / 5xx so the caller can
+ *     branch on `instanceof NotFoundError` / `instanceof RateLimitError`
+ *
+ * The published card DTO carries no feedback state (votes are tracked client-side
+ * for the current session), so there is deliberately NO query invalidation here —
+ * re-fetching the whole `staleTime: 10min` card on every vote would be wasteful.
+ */
+import { useMutation, type UseMutationResult } from '@tanstack/react-query';
+
+import { api } from '@/lib/api';
+import type { SubmitMechanicCardFeedbackBody } from '@/lib/api/schemas/mechanic-card-feedback.schemas';
+
+export interface SubmitMechanicCardFeedbackInput {
+  /** Published card UUID (the card the claim belongs to). */
+  cardId: string;
+  body: SubmitMechanicCardFeedbackBody;
+}
+
+export type UseSubmitMechanicCardFeedbackResult = UseMutationResult<
+  void,
+  Error,
+  SubmitMechanicCardFeedbackInput
+>;
+
+export function useSubmitMechanicCardFeedback(): UseSubmitMechanicCardFeedbackResult {
+  return useMutation<void, Error, SubmitMechanicCardFeedbackInput>({
+    mutationFn: ({ cardId, body }) => api.sharedGames.submitMechanicCardFeedback(cardId, body),
+  });
+}

--- a/apps/web/src/lib/api/clients/sharedGamesClient.ts
+++ b/apps/web/src/lib/api/clients/sharedGamesClient.ts
@@ -7,7 +7,7 @@
 
 import { z } from 'zod';
 
-import { isNotFoundError } from '../core/errors';
+import { createApiError, isNotFoundError } from '../core/errors';
 import { type HttpClient, downloadFile, getApiBase } from '../core/httpClient';
 import {
   agentDefinitionDtoSchema,
@@ -15,6 +15,10 @@ import {
   type AgentDefinitionDto,
   type KbCardDto,
 } from '../schemas/agent-definitions.schemas';
+import {
+  MECHANIC_CARD_FEEDBACK_ROUTES,
+  type SubmitMechanicCardFeedbackBody,
+} from '../schemas/mechanic-card-feedback.schemas';
 import {
   MECHANIC_CARD_ROUTES,
   PublishedMechanicCardDtoSchema,
@@ -1139,6 +1143,38 @@ export function createSharedGamesClient({ httpClient }: CreateSharedGamesClientP
           return null;
         }
         throw error;
+      }
+    },
+
+    /**
+     * Submit per-claim feedback on a published mechanic card (AUTHENTICATED).
+     * POST /api/v1/mechanic-cards/{cardId}/feedback — ME-M3.1, Issue #533.
+     *
+     * The endpoint is status-only (201 created · 200 updated · 404 · 429 · 401)
+     * so we don't parse a response body. Non-2xx responses are converted to the
+     * typed `ApiError` subclass (`NotFoundError` / `RateLimitError` / …) via
+     * `createApiError` so callers can branch on `instanceof`. A raw fetch is used
+     * (rather than `httpClient.post`) because a status-only 200/201 may carry an
+     * empty body, which `response.json()` would choke on.
+     *
+     * `errorType` is meaningful only for a 👎; it MUST be null for a 👍.
+     *
+     * @param cardId - Published card UUID (the card the claim belongs to)
+     * @param body - Feedback payload
+     */
+    async submitMechanicCardFeedback(
+      cardId: string,
+      body: SubmitMechanicCardFeedbackBody
+    ): Promise<void> {
+      const path = MECHANIC_CARD_FEEDBACK_ROUTES.feedback(cardId);
+      const response = await fetch(`${getApiBase()}${path}`, {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      if (!response.ok) {
+        throw await createApiError(path, response);
       }
     },
 

--- a/apps/web/src/lib/api/schemas/mechanic-card-feedback.schemas.ts
+++ b/apps/web/src/lib/api/schemas/mechanic-card-feedback.schemas.ts
@@ -1,0 +1,53 @@
+/**
+ * Per-claim mechanic-card feedback schemas (ME-M3.1, Issue #533).
+ *
+ * Backend endpoint (locked contract, already implemented):
+ *   POST /api/v1/mechanic-cards/{cardId}/feedback   → authenticated
+ *
+ * Request body (camelCase JSON):
+ *   { claimId, isPositive, errorType, description, suggestedCitation }
+ *
+ * `errorType` is meaningful ONLY for a 👎 (isPositive === false) and MUST be
+ * `null` for a 👍. `description` + `suggestedCitation` are always optional.
+ *
+ * Responses (status-only, no body needed):
+ *   201 → created (first vote for this (card,user,claim))
+ *   200 → updated (idempotent — the user changed their vote)
+ *   404 → card missing or suppressed/taken down
+ *   429 → per-day cap reached (10 new/day)
+ *   401 → unauthenticated
+ */
+import { z } from 'zod';
+
+/** The three "report error" categories a 👎 can carry. */
+export const MECHANIC_CARD_ERROR_TYPES = ['factual', 'ambiguous', 'contradicts_rule'] as const;
+export type MechanicCardErrorType = (typeof MECHANIC_CARD_ERROR_TYPES)[number];
+
+/** Human labels for the report-error type select (matches the card's English copy). */
+export const MECHANIC_CARD_ERROR_TYPE_LABELS: Record<MechanicCardErrorType, string> = {
+  factual: 'Factual error',
+  ambiguous: 'Ambiguous',
+  contradicts_rule: 'Contradicts a rule',
+};
+
+export const MechanicCardErrorTypeSchema = z.enum(MECHANIC_CARD_ERROR_TYPES);
+
+/**
+ * Request body for POST /api/v1/mechanic-cards/{cardId}/feedback.
+ * Kept as a plain type (the endpoint is status-only, there is no response DTO to
+ * parse) but mirrored by a zod schema so tests / defensive callers can validate.
+ */
+export const SubmitMechanicCardFeedbackBodySchema = z.object({
+  claimId: z.string().uuid(),
+  isPositive: z.boolean(),
+  /** Only for 👎; MUST be null for 👍. */
+  errorType: MechanicCardErrorTypeSchema.nullable(),
+  description: z.string().nullable(),
+  suggestedCitation: z.string().nullable(),
+});
+export type SubmitMechanicCardFeedbackBody = z.infer<typeof SubmitMechanicCardFeedbackBodySchema>;
+
+export const MECHANIC_CARD_FEEDBACK_ROUTES = {
+  /** Authenticated per-claim feedback endpoint. `cardId` is the published card id. */
+  feedback: (cardId: string) => `/api/v1/mechanic-cards/${cardId}/feedback`,
+} as const;


### PR DESCRIPTION
ME-M3.1 — root of the M3 feedback loop. Logged-in users rate individual claims on a published card; 👎 opens a structured error report. This persists the raw feedback rows; the card-counter/auto-suppression aggregation is **#534**.

**Backend**:
- New `mechanic_card_feedback` table (migration `AddMechanicCardFeedback`): UNIQUE `(card_id, user_id, claim_id)` → idempotent submit; index `(user_id, created_at)` backs the rate limit; FK → mechanic_cards CASCADE; CHECK `error_type IN (factual, ambiguous, contradicts_rule) OR NULL`.
- `SubmitMechanicCardFeedbackCommand` + validator + handler: card-exists (the `!IsSuppressed` filter makes a takedown 404), **upsert** (re-submit UPDATES in place — needs `.AsTracking()` under the PERF-06 NoTracking default — does NOT count against the cap), new feedback capped at **10/user/day**.
- `POST /api/v1/mechanic-cards/{cardId}/feedback` (authenticated) → 201 / 200 / 404 / 429 / 401. **Endpoint integration test 5/5.**

**Frontend**:
- Per-claim 👍/👎 controls in `MechanicCardView` (aria-labelled, `aria-pressed`, `print:hidden`). 👍 submits immediately; 👎 opens `ReportErrorDialog` (type select + description + optional citation).
- Card-scoped votes map (no global store), per-claim "thanks" state. 429 → limit toast (not marked submitted); 404 → unavailable toast; other errors keep the modal open. Client maps 404/429/401 to typed `ApiError` subclasses.

Verified: BE integration **5/5**; FE typecheck clean, eslint 0, **vitest 30/30**; Playwright feedback E2E scenario.

Note: migration is applied automatically in tests/dev; staging/prod apply per the deploy process (migrations not auto-applied on deploy).

Closes #533