### PR TITLE
fix(chat): render RAG citations and cite the PDF document id

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/StreamQaQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/StreamQaQueryHandler.cs
@@ -318,14 +318,30 @@ internal class StreamQaQueryHandler : IStreamingQueryHandler<StreamQaQuery, RagS
         // Calculate search confidence
         var searchConfidence = _qualityTrackingService.CalculateSearchConfidence(domainSearchResults);
 
-        // Build citations
-        var snippets = searchResults.Select(r => new Snippet(
-            r.TextContent,
-            $"PDF:{r.VectorDocumentId}",
-            r.PageNumber,
-            0,
-            (float)r.RelevanceScore
-        )).ToList();
+        // Build citations — Issue #W: the search result's VectorDocumentId is the
+        // vector_documents.Id, but the citation "source" must carry the pdf_documents.Id
+        // so the FE PDF viewer (GET /api/v1/pdfs/{id}/download) can resolve it — otherwise
+        // it 404s and the cited source is unreadable. Resolve VectorDocumentId →
+        // PdfDocumentId via the game's vector documents (typically 1-2 per game).
+        var vectorDocs = await _vectorDocumentRepository
+            .GetByGameIdAsync(Guid.Parse(gameId), cancellationToken).ConfigureAwait(false);
+        var pdfIdByVectorId = vectorDocs.ToDictionary(v => v.Id, v => v.PdfDocumentId);
+
+        var snippets = searchResults.Select(r =>
+        {
+            // Fall back to the vector id if resolution fails (keeps a stable source string).
+            var citationDocId =
+                Guid.TryParse(r.VectorDocumentId, out var vecId)
+                && pdfIdByVectorId.TryGetValue(vecId, out var pdfId)
+                    ? pdfId.ToString()
+                    : r.VectorDocumentId;
+            return new Snippet(
+                r.TextContent,
+                $"PDF:{citationDocId}",
+                r.PageNumber,
+                0,
+                (float)r.RelevanceScore);
+        }).ToList();
 
         return (true, snippets, domainSearchResults, searchConfidence);
     }

--- a/apps/web/src/hooks/queries/__tests__/useGameChat.test.tsx
+++ b/apps/web/src/hooks/queries/__tests__/useGameChat.test.tsx
@@ -118,6 +118,58 @@ describe('useGameChat', () => {
     expect(result.current.messages[1].isLowQuality).toBe(false);
   });
 
