### PR TITLE
fix(catalog): convenzione R2 cover deterministica (BGG L2.5 + Backfill L4 + pipeline) (#2947)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/EventHandlers/PdfDeletedEventHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/EventHandlers/PdfDeletedEventHandler.cs
@@ -37,34 +37,36 @@ internal sealed class PdfDeletedEventHandler : INotificationHandler<PdfDeletedDo
             return;
         }
 
-        var resourceKey = notification.CoverR2Key;
-
-        // Mirror of PdfProcessingPipelineService upload pattern (linee 539-549):
-        // resourceKey = "pdf-cover-{id}", fileId = "thumb.webp" | "preview.webp",
-        // category = GameImage → S3 prefix "game-images/{resourceKey}/{fileId}_".
-        await TryDeleteAsync("thumb.webp", resourceKey, notification.PdfDocumentId, cancellationToken).ConfigureAwait(false);
-        await TryDeleteAsync("preview.webp", resourceKey, notification.PdfDocumentId, cancellationToken).ConfigureAwait(false);
+        // Issue #2947: CoverR2Key is now the deterministic, un-suffixed key
+        // ("covers/pdf/{id:D}/cover") written by PdfProcessingPipelineService /
+        // BackfillPdfCoversJob. The ONLY physical object is the preview variant
+        // ("{key}-preview.webp") — there is no separate thumb object anymore.
+        // The categorized DeleteAsync cannot be used because it runs
+        // PathSecurity.ValidateIdentifier, which rejects '/' and '.'; delete via
+        // the raw-key primitive instead (mirrors CoverUrlResolver's raw-key reads).
+        var rawKey = $"{notification.CoverR2Key}-preview.webp";
+        await TryDeleteRawKeyAsync(rawKey, notification.PdfDocumentId, cancellationToken).ConfigureAwait(false);
     }
 
-    private async Task TryDeleteAsync(string fileId, string resourceKey, Guid pdfDocumentId, CancellationToken cancellationToken)
+    private async Task TryDeleteRawKeyAsync(string rawKey, Guid pdfDocumentId, CancellationToken cancellationToken)
     {
         try
         {
             var deleted = await _blobStorage
-                .DeleteAsync(fileId, BlobCategory.GameImage, resourceKey, cancellationToken)
+                .DeleteRawKeyAsync(rawKey, cancellationToken)
                 .ConfigureAwait(false);
 
             if (deleted)
             {
                 _logger.LogInformation(
-                    "Evicted cover blob {FileId} for PDF {PdfDocumentId} (resourceKey={ResourceKey}).",
-                    fileId, pdfDocumentId, resourceKey);
+                    "Evicted cover blob for PDF {PdfDocumentId} (rawKey={RawKey}).",
+                    pdfDocumentId, rawKey);
             }
             else
             {
                 _logger.LogDebug(
-                    "Cover blob {FileId} for PDF {PdfDocumentId} was not present (resourceKey={ResourceKey}).",
-                    fileId, pdfDocumentId, resourceKey);
+                    "Cover blob for PDF {PdfDocumentId} was not present (rawKey={RawKey}).",
+                    pdfDocumentId, rawKey);
             }
         }
         catch (OperationCanceledException)
@@ -81,8 +83,8 @@ internal sealed class PdfDeletedEventHandler : INotificationHandler<PdfDeletedDo
 #pragma warning restore CA1031
         {
             _logger.LogWarning(ex,
-                "Failed to delete cover blob {FileId} for PDF {PdfDocumentId} (resourceKey={ResourceKey}); leaving orphan.",
-                fileId, pdfDocumentId, resourceKey);
+                "Failed to delete cover blob for PDF {PdfDocumentId} (rawKey={RawKey}); leaving orphan.",
+                pdfDocumentId, rawKey);
         }
     }
 }

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Jobs/BackfillPdfCoversJob.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Jobs/BackfillPdfCoversJob.cs
@@ -67,9 +67,10 @@ public sealed class BackfillPdfCoversJob : IJob
         var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
         var extractor = scope.ServiceProvider.GetRequiredService<IPdfCoverExtractor>();
         var blob = scope.ServiceProvider.GetRequiredService<IBlobStorageService>();
+        var coverUploadPipeline = scope.ServiceProvider.GetRequiredService<IPdfCoverUploadPipeline>();
         var eventCollector = scope.ServiceProvider.GetService<IDomainEventCollector>();
 
-        await RunBatchAsync(db, extractor, blob, eventCollector, ct).ConfigureAwait(false);
+        await RunBatchAsync(db, extractor, blob, coverUploadPipeline, eventCollector, ct).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -80,6 +81,7 @@ public sealed class BackfillPdfCoversJob : IJob
         MeepleAiDbContext db,
         IPdfCoverExtractor extractor,
         IBlobStorageService blob,
+        IPdfCoverUploadPipeline coverUploadPipeline,
         IDomainEventCollector? eventCollector,
         CancellationToken ct)
     {
@@ -109,7 +111,7 @@ public sealed class BackfillPdfCoversJob : IJob
         {
             ct.ThrowIfCancellationRequested();
             var pdf = batch[i];
-            await ProcessOneAsync(pdf, db, extractor, blob, eventCollector, ct).ConfigureAwait(false);
+            await ProcessOneAsync(pdf, db, extractor, blob, coverUploadPipeline, eventCollector, ct).ConfigureAwait(false);
 
             if (i < batch.Count - 1)
             {
@@ -123,6 +125,7 @@ public sealed class BackfillPdfCoversJob : IJob
         MeepleAiDbContext db,
         IPdfCoverExtractor extractor,
         IBlobStorageService blob,
+        IPdfCoverUploadPipeline coverUploadPipeline,
         IDomainEventCollector? eventCollector,
         CancellationToken ct)
     {
@@ -146,20 +149,17 @@ public sealed class BackfillPdfCoversJob : IJob
             {
                 case PdfCoverExtractionOutcome.Generated:
                     {
-                        var resourceKey = $"pdf-cover-{pdf.Id}";
+                        // Issue #2947: deterministic DB key; the pipeline writes the
+                        // physical R2 object "{dbKey}-preview.webp" that the resolver
+                        // reconstructs. Only the preview size is uploaded (the
+                        // resolver never reads the thumbnail size).
+                        var dbKey = $"covers/pdf/{pdf.Id:D}/cover";
 
-                        using (var thumbStream = new MemoryStream(result.ThumbnailWebp!, writable: false))
-                        {
-                            await blob.StoreAsync(thumbStream, "thumb.webp", BlobCategory.GameImage, resourceKey, ct)
-                                .ConfigureAwait(false);
-                        }
-                        using (var previewStream = new MemoryStream(result.PreviewWebp!, writable: false))
-                        {
-                            await blob.StoreAsync(previewStream, "preview.webp", BlobCategory.GameImage, resourceKey, ct)
-                                .ConfigureAwait(false);
-                        }
+                        var persistedKey = await coverUploadPipeline
+                            .UploadAsync(dbKey, result.PreviewWebp!, ct)
+                            .ConfigureAwait(false);
 
-                        pdf.CoverR2Key = resourceKey;
+                        pdf.CoverR2Key = persistedKey;
                         pdf.CoverGenerationStatus = nameof(PdfCoverGenerationStatus.Generated);
                         pdf.CoverPageIndex = result.SelectedPageIndex;
                         pdf.CoverGenerationError = null;
@@ -167,12 +167,12 @@ public sealed class BackfillPdfCoversJob : IJob
                         eventCollector?.Collect(new PdfCoverGeneratedEvent(
                             pdfDocumentId: pdf.Id,
                             sharedGameId: pdf.SharedGameId,
-                            coverR2Key: resourceKey,
+                            coverR2Key: persistedKey,
                             coverPageIndex: result.SelectedPageIndex ?? 0));
 
                         _logger.LogInformation(
-                            "BackfillPdfCoversJob: cover generated for PDF {PdfId} from page {PageIndex}",
-                            pdf.Id, result.SelectedPageIndex);
+                            "BackfillPdfCoversJob: cover generated for PDF {PdfId} from page {PageIndex} (dbKey={DbKey})",
+                            pdf.Id, result.SelectedPageIndex, persistedKey);
                         break;
                     }
                 case PdfCoverExtractionOutcome.Skipped:
@@ -206,20 +206,18 @@ public sealed class BackfillPdfCoversJob : IJob
         catch (Exception ex)
 #pragma warning restore CA1031
         {
-            // Operator-recovery hint: when StoreAsync succeeded for one or both
-            // sizes BUT the subsequent SaveChangesAsync threw (transient DB
-            // error, RowVersion conflict, etc.), R2 will contain orphan
-            // thumb.webp / preview.webp under "game-images/pdf-cover-{Id}/".
-            // The entity ends up Failed without a CoverR2Key so
-            // PdfDeletedEventHandler can't reach them. We embed the prospective
-            // resourceKey in CoverGenerationError so operators can grep the bucket.
-            var resourceKey = $"pdf-cover-{pdf.Id}";
+            // Operator-recovery hint: when UploadAsync succeeded BUT the subsequent
+            // SaveChangesAsync threw (transient DB error, RowVersion conflict, etc.),
+            // R2 will contain an orphan preview under the deterministic key. The
+            // entity ends up Failed without a CoverR2Key so cleanup can't reach it.
+            // Embed the prospective physical key so operators can grep the bucket.
+            var orphanPhysicalKey = $"covers/pdf/{pdf.Id:D}/cover-preview.webp";
             _logger.LogWarning(ex,
                 "BackfillPdfCoversJob: unexpected error processing PDF {PdfId}; marking Failed. " +
-                "Inspect R2 prefix game-images/{ResourceKey}/ for orphan blobs and clean up manually if present.",
-                pdf.Id, resourceKey);
+                "Inspect R2 key {OrphanKey} for an orphan preview blob and clean up manually if present.",
+                pdf.Id, orphanPhysicalKey);
             pdf.CoverGenerationStatus = nameof(PdfCoverGenerationStatus.Failed);
-            var detail = ex.GetType().Name + ": orphan-check-key=" + resourceKey;
+            var detail = ex.GetType().Name + ": orphan-check-key=" + orphanPhysicalKey;
             pdf.CoverGenerationError = detail.Length > 500 ? detail[..500] : detail;
             try
             {

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Jobs/PdfCoverOrphanRecoveryJob.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Jobs/PdfCoverOrphanRecoveryJob.cs
@@ -21,10 +21,16 @@ namespace Api.BoundedContexts.DocumentProcessing.Application.Jobs;
 /// "Failed is terminal today, manual reset". This job automates the
 /// orphan-detection loop without requiring operator intervention.</para>
 /// <para>Daily cadence (03:00 UTC) because orphans are rare. The HEAD check
-/// via <see cref="IBlobStorageService.ExistsAsync"/> is cheap, but bounded by
-/// <see cref="BatchSize"/> = 50 per run to avoid runaway scans on very large
-/// catalogs. The inter-item sleep of <see cref="DelayBetweenItemsMs"/> = 1000ms
+/// via <see cref="IBlobStorageService.GetPresignedUrlForRawKeyAsync"/> is cheap,
+/// but bounded by <see cref="BatchSize"/> = 50 per run to avoid runaway scans on
+/// very large catalogs. The inter-item sleep of <see cref="DelayBetweenItemsMs"/> = 1000ms
 /// keeps the blob storage call rate at ~1 RPS.</para>
+/// <para>Issue #2947 fix: the PDF cover R2 key convention became a deterministic,
+/// slash-containing key (<c>covers/pdf/{pdfId:D}/cover</c>), which the categorized
+/// <see cref="IBlobStorageService.ExistsAsync"/> cannot check — it runs
+/// <c>PathSecurity.ValidateIdentifier</c>, which rejects <c>/</c> and <c>.</c>, so it
+/// always returned false and the job reset every valid cover. The existence
+/// check now mirrors <c>CoverUrlResolver</c> and uses the raw-key primitive.</para>
 /// </remarks>
 [DisallowConcurrentExecution]
 public sealed class PdfCoverOrphanRecoveryJob : IJob
@@ -107,14 +113,13 @@ public sealed class PdfCoverOrphanRecoveryJob : IJob
 
             try
             {
-                // Check for the preview variant as the canonical existence signal.
-                // If preview is missing, thumb is likely gone too — reset for full re-generation.
-                var previewFileId = $"{pdf.CoverR2Key}-preview.webp";
-                var exists = await blob.ExistsAsync(
-                    previewFileId,
-                    BlobCategory.GameImage,
-                    pdf.CoverR2Key!,
-                    ct).ConfigureAwait(false);
+                // Check for the preview variant as the canonical existence signal,
+                // via the RAW-KEY primitive (mirrors CoverUrlResolver): CoverR2Key
+                // is a deterministic key containing '/' (e.g. "covers/pdf/{id:D}/cover"),
+                // which the categorized ExistsAsync cannot validate/resolve.
+                var previewRawKey = $"{pdf.CoverR2Key}-preview.webp";
+                var exists = await blob.GetPresignedUrlForRawKeyAsync(previewRawKey)
+                    .ConfigureAwait(false) is not null;
 
                 if (!exists)
                 {

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs
@@ -56,6 +56,11 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
     // Nullable so pre-#1852 test constructors compile without adding a new mock param.
     private readonly IDomainEventCollector? _eventCollector;
 
+    // Issue #2947: deterministic R2 cover writes. Optional so pre-#2947 unit-test
+    // constructors compile; when null, cover generation is skipped like when
+    // _pdfCoverExtractor is null.
+    private readonly IPdfCoverUploadPipeline? _pdfCoverUploadPipeline;
+
     private readonly IPdfIndexingPipeline _indexingPipeline;
 
     public PdfProcessingPipelineService(
@@ -77,7 +82,8 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
         IFeatureFlagService? featureFlagService = null,
         IRoleClassifierService? roleClassifier = null,
         IPdfCoverExtractor? pdfCoverExtractor = null,
-        IDomainEventCollector? eventCollector = null)
+        IDomainEventCollector? eventCollector = null,
+        IPdfCoverUploadPipeline? pdfCoverUploadPipeline = null)
     {
         _db = db ?? throw new ArgumentNullException(nameof(db));
         _pdfClaimService = pdfClaimService ?? throw new ArgumentNullException(nameof(pdfClaimService));
@@ -101,6 +107,7 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
         // to compile without updating every mock site. The Collect() call
         // in ExtractCoverImageAsync is guarded with a null-check.
         _eventCollector = eventCollector;
+        _pdfCoverUploadPipeline = pdfCoverUploadPipeline;
     }
 
     public async Task ProcessAsync(
@@ -519,9 +526,9 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
         string filePath,
         CancellationToken cancellationToken)
     {
-        if (_pdfCoverExtractor is null)
+        if (_pdfCoverExtractor is null || _pdfCoverUploadPipeline is null)
         {
-            // Service not registered (unit-test scenarios) — leave default Pending.
+            // Cover services not registered (unit-test scenarios) — leave default Pending.
             return;
         }
 
@@ -539,43 +546,32 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
             {
                 case PdfCoverExtractionOutcome.Generated:
                     {
-                        var resourceKey = $"pdf-cover-{pdfDoc.Id}";
+                        // Issue #2947: deterministic DB key; the pipeline writes the
+                        // physical R2 object "{dbKey}-preview.webp" that the resolver
+                        // reconstructs. Only the preview size is uploaded (the
+                        // resolver never reads the thumbnail size).
+                        var dbKey = $"covers/pdf/{pdfDoc.Id:D}/cover";
 
-                        // Upload thumb + preview as separate blobs. The CoverR2Key
-                        // we persist is the resourceKey prefix — the resolver
-                        // endpoint reconstructs `{prefix}/{size}.webp` at read time.
-                        using (var thumbStream = new MemoryStream(result.ThumbnailWebp!, writable: false))
-                        {
-                            await _blobStorageService.StoreAsync(
-                                thumbStream, "thumb.webp", BlobCategory.GameImage, resourceKey, cancellationToken)
-                                .ConfigureAwait(false);
-                        }
-                        using (var previewStream = new MemoryStream(result.PreviewWebp!, writable: false))
-                        {
-                            await _blobStorageService.StoreAsync(
-                                previewStream, "preview.webp", BlobCategory.GameImage, resourceKey, cancellationToken)
-                                .ConfigureAwait(false);
-                        }
+                        var persistedKey = await _pdfCoverUploadPipeline
+                            .UploadAsync(dbKey, result.PreviewWebp!, cancellationToken)
+                            .ConfigureAwait(false);
 
-                        pdfDoc.CoverR2Key = resourceKey;
+                        pdfDoc.CoverR2Key = persistedKey;
                         pdfDoc.CoverGenerationStatus = "Generated";
                         pdfDoc.CoverPageIndex = result.SelectedPageIndex;
                         pdfDoc.CoverGenerationError = null;
 
                         // Issue #1852 (Gap A): raise the propagation event so
                         // PdfCoverGeneratedEventHandler can populate SharedGame.PdfCoverR2Key.
-                        // Dispatched by MeepleAiDbContext.SaveChangesAsync (~line 154) after
-                        // the pipeline transitions to Chunking. Guard is present so existing
-                        // test constructors that omit eventCollector keep working.
                         _eventCollector?.Collect(new PdfCoverGeneratedEvent(
                             pdfDocumentId: pdfDoc.Id,
                             sharedGameId: pdfDoc.SharedGameId,
-                            coverR2Key: resourceKey,
+                            coverR2Key: persistedKey,
                             coverPageIndex: result.SelectedPageIndex ?? 0));
 
                         _logger.LogInformation(
-                            "[PdfPipeline] Cover image generated for PDF {PdfId} from page {PageIndex} (resourceKey={ResourceKey})",
-                            pdfDoc.Id, result.SelectedPageIndex, resourceKey);
+                            "[PdfPipeline] Cover image generated for PDF {PdfId} from page {PageIndex} (dbKey={DbKey})",
+                            pdfDoc.Id, result.SelectedPageIndex, persistedKey);
                         break;
                     }
                 case PdfCoverExtractionOutcome.Skipped:
@@ -1072,4 +1068,14 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
         }
 #pragma warning restore CA1031
     }
+
+    /// <summary>
+    /// Issue #2947 test seam: exposes <see cref="ExtractCoverImageAsync"/> to the
+    /// unit-test assembly (InternalsVisibleTo Api.Tests) so the deterministic
+    /// cover-key behaviour can be asserted directly without driving the full
+    /// ProcessAsync pipeline.
+    /// </summary>
+    internal Task InvokeExtractCoverImageForTestAsync(
+        PdfDocumentEntity pdfDoc, string filePath, CancellationToken cancellationToken)
+        => ExtractCoverImageAsync(pdfDoc, filePath, cancellationToken);
 }

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/Events/PdfDeletedDomainEvent.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/Events/PdfDeletedDomainEvent.cs
@@ -5,22 +5,25 @@ namespace Api.BoundedContexts.DocumentProcessing.Domain.Events;
 /// <summary>
 /// Raised when a PDF document has been removed from the persistence store.
 /// Consumed by <c>PdfDeletedEventHandler</c> to evict the associated L4 cover
-/// artefacts from blob storage (thumb + preview), so the bucket does not
-/// accumulate orphaned <c>game-images/pdf-cover-{id}/*</c> objects.
+/// preview artefact from blob storage, so the bucket does not accumulate
+/// orphaned <c>covers/pdf/{PdfDocumentId:D}/cover-preview.webp</c> objects.
 /// </summary>
 /// <remarks>
 /// Issue #1831 AC: "Storage cleanup on PDF delete (R2 object removal in event handler)".
 /// Pattern coerente con <see cref="PdfCoverGeneratedEvent"/> introdotto in #1852.
+/// Issue #2947: key convention migrated to the deterministic
+/// <c>covers/pdf/{'{'}id:D{'}'}/cover</c> shape (no more <c>pdf-cover-{'{'}id{'}'}</c>
+/// prefix, no separate thumb object).
 /// </remarks>
 internal sealed class PdfDeletedDomainEvent : DomainEventBase
 {
     public Guid PdfDocumentId { get; }
 
     /// <summary>
-    /// Resource-key prefix used when the cover was uploaded
-    /// (<c>pdf-cover-{PdfDocumentId}</c>). Null when the PDF never produced a
-    /// cover (e.g. Skipped or Pending status at delete time) — the handler
-    /// then has no-op work to do.
+    /// Deterministic, un-suffixed R2 key used when the cover was uploaded
+    /// (<c>covers/pdf/{PdfDocumentId:D}/cover</c>). Null when the PDF never
+    /// produced a cover (e.g. Skipped or Pending status at delete time) — the
+    /// handler then has no-op work to do.
     /// </summary>
     public string? CoverR2Key { get; }
 

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/BggCoverDownloader.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/BggCoverDownloader.cs
@@ -1,5 +1,4 @@
 using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
-using Api.Services.Pdf;
 using Microsoft.Extensions.Logging;
 
 namespace Api.BoundedContexts.SharedGameCatalog.Application.Services;
@@ -7,16 +6,16 @@ namespace Api.BoundedContexts.SharedGameCatalog.Application.Services;
 internal sealed class BggCoverDownloader : IBggCoverDownloader
 {
     private readonly HttpClient _httpClient;
-    private readonly IBlobStorageService _blobStorageService;
+    private readonly IBggCoverUploadPipeline _uploadPipeline;
     private readonly ILogger<BggCoverDownloader> _logger;
 
     public BggCoverDownloader(
         HttpClient httpClient,
-        IBlobStorageService blobStorageService,
+        IBggCoverUploadPipeline uploadPipeline,
         ILogger<BggCoverDownloader> logger)
     {
         _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
-        _blobStorageService = blobStorageService ?? throw new ArgumentNullException(nameof(blobStorageService));
+        _uploadPipeline = uploadPipeline ?? throw new ArgumentNullException(nameof(uploadPipeline));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -31,8 +30,7 @@ internal sealed class BggCoverDownloader : IBggCoverDownloader
         }
 
         // SSRF guard (#2655 finding #10): only fetch HTTPS URLs that resolve to public IPs.
-        // Reuses the SharedGameCatalog SsrfSafeHttpClient validators (same bounded context). Fails
-        // closed — an invalid scheme or a private/reserved target aborts the download (returns null).
+        // Fails closed — an invalid scheme or a private/reserved target aborts the download.
         try
         {
             SsrfSafeHttpClient.ValidateUrlScheme(remoteImageUrl);
@@ -46,8 +44,6 @@ internal sealed class BggCoverDownloader : IBggCoverDownloader
                 bggId, remoteImageUrl);
             return null;
         }
-
-        var resourceKey = $"bgg-cover-{bggId}";
 
         try
         {
@@ -63,28 +59,25 @@ internal sealed class BggCoverDownloader : IBggCoverDownloader
                 return null;
             }
 
-            var imageStream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
-            await using var _ = imageStream.ConfigureAwait(false);
-
-            // Derive a safe filename from the URL path
-            var fileName = $"cover-{bggId}{GetExtension(remoteImageUrl)}";
-
-            var storageResult = await _blobStorageService
-                .StoreAsync(imageStream, fileName, BlobCategory.GameImage, resourceKey, cancellationToken)
-                .ConfigureAwait(false);
-
-            if (!storageResult.Success)
+            var imageBytes = await response.Content.ReadAsByteArrayAsync(cancellationToken).ConfigureAwait(false);
+            if (imageBytes.Length == 0)
             {
-                _logger.LogWarning(
-                    "BGG cover upload failed: BggId={BggId}, Error={Error}",
-                    bggId, storageResult.ErrorMessage);
+                _logger.LogWarning("BGG cover download returned empty body: BggId={BggId}", bggId);
                 return null;
             }
 
+            var extension = GetExtension(remoteImageUrl);
+
+            // Issue #2947: raw R2 PutObject to a deterministic key so
+            // CoverUrlResolver can reconstruct it via GetPresignedUrlForRawKeyAsync.
+            var r2Key = await _uploadPipeline
+                .UploadAsync(bggId, imageBytes, extension, cancellationToken)
+                .ConfigureAwait(false);
+
             _logger.LogInformation(
                 "BGG cover uploaded successfully: BggId={BggId}, R2Key={Key}",
-                bggId, resourceKey);
-            return resourceKey;
+                bggId, r2Key);
+            return r2Key;
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/CoverUrlResolver.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/CoverUrlResolver.cs
@@ -20,10 +20,11 @@ namespace Api.BoundedContexts.SharedGameCatalog.Application.Services;
 /// rejects <c>/</c> and <c>.</c>) and then did categorized prefix discovery —
 /// neither of which matches these layers' raw, slash-containing key shape, so
 /// the call always threw internally and returned null (silent no-op: covers
-/// never resolved). L2.5 (BGG) is intentionally UNCHANGED: its physical key is
-/// non-deterministic (<c>StoreAsync</c> mints a random fileId), so it cannot be
-/// resolved from the DB-persisted key via a raw-key lookup; it stays on the
-/// legacy path (still a placeholder today) pending a follow-up.
+/// never resolved).
+/// L2.5 (BGG) now resolves via <see cref="IBlobStorageService.GetPresignedUrlForRawKeyAsync"/>
+/// using the full deterministic key written by
+/// <c>BggCoverUploadPipeline</c> (Issue #2947): <c>bgg-covers/{bggId}/cover{ext}</c>,
+/// with no suffix appended (BGG keeps its original image extension).
 ///
 /// Issue #2123 (BGG ToS compliance): every resolution outcome — including the
 /// terminal <c>null</c> path that triggers a placeholder render on the FE —
@@ -88,19 +89,17 @@ internal static class CoverUrlResolver
             }
         }
 
-        // L2.5 BGG re-uploaded cover (Gap G2)
-        // Asymmetry vs L4/L2: BGG cover is stored as a single asset under the raw
-        // resource key (set by BggCoverDownloader.DownloadAndUploadAsync), with no
-        // -preview.webp or .webp suffix. The blob service treats arg 1 as the literal
-        // storage object path; arg 3 is the cache identifier (same key here is fine
-        // because the storage object IS the cache target).
+        // L2.5 BGG re-uploaded cover (Gap G2 / Issue #2947)
+        // The DB key is the FULL deterministic physical object key composed by
+        // BggCoverUploadPipeline (bgg-covers/{bggId}/cover{ext}). Unlike L4/L2,
+        // NO suffix is appended: BGG keeps its original image extension, so the
+        // stored key IS the physical key. Resolved via the raw-key method (the
+        // legacy GetPresignedDownloadUrlAsync validated the key with
+        // PathSecurity.ValidateIdentifier, which rejects '/' and '.').
         if (!string.IsNullOrWhiteSpace(sharedGame.BggCoverR2Key))
         {
             var url = await blobStorage
-                .GetPresignedDownloadUrlAsync(
-                    sharedGame.BggCoverR2Key,
-                    BlobCategory.GameImage,
-                    sharedGame.BggCoverR2Key)
+                .GetPresignedUrlForRawKeyAsync(sharedGame.BggCoverR2Key)
                 .ConfigureAwait(false);
             if (url is not null)
             {

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/IBggCoverUploadPipeline.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/IBggCoverUploadPipeline.cs
@@ -1,0 +1,33 @@
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Services;
+
+/// <summary>
+/// Issue #2947 — uploads a downloaded BGG cover image to R2 under a
+/// deterministic key so <see cref="CoverUrlResolver"/> can reconstruct it.
+/// <para>
+/// Unlike <c>CoverR2UploadPipeline</c> (Wikidata) and <c>PdfCoverUploadPipeline</c>
+/// which store a suffix-stripped DB key and append a suffix at read time, the
+/// BGG cover keeps its ORIGINAL image extension (BGG serves jpg/png, not webp).
+/// The returned key is therefore the FULL physical object key
+/// (<c>bgg-covers/{bggId}/cover{extension}</c>) and the resolver's L2.5 branch
+/// passes it verbatim to <c>GetPresignedUrlForRawKeyAsync</c> with NO suffix.
+/// </para>
+/// </summary>
+internal interface IBggCoverUploadPipeline
+{
+    /// <summary>
+    /// Uploads <paramref name="imageBytes"/> to R2 as
+    /// <c>bgg-covers/{bggId}/cover{extension}</c> with an immutable cache-control
+    /// header, then returns that exact key — the value to persist on
+    /// <c>SharedGameEntity.BggCoverR2Key</c>.
+    /// </summary>
+    /// <param name="bggId">BoardGameGeek game id; the cover namespace.</param>
+    /// <param name="imageBytes">The downloaded cover image bytes. Must be non-null and non-empty.</param>
+    /// <param name="extension">Dot-prefixed lowercase extension (e.g. <c>.jpg</c>);
+    /// null/empty/invalid normalizes to <c>.jpg</c>.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The full deterministic physical key persisted to the DB.</returns>
+    /// <exception cref="System.ArgumentException">When <paramref name="imageBytes"/> is null or empty.</exception>
+    /// <exception cref="Amazon.S3.AmazonS3Exception">When the underlying S3 client fails.</exception>
+    /// <exception cref="System.OperationCanceledException">When <paramref name="ct"/> signals cancellation.</exception>
+    Task<string> UploadAsync(int bggId, byte[] imageBytes, string extension, CancellationToken ct);
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs
@@ -234,6 +234,11 @@ internal static class SharedGameCatalogServiceExtensions
         // call (S3 misconfiguration surfaces synchronously instead of silently).
         RegisterCoverR2UploadPipeline(services);
 
+        // Issue #2947 — BGG cover R2 upload pipeline (deterministic key). Same
+        // S3_* config + lifetime as RegisterCoverR2UploadPipeline. Register both
+        // the interface and the concrete type (CLAUDE.md pitfall #2565).
+        RegisterBggCoverUploadPipeline(services);
+
         // Issue #1823 Wave 3 M9 (ADR DEC-3j): retry/dead-letter classifier for
         // the WikidataCoverEnrichmentJob scheduler. Stateless + thread-safe —
         // singleton lifetime.
@@ -336,6 +341,72 @@ internal static class SharedGameCatalogServiceExtensions
 
             return new CoverR2UploadPipeline(s3Client, options, logger);
         });
+    }
+
+    /// <summary>
+    /// Issue #2947 — registers <see cref="IBggCoverUploadPipeline"/> as a
+    /// singleton backed by a lazily-constructed <see cref="Amazon.S3.IAmazonS3"/>
+    /// client. Mirrors <see cref="RegisterCoverR2UploadPipeline"/> (same S3_* env
+    /// vars, same R2 header-strip hook, same singleton lifetime).
+    /// </summary>
+    private static void RegisterBggCoverUploadPipeline(IServiceCollection services)
+    {
+        services.AddSingleton<IBggCoverUploadPipeline>(sp =>
+        {
+            var config = sp.GetRequiredService<IConfiguration>();
+            var logger = sp.GetRequiredService<ILogger<BggCoverUploadPipeline>>();
+            return BuildBggCoverUploadPipeline(config, logger);
+        });
+    }
+
+    /// <summary>
+    /// Test seam (Issue #2947): registers only the BGG cover pipeline against a
+    /// caller-supplied service collection so a DI-resolution unit test can verify
+    /// the registration without spinning up the whole catalog context. The caller
+    /// MUST have already registered an <see cref="IConfiguration"/> on the same
+    /// collection (the singleton factory resolves it via
+    /// <c>sp.GetRequiredService&lt;IConfiguration&gt;()</c>).
+    /// </summary>
+    internal static void RegisterBggCoverUploadPipelineForTests(IServiceCollection services)
+    {
+        services.AddLogging();
+        RegisterBggCoverUploadPipeline(services);
+    }
+
+    private static BggCoverUploadPipeline BuildBggCoverUploadPipeline(
+        IConfiguration config,
+        ILogger<BggCoverUploadPipeline> logger)
+    {
+        var options = new S3StorageOptions
+        {
+            Endpoint = config["S3_ENDPOINT"] ?? throw new InvalidOperationException("S3_ENDPOINT is required for BggCoverUploadPipeline"),
+            AccessKey = config["S3_ACCESS_KEY"] ?? throw new InvalidOperationException("S3_ACCESS_KEY is required for BggCoverUploadPipeline"),
+            SecretKey = config["S3_SECRET_KEY"] ?? throw new InvalidOperationException("S3_SECRET_KEY is required for BggCoverUploadPipeline"),
+            BucketName = config["S3_BUCKET_NAME"] ?? throw new InvalidOperationException("S3_BUCKET_NAME is required for BggCoverUploadPipeline"),
+            Region = config["S3_REGION"] ?? "auto",
+            ForcePathStyle = bool.TryParse(config["S3_FORCE_PATH_STYLE"], out var forcePathStyle) && forcePathStyle,
+        };
+
+        var s3Config = new Amazon.S3.AmazonS3Config
+        {
+            ServiceURL = options.Endpoint,
+            ForcePathStyle = options.ForcePathStyle,
+            AuthenticationRegion = options.Region,
+        };
+
+        if (!string.Equals(options.Region, "auto", StringComparison.Ordinal)
+            && Amazon.RegionEndpoint.GetBySystemName(options.Region) != null)
+        {
+            s3Config.RegionEndpoint = Amazon.RegionEndpoint.GetBySystemName(options.Region);
+        }
+
+        var credentials = new Amazon.Runtime.BasicAWSCredentials(options.AccessKey, options.SecretKey);
+        var s3Client = new Amazon.S3.AmazonS3Client(credentials, s3Config);
+
+        // Issue #1357: R2 rejects x-amz-tagging-directive; strip it defensively.
+        s3Client.BeforeRequestEvent += BlobStorageServiceFactory.StripUnsupportedR2Headers;
+
+        return new BggCoverUploadPipeline(s3Client, options, logger);
     }
 
     /// <summary>

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/BggCoverUploadPipeline.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/BggCoverUploadPipeline.cs
@@ -1,0 +1,106 @@
+using Amazon.S3;
+using Amazon.S3.Model;
+using Api.BoundedContexts.SharedGameCatalog.Application.Services;
+using Api.Services.Pdf;
+using Microsoft.Extensions.Logging;
+using System.Globalization;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
+
+/// <summary>
+/// Issue #2947 — R2 upload pipeline for BGG-downloaded cover images. Mirrors
+/// <see cref="CoverR2UploadPipeline"/> / <c>PdfCoverUploadPipeline</c>: talks
+/// directly to <see cref="IAmazonS3"/> with a raw deterministic key rather than
+/// going through <c>IBlobStorageService.StoreAsync</c> (which mints a random
+/// fileId the resolver cannot reconstruct).
+/// </summary>
+internal sealed class BggCoverUploadPipeline : IBggCoverUploadPipeline
+{
+    // Cover assets are immutable for 1 year; re-uploads reuse the same key so
+    // Cloudflare CDN cache stays warm (mirrors CoverR2UploadPipeline).
+    private const string ImmutableCacheControl = "public, max-age=31536000, immutable";
+    private const string DefaultExtension = ".jpg";
+
+    private readonly IAmazonS3 _s3Client;
+    private readonly S3StorageOptions _options;
+    private readonly ILogger<BggCoverUploadPipeline> _logger;
+
+    public BggCoverUploadPipeline(
+        IAmazonS3 s3Client,
+        S3StorageOptions options,
+        ILogger<BggCoverUploadPipeline> logger)
+    {
+        _s3Client = s3Client ?? throw new ArgumentNullException(nameof(s3Client));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<string> UploadAsync(int bggId, byte[] imageBytes, string extension, CancellationToken ct)
+    {
+        if (imageBytes is null || imageBytes.Length == 0)
+        {
+            throw new ArgumentException("imageBytes must be non-null and non-empty.", nameof(imageBytes));
+        }
+
+        var ext = NormalizeExtension(extension);
+        var contentType = ContentTypeFor(ext);
+        // Deterministic physical key = DB key (resolver appends NO suffix for L2.5).
+        var objectKey = $"bgg-covers/{bggId.ToString(CultureInfo.InvariantCulture)}/cover{ext}";
+
+        using var stream = new MemoryStream(imageBytes, writable: false);
+        var request = new PutObjectRequest
+        {
+            BucketName = _options.BucketName,
+            Key = objectKey,
+            InputStream = stream,
+            ContentType = contentType,
+            AutoCloseStream = false,
+            // Required for S3-compatible providers (R2/MinIO) that don't support
+            // STREAMING-AWS4-HMAC-SHA256-PAYLOAD-TRAILER (mirrors CoverR2UploadPipeline).
+            DisablePayloadSigning = true,
+        };
+        request.Headers.CacheControl = ImmutableCacheControl;
+
+        // OperationCanceledException propagates naturally from PutObjectAsync.
+        try
+        {
+            var response = await _s3Client.PutObjectAsync(request, ct).ConfigureAwait(false);
+            _logger.LogInformation(
+                "Uploaded BGG cover to R2: BggId={BggId}, Key={Key}, Size={Size} bytes, ETag={ETag}",
+                bggId, objectKey, imageBytes.Length, response.ETag);
+            return objectKey;
+        }
+        catch (AmazonS3Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "R2 BGG cover upload failed: BggId={BggId}, Key={Key}, StatusCode={Status}, ErrorCode={ErrorCode}",
+                bggId, objectKey, ex.StatusCode, ex.ErrorCode);
+            throw;
+        }
+    }
+
+    private static string NormalizeExtension(string extension)
+    {
+        if (string.IsNullOrWhiteSpace(extension))
+        {
+            return DefaultExtension;
+        }
+
+        var ext = extension.StartsWith('.') ? extension : "." + extension;
+        ext = ext.ToLowerInvariant();
+        return ext switch
+        {
+            ".jpg" or ".jpeg" or ".png" or ".gif" or ".webp" => ext,
+            _ => DefaultExtension,
+        };
+    }
+
+    private static string ContentTypeFor(string normalizedExtension) => normalizedExtension switch
+    {
+        ".png" => "image/png",
+        ".gif" => "image/gif",
+        ".webp" => "image/webp",
+        _ => "image/jpeg",
+    };
+}

--- a/apps/api/src/Api/DevTools/MockImpls/MockBlobStorageService.cs
+++ b/apps/api/src/Api/DevTools/MockImpls/MockBlobStorageService.cs
@@ -108,4 +108,12 @@ internal sealed class MockBlobStorageService : IBlobStorageService
         return Task.FromResult<string?>(
             $"http://localhost/mock-s3/raw?key={Uri.EscapeDataString(rawKey)}&expiry={expirySeconds ?? 3600}");
     }
