### PR TITLE
feat(user-notifications): #2832 FE checkbox for card-suppression email pref

### DIFF
--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/DTOs/NotificationPreferencesDto.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/DTOs/NotificationPreferencesDto.cs
@@ -15,5 +15,6 @@ internal record NotificationPreferencesDto(
     bool InAppOnDocumentReady,
     bool InAppOnDocumentFailed,
     bool InAppOnRetryAvailable,
-    bool HasPushSubscription
+    bool HasPushSubscription,
+    bool EmailOnCardSuppressed // #535/#2832: opt-in admin email on mechanic-card suppression
 );

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Queries/GetNotificationPreferencesQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Queries/GetNotificationPreferencesQueryHandler.cs
@@ -26,7 +26,8 @@ internal class GetNotificationPreferencesQueryHandler : IQueryHandler<GetNotific
             prefs.EmailOnDocumentReady, prefs.EmailOnDocumentFailed, prefs.EmailOnRetryAvailable,
             prefs.PushOnDocumentReady, prefs.PushOnDocumentFailed, prefs.PushOnRetryAvailable,
             prefs.InAppOnDocumentReady, prefs.InAppOnDocumentFailed, prefs.InAppOnRetryAvailable,
-            prefs.HasPushSubscription
+            prefs.HasPushSubscription,
+            prefs.EmailOnCardSuppressed
         );
     }
 }

--- a/apps/web/src/components/notifications/NotificationPreferences.tsx
+++ b/apps/web/src/components/notifications/NotificationPreferences.tsx
@@ -175,6 +175,22 @@ const PREFERENCE_CATEGORIES: PreferenceCategory[] = [
       },
     ],
   },
+  {
+    // #535 / #2832: admin-only opt-in email when a mechanic card is suppressed.
+    id: 'card-suppressed',
+    title: 'Scheda meccanica soppressa (admin)',
+    description: 'Email quando una scheda meccaniche viene soppressa (auto o manuale)',
+    icon: Bell,
+    iconColor: 'bg-amber-100 dark:bg-amber-900/20 text-amber-600 dark:text-amber-400',
+    rows: [
+      {
+        key: 'emailOnCardSuppressed',
+        icon: Mail,
+        label: 'Email',
+        description: 'Ricevi email quando una scheda meccaniche viene soppressa',
+      },
+    ],
+  },
 ];
 
 // ============================================================================
@@ -225,6 +241,11 @@ export function NotificationPreferences() {
     try {
       const { userId: _userId, ...prefsWithoutUserId } = prefs;
       await api.notifications.updatePreferences(prefsWithoutUserId);
+      // #2832: card-suppression email opt-in persists via its dedicated endpoint (the generic PUT
+      // above only handles the Document preferences and would otherwise ignore this field).
+      await api.notifications.updateCardSuppressionEmailPreference(
+        prefs.emailOnCardSuppressed ?? false
+      );
       toast({
         title: 'Salvato',
         description: 'Preferenze di notifica aggiornate',

--- a/apps/web/src/components/notifications/__tests__/NotificationPreferences.cardSuppression.test.tsx
+++ b/apps/web/src/components/notifications/__tests__/NotificationPreferences.cardSuppression.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * #2832: the card-suppression email opt-in toggle renders and persists via its dedicated endpoint.
+ */
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockGetPreferences = vi.hoisted(() => vi.fn());
+const mockUpdatePreferences = vi.hoisted(() => vi.fn());
+const mockUpdateCardSuppression = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    notifications: {
+      getPreferences: mockGetPreferences,
+      updatePreferences: mockUpdatePreferences,
+      updateCardSuppressionEmailPreference: mockUpdateCardSuppression,
+    },
+  },
+}));
+
+vi.mock('@/hooks/useToast', () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+import { NotificationPreferences } from '../NotificationPreferences';
+
+function fullPrefs(overrides: Record<string, unknown> = {}) {
+  return {
+    userId: 'u1',
+    emailOnDocumentReady: true,
+    emailOnDocumentFailed: true,
+    emailOnRetryAvailable: false,
+    pushOnDocumentReady: true,
+    pushOnDocumentFailed: true,
+    pushOnRetryAvailable: false,
+    inAppOnDocumentReady: true,
+    inAppOnDocumentFailed: true,
+    inAppOnRetryAvailable: true,
+    hasPushSubscription: false,
+    inAppOnGameNightInvitation: true,
+    emailOnGameNightInvitation: true,
+    pushOnGameNightInvitation: true,
+    emailOnGameNightReminder: true,
+    pushOnGameNightReminder: true,
+    emailOnCardSuppressed: false,
+    ...overrides,
+  };
+}
+
+describe('NotificationPreferences — card-suppression email opt-in (#2832)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetPreferences.mockResolvedValue(fullPrefs());
+    mockUpdatePreferences.mockResolvedValue(undefined);
+    mockUpdateCardSuppression.mockResolvedValue(undefined);
+  });
+
+  it('renders the card-suppression toggle reflecting the loaded (off) state', async () => {
+    render(<NotificationPreferences />);
+    const toggle = await screen.findByTestId('pref-emailOnCardSuppressed');
+    expect(toggle).toBeInTheDocument();
+    expect(toggle).toHaveAttribute('aria-checked', 'false');
+  });
+
+  it('persists the opt-in via the dedicated endpoint on save', async () => {
+    render(<NotificationPreferences />);
+    const toggle = await screen.findByTestId('pref-emailOnCardSuppressed');
+
+    fireEvent.click(toggle); // off → on
+    fireEvent.click(screen.getByTestId('save-preferences'));
+
+    await waitFor(() => expect(mockUpdateCardSuppression).toHaveBeenCalledWith(true));
+  });
+});

