### PR TITLE
fix(game-night): guard diary spread against non-array (detail crash)

### DIFF
--- a/apps/web/src/components/game-night/GameNightDiaryPanel.tsx
+++ b/apps/web/src/components/game-night/GameNightDiaryPanel.tsx
@@ -32,7 +32,12 @@ export function GameNightDiaryPanel({ gameNightId, limit = 50 }: GameNightDiaryP
   const { data: entries, isLoading } = useGameNightDiaryQuery(gameNightId);
 
   const sortedEntries = useMemo(() => {
-    if (!entries) return [];
+    // Issue #S: for empty/Published game nights the diary query can yield a
+    // non-array value (envelope object or undefined). Spreading it threw
+    // "s is not iterable" and crashed the ENTIRE game-night detail into the
+    // error boundary. Guard with Array.isArray so a malformed/empty diary
+    // degrades to an empty timeline instead of blowing up the page.
+    if (!Array.isArray(entries)) return [];
     return [...entries]
       .sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime())
       .slice(0, limit);


### PR DESCRIPTION
Fixes a crash on /game-nights/[id] for empty/Published game nights. GameNightDiaryPanel spread the diary query result; for empty nights that value can be a non-array, throwing 'not iterable' and crashing the whole detail into the error boundary. Guards with Array.isArray to degrade to an empty timeline. Found during happy-path browser testing. Generated with Claude Code.