### PR TITLE
feat(libro-game): standalone campaign roster via non-live Session — BE (#2917)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/CreateGamebookCampaignCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/CreateGamebookCampaignCommand.cs
@@ -3,5 +3,15 @@ using MediatR;
 
 namespace Api.BoundedContexts.SessionTracking.Application.Commands;
 
-public sealed record CreateGamebookCampaignCommand(Guid GameId, Guid OwnerUserId, string Title)
+/// <summary>
+/// #2917 (decision #2759 Option A): optional roster fields. When present, the handler spins up a
+/// non-live Session carrying these participants (owner auto-seeded) + guest names. Optional/nullable
+/// for backward-compat with callers that only create the campaign.
+/// </summary>
+public sealed record CreateGamebookCampaignCommand(
+    Guid GameId,
+    Guid OwnerUserId,
+    string Title,
+    IReadOnlyList<ParticipantDto>? Participants = null,
+    IReadOnlyList<string>? GuestNames = null)
     : IRequest<GamebookCampaignDto>;

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/CreateGamebookCampaignHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/CreateGamebookCampaignHandler.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using Api.BoundedContexts.Authentication.Application.Queries;
 using Api.BoundedContexts.SessionTracking.Application.DTOs;
 using Api.BoundedContexts.SessionTracking.Domain.Entities;
 using Api.BoundedContexts.SessionTracking.Domain.Events;
@@ -39,7 +40,34 @@ public class CreateGamebookCampaignHandler : IRequestHandler<CreateGamebookCampa
         // SkipGameNightEnvelope=true keeps it night-less; SkipKbReadinessGate=true because gamebook
         // play does not depend on RAG KB readiness; live mode is NOT opened, so invariant #10
         // max-1-live stays scoped to GameNight play.
-        var participants = cmd.Participants?.Where(p => !p.IsOwner).ToList() ?? new List<ParticipantDto>();
+        //
+        // The roster MUST carry an IsOwner participant with the caller's real display name:
+        // CreateSessionCommandValidator requires one, and this mirrors the attach/start handlers
+        // (resolve the caller via GetUserByIdQuery so the owner shows their name, not a literal).
+        var owner = await _mediator.Send(new GetUserByIdQuery(cmd.OwnerUserId), cancellationToken).ConfigureAwait(false);
+        var ownerName = owner is not null && !string.IsNullOrWhiteSpace(owner.DisplayName)
+            ? owner.DisplayName
+            : owner?.Email ?? "Owner";
+
+        var participants = new List<ParticipantDto>
+        {
+            new() { Id = Guid.NewGuid(), UserId = cmd.OwnerUserId, DisplayName = ownerName, IsOwner = true, JoinOrder = 0 },
+        };
+        if (cmd.Participants is { Count: > 0 })
+        {
+            var joinOrder = 1;
+            foreach (var p in cmd.Participants.Where(p => !p.IsOwner))
+            {
+                participants.Add(new ParticipantDto
+                {
+                    Id = Guid.NewGuid(),
+                    UserId = p.UserId,
+                    DisplayName = p.DisplayName,
+                    IsOwner = false,
+                    JoinOrder = joinOrder++,
+                });
+            }
+        }
 
         await _unitOfWork.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
         var commitStarted = false;

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/CreateGamebookCampaignHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/CreateGamebookCampaignHandler.cs
@@ -4,6 +4,7 @@ using Api.BoundedContexts.SessionTracking.Domain.Entities;
 using Api.BoundedContexts.SessionTracking.Domain.Events;
 using Api.BoundedContexts.SessionTracking.Domain.Repositories;
 using Api.SharedKernel.Domain.ValueObjects;
+using Api.SharedKernel.Infrastructure.Persistence;
 using MediatR;
 
 namespace Api.BoundedContexts.SessionTracking.Application.Commands;
@@ -12,11 +13,16 @@ public class CreateGamebookCampaignHandler : IRequestHandler<CreateGamebookCampa
 {
     private readonly IGamebookCampaignSessionRepository _repo;
     private readonly IMediator _mediator;
+    private readonly IUnitOfWork _unitOfWork;
 
-    public CreateGamebookCampaignHandler(IGamebookCampaignSessionRepository repo, IMediator mediator)
+    public CreateGamebookCampaignHandler(
+        IGamebookCampaignSessionRepository repo,
+        IMediator mediator,
+        IUnitOfWork unitOfWork)
     {
         _repo = repo ?? throw new ArgumentNullException(nameof(repo));
         _mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
     }
 
     public async Task<GamebookCampaignDto> Handle(CreateGamebookCampaignCommand cmd, CancellationToken cancellationToken)
@@ -24,11 +30,49 @@ public class CreateGamebookCampaignHandler : IRequestHandler<CreateGamebookCampa
         // A0.2 (#1320): bare Guid cmd.GameId is still a SharedGame reference at the
         // wire level; wrap into GameRef.Shared until command DTO is updated upstream.
         var session = GamebookCampaignSession.Create(GameRef.Shared(cmd.GameId), cmd.OwnerUserId, cmd.Title);
-        await _repo.AddAsync(session, cancellationToken).ConfigureAwait(false);
-        await _repo.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
-        // Issue #1292 (AC-6.2): notify gamebook index cache so the new campaign
-        // appears within 500ms on the next GET /api/v1/gamebooks for the owner.
+        // #2917 (decision #2759 — Option A + no-live-mode): spin up a NON-LIVE Session to carry the
+        // roster. The Session factory auto-seeds the owner participant; extra User-linked participants
+        // + guest names come from the request. Campaign + Session commit in ONE explicit transaction —
+        // the inner CreateSessionCommand's SaveChanges enlists in the ambient tx (shared scoped
+        // DbContext), so a Session failure rolls the campaign INSERT back (no orphan).
+        // SkipGameNightEnvelope=true keeps it night-less; SkipKbReadinessGate=true because gamebook
+        // play does not depend on RAG KB readiness; live mode is NOT opened, so invariant #10
+        // max-1-live stays scoped to GameNight play.
+        var participants = cmd.Participants?.Where(p => !p.IsOwner).ToList() ?? new List<ParticipantDto>();
+
+        await _unitOfWork.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+        var commitStarted = false;
+        try
+        {
+            await _repo.AddAsync(session, cancellationToken).ConfigureAwait(false);
+            await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+            await _mediator.Send(new CreateSessionCommand(
+                cmd.OwnerUserId,
+                cmd.GameId,
+                "GameSpecific",
+                DateTime.UtcNow,
+                Location: null,
+                Participants: participants,
+                GuestNames: cmd.GuestNames,
+                GamebookCampaignId: session.Id,
+                SkipGameNightEnvelope: true,
+                SkipKbReadinessGate: true), cancellationToken).ConfigureAwait(false);
+
+            commitStarted = true;
+            await _unitOfWork.CommitTransactionAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception)
+        {
+            if (!commitStarted)
+                await _unitOfWork.RollbackTransactionAsync(cancellationToken).ConfigureAwait(false);
+            throw;
+        }
+
+        // Issue #1292 (AC-6.2): notify gamebook index cache so the new campaign appears within
+        // 500ms on the next GET /api/v1/gamebooks. Published AFTER commit so cache-invalidation
+        // subscribers never observe an uncommitted campaign.
         await _mediator.Publish(
             new GamebookCampaignCreatedDomainEvent(session.Id, session.GameRef.Id, session.OwnerUserId),
             cancellationToken).ConfigureAwait(false);

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/CreateGamebookCampaignValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/CreateGamebookCampaignValidator.cs
@@ -9,5 +9,16 @@ public sealed class CreateGamebookCampaignValidator : AbstractValidator<CreateGa
         RuleFor(x => x.GameId).NotEmpty();
         RuleFor(x => x.OwnerUserId).NotEmpty();
         RuleFor(x => x.Title).NotEmpty().MaximumLength(200);
+
+        // #2917: validate the optional roster consistently with the rest of the command.
+        RuleForEach(x => x.GuestNames)
+            .NotEmpty()
+            .MaximumLength(120)
+            .When(x => x.GuestNames is not null);
+
+        RuleForEach(x => x.Participants)
+            .Must(p => !string.IsNullOrWhiteSpace(p.DisplayName))
+            .WithMessage("Participant display name is required.")
+            .When(x => x.Participants is not null);
     }
 }

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/CreateSessionCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/CreateSessionCommand.cs
@@ -33,7 +33,8 @@ public record CreateSessionCommand(
     IReadOnlyList<string>? GuestNames = null,
     GameStateTier StateTier = GameStateTier.Minimal,
     Guid? GamebookCampaignId = null,
-    bool SkipGameNightEnvelope = false
+    bool SkipGameNightEnvelope = false,
+    bool SkipKbReadinessGate = false
 ) : ICommand<CreateSessionResult>;
 
 /// <summary>

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/CreateSessionCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/CreateSessionCommandHandler.cs
@@ -61,19 +61,24 @@ public class CreateSessionCommandHandler : ICommandHandler<CreateSessionCommand,
         await CheckSessionQuotaAsync(request.UserId, cancellationToken).ConfigureAwait(false);
 
         // Session Flow v2.1 — T4: KB readiness pre-check.
