### PR TITLE
feat(mechanic-extractor): #2837 DISTINCT filter-options endpoint for metrics dashboard

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/DTOs/MechanicMetricsDtos.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/DTOs/MechanicMetricsDtos.cs
@@ -40,3 +40,14 @@ internal sealed record MechanicRecentAnalysesResult(
 
 /// <summary>CSV export payload for the recent-analyses table (#532).</summary>
 internal sealed record ExportMechanicAnalysesResult(byte[] Content, string ContentType, string FileName);
+
+/// <summary>One selectable option (game or reviewer) for the dashboard filter dropdowns (#2837).</summary>
+internal sealed record MechanicFilterOptionDto(Guid Id, string Name);
+
+/// <summary>
+/// DISTINCT game + reviewer options for the metrics dashboard filter dropdowns (#2837), computed over
+/// ALL non-suppressed analyses (no recency cap, unlike the earlier recent(200)-derived options).
+/// </summary>
+internal sealed record MechanicMetricsFilterOptionsDto(
+    IReadOnlyList<MechanicFilterOptionDto> Games,
+    IReadOnlyList<MechanicFilterOptionDto> Reviewers);

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/MechanicMetrics/GetMechanicMetricsFilterOptionsQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/MechanicMetrics/GetMechanicMetricsFilterOptionsQuery.cs
@@ -1,0 +1,9 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Queries.MechanicMetrics;
+
+/// <summary>
+/// #2837: DISTINCT game + reviewer options for the metrics dashboard filter dropdowns (no recency cap).
+/// </summary>
+internal sealed record GetMechanicMetricsFilterOptionsQuery : IQuery<MechanicMetricsFilterOptionsDto>;

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/MechanicMetrics/GetMechanicMetricsFilterOptionsQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/MechanicMetrics/GetMechanicMetricsFilterOptionsQueryHandler.cs
@@ -1,0 +1,53 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
+using Api.Infrastructure;
+using Api.SharedKernel.Application.Interfaces;
+
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Queries.MechanicMetrics;
+
+internal sealed class GetMechanicMetricsFilterOptionsQueryHandler
+    : IQueryHandler<GetMechanicMetricsFilterOptionsQuery, MechanicMetricsFilterOptionsDto>
+{
+    private readonly MeepleAiDbContext _db;
+
+    public GetMechanicMetricsFilterOptionsQueryHandler(MeepleAiDbContext db)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+    }
+
+    public async Task<MechanicMetricsFilterOptionsDto> Handle(
+        GetMechanicMetricsFilterOptionsQuery request, CancellationToken cancellationToken)
+    {
+        // Games that have at least one (non-suppressed) analysis. The MechanicAnalyses query filter
+        // excludes suppressed rows; the join to SharedGames also drops soft-deleted games. DISTINCT on
+        // an anonymous {Id, Title} tuple (EF can't translate Distinct over a custom record); map after.
+        var gameRows = await (
+            from a in _db.MechanicAnalyses.AsNoTracking()
+            join g in _db.SharedGames on a.SharedGameId equals g.Id
+            select new { g.Id, g.Title })
+            .Distinct()
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+        var games = gameRows
+            .Select(x => new MechanicFilterOptionDto(x.Id, x.Title))
+            .OrderBy(o => o.Name, StringComparer.Ordinal)
+            .ToList();
+
+        // Reviewers that have reviewed at least one analysis.
+        var reviewerRows = await (
+            from a in _db.MechanicAnalyses.AsNoTracking()
+            where a.ReviewedBy != null
+            join u in _db.Users on a.ReviewedBy!.Value equals u.Id
+            select new { u.Id, Name = u.DisplayName ?? u.Email })
+            .Distinct()
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+        var reviewers = reviewerRows
+            .Select(x => new MechanicFilterOptionDto(x.Id, x.Name))
+            .OrderBy(o => o.Name, StringComparer.Ordinal)
+            .ToList();
+
+        return new MechanicMetricsFilterOptionsDto(games, reviewers);
+    }
+}