+  it('surfaces citations from the type-1 Citations-early SSE event when COMPLETE has citations:null (#V)', async () => {
+    // Real backend contract (verified on live SSE): citations arrive in the
+    // type-1 (CITATIONS) event as { text, source:"PDF:{docId}", page, score },
+    // while the type-4 COMPLETE payload carries citations:null. The hook MUST
+    // surface the type-1 citations (mapped to the FE Citation shape) or the chat
+    // renders zero CitationChip and the source PDF is unreachable.
+    const sseRealEvents = [
+      { type: 7, data: { token: 'Alla fine ' } },
+      { type: 7, data: { token: 'della partita si contano i punti.' } },
+      {
+        type: 1,
+        data: {
+          citations: [
+            {
+              text: 'Alice loses a total of 8 points',
+              source: 'PDF:853f6dcc-aaaa',
+              page: 6,
+              line: 0,
+              score: 0.85,
+            },
+            {
+              text: 'tiles directly adjacent',
+              source: 'PDF:853f6dcc-aaaa',
+              page: 5,
+              line: 0,
+              score: 0.83,
+            },
+          ],
+        },
+      },
+      { type: 4, data: { confidence: 0.8, citations: null } },
+    ];
+    vi.mocked(qaStream).mockReturnValueOnce(mockStream(sseRealEvents) as any);
+    const { result } = renderHook(() => useGameChat('azul'));
+    await act(async () => {
+      await result.current.ask('come si calcolano i punti a fine partita?');
+    });
+    const agent = result.current.messages[1];
+    expect(agent.citations).toHaveLength(2);
+    expect(agent.citations?.[0]).toEqual(
+      expect.objectContaining({
+        documentId: '853f6dcc-aaaa',
+        pageNumber: 6,
+        snippet: 'Alice loses a total of 8 points',
+        relevanceScore: 0.85,
+        copyrightTier: 'full',
+      })
+    );
+    expect(agent.isLowQuality).toBe(false);
+    expect(agent.outOfContext).toBe(false);
+  });
+
   it('derives outOfContext=true when no citations + confidence < 0.30', async () => {
     const oocEvents = [
       { type: 7, data: 'Non ho informazioni.' },

--- a/apps/web/src/hooks/queries/useGameChat.ts
+++ b/apps/web/src/hooks/queries/useGameChat.ts
@@ -59,6 +59,7 @@ const nextId = (prefix: string) => `${prefix}-${++messageIdCounter}-${Date.now()
 const TOKEN_EVENT_TYPE = 7;
 const COMPLETE_EVENT_TYPE = 4;
 const ERROR_EVENT_TYPE = 5;
+const CITATIONS_EVENT_TYPE = 1;
 
 // Soglie derivate frontend (backend non espone isLowQuality/outOfContext)
 const LOW_QUALITY_THRESHOLD = 0.7;
@@ -77,6 +78,28 @@ interface StreamingCompletePayload {
 
 interface ErrorPayload {
   readonly message?: string;
+}
+
+// Issue #V: the QA stream (POST /agents/qa/stream) delivers citations in the
+// type-1 (CITATIONS) event with the raw shape { text, source:"PDF:{docId}",
+// page, score }, while the type-4 COMPLETE payload carries citations:null in
+// production. Map that shape to the FE Citation type so the chat renders
+// CitationChip and can open the source PDF at the cited page.
+interface SseCitation {
+  readonly text?: string;
+  readonly source?: string;
+  readonly page?: number;
+  readonly score?: number;
+}
+
+function mapSseCitation(c: SseCitation): Citation {
+  return {
+    documentId: (c.source ?? '').replace(/^PDF:/, ''),
+    pageNumber: c.page ?? 0,
+    snippet: c.text ?? '',
+    relevanceScore: c.score ?? 0,
+    copyrightTier: 'full',
+  };
 }
 
 function toChatMessage(dto: ChatThreadMessageDto, idx: number): ChatMessage {
@@ -149,6 +172,7 @@ export function useGameChat(gameId: string, initialAgent: AgentKind = 'tutor'): 
       setIsError(false);
 
       let answerBuffer = '';
+      let collectedCitations: Citation[] = [];
 
       try {
         const stream = qaStream({
@@ -173,7 +197,11 @@ export function useGameChat(gameId: string, initialAgent: AgentKind = 'tutor'): 
           } else if (event.type === COMPLETE_EVENT_TYPE) {
             const payload = event.data as StreamingCompletePayload;
             const confidence = payload.confidence ?? undefined;
-            const citations = payload.Citations ?? payload.citations ?? [];
+            // Issue #V: prefer citations from the COMPLETE payload when present
+            // (back-compat with older streams/tests), otherwise fall back to the
+            // ones captured from the type-1 CITATIONS event (production path).
+            const streamedCitations = payload.Citations ?? payload.citations ?? [];
+            const citations = streamedCitations.length > 0 ? streamedCitations : collectedCitations;
             // Issue #2712: a grounded answer (valid citations) must NOT be degraded to the
             // "Non sono certo" card. The numeric confidence is currently compressed (rank-based),
             // so gating solely on it hid correct answers. Treat low-quality only when the RAG
@@ -205,8 +233,16 @@ export function useGameChat(gameId: string, initialAgent: AgentKind = 'tutor'): 
           } else if (event.type === ERROR_EVENT_TYPE) {
             const errPayload = event.data as ErrorPayload;
             throw new Error(errPayload?.message ?? 'QA stream error');
+          } else if (event.type === CITATIONS_EVENT_TYPE) {
+            // Issue #V: the early CITATIONS event is the ONLY place citations
+            // are delivered — the COMPLETE payload's citations field is null in
+            // production. Capture + map them here so they survive to the bubble.
+            const citData = event.data as { citations?: ReadonlyArray<SseCitation> } | null;
+            if (citData && Array.isArray(citData.citations)) {
+              collectedCitations = citData.citations.map(mapSseCitation);
+            }
           }
-          // Ignora type=0 (StateUpdate), type=1 (Citations early), type=8 (Follow-up).
+          // Ignora type=0 (StateUpdate) e type=8 (Follow-up).
         }
       } catch (e) {
         setIsError(true);


### PR DESCRIPTION
Restores the chat-in-game citation-to-PDF chain (2 fixes found during happy-path browser testing). 1) Citations delivered in the SSE type-1 event were ignored by useGameChat.ts, so grounded answers rendered zero citation chips. 2) The citation source used vector_documents.Id instead of pdf_documents.Id, so the source PDF returned 404 (StreamQaQueryHandler resolves it via IVectorDocumentRepository). Both verified end-to-end; TDD 18/18. Generated with Claude Code.