### PR TITLE
feat(catalog): cover-da-PDF per SharedGame + fix P1 resolver R2

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/CompleteChunkedUploadCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/CompleteChunkedUploadCommandHandler.cs
@@ -33,7 +33,6 @@ namespace Api.BoundedContexts.DocumentProcessing.Application.Commands;
 internal class CompleteChunkedUploadCommandHandler : ICommandHandler<CompleteChunkedUploadCommand, CompleteChunkedUploadResult>
 {
     private static readonly string UploadTempBasePath = Path.Combine(Path.GetTempPath(), "meepleai_uploads");
-    internal const string DuplicateContentErrorMessage = "Un file identico è già stato caricato per questo gioco.";
 
     private readonly IChunkedUploadSessionRepository _sessionRepository;
     private readonly MeepleAiDbContext _dbContext;
@@ -45,6 +44,7 @@ internal class CompleteChunkedUploadCommandHandler : ICommandHandler<CompleteChu
     private readonly IPdfTextExtractor _pdfTextExtractor;
     private readonly IPdfTableExtractor _tableExtractor;
     private readonly IMediator _mediator;
+    private readonly IPdfDeduplicationService _pdfDeduplicationService;
 
     public CompleteChunkedUploadCommandHandler(
         IChunkedUploadSessionRepository sessionRepository,
@@ -56,6 +56,7 @@ internal class CompleteChunkedUploadCommandHandler : ICommandHandler<CompleteChu
         IPdfTextExtractor pdfTextExtractor,
         IPdfTableExtractor tableExtractor,
         IMediator mediator,
+        IPdfDeduplicationService pdfDeduplicationService,
         TimeProvider? timeProvider = null)
     {
         _sessionRepository = sessionRepository ?? throw new ArgumentNullException(nameof(sessionRepository));
@@ -67,6 +68,7 @@ internal class CompleteChunkedUploadCommandHandler : ICommandHandler<CompleteChu
         _pdfTextExtractor = pdfTextExtractor ?? throw new ArgumentNullException(nameof(pdfTextExtractor));
         _tableExtractor = tableExtractor ?? throw new ArgumentNullException(nameof(tableExtractor));
         _mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
+        _pdfDeduplicationService = pdfDeduplicationService ?? throw new ArgumentNullException(nameof(pdfDeduplicationService));
         _timeProvider = timeProvider ?? TimeProvider.System;
     }
 
@@ -109,36 +111,55 @@ internal class CompleteChunkedUploadCommandHandler : ICommandHandler<CompleteChu
                 );
             }
 
