### PR TITLE
feat(mechanic-extractor): LLM model/provider override + force-regenerate + guardrail UX

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/GenerateMechanicAnalysisCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/GenerateMechanicAnalysisCommand.cs
@@ -20,12 +20,25 @@ namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands.MechanicExt
 ///   raises the aggregate's cap to <see cref="CostCapOverrideInput.NewCapUsd"/> immediately after
 ///   creation, preserving the override reason on the aggregate's audit fields
 ///   (<c>CostCapOverrideAt</c>/<c>CostCapOverrideBy</c>/<c>CostCapOverrideReason</c>).</param>
+/// <param name="ModelOverride">#539: optional LLM model override. Routing is by model name
+///   (<c>ILlmClient.SupportsModel</c>), so this alone selects the provider; null → DeepSeek default.</param>
+/// <param name="ProviderOverride">#539: optional provider label recorded for telemetry (e.g. "OpenRouter").</param>
+/// <param name="ForceRegenerate">#539: when true, skips the T7 idempotency short-circuit so a re-run
+///   with a different model creates a new analysis instead of returning the existing one.</param>
 internal record GenerateMechanicAnalysisCommand(
     Guid SharedGameId,
     Guid PdfDocumentId,
     Guid RequestedBy,
     decimal CostCapUsd,
-    CostCapOverrideInput? CostCapOverride = null) : ICommand<MechanicAnalysisGenerationResponseDto>;
+    CostCapOverrideInput? CostCapOverride = null,
+    // #539 eval: optional LLM override. The pipeline routes the provider purely by model name
+    // (ILlmClient.SupportsModel), so supplying ModelOverride is sufficient to switch provider;
+    // ProviderOverride only labels telemetry. Null → the ADR-007 DeepSeek defaults in the handler.
+    string? ModelOverride = null,
+    string? ProviderOverride = null,
+    // #539: bypass the T7 idempotency short-circuit so a re-run (e.g. with a different model)
+    // creates a NEW analysis instead of returning the existing one for the same (game, pdf, prompt).
+    bool ForceRegenerate = false) : ICommand<MechanicAnalysisGenerationResponseDto>;
 
 /// <summary>
 /// Admin-initiated raise of the default cost cap at planning time. Required when the cost

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/GenerateMechanicAnalysisCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/GenerateMechanicAnalysisCommandHandler.cs
@@ -108,6 +108,15 @@ internal sealed class GenerateMechanicAnalysisCommandHandler
 
         var promptVersion = _promptProvider.PromptVersion;
 
+        // #539 eval: resolve the effective provider/model. Null override → ADR-007 DeepSeek default.
+        // Routing is by model name (ILlmClient.SupportsModel), so the model alone selects the provider.
+        var effectiveProvider = string.IsNullOrWhiteSpace(request.ProviderOverride)
+            ? DefaultProvider
+            : request.ProviderOverride.Trim();
+        var effectiveModel = string.IsNullOrWhiteSpace(request.ModelOverride)
+            ? DefaultModel
+            : request.ModelOverride.Trim();
+
         // 1. SharedGame existence (404 if missing).
         var sharedGame = await _sharedGameRepository
             .GetByIdAsync(request.SharedGameId, cancellationToken)
@@ -131,29 +140,34 @@ internal sealed class GenerateMechanicAnalysisCommandHandler
                 resourceId: $"{request.SharedGameId}/{request.PdfDocumentId}");
         }
 
