### PR TITLE
refactor(design-tokens): collapse --c-{entity} accents to a single source (#2857)

### DIFF
--- a/apps/web/src/__tests__/styles/entity-token-consistency.test.ts
+++ b/apps/web/src/__tests__/styles/entity-token-consistency.test.ts
@@ -49,12 +49,13 @@ describe('entity token consistency across runtime sources (#2856)', () => {
   const globals = fs.readFileSync(path.join(STYLES, 'globals.css'), 'utf8');
   const designTokens = fs.readFileSync(path.join(STYLES, 'design-tokens.css'), 'utf8');
 
-  it.each(ENTITIES)('--c-%s matches across canonical, globals, design-tokens', entity => {
-    const c = tokenValues(canonical, entity);
-    const g = tokenValues(globals, entity);
-    const d = tokenValues(designTokens, entity);
-    expect(c.length).toBeGreaterThan(0);
-    expect(g).toEqual(c);
-    expect(d).toEqual(c);
+  it.each(ENTITIES)('--c-%s is declared only in canonical (single source)', entity => {
+    // After the physical collapse (#2857), each accent token is defined exactly
+    // once — in canonical. globals.css and design-tokens.css no longer redefine
+    // it, so CSS import-order can no longer pick a winner. (The `-text` variants
+    // remain duplicated for now — a separate follow-up.)
+    expect(tokenValues(canonical, entity).length).toBeGreaterThan(0);
+    expect(tokenValues(globals, entity)).toEqual([]);
+    expect(tokenValues(designTokens, entity)).toEqual([]);
   });
 });

--- a/apps/web/src/styles/design-tokens.css
+++ b/apps/web/src/styles/design-tokens.css
@@ -371,15 +371,6 @@
      * Cyan/teal/yellow hues (kb, tool, agent, toolkit) require lower L values
      * (perceptually light luminance — see hue-based perception note in audit).
      * ============================================================================ */
-    --c-game:    25 95% 38%;     /* Orange — 4.82:1 (was L=45%, FAIL — see #587, gate #601, then #807) */
-    --c-player:  262 83% 45%;    /* Purple — 8.55:1 (#807: was L=58%, FAIL 3.18:1) */
-    --c-session: 240 60% 35%;    /* Indigo — 12.22:1 (#807: was L=55%, FAIL 3.95:1) */
-    --c-agent:   38 92% 32%;     /* Amber — 4.87:1 (#807: was L=50%, FAIL 2.81:1; yellow hue) */
-    --c-kb:      174 60% 30%;    /* Teal — 5.12:1 (#807: was L=40%, FAIL 3.09:1; cyan hue) */
-    --c-chat:    220 80% 40%;    /* Blue — 7.72:1 (#807: was L=55%, FAIL 3.71:1) */
-    --c-event:   350 89% 38%;    /* Rose — 6.79:1 (#807: was L=60%, FAIL 3.45:1) */
-    --c-toolkit: 142 70% 30%;    /* Green — 4.88:1 (#807: was L=45%, FAIL 4.02:1) */
-    --c-tool:    195 80% 32%;    /* Sky Blue — 5.44:1 (#807: was L=50%, FAIL 2.95:1; cyan hue) */
 
     --c-success: 142 70% 45%;
     --c-warning: 38 92% 50%;
@@ -565,15 +556,6 @@
 
     /* V2 Entity Colors — dark mode overrides (Issue #572)
        Lighter HSLs for contrast on dark bg, mirror admin-mockups/design_files/tokens.css */
-    --c-game:    28 95% 58%;
-    --c-player:  262 75% 70%;
-    --c-session: 235 70% 70%;
-    --c-agent:   38 92% 62%;
-    --c-kb:      174 60% 55%;
-    --c-chat:    218 80% 68%;
-    --c-event:   350 85% 70%;
-    --c-toolkit: 142 60% 58%;
-    --c-tool:    195 75% 62%;
 
     /* ============================================================================
      * DARK MODE ENHANCEMENTS (Issue #2965 Wave 8)

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -559,18 +559,9 @@
 :root {
   /* MeepleCard v2 entity color shortcuts (Issue #4604, AA-aligned via #807 Iter 2 audit 2026-05-09) */
   /* Values match design-tokens.css --c-* tokens. Both used: --e-* feeds Tailwind utilities text-entity-X via @theme; --c-* used by entityHsl() helper. */
-  --c-game: 25 95% 38%;       /* 4.82:1 ✅ (#587, gate #601, then #807) */
   --c-game-text: 25 95% 32%;  /* 6.14:1 ✅ darker variant when used as text on light bg (#1094 Real-C-B, mirrors design-tokens-canonical.css:45) */
   --c-toolkit-text: 142 70% 24%;  /* ~5.6:1 ✅ darker variant for AA on light bg, paired with bg-entity-toolkit/12 (#1094 Real-C-E gamebook) */
   --c-session-text: 240 60% 35%;  /* PR #1721 follow-up: light theme value = same as --c-session (already 12.22:1 AA on cream). Dark theme overrides to 235 85% 85% for AA on dark surfaces. */
-  --c-player: 262 83% 45%;    /* 8.55:1 ✅ (#807: was L=58%) */
-  --c-session: 240 60% 35%;   /* 12.22:1 ✅ (#807: was L=55%) */
-  --c-agent: 38 92% 32%;      /* 4.87:1 ✅ (#807: was L=50%) */
-  --c-kb: 174 60% 30%;  /* 5.12:1 ✅ KB teal (#807: was L=40%, cyan hue requires lower L) */
-  --c-chat: 220 80% 40%;      /* 7.72:1 ✅ (#807: was L=55%) */
-  --c-event: 350 89% 38%;     /* 6.79:1 ✅ (#807: was L=60%) */
-  --c-toolkit: 142 70% 30%;   /* 4.88:1 ✅ Toolkit green (#807: was L=45%) */
-  --c-tool: 195 80% 32%;      /* 5.44:1 ✅ Sky Blue Epic #412 (#807: was L=50%) */
 
   /* Base theme tokens - Opzione A: Playful Boardroom */
   --radius: 0.625rem;
@@ -718,18 +709,9 @@
      Mirrors --c-* tokens in design-tokens.css .dark block.
      Issue #807 follow-up: A11y dark theme contrast fix (sessions-index, gamebook,
      session-live, session-summary specs). */
-  --c-game: 28 95% 58%;
   --c-game-text: 28 95% 70%;  /* 11.2:1 ✅ lighter variant for AA on dark bg (#1094 Real-C-B, mirrors design-tokens-canonical.css:199) */
   --c-toolkit-text: 142 60% 72%;  /* lighter variant for AA on dark bg (#1094 Real-C-E gamebook) */
   --c-session-text: 235 85% 85%;  /* PR #1721 follow-up: lighter variant for AA on dark `--card` + `--c-session/14` overlay (was --c-session 235 70% 70% → 3.85:1 fail in SessionShareCard theme toggle). Mirrors design-tokens-canonical.css */
-  --c-player: 262 75% 70%;
-  --c-session: 235 70% 70%;
-  --c-agent: 38 92% 62%;
-  --c-kb: 174 60% 55%;
-  --c-chat: 218 80% 68%;
-  --c-event: 350 85% 70%;
-  --c-toolkit: 142 60% 58%;
-  --c-tool: 195 75% 62%;
 
   /* NOTE: --bg, --bg-card, --text, --text-sec, --text-muted
      are unified tokens from design-tokens.css. Do NOT redefine here. */


### PR DESCRIPTION
Part of #2863 (B3 completion). Removes the duplicate --c-{entity} accent declarations from globals.css + design-tokens.css (light+dark), leaving canonical as the single source. Identical values → zero runtime change. Gate updated to assert single-source. 26 style tests + build green. Closes #2857.