### PR TITLE
chore(infra): #2772 scaffold containerized cloudflared (Option A, opt-in)

### DIFF
--- a/docs/for-developers/operations/cf-tunnel-containerization.md
+++ b/docs/for-developers/operations/cf-tunnel-containerization.md
@@ -1,0 +1,89 @@
+# Containerizing cloudflared (Cloudflare Tunnel) — Issue #2772 Option A
+
+**Status**: scaffold (draft). The repo half is committed; the **cutover is an ops task** that requires the Cloudflare dashboard + a staging deploy. Nothing here changes the running edge until an operator runs the steps below.
+
+**Issue**: [#2772](https://github.com/meepleAi-app/meepleai-monorepo/issues/2772) — intermittent `api.meepleai.app` 502 from host `docker-proxy` fragility (root cause B, split from #2770).
+
+## Problem recap
+
+`cloudflared` currently runs as a **VPS-native process** (not a container). It can only reach the API through the host-published port `127.0.0.1:8080` / `::1:8080` (`infra/compose.staging.yml` api `ports:`). Docker implements each published port with a userland `docker-proxy` process. Under VPS memory/disk pressure that `docker-proxy` gets OOM-killed; both host bindings then refuse connections **while the API container stays healthy on the `meepleai` docker network**. cloudflared logs `dial tcp [::1]:8080: connect: connection refused` → **502**.
+
+## What Option A does
+
+Run `cloudflared` as a **container on the `meepleai` docker network** so it reaches origins by container name (`http://meepleai-api:8080`) — the `docker-proxy` host path is removed from the request flow entirely.
+
+The repo scaffold (this PR) adds:
+- A `cloudflared` service in `infra/compose.staging.yml`, gated behind `profiles: [cf-tunnel]` so it is **not** started by the default `make staging`.
+- `infra/secrets/cloudflared.secret.example` — the `TUNNEL_TOKEN` template.
+- This runbook.
+
+It does **not** (and cannot, from a repo PR):
+- Change the Cloudflare dashboard tunnel ingress/origins (dashboard-only for a token/remotely-managed tunnel).
+- Stop the VPS-native `cloudflared`.
+- Free VPS resources.
+
+## Prerequisites
+
+- SSH to the staging VPS (`deploy@204.168.135.69`).
+- Cloudflare Zero Trust dashboard access for the tunnel that fronts `*.meepleai.app`.
+- The tunnel token (same one the VPS-native connector uses).
+- **Outbound UDP 7844** open from the VPS to the Cloudflare edge (QUIC, the default protocol when a token is supplied; falls back to HTTP2/TCP). Verify: `nc -uvz -w 3 <cf-edge-ip> 7844`. If UDP is blocked the connector still works over HTTP2, just less optimally.
+
+## Cutover (staging)
+
+1. **Provide the token** on the VPS:
+   ```bash
+   cd /opt/meepleai/repo/infra
+   printf 'TUNNEL_TOKEN=%s\n' "<paste-tunnel-token>" > secrets/cloudflared.secret
+   chmod 600 secrets/cloudflared.secret
+   ```
+
+2. **Start the containerized connector** (opt-in profile; leaves the native one running for now — a token tunnel supports multiple connectors):
+   ```bash
+   docker compose -f docker-compose.yml -f compose.staging.yml --profile cf-tunnel up -d cloudflared
+   docker logs meepleai-cloudflared --tail=50   # expect "Registered tunnel connection" lines
+   ```
+
+3. **Repoint origins in the Cloudflare dashboard** (Zero Trust → Networks → Tunnels → *your tunnel* → **Public Hostnames**). For each hostname change the **Service** origin from `http://localhost:<port>` to the container name on the `meepleai` network:
+
+   | Public hostname | Old origin | New origin |
+   |---|---|---|
+   | `api.meepleai.app` | `http://localhost:8080` | `http://meepleai-api:8080` |
+   | `meepleai.app` | `http://localhost:3000` | `http://meepleai-web:3000` |
+   | `grafana.meepleai.app` | `http://localhost:3001` | `http://meepleai-grafana:3000` |
+   | `prometheus.meepleai.app` | `http://localhost:9090` | `http://meepleai-prometheus:9090` |
+
+   > While **both** connectors run, the dashboard origin is shared. `http://meepleai-*` only resolves inside the container, so once you repoint, the **native** connector can no longer serve these hostnames — do step 4 promptly.
+
+4. **Stop the VPS-native connector** so only the containerized one serves traffic:
+   ```bash
+   sudo systemctl stop cloudflared
+   sudo systemctl disable cloudflared   # prevent restart on reboot
+   ```
+
+5. **Verify** (repeat a few times; the old failure was intermittent):
+   ```bash
+   for i in $(seq 1 10); do curl -s -o /dev/null -w '%{http_code}\n' https://api.meepleai.app/health; sleep 2; done
+   # expect 200 (or 503-Degraded), never 502
+   ```
+   The deploy smoke test `API Direct Health` (`.github/workflows/deploy-staging.yml`) allows `200 503` but **not** `502`, so a green staging deploy confirms the fix.
+
+## Rollback
+
+1. Re-point the dashboard origins back to `http://localhost:<port>`.
+2. `sudo systemctl enable --now cloudflared` (restart the native connector).
+3. `docker compose -f docker-compose.yml -f compose.staging.yml --profile cf-tunnel down` (or `stop cloudflared`).
+
+The host `ports:` bindings are untouched by this scaffold, so the native path is intact for rollback.
+
+## Optional follow-up (after the cutover is stable)
+
+- Drop the now-unused host publishes `127.0.0.1:8080/::1:8080` (api) and `:3000` (web) from `compose.staging.yml` — once all edge traffic goes via the docker network they are dead surface (and their `docker-proxy` processes are exactly the fragility this issue removes). Keep the monitoring publishes only if you still reach Grafana/Prometheus over an SSH tunnel.
+- Pin the `cloudflare/cloudflared` image to a specific version tag (the scaffold uses `:latest`).
+- Consider a container `healthcheck` via `cloudflared`'s `--metrics` `/ready` endpoint for autoheal.
+
+## Notes / references
+
+- Option B (VPS resource headroom so `docker-proxy` isn't OOM-killed) is largely addressed by #2764 (disk-gate ordering fix) — complementary, not a substitute.
+- Option C (host watchdog that `docker restart meepleai-api` when `:8080` is down) is a VPS-side mitigation, not a repo change.
+- cloudflared docker/token references: Cloudflare Tunnel docs (`cloudflare/cloudflared` — `TUNNEL_TOKEN` env, `tunnel --no-autoupdate run`, QUIC/UDP 7844 egress).

--- a/infra/compose.staging.yml
+++ b/infra/compose.staging.yml
@@ -159,6 +159,44 @@ services:
       options: { max-size: "10m", max-file: "3" }
 
   # ===========================================================================
+  # Edge — Cloudflare Tunnel (containerized) — Issue #2772 Option A · OPT-IN
+  # ===========================================================================
+  # Started ONLY with `--profile cf-tunnel`, so this scaffold cannot disturb the
+  # current VPS-native cloudflared until the cutover is validated. See the runbook:
+  # docs/for-developers/operations/cf-tunnel-containerization.md
+  #
+  # Why: the intermittent api.meepleai.app 502 (#2772) is caused by the host
+  # userland `docker-proxy` dying under VPS memory/disk pressure. A VPS-native
+  # cloudflared can only reach the API via the host-published 127.0.0.1/::1:8080
+  # port (docker-proxy in the path). On the `meepleai` docker network a
+  # containerized cloudflared reaches the container directly (http://meepleai-api:8080)
+  # — no docker-proxy, no single point of fragility.
+  #
+  # REQUIRES a matching Cloudflare dashboard change (Zero Trust → Networks →
+  # Tunnels → Public Hostnames): repoint api.meepleai.app origin from
+  # http://localhost:8080 to http://meepleai-api:8080 (and web/monitoring likewise).
+  # Uses the SAME remotely-managed tunnel token as the VPS-native cloudflared.
+  cloudflared:
+    profiles: [cf-tunnel]
+    image: cloudflare/cloudflared:latest  # TODO(ops): pin to a specific version tag before cutover
+    container_name: meepleai-cloudflared
+    restart: always
+    # Token supplied via TUNNEL_TOKEN (env_file) so it is not exposed in `ps`/command.
+    # Ingress/origins for a token (remotely-managed) tunnel live in the CF dashboard,
+    # not in a local config.yml.
+    command: ["tunnel", "--no-autoupdate", "run"]
+    env_file:
+      - ./secrets/cloudflared.secret   # TUNNEL_TOKEN=...
+    networks:
+      - meepleai
+    depends_on:
+      - api
+      - web
+    logging:
+      driver: "json-file"
+      options: { max-size: "10m", max-file: "3" }
+
+  # ===========================================================================
   # AI Services — internal-only (post-PR #738: CF Tunnel handles edge, no public exposure)
   # Resource limits are reduced vs base compose (CAX21 has 8GB total).
   # Use 'make staging' only when AI features are needed; prefer 'make staging-core' otherwise.

--- a/infra/secrets/cloudflared.secret.example
+++ b/infra/secrets/cloudflared.secret.example
@@ -1,0 +1,19 @@
+# Cloudflare Tunnel token — Issue #2772 (containerized cloudflared, Option A)
+# OPTIONAL until the `cf-tunnel` profile cutover.
+# Copy this file to infra/secrets/cloudflared.secret and fill in the value.
+#
+# Consumed by the `cloudflared` service (profiles: [cf-tunnel]) in compose.staging.yml.
+#
+# This is the SAME remotely-managed tunnel token already used by the VPS-native
+# cloudflared. Retrieve it from the Cloudflare Zero Trust dashboard:
+#   Networks → Tunnels → <your tunnel> → Configure → (token shown in the
+#   `cloudflared service install <TOKEN>` / `docker run ... run <TOKEN>` snippet).
+#
+# The token authenticates the connector to the tunnel; ingress/public-hostname
+# routes are managed in the dashboard (not here). Rotating the token rotates it
+# for every connector on this tunnel — keep the VPS-native and containerized
+# connectors in sync during the cutover window.
+#
+# SECURITY: never commit infra/secrets/cloudflared.secret — only this .example
+# template is committed (see infra/.gitignore + CLAUDE.md § Secret Management).
+TUNNEL_TOKEN=


### PR DESCRIPTION
Refs #2772. **Draft — scaffold only.** The repo half of Option A; the cutover is an ops task (CF dashboard + staging deploy) so this does NOT close #2772 on its own.

## Problem
`api.meepleai.app` intermittently 502s (#2772, root cause B of #2770). cloudflared runs **VPS-native** and reaches the API only via the host-published `127.0.0.1:8080`/`::1:8080` port, whose userland **`docker-proxy`** dies under VPS memory/disk pressure — both host bindings then refuse connections while the API stays healthy on the docker network.

## What this adds (Option A scaffold)
- **`infra/compose.staging.yml`**: an opt-in `cloudflared` service (`profiles: [cf-tunnel]`) on the `meepleai` docker network, reaching the API directly at `http://meepleai-api:8080` — no `docker-proxy` in the path. Token via `TUNNEL_TOKEN` (env_file), `command: tunnel --no-autoupdate run`, `restart: always`.
- **`infra/secrets/cloudflared.secret.example`**: the `TUNNEL_TOKEN` template.
- **`docs/for-developers/operations/cf-tunnel-containerization.md`**: the cutover runbook (dashboard origin edits, staging verify, rollback, UDP 7844 egress note).

## Non-breaking
The service is **only** started with `--profile cf-tunnel`, so the default `make staging` and the current VPS-native cloudflared are untouched until an operator runs the cutover.

## Out of repo scope (ops — see runbook)
- Repoint CF dashboard public-hostname origins `http://localhost:*` → `http://meepleai-*:*` (dashboard-only for a token tunnel).
- Provide the real `cloudflared.secret`, bring up the profile, stop the VPS-native connector, verify on staging.

## Validation
`docker compose -f docker-compose.yml -f compose.staging.yml --profile cf-tunnel config` renders the service without errors (checked with dummy secrets locally). Full behavioral validation requires the staging VPS + CF dashboard (the whole issue is flagged "needs a staging deploy to validate").

References: Cloudflare Tunnel docs (`cloudflare/cloudflared`: `TUNNEL_TOKEN` env, `tunnel --no-autoupdate run`, QUIC/UDP 7844 egress).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
