### PR TITLE
feat(mechanic-extractor): admin regenerate-with-engine + prompt viewer

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/DTOs/MechanicPromptDto.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/DTOs/MechanicPromptDto.cs
@@ -1,0 +1,18 @@
+namespace Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
+
+/// <summary>
+/// Read-only view of the Mechanic Extractor prompt for the current version (#539 follow-up).
+/// Lets an admin inspect exactly what the pipeline sends to the LLM: the shared system prompt
+/// (IP policy + JSON contract, ADR-051) plus each per-section prompt (schema + field rules).
+/// Sourced from <see cref="Services.MechanicExtractor.IMechanicPromptProvider"/> — no DB access.
+/// </summary>
+public sealed record MechanicPromptDto(
+    string PromptVersion,
+    string SystemPrompt,
+    IReadOnlyList<MechanicPromptSectionDto> Sections);
+
+/// <summary>One section's prompt. <c>Section</c> mirrors the <c>MechanicSection</c> enum value.</summary>
+public sealed record MechanicPromptSectionDto(
+    int Section,
+    string SectionName,
+    string Prompt);

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/MechanicExtractor/GetMechanicPromptQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/MechanicExtractor/GetMechanicPromptQuery.cs
@@ -1,0 +1,11 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Queries.MechanicExtractor;
+
+/// <summary>
+/// Returns the current Mechanic Extractor prompt (system + per-section) so an admin can inspect
+/// what the pipeline sends to the LLM (#539 follow-up). Read-only; sourced from
+/// <c>IMechanicPromptProvider</c>, no DB access, no parameters.
+/// </summary>
+internal sealed record GetMechanicPromptQuery : IQuery<MechanicPromptDto>;

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/MechanicExtractor/GetMechanicPromptQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/MechanicExtractor/GetMechanicPromptQueryHandler.cs
@@ -1,0 +1,41 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
+using Api.BoundedContexts.SharedGameCatalog.Application.Services.MechanicExtractor;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Queries.MechanicExtractor;
+
+/// <summary>
+/// Handler for <see cref="GetMechanicPromptQuery"/> (#539 follow-up). Assembles the system prompt
+/// and every per-section prompt from <see cref="IMechanicPromptProvider"/> for admin inspection.
+/// </summary>
+internal sealed class GetMechanicPromptQueryHandler
+    : IQueryHandler<GetMechanicPromptQuery, MechanicPromptDto>
+{
+    private readonly IMechanicPromptProvider _promptProvider;
+
+    public GetMechanicPromptQueryHandler(IMechanicPromptProvider promptProvider)
+    {
+        _promptProvider = promptProvider ?? throw new ArgumentNullException(nameof(promptProvider));
+    }
+
+    public Task<MechanicPromptDto> Handle(GetMechanicPromptQuery request, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var sections = Enum.GetValues<MechanicSection>()
+            .OrderBy(s => (int)s)
+            .Select(s => new MechanicPromptSectionDto(
+                Section: (int)s,
+                SectionName: s.ToString(),
+                Prompt: _promptProvider.GetSectionPrompt(s)))
+            .ToList();
+
+        var dto = new MechanicPromptDto(
+            PromptVersion: _promptProvider.PromptVersion,
+            SystemPrompt: _promptProvider.GetSystemPrompt(),
+            Sections: sections);
+
+        return Task.FromResult(dto);
+    }
+}

--- a/apps/api/src/Api/Routing/AdminMechanicAnalysesEndpoints.cs
+++ b/apps/api/src/Api/Routing/AdminMechanicAnalysesEndpoints.cs
@@ -114,6 +114,15 @@ internal static class AdminMechanicAnalysesEndpoints
         .WithName("AdminMechanicMetricsFilterOptions")
         .WithSummary("DISTINCT game + reviewer options for the metrics filter dropdowns (#2837)");
 