-        var kbReadiness = await _mediator
-            .Send(new GetKbReadinessQuery(request.GameId), cancellationToken)
-            .ConfigureAwait(false);
-
-        if (!kbReadiness.IsReady)
+        // #2917: standalone gamebook play passes SkipKbReadinessGate=true — gamebook play does not
+        // depend on RAG KB readiness, so it must not 422 on a game whose KB is not indexed.
+        if (!request.SkipKbReadinessGate)
         {
-            _logger.LogWarning(
-                "KB not ready for game {GameId} (state={State}, ready={Ready}, failed={Failed})",
-                request.GameId, kbReadiness.State, kbReadiness.ReadyPdfCount, kbReadiness.FailedPdfCount);
+            var kbReadiness = await _mediator
+                .Send(new GetKbReadinessQuery(request.GameId), cancellationToken)
+                .ConfigureAwait(false);
 
-            throw new UnprocessableEntityException(
-                errorCode: "kb_not_ready",
-                message: $"KB for game {request.GameId} is not ready (state: {kbReadiness.State}).");
+            if (!kbReadiness.IsReady)
+            {
+                _logger.LogWarning(
+                    "KB not ready for game {GameId} (state={State}, ready={Ready}, failed={Failed})",
+                    request.GameId, kbReadiness.State, kbReadiness.ReadyPdfCount, kbReadiness.FailedPdfCount);
+
+                throw new UnprocessableEntityException(
+                    errorCode: "kb_not_ready",
+                    message: $"KB for game {request.GameId} is not ready (state: {kbReadiness.State}).");
+            }
         }
 
         // Session Flow v2.1 — T4: Resolve or create the GameNight envelope.