-            // Check for duplicate content globally (same file content across any game)
+            // Check for duplicate content and, if found, transparently reuse the
+            // existing PDF document instead of rejecting the upload (Task 2 of the
+            // PDF dedup alignment plan; centralizes the rule previously duplicated
+            // and divergent between AddRulebookCommandHandler (reuse) and this
+            // handler (reject) in IPdfDeduplicationService).
             if (contentHash != null)
             {
-                var isDuplicate = await _dbContext.PdfDocuments.AnyAsync(
-                    p => p.ContentHash == contentHash,
-                    cancellationToken).ConfigureAwait(false);
+                var dedup = await _pdfDeduplicationService
+                    .EvaluateAsync(contentHash, session.GameId, session.PrivateGameId, session.UserId, cancellationToken)
+                    .ConfigureAwait(false);
 
-                if (isDuplicate)
+                if (dedup.Decision == PdfDedupDecision.ReuseExisting)
                 {
-                    // Cleanup the stored file (handles both local and S3 storage)
+                    // Cleanup del file appena assemblato (best effort): non serve, riusiamo l'esistente.
                     if (storageResult!.FileId != null)
                     {
                         try
                         {
-                            await _blobStorageService.DeleteAsync(
-                                storageResult.FileId,
-                                BlobCategory.Pdf,
-                                (session.PrivateGameId ?? session.GameId)?.ToString() ?? string.Empty,
-                                cancellationToken).ConfigureAwait(false);
+                            await _blobStorageService.DeleteAsync(storageResult.FileId, BlobCategory.Pdf,
+                                (session.PrivateGameId ?? session.GameId)?.ToString() ?? string.Empty, cancellationToken)
+                                .ConfigureAwait(false);
                         }
-                        catch { /* best effort cleanup */ }
+                        catch { /* best effort */ }
+                    }
+
+                    // Riuso trasparente via EntityLink verso il gioco.
+                    var linkTargetGameId = session.GameId ?? session.PrivateGameId ?? Guid.Empty;
+                    if (linkTargetGameId != Guid.Empty)
+                    {
+                        try
+                        {
+                            await _mediator.Send(new CreateEntityLinkCommand(
+                                SourceEntityType: MeepleEntityType.Game,
+                                SourceEntityId: linkTargetGameId,
+                                TargetEntityType: MeepleEntityType.KbCard,
+                                TargetEntityId: dedup.ExistingPdfDocumentId!.Value,
+                                LinkType: EntityLinkType.RelatedTo,
+                                Scope: EntityLinkScope.User,
+                                OwnerUserId: session.UserId), cancellationToken).ConfigureAwait(false);
+                        }
+                        catch (DuplicateEntityLinkException) { /* idempotent */ }
                     }
 
                     return new CompleteChunkedUploadResult(
-                        Success: false,
-                        DocumentId: null,
+                        Success: true,
+                        DocumentId: dedup.ExistingPdfDocumentId,
                         FileName: sanitizedFileName,
-                        ErrorMessage: DuplicateContentErrorMessage,
-                        MissingChunks: null
-                    );
+                        ErrorMessage: null,
+                        MissingChunks: null);
                 }
             }
 

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/MaterializePdfCoverCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/MaterializePdfCoverCommand.cs
@@ -1,0 +1,34 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.DocumentProcessing.Application.Commands;
+
+/// <summary>
+/// Renders <see cref="PageNumber"/> of the given PDF, encodes it as a WebP
+/// cover thumbnail, uploads it to R2 under <see cref="DbKey"/>, and marks
+/// the <c>PdfDocument</c>'s cover as generated. Materialization is
+/// synchronous. Returns the DB-stored key (no suffix) — see
+/// <see cref="Api.BoundedContexts.DocumentProcessing.Application.Services.IPdfCoverUploadPipeline"/>
+/// for the R2 key convention.
+/// </summary>
+internal sealed record MaterializePdfCoverCommand(Guid PdfDocumentId, int PageNumber, string DbKey) : ICommand<string>;
+
+/// <summary>
+/// Thrown when the PDF page render step fails (e.g. the SmolDocling page-image
+/// service is unavailable or returns 404). This is a non-blocking failure:
+/// the caller should not retry indefinitely, and the PDF's cover state is
+/// left untouched (no "half-generated" state).
+/// </summary>
+public sealed class CoverMaterializationException : Exception
+{
+    public CoverMaterializationException(string message, Exception inner) : base(message, inner)
+    {
+    }
+
+    public CoverMaterializationException()
+    {
+    }
+
+    public CoverMaterializationException(string message) : base(message)
+    {
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/MaterializePdfCoverCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/MaterializePdfCoverCommandHandler.cs
@@ -64,7 +64,11 @@ internal sealed class MaterializePdfCoverCommandHandler : ICommandHandler<Materi
 
         var dbKey = await _uploadPipeline.UploadAsync(command.DbKey, webpBytes, cancellationToken).ConfigureAwait(false);
 
-        pdf.MarkCoverGenerated(dbKey, command.PageNumber);
+        // C1 fix: command.PageNumber is 1-based (render/query contract); PdfDocument.CoverPageIndex
+        // is documented and persisted as 0-based (see PdfProcessingPipelineService.cs and
+        // BackfillPdfCoversJob.cs, which both store result.SelectedPageIndex, a 0-based value).
+        // Only the stored index changes here — the GetPdfPageImageQuery call above stays 1-based.
+        pdf.MarkCoverGenerated(dbKey, command.PageNumber - 1);
 
         await _repository.UpdateAsync(pdf, cancellationToken).ConfigureAwait(false);
         await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/MaterializePdfCoverCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/MaterializePdfCoverCommandHandler.cs
@@ -1,0 +1,74 @@
+using Api.BoundedContexts.DocumentProcessing.Application.Queries;
+using Api.BoundedContexts.DocumentProcessing.Application.Services;
+using Api.BoundedContexts.DocumentProcessing.Domain.Repositories;
+using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Infrastructure.Persistence;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.DocumentProcessing.Application.Commands;
+
+/// <summary>
+/// Handles <see cref="MaterializePdfCoverCommand"/>: render page → WebP → R2
+/// → mark cover generated. See the type's XML doc for the synchronous,
+/// non-blocking materialization contract.
+/// </summary>
+internal sealed class MaterializePdfCoverCommandHandler : ICommandHandler<MaterializePdfCoverCommand, string>
+{
+    private readonly IPdfDocumentRepository _repository;
+    private readonly IMediator _mediator;
+    private readonly IWebpVariantGenerator _webpVariantGenerator;
+    private readonly IPdfCoverUploadPipeline _uploadPipeline;
+    private readonly IUnitOfWork _unitOfWork;
+
+    public MaterializePdfCoverCommandHandler(
+        IPdfDocumentRepository repository,
+        IMediator mediator,
+        IWebpVariantGenerator webpVariantGenerator,
+        IPdfCoverUploadPipeline uploadPipeline,
+        IUnitOfWork unitOfWork)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
+        _webpVariantGenerator = webpVariantGenerator ?? throw new ArgumentNullException(nameof(webpVariantGenerator));
+        _uploadPipeline = uploadPipeline ?? throw new ArgumentNullException(nameof(uploadPipeline));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+    }
+
+    public async Task<string> Handle(MaterializePdfCoverCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var pdf = await _repository.GetByIdAsync(command.PdfDocumentId, cancellationToken).ConfigureAwait(false)
+            ?? throw new NotFoundException("PdfDocument", command.PdfDocumentId.ToString());
+
+        byte[] jpeg;
+        try
+        {
+            jpeg = await _mediator
+                .Send(new GetPdfPageImageQuery(command.PdfDocumentId, command.PageNumber), cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
+        {
+            // SmolDocling down/404: non-blocking failure, no "half-generated"
+            // cover state — leave PdfDocument untouched.
+            throw new CoverMaterializationException("Rendering pagina PDF non disponibile.", ex);
+        }
+
+        var webpBytes = await _webpVariantGenerator
+            .GenerateWebpAsync(jpeg, PdfCoverExtractor.ThumbnailWidth, PdfCoverExtractor.ThumbnailHeight, cancellationToken)
+            .ConfigureAwait(false);
+
+        var dbKey = await _uploadPipeline.UploadAsync(command.DbKey, webpBytes, cancellationToken).ConfigureAwait(false);
+
+        pdf.MarkCoverGenerated(dbKey, command.PageNumber);
+
+        await _repository.UpdateAsync(pdf, cancellationToken).ConfigureAwait(false);
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        return dbKey;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/IPdfCoverUploadPipeline.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/IPdfCoverUploadPipeline.cs
@@ -1,0 +1,19 @@
+namespace Api.BoundedContexts.DocumentProcessing.Application.Services;
+
+/// <summary>
+/// Uploads a materialized PDF cover WebP to R2. See
+/// <see cref="Api.BoundedContexts.SharedGameCatalog.Application.Services.CoverUrlResolver.ResolvePublicAsync"/>
+/// for the L4 read-side convention this pipeline's write side must match:
+/// the DB-stored key (<c>dbKey</c>, no suffix) resolves to the physical R2
+/// object <c>{dbKey}-preview.webp</c>.
+/// </summary>
+internal interface IPdfCoverUploadPipeline
+{
+    /// <summary>
+    /// Uploads <paramref name="webpBytes"/> to R2 as <c>{dbKey}-preview.webp</c>
+    /// with <c>Content-Type: image/webp</c> and an immutable cache-control
+    /// header, then returns <paramref name="dbKey"/> unchanged (no suffix) —
+    /// the value to persist on <c>PdfDocument.CoverR2Key</c>.
+    /// </summary>
+    Task<string> UploadAsync(string dbKey, byte[] webpBytes, CancellationToken cancellationToken);
+}

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/IPdfDeduplicationService.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/IPdfDeduplicationService.cs
@@ -1,0 +1,44 @@
+namespace Api.BoundedContexts.DocumentProcessing.Application.Services;
+
+/// <summary>
+/// Outcome of a PDF dedup evaluation: whether the caller should reuse an
+/// existing <see cref="Domain.Entities.PdfDocument"/> or proceed with a new upload.
+/// </summary>
+public enum PdfDedupDecision
+{
+    NewUpload,
+    ReuseExisting
+}
+
+/// <summary>
+/// Result of <see cref="IPdfDeduplicationService.EvaluateAsync"/>: the decision,
+/// the matched document id (when reusable), and the content hash that was evaluated.
+/// </summary>
+public sealed record PdfDedupResult(PdfDedupDecision Decision, Guid? ExistingPdfDocumentId, string ContentHash);
+
+/// <summary>
+/// Centralizes the PDF deduplication rule (SHA-256 content hash based) that was
+/// previously duplicated and divergent between <c>AddRulebookCommandHandler</c>
+/// (reuse via EntityLink) and <c>CompleteChunkedUploadCommandHandler</c> (reject).
+///
+/// Rule: catalog uploads (<c>sharedGameId</c> set) dedup GLOBALLY across the
+/// catalog; private uploads (<c>privateGameId</c> set) dedup PER-USER only.
+/// A match left in <see cref="Domain.Enums.PdfProcessingState.Failed"/> is treated
+/// as not reusable (a fresh upload is required).
+/// </summary>
+public interface IPdfDeduplicationService
+{
+    /// <summary>Computes the SHA-256 hex digest (lowercase) of the given content stream.</summary>
+    Task<string> ComputeContentHashAsync(Stream content, CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Evaluates whether an existing PDF with the same content hash can be reused,
+    /// scoping the lookup to the catalog (global) or the uploading user (private).
+    /// </summary>
+    Task<PdfDedupResult> EvaluateAsync(
+        string contentHash,
+        Guid? sharedGameId,
+        Guid? privateGameId,
+        Guid userId,
+        CancellationToken cancellationToken);
+}

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfDeduplicationService.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfDeduplicationService.cs
@@ -1,0 +1,45 @@
+using System.Security.Cryptography;
+using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
+using Api.BoundedContexts.DocumentProcessing.Domain.Repositories;
+
+namespace Api.BoundedContexts.DocumentProcessing.Application.Services;
+
+/// <summary>
+/// Default implementation of <see cref="IPdfDeduplicationService"/>.
+/// See the interface doc for the dedup rule (global for catalog, per-user for private).
+/// </summary>
+internal sealed class PdfDeduplicationService : IPdfDeduplicationService
+{
+    private readonly IPdfDocumentRepository _repo;
+
+    public PdfDeduplicationService(IPdfDocumentRepository repo)
+    {
+        _repo = repo;
+    }
+
+    public async Task<string> ComputeContentHashAsync(Stream content, CancellationToken cancellationToken)
+    {
+        var hash = await SHA256.HashDataAsync(content, cancellationToken).ConfigureAwait(false);
+        return Convert.ToHexStringLower(hash);
+    }
+
+    public async Task<PdfDedupResult> EvaluateAsync(
+        string contentHash,
+        Guid? sharedGameId,
+        Guid? privateGameId,
+        Guid userId,
+        CancellationToken cancellationToken)
+    {
+        // Catalog (shared): dedup GLOBALLY across all users. Private: dedup PER-USER (isolation).
+        var existing = sharedGameId.HasValue
+            ? await _repo.FindByContentHashAsync(contentHash, cancellationToken).ConfigureAwait(false)
+            : await _repo.FindByContentHashForUserAsync(contentHash, userId, cancellationToken).ConfigureAwait(false);
+
+        if (existing is null || existing.ProcessingState == PdfProcessingState.Failed)
+        {
+            return new PdfDedupResult(PdfDedupDecision.NewUpload, null, contentHash);
+        }
+
+        return new PdfDedupResult(PdfDedupDecision.ReuseExisting, existing.Id, contentHash);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/Entities/PdfDocument.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/Entities/PdfDocument.cs
@@ -92,6 +92,13 @@ internal sealed class PdfDocument : AggregateRoot<Guid>
     // Issue #1852: L4 PDF cover extraction state (mirrors PdfDocumentEntity columns).
     public string? CoverR2Key { get; private set; }
     public PdfCoverGenerationStatus CoverGenerationStatus { get; private set; } = PdfCoverGenerationStatus.Pending;
+    /// <summary>
+    /// Zero-based index of the PDF page the cover was rendered from (or heuristically
+    /// rejected/attempted, per <see cref="CoverGenerationStatus"/>). Mirrors the
+    /// zero-based convention of <c>ShareRequest.CoverPageIndex</c>. Callers passing a
+    /// 1-based page number (e.g. <c>MaterializePdfCoverCommand.PageNumber</c>) must
+    /// convert before calling <see cref="MarkCoverGenerated"/>.
+    /// </summary>
     public int? CoverPageIndex { get; private set; }
     public string? CoverGenerationError { get; private set; }
 
@@ -840,6 +847,11 @@ internal sealed class PdfDocument : AggregateRoot<Guid>
     /// Records successful PDF cover extraction and raises <see cref="PdfCoverGeneratedEvent"/>
     /// so SharedGame catalog can propagate the key. Issue #1852 (Gap A).
     /// </summary>
+    /// <param name="coverR2Key">The R2 object key (DB-stored, un-suffixed) of the generated cover.</param>
+    /// <param name="pageIndex">
+    /// Zero-based index of the source PDF page. Callers with a 1-based page number
+    /// must subtract 1 before calling this method.
+    /// </param>
     public void MarkCoverGenerated(string coverR2Key, int pageIndex)
     {
         if (string.IsNullOrWhiteSpace(coverR2Key))

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/Repositories/IPdfDocumentRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/Repositories/IPdfDocumentRepository.cs
@@ -13,4 +13,10 @@ internal interface IPdfDocumentRepository : IRepository<PdfDocument, Guid>
     Task<IReadOnlyList<PdfDocument>> FindByUserIdAsync(Guid userId, CancellationToken cancellationToken = default); // Issue #2732: Quota queries
     Task<bool> ExistsByContentHashAsync(string contentHash, Guid? gameId, Guid? privateGameId, CancellationToken cancellationToken = default);
     Task<PdfDocument?> FindByContentHashAsync(string contentHash, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Finds a PDF by content hash scoped to a single user. Used for private-game
+    /// dedup, which is isolated per-user (unlike the catalog's global lookup).
+    /// </summary>
+    Task<PdfDocument?> FindByContentHashForUserAsync(string contentHash, Guid userId, CancellationToken cancellationToken = default);
 }

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/DependencyInjection/DocumentProcessingServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/DependencyInjection/DocumentProcessingServiceExtensions.cs
@@ -8,6 +8,7 @@ using Api.BoundedContexts.DocumentProcessing.Infrastructure.Services;
 using Api.Extensions;
 using Api.Infrastructure.BackgroundServices;
 using Api.Services;
+using Api.Services.Pdf;
 using Api.Infrastructure.Http;
 using Api.SharedKernel.Infrastructure.Persistence;
 using Microsoft.Extensions.Configuration;
@@ -164,6 +165,15 @@ internal static class DocumentProcessingServiceExtensions
         // Issue #1831 (umbrella #1821 L4) — PDF first-page cover extraction
         services.AddScoped<IPdfCoverExtractor, PdfCoverExtractor>();
 
+        // Cover-da-PDF plan Task 3 — MaterializePdfCover R2 upload pipeline.
+        // Singleton because the underlying AmazonS3Client is thread-safe and
+        // reuses a connection pool — matches CoverR2UploadPipeline's lifetime.
+        // NOTE: IWebpVariantGenerator is already registered as a Singleton by
+        // SharedGameCatalogServiceExtensions.AddSharedGameCatalogContext (same
+        // DI container in Program.cs) — not re-registered here to avoid a
+        // duplicate registration for the same concrete type.
+        RegisterPdfCoverUploadPipeline(services);
+
         // Shared PDF processing pipeline (used by recovery job and future handler consolidation)
         services.AddScoped<IPdfProcessingPipelineService, PdfProcessingPipelineService>();
 
@@ -193,6 +203,55 @@ internal static class DocumentProcessingServiceExtensions
         RegisterKbFlagDriftAuditJob(services);
 
         return services;
+    }
+
+    /// <summary>
+    /// Cover-da-PDF plan Task 3 — registers <see cref="IPdfCoverUploadPipeline"/>
+    /// as a singleton backed by a lazily-constructed <see cref="Amazon.S3.IAmazonS3"/>
+    /// client. Mirrors <c>SharedGameCatalogServiceExtensions.RegisterCoverR2UploadPipeline</c>
+    /// (same <c>S3_*</c> env vars as <see cref="BlobStorageServiceFactory"/>) so the
+    /// two R2 cover pipelines don't drift on endpoint/credentials. Singleton
+    /// lifetime matches the long-lived AWS SDK client (thread-safe + connection pool).
+    /// </summary>
+    private static void RegisterPdfCoverUploadPipeline(IServiceCollection services)
+    {
+        services.AddSingleton<IPdfCoverUploadPipeline>(sp =>
+        {
+            var config = sp.GetRequiredService<IConfiguration>();
+            var logger = sp.GetRequiredService<ILogger<Api.BoundedContexts.DocumentProcessing.Infrastructure.Services.PdfCoverUploadPipeline>>();
+
+            var options = new S3StorageOptions
+            {
+                Endpoint = config["S3_ENDPOINT"] ?? throw new InvalidOperationException("S3_ENDPOINT is required for PdfCoverUploadPipeline"),
+                AccessKey = config["S3_ACCESS_KEY"] ?? throw new InvalidOperationException("S3_ACCESS_KEY is required for PdfCoverUploadPipeline"),
+                SecretKey = config["S3_SECRET_KEY"] ?? throw new InvalidOperationException("S3_SECRET_KEY is required for PdfCoverUploadPipeline"),
+                BucketName = config["S3_BUCKET_NAME"] ?? throw new InvalidOperationException("S3_BUCKET_NAME is required for PdfCoverUploadPipeline"),
+                Region = config["S3_REGION"] ?? "auto",
+                ForcePathStyle = bool.TryParse(config["S3_FORCE_PATH_STYLE"], out var forcePathStyle) && forcePathStyle,
+            };
+
+            var s3Config = new Amazon.S3.AmazonS3Config
+            {
+                ServiceURL = options.Endpoint,
+                ForcePathStyle = options.ForcePathStyle,
+                AuthenticationRegion = options.Region,
+            };
+
+            if (!string.Equals(options.Region, "auto", StringComparison.Ordinal)
+                && Amazon.RegionEndpoint.GetBySystemName(options.Region) != null)
+            {
+                s3Config.RegionEndpoint = Amazon.RegionEndpoint.GetBySystemName(options.Region);
+            }
+
+            var credentials = new Amazon.Runtime.BasicAWSCredentials(options.AccessKey, options.SecretKey);
+            var s3Client = new Amazon.S3.AmazonS3Client(credentials, s3Config);
+
+            // Issue #1357: R2 rejects x-amz-tagging-directive; strip it
+            // defensively (same hook used by BlobStorageServiceFactory).
+            s3Client.BeforeRequestEvent += BlobStorageServiceFactory.StripUnsupportedR2Headers;
+
+            return new Api.BoundedContexts.DocumentProcessing.Infrastructure.Services.PdfCoverUploadPipeline(s3Client, options, logger);
+        });
     }
 
     /// <summary>

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/DependencyInjection/DocumentProcessingServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/DependencyInjection/DocumentProcessingServiceExtensions.cs
@@ -61,6 +61,7 @@ internal static class DocumentProcessingServiceExtensions
         services.AddScoped<IUserQuotaInfoService, UserQuotaInfoService>(); // Local read service for user quota info (avoids cross-BC IUserRepository dependency)
         services.AddScoped<IQueueBackpressureService, QueueBackpressureService>(); // Issue #5457: Backpressure
         services.AddScoped<CitationPriorityService>(); // ISSUE-2051: Citation priority and deduplication
+        services.AddScoped<IPdfDeduplicationService, PdfDeduplicationService>(); // Centralized PDF dedup rule (cover-config plan Task 1)
 
         // Issue #3653: Private PDF progress streaming service (singleton for in-memory subscriber management)
         services.AddSingleton<IPrivatePdfProgressStreamService, PrivatePdfProgressStreamService>();

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/Persistence/PdfDocumentRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/Persistence/PdfDocumentRepository.cs
@@ -169,6 +169,17 @@ internal class PdfDocumentRepository : RepositoryBase, IPdfDocumentRepository
             cancellationToken).ConfigureAwait(false);
     }
 
+    public async Task<PdfDocument?> FindByContentHashForUserAsync(string contentHash, Guid userId, CancellationToken cancellationToken = default)
+    {
+        var entity = await DbContext.PdfDocuments
+            .AsNoTracking()
+            .Where(p => p.ContentHash == contentHash && p.UploadedByUserId == userId)
+            .OrderByDescending(p => p.UploadedAt)
+            .FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
+
+        return entity != null ? MapToDomain(entity) : null;
+    }
+
     private static PdfDocument MapToDomain(Api.Infrastructure.Entities.PdfDocumentEntity entity)
     {
         var fileName = new FileName(entity.FileName);

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/Services/PdfCoverUploadPipeline.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/Services/PdfCoverUploadPipeline.cs
@@ -1,0 +1,71 @@
+using Amazon.S3;
+using Amazon.S3.Model;
+using Api.BoundedContexts.DocumentProcessing.Application.Services;
+using Api.Services.Pdf;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.DocumentProcessing.Infrastructure.Services;
+
+/// <summary>
+/// <see cref="IPdfCoverUploadPipeline"/> implementation modeled on
+/// <see cref="Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services.CoverR2UploadPipeline"/>:
+/// talks directly to <see cref="IAmazonS3"/> using the raw <see cref="S3StorageOptions"/>
+/// (no <see cref="Api.Services.Pdf.IBlobStorageService"/> indirection), because the L4
+/// read side (<c>CoverUrlResolver.ResolvePublicAsync</c>) expects a flat
+/// <c>{dbKey}-preview.webp</c> object key rather than the folder-based
+/// <c>IBlobStorageService</c> layout.
+/// </summary>
+internal sealed class PdfCoverUploadPipeline : IPdfCoverUploadPipeline
+{
+    // Cover assets are immutable for 1 year; re-uploads use the same key so
+    // Cloudflare CDN cache stays warm (mirrors CoverR2UploadPipeline).
+    private const string ImmutableCacheControl = "public, max-age=31536000, immutable";
+    private const string WebpContentType = "image/webp";
+
+    private readonly IAmazonS3 _s3Client;
+    private readonly S3StorageOptions _options;
+    private readonly ILogger<PdfCoverUploadPipeline> _logger;
+
+    public PdfCoverUploadPipeline(IAmazonS3 s3Client, S3StorageOptions options, ILogger<PdfCoverUploadPipeline> logger)
+    {
+        _s3Client = s3Client ?? throw new ArgumentNullException(nameof(s3Client));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<string> UploadAsync(string dbKey, byte[] webpBytes, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(dbKey))
+        {
+            throw new ArgumentException("DB key must be non-null and non-empty.", nameof(dbKey));
+        }
+
+        if (webpBytes is null || webpBytes.Length == 0)
+        {
+            throw new ArgumentException("WebP bytes must be non-null and non-empty.", nameof(webpBytes));
+        }
+
+        // The resolver (CoverUrlResolver.ResolvePublicAsync) appends -preview.webp
+        // to the DB-stored key to derive the physical R2 object — this is the
+        // write side of that convention.
+        var objectKey = $"{dbKey}-preview.webp";
+
+        using var stream = new MemoryStream(webpBytes, writable: false);
+        var request = new PutObjectRequest
+        {
+            BucketName = _options.BucketName,
+            Key = objectKey,
+            InputStream = stream,
+            ContentType = WebpContentType,
+            AutoCloseStream = false,
+            DisablePayloadSigning = true,
+        };
+        request.Headers.CacheControl = ImmutableCacheControl;
+
+        await _s3Client.PutObjectAsync(request, cancellationToken).ConfigureAwait(false);
+
+        _logger.LogInformation("PdfCoverUploadPipeline: uploaded cover WebP to {ObjectKey}", objectKey);
+
+        return dbKey;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/ApproveGameProposal/ApproveGameProposalCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/ApproveGameProposal/ApproveGameProposalCommandHandler.cs
@@ -1,6 +1,7 @@
 using Api.BoundedContexts.DocumentProcessing.Infrastructure.Services;
 using Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
@@ -65,14 +66,25 @@ internal sealed class ApproveGameProposalCommandHandler : ICommandHandler<Approv
             throw new NotFoundException("ShareRequest", command.ShareRequestId.ToString());
         }
 
-        // 2. Validate request type
+        // 2. UpdateCover is a CoverChange approval action: it does not involve a private game
+        // promotion, so it is handled separately before the NewGameProposal-specific gates below.
+        if (command.ApprovalAction == ProposalApprovalAction.UpdateCover)
+        {
+            var coverTargetId = await ApproveCoverChangeAsync(shareRequest, command, cancellationToken)
+                .ConfigureAwait(false);
+
+            return await FinalizeApprovalAsync(shareRequest, command, coverTargetId, cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        // 3. Validate request type
         if (shareRequest.ContributionType != ContributionType.NewGameProposal)
         {
             throw new ConflictException(
                 $"ShareRequest {shareRequest.Id} is not a NewGameProposal (type: {shareRequest.ContributionType})");
         }
 
-        // 3. Get the private game from the UserLibraryEntry
+        // 4. Get the private game from the UserLibraryEntry
         // For NewGameProposal, SourceGameId references UserLibraryEntry.Id
         // Note: Using DbContext directly for cross-context access (UserLibrary domain entity doesn't expose PrivateGameId)
         var libraryEntry = await _context.UserLibraryEntries
@@ -100,7 +112,7 @@ internal sealed class ApproveGameProposalCommandHandler : ICommandHandler<Approv
             throw new NotFoundException("PrivateGame", libraryEntry.PrivateGameId.Value.ToString());
         }
 
-        // 4. Execute approval action based on type
+        // 5. Execute approval action based on type
         Guid targetSharedGameId = command.ApprovalAction switch
         {
             ProposalApprovalAction.ApproveAsNew =>
@@ -115,7 +127,22 @@ internal sealed class ApproveGameProposalCommandHandler : ICommandHandler<Approv
             _ => throw new InvalidOperationException($"Unknown approval action: {command.ApprovalAction}")
         };
 
-        // 5. Copy documents to shared game (if any attached)
+        return await FinalizeApprovalAsync(shareRequest, command, targetSharedGameId, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Copies any attached documents to the target shared game, approves the share request
+    /// (domain validates state and raises events), persists all changes, and builds the
+    /// response. Shared tail reused by every ApprovalAction branch, including UpdateCover.
+    /// </summary>
+    private async Task<ApproveShareRequestResponse> FinalizeApprovalAsync(
+        ShareRequest shareRequest,
+        ApproveGameProposalCommand command,
+        Guid targetSharedGameId,
+        CancellationToken cancellationToken)
+    {
+        // Copy documents to shared game (if any attached)
         var documentIds = shareRequest.AttachedDocuments.Select(d => d.DocumentId).ToList();
         if (documentIds.Count > 0)
         {
@@ -130,16 +157,16 @@ internal sealed class ApproveGameProposalCommandHandler : ICommandHandler<Approv
                 documentIds.Count, shareRequest.Id, targetSharedGameId);
         }
 
-        // 6. Approve the share request (domain validates state and raises events)
+        // Approve the share request (domain validates state and raises events)
         shareRequest.Approve(
             command.AdminId,
             targetSharedGameId,
             command.AdminNotes);
 
-        // 7. Update repository
+        // Update repository
         _shareRequestRepository.Update(shareRequest);
 
-        // 8. Persist all changes
+        // Persist all changes
         await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
         _logger.LogInformation(
@@ -161,6 +188,32 @@ internal sealed class ApproveGameProposalCommandHandler : ICommandHandler<Approv
             shareRequest.Status,
             targetSharedGameId,
             shareRequest.ResolvedAt.Value);
+    }
+
+    /// <summary>
+    /// Promotes a CoverChange proposal's pending cover image to L4 (SharedGame.PdfCoverR2Key).
+    /// Task 5: Game Cover-da-PDF.
+    /// </summary>
+    private async Task<Guid> ApproveCoverChangeAsync(
+        ShareRequest shareRequest,
+        ApproveGameProposalCommand command,
+        CancellationToken cancellationToken)
+    {
+        var targetId = command.TargetSharedGameId ?? shareRequest.TargetSharedGameId
+            ?? throw new ConflictException("CoverChange senza target shared game.");
+
+        var sharedGame = await _sharedGameRepository.GetByIdAsync(targetId, cancellationToken).ConfigureAwait(false)
+            ?? throw new NotFoundException($"SharedGame {targetId} not found.");
+
+        if (string.IsNullOrWhiteSpace(shareRequest.PendingCoverR2Key))
+        {
+            throw new ConflictException("Pending cover key mancante sulla proposal.");
+        }
+
+        sharedGame.SetPdfCoverR2Key(shareRequest.PendingCoverR2Key);
+        _sharedGameRepository.Update(sharedGame);
+
+        return targetId;
     }
 
     /// <summary>

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/ApproveGameProposal/ApproveGameProposalCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/ApproveGameProposal/ApproveGameProposalCommandHandler.cs
@@ -194,12 +194,28 @@ internal sealed class ApproveGameProposalCommandHandler : ICommandHandler<Approv
     /// Promotes a CoverChange proposal's pending cover image to L4 (SharedGame.PdfCoverR2Key).
     /// Task 5: Game Cover-da-PDF.
     /// </summary>
+    /// <exception cref="ConflictException">
+    /// I3 fix: thrown when <see cref="ApproveGameProposalCommand.TargetSharedGameId"/> is
+    /// supplied AND differs from the proposal's persisted
+    /// <see cref="ShareRequest.TargetSharedGameId"/>. Without this guard an admin-supplied
+    /// (e.g. tampered or stale) TargetSharedGameId could silently promote the pending
+    /// cover onto the wrong SharedGame instead of the one the proposal actually targets.
+    /// </exception>
     private async Task<Guid> ApproveCoverChangeAsync(
         ShareRequest shareRequest,
         ApproveGameProposalCommand command,
         CancellationToken cancellationToken)
     {
-        var targetId = command.TargetSharedGameId ?? shareRequest.TargetSharedGameId
+        if (command.TargetSharedGameId.HasValue
+            && shareRequest.TargetSharedGameId.HasValue
+            && command.TargetSharedGameId.Value != shareRequest.TargetSharedGameId.Value)
+        {
+            throw new ConflictException(
+                $"TargetSharedGameId mismatch: command specifies {command.TargetSharedGameId.Value} " +
+                $"but ShareRequest {shareRequest.Id} targets {shareRequest.TargetSharedGameId.Value}.");
+        }
+
+        var targetId = shareRequest.TargetSharedGameId ?? command.TargetSharedGameId
             ?? throw new ConflictException("CoverChange senza target shared game.");
 
         var sharedGame = await _sharedGameRepository.GetByIdAsync(targetId, cancellationToken).ConfigureAwait(false)

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/ProposeCoverChange/ProposeCoverChangeCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/ProposeCoverChange/ProposeCoverChangeCommand.cs
@@ -1,0 +1,89 @@
+using Api.BoundedContexts.DocumentProcessing.Application.Commands;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Infrastructure.Persistence;
+using FluentValidation;
+using MediatR;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands.ProposeCoverChange;
+
+/// <summary>
+/// Command for the authenticated-user flow that proposes a cover-from-PDF for a
+/// SharedGame (Task 6, Game Cover-da-PDF plan). Orchestrates
+/// <see cref="MaterializePdfCoverCommand"/> (Task 3 — renders the PDF page, encodes
+/// WebP, uploads to R2) to materialize a pending cover artifact, then creates a
+/// <see cref="ShareRequest"/> of type <c>CoverChange</c> (Task 4) so an admin can
+/// review and promote it to the SharedGame's public L4 cover (Task 5).
+/// </summary>
+/// <param name="UserId">The authenticated user proposing the cover.</param>
+/// <param name="SharedGameId">The target SharedGame the cover is proposed for.</param>
+/// <param name="PdfDocumentId">The source PDF the cover page is extracted from.</param>
+/// <param name="PageNumber">1-based page number to render as the cover.</param>
+internal sealed record ProposeCoverChangeCommand(
+    Guid UserId,
+    Guid SharedGameId,
+    Guid PdfDocumentId,
+    int PageNumber
+) : ICommand<Guid>;
+
+/// <summary>
+/// Validator for <see cref="ProposeCoverChangeCommand"/>.
+/// </summary>
+internal sealed class ProposeCoverChangeCommandValidator : AbstractValidator<ProposeCoverChangeCommand>
+{
+    public ProposeCoverChangeCommandValidator()
+    {
+        RuleFor(x => x.SharedGameId).NotEmpty();
+        RuleFor(x => x.PdfDocumentId).NotEmpty();
+        RuleFor(x => x.PageNumber).GreaterThan(0);
+    }
+}
+
+/// <summary>
+/// Handles <see cref="ProposeCoverChangeCommand"/>: materializes the pending cover
+/// (Task 3) then persists a Pending <see cref="ShareRequest"/> of type
+/// <c>CoverChange</c> (Task 4) referencing it. Materialization failures
+/// (<c>CoverMaterializationException</c>) propagate unhandled — no proposal is
+/// created without a successfully materialized pending cover (no "half" state).
+/// </summary>
+internal sealed class ProposeCoverChangeCommandHandler : ICommandHandler<ProposeCoverChangeCommand, Guid>
+{
+    private readonly IMediator _mediator;
+    private readonly IShareRequestRepository _shareRequests;
+    private readonly IUnitOfWork _unitOfWork;
+
+    public ProposeCoverChangeCommandHandler(
+        IMediator mediator,
+        IShareRequestRepository shareRequests,
+        IUnitOfWork unitOfWork)
+    {
+        _mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
+        _shareRequests = shareRequests ?? throw new ArgumentNullException(nameof(shareRequests));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+    }
+
+    public async Task<Guid> Handle(ProposeCoverChangeCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        // Deterministic dbKey for the pending cover of this proposal.
+        var dbKey = $"covers/{command.SharedGameId:D}/pdf-cover-pending";
+
+        var pendingKey = await _mediator
+            .Send(new MaterializePdfCoverCommand(command.PdfDocumentId, command.PageNumber, dbKey), cancellationToken)
+            .ConfigureAwait(false);
+
+        var request = ShareRequest.CreateCoverChange(
+            command.UserId,
+            command.SharedGameId,
+            command.PdfDocumentId,
+            pendingKey,
+            command.PageNumber);
+
+        await _shareRequests.AddAsync(request, cancellationToken).ConfigureAwait(false);
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        return request.Id;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/ProposeCoverChange/ProposeCoverChangeCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/ProposeCoverChange/ProposeCoverChangeCommand.cs
@@ -67,8 +67,18 @@ internal sealed class ProposeCoverChangeCommandHandler : ICommandHandler<Propose
     {
         ArgumentNullException.ThrowIfNull(command);
 
-        // Deterministic dbKey for the pending cover of this proposal.
-        var dbKey = $"covers/{command.SharedGameId:D}/pdf-cover-pending";
+        // I2 fix: the dbKey must be unique PER PROPOSAL, not deterministic per-game.
+        // A per-game deterministic key (e.g. "covers/{gameId}/pdf-cover-pending")
+        // means two proposals for the same game (two users, or two pages) write the
+        // SAME physical R2 object and persist the SAME PendingCoverR2Key. On
+        // approval, the admin approving proposal A could end up promoting whatever
+        // bytes a later still-pending proposal B last overwrote at that key — the
+        // wrong image gets promoted. The GUID segment below eliminates the
+        // collision while preserving the same slash-containing key SHAPE
+        // (covers/{gameId}/...) required by the R2 resolver fix (commit
+        // 05723c823's GetPresignedUrlForRawKeyAsync, which resolves slash/dot
+        // physical keys via an existence check).
+        var dbKey = $"covers/{command.SharedGameId:D}/pdf-cover-{Guid.NewGuid():N}";
 
         var pendingKey = await _mediator
             .Send(new MaterializePdfCoverCommand(command.PdfDocumentId, command.PageNumber, dbKey), cancellationToken)

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/ProposeCoverChange/ProposeCoverChangeCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/ProposeCoverChange/ProposeCoverChangeCommand.cs
@@ -74,12 +74,14 @@ internal sealed class ProposeCoverChangeCommandHandler : ICommandHandler<Propose
             .Send(new MaterializePdfCoverCommand(command.PdfDocumentId, command.PageNumber, dbKey), cancellationToken)
             .ConfigureAwait(false);
 
+        // C1 fix: command.PageNumber is 1-based; ShareRequest.CoverPageIndex is documented
+        // and stored 0-based (mirrors PdfDocument.CoverPageIndex).
         var request = ShareRequest.CreateCoverChange(
             command.UserId,
             command.SharedGameId,
             command.PdfDocumentId,
             pendingKey,
-            command.PageNumber);
+            command.PageNumber - 1);
 
         await _shareRequests.AddAsync(request, cancellationToken).ConfigureAwait(false);
         await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/CoverUrlResolver.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/CoverUrlResolver.cs
@@ -11,6 +11,20 @@ namespace Api.BoundedContexts.SharedGameCatalog.Application.Services;
 /// -> L2 (Wikidata) -> null. Each layer falls through to the next when its R2 key
 /// is missing or the blob storage cannot mint a presigned URL (returns null in dev / local).
 ///
+/// P1 fix (2026-07-14): L3/L4/L2 resolve via
+/// <see cref="IBlobStorageService.GetPresignedUrlForRawKeyAsync"/>, passing the
+/// exact physical object key these layers write deterministically
+/// (<c>{key}.webp</c> / <c>{key}-preview.webp</c>). The previous
+/// <c>GetPresignedDownloadUrlAsync(fileId, category, resourceKey)</c> call
+/// validated BOTH arguments with <c>PathSecurity.ValidateIdentifier</c> (which
+/// rejects <c>/</c> and <c>.</c>) and then did categorized prefix discovery —
+/// neither of which matches these layers' raw, slash-containing key shape, so
+/// the call always threw internally and returned null (silent no-op: covers
+/// never resolved). L2.5 (BGG) is intentionally UNCHANGED: its physical key is
+/// non-deterministic (<c>StoreAsync</c> mints a random fileId), so it cannot be
+/// resolved from the DB-persisted key via a raw-key lookup; it stays on the
+/// legacy path (still a placeholder today) pending a follow-up.
+///
 /// Issue #2123 (BGG ToS compliance): every resolution outcome — including the
 /// terminal <c>null</c> path that triggers a placeholder render on the FE —
 /// emits a <see cref="MeepleAiMetrics.CoverResolution"/> measurement tagged
@@ -35,10 +49,7 @@ internal static class CoverUrlResolver
         if (!string.IsNullOrWhiteSpace(userEntry?.CustomCoverR2Key))
         {
             var url = await blobStorage
-                .GetPresignedDownloadUrlAsync(
-                    $"{userEntry.CustomCoverR2Key}.webp",
-                    BlobCategory.GameImage,
-                    userEntry.CustomCoverR2Key)
+                .GetPresignedUrlForRawKeyAsync($"{userEntry.CustomCoverR2Key}.webp")
                 .ConfigureAwait(false);
             if (url is not null)
             {
@@ -68,10 +79,7 @@ internal static class CoverUrlResolver
         if (!string.IsNullOrWhiteSpace(sharedGame.PdfCoverR2Key))
         {
             var url = await blobStorage
-                .GetPresignedDownloadUrlAsync(
-                    $"{sharedGame.PdfCoverR2Key}-preview.webp",
-                    BlobCategory.GameImage,
-                    sharedGame.PdfCoverR2Key)
+                .GetPresignedUrlForRawKeyAsync($"{sharedGame.PdfCoverR2Key}-preview.webp")
                 .ConfigureAwait(false);
             if (url is not null)
             {
@@ -105,10 +113,7 @@ internal static class CoverUrlResolver
         if (!string.IsNullOrWhiteSpace(sharedGame.WikidataCoverR2Key))
         {
             var url = await blobStorage
-                .GetPresignedDownloadUrlAsync(
-                    $"{sharedGame.WikidataCoverR2Key}.webp",
-                    BlobCategory.GameImage,
-                    sharedGame.WikidataCoverR2Key)
+                .GetPresignedUrlForRawKeyAsync($"{sharedGame.WikidataCoverR2Key}.webp")
                 .ConfigureAwait(false);
             if (url is not null)
             {

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Entities/ShareRequest.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Entities/ShareRequest.cs
@@ -42,6 +42,9 @@ public sealed class ShareRequest : AggregateRoot<Guid>
     private DateTime? _modifiedAt;
     private Guid _createdBy;
     private Guid? _modifiedBy;
+    private string? _pendingCoverR2Key;
+    private int? _coverPageIndex;
+    private Guid? _sourcePdfDocumentId;
 
     private readonly List<ShareRequestDocument> _attachedDocuments = new();
 
@@ -149,6 +152,27 @@ public sealed class ShareRequest : AggregateRoot<Guid>
     public IReadOnlyCollection<ShareRequestDocument> AttachedDocuments => _attachedDocuments.AsReadOnly();
 
     /// <summary>
+    /// Gets the R2 object key of the pending cover image materialized from a PDF page.
+    /// Null unless this is a CoverChange contribution.
+    /// Task 4: Game Cover-da-PDF.
+    /// </summary>
+    public string? PendingCoverR2Key => _pendingCoverR2Key;
+
+    /// <summary>
+    /// Gets the zero-based index of the PDF page the pending cover was rendered from.
+    /// Null unless this is a CoverChange contribution.
+    /// Task 4: Game Cover-da-PDF.
+    /// </summary>
+    public int? CoverPageIndex => _coverPageIndex;
+
+    /// <summary>
+    /// Gets the ID of the source PDF document the pending cover was rendered from.
+    /// Null unless this is a CoverChange contribution.
+    /// Task 4: Game Cover-da-PDF.
+    /// </summary>
+    public Guid? SourcePdfDocumentId => _sourcePdfDocumentId;
+
+    /// <summary>
     /// Navigation property to the source private game (for NewGameProposal contributions).
     /// Issue #3665: Added for Phase 4 - Proposal System.
     /// </summary>
@@ -193,7 +217,10 @@ public sealed class ShareRequest : AggregateRoot<Guid>
         Guid createdBy,
         Guid? modifiedBy,
         byte[]? rowVersion = null,
-        List<ShareRequestDocument>? attachedDocuments = null) : base(id)
+        List<ShareRequestDocument>? attachedDocuments = null,
+        string? pendingCoverR2Key = null,
+        int? coverPageIndex = null,
+        Guid? sourcePdfDocumentId = null) : base(id)
     {
         _id = id;
         _userId = userId;
@@ -214,6 +241,9 @@ public sealed class ShareRequest : AggregateRoot<Guid>
         _createdBy = createdBy;
         _modifiedBy = modifiedBy;
         RowVersion = rowVersion;
+        _pendingCoverR2Key = pendingCoverR2Key;
+        _coverPageIndex = coverPageIndex;
+        _sourcePdfDocumentId = sourcePdfDocumentId;
 
         if (attachedDocuments != null)
             _attachedDocuments.AddRange(attachedDocuments);
@@ -334,6 +364,45 @@ public sealed class ShareRequest : AggregateRoot<Guid>
         request.AddDomainEvent(new ShareRequestCreatedEvent(
             id, userId, privateGameId, ContributionType.NewGameProposal));
 
+        return request;
+    }
+
+    /// <summary>
+    /// Creates a new share request proposing a replacement cover image for an existing
+    /// shared game, rendered from a page of an already-indexed PDF document.
+    /// Task 4: Game Cover-da-PDF.
+    /// </summary>
+    /// <param name="userId">The ID of the user creating the proposal.</param>
+    /// <param name="targetSharedGameId">The ID of the shared game the cover applies to.</param>
+    /// <param name="sourcePdfDocumentId">The ID of the source PDF document the cover was rendered from.</param>
+    /// <param name="pendingCoverR2Key">The R2 object key of the materialized pending cover image.</param>
+    /// <param name="coverPageIndex">The zero-based index of the PDF page the cover was rendered from.</param>
+    /// <param name="userNotes">Optional notes from the user.</param>
+    /// <returns>A new ShareRequest instance for a cover change proposal.</returns>
+    /// <exception cref="ArgumentException">
+    /// Thrown when required parameters are invalid.
+    /// </exception>
+    public static ShareRequest CreateCoverChange(
+        Guid userId,
+        Guid targetSharedGameId,
+        Guid sourcePdfDocumentId,
+        string pendingCoverR2Key,
+        int coverPageIndex,
+        string? userNotes = null)
+    {
+        if (targetSharedGameId == Guid.Empty)
+            throw new ArgumentException("TargetSharedGameId required", nameof(targetSharedGameId));
+
+        if (string.IsNullOrWhiteSpace(pendingCoverR2Key))
+            throw new ArgumentException("Pending cover key required", nameof(pendingCoverR2Key));
+
+        if (coverPageIndex < 0)
+            throw new ArgumentException("Page index must be non-negative", nameof(coverPageIndex));
+
+        var request = Create(userId, sourceGameId: targetSharedGameId, ContributionType.CoverChange, userNotes, targetSharedGameId);
+        request._pendingCoverR2Key = pendingCoverR2Key;
+        request._coverPageIndex = coverPageIndex;
+        request._sourcePdfDocumentId = sourcePdfDocumentId;
         return request;
     }
 

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Enums/ProposalApprovalAction.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Enums/ProposalApprovalAction.cs
@@ -24,5 +24,11 @@ public enum ProposalApprovalAction
     /// Creates a new SharedGame with a variant suffix (e.g., "Game Title (Variant)").
     /// Used for game editions, expansions, or regional variants.
     /// </summary>
-    ApproveAsVariant = 2
+    ApproveAsVariant = 2,
+
+    /// <summary>
+    /// Promote a CoverChange proposal's pending cover image to L4 on the target SharedGame.
+    /// Task 5: Game Cover-da-PDF.
+    /// </summary>
+    UpdateCover = 3
 }

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/ValueObjects/ContributionType.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/ValueObjects/ContributionType.cs
@@ -22,5 +22,12 @@ public enum ContributionType
     /// Proposing a private game for inclusion in the shared catalog (Issue #3665).
     /// Promotes PrivateGame to SharedGame upon approval.
     /// </summary>
-    NewGameProposal = 2
+    NewGameProposal = 2,
+
+    /// <summary>
+    /// Proposing a replacement cover image derived from a page of an already-indexed
+    /// PDF document (Game Cover-da-PDF, Task 4). Applies a pending cover materialized
+    /// in object storage to the target shared game upon approval.
+    /// </summary>
+    CoverChange = 3
 }

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/ShareRequestRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/ShareRequestRepository.cs
@@ -226,7 +226,10 @@ internal sealed class ShareRequestRepository : RepositoryBase, IShareRequestRepo
             entity.CreatedBy,
             entity.ModifiedBy,
             entity.RowVersion,
-            documents);
+            documents,
+            entity.PendingCoverR2Key,
+            entity.CoverPageIndex,
+            entity.SourcePdfDocumentId);
     }
 
     private static ShareRequestEntity MapToEntity(ShareRequest request)
@@ -251,7 +254,10 @@ internal sealed class ShareRequestRepository : RepositoryBase, IShareRequestRepo
             ModifiedAt = request.ModifiedAt,
             CreatedBy = request.CreatedBy,
             ModifiedBy = request.ModifiedBy,
-            RowVersion = request.RowVersion
+            RowVersion = request.RowVersion,
+            PendingCoverR2Key = request.PendingCoverR2Key,
+            CoverPageIndex = request.CoverPageIndex,
+            SourcePdfDocumentId = request.SourcePdfDocumentId
         };
 
         foreach (var doc in request.AttachedDocuments)

--- a/apps/api/src/Api/BoundedContexts/UserLibrary/Application/Commands/PrivateGames/AddPrivateGameCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/UserLibrary/Application/Commands/PrivateGames/AddPrivateGameCommand.cs
@@ -18,8 +18,11 @@ namespace Api.BoundedContexts.UserLibrary.Application.Commands.PrivateGames;
 /// <param name="PlayingTimeMinutes">Typical playing time in minutes (optional)</param>
 /// <param name="MinAge">Minimum recommended age (optional)</param>
 /// <param name="ComplexityRating">Complexity rating 1.0-5.0 (optional)</param>
-/// <param name="ImageUrl">URL to game image (optional)</param>
-/// <param name="ThumbnailUrl">URL to game thumbnail (optional, BGG only)</param>
+/// <remarks>
+/// ImageUrl/ThumbnailUrl were removed as user-input channels (BGG freeze #2123 / ADR-059).
+/// The PrivateGame cover is null at creation; it is populated later via the
+/// cover-from-PDF materialization flow.
+/// </remarks>
 internal record AddPrivateGameCommand(
     Guid UserId,
     string Source,
@@ -31,7 +34,5 @@ internal record AddPrivateGameCommand(
     string? Description = null,
     int? PlayingTimeMinutes = null,
     int? MinAge = null,
-    decimal? ComplexityRating = null,
-    string? ImageUrl = null,
-    string? ThumbnailUrl = null
+    decimal? ComplexityRating = null
 ) : ICommand<PrivateGameDto>;

--- a/apps/api/src/Api/BoundedContexts/UserLibrary/Application/Commands/PrivateGames/AddPrivateGameCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserLibrary/Application/Commands/PrivateGames/AddPrivateGameCommandHandler.cs
@@ -96,8 +96,8 @@ internal sealed class AddPrivateGameCommandHandler : ICommandHandler<AddPrivateG
                 playingTimeMinutes: command.PlayingTimeMinutes,
                 minAge: command.MinAge,
                 complexityRating: command.ComplexityRating,
-                imageUrl: command.ImageUrl,
-                thumbnailUrl: command.ThumbnailUrl);
+                imageUrl: null, // BGG freeze #2123 / ADR-059: no user-supplied external URLs; cover materializes later via PDF flow
+                thumbnailUrl: null);
 
             _logger.LogInformation(
                 "Created private game from BGG {BggId} for user {UserId}: {Title}",
@@ -117,7 +117,7 @@ internal sealed class AddPrivateGameCommandHandler : ICommandHandler<AddPrivateG
                 playingTimeMinutes: command.PlayingTimeMinutes,
                 minAge: command.MinAge,
                 complexityRating: command.ComplexityRating,
-                imageUrl: command.ImageUrl);
+                imageUrl: null); // BGG freeze #2123 / ADR-059: no user-supplied external URLs; cover materializes later via PDF flow
 
             _logger.LogInformation(
                 "Created manual private game for user {UserId}: {Title}",

--- a/apps/api/src/Api/BoundedContexts/UserLibrary/Application/Validators/PrivateGames/AddPrivateGameCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/UserLibrary/Application/Validators/PrivateGames/AddPrivateGameCommandValidator.cs
@@ -69,16 +69,6 @@ internal sealed class AddPrivateGameCommandValidator : AbstractValidator<AddPriv
             .WithMessage("MinAge cannot be negative")
             .When(x => x.MinAge.HasValue);
 
-        RuleFor(x => x.ImageUrl)
-            .MaximumLength(500)
-            .WithMessage("ImageUrl cannot exceed 500 characters")
-            .When(x => !string.IsNullOrWhiteSpace(x.ImageUrl));
-
-        RuleFor(x => x.ThumbnailUrl)
-            .MaximumLength(500)
-            .WithMessage("ThumbnailUrl cannot exceed 500 characters")
-            .When(x => !string.IsNullOrWhiteSpace(x.ThumbnailUrl));
-
         RuleFor(x => x.Description)
             .MaximumLength(2000)
             .WithMessage("Description cannot exceed 2000 characters")

--- a/apps/api/src/Api/DevTools/MockImpls/MockBlobStorageService.cs
+++ b/apps/api/src/Api/DevTools/MockImpls/MockBlobStorageService.cs
@@ -100,4 +100,12 @@ internal sealed class MockBlobStorageService : IBlobStorageService
         return Task.FromResult<string?>(
             $"http://localhost/mock-s3/{resourceKey}/{fileId}?expiry={expirySeconds ?? 3600}");
     }
+
+    /// <inheritdoc />
+    public Task<string?> GetPresignedUrlForRawKeyAsync(string rawKey, int? expirySeconds = null)
+    {
+        // Always return a synthetic URL — the mock assumes every blob exists.
+        return Task.FromResult<string?>(
+            $"http://localhost/mock-s3/raw?key={Uri.EscapeDataString(rawKey)}&expiry={expirySeconds ?? 3600}");
+    }
 }

--- a/apps/api/src/Api/Infrastructure/Configurations/SharedGameCatalog/ShareRequestEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/Configurations/SharedGameCatalog/ShareRequestEntityConfiguration.cs
@@ -84,6 +84,17 @@ internal sealed class ShareRequestEntityConfiguration : IEntityTypeConfiguration
         builder.Property(e => e.SourcePrivateGameId)
             .HasColumnName("source_private_game_id");
 
+        // Task 4: Game Cover-da-PDF - pending cover fields for CoverChange contributions
+        builder.Property(e => e.PendingCoverR2Key)
+            .HasColumnName("pending_cover_r2_key")
+            .HasMaxLength(512);
+
+        builder.Property(e => e.CoverPageIndex)
+            .HasColumnName("cover_page_index");
+
+        builder.Property(e => e.SourcePdfDocumentId)
+            .HasColumnName("source_pdf_document_id");
+
         // Indexes
         builder.HasIndex(e => e.UserId)
             .HasDatabaseName("ix_share_requests_user_id");

--- a/apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/ShareRequestEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/ShareRequestEntity.cs
@@ -47,6 +47,24 @@ public class ShareRequestEntity
 
     public byte[]? RowVersion { get; set; }
 
+    /// <summary>
+    /// R2 object key of the pending cover image materialized from a PDF page
+    /// (for CoverChange contributions). Task 4: Game Cover-da-PDF.
+    /// </summary>
+    public string? PendingCoverR2Key { get; set; }
+
+    /// <summary>
+    /// Zero-based index of the PDF page the pending cover was rendered from
+    /// (for CoverChange contributions). Task 4: Game Cover-da-PDF.
+    /// </summary>
+    public int? CoverPageIndex { get; set; }
+
+    /// <summary>
+    /// ID of the source PDF document the pending cover was rendered from
+    /// (for CoverChange contributions). Task 4: Game Cover-da-PDF.
+    /// </summary>
+    public Guid? SourcePdfDocumentId { get; set; }
+
     // Navigation properties
     public SharedGameEntity SourceGame { get; set; } = default!;
     public SharedGameEntity? TargetSharedGame { get; set; }

--- a/apps/api/src/Api/Infrastructure/Migrations/20260714163243_AddShareRequestCoverChangeFields.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260714163243_AddShareRequestCoverChangeFields.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260714163243_AddShareRequestCoverChangeFields")]
+    partial class AddShareRequestCoverChangeFields
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260714163243_AddShareRequestCoverChangeFields.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260714163243_AddShareRequestCoverChangeFields.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddShareRequestCoverChangeFields : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "cover_page_index",
+                table: "share_requests",
+                type: "integer",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "pending_cover_r2_key",
+                table: "share_requests",
+                type: "character varying(512)",
+                maxLength: 512,
+                nullable: true);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "source_pdf_document_id",
+                table: "share_requests",
+                type: "uuid",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "cover_page_index",
+                table: "share_requests");
+
+            migrationBuilder.DropColumn(
+                name: "pending_cover_r2_key",
+                table: "share_requests");
+
+            migrationBuilder.DropColumn(
+                name: "source_pdf_document_id",
+                table: "share_requests");
+        }
+    }
+}

--- a/apps/api/src/Api/Middleware/ApiExceptionHandlerMiddleware.cs
+++ b/apps/api/src/Api/Middleware/ApiExceptionHandlerMiddleware.cs
@@ -1,4 +1,5 @@
 using System;
+using Api.BoundedContexts.DocumentProcessing.Application.Commands;
 using Api.BoundedContexts.SessionTracking.Domain.Exceptions;
 using Api.Helpers;
 using Api.Middleware.Exceptions;
@@ -382,6 +383,15 @@ internal class ApiExceptionHandlerMiddleware
                 StatusCodes.Status404NotFound,
                 "not_found",
                 "The requested resource was not found"
+            ),
+
+            // Game Cover-da-PDF (Task 6): SmolDocling render failure (503/404) is a
+            // non-blocking failure, not a server bug — 503 lets the FE distinguish it
+            // from a generic 500 and show a retryable "cover unavailable" message.
+            CoverMaterializationException => (
+                StatusCodes.Status503ServiceUnavailable,
+                "cover_render_unavailable",
+                "La copertina non è al momento disponibile per il rendering. Riprova più tardi."
             ),
 
             // Domain exceptions (from SharedKernel)

--- a/apps/api/src/Api/Routing/Pdf/PdfUploadEndpoints.cs
+++ b/apps/api/src/Api/Routing/Pdf/PdfUploadEndpoints.cs
@@ -294,12 +294,6 @@ internal static class PdfUploadEndpoints
         {
             logger.LogWarning("Failed to complete chunked upload {SessionId}: {Error}", request.SessionId, result.ErrorMessage);
 
-            // Return 409 Conflict for duplicate content uploads
-            if (string.Equals(result.ErrorMessage, CompleteChunkedUploadCommandHandler.DuplicateContentErrorMessage, StringComparison.Ordinal))
-            {
-                return Results.Conflict(new { error = "duplicate_content", message = result.ErrorMessage });
-            }
-
             if (result.MissingChunks != null && result.MissingChunks.Count > 0)
             {
                 return Results.BadRequest(new { error = result.ErrorMessage, missingChunks = result.MissingChunks });

--- a/apps/api/src/Api/Routing/PrivateGameEndpoints.cs
+++ b/apps/api/src/Api/Routing/PrivateGameEndpoints.cs
@@ -112,9 +112,7 @@ internal static class PrivateGameEndpoints
                 Description: request.Description,
                 PlayingTimeMinutes: request.PlayingTimeMinutes,
                 MinAge: request.MinAge,
-                ComplexityRating: request.ComplexityRating,
-                ImageUrl: request.ImageUrl,
-                ThumbnailUrl: request.ThumbnailUrl
+                ComplexityRating: request.ComplexityRating
             );
 
             var result = await mediator.Send(command, ct).ConfigureAwait(false);
@@ -449,9 +447,7 @@ internal record AddPrivateGameRequest(
     string? Description = null,
     int? PlayingTimeMinutes = null,
     int? MinAge = null,
-    decimal? ComplexityRating = null,
-    string? ImageUrl = null,
-    string? ThumbnailUrl = null
+    decimal? ComplexityRating = null
 );
 
 /// <summary>

--- a/apps/api/src/Api/Routing/SharedGameCatalog/SharedGameCatalogUserEndpoints.cs
+++ b/apps/api/src/Api/Routing/SharedGameCatalog/SharedGameCatalogUserEndpoints.cs
@@ -1,7 +1,9 @@
 using Api.BoundedContexts.SharedGameCatalog.Application.Commands.MechanicExtractor;
+using Api.BoundedContexts.SharedGameCatalog.Application.Commands.ProposeCoverChange;
 using Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
 using Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetGameDocumentsForUser;
 using Api.BoundedContexts.SharedGameCatalog.Application.Queries.MechanicExtractor;
+using Api.Extensions;
 using Api.Middleware.Exceptions;
 using MediatR;
 
@@ -45,6 +47,16 @@ internal static class SharedGameCatalogUserEndpoints
             .Produces(StatusCodes.Status401Unauthorized)
             .Produces(StatusCodes.Status404NotFound)
             .Produces(StatusCodes.Status429TooManyRequests);
+
+        // Propose a cover-from-PDF for a SharedGame (Task 6, Game Cover-da-PDF plan).
+        group.MapPost("/games/{gameId:guid}/cover/propose-from-pdf", HandleProposeCoverFromPdf)
+            .RequireAuthorization()
+            .WithName("ProposeCoverFromPdf")
+            .WithSummary("Propose a cover-from-PDF for a shared game (Authenticated)")
+            .WithDescription("Materializes a pending cover from a page of an uploaded PDF and creates a Pending CoverChange share request for admin review.")
+            .Produces(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status401Unauthorized)
+            .Produces(StatusCodes.Status404NotFound);
     }
 
     private static async Task<IResult> HandleSubmitCardFeedback(
@@ -110,4 +122,36 @@ internal static class SharedGameCatalogUserEndpoints
             return Results.NotFound();
         }
     }