+        // #539 follow-up: read-only view of the current prompt (system + per-section) for inspection.
+        group.MapGet("/prompt", async (IMediator mediator, CancellationToken ct) =>
+        {
+            var result = await mediator.Send(new GetMechanicPromptQuery(), ct).ConfigureAwait(false);
+            return Results.Ok(result);
+        })
+        .WithName("AdminGetMechanicPrompt")
+        .WithSummary("Get the current Mechanic Extractor prompt (system + per-section) for inspection (#539)");
+
         // POST /api/v1/admin/mechanic-analyses
         // Enqueues the async AI pipeline (B5=B). Returns 202 Accepted with polling URL.
         group.MapPost("/", async (

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Queries/MechanicExtractor/GetMechanicPromptQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Queries/MechanicExtractor/GetMechanicPromptQueryHandlerTests.cs
@@ -1,0 +1,75 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Queries.MechanicExtractor;
+using Api.BoundedContexts.SharedGameCatalog.Application.Services.MechanicExtractor;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Queries.MechanicExtractor;
+
+/// <summary>
+/// Tests for <see cref="GetMechanicPromptQueryHandler"/> (#539 follow-up). Uses the REAL
+/// <see cref="EmbeddedMechanicPromptProvider"/> so the test also proves every per-section
+/// markdown resource (incl. the v1.1.0 additions setup/components/endgame) is embedded and
+/// loadable — a mock would hide a missing embedded resource.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public class GetMechanicPromptQueryHandlerTests
+{
+    private static GetMechanicPromptQueryHandler CreateHandler() =>
+        new(new EmbeddedMechanicPromptProvider());
+
+    [Fact]
+    public async Task Handle_ReturnsPromptVersion_SystemPrompt_AndEverySection()
+    {
+        var handler = CreateHandler();
+
+        var result = await handler.Handle(new GetMechanicPromptQuery(), CancellationToken.None);
+
+        result.Should().NotBeNull();
+        result.PromptVersion.Should().Be("v1.1.0");
+        result.SystemPrompt.Should().NotBeNullOrWhiteSpace();
+
+        var expectedCount = Enum.GetValues<MechanicSection>().Length;
+        result.Sections.Should().HaveCount(expectedCount);
+        result.Sections.Should().OnlyContain(s => !string.IsNullOrWhiteSpace(s.Prompt));
+        result.Sections.Should().OnlyContain(s => !string.IsNullOrWhiteSpace(s.SectionName));
+    }
+
+    [Fact]
+    public async Task Handle_IncludesV11Sections_SetupComponentsEndgame()
+    {
+        var handler = CreateHandler();
+
+        var result = await handler.Handle(new GetMechanicPromptQuery(), CancellationToken.None);
+
+        var names = result.Sections.Select(s => s.SectionName).ToList();
+        names.Should().Contain(nameof(MechanicSection.Setup));
+        names.Should().Contain(nameof(MechanicSection.Components));
+        names.Should().Contain(nameof(MechanicSection.EndgameScoring));
+    }
+
+    [Fact]
+    public async Task Handle_SectionsAreOrderedByEnumValueAscending()
+    {
+        var handler = CreateHandler();
+
+        var result = await handler.Handle(new GetMechanicPromptQuery(), CancellationToken.None);
+
+        var ordinals = result.Sections.Select(s => s.Section).ToList();
+        ordinals.Should().BeInAscendingOrder();
+        ordinals.Should().Equal(
+            Enum.GetValues<MechanicSection>().Select(s => (int)s).OrderBy(v => v));
+    }
+
+    [Fact]
+    public async Task Handle_NullRequest_Throws()
+    {
+        var handler = CreateHandler();
+
+        var act = async () => await handler.Handle(null!, CancellationToken.None);
+
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+}

--- a/apps/web/src/app/admin/(dashboard)/knowledge-base/mechanic-extractor/analyses/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/knowledge-base/mechanic-extractor/analyses/page.tsx
@@ -27,8 +27,10 @@ import {
   CheckIcon,
   ClockIcon,
   DollarSignIcon,
+  FileTextIcon,
   Loader2Icon,
   PlayIcon,
+  RefreshCwIcon,
   SendIcon,
   ShieldAlertIcon,
   SparklesIcon,
@@ -156,6 +158,9 @@ export default function MechanicAnalysesPage() {
   // #539: LLM model override + force-regenerate (bypass idempotency).
   const [selectedModel, setSelectedModel] = useState<string>('default');
   const [forceRegen, setForceRegen] = useState(false);
+  // #539 follow-up: regenerate-this-analysis model picker + prompt-viewer modal.
+  const [regenModel, setRegenModel] = useState<string>('default');
+  const [promptOpen, setPromptOpen] = useState(false);
   const [overrideEnabled, setOverrideEnabled] = useState(false);
   const [overrideCapUsd, setOverrideCapUsd] = useState<string>('1.00');
   const [overrideReason, setOverrideReason] = useState('');
@@ -284,6 +289,39 @@ export default function MechanicAnalysesPage() {
       const msg = e instanceof Error ? e.message : 'Generation failed';
       setGenerateError(msg);
     },
+  });
+
+  // #539 follow-up: regenerate the CURRENT analysis (same game+PDF) with a chosen engine.
+  // Reuses the generate endpoint with forceRegenerate=true (skips idempotency → new analysis).
+  const regenerateMutation = useMutation({
+    mutationFn: async () => {
+      if (!status) throw new Error('No analysis loaded to regenerate');
+      const modelOpt = MODEL_OPTIONS.find(m => m.value === regenModel);
+      return adminClient.generateMechanicAnalysis({
+        sharedGameId: status.sharedGameId,
+        pdfDocumentId: status.pdfDocumentId,
+        costCapUsd: Number.parseFloat(costCapUsd) || 0.5,
+        model: regenModel === 'default' ? undefined : regenModel,
+        provider: modelOpt?.provider || undefined,
+        forceRegenerate: true,
+      });
+    },
+    onSuccess: res => {
+      setLifecycleError(null);
+      setAnalysisId(res.id);
+      queryClient.invalidateQueries({ queryKey: ['mechanic-analysis', res.id] });
+    },
+    onError: (e: unknown) => {
+      setLifecycleError(e instanceof Error ? e.message : 'Regenerate failed');
+    },
+  });
+
+  // #539 follow-up: the current prompt (system + per-section), fetched lazily when the modal opens.
+  const promptQuery = useQuery({
+    queryKey: ['mechanic-prompt'],
+    queryFn: () => adminClient.getMechanicPrompt(),
+    enabled: promptOpen,
+    staleTime: 5 * 60_000,
   });
 
   const submitReviewMutation = useMutation({
@@ -832,6 +870,53 @@ export default function MechanicAnalysesPage() {
                 </Button>
               </div>
             )}
+
+            {/* #539 follow-up: regenerate this analysis with a different engine + inspect the prompt */}
+            {status && (
+              <div className="flex flex-wrap items-end gap-2 border-t border-border pt-4 dark:border-zinc-700">
+                <div className="flex flex-col gap-1">
+                  <label
+                    htmlFor="regen-model"
+                    className="text-xs font-medium text-muted-foreground"
+                  >
+                    Motore rigenerazione
+                  </label>
+                  <Select value={regenModel} onValueChange={setRegenModel}>
+                    <SelectTrigger id="regen-model" className="w-56">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {MODEL_OPTIONS.map(opt => (
+                        <SelectItem key={opt.value} value={opt.value}>
+                          {opt.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <Button
+                  variant="outline"
+                  onClick={() => regenerateMutation.mutate()}
+                  disabled={regenerateMutation.isPending}
+                  title="Riesegue l'intera pipeline (9 sezioni) sullo stesso PDF con il motore selezionato e crea una nuova analisi (forceRegenerate)."
+                >
+                  {regenerateMutation.isPending ? (
+                    <Loader2Icon className="mr-1 h-4 w-4 animate-spin" />
+                  ) : (
+                    <RefreshCwIcon className="mr-1 h-4 w-4" />
+                  )}
+                  Rigenera
+                </Button>
+                <Button
+                  variant="ghost"
+                  onClick={() => setPromptOpen(true)}
+                  title="Mostra il prompt di sistema e i prompt per-sezione inviati all'LLM."
+                >
+                  <FileTextIcon className="mr-1 h-4 w-4" />
+                  Vedi prompt
+                </Button>
+              </div>
+            )}
           </CardContent>
         </Card>
       )}
@@ -908,6 +993,52 @@ export default function MechanicAnalysesPage() {
               ) : null}
               Suppress
             </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* #539 follow-up: prompt viewer (system + per-section prompts, read-only) */}
+      <AlertDialog open={promptOpen} onOpenChange={setPromptOpen}>
+        <AlertDialogContent className="max-w-3xl">
+          <AlertDialogHeader>
+            <AlertDialogTitle>
+              Prompt Mechanic Extractor
+              {promptQuery.data ? ` — ${promptQuery.data.promptVersion}` : ''}
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              Prompt di sistema e prompt per-sezione inviati all&apos;LLM a ogni chiamata della
+              pipeline. Read-only.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <div className="max-h-[60vh] space-y-4 overflow-y-auto pr-2">
+            {promptQuery.isLoading && <p className="text-sm text-muted-foreground">Caricamento…</p>}
+            {promptQuery.isError && (
+              <p className="text-sm text-rose-600">Impossibile caricare il prompt.</p>
+            )}
+            {promptQuery.data && (
+              <>
+                <section>
+                  <h3 className="mb-1 text-sm font-semibold">System prompt</h3>
+                  <pre className="whitespace-pre-wrap rounded-md bg-muted p-3 text-xs">
+                    {promptQuery.data.systemPrompt}
+                  </pre>
+                </section>
+                {promptQuery.data.sections.map(s => (
+                  <section key={s.section}>
+                    <h3 className="mb-1 text-sm font-semibold">
+                      {MECHANIC_SECTION_LABELS[s.section] ?? s.sectionName}{' '}
+                      <span className="font-normal text-muted-foreground">({s.sectionName})</span>
+                    </h3>
+                    <pre className="whitespace-pre-wrap rounded-md bg-muted p-3 text-xs">
+                      {s.prompt}
+                    </pre>
+                  </section>
+                ))}
+              </>
+            )}
+          </div>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Chiudi</AlertDialogCancel>
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>

--- a/apps/web/src/lib/api/clients/admin/adminContentClient.ts
+++ b/apps/web/src/lib/api/clients/admin/adminContentClient.ts
@@ -55,6 +55,8 @@ import {
   MechanicClaimDtoSchema,
   MechanicClaimsListSchema,
   MECHANIC_ANALYSES_ROUTES,
+  MechanicPromptDtoSchema,
+  type MechanicPromptDto,
   type BulkApproveMechanicClaimsResponseDto,
   type BulkRejectMechanicClaimsRequest,
   type BulkRejectMechanicClaimsResponseDto,
@@ -577,6 +579,11 @@ export function createAdminContentClient(http: HttpClient) {
       );
       if (!result) throw new Error('Failed to enqueue mechanic analysis pipeline');
       return result;
+    },
+
+    // #539 follow-up: read-only prompt inspection (system + per-section).
+    async getMechanicPrompt(): Promise<MechanicPromptDto | null> {
+      return http.get(MECHANIC_ANALYSES_ROUTES.prompt, MechanicPromptDtoSchema);
     },
 
     async getMechanicAnalysisStatus(id: string): Promise<MechanicAnalysisStatusDto | null> {

--- a/apps/web/src/lib/api/schemas/mechanic-analyses.schemas.ts
+++ b/apps/web/src/lib/api/schemas/mechanic-analyses.schemas.ts
@@ -400,9 +400,25 @@ export const SUPPRESSION_REQUEST_SOURCE_LABELS: Record<number, string> = {
 
 // ========== Routes ==========
 
+/** #539 follow-up: read-only view of the current Mechanic Extractor prompt (system + per-section). */
+export const MechanicPromptDtoSchema = z.object({
+  promptVersion: z.string(),
+  systemPrompt: z.string(),
+  sections: z.array(
+    z.object({
+      section: z.number(),
+      sectionName: z.string(),
+      prompt: z.string(),
+    })
+  ),
+});
+export type MechanicPromptDto = z.infer<typeof MechanicPromptDtoSchema>;
+
 export const MECHANIC_ANALYSES_ROUTES = {
   list: '/api/v1/admin/mechanic-analyses',
   create: '/api/v1/admin/mechanic-analyses',
+  // #539 follow-up: read-only prompt inspection (system + per-section).
+  prompt: '/api/v1/admin/mechanic-analyses/prompt',
   status: (id: string) => `/api/v1/admin/mechanic-analyses/${id}/status`,
   submitReview: (id: string) => `/api/v1/admin/mechanic-analyses/${id}/submit-review`,
   approve: (id: string) => `/api/v1/admin/mechanic-analyses/${id}/approve`,


### PR DESCRIPTION
## Contesto

Follow-up dell'epic Mechanic Extractor (issue 539). Come admin, dalla pagina *Mechanic Analyses* si può ora:

1. **Rigenerare** l'analisi caricata sullo stesso PDF scegliendo il **motore** (OpenRouter / DeepSeek / Ollama). Riusa l'endpoint di generate con `forceRegenerate=true`, quindi bypassa l'idempotenza per prompt-version e produce una nuova analisi.
2. **Visualizzare il prompt** effettivamente inviato all'LLM (system + per-sezione) in un modal read-only.
3. **Cambiare engine** via selettore accanto alle lifecycle actions.

## Cosa cambia

**Backend**
- `GetMechanicPromptQuery` + handler su `IMechanicPromptProvider` (nessun accesso DB; admin-only ereditando il `RequireAdminSessionFilter` del group).
- `MechanicPromptDto` (`promptVersion`, `systemPrompt`, `sections[]`).
- `GET /api/v1/admin/mechanic-analyses/prompt` (segmento literal, nessuna collisione con `/{id}/...`).

**Frontend**
- Route + zod schema `MechanicPromptDtoSchema` + `adminClient.getMechanicPrompt()`.
- Controllo *Rigenera* (Select motore + bottone `forceRegenerate:true` su `sharedGameId`/`pdfDocumentId` dell'analisi corrente) e modal *Vedi prompt* (`AlertDialog`, fetch lazy on-open).

## Test / gate
- `GetMechanicPromptQueryHandlerTests` (4/4) esercita il **provider reale** `EmbeddedMechanicPromptProvider` → prova che tutte le 9 risorse `.md` per-sezione (incl. v1.1.0 setup/components/endgame) siano embedded e caricabili; asserisce `v1.1.0`, ordine sezioni ascendente, guard null-request.
- BE build `-warnaserror` ✅ · BE test ✅ · FE typecheck ✅ · FE lint ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)