--- a/apps/api/src/Api/Routing/GamebookCampaignEndpoints.cs
+++ b/apps/api/src/Api/Routing/GamebookCampaignEndpoints.cs
@@ -48,8 +48,21 @@ internal static class GamebookCampaignEndpoints
                 return Results.Unauthorized();
             }
 
+            // #2917: map the optional wire roster to ParticipantDto. The owner is seeded
+            // server-side by the Session factory (authenticated user), so a client-claimed
+            // IsOwner participant is harmless — the handler filters non-owner entries.
+            var participants = body.Participants
+                ?.Select(p => new ParticipantDto
+                {
+                    Id = Guid.NewGuid(),
+                    UserId = p.UserId,
+                    DisplayName = p.DisplayName,
+                    IsOwner = p.IsOwner,
+                })
+                .ToList();
+
             var dto = await mediator.Send(
-                new CreateGamebookCampaignCommand(body.GameId, userId, body.Title), ct
+                new CreateGamebookCampaignCommand(body.GameId, userId, body.Title, participants, body.GuestNames), ct
             ).ConfigureAwait(false);
 
             return Results.Created($"/api/v1/gamebook/campaigns/{dto.Id}", dto);
@@ -362,7 +375,16 @@ internal static class GamebookCampaignEndpoints
 }
 
 /// <summary>Request body for creating a new gamebook campaign.</summary>
