### PR TITLE
feat(frontend): #3006 #3007 /toolkit/history & /library/wishlist — fidelity + i18n

### DIFF
--- a/admin-mockups/MOCKUPS_INDEX.md
+++ b/admin-mockups/MOCKUPS_INDEX.md
@@ -78,6 +78,7 @@
 | `sp4-game-detail-tab-strategies.html` | sub-tab placeholder (#2148) | `/games/[id]/strategies` — AI placeholder, designer review required |
 | `sp4-game-detail-tab-chat.html` | sub-tab placeholder (#2148) | `/games/[id]/chat` — standalone (was partial via composite), designer review required |
 | `sp4-game-detail-tab-faqs.html` | sub-tab placeholder (#2148) | `/games/[id]/faqs` — game-scoped variant of public FAQ, designer review required |
+| `sp4-library-wishlist.html` | page-mock | `/library/wishlist` — personal wishlist (priority Alta/Media/Bassa, target price, notes); filters + sort + add/edit dialog. Issue #1491 |
 | `sp4-parts-common.jsx` | component-mock | Shared mockup runtime — `window.MAI` (entity helpers, StateBlock/Shimmer/SseBanner, fake dataset). Re-derived for sessions consolidation (2026-05-31). Replace with codebase modules at integration time. |
 | `sp4-session-catan-data.jsx` | component-mock | Catan-specific dataset (hex board 19-tiles, resources, settlements/cities/roads, dev cards). Premium #3/7. |
 | `sp4-session-catan-flavor.jsx` | component-mock | Catan flavor components — `HexBoard`, `RobberOverlay`, `DiceDisplay`, `TradePanel`, `DevCardsPanel`, `ResourceHandBar`. |
@@ -178,10 +179,10 @@ below) and the `/gamebook` family pages render directly from those._
 
 | Type | Count |
 |------|------:|
-| page-mock | 66 |
+| page-mock | 67 |
 | component-mock | 48 |
 | dev-fixture | 13 |
-| **Total** | **127** |
+| **Total** | **128** |
 
 > **Updated 2026-06-08** (#2025): 3 component-mock JSX Sara obsoleti eliminati
 > (`sp6-libro-game-{play-session,translation-viewer,glossary-editor}.jsx`).

--- a/apps/web/src/app/(authenticated)/library/wishlist/__tests__/WishlistStats.test.tsx
+++ b/apps/web/src/app/(authenticated)/library/wishlist/__tests__/WishlistStats.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+/**
+ * WishlistStats — header "qstat" line for /library/wishlist (Issue #3007,
+ * Task B5).
+ *
+ * Mirrors `MeepleWishlistCard.test.tsx`'s i18n strategy: a real `IntlProvider`
+ * wired to the flattened `it.json` catalog, so assertions check the actual
+ * rendered (interpolated) copy rather than raw message ids.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
+import { describe, expect, it } from 'vitest';
+
+import { flattenMessages } from '@/locales';
+import itMessages from '@/locales/it.json';
+
+import { WishlistStats } from '../_components/WishlistStats';
+
+import type { Priority } from '../_lib/wishlist-filters';
+import type { ReactElement } from 'react';
+
+const MESSAGES = flattenMessages(itMessages as unknown as Record<string, unknown>);
+const STATS_I18N = itMessages.pages.library.wishlist.stats;
+
+function renderWithIntl(ui: ReactElement) {
+  return render(
+    <IntlProvider locale="it" messages={MESSAGES}>
+      {ui}
+    </IntlProvider>
+  );
+}
+
+interface WishlistStatsShape {
+  total: number;
+  highCount: number;
+  totalSpend: number;
+  priorityCounts: Record<Priority, number>;
+}
+
+function buildStats(overrides: Partial<WishlistStatsShape> = {}): WishlistStatsShape {
+  return {
+    total: 12,
+    highCount: 5,
+    totalSpend: 350,
+    priorityCounts: { high: 5, medium: 4, low: 3 },
+    ...overrides,
+  };
+}
+
+describe('WishlistStats', () => {
+  it('renders the total games count', () => {
+    renderWithIntl(<WishlistStats stats={buildStats({ total: 12 })} />);
+    expect(screen.getByText(STATS_I18N.games.replace('{count}', '12'))).toBeInTheDocument();
+  });
+
+  it('renders the high-priority count', () => {
+    renderWithIntl(<WishlistStats stats={buildStats({ highCount: 5 })} />);
+    expect(screen.getByText(STATS_I18N.highPriority.replace('{count}', '5'))).toBeInTheDocument();
+  });
+
+  it('renders the estimated spend formatted as EUR currency', () => {
+    renderWithIntl(<WishlistStats stats={buildStats({ totalSpend: 350 })} />);
+    // NBSP/narrow-NBSP between amount and currency symbol can differ subtly
+    // by ICU data source — assert on the container's normalized text content
+    // instead of an exact string built independently via `Intl.NumberFormat`.
+    expect(screen.getByTestId('wishlist-stats').textContent).toMatch(/spesa stimata.*350,00.*€/);
+  });
+
+  it('renders zero values without crashing', () => {
+    renderWithIntl(<WishlistStats stats={buildStats({ total: 0, highCount: 0, totalSpend: 0 })} />);
+    expect(screen.getByText(STATS_I18N.games.replace('{count}', '0'))).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/(authenticated)/library/wishlist/__tests__/WishlistToolbar.test.tsx
+++ b/apps/web/src/app/(authenticated)/library/wishlist/__tests__/WishlistToolbar.test.tsx
@@ -187,6 +187,14 @@ describe('WishlistToolbar', () => {
     expect(screen.getByRole('checkbox', { name: PRIORITY_I18N.low })).toHaveTextContent('3');
   });
 
+  it('shows the priority icon (mockup PRIO map) in each priority chip', () => {
+    renderToolbar();
+
+    expect(screen.getByRole('checkbox', { name: PRIORITY_I18N.high })).toHaveTextContent('🔥');
+    expect(screen.getByRole('checkbox', { name: PRIORITY_I18N.medium })).toHaveTextContent('⭐');
+    expect(screen.getByRole('checkbox', { name: PRIORITY_I18N.low })).toHaveTextContent('⬇️');
+  });
+
   it('calls onChange with the new sort when a sort option is selected', async () => {
     const user = userEvent.setup();
     const { onChange } = renderToolbar({ state: baseState({ sort: 'priority' }) });

--- a/apps/web/src/app/(authenticated)/library/wishlist/__tests__/WishlistToolbar.test.tsx
+++ b/apps/web/src/app/(authenticated)/library/wishlist/__tests__/WishlistToolbar.test.tsx
@@ -1,0 +1,234 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+/**
+ * WishlistToolbar — filter/sort toolbar for /library/wishlist (Issue #3007,
+ * Task B5).
+ *
+ * Mirrors `MeepleWishlistCard.test.tsx`'s i18n strategy (real `IntlProvider`
+ * wired to the flattened `it.json` catalog) combined with
+ * `HistoryToolbar.test.tsx`'s search-debounce isolation pattern (locally
+ * scoped fake timers, driven via `fireEvent.change` rather than
+ * `userEvent.type` — mixing `userEvent`'s internal scheduling with fake
+ * timers is unreliable).
+ */
+
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { IntlProvider } from 'react-intl';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+
+import { flattenMessages } from '@/locales';
+import itMessages from '@/locales/it.json';
+
+import { WishlistToolbar } from '../_components/WishlistToolbar';
+
+import type { Priority, WishlistFilterState } from '../_lib/wishlist-filters';
+import type { ReactElement } from 'react';
+
+const MESSAGES = flattenMessages(itMessages as unknown as Record<string, unknown>);
+const FILTERS_I18N = itMessages.pages.library.wishlist.filters;
+const SUMMARY_I18N = itMessages.pages.library.wishlist.summary;
+const PRIORITY_I18N = itMessages.pages.library.wishlist.priority;
+
+function renderWithIntl(ui: ReactElement) {
+  return render(
+    <IntlProvider locale="it" messages={MESSAGES}>
+      {ui}
+    </IntlProvider>
+  );
+}
+
+function baseState(overrides: Partial<WishlistFilterState> = {}): WishlistFilterState {
+  return {
+    search: '',
+    priorities: [],
+    sort: 'priority',
+    ...overrides,
+  };
+}
+
+const PRIORITY_COUNTS: Record<Priority, number> = { high: 5, medium: 4, low: 3 };
+
+function renderToolbar(
+  overrides: Partial<{
+    state: WishlistFilterState;
+    onChange: (next: WishlistFilterState) => void;
+    priorityCounts: Record<Priority, number>;
+    totalCount: number;
+    resultCount: number;
+    onClearAll: () => void;
+  }> = {}
+) {
+  const onChange = overrides.onChange ?? vi.fn();
+  const onClearAll = overrides.onClearAll ?? vi.fn();
+
+  renderWithIntl(
+    <WishlistToolbar
+      state={overrides.state ?? baseState()}
+      onChange={onChange}
+      priorityCounts={overrides.priorityCounts ?? PRIORITY_COUNTS}
+      totalCount={overrides.totalCount ?? 12}
+      resultCount={overrides.resultCount ?? 12}
+      onClearAll={onClearAll}
+    />
+  );
+
+  return { onChange, onClearAll };
+}
+
+describe('WishlistToolbar', () => {
+  describe('search debounce', () => {
+    beforeEach(() => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('calls onChange with the updated search only after the 400ms debounce elapses', async () => {
+      const { onChange } = renderToolbar();
+
+      const searchInput = screen.getByRole('searchbox', {
+        name: FILTERS_I18N.searchAriaLabel,
+      });
+
+      fireEvent.change(searchInput, { target: { value: 'brass' } });
+
+      expect(onChange).not.toHaveBeenCalled();
+      expect(screen.getByText(FILTERS_I18N.searching)).toBeInTheDocument();
+
+      await act(async () => {
+        vi.advanceTimersByTime(400);
+      });
+
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ search: 'brass' }));
+      expect(screen.queryByText(FILTERS_I18N.searching)).not.toBeInTheDocument();
+    });
+
+    it('cancels the pending debounced commit when the search is cleared before it fires', async () => {
+      const { onChange } = renderToolbar();
+
+      const searchInput = screen.getByRole('searchbox', {
+        name: FILTERS_I18N.searchAriaLabel,
+      });
+
+      fireEvent.change(searchInput, { target: { value: 'catan' } });
+      await act(async () => {
+        vi.advanceTimersByTime(200);
+      });
+      expect(onChange).not.toHaveBeenCalled();
+
+      fireEvent.click(screen.getByRole('button', { name: FILTERS_I18N.clearSearch }));
+
+      await act(async () => {
+        vi.advanceTimersByTime(400);
+      });
+
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ search: '' }));
+    });
+  });
+
+  it('clears the search immediately (bypassing the debounce) when the clear button is clicked', async () => {
+    const user = userEvent.setup();
+    const { onChange } = renderToolbar({ state: baseState({ search: 'catan' }) });
+
+    await user.click(screen.getByRole('button', { name: FILTERS_I18N.clearSearch }));
+
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ search: '' }));
+  });
+
+  it('toggles a priority chip on, updating priorities via onChange', async () => {
+    const user = userEvent.setup();
+    const { onChange } = renderToolbar();
+
+    await user.click(screen.getByRole('checkbox', { name: PRIORITY_I18N.high }));
+
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ priorities: ['high'] }));
+  });
+
+  it('toggles a priority chip off when it is already selected', async () => {
+    const user = userEvent.setup();
+    const { onChange } = renderToolbar({ state: baseState({ priorities: ['high', 'medium'] }) });
+
+    await user.click(screen.getByRole('checkbox', { name: PRIORITY_I18N.high }));
+
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ priorities: ['medium'] }));
+  });
+
+  it('marks the "Tutti" chip as checked when no priority is selected', () => {
+    renderToolbar({ state: baseState({ priorities: [] }) });
+
+    expect(screen.getByRole('checkbox', { name: FILTERS_I18N.all })).toHaveAttribute(
+      'aria-checked',
+      'true'
+    );
+  });
+
+  it('clears all selected priorities when "Tutti" is clicked', async () => {
+    const user = userEvent.setup();
+    const { onChange } = renderToolbar({ state: baseState({ priorities: ['high', 'low'] }) });
+
+    await user.click(screen.getByRole('checkbox', { name: FILTERS_I18N.all }));
+
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ priorities: [] }));
+  });
+
+  it('shows the priority chip counts', () => {
+    renderToolbar({ priorityCounts: { high: 5, medium: 4, low: 3 }, totalCount: 12 });
+
+    expect(screen.getByRole('checkbox', { name: FILTERS_I18N.all })).toHaveTextContent('12');
+    expect(screen.getByRole('checkbox', { name: PRIORITY_I18N.high })).toHaveTextContent('5');
+    expect(screen.getByRole('checkbox', { name: PRIORITY_I18N.medium })).toHaveTextContent('4');
+    expect(screen.getByRole('checkbox', { name: PRIORITY_I18N.low })).toHaveTextContent('3');
+  });
+
+  it('calls onChange with the new sort when a sort option is selected', async () => {
+    const user = userEvent.setup();
+    const { onChange } = renderToolbar({ state: baseState({ sort: 'priority' }) });
+
+    await user.click(screen.getByRole('button', { name: FILTERS_I18N.sortBy }));
+    await user.click(await screen.findByRole('option', { name: FILTERS_I18N.sortOptions.oldest }));
+
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ sort: 'oldest' }));
+  });
+
+  it('marks the current sort option as selected in the popover', async () => {
+    const user = userEvent.setup();
+    renderToolbar({ state: baseState({ sort: 'alpha' }) });
+
+    await user.click(screen.getByRole('button', { name: FILTERS_I18N.sortBy }));
+
+    expect(
+      await screen.findByRole('option', { name: FILTERS_I18N.sortOptions.alpha })
+    ).toHaveAttribute('aria-selected', 'true');
+  });
+
+  describe('summary bar', () => {
+    it('is hidden when no filters are active', () => {
+      renderToolbar({ state: baseState() });
+
+      expect(screen.queryByText(/filtro/)).not.toBeInTheDocument();
+    });
+
+    it('shows the active-filter count and result/total, and "Cancella filtri" calls onClearAll', async () => {
+      const user = userEvent.setup();
+      const { onClearAll } = renderToolbar({
+        state: baseState({ priorities: ['high'], search: 'brass' }),
+        totalCount: 12,
+        resultCount: 3,
+      });
+
+      expect(screen.getByText('2 filtri attivi')).toBeInTheDocument();
+      expect(screen.getByText('3 giochi su 12')).toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: SUMMARY_I18N.clearAll }));
+
+      expect(onClearAll).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/apps/web/src/app/(authenticated)/library/wishlist/__tests__/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/library/wishlist/__tests__/page.test.tsx
@@ -109,6 +109,19 @@ const ITEM_2 = buildItem({
   priority: 'medium',
 });
 
+/**
+ * `Intl.NumberFormat`'s currency formatting inserts a non-breaking space
+ * (U+00A0) before the currency symbol. `toHaveTextContent`'s default
+ * whitespace normalization collapses runs of JS-`\s` whitespace (which
+ * includes NBSP) into a single regular space, but it only normalizes the
+ * *received* DOM text — the string passed in as the expected substring is
+ * matched as-is. Normalizing the expected substring here the same way keeps
+ * the comparison from failing on an NBSP-vs-regular-space mismatch.
+ */
+function normalizeNbsp(value: string): string {
+  return value.split(String.fromCharCode(160)).join(' ');
+}
+
 describe('WishlistPage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -146,6 +159,54 @@ describe('WishlistPage', () => {
     expect(screen.getByText('Wingspan')).toBeInTheDocument();
     expect(screen.getByText('Catan')).toBeInTheDocument();
     expect(screen.getAllByTestId('wishlist-card')).toHaveLength(2);
+  });
+
+  it('renders WishlistStats with totals computed from all items', () => {
+    const statsItems = [
+      buildItem({
+        id: '00000000-0000-0000-0000-000000000010',
+        gameId: 'game-10',
+        gameName: 'Ark Nova',
+        priority: 'high',
+        targetPrice: 40,
+      }),
+      buildItem({
+        id: '00000000-0000-0000-0000-000000000011',
+        gameId: 'game-11',
+        gameName: 'Brass Birmingham',
+        priority: 'high',
+        targetPrice: 20,
+      }),
+      buildItem({
+        id: '00000000-0000-0000-0000-000000000012',
+        gameId: 'game-12',
+        gameName: 'Azul',
+        priority: 'low',
+        targetPrice: null,
+      }),
+    ];
+
+    mockUseWishlist.mockReturnValue({
+      data: statsItems,
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    });
+
+    renderPage(<WishlistPage />);
+
+    // total=3, highCount=2 (Ark Nova + Brass Birmingham), totalSpend=40+20=60
+    // (Azul's null targetPrice is excluded from the sum) — matches computeStats().
+    const stats = screen.getByTestId('wishlist-stats');
+    const formattedSpend = normalizeNbsp(
+      new Intl.NumberFormat('it', { style: 'currency', currency: 'EUR' }).format(60)
+    );
+
+    expect(stats).toHaveTextContent(WISHLIST_I18N.stats.games.replace('{count}', '3'));
+    expect(stats).toHaveTextContent(WISHLIST_I18N.stats.highPriority.replace('{count}', '2'));
+    expect(stats).toHaveTextContent(
+      WISHLIST_I18N.stats.estimatedSpend.replace('{amount}', formattedSpend)
+    );
   });
 
   it('shows the empty state when there are no wishlist items', () => {

--- a/apps/web/src/app/(authenticated)/library/wishlist/__tests__/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/library/wishlist/__tests__/page.test.tsx
@@ -1,0 +1,195 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+/**
+ * WishlistPage — orchestrator smoke tests (Issue #3007, Task B6).
+ *
+ * Mirrors the sibling B1-B5 tests' i18n strategy: a real `IntlProvider` wired
+ * to the flattened `it.json` catalog (not `renderWithQuery`'s EN catalog),
+ * plus a real `QueryClientProvider` since `AddToWishlistDialog` (always
+ * mounted for the header "add" CTA) calls `useLibrary`/`useAddToWishlist`/
+ * `useUpdateWishlistItem` internally. All query hooks are mocked directly at
+ * the module level so no network call is ever attempted.
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { IntlProvider } from 'react-intl';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+import { flattenMessages } from '@/locales';
+import itMessages from '@/locales/it.json';
+
+import WishlistPage from '../page';
+
+import type { WishlistItemDto } from '@/lib/api/schemas/wishlist.schemas';
+import type { ReactElement } from 'react';
+
+const MESSAGES = flattenMessages(itMessages as unknown as Record<string, unknown>);
+const WISHLIST_I18N = itMessages.pages.library.wishlist;
+
+// ============================================================================
+// Mocks
+// ============================================================================
+
+const mockUseWishlist = vi.hoisted(() => vi.fn());
+const mockUseRemoveFromWishlist = vi.hoisted(() => vi.fn());
+const mockUseAddToWishlist = vi.hoisted(() => vi.fn());
+const mockUseUpdateWishlistItem = vi.hoisted(() => vi.fn());
+const mockUseLibrary = vi.hoisted(() => vi.fn());
+const mockToastSuccess = vi.hoisted(() => vi.fn());
+
+vi.mock('@/hooks/queries/useWishlist', () => ({
+  useWishlist: mockUseWishlist,
+  useRemoveFromWishlist: mockUseRemoveFromWishlist,
+  useAddToWishlist: mockUseAddToWishlist,
+  useUpdateWishlistItem: mockUseUpdateWishlistItem,
+}));
+
+vi.mock('@/hooks/queries/useLibrary', () => ({
+  useLibrary: mockUseLibrary,
+}));
+
+vi.mock('@/components/layout/Toast', () => ({
+  toast: {
+    success: (...args: unknown[]) => mockToastSuccess(...args),
+  },
+}));
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function renderPage(ui: ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <IntlProvider locale="it" messages={MESSAGES}>
+        {ui}
+      </IntlProvider>
+    </QueryClientProvider>
+  );
+}
+
+const LIBRARY_DATA = {
+  items: [
+    { gameId: 'game-1', gameTitle: 'Wingspan' },
+    { gameId: 'game-2', gameTitle: 'Catan' },
+  ],
+  page: 1,
+  pageSize: 500,
+  totalCount: 2,
+};
+
+function buildItem(overrides: Partial<WishlistItemDto> = {}): WishlistItemDto {
+  return {
+    id: '00000000-0000-0000-0000-000000000001',
+    userId: '00000000-0000-0000-0000-000000000002',
+    gameId: 'game-1',
+    gameName: 'Wingspan',
+    priority: 'high',
+    targetPrice: null,
+    notes: null,
+    addedAt: '2026-01-01T00:00:00Z',
+    updatedAt: null,
+    visibility: 'private',
+    ...overrides,
+  };
+}
+
+const ITEM_1 = buildItem();
+const ITEM_2 = buildItem({
+  id: '00000000-0000-0000-0000-000000000004',
+  gameId: 'game-2',
+  gameName: 'Catan',
+  priority: 'medium',
+});
+
+describe('WishlistPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseLibrary.mockReturnValue({ data: LIBRARY_DATA, isLoading: false, isError: false });
+    mockUseRemoveFromWishlist.mockReturnValue({ mutate: vi.fn() });
+    mockUseAddToWishlist.mockReturnValue({ mutate: vi.fn(), isPending: false });
+    mockUseUpdateWishlistItem.mockReturnValue({ mutate: vi.fn(), isPending: false });
+  });
+
+  it('renders the localized page title', () => {
+    mockUseWishlist.mockReturnValue({
+      data: [ITEM_1, ITEM_2],
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    });
+
+    renderPage(<WishlistPage />);
+
+    expect(
+      screen.getByRole('heading', { level: 1, name: WISHLIST_I18N.hero.title })
+    ).toBeInTheDocument();
+  });
+
+  it('renders a card for each fetched wishlist item', () => {
+    mockUseWishlist.mockReturnValue({
+      data: [ITEM_1, ITEM_2],
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    });
+
+    renderPage(<WishlistPage />);
+
+    expect(screen.getByText('Wingspan')).toBeInTheDocument();
+    expect(screen.getByText('Catan')).toBeInTheDocument();
+    expect(screen.getAllByTestId('wishlist-card')).toHaveLength(2);
+  });
+
+  it('shows the empty state when there are no wishlist items', () => {
+    mockUseWishlist.mockReturnValue({
+      data: [],
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    });
+
+    renderPage(<WishlistPage />);
+
+    expect(screen.getByText(WISHLIST_I18N.empty.noItems.title)).toBeInTheDocument();
+  });
+
+  it('shows the filtered-empty state when an active priority filter excludes every item', async () => {
+    const user = userEvent.setup();
+    mockUseWishlist.mockReturnValue({
+      data: [ITEM_1, ITEM_2],
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    });
+
+    renderPage(<WishlistPage />);
+
+    // ITEM_1/ITEM_2 are 'high'/'medium' — filtering to 'low' excludes both.
+    await user.click(screen.getByRole('checkbox', { name: WISHLIST_I18N.priority.low }));
+
+    expect(screen.getByText(WISHLIST_I18N.empty.filtered.title)).toBeInTheDocument();
+    expect(screen.queryByTestId('wishlist-card')).not.toBeInTheDocument();
+  });
+
+  it('shows the error state when the wishlist query rejects', () => {
+    mockUseWishlist.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      refetch: vi.fn(),
+    });
+
+    renderPage(<WishlistPage />);
+
+    expect(screen.getByRole('alert')).toHaveTextContent(WISHLIST_I18N.error.message);
+    expect(screen.getByRole('button', { name: WISHLIST_I18N.error.retry })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/(authenticated)/library/wishlist/__tests__/wishlist-filters.test.ts
+++ b/apps/web/src/app/(authenticated)/library/wishlist/__tests__/wishlist-filters.test.ts
@@ -159,6 +159,18 @@ describe('sortItems', () => {
     expect(result.map(i => i.id)).toEqual(['b', 'a']);
   });
 
+  it('ranks an unrecognized priority value as medium (never crashes)', () => {
+    const items = [
+      makeItem({ id: 'high', priority: 'high', addedAt: '2026-07-01T00:00:00Z' }),
+      makeItem({ id: 'unrecognized', priority: 'urgent', addedAt: '2026-07-01T00:00:00Z' }),
+      makeItem({ id: 'low', priority: 'low', addedAt: '2026-07-01T00:00:00Z' }),
+    ];
+    expect(() => sortItems(items, 'priority')).not.toThrow();
+    // 'urgent' falls back to the medium rank (1), so it sorts between high and low.
+    const result = sortItems(items, 'priority');
+    expect(result.map(i => i.id)).toEqual(['high', 'unrecognized', 'low']);
+  });
+
   it('sorts by recent (addedAt desc)', () => {
     const items = [
       makeItem({ id: 'a', addedAt: '2026-07-01T00:00:00Z' }),
@@ -208,6 +220,15 @@ describe('sortItems', () => {
     sortItems(items, 'recent');
     expect(items).toEqual(original);
   });
+
+  it('is stable (order-preserving) for two items that both have a null targetPrice', () => {
+    const items = [
+      makeItem({ id: 'first', targetPrice: null }),
+      makeItem({ id: 'second', targetPrice: null }),
+    ];
+    const result = sortItems(items, 'price');
+    expect(result.map(i => i.id)).toEqual(['first', 'second']);
+  });
 });
 
 // ─── computeStats ───────────────────────────────────────────────────────────
@@ -247,6 +268,32 @@ describe('computeStats', () => {
   it('normalizes a stray-cased priority when bucketing', () => {
     const items = [makeItem({ id: 'a', priority: 'HIGH' })];
     const stats = computeStats(items);
+    expect(stats.highCount).toBe(1);
+    expect(stats.priorityCounts).toEqual({ high: 1, medium: 0, low: 0 });
+  });
+
+  it('counts valid lowercase priority values correctly', () => {
+    const items = [
+      makeItem({ id: 'a', priority: 'high' }),
+      makeItem({ id: 'b', priority: 'medium' }),
+      makeItem({ id: 'c', priority: 'medium' }),
+      makeItem({ id: 'd', priority: 'low' }),
+    ];
+    const stats = computeStats(items);
+    expect(stats.priorityCounts).toEqual({ high: 1, medium: 2, low: 1 });
+  });
+
+  it('excludes an unrecognized priority value from priorityCounts/highCount instead of folding it into medium', () => {
+    const items = [
+      makeItem({ id: 'a', priority: 'high' }),
+      makeItem({ id: 'b', priority: 'urgent' }),
+      makeItem({ id: 'c', priority: '' }),
+    ];
+    const stats = computeStats(items);
+    // total still reflects every item, regardless of priority validity.
+    expect(stats.total).toBe(3);
+    // only the genuinely 'high' item is counted — 'urgent' and '' are excluded,
+    // not silently counted as 'medium'.
     expect(stats.highCount).toBe(1);
     expect(stats.priorityCounts).toEqual({ high: 1, medium: 0, low: 0 });
   });

--- a/apps/web/src/app/(authenticated)/library/wishlist/__tests__/wishlist-filters.test.ts
+++ b/apps/web/src/app/(authenticated)/library/wishlist/__tests__/wishlist-filters.test.ts
@@ -1,0 +1,280 @@
+/**
+ * wishlist-filters — unit tests for the pure filter/sort/stats helpers
+ * that drive the /library/wishlist page (Issue #3007, Task B1).
+ *
+ * All ordering assertions use explicit ISO `addedAt` timestamps — never
+ * `Date.now()` / `new Date()` (argless) — so the suite is deterministic
+ * regardless of when/where it runs.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import type { WishlistItemDto } from '@/lib/api/schemas/wishlist.schemas';
+
+import {
+  computeStats,
+  countActiveFilters,
+  filterItems,
+  sortItems,
+  PRIORITY_RANK,
+  type WishlistFilterState,
+} from '../_lib/wishlist-filters';
+
+const GAME_NAME_MAP = new Map<string, string>([
+  ['game-1', 'Wingspan'],
+  ['game-2', 'Catan'],
+]);
+
+function makeItem(overrides: Partial<WishlistItemDto> = {}): WishlistItemDto {
+  return {
+    id: 'item-1',
+    userId: 'user-1',
+    gameId: 'game-1',
+    gameName: undefined,
+    priority: 'medium',
+    targetPrice: null,
+    notes: null,
+    addedAt: '2026-07-01T10:00:00Z',
+    updatedAt: null,
+    visibility: 'Private',
+    ...overrides,
+  };
+}
+
+function baseFilterState(overrides: Partial<WishlistFilterState> = {}): WishlistFilterState {
+  return {
+    search: '',
+    priorities: [],
+    sort: 'recent',
+    ...overrides,
+  };
+}
+
+// ─── PRIORITY_RANK ──────────────────────────────────────────────────────────
+
+describe('PRIORITY_RANK', () => {
+  it('ranks high < medium < low', () => {
+    expect(PRIORITY_RANK.high).toBeLessThan(PRIORITY_RANK.medium);
+    expect(PRIORITY_RANK.medium).toBeLessThan(PRIORITY_RANK.low);
+  });
+});
+
+// ─── filterItems ────────────────────────────────────────────────────────────
+
+describe('filterItems', () => {
+  it('matches search against item.gameName (case-insensitive)', () => {
+    const items = [
+      makeItem({ id: 'a', gameName: 'Wingspan' }),
+      makeItem({ id: 'b', gameName: 'Catan' }),
+    ];
+    const result = filterItems(items, baseFilterState({ search: 'wing' }), GAME_NAME_MAP);
+    expect(result.map(i => i.id)).toEqual(['a']);
+  });
+
+  it('falls back to gameNameMap when item.gameName is absent', () => {
+    const items = [
+      makeItem({ id: 'a', gameId: 'game-1', gameName: undefined }),
+      makeItem({ id: 'b', gameId: 'game-2', gameName: undefined }),
+    ];
+    const result = filterItems(items, baseFilterState({ search: 'catan' }), GAME_NAME_MAP);
+    expect(result.map(i => i.id)).toEqual(['b']);
+  });
+
+  it('matches search against notes (case-insensitive)', () => {
+    const items = [
+      makeItem({ id: 'a', gameName: 'Wingspan', notes: 'Waiting for Black Friday sale' }),
+      makeItem({ id: 'b', gameName: 'Catan', notes: null }),
+    ];
+    const result = filterItems(items, baseFilterState({ search: 'BLACK FRIDAY' }), GAME_NAME_MAP);
+    expect(result.map(i => i.id)).toEqual(['a']);
+  });
+
+  it('returns all items when search is empty', () => {
+    const items = [makeItem({ id: 'a' }), makeItem({ id: 'b' })];
+    const result = filterItems(items, baseFilterState(), GAME_NAME_MAP);
+    expect(result).toHaveLength(2);
+  });
+
+  it('filters by priorities (multi-select, OR-combined)', () => {
+    const items = [
+      makeItem({ id: 'a', priority: 'high' }),
+      makeItem({ id: 'b', priority: 'medium' }),
+      makeItem({ id: 'c', priority: 'low' }),
+    ];
+    const result = filterItems(
+      items,
+      baseFilterState({ priorities: ['high', 'low'] }),
+      GAME_NAME_MAP
+    );
+    expect(result.map(i => i.id)).toEqual(['a', 'c']);
+  });
+
+  it('treats an empty priorities array as "match all"', () => {
+    const items = [makeItem({ id: 'a', priority: 'high' }), makeItem({ id: 'b', priority: 'low' })];
+    const result = filterItems(items, baseFilterState({ priorities: [] }), GAME_NAME_MAP);
+    expect(result).toHaveLength(2);
+  });
+
+  it('normalizes a stray-cased priority when matching the priorities filter', () => {
+    const items = [makeItem({ id: 'a', priority: 'HIGH' })];
+    const result = filterItems(items, baseFilterState({ priorities: ['high'] }), GAME_NAME_MAP);
+    expect(result.map(i => i.id)).toEqual(['a']);
+  });
+
+  it('AND-combines search and priorities', () => {
+    const items = [
+      makeItem({ id: 'a', gameName: 'Wingspan', priority: 'high' }),
+      makeItem({ id: 'b', gameName: 'Wingspan', priority: 'low' }),
+      makeItem({ id: 'c', gameName: 'Catan', priority: 'high' }),
+    ];
+    const result = filterItems(
+      items,
+      baseFilterState({ search: 'wingspan', priorities: ['high'] }),
+      GAME_NAME_MAP
+    );
+    expect(result.map(i => i.id)).toEqual(['a']);
+  });
+});
+
+// ─── sortItems ──────────────────────────────────────────────────────────────
+
+describe('sortItems', () => {
+  it('sorts by priority rank, then addedAt desc within the same rank', () => {
+    const items = [
+      makeItem({ id: 'low-old', priority: 'low', addedAt: '2026-07-01T00:00:00Z' }),
+      makeItem({ id: 'high-old', priority: 'high', addedAt: '2026-07-01T00:00:00Z' }),
+      makeItem({ id: 'high-new', priority: 'high', addedAt: '2026-07-05T00:00:00Z' }),
+      makeItem({ id: 'medium', priority: 'medium', addedAt: '2026-07-03T00:00:00Z' }),
+    ];
+    const result = sortItems(items, 'priority');
+    expect(result.map(i => i.id)).toEqual(['high-new', 'high-old', 'medium', 'low-old']);
+  });
+
+  it('normalizes a stray-cased priority when ranking', () => {
+    const items = [
+      makeItem({ id: 'a', priority: 'Low', addedAt: '2026-07-01T00:00:00Z' }),
+      makeItem({ id: 'b', priority: 'HIGH', addedAt: '2026-07-01T00:00:00Z' }),
+    ];
+    const result = sortItems(items, 'priority');
+    expect(result.map(i => i.id)).toEqual(['b', 'a']);
+  });
+
+  it('sorts by recent (addedAt desc)', () => {
+    const items = [
+      makeItem({ id: 'a', addedAt: '2026-07-01T00:00:00Z' }),
+      makeItem({ id: 'b', addedAt: '2026-07-10T00:00:00Z' }),
+      makeItem({ id: 'c', addedAt: '2026-07-05T00:00:00Z' }),
+    ];
+    const result = sortItems(items, 'recent');
+    expect(result.map(i => i.id)).toEqual(['b', 'c', 'a']);
+  });
+
+  it('sorts by oldest (addedAt asc)', () => {
+    const items = [
+      makeItem({ id: 'a', addedAt: '2026-07-01T00:00:00Z' }),
+      makeItem({ id: 'b', addedAt: '2026-07-10T00:00:00Z' }),
+      makeItem({ id: 'c', addedAt: '2026-07-05T00:00:00Z' }),
+    ];
+    const result = sortItems(items, 'oldest');
+    expect(result.map(i => i.id)).toEqual(['a', 'c', 'b']);
+  });
+
+  it('sorts alphabetically by gameName', () => {
+    const items = [
+      makeItem({ id: 'a', gameName: 'Wingspan' }),
+      makeItem({ id: 'b', gameName: 'Azul' }),
+      makeItem({ id: 'c', gameName: 'Catan' }),
+    ];
+    const result = sortItems(items, 'alpha');
+    expect(result.map(i => i.id)).toEqual(['b', 'c', 'a']);
+  });
+
+  it('sorts by price desc, with null targetPrice last', () => {
+    const items = [
+      makeItem({ id: 'no-price', targetPrice: null }),
+      makeItem({ id: 'cheap', targetPrice: 10 }),
+      makeItem({ id: 'expensive', targetPrice: 50 }),
+    ];
+    const result = sortItems(items, 'price');
+    expect(result.map(i => i.id)).toEqual(['expensive', 'cheap', 'no-price']);
+  });
+
+  it('does not mutate the input array', () => {
+    const items = [
+      makeItem({ id: 'a', addedAt: '2026-07-01T00:00:00Z' }),
+      makeItem({ id: 'b', addedAt: '2026-07-10T00:00:00Z' }),
+    ];
+    const original = [...items];
+    sortItems(items, 'recent');
+    expect(items).toEqual(original);
+  });
+});
+
+// ─── computeStats ───────────────────────────────────────────────────────────
+
+describe('computeStats', () => {
+  it('returns zeroed stats for an empty list', () => {
+    expect(computeStats([])).toEqual({
+      total: 0,
+      highCount: 0,
+      totalSpend: 0,
+      priorityCounts: { high: 0, medium: 0, low: 0 },
+    });
+  });
+
+  it('counts total, highCount, and priorityCounts per bucket', () => {
+    const items = [
+      makeItem({ id: 'a', priority: 'high' }),
+      makeItem({ id: 'b', priority: 'high' }),
+      makeItem({ id: 'c', priority: 'medium' }),
+      makeItem({ id: 'd', priority: 'low' }),
+    ];
+    const stats = computeStats(items);
+    expect(stats.total).toBe(4);
+    expect(stats.highCount).toBe(2);
+    expect(stats.priorityCounts).toEqual({ high: 2, medium: 1, low: 1 });
+  });
+
+  it('sums targetPrice, skipping null entries', () => {
+    const items = [
+      makeItem({ id: 'a', targetPrice: 10.5 }),
+      makeItem({ id: 'b', targetPrice: null }),
+      makeItem({ id: 'c', targetPrice: 24.5 }),
+    ];
+    expect(computeStats(items).totalSpend).toBe(35);
+  });
+
+  it('normalizes a stray-cased priority when bucketing', () => {
+    const items = [makeItem({ id: 'a', priority: 'HIGH' })];
+    const stats = computeStats(items);
+    expect(stats.highCount).toBe(1);
+    expect(stats.priorityCounts).toEqual({ high: 1, medium: 0, low: 0 });
+  });
+});
+
+// ─── countActiveFilters ─────────────────────────────────────────────────────
+
+describe('countActiveFilters', () => {
+  it('returns 0 when no filters are active', () => {
+    expect(countActiveFilters(baseFilterState())).toBe(0);
+  });
+
+  it('counts a non-empty search as 1', () => {
+    expect(countActiveFilters(baseFilterState({ search: 'wingspan' }))).toBe(1);
+  });
+
+  it('treats a whitespace-only search as inactive', () => {
+    expect(countActiveFilters(baseFilterState({ search: '   ' }))).toBe(0);
+  });
+
+  it('counts any non-empty priorities selection as 1, regardless of size', () => {
+    expect(countActiveFilters(baseFilterState({ priorities: ['high'] }))).toBe(1);
+    expect(countActiveFilters(baseFilterState({ priorities: ['high', 'low'] }))).toBe(1);
+  });
+
+  it('sums independent active categories', () => {
+    expect(countActiveFilters(baseFilterState({ search: 'wingspan', priorities: ['high'] }))).toBe(
+      2
+    );
+  });
+});

--- a/apps/web/src/app/(authenticated)/library/wishlist/_components/WishlistStats.tsx
+++ b/apps/web/src/app/(authenticated)/library/wishlist/_components/WishlistStats.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import type { JSX } from 'react';
+
+import { useTranslation } from '@/hooks/useTranslation';
+
+import type { Priority } from '../_lib/wishlist-filters';
+
+/**
+ * WishlistStats — header "qstat" line for /library/wishlist (Issue #3007,
+ * Task B5).
+ *
+ * Mirrors `admin-mockups/design_files/sp4-library-wishlist-ui.jsx`'s
+ * `Header` component `lw-qstat` span (~line 423):
+ * `{n} giochi · {n} alta priorità · spesa stimata {€}`.
+ *
+ * Consumes the exact return shape of `computeStats()` from Task B1
+ * (`_lib/wishlist-filters.ts`) as its `stats` prop. `priorityCounts` is
+ * accepted here for shape-parity with `computeStats`'s return type — the
+ * per-bucket breakdown is rendered by `WishlistToolbar`'s priority chips,
+ * not by this line.
+ */
+
+export interface WishlistStatsProps {
+  stats: {
+    total: number;
+    highCount: number;
+    totalSpend: number;
+    priorityCounts: Record<Priority, number>;
+  };
+}
+
+export function WishlistStats({ stats }: WishlistStatsProps): JSX.Element {
+  const { t, formatNumber } = useTranslation();
+
+  const formattedSpend = formatNumber(stats.totalSpend, {
+    style: 'currency',
+    currency: 'EUR',
+  });
+
+  return (
+    <span
+      className="flex flex-wrap items-center gap-2 text-sm text-muted-foreground"
+      data-testid="wishlist-stats"
+    >
+      <span className="font-semibold text-foreground">
+        {t('pages.library.wishlist.stats.games', { count: stats.total })}
+      </span>
+      <span aria-hidden="true">·</span>
+      <span className="font-semibold text-foreground">
+        {t('pages.library.wishlist.stats.highPriority', { count: stats.highCount })}
+      </span>
+      <span aria-hidden="true">·</span>
+      <span>{t('pages.library.wishlist.stats.estimatedSpend', { amount: formattedSpend })}</span>
+    </span>
+  );
+}

--- a/apps/web/src/app/(authenticated)/library/wishlist/_components/WishlistToolbar.tsx
+++ b/apps/web/src/app/(authenticated)/library/wishlist/_components/WishlistToolbar.tsx
@@ -1,0 +1,304 @@
+'use client';
+
+import { useEffect, useRef, useState, type JSX } from 'react';
+
+import { Loader2, Search as SearchIcon, X } from 'lucide-react';
+
+import { Badge } from '@/components/ui/data-display/badge';
+import {
+  Popover,
+  PopoverClose,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/overlays/popover';
+import { Button } from '@/components/ui/primitives/button';
+import { Input } from '@/components/ui/primitives/input';
+import { useTranslation } from '@/hooks/useTranslation';
+import { cn } from '@/lib/utils';
+
+import {
+  countActiveFilters,
+  type Priority,
+  type WishlistFilterState,
+  type WishlistSort,
+} from '../_lib/wishlist-filters';
+
+/** Debounce delay (ms) applied to search input before it is committed via `onChange`. */
+const SEARCH_DEBOUNCE_MS = 400;
+
+const PRIORITY_ORDER: readonly Priority[] = ['high', 'medium', 'low'];
+
+const SORT_OPTIONS: readonly WishlistSort[] = ['priority', 'recent', 'oldest', 'alpha', 'price'];
+
+/**
+ * Priority chip color classes. Only `destructive` and `muted` are registered
+ * as Tailwind utilities in `@theme inline` (`globals.css`) — `--color-warning`
+ * / `--color-success` live in `design-tokens.css`'s plain `:root` block, NOT
+ * inside `@theme`/`@theme inline`, so `bg-warning`/`text-warning` never
+ * generate real utility classes (dead no-op, same class of bug as the
+ * `--e-*` finding in the FU-2 cleanup — see MEMORY.md). `medium` therefore
+ * falls back to a neutral `text-foreground` treatment instead of a
+ * non-existent "warning" token.
+ */
+const PRIORITY_CHIP_CLASSNAMES: Record<Priority, string> = {
+  high: 'border-destructive/40 text-destructive hover:bg-destructive/10 aria-checked:border-destructive aria-checked:bg-destructive/10',
+  medium:
+    'border-border text-foreground hover:bg-muted aria-checked:border-foreground/60 aria-checked:bg-muted',
+  low: 'border-border text-muted-foreground hover:bg-muted aria-checked:border-muted-foreground aria-checked:bg-muted',
+};
+
+const CHIP_BASE_CLASSNAME =
+  'inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-semibold transition-colors';
+
+export interface WishlistToolbarProps {
+  state: WishlistFilterState;
+  onChange: (next: WishlistFilterState) => void;
+  priorityCounts: Record<Priority, number>;
+  totalCount: number;
+  resultCount: number;
+  onClearAll: () => void;
+}
+
+/**
+ * Filter/sort toolbar for /library/wishlist (Issue #3007, Task B5).
+ *
+ * Matches `admin-mockups/design_files/sp4-library-wishlist-ui.jsx`'s
+ * `Toolbar`: `[ search ] [ Tutti | Alta | Media | Bassa chips ] [ Ordina ]`,
+ * plus a conditional summary bar (`countActiveFilters(state) > 0`) showing
+ * the active-filter count, the filtered/total result count, and a "Cancella
+ * filtri" reset.
+ *
+ * Search is debounced 400ms client-side (`localSearch` state) — mirrors
+ * `toolkit/history/_components/HistoryToolbar.tsx`'s pattern — so `onChange`
+ * only fires once typing pauses; a "Cercando…" indicator is shown while the
+ * debounce is pending.
+ */
+export function WishlistToolbar({
+  state,
+  onChange,
+  priorityCounts,
+  totalCount,
+  resultCount,
+  onClearAll,
+}: WishlistToolbarProps): JSX.Element {
+  const { t } = useTranslation();
+
+  const [localSearch, setLocalSearch] = useState(state.search);
+  const [isSearching, setIsSearching] = useState(false);
+  const searchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const stateRef = useRef(state);
+  const onChangeRef = useRef(onChange);
+
+  useEffect(() => {
+    stateRef.current = state;
+  }, [state]);
+
+  useEffect(() => {
+    onChangeRef.current = onChange;
+  }, [onChange]);
+
+  useEffect(() => {
+    setLocalSearch(state.search);
+  }, [state.search]);
+
+  useEffect(
+    () => () => {
+      if (searchTimerRef.current) clearTimeout(searchTimerRef.current);
+    },
+    []
+  );
+
+  const commitSearch = (value: string) => {
+    if (searchTimerRef.current) {
+      clearTimeout(searchTimerRef.current);
+      searchTimerRef.current = null;
+    }
+    setIsSearching(false);
+    onChangeRef.current({ ...stateRef.current, search: value });
+  };
+
+  const handleSearchInput = (value: string) => {
+    setLocalSearch(value);
+    if (searchTimerRef.current) clearTimeout(searchTimerRef.current);
+    setIsSearching(true);
+    searchTimerRef.current = setTimeout(() => {
+      searchTimerRef.current = null;
+      commitSearch(value);
+    }, SEARCH_DEBOUNCE_MS);
+  };
+
+  const handleClearSearch = () => {
+    setLocalSearch('');
+    commitSearch('');
+  };
+
+  const togglePriority = (priority: Priority) => {
+    const next = state.priorities.includes(priority)
+      ? state.priorities.filter(p => p !== priority)
+      : [...state.priorities, priority];
+    onChange({ ...state, priorities: next });
+  };
+
+  const clearPriorities = () => onChange({ ...state, priorities: [] });
+
+  const allActive = state.priorities.length === 0;
+  const activeCount = countActiveFilters(state);
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex flex-col gap-3 lg:flex-row lg:flex-wrap lg:items-center">
+        {/* search */}
+        <div className="relative min-w-[240px] flex-1">
+          <SearchIcon
+            className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+            aria-hidden="true"
+          />
+          <Input
+            type="search"
+            value={localSearch}
+            onChange={e => handleSearchInput(e.target.value)}
+            onKeyDown={e => {
+              if (e.key === 'Escape') handleClearSearch();
+            }}
+            placeholder={t('pages.library.wishlist.filters.searchPlaceholder')}
+            aria-label={t('pages.library.wishlist.filters.searchAriaLabel')}
+            className="pl-9 pr-10"
+          />
+          <div className="absolute right-1 top-1/2 flex -translate-y-1/2 items-center gap-1">
+            {isSearching && (
+              <span className="flex items-center gap-1 pr-1 text-xs text-muted-foreground">
+                <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+                {t('pages.library.wishlist.filters.searching')}
+              </span>
+            )}
+            {localSearch && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="h-7 w-7"
+                onClick={handleClearSearch}
+                aria-label={t('pages.library.wishlist.filters.clearSearch')}
+              >
+                <X className="h-3.5 w-3.5" />
+              </Button>
+            )}
+          </div>
+        </div>
+
+        {/* priority chips */}
+        <div
+          className="flex flex-wrap items-center gap-2"
+          role="group"
+          aria-label={t('pages.library.wishlist.filters.priorityGroupAria')}
+        >
+          <button
+            type="button"
+            role="checkbox"
+            aria-checked={allActive}
+            aria-label={t('pages.library.wishlist.filters.all')}
+            onClick={clearPriorities}
+            className={cn(
+              CHIP_BASE_CLASSNAME,
+              allActive
+                ? 'border-primary bg-primary/10 text-primary'
+                : 'border-border text-muted-foreground hover:bg-muted'
+            )}
+          >
+            {t('pages.library.wishlist.filters.all')}
+            <span className="text-[10px] font-bold opacity-70">{totalCount}</span>
+          </button>
+          {PRIORITY_ORDER.map(priority => {
+            const active = state.priorities.includes(priority);
+            return (
+              <button
+                key={priority}
+                type="button"
+                role="checkbox"
+                aria-checked={active}
+                aria-label={t(`pages.library.wishlist.priority.${priority}`)}
+                onClick={() => togglePriority(priority)}
+                className={cn(CHIP_BASE_CLASSNAME, PRIORITY_CHIP_CLASSNAMES[priority])}
+              >
+                {t(`pages.library.wishlist.priority.${priority}`)}
+                <span className="text-[10px] font-bold opacity-70">{priorityCounts[priority]}</span>
+              </button>
+            );
+          })}
+        </div>
+
+        {/* sort */}
+        <div className="lg:ml-auto">
+          <Popover>
+            <PopoverTrigger asChild>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                aria-label={t('pages.library.wishlist.filters.sortBy')}
+                className="gap-1.5"
+              >
+                <span aria-hidden="true">↕</span>
+                {t(`pages.library.wishlist.filters.sortOptions.${state.sort}`)}
+                <span aria-hidden="true" className="text-[8px] opacity-70">
+                  ▼
+                </span>
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent
+              align="end"
+              className="w-56 p-2"
+              role="listbox"
+              aria-label={t('pages.library.wishlist.filters.sortAria')}
+            >
+              <div className="px-2 py-1 text-xs font-semibold text-muted-foreground">
+                {t('pages.library.wishlist.filters.sort')}
+              </div>
+              {SORT_OPTIONS.map(opt => {
+                const selected = state.sort === opt;
+                return (
+                  <PopoverClose key={opt} asChild>
+                    <button
+                      type="button"
+                      role="option"
+                      aria-selected={selected}
+                      onClick={() => onChange({ ...state, sort: opt })}
+                      className={cn(
+                        'flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-sm hover:bg-muted',
+                        selected && 'font-semibold text-foreground'
+                      )}
+                    >
+                      <span aria-hidden="true" className="w-3">
+                        {selected ? '●' : ''}
+                      </span>
+                      {t(`pages.library.wishlist.filters.sortOptions.${opt}`)}
+                    </button>
+                  </PopoverClose>
+                );
+              })}
+            </PopoverContent>
+          </Popover>
+        </div>
+      </div>
+
+      {/* summary bar */}
+      {activeCount > 0 && (
+        <div className="flex flex-wrap items-center gap-2 rounded-lg border border-border bg-muted/40 px-3 py-2 text-sm">
+          <Badge variant="secondary" className="gap-1">
+            {t('pages.library.wishlist.summary.activeFilters', { n: activeCount })}
+          </Badge>
+          <span className="text-muted-foreground" aria-hidden="true">
+            ·
+          </span>
+          <span className="text-muted-foreground">
+            {t('pages.library.wishlist.summary.results', { n: resultCount, total: totalCount })}
+          </span>
+          <span className="flex-1" />
+          <Button type="button" variant="ghost" size="sm" onClick={onClearAll}>
+            {t('pages.library.wishlist.summary.clearAll')}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/(authenticated)/library/wishlist/_components/WishlistToolbar.tsx
+++ b/apps/web/src/app/(authenticated)/library/wishlist/_components/WishlistToolbar.tsx
@@ -28,6 +28,18 @@ const SEARCH_DEBOUNCE_MS = 400;
 
 const PRIORITY_ORDER: readonly Priority[] = ['high', 'medium', 'low'];
 
+/**
+ * Per-priority icon, matching `admin-mockups/design_files/sp4-library-wishlist.jsx`'s
+ * `PRIO` map (`high` → 🔥, `medium` → ⭐, `low` → ⬇️). Rendered as an
+ * `aria-hidden="true"` span before the label so it's decorative only — the
+ * accessible name still comes from `aria-label`.
+ */
+const PRIORITY_ICONS: Record<Priority, string> = {
+  high: '🔥',
+  medium: '⭐',
+  low: '⬇️',
+};
+
 const SORT_OPTIONS: readonly WishlistSort[] = ['priority', 'recent', 'oldest', 'alpha', 'price'];
 
 /**
@@ -220,6 +232,7 @@ export function WishlistToolbar({
                 onClick={() => togglePriority(priority)}
                 className={cn(CHIP_BASE_CLASSNAME, PRIORITY_CHIP_CLASSNAMES[priority])}
               >
+                <span aria-hidden="true">{PRIORITY_ICONS[priority]}</span>
                 {t(`pages.library.wishlist.priority.${priority}`)}
                 <span className="text-[10px] font-bold opacity-70">{priorityCounts[priority]}</span>
               </button>

--- a/apps/web/src/app/(authenticated)/library/wishlist/_lib/wishlist-filters.ts
+++ b/apps/web/src/app/(authenticated)/library/wishlist/_lib/wishlist-filters.ts
@@ -26,17 +26,45 @@ export interface WishlistFilterState {
 }
 
 /**
- * Normalizes a wishlist item's raw `priority` string (case-insensitive) into
- * a known `Priority` bucket. Falls back to `'medium'` for unrecognized
- * values so a stray/unexpected value never crashes ranking or bucketing.
+ * Case-insensitively matches a raw `priority` string against a known
+ * `Priority` bucket. Returns `undefined` when the value isn't one of
+ * high/medium/low — the wishlist DTO only types `priority` as `z.string()`,
+ * not an enum, so a genuinely malformed value is possible and must be
+ * distinguishable from a real `'medium'`.
  */
-function normalizePriority(item: WishlistItemDto): Priority {
-  const value = item.priority.toLowerCase();
-  if (value === 'high' || value === 'medium' || value === 'low') return value;
-  return 'medium';
+function matchPriority(value: string): Priority | undefined {
+  const normalized = value.toLowerCase();
+  if (normalized === 'high' || normalized === 'medium' || normalized === 'low') return normalized;
+  return undefined;
 }
 
-/** Resolves the display name used for search matching and alpha sort. */
+/**
+ * Normalizes a wishlist item's raw `priority` string (case-insensitive) into
+ * a known `Priority` bucket, for ranking/filtering purposes. Falls back to
+ * `'medium'` for unrecognized values so a stray/unexpected value never
+ * crashes `sortItems('priority')` ranking or the priority-filter match in
+ * `filterItems`.
+ *
+ * NOTE: `computeStats.priorityCounts` deliberately does NOT use this
+ * fallback (it calls `matchPriority` directly) — an unrecognized value is
+ * excluded from the displayed counts rather than silently inflating the
+ * `medium` bucket.
+ */
+function normalizePriority(item: WishlistItemDto): Priority {
+  return matchPriority(item.priority) ?? 'medium';
+}
+
+/**
+ * Resolves the display name used for search matching in `filterItems`
+ * (falls back to the game catalog map when the wishlist item has no
+ * denormalized `gameName`).
+ *
+ * NOT used by `sortItems`'s `'alpha'` branch: that sorts on `item.gameName`
+ * directly and never consults `gameNameMap`, so an item with no
+ * denormalized name sorts as `''` there regardless of what this function
+ * would resolve. Callers that need alpha-sort to reflect catalog-resolved
+ * names must pre-resolve them before calling `sortItems`.
+ */
 function resolveGameName(item: WishlistItemDto, gameNameMap: Map<string, string>): string {
   return item.gameName ?? gameNameMap.get(item.gameId) ?? '';
 }
@@ -100,7 +128,15 @@ export function sortItems(items: WishlistItemDto[], sort: WishlistSort): Wishlis
   return sorted;
 }
 
-/** Header stats for the wishlist page: totals, high-priority count, sum of target prices, and per-bucket priority counts. */
+/**
+ * Header stats for the wishlist page: totals, high-priority count, sum of
+ * target prices, and per-bucket priority counts.
+ *
+ * A `priority` value that doesn't match high/medium/low (case-insensitive)
+ * is excluded from `priorityCounts`/`highCount` — it is NOT folded into
+ * `medium`. This keeps the displayed counts an honest reflection of known
+ * buckets; `total` still reflects every item regardless of its priority.
+ */
 export function computeStats(items: WishlistItemDto[]): {
   total: number;
   highCount: number;
@@ -111,7 +147,8 @@ export function computeStats(items: WishlistItemDto[]): {
   let totalSpend = 0;
 
   for (const item of items) {
-    priorityCounts[normalizePriority(item)] += 1;
+    const bucket = matchPriority(item.priority);
+    if (bucket) priorityCounts[bucket] += 1;
     if (item.targetPrice != null) totalSpend += item.targetPrice;
   }
 

--- a/apps/web/src/app/(authenticated)/library/wishlist/_lib/wishlist-filters.ts
+++ b/apps/web/src/app/(authenticated)/library/wishlist/_lib/wishlist-filters.ts
@@ -1,0 +1,132 @@
+/**
+ * wishlist-filters — pure filter/sort/stats helpers for /library/wishlist.
+ *
+ * Issue #3007 (Task B1). The wishlist endpoint returns a plain array with no
+ * search/priority-filter/sort support, so the entire wishlist experience
+ * (search, priority filter, sort, header stats) is computed client-side from
+ * these pure functions. Later tasks (B3-B6) build the UI on top of these
+ * types/functions — keep the exported names/signatures stable.
+ *
+ * No React, no i18n.
+ */
+
+import type { WishlistItemDto } from '@/lib/api/schemas/wishlist.schemas';
+
+export type WishlistSort = 'priority' | 'recent' | 'oldest' | 'alpha' | 'price';
+
+export type Priority = 'high' | 'medium' | 'low';
+
+/** Sort rank per priority bucket — lower ranks first (high wins). */
+export const PRIORITY_RANK: Record<Priority, number> = { high: 0, medium: 1, low: 2 };
+
+export interface WishlistFilterState {
+  search: string;
+  priorities: Priority[];
+  sort: WishlistSort;
+}
+
+/**
+ * Normalizes a wishlist item's raw `priority` string (case-insensitive) into
+ * a known `Priority` bucket. Falls back to `'medium'` for unrecognized
+ * values so a stray/unexpected value never crashes ranking or bucketing.
+ */
+function normalizePriority(item: WishlistItemDto): Priority {
+  const value = item.priority.toLowerCase();
+  if (value === 'high' || value === 'medium' || value === 'low') return value;
+  return 'medium';
+}
+
+/** Resolves the display name used for search matching and alpha sort. */
+function resolveGameName(item: WishlistItemDto, gameNameMap: Map<string, string>): string {
+  return item.gameName ?? gameNameMap.get(item.gameId) ?? '';
+}
+
+/** Filters items by search text (gameName + notes) and priorities. All criteria are AND-combined; values within `priorities` are OR-combined. */
+export function filterItems(
+  items: WishlistItemDto[],
+  f: WishlistFilterState,
+  gameNameMap: Map<string, string>
+): WishlistItemDto[] {
+  const search = f.search.trim().toLowerCase();
+  const prioritySet = new Set(f.priorities);
+
+  return items.filter(item => {
+    if (search) {
+      const haystack = [resolveGameName(item, gameNameMap), item.notes ?? '']
+        .join(' ')
+        .toLowerCase();
+      if (!haystack.includes(search)) return false;
+    }
+
+    if (prioritySet.size > 0 && !prioritySet.has(normalizePriority(item))) return false;
+
+    return true;
+  });
+}
+
+/** Returns a new, sorted array (input is never mutated). */
+export function sortItems(items: WishlistItemDto[], sort: WishlistSort): WishlistItemDto[] {
+  const sorted = [...items];
+
+  switch (sort) {
+    case 'priority':
+      sorted.sort((a, b) => {
+        const rankDiff = PRIORITY_RANK[normalizePriority(a)] - PRIORITY_RANK[normalizePriority(b)];
+        if (rankDiff !== 0) return rankDiff;
+        return new Date(b.addedAt).getTime() - new Date(a.addedAt).getTime();
+      });
+      break;
+    case 'recent':
+      sorted.sort((a, b) => new Date(b.addedAt).getTime() - new Date(a.addedAt).getTime());
+      break;
+    case 'oldest':
+      sorted.sort((a, b) => new Date(a.addedAt).getTime() - new Date(b.addedAt).getTime());
+      break;
+    case 'alpha':
+      sorted.sort((a, b) => (a.gameName ?? '').localeCompare(b.gameName ?? ''));
+      break;
+    case 'price':
+      sorted.sort((a, b) => {
+        if (a.targetPrice == null && b.targetPrice == null) return 0;
+        if (a.targetPrice == null) return 1;
+        if (b.targetPrice == null) return -1;
+        return b.targetPrice - a.targetPrice;
+      });
+      break;
+    default:
+      break;
+  }
+
+  return sorted;
+}
+
+/** Header stats for the wishlist page: totals, high-priority count, sum of target prices, and per-bucket priority counts. */
+export function computeStats(items: WishlistItemDto[]): {
+  total: number;
+  highCount: number;
+  totalSpend: number;
+  priorityCounts: Record<Priority, number>;
+} {
+  const priorityCounts: Record<Priority, number> = { high: 0, medium: 0, low: 0 };
+  let totalSpend = 0;
+
+  for (const item of items) {
+    priorityCounts[normalizePriority(item)] += 1;
+    if (item.targetPrice != null) totalSpend += item.targetPrice;
+  }
+
+  return {
+    total: items.length,
+    highCount: priorityCounts.high,
+    totalSpend,
+    priorityCounts,
+  };
+}
+
+/** Counts how many filter *categories* are active (search, priorities). `sort` is never counted. */
+export function countActiveFilters(f: WishlistFilterState): number {
+  let count = 0;
+  if (f.search.trim() !== '') count += 1;
+  if (f.priorities.length > 0) count += 1;
+  return count;
+}

--- a/apps/web/src/app/(authenticated)/library/wishlist/page.tsx
+++ b/apps/web/src/app/(authenticated)/library/wishlist/page.tsx
@@ -1,19 +1,22 @@
 'use client';
 
 /**
- * Wishlist Page (Issue #4114)
+ * Wishlist Page — orchestrator (Issue #3007, Task B6).
  *
- * Displays the current user's wishlist.
- * - Grid of WishlistCard components
- * - Add to Wishlist button with dialog
- * - Empty state when no items
- * - Loading skeleton while fetching
- * - Remove item action
+ * Assembles the pure filter/sort/stats pipeline (`_lib/wishlist-filters`,
+ * Task B1) with the presentational components built in B3-B5
+ * (`WishlistStats`, `WishlistToolbar`, `MeepleWishlistCard`,
+ * `AddToWishlistDialog`) into the full `/library/wishlist` experience. The
+ * wishlist endpoint returns a plain array with no search/filter/sort
+ * support, so the entire experience runs client-side over the full list.
+ *
+ * Mockup: `admin-mockups/design_files/sp4-library-wishlist-ui.jsx`.
  */
 
-import { useMemo } from 'react';
+import { useMemo, useState, type JSX } from 'react';
 
-import { Heart, PlusCircle } from 'lucide-react';
+import { AlertCircle, PlusCircle } from 'lucide-react';
+import Link from 'next/link';
 
 import { HubPageContainer } from '@/components/layout/PageContainer';
 import { Skeleton } from '@/components/ui/feedback/skeleton';
@@ -22,120 +25,266 @@ import { AddToWishlistDialog } from '@/components/wishlist/AddToWishlistDialog';
 import { MeepleWishlistCard } from '@/components/wishlist/MeepleWishlistCard';
 import { useLibrary } from '@/hooks/queries/useLibrary';
 import { useRemoveFromWishlist, useWishlist } from '@/hooks/queries/useWishlist';
+import { useTranslation } from '@/hooks/useTranslation';
+import type { WishlistItemDto } from '@/lib/api/schemas/wishlist.schemas';
+import { cn } from '@/lib/utils';
+
+import { WishlistStats } from './_components/WishlistStats';
+import { WishlistToolbar } from './_components/WishlistToolbar';
+import {
+  computeStats,
+  countActiveFilters,
+  filterItems,
+  sortItems,
+  type Priority,
+  type WishlistFilterState,
+} from './_lib/wishlist-filters';
 
 // ============================================================================
-// Skeleton
+// Constants
 // ============================================================================
 
-function WishlistSkeleton() {
-  return (
-    <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
-      {Array.from({ length: 8 }).map((_, i) => (
-        <div key={i} className="rounded-xl border bg-card shadow p-4 space-y-3">
-          <div className="flex items-center justify-between">
-            <Skeleton className="h-4 w-32" />
-            <Skeleton className="h-5 w-16 rounded-full" />
-          </div>
-          <Skeleton className="h-4 w-24" />
-          <Skeleton className="h-4 w-40" />
-          <Skeleton className="h-4 w-28" />
-        </div>
-      ))}
-    </div>
-  );
+/** Batch size for the library fetch that resolves the gameId → gameTitle map. */
+const LIBRARY_BATCH_LIMIT = 500;
+
+const DEFAULT_FILTER_STATE: WishlistFilterState = {
+  search: '',
+  priorities: [],
+  sort: 'priority',
+};
+
+interface LibraryTab {
+  id: 'library' | 'wishlist';
+  href: string;
 }
 
-// ============================================================================
-// Empty State
-// ============================================================================
-
-function WishlistEmpty({ onAdd }: { onAdd: React.ReactNode }) {
-  return (
-    <div className="flex flex-col items-center justify-center py-20 gap-4 text-center">
-      <Heart className="h-12 w-12 text-muted-foreground/40" />
-      <div>
-        <p className="text-lg font-semibold text-foreground">Your wishlist is empty</p>
-        <p className="text-sm text-muted-foreground mt-1">
-          Start adding games you want to play or own.
-        </p>
-      </div>
-      {onAdd}
-    </div>
-  );
-}
+const LIBRARY_TABS: LibraryTab[] = [
+  { id: 'library', href: '/library' },
+  { id: 'wishlist', href: '/library/wishlist' },
+];
 
 // ============================================================================
 // Page
 // ============================================================================
 
-export default function WishlistPage() {
-  const { data: items, isLoading, isError } = useWishlist();
-  const { mutate: removeItem } = useRemoveFromWishlist();
-  const { data: libraryData } = useLibrary();
+export default function WishlistPage(): JSX.Element {
+  const { t } = useTranslation();
 
-  // Build a gameId → gameTitle lookup from the user's library
+  const [filterState, setFilterState] = useState<WishlistFilterState>(DEFAULT_FILTER_STATE);
+  /** The item currently open in the edit dialog, or null when no edit dialog is open. */
+  const [editingItem, setEditingItem] = useState<WishlistItemDto | null>(null);
+
+  const { data, isLoading, isError, refetch } = useWishlist();
+  const { data: libraryData } = useLibrary({ pageSize: LIBRARY_BATCH_LIMIT });
+  const { mutate: removeItem } = useRemoveFromWishlist();
+
+  // Build a gameId → gameTitle lookup from the user's library, used as a
+  // fallback when a wishlist item has no denormalized `gameName`.
   const gameNameMap = useMemo(() => {
     const map = new Map<string, string>();
-    if (libraryData?.items) {
-      for (const entry of libraryData.items) {
-        map.set(entry.gameId, entry.gameTitle);
-      }
+    for (const entry of libraryData?.items ?? []) {
+      map.set(entry.gameId, entry.gameTitle);
     }
     return map;
   }, [libraryData?.items]);
 
-  function handleRemove(id: string) {
-    removeItem(id);
-  }
-
-  const addButton = (
-    <AddToWishlistDialog
-      trigger={
-        <Button>
-          <PlusCircle className="h-4 w-4" />
-          Add to Wishlist
-        </Button>
-      }
-    />
+  const allItems = useMemo(() => data ?? [], [data]);
+  const stats = useMemo(() => computeStats(allItems), [allItems]);
+  const filtered = useMemo(
+    () => sortItems(filterItems(allItems, filterState, gameNameMap), filterState.sort),
+    [allItems, filterState, gameNameMap]
   );
+  const activeFilterCount = countActiveFilters(filterState);
+
+  const hasItems = allItems.length > 0;
+  const noFilteredResults = hasItems && filtered.length === 0 && activeFilterCount > 0;
+
+  const handleClearAll = () => setFilterState(DEFAULT_FILTER_STATE);
+
+  const handleFilterPriority = (priority: Priority) => {
+    setFilterState(prev =>
+      prev.priorities.includes(priority)
+        ? prev
+        : { ...prev, priorities: [...prev.priorities, priority] }
+    );
+  };
 
   return (
-    <HubPageContainer className="py-6 space-y-6">
-      {/* Header */}
-      <div className="flex items-center justify-between">
+    <HubPageContainer className="flex flex-col gap-6">
+      {/* breadcrumb */}
+      <nav
+        aria-label={t('pages.library.wishlist.hero.breadcrumbWishlist')}
+        className="flex items-center gap-1.5 text-sm text-muted-foreground"
+      >
+        <Link href="/library" className="hover:text-foreground">
+          {t('pages.library.wishlist.hero.breadcrumbLibrary')}
+        </Link>
+        <span aria-hidden="true">›</span>
+        <span className="font-medium text-foreground">
+          {t('pages.library.wishlist.hero.breadcrumbWishlist')}
+        </span>
+      </nav>
+
+      {/* hero */}
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div>
-          <h1 className="text-2xl font-bold">My Wishlist</h1>
-          {!isLoading && !isError && items && items.length > 0 && (
-            <p className="text-sm text-muted-foreground mt-1">
-              {items.length} {items.length === 1 ? 'game' : 'games'}
-            </p>
-          )}
+          <h1 className="font-quicksand text-2xl font-bold text-foreground sm:text-3xl">
+            {t('pages.library.wishlist.hero.title')}
+          </h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            {t('pages.library.wishlist.hero.subtitle')}
+          </p>
         </div>
-        {!isLoading && !isError && items && items.length > 0 && addButton}
+        <AddToWishlistDialog
+          mode="add"
+          trigger={
+            <Button type="button" className="gap-1.5">
+              <PlusCircle className="h-4 w-4" aria-hidden="true" />
+              {t('pages.library.wishlist.hero.addCta')}
+            </Button>
+          }
+        />
       </div>
 
-      {/* Content */}
-      {isLoading && <WishlistSkeleton />}
+      {/* library / wishlist tabs */}
+      <nav
+        aria-label={t('pages.library.wishlist.hero.tabsAria')}
+        className="flex gap-1 overflow-x-auto border-b border-border"
+      >
+        {LIBRARY_TABS.map(tab => (
+          <Link
+            key={tab.id}
+            href={tab.href}
+            aria-current={tab.id === 'wishlist' ? 'page' : undefined}
+            className={cn(
+              'flex shrink-0 items-center gap-1.5 border-b-2 px-3 py-2 text-sm font-medium transition-colors',
+              tab.id === 'wishlist'
+                ? 'border-primary text-primary'
+                : 'border-transparent text-muted-foreground hover:text-foreground'
+            )}
+          >
+            {t(`pages.library.wishlist.hero.tab${tab.id === 'library' ? 'Library' : 'Wishlist'}`)}
+          </Link>
+        ))}
+      </nav>
 
-      {isError && (
-        <div className="py-10 text-center text-sm text-destructive">
-          Failed to load wishlist. Please try again.
+      <WishlistStats stats={stats} />
+
+      {!isLoading && !isError && hasItems && (
+        <WishlistToolbar
+          state={filterState}
+          onChange={setFilterState}
+          priorityCounts={stats.priorityCounts}
+          totalCount={stats.total}
+          resultCount={filtered.length}
+          onClearAll={handleClearAll}
+        />
+      )}
+
+      {/* loading */}
+      {isLoading && (
+        <div
+          role="status"
+          aria-busy="true"
+          aria-label={t('pages.library.wishlist.loading.ariaLabel')}
+          className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3"
+        >
+          {Array.from({ length: 6 }).map((_, i) => (
+            <Skeleton key={i} className="h-48 w-full rounded-xl" />
+          ))}
         </div>
       )}
 
-      {!isLoading && !isError && items && items.length === 0 && <WishlistEmpty onAdd={addButton} />}
+      {/* error */}
+      {!isLoading && isError && (
+        <div
+          role="alert"
+          className="flex flex-wrap items-center gap-3 rounded-lg border border-destructive/40 bg-destructive/10 px-4 py-3 text-sm text-destructive"
+        >
+          <AlertCircle className="h-4 w-4 shrink-0" aria-hidden="true" />
+          <span className="flex-1">{t('pages.library.wishlist.error.message')}</span>
+          <Button type="button" variant="outline" size="sm" onClick={() => void refetch()}>
+            {t('pages.library.wishlist.error.retry')}
+          </Button>
+        </div>
+      )}
 
-      {!isLoading && !isError && items && items.length > 0 && (
-        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
-          {items.map(item => (
+      {/* empty: no items at all */}
+      {!isLoading && !isError && !hasItems && (
+        <div className="flex flex-col items-center gap-3 rounded-lg border border-border bg-card px-6 py-16 text-center">
+          <span aria-hidden="true" className="text-4xl">
+            ❤️
+          </span>
+          <h2 className="text-lg font-semibold text-foreground">
+            {t('pages.library.wishlist.empty.noItems.title')}
+          </h2>
+          <p className="max-w-md text-sm text-muted-foreground">
+            {t('pages.library.wishlist.empty.noItems.body')}
+          </p>
+          <AddToWishlistDialog
+            mode="add"
+            trigger={<Button type="button">{t('pages.library.wishlist.empty.noItems.cta')}</Button>}
+          />
+        </div>
+      )}
+
+      {/* empty: filters exclude everything */}
+      {!isLoading && !isError && noFilteredResults && (
+        <div className="flex flex-col items-center gap-3 rounded-lg border border-border bg-card px-6 py-16 text-center">
+          <span aria-hidden="true" className="text-4xl">
+            🔍
+          </span>
+          <h2 className="text-lg font-semibold text-foreground">
+            {t('pages.library.wishlist.empty.filtered.title')}
+          </h2>
+          <p className="max-w-md text-sm text-muted-foreground">
+            {t('pages.library.wishlist.empty.filtered.body')}
+          </p>
+          <Button type="button" variant="outline" onClick={handleClearAll}>
+            {t('pages.library.wishlist.empty.filtered.cta')}
+          </Button>
+        </div>
+      )}
+
+      {/* grid */}
+      {!isLoading && !isError && hasItems && !noFilteredResults && (
+        <div
+          aria-label={t('pages.library.wishlist.card.gridAria')}
+          className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3"
+        >
+          {filtered.map(item => (
             <MeepleWishlistCard
               key={item.id}
               item={item}
-              gameName={gameNameMap.get(item.gameId)}
-              onRemove={handleRemove}
+              gameName={item.gameName ?? gameNameMap.get(item.gameId)}
+              onRemove={id => removeItem(id)}
+              onEdit={setEditingItem}
+              onFilterPriority={handleFilterPriority}
             />
           ))}
         </div>
+      )}
+
+      {/*
+        Edit dialog: conditionally rendered (rather than always-mounted with a
+        controlled `open` toggle) and keyed by item id. `AddToWishlistDialog`
+        only re-derives its internal form state (`buildInitialGame`, priority,
+        targetPrice, notes) on mount / on its own `handleOpenChange(true)` —
+        which Radix's `Dialog` invokes for *internal* open transitions
+        (trigger click, Escape, overlay), not for a parent-driven `open` prop
+        flip. Keying by `editingItem.id` forces a fresh mount (and therefore a
+        fresh prefill) every time a different item is opened for editing.
+      */}
+      {editingItem && (
+        <AddToWishlistDialog
+          key={editingItem.id}
+          mode="edit"
+          item={editingItem}
+          open
+          onOpenChange={next => {
+            if (!next) setEditingItem(null);
+          }}
+        />
       )}
     </HubPageContainer>
   );

--- a/apps/web/src/app/(authenticated)/toolkit/history/__tests__/HistoryCards.test.tsx
+++ b/apps/web/src/app/(authenticated)/toolkit/history/__tests__/HistoryCards.test.tsx
@@ -1,0 +1,161 @@
+/**
+ * HistoryCards — card stack view for /toolkit/history (Issue #3006, Task A5).
+ *
+ * Mirrors `HistoryTable.test.tsx`'s mocking strategy: `useTranslation` is
+ * mocked with an id-passthrough `t()` so label assertions check i18n message
+ * ids directly, and `formatDate`/`formatTime`/`formatRelativeTime` are mocked
+ * to stable strings so no assertion depends on wall-clock time (the
+ * component still computes a real `getRelativeTimeParts` value internally,
+ * but the mocked `formatRelativeTime` ignores its arguments).
+ */
+
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { HistoryRow } from '../_lib/history-filters';
+import { HistoryCards } from '../_components/HistoryCards';
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => ({
+    t: (id: string) => id,
+    formatDate: () => '10 lug 2026',
+    formatTime: () => '14:30',
+    formatRelativeTime: () => '2 giorni fa',
+  }),
+}));
+
+const COMPLETE_ROW: HistoryRow = {
+  id: 'row-1',
+  gameId: 'game-1',
+  gameName: 'Wingspan',
+  startedAt: '2026-07-10T14:30:00Z',
+  durationMinutes: 95,
+  playerNames: ['Alice Smith', 'Bob Jones', 'Cara Lee', 'Dan Ito'],
+  playerCount: 4,
+  winnerName: 'Alice Smith',
+  isCoop: false,
+  winScore: 42,
+  notes: 'Great game!',
+};
+
+const COOP_ROW: HistoryRow = {
+  id: 'row-2',
+  gameId: 'game-2',
+  gameName: 'Pandemic',
+  startedAt: '2026-07-08T10:00:00Z',
+  durationMinutes: 60,
+  playerNames: ['Dave', 'Eve'],
+  playerCount: 2,
+  winnerName: null,
+  isCoop: true,
+  winScore: null,
+  notes: null,
+};
+
+const SOLO_NO_WINNER_ROW: HistoryRow = {
+  id: 'row-3',
+  gameId: 'game-3',
+  gameName: 'Solo Quest',
+  startedAt: '2026-07-05T09:00:00Z',
+  durationMinutes: 30,
+  playerNames: ['Solo Player'],
+  playerCount: 1,
+  winnerName: null,
+  isCoop: false,
+  winScore: null,
+  notes: null,
+};
+
+function renderCards(
+  overrides: Partial<{
+    rows: HistoryRow[];
+    onOpenDetail: (row: HistoryRow) => void;
+  }> = {}
+) {
+  const onOpenDetail = overrides.onOpenDetail ?? vi.fn();
+  const rows = overrides.rows ?? [COMPLETE_ROW];
+
+  render(<HistoryCards rows={rows} onOpenDetail={onOpenDetail} />);
+
+  return { onOpenDetail };
+}
+
+describe('HistoryCards', () => {
+  it('renders the gameName and the winner label for a row', () => {
+    renderCards({ rows: [COMPLETE_ROW] });
+
+    expect(screen.getByText('Wingspan')).toBeInTheDocument();
+    expect(screen.getByText('Alice Smith')).toBeInTheDocument();
+  });
+
+  it('calls onOpenDetail with the row when the card is clicked', () => {
+    const { onOpenDetail } = renderCards({ rows: [COMPLETE_ROW] });
+
+    fireEvent.click(screen.getByText('Wingspan'));
+
+    expect(onOpenDetail).toHaveBeenCalledWith(COMPLETE_ROW);
+  });
+
+  it('calls onOpenDetail when Enter is pressed on a focused card', () => {
+    const { onOpenDetail } = renderCards({ rows: [COMPLETE_ROW] });
+
+    fireEvent.keyDown(screen.getByRole('button', { name: /Wingspan/ }), { key: 'Enter' });
+
+    expect(onOpenDetail).toHaveBeenCalledWith(COMPLETE_ROW);
+  });
+
+  it('shows the win score pill with the trophy icon for a non-coop row', () => {
+    renderCards({ rows: [COMPLETE_ROW] });
+
+    expect(screen.getByText('42')).toBeInTheDocument();
+  });
+
+  it('shows the Cooperativa badge and the Co-op pill for a coop row', () => {
+    renderCards({ rows: [COOP_ROW] });
+
+    expect(screen.getByText('pages.toolkitHistory.table.coop')).toBeInTheDocument();
+    expect(screen.getByText('pages.toolkitHistory.cards.coop')).toBeInTheDocument();
+  });
+
+  it('shows "—" with an aria-label for a non-coop row with no winner', () => {
+    renderCards({ rows: [SOLO_NO_WINNER_ROW] });
+
+    expect(screen.getByLabelText('pages.toolkitHistory.table.noWinner')).toHaveTextContent('—');
+  });
+
+  it('renders the relative date via formatRelativeTime', () => {
+    renderCards({ rows: [COMPLETE_ROW] });
+
+    expect(screen.getByText('2 giorni fa')).toBeInTheDocument();
+  });
+
+  it('renders the absolute date via formatDate in the card footer', () => {
+    renderCards({ rows: [COMPLETE_ROW] });
+
+    expect(screen.getByText('10 lug 2026')).toBeInTheDocument();
+  });
+
+  it('shows the note flag for a row with notes', () => {
+    renderCards({ rows: [COMPLETE_ROW] });
+
+    expect(screen.getByLabelText('pages.toolkitHistory.table.hasNote')).toBeInTheDocument();
+  });
+
+  it('does not show a note flag for a row without notes', () => {
+    renderCards({ rows: [COOP_ROW] });
+
+    expect(screen.queryByLabelText('pages.toolkitHistory.table.hasNote')).not.toBeInTheDocument();
+  });
+
+  it('renders the players aria-label with the player count and names', () => {
+    renderCards({ rows: [COMPLETE_ROW] });
+
+    expect(screen.getByLabelText('pages.toolkitHistory.table.playersAria')).toBeInTheDocument();
+  });
+
+  it('renders one card per row', () => {
+    renderCards({ rows: [COMPLETE_ROW, COOP_ROW, SOLO_NO_WINNER_ROW] });
+
+    expect(screen.getAllByRole('button')).toHaveLength(3);
+  });
+});

--- a/apps/web/src/app/(authenticated)/toolkit/history/__tests__/HistoryDetailModal.test.tsx
+++ b/apps/web/src/app/(authenticated)/toolkit/history/__tests__/HistoryDetailModal.test.tsx
@@ -1,0 +1,162 @@
+/**
+ * HistoryDetailModal — session detail drawer for /toolkit/history (Issue #3006, Task A8).
+ *
+ * Mirrors HistoryCards.test.tsx's mocking strategy for `useTranslation` (id-passthrough
+ * `t()` with `formatDate`/`formatTime` stubbed to stable strings) plus
+ * HistoryToolbar.test.tsx's interpolation-aware `t()` (`id::JSON(values)`) so
+ * title/sub assertions can check exact interpolated output without depending on the
+ * real ICU catalog.
+ *
+ * The Drawer renders via Radix Dialog in jsdom — `matchMedia` is mocked to
+ * `matches: true` (desktop) for deterministic synchronous rendering, mirroring
+ * `GameNightEditDrawer.test.tsx`'s jsdom shim (no vaul pointer-capture shims needed
+ * since we never exercise the mobile/vaul branch here).
+ */
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+import type { HistoryRow } from '../_lib/history-filters';
+import { HistoryDetailModal } from '../_components/HistoryDetailModal';
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => ({
+    t: (id: string, values?: Record<string, unknown>) =>
+      values ? `${id}::${JSON.stringify(values)}` : id,
+    formatDate: () => '10 lug 2026',
+    formatTime: () => '14:30',
+  }),
+}));
+
+function installMatchMedia(matches: boolean): void {
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: vi.fn().mockReturnValue({
+      matches,
+      media: '(min-width: 768px)',
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      onchange: null,
+    }),
+  });
+}
+
+const COMPLETE_ROW: HistoryRow = {
+  id: 'row-1',
+  gameId: 'game-1',
+  gameName: 'Wingspan',
+  startedAt: '2026-07-10T14:30:00Z',
+  durationMinutes: 95,
+  playerNames: ['Alice Smith', 'Bob Jones'],
+  playerCount: 2,
+  winnerName: 'Alice Smith',
+  isCoop: false,
+  winScore: 42,
+  notes: 'Great game!',
+};
+
+const NO_NOTES_ROW: HistoryRow = {
+  ...COMPLETE_ROW,
+  id: 'row-2',
+  notes: null,
+};
+
+beforeEach(() => {
+  installMatchMedia(true); // desktop → Radix Dialog, deterministic in jsdom
+});
+
+describe('HistoryDetailModal', () => {
+  it('renders nothing when row is null', () => {
+    const { container } = render(<HistoryDetailModal row={null} onClose={vi.fn()} />);
+
+    expect(container).toBeEmptyDOMElement();
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('shows the notes text when the row has notes', () => {
+    render(<HistoryDetailModal row={COMPLETE_ROW} onClose={vi.fn()} />);
+
+    expect(screen.getByText('Great game!')).toBeInTheDocument();
+    expect(screen.queryByText('pages.toolkitHistory.modal.notesEmpty')).not.toBeInTheDocument();
+  });
+
+  it('shows notesEmpty when the row has no notes', () => {
+    render(<HistoryDetailModal row={NO_NOTES_ROW} onClose={vi.fn()} />);
+
+    expect(screen.getByText('pages.toolkitHistory.modal.notesEmpty')).toBeInTheDocument();
+    expect(screen.queryByText('Great game!')).not.toBeInTheDocument();
+  });
+
+  it('shows "—" (noData) for the turns stat', () => {
+    render(<HistoryDetailModal row={COMPLETE_ROW} onClose={vi.fn()} />);
+
+    expect(screen.getByTestId('history-detail-modal-stat-turns')).toHaveTextContent(
+      'pages.toolkitHistory.modal.noData'
+    );
+  });
+
+  it('shows noData for variance/highlights and the real winScore for winnerScore', () => {
+    render(<HistoryDetailModal row={COMPLETE_ROW} onClose={vi.fn()} />);
+
+    expect(screen.getByTestId('history-detail-modal-stat-variance')).toHaveTextContent(
+      'pages.toolkitHistory.modal.noData'
+    );
+    expect(screen.getByTestId('history-detail-modal-stat-highlights')).toHaveTextContent(
+      'pages.toolkitHistory.modal.noData'
+    );
+    expect(screen.getByTestId('history-detail-modal-stat-winner-score')).toHaveTextContent('42');
+  });
+
+  it('falls back to noData for winnerScore when winScore is null', () => {
+    render(<HistoryDetailModal row={{ ...COMPLETE_ROW, winScore: null }} onClose={vi.fn()} />);
+
+    expect(screen.getByTestId('history-detail-modal-stat-winner-score')).toHaveTextContent(
+      'pages.toolkitHistory.modal.noData'
+    );
+  });
+
+  it('marks the winner in the leaderboard and shows noData for every score slot', () => {
+    render(<HistoryDetailModal row={COMPLETE_ROW} onClose={vi.fn()} />);
+
+    const winnerRow = screen.getByText('Alice Smith').closest('li');
+    expect(winnerRow).not.toBeNull();
+    expect(winnerRow).toHaveTextContent('🏆');
+    expect(winnerRow).toHaveTextContent('pages.toolkitHistory.modal.noData');
+
+    const nonWinnerRow = screen.getByText('Bob Jones').closest('li');
+    expect(nonWinnerRow).not.toBeNull();
+    expect(nonWinnerRow).not.toHaveTextContent('🏆');
+    expect(nonWinnerRow).toHaveTextContent('pages.toolkitHistory.modal.noData');
+  });
+
+  it('does not render a timeline section', () => {
+    render(<HistoryDetailModal row={COMPLETE_ROW} onClose={vi.fn()} />);
+
+    expect(screen.queryByText('pages.toolkitHistory.modal.timeline')).not.toBeInTheDocument();
+  });
+
+  it('calls onClose when the close button is clicked', async () => {
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+    render(<HistoryDetailModal row={COMPLETE_ROW} onClose={onClose} />);
+
+    await user.click(screen.getByRole('button', { name: 'pages.toolkitHistory.modal.close' }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the interpolated title and sub with the row data', () => {
+    render(<HistoryDetailModal row={COMPLETE_ROW} onClose={vi.fn()} />);
+
+    expect(
+      screen.getByText('pages.toolkitHistory.modal.title::{"game":"Wingspan","date":"10 lug 2026"}')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'pages.toolkitHistory.modal.sub::{"duration":"1h 35m","count":2,"time":"14:30"}'
+      )
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/(authenticated)/toolkit/history/__tests__/HistoryPagination.test.tsx
+++ b/apps/web/src/app/(authenticated)/toolkit/history/__tests__/HistoryPagination.test.tsx
@@ -1,0 +1,162 @@
+/**
+ * HistoryPagination — client-side pagination bar for /toolkit/history
+ * (Issue #3006, Task A6).
+ *
+ * `useTranslation` is mocked with an id-passthrough `t()` for keys without
+ * interpolation values, and a `id::JSON(values)` encoding for interpolated
+ * keys (`rangeMeta`, `mobileMeta`) so assertions can check both the message
+ * id and the exact values passed in, without depending on the real ICU
+ * message catalog.
+ *
+ * The component renders both a mobile and a desktop layout simultaneously
+ * (visibility toggled via Tailwind's `sm:` breakpoint, which jsdom does not
+ * evaluate), so tests scope queries to `history-pagination-desktop` /
+ * `history-pagination-mobile` via `within()` to avoid duplicate-match
+ * ambiguity between the two layouts.
+ */
+
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { HistoryPagination, type HistoryPaginationProps } from '../_components/HistoryPagination';
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => ({
+    t: (id: string, values?: Record<string, unknown>) =>
+      values ? `${id}::${JSON.stringify(values)}` : id,
+  }),
+}));
+
+function renderPagination(overrides: Partial<HistoryPaginationProps> = {}) {
+  const onPageChange = overrides.onPageChange ?? vi.fn();
+  const onPageSizeChange = overrides.onPageSizeChange ?? vi.fn();
+
+  const props: HistoryPaginationProps = {
+    page: overrides.page ?? 3,
+    total: overrides.total ?? 156,
+    pageSize: overrides.pageSize ?? 20,
+    onPageChange,
+    onPageSizeChange,
+  };
+
+  render(<HistoryPagination {...props} />);
+
+  return { onPageChange, onPageSizeChange };
+}
+
+describe('HistoryPagination', () => {
+  it('renders the range meta with the correct from/to/total for page 3 of a 156-item, 20-per-page set', () => {
+    renderPagination({ page: 3, total: 156, pageSize: 20 });
+
+    const desktop = screen.getByTestId('history-pagination-desktop');
+    expect(
+      within(desktop).getByText(
+        'pages.toolkitHistory.pagination.rangeMeta::{"from":41,"to":60,"total":156}'
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('renders the mobile meta with page/pages/total', () => {
+    renderPagination({ page: 3, total: 156, pageSize: 20 });
+
+    const mobile = screen.getByTestId('history-pagination-mobile');
+    // pages = ceil(156 / 20) = 8
+    expect(
+      within(mobile).getByText(
+        'pages.toolkitHistory.pagination.mobileMeta::{"page":3,"pages":8,"total":156}'
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('shows the empty-state label instead of the range meta when total is 0', () => {
+    renderPagination({ page: 1, total: 0, pageSize: 20 });
+
+    const desktop = screen.getByTestId('history-pagination-desktop');
+    expect(within(desktop).getByText('pages.toolkitHistory.pagination.empty')).toBeInTheDocument();
+    expect(within(desktop).queryByText(/rangeMeta/)).not.toBeInTheDocument();
+  });
+
+  it('calls onPageChange(page + 1) when "Succ." is clicked', async () => {
+    const user = userEvent.setup();
+    const { onPageChange } = renderPagination({ page: 3, total: 156, pageSize: 20 });
+
+    const desktop = screen.getByTestId('history-pagination-desktop');
+    await user.click(
+      within(desktop).getByRole('button', { name: 'pages.toolkitHistory.pagination.nextAria' })
+    );
+
+    expect(onPageChange).toHaveBeenCalledWith(4);
+  });
+
+  it('calls onPageChange(page - 1) when "Prec." is clicked', async () => {
+    const user = userEvent.setup();
+    const { onPageChange } = renderPagination({ page: 3, total: 156, pageSize: 20 });
+
+    const desktop = screen.getByTestId('history-pagination-desktop');
+    await user.click(
+      within(desktop).getByRole('button', { name: 'pages.toolkitHistory.pagination.prevAria' })
+    );
+
+    expect(onPageChange).toHaveBeenCalledWith(2);
+  });
+
+  it('disables the previous button and does not call onPageChange when already on page 1', async () => {
+    const user = userEvent.setup();
+    const { onPageChange } = renderPagination({ page: 1, total: 156, pageSize: 20 });
+
+    const desktop = screen.getByTestId('history-pagination-desktop');
+    const prevButton = within(desktop).getByRole('button', {
+      name: 'pages.toolkitHistory.pagination.prevAria',
+    });
+
+    expect(prevButton).toBeDisabled();
+    await user.click(prevButton);
+    expect(onPageChange).not.toHaveBeenCalled();
+  });
+
+  it('disables the next button when already on the last page', () => {
+    // pages = ceil(156 / 20) = 8
+    renderPagination({ page: 8, total: 156, pageSize: 20 });
+
+    const desktop = screen.getByTestId('history-pagination-desktop');
+    const nextButton = within(desktop).getByRole('button', {
+      name: 'pages.toolkitHistory.pagination.nextAria',
+    });
+
+    expect(nextButton).toBeDisabled();
+  });
+
+  it('marks the active page number with aria-current="page"', () => {
+    renderPagination({ page: 3, total: 156, pageSize: 20 });
+
+    const desktop = screen.getByTestId('history-pagination-desktop');
+    const activeButton = within(desktop).getByRole('button', { name: '3' });
+
+    expect(activeButton).toHaveAttribute('aria-current', 'page');
+    expect(within(desktop).getByRole('button', { name: '4' })).not.toHaveAttribute('aria-current');
+  });
+
+  it('renders ellipses for a page list with more than 7 pages', () => {
+    // pages = ceil(156 / 20) = 8 > 7
+    renderPagination({ page: 3, total: 156, pageSize: 20 });
+
+    const desktop = screen.getByTestId('history-pagination-desktop');
+    expect(within(desktop).getAllByText('···').length).toBeGreaterThan(0);
+  });
+
+  it('calls onPageSizeChange(50) when a new page size is selected', async () => {
+    const user = userEvent.setup();
+    const { onPageSizeChange } = renderPagination({ page: 3, total: 156, pageSize: 20 });
+
+    const desktop = screen.getByTestId('history-pagination-desktop');
+    const trigger = within(desktop).getByRole('combobox', {
+      name: 'pages.toolkitHistory.pagination.perPageAria',
+    });
+    await user.click(trigger);
+    const option = await screen.findByRole('option', { name: '50' });
+    await user.click(option);
+
+    expect(onPageSizeChange).toHaveBeenCalledWith(50);
+  });
+});

--- a/apps/web/src/app/(authenticated)/toolkit/history/__tests__/HistoryTable.test.tsx
+++ b/apps/web/src/app/(authenticated)/toolkit/history/__tests__/HistoryTable.test.tsx
@@ -1,0 +1,227 @@
+/**
+ * HistoryTable — desktop 8-column sortable table for /toolkit/history (Issue #3006, Task A4).
+ *
+ * `useTranslation` is mocked with an id-passthrough `t()` so header/label assertions
+ * check the i18n message ids directly (no locale-catalog coupling). `formatDate`/
+ * `formatTime`/`formatRelativeTime` are mocked to stable strings so the Data column
+ * never depends on wall-clock time.
+ */
+
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { HistoryRow, HistorySort } from '../_lib/history-filters';
+import { HistoryTable } from '../_components/HistoryTable';
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => ({
+    t: (id: string) => id,
+    formatDate: () => '10 lug 2026',
+    formatTime: () => '14:30',
+    formatRelativeTime: () => '2 giorni fa',
+  }),
+}));
+
+const COMPLETE_ROW: HistoryRow = {
+  id: 'row-1',
+  gameId: 'game-1',
+  gameName: 'Wingspan',
+  startedAt: '2026-07-10T14:30:00Z',
+  durationMinutes: 95,
+  playerNames: ['Alice Smith', 'Bob Jones', 'Cara Lee', 'Dan Ito'],
+  playerCount: 4,
+  winnerName: 'Alice Smith',
+  isCoop: false,
+  winScore: 42,
+  notes: 'Great game!',
+};
+
+const COOP_ROW: HistoryRow = {
+  id: 'row-2',
+  gameId: 'game-2',
+  gameName: 'Pandemic',
+  startedAt: '2026-07-08T10:00:00Z',
+  durationMinutes: 60,
+  playerNames: ['Dave', 'Eve'],
+  playerCount: 2,
+  winnerName: null,
+  isCoop: true,
+  winScore: null,
+  notes: null,
+};
+
+const SOLO_NO_WINNER_ROW: HistoryRow = {
+  id: 'row-3',
+  gameId: 'game-3',
+  gameName: 'Solo Quest',
+  startedAt: '2026-07-05T09:00:00Z',
+  durationMinutes: 30,
+  playerNames: ['Solo Player'],
+  playerCount: 1,
+  winnerName: null,
+  isCoop: false,
+  winScore: null,
+  notes: null,
+};
+
+function renderTable(
+  overrides: Partial<{
+    rows: HistoryRow[];
+    sort: HistorySort;
+    onSortChange: (s: HistorySort) => void;
+    onOpenDetail: (row: HistoryRow) => void;
+    onOpenGameStats: (gameId: string) => void;
+  }> = {}
+) {
+  const onSortChange = overrides.onSortChange ?? vi.fn();
+  const onOpenDetail = overrides.onOpenDetail ?? vi.fn();
+  const onOpenGameStats = overrides.onOpenGameStats ?? vi.fn();
+  const rows = overrides.rows ?? [COMPLETE_ROW, COOP_ROW, SOLO_NO_WINNER_ROW];
+  const sort = overrides.sort ?? 'recent';
+
+  render(
+    <table>
+      <HistoryTable
+        rows={rows}
+        sort={sort}
+        onSortChange={onSortChange}
+        onOpenDetail={onOpenDetail}
+        onOpenGameStats={onOpenGameStats}
+      />
+    </table>
+  );
+
+  return { onSortChange, onOpenDetail, onOpenGameStats };
+}
+
+describe('HistoryTable', () => {
+  it('renders the 8 column headers via i18n ids', () => {
+    renderTable();
+
+    expect(screen.getByText('pages.toolkitHistory.table.date')).toBeInTheDocument();
+    expect(screen.getByText('pages.toolkitHistory.table.game')).toBeInTheDocument();
+    expect(screen.getByText('pages.toolkitHistory.table.duration')).toBeInTheDocument();
+    expect(screen.getByText('pages.toolkitHistory.table.players')).toBeInTheDocument();
+    expect(screen.getByText('pages.toolkitHistory.table.winner')).toBeInTheDocument();
+    expect(screen.getByText('pages.toolkitHistory.table.score')).toBeInTheDocument();
+    expect(screen.getByText('pages.toolkitHistory.table.notes')).toBeInTheDocument();
+    expect(screen.getByText('pages.toolkitHistory.table.actions')).toBeInTheDocument();
+  });
+
+  it('clicking the Durata header always sorts by "longest"', () => {
+    const { onSortChange } = renderTable({ sort: 'recent' });
+
+    fireEvent.click(screen.getByText('pages.toolkitHistory.table.duration'));
+
+    expect(onSortChange).toHaveBeenCalledWith('longest');
+  });
+
+  it('clicking the Score header always sorts by "score"', () => {
+    const { onSortChange } = renderTable({ sort: 'longest' });
+
+    fireEvent.click(screen.getByText('pages.toolkitHistory.table.score'));
+
+    expect(onSortChange).toHaveBeenCalledWith('score');
+  });
+
+  it('clicking the Data header switches to "oldest" when currently "recent"', () => {
+    const { onSortChange } = renderTable({ sort: 'recent' });
+
+    fireEvent.click(screen.getByText('pages.toolkitHistory.table.date'));
+
+    expect(onSortChange).toHaveBeenCalledWith('oldest');
+  });
+
+  it('clicking the Data header switches to "recent" when currently "oldest"', () => {
+    const { onSortChange } = renderTable({ sort: 'oldest' });
+
+    fireEvent.click(screen.getByText('pages.toolkitHistory.table.date'));
+
+    expect(onSortChange).toHaveBeenCalledWith('recent');
+  });
+
+  it('sets aria-sort on the active sortable column header', () => {
+    renderTable({ sort: 'longest' });
+
+    const durationHeader = screen.getByText('pages.toolkitHistory.table.duration').closest('th');
+    const dateHeader = screen.getByText('pages.toolkitHistory.table.date').closest('th');
+
+    expect(durationHeader).toHaveAttribute('aria-sort', 'descending');
+    expect(dateHeader).toHaveAttribute('aria-sort', 'none');
+  });
+
+  it('shows the co-op short label in the Score column for a co-op row', () => {
+    renderTable({ rows: [COOP_ROW] });
+
+    expect(screen.getByText('pages.toolkitHistory.table.coopShort')).toBeInTheDocument();
+  });
+
+  it('shows the co-op badge in the Vincitore column for a co-op row', () => {
+    renderTable({ rows: [COOP_ROW] });
+
+    expect(screen.getByText('pages.toolkitHistory.table.coop')).toBeInTheDocument();
+  });
+
+  it('shows "—" in the Vincitore column for a non-coop row with no winner', () => {
+    renderTable({ rows: [SOLO_NO_WINNER_ROW] });
+
+    expect(screen.getByLabelText('pages.toolkitHistory.table.noWinner')).toHaveTextContent('—');
+  });
+
+  it('shows the winner name for a row with a winner', () => {
+    renderTable({ rows: [COMPLETE_ROW] });
+
+    expect(screen.getByText('Alice Smith')).toBeInTheDocument();
+  });
+
+  it('shows the win score for a non-coop row', () => {
+    renderTable({ rows: [COMPLETE_ROW] });
+
+    expect(screen.getByText('42')).toBeInTheDocument();
+  });
+
+  it('calls onOpenDetail when a row is clicked', () => {
+    const { onOpenDetail } = renderTable({ rows: [COMPLETE_ROW] });
+
+    fireEvent.click(screen.getByText('Wingspan'));
+
+    expect(onOpenDetail).toHaveBeenCalledWith(COMPLETE_ROW);
+  });
+
+  it('calls onOpenDetail when the view-details action is clicked', () => {
+    const { onOpenDetail } = renderTable({ rows: [COMPLETE_ROW] });
+
+    fireEvent.click(screen.getByLabelText('pages.toolkitHistory.table.viewDetails'));
+
+    expect(onOpenDetail).toHaveBeenCalledWith(COMPLETE_ROW);
+  });
+
+  it('calls onOpenGameStats with the gameId when the game-stats action is clicked', () => {
+    const { onOpenGameStats, onOpenDetail } = renderTable({ rows: [COMPLETE_ROW] });
+
+    fireEvent.click(screen.getByLabelText('pages.toolkitHistory.table.gameStats'));
+
+    expect(onOpenGameStats).toHaveBeenCalledWith('game-1');
+    expect(onOpenDetail).not.toHaveBeenCalled();
+  });
+
+  it('disables the notes action for a row with no notes', () => {
+    renderTable({ rows: [COOP_ROW] });
+
+    expect(screen.getByLabelText('pages.toolkitHistory.table.noNote')).toBeDisabled();
+  });
+
+  it('opens the detail view when the notes action is clicked for a row with notes', () => {
+    const { onOpenDetail } = renderTable({ rows: [COMPLETE_ROW] });
+
+    fireEvent.click(screen.getByLabelText('pages.toolkitHistory.table.hasNote'));
+
+    expect(onOpenDetail).toHaveBeenCalledWith(COMPLETE_ROW);
+  });
+
+  it('renders the players aria-label with the player count and names', () => {
+    renderTable({ rows: [COMPLETE_ROW] });
+
+    expect(screen.getByLabelText('pages.toolkitHistory.table.playersAria')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/(authenticated)/toolkit/history/__tests__/HistoryToolbar.test.tsx
+++ b/apps/web/src/app/(authenticated)/toolkit/history/__tests__/HistoryToolbar.test.tsx
@@ -17,7 +17,7 @@
  * interaction.
  */
 
-import { act, fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 
@@ -140,6 +140,34 @@ describe('HistoryToolbar', () => {
       expect(onChange).toHaveBeenCalledTimes(1);
       expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ search: 'wingspan' }));
     });
+
+    it('cancels the pending debounced commit when the search is cleared before it fires', async () => {
+      const { onChange } = renderToolbar();
+
+      const searchInput = screen.getByRole('searchbox', {
+        name: 'pages.toolkitHistory.filters.searchAriaLabel',
+      });
+
+      fireEvent.change(searchInput, { target: { value: 'catan' } });
+
+      // Advance partway through the debounce window — the commit is still pending.
+      await act(async () => {
+        vi.advanceTimersByTime(200);
+      });
+      expect(onChange).not.toHaveBeenCalled();
+
+      fireEvent.click(
+        screen.getByRole('button', { name: 'pages.toolkitHistory.filters.clearSearch' })
+      );
+
+      // Advance past where the original debounce would have fired.
+      await act(async () => {
+        vi.advanceTimersByTime(400);
+      });
+
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ search: '' }));
+    });
   });
 
   it('clears the search immediately (bypassing the debounce) when the clear button is clicked', async () => {
@@ -225,26 +253,40 @@ describe('HistoryToolbar', () => {
     );
   });
 
-  it('applies a relative date preset immediately and clears any custom bounds', async () => {
+  it('applies a relative date preset immediately, clears any custom bounds, and closes the popover', async () => {
     const user = userEvent.setup();
     const { onChange } = renderToolbar({
       state: baseState({ datePreset: 'custom', dateFrom: '2026-01-01', dateTo: '2026-02-01' }),
     });
 
     await user.click(screen.getByRole('button', { name: 'pages.toolkitHistory.filters.date' }));
+    expect(
+      screen.getByRole('listbox', { name: 'pages.toolkitHistory.filters.dateRange' })
+    ).toBeInTheDocument();
+
     await user.click(screen.getByText('pages.toolkitHistory.filters.dateOptions.last30'));
 
     expect(onChange).toHaveBeenCalledWith(
       expect.objectContaining({ datePreset: 'last30', dateFrom: undefined, dateTo: undefined })
     );
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole('listbox', { name: 'pages.toolkitHistory.filters.dateRange' })
+      ).not.toBeInTheDocument();
+    });
   });
 
-  it('applies a custom date range only after both dates are filled in and "Applica intervallo" is clicked', async () => {
+  it('keeps the popover open when switching to the custom preset, applies the range only after both dates are filled in and "Applica intervallo" is clicked, then closes it', async () => {
     const user = userEvent.setup();
     const { onChange } = renderToolbar();
 
     await user.click(screen.getByRole('button', { name: 'pages.toolkitHistory.filters.date' }));
     await user.click(screen.getByText('pages.toolkitHistory.filters.dateOptions.custom'));
+
+    expect(
+      screen.getByRole('listbox', { name: 'pages.toolkitHistory.filters.dateRange' })
+    ).toBeInTheDocument();
 
     const applyButton = screen.getByRole('button', {
       name: 'pages.toolkitHistory.filters.applyRange',
@@ -257,6 +299,11 @@ describe('HistoryToolbar', () => {
     fireEvent.change(toInput, { target: { value: '2026-06-30' } });
 
     expect(applyButton).not.toBeDisabled();
+    // Still open while the user is filling in the custom range.
+    expect(
+      screen.getByRole('listbox', { name: 'pages.toolkitHistory.filters.dateRange' })
+    ).toBeInTheDocument();
+
     await user.click(applyButton);
 
     expect(onChange).toHaveBeenCalledWith(
@@ -266,6 +313,12 @@ describe('HistoryToolbar', () => {
         dateTo: '2026-06-30',
       })
     );
+
+    await waitFor(() => {
+      expect(
+        screen.queryByRole('listbox', { name: 'pages.toolkitHistory.filters.dateRange' })
+      ).not.toBeInTheDocument();
+    });
   });
 
   it('calls onChange with the new sort when a sort option is selected', async () => {

--- a/apps/web/src/app/(authenticated)/toolkit/history/__tests__/HistoryToolbar.test.tsx
+++ b/apps/web/src/app/(authenticated)/toolkit/history/__tests__/HistoryToolbar.test.tsx
@@ -1,0 +1,335 @@
+/**
+ * HistoryToolbar — filter/sort toolbar for /toolkit/history (Issue #3006,
+ * Task A7).
+ *
+ * Mirrors `HistoryPagination.test.tsx`'s mocking strategy: `useTranslation`
+ * is mocked with an id-passthrough `t()` (interpolated calls encoded as
+ * `id::JSON(values)`) so assertions check i18n message ids/values directly
+ * without depending on the real ICU catalog.
+ *
+ * The search-debounce tests are isolated in their own `describe` block with
+ * locally-scoped fake timers (`vi.useFakeTimers` / `vi.useRealTimers` in
+ * `beforeEach`/`afterEach` of that block only) and drive the input via
+ * `fireEvent.change` rather than `userEvent.type` — mixing `userEvent`'s
+ * internal scheduling with fake timers is unreliable (see
+ * `GamePicker.test.tsx` for the same pattern in this codebase). All other
+ * tests use real timers with `userEvent` for realistic pointer/keyboard
+ * interaction.
+ */
+
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+
+import {
+  HistoryToolbar,
+  type HistoryToolbarGameOption,
+  type HistoryToolbarProps,
+  type HistoryToolbarWinnerOption,
+} from '../_components/HistoryToolbar';
+import { NO_WINNER_FILTER_VALUE, type HistoryFilterState } from '../_lib/history-filters';
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => ({
+    t: (id: string, values?: Record<string, unknown>) =>
+      values ? `${id}::${JSON.stringify(values)}` : id,
+  }),
+}));
+
+const GAME_OPTIONS: HistoryToolbarGameOption[] = [
+  { id: 'game-1', label: 'Wingspan', count: 12 },
+  { id: 'game-2', label: 'Catan', count: 8 },
+  { id: 'game-3', label: 'Pandemic', count: 5 },
+  { id: 'game-4', label: 'Azul', count: 4 },
+  { id: 'game-5', label: 'Terraforming Mars', count: 3 },
+];
+
+const WINNER_OPTIONS: HistoryToolbarWinnerOption[] = [
+  { value: 'Alice', label: 'Alice', count: 10 },
+  { value: 'Bob', label: 'Bob', count: 6 },
+  { value: NO_WINNER_FILTER_VALUE, label: 'raw-no-winner-label', count: 4 },
+];
+
+function baseState(overrides: Partial<HistoryFilterState> = {}): HistoryFilterState {
+  return {
+    search: '',
+    gameIds: [],
+    winners: [],
+    datePreset: 'all',
+    sort: 'recent',
+    ...overrides,
+  };
+}
+
+function renderToolbar(overrides: Partial<HistoryToolbarProps> = {}) {
+  const onChange = overrides.onChange ?? vi.fn();
+  const onViewChange = overrides.onViewChange ?? vi.fn();
+  const onClearAll = overrides.onClearAll ?? vi.fn();
+  const onExport = overrides.onExport ?? vi.fn();
+
+  const props: HistoryToolbarProps = {
+    state: overrides.state ?? baseState(),
+    onChange,
+    gameOptions: overrides.gameOptions ?? GAME_OPTIONS,
+    winnerOptions: overrides.winnerOptions ?? WINNER_OPTIONS,
+    view: overrides.view ?? 'table',
+    onViewChange,
+    totalCount: overrides.totalCount ?? 42,
+    resultCount: overrides.resultCount ?? 42,
+    onClearAll,
+    onExport,
+  };
+
+  render(<HistoryToolbar {...props} />);
+
+  return { onChange, onViewChange, onClearAll, onExport };
+}
+
+describe('HistoryToolbar', () => {
+  describe('search debounce', () => {
+    beforeEach(() => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('calls onChange with the updated search only after the 400ms debounce elapses', async () => {
+      const { onChange } = renderToolbar();
+
+      const searchInput = screen.getByRole('searchbox', {
+        name: 'pages.toolkitHistory.filters.searchAriaLabel',
+      });
+
+      fireEvent.change(searchInput, { target: { value: 'wingspan' } });
+
+      expect(onChange).not.toHaveBeenCalled();
+      expect(screen.getByText('pages.toolkitHistory.filters.searching')).toBeInTheDocument();
+
+      await act(async () => {
+        vi.advanceTimersByTime(400);
+      });
+
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ search: 'wingspan' }));
+      expect(screen.queryByText('pages.toolkitHistory.filters.searching')).not.toBeInTheDocument();
+    });
+
+    it('only commits the last value when the search changes multiple times within the debounce window', async () => {
+      const { onChange } = renderToolbar();
+
+      const searchInput = screen.getByRole('searchbox', {
+        name: 'pages.toolkitHistory.filters.searchAriaLabel',
+      });
+
+      fireEvent.change(searchInput, { target: { value: 'w' } });
+      await act(async () => {
+        vi.advanceTimersByTime(200);
+      });
+      fireEvent.change(searchInput, { target: { value: 'wi' } });
+      await act(async () => {
+        vi.advanceTimersByTime(200);
+      });
+      fireEvent.change(searchInput, { target: { value: 'wingspan' } });
+
+      await act(async () => {
+        vi.advanceTimersByTime(400);
+      });
+
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ search: 'wingspan' }));
+    });
+  });
+
+  it('clears the search immediately (bypassing the debounce) when the clear button is clicked', async () => {
+    const user = userEvent.setup();
+    const { onChange } = renderToolbar({ state: baseState({ search: 'catan' }) });
+
+    const clearButton = screen.getByRole('button', {
+      name: 'pages.toolkitHistory.filters.clearSearch',
+    });
+    await user.click(clearButton);
+
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ search: '' }));
+  });
+
+  it('toggles a game checkbox on, updating gameIds via onChange', async () => {
+    const user = userEvent.setup();
+    const { onChange } = renderToolbar();
+
+    await user.click(screen.getByRole('button', { name: 'pages.toolkitHistory.filters.games' }));
+    await user.click(await screen.findByRole('checkbox', { name: 'Catan' }));
+
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ gameIds: ['game-2'] }));
+  });
+
+  it('toggles a game checkbox off when it is already selected', async () => {
+    const user = userEvent.setup();
+    const { onChange } = renderToolbar({ state: baseState({ gameIds: ['game-1', 'game-2'] }) });
+
+    await user.click(screen.getByRole('button', { name: 'pages.toolkitHistory.filters.games' }));
+    await user.click(await screen.findByRole('checkbox', { name: 'Catan' }));
+
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ gameIds: ['game-1'] }));
+  });
+
+  it('caps visible game options at 4 and reveals the rest via "Mostra altri"', async () => {
+    const user = userEvent.setup();
+    renderToolbar();
+
+    await user.click(screen.getByRole('button', { name: 'pages.toolkitHistory.filters.games' }));
+
+    expect(screen.queryByRole('checkbox', { name: 'Terraforming Mars' })).not.toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole('button', {
+        name: 'pages.toolkitHistory.filters.showMore::{"n":1}',
+      })
+    );
+
+    expect(screen.getByRole('checkbox', { name: 'Terraforming Mars' })).toBeInTheDocument();
+  });
+
+  it('clears all selected games when "Tutti" is clicked', async () => {
+    const user = userEvent.setup();
+    const { onChange } = renderToolbar({ state: baseState({ gameIds: ['game-1', 'game-2'] }) });
+
+    await user.click(screen.getByRole('button', { name: 'pages.toolkitHistory.filters.games' }));
+    await user.click(screen.getByRole('option', { name: 'pages.toolkitHistory.filters.all' }));
+
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ gameIds: [] }));
+  });
+
+  it('formats winner options as "{name} (won)" and the sentinel as "No winner", toggling winners on select', async () => {
+    const user = userEvent.setup();
+    const { onChange } = renderToolbar();
+
+    await user.click(screen.getByRole('button', { name: 'pages.toolkitHistory.filters.winners' }));
+
+    expect(
+      screen.getByRole('checkbox', {
+        name: 'pages.toolkitHistory.filters.winnerWon::{"name":"Alice"}',
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('checkbox', { name: 'pages.toolkitHistory.filters.noWinner' })
+    ).toBeInTheDocument();
+
+    await user.click(
+      screen.getByRole('checkbox', { name: 'pages.toolkitHistory.filters.noWinner' })
+    );
+
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ winners: [NO_WINNER_FILTER_VALUE] })
+    );
+  });
+
+  it('applies a relative date preset immediately and clears any custom bounds', async () => {
+    const user = userEvent.setup();
+    const { onChange } = renderToolbar({
+      state: baseState({ datePreset: 'custom', dateFrom: '2026-01-01', dateTo: '2026-02-01' }),
+    });
+
+    await user.click(screen.getByRole('button', { name: 'pages.toolkitHistory.filters.date' }));
+    await user.click(screen.getByText('pages.toolkitHistory.filters.dateOptions.last30'));
+
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({ datePreset: 'last30', dateFrom: undefined, dateTo: undefined })
+    );
+  });
+
+  it('applies a custom date range only after both dates are filled in and "Applica intervallo" is clicked', async () => {
+    const user = userEvent.setup();
+    const { onChange } = renderToolbar();
+
+    await user.click(screen.getByRole('button', { name: 'pages.toolkitHistory.filters.date' }));
+    await user.click(screen.getByText('pages.toolkitHistory.filters.dateOptions.custom'));
+
+    const applyButton = screen.getByRole('button', {
+      name: 'pages.toolkitHistory.filters.applyRange',
+    });
+    expect(applyButton).toBeDisabled();
+
+    const fromInput = screen.getByLabelText('pages.toolkitHistory.filters.dateFromLabel');
+    const toInput = screen.getByLabelText('pages.toolkitHistory.filters.dateToLabel');
+    fireEvent.change(fromInput, { target: { value: '2026-06-01' } });
+    fireEvent.change(toInput, { target: { value: '2026-06-30' } });
+
+    expect(applyButton).not.toBeDisabled();
+    await user.click(applyButton);
+
+    expect(onChange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        datePreset: 'custom',
+        dateFrom: '2026-06-01',
+        dateTo: '2026-06-30',
+      })
+    );
+  });
+
+  it('calls onChange with the new sort when a sort option is selected', async () => {
+    const user = userEvent.setup();
+    const { onChange } = renderToolbar();
+
+    const sortTrigger = screen.getByRole('combobox', {
+      name: 'pages.toolkitHistory.filters.sortBy',
+    });
+    await user.click(sortTrigger);
+    await user.click(
+      await screen.findByRole('option', { name: 'pages.toolkitHistory.filters.sortOptions.oldest' })
+    );
+
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ sort: 'oldest' }));
+  });
+
+  it('calls onViewChange when the cards view button is clicked', async () => {
+    const user = userEvent.setup();
+    const { onViewChange } = renderToolbar({ view: 'table' });
+
+    await user.click(
+      screen.getByRole('button', { name: 'pages.toolkitHistory.filters.viewCards' })
+    );
+
+    expect(onViewChange).toHaveBeenCalledWith('cards');
+  });
+
+  it('calls onExport when the export button is clicked', async () => {
+    const user = userEvent.setup();
+    const { onExport } = renderToolbar();
+
+    await user.click(screen.getByRole('button', { name: 'pages.toolkitHistory.hero.exportCsv' }));
+
+    expect(onExport).toHaveBeenCalledTimes(1);
+  });
+
+  describe('summary bar', () => {
+    it('is hidden when no filters are active', () => {
+      renderToolbar({ state: baseState() });
+
+      expect(screen.queryByText(/summary\.activeFilters/)).not.toBeInTheDocument();
+    });
+
+    it('shows the active-filter count and result/total, and "Cancella tutto" calls onClearAll', async () => {
+      const user = userEvent.setup();
+      const { onClearAll } = renderToolbar({
+        state: baseState({ gameIds: ['game-1'], search: 'wingspan' }),
+        totalCount: 42,
+        resultCount: 7,
+      });
+
+      expect(
+        screen.getByText('pages.toolkitHistory.summary.activeFilters::{"n":2}')
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText('pages.toolkitHistory.summary.results::{"n":7,"total":42}')
+      ).toBeInTheDocument();
+
+      await user.click(
+        screen.getByRole('button', { name: 'pages.toolkitHistory.summary.clearAll' })
+      );
+
+      expect(onClearAll).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/apps/web/src/app/(authenticated)/toolkit/history/__tests__/history-filters.test.ts
+++ b/apps/web/src/app/(authenticated)/toolkit/history/__tests__/history-filters.test.ts
@@ -305,6 +305,57 @@ describe('filterRows', () => {
   });
 });
 
+// ─── filterRows — date range edge cases (Task A7 prerequisite fix) ────────
+
+describe('filterRows date range edge cases', () => {
+  it('datePreset custom includes a session started later the same day as dateTo (end-of-day upper bound)', () => {
+    const sameDayLateRow = toHistoryRow(
+      makeDto({ id: 'same-day', startedAt: '2026-06-01T22:30:00Z' }),
+      GAME_NAME_MAP,
+      UNKNOWN_LABEL
+    );
+
+    const result = filterRows(
+      [sameDayLateRow],
+      baseFilterState({ datePreset: 'custom', dateFrom: '2026-05-01', dateTo: '2026-06-01' }),
+      NOW
+    );
+
+    expect(result.map(r => r.id)).toEqual(['same-day']);
+  });
+
+  it('datePreset custom excludes a session started the day after dateTo', () => {
+    const nextDayRow = toHistoryRow(
+      makeDto({ id: 'next-day', startedAt: '2026-06-02T00:30:00Z' }),
+      GAME_NAME_MAP,
+      UNKNOWN_LABEL
+    );
+
+    const result = filterRows(
+      [nextDayRow],
+      baseFilterState({ datePreset: 'custom', dateFrom: '2026-05-01', dateTo: '2026-06-01' }),
+      NOW
+    );
+
+    expect(result).toEqual([]);
+  });
+
+  it('datePreset last30 excludes a session with a future startedAt beyond now', () => {
+    // NOW = 2026-07-15T12:00:00Z; a session "started" 5 days in the future
+    // is within the last-30-days lower bound but must still be excluded by
+    // the (now) upper bound.
+    const futureRow = toHistoryRow(
+      makeDto({ id: 'future', startedAt: '2026-07-20T00:00:00Z' }),
+      GAME_NAME_MAP,
+      UNKNOWN_LABEL
+    );
+
+    const result = filterRows([futureRow], baseFilterState({ datePreset: 'last30' }), NOW);
+
+    expect(result).toEqual([]);
+  });
+});
+
 // ─── sortRows ───────────────────────────────────────────────────────────────
 
 describe('sortRows', () => {

--- a/apps/web/src/app/(authenticated)/toolkit/history/__tests__/history-filters.test.ts
+++ b/apps/web/src/app/(authenticated)/toolkit/history/__tests__/history-filters.test.ts
@@ -1,0 +1,421 @@
+/**
+ * history-filters — unit tests for the pure filter/sort/paginate helpers
+ * that drive the /toolkit/history table (Issue #3006, Task A2).
+ *
+ * All date-dependent assertions use a fixed `NOW` — never `Date.now()` /
+ * `new Date()` (argless) — so the suite is deterministic regardless of
+ * when/where it runs.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import type { GameSessionDto } from '@/lib/api/schemas/games.schemas';
+
+import {
+  countActiveFilters,
+  filterRows,
+  paginate,
+  parseWinScore,
+  sortRows,
+  toHistoryRow,
+  type HistoryFilterState,
+  type HistoryRow,
+} from '../_lib/history-filters';
+
+const NOW = new Date('2026-07-15T12:00:00Z');
+
+const GAME_NAME_MAP = new Map<string, string>([
+  ['game-1', 'Wingspan'],
+  ['game-2', 'Catan'],
+]);
+
+const UNKNOWN_LABEL = 'Unknown game';
+
+function makeDto(overrides: Partial<GameSessionDto> = {}): GameSessionDto {
+  return {
+    id: 'session-1',
+    gameId: 'game-1',
+    status: 'Completed',
+    startedAt: '2026-07-10T10:00:00Z',
+    completedAt: '2026-07-10T12:00:00Z',
+    playerCount: 2,
+    players: [
+      { playerName: 'Alice', playerOrder: 0, color: null },
+      { playerName: 'Bob', playerOrder: 1, color: null },
+    ],
+    winnerName: 'Alice',
+    notes: null,
+    durationMinutes: 60,
+    scoringType: null,
+    scoreData: null,
+    turnOrderType: null,
+    ...overrides,
+  };
+}
+
+function baseFilterState(overrides: Partial<HistoryFilterState> = {}): HistoryFilterState {
+  return {
+    search: '',
+    gameIds: [],
+    winners: [],
+    datePreset: 'all',
+    sort: 'recent',
+    ...overrides,
+  };
+}
+
+// ─── parseWinScore ──────────────────────────────────────────────────────────
+
+describe('parseWinScore', () => {
+  it('returns the max value from a Record<string, number> scoreData payload', () => {
+    const dto = makeDto({ scoreData: JSON.stringify({ Alice: 42, Bob: 30 }) });
+    expect(parseWinScore(dto)).toBe(42);
+  });
+
+  it('returns the max value from a number[] scoreData payload', () => {
+    const dto = makeDto({ scoreData: JSON.stringify([10, 20, 30]) });
+    expect(parseWinScore(dto)).toBe(30);
+  });
+
+  it('returns null when scoreData is null', () => {
+    expect(parseWinScore(makeDto({ scoreData: null }))).toBeNull();
+  });
+
+  it('returns null when scoreData is undefined', () => {
+    expect(parseWinScore(makeDto({ scoreData: undefined }))).toBeNull();
+  });
+
+  it('returns null when scoreData is an empty string', () => {
+    expect(parseWinScore(makeDto({ scoreData: '' }))).toBeNull();
+  });
+
+  it('returns null when scoreData is invalid JSON', () => {
+    expect(parseWinScore(makeDto({ scoreData: '{not valid json' }))).toBeNull();
+  });
+
+  it('returns null when scoreData parses to an empty object', () => {
+    expect(parseWinScore(makeDto({ scoreData: '{}' }))).toBeNull();
+  });
+
+  it('returns null when scoreData parses to an empty array', () => {
+    expect(parseWinScore(makeDto({ scoreData: '[]' }))).toBeNull();
+  });
+
+  it('ignores non-numeric values in the payload', () => {
+    const dto = makeDto({ scoreData: JSON.stringify({ Alice: 42, Bob: 'DNF' }) });
+    expect(parseWinScore(dto)).toBe(42);
+  });
+});
+
+// ─── toHistoryRow ───────────────────────────────────────────────────────────
+
+describe('toHistoryRow', () => {
+  it('maps a dto to a HistoryRow using the game name map', () => {
+    const row = toHistoryRow(makeDto(), GAME_NAME_MAP, UNKNOWN_LABEL);
+    expect(row).toEqual<HistoryRow>({
+      id: 'session-1',
+      gameId: 'game-1',
+      gameName: 'Wingspan',
+      startedAt: '2026-07-10T10:00:00Z',
+      durationMinutes: 60,
+      playerNames: ['Alice', 'Bob'],
+      playerCount: 2,
+      winnerName: 'Alice',
+      isCoop: false,
+      winScore: null,
+      notes: null,
+    });
+  });
+
+  it('falls back to the unknown label when gameId is missing from the map', () => {
+    const row = toHistoryRow(makeDto({ gameId: 'ghost-game' }), GAME_NAME_MAP, UNKNOWN_LABEL);
+    expect(row.gameName).toBe(UNKNOWN_LABEL);
+  });
+
+  it('derives isCoop=true when winnerName is null and there is more than 1 player', () => {
+    const row = toHistoryRow(makeDto({ winnerName: null }), GAME_NAME_MAP, UNKNOWN_LABEL);
+    expect(row.isCoop).toBe(true);
+  });
+
+  it('derives isCoop=false for a single-player session with no winner', () => {
+    const row = toHistoryRow(
+      makeDto({
+        winnerName: null,
+        playerCount: 1,
+        players: [{ playerName: 'Alice', playerOrder: 0, color: null }],
+      }),
+      GAME_NAME_MAP,
+      UNKNOWN_LABEL
+    );
+    expect(row.isCoop).toBe(false);
+  });
+
+  it('derives isCoop=false when there is a winner, even with multiple players', () => {
+    const row = toHistoryRow(makeDto({ winnerName: 'Bob' }), GAME_NAME_MAP, UNKNOWN_LABEL);
+    expect(row.isCoop).toBe(false);
+  });
+
+  it('parses winScore from scoreData', () => {
+    const row = toHistoryRow(
+      makeDto({ scoreData: JSON.stringify({ Alice: 42, Bob: 30 }) }),
+      GAME_NAME_MAP,
+      UNKNOWN_LABEL
+    );
+    expect(row.winScore).toBe(42);
+  });
+});
+
+// ─── filterRows ─────────────────────────────────────────────────────────────
+
+describe('filterRows', () => {
+  const rows: HistoryRow[] = [
+    toHistoryRow(
+      makeDto({
+        id: 'r1',
+        gameId: 'game-1',
+        startedAt: '2026-07-10T10:00:00Z', // 5 days before NOW -> within last30
+        winnerName: 'Alice',
+        players: [
+          { playerName: 'Alice', playerOrder: 0, color: null },
+          { playerName: 'Bob', playerOrder: 1, color: null },
+        ],
+        durationMinutes: 60,
+        scoreData: JSON.stringify({ Alice: 42, Bob: 30 }),
+      }),
+      GAME_NAME_MAP,
+      UNKNOWN_LABEL
+    ),
+    toHistoryRow(
+      makeDto({
+        id: 'r2',
+        gameId: 'game-2',
+        startedAt: '2026-05-01T10:00:00Z', // ~75 days before NOW -> within last90, outside last30
+        winnerName: null,
+        playerCount: 3,
+        players: [
+          { playerName: 'Carol', playerOrder: 0, color: null },
+          { playerName: 'Dave', playerOrder: 1, color: null },
+          { playerName: 'Eve', playerOrder: 2, color: null },
+        ],
+        durationMinutes: 120,
+        scoreData: null,
+      }),
+      GAME_NAME_MAP,
+      UNKNOWN_LABEL
+    ),
+    toHistoryRow(
+      makeDto({
+        id: 'r3',
+        gameId: 'game-1',
+        startedAt: '2024-01-01T10:00:00Z', // well outside lastYear
+        winnerName: 'Charlie',
+        players: [
+          { playerName: 'Charlie', playerOrder: 0, color: null },
+          { playerName: 'Dana', playerOrder: 1, color: null },
+        ],
+        durationMinutes: 45,
+        scoreData: JSON.stringify([10, 20, 30]),
+      }),
+      GAME_NAME_MAP,
+      UNKNOWN_LABEL
+    ),
+  ];
+
+  it('matches search against gameName case-insensitively', () => {
+    const result = filterRows(rows, baseFilterState({ search: 'wingspan' }), NOW);
+    expect(result.map(r => r.id)).toEqual(['r1', 'r3']);
+  });
+
+  it('matches search against winnerName case-insensitively', () => {
+    const result = filterRows(rows, baseFilterState({ search: 'CHARLIE' }), NOW);
+    expect(result.map(r => r.id)).toEqual(['r3']);
+  });
+
+  it('matches search against player names case-insensitively', () => {
+    const result = filterRows(rows, baseFilterState({ search: 'eve' }), NOW);
+    expect(result.map(r => r.id)).toEqual(['r2']);
+  });
+
+  it('returns no rows when search matches nothing', () => {
+    const result = filterRows(rows, baseFilterState({ search: 'nonexistent-term' }), NOW);
+    expect(result).toEqual([]);
+  });
+
+  it('filters by gameIds', () => {
+    const result = filterRows(rows, baseFilterState({ gameIds: ['game-2'] }), NOW);
+    expect(result.map(r => r.id)).toEqual(['r2']);
+  });
+
+  it('filters by winners, matching the exact winnerName', () => {
+    const result = filterRows(rows, baseFilterState({ winners: ['Alice'] }), NOW);
+    expect(result.map(r => r.id)).toEqual(['r1']);
+  });
+
+  it("filters by winners using '__nowin__' to match winnerName === null", () => {
+    const result = filterRows(rows, baseFilterState({ winners: ['__nowin__'] }), NOW);
+    expect(result.map(r => r.id)).toEqual(['r2']);
+  });
+
+  it('filters by winners with multiple values (OR semantics)', () => {
+    const result = filterRows(rows, baseFilterState({ winners: ['Alice', '__nowin__'] }), NOW);
+    expect(result.map(r => r.id)).toEqual(['r1', 'r2']);
+  });
+
+  it('datePreset last30 excludes rows started more than 30 days ago', () => {
+    const result = filterRows(rows, baseFilterState({ datePreset: 'last30' }), NOW);
+    expect(result.map(r => r.id)).toEqual(['r1']);
+  });
+
+  it('datePreset last90 includes rows within 90 days but excludes older ones', () => {
+    const result = filterRows(rows, baseFilterState({ datePreset: 'last90' }), NOW);
+    expect(result.map(r => r.id)).toEqual(['r1', 'r2']);
+  });
+
+  it('datePreset lastYear excludes rows started more than a year ago', () => {
+    const result = filterRows(rows, baseFilterState({ datePreset: 'lastYear' }), NOW);
+    expect(result.map(r => r.id)).toEqual(['r1', 'r2']);
+  });
+
+  it('datePreset custom uses dateFrom/dateTo bounds (inclusive range)', () => {
+    const result = filterRows(
+      rows,
+      baseFilterState({ datePreset: 'custom', dateFrom: '2026-04-01', dateTo: '2026-06-01' }),
+      NOW
+    );
+    expect(result.map(r => r.id)).toEqual(['r2']);
+  });
+
+  it('datePreset all applies no date filtering', () => {
+    const result = filterRows(rows, baseFilterState({ datePreset: 'all' }), NOW);
+    expect(result.map(r => r.id)).toEqual(['r1', 'r2', 'r3']);
+  });
+
+  it('combines multiple active filters (search + gameIds + datePreset)', () => {
+    const result = filterRows(
+      rows,
+      baseFilterState({ search: 'alice', gameIds: ['game-1'], datePreset: 'last30' }),
+      NOW
+    );
+    expect(result.map(r => r.id)).toEqual(['r1']);
+  });
+
+  it('returns all rows when no filters are active', () => {
+    const result = filterRows(rows, baseFilterState(), NOW);
+    expect(result.map(r => r.id)).toEqual(['r1', 'r2', 'r3']);
+  });
+});
+
+// ─── sortRows ───────────────────────────────────────────────────────────────
+
+describe('sortRows', () => {
+  const rows: HistoryRow[] = [
+    toHistoryRow(
+      makeDto({
+        id: 'a',
+        startedAt: '2026-06-01T00:00:00Z',
+        durationMinutes: 30,
+        scoreData: JSON.stringify({ x: 10 }),
+      }),
+      GAME_NAME_MAP,
+      UNKNOWN_LABEL
+    ),
+    toHistoryRow(
+      makeDto({
+        id: 'b',
+        startedAt: '2026-07-01T00:00:00Z',
+        durationMinutes: 90,
+        scoreData: JSON.stringify({ x: 50 }),
+      }),
+      GAME_NAME_MAP,
+      UNKNOWN_LABEL
+    ),
+    toHistoryRow(
+      makeDto({
+        id: 'c',
+        startedAt: '2026-05-01T00:00:00Z',
+        durationMinutes: 60,
+        scoreData: null,
+      }),
+      GAME_NAME_MAP,
+      UNKNOWN_LABEL
+    ),
+  ];
+
+  it('sorts by recent (startedAt desc)', () => {
+    expect(sortRows(rows, 'recent').map(r => r.id)).toEqual(['b', 'a', 'c']);
+  });
+
+  it('sorts by oldest (startedAt asc)', () => {
+    expect(sortRows(rows, 'oldest').map(r => r.id)).toEqual(['c', 'a', 'b']);
+  });
+
+  it('sorts by longest (durationMinutes desc)', () => {
+    expect(sortRows(rows, 'longest').map(r => r.id)).toEqual(['b', 'c', 'a']);
+  });
+
+  it('sorts by score (winScore desc, nulls last)', () => {
+    expect(sortRows(rows, 'score').map(r => r.id)).toEqual(['b', 'a', 'c']);
+  });
+
+  it('does not mutate the input array', () => {
+    const original = rows.map(r => r.id);
+    sortRows(rows, 'recent');
+    expect(rows.map(r => r.id)).toEqual(original);
+  });
+});
+
+// ─── paginate ───────────────────────────────────────────────────────────────
+
+describe('paginate', () => {
+  const items = Array.from({ length: 45 }, (_, i) => i);
+
+  it('returns the first page (page 1, pageSize 20)', () => {
+    expect(paginate(items, 1, 20)).toEqual(items.slice(0, 20));
+  });
+
+  it('returns items 20..39 for page 2, pageSize 20', () => {
+    expect(paginate(items, 2, 20)).toEqual(Array.from({ length: 20 }, (_, i) => i + 20));
+  });
+
+  it('returns the remaining partial page', () => {
+    expect(paginate(items, 3, 20)).toEqual([40, 41, 42, 43, 44]);
+  });
+
+  it('returns an empty array when the page is beyond the data', () => {
+    expect(paginate(items, 10, 20)).toEqual([]);
+  });
+});
+
+// ─── countActiveFilters ─────────────────────────────────────────────────────
+
+describe('countActiveFilters', () => {
+  it('returns 0 when no filters are active', () => {
+    expect(countActiveFilters(baseFilterState())).toBe(0);
+  });
+
+  it('counts search + 1 game + custom date as 3', () => {
+    const count = countActiveFilters(
+      baseFilterState({ search: 'wingspan', gameIds: ['game-1'], datePreset: 'custom' })
+    );
+    expect(count).toBe(3);
+  });
+
+  it('counts winners as an active filter', () => {
+    expect(countActiveFilters(baseFilterState({ winners: ['Alice'] }))).toBe(1);
+  });
+
+  it('does not count sort as an active filter', () => {
+    expect(countActiveFilters(baseFilterState({ sort: 'longest' }))).toBe(0);
+  });
+
+  it('does not count whitespace-only search as active', () => {
+    expect(countActiveFilters(baseFilterState({ search: '   ' }))).toBe(0);
+  });
+
+  it('counts multiple gameIds/winners as a single active filter each', () => {
+    const count = countActiveFilters(
+      baseFilterState({ gameIds: ['game-1', 'game-2'], winners: ['Alice', 'Bob'] })
+    );
+    expect(count).toBe(2);
+  });
+});

--- a/apps/web/src/app/(authenticated)/toolkit/history/__tests__/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/toolkit/history/__tests__/page.test.tsx
@@ -1,0 +1,134 @@
+/**
+ * ToolkitHistoryPage — orchestrator smoke tests (Issue #3006, Task A9).
+ *
+ * Renders the real i18n catalog via `renderWithQuery` (EN messages, matching
+ * the established `@/__tests__/utils/query-test-utils` pattern used across
+ * the app) so assertions exercise the actual translation ids, not a
+ * passthrough mock. `api.sessions.getHistory` and `useLibrary` are mocked;
+ * `next/navigation`'s `useRouter` is mocked to a `push` spy since the empty
+ * state CTA navigates to `/toolkit`.
+ */
+
+import { screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { renderWithQuery } from '@/__tests__/utils/query-test-utils';
+
+import ToolkitHistoryPage from '../client';
+
+const mockGetHistory = vi.hoisted(() => vi.fn());
+const mockUseLibrary = vi.hoisted(() => vi.fn());
+const pushSpy = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    sessions: {
+      getHistory: mockGetHistory,
+    },
+  },
+}));
+
+vi.mock('@/hooks/queries/useLibrary', () => ({
+  useLibrary: mockUseLibrary,
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: pushSpy }),
+}));
+
+const LIBRARY_DATA = {
+  items: [
+    { gameId: 'game-1', gameTitle: 'Wingspan' },
+    { gameId: 'game-2', gameTitle: 'Pandemic' },
+  ],
+  page: 1,
+  pageSize: 500,
+  totalCount: 2,
+};
+
+const SESSION_1 = {
+  id: 'session-1',
+  gameId: 'game-1',
+  status: 'Completed',
+  startedAt: '2026-07-10T14:30:00Z',
+  completedAt: '2026-07-10T16:05:00Z',
+  playerCount: 2,
+  players: [
+    { playerName: 'Alice', playerOrder: 0, color: null },
+    { playerName: 'Bob', playerOrder: 1, color: null },
+  ],
+  winnerName: 'Alice',
+  notes: 'Great game!',
+  durationMinutes: 95,
+  scoringType: null,
+  scoreData: JSON.stringify({ Alice: 42, Bob: 30 }),
+  turnOrderType: null,
+};
+
+const SESSION_2 = {
+  id: 'session-2',
+  gameId: 'game-2',
+  status: 'Completed',
+  startedAt: '2026-07-05T10:00:00Z',
+  completedAt: '2026-07-05T11:00:00Z',
+  playerCount: 2,
+  players: [
+    { playerName: 'Cara', playerOrder: 0, color: null },
+    { playerName: 'Dan', playerOrder: 1, color: null },
+  ],
+  winnerName: null,
+  notes: null,
+  durationMinutes: 60,
+  scoringType: null,
+  scoreData: null,
+  turnOrderType: null,
+};
+
+function mockHistoryResponse(sessions: unknown[]) {
+  mockGetHistory.mockResolvedValue({
+    sessions,
+    total: sessions.length,
+    page: 1,
+    pageSize: 500,
+  });
+}
+
+describe('ToolkitHistoryPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseLibrary.mockReturnValue({ data: LIBRARY_DATA, isLoading: false, isError: false });
+  });
+
+  it('renders the localized page title', async () => {
+    mockHistoryResponse([SESSION_1, SESSION_2]);
+    renderWithQuery(<ToolkitHistoryPage />);
+
+    expect(await screen.findByRole('heading', { name: 'Session history' })).toBeInTheDocument();
+  });
+
+  it('renders a table row for each fetched session', async () => {
+    mockHistoryResponse([SESSION_1, SESSION_2]);
+    renderWithQuery(<ToolkitHistoryPage />);
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('row')).toHaveLength(3); // 1 header + 2 sessions
+    });
+    expect(screen.getByText('Wingspan')).toBeInTheDocument();
+    expect(screen.getByText('Pandemic')).toBeInTheDocument();
+  });
+
+  it('shows the empty state when there are no sessions', async () => {
+    mockHistoryResponse([]);
+    renderWithQuery(<ToolkitHistoryPage />);
+
+    expect(await screen.findByText('No sessions yet')).toBeInTheDocument();
+  });
+
+  it('shows the error state and retries when the query rejects', async () => {
+    mockGetHistory.mockRejectedValue(new Error('network down'));
+    renderWithQuery(<ToolkitHistoryPage />);
+
+    expect(await screen.findByRole('alert')).toHaveTextContent('Unable to load history');
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/(authenticated)/toolkit/history/__tests__/relative-time.test.ts
+++ b/apps/web/src/app/(authenticated)/toolkit/history/__tests__/relative-time.test.ts
@@ -1,0 +1,128 @@
+/**
+ * relative-time — bucket boundary tests (Issue #3006, Task A5 EXTRA SCOPE).
+ *
+ * All cases use a fixed `NOW` and construct `iso` from explicit millisecond
+ * offsets (via the readable MINUTE/HOUR/DAY/MONTH/YEAR constants below) so
+ * the tests are deterministic and independent of wall-clock time.
+ *
+ * Boundary cases specifically exercise the off-by-one fix: the escalation
+ * decision must be made on the ROUNDED value of the current unit, not the
+ * raw fractional diff (e.g. 59.6 minutes must escalate to "1 hour", not
+ * render as "60 minutes").
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { getRelativeTimeParts } from '../_lib/relative-time';
+
+const NOW = new Date('2026-07-15T12:00:00.000Z');
+
+const MINUTE = 60_000;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+const MONTH = 30 * DAY;
+const YEAR = 12 * MONTH;
+
+function isoAfter(offsetMs: number): string {
+  return new Date(NOW.getTime() + offsetMs).toISOString();
+}
+
+describe('getRelativeTimeParts', () => {
+  it('buckets a future diff of 10 minutes as {value: 10, unit: "minute"}', () => {
+    expect(getRelativeTimeParts(isoAfter(10 * MINUTE), NOW)).toEqual({
+      value: 10,
+      unit: 'minute',
+    });
+  });
+
+  it('buckets a past diff of 10 minutes as {value: -10, unit: "minute"}', () => {
+    expect(getRelativeTimeParts(isoAfter(-10 * MINUTE), NOW)).toEqual({
+      value: -10,
+      unit: 'minute',
+    });
+  });
+
+  it('escalates a 59.6-minute diff to {value: 1, unit: "hour"} instead of "60 minutes" (off-by-one fix)', () => {
+    expect(getRelativeTimeParts(isoAfter(59.6 * MINUTE), NOW)).toEqual({
+      value: 1,
+      unit: 'hour',
+    });
+  });
+
+  it('keeps a 58-minute diff in the minute bucket', () => {
+    expect(getRelativeTimeParts(isoAfter(58 * MINUTE), NOW)).toEqual({
+      value: 58,
+      unit: 'minute',
+    });
+  });
+
+  it('buckets a 5-hour diff as {value: 5, unit: "hour"}', () => {
+    expect(getRelativeTimeParts(isoAfter(5 * HOUR), NOW)).toEqual({
+      value: 5,
+      unit: 'hour',
+    });
+  });
+
+  it('escalates a 23.6-hour diff to {value: 1, unit: "day"}', () => {
+    expect(getRelativeTimeParts(isoAfter(23.6 * HOUR), NOW)).toEqual({
+      value: 1,
+      unit: 'day',
+    });
+  });
+
+  it('keeps a 22-hour diff in the hour bucket', () => {
+    expect(getRelativeTimeParts(isoAfter(22 * HOUR), NOW)).toEqual({
+      value: 22,
+      unit: 'hour',
+    });
+  });
+
+  it('buckets a 3-day diff as {value: 3, unit: "day"}', () => {
+    expect(getRelativeTimeParts(isoAfter(3 * DAY), NOW)).toEqual({
+      value: 3,
+      unit: 'day',
+    });
+  });
+
+  it('escalates a 29.6-day diff to {value: 1, unit: "month"}', () => {
+    expect(getRelativeTimeParts(isoAfter(29.6 * DAY), NOW)).toEqual({
+      value: 1,
+      unit: 'month',
+    });
+  });
+
+  it('keeps a 25-day diff in the day bucket', () => {
+    expect(getRelativeTimeParts(isoAfter(25 * DAY), NOW)).toEqual({
+      value: 25,
+      unit: 'day',
+    });
+  });
+
+  it('buckets a 2-month diff as {value: 2, unit: "month"}', () => {
+    expect(getRelativeTimeParts(isoAfter(2 * MONTH), NOW)).toEqual({
+      value: 2,
+      unit: 'month',
+    });
+  });
+
+  it('escalates an 11.6-month diff to {value: 1, unit: "year"}', () => {
+    expect(getRelativeTimeParts(isoAfter(11.6 * MONTH), NOW)).toEqual({
+      value: 1,
+      unit: 'year',
+    });
+  });
+
+  it('keeps a 6-month diff in the month bucket', () => {
+    expect(getRelativeTimeParts(isoAfter(6 * MONTH), NOW)).toEqual({
+      value: 6,
+      unit: 'month',
+    });
+  });
+
+  it('buckets a 2-year diff as {value: 2, unit: "year"}', () => {
+    expect(getRelativeTimeParts(isoAfter(2 * YEAR), NOW)).toEqual({
+      value: 2,
+      unit: 'year',
+    });
+  });
+});

--- a/apps/web/src/app/(authenticated)/toolkit/history/_components/HistoryCards.tsx
+++ b/apps/web/src/app/(authenticated)/toolkit/history/_components/HistoryCards.tsx
@@ -1,0 +1,186 @@
+'use client';
+
+import type { JSX } from 'react';
+
+import { EntityChip } from '@/components/ui/entity-chip/entity-chip';
+import { useTranslation } from '@/hooks/useTranslation';
+import { cn } from '@/lib/utils';
+
+import { getRelativeTimeParts } from '../_lib/relative-time';
+
+import type { HistoryRow } from '../_lib/history-filters';
+
+export interface HistoryCardsProps {
+  rows: HistoryRow[];
+  onOpenDetail: (row: HistoryRow) => void;
+}
+
+/** Max number of player avatars shown before collapsing the rest into a "+N" pill. */
+const MAX_AVATARS = 3;
+
+/** Formats a session duration in minutes as `"{h}h {m}m"`. */
+function formatDuration(minutes: number): string {
+  const h = Math.floor(minutes / 60);
+  const m = minutes % 60;
+  return `${h}h ${m}m`;
+}
+
+/** Derives up to 2 uppercase initials from a player's display name. */
+function getInitials(name: string): string {
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return '?';
+  if (parts.length === 1) return (parts[0] as string).slice(0, 2).toUpperCase();
+  const first = parts[0] as string;
+  const last = parts[parts.length - 1] as string;
+  return `${first[0]}${last[0]}`.toUpperCase();
+}
+
+interface HistoryCardProps {
+  row: HistoryRow;
+  onOpenDetail: (row: HistoryRow) => void;
+}
+
+/**
+ * A single session card matching the mockup's `SessionCard` structure:
+ * `chead` (game chip + relative date), `cmid` (avatar stack + winner cell +
+ * duration pill), `cfoot` (score pill + note flag + absolute date). The left
+ * border is highlighted when the session has a winner (a "win").
+ */
+function HistoryCard({ row, onOpenDetail }: HistoryCardProps): JSX.Element {
+  const { t, formatDate, formatRelativeTime } = useTranslation();
+  const now = new Date();
+  const { value: relValue, unit: relUnit } = getRelativeTimeParts(row.startedAt, now);
+
+  const isWin = !row.isCoop && row.winnerName != null;
+
+  const handleOpen = () => onOpenDetail(row);
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      aria-label={`${row.gameName} — ${t('pages.toolkitHistory.table.viewDetails')}`}
+      className={cn(
+        'flex cursor-pointer flex-col gap-3 rounded-lg border border-border bg-card p-4 shadow-sm transition-shadow hover:shadow-md',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+        isWin && 'border-l-4 border-l-primary'
+      )}
+      onClick={handleOpen}
+      onKeyDown={e => {
+        if (e.key === 'Enter') {
+          e.preventDefault();
+          handleOpen();
+        }
+      }}
+    >
+      {/* chead */}
+      <div className="flex items-center gap-2">
+        <EntityChip entity="game" label={row.gameName} />
+        <span className="flex-1" />
+        <span className="text-xs text-muted-foreground">
+          {formatRelativeTime(relValue, relUnit)}
+        </span>
+      </div>
+
+      {/* cmid */}
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="sr-only">{t('pages.toolkitHistory.table.players')}</span>
+        <span
+          role="img"
+          aria-label={t('pages.toolkitHistory.table.playersAria', {
+            count: row.playerCount,
+            names: row.playerNames.join(', '),
+          })}
+          className="inline-flex items-center -space-x-2"
+        >
+          {row.playerNames.slice(0, MAX_AVATARS).map((name, i) => (
+            <span
+              key={`${row.id}-avatar-${i}`}
+              aria-hidden="true"
+              className="inline-flex h-7 w-7 items-center justify-center rounded-full border border-border bg-muted text-xs font-semibold text-foreground"
+            >
+              {getInitials(name)}
+            </span>
+          ))}
+          {row.playerCount > MAX_AVATARS && (
+            <span
+              aria-hidden="true"
+              className="inline-flex h-7 w-7 items-center justify-center rounded-full border border-border bg-muted text-xs font-semibold text-muted-foreground"
+            >
+              +{row.playerCount - MAX_AVATARS}
+            </span>
+          )}
+        </span>
+
+        <span className="sr-only">{t('pages.toolkitHistory.table.winner')}</span>
+        {row.isCoop ? (
+          <span className="inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
+            <span aria-hidden="true">🤝</span>
+            {t('pages.toolkitHistory.table.coop')}
+          </span>
+        ) : row.winnerName == null ? (
+          <span
+            className="text-xs text-muted-foreground"
+            aria-label={t('pages.toolkitHistory.table.noWinner')}
+          >
+            —
+          </span>
+        ) : (
+          <span
+            className="inline-flex items-center gap-1 rounded-full bg-primary px-2 py-0.5 text-xs font-medium text-primary-foreground"
+            title={t('pages.toolkitHistory.table.winnerAria', { name: row.winnerName })}
+          >
+            <span aria-hidden="true">🏆</span>
+            {row.winnerName}
+          </span>
+        )}
+
+        <span className="ml-auto inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
+          <span aria-hidden="true">⏱</span>
+          {formatDuration(row.durationMinutes)}
+        </span>
+      </div>
+
+      {/* cfoot */}
+      <div className="flex items-center gap-2 border-t border-border pt-3">
+        {row.isCoop ? (
+          <span className="inline-flex items-center gap-1 rounded-md bg-muted px-2 py-1 text-xs font-semibold text-muted-foreground">
+            <span aria-hidden="true">🤝</span>
+            {t('pages.toolkitHistory.cards.coop')}
+          </span>
+        ) : (
+          <span className="inline-flex items-center gap-1 rounded-md bg-primary/10 px-2 py-1 text-xs font-semibold text-primary">
+            <span aria-hidden="true">🏆</span>
+            {row.winScore ?? '—'}
+          </span>
+        )}
+        <span className="flex-1" />
+        {row.notes && (
+          <span aria-label={t('pages.toolkitHistory.table.hasNote')} title={row.notes}>
+            <span aria-hidden="true">📝</span>
+          </span>
+        )}
+        <span className="text-xs text-muted-foreground">{formatDate(new Date(row.startedAt))}</span>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Card stack for /toolkit/history (Issue #3006, Task A5) — used for the
+ * "cards" view toggle on desktop and as the sole view on mobile.
+ *
+ * Matches `admin-mockups/design_files/sp4-toolkit-history-ui.jsx`'s
+ * `Cards`/`SessionCard` components. Shares the relative-time bucketing
+ * helper (`_lib/relative-time.ts`) with `HistoryTable` so both views render
+ * identical relative-date labels.
+ */
+export function HistoryCards({ rows, onOpenDetail }: HistoryCardsProps): JSX.Element {
+  return (
+    <div className="flex flex-col gap-3">
+      {rows.map(row => (
+        <HistoryCard key={row.id} row={row} onOpenDetail={onOpenDetail} />
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/app/(authenticated)/toolkit/history/_components/HistoryDetailModal.tsx
+++ b/apps/web/src/app/(authenticated)/toolkit/history/_components/HistoryDetailModal.tsx
@@ -1,0 +1,224 @@
+'use client';
+
+import type { JSX } from 'react';
+
+import {
+  Drawer,
+  DrawerClose,
+  DrawerContent,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerTitle,
+} from '@/components/ui/drawer/drawer';
+import { Button } from '@/components/ui/primitives/button';
+import { useTranslation } from '@/hooks/useTranslation';
+import { cn } from '@/lib/utils';
+
+import type { HistoryRow } from '../_lib/history-filters';
+
+export interface HistoryDetailModalProps {
+  row: HistoryRow | null;
+  onClose: () => void;
+}
+
+/** Formats a session duration in minutes as `"{h}h {m}m"` — mirrors HistoryTable/HistoryCards. */
+function formatDuration(minutes: number): string {
+  const h = Math.floor(minutes / 60);
+  const m = minutes % 60;
+  return `${h}h ${m}m`;
+}
+
+/** Derives up to 2 uppercase initials from a player's display name — mirrors HistoryTable/HistoryCards. */
+function getInitials(name: string): string {
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return '?';
+  if (parts.length === 1) return (parts[0] as string).slice(0, 2).toUpperCase();
+  const first = parts[0] as string;
+  const last = parts[parts.length - 1] as string;
+  return `${first[0]}${last[0]}`.toUpperCase();
+}
+
+/**
+ * Session detail overlay for /toolkit/history (Issue #3006, Task A8) — a desktop
+ * side panel / mobile bottom sheet via the shared `Drawer` primitive (`side="auto"`
+ * picks the mode from the viewport breakpoint).
+ *
+ * Matches `admin-mockups/design_files/sp4-toolkit-history-ui.jsx`'s `DetailModal`,
+ * degraded to the fields the real `HistoryRow` view-model actually carries:
+ *  - **Classifica finale**: player list from `playerNames`, winner marked with 🏆
+ *    (`playerName === winnerName`). Per-player scores are NOT derivable — the API
+ *    payload has no name→score correlation once mapped to `HistoryRow` — so every
+ *    score slot renders `modal.noData` rather than inventing a number.
+ *  - **Statistiche partita**: turns/variance/highlights have no backing data at all
+ *    → `modal.noData`. Only "Score vincitore" has real data (`row.winScore`).
+ *  - **Timeline eventi**: omitted entirely — the API exposes no session event log.
+ *  - **Note**: readonly display of `row.notes`, or `modal.notesEmpty` when absent.
+ *
+ * Footer actions (stats gioco / gioca di nuovo / modifica note / elimina) are
+ * unwired placeholders — no command exists yet for any of them.
+ */
+export function HistoryDetailModal({ row, onClose }: HistoryDetailModalProps): JSX.Element | null {
+  const { t, formatDate, formatTime } = useTranslation();
+
+  if (row == null) return null;
+
+  const startedAtDate = new Date(row.startedAt);
+  const noData = t('pages.toolkitHistory.modal.noData');
+
+  return (
+    <Drawer
+      open
+      onOpenChange={next => {
+        if (!next) onClose();
+      }}
+      side="auto"
+      entity="session"
+    >
+      <DrawerContent>
+        <DrawerHeader>
+          <div className="flex items-start justify-between gap-2">
+            <div className="flex flex-col gap-1">
+              <DrawerTitle>
+                {t('pages.toolkitHistory.modal.title', {
+                  game: row.gameName,
+                  date: formatDate(startedAtDate),
+                })}
+              </DrawerTitle>
+              <DrawerDescription>
+                {t('pages.toolkitHistory.modal.sub', {
+                  duration: formatDuration(row.durationMinutes),
+                  count: row.playerCount,
+                  time: formatTime(startedAtDate),
+                })}
+              </DrawerDescription>
+            </div>
+            <DrawerClose aria-label={t('pages.toolkitHistory.modal.close')} className="shrink-0">
+              <span aria-hidden="true">✕</span>
+            </DrawerClose>
+          </div>
+        </DrawerHeader>
+
+        <div className="flex min-h-0 flex-1 flex-col gap-6 overflow-y-auto p-4">
+          {/* Classifica finale */}
+          <section>
+            <h4 className="mb-2 text-sm font-semibold text-foreground">
+              {t('pages.toolkitHistory.modal.leaderboard')}
+            </h4>
+            <ul className="flex flex-col gap-2">
+              {row.playerNames.map((name, i) => {
+                const isWinner = !row.isCoop && row.winnerName != null && name === row.winnerName;
+                return (
+                  <li
+                    key={`${row.id}-player-${i}`}
+                    className={cn(
+                      'flex items-center justify-between rounded-md border border-border px-3 py-2',
+                      isWinner && 'border-primary/40 bg-primary/5'
+                    )}
+                  >
+                    <span className="flex items-center gap-2">
+                      <span
+                        aria-hidden="true"
+                        className="inline-flex h-7 w-7 items-center justify-center rounded-full border border-border bg-muted text-xs font-semibold text-foreground"
+                      >
+                        {getInitials(name)}
+                      </span>
+                      <span className="text-sm text-foreground">{name}</span>
+                    </span>
+                    <span className="flex items-center gap-1 text-sm text-muted-foreground">
+                      {noData}
+                      {isWinner && <span aria-hidden="true">🏆</span>}
+                    </span>
+                  </li>
+                );
+              })}
+            </ul>
+          </section>
+
+          {/* Note */}
+          <section>
+            <h4 className="mb-2 text-sm font-semibold text-foreground">
+              {t('pages.toolkitHistory.modal.notes')}
+            </h4>
+            {row.notes ? (
+              <p className="whitespace-pre-wrap rounded-md border border-border bg-muted/30 p-3 text-sm text-foreground">
+                {row.notes}
+              </p>
+            ) : (
+              <p className="text-sm text-muted-foreground">
+                {t('pages.toolkitHistory.modal.notesEmpty')}
+              </p>
+            )}
+          </section>
+
+          {/* Statistiche partita */}
+          <section>
+            <h4 className="mb-2 text-sm font-semibold text-foreground">
+              {t('pages.toolkitHistory.modal.stats')}
+            </h4>
+            <div className="grid grid-cols-2 gap-3">
+              <div
+                className="rounded-md border border-border p-3"
+                data-testid="history-detail-modal-stat-turns"
+              >
+                <div className="text-xs text-muted-foreground">
+                  {t('pages.toolkitHistory.modal.turns')}
+                </div>
+                <div className="text-sm font-semibold text-foreground">{noData}</div>
+              </div>
+              <div
+                className="rounded-md border border-border p-3"
+                data-testid="history-detail-modal-stat-winner-score"
+              >
+                <div className="text-xs text-muted-foreground">
+                  {t('pages.toolkitHistory.modal.winnerScore')}
+                </div>
+                <div className="text-sm font-semibold text-foreground">
+                  {row.winScore ?? noData}
+                </div>
+              </div>
+              <div
+                className="rounded-md border border-border p-3"
+                data-testid="history-detail-modal-stat-variance"
+              >
+                <div className="text-xs text-muted-foreground">
+                  {t('pages.toolkitHistory.modal.variance')}
+                </div>
+                <div className="text-sm font-semibold text-foreground">{noData}</div>
+              </div>
+              <div
+                className="rounded-md border border-border p-3"
+                data-testid="history-detail-modal-stat-highlights"
+              >
+                <div className="text-xs text-muted-foreground">
+                  {t('pages.toolkitHistory.modal.highlights')}
+                </div>
+                <div className="text-sm font-semibold text-foreground">{noData}</div>
+              </div>
+            </div>
+          </section>
+        </div>
+
+        <DrawerFooter className="flex-wrap">
+          <Button type="button" variant="outline" size="sm">
+            <span aria-hidden="true">📊</span>
+            {t('pages.toolkitHistory.modal.gameStats')}
+          </Button>
+          <Button type="button" variant="outline" size="sm">
+            <span aria-hidden="true">🎮</span>
+            {t('pages.toolkitHistory.modal.playAgain')}
+          </Button>
+          <span className="flex-1" />
+          <Button type="button" variant="ghost" size="sm">
+            <span aria-hidden="true">📝</span>
+            {t('pages.toolkitHistory.modal.editNotes')}
+          </Button>
+          <Button type="button" variant="destructive" size="sm">
+            <span aria-hidden="true">🗑</span>
+            {t('pages.toolkitHistory.modal.delete')}
+          </Button>
+        </DrawerFooter>
+      </DrawerContent>
+    </Drawer>
+  );
+}

--- a/apps/web/src/app/(authenticated)/toolkit/history/_components/HistoryPagination.tsx
+++ b/apps/web/src/app/(authenticated)/toolkit/history/_components/HistoryPagination.tsx
@@ -1,0 +1,207 @@
+'use client';
+
+import type { JSX } from 'react';
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/overlays/select';
+import { Button } from '@/components/ui/primitives/button';
+import { useTranslation } from '@/hooks/useTranslation';
+
+export interface HistoryPaginationProps {
+  page: number;
+  total: number;
+  pageSize: number;
+  onPageChange: (page: number) => void;
+  onPageSizeChange: (size: number) => void;
+}
+
+/** Selectable page-size options, matching the mockup's `[10, 20, 50, 100]`. */
+const PAGE_SIZE_OPTIONS = [10, 20, 50, 100];
+
+type PageListEntry = number | 'ellipsis-left' | 'ellipsis-right';
+
+/**
+ * Builds the visible page-number list with `…` ellipses for a given current
+ * page and page count. Ports the mockup's `pageList()` helper (also mirrored
+ * by `CatalogPagination`'s `getPageNumbers()`): all pages when `pages <= 7`,
+ * otherwise first + last page pinned with a sliding 3-page window around the
+ * current page and ellipses filling the gaps.
+ */
+function getPageList(current: number, pages: number): PageListEntry[] {
+  const out: PageListEntry[] = [];
+  if (pages <= 7) {
+    for (let i = 1; i <= pages; i++) out.push(i);
+    return out;
+  }
+
+  out.push(1);
+  let lo = Math.max(2, current - 1);
+  let hi = Math.min(pages - 1, current + 1);
+  if (current <= 3) {
+    lo = 2;
+    hi = 4;
+  }
+  if (current >= pages - 2) {
+    lo = pages - 3;
+    hi = pages - 1;
+  }
+  if (lo > 2) out.push('ellipsis-left');
+  for (let i = lo; i <= hi; i++) out.push(i);
+  if (hi < pages - 1) out.push('ellipsis-right');
+  out.push(pages);
+
+  return out;
+}
+
+/**
+ * Client-side pagination bar for /toolkit/history (Issue #3006, Task A6).
+ *
+ * `total` is the real filtered-result count (the history orchestrator fetches
+ * a batch and paginates the already-filtered rows client-side, per the task
+ * brief), so `pages = ceil(total / pageSize)` and the `{from}–{to}` range are
+ * computed directly here rather than trusting server metadata.
+ *
+ * Matches `admin-mockups/design_files/sp4-toolkit-history-ui.jsx`'s
+ * `Pagination` component: a desktop layout (← Prec. · page numbers with `···`
+ * ellipsis · Succ. → · range meta · per-page select) hidden below `sm`, and a
+ * compact mobile layout (← · "Pag. X di Y · N sess." · →) hidden at `sm` and
+ * up. Both are rendered so the pagination controls survive SSR/CSR without a
+ * media-query hydration flicker; only one is visible at a time via Tailwind's
+ * responsive display utilities.
+ */
+export function HistoryPagination({
+  page,
+  total,
+  pageSize,
+  onPageChange,
+  onPageSizeChange,
+}: HistoryPaginationProps): JSX.Element {
+  const { t } = useTranslation();
+
+  const pages = Math.max(1, Math.ceil(total / pageSize));
+  const from = total === 0 ? 0 : (page - 1) * pageSize + 1;
+  const to = Math.min(page * pageSize, total);
+  const rangeLabel =
+    total === 0
+      ? t('pages.toolkitHistory.pagination.empty')
+      : t('pages.toolkitHistory.pagination.rangeMeta', { from, to, total });
+  const mobileLabel = t('pages.toolkitHistory.pagination.mobileMeta', { page, pages, total });
+  const prevAria = t('pages.toolkitHistory.pagination.prevAria');
+  const nextAria = t('pages.toolkitHistory.pagination.nextAria');
+
+  const canPrev = page > 1;
+  const canNext = page < pages;
+
+  const handlePrev = () => {
+    if (canPrev) onPageChange(page - 1);
+  };
+  const handleNext = () => {
+    if (canNext) onPageChange(page + 1);
+  };
+
+  const pageList = getPageList(page, pages);
+
+  return (
+    <nav className="flex flex-col gap-3" aria-label={t('pages.toolkitHistory.pagination.listAria')}>
+      {/* Mobile layout */}
+      <div
+        data-testid="history-pagination-mobile"
+        className="flex items-center justify-between gap-3 sm:hidden"
+      >
+        <Button
+          variant="outline"
+          size="icon"
+          onClick={handlePrev}
+          disabled={!canPrev}
+          aria-label={prevAria}
+        >
+          <span aria-hidden="true">←</span>
+        </Button>
+        <span className="text-sm text-muted-foreground">{mobileLabel}</span>
+        <Button
+          variant="outline"
+          size="icon"
+          onClick={handleNext}
+          disabled={!canNext}
+          aria-label={nextAria}
+        >
+          <span aria-hidden="true">→</span>
+        </Button>
+      </div>
+
+      {/* Desktop layout */}
+      <div
+        data-testid="history-pagination-desktop"
+        className="hidden flex-wrap items-center gap-3 sm:flex"
+      >
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={handlePrev}
+          disabled={!canPrev}
+          aria-label={prevAria}
+        >
+          <span aria-hidden="true">←</span> {t('pages.toolkitHistory.pagination.prev')}
+        </Button>
+
+        <div className="flex items-center gap-1">
+          {pageList.map((entry, i) =>
+            typeof entry === 'number' ? (
+              <Button
+                key={entry}
+                variant={entry === page ? 'default' : 'outline'}
+                size="icon"
+                onClick={() => onPageChange(entry)}
+                aria-current={entry === page ? 'page' : undefined}
+              >
+                {entry}
+              </Button>
+            ) : (
+              <span key={`${entry}-${i}`} aria-hidden="true" className="px-2 text-muted-foreground">
+                ···
+              </span>
+            )
+          )}
+        </div>
+
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={handleNext}
+          disabled={!canNext}
+          aria-label={nextAria}
+        >
+          {t('pages.toolkitHistory.pagination.next')} <span aria-hidden="true">→</span>
+        </Button>
+
+        <span className="flex-1" />
+
+        <span className="text-sm text-muted-foreground">{rangeLabel}</span>
+
+        <label className="flex items-center gap-2 text-sm text-muted-foreground">
+          {t('pages.toolkitHistory.pagination.perPage')}
+          <Select value={String(pageSize)} onValueChange={value => onPageSizeChange(Number(value))}>
+            <SelectTrigger
+              className="h-9 w-[4.5rem]"
+              aria-label={t('pages.toolkitHistory.pagination.perPageAria')}
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {PAGE_SIZE_OPTIONS.map(n => (
+                <SelectItem key={n} value={String(n)}>
+                  {n}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </label>
+      </div>
+    </nav>
+  );
+}

--- a/apps/web/src/app/(authenticated)/toolkit/history/_components/HistoryTable.tsx
+++ b/apps/web/src/app/(authenticated)/toolkit/history/_components/HistoryTable.tsx
@@ -18,6 +18,8 @@ import { Button } from '@/components/ui/primitives/button';
 import { useTranslation } from '@/hooks/useTranslation';
 import { cn } from '@/lib/utils';
 
+import { getRelativeTimeParts } from '../_lib/relative-time';
+
 import type { HistoryRow, HistorySort } from '../_lib/history-filters';
 
 export interface HistoryTableProps {
@@ -46,26 +48,6 @@ function getInitials(name: string): string {
   const first = parts[0] as string;
   const last = parts[parts.length - 1] as string;
   return `${first[0]}${last[0]}`.toUpperCase();
-}
-
-/** Buckets an ISO timestamp relative to `now` into an `Intl.RelativeTimeFormat` value/unit pair. */
-function getRelativeTimeParts(
-  startedAt: string,
-  now: Date
-): { value: number; unit: Intl.RelativeTimeFormatUnit } {
-  const diffMinutes = (new Date(startedAt).getTime() - now.getTime()) / 60_000;
-  if (Math.abs(diffMinutes) < 60) return { value: Math.round(diffMinutes), unit: 'minute' };
-
-  const diffHours = diffMinutes / 60;
-  if (Math.abs(diffHours) < 24) return { value: Math.round(diffHours), unit: 'hour' };
-
-  const diffDays = diffHours / 24;
-  if (Math.abs(diffDays) < 30) return { value: Math.round(diffDays), unit: 'day' };
-
-  const diffMonths = diffDays / 30;
-  if (Math.abs(diffMonths) < 12) return { value: Math.round(diffMonths), unit: 'month' };
-
-  return { value: Math.round(diffMonths / 12), unit: 'year' };
 }
 
 interface SortableTableHeadProps {

--- a/apps/web/src/app/(authenticated)/toolkit/history/_components/HistoryTable.tsx
+++ b/apps/web/src/app/(authenticated)/toolkit/history/_components/HistoryTable.tsx
@@ -1,0 +1,320 @@
+'use client';
+
+import type { JSX } from 'react';
+
+import { ArrowDown, ArrowUp, ArrowUpDown } from 'lucide-react';
+
+import { Badge } from '@/components/ui/data-display/badge';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/data-display/table';
+import { EntityChip } from '@/components/ui/entity-chip/entity-chip';
+import { Button } from '@/components/ui/primitives/button';
+import { useTranslation } from '@/hooks/useTranslation';
+import { cn } from '@/lib/utils';
+
+import type { HistoryRow, HistorySort } from '../_lib/history-filters';
+
+export interface HistoryTableProps {
+  rows: HistoryRow[];
+  sort: HistorySort;
+  onSortChange: (sort: HistorySort) => void;
+  onOpenDetail: (row: HistoryRow) => void;
+  onOpenGameStats: (gameId: string) => void;
+}
+
+/** Max number of player avatars shown before collapsing the rest into a "+N" pill. */
+const MAX_AVATARS = 3;
+
+/** Formats a session duration in minutes as `"{h}h {m}m"`. */
+function formatDuration(minutes: number): string {
+  const h = Math.floor(minutes / 60);
+  const m = minutes % 60;
+  return `${h}h ${m}m`;
+}
+
+/** Derives up to 2 uppercase initials from a player's display name. */
+function getInitials(name: string): string {
+  const parts = name.trim().split(/\s+/).filter(Boolean);
+  if (parts.length === 0) return '?';
+  if (parts.length === 1) return (parts[0] as string).slice(0, 2).toUpperCase();
+  const first = parts[0] as string;
+  const last = parts[parts.length - 1] as string;
+  return `${first[0]}${last[0]}`.toUpperCase();
+}
+
+/** Buckets an ISO timestamp relative to `now` into an `Intl.RelativeTimeFormat` value/unit pair. */
+function getRelativeTimeParts(
+  startedAt: string,
+  now: Date
+): { value: number; unit: Intl.RelativeTimeFormatUnit } {
+  const diffMinutes = (new Date(startedAt).getTime() - now.getTime()) / 60_000;
+  if (Math.abs(diffMinutes) < 60) return { value: Math.round(diffMinutes), unit: 'minute' };
+
+  const diffHours = diffMinutes / 60;
+  if (Math.abs(diffHours) < 24) return { value: Math.round(diffHours), unit: 'hour' };
+
+  const diffDays = diffHours / 24;
+  if (Math.abs(diffDays) < 30) return { value: Math.round(diffDays), unit: 'day' };
+
+  const diffMonths = diffDays / 30;
+  if (Math.abs(diffMonths) < 12) return { value: Math.round(diffMonths), unit: 'month' };
+
+  return { value: Math.round(diffMonths / 12), unit: 'year' };
+}
+
+interface SortableTableHeadProps {
+  label: string;
+  active: boolean;
+  ariaSort: 'ascending' | 'descending' | 'none';
+  onSort: () => void;
+  className?: string;
+}
+
+/** A `<TableHead>` whose label is a click/keyboard-activatable sort trigger, with an `aria-sort` state. */
+function SortableTableHead({
+  label,
+  active,
+  ariaSort,
+  onSort,
+  className,
+}: SortableTableHeadProps): JSX.Element {
+  const Icon = !active ? ArrowUpDown : ariaSort === 'ascending' ? ArrowUp : ArrowDown;
+  return (
+    <TableHead aria-sort={ariaSort} className={cn('whitespace-nowrap', className)}>
+      <button
+        type="button"
+        onClick={onSort}
+        className="inline-flex items-center gap-1 rounded font-medium text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      >
+        {label}
+        <Icon
+          className={cn('h-3.5 w-3.5', active ? 'text-foreground' : 'text-muted-foreground')}
+          aria-hidden="true"
+        />
+      </button>
+    </TableHead>
+  );
+}
+
+/**
+ * Desktop 8-column sortable history table for /toolkit/history (Issue #3006, Task A4).
+ *
+ * Columns: Data, Gioco, Durata, Giocatori, Vincitore, Score, Note, Azioni — matching
+ * `admin-mockups/design_files/sp4-toolkit-history-ui.jsx`'s `Table`/`Row` components.
+ *
+ * Only Data/Durata/Score are sortable via header click — `HistorySort` has no 'game'
+ * value, so the Gioco column has no header-driven sort (the primary sort control is
+ * the toolbar dropdown built in a later task).
+ */
+export function HistoryTable({
+  rows,
+  sort,
+  onSortChange,
+  onOpenDetail,
+  onOpenGameStats,
+}: HistoryTableProps): JSX.Element {
+  const { t, formatDate, formatTime, formatRelativeTime } = useTranslation();
+  const now = new Date();
+
+  const isDateActive = sort === 'recent' || sort === 'oldest';
+  const dateAriaSort = sort === 'recent' ? 'descending' : sort === 'oldest' ? 'ascending' : 'none';
+
+  return (
+    <Table>
+      <TableHeader>
+        <TableRow>
+          <SortableTableHead
+            label={t('pages.toolkitHistory.table.date')}
+            active={isDateActive}
+            ariaSort={dateAriaSort}
+            onSort={() => onSortChange(sort === 'recent' ? 'oldest' : 'recent')}
+          />
+          <TableHead>{t('pages.toolkitHistory.table.game')}</TableHead>
+          <SortableTableHead
+            label={t('pages.toolkitHistory.table.duration')}
+            active={sort === 'longest'}
+            ariaSort={sort === 'longest' ? 'descending' : 'none'}
+            onSort={() => onSortChange('longest')}
+          />
+          <TableHead>{t('pages.toolkitHistory.table.players')}</TableHead>
+          <TableHead>{t('pages.toolkitHistory.table.winner')}</TableHead>
+          <SortableTableHead
+            label={t('pages.toolkitHistory.table.score')}
+            active={sort === 'score'}
+            ariaSort={sort === 'score' ? 'descending' : 'none'}
+            onSort={() => onSortChange('score')}
+          />
+          <TableHead className="text-center">{t('pages.toolkitHistory.table.notes')}</TableHead>
+          <TableHead className="text-right">{t('pages.toolkitHistory.table.actions')}</TableHead>
+        </TableRow>
+      </TableHeader>
+      <TableBody>
+        {rows.map(row => {
+          const { value: relValue, unit: relUnit } = getRelativeTimeParts(row.startedAt, now);
+          const startedAtDate = new Date(row.startedAt);
+
+          return (
+            <TableRow
+              key={row.id}
+              tabIndex={0}
+              className="cursor-pointer"
+              onClick={() => onOpenDetail(row)}
+              onKeyDown={e => {
+                if (e.key === 'Enter') {
+                  e.preventDefault();
+                  onOpenDetail(row);
+                }
+              }}
+            >
+              {/* Data */}
+              <TableCell>
+                <div className="text-foreground">
+                  {formatDate(startedAtDate)} · {formatTime(startedAtDate)}
+                </div>
+                <div className="text-xs text-muted-foreground">
+                  {formatRelativeTime(relValue, relUnit)}
+                </div>
+              </TableCell>
+
+              {/* Gioco */}
+              <TableCell>
+                <EntityChip entity="game" label={row.gameName} />
+              </TableCell>
+
+              {/* Durata */}
+              <TableCell>{formatDuration(row.durationMinutes)}</TableCell>
+
+              {/* Giocatori */}
+              <TableCell>
+                <span
+                  role="img"
+                  aria-label={t('pages.toolkitHistory.table.playersAria', {
+                    count: row.playerCount,
+                    names: row.playerNames.join(', '),
+                  })}
+                  className="inline-flex items-center -space-x-2"
+                >
+                  {row.playerNames.slice(0, MAX_AVATARS).map((name, i) => (
+                    <span
+                      key={`${row.id}-avatar-${i}`}
+                      aria-hidden="true"
+                      className="inline-flex h-7 w-7 items-center justify-center rounded-full border border-border bg-muted text-xs font-semibold text-foreground"
+                    >
+                      {getInitials(name)}
+                    </span>
+                  ))}
+                  {row.playerCount > MAX_AVATARS && (
+                    <span
+                      aria-hidden="true"
+                      className="inline-flex h-7 w-7 items-center justify-center rounded-full border border-border bg-muted text-xs font-semibold text-muted-foreground"
+                    >
+                      +{row.playerCount - MAX_AVATARS}
+                    </span>
+                  )}
+                </span>
+              </TableCell>
+
+              {/* Vincitore */}
+              <TableCell>
+                {row.isCoop ? (
+                  <Badge variant="secondary" className="gap-1">
+                    <span aria-hidden="true">🤝</span>
+                    {t('pages.toolkitHistory.table.coop')}
+                  </Badge>
+                ) : row.winnerName == null ? (
+                  <span
+                    className="text-muted-foreground"
+                    aria-label={t('pages.toolkitHistory.table.noWinner')}
+                  >
+                    —
+                  </span>
+                ) : (
+                  <Badge
+                    variant="default"
+                    className="gap-1"
+                    title={t('pages.toolkitHistory.table.winnerAria', { name: row.winnerName })}
+                  >
+                    <span aria-hidden="true">🏆</span>
+                    {row.winnerName}
+                  </Badge>
+                )}
+              </TableCell>
+
+              {/* Score */}
+              <TableCell>
+                {row.isCoop ? (
+                  <span className="text-muted-foreground">
+                    {t('pages.toolkitHistory.table.coopShort')}
+                  </span>
+                ) : (
+                  <span>{row.winScore ?? '—'}</span>
+                )}
+              </TableCell>
+
+              {/* Note */}
+              <TableCell className="text-center">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className={cn('px-2', !row.notes && 'opacity-40')}
+                  disabled={!row.notes}
+                  title={row.notes ?? undefined}
+                  aria-label={
+                    row.notes
+                      ? t('pages.toolkitHistory.table.hasNote')
+                      : t('pages.toolkitHistory.table.noNote')
+                  }
+                  onClick={e => {
+                    e.stopPropagation();
+                    if (row.notes) onOpenDetail(row);
+                  }}
+                >
+                  <span aria-hidden="true">📝</span>
+                </Button>
+              </TableCell>
+
+              {/* Azioni */}
+              <TableCell className="text-right">
+                <div className="flex justify-end gap-1">
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="px-2"
+                    aria-label={t('pages.toolkitHistory.table.viewDetails')}
+                    onClick={e => {
+                      e.stopPropagation();
+                      onOpenDetail(row);
+                    }}
+                  >
+                    <span aria-hidden="true">👁</span>
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="px-2"
+                    aria-label={t('pages.toolkitHistory.table.gameStats')}
+                    onClick={e => {
+                      e.stopPropagation();
+                      onOpenGameStats(row.gameId);
+                    }}
+                  >
+                    <span aria-hidden="true">📊</span>
+                  </Button>
+                </div>
+              </TableCell>
+            </TableRow>
+          );
+        })}
+      </TableBody>
+    </Table>
+  );
+}

--- a/apps/web/src/app/(authenticated)/toolkit/history/_components/HistoryToolbar.tsx
+++ b/apps/web/src/app/(authenticated)/toolkit/history/_components/HistoryToolbar.tsx
@@ -192,8 +192,16 @@ interface DateRangeFilterPopoverProps {
  * explicit "Applica intervallo" button — matching the mockup's `customMode`
  * pattern (selecting "custom" does not commit a range until Applica is
  * clicked with both bounds filled in).
+ *
+ * The popover is a CONTROLLED Radix `<Popover>` (`open`/`onOpenChange`) so it
+ * can be closed programmatically: selecting a non-custom preset or clicking
+ * "Applica intervallo" closes it (mirrors `setOpenDate(false)` in
+ * `admin-mockups/design_files/sp4-toolkit-history-ui.jsx:176,190`), while
+ * switching to the "custom" preset keeps it open so the user can fill in the
+ * date inputs.
  */
 function DateRangeFilterPopover({ state, onChange, t }: DateRangeFilterPopoverProps): JSX.Element {
+  const [open, setOpen] = useState(false);
   const [customMode, setCustomMode] = useState(state.datePreset === 'custom');
   const [customFrom, setCustomFrom] = useState(state.dateFrom ?? '');
   const [customTo, setCustomTo] = useState(state.dateTo ?? '');
@@ -219,11 +227,13 @@ function DateRangeFilterPopover({ state, onChange, t }: DateRangeFilterPopoverPr
       dateFrom: undefined,
       dateTo: undefined,
     });
+    setOpen(false);
   };
 
   const handleApply = () => {
     if (!customFrom || !customTo) return;
     onChange({ ...state, datePreset: 'custom', dateFrom: customFrom, dateTo: customTo });
+    setOpen(false);
   };
 
   const triggerLabel =
@@ -232,7 +242,7 @@ function DateRangeFilterPopover({ state, onChange, t }: DateRangeFilterPopoverPr
       : t(`pages.toolkitHistory.filters.dateOptions.${state.datePreset}`);
 
   return (
-    <Popover>
+    <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
         <Button
           type="button"

--- a/apps/web/src/app/(authenticated)/toolkit/history/_components/HistoryToolbar.tsx
+++ b/apps/web/src/app/(authenticated)/toolkit/history/_components/HistoryToolbar.tsx
@@ -1,0 +1,573 @@
+'use client';
+
+import { useEffect, useRef, useState, type JSX, type ReactNode } from 'react';
+
+import {
+  Calendar as CalendarIcon,
+  Download,
+  Filter as FilterIcon,
+  LayoutGrid,
+  List,
+  Loader2,
+  Search as SearchIcon,
+  X,
+} from 'lucide-react';
+
+import { Badge } from '@/components/ui/data-display/badge';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/overlays/popover';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/overlays/select';
+import { Button } from '@/components/ui/primitives/button';
+import { Checkbox } from '@/components/ui/primitives/checkbox';
+import { Input } from '@/components/ui/primitives/input';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/primitives/radio-group';
+import { useTranslation, type TranslationFunction } from '@/hooks/useTranslation';
+import { cn } from '@/lib/utils';
+
+import {
+  countActiveFilters,
+  NO_WINNER_FILTER_VALUE,
+  type DateRangePreset,
+  type HistoryFilterState,
+  type HistorySort,
+} from '../_lib/history-filters';
+
+/** Debounce delay (ms) applied to search input before it is committed via `onChange`. */
+const SEARCH_DEBOUNCE_MS = 400;
+
+/** Games popover: number of options shown before "Show more". */
+const GAMES_VISIBLE_THRESHOLD = 4;
+
+/** Winners popover: number of options shown before "Show more". */
+const WINNERS_VISIBLE_THRESHOLD = 5;
+
+const DATE_PRESETS: DateRangePreset[] = ['all', 'last30', 'last90', 'lastYear', 'custom'];
+
+const SORT_OPTIONS: HistorySort[] = ['recent', 'oldest', 'longest', 'score'];
+
+export interface HistoryToolbarGameOption {
+  id: string;
+  label: string;
+  count: number;
+}
+
+export interface HistoryToolbarWinnerOption {
+  value: string;
+  label: string;
+  count: number;
+}
+
+export interface HistoryToolbarProps {
+  state: HistoryFilterState;
+  onChange: (next: HistoryFilterState) => void;
+  gameOptions: HistoryToolbarGameOption[];
+  winnerOptions: HistoryToolbarWinnerOption[];
+  view: 'table' | 'cards';
+  onViewChange: (view: 'table' | 'cards') => void;
+  totalCount: number;
+  resultCount: number;
+  onClearAll: () => void;
+  onExport: () => void;
+}
+
+interface MultiSelectOption {
+  value: string;
+  label: string;
+  count: number;
+}
+
+interface MultiSelectPopoverProps {
+  icon: ReactNode;
+  triggerLabel: string;
+  ariaLabel: string;
+  options: MultiSelectOption[];
+  selected: string[];
+  onToggle: (value: string) => void;
+  onClear: () => void;
+  moreThreshold: number;
+  allLabel: string;
+  moreLabel: (n: number) => string;
+  lessLabel: string;
+}
+
+/**
+ * Reusable Popover + Checkbox multi-select used for both the Giochi and
+ * Vincitori filter groups. Mirrors `MultiDropdown` in
+ * `admin-mockups/design_files/sp4-toolkit-history-ui.jsx`: a "Tutti" clear
+ * option, then a `moreThreshold`-capped option list with a "Mostra
+ * altri/meno" toggle.
+ */
+function MultiSelectPopover({
+  icon,
+  triggerLabel,
+  ariaLabel,
+  options,
+  selected,
+  onToggle,
+  onClear,
+  moreThreshold,
+  allLabel,
+  moreLabel,
+  lessLabel,
+}: MultiSelectPopoverProps): JSX.Element {
+  const [showAll, setShowAll] = useState(false);
+  const visible = showAll ? options : options.slice(0, moreThreshold);
+  const hasMore = options.length > moreThreshold;
+  const count = selected.length;
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          aria-label={triggerLabel}
+          className={cn('gap-1.5', count > 0 && 'border-primary text-primary')}
+        >
+          <span aria-hidden="true">{icon}</span>
+          {triggerLabel}
+          {count > 0 && <span className="text-xs font-semibold">({count})</span>}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-64 p-2" role="listbox" aria-label={ariaLabel}>
+        <div className="px-2 py-1 text-xs font-semibold text-muted-foreground">{ariaLabel}</div>
+        <button
+          type="button"
+          role="option"
+          aria-selected={count === 0}
+          onClick={onClear}
+          className={cn(
+            'flex w-full items-center rounded px-2 py-1.5 text-left text-sm hover:bg-muted',
+            count === 0 && 'font-semibold text-foreground'
+          )}
+        >
+          {allLabel}
+        </button>
+        {visible.map(option => {
+          const isSelected = selected.includes(option.value);
+          return (
+            <div
+              key={option.value}
+              className="flex items-center gap-2 rounded px-2 py-1.5 text-sm hover:bg-muted"
+            >
+              <Checkbox
+                checked={isSelected}
+                onCheckedChange={() => onToggle(option.value)}
+                aria-label={option.label}
+              />
+              <span className="flex-1 truncate">{option.label}</span>
+              <span className="text-xs text-muted-foreground">{option.count}</span>
+            </div>
+          );
+        })}
+        {hasMore && (
+          <button
+            type="button"
+            onClick={() => setShowAll(a => !a)}
+            className="mt-1 w-full rounded px-2 py-1.5 text-left text-xs font-medium text-primary hover:bg-muted"
+          >
+            {showAll ? lessLabel : moreLabel(options.length - moreThreshold)}
+          </button>
+        )}
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+interface DateRangeFilterPopoverProps {
+  state: HistoryFilterState;
+  onChange: (next: HistoryFilterState) => void;
+  t: TranslationFunction;
+}
+
+/**
+ * Date-range filter: preset radio group (all/last30/last90/lastYear) applied
+ * immediately, plus a "custom" option that reveals two date inputs and an
+ * explicit "Applica intervallo" button — matching the mockup's `customMode`
+ * pattern (selecting "custom" does not commit a range until Applica is
+ * clicked with both bounds filled in).
+ */
+function DateRangeFilterPopover({ state, onChange, t }: DateRangeFilterPopoverProps): JSX.Element {
+  const [customMode, setCustomMode] = useState(state.datePreset === 'custom');
+  const [customFrom, setCustomFrom] = useState(state.dateFrom ?? '');
+  const [customTo, setCustomTo] = useState(state.dateTo ?? '');
+
+  useEffect(() => {
+    setCustomMode(state.datePreset === 'custom');
+    setCustomFrom(state.dateFrom ?? '');
+    setCustomTo(state.dateTo ?? '');
+  }, [state.datePreset, state.dateFrom, state.dateTo]);
+
+  const radioValue = customMode ? 'custom' : state.datePreset;
+  const isActive = state.datePreset !== 'all';
+
+  const handlePresetChange = (preset: string) => {
+    if (preset === 'custom') {
+      setCustomMode(true);
+      return;
+    }
+    setCustomMode(false);
+    onChange({
+      ...state,
+      datePreset: preset as DateRangePreset,
+      dateFrom: undefined,
+      dateTo: undefined,
+    });
+  };
+
+  const handleApply = () => {
+    if (!customFrom || !customTo) return;
+    onChange({ ...state, datePreset: 'custom', dateFrom: customFrom, dateTo: customTo });
+  };
+
+  const triggerLabel =
+    state.datePreset === 'custom' && state.dateFrom && state.dateTo
+      ? `${state.dateFrom} – ${state.dateTo}`
+      : t(`pages.toolkitHistory.filters.dateOptions.${state.datePreset}`);
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          aria-label={t('pages.toolkitHistory.filters.date')}
+          className={cn('gap-1.5', isActive && 'border-primary text-primary')}
+        >
+          <CalendarIcon className="h-3.5 w-3.5" aria-hidden="true" />
+          {triggerLabel}
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        className="w-72 p-3"
+        role="listbox"
+        aria-label={t('pages.toolkitHistory.filters.dateRange')}
+      >
+        <div className="mb-2 text-xs font-semibold text-muted-foreground">
+          {t('pages.toolkitHistory.filters.dateRange')}
+        </div>
+        <RadioGroup value={radioValue} onValueChange={handlePresetChange} className="gap-1">
+          {DATE_PRESETS.map(preset => (
+            <label
+              key={preset}
+              className="flex cursor-pointer items-center gap-2 rounded px-1 py-1 text-sm hover:bg-muted"
+            >
+              <RadioGroupItem value={preset} />
+              {t(`pages.toolkitHistory.filters.dateOptions.${preset}`)}
+            </label>
+          ))}
+        </RadioGroup>
+        {customMode && (
+          <div className="mt-3 space-y-2 border-t border-border pt-3">
+            <div className="grid grid-cols-2 gap-2">
+              <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+                {t('pages.toolkitHistory.filters.dateFrom')}
+                <Input
+                  type="date"
+                  value={customFrom}
+                  max={customTo || undefined}
+                  onChange={e => setCustomFrom(e.target.value)}
+                  aria-label={t('pages.toolkitHistory.filters.dateFromLabel')}
+                />
+              </label>
+              <label className="flex flex-col gap-1 text-xs text-muted-foreground">
+                {t('pages.toolkitHistory.filters.dateTo')}
+                <Input
+                  type="date"
+                  value={customTo}
+                  min={customFrom || undefined}
+                  onChange={e => setCustomTo(e.target.value)}
+                  aria-label={t('pages.toolkitHistory.filters.dateToLabel')}
+                />
+              </label>
+            </div>
+            <Button
+              type="button"
+              size="sm"
+              className="w-full"
+              disabled={!customFrom || !customTo}
+              onClick={handleApply}
+            >
+              {t('pages.toolkitHistory.filters.applyRange')}
+            </Button>
+          </div>
+        )}
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+/**
+ * Filter/sort toolbar for /toolkit/history (Issue #3006, Task A7).
+ *
+ * Matches `admin-mockups/design_files/sp4-toolkit-history-ui.jsx`'s
+ * `Toolbar`: `[ search ] [ Giochi | Data | Vincitori ] [ Ordina | Vista ]`,
+ * an "Esporta CSV" action, and a conditional summary bar (`nActive > 0`)
+ * showing the active-filter count, the filtered/total result count, and a
+ * "Cancella tutto" reset.
+ *
+ * Search is debounced 400ms client-side (`localSearch` state) so `onChange`
+ * — and therefore any parent-side refetch/re-filter — only fires once
+ * typing pauses; a "Cercando…" indicator is shown while the debounce is
+ * pending.
+ */
+export function HistoryToolbar({
+  state,
+  onChange,
+  gameOptions,
+  winnerOptions,
+  view,
+  onViewChange,
+  totalCount,
+  resultCount,
+  onClearAll,
+  onExport,
+}: HistoryToolbarProps): JSX.Element {
+  const { t } = useTranslation();
+
+  const [localSearch, setLocalSearch] = useState(state.search);
+  const [isSearching, setIsSearching] = useState(false);
+  const searchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const stateRef = useRef(state);
+  const onChangeRef = useRef(onChange);
+
+  useEffect(() => {
+    stateRef.current = state;
+  }, [state]);
+
+  useEffect(() => {
+    onChangeRef.current = onChange;
+  }, [onChange]);
+
+  useEffect(() => {
+    setLocalSearch(state.search);
+  }, [state.search]);
+
+  useEffect(
+    () => () => {
+      if (searchTimerRef.current) clearTimeout(searchTimerRef.current);
+    },
+    []
+  );
+
+  const commitSearch = (value: string) => {
+    if (searchTimerRef.current) {
+      clearTimeout(searchTimerRef.current);
+      searchTimerRef.current = null;
+    }
+    setIsSearching(false);
+    onChangeRef.current({ ...stateRef.current, search: value });
+  };
+
+  const handleSearchInput = (value: string) => {
+    setLocalSearch(value);
+    if (searchTimerRef.current) clearTimeout(searchTimerRef.current);
+    setIsSearching(true);
+    searchTimerRef.current = setTimeout(() => {
+      searchTimerRef.current = null;
+      commitSearch(value);
+    }, SEARCH_DEBOUNCE_MS);
+  };
+
+  const handleClearSearch = () => {
+    setLocalSearch('');
+    commitSearch('');
+  };
+
+  const gameFilterOptions: MultiSelectOption[] = gameOptions.map(g => ({
+    value: g.id,
+    label: g.label,
+    count: g.count,
+  }));
+
+  const winnerFilterOptions: MultiSelectOption[] = winnerOptions.map(w => ({
+    value: w.value,
+    label:
+      w.value === NO_WINNER_FILTER_VALUE
+        ? t('pages.toolkitHistory.filters.noWinner')
+        : t('pages.toolkitHistory.filters.winnerWon', { name: w.label }),
+    count: w.count,
+  }));
+
+  const activeCount = countActiveFilters(state);
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex flex-col gap-3 lg:flex-row lg:flex-wrap lg:items-center">
+        {/* search */}
+        <div className="relative min-w-[240px] flex-1">
+          <SearchIcon
+            className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground"
+            aria-hidden="true"
+          />
+          <Input
+            type="search"
+            value={localSearch}
+            onChange={e => handleSearchInput(e.target.value)}
+            onKeyDown={e => {
+              if (e.key === 'Escape') handleClearSearch();
+            }}
+            placeholder={t('pages.toolkitHistory.filters.searchPlaceholder')}
+            aria-label={t('pages.toolkitHistory.filters.searchAriaLabel')}
+            className="pl-9 pr-10"
+          />
+          <div className="absolute right-1 top-1/2 flex -translate-y-1/2 items-center gap-1">
+            {isSearching && (
+              <span className="flex items-center gap-1 pr-1 text-xs text-muted-foreground">
+                <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+                {t('pages.toolkitHistory.filters.searching')}
+              </span>
+            )}
+            {localSearch && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="h-7 w-7"
+                onClick={handleClearSearch}
+                aria-label={t('pages.toolkitHistory.filters.clearSearch')}
+              >
+                <X className="h-3.5 w-3.5" />
+              </Button>
+            )}
+          </div>
+        </div>
+
+        {/* filters */}
+        <div
+          className="flex flex-wrap items-center gap-2"
+          role="group"
+          aria-label={t('pages.toolkitHistory.filters.filterByGame')}
+        >
+          <MultiSelectPopover
+            icon="🎲"
+            triggerLabel={t('pages.toolkitHistory.filters.games')}
+            ariaLabel={t('pages.toolkitHistory.filters.filterByGame')}
+            options={gameFilterOptions}
+            selected={state.gameIds}
+            moreThreshold={GAMES_VISIBLE_THRESHOLD}
+            allLabel={t('pages.toolkitHistory.filters.all')}
+            moreLabel={n => t('pages.toolkitHistory.filters.showMore', { n })}
+            lessLabel={t('pages.toolkitHistory.filters.showLess')}
+            onToggle={value =>
+              onChange({
+                ...state,
+                gameIds: state.gameIds.includes(value)
+                  ? state.gameIds.filter(v => v !== value)
+                  : [...state.gameIds, value],
+              })
+            }
+            onClear={() => onChange({ ...state, gameIds: [] })}
+          />
+
+          <DateRangeFilterPopover state={state} onChange={onChange} t={t} />
+
+          <MultiSelectPopover
+            icon="🏆"
+            triggerLabel={t('pages.toolkitHistory.filters.winners')}
+            ariaLabel={t('pages.toolkitHistory.filters.filterByWinner')}
+            options={winnerFilterOptions}
+            selected={state.winners}
+            moreThreshold={WINNERS_VISIBLE_THRESHOLD}
+            allLabel={t('pages.toolkitHistory.filters.all')}
+            moreLabel={n => t('pages.toolkitHistory.filters.showMore', { n })}
+            lessLabel={t('pages.toolkitHistory.filters.showLess')}
+            onToggle={value =>
+              onChange({
+                ...state,
+                winners: state.winners.includes(value)
+                  ? state.winners.filter(v => v !== value)
+                  : [...state.winners, value],
+              })
+            }
+            onClear={() => onChange({ ...state, winners: [] })}
+          />
+        </div>
+
+        {/* sort + view + export */}
+        <div className="flex items-center gap-2 lg:ml-auto">
+          <Select
+            value={state.sort}
+            onValueChange={value => onChange({ ...state, sort: value as HistorySort })}
+          >
+            <SelectTrigger
+              className="h-9 w-auto min-w-[9rem]"
+              aria-label={t('pages.toolkitHistory.filters.sortBy')}
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {SORT_OPTIONS.map(opt => (
+                <SelectItem key={opt} value={opt}>
+                  {t(`pages.toolkitHistory.filters.sortOptions.${opt}`)}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+
+          <div
+            className="flex items-center gap-1 rounded-lg border border-border p-0.5"
+            role="group"
+            aria-label={t('pages.toolkitHistory.filters.view')}
+          >
+            <Button
+              type="button"
+              variant={view === 'table' ? 'default' : 'ghost'}
+              size="icon"
+              className="h-8 w-8"
+              aria-pressed={view === 'table'}
+              aria-label={t('pages.toolkitHistory.filters.viewTable')}
+              onClick={() => onViewChange('table')}
+            >
+              <List className="h-4 w-4" aria-hidden="true" />
+            </Button>
+            <Button
+              type="button"
+              variant={view === 'cards' ? 'default' : 'ghost'}
+              size="icon"
+              className="h-8 w-8"
+              aria-pressed={view === 'cards'}
+              aria-label={t('pages.toolkitHistory.filters.viewCards')}
+              onClick={() => onViewChange('cards')}
+            >
+              <LayoutGrid className="h-4 w-4" aria-hidden="true" />
+            </Button>
+          </div>
+
+          <Button type="button" variant="outline" size="sm" onClick={onExport} className="gap-1.5">
+            <Download className="h-3.5 w-3.5" aria-hidden="true" />
+            {t('pages.toolkitHistory.hero.exportCsv')}
+          </Button>
+        </div>
+      </div>
+
+      {/* summary bar */}
+      {activeCount > 0 && (
+        <div className="flex flex-wrap items-center gap-2 rounded-lg border border-border bg-muted/40 px-3 py-2 text-sm">
+          <Badge variant="secondary" className="gap-1">
+            <FilterIcon className="h-3 w-3" aria-hidden="true" />
+            {t('pages.toolkitHistory.summary.activeFilters', { n: activeCount })}
+          </Badge>
+          <span className="text-muted-foreground" aria-hidden="true">
+            ·
+          </span>
+          <span className="text-muted-foreground">
+            {t('pages.toolkitHistory.summary.results', { n: resultCount, total: totalCount })}
+          </span>
+          <span className="flex-1" />
+          <Button type="button" variant="ghost" size="sm" onClick={onClearAll}>
+            {t('pages.toolkitHistory.summary.clearAll')}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/(authenticated)/toolkit/history/_lib/history-filters.ts
+++ b/apps/web/src/app/(authenticated)/toolkit/history/_lib/history-filters.ts
@@ -1,0 +1,203 @@
+/**
+ * history-filters — pure filter/sort/paginate helpers for /toolkit/history.
+ *
+ * Issue #3006 (Task A2). The backend `GET` history endpoint returns a plain
+ * array with no search/winner-filter/sort support, so the entire history
+ * table experience (search, filter, sort, pagination) is computed
+ * client-side from these pure functions. Later tasks (A4-A9) build the UI
+ * and data-fetching layer on top of these types/functions — keep the
+ * exported names/signatures stable.
+ *
+ * No React, no i18n, no `Date.now()` — every date-relative computation takes
+ * an explicit `now: Date` argument so callers (and tests) stay deterministic.
+ */
+
+import type { GameSessionDto } from '@/lib/api/schemas/games.schemas';
+
+/** Sentinel value used in `HistoryFilterState.winners` to match sessions with no recorded winner (co-op / draw). */
+export const NO_WINNER_FILTER_VALUE = '__nowin__';
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+export type HistorySort = 'recent' | 'oldest' | 'longest' | 'score';
+
+export type DateRangePreset = 'all' | 'last30' | 'last90' | 'lastYear' | 'custom';
+
+export interface HistoryFilterState {
+  search: string;
+  gameIds: string[];
+  winners: string[];
+  datePreset: DateRangePreset;
+  dateFrom?: string;
+  dateTo?: string;
+  sort: HistorySort;
+}
+
+/** View-model row consumed by the history table — one per `GameSessionDto`. */
+export interface HistoryRow {
+  id: string;
+  gameId: string;
+  gameName: string;
+  startedAt: string;
+  durationMinutes: number;
+  playerNames: string[];
+  playerCount: number;
+  winnerName: string | null;
+  isCoop: boolean;
+  winScore: number | null;
+  notes: string | null;
+}
+
+/**
+ * Parses the polymorphic `scoreData` JSON payload and returns the highest
+ * numeric score found, or `null` when the payload is missing, invalid, or
+ * has no numeric values. Supports two shapes:
+ *   - `Record<string, number>` (e.g. `{ "Alice": 42, "Bob": 30 }`) — uses the values
+ *   - `number[]` (e.g. `[10, 20, 30]`)
+ */
+export function parseWinScore(dto: GameSessionDto): number | null {
+  if (!dto.scoreData) return null;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(dto.scoreData);
+  } catch {
+    return null;
+  }
+
+  let values: number[];
+  if (Array.isArray(parsed)) {
+    values = parsed.filter((v): v is number => typeof v === 'number');
+  } else if (parsed !== null && typeof parsed === 'object') {
+    values = Object.values(parsed as Record<string, unknown>).filter(
+      (v): v is number => typeof v === 'number'
+    );
+  } else {
+    return null;
+  }
+
+  return values.length > 0 ? Math.max(...values) : null;
+}
+
+/** Maps a `GameSessionDto` to the view-model `HistoryRow` consumed by the history table. */
+export function toHistoryRow(
+  dto: GameSessionDto,
+  gameNameMap: Map<string, string>,
+  unknownLabel: string
+): HistoryRow {
+  const playerNames = [...dto.players]
+    .sort((a, b) => a.playerOrder - b.playerOrder)
+    .map(p => p.playerName);
+
+  return {
+    id: dto.id,
+    gameId: dto.gameId,
+    gameName: gameNameMap.get(dto.gameId) ?? unknownLabel,
+    startedAt: dto.startedAt,
+    durationMinutes: dto.durationMinutes,
+    playerNames,
+    playerCount: dto.playerCount,
+    winnerName: dto.winnerName,
+    // Heuristic: a session with no recorded winner and more than one player is
+    // treated as a co-operative session (a single-player session with no
+    // winner is just "not finished scoring", not co-op).
+    isCoop: dto.winnerName == null && dto.players.length > 1,
+    winScore: parseWinScore(dto),
+    notes: dto.notes,
+  };
+}
+
+/** Resolves a `[start, end]` date bound (inclusive) for the given preset, or `[null, null]` when unbounded. */
+function resolveDateRange(f: HistoryFilterState, now: Date): [Date | null, Date | null] {
+  switch (f.datePreset) {
+    case 'last30':
+      return [new Date(now.getTime() - 30 * MS_PER_DAY), null];
+    case 'last90':
+      return [new Date(now.getTime() - 90 * MS_PER_DAY), null];
+    case 'lastYear':
+      return [new Date(now.getTime() - 365 * MS_PER_DAY), null];
+    case 'custom':
+      return [f.dateFrom ? new Date(f.dateFrom) : null, f.dateTo ? new Date(f.dateTo) : null];
+    case 'all':
+    default:
+      return [null, null];
+  }
+}
+
+/** Filters rows by search text, game, winner, and date range. All criteria are AND-combined; values within a single criterion (gameIds/winners) are OR-combined. */
+export function filterRows(rows: HistoryRow[], f: HistoryFilterState, now: Date): HistoryRow[] {
+  const search = f.search.trim().toLowerCase();
+  const gameIdSet = new Set(f.gameIds);
+  const winnerSet = new Set(f.winners);
+  const [rangeStart, rangeEnd] = resolveDateRange(f, now);
+
+  return rows.filter(row => {
+    if (search) {
+      const haystack = [row.gameName, row.winnerName ?? '', ...row.playerNames]
+        .join(' ')
+        .toLowerCase();
+      if (!haystack.includes(search)) return false;
+    }
+
+    if (gameIdSet.size > 0 && !gameIdSet.has(row.gameId)) return false;
+
+    if (winnerSet.size > 0) {
+      const matchesNoWinner = row.winnerName == null && winnerSet.has(NO_WINNER_FILTER_VALUE);
+      const matchesWinner = row.winnerName != null && winnerSet.has(row.winnerName);
+      if (!matchesNoWinner && !matchesWinner) return false;
+    }
+
+    if (rangeStart || rangeEnd) {
+      const startedAt = new Date(row.startedAt).getTime();
+      if (rangeStart && startedAt < rangeStart.getTime()) return false;
+      if (rangeEnd && startedAt > rangeEnd.getTime()) return false;
+    }
+
+    return true;
+  });
+}
+
+/** Returns a new, sorted array (input is never mutated). */
+export function sortRows(rows: HistoryRow[], sort: HistorySort): HistoryRow[] {
+  const sorted = [...rows];
+
+  switch (sort) {
+    case 'recent':
+      sorted.sort((a, b) => new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime());
+      break;
+    case 'oldest':
+      sorted.sort((a, b) => new Date(a.startedAt).getTime() - new Date(b.startedAt).getTime());
+      break;
+    case 'longest':
+      sorted.sort((a, b) => b.durationMinutes - a.durationMinutes);
+      break;
+    case 'score':
+      sorted.sort((a, b) => {
+        if (a.winScore == null && b.winScore == null) return 0;
+        if (a.winScore == null) return 1;
+        if (b.winScore == null) return -1;
+        return b.winScore - a.winScore;
+      });
+      break;
+    default:
+      break;
+  }
+
+  return sorted;
+}
+
+/** Slices `items` to the given 1-indexed `page` of size `pageSize`. */
+export function paginate<T>(items: T[], page: number, pageSize: number): T[] {
+  const start = (page - 1) * pageSize;
+  return items.slice(start, start + pageSize);
+}
+
+/** Counts how many filter *categories* are active (search, game, winner, date) — value counts within a category (e.g. 2 selected games) still count as 1. `sort` is never counted. */
+export function countActiveFilters(f: HistoryFilterState): number {
+  let count = 0;
+  if (f.search.trim() !== '') count += 1;
+  if (f.gameIds.length > 0) count += 1;
+  if (f.winners.length > 0) count += 1;
+  if (f.datePreset !== 'all') count += 1;
+  return count;
+}

--- a/apps/web/src/app/(authenticated)/toolkit/history/_lib/history-filters.ts
+++ b/apps/web/src/app/(authenticated)/toolkit/history/_lib/history-filters.ts
@@ -107,17 +107,32 @@ export function toHistoryRow(
   };
 }
 
-/** Resolves a `[start, end]` date bound (inclusive) for the given preset, or `[null, null]` when unbounded. */
+/**
+ * Resolves a `[start, end]` date bound (inclusive) for the given preset, or
+ * `[null, null]` when unbounded.
+ *
+ * Two fixes applied here (Issue #3006, Task A7 prerequisite):
+ *   1. Relative presets (`last30`/`last90`/`lastYear`) are capped at `now` —
+ *      without an upper bound, a future-dated session (e.g. a clock-skewed
+ *      or accidentally-future `startedAt`) would pass the filter.
+ *   2. A custom `dateTo` (a `YYYY-MM-DD` string) resolves to the END of that
+ *      day (`23:59:59.999`), not its start — otherwise `new Date(dateTo)`
+ *      parses to `00:00:00.000Z` and same-day sessions are excluded from
+ *      the range they were explicitly selected into.
+ */
 function resolveDateRange(f: HistoryFilterState, now: Date): [Date | null, Date | null] {
   switch (f.datePreset) {
     case 'last30':
-      return [new Date(now.getTime() - 30 * MS_PER_DAY), null];
+      return [new Date(now.getTime() - 30 * MS_PER_DAY), now];
     case 'last90':
-      return [new Date(now.getTime() - 90 * MS_PER_DAY), null];
+      return [new Date(now.getTime() - 90 * MS_PER_DAY), now];
     case 'lastYear':
-      return [new Date(now.getTime() - 365 * MS_PER_DAY), null];
+      return [new Date(now.getTime() - 365 * MS_PER_DAY), now];
     case 'custom':
-      return [f.dateFrom ? new Date(f.dateFrom) : null, f.dateTo ? new Date(f.dateTo) : null];
+      return [
+        f.dateFrom ? new Date(f.dateFrom) : null,
+        f.dateTo ? new Date(`${f.dateTo}T23:59:59.999Z`) : null,
+      ];
     case 'all':
     default:
       return [null, null];

--- a/apps/web/src/app/(authenticated)/toolkit/history/_lib/relative-time.ts
+++ b/apps/web/src/app/(authenticated)/toolkit/history/_lib/relative-time.ts
@@ -1,0 +1,62 @@
+/**
+ * relative-time — shared relative-time bucketing helper for /toolkit/history
+ * (Issue #3006, Task A5 EXTRA SCOPE).
+ *
+ * `HistoryTable` (Task A4) and `HistoryCards` (Task A5) both render a
+ * relative date string (e.g. "3 giorni fa") next to each session's absolute
+ * date. This module is the single source of truth for that computation so
+ * both views produce identical labels for identical timestamps — it was
+ * previously duplicated as an inline `getRelativeTimeParts` in
+ * `HistoryTable.tsx`.
+ *
+ * Pure, no React, no i18n: given an ISO timestamp and an explicit `now: Date`,
+ * returns an `Intl.RelativeTimeFormat` value/unit pair. Callers pass the pair
+ * straight to `formatRelativeTime(value, unit)` (react-intl `IntlShape`,
+ * exposed by `useTranslation`), which renders the localized label.
+ *
+ * Bucketing cascade: minute (< 60min) → hour (< 24h) → day (< 30d) →
+ * month (< 12mo, 30-day months) → year (12mo). The escalation decision is
+ * made on the ROUNDED value of the current unit, not the raw fractional
+ * diff — fixes an off-by-one where e.g. a diff of 59.6 minutes used to
+ * render as "60 minutes" (raw 59.6 < 60 picked the minute bucket, then the
+ * *value* was rounded up to 60 afterwards). Now the rounded minute value
+ * (60) is compared against the 60 threshold, so it correctly escalates to
+ * the hour bucket and renders as "1 hour" instead.
+ */
+
+export interface RelativeTimeParts {
+  value: number;
+  unit: Intl.RelativeTimeFormatUnit;
+}
+
+const MS_PER_MINUTE = 60_000;
+const MS_PER_HOUR = 60 * MS_PER_MINUTE;
+const MS_PER_DAY = 24 * MS_PER_HOUR;
+const MS_PER_MONTH = 30 * MS_PER_DAY;
+const MS_PER_YEAR = 12 * MS_PER_MONTH;
+
+/**
+ * Buckets an ISO timestamp relative to `now` into an
+ * `Intl.RelativeTimeFormat` value/unit pair, rounding to the nearest whole
+ * unit and escalating to the next unit whenever the rounded value would
+ * reach/exceed that unit's threshold (60 minutes, 24 hours, 30 days, 12
+ * months).
+ */
+export function getRelativeTimeParts(iso: string, now: Date): RelativeTimeParts {
+  const diffMs = new Date(iso).getTime() - now.getTime();
+
+  const minutes = Math.round(diffMs / MS_PER_MINUTE);
+  if (Math.abs(minutes) < 60) return { value: minutes, unit: 'minute' };
+
+  const hours = Math.round(diffMs / MS_PER_HOUR);
+  if (Math.abs(hours) < 24) return { value: hours, unit: 'hour' };
+
+  const days = Math.round(diffMs / MS_PER_DAY);
+  if (Math.abs(days) < 30) return { value: days, unit: 'day' };
+
+  const months = Math.round(diffMs / MS_PER_MONTH);
+  if (Math.abs(months) < 12) return { value: months, unit: 'month' };
+
+  const years = Math.round(diffMs / MS_PER_YEAR);
+  return { value: years, unit: 'year' };
+}

--- a/apps/web/src/app/(authenticated)/toolkit/history/client.tsx
+++ b/apps/web/src/app/(authenticated)/toolkit/history/client.tsx
@@ -240,7 +240,7 @@ export default function ToolkitHistoryPage(): JSX.Element {
 
       {/* toolkit tabs */}
       <nav
-        aria-label={t('pages.toolkitHistory.hero.breadcrumbToolkit')}
+        aria-label={t('pages.toolkitHistory.tabs.ariaLabel')}
         className="flex gap-1 overflow-x-auto border-b border-border"
       >
         {TOOLKIT_TABS.map(tab => (

--- a/apps/web/src/app/(authenticated)/toolkit/history/client.tsx
+++ b/apps/web/src/app/(authenticated)/toolkit/history/client.tsx
@@ -1,221 +1,383 @@
 'use client';
 
-import React, { useState } from 'react';
+import type { JSX } from 'react';
+import { useState } from 'react';
 
 import { useQuery } from '@tanstack/react-query';
-import { Calendar, Filter, Loader2, Trophy } from 'lucide-react';
+import { AlertCircle } from 'lucide-react';
+import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 
 import { HubPageContainer } from '@/components/layout/PageContainer';
-import { SessionDetailModal } from '@/components/session/SessionDetailModal';
-import type { Session } from '@/components/session/types';
-import { Badge } from '@/components/ui/data-display/badge';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/data-display/card';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/overlays/select';
+import { Skeleton } from '@/components/ui/feedback/skeleton';
 import { Button } from '@/components/ui/primitives/button';
-import { Input } from '@/components/ui/primitives/input';
-import { Label } from '@/components/ui/primitives/label';
+import { useLibrary } from '@/hooks/queries/useLibrary';
+import { useTranslation } from '@/hooks/useTranslation';
 import { api } from '@/lib/api';
+import { cn } from '@/lib/utils';
+import { downloadFile, rowsToCsv } from '@/lib/utils/csv';
+
+import { HistoryCards } from './_components/HistoryCards';
+import { HistoryDetailModal } from './_components/HistoryDetailModal';
+import { HistoryPagination } from './_components/HistoryPagination';
+import { HistoryTable } from './_components/HistoryTable';
+import { HistoryToolbar } from './_components/HistoryToolbar';
+import {
+  countActiveFilters,
+  filterRows,
+  NO_WINNER_FILTER_VALUE,
+  paginate,
+  sortRows,
+  toHistoryRow,
+  type HistoryFilterState,
+  type HistoryRow,
+  type HistorySort,
+} from './_lib/history-filters';
 
 /**
- * Toolkit History Page
+ * Toolkit History Page — orchestrator (Issue #3006, Task A9).
  *
- * Features:
- * - List finalized sessions
- * - Filters: game, date range, winner
- * - Pagination (20 items/page)
- * - Session detail modal
+ * Assembles the pure filter/sort/paginate pipeline (`_lib/history-filters`)
+ * with the presentational components built in A1-A8 into the full
+ * `/toolkit/history` experience. The backend history endpoint has no
+ * search/filter/sort support, so a single batch (`limit: 500`) is fetched
+ * once and the entire table experience — search, filters, sort, pagination,
+ * CSV export — runs client-side.
  */
-export default function ToolkitHistoryPage() {
+
+/** Batch size fetched from `GET /sessions/history` — see `_lib/history-filters.ts` header comment. */
+const HISTORY_BATCH_LIMIT = 500;
+
+/** Default page size, matching `HistoryPagination`'s `PAGE_SIZE_OPTIONS`. */
+const DEFAULT_PAGE_SIZE = 20;
+
+const DEFAULT_FILTER_STATE: HistoryFilterState = {
+  search: '',
+  gameIds: [],
+  winners: [],
+  datePreset: 'all',
+  sort: 'recent',
+};
+
+interface ToolkitTab {
+  id: 'stats' | 'history' | 'templates' | 'play';
+  href: string;
+  icon: string;
+}
+
+const TOOLKIT_TABS: ToolkitTab[] = [
+  { id: 'stats', href: '/toolkit/stats', icon: '📊' },
+  { id: 'history', href: '/toolkit/history', icon: '📜' },
+  { id: 'templates', href: '/toolkit/templates', icon: '🎨' },
+  { id: 'play', href: '/toolkit/play', icon: '🎮' },
+];
+
+/** Formats a session duration in minutes as `"{h}h {m}m"` — mirrors HistoryTable/HistoryCards/HistoryDetailModal. */
+function formatDuration(minutes: number): string {
+  const h = Math.floor(minutes / 60);
+  const m = minutes % 60;
+  return `${h}h ${m}m`;
+}
+
+export default function ToolkitHistoryPage(): JSX.Element {
   const router = useRouter();
+  const { t, formatDate, formatTime } = useTranslation();
 
-  const [selectedSession, setSelectedSession] = useState<Session | null>(null);
-  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [filterState, setFilterState] = useState<HistoryFilterState>(DEFAULT_FILTER_STATE);
+  const [view, setView] = useState<'table' | 'cards'>('table');
+  const [page, setPage] = useState(1);
+  const [pageSize, setPageSize] = useState(DEFAULT_PAGE_SIZE);
+  const [detailRow, setDetailRow] = useState<HistoryRow | null>(null);
 
-  // Filters
-  const [gameFilter, setGameFilter] = useState<string>('');
-  const [startDate, setStartDate] = useState<string>('');
-  const [endDate, setEndDate] = useState<string>('');
-
-  // Fetch session history from API
-  const { data: sessionsData, isLoading } = useQuery({
-    queryKey: ['session-history', gameFilter, startDate, endDate],
-    queryFn: () =>
-      api.sessions.getHistory({
-        gameId: gameFilter || undefined,
-        startDate: startDate || undefined,
-        endDate: endDate || undefined,
-        limit: 20,
-      }),
+  const historyQuery = useQuery({
+    queryKey: ['toolkit-history'],
+    queryFn: () => api.sessions.getHistory({ limit: HISTORY_BATCH_LIMIT }),
   });
-  const sessions: Session[] = (sessionsData?.sessions ?? []).map(s => ({
-    id: s.id,
-    sessionCode: s.id.slice(0, 6).toUpperCase(),
-    sessionType: s.gameId ? 'GameSpecific' : 'Generic',
-    gameId: s.gameId,
-    sessionDate: new Date(s.startedAt),
-    status: s.status === 'Completed' ? 'Finalized' : (s.status as Session['status']),
-    participantCount: s.playerCount,
-  }));
 
-  /**
-   * Handle view details
-   */
-  const handleViewDetails = (session: Session) => {
-    setSelectedSession(session);
-    setIsModalOpen(true);
+  // Full library page so every game a session references resolves to a real
+  // title — falls back to `unknownLabel` for sessions on games no longer in
+  // the user's library (e.g. removed private games).
+  const { data: libraryData } = useLibrary({ pageSize: HISTORY_BATCH_LIMIT });
+
+  const unknownLabel = t('pages.toolkitHistory.table.unknownGame');
+
+  const gameNameMap = new Map<string, string>();
+  for (const entry of libraryData?.items ?? []) {
+    gameNameMap.set(entry.gameId, entry.gameTitle);
+  }
+
+  const sessions = historyQuery.data?.sessions ?? [];
+  const allRows = sessions.map(dto => toHistoryRow(dto, gameNameMap, unknownLabel));
+
+  // Client-side pipeline: filter → sort → paginate. `now` is fresh per
+  // render — this is the orchestrator, not a pure helper, so determinism
+  // isn't required here (unlike `_lib/history-filters.ts`).
+  const now = new Date();
+  const filtered = sortRows(filterRows(allRows, filterState, now), filterState.sort);
+  const pageRows = paginate(filtered, page, pageSize);
+
+  const gameCounts = new Map<string, { label: string; count: number }>();
+  for (const row of allRows) {
+    const existing = gameCounts.get(row.gameId);
+    if (existing) existing.count += 1;
+    else gameCounts.set(row.gameId, { label: row.gameName, count: 1 });
+  }
+  const gameOptions = Array.from(gameCounts.entries())
+    .map(([id, { label, count }]) => ({ id, label, count }))
+    .sort((a, b) => b.count - a.count);
+
+  const winnerCounts = new Map<string, number>();
+  let noWinnerCount = 0;
+  for (const row of allRows) {
+    if (row.winnerName == null) {
+      noWinnerCount += 1;
+      continue;
+    }
+    winnerCounts.set(row.winnerName, (winnerCounts.get(row.winnerName) ?? 0) + 1);
+  }
+  // Winner labels are the raw name — HistoryToolbar re-translates the
+  // NO_WINNER_FILTER_VALUE entry's label itself, so what we pass here for it
+  // is ignored.
+  const winnerOptions = [
+    ...Array.from(winnerCounts.entries()).map(([value, count]) => ({ value, label: value, count })),
+    { value: NO_WINNER_FILTER_VALUE, label: NO_WINNER_FILTER_VALUE, count: noWinnerCount },
+  ];
+
+  const totalGames = new Set(allRows.map(row => row.gameId)).size;
+  const totalWinners = winnerCounts.size;
+  const activeFilterCount = countActiveFilters(filterState);
+
+  const handleFilterChange = (next: HistoryFilterState) => {
+    setFilterState(next);
+    setPage(1);
   };
 
-  /**
-   * Reset filters
-   */
-  const handleResetFilters = () => {
-    setGameFilter('');
-    setStartDate('');
-    setEndDate('');
+  const handleSortChange = (sort: HistorySort) => {
+    handleFilterChange({ ...filterState, sort });
   };
+
+  const handlePageSizeChange = (size: number) => {
+    setPageSize(size);
+    setPage(1);
+  };
+
+  const handleClearAll = () => {
+    setFilterState(DEFAULT_FILTER_STATE);
+    setPage(1);
+  };
+
+  const handleOpenGameStats = (_gameId: string) => {
+    // No per-game stats route yet — send the user to the aggregate stats tab.
+    router.push('/toolkit/stats');
+  };
+
+  const handleExport = () => {
+    const headers = [
+      t('pages.toolkitHistory.table.date'),
+      t('pages.toolkitHistory.table.game'),
+      t('pages.toolkitHistory.table.duration'),
+      t('pages.toolkitHistory.table.players'),
+      t('pages.toolkitHistory.table.winner'),
+      t('pages.toolkitHistory.table.score'),
+      t('pages.toolkitHistory.table.notes'),
+    ];
+    const csvRows = filtered.map(row => {
+      const startedAtDate = new Date(row.startedAt);
+      const winner = row.isCoop
+        ? t('pages.toolkitHistory.table.coop')
+        : (row.winnerName ?? t('pages.toolkitHistory.table.noWinner'));
+      return [
+        `${formatDate(startedAtDate)} ${formatTime(startedAtDate)}`,
+        row.gameName,
+        formatDuration(row.durationMinutes),
+        row.playerNames.join(', '),
+        winner,
+        row.isCoop ? null : row.winScore,
+        row.notes,
+      ];
+    });
+    downloadFile(rowsToCsv(headers, csvRows), 'storico-sessioni.csv');
+  };
+
+  const isLoading = historyQuery.isLoading;
+  const isError = historyQuery.isError;
+  const hasRows = allRows.length > 0;
+  const noFilteredResults = hasRows && filtered.length === 0 && activeFilterCount > 0;
+  const showBatchNote = sessions.length === HISTORY_BATCH_LIMIT;
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-blue-50 via-white to-purple-50 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900">
-      <HubPageContainer className="py-8">
-        {/* Header */}
-        <div className="text-center mb-8">
-          <div className="inline-flex items-center justify-center w-16 h-16 mb-4 rounded-full bg-purple-100 dark:bg-purple-900">
-            <Calendar className="w-8 h-8 text-purple-600 dark:text-purple-400" />
-          </div>
-          <h1 className="text-4xl font-bold mb-2 bg-gradient-to-r from-purple-600 to-blue-600 bg-clip-text text-transparent">
-            Session History
+    <HubPageContainer className="flex flex-col gap-6">
+      {/* breadcrumb */}
+      <nav
+        aria-label={t('pages.toolkitHistory.hero.breadcrumbToolkit')}
+        className="flex items-center gap-1.5 text-sm text-muted-foreground"
+      >
+        <span>{t('pages.toolkitHistory.hero.breadcrumbToolkit')}</span>
+        <span aria-hidden="true">›</span>
+        <span className="font-medium text-foreground">
+          {t('pages.toolkitHistory.hero.breadcrumbHistory')}
+        </span>
+      </nav>
+
+      {/* hero */}
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div>
+          <h1 className="font-quicksand text-2xl font-bold text-foreground sm:text-3xl">
+            {t('pages.toolkitHistory.hero.title')}
           </h1>
-          <p className="text-lg text-muted-foreground">Review past game sessions and statistics</p>
+          <p className="mt-1 text-sm text-muted-foreground">
+            {t('pages.toolkitHistory.hero.subtitle')}
+          </p>
         </div>
+        <p className="text-sm text-muted-foreground">
+          {t('pages.toolkitHistory.hero.quickStat', {
+            sessions: allRows.length,
+            games: totalGames,
+            winners: totalWinners,
+          })}
+        </p>
+      </div>
 
-        {/* Filters */}
-        <Card className="mb-6">
-          <CardHeader>
-            <CardTitle className="flex items-center gap-2">
-              <Filter className="w-5 h-5" />
-              Filters
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            <div className="grid md:grid-cols-4 gap-4">
-              <div>
-                <Label htmlFor="game-filter">Game</Label>
-                <Select value={gameFilter} onValueChange={setGameFilter}>
-                  <SelectTrigger id="game-filter">
-                    <SelectValue placeholder="All games" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="all">All games</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
+      {/* toolkit tabs */}
+      <nav
+        aria-label={t('pages.toolkitHistory.hero.breadcrumbToolkit')}
+        className="flex gap-1 overflow-x-auto border-b border-border"
+      >
+        {TOOLKIT_TABS.map(tab => (
+          <Link
+            key={tab.id}
+            href={tab.href}
+            aria-current={tab.id === 'history' ? 'page' : undefined}
+            className={cn(
+              'flex shrink-0 items-center gap-1.5 border-b-2 px-3 py-2 text-sm font-medium transition-colors',
+              tab.id === 'history'
+                ? 'border-primary text-primary'
+                : 'border-transparent text-muted-foreground hover:text-foreground'
+            )}
+          >
+            <span aria-hidden="true">{tab.icon}</span>
+            {t(`pages.toolkitHistory.tabs.${tab.id}`)}
+          </Link>
+        ))}
+      </nav>
 
-              <div>
-                <Label htmlFor="start-date">Start Date</Label>
-                <Input
-                  id="start-date"
-                  type="date"
-                  value={startDate}
-                  onChange={e => setStartDate(e.target.value)}
-                />
-              </div>
+      {/* loading */}
+      {isLoading && (
+        <div
+          role="status"
+          aria-busy="true"
+          aria-label={t('pages.toolkitHistory.loading.ariaLabel')}
+          className="flex flex-col gap-3"
+        >
+          {Array.from({ length: 6 }).map((_, i) => (
+            <Skeleton key={i} className="h-16 w-full rounded-lg" />
+          ))}
+        </div>
+      )}
 
-              <div>
-                <Label htmlFor="end-date">End Date</Label>
-                <Input
-                  id="end-date"
-                  type="date"
-                  value={endDate}
-                  onChange={e => setEndDate(e.target.value)}
-                />
-              </div>
+      {/* error */}
+      {!isLoading && isError && (
+        <div
+          role="alert"
+          className="flex flex-wrap items-center gap-3 rounded-lg border border-destructive/40 bg-destructive/10 px-4 py-3 text-sm text-destructive"
+        >
+          <AlertCircle className="h-4 w-4 shrink-0" aria-hidden="true" />
+          <span className="flex-1">{t('pages.toolkitHistory.error.message')}</span>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => void historyQuery.refetch()}
+          >
+            {t('pages.toolkitHistory.error.retry')}
+          </Button>
+        </div>
+      )}
 
-              <div className="flex items-end">
-                <Button variant="outline" onClick={handleResetFilters} className="w-full">
-                  Reset
-                </Button>
-              </div>
-            </div>
-          </CardContent>
-        </Card>
+      {/* empty (no sessions at all) */}
+      {!isLoading && !isError && !hasRows && (
+        <div className="flex flex-col items-center gap-3 rounded-lg border border-border bg-card px-6 py-16 text-center">
+          <span aria-hidden="true" className="text-4xl">
+            📜
+          </span>
+          <h2 className="text-lg font-semibold text-foreground">
+            {t('pages.toolkitHistory.empty.title')}
+          </h2>
+          <p className="max-w-md text-sm text-muted-foreground">
+            {t('pages.toolkitHistory.empty.body')}
+          </p>
+          <Button type="button" onClick={() => router.push('/toolkit')}>
+            {t('pages.toolkitHistory.empty.cta')}
+          </Button>
+        </div>
+      )}
 
-        {/* Session List */}
-        {isLoading ? (
-          <Card>
-            <CardContent className="py-12 text-center">
-              <Loader2 className="w-8 h-8 mx-auto mb-4 animate-spin text-purple-600" />
-              <p className="text-muted-foreground">Loading sessions...</p>
-            </CardContent>
-          </Card>
-        ) : sessions.length === 0 ? (
-          <Card>
-            <CardContent className="py-12 text-center">
-              <Calendar className="w-12 h-12 mx-auto mb-4 text-muted-foreground" />
-              <p className="text-muted-foreground mb-4">No sessions found</p>
-              <Button onClick={() => router.push('/toolkit')}>Start Your First Session</Button>
-            </CardContent>
-          </Card>
-        ) : (
-          <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
-            {sessions.map(session => (
-              <Card key={session.id} className="hover:shadow-lg transition-shadow">
-                <CardHeader>
-                  <div className="flex items-center justify-between">
-                    <div className="flex items-center gap-2">
-                      {session.gameIcon && <span className="text-2xl">{session.gameIcon}</span>}
-                      <div>
-                        <CardTitle className="text-base">
-                          {session.gameName || 'Generic Session'}
-                        </CardTitle>
-                        <p className="text-sm text-muted-foreground">{session.sessionCode}</p>
-                      </div>
-                    </div>
-                    <Badge variant={session.status === 'Finalized' ? 'default' : 'secondary'}>
-                      {session.status}
-                    </Badge>
-                  </div>
-                </CardHeader>
-                <CardContent className="space-y-3">
-                  <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                    <Calendar className="w-4 h-4" />
-                    <span>{new Date(session.sessionDate).toLocaleDateString('it-IT')}</span>
-                  </div>
-
-                  <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                    <Trophy className="w-4 h-4" />
-                    <span>{session.participantCount} players</span>
-                  </div>
-
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={() => handleViewDetails(session)}
-                    className="w-full"
-                  >
-                    View Details
-                  </Button>
-                </CardContent>
-              </Card>
-            ))}
-          </div>
-        )}
-
-        {/* Session Detail Modal */}
-        {selectedSession && (
-          <SessionDetailModal
-            session={selectedSession}
-            open={isModalOpen}
-            onOpenChange={setIsModalOpen}
+      {/* toolbar + results */}
+      {!isLoading && !isError && hasRows && (
+        <div className="flex flex-col gap-4">
+          <HistoryToolbar
+            state={filterState}
+            onChange={handleFilterChange}
+            gameOptions={gameOptions}
+            winnerOptions={winnerOptions}
+            view={view}
+            onViewChange={setView}
+            totalCount={allRows.length}
+            resultCount={filtered.length}
+            onClearAll={handleClearAll}
+            onExport={handleExport}
           />
-        )}
-      </HubPageContainer>
-    </div>
+
+          {showBatchNote && (
+            <p className="text-xs text-muted-foreground">
+              {t('pages.toolkitHistory.batchNote', { n: HISTORY_BATCH_LIMIT })}
+            </p>
+          )}
+
+          {noFilteredResults ? (
+            <div className="flex flex-col items-center gap-3 rounded-lg border border-border bg-card px-6 py-16 text-center">
+              <span aria-hidden="true" className="text-4xl">
+                🔍
+              </span>
+              <h2 className="text-lg font-semibold text-foreground">
+                {t('pages.toolkitHistory.filteredEmpty.title')}
+              </h2>
+              <p className="max-w-md text-sm text-muted-foreground">
+                {t('pages.toolkitHistory.filteredEmpty.body')}
+              </p>
+              <Button type="button" variant="outline" onClick={handleClearAll}>
+                {t('pages.toolkitHistory.filteredEmpty.cta')}
+              </Button>
+            </div>
+          ) : (
+            <>
+              {view === 'table' ? (
+                <div className="overflow-x-auto rounded-lg border border-border">
+                  <HistoryTable
+                    rows={pageRows}
+                    sort={filterState.sort}
+                    onSortChange={handleSortChange}
+                    onOpenDetail={setDetailRow}
+                    onOpenGameStats={handleOpenGameStats}
+                  />
+                </div>
+              ) : (
+                <HistoryCards rows={pageRows} onOpenDetail={setDetailRow} />
+              )}
+
+              <HistoryPagination
+                page={page}
+                total={filtered.length}
+                pageSize={pageSize}
+                onPageChange={setPage}
+                onPageSizeChange={handlePageSizeChange}
+              />
+            </>
+          )}
+        </div>
+      )}
+
+      <HistoryDetailModal row={detailRow} onClose={() => setDetailRow(null)} />
+    </HubPageContainer>
   );
 }

--- a/apps/web/src/components/library/MeepleLibraryGameCard.tsx
+++ b/apps/web/src/components/library/MeepleLibraryGameCard.tsx
@@ -333,8 +333,8 @@ export function MeepleLibraryGameCard({
 
       {/* Add to Wishlist dialog */}
       <AddToWishlistDialog
-        gameId={game.gameId}
-        gameName={game.gameTitle}
+        mode="add"
+        prefillGameId={game.gameId}
         open={wishlistDialogOpen}
         onOpenChange={setWishlistDialogOpen}
       />

--- a/apps/web/src/components/wishlist/AddToWishlistDialog.tsx
+++ b/apps/web/src/components/wishlist/AddToWishlistDialog.tsx
@@ -18,7 +18,7 @@
  * the combobox only searches the user's own library.
  */
 
-import React, { useMemo, useState } from 'react';
+import React, { useMemo, useRef, useState } from 'react';
 
 import { X } from 'lucide-react';
 
@@ -139,6 +139,8 @@ export function AddToWishlistDialog({
   const [selectedGame, setSelectedGame] = useState<SelectedGame | null>(buildInitialGame);
   const [query, setQuery] = useState('');
   const [comboOpen, setComboOpen] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(-1);
+  const comboContainerRef = useRef<HTMLDivElement | null>(null);
   const [priority, setPriority] = useState<Priority>(
     isEdit && item ? normalizePriority(item.priority) : 'medium'
   );
@@ -155,6 +157,7 @@ export function AddToWishlistDialog({
     setSelectedGame(buildInitialGame());
     setQuery('');
     setComboOpen(false);
+    setActiveIndex(-1);
     setPriority(isEdit && item ? normalizePriority(item.priority) : 'medium');
     setTargetPrice(isEdit && item?.targetPrice != null ? String(item.targetPrice) : '');
     setNotes(isEdit ? (item?.notes ?? '') : '');
@@ -179,6 +182,60 @@ export function AddToWishlistDialog({
     setSelectedGame(g);
     setQuery('');
     setComboOpen(false);
+    setActiveIndex(-1);
+  }
+
+  function comboOptionId(g: SelectedGame): string {
+    return `wishlist-game-option-${g.id}`;
+  }
+
+  /**
+   * ARIA combobox keyboard pattern (APG): ArrowDown/ArrowUp move the active
+   * descendant (opening the listbox if needed), Enter commits the active
+   * match, Escape closes the listbox. `preventDefault` on Enter is required
+   * so it doesn't trigger the form's implicit submission instead.
+   */
+  function handleComboKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+      e.preventDefault();
+      setComboOpen(true);
+      const direction = e.key === 'ArrowDown' ? 1 : -1;
+      setActiveIndex(i => {
+        if (matches.length === 0) return -1;
+        if (i < 0) return direction === 1 ? 0 : matches.length - 1;
+        return Math.min(Math.max(i + direction, 0), matches.length - 1);
+      });
+      return;
+    }
+    if (e.key === 'Enter') {
+      if (!comboOpen) return;
+      e.preventDefault();
+      const active = activeIndex >= 0 ? matches[activeIndex] : undefined;
+      if (active) {
+        pickGame(active);
+      }
+      return;
+    }
+    if (e.key === 'Escape') {
+      if (!comboOpen) return;
+      e.preventDefault();
+      setComboOpen(false);
+      setActiveIndex(-1);
+    }
+  }
+
+  /**
+   * Closes the listbox on blur only when focus left the combobox container
+   * entirely — keeps a keyboard user's Enter-select from racing a premature
+   * close, and mirrors the mousedown-preventDefault used for option clicks.
+   */
+  function handleComboBlur(e: React.FocusEvent<HTMLInputElement>) {
+    const next = e.relatedTarget as Node | null;
+    if (next && comboContainerRef.current?.contains(next)) {
+      return;
+    }
+    setComboOpen(false);
+    setActiveIndex(-1);
   }
 
   function handleSubmit(e: React.FormEvent) {
@@ -285,13 +342,18 @@ export function AddToWishlistDialog({
                 )}
               </div>
             ) : (
-              <div className="relative">
+              <div className="relative" ref={comboContainerRef}>
                 <Input
                   id="wishlist-game-combobox"
                   role="combobox"
                   aria-expanded={comboOpen}
                   aria-autocomplete="list"
                   aria-controls="wishlist-game-listbox"
+                  aria-activedescendant={
+                    comboOpen && activeIndex >= 0 && matches[activeIndex]
+                      ? comboOptionId(matches[activeIndex])
+                      : undefined
+                  }
                   aria-label={t('pages.library.wishlist.dialog.gameComboAria')}
                   placeholder={t('pages.library.wishlist.dialog.gameComboPlaceholder')}
                   value={query}
@@ -300,8 +362,10 @@ export function AddToWishlistDialog({
                   onChange={e => {
                     setQuery(e.target.value);
                     setComboOpen(true);
+                    setActiveIndex(-1);
                   }}
-                  onBlur={() => setComboOpen(false)}
+                  onKeyDown={handleComboKeyDown}
+                  onBlur={handleComboBlur}
                 />
                 {comboOpen && matches.length > 0 && (
                   <div
@@ -309,19 +373,28 @@ export function AddToWishlistDialog({
                     role="listbox"
                     className="absolute z-10 mt-1 max-h-60 w-full overflow-y-auto rounded-lg border border-border bg-card shadow-md"
                   >
-                    {matches.map(g => (
-                      <button
-                        key={g.id}
-                        type="button"
-                        role="option"
-                        aria-selected={false}
-                        onMouseDown={e => e.preventDefault()}
-                        onClick={() => pickGame(g)}
-                        className="flex w-full items-center px-3 py-2 text-left text-sm text-foreground hover:bg-muted"
-                      >
-                        {g.title}
-                      </button>
-                    ))}
+                    {matches.map((g, idx) => {
+                      const isActive = idx === activeIndex;
+                      return (
+                        <button
+                          key={g.id}
+                          id={comboOptionId(g)}
+                          type="button"
+                          role="option"
+                          aria-selected={isActive}
+                          tabIndex={-1}
+                          onMouseDown={e => e.preventDefault()}
+                          onMouseEnter={() => setActiveIndex(idx)}
+                          onClick={() => pickGame(g)}
+                          className={cn(
+                            'flex w-full items-center px-3 py-2 text-left text-sm text-foreground hover:bg-muted',
+                            isActive && 'bg-muted'
+                          )}
+                        >
+                          {g.title}
+                        </button>
+                      );
+                    })}
                   </div>
                 )}
               </div>

--- a/apps/web/src/components/wishlist/AddToWishlistDialog.tsx
+++ b/apps/web/src/components/wishlist/AddToWishlistDialog.tsx
@@ -1,49 +1,95 @@
 'use client';
 
 /**
- * AddToWishlistDialog — Dialog for adding a game to the wishlist.
+ * AddToWishlistDialog — Unified ADD/EDIT dialog for the wishlist (Issue #3007, Task B4).
  *
- * Accepts an optional gameId to pre-fill the form.
- * Fields: gameId (UUID text), priority (low/medium/high), target price (optional), notes (optional).
+ * `mode="add"` (default) creates a new wishlist entry via `useAddToWishlist`. The game
+ * field is a searchable combobox over the user's library (`useLibrary`); the selected
+ * game stays removable even when pre-filled via `prefillGameId`.
+ *
+ * `mode="edit"` updates an existing entry (`item`) via `useUpdateWishlistItem`. The game
+ * is locked to a non-removable chip (a wishlist entry's game cannot change); priority,
+ * target price and notes are pre-filled from `item`. Clearing a previously-set target
+ * price/notes sends `clearTargetPrice`/`clearNotes` so the API nulls them out instead of
+ * silently ignoring the empty value.
+ *
+ * Mockup: admin-mockups/design_files/sp4-library-wishlist-ui.jsx (`AddWishlistDialog`,
+ * ~lines 244-406). BGG search is out of scope (user-side BGG access ban, issue #2123) —
+ * the combobox only searches the user's own library.
  */
 
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 
+import { X } from 'lucide-react';
+
+import { toast } from '@/components/layout/Toast';
 import {
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
   DialogTrigger,
 } from '@/components/ui/overlays/dialog';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/overlays/select';
 import { Button } from '@/components/ui/primitives/button';
 import { Input } from '@/components/ui/primitives/input';
 import { Label } from '@/components/ui/primitives/label';
-import { useAddToWishlist } from '@/hooks/queries/useWishlist';
+import { Textarea } from '@/components/ui/primitives/textarea';
+import { useLibrary } from '@/hooks/queries/useLibrary';
+import { useAddToWishlist, useUpdateWishlistItem } from '@/hooks/queries/useWishlist';
+import { useTranslation } from '@/hooks/useTranslation';
+import type { WishlistItemDto } from '@/lib/api/schemas/wishlist.schemas';
+import { cn } from '@/lib/utils';
 
 // ============================================================================
-// Types
+// Types & constants
 // ============================================================================
+
+type Priority = 'high' | 'medium' | 'low';
+
+const PRIORITY_ORDER: readonly Priority[] = ['high', 'medium', 'low'];
+const KNOWN_PRIORITIES: readonly Priority[] = ['high', 'medium', 'low'];
+const NOTES_MAX = 200;
+const NOTES_NEAR_LIMIT = NOTES_MAX - 30;
+
+interface SelectedGame {
+  id: string;
+  title: string;
+}
 
 interface AddToWishlistDialogProps {
-  trigger?: React.ReactNode;
-  /** Pre-filled game ID (disables the game ID input) */
-  gameId?: string;
-  /** Display name for the pre-filled game */
-  gameName?: string;
+  /** 'add' (default) creates a new entry; 'edit' updates `item`. */
+  mode?: 'add' | 'edit';
+  /** The wishlist item being edited. Required when `mode === 'edit'`. */
+  item?: WishlistItemDto;
   /** Controlled open state (when provided, dialog is externally controlled) */
   open?: boolean;
   /** Controlled open change handler */
   onOpenChange?: (open: boolean) => void;
+  trigger?: React.ReactNode;
+  /** Pre-selects a game in add mode. Still removable via the combobox. */
+  prefillGameId?: string;
   onSuccess?: () => void;
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/** Case-insensitively normalizes a raw `priority` string, defaulting to 'medium'. */
+function normalizePriority(raw: string | undefined): Priority {
+  const lower = (raw ?? '').toLowerCase();
+  return (KNOWN_PRIORITIES as readonly string[]).includes(lower) ? (lower as Priority) : 'medium';
+}
+
+function priorityChipClasses(key: Priority, isSelected: boolean): string {
+  if (!isSelected) {
+    return 'border-border bg-card text-foreground hover:bg-muted';
+  }
+  if (key === 'high') return 'border-destructive bg-destructive/10 text-destructive';
+  if (key === 'low') return 'border-muted-foreground/40 bg-muted text-muted-foreground';
+  return 'border-primary bg-primary/10 text-primary';
 }
 
 // ============================================================================
@@ -51,56 +97,142 @@ interface AddToWishlistDialogProps {
 // ============================================================================
 
 export function AddToWishlistDialog({
-  trigger,
-  gameId,
-  gameName,
+  mode = 'add',
+  item,
   open: controlledOpen,
   onOpenChange: controlledOnOpenChange,
+  trigger,
+  prefillGameId,
   onSuccess,
 }: AddToWishlistDialogProps) {
+  const { t } = useTranslation();
+  const isEdit = mode === 'edit' && !!item;
+
   const [internalOpen, setInternalOpen] = useState(false);
   const isControlled = controlledOpen !== undefined;
   const open = isControlled ? controlledOpen : internalOpen;
   const setOpen = isControlled ? (controlledOnOpenChange ?? (() => {})) : setInternalOpen;
 
-  const [formGameId, setFormGameId] = useState(gameId ?? '');
-  const [priority, setPriority] = useState<'low' | 'medium' | 'high'>('medium');
-  const [targetPrice, setTargetPrice] = useState('');
-  const [notes, setNotes] = useState('');
+  const { data: libraryData } = useLibrary();
+  const libraryGames = useMemo<SelectedGame[]>(
+    () => (libraryData?.items ?? []).map(entry => ({ id: entry.gameId, title: entry.gameTitle })),
+    [libraryData?.items]
+  );
 
-  const { mutate: addToWishlist, isPending } = useAddToWishlist();
+  function resolveGameTitle(gameId: string): string | undefined {
+    return libraryGames.find(g => g.id === gameId)?.title;
+  }
+
+  function buildInitialGame(): SelectedGame | null {
+    if (isEdit && item) {
+      return {
+        id: item.gameId,
+        title: item.gameName ?? resolveGameTitle(item.gameId) ?? item.gameId,
+      };
+    }
+    if (prefillGameId) {
+      return { id: prefillGameId, title: resolveGameTitle(prefillGameId) ?? prefillGameId };
+    }
+    return null;
+  }
+
+  const [selectedGame, setSelectedGame] = useState<SelectedGame | null>(buildInitialGame);
+  const [query, setQuery] = useState('');
+  const [comboOpen, setComboOpen] = useState(false);
+  const [priority, setPriority] = useState<Priority>(
+    isEdit && item ? normalizePriority(item.priority) : 'medium'
+  );
+  const [targetPrice, setTargetPrice] = useState(
+    isEdit && item?.targetPrice != null ? String(item.targetPrice) : ''
+  );
+  const [notes, setNotes] = useState(isEdit ? (item?.notes ?? '') : '');
+
+  const { mutate: addToWishlist, isPending: isAdding } = useAddToWishlist();
+  const { mutate: updateWishlistItem, isPending: isUpdating } = useUpdateWishlistItem();
+  const isPending = isEdit ? isUpdating : isAdding;
+
+  function resetForm() {
+    setSelectedGame(buildInitialGame());
+    setQuery('');
+    setComboOpen(false);
+    setPriority(isEdit && item ? normalizePriority(item.priority) : 'medium');
+    setTargetPrice(isEdit && item?.targetPrice != null ? String(item.targetPrice) : '');
+    setNotes(isEdit ? (item?.notes ?? '') : '');
+  }
 
   function handleOpenChange(value: boolean) {
     setOpen(value);
     if (value) {
-      // Reset form, but keep pre-filled gameId
-      setFormGameId(gameId ?? '');
-      setPriority('medium');
-      setTargetPrice('');
-      setNotes('');
+      resetForm();
     }
+  }
+
+  const matches = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    const pool = q ? libraryGames.filter(g => g.title.toLowerCase().includes(q)) : libraryGames;
+    return pool.slice(0, 6);
+  }, [query, libraryGames]);
+
+  const canSubmit = !!selectedGame && !!priority && !isPending;
+
+  function pickGame(g: SelectedGame) {
+    setSelectedGame(g);
+    setQuery('');
+    setComboOpen(false);
   }
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
+    if (!selectedGame || !canSubmit) return;
 
-    const parsedPrice = targetPrice !== '' ? parseFloat(targetPrice) : undefined;
+    const parsedPrice = targetPrice.trim() !== '' ? parseFloat(targetPrice) : null;
+    const trimmedNotes = notes.trim();
+
+    function handleSuccess() {
+      toast.success(t('pages.library.wishlist.dialog.success'));
+      setOpen(false);
+      onSuccess?.();
+    }
+
+    if (isEdit && item) {
+      const hadPrice = item.targetPrice != null;
+      const hadNotes = !!item.notes;
+
+      updateWishlistItem(
+        {
+          id: item.id,
+          data: {
+            priority,
+            ...(parsedPrice != null
+              ? { targetPrice: parsedPrice }
+              : hadPrice
+                ? { clearTargetPrice: true as const }
+                : {}),
+            ...(trimmedNotes !== ''
+              ? { notes: trimmedNotes }
+              : hadNotes
+                ? { clearNotes: true as const }
+                : {}),
+          },
+        },
+        { onSuccess: handleSuccess }
+      );
+      return;
+    }
 
     addToWishlist(
       {
-        gameId: formGameId.trim(),
+        gameId: selectedGame.id,
         priority,
-        targetPrice: parsedPrice ?? null,
-        notes: notes.trim() || null,
+        targetPrice: parsedPrice,
+        notes: trimmedNotes !== '' ? trimmedNotes : null,
       },
-      {
-        onSuccess: () => {
-          setOpen(false);
-          onSuccess?.();
-        },
-      }
+      { onSuccess: handleSuccess }
     );
   }
+
+  const editSubPriority = isEdit && item ? normalizePriority(item.priority) : priority;
+  const editSubName = isEdit && item ? (item.gameName ?? selectedGame?.title ?? '') : '';
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
@@ -109,90 +241,189 @@ export function AddToWishlistDialog({
           <DialogTrigger asChild>{trigger}</DialogTrigger>
         ) : (
           <DialogTrigger asChild>
-            <Button>Add to Wishlist</Button>
+            <Button>{t('pages.library.wishlist.hero.addCta')}</Button>
           </DialogTrigger>
         ))}
 
       <DialogContent>
         <DialogHeader>
           <DialogTitle>
-            {gameName ? `Add "${gameName}" to Wishlist` : 'Add to Wishlist'}
+            {isEdit
+              ? t('pages.library.wishlist.dialog.editTitle')
+              : t('pages.library.wishlist.dialog.addTitle')}
           </DialogTitle>
+          <DialogDescription>
+            {isEdit
+              ? t('pages.library.wishlist.dialog.editSub', {
+                  name: editSubName,
+                  priority: t(`pages.library.wishlist.priority.${editSubPriority}`),
+                })
+              : t('pages.library.wishlist.dialog.addSub')}
+          </DialogDescription>
         </DialogHeader>
 
         <form onSubmit={handleSubmit} className="space-y-4">
-          {/* Game ID */}
+          {/* Game combobox */}
           <div className="space-y-1.5">
-            <Label htmlFor="wishlist-game-id">Game</Label>
-            {gameId && gameName ? (
-              <p className="text-sm font-medium py-2">{gameName}</p>
+            <Label htmlFor="wishlist-game-combobox">
+              {t('pages.library.wishlist.dialog.gameLabel')}
+            </Label>
+            {selectedGame ? (
+              <div className="flex items-center gap-2 rounded-lg border border-border bg-muted px-3 py-2.5">
+                <span className="flex-1 truncate text-sm font-medium text-foreground">
+                  {selectedGame.title}
+                </span>
+                {!isEdit && (
+                  <button
+                    type="button"
+                    onClick={() => setSelectedGame(null)}
+                    aria-label={t('pages.library.wishlist.dialog.gameRemoveAria')}
+                    className="rounded p-1 text-muted-foreground transition-colors hover:bg-card hover:text-foreground"
+                  >
+                    <X className="h-4 w-4" />
+                  </button>
+                )}
+              </div>
             ) : (
-              <Input
-                id="wishlist-game-id"
-                placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-                value={formGameId}
-                onChange={e => setFormGameId(e.target.value)}
-                required
-                disabled={!!gameId}
-              />
+              <div className="relative">
+                <Input
+                  id="wishlist-game-combobox"
+                  role="combobox"
+                  aria-expanded={comboOpen}
+                  aria-autocomplete="list"
+                  aria-controls="wishlist-game-listbox"
+                  aria-label={t('pages.library.wishlist.dialog.gameComboAria')}
+                  placeholder={t('pages.library.wishlist.dialog.gameComboPlaceholder')}
+                  value={query}
+                  autoComplete="off"
+                  onFocus={() => setComboOpen(true)}
+                  onChange={e => {
+                    setQuery(e.target.value);
+                    setComboOpen(true);
+                  }}
+                  onBlur={() => setComboOpen(false)}
+                />
+                {comboOpen && matches.length > 0 && (
+                  <div
+                    id="wishlist-game-listbox"
+                    role="listbox"
+                    className="absolute z-10 mt-1 max-h-60 w-full overflow-y-auto rounded-lg border border-border bg-card shadow-md"
+                  >
+                    {matches.map(g => (
+                      <button
+                        key={g.id}
+                        type="button"
+                        role="option"
+                        aria-selected={false}
+                        onMouseDown={e => e.preventDefault()}
+                        onClick={() => pickGame(g)}
+                        className="flex w-full items-center px-3 py-2 text-left text-sm text-foreground hover:bg-muted"
+                      >
+                        {g.title}
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
             )}
           </div>
 
-          {/* Priority */}
+          {/* Priority radio-chips */}
           <div className="space-y-1.5">
-            <Label htmlFor="wishlist-priority">Priority</Label>
-            <Select
-              value={priority}
-              onValueChange={v => setPriority(v as 'low' | 'medium' | 'high')}
+            <Label id="wishlist-priority-label">
+              {t('pages.library.wishlist.dialog.priorityLabel')}
+            </Label>
+            <div
+              role="radiogroup"
+              aria-labelledby="wishlist-priority-label"
+              className="flex flex-wrap gap-2"
             >
-              <SelectTrigger id="wishlist-priority">
-                <SelectValue placeholder="Select priority" />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="low">Low</SelectItem>
-                <SelectItem value="medium">Medium</SelectItem>
-                <SelectItem value="high">High</SelectItem>
-              </SelectContent>
-            </Select>
+              {PRIORITY_ORDER.map(key => {
+                const isSelected = priority === key;
+                return (
+                  <button
+                    key={key}
+                    type="button"
+                    role="radio"
+                    aria-checked={isSelected}
+                    onClick={() => setPriority(key)}
+                    className={cn(
+                      'rounded-full border px-3 py-1.5 text-sm font-semibold transition-colors',
+                      priorityChipClasses(key, isSelected)
+                    )}
+                  >
+                    {t(`pages.library.wishlist.priority.${key}`)}
+                  </button>
+                );
+              })}
+            </div>
           </div>
 
-          {/* Target Price (optional) */}
+          {/* Target price (optional) */}
           <div className="space-y-1.5">
             <Label htmlFor="wishlist-target-price">
-              Target Price <span className="text-muted-foreground text-xs">(optional)</span>
+              {t('pages.library.wishlist.dialog.priceLabel')}
             </Label>
-            <Input
-              id="wishlist-target-price"
-              type="number"
-              min="0"
-              step="0.01"
-              placeholder="e.g. 29.99"
-              value={targetPrice}
-              onChange={e => setTargetPrice(e.target.value)}
-            />
+            <div className="relative">
+              <span
+                aria-hidden="true"
+                className="pointer-events-none absolute left-3.5 top-1/2 -translate-y-1/2 text-sm text-muted-foreground"
+              >
+                €
+              </span>
+              <Input
+                id="wishlist-target-price"
+                type="number"
+                min="0"
+                max="999"
+                step="0.5"
+                placeholder={t('pages.library.wishlist.dialog.pricePlaceholder')}
+                aria-label={t('pages.library.wishlist.dialog.priceAria')}
+                value={targetPrice}
+                onChange={e => setTargetPrice(e.target.value)}
+                className="pl-7"
+              />
+            </div>
+            <p className="text-xs text-muted-foreground">
+              {t('pages.library.wishlist.dialog.priceHint')}
+            </p>
           </div>
 
           {/* Notes (optional) */}
           <div className="space-y-1.5">
-            <Label htmlFor="wishlist-notes">
-              Notes <span className="text-muted-foreground text-xs">(optional)</span>
-            </Label>
-            <textarea
+            <div className="flex items-center justify-between">
+              <Label htmlFor="wishlist-notes">
+                {t('pages.library.wishlist.dialog.notesLabel')}
+              </Label>
+              <span
+                className={cn(
+                  'text-xs',
+                  notes.length > NOTES_NEAR_LIMIT ? 'text-destructive' : 'text-muted-foreground'
+                )}
+              >
+                {t('pages.library.wishlist.dialog.notesCounter', { len: notes.length })}
+              </span>
+            </div>
+            <Textarea
               id="wishlist-notes"
               rows={3}
-              placeholder="Any notes about this game..."
+              maxLength={NOTES_MAX}
+              placeholder={t('pages.library.wishlist.dialog.notesPlaceholder')}
               value={notes}
               onChange={e => setNotes(e.target.value)}
-              className="flex w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring resize-none"
             />
           </div>
 
           <DialogFooter>
             <Button type="button" variant="outline" onClick={() => setOpen(false)}>
-              Cancel
+              {t('pages.library.wishlist.dialog.cancel')}
             </Button>
-            <Button type="submit" disabled={isPending || !formGameId.trim()}>
-              {isPending ? 'Adding…' : 'Add to Wishlist'}
+            <Button type="submit" disabled={!canSubmit}>
+              {isPending
+                ? t('pages.library.wishlist.dialog.submitting')
+                : isEdit
+                  ? t('pages.library.wishlist.dialog.save')
+                  : t('pages.library.wishlist.dialog.add')}
             </Button>
           </DialogFooter>
         </form>

--- a/apps/web/src/components/wishlist/MeepleWishlistCard.tsx
+++ b/apps/web/src/components/wishlist/MeepleWishlistCard.tsx
@@ -38,8 +38,10 @@ interface MeepleWishlistCardProps {
   /** Resolved game name — falls back to item.gameName, then a localized placeholder. */
   gameName?: string;
   onRemove: (id: string) => void;
-  onEdit: (item: WishlistItemDto) => void;
-  onFilterPriority: (priority: Priority) => void;
+  /** When omitted, the Edit action is not rendered. */
+  onEdit?: (item: WishlistItemDto) => void;
+  /** When omitted, the priority badge renders as a non-interactive `<span>`. */
+  onFilterPriority?: (priority: Priority) => void;
 }
 
 // ============================================================================
@@ -132,14 +134,23 @@ export function MeepleWishlistCard({
     >
       <div className="flex items-center justify-between px-1">
         <span aria-hidden="true">❤️</span>
-        <button
-          type="button"
-          onClick={() => onFilterPriority(priority)}
-          aria-label={t('pages.library.wishlist.priority.filterAria', { label: priorityLabel })}
-          className="rounded-full border border-border bg-muted px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide text-foreground transition-colors hover:bg-muted/70"
-        >
-          {priorityLabel}
-        </button>
+        {onFilterPriority ? (
+          <button
+            type="button"
+            onClick={() => onFilterPriority(priority)}
+            aria-label={t('pages.library.wishlist.priority.filterAria', { label: priorityLabel })}
+            className="rounded-full border border-border bg-muted px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide text-foreground transition-colors hover:bg-muted/70"
+          >
+            {priorityLabel}
+          </button>
+        ) : (
+          <span
+            className="rounded-full border border-border bg-muted px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide text-foreground"
+            data-testid="wishlist-priority-badge-static"
+          >
+            {priorityLabel}
+          </span>
+        )}
       </div>
 
       <MeepleCard
@@ -157,14 +168,16 @@ export function MeepleWishlistCard({
       </div>
 
       <div className="flex items-center justify-end gap-2 px-1">
-        <button
-          type="button"
-          onClick={() => onEdit(item)}
-          aria-label={t('pages.library.wishlist.card.editAria', { name: resolvedGameName })}
-          className="rounded-md px-2 py-1 text-xs font-semibold text-foreground transition-colors hover:bg-muted"
-        >
-          {t('pages.library.wishlist.card.edit')}
-        </button>
+        {onEdit && (
+          <button
+            type="button"
+            onClick={() => onEdit(item)}
+            aria-label={t('pages.library.wishlist.card.editAria', { name: resolvedGameName })}
+            className="rounded-md px-2 py-1 text-xs font-semibold text-foreground transition-colors hover:bg-muted"
+          >
+            {t('pages.library.wishlist.card.edit')}
+          </button>
+        )}
         <button
           type="button"
           onClick={() => onRemove(item.id)}

--- a/apps/web/src/components/wishlist/MeepleWishlistCard.tsx
+++ b/apps/web/src/components/wishlist/MeepleWishlistCard.tsx
@@ -3,14 +3,31 @@
 /**
  * MeepleWishlistCard — MeepleCard-based display for a single wishlist item.
  *
- * Shows priority badge (Italian labels), optional target price in metadata,
- * notes as subtitle, and Edit/Remove quick actions.
- * Uses the MeepleCard design system with entity="game".
+ * Issue #3007 (Task B3). Wraps `MeepleCard` (entity="game", variant="list")
+ * for the shared card chrome (cover, title, subtitle, target-price metadata)
+ * and layers on the wishlist-specific chrome that neither MeepleCard variant
+ * supports out of the box:
+ *   - a *clickable* priority badge (`ListCard`'s `badge` prop renders a
+ *     static `<span>`, see `meeple-card/variants/ListCard.tsx`)
+ *   - a high-priority left-border accent
+ *   - an added-at relative-time line
+ *   - Edit/Remove footer actions (`ListCard` never renders the `actions`
+ *     prop at all — only `GridCard` does, and only as hover-only icon
+ *     buttons over the cover, which doesn't match the mockup's always-visible
+ *     text actions)
+ *
+ * Mockup: `admin-mockups/design_files/sp4-library-wishlist-ui.jsx`
+ * (`WishlistCard`, ~lines 54-109). The mockup's `MetaBox`
+ * (category/players/duration/BGG) is intentionally omitted — `WishlistItemDto`
+ * has none of those fields.
  */
 
+import type { Priority } from '@/app/(authenticated)/library/wishlist/_lib/wishlist-filters';
 import { MeepleCard } from '@/components/ui/data-display/meeple-card';
 import type { MeepleCardMetadata } from '@/components/ui/data-display/meeple-card';
+import { useTranslation } from '@/hooks/useTranslation';
 import type { WishlistItemDto } from '@/lib/api/schemas/wishlist.schemas';
+import { cn } from '@/lib/utils';
 
 // ============================================================================
 // Types
@@ -18,27 +35,55 @@ import type { WishlistItemDto } from '@/lib/api/schemas/wishlist.schemas';
 
 interface MeepleWishlistCardProps {
   item: WishlistItemDto;
-  /** Resolved game name — falls back to item.gameName or truncated gameId */
+  /** Resolved game name — falls back to item.gameName, then a localized placeholder. */
   gameName?: string;
-  onRemove?: (id: string) => void;
-  onUpdate?: (id: string) => void;
+  onRemove: (id: string) => void;
+  onEdit: (item: WishlistItemDto) => void;
+  onFilterPriority: (priority: Priority) => void;
 }
 
 // ============================================================================
 // Helpers
 // ============================================================================
 
-function formatPriorityItalian(priority: string): string {
-  switch (priority.toLowerCase()) {
-    case 'high':
-      return 'Alta';
-    case 'medium':
-      return 'Media';
-    case 'low':
-      return 'Bassa';
-    default:
-      return priority.charAt(0).toUpperCase() + priority.slice(1).toLowerCase();
-  }
+const KNOWN_PRIORITIES: readonly Priority[] = ['high', 'medium', 'low'];
+
+/** Case-insensitively normalizes a raw `priority` string, defaulting to 'medium' for unknown values. */
+function normalizePriority(raw: string): Priority {
+  const lower = raw.toLowerCase();
+  return (KNOWN_PRIORITIES as readonly string[]).includes(lower) ? (lower as Priority) : 'medium';
+}
+
+const MS_PER_MINUTE = 60_000;
+const MS_PER_HOUR = 60 * MS_PER_MINUTE;
+const MS_PER_DAY = 24 * MS_PER_HOUR;
+const MS_PER_MONTH = 30 * MS_PER_DAY;
+const MS_PER_YEAR = 12 * MS_PER_MONTH;
+
+/**
+ * Buckets an ISO timestamp relative to `now` into an `Intl.RelativeTimeFormat`
+ * value/unit pair, escalating minute → hour → day → month → year.
+ */
+function getRelativeTimeParts(
+  iso: string,
+  now: Date
+): { value: number; unit: Intl.RelativeTimeFormatUnit } {
+  const diffMs = new Date(iso).getTime() - now.getTime();
+
+  const minutes = Math.round(diffMs / MS_PER_MINUTE);
+  if (Math.abs(minutes) < 60) return { value: minutes, unit: 'minute' };
+
+  const hours = Math.round(diffMs / MS_PER_HOUR);
+  if (Math.abs(hours) < 24) return { value: hours, unit: 'hour' };
+
+  const days = Math.round(diffMs / MS_PER_DAY);
+  if (Math.abs(days) < 30) return { value: days, unit: 'day' };
+
+  const months = Math.round(diffMs / MS_PER_MONTH);
+  if (Math.abs(months) < 12) return { value: months, unit: 'month' };
+
+  const years = Math.round(diffMs / MS_PER_YEAR);
+  return { value: years, unit: 'year' };
 }
 
 // ============================================================================
@@ -49,39 +94,86 @@ export function MeepleWishlistCard({
   item,
   gameName,
   onRemove,
-  onUpdate,
+  onEdit,
+  onFilterPriority,
 }: MeepleWishlistCardProps) {
-  const metadata: MeepleCardMetadata[] = [];
+  const { t, formatNumber, formatDate, formatRelativeTime } = useTranslation();
 
+  const priority = normalizePriority(item.priority);
+  const isHighPriority = priority === 'high';
+  const priorityLabel = t(`pages.library.wishlist.priority.${priority}`);
+  const resolvedGameName =
+    gameName ?? item.gameName ?? t('pages.library.wishlist.card.unknownGame');
+
+  const metadata: MeepleCardMetadata[] = [];
   if (item.targetPrice != null) {
-    metadata.push({ label: `Target: ${item.targetPrice.toFixed(2)}` });
+    metadata.push({
+      label: t('pages.library.wishlist.card.target'),
+      value: formatNumber(item.targetPrice, { style: 'currency', currency: 'EUR' }),
+    });
   }
 
-  const actions = [
-    ...(onUpdate ? [{ icon: '✏️', label: 'Edit', onClick: () => onUpdate(item.id) }] : []),
-    ...(onRemove
-      ? [
-          {
-            icon: '🗑️',
-            label: 'Remove',
-            onClick: () => onRemove(item.id),
-            variant: 'danger' as const,
-          },
-        ]
-      : []),
-  ];
+  const now = new Date();
+  const { value: relValue, unit: relUnit } = getRelativeTimeParts(item.addedAt, now);
+  const addedAtLabel = t('pages.library.wishlist.card.addedAt', {
+    when: formatRelativeTime(relValue, relUnit),
+  });
+  const addedAtTitle = t('pages.library.wishlist.card.addedTitle', {
+    date: formatDate(new Date(item.addedAt), { dateStyle: 'medium' }),
+  });
 
   return (
-    <MeepleCard
-      entity="game"
-      variant="list"
-      title={gameName || item.gameName || `Game ${item.gameId.slice(0, 8)}...`}
-      subtitle={item.notes ?? undefined}
-      badge={formatPriorityItalian(item.priority)}
-      metadata={metadata}
-      actions={actions.length > 0 ? actions : undefined}
-      headingLevel={2}
-      data-testid="wishlist-card"
-    />
+    <div
+      className={cn(
+        'flex flex-col gap-1.5 rounded-xl',
+        isHighPriority && 'border-l-4 border-l-destructive'
+      )}
+      data-testid="wishlist-card-shell"
+    >
+      <div className="flex items-center justify-between px-1">
+        <span aria-hidden="true">❤️</span>
+        <button
+          type="button"
+          onClick={() => onFilterPriority(priority)}
+          aria-label={t('pages.library.wishlist.priority.filterAria', { label: priorityLabel })}
+          className="rounded-full border border-border bg-muted px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide text-foreground transition-colors hover:bg-muted/70"
+        >
+          {priorityLabel}
+        </button>
+      </div>
+
+      <MeepleCard
+        entity="game"
+        variant="list"
+        title={resolvedGameName}
+        subtitle={item.notes ?? t('pages.library.wishlist.card.noNote')}
+        metadata={metadata}
+        headingLevel={2}
+        data-testid="wishlist-card"
+      />
+
+      <div className="flex items-center px-1 text-[11px] text-muted-foreground">
+        <span title={addedAtTitle}>{addedAtLabel}</span>
+      </div>
+
+      <div className="flex items-center justify-end gap-2 px-1">
+        <button
+          type="button"
+          onClick={() => onEdit(item)}
+          aria-label={t('pages.library.wishlist.card.editAria', { name: resolvedGameName })}
+          className="rounded-md px-2 py-1 text-xs font-semibold text-foreground transition-colors hover:bg-muted"
+        >
+          {t('pages.library.wishlist.card.edit')}
+        </button>
+        <button
+          type="button"
+          onClick={() => onRemove(item.id)}
+          aria-label={t('pages.library.wishlist.card.removeAria', { name: resolvedGameName })}
+          className="rounded-md px-2 py-1 text-xs font-semibold text-destructive transition-colors hover:bg-destructive/10"
+        >
+          {t('pages.library.wishlist.card.remove')}
+        </button>
+      </div>
+    </div>
   );
 }

--- a/apps/web/src/components/wishlist/__tests__/AddToWishlistDialog.test.tsx
+++ b/apps/web/src/components/wishlist/__tests__/AddToWishlistDialog.test.tsx
@@ -1,0 +1,221 @@
+/**
+ * @vitest-environment jsdom
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { IntlProvider } from 'react-intl';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { flattenMessages } from '@/locales';
+import itMessages from '@/locales/it.json';
+
+import { AddToWishlistDialog } from '../AddToWishlistDialog';
+
+import type { WishlistItemDto } from '@/lib/api/schemas/wishlist.schemas';
+import type { ReactElement } from 'react';
+
+const MESSAGES = flattenMessages(itMessages as unknown as Record<string, unknown>);
+
+// ============================================================================
+// Mocks
+// ============================================================================
+
+const mockAddMutate = vi.fn();
+const mockUpdateMutate = vi.fn();
+const mockToastSuccess = vi.fn();
+
+vi.mock('@/hooks/queries/useWishlist', () => ({
+  useAddToWishlist: () => ({ mutate: mockAddMutate, isPending: false }),
+  useUpdateWishlistItem: () => ({ mutate: mockUpdateMutate, isPending: false }),
+}));
+
+const LIBRARY_ITEMS = [
+  { gameId: 'game-catan', gameTitle: 'Catan' },
+  { gameId: 'game-brass', gameTitle: 'Brass: Birmingham' },
+];
+
+vi.mock('@/hooks/queries/useLibrary', () => ({
+  useLibrary: () => ({ data: { items: LIBRARY_ITEMS }, isLoading: false }),
+}));
+
+vi.mock('@/components/layout/Toast', () => ({
+  toast: {
+    success: (...args: unknown[]) => mockToastSuccess(...args),
+  },
+}));
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function renderWithIntl(ui: ReactElement) {
+  return render(
+    <IntlProvider locale="it" messages={MESSAGES}>
+      {ui}
+    </IntlProvider>
+  );
+}
+
+/**
+ * jsdom does not dispatch a native `submit` event on submit-button click, so submit the
+ * form directly. Radix `Dialog` renders its content into a portal on `document.body`
+ * (outside RTL's render `container`), so query from `document.body`.
+ */
+function submitForm() {
+  const form = document.body.querySelector('form');
+  expect(form).not.toBeNull();
+  fireEvent.submit(form as HTMLFormElement);
+}
+
+function buildItem(overrides: Partial<WishlistItemDto> = {}): WishlistItemDto {
+  return {
+    id: '00000000-0000-0000-0000-000000000001',
+    userId: '00000000-0000-0000-0000-000000000002',
+    gameId: 'game-brass',
+    gameName: 'Brass: Birmingham',
+    priority: 'high',
+    targetPrice: 42,
+    notes: 'Acquisto entro Q3',
+    addedAt: '2026-01-01',
+    updatedAt: null,
+    visibility: 'private',
+    ...overrides,
+  };
+}
+
+const GAME_COMBO_NAME = 'Cerca gioco da aggiungere';
+const PRICE_ARIA_NAME = 'Prezzo massimo che sei disposto a spendere';
+const NOTES_PLACEHOLDER = 'es. acquisto entro Q3, voglio aspettare la nuova edizione, ecc.';
+
+describe('AddToWishlistDialog', () => {
+  beforeEach(() => {
+    mockAddMutate.mockReset();
+    mockUpdateMutate.mockReset();
+    mockToastSuccess.mockReset();
+  });
+
+  describe('mode=add', () => {
+    it('calls useAddToWishlist with {gameId, priority, targetPrice, notes} on submit', async () => {
+      const user = userEvent.setup();
+      renderWithIntl(<AddToWishlistDialog mode="add" open onOpenChange={() => {}} />);
+
+      // Pick game via combobox
+      const combo = screen.getByRole('combobox', { name: GAME_COMBO_NAME });
+      await user.type(combo, 'Catan');
+      await user.click(screen.getByRole('option', { name: 'Catan' }));
+
+      // Switch priority to "Alta" (default is "Media")
+      await user.click(screen.getByRole('radio', { name: 'Alta' }));
+
+      // Target price
+      const priceInput = screen.getByRole('spinbutton', { name: PRICE_ARIA_NAME });
+      await user.type(priceInput, '29.99');
+
+      // Notes
+      const notesInput = screen.getByPlaceholderText(NOTES_PLACEHOLDER);
+      await user.type(notesInput, 'Da comprare presto');
+
+      submitForm();
+
+      expect(mockAddMutate).toHaveBeenCalledTimes(1);
+      const [payload] = mockAddMutate.mock.calls[0];
+      expect(payload).toEqual({
+        gameId: 'game-catan',
+        priority: 'high',
+        targetPrice: 29.99,
+        notes: 'Da comprare presto',
+      });
+    });
+
+    it('disables submit until a game is selected', () => {
+      renderWithIntl(<AddToWishlistDialog mode="add" open onOpenChange={() => {}} />);
+      expect(screen.getByRole('button', { name: 'Aggiungi' })).toBeDisabled();
+    });
+
+    it('enables submit once a game is pre-filled (priority defaults to "medium")', () => {
+      renderWithIntl(
+        <AddToWishlistDialog mode="add" open onOpenChange={() => {}} prefillGameId="game-catan" />
+      );
+      expect(screen.getByRole('button', { name: 'Aggiungi' })).toBeEnabled();
+      expect(screen.getByRole('radio', { name: 'Media' })).toHaveAttribute('aria-checked', 'true');
+    });
+
+    it('updates the notes counter as the user types', async () => {
+      const user = userEvent.setup();
+      renderWithIntl(
+        <AddToWishlistDialog mode="add" open onOpenChange={() => {}} prefillGameId="game-catan" />
+      );
+
+      const notesInput = screen.getByPlaceholderText(NOTES_PLACEHOLDER);
+      await user.type(notesInput, 'Hello');
+
+      expect(screen.getByText('5 / 200')).toBeInTheDocument();
+    });
+  });
+
+  describe('mode=edit', () => {
+    it('prefills the locked game chip, priority, price and notes from item', () => {
+      const item = buildItem();
+      renderWithIntl(<AddToWishlistDialog mode="edit" item={item} open onOpenChange={() => {}} />);
+
+      expect(screen.getByText('Brass: Birmingham')).toBeInTheDocument();
+      // Game is locked in edit mode — no remove button on the chip
+      expect(
+        screen.queryByRole('button', { name: 'Rimuovi gioco selezionato' })
+      ).not.toBeInTheDocument();
+
+      expect(screen.getByRole('radio', { name: 'Alta' })).toHaveAttribute('aria-checked', 'true');
+
+      const priceInput = screen.getByRole('spinbutton', { name: PRICE_ARIA_NAME });
+      expect(priceInput).toHaveValue(42);
+
+      const notesInput = screen.getByPlaceholderText(NOTES_PLACEHOLDER);
+      expect(notesInput).toHaveValue('Acquisto entro Q3');
+    });
+
+    it('sends clearTargetPrice: true when a previously-set target price is cleared', async () => {
+      const user = userEvent.setup();
+      const item = buildItem();
+      renderWithIntl(<AddToWishlistDialog mode="edit" item={item} open onOpenChange={() => {}} />);
+
+      const priceInput = screen.getByRole('spinbutton', { name: PRICE_ARIA_NAME });
+      await user.clear(priceInput);
+
+      submitForm();
+
+      expect(mockUpdateMutate).toHaveBeenCalledTimes(1);
+      const [payload] = mockUpdateMutate.mock.calls[0];
+      expect(payload).toEqual({
+        id: item.id,
+        data: {
+          priority: 'high',
+          clearTargetPrice: true,
+          notes: 'Acquisto entro Q3',
+        },
+      });
+    });
+
+    it('sends clearNotes: true when previously-set notes are cleared', async () => {
+      const user = userEvent.setup();
+      const item = buildItem();
+      renderWithIntl(<AddToWishlistDialog mode="edit" item={item} open onOpenChange={() => {}} />);
+
+      const notesInput = screen.getByPlaceholderText(NOTES_PLACEHOLDER);
+      await user.clear(notesInput);
+
+      submitForm();
+
+      expect(mockUpdateMutate).toHaveBeenCalledTimes(1);
+      const [payload] = mockUpdateMutate.mock.calls[0];
+      expect(payload).toEqual({
+        id: item.id,
+        data: {
+          priority: 'high',
+          targetPrice: 42,
+          clearNotes: true,
+        },
+      });
+    });
+  });
+});

--- a/apps/web/src/components/wishlist/__tests__/AddToWishlistDialog.test.tsx
+++ b/apps/web/src/components/wishlist/__tests__/AddToWishlistDialog.test.tsx
@@ -152,6 +152,70 @@ describe('AddToWishlistDialog', () => {
 
       expect(screen.getByText('5 / 200')).toBeInTheDocument();
     });
+
+    it('selects a game via ArrowDown + Enter (keyboard-only, no mouse)', async () => {
+      const user = userEvent.setup();
+      renderWithIntl(<AddToWishlistDialog mode="add" open onOpenChange={() => {}} />);
+
+      const combo = screen.getByRole('combobox', { name: GAME_COMBO_NAME });
+      await user.type(combo, 'Catan');
+
+      // Highlight the only match and commit it — no click involved.
+      await user.keyboard('{ArrowDown}');
+      const option = screen.getByRole('option', { name: 'Catan' });
+      expect(option).toHaveAttribute('aria-selected', 'true');
+      expect(combo).toHaveAttribute('aria-activedescendant', option.id);
+
+      await user.keyboard('{Enter}');
+
+      // Combobox is replaced by the locked/removable selected-game chip.
+      expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+      expect(screen.getByText('Catan')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Aggiungi' })).toBeEnabled();
+    });
+
+    it('closes the listbox on Escape without selecting a game', async () => {
+      const user = userEvent.setup();
+      renderWithIntl(<AddToWishlistDialog mode="add" open onOpenChange={() => {}} />);
+
+      const combo = screen.getByRole('combobox', { name: GAME_COMBO_NAME });
+      await user.type(combo, 'Catan');
+      await user.keyboard('{ArrowDown}');
+      expect(screen.getByRole('listbox')).toBeInTheDocument();
+
+      await user.keyboard('{Escape}');
+
+      expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Aggiungi' })).toBeDisabled();
+    });
+
+    it('shows a success toast and closes the dialog when the add mutation succeeds', () => {
+      const onOpenChange = vi.fn();
+      const onSuccess = vi.fn();
+      mockAddMutate.mockImplementation(
+        (_payload: unknown, options?: { onSuccess?: () => void }) => {
+          options?.onSuccess?.();
+        }
+      );
+
+      renderWithIntl(
+        <AddToWishlistDialog
+          mode="add"
+          open
+          onOpenChange={onOpenChange}
+          prefillGameId="game-catan"
+          onSuccess={onSuccess}
+        />
+      );
+
+      submitForm();
+
+      expect(mockAddMutate).toHaveBeenCalledTimes(1);
+      expect(mockToastSuccess).toHaveBeenCalledTimes(1);
+      expect(mockToastSuccess).toHaveBeenCalledWith('Aggiunto');
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+      expect(onSuccess).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('mode=edit', () => {
@@ -216,6 +280,35 @@ describe('AddToWishlistDialog', () => {
           clearNotes: true,
         },
       });
+    });
+
+    it('shows a success toast and closes the dialog when the update mutation succeeds', () => {
+      const onOpenChange = vi.fn();
+      const onSuccess = vi.fn();
+      const item = buildItem();
+      mockUpdateMutate.mockImplementation(
+        (_payload: unknown, options?: { onSuccess?: () => void }) => {
+          options?.onSuccess?.();
+        }
+      );
+
+      renderWithIntl(
+        <AddToWishlistDialog
+          mode="edit"
+          item={item}
+          open
+          onOpenChange={onOpenChange}
+          onSuccess={onSuccess}
+        />
+      );
+
+      submitForm();
+
+      expect(mockUpdateMutate).toHaveBeenCalledTimes(1);
+      expect(mockToastSuccess).toHaveBeenCalledTimes(1);
+      expect(mockToastSuccess).toHaveBeenCalledWith('Aggiunto');
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+      expect(onSuccess).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/apps/web/src/components/wishlist/__tests__/MeepleWishlistCard.test.tsx
+++ b/apps/web/src/components/wishlist/__tests__/MeepleWishlistCard.test.tsx
@@ -112,6 +112,19 @@ describe('MeepleWishlistCard', () => {
     expect(onFilterPriority).toHaveBeenCalledWith('high');
   });
 
+  it('renders the priority badge as a non-interactive element when onFilterPriority is omitted', () => {
+    renderWithIntl(
+      <MeepleWishlistCard item={buildItem({ priority: 'high' })} onRemove={vi.fn()} />
+    );
+
+    expect(
+      screen.queryByRole('button', { name: new RegExp(PRIORITY_I18N.high) })
+    ).not.toBeInTheDocument();
+    const badge = screen.getByTestId('wishlist-priority-badge-static');
+    expect(badge.tagName).toBe('SPAN');
+    expect(badge).toHaveTextContent(PRIORITY_I18N.high);
+  });
+
   it('calls onEdit with the item when the edit action is clicked', async () => {
     const user = userEvent.setup();
     const onEdit = vi.fn();

--- a/apps/web/src/components/wishlist/__tests__/MeepleWishlistCard.test.tsx
+++ b/apps/web/src/components/wishlist/__tests__/MeepleWishlistCard.test.tsx
@@ -2,13 +2,33 @@
  * @vitest-environment jsdom
  */
 
-import { render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { IntlProvider } from 'react-intl';
+import { describe, expect, it, vi } from 'vitest';
+
+import { flattenMessages } from '@/locales';
+import itMessages from '@/locales/it.json';
 
 import { MeepleWishlistCard } from '../MeepleWishlistCard';
 
-describe('MeepleWishlistCard', () => {
-  const mockItem = {
+import type { WishlistItemDto } from '@/lib/api/schemas/wishlist.schemas';
+import type { ReactElement } from 'react';
+
+const MESSAGES = flattenMessages(itMessages as unknown as Record<string, unknown>);
+const CARD_I18N = itMessages.pages.library.wishlist.card;
+const PRIORITY_I18N = itMessages.pages.library.wishlist.priority;
+
+function renderWithIntl(ui: ReactElement) {
+  return render(
+    <IntlProvider locale="it" messages={MESSAGES}>
+      {ui}
+    </IntlProvider>
+  );
+}
+
+function buildItem(overrides: Partial<WishlistItemDto> = {}): WishlistItemDto {
+  return {
     id: '00000000-0000-0000-0000-000000000001',
     userId: '00000000-0000-0000-0000-000000000002',
     gameId: '00000000-0000-0000-0000-000000000003',
@@ -19,22 +39,190 @@ describe('MeepleWishlistCard', () => {
     addedAt: '2026-01-01',
     updatedAt: null,
     visibility: 'private',
+    ...overrides,
   };
+}
 
+describe('MeepleWishlistCard', () => {
   it('renders with correct entity type', () => {
-    render(<MeepleWishlistCard item={mockItem} />);
+    renderWithIntl(
+      <MeepleWishlistCard
+        item={buildItem()}
+        onRemove={vi.fn()}
+        onEdit={vi.fn()}
+        onFilterPriority={vi.fn()}
+      />
+    );
     const card = screen.getByTestId('wishlist-card');
     expect(card).toHaveAttribute('data-entity', 'game');
   });
 
   it('displays game name as title', () => {
-    render(<MeepleWishlistCard item={mockItem} />);
+    renderWithIntl(
+      <MeepleWishlistCard
+        item={buildItem()}
+        onRemove={vi.fn()}
+        onEdit={vi.fn()}
+        onFilterPriority={vi.fn()}
+      />
+    );
     expect(screen.getByText('Catan')).toBeInTheDocument();
   });
 
-  it('falls back to truncated ID when no game name', () => {
-    const itemNoName = { ...mockItem, gameName: undefined };
-    render(<MeepleWishlistCard item={itemNoName} />);
-    expect(screen.getByText('Game 00000000...')).toBeInTheDocument();
+  it('falls back to the localized "unknown game" label when no game name is available', () => {
+    const itemNoName = buildItem({ gameName: undefined });
+    renderWithIntl(
+      <MeepleWishlistCard
+        item={itemNoName}
+        onRemove={vi.fn()}
+        onEdit={vi.fn()}
+        onFilterPriority={vi.fn()}
+      />
+    );
+    expect(screen.getByText(CARD_I18N.unknownGame)).toBeInTheDocument();
+  });
+
+  it('shows the localized priority badge label', () => {
+    renderWithIntl(
+      <MeepleWishlistCard
+        item={buildItem({ priority: 'high' })}
+        onRemove={vi.fn()}
+        onEdit={vi.fn()}
+        onFilterPriority={vi.fn()}
+      />
+    );
+    expect(
+      screen.getByRole('button', { name: new RegExp(PRIORITY_I18N.high) })
+    ).toBeInTheDocument();
+  });
+
+  it('calls onFilterPriority with the normalized priority when the badge is clicked', async () => {
+    const user = userEvent.setup();
+    const onFilterPriority = vi.fn();
+    renderWithIntl(
+      <MeepleWishlistCard
+        item={buildItem({ priority: 'high' })}
+        onRemove={vi.fn()}
+        onEdit={vi.fn()}
+        onFilterPriority={onFilterPriority}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: new RegExp(PRIORITY_I18N.high) }));
+    expect(onFilterPriority).toHaveBeenCalledWith('high');
+  });
+
+  it('calls onEdit with the item when the edit action is clicked', async () => {
+    const user = userEvent.setup();
+    const onEdit = vi.fn();
+    const item = buildItem();
+    renderWithIntl(
+      <MeepleWishlistCard
+        item={item}
+        onRemove={vi.fn()}
+        onEdit={onEdit}
+        onFilterPriority={vi.fn()}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: new RegExp(CARD_I18N.edit) }));
+    expect(onEdit).toHaveBeenCalledWith(item);
+  });
+
+  it('calls onRemove with the item id when the remove action is clicked', async () => {
+    const user = userEvent.setup();
+    const onRemove = vi.fn();
+    const item = buildItem();
+    renderWithIntl(
+      <MeepleWishlistCard
+        item={item}
+        onRemove={onRemove}
+        onEdit={vi.fn()}
+        onFilterPriority={vi.fn()}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: new RegExp(CARD_I18N.remove) }));
+    expect(onRemove).toHaveBeenCalledWith(item.id);
+  });
+
+  it('renders a left-border accent for a high-priority item', () => {
+    renderWithIntl(
+      <MeepleWishlistCard
+        item={buildItem({ priority: 'high' })}
+        onRemove={vi.fn()}
+        onEdit={vi.fn()}
+        onFilterPriority={vi.fn()}
+      />
+    );
+    const shell = screen.getByTestId('wishlist-card-shell');
+    expect(shell.className).toMatch(/border-l-destructive/);
+  });
+
+  it('does not render the left-border accent for a non-high-priority item', () => {
+    renderWithIntl(
+      <MeepleWishlistCard
+        item={buildItem({ priority: 'medium' })}
+        onRemove={vi.fn()}
+        onEdit={vi.fn()}
+        onFilterPriority={vi.fn()}
+      />
+    );
+    const shell = screen.getByTestId('wishlist-card-shell');
+    expect(shell.className).not.toMatch(/border-l-destructive/);
+  });
+
+  it('shows the target price with the € currency symbol when present', () => {
+    renderWithIntl(
+      <MeepleWishlistCard
+        item={buildItem({ targetPrice: 65 })}
+        onRemove={vi.fn()}
+        onEdit={vi.fn()}
+        onFilterPriority={vi.fn()}
+      />
+    );
+    expect(screen.getByText(/€/)).toBeInTheDocument();
+  });
+
+  it('shows the item notes when present', () => {
+    renderWithIntl(
+      <MeepleWishlistCard
+        item={buildItem({ notes: 'Great with kids' })}
+        onRemove={vi.fn()}
+        onEdit={vi.fn()}
+        onFilterPriority={vi.fn()}
+      />
+    );
+    expect(screen.getByText('Great with kids')).toBeInTheDocument();
+  });
+
+  it('shows the localized "no notes" placeholder when notes is absent', () => {
+    renderWithIntl(
+      <MeepleWishlistCard
+        item={buildItem({ notes: null })}
+        onRemove={vi.fn()}
+        onEdit={vi.fn()}
+        onFilterPriority={vi.fn()}
+      />
+    );
+    expect(screen.getByText(CARD_I18N.noNote)).toBeInTheDocument();
+  });
+
+  it('exposes accessible labels for the edit and remove actions including the game name', () => {
+    renderWithIntl(
+      <MeepleWishlistCard
+        item={buildItem({ gameName: 'Catan' })}
+        onRemove={vi.fn()}
+        onEdit={vi.fn()}
+        onFilterPriority={vi.fn()}
+      />
+    );
+    const shell = screen.getByTestId('wishlist-card-shell');
+    expect(
+      within(shell).getByRole('button', { name: CARD_I18N.editAria.replace('{name}', 'Catan') })
+    ).toBeInTheDocument();
+    expect(
+      within(shell).getByRole('button', { name: CARD_I18N.removeAria.replace('{name}', 'Catan') })
+    ).toBeInTheDocument();
   });
 });

--- a/apps/web/src/lib/utils/__tests__/csv.test.ts
+++ b/apps/web/src/lib/utils/__tests__/csv.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { escapeCSVField, rowsToCsv } from '../csv';
+
+describe('escapeCSVField', () => {
+  it('quotes fields containing comma, quote or newline', () => {
+    expect(escapeCSVField('a,b')).toBe('"a,b"');
+    expect(escapeCSVField('he said "hi"')).toBe('"he said ""hi"""');
+    expect(escapeCSVField('line1\nline2')).toBe('"line1\nline2"');
+  });
+  it('passes through plain fields and stringifies numbers/null', () => {
+    expect(escapeCSVField('plain')).toBe('plain');
+    expect(escapeCSVField(42)).toBe('42');
+    expect(escapeCSVField(null)).toBe('');
+  });
+});
+
+describe('rowsToCsv', () => {
+  it('joins headers + rows with CRLF and escapes each cell', () => {
+    const csv = rowsToCsv(
+      ['A', 'B'],
+      [
+        ['x', 'y,z'],
+        [1, null],
+      ]
+    );
+    expect(csv).toBe('A,B\r\nx,"y,z"\r\n1,');
+  });
+});

--- a/apps/web/src/lib/utils/csv.ts
+++ b/apps/web/src/lib/utils/csv.ts
@@ -1,0 +1,65 @@
+/**
+ * CSV Export Utilities
+ *
+ * Shared, framework-free helpers for building CSV content and triggering a
+ * browser download. Promoted from the private helpers in `lib/utils/export.ts`
+ * (Issue #2139) so other features (e.g. /toolkit/history "Esporta CSV") can
+ * reuse the same escaping and download mechanism without duplicating it.
+ *
+ * Issues #3006 / #3007
+ */
+
+/**
+ * Escape a single CSV field.
+ *
+ * Wraps the field in double quotes if it contains a comma, double quote, or
+ * newline, doubling any embedded double quotes per RFC 4180. `null`/`undefined`
+ * become an empty string; numbers are stringified.
+ */
+export function escapeCSVField(field: string | number | null | undefined): string {
+  if (field === null || field === undefined) {
+    return '';
+  }
+
+  const value = String(field);
+
+  if (value.includes(',') || value.includes('"') || value.includes('\n')) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+
+  return value;
+}
+
+/**
+ * Build a CSV string from headers and rows.
+ *
+ * Each cell is escaped via {@link escapeCSVField}; cells are joined with a
+ * comma and rows are joined with CRLF (`\r\n`), per RFC 4180.
+ */
+export function rowsToCsv(headers: string[], rows: (string | number | null)[][]): string {
+  const lines = [headers, ...rows].map(row => row.map(escapeCSVField).join(','));
+  return lines.join('\r\n');
+}
+
+/**
+ * Trigger a browser download for a file.
+ *
+ * @param content - File content
+ * @param filename - Filename for download
+ * @param mimeType - MIME type of the file (default: CSV)
+ */
+export function downloadFile(
+  content: string,
+  filename: string,
+  mimeType: string = 'text/csv;charset=utf-8;'
+): void {
+  const blob = new Blob([content], { type: mimeType });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -2534,7 +2534,8 @@
         "stats": "Stats",
         "history": "History",
         "templates": "Templates",
-        "play": "Play"
+        "play": "Play",
+        "ariaLabel": "Toolkit sections"
       },
       "filters": {
         "searchPlaceholder": "Search by game or winner…",

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -2171,6 +2171,111 @@
         "nextPage": "Next page",
         "lastPage": "Last page",
         "pageNumber": "Page {n}"
+      },
+      "wishlist": {
+        "hero": {
+          "breadcrumbLibrary": "Library",
+          "breadcrumbWishlist": "Wishlist",
+          "title": "Wishlist · Wanted games",
+          "subtitle": "Track the games you want to buy or try.",
+          "tabsAria": "Library sections",
+          "tabLibrary": "Library",
+          "tabWishlist": "Wishlist",
+          "addCta": "Add to wishlist",
+          "addCtaShort": "Add"
+        },
+        "stats": {
+          "games": "{count} games",
+          "highPriority": "{count} high priority",
+          "estimatedSpend": "estimated spend {amount}"
+        },
+        "filters": {
+          "searchPlaceholder": "Search by game name or notes…",
+          "searchAriaLabel": "Search by game name or notes",
+          "searching": "Searching…",
+          "clearSearch": "Clear search",
+          "priorityGroupAria": "Filter by priority (multi-select)",
+          "all": "All",
+          "sort": "Sort",
+          "sortBy": "Sort by",
+          "sortAria": "Sort wishlist",
+          "sortOptions": {
+            "priority": "By priority",
+            "recent": "Most recent",
+            "oldest": "Oldest",
+            "alpha": "Alphabetical",
+            "price": "Target price"
+          }
+        },
+        "summary": {
+          "activeFilters": "{n, plural, one {# active filter} other {# active filters}}",
+          "results": "{n, plural, one {# game} other {# games}} of {total}",
+          "clearAll": "Clear filters"
+        },
+        "priority": {
+          "high": "High",
+          "medium": "Medium",
+          "low": "Low",
+          "filterAria": "{label} priority — filter by this priority"
+        },
+        "card": {
+          "target": "Target",
+          "noNote": "No notes",
+          "addedAt": "Added {when}",
+          "addedTitle": "Added on {date}",
+          "edit": "Edit",
+          "editAria": "Edit wishlist item {name}",
+          "remove": "Remove",
+          "removeAria": "Remove {name} from wishlist",
+          "openGameAria": "Open game detail {name}",
+          "unknownGame": "Unnamed game",
+          "gridAria": "Wishlist games"
+        },
+        "dialog": {
+          "addTitle": "Add to wishlist",
+          "editTitle": "Edit wishlist",
+          "addSub": "Save a game you want to buy or try",
+          "editSub": "{name} · {priority} priority",
+          "close": "Close",
+          "error": "Error adding to wishlist.",
+          "retry": "Retry",
+          "gameLabel": "Game",
+          "gameComboPlaceholder": "Search by name or paste a game ID…",
+          "gameComboAria": "Search for a game to add",
+          "gameRemoveAria": "Remove selected game",
+          "priorityLabel": "Priority",
+          "priceLabel": "Target price (€)",
+          "pricePlaceholder": "65",
+          "priceHint": "Maximum price you're willing to spend — optional.",
+          "priceAria": "Maximum price you're willing to spend",
+          "notesLabel": "Notes",
+          "notesPlaceholder": "e.g. buy by Q3, waiting for the new edition, etc.",
+          "notesCounter": "{len} / 200",
+          "cancel": "Cancel",
+          "submitting": "Adding…",
+          "success": "Added",
+          "add": "Add",
+          "save": "Save"
+        },
+        "empty": {
+          "noItems": {
+            "title": "No games in your wishlist",
+            "body": "Add games you're interested in so you don't lose track of them — with priority, target price and notes.",
+            "cta": "Add your first"
+          },
+          "filtered": {
+            "title": "No games match the filters",
+            "body": "Try changing the priority or adjusting the name or notes search.",
+            "cta": "Clear filters"
+          }
+        },
+        "loading": {
+          "ariaLabel": "Loading wishlist"
+        },
+        "error": {
+          "message": "Unable to load the wishlist — please try again.",
+          "retry": "Retry"
+        }
       }
     },
     "onboarding": {

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -2520,6 +2520,142 @@
         "shareAction": "Share"
       }
     },
+    "toolkitHistory": {
+      "hero": {
+        "breadcrumbToolkit": "Toolkit",
+        "breadcrumbHistory": "History",
+        "title": "Session history",
+        "subtitle": "All finalized games, filterable by game, date and winner.",
+        "quickStat": "{sessions} sessions · {games} games · {winners} winners",
+        "exportCsv": "Export CSV",
+        "exportCsvShort": "CSV"
+      },
+      "tabs": {
+        "stats": "Stats",
+        "history": "History",
+        "templates": "Templates",
+        "play": "Play"
+      },
+      "filters": {
+        "searchPlaceholder": "Search by game or winner…",
+        "searchAriaLabel": "Search by game or winner",
+        "searching": "Searching…",
+        "clearSearch": "Clear search",
+        "games": "Games",
+        "filterByGame": "Filter by game",
+        "all": "All",
+        "showMore": "Show {n} more",
+        "showLess": "Show less",
+        "date": "Date",
+        "dateRange": "Date range",
+        "dateOptions": {
+          "all": "All dates",
+          "last30": "Last 30 days",
+          "last90": "Last 90 days",
+          "lastYear": "Last year",
+          "custom": "Custom dates"
+        },
+        "dateFrom": "From",
+        "dateTo": "To",
+        "dateFromLabel": "Start date",
+        "dateToLabel": "End date",
+        "applyRange": "Apply range",
+        "winners": "Winners",
+        "filterByWinner": "Filter by winner",
+        "winnerWon": "{name} (won)",
+        "noWinner": "No winner",
+        "sort": "Sort",
+        "sortBy": "Sort by",
+        "sortOptions": {
+          "recent": "Most recent",
+          "oldest": "Oldest",
+          "longest": "Longest",
+          "score": "Highest score"
+        },
+        "view": "View",
+        "viewTable": "Table view",
+        "viewCards": "Cards view"
+      },
+      "summary": {
+        "activeFilters": "{n, plural, one {# active filter} other {# active filters}}",
+        "results": "{n, plural, one {# session} other {# sessions}} of {total}",
+        "clearAll": "Clear all"
+      },
+      "table": {
+        "date": "Date",
+        "game": "Game",
+        "duration": "Duration",
+        "players": "Players",
+        "winner": "Winner",
+        "score": "Score",
+        "notes": "Notes",
+        "actions": "Actions",
+        "coop": "Cooperative",
+        "coopShort": "co-op",
+        "noWinner": "No winner",
+        "noNote": "No notes",
+        "hasNote": "Has notes",
+        "viewDetails": "View details",
+        "gameStats": "Game stats",
+        "unknownGame": "Unknown game",
+        "openInLibrary": "Open {game} in library",
+        "winnerAria": "Winner: {name}",
+        "playersAria": "{count} players: {names}"
+      },
+      "pagination": {
+        "prev": "Prev.",
+        "next": "Next",
+        "prevAria": "Previous page",
+        "nextAria": "Next page",
+        "mobileMeta": "Page {page} of {pages} · {total} sess.",
+        "rangeMeta": "{from}–{to} of {total} sessions",
+        "empty": "0 sessions",
+        "perPage": "Per page",
+        "perPageAria": "Sessions per page",
+        "listAria": "Session history pages"
+      },
+      "empty": {
+        "title": "No sessions yet",
+        "body": "Finalized games will appear here: filter by game, date or winner and open each one's details.",
+        "cta": "Create first session"
+      },
+      "filteredEmpty": {
+        "title": "No sessions match the filters",
+        "body": "Try adjusting the search or removing the active game, date or winner filters.",
+        "cta": "Clear filters"
+      },
+      "loading": {
+        "ariaLabel": "Loading session history"
+      },
+      "error": {
+        "message": "Unable to load history — try again.",
+        "retry": "Retry"
+      },
+      "modal": {
+        "title": "{game} · {date}",
+        "sub": "Duration {duration} · {count} players · {time}",
+        "close": "Close",
+        "leaderboard": "Final leaderboard",
+        "you": " · you",
+        "timeline": "Event timeline",
+        "notes": "Notes",
+        "notesEmpty": "No notes for this session.",
+        "stats": "Game statistics",
+        "turns": "Total turns",
+        "winnerScore": "Winner score",
+        "variance": "Score variance",
+        "highlights": "Highlights",
+        "noData": "—",
+        "gameStats": "Game stats",
+        "playAgain": "Play again",
+        "editNotes": "Edit notes",
+        "delete": "Delete"
+      },
+      "cards": {
+        "coop": "Co-op"
+      },
+      "batchNote": "Showing the first {n} results."
+    },
     "sessions": {
       "metadata": {
         "title": "My sessions — MeepleAI",

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -2292,7 +2292,7 @@
           "gameComboAria": "Cerca gioco da aggiungere",
           "gameRemoveAria": "Rimuovi gioco selezionato",
           "priorityLabel": "Priorità",
-          "priceLabel": "Target price (€)",
+          "priceLabel": "Prezzo target (€)",
           "pricePlaceholder": "65",
           "priceHint": "Prezzo massimo che sei disposto a spendere — opzionale.",
           "priceAria": "Prezzo massimo che sei disposto a spendere",

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -2219,6 +2219,111 @@
         "nextPage": "Pagina successiva",
         "lastPage": "Ultima pagina",
         "pageNumber": "Pagina {n}"
+      },
+      "wishlist": {
+        "hero": {
+          "breadcrumbLibrary": "Libreria",
+          "breadcrumbWishlist": "Wishlist",
+          "title": "Wishlist · Giochi desiderati",
+          "subtitle": "Tieni traccia dei giochi che vuoi comprare o provare.",
+          "tabsAria": "Sezioni libreria",
+          "tabLibrary": "Libreria",
+          "tabWishlist": "Wishlist",
+          "addCta": "Aggiungi alla wishlist",
+          "addCtaShort": "Aggiungi"
+        },
+        "stats": {
+          "games": "{count} giochi",
+          "highPriority": "{count} alta priorità",
+          "estimatedSpend": "spesa stimata {amount}"
+        },
+        "filters": {
+          "searchPlaceholder": "Cerca per nome gioco o note…",
+          "searchAriaLabel": "Cerca per nome gioco o note",
+          "searching": "Cercando…",
+          "clearSearch": "Cancella ricerca",
+          "priorityGroupAria": "Filtra per priorità (selezione multipla)",
+          "all": "Tutti",
+          "sort": "Ordina",
+          "sortBy": "Ordina per",
+          "sortAria": "Ordina wishlist",
+          "sortOptions": {
+            "priority": "Per priorità",
+            "recent": "Più recenti",
+            "oldest": "Più vecchi",
+            "alpha": "Alfabetico",
+            "price": "Prezzo target"
+          }
+        },
+        "summary": {
+          "activeFilters": "{n, plural, one {# filtro attivo} other {# filtri attivi}}",
+          "results": "{n, plural, one {# gioco} other {# giochi}} su {total}",
+          "clearAll": "Cancella filtri"
+        },
+        "priority": {
+          "high": "Alta",
+          "medium": "Media",
+          "low": "Bassa",
+          "filterAria": "Priorità {label} — filtra per questa priorità"
+        },
+        "card": {
+          "target": "Target",
+          "noNote": "Nessuna nota",
+          "addedAt": "Aggiunto {when}",
+          "addedTitle": "Aggiunto il {date}",
+          "edit": "Modifica",
+          "editAria": "Modifica wishlist item {name}",
+          "remove": "Rimuovi",
+          "removeAria": "Rimuovi {name} dalla wishlist",
+          "openGameAria": "Apri dettaglio gioco {name}",
+          "unknownGame": "Gioco senza nome",
+          "gridAria": "Wishlist giochi"
+        },
+        "dialog": {
+          "addTitle": "Aggiungi alla wishlist",
+          "editTitle": "Modifica wishlist",
+          "addSub": "Salva un gioco che vuoi comprare o provare",
+          "editSub": "{name} · priorità {priority}",
+          "close": "Chiudi",
+          "error": "Errore aggiungendo alla wishlist.",
+          "retry": "Riprova",
+          "gameLabel": "Gioco",
+          "gameComboPlaceholder": "Cerca per nome o incolla un game ID…",
+          "gameComboAria": "Cerca gioco da aggiungere",
+          "gameRemoveAria": "Rimuovi gioco selezionato",
+          "priorityLabel": "Priorità",
+          "priceLabel": "Target price (€)",
+          "pricePlaceholder": "65",
+          "priceHint": "Prezzo massimo che sei disposto a spendere — opzionale.",
+          "priceAria": "Prezzo massimo che sei disposto a spendere",
+          "notesLabel": "Note",
+          "notesPlaceholder": "es. acquisto entro Q3, voglio aspettare la nuova edizione, ecc.",
+          "notesCounter": "{len} / 200",
+          "cancel": "Annulla",
+          "submitting": "Aggiungo…",
+          "success": "Aggiunto",
+          "add": "Aggiungi",
+          "save": "Salva"
+        },
+        "empty": {
+          "noItems": {
+            "title": "Nessun gioco nella wishlist",
+            "body": "Aggiungi giochi che ti interessano per non perderli di vista — con priorità, prezzo target e note.",
+            "cta": "Aggiungi il primo"
+          },
+          "filtered": {
+            "title": "Nessun gioco corrisponde ai filtri",
+            "body": "Prova a cambiare priorità o a modificare la ricerca per nome o note.",
+            "cta": "Cancella filtri"
+          }
+        },
+        "loading": {
+          "ariaLabel": "Caricamento wishlist"
+        },
+        "error": {
+          "message": "Impossibile caricare la wishlist — riprova.",
+          "retry": "Riprova"
+        }
       }
     },
     "onboarding": {

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -2582,7 +2582,8 @@
         "stats": "Stats",
         "history": "History",
         "templates": "Templates",
-        "play": "Play"
+        "play": "Play",
+        "ariaLabel": "Sezioni Toolkit"
       },
       "filters": {
         "searchPlaceholder": "Cerca per gioco o vincitore…",

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -2568,6 +2568,142 @@
         "shareAction": "Condividi"
       }
     },
+    "toolkitHistory": {
+      "hero": {
+        "breadcrumbToolkit": "Toolkit",
+        "breadcrumbHistory": "History",
+        "title": "Storico sessioni",
+        "subtitle": "Tutte le partite finalizzate, filtrabili per gioco, data e vincitore.",
+        "quickStat": "{sessions} sessioni · {games} giochi · {winners} vincitori",
+        "exportCsv": "Esporta CSV",
+        "exportCsvShort": "CSV"
+      },
+      "tabs": {
+        "stats": "Stats",
+        "history": "History",
+        "templates": "Templates",
+        "play": "Play"
+      },
+      "filters": {
+        "searchPlaceholder": "Cerca per gioco o vincitore…",
+        "searchAriaLabel": "Cerca per gioco o vincitore",
+        "searching": "Cercando…",
+        "clearSearch": "Cancella ricerca",
+        "games": "Giochi",
+        "filterByGame": "Filtra per gioco",
+        "all": "Tutti",
+        "showMore": "Mostra altri {n}",
+        "showLess": "Mostra meno",
+        "date": "Data",
+        "dateRange": "Intervallo date",
+        "dateOptions": {
+          "all": "Tutte le date",
+          "last30": "Ultimi 30 giorni",
+          "last90": "Ultimi 90 giorni",
+          "lastYear": "Ultimo anno",
+          "custom": "Date custom"
+        },
+        "dateFrom": "Da",
+        "dateTo": "A",
+        "dateFromLabel": "Data inizio",
+        "dateToLabel": "Data fine",
+        "applyRange": "Applica intervallo",
+        "winners": "Vincitori",
+        "filterByWinner": "Filtra per vincitore",
+        "winnerWon": "{name} (vinto)",
+        "noWinner": "Senza vincitore",
+        "sort": "Ordina",
+        "sortBy": "Ordina per",
+        "sortOptions": {
+          "recent": "Più recente",
+          "oldest": "Più antica",
+          "longest": "Più lunga",
+          "score": "Score più alto"
+        },
+        "view": "Vista",
+        "viewTable": "Vista tabella",
+        "viewCards": "Vista cards"
+      },
+      "summary": {
+        "activeFilters": "{n, plural, one {# filtro attivo} other {# filtri attivi}}",
+        "results": "{n, plural, one {# sessione} other {# sessioni}} su {total}",
+        "clearAll": "Cancella tutto"
+      },
+      "table": {
+        "date": "Data",
+        "game": "Gioco",
+        "duration": "Durata",
+        "players": "Giocatori",
+        "winner": "Vincitore",
+        "score": "Score",
+        "notes": "Note",
+        "actions": "Azioni",
+        "coop": "Cooperativa",
+        "coopShort": "co-op",
+        "noWinner": "Senza vincitore",
+        "noNote": "Nessuna nota",
+        "hasNote": "Nota presente",
+        "viewDetails": "Vedi dettagli",
+        "gameStats": "Stats del gioco",
+        "unknownGame": "Gioco sconosciuto",
+        "openInLibrary": "Apri {game} in libreria",
+        "winnerAria": "Vincitore: {name}",
+        "playersAria": "{count} giocatori: {names}"
+      },
+      "pagination": {
+        "prev": "Prec.",
+        "next": "Succ.",
+        "prevAria": "Pagina precedente",
+        "nextAria": "Pagina successiva",
+        "mobileMeta": "Pag. {page} di {pages} · {total} sess.",
+        "rangeMeta": "{from}–{to} di {total} sessioni",
+        "empty": "0 sessioni",
+        "perPage": "Per pagina",
+        "perPageAria": "Sessioni per pagina",
+        "listAria": "Pagine storico sessioni"
+      },
+      "empty": {
+        "title": "Nessuna sessione ancora",
+        "body": "Le partite finalizzate appariranno qui: filtra per gioco, data o vincitore e apri il dettaglio di ognuna.",
+        "cta": "Crea prima sessione"
+      },
+      "filteredEmpty": {
+        "title": "Nessuna sessione corrisponde ai filtri",
+        "body": "Prova a modificare la ricerca o a rimuovere i filtri di gioco, data o vincitore attivi.",
+        "cta": "Rimuovi filtri"
+      },
+      "loading": {
+        "ariaLabel": "Caricamento storico sessioni"
+      },
+      "error": {
+        "message": "Impossibile caricare lo storico — riprova.",
+        "retry": "Riprova"
+      },
+      "modal": {
+        "title": "{game} · {date}",
+        "sub": "Durata {duration} · {count} giocatori · {time}",
+        "close": "Chiudi",
+        "leaderboard": "Classifica finale",
+        "you": " · tu",
+        "timeline": "Timeline eventi",
+        "notes": "Note",
+        "notesEmpty": "Nessuna nota per questa sessione.",
+        "stats": "Statistiche partita",
+        "turns": "Turni totali",
+        "winnerScore": "Score vincitore",
+        "variance": "Varianza score",
+        "highlights": "Highlights",
+        "noData": "—",
+        "gameStats": "Stats gioco",
+        "playAgain": "Gioca di nuovo",
+        "editNotes": "Modifica note",
+        "delete": "Elimina"
+      },
+      "cards": {
+        "coop": "Co-op"
+      },
+      "batchNote": "Mostrati i primi {n} risultati."
+    },
     "sessions": {
       "metadata": {
         "title": "Le mie partite — MeepleAI",

--- a/docs/superpowers/plans/2026-07-15-issue-3006-3007-history-wishlist-i18n-fidelity.md
+++ b/docs/superpowers/plans/2026-07-15-issue-3006-3007-history-wishlist-i18n-fidelity.md
@@ -1,0 +1,423 @@
+# Issue #3006 + #3007 — /toolkit/history & /library/wishlist: i18n + fidelity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Portare `/toolkit/history` (#3006) e `/library/wishlist` (#3007) a parità dei mockup `sp4-toolkit-history` e `sp4-library-wishlist`, con localizzazione completa (react-intl `it`/`en`), sui dati realmente esposti dal backend.
+
+**Architecture:** Due pagine indipendenti sullo stesso feature branch, un solo PR che chiude entrambe le issue. Ogni pagina è un client component con fetch React-Query esistente; filtri/sort/paginazione sono **client-side** (il backend non li supporta). I campi mockup senza dato reale (Score/Turni/Timeline/Highlights per history; MetaBox categoria/players/durata/BGG per wishlist) sono degradati graziosamente o omessi, documentati come gap-dati backend. Le stringhe entrano in nuovi namespace `pages.toolkitHistory.*` e `pages.library.wishlist.*`.
+
+**Tech Stack:** Next.js 16 (App Router), React 19, TypeScript, Tailwind 4 + shadcn/ui primitives, react-intl v7 (hook `@/hooks/useTranslation`), React Query (TanStack), Zod, Vitest + Testing Library.
+
+## Global Constraints
+
+- **i18n obbligatorio**: ZERO stringhe user-facing hardcoded. Ogni stringa via `t('pages.…')`. Aggiornare SEMPRE **entrambi** `apps/web/src/locales/it.json` e `apps/web/src/locales/en.json` con le stesse chiavi. Chiave mancante in un locale = fail.
+- **Token semantici only** (ESLint `local/no-hardcoded-color-utility` = error): `bg-card`, `text-foreground`, `text-muted-foreground`, `border-border`, entity utilities (`text-entity-game`, ecc.). Vietati `bg-white`/`text-gray-*`/`bg-slate-*`. `text-white` ammesso solo con bg colorato dichiarato nella stessa className.
+- **BGG asset ban (freeze #2123)**: nessuna richiesta browser a host BGG/geekdo. Non aggiungere immagini/cover da BGG. (Nessuna delle due pagine deve caricare cover esterne.)
+- **Card**: usare `MeepleCard` (`@/components/ui/data-display/meeple-card`), mai `GameCard`/`PlayerCard` deprecati.
+- **Data-driven only**: NON inventare campi non presenti nei DTO. Vedi tabelle "gap-dati" in ogni parte.
+- **Priority values**: lowercase `high|medium|low` end-to-end (DTO `priority: string`, mockup, i18n key suffix).
+- **Test culture**: `dotnet`/vitest culture-independent; formattazione numeri/date via `formatNumber`/`formatDate` di react-intl (locale-aware), non `toLocaleString` hardcoded.
+- **Branch**: `feature/issue-3006-3007-history-wishlist-i18n-fidelity` (parent `main-dev`). Commit atomici `feat|fix|test|docs(scope): …`. Un PR → `main-dev`.
+
+---
+
+## File Structure
+
+### Parte A — /toolkit/history (#3006)
+
+- Modify: `apps/web/src/app/(authenticated)/toolkit/history/client.tsx` — orchestratore pagina (fetch, stato filtri, view toggle, render tabella/cards/modal).
+- Create: `apps/web/src/app/(authenticated)/toolkit/history/_lib/history-filters.ts` — funzioni pure: filtro (search/game/date/winner), sort, paginazione, derive coop, parse `scoreData`.
+- Create: `apps/web/src/app/(authenticated)/toolkit/history/_components/HistoryToolbar.tsx` — search + multiselect gioco + date range + multiselect vincitore + sort + view toggle + summary.
+- Create: `apps/web/src/app/(authenticated)/toolkit/history/_components/HistoryTable.tsx` — tabella desktop 8 colonne sortabile.
+- Create: `apps/web/src/app/(authenticated)/toolkit/history/_components/HistoryCards.tsx` — card stack (view cards + mobile).
+- Create: `apps/web/src/app/(authenticated)/toolkit/history/_components/HistoryPagination.tsx` — prev/numeri/next + page-size selector + meta.
+- Create: `apps/web/src/app/(authenticated)/toolkit/history/_components/HistoryDetailModal.tsx` — modal desktop / bottom-sheet mobile via `Drawer`.
+- Create: `apps/web/src/lib/utils/csv.ts` — `escapeCSVField`, `downloadFile`, `rowsToCsv` (estratti/promossi da `lib/utils/export.ts` privato).
+- Create: `apps/web/src/app/(authenticated)/toolkit/history/__tests__/history-filters.test.ts`
+- Create: `apps/web/src/app/(authenticated)/toolkit/history/__tests__/page.test.tsx`
+- Modify: `apps/web/src/locales/it.json` + `en.json` — namespace `pages.toolkitHistory.*`.
+
+### Parte B — /library/wishlist (#3007)
+
+- Modify: `apps/web/src/app/(authenticated)/library/wishlist/page.tsx` — orchestratore (fetch, stato filtri, stats, dialog add/edit).
+- Create: `apps/web/src/app/(authenticated)/library/wishlist/_lib/wishlist-filters.ts` — funzioni pure: filtro (search/priority), sort (5 opzioni), stats (TOTAL_SPEND, PRIO_COUNTS).
+- Create: `apps/web/src/app/(authenticated)/library/wishlist/_components/WishlistToolbar.tsx` — search + chip priorità multiselect + sort popover + summary.
+- Create: `apps/web/src/app/(authenticated)/library/wishlist/_components/WishlistStats.tsx` — hero stats (giochi, alta priorità, spesa stimata).
+- Modify: `apps/web/src/components/wishlist/MeepleWishlistCard.tsx` — i18n + border-left Alta + badge cliccabile + added-at + edit action.
+- Modify: `apps/web/src/components/wishlist/AddToWishlistDialog.tsx` → rinominare concettualmente in dialog add/edit (prop `mode`): combobox gioco, radio-chip priorità, prezzo €, note counter 200, i18n.
+- Create: `apps/web/src/app/(authenticated)/library/wishlist/__tests__/wishlist-filters.test.ts`
+- Modify/Create: test per `MeepleWishlistCard`, `AddToWishlistDialog`, `page`.
+- Modify: `apps/web/src/locales/it.json` + `en.json` — namespace `pages.library.wishlist.*`.
+
+### Parte C — Docs
+
+- Modify: `admin-mockups/MOCKUPS_INDEX.md` — riga `sp4-library-wishlist.html` + Summary counts.
+
+---
+
+## PARTE A — /toolkit/history (#3006)
+
+**Gap-dati backend** (da `GameSessionDto`, `apps/web/src/lib/api/schemas/games.schemas.ts:86-127`): disponibili `id, gameId, status, startedAt, completedAt, playerCount, players[].{playerName,playerOrder,color}, winnerName, notes, durationMinutes, scoringType?, scoreData?`. NON disponibili: `gameName` (solo `gameId` → lookup), `players[].score`, `winScore`, `turns`, timeline, varianza, best, highlights. Colonna Score e stats-modal: tentare parse `scoreData` (JSON string) → se assente/non-parsabile mostrare `—`.
+
+**API** (`apps/web/src/lib/api/clients/sessionsClient.ts:82-119`): `api.sessions.getHistory({ gameId?, startDate?, endDate?, limit?, offset? })` → `{ sessions: GameSessionDto[], total, page, pageSize }` (⚠ `total` = size pagina, non conteggio reale). Strategia: fetch batch ampio (`limit: 500`, offset 0) e fare **tutto client-side** (filtro/sort/paginazione). Se il batch è pieno (500) mostrare nota "primi 500".
+
+**gameName lookup**: usare `useLibrary()` (map `gameId → gameTitle`) come già fa la wishlist page; per sessioni di giochi non in libreria fallback `t('pages.toolkitHistory.table.unknownGame')` = "Gioco sconosciuto". (Alternativa catalogo `api.games` opzionale — YAGNI: iniziare con library map.)
+
+### Task A1: CSV util condiviso
+
+**Files:**
+- Create: `apps/web/src/lib/utils/csv.ts`
+- Test: `apps/web/src/lib/utils/__tests__/csv.test.ts`
+
+**Interfaces:**
+- Produces: `escapeCSVField(field: string | number | null | undefined): string`, `rowsToCsv(headers: string[], rows: (string|number|null)[][]): string`, `downloadFile(content: string, filename: string, mimeType?: string): void`
+
+- [ ] **Step 1: Failing test** — `csv.test.ts`:
+```ts
+import { describe, it, expect } from 'vitest';
+import { escapeCSVField, rowsToCsv } from '../csv';
+
+describe('escapeCSVField', () => {
+  it('quotes fields containing comma, quote or newline', () => {
+    expect(escapeCSVField('a,b')).toBe('"a,b"');
+    expect(escapeCSVField('he said "hi"')).toBe('"he said ""hi"""');
+    expect(escapeCSVField('line1\nline2')).toBe('"line1\nline2"');
+  });
+  it('passes through plain fields and stringifies numbers/null', () => {
+    expect(escapeCSVField('plain')).toBe('plain');
+    expect(escapeCSVField(42)).toBe('42');
+    expect(escapeCSVField(null)).toBe('');
+  });
+});
+
+describe('rowsToCsv', () => {
+  it('joins headers + rows with CRLF and escapes each cell', () => {
+    const csv = rowsToCsv(['A', 'B'], [['x', 'y,z'], [1, null]]);
+    expect(csv).toBe('A,B\r\nx,"y,z"\r\n1,');
+  });
+});
+```
+- [ ] **Step 2: Run → FAIL** (`pnpm vitest run src/lib/utils/__tests__/csv.test.ts`) — module not found.
+- [ ] **Step 3: Implement** `csv.ts` (promuovi il pattern privato di `lib/utils/export.ts`): `escapeCSVField` (quota se contiene `,"\n`, raddoppia `"`, `null/undefined→''`, numeri→String), `rowsToCsv` (map escape, join cella `,`, join riga `\r\n`), `downloadFile` (Blob + `URL.createObjectURL` + anchor `download` + `revokeObjectURL`).
+- [ ] **Step 4: Run → PASS**.
+- [ ] **Step 5: Commit** `feat(utils): add shared CSV export helpers`.
+
+### Task A2: Funzioni pure filtro/sort/paginazione history
+
+**Files:**
+- Create: `apps/web/src/app/(authenticated)/toolkit/history/_lib/history-filters.ts`
+- Test: `apps/web/src/app/(authenticated)/toolkit/history/__tests__/history-filters.test.ts`
+
+**Interfaces:**
+- Consumes: `GameSessionDto` (`@/lib/api/schemas/games.schemas`).
+- Produces:
+  - `type HistorySort = 'recent' | 'oldest' | 'longest' | 'score'`
+  - `type DateRangePreset = 'all' | 'last30' | 'last90' | 'lastYear' | 'custom'`
+  - `interface HistoryFilterState { search: string; gameIds: string[]; winners: string[]; datePreset: DateRangePreset; dateFrom?: string; dateTo?: string; sort: HistorySort }`
+  - `interface HistoryRow` (view-model): `{ id; gameId; gameName: string; startedAt: string; durationMinutes: number; playerNames: string[]; playerCount: number; winnerName: string | null; isCoop: boolean; winScore: number | null; notes: string | null }`
+  - `parseWinScore(dto: GameSessionDto): number | null`
+  - `toHistoryRow(dto, gameNameMap: Map<string,string>, unknownLabel: string): HistoryRow`
+  - `filterRows(rows: HistoryRow[], f: HistoryFilterState, now: Date): HistoryRow[]`
+  - `sortRows(rows: HistoryRow[], sort: HistorySort): HistoryRow[]`
+  - `paginate<T>(items: T[], page: number, pageSize: number): T[]`
+  - `countActiveFilters(f: HistoryFilterState): number`
+
+- [ ] **Step 1: Failing tests** — coprire almeno:
+```ts
+// filterRows: search matcha gameName, winnerName, playerNames (case-insensitive)
+// filterRows: gameIds filtra per gioco; winners filtra ('__nowin__' = winnerName null)
+// filterRows: datePreset last30 esclude > 30 giorni fa (usare now fisso)
+// sortRows: recent = startedAt desc; longest = durationMinutes desc; score = winScore desc (null in fondo)
+// paginate: page 2 pageSize 20 ritorna item 20..39
+// parseWinScore: scoreData JSON con punteggi → max; assente/invalid → null
+// countActiveFilters: search+1 game+date custom → conta correttamente
+```
+(Scrivere ogni caso con `now = new Date('2026-07-15T12:00:00Z')` fisso; NON usare `Date.now()`.)
+- [ ] **Step 2: Run → FAIL**.
+- [ ] **Step 3: Implement** `history-filters.ts` con le funzioni pure. `isCoop` derivato: `winnerName == null && players.length > 1` (euristica documentata). `parseWinScore`: `try JSON.parse(scoreData)`; supporta shape `{playerId: number}` o `number[]` → `Math.max`; catch → null.
+- [ ] **Step 4: Run → PASS**.
+- [ ] **Step 5: Commit** `feat(toolkit-history): pure filter/sort/paginate helpers`.
+
+### Task A3: i18n namespace `pages.toolkitHistory`
+
+**Files:** Modify `apps/web/src/locales/it.json`, `apps/web/src/locales/en.json`.
+
+**Interfaces:** Produces le chiavi consumate da A4-A8. Struttura (valori IT verbatim dal mockup; EN = traduzione equivalente):
+
+```
+pages.toolkitHistory:
+  hero: { breadcrumbToolkit:"Toolkit", breadcrumbHistory:"History", title:"Storico sessioni",
+          subtitle:"Tutte le partite finalizzate, filtrabili per gioco, data e vincitore.",
+          quickStat:"{sessions} sessioni · {games} giochi · {winners} vincitori",
+          exportCsv:"Esporta CSV", exportCsvShort:"CSV" }
+  tabs: { stats:"Stats", history:"History", templates:"Templates", play:"Play" }
+  filters:
+    searchPlaceholder:"Cerca per gioco o vincitore…", searchAriaLabel:"Cerca per gioco o vincitore",
+    searching:"Cercando…", clearSearch:"Cancella ricerca",
+    games:"Giochi", filterByGame:"Filtra per gioco", all:"Tutti",
+    showMore:"Mostra altri {n}", showLess:"Mostra meno",
+    date:"Data", dateRange:"Intervallo date",
+    dateOptions: { all:"Tutte le date", last30:"Ultimi 30 giorni", last90:"Ultimi 90 giorni",
+                   lastYear:"Ultimo anno", custom:"Date custom" },
+    dateFrom:"Da", dateTo:"A", dateFromLabel:"Data inizio", dateToLabel:"Data fine", applyRange:"Applica intervallo",
+    winners:"Vincitori", filterByWinner:"Filtra per vincitore", winnerWon:"{name} (vinto)", noWinner:"Senza vincitore",
+    sort:"Ordina", sortBy:"Ordina per",
+    sortOptions: { recent:"Più recente", oldest:"Più antica", longest:"Più lunga", score:"Score più alto" },
+    view:"Vista", viewTable:"Vista tabella", viewCards:"Vista cards"
+  summary: { activeFilters:"{n, plural, one {# filtro attivo} other {# filtri attivi}}",
+             results:"{n, plural, one {# sessione} other {# sessioni}} su {total}", clearAll:"Cancella tutto" }
+  table: { date:"Data", game:"Gioco", duration:"Durata", players:"Giocatori", winner:"Vincitore",
+           score:"Score", notes:"Note", actions:"Azioni", coop:"Cooperativa", coopShort:"co-op",
+           noWinner:"Senza vincitore", noNote:"Nessuna nota", hasNote:"Nota presente",
+           viewDetails:"Vedi dettagli", gameStats:"Stats del gioco", unknownGame:"Gioco sconosciuto",
+           openInLibrary:"Apri {game} in libreria", winnerAria:"Vincitore: {name}",
+           playersAria:"{count} giocatori: {names}" }
+  pagination: { prev:"Prec.", next:"Succ.", prevAria:"Pagina precedente", nextAria:"Pagina successiva",
+                mobileMeta:"Pag. {page} di {pages} · {total} sess.",
+                rangeMeta:"{from}–{to} di {total} sessioni", empty:"0 sessioni",
+                perPage:"Per pagina", perPageAria:"Sessioni per pagina", listAria:"Pagine storico sessioni" }
+  empty: { title:"Nessuna sessione ancora",
+           body:"Le partite finalizzate appariranno qui: filtra per gioco, data o vincitore e apri il dettaglio di ognuna.",
+           cta:"Crea prima sessione" }
+  filteredEmpty: { title:"Nessuna sessione corrisponde ai filtri",
+                   body:"Prova a modificare la ricerca o a rimuovere i filtri di gioco, data o vincitore attivi.",
+                   cta:"Rimuovi filtri" }
+  loading: { ariaLabel:"Caricamento storico sessioni" }
+  error: { message:"Impossibile caricare lo storico — riprova.", retry:"Riprova" }
+  modal: { title:"{game} · {date}", sub:"Durata {duration} · {count} giocatori · {time}", close:"Chiudi",
+           leaderboard:"Classifica finale", you:" · tu", timeline:"Timeline eventi",
+           notes:"Note", notesEmpty:"Nessuna nota per questa sessione.",
+           stats:"Statistiche partita", turns:"Turni totali", winnerScore:"Score vincitore",
+           variance:"Varianza score", highlights:"Highlights", noData:"—",
+           gameStats:"Stats gioco", playAgain:"Gioca di nuovo", editNotes:"Modifica note", delete:"Elimina" }
+  cards: { coop:"Co-op" }
+  batchNote:"Mostrati i primi {n} risultati."
+```
+
+- [ ] **Step 1**: inserire il blocco sotto `pages` in `it.json` (JSON valido, virgole corrette).
+- [ ] **Step 2**: inserire lo stesso alberello con valori EN in `en.json` (es. title "Session History", subtitle "All finalized games, filterable by game, date and winner.", ecc.).
+- [ ] **Step 3: Verify** — `pnpm vitest run` del test locale parità chiavi se esiste, altrimenti `node -e "JSON.parse(require('fs').readFileSync('apps/web/src/locales/it.json'))"` per validità. (Se esiste un test di parità it/en, deve passare.)
+- [ ] **Step 4: Commit** `feat(i18n): add pages.toolkitHistory catalog (it/en)`.
+
+### Task A4: HistoryTable (desktop, 8 colonne sortabili)
+
+**Files:** Create `_components/HistoryTable.tsx`; test in `__tests__/HistoryTable.test.tsx`.
+
+**Interfaces:**
+- Consumes: `HistoryRow`, `HistorySort` (A2); `t` (useTranslation); primitives `Table*` (`@/components/ui/data-display/table`), `EntityChip`, `Button`, `Badge`.
+- Produces: `<HistoryTable rows={HistoryRow[]} sort={HistorySort} onSortChange={(s)=>void} onOpenDetail={(row)=>void} onOpenGameStats={(gameId)=>void} />`
+
+- [ ] **Step 1: Failing test** — render con 2 righe: verifica header i18n (`t('pages.toolkitHistory.table.game')`), click su header "Durata" chiama `onSortChange('longest')` con toggle asc/desc, riga coop mostra `co-op`, riga senza winner mostra `—`, click riga → `onOpenDetail`. Mock `useTranslation` con passthrough id.
+- [ ] **Step 2: Run → FAIL**.
+- [ ] **Step 3: Implement** tabella: colonne Data (`formatDate`+`formatTime`+rel), Gioco (`EntityChip entity="game"`), Durata (`{h}h {m}m`), Giocatori (avatar stack iniziali + `+N`, `aria-label` playersAria), Vincitore (coop → coop label; null → `—`; else chip 🏆), Score (`winScore ?? —`; coop → coopShort), Note (bottone 📝, dimmed se null), Azioni (👁 viewDetails + 📊 gameStats). Header sortabili con `aria-sort`. Token semantici + entity utilities.
+- [ ] **Step 4: Run → PASS**.
+- [ ] **Step 5: Commit** `feat(toolkit-history): HistoryTable desktop`.
+
+### Task A5: HistoryCards (view cards + mobile)
+
+**Files:** Create `_components/HistoryCards.tsx`; test.
+
+**Interfaces:** `<HistoryCards rows={HistoryRow[]} onOpenDetail={(row)=>void} />` — usa `MeepleCard entity="session"` o layout ad-hoc card (chead GameChip+rel, cmid avatar+winner+durata, cfoot score pill + data + note flag).
+
+- [ ] **Step 1: Failing test** — render 1 riga, verifica gameName + winner label + click → onOpenDetail.
+- [ ] **Step 2: Run → FAIL**. **Step 3: Implement**. **Step 4: PASS**. **Step 5: Commit** `feat(toolkit-history): HistoryCards stack`.
+
+### Task A6: HistoryPagination
+
+**Files:** Create `_components/HistoryPagination.tsx`; test.
+
+**Interfaces:** `<HistoryPagination page total pageSize onPageChange={(p)=>void} onPageSizeChange={(s)=>void} />` — page-size `[10,20,50,100]`, meta `rangeMeta`, mobile `mobileMeta`, ellissi numeri (riuso logica `CatalogPagination` se utile, ma con i18n `pages.toolkitHistory.pagination.*` e page-size selector aggiunto).
+
+- [ ] **Step 1: Failing test** — total 156, pageSize 20, page 3 → meta "41–60 di 156 sessioni"; click Succ. → onPageChange(4); cambio select → onPageSizeChange(50).
+- [ ] **Step 2-4** TDD. **Step 5: Commit** `feat(toolkit-history): HistoryPagination with page-size`.
+
+### Task A7: HistoryToolbar
+
+**Files:** Create `_components/HistoryToolbar.tsx`; test.
+
+**Interfaces:** `<HistoryToolbar state={HistoryFilterState} onChange={(next)=>void} gameOptions={{id,label,count}[]} winnerOptions={{value,label,count}[]} view={'table'|'cards'} onViewChange totalCount resultCount onClearAll onExport />`. Composizione: search (debounce 400ms locale, spinner "Cercando…"), multiselect Giochi (Popover + Checkbox, `showMore` dopo 4), date range (preset radio + custom inputs), multiselect Vincitori (`__nowin__` + `showMore` 5), sort (Select), view toggle (table/cards), summary bar condizionale (`countActiveFilters>0`).
+
+- [ ] **Step 1: Failing test** — digitare nel search chiama onChange con search aggiornato (dopo debounce, usare `vi.useFakeTimers`); toggle chip gioco aggiorna `gameIds`; summary mostra `activeFilters` quando ci sono filtri; Cancella tutto → onClearAll.
+- [ ] **Step 2-4** TDD (test focalizzati sui comportamenti chiave, non ogni pixel). **Step 5: Commit** `feat(toolkit-history): HistoryToolbar filters`.
+
+### Task A8: HistoryDetailModal (desktop dialog / mobile bottom-sheet)
+
+**Files:** Create `_components/HistoryDetailModal.tsx`; test.
+
+**Interfaces:** `<HistoryDetailModal row={HistoryRow | null} onClose />` — usa `Drawer` (`@/components/ui/drawer/drawer`) con `side="auto"` (bottom su mobile, right/dialog su desktop) O `Dialog` + `BottomSheet`. Sezioni: header (title/sub i18n), Classifica finale (da `players` + winnerName; score da parse scoreData o `—`), Note (readonly textarea o notesEmpty), Statistiche partita (Turni/Varianza/Highlights → `noData` "—" se assenti, documentato gap-dati). Timeline eventi **omessa** (nessun dato) — non renderizzare la sezione.
+
+- [ ] **Step 1: Failing test** — row con notes → mostra note; row senza notes → notesEmpty; sezione stats mostra "—" per turns. onClose su close button.
+- [ ] **Step 2-4** TDD. **Step 5: Commit** `feat(toolkit-history): HistoryDetailModal with graceful data degradation`.
+
+### Task A9: Orchestratore client.tsx + export CSV + page test
+
+**Files:** Modify `client.tsx`; test `__tests__/page.test.tsx`.
+
+**Interfaces:** Consuma A1-A8. Stato: `useState<HistoryFilterState>`, `view`, `page`, `pageSize`, `detailRow`. Fetch `useQuery(['toolkit-history'], () => api.sessions.getHistory({ limit: 500 }))` + `useLibrary()` per gameNameMap. Pipeline: `dtos → toHistoryRow → filterRows → sortRows → paginate`. Header con Export CSV (usa `rowsToCsv`+`downloadFile`, colonne = header tabella i18n). Empty vs filteredEmpty in base a `countActiveFilters`. Loading skeleton, error banner con retry (`refetch`).
+
+- [ ] **Step 1: Failing test** — mock `api.sessions.getHistory` (2 sessioni) + `useLibrary`; render → titolo `Storico sessioni` (via i18n mock), tabella con 2 righe; empty state quando getHistory ritorna `[]`; error state quando query rejecs. Riferimento pattern: `toolkit/stats/__tests__/page.test.tsx`, `sessionsClient.test.ts`.
+- [ ] **Step 2: Run → FAIL**.
+- [ ] **Step 3: Implement** orchestratore, rimuovendo TUTTE le stringhe EN hardcoded esistenti.
+- [ ] **Step 4: Run → PASS** + `pnpm typecheck` + `pnpm lint` puliti su questi file.
+- [ ] **Step 5: Commit** `feat(toolkit-history): #3006 full fidelity + i18n page`.
+
+---
+
+## PARTE B — /library/wishlist (#3007)
+
+**Gap-dati backend** (da `WishlistItemDto`, `apps/web/src/lib/api/schemas/wishlist.schemas.ts`): disponibili `id, userId, gameId, gameName?, priority, targetPrice, notes, addedAt, updatedAt, visibility`. NON disponibili: `emoji` cover, `category`, `players`, `duration`, `bgg` rating → **MetaBox del mockup NON implementabile** (omettere la sezione). `TOTAL_SPEND`/`PRIO_COUNTS` calcolabili client-side. Edit end-to-end già supportato (`useUpdateWishlistItem` + `UpdateWishlistItemRequest.{clearTargetPrice,clearNotes}`).
+
+**gameName**: `WishlistItemDto.gameName?` opzionale; fallback lookup via `useLibrary()` (già in page), poi `t('…card.unknownGame')`.
+
+### Task B1: Funzioni pure wishlist filtro/sort/stats
+
+**Files:** Create `wishlist/_lib/wishlist-filters.ts`; test `__tests__/wishlist-filters.test.ts`.
+
+**Interfaces:**
+- Consumes: `WishlistItemDto`.
+- Produces:
+  - `type WishlistSort = 'priority' | 'recent' | 'oldest' | 'alpha' | 'price'`
+  - `type Priority = 'high' | 'medium' | 'low'`
+  - `const PRIORITY_RANK: Record<Priority, number>` = `{high:0, medium:1, low:2}`
+  - `interface WishlistFilterState { search: string; priorities: Priority[]; sort: WishlistSort }`
+  - `filterItems(items, f, gameNameMap): WishlistItemDto[]` (search su gameName+notes; priorities multi)
+  - `sortItems(items, sort): WishlistItemDto[]`
+  - `computeStats(items): { total: number; highCount: number; totalSpend: number; priorityCounts: Record<Priority, number> }`
+  - `countActiveFilters(f): number`
+
+- [ ] **Step 1: Failing tests** — search matcha gameName+notes; priorities filtra; sort priority = rank poi addedAt desc; sort price = targetPrice desc (null in fondo); computeStats somma targetPrice saltando null, conta priorità. `now` fisso dove serve.
+- [ ] **Step 2: Run → FAIL**. **Step 3: Implement**. **Step 4: PASS**. **Step 5: Commit** `feat(wishlist): pure filter/sort/stats helpers`.
+
+### Task B2: i18n namespace `pages.library.wishlist`
+
+**Files:** Modify `it.json` + `en.json`.
+
+**Interfaces:** Produces chiavi per B3-B7. Struttura (IT verbatim dal mockup):
+
+```
+pages.library.wishlist:
+  hero: { breadcrumbLibrary:"Libreria", breadcrumbWishlist:"Wishlist",
+          title:"Wishlist · Giochi desiderati",
+          subtitle:"Tieni traccia dei giochi che vuoi comprare o provare.",
+          tabsAria:"Sezioni libreria", tabLibrary:"Libreria", tabWishlist:"Wishlist",
+          addCta:"Aggiungi alla wishlist", addCtaShort:"Aggiungi" }
+  stats: { games:"{count} giochi", highPriority:"{count} alta priorità", estimatedSpend:"spesa stimata {amount}" }
+  filters:
+    searchPlaceholder:"Cerca per nome gioco o note…", searchAriaLabel:"Cerca per nome gioco o note",
+    searching:"Cercando…", clearSearch:"Cancella ricerca",
+    priorityGroupAria:"Filtra per priorità (selezione multipla)", all:"Tutti",
+    sort:"Ordina", sortBy:"Ordina per", sortAria:"Ordina wishlist",
+    sortOptions: { priority:"Per priorità", recent:"Più recenti", oldest:"Più vecchi", alpha:"Alfabetico", price:"Prezzo target" }
+  summary: { activeFilters:"{n, plural, one {# filtro attivo} other {# filtri attivi}}",
+             results:"{n, plural, one {# gioco} other {# giochi}} su {total}", clearAll:"Cancella filtri" }
+  priority: { high:"Alta", medium:"Media", low:"Bassa",
+              filterAria:"Priorità {label} — filtra per questa priorità" }
+  card: { target:"Target", noNote:"Nessuna nota", addedAt:"Aggiunto {when}", addedTitle:"Aggiunto il {date}",
+          edit:"Modifica", editAria:"Modifica wishlist item {name}", remove:"Rimuovi",
+          removeAria:"Rimuovi {name} dalla wishlist", openGameAria:"Apri dettaglio gioco {name}",
+          unknownGame:"Gioco senza nome", gridAria:"Wishlist giochi" }
+  dialog: { addTitle:"Aggiungi alla wishlist", editTitle:"Modifica wishlist",
+            addSub:"Salva un gioco che vuoi comprare o provare", editSub:"{name} · priorità {priority}",
+            close:"Chiudi", error:"Errore aggiungendo alla wishlist.", retry:"Riprova",
+            gameLabel:"Gioco", gameComboPlaceholder:"Cerca per nome o incolla un game ID…",
+            gameComboAria:"Cerca gioco da aggiungere", gameRemoveAria:"Rimuovi gioco selezionato",
+            priorityLabel:"Priorità",
+            priceLabel:"Target price (€)", pricePlaceholder:"65",
+            priceHint:"Prezzo massimo che sei disposto a spendere — opzionale.",
+            priceAria:"Prezzo massimo che sei disposto a spendere",
+            notesLabel:"Note", notesPlaceholder:"es. acquisto entro Q3, voglio aspettare la nuova edizione, ecc.",
+            notesCounter:"{len} / 200",
+            cancel:"Annulla", submitting:"Aggiungo…", success:"Aggiunto", add:"Aggiungi", save:"Salva" }
+  empty: { noItems: { title:"Nessun gioco nella wishlist",
+                      body:"Aggiungi giochi che ti interessano per non perderli di vista — con priorità, prezzo target e note.",
+                      cta:"Aggiungi il primo" },
+           filtered: { title:"Nessun gioco corrisponde ai filtri",
+                       body:"Prova a cambiare priorità o a modificare la ricerca per nome o note.",
+                       cta:"Cancella filtri" } }
+  loading: { ariaLabel:"Caricamento wishlist" }
+  error: { message:"Impossibile caricare la wishlist — riprova.", retry:"Riprova" }
+```
+
+- [ ] **Step 1-2**: inserire in `it.json` e `en.json` (EN equivalente: title "Wishlist · Wanted games", ecc.).
+- [ ] **Step 3: Verify** JSON valido + parità chiavi.
+- [ ] **Step 4: Commit** `feat(i18n): add pages.library.wishlist catalog (it/en)`.
+
+### Task B3: MeepleWishlistCard i18n + fidelity
+
+**Files:** Modify `apps/web/src/components/wishlist/MeepleWishlistCard.tsx`; test `__tests__/MeepleWishlistCard.test.tsx`.
+
+**Interfaces:** `<MeepleWishlistCard item={WishlistItemDto} gameName? onRemove={(id)=>void} onEdit={(item)=>void} onFilterPriority={(p)=>void} />`. Rimuovere `formatPriorityItalian` hardcoded → `t('pages.library.wishlist.priority.'+priority)`. Aggiungere: border-left Alta (`border-l-2 border-l-entity...`/semantic danger), badge priorità cliccabile (onFilterPriority), Target price con `€` (`formatNumber`), added-at relativo (`formatRelativeTime`/`formatDate`), azione Edit (onEdit). NO MetaBox (gap-dati).
+
+- [ ] **Step 1: Failing test** — badge mostra label i18n; click badge → onFilterPriority(priority); click edit → onEdit(item); click remove → onRemove(id); item priority high ha border-left.
+- [ ] **Step 2-4** TDD. **Step 5: Commit** `feat(wishlist): MeepleWishlistCard i18n + priority filter + edit`.
+
+### Task B4: AddEditWishlistDialog
+
+**Files:** Modify `apps/web/src/components/wishlist/AddToWishlistDialog.tsx`; test.
+
+**Interfaces:** `<AddToWishlistDialog mode={'add'|'edit'} item?={WishlistItemDto} open? onOpenChange? trigger? prefillGameId? />`. Add usa `useAddToWishlist`; edit usa `useUpdateWishlistItem` (id + `UpdateWishlistItemRequest`, con `clearTargetPrice`/`clearNotes` quando svuotati). Campi: gioco (combobox ricerca su `useLibrary` games; in edit read-only chip), priorità radio-chip (`RadioGroup` stilizzato), prezzo € (`Input type=number`), note textarea `maxLength=200` + counter i18n. Titoli/sub/footer i18n via B2. Toast conferma via `sonner` (`success`).
+
+- [ ] **Step 1: Failing test** — mode add: submit chiama useAddToWishlist con {gameId,priority,targetPrice,notes}; mode edit: precompila da item, submit chiama useUpdateWishlistItem con clearTargetPrice quando prezzo svuotato; counter note aggiorna; canSubmit false senza gioco/priorità.
+- [ ] **Step 2-4** TDD (mock hooks). **Step 5: Commit** `feat(wishlist): unified add/edit dialog with combobox + radio-chip + i18n`.
+
+### Task B5: WishlistStats + WishlistToolbar
+
+**Files:** Create `_components/WishlistStats.tsx`, `_components/WishlistToolbar.tsx`; test.
+
+**Interfaces:**
+- `<WishlistStats stats={ReturnType<typeof computeStats>} />` — riga `games · highPriority · estimatedSpend` (i18n, `formatNumber` per €).
+- `<WishlistToolbar state onChange priorityCounts totalCount resultCount onClearAll />` — search debounce, chip priorità multiselect (`ToggleGroup type="multiple"` o chip ad-hoc con count + colore priorità), sort popover (`Popover` + radio), summary condizionale.
+
+- [ ] **Step 1: Failing test** — Stats mostra spesa formattata; Toolbar toggle chip aggiorna priorities; sort popover cambia sort; Cancella filtri → onClearAll.
+- [ ] **Step 2-4** TDD. **Step 5: Commit** `feat(wishlist): WishlistStats + WishlistToolbar`.
+
+### Task B6: Orchestratore page.tsx
+
+**Files:** Modify `apps/web/src/app/(authenticated)/library/wishlist/page.tsx`; test `__tests__/page.test.tsx`.
+
+**Interfaces:** Consuma B1-B5. Stato `useState<WishlistFilterState>`, `dialogState {mode, item}`. Fetch `useWishlist()` + `useLibrary()`. Pipeline `items → filterItems → sortItems`, `computeStats(items)`. Render: hero+breadcrumb+tabs, WishlistStats, addCta (apre dialog add), WishlistToolbar, grid `MeepleWishlistCard` (onEdit → dialog edit, onRemove → useRemoveFromWishlist, onFilterPriority → set priorities), empty.noItems vs empty.filtered (in base a countActiveFilters), loading skeleton, error banner. Rimuovere TUTTE le stringhe EN.
+
+- [ ] **Step 1: Failing test** — mock useWishlist (2 item) + useLibrary; render → title `Wishlist · Giochi desiderati`; stats corretti; empty.noItems quando 0 item; filter riduce le card; error state.
+- [ ] **Step 2: Run → FAIL**. **Step 3: Implement**. **Step 4: PASS** + typecheck + lint. **Step 5: Commit** `feat(wishlist): #3007 full fidelity + i18n page`.
+
+---
+
+## PARTE C — Docs + chiusura
+
+### Task C1: MOCKUPS_INDEX.md
+
+**Files:** Modify `admin-mockups/MOCKUPS_INDEX.md`.
+
+- [ ] **Step 1**: aggiungere nella sezione SP4 (ordine alfabetico, dopo `sp4-game-detail-tab-*`) la riga:
+```
+| `sp4-library-wishlist.html` | page-mock | `/library/wishlist` — personal wishlist (priority Alta/Media/Bassa, target price, notes); filters + sort + add/edit dialog. Issue #1491 |
+```
+- [ ] **Step 2**: aggiornare la tabella `## Summary`: `page-mock` +1, `Total` +1.
+- [ ] **Step 3: Commit** `docs(mockups): index sp4-library-wishlist → /library/wishlist`.
+
+### Task C2: Verifica finale + PR
+
+- [ ] **Step 1**: full test suite mirata: `pnpm vitest run` sui path toccati (toolkit/history, library/wishlist, wishlist components, csv, locales). Baseline pulita (0 nuovi fail vs main-dev).
+- [ ] **Step 2**: `pnpm typecheck && pnpm lint && pnpm lint:tokens` puliti; verificare nessuna stringa EN residua (`grep` euristico su `toolkit/history`, `wishlist`).
+- [ ] **Step 3**: verifica visiva con dev server **fresco** (NON il container Docker stantìo): `pnpm --dir apps/web dev` su porta alternativa, screenshot `/toolkit/history` e `/library/wishlist` vs mockup. (Oppure attendere rebuild container.)
+- [ ] **Step 4**: commento su #3007 documentando che il redirect era già risolto (fix 2026-07-11, `next.config.js:229`) e che questa PR copre il residuo i18n/fidelity + index.
+- [ ] **Step 5**: push + PR → `main-dev`, `Closes #3006, Closes #3007`, con changelog dei gap-dati backend documentati (Score/Turni/Timeline/Highlights history; MetaBox wishlist) come possibili follow-up.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- #3006 i18n → A3, A9 (rimozione stringhe EN). ✅
+- #3006 fidelity (tabella/sort/filtri/paginazione/export/mobile/modal) → A2,A4,A5,A6,A7,A8,A9. ✅
+- #3007 i18n → B2, B3, B4, B6. ✅
+- #3007 fidelity (stats/filtri/sort/card/add-edit dialog/empty) → B1,B3,B4,B5,B6. ✅
+- #3007 doc (MOCKUPS_INDEX) → C1. ✅
+- Redirect #3007 → già risolto upstream (documentato in C2 step 4). ✅
+- Gap-dati documentati → header Parte A/B + C2 step 5. ✅
+
+**Placeholder scan:** i valori i18n sono verbatim; i test-block chiave sono espliciti; per i componenti UI di dettaglio i test sono "focalizzati sui comportamenti chiave" (giustificato dalla mole — non ogni pixel). Nessun "TODO/TBD".
+
+**Type consistency:** `HistoryFilterState`/`HistorySort`/`HistoryRow` usati coerentemente A2→A4-A9; `WishlistFilterState`/`WishlistSort`/`Priority`/`PRIORITY_RANK` coerenti B1→B3-B6. `parseWinScore`, `computeStats`, `countActiveFilters` firmati una volta e riusati.
+
+**Vincolo noto:** "fidelity completa" è limitata dai dati backend (documentato). Non è un placeholder ma una scelta di scope approvata.


### PR DESCRIPTION
## Cosa

Reimplementazione a parità dei mockup `sp4-toolkit-history` / `sp4-library-wishlist` + localizzazione completa (react-intl it/en) di due pagine, chiudendo le follow-up del gap audit mockup→implementazione del 2026-07-15.

### #3006 — `/toolkit/history`
Da griglia minimale con stringhe hardcoded in inglese a vista completa:
- **Tabella desktop** 8 colonne sortabili (Data · Gioco · Durata · Giocatori · Vincitore · Score · Note · Azioni) + **vista cards** (toggle) + **layout mobile**
- **Filtri client-side**: ricerca (debounce 400ms), multi-select gioco, date range (preset + custom con fix end-of-day), multi-select vincitore
- **Sort** + **paginazione** client-side con selettore page-size
- **Detail modal** adaptive (dialog desktop / bottom-sheet mobile)
- **Export CSV**
- **i18n** completo (namespace `pages.toolkitHistory`, it + en)

> I filtri/sort/paginazione sono client-side perché l'endpoint `getHistory` ritorna un array nudo (nessun supporto server per ricerca/filtro-vincitore/sort). Fetch batch (limit 500) + pipeline client-side.

### #3007 — `/library/wishlist`
Il redirect `/library/wishlist → ?tab=wishlist` segnalato nell'issue **era già risolto upstream** (rimosso il 2026-07-11, `next.config.js:229-233`; l'osservazione dell'audit vedeva un container Docker con build datata). Questa PR copre il **residuo reale**:
- Pagina standalone portata a parità mockup: **stats** (spesa stimata, conteggi priorità), **filtri priorità** multi-select + **ricerca** + **sort popover**, dialog **add/edit unificato** (combobox su libreria interna, radio-chip priorità con icone, prezzo €, note con counter 200)
- **i18n** completo (namespace `pages.library.wishlist`), sostituendo le stringhe EN hardcoded in pagina, card e dialog
- Mockup `sp4-library-wishlist` indicizzato in `MOCKUPS_INDEX.md`

## Vincolo dati (scope approvato)
I mockup mostrano dati più ricchi dei DTO reali. La fidelity implementata è **layout + interazioni sui dati realmente esposti dal backend**, con graceful-degrade dei campi assenti — **nessun dato inventato**:
- history: Score/Turni/Timeline/Varianza/Highlights sono fixture del mockup non esposte dall'API → `—` o omessi (lo Score mostrato deriva dal parse di `scoreData` reale)
- wishlist: MetaBox (categoria/players/durata/BGG) e cover-emoji assenti dal DTO → omesse

## Come
Sviluppo TDD, esecuzione subagent-driven (18 task: implementer + review avversariale spec+quality per task, final whole-branch review su Opus).
- **211 test** verdi sui path toccati · `tsc --noEmit` exit 0 · `lint:tokens` 0 violazioni
- Vincoli rispettati e verificati nel final review: BGG asset ban (#2123 — il combobox usa la libreria interna, mai host BGG), token semantici (nessun `bg-white`/`text-gray-*`; evitate le classi dead `bg-warning`/`bg-success`), `MeepleCard`, parità chiavi/placeholder i18n it↔en (0 mismatch nei nuovi namespace)

## Follow-up (Minor, non-blocking)
Final review: **"Ready to merge, 0 Critical/Important"**. Minor da tracciare come issue di follow-up: helper duplicati (`formatDuration`/`getInitials`/`normalizePriority`), CSV filename hardcoded + hardening injection-guard (`=+-@`), footer del detail modal con bottoni non ancora wired, chiavi i18n per affordance non completate (`card.openGameAria`, dialog error-state), nit ARIA (role listbox, aria-label breadcrumb). Debito codebase-wide preesistente: classi Tailwind dead `bg/text-success`/`bg-warning` (~15-20 file, fuori scope).

Closes #3006
Closes #3007

🤖 Generated with [Claude Code](https://claude.com/claude-code)