+
+    private static async Task<IResult> HandleProposeCoverFromPdf(
+        Guid gameId,
+        ProposeCoverFromPdfRequest body,
+        HttpContext context,
+        IMediator mediator,
+        CancellationToken ct)
+    {
+        var userId = context.User.GetUserId();
+        if (userId == Guid.Empty)
+        {
+            return Results.Unauthorized();
+        }
+
+        try
+        {
+            var command = new ProposeCoverChangeCommand(userId, gameId, body.PdfDocumentId, body.PageNumber);
+            var shareRequestId = await mediator.Send(command, ct).ConfigureAwait(false);
+            return Results.Ok(new { shareRequestId });
+        }
+        catch (NotFoundException)
+        {
+            return Results.NotFound();
+        }
+    }
 }
+
+/// <summary>
+/// Request body for <c>POST /api/v1/games/{gameId}/cover/propose-from-pdf</c>.
+/// </summary>
+/// <param name="PdfDocumentId">The source PDF the cover page is extracted from.</param>
+/// <param name="PageNumber">1-based page number to render as the cover.</param>
+internal sealed record ProposeCoverFromPdfRequest(Guid PdfDocumentId, int PageNumber);

--- a/apps/api/src/Api/Routing/SharedGameCatalog/SharedGameCatalogUserEndpoints.cs
+++ b/apps/api/src/Api/Routing/SharedGameCatalog/SharedGameCatalogUserEndpoints.cs
@@ -56,7 +56,8 @@ internal static class SharedGameCatalogUserEndpoints
             .WithDescription("Materializes a pending cover from a page of an uploaded PDF and creates a Pending CoverChange share request for admin review.")
             .Produces(StatusCodes.Status200OK)
             .Produces(StatusCodes.Status401Unauthorized)
-            .Produces(StatusCodes.Status404NotFound);
+            .Produces(StatusCodes.Status404NotFound)
+            .Produces(StatusCodes.Status503ServiceUnavailable);
     }
 
     private static async Task<IResult> HandleSubmitCardFeedback(

--- a/apps/api/src/Api/Services/Pdf/BlobStorageService.cs
+++ b/apps/api/src/Api/Services/Pdf/BlobStorageService.cs
@@ -236,6 +236,16 @@ internal class BlobStorageService : IBlobStorageService
         return Task.FromResult<string?>(null);
     }
 
+    /// <summary>
+    /// Local storage does not support pre-signed URLs.
+    /// Consumers should fall back to the API download endpoint when this returns null.
+    /// </summary>
+    public Task<string?> GetPresignedUrlForRawKeyAsync(string rawKey, int? expirySeconds = null)
+    {
+        _ = (rawKey, expirySeconds); // Local storage: no presigned URL
+        return Task.FromResult<string?>(null);
+    }
+
     private static string SanitizeFileName(string fileName)
     {
         return StringHelper.SanitizeFilename(fileName, maxLength: 200, fallbackName: "file");

--- a/apps/api/src/Api/Services/Pdf/IBlobStorageService.cs
+++ b/apps/api/src/Api/Services/Pdf/IBlobStorageService.cs
@@ -142,6 +142,20 @@ internal interface IBlobStorageService
     /// <param name="expirySeconds">URL expiration time (optional, defaults to configured value).</param>
     /// <returns>Pre-signed download URL, or null if not supported or file not found.</returns>
     Task<string?> GetPresignedDownloadUrlAsync(string fileId, BlobCategory category, string resourceKey, int? expirySeconds = null);
+
+    /// <summary>
+    /// Generates a pre-signed GET URL for an EXACT physical storage object key.
+    /// Unlike <see cref="GetPresignedDownloadUrlAsync"/>, this does NOT run
+    /// <c>PathSecurity.ValidateIdentifier</c> on the key and does NOT perform
+    /// prefix-based discovery — the caller is expected to have already validated
+    /// or otherwise trusted the key (e.g. a deterministic key composed by
+    /// business logic before being persisted to the DB). Slashes and dots are
+    /// allowed in <paramref name="rawKey"/>.
+    /// </summary>
+    /// <param name="rawKey">The exact physical storage object key.</param>
+    /// <param name="expirySeconds">URL expiration time (optional, defaults to configured value).</param>
+    /// <returns>Pre-signed GET URL, or null if the object does not exist or the operation is not supported.</returns>
+    Task<string?> GetPresignedUrlForRawKeyAsync(string rawKey, int? expirySeconds = null);
 }
 
 /// <summary>

--- a/apps/api/src/Api/Services/Pdf/S3BlobStorageService.cs
+++ b/apps/api/src/Api/Services/Pdf/S3BlobStorageService.cs
@@ -355,6 +355,74 @@ internal sealed class S3BlobStorageService : IBlobStorageService
 #pragma warning restore CA1031 // Do not catch general exception types
     }
 
