### PR TITLE
fix(play-records): persist roster, scores and location on create (#2847)

### DIFF
--- a/apps/web/src/app/(authenticated)/play-records/new/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/play-records/new/page.test.tsx
@@ -26,15 +26,36 @@ vi.mock('next/navigation', async orig => ({
 
 // ─── SessionCreateForm — capture props ────────────────────────────────────────
 
-const captured: { initialValues?: unknown; initialPlayers?: unknown } = {};
+const captured: {
+  initialValues?: unknown;
+  initialPlayers?: unknown;
+  onSubmit?: (data: unknown, players: unknown) => unknown;
+} = {};
 
 vi.mock('@/components/play-records/SessionCreateForm', () => ({
   SessionCreateForm: (props: any) => {
     captured.initialValues = props.initialValues;
     captured.initialPlayers = props.initialPlayers;
+    captured.onSubmit = props.onSubmit;
     return <div data-testid="mock-form" />;
   },
   // PlayerEntry is a type-only import — erased at runtime, no mock needed.
+}));
+
+// ─── playRecordsApi — #2847 (#BB) orchestration ───────────────────────────────
+
+const mockAddPlayer = vi.fn().mockResolvedValue(undefined);
+const mockRecordScore = vi.fn().mockResolvedValue(undefined);
+const mockUpdateRecord = vi.fn().mockResolvedValue(undefined);
+const mockGetRecord = vi.fn();
+
+vi.mock('@/lib/api/play-records.api', () => ({
+  playRecordsApi: {
+    addPlayer: (...args: unknown[]) => mockAddPlayer(...args),
+    recordScore: (...args: unknown[]) => mockRecordScore(...args),
+    updateRecord: (...args: unknown[]) => mockUpdateRecord(...args),
+    getRecord: (...args: unknown[]) => mockGetRecord(...args),
+  },
 }));
 
 // ─── useGameNightPrefill — fixed prefill ──────────────────────────────────────
@@ -53,9 +74,11 @@ vi.mock('@/lib/domain-hooks/useGameNightPrefill', () => ({
 
 // ─── Remaining hooks ──────────────────────────────────────────────────────────
 
+const mockCreateMutate = vi.fn().mockResolvedValue('rec-1');
+
 vi.mock('@/lib/domain-hooks/usePlayRecords', () => ({
   useCreatePlayRecord: () => ({
-    mutateAsync: vi.fn(),
+    mutateAsync: (...args: unknown[]) => mockCreateMutate(...args),
     isPending: false,
   }),
 }));
@@ -98,5 +121,57 @@ describe('NewPlayRecordPage — gameNightId prefill', () => {
       location: 'Padova',
     });
     expect(captured.initialPlayers).toEqual([]);
+  });
+});
+
+describe('NewPlayRecordPage — persists roster/scores/location (#2847 #BB)', () => {
+  it('creates the record then adds players, records scores and saves the location', async () => {
+    mockCreateMutate.mockClear();
+    mockAddPlayer.mockClear();
+    mockRecordScore.mockClear();
+    mockUpdateRecord.mockClear();
+    mockGetRecord.mockClear();
+    // After the players are added, the record exposes their server-assigned ids.
+    mockGetRecord.mockResolvedValue({
+      players: [{ id: 'srv-marco', displayName: 'Marco' }],
+    });
+
+    renderPage();
+    await screen.findByTestId('mock-form');
+
+    const data = {
+      gameType: 'catalog',
+      gameId: undefined,
+      gameName: 'Azul',
+      sessionDate: new Date('2026-07-12T10:00:00.000Z'),
+      visibility: 'private',
+      enableScoring: true,
+      scoringDimensions: ['points'],
+      dimensionUnits: {},
+      notes: '',
+      location: 'HP-TEST location',
+    };
+    const players = [{ id: 'p1', name: 'Marco', score: '42' }];
+
+    await captured.onSubmit!(data, players);
+
+    // Base record created with the wizard's core fields.
+    expect(mockCreateMutate).toHaveBeenCalledWith(
+      expect.objectContaining({ gameName: 'Azul', scoringDimensions: ['points'] })
+    );
+    // Roster persisted.
+    expect(mockAddPlayer).toHaveBeenCalledWith('rec-1', { displayName: 'Marco' });
+    // Score persisted against the re-fetched player id.
+    expect(mockGetRecord).toHaveBeenCalledWith('rec-1');
+    expect(mockRecordScore).toHaveBeenCalledWith('rec-1', {
+      playerId: 'srv-marco',
+      dimension: 'points',
+      value: 42,
+      unit: undefined,
+    });
+    // Location persisted (not part of CreatePlayRecordRequest).
+    expect(mockUpdateRecord).toHaveBeenCalledWith('rec-1', { location: 'HP-TEST location' });
+    // Navigates to the created record.
+    expect(mockRouterPush).toHaveBeenCalledWith('/play-records/rec-1');
   });
 });

--- a/apps/web/src/app/(authenticated)/play-records/new/page.tsx
+++ b/apps/web/src/app/(authenticated)/play-records/new/page.tsx
@@ -21,16 +21,17 @@
 
 'use client';
 
-import { Suspense } from 'react';
+import { Suspense, useState } from 'react';
 
 import { ArrowLeft } from 'lucide-react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { toast } from 'sonner';
 
 import { FormPageContainer } from '@/components/layout/PageContainer';
-import { SessionCreateForm } from '@/components/play-records/SessionCreateForm';
+import { SessionCreateForm, type PlayerEntry } from '@/components/play-records/SessionCreateForm';
 import { Button } from '@/components/ui/primitives/button';
 import { useTranslation } from '@/hooks/useTranslation';
+import { playRecordsApi } from '@/lib/api/play-records.api';
 import type { SessionCreateForm as SessionFormData } from '@/lib/api/schemas/play-records.schemas';
 import { useGameNightPrefill } from '@/lib/domain-hooks/useGameNightPrefill';
 import { useCreatePlayRecord } from '@/lib/domain-hooks/usePlayRecords';
@@ -42,8 +43,18 @@ function NewPlayRecordContent() {
   const searchParams = useSearchParams();
   const gameNightId = searchParams.get('gameNightId');
   const { prefill, isLoading } = useGameNightPrefill(gameNightId);
+  // #2847 (#BB): the roster is persisted after create via extra calls, which are
+  // not part of the create mutation — track our own saving flag so the wizard
+  // stays disabled for the whole sequence.
+  const [isSaving, setIsSaving] = useState(false);
 
-  const handleSubmit = async (data: SessionFormData) => {
+  // Issue #2847 (#BB): the create wizard collected players, per-player scores and
+  // a location, but the submit only sent the base CreatePlayRecordRequest — the
+  // record persisted empty ("Planned", players:[], location:null). CreatePlayRecord
+  // does not accept players/scores/location, so persist them with the dedicated
+  // follow-up endpoints (addPlayer / recordScore / update) after the record exists.
+  const handleSubmit = async (data: SessionFormData, players: PlayerEntry[]) => {
+    setIsSaving(true);
     try {
       const recordId = await createRecord.mutateAsync({
         gameId: data.gameId,
@@ -55,6 +66,39 @@ function NewPlayRecordContent() {
         dimensionUnits: data.enableScoring ? data.dimensionUnits : undefined,
       });
 
+      // Persist the roster. addPlayer returns 204 (no id), so re-fetch afterwards
+      // to resolve the created player ids before recording scores.
+      for (const player of players) {
+        await playRecordsApi.addPlayer(recordId, { displayName: player.name });
+      }
+
+      // Per-player score → first scoring dimension (or "points"). Only when
+      // scoring is enabled and a numeric value was entered.
+      const scoredPlayers = players.filter(
+        p => p.score.trim() !== '' && !Number.isNaN(Number(p.score))
+      );
+      if (data.enableScoring && scoredPlayers.length > 0) {
+        const dimension = data.scoringDimensions?.[0] ?? 'points';
+        const unit = data.dimensionUnits?.[dimension];
+        const record = await playRecordsApi.getRecord(recordId);
+        for (const player of scoredPlayers) {
+          const persisted = record.players.find(rp => rp.displayName === player.name);
+          if (!persisted) continue;
+          await playRecordsApi.recordScore(recordId, {
+            playerId: persisted.id,
+            dimension,
+            value: Number(player.score),
+            unit,
+          });
+        }
+      }
+
+      // Location is not part of CreatePlayRecordRequest — persist it via update.
+      const location = data.location?.trim();
+      if (location) {
+        await playRecordsApi.updateRecord(recordId, { location });
+      }
+
       toast.success(t('playRecords.new.success.toast'), {
         description: t('playRecords.new.success.toastDescription'),
       });
@@ -65,6 +109,8 @@ function NewPlayRecordContent() {
         description:
           error instanceof Error ? error.message : t('playRecords.new.error.saveFailedDescription'),
       });
+    } finally {
+      setIsSaving(false);
     }
   };
 
@@ -108,7 +154,7 @@ function NewPlayRecordContent() {
         initialPlayers={prefill?.initialPlayers}
         onSubmit={handleSubmit}
         onCancel={handleCancel}
-        isSubmitting={createRecord.isPending}
+        isSubmitting={createRecord.isPending || isSaving}
       />
     </FormPageContainer>
   );

--- a/apps/web/src/components/play-records/SessionCreateForm.tsx
+++ b/apps/web/src/components/play-records/SessionCreateForm.tsx
@@ -51,7 +51,14 @@ import { GameCombobox } from './GameCombobox';
 // ─── Types ────────────────────────────────────────────────────────────────────
 
 export interface SessionCreateFormProps {
-  onSubmit: (data: SessionCreateFormData) => void;
+  /**
+   * Called on final submit. Issue #2847 (#BB): the roster (`players`) lives in
+   * component state (not a react-hook-form field), so it is passed as a second
+   * argument — the create flow persists players + their scores + location, which
+   * the form-data alone omitted. `onSubmit` may be async; the form waits for it
+   * before clearing the draft/state so a failed create keeps the entered data.
+   */
+  onSubmit: (data: SessionCreateFormData, players: PlayerEntry[]) => void | Promise<void>;
   onCancel?: () => void;
   isSubmitting?: boolean;
   /**
@@ -776,8 +783,11 @@ export function SessionCreateForm({
     onCancel?.();
   };
 
-  const handleFormSubmit = form.handleSubmit(data => {
-    onSubmit(data);
+  const handleFormSubmit = form.handleSubmit(async data => {
+    // Issue #2847 (#BB): pass the roster so the create flow can persist players +
+    // scores + location. Await the (possibly async) submit BEFORE clearing so a
+    // failed create leaves the entered data intact for a retry.
+    await onSubmit(data, players);
     clear();
     resetSessionCreation();
     form.reset();


### PR DESCRIPTION
## Finding #BB (Closes #2847)

The create wizard (`/play-records/new`) collected players, per-player scores and
a location, but the submit persisted an **empty** record — status "Planned",
`players:[]`, `location:null` — silently losing everything entered (the 2xx +
success toast were a false positive).

**Root cause (two gaps):**
- `SessionCreateForm.handleFormSubmit` passed only the react-hook-form `data` to
  `onSubmit`; the roster lives in component state (`players`), so it never
  reached the parent.
- The parent only called `create()`, and `CreatePlayRecordRequest` does **not**
  accept players/scores/location — those have dedicated follow-up endpoints
  (`addPlayer`, `recordScore`, `update`).

## Fix

- `SessionCreateForm` now passes `players` as a second `onSubmit` argument and
  **awaits** the (async) submit before clearing, so a failed create keeps the
  entered data for a retry. (Backward-compatible: the edit page ignores the arg.)
- The create page orchestrates the full sequence:
  `create → addPlayer per player → re-fetch to resolve server-assigned player ids
  → recordScore (single score → first scoring dimension, or "points") →
  update(location)`. A saving flag keeps the wizard disabled for the whole run.

## Tests

New page test drives `onSubmit` with a player + score + location and asserts
`addPlayer` / `getRecord` / `recordScore` / `update` are all called with the
right data (pre-fix only `create` ran). `SessionCreateForm` + edit-page suites
stay green (contract change is backward-compatible).

## Verification status

- ✅ Vitest orchestration test green.
- ⏳ Browser E2E (create with 1 player + score + location → `GET
  /play-records/{id}` has players + location) — pending the consolidated
  verify-then-merge sweep (U6-13/U6-28).

## Follow-up (out of scope)

The record is left in **"Planned"** status. Whether the wizard should
auto-start/complete it (and how to compute duration for a past game) is a
separate design decision — flagged for a follow-up. This PR stops the data loss.

Closes #2847.
