### PR TITLE
fix(seed): deterministic SharedGame ids to prevent orphan PDFs on re-seed (#2904)

### DIFF
--- a/apps/api/src/Api/Infrastructure/Seeders/Catalog/GameSeeder.cs
+++ b/apps/api/src/Api/Infrastructure/Seeders/Catalog/GameSeeder.cs
@@ -240,7 +240,7 @@ internal static class GameSeeder
     /// so PdfSeeder recognizes existing PDFs (no orphans, embeddings preserved) — Issue #2904 / #964.
     /// SHA-256 of a namespaced key truncated to 16 bytes; NOT for cryptographic use.
     /// </summary>
-    internal static Guid GenerateDeterministicGameId(int? bggId, string title)
+    internal static Guid GenerateDeterministicGameId(int? bggId, string? title)
     {
         var key = bggId is > 0
             ? $"sharedgame:bgg:{bggId.Value}"

--- a/apps/api/src/Api/Infrastructure/Seeders/Catalog/GameSeeder.cs
+++ b/apps/api/src/Api/Infrastructure/Seeders/Catalog/GameSeeder.cs
@@ -148,7 +148,7 @@ internal static class GameSeeder
     {
         return new SharedGameEntity
         {
-            Id = Guid.NewGuid(),
+            Id = GenerateDeterministicGameId(bgg.BggId, bgg.Name),
             BggId = bgg.BggId,
             Title = bgg.Name,
             YearPublished = bgg.YearPublished ?? DateTime.UtcNow.Year,
@@ -179,7 +179,7 @@ internal static class GameSeeder
     {
         return new SharedGameEntity
         {
-            Id = Guid.NewGuid(),
+            Id = GenerateDeterministicGameId(entry.BggId, entry.Title),
             BggId = entry.BggId is > 0 ? entry.BggId.Value : null,
             Title = entry.Title,
             YearPublished = Math.Clamp(entry.YearPublished ?? 2020, 1901, 2100),
@@ -211,7 +211,7 @@ internal static class GameSeeder
     {
         return new SharedGameEntity
         {
-            Id = Guid.NewGuid(),
+            Id = GenerateDeterministicGameId(entry.BggId, entry.Title),
             BggId = entry.BggId is > 0 ? entry.BggId.Value : null,
             Title = entry.Title,
             YearPublished = 2020,
@@ -232,5 +232,20 @@ internal static class GameSeeder
             CreatedAt = DateTime.UtcNow,
             IsDeleted = false
         };
+    }
+
+    /// <summary>
+    /// Deterministic SharedGame id derived from the game's stable identity (bggId when present,
+    /// otherwise the normalized title). Re-seeding after a DB wipe therefore reuses the same id,
+    /// so PdfSeeder recognizes existing PDFs (no orphans, embeddings preserved) — Issue #2904 / #964.
+    /// SHA-256 of a namespaced key truncated to 16 bytes; NOT for cryptographic use.
+    /// </summary>
+    internal static Guid GenerateDeterministicGameId(int? bggId, string title)
+    {
+        var key = bggId is > 0
+            ? $"sharedgame:bgg:{bggId.Value}"
+            : $"sharedgame:title:{(title ?? string.Empty).Trim().ToLowerInvariant()}";
+        var hash = System.Security.Cryptography.SHA256.HashData(System.Text.Encoding.UTF8.GetBytes(key));
+        return new Guid(hash[..16]);
     }
 }

--- a/apps/api/tests/Api.Tests/Infrastructure/Seeders/Catalog/GameSeederDeterministicIdTests.cs
+++ b/apps/api/tests/Api.Tests/Infrastructure/Seeders/Catalog/GameSeederDeterministicIdTests.cs
@@ -67,4 +67,14 @@ public sealed class GameSeederDeterministicIdTests
         first.Id.Should().Be(second.Id, "re-seeding the same manifest game must reuse the same SharedGame id");
         first.Id.Should().Be(GameSeeder.GenerateDeterministicGameId(entry.BggId, entry.Title));
     }
+
+    [Fact]
+    public void GenerateDeterministicGameId_NullTitle_NoBggId_DoesNotThrow()
+    {
+        // Defensive: the title fallback tolerates a null title (should never happen from the
+        // manifest, but the parameter is nullable and must not NRE).
+        var act = () => GameSeeder.GenerateDeterministicGameId(null, null);
+        act.Should().NotThrow();
+        GameSeeder.GenerateDeterministicGameId(null, null).Should().NotBe(Guid.Empty);
+    }
 }

--- a/apps/api/tests/Api.Tests/Infrastructure/Seeders/Catalog/GameSeederDeterministicIdTests.cs
+++ b/apps/api/tests/Api.Tests/Infrastructure/Seeders/Catalog/GameSeederDeterministicIdTests.cs
@@ -1,0 +1,70 @@
+using Api.Infrastructure.Seeders;
+using Api.Infrastructure.Seeders.Catalog;
+using Api.Models;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.Infrastructure.Seeders.Catalog;
+
+// Issue #2904: SharedGame ids must be deterministic (derived from bggId/title) so that
+// re-seeding after a DB wipe reuses the same id — preventing orphan PDFs and preserving
+// embeddings across deploys (#964).
+[Trait("Category", TestCategories.Unit)]
+public sealed class GameSeederDeterministicIdTests
+{
+    [Fact]
+    public void GenerateDeterministicGameId_SameBggId_ReturnsSameGuid()
+    {
+        var a = GameSeeder.GenerateDeterministicGameId(13, "Catan");
+        var b = GameSeeder.GenerateDeterministicGameId(13, "Catan");
+        a.Should().Be(b);
+    }
+
+    [Fact]
+    public void GenerateDeterministicGameId_DifferentBggId_ReturnsDifferentGuid()
+    {
+        var a = GameSeeder.GenerateDeterministicGameId(13, "Catan");
+        var b = GameSeeder.GenerateDeterministicGameId(9209, "Ticket to Ride");
+        a.Should().NotBe(b);
+    }
+
+    [Fact]
+    public void GenerateDeterministicGameId_BggIdWins_OverTitle()
+    {
+        // Same bggId but a drifting/renamed title must still resolve to the same id.
+        var a = GameSeeder.GenerateDeterministicGameId(13, "Catan");
+        var b = GameSeeder.GenerateDeterministicGameId(13, "Settlers of Catan");
+        a.Should().Be(b);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData(0)]
+    public void GenerateDeterministicGameId_NoBggId_FallsBackToTitle_CaseInsensitive(int? bggId)
+    {
+        var a = GameSeeder.GenerateDeterministicGameId(bggId, "Custom Homebrew");
+        var b = GameSeeder.GenerateDeterministicGameId(bggId, "  custom homebrew  ");
+        a.Should().Be(b, "title fallback is trimmed + lowercased for stability");
+    }
+
+    [Fact]
+    public void GenerateDeterministicGameId_IsNotEmpty()
+    {
+        GameSeeder.GenerateDeterministicGameId(13, "Catan").Should().NotBe(Guid.Empty);
+        GameSeeder.GenerateDeterministicGameId(null, "X").Should().NotBe(Guid.Empty);
+    }
+
+    [Fact]
+    public void CreateFromEnhancedData_IsIdempotent_SameEntryYieldsSameId()
+    {
+        var systemUserId = Guid.NewGuid();
+        var entry = new SeedManifestGame { Title = "Wingspan", BggId = 266192, Language = "en" };
+
+        var first = GameSeeder.CreateFromEnhancedData(entry, systemUserId);
+        var second = GameSeeder.CreateFromEnhancedData(entry, systemUserId);
+
+        first.Id.Should().Be(second.Id, "re-seeding the same manifest game must reuse the same SharedGame id");
+        first.Id.Should().Be(GameSeeder.GenerateDeterministicGameId(entry.BggId, entry.Title));
+    }
+}


### PR DESCRIPTION
## Problem

`GameSeeder` assigned `Guid.NewGuid()` to every newly-created `SharedGameEntity` (`GameSeeder.cs:151`, `:182`, `:214`). The seeder is idempotent only while the game row already exists (it matches on `bggId`/`title` and reuses the id). But when the DB is wiped and re-seeded (migration reset, `docker compose down -v`, staging reset, test), each game gets a **new random id**. Since `PdfSeeder` keys idempotency on `shared_game_id`, the id churn strands the previous PDFs as orphans — **144 orphan `pdf_documents` on staging** — and forces embeddings to be regenerated on every re-seed (defeating the goal of #964).

## Fix

Derive the `SharedGame` id **deterministically** from `bggId` (fallback: normalized title) via a new `GameSeeder.GenerateDeterministicGameId`, so the same game always resolves to the same id across re-seeds. `PdfSeeder` then recognizes existing PDFs → no new orphans, embeddings preserved.

- SHA-256 of a namespaced key (`sharedgame:bgg:{id}` / `sharedgame:title:{normalized}`) truncated to 16 bytes. Not for cryptographic use — chosen over MD5 to avoid the crypto-weakness lint.
- `bggId` takes precedence over title (a renamed title still resolves to the same id).
- **Existing DBs are unaffected**: the seeder still matches existing rows by `bggId`/`title` first, so it never re-creates games that are already present.

## Verification

- 7 new unit tests (`GameSeederDeterministicIdTests`): determinism, bggId-precedence, case-insensitive title fallback, non-empty, and end-to-end idempotence of `CreateFromEnhancedData`.
- **126 seeder tests pass** (no regressions across GameSeeder / CatalogSeeder / PdfSeeder / etc.).

## Out of scope (follow-up)

- Retroactive cleanup of the 144 existing orphan PDFs.
- Auto re-enqueue of PDFs stranded in `Pending` (done manually on staging in this session).

Closes #2904. Related: #964.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
