### PR TITLE
fix(kb): reconcile has_knowledge_base drift + KB-ready filter

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Jobs/KbFlagDriftAuditJob.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Jobs/KbFlagDriftAuditJob.cs
@@ -1,5 +1,6 @@
 using Api.Infrastructure;
 using Api.Observability;
+using Api.Services;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Quartz;
@@ -16,28 +17,42 @@ namespace Api.BoundedContexts.DocumentProcessing.Application.Jobs;
 /// If the tactical mediator.Publish(VectorDocumentIndexedEvent) inside
 /// FinalizeProcessingAsync is ever bypassed (regression, new ingestion path
 /// added without raising the event, swallowed exception in the projection
-/// handler, etc.) admin UIs silently revert to showing "no agent ready" while
-/// the catalog is otherwise healthy. This job catches the drift at most 10
-/// minutes after it appears so the SLO=0 alert fires.
+/// handler, an event that carried a null SharedGameId, etc.) admin + catalog
+/// UIs silently revert to showing "no agent ready" while the catalog is
+/// otherwise healthy.
 ///
-/// Each detected row increments
-/// <see cref="MeepleAiMetrics.PdfIndexedNoKbFlagTotal"/> and logs the
-/// PdfDocumentId + SharedGameId at Warning. The job is idempotent and best
-/// effort — it does NOT try to repair the drift (that is the job of Sub #2
-/// architecture refactor — VectorDocument.Create factory — or a manual
-/// re-index for already-stuck docs).
+/// This job now RECONCILES (not just audits) the drift: every 10 minutes it
+/// finds SharedGames that have a Ready PdfDocument but HasKnowledgeBase=false,
+/// flips the flag to true, and invalidates the catalog read-model cache the
+/// same way <c>VectorDocumentIndexedForKbFlagHandler</c> does — so the
+/// "AI-ready" flag becomes visible within one job cycle even when the inline
+/// event path failed. Each repaired row still increments
+/// <see cref="MeepleAiMetrics.PdfIndexedNoKbFlagTotal"/> and logs at Warning so
+/// the SLO=0 signal remains observable (a healthy pipeline reconciles nothing).
+///
+/// Idempotent and best effort. Bounded to 100 games per run — if drift is
+/// widespread the counter climbs across runs and the operator triages from the
+/// audit log while the backlog drains.
 /// </summary>
 [DisallowConcurrentExecution]
 internal sealed class KbFlagDriftAuditJob : IJob
 {
+    private const int MaxGamesPerRun = 100;
+
     private readonly MeepleAiDbContext _dbContext;
+    private readonly IHybridCacheService _cache;
+    private readonly ICacheInvalidationRetryPolicy _retryPolicy;
     private readonly ILogger<KbFlagDriftAuditJob> _logger;
 
     public KbFlagDriftAuditJob(
         MeepleAiDbContext dbContext,
+        IHybridCacheService cache,
+        ICacheInvalidationRetryPolicy retryPolicy,
         ILogger<KbFlagDriftAuditJob> logger)
     {
         _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+        _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+        _retryPolicy = retryPolicy ?? throw new ArgumentNullException(nameof(retryPolicy));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -49,56 +64,86 @@ internal sealed class KbFlagDriftAuditJob : IJob
 
         try
         {
-            // Inner join PdfDocuments (Ready) with SharedGames (HasKnowledgeBase=false)
-            // via SharedGameId. Projection-only, no tracking, no entity materialization.
-            // Limited to 100 rows per run — if drift is widespread the SLO=0 alert fires
-            // on the first batch and the operator triages from the audit log.
-            var driftedRows = await _dbContext.PdfDocuments
+            // Distinct SharedGameIds that violate the invariant: a Ready PDF exists
+            // but the game's HasKnowledgeBase flag is still false. Projection-only,
+            // no tracking. Limited to MaxGamesPerRun per run.
+            var driftedGameIds = await _dbContext.PdfDocuments
                 .AsNoTracking()
                 .Where(p => p.ProcessingState == "Ready" && p.SharedGameId != null)
                 .Join(
                     _dbContext.SharedGames.AsNoTracking().Where(g => !g.HasKnowledgeBase),
                     p => p.SharedGameId,
                     g => g.Id,
-                    (p, g) => new { PdfDocumentId = p.Id, SharedGameId = g.Id })
-                .Take(100)
+                    (p, g) => g.Id)
+                .Distinct()
+                .Take(MaxGamesPerRun)
                 .ToListAsync(cancellationToken)
                 .ConfigureAwait(false);
 
-            if (driftedRows.Count == 0)
+            if (driftedGameIds.Count == 0)
             {
                 _logger.LogDebug(
-                    "KbFlagDriftAuditJob: 0 drifted rows (FireTime={FireTime})",
+                    "KbFlagDriftAuditJob: 0 drifted games (FireTime={FireTime})",
                     context.FireTimeUtc);
-                context.Result = new { DriftedRows = 0 };
+                context.Result = new { RepairedGames = 0 };
                 return;
             }
 
-            foreach (var row in driftedRows)
+            // Load the drifted games TRACKED so we can flip the flag and persist.
+            var games = await _dbContext.SharedGames
+                .Where(g => driftedGameIds.Contains(g.Id))
+                .ToListAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+            foreach (var game in games)
             {
+                if (game.HasKnowledgeBase)
+                {
+                    continue; // raced with the inline handler — already healed
+                }
+
+                game.HasKnowledgeBase = true;
                 MeepleAiMetrics.RecordPdfIndexedNoKbFlagDrift();
                 _logger.LogWarning(
-                    "KbFlagDrift detected: PdfDocument {PdfDocumentId} is Ready but " +
-                    "SharedGame {SharedGameId} HasKnowledgeBase=false. " +
-                    "Root cause: VectorDocumentIndexedEvent was not published for this PDF " +
-                    "(#2243 Block A regression or new ingestion path bypassing the publish).",
-                    row.PdfDocumentId,
-                    row.SharedGameId);
+                    "KbFlagDrift reconciled: SharedGame {SharedGameId} had a Ready PDF but " +
+                    "HasKnowledgeBase=false — flag flipped to true. Root cause: the inline " +
+                    "VectorDocumentIndexedEvent projection did not run for this game " +
+                    "(#2243 Block A regression, a null SharedGameId on the event, or a new " +
+                    "ingestion path bypassing the publish).",
+                    game.Id);
+            }
+
+            await _dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+            // Invalidate the catalog read-model cache across replicas so the freshly
+            // flipped "AI-ready" flag appears immediately instead of waiting for the
+            // L1/L2 TTL — mirrors VectorDocumentIndexedForKbFlagHandler.
+            await _retryPolicy.ExecuteAsync(
+                token => new ValueTask(_cache.RemoveByTagAcrossReplicasAsync("search-games", token)),
+                "kb-reconcile.list",
+                cancellationToken).ConfigureAwait(false);
+
+            foreach (var game in games)
+            {
+                await _retryPolicy.ExecuteAsync(
+                    token => new ValueTask(_cache.RemoveByTagAcrossReplicasAsync($"shared-game:{game.Id}", token)),
+                    "kb-reconcile.detail",
+                    cancellationToken).ConfigureAwait(false);
             }
 
             _logger.LogError(
-                "KbFlagDriftAuditJob: {Count} drifted rows detected — SLO=0 violated. " +
+                "KbFlagDriftAuditJob: reconciled {Count} drifted games — SLO=0 violated. " +
                 "Investigate publish-event chain in UploadPdfCommandHandler.FinalizeProcessingAsync, " +
-                "PdfProcessingPipelineService and IndexPdfCommandHandler.",
-                driftedRows.Count);
+                "PdfIndexingPipeline and IndexPdfCommandHandler.",
+                games.Count);
 
