### PR TITLE
feat(mechanic-extractor): #532 ME-M2.3 admin metrics dashboard

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/DTOs/MechanicMetricsDtos.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/DTOs/MechanicMetricsDtos.cs
@@ -1,0 +1,42 @@
+namespace Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
+
+/// <summary>
+/// Operational KPIs for the Mechanic Extractor admin metrics dashboard (#532 ME-M2.3): cost, review
+/// velocity, approval rate, and the rejection-reasons breakdown. Computed over non-suppressed analyses.
+/// </summary>
+internal sealed record MechanicMetricsSummaryDto(
+    decimal TotalCostUsd,
+    int TotalAnalyses,
+    int PublishedCount,
+    int RejectedCount,
+    int InReviewCount,
+    decimal AverageCostUsd,
+    double? AverageReviewTimeHours,
+    double ApprovalRatePct,
+    IReadOnlyList<RejectionReasonCountDto> RejectionBreakdown);
+
+/// <summary>One rejection reason + how many analyses were rejected with it (#532).</summary>
+internal sealed record RejectionReasonCountDto(string Reason, int Count);
+
+/// <summary>Daily cost bucket for the time-series chart (#532). Gap-filled: days with no analyses report 0.</summary>
+internal sealed record MechanicCostByDayDto(DateOnly Date, decimal CostUsd, int AnalysisCount);
+
+/// <summary>One row of the recent-analyses table (#532).</summary>
+internal sealed record MechanicRecentAnalysisRowDto(
+    Guid Id,
+    Guid SharedGameId,
+    string GameName,
+    int Status,
+    Guid? ReviewedBy,
+    string? ReviewerName,
+    DateTime CreatedAt,
+    DateTime? ReviewedAt,
+    decimal EstimatedCostUsd);
+
+/// <summary>Paginated recent-analyses result (#532).</summary>
+internal sealed record MechanicRecentAnalysesResult(
+    IReadOnlyList<MechanicRecentAnalysisRowDto> Items,
+    int TotalCount);
+
+/// <summary>CSV export payload for the recent-analyses table (#532).</summary>
+internal sealed record ExportMechanicAnalysesResult(byte[] Content, string ContentType, string FileName);

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/MechanicMetrics/ExportMechanicAnalysesQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/MechanicMetrics/ExportMechanicAnalysesQuery.cs
@@ -1,0 +1,14 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Queries.MechanicMetrics;
+
+/// <summary>
+/// #532 ME-M2.3: CSV export of the recent-analyses table with the same optional filters as the grid.
+/// </summary>
+internal sealed record ExportMechanicAnalysesQuery(
+    Guid? GameId = null,
+    Guid? ReviewerId = null,
+    int? Status = null,
+    DateTime? StartDate = null,
+    DateTime? EndDate = null) : IQuery<ExportMechanicAnalysesResult>;

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/MechanicMetrics/ExportMechanicAnalysesQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/MechanicMetrics/ExportMechanicAnalysesQueryHandler.cs
@@ -1,0 +1,103 @@
+using System.Globalization;
+using System.Text;
+
+using Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
+using Api.Infrastructure;
+using Api.SharedKernel.Application.Interfaces;
+
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Queries.MechanicMetrics;
+
+internal sealed class ExportMechanicAnalysesQueryHandler
+    : IQueryHandler<ExportMechanicAnalysesQuery, ExportMechanicAnalysesResult>
+{
+    private const int MaxRows = 10_000;
+
+    private readonly MeepleAiDbContext _db;
+    private readonly TimeProvider _timeProvider;
+
+    public ExportMechanicAnalysesQueryHandler(MeepleAiDbContext db, TimeProvider timeProvider)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+    }
+
+    public async Task<ExportMechanicAnalysesResult> Handle(
+        ExportMechanicAnalysesQuery request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var query = _db.MechanicAnalyses.AsNoTracking().AsQueryable();
+        if (request.GameId is Guid gameId)
+        {
+            query = query.Where(a => a.SharedGameId == gameId);
+        }
+        if (request.ReviewerId is Guid reviewerId)
+        {
+            query = query.Where(a => a.ReviewedBy == reviewerId);
+        }
+        if (request.Status is int status)
+        {
+            query = query.Where(a => a.Status == status);
+        }
+        if (request.StartDate is DateTime start)
+        {
+            query = query.Where(a => a.CreatedAt >= start);
+        }
+        if (request.EndDate is DateTime end)
+        {
+            query = query.Where(a => a.CreatedAt <= end);
+        }
+
+        var rows = await query
+            .OrderByDescending(a => a.CreatedAt)
+            .Take(MaxRows)
+            .Select(a => new MechanicRecentAnalysisRowDto(
+                a.Id,
+                a.SharedGameId,
+                _db.SharedGames.Where(g => g.Id == a.SharedGameId).Select(g => g.Title).FirstOrDefault() ?? "—",
+                a.Status,
+                a.ReviewedBy,
+                a.ReviewedBy == null
+                    ? null
+                    : _db.Users.Where(u => u.Id == a.ReviewedBy).Select(u => u.DisplayName ?? u.Email).FirstOrDefault(),
+                a.CreatedAt,
+                a.ReviewedAt,
+                a.EstimatedCostUsd))
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var sb = new StringBuilder();
+        // Use '\n' consistently (not AppendLine → platform-dependent \r\n) so parsers get uniform rows.
+        sb.Append("Id,GameName,Status,ReviewerId,ReviewerName,CreatedAt,ReviewedAt,EstimatedCostUsd").Append('\n');
+        foreach (var r in rows)
+        {
+            sb.Append(r.Id).Append(',')
+                .Append(EscapeCsv(r.GameName)).Append(',')
+                .Append(r.Status.ToString(CultureInfo.InvariantCulture)).Append(',')
+                .Append(r.ReviewedBy?.ToString() ?? string.Empty).Append(',')
+                .Append(EscapeCsv(r.ReviewerName ?? string.Empty)).Append(',')
+                .Append(r.CreatedAt.ToString("O", CultureInfo.InvariantCulture)).Append(',')
+                .Append(r.ReviewedAt?.ToString("O", CultureInfo.InvariantCulture) ?? string.Empty).Append(',')
+                .Append(r.EstimatedCostUsd.ToString(CultureInfo.InvariantCulture))
+                .Append('\n');
+        }
+
+        var content = Encoding.UTF8.GetBytes(sb.ToString());
+        var stamp = _timeProvider.GetUtcNow().UtcDateTime.ToString("yyyyMMdd-HHmmss", CultureInfo.InvariantCulture);
+        return new ExportMechanicAnalysesResult(content, "text/csv", $"mechanic-analyses-{stamp}.csv");
+    }
+
+    private static string EscapeCsv(string value)
+    {
+        if (value.Contains(',', StringComparison.Ordinal)
+            || value.Contains('"', StringComparison.Ordinal)
+            || value.Contains('\n', StringComparison.Ordinal)
+            || value.Contains('\r', StringComparison.Ordinal))
+        {
+            return $"\"{value.Replace("\"", "\"\"", StringComparison.Ordinal)}\"";
+        }
+        return value;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/MechanicMetrics/GetMechanicCostByDayQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/MechanicMetrics/GetMechanicCostByDayQuery.cs
@@ -1,0 +1,13 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Queries.MechanicMetrics;
+
+/// <summary>
+/// #532 ME-M2.3: daily cost time-series for the last <paramref name="Days"/> days (gap-filled), with
+/// optional game / reviewer filters.
+/// </summary>
+internal sealed record GetMechanicCostByDayQuery(
+    int Days = 30,
+    Guid? GameId = null,
+    Guid? ReviewerId = null) : IQuery<IReadOnlyList<MechanicCostByDayDto>>;

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/MechanicMetrics/GetMechanicCostByDayQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/MechanicMetrics/GetMechanicCostByDayQueryHandler.cs
@@ -1,0 +1,63 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
+using Api.Infrastructure;
+using Api.SharedKernel.Application.Interfaces;
+
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Queries.MechanicMetrics;
+
+internal sealed class GetMechanicCostByDayQueryHandler
+    : IQueryHandler<GetMechanicCostByDayQuery, IReadOnlyList<MechanicCostByDayDto>>
+{
+    private const int MaxDays = 90;
+    private const int MinDays = 1;
+
+    private readonly MeepleAiDbContext _db;
+    private readonly TimeProvider _timeProvider;
+
+    public GetMechanicCostByDayQueryHandler(MeepleAiDbContext db, TimeProvider timeProvider)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+    }
+
+    public async Task<IReadOnlyList<MechanicCostByDayDto>> Handle(
+        GetMechanicCostByDayQuery request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        var days = Math.Clamp(request.Days, MinDays, MaxDays);
+
+        var todayUtc = _timeProvider.GetUtcNow().UtcDateTime.Date;
+        var startDate = todayUtc.AddDays(-(days - 1));
+
+        var query = _db.MechanicAnalyses.AsNoTracking().Where(a => a.CreatedAt >= startDate);
+        if (request.GameId is Guid gameId)
+        {
+            query = query.Where(a => a.SharedGameId == gameId);
+        }
+        if (request.ReviewerId is Guid reviewerId)
+        {
+            query = query.Where(a => a.ReviewedBy == reviewerId);
+        }
+
+        var byDay = await query
+            .GroupBy(a => a.CreatedAt.Date)
+            .Select(g => new { Date = g.Key, Cost = g.Sum(a => a.EstimatedCostUsd), Count = g.Count() })
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        // Gap-fill: emit one bucket per day so the chart has a continuous x-axis.
+        var result = new List<MechanicCostByDayDto>(days);
+        for (var i = 0; i < days; i++)
+        {
+            var day = startDate.AddDays(i);
+            var bucket = byDay.FirstOrDefault(b => b.Date == day);
+            result.Add(new MechanicCostByDayDto(
+                DateOnly.FromDateTime(day),
+                bucket?.Cost ?? 0m,
+                bucket?.Count ?? 0));
+        }
+
+        return result;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/MechanicMetrics/GetMechanicMetricsSummaryQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/MechanicMetrics/GetMechanicMetricsSummaryQuery.cs
@@ -1,0 +1,14 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Queries.MechanicMetrics;
+
+/// <summary>
+/// #532 ME-M2.3: cost / review-time / approval-rate KPIs + rejection breakdown over Mechanic Extractor
+/// analyses, with optional game / reviewer / created-at-range filters.
+/// </summary>
+internal sealed record GetMechanicMetricsSummaryQuery(
+    Guid? GameId = null,
+    Guid? ReviewerId = null,
+    DateTime? StartDate = null,
+    DateTime? EndDate = null) : IQuery<MechanicMetricsSummaryDto>;

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/MechanicMetrics/GetMechanicMetricsSummaryQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/MechanicMetrics/GetMechanicMetricsSummaryQueryHandler.cs
@@ -1,0 +1,87 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
+using Api.Infrastructure;
+using Api.SharedKernel.Application.Interfaces;
+
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Queries.MechanicMetrics;
+
+internal sealed class GetMechanicMetricsSummaryQueryHandler
+    : IQueryHandler<GetMechanicMetricsSummaryQuery, MechanicMetricsSummaryDto>
+{
+    // MechanicAnalysisStatus ints: Draft=0, InReview=1, Published=2, Rejected=3, PartiallyExtracted=4.
+    private const int StatusInReview = 1;
+    private const int StatusPublished = 2;
+    private const int StatusRejected = 3;
+    private const int StatusPartiallyExtracted = 4;
+
+    private readonly MeepleAiDbContext _db;
+
+    public GetMechanicMetricsSummaryQueryHandler(MeepleAiDbContext db)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+    }
+
+    public async Task<MechanicMetricsSummaryDto> Handle(
+        GetMechanicMetricsSummaryQuery request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        // Query filter already excludes IsSuppressed. AsNoTracking per PERF-05 (read-only analytics).
+        var query = _db.MechanicAnalyses.AsNoTracking().AsQueryable();
+
+        if (request.GameId is Guid gameId)
+        {
+            query = query.Where(a => a.SharedGameId == gameId);
+        }
+        if (request.ReviewerId is Guid reviewerId)
+        {
+            query = query.Where(a => a.ReviewedBy == reviewerId);
+        }
+        if (request.StartDate is DateTime start)
+        {
+            query = query.Where(a => a.CreatedAt >= start);
+        }
+        if (request.EndDate is DateTime end)
+        {
+            query = query.Where(a => a.CreatedAt <= end);
+        }
+
+        // Materialize the minimal projection for the filtered set — mechanic analyses are modest in
+        // volume, and review-time (TimeSpan.TotalHours) + rejection-reason grouping are cleanest in memory.
+        var rows = await query
+            .Select(a => new Row(a.Status, a.EstimatedCostUsd, a.CreatedAt, a.ReviewedAt, a.RejectionReason))
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var total = rows.Count;
+        var published = rows.Count(r => r.Status == StatusPublished);
+        var rejected = rows.Count(r => r.Status is StatusRejected or StatusPartiallyExtracted);
+        var inReview = rows.Count(r => r.Status == StatusInReview);
+        var totalCost = rows.Sum(r => r.Cost);
+        var averageCost = total > 0 ? totalCost / total : 0m;
+
+        var reviewed = rows.Where(r => r.ReviewedAt.HasValue).ToList();
+        double? averageReviewHours = reviewed.Count > 0
+            ? reviewed.Average(r => (r.ReviewedAt!.Value - r.CreatedAt).TotalHours)
+            : null;
+
+        // Approval rate over reviewed terminal states (Published vs Rejected/Partial).
+        var approvalDenominator = published + rejected;
+        var approvalRate = approvalDenominator > 0 ? (double)published / approvalDenominator * 100.0 : 0.0;
+
+        var rejectionBreakdown = rows
+            .Where(r => r.Status is StatusRejected or StatusPartiallyExtracted && !string.IsNullOrWhiteSpace(r.RejectionReason))
+            .GroupBy(r => r.RejectionReason!, StringComparer.Ordinal)
+            .Select(g => new RejectionReasonCountDto(g.Key, g.Count()))
+            .OrderByDescending(x => x.Count)
+            .ThenBy(x => x.Reason, StringComparer.Ordinal)
+            .ToList();
+
+        return new MechanicMetricsSummaryDto(
+            totalCost, total, published, rejected, inReview,
+            averageCost, averageReviewHours, approvalRate, rejectionBreakdown);
+    }
+
+    private sealed record Row(int Status, decimal Cost, DateTime CreatedAt, DateTime? ReviewedAt, string? RejectionReason);
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/MechanicMetrics/GetMechanicMetricsSummaryQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/MechanicMetrics/GetMechanicMetricsSummaryQueryHandler.cs
@@ -50,7 +50,7 @@ internal sealed class GetMechanicMetricsSummaryQueryHandler
         // Materialize the minimal projection for the filtered set — mechanic analyses are modest in
         // volume, and review-time (TimeSpan.TotalHours) + rejection-reason grouping are cleanest in memory.
         var rows = await query
-            .Select(a => new Row(a.Status, a.EstimatedCostUsd, a.CreatedAt, a.ReviewedAt, a.RejectionReason))
+            .Select(a => new Row(a.Status, a.EstimatedCostUsd, a.CreatedAt, a.ReviewedAt, a.RejectionReason, a.CreatedBy, a.ReviewedBy))
             .ToListAsync(cancellationToken)
             .ConfigureAwait(false);
 
@@ -61,9 +61,18 @@ internal sealed class GetMechanicMetricsSummaryQueryHandler
         var totalCost = rows.Sum(r => r.Cost);
         var averageCost = total > 0 ? totalCost / total : 0m;
 
-        var reviewed = rows.Where(r => r.ReviewedAt.HasValue).ToList();
-        double? averageReviewHours = reviewed.Count > 0
-            ? reviewed.Average(r => (r.ReviewedAt!.Value - r.CreatedAt).TotalHours)
+        // Review time reflects HUMAN review throughput only. System auto-transitions
+        // (AutoRejectFromDraft, MarkAsPartiallyExtracted) stamp ReviewedAt≈CreatedAt in the same
+        // pipeline run using the analysis' own CreatedBy as actor, so they'd drag the average toward
+        // zero. Include only terminal human decisions (Published/Rejected) reviewed by someone other
+        // than the creator (Partial=4 is always a system transition, so it's excluded by status).
+        var humanReviewed = rows
+            .Where(r => r.ReviewedAt.HasValue
+                && r.Status is StatusPublished or StatusRejected
+                && r.ReviewedBy.HasValue && r.ReviewedBy.Value != r.CreatedBy)
+            .ToList();
+        double? averageReviewHours = humanReviewed.Count > 0
+            ? humanReviewed.Average(r => (r.ReviewedAt!.Value - r.CreatedAt).TotalHours)
             : null;
 
         // Approval rate over reviewed terminal states (Published vs Rejected/Partial).
@@ -83,5 +92,7 @@ internal sealed class GetMechanicMetricsSummaryQueryHandler
             averageCost, averageReviewHours, approvalRate, rejectionBreakdown);
     }
 
