### PR TITLE
feat(seed): orphan pdf cleanup (#2907) + re-enqueue stranded Pending (#2908)

### DIFF
--- a/apps/api/src/Api/Infrastructure/Seeders/Catalog/CatalogSeedLayer.cs
+++ b/apps/api/src/Api/Infrastructure/Seeders/Catalog/CatalogSeedLayer.cs
@@ -61,6 +61,34 @@ internal sealed class CatalogSeedLayer : ISeedLayer
             config,
             manifestNameOverride: manifestOverride).ConfigureAwait(false);
 
+        // Issue #2907: retroactively remove orphan PDFs whose shared_game_id points to a missing
+        // or soft-deleted SharedGame (follow-up to #2904). Best-effort + idempotent. Runs BEFORE
+        // the re-enqueue pass so a soon-to-be-deleted orphan is never re-enqueued.
+        try
+        {
+            var mediator = context.Services.GetRequiredService<IMediator>();
+            await OrphanPdfCleanupSeeder
+                .CleanupAsync(context.DbContext, mediator, context.Logger, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            context.Logger.LogError(ex, "[Catalog] OrphanPdfCleanupSeeder failed — continuing");
+        }
+
+        // Issue #2908: re-enqueue valid-catalog PDFs stranded in Pending with no active
+        // ProcessingJob, so PdfProcessingQuartzJob picks them up. Best-effort + idempotent.
+        try
+        {
+            await ReattemptStalePendingPdfsSeeder
+                .ReattemptAsync(context.DbContext, context.SystemUserId, context.Logger, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            context.Logger.LogError(ex, "[Catalog] ReattemptStalePendingPdfsSeeder failed — continuing");
+        }
+
         // Badsworm dogfood persona: 10 library entries (incl. Nanolith) + mock KB
         // documents for dashboard validation. Runs after CatalogSeeder so the
         // SharedGames it references are guaranteed to exist. Idempotent.

--- a/apps/api/src/Api/Infrastructure/Seeders/Catalog/OrphanPdfCleanupSeeder.cs
+++ b/apps/api/src/Api/Infrastructure/Seeders/Catalog/OrphanPdfCleanupSeeder.cs
@@ -1,0 +1,76 @@
+using Api.BoundedContexts.DocumentProcessing.Application.Commands;
+using Api.Infrastructure;
+using Api.Middleware.Exceptions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Api.Infrastructure.Seeders.Catalog;
+
+/// <summary>
+/// Issue #2907: retroactively removes orphan <c>pdf_documents</c> — rows whose
+/// <c>shared_game_id</c> points to a SharedGame that no longer exists OR has been soft-deleted
+/// (the SharedGames <c>!IsDeleted</c> global query filter catches both). Follow-up to #2904,
+/// which stopped NEW orphans forming but left the existing backlog behind.
+///
+/// Delegates each deletion to the canonical <c>DeleteKbDocumentCommand</c> via <see cref="IMediator"/>
+/// so the full cascade (agent detach → pgvector embeddings → EF cascade of text_chunks +
+/// vector_document → best-effort blob + cache + PdfDeletedDomainEvent) is reused rather than
+/// re-implemented. Idempotent (a removed row vanishes from the anti-join / the command 404s on
+/// re-run) and resilient (per-orphan failures are logged and skipped).
+/// </summary>
+internal static class OrphanPdfCleanupSeeder
+{
+    /// <summary>
+    /// Returns the ids of PDFs whose <c>SharedGameId</c> is set but does not resolve to a live
+    /// (non-soft-deleted) SharedGame. PDFs with a null SharedGameId are out of scope.
+    /// </summary>
+    internal static Task<List<Guid>> FindOrphanPdfIdsAsync(MeepleAiDbContext db, CancellationToken ct)
+    {
+        var validGameIds = db.SharedGames.Select(g => g.Id);
+        return db.PdfDocuments
+            .Where(p => p.SharedGameId != null && !validGameIds.Contains(p.SharedGameId.Value))
+            .Select(p => p.Id)
+            .ToListAsync(ct);
+    }
+
+    public static async Task CleanupAsync(
+        MeepleAiDbContext db,
+        IMediator mediator,
+        ILogger logger,
+        CancellationToken ct)
+    {
+        var orphanIds = await FindOrphanPdfIdsAsync(db, ct).ConfigureAwait(false);
+        if (orphanIds.Count == 0)
+        {
+            logger.LogInformation("OrphanPdfCleanupSeeder: no orphan PDFs found");
+            return;
+        }
+
+        var removed = 0;
+        var skipped = 0;
+        foreach (var pdfId in orphanIds)
+        {
+            try
+            {
+                await mediator.Send(new DeleteKbDocumentCommand(pdfId), ct).ConfigureAwait(false);
+                removed++;
+            }
+            catch (NotFoundException)
+            {
+                // Already gone (concurrent delete or a previous run) — idempotent no-op.
+                skipped++;
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "OrphanPdfCleanupSeeder: failed to remove orphan PDF {PdfId}. Continuing.", pdfId);
+                db.ChangeTracker.Clear();
+                skipped++;
+            }
+        }
+
+        logger.LogInformation(
+            "OrphanPdfCleanupSeeder completed: {Removed} orphan PDFs removed, {Skipped} skipped",
+            removed, skipped);
+    }
+}

--- a/apps/api/src/Api/Infrastructure/Seeders/Catalog/PdfSeeder.cs
+++ b/apps/api/src/Api/Infrastructure/Seeders/Catalog/PdfSeeder.cs
@@ -236,33 +236,9 @@ internal static class PdfSeeder
                 db.PdfDocuments.Add(pdfEntity);
                 await db.SaveChangesAsync(ct).ConfigureAwait(false);
 
-                // Enqueue a ProcessingJob so PdfProcessingQuartzJob picks this PDF up.
-                // We write the EF entity directly (not the ProcessingJob.Create aggregate
-                // factory) to bypass the MaxQueueSize=100 guard — a seed run can push
-                // more than 100 PDFs and those limits are meant for user-driven enqueue,
-                // not batch seeding. We also initialise the five standard pipeline steps
-                // so the job row matches what EnqueuePdfCommandHandler would have produced.
-                var now = DateTimeOffset.UtcNow;
-                var jobEntity = new ProcessingJobEntity
-                {
-                    Id = Guid.NewGuid(),
-                    PdfDocumentId = pdfEntity.Id,
-                    UserId = systemUserId,
-                    Status = nameof(JobStatus.Queued),
-                    Priority = 0,
-                    CreatedAt = now,
-                    MaxRetries = 3,
-                    RetryCount = 0,
-                };
-                jobEntity.Steps = new List<ProcessingStepEntity>
-                {
-                    new() { Id = Guid.NewGuid(), ProcessingJobId = jobEntity.Id, StepName = nameof(ProcessingStepType.Upload),  Status = "Pending" },
-                    new() { Id = Guid.NewGuid(), ProcessingJobId = jobEntity.Id, StepName = nameof(ProcessingStepType.Extract), Status = "Pending" },
-                    new() { Id = Guid.NewGuid(), ProcessingJobId = jobEntity.Id, StepName = nameof(ProcessingStepType.Chunk),   Status = "Pending" },
-                    new() { Id = Guid.NewGuid(), ProcessingJobId = jobEntity.Id, StepName = nameof(ProcessingStepType.Embed),   Status = "Pending" },
-                    new() { Id = Guid.NewGuid(), ProcessingJobId = jobEntity.Id, StepName = nameof(ProcessingStepType.Index),   Status = "Pending" },
-                };
-                db.Set<ProcessingJobEntity>().Add(jobEntity);
+                // Enqueue a Queued ProcessingJob (+5 steps) so PdfProcessingQuartzJob picks
+                // this PDF up. See EnqueueProcessingJob for the direct-entity rationale.
+                var jobEntity = EnqueueProcessingJob(db, pdfEntity.Id, systemUserId);
                 await db.SaveChangesAsync(ct).ConfigureAwait(false);
 
                 // Track for subsequent iterations
@@ -361,17 +337,42 @@ internal static class PdfSeeder
         pdfEntity.RetryCount = 0;
         await db.SaveChangesAsync(ct).ConfigureAwait(false);
 
-        // Re-enqueue a ProcessingJob with the five standard pipeline steps (identical to the
-        // new-record flow) so PdfProcessingQuartzJob picks the repaired PDF up again.
-        var now = DateTimeOffset.UtcNow;
+        // Re-enqueue a Queued ProcessingJob (+5 steps) identical to the new-record flow so
+        // PdfProcessingQuartzJob picks the repaired PDF up again.
+        var jobEntity = EnqueueProcessingJob(db, existingId, systemUserId);
+        await db.SaveChangesAsync(ct).ConfigureAwait(false);
+
+        logger.LogInformation(
+            "PdfSeeder: repaired: re-uploaded missing blob for '{FileName}' (pdfId {Id}, JobId={JobId}, {Size} bytes) and reset to Pending",
+            fileName, existingId, jobEntity.Id, result.FileSizeBytes);
+        return true;
+    }
+
+    /// <summary>
+    /// Builds a Queued <see cref="ProcessingJobEntity"/> with the five standard pipeline steps
+    /// (Upload/Extract/Chunk/Embed/Index, all "Pending") and adds it to the change tracker so
+    /// <c>PdfProcessingQuartzJob</c> (polls <c>processing_jobs WHERE Status='Queued'</c>) picks
+    /// the PDF up.
+    ///
+    /// Writes the EF entity directly (not the <c>ProcessingJob.Create</c> aggregate factory) to
+    /// bypass the MaxQueueSize=100 guard — a batch seed/recovery run can push more than 100 PDFs
+    /// and that cap is meant for user-driven enqueue. The caller owns the <c>SaveChangesAsync</c>.
+    /// Shared by the new-record path, the missing-blob repair path, and the #2908 stale-Pending
+    /// re-enqueue seeder.
+    /// </summary>
+    internal static ProcessingJobEntity EnqueueProcessingJob(
+        MeepleAiDbContext db,
+        Guid pdfDocumentId,
+        Guid systemUserId)
+    {
         var jobEntity = new ProcessingJobEntity
         {
             Id = Guid.NewGuid(),
-            PdfDocumentId = existingId,
+            PdfDocumentId = pdfDocumentId,
             UserId = systemUserId,
             Status = nameof(JobStatus.Queued),
             Priority = 0,
-            CreatedAt = now,
+            CreatedAt = DateTimeOffset.UtcNow,
             MaxRetries = 3,
             RetryCount = 0,
         };
@@ -384,12 +385,7 @@ internal static class PdfSeeder
             new() { Id = Guid.NewGuid(), ProcessingJobId = jobEntity.Id, StepName = nameof(ProcessingStepType.Index),   Status = "Pending" },
         };
         db.Set<ProcessingJobEntity>().Add(jobEntity);
