### PR TITLE
fix(knowledge-base): serialize KB nav-counts queries to avoid DbContext concurrency 500

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbNavCounts/GetKbNavCountsQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetKbNavCounts/GetKbNavCountsQueryHandler.cs
@@ -33,14 +33,21 @@ internal sealed class GetKbNavCountsQueryHandler
         var asOf = _clock.GetUtcNow();
         var since = asOf.UtcDateTime - FeedbackWindow;
 
-        var queueTask = _jobs.CountByStatusesAsync(ActiveStatuses, cancellationToken);
-        var feedbackTask = _feedback.CountSinceAsync(since, cancellationToken);
-
-        await Task.WhenAll(queueTask, feedbackTask).ConfigureAwait(false);
+        // NOTE: these two counts MUST be awaited sequentially. Both repositories share the same
+        // scoped MeepleAiDbContext, and EF Core's DbContext is not thread-safe — running them
+        // concurrently via Task.WhenAll throws "A second operation was started on this context
+        // instance before a previous operation completed" (HTTP 500). The counts are cheap, so the
+        // extra round-trip is negligible.
+        var processingQueue = await _jobs
+            .CountByStatusesAsync(ActiveStatuses, cancellationToken)
+            .ConfigureAwait(false);
+        var feedback7d = await _feedback
+            .CountSinceAsync(since, cancellationToken)
+            .ConfigureAwait(false);
 
         return new KbNavCountsDto(
-            ProcessingQueue: await queueTask.ConfigureAwait(false),
-            Feedback7d: await feedbackTask.ConfigureAwait(false),
+            ProcessingQueue: processingQueue,
+            Feedback7d: feedback7d,
             AsOf: asOf);
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetKbNavCounts/GetKbNavCountsQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetKbNavCounts/GetKbNavCountsQueryHandlerTests.cs
@@ -67,28 +67,34 @@ public sealed class GetKbNavCountsQueryHandlerTests
     }
 
     [Fact]
-    public async Task Handle_RunsCountQueriesInParallel()
+    public async Task Handle_RunsCountQueriesSequentially()
     {
+        // Regression guard for the KB nav-counts 500: both repositories share the same
+        // scoped MeepleAiDbContext, which is NOT thread-safe. The handler must await the
+        // two counts sequentially — running them concurrently (Task.WhenAll) throws
+        // "A second operation was started on this context instance...". So while the
+        // queue count is still pending, the feedback count must NOT have started.
         var queueTcs = new TaskCompletionSource<int>();
         _jobs.CountByStatusesAsync(Arg.Any<IReadOnlyList<JobStatus>>(), Arg.Any<CancellationToken>())
             .Returns(queueTcs.Task);
         _feedback.CountSinceAsync(Arg.Any<DateTime>(), Arg.Any<CancellationToken>())
-            .Returns(0);
+            .Returns(9);
 
         var task = _sut.Handle(new GetKbNavCountsQuery(), CancellationToken.None);
 
-        // Give the scheduler a chance to enter both awaits
+        // Give the scheduler a chance to reach the first (still-pending) await.
         await Task.Yield();
 
-        // If the handler called repos sequentially it would still be on the first await
-        // and the feedback call would never have happened.
-        await _feedback.Received(1).CountSinceAsync(Arg.Any<DateTime>(), Arg.Any<CancellationToken>());
+        // Sequential: the feedback count must not run while the queue count is pending.
+        await _feedback.DidNotReceive().CountSinceAsync(Arg.Any<DateTime>(), Arg.Any<CancellationToken>());
 
-        queueTcs.SetResult(1);
+        // Completing the queue count lets the feedback count run.
+        queueTcs.SetResult(4);
         var result = await task;
 
-        result.ProcessingQueue.Should().Be(1);
-        result.Feedback7d.Should().Be(0);
+        await _feedback.Received(1).CountSinceAsync(Arg.Any<DateTime>(), Arg.Any<CancellationToken>());
+        result.ProcessingQueue.Should().Be(4);
+        result.Feedback7d.Should().Be(9);
     }
 
     [Fact]


### PR DESCRIPTION
## Bug
`GET /api/v1/admin/kb/nav-counts` returned **500** on every KB admin page load:
> System.InvalidOperationException: A second operation was started on this context instance before a previous operation completed.

`GetKbNavCountsQueryHandler` ran the processing-queue count and the feedback count concurrently via `Task.WhenAll`, but both repositories share the same scoped `MeepleAiDbContext` — EF Core's `DbContext` is not thread-safe. It's a race (the two queries don't always overlap), so it fired intermittently and surfaced to the admin as an "unexpected error" toast on the Knowledge Base explorer.

## Fix
Await the two (cheap) COUNT queries **sequentially**.

## Test
Replaced `Handle_RunsCountQueriesInParallel` (which pinned the buggy parallel behavior) with `Handle_RunsCountQueriesSequentially`: while the queue count is still pending, the feedback count must not have started.

## Context
Found while testing the admin KB doc viewer — selecting a game surfaced the "unexpected error" toast. The doc-content endpoint (`GET /kb-docs/{id}`) itself works (returns 200 for a Ready doc); the empty content panel in that report was a stale `?doc=<non-existent-id>` (404) plus this nav-counts 500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
