### PR TITLE
chore(scripts): lint:storybook-states follow-up polish + tests (#2929)

### DIFF
--- a/apps/web/scripts/__tests__/lint-storybook-states.test.ts
+++ b/apps/web/scripts/__tests__/lint-storybook-states.test.ts
@@ -7,7 +7,12 @@
 import { describe, it, expect } from 'vitest';
 import { CANONICAL_STATES, normalizeState, detectStates } from '../lint-storybook-states.mjs';
 import { buildFidelityIndex, classifyMockupEntry } from '../lint-storybook-states.mjs';
-import { scanEntries, buildJsonReport, parseArgs } from '../lint-storybook-states.mjs';
+import {
+  scanEntries,
+  buildJsonReport,
+  buildMdReport,
+  parseArgs,
+} from '../lint-storybook-states.mjs';
 
 describe('CANONICAL_STATES', () => {
   it('is exactly the 5 DEC-A5 states in order', () => {
@@ -52,6 +57,10 @@ describe('detectStates — heuristic', () => {
   it('does not treat a non-state string literal as a state', () => {
     const src = `HttpResponse.json({ error: 'server error' }, { status: 500 })`;
     expect(detectStates(src)).toEqual(new Set());
+  });
+  it('does not detect non-canonical state literals (offline, quota-*)', () => {
+    const src = `mswForState('offline'); mswForState('quota-soft'); mswForState('default');`;
+    expect(detectStates(src)).toEqual(new Set(['default']));
   });
 });
 
@@ -228,5 +237,53 @@ describe('parseArgs', () => {
   it('throws on unknown arg and on negative baseline', () => {
     expect(() => parseArgs(['--nope'])).toThrow();
     expect(() => parseArgs(['--max-baseline', '-1'])).toThrow();
+  });
+  it('throws a clear error when --max-baseline has no value', () => {
+    expect(() => parseArgs(['--max-baseline'])).toThrow(/value/i);
+  });
+});
+
+describe('buildMdReport', () => {
+  it('renders the metric table, coverage-gap rows and gate-semantics section', () => {
+    const report = buildJsonReport(
+      [
+        { mockup: 'a.html', routes: ['/a'], verdict: 'covered' },
+        { mockup: 'b.html', routes: ['/b'], verdict: 'coverage-gap', reason: 'no-fidelity' },
+      ],
+      5
+    );
+    const md = buildMdReport(report);
+    expect(md).toContain('# Storybook canonical-state coverage');
+    expect(md).toContain('| Total page-mock entries | 2 |');
+    expect(md).toContain('| Covered | 1 |');
+    expect(md).toContain('| Coverage gaps (baseline 5) | 1 |');
+    expect(md).toContain('## Coverage gaps');
+    expect(md).toContain('no-fidelity');
+    expect(md).toContain('## Gate semantics');
+    expect(md.endsWith('\n')).toBe(true);
+  });
+  it('includes a contract-violations section only when there are violations', () => {
+    const clean = buildMdReport(
+      buildJsonReport([{ mockup: 'a.html', routes: [], verdict: 'covered' }], 0)
+    );
+    expect(clean).not.toContain('## Contract violations');
+    const withViol = buildMdReport(
+      buildJsonReport(
+        [
+          {
+            mockup: 'c.html',
+            routes: ['/c'],
+            verdict: 'contract-violation',
+            storyPath: 's.tsx',
+            declared: ['error'],
+            detected: [],
+            missing: ['error'],
+          },
+        ],
+        0
+      )
+    );
+    expect(withViol).toContain('## Contract violations (must be 0)');
+    expect(withViol).toContain('**error**');
   });
 });

--- a/apps/web/scripts/lint-storybook-states.mjs
+++ b/apps/web/scripts/lint-storybook-states.mjs
@@ -36,7 +36,7 @@ export function normalizeState(raw) {
 }
 
 const OVERRIDE_RE = /canonicalStates\s*:\s*\[([^\]]*)\]/;
-const STATE_LITERAL_RE = /['"`](default|empty[\w-]*|loading|error|sse|offline|quota-(?:soft|hard))['"`]/g;
+const STATE_LITERAL_RE = /['"`](default|empty[\w-]*|loading|error|sse)['"`]/g;
 
 /**
  * Hybrid state detection: explicit override wins, else heuristic scan.
@@ -100,9 +100,11 @@ export function classifyMockupEntry(entry, fidelityIndex, io) {
   if (!storyPath) return { ...base, verdict: 'coverage-gap', reason: 'no-story-path' };
   if (!io.exists(storyPath)) return { ...base, verdict: 'coverage-gap', reason: 'story-missing' };
 
+  // normalizeState returns a canonical state or null, so filter(Boolean) already
+  // leaves only canonical values — no extra CANONICAL_STATES membership check needed.
   const declared = [
     ...new Set((acceptance.states_covered || []).map(normalizeState).filter(Boolean)),
-  ].filter((s) => CANONICAL_STATES.includes(s));
+  ];
 
   const detected = detectStates(io.readFile(storyPath));
   const missing = declared.filter((s) => !detected.has(s));
@@ -197,8 +199,10 @@ export function parseArgs(argv) {
     else if (a === '--verbose' || a === '-v') args.verbose = true;
     else if (a === '--help' || a === '-h') args.help = true;
     else if (a === '--max-baseline') {
-      const n = Number.parseInt(argv[++i], 10);
-      if (Number.isNaN(n) || n < 0) throw new Error(`--max-baseline requires a non-negative integer, got: ${argv[i]}`);
+      const raw = argv[++i];
+      if (raw === undefined) throw new Error('--max-baseline requires a value (non-negative integer)');
+      const n = Number.parseInt(raw, 10);
+      if (Number.isNaN(n) || n < 0) throw new Error(`--max-baseline requires a non-negative integer, got: ${raw}`);
       args.maxBaseline = n;
     } else if (a.startsWith('--max-baseline=')) {
       const n = Number.parseInt(a.slice('--max-baseline='.length), 10);


### PR DESCRIPTION
Chiude 4 dei 6 Minor non-bloccanti tracciati in #2929 (dal review di #2928). **Comportamento del gate invariato** — inventory `entries=68 covered=24 gaps=44 contract=0 skipped=0`, strict exit 0, 24/24 unit test.

## Fix

1. **`STATE_LITERAL_RE`** — rimosse le alternative `offline|quota-(?:soft|hard)`: dead code, `normalizeState` le scartava comunque. Set rilevato provabilmente identico (test di regressione aggiunto).
2. **`classifyMockupEntry`** — rimosso il `.filter(s => CANONICAL_STATES.includes(s))` ridondante dopo `.map(normalizeState).filter(Boolean)`: `normalizeState` già garantisce canonico-o-null → no-op.
3. **`parseArgs`** — `--max-baseline` senza valore ora lancia un errore chiaro (`requires a value`) invece di interpolare `undefined`. Exit code invariato (2).
4. **Test** — `buildMdReport` (2 test, prima senza copertura diretta) + parseArgs missing-value + `detectStates` non-canonical (regressione per #1).

## Deferiti (con rationale)

- **Semantica `error`** su esiti validation/narrativi → è una *domanda al designer*, non un fix codice.
- **Igiene celle route in `MOCKUPS_INDEX.md`** → tocca dati condivisi + il parser `parseMockupsIndex` usato da altri gate; fuori scope, più rischioso.

Restano tracciati in #2929 (che va tenuta aperta per i 2 residui, o chiusa se si decide di scartarli).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
