### PR TITLE
fix(di): #2865 resolve ProviderHealthCheckService w/o hosted lookup

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/DependencyInjection/KnowledgeBaseServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/DependencyInjection/KnowledgeBaseServiceExtensions.cs
@@ -241,11 +241,14 @@ internal static class KnowledgeBaseServiceExtensions
         services.AddScoped<HybridLlmService>(sp => (HybridLlmService)sp.GetRequiredService<ILlmService>());
 
         // ISSUE-962 (BGAI-020): Provider Health Check Service (Singleton - background service)
-        services.AddHostedService<ProviderHealthCheckService>();
-        services.AddSingleton<IProviderHealthCheckService>(sp =>
-            sp.GetServices<IHostedService>().OfType<ProviderHealthCheckService>().ToList()[0]);
-        services.AddSingleton<ProviderHealthCheckService>(sp =>
-            (ProviderHealthCheckService)sp.GetRequiredService<IProviderHealthCheckService>());
+        // #2865: register the concrete singleton FIRST, then have both the hosted-service role and
+        // the injectable IProviderHealthCheckService role resolve that same instance directly. The
+        // previous registration looked the instance up via the IHostedService collection and took
+        // [0], which threw ArgumentOutOfRangeException wherever hosted services are stripped (the
+        // integration test factory does exactly this to prevent background-service startup).
+        services.AddSingleton<ProviderHealthCheckService>();
+        services.AddHostedService(sp => sp.GetRequiredService<ProviderHealthCheckService>());
+        services.AddSingleton<IProviderHealthCheckService>(sp => sp.GetRequiredService<ProviderHealthCheckService>());
 
         // ISSUE-1725: LLM budget monitoring background service
         services.AddHostedService<LlmBudgetMonitoringService>();

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Infrastructure/ProviderHealthServiceResolutionTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Infrastructure/ProviderHealthServiceResolutionTests.cs
@@ -1,0 +1,67 @@
+using Api.BoundedContexts.KnowledgeBase.Application.Services;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.KnowledgeBase.Infrastructure;
+
+/// <summary>
+/// Regression guard for #2865: <see cref="IProviderHealthCheckService"/> must resolve from the
+/// integration DI container without depending on <c>ProviderHealthCheckService</c> being present
+/// in the <c>IHostedService</c> collection.
+///
+/// <para>
+/// The integration factory strips ALL <c>IHostedService</c> registrations
+/// (<see cref="IntegrationWebApplicationFactory"/>, "prevents background service startup failures").
+/// The previous registration resolved the singleton via
+/// <c>GetServices&lt;IHostedService&gt;().OfType&lt;ProviderHealthCheckService&gt;().ToList()[0]</c>,
+/// so under the stripped container that list was empty and <c>[0]</c> threw
+/// <see cref="ArgumentOutOfRangeException"/> — which the API exception middleware mapped to HTTP 400.
+/// Any integration test that resolves <c>ILlmService</c> (→ HybridLlmService → provider health)
+/// tripped this, e.g. <c>ExtractMetadata_WithValidFilePath_Returns200Ok</c>.
+/// </para>
+/// </summary>
+[Collection("Integration-GroupA")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "KnowledgeBase")]
+[Trait("Issue", "2865")]
+public sealed class ProviderHealthServiceResolutionTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly string _testDbName;
+    private WebApplicationFactory<Program> _factory = null!;
+
+    public ProviderHealthServiceResolutionTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+        _testDbName = $"provider_health_di_{Guid.NewGuid():N}";
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        // A valid connection string is enough — pure DI resolution does not touch the schema.
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_testDbName);
+        _factory = IntegrationWebApplicationFactory.Create(connectionString);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _factory?.Dispose();
+        await _fixture.DropIsolatedDatabaseAsync(_testDbName);
+    }
+
+    [Fact]
+    public void IProviderHealthCheckService_ResolvesUnderStrippedHostedServices_WithoutThrowing()
+    {
+        using var scope = _factory.Services.CreateScope();
+
+        var act = () => scope.ServiceProvider.GetRequiredService<IProviderHealthCheckService>();
+
+        act.Should().NotThrow(
+            "the injectable IProviderHealthCheckService must not depend on the IHostedService " +
+            "collection being populated (the integration factory strips hosted services) — #2865");
+    }
+}


### PR DESCRIPTION
Closes #2865

## Problema

`IProviderHealthCheckService` era registrato risolvendo l'istanza **dalla collection `IHostedService`** e prendendo `[0]`:

```csharp
services.AddHostedService<ProviderHealthCheckService>();
services.AddSingleton<IProviderHealthCheckService>(sp =>
    sp.GetServices<IHostedService>().OfType<ProviderHealthCheckService>().ToList()[0]);
```

`IntegrationWebApplicationFactory` rimuove **tutti** gli `IHostedService` (per evitare l'avvio dei background service nei test). In test quella lista è vuota → `[0]` lancia `ArgumentOutOfRangeException`, che il middleware mappa a **HTTP 400 `Invalid request parameters`**. Colpisce ogni integration test che risolve `ILlmService` (→ `HybridLlmService` → provider health), es. `ExtractMetadata_WithValidFilePath_Returns200Ok`.

Non è una regressione recente: `KnowledgeBaseServiceExtensions.cs` ultima modifica PR #2603 (2026-06-30); lo stripping hosted-service è infra di lunga data.

## Fix

Registra la singleton concreta per prima, poi fa risolvere **direttamente quella stessa istanza** sia al ruolo hosted-service sia a quello iniettabile — **lo stesso pattern già usato per `OpenRouterUsageService` (#5074)** in questo file (introdotto proprio per evitare `GetServices<IHostedService>()`). Stessa istanza condivisa in prod; sopravvive allo stripping nei test.

```csharp
services.AddSingleton<ProviderHealthCheckService>();
services.AddHostedService(sp => sp.GetRequiredService<ProviderHealthCheckService>());
services.AddSingleton<IProviderHealthCheckService>(sp => sp.GetRequiredService<ProviderHealthCheckService>());
```

## Test (TDD)
- **Nuovo** `ProviderHealthServiceResolutionTests` — risolve `IProviderHealthCheckService` dal container di integrazione (hosted-service stripped) e asserisce no-throw. RED con `ArgumentOutOfRangeException` prima del fix, GREEN dopo.
- `ExtractMetadata_WithValidFilePath_Returns200Ok` (victim end-to-end): ✅
- Provider-health esistenti (`ProviderHealthCheckServiceTests` / `GetLlmHealthQueryHandlerTests` / `LlmHealthIntegrationTests`): 18/18 ✅
- Classe wizard completa `AdminGameImportWizardEndpointsIntegrationTests`: 15/15 ✅ (era 14/15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)