### PR TITLE
refactor(meeple-card): migrate entity color helpers to theme-aware --c-* vars (#2862)

### DIFF
--- a/apps/web/src/__tests__/components/meeple-card/ManaPips.test.tsx
+++ b/apps/web/src/__tests__/components/meeple-card/ManaPips.test.tsx
@@ -76,10 +76,10 @@ describe('ManaPips', () => {
     const { container } = render(<ManaPips pips={pips} size="sm" />);
     const dot = container.querySelector('.rounded-full');
     expect(dot).not.toBeNull();
-    // Default KB color hsl(210, 40%, 48%) => rgb(73, 122, 171) in jsdom
-    // (lightness lowered from 55% to 48% by issue #636 to meet WCAG AA
-    // contrast for white text on the EntityBadge surface)
-    expect((dot as HTMLElement).style.background).toBe('rgb(73, 122, 171)');
+    // #2862: the default pip color now emits the theme-aware canonical
+    // --c-kb var (was the concrete light-only hsl that jsdom rendered as
+    // rgb(73, 122, 171)). jsdom preserves the `hsl(var(...))` form verbatim.
+    expect((dot as HTMLElement).style.background).toBe('hsl(var(--c-kb))');
   });
 
   it('uses different color for colorOverride vs default', () => {

--- a/apps/web/src/__tests__/styles/entity-text-tokens-c5.test.ts
+++ b/apps/web/src/__tests__/styles/entity-text-tokens-c5.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const CSS = readFileSync(
+  resolve(__dirname, '..', '..', 'styles', 'design-tokens-canonical.css'),
+  'utf8'
+);
+
+// #ffffff (light card) and #1e1710 (dark card) — the EntityBadge pill surface.
+const LIGHT_BG: [number, number, number] = [255, 255, 255];
+const DARK_BG: [number, number, number] = [30, 23, 16];
+
+function block(theme: 'light' | 'dark'): string {
+  if (theme === 'light') return CSS.slice(0, CSS.indexOf('[data-theme="dark"]'));
+  return CSS.slice(CSS.indexOf('[data-theme="dark"]'));
+}
+
+function hslToRgb(h: number, s: number, l: number): [number, number, number] {
+  s /= 100;
+  l /= 100;
+  const c = (1 - Math.abs(2 * l - 1)) * s;
+  const hp = h / 60;
+  const x = c * (1 - Math.abs((hp % 2) - 1));
+  let r = 0,
+    g = 0,
+    b = 0;
+  if (hp < 1) [r, g, b] = [c, x, 0];
+  else if (hp < 2) [r, g, b] = [x, c, 0];
+  else if (hp < 3) [r, g, b] = [0, c, x];
+  else if (hp < 4) [r, g, b] = [0, x, c];
+  else if (hp < 5) [r, g, b] = [x, 0, c];
+  else [r, g, b] = [c, 0, x];
+  const m = l - c / 2;
+  return [Math.round((r + m) * 255), Math.round((g + m) * 255), Math.round((b + m) * 255)];
+}
+function lum([r, g, b]: [number, number, number]): number {
+  const f = (v: number) => {
+    const s = v / 255;
+    return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+  };
+  return 0.2126 * f(r) + 0.7152 * f(g) + 0.0722 * f(b);
+}
+function contrast(a: [number, number, number], b: [number, number, number]): number {
+  const [hi, lo] = lum(a) > lum(b) ? [lum(a), lum(b)] : [lum(b), lum(a)];
+  return (hi + 0.05) / (lo + 0.05);
+}
+function readVar(theme: 'light' | 'dark', name: string): [number, number, number] {
+  const m = block(theme).match(new RegExp(name + ':\\s*(\\d+)\\s+(\\d+)%\\s+(\\d+)%'));
+  if (!m) throw new Error(`${name} not found in ${theme} block`);
+  return hslToRgb(Number(m[1]), Number(m[2]), Number(m[3]));
+}
+
+describe('C5 — new --c-*-text vars are AA on the EntityBadge pill (#2862)', () => {
+  it.each(['--c-event-text', '--c-agent-text', '--c-chat-text'])(
+    '%s light value >= 4.5:1 on white card',
+    name => {
+      expect(contrast(readVar('light', name), LIGHT_BG)).toBeGreaterThanOrEqual(4.5);
+    }
+  );
+  it.each(['--c-event-text', '--c-agent-text', '--c-chat-text'])(
+    '%s dark value >= 4.5:1 on dark card',
+    name => {
+      expect(contrast(readVar('dark', name), DARK_BG)).toBeGreaterThanOrEqual(4.5);
+    }
+  );
+});

--- a/apps/web/src/__tests__/styles/entity-text-tokens-c5.test.ts
+++ b/apps/web/src/__tests__/styles/entity-text-tokens-c5.test.ts
@@ -7,9 +7,13 @@ const CSS = readFileSync(
   'utf8'
 );
 
-// #ffffff (light card) and #1e1710 (dark card) — the EntityBadge pill surface.
+// The EntityBadge glass pill renders on Tailwind's `bg-card`, i.e. the semantic
+// `--card` token (globals.css), NOT the `--bg-card` mockup family. Its solid
+// value is the conservative AA surface: light `--card` = `0 0% 100%` (#ffffff),
+// dark `--card` = `0 0% 18%` (~#2e2e2e, globals.css:658). Validate against those
+// — the same target `--c-session-text` is tuned for (globals.css:714).
 const LIGHT_BG: [number, number, number] = [255, 255, 255];
-const DARK_BG: [number, number, number] = [30, 23, 16];
+const DARK_BG: [number, number, number] = hslToRgb(0, 0, 18);
 
 function block(theme: 'light' | 'dark'): string {
   if (theme === 'light') return CSS.slice(0, CSS.indexOf('[data-theme="dark"]'));

--- a/apps/web/src/components/ui/data-display/meeple-card/__tests__/tokens-entityTokens.test.ts
+++ b/apps/web/src/components/ui/data-display/meeple-card/__tests__/tokens-entityTokens.test.ts
@@ -3,28 +3,29 @@ import { describe, expect, it } from 'vitest';
 import { entityTokens } from '../tokens';
 
 describe('entityTokens()', () => {
-  it('returns solid color using existing entityHsl', () => {
+  // #2862 (C5): entityTokens now emits theme-aware canonical --c-* CSS vars.
+  it('returns solid color as the canonical --c-* var', () => {
     const t = entityTokens('game');
-    expect(t.solid).toBe('hsl(25, 95%, 39%)');
+    expect(t.solid).toBe('hsl(var(--c-game))');
   });
 
   it('returns fill with 0.12 alpha', () => {
     const t = entityTokens('game');
-    expect(t.fill).toBe('hsla(25, 95%, 39%, 0.12)');
+    expect(t.fill).toBe('hsl(var(--c-game) / 0.12)');
   });
 
   it('returns border with 0.35 alpha', () => {
     const t = entityTokens('game');
-    expect(t.border).toBe('hsla(25, 95%, 39%, 0.35)');
+    expect(t.border).toBe('hsl(var(--c-game) / 0.35)');
   });
 
   it('returns named tokens for hover, glow, shadow, muted, dashed', () => {
     const t = entityTokens('kb');
-    expect(t.hover).toBe('hsla(210, 40%, 48%, 0.22)');
-    expect(t.glow).toBe('hsla(210, 40%, 48%, 0.18)');
-    expect(t.shadow).toBe('hsla(210, 40%, 48%, 0.25)');
-    expect(t.muted).toBe('hsla(210, 40%, 48%, 0.06)');
-    expect(t.dashed).toBe('hsla(210, 40%, 48%, 0.25)');
+    expect(t.hover).toBe('hsl(var(--c-kb) / 0.22)');
+    expect(t.glow).toBe('hsl(var(--c-kb) / 0.18)');
+    expect(t.shadow).toBe('hsl(var(--c-kb) / 0.25)');
+    expect(t.muted).toBe('hsl(var(--c-kb) / 0.06)');
+    expect(t.dashed).toBe('hsl(var(--c-kb) / 0.25)');
   });
 
   it('returns textOn = #ffffff', () => {

--- a/apps/web/src/components/ui/data-display/meeple-card/__tests__/tokens.test.ts
+++ b/apps/web/src/components/ui/data-display/meeple-card/__tests__/tokens.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { entityColors, entityHsl, entityLabel, entityIcon, statusColors } from '../tokens';
+import {
+  entityColors,
+  entityHsl,
+  entityHslText,
+  entityLabel,
+  entityIcon,
+  statusColors,
+} from '../tokens';
 import type { MeepleEntityType } from '../types';
 
 const allEntities: MeepleEntityType[] = [
@@ -80,13 +87,35 @@ describe('entityColors', () => {
   });
 });
 
-describe('entityHsl', () => {
-  it('returns hsl string without alpha', () => {
-    expect(entityHsl('game')).toMatch(/^hsl\(/);
+describe('entityHsl (CSS-var-backed, theme-aware — #2862)', () => {
+  it('returns hsl(var(--c-<entity>)) without alpha', () => {
+    expect(entityHsl('game')).toBe('hsl(var(--c-game))');
   });
 
-  it('returns hsla string with alpha', () => {
-    expect(entityHsl('game', 0.5)).toMatch(/^hsla\(/);
+  it('returns hsl(var(--c-<entity>) / alpha) with alpha', () => {
+    expect(entityHsl('game', 0.5)).toBe('hsl(var(--c-game) / 0.5)');
+  });
+
+  it('maps gameNightEvent to the event palette', () => {
+    expect(entityHsl('gameNightEvent')).toBe('hsl(var(--c-event))');
+  });
+});
+
+describe('entityHslText (CSS-var-backed, theme-aware — #2862)', () => {
+  it.each(['game', 'kb', 'toolkit', 'session', 'event', 'agent', 'chat'] as const)(
+    '%s uses the -text variant',
+    entity => {
+      expect(entityHslText(entity)).toBe(`hsl(var(--c-${entity}-text))`);
+    }
+  );
+
+  it('player/tool fall back to the solid var (no -text)', () => {
+    expect(entityHslText('player')).toBe('hsl(var(--c-player))');
+    expect(entityHslText('tool')).toBe('hsl(var(--c-tool))');
+  });
+
+  it('gameNightEvent uses the event -text variant', () => {
+    expect(entityHslText('gameNightEvent')).toBe('hsl(var(--c-event-text))');
   });
 });
 

--- a/apps/web/src/components/ui/data-display/meeple-card/parts/EntityBadge.tsx
+++ b/apps/web/src/components/ui/data-display/meeple-card/parts/EntityBadge.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable local/no-hardcoded-color-utility -- glass bg-white/85 follows the mockup .e-bg pattern; entity color text via inline style. DS-12 primitive — see token-bridge-map.md for migration plan. */
 import { entityHslText, entityIcon, entityLabel } from '../tokens';
 
 import type { MeepleEntityType } from '../types';
@@ -19,7 +18,7 @@ export function EntityBadge({ entity, className = '', stacked = false }: EntityB
   return (
     <span
       data-slot="meeple-card-entity-badge"
-      className={`${positioning} inline-flex items-center gap-1 rounded-md bg-white/85 px-2 py-0.5 font-[var(--font-quicksand)] text-[9px] font-extrabold uppercase tracking-wide shadow-sm backdrop-blur-md ${className}`}
+      className={`${positioning} inline-flex items-center gap-1 rounded-md bg-card/85 px-2 py-0.5 font-[var(--font-quicksand)] text-[9px] font-extrabold uppercase tracking-wide shadow-sm backdrop-blur-md ${className}`}
       style={{ color: entityHslText(entity) }}
     >
       <span aria-hidden="true">{entityIcon[entity]}</span>

--- a/apps/web/src/components/ui/data-display/meeple-card/parts/__tests__/AccentBorder.test.tsx
+++ b/apps/web/src/components/ui/data-display/meeple-card/parts/__tests__/AccentBorder.test.tsx
@@ -2,7 +2,6 @@ import { describe, it, expect } from 'vitest';
 import { render } from '@testing-library/react';
 
 import { AccentBorder } from '../AccentBorder';
-import { entityHsl } from '../../tokens';
 
 describe('AccentBorder', () => {
   it('renders horizontal top bar (mockup-conformant: top-0 left-0 right-0 h-[3px])', () => {
@@ -21,12 +20,12 @@ describe('AccentBorder', () => {
     expect(el.className).not.toMatch(/\bw-\[3px\]\b/);
   });
 
-  it('uses entityHsl for inline background', () => {
+  it('uses the theme-aware entity CSS var for inline background (#2862)', () => {
     const { container } = render(<AccentBorder entity="player" />);
     const el = container.firstChild as HTMLElement;
-    // Browser renders HSL as RGB, so just verify it's set
-    expect(el.style.background).toBeTruthy();
-    expect(el.style.background).toContain('rgb');
+    // entityHsl now emits `hsl(var(--c-player))`; assert the var on the raw
+    // style attribute (robust to jsdom's CSSOM color parsing).
+    expect(el.getAttribute('style') ?? '').toContain('--c-player');
   });
 
   it('grows on group-hover via height transition', () => {

--- a/apps/web/src/components/ui/data-display/meeple-card/parts/__tests__/EntityBadge.test.tsx
+++ b/apps/web/src/components/ui/data-display/meeple-card/parts/__tests__/EntityBadge.test.tsx
@@ -14,10 +14,10 @@ describe('EntityBadge (glass restyle, #1856)', () => {
     expect(el.textContent).toContain(entityLabel.game);
   });
 
-  it('uses the glass background (bg-white/85 + backdrop-blur-md)', () => {
+  it('uses the theme-aware glass background (bg-card/85 + backdrop-blur-md — #2862)', () => {
     const { container } = render(<EntityBadge entity="game" />);
     const el = container.querySelector('[data-slot="meeple-card-entity-badge"]') as HTMLElement;
-    expect(el.className).toMatch(/bg-white\/85/);
+    expect(el.className).toMatch(/bg-card\/85/);
     expect(el.className).toMatch(/backdrop-blur-md/);
   });
 
@@ -63,7 +63,7 @@ describe('EntityBadge (glass restyle, #1856)', () => {
     for (const e of entities) {
       const { container, unmount } = render(<EntityBadge entity={e} />);
       const el = container.querySelector('[data-slot="meeple-card-entity-badge"]') as HTMLElement;
-      expect(el.className).toMatch(/bg-white\/85/);
+      expect(el.className).toMatch(/bg-card\/85/);
       expect(el.style.color).toBeTruthy();
       expect(el.style.color).not.toBe('');
       unmount();

--- a/apps/web/src/components/ui/data-display/meeple-card/tokens.ts
+++ b/apps/web/src/components/ui/data-display/meeple-card/tokens.ts
@@ -35,66 +35,53 @@ export const entityColors: Record<MeepleEntityType, { h: number; s: string; l: s
   gameNightEvent: { h: 350, s: '89%', l: '48%' },
 };
 
+/**
+ * Canonical entity -> --c-* var name. gameNightEvent reuses event's rose palette.
+ */
+const CSS_ENTITY: Record<MeepleEntityType, string> = {
+  game: 'game',
+  player: 'player',
+  session: 'session',
+  agent: 'agent',
+  kb: 'kb',
+  chat: 'chat',
+  event: 'event',
+  toolkit: 'toolkit',
+  tool: 'tool',
+  gameNightEvent: 'event',
+};
+
+/** Entity var names that have a canonical --c-*-text (AA text) variant. */
+const HAS_TEXT_VAR: ReadonlySet<string> = new Set([
+  'game',
+  'kb',
+  'toolkit',
+  'session',
+  'event',
+  'agent',
+  'chat',
+]);
+
+/**
+ * #2862 (C5): theme-aware, single-source entity color. Emits the canonical
+ * `--c-*` CSS var (which has light + dark values) instead of a hardcoded,
+ * light-only HSL. `alpha` (0..1) tints via modern `hsl(H S L / A)` syntax.
+ */
 export function entityHsl(entity: MeepleEntityType, alpha?: number): string {
-  const c = entityColors[entity];
-  if (alpha !== undefined) {
-    return `hsla(${c.h}, ${c.s}, ${c.l}, ${alpha})`;
-  }
-  return `hsl(${c.h}, ${c.s}, ${c.l})`;
+  const v = `var(--c-${CSS_ENTITY[entity]})`;
+  return alpha !== undefined ? `hsl(${v} / ${alpha})` : `hsl(${v})`;
 }
 
 /**
- * Darker text-only variant of entity colors for AA-safe use as text on **light theme** bg.
- *
- * ⚠️ **LIGHT THEME ONLY** — this helper returns hardcoded HSL values from
- * `entityTextOverrides` matching the `:root` block of `design-tokens-canonical.css`.
- * It does NOT mirror the dark-theme `:root[data-theme="dark"]` overrides (which
- * shift lightness lighter for dark bg AA). Consumers rendering on dark
- * surfaces should use the Tailwind utility `text-entity-{entity}-text`
- * (CSS-var based, theme-aware) or inline `style={{ color: 'hsl(var(--c-{entity}-text))' }}`
- * instead of calling `entityHslText()` directly.
- *
- * The `entityHsl()` solid variant is tuned for "color used as background under
- * white text" (matches `bg-entity-X` Tailwind utility). When the same entity
- * color is used as TEXT on a light bg or tinted-fill bg (e.g. ConnectionChip,
- * badge), the lightness needs to drop ~6-7% to clear AA 4.5:1.
- *
- * Mirrors the **light-theme** CSS `--c-{entity}-text` tokens in
- * `apps/web/src/styles/design-tokens-canonical.css:45` (`--c-game-text`)
- * and `:46` (`--c-kb-text`). Other entity overrides (toolkit/event/agent/chat/session)
- * are JS-only as of #1094 Real-C-misc cleanup — no CSS counterpart yet.
- *
- * Current consumers (ConnectionChipStripFooter, ConnectionBar) render on
- * `/sessions` and `/players` light-theme routes; the audit JSON v4 confirms
- * these specific surfaces are not captured in dark theme. If dark-theme
- * captures surface in Phase A.live v5, migrate consumers to the Tailwind
- * utility path (see #1094 follow-up).
- *
- * `game`, `kb`, `toolkit`, `event`, `agent`, `chat`, `session` have darker
- * variants today. `player` and `tool` fall back to `entityHsl()` solid until
- * violations surface.
- *
- * Refs: #1094 Real-C-B (§3.2), Real-C-E (§3.3), Real-C-misc (§3.4).
+ * #2862 (C5): theme-aware AA-safe entity text color. Uses the canonical
+ * `--c-*-text` var for entities that have one; falls back to the solid
+ * `--c-*` for player/tool (matching the pre-C5 fallback behavior).
  */
-const entityTextOverrides: Partial<Record<MeepleEntityType, { h: number; s: string; l: string }>> =
-  {
-    game: { h: 25, s: '95%', l: '32%' }, // matches --c-game-text light theme (#1094 Real-C-B)
-    kb: { h: 174, s: '60%', l: '28%' }, // matches --c-kb-text light theme (#1094 Real-C-F)
-    toolkit: { h: 142, s: '70%', l: '24%' }, // matches --c-toolkit-text light theme (#1094 Real-C-E)
-    // Phase A.live v4 misc residue (#1094 Real-C-misc cleanup): darker variants for
-    // ConnectionBar/ConnectionPip text on light bg or low-alpha entity-tinted bg.
-    event: { h: 350, s: '89%', l: '32%' }, // ~5.2:1 on #f7f3ee (was l=48% → 3.4:1 fail)
-    agent: { h: 38, s: '92%', l: '24%' }, // ~5.7:1 on #f7f3ee (was l=33% → 3.6:1 fail)
-    chat: { h: 220, s: '80%', l: '38%' }, // ~5.4:1 on #f7f3ee (was l=55% → 3.2:1 fail)
-    session: { h: 240, s: '60%', l: '32%' }, // ~6.0:1 on #f7f3ee (was l=55% → 4.8:1 borderline)
-  };
-
 export function entityHslText(entity: MeepleEntityType, alpha?: number): string {
-  const c = entityTextOverrides[entity] ?? entityColors[entity];
-  if (alpha !== undefined) {
-    return `hsla(${c.h}, ${c.s}, ${c.l}, ${alpha})`;
-  }
-  return `hsl(${c.h}, ${c.s}, ${c.l})`;
+  const name = CSS_ENTITY[entity];
+  const suffix = HAS_TEXT_VAR.has(name) ? '-text' : '';
+  const v = `var(--c-${name}${suffix})`;
+  return alpha !== undefined ? `hsl(${v} / ${alpha})` : `hsl(${v})`;
 }
 
 export const entityLabel: Record<MeepleEntityType, string> = {

--- a/apps/web/src/styles/design-tokens-canonical.css
+++ b/apps/web/src/styles/design-tokens-canonical.css
@@ -46,6 +46,9 @@
   --c-kb-text:   174 60% 28%; /* Real-C-F: hsl(174 60% 28%) ≈ #1d7268 vs #f7f3ee = 4.95:1 ✅ — replaces hardcoded #4ecdc4 (1.75:1 fail) */
   --c-toolkit-text: 142 70% 24%; /* Real-C-E gamebook: hsl(142 70% 24%) ≈ #0f5d2b vs #e3f0e8 = ~5.6:1 ✅ — replaces text-entity-toolkit (4.16:1 fail on toolkit/12 bg) */
   --c-session-text: 240 60% 35%; /* PR #1721 follow-up: light theme value = same as --c-session (already 12.22:1 AA on cream). Defined as a token so callers can use --c-session-text consistently across themes; dark theme overrides this to 235 85% 85% for AA on dark surfaces. */
+  --c-event-text: 350 89% 32%;   /* #2862 C5: ~5.2:1 on cream/white (from JS entityTextOverrides) */
+  --c-agent-text: 38 92% 24%;    /* #2862 C5: ~5.7:1 on cream/white */
+  --c-chat-text:  220 80% 38%;   /* #2862 C5: ~5.4:1 on cream/white */
 
   /* AAA contrast token (#1561 J — Aaron CORE spec 2026-05-23 §1b)
    * Light: hsl(32 36% 4%) ≈ #0f0a05 vs cream #f7f3ee = 15.1:1 (AAA-large + AAA-normal)
@@ -238,6 +241,9 @@
   --c-kb-text:   174 60% 55%;
   --c-toolkit-text: 142 60% 72%; /* Real-C-E gamebook dark: lighter variant for AA on dark bg */
   --c-session-text: 235 85% 85%; /* PR #1721 follow-up: lighter variant — hsl(235 85% 85%) ≈ #cdd1f9 hits AA ≥ 4.5:1 on dark `--card` + `--c-session/14` overlay (was --c-session 235 70% 70% ≈ #7d86e8 → 3.85:1 fail). Used by SessionShareCard theme toggle (line 189) and other components rendering text-entity-session text on dark surfaces. */
+  --c-event-text: 350 85% 78%;   /* #2862 C5: lighter for AA on dark card */
+  --c-agent-text: 38 92% 72%;    /* #2862 C5: lighter for AA on dark card */
+  --c-chat-text:  218 85% 80%;   /* #2862 C5: lighter for AA on dark card */
 
   /* AAA contrast dark — see :root docblock */
   --c-text-high-contrast: 0 0% 100%;

--- a/docs/superpowers/plans/2026-07-13-issue-2862-migrate-entity-tokens.md
+++ b/docs/superpowers/plans/2026-07-13-issue-2862-migrate-entity-tokens.md
@@ -1,0 +1,410 @@
+# Migrate MeepleCard Entity Accents to Canonical CSS Vars (Issue #2862 / C5) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make MeepleCard's entity accents theme-aware and single-source by rewriting `entityHsl`/`entityHslText` (tokens.ts) to emit `hsl(var(--c-*))` instead of hardcoded light-only JS HSL — fixing dark-mode divergence across ~19 call-sites with zero call-site edits — plus adding the 3 missing `--c-*-text` canonical vars and making the EntityBadge pill theme-aware so its (now theme-aware) text stays AA.
+
+**Architecture:** Rewrite the two color helpers to reference canonical `--c-*` / `--c-*-text` CSS variables (theme-switched at runtime). `entityTokens` (built on `entityHsl`) and all consumers inherit theme-awareness. `entityColors` (raw JS triplet) is kept for its external consumers. EntityBadge's `bg-white/85` pill → `bg-card/85` (theme-aware) so `--c-*-text` is legible in both themes.
+
+**Tech Stack:** TypeScript · CSS custom properties · Tailwind (semantic + entity utilities) · Vitest.
+
+**Spec:** `docs/superpowers/specs/2026-07-13-issue-2862-migrate-entity-tokens-design.md`
+
+## Global Constraints
+
+- Work on branch `feature/issue-2862-migrate-entity-tokens` (already created from `main-dev`); PR targets `main-dev`.
+- Frontend paths under `apps/web/`. Run from `apps/web/`. `pnpm exec vitest run <path>`, `pnpm typecheck`, `pnpm lint`, `pnpm build`.
+- `entityHsl(entity, alpha?)` → `hsl(var(--c-<name>))` or `hsl(var(--c-<name>) / <alpha>)`; `entityHslText(entity, alpha?)` → `hsl(var(--c-<name>-text))` (or `--c-<name>` when no text var). `name` = `CSS_ENTITY[entity]` (`gameNightEvent` → `event`; all others identity).
+- Entities WITH a `--c-*-text` var: game, kb, toolkit, session, event, agent, chat. WITHOUT (fall back to solid): player, tool.
+- New canonical text vars: `--c-event-text` (light `350 89% 32%` / dark `350 85% 78%`), `--c-agent-text` (light `38 92% 24%` / dark `38 92% 72%`), `--c-chat-text` (light `220 80% 38%` / dark `218 85% 80%`). All must be ≥ 4.5:1 (light on `#ffffff`, dark on `#1e1710`).
+- Keep `entityColors` (external consumers + #636 regression). Keep `--mc-*` surface + `statusColors`. a11y gate is BLOCKING; no hardcoded color utilities (`bg-card/85` is semantic — allowed).
+- Commit `type(scope): description` + `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`.
+
+---
+
+### Task 1: Add the 3 missing `--c-*-text` canonical vars + AA test
+
+**Files:**
+- Modify: `apps/web/src/styles/design-tokens-canonical.css` (light `:root` after line 48; dark `[data-theme="dark"]` after line 240)
+- Test: `apps/web/src/__tests__/styles/entity-text-tokens-c5.test.ts` (create)
+
+**Interfaces:**
+- Produces: `--c-event-text`, `--c-agent-text`, `--c-chat-text` (light + dark) in canonical CSS. Consumed by Task 2's `entityHslText`.
+
+- [ ] **Step 1: Write the failing AA test**
+
+Create `apps/web/src/__tests__/styles/entity-text-tokens-c5.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const CSS = readFileSync(
+  resolve(__dirname, '..', '..', 'styles', 'design-tokens-canonical.css'),
+  'utf8'
+);
+
+// #ffffff (light card) and #1e1710 (dark card) — the EntityBadge pill surface.
+const LIGHT_BG: [number, number, number] = [255, 255, 255];
+const DARK_BG: [number, number, number] = [30, 23, 16];
+
+function block(theme: 'light' | 'dark'): string {
+  if (theme === 'light') return CSS.slice(0, CSS.indexOf('[data-theme="dark"]'));
+  return CSS.slice(CSS.indexOf('[data-theme="dark"]'));
+}
+
+function hslToRgb(h: number, s: number, l: number): [number, number, number] {
+  s /= 100;
+  l /= 100;
+  const c = (1 - Math.abs(2 * l - 1)) * s;
+  const hp = h / 60;
+  const x = c * (1 - Math.abs((hp % 2) - 1));
+  let r = 0,
+    g = 0,
+    b = 0;
+  if (hp < 1) [r, g, b] = [c, x, 0];
+  else if (hp < 2) [r, g, b] = [x, c, 0];
+  else if (hp < 3) [r, g, b] = [0, c, x];
+  else if (hp < 4) [r, g, b] = [0, x, c];
+  else if (hp < 5) [r, g, b] = [x, 0, c];
+  else [r, g, b] = [c, 0, x];
+  const m = l - c / 2;
+  return [Math.round((r + m) * 255), Math.round((g + m) * 255), Math.round((b + m) * 255)];
+}
+function lum([r, g, b]: [number, number, number]): number {
+  const f = (v: number) => {
+    const s = v / 255;
+    return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+  };
+  return 0.2126 * f(r) + 0.7152 * f(g) + 0.0722 * f(b);
+}
+function contrast(a: [number, number, number], b: [number, number, number]): number {
+  const [hi, lo] = lum(a) > lum(b) ? [lum(a), lum(b)] : [lum(b), lum(a)];
+  return (hi + 0.05) / (lo + 0.05);
+}
+function readVar(theme: 'light' | 'dark', name: string): [number, number, number] {
+  const m = block(theme).match(new RegExp(name + ':\\s*(\\d+)\\s+(\\d+)%\\s+(\\d+)%'));
+  if (!m) throw new Error(`${name} not found in ${theme} block`);
+  return hslToRgb(Number(m[1]), Number(m[2]), Number(m[3]));
+}
+
+describe('C5 — new --c-*-text vars are AA on the EntityBadge pill (#2862)', () => {
+  it.each(['--c-event-text', '--c-agent-text', '--c-chat-text'])(
+    '%s light value >= 4.5:1 on white card',
+    name => {
+      expect(contrast(readVar('light', name), LIGHT_BG)).toBeGreaterThanOrEqual(4.5);
+    }
+  );
+  it.each(['--c-event-text', '--c-agent-text', '--c-chat-text'])(
+    '%s dark value >= 4.5:1 on dark card',
+    name => {
+      expect(contrast(readVar('dark', name), DARK_BG)).toBeGreaterThanOrEqual(4.5);
+    }
+  );
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm exec vitest run src/__tests__/styles/entity-text-tokens-c5.test.ts`
+Expected: FAIL — `--c-event-text not found in light block` (vars don't exist yet).
+
+- [ ] **Step 3: Add the light-theme vars**
+
+In `apps/web/src/styles/design-tokens-canonical.css`, after line 48 (`--c-session-text: 240 60% 35%;`), add:
+
+```css
+  --c-event-text: 350 89% 32%;   /* #2862 C5: ~5.2:1 on cream/white (from JS entityTextOverrides) */
+  --c-agent-text: 38 92% 24%;    /* #2862 C5: ~5.7:1 on cream/white */
+  --c-chat-text:  220 80% 38%;   /* #2862 C5: ~5.4:1 on cream/white */
+```
+
+- [ ] **Step 4: Add the dark-theme vars**
+
+In the `[data-theme="dark"]` block, after line 240 (`--c-session-text: 235 85% 85%; ...`), add:
+
+```css
+  --c-event-text: 350 85% 78%;   /* #2862 C5: lighter for AA on dark card */
+  --c-agent-text: 38 92% 72%;    /* #2862 C5: lighter for AA on dark card */
+  --c-chat-text:  218 85% 80%;   /* #2862 C5: lighter for AA on dark card */
+```
+
+- [ ] **Step 5: Run the AA test + the Phase B gates**
+
+Run: `pnpm exec vitest run src/__tests__/styles/entity-text-tokens-c5.test.ts`
+Expected: PASS (6 assertions). If any dark value is < 4.5:1, raise its lightness a few % and re-run.
+Run: `pnpm exec vitest run src/__tests__/styles/entity-token-golden.test.ts src/__tests__/styles/entity-token-consistency.test.ts`
+Expected: PASS — both gates exclude `-text` variants (they match `--c-<entity>:` only), so the new vars don't affect them.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/styles/design-tokens-canonical.css apps/web/src/__tests__/styles/entity-text-tokens-c5.test.ts
+git commit -m "$(cat <<'EOF'
+feat(design-tokens): add --c-event/agent/chat-text canonical vars (#2862)
+
+Completes the --c-*-text single source for the 3 entities that only had JS
+overrides. Light + dark, AA-verified on the card surface. C5 prep.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 2: Rewrite `entityHsl` / `entityHslText` to CSS-var-backed
+
+**Files:**
+- Modify: `apps/web/src/components/ui/data-display/meeple-card/tokens.ts` (rewrite `entityHsl` lines 38-44 + `entityHslText` lines 92-98; add `CSS_ENTITY` + `HAS_TEXT_VAR`; remove `entityTextOverrides` lines 79-90 if orphan)
+- Modify: `apps/web/src/components/ui/data-display/meeple-card/__tests__/tokens.test.ts` (update `entityHsl` form assertions; add new)
+
+**Interfaces:**
+- Consumes: the canonical `--c-*` / `--c-*-text` vars (Task 1 for event/agent/chat).
+- Produces: `entityHsl(entity, alpha?)` → `hsl(var(--c-<name>) [/ alpha])`; `entityHslText(entity, alpha?)` → `hsl(var(--c-<name>-text) [/ alpha])` or solid. `entityTokens` unchanged (auto-migrated). `entityColors` unchanged.
+
+- [ ] **Step 1: Update the tokens test to the new form (fails first)**
+
+In `apps/web/src/components/ui/data-display/meeple-card/__tests__/tokens.test.ts`, replace the `describe('entityHsl', ...)` block (lines 83-91) with:
+
+```ts
+describe('entityHsl (CSS-var-backed, theme-aware — #2862)', () => {
+  it('returns hsl(var(--c-<entity>)) without alpha', () => {
+    expect(entityHsl('game')).toBe('hsl(var(--c-game))');
+  });
+
+  it('returns hsl(var(--c-<entity>) / alpha) with alpha', () => {
+    expect(entityHsl('game', 0.5)).toBe('hsl(var(--c-game) / 0.5)');
+  });
+
+  it('maps gameNightEvent to the event palette', () => {
+    expect(entityHsl('gameNightEvent')).toBe('hsl(var(--c-event))');
+  });
+});
+
+describe('entityHslText (CSS-var-backed, theme-aware — #2862)', () => {
+  it.each(['game', 'kb', 'toolkit', 'session', 'event', 'agent', 'chat'] as const)(
+    '%s uses the -text variant',
+    entity => {
+      expect(entityHslText(entity)).toBe(`hsl(var(--c-${entity}-text))`);
+    }
+  );
+
+  it('player/tool fall back to the solid var (no -text)', () => {
+    expect(entityHslText('player')).toBe('hsl(var(--c-player))');
+    expect(entityHslText('tool')).toBe('hsl(var(--c-tool))');
+  });
+
+  it('gameNightEvent uses the event -text variant', () => {
+    expect(entityHslText('gameNightEvent')).toBe('hsl(var(--c-event-text))');
+  });
+});
+```
+
+Also add `entityHslText` to the import on line 2:
+```ts
+import { entityColors, entityHsl, entityHslText, entityLabel, entityIcon, statusColors } from '../tokens';
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm exec vitest run src/components/ui/data-display/meeple-card/__tests__/tokens.test.ts`
+Expected: FAIL — current `entityHsl('game')` returns `hsl(25, 95%, 39%)`, not `hsl(var(--c-game))`.
+
+- [ ] **Step 3: Rewrite the helpers in tokens.ts**
+
+In `apps/web/src/components/ui/data-display/meeple-card/tokens.ts`:
+
+(a) Replace the `entityHsl` function (lines 38-44) with:
+
+```ts
+/**
+ * Canonical entity -> --c-* var name. gameNightEvent reuses event's rose palette.
+ */
+const CSS_ENTITY: Record<MeepleEntityType, string> = {
+  game: 'game',
+  player: 'player',
+  session: 'session',
+  agent: 'agent',
+  kb: 'kb',
+  chat: 'chat',
+  event: 'event',
+  toolkit: 'toolkit',
+  tool: 'tool',
+  gameNightEvent: 'event',
+};
+
+/** Entity var names that have a canonical --c-*-text (AA text) variant. */
+const HAS_TEXT_VAR: ReadonlySet<string> = new Set([
+  'game',
+  'kb',
+  'toolkit',
+  'session',
+  'event',
+  'agent',
+  'chat',
+]);
+
+/**
+ * #2862 (C5): theme-aware, single-source entity color. Emits the canonical
+ * `--c-*` CSS var (which has light + dark values) instead of a hardcoded,
+ * light-only HSL. `alpha` (0..1) tints via modern `hsl(H S L / A)` syntax.
+ */
+export function entityHsl(entity: MeepleEntityType, alpha?: number): string {
+  const v = `var(--c-${CSS_ENTITY[entity]})`;
+  return alpha !== undefined ? `hsl(${v} / ${alpha})` : `hsl(${v})`;
+}
+```
+
+(b) Delete the `entityTextOverrides` const (lines 79-90) — it becomes orphan after (c). First confirm it has no other consumer:
+Run: `grep -rn "entityTextOverrides" apps/web/src` — expected: only its definition in tokens.ts (it is a private, non-exported const). If any other reference exists, keep it and note in your report.
+
+(c) Replace the `entityHslText` function (lines 92-98) with:
+
+```ts
+/**
+ * #2862 (C5): theme-aware AA-safe entity text color. Uses the canonical
+ * `--c-*-text` var for entities that have one; falls back to the solid
+ * `--c-*` for player/tool (matching the pre-C5 fallback behavior).
+ */
+export function entityHslText(entity: MeepleEntityType, alpha?: number): string {
+  const name = CSS_ENTITY[entity];
+  const suffix = HAS_TEXT_VAR.has(name) ? '-text' : '';
+  const v = `var(--c-${name}${suffix})`;
+  return alpha !== undefined ? `hsl(${v} / ${alpha})` : `hsl(${v})`;
+}
+```
+
+(Leave `entityColors`, `entityTokens`, `statusColors`, `entityLabel`, `entityIcon` untouched. `entityTokens` now emits CSS-var strings automatically because it calls the rewritten `entityHsl`.)
+
+- [ ] **Step 4: Run the tokens test + the meeple-card suite**
+
+Run: `pnpm exec vitest run src/components/ui/data-display/meeple-card/__tests__/tokens.test.ts`
+Expected: PASS (entityHsl/entityHslText new-form assertions + the unchanged entityColors + #636 regression).
+Run: `pnpm exec vitest run src/components/ui/data-display/meeple-card`
+Expected: PASS (variants, parts, acceptance-matrix — no class assertions, no crash).
+Run: `pnpm typecheck`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/ui/data-display/meeple-card/tokens.ts \
+        apps/web/src/components/ui/data-display/meeple-card/__tests__/tokens.test.ts
+git commit -m "$(cat <<'EOF'
+refactor(meeple-card): entityHsl/entityHslText emit canonical --c-* vars (#2862)
+
+Rewrites the two color helpers to reference the theme-aware canonical --c-* /
+--c-*-text CSS vars instead of hardcoded light-only JS HSL. entityTokens and all
+~19 accent call-sites become theme-aware + single-source with zero call-site
+edits. entityColors kept (external consumers + #636). Removes orphan
+entityTextOverrides.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 3: Make the EntityBadge pill theme-aware
+
+**Files:**
+- Modify: `apps/web/src/components/ui/data-display/meeple-card/parts/EntityBadge.tsx` (line 1 eslint-disable; line 22 `bg-white/85` → `bg-card/85`)
+
+**Interfaces:**
+- Consumes: the theme-aware `entityHslText` (Task 2). No new exports.
+
+- [ ] **Step 1: Swap the pill surface + drop the eslint-disable**
+
+In `apps/web/src/components/ui/data-display/meeple-card/parts/EntityBadge.tsx`:
+
+Remove line 1 entirely:
+```
+/* eslint-disable local/no-hardcoded-color-utility -- glass bg-white/85 follows the mockup .e-bg pattern; entity color text via inline style. DS-12 primitive — see token-bridge-map.md for migration plan. */
+```
+
+In the `className` on line 22, change `bg-white/85` to `bg-card/85` (theme-aware glass surface so the now-theme-aware `--c-*-text` is legible in both themes). The line becomes:
+
+```tsx
+      className={`${positioning} inline-flex items-center gap-1 rounded-md bg-card/85 px-2 py-0.5 font-[var(--font-quicksand)] text-[9px] font-extrabold uppercase tracking-wide shadow-sm backdrop-blur-md ${className}`}
+```
+
+- [ ] **Step 2: Lint the file (the disable removal must not re-introduce a violation)**
+
+Run: `pnpm exec eslint src/components/ui/data-display/meeple-card/parts/EntityBadge.tsx`
+Expected: no errors. (`bg-card/85` is a semantic utility; `text-*` is set via inline style, not a hardcoded class.)
+
+- [ ] **Step 3: Run EntityBadge's test (if any) + the parts suite**
+
+Run: `pnpm exec vitest run src/components/ui/data-display/meeple-card/parts`
+Expected: PASS. (EntityBadge tests assert `data-slot`/label/icon, not the bg class.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/components/ui/data-display/meeple-card/parts/EntityBadge.tsx
+git commit -m "$(cat <<'EOF'
+refactor(meeple-card): EntityBadge pill uses theme-aware bg-card/85 (#2862)
+
+The entity text is now theme-aware (--c-*-text flips per theme), so the pill
+surface must too — bg-white/85 (invariant white) would show light text on white
+in dark mode. Swaps to the semantic bg-card/85 and drops the now-unneeded
+no-hardcoded-color-utility disable.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 4: Final verification + PR
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Quality gates**
+
+Run each and confirm PASS:
+- `cd apps/web && pnpm exec vitest run src/components/ui/data-display/meeple-card src/__tests__/styles`
+- `cd apps/web && pnpm typecheck`
+- `cd apps/web && pnpm lint`
+- `cd apps/web && pnpm build`
+
+- [ ] **Step 2: Push + open PR to `main-dev`**
+
+```bash
+git push -u origin feature/issue-2862-migrate-entity-tokens
+gh pr create --base main-dev --title "refactor(meeple-card): migrate entity accents to canonical --c-* vars (#2862)" --body "$(cat <<'EOF'
+Closes #2862 (C5 / ST8 of umbrella #2863).
+
+## What
+Rewrites `entityHsl`/`entityHslText` (`meeple-card/tokens.ts`) to emit the canonical, theme-aware `--c-*` / `--c-*-text` CSS vars instead of hardcoded **light-only** JS HSL. `entityTokens` and all ~19 accent call-sites (dots, glows, Cover/Hero gradients, AccentBorder, TagStrip, ManaPips, ConnectionChip, EntityBadge) become theme-aware + single-source **with zero call-site edits** — fixing the audit's "the card re-derives colors in JS → diverges in dark". Adds the 3 missing `--c-*-text` canonical vars (event/agent/chat, light + dark, AA-verified). Makes the EntityBadge pill `bg-white/85` → `bg-card/85` so its now-theme-aware text stays AA in both themes.
+
+## Kept (out of scope, per design §5)
+`--mc-*` surface chrome (theme-aware warm-glass, no dark bug); `entityColors` (external consumers + #636 regression); `statusColors`.
+
+## Verification
+tokens test (new CSS-var form), --c-*-text AA test (light on #fff, dark on #1e1710), Phase B golden/consistency gates (unaffected — exclude -text), meeple-card suite, typecheck/lint/build — all green.
+
+## Designer review
+Visual delta: entity accents shift ~1% lightness (JS 39% → canonical 38%) and now render correctly in **dark mode** (previously light-only); the EntityBadge pill changes from white-glass to theme-aware card-glass. Gates don't inspect variant classes — please eyeball light + dark.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: After CI green + merge — close-out**
+
+Update issue #2862 (state + DoD) and tick its box in umbrella #2863's Phase C checklist — this completes Phase C (C1-C5 all done).
+
+---
+
+## Self-Review notes (author)
+
+- **Spec coverage:** §3 helper rewrite → Task 2; §3 EntityBadge → Task 3; §3 `--c-*-text` → Task 1; §4 testing → per-task + Task 4; §7 acceptance → all tasks. Mapped.
+- **Type consistency:** `CSS_ENTITY` / `HAS_TEXT_VAR` defined in Task 2 and used by both helpers; `entityHsl`/`entityHslText` signatures unchanged (alpha retained). Test assertions match the emitted strings exactly (`hsl(var(--c-game))`, `hsl(var(--c-game) / 0.5)`).
+- **Ordering:** Task 1 (CSS vars) before Task 2 (entityHslText references them) before Task 3 (relies on theme-aware text). Task-1 vars must exist before Task-3's badge renders theme-aware text AA — enforced by task order.
+- **Risk:** purely visual; gates green but designer review flagged in the PR. `--c-*-text` AA locked by Task-1 test.

--- a/docs/superpowers/specs/2026-07-13-issue-2862-migrate-entity-tokens-design.md
+++ b/docs/superpowers/specs/2026-07-13-issue-2862-migrate-entity-tokens-design.md
@@ -67,6 +67,8 @@ export function entityHslText(entity: MeepleEntityType, alpha?: number): string 
 
 I valori light provengono da `entityTextOverrides` (già AA su cream). I dark seguono il pattern esistente (più chiari; `--c-game-text` dark 70%, `--c-toolkit-text` dark 72%). `game/kb/toolkit/session` hanno già i `-text`. `player`/`tool` non hanno override (fallback al solido, replica il comportamento JS).
 
+**`EntityBadge` — pill theme-aware (aggiunta Opzione 2).** Il testo `entityHslText` diventa theme-aware (`--c-*-text` flippa: dark in light-theme, light in dark-theme), ma la pill è oggi `bg-white/85` (bianca **invariante**) → in dark il testo chiaro finirebbe su pill bianca = AA fail. Fix: `EntityBadge.tsx:22` cambia `bg-white/85` → **`bg-card/85`** (glass theme-aware: chiara in light, scura in dark) e si **rimuove l'`eslint-disable local/no-hardcoded-color-utility`** (non più necessario con l'utility semantica). Così `--c-*-text` è AA su entrambe le pill. È un cambio **visivo** alla pill (glass bianco → glass card) → designer-review.
+
 **`entityColors` / `entityTextOverrides`:** `entityColors` **resta** (consumer esterni + regression #636). `entityTextOverrides` non è più usato da `entityHslText` dopo la riscrittura → si può rimuovere SE non ha altri consumer (verifico via grep; se orfano, delete). `entityTokens`/`statusColors`/`entityLabel`/`entityIcon` invariati.
 
 ## 4. Testing
@@ -103,7 +105,8 @@ I valori light provengono da `entityTextOverrides` (già AA su cream). I dark se
 
 - [ ] `entityHsl(entity, alpha?)` emette `hsl(var(--c-<map(entity)>) [/ alpha])` (theme-aware); `gameNightEvent→event`.
 - [ ] `entityHslText(entity)` emette `hsl(var(--c-<e>-text))` per game/kb/toolkit/session/event/agent/chat e `hsl(var(--c-<e>))` per player/tool.
-- [ ] `--c-event-text`/`--c-agent-text`/`--c-chat-text` presenti in canonical (light + dark), tutti ≥ 4.5:1.
+- [ ] `--c-event-text`/`--c-agent-text`/`--c-chat-text` presenti in canonical (light + dark), tutti ≥ 4.5:1 (light su `--bg-card` #ffffff, dark su `--bg-card` dark).
+- [ ] `EntityBadge.tsx` pill `bg-white/85` → `bg-card/85`, `eslint-disable` rimosso; testo `--c-*-text` AA su entrambi i temi.
 - [ ] `entityTokens` e le ~19 call-site invariate ma ora theme-aware/single-source; `entityColors` invariato (+ #636 verde).
 - [ ] `entityTextOverrides` rimosso se orfano (grep-verificato).
 - [ ] `tokens.test.ts` aggiornato + nuovi assert verdi; golden/consistency verdi; acceptance-matrix verde.

--- a/docs/superpowers/specs/2026-07-13-issue-2862-migrate-entity-tokens-design.md
+++ b/docs/superpowers/specs/2026-07-13-issue-2862-migrate-entity-tokens-design.md
@@ -1,0 +1,110 @@
+# Design — Issue #2862 (C5): migrate variants to canonical entity tokens
+
+**Data:** 2026-07-13
+**Issue:** [#2862](https://github.com/meepleAi-app/meepleai-monorepo/issues/2862) (ST8) — umbrella [#2863](https://github.com/meepleAi-app/meepleai-monorepo/issues/2863) "MeepleCard family debt teardown"
+**Audit:** `docs/for-developers/audits/2026-07-12-meeplecard-css-drift-audit.md` (§4.4 "la card RI-DERIVA i colori in JS invece di leggere le CSS-var → diverge in dark"; §6 ST8)
+**Branch:** `feature/issue-2862-migrate-entity-tokens` da `main-dev`
+**Dipendenze:** B3 (Phase B `--c-*` canonici, mergiato) + C1 (#2858, mergiato).
+
+---
+
+## 1. Problema
+
+La verifica sul codice distingue due sistemi (come nelle issue C1-C4, la premessa "migrare `--mc-*` + entityHsl" va calibrata):
+
+1. **Chrome di superficie** — i 13 token `--mc-*` (`--mc-bg-card`, `--mc-border`, `--mc-text-*`, `--mc-shadow-*`, definiti in `design-tokens.css:501-518` + `.dark` 588-605): valori privati "warm glass" (#4604), **theme-aware in CSS** (light + dark). **Nessun bug dark.** Migrarli ai semantici è un redesign visivo, non un fix di debito → **fuori scope** (Q1).
+2. **Accenti entità** — `entityHsl()`/`entityHslText()`/`entityTokens()` in `tokens.ts`: emettono stringhe HSL **hardcoded LIGHT-ONLY** (da `entityColors`/`entityTextOverrides` JS). È **esattamente il debito** dell'audit: la card ri-deriva i colori in JS invece di leggere le CSS-var `--c-*` (Phase B, AA-tuned, theme-aware, con `-text` + dark override) → diverge in dark. ~19 call-site su varianti + parts.
+
+## 2. Decisioni (brainstorm 2026-07-13)
+
+1. **Q1 — accenti entità → canonico, tieni `--mc-*`.** Migrare gli accenti entità alle CSS-var `--c-*`; lasciare i `--mc-*` di superficie (theme-aware, deliberati).
+2. **Q2 — completa `entityHslText`.** Aggiungere i `--c-*-text` canonici mancanti (event/agent/chat) così `entityHslText` diventa CSS-var single-source.
+3. **`entityColors` NON si elimina** (adattamento post-discovery): è esportato e ha **consumer esterni** (`MeeplePlayerStateCard.tsx:52` legge `entityColors.player.h/s/l`; + regression test `tokens.test.ts` #636 su `entityColors` AA). Resta come **palette raw disaccoppiata**; `entityHsl`/`entityHslText` vengono riscritti **indipendenti** da esso.
+
+## 3. Migrazione — riscrivere gli helper, non le call-site
+
+Il 2° argomento di `entityHsl(entity, alpha?)` è **alpha** (`hsla(h,s,l,alpha)`), quindi la sostituzione canonica è pulita.
+
+**`tokens.ts` — riscrivere 2 helper (CSS-var-backed, disaccoppiati da `entityColors`):**
+
+```ts
+// entity -> canonical --c-* var name (gameNightEvent reuses event's rose palette)
+const CSS_ENTITY: Record<MeepleEntityType, string> = {
+  game: 'game', player: 'player', session: 'session', agent: 'agent', kb: 'kb',
+  chat: 'chat', event: 'event', toolkit: 'toolkit', tool: 'tool', gameNightEvent: 'event',
+};
+
+export function entityHsl(entity: MeepleEntityType, alpha?: number): string {
+  const v = `var(--c-${CSS_ENTITY[entity]})`;
+  return alpha !== undefined ? `hsl(${v} / ${alpha})` : `hsl(${v})`;
+}
+
+// entities with a canonical --c-*-text var (AA-safe text on light/tinted bg)
+const HAS_TEXT_VAR: ReadonlySet<MeepleEntityType> = new Set([
+  'game', 'kb', 'toolkit', 'session', 'event', 'agent', 'chat',
+]);
+
+export function entityHslText(entity: MeepleEntityType, alpha?: number): string {
+  const name = CSS_ENTITY[entity];
+  const suffix = HAS_TEXT_VAR.has(entity) ? '-text' : ''; // player/tool fall back to solid
+  const v = `var(--c-${name}${suffix})`;
+  return alpha !== undefined ? `hsl(${v} / ${alpha})` : `hsl(${v})`;
+}
+```
+
+(The `alpha` param is retained for signature stability though the sole consumer `EntityBadge` calls it without alpha.)
+
+- **Effetto**: `entityTokens()` (costruito su `entityHsl`) e **tutte le ~19 call-site** (dot CompactCard/ListCard, glow Grid/Featured, gradienti Cover/Hero, AccentBorder, TagStrip, ManaPips, ConnectionChip via entityTokens, EntityBadge via entityHslText) diventano **theme-aware + single-source `--c-*`** con **zero modifiche alle call-site**.
+- `entityHsl(entity, alpha)` → `hsl(var(--c-<e>) / alpha)`: gli alpha-tint (fill 0.12, border 0.35, glow 0.18…) e i gradienti (Cover 0.35→0.55, Hero 0.85→0.4) mantengono la struttura, base color letta dalla var. Le firme di `entityHsl`/`entityHslText` restano invariate (param `alpha` mantenuto per stabilità; l'unico consumer di `entityHslText`, `EntityBadge`, lo chiama senza alpha).
+
+**`design-tokens-canonical.css` — aggiungere 3 `--c-*-text` (light + dark):**
+
+| Var | Light (AA su cream #f7f3ee) | Dark (AA su bg scuro) |
+|---|---|---|
+| `--c-event-text` | `350 89% 32%` (dai JS override, ~5.2:1) | `350 85% 72%` |
+| `--c-agent-text` | `38 92% 24%` (~5.7:1) | `38 90% 68%` |
+| `--c-chat-text` | `220 80% 38%` (~5.4:1) | `220 85% 75%` |
+
+I valori light provengono da `entityTextOverrides` (già AA su cream). I dark seguono il pattern esistente (più chiari; `--c-game-text` dark 70%, `--c-toolkit-text` dark 72%). `game/kb/toolkit/session` hanno già i `-text`. `player`/`tool` non hanno override (fallback al solido, replica il comportamento JS).
+
+**`entityColors` / `entityTextOverrides`:** `entityColors` **resta** (consumer esterni + regression #636). `entityTextOverrides` non è più usato da `entityHslText` dopo la riscrittura → si può rimuovere SE non ha altri consumer (verifico via grep; se orfano, delete). `entityTokens`/`statusColors`/`entityLabel`/`entityIcon` invariati.
+
+## 4. Testing
+
+- **`tokens.test.ts`** (aggiornare la forma asserita di `entityHsl`, righe 84-90): `entityHsl('game')` → `hsl(var(--c-game))`; `entityHsl('game', 0.5)` → `hsl(var(--c-game) / 0.5)` (non più `hsla(`). I test `entityColors` + regression #636 su `entityColors` **restano invariati** (entityColors non cambia).
+- **Nuovi assert** in `tokens.test.ts`: `entityHsl(e)`/`entityHsl(e,a)` emettono `hsl(var(--c-<map(e)>) [/ a])` per tutte le 10 entità (+ `gameNightEvent→event`); `entityHslText(e)` emette `hsl(var(--c-<e>-text))` per le 7 con text-var e `hsl(var(--c-<e>))` per player/tool.
+- **Nuovi `--c-*-text`**: assert di esistenza + **AA-contrast** (riuso `hslToRgb`+`contrastRatio` già in tokens.test.ts) per event/agent/chat text su cream (light) e su bg dark ≥ 4.5:1. Se un dark value fallisce AA, aggiustarlo.
+- **Gate Phase B** (`entity-token-golden` / `entity-token-consistency`): **non toccati** — escludono esplicitamente i `-text` (`--c-game:` sì, `--c-game-text:` no). Restano verdi.
+- **Varianti/acceptance-matrix**: verdi (nessuna asserzione di classe/colore; nessun crash).
+- **Designer-review sul PR**: i gate non colgono regressioni visive. Delta atteso: entità ~1% lightness (JS 39% → canonico 38%) + **ora corrette in dark** (prima light-only).
+- `pnpm typecheck` / `lint` / `build`.
+
+## 5. Scope
+
+**In scope:** riscrivere `entityHsl`/`entityHslText` → CSS-var; aggiungere 3 `--c-*-text` canonici; aggiornare/estendere `tokens.test.ts`; rimuovere `entityTextOverrides` se orfano.
+
+**Fuori scope (deferiti):**
+- Eliminare `entityColors` → ha consumer esterni + regression #636; riconciliare quei consumer (`MeeplePlayerStateCard`, `Confetti`, `StatsHero`, `sidebar-filters`) al canonico è follow-up.
+- Migrazione `--mc-*` di superficie → redesign visivo (Q1), designer-led.
+- `statusColors` → palette status (non entità), hardcoded ma fuori dal tema entità.
+- Conversione HubGameCard/HubToolkitCard (grandfathered in C4).
+
+## 6. Rischi
+
+| Rischio | Mitigazione |
+|---|---|
+| Regressione visiva non colta dai gate | Delta ~1% lightness (più-corretto AA); designer-review esplicita sul PR |
+| Un dark value `--c-*-text` non-AA | Test contrast dedicato (riuso helper); aggiustare il valore se < 4.5:1 |
+| `entityColors` (39%) diverge da `--c-*` (38%) reso | Accettato: `entityColors` è palette raw per consumer non-variante; riconciliazione = follow-up. I gate/#636 restano coerenti |
+| Consumer esterno di `entityHsl` con alpha si aspetta `hsla(` | Nessuno: `entityHsl` è usato in `style`/gradient (accetta `hsl(.. / a)`); l'unico test sulla forma è `tokens.test.ts` (aggiornato) |
+| `entityHslText` chiamato con alpha da qualche consumer | Verificato: unico consumer `EntityBadge` chiama `entityHslText(entity)` senza alpha; il param si rimuove |
+
+## 7. Acceptance criteria
+
+- [ ] `entityHsl(entity, alpha?)` emette `hsl(var(--c-<map(entity)>) [/ alpha])` (theme-aware); `gameNightEvent→event`.
+- [ ] `entityHslText(entity)` emette `hsl(var(--c-<e>-text))` per game/kb/toolkit/session/event/agent/chat e `hsl(var(--c-<e>))` per player/tool.
+- [ ] `--c-event-text`/`--c-agent-text`/`--c-chat-text` presenti in canonical (light + dark), tutti ≥ 4.5:1.
+- [ ] `entityTokens` e le ~19 call-site invariate ma ora theme-aware/single-source; `entityColors` invariato (+ #636 verde).
+- [ ] `entityTextOverrides` rimosso se orfano (grep-verificato).
+- [ ] `tokens.test.ts` aggiornato + nuovi assert verdi; golden/consistency verdi; acceptance-matrix verde.
+- [ ] `pnpm typecheck`/`lint`/`build` verdi.


### PR DESCRIPTION
## C5 — Migrate entity tokens to canonical `--c-*` vars

Closes #2862 (C5 of umbrella #2863 "MeepleCard family debt teardown").

### Problem
`meeple-card/tokens.ts` `entityHsl` / `entityHslText` emitted **hardcoded, light-only** JS HSL strings (`hsl(25, 95%, 39%)`). Every entity-accent surface driven by them (dots, glows, Cover/Hero gradients, AccentBorder, tags, pips, ConnectionChip, EntityBadge) was therefore theme-invariant and duplicated the palette that already lives — theme-aware and AA-tuned — in the canonical `--c-*` CSS vars (Phase B).

### Change
- `entityHsl(entity, alpha?)` → `hsl(var(--c-<entity>))` / `hsl(var(--c-<entity>) / <alpha>)`. The migration is helper-level: **zero call-site edits**, all accent surfaces become theme-aware + single-source.
- `entityHslText(entity, alpha?)` → `hsl(var(--c-<entity>-text))` for entities with an AA text variant (game, kb, toolkit, session, event, agent, chat); player/tool fall back to the solid var (matches pre-C5 behavior).
- Added the 3 missing `--c-*-text` vars (event, agent, chat) to `design-tokens-canonical.css` (light + dark), with an AA-contrast regression test.
- `EntityBadge` glass pill: `bg-white/85` → semantic `bg-card/85`; removed its now-unnecessary file-level `eslint-disable local/no-hardcoded-color-utility`.
- Removed the orphan `entityTextOverrides` map.
- Kept `entityColors` (raw `{h,s,l}`) — it has external consumers and backs the #636 WCAG regression suite.

### Verification
- `vitest` meeple-card + styles: **326/326 pass**
- `pnpm typecheck`: 0 errors
- `pnpm eslint` (source): 0 errors
- `pnpm build`: compiled OK
- `pnpm lint:tokens`: 0 violations

Spec: `docs/superpowers/specs/2026-07-13-issue-2862-migrate-entity-tokens-design.md`
Plan: `docs/superpowers/plans/2026-07-13-issue-2862-migrate-entity-tokens.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)