### PR TITLE
feat(user-notifications): #535 ME-M3.3 admin notification on card suppression

### DIFF
--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Commands/UpdateCardSuppressionEmailPreferenceCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Commands/UpdateCardSuppressionEmailPreferenceCommand.cs
@@ -1,0 +1,10 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.UserNotifications.Application.Commands;
+
+/// <summary>
+/// #535 ME-M3.3: sets the calling admin's opt-in for mechanic-card-suppression emails. Dedicated command
+/// (not folded into <see cref="UpdateNotificationPreferencesCommand"/>) so an unrelated preferences save
+/// from the FE — which only sends the Document-preference fields — never resets this flag.
+/// </summary>
+internal record UpdateCardSuppressionEmailPreferenceCommand(Guid UserId, bool EmailOnCardSuppressed) : ICommand;

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Commands/UpdateCardSuppressionEmailPreferenceCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Commands/UpdateCardSuppressionEmailPreferenceCommandHandler.cs
@@ -1,0 +1,35 @@
+using Api.BoundedContexts.UserNotifications.Domain.Aggregates;
+using Api.BoundedContexts.UserNotifications.Domain.Repositories;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Infrastructure.Persistence;
+
+namespace Api.BoundedContexts.UserNotifications.Application.Commands;
+
+internal sealed class UpdateCardSuppressionEmailPreferenceCommandHandler
+    : ICommandHandler<UpdateCardSuppressionEmailPreferenceCommand>
+{
+    private readonly INotificationPreferencesRepository _repository;
+    private readonly IUnitOfWork _unitOfWork;
+
+    public UpdateCardSuppressionEmailPreferenceCommandHandler(
+        INotificationPreferencesRepository repository, IUnitOfWork unitOfWork)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+    }
+
+    public async Task Handle(UpdateCardSuppressionEmailPreferenceCommand command, CancellationToken cancellationToken)
+    {
+        var existing = await _repository.GetByUserIdAsync(command.UserId, cancellationToken).ConfigureAwait(false);
+        var prefs = existing ?? new NotificationPreferences(command.UserId);
+        prefs.UpdateCardSuppressionEmailPreference(command.EmailOnCardSuppressed);
+
+        if (existing is null)
+            await _repository.AddAsync(prefs, cancellationToken).ConfigureAwait(false);
+        else
+            await _repository.UpdateAsync(prefs, cancellationToken).ConfigureAwait(false);
+
+        // ADR-060: mutating handlers commit their own unit of work (repo Add/Update only stage).
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/EventHandlers/MechanicCardSuppressedAdminNotificationHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/EventHandlers/MechanicCardSuppressedAdminNotificationHandler.cs
@@ -1,0 +1,66 @@
+using Api.BoundedContexts.Authentication.Infrastructure.Persistence;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Events;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.BoundedContexts.UserNotifications.Application.Services;
+using Api.BoundedContexts.UserNotifications.Domain.ValueObjects;
+using Api.Infrastructure;
+using Api.SharedKernel.Application.EventHandlers;
+
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.UserNotifications.Application.EventHandlers;
+
+/// <summary>
+/// #535 ME-M3.3: fans out an admin in-app notification (with per-admin opt-in email) when a mechanic card
+/// is suppressed (auto #534 or manual). Auto-discovered by MediatR; dispatched post-commit via the
+/// domain-event outbox. In-app is created for every admin regardless of preferences; email is gated by
+/// <c>NotificationPreferences.EmailOnCardSuppressed</c> inside the dispatcher.
+/// </summary>
+internal sealed class MechanicCardSuppressedAdminNotificationHandler
+    : DomainEventHandlerBase<MechanicCardSuppressedEvent>
+{
+    // Metrics (#532) + re-process queue (#534) routes are not built yet; the dashboard is the closest
+    // real target and links to per-game comprehension metrics.
+    private const string DeepLink = "/admin/knowledge-base/mechanic-extractor/dashboard";
+
+    private readonly INotificationDispatcher _dispatcher;
+    private readonly IUserRepository _userRepository;
+    private readonly ISharedGameRepository _sharedGameRepository;
+
+    public MechanicCardSuppressedAdminNotificationHandler(
+        MeepleAiDbContext dbContext,
+        INotificationDispatcher dispatcher,
+        IUserRepository userRepository,
+        ISharedGameRepository sharedGameRepository,
+        ILogger<MechanicCardSuppressedAdminNotificationHandler> logger)
+        : base(dbContext, logger)
+    {
+        _dispatcher = dispatcher ?? throw new ArgumentNullException(nameof(dispatcher));
+        _userRepository = userRepository ?? throw new ArgumentNullException(nameof(userRepository));
+        _sharedGameRepository = sharedGameRepository ?? throw new ArgumentNullException(nameof(sharedGameRepository));
+    }
+
+    protected override async Task HandleEventAsync(
+        MechanicCardSuppressedEvent domainEvent, CancellationToken cancellationToken)
+    {
+        var game = await _sharedGameRepository
+            .GetByIdAsync(domainEvent.SharedGameId, cancellationToken)
+            .ConfigureAwait(false);
+        var title = string.IsNullOrWhiteSpace(game?.Title) ? "un gioco" : game!.Title;
+
+        var admins = await _userRepository.GetAdminUsersAsync(cancellationToken).ConfigureAwait(false);
+        foreach (var admin in admins)
+        {
+            await _dispatcher.DispatchAsync(new NotificationMessage
+            {
+                Type = NotificationType.AdminMechanicCardSuppressed,
+                RecipientUserId = admin.Id,
+                Payload = new GenericPayload(
+                    "[Admin] Scheda Meccanica Soppressa",
+                    $"La scheda meccaniche di «{title}» è stata soppressa. Motivo: {domainEvent.Reason}"),
+                DeepLinkPath = DeepLink,
+                SourceEventId = domainEvent.EventId
+            }, cancellationToken).ConfigureAwait(false);
+        }
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Domain/Aggregates/NotificationPreferences.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Domain/Aggregates/NotificationPreferences.cs
@@ -16,6 +16,9 @@ internal sealed class NotificationPreferences : AggregateRoot<Guid>
     public bool EmailOnDocumentFailed { get; private set; } = true;
     public bool EmailOnRetryAvailable { get; private set; }
 
+    // #535 ME-M3.3: opt-in email when a mechanic card is suppressed (admin-facing). Default off.
+    public bool EmailOnCardSuppressed { get; private set; }
+
     // PDF Processing - Push
     public bool PushOnDocumentReady { get; private set; } = true;
     public bool PushOnDocumentFailed { get; private set; } = true;
@@ -95,7 +98,8 @@ internal sealed class NotificationPreferences : AggregateRoot<Guid>
         bool slackOnRetryAvailable = false, bool slackOnGameNightInvitation = true,
         bool slackOnGameNightReminder = true, bool slackOnShareRequestCreated = true,
         bool slackOnShareRequestApproved = true, bool slackOnBadgeEarned = true,
-        string timeZone = "UTC", TimeOnly? quietHoursStart = null, TimeOnly? quietHoursEnd = null)
+        string timeZone = "UTC", TimeOnly? quietHoursStart = null, TimeOnly? quietHoursEnd = null,
+        bool emailOnCardSuppressed = false)
     {
         return new NotificationPreferences
         {
@@ -129,7 +133,8 @@ internal sealed class NotificationPreferences : AggregateRoot<Guid>
             SlackOnGameNightReminder = slackOnGameNightReminder,
             SlackOnShareRequestCreated = slackOnShareRequestCreated,
             SlackOnShareRequestApproved = slackOnShareRequestApproved,
-            SlackOnBadgeEarned = slackOnBadgeEarned
+            SlackOnBadgeEarned = slackOnBadgeEarned,
+            EmailOnCardSuppressed = emailOnCardSuppressed
         };
     }
 
@@ -138,6 +143,12 @@ internal sealed class NotificationPreferences : AggregateRoot<Guid>
         EmailOnDocumentReady = onReady;
         EmailOnDocumentFailed = onFailed;
         EmailOnRetryAvailable = onRetry;
+    }
+
+    /// <summary>#535: toggle the per-admin card-suppression email opt-in.</summary>
+    public void UpdateCardSuppressionEmailPreference(bool email)
+    {
+        EmailOnCardSuppressed = email;
     }
 
     public void UpdatePushPreferences(bool onReady, bool onFailed, bool onRetry)

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Domain/ValueObjects/NotificationType.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Domain/ValueObjects/NotificationType.cs
@@ -77,6 +77,9 @@ internal sealed class NotificationType : ValueObject
     // Admin notification when PDF processing starts (enriched with uploader details)
     public static readonly NotificationType AdminPdfProcessingStarted = new("admin_pdf_processing_started");
 
