### PR TITLE
test(e2e): #2784 graceful-skip real-UI-login admin specs (chiude #2784)

### DIFF
--- a/apps/web/e2e/_helpers/backendGuard.ts
+++ b/apps/web/e2e/_helpers/backendGuard.ts
@@ -1,0 +1,41 @@
+import type { Page } from '@playwright/test';
+
+/**
+ * Real-backend reachability guard for admin E2E specs that perform a real UI
+ * login (fill the /login form + submit against the API).
+ *
+ * Such specs cannot run under the local E2E auth bypass (`next dev`,
+ * PLAYWRIGHT_AUTH_BYPASS=true) because there is no backend at :8080 to validate
+ * the login — they hard-fail at the login step. This is a pre-existing
+ * backend-dependency, distinct from the #2784 role-cookie regression (which is
+ * fixed for mock-based specs via `seedMockRoleCookies`).
+ *
+ * Use in a spec's `test.beforeEach` BEFORE the login:
+ *   test.beforeEach(async ({ page }) => {
+ *     test.skip(!(await isBackendReachable(page)), NO_BACKEND_SKIP_REASON);
+ *     // ...existing real login...
+ *   });
+ *
+ * Locally (no backend) → probe fails → skip. In CI (real backend up) → probe
+ * succeeds → the spec runs normally. See issue #2784.
+ */
+const API_HEALTH_URL = `${
+  process.env.PLAYWRIGHT_API_BASE || process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8080'
+}/health/live`;
+
+export const NO_BACKEND_SKIP_REASON =
+  'Requires a real backend (real UI login) — skipped without one at :8080. #2784';
+
+/**
+ * Returns true only when the real backend `/health/live` endpoint responds OK.
+ * Never throws: any network/timeout error resolves to false (treat as
+ * unreachable → skip).
+ */
+export async function isBackendReachable(page: Page): Promise<boolean> {
+  try {
+    const res = await page.request.get(API_HEALTH_URL, { timeout: 3000 });
+    return res.ok();
+  } catch {
+    return false;
+  }
+}

--- a/apps/web/e2e/admin-first-time-setup/02-authentication-flow.spec.ts
+++ b/apps/web/e2e/admin-first-time-setup/02-authentication-flow.spec.ts
@@ -13,11 +13,18 @@
 
 import { test, expect } from '@playwright/test';
 