+
+    /// <inheritdoc />
+    public Task<bool> DeleteRawKeyAsync(string rawKey, CancellationToken ct = default)
+    {
+        _ = (rawKey, ct);
+        // Return true for the same "everything is present" mock semantics as DeleteAsync.
+        return Task.FromResult(true);
+    }
 }

--- a/apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/SharedGameEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/SharedGameCatalog/SharedGameEntity.cs
@@ -70,10 +70,12 @@ public class SharedGameEntity
     /// <summary>
     /// Issue #1852 (umbrella #1821 L4) — PDF cover key denormalized from
     /// PdfDocumentEntity.CoverR2Key via PdfCoverGeneratedEventHandler.
-    /// Stored in R2 at <c>covers/pdf/{SharedGameId}/{key}-preview.webp</c>.
+    /// Stored in R2 at <c>covers/pdf/{pdfId:D}/cover-preview.webp</c> (Issue #2947:
+    /// deterministic key keyed by the source PdfDocument's id, not SharedGameId).
     /// Has higher priority than Wikidata (L2) and user-uploaded (L3) covers
     /// but only when a PDF with a valid cover has been uploaded and processed.
-    /// Resolved to BlobCategory.GameImage when computing CoverUrl in DTOs.
+    /// Resolved via <c>IBlobStorageService.GetPresignedUrlForRawKeyAsync</c>
+    /// (raw-key primitive) when computing CoverUrl in DTOs — see CoverUrlResolver.
     /// </summary>
     public string? PdfCoverR2Key { get; set; }
 

--- a/apps/api/src/Api/Services/Pdf/BlobStorageService.cs
+++ b/apps/api/src/Api/Services/Pdf/BlobStorageService.cs
@@ -246,6 +246,18 @@ internal class BlobStorageService : IBlobStorageService
         return Task.FromResult<string?>(null);
     }
 
+    /// <summary>
+    /// Local storage does not host objects under raw R2-style keys (those are
+    /// only ever written directly to S3-compatible storage by the raw-key
+    /// upload paths). No-op returning false so callers treat it as "nothing to
+    /// delete here" rather than throwing.
+    /// </summary>
+    public Task<bool> DeleteRawKeyAsync(string rawKey, CancellationToken ct = default)
+    {
+        _ = (rawKey, ct); // Local storage: raw keys are not supported
+        return Task.FromResult(false);
+    }
+
     private static string SanitizeFileName(string fileName)
     {
         return StringHelper.SanitizeFilename(fileName, maxLength: 200, fallbackName: "file");

--- a/apps/api/src/Api/Services/Pdf/IBlobStorageService.cs
+++ b/apps/api/src/Api/Services/Pdf/IBlobStorageService.cs
@@ -156,6 +156,19 @@ internal interface IBlobStorageService
     /// <param name="expirySeconds">URL expiration time (optional, defaults to configured value).</param>
     /// <returns>Pre-signed GET URL, or null if the object does not exist or the operation is not supported.</returns>
     Task<string?> GetPresignedUrlForRawKeyAsync(string rawKey, int? expirySeconds = null);
+
+    /// <summary>
+    /// Deletes an object at an EXACT physical storage key. Unlike
+    /// <see cref="DeleteAsync"/>, this does NOT run <c>PathSecurity.ValidateIdentifier</c>
+    /// and does NOT perform categorized prefix discovery — the caller is expected
+    /// to have already validated or otherwise trusted the key (e.g. a deterministic
+    /// key composed by business logic before being persisted to the DB). Slashes
+    /// and dots are allowed in <paramref name="rawKey"/>.
+    /// </summary>
+    /// <param name="rawKey">The exact physical storage object key to delete.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>True if the delete request was issued successfully (best-effort; local storage returns false as it does not host raw keys).</returns>
+    Task<bool> DeleteRawKeyAsync(string rawKey, CancellationToken ct = default);
 }
 
 /// <summary>

--- a/apps/api/src/Api/Services/Pdf/S3BlobStorageService.cs
+++ b/apps/api/src/Api/Services/Pdf/S3BlobStorageService.cs
@@ -423,6 +423,48 @@ internal sealed class S3BlobStorageService : IBlobStorageService
 #pragma warning restore CA1031 // Do not catch general exception types
     }
 
+    /// <summary>
+    /// Deletes an object at an EXACT physical S3 key. Deliberately skips
+    /// <c>PathSecurity.ValidateIdentifier</c> and prefix discovery — the caller
+    /// (business logic that composed the key) is trusted. Mirrors
+    /// <see cref="GetPresignedUrlForRawKeyAsync"/>'s raw-key contract.
+    /// </summary>
+    public async Task<bool> DeleteRawKeyAsync(string rawKey, CancellationToken ct = default)
+    {
+        try
+        {
+            if (string.IsNullOrWhiteSpace(rawKey))
+            {
+                return false;
+            }
+
+            await _s3Client.DeleteObjectAsync(new DeleteObjectRequest
+            {
+                BucketName = _options.BucketName,
+                Key = rawKey,
+            }, ct).ConfigureAwait(false);
+
+            _logger.LogInformation("Deleted file from S3 (raw key): {Key}", rawKey);
+            return true;
+        }
+        catch (AmazonS3Exception ex)
+        {
+            _logger.LogWarning(ex, "S3 error deleting raw key {Key}: {ErrorCode}", rawKey, ex.ErrorCode);
+            return false;
+        }
+#pragma warning disable CA1031 // Do not catch general exception types
+        catch (Exception ex)
+        {
+            // SERVICE BOUNDARY PATTERN: S3 storage service boundary - must handle all errors gracefully
+            // Rationale: This is a service entry point that deletes files from S3 storage. Network and
+            // S3 operations can throw various runtime exceptions (timeouts, network errors, authentication failures).
+            // We must catch all exceptions to return false instead of crashing the service.
+            _logger.LogWarning(ex, "Unexpected error deleting raw key {Key}", rawKey);
+            return false;
+        }
+#pragma warning restore CA1031 // Do not catch general exception types
+    }
+
     private static string SanitizeFileName(string fileName)
     {
         return StringHelper.SanitizeFilename(fileName, maxLength: 200, fallbackName: "file");

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/EventHandlers/PdfDeletedEventHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/EventHandlers/PdfDeletedEventHandlerTests.cs
@@ -25,7 +25,7 @@ public sealed class PdfDeletedEventHandlerTests
         await Handler().Handle(evt, default);
 
         _blob.Verify(
-            b => b.DeleteAsync(It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            b => b.DeleteRawKeyAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
             Times.Never);
     }
 
@@ -37,7 +37,7 @@ public sealed class PdfDeletedEventHandlerTests
         await Handler().Handle(evt, default);
 
         _blob.Verify(
-            b => b.DeleteAsync(It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            b => b.DeleteRawKeyAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
             Times.Never);
     }
 
@@ -49,67 +49,74 @@ public sealed class PdfDeletedEventHandlerTests
         await Handler().Handle(evt, default);
 
         _blob.Verify(
-            b => b.DeleteAsync(It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            b => b.DeleteRawKeyAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()),
             Times.Never);
     }
 
+    // I1 (Important, #2947 holistic review fix): CoverR2Key is now the deterministic
+    // "covers/pdf/{id:D}/cover" convention. The physical object written by
+    // PdfProcessingPipelineService/PdfCoverUploadPipeline is ONLY the preview
+    // variant ("{key}-preview.webp") — there is no more separate thumb object.
+    // The handler must evict via the RAW-KEY delete primitive, not the
+    // categorized DeleteAsync (which validates + rejects '/' via PathSecurity).
+
     [Fact]
