### PR TITLE
feat(mechanic-extractor): #536 #537 Variant C deprecation banner + nav flag

### DIFF
--- a/apps/web/src/app/admin/(dashboard)/knowledge-base/mechanic-extractor/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/knowledge-base/mechanic-extractor/page.tsx
@@ -14,10 +14,13 @@ import {
   FileTextIcon,
   ChevronRightIcon,
   ShieldCheckIcon,
+  AlertTriangleIcon,
 } from 'lucide-react';
+import Link from 'next/link';
 
 import { Badge } from '@/components/ui/data-display/badge';
 import { Card, CardContent } from '@/components/ui/data-display/card';
+import { Alert, AlertTitle, AlertDescription } from '@/components/ui/feedback/alert';
 import { Skeleton } from '@/components/ui/feedback/skeleton';
 import {
   Select,
@@ -252,6 +255,22 @@ export default function MechanicExtractorPage() {
 
   return (
     <div className="space-y-6">
+      {/* #536 ME-M4.1: deprecation banner — this Variant C editor is superseded by the AI Analyses
+          flow. Persists ~6 months pre-removal (#538). */}
+      <Alert className="border-amber-400 bg-amber-50 text-amber-900 dark:border-amber-700 dark:bg-amber-950/30 dark:text-amber-200">
+        <AlertTriangleIcon className="h-4 w-4" />
+        <AlertTitle>Questo flow è deprecato</AlertTitle>
+        <AlertDescription className="flex flex-wrap items-center gap-3">
+          <span>
+            L&apos;editor Variant C è sostituito dalla nuova <strong>AI Analysis</strong>{' '}
+            (estrazione AI con revisione per-claim e citazioni).
+          </span>
+          <Button asChild size="sm" variant="outline">
+            <Link href="/admin/knowledge-base/mechanic-extractor/analyses">Vai ad AI Analysis</Link>
+          </Button>
+        </AlertDescription>
+      </Alert>
+
       {/* Header */}
       <div className="flex flex-wrap items-start justify-between gap-2">
         <div>

--- a/apps/web/src/components/layout/admin-nav/__tests__/admin-nav-config.test.ts
+++ b/apps/web/src/components/layout/admin-nav/__tests__/admin-nav-config.test.ts
@@ -1,10 +1,21 @@
-import { describe, it, expect } from 'vitest';
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
 
 import type { UserRole } from '@/types/auth';
 
 import { ADMIN_NAV_GROUPS } from '../admin-nav-config';
 
 const VALID_ROLES: UserRole[] = ['superadmin', 'admin', 'editor', 'user'];
+
+const ANALYSES_HREF = '/admin/knowledge-base/mechanic-extractor/analyses';
+const LEGACY_HREF = '/admin/knowledge-base/mechanic-extractor';
+const LEGACY_FLAG = 'NEXT_PUBLIC_SHOW_LEGACY_MECHANIC_EXTRACTOR';
+
+/** Re-import the config with a fresh module registry so the module-level flag read re-runs. */
+async function loadHrefs(): Promise<string[]> {
+  vi.resetModules();
+  const mod = await import('../admin-nav-config');
+  return mod.ADMIN_NAV_GROUPS.flatMap(g => g.items.map(i => i.href));
+}
 
 describe('ADMIN_NAV_GROUPS', () => {
   it('declares exactly the four groups A, B, C, D in order', () => {
@@ -40,5 +51,50 @@ describe('ADMIN_NAV_GROUPS', () => {
   it('has no duplicate hrefs across all groups', () => {
     const hrefs = ADMIN_NAV_GROUPS.flatMap(g => g.items.map(i => i.href));
     expect(new Set(hrefs).size).toBe(hrefs.length);
+  });
+
+  it('always exposes the AI-first Mechanic Analyses entry', () => {
+    const hrefs = ADMIN_NAV_GROUPS.flatMap(g => g.items.map(i => i.href));
+    expect(hrefs).toContain(ANALYSES_HREF);
+  });
+});
+
+// #537 ME-M4.2: the deprecated Variant C editor entry is gated behind
+// NEXT_PUBLIC_SHOW_LEGACY_MECHANIC_EXTRACTOR. The config reads the flag at module
+// load, so each state needs a fresh import via vi.resetModules().
+describe('ADMIN_NAV_GROUPS — legacy Mechanic Extractor gate (#537)', () => {
+  let original: string | undefined;
+
+  beforeEach(() => {
+    original = process.env[LEGACY_FLAG];
+  });
+
+  afterEach(() => {
+    if (original === undefined) {
+      delete process.env[LEGACY_FLAG];
+    } else {
+      process.env[LEGACY_FLAG] = original;
+    }
+    vi.resetModules();
+  });
+
+  it('hides the legacy editor entry when the flag is unset', async () => {
+    delete process.env[LEGACY_FLAG];
+    const hrefs = await loadHrefs();
+    expect(hrefs).toContain(ANALYSES_HREF);
+    expect(hrefs).not.toContain(LEGACY_HREF);
+  });
+
+  it("hides the legacy editor entry for non-'true' values", async () => {
+    process.env[LEGACY_FLAG] = 'false';
+    const hrefs = await loadHrefs();
+    expect(hrefs).not.toContain(LEGACY_HREF);
+  });
+
+  it("shows the legacy editor entry when the flag is 'true'", async () => {
+    process.env[LEGACY_FLAG] = 'true';
+    const hrefs = await loadHrefs();
+    expect(hrefs).toContain(ANALYSES_HREF);
+    expect(hrefs).toContain(LEGACY_HREF);
   });
 });

--- a/apps/web/src/components/layout/admin-nav/admin-nav-config.ts
+++ b/apps/web/src/components/layout/admin-nav/admin-nav-config.ts
@@ -21,6 +21,7 @@ import {
   Wrench,
 } from 'lucide-react';
 
+import { isLegacyMechanicExtractorEnabled } from '@/lib/feature-flags/legacy-mechanic-extractor';
 import type { UserRole } from '@/types/auth';
 
 export interface AdminNavItem {
@@ -102,11 +103,23 @@ export const ADMIN_NAV_GROUPS: AdminNavGroup[] = [
       { label: 'Agent Definitions', href: '/admin/agents/definitions', icon: Database },
       { label: 'RAG Inspector', href: '/admin/agents/inspector', icon: FileSearch },
       { label: 'RAG Quality', href: '/admin/rag-quality', icon: BarChart2 },
+      // AI-first flow (#528+): the primary Mechanic Extractor surface.
       {
-        label: 'Mechanic Extractor',
-        href: '/admin/knowledge-base/mechanic-extractor',
+        label: 'Mechanic Analyses',
+        href: '/admin/knowledge-base/mechanic-extractor/analyses',
         icon: Wrench,
       },
+      // #537 ME-M4.2: the deprecated Variant C editor menu entry is hidden by default,
+      // shown only when NEXT_PUBLIC_SHOW_LEGACY_MECHANIC_EXTRACTOR=true (staging/debug override).
+      ...(isLegacyMechanicExtractorEnabled()
+        ? [
+            {
+              label: 'Mechanic Extractor (legacy)',
+              href: '/admin/knowledge-base/mechanic-extractor',
+              icon: Wrench,
+            },
+          ]
+        : []),
       { label: 'Agent Usage', href: '/admin/agents/usage', icon: BarChart2 },
     ],
   },

--- a/apps/web/src/lib/feature-flags/__tests__/legacy-mechanic-extractor.test.ts
+++ b/apps/web/src/lib/feature-flags/__tests__/legacy-mechanic-extractor.test.ts
@@ -1,0 +1,61 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Tests for `isLegacyMechanicExtractorEnabled` (#537 ME-M4.2).
+ *
+ * The helper is a thin wrapper over a single `NEXT_PUBLIC_*` env read gating the
+ * deprecated Variant C editor's admin nav entry. Strict equality on the literal
+ * `'true'` — no truthy coercion — so the entry stays hidden unless explicitly opted in.
+ */
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { isLegacyMechanicExtractorEnabled } from '../legacy-mechanic-extractor';
+
+const ENV_KEY = 'NEXT_PUBLIC_SHOW_LEGACY_MECHANIC_EXTRACTOR';
+
+describe('isLegacyMechanicExtractorEnabled', () => {
+  let original: string | undefined;
+
+  beforeEach(() => {
+    original = process.env[ENV_KEY];
+  });
+
+  afterEach(() => {
+    if (original === undefined) {
+      delete process.env[ENV_KEY];
+    } else {
+      process.env[ENV_KEY] = original;
+    }
+  });
+
+  it("returns true when the flag is the literal string 'true'", () => {
+    process.env[ENV_KEY] = 'true';
+    expect(isLegacyMechanicExtractorEnabled()).toBe(true);
+  });
+
+  it("returns false when the flag is the literal string 'false'", () => {
+    process.env[ENV_KEY] = 'false';
+    expect(isLegacyMechanicExtractorEnabled()).toBe(false);
+  });
+
+  it("returns false for truthy-looking but non-'true' values (no coercion)", () => {
+    process.env[ENV_KEY] = '1';
+    expect(isLegacyMechanicExtractorEnabled()).toBe(false);
+
+    process.env[ENV_KEY] = 'yes';
+    expect(isLegacyMechanicExtractorEnabled()).toBe(false);
+
+    process.env[ENV_KEY] = 'TRUE';
+    expect(isLegacyMechanicExtractorEnabled()).toBe(false);
+  });
+
+  it('returns false when the flag is unset (deprecated entry hidden by default)', () => {
+    delete process.env[ENV_KEY];
+    expect(isLegacyMechanicExtractorEnabled()).toBe(false);
+  });
+
+  it('returns false for the empty string', () => {
+    process.env[ENV_KEY] = '';
+    expect(isLegacyMechanicExtractorEnabled()).toBe(false);
+  });
+});

--- a/apps/web/src/lib/feature-flags/legacy-mechanic-extractor.ts
+++ b/apps/web/src/lib/feature-flags/legacy-mechanic-extractor.ts
@@ -1,0 +1,14 @@
+/**
+ * Legacy (Variant C) Mechanic Extractor editor gate (ADR-051, #537 ME-M4.2).
+ *
+ * The Variant C manual editor at `/admin/knowledge-base/mechanic-extractor` is deprecated in favor of
+ * the AI-first analyses flow (#528+). Its admin nav entry is HIDDEN by default and only shown when
+ * `NEXT_PUBLIC_SHOW_LEGACY_MECHANIC_EXTRACTOR=true` (an env override for staging/debug). The route
+ * itself still resolves (with the #536 deprecation banner) so existing bookmarks keep working; only
+ * the menu entry is gated. Code removal is #538 (gated +6 months).
+ *
+ * Centralised here so the flag has one source of truth (mirrors `mechanic-validation.ts`).
+ */
+export function isLegacyMechanicExtractorEnabled(): boolean {
+  return process.env.NEXT_PUBLIC_SHOW_LEGACY_MECHANIC_EXTRACTOR === 'true';
+}


### PR DESCRIPTION
## Sommario

Chiude la coppia di quick-win M4 della roadmap Mechanic Extractor (#528–#539): deprecazione della UI Variant C (editor manuale) a favore del flow AI-first *Mechanic Analyses*.

### ME-M4.1 — deprecation banner (#536)
- Aggiunto un `Alert` ambra in cima all'editor legacy `/admin/knowledge-base/mechanic-extractor` che segnala la deprecazione e linka al nuovo flow **Mechanic Analyses** (`/admin/knowledge-base/mechanic-extractor/analyses`).
- La route continua a risolvere → i bookmark esistenti restano validi (rimozione codice tracciata da #538, gated +6 mesi).

### ME-M4.2 — nav entry gate (#537)
- La voce di menu admin dell'editor legacy è ora nascosta di default e mostrata solo con `NEXT_PUBLIC_SHOW_LEGACY_MECHANIC_EXTRACTOR=true` (override staging/debug).
- La voce AI-first **Mechanic Analyses** è sempre visibile.
- Flag centralizzato in `lib/feature-flags/legacy-mechanic-extractor.ts` (mirror di `mechanic-validation.ts`), strict-equality su `'true'` (nessuna coercizione truthy).

## Test
- `legacy-mechanic-extractor.test.ts`: 5 stati del flag (true / false / valori truthy non-'true' / unset / empty).
- `admin-nav-config.test.ts`: gating con fresh-import per stato del flag (`vi.resetModules`) — legacy nascosta se unset/non-'true', visibile con 'true'; Mechanic Analyses sempre presente.
- Page test legacy invariato (banner non rompe il render).
- 23 test pass · `pnpm typecheck` pulito · `eslint` 0 errori.

Closes #536
Closes #537

🤖 Generated with [Claude Code](https://claude.com/claude-code)