### PR TITLE
refactor(frontend): migrate gaming dark-surface components to semantic theme-aware tokens (FU-1)

### DIFF
--- a/apps/web/src/components/play-records/NewPlayRecordSheet.tsx
+++ b/apps/web/src/components/play-records/NewPlayRecordSheet.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable local/no-hardcoded-color-utility -- text-white / button color on style-prop colored bg or decorative inline gradient; mockup .e-bg pattern. Will be re-evaluated in DS-15 finalization audit. */
 'use client';
 
 /**
@@ -46,7 +45,7 @@ function StepIndicator({ current, total }: { current: number; total: number }) {
           key={i}
           className={cn(
             'h-1.5 rounded-full transition-all duration-200',
-            i < current ? 'w-4 bg-emerald-400' : i === current ? 'w-6 bg-card' : 'w-4 bg-card/20'
+            i < current ? 'w-4 bg-emerald-400' : i === current ? 'w-6 bg-primary' : 'w-4 bg-border'
           )}
         />
       ))}
@@ -219,14 +218,14 @@ export function NewPlayRecordSheet({
 
       {/* Sheet */}
       <div
-        className="relative z-10 flex flex-col rounded-t-2xl bg-[var(--gaming-bg-surface,#1a1a2e)] border-t border-border max-h-[92dvh]"
+        className="relative z-10 flex flex-col rounded-t-2xl bg-card border-t border-border max-h-[92dvh]"
         role="dialog"
         aria-modal="true"
         aria-label="Registra partita"
       >
         {/* Drag handle */}
         <div className="flex justify-center pt-3 pb-1">
-          <div className="h-1 w-10 rounded-full bg-card/20" />
+          <div className="h-1 w-10 rounded-full bg-border" />
         </div>
 
         {/* Header */}
