### PR TITLE
fix(game-night): dedup RSVP creation in Publish to prevent Multigraph cycle (#2835)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/GameNightEvent/GameNightEvent.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/GameNightEvent/GameNightEvent.cs
@@ -228,8 +228,10 @@ internal sealed class GameNightEvent : AggregateRoot<Guid>
 
         foreach (var userId in invitedUserIds)
         {
-            var rsvp = GameNightRsvp.Create(Id, userId);
-            _rsvps.Add(rsvp);
+            if (_rsvps.All(r => r.UserId != userId))
+            {
+                _rsvps.Add(GameNightRsvp.Create(Id, userId));
+            }
         }
 
         AddDomainEvent(new GameNightPublishedEvent(Id, OrganizerId, Title, ScheduledAt, invitedUserIds));

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/Entities/GameNightEventPublishRsvpTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/Entities/GameNightEventPublishRsvpTests.cs
@@ -1,0 +1,89 @@
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+using Api.BoundedContexts.GameManagement.Domain.Events;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Domain.Entities;
+
+/// <summary>
+/// Tests for RSVP deduplication in <see cref="GameNightEvent.Publish"/> (Issue #2835).
+///
+/// Regression guard: <c>Publish</c> must not create a second <c>GameNightRsvp</c> for a user
+/// that was already pre-invited during Draft creation. The pre-invite RSVP and the publish RSVP
+/// would otherwise both carry the same <c>(EventId, UserId)</c> unique-index key, which the
+/// persistence layer round-trips into two rows with the same key in one SaveChanges →
+/// EF Core <c>Multigraph.ThrowCycle</c> → HTTP 500. The dedup guard mirrors the one already
+/// present in <see cref="GameNightEvent.PreInvite"/> and <see cref="GameNightEvent.AddInvitees"/>.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "GameManagement")]
+public sealed class GameNightEventPublishRsvpTests
+{
+    private static GameNightEvent NewDraft() =>
+        GameNightEvent.Create(
+            organizerId: Guid.NewGuid(),
+            title: "Test Night",
+            scheduledAt: DateTimeOffset.UtcNow.AddHours(1));
+
+    [Fact]
+    public void Publish_WhenUserAlreadyPreInvited_DoesNotCreateDuplicateRsvp()
+    {
+        // Arrange: a draft with one pre-invited user (RSVP #1 created by PreInvite)
+        var userA = Guid.NewGuid();
+        var night = NewDraft();
+        night.PreInvite(new List<Guid> { userA });
+        night.Rsvps.Should().ContainSingle("PreInvite creates exactly one RSVP for userA");
+
+        // Act: publish passing the SAME pre-invited user (mirrors the handler, which reads
+        // existingInvitedIds from the RSVPs and passes them to Publish)
+        night.Publish(new List<Guid> { userA });
+
+        // Assert: still exactly one RSVP — no duplicate for the already-invited user
+        night.Rsvps.Should().ContainSingle("Publish must not add a second RSVP for an already-invited user");
+        night.Rsvps.Single().UserId.Should().Be(userA);
+        night.Status.Should().Be(GameNightStatus.Published);
+
+        // Exactly one GameNightPublishedEvent is raised (pre-invited users must still be notified)
+        night.DomainEvents.OfType<GameNightPublishedEvent>().Should().ContainSingle();
+        night.DomainEvents.OfType<GameNightPublishedEvent>().Single()
+            .InvitedUserIds.Should().Contain(userA, "pre-invited users must still be notified on publish");
+    }
+
+    [Fact]
+    public void Publish_WithNewUserHavingNoPriorRsvp_CreatesExactlyOneRsvp()
+    {
+        // Arrange: a draft with no pre-invites
+        var userA = Guid.NewGuid();
+        var night = NewDraft();
+        night.Rsvps.Should().BeEmpty();
+
+        // Act
+        night.Publish(new List<Guid> { userA });
+
+        // Assert: exactly one RSVP created for the freshly invited user
+        night.Rsvps.Should().ContainSingle();
+        night.Rsvps.Single().UserId.Should().Be(userA);
+        night.Status.Should().Be(GameNightStatus.Published);
+        night.DomainEvents.OfType<GameNightPublishedEvent>().Should().ContainSingle();
+    }
+
+    [Fact]
+    public void Publish_WithMixOfPreInvitedAndNewUsers_CreatesOneRsvpPerUser()
+    {
+        // Arrange: userA pre-invited; userB is new at publish time
+        var userA = Guid.NewGuid();
+        var userB = Guid.NewGuid();
+        var night = NewDraft();
+        night.PreInvite(new List<Guid> { userA });
+
+        // Act: publish with both — userA (already invited) and userB (new)
+        night.Publish(new List<Guid> { userA, userB });
+
+        // Assert: exactly two RSVPs, one per distinct user, no duplicate for userA
+        night.Rsvps.Should().HaveCount(2);
+        night.Rsvps.Select(r => r.UserId).Should().BeEquivalentTo(new[] { userA, userB });
+        night.Status.Should().Be(GameNightStatus.Published);
+        night.DomainEvents.OfType<GameNightPublishedEvent>().Should().ContainSingle();
+    }
+}

--- a/apps/api/tests/Api.Tests/Integration/GameManagement/GameNightEventPublishRsvpIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/GameManagement/GameNightEventPublishRsvpIntegrationTests.cs
@@ -1,0 +1,140 @@
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.BoundedContexts.GameManagement.Infrastructure.Persistence;
+using Api.Infrastructure;
+using Api.SharedKernel.Application.Services;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.Integration.GameManagement;
+
+/// <summary>
+/// Integration test reproducing the persistence path of Issue #2835: publishing a game night
+/// that has a pre-invited user must NOT create a duplicate <c>game_night_rsvps</c> row for that
+/// user.
+///
+/// <para>The bug: <c>CreateGameNightCommandHandler</c> calls <c>PreInvite(...)</c> at create time
+/// (persisting RSVP #1), then <c>PublishGameNightCommandHandler</c> reads the existing invited IDs
+/// back off the RSVPs and passes them to <c>Publish(...)</c>, which — before the fix — created a
+/// SECOND RSVP for the same <c>(event_id, user_id)</c>. Two rows with the same unique-index key in
+/// one <c>SaveChanges</c> made EF Core throw
+/// <c>InvalidOperationException: ... circular dependency was detected</c> (Multigraph.ThrowCycle)
+/// → HTTP 500.</para>
+///
+/// <para>This test exercises the full repository round-trip (AddAsync → SaveChanges →
+/// GetByIdAsync → Publish → UpdateAsync → SaveChanges) against a real Postgres container.
+/// It fails (Multigraph cycle) on origin/main-dev before the dedup guard is added to
+/// <see cref="GameNightEvent.Publish"/>, and passes after.</para>
+/// </summary>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "GameManagement")]
+[Trait("Issue", "2835")]
+public sealed class GameNightEventPublishRsvpIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private string _databaseName = null!;
+    private string _connectionString = null!;
+    private MeepleAiDbContext _dbContext = null!;
+
+    public GameNightEventPublishRsvpIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    private static CancellationToken TestCancellationToken => TestContext.Current.CancellationToken;
+
+    public async ValueTask InitializeAsync()
+    {
+        _databaseName = $"gamenight_publish_rsvp_{Guid.NewGuid():N}";
+        _connectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+        _dbContext = _fixture.CreateDbContext(_connectionString);
+        await _dbContext.Database.MigrateAsync(TestCancellationToken);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _dbContext.DisposeAsync();
+        await _fixture.DropIsolatedDatabaseAsync(_databaseName);
+    }
+
+    private GameNightEventRepository CreateRepository(MeepleAiDbContext dbContext) =>
+        new(dbContext, Mock.Of<IDomainEventCollector>(), Mock.Of<ILogger<GameNightEventRepository>>());
+
+    /// <summary>
+    /// Full path: create a Draft night with a pre-invited user, persist it, reload it,
+    /// publish it (passing the same invited user id — exactly what the real command handler
+    /// does), and save. Before #2835 the second SaveChanges throws the Multigraph cycle; after
+    /// the fix it succeeds and leaves exactly ONE rsvp row for (event, user) with the night
+    /// Published.
+    /// </summary>
+    [Fact(DisplayName = "Publishing a pre-invited game night persists exactly one RSVP (no Multigraph cycle) — #2835")]
+    public async Task Publish_WithPreInvitedUser_PersistsSingleRsvp()
+    {
+        // ── Arrange: create a draft with one pre-invited user and persist it ──
+        var invitedUserId = Guid.NewGuid();
+
+        await using (var dbCreate = _fixture.CreateDbContext(_connectionString))
+        {
+            var repoCreate = CreateRepository(dbCreate);
+            var draft = GameNightEvent.Create(
+                organizerId: Guid.NewGuid(),
+                title: "Boardgame Night",
+                scheduledAt: DateTimeOffset.UtcNow.AddDays(3));
+            draft.PreInvite(new List<Guid> { invitedUserId });
+
+            await repoCreate.AddAsync(draft, TestCancellationToken);
+            await dbCreate.SaveChangesAsync(TestCancellationToken);
+
+            _eventId = draft.Id;
+        }
+
+        // Sanity: the pre-invite produced exactly one persisted RSVP row.
+        await using (var dbSanity = _fixture.CreateDbContext(_connectionString))
+        {
+            var preInviteRows = await dbSanity.GameNightRsvps
+                .AsNoTracking()
+                .CountAsync(r => r.EventId == _eventId && r.UserId == invitedUserId, TestCancellationToken);
+            preInviteRows.Should().Be(1, "PreInvite persists exactly one RSVP for the invited user");
+        }
+
+        // ── Act: reload, publish (handler passes existing invited ids), save ──
+        await using (var dbPublish = _fixture.CreateDbContext(_connectionString))
+        {
+            var repoPublish = CreateRepository(dbPublish);
+
+            var night = await repoPublish.GetByIdAsync(_eventId, TestCancellationToken);
+            night.Should().NotBeNull();
+
+            // Mirror PublishGameNightCommandHandler: invited ids come from the existing RSVPs.
+            var existingInvitedIds = night!.Rsvps.Select(r => r.UserId).ToList();
+            night.Publish(existingInvitedIds);
+
+            await repoPublish.UpdateAsync(night, TestCancellationToken);
+
+            // This SaveChanges throws the Multigraph "circular dependency" cycle pre-fix.
+            Func<Task> act = async () => await dbPublish.SaveChangesAsync(TestCancellationToken);
+            await act.Should().NotThrowAsync(
+                "publishing a pre-invited night must not persist a duplicate (event, user) RSVP (#2835)");
+        }
+
+        // ── Assert: exactly one RSVP row survives and the night is Published ──
+        await using var dbVerify = _fixture.CreateDbContext(_connectionString);
+
+        var rsvpCount = await dbVerify.GameNightRsvps
+            .AsNoTracking()
+            .CountAsync(r => r.EventId == _eventId && r.UserId == invitedUserId, TestCancellationToken);
+        rsvpCount.Should().Be(1, "no duplicate RSVP row for the (event, user) unique key after publish");
+
+        var reloaded = await dbVerify.GameNightEvents
+            .AsNoTracking()
+            .FirstAsync(e => e.Id == _eventId, TestCancellationToken);
+        reloaded.Status.Should().Be("Published");
+    }
+
+    private Guid _eventId;
+}