-            context.Result = new { DriftedRows = driftedRows.Count };
+            context.Result = new { RepairedGames = games.Count };
         }
 #pragma warning disable CA1031 // Do not catch general exception types
         // Background job — must not throw or Quartz suspends the trigger.
         catch (Exception ex)
         {
-            _logger.LogError(ex, "KbFlagDriftAuditJob: unexpected error during audit");
+            _logger.LogError(ex, "KbFlagDriftAuditJob: unexpected error during reconcile");
             context.Result = new { Error = ex.Message };
         }
 #pragma warning restore CA1031

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Jobs/KbFlagDriftAuditJob.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Jobs/KbFlagDriftAuditJob.cs
@@ -90,7 +90,12 @@ internal sealed class KbFlagDriftAuditJob : IJob
             }
 
             // Load the drifted games TRACKED so we can flip the flag and persist.
+            // .AsTracking() is REQUIRED: MeepleAiDbContext defaults to NoTracking
+            // (PERF-06), so without it the loaded entities are detached and the
+            // SaveChangesAsync below is a silent no-op (the reconcile would never
+            // actually repair anything).
             var games = await _dbContext.SharedGames
+                .AsTracking()
                 .Where(g => driftedGameIds.Contains(g.Id))
                 .ToListAsync(cancellationToken)
                 .ConfigureAwait(false);

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/DependencyInjection/DocumentProcessingServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/DependencyInjection/DocumentProcessingServiceExtensions.cs
@@ -187,8 +187,9 @@ internal static class DocumentProcessingServiceExtensions
         // Issue #1831 follow-up: Register Quartz job for orphan cover recovery (daily at 03:00 UTC)
         RegisterPdfCoverOrphanRecoveryJob(services);
 
-        // Issue #2248 (epic #2242, Sub #6 Block B): periodic audit for the
-        // "Ready ⇒ HasKnowledgeBase" invariant. Runs every 10 minutes.
+        // Issue #2248 (epic #2242, Sub #6 Block B): periodic reconcile for the
+        // "Ready ⇒ HasKnowledgeBase" invariant. Runs every 10 minutes and repairs
+        // any SharedGame whose inline KB-flag projection was missed.
         RegisterKbFlagDriftAuditJob(services);
 
         return services;

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/PdfIndexingPipeline.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/PdfIndexingPipeline.cs
@@ -111,6 +111,17 @@ internal sealed class PdfIndexingPipeline : IPdfIndexingPipeline
             // Clear stale error from a previous failed run, if any —
             // matches the explicit reset in the legacy IndexPdfCommandHandler path.
             existing.IndexingError = null;
