### PR TITLE
fix(mechanic-extractor): sblocca happy-path E2E (default LLM config-driven + linkage picker↔validator)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/GenerateMechanicAnalysisCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/MechanicExtractor/GenerateMechanicAnalysisCommandHandler.cs
@@ -8,7 +8,9 @@ using Api.Middleware.Exceptions;
 using Api.Services;
 using Api.SharedKernel.Application.Interfaces;
 using Api.SharedKernel.Infrastructure.Persistence;
+using Api.BoundedContexts.SharedGameCatalog.Application.Configuration;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
 
 namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands.MechanicExtractor;
 
@@ -32,9 +34,10 @@ namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands.MechanicExt
 internal sealed class GenerateMechanicAnalysisCommandHandler
     : ICommandHandler<GenerateMechanicAnalysisCommand, MechanicAnalysisGenerationResponseDto>
 {
-    // B4=A: prompts v1 target DeepSeek. These defaults align with ADR-007 routing.
-    private const string DefaultProvider = "DeepSeek";
-    private const string DefaultModel = "deepseek-chat";
+    // #2951: default provider/model are now config-driven via MechanicExtractorLlmOptions
+    // (previously hardcoded consts). This lets an operator switch the default provider without
+    // a redeploy when the wired default is unavailable (e.g. DeepSeek credit exhausted → 402).
+    // Still overridable per-request via ProviderOverride/ModelOverride (#2926).
 
     // Conservative DeepSeek list pricing as of 2026-04 (project_deepseek_llm memory).
     // Runtime cost is captured per-section from the actual LlmCompletionResult, so any drift
@@ -70,6 +73,7 @@ internal sealed class GenerateMechanicAnalysisCommandHandler
     // prompt input. All writes go through repositories + IUnitOfWork.
     private readonly MeepleAiDbContext _dbContext;
     private readonly IMechanicPromptProvider _promptProvider;
+    private readonly MechanicExtractorLlmOptions _llmOptions;
     private readonly IAnalysisCostEstimator _costEstimator;
     private readonly IBackgroundTaskService _backgroundTaskService;
     private readonly IServiceScopeFactory _scopeFactory;
@@ -83,6 +87,7 @@ internal sealed class GenerateMechanicAnalysisCommandHandler
         ISharedGameDocumentRepository documentRepository,
         MeepleAiDbContext dbContext,
         IMechanicPromptProvider promptProvider,
+        IOptions<MechanicExtractorLlmOptions> llmOptions,
         IAnalysisCostEstimator costEstimator,
         IBackgroundTaskService backgroundTaskService,
         IServiceScopeFactory scopeFactory,
@@ -95,6 +100,7 @@ internal sealed class GenerateMechanicAnalysisCommandHandler
         _documentRepository = documentRepository ?? throw new ArgumentNullException(nameof(documentRepository));
         _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
         _promptProvider = promptProvider ?? throw new ArgumentNullException(nameof(promptProvider));
+        _llmOptions = llmOptions?.Value ?? throw new ArgumentNullException(nameof(llmOptions));
         _costEstimator = costEstimator ?? throw new ArgumentNullException(nameof(costEstimator));
         _backgroundTaskService = backgroundTaskService ?? throw new ArgumentNullException(nameof(backgroundTaskService));
         _scopeFactory = scopeFactory ?? throw new ArgumentNullException(nameof(scopeFactory));
@@ -114,10 +120,10 @@ internal sealed class GenerateMechanicAnalysisCommandHandler
         // #539 eval: resolve the effective provider/model. Null override → ADR-007 DeepSeek default.
         // Routing is by model name (ILlmClient.SupportsModel), so the model alone selects the provider.
         var effectiveProvider = string.IsNullOrWhiteSpace(request.ProviderOverride)
-            ? DefaultProvider
+            ? _llmOptions.DefaultProvider
             : request.ProviderOverride.Trim();
         var effectiveModel = string.IsNullOrWhiteSpace(request.ModelOverride)
-            ? DefaultModel
+            ? _llmOptions.DefaultModel
             : request.ModelOverride.Trim();
 
         // 1. SharedGame existence (404 if missing).

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Configuration/MechanicExtractorLlmOptions.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Configuration/MechanicExtractorLlmOptions.cs
@@ -1,0 +1,24 @@
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Configuration;
+
+/// <summary>
+/// Default LLM provider/model for the Mechanic Extractor generation pipeline (ADR-051 / #2951).
+/// Bound from configuration section <see cref="SectionName"/>.
+/// </summary>
+/// <remarks>
+/// Making the default config-driven (instead of a hardcoded <c>const</c>) lets an operator switch
+/// the provider without a redeploy when the wired default is unavailable — e.g. DeepSeek credit
+/// exhausted returns 402 on <c>chat/completions</c>, which the ME path surfaces as a hard abort
+/// (<c>Rejected</c>) with no automatic multi-provider fallback. Routing is by model name
+/// (<c>ILlmClient.SupportsModel</c>), so the model alone selects the provider. The defaults below
+/// preserve the pre-#2951 behaviour when the section is absent.
+/// </remarks>
+public sealed class MechanicExtractorLlmOptions
+{
+    public const string SectionName = "MechanicExtractorLlm";
+
+    /// <summary>Provider label recorded on the analysis (ADR-007 wired default: DeepSeek).</summary>
+    public string DefaultProvider { get; init; } = "DeepSeek";
+
+    /// <summary>Model id used for generation; selects the provider via <c>SupportsModel</c>.</summary>
+    public string DefaultModel { get; init; } = "deepseek-chat";
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/DTOs/MechanicAnalysisStatusDto.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/DTOs/MechanicAnalysisStatusDto.cs
@@ -36,7 +36,7 @@ public sealed record MechanicAnalysisStatusDto(
     int ClaimsCount,
     IReadOnlyList<MechanicSectionRunSummaryDto> SectionRuns,
     // #2807 (ME-FU-1): the "N/M sections produced claims" signal. SectionsWithClaims = number of
-    // distinct sections that yielded >=1 persisted claim; TotalSections = total expected (6).
+    // distinct sections that yielded >=1 persisted claim; TotalSections = total expected (9).
     // SectionsWithClaims < TotalSections means at least one section was dropped (e.g. failed the
     // well_formed check across all retries) and is silently absent from the review queue.
     int SectionsWithClaims,

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Repositories/ISharedGameDocumentRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Repositories/ISharedGameDocumentRepository.cs
@@ -86,8 +86,11 @@ public interface ISharedGameDocumentRepository
     Task<int> CountByUserAsync(Guid userId, CancellationToken cancellationToken = default);
 
     /// <summary>
-    /// Checks whether a specific PDF is linked to a shared game (any document type / any version).
-    /// Used by ISSUE-524 / M1.2 mechanic extractor handler to validate the (game, pdf) pair
+    /// Checks whether a specific PDF is linked to a shared game, accepting EITHER linkage source:
+    /// a curated <c>shared_game_documents</c> row (any document type / any version) OR the
+    /// denormalized <c>pdf_documents.shared_game_id</c> FK set by the standard <c>/ingest/pdf</c>
+    /// upload (#2952). Used by ISSUE-524 / M1.2 mechanic extractor handler to validate the
+    /// (game, pdf) pair — consistently with the picker, which lists by <c>shared_game_id</c> —
     /// without leaking <c>SharedGameDocument</c> entity projections into the command handler.
     /// </summary>
     Task<bool> IsPdfLinkedToGameAsync(

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs
@@ -44,6 +44,12 @@ internal static class SharedGameCatalogServiceExtensions
         services.Configure<MechanicGuardrailOptions>(
             configuration.GetSection(MechanicGuardrailOptions.SectionName));
 
+        // #2951: Mechanic Extractor default LLM provider/model — config-driven so the wired
+        // default (DeepSeek) can be overridden per-environment without a redeploy when it is
+        // unavailable (e.g. credit exhausted → 402). Routing is by model name (ADR-007).
+        services.Configure<MechanicExtractorLlmOptions>(
+            configuration.GetSection(MechanicExtractorLlmOptions.SectionName));
+
 
         // Register repositories
         services.AddScoped<ISharedGameRepository, SharedGameRepository>();

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/SharedGameDocumentRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Repositories/SharedGameDocumentRepository.cs
@@ -214,10 +214,29 @@ internal sealed class SharedGameDocumentRepository : RepositoryBase, ISharedGame
         Guid pdfDocumentId,
         CancellationToken cancellationToken = default)
     {
-        return await DbContext.SharedGameDocuments
+        // A PDF is linked to a game via EITHER the curated shared_game_documents join
+        // (created by the admin link / RAG wizard / import paths, carrying type/version/
+        // approval) OR the denormalized pdf_documents.shared_game_id FK set by the standard
+        // /ingest/pdf upload (#2952). The standard upload does not create a join row, so the
+        // mechanic-extractor picker — which lists PDFs by pdf_documents.shared_game_id — would
+        // otherwise offer PDFs this validator rejects with a 404. Accept both linkage sources
+        // so the picker and the validator agree on which (game, pdf) pairs are valid.
+        var linkedViaJoin = await DbContext.SharedGameDocuments
             .AsNoTracking()
             .AnyAsync(
                 d => d.SharedGameId == sharedGameId && d.PdfDocumentId == pdfDocumentId,
+                cancellationToken)
+            .ConfigureAwait(false);
+
+        if (linkedViaJoin)
+        {
+            return true;
+        }
+
+        return await DbContext.PdfDocuments
+            .AsNoTracking()
+            .AnyAsync(
+                p => p.Id == pdfDocumentId && p.SharedGameId == sharedGameId,
                 cancellationToken)
             .ConfigureAwait(false);
     }

--- a/apps/api/src/Api/appsettings.json
+++ b/apps/api/src/Api/appsettings.json
@@ -364,6 +364,11 @@
       "SuccessThreshold": 2
     }
   },
+  "MechanicExtractorLlm": {
+    "Comment": "#2951: default provider/model for the Mechanic Extractor pipeline. Override DefaultModel to switch provider without a redeploy (routing is by model name via ILlmClient.SupportsModel). Wired default: DeepSeek.",
+    "DefaultProvider": "DeepSeek",
+    "DefaultModel": "deepseek-chat"
+  },
   "HybridSearch": {
     "VectorWeight": 0.7,
     "KeywordWeight": 0.3,

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/MechanicAnalysisEndpointsIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/MechanicAnalysisEndpointsIntegrationTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Net.Http.Json;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Api.BoundedContexts.SharedGameCatalog.Application.Configuration;
 using Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
 using Api.Infrastructure;
@@ -16,6 +17,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Moq;
@@ -43,6 +45,7 @@ public sealed class MechanicAnalysisEndpointsIntegrationTests : IAsyncLifetime
 
     private readonly SharedTestcontainersFixture _fixture;
     private readonly string _testDbName;
+    private string _connectionString = null!;
     private WebApplicationFactory<Program> _factory = null!;
     private HttpClient _client = null!;
     private string _adminSessionToken = null!;
@@ -65,6 +68,7 @@ public sealed class MechanicAnalysisEndpointsIntegrationTests : IAsyncLifetime
     public async ValueTask InitializeAsync()
     {
         var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_testDbName);
+        _connectionString = connectionString;
 
         _backgroundTaskMock = new Mock<IBackgroundTaskService>();
         // Default: swallow background enqueue so the executor never runs under test.
@@ -184,20 +188,101 @@ public sealed class MechanicAnalysisEndpointsIntegrationTests : IAsyncLifetime
     [Fact]
     public async Task Generate_PdfNotLinkedToGame_Returns404()
     {
-        // Arrange — SharedGame exists, PDF exists, but no SharedGameDocument row linking them.
-        // The PDF still needs a valid SharedGameId FK (post-Phase 2d); the "not linked"
-        // condition under test is the absence of the SharedGameDocument approval row,
-        // not a dangling PdfDocument.SharedGameId.
-        var sharedGameId = await SeedSharedGameAsync();
-        var pdfDocumentId = await SeedPdfDocumentAsync(chunkCount: 3, sharedGameId);
+        // Arrange — the PDF's shared_game_id points to a DIFFERENT game and there is no
+        // shared_game_documents row linking it to the target game. #2952: linkage now also
+        // accepts pdf_documents.shared_game_id, so "not linked" means NEITHER source matches
+        // the target game — a PDF merely owned by another game must still 404 for this game.
+        var targetGameId = await SeedSharedGameAsync();
+        var otherGameId = await SeedSharedGameAsync();
+        var pdfDocumentId = await SeedPdfDocumentAsync(chunkCount: 3, otherGameId);
 
-        var body = new GenerateBody(sharedGameId, pdfDocumentId, CostCapUsd: 1.00m);
+        var body = new GenerateBody(targetGameId, pdfDocumentId, CostCapUsd: 1.00m);
 
         // Act
         var response = await SendGenerateAsync(body);
 
         // Assert
         response.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact]
+    public async Task Generate_PdfLinkedOnlyViaSharedGameIdFk_Returns202()
+    {
+        // Arrange — the standard /ingest/pdf upload sets pdf_documents.shared_game_id but does
+        // NOT create a shared_game_documents row (#2952). The mechanic-extractor picker lists
+        // such PDFs by the FK, so Generate must accept them. Seed a PDF + chunks linked ONLY via
+        // the FK (deliberately skip SeedSharedGameDocumentLinkAsync).
+        var sharedGameId = await SeedSharedGameAsync();
+        var pdfDocumentId = await SeedPdfDocumentAsync(chunkCount: 4, sharedGameId);
+
+        var body = new GenerateBody(sharedGameId, pdfDocumentId, CostCapUsd: 1.00m);
+
+        // Act
+        var response = await SendGenerateAsync(body);
+
+        // Assert — pre-#2952 this returned 404 (validator checked only shared_game_documents);
+        // now it is accepted because the PDF is linked via pdf_documents.shared_game_id.
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+
+        _backgroundTaskMock.Verify(
+            b => b.ExecuteWithCancellation(It.IsAny<string>(), It.IsAny<Func<CancellationToken, Task>>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Generate_HonoursConfiguredDefaultLlmProvider()
+    {
+        // Arrange — the default provider/model is config-driven (#2951). Wire a NON-default
+        // provider via the MechanicExtractorLlm section, then assert the created analysis records
+        // it. This proves the handler reads MechanicExtractorLlmOptions rather than a hardcoded
+        // const — the override differs from the wired DeepSeek default. The section uses init-only
+        // properties, so it must be supplied through configuration (not a post-configure delegate).
+        const string overrideProvider = "OpenRouter";
+        const string overrideModel = "meta-llama/llama-3.3-70b-instruct";
+
+        var (sharedGameId, pdfDocumentId) = await SeedHappyPathAsync(chunkCount: 4);
+
+        using var configuredFactory = IntegrationWebApplicationFactory
+            .Create(_connectionString)
+            .WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureAppConfiguration((_, config) =>
+                {
+                    config.AddInMemoryCollection(new Dictionary<string, string?>
+                    {
+                        [$"{MechanicExtractorLlmOptions.SectionName}:DefaultProvider"] = overrideProvider,
+                        [$"{MechanicExtractorLlmOptions.SectionName}:DefaultModel"] = overrideModel,
+                    });
+                });
+                builder.ConfigureTestServices(services =>
+                {
+                    services.RemoveAll<IBackgroundTaskService>();
+                    services.AddSingleton<IBackgroundTaskService>(_backgroundTaskMock.Object);
+                });
+            });
+        using var configuredClient = configuredFactory.CreateClient();
+
+        var body = new GenerateBody(sharedGameId, pdfDocumentId, CostCapUsd: 1.00m);
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Post, EndpointBase, _adminSessionToken, body);
+
+        // Act
+        var response = await configuredClient.SendAsync(request);
+
+        // Assert
+        response.StatusCode.Should().Be(HttpStatusCode.Accepted);
+        var dto = await response.Content.ReadFromJsonAsync<MechanicAnalysisGenerationResponseDto>(JsonOptions);
+        dto.Should().NotBeNull();
+
+        using var scope = configuredFactory.Services.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var analysis = await dbContext.Set<MechanicAnalysisEntity>()
+            .AsNoTracking()
+            .FirstOrDefaultAsync(a => a.Id == dto!.Id);
+
+        analysis.Should().NotBeNull();
+        analysis!.Provider.Should().Be(overrideProvider);
+        analysis.ModelUsed.Should().Be(overrideModel);
     }
 
     // ────────────────────────────────────────────────────────────────────────
@@ -396,9 +481,11 @@ public sealed class MechanicAnalysisEndpointsIntegrationTests : IAsyncLifetime
         dto.IsSuppressed.Should().BeFalse();
         // Background executor is mocked → no section runs recorded yet.
         dto.SectionRuns.Should().BeEmpty();
-        // #2807: N/M sections-with-claims signal — no claims produced yet → 0 of 6.
+        // #2807: N/M sections-with-claims signal — no claims produced yet → 0 of 9.
+        // TotalSections = Enum.GetValues<MechanicSection>().Length; the enum grew 6→9 with
+        // Setup/Components/EndgameScoring, so this expectation was stale (already red on main-dev).
         dto.SectionsWithClaims.Should().Be(0);
-        dto.TotalSections.Should().Be(6);
+        dto.TotalSections.Should().Be(9);
     }
 
     [Fact]

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/SharedGameDocumentRepositoryIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/SharedGameDocumentRepositoryIntegrationTests.cs
@@ -227,6 +227,91 @@ public sealed class SharedGameDocumentRepositoryIntegrationTests : IAsyncLifetim
 
     #endregion
 
+    #region IsPdfLinkedToGameAsync Tests
+
+    [Fact]
+    public async Task IsPdfLinkedToGameAsync_WhenLinkedViaSharedGameDocument_ReturnsTrue()
+    {
+        // Arrange: a curated shared_game_documents join row (admin link / wizard / import path).
+        var game = await CreateTestGameAsync();
+        var pdfDoc = await CreateTestPdfDocumentAsync(game.Id);
+        var joinRow = SharedGameDocument.Create(
+            game.Id,
+            pdfDoc.Id,
+            SharedGameDocumentType.Rulebook,
+            "1.0",
+            _testUserId);
+        await _repository.AddAsync(joinRow);
+        await _dbContext.SaveChangesAsync();
+
+        // Act
+        var linked = await _repository.IsPdfLinkedToGameAsync(game.Id, pdfDoc.Id);
+
+        // Assert
+        linked.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task IsPdfLinkedToGameAsync_WhenLinkedOnlyViaPdfSharedGameId_ReturnsTrue()
+    {
+        // Arrange: the standard /ingest/pdf upload sets pdf_documents.shared_game_id but does
+        // NOT create a shared_game_documents row (#2952). The mechanic-extractor picker lists
+        // PDFs by this FK, so the Generate validator must accept the same linkage source —
+        // otherwise the picker offers a PDF the validator rejects with 404.
+        var game = await CreateTestGameAsync();
+        var pdfDoc = await CreateTestPdfDocumentAsync(game.Id); // sets SharedGameId, no join row
+
+        // Act
+        var linked = await _repository.IsPdfLinkedToGameAsync(game.Id, pdfDoc.Id);
+
+        // Assert
+        linked.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task IsPdfLinkedToGameAsync_WhenPdfBelongsToDifferentGame_ReturnsFalse()
+    {
+        // Arrange: the PDF's shared_game_id points to game2; a query for game1 must not match
+        // (guards the OR fallback against over-matching any PDF with a shared_game_id).
+        var game1 = await CreateTestGameAsync();
+        var game2 = await CreateTestGameAsync();
+        var pdfDoc = await CreateTestPdfDocumentAsync(game2.Id);
+
+        // Act
+        var linked = await _repository.IsPdfLinkedToGameAsync(game1.Id, pdfDoc.Id);
+
+        // Assert
+        linked.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task IsPdfLinkedToGameAsync_WhenPdfHasNoSharedGame_ReturnsFalse()
+    {
+        // Arrange: a PDF with no shared_game_id and no join row (e.g. a private-game upload).
+        var game = await CreateTestGameAsync();
+        var orphanPdf = new PdfDocumentEntity
+        {
+            Id = Guid.NewGuid(),
+            SharedGameId = null,
+            FileName = $"orphan_{Guid.NewGuid():N}.pdf",
+            FilePath = "/test/orphan.pdf",
+            FileSizeBytes = 1024,
+            ContentType = "application/pdf",
+            UploadedByUserId = _testUserId,
+            UploadedAt = DateTime.UtcNow,
+        };
+        _dbContext.PdfDocuments.Add(orphanPdf);
+        await _dbContext.SaveChangesAsync();
+
+        // Act
+        var linked = await _repository.IsPdfLinkedToGameAsync(game.Id, orphanPdf.Id);
+
+        // Assert
+        linked.Should().BeFalse();
+    }
+
+    #endregion
+
     #region Helper Methods
 
     private async Task<SharedGame> CreateTestGameAsync()


### PR DESCRIPTION
## Cosa

Due fix che sbloccano l'**happy-path end-to-end** del Mechanic Extractor, emersi dal test E2E della pipeline AI-first (ADR-051). Prima di questi, un admin non riusciva a completare il flusso senza interventi manuali (config o DB).

## Fix 1 — Default LLM provider/model config-driven (#2951)

Il default era un `const` C# (`GenerateMechanicAnalysisCommandHandler.cs`). Col credito DeepSeek esaurito, il percorso ME (single-shot per nome-modello, senza fallback) restituiva 402 → analisi `Rejected`, rendendo la pipeline **dead-on-arrival**. Cambiare provider richiedeva ricompilare.

- Nuova options class `MechanicExtractorLlmOptions` (sezione `MechanicExtractorLlm`, `init` props, default retro-compat `DeepSeek`/`deepseek-chat`), sul modello di `MechanicGuardrailOptions`.
- Bind in `SharedGameCatalogServiceExtensions` + sezione in `appsettings.json`.
- Handler: inietta `IOptions<MechanicExtractorLlmOptions>`, rimpiazza i `const`. Override per-richiesta (`ProviderOverride`/`ModelOverride`) invariato.

→ Ora si passa a un modello OpenRouter cambiando la config, **senza redeploy**.

## Fix 2 — Linkage picker↔validator (#2952)

Il picker della form ME elenca i PDF via `pdf_documents.shared_game_id`, mentre il validator del Generate verificava solo `shared_game_documents`. L'upload standard `/ingest/pdf` popola solo la prima → il PDF appariva nel picker ma il Generate rispondeva **404 `SharedGameDocument`**.

- `IsPdfLinkedToGameAsync` (unico consumer: il handler ME) ora ritorna `true` se esiste una riga `shared_game_documents` **OPPURE** `pdf_documents.shared_game_id == sharedGameId`.
- Blast radius = 1 call site, **zero migration**, coerenza picker↔validator, nessuna perdita semantica (è un check di esistenza).

## Test

- `SharedGameDocumentRepositoryIntegrationTests` (+4): linked-via-join / linked-via-fk-only / different-game / no-shared-game (Testcontainers).
- `MechanicAnalysisEndpointsIntegrationTests`:
  - aggiornato `Generate_PdfNotLinkedToGame_Returns404` → ora usa un PDF di **altro** gioco (il fix cambia la semantica del 404).
  - nuovo `Generate_PdfLinkedOnlyViaSharedGameIdFk_Returns202` (fix 2 end-to-end).
  - nuovo `Generate_HonoursConfiguredDefaultLlmProvider` (fix 1: override config → provider/model registrati sull'analisi).

## Fuori scope (follow-up informato)

**Fallback automatico multi-provider** per il percorso ME: richiede toccare la pipeline async + il cost/provider recording per-sezione (il modello è deciso e persistito a livello di analisi), con imprecisione sull'osservabilità (metrics aggregano per modello). L'health-check attuale è inoltre cieco al 402 (ping `GET /models`), quindi non esiste una variante pre-flight affidabile. Il config-driven default sblocca già l'happy-path senza redeploy; il fallback automatico resta tracciato nell'issue 2951 come step separato con la valutazione del rischio.

Chiude #2951 e #2952. Contesto: epic Mechanic Extractor (539) + finding minori (issue 2953) e prerequisiti operativi (issue 2954).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
