### PR TITLE
docs(game-night): audit addendum gap residui #1889 + mockup stale note

### DIFF
--- a/admin-mockups/design_files/sp7-game-night-detail-rsvp.jsx
+++ b/admin-mockups/design_files/sp7-game-night-detail-rsvp.jsx
@@ -3,6 +3,13 @@
    Route: /game-nights/[id]
    Persona: misto host (Marco) + invitato (Davide)
    Coverage: US-31 Game Nights P1 — Sprint N+1
+
+   ⚠️ STALE vs runtime (invariante #16, 2026-07-15): questo mockup collassa
+   ancora "tagged" in RSVP pending ("In attesa") e non mostra il gate esplicito
+   "Invia inviti". Il comportamento CORRETTO (tagged Draft = "Da invitare" vs
+   invited Published = "In attesa" + CTA "Invia inviti") è realizzato nel
+   RUNTIME `GameNightDetailView.tsx` (PR #2969). Fonte di verità = runtime, non
+   questo file. Re-sync tracciato in #2979 prima di un eventuale demo replay.
    Pattern mobile : hero summary + 3 tab (Dettagli / Voting / Chat) +
                     bottom-sheet RSVP CTA sticky se invitato pending
    Pattern desktop: split-view 380px summary sidebar + main area tab content

--- a/docs/for-developers/audits/2026-07-15-sp7-spec-panel-invariant-diff.md
+++ b/docs/for-developers/audits/2026-07-15-sp7-spec-panel-invariant-diff.md
@@ -181,8 +181,30 @@ Da consolidare in una sessione socratic di dominio **prima** di autorare i mocku
 - Precondizione di sblocco reale (da commento #1889 + questo doc): **prima** autorare i 5 mockup agent-builder mancanti (D–H), che a loro volta richiedono la risoluzione degli 8 invarianti candidati (§3).
 
 ### Disposizione #1889
-Mantenere **OPEN / `deferred`**. Questo spec-panel ha evaso 2/5 acceptance criteria (diff invarianti + candidati invarianti) e ha prodotto la coda di follow-up che, una volta chiusa, rende autorabili i mockup e quindi eseguibile il demo.
+**Concludibile** (aggiornato 2026-07-15 dopo verifica gap residui — vedi §6). AC3/AC4/AC5 DONE, AC1 MOOT, AC2 metà (gap report statico ✅, replay web scorporato in chore non-bloccante #2980). L'intera wave agent-builder D–H è riconciliata al runtime shipped (ADR-085 + PR #2973). Residui tracciati: **#2978** (#17 pending-card, materiale), **#2979** (cleanup low).
 
 ---
 
-*Prodotto da spec-panel critique statico (Opus 4.8) — 2026-07-15. Nessun file di prodotto modificato oltre a questo audit.*
+## § 6 — Addendum: verifica gap residui (2026-07-15)
+
+Verifica avversariale post-audit (3 verificatori paralleli) sui gap che il diff §1 aveva saltato o rimandato.
+
+### 6.1 `sp7-game-night-join-public` vs #16/#17 — ✅ COMPLIANT (non era in Target-1)
+Il 6° mockup game-night (RSVP pubblico anonimo via token/QR, `/join/event/[code]`, #1169) — mai incluso in Target-1 (A/B/K/L/M) — diffato ora: **conforme** a #16 e #17.
+- **#16** COMPLIANT: il token-invitation esiste solo se un organizer lo conia esplicitamente (`CreateGameNightInvitationByEmailCommandHandler.cs:68-72` guard); la route pubblica è puramente lato-destinatario (`PublicJoinEventView.tsx:66-114`, GET + POST respond, nessun auto-invito). Mappa domain model :279/:290 (token = "invited", mai "tagged").
+- **#17** COMPLIANT: `Pending` default (`GameNightInvitationStatus.cs:9-10`, `.Create:130`); pannello conferma solo dopo `alreadyRespondedAs` (`PublicJoinEventView.tsx:106,332-350`); transizione pending→confermato in `GameNightInvitation.Respond:280-305`.
+- **Error-states** coperti: 410 expired/cancelled (`RespondToGameNightInvitationByTokenCommandHandler.cs:50-61`), 429 rate-limit (`GameNightEndpoints.cs:162/173` + FE countdown `PublicJoinEventView.tsx:187-207`).
+
+### 6.2 Invariante #17 card pending lato invitato — 🔴 REAL_GAP → #2978
+Il trattamento card pending dell'invitato (badge "Da confermare" + semitrasparenza + Conferma/Declina inline) in dashboard "Prossimi" e list `/game-nights` **non esiste**: solo contatori aggregati host-side (`ProssimiSection.tsx:37-39`; `GameNightListCard.tsx:168-196` gated su role, non su viewer-RSVP), e `GameNightDto` non porta `myRsvpStatus` (`game-nights.schemas.ts:33-50`). L'RSVP inline esiste solo sulla detail page. Unico gap **funzionale** materiale → **#2978** (BE DTO + FE dashboard/list + test).
+
+### 6.3 Notifiche I/J vs #16 — ⚠️ runtime corretto, gap solo doc/cleanup → #2979
+Runtime cablato end-to-end (`GameNightPublishedNotificationHandler` → `NotificationType.GameNightInvitation` deep-link → `GameNightDetailView` RsvpActionBar). I mockup I/J sono demo statici non nel diff + un dead-entry `game_night_published` FE/BE. Nessun gap funzionale → **#2979**.
+
+### 6.4 Note
+- **Mockup stale**: `sp7-game-night-detail-rsvp.jsx` intenzionalmente stale vs il fix #16 runtime (annotato nel file header); re-sync tracciato in #2979.
+- **Tensione Auto-RSVP** (§4 row-5): domanda di dominio aperta → #2979.
+
+---
+
+*Prodotto da spec-panel critique statico (Opus 4.8) — 2026-07-15, addendum §6 stessa data. Nessun file di prodotto modificato oltre a questo audit + annotazione mockup.*


### PR DESCRIPTION
## Contesto
Chiude i gap residui verificati (avversarialmente) su #1889 prima della conclusione dell'issue.

## Contenuto
- **Audit §6 addendum**: verifica dei gap che il diff §1 aveva saltato/rimandato.
  - `sp7-game-night-join-public` (6° mockup game-night) diffato vs #16/#17 → **✅ COMPLIANT** (token-invitation solo su azione esplicita organizer; pending default; 410/429 coperti).
  - **#17 card pending lato invitato** → **🔴 REAL_GAP** (manca in dashboard "Prossimi" + list; `GameNightDto` senza `myRsvpStatus`) → follow-up **#2978**.
  - **Notifiche I/J** → runtime corretto end-to-end; solo gap doc + dead-entry → **#2979**.
- **Mockup annotato**: `sp7-game-night-detail-rsvp.jsx` marcato STALE vs il fix #16 runtime (`GameNightDetailView`, PR #2969), per non ri-emergere il gap chiuso in un futuro demo.
- Disposizione #1889 → **concludibile**.

## Follow-up aperti
- #2978 (#17 pending-card, materiale) · #2979 (cleanup SP7 low) · #2980 (web demo replay, chore non-bloccante)

Solo documentazione.

🤖 Generated with [Claude Code](https://claude.com/claude-code)