### PR TITLE
fix(security): DTO hides internal flags on POST /game-sessions (#2920)

### DIFF
--- a/apps/api/src/Api/Routing/SessionTracking/SessionCommandEndpoints.cs
+++ b/apps/api/src/Api/Routing/SessionTracking/SessionCommandEndpoints.cs
@@ -1,4 +1,5 @@
 using Api.BoundedContexts.SessionTracking.Application.Commands;
+using Api.BoundedContexts.SessionTracking.Application.DTOs;
 using Api.BoundedContexts.SessionTracking.Domain.Enums;
 using Api.Extensions;
 using MediatR;
@@ -29,14 +30,50 @@ internal static class SessionCommandEndpoints
     /// </summary>
     public record UpdateSessionScoresRequest(ScoreType ScoringType, string ScoreData);
 
+    /// <summary>
+    /// #2920: request body for <c>POST /game-sessions</c>. Deliberately EXCLUDES the internal-only
+    /// orchestration flags on <see cref="CreateSessionCommand"/> — <c>GamebookCampaignId</c>,
+    /// <c>SkipGameNightEnvelope</c>, <c>SkipKbReadinessGate</c> — so a client cannot forge them.
+    /// Those are set only by internal MediatR orchestrators (StartGameNight / AttachGamebookCampaign
+    /// / the standalone gamebook handler). Binding the command directly let a client send e.g.
+    /// <c>skipKbReadinessGate: true</c> to bypass the KB-readiness gate.
+    /// </summary>
+    public record CreateSessionRequest(
+        Guid UserId,
+        Guid GameId,
+        string SessionType,
+        DateTime? SessionDate,
+        string? Location,
+        List<ParticipantDto> Participants,
+        Guid? GameNightEventId = null,
+        IReadOnlyList<string>? GuestNames = null,
+        GameStateTier StateTier = GameStateTier.Minimal)
+    {
+        /// <summary>
+        /// Maps to <see cref="CreateSessionCommand"/>, leaving the internal-only flags
+        /// (<c>GamebookCampaignId</c>, <c>SkipGameNightEnvelope</c>, <c>SkipKbReadinessGate</c>)
+        /// at their safe defaults (<c>null</c>/<c>false</c>/<c>false</c>).
+        /// </summary>
+        public CreateSessionCommand ToCommand() => new(
+            UserId,
+            GameId,
+            SessionType,
+            SessionDate,
+            Location,
+            Participants,
+            GameNightEventId: GameNightEventId,
+            GuestNames: GuestNames,
+            StateTier: StateTier);
+    }
+
     private static void MapCreateSessionEndpoint(RouteGroupBuilder group)
     {
         group.MapPost("/game-sessions", async (
-            CreateSessionCommand command,
+            CreateSessionRequest request,
             IMediator mediator,
             CancellationToken ct) =>
         {
-            var result = await mediator.Send(command, ct).ConfigureAwait(false);
+            var result = await mediator.Send(request.ToCommand(), ct).ConfigureAwait(false);
             return Results.Created($"/api/v1/game-sessions/{result.SessionId}", result);
         })
         .RequireAuthenticatedUser()

--- a/apps/api/tests/Api.Tests/Routing/SessionTracking/CreateSessionRequestTests.cs
+++ b/apps/api/tests/Api.Tests/Routing/SessionTracking/CreateSessionRequestTests.cs
@@ -1,0 +1,65 @@
+using Api.BoundedContexts.SessionTracking.Application.DTOs;
+using Api.Routing;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.Routing.SessionTracking;
+
+/// <summary>
+/// #2920: the POST /game-sessions endpoint binds a request DTO that excludes the internal-only
+/// orchestration flags, so a client cannot forge them. These tests pin that the DTO→command
+/// mapping leaves the flags at their safe defaults while forwarding the legitimate fields.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SessionTracking")]
+public sealed class CreateSessionRequestTests
+{
+    [Fact]
+    public void ToCommand_LeavesInternalFlagsAtSafeDefaults()
+    {
+        var request = new SessionCommandEndpoints.CreateSessionRequest(
+            UserId: Guid.NewGuid(),
+            GameId: Guid.NewGuid(),
+            SessionType: "Standard",
+            SessionDate: null,
+            Location: null,
+            Participants: new List<ParticipantDto>());
+
+        var command = request.ToCommand();
+
+        // The internal-only flags are NOT part of the request DTO, so they are structurally
+        // unforgeable and must always land on their safe defaults.
+        command.SkipKbReadinessGate.Should().BeFalse();
+        command.SkipGameNightEnvelope.Should().BeFalse();
+        command.GamebookCampaignId.Should().BeNull();
+    }
+
+    [Fact]
+    public void ToCommand_PropagatesLegitimateFields()
+    {
+        var userId = Guid.NewGuid();
+        var gameId = Guid.NewGuid();
+        var nightId = Guid.NewGuid();
+        var participants = new List<ParticipantDto> { new() { DisplayName = "Alice", IsOwner = true } };
+
+        var request = new SessionCommandEndpoints.CreateSessionRequest(
+            UserId: userId,
+            GameId: gameId,
+            SessionType: "GameSpecific",
+            SessionDate: null,
+            Location: "Home",
+            Participants: participants,
+            GameNightEventId: nightId,
+            GuestNames: new[] { "Bob" });
+
+        var command = request.ToCommand();
+
+        command.UserId.Should().Be(userId);
+        command.GameId.Should().Be(gameId);
+        command.SessionType.Should().Be("GameSpecific");
+        command.Location.Should().Be("Home");
+        command.Participants.Should().BeEquivalentTo(participants);
+        command.GameNightEventId.Should().Be(nightId);
+        command.GuestNames.Should().NotBeNull().And.Contain("Bob");
+    }
+}


### PR DESCRIPTION
## Summary
Closes #2920. `POST /game-sessions` bound `CreateSessionCommand` directly from the request body, so a client could forge the internal-only orchestration flags — most notably send `skipKbReadinessGate: true` to bypass the KB-readiness 422 gate on ordinary session creation (also `SkipGameNightEnvelope` / `GamebookCampaignId`). The `SkipKbReadinessGate` flag was added by #2917; this closes the hole it rode in on.

## Fix
- New `CreateSessionRequest` DTO that **structurally excludes** the three internal-only flags + a `ToCommand()` that maps to `CreateSessionCommand` with them at safe defaults (`null`/`false`/`false`).
- The endpoint binds the DTO instead of the command. The flags are now settable **only** by internal MediatR orchestrators (StartGameNight / AttachGamebookCampaign / the standalone gamebook handler), never by the HTTP client.

## Tests
- 2 unit tests: `ToCommand` leaves the internal flags at defaults + forwards the legitimate fields. Build 0 errors.
- No endpoint tests POST the create route with those flags → no regression (verified by grep).

## Out of scope
- `UserId` still comes from the request body (unchanged, pre-existing) — a separate impersonation-hardening concern; flag as a follow-up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)