### PR TITLE
fix(processing): stuck-job monitor never degrades jobs — isolate each degrade in its own scope (#2903)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/Services/ProcessingQueueMonitorService.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/Services/ProcessingQueueMonitorService.cs
@@ -177,7 +177,9 @@ internal sealed class ProcessingQueueMonitorService : BackgroundService
                     }
                 }
 #pragma warning disable CA1031 // Best-effort per-job degrade — one failure must not abort the whole check
-                catch (Exception ex)
+                // Let OperationCanceledException propagate so a shutdown signal exits promptly and
+                // is not mislogged as a transient degrade failure (ExecuteAsync breaks on it).
+                catch (Exception ex) when (ex is not OperationCanceledException)
                 {
                     _logger.LogError(ex,
                         "Failed to auto-degrade stuck job {JobId} (PDF: {FileName}); continuing with remaining jobs (Issue #2903)",

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/Services/ProcessingQueueMonitorService.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/Services/ProcessingQueueMonitorService.cs
@@ -98,9 +98,8 @@ internal sealed class ProcessingQueueMonitorService : BackgroundService
         using var scope = _scopeFactory.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
         var streamService = scope.ServiceProvider.GetRequiredService<IQueueStreamService>();
-        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
 
-        await CheckStuckJobsAsync(db, streamService, mediator, ct).ConfigureAwait(false);
+        await CheckStuckJobsAsync(db, streamService, ct).ConfigureAwait(false);
         await CheckQueueDepthAsync(db, streamService, ct).ConfigureAwait(false);
         await CheckFailureRateAsync(db, streamService, ct).ConfigureAwait(false);
     }
@@ -108,7 +107,6 @@ internal sealed class ProcessingQueueMonitorService : BackgroundService
     private async Task CheckStuckJobsAsync(
         MeepleAiDbContext db,
         IQueueStreamService streamService,
-        IMediator mediator,
         CancellationToken ct)
     {
         var cutoff = DateTimeOffset.UtcNow - StuckJobTimeout;
@@ -158,13 +156,34 @@ internal sealed class ProcessingQueueMonitorService : BackgroundService
                     continue;
                 }
 
-                var result = await mediator.Send(new DegradeStuckJobCommand(job.Id, stuckMinutes), ct).ConfigureAwait(false);
-                if (result.Degraded)
+                // Issue #2903: run each degrade in its OWN scope/DbContext. Sharing the monitor's
+                // DbContext across jobs let one degrade's domain-event outbox rows collide with the
+                // next on the same change-tracker (EF identity conflict: DomainEventOutboxEntity.Id
+                // == EventId), which threw out of the entire check every cycle — so NO stuck job was
+                // ever degraded. The per-job try/catch keeps a single failure from aborting the
+                // remaining jobs and the downstream queue-depth / failure-rate checks.
+                try
                 {
-                    _logger.LogWarning(
-                        "Auto-degraded stuck job {JobId} (PDF: {FileName}) to Failed after {Minutes:F1} min (Issue #2689)",
-                        job.Id, job.FileName, stuckMinutes);
+                    using var degradeScope = _scopeFactory.CreateScope();
+                    var degradeMediator = degradeScope.ServiceProvider.GetRequiredService<IMediator>();
+                    var result = await degradeMediator
+                        .Send(new DegradeStuckJobCommand(job.Id, stuckMinutes), ct)
+                        .ConfigureAwait(false);
+                    if (result.Degraded)
+                    {
+                        _logger.LogWarning(
+                            "Auto-degraded stuck job {JobId} (PDF: {FileName}) to Failed after {Minutes:F1} min (Issue #2689)",
+                            job.Id, job.FileName, stuckMinutes);
+                    }
                 }
+#pragma warning disable CA1031 // Best-effort per-job degrade — one failure must not abort the whole check
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex,
+                        "Failed to auto-degrade stuck job {JobId} (PDF: {FileName}); continuing with remaining jobs (Issue #2903)",
+                        job.Id, job.FileName);
+                }
+#pragma warning restore CA1031
             }
         }
     }

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Infrastructure/Services/ProcessingQueueMonitorServiceTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Infrastructure/Services/ProcessingQueueMonitorServiceTests.cs
@@ -314,4 +314,72 @@ public sealed class ProcessingQueueMonitorServiceTests
                 It.IsAny<CancellationToken>()),
             Times.Once);
     }
