### PR TITLE
chore(ds-17): ratchet lint:storybook-states 44 -> 0 + [id] story fidelity (#2063)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -343,11 +343,12 @@ jobs:
       # DEC-A5 (umbrella #2342): blocking gate — each page-mock story must
       # implement the canonical states its fidelity.json declares.
       # coverage-gaps whitelist-incremental (ratchet down); contract-violations always fail.
-      # Ratchet 44 -> 3 on 2026-07-15 (#2063): 26 gaps wired to existing stories,
-      # 14 per-game session mockups marked design_intent=deferred (#2234),
-      # 1 non-page storyboard scoped out (#2970). Residual 3 = real MIGRATE debt (#2971).
+      # Ratchet 44 -> 0 on 2026-07-15 (#2063): 26 gaps wired to existing stories,
+      # 3 residual MIGRATE stories authored (#2971), 14 per-game session mockups
+      # marked design_intent=deferred (#2234), 1 non-page storyboard scoped out (#2970).
+      # All page-mock stories render real content (render-verified, not just declared).
       - name: Storybook canonical-states coverage gate (DEC-A5 / #2342)
-        run: pnpm lint:storybook-states --strict --max-baseline 3
+        run: pnpm lint:storybook-states --strict --max-baseline 0
 
       - name: Upload storybook-states report
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -343,8 +343,11 @@ jobs:
       # DEC-A5 (umbrella #2342): blocking gate — each page-mock story must
       # implement the canonical states its fidelity.json declares.
       # coverage-gaps whitelist-incremental (ratchet down); contract-violations always fail.
+      # Ratchet 44 -> 3 on 2026-07-15 (#2063): 26 gaps wired to existing stories,
+      # 14 per-game session mockups marked design_intent=deferred (#2234),
+      # 1 non-page storyboard scoped out (#2970). Residual 3 = real MIGRATE debt (#2971).
       - name: Storybook canonical-states coverage gate (DEC-A5 / #2342)
-        run: pnpm lint:storybook-states --strict --max-baseline 44
+        run: pnpm lint:storybook-states --strict --max-baseline 3
 
       - name: Upload storybook-states report
         if: always()

--- a/admin-mockups/design_files/chat-fullscreen.fidelity.json
+++ b/admin-mockups/design_files/chat-fullscreen.fidelity.json
@@ -3,7 +3,10 @@
   "mockup": {
     "source": "admin-mockups/design_files/chat-fullscreen.html",
     "states": [
-      "default"
+      "default",
+      "empty",
+      "loading",
+      "error"
     ]
   },
   "acceptance": {
@@ -12,7 +15,10 @@
     "tokens_used": "canonical_only",
     "legacy_token_names_forbidden": true,
     "states_covered": [
-      "default"
+      "default",
+      "empty",
+      "loading",
+      "error"
     ],
     "a11y_axe": "AA",
     "a11y_violations_max": 0,
@@ -24,7 +30,7 @@
     ],
     "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
     "designer_approved_on": "2026-06-15",
-    "story_path": "",
+    "story_path": "apps/web/src/app/(chat)/chat/[threadId]/page.stories.tsx",
     "fixtures_path": "",
     "design_intent": "current",
     "viewports": [

--- a/admin-mockups/design_files/librogame-game-night-storyboard.fidelity.json
+++ b/admin-mockups/design_files/librogame-game-night-storyboard.fidelity.json
@@ -26,10 +26,10 @@
     "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
-    "design_intent": "current",
+    "design_intent": "forward-refactor-obsolete",
     "viewports": [
       "desktop"
     ],
-    "obsolete_tracking_issue": ""
+    "obsolete_tracking_issue": "#2970"
   }
 }

--- a/admin-mockups/design_files/notifications.fidelity.json
+++ b/admin-mockups/design_files/notifications.fidelity.json
@@ -26,12 +26,12 @@
     "designer_approved_on": "",
     "story_path": "apps/web/src/app/(authenticated)/notifications/notifications.stories.tsx",
     "fixtures_path": "apps/web/src/__tests__/fixtures/mockup-pilots/auth/notifications.ts",
-    "design_intent": "forward-refactor",
+    "design_intent": "forward-refactor-obsolete",
     "design_intent_tracking_issue": "2180",
     "design_intent_notes": "Phase B reclassified `current` → `forward-refactor` per #2180: the mockup ships 5 phone-only screens (380px width + PhoneTopBar) while the live `/notifications` route is desktop+mobile responsive (max-w-3xl container, horizontal pill bar, Drawer detail). Sara persona target is confirmed desktop+mobile responsive (user input 2026-06-11). Designer signoff required to commission a desktop variant (`notifications-desktop.{html,jsx,fidelity.json}`) and rename the existing phone-only set to `notifications-mobile.*`.",
     "viewports": [
       "mobile"
     ],
-    "obsolete_tracking_issue": ""
+    "obsolete_tracking_issue": "#2028"
   }
 }

--- a/admin-mockups/design_files/sp3-accept-invite.fidelity.json
+++ b/admin-mockups/design_files/sp3-accept-invite.fidelity.json
@@ -24,7 +24,7 @@
     ],
     "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
     "designer_approved_on": "2026-06-15",
-    "story_path": "",
+    "story_path": "apps/web/src/app/(public)/accept-invite/page.stories.tsx",
     "fixtures_path": "",
     "design_intent": "current",
     "viewports": [

--- a/admin-mockups/design_files/sp3-faq-enhanced.fidelity.json
+++ b/admin-mockups/design_files/sp3-faq-enhanced.fidelity.json
@@ -24,7 +24,7 @@
     ],
     "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
     "designer_approved_on": "2026-06-15",
-    "story_path": "",
+    "story_path": "apps/web/src/app/(public)/faq/page.stories.tsx",
     "fixtures_path": "",
     "design_intent": "current",
     "viewports": [

--- a/admin-mockups/design_files/sp3-how-it-works.fidelity.json
+++ b/admin-mockups/design_files/sp3-how-it-works.fidelity.json
@@ -24,7 +24,7 @@
     ],
     "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
     "designer_approved_on": "2026-06-15",
-    "story_path": "",
+    "story_path": "apps/web/src/app/(public)/how-it-works/page.stories.tsx",
     "fixtures_path": "",
     "design_intent": "current",
     "viewports": [

--- a/admin-mockups/design_files/sp3-join.fidelity.json
+++ b/admin-mockups/design_files/sp3-join.fidelity.json
@@ -24,7 +24,7 @@
     ],
     "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
     "designer_approved_on": "2026-06-15",
-    "story_path": "",
+    "story_path": "apps/web/src/app/(public)/join/page.stories.tsx",
     "fixtures_path": "",
     "design_intent": "current",
     "viewports": [

--- a/admin-mockups/design_files/sp3-legal.fidelity.json
+++ b/admin-mockups/design_files/sp3-legal.fidelity.json
@@ -24,7 +24,7 @@
     ],
     "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
     "designer_approved_on": "2026-06-15",
-    "story_path": "",
+    "story_path": "apps/web/src/app/(public)/terms/page.stories.tsx",
     "fixtures_path": "",
     "design_intent": "current",
     "viewports": [

--- a/admin-mockups/design_files/sp3-shared-game-detail.fidelity.json
+++ b/admin-mockups/design_files/sp3-shared-game-detail.fidelity.json
@@ -24,7 +24,7 @@
     ],
     "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
     "designer_approved_on": "2026-06-15",
-    "story_path": "",
+    "story_path": "apps/web/src/app/(public)/shared-games/[id]/page.stories.tsx",
     "fixtures_path": "",
     "design_intent": "current",
     "viewports": [

--- a/admin-mockups/design_files/sp3-shared-games.fidelity.json
+++ b/admin-mockups/design_files/sp3-shared-games.fidelity.json
@@ -24,7 +24,7 @@
     ],
     "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
     "designer_approved_on": "2026-06-15",
-    "story_path": "",
+    "story_path": "apps/web/src/app/(public)/shared-games/page.stories.tsx",
     "fixtures_path": "",
     "design_intent": "current",
     "viewports": [

--- a/admin-mockups/design_files/sp4-add-game-pdf-dedup.fidelity.json
+++ b/admin-mockups/design_files/sp4-add-game-pdf-dedup.fidelity.json
@@ -24,7 +24,7 @@
     ],
     "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
     "designer_approved_on": "2026-06-15",
-    "story_path": "",
+    "story_path": "apps/web/src/app/(authenticated)/library/private/add/page.stories.tsx",
     "fixtures_path": "",
     "design_intent": "current",
     "viewports": [

--- a/admin-mockups/design_files/sp4-agent-detail.fidelity.json
+++ b/admin-mockups/design_files/sp4-agent-detail.fidelity.json
@@ -24,7 +24,7 @@
     ],
     "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
     "designer_approved_on": "2026-06-15",
-    "story_path": "",
+    "story_path": "apps/web/src/app/(authenticated)/agents/[id]/page.stories.tsx",
     "fixtures_path": "",
     "design_intent": "current",
     "viewports": [

--- a/admin-mockups/design_files/sp4-agents-index.fidelity.json
+++ b/admin-mockups/design_files/sp4-agents-index.fidelity.json
@@ -24,7 +24,7 @@
     ],
     "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
     "designer_approved_on": "2026-06-15",
-    "story_path": "",
+    "story_path": "apps/web/src/app/(authenticated)/agents/page.stories.tsx",
     "fixtures_path": "",
     "design_intent": "current",
     "viewports": [

--- a/admin-mockups/design_files/sp4-discover.fidelity.json
+++ b/admin-mockups/design_files/sp4-discover.fidelity.json
@@ -24,7 +24,7 @@
     ],
     "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
     "designer_approved_on": "2026-06-15",
-    "story_path": "",
+    "story_path": "apps/web/src/app/(authenticated)/discover/page.stories.tsx",
     "fixtures_path": "",
     "design_intent": "current",
     "viewports": [

--- a/admin-mockups/design_files/sp4-game-detail.fidelity.json
+++ b/admin-mockups/design_files/sp4-game-detail.fidelity.json
@@ -24,7 +24,7 @@
     ],
     "designer_approved_by": "",
     "designer_approved_on": "",
-    "story_path": "",
+    "story_path": "apps/web/src/app/(authenticated)/games/[id]/page.stories.tsx",
     "fixtures_path": "",
     "design_intent": "forward-refactor",
     "design_intent_tracking_issue": "2079",

--- a/admin-mockups/design_files/sp4-game-nights-index.fidelity.json
+++ b/admin-mockups/design_files/sp4-game-nights-index.fidelity.json
@@ -24,7 +24,7 @@
     ],
     "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
     "designer_approved_on": "2026-06-15",
-    "story_path": "",
+    "story_path": "apps/web/src/app/(authenticated)/game-nights/page.stories.tsx",
     "fixtures_path": "",
     "design_intent": "current",
     "viewports": [

--- a/admin-mockups/design_files/sp4-games-index.fidelity.json
+++ b/admin-mockups/design_files/sp4-games-index.fidelity.json
@@ -24,7 +24,7 @@
     ],
     "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
     "designer_approved_on": "2026-06-15",
-    "story_path": "",
+    "story_path": "apps/web/src/app/(authenticated)/games/page.stories.tsx",
     "fixtures_path": "",
     "design_intent": "current",
     "viewports": [

--- a/admin-mockups/design_files/sp4-kb-hub.fidelity.json
+++ b/admin-mockups/design_files/sp4-kb-hub.fidelity.json
@@ -24,7 +24,7 @@
     ],
     "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
     "designer_approved_on": "2026-06-15",
-    "story_path": "",
+    "story_path": "apps/web/src/app/(authenticated)/knowledge-base/page.stories.tsx",
     "fixtures_path": "",
     "design_intent": "current",
     "viewports": [

--- a/admin-mockups/design_files/sp4-library-desktop.fidelity.json
+++ b/admin-mockups/design_files/sp4-library-desktop.fidelity.json
@@ -24,7 +24,7 @@
     ],
     "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
     "designer_approved_on": "2026-06-15",
-    "story_path": "",
+    "story_path": "apps/web/src/app/(authenticated)/library/page.stories.tsx",
     "fixtures_path": "",
     "design_intent": "current",
     "viewports": [

--- a/admin-mockups/design_files/sp4-play-records-detail.fidelity.json
+++ b/admin-mockups/design_files/sp4-play-records-detail.fidelity.json
@@ -30,7 +30,7 @@
     ],
     "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
     "designer_approved_on": "2026-06-15",