-        // 3. T7 idempotency — return the existing non-rejected analysis unchanged.
-        var existing = await _analysisRepository
-            .FindByPromptVersionAsync(request.SharedGameId, request.PdfDocumentId, promptVersion, cancellationToken)
-            .ConfigureAwait(false);
-        if (existing is not null)
+        // 3. T7 idempotency — return the existing non-rejected analysis unchanged. Skipped when
+        //    ForceRegenerate is set (#539), so a re-run with a different model creates a new row
+        //    instead of short-circuiting to the prior analysis for the same (game, pdf, prompt).
+        if (!request.ForceRegenerate)
         {
-            _logger.LogInformation(
-                "Mechanic analysis idempotent short-circuit: existing {ExistingId} for (SharedGame={SharedGame}, Pdf={Pdf}, PromptVersion={Version}, Status={Status}).",
-                existing.Id,
-                request.SharedGameId,
-                request.PdfDocumentId,
-                promptVersion,
-                existing.Status);
+            var existing = await _analysisRepository
+                .FindByPromptVersionAsync(request.SharedGameId, request.PdfDocumentId, promptVersion, cancellationToken)
+                .ConfigureAwait(false);
+            if (existing is not null)
+            {
+                _logger.LogInformation(
+                    "Mechanic analysis idempotent short-circuit: existing {ExistingId} for (SharedGame={SharedGame}, Pdf={Pdf}, PromptVersion={Version}, Status={Status}).",
+                    existing.Id,
+                    request.SharedGameId,
+                    request.PdfDocumentId,
+                    promptVersion,
+                    existing.Status);
 
-            return BuildResponse(
-                existing.Id,
-                existing.Status,
-                promptVersion,
-                effectiveCostCap: existing.CostCapUsd,
-                estimatedCost: 0m,
-                projectedTotalTokens: 0,
-                costCapOverrideApplied: existing.CostCapOverrideBy is not null,
-                isExisting: true);
+                return BuildResponse(
+                    existing.Id,
+                    existing.Status,
+                    promptVersion,
+                    effectiveCostCap: existing.CostCapUsd,
+                    estimatedCost: 0m,
+                    projectedTotalTokens: 0,
+                    costCapOverrideApplied: existing.CostCapOverrideBy is not null,
+                    isExisting: true);
+            }
         }
 
         // 4. Load retrieval context. M1.2 ships the same bundled rulebook content to every
@@ -173,8 +187,8 @@ internal sealed class GenerateMechanicAnalysisCommandHandler
         var retrievedPromptTokens = retrievalContext.Length / 4;
         var estimate = _costEstimator.Estimate(new AnalysisCostEstimateInput(
             PromptVersion: promptVersion,
-            Provider: DefaultProvider,
-            Model: DefaultModel,
+            Provider: effectiveProvider,
+            Model: effectiveModel,
             Sections: AllSections,
             TotalRetrievedPromptTokens: retrievedPromptTokens,
             InputCostPerMillionTokens: DefaultInputCostPerMillion,
@@ -208,8 +222,8 @@ internal sealed class GenerateMechanicAnalysisCommandHandler
             promptVersion: promptVersion,
             createdBy: request.RequestedBy,
             createdAt: utcNow,
-            modelUsed: DefaultModel,
-            provider: DefaultProvider,
+            modelUsed: effectiveModel,
+            provider: effectiveProvider,
             costCapUsd: request.CostCapUsd);
 
         if (hasOverride)

--- a/apps/api/src/Api/Routing/AdminMechanicAnalysesEndpoints.cs
+++ b/apps/api/src/Api/Routing/AdminMechanicAnalysesEndpoints.cs
@@ -141,7 +141,10 @@ internal static class AdminMechanicAnalysesEndpoints
                 PdfDocumentId: request.PdfDocumentId,
                 RequestedBy: adminId,
                 CostCapUsd: request.CostCapUsd,
-                CostCapOverride: overrideInput);
+                CostCapOverride: overrideInput,
+                ModelOverride: request.Model,
+                ProviderOverride: request.Provider,
+                ForceRegenerate: request.ForceRegenerate);
 
             var response = await mediator.Send(command, ct).ConfigureAwait(false);
 
@@ -403,7 +406,13 @@ internal sealed record GenerateMechanicAnalysisRequest(
     Guid SharedGameId,
     Guid PdfDocumentId,
     decimal CostCapUsd,
-    CostCapOverrideRequest? CostCapOverride = null);
+    CostCapOverrideRequest? CostCapOverride = null,
+    // #539 eval: optional LLM model/provider override (e.g. "meta-llama/llama-3.3-70b-instruct"
+    // → OpenRouter, "qwen2.5:3b" → Ollama). Null falls back to the DeepSeek defaults.
+    string? Model = null,
+    string? Provider = null,
+    // #539: force a fresh run (skip the idempotency short-circuit) — used by the "Regenerate" action.
+    bool ForceRegenerate = false);
 
 /// <summary>
 /// Optional planning-time cost cap override (B3=A). Mirrors

--- a/apps/web/src/app/admin/(dashboard)/knowledge-base/mechanic-extractor/analyses/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/knowledge-base/mechanic-extractor/analyses/page.tsx
@@ -85,7 +85,32 @@ const RUN_STATUS_BADGE_CLASS: Record<number, string> = {
   0: 'bg-green-100 text-green-800 border-green-300', // Succeeded
   1: 'bg-rose-100 text-rose-800 border-rose-300', // Failed
   2: 'bg-muted text-foreground border-border', // SkippedDueToCostCap
+  3: 'bg-amber-100 text-amber-800 border-amber-300', // RetainedWithGuardrailFlags
 };