-public sealed record CreateGamebookCampaignRequest(Guid GameId, string Title);
+/// <remarks>#2917: optional roster — <paramref name="Participants"/> (User-linked players) and
+/// <paramref name="GuestNames"/> (free guests) persist a non-live Session for standalone play.</remarks>
+public sealed record CreateGamebookCampaignRequest(
+    Guid GameId,
+    string Title,
+    IReadOnlyList<CreateCampaignParticipantRequest>? Participants = null,
+    IReadOnlyList<string>? GuestNames = null);
+
+/// <summary>#2917: minimal wire shape for a campaign roster participant (server assigns Id/JoinOrder).</summary>
+public sealed record CreateCampaignParticipantRequest(Guid? UserId, string DisplayName, bool IsOwner = false);
 
 /// <summary>
 /// Request body for updating the current paragraph progress for a specific book.

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Commands/CreateGamebookCampaignHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Commands/CreateGamebookCampaignHandlerTests.cs
@@ -1,3 +1,5 @@
+using Api.BoundedContexts.Authentication.Application.DTOs;
+using Api.BoundedContexts.Authentication.Application.Queries;
 using Api.BoundedContexts.SessionTracking.Application.Commands;
 using Api.BoundedContexts.SessionTracking.Application.DTOs;
 using Api.BoundedContexts.SessionTracking.Domain.Entities;
@@ -46,6 +48,11 @@ public sealed class CreateGamebookCampaignHandlerTests
             .Setup(m => m.Send(It.IsAny<CreateSessionCommand>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new CreateSessionResult(
                 Guid.NewGuid(), "ABC123", new List<ParticipantDto>(), Guid.Empty, false, null, null));
+
+        // Owner display-name resolution (null → the handler falls back to "Owner").
+        _mediator
+            .Setup(m => m.Send(It.IsAny<GetUserByIdQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((UserDto?)null);
     }
 
     private CreateGamebookCampaignHandler CreateHandler()
@@ -92,6 +99,9 @@ public sealed class CreateGamebookCampaignHandlerTests
                 && c.SkipGameNightEnvelope
                 && c.SkipKbReadinessGate
                 && c.GuestNames != null && c.GuestNames.Contains("Luca")
+                // Regression guard for the review finding: the dispatched command MUST carry the
+                // owner (CreateSessionCommandValidator requires an IsOwner participant).
+                && c.Participants.Any(p => p.IsOwner && p.UserId == userId)
                 && c.Participants.Any(p => p.DisplayName == "Alice")),
             It.IsAny<CancellationToken>()), Times.Once);
     }

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Commands/CreateGamebookCampaignHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Commands/CreateGamebookCampaignHandlerTests.cs
@@ -1,7 +1,9 @@
 using Api.BoundedContexts.SessionTracking.Application.Commands;
+using Api.BoundedContexts.SessionTracking.Application.DTOs;
 using Api.BoundedContexts.SessionTracking.Domain.Entities;
 using Api.BoundedContexts.SessionTracking.Domain.Repositories;
 using Api.SharedKernel.Domain.ValueObjects;
+using Api.SharedKernel.Infrastructure.Persistence;
 using FluentAssertions;
 using MediatR;
 using Moq;
@@ -32,41 +34,130 @@ public sealed class CreateGamebookCampaignHandlerTests
         public Task SaveChangesAsync(CancellationToken ct = default) => Task.CompletedTask;
     }
 