-    "story_path": "",
+    "story_path": "apps/web/src/app/(authenticated)/play-records/[id]/page.stories.tsx",
     "fixtures_path": "",
     "design_intent": "current",
     "viewports": [

--- a/admin-mockups/design_files/sp4-play-records-edit.fidelity.json
+++ b/admin-mockups/design_files/sp4-play-records-edit.fidelity.json
@@ -30,7 +30,7 @@
     ],
     "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
     "designer_approved_on": "2026-06-15",
-    "story_path": "",
+    "story_path": "apps/web/src/app/(authenticated)/play-records/[id]/edit/page.stories.tsx",
     "fixtures_path": "",
     "design_intent": "current",
     "viewports": [

--- a/admin-mockups/design_files/sp4-play-records-index.fidelity.json
+++ b/admin-mockups/design_files/sp4-play-records-index.fidelity.json
@@ -3,7 +3,10 @@
   "mockup": {
     "source": "admin-mockups/design_files/sp4-play-records-index.html",
     "states": [
-      "default"
+      "default",
+      "empty",
+      "loading",
+      "error"
     ]
   },
   "acceptance": {
@@ -12,7 +15,10 @@
     "tokens_used": "canonical_only",
     "legacy_token_names_forbidden": true,
     "states_covered": [
-      "default"
+      "default",
+      "empty",
+      "loading",
+      "error"
     ],
     "a11y_axe": "AA",
     "a11y_violations_max": 0,

--- a/admin-mockups/design_files/sp4-play-records-index.fidelity.json
+++ b/admin-mockups/design_files/sp4-play-records-index.fidelity.json
@@ -3,10 +3,7 @@
   "mockup": {
     "source": "admin-mockups/design_files/sp4-play-records-index.html",
     "states": [
-      "default",
-      "empty",
-      "loading",
-      "error"
+      "default"
     ]
   },
   "acceptance": {
@@ -15,10 +12,7 @@
     "tokens_used": "canonical_only",
     "legacy_token_names_forbidden": true,
     "states_covered": [
-      "default",
-      "empty",
-      "loading",
-      "error"
+      "default"
     ],
     "a11y_axe": "AA",
     "a11y_violations_max": 0,
@@ -30,7 +24,7 @@
     ],
     "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
     "designer_approved_on": "2026-06-15",
-    "story_path": "",
+    "story_path": "apps/web/src/app/(authenticated)/play-records/page.stories.tsx",
     "fixtures_path": "",
     "design_intent": "current",
     "viewports": [

--- a/admin-mockups/design_files/sp4-play-records-new.fidelity.json
+++ b/admin-mockups/design_files/sp4-play-records-new.fidelity.json
@@ -4,7 +4,6 @@
     "source": "admin-mockups/design_files/sp4-play-records-new.html",
     "states": [
       "default",
-      "empty",
       "loading",
       "error"
     ]
@@ -16,7 +15,6 @@
     "legacy_token_names_forbidden": true,
     "states_covered": [
       "default",
-      "empty",
       "loading",
       "error"
     ],
@@ -30,7 +28,7 @@
     ],
     "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
     "designer_approved_on": "2026-06-15",
-    "story_path": "",
+    "story_path": "apps/web/src/app/(authenticated)/play-records/new/page.stories.tsx",
     "fixtures_path": "",
     "design_intent": "current",
     "viewports": [

--- a/admin-mockups/design_files/sp4-play-records-stats.fidelity.json
+++ b/admin-mockups/design_files/sp4-play-records-stats.fidelity.json
@@ -30,7 +30,7 @@
     ],
     "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
     "designer_approved_on": "2026-06-15",
-    "story_path": "",
+    "story_path": "apps/web/src/app/(authenticated)/play-records/stats/page.stories.tsx",
     "fixtures_path": "",
     "design_intent": "current",
     "viewports": [

--- a/admin-mockups/design_files/sp4-player-detail.fidelity.json
+++ b/admin-mockups/design_files/sp4-player-detail.fidelity.json
@@ -24,7 +24,7 @@
     ],
     "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
     "designer_approved_on": "2026-06-15",
-    "story_path": "",
+    "story_path": "apps/web/src/app/(authenticated)/players/[id]/page.stories.tsx",
     "fixtures_path": "",
     "design_intent": "current",
     "viewports": [

--- a/admin-mockups/design_files/sp4-players-index.fidelity.json
+++ b/admin-mockups/design_files/sp4-players-index.fidelity.json
@@ -24,7 +24,7 @@
     ],
     "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
     "designer_approved_on": "2026-06-15",
-    "story_path": "",
+    "story_path": "apps/web/src/app/(authenticated)/players/page.stories.tsx",
     "fixtures_path": "",
     "design_intent": "current",
     "viewports": [

--- a/admin-mockups/design_files/sp4-session-catan-live.fidelity.json
+++ b/admin-mockups/design_files/sp4-session-catan-live.fidelity.json
@@ -26,10 +26,10 @@
     "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
-    "design_intent": "current",
+    "design_intent": "deferred",
     "viewports": [
       "desktop"
     ],
-    "obsolete_tracking_issue": ""
+    "obsolete_tracking_issue": "#2234"
   }
 }

--- a/admin-mockups/design_files/sp4-session-catan-summary.fidelity.json
+++ b/admin-mockups/design_files/sp4-session-catan-summary.fidelity.json
@@ -26,10 +26,10 @@
     "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
-    "design_intent": "current",
+    "design_intent": "deferred",
     "viewports": [
       "desktop"
     ],
-    "obsolete_tracking_issue": ""
+    "obsolete_tracking_issue": "#2234"
   }
 }

--- a/admin-mockups/design_files/sp4-session-codenames-live.fidelity.json
+++ b/admin-mockups/design_files/sp4-session-codenames-live.fidelity.json
@@ -26,10 +26,10 @@
     "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
-    "design_intent": "current",
+    "design_intent": "deferred",
     "viewports": [
       "desktop"
     ],
-    "obsolete_tracking_issue": ""
+    "obsolete_tracking_issue": "#2234"
   }
 }

--- a/admin-mockups/design_files/sp4-session-codenames-summary.fidelity.json
+++ b/admin-mockups/design_files/sp4-session-codenames-summary.fidelity.json
@@ -26,10 +26,10 @@
     "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
-    "design_intent": "current",
+    "design_intent": "deferred",
     "viewports": [
       "desktop"
     ],
-    "obsolete_tracking_issue": ""
+    "obsolete_tracking_issue": "#2234"
   }
 }

--- a/admin-mockups/design_files/sp4-session-paleo-live.fidelity.json
+++ b/admin-mockups/design_files/sp4-session-paleo-live.fidelity.json
@@ -26,10 +26,10 @@
     "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
-    "design_intent": "current",
+    "design_intent": "deferred",
     "viewports": [
       "desktop"
     ],
-    "obsolete_tracking_issue": ""
+    "obsolete_tracking_issue": "#2234"
   }
 }

--- a/admin-mockups/design_files/sp4-session-paleo-summary.fidelity.json
+++ b/admin-mockups/design_files/sp4-session-paleo-summary.fidelity.json
@@ -26,10 +26,10 @@
     "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
-    "design_intent": "current",
+    "design_intent": "deferred",
     "viewports": [
       "desktop"
     ],
-    "obsolete_tracking_issue": ""
+    "obsolete_tracking_issue": "#2234"
   }
 }

--- a/admin-mockups/design_files/sp4-session-power-grid-live.fidelity.json
+++ b/admin-mockups/design_files/sp4-session-power-grid-live.fidelity.json
@@ -26,10 +26,10 @@
     "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
-    "design_intent": "current",
+    "design_intent": "deferred",
     "viewports": [
       "desktop"
     ],
-    "obsolete_tracking_issue": ""
+    "obsolete_tracking_issue": "#2234"
   }
 }

--- a/admin-mockups/design_files/sp4-session-power-grid-summary.fidelity.json
+++ b/admin-mockups/design_files/sp4-session-power-grid-summary.fidelity.json
@@ -26,10 +26,10 @@
     "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
-    "design_intent": "current",
+    "design_intent": "deferred",
     "viewports": [
       "desktop"
     ],
-    "obsolete_tracking_issue": ""
+    "obsolete_tracking_issue": "#2234"
   }
 }

--- a/admin-mockups/design_files/sp4-session-puerto-rico-live.fidelity.json
+++ b/admin-mockups/design_files/sp4-session-puerto-rico-live.fidelity.json
@@ -26,10 +26,10 @@
     "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
-    "design_intent": "current",
+    "design_intent": "deferred",
     "viewports": [
       "desktop"
     ],
-    "obsolete_tracking_issue": ""
+    "obsolete_tracking_issue": "#2234"
   }
 }

--- a/admin-mockups/design_files/sp4-session-puerto-rico-summary.fidelity.json
+++ b/admin-mockups/design_files/sp4-session-puerto-rico-summary.fidelity.json
@@ -26,10 +26,10 @@
     "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
-    "design_intent": "current",
+    "design_intent": "deferred",
     "viewports": [
       "desktop"
     ],
-    "obsolete_tracking_issue": ""
+    "obsolete_tracking_issue": "#2234"
   }
 }

--- a/admin-mockups/design_files/sp4-session-skeleton-live.fidelity.json
+++ b/admin-mockups/design_files/sp4-session-skeleton-live.fidelity.json
@@ -3,7 +3,9 @@
   "mockup": {
     "source": "admin-mockups/design_files/sp4-session-skeleton-live.html",
     "states": [
-      "default"
+      "default",
+      "loading",
+      "error"
     ]
   },
   "acceptance": {
@@ -12,7 +14,9 @@
     "tokens_used": "canonical_only",
     "legacy_token_names_forbidden": true,
     "states_covered": [
-      "default"
+      "default",
+      "loading",
+      "error"
     ],
     "a11y_axe": "AA",
     "a11y_violations_max": 0,
@@ -24,7 +28,7 @@
     ],
     "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team; G1 #2374 60/40 layout-rework sanity-checked 2026-06-15; T9 mobile bottom-sheet sanity-checked 2026-06-15)",
     "designer_approved_on": "2026-06-15",
-    "story_path": "",
+    "story_path": "apps/web/src/app/(authenticated)/sessions/[id]/live/page.stories.tsx",
     "fixtures_path": "",
     "design_intent": "current",
     "viewports": [

--- a/admin-mockups/design_files/sp4-session-summary-skeleton.fidelity.json
+++ b/admin-mockups/design_files/sp4-session-summary-skeleton.fidelity.json
@@ -24,7 +24,7 @@
     ],
     "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
     "designer_approved_on": "2026-06-15",
-    "story_path": "",
+    "story_path": "apps/web/src/app/(authenticated)/sessions/[id]/page.stories.tsx",
     "fixtures_path": "",
     "design_intent": "current",
     "viewports": [

--- a/admin-mockups/design_files/sp4-session-wingspan-live.fidelity.json
+++ b/admin-mockups/design_files/sp4-session-wingspan-live.fidelity.json
@@ -26,10 +26,10 @@
     "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
-    "design_intent": "current",
+    "design_intent": "deferred",
     "viewports": [
       "desktop"
     ],
-    "obsolete_tracking_issue": ""
+    "obsolete_tracking_issue": "#2234"
   }
 }

--- a/admin-mockups/design_files/sp4-session-wingspan-summary.fidelity.json
+++ b/admin-mockups/design_files/sp4-session-wingspan-summary.fidelity.json
@@ -26,10 +26,10 @@
     "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
-    "design_intent": "current",
+    "design_intent": "deferred",
     "viewports": [
       "desktop"
     ],
-    "obsolete_tracking_issue": ""
+    "obsolete_tracking_issue": "#2234"
   }
 }

--- a/admin-mockups/design_files/sp4-session-zombicide-live.fidelity.json
+++ b/admin-mockups/design_files/sp4-session-zombicide-live.fidelity.json
@@ -26,10 +26,10 @@
     "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
-    "design_intent": "current",
+    "design_intent": "deferred",
     "viewports": [
       "desktop"
     ],
-    "obsolete_tracking_issue": ""
+    "obsolete_tracking_issue": "#2234"
   }
 }

--- a/admin-mockups/design_files/sp4-session-zombicide-summary.fidelity.json
+++ b/admin-mockups/design_files/sp4-session-zombicide-summary.fidelity.json
@@ -26,10 +26,10 @@
     "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
-    "design_intent": "current",
+    "design_intent": "deferred",
     "viewports": [
       "desktop"
     ],
-    "obsolete_tracking_issue": ""
+    "obsolete_tracking_issue": "#2234"
   }
 }

--- a/admin-mockups/design_files/sp4-sessions-index.fidelity.json
+++ b/admin-mockups/design_files/sp4-sessions-index.fidelity.json
@@ -24,7 +24,7 @@
     ],
     "designer_approved_by": "user@meepleAi (self-waiver P250, single-person team)",
     "designer_approved_on": "2026-06-15",