+    // #535 ME-M3.3: admin notification when a mechanic card is suppressed (auto or manual)
+    public static readonly NotificationType AdminMechanicCardSuppressed = new("admin_mechanic_card_suppressed");
+
     // ISSUE-44/47: Game night notification types
     public static readonly NotificationType GameNightInvitation = new("game_night_invitation");
     public static readonly NotificationType GameNightRsvpReceived = new("game_night_rsvp_received");
@@ -168,6 +171,7 @@ internal sealed class NotificationType : ValueObject
             "admin_access_request_created" => AdminAccessRequestCreated,
             "admin_manual_notification" => AdminManualNotification,
             "admin_pdf_processing_started" => AdminPdfProcessingStarted,
+            "admin_mechanic_card_suppressed" => AdminMechanicCardSuppressed,
             "slack_connection_revoked" => SlackConnectionRevoked,
             "mechanic_analysis_ready" => MechanicAnalysisReady,
             "mechanic_analysis_rejected" => MechanicAnalysisRejected,

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Persistence/NotificationPreferencesRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Persistence/NotificationPreferencesRepository.cs
@@ -76,7 +76,8 @@ internal class NotificationPreferencesRepository : RepositoryBase, INotification
             entity.SlackOnRetryAvailable, entity.SlackOnGameNightInvitation,
             entity.SlackOnGameNightReminder, entity.SlackOnShareRequestCreated,
             entity.SlackOnShareRequestApproved, entity.SlackOnBadgeEarned,
-            entity.TimeZone, entity.QuietHoursStart, entity.QuietHoursEnd
+            entity.TimeZone, entity.QuietHoursStart, entity.QuietHoursEnd,
+            entity.EmailOnCardSuppressed
         );
     }
 
@@ -89,6 +90,7 @@ internal class NotificationPreferencesRepository : RepositoryBase, INotification
             EmailOnDocumentReady = domain.EmailOnDocumentReady,
             EmailOnDocumentFailed = domain.EmailOnDocumentFailed,
             EmailOnRetryAvailable = domain.EmailOnRetryAvailable,
+            EmailOnCardSuppressed = domain.EmailOnCardSuppressed,
             PushOnDocumentReady = domain.PushOnDocumentReady,
             PushOnDocumentFailed = domain.PushOnDocumentFailed,
             PushOnRetryAvailable = domain.PushOnRetryAvailable,

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Services/NotificationDispatcher.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Services/NotificationDispatcher.cs
@@ -235,6 +235,7 @@ internal sealed class NotificationDispatcher : INotificationDispatcher
             || type == NotificationType.RateLimitReached
             || type == NotificationType.SlackConnectionRevoked
             || type == NotificationType.MechanicAnalysisRejected
+            || type == NotificationType.AdminMechanicCardSuppressed
             || type == NotificationType.AgentCreationFailed)
             return NotificationSeverity.Warning;
 
@@ -291,6 +292,7 @@ internal sealed class NotificationDispatcher : INotificationDispatcher
         if (type == NotificationType.AdminAccessRequestCreated) return "[Admin] Nuova richiesta accesso";
         if (type == NotificationType.AdminManualNotification) return "[Admin] Notifica manuale";
         if (type == NotificationType.AdminPdfProcessingStarted) return "[Admin] Elaborazione PDF avviata";
+        if (type == NotificationType.AdminMechanicCardSuppressed) return "[Admin] Scheda Meccanica Soppressa";
 
         return "Notifica MeepleAI";
     }
@@ -308,6 +310,8 @@ internal sealed class NotificationDispatcher : INotificationDispatcher
             return prefs.EmailOnGameNightInvitation;
         if (type == NotificationType.GameNightReminder)
             return prefs.EmailOnGameNightReminder;
+        if (type == NotificationType.AdminMechanicCardSuppressed)
+            return prefs.EmailOnCardSuppressed; // #535: opt-in (default off)
 
         // Default: send email for types not explicitly configured
         return true;
@@ -330,7 +334,8 @@ internal sealed class NotificationDispatcher : INotificationDispatcher
             || type == NotificationType.AdminModelStatusChanged
             || type == NotificationType.AdminAccessRequestCreated
             || type == NotificationType.AdminManualNotification
-            || type == NotificationType.AdminPdfProcessingStarted)
+            || type == NotificationType.AdminPdfProcessingStarted
+            || type == NotificationType.AdminMechanicCardSuppressed)
             return false;
 
         if (type == NotificationType.DocumentReady || type == NotificationType.RuleSpecGenerated)

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Slack/AdminAlertSlackBuilder.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Slack/AdminAlertSlackBuilder.cs
@@ -27,7 +27,8 @@ internal sealed class AdminAlertSlackBuilder : ISlackMessageBuilder
             || type == NotificationType.AdminOpenRouterThresholdAlert
             || type == NotificationType.AdminOpenRouterDailySummary
             || type == NotificationType.AdminSystemHealthAlert
-            || type == NotificationType.AdminModelStatusChanged;
+            || type == NotificationType.AdminModelStatusChanged
+            || type == NotificationType.AdminMechanicCardSuppressed; // #535
     }
 
     public object BuildMessage(INotificationPayload payload, string? deepLinkPath)

--- a/apps/api/src/Api/Infrastructure/Entities/UserNotifications/NotificationPreferencesEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/UserNotifications/NotificationPreferencesEntity.cs
@@ -7,6 +7,9 @@ public class NotificationPreferencesEntity
     public bool EmailOnDocumentReady { get; set; } = true;
     public bool EmailOnDocumentFailed { get; set; } = true;
     public bool EmailOnRetryAvailable { get; set; }
+
+    // #535 ME-M3.3: opt-in email on mechanic card suppression. Default false.
+    public bool EmailOnCardSuppressed { get; set; }
     public bool PushOnDocumentReady { get; set; } = true;
     public bool PushOnDocumentFailed { get; set; } = true;
     public bool PushOnRetryAvailable { get; set; }

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/UserNotifications/NotificationPreferencesEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/UserNotifications/NotificationPreferencesEntityConfiguration.cs
@@ -15,6 +15,7 @@ internal class NotificationPreferencesEntityConfiguration : IEntityTypeConfigura
         builder.Property(e => e.EmailOnDocumentReady).IsRequired().HasDefaultValue(true);
         builder.Property(e => e.EmailOnDocumentFailed).IsRequired().HasDefaultValue(true);
         builder.Property(e => e.EmailOnRetryAvailable).IsRequired().HasDefaultValue(false);
+        builder.Property(e => e.EmailOnCardSuppressed).IsRequired().HasDefaultValue(false); // #535
         builder.Property(e => e.PushOnDocumentReady).IsRequired().HasDefaultValue(true);
         builder.Property(e => e.PushOnDocumentFailed).IsRequired().HasDefaultValue(true);
         builder.Property(e => e.PushOnRetryAvailable).IsRequired().HasDefaultValue(false);

--- a/apps/api/src/Api/Infrastructure/Migrations/20260712091125_AddEmailOnCardSuppressedPreference.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260712091125_AddEmailOnCardSuppressedPreference.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260712091125_AddEmailOnCardSuppressedPreference")]
+    partial class AddEmailOnCardSuppressedPreference
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260712091125_AddEmailOnCardSuppressedPreference.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260712091125_AddEmailOnCardSuppressedPreference.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddEmailOnCardSuppressedPreference : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "EmailOnCardSuppressed",
+                table: "notification_preferences",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "EmailOnCardSuppressed",
+                table: "notification_preferences");
+        }
+    }
+}

--- a/apps/api/src/Api/Routing/NotificationPreferencesEndpoints.cs
+++ b/apps/api/src/Api/Routing/NotificationPreferencesEndpoints.cs
@@ -44,6 +44,24 @@ internal static class NotificationPreferencesEndpoints
         .RequireSession()
         .WithName("UpdateNotificationPreferences");
 