+
+/** #539: descriptive tooltip for the section-run Status column (what each numeric status means). */
+const SECTION_RUN_STATUS_DESC: Record<number, string> = {
+  0: 'Succeeded — sezione generata e superati tutti i guardrail.',
+  1: 'Failed — la sezione non ha prodotto output valido (JSON malformato dopo i retry, o chiamata LLM in errore/timeout).',
+  2: 'Skipped — sezione saltata perché il costo cumulato ha superato il cost cap.',
+  3: 'Retained with flags — output ben formato ma con guardrail (es. T4) flaggati; conservato in modalità advisory per la review umana.',
+};
+
+/**
+ * #539: LLM model override presets. The pipeline routes the provider purely by model name,
+ * so picking a model here selects the provider. Empty value = server default (DeepSeek).
+ */
+const MODEL_OPTIONS: ReadonlyArray<{ value: string; label: string; provider: string }> = [
+  // `default` is a sentinel (Radix Select forbids empty-string item values) → no override sent.
+  { value: 'default', label: 'Default (DeepSeek · deepseek-chat)', provider: '' },
+  {
+    value: 'meta-llama/llama-3.3-70b-instruct',
+    label: 'OpenRouter · llama-3.3-70b',
+    provider: 'OpenRouter',
+  },
+  { value: 'deepseek-chat', label: 'DeepSeek · deepseek-chat', provider: 'DeepSeek' },
+  { value: 'qwen2.5:3b', label: 'Ollama · qwen2.5:3b (locale)', provider: 'Ollama' },
+];
 
 function formatCurrency(value: number | null | undefined): string {
   if (value == null) return '—';
@@ -128,6 +153,9 @@ export default function MechanicAnalysesPage() {
   const [selectedGameId, setSelectedGameId] = useState('');
   const [selectedPdfId, setSelectedPdfId] = useState('');
   const [costCapUsd, setCostCapUsd] = useState<string>('0.50');
+  // #539: LLM model override + force-regenerate (bypass idempotency).
+  const [selectedModel, setSelectedModel] = useState<string>('default');
+  const [forceRegen, setForceRegen] = useState(false);
   const [overrideEnabled, setOverrideEnabled] = useState(false);
   const [overrideCapUsd, setOverrideCapUsd] = useState<string>('1.00');
   const [overrideReason, setOverrideReason] = useState('');
@@ -230,6 +258,8 @@ export default function MechanicAnalysesPage() {
       if (!Number.isFinite(cap) || cap <= 0) {
         throw new Error('Cost cap must be a positive number');
       }
+      const modelOpt = MODEL_OPTIONS.find(m => m.value === selectedModel);
+      const modelOverride = selectedModel === 'default' ? undefined : selectedModel;
       return adminClient.generateMechanicAnalysis({
         sharedGameId: selectedGameId,
         pdfDocumentId: selectedPdfId,
@@ -240,6 +270,9 @@ export default function MechanicAnalysesPage() {
               reason: overrideReason,
             }
           : undefined,
+        model: modelOverride,
+        provider: modelOpt?.provider || undefined,
+        forceRegenerate: forceRegen || undefined,
       });
     },
     onSuccess: res => {
@@ -455,6 +488,36 @@ export default function MechanicAnalysesPage() {
                   ))}
                 </SelectContent>
               </Select>
+            </div>
+
+            {/* #539: LLM model override + force-regenerate. */}
+            <div>
+              <label className="mb-1.5 block text-sm font-medium text-foreground">
+                Modello LLM
+              </label>
+              <Select value={selectedModel} onValueChange={setSelectedModel}>
+                <SelectTrigger data-testid="model-select">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {MODEL_OPTIONS.map(m => (
+                    <SelectItem key={m.value} value={m.value}>
+                      {m.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <label className="mt-2 flex items-start gap-2 text-xs text-muted-foreground">
+                <input
+                  type="checkbox"
+                  checked={forceRegen}
+                  onChange={e => setForceRegen(e.target.checked)}
+                  className="mt-0.5 h-4 w-4 rounded border-border"
+                  data-testid="force-regen-checkbox"
+                />
+                Rigenera con un nuovo modello (ignora l&apos;idempotenza: crea una nuova analisi
+                anche se ne esiste già una per questo gioco/PDF).
+              </label>
             </div>
 
             <div>
@@ -691,6 +754,7 @@ export default function MechanicAnalysesPage() {
                             <Badge
                               variant="outline"
                               className={RUN_STATUS_BADGE_CLASS[run.status] ?? ''}
+                              title={SECTION_RUN_STATUS_DESC[run.status] ?? undefined}
                             >
                               {MECHANIC_SECTION_RUN_STATUS_LABELS[run.status] ?? run.status}
                             </Badge>

--- a/apps/web/src/components/admin/mechanic-extractor/claims/ClaimsSection.tsx
+++ b/apps/web/src/components/admin/mechanic-extractor/claims/ClaimsSection.tsx
@@ -70,6 +70,33 @@ const VALIDATION_BADGE_CLASS: Record<string, string> = {
 };
 
 /**
+ * #539: human-readable ADR-051 guardrail taxonomy. Drives the per-badge tooltip and the
+ * "Cosa sono i badge" legend so reviewers understand what each T-rule checks.
+ */
+export const GUARDRAIL_DESCRIPTIONS: Record<string, { label: string; desc: string }> = {
+  T1: {
+    label: 'T1 · Quote cap',
+    desc: 'Ogni citazione (quote) deve essere breve (≤ N parole): nessuna copia verbatim lunga.',
+  },
+  T2: {
+    label: 'T2 · No long-verbatim',
+    desc: 'Il testo del claim non deve ricopiare alla lettera lunghe sequenze del regolamento (anti-plagio / tutela IP).',
+  },
+  T3a: {
+    label: 'T3a · Citazione presente',
+    desc: 'Ogni affermazione deve portare almeno una citazione della fonte.',
+  },
+  T3b: {
+    label: 'T3b · Grounding semantico',
+    desc: 'Il claim deve essere semanticamente coerente col chunk citato (similarità coseno sopra soglia).',
+  },
+  T4: {
+    label: 'T4 · Pagina/substring',
+    desc: 'La pagina citata deve esistere nel PDF e la quote deve essere un estratto reale di quella pagina.',
+  },
+};
+
+/**
  * Renders one Badge per template validation rule (T1-T4) with pass/fail/notRun
  * styling. Exported for direct unit testing and reuse across claim rows.
  */
@@ -88,16 +115,43 @@ export function ValidationBadges({
           className={VALIDATION_BADGE_CLASS[v.outcome] ?? VALIDATION_BADGE_CLASS.notRun}
           data-testid={`claim-validation-badge-${v.rule}`}
           aria-label={`${v.rule} ${v.outcome}${v.score != null ? ` score ${v.score.toFixed(2)}` : ''}${v.message ? `: ${v.message}` : ''}`}
-          title={
-            v.score != null
-              ? `${v.rule} ${v.outcome} (score ${v.score.toFixed(2)})`
-              : (v.message ?? `${v.rule} ${v.outcome}`)
-          }
+          title={`${GUARDRAIL_DESCRIPTIONS[v.rule]?.label ?? v.rule} — ${GUARDRAIL_DESCRIPTIONS[v.rule]?.desc ?? ''}\nEsito: ${v.outcome}${v.score != null ? ` (score ${v.score.toFixed(2)})` : ''}${v.message ? `\n${v.message}` : ''}`}
         >
           {v.outcome === 'pass' ? '✓' : v.outcome === 'fail' ? '✗' : '—'} {v.rule}
         </Badge>
       ))}
     </span>
+  );
+}
+
+/**
+ * #539: expandable legend explaining the T1-T4 guardrails + how claims are produced.
+ * Rendered once above the claim list so reviewers understand the ✓/✗/— badges.
+ */
+export function ValidationLegend(): React.JSX.Element {
+  return (
+    <details className="rounded-md border border-border bg-muted/40 p-3 text-xs dark:border-zinc-700 dark:bg-zinc-800/40">
+      <summary className="cursor-pointer font-medium text-foreground">
+        Cosa sono i badge T1–T4? (guardrail di qualità)
+      </summary>
+      <p className="mt-2 text-muted-foreground">
+        Ogni sezione è generata dall&apos;LLM come JSON (affermazioni + citazioni); una catena di
+        guardrail valida poi ogni claim. Esito badge: <span className="font-medium">✓</span>{' '}
+        superato
+        {' · '}
+        <span className="font-medium">✗</span> fallito
+        {' · '}
+        <span className="font-medium">—</span> non eseguito.
+      </p>
+      <ul className="mt-2 space-y-1">
+        {Object.values(GUARDRAIL_DESCRIPTIONS).map(g => (
+          <li key={g.label}>
+            <span className="font-medium text-foreground">{g.label}</span>{' '}
+            <span className="text-muted-foreground">— {g.desc}</span>
+          </li>
+        ))}
+      </ul>
+    </details>
   );
 }
 
@@ -360,6 +414,8 @@ export function ClaimsSection({
           </Select>
         )}
       </div>
+
+      <ValidationLegend />
 
       {actionError && (
         <div

--- a/apps/web/src/components/admin/mechanic-extractor/claims/__tests__/ClaimsSection.legend.test.tsx
+++ b/apps/web/src/components/admin/mechanic-extractor/claims/__tests__/ClaimsSection.legend.test.tsx
@@ -1,0 +1,30 @@
+/** @vitest-environment jsdom */
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { GUARDRAIL_DESCRIPTIONS, ValidationBadges, ValidationLegend } from '../ClaimsSection';
+
+describe('ValidationLegend (#539)', () => {
+  it('renders the guardrail taxonomy with a label per T-rule', () => {
+    render(<ValidationLegend />);
+    expect(screen.getByText(/Cosa sono i badge/i)).toBeInTheDocument();
+    for (const { label } of Object.values(GUARDRAIL_DESCRIPTIONS)) {
+      expect(screen.getByText(label)).toBeInTheDocument();
+    }
+  });
+
+  it('covers the five ADR-051 guardrail families', () => {
+    expect(Object.keys(GUARDRAIL_DESCRIPTIONS)).toEqual(
+      expect.arrayContaining(['T1', 'T2', 'T3a', 'T3b', 'T4'])
+    );
+  });
+});
+
+describe('ValidationBadges tooltip (#539)', () => {
+  it('embeds the guardrail description + outcome in the badge title', () => {
+    render(<ValidationBadges validations={[{ rule: 'T4', outcome: 'fail', message: null }]} />);
+    const badge = screen.getByTestId('claim-validation-badge-T4');
+    expect(badge).toHaveAttribute('title', expect.stringContaining('Pagina/substring'));
+    expect(badge).toHaveAttribute('title', expect.stringContaining('Esito: fail'));
+  });
+});

--- a/apps/web/src/lib/api/schemas/mechanic-analyses.schemas.ts
+++ b/apps/web/src/lib/api/schemas/mechanic-analyses.schemas.ts
@@ -331,6 +331,12 @@ export interface GenerateMechanicAnalysisRequest {
   pdfDocumentId: string;
   costCapUsd: number;
   costCapOverride?: CostCapOverrideRequest;
+  /** #539: LLM model override (routes provider by name, e.g. "meta-llama/llama-3.3-70b-instruct" → OpenRouter, "qwen2.5:3b" → Ollama). Null → DeepSeek default. */
+  model?: string;
+  /** #539: provider label for telemetry (e.g. "OpenRouter", "Ollama"). */
+  provider?: string;
+  /** #539: skip the idempotency short-circuit so a re-run with a different model creates a new analysis. */
+  forceRegenerate?: boolean;
 }
 
 export interface SuppressMechanicAnalysisRequest {


### PR DESCRIPTION
## Cosa

Consente a un admin di **eseguire/confrontare la stessa analisi Mechanic Extractor con LLM diversi** dalla pagina admin, e di rigenerare bypassando l'idempotenza. Nasce dal test end-to-end della pipeline ME (ADR-051) con AI esterna.

Il routing del pipeline è **per nome-modello** (`ILlmClient.SupportsModel`), quindi basta il modello a selezionare il provider: DeepSeek (default), OpenRouter (`meta-llama/llama-3.3-70b-instruct`), Ollama (`qwen2.5:3b`).

## Backend
- `GenerateMechanicAnalysisCommand`/`GenerateMechanicAnalysisRequest`: nuovi campi opzionali `ModelOverride`, `ProviderOverride`, `ForceRegenerate`.
- Handler: risolve provider/model effettivi (null → default DeepSeek ADR-007); `ForceRegenerate` salta lo short-circuit di idempotenza T7 (una re-run con modello diverso crea una nuova analisi).

## Frontend (pagina admin Mechanic Analyses)
- Selettore **Modello LLM** + checkbox **Rigenera (force)** sul form di generazione.
- **Tooltip descrittivo** sulla colonna Status delle section-runs (Succeeded / Failed / Skipped / Retained-with-flags).
- **Legenda espandibile T1–T4** + tooltip per-badge arricchiti che spiegano cosa controlla ogni guardrail e come nascono i claim.

## Test
- Backend: `dotnet build` verde.
- Frontend: `typecheck` pulito, `lint` 0 errori, nuovo test vitest `ClaimsSection.legend` (3/3).

## Fuori scope (follow-up)
Override del **contenuto** del prompt (prompt custom/alternativi): il prompt è un unico template embedded `v1.0.0`, quindi il contenuto per-run richiede persistenza + threading nell'executor async — da fare in una issue dedicata.

## Contesto
Emerso lavorando su ADR-051 / Mechanic Extractor (epic tracking di riferimento non linkata qui di proposito per non auto-chiuderla al merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