-    private sealed record Row(int Status, decimal Cost, DateTime CreatedAt, DateTime? ReviewedAt, string? RejectionReason);
+    private sealed record Row(
+        int Status, decimal Cost, DateTime CreatedAt, DateTime? ReviewedAt, string? RejectionReason,
+        Guid CreatedBy, Guid? ReviewedBy);
 }

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/MechanicMetrics/GetMechanicRecentAnalysesQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/MechanicMetrics/GetMechanicRecentAnalysesQuery.cs
@@ -1,0 +1,14 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Queries.MechanicMetrics;
+
+/// <summary>
+/// #532 ME-M2.3: paginated recent-analyses table with optional game / reviewer / status filters.
+/// </summary>
+internal sealed record GetMechanicRecentAnalysesQuery(
+    int Limit = 25,
+    int Offset = 0,
+    Guid? GameId = null,
+    Guid? ReviewerId = null,
+    int? Status = null) : IQuery<MechanicRecentAnalysesResult>;

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/MechanicMetrics/GetMechanicRecentAnalysesQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/MechanicMetrics/GetMechanicRecentAnalysesQueryHandler.cs
@@ -1,0 +1,65 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
+using Api.Infrastructure;
+using Api.SharedKernel.Application.Interfaces;
+
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Queries.MechanicMetrics;
+
+internal sealed class GetMechanicRecentAnalysesQueryHandler
+    : IQueryHandler<GetMechanicRecentAnalysesQuery, MechanicRecentAnalysesResult>
+{
+    private const int MaxLimit = 200;
+
+    private readonly MeepleAiDbContext _db;
+
+    public GetMechanicRecentAnalysesQueryHandler(MeepleAiDbContext db)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+    }
+
+    public async Task<MechanicRecentAnalysesResult> Handle(
+        GetMechanicRecentAnalysesQuery request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        var limit = Math.Clamp(request.Limit, 1, MaxLimit);
+        var offset = Math.Max(0, request.Offset);
+
+        var query = _db.MechanicAnalyses.AsNoTracking().AsQueryable();
+        if (request.GameId is Guid gameId)
+        {
+            query = query.Where(a => a.SharedGameId == gameId);
+        }
+        if (request.ReviewerId is Guid reviewerId)
+        {
+            query = query.Where(a => a.ReviewedBy == reviewerId);
+        }
+        if (request.Status is int status)
+        {
+            query = query.Where(a => a.Status == status);
+        }
+
+        var totalCount = await query.CountAsync(cancellationToken).ConfigureAwait(false);
+
+        var items = await query
+            .OrderByDescending(a => a.CreatedAt)
+            .Skip(offset)
+            .Take(limit)
+            .Select(a => new MechanicRecentAnalysisRowDto(
+                a.Id,
+                a.SharedGameId,
+                _db.SharedGames.Where(g => g.Id == a.SharedGameId).Select(g => g.Title).FirstOrDefault() ?? "—",
+                a.Status,
+                a.ReviewedBy,
+                a.ReviewedBy == null
+                    ? null
+                    : _db.Users.Where(u => u.Id == a.ReviewedBy).Select(u => u.DisplayName ?? u.Email).FirstOrDefault(),
+                a.CreatedAt,
+                a.ReviewedAt,
+                a.EstimatedCostUsd))
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return new MechanicRecentAnalysesResult(items, totalCount);
+    }
+}

--- a/apps/api/src/Api/Routing/AdminMechanicAnalysesEndpoints.cs
+++ b/apps/api/src/Api/Routing/AdminMechanicAnalysesEndpoints.cs
@@ -1,6 +1,7 @@
 using Api.BoundedContexts.Authentication.Application.DTOs;
 using Api.BoundedContexts.SharedGameCatalog.Application.Commands.MechanicExtractor;
 using Api.BoundedContexts.SharedGameCatalog.Application.Queries.MechanicExtractor;
+using Api.BoundedContexts.SharedGameCatalog.Application.Queries.MechanicMetrics;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
 using Api.Filters;
 using MediatR;
@@ -55,6 +56,54 @@ internal static class AdminMechanicAnalysesEndpoints
             "Returns a page of mechanic analyses ordered by CreatedAt DESC. Bypasses the " +
             "IsSuppressed query filter so suppressed rows remain reachable from the index. " +
             "Page defaults to 1, pageSize to 20 (capped at 100).");