+        // #535 ME-M3.3: dedicated toggle for the mechanic-card-suppression email opt-in. Separate from
+        // the Document-preferences PUT above so a partial FE save never resets it.
+        group.MapPut("/notifications/preferences/card-suppression", async (
+            UpdateCardSuppressionEmailPreferenceCommand command,
+            HttpContext context,
+            IMediator mediator,
+            CancellationToken ct) =>
+        {
+            var (authenticated, session, error) = context.TryGetActiveSession();
+            if (!authenticated) return error!;
+
+            var updatedCommand = command with { UserId = session!.Principal!.Subject.Id };
+            await mediator.Send(updatedCommand, ct).ConfigureAwait(false);
+            return Results.NoContent();
+        })
+        .RequireSession()
+        .WithName("UpdateCardSuppressionEmailPreference");
+
         // Issue #4416: Push notification subscription management
         group.MapPost("/notifications/push/subscribe", async (
             SubscribePushNotificationsCommand command,

--- a/apps/api/tests/Api.Tests/BoundedContexts/UserNotifications/Domain/NotificationPreferencesCardSuppressionTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/UserNotifications/Domain/NotificationPreferencesCardSuppressionTests.cs
@@ -1,0 +1,29 @@
+using Api.BoundedContexts.UserNotifications.Domain.Aggregates;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.UserNotifications.Domain;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "UserNotifications")]
+public sealed class NotificationPreferencesCardSuppressionTests
+{
+    [Fact]
+    public void New_DefaultsEmailOnCardSuppressed_False()
+    {
+        new NotificationPreferences(Guid.NewGuid()).EmailOnCardSuppressed.Should().BeFalse();
+    }
+
+    [Fact]
+    public void UpdateCardSuppressionEmailPreference_SetsFlag()
+    {
+        var prefs = new NotificationPreferences(Guid.NewGuid());
+
+        prefs.UpdateCardSuppressionEmailPreference(true);
+        prefs.EmailOnCardSuppressed.Should().BeTrue();
+
+        prefs.UpdateCardSuppressionEmailPreference(false);
+        prefs.EmailOnCardSuppressed.Should().BeFalse();
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/UserNotifications/Domain/NotificationTypeCardSuppressedTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/UserNotifications/Domain/NotificationTypeCardSuppressedTests.cs
@@ -1,0 +1,19 @@
+using Api.BoundedContexts.UserNotifications.Domain.ValueObjects;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.UserNotifications.Domain;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "UserNotifications")]
+public sealed class NotificationTypeCardSuppressedTests
+{
+    [Fact]
+    public void FromString_ParsesAdminMechanicCardSuppressed()
+    {
+        NotificationType.FromString("admin_mechanic_card_suppressed")
+            .Should().Be(NotificationType.AdminMechanicCardSuppressed);
+        NotificationType.AdminMechanicCardSuppressed.Value.Should().Be("admin_mechanic_card_suppressed");
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/UserNotifications/Infrastructure/UpdateCardSuppressionEmailPreferenceHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/UserNotifications/Infrastructure/UpdateCardSuppressionEmailPreferenceHandlerTests.cs
@@ -1,0 +1,71 @@
+using Api.BoundedContexts.UserNotifications.Application.Commands;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.UserNotifications;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using MediatR;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.UserNotifications.Infrastructure;
+
+/// <summary>
+/// #535: the dedicated card-suppression email preference command persists the opt-in flag (backend
+/// settability; the FE checkbox is a follow-up).
+/// </summary>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "UserNotifications")]
+public sealed class UpdateCardSuppressionEmailPreferenceHandlerTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly string _testDbName;
+    private WebApplicationFactory<Program> _factory = null!;
+    private Guid _userId;
+
+    public UpdateCardSuppressionEmailPreferenceHandlerTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+        _testDbName = $"me535_pref_{Guid.NewGuid():N}";
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        var conn = await _fixture.CreateIsolatedDatabaseAsync(_testDbName);
+        _factory = IntegrationWebApplicationFactory.Create(conn);
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        await db.Database.MigrateAsync();
+        (_userId, _) = await TestSessionHelper.CreateUserSessionAsync(db, Guid.NewGuid());
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_factory is not null)
+        {
+            await _factory.DisposeAsync();
+        }
+        await _fixture.DropIsolatedDatabaseAsync(_testDbName);
+    }
+
+    [Fact]
+    public async Task Command_PersistsFlag_CreatingPrefsWhenMissing()
+    {
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+            await mediator.Send(new UpdateCardSuppressionEmailPreferenceCommand(_userId, true));
+        }
+
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            var row = await db.Set<NotificationPreferencesEntity>().AsNoTracking().SingleAsync(p => p.UserId == _userId);
+            row.EmailOnCardSuppressed.Should().BeTrue();
+        }
+    }
+}

