### PR TITLE
fix: happy-path follow-ups — seed UTF-8 corruption + play-record wizard premature submit

### DIFF
--- a/apps/web/src/components/play-records/SessionCreateForm.tsx
+++ b/apps/web/src/components/play-records/SessionCreateForm.tsx
@@ -742,7 +742,11 @@ export function SessionCreateForm({
       location: initialDraft.location ?? '',
     });
     setPlayers(initialDraft.players);
-    setSessionField('currentStep', initialDraft.currentStep);
+    // Clamp the restored step to a valid index — a corrupted/stale draft must
+    // never open the wizard on an out-of-range step (broken StepIndicator +
+    // undefined STEP_FIELDS).
+    const restoredStep = Math.min(Math.max(initialDraft.currentStep, 0), STEP_COUNT - 1);
+    setSessionField('currentStep', restoredStep);
     // eslint-disable-next-line react-hooks/exhaustive-deps -- mount-once restore
   }, []);
 

--- a/apps/web/src/components/play-records/SessionCreateForm.tsx
+++ b/apps/web/src/components/play-records/SessionCreateForm.tsx
@@ -788,6 +788,16 @@ export function SessionCreateForm({
   };
 
   const handleFormSubmit = form.handleSubmit(async data => {
+    // Premature-submit guard: the record must ONLY be created from the final step
+    // (Punteggi). A create wizard can submit before the last step when an async
+    // re-render swaps the type="button" "Avanti" control for the type="submit"
+    // "Salva" control mid-interaction — that would create an empty record
+    // (status "Planned", players:[]) and navigate away, silently losing the
+    // roster. When the form submits early, advance instead of creating.
+    if (currentStep < STEP_COUNT - 1) {
+      nextStep();
+      return;
+    }
     // Issue #2847 (#BB): pass the roster so the create flow can persist players +
     // scores + location. Await the (possibly async) submit BEFORE clearing so a
     // failed create leaves the entered data intact for a retry.

--- a/apps/web/src/components/play-records/__tests__/SessionCreateForm.draft.test.tsx
+++ b/apps/web/src/components/play-records/__tests__/SessionCreateForm.draft.test.tsx
@@ -78,6 +78,35 @@ describe('SessionCreateForm — draft persistence wiring', () => {
     expect(mockSetSessionField).toHaveBeenCalledWith('currentStep', 1);
   });
 
+  it('clamps an out-of-range restored draft step to the last valid step (2)', () => {
+    // A corrupted/stale draft must never open the wizard on an invalid step
+    // index (would render a broken StepIndicator + undefined STEP_FIELDS).
+    mockCurrentStep = 0;
+    localStorage.setItem(
+      KEY,
+      JSON.stringify({
+        savedAt: Date.now(),
+        draft: {
+          schemaVersion: PLAY_RECORD_DRAFT_SCHEMA_VERSION,
+          currentStep: 99, // out of range
+          gameType: 'catalog',
+          gameName: 'Catan',
+          sessionDate: '2026-06-19T10:00:00.000Z',
+          visibility: 'Private',
+          enableScoring: false,
+          scoringDimensions: [],
+          dimensionUnits: {},
+          notes: '',
+          location: 'Verona',
+          players: [],
+        },
+      })
+    );
+    render(<SessionCreateForm {...props} />, { wrapper: wrapper() });
+    expect(mockSetSessionField).toHaveBeenCalledWith('currentStep', 2);
+    expect(mockSetSessionField).not.toHaveBeenCalledWith('currentStep', 99);
+  });
+
   it('AC-A3: does NOT restore when initialValues (gameNight prefill) is present', () => {
     mockCurrentStep = 1;
     localStorage.setItem(

--- a/apps/web/src/components/play-records/__tests__/SessionCreateForm.test.tsx
+++ b/apps/web/src/components/play-records/__tests__/SessionCreateForm.test.tsx
@@ -323,6 +323,45 @@ describe('SessionCreateForm — wizard 3-step', () => {
     });
   });
 
+  // ── Premature-submit guard ──────────────────────────────────────────────────
+  describe('Premature-submit guard', () => {
+    it('does NOT create a record when the form submits before the final step', async () => {
+      // Simulates a stray submit at Step 2 (Quando) — e.g. an async re-render
+      // swapping "Avanti" (type=button) for "Salva" (type=submit) mid-click.
+      // The record must NOT be created (would lose the roster); the wizard
+      // advances instead.
+      mockCurrentStep = 1;
+      const onSubmit = vi.fn();
+      const { container } = render(<SessionCreateForm {...defaultProps} onSubmit={onSubmit} />, {
+        wrapper: createWrapper(),
+      });
+
+      const form = container.querySelector('form');
+      expect(form).not.toBeNull();
+      fireEvent.submit(form as HTMLFormElement);
+
+      // handleSubmit validates asynchronously — wait for the guard to advance.
+      await waitFor(() => {
+        expect(mockNextStep).toHaveBeenCalled();
+      });
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
+
+    it('creates the record when the form submits on the final step (Punteggi)', async () => {
+      mockCurrentStep = 2;
+      const onSubmit = vi.fn();
+      const { container } = render(<SessionCreateForm {...defaultProps} onSubmit={onSubmit} />, {
+        wrapper: createWrapper(),
+      });
+
+      fireEvent.submit(container.querySelector('form') as HTMLFormElement);
+
+      await waitFor(() => {
+        expect(onSubmit).toHaveBeenCalled();
+      });
+    });
+  });
+
   // ── AC-3.7: Validation gate ─────────────────────────────────────────────────
   describe('AC-3.7: Validation gate — "Avanti" disabled when step invalid', () => {
     it('renders a next/continue button on step 1', () => {

--- a/apps/web/src/lib/stores/__tests__/play-records-store.test.ts
+++ b/apps/web/src/lib/stores/__tests__/play-records-store.test.ts
@@ -1,0 +1,54 @@
+/**
+ * play-records-store — wizard step navigation (nextStep / prevStep).
+ *
+ * The create wizard has 3 steps (Gioco / Quando / Punteggi), so the valid
+ * 0-indexed range for `currentStep` is [0, 2]. `nextStep` must cap at the last
+ * step index (2), never the out-of-range index 3 — otherwise the wizard renders
+ * a broken state (StepIndicator shows all steps "done" with none active, and
+ * `STEP_FIELDS[3]` is undefined). Regression guard for the off-by-one cap.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+
+import { usePlayRecordsStore } from '../play-records-store';
+
+describe('play-records-store — wizard step navigation', () => {
+  beforeEach(() => {
+    usePlayRecordsStore.getState().resetSessionCreation();
+  });
+
+  it('nextStep advances through the 3 steps and caps at the last index (2)', () => {
+    const store = usePlayRecordsStore;
+    expect(store.getState().sessionCreation.currentStep).toBe(0);
+
+    store.getState().nextStep(); // 0 → 1 (Quando)
+    expect(store.getState().sessionCreation.currentStep).toBe(1);
+
+    store.getState().nextStep(); // 1 → 2 (Punteggi — last step)
+    expect(store.getState().sessionCreation.currentStep).toBe(2);
+
+    store.getState().nextStep(); // 2 → 2 (capped; MUST NOT reach out-of-range 3)
+    expect(store.getState().sessionCreation.currentStep).toBe(2);
+  });
+
+  it('prevStep decrements and clamps at 0', () => {
+    const store = usePlayRecordsStore;
+    store.getState().nextStep();
+    store.getState().nextStep();
+    expect(store.getState().sessionCreation.currentStep).toBe(2);
+
+    store.getState().prevStep(); // 2 → 1
+    store.getState().prevStep(); // 1 → 0
+    store.getState().prevStep(); // 0 → 0 (clamped)
+    expect(store.getState().sessionCreation.currentStep).toBe(0);
+  });
+
+  it('resetSessionCreation returns the wizard to step 0', () => {
+    const store = usePlayRecordsStore;
+    store.getState().nextStep();
+    store.getState().nextStep();
+    expect(store.getState().sessionCreation.currentStep).toBe(2);
+
+    store.getState().resetSessionCreation();
+    expect(store.getState().sessionCreation.currentStep).toBe(0);
+  });
+});

--- a/apps/web/src/lib/stores/play-records-store.ts
+++ b/apps/web/src/lib/stores/play-records-store.ts
@@ -12,7 +12,10 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
-import type { PlayRecordStatus, PlayRecordVisibility } from '@/lib/api/schemas/play-records.schemas';
+import type {
+  PlayRecordStatus,
+  PlayRecordVisibility,
+} from '@/lib/api/schemas/play-records.schemas';
 
 // ========== State Interfaces ==========
 
@@ -52,10 +55,7 @@ export interface PlayRecordsStoreState {
 
   // Play History Filters
   filters: PlayHistoryFilters;
-  setFilter: <K extends keyof PlayHistoryFilters>(
-    field: K,
-    value: PlayHistoryFilters[K]
-  ) => void;
+  setFilter: <K extends keyof PlayHistoryFilters>(field: K, value: PlayHistoryFilters[K]) => void;
   resetFilters: () => void;
 
   // View Preferences
@@ -68,6 +68,10 @@ export interface PlayRecordsStoreState {
 }
 
 // ========== Default State ==========
+
+// The create wizard has 3 steps (Gioco / Quando / Punteggi), so the last valid
+// 0-indexed step is 2. `nextStep` must cap here — never the out-of-range index 3.
+const WIZARD_LAST_STEP_INDEX = 2;
 
 const DEFAULT_SESSION_CREATION: SessionCreationState = {
   currentStep: 0,
@@ -89,12 +93,12 @@ const DEFAULT_FILTERS: PlayHistoryFilters = {
 
 export const usePlayRecordsStore = create<PlayRecordsStoreState>()(
   persist(
-    (set) => ({
+    set => ({
       // Session Creation State
       sessionCreation: DEFAULT_SESSION_CREATION,
 
       setSessionField: (field, value) =>
-        set((state) => ({
+        set(state => ({
           sessionCreation: {
             ...state.sessionCreation,
             [field]: value,
@@ -102,15 +106,15 @@ export const usePlayRecordsStore = create<PlayRecordsStoreState>()(
         })),
 
       nextStep: () =>
-        set((state) => ({
+        set(state => ({
           sessionCreation: {
             ...state.sessionCreation,
-            currentStep: Math.min(state.sessionCreation.currentStep + 1, 3),
+            currentStep: Math.min(state.sessionCreation.currentStep + 1, WIZARD_LAST_STEP_INDEX),
           },
         })),
 
       prevStep: () =>
-        set((state) => ({
+        set(state => ({
           sessionCreation: {
             ...state.sessionCreation,
             currentStep: Math.max(state.sessionCreation.currentStep - 1, 0),
@@ -126,7 +130,7 @@ export const usePlayRecordsStore = create<PlayRecordsStoreState>()(
       filters: DEFAULT_FILTERS,
 
       setFilter: (field, value) =>
-        set((state) => ({
+        set(state => ({
           filters: {
             ...state.filters,
             [field]: value,
@@ -143,14 +147,14 @@ export const usePlayRecordsStore = create<PlayRecordsStoreState>()(
       sortBy: 'recent',
       sidebarOpen: true,
 
-      setViewMode: (viewMode) => set({ viewMode }),
-      setSortBy: (sortBy) => set({ sortBy }),
-      toggleSidebar: () => set((state) => ({ sidebarOpen: !state.sidebarOpen })),
+      setViewMode: viewMode => set({ viewMode }),
+      setSortBy: sortBy => set({ sortBy }),
+      toggleSidebar: () => set(state => ({ sidebarOpen: !state.sidebarOpen })),
     }),
     {
       name: 'play-records-storage',
       // Only persist view preferences, not active filters or creation state
-      partialize: (state) => ({
+      partialize: state => ({
         viewMode: state.viewMode,
         sortBy: state.sortBy,
         sidebarOpen: state.sidebarOpen,

--- a/infra/scripts/seed-sp4/lib/common.sh
+++ b/infra/scripts/seed-sp4/lib/common.sh
@@ -82,8 +82,17 @@ curl_json() {
   local method="$1" path="$2" jar="$3" data="${4:-}"
   local args=(-sS -X "$method" -H "Content-Type: application/json" -b "$jar" -c "$jar"
               -w "\n%{http_code}" "$API_BASE$path")
-  if [[ -n "$data" ]]; then args+=(-d "$data"); fi
-  curl "${args[@]}"
+  # Send the body via stdin (--data-binary @-), NOT as a `-d "$data"` argv arg.
+  # On Git Bash/MSYS (Windows) the native curl.exe re-encodes command-line args
+  # at the argv boundary, corrupting multibyte UTF-8 (e.g. accented designer
+  # names like "Vlaada Chvátil"). The API then receives invalid UTF-8 and rejects
+  # the body with HTTP 400 ("could not be converted to System.String").
+  # stdin bypasses argv re-encoding, so the exact bytes reach the server.
+  if [[ -n "$data" ]]; then
+    printf '%s' "$data" | curl "${args[@]}" --data-binary @-
+  else
+    curl "${args[@]}"
+  fi
 }
 
 # curl_get PATH COOKIE_JAR  →  body + code


### PR DESCRIPTION
Risolve i 2 follow-up emersi durante la verifica dell'happy-path testing program (#2845–#2851).

## Follow-up 1 — Wizard play-record: submit prematuro / "Punteggi non raggiungibile"

**Riprodotto in browser** (systematic-debugging): cliccando "Avanti" sullo Step 2 (Quando) il wizard poteva **creare il record e navigare al detail con roster vuoto** (status "Planned", 0 giocatori) invece di avanzare allo Step 3 (Punteggi) — perdendo silenziosamente giocatori/punteggi. Il flusso pulito 0→1→2 è corretto e **Step 3 È raggiungibile** (confermato via walk JS 0→1→2→3); il submit prematuro è una **race intermittente** dove un re-render async scambia il controllo `type="button"` "Avanti" con il `type="submit"` "Salva" a metà interazione, facendo partire un submit prima dell'ultimo step.

Tre fix (defense-in-depth):
1. **Guard submit** (`SessionCreateForm.handleFormSubmit`): un submit prima dell'ultimo step avanza il wizard invece di creare il record. Il record si crea **solo** dallo Step 3 (Punteggi), dove "Salva" è l'unico controllo renderizzato — in create **e** edit.
2. **Off-by-one cap** (`play-records-store.nextStep`): `Math.min(…, 3)` → `Math.min(…, 2)` (l'ultimo indice valido su 3 step 0-indexed è 2).
3. **Clamp draft step**: il restore del draft impostava `currentStep` senza clamp → un draft corrotto/stale poteva aprire uno step invalido. Ora clampato a `[0, STEP_COUNT-1]`.

Test aggiunti: guard (submit pre-final → `onSubmit` non chiamato, avanza; submit finale → crea), store nav (nextStep cap a 2, prevStep clamp a 0, reset→0), clamp draft (step out-of-range → 2). 247 test play-records verdi.

## Follow-up 2 — Seed `20-games`: corruzione UTF-8 multibyte

`make seed-sp4` falliva su codenames/carcassonne con **HTTP 400** (`The JSON value could not be converted to System.String. Path: $.designers[0]`), abortendo l'intero seed (bloccando library/private-games/records). Root cause: su Git Bash/MSYS (Windows) il `curl.exe` nativo **ri-codifica gli argomenti argv** al confine, corrompendo l'UTF-8 multibyte nel body JSON (nomi designer accentati come "Vlaada Chvátil"). L'API riceveva UTF-8 non valido e rifiutava.

`curl_json` ora passa il body via **stdin** (`--data-binary @-`) invece che come argomento `-d "$data"`. stdin bypassa la ri-codifica argv → i byte esatti arrivano al server. **Verificato live**: test A/B (`-d` arg → 400; stdin → 201); dopo il fix codenames + carcassonne si creano (201), step `20-games` completa con `failed=0`.

## Verifica
- ✅ Test unit: 247 play-records + store + guard verdi; typecheck pulito.
- ✅ Seed: verificato live (201, `failed=0`) sul container in esecuzione.
- ✅ Browser: Step 3 (Punteggi) raggiungibile via walk pulito; artefatti di test rimossi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)