### PR TITLE
test(rag): #2884 mock GetByGameIdAsync in StreamQaQueryHandlerTests

### DIFF
--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/StreamQaQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/StreamQaQueryHandlerTests.cs
@@ -94,6 +94,14 @@ public class StreamQaQueryHandlerTests
         _fakeTimeProvider = new FakeTimeProvider();
         _fakeTimeProvider.SetUtcNow(new DateTimeOffset(2024, 1, 1, 12, 0, 0, TimeSpan.Zero));
 
+        // Issue #2884: PR #2833 added GetByGameIdAsync in PerformSearchAndBuildCitationsAsync to
+        // resolve VectorDocumentId -> PdfDocumentId for citations. Default to an empty list so
+        // citation building falls back to the vector id (pre-#2833 behavior) instead of throwing
+        // ArgumentNullException on ToDictionary(null) when the mock is otherwise unconfigured.
+        _vectorDocumentRepositoryMock
+            .Setup(x => x.GetByGameIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<VectorDocument>());
+
         _handler = new StreamQaQueryHandler(
             _searchQueryHandler,
             _rerankerMock.Object,


### PR DESCRIPTION
## Problema (baseline-red #2884)

PR #2833 (`2c54205d6`) ha aggiunto in `StreamQaQueryHandler.PerformSearchAndBuildCitationsAsync` (`StreamQaQueryHandler.cs:326-328`) una chiamata:

```csharp
var vectorDocs = await _vectorDocumentRepository.GetByGameIdAsync(Guid.Parse(gameId), ct);
var pdfIdByVectorId = vectorDocs.ToDictionary(v => v.Id, v => v.PdfDocumentId);
```

…senza configurare il mock in `StreamQaQueryHandlerTests`. Moq (DefaultValue.Loose) ritorna `null` → `null.ToDictionary(...)` lancia `ArgumentNullException (Parameter 'source')`, facendo fallire **11 unit test** in modo deterministico sul job CI `Backend Fast (build + unit)`.

## Root cause

Solo un **mock gap nel test**, non un bug di produzione: l'implementazione reale (`VectorDocumentRepository.cs:56`) fa `entities.Select(...).ToList()` e **non ritorna mai null**.

## Fix

Aggiunto un mock di default per `GetByGameIdAsync` nel **costruttore** del test (setup globale, come il default passthrough di `_rerankerMock`), così tutti gli 11 test lo ereditano — solo 3 passano da `SetupHappyPathMocks`, quindi il fix va nel costruttore.

Lista vuota di default → citation building fa fallback a `VectorDocumentId`, identico al comportamento pre-#2833 ⇒ le asserzioni esistenti restano valide.

**Nessun null-guard di produzione aggiunto**: il contratto del repo non ritorna mai null; un `(vectorDocs ?? [])` maschererebbe future violazioni del contratto invece di farle emergere.

## Verifica

```
dotnet test --filter "FullyQualifiedName~StreamQaQueryHandlerTests"
Superato! - Non superati: 0. Superati: 23. Totale: 23.
```

Gli 11 test prima rossi ora verdi; nessuno degli altri 12 test della classe si è rotto.

Closes #2884

🤖 Generated with [Claude Code](https://claude.com/claude-code)