### PR TITLE
feat(library): remove BGG import CTA; wire game-detail create chips

### DIFF
--- a/apps/web/src/app/(authenticated)/library/_components/LibraryHub.tsx
+++ b/apps/web/src/app/(authenticated)/library/_components/LibraryHub.tsx
@@ -55,7 +55,6 @@ import { HubPageContainer } from '@/components/layout/PageContainer';
 import { useHybridHubItems } from '@/hooks/queries/useHybridHubItems';
 import { useLibrary, useRemoveGameFromLibrary } from '@/hooks/queries/useLibrary';
 import { useActivityFeed } from '@/hooks/useActivityFeed';
-import { useAdminRole } from '@/hooks/useAdminRole';
 import { useTranslation } from '@/hooks/useTranslation';
 import type { UserLibraryEntry } from '@/lib/api/schemas/library.schemas';
 import { deriveGamesTabEntries } from '@/lib/library/games-tab-filters';
@@ -114,10 +113,6 @@ export function LibraryHub(): ReactElement {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
-  // F2 (#1975): BGG import is admin-only (BGG ToS — see AddGameDrawer.tsx:18 note).
-  // Gate the CTA visibility behind admin role; non-admins get `undefined` callbacks
-  // which collapse the CTA buttons in LibraryHeroDesktop + EmptyLibrary.
-  const { isAdminOrAbove } = useAdminRole();
 
   const [tab, setTab] = useState<HybridHubTab>('all');
   const [selectionMode, setSelectionMode] = useState<LibrarySelectionMode>('browse');
@@ -233,7 +228,8 @@ export function LibraryHub(): ReactElement {
       subtitle: t('pages.library.hero.subtitle'),
       eyebrow: t('pages.library.hero.eyebrow'),
       ctaAdd: t('pages.library.hero.cta.add'),
-      // F2: label kept (i18n stable) — visibility gated by `onImportBgg` prop in hero.
+      // BGG import CTA removed from /library (BGG user-side ban #2123). The label is required by
+      // LibraryHeroDesktopLabels but the CTA no longer renders (onImportBgg intentionally omitted).
       ctaImportBgg: t('pages.library.hero.cta.importBgg'),
       ctaExportAriaLabel: t('pages.library.hero.cta.exportAriaLabel'),
     }),
@@ -294,8 +290,6 @@ export function LibraryHub(): ReactElement {
         title: t('pages.library.emptyState.empty.title'),
         subtitle: t('pages.library.emptyState.empty.subtitle'),
         cta: t('pages.library.emptyState.empty.cta'),
-        // F2 (#1975): only render the BGG secondary CTA for admin users.
-        ctaImportBgg: isAdminOrAbove ? t('pages.library.emptyState.empty.ctaImportBgg') : undefined,
         suggestions: {
           heading: t('pages.library.emptyState.empty.suggestions.heading'),
         },
@@ -311,7 +305,7 @@ export function LibraryHub(): ReactElement {
         cta: t('pages.library.emptyState.error.cta'),
       },
     }),