--- a/apps/api/src/Api/Routing/AdminMechanicAnalysesEndpoints.cs
+++ b/apps/api/src/Api/Routing/AdminMechanicAnalysesEndpoints.cs
@@ -105,6 +105,15 @@ internal static class AdminMechanicAnalysesEndpoints
         .WithName("AdminMechanicMetricsExport")
         .WithSummary("Mechanic Extractor analyses CSV export with the same filters as the grid (#532)");
 
+        // #2837: DISTINCT game/reviewer options for the dashboard filter dropdowns (no recency cap).
+        group.MapGet("/metrics/filter-options", async (IMediator mediator, CancellationToken ct) =>
+        {
+            var result = await mediator.Send(new GetMechanicMetricsFilterOptionsQuery(), ct).ConfigureAwait(false);
+            return Results.Ok(result);
+        })
+        .WithName("AdminMechanicMetricsFilterOptions")
+        .WithSummary("DISTINCT game + reviewer options for the metrics filter dropdowns (#2837)");
+
         // POST /api/v1/admin/mechanic-analyses
         // Enqueues the async AI pipeline (B5=B). Returns 202 Accepted with polling URL.
         group.MapPost("/", async (

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/MechanicMetricsFilterOptionsQueryTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/MechanicMetricsFilterOptionsQueryTests.cs
@@ -1,0 +1,79 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Queries.MechanicMetrics;
+using Api.Infrastructure;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using MediatR;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Infrastructure;
+
+/// <summary>#2837: DISTINCT game + reviewer filter options, deduped across all analyses (no recency cap).</summary>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class MechanicMetricsFilterOptionsQueryTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly string _testDbName;
+    private WebApplicationFactory<Program> _factory = null!;
+    private Guid _userId;
+    private Guid _reviewerId;
+
+    public MechanicMetricsFilterOptionsQueryTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+        _testDbName = $"me2837_options_{Guid.NewGuid():N}";
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        var conn = await _fixture.CreateIsolatedDatabaseAsync(_testDbName);
+        _factory = IntegrationWebApplicationFactory.Create(conn);
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        await db.Database.MigrateAsync();
+        (_userId, _) = await TestSessionHelper.CreateUserSessionAsync(db, Guid.NewGuid());
+        (_reviewerId, _) = await TestSessionHelper.CreateAdminSessionAsync(db, Guid.NewGuid());
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_factory is not null)
+        {
+            await _factory.DisposeAsync();
+        }
+        await _fixture.DropIsolatedDatabaseAsync(_testDbName);
+    }
+
+    [Fact]
+    public async Task FilterOptions_ReturnsDistinctGamesAndReviewers()
+    {
+        var now = DateTime.UtcNow;
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var g1 = await MechanicMetricsSeed.GameAsync(scope, _userId, "Catan");
+            var g2 = await MechanicMetricsSeed.GameAsync(scope, _userId, "Carcassonne");
+            // Same reviewer on two analyses (distinct dedup) + one unreviewed (no reviewer contribution).
+            await MechanicMetricsSeed.AnalysisAsync(scope, g1, _userId, status: 2, costUsd: 1m,
+                createdAt: now.AddMinutes(-3), reviewedAt: now, reviewedBy: _reviewerId);
+            await MechanicMetricsSeed.AnalysisAsync(scope, g2, _userId, status: 3, costUsd: 1m,
+                createdAt: now.AddMinutes(-2), reviewedAt: now, reviewedBy: _reviewerId, rejectionReason: "factual");
+            await MechanicMetricsSeed.AnalysisAsync(scope, g2, _userId, status: 1, costUsd: 1m, createdAt: now.AddMinutes(-1));
+        }
+
+        Api.BoundedContexts.SharedGameCatalog.Application.DTOs.MechanicMetricsFilterOptionsDto result;
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+            result = await mediator.Send(new GetMechanicMetricsFilterOptionsQuery());
+        }
+
+        result.Games.Select(g => g.Name).Should().BeEquivalentTo(new[] { "Carcassonne", "Catan" });
+        result.Reviewers.Should().ContainSingle(r => r.Id == _reviewerId); // deduped despite 2 reviewed analyses
+    }
+}