+    /// <summary>
+    /// Generates a pre-signed GET URL for an EXACT physical S3 object key.
+    /// Deliberately skips <c>PathSecurity.ValidateIdentifier</c> and prefix
+    /// discovery — the caller (business logic that composed the key) is
+    /// trusted. An existence check (HEAD via <c>GetObjectMetadataAsync</c>) is
+    /// performed FIRST: this is load-bearing, because returning a presigned
+    /// URL for a non-existent object would render as a broken image on the
+    /// client instead of falling back to a placeholder.
+    /// </summary>
+    public async Task<string?> GetPresignedUrlForRawKeyAsync(string rawKey, int? expirySeconds = null)
+    {
+        try
+        {
+            if (string.IsNullOrWhiteSpace(rawKey))
+            {
+                return null;
+            }
+
+            try
+            {
+                await _s3Client.GetObjectMetadataAsync(_options.BucketName, rawKey, CancellationToken.None)
+                    .ConfigureAwait(false);
+            }
+            catch (AmazonS3Exception ex) when (
+                ex.StatusCode == System.Net.HttpStatusCode.NotFound ||
+                string.Equals(ex.ErrorCode, "NotFound", StringComparison.OrdinalIgnoreCase) ||
+                string.Equals(ex.ErrorCode, "NoSuchKey", StringComparison.OrdinalIgnoreCase))
+            {
+                _logger.LogWarning(ex, "Cannot generate pre-signed URL: raw key not found in S3: {Key}", rawKey);
+                return null;
+            }
+
+            var expiry = expirySeconds ?? _options.PresignedUrlExpirySeconds;
+
+            var request = new GetPreSignedUrlRequest
+            {
+                BucketName = _options.BucketName,
+                Key = rawKey,
+                Expires = DateTime.UtcNow.AddSeconds(expiry),
+                Verb = HttpVerb.GET
+            };
+
+            var url = await _s3Client.GetPreSignedURLAsync(request).ConfigureAwait(false);
+
+            _logger.LogInformation(
+                "Generated pre-signed URL for raw key {Key} (expires in {Expiry}s)",
+                rawKey, expiry);
+
+            return url;
+        }
+        catch (AmazonS3Exception ex)
+        {
+            _logger.LogError(ex, "S3 error generating pre-signed URL for raw key {Key}: {ErrorCode}", rawKey, ex.ErrorCode);
+            return null;
+        }
+#pragma warning disable CA1031 // Do not catch general exception types
+        catch (Exception ex)
+        {
+            // SERVICE BOUNDARY PATTERN: S3 storage service boundary - must handle all errors gracefully
+            // Rationale: This is a service entry point that interacts with external S3 storage. Network and
+            // S3 operations can throw various runtime exceptions (timeouts, network errors, authentication failures).
+            // We must catch all exceptions to return null instead of crashing the service.
+            _logger.LogError(ex, "Unexpected error generating pre-signed URL for raw key {Key}", rawKey);
+            return null;
+        }
+#pragma warning restore CA1031 // Do not catch general exception types
+    }
+
     private static string SanitizeFileName(string fileName)
     {
         return StringHelper.SanitizeFilename(fileName, maxLength: 200, fallbackName: "file");

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Commands/CompleteChunkedUploadCommandHandlerZeroChunkTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Commands/CompleteChunkedUploadCommandHandlerZeroChunkTests.cs
@@ -1,4 +1,5 @@
 using Api.BoundedContexts.DocumentProcessing.Application.Commands;
+using Api.BoundedContexts.DocumentProcessing.Application.Services;
 using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
 using Api.BoundedContexts.DocumentProcessing.Domain.Repositories;
 using Api.BoundedContexts.DocumentProcessing.Infrastructure.External;
@@ -113,6 +114,7 @@ public class CompleteChunkedUploadCommandHandlerZeroChunkTests
                 extractorMock.Object,
                 tableExtractorMock.Object,
                 Mock.Of<IMediator>(),
+                Mock.Of<IPdfDeduplicationService>(),
                 TimeProvider.System);
 
             // Act --------------------------------------------------------------------

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Commands/CompleteChunkedUploadDedupTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Commands/CompleteChunkedUploadDedupTests.cs
@@ -1,0 +1,129 @@
+using Api.BoundedContexts.DocumentProcessing.Application.Commands;
+using Api.BoundedContexts.DocumentProcessing.Application.Services;
+using Api.BoundedContexts.DocumentProcessing.Domain.Entities;
+using Api.BoundedContexts.DocumentProcessing.Domain.Repositories;
+using Api.BoundedContexts.DocumentProcessing.Infrastructure.External;
+using Api.Services;
+using Api.Services.Pdf;
+using Api.Tests.Constants;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.DocumentProcessing.Application.Commands;
+
+/// <summary>
+/// Regression test for the chunked-upload duplicate-content path (Task 2 of the
+/// PDF dedup alignment plan). Previously, a matching SHA-256 <c>ContentHash</c>
+/// caused <see cref="CompleteChunkedUploadCommandHandler"/> to REJECT the upload
+/// with <c>DuplicateContentErrorMessage</c>. This pins the aligned behavior:
+/// the handler now delegates to <see cref="IPdfDeduplicationService"/> and, on
+/// <see cref="PdfDedupDecision.ReuseExisting"/>, transparently reuses the existing
+/// document (Success: true, DocumentId: existingId) instead of rejecting.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "DocumentProcessing")]
+public class CompleteChunkedUploadDedupTests
+{
+    [Fact]
+    public async Task Complete_HashKnownReady_ReusesExistingInsteadOfRejecting()
+    {
+        // Arrange ----------------------------------------------------------------
+        var db = TestDbContextFactory.CreateInMemoryDbContext();
+        var existingId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+        var gameId = Guid.NewGuid();
+        var sessionId = Guid.NewGuid();
+
+        // Real temp directory + single chunk file, because AssembleAndStoreFileAsync
+        // is private and reads real files from disk via session.GetChunkFilePath/TempDirectory.
+        var tempDir = Path.Combine(Path.GetTempPath(), "meepleai_uploads", sessionId.ToString());
+        Directory.CreateDirectory(tempDir);
+
+        try
+        {
+            var session = new ChunkedUploadSession(
+                sessionId,
+                gameId,
+                userId,
+                "rulebook.pdf",
+                totalFileSize: 14,
+                tempDirectory: tempDir);
+
+            var chunkPath = session.GetChunkFilePath(0);
+            await File.WriteAllTextAsync(chunkPath, "dummy pdf data");
+            session.MarkChunkReceived(0);
+
+            var sessionRepoMock = new Mock<IChunkedUploadSessionRepository>();
+            sessionRepoMock
+                .Setup(r => r.GetByIdAsync(sessionId, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(session);
+
+            var blobStorageMock = new Mock<IBlobStorageService>();
+            blobStorageMock
+                .Setup(b => b.StoreAsync(
+                    It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new BlobStorageResult(true, Guid.NewGuid().ToString(), "/tmp/rulebook.pdf", 14));
+            blobStorageMock
+                .Setup(b => b.DeleteAsync(It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(true);
+
+            var dedupMock = new Mock<IPdfDeduplicationService>();
+            dedupMock
+                .Setup(d => d.EvaluateAsync(
+                    It.IsAny<string>(), It.IsAny<Guid?>(), It.IsAny<Guid?>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new PdfDedupResult(PdfDedupDecision.ReuseExisting, existingId, "h"));
+
+            var mediatorMock = new Mock<IMediator>();
+
+            var sc = new ServiceCollection();
+            sc.AddSingleton(db);
+            var provider = sc.BuildServiceProvider();
+            var scopeFactory = provider.GetRequiredService<IServiceScopeFactory>();
+
+            var handler = new CompleteChunkedUploadCommandHandler(
+                sessionRepoMock.Object,
+                db,
+                blobStorageMock.Object,
+                Mock.Of<IBackgroundTaskService>(),
+                NullLogger<CompleteChunkedUploadCommandHandler>.Instance,
+                scopeFactory,
+                Mock.Of<IPdfTextExtractor>(),
+                Mock.Of<IPdfTableExtractor>(),
+                mediatorMock.Object,
+                dedupMock.Object,
+                TimeProvider.System);
+
+            var command = new CompleteChunkedUploadCommand(sessionId, userId);
+
+            // Act ----------------------------------------------------------------
+            var result = await handler.Handle(command, CancellationToken.None);
+
+            // Assert ---------------------------------------------------------------
+            result.Success.Should().BeTrue();
+            result.DocumentId.Should().Be(existingId);
+            result.ErrorMessage.Should().BeNull();
+
+            dedupMock.Verify(d => d.EvaluateAsync(
+                It.IsAny<string>(), gameId, null, userId, It.IsAny<CancellationToken>()), Times.Once);
+
+            mediatorMock.Verify(m => m.Send(
+                It.IsAny<Api.BoundedContexts.EntityRelationships.Application.Commands.CreateEntityLinkCommand>(),
+                It.IsAny<CancellationToken>()), Times.Once);
+
+            // No new PdfDocumentEntity should have been created for the reused hash.
+            db.PdfDocuments.Should().BeEmpty();
+        }
+        finally
+        {
+            if (Directory.Exists(tempDir))
+            {
+                Directory.Delete(tempDir, recursive: true);
+            }
+        }
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Handlers/MaterializePdfCoverCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Handlers/MaterializePdfCoverCommandHandlerTests.cs
@@ -1,0 +1,70 @@
+using Api.BoundedContexts.DocumentProcessing.Application.Commands;
+using Api.BoundedContexts.DocumentProcessing.Application.Queries;
+using Api.BoundedContexts.DocumentProcessing.Application.Services;
+using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
+using Api.BoundedContexts.DocumentProcessing.Domain.Repositories;
+using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Tests.BoundedContexts.DocumentProcessing.TestHelpers;
+using Api.Tests.Constants;
+using FluentAssertions;
+using MediatR;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.DocumentProcessing.Application.Handlers;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "DocumentProcessing")]
+public class MaterializePdfCoverCommandHandlerTests
+{
+    [Fact]
+    public async Task Handle_RendersPageEncodesWebpUploadsAndMarks()
+    {
+        var pdfId = Guid.NewGuid();
+        var pdf = new PdfDocumentBuilder().WithId(pdfId).ThatIsCompleted().Build();
+        var repo = new Mock<IPdfDocumentRepository>();
+        repo.Setup(r => r.GetByIdAsync(pdfId, It.IsAny<CancellationToken>())).ReturnsAsync(pdf);
+        var mediator = new Mock<IMediator>();
+        mediator.Setup(m => m.Send(It.IsAny<GetPdfPageImageQuery>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new byte[] { 0xFF, 0xD8 }); // JPEG magic
+        var webp = new Mock<IWebpVariantGenerator>();
+        webp.Setup(w => w.GenerateWebpAsync(It.IsAny<byte[]>(), 200, 300, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new byte[] { 0x52, 0x49, 0x46, 0x46 }); // RIFF
+        var pipeline = new Mock<IPdfCoverUploadPipeline>();
+        pipeline.Setup(p => p.UploadAsync(It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((string k, byte[] _, CancellationToken _) => k);
+        var uow = new Mock<IUnitOfWork>();
+
+        var handler = new MaterializePdfCoverCommandHandler(repo.Object, mediator.Object, webp.Object, pipeline.Object, uow.Object);
+        var cmd = new MaterializePdfCoverCommand(pdfId, PageNumber: 3, DbKey: "covers/g/pdf-cover");
+
+        var key = await handler.Handle(cmd, CancellationToken.None);
+
+        key.Should().Be("covers/g/pdf-cover");
+        pdf.CoverR2Key.Should().Be("covers/g/pdf-cover");
+        pdf.CoverPageIndex.Should().Be(3);
+        pdf.CoverGenerationStatus.Should().Be(PdfCoverGenerationStatus.Generated);
+        repo.Verify(r => r.UpdateAsync(pdf, It.IsAny<CancellationToken>()), Times.Once);
+        uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_SmolDoclingFails_ThrowsCoverMaterializationExceptionAndDoesNotMark()
+    {
+        var pdfId = Guid.NewGuid();
+        var pdf = new PdfDocumentBuilder().WithId(pdfId).ThatIsCompleted().Build();
+        var repo = new Mock<IPdfDocumentRepository>();
+        repo.Setup(r => r.GetByIdAsync(pdfId, It.IsAny<CancellationToken>())).ReturnsAsync(pdf);
+        var mediator = new Mock<IMediator>();
+        mediator.Setup(m => m.Send(It.IsAny<GetPdfPageImageQuery>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new HttpRequestException("503"));
+        var handler = new MaterializePdfCoverCommandHandler(repo.Object, mediator.Object,
+            Mock.Of<IWebpVariantGenerator>(), Mock.Of<IPdfCoverUploadPipeline>(), Mock.Of<IUnitOfWork>());
+
+        var act = () => handler.Handle(new MaterializePdfCoverCommand(pdfId, 3, "k"), CancellationToken.None);
+
+        await act.Should().ThrowAsync<CoverMaterializationException>();
+        pdf.CoverGenerationStatus.Should().Be(PdfCoverGenerationStatus.Pending); // non toccato
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Handlers/MaterializePdfCoverCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Handlers/MaterializePdfCoverCommandHandlerTests.cs
@@ -37,16 +37,55 @@ public class MaterializePdfCoverCommandHandlerTests
         var uow = new Mock<IUnitOfWork>();
 
         var handler = new MaterializePdfCoverCommandHandler(repo.Object, mediator.Object, webp.Object, pipeline.Object, uow.Object);
+        // PageNumber is 1-based (user-facing / render contract); CoverPageIndex must be
+        // stored 0-based to match PdfDocument.CoverPageIndex's documented convention and
+        // the two existing writers (PdfProcessingPipelineService, BackfillPdfCoversJob),
+        // both of which persist a 0-based SelectedPageIndex. Issue: C1 off-by-one fix.
         var cmd = new MaterializePdfCoverCommand(pdfId, PageNumber: 3, DbKey: "covers/g/pdf-cover");
 
         var key = await handler.Handle(cmd, CancellationToken.None);
 
         key.Should().Be("covers/g/pdf-cover");
         pdf.CoverR2Key.Should().Be("covers/g/pdf-cover");
-        pdf.CoverPageIndex.Should().Be(3);
+        pdf.CoverPageIndex.Should().Be(2, "CoverPageIndex is 0-based; PageNumber 3 (1-based) stores as index 2");
         pdf.CoverGenerationStatus.Should().Be(PdfCoverGenerationStatus.Generated);
         repo.Verify(r => r.UpdateAsync(pdf, It.IsAny<CancellationToken>()), Times.Once);
         uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    /// <summary>
+    /// Guards the render call itself stays 1-based (only the persisted index changes).
+    /// C1 fix: GetPdfPageImageQuery must still receive the original 1-based PageNumber.
+    /// </summary>
+    [Fact]
+    public async Task Handle_PassesOneBasedPageNumberToRenderQuery()
+    {
+        var pdfId = Guid.NewGuid();
+        var pdf = new PdfDocumentBuilder().WithId(pdfId).ThatIsCompleted().Build();
+        var repo = new Mock<IPdfDocumentRepository>();
+        repo.Setup(r => r.GetByIdAsync(pdfId, It.IsAny<CancellationToken>())).ReturnsAsync(pdf);
+        var mediator = new Mock<IMediator>();
+        mediator.Setup(m => m.Send(It.IsAny<GetPdfPageImageQuery>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new byte[] { 0xFF, 0xD8 });
+        var webp = new Mock<IWebpVariantGenerator>();
+        webp.Setup(w => w.GenerateWebpAsync(It.IsAny<byte[]>(), 200, 300, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new byte[] { 0x52, 0x49, 0x46, 0x46 });
+        var pipeline = new Mock<IPdfCoverUploadPipeline>();
+        pipeline.Setup(p => p.UploadAsync(It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((string k, byte[] _, CancellationToken _) => k);
+        var uow = new Mock<IUnitOfWork>();
+
+        var handler = new MaterializePdfCoverCommandHandler(repo.Object, mediator.Object, webp.Object, pipeline.Object, uow.Object);
+        var cmd = new MaterializePdfCoverCommand(pdfId, PageNumber: 5, DbKey: "covers/g/pdf-cover");
+
+        await handler.Handle(cmd, CancellationToken.None);
+
+        mediator.Verify(m => m.Send(
+            It.Is<GetPdfPageImageQuery>(q => q.PageNumber == 5),
+            It.IsAny<CancellationToken>()),
+            Times.Once,
+            "the render query must still use the original 1-based PageNumber");
+        pdf.CoverPageIndex.Should().Be(4, "only the persisted CoverPageIndex is 0-based, not the render call");
     }
 
     [Fact]

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Services/PdfDeduplicationServiceTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Services/PdfDeduplicationServiceTests.cs
@@ -1,0 +1,107 @@
+using Api.BoundedContexts.DocumentProcessing.Application.Services;
+using Api.BoundedContexts.DocumentProcessing.Domain.Entities;
+using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
+using Api.BoundedContexts.DocumentProcessing.Domain.Repositories;
+using Api.BoundedContexts.DocumentProcessing.Domain.ValueObjects;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.DocumentProcessing.Application.Services;
+
+/// <summary>
+/// Unit tests for <see cref="PdfDeduplicationService"/>.
+/// Verifies the centralized dedup rule (Task 1 of the PDF cover-config plan):
+/// catalog (shared game) PDFs use a GLOBAL content-hash lookup; private-game
+/// PDFs use a PER-USER lookup. A match in <see cref="PdfProcessingState.Failed"/>
+/// is treated as "no reusable match" (NewUpload); any other match is reused.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "DocumentProcessing")]
+public class PdfDeduplicationServiceTests
+{
+    private readonly Mock<IPdfDocumentRepository> _repo = new();
+
+    private PdfDeduplicationService Sut() => new(_repo.Object);
+
+    [Fact]
+    public async Task Evaluate_CatalogHashKnownAndReady_ReturnsReuseExisting()
+    {
+        var existing = PdfDocumentTestFactory.Ready();
+        _repo.Setup(r => r.FindByContentHashAsync("h", It.IsAny<CancellationToken>()))
+             .ReturnsAsync(existing);
+
+        var result = await Sut().EvaluateAsync("h", sharedGameId: Guid.NewGuid(),
+            privateGameId: null, userId: Guid.NewGuid(), CancellationToken.None);
+
+        result.Decision.Should().Be(PdfDedupDecision.ReuseExisting);
+        result.ExistingPdfDocumentId.Should().Be(existing.Id);
+    }
+
+    [Fact]
+    public async Task Evaluate_CatalogHashKnownButFailed_ReturnsNewUpload()
+    {
+        var existing = PdfDocumentTestFactory.Failed();
+        _repo.Setup(r => r.FindByContentHashAsync("h", It.IsAny<CancellationToken>()))
+             .ReturnsAsync(existing);
+
+        var result = await Sut().EvaluateAsync("h", Guid.NewGuid(), null, Guid.NewGuid(), CancellationToken.None);
+
+        result.Decision.Should().Be(PdfDedupDecision.NewUpload);
+    }
+
+    [Fact]
+    public async Task Evaluate_PrivateGame_UsesPerUserLookupNotGlobal()
+    {
+        var userId = Guid.NewGuid();
+        _repo.Setup(r => r.FindByContentHashForUserAsync("h", userId, It.IsAny<CancellationToken>()))
+             .ReturnsAsync((PdfDocument?)null);
+
+        var result = await Sut().EvaluateAsync("h", sharedGameId: null,
+            privateGameId: Guid.NewGuid(), userId: userId, CancellationToken.None);
+
+        result.Decision.Should().Be(PdfDedupDecision.NewUpload);
+        _repo.Verify(r => r.FindByContentHashAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        _repo.Verify(r => r.FindByContentHashForUserAsync("h", userId, It.IsAny<CancellationToken>()), Times.Once);
+    }
+}
+
+/// <summary>
+/// Test helper building <see cref="PdfDocument"/> instances via the domain factory,
+/// advancing state with the existing transition methods (no reflection).
+/// </summary>
+internal static class PdfDocumentTestFactory
+{
+    private static PdfDocument Create()
+    {
+        return new PdfDocument(
+            id: Guid.NewGuid(),
+            gameId: Guid.NewGuid(),
+            fileName: new FileName("rulebook.pdf"),
+            filePath: "/tmp/rulebook.pdf",
+            fileSize: new FileSize(1024),
+            uploadedByUserId: Guid.NewGuid());
+    }
+
+    /// <summary>Builds a <see cref="PdfDocument"/> advanced to <see cref="PdfProcessingState.Ready"/>.</summary>
+    public static PdfDocument Ready()
+    {
+        var document = Create();
+        document.TransitionTo(PdfProcessingState.Uploading);
+        document.TransitionTo(PdfProcessingState.Extracting);
+        document.TransitionTo(PdfProcessingState.Chunking);
+        document.TransitionTo(PdfProcessingState.Embedding);
+        document.TransitionTo(PdfProcessingState.Indexing);
+        document.TransitionTo(PdfProcessingState.Ready);
+        return document;
+    }
+
+    /// <summary>Builds a <see cref="PdfDocument"/> advanced to <see cref="PdfProcessingState.Failed"/>.</summary>
+    public static PdfDocument Failed()
+    {
+        var document = Create();
+        document.MarkAsFailed("simulated failure", ErrorCategory.Unknown, PdfProcessingState.Extracting);
+        return document;
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Infrastructure/Services/GamebookPhotoStorageServiceTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Infrastructure/Services/GamebookPhotoStorageServiceTests.cs
@@ -65,6 +65,12 @@ public sealed class GamebookPhotoStorageServiceTests
             _ = (fileId, category, resourceKey, expirySeconds);
             return Task.FromResult<string?>(null);
         }
+
+        public Task<string?> GetPresignedUrlForRawKeyAsync(string rawKey, int? expirySeconds = null)
+        {
+            _ = (rawKey, expirySeconds);
+            return Task.FromResult<string?>(null);
+        }
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────────

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/ApproveCoverChangeTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/ApproveCoverChangeTests.cs
@@ -1,0 +1,155 @@
+using Api.BoundedContexts.DocumentProcessing.Infrastructure.Services;
+using Api.BoundedContexts.SharedGameCatalog.Application.Commands.ApproveGameProposal;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+using Api.BoundedContexts.UserLibrary.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Tests.Constants;
+using Api.Tests.TestHelpers;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+using FluentAssertions;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Handlers;
+
+/// <summary>
+/// Tests for ApproveGameProposalCommandHandler's handling of ProposalApprovalAction.UpdateCover
+/// (Task 5: Game Cover-da-PDF — approval promotes the pending cover to L4 on the target SharedGame).
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public class ApproveCoverChangeTests
+{
+    [Fact]
+    public async Task Approve_UpdateCover_SetsL4KeyOnSharedGameAndApproves()
+    {
+        var target = Guid.NewGuid();
+        var sharedGame = SharedGameTestFactory.Existing(target);
+        var req = ShareRequest.CreateCoverChange(Guid.NewGuid(), target, Guid.NewGuid(), "covers/g/pdf-cover", 3, null);
+        var (handler, adminId) = ApproveHandlerBuilder.For(req, sharedGame);
+
+        var cmd = new ApproveGameProposalCommand(ShareRequestId: req.Id, AdminId: adminId,
+            ApprovalAction: ProposalApprovalAction.UpdateCover, TargetSharedGameId: target, AdminNotes: null);
+
+        await handler.Handle(cmd, TestContext.Current.CancellationToken);
+
+        sharedGame.PdfCoverR2Key.Should().Be("covers/g/pdf-cover");
+        req.Status.Should().Be(ShareRequestStatus.Approved);
+    }
+
+    [Fact]
+    public async Task Approve_UpdateCover_WithoutPendingCoverKey_ThrowsConflictException()
+    {
+        var target = Guid.NewGuid();
+        var sharedGame = SharedGameTestFactory.Existing(target);
+
+        // AdditionalContent targeting the same shared game never populates PendingCoverR2Key,
+        // exercising the "missing pending cover key" guard in ApproveCoverChangeAsync.
+        var req = ShareRequest.Create(Guid.NewGuid(), target, ContributionType.AdditionalContent, null, target);
+        var (handler, adminId) = ApproveHandlerBuilder.For(req, sharedGame);
+
+        var cmd = new ApproveGameProposalCommand(ShareRequestId: req.Id, AdminId: adminId,
+            ApprovalAction: ProposalApprovalAction.UpdateCover, TargetSharedGameId: target, AdminNotes: null);
+
+        var act = () => handler.Handle(cmd, TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<ConflictException>();
+    }
+
+    [Fact]
+    public async Task Approve_UpdateCover_NonExistentSharedGame_ThrowsNotFoundException()
+    {
+        var target = Guid.NewGuid();
+        var req = ShareRequest.CreateCoverChange(Guid.NewGuid(), target, Guid.NewGuid(), "covers/g/pdf-cover", 3, null);
+        var (handler, adminId) = ApproveHandlerBuilder.For(req, sharedGame: null);
+
+        var cmd = new ApproveGameProposalCommand(ShareRequestId: req.Id, AdminId: adminId,
+            ApprovalAction: ProposalApprovalAction.UpdateCover, TargetSharedGameId: target, AdminNotes: null);
+
+        var act = () => handler.Handle(cmd, TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+}
+
+/// <summary>
+/// Minimal local factory for constructing a SharedGame with a caller-chosen Id, using the
+/// internal reconstitution constructor (visible to Api.Tests via InternalsVisibleTo) so tests
+/// can align the SharedGame.Id with a ShareRequest's TargetSharedGameId.
+/// </summary>
+internal static class SharedGameTestFactory
+{
+    public static SharedGame Existing(Guid id)
+    {
+        return new SharedGame(
+            id: id,
+            title: "Test Shared Game",
+            yearPublished: 2020,
+            description: "A test game",
+            minPlayers: 2,
+            maxPlayers: 4,
+            playingTimeMinutes: 60,
+            minAge: 10,
+            complexityRating: 2.5m,
+            averageRating: null,
+            imageUrl: "https://example.com/image.jpg",
+            thumbnailUrl: "https://example.com/thumb.jpg",
+            rules: null,
+            status: GameStatus.Published,
+            createdBy: Guid.NewGuid(),
+            modifiedBy: null,
+            createdAt: DateTime.UtcNow,
+            modifiedAt: null,
+            isDeleted: false);
+    }
+}
+
+/// <summary>
+/// Minimal local builder that wires an ApproveGameProposalCommandHandler with mocked
+/// repositories/services for CoverChange approval tests. Moves the ShareRequest into
+/// InReview (required precondition for ShareRequest.Approve) and returns the admin id
+/// that started the review, so the caller's command uses a matching AdminId.
+/// </summary>
+internal static class ApproveHandlerBuilder
+{
+    public static (ApproveGameProposalCommandHandler Handler, Guid AdminId) For(
+        ShareRequest shareRequest,
+        SharedGame? sharedGame)
+    {
+        var adminId = Guid.NewGuid();
+        shareRequest.StartReview(adminId);
+
+        var shareRequestRepoMock = new Mock<IShareRequestRepository>();
+        shareRequestRepoMock
+            .Setup(r => r.GetByIdForUpdateAsync(shareRequest.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(shareRequest);
+
+        var privateGameRepoMock = new Mock<IPrivateGameRepository>();
+
+        var sharedGameRepoMock = new Mock<ISharedGameRepository>();
+        sharedGameRepoMock
+            .Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(sharedGame);
+
+        var documentServiceMock = new Mock<IShareRequestDocumentService>();
+        var unitOfWorkMock = new Mock<IUnitOfWork>();
+        var loggerMock = new Mock<ILogger<ApproveGameProposalCommandHandler>>();
+        var dbContext = TestDbContextFactory.CreateInMemoryDbContext($"ApproveCoverChangeTest_{Guid.NewGuid()}");
+
+        var handler = new ApproveGameProposalCommandHandler(
+            shareRequestRepoMock.Object,
+            privateGameRepoMock.Object,
+            sharedGameRepoMock.Object,
+            documentServiceMock.Object,
+            dbContext,
+            unitOfWorkMock.Object,
+            loggerMock.Object);
+
+        return (handler, adminId);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/ApproveCoverChangeTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/ApproveCoverChangeTests.cs
@@ -75,6 +75,32 @@ public class ApproveCoverChangeTests
 
         await act.Should().ThrowAsync<NotFoundException>();
     }
+
+    /// <summary>
+    /// I3 fix: an admin-supplied TargetSharedGameId that differs from the proposal's
+    /// persisted ShareRequest.TargetSharedGameId must be rejected, not silently honored —
+    /// otherwise a tampered/stale command could promote the pending cover onto the wrong
+    /// SharedGame instead of the one the proposal actually targets.
+    /// </summary>
+    [Fact]
+    public async Task Approve_UpdateCover_MismatchedTargetSharedGameId_ThrowsConflictException()
+    {
+        var proposalTarget = Guid.NewGuid();
+        var wrongTarget = Guid.NewGuid();
+        var sharedGame = SharedGameTestFactory.Existing(proposalTarget);
+        var req = ShareRequest.CreateCoverChange(Guid.NewGuid(), proposalTarget, Guid.NewGuid(), "covers/g/pdf-cover", 3, null);
+        var (handler, adminId) = ApproveHandlerBuilder.For(req, sharedGame);
+
+        // Command supplies a DIFFERENT TargetSharedGameId than the proposal's own target.
+        var cmd = new ApproveGameProposalCommand(ShareRequestId: req.Id, AdminId: adminId,
+            ApprovalAction: ProposalApprovalAction.UpdateCover, TargetSharedGameId: wrongTarget, AdminNotes: null);
+
+        var act = () => handler.Handle(cmd, TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<ConflictException>();
+        // The SharedGame that the proposal actually targets must remain untouched.
+        sharedGame.PdfCoverR2Key.Should().BeNull();
+    }
 }
 
 /// <summary>

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/GetSharedGameByIdQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/GetSharedGameByIdQueryHandlerTests.cs
@@ -233,12 +233,10 @@ public class GetSharedGameByIdQueryHandlerTests
             .Setup(r => r.GetByIdAsync(gameId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(game);
 
-        // CoverUrlResolver calls GetPresignedDownloadUrlAsync("{key}-preview.webp", GameImage, key, null)
+        // CoverUrlResolver calls GetPresignedUrlForRawKeyAsync("{key}-preview.webp", null)
         _blobStorageMock
-            .Setup(b => b.GetPresignedDownloadUrlAsync(
+            .Setup(b => b.GetPresignedUrlForRawKeyAsync(
                 $"{pdfKey}-preview.webp",
-                BlobCategory.GameImage,
-                pdfKey,
                 null))
             .ReturnsAsync(expectedUrl);
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/CoverUrlResolverTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/CoverUrlResolverTests.cs
@@ -63,13 +63,13 @@ public class CoverUrlResolverTests
     {
         var sg = new SharedGameEntity { PdfCoverR2Key = "pdf-key", WikidataCoverR2Key = "wiki-key" };
         var entry = new UserLibraryEntryEntity { CustomCoverR2Key = "custom-key" };
-        _blob.Setup(b => b.GetPresignedDownloadUrlAsync("custom-key.webp", BlobCategory.GameImage, "custom-key", null))
+        _blob.Setup(b => b.GetPresignedUrlForRawKeyAsync("custom-key.webp", null))
              .ReturnsAsync("https://r2/custom.webp");
 
         var url = await CoverUrlResolver.ResolveForUserAsync(sg, entry, _blob.Object);
 
         url.Should().Be("https://r2/custom.webp");
-        _blob.Verify(b => b.GetPresignedDownloadUrlAsync("pdf-key-preview.webp", It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<int?>()), Times.Never);
+        _blob.Verify(b => b.GetPresignedUrlForRawKeyAsync("pdf-key-preview.webp", It.IsAny<int?>()), Times.Never);
     }
 
     [Fact]
@@ -77,7 +77,7 @@ public class CoverUrlResolverTests
     {
         var sg = new SharedGameEntity { PdfCoverR2Key = "pdf-key", WikidataCoverR2Key = "wiki-key" };
         var entry = new UserLibraryEntryEntity { CustomCoverR2Key = null };
-        _blob.Setup(b => b.GetPresignedDownloadUrlAsync("pdf-key-preview.webp", BlobCategory.GameImage, "pdf-key", null))
+        _blob.Setup(b => b.GetPresignedUrlForRawKeyAsync("pdf-key-preview.webp", null))
              .ReturnsAsync("https://r2/pdf.webp");
 
         var url = await CoverUrlResolver.ResolveForUserAsync(sg, entry, _blob.Object);
@@ -89,7 +89,7 @@ public class CoverUrlResolverTests
     public async Task ResolvePublicAsync_L4WinsOverL2()
     {
         var sg = new SharedGameEntity { PdfCoverR2Key = "pdf-key", WikidataCoverR2Key = "wiki-key" };
-        _blob.Setup(b => b.GetPresignedDownloadUrlAsync("pdf-key-preview.webp", BlobCategory.GameImage, "pdf-key", null))
+        _blob.Setup(b => b.GetPresignedUrlForRawKeyAsync("pdf-key-preview.webp", null))
              .ReturnsAsync("https://r2/pdf.webp");
 
         var url = await CoverUrlResolver.ResolvePublicAsync(sg, _blob.Object);
@@ -101,7 +101,7 @@ public class CoverUrlResolverTests
     public async Task ResolvePublicAsync_NoL4_FallsBackToL2()
     {
         var sg = new SharedGameEntity { PdfCoverR2Key = null, WikidataCoverR2Key = "wiki-key" };
-        _blob.Setup(b => b.GetPresignedDownloadUrlAsync("wiki-key.webp", BlobCategory.GameImage, "wiki-key", null))
+        _blob.Setup(b => b.GetPresignedUrlForRawKeyAsync("wiki-key.webp", null))
              .ReturnsAsync("https://r2/wiki.webp");
 
         var url = await CoverUrlResolver.ResolvePublicAsync(sg, _blob.Object);
@@ -123,14 +123,59 @@ public class CoverUrlResolverTests
     public async Task ResolvePublicAsync_PresignedReturnsNull_FallsThroughToNextLayer()
     {
         var sg = new SharedGameEntity { PdfCoverR2Key = "pdf-key", WikidataCoverR2Key = "wiki-key" };
-        _blob.Setup(b => b.GetPresignedDownloadUrlAsync("pdf-key-preview.webp", It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<int?>()))
+        _blob.Setup(b => b.GetPresignedUrlForRawKeyAsync("pdf-key-preview.webp", It.IsAny<int?>()))
              .ReturnsAsync((string?)null);
-        _blob.Setup(b => b.GetPresignedDownloadUrlAsync("wiki-key.webp", It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<int?>()))
+        _blob.Setup(b => b.GetPresignedUrlForRawKeyAsync("wiki-key.webp", It.IsAny<int?>()))
              .ReturnsAsync("https://r2/wiki.webp");
 
         var url = await CoverUrlResolver.ResolvePublicAsync(sg, _blob.Object);
 
         url.Should().Be("https://r2/wiki.webp");
+    }
+
+    [Fact]
+    public async Task ResolvePublicAsync_L4SlashAndDotKey_ResolvesViaRawKeyMethod()
+    {
+        // P1 fix regression guard: the real PdfCoverR2Key shape is
+        // "covers/{sharedGameId:D}/pdf-cover-pending" (contains '/'). Before the fix,
+        // GetPresignedDownloadUrlAsync validated this via PathSecurity.ValidateIdentifier
+        // and always returned null. Now it must resolve via GetPresignedUrlForRawKeyAsync
+        // called with the exact physical key including the "-preview.webp" suffix.
+        var pdfKey = $"covers/{Guid.NewGuid():D}/pdf-cover-pending";
+        var sg = new SharedGameEntity { PdfCoverR2Key = pdfKey };
+        _blob.Setup(b => b.GetPresignedUrlForRawKeyAsync($"{pdfKey}-preview.webp", null))
+             .ReturnsAsync("https://r2/pdf-cover.webp");
+
+        var url = await CoverUrlResolver.ResolvePublicAsync(sg, _blob.Object);
+
+        url.Should().Be("https://r2/pdf-cover.webp");
+    }
+
+    [Fact]
+    public async Task ResolvePublicAsync_L2SlashAndDotKey_ResolvesViaRawKeyMethod()
+    {
+        var wikidataKey = $"covers/{Guid.NewGuid():D}/wikidata-cover";
+        var sg = new SharedGameEntity { WikidataCoverR2Key = wikidataKey };
+        _blob.Setup(b => b.GetPresignedUrlForRawKeyAsync($"{wikidataKey}.webp", null))
+             .ReturnsAsync("https://r2/wikidata-cover.webp");
+
+        var url = await CoverUrlResolver.ResolvePublicAsync(sg, _blob.Object);
+
+        url.Should().Be("https://r2/wikidata-cover.webp");
+    }
+
+    [Fact]
+    public async Task ResolveForUserAsync_L3SlashAndDotKey_ResolvesViaRawKeyMethod()
+    {
+        var customKey = $"covers/{Guid.NewGuid():D}/user-custom-cover";
+        var sg = new SharedGameEntity();
+        var entry = new UserLibraryEntryEntity { CustomCoverR2Key = customKey };
+        _blob.Setup(b => b.GetPresignedUrlForRawKeyAsync($"{customKey}.webp", null))
+             .ReturnsAsync("https://r2/user-custom-cover.webp");
+
+        var url = await CoverUrlResolver.ResolveForUserAsync(sg, entry, _blob.Object);
+
+        url.Should().Be("https://r2/user-custom-cover.webp");
     }
 
     // ----- Issue #2123 metric emission tests --------------------------------
@@ -141,7 +186,7 @@ public class CoverUrlResolverTests
         using var capture = new CoverMetricsCapture();
         var sg = new SharedGameEntity();
         var entry = new UserLibraryEntryEntity { CustomCoverR2Key = "custom-key" };
-        _blob.Setup(b => b.GetPresignedDownloadUrlAsync("custom-key.webp", BlobCategory.GameImage, "custom-key", null))
+        _blob.Setup(b => b.GetPresignedUrlForRawKeyAsync("custom-key.webp", null))
              .ReturnsAsync("https://r2/custom.webp");
 
         await CoverUrlResolver.ResolveForUserAsync(sg, entry, _blob.Object);
@@ -157,7 +202,7 @@ public class CoverUrlResolverTests
     {
         using var capture = new CoverMetricsCapture();
         var sg = new SharedGameEntity { PdfCoverR2Key = "pdf-key" };
-        _blob.Setup(b => b.GetPresignedDownloadUrlAsync("pdf-key-preview.webp", BlobCategory.GameImage, "pdf-key", null))
+        _blob.Setup(b => b.GetPresignedUrlForRawKeyAsync("pdf-key-preview.webp", null))
              .ReturnsAsync("https://r2/pdf.webp");
 
         await CoverUrlResolver.ResolvePublicAsync(sg, _blob.Object);
@@ -189,7 +234,7 @@ public class CoverUrlResolverTests
     {
         using var capture = new CoverMetricsCapture();
         var sg = new SharedGameEntity { WikidataCoverR2Key = "wiki-key" };
-        _blob.Setup(b => b.GetPresignedDownloadUrlAsync("wiki-key.webp", BlobCategory.GameImage, "wiki-key", null))
+        _blob.Setup(b => b.GetPresignedUrlForRawKeyAsync("wiki-key.webp", null))
              .ReturnsAsync("https://r2/wiki.webp");
 
         await CoverUrlResolver.ResolvePublicAsync(sg, _blob.Object);
@@ -223,7 +268,7 @@ public class CoverUrlResolverTests
         using var capture = new CoverMetricsCapture();
         var sg = new SharedGameEntity { WikidataCoverR2Key = "wiki-key" };
         var entry = new UserLibraryEntryEntity { CustomCoverR2Key = null };
-        _blob.Setup(b => b.GetPresignedDownloadUrlAsync("wiki-key.webp", BlobCategory.GameImage, "wiki-key", null))
+        _blob.Setup(b => b.GetPresignedUrlForRawKeyAsync("wiki-key.webp", null))
              .ReturnsAsync("https://r2/wiki.webp");
 
         await CoverUrlResolver.ResolveForUserAsync(sg, entry, _blob.Object);
@@ -246,9 +291,9 @@ public class CoverUrlResolverTests
         var sg = new SharedGameEntity { WikidataCoverR2Key = "wiki-key" };
         var entry = new UserLibraryEntryEntity { CustomCoverR2Key = "custom-key" };
 
-        _blob.Setup(b => b.GetPresignedDownloadUrlAsync("custom-key.webp", BlobCategory.GameImage, "custom-key", null))
+        _blob.Setup(b => b.GetPresignedUrlForRawKeyAsync("custom-key.webp", null))
              .ReturnsAsync((string?)null);
-        _blob.Setup(b => b.GetPresignedDownloadUrlAsync("wiki-key.webp", BlobCategory.GameImage, "wiki-key", null))
+        _blob.Setup(b => b.GetPresignedUrlForRawKeyAsync("wiki-key.webp", null))
              .ReturnsAsync("https://r2/wiki.webp");
 
         await CoverUrlResolver.ResolveForUserAsync(sg, entry, _blob.Object);
@@ -268,7 +313,7 @@ public class CoverUrlResolverTests
         var sg = new SharedGameEntity(); // no R2 keys at all
         var entry = new UserLibraryEntryEntity { CustomCoverR2Key = "custom-key" };
 
-        _blob.Setup(b => b.GetPresignedDownloadUrlAsync("custom-key.webp", BlobCategory.GameImage, "custom-key", null))
+        _blob.Setup(b => b.GetPresignedUrlForRawKeyAsync("custom-key.webp", null))
              .ReturnsAsync((string?)null);
 
         await CoverUrlResolver.ResolveForUserAsync(sg, entry, _blob.Object);

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Domain/Entities/ShareRequestCoverChangeTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Domain/Entities/ShareRequestCoverChangeTests.cs
@@ -1,0 +1,38 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+using Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Domain.Entities;
+
+/// <summary>
+/// Unit tests for ShareRequest.CreateCoverChange (cover-from-PDF proposal).
+/// Task 4: ContributionType.CoverChange + pending cover fields.
+/// </summary>
+[Trait("Category", "Unit")]
+public sealed class ShareRequestCoverChangeTests
+{
+    [Fact]
+    public void CreateCoverChange_WithValidData_SetsCoverChangeType()
+    {
+        var target = Guid.NewGuid();
+        var pdf = Guid.NewGuid();
+        var req = ShareRequest.CreateCoverChange(
+            userId: Guid.NewGuid(), targetSharedGameId: target, sourcePdfDocumentId: pdf,
+            pendingCoverR2Key: "covers/g/pdf-cover", coverPageIndex: 3, userNotes: null);
+
+        req.ContributionType.Should().Be(ContributionType.CoverChange);
+        req.TargetSharedGameId.Should().Be(target);
+        req.PendingCoverR2Key.Should().Be("covers/g/pdf-cover");
+        req.CoverPageIndex.Should().Be(3);
+        req.SourcePdfDocumentId.Should().Be(pdf);
+        req.Status.Should().Be(ShareRequestStatus.Pending);
+    }
+
+    [Fact]
+    public void CreateCoverChange_WithEmptyPendingKey_Throws()
+    {
+        var act = () => ShareRequest.CreateCoverChange(Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), "  ", 0, null);
+        act.Should().Throw<ArgumentException>();
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/ShareRequestRepositoryIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/ShareRequestRepositoryIntegrationTests.cs
@@ -1,0 +1,116 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Repositories;
+using Api.Infrastructure;
+using Api.SharedKernel.Application.Services;
+using Api.SharedKernel.Domain.Interfaces;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Infrastructure;
+
+/// <summary>
+/// Integration tests for ShareRequestRepository.
+/// Covers the round-trip persistence of the pending-cover fields
+/// (PendingCoverR2Key, CoverPageIndex, SourcePdfDocumentId) added in Task 4
+/// (Game Cover-da-PDF, ContributionType.CoverChange).
+/// </summary>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class ShareRequestRepositoryIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly string _testDbName;
+    private MeepleAiDbContext _dbContext = null!;
+    private IShareRequestRepository _repository = null!;
+    private ISharedGameRepository _sharedGameRepository = null!;
+    private static readonly Guid TestUserId = Guid.NewGuid();
+
+    public ShareRequestRepositoryIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+        _testDbName = $"sharerequest_test_{Guid.NewGuid():N}";
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_testDbName);
+
+        var options = new DbContextOptionsBuilder<MeepleAiDbContext>()
+            .UseNpgsql(connectionString, o => o.UseVector())
+            .Options;
+
+        var mockMediator = new Mock<IMediator>();
+        var eventCollectorMock = new Mock<IDomainEventCollector>();
+        eventCollectorMock.Setup(x => x.GetAndClearEvents())
+            .Returns(new List<IDomainEvent>().AsReadOnly());
+
+        _dbContext = new MeepleAiDbContext(options, mockMediator.Object, eventCollectorMock.Object);
+        await _dbContext.Database.MigrateAsync();
+
+        _repository = new ShareRequestRepository(_dbContext, eventCollectorMock.Object);
+        _sharedGameRepository = new SharedGameRepository(_dbContext, eventCollectorMock.Object);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _dbContext.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task AddAsync_ThenGetByIdAsync_RoundTripsCoverChangeFields()
+    {
+        // Arrange: a shared game must exist to satisfy the SourceGameId/TargetSharedGameId FK
+        var sharedGame = SharedGame.Create(
+            title: "Wingspan",
+            yearPublished: 2019,
+            description: "Bird-collection engine builder",
+            minPlayers: 1,
+            maxPlayers: 5,
+            playingTimeMinutes: 70,
+            minAge: 10,
+            complexityRating: 2.4m,
+            averageRating: 8.1m,
+            imageUrl: "https://example.com/wingspan.jpg",
+            thumbnailUrl: "https://example.com/wingspan-thumb.jpg",
+            rules: null,
+            createdBy: TestUserId);
+
+        await _sharedGameRepository.AddAsync(sharedGame);
+        await _dbContext.SaveChangesAsync();
+
+        var sourcePdfDocumentId = Guid.NewGuid();
+        const string pendingCoverR2Key = "covers/wingspan/pdf-page-cover.png";
+        const int coverPageIndex = 4;
+
+        var shareRequest = ShareRequest.CreateCoverChange(
+            userId: TestUserId,
+            targetSharedGameId: sharedGame.Id,
+            sourcePdfDocumentId: sourcePdfDocumentId,
+            pendingCoverR2Key: pendingCoverR2Key,
+            coverPageIndex: coverPageIndex,
+            userNotes: "Suggested cover from rulebook page 5");
+
+        // Act: persist, then force a fresh reload (no first-level cache) via a clean context
+        await _repository.AddAsync(shareRequest);
+        await _dbContext.SaveChangesAsync();
+        _dbContext.ChangeTracker.Clear();
+
+        var reloaded = await _repository.GetByIdAsync(shareRequest.Id);
+
+        // Assert
+        reloaded.Should().NotBeNull();
+        reloaded!.ContributionType.Should().Be(ContributionType.CoverChange);
+        reloaded.PendingCoverR2Key.Should().Be(pendingCoverR2Key);
+        reloaded.CoverPageIndex.Should().Be(coverPageIndex);
+        reloaded.SourcePdfDocumentId.Should().Be(sourcePdfDocumentId);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/UserLibrary/Application/Commands/PrivateGames/AddPrivateGameNoExternalUrlTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/UserLibrary/Application/Commands/PrivateGames/AddPrivateGameNoExternalUrlTests.cs
@@ -1,0 +1,24 @@
+using System.Linq;
+using Api.BoundedContexts.UserLibrary.Application.Commands.PrivateGames;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.UserLibrary.Application.Commands.PrivateGames;
+
+/// <summary>
+/// Compliance regression test: AddPrivateGameCommand must not expose external URL
+/// input channels (ImageUrl/ThumbnailUrl). BGG freeze (#2123 / ADR-059) forbids
+/// arbitrary user-supplied external image URLs.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+public class AddPrivateGameNoExternalUrlTests
+{
+    [Fact]
+    public void AddPrivateGameCommand_HasNoExternalUrlFields()
+    {
+        var props = typeof(AddPrivateGameCommand).GetProperties().Select(p => p.Name).ToArray();
+        props.Should().NotContain("ImageUrl");
+        props.Should().NotContain("ThumbnailUrl");
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/UserLibrary/Application/Handlers/PrivateGames/AddPrivateGameCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/UserLibrary/Application/Handlers/PrivateGames/AddPrivateGameCommandHandlerTests.cs
@@ -189,8 +189,7 @@ public sealed class AddPrivateGameCommandHandlerTests
             Description: "A detailed description",
             PlayingTimeMinutes: 90,
             MinAge: 12,
-            ComplexityRating: 3.5m,
-            ImageUrl: "https://example.com/image.jpg");
+            ComplexityRating: 3.5m);
 
         _privateGameRepositoryMock
             .Setup(r => r.AddAsync(It.IsAny<PrivateGame>(), It.IsAny<CancellationToken>()))
@@ -210,7 +209,7 @@ public sealed class AddPrivateGameCommandHandlerTests
         result.PlayingTimeMinutes.Should().Be(90);
         result.MinAge.Should().Be(12);
         result.ComplexityRating.Should().Be(3.5m);
-        result.ImageUrl.Should().Be("https://example.com/image.jpg");
+        result.ImageUrl.Should().BeNull(); // BGG freeze #2123: no external URL input; cover is null at creation
     }
 
     [Theory]
@@ -263,9 +262,7 @@ public sealed class AddPrivateGameCommandHandlerTests
             Description: "A game from BGG",
             PlayingTimeMinutes: 120,
             MinAge: 14,
-            ComplexityRating: 4.2m,
-            ImageUrl: "https://cf.geekdo-images.com/image.jpg",
-            ThumbnailUrl: "https://cf.geekdo-images.com/thumb.jpg");
+            ComplexityRating: 4.2m);
 
         _sharedGameRepositoryMock
             .Setup(r => r.GetByBggIdAsync(12345, It.IsAny<CancellationToken>()))
@@ -291,7 +288,7 @@ public sealed class AddPrivateGameCommandHandlerTests
         result.Title.Should().Be("Imported BGG Game");
         result.Source.Should().Be("BoardGameGeek");
         result.BggId.Should().Be(12345);
-        result.ThumbnailUrl.Should().Be("https://cf.geekdo-images.com/thumb.jpg");
+        result.ThumbnailUrl.Should().BeNull(); // BGG freeze #2123: no external URL input; cover is null at creation
         result.CanProposeToCatalog.Should().BeTrue(); // BGG games can be proposed
     }
 
@@ -534,9 +531,7 @@ public sealed class AddPrivateGameCommandHandlerTests
             Description: "Full description for mapping test",
             PlayingTimeMinutes: 180,
             MinAge: 10,
-            ComplexityRating: 2.8m,
-            ImageUrl: "https://example.com/full.jpg",
-            ThumbnailUrl: "https://example.com/thumb.jpg");
+            ComplexityRating: 2.8m);
 
         _sharedGameRepositoryMock
             .Setup(r => r.GetByBggIdAsync(55555, It.IsAny<CancellationToken>()))
@@ -571,8 +566,8 @@ public sealed class AddPrivateGameCommandHandlerTests
         result.PlayingTimeMinutes.Should().Be(180);
         result.MinAge.Should().Be(10);
         result.ComplexityRating.Should().Be(2.8m);
-        result.ImageUrl.Should().Be("https://example.com/full.jpg");
-        result.ThumbnailUrl.Should().Be("https://example.com/thumb.jpg");
+        result.ImageUrl.Should().BeNull(); // BGG freeze #2123: no external URL input; cover is null at creation
+        result.ThumbnailUrl.Should().BeNull(); // BGG freeze #2123: no external URL input; cover is null at creation
         result.CreatedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(5));
         result.UpdatedAt.Should().BeNull();
         result.BggSyncedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(5)); // BGG games have sync time
@@ -627,8 +622,7 @@ public sealed class AddPrivateGameCommandHandlerTests
             Description: "A custom game with full details",
             PlayingTimeMinutes: 90,
             MinAge: 12,
-            ComplexityRating: 3.5m,
-            ImageUrl: "https://example.com/image.jpg");
+            ComplexityRating: 3.5m);
 
         // Assert
         command.YearPublished.Should().Be(2023);
@@ -636,7 +630,6 @@ public sealed class AddPrivateGameCommandHandlerTests
         command.PlayingTimeMinutes.Should().Be(90);
         command.MinAge.Should().Be(12);
         command.ComplexityRating.Should().Be(3.5m);
-        command.ImageUrl.Should().Be("https://example.com/image.jpg");
     }
 
     [Fact]
@@ -652,13 +645,11 @@ public sealed class AddPrivateGameCommandHandlerTests
             BggId: 12345,
             Title: "BGG Imported Game",
             MinPlayers: 2,
-            MaxPlayers: 5,
-            ThumbnailUrl: "https://cf.geekdo-images.com/thumb.jpg");
+            MaxPlayers: 5);
 
         // Assert
         command.Source.Should().Be("BoardGameGeek");
         command.BggId.Should().Be(12345);
-        command.ThumbnailUrl.Should().Be("https://cf.geekdo-images.com/thumb.jpg");
     }
 
     [Theory]

--- a/apps/api/tests/Api.Tests/BoundedContexts/UserLibrary/Application/Validators/PrivateGames/AddPrivateGameCommandValidatorTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/UserLibrary/Application/Validators/PrivateGames/AddPrivateGameCommandValidatorTests.cs
@@ -698,52 +698,6 @@ public sealed class AddPrivateGameCommandValidatorTests
 
     #endregion
 
-    #region ImageUrl Validation
-
-    [Fact]
-    public void ImageUrl_TooLong_HasValidationError()
-    {
-        // Arrange
-        var longUrl = "https://example.com/" + new string('a', 500);
-        var command = new AddPrivateGameCommand(
-            UserId: Guid.NewGuid(),
-            Source: "Manual",
-            BggId: null,
-            Title: "Test",
-            MinPlayers: 2,
-            MaxPlayers: 4,
-            ImageUrl: longUrl);
-
-        // Act
-        var result = _validator.TestValidate(command);
-
-        // Assert
-        result.ShouldHaveValidationErrorFor(x => x.ImageUrl)
-            .WithErrorMessage("ImageUrl cannot exceed 500 characters");
-    }
-
-    [Fact]
-    public void ImageUrl_ValidLength_NoValidationError()
-    {
-        // Arrange
-        var command = new AddPrivateGameCommand(
-            UserId: Guid.NewGuid(),
-            Source: "Manual",
-            BggId: null,
-            Title: "Test",
-            MinPlayers: 2,
-            MaxPlayers: 4,
-            ImageUrl: "https://example.com/image.jpg");
-
-        // Act
-        var result = _validator.TestValidate(command);
-
-        // Assert
-        result.ShouldNotHaveValidationErrorFor(x => x.ImageUrl);
-    }
-
-    #endregion
-
     #region Description Validation
 
     [Fact]
@@ -787,8 +741,7 @@ public sealed class AddPrivateGameCommandValidatorTests
             Description: "A valid description",
             PlayingTimeMinutes: 60,
             MinAge: 12,
-            ComplexityRating: 3.0m,
-            ImageUrl: "https://example.com/image.jpg");
+            ComplexityRating: 3.0m);
 
         // Act
         var result = _validator.TestValidate(command);
@@ -812,9 +765,7 @@ public sealed class AddPrivateGameCommandValidatorTests
             Description: "A BGG game description",
             PlayingTimeMinutes: 120,
             MinAge: 14,
-            ComplexityRating: 4.2m,
-            ImageUrl: "https://cf.geekdo-images.com/image.jpg",
-            ThumbnailUrl: "https://cf.geekdo-images.com/thumb.jpg");
+            ComplexityRating: 4.2m);
 
         // Act
         var result = _validator.TestValidate(command);

--- a/apps/api/tests/Api.Tests/Integration/DocumentProcessing/S3BlobStorageIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/DocumentProcessing/S3BlobStorageIntegrationTests.cs
@@ -329,6 +329,62 @@ public sealed class S3BlobStorageIntegrationTests : IAsyncLifetime
         result.Should().BeNull();
     }
 
+    // ── P1 fix (2026-07-14): GetPresignedUrlForRawKeyAsync end-to-end ───────────
+    // Real R2/S3 round-trip proving the CoverUrlResolver fix actually resolves a
+    // slash-and-dot physical key — the exact shape L2/L3/L4 write (e.g.
+    // "covers/{gameId}/cover.webp"). Guarded by the same SkipIfNotAvailable()
+    // gate as the rest of this suite (Docker/TEST_S3_ENDPOINT required).
+
+    [Fact]
+    public async Task GetPresignedUrlForRawKeyAsync_ObjectUploadedAtSlashDotKey_ResolvesRealUrl()
+    {
+        SkipIfNotAvailable();
+
+        // Arrange: upload directly via the raw S3 client to the exact physical key
+        // shape CoverUrlResolver's L4/L2/L3 branches use (mirrors PdfCoverUploadPipeline's
+        // raw PutObjectAsync, bypassing IBlobStorageService.StoreAsync's categorized layout).
+        var rawKey = $"covers/{Guid.NewGuid():N}/cover.webp";
+        var content = "fake webp bytes"u8.ToArray();
+
+        await _s3Client.PutObjectAsync(new PutObjectRequest
+        {
+            BucketName = _options.BucketName,
+            Key = rawKey,
+            InputStream = new MemoryStream(content),
+            ContentType = "image/webp",
+        });
+
+        // Act
+        var url = await _sut.GetPresignedUrlForRawKeyAsync(rawKey, expirySeconds: 300);
+
+        // Assert
+        url.Should().NotBeNull("the object exists at the exact raw key and must resolve");
+        url.Should().Contain(_options.BucketName);
+
+        using var httpClient = new HttpClient();
+        var response = await httpClient.GetAsync(url);
+        response.IsSuccessStatusCode.Should().BeTrue($"presigned URL download failed: {response.StatusCode}");
+
+        var downloaded = await response.Content.ReadAsByteArrayAsync();
+        downloaded.Should().BeEquivalentTo(content);
+    }
+
+    [Fact]
+    public async Task GetPresignedUrlForRawKeyAsync_NoObjectAtKey_ReturnsNull()
+    {
+        SkipIfNotAvailable();
+
+        // Arrange: never uploaded — simulates a DB-persisted R2 key whose physical
+        // object was never written (or was deleted out-of-band).
+        var rawKey = $"covers/{Guid.NewGuid():N}/missing-cover.webp";
+
+        // Act
+        var url = await _sut.GetPresignedUrlForRawKeyAsync(rawKey);
+
+        // Assert
+        url.Should().BeNull("a presigned URL must never be minted for a non-existent object");
+    }
+
     [Fact]
     public async Task HealthCheck_WithRealMinIO_ReturnsHealthy()
     {

--- a/apps/api/tests/Api.Tests/Integration/GameManagement/GameNightPhotoUploadTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/GameManagement/GameNightPhotoUploadTests.cs
@@ -68,6 +68,8 @@ public sealed class GameNightPhotoUploadTests : IAsyncLifetime
             => $"{category.ToS3Folder()}/{resourceKey}/{fileId}_{fileName}";
         public Task<string?> GetPresignedDownloadUrlAsync(string fileId, BlobCategory category, string resourceKey, int? expirySeconds = null)
             => Task.FromResult<string?>(null);
+        public Task<string?> GetPresignedUrlForRawKeyAsync(string rawKey, int? expirySeconds = null)
+            => Task.FromResult<string?>(null);
     }
 
     public async ValueTask InitializeAsync()

--- a/apps/api/tests/Api.Tests/Integration/GameManagement/PlayRecordPhotoUploadTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/GameManagement/PlayRecordPhotoUploadTests.cs
@@ -94,6 +94,8 @@ public sealed class PlayRecordPhotoUploadTests : IAsyncLifetime
         // Local storage returns null (handler falls back to raw path).
         public Task<string?> GetPresignedDownloadUrlAsync(string fileId, BlobCategory category, string resourceKey, int? expirySeconds = null)
             => Task.FromResult<string?>(null);
+        public Task<string?> GetPresignedUrlForRawKeyAsync(string rawKey, int? expirySeconds = null)
+            => Task.FromResult<string?>(null);
     }
 
     // ---------------------------------------------------------------------------

--- a/apps/api/tests/Api.Tests/Integration/SharedGameCatalog/ProposeCoverChangeIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/SharedGameCatalog/ProposeCoverChangeIntegrationTests.cs
@@ -1,0 +1,214 @@
+using Api.BoundedContexts.DocumentProcessing.Application.Services;
+using Api.BoundedContexts.DocumentProcessing.Domain.Repositories;
+using Api.BoundedContexts.DocumentProcessing.Infrastructure.Persistence;
+using Api.BoundedContexts.SharedGameCatalog.Application.Commands.ProposeCoverChange;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Repositories;
+using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Services.Pdf;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Tests.BoundedContexts.DocumentProcessing.TestHelpers;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.Integration.SharedGameCatalog;
+
+/// <summary>
+/// Integration test for Task 6 (Game Cover-da-PDF plan): the authenticated user
+/// flow that proposes a cover-from-PDF for a SharedGame. Exercises the real
+/// MediatR pipeline end-to-end — <see cref="ProposeCoverChangeCommand"/> orchestrates
+/// the Task 3 <c>MaterializePdfCoverCommand</c> (materializes the pending cover) and
+/// the Task 4 <c>ShareRequest.CreateCoverChange</c> factory (creates the Pending
+/// proposal) against a real Postgres instance via Testcontainers.
+///
+/// SmolDocling dependency (named risk in the task brief): the materialization path
+/// calls GetPdfPageImageQuery, which posts to the "SmolDoclingService" named
+/// HttpClient. Since the real Python microservice isn't available under
+/// Testcontainers, this test registers a fake primary HttpMessageHandler for that
+/// named client (mirrors the pattern in WikimediaCircuitBreakerIntegrationTests)
+/// that always returns a fixed JPEG byte array. IWebpVariantGenerator and
+/// IPdfCoverUploadPipeline are mocked directly (both already internal-interface
+/// seams designed for substitution; exercising real Magick.NET/R2 upload here would
+/// test Task 3's own internals again, out of scope for this Task 6 test).
+/// </summary>
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+[Collection("Integration-GroupC")]
+public sealed class ProposeCoverChangeIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly string _testDbName;
+    private MeepleAiDbContext _dbContext = null!;
+    private ServiceProvider _serviceProvider = null!;
+
+    public ProposeCoverChangeIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+        _testDbName = $"proposecoverchange_test_{Guid.NewGuid():N}";
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_testDbName);
+
+        var services = IntegrationServiceCollectionBuilder.CreateBase(connectionString);
+
+        // Real repositories needed by the command chain under test.
+        services.AddScoped<IPdfDocumentRepository, PdfDocumentRepository>();
+        services.AddScoped<IShareRequestRepository, ShareRequestRepository>();
+        services.AddScoped<ISharedGameRepository, SharedGameRepository>();
+
+        // IWebpVariantGenerator / IPdfCoverUploadPipeline: mocked. Both are seams
+        // designed for substitution (see MaterializePdfCoverCommandHandlerTests,
+        // Task 3); exercising real Magick.NET encoding + R2 upload here would
+        // re-test Task 3's own internals, out of scope for this Task 6 test.
+        var webpMock = new Mock<IWebpVariantGenerator>();
+        webpMock
+            .Setup(w => w.GenerateWebpAsync(It.IsAny<byte[]>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new byte[] { 0x52, 0x49, 0x46, 0x46 }); // RIFF (WebP container magic)
+        services.AddScoped<IWebpVariantGenerator>(_ => webpMock.Object);
+
+        var pipelineMock = new Mock<IPdfCoverUploadPipeline>();
+        pipelineMock
+            .Setup(p => p.UploadAsync(It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string key, byte[] _, CancellationToken _) => key);
+        services.AddScoped<IPdfCoverUploadPipeline>(_ => pipelineMock.Object);
+
+        // IBlobStorageService: GetPdfPageImageQueryHandler retrieves the PDF bytes
+        // from storage before rendering. Returns a trivial non-empty stream — the
+        // fake SmolDocling handler below ignores the request body entirely.
+        var blobStorageMock = new Mock<IBlobStorageService>();
+        blobStorageMock
+            .Setup(b => b.RetrieveAsync(It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => new MemoryStream(new byte[] { 0x25, 0x50, 0x44, 0x46 })); // "%PDF"
+        services.AddSingleton<IBlobStorageService>(blobStorageMock.Object);
+
+        // Fake "SmolDoclingService" named HttpClient: GetPdfPageImageQueryHandler
+        // posts to /api/v1/page-image?page_number=N and expects JPEG bytes back.
+        // No Python microservice is reachable under Testcontainers, so the
+        // primary message handler is swapped for a fixed-response fake (same
+        // pattern as WikimediaCircuitBreakerIntegrationTests.FixedResponseHandler).
+        services.AddHttpClient("SmolDoclingService", client =>
+            {
+                client.BaseAddress = new Uri("http://smoldocling-service.test/");
+            })
+            .ConfigurePrimaryHttpMessageHandler(() => new FakeSmolDoclingHandler());
+
+        _serviceProvider = services.BuildServiceProvider();
+        _dbContext = _serviceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        await _dbContext.Database.MigrateAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _dbContext.DisposeAsync();
+        await _serviceProvider.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task Propose_MaterializesPendingCoverAndCreatesPendingShareRequest()
+    {
+        // Arrange: seed a User (FK target for PdfDocument.UploadedByUserId) + a
+        // SharedGame + a Ready PdfDocument pointed at it.
+        var userId = Guid.NewGuid();
+
+        _dbContext.Set<UserEntity>().Add(new UserEntity
+        {
+            Id = userId,
+            Email = $"propose-cover-{userId:N}@test.com",
+            DisplayName = "Propose Cover Test User",
+            Role = "user",
+            Tier = "free",
+            CreatedAt = DateTime.UtcNow
+        });
+        await _dbContext.SaveChangesAsync(CancellationToken.None);
+        _dbContext.ChangeTracker.Clear();
+
+        var sharedGame = SharedGame.Create(
+            title: "Wingspan",
+            yearPublished: 2019,
+            description: "Bird-collection engine builder",
+            minPlayers: 1,
+            maxPlayers: 5,
+            playingTimeMinutes: 70,
+            minAge: 10,
+            complexityRating: 2.4m,
+            averageRating: 8.1m,
+            imageUrl: "https://example.com/wingspan.jpg",
+            thumbnailUrl: "https://example.com/wingspan-thumb.jpg",
+            rules: null,
+            createdBy: userId);
+
+        var pdfDocument = new PdfDocumentBuilder()
+            .WithGameId(sharedGame.Id)
+            .WithUploadedBy(userId)
+            // GetPdfPageImageQueryHandler.ExtractFileIdFromPath expects the
+            // "{fileId}_{originalName}" convention used by the real upload path.
+            .WithFilePath("/uploads/00000000-0000-0000-0000-000000000001_test-rulebook.pdf")
+            .ThatIsCompleted()
+            .Build();
+
+        using (var scope = _serviceProvider.CreateScope())
+        {
+            var sharedGameRepo = scope.ServiceProvider.GetRequiredService<ISharedGameRepository>();
+            var pdfRepo = scope.ServiceProvider.GetRequiredService<IPdfDocumentRepository>();
+            var uow = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+
+            await sharedGameRepo.AddAsync(sharedGame);
+            await pdfRepo.AddAsync(pdfDocument);
+            await uow.SaveChangesAsync(CancellationToken.None);
+        }
+
+        _dbContext.ChangeTracker.Clear();
+
+        // Act
+        using var actScope = _serviceProvider.CreateScope();
+        var mediator = actScope.ServiceProvider.GetRequiredService<IMediator>();
+
+        var cmd = new ProposeCoverChangeCommand(userId, sharedGame.Id, pdfDocument.Id, PageNumber: 2);
+
+        var shareRequestId = await mediator.Send(cmd, CancellationToken.None);
+
+        // Assert
+        _dbContext.ChangeTracker.Clear();
+        var shareRequestRepo = actScope.ServiceProvider.GetRequiredService<IShareRequestRepository>();
+        var sr = await shareRequestRepo.GetByIdAsync(shareRequestId);
+
+        sr.Should().NotBeNull();
+        sr!.ContributionType.Should().Be(ContributionType.CoverChange);
+        sr.Status.Should().Be(ShareRequestStatus.Pending);
+        sr.PendingCoverR2Key.Should().NotBeNullOrWhiteSpace();
+        sr.CoverPageIndex.Should().Be(2);
+    }
+
+    /// <summary>
+    /// Fixed-response fake for the "SmolDoclingService" named HttpClient. Always
+    /// returns 200 OK with a minimal JPEG magic-number payload, regardless of the
+    /// requested page number — sufficient for GetPdfPageImageQueryHandler, whose
+    /// only postcondition on success is "returns the response body bytes".
+    /// </summary>
+    private sealed class FakeSmolDoclingHandler : DelegatingHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            var response = new HttpResponseMessage(System.Net.HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(new byte[] { 0xFF, 0xD8, 0xFF, 0xE0 }) // JPEG magic
+            };
+            return Task.FromResult(response);
+        }
+    }
+}

--- a/apps/api/tests/Api.Tests/Integration/SharedGameCatalog/ProposeCoverChangeIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/SharedGameCatalog/ProposeCoverChangeIntegrationTests.cs
@@ -194,6 +194,110 @@ public sealed class ProposeCoverChangeIntegrationTests : IAsyncLifetime
     }
 
     /// <summary>
+    /// I2 fix regression guard: two proposals for the SAME SharedGame (e.g. two
+    /// different users, or the same user proposing two different pages) must NOT
+    /// collide on the same physical R2 pending-cover object. Prior to the I2 fix,
+    /// <c>ProposeCoverChangeCommandHandler</c> built a per-GAME deterministic dbKey
+    /// (<c>covers/{gameId}/pdf-cover-pending</c>) — a second proposal for the same
+    /// game would overwrite the first proposal's R2 bytes at the same key and BOTH
+    /// <see cref="ShareRequest"/> rows would persist the identical
+    /// <see cref="ShareRequest.PendingCoverR2Key"/>. On approval, an admin approving
+    /// proposal A would actually promote whatever bytes proposal B (or a later
+    /// still-pending proposal) last wrote — silently promoting the wrong image.
+    /// The fix makes the dbKey unique per-proposal (a fresh GUID segment), while
+    /// preserving the same slash-containing key SHAPE (<c>covers/{gameId}/...</c>)
+    /// so it still resolves via <c>GetPresignedUrlForRawKeyAsync</c> (R2 resolver fix,
+    /// commit 05723c823).
+    /// </summary>
+    [Fact]
+    public async Task Propose_TwoProposalsForSameGame_ProduceDistinctPendingCoverKeys()
+    {
+        // Arrange: seed a User + a SharedGame + a Ready PdfDocument pointed at it —
+        // same fixture shape as the single-proposal test above.
+        var userId = Guid.NewGuid();
+
+        _dbContext.Set<UserEntity>().Add(new UserEntity
+        {
+            Id = userId,
+            Email = $"propose-cover-collision-{userId:N}@test.com",
+            DisplayName = "Propose Cover Collision Test User",
+            Role = "user",
+            Tier = "free",
+            CreatedAt = DateTime.UtcNow
+        });
+        await _dbContext.SaveChangesAsync(CancellationToken.None);
+        _dbContext.ChangeTracker.Clear();
+
+        var sharedGame = SharedGame.Create(
+            title: "Wingspan",
+            yearPublished: 2019,
+            description: "Bird-collection engine builder",
+            minPlayers: 1,
+            maxPlayers: 5,
+            playingTimeMinutes: 70,
+            minAge: 10,
+            complexityRating: 2.4m,
+            averageRating: 8.1m,
+            imageUrl: "https://example.com/wingspan.jpg",
+            thumbnailUrl: "https://example.com/wingspan-thumb.jpg",
+            rules: null,
+            createdBy: userId);
+
+        var pdfDocument = new PdfDocumentBuilder()
+            .WithGameId(sharedGame.Id)
+            .WithUploadedBy(userId)
+            .WithFilePath("/uploads/00000000-0000-0000-0000-000000000002_test-rulebook.pdf")
+            .ThatIsCompleted()
+            .Build();
+
+        using (var scope = _serviceProvider.CreateScope())
+        {
+            var sharedGameRepo = scope.ServiceProvider.GetRequiredService<ISharedGameRepository>();
+            var pdfRepo = scope.ServiceProvider.GetRequiredService<IPdfDocumentRepository>();
+            var uow = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+
+            await sharedGameRepo.AddAsync(sharedGame);
+            await pdfRepo.AddAsync(pdfDocument);
+            await uow.SaveChangesAsync(CancellationToken.None);
+        }
+
+        _dbContext.ChangeTracker.Clear();
+
+        // Act: propose TWO different pages of the SAME PdfDocument for the SAME
+        // SharedGame — mirrors two concurrent proposals racing on the same game.
+        using var actScope = _serviceProvider.CreateScope();
+        var mediator = actScope.ServiceProvider.GetRequiredService<IMediator>();
+
+        var cmdA = new ProposeCoverChangeCommand(userId, sharedGame.Id, pdfDocument.Id, PageNumber: 2);
+        var shareRequestIdA = await mediator.Send(cmdA, CancellationToken.None);
+
+        var cmdB = new ProposeCoverChangeCommand(userId, sharedGame.Id, pdfDocument.Id, PageNumber: 7);
+        var shareRequestIdB = await mediator.Send(cmdB, CancellationToken.None);
+
+        // Assert
+        _dbContext.ChangeTracker.Clear();
+        var shareRequestRepo = actScope.ServiceProvider.GetRequiredService<IShareRequestRepository>();
+        var srA = await shareRequestRepo.GetByIdAsync(shareRequestIdA);
+        var srB = await shareRequestRepo.GetByIdAsync(shareRequestIdB);
+
+        srA.Should().NotBeNull();
+        srB.Should().NotBeNull();
+        srA!.PendingCoverR2Key.Should().NotBeNullOrWhiteSpace();
+        srB!.PendingCoverR2Key.Should().NotBeNullOrWhiteSpace();
+
+        // The core I2 assertion: no collision between concurrent proposals for the
+        // same game.
+        srA.PendingCoverR2Key.Should().NotBe(srB.PendingCoverR2Key);
+
+        // Structural guard (not exact-value, per Guid.NewGuid() non-determinism):
+        // both keys must still match the per-game slash-containing shape required
+        // by the R2 resolver fix, with a unique 32-hex-char GUID segment.
+        var keyPattern = $"^covers/{sharedGame.Id:D}/pdf-cover-[0-9a-f]{{32}}$";
+        srA.PendingCoverR2Key.Should().MatchRegex(keyPattern);
+        srB.PendingCoverR2Key.Should().MatchRegex(keyPattern);
+    }
+
+    /// <summary>
     /// Fixed-response fake for the "SmolDoclingService" named HttpClient. Always
     /// returns 200 OK with a minimal JPEG magic-number payload, regardless of the
     /// requested page number — sufficient for GetPdfPageImageQueryHandler, whose

--- a/apps/api/tests/Api.Tests/Integration/SharedGameCatalog/ProposeCoverChangeIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/SharedGameCatalog/ProposeCoverChangeIntegrationTests.cs
@@ -189,7 +189,8 @@ public sealed class ProposeCoverChangeIntegrationTests : IAsyncLifetime
         sr!.ContributionType.Should().Be(ContributionType.CoverChange);
         sr.Status.Should().Be(ShareRequestStatus.Pending);
         sr.PendingCoverR2Key.Should().NotBeNullOrWhiteSpace();
-        sr.CoverPageIndex.Should().Be(2);
+        // C1 fix: PageNumber: 2 (1-based) must store as CoverPageIndex 1 (0-based).
+        sr.CoverPageIndex.Should().Be(1);
     }
 
     /// <summary>

--- a/apps/api/tests/Api.Tests/Middleware/ApiExceptionHandlerMiddlewareTests.cs
+++ b/apps/api/tests/Api.Tests/Middleware/ApiExceptionHandlerMiddlewareTests.cs
@@ -1,3 +1,4 @@
+using Api.BoundedContexts.DocumentProcessing.Application.Commands;
 using Api.Middleware;
 using Api.Middleware.Exceptions;
 using Api.Observability;
@@ -763,6 +764,36 @@ public class ApiExceptionHandlerMiddlewareTests
         errorResponse.RootElement.GetProperty("correlationId").ValueKind
             .Should().NotBe(System.Text.Json.JsonValueKind.Null,
                 "correlationId must be present so the client can report the incident");
+    }
+
+    [Fact]
+    public async Task InvokeAsync_CoverMaterializationException_Returns503WithCoverRenderUnavailable()
+    {
+        // Game Cover-da-PDF (Task 6, review fix): SmolDocling render failure is a
+        // non-blocking failure, not a server bug — the middleware maps it to 503 with
+        // error code "cover_render_unavailable" so the FE (Task 8) can show a
+        // non-blocking retry message instead of a generic 500.
+        var exception = new CoverMaterializationException(
+            "Rendering pagina PDF non disponibile.", new HttpRequestException("503"));
+        var middleware = new ApiExceptionHandlerMiddleware(
+            next: (context) => throw exception,
+            _loggerMock.Object,
+            _environmentMock.Object);
+
+        _httpContext.Response.Body = new MemoryStream();
+
+        await middleware.InvokeAsync(_httpContext);
+
+        _httpContext.Response.StatusCode.Should().Be(503,
+            "SmolDocling being down/404 is a transient rendering failure, not a server bug");
+
+        _httpContext.Response.Body.Seek(0, SeekOrigin.Begin);
+        using var reader = new StreamReader(_httpContext.Response.Body);
+        var responseBody = await reader.ReadToEndAsync(TestCancellationToken);
+        using var errorResponse = ParseErrorResponse(responseBody);
+
+        errorResponse.RootElement.GetProperty("error").GetString().Should().Be("cover_render_unavailable",
+            "the FE uses this distinct error code to render a non-blocking retry message");
     }
 
     private static JsonDocument ParseErrorResponse(string responseBody)

--- a/apps/api/tests/Api.Tests/Unit/Services/S3BlobStorageServiceTests.cs
+++ b/apps/api/tests/Api.Tests/Unit/Services/S3BlobStorageServiceTests.cs
@@ -488,6 +488,78 @@ public sealed class S3BlobStorageServiceTests : IDisposable
         result.Should().Be(expectedUrl);
     }
 
+    /// <summary>
+    /// I1 GATE (final whole-branch review of feature/game-cover-configuration): reproduces
+    /// the exact call shape used by <c>CoverUrlResolver.ResolvePublicAsync</c>'s L4 branch —
+    /// <c>GetPresignedDownloadUrlAsync($"{PdfCoverR2Key}-preview.webp", BlobCategory.GameImage,
+    /// PdfCoverR2Key)</c> — where <c>PdfCoverR2Key</c> is the flat, slash-containing key
+    /// written by <c>ProposeCoverChangeCommandHandler</c>
+    /// (<c>covers/{sharedGameId:D}/pdf-cover-pending</c>).
+    ///
+    /// Both the <c>fileId</c> and <c>resourceKey</c> arguments passed here contain <c>/</c>.
+    /// <see cref="S3BlobStorageService.GetPresignedDownloadUrlAsync"/> validates BOTH via
+    /// <c>PathSecurity.ValidateIdentifier</c> (regex <c>^[a-zA-Z0-9_-]+$</c>, which rejects
+    /// <c>/</c>) BEFORE ever touching <see cref="IAmazonS3"/>. This test asserts that
+    /// outcome deterministically (no S3/HTTP call should even be attempted) — settling
+    /// whether the flat-slash L4 key convention can resolve at all, independent of any
+    /// Testcontainers/MinIO transport environment noise.
+    /// </summary>
+    [Fact]
+    public async Task GetPresignedDownloadUrlAsync_FlatSlashPdfCoverKeyShape_ReturnsNullWithoutCallingS3()
+    {
+        // Arrange: exact shape CoverUrlResolver.ResolvePublicAsync passes for L4.
+        var pdfCoverR2Key = $"covers/{Guid.NewGuid():D}/pdf-cover-pending";
+        var fileId = $"{pdfCoverR2Key}-preview.webp";
+
+        // Act
+        var result = await _sut.GetPresignedDownloadUrlAsync(fileId, BlobCategory.GameImage, pdfCoverR2Key);
+
+        // Assert: PathSecurity.ValidateIdentifier throws ArgumentException on the slash
+        // before any S3 call — the catch-all handler converts it to a null return, which
+        // is indistinguishable from "not found" at the CoverUrlResolver call site.
+        result.Should().BeNull(
+            "PathSecurity.ValidateIdentifier rejects '/' in both fileId and resourceKey, " +
+            "so the flat-slash L4 key can never reach S3 — this is the I1 gate verdict");
+
+        _mockS3Client.Verify(x => x.ListObjectsV2Async(
+            It.IsAny<ListObjectsV2Request>(),
+            It.IsAny<CancellationToken>()),
+            Times.Never,
+            "validation must fail before any S3 round-trip is attempted");
+
+        _mockS3Client.Verify(x => x.GetPreSignedURLAsync(
+            It.IsAny<GetPreSignedUrlRequest>()),
+            Times.Never);
+    }
+
+    /// <summary>
+    /// Companion to the I1 gate above: confirms the ALREADY-SHIPPED L2 Wikidata convention
+    /// (<c>GetPresignedDownloadUrlAsync($"{WikidataCoverR2Key}.webp", GameImage,
+    /// WikidataCoverR2Key)</c>, same flat-slash shape) hits the identical validation
+    /// failure — proving this is a pre-existing, shared defect in the flat-slash key
+    /// convention itself, not something unique to the new PDF-cover (L4) feature.
+    /// </summary>
+    [Fact]
+    public async Task GetPresignedDownloadUrlAsync_FlatSlashWikidataKeyShape_ReturnsNullWithoutCallingS3()
+    {
+        // Arrange: exact shape CoverUrlResolver.ResolvePublicAsync passes for L2.
+        var wikidataCoverR2Key = $"covers/{Guid.NewGuid():D}/wikidata-cover";
+        var fileId = $"{wikidataCoverR2Key}.webp";
+
+        // Act
+        var result = await _sut.GetPresignedDownloadUrlAsync(fileId, BlobCategory.GameImage, wikidataCoverR2Key);
+
+        // Assert
+        result.Should().BeNull(
+            "the L2 Wikidata convention uses the identical flat-slash shape as L4 and " +
+            "hits the same PathSecurity.ValidateIdentifier rejection");
+
+        _mockS3Client.Verify(x => x.ListObjectsV2Async(
+            It.IsAny<ListObjectsV2Request>(),
+            It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
     // ── Issue #2271: non-seekable stream handling ────────────────────────────
     // R2 (and other S3-compatible providers) reject PutObject when the SDK's
     // checksum calculator cannot read a stream's Length. This happens when the

--- a/apps/api/tests/Api.Tests/Unit/Services/S3BlobStorageServiceTests.cs
+++ b/apps/api/tests/Api.Tests/Unit/Services/S3BlobStorageServiceTests.cs
@@ -649,6 +649,156 @@ public sealed class S3BlobStorageServiceTests : IDisposable
         capturedHeaderContentLength.Should().Be(content.Length);
     }
 
+    // ── P1 fix (2026-07-14): GetPresignedUrlForRawKeyAsync ──────────────────────
+    // R2 cover resolver defect: CoverUrlResolver's L2/L3/L4 branches pass raw,
+    // slash-and-dot-containing physical keys (e.g. "covers/{guid}/cover.webp")
+    // to what used to be GetPresignedDownloadUrlAsync, which validates both
+    // args via PathSecurity.ValidateIdentifier (rejects '/' and '.') — always
+    // throwing internally and returning null. GetPresignedUrlForRawKeyAsync is
+    // the fix: it accepts the exact physical key with no identifier validation
+    // and no prefix discovery, but DOES verify object existence first (HEAD)
+    // so a caller never gets a URL to a non-existent object.
+
+    [Fact]
+    public async Task GetPresignedUrlForRawKeyAsync_ObjectExists_ReturnsUrlForExactKeyNoValidation()
+    {
+        // Arrange: a slash-and-dot key that PathSecurity.ValidateIdentifier would reject.
+        var rawKey = $"covers/{Guid.NewGuid():D}/cover.webp";
+        var expectedUrl = $"https://test-bucket.s3.amazonaws.com/{rawKey}?presigned=true";
+
+        _mockS3Client.Setup(x => x.GetObjectMetadataAsync(
+            "test-bucket",
+            rawKey,
+            It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GetObjectMetadataResponse { HttpStatusCode = HttpStatusCode.OK });
+
+        _mockS3Client.Setup(x => x.GetPreSignedURLAsync(
+            It.IsAny<GetPreSignedUrlRequest>()))
+            .ReturnsAsync(expectedUrl);
+
+        // Act
+        var result = await _sut.GetPresignedUrlForRawKeyAsync(rawKey);
+
+        // Assert
+        result.Should().Be(expectedUrl);
+
+        _mockS3Client.Verify(x => x.GetPreSignedURLAsync(
+            It.Is<GetPreSignedUrlRequest>(r =>
+                r.BucketName == "test-bucket" &&
+                r.Key == rawKey &&
+                r.Verb == HttpVerb.GET)),
+            Times.Once);
+
+        // No prefix discovery / list call — this is a direct raw-key lookup.
+        _mockS3Client.Verify(x => x.ListObjectsV2Async(
+            It.IsAny<ListObjectsV2Request>(),
+            It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task GetPresignedUrlForRawKeyAsync_ObjectMissing_ReturnsNull()
+    {
+        // Arrange
+        var rawKey = $"covers/{Guid.NewGuid():D}/cover.webp";
+
+        _mockS3Client.Setup(x => x.GetObjectMetadataAsync(
+            "test-bucket",
+            rawKey,
+            It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new AmazonS3Exception("Not found") { StatusCode = HttpStatusCode.NotFound });
+
+        // Act
+        var result = await _sut.GetPresignedUrlForRawKeyAsync(rawKey);
+
+        // Assert
+        result.Should().BeNull();
+
+        _mockS3Client.Verify(x => x.GetPreSignedURLAsync(
+            It.IsAny<GetPreSignedUrlRequest>()),
+            Times.Never,
+            "a presigned URL must never be minted for a non-existent object");
+    }
+
+    [Fact]
+    public async Task GetPresignedUrlForRawKeyAsync_SlashAndDotKey_DoesNotThrowValidationException()
+    {
+        // Arrange: exact shape used by CoverUrlResolver's L4 branch (PdfCoverR2Key-preview.webp)
+        // and L2 branch (WikidataCoverR2Key.webp) — both contain '/' AND '.'.
+        var rawKey = $"covers/{Guid.NewGuid():D}/pdf-cover-pending-preview.webp";
+
+        _mockS3Client.Setup(x => x.GetObjectMetadataAsync(
+            "test-bucket",
+            rawKey,
+            It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GetObjectMetadataResponse { HttpStatusCode = HttpStatusCode.OK });
+
+        _mockS3Client.Setup(x => x.GetPreSignedURLAsync(
+            It.IsAny<GetPreSignedUrlRequest>()))
+            .ReturnsAsync("https://test-bucket.s3.amazonaws.com/presigned");
+
+        // Act
+        var result = await _sut.GetPresignedUrlForRawKeyAsync(rawKey);
+
+        // Assert: unlike GetPresignedDownloadUrlAsync, PathSecurity.ValidateIdentifier
+        // is never invoked, so the slash/dot key resolves instead of throwing internally.
+        result.Should().NotBeNull(
+            "GetPresignedUrlForRawKeyAsync must accept raw physical keys containing '/' and '.' " +
+            "without running PathSecurity.ValidateIdentifier");
+    }
+
+    [Fact]
+    public async Task GetPresignedUrlForRawKeyAsync_CustomExpiry_UsesProvidedValue()
+    {
+        // Arrange
+        var rawKey = "covers/game/cover.webp";
+        var customExpiry = 7200;
+        DateTime? capturedExpires = null;
+
+        _mockS3Client.Setup(x => x.GetObjectMetadataAsync(
+            "test-bucket",
+            rawKey,
+            It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GetObjectMetadataResponse { HttpStatusCode = HttpStatusCode.OK });
+
+        _mockS3Client.Setup(x => x.GetPreSignedURLAsync(
+            It.IsAny<GetPreSignedUrlRequest>()))
+            .Callback<GetPreSignedUrlRequest>(r => capturedExpires = r.Expires)
+            .ReturnsAsync("https://test-bucket.s3.amazonaws.com/presigned");
+
+        var before = DateTime.UtcNow.AddSeconds(customExpiry);
+
+        // Act
+        var result = await _sut.GetPresignedUrlForRawKeyAsync(rawKey, customExpiry);
+
+        // Assert
+        result.Should().NotBeNull();
+        capturedExpires.Should().NotBeNull();
+        capturedExpires!.Value.Should().BeCloseTo(before, TimeSpan.FromSeconds(5));
+    }
+
+    [Fact]
+    public async Task GetPresignedUrlForRawKeyAsync_S3ExceptionOnMetadata_ReturnsNull()
+    {
+        // Arrange: a non-404 S3 error on the HEAD check should still degrade to null,
+        // not throw and crash the resolver call chain.
+        var rawKey = "covers/game/cover.webp";
+
+        _mockS3Client.Setup(x => x.GetObjectMetadataAsync(
+            "test-bucket",
+            rawKey,
+            It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new AmazonS3Exception("Access denied") { StatusCode = HttpStatusCode.Forbidden });
+
+        // Act
+        var act = async () => await _sut.GetPresignedUrlForRawKeyAsync(rawKey);
+
+        // Assert: outer catch-all handles any AmazonS3Exception not matched by the
+        // inner NotFound-only catch, degrading to null instead of throwing.
+        var result = await act.Should().NotThrowAsync();
+        result.Subject.Should().BeNull();
+    }
+
     /// <summary>
     /// Simulates an HTTP request body or a forward-only stream. Throws on Length
     /// and Position to surface the AWS SDK's "Could not determine content length"

--- a/apps/api/tests/Api.Tests/Unit/UserLibrary/GetUserLibraryQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/Unit/UserLibrary/GetUserLibraryQueryHandlerTests.cs
@@ -47,6 +47,9 @@ public sealed class GetUserLibraryQueryHandlerTests : IDisposable
             .Setup(b => b.GetPresignedDownloadUrlAsync(
                 It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<int?>()))
             .ReturnsAsync((string?)null);
+        _mockBlobStorage
+            .Setup(b => b.GetPresignedUrlForRawKeyAsync(It.IsAny<string>(), It.IsAny<int?>()))
+            .ReturnsAsync((string?)null);
 
         _dbContext = TestDbContextFactory.CreateInMemoryDbContext();
 
@@ -394,10 +397,8 @@ public sealed class GetUserLibraryQueryHandlerTests : IDisposable
 
         // Configure blob storage: return the expected URL only for the "-preview.webp" variant key.
         _mockBlobStorage
-            .Setup(b => b.GetPresignedDownloadUrlAsync(
+            .Setup(b => b.GetPresignedUrlForRawKeyAsync(
                 $"{pdfCoverKey}-preview.webp",
-                BlobCategory.GameImage,
-                pdfCoverKey,
                 It.IsAny<int?>()))
             .ReturnsAsync(expectedCoverUrl);
 

--- a/apps/web/src/app/admin/(dashboard)/shared-games/[id]/client.tsx
+++ b/apps/web/src/app/admin/(dashboard)/shared-games/[id]/client.tsx
@@ -19,6 +19,7 @@ import {
   Download,
   ExternalLink,
   FileText,
+  Image as ImageIcon,
   Link2,
   MoreHorizontal,
   Settings2,
@@ -33,6 +34,7 @@ import { EditGameDrawer } from '@/components/admin/shared-games/EditGameDrawer';
 import { GameProcessingQueue } from '@/components/admin/shared-games/GameProcessingQueue';
 import { PdfIndexingStatus } from '@/components/admin/shared-games/PdfIndexingStatus';
 import { PdfUploadSection } from '@/components/admin/shared-games/PdfUploadSection';
+import { CoverPagePicker } from '@/components/shared-games/CoverPagePicker';
 import { Badge } from '@/components/ui/data-display/badge';
 import {
   Card,
@@ -51,6 +53,13 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/navigation/dropdown-menu';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/navigation/tabs';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from '@/components/ui/overlays/dialog';
 import {
   Select,
   SelectContent,
@@ -92,10 +101,13 @@ function DocumentItem({
   document,
   onDelete,
   isDeleting,
+  onSetCover,
 }: {
   document: SharedGameDocument;
   onDelete: (id: string) => void;
   isDeleting: boolean;
+  /** Opens the cover-da-PDF picker dialog for this document (Task 8). */
+  onSetCover: (document: SharedGameDocument) => void;
 }) {
   const handleDownload = useCallback(() => {
     // Download is not yet wired to a signed URL - placeholder
@@ -134,6 +146,10 @@ function DocumentItem({
             <DropdownMenuItem onClick={handleDownload}>
               <Download className="mr-2 h-4 w-4" />
               Download
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={() => onSetCover(document)}>
+              <ImageIcon className="mr-2 h-4 w-4" />
+              Imposta cover
             </DropdownMenuItem>
             <DropdownMenuSeparator />
             <DropdownMenuItem
@@ -191,6 +207,9 @@ export function GameDetailClient({ params }: GameDetailClientProps) {
 
   // ── Edit Game drawer ─────────────────────────────────────────────────────
   const [editDrawerOpen, setEditDrawerOpen] = useState(false);
+
+  // ── Cover-da-PDF picker dialog (Task 8: "Imposta cover" action) ──────────
+  const [coverPickerDocument, setCoverPickerDocument] = useState<SharedGameDocument | null>(null);
 
   const { data: linkedAgent, isLoading: linkedAgentLoading } = useQuery({
     queryKey: ['admin', 'shared-games', gameId, 'linked-agent'],
@@ -706,6 +725,7 @@ export function GameDetailClient({ params }: GameDetailClientProps) {
                       isDeleting={
                         deleteDocMutation.isPending && deleteDocMutation.variables === doc.id
                       }
+                      onSetCover={setCoverPickerDocument}
                     />
                   ))}
                   <div className="pt-2">
@@ -731,6 +751,34 @@ export function GameDetailClient({ params }: GameDetailClientProps) {
       {game && (
         <EditGameDrawer open={editDrawerOpen} onOpenChange={setEditDrawerOpen} game={game} />
       )}
+
+      {/* Cover-da-PDF picker dialog (Task 8: "Imposta cover" action) */}
+      <Dialog
+        open={coverPickerDocument !== null}
+        onOpenChange={open => !open && setCoverPickerDocument(null)}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Imposta cover da PDF</DialogTitle>
+            <DialogDescription>
+              Scegli una pagina del PDF da proporre come copertina. La proposta richiede
+              l&apos;approvazione di un amministratore.
+            </DialogDescription>
+          </DialogHeader>
+          {coverPickerDocument && (
+            <CoverPagePicker
+              gameId={gameId}
+              pdfDocumentId={coverPickerDocument.pdfDocumentId}
+              onProposed={() => {
+                setCoverPickerDocument(null);
+                queryClient.invalidateQueries({
+                  queryKey: ['admin', 'shared-games', gameId],
+                });
+              }}
+            />
+          )}
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/apps/web/src/components/admin/shared-games/PdfUploadSection.tsx
+++ b/apps/web/src/components/admin/shared-games/PdfUploadSection.tsx
@@ -19,6 +19,7 @@ import { FileUp, X, FileText, CheckCircle2, AlertCircle, Loader2, Zap } from 'lu
 import { toast } from 'sonner';
 
 import { KbCardStatusRow } from '@/components/documents/KbCardStatusRow';
+import { CoverPagePicker } from '@/components/shared-games/CoverPagePicker';
 import {
   Card,
   CardContent,
@@ -80,6 +81,10 @@ export function PdfUploadSection({
 
   // Processing status polling (Issue #5196 → refactored to useQuery in #2246 Block B)
   const [processingDoc, setProcessingDoc] = useState<PdfDocumentDto | null>(null);
+  // Cover-da-PDF prompt (Task 8, Game Cover-da-PDF plan): offered once the PDF
+  // reaches Ready, dismissed once the admin proposes a cover (or never shown
+  // again for this upload if dismissed).
+  const [coverPromptDismissed, setCoverPromptDismissed] = useState(false);
 
   const queryClient = useQueryClient();
   const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8080';
@@ -232,6 +237,7 @@ export function PdfUploadSection({
     setUploading(true);
     setUploadProgress(0);
     setError(null);
+    setCoverPromptDismissed(false);
 
     try {
       const formData = new FormData();
@@ -344,6 +350,7 @@ export function PdfUploadSection({
     setFile(null);
     setError(null);
     setProcessingDoc(null);
+    setCoverPromptDismissed(false);
     onPdfRemoved?.();
   }, [onPdfRemoved]);
 
@@ -399,6 +406,21 @@ export function PdfUploadSection({
               Stato elaborazione
             </p>
             <KbCardStatusRow document={processingDoc} />
+          </div>
+        )}
+
+        {/* Cover-da-PDF prompt (Task 8): offered once the PDF reaches Ready */}
+        {gameId && processingDoc?.processingState === 'Ready' && !coverPromptDismissed && (
+          <div data-testid="cover-page-picker-prompt" className="space-y-2 rounded-lg border p-4">
+            <p className="text-sm font-medium">Vuoi proporre una copertina da questo PDF?</p>
+            <CoverPagePicker
+              gameId={gameId}
+              pdfDocumentId={processingDoc.id}
+              onProposed={() => {
+                toast.success('Copertina proposta per approvazione');
+                setCoverPromptDismissed(true);
+              }}
+            />
           </div>
         )}
 

--- a/apps/web/src/components/shared-games/CoverPagePicker.tsx
+++ b/apps/web/src/components/shared-games/CoverPagePicker.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+/**
+ * CoverPagePicker — proposes a PDF page as a SharedGame cover (Task 8, Game
+ * Cover-da-PDF plan).
+ *
+ * Lets the user pick a page number from an already-uploaded PDF, preview it,
+ * and submit it as a cover proposal via `POST
+ * /api/v1/games/{gameId}/cover/propose-from-pdf`. The endpoint materializes a
+ * pending cover image and creates a Pending CoverChange share request for
+ * admin approval — this component does not apply the cover directly.
+ *
+ * If the backend render step (SmolDocling) fails, it responds 503 with
+ * `{ error: "cover_render_unavailable" }`. That failure is surfaced as a
+ * distinct, non-blocking message (retryable) rather than a generic error.
+ */
+
+import { useState } from 'react';
+import type { JSX } from 'react';
+
+import { Alert, AlertDescription } from '@/components/ui/feedback/alert';
+import { Button } from '@/components/ui/primitives/button';
+import { Input } from '@/components/ui/primitives/input';
+import { Label } from '@/components/ui/primitives/label';
+import { api } from '@/lib/api';
+
+export interface CoverPagePickerProps {
+  gameId: string;
+  pdfDocumentId: string;
+  onProposed: (shareRequestId: string) => void;
+}
+
+const COVER_RENDER_UNAVAILABLE_MESSAGE =
+  'Anteprima cover non disponibile al momento, riprova più tardi.';
+const GENERIC_ERROR_MESSAGE = 'Impossibile proporre la cover in questo momento.';
+
+/** Reads the machine-readable error code off an ApiError-shaped error, if present. */
+function getErrorCode(error: unknown): string | undefined {
+  if (error && typeof error === 'object' && 'code' in error) {
+    const code = (error as { code?: unknown }).code;
+    return typeof code === 'string' ? code : undefined;
+  }
+  return undefined;
+}
+
+export function CoverPagePicker({
+  gameId,
+  pdfDocumentId,
+  onProposed,
+}: CoverPagePickerProps): JSX.Element {
+  const [page, setPage] = useState(1);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function propose(): Promise<void> {
+    setBusy(true);
+    setError(null);
+    try {
+      const { shareRequestId } = await api.sharedGames.proposeCoverFromPdf(
+        gameId,
+        pdfDocumentId,
+        page
+      );
+      onProposed(shareRequestId);
+    } catch (err) {
+      // 503 cover_render_unavailable is a non-blocking, retryable failure
+      // (SmolDocling render hiccup) — distinct from a generic server error.
+      if (getErrorCode(err) === 'cover_render_unavailable') {
+        setError(COVER_RENDER_UNAVAILABLE_MESSAGE);
+      } else {
+        setError(GENERIC_ERROR_MESSAGE);
+      }
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="space-y-3">
+      {pdfDocumentId && (
+        // Dynamic API-served page preview (not a static/optimizable asset);
+        // matches CoverImagePicker.tsx's PDF-page-preview pattern.
+        // eslint-disable-next-line @next/next/no-img-element
+        <img
+          src={api.sharedGames.getPdfPageImageUrl(pdfDocumentId, page)}
+          alt={`Anteprima pagina ${page}`}
+          className="max-h-48 rounded border border-border object-contain"
+        />
+      )}
+
+      <div className="flex items-end gap-2">
+        <div className="flex-1 space-y-1">
+          <Label htmlFor="cover-page-picker-page">Pagina</Label>
+          <Input
+            id="cover-page-picker-page"
+            type="number"
+            min={1}
+            value={page}
+            onChange={e => setPage(Number(e.target.value))}
+            className="w-24"
+          />
+        </div>
+        <Button type="button" size="sm" disabled={busy} onClick={propose}>
+          {busy ? 'Invio...' : 'Proponi cover'}
+        </Button>
+      </div>
+
+      {error && (
+        <Alert variant="destructive">
+          <AlertDescription className="text-sm">{error}</AlertDescription>
+        </Alert>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/shared-games/__tests__/CoverPagePicker.test.tsx
+++ b/apps/web/src/components/shared-games/__tests__/CoverPagePicker.test.tsx
@@ -1,0 +1,66 @@
+/**
+ * CoverPagePicker Component Tests
+ *
+ * Task 8 (Game Cover-da-PDF plan): proposes a PDF page as a game cover via
+ * POST /api/v1/games/{gameId}/cover/propose-from-pdf, invoking onProposed
+ * with the resulting shareRequestId. Also covers the non-blocking 503
+ * ("cover_render_unavailable") failure mode from the backend render step.
+ */
+
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderWithQuery } from '@/__tests__/utils/query-test-utils';
+import { CoverPagePicker } from '../CoverPagePicker';
+
+const proposeMock = vi.fn();
+vi.mock('@/lib/api', () => ({
+  api: {
+    sharedGames: {
+      getPdfPageImageUrl: (id: string, p: number) => `/img/${id}/${p}`,
+      proposeCoverFromPdf: (...a: unknown[]) => proposeMock(...a),
+    },
+  },
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  proposeMock.mockResolvedValue({ shareRequestId: 'sr-1' });
+});
+
+describe('CoverPagePicker', () => {
+  it('proposes the selected page and calls onProposed', async () => {
+    const onProposed = vi.fn();
+    const user = userEvent.setup();
+    renderWithQuery(<CoverPagePicker gameId="g-1" pdfDocumentId="pdf-1" onProposed={onProposed} />);
+
+    const pageInput = screen.getByLabelText(/pagina/i);
+    await user.clear(pageInput);
+    await user.type(pageInput, '3');
+    await user.click(screen.getByRole('button', { name: /proponi cover/i }));
+
+    await waitFor(() => expect(proposeMock).toHaveBeenCalledWith('g-1', 'pdf-1', 3));
+    await waitFor(() => expect(onProposed).toHaveBeenCalledWith('sr-1'));
+  });
+
+  it('shows a non-blocking message when cover rendering is unavailable (503)', async () => {
+    const onProposed = vi.fn();
+    const user = userEvent.setup();
+
+    const error = new Error('cover_render_unavailable') as Error & {
+      statusCode: number;
+      code: string;
+    };
+    error.statusCode = 503;
+    error.code = 'cover_render_unavailable';
+    proposeMock.mockRejectedValueOnce(error);
+
+    renderWithQuery(<CoverPagePicker gameId="g-1" pdfDocumentId="pdf-1" onProposed={onProposed} />);
+
+    await user.click(screen.getByRole('button', { name: /proponi cover/i }));
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent(/anteprima cover non disponibile/i);
+    expect(onProposed).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/shared-games/index.ts
+++ b/apps/web/src/components/shared-games/index.ts
@@ -24,6 +24,7 @@ export { SharedGameDetailModal, type SharedGameDetailModalProps } from './Shared
 export { KnowledgeBaseTab, type KnowledgeBaseTabProps } from './KnowledgeBaseTab';
 export { ContributorsSection } from './ContributorsSection';
 export { MeepleContributorCard } from './MeepleContributorCard';
+export { CoverPagePicker, type CoverPagePickerProps } from './CoverPagePicker';
 
 // Re-export the replacement component for migration convenience
 export {

--- a/apps/web/src/lib/api/clients/sharedGamesClient.ts
+++ b/apps/web/src/lib/api/clients/sharedGamesClient.ts
@@ -1478,6 +1478,37 @@ export function createSharedGamesClient({ httpClient }: CreateSharedGamesClientP
       return `${getApiBase()}/api/v1/ingest/pdf/${encodeURIComponent(pdfId)}/page-image?page=${page}`;
     },
 
+    // ========== Cover-da-PDF (Task 8, Game Cover-da-PDF plan) ==========
+
+    /**
+     * Propose a PDF page as a game cover (AUTHENTICATED).
+     * POST /api/v1/games/{gameId}/cover/propose-from-pdf
+     *
+     * Materializes the given page as a pending cover image and creates a
+     * Pending CoverChange share request for admin review. If the render step
+     * (SmolDocling) fails, the backend responds 503 with
+     * `{ error: "cover_render_unavailable" }` — a non-blocking failure the
+     * caller should surface as a retryable message, not a hard error.
+     *
+     * @param gameId - SharedGame UUID
+     * @param pdfDocumentId - Source PDF UUID
+     * @param pageNumber - 1-based page number to render as the cover
+     * @returns The created share request ID
+     */
+    async proposeCoverFromPdf(
+      gameId: string,
+      pdfDocumentId: string,
+      pageNumber: number
+    ): Promise<{ shareRequestId: string }> {
+      const Schema = z.object({ shareRequestId: z.string() });
+      const result = await httpClient.post<z.infer<typeof Schema>>(
+        `/api/v1/games/${encodeURIComponent(gameId)}/cover/propose-from-pdf`,
+        { pdfDocumentId, pageNumber },
+        Schema
+      );
+      return result!;
+    },
+
     /**
      * Search knowledge base for a game (RAG test in Step 5).
      * POST /api/v1/knowledge-base/search

--- a/docs/superpowers/plans/2026-07-14-game-cover-pdf-source.md
+++ b/docs/superpowers/plans/2026-07-14-game-cover-pdf-source.md
@@ -1,0 +1,1033 @@
+# Cover-da-PDF (SharedGame) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Permettere a un utente di impostare la cover di uno SharedGame scegliendo una pagina di un PDF caricato, via proposta con approvazione admin (L4); consolidare la deduplicazione PDF in un servizio unico; chiudere i canali di URL esterni per compliance BGG.
+
+**Architecture:** DocumentProcessing *produce* l'artefatto (render pagina → WebP → R2 con key deterministica). SharedGameCatalog *possiede* la cover pubblica L4 e la scrittura passa dal proposal-system esistente (`ShareRequest` esteso con `ContributionType.CoverChange`). La dedup viene estratta da due handler divergenti in un `IPdfDeduplicationService` unico invocato da tutti i path di ingest.
+
+**Tech Stack:** .NET 9, ASP.NET Minimal APIs + MediatR (CQRS), EF Core + PostgreSQL, xUnit + Moq + FluentAssertions (unit), Testcontainers (integration); Next.js 16 + React 19 + Vitest (FE).
+
+## Global Constraints
+
+- **CQRS**: endpoint usano SOLO `IMediator.Send()` — mai injection diretta di servizi. (#2567)
+- **Eccezioni**: `ConflictException` (409), `NotFoundException` (404), `ForbiddenException` (403) — mai `InvalidOperationException` (500). (#2568)
+- **DDD**: entity con private setter + factory; value object immutabili; interfacce repository in Domain, implementazione in Infrastructure.
+- **DI**: registrare sia `IService` sia implementazione. (#2565)
+- **Compliance BGG (#2123 / ADR-059 §5)**: nessun URL esterno arbitrario come cover; solo R2/Wikimedia. Vietato passare host BGG a `<Image>`.
+- **Convenzione key cover L4**: `SharedGame.PdfCoverR2Key` memorizza la key **senza** suffisso; l'oggetto fisico R2 sta a `{key}-preview.webp` (il resolver appende `-preview.webp`, `CoverUrlResolver.cs:72`).
+- **Materializzazione sincrona**; su fallimento SmolDocling (503/404) l'operazione è rifiutata in modo non-bloccante, nessuno stato "cover a metà".
+- **Dedup**: SHA-256 (`ContentHash`); riuso trasparente via `EntityLink`; scope **globale sul catalogo** / **per-utente sui privati**.
+- **Test**: `[Trait("Category", TestCategories.Unit)]` (unit), Testcontainers (integration). Kill testhost prima di lanciare i test (#2593).
+- **Commit frequenti**, TDD stretto.
+
+---
+
+## File map
+
+**Backend — creati:**
+- `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/IPdfDeduplicationService.cs`
+- `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfDeduplicationService.cs`
+- `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/IPdfCoverUploadPipeline.cs`
+- `apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/Services/PdfCoverUploadPipeline.cs`
+- `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/MaterializePdfCoverCommand.cs` (+ Handler)
+- `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/ProposeCoverChange/ProposeCoverChangeCommand.cs` (+ Handler + Validator)
+- EF migration per i nuovi campi `ShareRequest`
+
+**Backend — modificati:**
+- `.../DocumentProcessing/Domain/Repositories/IPdfDocumentRepository.cs` (+ `FindByContentHashForUserAsync`)
+- `.../DocumentProcessing/Infrastructure/Persistence/PdfDocumentRepository.cs`
+- `.../DocumentProcessing/Application/Commands/CompleteChunkedUploadCommandHandler.cs`
+- `.../DocumentProcessing/Application/Commands/AddRulebookCommandHandler.cs` (usa il service)
+- `.../SharedGameCatalog/Domain/ValueObjects/ContributionType.cs`
+- `.../SharedGameCatalog/Domain/Entities/ShareRequest.cs`
+- `.../SharedGameCatalog/Domain/Enums/ProposalApprovalAction.cs`
+- `.../SharedGameCatalog/Application/Commands/ApproveGameProposal/ApproveGameProposalCommandHandler.cs`
+- `apps/api/src/Api/Routing/PrivateGameEndpoints.cs` + `.../UserLibrary/Application/Commands/PrivateGames/AddPrivateGameCommand.cs` (+ Handler)
+- DI registration + endpoint routing
+
+**Frontend — creati/modificati:**
+- `apps/web/src/components/shared-games/CoverPagePicker.tsx` (wrapper riusabile)
+- `apps/web/src/lib/api/clients/sharedGamesClient.ts` (+ endpoint propose-cover)
+- test Vitest associati
+
+---
+
+## Task 1: `IPdfDeduplicationService` — regola dedup centralizzata
+
+**Files:**
+- Create: `.../DocumentProcessing/Application/Services/IPdfDeduplicationService.cs`
+- Create: `.../DocumentProcessing/Application/Services/PdfDeduplicationService.cs`
+- Modify: `.../DocumentProcessing/Domain/Repositories/IPdfDocumentRepository.cs`
+- Modify: `.../DocumentProcessing/Infrastructure/Persistence/PdfDocumentRepository.cs`
+- Test: `apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Services/PdfDeduplicationServiceTests.cs`
+
+**Interfaces:**
+- Consumes: `IPdfDocumentRepository.FindByContentHashAsync(string, CancellationToken)` (globale), nuovo `FindByContentHashForUserAsync(string, Guid, CancellationToken)`.
+- Produces: `IPdfDeduplicationService.EvaluateAsync(string contentHash, Guid? sharedGameId, Guid? privateGameId, Guid userId, CancellationToken)` → `PdfDedupResult(PdfDedupDecision Decision, Guid? ExistingPdfDocumentId, string ContentHash)`; `ComputeContentHashAsync(Stream, CancellationToken)`.
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+// PdfDeduplicationServiceTests.cs
+[Trait("Category", TestCategories.Unit)]
+public class PdfDeduplicationServiceTests
+{
+    private readonly Mock<IPdfDocumentRepository> _repo = new();
+    private PdfDeduplicationService Sut() => new(_repo.Object);
+
+    [Fact]
+    public async Task Evaluate_CatalogHashKnownAndReady_ReturnsReuseExisting()
+    {
+        var existing = PdfDocumentTestFactory.Ready(); // helper: state Ready
+        _repo.Setup(r => r.FindByContentHashAsync("h", It.IsAny<CancellationToken>()))
+             .ReturnsAsync(existing);
+
+        var result = await Sut().EvaluateAsync("h", sharedGameId: Guid.NewGuid(),
+            privateGameId: null, userId: Guid.NewGuid(), CancellationToken.None);
+
+        result.Decision.Should().Be(PdfDedupDecision.ReuseExisting);
+        result.ExistingPdfDocumentId.Should().Be(existing.Id);
+    }
+
+    [Fact]
+    public async Task Evaluate_CatalogHashKnownButFailed_ReturnsNewUpload()
+    {
+        var existing = PdfDocumentTestFactory.Failed();
+        _repo.Setup(r => r.FindByContentHashAsync("h", It.IsAny<CancellationToken>()))
+             .ReturnsAsync(existing);
+
+        var result = await Sut().EvaluateAsync("h", Guid.NewGuid(), null, Guid.NewGuid(), CancellationToken.None);
+
+        result.Decision.Should().Be(PdfDedupDecision.NewUpload);
+    }
+
+    [Fact]
+    public async Task Evaluate_PrivateGame_UsesPerUserLookupNotGlobal()
+    {
+        var userId = Guid.NewGuid();
+        _repo.Setup(r => r.FindByContentHashForUserAsync("h", userId, It.IsAny<CancellationToken>()))
+             .ReturnsAsync((PdfDocument?)null);
+
+        var result = await Sut().EvaluateAsync("h", sharedGameId: null,
+            privateGameId: Guid.NewGuid(), userId: userId, CancellationToken.None);
+
+        result.Decision.Should().Be(PdfDedupDecision.NewUpload);
+        _repo.Verify(r => r.FindByContentHashAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        _repo.Verify(r => r.FindByContentHashForUserAsync("h", userId, It.IsAny<CancellationToken>()), Times.Once);
+    }
+}
+```
+
+- [ ] **Step 2: Run test → verify FAIL**
+
+Run: `cd apps/api && dotnet test tests/Api.Tests --filter "FullyQualifiedName~PdfDeduplicationServiceTests"`
+Expected: FAIL — `PdfDeduplicationService` / `FindByContentHashForUserAsync` non esistono.
+
+- [ ] **Step 3: Add repo method (interface + impl)**
+
+```csharp
+// IPdfDocumentRepository.cs — aggiungere
+Task<PdfDocument?> FindByContentHashForUserAsync(string contentHash, Guid userId, CancellationToken cancellationToken = default);
+```
+
+```csharp
+// PdfDocumentRepository.cs — aggiungere (per-user: isola i PDF privati)
+public async Task<PdfDocument?> FindByContentHashForUserAsync(string contentHash, Guid userId, CancellationToken cancellationToken = default)
+{
+    var entity = await DbContext.PdfDocuments
+        .AsNoTracking()
+        .Where(p => p.ContentHash == contentHash && p.UploadedByUserId == userId)
+        .OrderByDescending(p => p.UploadedAt)
+        .FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
+    return entity != null ? MapToDomain(entity) : null;
+}
+```
+
+- [ ] **Step 4: Implement the service**
+
+```csharp
+// IPdfDeduplicationService.cs
+public enum PdfDedupDecision { NewUpload, ReuseExisting }
+public sealed record PdfDedupResult(PdfDedupDecision Decision, Guid? ExistingPdfDocumentId, string ContentHash);
+
+public interface IPdfDeduplicationService
+{
+    Task<string> ComputeContentHashAsync(Stream content, CancellationToken cancellationToken);
+    Task<PdfDedupResult> EvaluateAsync(string contentHash, Guid? sharedGameId, Guid? privateGameId, Guid userId, CancellationToken cancellationToken);
+}
+```
+
+```csharp
+// PdfDeduplicationService.cs
+internal sealed class PdfDeduplicationService : IPdfDeduplicationService
+{
+    private readonly IPdfDocumentRepository _repo;
+    public PdfDeduplicationService(IPdfDocumentRepository repo) => _repo = repo;
+
+    public async Task<string> ComputeContentHashAsync(Stream content, CancellationToken ct)
+    {
+        var hash = await SHA256.HashDataAsync(content, ct).ConfigureAwait(false);
+        return Convert.ToHexStringLower(hash);
+    }
+
+    public async Task<PdfDedupResult> EvaluateAsync(string contentHash, Guid? sharedGameId,
+        Guid? privateGameId, Guid userId, CancellationToken ct)
+    {
+        // Catalog (shared): dedup GLOBALE. Private: dedup PER-UTENTE (isolamento).
+        var existing = sharedGameId.HasValue
+            ? await _repo.FindByContentHashAsync(contentHash, ct).ConfigureAwait(false)
+            : await _repo.FindByContentHashForUserAsync(contentHash, userId, ct).ConfigureAwait(false);
+
+        if (existing is null || existing.ProcessingState == PdfProcessingState.Failed)
+            return new PdfDedupResult(PdfDedupDecision.NewUpload, null, contentHash);
+
+        return new PdfDedupResult(PdfDedupDecision.ReuseExisting, existing.Id, contentHash);
+    }
+}
+```
+
+- [ ] **Step 5: Register in DI**
+
+In `DocumentProcessingServiceExtensions.cs` accanto agli altri `AddScoped`:
+```csharp
+services.AddScoped<IPdfDeduplicationService, PdfDeduplicationService>();
+```
+
+- [ ] **Step 6: Run test → verify PASS**
+
+Run: `cd apps/api && dotnet test tests/Api.Tests --filter "FullyQualifiedName~PdfDeduplicationServiceTests"`
+Expected: PASS (3 test).
+
+> Nota: se non esiste `PdfDocumentTestFactory`, crearlo nello stesso file test come helper statico che costruisce `PdfDocument` via il factory di dominio, impostando lo stato con i metodi di transizione esistenti (`Ready()` avanza fino a `PdfProcessingState.Ready`, `Failed()` fino a `Failed`).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/DocumentProcessing apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Services/PdfDeduplicationServiceTests.cs
+git commit -m "feat(pdf): centralizza regola dedup in IPdfDeduplicationService"
+```
+
+---
+
+## Task 2: Allineare il path chunked al riuso trasparente
+
+**Files:**
+- Modify: `.../DocumentProcessing/Application/Commands/CompleteChunkedUploadCommandHandler.cs:112-143`
+- Test: `apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Commands/CompleteChunkedUploadDedupTests.cs`
+
+**Interfaces:**
+- Consumes: `IPdfDeduplicationService.EvaluateAsync(...)` (Task 1), `IMediator` per `CreateEntityLinkCommand`.
+- Produces: `CompleteChunkedUploadResult` con `Success: true, DocumentId: existingId` (riuso) invece del rigetto.
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+[Trait("Category", TestCategories.Unit)]
+public class CompleteChunkedUploadDedupTests
+{
+    [Fact]
+    public async Task Complete_HashKnownReady_ReusesExistingInsteadOfRejecting()
+    {
+        var existingId = Guid.NewGuid();
+        var dedup = new Mock<IPdfDeduplicationService>();
+        dedup.Setup(d => d.EvaluateAsync(It.IsAny<string>(), It.IsAny<Guid?>(), It.IsAny<Guid?>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+             .ReturnsAsync(new PdfDedupResult(PdfDedupDecision.ReuseExisting, existingId, "h"));
+        var handler = ChunkedHandlerBuilder.WithDedup(dedup.Object);
+
+        var result = await handler.Handle(ChunkedHandlerBuilder.ValidCommand(), CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.DocumentId.Should().Be(existingId);
+        result.ErrorMessage.Should().BeNull();
+    }
+}
+```
+
+- [ ] **Step 2: Run test → verify FAIL**
+
+Run: `cd apps/api && dotnet test tests/Api.Tests --filter "FullyQualifiedName~CompleteChunkedUploadDedupTests"`
+Expected: FAIL — l'handler oggi ritorna `Success: false, ErrorMessage: DuplicateContentErrorMessage`.
+
+- [ ] **Step 3: Replace the reject block**
+
+Sostituire il blocco `if (contentHash != null) { var isDuplicate = ... AnyAsync ...; if (isDuplicate) { ... return Success:false ... } }` (righe ~112-143) con:
+
+```csharp
+if (contentHash != null)
+{
+    var dedup = await _pdfDeduplicationService
+        .EvaluateAsync(contentHash, session.GameId, session.PrivateGameId, session.UserId, cancellationToken)
+        .ConfigureAwait(false);
+
+    if (dedup.Decision == PdfDedupDecision.ReuseExisting)
+    {
+        // Cleanup del file appena assemblato (best effort): non serve, riusiamo l'esistente.
+        if (storageResult!.FileId != null)
+        {
+            try
+            {
+                await _blobStorageService.DeleteAsync(storageResult.FileId, BlobCategory.Pdf,
+                    (session.PrivateGameId ?? session.GameId)?.ToString() ?? string.Empty, cancellationToken)
+                    .ConfigureAwait(false);
+            }
+            catch { /* best effort */ }
+        }
+
+        // Riuso trasparente via EntityLink verso il gioco.
+        var linkTargetGameId = session.GameId ?? session.PrivateGameId ?? Guid.Empty;
+        if (linkTargetGameId != Guid.Empty)
+        {
+            try
+            {
+                await _mediator.Send(new CreateEntityLinkCommand(
+                    SourceEntityType: MeepleEntityType.Game,
+                    SourceEntityId: linkTargetGameId,
+                    TargetEntityType: MeepleEntityType.KbCard,
+                    TargetEntityId: dedup.ExistingPdfDocumentId!.Value,
+                    LinkType: EntityLinkType.RelatedTo,
+                    Scope: EntityLinkScope.User,
+                    OwnerUserId: session.UserId), cancellationToken).ConfigureAwait(false);
+            }
+            catch (DuplicateEntityLinkException) { /* idempotent */ }
+        }
+
+        return new CompleteChunkedUploadResult(
+            Success: true,
+            DocumentId: dedup.ExistingPdfDocumentId,
+            FileName: sanitizedFileName,
+            ErrorMessage: null,
+            MissingChunks: null);
+    }
+}
+```
+
+Iniettare `IPdfDeduplicationService _pdfDeduplicationService` e `IMediator _mediator` nel costruttore dell'handler (se `_mediator` non è già presente).
+
+- [ ] **Step 4: Run test → verify PASS**
+
+Run: `cd apps/api && dotnet test tests/Api.Tests --filter "FullyQualifiedName~CompleteChunkedUploadDedupTests"`
+Expected: PASS.
+
+- [ ] **Step 5: Rimuovere la costante morta**
+
+Se `DuplicateContentErrorMessage` (riga 36) non è più referenziata, rimuoverla. Verificare: `cd apps/api && dotnet build`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/CompleteChunkedUploadCommandHandler.cs apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Commands/CompleteChunkedUploadDedupTests.cs
+git commit -m "fix(pdf): il path chunked riusa il PDF duplicato invece di rigettarlo"
+```
+
+---
+
+## Task 3: `MaterializePdfCoverCommand` — render pagina → WebP → R2
+
+**Files:**
+- Create: `.../DocumentProcessing/Application/Services/IPdfCoverUploadPipeline.cs`
+- Create: `.../DocumentProcessing/Infrastructure/Services/PdfCoverUploadPipeline.cs`
+- Create: `.../DocumentProcessing/Application/Commands/MaterializePdfCoverCommand.cs` (+ Handler)
+- Test: `.../tests/Api.Tests/.../MaterializePdfCoverCommandHandlerTests.cs`
+
+**Interfaces:**
+- Consumes: `IMediator` per `GetPdfPageImageQuery(pdfDocumentId, pageNumber)` → `byte[]`; `WebpVariantGenerator.GenerateWebpAsync(byte[], int, int, ct)`; nuovo `IPdfCoverUploadPipeline.UploadAsync(string dbKey, byte[] webp, ct)`.
+- Produces: `MaterializePdfCoverCommand(Guid PdfDocumentId, int PageNumber, string DbKey) : ICommand<string>` → ritorna la **dbKey** (senza suffisso); handler chiama `PdfDocument.MarkCoverGenerated(dbKey, pageIndex)`.
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+[Trait("Category", TestCategories.Unit)]
+public class MaterializePdfCoverCommandHandlerTests
+{
+    [Fact]
+    public async Task Handle_RendersPageEncodesWebpUploadsAndMarks()
+    {
+        var pdfId = Guid.NewGuid();
+        var pdf = PdfDocumentTestFactory.Ready(pdfId);
+        var repo = new Mock<IPdfDocumentRepository>();
+        repo.Setup(r => r.GetByIdAsync(pdfId, It.IsAny<CancellationToken>())).ReturnsAsync(pdf);
+        var mediator = new Mock<IMediator>();
+        mediator.Setup(m => m.Send(It.IsAny<GetPdfPageImageQuery>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new byte[] { 0xFF, 0xD8 }); // JPEG magic
+        var webp = new Mock<IWebpVariantGenerator>();
+        webp.Setup(w => w.GenerateWebpAsync(It.IsAny<byte[]>(), 200, 300, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new byte[] { 0x52, 0x49, 0x46, 0x46 }); // RIFF
+        var pipeline = new Mock<IPdfCoverUploadPipeline>();
+        pipeline.Setup(p => p.UploadAsync(It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((string k, byte[] _, CancellationToken _) => k);
+        var uow = new Mock<IUnitOfWork>();
+
+        var handler = new MaterializePdfCoverCommandHandler(repo.Object, mediator.Object, webp.Object, pipeline.Object, uow.Object);
+        var cmd = new MaterializePdfCoverCommand(pdfId, PageNumber: 3, DbKey: "covers/g/pdf-cover");
+
+        var key = await handler.Handle(cmd, CancellationToken.None);
+
+        key.Should().Be("covers/g/pdf-cover");
+        pdf.CoverR2Key.Should().Be("covers/g/pdf-cover");
+        pdf.CoverPageIndex.Should().Be(3);
+        pdf.CoverGenerationStatus.Should().Be(PdfCoverGenerationStatus.Generated);
+        uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_SmolDoclingFails_ThrowsCoverMaterializationExceptionAndDoesNotMark()
+    {
+        var pdfId = Guid.NewGuid();
+        var pdf = PdfDocumentTestFactory.Ready(pdfId);
+        var repo = new Mock<IPdfDocumentRepository>();
+        repo.Setup(r => r.GetByIdAsync(pdfId, It.IsAny<CancellationToken>())).ReturnsAsync(pdf);
+        var mediator = new Mock<IMediator>();
+        mediator.Setup(m => m.Send(It.IsAny<GetPdfPageImageQuery>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new HttpRequestException("503"));
+        var handler = new MaterializePdfCoverCommandHandler(repo.Object, mediator.Object,
+            Mock.Of<IWebpVariantGenerator>(), Mock.Of<IPdfCoverUploadPipeline>(), Mock.Of<IUnitOfWork>());
+
+        var act = () => handler.Handle(new MaterializePdfCoverCommand(pdfId, 3, "k"), CancellationToken.None);
+
+        await act.Should().ThrowAsync<CoverMaterializationException>();
+        pdf.CoverGenerationStatus.Should().Be(PdfCoverGenerationStatus.Pending); // non toccato
+    }
+}
+```
+
+- [ ] **Step 2: Run test → verify FAIL**
+
+Run: `cd apps/api && dotnet test tests/Api.Tests --filter "FullyQualifiedName~MaterializePdfCoverCommandHandlerTests"`
+Expected: FAIL — tipi non esistono.
+
+- [ ] **Step 3: Create the upload pipeline** (convenzione suffisso `-preview.webp`)
+
+```csharp
+// IPdfCoverUploadPipeline.cs
+public interface IPdfCoverUploadPipeline
+{
+    // Carica il WebP all'oggetto fisico "{dbKey}-preview.webp"; ritorna dbKey (senza suffisso).
+    Task<string> UploadAsync(string dbKey, byte[] webpBytes, CancellationToken cancellationToken);
+}
+```
+
+```csharp
+// PdfCoverUploadPipeline.cs — modellato su CoverR2UploadPipeline.cs, suffisso -preview.webp
+internal sealed class PdfCoverUploadPipeline : IPdfCoverUploadPipeline
+{
+    private const string ImmutableCacheControl = "public, max-age=31536000, immutable";
+    private const string WebpContentType = "image/webp";
+    private readonly IAmazonS3 _s3Client;
+    private readonly S3StorageOptions _options;
+    private readonly ILogger<PdfCoverUploadPipeline> _logger;
+
+    public PdfCoverUploadPipeline(IAmazonS3 s3Client, S3StorageOptions options, ILogger<PdfCoverUploadPipeline> logger)
+    { _s3Client = s3Client; _options = options; _logger = logger; }
+
+    public async Task<string> UploadAsync(string dbKey, byte[] webpBytes, CancellationToken ct)
+    {
+        if (webpBytes is null || webpBytes.Length == 0)
+            throw new ArgumentException("WebP bytes must be non-null and non-empty.", nameof(webpBytes));
+
+        var objectKey = $"{dbKey}-preview.webp"; // il resolver L4 (CoverUrlResolver.cs:72) appende -preview.webp
+        using var stream = new MemoryStream(webpBytes, writable: false);
+        var request = new PutObjectRequest
+        {
+            BucketName = _options.BucketName,
+            Key = objectKey,
+            InputStream = stream,
+            ContentType = WebpContentType,
+            AutoCloseStream = false,
+            DisablePayloadSigning = true,
+        };
+        request.Headers.CacheControl = ImmutableCacheControl;
+        await _s3Client.PutObjectAsync(request, ct).ConfigureAwait(false);
+        return dbKey;
+    }
+}
+```
+
+- [ ] **Step 4: Create the command + handler**
+
+```csharp
+// MaterializePdfCoverCommand.cs
+public sealed record MaterializePdfCoverCommand(Guid PdfDocumentId, int PageNumber, string DbKey) : ICommand<string>;
+
+public sealed class CoverMaterializationException : Exception
+{
+    public CoverMaterializationException(string message, Exception inner) : base(message, inner) { }
+}
+
+internal sealed class MaterializePdfCoverCommandHandler : ICommandHandler<MaterializePdfCoverCommand, string>
+{
+    private readonly IPdfDocumentRepository _repo;
+    private readonly IMediator _mediator;
+    private readonly IWebpVariantGenerator _webp;
+    private readonly IPdfCoverUploadPipeline _pipeline;
+    private readonly IUnitOfWork _uow;
+
+    public MaterializePdfCoverCommandHandler(IPdfDocumentRepository repo, IMediator mediator,
+        IWebpVariantGenerator webp, IPdfCoverUploadPipeline pipeline, IUnitOfWork uow)
+    { _repo = repo; _mediator = mediator; _webp = webp; _pipeline = pipeline; _uow = uow; }
+
+    public async Task<string> Handle(MaterializePdfCoverCommand cmd, CancellationToken ct)
+    {
+        var pdf = await _repo.GetByIdAsync(cmd.PdfDocumentId, ct).ConfigureAwait(false)
+            ?? throw new NotFoundException($"PdfDocument {cmd.PdfDocumentId} not found.");
+
+        byte[] jpeg;
+        try
+        {
+            jpeg = await _mediator.Send(new GetPdfPageImageQuery(cmd.PdfDocumentId, cmd.PageNumber), ct).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
+        {
+            // SmolDocling down/404: non-bloccante, nessuno stato "a metà".
+            throw new CoverMaterializationException("Rendering pagina PDF non disponibile.", ex);
+        }
+
+        var webpBytes = await _webp.GenerateWebpAsync(jpeg, 200, 300, ct).ConfigureAwait(false);
+        var dbKey = await _pipeline.UploadAsync(cmd.DbKey, webpBytes, ct).ConfigureAwait(false);
+
+        pdf.MarkCoverGenerated(dbKey, cmd.PageNumber);
+        await _repo.UpdateAsync(pdf, ct).ConfigureAwait(false);
+        await _uow.SaveChangesAsync(ct).ConfigureAwait(false);
+        return dbKey;
+    }
+}
+```
+
+> `WebpVariantGenerator` è oggi `internal sealed` senza interfaccia: in questo step estrai `IWebpVariantGenerator` (metodo `GenerateWebpAsync(byte[], int, int, CancellationToken)`), fallo implementare alla classe esistente, e registralo in DI. Se `_repo.UpdateAsync`/`GetByIdAsync` non hanno la firma attesa, adegua al repository reale (verifica `IPdfDocumentRepository`).
+
+- [ ] **Step 5: Register DI**
+
+```csharp
+services.AddScoped<IPdfCoverUploadPipeline, PdfCoverUploadPipeline>();
+services.AddScoped<IWebpVariantGenerator, WebpVariantGenerator>();
+services.AddScoped<MaterializePdfCoverCommandHandler>(); // se non auto-registrato via MediatR scan
+```
+
+- [ ] **Step 6: Run test → verify PASS**
+
+Run: `cd apps/api && dotnet test tests/Api.Tests --filter "FullyQualifiedName~MaterializePdfCoverCommandHandlerTests"`
+Expected: PASS (2 test).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/DocumentProcessing apps/api/tests/Api.Tests
+git commit -m "feat(pdf): MaterializePdfCover render pagina -> WebP -> R2 (suffisso -preview.webp)"
+```
+
+---
+
+## Task 4: `ContributionType.CoverChange` + campi pending su ShareRequest + migration
+
+**Files:**
+- Modify: `.../SharedGameCatalog/Domain/ValueObjects/ContributionType.cs`
+- Modify: `.../SharedGameCatalog/Domain/Entities/ShareRequest.cs` (campi + validazione `Create`)
+- Modify: `.../Infrastructure/Configurations/SharedGameCatalog/ShareRequestEntityConfiguration.cs`
+- Create: EF migration
+- Test: `.../tests/Api.Tests/.../ShareRequestCoverChangeTests.cs`
+
+**Interfaces:**
+- Produces: `ShareRequest.CreateCoverChange(Guid userId, Guid targetSharedGameId, Guid sourcePdfDocumentId, string pendingCoverR2Key, int coverPageIndex, string? userNotes)`; nuove proprietà `PendingCoverR2Key`, `CoverPageIndex`, `SourcePdfDocumentId`.
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+[Trait("Category", "Unit")]
+public sealed class ShareRequestCoverChangeTests
+{
+    [Fact]
+    public void CreateCoverChange_WithValidData_SetsCoverChangeType()
+    {
+        var target = Guid.NewGuid();
+        var pdf = Guid.NewGuid();
+        var req = ShareRequest.CreateCoverChange(
+            userId: Guid.NewGuid(), targetSharedGameId: target, sourcePdfDocumentId: pdf,
+            pendingCoverR2Key: "covers/g/pdf-cover", coverPageIndex: 3, userNotes: null);
+
+        req.ContributionType.Should().Be(ContributionType.CoverChange);
+        req.TargetSharedGameId.Should().Be(target);
+        req.PendingCoverR2Key.Should().Be("covers/g/pdf-cover");
+        req.CoverPageIndex.Should().Be(3);
+        req.SourcePdfDocumentId.Should().Be(pdf);
+        req.Status.Should().Be(ShareRequestStatus.Pending);
+    }
+
+    [Fact]
+    public void CreateCoverChange_WithEmptyPendingKey_Throws()
+    {
+        var act = () => ShareRequest.CreateCoverChange(Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), "  ", 0, null);
+        act.Should().Throw<ArgumentException>();
+    }
+}
+```
+
+- [ ] **Step 2: Run test → verify FAIL**
+
+Run: `cd apps/api && dotnet test tests/Api.Tests --filter "FullyQualifiedName~ShareRequestCoverChangeTests"`
+Expected: FAIL — `ContributionType.CoverChange` / `CreateCoverChange` non esistono.
+
+- [ ] **Step 3: Extend enum + entity**
+
+```csharp
+// ContributionType.cs
+public enum ContributionType
+{
+    NewGame = 0,
+    AdditionalContent = 1,
+    NewGameProposal = 2,
+    CoverChange = 3,
+}
+```
+
+```csharp
+// ShareRequest.cs — nuove proprietà (private setter)
+public string? PendingCoverR2Key { get; private set; }
+public int? CoverPageIndex { get; private set; }
+public Guid? SourcePdfDocumentId { get; private set; }
+
+// factory dedicato
+public static ShareRequest CreateCoverChange(Guid userId, Guid targetSharedGameId,
+    Guid sourcePdfDocumentId, string pendingCoverR2Key, int coverPageIndex, string? userNotes = null)
+{
+    if (targetSharedGameId == Guid.Empty) throw new ArgumentException("TargetSharedGameId required", nameof(targetSharedGameId));
+    if (string.IsNullOrWhiteSpace(pendingCoverR2Key)) throw new ArgumentException("Pending cover key required", nameof(pendingCoverR2Key));
+    if (coverPageIndex < 0) throw new ArgumentException("Page index must be non-negative", nameof(coverPageIndex));
+
+    var req = Create(userId, sourceGameId: targetSharedGameId, ContributionType.CoverChange, userNotes, targetSharedGameId);
+    req.PendingCoverR2Key = pendingCoverR2Key;
+    req.CoverPageIndex = coverPageIndex;
+    req.SourcePdfDocumentId = sourcePdfDocumentId;
+    return req;
+}
+```
+
+- [ ] **Step 4: EF configuration + migration**
+
+Aggiungere in `ShareRequestEntityConfiguration.cs`:
+```csharp
+builder.Property(x => x.PendingCoverR2Key).HasMaxLength(512);
+builder.Property(x => x.CoverPageIndex);
+builder.Property(x => x.SourcePdfDocumentId);
+```
+
+Run:
+```bash
+cd apps/api/src/Api && dotnet ef migrations add AddShareRequestCoverChangeFields
+```
+Review dello SQL generato (solo `ADD COLUMN` nullable, nessun drop).
+
+- [ ] **Step 5: Run test + build → verify PASS**
+
+Run: `cd apps/api && dotnet test tests/Api.Tests --filter "FullyQualifiedName~ShareRequestCoverChangeTests" && dotnet build`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/SharedGameCatalog apps/api/src/Api/Infrastructure/Configurations apps/api/src/Api/Infrastructure/Migrations apps/api/tests/Api.Tests
+git commit -m "feat(catalog): ContributionType.CoverChange + campi pending cover su ShareRequest"
+```
+
+---
+
+## Task 5: Approvazione `UpdateCover` → promuove pending → L4
+
+**Files:**
+- Modify: `.../SharedGameCatalog/Domain/Enums/ProposalApprovalAction.cs`
+- Modify: `.../Application/Commands/ApproveGameProposal/ApproveGameProposalCommandHandler.cs`
+- Test: `.../tests/Api.Tests/.../ApproveCoverChangeTests.cs`
+
+**Interfaces:**
+- Consumes: `ShareRequest.PendingCoverR2Key`, `SharedGame.SetPdfCoverR2Key(string)`, `ShareRequest.Approve(adminId, targetSharedGameId, feedback)`.
+- Produces: nuovo `ProposalApprovalAction.UpdateCover`; alla sua gestione, `SharedGame.PdfCoverR2Key` = `shareRequest.PendingCoverR2Key`.
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+[Trait("Category", TestCategories.Unit)]
+public class ApproveCoverChangeTests
+{
+    [Fact]
+    public async Task Approve_UpdateCover_SetsL4KeyOnSharedGameAndApproves()
+    {
+        var target = Guid.NewGuid();
+        var sharedGame = SharedGameTestFactory.Existing(target);
+        var req = ShareRequest.CreateCoverChange(Guid.NewGuid(), target, Guid.NewGuid(), "covers/g/pdf-cover", 3, null);
+        var (handler, repos) = ApproveHandlerBuilder.For(req, sharedGame);
+
+        var cmd = new ApproveGameProposalCommand(ShareRequestId: req.Id, AdminId: Guid.NewGuid(),
+            ApprovalAction: ProposalApprovalAction.UpdateCover, TargetSharedGameId: target, AdminNotes: null);
+
+        await handler.Handle(cmd, CancellationToken.None);
+
+        sharedGame.PdfCoverR2Key.Should().Be("covers/g/pdf-cover");
+        req.Status.Should().Be(ShareRequestStatus.Approved);
+    }
+}
+```
+
+- [ ] **Step 2: Run test → verify FAIL**
+
+Run: `cd apps/api && dotnet test tests/Api.Tests --filter "FullyQualifiedName~ApproveCoverChangeTests"`
+Expected: FAIL — `ProposalApprovalAction.UpdateCover` non esiste.
+
+- [ ] **Step 3: Extend enum + handler switch**
+
+```csharp
+// ProposalApprovalAction.cs — aggiungere
+UpdateCover,
+```
+
+Nel `switch` di `ApproveGameProposalCommandHandler.Handle` (righe ~104-141), aggiungere il caso:
+```csharp
+ProposalApprovalAction.UpdateCover => await ApproveCoverChangeAsync(shareRequest, command, cancellationToken),
+```
+
+E il metodo privato:
+```csharp
+private async Task<Guid> ApproveCoverChangeAsync(ShareRequest shareRequest, ApproveGameProposalCommand command, CancellationToken ct)
+{
+    var targetId = command.TargetSharedGameId ?? shareRequest.TargetSharedGameId
+        ?? throw new ConflictException("CoverChange senza target shared game.");
+    var sharedGame = await _sharedGameRepository.GetByIdAsync(targetId, ct).ConfigureAwait(false)
+        ?? throw new NotFoundException($"SharedGame {targetId} not found.");
+
+    if (string.IsNullOrWhiteSpace(shareRequest.PendingCoverR2Key))
+        throw new ConflictException("Pending cover key mancante sulla proposal.");
+
+    sharedGame.SetPdfCoverR2Key(shareRequest.PendingCoverR2Key);
+    _sharedGameRepository.Update(sharedGame);
+    return targetId;
+}
+```
+
+(la chiamata a `shareRequest.Approve(...)` + `SaveChangesAsync` avviene già a valle nello switch, righe ~133-137, riusando quel path.)
+
+- [ ] **Step 4: Run test → verify PASS**
+
+Run: `cd apps/api && dotnet test tests/Api.Tests --filter "FullyQualifiedName~ApproveCoverChangeTests"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/SharedGameCatalog apps/api/tests/Api.Tests
+git commit -m "feat(catalog): approvazione UpdateCover promuove la cover pending a L4"
+```
+
+---
+
+## Task 6: `ProposeCoverChangeCommand` + endpoint utente (materializza + crea proposal)
+
+**Files:**
+- Create: `.../SharedGameCatalog/Application/Commands/ProposeCoverChange/ProposeCoverChangeCommand.cs` (+ Handler + Validator)
+- Modify: routing (nuovo endpoint `POST /api/v1/games/{gameId}/cover/propose-from-pdf`)
+- Test: `.../tests/Api.Tests/Integration/.../ProposeCoverChangeIntegrationTests.cs`
+
+**Interfaces:**
+- Consumes: `MaterializePdfCoverCommand` (Task 3), `ShareRequest.CreateCoverChange` (Task 4), `IShareRequestRepository`.
+- Produces: `ProposeCoverChangeCommand(Guid UserId, Guid SharedGameId, Guid PdfDocumentId, int PageNumber) : ICommand<Guid>` → ritorna `shareRequestId`.
+
+- [ ] **Step 1: Write the failing integration test**
+
+```csharp
+[Trait("Category", TestCategories.Integration)]
+[Collection("Integration")]
+public class ProposeCoverChangeIntegrationTests
+{
+    // Usa il fixture Testcontainers Postgres del progetto.
+    [Fact]
+    public async Task Propose_MaterializesPendingCoverAndCreatesPendingShareRequest()
+    {
+        var (mediator, ctx, seed) = await ArrangeAsync(); // seed: SharedGame + PdfDocument Ready con SharedGameId
+        var cmd = new ProposeCoverChangeCommand(seed.UserId, seed.SharedGameId, seed.PdfDocumentId, PageNumber: 2);
+
+        var shareRequestId = await mediator.Send(cmd, CancellationToken.None);
+
+        var sr = await ctx.ShareRequests.FindAsync(shareRequestId);
+        sr!.ContributionType.Should().Be(ContributionType.CoverChange);
+        sr.Status.Should().Be(ShareRequestStatus.Pending);
+        sr.PendingCoverR2Key.Should().NotBeNullOrWhiteSpace();
+        sr.CoverPageIndex.Should().Be(2);
+    }
+}
+```
+
+- [ ] **Step 2: Run test → verify FAIL**
+
+Run: `cd apps/api && dotnet test tests/Api.Tests --filter "FullyQualifiedName~ProposeCoverChangeIntegrationTests"`
+Expected: FAIL — `ProposeCoverChangeCommand` non esiste. (Richiede Docker per Testcontainers.)
+
+- [ ] **Step 3: Command + Validator + Handler**
+
+```csharp
+// ProposeCoverChangeCommand.cs
+public sealed record ProposeCoverChangeCommand(Guid UserId, Guid SharedGameId, Guid PdfDocumentId, int PageNumber) : ICommand<Guid>;
+
+public sealed class ProposeCoverChangeCommandValidator : AbstractValidator<ProposeCoverChangeCommand>
+{
+    public ProposeCoverChangeCommandValidator()
+    {
+        RuleFor(x => x.SharedGameId).NotEmpty();
+        RuleFor(x => x.PdfDocumentId).NotEmpty();
+        RuleFor(x => x.PageNumber).GreaterThan(0);
+    }
+}
+
+internal sealed class ProposeCoverChangeCommandHandler : ICommandHandler<ProposeCoverChangeCommand, Guid>
+{
+    private readonly IMediator _mediator;
+    private readonly IShareRequestRepository _shareRequests;
+    private readonly IUnitOfWork _uow;
+
+    public ProposeCoverChangeCommandHandler(IMediator mediator, IShareRequestRepository shareRequests, IUnitOfWork uow)
+    { _mediator = mediator; _shareRequests = shareRequests; _uow = uow; }
+
+    public async Task<Guid> Handle(ProposeCoverChangeCommand cmd, CancellationToken ct)
+    {
+        // dbKey deterministica per la pending cover della proposal
+        var dbKey = $"covers/{cmd.SharedGameId:D}/pdf-cover-pending";
+        var pendingKey = await _mediator.Send(
+            new MaterializePdfCoverCommand(cmd.PdfDocumentId, cmd.PageNumber, dbKey), ct).ConfigureAwait(false);
+
+        var req = ShareRequest.CreateCoverChange(cmd.UserId, cmd.SharedGameId, cmd.PdfDocumentId, pendingKey, cmd.PageNumber);
+        await _shareRequests.AddAsync(req, ct).ConfigureAwait(false);
+        await _uow.SaveChangesAsync(ct).ConfigureAwait(false);
+        return req.Id;
+    }
+}
+```
+
+- [ ] **Step 4: Endpoint (CQRS, solo IMediator)**
+
+Nel routing degli SharedGame (seguire il pattern degli endpoint esistenti):
+```csharp
+app.MapPost("/api/v1/games/{gameId:guid}/cover/propose-from-pdf",
+    async (Guid gameId, ProposeCoverFromPdfRequest body, HttpContext http, IMediator m, CancellationToken ct) =>
+    {
+        var userId = http.GetUserId(); // helper esistente per l'utente autenticato
+        var id = await m.Send(new ProposeCoverChangeCommand(userId, gameId, body.PdfDocumentId, body.PageNumber), ct);
+        return Results.Ok(new { shareRequestId = id });
+    }).RequireAuthorization();
+
+internal record ProposeCoverFromPdfRequest(Guid PdfDocumentId, int PageNumber);
+```
+
+- [ ] **Step 5: Run test → verify PASS**
+
+Kill testhost, poi:
+Run: `cd apps/api && dotnet test tests/Api.Tests --filter "FullyQualifiedName~ProposeCoverChangeIntegrationTests"`
+Expected: PASS (richiede Docker attivo).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/SharedGameCatalog apps/api/src/Api/Routing apps/api/tests/Api.Tests
+git commit -m "feat(catalog): endpoint utente propone cover-da-PDF (materializza + ShareRequest CoverChange)"
+```
+
+---
+
+## Task 7: Chiudere i canali URL esterni (`ImageUrl`/`ThumbnailUrl`)
+
+**Files:**
+- Modify: `apps/api/src/Api/Routing/PrivateGameEndpoints.cs` (`AddPrivateGameRequest:442-455`)
+- Modify: `.../UserLibrary/Application/Commands/PrivateGames/AddPrivateGameCommand.cs` + Handler
+- Test: `.../tests/Api.Tests/.../AddPrivateGameNoExternalUrlTests.cs`
+
+**Interfaces:**
+- Produces: `AddPrivateGameRequest` e `AddPrivateGameCommand` **senza** `ImageUrl`/`ThumbnailUrl`; il DTO risultante non espone più URL esterni impostati dall'utente.
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+[Trait("Category", TestCategories.Unit)]
+public class AddPrivateGameNoExternalUrlTests
+{
+    [Fact]
+    public void AddPrivateGameCommand_HasNoExternalUrlFields()
+    {
+        var props = typeof(AddPrivateGameCommand).GetProperties().Select(p => p.Name).ToArray();
+        props.Should().NotContain("ImageUrl");
+        props.Should().NotContain("ThumbnailUrl");
+    }
+}
+```
+
+- [ ] **Step 2: Run test → verify FAIL**
+
+Run: `cd apps/api && dotnet test tests/Api.Tests --filter "FullyQualifiedName~AddPrivateGameNoExternalUrlTests"`
+Expected: FAIL — i campi esistono ancora.
+
+- [ ] **Step 3: Remove the fields**
+
+- In `AddPrivateGameRequest` (`PrivateGameEndpoints.cs:453-454`) rimuovere `string? ImageUrl = null` e `string? ThumbnailUrl = null`.
+- In `AddPrivateGameCommand` rimuovere gli stessi due parametri.
+- Nel handler / mapping (`AddPrivateGameCommandHandler` `MapToDto:149-171`) rimuovere il pass-through `ImageUrl:`/`ThumbnailUrl:` — impostare la cover del `PrivateGame` a null (placeholder) alla creazione; la cover-da-PDF si imposta poi via il flusso di materializzazione.
+- Aggiornare il costruttore dell'endpoint che mappava request→command.
+
+> Il campo di dominio `PrivateGame.ImageUrl` NON viene rimosso qui (evita migration distruttiva); smette solo di essere popolato da input utente esterno. La sua valorizzazione via cover-da-PDF è un follow-up (vedi Coverage).
+
+- [ ] **Step 4: Run test + build → verify PASS**
+
+Run: `cd apps/api && dotnet test tests/Api.Tests --filter "FullyQualifiedName~AddPrivateGameNoExternalUrlTests" && dotnet build`
+Expected: PASS. Correggere eventuali call-site che passavano i due campi.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/Api/Routing/PrivateGameEndpoints.cs apps/api/src/Api/BoundedContexts/UserLibrary apps/api/tests/Api.Tests
+git commit -m "fix(compliance): rimuove ImageUrl/ThumbnailUrl esterni da AddPrivateGame (freeze BGG #2123)"
+```
+
+---
+
+## Task 8: FE `CoverPagePicker` + client endpoint + due ingressi
+
+**Files:**
+- Create: `apps/web/src/components/shared-games/CoverPagePicker.tsx`
+- Modify: `apps/web/src/lib/api/clients/sharedGamesClient.ts` (+ `proposeCoverFromPdf`)
+- Test: `apps/web/src/components/shared-games/__tests__/CoverPagePicker.test.tsx`
+
+**Interfaces:**
+- Consumes: `CoverImagePicker` (componente presentazionale esistente, props `{ pdfDocumentId, value, onChange }`), endpoint `POST /api/v1/games/{gameId}/cover/propose-from-pdf`.
+- Produces: `<CoverPagePicker gameId pdfDocumentId onProposed />` — al conferma chiama `proposeCoverFromPdf` e invoca `onProposed(shareRequestId)`.
+
+- [ ] **Step 1: Add the client method**
+
+```typescript
+// sharedGamesClient.ts
+async proposeCoverFromPdf(gameId: string, pdfDocumentId: string, pageNumber: number): Promise<{ shareRequestId: string }> {
+  const Schema = z.object({ shareRequestId: z.string() });
+  const result = await httpClient.post<z.infer<typeof Schema>>(
+    `/api/v1/games/${encodeURIComponent(gameId)}/cover/propose-from-pdf`,
+    { pdfDocumentId, pageNumber },
+    Schema
+  );
+  return result!;
+}
+```
+
+- [ ] **Step 2: Write the failing test**
+
+```tsx
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderWithQuery } from '@/__tests__/utils/query-test-utils';
+import { CoverPagePicker } from '../CoverPagePicker';
+
+const proposeMock = vi.fn();
+vi.mock('@/lib/api/clients/sharedGamesClient', () => ({
+  api: { sharedGames: {
+    getPdfPageImageUrl: (id: string, p: number) => `/img/${id}/${p}`,
+    proposeCoverFromPdf: (...a: unknown[]) => proposeMock(...a),
+  } },
+}));
+
+beforeEach(() => { vi.clearAllMocks(); proposeMock.mockResolvedValue({ shareRequestId: 'sr-1' }); });
+
+describe('CoverPagePicker', () => {
+  it('proposes the selected page and calls onProposed', async () => {
+    const onProposed = vi.fn();
+    const user = userEvent.setup();
+    renderWithQuery(<CoverPagePicker gameId="g-1" pdfDocumentId="pdf-1" onProposed={onProposed} />);
+
+    await user.type(screen.getByLabelText(/pagina/i), '3');
+    await user.click(screen.getByRole('button', { name: /proponi cover/i }));
+
+    await waitFor(() => expect(proposeMock).toHaveBeenCalledWith('g-1', 'pdf-1', 3));
+    await waitFor(() => expect(onProposed).toHaveBeenCalledWith('sr-1'));
+  });
+});
+```
+
+- [ ] **Step 3: Run test → verify FAIL**
+
+Run: `cd apps/web && pnpm test -- CoverPagePicker`
+Expected: FAIL — componente non esiste.
+
+- [ ] **Step 4: Implement the component**
+
+```tsx
+// CoverPagePicker.tsx
+'use client';
+import { useState } from 'react';
+import { api } from '@/lib/api/clients/sharedGamesClient';
+
+interface CoverPagePickerProps {
+  gameId: string;
+  pdfDocumentId: string;
+  onProposed: (shareRequestId: string) => void;
+}
+
+export function CoverPagePicker({ gameId, pdfDocumentId, onProposed }: CoverPagePickerProps): JSX.Element {
+  const [page, setPage] = useState(1);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function propose() {
+    setBusy(true); setError(null);
+    try {
+      const { shareRequestId } = await api.sharedGames.proposeCoverFromPdf(gameId, pdfDocumentId, page);
+      onProposed(shareRequestId);
+    } catch {
+      setError('Impossibile proporre la cover in questo momento.');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div>
+      {pdfDocumentId && (
+        <img src={api.sharedGames.getPdfPageImageUrl(pdfDocumentId, page)} alt={`Anteprima pagina ${page}`} />
+      )}
+      <label>
+        Pagina
+        <input type="number" min={1} value={page} onChange={(e) => setPage(Number(e.target.value))} />
+      </label>
+      <button type="button" disabled={busy} onClick={propose}>Proponi cover</button>
+      {error && <p role="alert">{error}</p>}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 5: Run test → verify PASS**
+
+Run: `cd apps/web && pnpm test -- CoverPagePicker`
+Expected: PASS.
+
+- [ ] **Step 6: Wire the two entry points**
+
+- Ingresso 1 (post-upload): dopo che un PDF diventa `Ready`, montare `<CoverPagePicker>` in un prompt.
+- Ingresso 2: azione "Imposta cover" sulla pagina del gioco che elenca i PDF `Ready` e apre lo stesso `<CoverPagePicker>`.
+
+Verificare typecheck/lint: `cd apps/web && pnpm typecheck && pnpm lint`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/src/components/shared-games/CoverPagePicker.tsx apps/web/src/lib/api/clients/sharedGamesClient.ts apps/web/src/components/shared-games/__tests__/CoverPagePicker.test.tsx
+git commit -m "feat(web): CoverPagePicker + propose-cover-from-pdf (due ingressi)"
+```
+
+---
+
+## Coverage vs spec (self-review)
+
+**Coperto dal Piano 1** (SharedGame end-to-end + consolidamenti trasversali):
+- WP1 (dedup consolidamento): Task 1-2 ✅
+- WP2 (materializzazione + chiusura URL): Task 3, Task 7 ✅
+- WP3 (picker FE, due ingressi): Task 8 ✅
+- WP4 (governance ShareRequest CoverChange): Task 4-6 ✅
+- WP7 parziale: metrica `r2_pdf` è **già** emessa dal resolver esistente (`CoverUrlResolver.cs:78`) → nessun lavoro. Attribuzione/cascade-clear non pertinenti a L4 PDF (riguardano L2 Wikidata) → Piano 2.
+
+**Rimandato esplicitamente** (non è un buco silenzioso):
+- **PrivateGame cover-da-PDF end-to-end**: il primitivo `MaterializePdfCover` (Task 3) è pronto, ma il PrivateGame non ha un resolver né un campo cover R2 dedicato. Wiring completo (nuovo campo cover R2 su PrivateGame + esposizione presigned) → **piano dedicato**. Task 7 chiude comunque il canale URL esterno subito.
+- **Reference-counting al delete del PDF** (DEC-6, "eliminabile solo all'ultimo EntityLink"): richiede di individuare il call-site di eliminazione PDF e agganciarvi `IEntityLinkRepository.GetCountForEntityAsync`. → piano dedicato (evita di inventare un delete-flow non ancora identificato).
+- **Wikidata cover on-demand + metadati (WP5, WP6)** + attribuzione/cascade-clear (resto di WP7): → **Piano 2**.
+- **Auto-selezione pagina-cover** (#1852 Gap A): fuori scope (scelta esplicita utente).
+
+**Type-consistency check**: `PdfDedupResult`/`PdfDedupDecision` (Task 1) usati coerenti in Task 2; `MaterializePdfCoverCommand(Guid, int, string)` (Task 3) invocato con la stessa firma in Task 6; `ShareRequest.CreateCoverChange(...)` (Task 4) consumato in Task 6; `ProposalApprovalAction.UpdateCover` (Task 5) coerente col command in Task 5-test; `PdfCoverR2Key` senza suffisso + physical `-preview.webp` coerente tra Task 3 (upload) e resolver (`CoverUrlResolver.cs:72`). Nessuna incoerenza.

--- a/docs/superpowers/specs/2026-07-14-game-cover-configuration-design.md
+++ b/docs/superpowers/specs/2026-07-14-game-cover-configuration-design.md
@@ -1,0 +1,328 @@
+# Game Cover Configuration — Design Spec
+
+**Data**: 2026-07-14
+**Stato**: Design approvato (brainstorming) — pronto per implementation plan
+**Branch**: `feature/game-cover-configuration`
+**Bounded context toccati**: `DocumentProcessing`, `SharedGameCatalog`, `UserLibrary`, `GameManagement`
+
+---
+
+## 1. Contesto e problema
+
+Un gioco (di catalogo o privato) deve poter avere una **cover** configurabile da due attori:
+
+1. **Admin** — gestisce le cover degli shared game del catalogo comune.
+2. **Utente** — quando crea un gioco o aggiunge un PDF a un gioco, può impostarne la cover, opzionalmente usando **una pagina del PDF** caricato. In aggiunta, sia utente sia admin possono **recuperare dati (cover + metadati) da Wikidata**.
+
+La ricognizione del codebase (2026-07-14) ha rivelato che **gran parte delle primitive esiste già**, ma in modo asimmetrico (spesso solo lato admin) e non "cablato" nel flusso utente. Questo spec definisce il wiring mancante e i consolidamenti necessari, entro i vincoli di compliance del **freeze BGG (#2123 / ADR-059 §5)**.
+
+### Obiettivo
+
+Rendere disponibile la configurazione cover a utente e admin, con tre sorgenti (pagina-PDF, Wikidata, placeholder di default), governance appropriata per il bene condiviso, deduplicazione PDF coerente, e piena aderenza ai vincoli di licenza/attribuzione/compliance.
+
+---
+
+## 2. Decisioni chiave (decision log)
+
+| ID | Decisione | Motivazione |
+|----|-----------|-------------|
+| **DEC-1** | La cover che un utente sceglie su uno **SharedGame** è **condivisa (L4)**, visibile a tutti. | Scelta prodotto. Implica governance di scrittura (DEC-5). |
+| **DEC-2** | Il flusso copre **entrambe** le entità: `PrivateGame` (cover privata) e `SharedGame` (cover condivisa). | Scelta prodotto. Due percorsi/command distinti. |
+| **DEC-3** | Sorgenti cover utente: **pagina-PDF + Wikidata + placeholder** (default). Nessun upload di immagine arbitraria. | YAGNI + compliance: la provenienza è un rulebook caricato dall'utente o una fonte CC0/whitelist. Chiude il canale URL esterno. |
+| **DEC-4** | **Un** componente `CoverPagePicker` riusato, esposto da **due ingressi**: fine upload PDF + azione "Imposta cover" sul gioco. | Aderente al requisito ("crea gioco / aggiunge PDF"), DRY. |
+| **DEC-5** | Governance cover **pagina-PDF su SharedGame (L4)** = **proposal + approvazione admin**, estendendo `ShareRequest` con `ContributionType.CoverChange`. | La pagina-PDF è contenuto **arbitrario** → rischio vandalismo sul catalogo pubblico. Riusa l'infrastruttura di moderazione esistente. |
+| **DEC-6** | La cover-da-pagina è **materializzata come copia WebP indipendente in R2** (sync); il PDF sorgente è **reference-counted** (eliminabile solo all'ultimo `EntityLink`). | Evita il re-render on-the-fly; la cover non si rompe mai. |
+| **DEC-7** | Dedup PDF via `ContentHash` (SHA-256): **riuso trasparente** via `EntityLink`, scope **globale sul catalogo** / **per-utente sui privati**. Allineare il path chunked al riuso. | "Non vogliamo doppioni"; rispetta il confine `SharedGameId`/`PrivateGameId`. |
+| **DEC-8** | Wikidata: scope **cover + metadati**. Cover L2 utente **diretta** (deterministica + licenza-validata). Metadati **fill-gaps only** (non sovrascrivono BGG/manuali). | Il recupero Wikidata è deterministico (P18 del QID), non arbitrario → nessuna moderazione. Fill-gaps è additive, zero perdita dati. |
+| **DEC-9** | Materializzazione cover **sincrona** (spinner ~1-2s), non async. | È una singola pagina; l'anteprima è già stata renderizzata prima della conferma. |
+
+---
+
+## 3. Stato attuale del codebase (evidence)
+
+### 3.1 Sistema cover a livelli
+
+`CoverUrlResolver` (`SharedGameCatalog/Application/Services/CoverUrlResolver.cs:104`) risolve server-side in ordine di priorità e restituisce una presigned R2 URL nel campo `SharedGameDto.coverUrl`:
+
+| Livello | Sorgente | Campo | Stato |
+|---------|----------|-------|-------|
+| L3 | Cover custom utente | `UserLibraryEntry.CustomCoverR2Key` | ⏳ non implementato (#1824) |
+| L4 | Cover da pagina PDF | `SharedGame.PdfCoverR2Key` / `PdfDocument.CoverR2Key`+`CoverPageIndex` | ⚠️ parziale (`MarkCoverGenerated()` esiste, #1852) |
+| L2.5 | BGG re-upload server-side | `SharedGame.BggCoverR2Key` | ✅ (admin/pipeline) |
+| L2 | Wikidata | `SharedGame.WikidataCoverR2Key` (+`WikidataCoverLicense/Attribution/SourceUrl`) | ✅ (job M8) |
+| — | Placeholder deterministico | — (`cover-utils.ts`) | ✅ |
+
+Entity: `SharedGameEntity.cs` (`ImageUrl:28`, `ThumbnailUrl:29` — legacy nullable; `WikidataCoverR2Key:68`, `PdfCoverR2Key:78`, `BggCoverR2Key:112`; license/attribution `81-87`). Domain: `SharedGame.cs` (`SetPdfCoverR2Key:616`, `AssignWikidataQid:651`, `SetWikidataCover:703`, `EnrichFromBgg:544`).
+
+Frontend fallback: `cover-utils.ts` (`shouldUsePlaceholder:93`, `isBlockedImageHost:77`, `BLOCKED_IMAGE_HOSTS:26-33`, `hashToHue:133`, `extractInitials:208`).
+
+### 3.2 Primitive PDF → immagine (già disponibili)
+
+- `GetPdfPageImageQuery(PdfDocumentId, PageNumber)` → handler chiama SmolDocling `POST /api/v1/page-image` (`smoldocling-service/src/main.py:315`, `pdf2image`+ghostscript, DPI 150, JPEG q85).
+- Endpoint `GET /ingest/pdf/{pdfId}/page-image?page=N` → JPEG (`PdfUploadEndpoints.cs:125`, autenticato).
+- FE: `CoverImagePicker.tsx` (admin import wizard) — 3 tab (Placeholder / Dal PDF / Upload custom). `PdfViewerModal.tsx` (react-pdf).
+- `PdfDocument.cs`: `PageCount:27`, `CoverR2Key:93`, `CoverPageIndex:95`, `CoverGenerationStatus:94`, `MarkCoverGenerated:843-855`, `CreateCopy:941` (#2732, copia su approvazione share; call-site `ShareRequestDocumentService.cs:201`).
+- State machine 7 stati: Pending → Uploading → Extracting → Chunking → Embedding → Indexing → Ready (+ Failed).
+
+### 3.3 Deduplicazione PDF (esiste, ma incoerente)
+
+- `PdfDocument.ContentHash` (`:60-61`, SHA-256). Repository: `FindByContentHashAsync:152`, `ExistsByContentHashAsync(hash, gameId, privateGameId):163-166`.
+- `AddRulebookCommandHandler.cs:93-158` — **riuso trasparente**: hash → lookup globale → se `Ready`/in-corso, riusa via `EntityLink` (nessun ri-upload); se `Failed`, tratta come nuovo. Messaggio *"Regolamento già disponibile — collegato al tuo gioco!"*.
+- `CompleteChunkedUploadCommandHandler.cs:112-139` — **comportamento opposto**: rigetta con `DuplicateContentErrorMessage:36`.
+
+### 3.4 Proposal system (moderazione, esiste)
+
+`ShareRequest` (entity) + `ContributionType` (VO) + `ApproveGameProposalCommand`/Handler/Validator + `ProposalApprovalAction` (enum) + notifiche (`ShareRequestReviewStarted/Approved`) + email (`EmailService.ShareRequests`) + endpoint admin (`SharedGameCatalogAdminShareRequestEndpoints`). Usato oggi per proporre un gioco privato al catalogo (private→shared). `PdfDocument.CreateCopy:941` (call-site `ShareRequestDocumentService.cs:201`) dimostra il pattern copia-su-approvazione (#2732).
+
+### 3.5 Integrazione Wikidata (cover completa admin-only; metadati assenti)
+
+**Cover L2 — production-hardened, trigger solo-admin.** Catena: `WikidataCatalogProvider.FetchCoverImageAsync(qid)` (`:116`, SPARQL `wdt:P18`, QID regex `^Q\d+$` `:211`) → `WikimediaCommonsClient.FetchLicenseAsync` (`:60`) + `LicenseValidator` whitelist PD/CC0/CC-BY/CC-BY-SA (`:34`) → WebP 200×300 q85 (`WebpVariantGenerator.cs:40`) → `CoverR2UploadPipeline.cs:35` (`covers/{gameId}/cover.webp`) → `EnrichCatalogCoverCommandHandler.cs:97` (M8) → `SharedGame.SetWikidataCover`. **Runner condiviso** `WikidataCoverEnrichmentRunner.EnrichAndRecordAsync` (`:45`) è single-source-of-truth per scheduler **e** admin. Scheduler Quartz 1 min batch 30 (`WikidataCoverEnrichmentJob.cs:38`). Rate-limit 5 RPS shared (`InMemoryWikimediaRateLimiter`), circuit breaker Polly, retry max-3 + DLQ + audit. Freshness 90gg, re-verifica trimestrale M15.
+
+**Esposizione HTTP — solo admin.** `POST /api/v1/admin/wikidata/enrichment/{gameId}` (+dead-letters, bulk-retry, SSE, `AdminWikidataCoverEnrichmentEndpoints.cs:30-76`); `POST /admin/catalog/covers/enrich-batch` max 200 fire-and-forget (`SharedGameCatalogAdminEndpoints.cs:429`). Command `AdminEnrichWikidataCoverCommand.cs:24`. Nessun endpoint user.
+
+**Metadati non-cover — ASSENTI come scrittura.** Solo preview read-only: `WikidataSearchQuery`→`WikidataSearchResult` con `FieldProvenance` (`:12-27`, `Fields:24`), per la seed-queue admin. Nessun command idrata un `SharedGame` esistente. `SharedGame.AssignWikidataQid:651` linka solo il QID. Metadati di gioco vengono da BGG (`EnrichFromBgg:544`) o seed.
+
+**Attribuzione.** `MeepleCardAttributionFooter.tsx:29` rende license+attribution+sourceUrl (null se license null). `AttributionTextExtractor.cs:27` HTML-strip server-side. Wikimedia in allowlist `next.config.js:148`.
+
+### 3.6 Freeze BGG (#2123 / ADR-059 §5)
+
+Ban lato browser di host `*.geekdo-images.com` / `*.boardgamegeek.com`. Enforcement: Next.js allowlist fail-closed (`next.config.js`), ESLint `local/no-bgg-host`, safe-loader runtime + metrica SLO=0 `meepleai_bgg_url_attempted_render_total`. `AddPrivateGameRequest` espone `ImageUrl:string?` (`:453`) **e** `ThumbnailUrl:string?` (`:454`): **entrambi** canali di rientro di URL esterni da chiudere. BGG resta admin-server-side-only; Wikimedia (CC0/whitelist) è la fonte "giusta" da esporre agli utenti.
+
+---
+
+## 4. Design
+
+### § 4.1 Le tre sorgenti cover
+
+Default = placeholder deterministico. Sorgenti attive:
+
+| Sorgente | Per | Natura | Livello |
+|----------|-----|--------|---------|
+| Pagina-PDF | User + Admin | contenuto **arbitrario** | L4 (`PdfCoverR2Key`) |
+| Wikidata | User + Admin | **deterministico** (P18 del QID), licenza-validato | L2 (`WikidataCoverR2Key`) |
+| Placeholder | — | fallback automatico | — |
+
+**Vincolo**: Wikidata richiede un `WikidataQid` assegnato → disponibile **solo su SharedGame** (catalogo). I `PrivateGame` non hanno QID → sorgente = pagina-PDF + placeholder.
+
+### § 4.2 Matrice di governance
+
+| Attore | Entità | Sorgente | Approvazione |
+|--------|--------|----------|--------------|
+| User | PrivateGame | pagina-PDF | **no** (cover privata) |
+| User | PrivateGame | Wikidata | **N/A** (no QID sui private game) |
+| User | SharedGame | pagina-PDF (L4) | **sì** — proposal + admin |
+| User | SharedGame | Wikidata cover (L2) | **no** — diretto |
+| User | SharedGame | Wikidata metadati | **no** — diretto, **solo fill-gaps** |
+| Admin | SharedGame | tutte | **no** (`forceRefresh` admin-only) |
+
+### § 4.3 Cover-da-PDF: un picker, due ingressi
+
+- Componente unico `CoverPagePicker` (wrapper/estrazione da `CoverImagePicker` admin, oggi in `admin/.../shared-games/import/`). Per l'utente: tab *Dal PDF* + placeholder default.
+- **Ingresso 1**: al termine dell'upload PDF (`ProcessingState == Ready`) → prompt "usa una pagina come cover?".
+- **Ingresso 2**: azione "Imposta cover" sulla pagina del gioco → elenca i PDF `Ready` → picker.
+- Conferma → command `MaterializePdfCover` **sync**: render pagina (via `GetPdfPageImageQuery`) → encode WebP → upload R2 → set key. Su SharedGame → non scrive L4 direttamente, ma crea la proposal (§ 4.4).
+
+Data flow (SharedGame, con moderazione):
+
+```
+utente sceglie (pdfId, pageN)
+  → MaterializePdfCover: render → WebP → R2 (area "pending")
+  → ShareRequest{ ContributionType: CoverChange, pendingCoverR2Key, pdfId, pageIndex }
+  → notifica/email admin (infra esistente)
+admin approva → promuove pendingCoverR2Key → SharedGame.PdfCoverR2Key (L4)
+admin rifiuta  → cleanup best-effort della pending R2 key
+```
+
+Per `PrivateGame`: stesso `MaterializePdfCover`, scrittura **diretta** sulla cover del gioco privato (nessuna coda).
+
+### § 4.4 Governance L4 pagina-PDF: estensione ShareRequest
+
+Aggiungere il valore `CoverChange` a `ContributionType`; il flusso di approvazione riusa `ApproveGameProposalCommand` + notifiche + email + endpoint admin. All'approvazione: promozione della pending key a `SharedGame.PdfCoverR2Key`. Al rifiuto: cleanup della pending key.
+
+### § 4.5 Wikidata cover on-demand (utente diretto)
+
+- Nuovo endpoint autenticato `POST /api/v1/games/{gameId}/cover/wikidata-refresh` → command `UserRequestWikidataCoverCommand` → **stesso** `WikidataCoverEnrichmentRunner.EnrichAndRecordAsync` (`:45`).
+- **Identità dell'attore** (decisione di WP5): la signature attuale è `EnrichAndRecordAsync(Guid gameId, bool forceRefresh, Guid? triggeredByAdminUserId = null, CancellationToken)`. Passare uno user non-admin nel parametro `triggeredByAdminUserId` è semanticamente errato e inquina l'audit. WP5 **generalizza** l'identità: rinominare `triggeredByAdminUserId` in un attore tipizzato (`TriggeredBy { UserId, Role }`) — oppure, per minimizzare il blast radius, aggiungere un parametro distinto `triggeredByUserId` + flag `isAdminTrigger`. L'audit deve registrare id + ruolo corretti.
+- **`forceRefresh` enforced al command boundary**: `UserRequestWikidataCoverCommand` **non espone affatto** `forceRefresh` (il campo non esiste nel command user; solo il path admin può passare `true`). Non è una validazione UI — è assenza del campo dal contratto.
+- **Rate-limit per-utente**: max **10 refresh Wikidata / utente / ora**, backing store **Redis** (sliding window), a monte del runner. In aggiunta al budget Wikimedia condiviso (5 RPS, `InMemoryWikimediaRateLimiter`) che il trigger user NON bypassa.
+- Precondizione: il gioco deve avere `WikidataQid` assegnato; altrimenti l'opzione non è offerta.
+
+### § 4.6 Wikidata metadati (nuovo, fill-gaps)
+
+- Nuovo metodo di dominio `SharedGame.EnrichFromWikidata(fields, provenance)` + command di scrittura, alimentato da `WikidataSearchResult.Fields` + `FieldProvenance`.
+- **Policy di conflitto vs BGG — fill-gaps only**: Wikidata idrata **solo i campi vuoti**; **non sovrascrive** valori già presenti, verificando via `FieldProvenance`. L'admin può forzare l'overwrite; l'utente no.
+- **Definizione di "campo vuoto" (gap)**: un campo è un gap se **(a)** non ha `FieldProvenance` (nessuna fonte lo ha reclamato) **e (b)** il valore è nullo o, per le stringhe, whitespace-only. La `FieldProvenance` ha **precedenza sul valore**: provenance presente ⇒ campo reclamato ⇒ **non-gap**, anche se il valore è null (evita che Wikidata sovrascriva una scelta deliberata di lasciare un campo non valorizzato). Per i numerici (anno, min/max giocatori) uno `0`/sentinella con provenance presente **non** è un gap.
+- Esposizione: endpoint admin subito; endpoint user (diretto, fill-gaps) coerente con DEC-8.
+
+### § 4.7 Deduplicazione PDF (consolidamento)
+
+- Estrarre la regola *"hash noto → riusa via EntityLink"* in un `PdfDeduplicationService` di dominio, invocato da **tutti** i path di ingest.
+- **Allineare `CompleteChunkedUploadCommandHandler`**: da rigetto (`DuplicateContentErrorMessage`) a riuso trasparente con feedback esplicito.
+- Scope: **globale** sui PDF di catalogo (`SharedGameId`), **per-utente** sui privati (`PrivateGameId`), via il parametro già presente in `ExistsByContentHashAsync(hash, gameId, privateGameId)`.
+- Regola lifecycle: un PDF è **eliminabile solo alla rimozione dell'ultimo `EntityLink`** (reference counting).
+
+### § 4.8 Error handling & compliance
+
+- SmolDocling 503/404 alla conferma → materializzazione **rifiutata**, messaggio non-bloccante, gioco resta con placeholder. Nessuno stato "cover a metà".
+- Selezione pagina disponibile **solo** con `ProcessingState == Ready` && `PageCount != null`.
+- Licenza whitelist PD/CC0/CC-BY/CC-BY-SA; cover non conformi → skip senza far apparire un "errore utente" nella UX.
+- **Attribuzione**: ogni cover Wikidata popola le 3 colonne o la footer sparisce; **azzerare** le 3 colonne quando L3/L4 rimpiazza L2 (fix del cascade-gap noto; **net-new**: il resolver oggi solo legge — serve un nuovo command/handler che azzeri le colonne al cambio di livello vincente).
+- Nessun URL esterno arbitrario come cover utente: **chiudere entrambi** i campi `AddPrivateGameRequest.ImageUrl` **e** `ThumbnailUrl` (`PrivateGameEndpoints.cs:453-454`, compliance BGG #2123).
+- Metrica: `meepleai.cover.resolution.total{source=r2_pdf|r2_wikidata|placeholder}`.
+
+---
+
+## 5. Scenari di accettazione (Gherkin)
+
+### WP1 — Dedup PDF
+
+```gherkin
+Scenario: Riuso trasparente su hash noto (path chunked, oggi rigetta)
+  Given un PDF Ready con ContentHash H esiste per un gioco di catalogo
+  When un utente carica via upload chunked un file con lo stesso ContentHash H
+  Then il sistema NON crea un doppione fisico
+  And collega l'utente al PDF esistente via EntityLink
+  And mostra il feedback esplicito "Regolamento già disponibile — collegato al tuo gioco!"
+
+Scenario: Isolamento sui PDF privati
+  Given l'utente A ha un PDF privato con ContentHash H (PrivateGameId)
+  When l'utente B carica lo stesso file su un proprio gioco privato
+  Then B ottiene un proprio record (nessun cross-user link sui privati)
+
+Scenario: Eliminazione bloccata finché esistono link
+  Given un PDF con 2 EntityLink attivi
+  When si rimuove 1 dei 2 link
+  Then il PDF NON viene eliminato
+  When si rimuove anche il secondo link
+  Then il PDF diventa eliminabile
+```
+
+### WP2 — Materializzazione cover-da-PDF
+
+```gherkin
+Scenario: Utente sceglie pagina 3 come cover (PrivateGame)
+  Given un PDF Ready con PageCount=12 su un gioco privato
+  When l'utente seleziona pagina 3 e conferma
+  Then la pagina 3 è renderizzata → WebP → caricata su R2
+  And la cover del gioco privato punta alla nuova key
+  And le richieste successive NON ri-renderizzano il PDF
+
+Scenario: SmolDocling non disponibile alla conferma
+  Given SmolDocling risponde 503
+  When l'utente conferma la pagina-cover
+  Then la materializzazione è rifiutata con messaggio non-bloccante
+  And il gioco resta con placeholder (nessuno stato cover-a-metà)
+```
+
+### WP3/WP4 — Picker + proposal L4 (SharedGame)
+
+```gherkin
+Scenario: Cover-da-PDF su gioco di catalogo passa da approvazione admin
+  Given un utente sceglie pagina 5 di un PDF su uno SharedGame
+  When conferma
+  Then viene creata una ShareRequest con ContributionType=CoverChange e la pending R2 key
+  And un admin riceve notifica
+  When l'admin approva
+  Then SharedGame.PdfCoverR2Key = pending key (L4 pubblica)
+  When invece l'admin rifiuta
+  Then la pending R2 key viene ripulita best-effort
+```
+
+### WP5 — Wikidata cover on-demand utente
+
+```gherkin
+Scenario: Utente recupera la cover Wikidata (diretto, no approvazione)
+  Given uno SharedGame con WikidataQid assegnato e nessuna cover L3/L4
+  When l'utente invoca POST /api/v1/games/{id}/cover/wikidata-refresh
+  Then il runner condiviso recupera P18, valida la licenza, materializza L2
+  And le 3 colonne di attribuzione vengono popolate
+  And nessuna approvazione admin è richiesta
+
+Scenario: Rate-limit per-utente
+  Given l'utente ha superato la propria soglia di refresh Wikidata
+  When invoca di nuovo l'endpoint
+  Then riceve un errore di rate-limit per-utente
+  And il budget Wikimedia condiviso (5 RPS) non viene intaccato
+
+Scenario: forceRefresh negato all'utente
+  When un utente prova a forzare il refresh entro la finestra di freshness 90gg
+  Then l'operazione è negata (forceRefresh è admin-only)
+
+Scenario: L2 non sovrascrive una cover superiore
+  Given uno SharedGame con cover L4 (pagina-PDF approvata)
+  When un utente recupera la cover Wikidata (L2)
+  Then il resolver continua a servire L4 (L2 sta sotto)
+```
+
+### WP6 — Wikidata metadati (fill-gaps)
+
+```gherkin
+Scenario: Wikidata riempie solo i campi vuoti
+  Given uno SharedGame con "anno" valorizzato da BGG e "descrizione" vuota
+  When si esegue l'enrichment metadati da Wikidata
+  Then la "descrizione" viene riempita da Wikidata
+  And l'"anno" (provenance BGG) NON viene sovrascritto
+
+Scenario: Admin può forzare l'overwrite
+  Given un campo con provenance BGG
+  When un admin esegue l'enrichment Wikidata con override
+  Then il campo viene sovrascritto (privilegio admin-only)
+```
+
+### WP7 — Attribuzione & metriche
+
+```gherkin
+Scenario: Attribuzione mostrata per cover Wikidata
+  Given uno SharedGame con cover L2 Wikidata (license CC-BY)
+  Then la footer di attribuzione mostra license + attribution + sourceUrl
+
+Scenario: Cascade-clear al rimpiazzo di L2
+  Given uno SharedGame con cover L2 e attribuzione popolata
+  When una cover L4 (pagina-PDF) viene approvata e diventa vincente
+  Then le 3 colonne di attribuzione Wikidata vengono azzerate
+```
+
+---
+
+## 6. Work package
+
+| WP | Contenuto | Dipende da |
+|----|-----------|-----------|
+| **WP1** | Consolidamento dedup PDF: `PdfDeduplicationService` unico + allineamento `CompleteChunkedUploadCommandHandler` al riuso + regola reference-counting | — |
+| **WP2** | Command `MaterializePdfCover` sync (render→WebP→R2) + chiusura di `AddPrivateGameRequest.ImageUrl` **e** `ThumbnailUrl` | WP1 |
+| **WP3** | FE `CoverPagePicker` (wrapper) + due ingressi (post-upload + azione "Imposta cover") | WP2 |
+| **WP4** | Governance L4 pagina-PDF: `ContributionType.CoverChange` su `ShareRequest` + promozione/cleanup su approvazione/rifiuto | WP2 |
+| **WP5** | Wikidata cover on-demand user: endpoint + `UserRequestWikidataCoverCommand` + rate-limit per-utente | — |
+| **WP6** | Wikidata metadati: `SharedGame.EnrichFromWikidata` + policy fill-gaps + command + esposizione admin/user | — |
+| **WP7** | Compliance: attribuzione footer su tutte le cover + cascade-clear + metriche `cover.resolution.total` | WP4, WP5 |
+
+Ordine di valore suggerito: WP1 → WP2 → WP3 → WP4 (fronte cover-da-PDF), poi WP5 → WP6 (fronte Wikidata), infine WP7 (compliance trasversale).
+
+---
+
+## 7. Strategia di test
+
+- **Unit (dominio)**: `PdfDeduplicationService` (globale/privato, stati Ready/Failed), regola reference-counting, `MaterializePdfCover` state transitions, `EnrichFromWikidata` fill-gaps + provenance.
+- **Integration (Testcontainers Postgres)**: dedup end-to-end sui due path (diretto + chunked ora coerenti), proposal CoverChange → approvazione → promozione L4, Wikidata refresh user → L2, rate-limit per-utente.
+- **E2E / acceptance**: gli scenari Gherkin di § 5.
+- Target coverage backend 90%+, frontend 85%+ (baseline di progetto).
+
+---
+
+## 8. Out of scope / follow-up
+
+- **Upload immagine custom utente (L3, #1824)**: escluso per compliance (provenance ignota). Resta un possibile follow-up separato.
+- **Async/batch materializzazione**: non necessario per una singola pagina (DEC-9). Da rivalutare solo se emergono flussi batch.
+- **Promozione PrivateGame → SharedGame** (#3665 Phase 4): fuori scope. **Regola esplicita sulla cover**: la promozione **non** trasferisce la cover privata (materializzata da PDF) a L4 — la cover pubblica deve passare dal flusso `CoverChange` proposal come qualsiasi altra cover di catalogo. La copia WebP privata resta associata al `PrivateGame` finché esiste, poi orfanizzata (cleanup best-effort).
+- **Selezione automatica della pagina-cover "migliore"** (#1852 Gap A): questo spec richiede scelta esplicita dell'utente; l'auto-selezione resta follow-up.
+
+---
+
+## 9. Riferimenti
+
+- Freeze BGG: #2123, [ADR-059 §5](../../for-claude/architecture/adr/adr-059-catalog-seed-legal-posture.md)
+- Proposal system: #3665 (private→shared), pattern copy-on-approval #2732
+- Cover L3 user custom: #1824 (non implementato)
+- PDF cover gap: #1852 (`MarkCoverGenerated`)
+- Citation dedup (contesto SHA-256): #2051
+- File chiave: vedi § 3 per le citazioni `path:riga`.


### PR DESCRIPTION
## Sommario

Implementa la configurazione della **cover di uno SharedGame da una pagina di PDF** (proposta utente → approvazione admin, livello L4), consolida la **deduplicazione PDF**, e — durante l'implementazione — scopre e corregge un **P1 architetturale pre-esistente**: il resolver R2 non risolveva *nessuna* cover.

- Spec: `docs/superpowers/specs/2026-07-14-game-cover-configuration-design.md`
- Piano: `docs/superpowers/plans/2026-07-14-game-cover-pdf-source.md`

## Cosa contiene (8 task TDD)

- **Dedup PDF**: `IPdfDeduplicationService` unico (globale-catalogo / per-utente-privati); il path chunked ora **riusa** il duplicato via `EntityLink` invece di rigettarlo.
- **`MaterializePdfCover`**: render pagina → WebP → R2 (convenzione key `-preview.webp`).
- **Governance**: `ContributionType.CoverChange` su `ShareRequest` + approvazione `UpdateCover` che promuove la cover pending a L4.
- **Endpoint utente** `POST /api/v1/games/{gameId}/cover/propose-from-pdf` + `CoverMaterializationException` → **503 `cover_render_unavailable`** (non-bloccante).
- **Compliance BGG (#2123)**: rimossi `ImageUrl`/`ThumbnailUrl` da `AddPrivateGameRequest`/`Command`.
- **FE** `CoverPagePicker` + due ingressi (post-upload PDF + azione "Imposta cover"), con gestione 503 non-bloccante.

## Fix P1 pre-esistente — resolver R2

Scoperto dal final review olistico: `CoverUrlResolver` → `GetPresignedDownloadUrlAsync` validava `fileId`/`resourceKey` con `PathSecurity.ValidateIdentifier` (regex `^[a-zA-Z0-9_-]+$`, rifiuta `/` e `.`), ma il resolver passa key con `.webp`/`/` → **nessuna cover R2 (L2 Wikidata, L4 PDF, L2.5 BGG) risolveva** → sempre placeholder.

**Fix**: nuovo `IBlobStorageService.GetPresignedUrlForRawKeyAsync(rawKey)` con **existence-check fail-closed** (HEAD prima di generare l'URL → mai un'URL a un oggetto inesistente, degrada a placeholder non a immagine rotta); il resolver usa il physical key esatto per L2/L3/L4. Sblocca **cover-da-PDF (L4) + cover Wikidata (L2)**. L2.5 BGG lasciato invariato (follow-up).

## ⚠️ Gate obbligatorio PRIMA del merge

**Verifica su staging** che una cover Wikidata/PDF risolva davvero (round-trip R2 reale, presigned GET). Gli integration test MinIO **skippano localmente** per il limite baseline `DisablePayloadSigning`-over-HTTP — il fix è provato a livello unit ma la conferma end-to-end in produzione richiede staging.

## Follow-up (non-blocker, da tracciare come issue)

- **BGG L2.5 + Backfill L4**: convenzione `StoreAsync` con `fileId` non-deterministico da unificare — restano placeholder (P1 residuo condiviso).
- **Compliance**: `UpdatePrivateGameCommand.ImageUrl` è un canale URL esterno ancora aperto (buco freeze-BGG via PUT); il FE `AddPrivateGameForm` invia ancora `imageUrl`/`thumbnailUrl` (ora droppati).
- **Reference-counting** al delete PDF (DEC-6): `DeletePdfCommandHandler` non consulta gli `EntityLink` → un PDF riusato può essere orfanizzato.
- **Centralizzazione dedup incompleta**: `AddRulebookCommandHandler` non ancora migrato a `IPdfDeduplicationService`.
- **Validator** mancante su `MaterializePdfCoverCommand` (safe oggi: unico caller valida `PageNumber > 0`).

## Test & qualità

- 2770+ test bounded-context unit + suite targeted, **0 failure**; build backend pulito; frontend typecheck/lint pulito.
- Ogni task è passato per implementer + reviewer per-task (TDD subagent-driven); **final review olistico su opus** ha individuato 4 bug cross-cutting (off-by-one `CoverPageIndex`, resolver R2, collisione key pending, target-override) tutti fixati e **ri-reviewati CLOSED**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