+import { isBackendReachable, NO_BACKEND_SKIP_REASON } from '../_helpers/backendGuard';
 import { loginAsAdmin } from '../utils/admin-setup-helpers';
 
 test.describe.configure({ mode: 'serial' });
 test.describe('Authentication Flow', () => {
   test.use({ storageState: undefined }); // Start with no auth
+
+  // Every test in this suite exercises the real login/auth flow against the
+  // backend — skip the whole suite when no backend is reachable. See #2784.
+  test.beforeEach(async ({ page }) => {
+    test.skip(!(await isBackendReachable(page)), NO_BACKEND_SKIP_REASON);
+  });
 
   test('admin first login with email/password (no 2FA)', async ({ page }) => {
     // Navigate to login page
@@ -36,7 +43,7 @@ test.describe('Authentication Flow', () => {
 
     // Set up response listener BEFORE clicking submit
     const responsePromise = page.waitForResponse(
-      (response) => response.url().includes('/api/v1/auth/login') && response.status() === 200
+      response => response.url().includes('/api/v1/auth/login') && response.status() === 200
     );
 
     // Submit login form
@@ -74,7 +81,7 @@ test.describe('Authentication Flow', () => {
     const cookies = await context.cookies();
     // Session cookie may have various names: session, sessionToken, .AspNetCore.Session, etc.
     const sessionCookie = cookies.find(
-      (c) =>
+      c =>
         c.name.toLowerCase().includes('session') ||
         c.name.toLowerCase().includes('auth') ||
         c.name.startsWith('.')
@@ -107,7 +114,7 @@ test.describe('Authentication Flow', () => {
     // Get session cookie (flexible name matching)
     const cookies = await page.context().cookies();
     const sessionCookie = cookies.find(
-      (c) =>
+      c =>
         c.name.toLowerCase().includes('session') ||
         c.name.toLowerCase().includes('auth') ||
         c.name.startsWith('.')
@@ -137,8 +144,8 @@ test.describe('Authentication Flow', () => {
     await page.fill('input[name="email"]', 'admin@meepleai.dev');
     await page.fill('input[name="password"]', 'WrongPassword123');
 
-    const responsePromise = page.waitForResponse(
-      (response) => response.url().includes('/api/v1/auth/login')
+    const responsePromise = page.waitForResponse(response =>
+      response.url().includes('/api/v1/auth/login')
     );
 
     await page.click('button[type="submit"]');
@@ -182,7 +189,7 @@ test.describe('Authentication Flow', () => {
     // Verify session cleared
     const cookies = await context.cookies();
     const sessionCookie = cookies.find(
-      (c) =>
+      c =>
         c.name.toLowerCase().includes('session') ||
         c.name.toLowerCase().includes('auth') ||
         c.name.startsWith('.')
@@ -256,9 +263,9 @@ test.describe('Authentication Flow', () => {
     expect(page.url()).toContain('/admin');
 
     // Verify admin content visible
-    await expect(
-      page.locator('h1:has-text("Users"), h1:has-text("User Management")')
-    ).toBeVisible({ timeout: 5000 });
+    await expect(page.locator('h1:has-text("Users"), h1:has-text("User Management")')).toBeVisible({
+      timeout: 5000,
+    });
 
     console.log('✅ Admin routes accessible');
   });

--- a/apps/web/e2e/admin-first-time-setup/03-admin-wizard-complete.spec.ts
+++ b/apps/web/e2e/admin-first-time-setup/03-admin-wizard-complete.spec.ts
@@ -13,11 +13,8 @@
 
 import { test, expect } from '@playwright/test';
 
-import {
-  loginAsAdmin,
-  navigateToWizard,
-  cleanupTestData,
-} from '../utils/admin-setup-helpers';
+import { isBackendReachable, NO_BACKEND_SKIP_REASON } from '../_helpers/backendGuard';
+import { loginAsAdmin, navigateToWizard, cleanupTestData } from '../utils/admin-setup-helpers';
 
 // Shared state across wizard steps
 let testPdfId: string;
@@ -26,10 +23,22 @@ let testChatThreadId: string;
 
 test.describe.configure({ mode: 'serial' });
 test.describe('Admin Wizard - Complete Flow', () => {
+  // Every test performs a real UI login — skip the whole suite without a
+  // reachable backend. See #2784.
+  test.beforeEach(async ({ page }) => {
+    test.skip(!(await isBackendReachable(page)), NO_BACKEND_SKIP_REASON);
+  });
+
   // Login before all tests
   test.beforeAll(async ({ browser }) => {
     const context = await browser.newContext();
     const page = await context.newPage();
+    // Guard the pre-warm login too: without a backend the login would hard-fail
+    // and fail the suite even though every test is skipped by beforeEach.
+    if (!(await isBackendReachable(page))) {
+      await context.close();
+      return;
+    }
     await loginAsAdmin(page);
     await context.close();
   });
@@ -67,9 +76,9 @@ test.describe('Admin Wizard - Complete Flow', () => {
     await navigateToWizard(page);
 
     // Verify we're on step 1
-    await expect(
-      page.locator('text=/Step 1|PDF Upload|Upload Rulebook/i')
-    ).toBeVisible({ timeout: 5000 });
+    await expect(page.locator('text=/Step 1|PDF Upload|Upload Rulebook/i')).toBeVisible({
+      timeout: 5000,
+    });
 
     // Select a seeded game (using Pandemic for test)
     const gameSelect = page.locator('select[name="gameSelect"], select[name="game"]');
@@ -102,7 +111,7 @@ test.describe('Admin Wizard - Complete Flow', () => {
 
     // Wait for upload response
     const uploadPromise = page.waitForResponse(
-      (response) =>
+      response =>
         response.url().includes('/api/v1/documents') &&
         (response.status() === 200 || response.status() === 201),
       { timeout: 30000 }
@@ -135,9 +144,9 @@ test.describe('Admin Wizard - Complete Flow', () => {
     // For isolated test, we skip step 1 and go directly
 
     // Verify we're on step 2
-    await expect(
-      page.locator('text=/Step 2|Game Selection|Select Game/i')
-    ).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('text=/Step 2|Game Selection|Select Game/i')).toBeVisible({
+      timeout: 10000,
+    });
 
     // Select Pandemic from dropdown
     const gameIdSelect = page.locator('select[name="gameId"]');
@@ -164,9 +173,9 @@ test.describe('Admin Wizard - Complete Flow', () => {
     await navigateToWizard(page);
 
     // Verify we're on step 3
-    await expect(
-      page.locator('text=/Step 3|Chat Setup|RAG Agent/i')
-    ).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('text=/Step 3|Chat Setup|RAG Agent/i')).toBeVisible({
+      timeout: 10000,
+    });
 
     // Wait for PDF processing status
     console.log('⏳ Waiting for PDF processing...');
@@ -222,9 +231,7 @@ test.describe('Admin Wizard - Complete Flow', () => {
     await navigateToWizard(page);
 
     // Verify we're on step 4
-    await expect(
-      page.locator('text=/Step 4|Q&A|Test/i')
-    ).toBeVisible({ timeout: 10000 });
+    await expect(page.locator('text=/Step 4|Q&A|Test/i')).toBeVisible({ timeout: 10000 });
 
     // Send test question
     const testQuestion = 'How many players can play Pandemic?';
@@ -238,7 +245,7 @@ test.describe('Admin Wizard - Complete Flow', () => {
 
     // Wait for agent response
     const messagePromise = page.waitForResponse(
-      (response) =>
+      response =>
         response.url().includes('/api/v1/chat/messages') &&
         (response.status() === 200 || response.status() === 201),
       { timeout: 30000 }

--- a/apps/web/e2e/admin-first-time-setup/04-bounded-contexts-access.spec.ts
+++ b/apps/web/e2e/admin-first-time-setup/04-bounded-contexts-access.spec.ts
@@ -12,12 +12,14 @@
 
 import { test, expect } from '@playwright/test';
 
+import { isBackendReachable, NO_BACKEND_SKIP_REASON } from '../_helpers/backendGuard';
 import { loginAsAdmin, sendTestQuestion } from '../utils/admin-setup-helpers';
 
 test.describe.configure({ mode: 'serial' });
 test.describe('Bounded Context Access', () => {
   // Ensure admin is logged in for all tests
   test.beforeEach(async ({ page }) => {
+    test.skip(!(await isBackendReachable(page)), NO_BACKEND_SKIP_REASON);
     await loginAsAdmin(page);
   });
 

--- a/apps/web/e2e/admin-first-time-setup/05-complete-first-time-journey.spec.ts
+++ b/apps/web/e2e/admin-first-time-setup/05-complete-first-time-journey.spec.ts
@@ -14,6 +14,7 @@
 
 import { test, expect } from '@playwright/test';
 
+import { isBackendReachable, NO_BACKEND_SKIP_REASON } from '../_helpers/backendGuard';
 import {
   verifyServiceHealth,
   verifySharedGamesSeeded,
@@ -24,6 +25,12 @@ import {
 test.describe('Complete First-Time Journey', () => {
   // Extended timeout for complete journey
   test.setTimeout(300000); // 5 minutes
+
+  // The single journey test performs a real UI login (Phase 2) — skip without
+  // a reachable backend. See #2784.
+  test.beforeEach(async ({ page }) => {
+    test.skip(!(await isBackendReachable(page)), NO_BACKEND_SKIP_REASON);
+  });
 
   // Cleanup data
   let createdPdfId: string | undefined;

--- a/apps/web/e2e/admin-games-workflow.spec.ts
+++ b/apps/web/e2e/admin-games-workflow.spec.ts
@@ -11,8 +11,11 @@
 
 import { test, expect } from '@playwright/test';
 
+import { isBackendReachable, NO_BACKEND_SKIP_REASON } from './_helpers/backendGuard';
+
 test.describe('Admin Games Management Dashboard', () => {
   test.beforeEach(async ({ page }) => {
+    test.skip(!(await isBackendReachable(page)), NO_BACKEND_SKIP_REASON);
     // Login as admin
     await page.goto('/login');
     await page.fill('[name="email"]', 'admin@meepleai.com');

--- a/apps/web/e2e/admin-management-integration.spec.ts
+++ b/apps/web/e2e/admin-management-integration.spec.ts
@@ -12,11 +12,14 @@
 
 import { test, expect } from '@playwright/test';
 
+import { isBackendReachable, NO_BACKEND_SKIP_REASON } from './_helpers/backendGuard';
+
 const ADMIN_EMAIL = 'admin@test.com';
 const ADMIN_PASSWORD = 'Admin123!';
 
 test.describe('Admin Management Integration - Issue #903', () => {
   test.beforeEach(async ({ page }) => {
+    test.skip(!(await isBackendReachable(page)), NO_BACKEND_SKIP_REASON);
     // Login as admin
     await page.goto('/login');
     await page.fill('input[name="email"]', ADMIN_EMAIL);

--- a/apps/web/e2e/admin/api-keys-ui-security.spec.ts
+++ b/apps/web/e2e/admin/api-keys-ui-security.spec.ts
@@ -13,11 +13,14 @@
 
 import { test, expect } from '@playwright/test';
 
+import { isBackendReachable, NO_BACKEND_SKIP_REASON } from '../_helpers/backendGuard';
+
 const BASE_URL = process.env.NEXT_PUBLIC_WEB_BASE || 'http://localhost:3000';
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8080';
 
 test.describe('API Keys UI Security - Issue #914', () => {
   test.beforeEach(async ({ page }) => {
+    test.skip(!(await isBackendReachable(page)), NO_BACKEND_SKIP_REASON);
     // Login as admin
     await page.goto(`${BASE_URL}/login`);
     await page.fill('input[name="email"]', 'demo@meepleai.dev');

--- a/apps/web/e2e/admin/game-import-wizard.spec.ts
+++ b/apps/web/e2e/admin/game-import-wizard.spec.ts
@@ -15,6 +15,8 @@ import path from 'path';
 
 import { test, expect } from '@playwright/test';
 
+import { isBackendReachable, NO_BACKEND_SKIP_REASON } from '../_helpers/backendGuard';
+
 // Test data paths
 const TEST_PDF_PATH = path.join(__dirname, '..', 'test-data', 'wingspan_rulebook.pdf');
 const WIZARD_URL = '/admin/shared-games/import';
@@ -55,6 +57,10 @@ async function loginAsEditor(page: any) {
 }
 
 test.describe('Game Import Wizard E2E', () => {
+  test.beforeEach(async ({ page }) => {
+    test.skip(!(await isBackendReachable(page)), NO_BACKEND_SKIP_REASON);
+  });
+
   test.describe('Happy Path', () => {
     test('completes full import workflow', async ({ page }) => {
       // Setup: Authenticate as admin

--- a/apps/web/e2e/admin/shared-games-accessibility.spec.ts
+++ b/apps/web/e2e/admin/shared-games-accessibility.spec.ts
@@ -13,6 +13,8 @@
 import AxeBuilder from '@axe-core/playwright';
 import { test, expect } from '@playwright/test';
 
+import { isBackendReachable, NO_BACKEND_SKIP_REASON } from '../_helpers/backendGuard';
+
 test.describe('SharedGameCatalog Accessibility (WCAG AA)', () => {
   test.beforeEach(async ({ page }) => {
     // Note: axe-playwright auto-injects axe-core, no manual injection needed
@@ -34,6 +36,7 @@ test.describe('SharedGameCatalog Accessibility (WCAG AA)', () => {
   });
 
   test('Admin list page should have no WCAG AA violations', async ({ page }) => {
+    test.skip(!(await isBackendReachable(page)), NO_BACKEND_SKIP_REASON);
     // Login as admin
     await page.goto('/login');
     await page.fill('input[type="email"]', 'admin@meepleai.dev');
@@ -78,6 +81,7 @@ test.describe('SharedGameCatalog Accessibility (WCAG AA)', () => {
   });
 
   test('Keyboard navigation should work throughout admin UI', async ({ page }) => {
+    test.skip(!(await isBackendReachable(page)), NO_BACKEND_SKIP_REASON);
     await page.goto('/login');
     await page.fill('input[type="email"]', 'admin@meepleai.dev');
     await page.fill('input[type="password"]', 'Admin123!');

--- a/apps/web/e2e/admin/shared-games-approval-queue.spec.ts
+++ b/apps/web/e2e/admin/shared-games-approval-queue.spec.ts
@@ -14,8 +14,11 @@
 
 import { test, expect } from '@playwright/test';
 
+import { isBackendReachable, NO_BACKEND_SKIP_REASON } from '../_helpers/backendGuard';
+
 test.describe('Approval Queue Page', () => {
   test.beforeEach(async ({ page }) => {
+    test.skip(!(await isBackendReachable(page)), NO_BACKEND_SKIP_REASON);
     // Login as admin
     await page.goto('/login');
     await page.fill('input[type="email"]', 'admin@meepleai.dev');
@@ -56,10 +59,16 @@ test.describe('Approval Queue Page', () => {
   test.describe('Filters', () => {
     test('should display filter controls', async ({ page }) => {
       // Urgency filter
-      await expect(page.locator('text=All Items').or(page.locator('text=Urgent Only'))).toBeVisible();
+      await expect(
+        page.locator('text=All Items').or(page.locator('text=Urgent Only'))
+      ).toBeVisible();
 
       // Sort filter
-      await expect(page.locator('text=Oldest First').or(page.locator('text=Newest First').or(page.locator('text=Most Urgent')))).toBeVisible();
+      await expect(
+        page
+          .locator('text=Oldest First')
+          .or(page.locator('text=Newest First').or(page.locator('text=Most Urgent')))
+      ).toBeVisible();
     });
 
     test('should filter by urgency', async ({ page }) => {
@@ -103,7 +112,7 @@ test.describe('Approval Queue Page', () => {
       const rejectButton = page.locator('button:has-text("Reject")');
 
       // At least one should be visible if items exist
-      const hasItems = await page.locator('[data-testid="queue-item"]').count() > 0;
+      const hasItems = (await page.locator('[data-testid="queue-item"]').count()) > 0;
       if (hasItems) {
         await expect(approveButton.or(rejectButton)).toBeVisible();
       }
@@ -129,7 +138,7 @@ test.describe('Approval Queue Page', () => {
       const urgentBadge = page.locator('text=Urgent');
 
       // If urgent items exist, badge should be visible
-      const hasUrgent = await urgentBadge.count() > 0;
+      const hasUrgent = (await urgentBadge.count()) > 0;
       if (hasUrgent) {
         await expect(urgentBadge.first()).toBeVisible();
       }
@@ -140,7 +149,7 @@ test.describe('Approval Queue Page', () => {
       const daysBadge = page.locator('text=/\\d+ day(s)? pending/');
 
       // If items exist, should show days
-      const hasItems = await daysBadge.count() > 0;
+      const hasItems = (await daysBadge.count()) > 0;
       if (hasItems) {
         await expect(daysBadge.first()).toBeVisible();
       }
@@ -148,9 +157,15 @@ test.describe('Approval Queue Page', () => {
 
     test('should have action buttons for each item', async ({ page }) => {
       // Look for item action buttons
-      const eyeButton = page.locator('button').filter({ has: page.locator('[data-testid="eye-icon"]') });
-      const checkButton = page.locator('button').filter({ has: page.locator('[data-testid="check-icon"]') });
-      const xButton = page.locator('button').filter({ has: page.locator('[data-testid="x-icon"]') });
+      const eyeButton = page
+        .locator('button')
+        .filter({ has: page.locator('[data-testid="eye-icon"]') });
+      const checkButton = page
+        .locator('button')
+        .filter({ has: page.locator('[data-testid="check-icon"]') });
+      const xButton = page
+        .locator('button')
+        .filter({ has: page.locator('[data-testid="x-icon"]') });
 
       // Just verify the page loads without errors
       await page.waitForTimeout(500);
@@ -167,7 +182,9 @@ test.describe('Approval Queue Page', () => {
       await page.waitForTimeout(300);
 
       // Look for bulk approve button
-      const approveButton = page.locator('button:has-text("Approve")').filter({ hasText: /\(\d+\)/ });
+      const approveButton = page
+        .locator('button:has-text("Approve")')
+        .filter({ hasText: /\(\d+\)/ });
 
       const isVisible = await approveButton.isVisible();
       if (isVisible) {
@@ -202,7 +219,10 @@ test.describe('Approval Queue Page', () => {
   test.describe('Preview', () => {
     test('should open preview when clicking eye icon', async ({ page }) => {
       // Find an eye icon button
-      const previewButton = page.locator('button').filter({ has: page.locator('svg[data-lucide="eye"]') }).first();
+      const previewButton = page
+        .locator('button')
+        .filter({ has: page.locator('svg[data-lucide="eye"]') })
+        .first();
 
       const hasPreviewButton = await previewButton.isVisible();
       if (hasPreviewButton) {
@@ -215,7 +235,11 @@ test.describe('Approval Queue Page', () => {
 
     test('preview should have link to full details', async ({ page }) => {
       // Find an eye icon button
-      const previewButton = page.locator('button').filter({ has: page.locator('svg') }).filter({ hasText: '' }).first();
+      const previewButton = page
+        .locator('button')
+        .filter({ has: page.locator('svg') })
+        .filter({ hasText: '' })
+        .first();
 
       const hasPreviewButton = await previewButton.isVisible();
       if (hasPreviewButton) {

--- a/apps/web/e2e/admin/shared-games-bgg-import.spec.ts
+++ b/apps/web/e2e/admin/shared-games-bgg-import.spec.ts
@@ -12,12 +12,15 @@
 
 import { test, expect } from '@playwright/test';
 
+import { isBackendReachable, NO_BACKEND_SKIP_REASON } from '../_helpers/backendGuard';
+
 // Test configuration
 const TEST_BGG_ID = '13'; // Catan - a well-known game for testing
 const TEST_BGG_URL = 'https://boardgamegeek.com/boardgame/13/catan';
 
 test.describe('BGG Import Workflow', () => {
   test.beforeEach(async ({ page }) => {
+    test.skip(!(await isBackendReachable(page)), NO_BACKEND_SKIP_REASON);
     // Login as admin
     await page.goto('/login');
     await page.fill('input[type="email"]', 'admin@meepleai.dev');
@@ -136,7 +139,9 @@ test.describe('BGG Import Workflow', () => {
       await page.waitForTimeout(1500);
 
       // Should show error message
-      await expect(page.locator('text=not found').or(page.locator('text=Game not found'))).toBeVisible();
+      await expect(
+        page.locator('text=not found').or(page.locator('text=Game not found'))
+      ).toBeVisible();
     });
 
     test('should handle rate limit errors', async ({ page }) => {

--- a/apps/web/e2e/admin/shared-games-detail-page.spec.ts
+++ b/apps/web/e2e/admin/shared-games-detail-page.spec.ts
@@ -16,10 +16,13 @@
 
 import { test, expect } from '@playwright/test';
 
+import { isBackendReachable, NO_BACKEND_SKIP_REASON } from '../_helpers/backendGuard';
+
 test.describe('Game Detail Page', () => {
   let testGameId: string;
 
   test.beforeEach(async ({ page }) => {
+    test.skip(!(await isBackendReachable(page)), NO_BACKEND_SKIP_REASON);
     // Login as admin
     await page.goto('/login');
     await page.fill('input[type="email"]', 'admin@meepleai.dev');
@@ -61,7 +64,7 @@ test.describe('Game Detail Page', () => {
 
     test('should display BGG link if game has bggId', async ({ page }) => {
       const bggLink = page.locator('a[href*="boardgamegeek.com"]');
-      const hasBggLink = await bggLink.count() > 0;
+      const hasBggLink = (await bggLink.count()) > 0;
 
       if (hasBggLink) {
         await expect(bggLink).toHaveAttribute('target', '_blank');
@@ -119,8 +122,8 @@ test.describe('Game Detail Page', () => {
       const image = page.locator('img[alt]');
       const placeholder = page.locator('svg[data-lucide]');
 
-      const hasImage = await image.count() > 0;
-      const hasPlaceholder = await placeholder.count() > 0;
+      const hasImage = (await image.count()) > 0;
+      const hasPlaceholder = (await placeholder.count()) > 0;
 
       expect(hasImage || hasPlaceholder).toBeTruthy();
     });
@@ -146,7 +149,9 @@ test.describe('Game Detail Page', () => {
     });
 
     test('should display documents list section', async ({ page }) => {
-      await expect(page.locator('h2:has-text("Documents"), h3:has-text("Documents")')).toBeVisible();
+      await expect(
+        page.locator('h2:has-text("Documents"), h3:has-text("Documents")')
+      ).toBeVisible();
     });
 
     test('should show empty state if no documents', async ({ page }) => {
@@ -184,7 +189,9 @@ test.describe('Game Detail Page', () => {
       }
     });
 
-    test('should display Approve and Reject buttons for Pending Approval games', async ({ page }) => {
+    test('should display Approve and Reject buttons for Pending Approval games', async ({
+      page,
+    }) => {
       const status = await page.locator('text=Pending Approval').count();
 
       if (status > 0) {
@@ -260,7 +267,7 @@ test.describe('Game Detail Page', () => {
 
     test('should navigate to external BGG link', async ({ page }) => {
       const bggLink = page.locator('a[href*="boardgamegeek.com"]').first();
-      const hasBggLink = await bggLink.count() > 0;
+      const hasBggLink = (await bggLink.count()) > 0;
 
       if (hasBggLink) {
         // Check it opens in new tab

--- a/apps/web/e2e/admin/shared-games-permissions.spec.ts
+++ b/apps/web/e2e/admin/shared-games-permissions.spec.ts
@@ -11,6 +11,8 @@
 
 import { test, expect } from '@playwright/test';
 
+import { isBackendReachable, NO_BACKEND_SKIP_REASON } from '../_helpers/backendGuard';
+
 test.describe('SharedGameCatalog Permission Enforcement', () => {
   test('User (unauthenticated) cannot access admin endpoints', async ({ page }) => {
     // Try to access admin page without login
@@ -21,6 +23,7 @@ test.describe('SharedGameCatalog Permission Enforcement', () => {
   });
 
   test('Editor cannot publish game (AdminOrEditor policy allows)', async ({ page }) => {
+    test.skip(!(await isBackendReachable(page)), NO_BACKEND_SKIP_REASON);
     // Login as editor (assumes editor@meepleai.dev exists)
     await page.goto('/login');
     await page.fill('input[type="email"]', 'editor@meepleai.dev');
@@ -41,6 +44,7 @@ test.describe('SharedGameCatalog Permission Enforcement', () => {
   });
 
   test('Editor cannot access bulk import (Admin only)', async ({ page }) => {
+    test.skip(!(await isBackendReachable(page)), NO_BACKEND_SKIP_REASON);
     await page.goto('/login');
     await page.fill('input[type="email"]', 'editor@meepleai.dev');
     await page.fill('input[type="password"]', 'Editor123!');
@@ -61,6 +65,7 @@ test.describe('SharedGameCatalog Permission Enforcement', () => {
   });
 
   test('Editor cannot approve delete requests (Admin only)', async ({ page }) => {
+    test.skip(!(await isBackendReachable(page)), NO_BACKEND_SKIP_REASON);
     await page.goto('/login');
     await page.fill('input[type="email"]', 'editor@meepleai.dev');
     await page.fill('input[type="password"]', 'Editor123!');
@@ -81,6 +86,7 @@ test.describe('SharedGameCatalog Permission Enforcement', () => {
   });
 
   test('Regular user cannot create games (API returns 403)', async ({ page, request }) => {
+    test.skip(!(await isBackendReachable(page)), NO_BACKEND_SKIP_REASON);
     // Login as regular user
     await page.goto('/login');
     await page.fill('input[type="email"]', 'user@meepleai.dev');

--- a/apps/web/e2e/admin/shared-games-rag-full-flow.spec.ts
+++ b/apps/web/e2e/admin/shared-games-rag-full-flow.spec.ts
@@ -18,6 +18,8 @@ import path from 'path';
 
 import { test, expect, type Page } from '@playwright/test';
 
+import { isBackendReachable, NO_BACKEND_SKIP_REASON } from '../_helpers/backendGuard';
+
 const API_BASE =
   process.env.PLAYWRIGHT_API_BASE || process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8080';
 
@@ -42,6 +44,7 @@ test.describe('Admin Shared Game + RAG Full Flow (#253)', () => {
   const testGameTitle = `E2E RAG Flow ${Date.now()}`;
 
   test.beforeEach(async ({ page }) => {
+    test.skip(!(await isBackendReachable(page)), NO_BACKEND_SKIP_REASON);
     await loginAsAdmin(page);
   });
 

--- a/apps/web/e2e/admin/shared-games-workflow.spec.ts
+++ b/apps/web/e2e/admin/shared-games-workflow.spec.ts
@@ -13,8 +13,11 @@
 
 import { test, expect } from '@playwright/test';
 
+import { isBackendReachable, NO_BACKEND_SKIP_REASON } from '../_helpers/backendGuard';
+
 test.describe('SharedGameCatalog Admin Workflow', () => {
   test.beforeEach(async ({ page }) => {
+    test.skip(!(await isBackendReachable(page)), NO_BACKEND_SKIP_REASON);
     // Login as admin (auto-seeded: admin@meepleai.dev / Admin123!)
     await page.goto('/login');
     await page.fill('input[type="email"]', 'admin@meepleai.dev');

--- a/apps/web/e2e/agent-chat.spec.ts
+++ b/apps/web/e2e/agent-chat.spec.ts
@@ -10,8 +10,11 @@
 
 import { test, expect } from '@playwright/test';
 
+import { isBackendReachable, NO_BACKEND_SKIP_REASON } from './_helpers/backendGuard';
+
 test.describe('Agent Chat - User Flow', () => {
   test.beforeEach(async ({ page }) => {
+    test.skip(!(await isBackendReachable(page)), NO_BACKEND_SKIP_REASON);
     // Login
     await page.goto('/login');
     await page.fill('input[name="username"]', 'testuser');
@@ -87,6 +90,7 @@ test.describe('Agent Chat - User Flow', () => {
 
 test.describe('Agent Chat - Admin Flow', () => {
   test.beforeEach(async ({ page }) => {
+    test.skip(!(await isBackendReachable(page)), NO_BACKEND_SKIP_REASON);
     // Login as admin
     await page.goto('/login');
     await page.fill('input[name="username"]', 'admin');

--- a/apps/web/e2e/flows/admin-embedding-flow.spec.ts
+++ b/apps/web/e2e/flows/admin-embedding-flow.spec.ts
@@ -38,6 +38,7 @@ import * as path from 'path';
 
 import { test, expect, BrowserContext, Page } from '@playwright/test';
 
+import { isBackendReachable, NO_BACKEND_SKIP_REASON } from '../_helpers/backendGuard';
 import { checkFlowPrerequisites, formatHealthResults } from '../helpers/flow-health-gate';
 import { env } from '../helpers/onboarding-environment';
 import { QueueDashboardPage } from '../pages/admin/QueueDashboardPage';
@@ -86,6 +87,12 @@ const state: Partial<EmbeddingFlowState> = {};
 test.describe.configure({ mode: 'serial' });
 
 test.describe('Admin Embedding Flow @flow @rag @slow', () => {
+  // Test 1 performs a real UI login via LoginPage — skip the flow without a
+  // reachable backend (complements the beforeAll health gate). See #2784.
+  test.beforeEach(async ({ page }) => {
+    test.skip(!(await isBackendReachable(page)), NO_BACKEND_SKIP_REASON);
+  });
+
   test.beforeAll(async () => {
     const health = await checkFlowPrerequisites(['api', 'frontend', 'embedding']);
     const unhealthy = health.filter(h => !h.healthy);

--- a/apps/web/e2e/rag-strategy-builder.spec.ts
+++ b/apps/web/e2e/rag-strategy-builder.spec.ts
@@ -16,6 +16,8 @@
 
 import { test, expect, type Page, type Locator } from '@playwright/test';
 
+import { isBackendReachable, NO_BACKEND_SKIP_REASON } from './_helpers/backendGuard';
+
 // Test configuration
 const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL || 'http://localhost:3000';
 const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080';
@@ -93,6 +95,9 @@ async function dragBlockToCanvas(
 
 test.describe('RAG Visual Strategy Builder', () => {
   test.beforeEach(async ({ page }) => {
+    // Every test performs a real UI login via loginAsAdmin — skip without a
+    // reachable backend (local E2E bypass has no backend at :8080). See #2784.
+    test.skip(!(await isBackendReachable(page)), NO_BACKEND_SKIP_REASON);
     // Skip login for mock tests, use auth in real E2E
     test.skip(process.env.CI === 'true', 'Requires running backend');
   });
@@ -227,7 +232,9 @@ test.describe('RAG Visual Strategy Builder', () => {
       await dragBlockToCanvas(page, 'cross-encoder-reranking', 400, 200);
 
       // Get output handle of first block and input handle of second
-      const outputHandle = page.locator('[data-testid^="node-"] [data-handletype="source"]').first();
+      const outputHandle = page
+        .locator('[data-testid^="node-"] [data-handletype="source"]')
+        .first();
       const inputHandle = page.locator('[data-testid^="node-"] [data-handletype="target"]').last();
 
       const outputBox = await outputHandle.boundingBox();
@@ -255,7 +262,9 @@ test.describe('RAG Visual Strategy Builder', () => {
       await dragBlockToCanvas(page, 'vector-search', 400, 200);
 
       // Try to connect (hallucination detection can't connect to vector search)
-      const outputHandle = page.locator('[data-testid^="node-"] [data-handletype="source"]').first();
+      const outputHandle = page
+        .locator('[data-testid^="node-"] [data-handletype="source"]')
+        .first();
       const inputHandle = page.locator('[data-testid^="node-"] [data-handletype="target"]').last();
 
       const outputBox = await outputHandle.boundingBox();
@@ -280,7 +289,9 @@ test.describe('RAG Visual Strategy Builder', () => {
       await dragBlockToCanvas(page, 'vector-search', 100, 200);
       await dragBlockToCanvas(page, 'cross-encoder-reranking', 400, 200);
 
-      const outputHandle = page.locator('[data-testid^="node-"] [data-handletype="source"]').first();
+      const outputHandle = page
+        .locator('[data-testid^="node-"] [data-handletype="source"]')
+        .first();
       const outputBox = await outputHandle.boundingBox();
 
       if (outputBox) {
@@ -408,7 +419,9 @@ test.describe('RAG Visual Strategy Builder', () => {
       await dragBlockToCanvas(page, 'confidence-scoring', 400, 200);
 
       // Connect them
-      const outputHandle = page.locator('[data-testid^="node-"] [data-handletype="source"]').first();
+      const outputHandle = page
+        .locator('[data-testid^="node-"] [data-handletype="source"]')
+        .first();
       const inputHandle = page.locator('[data-testid^="node-"] [data-handletype="target"]').last();
 
       const outputBox = await outputHandle.boundingBox();
@@ -541,7 +554,9 @@ test.describe('RAG Visual Strategy Builder', () => {
       await dragBlockToCanvas(page, 'confidence-scoring', 400, 200);
 
       // Connect them
-      const outputHandle = page.locator('[data-testid^="node-"] [data-handletype="source"]').first();
+      const outputHandle = page
+        .locator('[data-testid^="node-"] [data-handletype="source"]')
+        .first();
       const inputHandle = page.locator('[data-testid^="node-"] [data-handletype="target"]').last();
 
       const outputBox = await outputHandle.boundingBox();
@@ -621,7 +636,9 @@ test.describe('RAG Visual Strategy Builder', () => {
       await dragBlockToCanvas(page, 'confidence-scoring', 400, 200);
 
       // Connect
-      const outputHandle = page.locator('[data-testid^="node-"] [data-handletype="source"]').first();
+      const outputHandle = page
+        .locator('[data-testid^="node-"] [data-handletype="source"]')
+        .first();
       const inputHandle = page.locator('[data-testid^="node-"] [data-handletype="target"]').last();
 
       const outputBox = await outputHandle.boundingBox();


### PR DESCRIPTION
Closes #2784

Completa #2784. I mock-based erano fixati col cookie-seed (PR #2841). I restanti **~18 spec REAL_UI_LOGIN** (compilano `/login` + submit contro l'API) hard-failano in locale sotto il bypass per **assenza di backend** — dipendenza pre-esistente, non la regressione v1-sunset.

## Modifiche (19 file)
- Nuovo helper `e2e/_helpers/backendGuard.ts`: `isBackendReachable(page)` (probe `/health/live`, timeout 3s, non lancia) + `NO_BACKEND_SKIP_REASON`.
- Ogni spec real-login: `test.skip(!(await isBackendReachable(page)), NO_BACKEND_SKIP_REASON)` all'inizio del beforeEach di login → **skip in locale** (no backend), **run in CI** (backend reale).

Applicato da subagent paralleli su cluster disgiunti, con cautela: guardati SOLO i test con login reale. **Preservati** i test pubblici (`/library`), il redirect intenzionale unauthenticated→`/login` + i 401, e i describe mocked. `tsc --noEmit` pulito, eslint pulito.

## Risultato
Nessun admin E2E spec hard-fa più in locale: **mock-based passano** (ruolo seedato), **real-login skippano gracefully**. Con PR #2821 (proxy-fix) + #2841 (38 mock-based) + questo (18 real-login), la mappatura 117-spec è coperta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)