### PR TITLE
fix(web): keep public share routes reachable by guests (#2846, supersedes #2812)

### DIFF
--- a/apps/web/src/lib/routing/__tests__/protected-routes.test.ts
+++ b/apps/web/src/lib/routing/__tests__/protected-routes.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+
+import { isAdminPath, isProtectedPath } from '../protected-routes';
+
+describe('isProtectedPath (Issue #2846)', () => {
+  describe('public share routes under a protected prefix stay public', () => {
+    // Pre-fix these matched `startsWith('/library')` / `startsWith('/game-nights')`
+    // / `startsWith('/play-records')` and were redirected to /login.
+    it.each([
+      '/library/shared/abc123token', // #DD
+      '/game-nights/shared/nighttoken',
+      '/play-records/shared/recaptoken',
+    ])('%s is NOT protected', pathname => {
+      expect(isProtectedPath(pathname)).toBe(false);
+    });
+  });
+
+  describe('sibling public landing is not swallowed by boundary matching', () => {
+    it('/library-public is NOT protected (#G)', () => {
+      expect(isProtectedPath('/library-public')).toBe(false);
+    });
+  });
+
+  describe('public catalog detail is a separate top-level route', () => {
+    it.each(['/shared-games', '/shared-games/some-game-id'])('%s is NOT protected', pathname => {
+      expect(isProtectedPath(pathname)).toBe(false);
+    });
+  });
+
+  describe('protected routes remain protected', () => {
+    it.each([
+      '/library',
+      '/library/private',
+      '/library/private/add',
+      '/games', // hub
+      '/games/some-catalog-id', // #EE — intended gating (public catalog is /shared-games/{id})
+      '/game-nights',
+      '/game-nights/upcoming',
+      '/play-records',
+      '/play-records/new',
+      '/admin',
+      '/editor',
+      '/dashboard',
+    ])('%s IS protected', pathname => {
+      expect(isProtectedPath(pathname)).toBe(true);
+    });
+  });
+
+  describe('unrelated public pages are not protected', () => {
+    it.each(['/', '/about', '/login', '/register', '/faq', '/pricing'])(
+      '%s is NOT protected',
+      pathname => {
+        expect(isProtectedPath(pathname)).toBe(false);
+      }
+    );
+  });
+});
+
+describe('isAdminPath', () => {
+  it.each(['/admin', '/admin/users', '/admin/shared-games/categories'])('%s IS admin', pathname => {
+    expect(isAdminPath(pathname)).toBe(true);
+  });
+
+  it.each(['/administrator', '/library', '/games', '/'])(
+    '%s is NOT admin (boundary-aware)',
+    pathname => {
+      expect(isAdminPath(pathname)).toBe(false);
+    }
+  );
+});

--- a/apps/web/src/lib/routing/protected-routes.ts
+++ b/apps/web/src/lib/routing/protected-routes.ts
@@ -1,0 +1,98 @@
+/**
+ * Route authorization policy for the auth proxy (Issue #2846).
+ *
+ * Extracted from `proxy.ts` so the protected/public/admin route sets and the
+ * boundary-aware decision can be unit-tested in isolation (the proxy function
+ * itself needs a full NextRequest/edge harness).
+ */
+
+import { matchesRoutePrefix } from './route-matching';
+
+/**
+ * Protected routes that require authentication.
+ * Unauthenticated users hitting these are redirected to /login.
+ *
+ * Kept alphabetised so the diff is easy to read and additions are mechanical.
+ * Sources of truth for what belongs here:
+ *   - any top-level path under `src/app/(authenticated)/` whose Server Component
+ *     should not render for an anonymous visitor
+ *   - any path under `src/app/(chat)/`
+ *   - `/admin` (its own (dashboard) subtree)
+ *
+ * `#2118` sweep: added the remaining `(authenticated)` top-levels that were
+ * silently missing from this list.
+ */
+export const PROTECTED_ROUTES = [
+  '/admin',
+  '/agents',
+  '/chat',
+  '/dashboard',
+  '/discover',
+  '/editor',
+  '/game-nights',
+  '/gamebook',
+  '/games',
+  '/hub',
+  '/knowledge-base',
+  '/library',
+  '/n8n',
+  '/notifications',
+  '/onboarding',
+  '/pipeline-builder',
+  '/play-records',
+  '/players',
+  '/private-games',
+  '/profile',
+  '/sessions',
+  '/settings',
+  '/setup',
+  '/toolkit',
+  '/toolkits',
+  '/upload',
+  '/versions',
+] as const;
+
+/**
+ * Public routes that live UNDER a protected prefix and must stay reachable by
+ * guests (Issue #2846). Boundary-aware matching already stops `/library` from
+ * swallowing the sibling `/library-public` landing (#G), but the public share
+ * pages under the `(public)` route group are genuine sub-paths of a protected
+ * prefix, so `matchesRoutePrefix` would still gate them. They are whitelisted
+ * here and subtracted from the protected set.
+ *
+ * These mirror `apps/web/src/app/(public)/**` share routes:
+ *   - `/library/shared/{token}`      (#DD) — shared library links
+ *   - `/game-nights/shared/{token}`  — shared game-night summaries
+ *   - `/play-records/shared/{token}` — shared play-record recaps
+ *
+ * NOTE: the public catalog detail is `/shared-games/{id}` (its own top-level
+ * public route, not under any protected prefix), so `/games/{id}` correctly
+ * stays protected (#EE — intended gating, confirmed 2026-07-12).
+ */
+export const PUBLIC_ROUTES = [
+  '/library/shared',
+  '/game-nights/shared',
+  '/play-records/shared',
+] as const;
+
+/**
+ * Admin-only routes that require the admin (or superadmin) role.
+ */
+export const ADMIN_ONLY_ROUTES = ['/admin'] as const;
+
+/**
+ * True when `pathname` requires authentication: it is boundary-matched by a
+ * protected prefix AND is not one of the whitelisted public share routes.
+ */
+export function isProtectedPath(pathname: string): boolean {
+  return (
+    matchesRoutePrefix(pathname, PROTECTED_ROUTES) && !matchesRoutePrefix(pathname, PUBLIC_ROUTES)
+  );
+}
+
+/**
+ * True when `pathname` is admin-only (boundary-aware).
+ */
+export function isAdminPath(pathname: string): boolean {
+  return matchesRoutePrefix(pathname, ADMIN_ONLY_ROUTES);
+}

--- a/apps/web/src/lib/routing/route-matching.test.ts
+++ b/apps/web/src/lib/routing/route-matching.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import { matchesRoutePrefix } from './route-matching';
+
+describe('matchesRoutePrefix', () => {
+  const routes = ['/library', '/games', '/admin', '/chat'];
+
+  it('matches an exact route', () => {
+    expect(matchesRoutePrefix('/library', routes)).toBe(true);
+    expect(matchesRoutePrefix('/chat', routes)).toBe(true);
+  });
+
+  it('matches a sub-path of a route', () => {
+    expect(matchesRoutePrefix('/library/abc-123', routes)).toBe(true);
+    expect(matchesRoutePrefix('/games/xyz/faqs', routes)).toBe(true);
+  });
+
+  it('does NOT match a sibling path that only shares a prefix (regression: /library-public)', () => {
+    // Plain `'/library-public'.startsWith('/library')` returns true and wrongly
+    // redirected this public landing to /login. Boundary matching fixes it.
+    expect(matchesRoutePrefix('/library-public', routes)).toBe(false);
+  });
+
+  it('does NOT match other prefix-collision siblings', () => {
+    expect(matchesRoutePrefix('/gamespider', routes)).toBe(false);
+    expect(matchesRoutePrefix('/administrator', routes)).toBe(false);
+  });
+
+  it('does NOT match an unrelated public path', () => {
+    expect(matchesRoutePrefix('/faq', routes)).toBe(false);
+    expect(matchesRoutePrefix('/shared-games', routes)).toBe(false);
+  });
+
+  it('returns false for an empty routes list', () => {
+    expect(matchesRoutePrefix('/library', [])).toBe(false);
+  });
+});

--- a/apps/web/src/lib/routing/route-matching.ts
+++ b/apps/web/src/lib/routing/route-matching.ts
@@ -1,0 +1,15 @@
+/**
+ * Boundary-aware route prefix matching.
+ *
+ * A pathname matches a route only when it equals the route exactly or starts
+ * with `route + '/'`. This prevents prefix-collision bugs where an unrelated
+ * public path is caught by a protected prefix — e.g. `/library-public` being
+ * matched by the protected route `/library`, since plain
+ * `'/library-public'.startsWith('/library')` returns `true`.
+ *
+ * Used by the auth proxy to decide whether a request path is protected /
+ * admin-only, and to validate the post-login `from` redirect target.
+ */
+export function matchesRoutePrefix(pathname: string, routes: readonly string[]): boolean {
+  return routes.some(route => pathname === route || pathname.startsWith(`${route}/`));
+}

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -28,7 +28,7 @@
 import { NextResponse } from 'next/server';
 
 import * as metrics from '@/lib/metrics/session-cache-metrics';
-import { matchesRoutePrefix } from '@/lib/routing/route-matching';
+import { isAdminPath, isProtectedPath } from '@/lib/routing/protected-routes';
 import { isAdminRole } from '@/lib/utils/roles';
 
 import type { NextRequest } from 'next/server';
@@ -39,57 +39,10 @@ import type { NextRequest } from 'next/server';
 // Configuration
 // ============================================================================
 
-/**
- * Protected routes that require authentication
- * Unauthenticated users will be redirected to /login
- *
- * Kept alphabetised so the diff is easy to read and additions are mechanical.
- * Sources of truth for what belongs here:
- *   - any top-level path under `src/app/(authenticated)/` whose Server Component
- *     should not render for an anonymous visitor
- *   - any path under `src/app/(chat)/`
- *   - `/admin` (its own (dashboard) subtree)
- *
- * `#2118` sweep: added the remaining `(authenticated)` top-levels that were
- * silently missing from this list. Before the sweep, anonymous users hitting
- * `/hub/games`, `/dashboard`, `/profile`, etc. saw the authenticated chrome
- * (`UserShell` / `AppTopBar`) with an empty session and relied on each page
- * hook to surface a 401 — which produced a flash of broken UI.
- */
-const PROTECTED_ROUTES = [
-  '/admin',
-  '/agents',
-  '/chat',
-  '/dashboard',
-  '/discover',
-  '/editor',
-  '/game-nights',
-  '/gamebook',
-  '/games',
-  '/hub',
-  '/knowledge-base',
-  '/library',
-  '/n8n',
-  '/notifications',
-  '/onboarding',
-  '/pipeline-builder',
-  '/play-records',
-  '/players',
-  '/private-games',
-  '/profile',
-  '/sessions',
-  '/settings',
-  '/setup',
-  '/toolkit',
-  '/toolkits',
-  '/upload',
-  '/versions',
-];
-
-/**
- * Admin-only routes that require admin role
- */
-const ADMIN_ONLY_ROUTES = ['/admin'];
+// Route authorization policy (protected / public-share / admin prefix sets and
+// the boundary-aware decision helpers) lives in `@/lib/routing/protected-routes`
+// so it can be unit-tested without a full edge/NextRequest harness — see
+// `isProtectedPath` / `isAdminPath`.
 
 /**
  * Public routes that don't require authentication
@@ -455,12 +408,14 @@ export async function proxy(request: NextRequest) {
   const isAdminViewMode = isAdmin && viewModeCookie?.value !== 'user';
 
   // Check if the current route is protected or public auth route
-  // Boundary-aware matching (matchesRoutePrefix): a route matches only on an
-  // exact hit or a `route + '/'` sub-path, so protected `/library` no longer
-  // swallows the public `/library-public` landing (plain startsWith did).
-  const isProtectedRoute = matchesRoutePrefix(pathname, PROTECTED_ROUTES);
+  // Boundary-aware matching: a route matches only on an exact hit or a
+  // `route + '/'` sub-path, so protected `/library` no longer swallows the
+  // public `/library-public` landing (plain startsWith did). Issue #2846:
+  // isProtectedPath also subtracts the public share routes (`/library/shared/*`,
+  // `/game-nights/shared/*`, `/play-records/shared/*`) so guests can reach them.
+  const isProtectedRoute = isProtectedPath(pathname);
   const isPublicAuthRoute = PUBLIC_AUTH_ROUTES.some(route => pathname === route);
-  const isAdminRoute = matchesRoutePrefix(pathname, ADMIN_ONLY_ROUTES);
+  const isAdminRoute = isAdminPath(pathname);
   const isHomePage = pathname === '/';
 
   // Redirect unauthenticated users from protected routes to login
@@ -485,7 +440,7 @@ export async function proxy(request: NextRequest) {
     const fromParam = request.nextUrl.searchParams.get('from');
     const defaultDest = isAdminViewMode ? '/admin' : '/library';
     const redirectUrl =
-      fromParam && matchesRoutePrefix(fromParam, PROTECTED_ROUTES)
+      fromParam && isProtectedPath(fromParam)
         ? new URL(fromParam, request.url)
         : new URL(defaultDest, request.url);
     const response = NextResponse.redirect(redirectUrl);

--- a/apps/web/src/proxy.ts
+++ b/apps/web/src/proxy.ts
@@ -28,6 +28,7 @@
 import { NextResponse } from 'next/server';
 
 import * as metrics from '@/lib/metrics/session-cache-metrics';
+import { matchesRoutePrefix } from '@/lib/routing/route-matching';
 import { isAdminRole } from '@/lib/utils/roles';
 
 import type { NextRequest } from 'next/server';
@@ -454,9 +455,12 @@ export async function proxy(request: NextRequest) {
   const isAdminViewMode = isAdmin && viewModeCookie?.value !== 'user';
 
   // Check if the current route is protected or public auth route
-  const isProtectedRoute = PROTECTED_ROUTES.some(route => pathname.startsWith(route));
+  // Boundary-aware matching (matchesRoutePrefix): a route matches only on an
+  // exact hit or a `route + '/'` sub-path, so protected `/library` no longer
+  // swallows the public `/library-public` landing (plain startsWith did).
+  const isProtectedRoute = matchesRoutePrefix(pathname, PROTECTED_ROUTES);
   const isPublicAuthRoute = PUBLIC_AUTH_ROUTES.some(route => pathname === route);
-  const isAdminRoute = ADMIN_ONLY_ROUTES.some(route => pathname.startsWith(route));
+  const isAdminRoute = matchesRoutePrefix(pathname, ADMIN_ONLY_ROUTES);
   const isHomePage = pathname === '/';
 
   // Redirect unauthenticated users from protected routes to login
@@ -481,7 +485,7 @@ export async function proxy(request: NextRequest) {
     const fromParam = request.nextUrl.searchParams.get('from');
     const defaultDest = isAdminViewMode ? '/admin' : '/library';
     const redirectUrl =
-      fromParam && PROTECTED_ROUTES.some(route => fromParam.startsWith(route))
+      fromParam && matchesRoutePrefix(fromParam, PROTECTED_ROUTES)
         ? new URL(fromParam, request.url)
         : new URL(defaultDest, request.url);
     const response = NextResponse.redirect(redirectUrl);


### PR DESCRIPTION
## Findings #G / #DD / #EE (Closes #2846)

Public routes were redirected to `/login` for guests because the proxy matched
protected prefixes with plain `pathname.startsWith(route)`, so `/library` and
`/game-nights` swallowed unrelated public sub-paths.

## Fix

Builds on the boundary-aware `matchesRoutePrefix` helper from **PR #2812** (which
this PR supersedes — its helper + boundary-match change are included here).

Extracts the route-authorization policy from `proxy.ts` into
`@/lib/routing/protected-routes` (`PROTECTED_ROUTES` / `PUBLIC_ROUTES` /
`ADMIN_ONLY_ROUTES` + `isProtectedPath` / `isAdminPath`) so it is unit-testable
without a full edge/NextRequest harness.

`isProtectedPath` = boundary-matched by a protected prefix **AND NOT** a
whitelisted public share route:

| Route | Before | After |
|---|---|---|
| `/library-public` (#G) | → /login | public (boundary match) |
| `/library/shared/{token}` (#DD) | → /login | public (whitelist) |
| `/game-nights/shared/{token}` | → /login | public (whitelist, same latent bug) |
| `/play-records/shared/{token}` | → /login | public (whitelist, same latent bug) |
| `/games/{id}` (#EE) | → /login | **stays protected** |

**#EE decision (confirmed 2026-07-12):** `/games/{id}` stays protected — the
public catalog detail is the separate top-level `/shared-games/{id}` route, so
catalog gating is intended, not a bug. I also proactively whitelisted the
`/game-nights/shared` and `/play-records/shared` public share pages, which had
the identical latent prefix-collision.

## Tests

`protected-routes.test.ts` — the three `.../shared/*` routes + `/library-public`
+ `/shared-games/{id}` resolve to NOT protected; `/library`, `/games/{id}`,
`/admin`, etc. stay protected. The `.../shared/*` cases returned `true`
(login redirect) under the old plain-startsWith logic.

## Verification status

- ✅ Unit tests green; `pnpm typecheck` clean.
- ⏳ Browser E2E (guest hits `/library/shared/{token}` → no redirect to /login) —
  pending the consolidated verify-then-merge sweep. Re-runs the happy-path guest tour.

Closes #2846. Supersedes #2812.
