### PR TITLE
refactor(frontend): remove dead --e-* entity tokens, fix broken accents (FU-2)

### DIFF
--- a/apps/web/src/components/dashboard/WelcomeHero.tsx
+++ b/apps/web/src/components/dashboard/WelcomeHero.tsx
@@ -2,10 +2,10 @@
 
 /* eslint-disable local/no-hardcoded-color-utility --
  * Avatar + primary CTA render white text on inline `style={{ background:
- * 'linear-gradient(... hsl(var(--e-*)) ...)' }}` (entity-tinted bg). The lint
- * rule inspects className strings only, so it cannot see the entity bg in the
- * style prop. Mockup-faithful (.e-bg pattern). Will be re-evaluated when
- * DS-12 introduces shared <EntityAvatar> / <EntityButton> primitives.
+ * 'linear-gradient(... hsl(var(--c-game)) ...)' }}` (brand-tinted bg). The lint
+ * rule inspects className strings only, so it cannot see the colored bg in the
+ * style prop. Will be re-evaluated when shared <EntityAvatar> / <EntityButton>
+ * primitives are introduced.
  */
 
 import { useRouter } from 'next/navigation';

--- a/apps/web/src/components/ui/btn/btn.test.tsx
+++ b/apps/web/src/components/ui/btn/btn.test.tsx
@@ -53,35 +53,37 @@ describe('Btn', () => {
     expect(screen.getByRole('button')).toHaveClass('bg-transparent');
   });
 
