### PR TITLE
refactor(design-tokens): remove dead v1 --c-* aliases + cross-file consistency gate (#2856)

### DIFF
--- a/apps/web/src/__tests__/styles/entity-token-consistency.test.ts
+++ b/apps/web/src/__tests__/styles/entity-token-consistency.test.ts
@@ -1,0 +1,60 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { describe, it, expect } from 'vitest';
+
+/**
+ * Cross-file entity-token consistency gate (issue #2856, follow-up of audit
+ * docs/for-developers/audits/2026-07-12-meeplecard-css-drift-audit.md).
+ *
+ * The `--c-{entity}` accent tokens are (currently) declared in three runtime
+ * stylesheets loaded together: `design-tokens-canonical.css`, `globals.css`,
+ * and `design-tokens.css` (the last two @imported). Their values MUST be
+ * identical everywhere, otherwise the winning value depends on CSS import-order
+ * — exactly the silent drift the audit surfaced (canonical 45% vs globals 38%).
+ *
+ * This gate asserts the light + dark values of every entity token match across
+ * all three files. Paired with entity-token-golden.test.ts (canonical ↔ mockup),
+ * it pins the full chain: mockup == canonical == globals == design-tokens.
+ *
+ * The dead v1 "short aliases" block in design-tokens.css was removed in #2857.
+ * The remaining physical de-duplication (collapse to a single source) is a
+ * follow-up; this gate makes any new divergence a red build in the meantime.
+ */
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const STYLES = path.resolve(HERE, '../../styles');
+
+const ENTITIES = [
+  'game',
+  'player',
+  'session',
+  'agent',
+  'kb',
+  'chat',
+  'event',
+  'toolkit',
+  'tool',
+] as const;
+
+function tokenValues(css: string, entity: string): string[] {
+  // Matches `--c-game: ...;` but NOT `--c-game-text: ...;`.
+  const re = new RegExp('--c-' + entity + ':\\s*([^;]+);', 'g');
+  return [...css.matchAll(re)].map(m => m[1].trim()).sort();
+}
+
+describe('entity token consistency across runtime sources (#2856)', () => {
+  const canonical = fs.readFileSync(path.join(STYLES, 'design-tokens-canonical.css'), 'utf8');
+  const globals = fs.readFileSync(path.join(STYLES, 'globals.css'), 'utf8');
+  const designTokens = fs.readFileSync(path.join(STYLES, 'design-tokens.css'), 'utf8');
+
+  it.each(ENTITIES)('--c-%s matches across canonical, globals, design-tokens', entity => {
+    const c = tokenValues(canonical, entity);
+    const g = tokenValues(globals, entity);
+    const d = tokenValues(designTokens, entity);
+    expect(c.length).toBeGreaterThan(0);
+    expect(g).toEqual(c);
+    expect(d).toEqual(c);
+  });
+});

--- a/apps/web/src/styles/design-tokens.css
+++ b/apps/web/src/styles/design-tokens.css
@@ -360,15 +360,6 @@
     --color-entity-event: 350 89% 60%;    /* Rose */
     --color-entity-tool: 195 80% 50%;     /* Sky Blue — Epic #412 */
 
-    /* Short aliases for v2 mockup compatibility (direct values, not var()) */
-    --c-game: 25 95% 45%;
-    --c-player: 262 83% 58%;
-    --c-session: 240 60% 55%;
-    --c-agent: 38 92% 50%;
-    --c-kb: 210 40% 55%;
-    --c-chat: 220 80% 55%;
-    --c-event: 350 89% 60%;
-
     /* ============================================================================
      * V2 Entity & Semantic Colors (Issue #572 — V2 Phase 0)
      * Aligned with admin-mockups/design_files/tokens.css (design system source of truth).


### PR DESCRIPTION
Part of #2863 (Phase B2 + safe part of B3).

- **B2 (#2856)**: adds a cross-file gate asserting `--c-{entity}` values are identical across `design-tokens-canonical.css`, `globals.css` and `design-tokens.css`. Paired with the golden test (#2855), it pins `mockup == canonical == globals == design-tokens` — import-order can no longer pick a silent winner.
- **B3 (#2857, partial)**: removes the dead **v1 "short aliases"** `--c-*` block in `design-tokens.css` (fully overridden by the v2 block in the same selector → never won). Verified: 26 style tests green.

The full physical collapse (removing the *live* duplicate blocks so a single source remains) changes which declaration wins and needs visual/CI verification — left as a follow-up on #2857, not forced through --admin.

Closes #2856. Refs #2857.

🤖 Generated with [Claude Code](https://claude.com/claude-code)