@@ -236,7 +235,7 @@ export function NewPlayRecordSheet({
               <button
                 type="button"
                 onClick={() => setStep(s => s - 1)}
-                className="flex h-8 w-8 items-center justify-center rounded-full text-foreground/80 hover:bg-card/5"
+                className="flex h-8 w-8 items-center justify-center rounded-full text-foreground/80 hover:bg-muted"
                 aria-label="Passo precedente"
               >
                 <ChevronLeft className="h-5 w-5" />
@@ -247,7 +246,7 @@ export function NewPlayRecordSheet({
           <button
             type="button"
             onClick={handleClose}
-            className="flex h-8 w-8 items-center justify-center rounded-full text-foreground/80 hover:bg-card/5"
+            className="flex h-8 w-8 items-center justify-center rounded-full text-foreground/80 hover:bg-muted"
             aria-label="Chiudi"
           >
             <X className="h-5 w-5" />
@@ -260,7 +259,7 @@ export function NewPlayRecordSheet({
           {step === 0 && (
             <div className="flex flex-col gap-5">
               <div>
-                <p className="text-base font-bold text-white mb-1">Quale gioco hai giocato?</p>
+                <p className="text-base font-bold text-foreground mb-1">Quale gioco hai giocato?</p>
                 <p className="text-xs text-muted-foreground">
                   Cerca nella tua libreria o inserisci il nome
                 </p>
@@ -288,7 +287,7 @@ export function NewPlayRecordSheet({
                     value={gameName}
                     onChange={e => setGameName(e.target.value)}
                     placeholder="Es. Catan, Puerto Rico…"
-                    className="w-full rounded-xl bg-card/5 border border-border px-3 py-2.5 text-sm text-white placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring/30"
+                    className="w-full rounded-xl bg-muted border border-border px-3 py-2.5 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring/30"
                     data-testid="game-name-input"
                   />
                 </div>
@@ -302,7 +301,7 @@ export function NewPlayRecordSheet({
                   type="date"
                   value={sessionDate}
                   onChange={e => setSessionDate(e.target.value)}
-                  className="w-full rounded-xl bg-card/5 border border-border px-3 py-2.5 text-sm text-white focus:outline-none focus:ring-1 focus:ring-ring/30"
+                  className="w-full rounded-xl bg-muted border border-border px-3 py-2.5 text-sm text-foreground focus:outline-none focus:ring-1 focus:ring-ring/30"
                   data-testid="session-date-input"
                 />
               </div>
@@ -320,8 +319,8 @@ export function NewPlayRecordSheet({
                       className={cn(
                         'flex-1 rounded-xl border py-2.5 text-sm font-semibold transition-colors',
                         visibility === v
-                          ? 'border-emerald-500/40 bg-emerald-500/15 text-emerald-400'
-                          : 'border-border bg-card/5 text-foreground/80 hover:border-border'
+                          ? 'border-emerald-500/40 bg-emerald-500/15 text-emerald-700 dark:text-emerald-400'
+                          : 'border-border bg-muted text-foreground/80 hover:border-border'
                       )}
                       data-testid={`visibility-${v.toLowerCase()}`}
                     >
@@ -337,7 +336,7 @@ export function NewPlayRecordSheet({
           {step === 1 && (
             <div className="flex flex-col gap-4">
               <div>
-                <p className="text-base font-bold text-white mb-1">Chi ha giocato?</p>
+                <p className="text-base font-bold text-foreground mb-1">Chi ha giocato?</p>
                 <p className="text-xs text-muted-foreground mb-0.5">
                   {gameName} •{' '}
                   {new Date(sessionDate + 'T12:00:00').toLocaleDateString('it-IT', {
@@ -352,9 +351,9 @@ export function NewPlayRecordSheet({
                 {players.map(p => (
                   <div
                     key={p.id}
-                    className="flex items-center gap-3 rounded-xl bg-card/5 border border-border px-3 py-2.5"
+                    className="flex items-center gap-3 rounded-xl bg-muted/50 border border-border px-3 py-2.5"
                   >
-                    <span className="flex-1 text-sm font-semibold text-white truncate">
+                    <span className="flex-1 text-sm font-semibold text-foreground truncate">
                       {p.name}
                     </span>
                     <div className="flex items-center gap-1.5">
@@ -363,13 +362,13 @@ export function NewPlayRecordSheet({
                         value={p.score}
                         onChange={e => updateScore(p.id, e.target.value)}
                         placeholder="Pts"
-                        className="w-16 rounded-lg bg-card/5 border border-border px-2 py-1 text-center text-sm text-white placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring/30"
+                        className="w-16 rounded-lg bg-muted border border-border px-2 py-1 text-center text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring/30"
                         data-testid={`player-score-${p.name}`}
                       />
                       <button
                         type="button"
                         onClick={() => removePlayer(p.id)}
-                        className="flex h-6 w-6 items-center justify-center rounded-full text-muted-foreground hover:text-red-400"
+                        className="flex h-6 w-6 items-center justify-center rounded-full text-muted-foreground hover:text-destructive"
                         aria-label={`Rimuovi ${p.name}`}
                       >
                         <X className="h-3.5 w-3.5" />
@@ -387,13 +386,13 @@ export function NewPlayRecordSheet({
                   onChange={e => setNewPlayerName(e.target.value)}
                   onKeyDown={e => e.key === 'Enter' && addPlayer()}
                   placeholder="Nome giocatore…"
-                  className="flex-1 rounded-xl bg-card/5 border border-border px-3 py-2.5 text-sm text-white placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring/30"
+                  className="flex-1 rounded-xl bg-muted border border-border px-3 py-2.5 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring/30"
                   data-testid="new-player-input"
                 />
                 <button
                   type="button"
                   onClick={addPlayer}
-                  className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-xl bg-card/5 border border-border text-foreground/80 hover:bg-card/10"
+                  className="flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-xl bg-muted border border-border text-foreground/80 hover:bg-muted/80"
                   aria-label="Aggiungi giocatore"
                   data-testid="add-player-btn"
                 >
@@ -404,11 +403,13 @@ export function NewPlayRecordSheet({
               {/* Vincitore auto */}
               {winnerPlayer && (
                 <div className="flex items-center gap-2 rounded-xl bg-amber-500/10 border border-amber-500/20 px-3 py-2.5">
-                  <Trophy className="h-4 w-4 text-amber-400 flex-shrink-0" />
-                  <p className="text-sm font-semibold text-amber-400">
-                    Vincitore: <span className="text-white">{winnerPlayer.name}</span>
+                  <Trophy className="h-4 w-4 text-amber-500 dark:text-amber-400 flex-shrink-0" />
+                  <p className="text-sm font-semibold text-amber-700 dark:text-amber-400">
+                    Vincitore: <span className="text-foreground">{winnerPlayer.name}</span>
                     {winnerPlayer.score && (
-                      <span className="text-amber-400/70 ml-1">({winnerPlayer.score} pts)</span>
+                      <span className="text-amber-700/80 dark:text-amber-400/70 ml-1">
+                        ({winnerPlayer.score} pts)
+                      </span>
                     )}
                   </p>
                 </div>
@@ -420,7 +421,7 @@ export function NewPlayRecordSheet({
           {step === 2 && (
             <div className="flex flex-col gap-5">
               <div>
-                <p className="text-base font-bold text-white mb-0.5">Riepilogo partita</p>
+                <p className="text-base font-bold text-foreground mb-0.5">Riepilogo partita</p>
                 <p className="text-xs text-muted-foreground">
                   {gameName} • {players.length} {players.length === 1 ? 'giocatore' : 'giocatori'}
                 </p>
@@ -436,7 +437,7 @@ export function NewPlayRecordSheet({
                         'flex items-center justify-between rounded-xl px-3 py-2.5',
                         i === 0
                           ? 'bg-amber-500/10 border border-amber-500/20'
-                          : 'bg-card/5 border border-border'
+                          : 'bg-muted/50 border border-border'
                       )}
                     >
                       <div className="flex items-center gap-2.5">
@@ -444,7 +445,7 @@ export function NewPlayRecordSheet({
                         <span
                           className={cn(
                             'text-sm font-semibold',
-                            i === 0 ? 'text-amber-300' : 'text-white'
+                            i === 0 ? 'text-amber-700 dark:text-amber-300' : 'text-foreground'
                           )}
                         >
                           {p.name}
@@ -454,7 +455,7 @@ export function NewPlayRecordSheet({
                         <span
                           className={cn(
                             'text-sm font-bold',
-                            i === 0 ? 'text-amber-400' : 'text-foreground/80'
+                            i === 0 ? 'text-amber-700 dark:text-amber-400' : 'text-foreground/80'
                           )}
                         >
                           {p.score} pts
@@ -475,7 +476,7 @@ export function NewPlayRecordSheet({
                   onChange={e => setNotes(e.target.value)}
                   placeholder="Come è andata la partita?"
                   rows={3}
-                  className="w-full rounded-xl bg-card/5 border border-border px-3 py-2.5 text-sm text-white placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring/30 resize-none"
+                  className="w-full rounded-xl bg-muted border border-border px-3 py-2.5 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring/30 resize-none"
                   data-testid="notes-input"
                 />
               </div>
@@ -483,7 +484,7 @@ export function NewPlayRecordSheet({
               {/* Error */}
               {errorMsg && (
                 <div
-                  className="rounded-xl border border-red-500/20 bg-red-500/10 px-4 py-3 text-sm text-red-400"
+                  className="rounded-xl border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive"
                   data-testid="save-error"
                 >
                   {errorMsg}

--- a/apps/web/src/components/session/ScoreNumpad.tsx
+++ b/apps/web/src/components/session/ScoreNumpad.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable local/no-hardcoded-color-utility -- text-white / button color on style-prop colored bg or entity-colored CTA; mockup .e-bg pattern. DS-12 will introduce primitives encoding bg via className. */
 'use client';
 
 import React, { useState } from 'react';
@@ -60,25 +59,21 @@ export function ScoreNumpad({
   return (
     <div
       className={cn(
-        'flex flex-col items-center gap-4 rounded-2xl bg-[var(--gaming-surface,#1a1a2e)] p-4',
+        'flex flex-col items-center gap-4 rounded-2xl border border-border bg-card p-4',
         className
       )}
       aria-label={`Numpad per ${playerName}`}
     >
       {/* Header */}
       <div className="flex w-full items-center justify-between">
-        <span className="text-sm font-medium text-[var(--text-sec,#ccc)]">
-          {playerName}
-        </span>
+        <span className="text-sm font-medium text-muted-foreground">{playerName}</span>
         {currentScore !== undefined && (
-          <span className="text-xs text-[var(--text-sec,#aaa)]">
-            Attuale: {currentScore}
-          </span>
+          <span className="text-xs text-muted-foreground">Attuale: {currentScore}</span>
         )}
         <button
           aria-label="Chiudi"
           onClick={onClose}
-          className="text-[var(--text-sec,#ccc)] hover:text-white"
+          className="text-muted-foreground hover:text-foreground"
         >
           ✕
         </button>
@@ -88,7 +83,7 @@ export function ScoreNumpad({
       <div
         aria-live="polite"
         aria-label={`Valore corrente: ${displayValue}`}
-        className="text-5xl font-bold tabular-nums text-white"
+        className="text-5xl font-bold tabular-nums text-foreground"
       >
         {displayValue}
       </div>
@@ -102,7 +97,7 @@ export function ScoreNumpad({
                 key="delete"
                 aria-label="Cancella"
                 onClick={action}
-                className="flex items-center justify-center rounded-xl bg-card/10 p-4 text-white hover:bg-card/20 active:scale-95"
+                className="flex items-center justify-center rounded-xl bg-muted p-4 text-foreground hover:bg-muted/80 active:scale-95"
               >
                 <Delete className="h-5 w-5" aria-hidden="true" />
               </button>
@@ -127,7 +122,7 @@ export function ScoreNumpad({
               key={label}
               aria-label={label}
               onClick={action}
-              className="rounded-xl bg-card/10 p-4 text-lg font-semibold text-white hover:bg-card/20 active:scale-95"
+              className="rounded-xl bg-muted p-4 text-lg font-semibold text-foreground hover:bg-muted/80 active:scale-95"
             >
               {label}
             </button>

--- a/apps/web/src/components/session/live/GameOverModal.tsx
+++ b/apps/web/src/components/session/live/GameOverModal.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable local/no-hardcoded-color-utility -- text-white / button color on style-prop colored bg or entity-colored CTA; mockup .e-bg pattern. DS-12 will introduce primitives encoding bg via className. */
+/* eslint-disable local/no-hardcoded-color-utility -- single exception: text-white on the avatar initials, whose bg is a dynamic per-player color set via inline style (avatarColor) and so cannot be declared in className. All other surfaces migrated to semantic/theme-aware tokens. */
 /**
  * GameOverModal — shown when a session is completed
  *
@@ -31,9 +31,9 @@ interface GameOverModalProps {
 }
 
 const RANK_ICONS = [
-  <Trophy key="1" className="h-5 w-5 text-amber-400" />,
-  <Medal key="2" className="h-5 w-5 text-slate-300" />,
-  <Medal key="3" className="h-5 w-5 text-amber-700" />,
+  <Trophy key="1" className="h-5 w-5 text-amber-500 dark:text-amber-400" />,
+  <Medal key="2" className="h-5 w-5 text-muted-foreground" />,
+  <Medal key="3" className="h-5 w-5 text-amber-700 dark:text-amber-500" />,
 ];
 
 export function GameOverModal({ gameName, players, sessionId, onClose }: GameOverModalProps) {
@@ -59,16 +59,16 @@ export function GameOverModal({ gameName, players, sessionId, onClose }: GameOve
       aria-label="Partita terminata"
       className="fixed inset-0 z-50 flex items-end sm:items-center justify-center bg-foreground/70 backdrop-blur-sm"
     >
-      <div className="w-full max-w-md bg-[var(--gaming-card-bg,#1a1a2e)] border border-border rounded-t-2xl sm:rounded-2xl p-6 space-y-6">
+      <div className="w-full max-w-md bg-card border border-border rounded-t-2xl sm:rounded-2xl p-6 space-y-6">
         {/* Header */}
         <div className="text-center space-y-2">
           <div className="flex justify-center">
-            <Crown className="h-10 w-10 text-amber-400" />
+            <Crown className="h-10 w-10 text-amber-500 dark:text-amber-400" />
           </div>
           <h2 className="text-2xl font-bold font-quicksand">Partita terminata!</h2>
           <p className="text-sm text-muted-foreground">{gameName}</p>
           {winner && (
-            <p className="text-base font-semibold text-amber-300">
+            <p className="text-base font-semibold text-amber-700 dark:text-amber-300">
               Vincitore: {winner.displayName} ({winner.totalScore} pts)
             </p>
           )}
@@ -83,7 +83,7 @@ export function GameOverModal({ gameName, players, sessionId, onClose }: GameOve
                 'flex items-center gap-3 rounded-xl px-4 py-3 border',
                 player.rank === 1
                   ? 'border-amber-500/50 bg-amber-500/10'
-                  : 'border-border bg-card/5'
+                  : 'border-border bg-muted/50'
               )}
             >
               {/* Rank icon */}
@@ -119,7 +119,7 @@ export function GameOverModal({ gameName, players, sessionId, onClose }: GameOve
         <div className="flex gap-3">
           <button
             onClick={handleNewSession}
-            className="flex-1 rounded-xl bg-card/10 py-3 text-sm font-medium hover:bg-card/20 transition-colors"
+            className="flex-1 rounded-xl bg-muted py-3 text-sm font-medium hover:bg-muted/80 transition-colors"
           >
             Nuova partita
           </button>

--- a/apps/web/src/styles/premium-gaming.css
+++ b/apps/web/src/styles/premium-gaming.css
@@ -22,7 +22,6 @@
     --gaming-accent-ai: #8b5cf6;
     --gaming-accent-success: #22c55e;
     --gaming-accent-info: #3b82f6;
-    --gaming-surface: #1a1a2e;
     --gaming-blur: 12px;
   }
 }


### PR DESCRIPTION
## FU-1 — cleanup-frontend-legacy follow-up

`ScoreNumpad`, `GameOverModal` and `NewPlayRecordSheet` hardcoded a dark navy surface `bg-[var(--gaming-*,#1a1a2e)]` whose children assumed a *dark* background (`text-white`, `bg-card/NN` white-overlay fills). That clashed with the cream (light) default theme, and — critically — a naive container swap would have turned every `text-white` child into white-on-white. This migrates the container **and every child** to semantic, theme-aware tokens.

### Changes
- **Container** `bg-[var(--gaming-*)]` → `bg-card` (+ `border border-border` where needed to keep the panel visible on cream).
- **`text-white` → `text-foreground`** everywhere, except the 2 legit cases where the bg is a colored gradient (ScoreNumpad confirm key) or a dynamic per-player inline `avatarColor` (GameOverModal avatar) — allowed by the eslint exemption.
- **`bg-card/NN` white-overlay fills** → `bg-muted` / `bg-border` / `bg-primary` (they vanish on a light surface).
- **Hue accents** (amber/emerald) → dual-theme `light dark:dark` variants for AA on both cream and dark; error text → semantic `text-destructive`.
- Silver medal icon `text-slate-300` (banned neutral) → `text-muted-foreground`.
- Removed the now-orphaned `--gaming-surface` custom property from `premium-gaming.css` (ScoreNumpad was its **sole** consumer; the `.glass-*` / `.gaming-glass` / `.gradient-primary` class layer stays — still used by 6 live components). `--gaming-card-bg` / `--gaming-bg-surface` were never defined and only ever hit the hardcoded `#1a1a2e` fallback.
- Dropped the file-level `eslint-disable` on ScoreNumpad + NewPlayRecordSheet (no banned utilities remain); GameOverModal keeps a **narrowed** one for the single avatar `text-white`.

### Verification
- `pnpm typecheck` ✅ · `pnpm lint` (3 files) ✅ · `ScoreNumpad` vitest ✅ · pre-push `next build` ✅
- **Objective WCAG contrast check** (Storybook, light theme, OKLCH-aware): **0 real regressions** across all 3 components — semantic text 6.8–17.4:1, amber accent 5.0:1, emerald accent 4.66:1. (Remaining flags are pre-existing dynamic avatar colors + a gradient-button false-positive.)
- Dark theme covered by the design-system's AA-audited semantic tokens + standard `dark:` accent variants.

> Note: `GameOverModal` currently has **0 consumers** (dead, likely WIP for session-live epic #2354) — migrated for consistency, not deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)