### PR TITLE
fix(editor): grant superadmin access to editor + agent-proposals (#2845 #GG)

### DIFF
--- a/apps/web/src/__tests__/lib/utils/roles.test.ts
+++ b/apps/web/src/__tests__/lib/utils/roles.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { isAdminRole } from '@/lib/utils/roles';
+import { canUseEditor, isAdminRole } from '@/lib/utils/roles';
 
 describe('isAdminRole', () => {
   it('returns true for "Admin"', () => {
@@ -37,5 +37,55 @@ describe('isAdminRole', () => {
 
   it('returns false for empty string', () => {
     expect(isAdminRole('')).toBe(false);
+  });
+});
+
+describe('canUseEditor', () => {
+  // Issue #2845 / finding #GG: the RuleSpec editor + agent-proposals guards
+  // used a flat, case-sensitive compare (role !== 'Admin' && role !== 'Editor').
+  // The backend normalizes roles to lowercase, so 'superadmin' AND 'admin' were
+  // both denied. canUseEditor must be case-insensitive and grant superadmin.
+  it('returns true for "superadmin" (was the reported bug)', () => {
+    expect(canUseEditor('superadmin')).toBe(true);
+  });
+
+  it('returns true for "SuperAdmin" (mixed case)', () => {
+    expect(canUseEditor('SuperAdmin')).toBe(true);
+  });
+
+  it('returns true for "admin" (lowercase from backend)', () => {
+    expect(canUseEditor('admin')).toBe(true);
+  });
+
+  it('returns true for "Admin" (PascalCase)', () => {
+    expect(canUseEditor('Admin')).toBe(true);
+  });
+
+  it('returns true for "editor"', () => {
+    expect(canUseEditor('editor')).toBe(true);
+  });
+
+  it('returns true for "Editor" (PascalCase)', () => {
+    expect(canUseEditor('Editor')).toBe(true);
+  });
+
+  it('returns false for "user"', () => {
+    expect(canUseEditor('user')).toBe(false);
+  });
+
+  it('returns false for "creator" (not an editor role)', () => {
+    expect(canUseEditor('creator')).toBe(false);
+  });
+
+  it('returns false for null', () => {
+    expect(canUseEditor(null)).toBe(false);
+  });
+
+  it('returns false for undefined', () => {
+    expect(canUseEditor(undefined)).toBe(false);
+  });
+
+  it('returns false for empty string', () => {
+    expect(canUseEditor('')).toBe(false);
   });
 });

--- a/apps/web/src/app/(authenticated)/editor/agent-proposals/[id]/test/page.tsx
+++ b/apps/web/src/app/(authenticated)/editor/agent-proposals/[id]/test/page.tsx
@@ -33,6 +33,7 @@ import { Button } from '@/components/ui/primitives/button';
 import { Input } from '@/components/ui/primitives/input';
 import { ScrollArea } from '@/components/ui/primitives/scroll-area';
 import { agentTypologiesApi } from '@/lib/api/agent-typologies.api';
+import { canUseEditor } from '@/lib/utils/roles';
 
 interface TestMessage {
   id: string;
@@ -59,7 +60,7 @@ function EditorAuthGuard({
     return <HubPageContainer className="p-6">Loading...</HubPageContainer>;
   }
 
-  if (!user || (user.role !== 'Editor' && user.role !== 'Admin')) {
+  if (!user || !canUseEditor(user.role)) {
     return (
       <HubPageContainer className="p-6">
         <div className="text-center p-12">

--- a/apps/web/src/app/(authenticated)/editor/agent-proposals/client.tsx
+++ b/apps/web/src/app/(authenticated)/editor/agent-proposals/client.tsx
@@ -18,6 +18,7 @@ import { useRouter } from 'next/navigation';
 import { useAuth } from '@/components/auth/AuthProvider';
 import { HubPageContainer } from '@/components/layout/PageContainer';
 import { Button } from '@/components/ui/primitives/button';
+import { canUseEditor } from '@/lib/utils/roles';
 
 import { ProposalsList } from './_components/ProposalsList';
 
@@ -39,7 +40,7 @@ function EditorAuthGuard({
     return <HubPageContainer className="p-6">Loading...</HubPageContainer>;
   }
 
-  if (!user || (user.role !== 'Editor' && user.role !== 'Admin')) {
+  if (!user || !canUseEditor(user.role)) {
     return (
       <HubPageContainer className="p-6">
         <div className="text-center p-12">

--- a/apps/web/src/app/(authenticated)/editor/editor-client.tsx
+++ b/apps/web/src/app/(authenticated)/editor/editor-client.tsx
@@ -42,6 +42,7 @@ import { logger } from '@/lib/logger';
 import { sanitizeHtml } from '@/lib/security/sanitize';
 import { cn } from '@/lib/utils';
 import { getErrorMessage } from '@/lib/utils/errorHandler';
+import { canUseEditor } from '@/lib/utils/roles';
 import {
   useRuleSpecLockStore,
   selectHasLock,
@@ -486,8 +487,10 @@ export function EditorClient() {
     );
   }
 
-  // RequireRole already checked permissions, this is redundant but kept for safety
-  if (user && user.role !== 'Admin' && user.role !== 'Editor') {
+  // RequireRole already checked permissions, this is redundant but kept for safety.
+  // Issue #2845/#GG: use the case-insensitive, superadmin-aware helper — a flat
+  // `role !== 'Admin'` compare denied the lowercase roles the backend emits.
+  if (user && !canUseEditor(user.role)) {
     return (
       <main className="p-6 font-sans">
         <h1>Editor RuleSpec</h1>

--- a/apps/web/src/lib/utils/roles.ts
+++ b/apps/web/src/lib/utils/roles.ts
@@ -51,3 +51,18 @@ export function isAdminRole(role: string | null | undefined): boolean {
   const normalized = normalizeRole(role);
   return normalized === 'admin' || normalized === 'superadmin';
 }
+
+/**
+ * Check if a role may use the RuleSpec editor / agent-proposals surfaces
+ * (case-insensitive, superadmin-aware).
+ *
+ * Issue #2845 / finding #GG: the editor guards used a flat, case-sensitive
+ * compare (`role !== 'Admin' && role !== 'Editor'`) which denied both the
+ * lowercase `superadmin` and `admin` roles the backend actually emits.
+ * Grants: superadmin ≥ admin ≥ editor. Denies user/creator.
+ */
+export function canUseEditor(role: string | null | undefined): boolean {
+  if (!role) return false;
+  const normalized = normalizeRole(role);
+  return normalized === 'superadmin' || normalized === 'admin' || normalized === 'editor';
+}


### PR DESCRIPTION
## Finding #GG (part of #2845)

The RuleSpec editor (`/editor`) and both agent-proposals guards denied any user
whose role wasn't the exact PascalCase literal `'Admin'` or `'Editor'`. The
backend normalizes roles to **lowercase** (`Role.cs` `ToLowerInvariant`), so a
`superadmin` — and even a plain `admin` — failed the flat, case-sensitive
compare and hit *"Non hai i permessi necessari"* / *"Access Denied"*.

`RequireRole` already handled the hierarchy correctly (case-insensitive +
superadmin-aware); only these three inline guards were stale.

## Fix

- Add centralized `canUseEditor(role)` to `lib/utils/roles.ts` — case-insensitive,
  superadmin ≥ admin ≥ editor, denies user/creator.
- Wire the three guards to it:
  - `editor/editor-client.tsx`
  - `editor/agent-proposals/client.tsx`
  - `editor/agent-proposals/[id]/test/page.tsx`

## Tests

- `roles.test.ts`: 11 new cases covering superadmin/admin/editor grant + user/
  creator/empty/null deny across casings (red → green).
- `pnpm typecheck` clean, lint clean.

## Verification

- Unit-tested pure guard logic (the fix is a 1-line delegation per guard).
- Browser E2E (superadmin opens `/editor` and sees the editor, not the denial)
  pending the consolidated container-rebuild verification sweep — the running
  web container is a prod standalone build, so this change needs a rebuild to
  be exercised live. Re-runs happy-path scenario U4-14.

Part of #2845 (finding #GG). Does not close the umbrella — #FF and #HH follow.
