### PR TITLE
feat(libro-game): campaign setup wizard roster UI — FE completion (#2917)

### DIFF
--- a/apps/web/src/components/features/gamebook/CampaignSetupDrawer.stories.tsx
+++ b/apps/web/src/components/features/gamebook/CampaignSetupDrawer.stories.tsx
@@ -117,7 +117,7 @@ export const Frame01_Step1Name: Story = {
 // ── Frame 02 · Step 2 Players ──────────────────────────────────────────────
 
 export const Frame02_Step2Players: Story = {
-  name: '02 · Step 2 Giocatori — 4 player chip + add custom',
+  name: '02 · Step 2 Giocatori — roster editabile (host + guests)',
   args: {
     open: true,
     initialStep: 2,
@@ -127,8 +127,10 @@ export const Frame02_Step2Players: Story = {
     docs: {
       description: {
         story:
-          'Stato 02 mockup — step 2/3. Aaron (host) + Marco, Giulia, Luca (guest) come player chip. ' +
-          'Add custom button (dashed, disabled). Suggerimento agente Nanolith Tutor. ' +
+          'Stato 02 mockup — step 2/3 (#2917). Roster editabile via <PlayerSetup>: host = ' +
+          'utente corrente (fallback "Tu" senza sessione) + guest del preset group-a ' +
+          '(Marco, Giulia, Luca). Input "Nome giocatore" + bottone "Aggiungi" ABILITATI ' +
+          '(add/remove/reorder). Suggerimento agente Nanolith Tutor riflette il roster live. ' +
           'Stepper: [✓ Nome done | 2 Giocatori active | 3 pending]. ' +
           'Reso statico via initialStep:2 (test-seam prop).',
       },
@@ -154,6 +156,7 @@ export const Frame03_Step3Confirm: Story = {
         story:
           'Stato 03 mockup — step 3/3. Review card con cover-mini, meta-rows ' +
           '(Preset / Giocatori / Lingua agente / Durata stimata) + info box "Cosa succede ora". ' +
+          'La riga Giocatori mostra il roster REALE assemblato allo step 2 (#2917), non il preset. ' +
           'CTA "📖 Inizia sessione" abilitato. Stepper: [✓ Nome | ✓ Giocatori | 3 Conferma active]. ' +
           'Reso statico via initialStep:3 (test-seam prop). ' +
           'MSW handler mocks POST /api/v1/gamebook/campaigns → 201 (no real network error).',

--- a/apps/web/src/components/features/gamebook/CampaignSetupDrawer.tsx
+++ b/apps/web/src/components/features/gamebook/CampaignSetupDrawer.tsx
@@ -1,28 +1,32 @@
 'use client';
 
 /**
- * CampaignSetupDrawer — Iter 4 (M4 in storyboard).
+ * CampaignSetupDrawer — Iter 4 (M4 in storyboard) + Iter 5 roster wire-up (#2917).
  *
  * 3-step setup wizard for "Nuova campagna libro game", replacing the
  * minimal `NewCampaignDialog` (1-step modal with just a title field).
  *
- * UX per storyboard `nanolith-runthrough-setup-wizard.html`:
+ * UX per storyboard `librogame-runthrough-setup-wizard.html`:
  *   Step 1 · Name       — campaign title + group preset (Gruppo A · I ragazzi,
  *                          Gruppo B · Coppia, Custom)
- *   Step 2 · Players    — host (Aaron) + guest chips, add custom (visual)
- *   Step 3 · Confirm    — review card with ManaPips + CTA "📖 Inizia sessione"
+ *   Step 2 · Players    — editable roster via `<PlayerSetup>`: the owner is the
+ *                          Host entry (real display name), extra players are free
+ *                          guests that the user can add/remove/reorder.
+ *   Step 3 · Confirm    — review card with the REAL roster + CTA "📖 Inizia sessione"
  *   Validation          — title ≥ 3 chars
  *
- * Backend contract (Iter 1.A): POST /api/v1/gamebook/campaigns accepts
- * `{ gameId, title }` only. Preset + players are presentation-layer for now;
- * iter futuro estenderà lo schema (issue separata) — quando arriva, sostituire
- * il payload in `mutation.mutate()` senza toccare la UI.
+ * Backend contract (#2917): POST /api/v1/gamebook/campaigns accepts
+ * `{ gameId, title, participants?, guestNames? }`. The owner is auto-seeded
+ * server-side, so we only send `guestNames` (everyone but the Host). MVP:
+ * every extra player is a free guest — no User lookup (`participants` stays
+ * empty). Omitting the roster keeps the legacy campaign-only behavior.
  */
 
 import {
   cloneElement,
   isValidElement,
   useEffect,
+  useMemo,
   useRef,
   useState,
   type MouseEvent,
@@ -33,6 +37,7 @@ import {
 import { useMutation } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 
+import { PlayerSetup, PLAYER_COLORS, type SetupPlayer } from '@/components/game-night';
 import {
   Drawer,
   DrawerContent,
@@ -40,6 +45,7 @@ import {
   DrawerHeader,
   DrawerTitle,
 } from '@/components/ui/drawer/drawer';
+import { useCurrentUser } from '@/hooks/queries/useCurrentUser';
 import { createCampaign } from '@/lib/api/gamebook-campaigns';
 
 // ─── Types ──────────────────────────────────────────────────────────────────
@@ -94,6 +100,21 @@ const PRESETS: readonly PresetConfig[] = [
 const MIN_TITLE_LENGTH = 3;
 const MAX_TITLE_LENGTH = 200;
 
+/**
+ * Derive an editable `SetupPlayer[]` roster from a preset, substituting the
+ * owner's real display name into the Host entry (the preset stores a demo
+ * "Aaron" placeholder). Colors are drawn from `PLAYER_COLORS` by position so
+ * the roster starts with unique colors; `PlayerSetup` keeps them unique on edit.
+ */
+function presetToRoster(preset: PresetConfig, ownerName: string): SetupPlayer[] {
+  return preset.players.map((p, i) => ({
+    id: p.id,
+    name: p.role === 'host' ? ownerName : p.name,
+    color: PLAYER_COLORS[i % PLAYER_COLORS.length].value,
+    role: p.role === 'host' ? 'Host' : 'Player',
+  }));
+}
+
 export interface CampaignSetupDrawerProps {
   readonly gameId: string;
   readonly gameTitle: string;
@@ -135,6 +156,9 @@ export function CampaignSetupDrawer({
   initialPresetId,
 }: CampaignSetupDrawerProps): ReactElement {
   const router = useRouter();
+  const { data: currentUser } = useCurrentUser();
+  const ownerName = currentUser?.displayName || currentUser?.email || 'Tu';
+
   const [internalOpen, setInternalOpen] = useState(false);
   const isControlled = openProp !== undefined;
   const open = isControlled ? openProp : internalOpen;
@@ -145,10 +169,45 @@ export function CampaignSetupDrawer({
   const [step, setStep] = useState<StepId>(initialStep ?? 1);
   const [title, setTitle] = useState(initialTitle ?? 'Campagna con i ragazzi');
   const [presetId, setPresetId] = useState<PresetId>(initialPresetId ?? 'group-a');
-  const preset = PRESETS.find(p => p.id === presetId) ?? PRESETS[0];
+  const preset = useMemo(() => PRESETS.find(p => p.id === presetId) ?? PRESETS[0], [presetId]);
+
+  // Editable roster (Step 2). Derived from the selected preset, with the Host
+  // entry carrying the owner's real display name. Re-derived only when the
+  // preset changes OR when the owner name first resolves — user edits made
+  // while staying on the same preset are preserved (guarded by the sync ref).
+  const [players, setPlayers] = useState<SetupPlayer[]>(() => presetToRoster(preset, ownerName));
+  const rosterSyncRef = useRef<{ presetId: PresetId; ownerName: string }>({
+    presetId,
+    ownerName,
+  });
+
+  useEffect(() => {
+    const last = rosterSyncRef.current;
+    const presetChanged = last.presetId !== presetId;
+    // Only patch the Host name when it actually resolves (placeholder → real),
+    // never overwrite a real name with the "Tu" fallback if the user logs out.
+    const ownerResolved = last.ownerName !== ownerName && ownerName !== 'Tu';
+    if (!presetChanged && !ownerResolved) return;
+
+    rosterSyncRef.current = { presetId, ownerName };
+    if (presetChanged) {
+      // Full re-derive from the new preset (drops prior edits by design).
+      setPlayers(presetToRoster(preset, ownerName));
+    } else {
+      // Owner name resolved while on the same preset: patch the Host entry only,
+      // preserving any guest edits already made.
+      setPlayers(prev => prev.map(p => (p.role === 'Host' ? { ...p, name: ownerName } : p)));
+    }
+  }, [presetId, preset, ownerName]);
 
   const mutation = useMutation({
-    mutationFn: () => createCampaign({ gameId, title: title.trim() }),
+    mutationFn: () => {
+      const guestNames = players
+        .filter(p => p.role !== 'Host')
+        .map(p => p.name.trim())
+        .filter(Boolean);
+      return createCampaign({ gameId, title: title.trim(), guestNames });
+    },
     onSuccess: campaign => {
       reset();
       router.push(`/library/${gameId}/play/${campaign.id}`);
@@ -180,6 +239,9 @@ export function CampaignSetupDrawer({
     setStep(1);
     setTitle('Campagna con i ragazzi');
     setPresetId('group-a');
+    const defaultPreset = PRESETS.find(p => p.id === 'group-a') ?? PRESETS[0];
+    setPlayers(presetToRoster(defaultPreset, ownerName));
+    rosterSyncRef.current = { presetId: 'group-a', ownerName };
     mutation.reset();
     isInitialMountRef.current = true;
   }
@@ -249,12 +311,13 @@ export function CampaignSetupDrawer({
               onPresetChange={setPresetId}
             />
           )}
-          {step === 2 && <StepPlayers preset={preset} />}
+          {step === 2 && <StepPlayers players={players} onPlayersChange={setPlayers} />}
           {step === 3 && (
             <StepConfirm
               gameTitle={gameTitle}
               campaignTitle={trimmedTitle}
               preset={preset}
+              players={players}
               error={
                 mutation.isError
                   ? mutation.error instanceof Error
@@ -435,62 +498,16 @@ function StepName({
 
 // ─── Step 2 · Players ───────────────────────────────────────────────────────
 
-function StepPlayers({ preset }: { preset: PresetConfig }): ReactElement {
+interface StepPlayersProps {
+  readonly players: SetupPlayer[];
+  readonly onPlayersChange: (players: SetupPlayer[]) => void;
+}
+
+function StepPlayers({ players, onPlayersChange }: StepPlayersProps): ReactElement {
   return (
     <div className="grid gap-4">
-      <div>
-        <h3 className="mb-2 text-[11px] font-bold uppercase tracking-wide text-muted-foreground">
-          Party · {preset.players.length} {preset.players.length === 1 ? 'giocatore' : 'giocatori'}
-        </h3>
-        <div className="grid grid-cols-2 gap-2">
-          {preset.players.map(p => {
-            const isHost = p.role === 'host';
-            return (
-              <div
-                key={p.id}
-                className={
-                  isHost
-                    ? 'flex items-center gap-2 rounded-md border border-[hsl(var(--c-session)/0.55)] bg-[hsl(var(--c-session)/0.1)] px-3 py-2'
-                    : 'flex items-center gap-2 rounded-md border border-[hsl(var(--c-player)/0.35)] bg-[hsl(var(--c-player)/0.08)] px-3 py-2'
-                }
-              >
-                <span
-                  className={
-                    isHost
-                      ? 'flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-[hsl(var(--c-session))] font-mono text-xs font-bold text-white'
-                      : 'flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-[hsl(var(--c-player))] font-mono text-xs font-bold text-white'
-                  }
-                  aria-hidden="true"
-                >
-                  {p.initial}
-                </span>
-                <span className="flex-1 truncate">
-                  <span className="block text-sm font-semibold text-foreground">{p.name}</span>
-                  <span
-                    className={
-                      isHost
-                        ? 'block font-mono text-[10px] text-[hsl(var(--c-session))]'
-                        : 'block font-mono text-[10px] text-[hsl(var(--c-player))]'
-                    }
-                  >
-                    {isHost ? '⭐ Host · tu' : 'guest'}
-                  </span>
-                </span>
-              </div>
-            );
-          })}
-          {/* Add-custom slot (visual only for Iter 4 — wire-up in iter futuro) */}
-          <button
-            type="button"
-            disabled
-            className="flex items-center justify-center gap-1 rounded-md border-2 border-dashed border-border bg-transparent px-3 py-2 text-sm font-semibold text-muted-foreground opacity-60"
-            aria-disabled="true"
-            title="Aggiunta custom — disponibile in iter futuro"
-          >
-            ＋ Aggiungi giocatore
-          </button>
-        </div>
-      </div>
+      {/* Editable roster (#2917): host = owner, extra players = free guests. */}
+      <PlayerSetup players={players} onPlayersChange={onPlayersChange} />
 
       <div className="flex gap-3 rounded-md border border-[hsl(var(--c-agent)/0.25)] bg-[hsl(var(--c-agent)/0.08)] p-3 text-sm">
         <span aria-hidden="true" className="text-lg">
@@ -498,7 +515,7 @@ function StepPlayers({ preset }: { preset: PresetConfig }): ReactElement {
         </span>
         <span className="text-muted-foreground">
           <strong className="font-bold text-[hsl(var(--c-agent))]">Nanolith Tutor</strong> consiglia{' '}
-          <strong className="font-semibold">{preset.players.length} giocatori</strong> per la prima
+          <strong className="font-semibold">{players.length} giocatori</strong> per la prima
           campagna.
         </span>
       </div>
@@ -512,11 +529,23 @@ interface StepConfirmProps {
   readonly gameTitle: string;
   readonly campaignTitle: string;
   readonly preset: PresetConfig;
+  readonly players: readonly SetupPlayer[];
   readonly error: string | null;
 }
 
-function StepConfirm({ gameTitle, campaignTitle, preset, error }: StepConfirmProps): ReactElement {
-  const playerNames = preset.players.map(p => p.name).join(' · ');
+function StepConfirm({
+  gameTitle,
+  campaignTitle,
+  preset,
+  players,
+  error,
+}: StepConfirmProps): ReactElement {
+  // Show the REAL roster the user assembled in Step 2 (host + guests), not the
+  // static preset — the confirm screen must match exactly what gets persisted.
+  const playerNames = players
+    .map(p => p.name.trim())
+    .filter(Boolean)
+    .join(' · ');
   return (
     <div className="grid gap-3">
       <article

--- a/apps/web/src/components/features/gamebook/__tests__/CampaignSetupDrawer.test.tsx
+++ b/apps/web/src/components/features/gamebook/__tests__/CampaignSetupDrawer.test.tsx
@@ -17,6 +17,13 @@ vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: pushSpy }),
 }));
 
+// Deterministic owner display name so the Host roster entry is stable (#2917).
+vi.mock('@/hooks/queries/useCurrentUser', () => ({
+  useCurrentUser: () => ({
+    data: { id: 'owner-1', email: 'owner@example.com', displayName: 'Owner', role: 'user' },
+  }),
+}));
+
 /**
  * Force desktop mode so Radix Dialog is used instead of Vaul.
  * Vaul requires PointerEvent capture, scrollIntoView, and transform parsing
@@ -135,7 +142,7 @@ describe('CampaignSetupDrawer — Step 1 (Name + Preset)', () => {
 // ─── Step 2: Players ─────────────────────────────────────────────────────────
 
 describe('CampaignSetupDrawer — Step 2 (Players)', () => {
-  it('renders host + guest chips for default preset group-a', async () => {
+  it('renders the editable roster (owner host + preset guests) for group-a', async () => {
     const user = userEvent.setup();
     wrap(
       <CampaignSetupDrawer gameId="g1" gameTitle="Nanolith" open={true} onOpenChange={() => {}} />
@@ -148,18 +155,40 @@ describe('CampaignSetupDrawer — Step 2 (Players)', () => {
 
     await user.click(screen.getByTestId('campaign-setup-next'));
 
-    // Step 2 should show player chips for group-a (Aaron host + Marco + Giulia + Luca)
-    expect(screen.getByText('Aaron')).toBeInTheDocument();
+    // PlayerSetup shows the roster: Host = real owner display name (NOT demo "Aaron"),
+    // plus the preset guests Marco / Giulia / Luca.
+    expect(screen.getByText('Owner')).toBeInTheDocument();
+    expect(screen.queryByText('Aaron')).not.toBeInTheDocument();
     expect(screen.getByText('Marco')).toBeInTheDocument();
     expect(screen.getByText('Giulia')).toBeInTheDocument();
     expect(screen.getByText('Luca')).toBeInTheDocument();
 
-    // Host indicator
-    expect(screen.getByText(/Host · tu/)).toBeInTheDocument();
+    // Host role badge is present (PlayerSetup renders a "Host" role toggle).
+    expect(screen.getByRole('button', { name: /Ruolo di Owner: Host/ })).toBeInTheDocument();
 
-    // "Aggiungi giocatore" button should be disabled
-    const addButton = screen.getByRole('button', { name: /Aggiungi giocatore/ });
-    expect(addButton).toHaveAttribute('aria-disabled', 'true');
+    // The add-player affordance is now ENABLED: an input + a real "Aggiungi" button.
+    expect(screen.getByLabelText('Nome nuovo giocatore')).toBeEnabled();
+    const addButton = screen.getByRole('button', { name: /^Aggiungi$/ });
+    expect(addButton).not.toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('adding a player extends the roster', async () => {
+    const user = userEvent.setup();
+    wrap(
+      <CampaignSetupDrawer gameId="g1" gameTitle="Nanolith" open={true} onOpenChange={() => {}} />
+    );
+
+    const titleInput = screen.getByTestId('campaign-setup-title');
+    await user.clear(titleInput);
+    await user.type(titleInput, 'Test campaign');
+    await user.click(screen.getByTestId('campaign-setup-next'));
+
+    // Add a new player via the enabled input + button.
+    const nameInput = screen.getByLabelText('Nome nuovo giocatore');
+    await user.type(nameInput, 'Priya');
+    await user.click(screen.getByRole('button', { name: /^Aggiungi$/ }));
+
+    expect(screen.getByText('Priya')).toBeInTheDocument();
   });
 
   it('shows agent suggestion card with player count', async () => {
@@ -173,11 +202,9 @@ describe('CampaignSetupDrawer — Step 2 (Players)', () => {
     await user.type(titleInput, 'Test campaign');
     await user.click(screen.getByTestId('campaign-setup-next'));
 
-    // Agent suggestion card — "4 giocatori" appears in both the party heading and
-    // the agent <strong>, so use getAllByText to confirm at least one instance.
+    // Agent suggestion card reflects the live roster length (4 for group-a).
     expect(screen.getByText(/Nanolith Tutor/)).toBeInTheDocument();
-    const playerCountMatches = screen.getAllByText(/4 giocatori/);
-    expect(playerCountMatches.length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText(/4 giocatori/)).toBeInTheDocument();
   });
 });
 
@@ -205,9 +232,12 @@ describe('CampaignSetupDrawer — Step 3 (Confirm)', () => {
     // Campaign title heading
     expect(screen.getByText('Test campaign')).toBeInTheDocument();
 
-    // Preset row
+    // Preset row (still shown for context)
     expect(screen.getByText('Preset')).toBeInTheDocument();
     expect(screen.getByText('Gruppo A · I ragazzi')).toBeInTheDocument();
+
+    // Giocatori row shows the REAL roster (owner Host + guests), not the demo preset.
+    expect(screen.getByText('Owner · Marco · Giulia · Luca')).toBeInTheDocument();
 
     // Submit button
     expect(screen.getByTestId('campaign-setup-submit')).toBeInTheDocument();
@@ -287,9 +317,18 @@ describe('CampaignSetupDrawer — Footer + Submit', () => {
 
     await user.click(screen.getByTestId('campaign-setup-submit'));
 
+    // Payload now carries the real roster (#2917). The owner is the Host and is
+    // auto-seeded server-side, so guestNames excludes the owner ("Owner") and
+    // contains only the preset guests.
     await waitFor(() =>
-      expect(client.createCampaign).toHaveBeenCalledWith({ gameId: 'g1', title: 'Test campaign' })
+      expect(client.createCampaign).toHaveBeenCalledWith({
+        gameId: 'g1',
+        title: 'Test campaign',
+        guestNames: ['Marco', 'Giulia', 'Luca'],
+      })
     );
+    const payload = vi.mocked(client.createCampaign).mock.calls[0][0];
+    expect(payload.guestNames).not.toContain('Owner');
     await waitFor(() => expect(pushSpy).toHaveBeenCalledWith('/library/g1/play/c1'));
   });
 

--- a/apps/web/src/lib/api/gamebook-campaigns.ts
+++ b/apps/web/src/lib/api/gamebook-campaigns.ts
@@ -101,6 +101,20 @@ export type GamebookCampaignSpine = z.infer<typeof GamebookCampaignSpineSchema>;
 export interface CreateCampaignInput {
   gameId: string;
   title: string;
+  /**
+   * Issue #2917: standalone campaign roster (User-linked participants). The
+   * OWNER (authenticated user) is auto-seeded server-side and MUST NOT be sent
+   * here. Reserved for future use — the MVP FE leaves this empty/undefined and
+   * sends every extra player as a free `guestName`. Omitted fields serialize to
+   * `null` on the wire, which the backend treats as "no participants".
+   */
+  participants?: { userId: string | null; displayName: string }[];
+  /**
+   * Issue #2917: free-guest roster names (everyone but the owner). When both
+   * `participants` and `guestNames` are absent the backend keeps the legacy
+   * campaign-only behavior (backward-compatible).
+   */
+  guestNames?: string[];
 }
 
 async function parseJson<T>(res: Response, schema: z.ZodSchema<T>): Promise<T> {


### PR DESCRIPTION
FE completion for #2917. The backend landed separately in **#2921** (which closed the issue), but the **frontend was never wired** — the campaign setup wizard still sent `{gameId, title}` with static demo-preset chips + a disabled "＋ Aggiungi giocatore". This PR delivers the missing UI so the roster the BE already accepts actually gets sent.

> Rebased onto `main-dev` after #2921; the earlier version of this branch also carried a redundant BE implementation — dropped in favor of the merged #2921 BE. This is now **FE-only** (4 files).

## Changes
- `gamebook-campaigns.ts`: `CreateCampaignInput` `+guestNames` `+participants` (optional). `createCampaign` already serializes the whole input, matching the merged BE's `CreateGamebookCampaignRequest { gameId, title, participants?, guestNames? }`.
- `CampaignSetupDrawer` Step 2: static demo chips + disabled button → shipped `<PlayerSetup>` picker (add/remove/reorder, guests). Roster derived from the preset with **Host = owner's real display name** (`useCurrentUser`), re-synced on preset change / owner-resolve while preserving edits.
- Step 3 confirm now shows the **real roster** (host + guests) that gets persisted, not the static preset.
- Submit sends `guestNames` = every non-Host player (owner is server-seeded); `participants` empty for MVP.

## Verification (against the merged #2921 BE)
- `pnpm typecheck` clean · `CampaignSetupDrawer` **19/19** green (Step 2 rewritten for PlayerSetup, submit asserts `guestNames`, Step 3 asserts the real roster) · PlayerSetup untouched.
- Contract confirmed compatible: FE sends `{gameId, title, guestNames}`; merged BE endpoint accepts `guestNames` (ASP.NET Core case-insensitive JSON binding).

Refs #2917 #2921 #2759