### PR TITLE
fix(sessions): validate sessions/history as a bare array, not paginated (#2848)

### DIFF
--- a/apps/web/src/lib/api/__tests__/sessionsClient.crud.test.ts
+++ b/apps/web/src/lib/api/__tests__/sessionsClient.crud.test.ts
@@ -54,15 +54,10 @@ describe('sessionsClient CRUD and lifecycle', () => {
   });
 
   describe('getHistory', () => {
-    it('should fetch session history without filters', async () => {
-      const mockResponse = {
-        sessions: [],
-        total: 0,
-        page: 1,
-        pageSize: 20,
-      };
-
-      vi.mocked(mockHttpClient.get).mockResolvedValueOnce(mockResponse);
+    // Issue #2848 (#Z): /sessions/history returns a bare List<GameSessionDto>;
+    // getHistory validates the array and wraps it into a PaginatedSessionsResponse.
+    it('should wrap the empty array into a paginated response', async () => {
+      vi.mocked(mockHttpClient.get).mockResolvedValueOnce([]);
 
       const result = await client.getHistory();
 
@@ -70,18 +65,12 @@ describe('sessionsClient CRUD and lifecycle', () => {
         '/api/v1/sessions/history?',
         expect.any(Object)
       );
-      expect(result).toEqual(mockResponse);
+      expect(result).toEqual({ sessions: [], total: 0, page: 1, pageSize: 20 });
     });
 
-    it('should fetch session history with filters', async () => {
-      const mockResponse = {
-        sessions: [{ id: 'session-1', gameId: 'game-1' }],
-        total: 1,
-        page: 1,
-        pageSize: 10,
-      };
-
-      vi.mocked(mockHttpClient.get).mockResolvedValueOnce(mockResponse);
+    it('should wrap the returned array and apply filters', async () => {
+      const sessions = [{ id: 'session-1', gameId: 'game-1' }];
+      vi.mocked(mockHttpClient.get).mockResolvedValueOnce(sessions);
 
       const result = await client.getHistory({
         gameId: 'game-1',
@@ -99,7 +88,7 @@ describe('sessionsClient CRUD and lifecycle', () => {
         expect.stringContaining('startDate=2024-01-01'),
         expect.any(Object)
       );
-      expect(result).toEqual(mockResponse);
+      expect(result).toEqual({ sessions, total: 1, page: 1, pageSize: 10 });
     });
 
     it('should return empty response on null', async () => {

--- a/apps/web/src/lib/api/clients/__tests__/sessionsClient.test.ts
+++ b/apps/web/src/lib/api/clients/__tests__/sessionsClient.test.ts
@@ -89,32 +89,56 @@ describe('SessionsClient - Issue #3026', () => {
   });
 
   describe('getHistory', () => {
-    it('should fetch session history without filters', async () => {
-      const mockResponse = {
-        sessions: [{ ...mockSession, status: 'Completed' }],
-        total: 1,
-        page: 1,
-        pageSize: 20,
-      };
-      vi.mocked(mockHttpClient.get).mockResolvedValue(mockResponse);
+    // Issue #2848 (#Z): GET /api/v1/sessions/history returns a BARE array
+    // (`.Produces<List<GameSessionDto>>`), unlike /sessions/active which returns a
+    // paginated envelope. getHistory validates the array and wraps it into the
+    // PaginatedSessionsResponse its callers expect. A schema-valid fixture is used
+    // so the array-schema assertion below is meaningful.
+    const validHistorySession = {
+      id: 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
+      gameId: '6ba7b810-9dad-41d1-80b4-00c04fd430c8',
+      status: 'Completed',
+      startedAt: '2024-01-15T10:00:00Z',
+      completedAt: '2024-01-15T12:00:00Z',
+      playerCount: 2,
+      players: [],
+      winnerName: null,
+      notes: null,
+      durationMinutes: 120,
+    };
+
+    it('wraps the bare array the BE returns into a paginated response', async () => {
+      vi.mocked(mockHttpClient.get).mockResolvedValue([validHistorySession]);
 
       const client = createSessionsClient({ httpClient: mockHttpClient });
       const result = await client.getHistory();
 
-      expect(result).toEqual(mockResponse);
+      expect(result).toEqual({
+        sessions: [validHistorySession],
+        total: 1,
+        page: 1,
+        pageSize: 20,
+      });
       expect(mockHttpClient.get).toHaveBeenCalledWith(
         '/api/v1/sessions/history?',
         expect.any(Object)
       );
     });
 
+    it('validates against a schema that accepts the bare array (root cause of #2848)', async () => {
+      vi.mocked(mockHttpClient.get).mockResolvedValue([validHistorySession]);
+
+      const client = createSessionsClient({ httpClient: mockHttpClient });
+      await client.getHistory();
+
+      const schemaArg = vi.mocked(mockHttpClient.get).mock.calls[0]?.[1] as
+        | { safeParse: (x: unknown) => { success: boolean } }
+        | undefined;
+      expect(schemaArg?.safeParse([validHistorySession]).success).toBe(true);
+    });
+
     it('should apply all filters', async () => {
-      vi.mocked(mockHttpClient.get).mockResolvedValue({
-        sessions: [],
-        total: 0,
-        page: 1,
-        pageSize: 10,
-      });
+      vi.mocked(mockHttpClient.get).mockResolvedValue([]);
 
       const client = createSessionsClient({ httpClient: mockHttpClient });
       await client.getHistory({

--- a/apps/web/src/lib/api/clients/sessionsClient.ts
+++ b/apps/web/src/lib/api/clients/sessionsClient.ts
@@ -5,6 +5,8 @@
  * Covers: Game sessions management (active, history, CRUD, lifecycle)
  */
 
+import { z } from 'zod';
+
 import {
   GameSessionDtoSchema,
   PaginatedSessionsResponseSchema,
@@ -85,14 +87,21 @@ export function createSessionsClient({ httpClient }: CreateSessionsClientParams)
       if (filters?.limit) params.append('limit', filters.limit.toString());
       if (filters?.offset) params.append('offset', filters.offset.toString());
 
-      const response = await httpClient.get(
+      const limit = filters?.limit || 20;
+      const offset = filters?.offset || 0;
+
+      // Issue #2848 (#Z): GET /api/v1/sessions/history returns a BARE array
+      // (`.Produces<List<GameSessionDto>>`), unlike /sessions/active which
+      // returns a paginated envelope. Validate the array (previously this used
+      // PaginatedSessionsResponseSchema and threw "Response validation failed"
+      // on the array) and wrap it into the PaginatedSessionsResponse callers
+      // expect. The BE does not return a total count, so total = page length.
+      const sessions = await httpClient.get(
         `/api/v1/sessions/history?${params}`,
-        PaginatedSessionsResponseSchema
+        z.array(GameSessionDtoSchema)
       );
 
-      if (!response) {
-        const limit = filters?.limit || 20;
-        const offset = filters?.offset || 0;
+      if (!sessions) {
         return {
           sessions: [],
           total: 0,
@@ -101,7 +110,12 @@ export function createSessionsClient({ httpClient }: CreateSessionsClientParams)
         };
       }
 
-      return response;
+      return {
+        sessions,
+        total: sessions.length,
+        page: Math.floor(offset / limit) + 1,
+        pageSize: limit,
+      };
     },
 
     // ========== Session CRUD ==========


### PR DESCRIPTION
## Finding #Z (Closes #2848)

`/players/{id}/sessions` showed *"Schema validation failed: Response validation
failed for /api/v1/sessions/history?limit=50"* and `/players/{id}/stats` stayed
empty (stats derive from the same history).

**Root cause:** the BE endpoint `GET /api/v1/sessions/history` returns a BARE
array (`.Produces<List<GameSessionDto>>`), unlike `/sessions/active` which
returns a paginated envelope. But `sessionsClient.getHistory` validated the
response with `PaginatedSessionsResponseSchema` (`{ sessions, total, page,
pageSize }`), so Zod threw on the array and the consumer surfaced the error.

## Fix (FE)

Validate with `z.array(GameSessionDtoSchema)` and wrap the array into the
`PaginatedSessionsResponse` its callers expect (`total = page length`; the
endpoint returns no count). `getActive` is untouched. The BE contract is
deliberately a bare list and has other consumers, so the fix is FE-side.

## Tests

Rewrote the `getHistory` unit tests — they previously mocked a paginated object
the real BE never returns — to mock the bare array and assert the wrapped
result, plus a root-cause assertion that the schema now passed accepts the
array. All `sessionsClient` suites green.

## Verification status

- ✅ Vitest red → green.
- ⏳ Browser E2E (`/players/{id}/sessions` renders the list, `/stats` renders
  KPIs) — pending the consolidated verify-then-merge sweep. Re-runs U6-21/U6-22.

Closes #2848.
