### PR TITLE
fix(notifications): persist preferences update (commit unit of work) (#2849)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Commands/UpdateNotificationPreferencesCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Commands/UpdateNotificationPreferencesCommandHandler.cs
@@ -2,22 +2,26 @@ using Api.BoundedContexts.UserNotifications.Application.Commands;
 using Api.BoundedContexts.UserNotifications.Domain.Aggregates;
 using Api.BoundedContexts.UserNotifications.Domain.Repositories;
 using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Infrastructure.Persistence;
 
 namespace Api.BoundedContexts.UserNotifications.Application.Commands;
 
 internal class UpdateNotificationPreferencesCommandHandler : ICommandHandler<UpdateNotificationPreferencesCommand>
 {
     private readonly INotificationPreferencesRepository _repository;
+    private readonly IUnitOfWork _unitOfWork;
 
-    public UpdateNotificationPreferencesCommandHandler(INotificationPreferencesRepository repository)
+    public UpdateNotificationPreferencesCommandHandler(
+        INotificationPreferencesRepository repository, IUnitOfWork unitOfWork)
     {
         _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
     }
 
     public async Task Handle(UpdateNotificationPreferencesCommand command, CancellationToken cancellationToken)
     {
-        var prefs = await _repository.GetByUserIdAsync(command.UserId, cancellationToken).ConfigureAwait(false)
-            ?? new NotificationPreferences(command.UserId);
+        var existing = await _repository.GetByUserIdAsync(command.UserId, cancellationToken).ConfigureAwait(false);
+        var prefs = existing ?? new NotificationPreferences(command.UserId);
 
         prefs.UpdateAllPreferences(
             command.EmailOnDocumentReady, command.EmailOnDocumentFailed, command.EmailOnRetryAvailable,
@@ -25,9 +29,14 @@ internal class UpdateNotificationPreferencesCommandHandler : ICommandHandler<Upd
             command.InAppOnDocumentReady, command.InAppOnDocumentFailed, command.InAppOnRetryAvailable
         );
 
-        if (await _repository.GetByUserIdAsync(command.UserId, cancellationToken).ConfigureAwait(false) == null)
+        if (existing is null)
             await _repository.AddAsync(prefs, cancellationToken).ConfigureAwait(false);
         else
             await _repository.UpdateAsync(prefs, cancellationToken).ConfigureAwait(false);
+
+        // Issue #2849 / ADR-060: the repository Add/Update only stages the change;
+        // the mutating handler must commit its own unit of work. Without this the
+        // PUT returned 204 but nothing persisted (GET kept returning the old value).
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/UserNotifications/Infrastructure/UpdateNotificationPreferencesHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/UserNotifications/Infrastructure/UpdateNotificationPreferencesHandlerTests.cs
@@ -1,0 +1,125 @@
+using Api.BoundedContexts.UserNotifications.Application.Commands;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.UserNotifications;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using MediatR;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.UserNotifications.Infrastructure;
+
+/// <summary>
+/// Issue #2849 / finding #T: <c>PUT /api/v1/notifications/preferences</c> returned 204 but did
+/// not persist — the command handler staged the repository Add/Update but never committed the
+/// unit of work (ADR-060). These tests drive the command through MediatR (full pipeline) and then
+/// re-read the row in a fresh scope to assert persistence.
+/// </summary>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "UserNotifications")]
+public sealed class UpdateNotificationPreferencesHandlerTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly string _testDbName;
+    private WebApplicationFactory<Program> _factory = null!;
+    private Guid _userId;
+
+    public UpdateNotificationPreferencesHandlerTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+        _testDbName = $"t2849_notifpref_{Guid.NewGuid():N}";
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        var conn = await _fixture.CreateIsolatedDatabaseAsync(_testDbName);
+        _factory = IntegrationWebApplicationFactory.Create(conn);
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        await db.Database.MigrateAsync();
+        (_userId, _) = await TestSessionHelper.CreateUserSessionAsync(db, Guid.NewGuid());
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_factory is not null)
+        {
+            await _factory.DisposeAsync();
+        }
+        await _fixture.DropIsolatedDatabaseAsync(_testDbName);
+    }
+
+    private static UpdateNotificationPreferencesCommand BuildCommand(Guid userId, bool emailOnDocumentReady) =>
+        new(
+            UserId: userId,
+            EmailOnDocumentReady: emailOnDocumentReady,
+            EmailOnDocumentFailed: true,
+            EmailOnRetryAvailable: true,
+            PushOnDocumentReady: true,
+            PushOnDocumentFailed: true,
+            PushOnRetryAvailable: true,
+            InAppOnDocumentReady: true,
+            InAppOnDocumentFailed: true,
+            InAppOnRetryAvailable: true);
+
+    [Fact]
+    public async Task Command_CreatesAndPersistsPrefs_WhenMissing()
+    {
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+            await mediator.Send(BuildCommand(_userId, emailOnDocumentReady: false));
+        }
+
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            var row = await db.Set<NotificationPreferencesEntity>()
+                .AsNoTracking()
+                .SingleOrDefaultAsync(p => p.UserId == _userId);
+
+            row.Should().NotBeNull("the PUT must persist a preferences row");
+            row!.EmailOnDocumentReady.Should().BeFalse();
+        }
+    }
+
+    [Fact]
+    public async Task Command_UpdatesAndPersistsExistingPrefs()
+    {
+        // Seed an existing prefs row with EmailOnDocumentReady = true (the finding's starting state).
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            db.Set<NotificationPreferencesEntity>().Add(new NotificationPreferencesEntity
+            {
+                Id = Guid.NewGuid(),
+                UserId = _userId,
+                EmailOnDocumentReady = true,
+                TimeZone = "UTC",
+            });
+            await db.SaveChangesAsync();
+        }
+
+        // Toggle EmailOnDocumentReady true -> false via the command.
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+            await mediator.Send(BuildCommand(_userId, emailOnDocumentReady: false));
+        }
+
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            var row = await db.Set<NotificationPreferencesEntity>()
+                .AsNoTracking()
+                .SingleAsync(p => p.UserId == _userId);
+
+            row.EmailOnDocumentReady.Should().BeFalse("the PUT must persist the toggled value");
+        }
+    }
+}


### PR DESCRIPTION
## Finding #T (Closes #2849)

`PUT /api/v1/notifications/preferences` returned **204** but did not persist —
a subsequent GET (even after reload) kept returning the original value.

**Root cause:** `UpdateNotificationPreferencesCommandHandler` staged the
repository Add/Update (`DbSet.Add`/`Update` only) but **never committed the
unit of work**. Per ADR-060, mutating command handlers must call
`IUnitOfWork.SaveChangesAsync` themselves — the sibling
`UpdateCardSuppressionEmailPreferenceCommandHandler` already does; this one
didn't even inject `IUnitOfWork`.

## Fix

- Inject `IUnitOfWork` and `SaveChangesAsync` after Add/Update.
- Drop the redundant second `GetByUserIdAsync` round-trip (capture `existing` once).

## Tests

New Testcontainers integration test drives the command through MediatR (full
pipeline + DI) then re-reads the row in a fresh scope:
- create-when-missing → row persisted
- update-existing (`true → false`, the exact finding) → toggled value persisted

Both **red** pre-fix (row null / value unchanged), **green** post-fix. Verified
locally against Testcontainers Postgres.

## Verification status

- ✅ Testcontainers integration test red → green (real Postgres, full MediatR/DI pipeline).
- ⏳ Browser E2E (toggle a preference, save, reload → value sticks) — pending the
  consolidated verify-then-merge sweep. Re-runs happy-path scenario U8-09.

Closes #2849.
