### PR TITLE
fix(shared-games): repair admin CRUD for superadmin + create response (#2845 #HH)

### DIFF
--- a/apps/api/src/Api/Extensions/ClaimsPrincipalExtensions.cs
+++ b/apps/api/src/Api/Extensions/ClaimsPrincipalExtensions.cs
@@ -20,4 +20,24 @@ public static class ClaimsPrincipalExtensions
 
         return Guid.TryParse(userIdClaim, out var userId) ? userId : Guid.Empty;
     }
+
+    /// <summary>
+    /// True when the principal has admin privileges (Admin or SuperAdmin).
+    ///
+    /// Issue #2845 / finding #HH: role claims are PascalCase
+    /// (<see cref="Api.Infrastructure.Authentication"/> normalizes to
+    /// "SuperAdmin" / "Admin" / "Editor"). Handlers that checked only
+    /// <c>IsInRole("Admin")</c> denied a superadmin the admin path — e.g. the
+    /// shared-game delete fell through to the Editor "request" branch (202,
+    /// no-op) for a superadmin.
+    /// </summary>
+    public static bool IsAdmin(this ClaimsPrincipal user) =>
+        user.IsInRole("Admin") || user.IsInRole("SuperAdmin");
+
+    /// <summary>
+    /// True when the principal is admin, superadmin, or editor. Mirrors the
+    /// "AdminOrEditorPolicy" role set (SuperAdmin, Admin, Editor).
+    /// </summary>
+    public static bool IsAdminOrEditor(this ClaimsPrincipal user) =>
+        user.IsInRole("Admin") || user.IsInRole("SuperAdmin") || user.IsInRole("Editor");
 }

--- a/apps/api/src/Api/Routing/SharedGameCatalog/SharedGameCatalogAdminEndpoints.cs
+++ b/apps/api/src/Api/Routing/SharedGameCatalog/SharedGameCatalogAdminEndpoints.cs
@@ -941,7 +941,10 @@ internal static class SharedGameCatalogAdminEndpoints
             return Results.Unauthorized();
         }
 
