### PR TITLE
chore(ds-17): reclassify storyboard mockup as dev-fixture (#2970)

### DIFF
--- a/admin-mockups/MOCKUPS_INDEX.md
+++ b/admin-mockups/MOCKUPS_INDEX.md
@@ -165,7 +165,7 @@ below) and the `/gamebook` family pages render directly from those._
 
 | File | Type | Mapped routes |
 |------|------|---------------|
-| `librogame-game-night-storyboard.html` | page-mock | `/game-nights/[id]` (storyboard variant — was `nanolith-game-night-storyboard.html` pre-rename post-IA consolidation #871, sync inline 2026-06-08 #2025) |
+| `librogame-game-night-storyboard.html` | dev-fixture | Meta-storyboard: embeds the `librogame-runthrough-*` mockups via `<iframe>` as a pre-implementation validation timeline (was `nanolith-game-night-storyboard.html` pre-rename #871, sync inline 2026-06-08 #2025). Not a page render-surface — route `/game-nights/[id]` is covered by `game-night-detail-rsvp.stories.tsx`. Scoped out of `lint:storybook-states` per #2970 (Option B). |
 | `primitive-nav-bottom-mobile.html` | component-mock | Mobile bottom-nav primitive (global, was `nanolith-nav-bottom-mobile.html` pre-#2152) |
 | `primitive-nav-chat-panel.html` | component-mock | Chat slide-over panel (used globally via `useChatPanel`, was `nanolith-nav-chat-panel.html` pre-#2152) |
 | `primitive-nav-topbar.html` | component-mock | Top-bar primitive (global, was `nanolith-nav-topbar.html` pre-#2152) |
@@ -178,9 +178,9 @@ below) and the `/gamebook` family pages render directly from those._
 
 | Type | Count |
 |------|------:|
-| page-mock | 67 |
+| page-mock | 66 |
 | component-mock | 48 |
-| dev-fixture | 12 |
+| dev-fixture | 13 |
 | **Total** | **127** |
 
 > **Updated 2026-06-08** (#2025): 3 component-mock JSX Sara obsoleti eliminati

--- a/admin-mockups/design_files/librogame-game-night-storyboard.fidelity.json
+++ b/admin-mockups/design_files/librogame-game-night-storyboard.fidelity.json
@@ -26,10 +26,10 @@
     "designer_approved_on": "2026-06-15",
     "story_path": "",
     "fixtures_path": "",
-    "design_intent": "forward-refactor-obsolete",
+    "design_intent": "current",
     "viewports": [
       "desktop"
     ],
-    "obsolete_tracking_issue": "#2970"
+    "obsolete_tracking_issue": ""
   }
 }


### PR DESCRIPTION
## Cosa

Risolve **#2970** (designer review) con **Opzione B**: riclassifica `librogame-game-night-storyboard.html` da `page-mock` a `dev-fixture` e ripristina `design_intent: current` nel fidelity (era provvisoriamente `forward-refactor-obsolete`).

## Perché B (non A "conferma obsolete")

Lo storyboard **non è obsoleto** — è un **meta-storyboard**: embedda i mockup `librogame-runthrough-*` via `<iframe>` come timeline di validazione pre-implementazione FE. Non è una render-surface di route. Marcarlo `obsolete` è una **bugia semantica**; la classe corretta è `dev-fixture` (*"prototype / reference, not for production cloning"*), con precedente diretto in `state-matrix.html` (artefatto di validazione multi-route che porta anch'esso un `fidelity.json` `current`).

La route `/game-nights/[id]` resta coperta da `game-night-detail-rsvp.stories.tsx` (verificato).

## Meccanica

`lint:storybook-states` walka solo le righe `page-mock` di `MOCKUPS_INDEX` (`inject-annotations.mjs` filtra `type === 'page-mock'`). Riclassificando a `dev-fixture`, lo storyboard **esce dal walk** → l'entry passa da `skipped-obsolete` (1 → 0) senza creare `coverage-gap` né `contract-violation`. **Gate resta verde** a `--max-baseline 0`. Il fidelity `current` con `obsolete_tracking_issue` vuoto passa `validate-fidelity`.

## Diff (2 file)

- `admin-mockups/MOCKUPS_INDEX.md` — riga storyboard `page-mock → dev-fixture` + summary counts (page-mock 67→66, dev-fixture 12→13)
- `admin-mockups/design_files/librogame-game-night-storyboard.fidelity.json` — `design_intent: forward-refactor-obsolete → current`, `obsolete_tracking_issue: "#2970" → ""`

## Verifica

- `validate-fidelity` sullo storyboard → **PASS** (`design_intent: current` valido, tracking non richiesto)
- `lint:storybook-states` locale: lo storyboard **esce dal walk** come previsto (`skipped-obsolete 1→0`), `gaps` invariato
- `typecheck` → PASS (pre-commit)
- Nota: la modifica è provabilmente **gate-neutrale** — rimuove solo lo storyboard, non può introdurre gap/contract-violation su nessuna piattaforma. Gli audit rigenerati localmente sono stati **esclusi** dal diff (l'ambiente Windows sotto-parsa l'indice; CI li rigenera correttamente).

Closes #2970. Companion #2971 (3 story residue, già su disco da PR #2972) non toccato.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
