### PR TITLE
chore: complete #2929 residual minors — error semantics + route hygiene

### DIFF
--- a/admin-mockups/design_files/librogame-runthrough-session-end.fidelity.json
+++ b/admin-mockups/design_files/librogame-runthrough-session-end.fidelity.json
@@ -3,8 +3,7 @@
   "mockup": {
     "source": "admin-mockups/design_files/librogame-runthrough-session-end.html",
     "states": [
-      "default",
-      "error"
+      "default"
     ]
   },
   "acceptance": {
@@ -13,10 +12,9 @@
     "tokens_used": "canonical_only",
     "legacy_token_names_forbidden": true,
     "states_covered": [
-      "default",
-      "error"
+      "default"
     ],
-    "_state_mapping_note": "default: Frame01_Paused (save & exit, session paused, resume-card) + Frame02_Victory (campaign complete, highlights timeline). error: Frame03_Defeat (party wipe, failure outcome) + Frame04_Cancelled (abandon confirmation, destructive action). Precise semantic names preserved in mock SessionEndMockOutcome union (paused|victory|defeat|cancelled) and story Frame `name` fields.",
+    "_state_mapping_note": "default: Frame01_Paused (save & exit, session paused, resume-card) + Frame02_Victory (campaign complete, highlights timeline). Frame03_Defeat (party wipe) + Frame04_Cancelled (abandon confirmation) are NARRATIVE OUTCOMES, not the canonical 'error' state (reserved for technical failures) — they remain story variants (SessionEndMockOutcome union paused|victory|defeat|cancelled) without a canonical state. De-mapped from 'error' per #2929.",
     "a11y_axe": "AA",
     "a11y_violations_max": 0,
     "responsive_breakpoints": [

--- a/admin-mockups/design_files/librogame-runthrough-setup-wizard.fidelity.json
+++ b/admin-mockups/design_files/librogame-runthrough-setup-wizard.fidelity.json
@@ -16,6 +16,7 @@
       "default",
       "error"
     ],
+    "_state_mapping_note": "error: Frame04_ValidationErr — inline form validation failure (title < 3 chars). Kept as canonical 'error' per #2929: a form validation-failure IS a legitimate UI error-state (distinct from a technical/network error, but a recognised error state nonetheless).",
     "a11y_axe": "AA",
     "a11y_violations_max": 0,
     "responsive_breakpoints": [

--- a/admin-mockups/design_files/sp7-game-night-detail-rsvp.fidelity.json
+++ b/admin-mockups/design_files/sp7-game-night-detail-rsvp.fidelity.json
@@ -3,7 +3,9 @@
   "mockup": {
     "source": "admin-mockups/design_files/sp7-game-night-detail-rsvp.html",
     "states": [
-      "default"
+      "default",
+      "loading",
+      "error"
     ]
   },
   "acceptance": {
@@ -12,8 +14,11 @@
     "tokens_used": "canonical_only",
     "legacy_token_names_forbidden": true,
     "states_covered": [
-      "default"
+      "default",
+      "loading",
+      "error"
     ],
+    "_state_mapping_note": "loading + error (404 not found) are implemented by the story (Loading + ErrorState frames via mswForSp7DetailRsvpState('loading'|'error')); error here is a genuine technical failure. Synced from [default] per #2929 to match the story's real coverage.",
     "a11y_axe": "AA",
     "a11y_violations_max": 0,
     "responsive_breakpoints": [

--- a/apps/web/scripts/__tests__/lint-storybook-states.test.ts
+++ b/apps/web/scripts/__tests__/lint-storybook-states.test.ts
@@ -12,6 +12,7 @@ import {
   buildJsonReport,
   buildMdReport,
   parseArgs,
+  cleanReportRoute,
 } from '../lint-storybook-states.mjs';
 
 describe('CANONICAL_STATES', () => {
@@ -240,6 +241,41 @@ describe('parseArgs', () => {
   });
   it('throws a clear error when --max-baseline has no value', () => {
     expect(() => parseArgs(['--max-baseline'])).toThrow(/value/i);
+  });
+});
+
+describe('cleanReportRoute', () => {
+  it('extracts the route path up to the first whitespace (strips trailing prose)', () => {
+    expect(cleanReportRoute('/sessions/[id]/live Catan demo (medium euro')).toBe(
+      '/sessions/[id]/live'
+    );
+    expect(cleanReportRoute('/games/[id]/faqs (reuse)')).toBe('/games/[id]/faqs');
+  });
+  it('preserves query strings and dynamic segments (no whitespace)', () => {
+    expect(cleanReportRoute('/games?tab=discover')).toBe('/games?tab=discover');
+    expect(cleanReportRoute('/shared-games/[token]')).toBe('/shared-games/[token]');
+  });
+  it('trims and returns null for non-route tokens', () => {
+    expect(cleanReportRoute('  /library  ')).toBe('/library');
+    expect(cleanReportRoute('used globally')).toBeNull();
+    expect(cleanReportRoute(42 as unknown as string)).toBeNull();
+  });
+});
+
+describe('buildJsonReport — route hygiene', () => {
+  it('cleans dirty routes in coverageGaps for the report', () => {
+    const report = buildJsonReport(
+      [
+        {
+          mockup: 'a.html',
+          routes: ['/sessions/[id]/live Catan demo (medium'],
+          verdict: 'coverage-gap',
+          reason: 'no-story-path',
+        },
+      ],
+      0
+    );
+    expect(report.coverageGaps[0].routes).toEqual(['/sessions/[id]/live']);
   });
 });
 

--- a/apps/web/scripts/lint-storybook-states.mjs
+++ b/apps/web/scripts/lint-storybook-states.mjs
@@ -128,6 +128,23 @@ export function scanEntries(indexMd, fidelityIndex, io) {
   return entries.map((e) => classifyMockupEntry(e, fidelityIndex, io));
 }
 
+/**
+ * Extract a clean route path for report display: the leading `/…` up to the first
+ * whitespace. MOCKUPS_INDEX cells sometimes append prose after the route (e.g.
+ * `/sessions/[id]/live Catan demo (...`); the shared parser's cleanRoute only strips
+ * balanced parens, so the prose survives into entry.routes. This cleanup is
+ * report-cosmetic ONLY — routes are never used in classification (#2929).
+ */
+export function cleanReportRoute(raw) {
+  if (typeof raw !== 'string') return null;
+  const m = raw.trim().match(/^\/\S*/);
+  return m ? m[0] : null;
+}
+
+function cleanReportRoutes(routes) {
+  return (routes || []).map(cleanReportRoute).filter(Boolean);
+}
+
 export function buildJsonReport(results, baseline) {
   const counts = { covered: 0, coverageGaps: 0, contractViolations: 0, skippedObsolete: 0 };
   const coverageGaps = [];
@@ -136,11 +153,11 @@ export function buildJsonReport(results, baseline) {
     if (r.verdict === 'covered') counts.covered += 1;
     else if (r.verdict === 'coverage-gap') {
       counts.coverageGaps += 1;
-      coverageGaps.push({ mockup: r.mockup, routes: r.routes, reason: r.reason });
+      coverageGaps.push({ mockup: r.mockup, routes: cleanReportRoutes(r.routes), reason: r.reason });
     } else if (r.verdict === 'contract-violation') {
       counts.contractViolations += 1;
       contractViolations.push({
-        mockup: r.mockup, routes: r.routes, storyPath: r.storyPath,
+        mockup: r.mockup, routes: cleanReportRoutes(r.routes), storyPath: r.storyPath,
         declared: r.declared, detected: r.detected, missing: r.missing,
       });
     } else if (r.verdict === 'skipped-obsolete') counts.skippedObsolete += 1;

--- a/apps/web/src/components/features/gamebook/_librogame/SessionEnd.stories.tsx
+++ b/apps/web/src/components/features/gamebook/_librogame/SessionEnd.stories.tsx
@@ -68,12 +68,12 @@ const meta: Meta<typeof SessionEndMock> = {
           'Sostituire con il vero SessionEndModal quando estratto dallo overlay store.',
       },
     },
-    // fidelity.json `_state_mapping_note` documents the intentional canonical mapping:
-    // default = Frame01_Paused + Frame02_Victory (happy-path outcomes), error =
-    // Frame03_Defeat + Frame04_Cancelled (failure/destructive outcomes). Driven via
-    // `outcome` prop values (paused/victory/defeat/cancelled), not canonical string
-    // literals — lint:storybook-states heuristic can't see them (#2342 Task 4 bonifica).
-    canonicalStates: ['default', 'error'],
+    // Only `default` is a canonical UI state here (Frame01_Paused + Frame02_Victory,
+    // happy-path outcomes). Frame03_Defeat + Frame04_Cancelled are NARRATIVE OUTCOMES
+    // (defeat/abandon), not the canonical `error` state (reserved for technical
+    // failures) — they remain story variants driven by the `outcome` prop without a
+    // canonical state. De-mapped from `error` per #2929.
+    canonicalStates: ['default'],
   },
   args: {
     outcome: 'paused' as SessionEndMockOutcome,

--- a/audits/2026-07-14-storybook-states-coverage.json
+++ b/audits/2026-07-14-storybook-states-coverage.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-14T14:58:39.293Z",
+  "generatedAt": "2026-07-14T16:20:03.576Z",
   "generatedFrom": "admin-mockups/MOCKUPS_INDEX.md",
   "canonicalStates": [
     "default",
@@ -75,7 +75,7 @@
     {
       "mockup": "sp3-shared-game-detail.html",
       "routes": [
-        "/shared-games/[id] (Wave A.3"
+        "/shared-games/[id]"
       ],
       "reason": "no-story-path"
     },
@@ -208,112 +208,112 @@
     {
       "mockup": "sp4-session-catan-live.html",
       "routes": [
-        "/sessions/[id]/live Catan demo (medium euro + trading"
+        "/sessions/[id]/live"
       ],
       "reason": "no-story-path"
     },
     {
       "mockup": "sp4-session-catan-summary.html",
       "routes": [
-        "/sessions/[id] Catan post-game . Premium #3/7."
+        "/sessions/[id]"
       ],
       "reason": "no-story-path"
     },
     {
       "mockup": "sp4-session-codenames-live.html",
       "routes": [
-        "/sessions/[id]/live Codenames demo (team deduction party game"
+        "/sessions/[id]/live"
       ],
       "reason": "no-story-path"
     },
     {
       "mockup": "sp4-session-codenames-summary.html",
       "routes": [
-        "/sessions/[id] Codenames post-game . Premium #7/7."
+        "/sessions/[id]"
       ],
       "reason": "no-story-path"
     },
     {
       "mockup": "sp4-session-paleo-live.html",
       "routes": [
-        "/sessions/[id]/live Paleo demo (co-op preistorico Simultaneous"
+        "/sessions/[id]/live"
       ],
       "reason": "no-story-path"
     },
     {
       "mockup": "sp4-session-paleo-summary.html",
       "routes": [
-        "/sessions/[id] Paleo post-game . Premium #6/7."
+        "/sessions/[id]"
       ],
       "reason": "no-story-path"
     },
     {
       "mockup": "sp4-session-power-grid-live.html",
       "routes": [
-        "/sessions/[id]/live Power Grid demo (heavy euro auction + network"
+        "/sessions/[id]/live"
       ],
       "reason": "no-story-path"
     },
     {
       "mockup": "sp4-session-power-grid-summary.html",
       "routes": [
-        "/sessions/[id] Power Grid post-game . Premium #4/7."
+        "/sessions/[id]"
       ],
       "reason": "no-story-path"
     },
     {
       "mockup": "sp4-session-puerto-rico-live.html",
       "routes": [
-        "/sessions/[id]/live Puerto Rico demo (heavy euro role-selection"
+        "/sessions/[id]/live"
       ],
       "reason": "no-story-path"
     },
     {
       "mockup": "sp4-session-puerto-rico-summary.html",
       "routes": [
-        "/sessions/[id] Puerto Rico post-game . Premium #2/7."
+        "/sessions/[id]"
       ],
       "reason": "no-story-path"
     },
     {
       "mockup": "sp4-session-skeleton-live.html",
       "routes": [
-        "/sessions/[id]/live **generic skeleton** . Consumes AiToolkitSuggestionDto polymorphically. Demo shows side-by-side Wingspan  vs Paleo . Closes #1750 ."
+        "/sessions/[id]/live"
       ],
       "reason": "no-story-path"
     },
     {
       "mockup": "sp4-session-summary-skeleton.html",
       "routes": [
-        "/sessions/[id] **generic post-game skeleton** . Demo shows side-by-side Wingspan vs Paleo. Closes #1750 ."
+        "/sessions/[id]"
       ],
       "reason": "no-story-path"
     },
     {
       "mockup": "sp4-session-wingspan-live.html",
       "routes": [
-        "/sessions/[id]/live Wingspan demo + consolidated tabs ?tab=scores\\|photos\\|agent\\|players\\|chat\\|tools\\|notes (was 4 separate sub-routes pre-2026-05-31"
+        "/sessions/[id]/live"
       ],
       "reason": "no-story-path"
     },
     {
       "mockup": "sp4-session-wingspan-summary.html",
       "routes": [
-        "/sessions/[id] Wingspan demo + consolidated tabs ?tab=scoreboard\\|notes\\|players (was 3 separate sub-routes pre-2026-05-31"
+        "/sessions/[id]"
       ],
       "reason": "no-story-path"
     },
     {
       "mockup": "sp4-session-zombicide-live.html",
       "routes": [
-        "/sessions/[id]/live Zombicide GH demo (co-op miniatures dungeon-crawler"
+        "/sessions/[id]/live"
       ],
       "reason": "no-story-path"
     },
     {
       "mockup": "sp4-session-zombicide-summary.html",
       "routes": [
-        "/sessions/[id] Zombicide post-game . Premium #5/7."
+        "/sessions/[id]"
       ],
       "reason": "no-story-path"
     },
@@ -336,7 +336,7 @@
     {
       "mockup": "librogame-game-night-storyboard.html",
       "routes": [
-        "/game-nights/[id] (storyboard variant — was nanolith-game-night-storyboard.html pre-rename post-IA consolidation #871"
+        "/game-nights/[id]"
       ],
       "reason": "no-story-path"
     }

--- a/audits/2026-07-14-storybook-states-coverage.md
+++ b/audits/2026-07-14-storybook-states-coverage.md
@@ -1,6 +1,6 @@
 # Storybook canonical-state coverage (DEC-A5 / #2342)
 
-Generated: 2026-07-14T14:58:39.293Z
+Generated: 2026-07-14T16:20:03.576Z
 Source: `admin-mockups/MOCKUPS_INDEX.md` · Canonical states: default, empty, loading, error, sse
 
 | Metric | Count |
@@ -22,7 +22,7 @@ Source: `admin-mockups/MOCKUPS_INDEX.md` · Canonical states: default, empty, lo
 | `sp3-how-it-works.html` | /how-it-works | no-story-path |
 | `sp3-join.html` | /join, /sessions/join | no-story-path |
 | `sp3-legal.html` | /privacy, /terms, /cookies, /cookie-settings | no-story-path |
-| `sp3-shared-game-detail.html` | /shared-games/[id] (Wave A.3 | no-story-path |
+| `sp3-shared-game-detail.html` | /shared-games/[id] | no-story-path |
 | `sp3-shared-games.html` | /shared-games | no-story-path |
 | `sp4-add-game-pdf-dedup.html` | /library/private/add, /upload | no-story-path |
 | `sp4-agent-detail.html` | /agents/[id], /library/[gameId]/agent | no-story-path |
@@ -40,25 +40,25 @@ Source: `admin-mockups/MOCKUPS_INDEX.md` · Canonical states: default, empty, lo
 | `sp4-play-records-stats.html` | /play-records/stats | no-story-path |
 | `sp4-player-detail.html` | /players/[id], /players/[id]/{achievements | no-story-path |
 | `sp4-players-index.html` | /players | no-story-path |
-| `sp4-session-catan-live.html` | /sessions/[id]/live Catan demo (medium euro + trading | no-story-path |
-| `sp4-session-catan-summary.html` | /sessions/[id] Catan post-game . Premium #3/7. | no-story-path |
-| `sp4-session-codenames-live.html` | /sessions/[id]/live Codenames demo (team deduction party game | no-story-path |
-| `sp4-session-codenames-summary.html` | /sessions/[id] Codenames post-game . Premium #7/7. | no-story-path |
-| `sp4-session-paleo-live.html` | /sessions/[id]/live Paleo demo (co-op preistorico Simultaneous | no-story-path |
-| `sp4-session-paleo-summary.html` | /sessions/[id] Paleo post-game . Premium #6/7. | no-story-path |
-| `sp4-session-power-grid-live.html` | /sessions/[id]/live Power Grid demo (heavy euro auction + network | no-story-path |
-| `sp4-session-power-grid-summary.html` | /sessions/[id] Power Grid post-game . Premium #4/7. | no-story-path |
-| `sp4-session-puerto-rico-live.html` | /sessions/[id]/live Puerto Rico demo (heavy euro role-selection | no-story-path |
-| `sp4-session-puerto-rico-summary.html` | /sessions/[id] Puerto Rico post-game . Premium #2/7. | no-story-path |
-| `sp4-session-skeleton-live.html` | /sessions/[id]/live **generic skeleton** . Consumes AiToolkitSuggestionDto polymorphically. Demo shows side-by-side Wingspan  vs Paleo . Closes #1750 . | no-story-path |
-| `sp4-session-summary-skeleton.html` | /sessions/[id] **generic post-game skeleton** . Demo shows side-by-side Wingspan vs Paleo. Closes #1750 . | no-story-path |
-| `sp4-session-wingspan-live.html` | /sessions/[id]/live Wingspan demo + consolidated tabs ?tab=scores\|photos\|agent\|players\|chat\|tools\|notes (was 4 separate sub-routes pre-2026-05-31 | no-story-path |
-| `sp4-session-wingspan-summary.html` | /sessions/[id] Wingspan demo + consolidated tabs ?tab=scoreboard\|notes\|players (was 3 separate sub-routes pre-2026-05-31 | no-story-path |
-| `sp4-session-zombicide-live.html` | /sessions/[id]/live Zombicide GH demo (co-op miniatures dungeon-crawler | no-story-path |
-| `sp4-session-zombicide-summary.html` | /sessions/[id] Zombicide post-game . Premium #5/7. | no-story-path |
+| `sp4-session-catan-live.html` | /sessions/[id]/live | no-story-path |
+| `sp4-session-catan-summary.html` | /sessions/[id] | no-story-path |
+| `sp4-session-codenames-live.html` | /sessions/[id]/live | no-story-path |
+| `sp4-session-codenames-summary.html` | /sessions/[id] | no-story-path |
+| `sp4-session-paleo-live.html` | /sessions/[id]/live | no-story-path |
+| `sp4-session-paleo-summary.html` | /sessions/[id] | no-story-path |
+| `sp4-session-power-grid-live.html` | /sessions/[id]/live | no-story-path |
+| `sp4-session-power-grid-summary.html` | /sessions/[id] | no-story-path |
+| `sp4-session-puerto-rico-live.html` | /sessions/[id]/live | no-story-path |
+| `sp4-session-puerto-rico-summary.html` | /sessions/[id] | no-story-path |
+| `sp4-session-skeleton-live.html` | /sessions/[id]/live | no-story-path |
+| `sp4-session-summary-skeleton.html` | /sessions/[id] | no-story-path |
+| `sp4-session-wingspan-live.html` | /sessions/[id]/live | no-story-path |
+| `sp4-session-wingspan-summary.html` | /sessions/[id] | no-story-path |
+| `sp4-session-zombicide-live.html` | /sessions/[id]/live | no-story-path |
+| `sp4-session-zombicide-summary.html` | /sessions/[id] | no-story-path |
 | `sp4-sessions-index.html` | /sessions, /games/[id]/sessions | no-story-path |
 | `chat-fullscreen.html` | /chat/[threadId], /chat/new | no-story-path |
-| `librogame-game-night-storyboard.html` | /game-nights/[id] (storyboard variant — was nanolith-game-night-storyboard.html pre-rename post-IA consolidation #871 | no-story-path |
+| `librogame-game-night-storyboard.html` | /game-nights/[id] | no-story-path |
 
 ## Gate semantics
 


### PR DESCRIPTION
Completa i **2 Minor residui** che #2929 aveva triato fuori scope (decisioni prese dall'owner via spec-panel). Gate invariato: `entries=68 covered=24 gaps=44 contract=0`, 28/28 test.

## #5 — semantica `error` (principio: error = errore tecnico)

Recon ha trovato 4 story che mappano `error`; solo 2 erano non-tecniche.

- **SessionEnd** → **declass**: Defeat/Cancelled sono **outcome narrativi**, non errori. `states_covered` e override ridotti a `[default]` (in lockstep); i frame restano varianti story senza stato canonico.
- **CampaignSetupDrawer** → **mantieni + documenta**: la validation-failure inline È un error-state UI legittimo. `_state_mapping_note` aggiunto, stati invariati.
- **game-night-detail-rsvp** → **sync**: la fidelity dichiarava solo `[default]` mentre la story copre già `[default,loading,error]` (404 tecnico + loading reali) → fidelity allineata verso l'alto.
- **EncounterCheatsheetView** → nessuna azione (409 = errore tecnico genuino).

Tutte le fidelity mantengono la set-equality `mockup.states == states_covered` (`lint:fidelity` verde).

## #6 — igiene route nel report (opzione C, isolata)

Alcune celle di `MOCKUPS_INDEX.md` appendono prosa dopo la route (es. `/sessions/[id]/live Catan demo (...`); il `cleanRoute` del parser condiviso rimuove solo le parentesi bilanciate. Nuovo `cleanReportRoute` (prende `/…` fino al primo spazio) applicato **solo** nel report del gate. **Zero impatto** su classificazione/denominatore/altri gate (le route non sono usate nel verdetto). Query string e segmenti dinamici preservati.

Prima: `"/sessions/[id]/live Catan demo (medium"` → dopo: `"/sessions/[id]/live"`.

Chiude i residui di #2929.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
