### PR TITLE
chore(infra): #2772 docker-proxy watchdog (Option C interim)

### DIFF
--- a/infra/hetzner/docker-proxy-watchdog.cron
+++ b/infra/hetzner/docker-proxy-watchdog.cron
@@ -1,0 +1,5 @@
+# Issue #2772 Option C — restart meepleai-api if the host :8080 docker-proxy dies.
+# Interim mitigation until the containerized-cloudflared cutover (Option A, #2909).
+# Runs every minute; the script itself is quiet on the happy path and enforces a
+# 10-min restart cooldown (loop guard).
+* * * * * /usr/local/bin/docker-proxy-watchdog.sh >> /var/log/meepleai-docker-proxy-watchdog.log 2>&1

--- a/infra/hetzner/docker-proxy-watchdog.md
+++ b/infra/hetzner/docker-proxy-watchdog.md
@@ -1,0 +1,93 @@
+# docker-proxy watchdog — Issue #2772 Option C (interim)
+
+Host-side watchdog that restarts `meepleai-api` when the userland `docker-proxy`
+for its published `:8080` port dies (the intermittent `api.meepleai.app` 502 in
+[#2772](https://github.com/meepleAi-app/meepleai-monorepo/issues/2772)).
+
+**This is an interim band-aid.** The structural fix is the containerized
+cloudflared cutover (Option A — scaffold in PR #2909,
+`docs/for-developers/operations/cf-tunnel-containerization.md`). **Remove this
+watchdog once that cutover is validated** — on the docker network there is no
+`docker-proxy` in the path, so nothing to restart.
+
+## What it does
+
+Every minute it probes both host bindings `127.0.0.1:8080` and `::1:8080`. If
+**both** are unreachable across 3 checks **and** the `meepleai-api` container is
+running, it `docker restart`s the container (which recreates `docker-proxy`).
+Guards:
+- **Quiet on the happy path** (no log spam).
+- **10-min restart cooldown** (`WATCHDOG_COOLDOWN`) so a genuinely-broken API
+  isn't restart-looped — if `:8080` is still down inside the cooldown, the API
+  itself (not `docker-proxy`) is the fault and needs a human.
+- **Does not restart a stopped container** (the restart policy / a separate
+  alert owns that case).
+
+Requires `docker` + `curl` on the host (both already present on the VPS).
+
+## Install (cron — matches `backup.cron`)
+
+On the VPS (`deploy@204.168.135.69`):
+
+```bash
+sudo install -m 0755 infra/hetzner/docker-proxy-watchdog.sh /usr/local/bin/docker-proxy-watchdog.sh
+# add the cron line (runs as root so it can talk to the docker socket)
+sudo crontab -l 2>/dev/null | { cat; cat infra/hetzner/docker-proxy-watchdog.cron; } | sudo crontab -
+# verify
+sudo /usr/local/bin/docker-proxy-watchdog.sh; echo "exit=$?"   # happy path exits 0, silent
+tail -f /var/log/meepleai-docker-proxy-watchdog.log
+```
+
+## Alternative: systemd timer
+
+If you prefer systemd over cron, drop the cron line and use:
+
+```ini
+# /etc/systemd/system/meepleai-docker-proxy-watchdog.service
+[Unit]
+Description=meepleai docker-proxy watchdog (#2772 Option C)
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/docker-proxy-watchdog.sh
+```
+
+```ini
+# /etc/systemd/system/meepleai-docker-proxy-watchdog.timer
+[Unit]
+Description=Run the meepleai docker-proxy watchdog every minute
+
+[Timer]
+OnBootSec=60
+OnUnitActiveSec=60
+AccuracySec=10s
+
+[Install]
+WantedBy=timers.target
+```
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now meepleai-docker-proxy-watchdog.timer
+```
+
+## Uninstall (after the Option A cutover)
+
+```bash
+sudo crontab -l | grep -v docker-proxy-watchdog.sh | sudo crontab -   # or disable the timer
+sudo rm -f /usr/local/bin/docker-proxy-watchdog.sh /var/run/meepleai-docker-proxy-watchdog.last
+# systemd variant:
+# sudo systemctl disable --now meepleai-docker-proxy-watchdog.timer
+# sudo rm -f /etc/systemd/system/meepleai-docker-proxy-watchdog.{service,timer} && sudo systemctl daemon-reload
+```
+
+## Tunables (env)
+
+| Var | Default | Meaning |
+|---|---|---|
+| `WATCHDOG_CONTAINER` | `meepleai-api` | container to probe/restart |
+| `WATCHDOG_PORT` | `8080` | host port to probe |
+| `WATCHDOG_COOLDOWN` | `600` | min seconds between restarts |
+| `WATCHDOG_STATE` | `/var/run/meepleai-docker-proxy-watchdog.last` | last-restart timestamp file |

--- a/infra/hetzner/docker-proxy-watchdog.sh
+++ b/infra/hetzner/docker-proxy-watchdog.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# docker-proxy-watchdog.sh — Issue #2772 Option C (interim mitigation)
+#
+# The intermittent api.meepleai.app 502 (#2772) happens when the host userland
+# `docker-proxy` process for the api's published port dies under VPS
+# memory/disk pressure: both host bindings (127.0.0.1:8080 + ::1:8080) then
+# refuse connections while the container stays healthy on the docker network,
+# so cloudflared (VPS-native) gets `connection refused` → 502.
+#
+# This watchdog detects that specific signature — host :8080 unreachable while
+# the container is running — and `docker restart`s the container to recreate
+# docker-proxy. It is an INTERIM band-aid; the structural fix is the
+# containerized cloudflared cutover (Option A, PR #2909 scaffold). Remove this
+# watchdog once that cutover is validated.
+#
+# Deploy: copy to /usr/local/bin/, chmod +x, schedule via docker-proxy-watchdog.cron.
+# Requires: docker + curl on the host (both already present on the VPS).
+# Tunables via env: WATCHDOG_CONTAINER, WATCHDOG_PORT, WATCHDOG_COOLDOWN, WATCHDOG_STATE.
+set -euo pipefail
+
+CONTAINER="${WATCHDOG_CONTAINER:-meepleai-api}"
+PORT="${WATCHDOG_PORT:-8080}"
+COOLDOWN="${WATCHDOG_COOLDOWN:-600}"   # min seconds between restarts (loop guard)
+STATE_FILE="${WATCHDOG_STATE:-/var/run/meepleai-docker-proxy-watchdog.last}"
+RETRIES=3
+RETRY_DELAY=5
+
+log() { echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) [docker-proxy-watchdog] $*"; }
+
+# Connection-level probe of one host binding. Returns 0 (up) if curl connects at
+# all — even a 404/503 means docker-proxy is alive. Only a refused connection
+# (curl rc 7) or a connect/transfer timeout (rc 28) counts as the binding being
+# down. A hung API (timeout) is also worth a restart, so rc 28 counts as down.
+port_up() {  # $1 = host: 127.0.0.1 | ::1
+  local host="$1" url rc=0
+  if [ "$host" = "::1" ]; then url="http://[::1]:${PORT}/health/live"; else url="http://${host}:${PORT}/health/live"; fi
+  curl -s -o /dev/null --connect-timeout 3 --max-time 5 "$url" || rc=$?
+  [ "$rc" -ne 7 ] && [ "$rc" -ne 28 ]
+}
+
+# Both dual-stack bindings down = docker-proxy dead (per #2770 diagnosis).
+both_down() { ! port_up 127.0.0.1 && ! port_up ::1; }
+
+# Require the failure to persist across RETRIES checks to ignore transient blips.
+confirm_down() {
+  local i
+  for i in $(seq 1 "$RETRIES"); do
+    both_down || return 1          # recovered on some check → not down
+    [ "$i" -lt "$RETRIES" ] && sleep "$RETRY_DELAY"
+  done
+  return 0
+}
+
+main() {
+  # Happy path: bindings reachable → stay quiet (cron logs would spam otherwise).
+  confirm_down || exit 0
+
+  log "host :${PORT} unreachable on both 127.0.0.1 and ::1 after ${RETRIES} checks."
+
+  local running
+  running=$(docker inspect -f '{{.State.Running}}' "$CONTAINER" 2>/dev/null || echo "missing")
+  if [ "$running" != "true" ]; then
+    log "container ${CONTAINER} not running (state=${running}); NOT restarting (restart policy / separate alert owns a down container)."
+    exit 0
+  fi
+
+  local now last
+  now=$(date +%s)
+  last=$(cat "$STATE_FILE" 2>/dev/null || echo 0)
+  if [ $((now - last)) -lt "$COOLDOWN" ]; then
+    log "within cooldown ($((now - last))s < ${COOLDOWN}s); NOT restarting. If :${PORT} is still down, the API itself (not docker-proxy) is likely the fault — investigate."
+    exit 0
+  fi
+
+  log "container ${CONTAINER} running but host :${PORT} down → docker-proxy likely dead. Restarting to recreate it."
+  mkdir -p "$(dirname "$STATE_FILE")"
+  echo "$now" > "$STATE_FILE"
+  if docker restart "$CONTAINER" >/dev/null; then
+    log "docker restart ${CONTAINER} issued; will re-verify next run."
+  else
+    log "ERROR: docker restart ${CONTAINER} failed."
+    exit 1
+  fi
+}
+
+main "$@"


### PR DESCRIPTION
Refs #2772 — **interim mitigation (Option C)**. Complements the Option A scaffold (#2909); does not resolve #2772 on its own (the structural fix is the Option A cutover, which is ops-side).

## What
A host-side watchdog for the intermittent `api.meepleai.app` 502 (#2772): when the userland `docker-proxy` for the api's `:8080` port dies under VPS pressure, both host bindings refuse connections while the container stays healthy on the docker network → cloudflared 502. This restarts the container to recreate `docker-proxy`.

- `infra/hetzner/docker-proxy-watchdog.sh` — probes `127.0.0.1:8080` + `::1:8080`; restarts `meepleai-api` **only** if both are down across 3 checks **and** the container is running; 10-min cooldown loop-guard; quiet on the happy path.
- `infra/hetzner/docker-proxy-watchdog.cron` — every-minute schedule (matches `backup.cron`).
- `infra/hetzner/docker-proxy-watchdog.md` — install (cron + systemd alternative), tunables, uninstall-after-cutover.

## Interim
Band-aid until the Option A cutover (containerized cloudflared, #2909) — remove after. Repo-side only; installing on the VPS is an ops step (commands in the doc).

## Validation
`bash -n` clean; dry-run exercises the happy path (silent, exit 0) and the down path (logs + no restart when the container is missing) locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
