### PR TITLE
feat(seed): self-heal orphan + stale-Pending PDFs (#2907, #2908)

### DIFF
--- a/apps/api/src/Api/Infrastructure/Seeders/Catalog/CatalogSeeder.cs
+++ b/apps/api/src/Api/Infrastructure/Seeders/Catalog/CatalogSeeder.cs
@@ -96,6 +96,12 @@ internal static class CatalogSeeder
         await PdfSeeder.SeedAsync(db, manifest, gameMap, systemUserId, primaryBlob, seedBlob, logger, ct)
             .ConfigureAwait(false);
 
+        // Step 2.5: Seed self-healing — remove orphan PDFs (#2907), then re-enqueue any valid PDF
+        // stranded in Pending with no active job (#2908). Both idempotent (no-op once healthy).
+        await SeedMaintenanceSeeder.CleanupOrphanPdfsAsync(db, logger, ct).ConfigureAwait(false);
+        await SeedMaintenanceSeeder.ReenqueueStalePendingPdfsAsync(db, systemUserId, logger, ct)
+            .ConfigureAwait(false);
+
         // Step 3: Seed agents for games with seedAgent=true (Dev only)
         if (profile >= SeedProfile.Dev)
         {

--- a/apps/api/src/Api/Infrastructure/Seeders/Catalog/SeedMaintenanceSeeder.cs
+++ b/apps/api/src/Api/Infrastructure/Seeders/Catalog/SeedMaintenanceSeeder.cs
@@ -51,6 +51,18 @@ internal static class SeedMaintenanceSeeder
             return 0;
         }
 
+        // Remove the orphans' processing_jobs (and their steps) explicitly rather than relying on
+        // the DB-level ON DELETE CASCADE — this keeps the delete provider-agnostic (the InMemory
+        // test provider does not enforce FK cascades) and covered by unit tests.
+        var orphanIds = orphans.Select(p => p.Id).ToHashSet();
+        var orphanJobs = await db.Set<ProcessingJobEntity>()
+            .Include(j => j.Steps)
+            .Where(j => orphanIds.Contains(j.PdfDocumentId))
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+        if (orphanJobs.Count > 0)
+            db.Set<ProcessingJobEntity>().RemoveRange(orphanJobs);
+
         db.PdfDocuments.RemoveRange(orphans);
         await db.SaveChangesAsync(ct).ConfigureAwait(false);
         logger.LogInformation(
@@ -76,6 +88,10 @@ internal static class SeedMaintenanceSeeder
         var queued = nameof(JobStatus.Queued);
         var processing = nameof(JobStatus.Processing);
 
+        // Deliberately WITHOUT IgnoreQueryFilters (asymmetric with CleanupOrphanPdfsAsync): a
+        // soft-deleted game is excluded here, so its PDFs are NOT re-processed — we don't index a
+        // removed game. Cleanup, by contrast, keeps those PDFs (the game may be restored); if it is
+        // un-deleted a later seed run re-enqueues its Pending PDFs. Both paths are conservative.
         var validGameIds = (await db.SharedGames
             .Select(g => g.Id)
             .ToListAsync(ct)

--- a/apps/api/src/Api/Infrastructure/Seeders/Catalog/SeedMaintenanceSeeder.cs
+++ b/apps/api/src/Api/Infrastructure/Seeders/Catalog/SeedMaintenanceSeeder.cs
@@ -1,0 +1,137 @@
+using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
+using Api.Infrastructure.Entities.DocumentProcessing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Api.Infrastructure.Seeders.Catalog;
+
+/// <summary>
+/// Seed-time self-healing for the PDF catalog (runs in the Catalog layer, after PdfSeeder).
+/// Complements the deterministic-id fix (#2904) — which stops NEW orphans from forming — by
+/// repairing state left behind by earlier non-idempotent re-seeds:
+/// <list type="bullet">
+/// <item><see cref="CleanupOrphanPdfsAsync"/> (#2907): hard-deletes pdf_documents whose
+/// SharedGameId no longer resolves to any shared_games row.</item>
+/// <item><see cref="ReenqueueStalePendingPdfsAsync"/> (#2908): enqueues a Queued ProcessingJob
+/// for valid-catalog PDFs stuck in Pending with no active job, so PdfProcessingQuartzJob
+/// (every 10s) picks them up through the RAG pipeline.</item>
+/// </list>
+/// Both are idempotent — a no-op once the catalog is healthy.
+/// </summary>
+internal static class SeedMaintenanceSeeder
+{
+    /// <summary>
+    /// #2907: hard-delete orphan PDF documents whose <c>SharedGameId</c> points to a game that no
+    /// longer exists (physically absent — <see cref="EntityFrameworkQueryableExtensions.IgnoreQueryFilters{TEntity}"/>
+    /// so a merely soft-deleted game is NOT treated as an orphan). Associated processing_jobs
+    /// cascade via FK; blob files are shared/idempotent in the seed bucket and are NOT touched.
+    /// </summary>
+    /// <returns>The number of orphan documents removed.</returns>
+    public static async Task<int> CleanupOrphanPdfsAsync(
+        MeepleAiDbContext db,
+        ILogger logger,
+        CancellationToken ct)
+    {
+        var gameIdSet = (await db.SharedGames
+            .IgnoreQueryFilters()
+            .Select(g => g.Id)
+            .ToListAsync(ct)
+            .ConfigureAwait(false)).ToHashSet();
+
+        var orphans = (await db.PdfDocuments
+            .Where(p => p.SharedGameId != null)
+            .ToListAsync(ct)
+            .ConfigureAwait(false))
+            .Where(p => !gameIdSet.Contains(p.SharedGameId!.Value))
+            .ToList();
+
+        if (orphans.Count == 0)
+        {
+            logger.LogInformation("SeedMaintenance: no orphan PDF documents to clean up (#2907)");
+            return 0;
+        }
+
+        db.PdfDocuments.RemoveRange(orphans);
+        await db.SaveChangesAsync(ct).ConfigureAwait(false);
+        logger.LogInformation(
+            "SeedMaintenance: hard-deleted {Count} orphan PDF document(s) with a dangling shared_game_id (#2907)",
+            orphans.Count);
+        return orphans.Count;
+    }
+
+    /// <summary>
+    /// #2908: enqueue a Queued ProcessingJob (+ the five pipeline steps, matching PdfSeeder) for
+    /// valid-catalog PDFs stuck in <see cref="PdfProcessingState.Pending"/> with no active
+    /// (Queued/Processing) job. Scoped to games that still exist so orphans are never re-processed
+    /// (<see cref="CleanupOrphanPdfsAsync"/> removes those). Idempotent.
+    /// </summary>
+    /// <returns>The number of PDFs re-enqueued.</returns>
+    public static async Task<int> ReenqueueStalePendingPdfsAsync(
+        MeepleAiDbContext db,
+        Guid systemUserId,
+        ILogger logger,
+        CancellationToken ct)
+    {
+        var pending = nameof(PdfProcessingState.Pending);
+        var queued = nameof(JobStatus.Queued);
+        var processing = nameof(JobStatus.Processing);
+
+        var validGameIds = (await db.SharedGames
+            .Select(g => g.Id)
+            .ToListAsync(ct)
+            .ConfigureAwait(false)).ToHashSet();
+
+        var pendingPdfs = await db.PdfDocuments
+            .Where(p => p.SharedGameId != null && p.ProcessingState == pending)
+            .Select(p => new { p.Id, SharedGameId = p.SharedGameId!.Value })
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+
+        var activeJobPdfIds = (await db.Set<ProcessingJobEntity>()
+            .Where(j => j.Status == queued || j.Status == processing)
+            .Select(j => j.PdfDocumentId)
+            .ToListAsync(ct)
+            .ConfigureAwait(false)).ToHashSet();
+
+        var toEnqueue = pendingPdfs
+            .Where(p => validGameIds.Contains(p.SharedGameId) && !activeJobPdfIds.Contains(p.Id))
+            .ToList();
+
+        if (toEnqueue.Count == 0)
+        {
+            logger.LogInformation("SeedMaintenance: no stale Pending PDFs to re-enqueue (#2908)");
+            return 0;
+        }
+
+        var now = DateTimeOffset.UtcNow;
+        foreach (var pdf in toEnqueue)
+        {
+            var job = new ProcessingJobEntity
+            {
+                Id = Guid.NewGuid(),
+                PdfDocumentId = pdf.Id,
+                UserId = systemUserId,
+                Status = queued,
+                Priority = 0,
+                CreatedAt = now,
+                MaxRetries = 3,
+                RetryCount = 0,
+            };
+            job.Steps = new List<ProcessingStepEntity>
+            {
+                new() { Id = Guid.NewGuid(), ProcessingJobId = job.Id, StepName = nameof(ProcessingStepType.Upload),  Status = "Pending" },
+                new() { Id = Guid.NewGuid(), ProcessingJobId = job.Id, StepName = nameof(ProcessingStepType.Extract), Status = "Pending" },
+                new() { Id = Guid.NewGuid(), ProcessingJobId = job.Id, StepName = nameof(ProcessingStepType.Chunk),   Status = "Pending" },
+                new() { Id = Guid.NewGuid(), ProcessingJobId = job.Id, StepName = nameof(ProcessingStepType.Embed),   Status = "Pending" },
+                new() { Id = Guid.NewGuid(), ProcessingJobId = job.Id, StepName = nameof(ProcessingStepType.Index),   Status = "Pending" },
+            };
+            db.Set<ProcessingJobEntity>().Add(job);
+        }
+
+        await db.SaveChangesAsync(ct).ConfigureAwait(false);
+        logger.LogInformation(
+            "SeedMaintenance: re-enqueued {Count} stale Pending PDF(s) with no active job (#2908)",
+            toEnqueue.Count);
+        return toEnqueue.Count;
+    }
+}

--- a/apps/api/tests/Api.Tests/Infrastructure/Seeders/Catalog/SeedMaintenanceSeederTests.cs
+++ b/apps/api/tests/Api.Tests/Infrastructure/Seeders/Catalog/SeedMaintenanceSeederTests.cs
@@ -51,19 +51,22 @@ public sealed class SeedMaintenanceSeederTests
     // ── #2907 ──────────────────────────────────────────────────────────
 
     [Fact]
-    public async Task CleanupOrphanPdfs_RemovesDanglingPdfs_KeepsValidOnes()
+    public async Task CleanupOrphanPdfs_RemovesDanglingPdfs_AndTheirJobs_KeepsValidOnes()
     {
         var dbName = $"seedmaint_cleanup_{Guid.NewGuid():N}";
         var orphanGameId = Guid.NewGuid(); // never inserted into shared_games
-        Guid validGameId;
+        Guid validGameId, orphanPdfId;
 
         using (var db = TestDbContextFactory.CreateInMemoryDbContext(dbName))
         {
             var game = NewGame("Valid", 13);
             validGameId = game.Id;
             db.SharedGames.Add(game);
-            db.PdfDocuments.Add(NewPdf(validGameId, "valid.pdf"));
-            db.PdfDocuments.Add(NewPdf(orphanGameId, "orphan.pdf"));
+            var validPdf = NewPdf(validGameId, "valid.pdf");
+            var orphanPdf = NewPdf(orphanGameId, "orphan.pdf");
+            orphanPdfId = orphanPdf.Id;
+            db.PdfDocuments.AddRange(validPdf, orphanPdf);
+            db.Set<ProcessingJobEntity>().Add(NewQueuedJob(orphanPdfId, Guid.NewGuid()));
             await db.SaveChangesAsync();
         }
 
@@ -78,6 +81,12 @@ public sealed class SeedMaintenanceSeederTests
         {
             var remaining = await db.PdfDocuments.Select(p => p.SharedGameId).ToListAsync();
             remaining.Should().ContainSingle().Which.Should().Be(validGameId);
+
+            // The orphan's ProcessingJob is removed explicitly (not relying on the DB cascade).
+            var orphanJobs = await db.Set<ProcessingJobEntity>()
+                .Where(j => j.PdfDocumentId == orphanPdfId)
+                .ToListAsync();
+            orphanJobs.Should().BeEmpty();
         }
     }
 

--- a/apps/api/tests/Api.Tests/Infrastructure/Seeders/Catalog/SeedMaintenanceSeederTests.cs
+++ b/apps/api/tests/Api.Tests/Infrastructure/Seeders/Catalog/SeedMaintenanceSeederTests.cs
@@ -1,0 +1,187 @@
+using Api.Infrastructure.Entities;
+using Api.Infrastructure.Entities.DocumentProcessing;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Infrastructure.Seeders;
+using Api.Infrastructure.Seeders.Catalog;
+using Api.Models;
+using Api.Tests.Constants;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Api.Tests.Infrastructure.Seeders.Catalog;
+
+// Issue #2907 (orphan cleanup) + #2908 (stale-Pending re-enqueue): seed-time self-healing.
+[Trait("Category", TestCategories.Unit)]
+public sealed class SeedMaintenanceSeederTests
+{
+    private static SharedGameEntity NewGame(string title, int bggId)
+        => GameSeeder.CreateFromEnhancedData(
+            new SeedManifestGame { Title = title, BggId = bggId, Language = "en", Description = "d" },
+            Guid.NewGuid());
+
+    private static PdfDocumentEntity NewPdf(Guid sharedGameId, string fileName, string state = "Pending")
+        => new()
+        {
+            Id = Guid.NewGuid(),
+            SharedGameId = sharedGameId,
+            FileName = fileName,
+            FilePath = "/tmp/" + fileName,
+            FileSizeBytes = 100,
+            UploadedByUserId = Guid.NewGuid(),
+            UploadedAt = DateTime.UtcNow,
+            ProcessingState = state,
+        };
+
+    private static ProcessingJobEntity NewQueuedJob(Guid pdfId, Guid userId)
+        => new()
+        {
+            Id = Guid.NewGuid(),
+            PdfDocumentId = pdfId,
+            UserId = userId,
+            Status = "Queued",
+            Priority = 0,
+            CreatedAt = DateTimeOffset.UtcNow,
+            MaxRetries = 3,
+            RetryCount = 0,
+        };
+
+    // ── #2907 ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task CleanupOrphanPdfs_RemovesDanglingPdfs_KeepsValidOnes()
+    {
+        var dbName = $"seedmaint_cleanup_{Guid.NewGuid():N}";
+        var orphanGameId = Guid.NewGuid(); // never inserted into shared_games
+        Guid validGameId;
+
+        using (var db = TestDbContextFactory.CreateInMemoryDbContext(dbName))
+        {
+            var game = NewGame("Valid", 13);
+            validGameId = game.Id;
+            db.SharedGames.Add(game);
+            db.PdfDocuments.Add(NewPdf(validGameId, "valid.pdf"));
+            db.PdfDocuments.Add(NewPdf(orphanGameId, "orphan.pdf"));
+            await db.SaveChangesAsync();
+        }
+
+        using (var db = TestDbContextFactory.CreateInMemoryDbContext(dbName))
+        {
+            var removed = await SeedMaintenanceSeeder.CleanupOrphanPdfsAsync(
+                db, NullLogger.Instance, CancellationToken.None);
+            removed.Should().Be(1);
+        }
+
+        using (var db = TestDbContextFactory.CreateInMemoryDbContext(dbName))
+        {
+            var remaining = await db.PdfDocuments.Select(p => p.SharedGameId).ToListAsync();
+            remaining.Should().ContainSingle().Which.Should().Be(validGameId);
+        }
+    }
+
+    [Fact]
+    public async Task CleanupOrphanPdfs_NoOrphans_ReturnsZero()
+    {
+        var dbName = $"seedmaint_clean_noop_{Guid.NewGuid():N}";
+        using (var db = TestDbContextFactory.CreateInMemoryDbContext(dbName))
+        {
+            var game = NewGame("Valid", 42);
+            db.SharedGames.Add(game);
+            db.PdfDocuments.Add(NewPdf(game.Id, "valid.pdf"));
+            await db.SaveChangesAsync();
+        }
+
+        using (var db = TestDbContextFactory.CreateInMemoryDbContext(dbName))
+        {
+            var removed = await SeedMaintenanceSeeder.CleanupOrphanPdfsAsync(
+                db, NullLogger.Instance, CancellationToken.None);
+            removed.Should().Be(0);
+        }
+    }
+
+    // ── #2908 ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ReenqueueStalePendingPdfs_EnqueuesOnlyValidPendingWithoutActiveJob()
+    {
+        var dbName = $"seedmaint_reenqueue_{Guid.NewGuid():N}";
+        var systemUserId = Guid.NewGuid();
+        var orphanGameId = Guid.NewGuid();
+        Guid pendingNoJobId, pendingWithJobId, orphanPendingId, readyId;
+
+        using (var db = TestDbContextFactory.CreateInMemoryDbContext(dbName))
+        {
+            var game = NewGame("Valid", 7);
+            db.SharedGames.Add(game);
+
+            var pendingNoJob = NewPdf(game.Id, "a.pdf", "Pending");           // → enqueue
+            var pendingWithJob = NewPdf(game.Id, "b.pdf", "Pending");         // has active job → skip
+            var orphanPending = NewPdf(orphanGameId, "c.pdf", "Pending");     // orphan → skip
+            var ready = NewPdf(game.Id, "d.pdf", "Ready");                    // not Pending → skip
+            pendingNoJobId = pendingNoJob.Id;
+            pendingWithJobId = pendingWithJob.Id;
+            orphanPendingId = orphanPending.Id;
+            readyId = ready.Id;
+            db.PdfDocuments.AddRange(pendingNoJob, pendingWithJob, orphanPending, ready);
+            db.Set<ProcessingJobEntity>().Add(NewQueuedJob(pendingWithJobId, systemUserId));
+            await db.SaveChangesAsync();
+        }
+
+        using (var db = TestDbContextFactory.CreateInMemoryDbContext(dbName))
+        {
+            var count = await SeedMaintenanceSeeder.ReenqueueStalePendingPdfsAsync(
+                db, systemUserId, NullLogger.Instance, CancellationToken.None);
+            count.Should().Be(1);
+        }
+
+        using (var db = TestDbContextFactory.CreateInMemoryDbContext(dbName))
+        {
+            var queuedPdfIds = await db.Set<ProcessingJobEntity>()
+                .Where(j => j.Status == "Queued")
+                .Select(j => j.PdfDocumentId)
+                .ToListAsync();
+
+            queuedPdfIds.Should().Contain(pendingNoJobId);      // newly enqueued
+            queuedPdfIds.Should().Contain(pendingWithJobId);    // its original job (not duplicated)
+            queuedPdfIds.Count(id => id == pendingWithJobId).Should().Be(1, "must not double-enqueue");
+            queuedPdfIds.Should().NotContain(orphanPendingId);  // orphan skipped
+            queuedPdfIds.Should().NotContain(readyId);          // Ready skipped
+
+            // the newly-created job has the 5 pipeline steps
+            var newJob = await db.Set<ProcessingJobEntity>()
+                .Include(j => j.Steps)
+                .FirstAsync(j => j.PdfDocumentId == pendingNoJobId);
+            newJob.Steps.Should().HaveCount(5);
+        }
+    }
+
+    [Fact]
+    public async Task ReenqueueStalePendingPdfs_Idempotent_SecondRunEnqueuesNothing()
+    {
+        var dbName = $"seedmaint_reenqueue_idem_{Guid.NewGuid():N}";
+        var systemUserId = Guid.NewGuid();
+
+        using (var db = TestDbContextFactory.CreateInMemoryDbContext(dbName))
+        {
+            var game = NewGame("Valid", 99);
+            db.SharedGames.Add(game);
+            db.PdfDocuments.Add(NewPdf(game.Id, "a.pdf", "Pending"));
+            await db.SaveChangesAsync();
+        }
+
+        using (var db = TestDbContextFactory.CreateInMemoryDbContext(dbName))
+        {
+            (await SeedMaintenanceSeeder.ReenqueueStalePendingPdfsAsync(
+                db, systemUserId, NullLogger.Instance, CancellationToken.None)).Should().Be(1);
+        }
+
+        using (var db = TestDbContextFactory.CreateInMemoryDbContext(dbName))
+        {
+            (await SeedMaintenanceSeeder.ReenqueueStalePendingPdfsAsync(
+                db, systemUserId, NullLogger.Instance, CancellationToken.None))
+                .Should().Be(0, "the PDF now has an active Queued job");
+        }
+    }
+}


### PR DESCRIPTION
## Context

Follow-up to #2904 (deterministic SharedGame ids). #2904 stops **new** orphans from forming; this PR repairs state left by earlier non-idempotent re-seeds and heals PDFs stranded during past runs. Both were done manually via SQL on staging during the seed investigation — this makes them automatic and idempotent.

## Changes

New `SeedMaintenanceSeeder`, invoked by `CatalogSeeder.SeedAsync` right after `PdfSeeder` (Catalog layer → staging/dev):

1. **`CleanupOrphanPdfsAsync` (#2907)** — hard-deletes `pdf_documents` whose `SharedGameId` no longer resolves to **any** `shared_games` row. Uses `IgnoreQueryFilters()` so a merely soft-deleted game is **not** treated as an orphan (physically-absent only). Associated `processing_jobs` cascade via FK. Blob files are shared/idempotent in the seed bucket and are **not** touched.
2. **`ReenqueueStalePendingPdfsAsync` (#2908)** — enqueues a `Queued` `ProcessingJob` (+ 5 pipeline steps, matching `PdfSeeder`) for valid-catalog PDFs stuck in `Pending` with **no active** (`Queued`/`Processing`) job. Scoped to games that still exist, so orphans are never re-processed.

Both idempotent — a no-op once healthy. Cleanup runs before re-enqueue so orphans are gone before the re-enqueue scan.

## Verification

- 4 unit tests (`SeedMaintenanceSeederTests`): cleanup removes only danglers / no-op when clean; re-enqueue targets only valid+jobless+Pending (skips orphan/Ready/already-queued, no double-enqueue, 5 steps) + idempotence on a second run.
- **131 seeder tests pass** (no regressions).

On staging this session the equivalents (manual SQL) took the catalog 77→127 Ready and cleared 2 stuck jobs; the 144 orphans remain and this cleanup will remove them on the next Catalog seed.

Closes #2907, #2908. Related: #2904, #964.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