### PR DESCRIPTION
## Sintesi

Fixa **#2835**: `POST /api/v1/game-nights/{id}/publish` restituiva **HTTP 500** (`Multigraph.ThrowCycle`) quando la game night aveva ≥1 utente pre-invitato. Scoperto e diagnosticato durante l'happy-path testing program (finding #R).

## Root cause

`CreateGameNightCommandHandler` chiama `GameNightEvent.PreInvite(invitedUserIds)` al Create → crea l'RSVP #1 (committato). Poi `PublishGameNightCommandHandler` passa `existingInvitedIds = gameNight.Rsvps.Select(r => r.UserId)` (= gli stessi utenti pre-invitati) a `GameNightEvent.Publish()`, che creava un **secondo** RSVP per gli stessi utenti perché — a differenza di `PreInvite()`/`AddInvitees()` — **mancava il guard di dedup**. Due `GameNightRsvpEntity` con lo stesso `(event_id, user_id)` unique index nello stesso `SaveChanges` → ciclo non ordinabile topologicamente da EF.

## Fix

Aggiunto in `GameNightEvent.Publish()` lo stesso dedup guard `if (_rsvps.All(r => r.UserId != userId))` già presente in `PreInvite()`/`AddInvitees()`. Il `GameNightPublishedEvent` continua a portare l'intera lista `invitedUserIds` → i pre-invitati vengono comunque notificati al publish.

## Test (TDD)

- **Domain unit** (`GameNightEventPublishRsvpTests`, 3 test): pre-invited + publish → 1 RSVP + esattamente 1 `GameNightPublishedEvent`; new-user-only; mixed → un RSVP per utente distinto.
- **Integration Testcontainers** (`GameNightEventPublishRsvpIntegrationTests`): create-with-pre-invite → save → reload → publish → save persiste esattamente 1 rsvp con status Published. **Confermato fallire con `Multigraph.ThrowCycle` pre-fix**, verde post-fix.
- 12 test adiacenti (`GameNightEventMaxLiveTests`) senza regressione. `dotnet build` 0 errori.

Verifica E2E manuale: publish di una GN con pre-invitato dava 500 `Multigraph.ThrowCycle` (stack trace reale catturato); il fix elimina il duplicato alla radice.

Closes #2835

🤖 Generated with [Claude Code](https://claude.com/claude-code)
