### PR TITLE
fix(frontend): resolve useEntityActions placeholder handlers (#2776)

### DIFF
--- a/apps/web/src/hooks/__tests__/useEntityActions.test.tsx
+++ b/apps/web/src/hooks/__tests__/useEntityActions.test.tsx
@@ -1,0 +1,183 @@
+/**
+ * Tests for useEntityActions — quick-action handler side effects (Issue #2776).
+ *
+ * Drives the hook directly per entity (the only way to exercise the non-`game`
+ * branches, which have no rendered consumer today). Asserts the corrected side
+ * effects for the 5 placeholder handlers + 2 sibling "Condividi" fixes.
+ */
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { useEntityActions } from '../useEntityActions';
+
+// ============================================================================
+// Mocks
+// ============================================================================
+
+const mockPush = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+const mockToastSuccess = vi.fn();
+const mockToastError = vi.fn();
+vi.mock('sonner', () => ({
+  toast: {
+    success: (...args: unknown[]) => mockToastSuccess(...args),
+    error: (...args: unknown[]) => mockToastError(...args),
+    info: vi.fn(),
+    warning: vi.fn(),
+  },
+}));
+
+const mockGetPdfDownloadUrl = vi.fn((id: string) => `https://api.test/api/v1/pdfs/${id}/download`);
+const mockExportChat = vi.fn<(chatId: string, req: { format: string }) => Promise<void>>();
+vi.mock('@/lib/api', () => ({
+  api: {
+    pdf: { getPdfDownloadUrl: (id: string) => mockGetPdfDownloadUrl(id) },
+    chat: { exportChat: (chatId: string, req: { format: string }) => mockExportChat(chatId, req) },
+  },
+}));
+
+// Collection hooks — mocked to keep the hook out of React Query.
+vi.mock('@/hooks/queries/useCollections', () => ({
+  useAddToCollection: () => ({ mutate: vi.fn() }),
+  useCollectionStatus: () => ({ data: undefined }),
+  useRemoveFromCollection: () => ({ remove: vi.fn() }),
+}));
+vi.mock('@/hooks/useCollectionActions', () => ({
+  useCollectionActions: () => ({ isInCollection: false, add: vi.fn(), remove: vi.fn() }),
+}));
+
+const mockWriteText = vi.fn<(text: string) => Promise<void>>();
+const mockOpen = vi.fn();
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+const SESSION_ID = '00000000-0000-4000-8000-0000000000s1';
+const KB_ID = '00000000-0000-4000-8000-0000000000k1';
+const CHAT_ID = '00000000-0000-4000-8000-0000000000c1';
+const PLAYER_ID = '00000000-0000-4000-8000-0000000000p1';
+const EVENT_ID = '00000000-0000-4000-8000-0000000000e1';
+const GAME_ID = '00000000-0000-4000-8000-0000000000g1';
+
+type Entity = Parameters<typeof useEntityActions>[0]['entity'];
+
+function actionsFor(entity: Entity, id: string, data?: Record<string, unknown>) {
+  const { result } = renderHook(() => useEntityActions({ entity, id, userId: 'user-1', data }));
+  return result.current.quickActions;
+}
+
+function clickByLabel(entity: Entity, id: string, label: string, data?: Record<string, unknown>) {
+  const action = actionsFor(entity, id, data).find(a => a.label === label);
+  if (!action) throw new Error(`action "${label}" not found for entity "${entity}"`);
+  action.onClick();
+  return action;
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('useEntityActions — quick-action side effects (#2776)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockWriteText.mockResolvedValue(undefined);
+    mockExportChat.mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText: mockWriteText },
+      configurable: true,
+    });
+    vi.stubGlobal('open', mockOpen);
+  });
+
+  describe('session — Condividi codice', () => {
+    it('copies the session code and shows a success toast', async () => {
+      clickByLabel('session', SESSION_ID, 'Condividi codice', { sessionCode: 'SESS-CODE-123' });
+
+      await waitFor(() => expect(mockWriteText).toHaveBeenCalledWith('SESS-CODE-123'));
+      expect(mockToastSuccess).toHaveBeenCalledWith('Codice sessione copiato');
+    });
+
+    it('shows an error toast when the clipboard write fails', async () => {
+      mockWriteText.mockRejectedValueOnce(new Error('denied'));
+
+      clickByLabel('session', SESSION_ID, 'Condividi codice', { sessionCode: 'SESS-CODE-123' });
+
+      await waitFor(() => expect(mockToastError).toHaveBeenCalled());
+      expect(mockToastSuccess).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('kb — Download', () => {
+    it('opens the correct pdf download URL (not the dead /documents route)', () => {
+      clickByLabel('kb', KB_ID, 'Download');
+
+      expect(mockGetPdfDownloadUrl).toHaveBeenCalledWith(KB_ID);
+      expect(mockOpen).toHaveBeenCalledWith(
+        `https://api.test/api/v1/pdfs/${KB_ID}/download`,
+        '_blank'
+      );
+    });
+  });
+
+  describe('chat — Esporta', () => {
+    it('calls the real export API with default pdf format + success toast', async () => {
+      clickByLabel('chat', CHAT_ID, 'Esporta');
+
+      await waitFor(() => expect(mockExportChat).toHaveBeenCalledWith(CHAT_ID, { format: 'pdf' }));
+      expect(mockToastSuccess).toHaveBeenCalledWith('Chat esportata');
+      expect(mockPush).not.toHaveBeenCalled();
+    });
+
+    it('shows an error toast when the export fails', async () => {
+      mockExportChat.mockRejectedValueOnce(new Error('boom'));
+
+      clickByLabel('chat', CHAT_ID, 'Esporta');
+
+      await waitFor(() => expect(mockToastError).toHaveBeenCalled());
+    });
+  });
+
+  describe('player — Invita a Sessione', () => {
+    it('navigates to the session wizard with the invitePlayer param', () => {
+      clickByLabel('player', PLAYER_ID, 'Invita a Sessione');
+
+      expect(mockPush).toHaveBeenCalledWith(`/sessions/new?invitePlayer=${PLAYER_ID}`);
+    });
+  });
+
+  describe('event — Partecipa', () => {
+    it('navigates to the real game-nights detail route (not the dead /events route)', () => {
+      clickByLabel('event', EVENT_ID, 'Partecipa');
+
+      expect(mockPush).toHaveBeenCalledWith(`/game-nights/${EVENT_ID}`);
+    });
+  });
+
+  describe('event — Condividi (sibling)', () => {
+    it('copies the game-nights URL (not the dead /events URL) with a success toast', async () => {
+      clickByLabel('event', EVENT_ID, 'Condividi');
+
+      await waitFor(() =>
+        expect(mockWriteText).toHaveBeenCalledWith(
+          `${window.location.origin}/game-nights/${EVENT_ID}`
+        )
+      );
+      expect(mockToastSuccess).toHaveBeenCalled();
+    });
+  });
+
+  describe('game — Condividi (sibling)', () => {
+    it('copies the game URL and shows a success toast', async () => {
+      clickByLabel('game', GAME_ID, 'Condividi');
+
+      await waitFor(() =>
+        expect(mockWriteText).toHaveBeenCalledWith(`${window.location.origin}/games/${GAME_ID}`)
+      );
+      expect(mockToastSuccess).toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/web/src/hooks/useEntityActions.ts
+++ b/apps/web/src/hooks/useEntityActions.ts
@@ -33,8 +33,10 @@ import {
   Wrench,
 } from 'lucide-react';
 import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
 
 import type { MeepleEntityType } from '@/components/ui/data-display/meeple-card';
+import { api } from '@/lib/api';
 import type { EntityType } from '@/lib/api/schemas/collections.schemas';
 import type { QuickAction } from '@/types/quick-action';
 
@@ -87,6 +89,38 @@ export interface EntityActions {
     destructive?: boolean;
     separator?: boolean;
   }>;
+}
+
+// ============================================================================
+// Handler helpers
+// ============================================================================
+
+/**
+ * Copy text to the clipboard with success/error toast feedback.
+ * Guards against restricted contexts where the Clipboard API is unavailable.
+ */
+async function copyWithToast(text: string, successMessage: string): Promise<void> {
+  try {
+    if (typeof navigator === 'undefined' || !navigator.clipboard) {
+      throw new Error('Clipboard API unavailable');
+    }
+    await navigator.clipboard.writeText(text);
+    toast.success(successMessage);
+  } catch {
+    toast.error('Copia non riuscita');
+  }
+}
+
+/**
+ * Export a chat thread (default PDF) via the existing export pipeline, with toast feedback.
+ */
+async function exportChatWithToast(chatId: string): Promise<void> {
+  try {
+    await api.chat.exportChat(chatId, { format: 'pdf' });
+    toast.success('Chat esportata');
+  } catch {
+    toast.error('Esportazione non riuscita');
+  }
 }
 
 // ============================================================================
@@ -197,7 +231,10 @@ export function useEntityActions({
               icon: Share2,
               label: 'Condividi',
               onClick: () => {
-                navigator.clipboard?.writeText(`${window.location.origin}/games/${id}`);
+                void copyWithToast(
+                  `${window.location.origin}/games/${id}`,
+                  'Link copiato negli appunti'
+                );
               },
             },
           ],
@@ -237,9 +274,8 @@ export function useEntityActions({
               icon: Share2,
               label: 'Condividi codice',
               onClick: () => {
-                // TODO: Copy session code to clipboard
                 const sessionCode = (data?.sessionCode as string | undefined) || id;
-                navigator.clipboard?.writeText(sessionCode);
+                void copyWithToast(sessionCode, 'Codice sessione copiato');
               },
             },
           ],
@@ -300,8 +336,8 @@ export function useEntityActions({
               icon: Download,
               label: 'Download',
               onClick: () => {
-                // TODO: Trigger download
-                window.open(`/api/v1/documents/${id}/download`, '_blank');
+                // Browser-native download via the canonical pdf endpoint (session-cookie auth).
+                window.open(api.pdf.getPdfDownloadUrl(id), '_blank');
               },
             },
             {
@@ -340,8 +376,7 @@ export function useEntityActions({
               icon: FileDown,
               label: 'Esporta',
               onClick: () => {
-                // TODO: Export chat history
-                router.push(`/chat/${id}/export`);
+                void exportChatWithToast(id);
               },
             },
           ],
@@ -375,7 +410,8 @@ export function useEntityActions({
               icon: UserPlus,
               label: 'Invita a Sessione',
               onClick: () => {
-                // TODO: Open session invite modal
+                // Navigates to the session wizard. The invitePlayer param is reserved for a
+                // future roster pre-fill (the wizard does not consume it yet — see #2776).
                 router.push(`/sessions/new?invitePlayer=${id}`);
               },
             },
@@ -405,15 +441,18 @@ export function useEntityActions({
               icon: CheckCircle,
               label: 'Partecipa',
               onClick: () => {
-                // TODO: RSVP to event
-                router.push(`/events/${id}/rsvp`);
+                // RSVP lives on the game-night detail page (event id === game-night id).
+                router.push(`/game-nights/${id}`);
               },
             },
             {
               icon: Share2,
               label: 'Condividi',
               onClick: () => {
-                navigator.clipboard?.writeText(`${window.location.origin}/events/${id}`);
+                void copyWithToast(
+                  `${window.location.origin}/game-nights/${id}`,
+                  'Link copiato negli appunti'
+                );
               },
             },
           ],

--- a/docs/superpowers/specs/2026-07-13-issue-2776-entity-actions-ux-design.md
+++ b/docs/superpowers/specs/2026-07-13-issue-2776-entity-actions-ux-design.md
@@ -1,0 +1,106 @@
+# Issue #2776 — `useEntityActions` quick-action UX cleanup — Design
+
+**Date**: 2026-07-13
+**Issue**: [#2776](https://github.com/meepleAi-app/meepleai-monorepo/issues/2776) (tech-debt, area/frontend, parent #564)
+**Branch**: `feature/issue-2776-entity-actions-ux`
+**Scope**: 1 file (`apps/web/src/hooks/useEntityActions.ts`) + unit tests
+
+---
+
+## Context
+
+Issue #2776 flags 5 quick-action handlers in `useEntityActions.ts` whose intended UX was
+stubbed with a `// TODO` and a simpler navigation/fallback. The design intent was to be
+recovered from the `admin-mockups/` design files, not invented.
+
+A read-only discovery pass (5 parallel agents, one per handler, mockups + reuse) produced two
+material findings:
+
+### Finding A — the 5 handlers are unreachable today (dead branches)
+
+`useEntityActions` is consumed by exactly **one** component, `MeepleGameCard.tsx`, always with
+`entity: 'game'`. The only wrapper, `useContextualActions.ts`, has **no consumer at all**. So
+the `switch` branches for `session`, `kb`, `chat`, `player`, `event` — i.e. **all 5 TODOs** —
+are never rendered. This matches the issue's own note ("no user-facing breakage today").
+
+Consequence: this is genuine **code-cleanup**, not a UX-facing bugfix. There is zero runtime
+risk, and we should keep changes minimal + honest rather than build new UI components for code
+nobody calls. (`useContextualActions` also hard-caps visible actions at 4 via `slice(0, 4)`.)
+
+### Finding B — 3 of the 5 fallbacks are broken links (not "working fallbacks")
+
+The issue states the handlers "are not broken (a working fallback exists)". That is **false**
+for 3 of them:
+
+| Handler | Fallback | Reality |
+|---|---|---|
+| `kb` Download | `window.open('/api/v1/documents/{id}/download')` | 🔴 backend route does not exist (correct is `/api/v1/pdfs/{id}/download`) |
+| `chat` Esporta | `router.push('/chat/{id}/export')` | 🔴 no such Next route → 404 |
+| `event` Partecipa | `router.push('/events/{id}/rsvp')` | 🔴 no `/events/[id]` route at all |
+
+Plus the sibling `event` "Condividi" copies `${origin}/events/{id}` — also a dead URL.
+
+---
+
+## Decisions (per-handler)
+
+All edits stay inside `useEntityActions.ts`. No new components, no backend, no new routes.
+Reuse only what already ships.
+
+| # | Handler | Decision | Implementation |
+|---|---------|----------|----------------|
+| 1 | `session` Condividi codice | **toast feedback** | async guard + `await clipboard.writeText(sessionCode)` → `toast.success('Codice sessione copiato')`; catch → `toast.error`. Drop TODO. |
+| 2 | `kb` Download | **fix dead URL** | `window.open(api.pdf.getPdfDownloadUrl(id), '_blank')` (canonical `KbDocActions` pattern). Drop TODO. |
+| 3 | `chat` Esporta | **real export, default PDF** | `await api.chat.exportChat(id, { format: 'pdf' })` + success/error toast. Infra already wired (`ExportFormat = pdf\|txt\|md`). Drop TODO. |
+| 4 | `player` Invita a Sessione | **keep nav + drop TODO** | Premise ("asse-B invite drawer") unsupported: no mockup, cascade drawer is entity-**detail** not a form, and there is no "add existing player to session" endpoint. The `/sessions/new` wizard does not read `invitePlayer`. Per issue DoD ("else keep navigation and remove the TODO"): keep `router.push('/sessions/new?invitePlayer={id}')`, replace TODO with an honest comment. |
+| 5 | `event` Partecipa (RSVP) | **fix dead route** | `router.push('/game-nights/{id}')` — the real detail route hosting the RSVP action bar (`event` id = game-night id). Inline click-to-mutate is not viable (RSVP is a 3-way choice with 409/410 lifecycle guards that live on the detail page). Drop TODO. |
+
+### Sibling fixes (chosen scope: "include coherent siblings")
+
+| # | Sibling | Decision |
+|---|---------|----------|
+| 6 | `event` Condividi | Fix dead copy URL `/events/{id}` → `/game-nights/{id}` + add copy→toast feedback. |
+| 7 | `game` Condividi | Add copy→toast feedback (same no-feedback gap as #1). URL `/games/{id}` unchanged. |
+
+The three "copy to clipboard" actions (session code, game URL, event URL) are unified through a
+single module-level `copyWithToast(text, successMessage)` helper (guard + await + success/error
+toast) to avoid duplication.
+
+### Explicitly out of scope (why chat-export stays single-action)
+
+The `chat` export intent was a "format picker". `QuickAction` has **no submenu primitive** and
+the wrapper caps at 4 actions; three flat export actions would be truncated and, on an unrendered
+branch, would be dead code. So we ship a single `Esporta` (default `pdf`) that calls the existing
+export infra. A true multi-format picker is deferred to when the `chat` branch gains a real
+consumer + a picker design.
+
+---
+
+## Testing strategy
+
+No test file exists for `useEntityActions` today. Add `apps/web/src/hooks/__tests__/useEntityActions.test.tsx`
+(vitest + `@testing-library/react` `renderHook`), driving the hook **directly per entity** (the
+only way to exercise the non-`game` branches). Mock: `sonner` (`toast`), `next/navigation`
+(`useRouter`), `@/lib/api` (`api.pdf.getPdfDownloadUrl`, `api.chat.exportChat`), `navigator.clipboard`,
+and `window.open`. Assert the corrected side effects per handler:
+
+- session/game/event Condividi → clipboard written + `toast.success`; on clipboard rejection → `toast.error`.
+- kb Download → `window.open` called with `/api/v1/pdfs/{id}/download`.
+- chat Esporta → `api.chat.exportChat(id, { format: 'pdf' })` called; success/error toast.
+- player Invita → `router.push('/sessions/new?invitePlayer={id}')` (unchanged, no TODO).
+- event Partecipa → `router.push('/game-nights/{id}')`.
+
+TDD: write these assertions first (red), then edit the handlers (green).
+
+## DoD (from issue, mapped)
+
+- [x] Copy-code: success toast + failure fallback → handlers 1/6/7.
+- [x] Invite: design does not call for a modal → keep navigation, remove TODO (handler 4).
+- [x] Export / Download / RSVP: implement the richer/correct flow (2, 3) or redirect to the real UX (5).
+- [x] Remove the resolved `// TODO:` markers.
+
+## Follow-up (not this PR)
+
+- The 5 non-`game` branches (and `useContextualActions`) are unreferenced. Track a separate
+  decision to either wire a real multi-entity consumer or remove the dead branches. Not done here
+  to keep #2776 a minimal, reviewable cleanup.


### PR DESCRIPTION
## Summary
Resolves #2776 — the 5 TODO-stubbed quick-action handlers in `useEntityActions.ts` (+2 sibling fixes), using shipped infra only (no new UI/backend).

## Discovery findings
- **All 5 handlers are unreachable today**: `useEntityActions` is consumed only by `MeepleGameCard.tsx` with `entity='game'`; the sole wrapper `useContextualActions` has no consumer. The `session/kb/chat/player/event` branches are never rendered.
- **3 of 5 fallbacks were dead links** (not "working fallbacks" as the issue text assumed): kb Download (`/api/v1/documents/{id}/download` doesn't exist), chat Esporta (`/chat/{id}/export` → 404), event Partecipa (`/events/{id}/rsvp` — no such route). Plus the sibling event "Condividi" copied a dead `/events/{id}` URL.

## Changes (all in `useEntityActions.ts`)
| Handler | Fix |
|---|---|
| session / game / event **Condividi** | async copy + success/error toast via a shared `copyWithToast` helper |
| kb **Download** | correct URL via `api.pdf.getPdfDownloadUrl` (`/api/v1/pdfs/{id}/download`) |
| chat **Esporta** | real export (default `pdf`) via `api.chat.exportChat` instead of the 404 route |
| event **Partecipa** | navigate to `/game-nights/{id}` (the real RSVP surface) |
| player **Invita** | keep navigation per issue DoD, drop TODO (asse-B invite-drawer premise unsupported: no mockup, no "add player to session" endpoint) |

## Tests
- New `useEntityActions.test.tsx`: **9 unit tests**, one per handler side effect (incl. clipboard/export failure paths). TDD red → green.
- `pnpm typecheck` ✅ · `pnpm lint` (source) ✅ · target suite **9/9** ✅

## Out of scope / follow-up
- chat export multi-format picker (infra supports `txt`/`md`) deferred until the branch gains a real consumer + picker design.
- The unreferenced non-`game` branches (+`useContextualActions`) warrant a separate decision (wire a consumer vs remove dead branches).
- Design doc: `docs/superpowers/specs/2026-07-13-issue-2776-entity-actions-ux-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)