### PR TITLE
feat(mechanic-extractor): #2961 multi-provider fallback on ME LLM path

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/HybridLlmService.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/HybridLlmService.cs
@@ -462,39 +462,54 @@ internal class HybridLlmService : ILlmService
 
         while (client != null && attemptedProviders.Add(client.ProviderName))
         {
-            var stopwatch = Stopwatch.StartNew();
-            try
+            // Review #2990: fail fast when the current provider's circuit is already OPEN, matching
+            // GenerateCompletionWithModelAsync. The first (preferred) client is selected via
+            // SupportsModel — bypassing the selector's circuit gating — so without this check a
+            // known-broken provider (e.g. DeepSeek tripped by sustained 402s) would incur a wasted
+            // live call on every section before falling back. Subsequent fallback hops are already
+            // circuit-gated by GetNextFallbackAsync, so this is a harmless recheck for them.
+            if (_circuitBreakerRegistry.GetState(client.ProviderName) == CircuitState.Open)
             {
-                _logger.LogInformation(
-                    "Generating completion with model {Model} via {Provider} (max_tokens={MaxTokens}, multi-provider fallback enabled)",
-                    currentModel, client.ProviderName, effectiveMaxTokens);
-
-                var result = await client.GenerateCompletionAsync(
-                    currentModel, systemPrompt, userPrompt, DefaultTemperature, effectiveMaxTokens, ct)
-                    .ConfigureAwait(false);
-
-                stopwatch.Stop();
-
-                if (result.Success)
-                {
-                    _providerSelector.RecordSuccess(client.ProviderName, currentModel, stopwatch.ElapsedMilliseconds, result);
-                    // Fire-and-forget cost logging (CancellationToken.None to survive request cancellation).
-                    _ = _costService.LogSuccessAsync(result, LlmUserContext.Anonymous, stopwatch.ElapsedMilliseconds, source, CancellationToken.None);
-                    return result;
-                }
-
                 _logger.LogWarning(
-                    "Model {Model} via {Provider} failed: {Error} — attempting provider fallback",
-                    currentModel, client.ProviderName, result.ErrorMessage);
-                _providerSelector.RecordFailure(client.ProviderName, currentModel, stopwatch.ElapsedMilliseconds, result);
-                lastFailure = result;
+                    "Circuit breaker OPEN for {Provider}, skipping call and trying fallback", client.ProviderName);
+                lastFailure = LlmCompletionResult.CreateFailure($"Provider {client.ProviderName} circuit breaker open");
             }
-            catch (Exception ex)
+            else
             {
-                stopwatch.Stop();
-                _logger.LogError(ex, "Error generating completion with model {Model} via {Provider}", currentModel, client.ProviderName);
-                _providerSelector.RecordFailure(client.ProviderName, currentModel, stopwatch.ElapsedMilliseconds);
-                lastFailure = LlmCompletionResult.CreateFailure($"Error: {ex.Message}");
+                var stopwatch = Stopwatch.StartNew();
+                try
+                {
+                    _logger.LogInformation(
+                        "Generating completion with model {Model} via {Provider} (max_tokens={MaxTokens}, multi-provider fallback enabled)",
+                        currentModel, client.ProviderName, effectiveMaxTokens);
+
+                    var result = await client.GenerateCompletionAsync(
+                        currentModel, systemPrompt, userPrompt, DefaultTemperature, effectiveMaxTokens, ct)
+                        .ConfigureAwait(false);
+
+                    stopwatch.Stop();
+
+                    if (result.Success)
+                    {
+                        _providerSelector.RecordSuccess(client.ProviderName, currentModel, stopwatch.ElapsedMilliseconds, result);
+                        // Fire-and-forget cost logging (CancellationToken.None to survive request cancellation).
+                        _ = _costService.LogSuccessAsync(result, LlmUserContext.Anonymous, stopwatch.ElapsedMilliseconds, source, CancellationToken.None);
+                        return result;
+                    }
+
+                    _logger.LogWarning(
+                        "Model {Model} via {Provider} failed: {Error} — attempting provider fallback",
+                        currentModel, client.ProviderName, result.ErrorMessage);
+                    _providerSelector.RecordFailure(client.ProviderName, currentModel, stopwatch.ElapsedMilliseconds, result);
+                    lastFailure = result;
+                }
+                catch (Exception ex)
+                {
+                    stopwatch.Stop();
+                    _logger.LogError(ex, "Error generating completion with model {Model} via {Provider}", currentModel, client.ProviderName);
+                    _providerSelector.RecordFailure(client.ProviderName, currentModel, stopwatch.ElapsedMilliseconds);
+                    lastFailure = LlmCompletionResult.CreateFailure($"Error: {ex.Message}");
+                }
             }
 
             // Advance to the next available provider in the DB-driven fallback chain. The selector

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/HybridLlmService.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/HybridLlmService.cs
@@ -430,6 +430,94 @@ internal class HybridLlmService : ILlmService
     }
 
     /// <inheritdoc/>
