### PR TITLE
test(mechanic-extractor): fix stale MechanicAnalyses badge assertion (6->9)

### DIFF
--- a/apps/web/src/app/admin/(dashboard)/knowledge-base/mechanic-extractor/analyses/__tests__/page.test.tsx
+++ b/apps/web/src/app/admin/(dashboard)/knowledge-base/mechanic-extractor/analyses/__tests__/page.test.tsx
@@ -158,7 +158,7 @@ describe('MechanicAnalysesPage', () => {
     it('renders pipeline summary badge', () => {
       renderWithQuery(<MechanicAnalysesPage />);
       // Internal IDs (ISSUE-524 / ADR-051 / M1.2) intentionally not in the UI.
-      expect(screen.getByText(/6 sections · cost-cap enforced/i)).toBeInTheDocument();
+      expect(screen.getByText(/9 sections · cost-cap enforced/i)).toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
## Baseline test fix

`MechanicAnalysesPage > header > renders pipeline summary badge` was failing on the **main-dev baseline** (Frontend Tests shard 1/4) independently of any PR — confirmed by running it on clean `main-dev`.

**Root cause**: the pipeline summary badge (`analyses/page.tsx:420`) renders `9 sections · cost-cap enforced` — v1.1.0 added Setup/Components/Endgame, taking sections from 6 → 9 (see the `page.tsx:137` comment) — but the test assertion (`page.test.tsx:161`) still expected `6 sections`. The component was updated; the test was not.

One-char fix: assertion `6` → `9`.

### Verification
- `pnpm exec vitest run mechanic-extractor/analyses/__tests__/page.test.tsx` → **19/19 pass** (was 18/19).
- Unblocks the `Frontend Tests` CI gate for all PRs targeting `main-dev`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)