+            // Heal a missing SharedGameId link on the pre-existing "processing" row.
+            // Root cause of the has_knowledge_base drift: when the row was created in
+            // "processing" state without a SharedGameId, the VectorDocumentIndexedEvent
+            // emitted on the completed-transition below carried a null SharedGameId, so
+            // VectorDocumentIndexedForKbFlagHandler skipped the flag update even though the
+            // caller knows the SharedGameId here. Backfill it so the event — and the row —
+            // both carry the link.
+            if (existing.SharedGameId is null && sharedGameId is not null)
+            {
+                existing.SharedGameId = sharedGameId;
+            }
         }
 
         try
@@ -158,7 +169,9 @@ internal sealed class PdfIndexingPipeline : IPdfIndexingPipeline
                     documentId: existing.Id,
                     gameId: existing.GameId ?? Guid.Empty,
                     chunkCount: existing.ChunkCount,
-                    sharedGameId: existing.SharedGameId),
+                    // Prefer the healed row value; fall back to the caller-supplied id so the
+                    // KB-flag projection never receives a null SharedGameId when the caller knew it.
+                    sharedGameId: existing.SharedGameId ?? sharedGameId),
                 CancellationToken.None).ConfigureAwait(false);
         }
     }

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/EventHandlers/VectorDocumentIndexedForKbFlagHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/EventHandlers/VectorDocumentIndexedForKbFlagHandler.cs
@@ -71,7 +71,12 @@ internal sealed class VectorDocumentIndexedForKbFlagHandler
 
         // Load the SharedGame row, flip the flag if needed, save.
         // Idempotent: returns early if HasKnowledgeBase is already true.
+        // .AsTracking() is REQUIRED: MeepleAiDbContext defaults to NoTracking
+        // (PERF-06), so without it the entity is detached and SaveChangesAsync
+        // below persists nothing — the flag would silently never flip (the
+        // production root cause of the has_knowledge_base drift).
         var sharedGame = await _context.SharedGames
+            .AsTracking()
             .FirstOrDefaultAsync(g => g.Id == sharedGameId.Value, cancellationToken)
             .ConfigureAwait(false);
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Jobs/KbFlagDriftAuditJobTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Jobs/KbFlagDriftAuditJobTests.cs
@@ -2,9 +2,11 @@ using Api.BoundedContexts.DocumentProcessing.Application.Jobs;
 using Api.Infrastructure;
 using Api.Infrastructure.Entities;
 using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Services;
 using Api.Tests.Constants;
 using Api.Tests.TestHelpers;
 using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Quartz;
@@ -13,8 +15,9 @@ using Xunit;
 namespace Api.Tests.BoundedContexts.DocumentProcessing.Application.Jobs;
 
 /// <summary>
-/// Issue #2248 (epic #2242, Sub #6 Block B): unit tests for the periodic audit
-/// that guards the "Ready ⇒ HasKnowledgeBase" invariant.
+/// Issue #2248 (epic #2242, Sub #6 Block B): unit tests for the periodic reconcile
+/// that repairs the "Ready ⇒ HasKnowledgeBase" invariant when the inline projection
+/// was missed (e.g. a VectorDocumentIndexedEvent carrying a null SharedGameId).
 /// </summary>
 [Trait("Category", TestCategories.Unit)]
 [Trait("BoundedContext", "DocumentProcessing")]