+    private readonly FakeRepo _repo = new();
+    private readonly Mock<IMediator> _mediator = new();
+    private readonly Mock<IUnitOfWork> _uow = new();
+
+    public CreateGamebookCampaignHandlerTests()
+    {
+        // #2917: the handler dispatches CreateSessionCommand for the roster. Default to a
+        // standalone (night-less) result so the happy-path tests don't need per-test setup.
+        _mediator
+            .Setup(m => m.Send(It.IsAny<CreateSessionCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new CreateSessionResult(
+                Guid.NewGuid(), "ABC123", new List<ParticipantDto>(), Guid.Empty, false, null, null));
+    }
+
+    private CreateGamebookCampaignHandler CreateHandler()
+        => new(_repo, _mediator.Object, _uow.Object);
+
     [Fact]
     public async Task Handle_WithValidCommand_PersistsAndReturnsDto()
     {
-        // Arrange
-        var repo = new FakeRepo();
-        var mediator = new Mock<IMediator>();
-        var handler = new CreateGamebookCampaignHandler(repo, mediator.Object);
+        var handler = CreateHandler();
         var gameId = Guid.NewGuid();
         var userId = Guid.NewGuid();
         var cmd = new CreateGamebookCampaignCommand(gameId, userId, "My Campaign");
 
-        // Act
         var dto = await handler.Handle(cmd, CancellationToken.None);
 
-        // Assert
         dto.Title.Should().Be("My Campaign");
         dto.OwnerUserId.Should().Be(userId);
         dto.CurrentParagraph.Should().Be(0);
         dto.Id.Should().NotBeEmpty();
-        // Issue #1392: DTO must expose GameRef discriminator so FE can
-        // distinguish shared vs private campaigns without hardcoding Shared.
-        // Issue #1405: legacy GameId alias removed; gameRefId is the canonical
-        // ref identifier.
         dto.GameRefId.Should().Be(gameId);
         dto.GameRefKind.Should().Be((int)GameRefKind.Shared);
-        repo.Store.Should().HaveCount(1);
+        _repo.Store.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task Handle_WithRoster_DispatchesCreateSessionLinkedToCampaign()
+    {
+        var handler = CreateHandler();
+        var gameId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var cmd = new CreateGamebookCampaignCommand(
+            gameId, userId, "Campaign",
+            Participants: new List<ParticipantDto> { new() { DisplayName = "Alice", IsOwner = false } },
+            GuestNames: new List<string> { "Luca" });
+
+        await handler.Handle(cmd, CancellationToken.None);
+
+        var campaignId = _repo.Store[0].Id;
+        _mediator.Verify(m => m.Send(
+            It.Is<CreateSessionCommand>(c =>
+                c.GamebookCampaignId == campaignId
+                && c.UserId == userId
+                && c.GameId == gameId
+                && c.SkipGameNightEnvelope
+                && c.SkipKbReadinessGate
+                && c.GuestNames != null && c.GuestNames.Contains("Luca")
+                && c.Participants.Any(p => p.DisplayName == "Alice")),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_DoesNotOpenLiveMode()
+    {
+        // Decision #2759 point 2: the standalone Session must NOT open live mode, so invariant
+        // #10 max-1-live stays scoped to GameNight play. (Contrast: the attach handler DOES.)
+        var handler = CreateHandler();
+        var cmd = new CreateGamebookCampaignCommand(Guid.NewGuid(), Guid.NewGuid(), "Campaign");
+
+        await handler.Handle(cmd, CancellationToken.None);
+
+        _mediator.Verify(
+            m => m.Send(It.IsAny<OpenSessionLiveModeCommand>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_HappyPath_CommitsTransaction()
+    {
+        var handler = CreateHandler();
+        var cmd = new CreateGamebookCampaignCommand(Guid.NewGuid(), Guid.NewGuid(), "Campaign");
+
+        await handler.Handle(cmd, CancellationToken.None);
+
+        _uow.Verify(u => u.BeginTransactionAsync(It.IsAny<CancellationToken>()), Times.Once);
+        _uow.Verify(u => u.CommitTransactionAsync(It.IsAny<CancellationToken>()), Times.Once);
+        _uow.Verify(u => u.RollbackTransactionAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_SessionFailure_RollsBackTransaction()
+    {
+        var handler = CreateHandler();
+        _mediator
+            .Setup(m => m.Send(It.IsAny<CreateSessionCommand>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("session failed"));
+        var cmd = new CreateGamebookCampaignCommand(Guid.NewGuid(), Guid.NewGuid(), "Campaign");
+
+        var act = () => handler.Handle(cmd, CancellationToken.None);
+
+        await act.Should().ThrowAsync<InvalidOperationException>();
+        _uow.Verify(u => u.RollbackTransactionAsync(It.IsAny<CancellationToken>()), Times.Once);
+        _uow.Verify(u => u.CommitTransactionAsync(It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
     public void Constructor_WhenRepoIsNull_ThrowsArgumentNullException()
     {
-        // Act
-        var act = () => new CreateGamebookCampaignHandler(null!, new Mock<IMediator>().Object);
-
-        // Assert
+        var act = () => new CreateGamebookCampaignHandler(null!, _mediator.Object, _uow.Object);
         act.Should().Throw<ArgumentNullException>().WithParameterName("repo");
+    }
+
+    [Fact]
+    public void Constructor_WhenMediatorIsNull_ThrowsArgumentNullException()
+    {
+        var act = () => new CreateGamebookCampaignHandler(_repo, null!, _uow.Object);
+        act.Should().Throw<ArgumentNullException>().WithParameterName("mediator");
+    }
+
+    [Fact]
+    public void Constructor_WhenUnitOfWorkIsNull_ThrowsArgumentNullException()
+    {
+        var act = () => new CreateGamebookCampaignHandler(_repo, _mediator.Object, null!);
+        act.Should().Throw<ArgumentNullException>().WithParameterName("unitOfWork");
     }
 }


### PR DESCRIPTION
## Summary
Backend half of #2917 (implementing decision #2759 — **Option A + no-live-mode**): the standalone gamebook create now persists the player roster by spinning up a **non-live** `Session` linked via `GamebookCampaignId`. Part of #2917 (FE PlayerSetup wiring lands in a follow-up PR that closes the issue).

## Changes
- `CreateSessionCommand`: new `SkipKbReadinessGate` flag (default `false`); the handler guards the KB-readiness 422 gate with it — standalone gamebook create must not 422 on an unindexed KB. Backward-compat: all existing internal callers keep the gate.
- `CreateGamebookCampaignCommand`/`Request`: optional roster (`participants` + `guestNames`) via a minimal `CreateCampaignParticipantRequest` wire type mapped to `ParticipantDto`.
- `CreateGamebookCampaignHandler`: injects `IUnitOfWork`; seeds the owner (real display name via `GetUserByIdQuery`) + extra participants + guests, then wraps campaign-create + a dispatched `CreateSessionCommand` (`SkipGameNightEnvelope=true`, `SkipKbReadinessGate=true`, **no live mode**) in one explicit transaction so a Session failure rolls the campaign back. Domain event published post-commit.

## Review findings (holistic review) — addressed
- 🔴 **Blocking**: the owner was filtered out of the dispatched roster, but `CreateSessionCommandValidator` requires an `IsOwner` participant → every create would fail `ValidationException` at runtime (missed by unit tests that mock `IMediator`). **Fixed**: owner is now seeded into the command + a regression assert added.
- 🟡 owner display name (was literal "Owner") — fixed by the same change.
- 🟡 `SkipKbReadinessGate` client-bindable on `POST /game-sessions` (pre-existing direct-binding pattern) — tracked in **#2920**.

## Tests
- 8 handler unit tests (dispatch carries owner + `SkipKbReadinessGate`+`SkipGameNightEnvelope`, no-live-mode, atomicity begin/commit/rollback, null-guards). `CreateSessionCommandHandler` behavior unchanged (11/11). Build 0 errors.
- **Gap (transparency)**: no end-to-end integration test exercising the real `ValidationBehavior`/validator + real transaction — the fix is verified at unit level (owner always present) and mirrors the in-production attach/start handlers. To be added with the FE PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)