### PR TITLE
refactor(agent): scope agent-*.css to the agent feature (#2852)

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -22,10 +22,12 @@ import type { Metadata, Viewport } from 'next';
 import '../styles/design-tokens-canonical.css';
 import '../styles/globals.css';
 import '../styles/diff-viewer.css';
-import '../styles/agent-theme.css';
-import '../styles/agent-typography.css';
-import '../styles/agent-animations.css';
 import 'prismjs/themes/prism-tomorrow.css';
+// Agent neon-brutalist styles (agent-theme/typography/animations) are NOT loaded
+// globally — they are scoped to the agent feature via
+// `@/components/agent/agent-theme-styles`, imported by the agent components that
+// consume `--agent-*` (issue #2852). This keeps ~450 LOC + a Google Fonts
+// @import off every non-agent page.
 
 const quicksand = Quicksand({
   subsets: ['latin'],

--- a/apps/web/src/components/agent/agent-theme-styles.ts
+++ b/apps/web/src/components/agent/agent-theme-styles.ts
@@ -1,0 +1,14 @@
+/**
+ * Domain-scoped agent styling (neon-brutalist, issue #3237).
+ *
+ * Imported by the agent feature components rather than the global root layout so
+ * the ~450 LOC of `--agent-*` tokens/classes plus a Google Fonts `@import` don't
+ * ship in every page's CSS bundle (issue #2852). Consumers: AgentConfigSheet,
+ * TemplateCarousel, TokenQuotaDisplay, LockedSlotCard.
+ *
+ * Load order matters: theme (custom properties) must precede typography and
+ * animations, which consume `--agent-*` values.
+ */
+import '@/styles/agent-theme.css';
+import '@/styles/agent-typography.css';
+import '@/styles/agent-animations.css';

--- a/apps/web/src/components/agent/config/AgentConfigSheet.tsx
+++ b/apps/web/src/components/agent/config/AgentConfigSheet.tsx
@@ -14,6 +14,8 @@
 
 'use client';
 
+import '@/components/agent/agent-theme-styles';
+
 import { useState } from 'react';
 
 import { ArrowLeft, HelpCircle } from 'lucide-react';
@@ -44,12 +46,7 @@ interface AgentConfigSheetProps {
 
 type ViewState = 'config' | 'template-info' | 'model-pricing';
 
-export function AgentConfigSheet({
-  isOpen,
-  onClose,
-  gameId,
-  gameTitle,
-}: AgentConfigSheetProps) {
+export function AgentConfigSheet({ isOpen, onClose, gameId, gameTitle }: AgentConfigSheetProps) {
   const [view, setView] = useState<ViewState>('config');
 
   const isLaunching = false;
@@ -91,12 +88,7 @@ export function AgentConfigSheet({
                 {view === 'model-pricing' && 'Model Pricing'}
               </SheetTitle>
             </div>
-            <Button
-              variant="ghost"
-              size="icon"
-              className="h-8 w-8"
-              aria-label="Help"
-            >
+            <Button variant="ghost" size="icon" className="h-8 w-8" aria-label="Help">
               <HelpCircle className="h-4 w-4 text-muted-foreground" />
             </Button>
           </div>

--- a/apps/web/src/components/agent/config/TemplateCarousel.tsx
+++ b/apps/web/src/components/agent/config/TemplateCarousel.tsx
@@ -6,6 +6,8 @@
 
 'use client';
 
+import '@/components/agent/agent-theme-styles';
+
 import { useState } from 'react';
 
 import { Info } from 'lucide-react';

--- a/apps/web/src/components/agent/config/TokenQuotaDisplay.tsx
+++ b/apps/web/src/components/agent/config/TokenQuotaDisplay.tsx
@@ -9,6 +9,8 @@
 
 'use client';
 
+import '@/components/agent/agent-theme-styles';
+
 import { AlertTriangle } from 'lucide-react';
 
 import { useSessionQuota } from '@/hooks/queries/useSessionQuota';

--- a/apps/web/src/components/agent/slots/LockedSlotCard.tsx
+++ b/apps/web/src/components/agent/slots/LockedSlotCard.tsx
@@ -12,6 +12,8 @@
 
 'use client';
 
+import '@/components/agent/agent-theme-styles';
+
 import { useState } from 'react';
 
 import { Lock, Sparkles, Zap, Clock, Headphones, X } from 'lucide-react';


### PR DESCRIPTION
Part of #2863 (Phase A1).

Moves `agent-theme.css`/`agent-typography.css`/`agent-animations.css` out of the global root layout (`app/layout.tsx`) into a shared module `@/components/agent/agent-theme-styles`, imported by the 4 components that consume `--agent-*` / `.agent-*`: `AgentConfigSheet`, `LockedSlotCard`, `TokenQuotaDisplay`, `TemplateCarousel` (grep-exhaustive consumer set).

Keeps ~450 LOC of neon-brutalist tokens/classes + a Google Fonts `@import` off every non-agent page's CSS bundle.

**Verified**: `pnpm build` green (all routes compile), 266 agent-component tests pass, typecheck clean.

Closes #2852.

🤖 Generated with [Claude Code](https://claude.com/claude-code)