-        await db.SaveChangesAsync(ct).ConfigureAwait(false);
-
-        logger.LogInformation(
-            "PdfSeeder: repaired: re-uploaded missing blob for '{FileName}' (pdfId {Id}, JobId={JobId}, {Size} bytes) and reset to Pending",
-            fileName, existingId, jobEntity.Id, result.FileSizeBytes);
-        return true;
+        return jobEntity;
     }
 
     /// <summary>

--- a/apps/api/src/Api/Infrastructure/Seeders/Catalog/ReattemptStalePendingPdfsSeeder.cs
+++ b/apps/api/src/Api/Infrastructure/Seeders/Catalog/ReattemptStalePendingPdfsSeeder.cs
@@ -1,0 +1,73 @@
+using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
+using Api.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Api.Infrastructure.Seeders.Catalog;
+
+/// <summary>
+/// Issue #2908: re-enqueues PDFs stranded in <c>ProcessingState='Pending'</c> for a valid catalog
+/// game but with NO active (<c>Queued</c>/<c>Processing</c>) ProcessingJob — they would otherwise
+/// sit in Pending forever because <c>PdfProcessingQuartzJob</c> only polls <c>Queued</c> jobs.
+///
+/// Creates a <c>Queued</c> ProcessingJob (+5 steps) via the shared
+/// <see cref="PdfSeeder.EnqueueProcessingJob"/> helper — identical to how PdfSeeder enqueues a new
+/// PDF. Scoped to valid catalog games (excludes orphans handled by <see cref="OrphanPdfCleanupSeeder"/>),
+/// idempotent (a re-enqueued PDF gains a Queued job and is excluded on re-run), and resilient.
+/// </summary>
+internal static class ReattemptStalePendingPdfsSeeder
+{
+    /// <summary>
+    /// Returns the ids of PDFs in <c>Pending</c> state for a live catalog SharedGame that have no
+    /// active (<c>Queued</c>/<c>Processing</c>) ProcessingJob. A stale terminal job
+    /// (Completed/Failed/Cancelled) does not count as active.
+    /// </summary>
+    internal static Task<List<Guid>> FindStrandedPendingPdfIdsAsync(MeepleAiDbContext db, CancellationToken ct)
+    {
+        var validGameIds = db.SharedGames.Select(g => g.Id);
+        return db.PdfDocuments
+            .Where(p => p.ProcessingState == nameof(PdfProcessingState.Pending)
+                && p.SharedGameId != null
+                && validGameIds.Contains(p.SharedGameId.Value)
+                && !db.ProcessingJobs.Any(j => j.PdfDocumentId == p.Id
+                    && (j.Status == nameof(JobStatus.Queued) || j.Status == nameof(JobStatus.Processing))))
+            .Select(p => p.Id)
+            .ToListAsync(ct);
+    }
+
+    public static async Task ReattemptAsync(
+        MeepleAiDbContext db,
+        Guid systemUserId,
+        ILogger logger,
+        CancellationToken ct)
+    {
+        var strandedIds = await FindStrandedPendingPdfIdsAsync(db, ct).ConfigureAwait(false);
+        if (strandedIds.Count == 0)
+        {
+            logger.LogInformation("ReattemptStalePendingPdfsSeeder: no stranded Pending PDFs found");
+            return;
+        }
+
+        var enqueued = 0;
+        var skipped = 0;
+        foreach (var pdfId in strandedIds)
+        {
+            try
+            {
+                PdfSeeder.EnqueueProcessingJob(db, pdfId, systemUserId);
+                await db.SaveChangesAsync(ct).ConfigureAwait(false);
+                enqueued++;
+            }
+            catch (Exception ex)
+            {
+                logger.LogWarning(ex, "ReattemptStalePendingPdfsSeeder: failed to re-enqueue PDF {PdfId}. Continuing.", pdfId);
+                db.ChangeTracker.Clear();
+                skipped++;
+            }
+        }
+
+        logger.LogInformation(
+            "ReattemptStalePendingPdfsSeeder completed: {Enqueued} PDFs re-enqueued, {Skipped} skipped",
+            enqueued, skipped);
+    }
+}