--- a/apps/web/src/app/admin/(dashboard)/knowledge-base/mechanic-extractor/metrics/__tests__/page.test.tsx
+++ b/apps/web/src/app/admin/(dashboard)/knowledge-base/mechanic-extractor/metrics/__tests__/page.test.tsx
@@ -9,6 +9,7 @@ import { renderWithQuery } from '@/__tests__/utils/query-test-utils';
 const mockGetSummary = vi.hoisted(() => vi.fn());
 const mockGetCostByDay = vi.hoisted(() => vi.fn());
 const mockGetRecent = vi.hoisted(() => vi.fn());
+const mockGetFilterOptions = vi.hoisted(() => vi.fn());
 const mockExportCsv = vi.hoisted(() => vi.fn());
 
 vi.mock('@/lib/api/clients/adminClient', () => ({
@@ -16,6 +17,7 @@ vi.mock('@/lib/api/clients/adminClient', () => ({
     getMechanicMetricsSummary: mockGetSummary,
     getMechanicCostByDay: mockGetCostByDay,
     getMechanicRecentAnalyses: mockGetRecent,
+    getMechanicMetricsFilterOptions: mockGetFilterOptions,
     exportMechanicAnalysesCsv: mockExportCsv,
   }),
 }));
@@ -57,6 +59,10 @@ describe('MechanicMetricsPage', () => {
         },
       ],
       totalCount: 1,
+    });
+    mockGetFilterOptions.mockResolvedValue({
+      games: [{ id: 'g1', name: 'Catan' }],
+      reviewers: [{ id: 'u1', name: 'Alice' }],
     });
     mockExportCsv.mockResolvedValue(new Blob(['x'], { type: 'text/csv' }));
   });

--- a/apps/web/src/app/admin/(dashboard)/knowledge-base/mechanic-extractor/metrics/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/knowledge-base/mechanic-extractor/metrics/page.tsx
@@ -85,37 +85,15 @@ export default function MechanicMetricsPage(): JSX.Element {
     staleTime: 30_000,
   });
 
-  // Filter dropdown options: distinct games/reviewers derived from the 200 most-recent analyses.
-  // KNOWN LIMITATION (#532 follow-up): games/reviewers whose analyses all fall outside this window
-  // won't appear as filter options once volume exceeds 200 rows. A dedicated DISTINCT endpoint is the
-  // proper fix — deferred; the summary/recent/export results themselves are NOT capped by this.
+  // Filter dropdown options: DISTINCT games/reviewers across ALL analyses (#2837 — no recency cap).
   const optionsQuery = useQuery({
     queryKey: ['me-metrics', 'filter-options'],
-    queryFn: () => adminClient.getMechanicRecentAnalyses({ limit: 200 }),
+    queryFn: () => adminClient.getMechanicMetricsFilterOptions(),
     staleTime: 5 * 60_000,
   });
 
-  const gameOptions = useMemo(() => {
-    const map = new Map<string, string>();
-    for (const r of optionsQuery.data?.items ?? []) {
-      map.set(r.sharedGameId, r.gameName);
-    }
-    return Array.from(map, ([id, name]) => ({ id, name })).sort((a, b) =>
-      a.name.localeCompare(b.name)
-    );
-  }, [optionsQuery.data]);
-
-  const reviewerOptions = useMemo(() => {
-    const map = new Map<string, string>();
-    for (const r of optionsQuery.data?.items ?? []) {
-      if (r.reviewedBy) {
-        map.set(r.reviewedBy, r.reviewerName ?? r.reviewedBy);
-      }
-    }
-    return Array.from(map, ([id, name]) => ({ id, name })).sort((a, b) =>
-      a.name.localeCompare(b.name)
-    );
-  }, [optionsQuery.data]);
+  const gameOptions = optionsQuery.data?.games ?? [];
+  const reviewerOptions = optionsQuery.data?.reviewers ?? [];
 
   const summary = summaryQuery.data;
   const recent = recentQuery.data;

