### PR TITLE
feat(mechanic-extractor): add Setup, Components and End-game/Scoring sections (v1.1.0)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/GenerateMechanicAnalysisCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/GenerateMechanicAnalysisCommandHandler.cs
@@ -55,7 +55,10 @@ internal sealed class GenerateMechanicAnalysisCommandHandler
         MechanicSection.Victory,
         MechanicSection.Resources,
         MechanicSection.Phases,
-        MechanicSection.Faq
+        MechanicSection.Faq,
+        MechanicSection.Setup,
+        MechanicSection.Components,
+        MechanicSection.EndgameScoring
     };
 
     private readonly IMechanicAnalysisRepository _analysisRepository;

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/MechanicExtractor/GetPublishedMechanicCardByGameQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/MechanicExtractor/GetPublishedMechanicCardByGameQueryHandler.cs
@@ -92,7 +92,23 @@ internal sealed class GetPublishedMechanicCardByGameQueryHandler
             DocumentName: apa.DocumentName);
     }
 
-    // Unknown section names sort last (defensive; the snapshot only writes enum names).
+    // Logical reading order for the card (v1.1.0: Setup/Components float up near the top since their
+    // enum values are append-only 6/7). Mirrors the FE MECHANIC_SECTION_DISPLAY_ORDER map. Unknown
+    // section names sort last (defensive; the snapshot only writes enum names).
     private static int SectionOrder(string section) =>
-        Enum.TryParse<MechanicSection>(section, ignoreCase: false, out var parsed) ? (int)parsed : int.MaxValue;
+        Enum.TryParse<MechanicSection>(section, ignoreCase: false, out var parsed)
+            ? parsed switch
+            {
+                MechanicSection.Summary => 0,
+                MechanicSection.Setup => 1,
+                MechanicSection.Components => 2,
+                MechanicSection.Mechanics => 3,
+                MechanicSection.Resources => 4,
+                MechanicSection.Phases => 5,
+                MechanicSection.Victory => 6,
+                MechanicSection.EndgameScoring => 7,
+                MechanicSection.Faq => 8,
+                _ => int.MaxValue
+            }
+            : int.MaxValue;
 }

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/EmbeddedMechanicPromptProvider.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/EmbeddedMechanicPromptProvider.cs
@@ -15,7 +15,9 @@ internal sealed class EmbeddedMechanicPromptProvider : IMechanicPromptProvider
     private static readonly Assembly Assembly = typeof(EmbeddedMechanicPromptProvider).Assembly;
     private readonly ConcurrentDictionary<string, string> _cache = new(StringComparer.Ordinal);
 
-    public string PromptVersion => "v1.0.0";
+    // v1.1.0 (#539 follow-up): added Setup / Components / EndgameScoring sections. Bumping the
+    // version so idempotency (FindByPromptVersionAsync) treats new runs as distinct from v1.0.0.
+    public string PromptVersion => "v1.1.0";
 
     public string GetSystemPrompt() => LoadResource("system.md");
 
@@ -29,6 +31,9 @@ internal sealed class EmbeddedMechanicPromptProvider : IMechanicPromptProvider
             MechanicSection.Resources => "resources.md",
             MechanicSection.Phases => "phases.md",
             MechanicSection.Faq => "faq.md",
+            MechanicSection.Setup => "setup.md",
+            MechanicSection.Components => "components.md",
+            MechanicSection.EndgameScoring => "endgame.md",
             _ => throw new ArgumentOutOfRangeException(nameof(section), section, "Unknown Mechanic section.")
         };
 

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/MechanicAnalysisExecutor.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/MechanicAnalysisExecutor.cs
@@ -51,7 +51,10 @@ internal sealed class MechanicAnalysisExecutor : IMechanicAnalysisExecutor
         MechanicSection.Victory,
         MechanicSection.Resources,
         MechanicSection.Phases,
-        MechanicSection.Faq
+        MechanicSection.Faq,
+        MechanicSection.Setup,
+        MechanicSection.Components,
+        MechanicSection.EndgameScoring
     };
 
     private readonly IMechanicAnalysisRepository _analysisRepository;

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/MechanicOutputParser.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/MechanicOutputParser.cs
@@ -5,7 +5,7 @@ using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
 namespace Api.BoundedContexts.SharedGameCatalog.Application.Services.MechanicExtractor;
 
 /// <summary>