--- a/apps/web/src/lib/api/clients/notifications.ts
+++ b/apps/web/src/lib/api/clients/notifications.ts
@@ -34,6 +34,7 @@ export interface NotificationsClient {
   markAllNotificationsRead(): Promise<number>;
   getPreferences(): Promise<NotificationPreferences>;
   updatePreferences(prefs: Omit<NotificationPreferences, 'userId'>): Promise<void>;
+  updateCardSuppressionEmailPreference(enabled: boolean): Promise<void>;
 }
 
 export interface GetNotificationsParams {
@@ -117,7 +118,10 @@ export function createNotificationsClient({
      * Issue #4220: Multi-channel notification configuration
      */
     async getPreferences(): Promise<NotificationPreferences> {
-      const data = await httpClient.get('/api/v1/notifications/preferences', NotificationPreferencesSchema);
+      const data = await httpClient.get(
+        '/api/v1/notifications/preferences',
+        NotificationPreferencesSchema
+      );
       if (!data) throw new Error('Failed to fetch preferences');
       return data;
     },
@@ -128,6 +132,16 @@ export function createNotificationsClient({
      */
     async updatePreferences(prefs: Omit<NotificationPreferences, 'userId'>): Promise<void> {
       await httpClient.put('/api/v1/notifications/preferences', prefs);
+    },
+
+    /**
+     * Update the mechanic-card-suppression email opt-in (#535 / #2832).
+     * Dedicated endpoint so a generic preferences save never resets this flag.
+     */
+    async updateCardSuppressionEmailPreference(enabled: boolean): Promise<void> {
+      await httpClient.put('/api/v1/notifications/preferences/card-suppression', {
+        emailOnCardSuppressed: enabled,
+      });
     },
   };
 }

--- a/apps/web/src/lib/api/schemas/notifications.schemas.ts
+++ b/apps/web/src/lib/api/schemas/notifications.schemas.ts
@@ -92,6 +92,8 @@ export const NotificationPreferencesSchema = z.object({
   pushOnGameNightInvitation: z.boolean().optional().default(true),
   emailOnGameNightReminder: z.boolean().optional().default(true),
   pushOnGameNightReminder: z.boolean().optional().default(true),
+  // #535 / #2832: opt-in admin email when a mechanic card is suppressed (default off).
+  emailOnCardSuppressed: z.boolean().optional().default(false),
 });
 export type NotificationPreferences = z.infer<typeof NotificationPreferencesSchema>;
 


### PR DESCRIPTION
## Sommario
Follow-up di **#535**. Wire del checkbox FE per la preferenza email opt-in sulla soppressione card (il backend era già completo in #535).

## Cosa fa
- **BE**: `GET /notifications/preferences` ora ritorna `EmailOnCardSuppressed` (esteso `NotificationPreferencesDto` + handler mapping) → il FE legge lo stato iniziale.
- **FE**: schema zod `emailOnCardSuppressed` (optional, default false) + `notificationsClient.updateCardSuppressionEmailPreference(enabled)` (PUT dedicato `/notifications/preferences/card-suppression` — non il PUT Document generico che resetterebbe il flag) + toggle "Scheda meccanica soppressa (admin)" in `NotificationPreferences`, persistito su "Salva" via l'endpoint dedicato.

## Test
2 component test (toggle rende off-state + persiste opt-in via endpoint dedicato). API build + FE typecheck + lint verdi.

Closes #2832

🤖 Generated with [Claude Code](https://claude.com/claude-code)