### PR TITLE
fix(toolkit): allow private-game toolkit creation (validator XOR) (#2851)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Validators/ToolkitValidators.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Validators/ToolkitValidators.cs
@@ -9,9 +9,24 @@ internal class CreateToolkitCommandValidator : AbstractValidator<CreateToolkitCo
 {
     public CreateToolkitCommandValidator()
     {
-        RuleFor(x => x.GameId).Must(id => id.HasValue && id.Value != Guid.Empty).WithMessage("GameId is required");
+        // Issue #2851/#Q: a toolkit belongs to EITHER a shared game (GameId) or a
+        // private game (PrivateGameId) — mutually exclusive, matching the
+        // GameToolkit aggregate ctor (#4972). The old rule required GameId always,
+        // so the FE's private-game create ({ privateGameId, name, ... }) failed
+        // with 422 even though the command/handler/entity already support it.
+        RuleFor(x => x)
+            .Must(HasExactlyOneGameReference)
+            .WithMessage("Exactly one of GameId or PrivateGameId is required (mutually exclusive).")
+            .OverridePropertyName(nameof(CreateToolkitCommand.GameId));
         RuleFor(x => x.Name).NotEmpty().MaximumLength(200).WithMessage("Name is required (max 200 chars)");
         RuleFor(x => x.CreatedByUserId).NotEmpty().WithMessage("CreatedByUserId is required");
+    }
+
+    private static bool HasExactlyOneGameReference(CreateToolkitCommand command)
+    {
+        var hasGameId = command.GameId.HasValue && command.GameId.Value != Guid.Empty;
+        var hasPrivateGameId = command.PrivateGameId.HasValue && command.PrivateGameId.Value != Guid.Empty;
+        return hasGameId ^ hasPrivateGameId;
     }
 }
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameToolkit/Application/Validators/ToolkitValidatorTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameToolkit/Application/Validators/ToolkitValidatorTests.cs
@@ -70,6 +70,56 @@ public class ToolkitValidatorTests
         result.ShouldHaveValidationErrorFor(x => x.CreatedByUserId);
     }
 
+    // Issue #2851/#Q: a toolkit belongs to EITHER a shared game (GameId) or a
+    // private game (PrivateGameId), mutually exclusive — matching the GameToolkit
+    // aggregate ctor. The old validator required GameId always, so the FE's
+    // private-game create ({ privateGameId, ... }) failed with 422.
+
+    [Fact]
+    public void CreateToolkit_PrivateGameIdOnly_PassesValidation()
+    {
+        var validator = new CreateToolkitCommandValidator();
+        var command = new CreateToolkitCommand(
+            GameId: null,
+            Name: "Private Toolkit",
+            CreatedByUserId: Guid.NewGuid(),
+            PrivateGameId: Guid.NewGuid());
+
+        var result = validator.TestValidate(command);
+
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void CreateToolkit_BothGameIdAndPrivateGameId_FailsValidation()
+    {
+        var validator = new CreateToolkitCommandValidator();
+        var command = new CreateToolkitCommand(
+            GameId: Guid.NewGuid(),
+            Name: "Toolkit",
+            CreatedByUserId: Guid.NewGuid(),
+            PrivateGameId: Guid.NewGuid());
+
+        var result = validator.TestValidate(command);
+
+        result.ShouldHaveValidationErrorFor(x => x.GameId);
+    }
+
+    [Fact]
+    public void CreateToolkit_NeitherGameIdNorPrivateGameId_FailsValidation()
+    {
+        var validator = new CreateToolkitCommandValidator();
+        var command = new CreateToolkitCommand(
+            GameId: null,
+            Name: "Toolkit",
+            CreatedByUserId: Guid.NewGuid(),
+            PrivateGameId: null);
+
+        var result = validator.TestValidate(command);
+
+        result.ShouldHaveValidationErrorFor(x => x.GameId);
+    }
+
     // ========================================================================
     // UpdateToolkitCommandValidator
     // ========================================================================


### PR DESCRIPTION
## Finding #Q (Closes #2851)

Creating a toolkit for a **private game** from the UI failed with **422
"GameId is required"**. `usePrivateToolkitEditor.createToolkit` posts
`{ privateGameId, name, overrides }` to `POST /api/v1/game-toolkits/`.

**Root cause:** the whole chain already supports private-game toolkits — the
endpoint binds `PrivateGameId`, `CreateToolkitCommand` carries it, the handler
passes it through + saves, the `GameToolkit` aggregate ctor (#4972) takes
exactly one of `gameId`/`privateGameId`, and `GameToolkitEntity` has both
nullable columns. **Only the validator was stale:** it required `GameId`
unconditionally. (Passing `gameId = privateGameId` then hit the aggregate's
mutual-exclusivity guard → 400.)

## Fix

`CreateToolkitCommandValidator` now requires **exactly one** of `GameId` /
`PrivateGameId` (XOR), matching the aggregate. The error stays reported under
`GameId` so existing empty-GameId coverage holds. No FE change needed — the FE
already sends the right payload.

## Tests

- private-game-only create **passes** (was the 422)
- both-set / neither-set **fail**
- existing shared-game create + all other ToolkitValidator cases stay green (37).

## Verification status

- ✅ Validator unit tests green.
- ⏳ Browser E2E (create a toolkit from a private game → succeeds) — pending the
  consolidated verify-then-merge sweep (U3-09).

Closes #2851.