--- a/apps/api/tests/Api.Tests/UserNotifications/Application/EventHandlers/MechanicCardSuppressedAdminNotificationHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/UserNotifications/Application/EventHandlers/MechanicCardSuppressedAdminNotificationHandlerTests.cs
@@ -1,0 +1,106 @@
+using Api.BoundedContexts.Authentication.Domain.Entities;
+using Api.BoundedContexts.Authentication.Infrastructure.Persistence;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Events;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.BoundedContexts.UserNotifications.Application.EventHandlers;
+using Api.BoundedContexts.UserNotifications.Application.Services;
+using Api.BoundedContexts.UserNotifications.Domain.ValueObjects;
+using Api.Infrastructure;
+using Api.Tests.BoundedContexts.Authentication.TestHelpers;
+using Api.Tests.Constants;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+using Role = Api.SharedKernel.Domain.ValueObjects.Role;
+
+namespace Api.Tests.UserNotifications.Application.EventHandlers;
+
+/// <summary>
+/// #535 ME-M3.3: the handler fans out an in-app admin notification per admin (incl. superadmin) when a
+/// mechanic card is suppressed, with per-event dedup and a body carrying game title + reason.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "UserNotifications")]
+public sealed class MechanicCardSuppressedAdminNotificationHandlerTests : IAsyncLifetime
+{
+    private readonly Mock<INotificationDispatcher> _dispatcher = new();
+    private readonly Mock<IUserRepository> _userRepo = new();
+    private readonly Mock<ISharedGameRepository> _sharedGameRepo = new();
+    private readonly MeepleAiDbContext _dbContext = TestDbContextFactory.CreateInMemoryDbContext();
+    private MechanicCardSuppressedAdminNotificationHandler _sut = null!;
+
+    private readonly Guid _cardId = Guid.NewGuid();
+    private readonly Guid _gameId = Guid.NewGuid();
+    private readonly Guid _actorId = Guid.NewGuid();
+    private readonly Guid _adminId = Guid.NewGuid();
+    private readonly Guid _superAdminId = Guid.NewGuid();
+
+    public ValueTask InitializeAsync()
+    {
+        _sut = new MechanicCardSuppressedAdminNotificationHandler(
+            _dbContext, _dispatcher.Object, _userRepo.Object, _sharedGameRepo.Object,
+            new Mock<ILogger<MechanicCardSuppressedAdminNotificationHandler>>().Object);
+
+        var admin = new UserBuilder().WithId(_adminId).WithEmail("admin@example.com")
+            .WithDisplayName("Admin One").WithRole(Role.Admin).Build();
+        var superAdmin = new UserBuilder().WithId(_superAdminId).WithEmail("super@example.com")
+            .WithDisplayName("Super Admin").WithRole(Role.SuperAdmin).Build();
+        _userRepo.Setup(r => r.GetAdminUsersAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<User> { admin, superAdmin });
+
+        return ValueTask.CompletedTask;
+    }
+
+    public async ValueTask DisposeAsync() => await _dbContext.DisposeAsync();
+
+    private static SharedGame Catan() => SharedGame.Create(
+        "Catan", 2020, "desc", 1, 4, 60, 10, 2.0m, 7.0m,
+        "https://example.com/img.jpg", "https://example.com/thumb.jpg", null, Guid.NewGuid(), null);
+
+    [Fact]
+    public async Task Handle_DispatchesToAllAdmins_WithTypeDedupAndBody()
+    {
+        _sharedGameRepo.Setup(r => r.GetByIdAsync(_gameId, It.IsAny<CancellationToken>())).ReturnsAsync(Catan());
+        var evt = new MechanicCardSuppressedEvent(_cardId, _gameId, _actorId,
+            "auto_feedback: 5 error reports, feedback score 0.20 below 0.50 threshold");
+
+        await _sut.Handle(evt, CancellationToken.None);
+
+        _dispatcher.Verify(d => d.DispatchAsync(
+            It.Is<NotificationMessage>(m =>
+                m.Type == NotificationType.AdminMechanicCardSuppressed
+                && m.SourceEventId == evt.EventId
+                && m.DeepLinkPath == "/admin/knowledge-base/mechanic-extractor/dashboard"
+                && ((GenericPayload)m.Payload).Body.Contains("Catan")
+                && ((GenericPayload)m.Payload).Body.Contains("auto_feedback")),
+            It.IsAny<CancellationToken>()), Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task Handle_WhenGameMissing_UsesFallbackTitle()
+    {
+        _sharedGameRepo.Setup(r => r.GetByIdAsync(_gameId, It.IsAny<CancellationToken>())).ReturnsAsync((SharedGame?)null);
+        var evt = new MechanicCardSuppressedEvent(_cardId, _gameId, _actorId, "manual takedown for legal reasons here");
+
+        await _sut.Handle(evt, CancellationToken.None);
+
+        _dispatcher.Verify(d => d.DispatchAsync(
+            It.Is<NotificationMessage>(m => ((GenericPayload)m.Payload).Body.Contains("un gioco")),
+            It.IsAny<CancellationToken>()), Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task Handle_WhenNoAdmins_SkipsDispatch()
+    {
+        _userRepo.Setup(r => r.GetAdminUsersAsync(It.IsAny<CancellationToken>())).ReturnsAsync(new List<User>());
+        _sharedGameRepo.Setup(r => r.GetByIdAsync(_gameId, It.IsAny<CancellationToken>())).ReturnsAsync(Catan());
+        var evt = new MechanicCardSuppressedEvent(_cardId, _gameId, _actorId, "manual takedown for legal reasons here");
+
+        await _sut.Handle(evt, CancellationToken.None);
+
+        _dispatcher.Verify(d => d.DispatchAsync(It.IsAny<NotificationMessage>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+}

--- a/docs/superpowers/plans/2026-07-12-issue-535-suppression-notification.md
+++ b/docs/superpowers/plans/2026-07-12-issue-535-suppression-notification.md
@@ -1,0 +1,584 @@
+# #535 ME-M3.3 Admin Suppression Notification — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development or superpowers:executing-plans. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** When a MechanicCard is suppressed, notify all admins in-app (always) with an opt-in per-admin email, including game title + reason + a deep-link.
+
+**Architecture:** The existing `MechanicCardSuppressedEvent` (#534) is handled by a new `DomainEventHandlerBase<MechanicCardSuppressedEvent>` in the UserNotifications BC that fans out `INotificationDispatcher.DispatchAsync` to every admin. A new `NotificationType.AdminMechanicCardSuppressed` is wired through the dispatcher's title/severity/slack/email switches. A new per-user preference `EmailOnCardSuppressed` (default false) gates the email channel and is settable via a dedicated command + endpoint.
+
+**Tech Stack:** .NET 9, MediatR (`ICommand`/`ICommandHandler`, `INotificationHandler`), EF Core + PostgreSQL, xUnit + Testcontainers.
+
+**Spec:** `docs/superpowers/specs/2026-07-12-issue-535-suppression-notification.md`
+
+## Global Constraints
+- Event handler auto-discovered by MediatR (no manual DI). Cross-BC references are same-assembly (`internal` OK).
+- In-app notification is created by `DispatchAsync` regardless of prefs (AC-2). Email is gated by `IsEmailEnabledForType` → `prefs.EmailOnCardSuppressed`; `preferences == null` still sends email (existing dispatcher behavior).
+- Dedup: every dispatched `NotificationMessage` sets `SourceEventId = domainEvent.EventId`.
+- Admins resolved via `IUserRepository.GetAdminUsersAsync()` (includes admin + superadmin).
+- DeepLinkPath = `/admin/knowledge-base/mechanic-extractor/dashboard` (metrics #532 / re-process #534 routes don't exist yet).
+- Backend test path `apps/api/tests/Api.Tests`; run with explicit csproj + kill testhost first.
+
+---
+
+### Task 1: `NotificationType.AdminMechanicCardSuppressed` + dispatcher wiring
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/UserNotifications/Domain/ValueObjects/NotificationType.cs`
+- Modify: `apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Services/NotificationDispatcher.cs`
+- Modify: `apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Slack/AdminAlertSlackBuilder.cs`
+- Test: `apps/api/tests/Api.Tests/BoundedContexts/UserNotifications/Domain/NotificationTypeCardSuppressedTests.cs`
+
+**Interfaces:**
+- Produces: `NotificationType.AdminMechanicCardSuppressed` (value `"admin_mechanic_card_suppressed"`); `IsEmailEnabledForType` returns `prefs.EmailOnCardSuppressed` for it (consumed by Task 2's pref).
+
+- [ ] **Step 1: Write the failing test**
+
+`NotificationTypeCardSuppressedTests.cs`:
+```csharp
+using Api.BoundedContexts.UserNotifications.Domain.ValueObjects;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.UserNotifications.Domain;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "UserNotifications")]
+public sealed class NotificationTypeCardSuppressedTests
+{
+    [Fact]
+    public void FromString_ParsesAdminMechanicCardSuppressed()
+    {
+        NotificationType.FromString("admin_mechanic_card_suppressed")
+            .Should().Be(NotificationType.AdminMechanicCardSuppressed);
+        NotificationType.AdminMechanicCardSuppressed.Value.Should().Be("admin_mechanic_card_suppressed");
+    }
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL** (member/parse missing):
+```bash
+cd apps/api/src/Api
+dotnet test ../../tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~NotificationTypeCardSuppressedTests"
+```
+
+- [ ] **Step 3: Add the type + FromString case**
+
+In `NotificationType.cs`, after the last `Admin*` member (near `AdminPdfProcessingStarted`):
+```csharp
+    public static readonly NotificationType AdminMechanicCardSuppressed = new("admin_mechanic_card_suppressed");
+```
+In `FromString(...)` switch, add:
+```csharp
+            "admin_mechanic_card_suppressed" => AdminMechanicCardSuppressed,
+```
+
+- [ ] **Step 4: Wire the dispatcher (NotificationDispatcher.cs)**
+
+`IsEmailEnabledForType` — before the final `return true;`:
+```csharp
+        if (type == NotificationType.AdminMechanicCardSuppressed)
+            return prefs.EmailOnCardSuppressed;
+```
+`ResolveTitle` — in the `// Admin types` block, before `return "Notifica MeepleAI";`:
+```csharp
+        if (type == NotificationType.AdminMechanicCardSuppressed) return "[Admin] Scheda Meccanica Soppressa";
+```
+`ResolveSeverity` — add to the `Warning` block's OR chain:
+```csharp
+            || type == NotificationType.AdminMechanicCardSuppressed
+```
+`IsSlackEnabledForType` — add to the admin-types exclusion OR chain (returns false):
+```csharp
+            || type == NotificationType.AdminMechanicCardSuppressed
+```
+
+- [ ] **Step 5: Wire AdminAlertSlackBuilder.CanHandle**
+
+In `AdminAlertSlackBuilder.cs` `CanHandle` OR-chain, add:
+```csharp
+            || type == NotificationType.AdminMechanicCardSuppressed
+```
+
+> `prefs.EmailOnCardSuppressed` does not exist until Task 2 — Task 1 will not compile standalone. Implement Task 1 + Task 2 together, or add the `EmailOnCardSuppressed` property (Task 2 Step 3) first. Recommended: do Task 2's aggregate/entity property before compiling Task 1.
+
+- [ ] **Step 6: Run — expect PASS** (after Task 2 property exists):
+```bash
+dotnet test ../../tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~NotificationTypeCardSuppressedTests"
+```
+
+- [ ] **Step 7: Commit**
+```bash
+git add apps/api/src/Api/BoundedContexts/UserNotifications/Domain/ValueObjects/NotificationType.cs apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure apps/api/tests/Api.Tests/BoundedContexts/UserNotifications/Domain/NotificationTypeCardSuppressedTests.cs
+git commit -m "feat(user-notifications): #535 AdminMechanicCardSuppressed type + dispatcher wiring"
+```
+
+---
+
+### Task 2: `EmailOnCardSuppressed` preference (persisted, default false)
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/UserNotifications/Domain/Aggregates/NotificationPreferences.cs`
+- Modify: `apps/api/src/Api/Infrastructure/Entities/UserNotifications/NotificationPreferencesEntity.cs`
+- Modify: `apps/api/src/Api/Infrastructure/EntityConfigurations/UserNotifications/NotificationPreferencesEntityConfiguration.cs`
+- Modify: `apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Persistence/NotificationPreferencesRepository.cs`
+- Create: migration via `dotnet ef migrations add AddEmailOnCardSuppressedPreference`
+- Test: `apps/api/tests/Api.Tests/BoundedContexts/UserNotifications/Domain/NotificationPreferencesCardSuppressionTests.cs`
+
+**Interfaces:**
+- Produces: `NotificationPreferences.EmailOnCardSuppressed` (bool, default false); `NotificationPreferences.UpdateCardSuppressionEmailPreference(bool email)`; `Reconstitute(..., bool emailOnCardSuppressed = false)`.
+
+- [ ] **Step 1: Write the failing aggregate test**
+
+`NotificationPreferencesCardSuppressionTests.cs`:
+```csharp
+using Api.BoundedContexts.UserNotifications.Domain.Aggregates;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.UserNotifications.Domain;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "UserNotifications")]
+public sealed class NotificationPreferencesCardSuppressionTests
+{
+    [Fact]
+    public void New_DefaultsEmailOnCardSuppressed_False()
+    {
+        new NotificationPreferences(Guid.NewGuid()).EmailOnCardSuppressed.Should().BeFalse();
+    }
+
+    [Fact]
+    public void UpdateCardSuppressionEmailPreference_SetsFlag()
+    {
+        var prefs = new NotificationPreferences(Guid.NewGuid());
+        prefs.UpdateCardSuppressionEmailPreference(true);
+        prefs.EmailOnCardSuppressed.Should().BeTrue();
+        prefs.UpdateCardSuppressionEmailPreference(false);
+        prefs.EmailOnCardSuppressed.Should().BeFalse();
+    }
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL** (property/method missing).
+
+- [ ] **Step 3: Aggregate property + method + Reconstitute param**
+
+In `NotificationPreferences.cs`, add the property near the email bools:
+```csharp
+    /// <summary>#535: opt-in email when one of the admin's games has a mechanic card suppressed. Default off.</summary>
+    public bool EmailOnCardSuppressed { get; private set; }
+```
+Add the update method near the other `UpdateXxxPreferences` methods:
+```csharp
+    /// <summary>#535: toggle the per-admin card-suppression email opt-in.</summary>
+    public void UpdateCardSuppressionEmailPreference(bool email)
+    {
+        EmailOnCardSuppressed = email;
+    }
+```
+In the `Reconstitute(...)` factory signature, append the last parameter (after `quietHoursEnd`):
+```csharp
+        TimeOnly? quietHoursEnd = null,
+        bool emailOnCardSuppressed = false
+```
+and set it in the returned instance body: `EmailOnCardSuppressed = emailOnCardSuppressed,`.
+
+> Confirm the exact tail of the `Reconstitute` parameter list + object initializer before editing; append the new param LAST with a default so existing callers stay valid.
+
+- [ ] **Step 4: Entity + config**
+
+`NotificationPreferencesEntity.cs` — add near the email bools:
+```csharp
+    public bool EmailOnCardSuppressed { get; set; }
+```
+`NotificationPreferencesEntityConfiguration.cs` — add near the email property configs:
+```csharp
+        builder.Property(e => e.EmailOnCardSuppressed).IsRequired().HasDefaultValue(false);
+```
+
+- [ ] **Step 5: Repo mapper both directions**
+
+`NotificationPreferencesRepository.cs` `MapToDomain` — append `entity.EmailOnCardSuppressed` as the LAST argument of the `Reconstitute(...)` call (after `entity.QuietHoursEnd`).
+`MapToPersistence` — add to the entity initializer:
+```csharp
+            EmailOnCardSuppressed = domain.EmailOnCardSuppressed,
+```
+
+- [ ] **Step 6: Migration**
+```bash
+cd apps/api/src/Api
+dotnet build
+dotnet ef migrations add AddEmailOnCardSuppressedPreference --no-build
+```
+Verify the generated `Up()` adds a single `AddColumn<bool>(... "notification_preferences" ... defaultValue: false)` and `Down()` drops it. If `Up()` is empty (stale build), delete the `.cs`+`.Designer.cs`, `dotnet build`, re-run with build.
+
+- [ ] **Step 7: Run — expect PASS**:
+```bash
+dotnet test ../../tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~NotificationPreferencesCardSuppressionTests"
+```
+
+- [ ] **Step 8: Commit**
+```bash
+git add apps/api/src/Api/BoundedContexts/UserNotifications apps/api/src/Api/Infrastructure apps/api/tests/Api.Tests/BoundedContexts/UserNotifications/Domain/NotificationPreferencesCardSuppressionTests.cs
+git commit -m "feat(user-notifications): #535 EmailOnCardSuppressed preference (default off)"
+```
+
+---
+
+### Task 3: Settable via API — command + endpoint
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/UserNotifications/Application/Commands/UpdateCardSuppressionEmailPreferenceCommand.cs`
+- Create: `.../UpdateCardSuppressionEmailPreferenceCommandHandler.cs`
+- Modify: `apps/api/src/Api/Routing/NotificationPreferencesEndpoints.cs`
+- Test: `apps/api/tests/Api.Tests/BoundedContexts/UserNotifications/Infrastructure/UpdateCardSuppressionEmailPreferenceHandlerTests.cs`
+
+**Interfaces:**
+- Consumes: `INotificationPreferencesRepository` (`GetByUserIdAsync`, `AddAsync`, `UpdateAsync`), `NotificationPreferences.UpdateCardSuppressionEmailPreference` (Task 2).
+- Produces: `record UpdateCardSuppressionEmailPreferenceCommand(Guid UserId, bool EmailOnCardSuppressed) : ICommand`.
+
+- [ ] **Step 1: Write the failing integration test**
+
+`UpdateCardSuppressionEmailPreferenceHandlerTests.cs`:
+```csharp
+using Api.BoundedContexts.UserNotifications.Application.Commands;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.UserNotifications;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using MediatR;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.UserNotifications.Infrastructure;
+
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "UserNotifications")]
+public sealed class UpdateCardSuppressionEmailPreferenceHandlerTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly string _testDbName;
+    private WebApplicationFactory<Program> _factory = null!;
+    private Guid _userId;
+
+    public UpdateCardSuppressionEmailPreferenceHandlerTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+        _testDbName = $"me535_pref_{Guid.NewGuid():N}";
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        var conn = await _fixture.CreateIsolatedDatabaseAsync(_testDbName);
+        _factory = IntegrationWebApplicationFactory.Create(conn);
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        await db.Database.MigrateAsync();
+        (_userId, _) = await TestSessionHelper.CreateUserSessionAsync(db, Guid.NewGuid());
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_factory is not null) await _factory.DisposeAsync();
+        await _fixture.DropIsolatedDatabaseAsync(_testDbName);
+    }
+
+    [Fact]
+    public async Task Command_PersistsFlag()
+    {
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+            await mediator.Send(new UpdateCardSuppressionEmailPreferenceCommand(_userId, true));
+        }
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            var row = await db.Set<NotificationPreferencesEntity>().AsNoTracking().SingleAsync(p => p.UserId == _userId);
+            row.EmailOnCardSuppressed.Should().BeTrue();
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run — expect FAIL** (command type missing).
+
+- [ ] **Step 3: Command + handler**
+
+`UpdateCardSuppressionEmailPreferenceCommand.cs`:
+```csharp
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.UserNotifications.Application.Commands;
+
+/// <summary>#535: sets the calling admin's opt-in for card-suppression emails.</summary>
+internal record UpdateCardSuppressionEmailPreferenceCommand(Guid UserId, bool EmailOnCardSuppressed) : ICommand;
+```
+`UpdateCardSuppressionEmailPreferenceCommandHandler.cs` (mirror `UpdateNotificationPreferencesCommandHandler`):
+```csharp
+using Api.BoundedContexts.UserNotifications.Domain.Aggregates;
+using Api.BoundedContexts.UserNotifications.Domain.Repositories;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.UserNotifications.Application.Commands;
+
+internal sealed class UpdateCardSuppressionEmailPreferenceCommandHandler
+    : ICommandHandler<UpdateCardSuppressionEmailPreferenceCommand>
+{
+    private readonly INotificationPreferencesRepository _repository;
+
+    public UpdateCardSuppressionEmailPreferenceCommandHandler(INotificationPreferencesRepository repository)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+    }
+
+    public async Task Handle(UpdateCardSuppressionEmailPreferenceCommand command, CancellationToken cancellationToken)
+    {
+        var existing = await _repository.GetByUserIdAsync(command.UserId, cancellationToken).ConfigureAwait(false);
+        var prefs = existing ?? new NotificationPreferences(command.UserId);
+        prefs.UpdateCardSuppressionEmailPreference(command.EmailOnCardSuppressed);
+
+        if (existing is null)
+            await _repository.AddAsync(prefs, cancellationToken).ConfigureAwait(false);
+        else
+            await _repository.UpdateAsync(prefs, cancellationToken).ConfigureAwait(false);
+    }
+}
+```
+
+- [ ] **Step 4: Endpoint**
+
+In `NotificationPreferencesEndpoints.cs`, after the existing `PUT /notifications/preferences` mapping, add (mirror its auth + user-id resolution):
+```csharp
+        group.MapPut("/notifications/preferences/card-suppression", async (
+            UpdateCardSuppressionEmailPreferenceRequest body,
+            HttpContext context,
+            IMediator mediator,
+            CancellationToken ct) =>
+        {
+            var userId = /* resolve from context, mirror the sibling endpoint */;
+            await mediator.Send(new UpdateCardSuppressionEmailPreferenceCommand(userId, body.EmailOnCardSuppressed), ct);
+            return Results.NoContent();
+        })
+        .RequireAuthorization()
+        .WithName("UpdateCardSuppressionEmailPreference");
+```
+with `internal record UpdateCardSuppressionEmailPreferenceRequest(bool EmailOnCardSuppressed);`.
+
+> Open `NotificationPreferencesEndpoints.cs` and mirror EXACTLY how the existing `PUT /notifications/preferences` resolves the user id (it may bind `UpdateNotificationPreferencesCommand` directly with UserId in the body, or read a claim). Match that pattern so auth is consistent. If the sibling binds the command directly with UserId from the body, do the same (bind `UpdateCardSuppressionEmailPreferenceCommand` directly) and drop the request record.
+
+- [ ] **Step 5: Run — expect PASS**:
+```bash
+dotnet test ../../tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~UpdateCardSuppressionEmailPreferenceHandlerTests"
+```
+
+- [ ] **Step 6: Commit**
+```bash
+git add apps/api/src/Api/BoundedContexts/UserNotifications/Application/Commands apps/api/src/Api/Routing/NotificationPreferencesEndpoints.cs apps/api/tests/Api.Tests/BoundedContexts/UserNotifications/Infrastructure/UpdateCardSuppressionEmailPreferenceHandlerTests.cs
+git commit -m "feat(user-notifications): #535 settable card-suppression email preference API"
+```
+
+---
+
+### Task 4: Event handler — admin fan-out (AC-2 + AC-3 + AC-4)
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/UserNotifications/Application/EventHandlers/MechanicCardSuppressedAdminNotificationHandler.cs`
+- Test: `apps/api/tests/Api.Tests/BoundedContexts/UserNotifications/Infrastructure/MechanicCardSuppressedAdminNotificationHandlerTests.cs`
+
+**Interfaces:**
+- Consumes: `MechanicCardSuppressedEvent` (SharedGameCatalog), `IUserRepository.GetAdminUsersAsync`, `ISharedGameRepository.GetByIdAsync`, `INotificationDispatcher.DispatchAsync`, `NotificationType.AdminMechanicCardSuppressed` (Task 1), `GenericPayload`.
+
+- [ ] **Step 1: Write the failing integration test**
+
+`MechanicCardSuppressedAdminNotificationHandlerTests.cs`. Seeds two admins (1 admin + 1 superadmin) + a published card (reuse the #534 seed helper `MechanicCardAutoSuppressionSeed.CardWithFeedbackAsync` for the card/game), then suppresses the card through the real repo path so the event dispatches, and asserts each admin has an in-app Notification of the new type.
+```csharp
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.BoundedContexts.UserNotifications.Domain.ValueObjects;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.UserNotifications;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Tests.BoundedContexts.SharedGameCatalog.Infrastructure;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.UserNotifications.Infrastructure;
+
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "UserNotifications")]
+public sealed class MechanicCardSuppressedAdminNotificationHandlerTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly string _testDbName;
+    private WebApplicationFactory<Program> _factory = null!;
+    private Guid _seedUserId;
+
+    public MechanicCardSuppressedAdminNotificationHandlerTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+        _testDbName = $"me535_handler_{Guid.NewGuid():N}";
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        var conn = await _fixture.CreateIsolatedDatabaseAsync(_testDbName);
+        _factory = IntegrationWebApplicationFactory.Create(conn);
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        await db.Database.MigrateAsync();
+        (_seedUserId, _) = await TestSessionHelper.CreateUserSessionAsync(db, Guid.NewGuid());
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_factory is not null) await _factory.DisposeAsync();
+        await _fixture.DropIsolatedDatabaseAsync(_testDbName);
+    }
+
+    [Fact]
+    public async Task Suppression_NotifiesAllAdmins_InApp()
+    {
+        Guid adminId, superAdminId, cardId;
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            (adminId, _) = await TestSessionHelper.CreateAdminSessionAsync(db, Guid.NewGuid());
+            (superAdminId, _) = await TestSessionHelper.CreateSuperAdminSessionAsync(db, Guid.NewGuid());
+            cardId = await MechanicCardAutoSuppressionSeed.CardWithFeedbackAsync(scope, _seedUserId, negatives: 0, positives: 0);
+        }
+
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var repo = scope.ServiceProvider.GetRequiredService<IMechanicCardRepository>();
+            var uow = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+            var card = await repo.GetByIdIgnoringFiltersAsync(cardId);
+            card!.Suppress(_seedUserId, "manual takedown for the admin-notification integration test", DateTime.UtcNow);
+            repo.Update(card);
+            await uow.SaveChangesAsync();
+        }
+
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            var typeValue = NotificationType.AdminMechanicCardSuppressed.Value;
+            foreach (var id in new[] { adminId, superAdminId })
+            {
+                (await db.Set<NotificationEntity>().CountAsync(n => n.UserId == id && n.Type == typeValue))
+                    .Should().Be(1, $"admin {id} should get exactly one in-app suppression notification");
+            }
+        }
+    }
+}
+```
+
+> Verify the helper names: `TestSessionHelper.CreateAdminSessionAsync` / `CreateSuperAdminSessionAsync` (the #533 test used `CreateUserSessionAsync`; check `TestSessionHelper` for the role-specific factories — it exposes `CreateSessionAsync(db, "Admin"/"SuperAdmin", ...)`). Verify `NotificationEntity` name/namespace + its `Type` column is the string value. Adjust the count query if notifications are read via a DbSet property (e.g. `db.Notifications`).
+
+- [ ] **Step 2: Run — expect FAIL** (handler missing → 0 notifications).
+
+- [ ] **Step 3: Implement the handler**
+
+`MechanicCardSuppressedAdminNotificationHandler.cs`:
+```csharp
+using Api.BoundedContexts.Authentication.Infrastructure.Persistence;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Events;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.BoundedContexts.UserNotifications.Application.Services;
+using Api.BoundedContexts.UserNotifications.Domain.ValueObjects;
+using Api.Infrastructure;
+using Api.SharedKernel.Application.EventHandlers;
+
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.UserNotifications.Application.EventHandlers;
+
+/// <summary>
+/// #535 ME-M3.3: fans out an admin in-app notification (email opt-in per admin) when a mechanic card is
+/// suppressed. Auto-discovered by MediatR; dispatched post-commit via the domain-event outbox.
+/// </summary>
+internal sealed class MechanicCardSuppressedAdminNotificationHandler
+    : DomainEventHandlerBase<MechanicCardSuppressedEvent>
+{
+    private const string DeepLink = "/admin/knowledge-base/mechanic-extractor/dashboard";
+
+    private readonly INotificationDispatcher _dispatcher;
+    private readonly IUserRepository _userRepository;
+    private readonly ISharedGameRepository _sharedGameRepository;
+
+    public MechanicCardSuppressedAdminNotificationHandler(
+        MeepleAiDbContext dbContext,
+        INotificationDispatcher dispatcher,
+        IUserRepository userRepository,
+        ISharedGameRepository sharedGameRepository,
+        ILogger<MechanicCardSuppressedAdminNotificationHandler> logger)
+        : base(dbContext, logger)
+    {
+        _dispatcher = dispatcher ?? throw new ArgumentNullException(nameof(dispatcher));
+        _userRepository = userRepository ?? throw new ArgumentNullException(nameof(userRepository));
+        _sharedGameRepository = sharedGameRepository ?? throw new ArgumentNullException(nameof(sharedGameRepository));
+    }
+
+    protected override async Task HandleEventAsync(MechanicCardSuppressedEvent domainEvent, CancellationToken cancellationToken)
+    {
+        var game = await _sharedGameRepository.GetByIdAsync(domainEvent.SharedGameId, cancellationToken).ConfigureAwait(false);
+        var title = string.IsNullOrWhiteSpace(game?.Title) ? "un gioco" : game!.Title;
+
+        var admins = await _userRepository.GetAdminUsersAsync(cancellationToken).ConfigureAwait(false);
+        foreach (var admin in admins)
+        {
+            await _dispatcher.DispatchAsync(new NotificationMessage
+            {
+                Type = NotificationType.AdminMechanicCardSuppressed,
+                RecipientUserId = admin.Id,
+                Payload = new GenericPayload(
+                    "[Admin] Scheda Meccanica Soppressa",
+                    $"La scheda meccaniche di «{title}» è stata soppressa. Motivo: {domainEvent.Reason}"),
+                DeepLinkPath = DeepLink,
+                SourceEventId = domainEvent.EventId
+            }, cancellationToken).ConfigureAwait(false);
+        }
+    }
+}
+```
+
+> Verify: `GenericPayload` namespace (`Api.BoundedContexts.UserNotifications.Domain.ValueObjects`), `NotificationMessage` namespace (`...Application.Services`), `IUserRepository` namespace + that domain `User` exposes `.Id`, `SharedGame` exposes `.Title`, and `DomainEventHandlerBase` ctor `(MeepleAiDbContext, ILogger)`. Base class handles logging + rethrow; do not add a top-level try/catch (mirror `SharedGameSubmittedForApprovalNotificationHandler`).
+
+- [ ] **Step 4: Run — expect PASS**:
+```bash
+dotnet test ../../tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~MechanicCardSuppressedAdminNotificationHandlerTests"
+```
+
+- [ ] **Step 5: Full build + #535 suite green**:
+```bash
+dotnet build
+dotnet test ../../tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~CardSuppress|FullyQualifiedName~NotificationTypeCardSuppressed|FullyQualifiedName~NotificationPreferencesCardSuppression"
+```
+
+- [ ] **Step 6: Commit**
+```bash
+git add apps/api/src/Api/BoundedContexts/UserNotifications/Application/EventHandlers apps/api/tests/Api.Tests/BoundedContexts/UserNotifications/Infrastructure/MechanicCardSuppressedAdminNotificationHandlerTests.cs
+git commit -m "feat(user-notifications): #535 admin fan-out notification on card suppression"
+```
+
+---
+
+## Self-Review
+- **AC-1** (event) → pre-existing (#534). ✓
+- **AC-2** (in-app all admins) → Task 4 handler + `GetAdminUsersAsync` (incl superadmin). ✓
+- **AC-3** (email opt-in) → Task 1 dispatcher `IsEmailEnabledForType` + Task 2 pref (default false) + Task 3 settable API. ✓ (FE checkbox = follow-up.)
+- **AC-4** (game + reason + link) → Task 4 payload body + DeepLinkPath. ✓ (metrics/re-process routes don't exist → dashboard.)
+- **Placeholders**: two flagged verification points (endpoint user-id resolution; test-helper role factories + NotificationEntity DbSet) — concrete "open file X, mirror pattern Y" instructions, resolved during execution.
+- **Type consistency**: `AdminMechanicCardSuppressed`, `EmailOnCardSuppressed`, `UpdateCardSuppressionEmailPreference`, `UpdateCardSuppressionEmailPreferenceCommand` used identically across tasks.

--- a/docs/superpowers/specs/2026-07-12-issue-535-suppression-notification.md
+++ b/docs/superpowers/specs/2026-07-12-issue-535-suppression-notification.md
@@ -1,0 +1,72 @@
+# #535 — ME-M3.3 Admin notification on card suppression (spec)
+
+**Parent ADR**: ADR-051 · **Depends on**: #534 (suppression + event) · **BC**: UserNotifications (+ SharedGameCatalog event) · **Date**: 2026-07-12
+
+## Obiettivo
+Quando una `MechanicCard` viene soppressa (auto #534 o manuale), notificare **tutti gli admin** in-app, con **email opzionale**
+per-admin (opt-in), includendo gioco + motivo + deep-link.
+
+## Stato AC
+- **AC-1** ✅ già fatto: `MechanicCardSuppressedEvent(CardId, SharedGameId, ActorId, Reason)` alzato da `MechanicCard.Suppress` (#534).
+- **AC-2**: handler in UserNotifications BC → notifica in-app a tutti gli admin (incl. superadmin).
+- **AC-3**: email opzionale se admin ha `EmailOnCardSuppressed=true` (default false, opt-in). **Scelta utente**: backend completo +
+  settabile via API; checkbox FE = **follow-up** (nuova issue).
+- **AC-4**: payload include gioco (title risolto) + motivo; deep-link.
+
+## Decisioni (discovery 2026-07-12)
+1. **Handler** `DomainEventHandlerBase<MechanicCardSuppressedEvent>` (pattern raccomandato `SharedGameSubmittedForApprovalNotificationHandler`),
+   admin via `IUserRepository.GetAdminUsersAsync()` (**include superadmin**, vs il literal `"admin"` di `NewShareRequestAdminAlertHandler`).
+   Dispatch cross-BC ok (stesso assembly, evento `internal`). Auto-discovered da MediatR (no DI manuale).
+2. **Email**: il dispatcher accoda l'email come `NotificationQueueItem` col **payload generico** (title/body/deeplink) — **nessun
+   template per-tipo necessario**. AC-3 = solo pref `EmailOnCardSuppressed` + map in `IsEmailEnabledForType`.
+   ⚠️ Il dispatcher fa `if (preferences == null || IsEmailEnabledForType(...))` → admin **senza** riga preferenze ricevono email
+   (default-on per null-prefs, comportamento esistente); solo chi ha una riga con `EmailOnCardSuppressed=false` non la riceve.
+3. **In-app sempre**: `DispatchAsync` persiste la Notification (in-app) prima del routing canali → AC-2 soddisfatto a prescindere dalle pref.
+4. **Dedup** (CF-1): `SourceEventId = domainEvent.EventId` → una notifica per (admin, event); fan-out per admin ok.
+5. **DeepLink** (AC-4): metrics (#532) e re-process queue (#534 deferito) **non esistono** → punto a `/admin/knowledge-base/mechanic-extractor/dashboard`
+   (la "AI Comprehension Validation dashboard", proxy metrics reale). Aggiornabile quando #532 atterra.
+6. **Settabilità** (AC-3): NON estendere `UpdateNotificationPreferencesCommand` (il FE invia 10 campi Document; un campo extra verrebbe
+   resettato a false a ogni save). Command **dedicato** `UpdateCardSuppressionEmailPreferenceCommand` + endpoint `PUT /notifications/preferences/card-suppression`
+   (pattern per-gruppo come `UpdateSlackPreferencesCommand`).
+
+## Componenti
+
+### 1. Nuovo `NotificationType.AdminMechanicCardSuppressed` = `"admin_mechanic_card_suppressed"`
+File `Domain/ValueObjects/NotificationType.cs`: aggiungi il member + il caso in `FromString`.
+
+### 2. Dispatcher wiring (`Infrastructure/Services/NotificationDispatcher.cs`)
+- `IsEmailEnabledForType`: `if (type == AdminMechanicCardSuppressed) return prefs.EmailOnCardSuppressed;` (prima del default `return true`).
+- `ResolveTitle`: `"[Admin] Scheda Meccanica Soppressa"`.
+- `ResolveSeverity`: block `Warning`.
+- `IsSlackEnabledForType`: aggiungi all'esclusione admin (→ `false`, mai user-DM).
+- `Infrastructure/Slack/AdminAlertSlackBuilder.cs` `CanHandle`: aggiungi alla OR-chain (formatting canale admin).
+
+### 3. Preferenza `EmailOnCardSuppressed` (default false)
+- Aggregate `Domain/Aggregates/NotificationPreferences.cs`: prop `{ get; private set; }` (no `= true`) + param in coda a `Reconstitute` (`bool emailOnCardSuppressed = false`) + metodo `UpdateCardSuppressionEmailPreference(bool email)`.
+- Entity `Infrastructure/Entities/UserNotifications/NotificationPreferencesEntity.cs`: `public bool EmailOnCardSuppressed { get; set; }` (default false).
+- Config `.../NotificationPreferencesEntityConfiguration.cs`: `builder.Property(e => e.EmailOnCardSuppressed).IsRequired().HasDefaultValue(false);`.
+- Repo mapper `Infrastructure/Persistence/NotificationPreferencesRepository.cs`: `MapToDomain` (append `entity.EmailOnCardSuppressed`) + `MapToPersistence` (`EmailOnCardSuppressed = domain.EmailOnCardSuppressed`).
+- Migration generata (`dotnet ef migrations add`, nome colonna automatico).
+
+### 4. Event handler (nuovo) `Application/EventHandlers/MechanicCardSuppressedAdminNotificationHandler.cs`
+`internal sealed : DomainEventHandlerBase<MechanicCardSuppressedEvent>`, ctor `(MeepleAiDbContext, INotificationDispatcher, IUserRepository, ISharedGameRepository, ILogger<>)` : base(dbContext, logger). Override `HandleEventAsync`:
+- risolve title gioco via `ISharedGameRepository.GetByIdAsync(evt.SharedGameId)` (fallback `"un gioco"`);
+- `admins = await _userRepository.GetAdminUsersAsync(ct)`;
+- per ogni admin: `_dispatcher.DispatchAsync(new NotificationMessage { Type = AdminMechanicCardSuppressed, RecipientUserId = admin.Id, Payload = new GenericPayload("[Admin] Scheda Meccanica Soppressa", $"La scheda meccaniche di «{title}» è stata soppressa. Motivo: {evt.Reason}"), DeepLinkPath = "/admin/knowledge-base/mechanic-extractor/dashboard", SourceEventId = evt.EventId }, ct)`.
+
+### 5. Settabilità (nuovo) `Application/Commands/UpdateCardSuppressionEmailPreferenceCommand.cs` + Handler
+`record UpdateCardSuppressionEmailPreferenceCommand(Guid UserId, bool EmailOnCardSuppressed) : ICommand`. Handler: `prefs = GetByUserIdAsync ?? new NotificationPreferences(userId)` → `prefs.UpdateCardSuppressionEmailPreference(cmd.EmailOnCardSuppressed)` → Add/Update (mirror `UpdateNotificationPreferencesCommandHandler`).
+Endpoint in `Routing/NotificationPreferencesEndpoints.cs`: `PUT /notifications/preferences/card-suppression` (auth utente → UserId dal claim/command).
+
+## Test (TDD)
+- **Aggregate unit**: `UpdateCardSuppressionEmailPreference(true)` setta il bool; default false su `new NotificationPreferences(userId)`.
+- **NotificationType unit**: `FromString("admin_mechanic_card_suppressed") == AdminMechanicCardSuppressed`.
+- **Handler integration** (Testcontainers, evento reale via `card.Suppress` + `repo.Update` + `SaveChanges`):
+  - 2 admin (1 admin + 1 superadmin) → entrambi ricevono 1 Notification in-app `AdminMechanicCardSuppressed`, body contiene game title + reason, DeepLinkPath set, dedup per `SourceEventId`.
+  - admin con `EmailOnCardSuppressed=true` → email queue item creato; admin con riga pref `false` → nessun email item (in-app comunque presente).
+- **Command integration**: `UpdateCardSuppressionEmailPreferenceCommand` persiste il bool (settable API) + endpoint `PUT` 200.
+
+## Fuori scope (follow-up)
+- **Checkbox FE** in `apps/web/.../notifications/preferences/` → nuova issue.
+- Deep-link a metrics (#532) / re-process queue (#534 deferito) quando le route esisteranno.
+- Slack canale admin: `CanHandle` incluso per consistenza ma la consegna dipende da config Slack (fuori AC).


### PR DESCRIPTION
## Sommario
Chiude #535 (ME-M3.3): quando una `MechanicCard` viene soppressa (auto #534 o manuale), notifica **tutti gli admin** in-app, con **email opzionale** per-admin (opt-in), includendo gioco + motivo + deep-link.

Spec: `docs/superpowers/specs/2026-07-12-issue-535-suppression-notification.md` · Plan: `docs/superpowers/plans/2026-07-12-issue-535-suppression-notification.md`

## AC
- **AC-1** ✅ pre-esistente: `MechanicCardSuppressedEvent` alzato da `MechanicCard.Suppress` (#534).
- **AC-2** ✅ notifica in-app a tutti gli admin (incl. superadmin): `MechanicCardSuppressedAdminNotificationHandler : DomainEventHandlerBase` → `IUserRepository.GetAdminUsersAsync()` → `INotificationDispatcher.DispatchAsync` per admin (dedup via `SourceEventId`).
- **AC-3** ✅ email opt-in per-admin: nuova pref `EmailOnCardSuppressed` (default off) letta dal dispatcher (`IsEmailEnabledForType`); settabile via `PUT /notifications/preferences/card-suppression`. **Checkbox FE = follow-up** (issue #TBD).
- **AC-4** ✅ payload include game title (risolto via `ISharedGameRepository`) + motivo; deep-link → `/admin/knowledge-base/mechanic-extractor/dashboard`.

## Cosa fa
- Nuovo `NotificationType.AdminMechanicCardSuppressed` cablato nel dispatcher (title / severity=Warning / esclusione user-DM / email routing) + `AdminAlertSlackBuilder.CanHandle`.
- Nuova pref `EmailOnCardSuppressed` end-to-end (aggregate + entity + config + repo mapper + migration) — l'in-app è sempre creato; l'email è opt-in.
- Command dedicato `UpdateCardSuppressionEmailPreferenceCommand` + endpoint (separato dal PUT Document-prefs così un save parziale FE non resetta il flag).

## Decisioni
- **Reprocess/metrics deep-link**: metrics (#532) e re-process queue (#534 deferito) non esistono → link alla dashboard esistente (proxy metrics reale).
- **Niente template email per-tipo**: il dispatcher accoda l'email come `NotificationQueueItem` col payload generico.
- **Handler test = unit** (mock dispatcher/repos): il factory di integrazione usa `OutboxOnly` (no dispatch inline), quindi il test unit mirror `SharedGameSubmittedForApprovalNotificationHandlerTests` è deterministico.

## Review avversariale
Reviewer indipendente (opus): **0 difetti** su 6 aree scrutinate (Reconstitute posizionale, opt-in gating, dedup handler, dispatcher switch, SaveChanges ADR-060, migration) — tutte CONFIRMED clean.

## Test
7 verdi: 2 domain unit (type FromString + pref default/toggle) + 3 handler unit (fan-out a tutti gli admin con dedup+body, fallback title, no-admins skip) + 1 settability integration (Testcontainers) + 1 config. `dotnet build` API+Tests pulito.

## Fuori scope (follow-up)
- Checkbox FE in `notifications/preferences/`.
- Deep-link a metrics (#532) / re-process queue quando esisteranno.

Closes #535

🤖 Generated with [Claude Code](https://claude.com/claude-code)