+
+        // #532 ME-M2.3: metrics dashboard endpoints (KPIs, cost time-series, recent table, CSV export).
+        group.MapGet("/metrics/summary", async (
+            Guid? gameId, Guid? reviewerId, DateTime? startDate, DateTime? endDate,
+            IMediator mediator, CancellationToken ct) =>
+        {
+            var result = await mediator
+                .Send(new GetMechanicMetricsSummaryQuery(gameId, reviewerId, startDate, endDate), ct)
+                .ConfigureAwait(false);
+            return Results.Ok(result);
+        })
+        .WithName("AdminMechanicMetricsSummary")
+        .WithSummary("Mechanic Extractor metrics KPIs: cost, review time, approval rate, rejection breakdown (#532)");
+
+        group.MapGet("/metrics/cost-by-day", async (
+            int? days, Guid? gameId, Guid? reviewerId, IMediator mediator, CancellationToken ct) =>
+        {
+            var result = await mediator
+                .Send(new GetMechanicCostByDayQuery(days ?? 30, gameId, reviewerId), ct)
+                .ConfigureAwait(false);
+            return Results.Ok(result);
+        })
+        .WithName("AdminMechanicMetricsCostByDay")
+        .WithSummary("Mechanic Extractor daily cost time-series, gap-filled (#532)");
+
+        group.MapGet("/metrics/recent", async (
+            int? limit, int? offset, Guid? gameId, Guid? reviewerId, int? status,
+            IMediator mediator, CancellationToken ct) =>
+        {
+            var result = await mediator
+                .Send(new GetMechanicRecentAnalysesQuery(limit ?? 25, offset ?? 0, gameId, reviewerId, status), ct)
+                .ConfigureAwait(false);
+            return Results.Ok(result);
+        })
+        .WithName("AdminMechanicMetricsRecent")
+        .WithSummary("Mechanic Extractor recent analyses (paged + filtered by game/reviewer/status) (#532)");
+
+        group.MapGet("/metrics/export", async (
+            Guid? gameId, Guid? reviewerId, int? status, DateTime? startDate, DateTime? endDate,
+            IMediator mediator, CancellationToken ct) =>
+        {
+            var result = await mediator
+                .Send(new ExportMechanicAnalysesQuery(gameId, reviewerId, status, startDate, endDate), ct)
+                .ConfigureAwait(false);
+            return Results.File(result.Content, result.ContentType, result.FileName);
+        })
+        .WithName("AdminMechanicMetricsExport")
+        .WithSummary("Mechanic Extractor analyses CSV export with the same filters as the grid (#532)");
 
         // POST /api/v1/admin/mechanic-analyses
         // Enqueues the async AI pipeline (B5=B). Returns 202 Accepted with polling URL.

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/MechanicAnalysesExportQueryTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/MechanicAnalysesExportQueryTests.cs
@@ -1,0 +1,81 @@
+using System.Text;
+
+using Api.BoundedContexts.SharedGameCatalog.Application.Queries.MechanicMetrics;
+using Api.Infrastructure;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using MediatR;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Infrastructure;
+
+/// <summary>#532: CSV export emits a header + one row per analysis, with comma-containing values quoted.</summary>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class MechanicAnalysesExportQueryTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly string _testDbName;
+    private WebApplicationFactory<Program> _factory = null!;
+    private Guid _userId;
+
+    public MechanicAnalysesExportQueryTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+        _testDbName = $"me532_export_{Guid.NewGuid():N}";
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        var conn = await _fixture.CreateIsolatedDatabaseAsync(_testDbName);
+        _factory = IntegrationWebApplicationFactory.Create(conn);
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        await db.Database.MigrateAsync();
+        (_userId, _) = await TestSessionHelper.CreateUserSessionAsync(db, Guid.NewGuid());
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_factory is not null)
+        {
+            await _factory.DisposeAsync();
+        }
+        await _fixture.DropIsolatedDatabaseAsync(_testDbName);
+    }
+
+    [Fact]
+    public async Task Export_EmitsHeaderAndRows_WithCsvEscaping()
+    {
+        var now = DateTime.UtcNow;
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var game = await MechanicMetricsSeed.GameAsync(scope, _userId, "Ticket, Ride"); // comma → must be quoted
+            await MechanicMetricsSeed.AnalysisAsync(scope, game, _userId, status: 2, costUsd: 1.25m,
+                createdAt: now.AddMinutes(-2), reviewedAt: now, reviewedBy: _userId);
+            await MechanicMetricsSeed.AnalysisAsync(scope, game, _userId, status: 1, costUsd: 0.30m, createdAt: now.AddMinutes(-1));
+        }
+
+        Api.BoundedContexts.SharedGameCatalog.Application.DTOs.ExportMechanicAnalysesResult result;
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+            result = await mediator.Send(new ExportMechanicAnalysesQuery());
+        }
+
+        result.ContentType.Should().Be("text/csv");
+        result.FileName.Should().StartWith("mechanic-analyses-").And.EndWith(".csv");
+
+        var csv = Encoding.UTF8.GetString(result.Content);
+        var lines = csv.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        lines[0].Should().Be("Id,GameName,Status,ReviewerId,ReviewerName,CreatedAt,ReviewedAt,EstimatedCostUsd");
+        lines.Should().HaveCount(3); // header + 2 rows
+        csv.Should().Contain("\"Ticket, Ride\""); // comma-containing game name quoted
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/MechanicCostByDayQueryTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/MechanicCostByDayQueryTests.cs
@@ -1,0 +1,79 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Queries.MechanicMetrics;
+using Api.Infrastructure;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using MediatR;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Infrastructure;
+
+/// <summary>#532: the daily cost time-series buckets cost/count per day and gap-fills empty days.</summary>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class MechanicCostByDayQueryTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly string _testDbName;
+    private WebApplicationFactory<Program> _factory = null!;
+    private Guid _userId;
+
+    public MechanicCostByDayQueryTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+        _testDbName = $"me532_costday_{Guid.NewGuid():N}";
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        var conn = await _fixture.CreateIsolatedDatabaseAsync(_testDbName);
+        _factory = IntegrationWebApplicationFactory.Create(conn);
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        await db.Database.MigrateAsync();
+        (_userId, _) = await TestSessionHelper.CreateUserSessionAsync(db, Guid.NewGuid());
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_factory is not null)
+        {
+            await _factory.DisposeAsync();
+        }
+        await _fixture.DropIsolatedDatabaseAsync(_testDbName);
+    }
+
+    [Fact]
+    public async Task CostByDay_SumsPerDay_AndGapFills()
+    {
+        var now = DateTime.UtcNow;
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var game = await MechanicMetricsSeed.GameAsync(scope, _userId);
+            // Two InReview today (1.00 + 2.00), one InReview 3 days ago (5.00). InReview avoids the
+            // one-Published-per-game constraint.
+            await MechanicMetricsSeed.AnalysisAsync(scope, game, _userId, status: 1, costUsd: 1.00m, createdAt: now);
+            await MechanicMetricsSeed.AnalysisAsync(scope, game, _userId, status: 1, costUsd: 2.00m, createdAt: now);
+            await MechanicMetricsSeed.AnalysisAsync(scope, game, _userId, status: 1, costUsd: 5.00m, createdAt: now.AddDays(-3));
+        }
+
+        IReadOnlyList<Api.BoundedContexts.SharedGameCatalog.Application.DTOs.MechanicCostByDayDto> series;
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+            series = await mediator.Send(new GetMechanicCostByDayQuery(Days: 7));
+        }
+
+        series.Should().HaveCount(7);
+        var today = DateOnly.FromDateTime(now.Date);
+        series.Single(d => d.Date == today).Should().BeEquivalentTo(new { CostUsd = 3.00m, AnalysisCount = 2 },
+            o => o.ExcludingMissingMembers());
+        series.Single(d => d.Date == today.AddDays(-3)).CostUsd.Should().Be(5.00m);
+        series.Where(d => d.Date != today && d.Date != today.AddDays(-3)).Should().OnlyContain(d => d.CostUsd == 0m);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/MechanicMetricsEndpointsTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/MechanicMetricsEndpointsTests.cs
@@ -1,0 +1,81 @@
+using System.Net;
+
+using Api.Infrastructure;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Infrastructure;
+
+/// <summary>#532: the metrics endpoints are admin-gated and route to the query handlers.</summary>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class MechanicMetricsEndpointsTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly string _testDbName;
+    private WebApplicationFactory<Program> _factory = null!;
+    private HttpClient _client = null!;
+    private string _adminToken = null!;
+
+    public MechanicMetricsEndpointsTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+        _testDbName = $"me532_endpoints_{Guid.NewGuid():N}";
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        var conn = await _fixture.CreateIsolatedDatabaseAsync(_testDbName);
+        _factory = IntegrationWebApplicationFactory.Create(conn);
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            await db.Database.MigrateAsync();
+            (_, _adminToken) = await TestSessionHelper.CreateAdminSessionAsync(db, Guid.NewGuid());
+        }
+        _client = _factory.CreateClient();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _client?.Dispose();
+        if (_factory is not null)
+        {
+            await _factory.DisposeAsync();
+        }
+        await _fixture.DropIsolatedDatabaseAsync(_testDbName);
+    }
+
+    [Fact]
+    public async Task Summary_WithAdminSession_Returns200()
+    {
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get, "/api/v1/admin/mechanic-analyses/metrics/summary", _adminToken);
+        var response = await _client.SendAsync(request);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact]
+    public async Task Summary_WithoutSession_IsRejected()
+    {
+        var response = await _client.GetAsync("/api/v1/admin/mechanic-analyses/metrics/summary");
+        response.StatusCode.Should().BeOneOf(HttpStatusCode.Unauthorized, HttpStatusCode.Forbidden);
+    }
+
+    [Fact]
+    public async Task Export_WithAdminSession_ReturnsCsv()
+    {
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Get, "/api/v1/admin/mechanic-analyses/metrics/export", _adminToken);
+        var response = await _client.SendAsync(request);
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        response.Content.Headers.ContentType!.MediaType.Should().Be("text/csv");
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/MechanicMetricsSeed.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/MechanicMetricsSeed.cs
@@ -1,0 +1,71 @@
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Infrastructure;
+
+/// <summary>
+/// Shared seed helpers for the #532 metrics-dashboard query tests: a shared game + mechanic analyses
+/// with explicit status / cost / review timestamps / rejection reason.
+/// </summary>
+internal static class MechanicMetricsSeed
+{
+    public static async Task<Guid> GameAsync(IServiceScope scope, Guid createdBy, string title = "Catan")
+    {
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var gameId = Guid.NewGuid();
+        db.SharedGames.Add(new SharedGameEntity
+        {
+            Id = gameId,
+            Title = title,
+            Description = "metrics seed",
+            ImageUrl = string.Empty,
+            ThumbnailUrl = string.Empty,
+            YearPublished = 1995,
+            MinPlayers = 3,
+            MaxPlayers = 4,
+            PlayingTimeMinutes = 90,
+            MinAge = 10,
+            Status = 1,
+            CreatedBy = createdBy,
+            CreatedAt = DateTime.UtcNow
+        });
+        await db.SaveChangesAsync();
+        return gameId;
+    }
+
+    public static async Task<Guid> AnalysisAsync(
+        IServiceScope scope,
+        Guid gameId,
+        Guid createdBy,
+        int status,
+        decimal costUsd,
+        DateTime createdAt,
+        DateTime? reviewedAt = null,
+        Guid? reviewedBy = null,
+        string? rejectionReason = null)
+    {
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var id = Guid.NewGuid();
+        db.MechanicAnalyses.Add(new MechanicAnalysisEntity
+        {
+            Id = id,
+            SharedGameId = gameId,
+            PdfDocumentId = Guid.NewGuid(),
+            PromptVersion = "v1.0.0",
+            Status = status,
+            CreatedBy = createdBy,
+            CreatedAt = createdAt,
+            ReviewedBy = reviewedBy,
+            ReviewedAt = reviewedAt,
+            RejectionReason = rejectionReason,
+            TotalTokensUsed = 0,
+            EstimatedCostUsd = costUsd,
+            ModelUsed = "test-model",
+            Provider = "test-provider",
+            CostCapUsd = 1.00m
+        });
+        await db.SaveChangesAsync();
+        return id;
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/MechanicMetricsSummaryQueryTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/MechanicMetricsSummaryQueryTests.cs
@@ -1,0 +1,101 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Queries.MechanicMetrics;
+using Api.Infrastructure;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using MediatR;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Infrastructure;
+
+/// <summary>
+/// #532: the metrics summary query computes cost / review-time / approval-rate KPIs + rejection breakdown
+/// over mechanic analyses, honoring the game / reviewer / date filters.
+/// </summary>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class MechanicMetricsSummaryQueryTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly string _testDbName;
+    private WebApplicationFactory<Program> _factory = null!;
+    private Guid _userId;
+    private readonly Guid _reviewerId = Guid.NewGuid();
+
+    public MechanicMetricsSummaryQueryTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+        _testDbName = $"me532_summary_{Guid.NewGuid():N}";
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        var conn = await _fixture.CreateIsolatedDatabaseAsync(_testDbName);
+        _factory = IntegrationWebApplicationFactory.Create(conn);
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        await db.Database.MigrateAsync();
+        (_userId, _) = await TestSessionHelper.CreateUserSessionAsync(db, Guid.NewGuid());
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_factory is not null)
+        {
+            await _factory.DisposeAsync();
+        }
+        await _fixture.DropIsolatedDatabaseAsync(_testDbName);
+    }
+
+    [Fact]
+    public async Task Summary_ComputesKpis_AndRejectionBreakdown()
+    {
+        var now = DateTime.UtcNow;
+        using (var scope = _factory.Services.CreateScope())
+        {
+            // At most one Published per game (ux_mechanic_analyses_published_per_game) → 2 games.
+            var game1 = await MechanicMetricsSeed.GameAsync(scope, _userId, "Catan");
+            var game2 = await MechanicMetricsSeed.GameAsync(scope, _userId, "Carcassonne");
+            // game1: Published 1.00 (review 2h) + Rejected 0.50 "factual" (review 1h) + InReview 0.20.
+            await MechanicMetricsSeed.AnalysisAsync(scope, game1, _userId, status: 2, costUsd: 1.00m,
+                createdAt: now.AddHours(-2), reviewedAt: now, reviewedBy: _reviewerId);
+            await MechanicMetricsSeed.AnalysisAsync(scope, game1, _userId, status: 3, costUsd: 0.50m,
+                createdAt: now.AddHours(-1), reviewedAt: now, reviewedBy: _reviewerId, rejectionReason: "factual");
+            await MechanicMetricsSeed.AnalysisAsync(scope, game1, _userId, status: 1, costUsd: 0.20m,
+                createdAt: now);
+            // game2: Published 3.00 (review 4h).
+            await MechanicMetricsSeed.AnalysisAsync(scope, game2, _userId, status: 2, costUsd: 3.00m,
+                createdAt: now.AddHours(-4), reviewedAt: now, reviewedBy: _reviewerId);
+        }
+
+        MechanicMetricsSummaryDtoAsserts(await RunAsync(new GetMechanicMetricsSummaryQuery()));
+    }
+
+    private static void MechanicMetricsSummaryDtoAsserts(
+        Api.BoundedContexts.SharedGameCatalog.Application.DTOs.MechanicMetricsSummaryDto dto)
+    {
+        dto.TotalAnalyses.Should().Be(4);
+        dto.TotalCostUsd.Should().Be(4.70m);
+        dto.PublishedCount.Should().Be(2);
+        dto.RejectedCount.Should().Be(1);
+        dto.InReviewCount.Should().Be(1);
+        dto.AverageCostUsd.Should().BeApproximately(1.175m, 0.001m);
+        dto.ApprovalRatePct.Should().BeApproximately(66.667, 0.01);
+        dto.AverageReviewTimeHours.Should().NotBeNull();
+        dto.AverageReviewTimeHours!.Value.Should().BeApproximately(2.333, 0.01); // avg(2,4,1)
+        dto.RejectionBreakdown.Should().ContainSingle(r => r.Reason == "factual" && r.Count == 1);
+    }
+
+    private async Task<Api.BoundedContexts.SharedGameCatalog.Application.DTOs.MechanicMetricsSummaryDto> RunAsync(
+        GetMechanicMetricsSummaryQuery query)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+        return await mediator.Send(query);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/MechanicMetricsSummaryQueryTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/MechanicMetricsSummaryQueryTests.cs
@@ -76,6 +76,27 @@ public sealed class MechanicMetricsSummaryQueryTests : IAsyncLifetime
         MechanicMetricsSummaryDtoAsserts(await RunAsync(new GetMechanicMetricsSummaryQuery()));
     }
 