-        var isAdmin = context.User.IsInRole("Admin");
+        // Issue #2845/#HH: include SuperAdmin — a superadmin's role claim is
+        // "SuperAdmin", so IsInRole("Admin") alone routed them to the Editor
+        // "request delete" branch (202, no-op) instead of a direct delete.
+        var isAdmin = context.User.IsAdmin();
 
         if (isAdmin)
         {

--- a/apps/api/src/Api/Routing/SharedGameCatalog/SharedGameCatalogPublicEndpoints.cs
+++ b/apps/api/src/Api/Routing/SharedGameCatalog/SharedGameCatalogPublicEndpoints.cs
@@ -5,6 +5,7 @@ using Api.BoundedContexts.SharedGameCatalog.Application.Queries;
 using Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetTopContributors;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using Api.Extensions;
 using Api.Models;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
@@ -144,7 +145,10 @@ internal static class SharedGameCatalogPublicEndpoints
         // Admin/Editor can see all statuses
         if (result is not null)
         {
-            var isAdminOrEditor = context.User.IsInRole("Admin") || context.User.IsInRole("Editor");
+            // Issue #2845/#HH: include SuperAdmin so a superadmin can load the
+            // admin detail page for draft/archived games (IsInRole("Admin")
+            // alone hid non-Published games from a superadmin → "Failed to load").
+            var isAdminOrEditor = context.User.IsAdminOrEditor();
             if (!isAdminOrEditor && result.Status != GameStatus.Published)
             {
                 return Results.NotFound(); // Hide draft/archived games from public

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/SharedGameCatalogEndpointsIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/SharedGameCatalogEndpointsIntegrationTests.cs
@@ -640,6 +640,43 @@ public sealed class SharedGameCatalogEndpointsIntegrationTests : IAsyncLifetime
         response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
     }
 
+    // ========================================
+    // DELETE SHARED GAME TESTS (Issue #2845 / finding #HH, leg 3)
+    // ========================================
+
+    [Fact]
+    public async Task DeleteSharedGame_WithSuperAdmin_Returns204AndSoftDeletes()
+    {
+        // Arrange — a superadmin (role claim "SuperAdmin"). Before the fix,
+        // HandleDeleteGame used IsInRole("Admin"), which is false for a
+        // superadmin, so it fell through to the Editor "request delete" branch
+        // (202 Accepted, no actual delete).
+        using var authScope = _factory.Services.CreateScope();
+        var authDbContext = authScope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (superAdminUserId, sessionToken) =
+            await TestSessionHelper.CreateSuperAdminSessionAsync(authDbContext);
+
+        var game = await CreateTestGameAsync(GameStatus.Published, superAdminUserId);
+
+        // Act
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Delete,
+            $"/api/v1/admin/shared-games/{game.Id}",
+            sessionToken,
+            new { reason = "integration test — superadmin direct delete" });
+        var response = await _client.SendAsync(request);
+
+        // Assert — direct delete (204), NOT the Editor request path (202).
+        response.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        using var assertScope = _factory.Services.CreateScope();
+        var dbContext = assertScope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var deleted = await dbContext.SharedGames
+            .IgnoreQueryFilters()
+            .FirstAsync(g => g.Id == game.Id, TestContext.Current.CancellationToken);
+        deleted.IsDeleted.Should().BeTrue("a superadmin delete must soft-delete the game, not just enqueue a request");
+    }
+
     /// <summary>
     /// Helper to create a game with a specific BGG ID for duplicate tests.
     /// </summary>

--- a/apps/api/tests/Api.Tests/Extensions/ClaimsPrincipalExtensionsTests.cs
+++ b/apps/api/tests/Api.Tests/Extensions/ClaimsPrincipalExtensionsTests.cs
@@ -1,0 +1,56 @@
+using System.Security.Claims;
+using Api.Extensions;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.Extensions;
+
+/// <summary>
+/// Issue #2845 / finding #HH: role claims are PascalCase ("SuperAdmin" / "Admin"
+/// / "Editor"), so handlers that checked only <c>IsInRole("Admin")</c> denied a
+/// superadmin the admin path. These helpers centralize the case-correct check.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+public sealed class ClaimsPrincipalExtensionsTests
+{
+    private static ClaimsPrincipal PrincipalWithRole(string? role)
+    {
+        var claims = role is null ? Array.Empty<Claim>() : new[] { new Claim(ClaimTypes.Role, role) };
+        return new ClaimsPrincipal(new ClaimsIdentity(claims, authenticationType: "test"));
+    }
+
+    [Theory]
+    [InlineData("SuperAdmin", true)]
+    [InlineData("Admin", true)]
+    [InlineData("Editor", false)]
+    [InlineData("User", false)]
+    [InlineData("Creator", false)]
+    public void IsAdmin_ReturnsExpected(string role, bool expected)
+    {
+        PrincipalWithRole(role).IsAdmin().Should().Be(expected);
+    }
+
+    [Fact]
+    public void IsAdmin_WithNoRoleClaim_ReturnsFalse()
+    {
+        PrincipalWithRole(null).IsAdmin().Should().BeFalse();
+    }
+
+    [Theory]
+    [InlineData("SuperAdmin", true)]
+    [InlineData("Admin", true)]
+    [InlineData("Editor", true)]
+    [InlineData("User", false)]
+    [InlineData("Creator", false)]
+    public void IsAdminOrEditor_ReturnsExpected(string role, bool expected)
+    {
+        PrincipalWithRole(role).IsAdminOrEditor().Should().Be(expected);
+    }
+
+    [Fact]
+    public void IsAdminOrEditor_WithNoRoleClaim_ReturnsFalse()
+    {
+        PrincipalWithRole(null).IsAdminOrEditor().Should().BeFalse();
+    }
+}

--- a/apps/web/src/lib/api/clients/__tests__/sharedGamesClient.test.ts
+++ b/apps/web/src/lib/api/clients/__tests__/sharedGamesClient.test.ts
@@ -197,8 +197,12 @@ describe('SharedGamesClient - Issue #3026', () => {
     });
 
     describe('create', () => {
-      it('should create a new game', async () => {
-        vi.mocked(mockHttpClient.post).mockResolvedValue({ id: 'new-game-123' });
+      // Issue #2845/#HH (leg 1): POST /admin/shared-games returns a BARE Guid
+      // string (`.Produces<Guid>`), not `{ id }`. Validating with an object
+      // schema rejected a successful 201 → no redirect + duplicate creations.
+      it('returns the bare game id the BE responds with', async () => {
+        const newId = 'f47ac10b-58cc-4372-a567-0e02b2c3d479';
+        vi.mocked(mockHttpClient.post).mockResolvedValue(newId);
 
         const client = createSharedGamesClient({ httpClient: mockHttpClient });
         const result = await client.create({
@@ -208,12 +212,17 @@ describe('SharedGamesClient - Issue #3026', () => {
           maxPlayers: 4,
         });
 
-        expect(result).toBe('new-game-123');
+        expect(result).toBe(newId);
         expect(mockHttpClient.post).toHaveBeenCalledWith(
           '/api/v1/admin/shared-games',
           expect.objectContaining({ title: 'New Game' }),
           expect.any(Object)
         );
+        // The schema passed must accept the bare guid string (root cause of leg 1).
+        const schemaArg = vi.mocked(mockHttpClient.post).mock.calls[0]?.[2] as
+          | { safeParse: (x: unknown) => { success: boolean } }
+          | undefined;
+        expect(schemaArg?.safeParse(newId).success).toBe(true);
       });
     });
 

--- a/apps/web/src/lib/api/clients/sharedGamesClient.ts
+++ b/apps/web/src/lib/api/clients/sharedGamesClient.ts
@@ -345,12 +345,12 @@ export function createSharedGamesClient({ httpClient }: CreateSharedGamesClientP
      * @returns Created game ID
      */
     async create(request: CreateSharedGameRequest): Promise<string> {
-      const result = await httpClient.post<CreatedResponse>(
-        '/api/v1/admin/shared-games',
-        request,
-        CreatedResponseSchema
-      );
-      return result.id;
+      // Issue #2845/#HH (leg 1): POST /admin/shared-games returns a BARE Guid
+      // string (`.Produces<Guid>`), not an object. Validating with
+      // CreatedResponseSchema ({ id }) made the FE reject a successful 201
+      // ("Schema validation failed") → no redirect + duplicate creations.
+      // Validate the bare id string instead.
+      return httpClient.post<string>('/api/v1/admin/shared-games', request, z.string().uuid());
     },
 
     /**


### PR DESCRIPTION
## Finding #HH (part of #2845)

Admin shared-game CRUD was broken on three legs for a **superadmin**
(`admin@meepleai.app`, role `superadmin`).

### Leg 1 — CREATE (schema-validation fail)
`POST /admin/shared-games` returns a **bare Guid** string (`.Produces<Guid>`),
but `sharedGamesClient.create` validated it with `CreatedResponseSchema` ({ id }).
Zod rejected the successful 201 ("Schema validation failed") → no redirect +
repeated creates → duplicates.
**Fix (FE):** validate `z.string().uuid()` and return the id.

### Leg 2 — DETAIL ("Failed to load")
The public `GET /shared-games/{id}` (used by the admin detail page's `getById`)
hid non-Published games from a superadmin — it gated all-status visibility on
`IsInRole("Admin") || IsInRole("Editor")`, false for a superadmin (role claim
"SuperAdmin") → draft/archived → 404.
**Fix (BE):** `IsAdminOrEditor()`.

### Leg 3 — DELETE (202 no-op)
`HandleDeleteGame` chose direct-delete vs Editor-request via `IsInRole("Admin")`,
false for a superadmin → Editor branch → **202 + the game was not deleted**.
**Fix (BE):** `IsAdmin()`.

## Shared helper
New `ClaimsPrincipal.IsAdmin()` (Admin|SuperAdmin) + `IsAdminOrEditor()`
(Admin|SuperAdmin|Editor) — single source of truth for the case-correct role
check (roles are PascalCase per `NormalizeRoleClaim`).

## Tests
- Unit: `ClaimsPrincipalExtensions` across roles.
- Integration (Testcontainers): superadmin `DELETE` → **204 + soft-deleted**
  (was 202 no-op). Verified locally.
- FE unit: `create` returns the bare guid + schema accepts a bare uuid.

## Verification status
- ✅ Unit + Testcontainers integration + FE unit green.
- ⏳ Browser E2E (superadmin create → redirect, open detail, delete → gone) —
  pending the consolidated verify-then-merge sweep (A3-02/03/03b/04/18).
  The reported "405 on `/admin/shared-games/{id}`" will be confirmed there —
  the detail page loads via the public `getById`; leg-2 restores all-status
  visibility for a superadmin.

Part of #2845 (finding #HH). Does not close the umbrella — #FF follows.
