### PR TITLE
test(ui-library): guard COMPONENT_MAP <-> registry coherence (#2853)

### DIFF
--- a/apps/web/src/components/admin/ui-library/__tests__/component-map.registry-coherence.test.ts
+++ b/apps/web/src/components/admin/ui-library/__tests__/component-map.registry-coherence.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+
+import { COMPONENT_REGISTRY } from '@/config/component-registry';
+
+import { COMPONENT_MAP } from '../component-map';
+
+/**
+ * Guards coherence between the UI-library showcase's two paired structures:
+ * `COMPONENT_REGISTRY` (the catalog metadata) and `COMPONENT_MAP` (id → real
+ * React component used by StaticRenderer/ComponentDetail).
+ *
+ * Every `COMPONENT_MAP` key MUST correspond to a live registry entry id;
+ * otherwise the map holds a renderer for an id the catalog no longer lists —
+ * dead code that can silently drift (see audit
+ * docs/for-developers/audits/2026-07-12-meeplecard-css-drift-audit.md, issue #2853,
+ * follow-up of the 49-entry registry cleanup in #2843).
+ */
+describe('COMPONENT_MAP ↔ COMPONENT_REGISTRY coherence', () => {
+  it('every COMPONENT_MAP key maps to an existing registry entry id', () => {
+    const registryIds = new Set(COMPONENT_REGISTRY.map(e => e.id));
+    const orphanKeys = Object.keys(COMPONENT_MAP).filter(key => !registryIds.has(key));
+    expect(orphanKeys).toEqual([]);
+  });
+
+  it('detects an orphan key (negative control)', () => {
+    const registryIds = new Set(['meeple-card', 'badge']);
+    const fakeMap = { 'meeple-card': 0, 'ghost-key': 0 };
+    const orphanKeys = Object.keys(fakeMap).filter(key => !registryIds.has(key));
+    expect(orphanKeys).toEqual(['ghost-key']);
+  });
+});


### PR DESCRIPTION
Part of #2863 (Phase A2).

Adds a regression guard asserting every `COMPONENT_MAP` key maps to a live `COMPONENT_REGISTRY` id (plus a negative control that proves the check bites).

After #2843 removed 49 registry entries, there are **0 orphan map keys**, so no `component-map.ts` edit was needed — this test simply locks in that invariant so a renderer can't outlive its catalog entry.

Closes #2853.

🤖 Generated with [Claude Code](https://claude.com/claude-code)