+    [Fact]
+    public async Task ReviewTime_ExcludesSystemAutoTransitions()
+    {
+        var now = DateTime.UtcNow;
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var humanGame = await MechanicMetricsSeed.GameAsync(scope, _userId, "HumanReviewed");
+            var systemGame = await MechanicMetricsSeed.GameAsync(scope, _userId, "AutoRejected");
+            // Human-approved: reviewed by a different admin, 4h elapsed → counts.
+            await MechanicMetricsSeed.AnalysisAsync(scope, humanGame, _userId, status: 2, costUsd: 1.00m,
+                createdAt: now.AddHours(-4), reviewedAt: now, reviewedBy: _reviewerId);
+            // System auto-reject: ReviewedBy == CreatedBy, ReviewedAt≈CreatedAt → must be excluded.
+            await MechanicMetricsSeed.AnalysisAsync(scope, systemGame, _userId, status: 3, costUsd: 0.10m,
+                createdAt: now.AddMinutes(-1), reviewedAt: now, reviewedBy: _userId, rejectionReason: "llm_generation_failed");
+        }
+
+        var dto = await RunAsync(new GetMechanicMetricsSummaryQuery());
+        dto.AverageReviewTimeHours.Should().NotBeNull();
+        dto.AverageReviewTimeHours!.Value.Should().BeApproximately(4.0, 0.05); // only the human-reviewed 4h row
+    }
+
     private static void MechanicMetricsSummaryDtoAsserts(
         Api.BoundedContexts.SharedGameCatalog.Application.DTOs.MechanicMetricsSummaryDto dto)
     {

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/MechanicRecentAnalysesQueryTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/MechanicRecentAnalysesQueryTests.cs
@@ -1,0 +1,104 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
+using Api.BoundedContexts.SharedGameCatalog.Application.Queries.MechanicMetrics;
+using Api.Infrastructure;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using MediatR;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Infrastructure;
+
+/// <summary>#532: the recent-analyses query filters (game/reviewer/status), paginates, and resolves names.</summary>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class MechanicRecentAnalysesQueryTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly string _testDbName;
+    private WebApplicationFactory<Program> _factory = null!;
+    private Guid _userId;
+    private Guid _game1;
+    private Guid _game2;
+
+    public MechanicRecentAnalysesQueryTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+        _testDbName = $"me532_recent_{Guid.NewGuid():N}";
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        var conn = await _fixture.CreateIsolatedDatabaseAsync(_testDbName);
+        _factory = IntegrationWebApplicationFactory.Create(conn);
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        await db.Database.MigrateAsync();
+        (_userId, _) = await TestSessionHelper.CreateUserSessionAsync(db, Guid.NewGuid());
+
+        var now = DateTime.UtcNow;
+        _game1 = await MechanicMetricsSeed.GameAsync(scope, _userId, "Catan");
+        _game2 = await MechanicMetricsSeed.GameAsync(scope, _userId, "Carcassonne");
+        // game1: Published (reviewed by _userId). game2: Rejected + InReview.
+        await MechanicMetricsSeed.AnalysisAsync(scope, _game1, _userId, status: 2, costUsd: 1.00m,
+            createdAt: now.AddMinutes(-3), reviewedAt: now, reviewedBy: _userId);
+        await MechanicMetricsSeed.AnalysisAsync(scope, _game2, _userId, status: 3, costUsd: 0.50m,
+            createdAt: now.AddMinutes(-2), reviewedAt: now, reviewedBy: _userId, rejectionReason: "factual");
+        await MechanicMetricsSeed.AnalysisAsync(scope, _game2, _userId, status: 1, costUsd: 0.20m,
+            createdAt: now.AddMinutes(-1));
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_factory is not null)
+        {
+            await _factory.DisposeAsync();
+        }
+        await _fixture.DropIsolatedDatabaseAsync(_testDbName);
+    }
+
+    private async Task<MechanicRecentAnalysesResult> RunAsync(GetMechanicRecentAnalysesQuery q)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+        return await mediator.Send(q);
+    }
+
+    [Fact]
+    public async Task Recent_ReturnsAll_WithNamesResolved()
+    {
+        var result = await RunAsync(new GetMechanicRecentAnalysesQuery());
+        result.TotalCount.Should().Be(3);
+        result.Items.Should().HaveCount(3);
+        result.Items.Should().Contain(i => i.GameName == "Catan" && i.Status == 2 && i.ReviewerName != null);
+    }
+
+    [Fact]
+    public async Task Recent_FiltersByGame()
+    {
+        var result = await RunAsync(new GetMechanicRecentAnalysesQuery(GameId: _game1));
+        result.TotalCount.Should().Be(1);
+        result.Items.Should().OnlyContain(i => i.SharedGameId == _game1);
+    }
+
+    [Fact]
+    public async Task Recent_FiltersByStatus()
+    {
+        var result = await RunAsync(new GetMechanicRecentAnalysesQuery(Status: 3));
+        result.TotalCount.Should().Be(1);
+        result.Items.Should().OnlyContain(i => i.Status == 3);
+    }
+
+    [Fact]
+    public async Task Recent_Paginates()
+    {
+        var result = await RunAsync(new GetMechanicRecentAnalysesQuery(Limit: 1, Offset: 0));
+        result.TotalCount.Should().Be(3); // total ignores paging
+        result.Items.Should().HaveCount(1);
+    }
+}

--- a/apps/web/src/app/admin/(dashboard)/knowledge-base/mechanic-extractor/metrics/__tests__/page.test.tsx
+++ b/apps/web/src/app/admin/(dashboard)/knowledge-base/mechanic-extractor/metrics/__tests__/page.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * #532 ME-M2.3 metrics dashboard page tests.
+ */
+import { screen, waitFor, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { renderWithQuery } from '@/__tests__/utils/query-test-utils';
+
+const mockGetSummary = vi.hoisted(() => vi.fn());
+const mockGetCostByDay = vi.hoisted(() => vi.fn());
+const mockGetRecent = vi.hoisted(() => vi.fn());
+const mockExportCsv = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/api/clients/adminClient', () => ({
+  createAdminClient: () => ({
+    getMechanicMetricsSummary: mockGetSummary,
+    getMechanicCostByDay: mockGetCostByDay,
+    getMechanicRecentAnalyses: mockGetRecent,
+    exportMechanicAnalysesCsv: mockExportCsv,
+  }),
+}));
+
+vi.mock('@/lib/api/core/httpClient', () => ({
+  HttpClient: class {},
+  getApiBase: () => '',
+}));
+
+import MechanicMetricsPage from '../page';
+
+describe('MechanicMetricsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSummary.mockResolvedValue({
+      totalCostUsd: 4.7,
+      totalAnalyses: 4,
+      publishedCount: 2,
+      rejectedCount: 1,
+      inReviewCount: 1,
+      averageCostUsd: 1.18,
+      averageReviewTimeHours: 2.3,
+      approvalRatePct: 66.7,
+      rejectionBreakdown: [{ reason: 'factual', count: 1 }],
+    });
+    mockGetCostByDay.mockResolvedValue([{ date: '2026-07-10', costUsd: 1, analysisCount: 1 }]);
+    mockGetRecent.mockResolvedValue({
+      items: [
+        {
+          id: 'a1',
+          sharedGameId: 'g1',
+          gameName: 'Catan',
+          status: 2,
+          reviewedBy: 'u1',
+          reviewerName: 'Alice',
+          createdAt: '2026-07-10T00:00:00Z',
+          reviewedAt: '2026-07-10T02:00:00Z',
+          estimatedCostUsd: 1.25,
+        },
+      ],
+      totalCount: 1,
+    });
+    mockExportCsv.mockResolvedValue(new Blob(['x'], { type: 'text/csv' }));
+  });
+
+  it('renders KPI tiles, chart, rejection breakdown, and the recent table', async () => {
+    renderWithQuery(<MechanicMetricsPage />);
+
+    expect(await screen.findByText('67%')).toBeInTheDocument(); // approval rate 66.7 → 67%
+    expect(screen.getByText('$1.18')).toBeInTheDocument(); // avg cost
+    expect(screen.getByText('2.3 h')).toBeInTheDocument(); // avg review time
+    expect(screen.getByTestId('mechanic-cost-chart')).toBeInTheDocument();
+
+    expect(await screen.findByText('Catan')).toBeInTheDocument(); // recent table row
+    expect(screen.getByTestId('rejection-breakdown')).toHaveTextContent('factual');
+  });
+
+  it('renders the three filter dropdowns', async () => {
+    renderWithQuery(<MechanicMetricsPage />);
+    await screen.findByText('67%');
+    expect(screen.getByLabelText('Filtra per gioco')).toBeInTheDocument();
+    expect(screen.getByLabelText('Filtra per reviewer')).toBeInTheDocument();
+    expect(screen.getByLabelText('Filtra per status')).toBeInTheDocument();
+  });
+
+  it('triggers CSV export when the export button is clicked', async () => {
+    const createUrl = vi.fn(() => 'blob:x');
+    const revokeUrl = vi.fn();
+    Object.defineProperty(URL, 'createObjectURL', { value: createUrl, configurable: true });
+    Object.defineProperty(URL, 'revokeObjectURL', { value: revokeUrl, configurable: true });
+
+    renderWithQuery(<MechanicMetricsPage />);
+    await screen.findByText('67%');
+
+    fireEvent.click(screen.getByTestId('export-csv'));
+
+    await waitFor(() => expect(mockExportCsv).toHaveBeenCalledTimes(1));
+  });
+});

