### PR TITLE
fix(seed): derive prod/staging seed profile from ASPNETCORE_ENVIRONMENT (#2893)

### DIFF
--- a/apps/api/src/Api/Infrastructure/Seeders/SeedOrchestrator.cs
+++ b/apps/api/src/Api/Infrastructure/Seeders/SeedOrchestrator.cs
@@ -80,7 +80,8 @@ internal sealed class SeedOrchestrator
     }
 
     /// <summary>
-    /// Resolve seed profile from SEED_PROFILE env var → Seeding:Profile config → default Dev.
+    /// Resolve seed profile in precedence order: SEED_PROFILE env var → Seeding:Profile config →
+    /// ASPNETCORE_ENVIRONMENT derivation (Production→Prod, Staging→Staging) → default Dev (#2893).
     /// </summary>
     internal static SeedProfile ResolveProfile(IConfiguration? configuration)
     {

--- a/apps/api/src/Api/Infrastructure/Seeders/SeedOrchestrator.cs
+++ b/apps/api/src/Api/Infrastructure/Seeders/SeedOrchestrator.cs
@@ -94,7 +94,19 @@ internal sealed class SeedOrchestrator
         if (!string.IsNullOrWhiteSpace(configValue) && Enum.TryParse<SeedProfile>(configValue, ignoreCase: true, out var cfgProfile))
             return cfgProfile;
 
-        // 3. Default to Dev for local development
+        // 3. Derive from ASPNETCORE_ENVIRONMENT so Production/Staging never fall open to the
+        //    Dev default (#2893). A prod deploy that forgets to set SEED_PROFILE previously
+        //    resolved to Dev, which would seed dev.yml + LivedIn synthetic data in production.
+        var aspNetEnv = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
+        if (!string.IsNullOrWhiteSpace(aspNetEnv))
+        {
+            if (aspNetEnv.Equals("Production", StringComparison.OrdinalIgnoreCase))
+                return SeedProfile.Prod;
+            if (aspNetEnv.Equals("Staging", StringComparison.OrdinalIgnoreCase))
+                return SeedProfile.Staging;
+        }
+
+        // 4. Default to Dev for local development (Development + any unrecognized environment)
         return SeedProfile.Dev;
     }
 

--- a/apps/api/tests/Api.Tests/Infrastructure/Seeders/SeedOrchestratorTests.cs
+++ b/apps/api/tests/Api.Tests/Infrastructure/Seeders/SeedOrchestratorTests.cs
@@ -72,6 +72,7 @@ public sealed class SeedOrchestratorTests
     [InlineData("Production", SeedProfile.Prod)]
     [InlineData("production", SeedProfile.Prod)]
     [InlineData("Staging", SeedProfile.Staging)]
+    [InlineData("staging", SeedProfile.Staging)]
     [InlineData("Development", SeedProfile.Dev)]
     [InlineData("SomethingElse", SeedProfile.Dev)]
     public void ResolveProfile_DerivesFromAspNetCoreEnvironment_WhenNoEnvVarOrConfig(string aspNetEnv, SeedProfile expected)

--- a/apps/api/tests/Api.Tests/Infrastructure/Seeders/SeedOrchestratorTests.cs
+++ b/apps/api/tests/Api.Tests/Infrastructure/Seeders/SeedOrchestratorTests.cs
@@ -53,8 +53,79 @@ public sealed class SeedOrchestratorTests
     public void ResolveProfile_DefaultsToDev_WhenNothingConfigured()
     {
         Environment.SetEnvironmentVariable("SEED_PROFILE", null);
-        var result = SeedOrchestrator.ResolveProfile(null);
-        result.Should().Be(SeedProfile.Dev);
+        var previousAspNetEnv = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
+        Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", null);
+        try
+        {
+            var result = SeedOrchestrator.ResolveProfile(null);
+            result.Should().Be(SeedProfile.Dev);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", previousAspNetEnv);
+        }
+    }
+
+    // #2893: when SEED_PROFILE and Seeding:Profile are both absent, the profile is derived
+    // from ASPNETCORE_ENVIRONMENT so Production never falls open to the Dev default.
+    [Theory]
+    [InlineData("Production", SeedProfile.Prod)]
+    [InlineData("production", SeedProfile.Prod)]
+    [InlineData("Staging", SeedProfile.Staging)]
+    [InlineData("Development", SeedProfile.Dev)]
+    [InlineData("SomethingElse", SeedProfile.Dev)]
+    public void ResolveProfile_DerivesFromAspNetCoreEnvironment_WhenNoEnvVarOrConfig(string aspNetEnv, SeedProfile expected)
+    {
+        Environment.SetEnvironmentVariable("SEED_PROFILE", null);
+        var previousAspNetEnv = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
+        Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", aspNetEnv);
+        try
+        {
+            var result = SeedOrchestrator.ResolveProfile(null);
+            result.Should().Be(expected);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", previousAspNetEnv);
+        }
+    }
+
+    [Fact]
+    public void ResolveProfile_EnvVar_TakesPrecedenceOver_AspNetCoreEnvironment()
+    {
+        var previousAspNetEnv = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
+        Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "Development");
+        Environment.SetEnvironmentVariable("SEED_PROFILE", "Prod");
+        try
+        {
+            var result = SeedOrchestrator.ResolveProfile(null);
+            result.Should().Be(SeedProfile.Prod);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("SEED_PROFILE", null);
+            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", previousAspNetEnv);
+        }
+    }
+
+    [Fact]
+    public void ResolveProfile_Config_TakesPrecedenceOver_AspNetCoreEnvironment()
+    {
+        Environment.SetEnvironmentVariable("SEED_PROFILE", null);
+        var previousAspNetEnv = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
+        Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", "Production");
+        try
+        {
+            var config = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?> { ["Seeding:Profile"] = "Staging" })
+                .Build();
+            var result = SeedOrchestrator.ResolveProfile(config);
+            result.Should().Be(SeedProfile.Staging);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", previousAspNetEnv);
+        }
     }
 
     [Fact]