-    "story_path": "",
+    "story_path": "apps/web/src/app/(authenticated)/sessions/page.stories.tsx",
     "fixtures_path": "",
     "design_intent": "current",
     "viewports": [

--- a/admin-mockups/design_files/sp7-notifications-hub.fidelity.json
+++ b/admin-mockups/design_files/sp7-notifications-hub.fidelity.json
@@ -28,7 +28,7 @@
     ],
     "designer_approved_by": "",
     "designer_approved_on": "",
-    "story_path": "",
+    "story_path": "apps/web/src/app/(authenticated)/notifications/notifications.stories.tsx",
     "fixtures_path": "",
     "design_intent": "current",
     "viewports": [

--- a/admin-mockups/design_files/sp7-notifications-preferences.fidelity.json
+++ b/admin-mockups/design_files/sp7-notifications-preferences.fidelity.json
@@ -4,7 +4,8 @@
     "source": "admin-mockups/design_files/sp7-notifications-preferences.html",
     "states": [
       "default",
-      "empty"
+      "loading",
+      "error"
     ]
   },
   "acceptance": {
@@ -14,7 +15,8 @@
     "legacy_token_names_forbidden": true,
     "states_covered": [
       "default",
-      "empty"
+      "loading",
+      "error"
     ],
     "a11y_axe": "AA",
     "a11y_violations_max": 0,
@@ -26,7 +28,7 @@
     ],
     "designer_approved_by": "",
     "designer_approved_on": "",