-  it('entity prop applies entity background on primary variant', () => {
+  it('entity prop sets data-entity and no inline color on primary variant', () => {
     render(
       <Btn variant="primary" entity="game">
         x
       </Btn>
     );
     const btn = screen.getByRole('button');
-    expect(btn.style.backgroundColor).toBe('hsl(var(--e-game))');
+    expect(btn).toHaveAttribute('data-entity', 'game');
+    expect(btn.style.backgroundColor).toBe('');
   });
 
-  it('entity=kb maps to --e-document css variable', () => {
+  it('entity=kb sets data-entity="kb"', () => {
     render(
       <Btn variant="primary" entity="kb">
         x
       </Btn>
     );
     const btn = screen.getByRole('button');
-    expect(btn.style.backgroundColor).toBe('hsl(var(--e-document))');
+    expect(btn).toHaveAttribute('data-entity', 'kb');
   });
 
-  it('entity prop applies entity border + color on outline variant', () => {
+  it('entity prop no longer inline-colors the outline variant', () => {
     render(
       <Btn variant="outline" entity="agent">
         x
       </Btn>
     );
     const btn = screen.getByRole('button');
-    expect(btn.style.borderColor).toBe('hsl(var(--e-agent))');
-    expect(btn.style.color).toBe('hsl(var(--e-agent))');
+    expect(btn).toHaveAttribute('data-entity', 'agent');
+    expect(btn.style.borderColor).toBe('');
+    expect(btn.style.color).toBe('');
   });
 
   it('entity prop has no inline style effect on ghost/secondary/destructive', () => {

--- a/apps/web/src/components/ui/btn/btn.tsx
+++ b/apps/web/src/components/ui/btn/btn.tsx
@@ -1,23 +1,9 @@
-import type { CSSProperties, JSX, MouseEventHandler, ReactNode } from 'react';
+import type { JSX, MouseEventHandler, ReactNode } from 'react';
 
 import { Slot } from '@radix-ui/react-slot';
 import clsx from 'clsx';
 
 import type { EntityType } from '@/components/ui/entity-tokens';
-
-// Map EntityType -> CSS variable key. Mirrors entity-card mapping
-// so `kb` resolves to `--c-kb` (pre-existing naming from design tokens).
-const ENTITY_CSS_VAR_KEY: Record<EntityType, string> = {
-  game: 'game',
-  player: 'player',
-  session: 'session',
-  agent: 'agent',
-  kb: 'document',
-  chat: 'chat',
-  event: 'event',
-  toolkit: 'toolkit',
-  tool: 'tool',
-};
 
 export type BtnVariant = 'primary' | 'secondary' | 'outline' | 'ghost' | 'destructive';
 export type BtnSize = 'sm' | 'md' | 'lg';
@@ -103,19 +89,6 @@ export function Btn({
     className
   );
 
-  const style: CSSProperties | undefined = (() => {
-    if (!entity) return undefined;
-    const key = ENTITY_CSS_VAR_KEY[entity];
-    const color = `hsl(var(--e-${key}))`;
-    if (variant === 'primary') {
-      return { backgroundColor: color, color: 'white' };
-    }
-    if (variant === 'outline') {
-      return { borderColor: color, color };
-    }
-    return undefined;
-  })();
-
   const content = (
     <>
       {loading ? <Spinner /> : leftIcon}
@@ -129,8 +102,8 @@ export function Btn({
       <Slot
         id={id}
         data-testid={testId}
+        data-entity={entity || undefined}
         className={classes}
-        style={style}
         data-loading={loading || undefined}
         aria-busy={loading || undefined}
       >
@@ -144,8 +117,8 @@ export function Btn({
       type={type}
       id={id}
       data-testid={testId}
+      data-entity={entity || undefined}
       className={classes}
-      style={style}
       disabled={isDisabled}
       aria-busy={loading || undefined}
       onClick={onClick}

--- a/apps/web/src/components/ui/data-display/entity-list-view/components/entity-table-view.tsx
+++ b/apps/web/src/components/ui/data-display/entity-list-view/components/entity-table-view.tsx
@@ -84,7 +84,7 @@ export interface EntityTableViewProps<T> {
 // Auto-generate columns from MeepleCardProps
 // ============================================================================
 
-function createDefaultColumns(entity: MeepleEntityType): ColumnDef<TableRowData, unknown>[] {
+function createDefaultColumns(): ColumnDef<TableRowData, unknown>[] {
   return [
     {
       accessorKey: 'title',
@@ -104,8 +104,7 @@ function createDefaultColumns(entity: MeepleEntityType): ColumnDef<TableRowData,
               <span
                 className={cn(
                   'ml-2 inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-semibold uppercase',
-                  `bg-[hsl(var(--e-${entity}))/0.1]`,
-                  `text-[hsl(var(--e-${entity}))]`
+                  'bg-muted text-muted-foreground'
                 )}
               >
                 {row.original.badge}
@@ -219,8 +218,8 @@ export function EntityTableView<T>({
     if (customColumns && customColumns.length > 0) {
       return createColumnsFromConfig(customColumns);
     }
-    return createDefaultColumns(entity);
-  }, [customColumns, entity]);
+    return createDefaultColumns();
+  }, [customColumns]);
 
   // Row click handler
   const handleRowClick = useMemo(() => {

--- a/apps/web/src/components/ui/drawer/drawer.test.tsx
+++ b/apps/web/src/components/ui/drawer/drawer.test.tsx
@@ -184,10 +184,10 @@ describe('Drawer (desktop / Radix)', () => {
     const dialog = screen.getByRole('dialog');
     const accent = dialog.querySelector('[data-drawer-accent="game"]');
     expect(accent).toBeInTheDocument();
-    expect(accent?.getAttribute('style')).toContain('hsl(var(--e-game))');
+    expect(accent?.className).toContain('bg-primary');
   });
 
-  it('maps kb entity to --e-document on desktop accent', () => {
+  it('renders the desktop accent for kb entity', () => {
     render(
       <Drawer open onOpenChange={() => {}} side="desktop-right" entity="kb">
         <DrawerContent>
@@ -198,7 +198,8 @@ describe('Drawer (desktop / Radix)', () => {
       </Drawer>
     );
     const accent = screen.getByRole('dialog').querySelector('[data-drawer-accent="kb"]');
-    expect(accent?.getAttribute('style')).toContain('hsl(var(--e-document))');
+    expect(accent).toBeInTheDocument();
+    expect(accent?.className).toContain('bg-primary');
   });
 
   it('has no a11y violations on desktop', async () => {
@@ -268,7 +269,7 @@ describe('Drawer (mobile / vaul)', () => {
     await screen.findByText('player drawer');
     const accent = document.querySelector('[data-drawer-accent="player"]');
     expect(accent).not.toBeNull();
-    expect(accent?.getAttribute('style')).toContain('hsl(var(--e-player))');
+    expect(accent?.className).toContain('bg-primary');
   });
 
   it('DrawerClose triggers onOpenChange(false) on mobile', async () => {

--- a/apps/web/src/components/ui/drawer/drawer.tsx
+++ b/apps/web/src/components/ui/drawer/drawer.tsx
@@ -6,7 +6,6 @@ import {
   useContext,
   useMemo,
   type ButtonHTMLAttributes,
-  type CSSProperties,
   type HTMLAttributes,
   type ReactNode,
 } from 'react';
@@ -17,19 +16,6 @@ import { Drawer as VaulDrawer } from 'vaul';
 
 import { useDrawerBreakpoint } from '@/components/ui/drawer/use-drawer-breakpoint';
 import type { EntityType } from '@/components/ui/entity-tokens';
-
-// Mirror EntityCard: `kb` -> `--c-kb` (pre-existing token name).
-const ENTITY_CSS_VAR_KEY: Record<EntityType, string> = {
-  game: 'game',
-  player: 'player',
-  session: 'session',
-  agent: 'agent',
-  kb: 'document',
-  chat: 'chat',
-  event: 'event',
-  toolkit: 'toolkit',
-  tool: 'tool',
-};
 
 export type DrawerSide = 'auto' | 'mobile-bottom' | 'desktop-right';
 export type DrawerDirection = 'bottom' | 'right';
@@ -68,11 +54,6 @@ function resolveMode(
   if (side === 'mobile-bottom') return 'mobile';
   if (side === 'desktop-right') return 'desktop';
   return breakpoint;
-}
-
-function entityAccentStyle(entity: EntityType | undefined): CSSProperties | undefined {
-  if (!entity) return undefined;
-  return { backgroundColor: `hsl(var(--e-${ENTITY_CSS_VAR_KEY[entity]}))` };
 }
 
 export function Drawer({
@@ -119,8 +100,10 @@ export const DrawerContent = forwardRef<HTMLDivElement, DrawerContentProps>(func
           <div
             data-drawer-accent={entity}
             aria-hidden="true"
-            className={clsx('mx-auto mt-2 h-1 w-12 rounded-full', !entity && 'bg-border')}
-            style={entityAccentStyle(entity)}
+            className={clsx(
+              'mx-auto mt-2 h-1 w-12 rounded-full',
+              entity ? 'bg-primary' : 'bg-border'
+            )}
           />
           {children}
         </VaulDrawer.Content>
@@ -135,8 +118,7 @@ export const DrawerContent = forwardRef<HTMLDivElement, DrawerContentProps>(func
           <div
             data-drawer-accent={entity}
             aria-hidden="true"
-            className="absolute inset-y-0 left-0 w-1 rounded-l-2xl"
-            style={entityAccentStyle(entity)}
+            className="absolute inset-y-0 left-0 w-1 rounded-l-2xl bg-primary"
           />
         )}
         {children}

--- a/apps/web/src/components/ui/entity-card/entity-card.test.tsx
+++ b/apps/web/src/components/ui/entity-card/entity-card.test.tsx
@@ -33,17 +33,18 @@ describe('EntityCard', () => {
     );
     const el = container.querySelector<HTMLElement>('[data-entity="game"]');
     expect(el?.className).toMatch(/border-l-4/);
-    expect(el?.style.borderLeftColor).toBe('hsl(var(--e-game))');
+    expect(el?.style.borderLeftColor).toBe('');
   });
 
-  it('maps kb entity to --e-document css variable', () => {
+  it('renders with data-entity="kb" and no inline border color', () => {
     const { container } = render(
       <EntityCard entity="kb">
         <span>x</span>
       </EntityCard>
     );
     const el = container.querySelector<HTMLElement>('[data-entity="kb"]');
-    expect(el?.style.borderLeftColor).toBe('hsl(var(--e-document))');
+    expect(el).toBeInTheDocument();
+    expect(el?.style.borderLeftColor).toBe('');
   });
 
   it('omits left border when entityBorder=false', () => {

--- a/apps/web/src/components/ui/entity-card/entity-card.tsx
+++ b/apps/web/src/components/ui/entity-card/entity-card.tsx
@@ -1,22 +1,8 @@
-import type { CSSProperties, JSX, ReactNode } from 'react';
+import type { JSX, ReactNode } from 'react';
 
 import clsx from 'clsx';
 
 import type { EntityType } from '@/components/ui/entity-tokens';
-
-// Map EntityType -> CSS variable key. Mirrors TAILWIND_KEY in entity-tokens.ts
-// so `kb` resolves to `--c-kb` (pre-existing naming from design tokens).
-const ENTITY_CSS_VAR_KEY: Record<EntityType, string> = {
-  game: 'game',
-  player: 'player',
-  session: 'session',
-  agent: 'agent',
-  kb: 'document',
-  chat: 'chat',
-  event: 'event',
-  toolkit: 'toolkit',
-  tool: 'tool',
-};
 
 export type EntityCardVariant = 'default' | 'elevated' | 'flat';
 
@@ -58,10 +44,6 @@ export function EntityCard({
     className
   );
 
-  const style: CSSProperties | undefined = entityBorder
-    ? { borderLeftColor: `hsl(var(--e-${ENTITY_CSS_VAR_KEY[entity]}))` }
-    : undefined;
-
   if (onClick) {
     return (
       <button
@@ -70,7 +52,6 @@ export function EntityCard({
         data-entity={entity}
         onClick={onClick}
         className={clsx('block w-full text-left', classes)}
-        style={style}
       >
         {children}
       </button>
@@ -78,7 +59,7 @@ export function EntityCard({
   }
 
   return (
-    <div data-entity={entity} className={classes} style={style}>
+    <div data-entity={entity} className={classes}>
       {children}
     </div>
   );

--- a/apps/web/src/components/ui/entity-pip/entity-pip.tsx
+++ b/apps/web/src/components/ui/entity-pip/entity-pip.tsx
@@ -38,8 +38,6 @@ export function EntityPip({
   // Pill (with count) size classes
   const pillSize = size === 'sm' ? 'h-4 min-w-4 px-1 text-[10px]' : 'h-5 min-w-5 px-1.5 text-xs';
 
-  const tailwindKey = token.bg.replace('bg-entity-', '');
-
   const baseClasses = clsx(
     'inline-flex items-center justify-center rounded-full font-medium',
     token.bg,
@@ -48,11 +46,6 @@ export function EntityPip({
     isEmpty && 'opacity-40 cursor-default',
     className
   );
-
-  // Use entity color at 0.35 alpha for ring via CSS variable in globals.css
-  const ringStyle = active
-    ? { boxShadow: `0 0 0 2px hsl(var(--e-${tailwindKey}) / 0.35)` }
-    : undefined;
 
   const content = hasCount ? count : null;
 
@@ -65,7 +58,6 @@ export function EntityPip({
         onClick={onClick}
         disabled={isEmpty}
         className={baseClasses}
-        style={ringStyle}
       >
         {content}
       </button>
@@ -73,7 +65,7 @@ export function EntityPip({
   }
 
   return (
-    <span role="presentation" data-entity={entity} className={baseClasses} style={ringStyle}>
+    <span role="presentation" data-entity={entity} className={baseClasses}>
       {content}
     </span>
   );

--- a/apps/web/src/components/ui/notification-card/notification-card.test.tsx
+++ b/apps/web/src/components/ui/notification-card/notification-card.test.tsx
@@ -46,19 +46,20 @@ describe('NotificationCard', () => {
     expect(screen.getByTestId('n-icon')).toBeInTheDocument();
   });
 
-  it('entity=game sets border-left to --e-game', () => {
+  it('entity=game keeps the border-l-4 accent (no inline color)', () => {
     const { container } = render(<NotificationCard entity="game" title="x" timestamp="ora" />);
     const el = container.querySelector<HTMLElement>('[data-entity="game"]');
     expect(el?.className).toMatch(/border-l-4/);
-    expect(el?.style.borderLeftColor).toBe('hsl(var(--e-game))');
+    expect(el?.style.borderLeftColor).toBe('');
   });
 
-  it('entity=kb maps to --e-document css var', () => {
+  it('renders with data-entity="kb" and no inline border color', () => {
     const { container } = render(
       <NotificationCard entity="kb" title="Nuova regola" timestamp="ieri" />
     );
     const el = container.querySelector<HTMLElement>('[data-entity="kb"]');
-    expect(el?.style.borderLeftColor).toBe('hsl(var(--e-document))');
+    expect(el).toBeInTheDocument();
+    expect(el?.style.borderLeftColor).toBe('');
   });
 
   it('unread=true shows unread dot pip', () => {

--- a/apps/web/src/components/ui/notification-card/notification-card.tsx
+++ b/apps/web/src/components/ui/notification-card/notification-card.tsx
@@ -1,21 +1,8 @@
-import type { CSSProperties, JSX, MouseEvent, ReactNode } from 'react';
+import type { JSX, MouseEvent, ReactNode } from 'react';
 
 import clsx from 'clsx';
 
 import type { EntityType } from '@/components/ui/entity-tokens';
-
-// Map EntityType -> CSS variable key (mirrors EntityCard/EntityPip: kb -> document)
-const ENTITY_CSS_VAR_KEY: Record<EntityType, string> = {
-  game: 'game',
-  player: 'player',
-  session: 'session',
-  agent: 'agent',
-  kb: 'document',
-  chat: 'chat',
-  event: 'event',
-  toolkit: 'toolkit',
-  tool: 'tool',
-};
 
 export interface NotificationCardProps {
   readonly entity: EntityType;
@@ -61,17 +48,12 @@ export function NotificationCard({
   dismissAriaLabel = 'Rimuovi notifica',
   className,
 }: NotificationCardProps): JSX.Element {
-  const cssKey = ENTITY_CSS_VAR_KEY[entity];
-  const entityColor = `hsl(var(--e-${cssKey}))`;
-
   const containerClasses = clsx(
     'group relative flex gap-3 rounded-xl border-l-4 bg-card p-4 text-foreground transition-colors',
     unread && 'bg-muted/20',
     onClick && 'w-full cursor-pointer text-left hover:bg-muted/40',
     className
   );
-
-  const style: CSSProperties = { borderLeftColor: entityColor };
 
   const titleClasses = clsx(
     'text-sm leading-tight',
@@ -92,8 +74,7 @@ export function NotificationCard({
             <span
               data-testid="unread-dot"
               aria-hidden="true"
-              className="inline-block h-2 w-2 flex-shrink-0 rounded-full"
-              style={{ backgroundColor: entityColor }}
+              className="inline-block h-2 w-2 flex-shrink-0 rounded-full bg-primary"
             />
           )}
           <span className={titleClasses}>{title}</span>
@@ -151,27 +132,20 @@ export function NotificationCard({
           onClick={onClick}
           onKeyDown={handleKeyDown}
           className={containerClasses}
-          style={style}
         >
           {content}
         </div>
       );
     }
     return (
-      <button
-        type="button"
-        data-entity={entity}
-        onClick={onClick}
-        className={containerClasses}
-        style={style}
-      >
+      <button type="button" data-entity={entity} onClick={onClick} className={containerClasses}>
         {content}
       </button>
     );
   }
 
   return (
-    <article data-entity={entity} className={containerClasses} style={style}>
+    <article data-entity={entity} className={containerClasses}>
       {content}
     </article>
   );

--- a/apps/web/src/components/ui/settings-row/settings-row.test.tsx
+++ b/apps/web/src/components/ui/settings-row/settings-row.test.tsx
@@ -94,11 +94,9 @@ describe('SettingsRow', () => {
     expect(label.className).toMatch(/destructive/);
   });
 
-  it('applies entity color to icon wrapper via inline style', () => {
-    render(<SettingsRow label="KB" icon={<span>📚</span>} entity="kb" />);
-    const icon = screen.getByTestId('settings-row-icon');
-    // kb maps to --e-document
-    expect(icon.getAttribute('style')).toMatch(/--e-document/);
+  it('sets data-entity on the row wrapper for the given entity', () => {
+    const { container } = render(<SettingsRow label="KB" icon={<span>📚</span>} entity="kb" />);
+    expect(container.querySelector('li')).toHaveAttribute('data-entity', 'kb');
   });
 
   it('merges className on the li wrapper', () => {

--- a/apps/web/src/components/ui/settings-row/settings-row.tsx
+++ b/apps/web/src/components/ui/settings-row/settings-row.tsx
@@ -1,21 +1,8 @@
-import type { CSSProperties, JSX, ReactNode } from 'react';
+import type { JSX, ReactNode } from 'react';
 
 import clsx from 'clsx';
 
 import type { EntityType } from '@/components/ui/entity-tokens';
-
-// Mirror entity-card / btn ENTITY_CSS_VAR_KEY mapping so `kb` resolves to `--c-kb`
-const ENTITY_CSS_VAR_KEY: Record<EntityType, string> = {
-  game: 'game',
-  player: 'player',
-  session: 'session',
-  agent: 'agent',
-  kb: 'document',
-  chat: 'chat',
-  event: 'event',
-  toolkit: 'toolkit',
-  tool: 'tool',
-};
 
 export interface SettingsRowProps {
   readonly icon?: ReactNode;
@@ -69,10 +56,6 @@ export function SettingsRow({
   const useButton = Boolean(onClick);
   const useLink = !useButton && Boolean(href);
 
-  const iconStyle: CSSProperties | undefined = entity
-    ? { color: `hsl(var(--e-${ENTITY_CSS_VAR_KEY[entity]}))` }
-    : undefined;
-
   const showAutoChevron = isInteractive && trailing === undefined;
 
   const innerClasses = clsx(
@@ -89,7 +72,7 @@ export function SettingsRow({
   const body = (
     <>
       {icon !== undefined ? (
-        <span data-testid="settings-row-icon" className="flex-shrink-0 text-lg" style={iconStyle}>
+        <span data-testid="settings-row-icon" className="flex-shrink-0 text-lg">
           {icon}
         </span>
       ) : null}
@@ -109,7 +92,7 @@ export function SettingsRow({
   );
 
   return (
-    <li className={className}>
+    <li className={className} data-entity={entity}>
       {useButton ? (
         <button
           type="button"

--- a/apps/web/src/components/ui/step-progress/step-progress.test.tsx
+++ b/apps/web/src/components/ui/step-progress/step-progress.test.tsx
@@ -19,13 +19,12 @@ describe('StepProgress', () => {
     expect(screen.getByText('Step 3')).toBeInTheDocument();
   });
 
-  it('completed steps have completed styling (inline background color)', () => {
+  it('completed steps have completed styling (bg-primary fill)', () => {
     const { container } = render(<StepProgress steps={makeSteps(4)} currentIndex={2} />);
     const completed = container.querySelector('[data-step-status="completed"]');
     expect(completed).toBeInTheDocument();
-    // Check data-step-circle child has inline style
     const circle = completed?.querySelector('[data-step-circle]') as HTMLElement | null;
-    expect(circle?.style.backgroundColor).toMatch(/hsl/i);
+    expect(circle?.className).toMatch(/bg-primary/);
   });
 
   it('current step has current styling (ring and scale)', () => {
@@ -69,22 +68,22 @@ describe('StepProgress', () => {
     expect(items[3]?.getAttribute('data-step-status')).toBe('pending');
   });
 
-  it('entity prop applies correct HSL inline to completed circles', () => {
+  it('completed circles use the bg-primary fill', () => {
     const { container } = render(
       <StepProgress steps={makeSteps(3)} currentIndex={2} entity="session" />
     );
     const completed = container.querySelector(
       '[data-step-status="completed"] [data-step-circle]'
     ) as HTMLElement | null;
-    expect(completed?.style.backgroundColor).toContain('var(--e-session)');
+    expect(completed?.className).toMatch(/bg-primary/);
   });
 
-  it('default entity (no prop) uses --e-game brand color', () => {
+  it('current + completed circles are branded with bg-primary', () => {
     const { container } = render(<StepProgress steps={makeSteps(3)} currentIndex={2} />);
     const completed = container.querySelector(
       '[data-step-status="completed"] [data-step-circle]'
     ) as HTMLElement | null;
-    expect(completed?.style.backgroundColor).toContain('var(--e-game)');
+    expect(completed?.className).toMatch(/bg-primary/);
   });
 
   it('sets role="progressbar" and aria-valuenow reflects currentIndex+1', () => {
@@ -118,14 +117,12 @@ describe('StepProgress', () => {
     expect(bar?.className).toMatch(/custom-xyz/);
   });
 
-  it('handles kb entity mapping to --e-document', () => {
+  it('sets data-entity="kb" on the progressbar root', () => {
     const { container } = render(
       <StepProgress steps={makeSteps(3)} currentIndex={2} entity="kb" />
     );
-    const completed = container.querySelector(
-      '[data-step-status="completed"] [data-step-circle]'
-    ) as HTMLElement | null;
-    expect(completed?.style.backgroundColor).toContain('var(--e-document)');
+    const bar = container.querySelector('[role="progressbar"]');
+    expect(bar).toHaveAttribute('data-entity', 'kb');
   });
 
   it('handles 2 steps (min edge)', () => {

--- a/apps/web/src/components/ui/step-progress/step-progress.tsx
+++ b/apps/web/src/components/ui/step-progress/step-progress.tsx
@@ -1,4 +1,4 @@
-import type { CSSProperties, JSX } from 'react';
+import type { JSX } from 'react';
 
 import clsx from 'clsx';
 
@@ -14,19 +14,6 @@ export type StepEntityKey =
   | 'event'
   | 'toolkit'
   | 'tool';
-
-// Mirror of ENTITY_CSS_VAR_KEY in btn.tsx / entity-tokens.ts — `kb` maps to `document`
-const ENTITY_CSS_VAR_KEY: Record<StepEntityKey, string> = {
-  game: 'game',
-  player: 'player',
-  session: 'session',
-  agent: 'agent',
-  kb: 'document',
-  chat: 'chat',
-  event: 'event',
-  toolkit: 'toolkit',
-  tool: 'tool',
-};
 
 export interface Step {
   readonly label: string;
@@ -55,9 +42,6 @@ export function StepProgress({
   className,
   ariaLabel = 'Progresso',
 }: StepProgressProps): JSX.Element {
-  const varKey = ENTITY_CSS_VAR_KEY[entity];
-  const entityColor = `hsl(var(--e-${varKey}))`;
-
   const statuses: StepStatus[] = steps.map((s, i) => deriveStatus(i, currentIndex, s.status));
 
   return (
@@ -67,6 +51,7 @@ export function StepProgress({
       aria-valuemin={1}
       aria-valuemax={steps.length}
       aria-valuenow={currentIndex + 1}
+      data-entity={entity}
       className={clsx('w-full', className)}
     >
       <ol className="flex items-start justify-between gap-0">
@@ -80,27 +65,13 @@ export function StepProgress({
           const connectorFilled =
             status === 'completed' && (nextStatus === 'completed' || nextStatus === 'current');
 
-          const circleStyle: CSSProperties | undefined =
-            status === 'completed' || status === 'current'
-              ? { backgroundColor: entityColor }
-              : undefined;
-
-          const connectorStyle: CSSProperties | undefined = connectorFilled
-            ? { backgroundColor: entityColor }
-            : undefined;
-
           const circleClasses = clsx(
             'flex h-8 w-8 items-center justify-center rounded-full text-xs font-semibold transition-transform',
-            status === 'completed' && 'text-white',
+            status === 'completed' && 'bg-primary text-primary-foreground',
             status === 'current' &&
-              'text-white ring-2 ring-offset-2 ring-offset-background scale-110',
+              'bg-primary text-primary-foreground ring-2 ring-primary ring-offset-2 ring-offset-background scale-110',
             status === 'pending' && 'bg-muted text-muted-foreground'
           );
-
-          const currentRingStyle: CSSProperties | undefined =
-            status === 'current'
-              ? { ...circleStyle, boxShadow: `0 0 0 2px ${entityColor}` }
-              : circleStyle;
 
           return (
             <li
@@ -110,12 +81,7 @@ export function StepProgress({
               className={clsx('flex flex-col items-center', isLast ? 'flex-none' : 'flex-1')}
             >
               <div className="flex w-full items-center">
-                <div
-                  data-step-circle
-                  className={circleClasses}
-                  style={currentRingStyle}
-                  aria-hidden="true"
-                >
+                <div data-step-circle className={circleClasses} aria-hidden="true">
                   {status === 'completed' ? (
                     <svg
                       xmlns="http://www.w3.org/2000/svg"
@@ -139,9 +105,8 @@ export function StepProgress({
                     data-step-connector-filled={connectorFilled}
                     className={clsx(
                       'mx-2 h-0.5 flex-1 rounded-full',
-                      !connectorFilled && 'bg-muted'
+                      connectorFilled ? 'bg-primary' : 'bg-muted'
                     )}
-                    style={connectorStyle}
                     aria-hidden="true"
                   />
                 )}

--- a/apps/web/src/components/ui/toggle-switch/toggle-switch.test.tsx
+++ b/apps/web/src/components/ui/toggle-switch/toggle-switch.test.tsx
@@ -46,10 +46,10 @@ describe('ToggleSwitch', () => {
     expect(onCheckedChange).not.toHaveBeenCalled();
   });
 
-  it('active state sets backgroundColor inline via entity color', () => {
+  it('active state uses the bg-primary track', () => {
     render(<ToggleSwitch checked onCheckedChange={() => {}} entity="game" ariaLabel="T" />);
     const sw = screen.getByRole('switch');
-    expect(sw.getAttribute('style')).toMatch(/--e-game/);
+    expect(sw.className).toMatch(/bg-primary/);
   });
 
   it('default entity is "game"', () => {
@@ -57,10 +57,10 @@ describe('ToggleSwitch', () => {
     expect(screen.getByRole('switch')).toHaveAttribute('data-entity', 'game');
   });
 
-  it('kb entity maps to --e-document CSS var', () => {
+  it('kb entity sets data-entity="kb"', () => {
     render(<ToggleSwitch checked onCheckedChange={() => {}} entity="kb" ariaLabel="T" />);
     const sw = screen.getByRole('switch');
-    expect(sw.getAttribute('style')).toMatch(/--e-document/);
+    expect(sw).toHaveAttribute('data-entity', 'kb');
   });
 
   it('size "sm" uses smaller track dimensions', () => {

--- a/apps/web/src/components/ui/toggle-switch/toggle-switch.tsx
+++ b/apps/web/src/components/ui/toggle-switch/toggle-switch.tsx
@@ -1,21 +1,8 @@
-import type { CSSProperties, JSX } from 'react';
+import type { JSX } from 'react';
 
 import clsx from 'clsx';
 
 import type { EntityType } from '@/components/ui/entity-tokens';
-
-// Mirror entity-card / btn ENTITY_CSS_VAR_KEY mapping so `kb` resolves to `--c-kb`
-const ENTITY_CSS_VAR_KEY: Record<EntityType, string> = {
-  game: 'game',
-  player: 'player',
-  session: 'session',
-  agent: 'agent',
-  kb: 'document',
-  chat: 'chat',
-  event: 'event',
-  toolkit: 'toolkit',
-  tool: 'tool',
-};
 
 export type ToggleSwitchSize = 'sm' | 'md';
 
@@ -61,16 +48,11 @@ export function ToggleSwitch({
     console.warn('ToggleSwitch: provide `ariaLabel` or `ariaLabelledBy` for accessibility.');
   }
 
-  const cssKey = ENTITY_CSS_VAR_KEY[entity];
-  const entityColor = `hsl(var(--e-${cssKey}))`;
-
-  const trackStyle: CSSProperties = checked ? { backgroundColor: entityColor } : {};
-
   const trackClasses = clsx(
     'relative inline-flex items-center rounded-full transition-colors',
-    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2',
+    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2',
     TRACK_CLASSES[size],
-    !checked && 'bg-muted',
+    checked ? 'bg-primary' : 'bg-muted',
     disabled && 'opacity-50 cursor-not-allowed',
     className
   );
@@ -80,11 +62,6 @@ export function ToggleSwitch({
     THUMB_CLASSES[size],
     checked ? THUMB_TRANSLATE[size] : 'translate-x-0.5'
   );
-
-  const focusRingStyle: CSSProperties = {
-    // via CSS custom property so ring uses entity color
-    ['--tw-ring-color' as string]: entityColor,
-  };
 
   return (
     <button
@@ -98,7 +75,6 @@ export function ToggleSwitch({
       disabled={disabled}
       data-entity={entity}
       className={trackClasses}
-      style={{ ...trackStyle, ...focusRingStyle }}
       onClick={() => {
         if (!disabled) onCheckedChange(!checked);
       }}

--- a/apps/web/src/styles/design-tokens.css
+++ b/apps/web/src/styles/design-tokens.css
@@ -516,15 +516,6 @@
   --mc-nav-footer-bg: rgba(245, 240, 235, 0.28);
   --mc-nav-icon-bg: rgba(255, 255, 255, 0.60);
   --mc-nav-icon-border: rgba(200, 180, 160, 0.30);
-  --e-game-h: 25;    --e-game-s: 95%;    --e-game-l: 45%;
-  --e-player-h: 262;  --e-player-s: 83%;   --e-player-l: 58%;
-  --e-session-h: 240;  --e-session-s: 60%;  --e-session-l: 55%;
-  --e-agent-h: 38;    --e-agent-s: 92%;    --e-agent-l: 50%;
-  --e-kb-h: 210;      --e-kb-s: 40%;       --e-kb-l: 55%;
-  --e-chat-h: 220;    --e-chat-s: 80%;     --e-chat-l: 55%;
-  --e-event-h: 350;   --e-event-s: 89%;    --e-event-l: 60%;
-  --e-toolkit-h: 142;  --e-toolkit-s: 70%;  --e-toolkit-l: 45%;
-  --e-tool-h: 195;    --e-tool-s: 80%;     --e-tool-l: 50%;
   }
 
   /* Dark mode adjustments */


### PR DESCRIPTION
## FU-2 — cleanup-frontend-legacy follow-up

The composite entity tokens `--e-<entity>` (consumed as inline `hsl(var(--e-game))` etc.) were removed from the runtime CSS in #2857, so **every inline entity color was dead** (invalid `var()` → property dropped → `transparent`).

### 🔴 Premise correction (verified empirically)
The original FU-2 plan assumed "remove dead code = zero visual change". A Storybook computed-style check disproved that for a subset: because the dead `--e-*` was the **sole** background source and the className set `text-white` with **no fallback**, these LIVE components rendered **transparent → white text invisible**:

| Element | measured `background-color` (before) |
|---|---|
| `toggle-switch` checked track | `rgba(0,0,0,0)` |
| `step-progress` completed/current circle | `rgba(0,0,0,0)` |
| `step-progress` filled connector | `rgba(0,0,0,0)` |
| `drawer` entity accent | (same, transparent) |
| `notification-card` unread dot | (same, transparent) |

Used on settings, cookie-consent, onboarding, admin rag-wizard, notifications. (Approved disposition: **fix-and-remove with canonical tokens**.)

### Changes
- **Broken accents → canonical `bg-primary` / `text-primary-foreground` / `border-primary`** (uniform brand, no per-entity palette → no design review). AA on both themes by design — the same pairing primary buttons already use.
- **Harmless accents → drop the dead inline (zero visual change)**: `btn`, `entity-card` + `notification-card` left border, `entity-pip` ring (`bg-entity-*` already colors the pip), `settings-row` icon, `entity-table-view` badge (→ neutral `bg-muted`).
- Every entity primitive keeps its `entity` prop and now exposes it as a **`data-entity`** hook (btn + step-progress gained it) — the anchor for restoring per-entity coloring.
- Removed the orphaned split `--e-*-h/s/l` tokens from `design-tokens.css` and the stale `--e-*` mention in `WelcomeHero`'s eslint-disable comment.
- Updated 7 unit-test files that asserted on the dead inline `--e-*` strings.

### Deferred
Per-entity coloring (wiring the **working** `bg-entity-*` utilities via `data-entity`) → **#2955** (needs design review; changes colors across live components).

### Verification
- `pnpm typecheck` ✅ · `pnpm lint` (10 files) ✅ · component tests (9 files / 160) ✅ · consumer tests (settings + onboarding, 29 files / 145) ✅ · pre-push `next build` ✅
- **0** `--e-<entity>` references remain in `src`. (The surviving `var(--e)` single-var `.e-bg` pattern + `--entity-*` / `--c-*` are separate, working mechanisms.)
- Net: **−258 / +74**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)