-/// Parses the six section-level JSON envelopes emitted by the Mechanic Extractor pipeline
+/// Parses the nine section-level JSON envelopes emitted by the Mechanic Extractor pipeline
 /// into a flat list of <see cref="MechanicClaim"/> entities ready to be attached to a
 /// <see cref="Domain.Aggregates.MechanicAnalysis"/> aggregate.
 /// </summary>
@@ -75,6 +75,9 @@ internal static class MechanicOutputParser
                     MechanicSection.Resources => ParseResources(analysisId, root),
                     MechanicSection.Phases => ParsePhases(analysisId, root),
                     MechanicSection.Faq => ParseFaq(analysisId, root),
+                    MechanicSection.Setup => ParseSetup(analysisId, root),
+                    MechanicSection.Components => ParseComponents(analysisId, root),
+                    MechanicSection.EndgameScoring => ParseEndgame(analysisId, root),
                     _ => Array.Empty<MechanicClaim>()
                 };
 
@@ -427,6 +430,195 @@ internal static class MechanicOutputParser
                 claimId: claimId,
                 analysisId: analysisId,
                 section: MechanicSection.Faq,
+                text: text,
+                displayOrder: displayOrder++,
+                citations: citations,
+                sourceAnchor: anchor);
+        }
+    }
+
+    // ============================================================
+    // Section: Setup (v1.1.0)
+    // Schema: { "setup": [{ "description": "...", "order": 1, "playerCountNote": "...", "citations": [...] }] }
+    // Emitted in declared `order`; falls back to source array order when missing/duplicate.
+    // ============================================================
+    private static IEnumerable<MechanicClaim> ParseSetup(Guid analysisId, JsonElement root)
+    {
+        if (!root.TryGetProperty("setup", out var items) || items.ValueKind != JsonValueKind.Array)
+        {
+            yield break;
+        }
+
+        var buffered = new List<(int? Order, int SourceIndex, JsonElement Element)>();
+        var sourceIndex = 0;
+        foreach (var item in items.EnumerateArray())
+        {
+            if (item.ValueKind != JsonValueKind.Object)
+            {
+                sourceIndex++;
+                continue;
+            }
+
+            int? order = null;
+            if (item.TryGetProperty("order", out var orderEl)
+                && orderEl.ValueKind == JsonValueKind.Number
+                && orderEl.TryGetInt32(out var parsedOrder))
+            {
+                order = parsedOrder;
+            }
+
+            buffered.Add((order, sourceIndex, item));
+            sourceIndex++;
+        }
+
+        var ordered = buffered
+            .OrderBy(x => x.Order ?? int.MaxValue)
+            .ThenBy(x => x.SourceIndex);
+
+        var displayOrder = 0;
+        foreach (var (_, srcIdx, item) in ordered)
+        {
+            var description = ReadString(item, "description");
+            if (string.IsNullOrWhiteSpace(description))
+            {
+                continue;
+            }
+
+            var claimId = Guid.NewGuid();
+            var citations = ExtractCitations(item, claimId).ToList();
+            if (citations.Count == 0)
+            {
+                continue;
+            }
+
+            var note = ReadString(item, "playerCountNote");
+            var text = string.IsNullOrWhiteSpace(note)
+                ? description!
+                : $"{description!.Trim()} ({note!.Trim()})";
+
+            yield return BuildClaim(
+                claimId: claimId,
+                analysisId: analysisId,
+                section: MechanicSection.Setup,
+                text: text,
+                displayOrder: displayOrder++,
+                citations: citations,
+                sourceAnchor: $"$.setup[{srcIdx}]");
+        }
+    }
+
+    // ============================================================
+    // Section: Components (v1.1.0)
+    // Schema: { "components": [{ "name": "...", "description": "...", "quantity": "...", "citations": [...] }] }
+    // ============================================================
+    private static IEnumerable<MechanicClaim> ParseComponents(Guid analysisId, JsonElement root)
+    {
+        if (!root.TryGetProperty("components", out var items) || items.ValueKind != JsonValueKind.Array)
+        {
+            yield break;
+        }
+
+        var sourceIndex = 0;
+        var displayOrder = 0;
+        foreach (var item in items.EnumerateArray())
+        {
+            var anchor = $"$.components[{sourceIndex}]";
+            sourceIndex++;
+
+            if (item.ValueKind != JsonValueKind.Object)
+            {
+                continue;
+            }
+
+            var description = ReadString(item, "description");
+            if (string.IsNullOrWhiteSpace(description))
+            {
+                continue;
+            }
+
+            var claimId = Guid.NewGuid();
+            var citations = ExtractCitations(item, claimId).ToList();
+            if (citations.Count == 0)
+            {
+                continue;
+            }
+
+            var name = ReadString(item, "name");
+            var quantity = ReadString(item, "quantity");
+            string? label;
+            if (string.IsNullOrWhiteSpace(quantity))
+            {
+                label = string.IsNullOrWhiteSpace(name) ? null : name!.Trim();
+            }
+            else if (string.IsNullOrWhiteSpace(name))
+            {
+                label = $"×{quantity!.Trim()}";
+            }
+            else
+            {
+                label = $"{name!.Trim()} (×{quantity!.Trim()})";
+            }
+
+            var text = string.IsNullOrWhiteSpace(label)
+                ? description!
+                : $"{label}: {description!.Trim()}";
+
+            yield return BuildClaim(
+                claimId: claimId,
+                analysisId: analysisId,
+                section: MechanicSection.Components,
+                text: text,
+                displayOrder: displayOrder++,
+                citations: citations,
+                sourceAnchor: anchor);
+        }
+    }
+
+    // ============================================================
+    // Section: EndgameScoring (v1.1.0)
+    // Schema: { "endgame": [{ "name": "...", "description": "...", "citations": [...] }] }
+    // ============================================================
+    private static IEnumerable<MechanicClaim> ParseEndgame(Guid analysisId, JsonElement root)
+    {
+        if (!root.TryGetProperty("endgame", out var items) || items.ValueKind != JsonValueKind.Array)
+        {
+            yield break;
+        }
+
+        var sourceIndex = 0;
+        var displayOrder = 0;
+        foreach (var item in items.EnumerateArray())
+        {
+            var anchor = $"$.endgame[{sourceIndex}]";
+            sourceIndex++;
+
+            if (item.ValueKind != JsonValueKind.Object)
+            {
+                continue;
+            }
+
+            var description = ReadString(item, "description");
+            if (string.IsNullOrWhiteSpace(description))
+            {
+                continue;
+            }
+
+            var claimId = Guid.NewGuid();
+            var citations = ExtractCitations(item, claimId).ToList();
+            if (citations.Count == 0)
+            {
+                continue;
+            }
+
+            var name = ReadString(item, "name");
+            var text = string.IsNullOrWhiteSpace(name)
+                ? description!
+                : $"{name!.Trim()}: {description!.Trim()}";
+
+            yield return BuildClaim(
+                claimId: claimId,
+                analysisId: analysisId,
+                section: MechanicSection.EndgameScoring,
                 text: text,
                 displayOrder: displayOrder++,
                 citations: citations,

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Enums/MechanicSection.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Enums/MechanicSection.cs
@@ -11,5 +11,11 @@ public enum MechanicSection
     Victory = 2,
     Resources = 3,
     Phases = 4,
-    Faq = 5
+    Faq = 5,
+    // v1.1.0 (#539 follow-up): values are persisted as int — APPEND only, never renumber.
+    // Display order is controlled separately (Setup/Components render high in the card, not at
+    // the tail); see the FE section-order map + the card grouping.
+    Setup = 6,
+    Components = 7,
+    EndgameScoring = 8
 }

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Prompts/MechanicExtractor/v1/components.md
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Prompts/MechanicExtractor/v1/components.md
@@ -1,0 +1,37 @@
+# Components Section (v1.1.0)
+
+Extract the **physical game components** (the box contents / materials list).
+
+## Output schema
+
+```json
+{
+  "components": [
+    {
+      "name": "string (component name, Italiano or original)",
+      "description": "string (Italiano, ≤200 chars, what it is / what it is for)",
+      "quantity": "string (optional, e.g. '100', '4 per giocatore')",
+      "citations": [
+        {
+          "pdf_page": 2,
+          "quote": "string ≤25 words",
+          "chunk_id": "string (optional)"
+        }
+      ]
+    }
+  ]
+}
+```
+
+## Field rules
+
+- `name`: The component name (e.g. "Tessere", "Plancia giocatore", "Segnalini punteggio").
+- `description`: Short Italiano note on what it is or its role. Reformulate, do not transcribe.
+- `quantity`: Optional. As stated in the rulebook (a number or a per-player expression).
+- `citations`: At least one citation per component.
+
+## Extraction guidance
+
+- Extract the **physical inventory** described in the components/contents section of the rulebook.
+- Between **0 and 20 components**. Merge trivial duplicates into one entry.
+- This is the physical materials list — abstract resources/currencies spent during play belong to the Resources section.

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Prompts/MechanicExtractor/v1/endgame.md
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Prompts/MechanicExtractor/v1/endgame.md
@@ -1,0 +1,36 @@
+# End of Game & Scoring Section (v1.1.0)
+
+Extract **when the game ends** and **how final scoring works**.
+
+## Output schema
+
+```json
+{
+  "endgame": [
+    {
+      "name": "string (short Italiano label, e.g. 'Trigger di fine partita', 'Punteggio maggioranze')",
+      "description": "string (Italiano, reformulated, ≤280 chars)",
+      "citations": [
+        {
+          "pdf_page": 12,
+          "quote": "string ≤25 words",
+          "chunk_id": "string (optional)"
+        }
+      ]
+    }
+  ]
+}
+```
+
+## Field rules
+
+- `name`: A short label for an end-of-game trigger or a scoring rule.
+- `description`: Italiano, reformulated explanation of the end condition or how those points are scored.
+- `citations`: At least one citation per entry.
+
+## Extraction guidance
+
+- Include (a) the **end-of-game trigger(s)** — what causes the game to end — and (b) the **final scoring rules** — how points are counted at the end.
+- Between **1 and 10 entries**.
+- The primary *win* condition (who wins) belongs to the Victory section; here focus on the end trigger and the scoring breakdown.
+- Do not invent scoring not stated in the retrieved chunks.

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Prompts/MechanicExtractor/v1/setup.md
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Prompts/MechanicExtractor/v1/setup.md
@@ -1,0 +1,38 @@
+# Setup Section (v1.1.0)
+
+Extract the **one-time pre-game setup steps** players perform BEFORE play begins.
+
+## Output schema
+
+```json
+{
+  "setup": [
+    {
+      "description": "string (Italiano, reformulated setup step, ≤240 chars)",
+      "order": 1,
+      "playerCountNote": "string (optional, Italiano — how the step changes with player count)",
+      "citations": [
+        {
+          "pdf_page": 3,
+          "quote": "string ≤25 words",
+          "chunk_id": "string (optional)"
+        }
+      ]
+    }
+  ]
+}
+```
+
+## Field rules
+
+- `description`: Italiano, reformulated. A single preparation step (board layout, decks, starting resources/hand, player positions, tokens).
+- `order`: Integer, 1-based, in the order the rulebook performs setup.
+- `playerCountNote`: Optional. Only when the step differs by player count (e.g. "con 2 giocatori si rimuovono 20 tessere").
+- `citations`: At least one citation per step.
+
+## Extraction guidance
+
+- Extract only the **one-time PRE-game preparation**. Do NOT include recurring turn/round phases — those belong to the Phases section.
+- Between **0 and 15 steps**, in setup order (use `order` starting at 1).
+- Keep each step atomic. Merge "shuffle the deck and deal 4 cards" into one step unless the rulebook treats them as separate.
+- Omit the `setup` field entirely if the rulebook has no distinct setup (rare).

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/MechanicOutputParserV11SectionsTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/MechanicOutputParserV11SectionsTests.cs
@@ -1,0 +1,92 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Services.MechanicExtractor;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Services.MechanicExtractor;
+
+// v1.1.0 (#539 follow-up): Setup / Components / EndgameScoring sections.
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public class MechanicOutputParserV11SectionsTests
+{
+    [Fact]
+    public void Parse_Setup_OrdersByDeclaredOrder_AndAppendsPlayerCountNote()
+    {
+        // item[0] has order=2, item[1] has order=1 → item[1] must be emitted first, with its
+        // playerCountNote appended and the RAW source-index anchor ($.setup[1]).
+        var json = """
+        {"setup":[
+          {"description":"Distribuisci le plance","order":2,"citations":[{"pdf_page":3,"quote":"plance ai giocatori"}]},
+          {"description":"Prepara il sacchetto","order":1,"playerCountNote":"in 2 rimuovi 20 tessere","citations":[{"pdf_page":3,"quote":"riempi il sacchetto"}]}
+        ]}
+        """;
+        var outputs = new Dictionary<MechanicSection, string> { [MechanicSection.Setup] = json };
+
+        var claims = MechanicOutputParser.Parse(Guid.NewGuid(), outputs);
+
+        claims.Should().HaveCount(2);
+        claims.Should().OnlyContain(c => c.Section == MechanicSection.Setup);
+        claims[0].Text.Should().Contain("Prepara il sacchetto").And.Contain("in 2 rimuovi 20 tessere");
+        claims[0].SourceAnchor.Should().Be("$.setup[1]");
+        claims[1].Text.Should().Contain("Distribuisci le plance");
+    }
+
+    [Fact]
+    public void Parse_Components_IncludesNameAndQuantity()
+    {
+        var json = """
+        {"components":[
+          {"name":"Tessere","description":"pezzi in ceramica","quantity":"100","citations":[{"pdf_page":2,"quote":"cento tessere"}]}
+        ]}
+        """;
+        var outputs = new Dictionary<MechanicSection, string> { [MechanicSection.Components] = json };
+
+        var claims = MechanicOutputParser.Parse(Guid.NewGuid(), outputs);
+
+        claims.Should().ContainSingle();
+        claims[0].Section.Should().Be(MechanicSection.Components);
+        claims[0].Text.Should().Contain("Tessere").And.Contain("100").And.Contain("pezzi in ceramica");
+        claims[0].SourceAnchor.Should().Be("$.components[0]");
+    }
+
+    [Fact]
+    public void Parse_Endgame_EmitsNamedScoringClaimsWithRawAnchors()
+    {
+        var json = """
+        {"endgame":[
+          {"name":"Trigger","description":"finisce quando un giocatore completa una riga","citations":[{"pdf_page":9,"quote":"riga completata"}]},
+          {"description":"punti per colonne complete","citations":[{"pdf_page":9,"quote":"colonne complete"}]}
+        ]}
+        """;
+        var outputs = new Dictionary<MechanicSection, string> { [MechanicSection.EndgameScoring] = json };
+
+        var claims = MechanicOutputParser.Parse(Guid.NewGuid(), outputs);
+
+        claims.Should().HaveCount(2);
+        claims.Should().OnlyContain(c => c.Section == MechanicSection.EndgameScoring);
+        claims[0].Text.Should().StartWith("Trigger:");
+        claims[0].SourceAnchor.Should().Be("$.endgame[0]");
+        claims[1].SourceAnchor.Should().Be("$.endgame[1]");
+    }
+
+    [Fact]
+    public void Parse_NewSection_DropsItemsWithoutCitations()
+    {
+        // Domain factory requires ≥1 citation (ADR-051 T3) — items without one are dropped.
+        var json = """
+        {"components":[
+          {"name":"NoCite","description":"manca la citazione"},
+          {"name":"Good","description":"con citazione","citations":[{"pdf_page":2,"quote":"ok"}]}
+        ]}
+        """;
+        var outputs = new Dictionary<MechanicSection, string> { [MechanicSection.Components] = json };
+
+        var claims = MechanicOutputParser.Parse(Guid.NewGuid(), outputs);
+
+        claims.Should().ContainSingle();
+        claims[0].Text.Should().Contain("Good");
+        claims[0].SourceAnchor.Should().Be("$.components[1]");
+    }
+}

--- a/apps/web/src/app/admin/(dashboard)/knowledge-base/mechanic-extractor/analyses/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/knowledge-base/mechanic-extractor/analyses/page.tsx
@@ -132,8 +132,8 @@ function isPipelineRunning(status: MechanicAnalysisStatusDto | null | undefined)
   //   - PartiallyExtracted: ADR-051 Sprint 2 salvage state (also terminal)
   if (status.status !== MechanicAnalysisStatus.Draft) return false;
   if (status.sectionRuns.length === 0) return true;
-  // All 6 sections should complete; stop when each has a completedAt.
-  return status.sectionRuns.length < 6;
+  // All 9 sections should complete; stop when each has a completedAt (v1.1.0 added Setup/Components/Endgame).
+  return status.sectionRuns.length < 9;
 }
 
 export default function MechanicAnalysesPage() {
@@ -379,7 +379,7 @@ export default function MechanicAnalysesPage() {
           variant="outline"
           className="mt-2 border-sky-300 bg-sky-50 text-sky-800 dark:bg-sky-950/30 dark:text-sky-300"
         >
-          <SparklesIcon className="mr-1 h-3 w-3" />6 sections · cost-cap enforced
+          <SparklesIcon className="mr-1 h-3 w-3" />9 sections · cost-cap enforced
         </Badge>
       </div>
 

--- a/apps/web/src/components/admin/mechanic-extractor/claims/ClaimsSection.tsx
+++ b/apps/web/src/components/admin/mechanic-extractor/claims/ClaimsSection.tsx
@@ -35,6 +35,7 @@ import { createAdminClient } from '@/lib/api/clients/adminClient';
 import { HttpClient } from '@/lib/api/core/httpClient';
 import {
   MECHANIC_CLAIM_STATUS_LABELS,
+  MECHANIC_SECTION_DISPLAY_ORDER,
   MECHANIC_SECTION_LABELS,
   MechanicClaimStatus,
   type MechanicClaimDto,
@@ -221,8 +222,11 @@ export function ClaimsSection({
       arr.push(c);
       map.set(key, arr);
     }
-    // Stable section ordering by enum number; claims by displayOrder within.
-    const orderedKeys = Array.from(map.keys()).sort((a, b) => a - b);
+    // Section ordering by logical display order (v1.1.0: Setup/Components float up near the top,
+    // since their enum values are append-only 6/7); claims by displayOrder within.
+    const orderedKeys = Array.from(map.keys()).sort(
+      (a, b) => (MECHANIC_SECTION_DISPLAY_ORDER[a] ?? a) - (MECHANIC_SECTION_DISPLAY_ORDER[b] ?? b)
+    );
     return orderedKeys.map(section => ({
       section,
       claims: (map.get(section) ?? []).slice().sort((a, b) => a.displayOrder - b.displayOrder),

--- a/apps/web/src/lib/api/schemas/mechanic-analyses.schemas.ts
+++ b/apps/web/src/lib/api/schemas/mechanic-analyses.schemas.ts
@@ -77,6 +77,27 @@ export const MECHANIC_SECTION_LABELS: Record<number, string> = {
   3: 'Resources',
   4: 'Phases',
   5: 'FAQ',
+  // v1.1.0 (#539 follow-up): Setup / Components / EndgameScoring.
+  6: 'Preparazione',
+  7: 'Componenti',
+  8: 'Fine partita',
+};
+
+/**
+ * Logical display order for the section groups (card + admin review). The enum values are
+ * append-only (6/7/8), so Setup/Components would otherwise render after FAQ; this map floats
+ * them to their natural reading position. Sections absent here fall back to their numeric value.
+ */
+export const MECHANIC_SECTION_DISPLAY_ORDER: Record<number, number> = {
+  0: 0, // Summary
+  6: 1, // Preparazione (Setup)
+  7: 2, // Componenti (Components)
+  1: 3, // Mechanics
+  3: 4, // Resources
+  4: 5, // Phases
+  2: 6, // Victory
+  8: 7, // Fine partita (EndgameScoring)
+  5: 8, // FAQ
 };
 
 /**


### PR DESCRIPTION
## Cosa
Aggiunge **3 sezioni** al Mechanic Extractor (prima ne estraeva solo 6): **Setup / Preparazione**, **Componenti**, **Fine partita & Punteggio**. Il setup (1-2 pagine di ogni regolamento) e l'inventario componenti non venivano estratti.

## Come vengono estratte (stesso pattern delle 6 esistenti)
Ogni sezione = **1 chiamata LLM** con `system.md` (policy IP ADR-051 + contratto JSON + output Italiano) + un prompt-sezione embedded (schema JSON + regole campo) + i chunk del rulebook → guardrail T1-T4 (+ retry) → `MechanicOutputParser` → claim + citazioni.

## Modifiche
**Backend**
- `MechanicSection` enum: append `Setup=6 / Components=7 / EndgameScoring=8` (mai rinumerare — i valori sono persistiti come int).
- 3 prompt embedded `Infrastructure/Prompts/MechanicExtractor/v1/{setup,components,endgame}.md` (glob `*.md` già in `Api.csproj`).
- `EmbeddedMechanicPromptProvider`: 3 mapping + `PromptVersion` → **v1.1.0**.
- `MechanicOutputParser`: 3 case + metodi che usano il campo `description` (riconosciuto dai guardrail per T3a/T3b/T2/T4).
- `AllSections` in executor **e** cost estimator; ordine card via `SectionOrder`.

**Frontend**
- Label sezioni + `MECHANIC_SECTION_DISPLAY_ORDER` (Setup/Componenti in alto, non dopo FAQ) applicato in ClaimsSection + card.
- Section count `6 → 9` (polling `isPipelineRunning` + badge).

## Note
- **v1.1.0** forza la rigenerazione (l'idempotenza si aggancia alla prompt-version): le analisi v1.0.0 restano intatte; le nuove hanno 9 sezioni.
- +3 sezioni ≈ **+50% costo/latenza** per run.

## Test
`dotnet test` verde; `MechanicOutputParserV11SectionsTests` (setup ordering + playerCountNote, components name/quantity, endgame anchors, drop no-citation) — 7/7 col resto del parser. FE typecheck pulito, lint 0 errori.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