+    public async Task<LlmCompletionResult> GenerateCompletionWithModelFallbackAsync(
+        string preferredModel,
+        string systemPrompt,
+        string userPrompt,
+        RequestSource source = RequestSource.Manual,
+        int? maxTokens = null,
+        CancellationToken ct = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(preferredModel);
+        ArgumentException.ThrowIfNullOrWhiteSpace(systemPrompt);
+        ArgumentException.ThrowIfNullOrWhiteSpace(userPrompt);
+
+        var effectiveMaxTokens = maxTokens ?? DefaultMaxTokens;
+
+        // Issue #2961: the first attempt uses the explicit PREFERRED model (selects its provider
+        // via SupportsModel, like GenerateCompletionWithModelAsync). On a hard failure we then
+        // reuse the SAME DB-driven fallback engine as the tier path (ILlmProviderSelector.
+        // GetNextFallbackAsync) instead of duplicating the provider ordering — so a single
+        // provider outage (e.g. DeepSeek 402) does not abort the Mechanic Extractor pipeline.
+        var client = _clients.FirstOrDefault(c => c.SupportsModel(preferredModel));
+        if (client == null)
+        {
+            _logger.LogError("No client found supporting preferred model {Model}", preferredModel);
+            return LlmCompletionResult.CreateFailure($"No provider supports model: {preferredModel}");
+        }
+
+        var currentModel = preferredModel;
+        var attemptedProviders = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        LlmCompletionResult? lastFailure = null;
+
+        while (client != null && attemptedProviders.Add(client.ProviderName))
+        {
+            var stopwatch = Stopwatch.StartNew();
+            try
+            {
+                _logger.LogInformation(
+                    "Generating completion with model {Model} via {Provider} (max_tokens={MaxTokens}, multi-provider fallback enabled)",
+                    currentModel, client.ProviderName, effectiveMaxTokens);
+
+                var result = await client.GenerateCompletionAsync(
+                    currentModel, systemPrompt, userPrompt, DefaultTemperature, effectiveMaxTokens, ct)
+                    .ConfigureAwait(false);
+
+                stopwatch.Stop();
+
+                if (result.Success)
+                {
+                    _providerSelector.RecordSuccess(client.ProviderName, currentModel, stopwatch.ElapsedMilliseconds, result);
+                    // Fire-and-forget cost logging (CancellationToken.None to survive request cancellation).
+                    _ = _costService.LogSuccessAsync(result, LlmUserContext.Anonymous, stopwatch.ElapsedMilliseconds, source, CancellationToken.None);
+                    return result;
+                }
+
+                _logger.LogWarning(
+                    "Model {Model} via {Provider} failed: {Error} — attempting provider fallback",
+                    currentModel, client.ProviderName, result.ErrorMessage);
+                _providerSelector.RecordFailure(client.ProviderName, currentModel, stopwatch.ElapsedMilliseconds, result);
+                lastFailure = result;
+            }
+            catch (Exception ex)
+            {
+                stopwatch.Stop();
+                _logger.LogError(ex, "Error generating completion with model {Model} via {Provider}", currentModel, client.ProviderName);
+                _providerSelector.RecordFailure(client.ProviderName, currentModel, stopwatch.ElapsedMilliseconds);
+                lastFailure = LlmCompletionResult.CreateFailure($"Error: {ex.Message}");
+            }
+
+            // Advance to the next available provider in the DB-driven fallback chain. The selector
+            // skips already-attempted providers and honours circuit-breaker/health/enabled state.
+            var nextSelection = await _providerSelector.GetNextFallbackAsync(client.ProviderName, attemptedProviders, ct)
+                .ConfigureAwait(false);
+            client = nextSelection.Client;
+            if (client != null)
+            {
+                currentModel = nextSelection.Decision.ModelId;
+            }
+            else
+            {
+                _logger.LogWarning(
+                    "No additional fallback providers available after failures: {Providers}",
+                    string.Join(", ", attemptedProviders));
+            }
+        }
+
+        return lastFailure ?? LlmCompletionResult.CreateFailure("Provider error: No providers available");
+    }
+
+    /// <inheritdoc/>
     public async Task<LlmCompletionResult> GenerateMultimodalCompletionAsync(
         IReadOnlyList<LlmMessage> messages,
         RequestSource source = RequestSource.Manual,

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Configuration/MechanicExtractorLlmOptions.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Configuration/MechanicExtractorLlmOptions.cs
@@ -6,11 +6,13 @@ namespace Api.BoundedContexts.SharedGameCatalog.Application.Configuration;
 /// </summary>
 /// <remarks>
 /// Making the default config-driven (instead of a hardcoded <c>const</c>) lets an operator switch
-/// the provider without a redeploy when the wired default is unavailable — e.g. DeepSeek credit
-/// exhausted returns 402 on <c>chat/completions</c>, which the ME path surfaces as a hard abort
-/// (<c>Rejected</c>) with no automatic multi-provider fallback. Routing is by model name
-/// (<c>ILlmClient.SupportsModel</c>), so the model alone selects the provider. The defaults below
-/// preserve the pre-#2951 behaviour when the section is absent.
+/// the provider without a redeploy. Since #2961 the ME path also has automatic multi-provider
+/// fallback (<c>ILlmService.GenerateCompletionWithModelFallbackAsync</c>), so a transient failure
+/// of the wired default — e.g. DeepSeek credit exhausted returning 402 on <c>chat/completions</c> —
+/// retries the next provider in the DB-driven chain and only aborts (<c>AbortedLlmFailed</c>) if
+/// every provider fails. Routing is by model name (<c>ILlmClient.SupportsModel</c>), so the model
+/// alone selects the provider. The defaults below preserve the pre-#2951 behaviour when the section
+/// is absent.
 /// </remarks>
 public sealed class MechanicExtractorLlmOptions
 {

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/MechanicAnalysisPipeline.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/MechanicAnalysisPipeline.cs
@@ -19,9 +19,12 @@ namespace Api.BoundedContexts.SharedGameCatalog.Application.Services.MechanicExt
 /// cumulative cost check → <see cref="MechanicAnalysisSectionRunEntity"/> emission.
 /// </summary>
 /// <remarks>
-/// Provider selection is delegated to <see cref="ILlmService"/>; the pipeline simply asks
-/// for the requested model and records the metadata. In M1.3 we will switch to explicit
-/// JSON schema strict mode via <c>ILlmClient</c> to reduce parse failures.
+/// Provider selection is delegated to <see cref="ILlmService"/>; the pipeline asks for the
+/// requested model via the fallback-enabled path
+/// (<see cref="ILlmService.GenerateCompletionWithModelFallbackAsync"/>, #2961) so a single
+/// provider outage (e.g. DeepSeek 402) does not abort the run, and records the effective
+/// provider/model per section. In M1.3 we will switch to explicit JSON schema strict mode via
+/// <c>ILlmClient</c> to reduce parse failures.
 /// </remarks>
 internal sealed class MechanicAnalysisPipeline : IMechanicAnalysisPipeline
 {
@@ -170,8 +173,11 @@ internal sealed class MechanicAnalysisPipeline : IMechanicAnalysisPipeline
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            var result = await _llmService.GenerateCompletionWithModelAsync(
-                explicitModel: request.Model,
+            // #2961: use the fallback-enabled path so a hard failure of the requested provider
+            // (e.g. DeepSeek 402 credit-exhausted) automatically retries the next available
+            // provider via the DB-driven fallback chain instead of aborting the whole analysis.
+            var result = await _llmService.GenerateCompletionWithModelFallbackAsync(
+                preferredModel: request.Model,
                 systemPrompt: currentSystemPrompt,
                 userPrompt: userPrompt,
                 source: RequestSource.Manual,

--- a/apps/api/src/Api/Services/ILlmService.cs
+++ b/apps/api/src/Api/Services/ILlmService.cs
@@ -97,6 +97,34 @@ internal interface ILlmService
         RequestSource source = RequestSource.Manual,
         int? maxTokens = null,
         CancellationToken ct = default);
+
+    /// <summary>
+    /// Issue #2961: Generate a completion with an explicit PREFERRED model and, on a hard
+    /// failure of that provider (e.g. a 402 credit-exhausted), automatically fall back to the
+    /// next available provider's default model via the DB-driven fallback chain, until one
+    /// succeeds or the chain is exhausted. Used by the Mechanic Extractor pipeline so a single
+    /// provider outage does not abort the whole analysis.
+    /// </summary>
+    /// <remarks>
+    /// Unlike <see cref="GenerateCompletionWithModelAsync"/> (single-shot, #4332 ensemble), this
+    /// retries across providers. The default interface implementation delegates to the single-shot
+    /// method (no fallback), preserving behaviour for mocks/fakes that do not override it;
+    /// <c>HybridLlmService</c> overrides it with the real multi-provider fallback loop.
+    /// </remarks>
+    /// <param name="preferredModel">Model ID tried first; selects the preferred provider via <c>SupportsModel</c>.</param>
+    /// <param name="systemPrompt">System-level instructions for the LLM.</param>
+    /// <param name="userPrompt">User's input prompt.</param>
+    /// <param name="source">Request source for cost tracking.</param>
+    /// <param name="maxTokens">Optional override for the provider's max_tokens cap.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task<LlmCompletionResult> GenerateCompletionWithModelFallbackAsync(
+        string preferredModel,
+        string systemPrompt,
+        string userPrompt,
+        RequestSource source = RequestSource.Manual,
+        int? maxTokens = null,
+        CancellationToken ct = default)
+        => GenerateCompletionWithModelAsync(preferredModel, systemPrompt, userPrompt, source, maxTokens, ct);
 }
 
 /// <summary>

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/HybridLlmServiceModelFallbackTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/HybridLlmServiceModelFallbackTests.cs
@@ -192,4 +192,41 @@ public sealed class HybridLlmServiceModelFallbackTests
                 It.IsAny<double>(), It.IsAny<int>(), It.IsAny<CancellationToken>()),
             Times.Never);
     }
