### PR TITLE
refactor(design-tokens): align entity accent tokens to AA values + golden test (#2855)

### DIFF
--- a/admin-mockups/design_files/tokens.css
+++ b/admin-mockups/design_files/tokens.css
@@ -4,15 +4,15 @@
 
 :root {
   /* ─── Entity Colors (HSL triplets for alpha composability) ─── */
-  --c-game:    25 95% 45%;
-  --c-player:  262 83% 58%;
-  --c-session: 240 60% 55%;
-  --c-agent:   38 92% 50%;
-  --c-kb:      174 60% 40%;
-  --c-chat:    220 80% 55%;
-  --c-event:   350 89% 60%;
-  --c-toolkit: 142 70% 45%;
-  --c-tool:    195 80% 50%;
+  --c-game:    25 95% 38%;
+  --c-player:  262 83% 45%;
+  --c-session: 240 60% 35%;
+  --c-agent:   38 92% 32%;
+  --c-kb:      174 60% 30%;
+  --c-chat:    220 80% 40%;
+  --c-event:   350 89% 38%;
+  --c-toolkit: 142 70% 30%;
+  --c-tool:    195 80% 32%;
 
   /* ─── Semantic Colors ─── */
   --c-success: 142 70% 45%;

--- a/apps/web/src/__tests__/styles/entity-token-golden.test.ts
+++ b/apps/web/src/__tests__/styles/entity-token-golden.test.ts
@@ -1,0 +1,55 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, it, expect } from 'vitest';
+
+/**
+ * Golden token test (issue #2855, follow-up of audit
+ * docs/for-developers/audits/2026-07-12-meeplecard-css-drift-audit.md).
+ *
+ * The design tokens have a single source of truth: the mockup
+ * `admin-mockups/design_files/tokens.css` is mirrored by the app's
+ * `design-tokens-canonical.css`. This test asserts every entity accent token
+ * `--c-{entity}` (all light + dark declarations, in order) is identical between
+ * the two files, so the app cannot silently drift from the mockup.
+ *
+ * The canonical (and mockup) light values were aligned to the AA-safe #807 gate
+ * values that already win at runtime via globals.css import-order — chosen over
+ * the original vivid mockup values to avoid an AA migration of 68 text sites
+ * (see the audit + issue #2855 decision).
+ */
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const CANONICAL = path.resolve(HERE, '../../styles/design-tokens-canonical.css');
+const MOCKUP = path.resolve(HERE, '../../../../../admin-mockups/design_files/tokens.css');
+
+const ENTITIES = [
+  'game',
+  'player',
+  'session',
+  'agent',
+  'kb',
+  'chat',
+  'event',
+  'toolkit',
+  'tool',
+] as const;
+
+function extractEntityTokens(css: string, entity: string): string[] {
+  // Matches `--c-game: ...;` but NOT `--c-game-text: ...;` (the ':' must follow the entity name).
+  const re = new RegExp('--c-' + entity + ':\\s*([^;]+);', 'g');
+  return [...css.matchAll(re)].map(m => m[1].trim());
+}
+
+describe('entity token golden — canonical mirrors the mockup', () => {
+  const canonicalCss = fs.readFileSync(CANONICAL, 'utf8');
+  const mockupCss = fs.readFileSync(MOCKUP, 'utf8');
+
+  it.each(ENTITIES)('--c-%s values are identical in canonical and mockup', entity => {
+    const canonical = extractEntityTokens(canonicalCss, entity);
+    const mockup = extractEntityTokens(mockupCss, entity);
+    expect(canonical.length).toBeGreaterThan(0);
+    expect(canonical).toEqual(mockup);
+  });
+});

--- a/apps/web/src/styles/design-tokens-canonical.css
+++ b/apps/web/src/styles/design-tokens-canonical.css
@@ -19,15 +19,15 @@
 
 :root {
   /* ─── Entity Colors (HSL triplets for alpha composability) ─── */
-  --c-game:    25 95% 45%;
-  --c-player:  262 83% 58%;
-  --c-session: 240 60% 55%;
-  --c-agent:   38 92% 50%;
-  --c-kb:      174 60% 40%;
-  --c-chat:    220 80% 55%;
-  --c-event:   350 89% 60%;
-  --c-toolkit: 142 70% 45%;
-  --c-tool:    195 80% 50%;
+  --c-game:    25 95% 38%;
+  --c-player:  262 83% 45%;
+  --c-session: 240 60% 35%;
+  --c-agent:   38 92% 32%;
+  --c-kb:      174 60% 30%;
+  --c-chat:    220 80% 40%;
+  --c-event:   350 89% 38%;
+  --c-toolkit: 142 70% 30%;
+  --c-tool:    195 80% 32%;
 
   /* ─── Entity Color TEXT variants (darker — for AA 4.5:1 text contrast) ─── *
    * Entity colors above are sized for non-text usage (borders, backgrounds,


### PR DESCRIPTION
Part of #2863 (Phase B1).

Resolves the `--c-{entity}` accent divergence surfaced by the audit: `design-tokens-canonical.css` + `admin-mockups/design_files/tokens.css` had the vivid mockup light values (e.g. game L=45%), while `globals.css` overrode them with the AA-safe #807 values (L=38%) that **already win at runtime** via CSS import-order.

**Decision (user)**: align to **38% (AA-safe)** rather than restore 45% mockup-fidelity — the latter would require migrating **68 `text-[--c-entity]` sites in 32 files** to `--c-*-text` (a11y-blocking gate). Documented in the audit + issue #2855.

Changes:
- 9 light `--c-{entity}` values in canonical + mockup aligned to the globals/#807 values (dark already coincided).
- New **golden test** asserting canonical mirrors the mockup for every entity token.

**Zero runtime rendering change** — globals already won at these values.

Closes #2855.

🤖 Generated with [Claude Code](https://claude.com/claude-code)