### PR TITLE
feat(game-night): invia-inviti gate #16 + max-live #10 (#2963, #2965)

### DIFF
--- a/admin-mockups/briefs/SP7-game-night-agent-builder.md
+++ b/admin-mockups/briefs/SP7-game-night-agent-builder.md
@@ -249,8 +249,8 @@ grep -E "hsl\([0-9]+,?\s*89%,\s*48%\)|hsla\([0-9]+,?\s*89%" \
 | `state-04-step3-party` | Step 3 player picker + email | Tag chips entity=player, autocomplete dropdown |
 | `state-05-step4-games` | Step 4 game multi-select | Library cards + duration/players matching |
 | `state-06-step4-conflict` | 2 game candidates con duration totale > "tutto il giorno" | Banner red "Troppo lungo per una sera" |
-| `state-07-review` | Riepilogo finale (read-only summary) | "Crea e invia inviti" CTA primary |
-| `state-08-success` | Post-submit: redirect a B con toast | "Invitato 6 giocatori, attendi RSVP" |
+| `state-07-review` | Riepilogo finale (read-only summary) | "Crea serata" CTA primary (**tagging silente, NESSUN invio inviti al submit** — invariante #16; gli inviti si mandano dopo, dal detail page B) |
+| `state-08-success` | Post-submit: redirect a B con toast | "Serata creata · 6 giocatori taggati. Invia gli inviti dal dettaglio." |
 | `state-09-mobile-step-flow` | Mobile vista wizard (4 step single column) | Bottom bar fixed con CTA "Avanti" / "Indietro" |
 
 Desktop variants:
@@ -269,7 +269,7 @@ Desktop variants:
 
 ### Coverage Gherkin
 
-US-31 happy: G31.1 (create + send invites), G31.5 (game candidates max 3), G31.7 (auto-RSVP regulars), G31.10 (mobile single-column wizard).
+US-31 happy: G31.1 (create + tag players — NO auto-invite al submit, invariante #16), G31.5 (game candidates max 3), G31.7 (auto-RSVP regulars), G31.10 (mobile single-column wizard).
 
 ---
 

--- a/apps/web/src/__tests__/fixtures/mockup-pilots/sp6-7-nano/sp7-game-night-detail-rsvp.ts
+++ b/apps/web/src/__tests__/fixtures/mockup-pilots/sp6-7-nano/sp7-game-night-detail-rsvp.ts
@@ -20,6 +20,7 @@
 import { http, HttpResponse } from 'msw';
 
 export type Sp7DetailRsvpState =
+  | 'host-draft-tagged'
   | 'host-pending'
   | 'host-ready'
   | 'invitee-pending'
@@ -87,6 +88,10 @@ const RSVPS_INVITEE_CONFIRMED = RSVPS_HOST_PENDING.map(r =>
 
 function eventForState(state: Sp7DetailRsvpState) {
   switch (state) {
+    case 'host-draft-tagged':
+      // #2963 / invariant #16: Draft night → tagged players (no invite sent),
+      // host sees the "Invia inviti" (publish) CTA.
+      return { ...NIGHT_BASE, status: 'Draft' };
     case 'cancelled':
       return { ...NIGHT_BASE, status: 'Cancelled', cancellationReason: 'Conflitto reggia' };
     case 'in-progress':

--- a/apps/web/src/app/(authenticated)/game-nights/[id]/_components/GameNightDetailView.tsx
+++ b/apps/web/src/app/(authenticated)/game-nights/[id]/_components/GameNightDetailView.tsx
@@ -281,8 +281,16 @@ export function GameNightDetailView({ id }: { id: string }): React.JSX.Element {
 
   const hostLabel = t('gameNightDetail.participants.hostLabel');
 
-  function rsvpStatusLabel(status: string): string {
+  // #2963 / invariant #16: on a Draft night the roster shows *tagged* players
+  // (silently added at creation, no invite sent yet). Only after the host hits
+  // "Invia inviti" (publish → Published) do Pending rows read as *invited,
+  // awaiting reply*. The RSVP status itself is Pending in both cases — the
+  // distinction is the parent event status, so it is resolved here at the caller.
+  function rsvpStatusLabel(status: string, tagged: boolean): string {
     const key = status.toLowerCase() as 'accepted' | 'declined' | 'maybe' | 'pending';
+    if (tagged && key === 'pending') {
+      return t('gameNightDetail.participants.rsvpStatus.tagged');
+    }
     return t(`gameNightDetail.participants.rsvpStatus.${key}`);
   }
 
@@ -423,7 +431,7 @@ export function GameNightDetailView({ id }: { id: string }): React.JSX.Element {
                   userId={rsvp.userId}
                   userName={rsvp.userName}
                   status={rsvp.status}
-                  statusLabel={rsvpStatusLabel(rsvp.status)}
+                  statusLabel={rsvpStatusLabel(rsvp.status, isDraft)}
                   isMe={rsvp.userId === viewer?.id}
                   isHost={rsvp.userId === event.organizerId}
                   hostLabel={hostLabel}

--- a/apps/web/src/app/(authenticated)/game-nights/[id]/_components/__tests__/GameNightDetailView.inviteCta.test.tsx
+++ b/apps/web/src/app/(authenticated)/game-nights/[id]/_components/__tests__/GameNightDetailView.inviteCta.test.tsx
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { GameNightDetailView } from '../GameNightDetailView';
+
+// #2963 / invariant #16 (tagged vs invited): a Draft night shows *tagged*
+// players (no invite sent) with the "Invia inviti" host CTA; publishing turns
+// Pending rows into *invited, awaiting reply*.
+
+const detailMock = vi.fn();
+const getTabMock = vi.fn<(key: string) => string | null>();
+
+vi.mock('@/hooks/queries/useGameNightDetail', () => ({
+  useGameNightDetail: () => detailMock(),
+}));
+vi.mock('@/hooks/queries/useCurrentUser', () => ({
+  useCurrentUser: () => ({ data: { id: 'org-1' } }),
+}));
+vi.mock('@/hooks/queries/useGameNights', () => ({
+  usePublishGameNight: () => ({ mutate: vi.fn(), isPending: false }),
+  useCancelGameNight: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+vi.mock('@/hooks/queries/useSharedGames', () => ({
+  useSharedGames: () => ({ data: { items: [] } }),
+}));
+vi.mock('@/stores/game-night', () => ({
+  useGameNightStore: () => ({
+    addPlayer: vi.fn(),
+    addGame: vi.fn(),
+    reset: vi.fn(),
+    activeSessions: [],
+  }),
+}));
+vi.mock('@/hooks/useToast', () => ({ useToast: () => ({ toast: vi.fn() }) }));
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => ({ t: (k: string) => k, locale: 'it-IT' }),
+}));
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  useSearchParams: () => ({ get: getTabMock }),
+}));
+
+vi.mock('@/components/features/game-night-detail', () => ({
+  GameNightDetailHero: () => <div data-testid="hero" />,
+  GameNightCancelledBanner: () => null,
+  GameNightRsvpActionBar: () => null,
+  // Expose the resolved status props so the tagged-vs-invited copy is assertable.
+  GameNightRsvpRow: (props: { status: string; statusLabel: string }) => (
+    <div data-testid="rsvp-row" data-status={props.status} data-status-label={props.statusLabel} />
+  ),
+}));
+vi.mock('@/components/game-night/GameNightActions', () => ({
+  GameNightActions: () => <div data-testid="game-night-actions" />,
+}));
+vi.mock('@/components/game-night/GameNightSessionsList', () => ({
+  GameNightSessionsList: () => <div data-testid="sessions-list" />,
+}));
+vi.mock('@/components/game-night/GameNightDiaryPanel', () => ({
+  GameNightDiaryPanel: () => <div data-testid="diary-panel" />,
+}));
+vi.mock('@/components/game-night/planning/GameNightPlanningLayout', () => ({
+  GameNightPlanningLayout: () => null,
+}));
+vi.mock('../GameNightEditDrawer', () => ({ GameNightEditDrawer: () => null }));
+vi.mock('@/components/features/game-night-detail/voting/VotingPanel', () => ({
+  VotingPanel: () => <div data-testid="voting-panel" />,
+}));
+
+const baseEvent = {
+  id: 'gn-1',
+  organizerId: 'org-1',
+  organizerName: 'Marco',
+  title: 'Serata',
+  description: null,
+  scheduledAt: '2026-08-01T20:00:00.000Z',
+  location: null,
+  maxPlayers: null,
+  gameIds: [] as string[],
+  acceptedCount: 1,
+};
+
+const roster = [
+  { id: 'r1', userId: 'org-1', userName: 'Marco', status: 'Accepted' },
+  { id: 'r2', userId: 'guest-1', userName: 'Davide', status: 'Pending' },
+];
+
+function mockDetail(status: 'Draft' | 'Published') {
+  detailMock.mockReturnValue({
+    event: { ...baseEvent, status },
+    rsvps: roster,
+    actor: { actor: 'host' },
+    isLoading: false,
+    isError: false,
+    currentResponse: undefined,
+    pendingResponse: null,
+    submitRsvp: vi.fn(),
+    isSubmitting: false,
+  });
+}
+
+function pendingRowLabel(): string | null {
+  const row = screen
+    .getAllByTestId('rsvp-row')
+    .find(el => el.getAttribute('data-status') === 'Pending');
+  return row?.getAttribute('data-status-label') ?? null;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getTabMock.mockReturnValue(null);
+});
+
+describe('GameNightDetailView — Invia inviti / tagged vs invited (#2963, invariant #16)', () => {
+  it('renders the "Invia inviti" host CTA on a Draft night', () => {
+    mockDetail('Draft');
+    render(<GameNightDetailView id="gn-1" />);
+    const cta = screen.getByTestId('publish-game-night');
+    // t() returns the key in the test harness — the button resolves the publish
+    // label key, whose value is "Invia inviti" (it) / "Send invites" (en).
+    expect(cta).toHaveTextContent('gameNightDetail.actor.host.publish');
+  });
+
+  it('labels Pending roster rows as *tagged* (no invite sent) on a Draft night', () => {
+    mockDetail('Draft');
+    render(<GameNightDetailView id="gn-1" />);
+    expect(pendingRowLabel()).toBe('gameNightDetail.participants.rsvpStatus.tagged');
+  });
+
+  it('labels Pending roster rows as *invited/pending* once Published', () => {
+    mockDetail('Published');
+    render(<GameNightDetailView id="gn-1" />);
+    expect(pendingRowLabel()).toBe('gameNightDetail.participants.rsvpStatus.pending');
+    // The publish CTA is gone once the night is Published (invites already sent).
+    expect(screen.queryByTestId('publish-game-night')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/(authenticated)/game-nights/[id]/game-night-detail-rsvp.stories.tsx
+++ b/apps/web/src/app/(authenticated)/game-nights/[id]/game-night-detail-rsvp.stories.tsx
@@ -184,6 +184,20 @@ export const Frame12_DesktopSplitVoting: Story = {
   },
 };
 
+export const Frame13_HostDraftTagged: Story = {
+  name: '13 · Host · Draft · giocatori taggati + "Invia inviti" (#2963, invariante #16)',
+  args: { id: 'gn-padovani-may17' },
+  parameters: {
+    msw: { handlers: mswForSp7DetailRsvpState('host-draft-tagged') },
+    docs: {
+      description: {
+        story:
+          'Invariante #16 (tagged vs invited): su una serata Draft i giocatori sono *taggati* (aggiunti, nessun invito inviato) — le righe Pending mostrano "Da invitare" e l\'host vede la CTA "Invia inviti" (publish → Published). Solo dopo l\'invio le righe diventano "In attesa" (invitati). Vedi #2963.',
+      },
+    },
+  },
+};
+
 // ── State variant frames (axis = LoadState) ────────────────────────────────
 
 export const Loading: Story = {

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -3932,9 +3932,9 @@
       "host": {
         "edit": "Edit",
         "cancel": "Cancel game night",
-        "publish": "Publish",
+        "publish": "Send invites",
         "kickGuest": "Remove",
-        "publishedToast": "Game night published",
+        "publishedToast": "Invites sent",
         "publishedToastDescription": "Guests will receive a notification.",
         "cancelledToast": "Game night cancelled"
       },
@@ -3956,7 +3956,8 @@
         "accepted": "Going",
         "declined": "Declined",
         "maybe": "Maybe",
-        "pending": "Pending"
+        "pending": "Pending",
+        "tagged": "To invite"
       }
     },
     "cancelled": {

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -3985,9 +3985,9 @@
       "host": {
         "edit": "Modifica",
         "cancel": "Annulla serata",
-        "publish": "Pubblica",
+        "publish": "Invia inviti",
         "kickGuest": "Rimuovi",
-        "publishedToast": "Serata pubblicata",
+        "publishedToast": "Inviti inviati",
         "publishedToastDescription": "Gli invitati riceveranno una notifica.",
         "cancelledToast": "Serata annullata"
       },
@@ -4009,7 +4009,8 @@
         "accepted": "Confermato",
         "declined": "Declinato",
         "maybe": "Forse",
-        "pending": "In attesa"
+        "pending": "In attesa",
+        "tagged": "Da invitare"
       }
     },
     "cancelled": {


### PR DESCRIPTION
## Contesto
Risolve #2963 e #2965 (follow-up dello spec-panel #1889). Il domain model + backend già supportano entrambe le invarianti; il gap era nel FE/mockup.

## #2963 — invariante #16 tagged→invited
Il detail page game-night ora rende esplicito il gate tagged→invited:
- **CTA host "Invia inviti"** sulle serate Draft (relabel dell'azione `publish` — Draft→Published invia le notifiche).
- **Roster RSVP distingue tagged vs invited**: su Draft le righe `Pending` mostrano *"Da invitare"* (taggato, nessun invito); su Published *"In attesa"* (invitato). La distinzione deriva da `event.status` (backend `PreInvite`/Draft vs `Publish`/Published), non da un flag per-RSVP.
- **Brief SP7 sez. A corretto**: creazione = tag silente, no auto-invite al submit.
- Nuovo unit test (`GameNightDetailView.inviteCta.test.tsx`, 3 casi) + frame Storybook `Frame13_HostDraftTagged`.

## #2965 — invariante #10 max-1-live: già soddisfatta
Verificato che il gate è **già pienamente applicato e testato nel runtime**:
- `/live` route (`NightLiveClientView`) → `useStartNextGame` `isMaxLiveBlockedError` + `BlockedLiveSessionModal` + start CTA nascosta durante il live.
- Test esistenti: `useStartNextGame.test.tsx`, `BlockedLiveSessionModal.test.tsx`, `NightLiveClientView.test.tsx`.
- La "CTA Avvia sessione live incondizionata" segnalata dall'audit era un **artefatto del mockup statico**, non un gap runtime (il detail page non ha quella CTA). Nessun codice necessario.

## Verifiche
typecheck ✅ · eslint ✅ · lint:storybook-states (contract=0) ✅ · 14 test game-night-detail verdi (3 nuovi + 11 esistenti, 0 regressioni).

## Nota
Il mockup statico `sp7-game-night-detail-rsvp.jsx` (design reference) non è stato editato: il comportamento reale è nel page-client `GameNightDetailView` (che la story renderizza via MSW), ora allineato alle invarianti. Il re-sync visivo del mockup è low-priority.

`Closes #2963. Closes #2965.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)