-    public async Task Handle_HappyPath_DeletesBothThumbAndPreview()
+    public async Task Handle_HappyPath_DeletesPreviewRawKey()
     {
         var pdfId = Guid.NewGuid();
-        var key = $"pdf-cover-{pdfId}";
-        _blob.Setup(b => b.DeleteAsync(It.IsAny<string>(), BlobCategory.GameImage, key, It.IsAny<CancellationToken>()))
+        var key = $"covers/pdf/{pdfId:D}/cover";
+        var expectedRawKey = $"{key}-preview.webp";
+        _blob.Setup(b => b.DeleteRawKeyAsync(expectedRawKey, It.IsAny<CancellationToken>()))
              .ReturnsAsync(true);
         var evt = new PdfDeletedDomainEvent(pdfId, key);
 
         await Handler().Handle(evt, default);
 
-        _blob.Verify(b => b.DeleteAsync("thumb.webp", BlobCategory.GameImage, key, It.IsAny<CancellationToken>()), Times.Once);
-        _blob.Verify(b => b.DeleteAsync("preview.webp", BlobCategory.GameImage, key, It.IsAny<CancellationToken>()), Times.Once);
+        _blob.Verify(b => b.DeleteRawKeyAsync(expectedRawKey, It.IsAny<CancellationToken>()), Times.Once);
+        // The defunct thumb object no longer exists on this branch — no separate delete call.
+        _blob.Verify(b => b.DeleteRawKeyAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
     public async Task Handle_BlobNotFound_LogsButDoesNotThrow()
     {
         var pdfId = Guid.NewGuid();
-        var key = $"pdf-cover-{pdfId}";
-        _blob.Setup(b => b.DeleteAsync(It.IsAny<string>(), BlobCategory.GameImage, key, It.IsAny<CancellationToken>()))
+        var key = $"covers/pdf/{pdfId:D}/cover";
+        var expectedRawKey = $"{key}-preview.webp";
+        _blob.Setup(b => b.DeleteRawKeyAsync(expectedRawKey, It.IsAny<CancellationToken>()))
              .ReturnsAsync(false);
         var evt = new PdfDeletedDomainEvent(pdfId, key);
 
         var act = async () => await Handler().Handle(evt, default);
 
         await act.Should().NotThrowAsync();
-        // Both attempts still made — handler doesn't short-circuit on first false.
-        _blob.Verify(b => b.DeleteAsync("thumb.webp", BlobCategory.GameImage, key, It.IsAny<CancellationToken>()), Times.Once);
-        _blob.Verify(b => b.DeleteAsync("preview.webp", BlobCategory.GameImage, key, It.IsAny<CancellationToken>()), Times.Once);
+        _blob.Verify(b => b.DeleteRawKeyAsync(expectedRawKey, It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
-    public async Task Handle_BlobThrows_SwallowsExceptionAndContinuesWithSecondBlob()
+    public async Task Handle_BlobThrows_SwallowsException()
     {
         var pdfId = Guid.NewGuid();
-        var key = $"pdf-cover-{pdfId}";
-        _blob.Setup(b => b.DeleteAsync("thumb.webp", BlobCategory.GameImage, key, It.IsAny<CancellationToken>()))
+        var key = $"covers/pdf/{pdfId:D}/cover";
+        var expectedRawKey = $"{key}-preview.webp";
+        _blob.Setup(b => b.DeleteRawKeyAsync(expectedRawKey, It.IsAny<CancellationToken>()))
              .ThrowsAsync(new InvalidOperationException("S3 unreachable"));
-        _blob.Setup(b => b.DeleteAsync("preview.webp", BlobCategory.GameImage, key, It.IsAny<CancellationToken>()))
-             .ReturnsAsync(true);
         var evt = new PdfDeletedDomainEvent(pdfId, key);
 
         var act = async () => await Handler().Handle(evt, default);
 
         await act.Should().NotThrowAsync();
-        _blob.Verify(b => b.DeleteAsync("preview.webp", BlobCategory.GameImage, key, It.IsAny<CancellationToken>()), Times.Once);
+        _blob.Verify(b => b.DeleteRawKeyAsync(expectedRawKey, It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
     public async Task Handle_CancellationRequested_PropagatesOperationCanceledException()
     {
         var pdfId = Guid.NewGuid();
-        var key = $"pdf-cover-{pdfId}";
+        var key = $"covers/pdf/{pdfId:D}/cover";
         using var cts = new CancellationTokenSource();
         cts.Cancel();
-        _blob.Setup(b => b.DeleteAsync(It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), cts.Token))
+        _blob.Setup(b => b.DeleteRawKeyAsync(It.IsAny<string>(), cts.Token))
              .ThrowsAsync(new OperationCanceledException(cts.Token));
         var evt = new PdfDeletedDomainEvent(pdfId, key);
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Jobs/BackfillPdfCoversJobTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Jobs/BackfillPdfCoversJobTests.cs
@@ -23,6 +23,7 @@ public sealed class BackfillPdfCoversJobTests : IDisposable
     private readonly MeepleAiDbContext _db;
     private readonly Mock<IPdfCoverExtractor> _extractor = new();
     private readonly Mock<IBlobStorageService> _blob = new();
+    private readonly Mock<IPdfCoverUploadPipeline> _coverPipeline = new();
     private readonly Mock<IDomainEventCollector> _eventCollector = new();
     private readonly List<IDomainEvent> _collectedEvents = new();
 
@@ -75,7 +76,7 @@ public sealed class BackfillPdfCoversJobTests : IDisposable
     [Fact]
     public async Task RunBatchAsync_NoEligiblePdfs_DoesNothing()
     {
-        await CreateJob().RunBatchAsync(_db, _extractor.Object, _blob.Object, _eventCollector.Object, default);
+        await CreateJob().RunBatchAsync(_db, _extractor.Object, _blob.Object, _coverPipeline.Object, _eventCollector.Object, default);
 
         _extractor.Verify(e => e.ExtractAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()), Times.Never);
         _blob.Verify(b => b.RetrieveAsync(It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
@@ -99,7 +100,7 @@ public sealed class BackfillPdfCoversJobTests : IDisposable
         ConfigureExtractorReturning(PdfCoverExtractionOutcome.Skipped);
         ConfigureBlobReturningStream();
 
-        await CreateJob().RunBatchAsync(_db, _extractor.Object, _blob.Object, _eventCollector.Object, default);
+        await CreateJob().RunBatchAsync(_db, _extractor.Object, _blob.Object, _coverPipeline.Object, _eventCollector.Object, default);
 
         _extractor.Verify(e => e.ExtractAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()), Times.Once);
     }
@@ -112,7 +113,7 @@ public sealed class BackfillPdfCoversJobTests : IDisposable
         _blob.Setup(b => b.RetrieveAsync(It.IsAny<string>(), BlobCategory.Pdf, It.IsAny<string>(), It.IsAny<CancellationToken>()))
              .ReturnsAsync((Stream?)null);
 
-        await CreateJob().RunBatchAsync(_db, _extractor.Object, _blob.Object, _eventCollector.Object, default);
+        await CreateJob().RunBatchAsync(_db, _extractor.Object, _blob.Object, _coverPipeline.Object, _eventCollector.Object, default);
 
         _extractor.Verify(e => e.ExtractAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()), Times.Never);
 
@@ -122,7 +123,7 @@ public sealed class BackfillPdfCoversJobTests : IDisposable
     }
 
     [Fact]
-    public async Task RunBatchAsync_ExtractGenerated_UploadsBothSizesAndPersistsKeyAndEmitsEvent()
+    public async Task RunBatchAsync_ExtractGenerated_UploadsPreviewViaPipelineAndPersistsDeterministicKeyAndEmitsEvent()
     {
         var sharedGameId = Guid.NewGuid();
         var pdf = SeedPdf(sharedGameId: sharedGameId);
@@ -137,14 +138,22 @@ public sealed class BackfillPdfCoversJobTests : IDisposable
                       SelectedPageIndex = 1,
                   });
 
-        await CreateJob().RunBatchAsync(_db, _extractor.Object, _blob.Object, _eventCollector.Object, default);
+        var expectedKey = $"covers/pdf/{pdf.Id:D}/cover";
+        _coverPipeline
+            .Setup(p => p.UploadAsync(expectedKey, It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedKey);
 
-        var expectedKey = $"pdf-cover-{pdf.Id}";
+        await CreateJob().RunBatchAsync(_db, _extractor.Object, _blob.Object, _coverPipeline.Object, _eventCollector.Object, default);
 
-        _blob.Verify(b => b.StoreAsync(It.IsAny<Stream>(), "thumb.webp", BlobCategory.GameImage, expectedKey, It.IsAny<CancellationToken>()),
-            Times.Once);
-        _blob.Verify(b => b.StoreAsync(It.IsAny<Stream>(), "preview.webp", BlobCategory.GameImage, expectedKey, It.IsAny<CancellationToken>()),
-            Times.Once);
+        // Only the PREVIEW size is uploaded (the resolver only reads -preview.webp).
+        _coverPipeline.Verify(p => p.UploadAsync(
+            expectedKey,
+            It.Is<byte[]>(b => b.SequenceEqual(new byte[] { 4, 5, 6, 7 })),
+            It.IsAny<CancellationToken>()), Times.Once);
+        // StoreAsync must NOT be used for the cover write anymore.
+        _blob.Verify(b => b.StoreAsync(
+            It.IsAny<Stream>(), It.IsAny<string>(), BlobCategory.GameImage, It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
 
         var refreshed = _db.PdfDocuments.AsNoTracking().Single(p => p.Id == pdf.Id);
         refreshed.CoverGenerationStatus.Should().Be(nameof(PdfCoverGenerationStatus.Generated));
@@ -154,7 +163,7 @@ public sealed class BackfillPdfCoversJobTests : IDisposable
 
         _collectedEvents.Should().ContainSingle()
             .Which.Should().BeOfType<PdfCoverGeneratedEvent>()
-            .Which.SharedGameId.Should().Be(sharedGameId);
+            .Which.CoverR2Key.Should().Be(expectedKey);
     }
 
     [Fact]
@@ -170,13 +179,13 @@ public sealed class BackfillPdfCoversJobTests : IDisposable
                       SelectedPageIndex = 0,
                   });
 
-        await CreateJob().RunBatchAsync(_db, _extractor.Object, _blob.Object, _eventCollector.Object, default);
+        await CreateJob().RunBatchAsync(_db, _extractor.Object, _blob.Object, _coverPipeline.Object, _eventCollector.Object, default);
 
         var refreshed = _db.PdfDocuments.AsNoTracking().Single(p => p.Id == pdf.Id);
         refreshed.CoverGenerationStatus.Should().Be(nameof(PdfCoverGenerationStatus.Skipped));
         refreshed.CoverR2Key.Should().BeNull();
 
-        _blob.Verify(b => b.StoreAsync(It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+        _coverPipeline.Verify(p => p.UploadAsync(It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<CancellationToken>()),
             Times.Never);
         _collectedEvents.Should().BeEmpty();
     }
@@ -194,7 +203,7 @@ public sealed class BackfillPdfCoversJobTests : IDisposable
                       ErrorMessage = "PDF corrupt",
                   });
 
-        await CreateJob().RunBatchAsync(_db, _extractor.Object, _blob.Object, _eventCollector.Object, default);
+        await CreateJob().RunBatchAsync(_db, _extractor.Object, _blob.Object, _coverPipeline.Object, _eventCollector.Object, default);
 
         var refreshed = _db.PdfDocuments.AsNoTracking().Single(p => p.Id == pdf.Id);
         refreshed.CoverGenerationStatus.Should().Be(nameof(PdfCoverGenerationStatus.Failed));
@@ -218,14 +227,14 @@ public sealed class BackfillPdfCoversJobTests : IDisposable
 
         // Speed up test — bypass the default 500ms inter-item sleep would still
         // run, but xUnit defaults to 60s timeout so it's fine.
-        await CreateJob().RunBatchAsync(_db, _extractor.Object, _blob.Object, _eventCollector.Object, default);
+        await CreateJob().RunBatchAsync(_db, _extractor.Object, _blob.Object, _coverPipeline.Object, _eventCollector.Object, default);
 
         var refreshedFirst = _db.PdfDocuments.AsNoTracking().Single(p => p.Id == first.Id);
         refreshedFirst.CoverGenerationStatus.Should().Be(nameof(PdfCoverGenerationStatus.Failed));
         // Error message encodes the orphan-check hint (#1873 review fix H2): contains the
         // exception type name and the resourceKey operators must inspect for orphan blobs.
         refreshedFirst.CoverGenerationError.Should().Contain(nameof(InvalidOperationException));
-        refreshedFirst.CoverGenerationError.Should().Contain($"pdf-cover-{first.Id}");
+        refreshedFirst.CoverGenerationError.Should().Contain($"covers/pdf/{first.Id:D}/cover-preview.webp");
 
         var refreshedSecond = _db.PdfDocuments.AsNoTracking().Single(p => p.Id == second.Id);
         refreshedSecond.CoverGenerationStatus.Should().Be(nameof(PdfCoverGenerationStatus.Skipped));
@@ -243,7 +252,7 @@ public sealed class BackfillPdfCoversJobTests : IDisposable
         ConfigureBlobReturningStream();
         ConfigureExtractorReturning(PdfCoverExtractionOutcome.Skipped);
 
-        await CreateJob().RunBatchAsync(_db, _extractor.Object, _blob.Object, _eventCollector.Object, default);
+        await CreateJob().RunBatchAsync(_db, _extractor.Object, _blob.Object, _coverPipeline.Object, _eventCollector.Object, default);
 
         _extractor.Verify(e => e.ExtractAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()),
             Times.Exactly(BackfillPdfCoversJob.BatchSize));
@@ -273,7 +282,7 @@ public sealed class BackfillPdfCoversJobTests : IDisposable
 
         ConfigureExtractorReturning(PdfCoverExtractionOutcome.Skipped);
 
-        await CreateJob().RunBatchAsync(_db, _extractor.Object, _blob.Object, _eventCollector.Object, default);
+        await CreateJob().RunBatchAsync(_db, _extractor.Object, _blob.Object, _coverPipeline.Object, _eventCollector.Object, default);
 
         retrieveCallOrder.Should().HaveCount(2);
         var olderKey = PdfStorageKey.ForPdf(older.Id);

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Jobs/PdfCoverOrphanRecoveryJobTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Jobs/PdfCoverOrphanRecoveryJobTests.cs
@@ -60,29 +60,33 @@ public sealed class PdfCoverOrphanRecoveryJobTests : IDisposable
         return pdf;
     }
 
+    // #2947 fix: the job checks existence via the RAW-KEY primitive
+    // (GetPresignedUrlForRawKeyAsync), mirroring CoverUrlResolver, NOT the
+    // categorized ExistsAsync (which runs PathSecurity.ValidateIdentifier and
+    // rejects the '/' in the deterministic "covers/pdf/{id:D}/cover" key
+    // convention). All mocks below target GetPresignedUrlForRawKeyAsync.
+
     [Fact]
     public async Task RunBatchAsync_NoGeneratedPdfs_NoOp()
     {
-        // No PDFs in DB at all → ExistsAsync must never be called
+        // No PDFs in DB at all → the raw-key existence check must never be called
         await CreateJob().RunBatchAsync(_db, _blob.Object, CancellationToken.None);
 
-        _blob.Verify(b => b.ExistsAsync(
-                It.IsAny<string>(), It.IsAny<BlobCategory>(),
-                It.IsAny<string>(), It.IsAny<CancellationToken>()),
+        _blob.Verify(b => b.GetPresignedUrlForRawKeyAsync(
+                It.IsAny<string>(), It.IsAny<int?>()),
             Times.Never);
     }
 
     [Fact]
     public async Task RunBatchAsync_AllGeneratedExist_NoReset()
     {
-        // 3 PDFs, all with CoverR2Key, all returning true from ExistsAsync
+        // 3 PDFs, all with CoverR2Key, all resolving to a non-null presigned URL
         SeedPdf(coverR2Key: "pdf-cover-aaa");
         SeedPdf(coverR2Key: "pdf-cover-bbb");
         SeedPdf(coverR2Key: "pdf-cover-ccc");
 
-        _blob.Setup(b => b.ExistsAsync(It.IsAny<string>(), BlobCategory.GameImage,
-                It.IsAny<string>(), It.IsAny<CancellationToken>()))
-             .ReturnsAsync(true);
+        _blob.Setup(b => b.GetPresignedUrlForRawKeyAsync(It.IsAny<string>(), It.IsAny<int?>()))
+             .ReturnsAsync("https://presigned.example/cover-preview.webp");
 
         await CreateJob().RunBatchAsync(_db, _blob.Object, CancellationToken.None);
 
@@ -98,15 +102,14 @@ public sealed class PdfCoverOrphanRecoveryJobTests : IDisposable
     [Fact]
     public async Task RunBatchAsync_OrphanDetected_ResetsToPending()
     {
-        // 1 PDF with key, ExistsAsync returns false → orphan → reset all 4 fields
+        // 1 PDF with key, raw-key check returns null (object absent) → orphan → reset all 4 fields
         var orphan = SeedPdf(coverR2Key: "pdf-cover-missing");
         orphan.CoverGenerationError = "stale-error";
         orphan.CoverPageIndex = 2;
         _db.SaveChanges();
 
-        _blob.Setup(b => b.ExistsAsync(It.IsAny<string>(), BlobCategory.GameImage,
-                It.IsAny<string>(), It.IsAny<CancellationToken>()))
-             .ReturnsAsync(false);
+        _blob.Setup(b => b.GetPresignedUrlForRawKeyAsync(It.IsAny<string>(), It.IsAny<int?>()))
+             .ReturnsAsync((string?)null);
 
         await CreateJob().RunBatchAsync(_db, _blob.Object, CancellationToken.None);
 
@@ -126,29 +129,26 @@ public sealed class PdfCoverOrphanRecoveryJobTests : IDisposable
             SeedPdf(coverR2Key: $"pdf-cover-{i:D2}", updatedAt: DateTime.UtcNow.AddMinutes(-i));
         }
 
-        _blob.Setup(b => b.ExistsAsync(It.IsAny<string>(), BlobCategory.GameImage,
-                It.IsAny<string>(), It.IsAny<CancellationToken>()))
-             .ReturnsAsync(true); // All exist → no resets, only call count matters
+        _blob.Setup(b => b.GetPresignedUrlForRawKeyAsync(It.IsAny<string>(), It.IsAny<int?>()))
+             .ReturnsAsync("https://presigned.example/cover-preview.webp"); // All exist → no resets, only call count matters
 
         await CreateJob().RunBatchAsync(_db, _blob.Object, CancellationToken.None);
 
-        _blob.Verify(b => b.ExistsAsync(It.IsAny<string>(), BlobCategory.GameImage,
-                It.IsAny<string>(), It.IsAny<CancellationToken>()),
+        _blob.Verify(b => b.GetPresignedUrlForRawKeyAsync(It.IsAny<string>(), It.IsAny<int?>()),
             Times.Exactly(PdfCoverOrphanRecoveryJob.BatchSize));
     }
 
     [Fact]
     public async Task RunBatchAsync_ExistsAsyncThrows_LogsAndContinuesBatch()
     {
-        // First PDF: ExistsAsync throws → skip (stays Generated)
-        // Second PDF: ExistsAsync returns false → reset to Pending
+        // First PDF: raw-key check throws → skip (stays Generated)
+        // Second PDF: raw-key check returns null → reset to Pending
         var first = SeedPdf(coverR2Key: "pdf-cover-throws", updatedAt: DateTime.UtcNow.AddMinutes(-10));
         var second = SeedPdf(coverR2Key: "pdf-cover-missing", updatedAt: DateTime.UtcNow);
 
-        _blob.SetupSequence(b => b.ExistsAsync(It.IsAny<string>(), BlobCategory.GameImage,
-                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+        _blob.SetupSequence(b => b.GetPresignedUrlForRawKeyAsync(It.IsAny<string>(), It.IsAny<int?>()))
              .ThrowsAsync(new InvalidOperationException("Network error"))
-             .ReturnsAsync(false);
+             .ReturnsAsync((string?)null);
 
         await CreateJob().RunBatchAsync(_db, _blob.Object, CancellationToken.None);
 
@@ -160,5 +160,38 @@ public sealed class PdfCoverOrphanRecoveryJobTests : IDisposable
         secondResult.CoverGenerationStatus.Should().Be(nameof(PdfCoverGenerationStatus.Pending),
             "second orphan must be reset despite first item throwing");
         secondResult.CoverR2Key.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task RunBatchAsync_NewConventionKey_RawKeyExists_NoReset()
+    {
+        var pdf = SeedPdf(coverR2Key: $"covers/pdf/{Guid.NewGuid():D}/cover");
+
+        _blob.Setup(b => b.GetPresignedUrlForRawKeyAsync(
+                $"{pdf.CoverR2Key}-preview.webp", It.IsAny<int?>()))
+             .ReturnsAsync("https://presigned.example/cover-preview.webp");
+
+        await CreateJob().RunBatchAsync(_db, _blob.Object, CancellationToken.None);
+
+        var result = _db.PdfDocuments.AsNoTracking().Single(p => p.Id == pdf.Id);
+        result.CoverGenerationStatus.Should().Be(nameof(PdfCoverGenerationStatus.Generated),
+            "the raw object exists in R2 — a valid new-convention cover must not be reset");
+        result.CoverR2Key.Should().Be(pdf.CoverR2Key);
+    }
+
+    [Fact]
+    public async Task RunBatchAsync_NewConventionKey_RawKeyMissing_ResetsToPending()
+    {
+        var pdf = SeedPdf(coverR2Key: $"covers/pdf/{Guid.NewGuid():D}/cover");
+
+        _blob.Setup(b => b.GetPresignedUrlForRawKeyAsync(
+                $"{pdf.CoverR2Key}-preview.webp", It.IsAny<int?>()))
+             .ReturnsAsync((string?)null);
+
+        await CreateJob().RunBatchAsync(_db, _blob.Object, CancellationToken.None);
+
+        var result = _db.PdfDocuments.AsNoTracking().Single(p => p.Id == pdf.Id);
+        result.CoverGenerationStatus.Should().Be(nameof(PdfCoverGenerationStatus.Pending));
+        result.CoverR2Key.Should().BeNull();
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineServiceCoverTestFactory.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineServiceCoverTestFactory.cs
@@ -1,0 +1,50 @@
+using Api.BoundedContexts.DocumentProcessing.Application.Services;
+using Api.BoundedContexts.DocumentProcessing.Infrastructure.External;
+using Api.BoundedContexts.KnowledgeBase.Application.Services;
+using Api.Infrastructure;
+using Api.Services;
+using Api.Services.Pdf;
+using Api.SharedKernel.Application.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace Api.Tests.BoundedContexts.DocumentProcessing.Application.Services;
+
+/// <summary>
+/// Issue #2947 — builds a <see cref="PdfProcessingPipelineService"/> with only the
+/// collaborators the cover path touches wired to real/mocked instances and all
+/// other required constructor dependencies stubbed with permissive mocks. Keeps
+/// the cover-focused test independent of the large main fixture.
+/// </summary>
+internal static class PdfProcessingPipelineServiceCoverTestFactory
+{
+    public static PdfProcessingPipelineService Create(
+        MeepleAiDbContext db,
+        IBlobStorageService blob,
+        IPdfCoverExtractor coverExtractor,
+        IPdfCoverUploadPipeline coverUploadPipeline,
+        IDomainEventCollector eventCollector)
+    {
+        return new PdfProcessingPipelineService(
+            db: db,
+            pdfClaimService: Mock.Of<IPdfClaimService>(),
+            pdfTextExtractor: Mock.Of<IPdfTextExtractor>(),
+            tableExtractor: Mock.Of<IPdfTableExtractor>(),
+            chunkingService: Mock.Of<ITextChunkingService>(),
+            embeddingService: Mock.Of<IEmbeddingService>(),
+            blobStorageService: blob,
+            timeProvider: TimeProvider.System,
+            logger: NullLogger<PdfProcessingPipelineService>.Instance,
+            languageDetector: Mock.Of<ILanguageDetector>(),
+            chunkTranslationService: Mock.Of<IChunkTranslationService>(),
+            indexingPipeline: Mock.Of<IPdfIndexingPipeline>(),
+            raptorIndexer: null,
+            entityExtractor: null,
+            vectorStore: null,
+            featureFlagService: null,
+            roleClassifier: null,
+            pdfCoverExtractor: coverExtractor,
+            eventCollector: eventCollector,
+            pdfCoverUploadPipeline: coverUploadPipeline);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineServiceCoverTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineServiceCoverTests.cs
@@ -1,0 +1,94 @@
+using Api.BoundedContexts.DocumentProcessing.Application.Services;
+using Api.BoundedContexts.DocumentProcessing.Domain.Events;
+using Api.BoundedContexts.KnowledgeBase.Application.Services;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Services;
+using Api.Services.Pdf;
+using Api.SharedKernel.Application.Services;
+using Api.SharedKernel.Domain.Interfaces;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.DocumentProcessing.Application.Services;
+
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "DocumentProcessing")]
+public sealed class PdfProcessingPipelineServiceCoverTests : IDisposable
+{
+    private readonly MeepleAiDbContext _db;
+    private readonly Mock<IPdfCoverExtractor> _coverExtractor = new();
+    private readonly Mock<IPdfCoverUploadPipeline> _coverPipeline = new();
+    private readonly Mock<IBlobStorageService> _blob = new();
+    private readonly Mock<IDomainEventCollector> _eventCollector = new();
+    private readonly List<IDomainEvent> _collected = new();
+
+    public PdfProcessingPipelineServiceCoverTests()
+    {
+        var options = new DbContextOptionsBuilder<MeepleAiDbContext>()
+            .UseInMemoryDatabase($"PdfPipelineCover_{Guid.NewGuid()}")
+            .Options;
+        _db = new MeepleAiDbContext(options, new Mock<IMediator>().Object, new Mock<IDomainEventCollector>().Object);
+        _eventCollector.Setup(c => c.Collect(It.IsAny<IDomainEvent>()))
+                       .Callback<IDomainEvent>(e => _collected.Add(e));
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    [Fact]
+    public async Task ExtractCoverImageAsync_Generated_UploadsPreviewViaPipelineWithDeterministicKey()
+    {
+        var pdf = new PdfDocumentEntity
+        {
+            Id = Guid.NewGuid(),
+            FileName = "rules.pdf",
+            FilePath = "/tmp/rules.pdf",
+            FileSizeBytes = 1,
+            ContentType = "application/pdf",
+            UploadedByUserId = Guid.NewGuid(),
+            UploadedAt = DateTime.UtcNow,
+            ProcessingState = "Extracting",
+            CoverGenerationStatus = "Pending",
+            SharedGameId = Guid.NewGuid(),
+        };
+
+        _blob.Setup(b => b.RetrieveAsync(It.IsAny<string>(), BlobCategory.Pdf, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+             .ReturnsAsync(() => new MemoryStream(new byte[] { 0x25, 0x50, 0x44, 0x46 }));
+        _coverExtractor.Setup(e => e.ExtractAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+                       .ReturnsAsync(new PdfCoverExtractionResult
+                       {
+                           Outcome = PdfCoverExtractionOutcome.Generated,
+                           ThumbnailWebp = new byte[] { 1 },
+                           PreviewWebp = new byte[] { 9, 9, 9 },
+                           SelectedPageIndex = 0,
+                       });
+
+        var expectedKey = $"covers/pdf/{pdf.Id:D}/cover";
+        _coverPipeline.Setup(p => p.UploadAsync(expectedKey, It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+                      .ReturnsAsync(expectedKey);
+
+        var sut = PdfProcessingPipelineServiceCoverTestFactory.Create(
+            _db, _blob.Object, _coverExtractor.Object, _coverPipeline.Object, _eventCollector.Object);
+
+        await sut.InvokeExtractCoverImageForTestAsync(pdf, "/tmp/rules.pdf", CancellationToken.None);
+
+        _coverPipeline.Verify(p => p.UploadAsync(
+            expectedKey,
+            It.Is<byte[]>(b => b.SequenceEqual(new byte[] { 9, 9, 9 })),
+            It.IsAny<CancellationToken>()), Times.Once);
+        _blob.Verify(b => b.StoreAsync(
+            It.IsAny<Stream>(), It.IsAny<string>(), BlobCategory.GameImage, It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+
+        pdf.CoverR2Key.Should().Be(expectedKey);
+        pdf.CoverGenerationStatus.Should().Be("Generated");
+
+        _collected.Should().ContainSingle()
+            .Which.Should().BeOfType<PdfCoverGeneratedEvent>()
+            .Which.CoverR2Key.Should().Be(expectedKey);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Infrastructure/Services/GamebookPhotoStorageServiceTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Infrastructure/Services/GamebookPhotoStorageServiceTests.cs
@@ -66,6 +66,12 @@ public sealed class GamebookPhotoStorageServiceTests
             return Task.FromResult<string?>(null);
         }
 
+        public Task<bool> DeleteRawKeyAsync(string rawKey, CancellationToken ct = default)
+        {
+            _ = (rawKey, ct);
+            return Task.FromResult(true);
+        }
+
         public Task<string?> GetPresignedUrlForRawKeyAsync(string rawKey, int? expirySeconds = null)
         {
             _ = (rawKey, expirySeconds);

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/BggCoverDownloaderTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/BggCoverDownloaderTests.cs
@@ -1,6 +1,5 @@
 using System.Net;
 using Api.BoundedContexts.SharedGameCatalog.Application.Services;
-using Api.Services.Pdf;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -11,80 +10,81 @@ namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Services;
 
 public sealed class BggCoverDownloaderTests
 {
-    private readonly Mock<IBlobStorageService> _blobMock = new();
+    private readonly Mock<IBggCoverUploadPipeline> _pipelineMock = new();
     private readonly Mock<ILogger<BggCoverDownloader>> _loggerMock = new();
 
-    // A public, non-private IP literal (RFC 5737 TEST-NET-3). Using an IP literal keeps the SSRF
-    // guard's DNS resolution offline/deterministic in unit tests (Dns.GetHostAddressesAsync on a
-    // literal returns it without a DNS query), while still passing the private-IP check.
+    // RFC 5737 TEST-NET-3 literal keeps the SSRF DNS check offline/deterministic.
     private const string PublicHttpsUrl = "https://203.0.113.10/abc.jpg";
 
     [Fact]
-    public async Task DownloadAndUploadAsync_OnSuccess_ReturnsR2Key()
+    public async Task DownloadAndUploadAsync_OnSuccess_ReturnsPipelineKey()
     {
-        // Arrange
-        var httpClient = BuildHttpClient(HttpStatusCode.OK, content: new byte[] { 0x89, 0x50, 0x4E, 0x47 /* fake PNG header */ });
-        _blobMock.Setup(b => b.StoreAsync(
-                It.IsAny<Stream>(),
-                It.IsAny<string>(),
-                BlobCategory.GameImage,
-                "bgg-cover-13",
-                It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new BlobStorageResult(Success: true, FileId: "bgg-cover-13", FilePath: "bgg-cover-13", FileSizeBytes: 4, ErrorMessage: null));
+        var httpClient = BuildHttpClient(HttpStatusCode.OK, content: new byte[] { 0x89, 0x50, 0x4E, 0x47 });
+        _pipelineMock
+            .Setup(p => p.UploadAsync(13, It.IsAny<byte[]>(), ".jpg", It.IsAny<CancellationToken>()))
+            .ReturnsAsync("bgg-covers/13/cover.jpg");
 
-        var sut = new BggCoverDownloader(httpClient, _blobMock.Object, _loggerMock.Object);
+        var sut = new BggCoverDownloader(httpClient, _pipelineMock.Object, _loggerMock.Object);
 
-        // Act
         var result = await sut.DownloadAndUploadAsync(13, PublicHttpsUrl, CancellationToken.None);
 
-        // Assert
-        result.Should().Be("bgg-cover-13");
+        result.Should().Be("bgg-covers/13/cover.jpg");
+        _pipelineMock.Verify(p => p.UploadAsync(13, It.IsAny<byte[]>(), ".jpg", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task DownloadAndUploadAsync_PassesUrlExtensionToPipeline()
+    {
+        var httpClient = BuildHttpClient(HttpStatusCode.OK, content: new byte[] { 0x01 });
+        _pipelineMock
+            .Setup(p => p.UploadAsync(99, It.IsAny<byte[]>(), ".png", It.IsAny<CancellationToken>()))
+            .ReturnsAsync("bgg-covers/99/cover.png");
+
+        var sut = new BggCoverDownloader(httpClient, _pipelineMock.Object, _loggerMock.Object);
+
+        var result = await sut.DownloadAndUploadAsync(99, "https://203.0.113.10/image.PNG", CancellationToken.None);
+
+        result.Should().Be("bgg-covers/99/cover.png");
+        _pipelineMock.Verify(p => p.UploadAsync(99, It.IsAny<byte[]>(), ".png", It.IsAny<CancellationToken>()), Times.Once);
     }
 
     [Fact]
     public async Task DownloadAndUploadAsync_OnHttpError_ReturnsNull()
     {
-        // Arrange
         var httpClient = BuildHttpClient(HttpStatusCode.NotFound);
-        var sut = new BggCoverDownloader(httpClient, _blobMock.Object, _loggerMock.Object);
+        var sut = new BggCoverDownloader(httpClient, _pipelineMock.Object, _loggerMock.Object);
 
-        // Act
         var result = await sut.DownloadAndUploadAsync(13, PublicHttpsUrl, CancellationToken.None);
 
-        // Assert
         result.Should().BeNull();
-        _blobMock.Verify(b => b.StoreAsync(
-            It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
-            Times.Never);
+        _pipelineMock.Verify(p => p.UploadAsync(
+            It.IsAny<int>(), It.IsAny<byte[]>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     [Fact]
-    public async Task DownloadAndUploadAsync_OnUploadFailure_ReturnsNull()
+    public async Task DownloadAndUploadAsync_OnPipelineThrows_ReturnsNull()
     {
-        // Arrange
         var httpClient = BuildHttpClient(HttpStatusCode.OK, content: new byte[] { 0x01 });
-        _blobMock.Setup(b => b.StoreAsync(
-                It.IsAny<Stream>(), It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new BlobStorageResult(Success: false, FileId: null, FilePath: null, FileSizeBytes: 0, ErrorMessage: "S3 unavailable"));
+        _pipelineMock
+            .Setup(p => p.UploadAsync(It.IsAny<int>(), It.IsAny<byte[]>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new Amazon.S3.AmazonS3Exception("S3 unavailable"));
 
-        var sut = new BggCoverDownloader(httpClient, _blobMock.Object, _loggerMock.Object);
+        var sut = new BggCoverDownloader(httpClient, _pipelineMock.Object, _loggerMock.Object);
 
-        // Act
         var result = await sut.DownloadAndUploadAsync(13, PublicHttpsUrl, CancellationToken.None);
 
-        // Assert
         result.Should().BeNull();
     }
 
-    // ---- SSRF guard (#2655 finding #10) ----
+    // ---- SSRF guard (#2655 finding #10) — unchanged behaviour ----
 
     [Theory]
-    [InlineData("http://203.0.113.10/abc.jpg")]      // non-HTTPS scheme
-    [InlineData("ftp://203.0.113.10/abc.jpg")]        // non-HTTP scheme
+    [InlineData("http://203.0.113.10/abc.jpg")]
+    [InlineData("ftp://203.0.113.10/abc.jpg")]
     public async Task DownloadAndUploadAsync_NonHttpsUrl_BlockedWithoutFetching(string url)
     {
         var handler = TrackingHandler(HttpStatusCode.OK, new byte[] { 0x01 });
-        var sut = new BggCoverDownloader(new HttpClient(handler.Object), _blobMock.Object, _loggerMock.Object);
+        var sut = new BggCoverDownloader(new HttpClient(handler.Object), _pipelineMock.Object, _loggerMock.Object);
 
         var result = await sut.DownloadAndUploadAsync(13, url, CancellationToken.None);
 
@@ -93,13 +93,13 @@ public sealed class BggCoverDownloaderTests
     }
 
     [Theory]
-    [InlineData("https://127.0.0.1/abc.jpg")]         // loopback
-    [InlineData("https://169.254.169.254/latest")]    // cloud metadata endpoint
-    [InlineData("https://10.0.0.5/abc.jpg")]          // RFC 1918 private
+    [InlineData("https://127.0.0.1/abc.jpg")]
+    [InlineData("https://169.254.169.254/latest")]
+    [InlineData("https://10.0.0.5/abc.jpg")]
     public async Task DownloadAndUploadAsync_PrivateOrReservedIp_BlockedWithoutFetching(string url)
     {
         var handler = TrackingHandler(HttpStatusCode.OK, new byte[] { 0x01 });
-        var sut = new BggCoverDownloader(new HttpClient(handler.Object), _blobMock.Object, _loggerMock.Object);
+        var sut = new BggCoverDownloader(new HttpClient(handler.Object), _pipelineMock.Object, _loggerMock.Object);
 
         var result = await sut.DownloadAndUploadAsync(13, url, CancellationToken.None);
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/CoverUrlResolverTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/CoverUrlResolverTests.cs
@@ -217,8 +217,8 @@ public class CoverUrlResolverTests
     public async Task ResolvePublicAsync_EmitsR2BggMetric_WhenL25BggCoverWins()
     {
         using var capture = new CoverMetricsCapture();
-        var sg = new SharedGameEntity { BggCoverR2Key = "bgg-key" };
-        _blob.Setup(b => b.GetPresignedDownloadUrlAsync("bgg-key", BlobCategory.GameImage, "bgg-key", null))
+        var sg = new SharedGameEntity { BggCoverR2Key = "bgg-covers/13/cover.jpg" };
+        _blob.Setup(b => b.GetPresignedUrlForRawKeyAsync("bgg-covers/13/cover.jpg", null))
              .ReturnsAsync("https://r2/bgg.jpg");
 
         await CoverUrlResolver.ResolvePublicAsync(sg, _blob.Object);
@@ -227,6 +227,25 @@ public class CoverUrlResolverTests
             m.Name == "meepleai.cover.resolution.total" &&
             m.Value == 1 &&
             string.Equals(m.Tags["source"] as string, "r2_bgg", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task ResolvePublicAsync_L25BggSlashKey_ResolvesViaRawKeyMethodNoSuffix()
+    {
+        // Issue #2947: BGG DB key is the FULL physical key (contains '/' and a
+        // dot-extension) and the resolver passes it verbatim to
+        // GetPresignedUrlForRawKeyAsync with NO appended suffix. The legacy
+        // GetPresignedDownloadUrlAsync path (PathSecurity.ValidateIdentifier)
+        // would have rejected the '/' and '.'.
+        var sg = new SharedGameEntity { BggCoverR2Key = "bgg-covers/42/cover.png" };
+        _blob.Setup(b => b.GetPresignedUrlForRawKeyAsync("bgg-covers/42/cover.png", null))
+             .ReturnsAsync("https://r2/bgg-42.png");
+
+        var url = await CoverUrlResolver.ResolvePublicAsync(sg, _blob.Object);
+
+        url.Should().Be("https://r2/bgg-42.png");
+        _blob.Verify(b => b.GetPresignedDownloadUrlAsync(
+            It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<int?>()), Times.Never);
     }
 
     [Fact]

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Services/BggCoverUploadPipelineTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Services/BggCoverUploadPipelineTests.cs
@@ -3,6 +3,8 @@ using Amazon.S3.Model;
 using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
 using Api.Services.Pdf;
 using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Moq;
 using System.Net;
@@ -156,5 +158,40 @@ public sealed class BggCoverUploadPipelineTests : IDisposable
     {
         Action act = () => new BggCoverUploadPipeline(_mockS3Client.Object, _options, null!);
         act.Should().Throw<ArgumentNullException>().WithParameterName("logger");
+    }
+}
+
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class BggCoverUploadPipelineDiTests
+{
+    [Fact]
+    public void AddSharedGameCatalogContext_RegistersBggCoverUploadPipeline()
+    {
+        var config = new Microsoft.Extensions.Configuration.ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["S3_ENDPOINT"] = "https://test.r2.cloudflarestorage.com",
+                ["S3_ACCESS_KEY"] = "ak",
+                ["S3_SECRET_KEY"] = "sk",
+                ["S3_BUCKET_NAME"] = "bucket",
+                ["S3_REGION"] = "auto",
+            })
+            .Build();
+
+        var services = new Microsoft.Extensions.DependencyInjection.ServiceCollection();
+        // The pipeline factory resolves IConfiguration from DI
+        // (sp.GetRequiredService<IConfiguration>()), so the built config MUST be
+        // registered on the same collection — otherwise resolution throws
+        // "No service for type 'IConfiguration'" instead of returning the pipeline.
+        services.AddSingleton<Microsoft.Extensions.Configuration.IConfiguration>(config);
+        Api.BoundedContexts.SharedGameCatalog.Infrastructure.DependencyInjection.SharedGameCatalogServiceExtensions
+            .RegisterBggCoverUploadPipelineForTests(services);
+
+        using var provider = services.BuildServiceProvider();
+        var pipeline = provider.GetService<Api.BoundedContexts.SharedGameCatalog.Application.Services.IBggCoverUploadPipeline>();
+
+        pipeline.Should().NotBeNull();
+        pipeline.Should().BeOfType<BggCoverUploadPipeline>();
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Services/BggCoverUploadPipelineTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Services/BggCoverUploadPipelineTests.cs
@@ -1,0 +1,160 @@
+using Amazon.S3;
+using Amazon.S3.Model;
+using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
+using Api.Services.Pdf;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System.Net;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
+
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class BggCoverUploadPipelineTests : IDisposable
+{
+    private readonly Mock<IAmazonS3> _mockS3Client;
+    private readonly Mock<ILogger<BggCoverUploadPipeline>> _mockLogger;
+    private readonly S3StorageOptions _options;
+    private readonly BggCoverUploadPipeline _sut;
+
+    public BggCoverUploadPipelineTests()
+    {
+        _mockS3Client = new Mock<IAmazonS3>(MockBehavior.Strict);
+        _mockLogger = new Mock<ILogger<BggCoverUploadPipeline>>();
+        _options = new S3StorageOptions
+        {
+            Endpoint = "https://test.r2.cloudflarestorage.com",
+            AccessKey = "test-access-key",
+            SecretKey = "test-secret-key",
+            BucketName = "test-bucket",
+            Region = "auto",
+            PresignedUrlExpirySeconds = 3600,
+            EnableEncryption = true,
+            ForcePathStyle = false
+        };
+        _sut = new BggCoverUploadPipeline(_mockS3Client.Object, _options, _mockLogger.Object);
+    }
+
+    public void Dispose() => _mockS3Client.Reset();
+
+    [Fact]
+    public async Task UploadAsync_ValidBytes_PutsObjectWithDeterministicKeyIncludingExtension()
+    {
+        var bytes = new byte[] { 0x89, 0x50, 0x4E, 0x47 };
+        PutObjectRequest? captured = null;
+        _mockS3Client
+            .Setup(x => x.PutObjectAsync(It.IsAny<PutObjectRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<PutObjectRequest, CancellationToken>((req, _) => captured = req)
+            .ReturnsAsync(new PutObjectResponse { HttpStatusCode = HttpStatusCode.OK, ETag = "\"abc\"" });
+
+        var key = await _sut.UploadAsync(13, bytes, ".jpg", CancellationToken.None);
+
+        captured.Should().NotBeNull();
+        captured!.Key.Should().Be("bgg-covers/13/cover.jpg", "physical R2 key is deterministic + keeps the source extension");
+        captured.BucketName.Should().Be("test-bucket");
+        key.Should().Be("bgg-covers/13/cover.jpg", "the returned DB key is the exact physical key (resolver appends no suffix)");
+    }
+
+    [Fact]
+    public async Task UploadAsync_NullOrEmptyExtension_DefaultsToJpg()
+    {
+        var bytes = new byte[] { 0x01 };
+        var keys = new List<string>();
+        _mockS3Client
+            .Setup(x => x.PutObjectAsync(It.IsAny<PutObjectRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<PutObjectRequest, CancellationToken>((req, _) => keys.Add(req.Key))
+            .ReturnsAsync(new PutObjectResponse { HttpStatusCode = HttpStatusCode.OK });
+
+        var k1 = await _sut.UploadAsync(7, bytes, null!, CancellationToken.None);
+        var k2 = await _sut.UploadAsync(8, bytes, "", CancellationToken.None);
+
+        k1.Should().Be("bgg-covers/7/cover.jpg");
+        k2.Should().Be("bgg-covers/8/cover.jpg");
+        keys.Should().BeEquivalentTo(new[] { "bgg-covers/7/cover.jpg", "bgg-covers/8/cover.jpg" });
+    }
+
+    [Fact]
+    public async Task UploadAsync_SetsCacheControlImmutable1Year()
+    {
+        var bytes = new byte[] { 0x01 };
+        PutObjectRequest? captured = null;
+        _mockS3Client
+            .Setup(x => x.PutObjectAsync(It.IsAny<PutObjectRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<PutObjectRequest, CancellationToken>((req, _) => captured = req)
+            .ReturnsAsync(new PutObjectResponse { HttpStatusCode = HttpStatusCode.OK });
+
+        await _sut.UploadAsync(1, bytes, ".png", CancellationToken.None);
+
+        captured.Should().NotBeNull();
+        captured!.Headers.CacheControl.Should().Be("public, max-age=31536000, immutable");
+    }
+
+    [Fact]
+    public async Task UploadAsync_NullBytes_ThrowsArgumentException()
+    {
+        Func<Task> act = async () => await _sut.UploadAsync(1, null!, ".jpg", CancellationToken.None);
+
+        await act.Should().ThrowAsync<ArgumentException>().WithMessage("*imageBytes*");
+        _mockS3Client.Verify(x => x.PutObjectAsync(It.IsAny<PutObjectRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task UploadAsync_EmptyBytes_ThrowsArgumentException()
+    {
+        Func<Task> act = async () => await _sut.UploadAsync(1, Array.Empty<byte>(), ".jpg", CancellationToken.None);
+
+        await act.Should().ThrowAsync<ArgumentException>().WithMessage("*imageBytes*");
+        _mockS3Client.Verify(x => x.PutObjectAsync(It.IsAny<PutObjectRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task UploadAsync_Cancellation_RethrowsOperationCanceledException()
+    {
+        var bytes = new byte[] { 0x01 };
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        _mockS3Client
+            .Setup(x => x.PutObjectAsync(It.IsAny<PutObjectRequest>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new OperationCanceledException(cts.Token));
+
+        Func<Task> act = async () => await _sut.UploadAsync(1, bytes, ".jpg", cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
+    public async Task UploadAsync_S3Exception_Rethrows()
+    {
+        var bytes = new byte[] { 0x01 };
+        _mockS3Client
+            .Setup(x => x.PutObjectAsync(It.IsAny<PutObjectRequest>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new AmazonS3Exception("boom") { StatusCode = HttpStatusCode.InternalServerError, ErrorCode = "InternalError" });
+
+        Func<Task> act = async () => await _sut.UploadAsync(1, bytes, ".jpg", CancellationToken.None);
+
+        await act.Should().ThrowAsync<AmazonS3Exception>();
+    }
+
+    [Fact]
+    public void Ctor_NullS3Client_ThrowsArgumentNullException()
+    {
+        Action act = () => new BggCoverUploadPipeline(null!, _options, _mockLogger.Object);
+        act.Should().Throw<ArgumentNullException>().WithParameterName("s3Client");
+    }
+
+    [Fact]
+    public void Ctor_NullOptions_ThrowsArgumentNullException()
+    {
+        Action act = () => new BggCoverUploadPipeline(_mockS3Client.Object, null!, _mockLogger.Object);
+        act.Should().Throw<ArgumentNullException>().WithParameterName("options");
+    }
+
+    [Fact]
+    public void Ctor_NullLogger_ThrowsArgumentNullException()
+    {
+        Action act = () => new BggCoverUploadPipeline(_mockS3Client.Object, _options, null!);
+        act.Should().Throw<ArgumentNullException>().WithParameterName("logger");
+    }
+}

--- a/apps/api/tests/Api.Tests/Integration/GameManagement/GameNightPhotoUploadTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/GameManagement/GameNightPhotoUploadTests.cs
@@ -70,6 +70,8 @@ public sealed class GameNightPhotoUploadTests : IAsyncLifetime
             => Task.FromResult<string?>(null);
         public Task<string?> GetPresignedUrlForRawKeyAsync(string rawKey, int? expirySeconds = null)
             => Task.FromResult<string?>(null);
+        public Task<bool> DeleteRawKeyAsync(string rawKey, CancellationToken ct = default)
+            => Task.FromResult(true);
     }
 
     public async ValueTask InitializeAsync()

--- a/apps/api/tests/Api.Tests/Integration/GameManagement/PlayRecordPhotoUploadTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/GameManagement/PlayRecordPhotoUploadTests.cs
@@ -96,6 +96,8 @@ public sealed class PlayRecordPhotoUploadTests : IAsyncLifetime
             => Task.FromResult<string?>(null);
         public Task<string?> GetPresignedUrlForRawKeyAsync(string rawKey, int? expirySeconds = null)
             => Task.FromResult<string?>(null);
+        public Task<bool> DeleteRawKeyAsync(string rawKey, CancellationToken ct = default)
+            => Task.FromResult(true);
     }
 
     // ---------------------------------------------------------------------------

--- a/apps/api/tests/Api.Tests/Integration/SharedGameCatalog/CoverR2ConventionIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/SharedGameCatalog/CoverR2ConventionIntegrationTests.cs
@@ -1,0 +1,220 @@
+using Amazon.Runtime;
+using Amazon.S3;
+using Amazon.S3.Model;
+using Api.BoundedContexts.DocumentProcessing.Infrastructure.Services;
+using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
+using Api.Services.Pdf;
+using Api.Tests.Infrastructure;
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Containers;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.Integration.SharedGameCatalog;
+
+/// <summary>
+/// Issue #2947 — end-to-end round-trip proving the deterministic R2 cover-key
+/// convention actually resolves through a real S3-compatible store: write via
+/// each dedicated upload pipeline (raw <see cref="IAmazonS3.PutObjectAsync"/>
+/// against a deterministic key), then resolve via
+/// <see cref="S3BlobStorageService.GetPresignedUrlForRawKeyAsync"/> exactly as
+/// <c>CoverUrlResolver</c> does, and HTTP-GET the presigned URL to confirm the
+/// bytes round-trip.
+/// </summary>
+/// <remarks>
+/// Uses the same standalone MinIO Testcontainer + skip convention as
+/// <see cref="Api.Tests.Integration.DocumentProcessing.S3BlobStorageIntegrationTests"/>
+/// (harness copied verbatim per Issue #2947 Task 6 Step 1). MinIO-over-HTTP does
+/// not support <c>DisablePayloadSigning</c>, so these tests are expected to skip
+/// locally and only run where MinIO/R2-HTTPS is genuinely reachable (CI gated
+/// lane / staging). See CLAUDE.md "Known Flaky Tests" — this is intentional, not
+/// a regression.
+/// </remarks>
+[Trait("Category", "Integration")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class CoverR2ConventionIntegrationTests : IAsyncLifetime
+{
+    private IContainer? _minioContainer;
+    private IAmazonS3 _s3Client = null!;
+    private S3StorageOptions _options = null!;
+    private bool _skipTests;
+
+    private const string TestBucket = TestcontainersConfiguration.MinioTestBucket;
+    private const string RootUser = TestcontainersConfiguration.MinioRootUser;
+    private const string RootPassword = TestcontainersConfiguration.MinioRootPassword;
+
+    private void SkipIfNotAvailable()
+    {
+        if (_skipTests)
+            Assert.Skip("S3 storage tests require Docker or TEST_S3_ENDPOINT environment variable");
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        var externalEndpoint = Environment.GetEnvironmentVariable("TEST_S3_ENDPOINT");
+        string endpoint;
+
+        if (!string.IsNullOrWhiteSpace(externalEndpoint))
+        {
+            endpoint = externalEndpoint;
+            Console.WriteLine($"Using external S3 endpoint: {endpoint}");
+        }
+        else
+        {
+            try
+            {
+                _minioContainer = new ContainerBuilder()
+                    .WithImage(TestcontainersConfiguration.MinioImage)
+                    .WithPortBinding(TestcontainersConfiguration.MinioApiPort, true)
+                    .WithPortBinding(TestcontainersConfiguration.MinioConsolePort, true)
+                    .WithEnvironment("MINIO_ROOT_USER", RootUser)
+                    .WithEnvironment("MINIO_ROOT_PASSWORD", RootPassword)
+                    .WithCommand("server", "/data", "--console-address", ":9001")
+                    .WithWaitStrategy(Wait.ForUnixContainer()
+                        .UntilHttpRequestIsSucceeded(r => r
+                            .ForPath("/minio/health/live")
+                            .ForPort(TestcontainersConfiguration.MinioApiPort)
+                            .ForStatusCode(System.Net.HttpStatusCode.OK)))
+                    .WithCleanUp(true)
+                    .Build();
+
+                await _minioContainer.StartAsync();
+
+                var port = _minioContainer.GetMappedPublicPort(TestcontainersConfiguration.MinioApiPort);
+                endpoint = $"http://localhost:{port}";
+                Console.WriteLine($"MinIO container started at {endpoint}");
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Failed to start MinIO container: {ex.Message}. S3 tests will be skipped.");
+                _skipTests = true;
+                return;
+            }
+        }
+
+        try
+        {
+            var credentials = new BasicAWSCredentials(
+                Environment.GetEnvironmentVariable("TEST_S3_ACCESS_KEY") ?? RootUser,
+                Environment.GetEnvironmentVariable("TEST_S3_SECRET_KEY") ?? RootPassword);
+
+            var s3Config = new AmazonS3Config
+            {
+                ServiceURL = endpoint,
+                ForcePathStyle = true, // Required for MinIO
+                AuthenticationRegion = "us-east-1"
+            };
+
+            _s3Client = new AmazonS3Client(credentials, s3Config);
+
+            try
+            {
+                await _s3Client.PutBucketAsync(new PutBucketRequest { BucketName = TestBucket });
+            }
+            catch (AmazonS3Exception ex) when (ex.ErrorCode == "BucketAlreadyOwnedByYou" || ex.ErrorCode == "BucketAlreadyExists")
+            {
+                // Bucket already exists, OK
+            }
+
+            _options = new S3StorageOptions
+            {
+                Endpoint = endpoint,
+                AccessKey = Environment.GetEnvironmentVariable("TEST_S3_ACCESS_KEY") ?? RootUser,
+                SecretKey = Environment.GetEnvironmentVariable("TEST_S3_SECRET_KEY") ?? RootPassword,
+                BucketName = TestBucket,
+                Region = "us-east-1",
+                PresignedUrlExpirySeconds = 3600,
+                EnableEncryption = false, // MinIO doesn't require SSE
+                ForcePathStyle = true
+            };
+
+            // Quick smoke test to verify S3 connectivity (mirrors S3BlobStorageIntegrationTests).
+            var probeLogger = new Mock<Microsoft.Extensions.Logging.ILogger<S3BlobStorageService>>().Object;
+            var probeService = new S3BlobStorageService(_s3Client, _options, probeLogger);
+            using var probe = new MemoryStream("probe"u8.ToArray());
+            var probeResult = await probeService.StoreAsync(probe, "probe.txt", BlobCategory.Pdf, "healthcheck");
+            if (!probeResult.Success)
+            {
+                Console.WriteLine($"S3 connectivity probe failed: {probeResult.ErrorMessage}. Tests will be skipped.");
+                _skipTests = true;
+                return;
+            }
+            await probeService.DeleteAsync(probeResult.FileId!, BlobCategory.Pdf, "healthcheck");
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Failed to initialize S3 client: {ex.Message}. S3 tests will be skipped.");
+            _skipTests = true;
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _s3Client?.Dispose();
+
+        if (_minioContainer != null)
+        {
+            await _minioContainer.StopAsync();
+            await _minioContainer.DisposeAsync();
+        }
+    }
+
+    private S3BlobStorageService BuildBlobService()
+        => new(_s3Client, _options, new Mock<Microsoft.Extensions.Logging.ILogger<S3BlobStorageService>>().Object);
+
+    [Fact]
+    public async Task BggCover_Uploaded_ResolvesViaRawKeyNoSuffix_And200()
+    {
+        SkipIfNotAvailable();
+
+        var bggPipeline = new BggCoverUploadPipeline(_s3Client, _options, NullLogger<BggCoverUploadPipeline>.Instance);
+        var bytes = new byte[] { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A };
+
+        var dbKey = await bggPipeline.UploadAsync(13, bytes, ".jpg", CancellationToken.None);
+        dbKey.Should().Be("bgg-covers/13/cover.jpg");
+
+        var blob = BuildBlobService();
+        var url = await blob.GetPresignedUrlForRawKeyAsync(dbKey);
+        url.Should().NotBeNull();
+
+        using var http = new HttpClient();
+        using var resp = await http.GetAsync(url);
+        resp.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
+        (await resp.Content.ReadAsByteArrayAsync()).Should().BeEquivalentTo(bytes);
+    }
+
+    [Fact]
+    public async Task PdfCover_Uploaded_ResolvesViaPreviewSuffix_And200()
+    {
+        SkipIfNotAvailable();
+
+        var pdfPipeline = new PdfCoverUploadPipeline(_s3Client, _options, NullLogger<PdfCoverUploadPipeline>.Instance);
+        var id = Guid.NewGuid();
+        var dbKey = $"covers/pdf/{id:D}/cover";
+        var bytes = new byte[] { 0x52, 0x49, 0x46, 0x46 };
+
+        var returned = await pdfPipeline.UploadAsync(dbKey, bytes, CancellationToken.None);
+        returned.Should().Be(dbKey);
+
+        var blob = BuildBlobService();
+        var url = await blob.GetPresignedUrlForRawKeyAsync($"{dbKey}-preview.webp");
+        url.Should().NotBeNull();
+
+        using var http = new HttpClient();
+        using var resp = await http.GetAsync(url);
+        resp.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
+        (await resp.Content.ReadAsByteArrayAsync()).Should().BeEquivalentTo(bytes);
+    }
+
+    [Fact]
+    public async Task MissingKey_ResolvesToNull_FailClosed()
+    {
+        SkipIfNotAvailable();
+
+        var blob = BuildBlobService();
+        var url = await blob.GetPresignedUrlForRawKeyAsync("bgg-covers/999/cover.jpg");
+        url.Should().BeNull("fail-closed existence check must return null for a non-existent object");
+    }
+}

--- a/docs/for-developers/audits/2026-07-15-issue-2947-r2-cover-convention.md
+++ b/docs/for-developers/audits/2026-07-15-issue-2947-r2-cover-convention.md
@@ -1,0 +1,66 @@
+# Issue #2947 — Deterministic R2 cover keys
+
+All cover write-sites now compose a deterministic physical R2 key that
+`CoverUrlResolver` reconstructs from the DB-persisted key via
+`IBlobStorageService.GetPresignedUrlForRawKeyAsync` (the earlier
+`IBlobStorageService.StoreAsync` path minted a random `Guid.NewGuid()` fileId
+that could not be reconstructed).
+
+| Layer | Writer | DB key (persisted) | Physical R2 object | Resolver read |
+|-------|--------|--------------------|--------------------|---------------|
+| L2 Wikidata | `CoverR2UploadPipeline` | `covers/{gameId}/cover` | `covers/{gameId}/cover.webp` | `{dbKey}.webp` |
+| L2.5 BGG | `BggCoverUploadPipeline` | `bgg-covers/{bggId}/cover{ext}` | same as DB key | `{dbKey}` (no suffix) |
+| L4 PDF (pipeline + backfill) | `PdfCoverUploadPipeline` | `covers/pdf/{pdfId:D}/cover` | `covers/pdf/{pdfId:D}/cover-preview.webp` | `{dbKey}-preview.webp` |
+
+BGG is the only layer that does NOT append a suffix at read time: it keeps the
+source image extension (BGG serves jpg/png, not webp), so the DB key IS the
+physical key.
+
+## Write-sites migrated
+
+- `BggCoverDownloader.DownloadAndUploadAsync` — now delegates to
+  `IBggCoverUploadPipeline.UploadAsync`, a raw `IAmazonS3.PutObjectAsync` call
+  against the deterministic key `bgg-covers/{bggId}/cover{ext}` (mirrors the
+  existing `CoverR2UploadPipeline` / `PdfCoverUploadPipeline` pattern).
+- `BackfillPdfCoversJob.ProcessOneAsync` (Generated branch) — now calls
+  `IPdfCoverUploadPipeline.UploadAsync(dbKey, previewBytes, ct)` instead of two
+  `IBlobStorageService.StoreAsync` calls. Only the preview size is written; the
+  thumbnail size is dropped since the resolver never reads it.
+- `PdfProcessingPipelineService.ExtractCoverImageAsync` (Generated branch) —
+  same change as the backfill job, via an optional `IPdfCoverUploadPipeline?`
+  constructor parameter (null-safe for pre-#2947 unit-test constructors).
+
+## Resolver change
+
+`CoverUrlResolver.ResolvePublicAsync`'s L2.5 BGG branch switched from the
+legacy `GetPresignedDownloadUrlAsync(fileId, category, resourceKey)` — which
+validated both arguments via `PathSecurity.ValidateIdentifier` (rejecting `/`
+and `.`, so a slash-and-dot-containing key like `bgg-covers/13/cover.jpg`
+always failed silently) — to `GetPresignedUrlForRawKeyAsync(BggCoverR2Key)`
+with no suffix appended.
+
+## Root cause
+
+`S3BlobStorageService.StoreAsync` mints a random `Guid.NewGuid()` fileId
+(`S3BlobStorageService.cs:69`), producing a physical key
+`game-images/{resourceKey}/{guid}_{file}` that cannot be reconstructed from the
+DB-persisted key alone. Every migrated write-site instead talks directly to
+`IAmazonS3.PutObjectAsync` with a key computed purely from IDs already
+persisted on the entity (`bggId`, `pdfId`), so the resolver can rebuild the
+exact physical key at read time without any additional lookup or random
+component.
+
+## Test coverage
+
+- Unit tests (`Mock<IAmazonS3>`) assert the exact deterministic
+  `PutObjectRequest.Key` for `BggCoverUploadPipeline`.
+- `CoverUrlResolverTests` covers the L2.5 raw-key resolution path plus a
+  slash/dot regression guard.
+- `BggCoverDownloaderTests` / `BackfillPdfCoversJobTests` /
+  `PdfProcessingPipelineServiceCoverTests` assert the pipeline is invoked with
+  the deterministic key and that the legacy `StoreAsync` call is never made.
+- `CoverR2ConventionIntegrationTests` (gated, `[Trait("Category", "Integration")]`)
+  proves the full write → resolve → HTTP GET round-trip against a real
+  S3-compatible store (MinIO Testcontainer / `TEST_S3_ENDPOINT`). Skips locally
+  per the documented `DisablePayloadSigning`-over-HTTP MinIO limitation; runs
+  in the gated CI/staging lane.

--- a/docs/superpowers/plans/2026-07-15-issue-2947-r2-cover-convention.md
+++ b/docs/superpowers/plans/2026-07-15-issue-2947-r2-cover-convention.md
@@ -1,0 +1,1658 @@
+# Issue #2947 — Unify R2 Cover Convention (BGG L2.5 + Backfill L4 + Pipeline L4) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make every cover write-site produce a *deterministic* R2 physical key that `CoverUrlResolver` can reconstruct from the DB-persisted key, so BGG (L2.5) and PDF-cover (L4 pipeline + L4 backfill) covers resolve instead of falling through to placeholder.
+
+**Architecture:** The proven pattern (`CoverR2UploadPipeline` for Wikidata, `PdfCoverUploadPipeline` for PDF materialization) talks directly to `IAmazonS3.PutObjectAsync` with a *raw, deterministic* object key, and the resolver reconstructs that exact key at read time via `IBlobStorageService.GetPresignedUrlForRawKeyAsync(rawKey)`. Today the three remaining write-sites (`BggCoverDownloader`, `BackfillPdfCoversJob`, `PdfProcessingPipelineService`) instead call `IBlobStorageService.StoreAsync`, which mints a random `Guid.NewGuid()` fileId (`S3BlobStorageService.cs:69`) → the physical key `game-images/{resourceKey}/{guid}_{file}` is non-reconstructible from the DB-persisted base key. This plan introduces two dedicated raw-S3 upload pipelines (`BggCoverUploadPipeline`, and reuses the existing `PdfCoverUploadPipeline` for the two PDF write-sites), rewires the three write-sites to persist a deterministic key, and switches the resolver's L2.5 BGG branch from the legacy `GetPresignedDownloadUrlAsync` to `GetPresignedUrlForRawKeyAsync`.
+
+**Tech Stack:** .NET 9, ASP.NET Minimal APIs + MediatR (CQRS), AWSSDK.S3 (`IAmazonS3`), EF Core (InMemory for unit tests), xUnit + Moq + FluentAssertions, Quartz (backfill job).
+
+## Global Constraints
+
+- **Branch name:** `feature/issue-2947-r2-cover-convention` — created FROM `main-dev` (HEAD = `963ebbd65`, merge of #2943). Run the pre-creation safety check: `git branch --show-current` MUST print `main-dev`, `git status` MUST be clean of source changes, then `git checkout -b feature/issue-2947-r2-cover-convention`.
+- **PR target:** parent branch `main-dev` (NOT `main`). After creating the branch: `git config branch.feature/issue-2947-r2-cover-convention.parent main-dev`.
+- **Commit convention:** `feat|fix|refactor|test|chore(scope): description`. Scope = `catalog` for BGG, `pdf`/`docproc` for PDF pipeline/backfill.
+- **GOTCHA — Meziantou MA0025:** `throw new NotImplementedException()` stubs are a BUILD ERROR. Every task does REAL TDD: red test → minimal REAL implementation. Never scaffold with a throwing stub.
+- **GOTCHA — SonarAnalyzer S1135:** a `// TODO(...)` comment in C# is a BUILD ERROR. Use `// Follow-up:` if you must annotate deferred work.
+- **GOTCHA — CQRS:** endpoints call ONLY `IMediator.Send()`; never inject a service directly into an endpoint. (This plan touches no endpoints — services + a Quartz job + a static resolver — so no endpoint edits.)
+- **GOTCHA — DDD:** entities have private setters + factory methods; value objects are immutable records with validation in their factory. (This plan adds no new entity/VO; `SharedGameEntity.BggCoverR2Key` is an existing EF persistence entity with a public setter — leave it as-is.)
+- **GOTCHA — Exceptions:** use `ConflictException` (409) / `NotFoundException` (404); NEVER `InvalidOperationException` (500) for domain/validation errors. Argument validation on new pipelines uses `ArgumentException` (matches `CoverR2UploadPipeline`/`PdfCoverUploadPipeline`).
+- **GOTCHA — DI:** register BOTH the interface `IService` and its implementation. New pipeline is registered as a singleton via a factory delegate that lazily builds the `AmazonS3Client` from `S3_*` config (mirror `RegisterCoverR2UploadPipeline` / `RegisterPdfCoverUploadPipeline` verbatim, including `s3Client.BeforeRequestEvent += BlobStorageServiceFactory.StripUnsupportedR2Headers`).
+- **GOTCHA — test namespace `Unit` collision:** `Api.Tests.Unit` exists; if you `using MediatR;` (which exposes `Unit`) in a test that also references the `Unit` type, fully-qualify. This plan's tests do not need MediatR's `Unit`. When mocking an `ICommand : IRequest` handler you would use `.Returns(Task.CompletedTask)` NOT `.ReturnsAsync(Unit.Value)` — not needed here (no command handler is mocked).
+- **GOTCHA — testhost:** kill any lingering testhost before running tests: `tasklist | grep testhost` → `taskkill //PID <PID> //F`. Percentages/culture: use `$"{val*100:0}%"` (culture-independent) — not applicable in this plan (no percentage formatting).
+- **Test commands (this repo):** BE `cd apps/api/src/Api && dotnet test --filter "<FullyQualifiedName~...>"` (run from the API project dir; the test project is referenced). FE not used (BE-only issue).
+- **Integration-test caveat (documented, NOT a blocker):** the Testcontainers-MinIO end-to-end R2 test skips locally because MinIO-over-HTTP rejects `DisablePayloadSigning`. This plan is **unit-first**: every write-site is covered by a `Mock<IAmazonS3>`-based unit test that asserts the exact deterministic `PutObjectRequest.Key`, plus a resolver unit test asserting the reconstructed raw key. Task 6 adds a **skippable** MinIO integration test guarded exactly like the existing gated integration tests so CI runs it where MinIO/R2-HTTPS is available and it is inert locally.
+
+---
+
+## File Structure
+
+**New files:**
+- `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/IBggCoverUploadPipeline.cs` — contract for the BGG raw-S3 upload pipeline (returns the exact physical key persisted to `BggCoverR2Key`).
+- `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/BggCoverUploadPipeline.cs` — `IAmazonS3` PutObject to `bgg-covers/{bggId}/cover{ext}`; returns that full key verbatim (BGG images keep their original extension; the resolver passes the key with NO suffix appended).
+- `apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Services/BggCoverUploadPipelineTests.cs` — unit tests (Mock<IAmazonS3>) asserting deterministic key, content-type, cache-control, validation, cancellation, S3-error rethrow.
+- `apps/api/tests/Api.Tests/Integration/SharedGameCatalog/CoverR2ConventionIntegrationTests.cs` — gated MinIO/R2 end-to-end round-trip (write via each pipeline → resolve via `GetPresignedUrlForRawKeyAsync` → HTTP-GET the presigned URL → assert 200 + bytes).
+
+**Modified files:**
+- `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/BggCoverDownloader.cs` — inject `IBggCoverUploadPipeline` instead of `IBlobStorageService`; on HTTP success, buffer bytes and delegate to the pipeline; return the pipeline's raw key.
+- `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/CoverUrlResolver.cs:91-110` — L2.5 BGG branch (comment starts line 91, `if` block ends line 110) resolves via `GetPresignedUrlForRawKeyAsync(sharedGame.BggCoverR2Key)` (no suffix), not the legacy `GetPresignedDownloadUrlAsync(...)`.
+- `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs` — register `IBggCoverUploadPipeline` singleton; adjust the `AddHttpClient<IBggCoverDownloader, BggCoverDownloader>` registration (typed client still works — the pipeline is resolved from DI, not the HttpClient factory).
+- `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Jobs/BackfillPdfCoversJob.cs:121-235` — replace the two `blob.StoreAsync` calls (`ProcessOneAsync` Generated branch) with a single `IPdfCoverUploadPipeline.UploadAsync(dbKey, previewBytes, ct)`; inject the pipeline via the DI scope; persist the deterministic dbKey.
+- `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs:517-609` — replace the two `_blobStorageService.StoreAsync` calls in `ExtractCoverImageAsync` with `_pdfCoverUploadPipeline.UploadAsync(dbKey, previewBytes, ct)`; add the optional `IPdfCoverUploadPipeline?` ctor param; persist the deterministic dbKey.
+- `apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/BggCoverDownloaderTests.cs` — update mocks from `IBlobStorageService.StoreAsync` to `IBggCoverUploadPipeline.UploadAsync`.
+- `apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/CoverUrlResolverTests.cs` — L2.5 BGG metric test switches expectation to `GetPresignedUrlForRawKeyAsync`; add a slash/dot BGG key regression test.
+- `apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Jobs/BackfillPdfCoversJobTests.cs` — replace `StoreAsync` verifications with `IPdfCoverUploadPipeline.UploadAsync` verifications; assert the persisted deterministic key.
+
+**Key conventions locked by this plan:**
+- **BGG physical + DB key (L2.5):** physical R2 object = `bgg-covers/{bggId}/cover{ext}` (ext preserved, e.g. `.jpg`). DB `BggCoverR2Key` = that SAME full key verbatim. Resolver calls `GetPresignedUrlForRawKeyAsync(BggCoverR2Key)` with **no** suffix. (Asymmetry vs L4/L2 which append a suffix — documented in the resolver + interface XML doc.)
+- **PDF cover DB key (L4, both write-sites):** DB `CoverR2Key`/`PdfCoverR2Key` = `covers/pdf/{pdfId:D}/cover` (no suffix). Physical R2 object = `covers/pdf/{pdfId:D}/cover-preview.webp` (the `-preview.webp` suffix is appended by `PdfCoverUploadPipeline.UploadAsync` AND by the resolver's L4 branch — they must match). Only the **preview** size is uploaded to R2 (the resolver only ever reads `-preview.webp`; the thumbnail size was never read by the resolver and is dropped from the R2 write to remove the non-deterministic second blob).
+
+---
+
+### Task 1: BGG raw-S3 upload pipeline (`IBggCoverUploadPipeline` + impl)
+
+De-risking slice: a self-contained new pipeline with no consumers yet. Mirrors `PdfCoverUploadPipeline` exactly (raw `IAmazonS3`, no `IBlobStorageService` indirection).
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/IBggCoverUploadPipeline.cs`
+- Create: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/BggCoverUploadPipeline.cs`
+- Test: `apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Services/BggCoverUploadPipelineTests.cs`
+
+**Interfaces:**
+- Consumes: `Amazon.S3.IAmazonS3`, `Api.Services.Pdf.S3StorageOptions` (existing options record with `.BucketName`), `Amazon.S3.Model.PutObjectRequest`/`PutObjectResponse`.
+- Produces: `internal interface IBggCoverUploadPipeline { Task<string> UploadAsync(int bggId, byte[] imageBytes, string extension, CancellationToken ct); }` — returns the full physical key `bgg-covers/{bggId}/cover{extension}` (verbatim, persisted to `SharedGameEntity.BggCoverR2Key`). `extension` is a dot-prefixed lowercase extension (e.g. `.jpg`); the pipeline normalizes a null/empty/invalid extension to `.jpg`.
+
+- [ ] **Step 1: Write the failing test file**
+
+Create `apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Services/BggCoverUploadPipelineTests.cs`:
+
+```csharp
+using Amazon.S3;
+using Amazon.S3.Model;
+using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
+using Api.Services.Pdf;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using System.Net;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
+
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class BggCoverUploadPipelineTests : IDisposable
+{
+    private readonly Mock<IAmazonS3> _mockS3Client;
+    private readonly Mock<ILogger<BggCoverUploadPipeline>> _mockLogger;
+    private readonly S3StorageOptions _options;
+    private readonly BggCoverUploadPipeline _sut;
+
+    public BggCoverUploadPipelineTests()
+    {
+        _mockS3Client = new Mock<IAmazonS3>(MockBehavior.Strict);
+        _mockLogger = new Mock<ILogger<BggCoverUploadPipeline>>();
+        _options = new S3StorageOptions
+        {
+            Endpoint = "https://test.r2.cloudflarestorage.com",
+            AccessKey = "test-access-key",
+            SecretKey = "test-secret-key",
+            BucketName = "test-bucket",
+            Region = "auto",
+            PresignedUrlExpirySeconds = 3600,
+            EnableEncryption = true,
+            ForcePathStyle = false
+        };
+        _sut = new BggCoverUploadPipeline(_mockS3Client.Object, _options, _mockLogger.Object);
+    }
+
+    public void Dispose() => _mockS3Client.Reset();
+
+    [Fact]
+    public async Task UploadAsync_ValidBytes_PutsObjectWithDeterministicKeyIncludingExtension()
+    {
+        var bytes = new byte[] { 0x89, 0x50, 0x4E, 0x47 };
+        PutObjectRequest? captured = null;
+        _mockS3Client
+            .Setup(x => x.PutObjectAsync(It.IsAny<PutObjectRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<PutObjectRequest, CancellationToken>((req, _) => captured = req)
+            .ReturnsAsync(new PutObjectResponse { HttpStatusCode = HttpStatusCode.OK, ETag = "\"abc\"" });
+
+        var key = await _sut.UploadAsync(13, bytes, ".jpg", CancellationToken.None);
+
+        captured.Should().NotBeNull();
+        captured!.Key.Should().Be("bgg-covers/13/cover.jpg", "physical R2 key is deterministic + keeps the source extension");
+        captured.BucketName.Should().Be("test-bucket");
+        key.Should().Be("bgg-covers/13/cover.jpg", "the returned DB key is the exact physical key (resolver appends no suffix)");
+    }
+
+    [Fact]
+    public async Task UploadAsync_NullOrEmptyExtension_DefaultsToJpg()
+    {
+        var bytes = new byte[] { 0x01 };
+        var keys = new List<string>();
+        _mockS3Client
+            .Setup(x => x.PutObjectAsync(It.IsAny<PutObjectRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<PutObjectRequest, CancellationToken>((req, _) => keys.Add(req.Key))
+            .ReturnsAsync(new PutObjectResponse { HttpStatusCode = HttpStatusCode.OK });
+
+        var k1 = await _sut.UploadAsync(7, bytes, null!, CancellationToken.None);
+        var k2 = await _sut.UploadAsync(8, bytes, "", CancellationToken.None);
+
+        k1.Should().Be("bgg-covers/7/cover.jpg");
+        k2.Should().Be("bgg-covers/8/cover.jpg");
+        keys.Should().BeEquivalentTo(new[] { "bgg-covers/7/cover.jpg", "bgg-covers/8/cover.jpg" });
+    }
+
+    [Fact]
+    public async Task UploadAsync_SetsCacheControlImmutable1Year()
+    {
+        var bytes = new byte[] { 0x01 };
+        PutObjectRequest? captured = null;
+        _mockS3Client
+            .Setup(x => x.PutObjectAsync(It.IsAny<PutObjectRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<PutObjectRequest, CancellationToken>((req, _) => captured = req)
+            .ReturnsAsync(new PutObjectResponse { HttpStatusCode = HttpStatusCode.OK });
+
+        await _sut.UploadAsync(1, bytes, ".png", CancellationToken.None);
+
+        captured.Should().NotBeNull();
+        captured!.Headers.CacheControl.Should().Be("public, max-age=31536000, immutable");
+    }
+
+    [Fact]
+    public async Task UploadAsync_NullBytes_ThrowsArgumentException()
+    {
+        Func<Task> act = async () => await _sut.UploadAsync(1, null!, ".jpg", CancellationToken.None);
+
+        await act.Should().ThrowAsync<ArgumentException>().WithMessage("*imageBytes*");
+        _mockS3Client.Verify(x => x.PutObjectAsync(It.IsAny<PutObjectRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task UploadAsync_EmptyBytes_ThrowsArgumentException()
+    {
+        Func<Task> act = async () => await _sut.UploadAsync(1, Array.Empty<byte>(), ".jpg", CancellationToken.None);
+
+        await act.Should().ThrowAsync<ArgumentException>().WithMessage("*imageBytes*");
+        _mockS3Client.Verify(x => x.PutObjectAsync(It.IsAny<PutObjectRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task UploadAsync_Cancellation_RethrowsOperationCanceledException()
+    {
+        var bytes = new byte[] { 0x01 };
+        using var cts = new CancellationTokenSource();
+        cts.Cancel();
+        _mockS3Client
+            .Setup(x => x.PutObjectAsync(It.IsAny<PutObjectRequest>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new OperationCanceledException(cts.Token));
+
+        Func<Task> act = async () => await _sut.UploadAsync(1, bytes, ".jpg", cts.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>();
+    }
+
+    [Fact]
+    public async Task UploadAsync_S3Exception_Rethrows()
+    {
+        var bytes = new byte[] { 0x01 };
+        _mockS3Client
+            .Setup(x => x.PutObjectAsync(It.IsAny<PutObjectRequest>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new AmazonS3Exception("boom") { StatusCode = HttpStatusCode.InternalServerError, ErrorCode = "InternalError" });
+
+        Func<Task> act = async () => await _sut.UploadAsync(1, bytes, ".jpg", CancellationToken.None);
+
+        await act.Should().ThrowAsync<AmazonS3Exception>();
+    }
+
+    [Fact]
+    public void Ctor_NullS3Client_ThrowsArgumentNullException()
+    {
+        Action act = () => new BggCoverUploadPipeline(null!, _options, _mockLogger.Object);
+        act.Should().Throw<ArgumentNullException>().WithParameterName("s3Client");
+    }
+
+    [Fact]
+    public void Ctor_NullOptions_ThrowsArgumentNullException()
+    {
+        Action act = () => new BggCoverUploadPipeline(_mockS3Client.Object, null!, _mockLogger.Object);
+        act.Should().Throw<ArgumentNullException>().WithParameterName("options");
+    }
+
+    [Fact]
+    public void Ctor_NullLogger_ThrowsArgumentNullException()
+    {
+        Action act = () => new BggCoverUploadPipeline(_mockS3Client.Object, _options, null!);
+        act.Should().Throw<ArgumentNullException>().WithParameterName("logger");
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails (does not compile)**
+
+Run: `cd apps/api/src/Api && dotnet test --filter "FullyQualifiedName~BggCoverUploadPipelineTests"`
+Expected: BUILD FAIL — `The type or namespace name 'BggCoverUploadPipeline' could not be found` (the interface + impl do not exist yet).
+
+- [ ] **Step 3: Create the interface**
+
+Create `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/IBggCoverUploadPipeline.cs`:
+
+```csharp
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Services;
+
+/// <summary>
+/// Issue #2947 — uploads a downloaded BGG cover image to R2 under a
+/// deterministic key so <see cref="CoverUrlResolver"/> can reconstruct it.
+/// <para>
+/// Unlike <c>CoverR2UploadPipeline</c> (Wikidata) and <c>PdfCoverUploadPipeline</c>
+/// which store a suffix-stripped DB key and append a suffix at read time, the
+/// BGG cover keeps its ORIGINAL image extension (BGG serves jpg/png, not webp).
+/// The returned key is therefore the FULL physical object key
+/// (<c>bgg-covers/{bggId}/cover{extension}</c>) and the resolver's L2.5 branch
+/// passes it verbatim to <c>GetPresignedUrlForRawKeyAsync</c> with NO suffix.
+/// </para>
+/// </summary>
+internal interface IBggCoverUploadPipeline
+{
+    /// <summary>
+    /// Uploads <paramref name="imageBytes"/> to R2 as
+    /// <c>bgg-covers/{bggId}/cover{extension}</c> with an immutable cache-control
+    /// header, then returns that exact key — the value to persist on
+    /// <c>SharedGameEntity.BggCoverR2Key</c>.
+    /// </summary>
+    /// <param name="bggId">BoardGameGeek game id; the cover namespace.</param>
+    /// <param name="imageBytes">The downloaded cover image bytes. Must be non-null and non-empty.</param>
+    /// <param name="extension">Dot-prefixed lowercase extension (e.g. <c>.jpg</c>);
+    /// null/empty/invalid normalizes to <c>.jpg</c>.</param>
+    /// <param name="ct">Cancellation token.</param>
+    /// <returns>The full deterministic physical key persisted to the DB.</returns>
+    /// <exception cref="System.ArgumentException">When <paramref name="imageBytes"/> is null or empty.</exception>
+    /// <exception cref="Amazon.S3.AmazonS3Exception">When the underlying S3 client fails.</exception>
+    /// <exception cref="System.OperationCanceledException">When <paramref name="ct"/> signals cancellation.</exception>
+    Task<string> UploadAsync(int bggId, byte[] imageBytes, string extension, CancellationToken ct);
+}
+```
+
+- [ ] **Step 4: Create the implementation**
+
+Create `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/BggCoverUploadPipeline.cs`:
+
+```csharp
+using Amazon.S3;
+using Amazon.S3.Model;
+using Api.BoundedContexts.SharedGameCatalog.Application.Services;
+using Api.Services.Pdf;
+using Microsoft.Extensions.Logging;
+using System.Globalization;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
+
+/// <summary>
+/// Issue #2947 — R2 upload pipeline for BGG-downloaded cover images. Mirrors
+/// <see cref="CoverR2UploadPipeline"/> / <c>PdfCoverUploadPipeline</c>: talks
+/// directly to <see cref="IAmazonS3"/> with a raw deterministic key rather than
+/// going through <c>IBlobStorageService.StoreAsync</c> (which mints a random
+/// fileId the resolver cannot reconstruct).
+/// </summary>
+internal sealed class BggCoverUploadPipeline : IBggCoverUploadPipeline
+{
+    // Cover assets are immutable for 1 year; re-uploads reuse the same key so
+    // Cloudflare CDN cache stays warm (mirrors CoverR2UploadPipeline).
+    private const string ImmutableCacheControl = "public, max-age=31536000, immutable";
+    private const string DefaultExtension = ".jpg";
+
+    private readonly IAmazonS3 _s3Client;
+    private readonly S3StorageOptions _options;
+    private readonly ILogger<BggCoverUploadPipeline> _logger;
+
+    public BggCoverUploadPipeline(
+        IAmazonS3 s3Client,
+        S3StorageOptions options,
+        ILogger<BggCoverUploadPipeline> logger)
+    {
+        _s3Client = s3Client ?? throw new ArgumentNullException(nameof(s3Client));
+        _options = options ?? throw new ArgumentNullException(nameof(options));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<string> UploadAsync(int bggId, byte[] imageBytes, string extension, CancellationToken ct)
+    {
+        if (imageBytes is null || imageBytes.Length == 0)
+        {
+            throw new ArgumentException("imageBytes must be non-null and non-empty.", nameof(imageBytes));
+        }
+
+        var ext = NormalizeExtension(extension);
+        var contentType = ContentTypeFor(ext);
+        // Deterministic physical key = DB key (resolver appends NO suffix for L2.5).
+        var objectKey = $"bgg-covers/{bggId.ToString(CultureInfo.InvariantCulture)}/cover{ext}";
+
+        using var stream = new MemoryStream(imageBytes, writable: false);
+        var request = new PutObjectRequest
+        {
+            BucketName = _options.BucketName,
+            Key = objectKey,
+            InputStream = stream,
+            ContentType = contentType,
+            AutoCloseStream = false,
+            // Required for S3-compatible providers (R2/MinIO) that don't support
+            // STREAMING-AWS4-HMAC-SHA256-PAYLOAD-TRAILER (mirrors CoverR2UploadPipeline).
+            DisablePayloadSigning = true,
+        };
+        request.Headers.CacheControl = ImmutableCacheControl;
+
+        // OperationCanceledException propagates naturally from PutObjectAsync.
+        try
+        {
+            var response = await _s3Client.PutObjectAsync(request, ct).ConfigureAwait(false);
+            _logger.LogInformation(
+                "Uploaded BGG cover to R2: BggId={BggId}, Key={Key}, Size={Size} bytes, ETag={ETag}",
+                bggId, objectKey, imageBytes.Length, response.ETag);
+            return objectKey;
+        }
+        catch (AmazonS3Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "R2 BGG cover upload failed: BggId={BggId}, Key={Key}, StatusCode={Status}, ErrorCode={ErrorCode}",
+                bggId, objectKey, ex.StatusCode, ex.ErrorCode);
+            throw;
+        }
+    }
+
+    private static string NormalizeExtension(string extension)
+    {
+        if (string.IsNullOrWhiteSpace(extension))
+        {
+            return DefaultExtension;
+        }
+
+        var ext = extension.StartsWith('.') ? extension : "." + extension;
+        ext = ext.ToLowerInvariant();
+        return ext switch
+        {
+            ".jpg" or ".jpeg" or ".png" or ".gif" or ".webp" => ext,
+            _ => DefaultExtension,
+        };
+    }
+
+    private static string ContentTypeFor(string normalizedExtension) => normalizedExtension switch
+    {
+        ".png" => "image/png",
+        ".gif" => "image/gif",
+        ".webp" => "image/webp",
+        _ => "image/jpeg",
+    };
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd apps/api/src/Api && dotnet test --filter "FullyQualifiedName~BggCoverUploadPipelineTests"`
+Expected: PASS (10 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/IBggCoverUploadPipeline.cs apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/BggCoverUploadPipeline.cs apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Services/BggCoverUploadPipelineTests.cs
+git commit -m "feat(catalog): add deterministic BggCoverUploadPipeline (raw R2 PutObject)"
+```
+
+---
+
+### Task 2: Rewire `BggCoverDownloader` to the new pipeline + resolver L2.5 branch
+
+Switches the BGG write-site off `IBlobStorageService.StoreAsync` and the resolver's read-side off the legacy `GetPresignedDownloadUrlAsync`. This is the "smallest self-contained slice" from the triage.
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/BggCoverDownloader.cs:9-94`
+- Modify: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/CoverUrlResolver.cs:91-110`
+- Test: `apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/BggCoverDownloaderTests.cs`
+- Test: `apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/CoverUrlResolverTests.cs`
+
+**Interfaces:**
+- Consumes: `IBggCoverUploadPipeline.UploadAsync(int bggId, byte[] imageBytes, string extension, CancellationToken ct) → Task<string>` (Task 1). `IBlobStorageService.GetPresignedUrlForRawKeyAsync(string rawKey, int? expirySeconds = null) → Task<string?>` (existing, `IBlobStorageService.cs:158`).
+- Produces: `BggCoverDownloader.DownloadAndUploadAsync(int bggId, string remoteImageUrl, CancellationToken ct) → Task<string?>` now returns the pipeline's full raw key (e.g. `bgg-covers/13/cover.jpg`) instead of `bgg-cover-{bggId}`. The value persisted to `SharedGameEntity.BggCoverR2Key` by `CreateSharedGameFromPdfCommandHandler.cs:174` therefore changes shape — the resolver is updated in the same task to match.
+
+- [ ] **Step 1: Update the resolver test for the new L2.5 raw-key call**
+
+In `apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/CoverUrlResolverTests.cs`, replace the body of `ResolvePublicAsync_EmitsR2BggMetric_WhenL25BggCoverWins` (currently lines 216-230, using `GetPresignedDownloadUrlAsync`) with:
+
+```csharp
+    [Fact]
+    public async Task ResolvePublicAsync_EmitsR2BggMetric_WhenL25BggCoverWins()
+    {
+        using var capture = new CoverMetricsCapture();
+        var sg = new SharedGameEntity { BggCoverR2Key = "bgg-covers/13/cover.jpg" };
+        _blob.Setup(b => b.GetPresignedUrlForRawKeyAsync("bgg-covers/13/cover.jpg", null))
+             .ReturnsAsync("https://r2/bgg.jpg");
+
+        await CoverUrlResolver.ResolvePublicAsync(sg, _blob.Object);
+
+        capture.LongMeasurements.Should().ContainSingle(m =>
+            m.Name == "meepleai.cover.resolution.total" &&
+            m.Value == 1 &&
+            string.Equals(m.Tags["source"] as string, "r2_bgg", StringComparison.Ordinal));
+    }
+```
+
+Then add a new regression test directly below it:
+
+```csharp
+    [Fact]
+    public async Task ResolvePublicAsync_L25BggSlashKey_ResolvesViaRawKeyMethodNoSuffix()
+    {
+        // Issue #2947: BGG DB key is the FULL physical key (contains '/' and a
+        // dot-extension) and the resolver passes it verbatim to
+        // GetPresignedUrlForRawKeyAsync with NO appended suffix. The legacy
+        // GetPresignedDownloadUrlAsync path (PathSecurity.ValidateIdentifier)
+        // would have rejected the '/' and '.'.
+        var sg = new SharedGameEntity { BggCoverR2Key = "bgg-covers/42/cover.png" };
+        _blob.Setup(b => b.GetPresignedUrlForRawKeyAsync("bgg-covers/42/cover.png", null))
+             .ReturnsAsync("https://r2/bgg-42.png");
+
+        var url = await CoverUrlResolver.ResolvePublicAsync(sg, _blob.Object);
+
+        url.Should().Be("https://r2/bgg-42.png");
+        _blob.Verify(b => b.GetPresignedDownloadUrlAsync(
+            It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<int?>()), Times.Never);
+    }
+```
+
+- [ ] **Step 2: Run resolver test to verify it fails**
+
+Run: `cd apps/api/src/Api && dotnet test --filter "FullyQualifiedName~CoverUrlResolverTests.ResolvePublicAsync_L25BggSlashKey_ResolvesViaRawKeyMethodNoSuffix"`
+Expected: FAIL — the resolver still calls `GetPresignedDownloadUrlAsync` (the `GetPresignedUrlForRawKeyAsync` setup is never hit) so `url` is `null` and the `GetPresignedDownloadUrlAsync ... Times.Never` verify fails.
+
+- [ ] **Step 3: Update the resolver L2.5 branch**
+
+In `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/CoverUrlResolver.cs`, replace lines 91-110 (the L2.5 BGG block) with:
+
+```csharp
+        // L2.5 BGG re-uploaded cover (Gap G2 / Issue #2947)
+        // The DB key is the FULL deterministic physical object key composed by
+        // BggCoverUploadPipeline (bgg-covers/{bggId}/cover{ext}). Unlike L4/L2,
+        // NO suffix is appended: BGG keeps its original image extension, so the
+        // stored key IS the physical key. Resolved via the raw-key method (the
+        // legacy GetPresignedDownloadUrlAsync validated the key with
+        // PathSecurity.ValidateIdentifier, which rejects '/' and '.').
+        if (!string.IsNullOrWhiteSpace(sharedGame.BggCoverR2Key))
+        {
+            var url = await blobStorage
+                .GetPresignedUrlForRawKeyAsync(sharedGame.BggCoverR2Key)
+                .ConfigureAwait(false);
+            if (url is not null)
+            {
+                EmitResolution("r2_bgg");
+                return url;
+            }
+        }
+```
+
+Also update the class-level XML doc: in the `<summary>` block (`CoverUrlResolver.cs:22-26`), replace the sentence beginning "L2.5 (BGG) is intentionally UNCHANGED..." through "...pending a follow-up." with:
+
+```csharp
+/// L2.5 (BGG) now resolves via <see cref="IBlobStorageService.GetPresignedUrlForRawKeyAsync"/>
+/// using the full deterministic key written by
+/// <c>BggCoverUploadPipeline</c> (Issue #2947): <c>bgg-covers/{bggId}/cover{ext}</c>,
+/// with no suffix appended (BGG keeps its original image extension).
+```
+
+- [ ] **Step 4: Run resolver tests to verify they pass**
+
+Run: `cd apps/api/src/Api && dotnet test --filter "FullyQualifiedName~CoverUrlResolverTests"`
+Expected: PASS (all resolver tests, including the updated BGG metric test + the new slash-key regression test).
+
+- [ ] **Step 5: Update the BggCoverDownloader test to mock the pipeline**
+
+Replace `apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/BggCoverDownloaderTests.cs` in full:
+
+```csharp
+using System.Net;
+using Api.BoundedContexts.SharedGameCatalog.Application.Services;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Moq.Protected;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Services;
+
+public sealed class BggCoverDownloaderTests
+{
+    private readonly Mock<IBggCoverUploadPipeline> _pipelineMock = new();
+    private readonly Mock<ILogger<BggCoverDownloader>> _loggerMock = new();
+
+    // RFC 5737 TEST-NET-3 literal keeps the SSRF DNS check offline/deterministic.
+    private const string PublicHttpsUrl = "https://203.0.113.10/abc.jpg";
+
+    [Fact]
+    public async Task DownloadAndUploadAsync_OnSuccess_ReturnsPipelineKey()
+    {
+        var httpClient = BuildHttpClient(HttpStatusCode.OK, content: new byte[] { 0x89, 0x50, 0x4E, 0x47 });
+        _pipelineMock
+            .Setup(p => p.UploadAsync(13, It.IsAny<byte[]>(), ".jpg", It.IsAny<CancellationToken>()))
+            .ReturnsAsync("bgg-covers/13/cover.jpg");
+
+        var sut = new BggCoverDownloader(httpClient, _pipelineMock.Object, _loggerMock.Object);
+
+        var result = await sut.DownloadAndUploadAsync(13, PublicHttpsUrl, CancellationToken.None);
+
+        result.Should().Be("bgg-covers/13/cover.jpg");
+        _pipelineMock.Verify(p => p.UploadAsync(13, It.IsAny<byte[]>(), ".jpg", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task DownloadAndUploadAsync_PassesUrlExtensionToPipeline()
+    {
+        var httpClient = BuildHttpClient(HttpStatusCode.OK, content: new byte[] { 0x01 });
+        _pipelineMock
+            .Setup(p => p.UploadAsync(99, It.IsAny<byte[]>(), ".png", It.IsAny<CancellationToken>()))
+            .ReturnsAsync("bgg-covers/99/cover.png");
+
+        var sut = new BggCoverDownloader(httpClient, _pipelineMock.Object, _loggerMock.Object);
+
+        var result = await sut.DownloadAndUploadAsync(99, "https://203.0.113.10/image.PNG", CancellationToken.None);
+
+        result.Should().Be("bgg-covers/99/cover.png");
+        _pipelineMock.Verify(p => p.UploadAsync(99, It.IsAny<byte[]>(), ".png", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task DownloadAndUploadAsync_OnHttpError_ReturnsNull()
+    {
+        var httpClient = BuildHttpClient(HttpStatusCode.NotFound);
+        var sut = new BggCoverDownloader(httpClient, _pipelineMock.Object, _loggerMock.Object);
+
+        var result = await sut.DownloadAndUploadAsync(13, PublicHttpsUrl, CancellationToken.None);
+
+        result.Should().BeNull();
+        _pipelineMock.Verify(p => p.UploadAsync(
+            It.IsAny<int>(), It.IsAny<byte[]>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task DownloadAndUploadAsync_OnPipelineThrows_ReturnsNull()
+    {
+        var httpClient = BuildHttpClient(HttpStatusCode.OK, content: new byte[] { 0x01 });
+        _pipelineMock
+            .Setup(p => p.UploadAsync(It.IsAny<int>(), It.IsAny<byte[]>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new Amazon.S3.AmazonS3Exception("S3 unavailable"));
+
+        var sut = new BggCoverDownloader(httpClient, _pipelineMock.Object, _loggerMock.Object);
+
+        var result = await sut.DownloadAndUploadAsync(13, PublicHttpsUrl, CancellationToken.None);
+
+        result.Should().BeNull();
+    }
+
+    // ---- SSRF guard (#2655 finding #10) — unchanged behaviour ----
+
+    [Theory]
+    [InlineData("http://203.0.113.10/abc.jpg")]
+    [InlineData("ftp://203.0.113.10/abc.jpg")]
+    public async Task DownloadAndUploadAsync_NonHttpsUrl_BlockedWithoutFetching(string url)
+    {
+        var handler = TrackingHandler(HttpStatusCode.OK, new byte[] { 0x01 });
+        var sut = new BggCoverDownloader(new HttpClient(handler.Object), _pipelineMock.Object, _loggerMock.Object);
+
+        var result = await sut.DownloadAndUploadAsync(13, url, CancellationToken.None);
+
+        result.Should().BeNull("a non-HTTPS URL must be blocked by the SSRF guard");
+        VerifyNoHttpCall(handler);
+    }
+
+    [Theory]
+    [InlineData("https://127.0.0.1/abc.jpg")]
+    [InlineData("https://169.254.169.254/latest")]
+    [InlineData("https://10.0.0.5/abc.jpg")]
+    public async Task DownloadAndUploadAsync_PrivateOrReservedIp_BlockedWithoutFetching(string url)
+    {
+        var handler = TrackingHandler(HttpStatusCode.OK, new byte[] { 0x01 });
+        var sut = new BggCoverDownloader(new HttpClient(handler.Object), _pipelineMock.Object, _loggerMock.Object);
+
+        var result = await sut.DownloadAndUploadAsync(13, url, CancellationToken.None);
+
+        result.Should().BeNull("a URL resolving to a private/reserved IP must be blocked by the SSRF guard");
+        VerifyNoHttpCall(handler);
+    }
+
+    private static HttpClient BuildHttpClient(HttpStatusCode statusCode, byte[]? content = null)
+        => new(TrackingHandler(statusCode, content).Object);
+
+    private static Mock<HttpMessageHandler> TrackingHandler(HttpStatusCode statusCode, byte[]? content = null)
+    {
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(new HttpResponseMessage
+            {
+                StatusCode = statusCode,
+                Content = content is null ? null : new ByteArrayContent(content)
+            });
+        return handler;
+    }
+
+    private static void VerifyNoHttpCall(Mock<HttpMessageHandler> handler)
+        => handler.Protected().Verify(
+            "SendAsync",
+            Times.Never(),
+            ItExpr.IsAny<HttpRequestMessage>(),
+            ItExpr.IsAny<CancellationToken>());
+}
+```
+
+- [ ] **Step 6: Run downloader test to verify it fails (does not compile)**
+
+Run: `cd apps/api/src/Api && dotnet test --filter "FullyQualifiedName~BggCoverDownloaderTests"`
+Expected: BUILD FAIL — `BggCoverDownloader` constructor still takes `IBlobStorageService`, not `IBggCoverUploadPipeline`.
+
+- [ ] **Step 7: Rewire `BggCoverDownloader`**
+
+Replace `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/BggCoverDownloader.cs` in full:
+
+```csharp
+using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Services;
+
+internal sealed class BggCoverDownloader : IBggCoverDownloader
+{
+    private readonly HttpClient _httpClient;
+    private readonly IBggCoverUploadPipeline _uploadPipeline;
+    private readonly ILogger<BggCoverDownloader> _logger;
+
+    public BggCoverDownloader(
+        HttpClient httpClient,
+        IBggCoverUploadPipeline uploadPipeline,
+        ILogger<BggCoverDownloader> logger)
+    {
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        _uploadPipeline = uploadPipeline ?? throw new ArgumentNullException(nameof(uploadPipeline));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<string?> DownloadAndUploadAsync(
+        int bggId,
+        string remoteImageUrl,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(remoteImageUrl))
+        {
+            return null;
+        }
+
+        // SSRF guard (#2655 finding #10): only fetch HTTPS URLs that resolve to public IPs.
+        // Fails closed — an invalid scheme or a private/reserved target aborts the download.
+        try
+        {
+            SsrfSafeHttpClient.ValidateUrlScheme(remoteImageUrl);
+            await SsrfSafeHttpClient.ValidateResolvedIpAsync(remoteImageUrl, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (ex is ArgumentException or InvalidOperationException)
+        {
+            _logger.LogWarning(
+                ex,
+                "BGG cover download blocked by SSRF guard: BggId={BggId}, Url={Url}",
+                bggId, remoteImageUrl);
+            return null;
+        }
+
+        try
+        {
+            using var response = await _httpClient
+                .GetAsync(remoteImageUrl, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning(
+                    "BGG cover download failed: BggId={BggId}, Url={Url}, Status={Status}",
+                    bggId, remoteImageUrl, response.StatusCode);
+                return null;
+            }
+
+            var imageBytes = await response.Content.ReadAsByteArrayAsync(cancellationToken).ConfigureAwait(false);
+            if (imageBytes.Length == 0)
+            {
+                _logger.LogWarning("BGG cover download returned empty body: BggId={BggId}", bggId);
+                return null;
+            }
+
+            var extension = GetExtension(remoteImageUrl);
+
+            // Issue #2947: raw R2 PutObject to a deterministic key so
+            // CoverUrlResolver can reconstruct it via GetPresignedUrlForRawKeyAsync.
+            var r2Key = await _uploadPipeline
+                .UploadAsync(bggId, imageBytes, extension, cancellationToken)
+                .ConfigureAwait(false);
+
+            _logger.LogInformation(
+                "BGG cover uploaded successfully: BggId={BggId}, R2Key={Key}",
+                bggId, r2Key);
+            return r2Key;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            _logger.LogError(ex, "Unexpected error in BGG cover download/upload: BggId={BggId}", bggId);
+            return null;
+        }
+    }
+
+    private static string GetExtension(string url)
+    {
+        try
+        {
+            var uri = new Uri(url);
+            var path = uri.AbsolutePath;
+            var ext = Path.GetExtension(path);
+            return string.IsNullOrEmpty(ext) || ext.Length > 5 ? ".jpg" : ext.ToLowerInvariant();
+        }
+        catch
+        {
+            return ".jpg";
+        }
+    }
+}
+```
+
+- [ ] **Step 8: Run downloader tests to verify they pass**
+
+Run: `cd apps/api/src/Api && dotnet test --filter "FullyQualifiedName~BggCoverDownloaderTests"`
+Expected: PASS (6 tests: success, extension-passthrough, http-error, pipeline-throws, 2 SSRF theories).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/BggCoverDownloader.cs apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/CoverUrlResolver.cs apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/BggCoverDownloaderTests.cs apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/CoverUrlResolverTests.cs
+git commit -m "refactor(catalog): BGG L2.5 writes deterministic key + resolver reconstructs via raw-key lookup"
+```
+
+---
+
+### Task 3: Register `IBggCoverUploadPipeline` in DI + wire into the typed `BggCoverDownloader`
+
+Without this, the app fails at startup resolving `BggCoverDownloader`'s new constructor dependency. Mirrors `RegisterCoverR2UploadPipeline` verbatim.
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs:188-235` (add registration call) + a new private `RegisterBggCoverUploadPipeline` method near `RegisterCoverR2UploadPipeline` (`:300-339`).
+- Test: `apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Services/BggCoverUploadPipelineTests.cs` (add a DI-resolution smoke test in the SAME file — no new file).
+
+**Interfaces:**
+- Consumes: `IServiceCollection`, `IConfiguration` (`S3_ENDPOINT`/`S3_ACCESS_KEY`/`S3_SECRET_KEY`/`S3_BUCKET_NAME`/`S3_REGION`/`S3_FORCE_PATH_STYLE`), `Api.Services.Pdf.BlobStorageServiceFactory.StripUnsupportedR2Headers`, `Amazon.S3.AmazonS3Client`.
+- Produces: `services.AddSingleton<IBggCoverUploadPipeline>(...)` resolvable from the DI container. The typed `AddHttpClient<IBggCoverDownloader, BggCoverDownloader>` already resolves `IBggCoverUploadPipeline` + `ILogger<BggCoverDownloader>` from DI automatically.
+
+- [ ] **Step 1: Write the failing DI-resolution test**
+
+Append to `apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Services/BggCoverUploadPipelineTests.cs` a new nested test class at the end of the file (after the closing brace of `BggCoverUploadPipelineTests`), so it lives in the same file but is independently discoverable:
+
+```csharp
+
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class BggCoverUploadPipelineDiTests
+{
+    [Fact]
+    public void AddSharedGameCatalogContext_RegistersBggCoverUploadPipeline()
+    {
+        var config = new Microsoft.Extensions.Configuration.ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["S3_ENDPOINT"] = "https://test.r2.cloudflarestorage.com",
+                ["S3_ACCESS_KEY"] = "ak",
+                ["S3_SECRET_KEY"] = "sk",
+                ["S3_BUCKET_NAME"] = "bucket",
+                ["S3_REGION"] = "auto",
+            })
+            .Build();
+
+        var services = new Microsoft.Extensions.DependencyInjection.ServiceCollection();
+        // The pipeline factory resolves IConfiguration from DI
+        // (sp.GetRequiredService<IConfiguration>()), so the built config MUST be
+        // registered on the same collection — otherwise resolution throws
+        // "No service for type 'IConfiguration'" instead of returning the pipeline.
+        services.AddSingleton<Microsoft.Extensions.Configuration.IConfiguration>(config);
+        Api.BoundedContexts.SharedGameCatalog.Infrastructure.DependencyInjection.SharedGameCatalogServiceExtensions
+            .RegisterBggCoverUploadPipelineForTests(services);
+
+        using var provider = services.BuildServiceProvider();
+        var pipeline = provider.GetService<Api.BoundedContexts.SharedGameCatalog.Application.Services.IBggCoverUploadPipeline>();
+
+        pipeline.Should().NotBeNull();
+        pipeline.Should().BeOfType<BggCoverUploadPipeline>();
+    }
+}
+```
+
+Add the `using Microsoft.Extensions.DependencyInjection;` import at the top of the test file (needed for `GetService`/`BuildServiceProvider`).
+
+- [ ] **Step 2: Run the DI test to verify it fails (does not compile)**
+
+Run: `cd apps/api/src/Api && dotnet test --filter "FullyQualifiedName~BggCoverUploadPipelineDiTests"`
+Expected: BUILD FAIL — `RegisterBggCoverUploadPipelineForTests` does not exist.
+
+- [ ] **Step 3: Add the registration method + call it, and expose a test seam**
+
+In `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs`, add the registration call immediately after the existing `RegisterCoverR2UploadPipeline(services);` line (currently `:235`):
+
+```csharp
+        // Issue #2947 — BGG cover R2 upload pipeline (deterministic key). Same
+        // S3_* config + lifetime as RegisterCoverR2UploadPipeline. Register both
+        // the interface and the concrete type (CLAUDE.md pitfall #2565).
+        RegisterBggCoverUploadPipeline(services);
+```
+
+Then add, directly after the closing brace of `RegisterCoverR2UploadPipeline` (currently ends `:339`), two methods:
+
+```csharp
+    /// <summary>
+    /// Issue #2947 — registers <see cref="IBggCoverUploadPipeline"/> as a
+    /// singleton backed by a lazily-constructed <see cref="Amazon.S3.IAmazonS3"/>
+    /// client. Mirrors <see cref="RegisterCoverR2UploadPipeline"/> (same S3_* env
+    /// vars, same R2 header-strip hook, same singleton lifetime).
+    /// </summary>
+    private static void RegisterBggCoverUploadPipeline(IServiceCollection services)
+    {
+        services.AddSingleton<IBggCoverUploadPipeline>(sp =>
+        {
+            var config = sp.GetRequiredService<IConfiguration>();
+            var logger = sp.GetRequiredService<ILogger<BggCoverUploadPipeline>>();
+            return BuildBggCoverUploadPipeline(config, logger);
+        });
+    }
+
+    /// <summary>
+    /// Test seam (Issue #2947): registers only the BGG cover pipeline against a
+    /// caller-supplied service collection so a DI-resolution unit test can verify
+    /// the registration without spinning up the whole catalog context. The caller
+    /// MUST have already registered an <see cref="IConfiguration"/> on the same
+    /// collection (the singleton factory resolves it via
+    /// <c>sp.GetRequiredService&lt;IConfiguration&gt;()</c>).
+    /// </summary>
+    internal static void RegisterBggCoverUploadPipelineForTests(IServiceCollection services)
+    {
+        services.AddLogging();
+        RegisterBggCoverUploadPipeline(services);
+    }
+
+    private static BggCoverUploadPipeline BuildBggCoverUploadPipeline(
+        IConfiguration config,
+        ILogger<BggCoverUploadPipeline> logger)
+    {
+        var options = new S3StorageOptions
+        {
+            Endpoint = config["S3_ENDPOINT"] ?? throw new InvalidOperationException("S3_ENDPOINT is required for BggCoverUploadPipeline"),
+            AccessKey = config["S3_ACCESS_KEY"] ?? throw new InvalidOperationException("S3_ACCESS_KEY is required for BggCoverUploadPipeline"),
+            SecretKey = config["S3_SECRET_KEY"] ?? throw new InvalidOperationException("S3_SECRET_KEY is required for BggCoverUploadPipeline"),
+            BucketName = config["S3_BUCKET_NAME"] ?? throw new InvalidOperationException("S3_BUCKET_NAME is required for BggCoverUploadPipeline"),
+            Region = config["S3_REGION"] ?? "auto",
+            ForcePathStyle = bool.TryParse(config["S3_FORCE_PATH_STYLE"], out var forcePathStyle) && forcePathStyle,
+        };
+
+        var s3Config = new Amazon.S3.AmazonS3Config
+        {
+            ServiceURL = options.Endpoint,
+            ForcePathStyle = options.ForcePathStyle,
+            AuthenticationRegion = options.Region,
+        };
+
+        if (!string.Equals(options.Region, "auto", StringComparison.Ordinal)
+            && Amazon.RegionEndpoint.GetBySystemName(options.Region) != null)
+        {
+            s3Config.RegionEndpoint = Amazon.RegionEndpoint.GetBySystemName(options.Region);
+        }
+
+        var credentials = new Amazon.Runtime.BasicAWSCredentials(options.AccessKey, options.SecretKey);
+        var s3Client = new Amazon.S3.AmazonS3Client(credentials, s3Config);
+
+        // Issue #1357: R2 rejects x-amz-tagging-directive; strip it defensively.
+        s3Client.BeforeRequestEvent += BlobStorageServiceFactory.StripUnsupportedR2Headers;
+
+        return new BggCoverUploadPipeline(s3Client, options, logger);
+    }
+```
+
+At the top of the file, ensure the namespace `Api.BoundedContexts.SharedGameCatalog.Application.Services` (for `IBggCoverUploadPipeline`) and `Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services` (for `BggCoverUploadPipeline`) are in scope. Check the existing `using` block; the file already lives in the `Infrastructure.DependencyInjection` namespace and references `CoverR2UploadPipeline` (Infrastructure.Services) + `BggCoverDownloader` (Application.Services), so both namespaces are already imported — verify with a quick read before adding; add whichever is missing.
+
+- [ ] **Step 4: Run the DI test + the pipeline unit tests to verify they pass**
+
+Run: `cd apps/api/src/Api && dotnet test --filter "FullyQualifiedName~BggCoverUploadPipeline"`
+Expected: PASS (10 pipeline unit tests + 1 DI-resolution test).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/DependencyInjection/SharedGameCatalogServiceExtensions.cs apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Services/BggCoverUploadPipelineTests.cs
+git commit -m "chore(catalog): register IBggCoverUploadPipeline singleton in DI"
+```
+
+---
+
+### Task 4: Rewire `BackfillPdfCoversJob` L4 to `IPdfCoverUploadPipeline`
+
+Replaces the two non-deterministic `blob.StoreAsync` calls in the Generated branch with a single deterministic `IPdfCoverUploadPipeline.UploadAsync`, and persists the deterministic dbKey.
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Jobs/BackfillPdfCoversJob.cs:60-235`
+- Test: `apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Jobs/BackfillPdfCoversJobTests.cs`
+
+**Interfaces:**
+- Consumes: `IPdfCoverUploadPipeline.UploadAsync(string dbKey, byte[] webpBytes, CancellationToken cancellationToken) → Task<string>` (existing, returns `dbKey` unchanged; writes physical `{dbKey}-preview.webp`). `IBlobStorageService.RetrieveAsync(...)` still used to LOAD the source PDF bytes (unchanged). `IPdfCoverExtractor.ExtractAsync(...)` unchanged.
+- Produces: `BackfillPdfCoversJob.RunBatchAsync(MeepleAiDbContext db, IPdfCoverExtractor extractor, IBlobStorageService blob, IPdfCoverUploadPipeline coverUploadPipeline, IDomainEventCollector? eventCollector, CancellationToken ct)` — the internal batch runner gains a new `coverUploadPipeline` parameter (inserted after `blob`). `PdfDocument.CoverR2Key` is persisted as the deterministic `covers/pdf/{pdfId:D}/cover` (no suffix). `PdfCoverGeneratedEvent.coverR2Key` carries the SAME deterministic dbKey.
+
+- [ ] **Step 1: Update the backfill test for the new pipeline param + deterministic key**
+
+In `apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Jobs/BackfillPdfCoversJobTests.cs`:
+
+Add a field + resolve import at the top of the class (after `private readonly Mock<IBlobStorageService> _blob = new();`, line 25):
+
+```csharp
+    private readonly Mock<IPdfCoverUploadPipeline> _coverPipeline = new();
+```
+
+Update `RunBatchAsync` call-sites: every `.RunBatchAsync(_db, _extractor.Object, _blob.Object, _eventCollector.Object, default)` becomes `.RunBatchAsync(_db, _extractor.Object, _blob.Object, _coverPipeline.Object, _eventCollector.Object, default)`. (9 call-sites: lines 78, 102, 115, 140, 173, 197, 221, 246, 276 in the pre-edit file — insert `_coverPipeline.Object` after `_blob.Object` at each. Line numbers shift as you edit; a global find/replace of the exact `_blob.Object, _eventCollector.Object, default` fragment is the reliable way to catch all 9.)
+
+Replace the body of `RunBatchAsync_ExtractGenerated_UploadsBothSizesAndPersistsKeyAndEmitsEvent` (currently lines 124-158) with:
+
+```csharp
+    [Fact]
+    public async Task RunBatchAsync_ExtractGenerated_UploadsPreviewViaPipelineAndPersistsDeterministicKeyAndEmitsEvent()
+    {
+        var sharedGameId = Guid.NewGuid();
+        var pdf = SeedPdf(sharedGameId: sharedGameId);
+
+        ConfigureBlobReturningStream();
+        _extractor.Setup(e => e.ExtractAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+                  .ReturnsAsync(new PdfCoverExtractionResult
+                  {
+                      Outcome = PdfCoverExtractionOutcome.Generated,
+                      ThumbnailWebp = new byte[] { 1, 2, 3 },
+                      PreviewWebp = new byte[] { 4, 5, 6, 7 },
+                      SelectedPageIndex = 1,
+                  });
+
+        var expectedKey = $"covers/pdf/{pdf.Id:D}/cover";
+        _coverPipeline
+            .Setup(p => p.UploadAsync(expectedKey, It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedKey);
+
+        await CreateJob().RunBatchAsync(_db, _extractor.Object, _blob.Object, _coverPipeline.Object, _eventCollector.Object, default);
+
+        // Only the PREVIEW size is uploaded (the resolver only reads -preview.webp).
+        _coverPipeline.Verify(p => p.UploadAsync(
+            expectedKey,
+            It.Is<byte[]>(b => b.SequenceEqual(new byte[] { 4, 5, 6, 7 })),
+            It.IsAny<CancellationToken>()), Times.Once);
+        // StoreAsync must NOT be used for the cover write anymore.
+        _blob.Verify(b => b.StoreAsync(
+            It.IsAny<Stream>(), It.IsAny<string>(), BlobCategory.GameImage, It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+
+        var refreshed = _db.PdfDocuments.AsNoTracking().Single(p => p.Id == pdf.Id);
+        refreshed.CoverGenerationStatus.Should().Be(nameof(PdfCoverGenerationStatus.Generated));
+        refreshed.CoverR2Key.Should().Be(expectedKey);
+        refreshed.CoverPageIndex.Should().Be(1);
+        refreshed.CoverGenerationError.Should().BeNull();
+
+        _collectedEvents.Should().ContainSingle()
+            .Which.Should().BeOfType<PdfCoverGeneratedEvent>()
+            .Which.CoverR2Key.Should().Be(expectedKey);
+    }
+```
+
+Update `RunBatchAsync_ExtractSkipped_SetsSkippedStatusAndNoUpload` (currently lines 160-182): change the `_blob.Verify(b => b.StoreAsync(...))` assertion to also verify the pipeline is never called — replace the two `_blob.Verify(...StoreAsync...)` lines (179-180) with:
+
+```csharp
+        _coverPipeline.Verify(p => p.UploadAsync(It.IsAny<string>(), It.IsAny<byte[]>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+```
+
+Add `using System.Linq;` at the top of the test file if not already present (needed for `SequenceEqual`). Add `using Api.BoundedContexts.DocumentProcessing.Application.Services;` — already present (line 2).
+
+- [ ] **Step 2: Run the backfill test to verify it fails (does not compile)**
+
+Run: `cd apps/api/src/Api && dotnet test --filter "FullyQualifiedName~BackfillPdfCoversJobTests"`
+Expected: BUILD FAIL — `RunBatchAsync` has no overload taking `IPdfCoverUploadPipeline`.
+
+- [ ] **Step 3: Rewire `BackfillPdfCoversJob`**
+
+In `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Jobs/BackfillPdfCoversJob.cs`:
+
+Add the `using` for the pipeline interface (top of file, after line 1 `using Api.BoundedContexts.DocumentProcessing.Application.Services;` — that namespace already covers `IPdfCoverUploadPipeline`, so no new using needed).
+
+Replace `Execute` (lines 60-73) body's service resolution + `RunBatchAsync` call:
+
+```csharp
+    public async Task Execute(IJobExecutionContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        var ct = context.CancellationToken;
+        _logger.LogDebug("BackfillPdfCoversJob started: FireTime={FireTime}", context.FireTimeUtc);
+
+        using var scope = _serviceProvider.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var extractor = scope.ServiceProvider.GetRequiredService<IPdfCoverExtractor>();
+        var blob = scope.ServiceProvider.GetRequiredService<IBlobStorageService>();
+        var coverUploadPipeline = scope.ServiceProvider.GetRequiredService<IPdfCoverUploadPipeline>();
+        var eventCollector = scope.ServiceProvider.GetService<IDomainEventCollector>();
+
+        await RunBatchAsync(db, extractor, blob, coverUploadPipeline, eventCollector, ct).ConfigureAwait(false);
+    }
+```
+
+Update `RunBatchAsync` signature (line 79-84) + the `ProcessOneAsync` call (line 112):
+
+```csharp
+    internal async Task RunBatchAsync(
+        MeepleAiDbContext db,
+        IPdfCoverExtractor extractor,
+        IBlobStorageService blob,
+        IPdfCoverUploadPipeline coverUploadPipeline,
+        IDomainEventCollector? eventCollector,
+        CancellationToken ct)
+    {
+```
+
+...and inside the `for` loop replace the `ProcessOneAsync(pdf, db, extractor, blob, eventCollector, ct)` call (line 112) with:
+
+```csharp
+            await ProcessOneAsync(pdf, db, extractor, blob, coverUploadPipeline, eventCollector, ct).ConfigureAwait(false);
+```
+
+Update `ProcessOneAsync` signature (lines 121-127) to add the pipeline param after `blob`:
+
+```csharp
+    private async Task ProcessOneAsync(
+        PdfDocumentEntity pdf,
+        MeepleAiDbContext db,
+        IPdfCoverExtractor extractor,
+        IBlobStorageService blob,
+        IPdfCoverUploadPipeline coverUploadPipeline,
+        IDomainEventCollector? eventCollector,
+        CancellationToken ct)
+    {
+```
+
+Replace the `case PdfCoverExtractionOutcome.Generated:` block (lines 147-177) with the deterministic-key + single preview upload:
+
+```csharp
+                case PdfCoverExtractionOutcome.Generated:
+                    {
+                        // Issue #2947: deterministic DB key; the pipeline writes the
+                        // physical R2 object "{dbKey}-preview.webp" that the resolver
+                        // reconstructs. Only the preview size is uploaded (the
+                        // resolver never reads the thumbnail size).
+                        var dbKey = $"covers/pdf/{pdf.Id:D}/cover";
+
+                        var persistedKey = await coverUploadPipeline
+                            .UploadAsync(dbKey, result.PreviewWebp!, ct)
+                            .ConfigureAwait(false);
+
+                        pdf.CoverR2Key = persistedKey;
+                        pdf.CoverGenerationStatus = nameof(PdfCoverGenerationStatus.Generated);
+                        pdf.CoverPageIndex = result.SelectedPageIndex;
+                        pdf.CoverGenerationError = null;
+
+                        eventCollector?.Collect(new PdfCoverGeneratedEvent(
+                            pdfDocumentId: pdf.Id,
+                            sharedGameId: pdf.SharedGameId,
+                            coverR2Key: persistedKey,
+                            coverPageIndex: result.SelectedPageIndex ?? 0));
+
+                        _logger.LogInformation(
+                            "BackfillPdfCoversJob: cover generated for PDF {PdfId} from page {PageIndex} (dbKey={DbKey})",
+                            pdf.Id, result.SelectedPageIndex, persistedKey);
+                        break;
+                    }
+```
+
+Finally, update the orphan-hint comment + `resourceKey` in the outer `catch` (lines 208-223). The old comment references `game-images/pdf-cover-{Id}/` (the `StoreAsync` layout). Replace the `resourceKey` computation and its log/error text (lines 216-223) with:
+
+```csharp
+            // Operator-recovery hint: when UploadAsync succeeded BUT the subsequent
+            // SaveChangesAsync threw (transient DB error, RowVersion conflict, etc.),
+            // R2 will contain an orphan preview under the deterministic key. The
+            // entity ends up Failed without a CoverR2Key so cleanup can't reach it.
+            // Embed the prospective physical key so operators can grep the bucket.
+            var orphanPhysicalKey = $"covers/pdf/{pdf.Id:D}/cover-preview.webp";
+            _logger.LogWarning(ex,
+                "BackfillPdfCoversJob: unexpected error processing PDF {PdfId}; marking Failed. " +
+                "Inspect R2 key {OrphanKey} for an orphan preview blob and clean up manually if present.",
+                pdf.Id, orphanPhysicalKey);
+            pdf.CoverGenerationStatus = nameof(PdfCoverGenerationStatus.Failed);
+            var detail = ex.GetType().Name + ": orphan-check-key=" + orphanPhysicalKey;
+            pdf.CoverGenerationError = detail.Length > 500 ? detail[..500] : detail;
+```
+
+(The existing test `RunBatchAsync_ExtractorThrows_MarksFailedAndContinuesNextItem` asserts `CoverGenerationError` contains `nameof(InvalidOperationException)` — still true — and contains `$"pdf-cover-{first.Id}"`. That substring changes: update that test's assertion in Step 1's file to `refreshedFirst.CoverGenerationError.Should().Contain($"covers/pdf/{first.Id:D}/cover-preview.webp");` — apply this edit now as part of the same test-file update if not already done in Step 1. Re-run confirms.)
+
+Apply the `RunBatchAsync_ExtractorThrows...` assertion fix: in the test file, change line 228 `refreshedFirst.CoverGenerationError.Should().Contain($"pdf-cover-{first.Id}");` to:
+
+```csharp
+        refreshedFirst.CoverGenerationError.Should().Contain($"covers/pdf/{first.Id:D}/cover-preview.webp");
+```
+
+- [ ] **Step 4: Run the backfill tests to verify they pass**
+
+Run: `cd apps/api/src/Api && dotnet test --filter "FullyQualifiedName~BackfillPdfCoversJobTests"`
+Expected: PASS (all backfill tests, including the rewritten Generated + Skipped + ExtractorThrows tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Jobs/BackfillPdfCoversJob.cs apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Jobs/BackfillPdfCoversJobTests.cs
+git commit -m "refactor(pdf): backfill job writes deterministic cover key via IPdfCoverUploadPipeline"
+```
+
+---
+
+### Task 5: Rewire `PdfProcessingPipelineService.ExtractCoverImageAsync` L4 to `IPdfCoverUploadPipeline`
+
+Replaces the two non-deterministic `_blobStorageService.StoreAsync` calls in the pipeline's cover-store block with a single deterministic `IPdfCoverUploadPipeline.UploadAsync`.
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs:38-104` (ctor) + `:517-609` (`ExtractCoverImageAsync`)
+- Modify: `apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/DependencyInjection/DocumentProcessingServiceExtensions.cs:178` (the `AddScoped<IPdfProcessingPipelineService, PdfProcessingPipelineService>()` auto-resolves the new ctor param from DI since `IPdfCoverUploadPipeline` is already registered at `:175` — verify only, likely no edit needed)
+- Test: reuse existing `PdfProcessingPipelineService` unit tests (find the suite) — add ONE focused cover test if the existing suite doesn't already assert the store call; see Step 1.
+
+**Interfaces:**
+- Consumes: `IPdfCoverUploadPipeline.UploadAsync(string dbKey, byte[] webpBytes, CancellationToken cancellationToken) → Task<string>` (existing).
+- Produces: `PdfProcessingPipelineService` gains an optional `IPdfCoverUploadPipeline? pdfCoverUploadPipeline = null` ctor param (LAST position, after `eventCollector`, so all existing positional test constructors keep compiling). `ExtractCoverImageAsync` persists `pdfDoc.CoverR2Key = "covers/pdf/{pdfDoc.Id:D}/cover"` and raises `PdfCoverGeneratedEvent` with that same key. When the pipeline is null (older unit-test constructors), cover generation is skipped exactly like when `_pdfCoverExtractor` is null.
+
+- [ ] **Step 1: Find the existing pipeline test suite + write the failing cover test**
+
+Locate the test class:
+Run: `ls apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Services/ | grep -i PdfProcessingPipeline`
+
+Open the primary suite (expected `PdfProcessingPipelineServiceTests.cs` or a `...CoverTests.cs` sibling). Add a new test that constructs the service WITH a mocked `IPdfCoverUploadPipeline` and asserts the deterministic key. Because the ctor is long, add a focused test in a NEW sibling file to avoid disturbing the large existing fixture:
+
+Create `apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineServiceCoverTests.cs`:
+
+```csharp
+using Api.BoundedContexts.DocumentProcessing.Application.Services;
+using Api.BoundedContexts.DocumentProcessing.Domain.Events;
+using Api.BoundedContexts.KnowledgeBase.Application.Services;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Services;
+using Api.Services.Pdf;
+using Api.SharedKernel.Application.Services;
+using Api.SharedKernel.Domain.Interfaces;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.DocumentProcessing.Application.Services;
+
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "DocumentProcessing")]
+public sealed class PdfProcessingPipelineServiceCoverTests : IDisposable
+{
+    private readonly MeepleAiDbContext _db;
+    private readonly Mock<IPdfCoverExtractor> _coverExtractor = new();
+    private readonly Mock<IPdfCoverUploadPipeline> _coverPipeline = new();
+    private readonly Mock<IBlobStorageService> _blob = new();
+    private readonly Mock<IDomainEventCollector> _eventCollector = new();
+    private readonly List<IDomainEvent> _collected = new();
+
+    public PdfProcessingPipelineServiceCoverTests()
+    {
+        var options = new DbContextOptionsBuilder<MeepleAiDbContext>()
+            .UseInMemoryDatabase($"PdfPipelineCover_{Guid.NewGuid()}")
+            .Options;
+        _db = new MeepleAiDbContext(options, new Mock<IMediator>().Object, new Mock<IDomainEventCollector>().Object);
+        _eventCollector.Setup(c => c.Collect(It.IsAny<IDomainEvent>()))
+                       .Callback<IDomainEvent>(e => _collected.Add(e));
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    [Fact]
+    public async Task ExtractCoverImageAsync_Generated_UploadsPreviewViaPipelineWithDeterministicKey()
+    {
+        var pdf = new PdfDocumentEntity
+        {
+            Id = Guid.NewGuid(),
+            FileName = "rules.pdf",
+            FilePath = "/tmp/rules.pdf",
+            FileSizeBytes = 1,
+            ContentType = "application/pdf",
+            UploadedByUserId = Guid.NewGuid(),
+            UploadedAt = DateTime.UtcNow,
+            ProcessingState = "Extracting",
+            CoverGenerationStatus = "Pending",
+            SharedGameId = Guid.NewGuid(),
+        };
+
+        _blob.Setup(b => b.RetrieveAsync(It.IsAny<string>(), BlobCategory.Pdf, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+             .ReturnsAsync(() => new MemoryStream(new byte[] { 0x25, 0x50, 0x44, 0x46 }));
+        _coverExtractor.Setup(e => e.ExtractAsync(It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+                       .ReturnsAsync(new PdfCoverExtractionResult
+                       {
+                           Outcome = PdfCoverExtractionOutcome.Generated,
+                           ThumbnailWebp = new byte[] { 1 },
+                           PreviewWebp = new byte[] { 9, 9, 9 },
+                           SelectedPageIndex = 0,
+                       });
+
+        var expectedKey = $"covers/pdf/{pdf.Id:D}/cover";
+        _coverPipeline.Setup(p => p.UploadAsync(expectedKey, It.IsAny<byte[]>(), It.IsAny<CancellationToken>()))
+                      .ReturnsAsync(expectedKey);
+
+        var sut = PdfProcessingPipelineServiceCoverTestFactory.Create(
+            _db, _blob.Object, _coverExtractor.Object, _coverPipeline.Object, _eventCollector.Object);
+
+        await sut.InvokeExtractCoverImageForTestAsync(pdf, "/tmp/rules.pdf", CancellationToken.None);
+
+        _coverPipeline.Verify(p => p.UploadAsync(
+            expectedKey,
+            It.Is<byte[]>(b => b.SequenceEqual(new byte[] { 9, 9, 9 })),
+            It.IsAny<CancellationToken>()), Times.Once);
+        _blob.Verify(b => b.StoreAsync(
+            It.IsAny<Stream>(), It.IsAny<string>(), BlobCategory.GameImage, It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+
+        pdf.CoverR2Key.Should().Be(expectedKey);
+        pdf.CoverGenerationStatus.Should().Be("Generated");
+
+        _collected.Should().ContainSingle()
+            .Which.Should().BeOfType<PdfCoverGeneratedEvent>()
+            .Which.CoverR2Key.Should().Be(expectedKey);
+    }
+}
+```
+
+This test needs a factory + a test seam to reach the private `ExtractCoverImageAsync`. To avoid weakening production visibility, expose the method for tests via an `internal` wrapper method on the service AND an `InternalsVisibleTo` (already present for `Api.Tests`). Add the factory + wrapper as part of Step 3 — but write the test first so it fails.
+
+- [ ] **Step 2: Run the cover test to verify it fails (does not compile)**
+
+Run: `cd apps/api/src/Api && dotnet test --filter "FullyQualifiedName~PdfProcessingPipelineServiceCoverTests"`
+Expected: BUILD FAIL — `PdfProcessingPipelineServiceCoverTestFactory` and `InvokeExtractCoverImageForTestAsync` do not exist, and the ctor has no `IPdfCoverUploadPipeline` param.
+
+- [ ] **Step 3: Add the ctor param + rewire `ExtractCoverImageAsync` + add the test seam**
+
+In `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs`:
+
+Add the field after `_eventCollector` (line 57):
+
+```csharp
+    // Issue #2947: deterministic R2 cover writes. Optional so pre-#2947 unit-test
+    // constructors compile; when null, cover generation is skipped like when
+    // _pdfCoverExtractor is null.
+    private readonly IPdfCoverUploadPipeline? _pdfCoverUploadPipeline;
+```
+
+Add the ctor parameter as the LAST positional param (after `IDomainEventCollector? eventCollector = null`, line 80) and assign it (after line 103):
+
+```csharp
+        IDomainEventCollector? eventCollector = null,
+        IPdfCoverUploadPipeline? pdfCoverUploadPipeline = null)
+```
+
+```csharp
+        _eventCollector = eventCollector;
+        _pdfCoverUploadPipeline = pdfCoverUploadPipeline;
+```
+
+Update the `ExtractCoverImageAsync` guard (lines 522-526) to also require the pipeline:
+
+```csharp
+        if (_pdfCoverExtractor is null || _pdfCoverUploadPipeline is null)
+        {
+            // Cover services not registered (unit-test scenarios) — leave default Pending.
+            return;
+        }
+```
+
+Replace the `case PdfCoverExtractionOutcome.Generated:` block (lines 540-580) with:
+
+```csharp
+                case PdfCoverExtractionOutcome.Generated:
+                    {
+                        // Issue #2947: deterministic DB key; the pipeline writes the
+                        // physical R2 object "{dbKey}-preview.webp" that the resolver
+                        // reconstructs. Only the preview size is uploaded (the
+                        // resolver never reads the thumbnail size).
+                        var dbKey = $"covers/pdf/{pdfDoc.Id:D}/cover";
+
+                        var persistedKey = await _pdfCoverUploadPipeline
+                            .UploadAsync(dbKey, result.PreviewWebp!, cancellationToken)
+                            .ConfigureAwait(false);
+
+                        pdfDoc.CoverR2Key = persistedKey;
+                        pdfDoc.CoverGenerationStatus = "Generated";
+                        pdfDoc.CoverPageIndex = result.SelectedPageIndex;
+                        pdfDoc.CoverGenerationError = null;
+
+                        // Issue #1852 (Gap A): raise the propagation event so
+                        // PdfCoverGeneratedEventHandler can populate SharedGame.PdfCoverR2Key.
+                        _eventCollector?.Collect(new PdfCoverGeneratedEvent(
+                            pdfDocumentId: pdfDoc.Id,
+                            sharedGameId: pdfDoc.SharedGameId,
+                            coverR2Key: persistedKey,
+                            coverPageIndex: result.SelectedPageIndex ?? 0));
+
+                        _logger.LogInformation(
+                            "[PdfPipeline] Cover image generated for PDF {PdfId} from page {PageIndex} (dbKey={DbKey})",
+                            pdfDoc.Id, result.SelectedPageIndex, persistedKey);
+                        break;
+                    }
+```
+
+Add an internal test-seam wrapper method at the end of the class (before the final closing brace) so the test can invoke the private method without reflection:
+
+```csharp
+    /// <summary>
+    /// Issue #2947 test seam: exposes <see cref="ExtractCoverImageAsync"/> to the
+    /// unit-test assembly (InternalsVisibleTo Api.Tests) so the deterministic
+    /// cover-key behaviour can be asserted directly without driving the full
+    /// ProcessAsync pipeline.
+    /// </summary>
+    internal Task InvokeExtractCoverImageForTestAsync(
+        PdfDocumentEntity pdfDoc, string filePath, CancellationToken cancellationToken)
+        => ExtractCoverImageAsync(pdfDoc, filePath, cancellationToken);
+```
+
+Add the test factory. Create `apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineServiceCoverTestFactory.cs`:
+
+```csharp
+using Api.BoundedContexts.DocumentProcessing.Application.Services;
+using Api.BoundedContexts.KnowledgeBase.Application.Services;
+using Api.Infrastructure;
+using Api.Services;
+using Api.Services.Pdf;
+using Api.SharedKernel.Application.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+
+namespace Api.Tests.BoundedContexts.DocumentProcessing.Application.Services;
+
+/// <summary>
+/// Issue #2947 — builds a <see cref="PdfProcessingPipelineService"/> with only the
+/// collaborators the cover path touches wired to real/mocked instances and all
+/// other required constructor dependencies stubbed with permissive mocks. Keeps
+/// the cover-focused test independent of the large main fixture.
+/// </summary>
+internal static class PdfProcessingPipelineServiceCoverTestFactory
+{
+    public static PdfProcessingPipelineService Create(
+        MeepleAiDbContext db,
+        IBlobStorageService blob,
+        IPdfCoverExtractor coverExtractor,
+        IPdfCoverUploadPipeline coverUploadPipeline,
+        IDomainEventCollector eventCollector)
+    {
+        return new PdfProcessingPipelineService(
+            db: db,
+            pdfClaimService: Mock.Of<IPdfClaimService>(),
+            pdfTextExtractor: Mock.Of<IPdfTextExtractor>(),
+            tableExtractor: Mock.Of<IPdfTableExtractor>(),
+            chunkingService: Mock.Of<ITextChunkingService>(),
+            embeddingService: Mock.Of<IEmbeddingService>(),
+            blobStorageService: blob,
+            timeProvider: TimeProvider.System,
+            logger: NullLogger<PdfProcessingPipelineService>.Instance,
+            languageDetector: Mock.Of<ILanguageDetector>(),
+            chunkTranslationService: Mock.Of<IChunkTranslationService>(),
+            indexingPipeline: Mock.Of<IPdfIndexingPipeline>(),
+            raptorIndexer: null,
+            entityExtractor: null,
+            vectorStore: null,
+            featureFlagService: null,
+            roleClassifier: null,
+            pdfCoverExtractor: coverExtractor,
+            eventCollector: eventCollector,
+            pdfCoverUploadPipeline: coverUploadPipeline);
+    }
+}
+```
+
+> Note for the implementer: the exact interface names for the stubbed collaborators (`IPdfClaimService`, `IPdfTextExtractor`, `IPdfTableExtractor`, `ITextChunkingService`, `IEmbeddingService`, `ILanguageDetector`, `IChunkTranslationService`, `IPdfIndexingPipeline`) are read verbatim from the `PdfProcessingPipelineService` constructor (`PdfProcessingPipelineService.cs:61-80`). If any namespace `using` is missing when compiling the factory, add the one the compiler names — do not guess; the compiler error states the exact type and namespace.
+
+- [ ] **Step 4: Run the cover test to verify it passes**
+
+Run: `cd apps/api/src/Api && dotnet test --filter "FullyQualifiedName~PdfProcessingPipelineServiceCoverTests"`
+Expected: PASS (1 test). Then run the full pipeline suite to confirm no regression from the ctor change:
+Run: `cd apps/api/src/Api && dotnet test --filter "FullyQualifiedName~PdfProcessingPipelineService"`
+Expected: PASS (existing suite + new cover test).
+
+- [ ] **Step 5: Verify DI still resolves the pipeline service (no edit expected)**
+
+Read `apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/DependencyInjection/DocumentProcessingServiceExtensions.cs:178`. The `AddScoped<IPdfProcessingPipelineService, PdfProcessingPipelineService>()` uses constructor injection; `IPdfCoverUploadPipeline` is registered (`:175`) so the new optional param resolves automatically. No edit required — this step is a read-only confirmation. If the build's DI validation flags a missing dependency, only then add an explicit factory (it should not).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineServiceCoverTests.cs apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineServiceCoverTestFactory.cs
+git commit -m "refactor(pdf): pipeline cover-store writes deterministic key via IPdfCoverUploadPipeline"
+```
+
+---
+
+### Task 6: Gated R2/MinIO end-to-end round-trip integration test
+
+Adds the issue-mandated integration test, guarded so it runs where MinIO/R2-HTTPS is available and is inert locally (the documented `DisablePayloadSigning`-over-HTTP MinIO limitation). Proves the full write→resolve→GET loop for all three deterministic key shapes.
+
+**Files:**
+- Create: `apps/api/tests/Api.Tests/Integration/SharedGameCatalog/CoverR2ConventionIntegrationTests.cs`
+
+**Interfaces:**
+- Consumes: the existing Testcontainers/MinIO integration harness conventions (`[Trait("Category", "Integration")]` + a skip guard). `S3BlobStorageService.GetPresignedUrlForRawKeyAsync`, `BggCoverUploadPipeline.UploadAsync`, `PdfCoverUploadPipeline.UploadAsync`.
+- Produces: an integration test class that is skipped locally and executes in the gated CI lane.
+
+- [ ] **Step 1: Read one existing MinIO/S3 integration test to copy the exact harness + skip convention**
+
+Run: `ls apps/api/tests/Api.Tests/Integration/ -R | grep -i -E "s3|minio|blob|storage"`
+Open the closest match (e.g. `S3BlobStorageIntegrationTests.cs`) and copy: the Testcontainers MinIO container fixture, the `[Trait("Category", "Integration")]` attributes, and the exact skip mechanism used (the note in CLAUDE.md "Known Flaky Tests" references `S3BlobStorageIntegrationTests` with "11 skipped tests ... only require Docker"). Match that skip guard EXACTLY (same `Skip = "..."` string style or same `[Trait("Skip", ...)]` used by that file).
+
+- [ ] **Step 2: Write the integration test**
+
+Create `apps/api/tests/Api.Tests/Integration/SharedGameCatalog/CoverR2ConventionIntegrationTests.cs`. The body must:
+1. Spin up the MinIO Testcontainer + build an `IAmazonS3` client + `S3StorageOptions` pointing at it (copy from the harness read in Step 1).
+2. Construct `S3BlobStorageService` (for `GetPresignedUrlForRawKeyAsync`), `BggCoverUploadPipeline`, and `PdfCoverUploadPipeline` against that client.
+3. Three scenarios, each: upload via the pipeline → get the DB key → compute the physical key the resolver would request → call `GetPresignedUrlForRawKeyAsync` → HTTP-GET the URL → assert `200 OK` and body bytes equal the uploaded bytes.
+   - BGG: `BggCoverUploadPipeline.UploadAsync(13, bytes, ".jpg", ct)` returns `bgg-covers/13/cover.jpg`; resolver requests `GetPresignedUrlForRawKeyAsync("bgg-covers/13/cover.jpg")` (no suffix).
+   - PDF: `PdfCoverUploadPipeline.UploadAsync("covers/pdf/{guid:D}/cover", bytes, ct)` returns the dbKey; resolver requests `GetPresignedUrlForRawKeyAsync("covers/pdf/{guid:D}/cover-preview.webp")`.
+   - Miss: `GetPresignedUrlForRawKeyAsync("bgg-covers/999/cover.jpg")` (never uploaded) returns `null` (fail-closed existence check).
+
+Use the EXACT container/fixture/skip pattern from Step 1's file — do NOT invent a new harness. Structure (fill the harness specifics from Step 1):
+
+```csharp
+using Amazon.S3;
+using Api.BoundedContexts.SharedGameCatalog.Infrastructure.Services;
+using Api.BoundedContexts.DocumentProcessing.Infrastructure.Services;
+using Api.Services.Pdf;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Api.Tests.Integration.SharedGameCatalog;
+
+[Trait("Category", "Integration")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class CoverR2ConventionIntegrationTests
+    // : IClassFixture<MinioContainerFixture>  // <-- use the exact fixture type from Step 1
+{
+    // Copy the container/client/options setup from the harness read in Step 1.
+    // Inject the fixture, expose `IAmazonS3 _s3`, `S3StorageOptions _options`,
+    // and a helper to build S3BlobStorageService.
+
+    [Fact] // apply the SAME skip guard as the existing S3 integration tests (Step 1)
+    public async Task BggCover_Uploaded_ResolvesViaRawKeyNoSuffix_And200()
+    {
+        var bggPipeline = new BggCoverUploadPipeline(_s3, _options, NullLogger<BggCoverUploadPipeline>.Instance);
+        var bytes = new byte[] { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A };
+
+        var dbKey = await bggPipeline.UploadAsync(13, bytes, ".jpg", CancellationToken.None);
+        dbKey.Should().Be("bgg-covers/13/cover.jpg");
+
+        var blob = BuildBlobService();
+        var url = await blob.GetPresignedUrlForRawKeyAsync(dbKey);
+        url.Should().NotBeNull();
+
+        using var http = new HttpClient();
+        using var resp = await http.GetAsync(url);
+        resp.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
+        (await resp.Content.ReadAsByteArrayAsync()).Should().BeEquivalentTo(bytes);
+    }
+
+    [Fact] // same skip guard
+    public async Task PdfCover_Uploaded_ResolvesViaPreviewSuffix_And200()
+    {
+        var pdfPipeline = new PdfCoverUploadPipeline(_s3, _options, NullLogger<PdfCoverUploadPipeline>.Instance);
+        var id = Guid.NewGuid();
+        var dbKey = $"covers/pdf/{id:D}/cover";
+        var bytes = new byte[] { 0x52, 0x49, 0x46, 0x46 };
+
+        var returned = await pdfPipeline.UploadAsync(dbKey, bytes, CancellationToken.None);
+        returned.Should().Be(dbKey);
+
+        var blob = BuildBlobService();
+        var url = await blob.GetPresignedUrlForRawKeyAsync($"{dbKey}-preview.webp");
+        url.Should().NotBeNull();
+
+        using var http = new HttpClient();
+        using var resp = await http.GetAsync(url);
+        resp.StatusCode.Should().Be(System.Net.HttpStatusCode.OK);
+        (await resp.Content.ReadAsByteArrayAsync()).Should().BeEquivalentTo(bytes);
+    }
+
+    [Fact] // same skip guard
+    public async Task MissingKey_ResolvesToNull_FailClosed()
+    {
+        var blob = BuildBlobService();
+        var url = await blob.GetPresignedUrlForRawKeyAsync("bgg-covers/999/cover.jpg");
+        url.Should().BeNull("fail-closed existence check must return null for a non-existent object");
+    }
+
+    // private S3BlobStorageService BuildBlobService() => ... (from Step 1 harness)
+}
+```
+
+- [ ] **Step 3: Run the integration test to confirm it is discovered + skips locally**
+
+Run: `cd apps/api/src/Api && dotnet test --filter "FullyQualifiedName~CoverR2ConventionIntegrationTests"`
+Expected: SKIPPED locally (3 tests skipped with the harness's skip reason), OR PASS if Docker/MinIO is available — either outcome is green (no failures). If it FAILS with a `DisablePayloadSigning`-over-HTTP error, the skip guard from Step 1 was not applied correctly — re-check against the existing `S3BlobStorageIntegrationTests` guard.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/api/tests/Api.Tests/Integration/SharedGameCatalog/CoverR2ConventionIntegrationTests.cs
+git commit -m "test(catalog): gated MinIO end-to-end round-trip for deterministic cover keys"
+```
+
+---
+
+### Task 7: Full-suite regression sweep for the touched contexts + doc update
+
+Confirms no collateral breakage in the two bounded contexts and records the convention.
+
+**Files:**
+- Modify: `docs/for-developers/specs/2026-07-14-game-cover-configuration-design.md` (append a short "Issue #2947 — deterministic BGG/PDF cover keys" subsection documenting the three key shapes). If the file does not exist at that path, create `docs/for-developers/audits/2026-07-15-issue-2947-r2-cover-convention.md` instead with the same content.
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: green test suites for `SharedGameCatalog` + `DocumentProcessing`; a documented convention.
+
+- [ ] **Step 1: Kill lingering testhost then run the SharedGameCatalog unit suite**
+
+Run: `tasklist | grep testhost` → if any, `taskkill //PID <PID> //F`
+Run: `cd apps/api/src/Api && dotnet test --filter "BoundedContext=SharedGameCatalog&Category=Unit"`
+Expected: PASS (0 failures). Fix any regression at its root cause (do NOT skip tests).
+
+- [ ] **Step 2: Run the DocumentProcessing unit suite**
+
+Run: `cd apps/api/src/Api && dotnet test --filter "BoundedContext=DocumentProcessing&Category=Unit"`
+Expected: PASS (0 failures).
+
+- [ ] **Step 3: Document the convention**
+
+Read the spec path. If `docs/for-developers/specs/2026-07-14-game-cover-configuration-design.md` exists, append this subsection at the end:
+
+```markdown
+## Issue #2947 — Deterministic R2 cover keys (BGG L2.5 + PDF L4)
+
+All cover write-sites now compose a deterministic physical R2 key that
+`CoverUrlResolver` reconstructs from the DB-persisted key via
+`IBlobStorageService.GetPresignedUrlForRawKeyAsync` (the earlier
+`IBlobStorageService.StoreAsync` path minted a random `Guid.NewGuid()` fileId
+that could not be reconstructed).
+
+| Layer | Writer | DB key (persisted) | Physical R2 object | Resolver read |
+|-------|--------|--------------------|--------------------|---------------|
+| L2 Wikidata | `CoverR2UploadPipeline` | `covers/{gameId}/cover` | `covers/{gameId}/cover.webp` | `{dbKey}.webp` |
+| L2.5 BGG | `BggCoverUploadPipeline` | `bgg-covers/{bggId}/cover{ext}` | same as DB key | `{dbKey}` (no suffix) |
+| L4 PDF (pipeline + backfill) | `PdfCoverUploadPipeline` | `covers/pdf/{pdfId:D}/cover` | `covers/pdf/{pdfId:D}/cover-preview.webp` | `{dbKey}-preview.webp` |
+
+BGG is the only layer that does NOT append a suffix at read time: it keeps the
+source image extension (BGG serves jpg/png, not webp), so the DB key IS the
+physical key.
+```
+
+If the spec file is absent, create `docs/for-developers/audits/2026-07-15-issue-2947-r2-cover-convention.md` with a top-level `# Issue #2947 — Deterministic R2 cover keys` heading followed by the same table + prose.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/for-developers/specs/2026-07-14-game-cover-configuration-design.md
+git commit -m "docs(catalog): document deterministic R2 cover-key convention (#2947)"
+```
+
+(If you created the audit file instead, `git add docs/for-developers/audits/2026-07-15-issue-2947-r2-cover-convention.md`.)
+
+- [ ] **Step 5: Push + open PR to `main-dev`**
+
+```bash
+git push -u origin feature/issue-2947-r2-cover-convention
+gh pr create --base main-dev --title "fix(catalog): unify deterministic R2 cover convention (BGG L2.5 + PDF L4) #2947" --body "$(cat <<'EOF'
+## Summary
+Resolves the P1 follow-up from #2943: all cover write-sites now compose deterministic R2 physical keys that `CoverUrlResolver` reconstructs from the DB-persisted key, so BGG (L2.5), PDF-pipeline (L4), and PDF-backfill (L4) covers resolve instead of falling through to placeholder.
+
+- New `BggCoverUploadPipeline` (raw `IAmazonS3` PutObject → `bgg-covers/{bggId}/cover{ext}`), rewired `BggCoverDownloader`; resolver L2.5 now uses `GetPresignedUrlForRawKeyAsync`.
+- `BackfillPdfCoversJob` + `PdfProcessingPipelineService` now write the single preview via `IPdfCoverUploadPipeline` to `covers/pdf/{pdfId:D}/cover-preview.webp`, persisting `covers/pdf/{pdfId:D}/cover`.
+- Gated MinIO end-to-end round-trip test (skips locally per the documented `DisablePayloadSigning`-over-HTTP MinIO limit).
+
+## Test plan
+- `dotnet test --filter "BoundedContext=SharedGameCatalog&Category=Unit"` — green
+- `dotnet test --filter "BoundedContext=DocumentProcessing&Category=Unit"` — green
+- Integration round-trip runs in the gated MinIO/R2 lane.
+
+Closes #2947
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage** (every scope item → a task):
+- BGG write-site (`BggCoverDownloader.DownloadAndUploadAsync`, formerly `:72-87`) → **Task 1 + 2 + 3** (new pipeline, rewire, DI).
+- Resolver L2.5 branch (`CoverUrlResolver.cs:97-110`) → **Task 2** (switched to `GetPresignedUrlForRawKeyAsync`).
+- Backfill write-site (`BackfillPdfCoversJob.ProcessOneAsync`, formerly `:149-171`) → **Task 4**.
+- Pipeline write-site (`PdfProcessingPipelineService`, formerly `:549-566`) → **Task 5**.
+- `BggCoverDownloaderTests` + `CoverUrlResolverTests` updated → **Task 2** (explicitly rewritten with real code).
+- Integration test (R2/MinIO end-to-end) → **Task 6** (gated, unit-first caveat honored).
+- No new endpoint (CQRS untouched); no new entity/VO (DDD untouched). ✅ All scope items mapped.
+
+**2. Placeholder scan:** No "TBD/TODO/handle edge cases/similar to Task N". Task 6's harness specifics are deferred to a READ of the existing `S3BlobStorageIntegrationTests` (an intentional "copy the exact existing convention" instruction, with a concrete structural skeleton provided) rather than an invented harness — this is a fidelity requirement, not a placeholder. Task 5's factory carries an explicit "read the ctor verbatim; add the using the compiler names" note rather than guessing namespaces. No `throw new NotImplementedException()` stubs (MA0025). No `// TODO(` comments (S1135) — used "// Follow-up:" style nowhere-needed. ✅
+
+**3. Type consistency:**
+- `IBggCoverUploadPipeline.UploadAsync(int bggId, byte[] imageBytes, string extension, CancellationToken ct) → Task<string>` — identical in the interface (Task 1 Step 3), impl (Task 1 Step 4), downloader consumer (Task 2 Step 7), downloader tests (Task 2 Step 5), and DI build method (Task 3). ✅
+- `IPdfCoverUploadPipeline.UploadAsync(string dbKey, byte[] webpBytes, CancellationToken cancellationToken) → Task<string>` — read verbatim from the existing interface; used identically in Task 4 + Task 5. ✅
+- Deterministic keys are consistent everywhere: BGG `bgg-covers/{bggId}/cover{ext}`; PDF DB `covers/pdf/{pdfId:D}/cover`, physical `covers/pdf/{pdfId:D}/cover-preview.webp`. Resolver L4 appends `-preview.webp` (matches `PdfCoverUploadPipeline` write) and L2.5 appends nothing (matches `BggCoverUploadPipeline` returning the full key). ✅
+- `RunBatchAsync` / `ProcessOneAsync` new `IPdfCoverUploadPipeline` param inserted after `blob` consistently in signature + all call-sites + all 8 test call-sites. ✅
+- `PdfProcessingPipelineService` new ctor param is LAST + optional (`= null`), so existing positional constructors compile; guard skips cover work when null. ✅
+
+**Cross-cutting caution documented:** Task 4/5 drop the thumbnail R2 write (only preview is uploaded) because the resolver only ever reads `-preview.webp`. This is called out in-code and in the docs table so a reviewer sees the intentional behaviour change (no orphan random-fileId thumbnail blob).


### PR DESCRIPTION
## Contesto

P1 follow-up a #2943: unifica la convenzione delle chiavi R2 per le cover in modo che i physical key siano **deterministici** e ricostruibili dal resolver. Root cause: `IBlobStorageService.StoreAsync` conia un `fileId` random (`Guid.NewGuid()`) → chiave non ricostruibile → la cover non risolve mai (sempre placeholder).

## Cosa cambia

**Write-site → chiavi deterministiche via raw `PutObjectAsync`** (mirror del pattern provato `CoverR2UploadPipeline`/`PdfCoverUploadPipeline`):
- **BGG L2.5** · `bgg-covers/{bggId}/cover{ext}` — nuovo `BggCoverUploadPipeline` + resolver `CoverUrlResolver` legge via `GetPresignedUrlForRawKeyAsync` (chiave identica byte-per-byte)
- **L4 PDF** (pipeline + backfill) · `covers/pdf/{pdfId:D}/cover` → oggetto `{key}-preview.webp` — `BackfillPdfCoversJob` + `PdfProcessingPipelineService` usano `IPdfCoverUploadPipeline`
- DI: `IBggCoverUploadPipeline` registrato singleton

**Riconciliazione consumer L4** (dalla review olistica — cross-cutting):
- `PdfCoverOrphanRecoveryJob` ora verifica l'esistenza con la **stessa raw-key** del resolver (prima `ExistsAsync` → `ValidateIdentifier` rifiutava `/` e `.` → azzerava ogni cover valida entro 24h)
- `PdfDeletedEventHandler` evince l'oggetto fisico corretto via nuovo `DeleteRawKeyAsync` (prima orfanava blob R2 a ogni delete)

## Verifica

- Determinismo **write-key == read-key** verificato byte-per-byte su tutti e 3 i tier (review olistica opus)
- Unit: BggCoverUploadPipeline 10/10, resolver 18/18, downloader 9/9, DI 11/11, backfill 9/9, pipeline 1/1; cleanup jobs 7/7 + 7/7 (nuovi test sulla chiave nuova); regressione SharedGameCatalog 1819/0 + DocumentProcessing 419/0; build 0/0
- Round-trip MinIO reale: test gated (`Assert.Skip` senza Docker) → verifica deferita a CI/staging
- Review olistica whole-branch (opus): 1 Critical + 2 Important (cleanup job non riconciliati) → **fixati** → re-review: **FIX CONFIRMED — READY TO MERGE**

> ℹ️ **Nota CI baseline**: `main-dev` ha fail pre-esistenti (`ContributionType_HasThreeValues` da `CoverChange=3` di #2943; `SessionLiveView.test.tsx` flaky) indipendenti da questa PR. Unico check *required* = GitGuardian.

Closes #2947

🤖 Generated with [Claude Code](https://claude.com/claude-code)