### PR TITLE
chore(observability): fix false-low B1 gate + document dispatched.total cardinality (#2923)

### DIFF
--- a/apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.DomainEventOutbox.cs
+++ b/apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.DomainEventOutbox.cs
@@ -24,12 +24,19 @@ internal static partial class MeepleAiMetrics
 
     /// <summary>
     /// Incremented once per successful <c>MediatR.Publish</c> from
-    /// <c>DomainEventOutboxProcessor</c>. Tag: <c>event_type</c> (same labelling as
-    /// <see cref="DomainEventOutboxEnqueued"/>).
+    /// <c>DomainEventOutboxProcessor</c>, when a row transitions Pending → Sent.
+    /// Tag: <c>event_type</c> (same labelling as <see cref="DomainEventOutboxEnqueued"/>).
     ///
-    /// <para>Used to compute <i>throughput</i>. The dispatched rate must converge with the
-    /// enqueued rate over a sliding window (otherwise backlog grows — see
-    /// <see cref="MeepleAiMetrics"/> health gauges below).</para>
+    /// <para>Used to compute dispatch <i>throughput</i>.</para>
+    ///
+    /// <para>#2923 — cardinality caveat: this counter is emitted ONLY by the processor,
+    /// so a per-<c>event_type</c> series first appears only AFTER the first dispatch of that
+    /// type following a process restart. At low volume its label cardinality therefore lags
+    /// <see cref="DomainEventOutboxEnqueued"/> (which observes every type at enqueue time).
+    /// The <c>dispatched / enqueued</c> rate ratio is consequently NOT a reliable backlog
+    /// signal at low volume — do not gate on it. The canonical backlog signals are the
+    /// <c>pending.count</c> and <c>pending.oldest_age_seconds</c> gauges (Grafana alerts in
+    /// <c>infra/prometheus/alerts/domain-event-outbox.yml</c>).</para>
     /// </summary>
     public static readonly Counter<long> DomainEventOutboxDispatched = Meter.CreateCounter<long>(
         name: "meepleai.domain_event_outbox.dispatched.total",

--- a/apps/api/tests/Api.Tests/Integration/DomainEventOutbox/DomainEventOutboxProcessorIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/DomainEventOutbox/DomainEventOutboxProcessorIntegrationTests.cs
@@ -1,8 +1,10 @@
+using System.Diagnostics.Metrics;
 using System.Text.Json;
 using Api.Infrastructure;
 using Api.Infrastructure.BackgroundJobs;
 using Api.Infrastructure.DomainEventOutbox;
 using Api.Infrastructure.Entities.DomainEventOutbox;
+using Api.Observability;
 using Api.SharedKernel.Domain.Interfaces;
 using Api.Tests.Constants;
 using Api.Tests.Infrastructure;
@@ -183,6 +185,86 @@ public sealed class DomainEventOutboxProcessorIntegrationTests : IAsyncLifetime
             t => t.RecordSnapshot(It.IsAny<long>(), It.IsAny<double>(), It.IsAny<long>()),
             Times.AtLeastOnce,
             "the processor must refresh the health snapshot after the batch");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────────────────────────
+    // #2923 — dispatched counter emits one series per event_type (cardinality parity)
+    // ─────────────────────────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task RunOnceAsync_EmitsDispatchedCounter_PerEventType()
+    {
+        // Arrange: two Pending rows carrying DISTINCT event_type aliases mapped to the same CLR
+        // fixture (the counter tags on row.EventType, not the CLR type). #2923: this proves the
+        // processor emits meepleai.domain_event_outbox.dispatched.total once PER event_type, so
+        // dispatched label cardinality tracks enqueued cardinality — the "partial coverage"
+        // reported in #2923 is a low-volume observability artefact, not a code defect.
+        const string aliasAlpha = "test.fake.event.alpha.2923";
+        const string aliasBeta = "test.fake.event.beta.2923";
+
+        var resolverMock = Mock.Get(_serviceProvider!.GetRequiredService<IDomainEventTypeResolver>());
+        resolverMock.Setup(r => r.Resolve(aliasAlpha)).Returns(typeof(FakeEvent));
+        resolverMock.Setup(r => r.Resolve(aliasBeta)).Returns(typeof(FakeEvent));
+
+        var now = DateTimeOffset.UtcNow;
+        await using (var scope = _serviceProvider!.CreateAsyncScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            var i = 0;
+            foreach (var alias in new[] { aliasAlpha, aliasBeta })
+            {
+                var ev = new FakeEvent(Marker: i);
+                var row = DomainEventOutboxEntity.Enqueue(
+                    ev,
+                    alias,
+                    JsonSerializer.Serialize(ev, DomainEventJsonOptions.Default),
+                    payloadVersion: 1,
+                    correlationId: null,
+                    now: now.AddSeconds(i));
+                db.DomainEventOutbox.Add(row);
+                i++;
+            }
+            await db.SaveChangesAsync(TestCancellationToken);
+        }
+
+        var dispatched = new List<(long Value, KeyValuePair<string, object?>[] Tags)>();
+        using var listener = new MeterListener
+        {
+            InstrumentPublished = (instrument, l) =>
+            {
+                if (string.Equals(instrument.Meter.Name, MeepleAiMetrics.MeterName, StringComparison.Ordinal) &&
+                    string.Equals(instrument.Name, "meepleai.domain_event_outbox.dispatched.total", StringComparison.Ordinal))
+                {
+                    l.EnableMeasurementEvents(instrument);
+                }
+            }
+        };
+        listener.SetMeasurementEventCallback<long>((inst, value, tags, state) =>
+            dispatched.Add((value, tags.ToArray())));
+        listener.Start();
+
+        // Act
+        var processor = _serviceProvider!.GetRequiredService<DomainEventOutboxProcessor>();
+        var processed = await processor.RunOnceAsync(batchSize: 100, cancellationToken: TestCancellationToken);
+
+        // Assert
+        processed.Should().Be(2);
+
+        var dispatchedEventTypes = dispatched
+            .Select(m => m.Tags.SingleOrDefault(t =>
+                string.Equals(t.Key, "event_type", StringComparison.Ordinal)).Value as string)
+            .ToList();
+
+        dispatchedEventTypes.Should().Contain(aliasAlpha,
+            "the dispatched counter must fire with event_type=alpha (#2923 cardinality parity)");
+        dispatchedEventTypes.Should().Contain(aliasBeta,
+            "the dispatched counter must fire with event_type=beta (#2923 cardinality parity)");
+        dispatched
+            .Where(m => m.Tags.Any(t =>
+                string.Equals(t.Key, "event_type", StringComparison.Ordinal) &&
+                (t.Value as string) is aliasAlpha or aliasBeta))
+            .Should().AllSatisfy(m => m.Value.Should().Be(1,
+                because: "each dispatched row emits exactly one counter tick"));
     }
 
     // ─────────────────────────────────────────────────────────────────────────────────────────────

--- a/audits/2026-06-07-issue-1535-phase-b-cutover-pr-draft.md
+++ b/audits/2026-06-07-issue-1535-phase-b-cutover-pr-draft.md
@@ -70,6 +70,26 @@ rate should drop from 2× to 1× within one poll interval. A ratio sustained at
 1.5× or anything > 1.05× indicates the inline path is still firing for some
 reason — investigate.
 
+> **Correction — #2923 (2026-07-14)**: the "2× in Phase A" premise above is
+> inaccurate. `meepleai_domain_event_outbox_dispatched_total` is emitted **only** by
+> the `DomainEventOutboxProcessor` (one tick per Pending → Sent transition, verified in
+> `DomainEventOutboxProcessor.cs`); the inline Hybrid `MediatR.Publish` path does NOT
+> increment it. The ratio is therefore ≈ 1× in **both** phases — and because a
+> per-`event_type` series first appears only after that type's first post-restart
+> dispatch, the ratio reads artificially low at low volume (this is the "partial
+> `event_type` coverage" reported in #2923, an observability artefact — not a code
+> defect; the DB ground truth shows 0 Pending / all `dispatched_at` set). **Do not gate
+> on this ratio.** Use the backlog gauges instead — which are what the production
+> Grafana alerts already page on:
+>
+> ```promql
+> meepleai_domain_event_outbox_pending_count == 0
+> and meepleai_domain_event_outbox_pending_oldest_age_seconds < 10
+> ```
+>
+> See `infra/prometheus/alerts/domain-event-outbox.yml` and the counter docstring in
+> `apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.DomainEventOutbox.cs`.
+
 #### Gate B2 — Zero `domain_event_log.dispatch_failures_total` increment
 
 ```promql


### PR DESCRIPTION
## Summary
The `dispatched.total / enqueued.total` ratio gate (**B1**) read false-low during the #1990 OutboxOnly soak. After tracing the processor, DbContext, config and Prometheus alerts: **this is an observability artefact, not a code defect.**

- The `DomainEventOutboxProcessor` already emits `dispatched.total` **per `event_type`** (one tick per Pending→Sent transition — `DomainEventOutboxProcessor.cs:249-253`).
- A per-`event_type` Prometheus series first appears only **after that type's first dispatch post-restart**, so at low volume `dispatched` label cardinality lags `enqueued` (which observes every type at enqueue time). DB ground truth during the soak: 0 Pending, all `dispatched_at` set.
- The B1 runbook premise ("2× in Phase A because inline + outbox both fired the counter") was **wrong** — the inline Hybrid path never incremented the counter, so the ratio is ≈1× in both phases.

## Changes
- **Runbook fix** (`audits/2026-06-07-issue-1535-phase-b-cutover-pr-draft.md`): dated `#2923` correction on Gate B1 — stop gating on the fragile ratio; use the `pending_count` / `pending_oldest_age_seconds` gauges (which the production Grafana alerts already page on).
- **Docstring** (`MeepleAiMetrics.DomainEventOutbox.cs`): cardinality caveat on `DomainEventOutboxDispatched`.
- **Test** (`DomainEventOutboxProcessorIntegrationTests.cs`): `RunOnceAsync_EmitsDispatchedCounter_PerEventType` — 2 distinct `event_type` aliases → 2 `dispatched.total` series, cementing the Done-when #1 cardinality parity.

## Verification
- `dotnet build` Api.Tests: **0 errors**.
- New integration test runs on CI (Testcontainers Postgres).

Closes #2923

🤖 Generated with [Claude Code](https://claude.com/claude-code)