### PR TITLE
fix(auth): #2894 wrap backup-code verify in execution strategy + inline 2FA email in tests

### DIFF
--- a/apps/api/src/Api/Services/TotpService.cs
+++ b/apps/api/src/Api/Services/TotpService.cs
@@ -505,84 +505,120 @@ internal class TotpService : ITotpService
 
     private async Task<bool> ExecuteBackupCodeTransactionAsync(Guid userId, string backupCode, CancellationToken cancellationToken)
     {
-        // Use transaction with Serializable isolation to prevent concurrent use of same code
-        using var transaction = await _dbContext.Database.BeginTransactionAsync(System.Data.IsolationLevel.Serializable, cancellationToken).ConfigureAwait(false);
-        try
+        // Issue #2894: the DbContext enables EnableRetryOnFailure (NpgsqlRetryingExecutionStrategy) both in
+        // production (InfrastructureServiceExtensions.cs) and in the integration test factory, which forbids a
+        // user-initiated transaction unless it runs through an execution strategy. Wrap the whole
+        // read-verify-mark-used unit so a serialization conflict rolls back and re-runs atomically as one
+        // retriable operation — matching the repo convention (HandleOAuthCallbackCommandHandler, AuditLoggingBehavior, …).
+        var strategy = _dbContext.Database.CreateExecutionStrategy();
+        var outcome = await strategy.ExecuteAsync(async () =>
         {
-            // Get all unused backup codes for user (within transaction)
-            var backupCodes = await _dbContext.UserBackupCodes
-                .Where(bc => bc.UserId == userId && !bc.IsUsed)
-                .ToListAsync(cancellationToken).ConfigureAwait(false);
-
-            if (backupCodes.Count == 0)
+            // Use transaction with Serializable isolation to prevent concurrent use of same code
+            using var transaction = await _dbContext.Database.BeginTransactionAsync(System.Data.IsolationLevel.Serializable, cancellationToken).ConfigureAwait(false);
+            try
             {
-                _logger.LogWarning("Backup code verify failed: No unused codes for user {UserId}", userId);
-                await _auditService.LogAsync(userId.ToString(), "BackupCodeVerify", "TwoFactor", userId.ToString(), "Failed",
-                    "No unused backup codes available").ConfigureAwait(false);
-                return false;
-            }
+                // Get all unused backup codes for user (within transaction)
+                var backupCodes = await _dbContext.UserBackupCodes
+                    .Where(bc => bc.UserId == userId && !bc.IsUsed)
+                    .ToListAsync(cancellationToken).ConfigureAwait(false);
 
-            // Verify code against hashed codes (constant-time comparison via PBKDF2)
-            foreach (var storedCode in backupCodes)
-            {
-                var isMatch = VerifyBackupCode(storedCode.CodeHash, backupCode);
-                if (isMatch)
+                if (backupCodes.Count == 0)
                 {
-                    // Mark as used (atomic with transaction commit)
-                    storedCode.IsUsed = true;
-                    storedCode.UsedAt = _timeProvider.GetUtcNow().UtcDateTime;
-                    await _dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-                    await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
-
-                    var remainingCodes = backupCodes.Count - 1;
-                    await _auditService.LogAsync(userId.ToString(), "BackupCodeUsed", "TwoFactor", userId.ToString(), "Success",
-                        $"User authenticated with backup code ({remainingCodes} remaining)").ConfigureAwait(false);
-                    _logger.LogInformation("Backup code used for user {UserId}, {Remaining} codes remaining",
-                        userId, remainingCodes);
-
-                    // Warn if low on backup codes
-                    if (remainingCodes < 3)
-                    {
-                        _logger.LogWarning("User {UserId} has only {Remaining} backup codes remaining",
-                            userId, remainingCodes);
-                    }
-
-                    // SEC-05: Clear failed attempts on successful verification
-                    await ClearFailedAttemptsAsync(userId, "backup").ConfigureAwait(false);
-
-                    // SEC-08: Track successful backup code use
-                    MeepleAiMetrics.Record2FAVerification("backup_code", success: true, userId: userId.ToString());
-
-                    return true;
+                    _logger.LogWarning("Backup code verify failed: No unused codes for user {UserId}", userId);
+                    await _auditService.LogAsync(userId.ToString(), "BackupCodeVerify", "TwoFactor", userId.ToString(), "Failed",
+                        "No unused backup codes available").ConfigureAwait(false);
+                    return BackupCodeOutcome.NoCodes;
                 }
+
+                // Verify code against hashed codes (constant-time comparison via PBKDF2)
+                foreach (var storedCode in backupCodes)
+                {
+                    var isMatch = VerifyBackupCode(storedCode.CodeHash, backupCode);
+                    if (isMatch)
+                    {
+                        // Mark as used (atomic with transaction commit)
+                        storedCode.IsUsed = true;
+                        storedCode.UsedAt = _timeProvider.GetUtcNow().UtcDateTime;
+                        await _dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+                        await transaction.CommitAsync(cancellationToken).ConfigureAwait(false);
+
+                        var remainingCodes = backupCodes.Count - 1;
+                        await _auditService.LogAsync(userId.ToString(), "BackupCodeUsed", "TwoFactor", userId.ToString(), "Success",
+                            $"User authenticated with backup code ({remainingCodes} remaining)").ConfigureAwait(false);
+                        _logger.LogInformation("Backup code used for user {UserId}, {Remaining} codes remaining",
+                            userId, remainingCodes);
+
+                        // Warn if low on backup codes
+                        if (remainingCodes < 3)
+                        {
+                            _logger.LogWarning("User {UserId} has only {Remaining} backup codes remaining",
+                                userId, remainingCodes);
+                        }
+
+                        // Non-transactional side-effects (Clear failed attempts, metrics) run once
+                        // after the strategy completes — see the switch below.
+                        return BackupCodeOutcome.Matched;
+                    }
+                }
+
+                // No match found. Non-transactional side-effects (failed-attempt tracking, alert, metrics)
+                // run once after the strategy completes — see the switch below.
+                _logger.LogWarning("Backup code verify failed: Invalid code for user {UserId}", userId);
+                await _auditService.LogAsync(userId.ToString(), "BackupCodeVerify", "TwoFactor", userId.ToString(), "Failed",
+                    "Failed backup code attempt").ConfigureAwait(false);
+
+                return BackupCodeOutcome.NoMatch;
             }
+            catch (DbUpdateException ex)
+            {
+                // Rewrapping a statement-time serialization failure (DbUpdateException) as a NON-transient
+                // InvalidOperationException intentionally suppresses an execution-strategy retry for this
+                // path — do NOT "simplify" this catch. A commit-time 40001 still propagates as a transient
+                // PostgresException and IS retried, which is why the side-effects live outside the strategy.
+                _logger.LogError(ex, "Database error during backup code verification for user {UserId}", userId);
+                await transaction.RollbackAsync(cancellationToken).ConfigureAwait(false);
+                throw new InvalidOperationException("Failed to verify backup code due to database error", ex);
+            }
+            catch (CryptographicException ex)
+            {
+                _logger.LogError(ex, "Cryptographic error during backup code verification for user {UserId}", userId);
+                await transaction.RollbackAsync(cancellationToken).ConfigureAwait(false);
+                throw new InvalidOperationException("Failed to verify backup code due to cryptographic error", ex);
+            }
+        }).ConfigureAwait(false);
 
-            // No match found
-            _logger.LogWarning("Backup code verify failed: Invalid code for user {UserId}", userId);
-            await _auditService.LogAsync(userId.ToString(), "BackupCodeVerify", "TwoFactor", userId.ToString(), "Failed",
-                "Failed backup code attempt").ConfigureAwait(false);
-
-            // SEC-05: Track failed attempt for lockout mechanism
-            await TrackFailedAttemptAsync(userId, "backup").ConfigureAwait(false);
-            await CheckAndTriggerSecurityAlertAsync(userId, "BackupCode", cancellationToken).ConfigureAwait(false);
-
-            // SEC-08: Track failed backup code attempt
-            MeepleAiMetrics.Record2FAVerification("backup_code", success: false, userId: userId.ToString());
-
-            return false;
-        }
-        catch (DbUpdateException ex)
+        // #2894 review: non-transactional side-effects run exactly ONCE on the final outcome, deliberately
+        // OUTSIDE strategy.ExecuteAsync. A commit-time serialization conflict (Postgres 40001) is transient,
+        // so the strategy re-runs the delegate — but the Redis lockout counters, the security alert, and the
+        // metrics below must not double-fire on that retry. The DB read-verify-mark-used unit is what re-runs.
+        switch (outcome)
         {
-            _logger.LogError(ex, "Database error during backup code verification for user {UserId}", userId);
-            await transaction.RollbackAsync(cancellationToken).ConfigureAwait(false);
-            throw new InvalidOperationException("Failed to verify backup code due to database error", ex);
+            case BackupCodeOutcome.Matched:
+                await ClearFailedAttemptsAsync(userId, "backup").ConfigureAwait(false); // SEC-05
+                MeepleAiMetrics.Record2FAVerification("backup_code", success: true, userId: userId.ToString()); // SEC-08
+                return true;
+
+            case BackupCodeOutcome.NoMatch:
+                await TrackFailedAttemptAsync(userId, "backup").ConfigureAwait(false); // SEC-05 lockout
+                await CheckAndTriggerSecurityAlertAsync(userId, "BackupCode", cancellationToken).ConfigureAwait(false);
+                MeepleAiMetrics.Record2FAVerification("backup_code", success: false, userId: userId.ToString()); // SEC-08
+                return false;
+
+            case BackupCodeOutcome.NoCodes:
+            default:
+                return false;
         }
