### PR TITLE
chore(infra): drop orphan compose.meepleai.yml ref from deploy-meepleai.ps1 (#2898)

### DIFF
--- a/scripts/deployment/deploy-meepleai.ps1
+++ b/scripts/deployment/deploy-meepleai.ps1
@@ -35,11 +35,12 @@ $ScriptDir = Split-Path -Parent $PSCommandPath
 $ProjectRoot = Split-Path -Parent (Split-Path -Parent $ScriptDir)
 $InfraDir = Join-Path $ProjectRoot 'infra'
 
-# Compose files (post-PR #738 — Traefik decommissioned, edge=CF Tunnel)
+# Compose files (post-PR #738 — Traefik decommissioned, edge=CF Tunnel).
+# compose.meepleai.yml (legacy Traefik/socket-proxy override for meepleai.io) was
+# dropped from the tree and is obsolete under CF Tunnel — removed here (#2898).
 $ComposeFiles = @(
     '-f', 'docker-compose.yml',
-    '-f', 'compose.prod.yml',
-    '-f', 'compose.meepleai.yml'
+    '-f', 'compose.prod.yml'
 )
 
 Set-Location $InfraDir

--- a/scripts/deployment/deploy-meepleai.ps1
+++ b/scripts/deployment/deploy-meepleai.ps1
@@ -2,7 +2,7 @@
 # MeepleAI Production Deployment Script (PowerShell)
 # =============================================================================
 #
-# Deploys MeepleAI to production at meepleai.io
+# Deploys MeepleAI to production at meepleai.app
 #
 # Usage:
 #   .\scripts\deployment\deploy-meepleai.ps1 [command]
@@ -151,9 +151,9 @@ function Show-Status {
     Write-Host "           Endpoints                    " -ForegroundColor Cyan
     Write-Host "=========================================" -ForegroundColor Cyan
     Write-Host ""
-    Write-Host "  🌐 Website:    https://www.meepleai.io"
-    Write-Host "  🔌 API:        https://api.meepleai.io"
-    Write-Host "  📊 Grafana:    https://grafana.meepleai.io"
+    Write-Host "  🌐 Website:    https://meepleai.app"
+    Write-Host "  🔌 API:        https://api.meepleai.app"
+    Write-Host "  📊 Grafana:    https://grafana.meepleai.app"
     Write-Host "  ☁️  Edge:       Cloudflare Tunnel (cloudflared on VPS)"
     Write-Host ""
 }


### PR DESCRIPTION
## Problem

`scripts/deployment/deploy-meepleai.ps1` mounted a third compose file that **does not exist**:

```powershell
$ComposeFiles = @(
    '-f', 'docker-compose.yml',
    '-f', 'compose.prod.yml',
    '-f', 'compose.meepleai.yml'   # <-- missing
)
```

`compose.meepleai.yml` is absent from the repo, the prod-intended checkout, and active compose projects, so every `docker compose @ComposeFiles ...` call (`up`/`down`/`restart`/`logs`/`status`/`backup`/`update`) would fail with a missing-file error.

## Root cause

The file existed — added in `47367438a` (2026-01-20) as a **Traefik override for `meepleai.io`** (socket-proxy + Traefik + Let's Encrypt + `api/www/grafana.meepleai.io` routers). It was later dropped from the tree, but the script kept referencing it. It is doubly obsolete:
- **Traefik was decommissioned** (post-PR #738 → Cloudflare Tunnel). The script itself already declares `edge=CF Tunnel` and had removed the Traefik dirs — only the array line was left behind.
- The domain is **`meepleai.app`**, not the historical `meepleai.io`.

## Changes

1. **Drop the orphan `-f compose.meepleai.yml` line** → `docker-compose.yml + compose.prod.yml` only. Self-sufficient and consistent with the working staging deploy (`deploy-staging.sh` mounts `docker-compose.yml + compose.staging.yml`, no third file). `compose.prod.yml` has all services + volumes; edge is CF Tunnel on the VPS, not in compose.
2. **Update endpoints to `meepleai.app`** (prod domain, confirmed). Header + `Show-Status` now print the real Cloudflare Tunnel hostnames used on `meepleai.app` (per `compose.staging.yml:122,262`):
   - Website → `https://meepleai.app`
   - API → `https://api.meepleai.app`
   - Grafana → `https://grafana.meepleai.app`

The line-39 comment intentionally keeps the `meepleai.io` reference — it documents the obsolete legacy Traefik override that targeted that domain.

## Verification

- PowerShell parse check: no syntax errors (both commits).
- No active `-f compose.meepleai.yml` reference remains; no active `meepleai.io` endpoint remains (only the historical comment).
- Domain/hostname structure cross-checked against `compose.staging.yml` (the live `meepleai.app` reference) and the running staging host via SSH.

Closes #2898

🤖 Generated with [Claude Code](https://claude.com/claude-code)
