### PR TITLE
docs(agent-builder): allinea SP7 brief al backend admin AgentDefinition (ADR-085, #2964)

### DIFF
--- a/admin-mockups/briefs/SP7-game-night-agent-builder.md
+++ b/admin-mockups/briefs/SP7-game-night-agent-builder.md
@@ -64,10 +64,10 @@ Già documentato in [SP6 Capitolo 2](./SP6-libro-game.md#capitolo-2--iter-1-dogf
 | **A** | `sp7-game-night-new.{html,jsx}` | `/game-nights/new` | US-31 | Multistep wizard 4 step (mobile) / split-form (desktop) |
 | **B** | `sp7-game-night-detail-rsvp.{html,jsx}` | `/game-nights/[id]` | US-31 | Hub detail + RSVP + game voting |
 | **C** | ~~`sp7-game-night-edit.{html,jsx}`~~ — **NOT COMMISSIONED** (ADR-079: drawer overlay) | `/game-nights/[id]?action=edit` | US-31 | Form edit + cancel/reschedule states rendered as drawer overlay from B detail page |
-| **D** | `sp7-agent-proposals-list.{html,jsx}` | `/editor/agent-proposals` | US-33 | Grid + filters + status badge |
-| **E** | `sp7-agent-builder-create.{html,jsx}` | `/editor/agent-proposals/create` | US-33 | Multistep wizard 4 step (KB → prompt → tone → review) |
-| **F** | `sp7-agent-builder-test.{html,jsx}` | `/editor/agent-proposals/[id]/test` | US-33 | Playground chat + feedback annotation |
-| **G** | `sp7-agent-builder-edit.{html,jsx}` | `/editor/agent-proposals/[id]/edit` | US-33 | Form edit + version diff |
+| **D** | ~~`sp7-agent-proposals-list`~~ — **già shipped** (admin) | `/admin/agents/definitions` (admin-only, ADR-085) | US-33 | Grid + filters + status badge |
+| **E** | ~~`sp7-agent-builder-create`~~ — **già shipped** (admin) | `/admin/agents/definitions/create` (admin-only, ADR-085) | US-33 | Wizard admin (no tone-picker/confidence — fuori MVP) |
+| **F** | ~~`sp7-agent-builder-test`~~ — **già shipped** (admin) | `/admin/agents/definitions/playground` (admin-only, ADR-085) | US-33 | Playground chat (`PlaygroundChatCommand`) |
+| **G** | ~~`sp7-agent-builder-edit`~~ — **già shipped** (admin, no version-diff) | `/admin/agents/definitions/[id]/edit` (admin-only, ADR-085) | US-33 | Form edit (version-diff fuori MVP) |
 | **H** | `sp7-library-game-agent.{html,jsx}` | `/library/games/[gameId]/agent` | US-13/33 | Chat inline a livello game (full-screen mobile / split desktop) |
 | **I** | `sp7-notifications-hub.{html,jsx}` | `/notifications` | US-41 | Timeline + grouping + bulk actions |
 | **J** | `sp7-notifications-preferences.{html,jsx}` | `/notifications/preferences` | US-41 | Preferences form + channel settings |
@@ -538,6 +538,17 @@ US-31: G31.16 (summary aggregation), G31.17 (share riepilogo), G31.18 (archive f
 ---
 
 # WAVE 2 — Agent Builder Flow (US-33)
+
+> ## ⚠️ CORREZIONE 2026-07-15 — allineamento al backend (ADR-085, issue #2964)
+>
+> Lo spec-panel #1889 ha verificato che la superficie agent-builder descritta in questa wave **NON corrisponde al backend reale**. Correzioni **normative** (governate da [ADR-085](../../docs/for-claude/architecture/adr/adr-085-agent-builder-admin-backend-alignment.md); invarianti in [`agent-builder-domain-invariants.md`](../../docs/for-developers/specs/2026-07-15-agent-builder-domain-invariants.md)):
+> - **Route/entità**: D–G vivono su `/admin/agent-definitions*` **admin-only** (`RequireAdminSessionFilter`), NON `/editor/agent-proposals*`. Entità = `AgentDefinition`, non `AgentProposal`.
+> - **Persona**: la **costruzione** agenti è **admin/dogfood (Aaron)**, non Marco. Marco **usa** gli agenti via chat inline (mockup H).
+> - **Già shipped → non commissionare**: la UI admin agent-builder **esiste già in produzione** (`/admin/agents/definitions` — list/create-wizard/test-playground/edit). I mockup D–G sono **ridondanti** e **non vanno commissionati** (disposition analoga ad ADR-079/mockup C).
+> - **Fuori MVP**: status `Archived` (è soft-delete, non un lifecycle status), **confidence-threshold slider** + **tone-preset picker a 5 toni** (E-Step 3), **version history/rollback** (G) — non supportati dal backend. Il publish **passa obbligatoriamente da Testing** (niente "Pubblica subito" da Draft in E). Analogo tono grezzo backend = `TypologySlug` {arbitro, game-master, chat}.
+> - **H resta user-facing** (chat inline, `/library/games/[id]/agent`).
+>
+> Le sezioni D–G sottostanti restano come **spec storica del design-intent user-facing** (differito); per l'MVP fanno fede questo banner + ADR-085.
 
 ## D — Agent Proposals List (`sp7-agent-proposals-list`)
 

--- a/docs/for-claude/architecture/adr/adr-085-agent-builder-admin-backend-alignment.md
+++ b/docs/for-claude/architecture/adr/adr-085-agent-builder-admin-backend-alignment.md
@@ -1,0 +1,87 @@
+# ADR-085 — SP7 Agent-Builder: allineamento al backend admin `AgentDefinition` (MVP)
+
+**Status**: Accepted
+**Date**: 2026-07-15
+**Deciders**: @badsworm (ratificato 2026-07-15 via [#2964](https://github.com/meepleAi-app/meepleai-monorepo/issues/2964); opzione "Allinea a backend (MVP)")
+**Tracking**: [#2964](https://github.com/meepleAi-app/meepleai-monorepo/issues/2964) — deriva dallo spec-panel [#1889](https://github.com/meepleAi-app/meepleai-monorepo/issues/1889)
+**Related**: audit `docs/for-developers/audits/2026-07-15-sp7-spec-panel-invariant-diff.md` (§2 AB-11) · brief `admin-mockups/briefs/SP7-game-night-agent-builder.md` (sez. D–H) · spec `docs/for-developers/specs/2026-07-15-agent-builder-domain-invariants.md` (8 invarianti)
+
+## Context
+
+Il brief SP7 (sez. D–H) commissiona una superficie **agent-builder user-facing** su route `/editor/agent-proposals*`, con entità `AgentProposal`, persona primaria **Marco (power-user regolare)** che crea/testa/pubblica agenti, status `{Draft, Testing, Published, Archived}`, un **confidence-threshold slider**, un **tone-preset picker** e **version history + rollback**.
+
+Lo spec-panel #1889 (audit §2, finding **AB-11**) ha verificato sul codebase che il claim del brief *"backend già pronto per US-33"* è **fuorviante su 4 punti**:
+
+| # | Brief assume | Backend reale (`KnowledgeBase` BC) |
+|---|---|---|
+| 1 | `AgentProposal` + route `/editor/agent-proposals*` user-facing | `AgentDefinition` + route `/admin/agent-definitions*` **admin-only** (`RequireAdminSessionFilter`) |
+| 2 | Status `{Draft, Testing, Published, Archived}` | Enum `{Draft, Testing, Published}` — **no `Archived`** (esiste `SoftDelete()/Restore()`) |
+| 3 | Confidence-threshold slider + tone-preset + system-prompt strutturato (E-Step 3) | `AgentDefinitionConfig` persiste solo `Model/MaxTokens/Temperature` + `Prompts` generico (JSONB) — **campi assenti** |
+| 4 | Version history + rollback (G, G33.9) | **Assenti** |
+
+Supportato pienamente: solo KB+Game linking (`KbCardIds` + `GameId`), CQRS core (Create/Update/Delete/Publish/Unpublish/StartTesting + query), testing via `PlaygroundChatCommand`. La state machine reale è matura ma **`Publish()` blocca la transizione diretta Draft→Published** (richiede il passaggio da `Testing`); `StartTesting()` blocca il ritorno da `Published` ("Unpublish first"). Il `DELETE` REST è **hard-delete** (`SoftDelete()/Restore()` esistono sull'aggregato ma **non sono esposti via REST**), quindi "Archived" non ha oggi alcuna superficie API.
+
+**Scoperta decisiva — l'admin FE agent-builder è GIÀ shipped.** Verifica FE: esiste `apps/web/src/app/admin/(dashboard)/agents/definitions/` con `page.tsx` (builder table), `create/page.tsx` (wizard con step `BasicInfoStep/PromptEditorStep/ToolsStrategyStep/ReviewStep` + `AgentPreviewPanel`), `[id]/page.tsx`, `[id]/edit/page.tsx`, `playground/page.tsx`, oltre a API client (`lib/api/agent-definitions.api.ts`), schemas, hook (`hooks/admin/useAgentDefinitions.ts`) e voci nav admin. **I mockup SP7 D–G ridisegnano quindi una superficie già costruita e in produzione** (list/create/test/edit come admin-tool). Nota drift da verificare: la sidebar admin punta a `/admin/agent-definitions` (flat) mentre le pagine App Router vivono sotto `/admin/(dashboard)/agents/definitions` → URL effettivo `/admin/agents/definitions`.
+
+Nota parziale-mapping: il "tone-preset picker" del brief ha un analogo grezzo nel backend (`TypologySlug` ∈ {arbitro, game-master, chat} + `ChatLanguage`), ma non è il picker a 5 toni + confidence-slider descritto in E-Step 3.
+
+Serviva una decisione — la stessa che l'audit segnalava come *"precede tutto il resto"*: **allineare i mockup al backend esistente** oppure **estendere il backend allo scope del brief**.
+
+## Decision
+
+**MVP = allineare al backend esistente. L'agent-building è un tool ADMIN (AI-Lab), non una feature user-facing `/editor/`.**
+
+La superficie di **costruzione** agenti (mockup D–G) è ri-scopata come **admin surface** sopra `/admin/agent-definitions` (admin-gated). La superficie **user-facing** è solo:
+- **H** (`sp7-library-game-agent`, `/library/games/[gameId]/agent`) — Marco **usa** un agente pubblicato via chat inline;
+- il tab "agent" del game-detail (già esistente).
+
+**Ripartizione persona**: **Aaron (admin/dogfood) COSTRUISCE** gli agenti; **Marco (power-user) li USA**. La persona "Marco costruisce agenti al `/editor/`" del brief è **differita** (richiede l'estensione backend user-facing — vedi § Consequences/Negative).
+
+## Allineamenti concreti (per punto di mismatch)
+
+1. **Nomenclatura + route**: mockup D–G → `/admin/agent-definitions*` (admin-gated), entità `AgentDefinition`. NON `/editor/agent-proposals` / `AgentProposal`. Endpoint reali: base `GET/POST/PUT/DELETE /admin/agent-definitions` + `/start-testing`, `/publish`, `/unpublish`, `/stats`, `/catalog-stats`.
+2. **Lifecycle**: `{Draft → Testing → Published}`. **`Archived` NON è un 4° status di lifecycle** ma il soft-delete (`SoftDelete()/Restore()`) → nella UI "Archiviati" = filtro sui soft-deleted, non un badge di stato accanto a Draft/Testing/Published. Il **publish passa obbligatoriamente da Testing** (`Publish()` rifiuta Draft→Published diretto) → E-wizard "Pubblica subito" **rimosso**; il flusso è "Crea come Draft → testa (F) → pubblica".
+3. **Config fields (E-Step 3)**: confidence-threshold slider + tone-preset picker + system-prompt strutturato sono **OUT of MVP** (il backend persiste solo `Model/MaxTokens/Temperature` + `Prompts` generico). Differiti come estensione backend, tracciati. L'MVP usa i campi esistenti.
+4. **Version history / rollback (G)**: **OUT of MVP** (nessun supporto backend). Mockup **G differito/tagliato** dalla wave MVP.
+
+**Testing/playground (F)**: mappa su `PlaygroundChatCommand` esistente — in scope MVP.
+
+Le **8 invarianti agent-builder** risolte coerentemente con questa direzione sono formalizzate in `docs/for-developers/specs/2026-07-15-agent-builder-domain-invariants.md`.
+
+## Consequences
+
+### Positive
+- **Backend già pronto per l'MVP allineato**: `AgentDefinition` è maturo (state machine con guard, CQRS, KB+Game linking, soft-delete). Zero backend work per l'MVP admin-tool.
+- **Basso rischio + sicurezza**: la costruzione agenti resta dietro `RequireAdminSessionFilter` (nessuna esposizione user-facing non presidiata).
+- **Sblocca #1889**: definito il perimetro reale, i mockup D–G (mancanti) diventano autorabili come admin-surface; poi il demo replay diventa eseguibile.
+- **Coerenza demo**: il caso dogfood (Aaron costruisce agenti Nanolith) è esattamente admin-tool.
+
+### Negative
+- **Persona "Marco costruisce agenti" differita**: l'MVP non attiva la US-33 nella sua forma user-facing piena. Marco usa gli agenti (H) ma non li crea. Riabilitabile con l'estensione backend (route user-facing + ownership per-utente).
+- **Confidence-threshold + tone-preset + version/rollback differiti**: 3 feature del brief non entrano nell'MVP. Vanno tracciate come estensioni backend se il prodotto le vuole.
+- **Il brief SP7 va corretto** (routes/persona/scope D–G) per non rigenerare mockup disallineati — fatto in questo PR.
+
+### Trade-offs accettati
+- MVP admin-only ora, user-facing dopo (se giustificato da signal d'uso), invece di costruire subito il flusso user-facing completo. Coerente con il principio YAGNI + "backend existing > speculative build".
+
+## Implementation guidance
+
+1. **Brief SP7** (`admin-mockups/briefs/SP7-game-night-agent-builder.md`): correggere sez. D–G (route → `/admin/agent-definitions`, persona → admin/dogfood, rimuovere `Archived`-status/confidence-slider/tone-preset/version-rollback dallo scope MVP, publish via Testing). H resta user-facing. **Fatto in questo PR.**
+2. **Domain invariants** (`docs/for-developers/specs/2026-07-15-agent-builder-domain-invariants.md`): 8 invarianti risolti per align-to-backend. **Fatto in questo PR.**
+3. **Mockup D–G: NON ri-commissionare.** La superficie admin agent-builder è **già in produzione** (`/admin/agents/definitions` — list/create-wizard/test-playground/edit + componenti + API client + nav). I mockup SP7 D–G sono ridondanti con FE shipped → dispositi come *"not commissioned"* (analogo alla disposition di ADR-079 per il mockup C). L'eventuale allineamento visivo dei mockup alla UI admin reale è opzionale e a bassa priorità.
+4. **Impatto su #1889**: il blocco *"5 mockup agent-builder mancanti (D–H)"* si dissolve in gran parte — D–G esistono come admin FE shipped; resta genuinamente da autorare solo **H** (chat inline user-facing) se non già coperto dal tab agent del game-detail. Il demo replay #1889, se rieseguito, va scopato su H + game-night, non su D–G.
+5. **Estensione backend user-facing** (route `/editor/*`, ownership per-utente, `Archived` status, confidence/tone/version): **tracciata come futura**, fuori MVP, da aprire se il prodotto conferma la persona "Marco builder".
+6. **Drift da verificare** (fuori scope di questo ADR): nav admin punta a `/admin/agent-definitions` (flat) vs pagine sotto `/admin/(dashboard)/agents/definitions` (URL `/admin/agents/definitions`). Segnalare in issue separata se confermato.
+
+## Rollback / reversibility
+
+L'ADR è documentazione. La reversibilità è totale a livello doc: se il prodotto decide per la direzione user-facing, si riparte dal brief originale + issue di estensione backend. Nessun codice viene rimosso da questa decisione (l'MVP riusa il backend esistente).
+
+## References
+
+- Issue #2964 — decisione (sorgente di questo ADR)
+- Issue #1889 — spec-panel che ha scoperto il mismatch (AB-11)
+- Audit `docs/for-developers/audits/2026-07-15-sp7-spec-panel-invariant-diff.md` §2
+- Spec `docs/for-developers/specs/2026-07-15-agent-builder-domain-invariants.md` (8 invarianti)
+- Backend: `apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Entities/AgentDefinition.cs` + `Routing/AdminAgentDefinitionEndpoints.cs`
+- Brief: `admin-mockups/briefs/SP7-game-night-agent-builder.md` (sez. D–H — corretta nello stesso PR)

--- a/docs/for-developers/specs/2026-07-15-agent-builder-domain-invariants.md
+++ b/docs/for-developers/specs/2026-07-15-agent-builder-domain-invariants.md
@@ -1,0 +1,71 @@
+# Domain Invariants — Agent Builder (SP7 US-33)
+
+**Data**: 2026-07-15
+**Origine**: spec-panel [#1889](https://github.com/meepleAi-app/meepleai-monorepo/issues/1889) (audit §3, 8 invarianti candidati) → risolti via [#2964](https://github.com/meepleAi-app/meepleai-monorepo/issues/2964) direzione "allinea a backend (MVP)".
+**Decisione governante**: [ADR-085](../../for-claude/architecture/adr/adr-085-agent-builder-admin-backend-alignment.md)
+**Scope**: bounded context `KnowledgeBase` — aggregato `AgentDefinition`
+
+> Questo doc consolida le ambiguità AB-1..AB-8 del brief agent-builder in invarianti **allineati al backend `AgentDefinition` esistente** (admin-only). NON introduce lo scope user-facing `/editor/*` del brief (differito — vedi ADR-085 § Consequences).
+
+---
+
+## Backend di riferimento (verificato)
+
+| Elemento | Realtà |
+|---|---|
+| Aggregato | `AgentDefinition` (non `AgentProposal`) — `KnowledgeBase/Domain/Entities/AgentDefinition.cs` |
+| Route | `/api/v1/admin/agent-definitions*` — `RequireAdminSessionFilter` (admin-only) |
+| Status enum | `{Draft=0, Testing=1, Published=2}` |
+| Config persistiti | `Model`, `MaxTokens`, `Temperature` + `Prompts`(JSONB), `Tools`, `Strategy`, `KbCardIds`, `GameId?`, `TypologySlug`({arbitro,game-master,chat}), `ChatLanguage`, `IsActive`, soft-delete |
+| Testing | `PlaygroundChatCommand` (SSE) + `PlaygroundTestScenario` (scenari salvati) |
+| Assenti | `ConfidenceThreshold`, `Tone` picker, version-history/rollback |
+
+---
+
+## Invarianti
+
+### I-AB-1 — Lifecycle a 3 stati, publish via Testing
+Il lifecycle è **`Draft → Testing → Published`** (enum backend). Transizioni legali:
+- `StartTesting()`: Draft/Testing → Testing. **Blocca** da Published ("Unpublish first").
+- `Publish()`: **blocca Draft→Published diretto** ("Move to Testing first") → l'agente deve passare da Testing. Setta `IsActive = true`.
+- `Unpublish()`: Published → Draft (`IsActive = false`).
+
+**`Archived` NON è un 4° status di lifecycle.** È il soft-delete (`SoftDelete()/Restore()`), oggi **non esposto via REST** (il `DELETE` è hard-delete). Nella UI "Archiviati" = filtro sui soft-deleted (richiede esporre SoftDelete via REST — futuro), non un badge accanto a Draft/Testing/Published.
+
+### I-AB-2 — Nessun confidence-threshold per-agente (MVP)
+Il backend **non persiste** un `ConfidenceThreshold` per agente. La confidence renderizzata a runtime (`RagValidation/ConfidenceValidationService`) è un **output** della generazione, non una soglia configurabile per agente. **MVP**: nessun gate/slider confidence nel builder. Differito come estensione backend; quando aggiunto, definire semantica deterministica (tier-di-disclaimer XOR refuse-gate).
+
+### I-AB-3 — Cardinalità Agent↔Game + surfacing inline
+`AgentDefinition.GameId` è **opzionale (0..1)**: un agente è legato ad al più 1 game. Un game può avere **N** agenti. Surfacing inline (mockup H, `/library/games/[id]/agent`): **solo agenti `Published` + `IsActive`** sono esposti all'utente; gli agenti `Draft`/`Testing` non compaiono mai inline. Regola di selezione quando >1 Published per game: **default = più recentemente pubblicato** (rivedibile se emerge un "default agent" designato).
+
+### I-AB-4 — Ownership & visibilità: admin-only (MVP)
+**MVP**: la costruzione agenti è **admin-only** (`RequireAdminSessionFilter`). Nessuna ownership per-utente. Gli agenti `Published` sono visibili a **tutti gli utenti** del game linkato via chat inline (H). Costruzione/edit/publish = admin/dogfood. La ownership per-utente + route user-facing `/editor/*` è **estensione futura** (ADR-085), non MVP.
+
+### I-AB-5 — Publish gate = passaggio da Testing
+Il publish richiede il passaggio da `Testing` (guard backend `Publish()`). **Nessun** "Pubblica subito" da Draft. MVP: **nessun gate di qualità aggiuntivo** (KB non-vuoto NON è richiesto — 0-KB ammesso, l'agente userà i soli prompt). Il flusso canonico è **Crea (Draft) → testa (playground) → pubblica**.
+
+### I-AB-6 — Nessun versioning/rollback (MVP)
+Il backend **non ha** version history né rollback. `UpdateAgentDefinitionCommand` muta l'agente **in place**. **MVP**: niente "Last 5 versions"/diff/ripristino (mockup G della feature version-diff = fuori MVP). Differito come estensione backend.
+
+### I-AB-7 — Linking KB
+Gli agenti linkano KB via `KbCardIds` (lista Guid). MVP: il link non impone un precondition di readiness a livello di dominio; la gestione di un KB non-ready/failed è **best-effort a runtime** (l'agente ignora i chunk non disponibili). Se in futuro si vuole vietare il link di KB non-`Ready`, va aggiunta una validazione esplicita.
+
+### I-AB-8 — Catalogo eventi + terminologia
+Gli agenti sono **RAG su KB**: usare **"indicizzazione"**, mai **"training"** (correggere il copy notifiche I/J `agent training` → `agent indexing/ready`). Eventi lifecycle candidati a notifica: **publish**, **KB index-complete** (sul KB linkato), **invocation-milestone** (backend traccia `InvocationCount`/`LastInvokedAt`). MVP: definire in fase impl quali emettono notifica; il "daily summary" del brief è opzionale.
+
+---
+
+## Note di mapping (brief ↔ backend)
+
+- **"tone preset" (E-Step 3)** → analogo parziale: `TypologySlug` ∈ {arbitro, game-master, chat} + `ChatLanguage`. NON il picker a 5 toni + confidence-slider del brief.
+- **"AgentProposal"** → `AgentDefinition`.
+- **status "Archived"** → soft-delete (non lifecycle).
+- **"Testing"** → status persistito reale (`Testing=1`), entrato via `StartTesting()`.
+
+---
+
+## Riferimenti
+- ADR-085 — decisione align-to-backend
+- Audit `docs/for-developers/audits/2026-07-15-sp7-spec-panel-invariant-diff.md` §2-§3
+- Brief `admin-mockups/briefs/SP7-game-night-agent-builder.md` (sez. D–H — corretta)
+- Backend: `AgentDefinition.cs`, `AdminAgentDefinitionEndpoints.cs`, `AgentPlaygroundEndpoints.cs`


### PR DESCRIPTION
## Contesto
Risolve #2964 (deriva dallo spec-panel #1889, finding AB-11): il brief SP7 agent-builder assumeva `AgentProposal` + `/editor/*` user-facing, ma il backend reale è `AgentDefinition` + `/admin/agent-definitions` **admin-only**.

## Decisione (ratificata #2964): allinea a backend (MVP)
L'agent-builder è un **admin-tool**, non una feature user-facing. Scoperta: la **UI admin agent-builder è già in produzione** (`/admin/agents/definitions` — list/create-wizard/test-playground/edit) → i mockup SP7 D–G sono ridondanti e **non vanno commissionati**.

## Contenuto
- **ADR-085** — `agent-builder-admin-backend-alignment`: decisione + 4 mismatch + implementation guidance.
- **Spec 8 invarianti** — `2026-07-15-agent-builder-domain-invariants.md`: lifecycle 3-stati (publish via Testing), no confidence/tone/version in MVP, ownership admin-only, mapping tone→`TypologySlug`.
- **Brief SP7** — banner normativo Wave 2 + tabella scope D–G corretta (route `/admin/agent-definitions`, persona admin/dogfood, scope out-of-MVP).

## Impatto su #1889
Il blocco "5 mockup agent-builder mancanti (D–H)" si dissolve in gran parte: D–G esistono come admin FE shipped; resta solo H (chat inline user-facing).

## Scope
Solo documentazione. Nessun codice di prodotto modificato. `Closes #2964`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)