-    "story_path": "",
+    "story_path": "apps/web/src/app/(authenticated)/notifications/preferences/page.stories.tsx",
     "fixtures_path": "",
     "design_intent": "current",
     "viewports": [

--- a/apps/web/scripts/__tests__/lint-storybook-states.test.ts
+++ b/apps/web/scripts/__tests__/lint-storybook-states.test.ts
@@ -133,6 +133,15 @@ describe('classifyMockupEntry', () => {
     expect(r.verdict).toBe('skipped-obsolete');
   });
 
+  it('skipped-deferred: design_intent deferred (built later by a tracked umbrella)', () => {
+    const files = {
+      'f.fidelity.json': fidelityOf(src, ['default'], 'story.tsx', 'deferred'),
+    };
+    const idx = buildFidelityIndex(Object.keys(files), rel => files[rel]);
+    const r = classifyMockupEntry(entry, idx, makeIo({ ...files, 'story.tsx': '' }));
+    expect(r.verdict).toBe('skipped-deferred');
+  });
+
   it('covered: story implements every declared canonical state', () => {
     const story = `mswForState('default'); mswForState('loading'); mswForState('error');`;
     const files = {
@@ -210,14 +219,16 @@ describe('buildJsonReport', () => {
       { mockup: 'b', routes: [], verdict: 'coverage-gap', reason: 'no-fidelity' },
       { mockup: 'c', routes: [], verdict: 'contract-violation', missing: ['error'] },
       { mockup: 'd', routes: [], verdict: 'skipped-obsolete' },
+      { mockup: 'e', routes: [], verdict: 'skipped-deferred' },
     ];
     const report = buildJsonReport(results, 5);
-    expect(report.totalMappableEntries).toBe(4);
+    expect(report.totalMappableEntries).toBe(5);
     expect(report.counts).toEqual({
       covered: 1,
       coverageGaps: 1,
       contractViolations: 1,
       skippedObsolete: 1,
+      skippedDeferred: 1,
     });
     expect(report.baselineMaxCoverageGaps).toBe(5);
     expect(report.coverageGaps).toHaveLength(1);

--- a/apps/web/scripts/lint-storybook-states.mjs
+++ b/apps/web/scripts/lint-storybook-states.mjs
@@ -94,6 +94,10 @@ export function classifyMockupEntry(entry, fidelityIndex, io) {
   if (!hit) return { ...base, verdict: 'coverage-gap', reason: 'no-fidelity' };
 
   const acceptance = hit.fidelity.acceptance || {};
+  // NB: obsolete/deferred short-circuit BEFORE the contract-violation check below,
+  // so a wired story that omits a declared state would NOT block if its fidelity is
+  // obsolete/deferred. Intentional (these intents exclude the entry from the gate);
+  // deferred entries carry story_path='' by construction, so this is inert today.
   if (acceptance.design_intent === 'forward-refactor-obsolete') {
     return { ...base, verdict: 'skipped-obsolete' };
   }
@@ -301,7 +305,8 @@ async function main() {
   const c = report.counts;
   process.stdout.write(
     `[lint:storybook-states] entries=${report.totalMappableEntries} covered=${c.covered} ` +
-      `gaps=${c.coverageGaps} contract=${c.contractViolations} skipped=${c.skippedObsolete}\n` +
+      `gaps=${c.coverageGaps} contract=${c.contractViolations} ` +
+      `skipped-obsolete=${c.skippedObsolete} skipped-deferred=${c.skippedDeferred}\n` +
       `  JSON: ${relative(REPO_ROOT, JSON_OUT)}\n  MD:   ${relative(REPO_ROOT, MD_OUT)}\n`
   );
   if (args.verbose) {

--- a/apps/web/scripts/lint-storybook-states.mjs
+++ b/apps/web/scripts/lint-storybook-states.mjs
@@ -7,6 +7,8 @@
  *   - coverage-gap       : no fidelity, or fidelity without story_path (whitelist-incremental)
  *   - contract-violation : story omits a declared canonical state (always blocking)
  *   - skipped-obsolete   : fidelity design_intent === 'forward-refactor-obsolete'
+ *   - skipped-deferred   : fidelity design_intent === 'deferred' (built later by a tracked
+ *                          umbrella, e.g. per-game session mockups → Phase C-3 #2234)
  *
  * Modes: inventory (default, exit 0) | strict (--strict --max-baseline N).
  * Refs: docs/superpowers/specs/2026-07-14-lint-storybook-states-design.md
@@ -95,6 +97,9 @@ export function classifyMockupEntry(entry, fidelityIndex, io) {
   if (acceptance.design_intent === 'forward-refactor-obsolete') {
     return { ...base, verdict: 'skipped-obsolete' };
   }
+  if (acceptance.design_intent === 'deferred') {
+    return { ...base, verdict: 'skipped-deferred' };
+  }
 
   const storyPath = acceptance.story_path;
   if (!storyPath) return { ...base, verdict: 'coverage-gap', reason: 'no-story-path' };
@@ -146,7 +151,9 @@ function cleanReportRoutes(routes) {
 }
 
 export function buildJsonReport(results, baseline) {
-  const counts = { covered: 0, coverageGaps: 0, contractViolations: 0, skippedObsolete: 0 };
+  const counts = {
+    covered: 0, coverageGaps: 0, contractViolations: 0, skippedObsolete: 0, skippedDeferred: 0,
+  };
   const coverageGaps = [];
   const contractViolations = [];
   for (const r of results) {
@@ -161,6 +168,7 @@ export function buildJsonReport(results, baseline) {
         declared: r.declared, detected: r.detected, missing: r.missing,
       });
     } else if (r.verdict === 'skipped-obsolete') counts.skippedObsolete += 1;
+    else if (r.verdict === 'skipped-deferred') counts.skippedDeferred += 1;
   }
   return {
     generatedAt: new Date().toISOString(),
@@ -185,7 +193,8 @@ export function buildMdReport(report) {
   lines.push(`| Covered | ${counts.covered} |`);
   lines.push(`| Coverage gaps (baseline ${report.baselineMaxCoverageGaps ?? 'n/a'}) | ${counts.coverageGaps} |`);
   lines.push(`| Contract violations (always blocking) | ${counts.contractViolations} |`);
-  lines.push(`| Skipped (obsolete) | ${counts.skippedObsolete} |`, '');
+  lines.push(`| Skipped (obsolete) | ${counts.skippedObsolete} |`);
+  lines.push(`| Skipped (deferred) | ${counts.skippedDeferred} |`, '');
   if (report.contractViolations.length) {
     lines.push('## Contract violations (must be 0)', '');
     lines.push('| Mockup | Story | Declared | Detected | Missing |', '| --- | --- | --- | --- | --- |');
@@ -205,6 +214,7 @@ export function buildMdReport(report) {
   lines.push('## Gate semantics', '');
   lines.push('- **contract-violation**: story omits a state its fidelity declares → **always fails** (fix story or align `states_covered`).');
   lines.push('- **coverage-gap**: mockup with no fidelity/story → tolerated under `--max-baseline N`; a NEW gap fails. Migrate a page → lower `N` (ratchet-down).');
+  lines.push('- **skipped-obsolete / skipped-deferred**: fidelity `design_intent` is `forward-refactor-obsolete` (retired) or `deferred` (built later by a tracked umbrella) → excluded from the gap count; requires a tracking issue.');
   return lines.join('\n') + '\n';
 }
 

--- a/apps/web/scripts/mockup-annotations/__tests__/validate-fidelity.test.ts
+++ b/apps/web/scripts/mockup-annotations/__tests__/validate-fidelity.test.ts
@@ -176,4 +176,30 @@ describe('FidelitySchema design_intent + viewports (DEC-P3-1+2+4)', () => {
     expect(result.ok).toBe(false);
     expect(result.errors.some(e => e.includes('obsolete_tracking_issue'))).toBe(true);
   });
+
+  it('accepts design_intent="deferred" (#2063 ratchet enum extension)', () => {
+    const result = FidelitySchema.safeParse({
+      mockup: { source: REAL_MOCKUP, states: ['default'] },
+      acceptance: {
+        states_covered: ['default'],
+        design_intent: 'deferred',
+        obsolete_tracking_issue: '#2234',
+      },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('FAIL — design_intent="deferred" requires obsolete_tracking_issue', async () => {
+    const file = writeFixture('deferred-no-tracking.fidelity.json', {
+      mockup: { source: REAL_MOCKUP, states: ['default'] },
+      acceptance: {
+        states_covered: ['default'],
+        design_intent: 'deferred',
+        // obsolete_tracking_issue intentionally missing
+      },
+    });
+    const result = await validate(file);
+    expect(result.ok).toBe(false);
+    expect(result.errors.some(e => e.includes('obsolete_tracking_issue'))).toBe(true);
+  });
 });

--- a/apps/web/scripts/mockup-annotations/validate-fidelity.mjs
+++ b/apps/web/scripts/mockup-annotations/validate-fidelity.mjs
@@ -61,11 +61,15 @@ export const FidelitySchema = z.object({
     fixtures_path: z.string().default(''),
 
     // DEC-P3-1+2 (2026-06-10): design intent classification
+    // 'deferred' added 2026-07-15 (#2063 ratchet): a current-intent mockup whose
+    // story authoring is deliberately deferred to a tracked umbrella (e.g. per-game
+    // session mockups → Phase C-3 #2234). Excluded from lint:storybook-states like
+    // obsolete, but semantically distinct (will be built later, not retired).
     design_intent: z
-      .enum(['current', 'forward-refactor', 'forward-refactor-obsolete'])
+      .enum(['current', 'forward-refactor', 'forward-refactor-obsolete', 'deferred'])
       .default('current')
       .describe(
-        'Mockup intent vs codebase corrente. forward-refactor-obsolete → skip story migration, tracking issue required.'
+        'Mockup intent vs codebase corrente. forward-refactor-obsolete → skip story migration; deferred → skip until a tracked umbrella builds it. Both require a tracking issue.'
       ),
 
     // DEC-P3-4 (2026-06-10): viewport opt-in (default desktop)
@@ -151,11 +155,14 @@ function crossReferenceCheck(fidelity, fidelityFilePath) {
   // DS-17 Phase B (#2127): accept 'PENDING' sentinel during the window between fidelity
   // stub generation and designer sign-off + tracking issue creation.
   // create-tracking-issues.mjs replaces PENDING with the real #NNNN ref post-signoff.
+  // #2063 ratchet (2026-07-15): 'deferred' carries the same tracking-issue requirement
+  // (the umbrella that will build the story, e.g. #2234), reusing obsolete_tracking_issue.
   const tracking = fidelity.acceptance.obsolete_tracking_issue;
-  if (fidelity.acceptance.design_intent === 'forward-refactor-obsolete' && !tracking) {
+  const intent = fidelity.acceptance.design_intent;
+  if ((intent === 'forward-refactor-obsolete' || intent === 'deferred') && !tracking) {
     errors.push(
-      `acceptance.design_intent='forward-refactor-obsolete' requires acceptance.obsolete_tracking_issue (use 'PENDING' placeholder pre-signoff or '#NNNN' post-signoff). ` +
-        `Open a GitHub issue tracking mockup rewrite OR component rollback (DEC-P3-2).`
+      `acceptance.design_intent='${intent}' requires acceptance.obsolete_tracking_issue (use 'PENDING' placeholder pre-signoff or '#NNNN' post-signoff). ` +
+        `Open/link a GitHub issue tracking the mockup rewrite, component rollback, or deferred build (DEC-P3-2).`
     );
   }
 

--- a/apps/web/src/app/(authenticated)/agents/[id]/page.stories.tsx
+++ b/apps/web/src/app/(authenticated)/agents/[id]/page.stories.tsx
@@ -2,26 +2,53 @@
  * sp4-agent-detail — DS-17-12 #2214 sub-issue.
  *
  * Mockup parity: `admin-mockups/design_files/sp4-agent-detail.{html,jsx}`.
+ *
+ * #2063: useParams() mocked from navigation.segments (UUID required by AgentDtoSchema).
+ * The global agents handler is host-scoped to :8080, but httpClient uses a relative
+ * URL in Storybook → it never intercepts. So this story scopes its own wildcard-host
+ * handler returning a valid AgentDto.
  */
+import { http, HttpResponse } from 'msw';
 
 import AgentDetailPage from './page';
 
 import type { Meta, StoryObj } from '@storybook/react';
 
+const ID = '11111111-1111-4111-8111-111111111111';
+
+/** AgentDtoSchema-valid fixture. */
+const AGENT = {
+  id: ID,
+  name: 'Chess Expert',
+  type: 'qa',
+  strategyName: 'hybrid-rag',
+  strategyParameters: {},
+  isActive: true,
+  createdAt: '2026-07-15T10:00:00.000Z',
+  lastInvokedAt: null,
+  invocationCount: 0,
+  isRecentlyUsed: false,
+  isIdle: true,
+};
+
 const meta: Meta<typeof AgentDetailPage> = {
   title: 'Authenticated / sp4-agent-detail',
   component: AgentDetailPage,
   parameters: {
-    // DS-17 #2063: heuristic can't read named exports/http.get; declare states explicitly.
+    // DS-17 #2063: http.get-driven (no quoted state literal) → declare states.
     canonicalStates: ['default'],
     layout: 'fullscreen',
     nextjs: {
       appDirectory: true,
       navigation: {
-        pathname: '/agents/sp4-agent-detail-fixture',
+        pathname: `/agents/${ID}`,
+        segments: [['id', ID]],
       },
     },
     viewport: { defaultViewport: 'desktop' },
+    msw: {
+      handlers: [http.get('*/api/v1/agents/:id', () => HttpResponse.json(AGENT))],
+    },
     docs: {
       description: {
         component: '#2214 DS-17-12. Authenticated agent detail view.',

--- a/apps/web/src/app/(authenticated)/agents/[id]/page.stories.tsx
+++ b/apps/web/src/app/(authenticated)/agents/[id]/page.stories.tsx
@@ -12,6 +12,8 @@ const meta: Meta<typeof AgentDetailPage> = {
   title: 'Authenticated / sp4-agent-detail',
   component: AgentDetailPage,
   parameters: {
+    // DS-17 #2063: heuristic can't read named exports/http.get; declare states explicitly.
+    canonicalStates: ['default'],
     layout: 'fullscreen',
     nextjs: {
       appDirectory: true,

--- a/apps/web/src/app/(authenticated)/agents/page.stories.tsx
+++ b/apps/web/src/app/(authenticated)/agents/page.stories.tsx
@@ -12,6 +12,8 @@ const meta: Meta<typeof AgentsIndexPage> = {
   title: 'Authenticated / sp4-agents-index',
   component: AgentsIndexPage,
   parameters: {
+    // DS-17 #2063: heuristic can't read named exports/http.get; declare states explicitly.
+    canonicalStates: ['default'],
     layout: 'fullscreen',
     nextjs: { appDirectory: true },
     viewport: { defaultViewport: 'desktop' },

--- a/apps/web/src/app/(authenticated)/discover/page.stories.tsx
+++ b/apps/web/src/app/(authenticated)/discover/page.stories.tsx
@@ -12,6 +12,8 @@ const meta: Meta<typeof DiscoverPage> = {
   title: 'Authenticated / sp4-discover',
   component: DiscoverPage,
   parameters: {
+    // DS-17 #2063: heuristic can't read named exports/http.get; declare states explicitly.
+    canonicalStates: ['default'],
     layout: 'fullscreen',
     nextjs: { appDirectory: true },
     viewport: { defaultViewport: 'desktop' },

--- a/apps/web/src/app/(authenticated)/game-nights/page.stories.tsx
+++ b/apps/web/src/app/(authenticated)/game-nights/page.stories.tsx
@@ -11,6 +11,8 @@ const meta: Meta<typeof GameNightsPage> = {
   title: 'Authenticated / sp4-game-nights-index',
   component: GameNightsPage,
   parameters: {
+    // DS-17 #2063: heuristic can't read named exports/http.get; declare states explicitly.
+    canonicalStates: ['default'],
     layout: 'fullscreen',
     nextjs: { appDirectory: true },
     viewport: { defaultViewport: 'desktop' },

--- a/apps/web/src/app/(authenticated)/games/[id]/page.stories.tsx
+++ b/apps/web/src/app/(authenticated)/games/[id]/page.stories.tsx
@@ -42,8 +42,8 @@ const FIXTURE_GAME_ID = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
 
 /** LibraryGameDetail-compatible shape returned by /api/v1/library/games/:id */
 const mockLibraryGameDetail = {
-  libraryEntryId: 'entry-001',
-  userId: 'storybook-user',
+  id: 'b2c3d4e5-f6a7-8901-bcde-f01234567890',
+  userId: 'c3d4e5f6-a7b8-4901-8bcd-ef0123456789',
   gameId: FIXTURE_GAME_ID,
   addedAt: '2025-09-01T10:00:00Z',
   notes: 'Grande gioco da tavolo',
@@ -59,11 +59,11 @@ const mockLibraryGameDetail = {
   gameYearPublished: 2016,
   gameIconUrl: null,
   gameImageUrl: null,
-  description:
+  gameDescription:
     'Corporations compete to terraform Mars by raising the temperature, oxygen level, and ocean coverage. Players build infrastructure and accumulate victory points.',
   minPlayers: 1,
   maxPlayers: 5,
-  playingTimeMinutes: 120,
+  playTimeMinutes: 120,
   minAge: 12,
   complexityRating: 3.2,
   averageRating: 8.4,
@@ -79,12 +79,12 @@ const mockLibraryGameDetail = {
     { id: 'mec-1', name: 'Gestione mano', slug: 'gestione-mano' },
     { id: 'mec-2', name: 'Posizionamento tessere', slug: 'posizionamento-tessere' },
   ],
-  designers: [{ id: 'des-1', name: 'Jacob Fryxelius' }],
+  designers: ['Jacob Fryxelius'],
   publishers: [{ id: 'pub-1', name: 'FryxGames' }],
   bggId: null,
   recentSessions: [
     {
-      id: 'sess-1',
+      id: 'd4e5f6a7-b8c9-4012-9def-234567890123',
       playedAt: '2026-05-20T19:30:00Z',
       durationMinutes: 105,
       durationFormatted: '1h 45m',
@@ -106,7 +106,7 @@ const mockSharedGame = {
   yearPublished: 2016,
   thumbnailUrl: null,
   imageUrl: null,
-  description: mockLibraryGameDetail.description,
+  description: mockLibraryGameDetail.gameDescription,
   minPlayers: 1,
   maxPlayers: 5,
   playingTimeMinutes: 120,
@@ -171,7 +171,7 @@ const meta: Meta<typeof GameDetailPage> = {
       navigation: {
         pathname: `/games/${FIXTURE_GAME_ID}`,
         // useParams reads from the segment — storybook/nextjs resolves [id] from pathname
-        params: { id: FIXTURE_GAME_ID },
+        segments: [['id', FIXTURE_GAME_ID]],
       },
     },
     viewport: { defaultViewport: 'desktop' },

--- a/apps/web/src/app/(authenticated)/games/[id]/page.stories.tsx
+++ b/apps/web/src/app/(authenticated)/games/[id]/page.stories.tsx
@@ -163,6 +163,8 @@ const meta: Meta<typeof GameDetailPage> = {
   title: 'Authenticated / sp4-game-detail',
   component: GameDetailPage,
   parameters: {
+    // DS-17 #2063: heuristic can't read named exports/http.get; declare states explicitly.
+    canonicalStates: ['default'],
     layout: 'fullscreen',
     nextjs: {
       appDirectory: true,

--- a/apps/web/src/app/(authenticated)/games/page.stories.tsx
+++ b/apps/web/src/app/(authenticated)/games/page.stories.tsx
@@ -12,6 +12,8 @@ const meta: Meta<typeof GamesIndexPage> = {
   title: 'Authenticated / sp4-games-index',
   component: GamesIndexPage,
   parameters: {
+    // DS-17 #2063: heuristic can't read named exports/http.get; declare states explicitly.
+    canonicalStates: ['default'],
     layout: 'fullscreen',
     nextjs: { appDirectory: true },
     viewport: { defaultViewport: 'desktop' },

--- a/apps/web/src/app/(authenticated)/knowledge-base/page.stories.tsx
+++ b/apps/web/src/app/(authenticated)/knowledge-base/page.stories.tsx
@@ -11,6 +11,8 @@ const meta: Meta<typeof KbHubPage> = {
   title: 'Authenticated / sp4-kb-hub',
   component: KbHubPage,
   parameters: {
+    // DS-17 #2063: heuristic can't read named exports/http.get; declare states explicitly.
+    canonicalStates: ['default'],
     layout: 'fullscreen',
     nextjs: { appDirectory: true },
     viewport: { defaultViewport: 'desktop' },

--- a/apps/web/src/app/(authenticated)/library/private/add/page.stories.tsx
+++ b/apps/web/src/app/(authenticated)/library/private/add/page.stories.tsx
@@ -13,6 +13,8 @@ const meta: Meta<typeof PrivateAddPage> = {
   title: 'Authenticated / sp4-add-game-pdf-dedup',
   component: PrivateAddPage,
   parameters: {
+    // DS-17 #2063: heuristic can't read named exports/http.get; declare states explicitly.
+    canonicalStates: ['default'],
     layout: 'fullscreen',
     nextjs: { appDirectory: true },
     viewport: { defaultViewport: 'desktop' },

--- a/apps/web/src/app/(authenticated)/notifications/notifications.stories.tsx
+++ b/apps/web/src/app/(authenticated)/notifications/notifications.stories.tsx
@@ -1,5 +1,10 @@
 /**
- * @mockup admin-mockups/design_files/notifications.html
+ * @mockup admin-mockups/design_files/sp7-notifications-hub.html
+ *
+ * Repointed 2026-07-15 (#2063 ratchet): the canonical /notifications mockup is
+ * sp7-notifications-hub.html; notifications.html is the superseded SP1 legacy
+ * archive (#2028, now design_intent=forward-refactor-obsolete). This story is
+ * wired as sp7-notifications-hub's fidelity.story_path.
  *
  * Notifications argTypes matrix story — DS-17 Phase C-1 (sub-issue #2160).
  *

--- a/apps/web/src/app/(authenticated)/notifications/preferences/page.stories.tsx
+++ b/apps/web/src/app/(authenticated)/notifications/preferences/page.stories.tsx
@@ -1,0 +1,96 @@
+/**
+ * @mockup admin-mockups/design_files/sp7-notifications-preferences.html
+ *
+ * sp7-notifications-preferences — DS-17 residual MIGRATE (#2971, umbrella #2063).
+ *
+ * Route /notifications/preferences → NotificationPreferences (raw useState/useEffect
+ * + httpClient GET /api/v1/notifications/preferences on mount; no React Query/SSE).
+ * DEC-A5 states: default (loaded prefs) / loading (spinner) / error (500 → error wall).
+ * `empty` N/A (preferences is always a complete object) and `sse` N/A (no realtime).
+ *
+ * The Default GET fixture MUST be NotificationPreferencesSchema-valid (uuid userId +
+ * all booleans) or the Zod parse throws and the story falls into the error wall.
+ */
+import { http, HttpResponse } from 'msw';
+
+import { NotificationPreferences } from '@/components/notifications/NotificationPreferences';
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+const PREFS = '*/api/v1/notifications/preferences';
+
+/** NotificationPreferencesSchema-valid fixture (all required booleans + valid uuid). */
+const VALID_PREFS = {
+  userId: '11111111-1111-4111-8111-111111111111',
+  emailOnDocumentReady: true,
+  emailOnDocumentFailed: true,
+  emailOnRetryAvailable: false,
+  pushOnDocumentReady: false,
+  pushOnDocumentFailed: true,
+  pushOnRetryAvailable: false,
+  inAppOnDocumentReady: true,
+  inAppOnDocumentFailed: true,
+  inAppOnRetryAvailable: true,
+  hasPushSubscription: false,
+  inAppOnGameNightInvitation: true,
+  emailOnGameNightInvitation: true,
+  pushOnGameNightInvitation: false,
+  emailOnGameNightReminder: true,
+  pushOnGameNightReminder: false,
+  emailOnCardSuppressed: false,
+};
+
+const meta: Meta<typeof NotificationPreferences> = {
+  title: 'Authenticated / sp7-notifications-preferences',
+  component: NotificationPreferences,
+  parameters: {
+    layout: 'fullscreen',
+    // DS-17 #2063: httpClient GET (no quoted state literal) → declare states explicitly.
+    canonicalStates: ['default', 'loading', 'error'],
+    nextjs: { appDirectory: true, navigation: { pathname: '/notifications/preferences' } },
+    viewport: { defaultViewport: 'desktop' },
+    docs: {
+      description: {
+        component:
+          '#2971 DS-17 MIGRATE. Notification preferences (document + game-night categories). ' +
+          'Default = loaded prefs; Loading = spinner; Error = 500 error wall.',
+      },
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof NotificationPreferences>;
+
+/** Default: loaded preferences — 6 category cards of toggles + save button. */
+export const Default: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.get(PREFS, () => HttpResponse.json(VALID_PREFS)),
+        // Permissive PUTs so a Save interaction doesn't emit unhandled-request warnings.
+        http.put(PREFS, () => new HttpResponse(null, { status: 204 })),
+        http.put(`${PREFS}/card-suppression`, () => new HttpResponse(null, { status: 204 })),
+      ],
+    },
+  },
+};
+
+/** Loading: GET never resolves — shows the initial spinner. */
+export const Loading: Story = {
+  parameters: {
+    msw: { handlers: [http.get(PREFS, () => new Promise(() => {}))] },
+  },
+};
+
+/** Error: GET returns 500 → Zod/httpClient throws → error wall with Riprova. */
+export const Error: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.get(PREFS, () => HttpResponse.json({ error: 'server_error' }, { status: 500 })),
+      ],
+    },
+  },
+};

--- a/apps/web/src/app/(authenticated)/play-records/[id]/edit/page.stories.tsx
+++ b/apps/web/src/app/(authenticated)/play-records/[id]/edit/page.stories.tsx
@@ -24,6 +24,8 @@ const meta: Meta<typeof PlayRecordEditPage> = {
   title: 'Authenticated / sp4-play-records-edit',
   component: PlayRecordEditPage,
   parameters: {
+    // DS-17 #2063: heuristic can't read named exports/http.get; declare states explicitly.
+    canonicalStates: ['default', 'empty', 'loading', 'error'],
     layout: 'fullscreen',
     nextjs: {
       appDirectory: true,

--- a/apps/web/src/app/(authenticated)/play-records/[id]/edit/page.stories.tsx
+++ b/apps/web/src/app/(authenticated)/play-records/[id]/edit/page.stories.tsx
@@ -31,7 +31,7 @@ const meta: Meta<typeof PlayRecordEditPage> = {
       appDirectory: true,
       navigation: {
         pathname: `/play-records/${ID}/edit`,
-        params: { id: ID },
+        segments: [['id', ID]],
       },
     },
     viewport: { defaultViewport: 'desktop' },
@@ -65,7 +65,7 @@ export const Empty: Story = {
       appDirectory: true,
       navigation: {
         pathname: '/play-records/pr-inprogress-1/edit',
-        params: { id: 'pr-inprogress-1' },
+        segments: [['id', 'pr-inprogress-1']],
       },
     },
     msw: {

--- a/apps/web/src/app/(authenticated)/play-records/[id]/page.stories.tsx
+++ b/apps/web/src/app/(authenticated)/play-records/[id]/page.stories.tsx
@@ -21,6 +21,8 @@ const meta: Meta<typeof PlayRecordDetailPage> = {
   title: 'Authenticated / sp4-play-records-detail',
   component: PlayRecordDetailPage,
   parameters: {
+    // DS-17 #2063: heuristic can't read named exports/http.get; declare states explicitly.
+    canonicalStates: ['default', 'empty', 'loading', 'error'],
     layout: 'fullscreen',
     nextjs: {
       appDirectory: true,

--- a/apps/web/src/app/(authenticated)/play-records/[id]/page.stories.tsx
+++ b/apps/web/src/app/(authenticated)/play-records/[id]/page.stories.tsx
@@ -28,7 +28,7 @@ const meta: Meta<typeof PlayRecordDetailPage> = {
       appDirectory: true,
       navigation: {
         pathname: `/play-records/${ID}`,
-        params: { id: ID },
+        segments: [['id', ID]],
       },
     },
     viewport: { defaultViewport: 'desktop' },
@@ -59,7 +59,7 @@ export const Empty: Story = {
       appDirectory: true,
       navigation: {
         pathname: '/play-records/pr-coop-1',
-        params: { id: 'pr-coop-1' },
+        segments: [['id', 'pr-coop-1']],
       },
     },
     msw: {

--- a/apps/web/src/app/(authenticated)/play-records/new/page.stories.tsx
+++ b/apps/web/src/app/(authenticated)/play-records/new/page.stories.tsx
@@ -17,6 +17,8 @@ const meta: Meta<typeof PlayRecordNewPage> = {
   title: 'Authenticated / sp4-play-records-new',
   component: PlayRecordNewPage,
   parameters: {
+    // DS-17 #2063: heuristic can't read named exports/http.get; declare states explicitly.
+    canonicalStates: ['default', 'loading', 'error'],
     layout: 'fullscreen',
     nextjs: { appDirectory: true, navigation: { pathname: '/play-records/new' } },
     viewport: { defaultViewport: 'desktop' },

--- a/apps/web/src/app/(authenticated)/play-records/page.stories.tsx
+++ b/apps/web/src/app/(authenticated)/play-records/page.stories.tsx
@@ -11,6 +11,8 @@ const meta: Meta<typeof PlayRecordsPage> = {
   title: 'Authenticated / sp4-play-records-index',
   component: PlayRecordsPage,
   parameters: {
+    // DS-17 #2063: heuristic can't read named exports/http.get; declare states explicitly.
+    canonicalStates: ['default'],
     layout: 'fullscreen',
     nextjs: { appDirectory: true },
     viewport: { defaultViewport: 'desktop' },

--- a/apps/web/src/app/(authenticated)/play-records/page.stories.tsx
+++ b/apps/web/src/app/(authenticated)/play-records/page.stories.tsx
@@ -1,18 +1,31 @@
 /**
  * sp4-play-records-index — DS-17-13 #2220.
  * Mockup parity: `admin-mockups/design_files/sp4-play-records-index.{html,jsx}`.
+ *
+ * DEC-A5 states: default (loaded list) / empty (first-run, no records) /
+ * loading (skeleton) / error (500). sse N/A.
+ *
+ * The page renders <PlayHistory/> which fetches via usePlayHistory →
+ * React Query GET /api/v1/play-records/history. Default relies on the global
+ * MSW history handler; Empty/Loading/Error override that endpoint. (#2063 ratchet:
+ * corrected from a false "store-driven, loading/error N/A" downshift.)
  */
+import { http, HttpResponse } from 'msw';
 
 import PlayRecordsPage from './page';
 
 import type { Meta, StoryObj } from '@storybook/react';
 
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8080';
+const HISTORY = `${API_BASE}/api/v1/play-records/history`;
+
 const meta: Meta<typeof PlayRecordsPage> = {
   title: 'Authenticated / sp4-play-records-index',
   component: PlayRecordsPage,
   parameters: {
-    // DS-17 #2063: heuristic can't read named exports/http.get; declare states explicitly.
-    canonicalStates: ['default'],
+    // DS-17 #2063: PlayHistory renders skeleton/error/empty/default from a React
+    // Query fetch; the heuristic can't read those, so declare states explicitly.
+    canonicalStates: ['default', 'empty', 'loading', 'error'],
     layout: 'fullscreen',
     nextjs: { appDirectory: true },
     viewport: { defaultViewport: 'desktop' },
@@ -26,4 +39,36 @@ export default meta;
 
 type Story = StoryObj<typeof PlayRecordsPage>;
 
+/** Default: loaded history list (global MSW history handler). */
 export const Default: Story = {};
+
+/** Empty: first-run empty state — history returns zero records. */
+export const Empty: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.get(HISTORY, () =>
+          HttpResponse.json({ records: [], totalCount: 0, page: 1, pageSize: 20, totalPages: 0 })
+        ),
+      ],
+    },
+  },
+};
+
+/** Loading: GET /history never resolves — shows skeleton shimmer. */
+export const Loading: Story = {
+  parameters: {
+    msw: { handlers: [http.get(HISTORY, () => new Promise(() => {}))] },
+  },
+};
+
+/** Error: GET /history returns 500 — shows error alert with retry. */
+export const Error: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.get(HISTORY, () => HttpResponse.json({ error: 'server_error' }, { status: 500 })),
+      ],
+    },
+  },
+};

--- a/apps/web/src/app/(authenticated)/play-records/stats/page.stories.tsx
+++ b/apps/web/src/app/(authenticated)/play-records/stats/page.stories.tsx
@@ -21,6 +21,8 @@ const meta: Meta<typeof StatisticsPage> = {
   title: 'Authenticated / sp4-play-records-stats',
   component: StatisticsPage,
   parameters: {
+    // DS-17 #2063: heuristic can't read named exports/http.get; declare states explicitly.
+    canonicalStates: ['default', 'empty', 'loading', 'error'],
     layout: 'fullscreen',
     nextjs: { appDirectory: true, navigation: { pathname: '/play-records/stats' } },
     viewport: { defaultViewport: 'desktop' },

--- a/apps/web/src/app/(authenticated)/players/[id]/page.stories.tsx
+++ b/apps/web/src/app/(authenticated)/players/[id]/page.stories.tsx
@@ -17,7 +17,7 @@ const meta: Meta<typeof PlayerDetailPage> = {
     layout: 'fullscreen',
     nextjs: {
       appDirectory: true,
-      navigation: { pathname: '/players/sp4-fixture-id' },
+      navigation: { pathname: '/players/sp4-fixture-id', segments: [['id', 'sp4-fixture-id']] },
     },
     viewport: { defaultViewport: 'desktop' },
     docs: {

--- a/apps/web/src/app/(authenticated)/players/[id]/page.stories.tsx
+++ b/apps/web/src/app/(authenticated)/players/[id]/page.stories.tsx
@@ -12,6 +12,8 @@ const meta: Meta<typeof PlayerDetailPage> = {
   title: 'Authenticated / sp4-player-detail',
   component: PlayerDetailPage,
   parameters: {
+    // DS-17 #2063: heuristic can't read named exports/http.get; declare states explicitly.
+    canonicalStates: ['default'],
     layout: 'fullscreen',
     nextjs: {
       appDirectory: true,

--- a/apps/web/src/app/(authenticated)/players/page.stories.tsx
+++ b/apps/web/src/app/(authenticated)/players/page.stories.tsx
@@ -11,6 +11,8 @@ const meta: Meta<typeof PlayersPage> = {
   title: 'Authenticated / sp4-players-index',
   component: PlayersPage,
   parameters: {
+    // DS-17 #2063: heuristic can't read named exports/http.get; declare states explicitly.
+    canonicalStates: ['default'],
     layout: 'fullscreen',
     nextjs: { appDirectory: true },
     viewport: { defaultViewport: 'desktop' },

--- a/apps/web/src/app/(authenticated)/sessions/[id]/live/page.stories.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/[id]/live/page.stories.tsx
@@ -1,0 +1,106 @@
+/**
+ * @mockup admin-mockups/design_files/sp4-session-skeleton-live.html
+ *
+ * sp4-session-skeleton-live — DS-17 residual MIGRATE (#2971, umbrella #2063).
+ *
+ * Route /sessions/[id]/live → SessionLiveView (generic skeleton renderer, epic
+ * #2354 G1 #2374). Primary loader: useLiveSession → GET /api/v1/live-sessions/:id
+ * → LiveSessionDto (Zod-validated). FSM: loading → error → not-found(null) → default.
+ * DEC-A5 states: default / loading / error.
+ *
+ * ⚠️ Storybook limitation (honest, documented): the Default state's secondary
+ * cascade opens a native EventSource (SSE) to .../stream and a SignalR hub, which
+ * MSW's Service Worker cannot mock. So Default renders the real 2-col layout WITH
+ * a "reconnecting" ConnectionLostBanner overlay — the layout is faithful, the
+ * connection banner is an environment artifact, not masking. Loading/Error render
+ * the shell states cleanly.
+ */
+import { http, HttpResponse } from 'msw';
+
+import SessionLivePage from './page';
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+const ID = '33333333-3333-4333-8333-333333333333';
+const SESSION_URL = '*/api/v1/live-sessions/:id';
+
+/** LiveSessionDtoSchema-valid fixture (empty rosters + empty scoring config). */
+const VALID_SESSION = {
+  id: ID,
+  sessionCode: 'ABC123',
+  gameId: '44444444-4444-4444-8444-444444444444',
+  gameName: 'Catan',
+  gameSlug: 'catan',
+  createdByUserId: '55555555-5555-4555-8555-555555555555',
+  status: 'InProgress',
+  visibility: 'Private',
+  groupId: null,
+  createdAt: '2026-07-15T10:00:00.000Z',
+  startedAt: '2026-07-15T10:01:00.000Z',
+  pausedAt: null,
+  completedAt: null,
+  updatedAt: '2026-07-15T10:05:00.000Z',
+  lastSavedAt: '2026-07-15T10:05:00.000Z',
+  currentTurnIndex: 0,
+  currentTurnPlayerId: null,
+  agentMode: 'None',
+  notes: null,
+  players: [],
+  teams: [],
+  roundScores: [],
+  scoringConfig: { enabledDimensions: [], dimensionUnits: {} },
+};
+
+const meta: Meta<typeof SessionLivePage> = {
+  title: 'Authenticated / sp4-session-skeleton-live',
+  component: SessionLivePage,
+  parameters: {
+    layout: 'fullscreen',
+    // DS-17 #2063: http.get-driven FSM (no quoted state literal) → declare states.
+    canonicalStates: ['default', 'loading', 'error'],
+    nextjs: {
+      appDirectory: true,
+      // @storybook/nextjs mocks useParams() from navigation.segments (key-value
+      // tuples), NOT `params`. SessionLiveView reads useParams().id → resolveSessionId.
+      navigation: { pathname: `/sessions/${ID}/live`, segments: [['id', ID]] },
+    },
+    viewport: { defaultViewport: 'desktop' },
+    docs: {
+      description: {
+        component:
+          '#2971 DS-17 MIGRATE. Generic live-session skeleton renderer. Default = loaded ' +
+          'layout (SSE/SignalR not mockable → reconnecting banner overlay); Loading = shell ' +
+          'skeleton; Error = error shell.',
+      },
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof SessionLivePage>;
+
+/** Default: loaded session layout (with a reconnecting banner — SSE unmockable). */
+export const Default: Story = {
+  parameters: {
+    msw: { handlers: [http.get(SESSION_URL, () => HttpResponse.json(VALID_SESSION))] },
+  },
+};
+
+/** Loading: GET never resolves — shows the loading shell. */
+export const Loading: Story = {
+  parameters: {
+    msw: { handlers: [http.get(SESSION_URL, () => new Promise(() => {}))] },
+  },
+};
+
+/** Error: GET returns 500 → error shell. */
+export const Error: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.get(SESSION_URL, () => HttpResponse.json({ error: 'server_error' }, { status: 500 })),
+      ],
+    },
+  },
+};

--- a/apps/web/src/app/(authenticated)/sessions/[id]/page.stories.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/[id]/page.stories.tsx
@@ -11,6 +11,8 @@ const meta: Meta<typeof SessionDetailPage> = {
   title: 'Authenticated / sp4-session-summary-skeleton',
   component: SessionDetailPage,
   parameters: {
+    // DS-17 #2063: heuristic can't read named exports/http.get; declare states explicitly.
+    canonicalStates: ['default'],
     layout: 'fullscreen',
     nextjs: {
       appDirectory: true,

--- a/apps/web/src/app/(authenticated)/sessions/[id]/page.stories.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/[id]/page.stories.tsx
@@ -1,24 +1,56 @@
 /**
  * sp4-session-summary-skeleton — DS-17-15 #2231.
  * Mockup parity: `admin-mockups/design_files/sp4-session-summary-skeleton.{html,jsx}`.
+ *
+ * #2063: useParams() is mocked from navigation.segments (not `params`), and the
+ * global sessions handler returns Zod-invalid/non-'Completed' data → this story
+ * scopes its own valid GameSessionDto handler so the summary renders (not not-found).
  */
+import { http, HttpResponse } from 'msw';
 
-import SessionDetailPage from './page';
+import { SessionSummaryView } from './_components/SessionSummaryView';
 
 import type { Meta, StoryObj } from '@storybook/react';
 
-const meta: Meta<typeof SessionDetailPage> = {
+const ID = '00000000-0000-4000-8000-000000000756';
+
+/** GameSessionDtoSchema-valid completed session. */
+const SUMMARY = {
+  id: ID,
+  gameId: '00000000-0000-4000-8000-0000000000aa',
+  status: 'Completed',
+  startedAt: '2026-05-04T19:00:00.000Z',
+  completedAt: '2026-05-04T20:30:00.000Z',
+  playerCount: 2,
+  players: [
+    { playerName: 'Marco Rossi', playerOrder: 0, color: null },
+    { playerName: 'Anna Bianchi', playerOrder: 1, color: null },
+  ],
+  winnerName: 'Marco Rossi',
+  notes: null,
+  durationMinutes: 90,
+};
+
+const meta: Meta<typeof SessionSummaryView> = {
   title: 'Authenticated / sp4-session-summary-skeleton',
-  component: SessionDetailPage,
+  component: SessionSummaryView,
+  args: { sessionId: ID },
   parameters: {
-    // DS-17 #2063: heuristic can't read named exports/http.get; declare states explicitly.
+    // DS-17 #2063: http.get-driven FSM (no quoted state literal) → declare states.
     canonicalStates: ['default'],
     layout: 'fullscreen',
     nextjs: {
       appDirectory: true,
-      navigation: { pathname: '/sessions/sp4-fixture-session-id' },
+      navigation: { pathname: `/sessions/${ID}`, segments: [['id', ID]] },
     },
     viewport: { defaultViewport: 'desktop' },
+    msw: {
+      handlers: [
+        http.get('*/api/v1/sessions/:id/diary', () => HttpResponse.json([])),
+        http.get('*/api/v1/live-sessions/:id/vision-snapshots', () => HttpResponse.json([])),
+        http.get('*/api/v1/sessions/:id', () => HttpResponse.json(SUMMARY)),
+      ],
+    },
     docs: {
       description: {
         component: '#2231 DS-17-15. Session summary skeleton (Phase C-2 skeleton-first base).',
@@ -29,6 +61,6 @@ const meta: Meta<typeof SessionDetailPage> = {
 
 export default meta;
 
-type Story = StoryObj<typeof SessionDetailPage>;
+type Story = StoryObj<typeof SessionSummaryView>;
 
 export const Default: Story = {};

--- a/apps/web/src/app/(authenticated)/sessions/page.stories.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/page.stories.tsx
@@ -11,6 +11,8 @@ const meta: Meta<typeof SessionsPage> = {
   title: 'Authenticated / sp4-sessions-index',
   component: SessionsPage,
   parameters: {
+    // DS-17 #2063: heuristic can't read named exports/http.get; declare states explicitly.
+    canonicalStates: ['default'],
     layout: 'fullscreen',
     nextjs: { appDirectory: true },
     viewport: { defaultViewport: 'desktop' },

--- a/apps/web/src/app/(chat)/chat/[threadId]/page.stories.tsx
+++ b/apps/web/src/app/(chat)/chat/[threadId]/page.stories.tsx
@@ -1,0 +1,104 @@
+/**
+ * @mockup admin-mockups/design_files/chat-fullscreen.html
+ *
+ * chat-fullscreen — DS-17 residual MIGRATE (#2971, umbrella #2063).
+ *
+ * Route /chat/[threadId] → ChatThreadView (chat-unified). On mount:
+ * getThreadById → GET /api/v1/chat-threads/:id → ChatThreadDto (Zod-validated).
+ * DEC-A5 states: default (thread w/ messages) / empty (thread, no messages) /
+ * loading (spinner) / error (500). `sse` (streaming answer) needs a play
+ * interaction + ReadableStream mock + gameId-gated branch → out of scope here.
+ *
+ * The Default/Empty GET fixtures MUST be ChatThreadDtoSchema-valid (uuid ids +
+ * RFC3339 datetimes WITH offset) or the Zod parse drops silently into error.
+ */
+import { http, HttpResponse } from 'msw';
+
+import { ChatThreadView } from '@/components/chat-unified/ChatThreadView';
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+const THREAD_ID = '22222222-2222-4222-8222-222222222222';
+const THREAD_URL = '*/api/v1/chat-threads/:id';
+
+/** ChatThreadDtoSchema-valid fixture (gameId null = dependency-free). */
+const BASE_THREAD = {
+  id: THREAD_ID,
+  gameId: null,
+  agentId: null,
+  agentType: null,
+  title: 'Regole di Catan',
+  createdAt: '2026-07-15T10:00:00.000Z',
+  lastMessageAt: '2026-07-15T10:05:00.000Z',
+  messageCount: 2,
+  messages: [
+    { content: 'Come funziona il ladro?', role: 'user', timestamp: '2026-07-15T10:04:00.000Z' },
+    {
+      content: 'Il ladro blocca la produzione della casella su cui viene spostato.',
+      role: 'assistant',
+      timestamp: '2026-07-15T10:05:00.000Z',
+    },
+  ],
+};
+
+const meta: Meta<typeof ChatThreadView> = {
+  title: 'Authenticated / chat-fullscreen',
+  component: ChatThreadView,
+  args: { threadId: THREAD_ID },
+  parameters: {
+    layout: 'fullscreen',
+    // DS-17 #2063: on-mount http.get (no quoted state literal) → declare states.
+    canonicalStates: ['default', 'empty', 'loading', 'error'],
+    nextjs: { appDirectory: true, navigation: { pathname: `/chat/${THREAD_ID}` } },
+    viewport: { defaultViewport: 'desktop' },
+    docs: {
+      description: {
+        component:
+          '#2971 DS-17 MIGRATE. Fullscreen chat thread. Default = loaded thread with ' +
+          'messages; Empty = thread with no messages; Loading = spinner; Error = 500.',
+      },
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ChatThreadView>;
+
+/** Default: loaded thread with a user + assistant message. */
+export const Default: Story = {
+  parameters: {
+    msw: { handlers: [http.get(THREAD_URL, () => HttpResponse.json(BASE_THREAD))] },
+  },
+};
+
+/** Empty: thread exists but has no messages yet. */
+export const Empty: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.get(THREAD_URL, () =>
+          HttpResponse.json({ ...BASE_THREAD, messageCount: 0, messages: [] })
+        ),
+      ],
+    },
+  },
+};
+
+/** Loading: GET never resolves — shows the spinner. */
+export const Loading: Story = {
+  parameters: {
+    msw: { handlers: [http.get(THREAD_URL, () => new Promise(() => {}))] },
+  },
+};
+
+/** Error: GET returns 500 → error state. */
+export const Error: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.get(THREAD_URL, () => HttpResponse.json({ error: 'server_error' }, { status: 500 })),
+      ],
+    },
+  },
+};

--- a/apps/web/src/app/(public)/accept-invite/page.stories.tsx
+++ b/apps/web/src/app/(public)/accept-invite/page.stories.tsx
@@ -15,6 +15,8 @@ const meta: Meta<typeof AcceptInvitePage> = {
   title: 'Public / sp3-accept-invite',
   component: AcceptInvitePage,
   parameters: {
+    // DS-17 #2063: heuristic can't read named exports/http.get; declare states explicitly.
+    canonicalStates: ['default'],
     layout: 'fullscreen',
     nextjs: { appDirectory: true },
     viewport: { defaultViewport: 'desktop' },

--- a/apps/web/src/app/(public)/faq/page.stories.tsx
+++ b/apps/web/src/app/(public)/faq/page.stories.tsx
@@ -15,6 +15,8 @@ const meta: Meta<typeof FaqPage> = {
   title: 'Public / sp3-faq-enhanced',
   component: FaqPage,
   parameters: {
+    // DS-17 #2063: heuristic can't read named exports/http.get; declare states explicitly.
+    canonicalStates: ['default'],
     layout: 'fullscreen',
     nextjs: { appDirectory: true },
     viewport: { defaultViewport: 'desktop' },

--- a/apps/web/src/app/(public)/how-it-works/page.stories.tsx
+++ b/apps/web/src/app/(public)/how-it-works/page.stories.tsx
@@ -14,6 +14,8 @@ const meta: Meta<typeof HowItWorksPage> = {
   title: 'Public / sp3-how-it-works',
   component: HowItWorksPage,
   parameters: {
+    // DS-17 #2063: heuristic can't read named exports/http.get; declare states explicitly.
+    canonicalStates: ['default'],
     layout: 'fullscreen',
     nextjs: { appDirectory: true },
     viewport: { defaultViewport: 'desktop' },

--- a/apps/web/src/app/(public)/join/page.stories.tsx
+++ b/apps/web/src/app/(public)/join/page.stories.tsx
@@ -15,6 +15,8 @@ const meta: Meta<typeof JoinPage> = {
   title: 'Public / sp3-join',
   component: JoinPage,
   parameters: {
+    // DS-17 #2063: heuristic can't read named exports/http.get; declare states explicitly.
+    canonicalStates: ['default'],
     layout: 'fullscreen',
     nextjs: { appDirectory: true },
     viewport: { defaultViewport: 'desktop' },

--- a/apps/web/src/app/(public)/shared-games/[id]/page.stories.tsx
+++ b/apps/web/src/app/(public)/shared-games/[id]/page.stories.tsx
@@ -4,35 +4,66 @@
  * Mockup parity: `admin-mockups/design_files/sp3-shared-game-detail.{html,jsx}`.
  * Post Stage 0 BGG cleanup (commit 564d854b9) — KB entry boardgamegeek.com removed.
  *
- * NOTE: this route renders the PUBLIC community view of a shared game
- * (`page-client.tsx` uses `useSharedGameDetail` + `ContributorsSection`),
- * NOT the private library view at `/library/[gameId]` which uses
- * `GameDetailDesktop` (M1-M7 EPIC #2096 deliverables shipped via PR #2207).
- * The two routes are separate concerns despite the mockup name.
+ * #2063: the route page (`page.tsx`) is an async SERVER component (`await params` +
+ * `getSharedGameDetail`), which @storybook/nextjs cannot render. So this story renders
+ * the CLIENT orchestrator `SharedGameDetailPageClient` directly with props (it seeds
+ * React Query via `useSharedGameDetail({ id, initialData: detail })` → renders on mount,
+ * no MSW round-trip). The fixture is `.parse()`d so schema defaults fill the output type.
  */
+import { SharedGameDetailSchema } from '@/lib/api/schemas/shared-games.schemas';
 
-import SharedGameDetailPage from './page';
+import { SharedGameDetailPageClient } from './page-client';
 
 import type { Meta, StoryObj } from '@storybook/react';
 
-const meta: Meta<typeof SharedGameDetailPage> = {
+const ID = '11111111-1111-4111-8111-111111111111';
+
+/** SharedGameDetailSchema-valid fixture (parse fills defaulted fields for the output type). */
+const DETAIL = SharedGameDetailSchema.parse({
+  id: ID,
+  bggId: null,
+  title: 'Fixture Game',
+  yearPublished: 2020,
+  description: 'A shared game fixture.',
+  minPlayers: 2,
+  maxPlayers: 4,
+  playingTimeMinutes: 60,
+  minAge: 10,
+  complexityRating: 2.5,
+  averageRating: 7.0,
+  imageUrl: '',
+  thumbnailUrl: '',
+  rules: null,
+  status: 'Published',
+  createdBy: '22222222-2222-4222-8222-222222222222',
+  modifiedBy: null,
+  createdAt: '2024-01-01T00:00:00Z',
+  modifiedAt: null,
+  faqs: [],
+  erratas: [],
+  designers: [],
+  publishers: [],
+  categories: [],
+  mechanics: [],
+});
+
+const meta: Meta<typeof SharedGameDetailPageClient> = {
   title: 'Public / sp3-shared-game-detail',
-  component: SharedGameDetailPage,
+  component: SharedGameDetailPageClient,
+  args: { id: ID, detail: DETAIL, contributors: [] },
   parameters: {
-    // DS-17 #2063: heuristic can't read named exports/http.get; declare states explicitly.
+    // DS-17 #2063: renders the client orchestrator with props (no quoted state literal).
     canonicalStates: ['default'],
     layout: 'fullscreen',
     nextjs: {
       appDirectory: true,
-      navigation: {
-        pathname: '/shared-games/sp3-shared-game-detail-fixture',
-      },
+      navigation: { pathname: `/shared-games/${ID}` },
     },
     viewport: { defaultViewport: 'desktop' },
     docs: {
       description: {
         component:
-          '#2208 DS-17-10. Public community view of a shared game. Renders `(public)/shared-games/[id]/page.tsx` server wrapper that delegates to `page-client.tsx`.',
+          '#2208 DS-17-10. Public community view of a shared game (client orchestrator `page-client.tsx`; the async server `page.tsx` wrapper is not Storybook-renderable).',
       },
     },
   },
@@ -40,6 +71,6 @@ const meta: Meta<typeof SharedGameDetailPage> = {
 
 export default meta;
 
-type Story = StoryObj<typeof SharedGameDetailPage>;
+type Story = StoryObj<typeof SharedGameDetailPageClient>;
 
 export const Default: Story = {};

--- a/apps/web/src/app/(public)/shared-games/[id]/page.stories.tsx
+++ b/apps/web/src/app/(public)/shared-games/[id]/page.stories.tsx
@@ -19,6 +19,8 @@ const meta: Meta<typeof SharedGameDetailPage> = {
   title: 'Public / sp3-shared-game-detail',
   component: SharedGameDetailPage,
   parameters: {
+    // DS-17 #2063: heuristic can't read named exports/http.get; declare states explicitly.
+    canonicalStates: ['default'],
     layout: 'fullscreen',
     nextjs: {
       appDirectory: true,

--- a/apps/web/src/app/(public)/shared-games/page.stories.tsx
+++ b/apps/web/src/app/(public)/shared-games/page.stories.tsx
@@ -11,6 +11,8 @@ const meta: Meta<typeof SharedGamesPage> = {
   title: 'Public / sp3-shared-games',
   component: SharedGamesPage,
   parameters: {
+    // DS-17 #2063: heuristic can't read named exports/http.get; declare states explicitly.
+    canonicalStates: ['default'],
     layout: 'fullscreen',
     nextjs: { appDirectory: true },
     viewport: { defaultViewport: 'desktop' },

--- a/apps/web/src/app/(public)/terms/page.stories.tsx
+++ b/apps/web/src/app/(public)/terms/page.stories.tsx
@@ -15,6 +15,8 @@ const meta: Meta<typeof TermsPage> = {
   title: 'Public / sp3-legal',
   component: TermsPage,
   parameters: {
+    // DS-17 #2063: heuristic can't read named exports/http.get; declare states explicitly.
+    canonicalStates: ['default'],
     layout: 'fullscreen',
     nextjs: { appDirectory: true },
     viewport: { defaultViewport: 'desktop' },

--- a/apps/web/src/components/features/gamebook/ResumeBooksList.stories.tsx
+++ b/apps/web/src/components/features/gamebook/ResumeBooksList.stories.tsx
@@ -41,7 +41,7 @@
  *       umbrella #2063, sub-issue #2174 (Phase D-2).
  */
 
-import { fn } from '@storybook/test';
+import { fn } from 'storybook/test';
 
 import {
   ResumePickerStaleMock,

--- a/audits/2026-07-14-storybook-states-coverage.json
+++ b/audits/2026-07-14-storybook-states-coverage.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-14T16:20:03.576Z",
+  "generatedAt": "2026-07-15T07:35:14.571Z",
   "generatedFrom": "admin-mockups/MOCKUPS_INDEX.md",
   "canonicalStates": [
     "default",
@@ -9,269 +9,19 @@
     "sse"
   ],
   "totalMappableEntries": 68,
-  "baselineMaxCoverageGaps": null,
+  "baselineMaxCoverageGaps": 3,
   "counts": {
-    "covered": 24,
-    "coverageGaps": 44,
+    "covered": 50,
+    "coverageGaps": 3,
     "contractViolations": 0,
-    "skippedObsolete": 0
+    "skippedObsolete": 1,
+    "skippedDeferred": 14
   },
   "coverageGaps": [
-    {
-      "mockup": "sp7-notifications-hub.html",
-      "routes": [
-        "/notifications"
-      ],
-      "reason": "no-story-path"
-    },
     {
       "mockup": "sp7-notifications-preferences.html",
       "routes": [
         "/notifications/preferences"
-      ],
-      "reason": "no-story-path"
-    },
-    {
-      "mockup": "sp3-accept-invite.html",
-      "routes": [
-        "/accept-invite",
-        "/invites/[token]"
-      ],
-      "reason": "no-story-path"
-    },
-    {
-      "mockup": "sp3-faq-enhanced.html",
-      "routes": [
-        "/faq",
-        "/games/[id]/faqs"
-      ],
-      "reason": "no-story-path"
-    },
-    {
-      "mockup": "sp3-how-it-works.html",
-      "routes": [
-        "/how-it-works"
-      ],
-      "reason": "no-story-path"
-    },
-    {
-      "mockup": "sp3-join.html",
-      "routes": [
-        "/join",
-        "/sessions/join"
-      ],
-      "reason": "no-story-path"
-    },
-    {
-      "mockup": "sp3-legal.html",
-      "routes": [
-        "/privacy",
-        "/terms",
-        "/cookies",
-        "/cookie-settings"
-      ],
-      "reason": "no-story-path"
-    },
-    {
-      "mockup": "sp3-shared-game-detail.html",
-      "routes": [
-        "/shared-games/[id]"
-      ],
-      "reason": "no-story-path"
-    },
-    {
-      "mockup": "sp3-shared-games.html",
-      "routes": [
-        "/shared-games"
-      ],
-      "reason": "no-story-path"
-    },
-    {
-      "mockup": "sp4-add-game-pdf-dedup.html",
-      "routes": [
-        "/library/private/add",
-        "/upload"
-      ],
-      "reason": "no-story-path"
-    },
-    {
-      "mockup": "sp4-agent-detail.html",
-      "routes": [
-        "/agents/[id]",
-        "/library/[gameId]/agent"
-      ],
-      "reason": "no-story-path"
-    },
-    {
-      "mockup": "sp4-agents-index.html",
-      "routes": [
-        "/agents",
-        "/editor/agent-proposals/*",
-        "/chat/agents/create"
-      ],
-      "reason": "no-story-path"
-    },
-    {
-      "mockup": "sp4-discover.html",
-      "routes": [
-        "/discover"
-      ],
-      "reason": "no-story-path"
-    },
-    {
-      "mockup": "sp4-game-detail.html",
-      "routes": [
-        "/games/[id]",
-        "/library/[gameId]",
-        "/private-games/[id]"
-      ],
-      "reason": "no-story-path"
-    },
-    {
-      "mockup": "sp4-game-nights-index.html",
-      "routes": [
-        "/game-nights"
-      ],
-      "reason": "no-story-path"
-    },
-    {
-      "mockup": "sp4-games-index.html",
-      "routes": [
-        "/games"
-      ],
-      "reason": "no-story-path"
-    },
-    {
-      "mockup": "sp4-kb-hub.html",
-      "routes": [
-        "/knowledge-base"
-      ],
-      "reason": "no-story-path"
-    },
-    {
-      "mockup": "sp4-library-desktop.html",
-      "routes": [
-        "/library"
-      ],
-      "reason": "no-story-path"
-    },
-    {
-      "mockup": "sp4-play-records-detail.html",
-      "routes": [
-        "/play-records/[id]"
-      ],
-      "reason": "no-story-path"
-    },
-    {
-      "mockup": "sp4-play-records-edit.html",
-      "routes": [
-        "/play-records/[id]/edit"
-      ],
-      "reason": "no-story-path"
-    },
-    {
-      "mockup": "sp4-play-records-index.html",
-      "routes": [
-        "/play-records"
-      ],
-      "reason": "no-story-path"
-    },
-    {
-      "mockup": "sp4-play-records-new.html",
-      "routes": [
-        "/play-records/new"
-      ],
-      "reason": "no-story-path"
-    },
-    {
-      "mockup": "sp4-play-records-stats.html",
-      "routes": [
-        "/play-records/stats"
-      ],
-      "reason": "no-story-path"
-    },
-    {
-      "mockup": "sp4-player-detail.html",
-      "routes": [
-        "/players/[id]",
-        "/players/[id]/{achievements"
-      ],
-      "reason": "no-story-path"
-    },
-    {
-      "mockup": "sp4-players-index.html",
-      "routes": [
-        "/players"
-      ],
-      "reason": "no-story-path"
-    },
-    {
-      "mockup": "sp4-session-catan-live.html",
-      "routes": [
-        "/sessions/[id]/live"
-      ],
-      "reason": "no-story-path"
-    },
-    {
-      "mockup": "sp4-session-catan-summary.html",
-      "routes": [
-        "/sessions/[id]"
-      ],
-      "reason": "no-story-path"
-    },
-    {
-      "mockup": "sp4-session-codenames-live.html",
-      "routes": [
-        "/sessions/[id]/live"
-      ],
-      "reason": "no-story-path"
-    },
-    {
-      "mockup": "sp4-session-codenames-summary.html",
-      "routes": [
-        "/sessions/[id]"
-      ],
-      "reason": "no-story-path"
-    },
-    {
-      "mockup": "sp4-session-paleo-live.html",
-      "routes": [
-        "/sessions/[id]/live"
-      ],
-      "reason": "no-story-path"
-    },
-    {
-      "mockup": "sp4-session-paleo-summary.html",
-      "routes": [
-        "/sessions/[id]"
-      ],
-      "reason": "no-story-path"
-    },
-    {
-      "mockup": "sp4-session-power-grid-live.html",
-      "routes": [
-        "/sessions/[id]/live"
-      ],
-      "reason": "no-story-path"
-    },
-    {
-      "mockup": "sp4-session-power-grid-summary.html",
-      "routes": [
-        "/sessions/[id]"
-      ],
-      "reason": "no-story-path"
-    },
-    {
-      "mockup": "sp4-session-puerto-rico-live.html",
-      "routes": [
-        "/sessions/[id]/live"
-      ],
-      "reason": "no-story-path"
-    },
-    {
-      "mockup": "sp4-session-puerto-rico-summary.html",
-      "routes": [
-        "/sessions/[id]"
       ],
       "reason": "no-story-path"
     },
@@ -283,60 +33,10 @@
       "reason": "no-story-path"
     },
     {
-      "mockup": "sp4-session-summary-skeleton.html",
-      "routes": [
-        "/sessions/[id]"
-      ],
-      "reason": "no-story-path"
-    },
-    {
-      "mockup": "sp4-session-wingspan-live.html",
-      "routes": [
-        "/sessions/[id]/live"
-      ],
-      "reason": "no-story-path"
-    },
-    {
-      "mockup": "sp4-session-wingspan-summary.html",
-      "routes": [
-        "/sessions/[id]"
-      ],
-      "reason": "no-story-path"
-    },
-    {
-      "mockup": "sp4-session-zombicide-live.html",
-      "routes": [
-        "/sessions/[id]/live"
-      ],
-      "reason": "no-story-path"
-    },
-    {
-      "mockup": "sp4-session-zombicide-summary.html",
-      "routes": [
-        "/sessions/[id]"
-      ],
-      "reason": "no-story-path"
-    },
-    {
-      "mockup": "sp4-sessions-index.html",
-      "routes": [
-        "/sessions",
-        "/games/[id]/sessions"
-      ],
-      "reason": "no-story-path"
-    },
-    {
       "mockup": "chat-fullscreen.html",
       "routes": [
         "/chat/[threadId]",
         "/chat/new"
-      ],
-      "reason": "no-story-path"
-    },
-    {
-      "mockup": "librogame-game-night-storyboard.html",
-      "routes": [
-        "/game-nights/[id]"
       ],
       "reason": "no-story-path"
     }

--- a/audits/2026-07-14-storybook-states-coverage.json
+++ b/audits/2026-07-14-storybook-states-coverage.json
@@ -1,5 +1,5 @@
 {
-  "generatedAt": "2026-07-15T07:35:14.571Z",
+  "generatedAt": "2026-07-15T07:55:27.529Z",
   "generatedFrom": "admin-mockups/MOCKUPS_INDEX.md",
   "canonicalStates": [
     "default",

--- a/audits/2026-07-14-storybook-states-coverage.md
+++ b/audits/2026-07-14-storybook-states-coverage.md
@@ -1,6 +1,6 @@
 # Storybook canonical-state coverage (DEC-A5 / #2342)
 
-Generated: 2026-07-15T07:35:14.571Z
+Generated: 2026-07-15T07:55:27.529Z
 Source: `admin-mockups/MOCKUPS_INDEX.md` · Canonical states: default, empty, loading, error, sse
 
 | Metric | Count |

--- a/audits/2026-07-14-storybook-states-coverage.md
+++ b/audits/2026-07-14-storybook-states-coverage.md
@@ -1,66 +1,27 @@
 # Storybook canonical-state coverage (DEC-A5 / #2342)
 
-Generated: 2026-07-14T16:20:03.576Z
+Generated: 2026-07-15T07:35:14.571Z
 Source: `admin-mockups/MOCKUPS_INDEX.md` · Canonical states: default, empty, loading, error, sse
 
 | Metric | Count |
 | --- | --- |
 | Total page-mock entries | 68 |
-| Covered | 24 |
-| Coverage gaps (baseline n/a) | 44 |
+| Covered | 50 |
+| Coverage gaps (baseline 3) | 3 |
 | Contract violations (always blocking) | 0 |
-| Skipped (obsolete) | 0 |
+| Skipped (obsolete) | 1 |
+| Skipped (deferred) | 14 |
 
 ## Coverage gaps (whitelist-incremental, ratchet down)
 
 | Mockup | Routes | Reason |
 | --- | --- | --- |
-| `sp7-notifications-hub.html` | /notifications | no-story-path |
 | `sp7-notifications-preferences.html` | /notifications/preferences | no-story-path |
-| `sp3-accept-invite.html` | /accept-invite, /invites/[token] | no-story-path |
-| `sp3-faq-enhanced.html` | /faq, /games/[id]/faqs | no-story-path |
-| `sp3-how-it-works.html` | /how-it-works | no-story-path |
-| `sp3-join.html` | /join, /sessions/join | no-story-path |
-| `sp3-legal.html` | /privacy, /terms, /cookies, /cookie-settings | no-story-path |
-| `sp3-shared-game-detail.html` | /shared-games/[id] | no-story-path |
-| `sp3-shared-games.html` | /shared-games | no-story-path |
-| `sp4-add-game-pdf-dedup.html` | /library/private/add, /upload | no-story-path |
-| `sp4-agent-detail.html` | /agents/[id], /library/[gameId]/agent | no-story-path |
-| `sp4-agents-index.html` | /agents, /editor/agent-proposals/*, /chat/agents/create | no-story-path |
-| `sp4-discover.html` | /discover | no-story-path |
-| `sp4-game-detail.html` | /games/[id], /library/[gameId], /private-games/[id] | no-story-path |
-| `sp4-game-nights-index.html` | /game-nights | no-story-path |
-| `sp4-games-index.html` | /games | no-story-path |
-| `sp4-kb-hub.html` | /knowledge-base | no-story-path |
-| `sp4-library-desktop.html` | /library | no-story-path |
-| `sp4-play-records-detail.html` | /play-records/[id] | no-story-path |
-| `sp4-play-records-edit.html` | /play-records/[id]/edit | no-story-path |
-| `sp4-play-records-index.html` | /play-records | no-story-path |
-| `sp4-play-records-new.html` | /play-records/new | no-story-path |
-| `sp4-play-records-stats.html` | /play-records/stats | no-story-path |
-| `sp4-player-detail.html` | /players/[id], /players/[id]/{achievements | no-story-path |
-| `sp4-players-index.html` | /players | no-story-path |
-| `sp4-session-catan-live.html` | /sessions/[id]/live | no-story-path |
-| `sp4-session-catan-summary.html` | /sessions/[id] | no-story-path |
-| `sp4-session-codenames-live.html` | /sessions/[id]/live | no-story-path |
-| `sp4-session-codenames-summary.html` | /sessions/[id] | no-story-path |
-| `sp4-session-paleo-live.html` | /sessions/[id]/live | no-story-path |
-| `sp4-session-paleo-summary.html` | /sessions/[id] | no-story-path |
-| `sp4-session-power-grid-live.html` | /sessions/[id]/live | no-story-path |
-| `sp4-session-power-grid-summary.html` | /sessions/[id] | no-story-path |
-| `sp4-session-puerto-rico-live.html` | /sessions/[id]/live | no-story-path |
-| `sp4-session-puerto-rico-summary.html` | /sessions/[id] | no-story-path |
 | `sp4-session-skeleton-live.html` | /sessions/[id]/live | no-story-path |
-| `sp4-session-summary-skeleton.html` | /sessions/[id] | no-story-path |
-| `sp4-session-wingspan-live.html` | /sessions/[id]/live | no-story-path |
-| `sp4-session-wingspan-summary.html` | /sessions/[id] | no-story-path |
-| `sp4-session-zombicide-live.html` | /sessions/[id]/live | no-story-path |
-| `sp4-session-zombicide-summary.html` | /sessions/[id] | no-story-path |
-| `sp4-sessions-index.html` | /sessions, /games/[id]/sessions | no-story-path |
 | `chat-fullscreen.html` | /chat/[threadId], /chat/new | no-story-path |
-| `librogame-game-night-storyboard.html` | /game-nights/[id] | no-story-path |
 
 ## Gate semantics
 
 - **contract-violation**: story omits a state its fidelity declares → **always fails** (fix story or align `states_covered`).
 - **coverage-gap**: mockup with no fidelity/story → tolerated under `--max-baseline N`; a NEW gap fails. Migrate a page → lower `N` (ratchet-down).
+- **skipped-obsolete / skipped-deferred**: fidelity `design_intent` is `forward-refactor-obsolete` (retired) or `deferred` (built later by a tracked umbrella) → excluded from the gap count; requires a tracking issue.


### PR DESCRIPTION
## Cosa

Ratchet del gate CI `lint:storybook-states` da **`--max-baseline 44` a `3`**, chiudendo il grosso dell'acceptance criterion "migration 100%" dell'umbrella #2063.

Deriva dal [triage verificato dei 44 coverage-gap](https://github.com/meepleAi-app/meepleai-monorepo/issues/2063#issuecomment-4977825728) (tutti `reason=no-story-path`): **il 59% era debito di *wiring*, non di *migration***.

| Disposizione | N | Azione |
|---|---|---|
| **WIRE** | 26 | La story esisteva già → popolato `acceptance.story_path` nel fidelity |
| **DEFER-2234** | 14 | Session per-game → `design_intent: deferred` (nuovo), escluse dal gate → Phase C-3 #2234 |
| **MIGRATE** | 3 | Story da scrivere → restano gap tracciati in #2971 |
| **SCOPE-OUT** | 1 | `librogame-game-night-storyboard` (meta-storyboard non-page) → obsolete, review designer #2970 |

## Dettaglio

- **Gate**: nuovo `design_intent: 'deferred'` → verdetto `skipped-deferred` (`lint-storybook-states.mjs`), enum + requisito tracking-issue nel validator (`validate-fidelity.mjs`), report/test aggiornati.
- **Fidelity**: 26 `story_path` wired; 14 marcati `deferred` (#2234); `librogame-game-night-storyboard` + `notifications.html` (SP1 legacy) obsolete (#2970, #2028); downshift onesto di `play-records-new` (nessun export `Empty`).
- **Stories**: `parameters.canonicalStates` override su 24 story minimali che l'euristica `detectStates` non riesce a leggere (`export const Default = {}` / `http.get` senza literal); repoint `@mockup` di notifications al canonico sp7.
- **CI**: flip `--max-baseline 44 → 3`.

## Review adversariale (3 reviewer + verify)

4 finding confermati, 1 **HIGH corretto in questo branch**:
- 🔴 **HIGH** — `play-records-index` era stato downshiftato a `[default]` con rationale falsa ("store-driven"). In realtà `PlayHistory` fa fetch via React Query e renderizza skeleton/error/empty reali. **Corretto**: ripristinato il contratto a 4 stati e scritte story `Empty/Loading/Error` reali via MSW (commit `f76eb77e3`).
- 🟡 LOW — stdout ometteva `skipped-deferred` → aggiunto.
- 🟡 LOW (latente) — short-circuit `deferred`/`obsolete` prima di contract-violation → documentato (inerte: i deferred hanno `story_path=''`).
- 🟡 LOW (**pre-esistente, non causato da questo PR**) — `lint:bgg-mockups` è rosso su `main-dev` (329 > baseline 325), identico sul parent commit. Da NON attribuire a questo ratchet.

## Verifica

```
lint:storybook-states --strict --max-baseline 3  →  covered 50, gaps 3, contract 0, skipped-deferred 14  (exit 0)
lint:fidelity --all                              →  PASS
typecheck                                        →  exit 0
vitest (gate + validator)                        →  44 passed
```

## Residuo (→ #2971)

3 vere migration da scrivere per portare il gate a `--max-baseline 0`: `sp7-notifications-preferences`, `sp4-session-skeleton-live`, `chat-fullscreen`.

Closes: nessuna (umbrella #2063 resta aperta per Phase 4/5). Refs: #2063, #2342 (gate owner), #2234, #2970, #2971.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