@@ -22,6 +25,25 @@ namespace Api.Tests.BoundedContexts.DocumentProcessing.Application.Jobs;
 public sealed class KbFlagDriftAuditJobTests
 {
     private readonly Mock<ILogger<KbFlagDriftAuditJob>> _logger = new();
+    private readonly Mock<IHybridCacheService> _cache = new();
+    private readonly Mock<ICacheInvalidationRetryPolicy> _retryPolicy = new();
+
+    public KbFlagDriftAuditJobTests()
+    {
+        _cache
+            .Setup(c => c.RemoveByTagAcrossReplicasAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(0);
+        // Execute the wrapped invalidation so the cache mock is genuinely exercised.
+        _retryPolicy
+            .Setup(p => p.ExecuteAsync(
+                It.IsAny<Func<CancellationToken, ValueTask>>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .Returns<Func<CancellationToken, ValueTask>, string, CancellationToken>((op, _, ct) => op(ct).AsTask());
+    }
+
+    private KbFlagDriftAuditJob CreateJob(MeepleAiDbContext db) =>
+        new(db, _cache.Object, _retryPolicy.Object, _logger.Object);
 
     private static PdfDocumentEntity ReadyPdf(Guid id, Guid sharedGameId) =>
         new()
@@ -69,59 +91,58 @@ public sealed class KbFlagDriftAuditJobTests
     }
 
     [Fact]
-    public async Task Execute_NoDriftedRows_LogsZeroAndReturns()
+    public async Task Execute_NoDriftedGames_ReturnsZeroAndDoesNotTouchCache()
     {
         var sharedGameId = Guid.NewGuid();
         await using var db = TestDbContextFactory.CreateInMemoryDbContext();
 
-        // Healthy state: PDF Ready and SharedGame.HasKnowledgeBase=true (the invariant holds)
+        // Healthy state: PDF Ready and SharedGame.HasKnowledgeBase=true (invariant holds)
         db.SharedGames.Add(Game(sharedGameId, hasKb: true));
         db.PdfDocuments.Add(ReadyPdf(Guid.NewGuid(), sharedGameId));
         await db.SaveChangesAsync();
 
-        var job = new KbFlagDriftAuditJob(db, _logger.Object);
         var ctx = FakeContext();
+        await CreateJob(db).Execute(ctx);
 
-        await job.Execute(ctx);
-
-        ctx.Result.Should().BeEquivalentTo(new { DriftedRows = 0 });
+        ctx.Result.Should().BeEquivalentTo(new { RepairedGames = 0 });
+        _cache.Verify(
+            c => c.RemoveByTagAcrossReplicasAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 
     [Fact]
-    public async Task Execute_DriftDetected_LogsWarningAndIncrementsCounter()
+    public async Task Execute_DriftDetected_RepairsFlagAndInvalidatesCache()
     {
         var sharedGameId = Guid.NewGuid();
-        var pdfId = Guid.NewGuid();
         await using var db = TestDbContextFactory.CreateInMemoryDbContext();
 
-        // Drifted state: PDF Ready but SharedGame.HasKnowledgeBase=false (the bug
-        // #2243 Block A patches and Sub #2 architecture refactor structurally fixes).
+        // Drifted state: PDF Ready but SharedGame.HasKnowledgeBase=false.
         db.SharedGames.Add(Game(sharedGameId, hasKb: false));
-        db.PdfDocuments.Add(ReadyPdf(pdfId, sharedGameId));
+        db.PdfDocuments.Add(ReadyPdf(Guid.NewGuid(), sharedGameId));
         await db.SaveChangesAsync();
 
-        var job = new KbFlagDriftAuditJob(db, _logger.Object);
         var ctx = FakeContext();
+        await CreateJob(db).Execute(ctx);
 
-        await job.Execute(ctx);
+        ctx.Result.Should().BeEquivalentTo(new { RepairedGames = 1 });
 
-        ctx.Result.Should().BeEquivalentTo(new { DriftedRows = 1 });
+        // The flag is now actually repaired in the DB (the key new behaviour).
+        var reloaded = await db.SharedGames.AsNoTracking().SingleAsync(g => g.Id == sharedGameId);
+        reloaded.HasKnowledgeBase.Should().BeTrue();
 
-        // Warning per drifted row + 1 Error summary line.
-        _logger.Verify(
-            x => x.Log(
-                LogLevel.Warning,
-                It.IsAny<EventId>(),
-                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("KbFlagDrift detected", StringComparison.Ordinal)),
-                null,
-                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+        // Cache invalidated: the "search-games" list tag + the per-game detail tag.
+        _cache.Verify(
+            c => c.RemoveByTagAcrossReplicasAsync("search-games", It.IsAny<CancellationToken>()),
+            Times.Once);
+        _cache.Verify(
+            c => c.RemoveByTagAcrossReplicasAsync($"shared-game:{sharedGameId}", It.IsAny<CancellationToken>()),
             Times.Once);
 
         _logger.Verify(
             x => x.Log(
-                LogLevel.Error,
+                LogLevel.Warning,
                 It.IsAny<EventId>(),
-                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("SLO=0 violated", StringComparison.Ordinal)),
+                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("KbFlagDrift reconciled", StringComparison.Ordinal)),
                 null,
                 It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
             Times.Once);
@@ -132,22 +153,19 @@ public sealed class KbFlagDriftAuditJobTests
     {
         await using var db = TestDbContextFactory.CreateInMemoryDbContext();
 
-        // A PDF with null SharedGameId (private game / orphan) must not appear in the audit.
         var orphan = ReadyPdf(Guid.NewGuid(), sharedGameId: Guid.NewGuid());
         orphan.SharedGameId = null;
         db.PdfDocuments.Add(orphan);
         await db.SaveChangesAsync();
 
-        var job = new KbFlagDriftAuditJob(db, _logger.Object);
         var ctx = FakeContext();
+        await CreateJob(db).Execute(ctx);
 
-        await job.Execute(ctx);
-
-        ctx.Result.Should().BeEquivalentTo(new { DriftedRows = 0 });
+        ctx.Result.Should().BeEquivalentTo(new { RepairedGames = 0 });
     }
 
     [Fact]
-    public async Task Execute_PdfNotReady_DoesNotDrift()
+    public async Task Execute_PdfNotReady_DoesNotRepairFlag()
     {
         var sharedGameId = Guid.NewGuid();
         await using var db = TestDbContextFactory.CreateInMemoryDbContext();
@@ -158,11 +176,11 @@ public sealed class KbFlagDriftAuditJobTests
         db.PdfDocuments.Add(indexing);
         await db.SaveChangesAsync();
 
-        var job = new KbFlagDriftAuditJob(db, _logger.Object);
         var ctx = FakeContext();
+        await CreateJob(db).Execute(ctx);
 
-        await job.Execute(ctx);
-
-        ctx.Result.Should().BeEquivalentTo(new { DriftedRows = 0 });
+        ctx.Result.Should().BeEquivalentTo(new { RepairedGames = 0 });
+        var reloaded = await db.SharedGames.AsNoTracking().SingleAsync(g => g.Id == sharedGameId);
+        reloaded.HasKnowledgeBase.Should().BeFalse();
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/PdfIndexingPipelineSharedGameIdHealTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/PdfIndexingPipelineSharedGameIdHealTests.cs
@@ -1,0 +1,80 @@
+using Api.BoundedContexts.KnowledgeBase.Application.Services;
+using Api.BoundedContexts.KnowledgeBase.Domain.Events;
+using Api.Infrastructure.Entities;
+using Api.Tests.Constants;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Services;
+
+/// <summary>
+/// Regression test for the has_knowledge_base drift root cause: when a
+/// VectorDocument row was created in "processing" state WITHOUT a SharedGameId,
+/// the completed-transition previously published a VectorDocumentIndexedEvent
+/// with a null SharedGameId, so VectorDocumentIndexedForKbFlagHandler skipped the
+/// flag update. IndexAsync now heals the row's SharedGameId from the caller-supplied
+/// value and publishes the event with it.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "KnowledgeBase")]
+public sealed class PdfIndexingPipelineSharedGameIdHealTests
+{
+    [Fact]
+    public async Task IndexAsync_CompletesProcessingRowWithNullSharedGameId_PublishesEventWithSharedGameIdAndHealsRow()
+    {
+        var pdfDocumentId = Guid.NewGuid();
+        var sharedGameId = Guid.NewGuid();
+        var gameId = Guid.NewGuid();
+
+        await using var db = TestDbContextFactory.CreateInMemoryDbContext();
+        // Pre-existing "processing" row created WITHOUT the SharedGameId link.
+        db.VectorDocuments.Add(new VectorDocumentEntity
+        {
+            Id = Guid.NewGuid(),
+            GameId = gameId,
+            SharedGameId = null,
+            PdfDocumentId = pdfDocumentId,
+            ChunkCount = 0,
+            TotalCharacters = 0,
+            IndexingStatus = "processing",
+            IndexedAt = DateTime.UtcNow.AddMinutes(-1),
+        });
+        await db.SaveChangesAsync();
+
+        VectorDocumentIndexedEvent? published = null;
+        var mediator = new Mock<IMediator>();
+        mediator
+            .Setup(m => m.Publish(It.IsAny<VectorDocumentIndexedEvent>(), It.IsAny<CancellationToken>()))
+            .Callback<VectorDocumentIndexedEvent, CancellationToken>((e, _) => published = e)
+            .Returns(Task.CompletedTask);
+
+        var pipeline = new PdfIndexingPipeline(
+            db,
+            mediator.Object,
+            TimeProvider.System,
+            NullLogger<PdfIndexingPipeline>.Instance);
+
+        await pipeline.IndexAsync(
+            pdfDocumentId: pdfDocumentId,
+            gameId: gameId,
+            sharedGameId: sharedGameId,
+            chunkCount: 12,
+            totalCharacters: 3400,
+            language: "en");
+
+        // The event carries the SharedGameId the caller knew — not null.
+        published.Should().NotBeNull();
+        published!.SharedGameId.Should().Be(sharedGameId);
+
+        // The row itself is healed so the link survives for downstream reads.
+        var reloaded = await db.VectorDocuments.AsNoTracking()
+            .SingleAsync(v => v.PdfDocumentId == pdfDocumentId);
+        reloaded.SharedGameId.Should().Be(sharedGameId);
+        reloaded.IndexingStatus.Should().Be("completed");
+    }
+}

--- a/apps/api/tests/Api.Tests/Integration/SharedGameCatalog/KbFlagNoTrackingPersistenceTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/SharedGameCatalog/KbFlagNoTrackingPersistenceTests.cs
@@ -1,0 +1,168 @@
+using Api.BoundedContexts.DocumentProcessing.Application.Jobs;
+using Api.BoundedContexts.KnowledgeBase.Domain.Events;
+using Api.BoundedContexts.SharedGameCatalog.Application.EventHandlers;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Services;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Quartz;
+using Xunit;
+
+namespace Api.Tests.Integration.SharedGameCatalog;
+
+/// <summary>
+/// Regression for the has_knowledge_base NoTracking silent no-op (PERF-06, cf. #2734, #2660).
+///
+/// Both writers that maintain <c>shared_games.has_knowledge_base</c> load the SharedGame row and
+/// mutate it before <c>SaveChangesAsync</c>. <see cref="MeepleAiDbContext"/> defaults to
+/// <c>QueryTrackingBehavior.NoTracking</c> in production (and in
+/// <see cref="IntegrationWebApplicationFactory"/>), so without an explicit <c>.AsTracking()</c> the
+/// save persists NOTHING — the "AI-ready" flag silently stays false.
+///
+/// The two writers:
+///  - <see cref="KbFlagDriftAuditJob"/> (periodic reconcile) — repairs drifted games.
+///  - <see cref="VectorDocumentIndexedForKbFlagHandler"/> (inline projection) — flips the flag on index.
+///
+/// Category=Unit tests missed this because <c>TestDbContextFactory</c> uses the EF Core in-memory
+/// provider with default TrackAll semantics; these tests run against real Postgres via
+/// Testcontainers with the production NoTracking default, so the mutation must actually persist.
+/// </summary>
+[Collection("Integration-GroupD")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("Dependency", "PostgreSQL")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+[Trait("Issue", "2248")]
+public sealed class KbFlagNoTrackingPersistenceTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly string _databaseName = $"kb_flag_notracking_{Guid.NewGuid():N}";
+    private WebApplicationFactory<Program> _factory = null!;
+
+    public KbFlagNoTrackingPersistenceTests(SharedTestcontainersFixture fixture) => _fixture = fixture;
+
+    public async ValueTask InitializeAsync()
+    {
+        var conn = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+        await TestcontainersWaitHelpers.WaitForPostgresReadyAsync(conn);
+        _factory = IntegrationWebApplicationFactory.Create(conn);
+        using var scope = _factory.Services.CreateScope();
+        await scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>().Database.MigrateAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_factory != null) await _factory.DisposeAsync();
+        await _fixture.DropIsolatedDatabaseAsync(_databaseName);
+    }
+
+    private static IJobExecutionContext FakeJobContext()
+    {
+        var ctx = new Mock<IJobExecutionContext>();
+        ctx.SetupGet(c => c.FireTimeUtc).Returns(DateTimeOffset.UtcNow);
+        ctx.SetupGet(c => c.CancellationToken).Returns(CancellationToken.None);
+        ctx.SetupProperty(c => c.Result);
+        return ctx.Object;
+    }
+
+    /// <summary>Seeds User → SharedGame(HasKnowledgeBase=false) → Ready PdfDocument (FK order).</summary>
+    private async Task<Guid> SeedDriftedGameAsync(bool withReadyPdf)
+    {
+        var userId = Guid.NewGuid();
+        var gameId = Guid.NewGuid();
+
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        db.Users.Add(new UserEntity
+        {
+            Id = userId,
+            Email = $"seed-{userId:N}@meepleai.dev",
+            Tier = "premium",
+            Role = "admin",
+        });
+        db.SharedGames.Add(new SharedGameEntity
+        {
+            Id = gameId,
+            Title = "Gloomhaven",
+            HasKnowledgeBase = false,
+        });
+        if (withReadyPdf)
+        {
+            db.PdfDocuments.Add(new PdfDocumentEntity
+            {
+                Id = Guid.NewGuid(),
+                FileName = "rules.pdf",
+                FilePath = "/uploads/rules.pdf",
+                UploadedByUserId = userId,
+                SharedGameId = gameId,
+                ProcessingState = "Ready",
+            });
+        }
+        await db.SaveChangesAsync();
+        return gameId;
+    }
+
+    private async Task<bool> ReloadHasKnowledgeBaseAsync(Guid gameId)
+    {
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var game = await db.SharedGames.AsNoTracking().FirstAsync(g => g.Id == gameId);
+        return game.HasKnowledgeBase;
+    }
+
+    [Fact(DisplayName = "#2248: KbFlagDriftAuditJob persists HasKnowledgeBase=true under NoTracking (real DB)")]
+    public async Task ReconcileJob_PersistsHasKnowledgeBaseFlag()
+    {
+        var gameId = await SeedDriftedGameAsync(withReadyPdf: true);
+
+        // Execute the reconcile against a NoTracking DbContext resolved from the real container.
+        await using (var scope = _factory.Services.CreateAsyncScope())
+        {
+            var job = new KbFlagDriftAuditJob(
+                scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>(),
+                scope.ServiceProvider.GetRequiredService<IHybridCacheService>(),
+                scope.ServiceProvider.GetRequiredService<ICacheInvalidationRetryPolicy>(),
+                scope.ServiceProvider.GetRequiredService<ILogger<KbFlagDriftAuditJob>>());
+
+            await job.Execute(FakeJobContext());
+        }
+
+        // Fresh context: the flag must have actually flipped (fails without .AsTracking()).
+        (await ReloadHasKnowledgeBaseAsync(gameId)).Should().BeTrue(
+            "KbFlagDriftAuditJob must load SharedGames .AsTracking() so the flip persists under the NoTracking default");
+    }
+
+    [Fact(DisplayName = "#2248: VectorDocumentIndexedForKbFlagHandler persists HasKnowledgeBase=true under NoTracking (real DB)")]
+    public async Task InlineHandler_PersistsHasKnowledgeBaseFlag()
+    {
+        var gameId = await SeedDriftedGameAsync(withReadyPdf: false);
+
+        await using (var scope = _factory.Services.CreateAsyncScope())
+        {
+            var handler = new VectorDocumentIndexedForKbFlagHandler(
+                scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>(),
+                scope.ServiceProvider.GetRequiredService<IHybridCacheService>(),
+                scope.ServiceProvider.GetRequiredService<ICacheInvalidationRetryPolicy>(),
+                scope.ServiceProvider.GetRequiredService<ILogger<VectorDocumentIndexedForKbFlagHandler>>());
+
+            var evt = new VectorDocumentIndexedEvent(
+                documentId: Guid.NewGuid(),
+                gameId: Guid.NewGuid(),
+                chunkCount: 12,
+                sharedGameId: gameId);
+
+            await handler.Handle(evt, CancellationToken.None);
+        }
+
+        (await ReloadHasKnowledgeBaseAsync(gameId)).Should().BeTrue(
+            "VectorDocumentIndexedForKbFlagHandler must load the SharedGame .AsTracking() so the flip persists under the NoTracking default");
+    }
+}

--- a/apps/web/src/app/(public)/shared-games/page-client.tsx
+++ b/apps/web/src/app/(public)/shared-games/page-client.tsx
@@ -51,6 +51,7 @@ import {
 
 const SEARCH_DEBOUNCE_MS = 300;
 const VALID_CHIP_KEYS: ReadonlySet<ChipKey> = new Set([
+  'with-kb',
   'with-toolkit',
   'with-agent',
   'top-rated',

--- a/apps/web/src/hooks/useSharedGames.ts
+++ b/apps/web/src/hooks/useSharedGames.ts
@@ -58,6 +58,7 @@ export interface UseSharedGamesResult {
 function chipsToBackendArgs(chips: readonly ChipKey[]): Partial<SearchSharedGamesArgs> {
   // Build a mutable bag, then cast to the readonly partial when returning.
   const args: {
+    hasKb?: boolean;
     hasToolkit?: boolean;
     hasAgent?: boolean;
     isTopRated?: boolean;
@@ -65,6 +66,9 @@ function chipsToBackendArgs(chips: readonly ChipKey[]): Partial<SearchSharedGame
   } = {};
   for (const chip of chips) {
     switch (chip) {
+      case 'with-kb':
+        args.hasKb = true;
+        break;
       case 'with-toolkit':
         args.hasToolkit = true;
         break;

--- a/apps/web/src/lib/library/__tests__/library-filters.test.ts
+++ b/apps/web/src/lib/library/__tests__/library-filters.test.ts
@@ -202,6 +202,42 @@ describe('sortLibraryEntries', () => {
     expect(result.map(e => e.gameTitle)).toEqual(['Azul', 'Wingspan', 'Catan', 'Brass']);
   });
 
+  it('surfaces KB-ready entries first in the default (recent) sort, then by addedAt', () => {
+    const mixed: readonly UserLibraryEntry[] = [
+      baseEntry({
+        id: 'a',
+        gameId: 'g-a',
+        gameTitle: 'NoKbNewest',
+        addedAt: '2026-04-30T10:00:00.000Z',
+        hasKb: false,
+      }),
+      baseEntry({
+        id: 'b',
+        gameId: 'g-b',
+        gameTitle: 'KbOlder',
+        addedAt: '2026-04-27T10:00:00.000Z',
+        hasKb: true,
+      }),
+      baseEntry({
+        id: 'c',
+        gameId: 'g-c',
+        gameTitle: 'KbNewer',
+        addedAt: '2026-04-29T10:00:00.000Z',
+        hasKb: true,
+      }),
+      baseEntry({
+        id: 'd',
+        gameId: 'g-d',
+        gameTitle: 'NoKbOlder',
+        addedAt: '2026-04-28T10:00:00.000Z',
+        hasKb: false,
+      }),
+    ];
+    const result = sortLibraryEntries(mixed, 'recent');
+    // KB-ready first (by addedAt DESC among them), then the rest (by addedAt DESC).
+    expect(result.map(e => e.gameTitle)).toEqual(['KbNewer', 'KbOlder', 'NoKbNewest', 'NoKbOlder']);
+  });
+
   it('sorts by title alphabetically (case-insensitive)', () => {
     const result = sortLibraryEntries(entries, 'title');
     expect(result.map(e => e.gameTitle)).toEqual(['Azul', 'Brass', 'Catan', 'Wingspan']);

--- a/apps/web/src/lib/library/library-filters.ts
+++ b/apps/web/src/lib/library/library-filters.ts
@@ -120,7 +120,15 @@ export function sortLibraryEntries(
       return copy.sort(compareState);
     case 'recent':
     default:
-      return copy.sort((a, b) => Date.parse(b.addedAt) - Date.parse(a.addedAt));
+      // Default view: surface KB-ready games first (primary tie-breaker), then most
+      // recently added. Mirrors the /games catalog default sort so an unfiltered
+      // library also puts AI-ready entries at the top ("Solo con KB pronta" off).
+      return copy.sort((a, b) => {
+        const aKb = a.hasKb ? 0 : 1;
+        const bKb = b.hasKb ? 0 : 1;
+        if (aKb !== bKb) return aKb - bKb;
+        return Date.parse(b.addedAt) - Date.parse(a.addedAt);
+      });
   }
 }
 

--- a/apps/web/src/lib/shared-games/__tests__/filters.test.ts
+++ b/apps/web/src/lib/shared-games/__tests__/filters.test.ts
@@ -10,13 +10,19 @@ import {
 } from '../filters';
 
 describe('FILTER_CHIPS', () => {
-  it('exposes the 4 chips required by the sp3-shared-games mockup', () => {
+  it('exposes the KB-ready chip first, then the sp3-shared-games mockup chips', () => {
     expect(FILTER_CHIPS.map(c => c.key)).toEqual([
+      'with-kb',
       'with-toolkit',
       'with-agent',
       'top-rated',
       'new',
     ]);
+  });
+
+  it('maps the with-kb chip to the "Solo con KB pronta" i18n label key', () => {
+    const kbChip = FILTER_CHIPS.find(c => c.key === 'with-kb');
+    expect(kbChip?.i18nKey).toBe('pages.sharedGames.chips.withKb');
   });
 });
 

--- a/apps/web/src/lib/shared-games/filters.ts
+++ b/apps/web/src/lib/shared-games/filters.ts
@@ -11,9 +11,13 @@
  * a name→id map.
  */
 
-export type ChipKey = 'with-toolkit' | 'with-agent' | 'top-rated' | 'new';
+export type ChipKey = 'with-kb' | 'with-toolkit' | 'with-agent' | 'top-rated' | 'new';
 
 export const FILTER_CHIPS: readonly { readonly key: ChipKey; readonly i18nKey: string }[] = [
+  // "Solo con KB pronta" — filter to AI-ready games (SharedGame.HasKnowledgeBase).
+  // Backend maps ?hasKb=true → SearchSharedGamesQuery.HasKnowledgeBase; when this
+  // chip is OFF the default Title sort already lists KB-ready games first.
+  { key: 'with-kb', i18nKey: 'pages.sharedGames.chips.withKb' },
   { key: 'with-toolkit', i18nKey: 'pages.sharedGames.chips.withToolkit' },
   { key: 'with-agent', i18nKey: 'pages.sharedGames.chips.withAgent' },
   { key: 'top-rated', i18nKey: 'pages.sharedGames.chips.topRated' },

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -3012,6 +3012,7 @@
         "totalCounter": "{total, plural, =1 {1 game in the catalog} other {# games in the catalog}}"
       },
       "chips": {
+        "withKb": "KB-ready only",
         "withToolkit": "With toolkit",
         "withAgent": "With agent",
         "topRated": "Top rated",

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -3062,6 +3062,7 @@
         "totalCounter": "{total, plural, =1 {1 gioco nel catalogo} other {# giochi nel catalogo}}"
       },
       "chips": {
+        "withKb": "Solo con KB pronta",
         "withToolkit": "Con toolkit",
         "withAgent": "Con agente",
         "topRated": "Top rated",


### PR DESCRIPTION
## Problema

`shared_games.has_knowledge_base` restava `false` per **ogni** gioco indicizzato dal path async (osservato: 0/126 in locale, 0/127 in staging) nonostante la KB fosse completa. Effetto: le viste flag-gated (Discover, filtro "AI-ready", dettaglio gioco, agenti) mostravano "nessun gioco con KB".

## Root cause

`PdfIndexingPipeline` sulla transizione → `completed` (ramo riga esistente) pubblicava `VectorDocumentIndexedEvent` con `existing.SharedGameId`, che è **null** quando la riga "processing" era stata creata prima di conoscere lo `SharedGameId`. La proiezione `VectorDocumentIndexedForKbFlagHandler` skippa l'aggiornamento del flag se lo `SharedGameId` dell'evento è null → il flag non veniva mai settato. Il `KbFlagDriftAuditJob` rilevava la deriva (alert SLO=0) ma era **audit-only**.

## Fix

**Backend**
- `PdfIndexingPipeline`: heal di `existing.SharedGameId` dal parametro noto sulla transizione completed + publish con `existing.SharedGameId ?? sharedGameId` → la proiezione non riceve mai più null.
- `KbFlagDriftAuditJob`: da **audit** a **reconcile**. Ripara `has_knowledge_base=true` per i giochi con un PDF `Ready` e invalida la cache read-model del catalogo come fa l'handler inline. Auto-guarisce lo storico bloccato al deploy; metrica + alert SLO=0 preservati (una pipeline sana riconcilia zero).

**Frontend**
- `shared-games`: nuovo chip filtro **"with-kb"** ("Solo con KB pronta" / "KB-ready only") wirato al plumbing già esistente `?hasKb` → `SearchSharedGamesQuery.HasKnowledgeBase`. Con chip OFF, il sort di default (Title) già elenca i KB-ready per primi.
- `library`: il sort di default (recent) ora mette i giochi KB-ready per primi.

## Test / gate
- BE: `PdfIndexingPipelineSharedGameIdHealTests` (1) + `KbFlagDriftAuditJobTests` reconcile (4).
- FE: `filters` + `library-filters` (45).
- BE build `-warnaserror` ✅ · BE test ✅ · FE typecheck ✅ · FE lint ✅

## Note ops (già eseguite, fuori PR)
- Backfill una-tantum del flag applicato a **locale (127)** e **staging (127)** per rendere subito visibile la KB esistente; la reconcile-job lo rende poi automatico.

## Scope / follow-up
- Coperti `/games` (shared-games) + `/library`. Superfici agenti dedicate non incluse (nessuna lista-agenti standalone in scope; il filtro `hasAgent` per i giochi esiste già).

🤖 Generated with [Claude Code](https://claude.com/claude-code)