--- a/infra/compose.prod.yml
+++ b/infra/compose.prod.yml
@@ -72,6 +72,10 @@ services:
       - ./secrets/prod/storage.secret
     environment:
       ASPNETCORE_ENVIRONMENT: Production
+      # #2893: pin the seed profile explicitly so production never falls back to the
+      # Dev default (which would seed dev.yml + LivedIn synthetic data). Prod runs the
+      # Core layer only (admin + AI models); the game catalog is populated separately.
+      SEED_PROFILE: Prod
       ASPNETCORE_URLS: http://+:8080
       POSTGRES_HOST: postgres
       POSTGRES_USER: ${POSTGRES_USER:-meeple}


### PR DESCRIPTION
## Problem

`SeedOrchestrator.ResolveProfile` (`apps/api/src/Api/Infrastructure/Seeders/SeedOrchestrator.cs`) resolves the seed profile as:

```
env SEED_PROFILE  →  config Seeding:Profile  →  DEFAULT = Dev
```

`infra/compose.prod.yml` sets neither `SEED_PROFILE` nor `Seeding:Profile` (only `ASPNETCORE_ENVIRONMENT=Production`), so a **production** boot resolved to the `Dev` default → the Catalog layer loads `dev.yml` (160 games incl. the synthetic `Nanolith`) and the **`LivedInSeedLayer`** (synthetic data) runs **in production**.

Only `compose.staging.yml:66` wires `SEED_PROFILE` (`=Staging`); prod was never given one. Full analysis + live verification in #2893.

## Fix

- **`ResolveProfile`**: add a derivation step from `ASPNETCORE_ENVIRONMENT` — `Production→Prod`, `Staging→Staging` — before the `Dev` fallback. `Development` and any unrecognized/empty environment still fall through to `Dev`, so `make dev` and CI (which set no explicit `SEED_PROFILE`) are **unchanged**.
- **`compose.prod.yml`**: pin `SEED_PROFILE: Prod` explicitly (mirror of staging; belt-and-suspenders on top of the code change).
- **Tests**: cover the new derivation (`Production/Staging/Development/unknown`) and precedence (`SEED_PROFILE` and `Seeding:Profile` still win over `ASPNETCORE_ENVIRONMENT`); the existing default-Dev test now also clears `ASPNETCORE_ENVIRONMENT` to assert the true final fallback.

## Behaviour matrix (after)

| Env | `SEED_PROFILE` | Resolved profile | Change |
|---|---|---|---|
| dev (`make dev`) | (none) → ASPNETCORE=Development | `Dev` | unchanged |
| staging | `Staging` (explicit) | `Staging` | unchanged |
| **prod** | `Prod` (now explicit) / ASPNETCORE=Production | **`Prod`** | **fixed** (was `Dev`) |
| CI/test | (none) | `Dev` | unchanged |

## Notes / non-goals

- With `Prod`, the Catalog layer (`MinimumProfile = Staging`) does **not** run — prod seeds the **Core layer only** (admin + AI models). This is by design; the production game catalog is populated separately via the admin **Catalog Seed Pipeline** (#1903). No catalog regression.
- **Out of scope**: `scripts/deployment/deploy-meepleai.ps1` references `compose.meepleai.yml`, which does not exist in the repo or on the known host — flagged in #2893 for separate reconciliation.

## Verification

- `dotnet test --filter SeedOrchestratorTests` → **19/19 pass** (12 existing + 7 new).
- Live-checked staging (`204.168.135.69`): already resolves `Seeding with profile: Staging`, so this change is a no-op there.

Closes #2893

🤖 Generated with [Claude Code](https://claude.com/claude-code)