-        catch (CryptographicException ex)
-        {
-            _logger.LogError(ex, "Cryptographic error during backup code verification for user {UserId}", userId);
-            await transaction.RollbackAsync(cancellationToken).ConfigureAwait(false);
-            throw new InvalidOperationException("Failed to verify backup code due to cryptographic error", ex);
-        }
+    }
+
+    /// <summary>
+    /// Outcome of the transactional backup-code check, returned from the retriable execution strategy so
+    /// non-transactional side-effects (Redis lockout counters, security alert, metrics) run exactly once.
+    /// </summary>
+    private enum BackupCodeOutcome
+    {
+        NoCodes,
+        NoMatch,
+        Matched
     }
 
     /// <summary>

--- a/apps/api/tests/Api.Tests/Integration/Authentication/AdminDisable2FAIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/Authentication/AdminDisable2FAIntegrationTests.cs
@@ -4,6 +4,7 @@ using Api.BoundedContexts.Authentication.Domain.Events;
 using Api.BoundedContexts.Authentication.Domain.ValueObjects;
 using Api.BoundedContexts.Authentication.Infrastructure.Persistence;
 using Api.Infrastructure;
+using Api.Infrastructure.DomainEventOutbox;
 using Api.Services;
 using Api.SharedKernel.Infrastructure.Persistence;
 using Api.Tests.BoundedContexts.Authentication.TestHelpers;