+
+    [Fact]
+    public async Task GenerateCompletionWithModelFallbackAsync_PreferredProviderCircuitOpen_SkipsItWithoutCalling_AndFallsBack()
+    {
+        // Review #2990: the preferred provider is selected via SupportsModel (bypassing the
+        // selector's circuit gating). When its circuit is already OPEN — the exact sustained-402
+        // scenario this feature targets — it must be skipped WITHOUT a wasted live call and fall
+        // straight to the healthy fallback, matching GenerateCompletionWithModelAsync's fail-fast.
+        _circuitBreakerRegistryMock.Setup(r => r.GetState("DeepSeek")).Returns(CircuitState.Open);
+        _circuitBreakerRegistryMock.Setup(r => r.GetState("OpenRouter")).Returns(CircuitState.Closed);
+
+        // If the preferred (open-circuit) provider were wrongly called it would return a failure —
+        // this keeps the pre-fix RED a clean Verify(Never) assertion failure, not an NRE.
+        _deepSeekMock
+            .Setup(c => c.GenerateCompletionAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<double>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(LlmCompletionResult.CreateFailure("should not be called — circuit open"));
+        _openRouterMock
+            .Setup(c => c.GenerateCompletionAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<double>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SuccessFrom("OpenRouter"));
+
+        var sut = CreateSut();
+
+        var result = await sut.GenerateCompletionWithModelFallbackAsync(
+            PreferredModel, "system", "user", RequestSource.Manual, maxTokens: 4000, ct: CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.Cost.Provider.Should().Be("OpenRouter");
+        _deepSeekMock.Verify(
+            c => c.GenerateCompletionAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<double>(), It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/HybridLlmServiceModelFallbackTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/HybridLlmServiceModelFallbackTests.cs
@@ -1,0 +1,195 @@
+using Api.BoundedContexts.KnowledgeBase.Application.Services;
+using Api.BoundedContexts.KnowledgeBase.Domain.Enums;
+using Api.BoundedContexts.KnowledgeBase.Domain.Services;
+using Api.BoundedContexts.SystemConfiguration.Domain.Repositories;
+using Api.Configuration;
+using Api.Services;
+using Api.Services.LlmClients;
+using Api.Tests.Constants;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+using FluentAssertions;
+
+namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Services;
+
+/// <summary>
+/// Issue #2961: multi-provider fallback for the explicit-model path used by the Mechanic
+/// Extractor. Unlike <see cref="HybridLlmService.GenerateCompletionWithModelAsync"/>
+/// (single-shot, #4332 ensemble), <c>GenerateCompletionWithModelFallbackAsync</c> must, on a
+/// hard failure of the preferred provider (e.g. DeepSeek 402 credit-exhausted), fall back to the
+/// next available provider's default model via the DB-driven fallback chain
+/// (<see cref="LlmProviderSelector"/>), until one succeeds or the chain is exhausted.
+/// The selector is exercised for real (mocked deps) so the reuse — not a re-implementation — of
+/// the existing fallback engine is verified end-to-end.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "KnowledgeBase")]
+[Trait("Issue", "2961")]
+public sealed class HybridLlmServiceModelFallbackTests
+{
+    private readonly Mock<ILlmClient> _deepSeekMock = new();
+    private readonly Mock<ILlmClient> _openRouterMock = new();
+    private readonly Mock<ILlmRoutingStrategy> _routingStrategyMock = new();
+    private readonly Mock<IAiModelConfigurationRepository> _modelConfigMock = new();
+    private readonly Mock<ICircuitBreakerRegistry> _circuitBreakerRegistryMock = new();
+    private readonly Mock<ILlmCostService> _costServiceMock = new();
+    private readonly ILogger<HybridLlmService> _logger;
+    private readonly ILogger<LlmProviderSelector> _selectorLogger;
+
+    private const string PreferredModel = "deepseek-chat";
+
+    public HybridLlmServiceModelFallbackTests()
+    {
+        var loggerFactory = new LoggerFactory();
+        _logger = loggerFactory.CreateLogger<HybridLlmService>();
+        _selectorLogger = loggerFactory.CreateLogger<LlmProviderSelector>();
+
+        // DeepSeek is the preferred provider (owns the explicit model).
+        _deepSeekMock.Setup(c => c.ProviderName).Returns("DeepSeek");
+        _deepSeekMock.Setup(c => c.SupportsModel(PreferredModel)).Returns(true);
+
+        // OpenRouter is the fallback provider (reached via the selector's fallback chain).
+        _openRouterMock.Setup(c => c.ProviderName).Returns("OpenRouter");
+        _openRouterMock.Setup(c => c.SupportsModel(It.IsAny<string>())).Returns(true);
+
+        // Empty DB config → selector uses the configured FallbackChain + hardcoded default models.
+        _modelConfigMock
+            .Setup(r => r.GetActiveAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<Api.BoundedContexts.SystemConfiguration.Domain.Entities.AiModelConfiguration>());
+
+        _circuitBreakerRegistryMock.Setup(r => r.AllowsRequests(It.IsAny<string>())).Returns(true);
+        _circuitBreakerRegistryMock.Setup(r => r.GetState(It.IsAny<string>())).Returns(CircuitState.Closed);
+    }
+
+    private ILlmService CreateSut()
+    {
+        var clients = new[] { _deepSeekMock.Object, _openRouterMock.Object };
+        var aiSettings = Options.Create(new AiProviderSettings
+        {
+            PreferredProvider = "",
+            Providers = new Dictionary<string, ProviderConfig>
+            {
+                ["DeepSeek"] = new() { Enabled = true, BaseUrl = "https://api.deepseek.com", Models = [PreferredModel] },
+                ["OpenRouter"] = new() { Enabled = true, BaseUrl = "https://openrouter.ai/api/v1", Models = ["fallback-model"] }
+            },
+            FallbackChain = ["DeepSeek", "OpenRouter"]
+        });
+
+        var selector = new LlmProviderSelector(
+            clients,
+            _routingStrategyMock.Object,
+            _circuitBreakerRegistryMock.Object,
+            aiSettings,
+            _modelConfigMock.Object,
+            _selectorLogger);
+
+        return new HybridLlmService(
+            clients,
+            selector,
+            _circuitBreakerRegistryMock.Object,
+            _costServiceMock.Object,
+            _logger);
+    }
+
+    private static LlmCompletionResult SuccessFrom(string provider) =>
+        LlmCompletionResult.CreateSuccess(
+            $"ok from {provider}",
+            new LlmUsage(10, 5, 15),
+            new LlmCost { InputCost = 0m, OutputCost = 0m, ModelId = "m", Provider = provider });
+
+    [Fact]
+    public async Task GenerateCompletionWithModelFallbackAsync_PreferredProviderFails_FallsBackToNextProvider()
+    {
+        // Preferred provider (DeepSeek) hard-fails on the explicit model, e.g. 402 credit exhausted.
+        _deepSeekMock
+            .Setup(c => c.GenerateCompletionAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<double>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(LlmCompletionResult.CreateFailure("402 Payment Required"));
+
+        // Fallback provider (OpenRouter) succeeds.
+        _openRouterMock
+            .Setup(c => c.GenerateCompletionAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<double>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SuccessFrom("OpenRouter"));
+
+        var sut = CreateSut();
+
+        var result = await sut.GenerateCompletionWithModelFallbackAsync(
+            PreferredModel, "system", "user", RequestSource.Manual, maxTokens: 4000, ct: CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.Cost.Provider.Should().Be("OpenRouter");
+    }
+
+    [Fact]
+    public async Task GenerateCompletionWithModelFallbackAsync_PreferredProviderSucceeds_DoesNotFallBack()
+    {
+        // Preferred provider succeeds on the first attempt → no fallback provider is consulted.
+        _deepSeekMock
+            .Setup(c => c.GenerateCompletionAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<double>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SuccessFrom("DeepSeek"));
+
+        var sut = CreateSut();
+
+        var result = await sut.GenerateCompletionWithModelFallbackAsync(
+            PreferredModel, "system", "user", RequestSource.Manual, maxTokens: 4000, ct: CancellationToken.None);
+
+        result.Success.Should().BeTrue();
+        result.Cost.Provider.Should().Be("DeepSeek");
+        _openRouterMock.Verify(
+            c => c.GenerateCompletionAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<double>(), It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task GenerateCompletionWithModelFallbackAsync_AllProvidersFail_ReturnsFailure_DoesNotThrow()
+    {
+        // Every provider hard-fails → the chain is exhausted and an honest failure is returned.
+        _deepSeekMock
+            .Setup(c => c.GenerateCompletionAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<double>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(LlmCompletionResult.CreateFailure("402 Payment Required"));
+        _openRouterMock
+            .Setup(c => c.GenerateCompletionAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<double>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(LlmCompletionResult.CreateFailure("500 Internal Server Error"));
+
+        var sut = CreateSut();
+
+        var result = await sut.GenerateCompletionWithModelFallbackAsync(
+            PreferredModel, "system", "user", RequestSource.Manual, maxTokens: 4000, ct: CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task GenerateCompletionWithModelFallbackAsync_NoProviderSupportsModel_ReturnsFailure_WithoutCallingAnyProvider()
+    {
+        const string UnknownModel = "unknown-model";
+        _deepSeekMock.Setup(c => c.SupportsModel(UnknownModel)).Returns(false);
+        _openRouterMock.Setup(c => c.SupportsModel(UnknownModel)).Returns(false);
+
+        var sut = CreateSut();
+
+        var result = await sut.GenerateCompletionWithModelFallbackAsync(
+            UnknownModel, "system", "user", RequestSource.Manual, maxTokens: 4000, ct: CancellationToken.None);
+
+        result.Success.Should().BeFalse();
+        result.ErrorMessage.Should().Contain("No provider supports model");
+        _deepSeekMock.Verify(
+            c => c.GenerateCompletionAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<double>(), It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/MechanicAnalysisPipelineTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Services/MechanicExtractor/MechanicAnalysisPipelineTests.cs
@@ -182,6 +182,40 @@ public sealed class MechanicAnalysisPipelineTests
         result.Outcome.Should().Be(MechanicPipelineOutcome.AbortedCostCap);
     }
 
+    [Fact]
+    public async Task RunAsync_UsesMultiProviderFallbackPath_NotSingleShot()
+    {
+        // #2961: the ME pipeline must call the resilient multi-provider fallback completion
+        // (GenerateCompletionWithModelFallbackAsync), so a single provider outage (e.g. DeepSeek
+        // 402) can fall back instead of hard-aborting the analysis. Both LLM methods are mocked so
+        // the pipeline completes whichever it calls — the assertion is on WHICH one it called.
+        var llm = new Mock<ILlmService>();
+        var okResult = LlmCompletionResult.CreateSuccess(
+            WellFormedJson,
+            usage: new LlmUsage(10, 5, 15),
+            cost: new LlmCost { InputCost = 0.0001m, OutputCost = 0.0001m, ModelId = "test-model", Provider = "test-provider" });
+        llm
+            .Setup(s => s.GenerateCompletionWithModelAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<RequestSource>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(okResult);
+        llm
+            .Setup(s => s.GenerateCompletionWithModelFallbackAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<RequestSource>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(okResult);
+
+        var pipeline = BuildPipelineFrom(llm, MechanicValidationResult.Valid());
+
+        await pipeline.RunAsync(BuildRequest(MechanicSection.Summary), CancellationToken.None);
+
+        llm.Verify(
+            s => s.GenerateCompletionWithModelFallbackAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<RequestSource>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
     // ---- fakes / builders -------------------------------------------------
 
     private static MechanicPipelineRequest BuildRequest(params MechanicSection[] sections) =>
@@ -216,12 +250,26 @@ public sealed class MechanicAnalysisPipelineTests
                     Provider = "test-provider"
                 });
 
+        // #2961: the pipeline now calls the fallback-enabled path; mock BOTH so behaviour tests
+        // are agnostic to which completion method the pipeline invokes.
         llm
             .Setup(s => s.GenerateCompletionWithModelAsync(
                 It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
                 It.IsAny<RequestSource>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(effectiveLlmResult);
+        llm
+            .Setup(s => s.GenerateCompletionWithModelFallbackAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<RequestSource>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(effectiveLlmResult);
 
+        return BuildPipelineFrom(llm, validation);
+    }
+
+    private static MechanicAnalysisPipeline BuildPipelineFrom(
+        Mock<ILlmService> llm,
+        MechanicValidationResult validation)
+    {
         var promptProvider = new Mock<IMechanicPromptProvider>();
         promptProvider.SetupGet(p => p.PromptVersion).Returns("v1.0.0");
         promptProvider.Setup(p => p.GetSystemPrompt()).Returns("system");

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Domain/ValueObjects/ContributionTypeTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Domain/ValueObjects/ContributionTypeTests.cs
@@ -30,16 +30,17 @@ public sealed class ContributionTypeTests
     #region Enum Completeness Tests
 
     [Fact]
-    public void ContributionType_HasThreeValues()
+    public void ContributionType_HasFourValues()
     {
+        // NewGame(0), AdditionalContent(1), NewGameProposal(2), CoverChange(3).
         var values = Enum.GetValues<ContributionType>();
-        values.Should().HaveCount(3);
+        values.Should().HaveCount(4);
     }
 
     [Fact]
     public void ContributionType_AllValuesCanBeParsed()
     {
-        var names = new[] { "NewGame", "AdditionalContent", "NewGameProposal" };
+        var names = new[] { "NewGame", "AdditionalContent", "NewGameProposal", "CoverChange" };
 
         foreach (var name in names)
         {
@@ -76,7 +77,7 @@ public sealed class ContributionTypeTests
     [Fact]
     public void ContributionType_IsDefined_ReturnsFalseForInvalidValues()
     {
-        Enum.IsDefined(typeof(ContributionType), 3).Should().BeFalse();
+        Enum.IsDefined(typeof(ContributionType), 4).Should().BeFalse();
         Enum.IsDefined(typeof(ContributionType), -1).Should().BeFalse();
         Enum.IsDefined(typeof(ContributionType), 100).Should().BeFalse();
     }


### PR DESCRIPTION
## Contesto
Follow-up di #2951 / PR #2957 (default LLM ME reso config-driven). Il percorso Mechanic Extractor usava `ILlmService.GenerateCompletionWithModelAsync` (single-shot, #4332 ensemble): su fallimento hard del provider richiesto (es. DeepSeek 402 credito esaurito) `RunSectionAsync` **abortiva l'intera analisi** (`AbortedLlmFailed`) senza tentare un altro provider.

Spec elaborata (decisione di design via `/sc:spec-panel`): [commento su #2961](https://github.com/meepleAi-app/meepleai-monorepo/issues/2961#issuecomment-4980401927).

## Soluzione — Opzione C (fallback runtime DB-driven, riusa il selector)
Né la lista statica in options (opzione A → duplica l'ordinamento provider) né il solo default DB-driven (opzione B → non aggiunge il ritentativo su 402). Invece:

- **Nuovo `ILlmService.GenerateCompletionWithModelFallbackAsync`**: parte dal modello preferito esplicito, poi su `!Success` **riusa lo stesso motore di fallback DB-driven del tier-path** (`ILlmProviderSelector.GetNextFallbackAsync` → `BuildFallbackOrderAsync`), onorando circuit-breaker/health/enabled. Zero duplicazione dell'ordinamento provider.
- **Default interface method** (delega al single-shot) → le altre 7 impl/fake di `ILlmService` restano intatte; solo `HybridLlmService` fa l'override reale. La semantica dell'ensemble (#4332) resta invariata.
- **`RunSectionAsync`** ora usa il path con fallback.

## Osservabilità (#532)
Il provider/modello **effettivo è già registrato per-sezione** (`result.Cost.Provider` → `MechanicAnalysisSectionRunEntity`), quindi un'analisi a provider misti resta osservabile. L'aggregato `MechanicAnalysis` mantiene il provider richiesto.

## Test (TDD, RED→GREEN verificati)
- **4 unit** sul core loop (`HybridLlmServiceModelFallbackTests`): fallback riesce · preferred-success → no fallback · tutti falliscono → failure onesto (no throw) · modello non supportato → failure immediato senza chiamare provider.
- **1 test di wiring** (`MechanicAnalysisPipelineTests`): il pipeline usa il path resiliente, non il single-shot.
- **84 test LLM+ME di regressione verdi**, 0 falliti.

## Note
- Relazione con #2953 #5 (health-check cieco al 402): **complementare, non bloccante** — il fallback reagisce alla completion reale (`!result.Success`), non a un pre-flight.
- Parte dell'epic #539.

Closes #2961

🤖 Generated with [Claude Code](https://claude.com/claude-code)