--- a/apps/api/tests/Api.Tests/Infrastructure/Seeders/Catalog/OrphanPdfCleanupSeederTests.cs
+++ b/apps/api/tests/Api.Tests/Infrastructure/Seeders/Catalog/OrphanPdfCleanupSeederTests.cs
@@ -1,0 +1,162 @@
+using Api.BoundedContexts.DocumentProcessing.Application.Commands;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Infrastructure.Entities.DocumentProcessing;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Infrastructure.Seeders.Catalog;
+using Api.Middleware.Exceptions;
+using Api.Tests.Constants;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.Infrastructure.Seeders.Catalog;
+
+/// <summary>
+/// Unit tests for #2907 — orphan pdf cleanup.
+/// The selection logic (anti-join, honoring the SharedGames !IsDeleted global filter) is exercised
+/// against in-memory EF; the delete cascade itself is delegated to DeleteKbDocumentCommand and
+/// verified via a mocked IMediator here (real cascade is covered by an Integration test).
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+public sealed class OrphanPdfCleanupSeederTests
+{
+    private readonly Mock<IMediator> _mediator = new();
+    private readonly Mock<ILogger> _logger = new();
+
+    public OrphanPdfCleanupSeederTests()
+    {
+        _mediator
+            .Setup(m => m.Send(It.IsAny<DeleteKbDocumentCommand>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+    }
+
+    private static Guid SeedGame(MeepleAiDbContext db, bool softDeleted = false)
+    {
+        var gameId = Guid.NewGuid();
+        db.SharedGames.Add(new SharedGameEntity { Id = gameId, Title = "Test Game", IsDeleted = softDeleted });
+        return gameId;
+    }
+
+    private static Guid SeedPdf(MeepleAiDbContext db, Guid? sharedGameId)
+    {
+        var pdfId = Guid.NewGuid();
+        db.PdfDocuments.Add(new PdfDocumentEntity
+        {
+            Id = pdfId,
+            SharedGameId = sharedGameId,
+            FileName = "rules.pdf",
+            FilePath = $"pdfs/{pdfId}/file.pdf",
+            ContentHash = "hash",
+            UploadedByUserId = Guid.NewGuid(),
+            DocumentType = "base",
+            DocumentCategory = "Rulebook",
+            ProcessingState = nameof(Api.BoundedContexts.DocumentProcessing.Domain.Enums.PdfProcessingState.Ready),
+        });
+        return pdfId;
+    }
+
+    // ---- selection logic ----
+
+    [Fact]
+    public async Task FindOrphanPdfIds_MissingParent_ReturnsOrphan()
+    {
+        using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        var orphanPdfId = SeedPdf(db, Guid.NewGuid()); // SharedGameId points at a game that does not exist
+        await db.SaveChangesAsync();
+
+        var orphans = await OrphanPdfCleanupSeeder.FindOrphanPdfIdsAsync(db, CancellationToken.None);
+
+        orphans.Should().ContainSingle().Which.Should().Be(orphanPdfId);
+    }
+
+    [Fact]
+    public async Task FindOrphanPdfIds_SoftDeletedParent_ReturnsOrphan()
+    {
+        using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        var softDeletedGameId = SeedGame(db, softDeleted: true);
+        var orphanPdfId = SeedPdf(db, softDeletedGameId);
+        await db.SaveChangesAsync();
+
+        var orphans = await OrphanPdfCleanupSeeder.FindOrphanPdfIdsAsync(db, CancellationToken.None);
+
+        orphans.Should().ContainSingle().Which.Should().Be(orphanPdfId);
+    }
+
+    [Fact]
+    public async Task FindOrphanPdfIds_ValidParent_NotReturned()
+    {
+        using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        var gameId = SeedGame(db);
+        SeedPdf(db, gameId);
+        await db.SaveChangesAsync();
+
+        var orphans = await OrphanPdfCleanupSeeder.FindOrphanPdfIdsAsync(db, CancellationToken.None);
+
+        orphans.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task FindOrphanPdfIds_NullSharedGameId_NotReturned()
+    {
+        using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        SeedPdf(db, sharedGameId: null); // dangling but not a shared-game orphan (out of #2907 scope)
+        await db.SaveChangesAsync();
+
+        var orphans = await OrphanPdfCleanupSeeder.FindOrphanPdfIdsAsync(db, CancellationToken.None);
+
+        orphans.Should().BeEmpty();
+    }
+
+    // ---- cleanup delegation ----
+
+    [Fact]
+    public async Task CleanupAsync_SendsDeleteCommandForOrphansOnly()
+    {
+        using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        var validGameId = SeedGame(db);
+        var validPdfId = SeedPdf(db, validGameId);
+        var orphanPdfId = SeedPdf(db, Guid.NewGuid());
+        await db.SaveChangesAsync();
+
+        await OrphanPdfCleanupSeeder.CleanupAsync(db, _mediator.Object, _logger.Object, CancellationToken.None);
+
+        _mediator.Verify(m => m.Send(It.Is<DeleteKbDocumentCommand>(c => c.Id == orphanPdfId), It.IsAny<CancellationToken>()), Times.Once);
+        _mediator.Verify(m => m.Send(It.Is<DeleteKbDocumentCommand>(c => c.Id == validPdfId), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task CleanupAsync_NoOrphans_SendsNothing()
+    {
+        using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        var validGameId = SeedGame(db);
+        SeedPdf(db, validGameId);
+        await db.SaveChangesAsync();
+
+        await OrphanPdfCleanupSeeder.CleanupAsync(db, _mediator.Object, _logger.Object, CancellationToken.None);
+
+        _mediator.Verify(m => m.Send(It.IsAny<DeleteKbDocumentCommand>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task CleanupAsync_MediatorThrowsNotFound_SkipsAndContinues()
+    {
+        using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        var orphanPdfId1 = SeedPdf(db, Guid.NewGuid());
+        var orphanPdfId2 = SeedPdf(db, Guid.NewGuid());
+        await db.SaveChangesAsync();
+
+        _mediator
+            .Setup(m => m.Send(It.Is<DeleteKbDocumentCommand>(c => c.Id == orphanPdfId1), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new NotFoundException("KbDocument", orphanPdfId1.ToString()));
+
+        Func<Task> act = () => OrphanPdfCleanupSeeder.CleanupAsync(db, _mediator.Object, _logger.Object, CancellationToken.None);
+
+        await act.Should().NotThrowAsync();
+        // The failed orphan does not abort the batch: the second orphan is still processed.
+        _mediator.Verify(m => m.Send(It.Is<DeleteKbDocumentCommand>(c => c.Id == orphanPdfId2), It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/apps/api/tests/Api.Tests/Infrastructure/Seeders/Catalog/ReattemptStalePendingPdfsSeederTests.cs
+++ b/apps/api/tests/Api.Tests/Infrastructure/Seeders/Catalog/ReattemptStalePendingPdfsSeederTests.cs
@@ -1,0 +1,181 @@
+using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Infrastructure.Entities.DocumentProcessing;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Infrastructure.Seeders.Catalog;
+using Api.Tests.Constants;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.Infrastructure.Seeders.Catalog;
+
+/// <summary>
+/// Unit tests for #2908 — re-enqueue PDFs stranded in Pending with no active ProcessingJob.
+/// In-memory EF (FK not enforced) is sufficient: we assert selection + enqueue-shape + idempotency.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+public sealed class ReattemptStalePendingPdfsSeederTests
+{
+    private readonly Mock<ILogger> _logger = new();
+    private readonly Guid _systemUserId = Guid.NewGuid();
+
+    private static Guid SeedGame(MeepleAiDbContext db, bool softDeleted = false)
+    {
+        var gameId = Guid.NewGuid();
+        db.SharedGames.Add(new SharedGameEntity { Id = gameId, Title = "Test Game", IsDeleted = softDeleted });
+        return gameId;
+    }
+
+    private static Guid SeedPdf(MeepleAiDbContext db, Guid? gameId, string state)
+    {
+        var pdfId = Guid.NewGuid();
+        db.PdfDocuments.Add(new PdfDocumentEntity
+        {
+            Id = pdfId,
+            SharedGameId = gameId,
+            FileName = "rules.pdf",
+            FilePath = $"pdfs/{pdfId}/file.pdf",
+            ContentHash = "hash",
+            UploadedByUserId = Guid.NewGuid(),
+            DocumentType = "base",
+            DocumentCategory = "Rulebook",
+            ProcessingState = state,
+        });
+        return pdfId;
+    }
+
+    private static void SeedJob(MeepleAiDbContext db, Guid pdfId, Guid userId, string status)
+    {
+        db.ProcessingJobs.Add(new ProcessingJobEntity
+        {
+            Id = Guid.NewGuid(),
+            PdfDocumentId = pdfId,
+            UserId = userId,
+            Status = status,
+            Priority = 0,
+            CreatedAt = DateTimeOffset.UtcNow,
+            MaxRetries = 3,
+            RetryCount = 0,
+        });
+    }
+
+    [Fact]
+    public async Task ReattemptAsync_PendingValidGameNoActiveJob_EnqueuesQueuedJobWithFiveSteps()
+    {
+        using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        var gameId = SeedGame(db);
+        var pdfId = SeedPdf(db, gameId, nameof(PdfProcessingState.Pending));
+        await db.SaveChangesAsync();
+
+        await ReattemptStalePendingPdfsSeeder.ReattemptAsync(db, _systemUserId, _logger.Object, CancellationToken.None);
+
+        var jobs = db.ProcessingJobs.Include(j => j.Steps).Where(j => j.PdfDocumentId == pdfId).ToList();
+        jobs.Should().HaveCount(1);
+        var job = jobs[0];
+        job.Status.Should().Be(nameof(JobStatus.Queued));
+        job.UserId.Should().Be(_systemUserId);
+        job.Priority.Should().Be(0);
+        job.MaxRetries.Should().Be(3);
+        job.Steps.Should().HaveCount(5);
+        job.Steps.Select(s => s.StepName).Should().BeEquivalentTo(new[]
+        {
+            nameof(ProcessingStepType.Upload),
+            nameof(ProcessingStepType.Extract),
+            nameof(ProcessingStepType.Chunk),
+            nameof(ProcessingStepType.Embed),
+            nameof(ProcessingStepType.Index),
+        });
+        job.Steps.Should().OnlyContain(s => s.Status == "Pending");
+    }
+
+    [Fact]
+    public async Task ReattemptAsync_PendingWithQueuedJob_DoesNothing()
+    {
+        using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        var gameId = SeedGame(db);
+        var pdfId = SeedPdf(db, gameId, nameof(PdfProcessingState.Pending));
+        SeedJob(db, pdfId, _systemUserId, nameof(JobStatus.Queued));
+        await db.SaveChangesAsync();
+
+        await ReattemptStalePendingPdfsSeeder.ReattemptAsync(db, _systemUserId, _logger.Object, CancellationToken.None);
+
+        db.ProcessingJobs.Where(j => j.PdfDocumentId == pdfId).Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task ReattemptAsync_PendingWithProcessingJob_DoesNothing()
+    {
+        using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        var gameId = SeedGame(db);
+        var pdfId = SeedPdf(db, gameId, nameof(PdfProcessingState.Pending));
+        SeedJob(db, pdfId, _systemUserId, nameof(JobStatus.Processing));
+        await db.SaveChangesAsync();
+
+        await ReattemptStalePendingPdfsSeeder.ReattemptAsync(db, _systemUserId, _logger.Object, CancellationToken.None);
+
+        db.ProcessingJobs.Where(j => j.PdfDocumentId == pdfId).Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task ReattemptAsync_PendingWithOnlyTerminalJob_ReEnqueues()
+    {
+        // A stale Completed job (produced 0 chunks) is NOT active → the PDF is stranded → re-enqueue.
+        using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        var gameId = SeedGame(db);
+        var pdfId = SeedPdf(db, gameId, nameof(PdfProcessingState.Pending));
+        SeedJob(db, pdfId, _systemUserId, nameof(JobStatus.Completed));
+        await db.SaveChangesAsync();
+
+        await ReattemptStalePendingPdfsSeeder.ReattemptAsync(db, _systemUserId, _logger.Object, CancellationToken.None);
+
+        var jobs = db.ProcessingJobs.Where(j => j.PdfDocumentId == pdfId).ToList();
+        jobs.Should().HaveCount(2); // the old Completed + the new Queued
+        jobs.Count(j => j.Status == nameof(JobStatus.Queued)).Should().Be(1);
+    }
+
+    [Fact]
+    public async Task ReattemptAsync_PendingButOrphanGame_Skips()
+    {
+        // SharedGame soft-deleted → excluded by the !IsDeleted filter → PDF is an orphan, out of #2908 scope.
+        using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        var orphanGameId = SeedGame(db, softDeleted: true);
+        var pdfId = SeedPdf(db, orphanGameId, nameof(PdfProcessingState.Pending));
+        await db.SaveChangesAsync();
+
+        await ReattemptStalePendingPdfsSeeder.ReattemptAsync(db, _systemUserId, _logger.Object, CancellationToken.None);
+
+        db.ProcessingJobs.Where(j => j.PdfDocumentId == pdfId).Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ReattemptAsync_NonPendingState_Skips()
+    {
+        using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        var gameId = SeedGame(db);
+        var pdfId = SeedPdf(db, gameId, nameof(PdfProcessingState.Ready));
+        await db.SaveChangesAsync();
+
+        await ReattemptStalePendingPdfsSeeder.ReattemptAsync(db, _systemUserId, _logger.Object, CancellationToken.None);
+
+        db.ProcessingJobs.Where(j => j.PdfDocumentId == pdfId).Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task ReattemptAsync_RunTwice_IsIdempotent()
+    {
+        using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        var gameId = SeedGame(db);
+        var pdfId = SeedPdf(db, gameId, nameof(PdfProcessingState.Pending));
+        await db.SaveChangesAsync();
+
+        await ReattemptStalePendingPdfsSeeder.ReattemptAsync(db, _systemUserId, _logger.Object, CancellationToken.None);
+        await ReattemptStalePendingPdfsSeeder.ReattemptAsync(db, _systemUserId, _logger.Object, CancellationToken.None);
+
+        db.ProcessingJobs.Where(j => j.PdfDocumentId == pdfId).Should().HaveCount(1);
+    }
+}

--- a/apps/api/tests/Api.Tests/Integration/DocumentProcessing/OrphanCleanupAndReattemptIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/DocumentProcessing/OrphanCleanupAndReattemptIntegrationTests.cs
@@ -1,0 +1,251 @@
+using Api.BoundedContexts.DocumentProcessing.Infrastructure.External;
+using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
+using Api.BoundedContexts.KnowledgeBase.Infrastructure.Persistence;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Infrastructure.Seeders.Catalog;
+using Api.Services;
+using Api.Services.Pdf;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.Integration.DocumentProcessing;
+
+/// <summary>
+/// Integration tests for the #2907 (orphan cleanup) + #2908 (re-enqueue stale Pending) seed passes.
+/// Exercises the real Npgsql anti-join (honoring the SharedGames !IsDeleted global filter), the real
+/// EF cascade delete of text_chunks + vector_document, and the interaction (cleanup before re-enqueue).
+/// pgvector embeddings deletion is delegated to a mocked IVectorStoreAdapter (no real embeddings table),
+/// mirroring DeleteKbDocumentCommandHandlerIntegrationTests.
+/// </summary>
+[Collection("Integration-GroupA")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("Dependency", "PostgreSQL")]
+[Trait("BoundedContext", "DocumentProcessing")]
+[Trait("Issue", "2907")]
+public sealed class OrphanCleanupAndReattemptIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private string _databaseName = string.Empty;
+    private MeepleAiDbContext? _dbContext;
+    private IServiceProvider? _serviceProvider;
+    private IMediator? _mediator;
+
+    private static CancellationToken Ct => TestContext.Current.CancellationToken;
+
+    private static readonly Guid SystemUserId = new("A0000000-0000-0000-0000-0000000029A7");
+    private static readonly Guid ValidGameId = new("B0000000-0000-0000-0000-0000000029A7");
+    private static readonly Guid SoftDeletedGameId = new("B0000000-0000-0000-0000-0000000029A8");
+
+    public OrphanCleanupAndReattemptIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        _databaseName = $"test_orphancleanup_{Guid.NewGuid():N}";
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+
+        var services = IntegrationServiceCollectionBuilder.CreateBase(connectionString);
+        services.AddScoped<IAgentDefinitionRepository, AgentDefinitionRepository>();
+
+        var blobMock = new Mock<IBlobStorageService>();
+        blobMock.Setup(b => b.DeleteAsync(
+                It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        services.AddSingleton<IBlobStorageService>(blobMock.Object);
+
+        var cacheMock = new Mock<IAiResponseCacheService>();
+        cacheMock.Setup(c => c.InvalidateGameAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        services.AddSingleton<IAiResponseCacheService>(cacheMock.Object);
+
+        var vectorStoreMock = new Mock<IVectorStoreAdapter>();
+        vectorStoreMock.Setup(v => v.DeleteByVectorDocumentIdAsync(
+                It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        services.AddScoped<IVectorStoreAdapter>(_ => vectorStoreMock.Object);
+
+        _serviceProvider = services.BuildServiceProvider();
+        _dbContext = _serviceProvider.GetRequiredService<MeepleAiDbContext>();
+        _mediator = _serviceProvider.GetRequiredService<IMediator>();
+
+        await TestMigrationHelper.MigrateWithRetryAsync(_dbContext, Ct);
+        await SeedBaseEntitiesAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_dbContext != null)
+            await _dbContext.DisposeAsync();
+
+        if (_serviceProvider is IAsyncDisposable asyncDisposable)
+            await asyncDisposable.DisposeAsync();
+        else
+            (_serviceProvider as IDisposable)?.Dispose();
+
+        if (!string.IsNullOrEmpty(_databaseName))
+        {
+            try
+            {
+                await _fixture.DropIsolatedDatabaseAsync(_databaseName);
+            }
+            catch
+            {
+                // Ignore cleanup errors
+            }
+        }
+    }
+
+    [Fact]
+    public async Task CleanupThenReattempt_RemovesOrphansCascade_AndReEnqueuesOnlyValidPending()
+    {
+        // Arrange
+        var orphanReadyPdfId = await SeedPdfWithChildrenAsync(SoftDeletedGameId, "Ready");
+        var orphanPendingPdfId = await SeedPdfWithChildrenAsync(SoftDeletedGameId, "Pending");
+        var validPendingPdfId = await SeedPdfWithChildrenAsync(ValidGameId, "Pending");
+        var validReadyPdfId = await SeedPdfWithChildrenAsync(ValidGameId, "Ready");
+
+        // Act — the CatalogSeedLayer order: cleanup (#2907) then re-enqueue (#2908)
+        await OrphanPdfCleanupSeeder.CleanupAsync(_dbContext!, _mediator!, NullLogger.Instance, Ct);
+        await ReattemptStalePendingPdfsSeeder.ReattemptAsync(_dbContext!, SystemUserId, NullLogger.Instance, Ct);
+
+        // Assert — orphans (soft-deleted parent) removed with a real EF cascade
+        (await _dbContext!.PdfDocuments.FindAsync(new object[] { orphanReadyPdfId }, Ct))
+            .Should().BeNull("orphan PDF must be hard-deleted");
+        (await _dbContext.PdfDocuments.FindAsync(new object[] { orphanPendingPdfId }, Ct))
+            .Should().BeNull("orphan Pending PDF must be hard-deleted, not re-enqueued");
+        (await _dbContext.TextChunks.CountAsync(c => c.PdfDocumentId == orphanReadyPdfId, Ct))
+            .Should().Be(0, "text chunks cascade-delete with the orphan PDF");
+        (await _dbContext.VectorDocuments.CountAsync(v => v.PdfDocumentId == orphanReadyPdfId, Ct))
+            .Should().Be(0, "vector document cascade-deletes with the orphan PDF");
+
+        // Assert — valid PDFs untouched by cleanup
+        (await _dbContext.PdfDocuments.FindAsync(new object[] { validPendingPdfId }, Ct))
+            .Should().NotBeNull("valid-game PDF must survive cleanup");
+        (await _dbContext.PdfDocuments.FindAsync(new object[] { validReadyPdfId }, Ct))
+            .Should().NotBeNull("valid-game PDF must survive cleanup");
+
+        // Assert — only the valid Pending PDF is re-enqueued (exactly one Queued job)
+        (await _dbContext.ProcessingJobs.CountAsync(
+                j => j.PdfDocumentId == validPendingPdfId && j.Status == "Queued", Ct))
+            .Should().Be(1, "valid Pending PDF with no active job must be re-enqueued");
+        (await _dbContext.ProcessingJobs.CountAsync(j => j.PdfDocumentId == validReadyPdfId, Ct))
+            .Should().Be(0, "a Ready PDF must not be re-enqueued");
+    }
+
+    [Fact]
+    public async Task Cleanup_IsIdempotent_OnSecondRun()
+    {
+        var orphanPdfId = await SeedPdfWithChildrenAsync(SoftDeletedGameId, "Ready");
+        var validPdfId = await SeedPdfWithChildrenAsync(ValidGameId, "Ready");
+
+        await OrphanPdfCleanupSeeder.CleanupAsync(_dbContext!, _mediator!, NullLogger.Instance, Ct);
+        // Second run must be a safe no-op (the orphan is already gone).
+        await OrphanPdfCleanupSeeder.CleanupAsync(_dbContext!, _mediator!, NullLogger.Instance, Ct);
+
+        (await _dbContext!.PdfDocuments.FindAsync(new object[] { orphanPdfId }, Ct)).Should().BeNull();
+        (await _dbContext.PdfDocuments.FindAsync(new object[] { validPdfId }, Ct)).Should().NotBeNull();
+    }
+
+    // ── seeding helpers ──────────────────────────────────────────────────
+
+    private async Task<Guid> SeedPdfWithChildrenAsync(Guid sharedGameId, string processingState)
+    {
+        var pdfId = Guid.NewGuid();
+
+        _dbContext!.PdfDocuments.Add(new PdfDocumentEntity
+        {
+            Id = pdfId,
+            SharedGameId = sharedGameId,
+            UploadedByUserId = SystemUserId,
+            FileName = $"test-{pdfId:N}.pdf",
+            FilePath = $"pdfs/{pdfId:N}/file.pdf",
+            FileSizeBytes = 2048,
+            ProcessingState = processingState,
+            UploadedAt = DateTime.UtcNow,
+            PageCount = 4,
+        });
+
+        for (var i = 0; i < 2; i++)
+        {
+            _dbContext.TextChunks.Add(new TextChunkEntity
+            {
+                Id = Guid.NewGuid(),
+                PdfDocumentId = pdfId,
+                SharedGameId = sharedGameId,
+                Content = $"Chunk {i}",
+                ChunkIndex = i,
+                PageNumber = i + 1,
+                CharacterCount = 8,
+                CreatedAt = DateTime.UtcNow,
+            });
+        }
+
+        _dbContext.VectorDocuments.Add(new VectorDocumentEntity
+        {
+            Id = Guid.NewGuid(),
+            PdfDocumentId = pdfId,
+            GameId = sharedGameId,
+            ChunkCount = 2,
+            TotalCharacters = 16,
+            IndexedAt = DateTime.UtcNow,
+            IndexingStatus = "completed",
+            EmbeddingModel = "test-model",
+            EmbeddingDimensions = 384,
+        });
+
+        await _dbContext.SaveChangesAsync(Ct);
+        return pdfId;
+    }
+
+    private async Task SeedBaseEntitiesAsync()
+    {
+        if (!await _dbContext!.Users.AnyAsync(u => u.Id == SystemUserId, Ct))
+        {
+            _dbContext.Users.Add(new UserEntity
+            {
+                Id = SystemUserId,
+                Email = "seed-orphan@meepleai.dev",
+                DisplayName = "SeedSystem",
+                Role = "Admin",
+                Tier = "Free",
+                CreatedAt = DateTime.UtcNow,
+            });
+        }
+
+        if (!await _dbContext.SharedGames.AnyAsync(g => g.Id == ValidGameId, Ct))
+        {
+            _dbContext.SharedGames.Add(new SharedGameEntity
+            {
+                Id = ValidGameId,
+                Title = "Valid Catalog Game",
+                CreatedAt = DateTime.UtcNow,
+            });
+        }
+
+        // A soft-deleted parent: its row exists but the !IsDeleted filter hides it, so PDFs
+        // pointing at it are treated as orphans by #2907.
+        if (!await _dbContext.SharedGames.IgnoreQueryFilters().AnyAsync(g => g.Id == SoftDeletedGameId, Ct))
+        {
+            _dbContext.SharedGames.Add(new SharedGameEntity
+            {
+                Id = SoftDeletedGameId,
+                Title = "Soft-Deleted Game",
+                CreatedAt = DateTime.UtcNow,
+                IsDeleted = true,
+            });
+        }
+
+        await _dbContext.SaveChangesAsync(Ct);
+    }
+}

--- a/docs/superpowers/specs/2026-07-14-issue-2907-2908-seed-orphan-cleanup-reenqueue-design.md
+++ b/docs/superpowers/specs/2026-07-14-issue-2907-2908-seed-orphan-cleanup-reenqueue-design.md
@@ -1,0 +1,91 @@
+# Issues #2907 + #2908 — Seed self-healing: orphan cleanup + re-enqueue — Design
+
+**Date**: 2026-07-14
+**Issues**: [#2907](https://github.com/meepleAi-app/meepleai-monorepo/issues/2907) (orphan pdf cleanup, tech-debt/backend/P3) · [#2908](https://github.com/meepleAi-app/meepleai-monorepo/issues/2908) (re-enqueue stranded Pending, tech-debt/backend/P3)
+**Branch**: `feature/issue-2907-2908-seed-orphan-cleanup-reenqueue` (combined PR)
+**Parent context**: follow-ups to #2904 (deterministic SharedGame ids, PR #2905 merged 2026-07-13) which stopped *new* orphans; these clean up the *existing* backlog + un-strand Pending PDFs.
+
+---
+
+## Discovery findings that changed the design
+
+1. **#2907 "soft-delete" premise is unfounded.** `pdf_documents` has **no** `IsDeleted`/`DeletedAt`; the `PdfDocument` aggregate has no soft-delete method. Every existing delete path is a **hard cascade delete**. → **Decision (user-confirmed): hard-delete cascade**, not new soft-delete infra.
+2. **`pgvector_embeddings` has no FK cascade** (raw-SQL table). A naive EF `Remove` leaves embeddings dangling. The canonical cascade order lives in `DeleteKbDocumentCommandHandler` (pgvector purge via `IVectorStoreAdapter` → EF `Remove` → blob → cache → domain event).
+3. **`DeleteKbDocumentCommand` is `record DeleteKbDocumentCommand(Guid Id)`** — clean. → #2907 **reuses the canonical handler via `IMediator`** instead of re-implementing the cascade. Zero duplication; agent-detach + pgvector + cascade + blob + cache + `PdfDeletedDomainEvent` come for free; idempotent (`NotFoundException` on re-run).
+4. **`processing_jobs` FK → `pdf_documents` is `OnDelete(Cascade)`.** Deleting an orphan PDF auto-removes its jobs/steps. "Zombie job" risk resolved.
+5. **The enqueue block is duplicated** in `PdfSeeder` (new-record path L245-266 + `TryRepairMissingBlobAsync` L366-387). #2908 would be a 3rd copy → **extract `EnqueueProcessingJob` helper** and refactor both.
+6. **`CatalogSeedLayer` already resolves `IMediator`** and runs best-effort post-`CatalogSeeder` steps (Badsworm, GameBook) → the natural hook point.
+
+## Decisions (user-confirmed)
+
+| # | Decision |
+|---|----------|
+| Delete semantics | **Hard-delete cascade** via `IMediator.Send(DeleteKbDocumentCommand(id))` (mirrors the canonical handler). |
+| Orphan definition | **missing OR soft-deleted parent** — `pdf.SharedGameId ∉ db.SharedGames` (the `!IsDeleted` global filter naturally catches both), matching the issue's own SQL (`AND NOT sg.is_deleted`). |
+| Delivery | **1 combined PR**, gating **Staging+** (inline in `CatalogSeedLayer`, where the 144 known orphans live; Prod runs Core-only). |
+| Ordering | #2907 cleanup **before** #2908 re-enqueue (never re-enqueue an about-to-be-deleted orphan). |
+
+## Design
+
+Two new `internal static` seeders under `Infrastructure/Seeders/Catalog/`, invoked from `CatalogSeedLayer.SeedAsync` **after** `CatalogSeeder.SeedAsync` (which contains GameSeeder → PdfSeeder), each wrapped in best-effort `try/catch`:
+
+### #2907 — `OrphanPdfCleanupSeeder.CleanupAsync(db, mediator, logger, ct)`
+```
+validGameIds = db.SharedGames.Select(g => g.Id)        // global !IsDeleted filter applies
+orphanIds    = db.PdfDocuments
+                 .Where(p => p.SharedGameId != null && !validGameIds.Contains(p.SharedGameId.Value))
+                 .Select(p => p.Id).ToListAsync()
+foreach id:  try { await mediator.Send(new DeleteKbDocumentCommand(id), ct); removed++ }
+             catch (NotFoundException) { skipped++ }          // already gone → idempotent
+             catch (Exception ex) { log; db.ChangeTracker.Clear(); skipped++ }   // resilient
+log summary (removed / skipped)
+```
+- PDFs with `SharedGameId == null` are **not** shared-game-orphans → untouched (out of scope; issue targets `shared_game_id`).
+- Idempotent: hard-deleted rows vanish from the anti-join on re-run.
+
+### #2908 — `ReattemptStalePendingPdfsSeeder.ReattemptAsync(db, systemUserId, logger, ct)`
+```
+validGameIds = db.SharedGames.Select(g => g.Id)
+strandedIds  = db.PdfDocuments.Where(p =>
+                 p.ProcessingState == nameof(PdfProcessingState.Pending)
+                 && p.SharedGameId != null && validGameIds.Contains(p.SharedGameId.Value)
+                 && !db.ProcessingJobs.Any(j => j.PdfDocumentId == p.Id
+                       && (j.Status == nameof(JobStatus.Queued) || j.Status == nameof(JobStatus.Processing))))
+                 .Select(p => p.Id).ToListAsync()
+foreach id:  PdfSeeder.EnqueueProcessingJob(db, id, systemUserId); await db.SaveChangesAsync(ct); enqueued++
+log summary (enqueued / skipped)
+```
+- Scoped to valid catalog games (the `validGameIds` filter excludes orphans/soft-deleted) — so it never re-enqueues an orphan even if run standalone.
+- "no active job" = no `Queued`/`Processing` job (a stale `Completed`/`Failed`/`Cancelled` job does **not** count as active → re-enqueue).
+- Idempotent: after enqueue the PDF has a `Queued` job → excluded on re-run.
+
+### Shared helper — `PdfSeeder.EnqueueProcessingJob(db, pdfId, systemUserId) : ProcessingJobEntity`
+Extracts the exact `ProcessingJobEntity{Status=Queued, Priority=0, MaxRetries=3} + 5 ProcessingStepEntity{Status="Pending"}` block (currently copy-pasted twice). Adds to the change tracker and returns the entity; **caller** owns `SaveChangesAsync`. Both existing `PdfSeeder` copies are refactored to call it (behavior-preserving).
+
+### Hook — `CatalogSeedLayer.SeedAsync`
+After `await CatalogSeeder.SeedAsync(...)`, before Badsworm:
+```
+try { var mediator = context.Services.GetRequiredService<IMediator>();
+      await OrphanPdfCleanupSeeder.CleanupAsync(context.DbContext, mediator, context.Logger, ct); }
+catch (Exception ex) { context.Logger.LogError(ex, "[Catalog] OrphanPdfCleanupSeeder failed — continuing"); }
+
+try { await ReattemptStalePendingPdfsSeeder.ReattemptAsync(context.DbContext, context.SystemUserId, context.Logger, ct); }
+catch (Exception ex) { context.Logger.LogError(ex, "[Catalog] ReattemptStalePendingPdfsSeeder failed — continuing"); }
+```
+
+## Testing strategy
+
+- **Unit** (`TestDbContextFactory.CreateInMemoryDbContext` + Moq), following `PdfSeederBlobTests`:
+  - `OrphanPdfCleanupSeederTests`: orphan (missing parent) → `mediator.Send(DeleteKbDocumentCommand(id))`; soft-deleted parent → also sent; valid parent → **not** sent; `SharedGameId == null` → not sent; `mediator` throws `NotFoundException` → skipped, loop continues. EF global query filter is honored in-memory, so soft-deleted-parent is testable without Testcontainers.
+  - `ReattemptStalePendingPdfsSeederTests`: Pending+valid+no-job → 1 Queued job + 5 Pending steps; existing Queued → noop; existing Processing → noop; only Completed/Failed job → enqueue; orphan game → skip; non-Pending (Ready/Failed) → skip; double-invocation → exactly 1 job.
+  - Existing `PdfSeederBlobTests` must still pass after the `EnqueueProcessingJob` extraction (regression guard for the refactor).
+- **Integration** (Testcontainers `Integration-GroupA`, `[Trait BoundedContext=DocumentProcessing]`): real Npgsql cascade — seed an orphan PDF with text_chunks + vector_document + pgvector embeddings and a valid Pending PDF; run both seeders in order; assert the orphan and all its children are gone (real cascade) and the valid Pending PDF gained a Queued job. Validated on CI (local full integration suite is unreliable).
+
+## DoD mapping
+
+- #2907: retroactive orphan cleanup ✔ (hard-delete cascade via canonical command, idempotent, audit via logger counters). Soft-delete reinterpreted → hard-delete per finding #1 (documented).
+- #2908: auto re-enqueue Pending-with-no-active-job scoped to valid catalog games ✔; idempotent; uses the direct-entity enqueue (bypasses MaxQueueSize like PdfSeeder).
+
+## Out of scope / follow-up
+- Prod-profile orphan cleanup (would need a `MinimumProfile=Prod` layer) — deferred; known orphans are on staging.
+- `StalePdfRecoveryService` overlap (it re-drives Pending in-process): #2908 runs at seed-time before its 30s delay and only creates a Queued job; no code change here, noted for awareness.


### PR DESCRIPTION
## Summary
Resolves #2907 and #2908 — the two remaining follow-ups to #2904 (deterministic SharedGame ids). Two idempotent, best-effort seed passes wired into `CatalogSeedLayer` after `CatalogSeeder` (Staging+), in order **cleanup → re-enqueue**.

## Discovery findings that shaped the design
- **#2907 "soft-delete" premise is unfounded**: `pdf_documents` has no `IsDeleted` column; every delete path is a hard cascade. → **hard-delete** (user-confirmed).
- **`pgvector_embeddings` has no FK cascade** → must purge explicitly. Rather than re-implement the cascade, #2907 **delegates to the canonical `DeleteKbDocumentCommand` via `IMediator`** (reuses agent-detach + pgvector purge + EF cascade of chunks/vector_document + blob + cache + domain event).
- **`processing_jobs` FK is `OnDelete(Cascade)`** → deleting an orphan PDF auto-removes its jobs; no zombie jobs.
- **The enqueue block was duplicated** in `PdfSeeder` → extracted the shared `EnqueueProcessingJob` helper.

## Changes
| File | Change |
|------|--------|
| `OrphanPdfCleanupSeeder.cs` (new) | #2907: anti-join `SharedGameId ∉ db.SharedGames` (the `!IsDeleted` filter catches missing **and** soft-deleted parents, per the issue's own SQL) → delete each via `DeleteKbDocumentCommand`. Idempotent + resilient. |
| `ReattemptStalePendingPdfsSeeder.cs` (new) | #2908: `Pending` + valid catalog game + no active (`Queued`/`Processing`) job → enqueue via `PdfSeeder.EnqueueProcessingJob`. |
| `PdfSeeder.cs` | Extract `EnqueueProcessingJob` from two duplicated inline blocks (behavior-preserving). |
| `CatalogSeedLayer.cs` | Hook both passes after `CatalogSeeder`, best-effort try/catch, **#2907 before #2908**. |

## Decisions (user-confirmed)
- Hard-delete cascade via mediator reuse · orphan = missing **or** soft-deleted parent · 1 combined PR gated **Staging+** (Prod runs Core-only; known orphans are on staging).

## Tests
- **14 unit** (in-memory EF): orphan selection (missing/soft-deleted/valid/null), delegation to `DeleteKbDocumentCommand`, `NotFound` resilience; re-enqueue selection (Queued/Processing→noop, terminal→enqueue, orphan→skip, non-Pending→skip), enqueue shape, idempotency. All green + `PdfSeederBlobTests` still green (refactor guard).
- **2 integration** (`Integration-GroupA`, Testcontainers): real EF cascade of text_chunks + vector_document, cleanup→re-enqueue interaction, idempotency. Validated on CI.
- Local: `dotnet build` (Api + Api.Tests) 0 errors; seeder unit suite 92/92.

## Out of scope / follow-up
- Prod-profile orphan cleanup (would need a `MinimumProfile=Prod` layer) — deferred; known orphans are on staging.

Design doc: `docs/superpowers/specs/2026-07-14-issue-2907-2908-seed-orphan-cleanup-reenqueue-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)