@@ -13,6 +14,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Moq;
 using Npgsql;
 using Xunit;
@@ -72,6 +74,14 @@ public sealed class AdminDisable2FAIntegrationTests : IAsyncLifetime
         _output($"Isolated database created: {_databaseName}");
 
         var services = IntegrationServiceCollectionBuilder.CreateBase(_isolatedDbConnectionString);
+
+        // Issue #2894: these tests assert the E2E email side-effect, which is raised by
+        // TwoFactorDisabledEventHandler (a domain-event handler). CreateBase defaults to OutboxOnly —
+        // out-of-band dispatch via the DomainEventOutboxProcessor, which doesn't run inline here — so the
+        // handler never fires against the mock IEmailService (was 0 times). Override to Hybrid so the event
+        // dispatches inline during SaveChangesAsync, per IntegrationServiceCollectionBuilder's docstring.
+        services.AddSingleton<IOptions<DomainEventOutboxOptions>>(
+            Options.Create(new DomainEventOutboxOptions { Mode = DomainEventDispatchMode.Hybrid }));
 
         services.AddScoped<IUserRepository, UserRepository>();
         services.AddSingleton<TimeProvider>(TimeProvider.System);


### PR DESCRIPTION
## Fixes #2894

Clears all 7 baseline-red `BoundedContext=Authentication` integration tests (surfaced during #2804 verification). Two root causes.

### Cluster B — latent **PRODUCTION bug** (`TotpService.cs`)
`ExecuteBackupCodeTransactionAsync` opened `BeginTransactionAsync(Serializable)` directly. With `EnableRetryOnFailure` (NpgsqlRetryingExecutionStrategy) configured in prod (`InfrastructureServiceExtensions.cs:158`) **and** the test factory, EF forbids user-initiated transactions unless run through an execution strategy — so backup-code verification threw `InvalidOperationException` at runtime. `TotpService` was the **only** unwrapped transaction site in the repo.

**Fix**: wrap the read-verify-mark-used unit in `Database.CreateExecutionStrategy().ExecuteAsync(...)`.

Security semantics verified preserved (code review): single-use (`ReplayAttack_ReuseBackupCode`) and concurrent single-winner (`ReplayAttack_ConcurrentBackupCodeUse`, `successCount==1`) hold even on the retry path — a retried delegate re-reads and finds the code already used.

**Code-review hardening (return-result refactor)**: a serialization conflict raised at `CommitAsync` throws a transient `PostgresException` (40001) that the strategy retries. To stop the **non-transactional** side-effects (Redis lockout counters, security alert, metrics) from double-firing on that retry, the transactional delegate now returns a `BackupCodeOutcome` enum and those side-effects run exactly **once** outside `ExecuteAsync`. The statement-time-conflict catch is documented as intentionally non-transient (suppresses retry).

### Cluster A — test observability (`AdminDisable2FAIntegrationTests.cs`)
The 3 tests asserting `SendTwoFactorDisabledEmailAsync` (`Times.Once`) failed because the email is raised by `TwoFactorDisabledEventHandler` (a domain-event handler) dispatched via the outbox under the factory's default `OutboxOnly` mode → never fires inline against the mock.

**Fix**: override the dispatch mode to `Hybrid` in the test setup (documented in `IntegrationServiceCollectionBuilder`) so the event dispatches inline.

### Not a bug
Dev running `DomainEventOutbox.Mode=Hybrid` vs prod `OutboxOnly` is **deliberate and documented** (`appsettings.json:7`) — unchanged.

### Verification
- ✅ 23/23 tests in both files green locally (7 baseline-red cleared), pre-fix RED confirmed.
- ✅ Code review: **ready to merge** (0 Critical), Important finding on retry-side-effect duplication addressed by the refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)