--- a/apps/web/src/lib/api/clients/admin/adminMechanicMetricsClient.ts
+++ b/apps/web/src/lib/api/clients/admin/adminMechanicMetricsClient.ts
@@ -9,9 +9,11 @@ import {
   MechanicMetricsSummarySchema,
   MechanicCostByDayArraySchema,
   MechanicRecentAnalysesResultSchema,
+  MechanicMetricsFilterOptionsSchema,
   type MechanicMetricsSummary,
   type MechanicCostByDay,
   type MechanicRecentAnalysesResult,
+  type MechanicMetricsFilterOptions,
 } from '../../schemas/admin-mechanic-metrics.schemas';
 
 import type { HttpClient } from '../../core/httpClient';
@@ -70,6 +72,11 @@ export function createAdminMechanicMetricsClient(http: HttpClient) {
         status: params.status,
       });
       return http.get(`${BASE}/recent${qs}`, MechanicRecentAnalysesResultSchema);
+    },
+
+    // #2837: DISTINCT game/reviewer options for the filter dropdowns (no recency cap).
+    async getMechanicMetricsFilterOptions(): Promise<MechanicMetricsFilterOptions | null> {
+      return http.get(`${BASE}/filter-options`, MechanicMetricsFilterOptionsSchema);
     },
 
     async exportMechanicAnalysesCsv(filters: MechanicMetricsFilters = {}): Promise<Blob> {

--- a/apps/web/src/lib/api/schemas/admin-mechanic-metrics.schemas.ts
+++ b/apps/web/src/lib/api/schemas/admin-mechanic-metrics.schemas.ts
@@ -52,3 +52,16 @@ export const MechanicRecentAnalysesResultSchema = z.object({
   totalCount: z.number(),
 });
 export type MechanicRecentAnalysesResult = z.infer<typeof MechanicRecentAnalysesResultSchema>;
+
+// #2837: DISTINCT filter options (no recency cap).
+export const MechanicFilterOptionSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+});
+export type MechanicFilterOption = z.infer<typeof MechanicFilterOptionSchema>;
+
+export const MechanicMetricsFilterOptionsSchema = z.object({
+  games: z.array(MechanicFilterOptionSchema),
+  reviewers: z.array(MechanicFilterOptionSchema),
+});
+export type MechanicMetricsFilterOptions = z.infer<typeof MechanicMetricsFilterOptionsSchema>;


### PR DESCRIPTION
## Sommario
Follow-up di **#532**. Risolve la limitazione dei dropdown filtro (gioco/reviewer) che derivavano le opzioni dai 200 analisi più recenti → giochi/reviewer fuori da quella finestra non erano selezionabili.

## Cosa fa
- **BE**: nuovo `GET /admin/mechanic-analyses/metrics/filter-options` → `{ games, reviewers }` **DISTINCT** su TUTTe le analisi non-soppresse (no cap 200). Query handler CQRS: `Distinct()` su tuple anonime (EF non traduce Distinct su record custom) → map al DTO in memoria; join a SharedGames/users per i nomi.
- **FE**: schema `MechanicMetricsFilterOptions` + `adminMechanicMetricsClient.getMechanicMetricsFilterOptions()` + la page consuma direttamente `games`/`reviewers` (rimosso il commento `KNOWN LIMITATION` + il fetch recent(200)).

## Test
BE: distinct corretto (2 giochi, reviewer deduplicato su 2 analisi). FE: page test aggiornato col nuovo mock. Typecheck + lint verdi.

Closes #2837

🤖 Generated with [Claude Code](https://claude.com/claude-code)