### PR TITLE
chore(infra): opt-in GPU overlay per embedding-service seed-index bake

### DIFF
--- a/infra/compose.gpu.local.yml
+++ b/infra/compose.gpu.local.yml
@@ -1,0 +1,25 @@
+# Opt-in GPU overlay for the embedding-service (issue #539 — seed-index bake acceleration).
+#
+# Gives the embedding-service access to the host NVIDIA GPU so the
+# nomic/sentence-transformers embedding runs on the GPU instead of saturating CPU
+# cores (~6x faster `make seed-index` bake on a GPU host).
+#
+# This is a STANDALONE opt-in overlay: it is NOT referenced by the default compose
+# stack, so `make dev` is unaffected on machines without an NVIDIA GPU. A
+# `driver: nvidia` reservation would make `make dev` FAIL if merged into a shared
+# default compose file — that is why it lives here as a separate overlay you opt into.
+#
+# Apply it explicitly only when you have an NVIDIA GPU + container runtime:
+#
+#   docker compose -p meepleai \
+#     -f docker-compose.yml -f compose.dev.yml -f compose.gpu.local.yml \
+#     up -d --no-deps embedding-service
+services:
+  embedding-service:
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]


### PR DESCRIPTION
Aggiunge `infra/compose.gpu.local.yml`: overlay compose **opt-in** che riserva la GPU NVIDIA host per l'`embedding-service` → ~6x più veloce `make seed-index` su host con GPU (issue #539).

**Safe da committare**: è un overlay standalone NON referenziato dallo stack di default → `make dev` invariato su macchine senza GPU. Si applica esplicitamente con `-f compose.gpu.local.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)