### PR TITLE
fix(ci): fail Deep Health Check loudly on 502 origin-unreachable (#2772)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1285,19 +1285,36 @@ jobs:
           # API was up and serving. The critical-service gate below only requires postgres+redis
           # Healthy, so a Degraded overall status (e.g. a non-critical slack_queue backlog) must not
           # fail the deploy. Same fix as the in-container health wait earlier in this workflow.
+          # #2772 — capture the HTTP status alongside the body. An app-level health response is
+          # 200 (Healthy) or 503 (Degraded, still a valid JSON body — see #2655). A 502/504/000 is an
+          # edge/origin-unreachable failure (e.g. the host docker-proxy for :8080 died and Cloudflare
+          # can't reach the API origin) and MUST fail loud instead of being silently skipped by the jq
+          # parse below — a 502 HTML body has no postgres/redis keys, so STATUS goes empty → "skipping"
+          # → a false green. Only a 200/503 is treated as a real response and breaks the wait loop.
           HEALTH=""
+          HTTP_STATUS="000"
           for i in {1..30}; do
-            HEALTH=$(curl -s "${CF_HEADERS[@]}" https://api.meepleai.app/health 2>/dev/null || true)
-            if [ -n "$HEALTH" ]; then
-              echo "📋 Health response received"
+            HTTP_STATUS=$(curl -s -o /tmp/api_health_body -w "%{http_code}" "${CF_HEADERS[@]}" https://api.meepleai.app/health 2>/dev/null || echo "000")
+            HEALTH=$(cat /tmp/api_health_body 2>/dev/null || true)
+            if [ "$HTTP_STATUS" = "200" ] || [ "$HTTP_STATUS" = "503" ]; then
+              echo "📋 Health response received (HTTP $HTTP_STATUS)"
               break
             fi
-            echo "⏳ Waiting for API... ($i/30)"
+            echo "⏳ Waiting for API... ($i/30) [HTTP $HTTP_STATUS]"
             sleep 10
           done
 
-          if [ -z "$HEALTH" ]; then
-            echo "❌ API did not respond within 5 minutes"
+          # Hard guard (#2772): only a 200/503 is a genuine app health response. Anything else
+          # (502/504 from the edge, or 000 = no response) means the API origin was never reached —
+          # an infrastructure failure, not a healthy deploy. Fail loud instead of silently skipping.
+          if [ "$HTTP_STATUS" != "200" ] && [ "$HTTP_STATUS" != "503" ]; then
+            echo "❌ API /health returned HTTP $HTTP_STATUS after 5 minutes — origin unreachable (502/504) or no response (000)."
+            echo "   Infrastructure/edge failure (Cloudflare tunnel cannot reach the API origin — see #2772), NOT a healthy deploy."
+            if [ -n "$HEALTH" ]; then
+              echo "   First 500 bytes of body:"
+              echo "$HEALTH" | head -c 500
+              echo
+            fi
             exit 1
           fi
 


### PR DESCRIPTION
## Context

Repo-side residual of #2772. The structural 502 fix (containerize cloudflared / repoint CF origins) is an **operator cutover** and stays out of scope — this PR closes the "Related cleanup" the issue calls out: the Deep Health Check silently tolerating a 502.

## Bug

The staging `Deep Health Check` step captured only the `/health` **body** (`curl -s`), never the HTTP status. When the API origin is unreachable (host `docker-proxy` for `:8080` down), Cloudflare returns a **502 with a non-empty HTML body**, so:

1. the wait loop saw a non-empty `$HEALTH` → "response received" → break;
2. `jq` failed to find `postgres`/`redis` in the HTML → `STATUS` empty → `"⚠️ … (skipping)"`;
3. `FAIL` stayed `0` → **green** — a false pass masking the infra failure.

## Fix

Capture `%{http_code}` alongside the body and treat **only 200/503** as a genuine app health response (503 Degraded stays valid per #2655 — a non-critical backlog must not fail the deploy). Any **502/504/000** now fails loud after the retry window with an origin-unreachable message.

- 200 Healthy → pass
- 503 Degraded (valid JSON body) → pass (unchanged, #2655)
- 502 / 504 / 000 → **fail loud** (was: silently skipped)
- 502→200 / 502→503 recovery within the loop → pass

## Validation

- Guard logic extracted + unit-tested against all status codes (7/7: 200/503 pass, 502/504/000 fail, recovery paths pass).
- `deploy-staging.yml` re-validated as well-formed YAML.
- `Web Health Check` + `Smoke Tests` steps untouched.

Refs #2772 #2655 #2770

🤖 Generated with [Claude Code](https://claude.com/claude-code)