+
+    // ──────────────────────────────────────────────────────────────────
+    // Issue #2903: multiple stuck jobs are ALL degraded. Previously the second
+    // degrade collided with the first on the shared DbContext (outbox identity
+    // conflict), throwing out of the whole check so no job was recovered.
+    // ──────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task CheckStuckJobs_MultipleStuckJobs_DegradesEachOne()
+    {
+        var dbName = $"monitor_multi_{Guid.NewGuid():N}";
+        var startedAt = DateTimeOffset.UtcNow.AddMinutes(-40);
+        var job1 = await SeedStuckJobAsync(dbName, startedAt);
+        var job2 = await SeedStuckJobAsync(dbName, startedAt);
+
+        var (scopeFactory, mediatorMock, _) = BuildScopeFactory(dbName);
+        var tp = new FakeTimeProvider(DateTimeOffset.UtcNow);
+        var monitor = BuildMonitor(scopeFactory, tp);
+        tp.Advance(TimeSpan.FromMinutes(31));
+
+        await monitor.RunChecksAsync(CancellationToken.None);
+
+        mediatorMock.Verify(
+            m => m.Send(It.Is<DegradeStuckJobCommand>(c => c.JobId == job1), It.IsAny<CancellationToken>()),
+            Times.Once);
+        mediatorMock.Verify(
+            m => m.Send(It.Is<DegradeStuckJobCommand>(c => c.JobId == job2), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    // ──────────────────────────────────────────────────────────────────
+    // Issue #2903: a single degrade failure (the real bug threw an EF identity
+    // conflict) must NOT abort the remaining jobs or the whole check.
+    // ──────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task CheckStuckJobs_OneDegradeThrows_StillDegradesTheOthers()
+    {
+        var dbName = $"monitor_resilient_{Guid.NewGuid():N}";
+        var startedAt = DateTimeOffset.UtcNow.AddMinutes(-40);
+        var job1 = await SeedStuckJobAsync(dbName, startedAt);
+        var job2 = await SeedStuckJobAsync(dbName, startedAt);
+
+        var (scopeFactory, mediatorMock, _) = BuildScopeFactory(dbName);
+        // First job's degrade blows up (simulating the outbox identity conflict);
+        // the check must swallow it and still degrade the second job.
+        mediatorMock
+            .Setup(m => m.Send(
+                It.Is<DegradeStuckJobCommand>(c => c.JobId == job1),
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("simulated outbox identity conflict"));
+
+        var tp = new FakeTimeProvider(DateTimeOffset.UtcNow);
+        var monitor = BuildMonitor(scopeFactory, tp);
+        tp.Advance(TimeSpan.FromMinutes(31));
+
+        // Must NOT throw out of the check.
+        var act = async () => await monitor.RunChecksAsync(CancellationToken.None);
+        await act.Should().NotThrowAsync();
+
+        // Both degrades were attempted despite the first throwing.
+        mediatorMock.Verify(
+            m => m.Send(It.Is<DegradeStuckJobCommand>(c => c.JobId == job1), It.IsAny<CancellationToken>()),
+            Times.Once);
+        mediatorMock.Verify(
+            m => m.Send(It.Is<DegradeStuckJobCommand>(c => c.JobId == job2), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Infrastructure/Services/ProcessingQueueMonitorServiceTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Infrastructure/Services/ProcessingQueueMonitorServiceTests.cs
@@ -382,4 +382,31 @@ public sealed class ProcessingQueueMonitorServiceTests
             m => m.Send(It.Is<DegradeStuckJobCommand>(c => c.JobId == job2), It.IsAny<CancellationToken>()),
             Times.Once);
     }
+
+    // ──────────────────────────────────────────────────────────────────
+    // Issue #2903 (review): the per-job try/catch must NOT swallow cancellation —
+    // a shutdown signal has to propagate so the service exits promptly and is not
+    // mislogged as a transient degrade failure.
+    // ──────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task CheckStuckJobs_DegradeCancelled_PropagatesCancellation()
+    {
+        var dbName = $"monitor_cancel_{Guid.NewGuid():N}";
+        var startedAt = DateTimeOffset.UtcNow.AddMinutes(-40);
+        await SeedStuckJobAsync(dbName, startedAt);
+
+        var (scopeFactory, mediatorMock, _) = BuildScopeFactory(dbName);
+        mediatorMock
+            .Setup(m => m.Send(It.IsAny<DegradeStuckJobCommand>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new OperationCanceledException());
+
+        var tp = new FakeTimeProvider(DateTimeOffset.UtcNow);
+        var monitor = BuildMonitor(scopeFactory, tp);
+        tp.Advance(TimeSpan.FromMinutes(31));
+
+        // Cancellation must bubble out, not be caught as a transient degrade error.
+        var act = async () => await monitor.RunChecksAsync(CancellationToken.None);
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
 }


### PR DESCRIPTION
## Problem

On staging, 2 rows sat in `processing_jobs.status='Processing'` for **~10 hours** and were never auto-degraded. `ProcessingQueueMonitorService` **is** registered and **does** run every 2 min, and the stuck-job query finds them correctly — the failure is in the **degrade path**:

```
[ERR] Error during queue monitoring check
System.InvalidOperationException: The instance of entity type 'DomainEventOutboxEntity' cannot be
  tracked because another instance with the same key value for {'Id'} is already being tracked.
  at Api.Infrastructure.MeepleAiDbContext.EnqueueOutboxRows(...)
  at ...DegradeStuckJobCommandHandler.Handle(...)
  at ...ProcessingQueueMonitorService.CheckStuckJobsAsync(...)
```

`RunChecksAsync` creates **one** DI scope (→ one `MeepleAiDbContext`) and loops `DegradeStuckJobCommand` over every stuck job **on that shared context**. `DomainEventOutboxEntity.Enqueue` sets `Id = ev.EventId`. The first degrade's outbox rows (`job.Fail()` + `pdf.MarkAsFailed()`) stay on the shared change-tracker; the next job's `SaveChangesAsync → EnqueueOutboxRows` then hits an EF identity conflict. The exception bubbles out of `CheckStuckJobsAsync` and is swallowed at the `ExecuteAsync` boundary — so **the entire check (stuck-jobs + queue-depth + failure-rate) aborts every cycle and no stuck job is ever recovered.**

This is exactly what wedged the 50 staging PDFs (worker slots held by never-degraded jobs).

## Fix (targeted — does not touch the outbox core)

- **Isolate each degrade**: run every `DegradeStuckJobCommand` in its own DI scope / `MeepleAiDbContext`, so per-job outbox rows can never collide on a shared change-tracker. The read-only stuck-job query stays on the shared context.
- **Per-job try/catch**: a single degrade failure no longer aborts the remaining jobs or the downstream queue-depth / failure-rate checks.

The `StartedAt != null` query filter is **not** the problem (the wedged jobs had `started_at` populated) — the query found them; the degrade crashed.

## Verification

- 2 new regression tests: `MultipleStuckJobs_DegradesEachOne` (all stuck jobs degraded) and `OneDegradeThrows_StillDegradesTheOthers` (a throwing degrade doesn't abort the check — this reproduces the failure mode the shared scope caused).
- **9 monitor tests pass**.

Closes #2903.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