-    [t, isAdminOrAbove]
+    [t]
   );
 
   const bulkLabels = useMemo<BulkSelectionBarLabels>(() => {
@@ -403,7 +397,6 @@ export function LibraryHub(): ReactElement {
 
   // ─── Callbacks ───
   const handleAddGame = useCallback(() => router.push('/library?action=add'), [router]);
-  const handleImportBgg = useCallback(() => router.push('/library?action=import-bgg'), [router]);
 
   const handleCardClick = useCallback(
     (itemId: string) => {
@@ -479,12 +472,7 @@ export function LibraryHub(): ReactElement {
       data-state={effectiveKind}
       className="gap-6 p-6 pb-24 sm:p-7"
     >
-      <LibraryHeroDesktop
-        labels={heroLabels}
-        stats={heroStatRows}
-        onAddGame={handleAddGame}
-        onImportBgg={isAdminOrAbove ? handleImportBgg : undefined}
-      />
+      <LibraryHeroDesktop labels={heroLabels} stats={heroStatRows} onAddGame={handleAddGame} />
       <div className="flex flex-col gap-4 lg:flex-row lg:items-start">
         <div className="flex flex-1 flex-col gap-4">
           <LibraryTabs<HybridHubTab> tabs={tabsConfig} active={tab} onChange={setTab} />
@@ -544,7 +532,6 @@ export function LibraryHub(): ReactElement {
                   kind={effectiveKind}
                   labels={emptyLabels}
                   onAddGame={handleAddGame}
-                  onImportBgg={isAdminOrAbove ? handleImportBgg : undefined}
                   onClearFilters={handleClearFilters}
                   onRetry={handleRetry}
                 />

--- a/apps/web/src/app/(authenticated)/library/_components/__tests__/LibraryHub.test.tsx
+++ b/apps/web/src/app/(authenticated)/library/_components/__tests__/LibraryHub.test.tsx
@@ -115,23 +115,6 @@ vi.mock('@/hooks/useMiniNavConfig', () => ({
   useMiniNavConfig: (cfg: unknown) => useMiniNavConfigMock(cfg),
 }));
 
-// ─── useAdminRole mock (F2 #1975: BGG admin-only gate) ────────────────────
-
-type MockAdminRoleReturn = {
-  user: null;
-  isSuperAdmin: boolean;
-  isAdminOrAbove: boolean;
-  isEditorOrAbove: boolean;
-  hasRole: (role: string) => boolean;
-  isLoading: boolean;
-};
-
-const useAdminRoleMock = vi.fn<[], MockAdminRoleReturn>();
-
-vi.mock('@/hooks/useAdminRole', () => ({
-  useAdminRole: () => useAdminRoleMock(),
-}));
-
 // ─── useActivityFeed mock (Phase 3b #1593) ────────────────────────────────
 
 type MockActivityFeedReturn = {
@@ -480,15 +463,6 @@ describe('LibraryHub (Phase 2a hybrid hub)', () => {
       isError: false,
       error: null,
     });
-    // F2 #1975 default: regular user (BGG CTAs hidden).
-    useAdminRoleMock.mockReturnValue({
-      user: null,
-      isSuperAdmin: false,
-      isAdminOrAbove: false,
-      isEditorOrAbove: false,
-      hasRole: () => false,
-      isLoading: false,
-    });
   });
 
   // ─── 6 hub tabs ──────────────────────────────────────────────────────────
@@ -593,19 +567,11 @@ describe('LibraryHub (Phase 2a hybrid hub)', () => {
     expect(
       within(empty).getByRole('button', { name: /Aggiungi il tuo primo gioco/i })
     ).toBeInTheDocument();
-    // F2 #1975: BGG secondary CTA is admin-only; default user → hidden.
+    // BGG import CTA removed from /library (BGG user-side ban #2123) — never rendered.
     expect(within(empty).queryByRole('button', { name: /Importa.*BGG/i })).toBeNull();
   });
 
-  it('does not render the BGG import CTA in empty state even for admins (removed from /library, BGG user-side ban #2123)', () => {
-    useAdminRoleMock.mockReturnValue({
-      user: null,
-      isSuperAdmin: false,
-      isAdminOrAbove: true,
-      isEditorOrAbove: true,
-      hasRole: () => true,
-      isLoading: false,
-    });
+  it('does not render the BGG import CTA in the empty state (removed from /library, BGG user-side ban #2123)', () => {
     const { container } = renderHub(
       makeHub({ sources: emptySources, totalCounts: { ...zeroCounts } })
     );
@@ -888,15 +854,6 @@ describe('LibraryHub — games tab (#1566)', () => {
       isError: false,
       error: null,
     });
-    // F2 #1975 default: regular user (BGG CTAs hidden).
-    useAdminRoleMock.mockReturnValue({
-      user: null,
-      isSuperAdmin: false,
-      isAdminOrAbove: false,
-      isEditorOrAbove: false,
-      hasRole: () => false,
-      isLoading: false,
-    });
   });
 
   it('renders GamesFiltersInline + GamesResultsGrid when tab=games with entries', async () => {
@@ -1009,15 +966,6 @@ describe('LibraryHub — Phase 3b drawer + rail integration (#1593)', () => {
       isSuccess: true,
       isError: false,
       error: null,
-    });
-    // F2 #1975 default: regular user (BGG CTAs hidden).
-    useAdminRoleMock.mockReturnValue({
-      user: null,
-      isSuperAdmin: false,
-      isAdminOrAbove: false,
-      isEditorOrAbove: false,
-      hasRole: () => false,
-      isLoading: false,
     });
     // Force Radix Dialog (desktop) mode for drawer tests.
     installMatchMedia(true);
@@ -1148,15 +1096,6 @@ describe('LibraryHub — a11y axe (#1842)', () => {
       isSuccess: true,
       isError: false,
       error: null,
-    });
-    // F2 #1975 default: regular user (BGG CTAs hidden).
-    useAdminRoleMock.mockReturnValue({
-      user: null,
-      isSuperAdmin: false,
-      isAdminOrAbove: false,
-      isEditorOrAbove: false,
-      hasRole: () => false,
-      isLoading: false,
     });
     // LibraryHub renders a Drawer (AdvancedFiltersDrawer) which calls
     // window.matchMedia synchronously via useSyncExternalStore. Without this

--- a/apps/web/src/app/(authenticated)/library/_components/__tests__/LibraryHub.test.tsx
+++ b/apps/web/src/app/(authenticated)/library/_components/__tests__/LibraryHub.test.tsx
@@ -597,7 +597,7 @@ describe('LibraryHub (Phase 2a hybrid hub)', () => {
     expect(within(empty).queryByRole('button', { name: /Importa.*BGG/i })).toBeNull();
   });
 
-  it('renders BGG secondary CTA in empty state only for admin users (F2 #1975)', () => {
+  it('does not render the BGG import CTA in empty state even for admins (removed from /library, BGG user-side ban #2123)', () => {
     useAdminRoleMock.mockReturnValue({
       user: null,
       isSuperAdmin: false,
@@ -611,7 +611,7 @@ describe('LibraryHub (Phase 2a hybrid hub)', () => {
     );
     const empty = container.querySelector('[data-slot="library-empty-state"]') as HTMLElement;
     expect(empty).toHaveAttribute('data-kind', 'empty');
-    expect(within(empty).getByRole('button', { name: /Importa.*BGG/i })).toBeInTheDocument();
+    expect(within(empty).queryByRole('button', { name: /Importa.*BGG/i })).toBeNull();
   });
 
   // ─── FSM: filtered-empty ───────────────────────────────────────────────

--- a/apps/web/src/components/game-detail/GameDetailDesktop.tsx
+++ b/apps/web/src/components/game-detail/GameDetailDesktop.tsx
@@ -19,6 +19,7 @@ import { useGameSessionContributors } from '@/hooks/queries/useGameSessionContri
 import { useLibraryGameDetail } from '@/hooks/queries/useLibrary';
 import { useConnectionBarNav } from '@/hooks/useConnectionBarNav';
 
+import { getEntityCreateHref } from './entity-create-href';
 import { GameHero, type GameHeroMetaItem } from './GameHero';
 import { GameTabsPanel } from './GameTabsPanel';
 
@@ -53,26 +54,12 @@ export function GameDetailDesktop({
 }: GameDetailDesktopProps) {
   const { data: game, isLoading, isError } = useLibraryGameDetail(gameId);
   const router = useRouter();
-  // ConnectionBar "+" (empty pip) → create that entity. Per-entity targets:
-  // agent/kb are full-page routes under the game; chat/session are prefilled wizards.
+  // ConnectionBar "+" (empty pip) → create that entity. Per-entity target URLs
+  // live in the pure `getEntityCreateHref` helper (unit-tested in isolation).
   const handleCreateEntity = useCallback(
     (entityType: MeepleEntityType) => {
-      switch (entityType) {
-        case 'agent':
-          router.push(`/library/${gameId}/agent`);
-          break;
-        case 'kb':
-          router.push(`/library/${gameId}/kb`);
-          break;
-        case 'chat':
-          router.push(`/chat/new?game=${gameId}`);
-          break;
-        case 'session':
-          router.push(`/sessions/new?gameId=${gameId}`);
-          break;
-        default:
-          break;
-      }
+      const href = getEntityCreateHref(entityType, gameId);
+      if (href) router.push(href);
     },
     [router, gameId]
   );

--- a/apps/web/src/components/game-detail/GameDetailDesktop.tsx
+++ b/apps/web/src/components/game-detail/GameDetailDesktop.tsx
@@ -1,6 +1,8 @@
 'use client';
 
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
+
+import { useRouter } from 'next/navigation';
 
 import { CustomCoverDialog } from '@/components/features/library/custom-cover/CustomCoverDialog';
 import { EditCoverOverlay } from '@/components/features/library/custom-cover/EditCoverOverlay';
@@ -9,7 +11,10 @@ import {
   ConnectionBar,
   buildGameConnectionPips,
 } from '@/components/ui/data-display/connection-bar';
-import type { MeepleCardMetadata } from '@/components/ui/data-display/meeple-card/types';
+import type {
+  MeepleCardMetadata,
+  MeepleEntityType,
+} from '@/components/ui/data-display/meeple-card/types';
 import { useGameSessionContributors } from '@/hooks/queries/useGameSessionContributors';
 import { useLibraryGameDetail } from '@/hooks/queries/useLibrary';
 import { useConnectionBarNav } from '@/hooks/useConnectionBarNav';
@@ -47,7 +52,31 @@ export function GameDetailDesktop({
   isPrivateGame,
 }: GameDetailDesktopProps) {
   const { data: game, isLoading, isError } = useLibraryGameDetail(gameId);
-  const { handlePipClick } = useConnectionBarNav(gameId);
+  const router = useRouter();
+  // ConnectionBar "+" (empty pip) → create that entity. Per-entity targets:
+  // agent/kb are full-page routes under the game; chat/session are prefilled wizards.
+  const handleCreateEntity = useCallback(
+    (entityType: MeepleEntityType) => {
+      switch (entityType) {
+        case 'agent':
+          router.push(`/library/${gameId}/agent`);
+          break;
+        case 'kb':
+          router.push(`/library/${gameId}/kb`);
+          break;
+        case 'chat':
+          router.push(`/chat/new?game=${gameId}`);
+          break;
+        case 'session':
+          router.push(`/sessions/new?gameId=${gameId}`);
+          break;
+        default:
+          break;
+      }
+    },
+    [router, gameId]
+  );
+  const { handlePipClick } = useConnectionBarNav(gameId, handleCreateEntity);
   // #2036: Top session contributors strip. Public endpoint — runs even when
   // the user hasn't actually added the game to their library yet (the share
   // surfaces social proof before deciding to play). `enabled` gates on gameId

--- a/apps/web/src/components/game-detail/__tests__/entity-create-href.test.ts
+++ b/apps/web/src/components/game-detail/__tests__/entity-create-href.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+
+import { getEntityCreateHref } from '../entity-create-href';
+
+describe('getEntityCreateHref', () => {
+  const gameId = 'game-abc-123';
+
+  it('maps agent to the game-scoped agent creation route', () => {
+    expect(getEntityCreateHref('agent', gameId)).toBe(`/library/${gameId}/agent`);
+  });
+
+  it('maps kb to the game-scoped KB creation route', () => {
+    expect(getEntityCreateHref('kb', gameId)).toBe(`/library/${gameId}/kb`);
+  });
+
+  it('maps chat to the new-chat wizard prefilled with the game (?game=)', () => {
+    expect(getEntityCreateHref('chat', gameId)).toBe(`/chat/new?game=${gameId}`);
+  });
+
+  it('maps session to the new-session wizard prefilled with the game (?gameId=)', () => {
+    expect(getEntityCreateHref('session', gameId)).toBe(`/sessions/new?gameId=${gameId}`);
+  });
+
+  it('returns null for entity types without a game-scoped create surface', () => {
+    expect(getEntityCreateHref('player', gameId)).toBeNull();
+    expect(getEntityCreateHref('game', gameId)).toBeNull();
+    expect(getEntityCreateHref('toolkit', gameId)).toBeNull();
+  });
+});

--- a/apps/web/src/components/game-detail/entity-create-href.ts
+++ b/apps/web/src/components/game-detail/entity-create-href.ts
@@ -1,0 +1,31 @@
+import type { MeepleEntityType } from '@/components/ui/data-display/meeple-card/types';
+
+/**
+ * Maps a ConnectionBar entity type to the "create new {entity}" target URL for a
+ * given game. Extracted as a pure function so the per-entity route mapping is
+ * unit-testable in isolation — it guards the bug class where a wrong param
+ * silently turns the ConnectionBar "+" (empty pip) create action into a dead click.
+ *
+ * Returns `null` for entity types that have no game-scoped create surface (the
+ * caller then performs no navigation).
+ *
+ * Route targets:
+ *   - agent   → full-page agent creation under the game
+ *   - kb      → full-page KB (PDF upload) under the game
+ *   - chat    → new-chat wizard, prefilled with the game (`?game=`)
+ *   - session → new-session wizard, prefilled with the game (`?gameId=`)
+ */
+export function getEntityCreateHref(entityType: MeepleEntityType, gameId: string): string | null {
+  switch (entityType) {
+    case 'agent':
+      return `/library/${gameId}/agent`;
+    case 'kb':
+      return `/library/${gameId}/kb`;
+    case 'chat':
+      return `/chat/new?game=${gameId}`;
+    case 'session':
+      return `/sessions/new?gameId=${gameId}`;
+    default:
+      return null;
+  }
+}

--- a/apps/web/src/hooks/__tests__/useConnectionBarNav.test.ts
+++ b/apps/web/src/hooks/__tests__/useConnectionBarNav.test.ts
@@ -46,7 +46,27 @@ describe('useConnectionBarNav', () => {
     expect(state.sourceEntityId).toBe('game-123');
   });
 
-  it('does nothing when isEmpty is true (create action — caller handles)', () => {
+  it('calls onCreateEntity with the entityType when isEmpty (create action)', () => {
+    const onCreateEntity = vi.fn();
+    const { result } = renderHook(() => useConnectionBarNav('game-123', onCreateEntity));
+    const pip = {
+      entityType: 'chat' as const,
+      count: 0,
+      label: 'Chat',
+      icon: vi.fn() as any,
+      isEmpty: true,
+    };
+    const rect = new DOMRect(100, 200, 50, 30);
+
+    act(() => result.current.handlePipClick(pip, rect));
+
+    expect(onCreateEntity).toHaveBeenCalledTimes(1);
+    expect(onCreateEntity).toHaveBeenCalledWith('chat');
+    // No DeckStack for the create action.
+    expect(useCascadeNavigationStore.getState().state).toBe('closed');
+  });
+
+  it('does nothing when isEmpty and no onCreateEntity provided (backward compatible)', () => {
     const { result } = renderHook(() => useConnectionBarNav('game-123'));
     const pip = {
       entityType: 'chat' as const,
@@ -59,7 +79,24 @@ describe('useConnectionBarNav', () => {
 
     act(() => result.current.handlePipClick(pip, rect));
 
-    const state = useCascadeNavigationStore.getState();
-    expect(state.state).toBe('closed'); // no action taken
+    expect(useCascadeNavigationStore.getState().state).toBe('closed'); // no action taken
+  });
+
+  it('does NOT call onCreateEntity when count >= 1 (opens DeckStack instead)', () => {
+    const onCreateEntity = vi.fn();
+    const { result } = renderHook(() => useConnectionBarNav('game-123', onCreateEntity));
+    const pip = {
+      entityType: 'agent' as const,
+      count: 2,
+      label: 'Agent',
+      icon: vi.fn() as any,
+      isEmpty: false,
+    };
+    const rect = new DOMRect(100, 200, 50, 30);
+
+    act(() => result.current.handlePipClick(pip, rect));
+
+    expect(onCreateEntity).not.toHaveBeenCalled();
+    expect(useCascadeNavigationStore.getState().state).toBe('deckStack');
   });
 });

--- a/apps/web/src/hooks/useConnectionBarNav.ts
+++ b/apps/web/src/hooks/useConnectionBarNav.ts
@@ -8,22 +8,27 @@ import { useCascadeNavigationStore } from '@/lib/stores/cascade-navigation-store
 /**
  * Hook that wires ConnectionBar pip clicks to the cascade navigation store.
  * Rules (from spec):
- *   isEmpty === true → create action (handled by caller via onCreateEntity)
+ *   isEmpty === true → create action for this entity type, delegated to the
+ *                      caller-supplied `onCreateEntity` callback (noop if absent)
  *   count >= 1       → openDeckStack (DeckStack resolves to drawer when 1 item)
  */
-export function useConnectionBarNav(sourceEntityId: string) {
+export function useConnectionBarNav(
+  sourceEntityId: string,
+  onCreateEntity?: (entityType: ConnectionPip['entityType']) => void
+) {
   const openDeckStack = useCascadeNavigationStore(s => s.openDeckStack);
 
   const handlePipClick = useCallback(
     (pip: ConnectionPip, anchorRect: DOMRect) => {
       if (pip.isEmpty) {
-        // count === 0: create action — caller handles via onCreateEntity callback
+        // count === 0: create a new entity of this type via the caller's flow.
+        onCreateEntity?.(pip.entityType);
         return;
       }
-      // count >= 1: show DeckStack (DeckStack auto-resolves to drawer when it has exactly 1 item)
+      // count >= 1: show DeckStack (auto-resolves to drawer when exactly 1 item)
       openDeckStack(pip.entityType, sourceEntityId, anchorRect);
     },
-    [sourceEntityId, openDeckStack]
+    [sourceEntityId, openDeckStack, onCreateEntity]
   );
 
   return { handlePipClick };


### PR DESCRIPTION
Due fix UX su /library (segnalati dall'utente).

## 1. Rimuovi "Importa BGG" da /library
Il CTA "Importa BGG" era già admin-only (F2 #1975), ma il BGG user-side asset ban (#2123) impone che non compaia affatto qui. Rimossi: handler `handleImportBgg`, prop `onImportBgg` su `LibraryHeroDesktop`/`EmptyLibrary` (i CTA sono gated su di essi), `emptyLabels.ctaImportBgg`, e `useAdminRole`/`isAdminOrAbove` ora inutilizzati.

La capability BGG del drawer condiviso (`?action=import-bgg`, AddGameDrawer) resta intatta per uso **admin server-to-server** legittimo (ADR-059) — rimosso solo l'entry-point da /library. `heroLabels.ctaImportBgg` tenuto (è `string` required dal type; innocuo senza `onImportBgg`).

## 2. Wira i "+" del dettaglio gioco alla creazione entità
Sotto l'hero, i chip `ConnectionBar` (agent/kb/chat/session) mostrano un "+" quando l'entità è a 0. Cliccandolo **non succedeva nulla**: `useConnectionBarNav` faceva `return` su `pip.isEmpty` (il callback `onCreateEntity` era progettato ma mai wirato). Ora:
- Hook: aggiunto param `onCreateEntity?(entityType)`, invocato su `isEmpty`. Retro-compatibile (noop senza callback); ramo count≥1 (DeckStack) invariato.
- `GameDetailDesktop`: `handleCreateEntity` per-entità → agent `/library/{id}/agent`, kb `/library/{id}/kb`, chat `/chat/new?game={id}`, session `/sessions/new?gameId={id}` (route/param già esistenti).

## Test / gate
- `LibraryHub.test`: il CTA BGG non renderizza (anche admin).
- `useConnectionBarNav.test`: isEmpty→onCreateEntity, backward-compat noop, count≥1→openDeckStack (5/5).
- FE typecheck ✅ · eslint ✅ · vitest suite toccate ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)