--- a/apps/web/src/app/admin/(dashboard)/knowledge-base/mechanic-extractor/metrics/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/knowledge-base/mechanic-extractor/metrics/page.tsx
@@ -1,0 +1,355 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import type { JSX } from 'react';
+
+import { useQuery } from '@tanstack/react-query';
+import { CheckCircle2, Clock, DollarSign, ListChecks } from 'lucide-react';
+
+import { MechanicCostChart } from '@/components/admin/mechanic-extractor/metrics/MechanicCostChart';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/data-display/card';
+import { StatCard } from '@/components/ui/data-display/stat-card';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/data-display/table';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/overlays/select';
+import { Button } from '@/components/ui/primitives/button';
+import { createAdminClient } from '@/lib/api/clients/adminClient';
+import { HttpClient } from '@/lib/api/core/httpClient';
+
+type Period = 7 | 30 | 90;
+const PERIODS: Period[] = [7, 30, 90];
+const RECENT_PAGE_SIZE = 25;
+
+const STATUS_LABELS: Record<number, string> = {
+  0: 'Draft',
+  1: 'In Review',
+  2: 'Published',
+  3: 'Rejected',
+  4: 'Partial',
+};
+const STATUS_FILTER_OPTIONS = [0, 1, 2, 3, 4];
+
+const ALL = 'all';
+
+export default function MechanicMetricsPage(): JSX.Element {
+  const adminClient = useMemo(() => createAdminClient({ httpClient: new HttpClient() }), []);
+
+  const [period, setPeriod] = useState<Period>(30);
+  const [gameId, setGameId] = useState<string | undefined>();
+  const [reviewerId, setReviewerId] = useState<string | undefined>();
+  const [status, setStatus] = useState<number | undefined>();
+  const [offset, setOffset] = useState(0);
+
+  const startDate = useMemo(() => {
+    const d = new Date();
+    d.setUTCDate(d.getUTCDate() - period);
+    return d.toISOString();
+  }, [period]);
+
+  const summaryQuery = useQuery({
+    queryKey: ['me-metrics', 'summary', gameId, reviewerId, startDate],
+    queryFn: () => adminClient.getMechanicMetricsSummary({ gameId, reviewerId, startDate }),
+    staleTime: 60_000,
+  });
+
+  const costQuery = useQuery({
+    queryKey: ['me-metrics', 'cost', period, gameId, reviewerId],
+    queryFn: () => adminClient.getMechanicCostByDay(period, { gameId, reviewerId }),
+    staleTime: 60_000,
+  });
+
+  const recentQuery = useQuery({
+    queryKey: ['me-metrics', 'recent', offset, gameId, reviewerId, status],
+    queryFn: () =>
+      adminClient.getMechanicRecentAnalyses({
+        limit: RECENT_PAGE_SIZE,
+        offset,
+        gameId,
+        reviewerId,
+        status,
+      }),
+    staleTime: 30_000,
+  });
+
+  // Filter dropdown options: distinct games/reviewers across a broad unfiltered fetch.
+  const optionsQuery = useQuery({
+    queryKey: ['me-metrics', 'filter-options'],
+    queryFn: () => adminClient.getMechanicRecentAnalyses({ limit: 200 }),
+    staleTime: 5 * 60_000,
+  });
+
+  const gameOptions = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const r of optionsQuery.data?.items ?? []) {
+      map.set(r.sharedGameId, r.gameName);
+    }
+    return Array.from(map, ([id, name]) => ({ id, name })).sort((a, b) =>
+      a.name.localeCompare(b.name)
+    );
+  }, [optionsQuery.data]);
+
+  const reviewerOptions = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const r of optionsQuery.data?.items ?? []) {
+      if (r.reviewedBy) {
+        map.set(r.reviewedBy, r.reviewerName ?? r.reviewedBy);
+      }
+    }
+    return Array.from(map, ([id, name]) => ({ id, name })).sort((a, b) =>
+      a.name.localeCompare(b.name)
+    );
+  }, [optionsQuery.data]);
+
+  const summary = summaryQuery.data;
+  const recent = recentQuery.data;
+
+  const handleExport = async () => {
+    const blob = await adminClient.exportMechanicAnalysesCsv({
+      gameId,
+      reviewerId,
+      status,
+      startDate,
+    });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = 'mechanic-analyses.csv';
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <div className="space-y-6" data-testid="mechanic-metrics-page">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="font-quicksand text-2xl font-bold tracking-tight text-foreground">
+            Mechanic Extractor — Metriche
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            Costi, tempi di review e approval rate della pipeline AI.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          {PERIODS.map(p => (
+            <Button
+              key={p}
+              size="sm"
+              variant={period === p ? 'default' : 'outline'}
+              onClick={() => setPeriod(p)}
+            >
+              {p}g
+            </Button>
+          ))}
+          <Button size="sm" variant="outline" onClick={handleExport} data-testid="export-csv">
+            Export CSV
+          </Button>
+        </div>
+      </div>
+
+      {/* Filters */}
+      <div className="flex flex-wrap items-center gap-2">
+        <Select
+          value={gameId ?? ALL}
+          onValueChange={v => {
+            setGameId(v === ALL ? undefined : v);
+            setOffset(0);
+          }}
+        >
+          <SelectTrigger className="w-48" aria-label="Filtra per gioco">
+            <SelectValue placeholder="Gioco" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={ALL}>Tutti i giochi</SelectItem>
+            {gameOptions.map(g => (
+              <SelectItem key={g.id} value={g.id}>
+                {g.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <Select
+          value={reviewerId ?? ALL}
+          onValueChange={v => {
+            setReviewerId(v === ALL ? undefined : v);
+            setOffset(0);
+          }}
+        >
+          <SelectTrigger className="w-48" aria-label="Filtra per reviewer">
+            <SelectValue placeholder="Reviewer" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={ALL}>Tutti i reviewer</SelectItem>
+            {reviewerOptions.map(r => (
+              <SelectItem key={r.id} value={r.id}>
+                {r.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <Select
+          value={status === undefined ? ALL : String(status)}
+          onValueChange={v => {
+            setStatus(v === ALL ? undefined : Number(v));
+            setOffset(0);
+          }}
+        >
+          <SelectTrigger className="w-40" aria-label="Filtra per status">
+            <SelectValue placeholder="Status" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={ALL}>Tutti gli status</SelectItem>
+            {STATUS_FILTER_OPTIONS.map(s => (
+              <SelectItem key={s} value={String(s)}>
+                {STATUS_LABELS[s]}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {/* KPI tiles */}
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <StatCard
+          label="Costo medio / analisi"
+          value={summary ? `$${summary.averageCostUsd.toFixed(2)}` : '—'}
+          icon={DollarSign}
+          loading={summaryQuery.isLoading}
+        />
+        <StatCard
+          label="Tempo review medio"
+          value={
+            summary?.averageReviewTimeHours != null
+              ? `${summary.averageReviewTimeHours.toFixed(1)} h`
+              : '—'
+          }
+          icon={Clock}
+          loading={summaryQuery.isLoading}
+        />
+        <StatCard
+          label="Approval rate"
+          value={summary ? `${summary.approvalRatePct.toFixed(0)}%` : '—'}
+          icon={CheckCircle2}
+          loading={summaryQuery.isLoading}
+        />
+        <StatCard
+          label="Analisi totali"
+          value={summary ? summary.totalAnalyses : '—'}
+          icon={ListChecks}
+          loading={summaryQuery.isLoading}
+        />
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+        {/* Cost time-series */}
+        <Card className="lg:col-span-2">
+          <CardHeader>
+            <CardTitle className="text-base">Costo giornaliero ({period}g)</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <MechanicCostChart data={costQuery.data ?? []} />
+          </CardContent>
+        </Card>
+
+        {/* Rejection breakdown */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Motivi di rifiuto</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {summary && summary.rejectionBreakdown.length > 0 ? (
+              <ul className="space-y-2" data-testid="rejection-breakdown">
+                {summary.rejectionBreakdown.map(r => (
+                  <li key={r.reason} className="flex items-center justify-between text-sm">
+                    <span className="text-foreground">{r.reason}</span>
+                    <span className="font-semibold text-muted-foreground">{r.count}</span>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p className="text-sm text-muted-foreground">Nessun rifiuto nel periodo.</p>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Recent analyses table */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Analisi recenti</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Gioco</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Reviewer</TableHead>
+                  <TableHead>Creata</TableHead>
+                  <TableHead className="text-right">Costo</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {(recent?.items ?? []).map(row => (
+                  <TableRow key={row.id}>
+                    <TableCell className="font-medium">{row.gameName}</TableCell>
+                    <TableCell>{STATUS_LABELS[row.status] ?? row.status}</TableCell>
+                    <TableCell>{row.reviewerName ?? '—'}</TableCell>
+                    <TableCell>{new Date(row.createdAt).toLocaleDateString()}</TableCell>
+                    <TableCell className="text-right">${row.estimatedCostUsd.toFixed(2)}</TableCell>
+                  </TableRow>
+                ))}
+                {(recent?.items?.length ?? 0) === 0 && (
+                  <TableRow>
+                    <TableCell colSpan={5} className="text-center text-sm text-muted-foreground">
+                      Nessuna analisi.
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          </div>
+          <div className="mt-3 flex items-center justify-between">
+            <span className="text-xs text-muted-foreground">
+              {recent ? `${recent.totalCount} totali` : ''}
+            </span>
+            <div className="flex items-center gap-2">
+              <Button
+                size="sm"
+                variant="outline"
+                disabled={offset === 0}
+                onClick={() => setOffset(Math.max(0, offset - RECENT_PAGE_SIZE))}
+              >
+                Precedente
+              </Button>
+              <Button
+                size="sm"
+                variant="outline"
+                disabled={!recent || offset + RECENT_PAGE_SIZE >= recent.totalCount}
+                onClick={() => setOffset(offset + RECENT_PAGE_SIZE)}
+              >
+                Successiva
+              </Button>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/apps/web/src/app/admin/(dashboard)/knowledge-base/mechanic-extractor/metrics/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/knowledge-base/mechanic-extractor/metrics/page.tsx
@@ -5,6 +5,7 @@ import type { JSX } from 'react';
 
 import { useQuery } from '@tanstack/react-query';
 import { CheckCircle2, Clock, DollarSign, ListChecks } from 'lucide-react';
+import { toast } from 'sonner';
 
 import { MechanicCostChart } from '@/components/admin/mechanic-extractor/metrics/MechanicCostChart';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/data-display/card';
@@ -51,6 +52,7 @@ export default function MechanicMetricsPage(): JSX.Element {
   const [reviewerId, setReviewerId] = useState<string | undefined>();
   const [status, setStatus] = useState<number | undefined>();
   const [offset, setOffset] = useState(0);
+  const [isExporting, setIsExporting] = useState(false);
 
   const startDate = useMemo(() => {
     const d = new Date();
@@ -83,7 +85,10 @@ export default function MechanicMetricsPage(): JSX.Element {
     staleTime: 30_000,
   });
 
-  // Filter dropdown options: distinct games/reviewers across a broad unfiltered fetch.
+  // Filter dropdown options: distinct games/reviewers derived from the 200 most-recent analyses.
+  // KNOWN LIMITATION (#532 follow-up): games/reviewers whose analyses all fall outside this window
+  // won't appear as filter options once volume exceeds 200 rows. A dedicated DISTINCT endpoint is the
+  // proper fix — deferred; the summary/recent/export results themselves are NOT capped by this.
   const optionsQuery = useQuery({
     queryKey: ['me-metrics', 'filter-options'],
     queryFn: () => adminClient.getMechanicRecentAnalyses({ limit: 200 }),
@@ -116,20 +121,28 @@ export default function MechanicMetricsPage(): JSX.Element {
   const recent = recentQuery.data;
 
   const handleExport = async () => {
-    const blob = await adminClient.exportMechanicAnalysesCsv({
-      gameId,
-      reviewerId,
-      status,
-      startDate,
-    });
-    const url = URL.createObjectURL(blob);
-    const link = document.createElement('a');
-    link.href = url;
-    link.download = 'mechanic-analyses.csv';
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
-    URL.revokeObjectURL(url);
+    if (isExporting) return;
+    setIsExporting(true);
+    try {
+      const blob = await adminClient.exportMechanicAnalysesCsv({
+        gameId,
+        reviewerId,
+        status,
+        startDate,
+      });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = 'mechanic-analyses.csv';
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+    } catch {
+      toast.error('Esportazione CSV fallita. Riprova.');
+    } finally {
+      setIsExporting(false);
+    }
   };
 
   return (
@@ -154,8 +167,14 @@ export default function MechanicMetricsPage(): JSX.Element {
               {p}g
             </Button>
           ))}
-          <Button size="sm" variant="outline" onClick={handleExport} data-testid="export-csv">
-            Export CSV
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={handleExport}
+            disabled={isExporting}
+            data-testid="export-csv"
+          >
+            {isExporting ? 'Esporto…' : 'Export CSV'}
           </Button>
         </div>
       </div>

--- a/apps/web/src/components/admin/mechanic-extractor/metrics/MechanicCostChart.tsx
+++ b/apps/web/src/components/admin/mechanic-extractor/metrics/MechanicCostChart.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { Suspense } from 'react';
+import type { JSX } from 'react';
+
+import dynamic from 'next/dynamic';
+
+import type { MechanicCostByDay } from '@/lib/api/schemas/admin-mechanic-metrics.schemas';
+
+// #532: daily-cost bar chart. Mirrors the AdminCharts dynamic-import pattern so recharts stays out of
+// the SSR bundle but renders synchronously under NODE_ENV=test.
+const isTest = process.env.NODE_ENV === 'test';
+const recharts = isTest ? require('recharts') : null;
+
+const ResponsiveContainer = isTest
+  ? recharts.ResponsiveContainer
+  : dynamic(() => import('recharts').then(m => m.ResponsiveContainer), { ssr: false });
+const BarChart = isTest
+  ? recharts.BarChart
+  : dynamic(() => import('recharts').then(m => m.BarChart), { ssr: false });
+const Bar = isTest
+  ? recharts.Bar
+  : dynamic(() => import('recharts').then(m => m.Bar), { ssr: false });
+const XAxis = isTest
+  ? recharts.XAxis
+  : dynamic(() => import('recharts').then(m => m.XAxis), { ssr: false });
+const YAxis = isTest
+  ? recharts.YAxis
+  : dynamic(() => import('recharts').then(m => m.YAxis), { ssr: false });
+const CartesianGrid = isTest
+  ? recharts.CartesianGrid
+  : dynamic(() => import('recharts').then(m => m.CartesianGrid), { ssr: false });
+const Tooltip = isTest
+  ? recharts.Tooltip
+  : dynamic(() => import('recharts').then(m => m.Tooltip), { ssr: false });
+
+export interface MechanicCostChartProps {
+  data: MechanicCostByDay[];
+}
+
+export function MechanicCostChart({ data }: MechanicCostChartProps): JSX.Element {
+  return (
+    <div data-testid="mechanic-cost-chart" className="h-72 w-full">
+      <Suspense
+        fallback={<div className="text-sm text-muted-foreground">Caricamento grafico…</div>}
+      >
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart data={data}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="date" tick={{ fontSize: 11 }} />
+            <YAxis tick={{ fontSize: 11 }} />
+            <Tooltip />
+            <Bar dataKey="costUsd" fill="#1a73e8" name="Costo USD" />
+          </BarChart>
+        </ResponsiveContainer>
+      </Suspense>
+    </div>
+  );
+}

--- a/apps/web/src/components/layout/admin-nav/admin-nav-config.ts
+++ b/apps/web/src/components/layout/admin-nav/admin-nav-config.ts
@@ -109,6 +109,12 @@ export const ADMIN_NAV_GROUPS: AdminNavGroup[] = [
         href: '/admin/knowledge-base/mechanic-extractor/analyses',
         icon: Wrench,
       },
+      // #532 ME-M2.3: operational metrics dashboard (cost / review-time / approval-rate).
+      {
+        label: 'Mechanic Metrics',
+        href: '/admin/knowledge-base/mechanic-extractor/metrics',
+        icon: BarChart2,
+      },
       // #537 ME-M4.2: the deprecated Variant C editor menu entry is hidden by default,
       // shown only when NEXT_PUBLIC_SHOW_LEGACY_MECHANIC_EXTRACTOR=true (staging/debug override).
       ...(isLegacyMechanicExtractorEnabled()

--- a/apps/web/src/lib/api/clients/admin/adminMechanicMetricsClient.ts
+++ b/apps/web/src/lib/api/clients/admin/adminMechanicMetricsClient.ts
@@ -1,0 +1,94 @@
+/**
+ * Admin Mechanic Extractor — Metrics Dashboard Client (#532 ME-M2.3)
+ *
+ * Wraps the `/api/v1/admin/mechanic-analyses/metrics/*` endpoints (KPIs, daily cost, recent table,
+ * CSV export). Composed into the flat `adminClient` object.
+ */
+import { getApiBase } from '../../core/httpClient';
+import {
+  MechanicMetricsSummarySchema,
+  MechanicCostByDayArraySchema,
+  MechanicRecentAnalysesResultSchema,
+  type MechanicMetricsSummary,
+  type MechanicCostByDay,
+  type MechanicRecentAnalysesResult,
+} from '../../schemas/admin-mechanic-metrics.schemas';
+
+import type { HttpClient } from '../../core/httpClient';
+
+const BASE = '/api/v1/admin/mechanic-analyses/metrics';
+
+export interface MechanicMetricsFilters {
+  gameId?: string;
+  reviewerId?: string;
+  status?: number;
+  startDate?: string;
+  endDate?: string;
+}
+
+function buildQuery(params: Record<string, string | number | undefined>): string {
+  const sp = new URLSearchParams();
+  for (const [key, value] of Object.entries(params)) {
+    if (value !== undefined && value !== '') {
+      sp.set(key, String(value));
+    }
+  }
+  const qs = sp.toString();
+  return qs ? `?${qs}` : '';
+}
+
+export function createAdminMechanicMetricsClient(http: HttpClient) {
+  return {
+    async getMechanicMetricsSummary(
+      filters: MechanicMetricsFilters = {}
+    ): Promise<MechanicMetricsSummary | null> {
+      const qs = buildQuery({
+        gameId: filters.gameId,
+        reviewerId: filters.reviewerId,
+        startDate: filters.startDate,
+        endDate: filters.endDate,
+      });
+      return http.get(`${BASE}/summary${qs}`, MechanicMetricsSummarySchema);
+    },
+
+    async getMechanicCostByDay(
+      days: number,
+      filters: Pick<MechanicMetricsFilters, 'gameId' | 'reviewerId'> = {}
+    ): Promise<MechanicCostByDay[] | null> {
+      const qs = buildQuery({ days, gameId: filters.gameId, reviewerId: filters.reviewerId });
+      return http.get(`${BASE}/cost-by-day${qs}`, MechanicCostByDayArraySchema);
+    },
+
+    async getMechanicRecentAnalyses(
+      params: { limit?: number; offset?: number } & MechanicMetricsFilters = {}
+    ): Promise<MechanicRecentAnalysesResult | null> {
+      const qs = buildQuery({
+        limit: params.limit,
+        offset: params.offset,
+        gameId: params.gameId,
+        reviewerId: params.reviewerId,
+        status: params.status,
+      });
+      return http.get(`${BASE}/recent${qs}`, MechanicRecentAnalysesResultSchema);
+    },
+
+    async exportMechanicAnalysesCsv(filters: MechanicMetricsFilters = {}): Promise<Blob> {
+      const qs = buildQuery({
+        gameId: filters.gameId,
+        reviewerId: filters.reviewerId,
+        status: filters.status,
+        startDate: filters.startDate,
+        endDate: filters.endDate,
+      });
+      const response = await fetch(`${getApiBase()}${BASE}/export${qs}`, {
+        credentials: 'include',
+      });
+      if (!response.ok) {
+        throw new Error(`CSV export failed: ${response.status} ${response.statusText}`);
+      }
+      return response.blob();
+    },
+  };
+}
+
+export type AdminMechanicMetricsClient = ReturnType<typeof createAdminMechanicMetricsClient>;

--- a/apps/web/src/lib/api/clients/admin/index.ts
+++ b/apps/web/src/lib/api/clients/admin/index.ts
@@ -15,3 +15,8 @@ export {
   ADMIN_MECHANIC_EXTRACTOR_VALIDATION_ROUTES,
 } from './adminMechanicExtractorValidationClient';
 export { createAdminProvidersClient, type AdminProvidersClient } from './adminProvidersClient';
+export {
+  createAdminMechanicMetricsClient,
+  type AdminMechanicMetricsClient,
+  type MechanicMetricsFilters,
+} from './adminMechanicMetricsClient';

--- a/apps/web/src/lib/api/clients/adminClient.ts
+++ b/apps/web/src/lib/api/clients/adminClient.ts
@@ -16,6 +16,7 @@ import {
   createAdminConfigClient,
   createAdminMechanicExtractorValidationClient,
   createAdminProvidersClient,
+  createAdminMechanicMetricsClient,
 } from './admin';
 
 import type { HttpClient } from '../core/httpClient';
@@ -91,6 +92,7 @@ export function createAdminClient({ httpClient }: CreateAdminClientParams) {
     ...createAdminMechanicExtractorValidationClient(http),
     ...createAdminConfigClient(http),
     ...createAdminProvidersClient(http),
+    ...createAdminMechanicMetricsClient(http),
   };
 }
 

--- a/apps/web/src/lib/api/schemas/admin-mechanic-metrics.schemas.ts
+++ b/apps/web/src/lib/api/schemas/admin-mechanic-metrics.schemas.ts
@@ -1,0 +1,54 @@
+/**
+ * Admin Mechanic Extractor — Metrics Dashboard Schemas (#532 ME-M2.3)
+ *
+ * Zod schemas + inferred types mirroring the backend DTOs in
+ * apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/DTOs/MechanicMetricsDtos.cs
+ * (camelCase JSON per Program.cs). DateOnly → "yyyy-MM-dd" string; decimal → number.
+ */
+import { z } from 'zod';
+
+export const RejectionReasonCountSchema = z.object({
+  reason: z.string(),
+  count: z.number(),
+});
+export type RejectionReasonCount = z.infer<typeof RejectionReasonCountSchema>;
+
+export const MechanicMetricsSummarySchema = z.object({
+  totalCostUsd: z.number(),
+  totalAnalyses: z.number(),
+  publishedCount: z.number(),
+  rejectedCount: z.number(),
+  inReviewCount: z.number(),
+  averageCostUsd: z.number(),
+  averageReviewTimeHours: z.number().nullable(),
+  approvalRatePct: z.number(),
+  rejectionBreakdown: z.array(RejectionReasonCountSchema),
+});
+export type MechanicMetricsSummary = z.infer<typeof MechanicMetricsSummarySchema>;
+
+export const MechanicCostByDaySchema = z.object({
+  date: z.string(),
+  costUsd: z.number(),
+  analysisCount: z.number(),
+});
+export const MechanicCostByDayArraySchema = z.array(MechanicCostByDaySchema);
+export type MechanicCostByDay = z.infer<typeof MechanicCostByDaySchema>;
+
+export const MechanicRecentAnalysisRowSchema = z.object({
+  id: z.string(),
+  sharedGameId: z.string(),
+  gameName: z.string(),
+  status: z.number(),
+  reviewedBy: z.string().nullable(),
+  reviewerName: z.string().nullable(),
+  createdAt: z.string(),
+  reviewedAt: z.string().nullable(),
+  estimatedCostUsd: z.number(),
+});
+export type MechanicRecentAnalysisRow = z.infer<typeof MechanicRecentAnalysisRowSchema>;
+
+export const MechanicRecentAnalysesResultSchema = z.object({
+  items: z.array(MechanicRecentAnalysisRowSchema),
+  totalCount: z.number(),
+});
+export type MechanicRecentAnalysesResult = z.infer<typeof MechanicRecentAnalysesResultSchema>;

--- a/docs/superpowers/plans/2026-07-12-issue-532-metrics-dashboard.md
+++ b/docs/superpowers/plans/2026-07-12-issue-532-metrics-dashboard.md
@@ -1,0 +1,61 @@
+# #532 ME-M2.3 Metrics Dashboard Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:executing-plans. Steps use `- [ ]`. This plan mirrors mapped precedents — each task points to the exact precedent file:line to copy the shape from (spec has the locked contract).
+
+**Goal:** Full admin metrics dashboard for Mechanic Extractor (cost / review-time / approval-rate KPIs, rejection breakdown, daily-cost time-series, filterable+paginated recent-analyses table, CSV export) — all 6 ACs, BE + FE.
+
+**Spec (locked contract):** `docs/superpowers/specs/2026-07-12-issue-532-metrics-dashboard.md`
+
+## Global Constraints
+- CQRS `IQuery<T>`/`IQueryHandler<T,R>`; metrics query handlers inject `MeepleAiDbContext`, query `MechanicAnalyses.AsNoTracking()` (analytics precedent — NOT a repo). Query filter already excludes `IsSuppressed`.
+- BE endpoints on the existing group `app.MapGroup("/admin/mechanic-analyses").AddEndpointFilter<RequireAdminSessionFilter>()` (`Routing/AdminMechanicAnalysesEndpoints.cs:32`) — no per-endpoint auth needed.
+- Status ints: Draft0/InReview1/Published2/Rejected3/PartiallyExtracted4. Approved=2; Rejected∈{3,4}. Approval rate over reviewed (`ReviewedAt != null`).
+- FE route `/admin/knowledge-base/mechanic-extractor/metrics` (sibling-consistent). recharts via `components/admin/AdminCharts.tsx`; table via `EntityTableView`; KPI tiles mirror `components/admin/agents/MetricsKpiCards.tsx`.
+- Backend tests `apps/api/tests/Api.Tests` (kill testhost first). FE tests Vitest.
+
+## BE precedents to mirror (exact)
+- KPI aggregation: `BoundedContexts/Administration/Application/Queries/GetAiRequestStatsQueryHandler.cs` (+ `AiRequestStats` DTO).
+- Daily time-series + gap-fill: `.../GetApiRequestsByDayQueryHandler.cs` (+ `ApiRequestByDayDto`).
+- Filtered+paginated: `.../GetAiRequestsQueryHandler.cs` (+ `AiRequestListResult`).
+- CSV export: `.../ExportAuditLogsQueryHandler.cs` + `Routing/AdminAuditLogEndpoints.cs:48-72` (`Results.File`).
+- Endpoint reg: `Routing/AnalyticsEndpoints.cs` (query-param binding).
+
+---
+
+### Task 1: BE — DTOs + summary query (KPIs + rejection breakdown)
+**Files:** Create `BoundedContexts/SharedGameCatalog/Application/DTOs/MechanicMetricsDtos.cs` (all 5 DTOs from spec); `Application/Queries/MechanicMetrics/GetMechanicMetricsSummaryQuery.cs` + `...Handler.cs`. Test: `tests/.../SharedGameCatalog/Infrastructure/MechanicMetricsSummaryQueryTests.cs`.
+- [ ] Write failing integration test: seed a game + analyses (2 Published w/ cost 1.0+3.0, 1 Rejected reason "factual", 1 InReview) → send `GetMechanicMetricsSummaryQuery(null,null,null,null)` via IMediator → assert `TotalCostUsd`, `PublishedCount=2`, `RejectedCount=1`, `AverageCostUsd`, `ApprovalRatePct` (2/3), `RejectionBreakdown` contains ("factual",1). Reuse `MechanicCardAutoSuppressionSeed`-style seeding (SharedGame + MechanicAnalysisEntity with the fields).
+- [ ] Run → FAIL (types missing).
+- [ ] Implement DTOs + handler (mirror `GetAiRequestStatsQueryHandler`: `MechanicAnalyses.AsNoTracking()` + optional `.Where` filters (gameId/reviewerId/startDate/endDate on CreatedAt) → materialize to a lightweight projection → compute counts/avg/approval/rejection-breakdown in memory or via grouped queries). `AverageReviewTimeHours` = avg of `(ReviewedAt-CreatedAt).TotalHours` where ReviewedAt != null (null if none).
+- [ ] Run → PASS. Commit `feat(mechanic-extractor): #532 BE metrics summary query + DTOs`.
+
+### Task 2: BE — cost-by-day time-series + recent paginated list
+**Files:** `Application/Queries/MechanicMetrics/GetMechanicCostByDayQuery.cs`+Handler; `GetMechanicRecentAnalysesQuery.cs`+Handler. Tests: `MechanicCostByDayQueryTests.cs`, `MechanicRecentAnalysesQueryTests.cs`.
+- [ ] cost-by-day: failing test (2 analyses today, 1 three days ago; `days=7`) → 7 buckets, correct sums, gap-filled zeros. Implement mirroring `GetApiRequestsByDayQueryHandler` (`GroupBy(a => a.CreatedAt.Date)` → `{Date, Sum(EstimatedCostUsd), Count}` → gap-fill loop over `days`). Optional gameId/reviewerId filters.
+- [ ] recent: failing test (seed 3 analyses across 2 games/statuses) → filter by gameId returns only that game; by status filters; pagination `limit/offset` + `TotalCount`; rows carry GameName (join SharedGame) + ReviewerName (LEFT join users on ReviewedBy). Implement mirroring `GetAiRequestsQueryHandler` (filter chain + `CountAsync` + `OrderByDescending(CreatedAt).Skip/Take`). Map to `MechanicRecentAnalysisRowDto`.
+- [ ] Run both → PASS. Commit `feat(mechanic-extractor): #532 BE cost-by-day + recent analyses queries`.
+
+### Task 3: BE — CSV export + endpoint registration
+**Files:** `Application/Queries/MechanicMetrics/ExportMechanicAnalysesQuery.cs`+Handler (+ `ExportMechanicAnalysesResult(byte[] Content, string ContentType, string FileName)`); modify `Routing/AdminMechanicAnalysesEndpoints.cs` (4 new `group.MapGet` under `/metrics/*`). Tests: `ExportMechanicAnalysesQueryTests.cs` + endpoint integration for one path.
+- [ ] export: failing test → CSV bytes contain header `Id,GameName,Status,ReviewerId,CreatedAt,ReviewedAt,EstimatedCostUsd` + one row per analysis, proper escaping (mirror `ExportAuditLogsQueryHandler` `EscapeCsv`), cap 10k. `ContentType="text/csv"`, `FileName="mechanic-analyses-{yyyyMMdd-HHmmss}.csv"`.
+- [ ] endpoints: add `GET /metrics/summary`, `/metrics/cost-by-day`, `/metrics/recent`, `/metrics/export` handlers to the group (query-param binding like `AnalyticsEndpoints`; export returns `Results.File(r.Content, r.ContentType, r.FileName)`). Integration test hits `GET /api/v1/admin/mechanic-analyses/metrics/summary` (admin session via `TestSessionHelper.CreateAdminSessionAsync`) → 200 + shape.
+- [ ] `dotnet build` + run BE #532 suite → PASS. Commit `feat(mechanic-extractor): #532 BE CSV export + metrics endpoints`.
+
+### Task 4: FE — client + zod schemas
+**Files:** `apps/web/src/lib/api/schemas/admin-mechanic-metrics.schemas.ts` (zod mirror of the 5 DTOs); `apps/web/src/lib/api/clients/admin/adminMechanicMetricsClient.ts` (`getSummary/getCostByDay/getRecent(params)` + `exportCsv(params): Promise<Blob>`); compose into `adminClient.ts`. Test: `__tests__` schema parse + client (mock http).
+- [ ] Failing test: schema parses a sample summary/cost-by-day/recent payload; client `getSummary` calls the right URL (mock HttpClient). Implement mirroring `adminAnalyticsClient.ts` (`http.get(url, Schema)`) + `exportLedgerEntries` blob pattern for `exportCsv`.
+- [ ] Run → PASS. `pnpm typecheck`. Commit `feat(mechanic-extractor): #532 FE metrics client + schemas`.
+
+### Task 5: FE — dashboard page (KPI + chart + table + filters + CSV)
+**Files:** `apps/web/src/app/admin/(dashboard)/knowledge-base/mechanic-extractor/metrics/page.tsx` + supporting components under `components/admin/mechanic-extractor/metrics/` (KpiCards, CostChart, RecentTable with filters). Tests: `__tests__/page.test.tsx`.
+- [ ] Failing test: render page (mock client via `vi.mock`), assert KPI tiles + chart container + table render; changing a filter dropdown updates the query (assert client called with the filter); date-range toggle 7/30/90 re-queries cost-by-day; CSV button triggers `exportCsv`. Mock recharts if needed (jsdom).
+- [ ] Implement: `'use client'` page with `useQuery` per endpoint keyed on `{period,gameId,reviewerId,status,offset}`; KPI tiles (mirror `MetricsKpiCards`); `AdminCharts` BarChart for cost-by-day; `EntityTableView` for recent + 3 filter dropdowns (game options from a `getRecent` distinct or a small `/metrics/filters` — simplest: derive game/reviewer options from the recent result's rows, or add a lightweight distinct query; status is a fixed enum list); Export CSV button → `exportCsv` → blob download (mirror `downloadFile` util `lib/utils/export.ts`).
+- [ ] `pnpm typecheck` + `pnpm lint` + `pnpm exec vitest run <files>` → PASS. Commit `feat(mechanic-extractor): #532 FE metrics dashboard page`.
+
+### Task 6: Nav + wire-up + final
+- [ ] Add a nav entry "Mechanic Metrics" → `/admin/knowledge-base/mechanic-extractor/metrics` in `admin-nav-config.ts` (group D, near "Mechanic Analyses").
+- [ ] Full `dotnet build` + BE suite + FE typecheck/lint/vitest green.
+- [ ] Commit `feat(mechanic-extractor): #532 nav entry + wire-up`.
+
+## Self-Review
+Covers all 6 ACs: route (Task 5) · KPIs+rejection breakdown (Task 1) · cost time-series (Task 2) · recent table (Task 2) · filters (Task 2 BE params + Task 5 UI) · CSV export (Task 3 BE + Task 5 button). Filter data-source for reviewer/game dropdowns: derive from recent rows or a light distinct — decide in Task 5 (simplest that avoids an extra heavy query).

--- a/docs/superpowers/specs/2026-07-12-issue-532-metrics-dashboard.md
+++ b/docs/superpowers/specs/2026-07-12-issue-532-metrics-dashboard.md
@@ -1,0 +1,72 @@
+# #532 — ME-M2.3 Admin metrics dashboard (spec)
+
+**Parent ADR**: ADR-051 · **Depends on**: #527 · **BC**: SharedGameCatalog (BE) + admin FE · **Date**: 2026-07-12
+**Scope scelto (utente)**: Full 6 AC in un PR (BE completo + FE completa incl. UI filtri).
+
+## Obiettivo
+Dashboard admin operativa per costi + qualità della pipeline Mechanic Extractor: KPI, breakdown rejection,
+time-series costo giornaliero, tabella analisi recenti filtrabile, export CSV.
+
+## Dati (verificati)
+`MechanicAnalysisEntity` (DbSet `MechanicAnalyses`, query filter `!IsSuppressed`): `EstimatedCostUsd` (decimal),
+`TotalTokensUsed` (int), `Status` (int: Draft0/InReview1/Published2/Rejected3/PartiallyExtracted4), `SharedGameId`,
+`CreatedAt`, `ReviewedBy` (Guid?), `ReviewedAt` (DateTime?, set su approve+reject+auto+partial), `RejectionReason` (string?).
+- **Approval rate** = Published / (Published + Rejected + PartiallyExtracted), su reviewed (ReviewedAt != null).
+- **Review time** = ReviewedAt − CreatedAt (solo reviewed).
+- **Rejection breakdown** = GROUP BY RejectionReason dove Status ∈ {3,4}.
+Le query metrics interrogano `MeepleAiDbContext.MechanicAnalyses` direttamente `.AsNoTracking()` (pattern analytics
+Administration, NO repo). CQRS `IQuery<T>`/`IQueryHandler<T,R>`.
+
+## Route (riconciliazione)
+AC dice `/admin/mechanic-extractor/metrics`; i sibling stanno sotto `/admin/knowledge-base/mechanic-extractor/`.
+→ **FE**: `/admin/knowledge-base/mechanic-extractor/metrics` (coerenza sibling + già target del deep-link #535).
+→ **BE**: sub-path del group esistente `/admin/mechanic-analyses` (`AdminMechanicAnalysesEndpoints`, filter `RequireAdminSessionFilter`).
+
+## API contract (LOCKED)
+
+### DTOs (`Application/DTOs/MechanicMetricsDtos.cs`)
+```csharp
+internal sealed record MechanicMetricsSummaryDto(
+    decimal TotalCostUsd, int TotalAnalyses, int PublishedCount, int RejectedCount, int InReviewCount,
+    decimal AverageCostUsd, double? AverageReviewTimeHours, double ApprovalRatePct,
+    IReadOnlyList<RejectionReasonCountDto> RejectionBreakdown);
+internal sealed record RejectionReasonCountDto(string Reason, int Count);
+internal sealed record MechanicCostByDayDto(DateOnly Date, decimal CostUsd, int AnalysisCount);
+internal sealed record MechanicRecentAnalysisRowDto(
+    Guid Id, Guid SharedGameId, string GameName, int Status, Guid? ReviewedBy, string? ReviewerName,
+    DateTime CreatedAt, DateTime? ReviewedAt, decimal EstimatedCostUsd);
+internal sealed record MechanicRecentAnalysesResult(IReadOnlyList<MechanicRecentAnalysisRowDto> Items, int TotalCount);
+```
+
+### Endpoints (group `/admin/mechanic-analyses`)
+| Verb/Path | Query params | Response |
+|---|---|---|
+| `GET /metrics/summary` | `gameId?`, `reviewerId?`, `startDate?`, `endDate?` | `MechanicMetricsSummaryDto` |
+| `GET /metrics/cost-by-day` | `days`=7\|30\|90 (default 30), `gameId?`, `reviewerId?` | `MechanicCostByDayDto[]` (gap-filled) |
+| `GET /metrics/recent` | `limit`=25, `offset`=0, `gameId?`, `reviewerId?`, `status?` | `MechanicRecentAnalysesResult` |
+| `GET /metrics/export` | `gameId?`, `reviewerId?`, `status?`, `startDate?`, `endDate?` | CSV `Results.File` (`mechanic-analyses-{yyyyMMdd-HHmmss}.csv`) |
+
+Query handlers: `GetMechanicMetricsSummaryQuery(...)`, `GetMechanicCostByDayQuery(...)`, `GetMechanicRecentAnalysesQuery(...)`,
+`ExportMechanicAnalysesQuery(...)`. Summary usa `GroupBy(_ => 1)` + `Count(predicate)`/`Average`/`Sum` (pattern
+`GetAiRequestStatsQueryHandler`); cost-by-day `GroupBy(CreatedAt.Date)` + gap-fill loop (pattern `GetApiRequestsByDayQueryHandler`);
+recent = filtered + `Skip/Take` + `CountAsync` (pattern `GetAiRequestsQueryHandler`) + join SharedGame (GameName) + LEFT join users (ReviewerName);
+export = StringBuilder CSV + `ExportMechanicAnalysesResult(byte[] Content, string ContentType, string FileName)` (pattern `ExportAuditLogsQueryHandler`, cap 10k righe).
+
+## FE (`apps/web`)
+- **Client**: nuovo `createAdminMechanicMetricsClient(http)` (o metodi su `adminClient`) → `getSummary/getCostByDay/getRecent(params)` + `exportCsv(params): Promise<Blob>` (fetch().blob(), pattern `exportLedgerEntries`). Zod schemas mirror dei DTO.
+- **Page** `app/admin/(dashboard)/knowledge-base/mechanic-extractor/metrics/page.tsx` (`'use client'`):
+  - Date-range toggle 7/30/90d (pattern agent analytics).
+  - KPI tiles (pattern `MetricsKpiCards`, lucide DollarSign/Clock/CheckCircle): avg cost, avg review time, approval rate, total analyses.
+  - Rejection breakdown (bar o lista).
+  - Cost-by-day chart (recharts `BarChart`/`LineChart` via `AdminCharts`).
+  - Recent-analyses table (`EntityTableView`) con paginazione + **filtri UI**: dropdown game (data-source: giochi con analisi), dropdown reviewer (reviewer distinti), dropdown status. I filtri ripilotano `useQuery` via queryKey.
+  - Bottone **Export CSV** → download blob.
+- React Query `useQuery` keyed su `{period, gameId, reviewerId, status, offset}`.
+
+## Test (TDD)
+- **BE** (Testcontainers): summary KPI (cost avg, approval rate, rejection breakdown) su set seedato (published/rejected/inreview mix); cost-by-day gap-fill + somma per giorno; recent filtered+paginated (per game/reviewer/status) + TotalCount; export CSV header + row count + escaping. + query handler unit dove sensato.
+- **FE** (Vitest): page render KPI + chart + table (mock client); filtri cambiano queryKey; export button chiama client. Schemas parse.
+
+## Fuori scope
+- Nessuno (full 6 AC). Filtri per-reviewer data-source = reviewer distinti dalle analisi (no admin user list separata).
+- Certification/quality metrics (M2 `MechanicAnalysisMetrics`) restano fuori (#532 = cost/velocity).


### PR DESCRIPTION
## Sommario
Chiude #532 (ME-M2.3): dashboard admin operativa per costi + qualità della pipeline Mechanic Extractor. **Full 6 AC in un PR** (BE + FE).

Spec: `docs/superpowers/specs/2026-07-12-issue-532-metrics-dashboard.md` · Plan: `docs/superpowers/plans/2026-07-12-issue-532-metrics-dashboard.md`

## AC coperti
- ✅ Route `/admin/knowledge-base/mechanic-extractor/metrics` (riconciliata coi sibling; AC diceva `/admin/mechanic-extractor/metrics`) + nav entry.
- ✅ KPI: costo medio/analisi, tempo review medio, approval rate, rejection-reasons breakdown.
- ✅ Time-series: costo giornaliero (toggle 7/30/90g, gap-filled, recharts).
- ✅ Tabella analisi recenti (status + reviewer + cost) paginata.
- ✅ Filtri: per gioco, per reviewer, per status (dropdown UI).
- ✅ Export CSV.

## BE (SharedGameCatalog)
4 endpoint GET admin-gated sotto `/admin/mechanic-analyses/metrics/*` (`summary`, `cost-by-day`, `recent`, `export`) → query handlers CQRS su `MechanicAnalyses.AsNoTracking()`, mirror dei precedenti `GetAiRequestStats` / `GetApiRequestsByDay` / `GetAiRequests` / `ExportAuditLogs`. Approval rate = Published/(Published+Rejected+Partial); review-time solo cohort **human-reviewed**; rejection breakdown GROUP BY reason; CSV cap 10k + escaping.

## FE (Next.js)
zod schemas + `adminMechanicMetricsClient` (summary/cost-by-day/recent + CSV blob) composto in `adminClient`; pagina `'use client'` con KPI `StatCard`, chart recharts (`MechanicCostChart`, dynamic import), tabella + 3 filtri dropdown + paginazione + bottone Export CSV con error-handling.

## Review avversariale (opus) — 3 finding CONFIRMED, tutti fixati
1. **Review-time KPI skew**: la media includeva le transizioni di sistema (auto-reject/partial, `ReviewedAt≈CreatedAt` con `ReviewedBy==CreatedBy`) → trascinava a zero. Fix: media solo su decisioni umane (`Published/Rejected` con `ReviewedBy != CreatedBy`) + regression test.
2. **Export senza error-handling**: aggiunto try/catch + toast + `disabled` (pattern `activity/page.tsx`).
3. **Filtri dropdown cap 200** (degrada gracefully): documentata la limitazione come follow-up (summary/recent/export NON sono cappati).

Verificati NON difetti dal reviewer: approval-denominator (matcha spec), correlated subquery (pattern shipped, no N+1), `GroupBy(.Date)`, `IsSuppressed` filter, soft-delete fallback, null handling, CSV formula-injection (pattern pre-esistente accettato).

## Test
BE: 32 test (summary KPI + system-exclusion, cost-by-day gap-fill, recent filtered/paginated, export CSV, endpoint smoke). FE: 3 page test + typecheck + lint. Tutti verdi.

Closes #532

🤖 Generated with [Claude Code](https://claude.com/claude-code)