### PR TITLE
fix(mechanic-extractor): widen section_range check constraints to 0-8

### DIFF
--- a/apps/api/src/Api/Infrastructure/Configurations/SharedGameCatalog/MechanicAnalysisSectionRunEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/Configurations/SharedGameCatalog/MechanicAnalysisSectionRunEntityConfiguration.cs
@@ -14,9 +14,12 @@ internal sealed class MechanicAnalysisSectionRunEntityConfiguration : IEntityTyp
     {
         builder.ToTable("mechanic_analysis_section_runs", t =>
         {
+            // #2974: MechanicSection has 9 values (0-8), incl. Setup/Components/EndgameScoring.
+            // Keep the upper bound in sync with the enum — MechanicSectionRangeConstraintTests
+            // guards against drift (a 0-5 bound crashes the pipeline on any section > 5).
             t.HasCheckConstraint(
                 "ck_mechanic_section_runs_section_range",
-                "section BETWEEN 0 AND 5");
+                "section BETWEEN 0 AND 8");
 
             // 0=Succeeded, 1=Failed, 2=SkippedDueToCostCap, 3=RetainedWithGuardrailFlags (D9).
             t.HasCheckConstraint(

--- a/apps/api/src/Api/Infrastructure/Configurations/SharedGameCatalog/MechanicClaimEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/Configurations/SharedGameCatalog/MechanicClaimEntityConfiguration.cs
@@ -20,9 +20,11 @@ internal sealed class MechanicClaimEntityConfiguration : IEntityTypeConfiguratio
                 "ck_mechanic_claims_status_range",
                 "status BETWEEN 0 AND 2");
 
+            // #2974: MechanicSection has 9 values (0-8). Keep in sync with the enum
+            // (MechanicSectionRangeConstraintTests guards against drift).
             t.HasCheckConstraint(
                 "ck_mechanic_claims_section_range",
-                "section BETWEEN 0 AND 5");
+                "section BETWEEN 0 AND 8");
 
             t.HasCheckConstraint(
                 "ck_mechanic_claims_display_order_non_negative",

--- a/apps/api/src/Api/Infrastructure/Configurations/SharedGameCatalog/MechanicGoldenClaimEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/Configurations/SharedGameCatalog/MechanicGoldenClaimEntityConfiguration.cs
@@ -18,9 +18,11 @@ internal sealed class MechanicGoldenClaimEntityConfiguration : IEntityTypeConfig
     {
         builder.ToTable("mechanic_golden_claims", t =>
         {
+            // #2974: MechanicSection has 9 values (0-8). Keep in sync with the enum
+            // (MechanicSectionRangeConstraintTests guards against drift).
             t.HasCheckConstraint(
                 "ck_mechanic_golden_claims_section_range",
-                "section BETWEEN 0 AND 5");
+                "section BETWEEN 0 AND 8");
 
             t.HasCheckConstraint(
                 "ck_mechanic_golden_claims_expected_page_positive",

--- a/apps/api/src/Api/Infrastructure/Migrations/20260715084357_FixMechanicSectionRangeConstraint.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260715084357_FixMechanicSectionRangeConstraint.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260715084357_FixMechanicSectionRangeConstraint")]
+    partial class FixMechanicSectionRangeConstraint
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260715084357_FixMechanicSectionRangeConstraint.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260715084357_FixMechanicSectionRangeConstraint.cs
@@ -1,0 +1,72 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class FixMechanicSectionRangeConstraint : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropCheckConstraint(
+                name: "ck_mechanic_golden_claims_section_range",
+                table: "mechanic_golden_claims");
+
+            migrationBuilder.DropCheckConstraint(
+                name: "ck_mechanic_claims_section_range",
+                table: "mechanic_claims");
+
+            migrationBuilder.DropCheckConstraint(
+                name: "ck_mechanic_section_runs_section_range",
+                table: "mechanic_analysis_section_runs");
+
+            migrationBuilder.AddCheckConstraint(
+                name: "ck_mechanic_golden_claims_section_range",
+                table: "mechanic_golden_claims",
+                sql: "section BETWEEN 0 AND 8");
+
+            migrationBuilder.AddCheckConstraint(
+                name: "ck_mechanic_claims_section_range",
+                table: "mechanic_claims",
+                sql: "section BETWEEN 0 AND 8");
+
+            migrationBuilder.AddCheckConstraint(
+                name: "ck_mechanic_section_runs_section_range",
+                table: "mechanic_analysis_section_runs",
+                sql: "section BETWEEN 0 AND 8");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropCheckConstraint(
+                name: "ck_mechanic_golden_claims_section_range",
+                table: "mechanic_golden_claims");
+
+            migrationBuilder.DropCheckConstraint(
+                name: "ck_mechanic_claims_section_range",
+                table: "mechanic_claims");
+
+            migrationBuilder.DropCheckConstraint(
+                name: "ck_mechanic_section_runs_section_range",
+                table: "mechanic_analysis_section_runs");
+
+            migrationBuilder.AddCheckConstraint(
+                name: "ck_mechanic_golden_claims_section_range",
+                table: "mechanic_golden_claims",
+                sql: "section BETWEEN 0 AND 5");
+
+            migrationBuilder.AddCheckConstraint(
+                name: "ck_mechanic_claims_section_range",
+                table: "mechanic_claims",
+                sql: "section BETWEEN 0 AND 5");
+
+            migrationBuilder.AddCheckConstraint(
+                name: "ck_mechanic_section_runs_section_range",
+                table: "mechanic_analysis_section_runs",
+                sql: "section BETWEEN 0 AND 5");
+        }
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Domain/Enums/MechanicSectionRangeConstraintTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Domain/Enums/MechanicSectionRangeConstraintTests.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Linq;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Enums;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Domain.Enums;
+
+/// <summary>
+/// #2974 regression guard. The EF check constraints
+/// <c>ck_mechanic_{section_runs,claims,golden_claims}_section_range</c> use
+/// <c>section BETWEEN 0 AND 8</c>. If <see cref="MechanicSection"/> grows without updating
+/// those constraints (+ a migration), the pipeline crashes at persistence time with
+/// Npgsql 23514 on any section &gt; the stale bound (that is exactly how a 0-5 bound
+/// silently broke every real analysis once Setup/Components/EndgameScoring were added).
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class MechanicSectionRangeConstraintTests
+{
+    // Must match the upper bound hardcoded in the three *EntityConfiguration files.
+    private const int CheckConstraintUpperBound = 8;
+
+    [Fact]
+    public void MechanicSection_upper_bound_matches_check_constraints()
+    {
+        var maxSectionIndex = Enum.GetValues<MechanicSection>().Cast<int>().Max();
+
+        maxSectionIndex.Should().Be(
+            CheckConstraintUpperBound,
+            "the ck_mechanic_*_section_range CHECK constraints allow only 'section BETWEEN 0 AND {0}'; " +
+            "if MechanicSection changed, update all three EntityConfiguration files and add a migration (#2974)",
+            CheckConstraintUpperBound);
+    }
+
+    [Fact]
+    public void MechanicSection_values_are_contiguous_from_zero()
+    {
+        // A "BETWEEN 0 AND N" constraint assumes contiguous 0..N values with no gaps.
+        var values = Enum.GetValues<MechanicSection>().Cast<int>().OrderBy(x => x).ToArray();
+
+        values.Should().Equal(
+            Enumerable.Range(0, values.Length).ToArray(),
+            "the section range CHECK constraint assumes contiguous enum values starting at 0");
+    }
+}


### PR DESCRIPTION
## Cosa

Fix del bug **#2974**: i 3 check constraint `ck_mechanic_{section_runs,claims,golden_claims}_section_range` erano `section BETWEEN 0 AND 5`, ma l'enum `MechanicSection` ha **9 valori (0-8)**. Le sezioni Setup/Components/EndgameScoring furono aggiunte senza allargare i constraint → ogni analisi ME reale che produce una sezione > 5 **crasha** al salvataggio (`Npgsql 23514`) e va in `Rejected / pipeline_crashed`.

**Riprodotto su staging** generando le card Mage Knight + Catan (bloccate finché non ho allargato i constraint a mano).

## Modifiche
- 3 `*EntityConfiguration`: constraint → `section BETWEEN 0 AND 8` (+ commento che lega all'enum).
- Migration `FixMechanicSectionRangeConstraint` (Drop + Add, reversibile).
- `MechanicSectionRangeConstraintTests`: 2 test-guard che falliscono se l'enum cresce oltre il bound o diventa non contiguo — così il drift non può ripresentarsi in silenzio.

## Perché non colto prima
Nessun test persisteva una sezione > 5, e il build API usato per la demo locale precedeva l'estensione dell'enum.

## Deploy
Su **staging** il fix è già applicato manualmente (ALTER dei 3 constraint a 0-8) per sbloccare le card; questa migration lo formalizza per **prod** e per ogni fresh DB.

Closes #2974.

🤖 Generated with [Claude Code](https://claude.com/claude-code)