### PR TITLE
refactor(meeple-card): consolidate status-mapping + disambiguate connection builders (#2860)

### DIFF
--- a/apps/web/src/components/agent/AgentCharacterSheet.tsx
+++ b/apps/web/src/components/agent/AgentCharacterSheet.tsx
@@ -26,7 +26,10 @@ import { useRouter } from 'next/navigation';
 
 import { ChatThreadView } from '@/components/chat-unified/ChatThreadView';
 import { AgentStatusBadge } from '@/components/ui/agent/AgentStatusBadge';
-import { ConnectionBar, buildAgentConnections } from '@/components/ui/data-display/connection-bar';
+import {
+  ConnectionBar,
+  buildAgentConnectionPips,
+} from '@/components/ui/data-display/connection-bar';
 import { KbStatusBadge } from '@/components/ui/data-display/extra-meeple-card/badge-stubs';
 import { Button } from '@/components/ui/primitives/button';
 import { useAgentKbDocs, useAgentThreads } from '@/hooks/queries/useAgentData';
@@ -73,7 +76,7 @@ export const AgentCharacterSheet = React.memo(function AgentCharacterSheet({
   const agentConnections =
     docsLoading || threadsLoading
       ? []
-      : buildAgentConnections({
+      : buildAgentConnectionPips({
           gameCount: data.gameId ? 1 : 0,
           kbCount: docs.length,
           chatCount: threads.length,

--- a/apps/web/src/components/agent/__tests__/AgentCharacterSheet.test.tsx
+++ b/apps/web/src/components/agent/__tests__/AgentCharacterSheet.test.tsx
@@ -18,7 +18,7 @@ vi.mock('@/hooks/useConnectionBarNav', () => ({
 vi.mock('@/components/ui/data-display/connection-bar', () => ({
   ConnectionBar: ({ connections }: { connections: Array<unknown> }) =>
     connections.length > 0 ? <div data-testid="connection-bar" /> : null,
-  buildAgentConnections: () => [{ count: 1 }], // always returns non-empty (real impl always returns 3 pips)
+  buildAgentConnectionPips: () => [{ count: 1 }], // always returns non-empty (real impl always returns 3 pips)
 }));
 vi.mock('@/components/chat-unified/ChatThreadView', () => ({
   ChatThreadView: () => <div data-testid="chat-thread-view" />,

--- a/apps/web/src/components/game-detail/GameDetailDesktop.tsx
+++ b/apps/web/src/components/game-detail/GameDetailDesktop.tsx
@@ -5,7 +5,10 @@ import { useState } from 'react';
 import { CustomCoverDialog } from '@/components/features/library/custom-cover/CustomCoverDialog';
 import { EditCoverOverlay } from '@/components/features/library/custom-cover/EditCoverOverlay';
 import { SessionContributorsStrip } from '@/components/features/library/SessionContributorsStrip';
-import { ConnectionBar, buildGameConnections } from '@/components/ui/data-display/connection-bar';
+import {
+  ConnectionBar,
+  buildGameConnectionPips,
+} from '@/components/ui/data-display/connection-bar';
 import type { MeepleCardMetadata } from '@/components/ui/data-display/meeple-card/types';
 import { useGameSessionContributors } from '@/hooks/queries/useGameSessionContributors';
 import { useLibraryGameDetail } from '@/hooks/queries/useLibrary';
@@ -116,7 +119,7 @@ export function GameDetailDesktop({
   // threads for the game. Both default to 0 when the BE field is undefined
   // (legacy response shapes).
   const gameConnections = game
-    ? buildGameConnections({
+    ? buildGameConnectionPips({
         agentCount: game.agentCount ?? 0,
         kbCount: game.hasCustomPdf || game.hasRagAccess ? 1 : 0,
         chatCount: game.chatThreadCount ?? 0,

--- a/apps/web/src/components/game-detail/__tests__/GameDetailDesktop.test.tsx
+++ b/apps/web/src/components/game-detail/__tests__/GameDetailDesktop.test.tsx
@@ -50,7 +50,7 @@ vi.mock('@/hooks/useConnectionBarNav', () => ({
 vi.mock('@/components/ui/data-display/connection-bar', () => ({
   ConnectionBar: ({ connections }: { connections: Array<{ count: number }> }) =>
     connections.length > 0 ? <div data-testid="connection-bar" /> : null,
-  buildGameConnections: (counts: Record<string, number>) =>
+  buildGameConnectionPips: (counts: Record<string, number>) =>
     Object.values(counts).some(v => v > 0) ? [{ count: 1 }] : [],
 }));
 

--- a/apps/web/src/components/library/kb-utils.ts
+++ b/apps/web/src/components/library/kb-utils.ts
@@ -3,6 +3,8 @@
  * Extracted from meeple-info-card.tsx for reuse in KbDrawerSheet and GameBackContent.
  */
 
+import { mapProcessingStateToDisplayStatus } from '@/lib/kb/processing-status';
+
 export function formatFileSize(bytes: number): string {
   if (bytes < 1024) return bytes + ' B';
   if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + ' KB';
@@ -50,31 +52,14 @@ export function getDocumentStatus(doc: {
 }
 
 /**
- * Map processingState (PascalCase) to DocumentIndexingStatus for MeepleCard kbCards prop.
+ * Map processingState (PascalCase) or processingStatus to KbDisplayStatus for
+ * MeepleCard kbCards prop (#2860: delegates to shared module).
  */
 export function mapToIndexingStatus(doc: {
   processingState?: string;
   processingStatus?: string;
 }): 'processing' | 'indexed' | 'failed' | 'none' {
-  const state = doc.processingState || doc.processingStatus || '';
-  switch (state) {
-    case 'Ready':
-    case 'completed':
-      return 'indexed';
-    case 'Failed':
-    case 'failed':
-      return 'failed';
-    case 'Extracting':
-    case 'Chunking':
-    case 'Embedding':
-    case 'Indexing':
-    case 'Uploading':
-    case 'Pending':
-    case 'processing':
-      return 'processing';
-    default:
-      return 'none';
-  }
+  return mapProcessingStateToDisplayStatus(doc.processingState || doc.processingStatus);
 }
 
 /**

--- a/apps/web/src/components/ui/data-display/connection-bar/__tests__/build-connections.test.ts
+++ b/apps/web/src/components/ui/data-display/connection-bar/__tests__/build-connections.test.ts
@@ -1,55 +1,72 @@
 import { describe, it, expect } from 'vitest';
-import { buildGameConnections, buildSessionConnections } from '../build-connections';
 
-describe('buildGameConnections', () => {
-  it('returns 4 pips: agent, kb, chat, session', () => {
-    const pips = buildGameConnections({
+import {
+  buildGameConnectionPips,
+  buildPlayerConnectionPips,
+  buildSessionConnectionPips,
+  buildAgentConnectionPips,
+  buildKbConnectionPips,
+  buildChatConnectionPips,
+  buildEventConnectionPips,
+  buildToolkitConnectionPips,
+  buildToolConnectionPips,
+} from '../build-connections';
+
+// Locks each builder's slot order (entityType sequence) against silent drift (#2860).
+describe('connection-bar build*ConnectionPips slot order', () => {
+  it('game -> agent, kb, chat, session', () => {
+    const pips = buildGameConnectionPips({
       agentCount: 1,
       kbCount: 3,
       chatCount: 5,
-      sessionCount: 23,
+      sessionCount: 2,
     });
-    expect(pips).toHaveLength(4);
     expect(pips.map(p => p.entityType)).toEqual(['agent', 'kb', 'chat', 'session']);
   });
-
-  it('sets count correctly', () => {
-    const pips = buildGameConnections({ agentCount: 0, kbCount: 2, chatCount: 0, sessionCount: 1 });
-    expect(pips[0].count).toBe(0); // agent
-    expect(pips[1].count).toBe(2); // kb
+  it('player -> session, game', () => {
+    const pips = buildPlayerConnectionPips({ sessionCount: 4, favoriteGameCount: 2 });
+    expect(pips.map(p => p.entityType)).toEqual(['session', 'game']);
   });
-
-  it('sets isEmpty = true when count is 0', () => {
-    const pips = buildGameConnections({ agentCount: 0, kbCount: 2, chatCount: 0, sessionCount: 1 });
-    expect(pips[0].isEmpty).toBe(true); // agent count 0
-    expect(pips[1].isEmpty).toBe(false); // kb count 2
-    expect(pips[2].isEmpty).toBe(true); // chat count 0
-    expect(pips[3].isEmpty).toBe(false); // session count 1
-  });
-});
-
-describe('buildSessionConnections', () => {
-  it('returns 4 pips: game, player, tool, agent', () => {
-    const pips = buildSessionConnections({
+  it('session -> game, player, tool, agent', () => {
+    const pips = buildSessionConnectionPips({
       gameCount: 1,
       playerCount: 4,
       toolCount: 3,
       agentCount: 1,
     });
-    expect(pips).toHaveLength(4);
     expect(pips.map(p => p.entityType)).toEqual(['game', 'player', 'tool', 'agent']);
   });
-
-  it('sets isEmpty correctly', () => {
-    const pips = buildSessionConnections({
-      gameCount: 0,
-      playerCount: 4,
-      toolCount: 0,
-      agentCount: 1,
+  it('agent -> game, kb, chat', () => {
+    const pips = buildAgentConnectionPips({ gameCount: 1, kbCount: 2, chatCount: 3 });
+    expect(pips.map(p => p.entityType)).toEqual(['game', 'kb', 'chat']);
+  });
+  it('kb -> game, agent', () => {
+    const pips = buildKbConnectionPips({ gameCount: 1, agentCount: 2 });
+    expect(pips.map(p => p.entityType)).toEqual(['game', 'agent']);
+  });
+  it('chat -> agent, game', () => {
+    const pips = buildChatConnectionPips({ agentCount: 1, gameCount: 2 });
+    expect(pips.map(p => p.entityType)).toEqual(['agent', 'game']);
+  });
+  it('event -> player, game, session', () => {
+    const pips = buildEventConnectionPips({ participantCount: 5, gameCount: 2, sessionCount: 1 });
+    expect(pips.map(p => p.entityType)).toEqual(['player', 'game', 'session']);
+  });
+  it('toolkit -> game, tool, session', () => {
+    const pips = buildToolkitConnectionPips({ gameCount: 1, toolCount: 4, sessionCount: 2 });
+    expect(pips.map(p => p.entityType)).toEqual(['game', 'tool', 'session']);
+  });
+  it('tool -> toolkit', () => {
+    const pips = buildToolConnectionPips({ toolkitCount: 3 });
+    expect(pips.map(p => p.entityType)).toEqual(['toolkit']);
+  });
+  it('sets isEmpty when count is 0', () => {
+    const pips = buildGameConnectionPips({
+      agentCount: 0,
+      kbCount: 2,
+      chatCount: 0,
+      sessionCount: 1,
     });
-    expect(pips[0].isEmpty).toBe(true); // game count 0
-    expect(pips[1].isEmpty).toBe(false); // player count 4
-    expect(pips[2].isEmpty).toBe(true); // tool count 0
-    expect(pips[3].isEmpty).toBe(false); // agent count 1
+    expect(pips.map(p => p.isEmpty)).toEqual([true, false, true, false]);
   });
 });

--- a/apps/web/src/components/ui/data-display/connection-bar/build-connections.ts
+++ b/apps/web/src/components/ui/data-display/connection-bar/build-connections.ts
@@ -11,7 +11,7 @@ function pip(
   return { entityType, count, label, icon, isEmpty: count === 0 };
 }
 
-export function buildGameConnections(counts: {
+export function buildGameConnectionPips(counts: {
   agentCount: number;
   kbCount: number;
   chatCount: number;
@@ -25,7 +25,7 @@ export function buildGameConnections(counts: {
   ];
 }
 
-export function buildPlayerConnections(counts: {
+export function buildPlayerConnectionPips(counts: {
   sessionCount: number;
   favoriteGameCount: number;
 }): ConnectionPip[] {
@@ -35,7 +35,7 @@ export function buildPlayerConnections(counts: {
   ];
 }
 
-export function buildSessionConnections(counts: {
+export function buildSessionConnectionPips(counts: {
   gameCount: number;
   playerCount: number;
   toolCount: number;
@@ -49,7 +49,7 @@ export function buildSessionConnections(counts: {
   ];
 }
 
-export function buildAgentConnections(counts: {
+export function buildAgentConnectionPips(counts: {
   gameCount: number;
   kbCount: number;
   chatCount: number;
@@ -61,7 +61,7 @@ export function buildAgentConnections(counts: {
   ];
 }
 
-export function buildKbConnections(counts: {
+export function buildKbConnectionPips(counts: {
   gameCount: number;
   agentCount: number;
 }): ConnectionPip[] {
@@ -71,7 +71,7 @@ export function buildKbConnections(counts: {
   ];
 }
 
-export function buildChatConnections(counts: {
+export function buildChatConnectionPips(counts: {
   agentCount: number;
   gameCount: number;
 }): ConnectionPip[] {
@@ -81,7 +81,7 @@ export function buildChatConnections(counts: {
   ];
 }
 
-export function buildEventConnections(counts: {
+export function buildEventConnectionPips(counts: {
   participantCount: number;
   gameCount: number;
   sessionCount: number;
@@ -93,7 +93,7 @@ export function buildEventConnections(counts: {
   ];
 }
 
-export function buildToolkitConnections(counts: {
+export function buildToolkitConnectionPips(counts: {
   gameCount: number;
   toolCount: number;
   sessionCount: number;
@@ -105,6 +105,6 @@ export function buildToolkitConnections(counts: {
   ];
 }
 
-export function buildToolConnections(counts: { toolkitCount: number }): ConnectionPip[] {
+export function buildToolConnectionPips(counts: { toolkitCount: number }): ConnectionPip[] {
   return [pip('toolkit', counts.toolkitCount, 'Toolkit', Wrench)];
 }

--- a/apps/web/src/components/ui/data-display/connection-bar/index.ts
+++ b/apps/web/src/components/ui/data-display/connection-bar/index.ts
@@ -1,13 +1,13 @@
 export { ConnectionBar } from './ConnectionBar';
 export type { ConnectionPip, ConnectionBarProps } from './types';
 export {
-  buildGameConnections,
-  buildPlayerConnections,
-  buildSessionConnections,
-  buildAgentConnections,
-  buildKbConnections,
-  buildChatConnections,
-  buildEventConnections,
-  buildToolkitConnections,
-  buildToolConnections,
+  buildGameConnectionPips,
+  buildPlayerConnectionPips,
+  buildSessionConnectionPips,
+  buildAgentConnectionPips,
+  buildKbConnectionPips,
+  buildChatConnectionPips,
+  buildEventConnectionPips,
+  buildToolkitConnectionPips,
+  buildToolConnectionPips,
 } from './build-connections';

--- a/apps/web/src/components/ui/data-display/extra-meeple-card/drawer-helpers.ts
+++ b/apps/web/src/components/ui/data-display/extra-meeple-card/drawer-helpers.ts
@@ -1,27 +1,15 @@
 import type { PdfDocumentDto } from '@/lib/api/schemas/pdf.schemas';
+import { mapProcessingStateToDisplayStatus } from '@/lib/kb/processing-status';
 
 // ============================================================================
 // PDF Document Helpers (Issue #5195)
 // ============================================================================
 
-/** Map PdfProcessingState string → KbDocumentPreview status */
+/** Map PdfProcessingState string → KbDocumentPreview status (#2860: delegates to shared module). */
 export function mapProcessingStateToStatus(
   state: string
 ): 'processing' | 'indexed' | 'failed' | 'none' {
-  switch (state) {
-    case 'Ready':
-      return 'indexed';
-    case 'Failed':
-      return 'failed';
-    case 'Extracting':
-    case 'Chunking':
-    case 'Embedding':
-    case 'Indexing':
-    case 'Uploading':
-      return 'processing';
-    default:
-      return 'none';
-  }
+  return mapProcessingStateToDisplayStatus(state);
 }
 
 /** Map raw JSON object from /api/v1/games/{id}/pdfs → PdfDocumentDto */

--- a/apps/web/src/components/ui/data-display/extra-meeple-card/hooks/use-kb-detail.ts
+++ b/apps/web/src/components/ui/data-display/extra-meeple-card/hooks/use-kb-detail.ts
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import { mapProcessingStateToDisplayStatus } from '@/lib/kb/processing-status';
+
 import type { KbDetailData } from '../types';
 
 // ============================================================================
@@ -52,16 +54,9 @@ export function useKbDetail(pdfId: string): UseKbDetailResult {
 }
 
 function mapToKbDetailData(doc: Record<string, unknown>): KbDetailData {
-  const rawStatus = String(doc.processingStatus ?? 'none').toLowerCase();
-  const statusMap: Record<string, KbDetailData['status']> = {
-    uploaded: 'processing',
-    extracting: 'processing',
-    indexing: 'processing',
-    indexed: 'indexed',
-    failed: 'failed',
-    none: 'none',
-  };
-  const status = statusMap[rawStatus] ?? 'none';
+  const status = mapProcessingStateToDisplayStatus(
+    doc.processingStatus as string | null | undefined
+  );
 
   const extractedText = doc.extractedText != null ? String(doc.extractedText) : undefined;
   const MAX_CHARS = 2000; // ~500 words

--- a/apps/web/src/components/ui/data-display/meeple-card/nav-items/__tests__/buildChatConnections.test.ts
+++ b/apps/web/src/components/ui/data-display/meeple-card/nav-items/__tests__/buildChatConnections.test.ts
@@ -41,4 +41,9 @@ describe('buildChatConnections', () => {
     items[3].onClick?.();
     expect(handlers.onArchiveClick).toHaveBeenCalledOnce();
   });
+
+  it('emits the canonical entityType slot order (#2860)', () => {
+    const items = buildChatConnections({ messageCount: 10 }, handlers);
+    expect(items.map(i => i.entityType)).toEqual(['chat', 'kb', 'agent', 'chat']);
+  });
 });

--- a/apps/web/src/components/ui/data-display/meeple-card/nav-items/__tests__/buildKbConnections.test.ts
+++ b/apps/web/src/components/ui/data-display/meeple-card/nav-items/__tests__/buildKbConnections.test.ts
@@ -31,4 +31,9 @@ describe('buildKbConnections', () => {
     expect(items[2].count).toBeUndefined();
     expect(items[3].count).toBeUndefined();
   });
+
+  it('emits kb entityType for all 4 slots (#2860)', () => {
+    const items = buildKbConnections({ chunkCount: 1 }, handlers);
+    expect(items.map(i => i.entityType)).toEqual(['kb', 'kb', 'kb', 'kb']);
+  });
 });

--- a/apps/web/src/lib/kb/__tests__/processing-status.test.ts
+++ b/apps/web/src/lib/kb/__tests__/processing-status.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+
+import { mapProcessingStateToDisplayStatus } from '../processing-status';
+
+describe('mapProcessingStateToDisplayStatus', () => {
+  // Full canonical ProcessingState enum coverage (PascalCase).
+  const canonical: Array<[string, 'processing' | 'indexed' | 'failed' | 'none']> = [
+    ['Pending', 'processing'], // resolved canonical value (was 'none' in one mapper)
+    ['Uploading', 'processing'],
+    ['Extracting', 'processing'],
+    ['Chunking', 'processing'],
+    ['Embedding', 'processing'],
+    ['Indexing', 'processing'],
+    ['Ready', 'indexed'],
+    ['Failed', 'failed'],
+  ];
+
+  it.each(canonical)('maps canonical %s -> %s', (state, expected) => {
+    expect(mapProcessingStateToDisplayStatus(state)).toBe(expected);
+  });
+
+  it.each(canonical)('is case-insensitive: %s lowercased -> %s', (state, expected) => {
+    expect(mapProcessingStateToDisplayStatus(state.toLowerCase())).toBe(expected);
+  });
+
+  it.each([
+    ['completed', 'indexed'] as const,
+    ['uploaded', 'processing'] as const,
+    ['processing', 'processing'] as const,
+  ])('maps legacy alias %s -> %s', (state, expected) => {
+    expect(mapProcessingStateToDisplayStatus(state)).toBe(expected);
+  });
+
+  // Regression guard: these were dropped to 'none' by use-kb-detail's old statusMap.
+  it.each(['Chunking', 'Embedding', 'Pending', 'Uploading'])(
+    'previously-dropped state %s now maps to processing',
+    state => {
+      expect(mapProcessingStateToDisplayStatus(state)).toBe('processing');
+    }
+  );
+
+  it.each([null, undefined, '', '   ', 'garbage'])('maps %s -> none', state => {
+    expect(mapProcessingStateToDisplayStatus(state as string | null | undefined)).toBe('none');
+  });
+});

--- a/apps/web/src/lib/kb/processing-status.ts
+++ b/apps/web/src/lib/kb/processing-status.ts
@@ -1,0 +1,47 @@
+import type { ProcessingState } from '@/lib/api/schemas/kb-docs.schemas';
+
+/**
+ * Canonical display status for a KB/PDF document across the app (card badges,
+ * drawer, library). Consolidates the three previously-divergent mappers
+ * (extra-meeple-card/drawer-helpers, library/kb-utils, use-kb-detail). #2860.
+ */
+export type KbDisplayStatus = 'processing' | 'indexed' | 'failed' | 'none';
+
+/**
+ * Exhaustive over the canonical ProcessingState enum (lowercased). The
+ * `satisfies` clause makes a newly-added ProcessingState value a compile error
+ * here until it is mapped. Pending -> processing is the resolved canonical value.
+ */
+const CANONICAL = {
+  pending: 'processing',
+  uploading: 'processing',
+  extracting: 'processing',
+  chunking: 'processing',
+  embedding: 'processing',
+  indexing: 'processing',
+  ready: 'indexed',
+  failed: 'failed',
+} satisfies Record<Lowercase<ProcessingState>, KbDisplayStatus>;
+
+/**
+ * Legacy / alternate payload spellings. The /api/v1/pdfs/{id}/text endpoint
+ * emits lowercase `uploaded`; some list endpoints emit `completed`/`processing`.
+ */
+const ALIASES: Record<string, KbDisplayStatus> = {
+  completed: 'indexed',
+  uploaded: 'processing',
+  processing: 'processing',
+};
+
+/**
+ * Map any PDF processing-state string (canonical PascalCase, lowercase, or a
+ * known alias) to a KbDisplayStatus. Unknown / empty -> 'none'.
+ */
+export function mapProcessingStateToDisplayStatus(
+  state: string | null | undefined
+): KbDisplayStatus {
+  const key = String(state ?? '')
+    .trim()
+    .toLowerCase();
+  return (CANONICAL as Record<string, KbDisplayStatus>)[key] ?? ALIASES[key] ?? 'none';
+}

--- a/docs/for-developers/frontend/card-decision-table.md
+++ b/docs/for-developers/frontend/card-decision-table.md
@@ -73,3 +73,15 @@ one that composes the canonical card — **never** a standalone renderer.
   `local/no-standalone-card-renderer` forbids it) and do **not** hand-roll
   cover/stars/badge (C4 body-gate, #2861).
 - Need a detail/drawer surface? Add an `ExtraMeepleCard` entity variant.
+
+## Connection builders — two families (#2860)
+
+Two intentionally-separate connection families; do NOT merge them (incompatible
+output types). Pick by render surface:
+
+| Family | Builder | Output | Rendered by | Surface |
+|---|---|---|---|---|
+| Pips | `build*ConnectionPips` (`ui/data-display/connection-bar/`) | `ConnectionPip[]` (icon in payload, count required, `isEmpty`) | `ConnectionBar` | detail pages — read-only cascade-nav strip |
+| Chips | `build*Connections` (`ui/data-display/meeple-card/nav-items/`) | `ConnectionChipProps[]` (entity-derived icon, optional count, `items`/`onCreate`/`onClick`/`href`) | `ConnectionChipStrip` → `ConnectionChip` | card footers — nav + actions |
+
+Each builder's slot order is locked by tests in the respective `__tests__/` dir.

--- a/docs/superpowers/plans/2026-07-13-issue-2860-consolidate-connections-status.md
+++ b/docs/superpowers/plans/2026-07-13-issue-2860-consolidate-connections-status.md
@@ -1,0 +1,552 @@
+# Consolidate build*Connections + status-mapping (Issue #2860 / C3) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Unify the 3 divergent PDF status-mappers into one shared, enum-exhaustive module (fixing a real gap where Chunking/Embedding/Pending/Uploading rendered as `none`), and disambiguate the two `build*Connections` families by renaming the smaller (`connection-bar`) family to `build*ConnectionPips` + locking every builder's slot order with tests.
+
+**Architecture:** A pure `lib/kb/processing-status.ts` module maps any PDF processing-state string (case-insensitive, alias-aware) to a `KbDisplayStatus`; the 3 existing mappers become thin delegators. The `connection-bar` builders are renamed so no two `build*Connections` functions with incompatible outputs share a name; slot-order snapshot assertions guard both families against silent drift.
+
+**Tech Stack:** Next.js 16 · React 19 · TypeScript · Vitest · Zod (`ProcessingState` enum).
+
+**Spec:** `docs/superpowers/specs/2026-07-13-issue-2860-consolidate-connections-status-design.md`
+
+## Global Constraints
+
+- Work on branch `feature/issue-2860-consolidate-connections-status` (already created from `main-dev`); PR targets `main-dev`.
+- Frontend paths under `apps/web/`. Run commands from `apps/web/`. Single-file test: `pnpm exec vitest run <path>`. `pnpm typecheck`, `pnpm lint`, `pnpm build`.
+- Canonical `ProcessingState` enum (`apps/web/src/lib/api/schemas/kb-docs.schemas.ts:18-29`): `Pending | Uploading | Extracting | Chunking | Embedding | Indexing | Ready | Failed`.
+- **`Pending → 'processing'`** (canonical decision — the 3 mappers currently disagree; this is the resolved value).
+- `KbDisplayStatus = 'processing' | 'indexed' | 'failed' | 'none'` (matches `KbDetailData['status']` and both existing mapper return types verbatim).
+- `build*Connections` families are NOT merged (incompatible types). Only the `connection-bar` family is renamed; `nav-items` keeps its names.
+- No hardcoded color utilities; commit format `type(scope): description` + `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+
+---
+
+### Task 1: Shared `processing-status` module
+
+**Files:**
+- Create: `apps/web/src/lib/kb/processing-status.ts`
+- Test: `apps/web/src/lib/kb/__tests__/processing-status.test.ts`
+
+**Interfaces:**
+- Produces: `type KbDisplayStatus = 'processing' | 'indexed' | 'failed' | 'none'` and `mapProcessingStateToDisplayStatus(state: string | null | undefined): KbDisplayStatus`. Consumed by Task 2.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/web/src/lib/kb/__tests__/processing-status.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+
+import { mapProcessingStateToDisplayStatus } from '../processing-status';
+
+describe('mapProcessingStateToDisplayStatus', () => {
+  // Full canonical ProcessingState enum coverage (PascalCase).
+  const canonical: Array<[string, 'processing' | 'indexed' | 'failed' | 'none']> = [
+    ['Pending', 'processing'], // resolved canonical value (was 'none' in one mapper)
+    ['Uploading', 'processing'],
+    ['Extracting', 'processing'],
+    ['Chunking', 'processing'],
+    ['Embedding', 'processing'],
+    ['Indexing', 'processing'],
+    ['Ready', 'indexed'],
+    ['Failed', 'failed'],
+  ];
+
+  it.each(canonical)('maps canonical %s -> %s', (state, expected) => {
+    expect(mapProcessingStateToDisplayStatus(state)).toBe(expected);
+  });
+
+  it.each(canonical)('is case-insensitive: %s lowercased -> %s', (state, expected) => {
+    expect(mapProcessingStateToDisplayStatus(state.toLowerCase())).toBe(expected);
+  });
+
+  it.each([
+    ['completed', 'indexed'] as const,
+    ['uploaded', 'processing'] as const,
+    ['processing', 'processing'] as const,
+  ])('maps legacy alias %s -> %s', (state, expected) => {
+    expect(mapProcessingStateToDisplayStatus(state)).toBe(expected);
+  });
+
+  // Regression guard: these were dropped to 'none' by use-kb-detail's old statusMap.
+  it.each(['Chunking', 'Embedding', 'Pending', 'Uploading'])(
+    'previously-dropped state %s now maps to processing',
+    state => {
+      expect(mapProcessingStateToDisplayStatus(state)).toBe('processing');
+    }
+  );
+
+  it.each([null, undefined, '', '   ', 'garbage'])('maps %s -> none', state => {
+    expect(mapProcessingStateToDisplayStatus(state as string | null | undefined)).toBe('none');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm exec vitest run src/lib/kb/__tests__/processing-status.test.ts`
+Expected: FAIL — `Cannot find module '../processing-status'`.
+
+- [ ] **Step 3: Implement the module**
+
+Create `apps/web/src/lib/kb/processing-status.ts`:
+
+```ts
+import type { ProcessingState } from '@/lib/api/schemas/kb-docs.schemas';
+
+/**
+ * Canonical display status for a KB/PDF document across the app (card badges,
+ * drawer, library). Consolidates the three previously-divergent mappers
+ * (extra-meeple-card/drawer-helpers, library/kb-utils, use-kb-detail). #2860.
+ */
+export type KbDisplayStatus = 'processing' | 'indexed' | 'failed' | 'none';
+
+/**
+ * Exhaustive over the canonical ProcessingState enum (lowercased). The
+ * `satisfies` clause makes a newly-added ProcessingState value a compile error
+ * here until it is mapped. Pending -> processing is the resolved canonical value.
+ */
+const CANONICAL = {
+  pending: 'processing',
+  uploading: 'processing',
+  extracting: 'processing',
+  chunking: 'processing',
+  embedding: 'processing',
+  indexing: 'processing',
+  ready: 'indexed',
+  failed: 'failed',
+} satisfies Record<Lowercase<ProcessingState>, KbDisplayStatus>;
+
+/**
+ * Legacy / alternate payload spellings. The /api/v1/pdfs/{id}/text endpoint
+ * emits lowercase `uploaded`; some list endpoints emit `completed`/`processing`.
+ */
+const ALIASES: Record<string, KbDisplayStatus> = {
+  completed: 'indexed',
+  uploaded: 'processing',
+  processing: 'processing',
+};
+
+/**
+ * Map any PDF processing-state string (canonical PascalCase, lowercase, or a
+ * known alias) to a KbDisplayStatus. Unknown / empty -> 'none'.
+ */
+export function mapProcessingStateToDisplayStatus(
+  state: string | null | undefined
+): KbDisplayStatus {
+  const key = String(state ?? '')
+    .trim()
+    .toLowerCase();
+  return (CANONICAL as Record<string, KbDisplayStatus>)[key] ?? ALIASES[key] ?? 'none';
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes + typecheck**
+
+Run: `pnpm exec vitest run src/lib/kb/__tests__/processing-status.test.ts`
+Expected: PASS.
+Run: `pnpm typecheck`
+Expected: PASS (the `satisfies` clause compiles — all 8 lowercase enum keys present).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/lib/kb/processing-status.ts apps/web/src/lib/kb/__tests__/processing-status.test.ts
+git commit -m "$(cat <<'EOF'
+feat(kb): shared processing-status mapper with enum coverage (#2860)
+
+Case-insensitive, alias-aware map from PDF ProcessingState to KbDisplayStatus.
+Pending -> processing (resolved). satisfies Record<Lowercase<ProcessingState>,...>
+makes a new enum value a compile error until mapped.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 2: Delegate the 3 mappers to the shared module
+
+**Files:**
+- Modify: `apps/web/src/components/ui/data-display/extra-meeple-card/drawer-helpers.ts:8-25`
+- Modify: `apps/web/src/components/library/kb-utils.ts:55-78`
+- Modify: `apps/web/src/components/ui/data-display/extra-meeple-card/hooks/use-kb-detail.ts:54-64`
+- Test: update any existing tests for these mappers to the new canonical behavior.
+
+**Interfaces:**
+- Consumes: `mapProcessingStateToDisplayStatus` (Task 1).
+- Produces: no new exports; the three existing functions keep their signatures and now delegate. Behavior deltas: `drawer-helpers.mapProcessingStateToStatus('Pending')` `'none'→'processing'`; `use-kb-detail` now maps `Chunking/Embedding/Pending/Uploading` `'none'→'processing'`.
+
+- [ ] **Step 1: Delegate `drawer-helpers.ts`**
+
+In `apps/web/src/components/ui/data-display/extra-meeple-card/drawer-helpers.ts`, add the import at the top and replace the `mapProcessingStateToStatus` function body (lines 8-25). Result:
+
+```ts
+import { mapProcessingStateToDisplayStatus } from '@/lib/kb/processing-status';
+import type { PdfDocumentDto } from '@/lib/api/schemas/pdf.schemas';
+
+// ============================================================================
+// PDF Document Helpers (Issue #5195)
+// ============================================================================
+
+/** Map PdfProcessingState string -> KbDocumentPreview status (#2860: delegates to shared module). */
+export function mapProcessingStateToStatus(
+  state: string
+): 'processing' | 'indexed' | 'failed' | 'none' {
+  return mapProcessingStateToDisplayStatus(state);
+}
+```
+
+(Leave `mapRawToPdfDocumentDto` below it untouched.)
+
+- [ ] **Step 2: Delegate `kb-utils.ts`**
+
+In `apps/web/src/components/library/kb-utils.ts`, add the import and replace the `mapToIndexingStatus` body (lines 55-78):
+
+```ts
+import { mapProcessingStateToDisplayStatus } from '@/lib/kb/processing-status';
+
+/**
+ * Map processingState (PascalCase) or processingStatus to KbDisplayStatus.
+ * #2860: delegates to the shared module.
+ */
+export function mapToIndexingStatus(doc: {
+  processingState?: string;
+  processingStatus?: string;
+}): 'processing' | 'indexed' | 'failed' | 'none' {
+  return mapProcessingStateToDisplayStatus(doc.processingState || doc.processingStatus);
+}
+```
+
+(Leave `getDocumentStatus` and `isDocumentReady` untouched. Place the import with the other imports at the top of the file.)
+
+- [ ] **Step 3: Delegate `use-kb-detail.ts`**
+
+In `apps/web/src/components/ui/data-display/extra-meeple-card/hooks/use-kb-detail.ts`, add the import at the top, then replace the inline `statusMap` block (lines 55-64) so the `status` const uses the shared module:
+
+Replace:
+
+```ts
+  const rawStatus = String(doc.processingStatus ?? 'none').toLowerCase();
+  const statusMap: Record<string, KbDetailData['status']> = {
+    uploaded: 'processing',
+    extracting: 'processing',
+    indexing: 'processing',
+    indexed: 'indexed',
+    failed: 'failed',
+    none: 'none',
+  };
+  const status = statusMap[rawStatus] ?? 'none';
+```
+
+with:
+
+```ts
+  const status = mapProcessingStateToDisplayStatus(
+    doc.processingStatus as string | null | undefined
+  );
+```
+
+And add to the imports at the top of the file:
+
+```ts
+import { mapProcessingStateToDisplayStatus } from '@/lib/kb/processing-status';
+```
+
+- [ ] **Step 4: Run the mapper + KB test suites and reconcile behavior deltas**
+
+Run: `pnpm exec vitest run src/components/ui/data-display/extra-meeple-card src/components/library`
+Expected: mostly PASS. If any existing test asserted an OLD behavior that this change intentionally corrects, update that assertion to the new canonical value:
+- `drawer-helpers` / game-detail: `Pending` now yields `'processing'` (was `'none'`).
+- `use-kb-detail`: `Chunking`/`Embedding`/`Pending`/`Uploading` now yield `'processing'` (was `'none'`).
+Do NOT revert the delegation to keep an old assertion — the old behavior was the defect being fixed. `kb-utils` had no behavior change (it already mapped Pending -> processing).
+
+- [ ] **Step 5: Typecheck**
+
+Run: `pnpm typecheck`
+Expected: PASS. (`mapProcessingStateToDisplayStatus` returns `KbDisplayStatus`, assignable to each mapper's return type and to `KbDetailData['status']` — all are the same 4 literals.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/components/ui/data-display/extra-meeple-card/drawer-helpers.ts \
+        apps/web/src/components/library/kb-utils.ts \
+        apps/web/src/components/ui/data-display/extra-meeple-card/hooks/use-kb-detail.ts
+# plus any test files you updated in Step 4
+git commit -m "$(cat <<'EOF'
+refactor(kb): 3 status-mappers delegate to shared processing-status (#2860)
+
+drawer-helpers, kb-utils, and use-kb-detail now call
+mapProcessingStateToDisplayStatus. Fixes use-kb-detail dropping
+Chunking/Embedding/Pending/Uploading to 'none'; unifies Pending -> processing.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 3: Rename `connection-bar` builders to `build*ConnectionPips`
+
+**Files:**
+- Modify: `apps/web/src/components/ui/data-display/connection-bar/build-connections.ts` (rename 9 functions)
+- Modify: `apps/web/src/components/ui/data-display/connection-bar/index.ts` (barrel)
+- Modify: `apps/web/src/components/agent/AgentCharacterSheet.tsx` (import + call: `buildAgentConnections` -> `buildAgentConnectionPips`)
+- Modify: `apps/web/src/components/game-detail/GameDetailDesktop.tsx` (import + call: `buildGameConnections` -> `buildGameConnectionPips`)
+- Modify: `apps/web/src/components/ui/data-display/connection-bar/__tests__/build-connections.test.ts` (rename + extend to all 9)
+
+**Interfaces:**
+- Produces: `connection-bar` exports become `buildGameConnectionPips`, `buildPlayerConnectionPips`, `buildSessionConnectionPips`, `buildAgentConnectionPips`, `buildKbConnectionPips`, `buildChatConnectionPips`, `buildEventConnectionPips`, `buildToolkitConnectionPips`, `buildToolConnectionPips` (all `→ ConnectionPip[]`). The `nav-items` `build*Connections` names are unchanged.
+
+- [ ] **Step 1: Rename the 9 functions in `build-connections.ts`**
+
+In `apps/web/src/components/ui/data-display/connection-bar/build-connections.ts`, rename each `export function build<Entity>Connections` to `export function build<Entity>ConnectionPips` (bodies unchanged). The 9 names:
+`buildGameConnectionPips`, `buildPlayerConnectionPips`, `buildSessionConnectionPips`, `buildAgentConnectionPips`, `buildKbConnectionPips`, `buildChatConnectionPips`, `buildEventConnectionPips`, `buildToolkitConnectionPips`, `buildToolConnectionPips`.
+
+- [ ] **Step 2: Update the barrel `index.ts`**
+
+Replace the export block in `apps/web/src/components/ui/data-display/connection-bar/index.ts`:
+
+```ts
+export { ConnectionBar } from './ConnectionBar';
+export type { ConnectionPip, ConnectionBarProps } from './types';
+export {
+  buildGameConnectionPips,
+  buildPlayerConnectionPips,
+  buildSessionConnectionPips,
+  buildAgentConnectionPips,
+  buildKbConnectionPips,
+  buildChatConnectionPips,
+  buildEventConnectionPips,
+  buildToolkitConnectionPips,
+  buildToolConnectionPips,
+} from './build-connections';
+```
+
+- [ ] **Step 3: Update the 2 production consumers**
+
+- `apps/web/src/components/agent/AgentCharacterSheet.tsx:29` — change the named import `buildAgentConnections` to `buildAgentConnectionPips`, and rename its call-site(s) in the file (search the file for `buildAgentConnections`).
+- `apps/web/src/components/game-detail/GameDetailDesktop.tsx:8` — change the named import `buildGameConnections` to `buildGameConnectionPips`, and rename its call-site(s) in the file (search the file for `buildGameConnections`).
+
+- [ ] **Step 4: Typecheck to catch any missed rename**
+
+Run: `pnpm typecheck`
+Expected: PASS. If it reports `buildGameConnections`/`buildAgentConnections` is not exported from `connection-bar`, fix the remaining call-site it names. (The `nav-items` builders keep the old names, so only `connection-bar` importers should be affected.)
+
+- [ ] **Step 5: Rewrite the connection-bar test to cover all 9 with slot-order assertions**
+
+Replace `apps/web/src/components/ui/data-display/connection-bar/__tests__/build-connections.test.ts` with:
+
+```ts
+import { describe, it, expect } from 'vitest';
+
+import {
+  buildGameConnectionPips,
+  buildPlayerConnectionPips,
+  buildSessionConnectionPips,
+  buildAgentConnectionPips,
+  buildKbConnectionPips,
+  buildChatConnectionPips,
+  buildEventConnectionPips,
+  buildToolkitConnectionPips,
+  buildToolConnectionPips,
+} from '../build-connections';
+
+// Locks each builder's slot order (entityType sequence) against silent drift (#2860).
+describe('connection-bar build*ConnectionPips slot order', () => {
+  it('game -> agent, kb, chat, session', () => {
+    const pips = buildGameConnectionPips({ agentCount: 1, kbCount: 3, chatCount: 5, sessionCount: 2 });
+    expect(pips.map(p => p.entityType)).toEqual(['agent', 'kb', 'chat', 'session']);
+  });
+  it('player -> session, game', () => {
+    const pips = buildPlayerConnectionPips({ sessionCount: 4, favoriteGameCount: 2 });
+    expect(pips.map(p => p.entityType)).toEqual(['session', 'game']);
+  });
+  it('session -> game, player, tool, agent', () => {
+    const pips = buildSessionConnectionPips({ gameCount: 1, playerCount: 4, toolCount: 3, agentCount: 1 });
+    expect(pips.map(p => p.entityType)).toEqual(['game', 'player', 'tool', 'agent']);
+  });
+  it('agent -> game, kb, chat', () => {
+    const pips = buildAgentConnectionPips({ gameCount: 1, kbCount: 2, chatCount: 3 });
+    expect(pips.map(p => p.entityType)).toEqual(['game', 'kb', 'chat']);
+  });
+  it('kb -> game, agent', () => {
+    const pips = buildKbConnectionPips({ gameCount: 1, agentCount: 2 });
+    expect(pips.map(p => p.entityType)).toEqual(['game', 'agent']);
+  });
+  it('chat -> agent, game', () => {
+    const pips = buildChatConnectionPips({ agentCount: 1, gameCount: 2 });
+    expect(pips.map(p => p.entityType)).toEqual(['agent', 'game']);
+  });
+  it('event -> player, game, session', () => {
+    const pips = buildEventConnectionPips({ participantCount: 5, gameCount: 2, sessionCount: 1 });
+    expect(pips.map(p => p.entityType)).toEqual(['player', 'game', 'session']);
+  });
+  it('toolkit -> game, tool, session', () => {
+    const pips = buildToolkitConnectionPips({ gameCount: 1, toolCount: 4, sessionCount: 2 });
+    expect(pips.map(p => p.entityType)).toEqual(['game', 'tool', 'session']);
+  });
+  it('tool -> toolkit', () => {
+    const pips = buildToolConnectionPips({ toolkitCount: 3 });
+    expect(pips.map(p => p.entityType)).toEqual(['toolkit']);
+  });
+  it('sets isEmpty when count is 0', () => {
+    const pips = buildGameConnectionPips({ agentCount: 0, kbCount: 2, chatCount: 0, sessionCount: 1 });
+    expect(pips.map(p => p.isEmpty)).toEqual([true, false, true, false]);
+  });
+});
+```
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run: `pnpm exec vitest run src/components/ui/data-display/connection-bar`
+Expected: PASS (10 tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/src/components/ui/data-display/connection-bar/build-connections.ts \
+        apps/web/src/components/ui/data-display/connection-bar/index.ts \
+        apps/web/src/components/agent/AgentCharacterSheet.tsx \
+        apps/web/src/components/game-detail/GameDetailDesktop.tsx \
+        apps/web/src/components/ui/data-display/connection-bar/__tests__/build-connections.test.ts
+git commit -m "$(cat <<'EOF'
+refactor(connection-bar): rename builders to build*ConnectionPips + lock slot order (#2860)
+
+Removes the name collision with meeple-card/nav-items build*Connections (which
+return the incompatible ConnectionChipProps[]). Snapshot-locks all 9 pip
+builders' entityType slot order.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 4: Lock nav-items slot order + document the two families
+
+**Files:**
+- Modify (as needed): the 9 `apps/web/src/components/ui/data-display/meeple-card/nav-items/__tests__/build*Connections.test.ts`
+- Modify: `docs/for-developers/frontend/card-decision-table.md`
+
+**Interfaces:** none (tests + doc only).
+
+- [ ] **Step 1: Ensure every nav-items builder test asserts its entityType slot order**
+
+For each of the 9 files in `apps/web/src/components/ui/data-display/meeple-card/nav-items/__tests__/`, confirm there is an assertion of the form `expect(items.map(i => i.entityType)).toEqual([...])`. `buildAgentConnections.test.ts:19-22` already has one. For any file lacking it, add a test using the canonical order below (call the builder with all counts > 0 and empty handlers `{}` — handlers are optional):
+
+| Builder | entityType order |
+|---|---|
+| buildGameConnections | `['kb', 'agent', 'chat', 'session']` |
+| buildAgentConnections | `['chat', 'kb', 'agent', 'agent']` (present) |
+| buildKbConnections | `['kb', 'kb', 'kb', 'kb']` |
+| buildSessionConnections | `['player', 'session', 'tool', 'session']` |
+| buildPlayerConnections | `['player', 'session', 'game', 'player']` |
+| buildToolConnections | `['tool', 'tool', 'tool', 'tool']` |
+| buildToolkitConnections | `['tool', 'toolkit', 'toolkit', 'session']` |
+| buildChatConnections | `['chat', 'kb', 'agent', 'chat']` |
+| buildEventConnections | `['player', 'event', 'game', 'event']` |
+
+Example assertion to add to a file missing one (adapt the builder call to that builder's `counts`/`handlers` params — read the builder's signature; counts all > 0):
+
+```ts
+  it('emits the canonical entityType slot order', () => {
+    const items = buildGameConnections(
+      { kbCount: 1, agentCount: 1, chatCount: 1, sessionCount: 1 },
+      {}
+    );
+    expect(items.map(i => i.entityType)).toEqual(['kb', 'agent', 'chat', 'session']);
+  });
+```
+
+- [ ] **Step 2: Run all nav-items builder tests**
+
+Run: `pnpm exec vitest run src/components/ui/data-display/meeple-card/nav-items`
+Expected: PASS (all 9 files green, each asserting entityType order).
+
+- [ ] **Step 3: Document the two connection families in the decision-table**
+
+Append a section to `docs/for-developers/frontend/card-decision-table.md`:
+
+```markdown
+## Connection builders — two families (#2860)
+
+Two intentionally-separate connection families; do NOT merge them (incompatible
+output types). Pick by render surface:
+
+| Family | Builder | Output | Rendered by | Surface |
+|---|---|---|---|---|
+| Pips | `build*ConnectionPips` (`ui/data-display/connection-bar/`) | `ConnectionPip[]` (icon in payload, count required, `isEmpty`) | `ConnectionBar` | detail pages — read-only cascade-nav strip |
+| Chips | `build*Connections` (`ui/data-display/meeple-card/nav-items/`) | `ConnectionChipProps[]` (entity-derived icon, optional count, `items`/`onCreate`/`onClick`/`href`) | `ConnectionChipStrip` → `ConnectionChip` | card footers — nav + actions |
+
+Each builder's slot order is locked by tests in the respective `__tests__/` dir.
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/components/ui/data-display/meeple-card/nav-items/__tests__/ \
+        docs/for-developers/frontend/card-decision-table.md
+git commit -m "$(cat <<'EOF'
+test(meeple-card): lock nav-items connection slot order + document families (#2860)
+
+Ensures every nav-items build*Connections test asserts its entityType slot
+order; documents the Pips-vs-Chips family split in the card decision-table.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 5: Final verification + PR
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Full quality gates**
+
+Run each and confirm PASS:
+- `cd apps/web && pnpm exec vitest run src/lib/kb src/components/ui/data-display/connection-bar src/components/ui/data-display/meeple-card/nav-items src/components/ui/data-display/extra-meeple-card src/components/library`
+- `cd apps/web && pnpm typecheck`
+- `cd apps/web && pnpm lint`
+- `cd apps/web && pnpm build`
+
+- [ ] **Step 2: Push + open PR to `main-dev`**
+
+```bash
+git push -u origin feature/issue-2860-consolidate-connections-status
+gh pr create --base main-dev --title "refactor(meeple-card): consolidate status-mapping + disambiguate connection builders (#2860)" --body "$(cat <<'EOF'
+Closes #2860 (C3 / ST6 of umbrella #2863).
+
+## What
+- `lib/kb/processing-status.ts`: one case-insensitive, alias-aware mapper (`ProcessingState` -> `KbDisplayStatus`) with compile-time enum coverage (`satisfies`). The 3 divergent mappers (drawer-helpers, kb-utils, use-kb-detail) now delegate. Fixes use-kb-detail dropping Chunking/Embedding/Pending/Uploading to `none`; resolves Pending -> processing.
+- `connection-bar` builders renamed `build*ConnectionPips` (removes the name collision with `nav-items` `build*Connections`, which return the incompatible `ConnectionChipProps[]`). Both families' slot orders are locked by tests. Families documented in the card decision-table.
+
+## Design
+`docs/superpowers/specs/2026-07-13-issue-2860-consolidate-connections-status-design.md`. The two connection families are NOT merged (incompatible types — verified); only disambiguated + locked.
+
+## Visible delta
+The game-detail drawer now shows an "in elaborazione" badge for PDFs in Pending/Chunking/Embedding (previously no badge) — more accurate.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: After CI green + merge — close-out**
+
+Update issue #2860 (state + DoD) and tick its box in umbrella #2863's Phase C checklist.
+
+---
+
+## Self-Review notes (author)
+
+- **Spec coverage:** §3 Part A → Tasks 3-4; §4 Part B → Tasks 1-2; §5 testing → per-task + Task 5; §9 acceptance → Task 5 gates. All mapped.
+- **Type consistency:** `KbDisplayStatus` (Task 1) == the 4 literals returned by all 3 mappers and `KbDetailData['status']` (verified types.ts:440) — delegation type-checks. `build*ConnectionPips` names consistent across build-connections.ts, index.ts, consumers, and test (Task 3).
+- **Ordering:** Part B (Tasks 1-2) and Part A (Tasks 3-4) are independent; either order works. Task 2 depends on Task 1; Task 3 is self-contained.
+- **No merge:** the plan renames only `connection-bar` and never touches `ConnectionPip`/`ConnectionChipProps` types (per spec §7).

--- a/docs/superpowers/specs/2026-07-13-issue-2860-consolidate-connections-status-design.md
+++ b/docs/superpowers/specs/2026-07-13-issue-2860-consolidate-connections-status-design.md
@@ -1,0 +1,156 @@
+# Design — Issue #2860 (C3): consolidate `build*Connections` + status-mapping
+
+**Data:** 2026-07-13
+**Issue:** [#2860](https://github.com/meepleAi-app/meepleai-monorepo/issues/2860) (ST6) — umbrella [#2863](https://github.com/meepleAi-app/meepleai-monorepo/issues/2863) "MeepleCard family debt teardown"
+**Audit:** `docs/for-developers/audits/2026-07-12-meeplecard-css-drift-audit.md` (§4.4 friction-functions, §3 barriera MAJOR "2 build*Connections ordine invertito" + "3 status-mapping enum incompleto")
+**Branch:** `feature/issue-2860-consolidate-connections-status` da `main-dev`
+**Dipendenze:** nessuna.
+
+---
+
+## 1. Problema
+
+L'audit ha rilevato due cluster di funzioni-doppione nella family MeepleCard:
+
+1. **Due famiglie `build*Connections` parallele**, type-incompatibili, con builder omonimi.
+2. **Tre catene di status-mapping** PDF non riconciliate, una con enum incompleto (`use-kb-detail` omette Chunking/Embedding/Uploading/Pending).
+
+La verifica sul codice mostra che i due cluster hanno natura diversa (come nel caso C1, la premessa "consolidare in uno" dell'audit va calibrata sulla realtà).
+
+### 1.1 build*Connections — due famiglie NON fondibili
+
+| | `connection-bar/build-connections.ts` | `meeple-card/nav-items/build*Connections.ts` |
+|---|---|---|
+| Firma | `build*Connections(counts)` | `build*Connections(counts, handlers)` |
+| Output | `ConnectionPip[]` (icon nel payload, `count` required, `isEmpty`) | `ConnectionChipProps[]` (icon derivata, `count` opzionale, `items`/`onCreate`/`onClick`/`href`) |
+| Reso da | `ConnectionBar` (stateless, cascade-nav) | `ConnectionChipStrip`→`ConnectionChip` (stateful) |
+| Superficie | **detail page** (`GameDetailDesktop`, `PlayerConnectionBar`, `AgentCharacterSheet`) — ~5 consumer | **footer card** (`MeepleAgentCard`, `MeepleKbCard`, …) — ~21 consumer |
+| Semantica slot | "a cosa è connesso X" (game/kb/chat) | nav + **azioni** (Reindex, Download, Config, Chunks) |
+
+Solo 3 campi in comune (`entityType`, `count`, `label`); modelli icon/count/interaction incompatibili → **non fondibili in un tipo/builder unico** (comprometterebbe interaction model, state, variant; ~40 consumer). Il vero difetto non è "due famiglie" ma: (a) i **nomi collisi** (`buildAgentConnections` esiste in entrambe, type-incompatibile → confonde chi porta un mockup); (b) lo **slot-order senza gate** (può driftare in silenzio).
+
+### 1.2 status-mapping — 3 catene, una col bug
+
+Enum canonico `ProcessingState` (`lib/api/schemas/kb-docs.schemas.ts:18-29`, esportato come union): `Pending | Uploading | Extracting | Chunking | Embedding | Indexing | Ready | Failed`. Tutti e 3 i mapper → `'processing' | 'indexed' | 'failed' | 'none'`:
+
+| Input | Mapper 1 (`drawer-helpers.ts`) | Mapper 2 (`kb-utils.ts`) | Mapper 3 (`use-kb-detail.ts`) |
+|---|---|---|---|
+| Pending | none | processing | **GAP → none** |
+| Uploading | processing | processing | **GAP** (si aspetta `uploaded`) |
+| Chunking | processing | processing | **GAP → none** |
+| Embedding | processing | processing | **GAP → none** |
+| Extracting/Indexing/Ready/Failed | ✓ | ✓ | ✓ |
+
+Mapper 3 lowercasa l'input, si aspetta `uploaded` (non `Uploading`), e **manca** Chunking/Embedding/Pending/Uploading → un PDF in quegli stati mostra `none` invece di `processing` (**bug reale**). In più, disaccordo semantico su Pending: `none` (M1) vs `processing` (M2).
+
+## 2. Decisioni (brainstorm 2026-07-13)
+
+1. **Parte A → disambigua + lock (non merge).** Rinominare la famiglia piccola `connection-bar` → `build*ConnectionPips` (elimina la collisione di nome, ~5 consumer); snapshot-lock dello slot-order di ENTRAMBE le famiglie; nota nella decision-table.
+2. **Parte B → modulo condiviso.** Unificare i 3 mapper in `lib/kb/processing-status.ts`, case-insensitive + alias-aware, con enum-coverage a compile-time (`satisfies`) + runtime.
+3. **Pending → `processing`** (canonico, coerente col Mapper 2 completo).
+
+## 3. Parte A — disambigua + lock `build*Connections`
+
+**Rename (solo famiglia piccola).** I 9 builder in `connection-bar/build-connections.ts` da `build<Entity>Connections` → **`build<Entity>ConnectionPips`** (output `ConnectionPip[]` esplicito nel nome). Aggiornare:
+- il barrel `connection-bar/index.ts`;
+- tutti i consumer (grep-verificati: `GameDetailDesktop`, `AgentCharacterSheet`, `PlayerConnectionBar`, `useConnectionBarNav`, ed eventuali detail-strip — ~5-8 file);
+- il test `connection-bar/__tests__/build-connections.test.ts`.
+
+I 9 builder in `nav-items/` **restano** `build*Connections` (famiglia primaria card, ~21 consumer, zero rename). Risolta la collisione: non esistono più due `buildAgentConnections` type-incompatibili.
+
+**Snapshot / lock slot-order (entrambe le famiglie).** Ogni builder deve avere un test che asserisce la **sequenza esatta di `entityType` (e label)** emessa:
+- `nav-items/__tests__/build*Connections.test.ts` (8 file esistenti) — verificare che ognuno asserisca l'ordine-slot; completare dove manca.
+- `connection-bar/__tests__/build-connections.test.ts` — estendere a coprire tutti e 9 i builder con asserzione d'ordine.
+
+Così l'"inverted slot order" non può più driftare in silenzio (documenta anche che le due famiglie sono intenzionalmente diverse).
+
+**Doc.** Nota in `card-decision-table.md` (§ Connection builders): `ConnectionPip`/`build*ConnectionPips` → `ConnectionBar` (detail-page cascade-nav); `ConnectionChipProps`/`build*Connections` → `ConnectionChipStrip` (footer card, nav+azioni). Quale usare per quale superficie.
+
+## 4. Parte B — modulo status-mapping unificato
+
+**Nuovo modulo** `apps/web/src/lib/kb/processing-status.ts` (funzione pura, no React):
+
+```ts
+import type { ProcessingState } from '@/lib/api/schemas/kb-docs.schemas';
+
+export type KbDisplayStatus = 'processing' | 'indexed' | 'failed' | 'none';
+
+// Esaustivo sull'enum canonico: un nuovo ProcessingState → errore TS al build.
+const CANONICAL = {
+  pending: 'processing',   // DEC-Q2: Pending → processing
+  uploading: 'processing',
+  extracting: 'processing',
+  chunking: 'processing',
+  embedding: 'processing',
+  indexing: 'processing',
+  ready: 'indexed',
+  failed: 'failed',
+} satisfies Record<Lowercase<ProcessingState>, KbDisplayStatus>;
+
+// Alias/varianti legacy (endpoint /pdfs/{id}/text: payload lowercase diverso).
+const ALIASES: Record<string, KbDisplayStatus> = {
+  completed: 'indexed',    // alias di Ready
+  uploaded: 'processing',  // alias di Uploading
+  processing: 'processing',
+};
+
+export function mapProcessingStateToDisplayStatus(
+  state: string | null | undefined
+): KbDisplayStatus {
+  const k = String(state ?? '').trim().toLowerCase();
+  return (CANONICAL as Record<string, KbDisplayStatus>)[k] ?? ALIASES[k] ?? 'none';
+}
+```
+
+- **Case-insensitive + alias-aware** → assorbe i 3 formati di input (PascalCase canonico, lowercase, `uploaded`/`completed`). Corregge il bug del Mapper 3 (Chunking/Embedding/Pending/Uploading → `processing`).
+- `satisfies Record<Lowercase<ProcessingState>, …>` = **enum-coverage a compile-time**.
+
+**Sostituzione dei 3 mapper** (delegano al modulo; firme pubbliche invariate dove hanno consumer, per minimizzare churn):
+- `extra-meeple-card/drawer-helpers.ts` `mapProcessingStateToStatus(state)` → `return mapProcessingStateToDisplayStatus(state)`.
+- `library/kb-utils.ts` `mapToIndexingStatus(input)` → `return mapProcessingStateToDisplayStatus(input.processingState ?? input.processingStatus)`.
+- `use-kb-detail.ts` `statusMap` → rimpiazzato dalla chiamata al modulo (bug risolto).
+
+## 5. Testing
+
+- **`lib/kb/__tests__/processing-status.test.ts`** (enum-coverage):
+  - Per ciascuno degli 8 stati canonici (PascalCase) + le loro varianti lowercase + i 3 alias (`completed`/`uploaded`/`processing`) → asserisce il `KbDisplayStatus` atteso.
+  - Asserisce esplicitamente `Pending → 'processing'` e `Chunking/Embedding/Uploading → 'processing'` (i gap del Mapper 3).
+  - `null`/`undefined`/`''`/stringa ignota → `'none'`.
+  - L'esaustività sugli 8 canonici è garantita a compile-time dal `satisfies` (un nuovo enum value rompe il build).
+- **Snapshot slot-order** (Parte A): ogni builder delle due famiglie ha un test d'ordine (vedi §3).
+- **Verifica finale:** `pnpm test` mirato (kb/status + connection builders), `pnpm typecheck`, `pnpm lint`, `pnpm build`.
+
+## 6. Strategia TDD (ordine)
+
+1. **Parte B**: `processing-status.ts` + `processing-status.test.ts` (rosso→verde); poi sostituisco i 3 mapper e aggiorno/riduco i loro test esistenti (i test dei mapper diventano thin, o si spostano nel test del modulo).
+2. **Parte A**: rename `connection-bar` builders + barrel + consumer + test (typecheck-guidato); poi snapshot slot-order su entrambe le famiglie; poi doc.
+
+Le due parti sono indipendenti; stesso PR.
+
+## 7. Scope
+
+**In scope:** rename `connection-bar` builders + snapshot slot-order (entrambe le famiglie) + doc; modulo `processing-status` + sostituzione dei 3 mapper + enum-coverage test.
+
+**Fuori scope (deferiti):**
+- Merge dei tipi `ConnectionPip`/`ConnectionChipProps` → rifiutato (non fondibili, §1.1).
+- Rename dei builder `nav-items` → non necessario (collisione già risolta rinominando `connection-bar`).
+- Verificare col BE il payload `uploaded` dell'endpoint `/pdfs/{id}/text` → il modulo lo gestisce via alias; un allineamento BE è follow-up separato.
+
+## 8. Rischi
+
+| Rischio | Mitigazione |
+|---|---|
+| Rename `connection-bar` builders rompe consumer non trovati | Rename typecheck-guidato (`pnpm typecheck` fallisce su ogni consumer non aggiornato); grep pre-rename |
+| Cambio semantica Pending (`none`→`processing`) regredisce il game-detail drawer | Deciso in Q2; delta visibile atteso e più corretto (badge "in elaborazione" per Pending) |
+| Il modulo unificato cambia output per stati che un mapper trattava diversamente | Enum-coverage test esplicita la matrice attesa; i 3 mapper convergono sul canonico (è l'obiettivo) |
+| Alias `uploaded`/`completed` non esaustivi vs payload BE reale | Default `none` sicuro; test copre i casi noti; disallineamento BE = follow-up |
+
+## 9. Acceptance criteria
+
+- [ ] `connection-bar` builders rinominati `build*ConnectionPips`; barrel + consumer + test aggiornati; `pnpm typecheck` verde.
+- [ ] Ogni builder di entrambe le famiglie ha un test che asserisce la sequenza-slot esatta.
+- [ ] `card-decision-table.md` documenta la split delle 2 famiglie connection.
+- [ ] `lib/kb/processing-status.ts` presente; `mapProcessingStateToDisplayStatus` case-insensitive + alias-aware; Pending→processing; enum-coverage a compile-time (`satisfies`) + runtime.
+- [ ] I 3 mapper (`drawer-helpers`, `kb-utils`, `use-kb-detail`) delegano al modulo; il gap Chunking/Embedding/Pending/Uploading del Mapper 3 è corretto.
+- [ ] `processing-status.test.ts` verde (8 canonici + lowercase + 3 alias + null/ignoto→none).
+- [ ] `pnpm test` mirato, `pnpm typecheck`, `pnpm lint`, `pnpm build` verdi.


### PR DESCRIPTION
Closes #2860 (C3 / ST6 of umbrella #2863 "MeepleCard family debt teardown").

## What
- **Status-mapping unified.** New `apps/web/src/lib/kb/processing-status.ts` — one case-insensitive, alias-aware mapper `mapProcessingStateToDisplayStatus(state) → KbDisplayStatus` with compile-time enum coverage (`satisfies Record<Lowercase<ProcessingState>, KbDisplayStatus>`). The 3 previously-divergent mappers (`drawer-helpers`, `kb-utils`, `use-kb-detail`) now delegate. **Fixes a real bug**: `use-kb-detail` silently dropped `Chunking`/`Embedding`/`Pending`/`Uploading` to `none`; they now map to `processing`. Resolves the Pending disagreement to `processing`.
- **Connection builders disambiguated.** The `connection-bar` builders renamed `build*Connections` → `build*ConnectionPips`, removing the name collision with `meeple-card/nav-items/build*Connections` (which return the incompatible `ConnectionChipProps[]`). The two families are intentionally **NOT merged** (incompatible icon/count/interaction models — verified); only disambiguated + slot-order-locked by tests, and documented in the card decision-table.

## Design
`docs/superpowers/specs/2026-07-13-issue-2860-consolidate-connections-status-design.md` · Plan: `docs/superpowers/plans/2026-07-13-issue-2860-consolidate-connections-status.md`.

## Visible delta
The game-detail drawer now shows an "in elaborazione" badge for PDFs in Pending/Chunking/Embedding (previously no badge) — more accurate.

## Verification
- `pnpm typecheck` clean (confirms `satisfies` exhaustiveness + no missed rename).
- Vitest over the C3 surface (kb + connection-bar + nav-items + extra-meeple-card + library): 808 tests pass; `processing-status.test.ts` 28 tests.
- Whole-branch review (opus) caught + fixed a Critical: two consumer test files (`AgentCharacterSheet.test`, `GameDetailDesktop.test`) had `vi.mock` factories keyed by the old builder names (undefined post-rename, past typecheck); mock keys renamed, 10/10 pass.
- `pnpm lint` 0 errors; clean `pnpm build` 160/160 static pages.

Note: this branch was implemented inline (subagent per-task reviews hit an account session limit mid-run); the whole-branch opus review served as the independent gate and its Critical finding is fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)