### PR TITLE
feat(ci): #2997 enforce designer signoff attestation (ADR-077 lint:fidelity gate)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -360,6 +360,21 @@ jobs:
             audits/2026-07-14-storybook-states-coverage.md
           retention-days: 14
 
+      # ADR-077 (#2997): Designer signoff attestation gate. Every
+      # design_intent="current" fidelity file MUST carry a non-empty
+      # acceptance.designer_approved_by — the "self-waiver P250" solo-maintainer
+      # token is an accepted approval (developer-is-designer exception). Signoff
+      # failures are STRICT (never baselined). Pre-existing structural
+      # (mockup.source cross-reference) drift is whitelist-incremental via
+      # `--max-baseline 3` (3 orphaned fidelity files whose source mockups were
+      # deleted: sp4-play-records-data / scaffold / pr-form-core — reconcile to
+      # ratchet the baseline down). Doc template examples (templates/**) are
+      # excluded as non-surface illustrations. `pnpm lint:fidelity` scans the
+      # whole repo (REPO_ROOT resolved from __dirname) regardless of job cwd.
+      # ADR: docs/for-claude/architecture/adr/adr-077-designer-signoff-ci-gate.md
+      - name: Designer signoff + fidelity gate (ADR-077 / #2997)
+        run: pnpm lint:fidelity
+
       # Issue #2123 — BGG ToS compliance gate
       - name: BGG ToS compliance gate (#2123)
         run: pnpm lint:bgg

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -58,7 +58,7 @@
     "lint:bgg-mockups": "node scripts/lint-bgg-mockups.mjs",
     "lint:mockup-state-naming": "node scripts/validate-state-naming.mjs",
     "lint:storybook-states": "node scripts/lint-storybook-states.mjs",
-    "lint:fidelity": "node scripts/mockup-annotations/validate-fidelity.mjs --all",
+    "lint:fidelity": "node scripts/mockup-annotations/validate-fidelity.mjs --all --max-baseline 3",
     "mockup-annotations:inject": "node scripts/mockup-annotations/inject-annotations.mjs",
     "mockup-annotations:audit": "node scripts/mockup-annotations/audit-coverage.mjs",
     "typecheck": "tsc --noEmit",

--- a/apps/web/scripts/mockup-annotations/__tests__/validate-fidelity.test.ts
+++ b/apps/web/scripts/mockup-annotations/__tests__/validate-fidelity.test.ts
@@ -12,7 +12,13 @@ import { writeFileSync, unlinkSync, mkdirSync, rmSync, existsSync } from 'node:f
 import { resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 
-import { validate, FidelitySchema } from '../validate-fidelity.mjs';
+import {
+  validate,
+  FidelitySchema,
+  checkApprovalStatus,
+  computeGateVerdict,
+  P250_WAIVER_TOKEN,
+} from '../validate-fidelity.mjs';
 
 const TMP_DIR = resolve(tmpdir(), `mockup-fidelity-tests-${process.pid}`);
 
@@ -201,5 +207,128 @@ describe('FidelitySchema design_intent + viewports (DEC-P3-1+2+4)', () => {
     const result = await validate(file);
     expect(result.ok).toBe(false);
     expect(result.errors.some(e => e.includes('obsolete_tracking_issue'))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ADR-077 — Designer signoff attestation (Option D)
+// ---------------------------------------------------------------------------
+
+describe('checkApprovalStatus (ADR-077 signoff)', () => {
+  const withApprover = (design_intent: string, designer_approved_by: string) => ({
+    acceptance: { design_intent, designer_approved_by },
+  });
+
+  it('FAIL — design_intent="current" with empty designer_approved_by', () => {
+    const errors = checkApprovalStatus(withApprover('current', ''));
+    expect(errors.length).toBe(1);
+    expect(errors[0]).toContain('designer_approved_by');
+  });
+
+  it('FAIL — design_intent="current" with whitespace-only approver (trim)', () => {
+    const errors = checkApprovalStatus(withApprover('current', '   '));
+    expect(errors.length).toBe(1);
+  });
+
+  it('PASS — design_intent="current" with P250 self-waiver token', () => {
+    const errors = checkApprovalStatus(
+      withApprover('current', `user@meepleAi (${P250_WAIVER_TOKEN}, single-person team)`)
+    );
+    expect(errors).toEqual([]);
+  });
+
+  it('PASS — design_intent="current" with a real approver name', () => {
+    const errors = checkApprovalStatus(withApprover('current', 'Jane Designer'));
+    expect(errors).toEqual([]);
+  });
+
+  it('PASS (advisory) — non-current intents are not signoff-gated even when empty', () => {
+    expect(checkApprovalStatus(withApprover('forward-refactor', ''))).toEqual([]);
+    expect(checkApprovalStatus(withApprover('forward-refactor-obsolete', ''))).toEqual([]);
+    expect(checkApprovalStatus(withApprover('deferred', ''))).toEqual([]);
+  });
+
+  it('treats an absent design_intent as "current" (schema default parity)', () => {
+    const errors = checkApprovalStatus({ acceptance: { designer_approved_by: '' } });
+    expect(errors.length).toBe(1);
+  });
+});
+
+describe('validate() surfaces approvalErrors separately from structural ok', () => {
+  it('current + empty approver → structurally ok:true but approvalErrors populated', async () => {
+    const file = writeFixture('signoff-missing.fidelity.json', {
+      mockup: { source: REAL_MOCKUP, states: ['default'] },
+      acceptance: { states_covered: ['default'] }, // design_intent defaults current, approver empty
+    });
+    const result = await validate(file);
+    expect(result.ok).toBe(true); // structural validity unchanged (non-breaking)
+    expect(result.approvalErrors.length).toBe(1);
+  });
+
+  it('current + P250 waiver → ok:true, no approvalErrors', async () => {
+    const file = writeFixture('signoff-waiver.fidelity.json', {
+      mockup: { source: REAL_MOCKUP, states: ['default'] },
+      acceptance: {
+        states_covered: ['default'],
+        designer_approved_by: `dev@meepleAi (${P250_WAIVER_TOKEN}, single-person team)`,
+        designer_approved_on: '2026-06-15',
+      },
+    });
+    const result = await validate(file);
+    expect(result.ok).toBe(true);
+    expect(result.approvalErrors).toEqual([]);
+  });
+
+  it('forward-refactor + empty approver → ok:true, no approvalErrors (advisory)', async () => {
+    const file = writeFixture('fr-no-signoff.fidelity.json', {
+      mockup: { source: REAL_MOCKUP, states: ['default'] },
+      acceptance: {
+        states_covered: ['default'],
+        design_intent: 'forward-refactor',
+      },
+    });
+    const result = await validate(file);
+    expect(result.ok).toBe(true);
+    expect(result.approvalErrors).toEqual([]);
+  });
+});
+
+describe('computeGateVerdict (strict signoff + baselined structural)', () => {
+  const ok = () => ({ ok: true, approvalErrors: [] });
+  const structuralFail = () => ({ ok: false, errors: ['bad source'], approvalErrors: [] });
+  const signoffFail = () => ({ ok: true, approvalErrors: ['missing signoff'] });
+
+  it('all pass → pass:true', () => {
+    const v = computeGateVerdict([ok(), ok()], 0);
+    expect(v.pass).toBe(true);
+    expect(v.structuralFailCount).toBe(0);
+    expect(v.approvalFailCount).toBe(0);
+  });
+
+  it('structural failures within baseline, no signoff → pass:true', () => {
+    const v = computeGateVerdict([ok(), structuralFail(), structuralFail(), structuralFail()], 3);
+    expect(v.pass).toBe(true);
+    expect(v.structuralFailCount).toBe(3);
+    expect(v.overBaseline).toBe(false);
+  });
+
+  it('structural failures exceeding baseline → pass:false', () => {
+    const v = computeGateVerdict(
+      [structuralFail(), structuralFail(), structuralFail(), structuralFail()],
+      3
+    );
+    expect(v.pass).toBe(false);
+    expect(v.overBaseline).toBe(true);
+  });
+
+  it('signoff failure → pass:false regardless of baseline', () => {
+    const v = computeGateVerdict([ok(), signoffFail()], 100);
+    expect(v.pass).toBe(false);
+    expect(v.approvalFailCount).toBe(1);
+  });
+
+  it('signoff failure + structural within baseline → still pass:false', () => {
+    const v = computeGateVerdict([signoffFail(), structuralFail()], 3);
+    expect(v.pass).toBe(false);
   });
 });

--- a/apps/web/scripts/mockup-annotations/__tests__/validate-fidelity.test.ts
+++ b/apps/web/scripts/mockup-annotations/__tests__/validate-fidelity.test.ts
@@ -291,12 +291,32 @@ describe('validate() surfaces approvalErrors separately from structural ok', () 
     expect(result.ok).toBe(true);
     expect(result.approvalErrors).toEqual([]);
   });
+
+  // Regression (PR #3012 review): a schema-INVALID current file with an empty
+  // approver must still surface a signoff failure — otherwise it is silently
+  // reclassified as baseline-tolerated structural drift, violating the strict
+  // "signoff is never baselined" invariant.
+  it('current + empty approver + schema-invalid → ok:false AND approvalErrors populated', async () => {
+    const file = writeFixture('signoff-plus-schema-fail.fidelity.json', {
+      mockup: { source: REAL_MOCKUP, states: ['typo-state'] }, // fails StateName enum
+      acceptance: { states_covered: ['default'], design_intent: 'current' }, // approver empty
+    });
+    const result = await validate(file);
+    expect(result.ok).toBe(false); // structural (schema) failure
+    expect(result.approvalErrors.length).toBe(1); // signoff still flagged
+  });
 });
 
 describe('computeGateVerdict (strict signoff + baselined structural)', () => {
   const ok = () => ({ ok: true, approvalErrors: [] });
   const structuralFail = () => ({ ok: false, errors: ['bad source'], approvalErrors: [] });
   const signoffFail = () => ({ ok: true, approvalErrors: ['missing signoff'] });
+  // Schema-invalid AND missing signoff (the PR #3012 review regression case).
+  const structuralAndSignoffFail = () => ({
+    ok: false,
+    errors: ['schema'],
+    approvalErrors: ['missing signoff'],
+  });
 
   it('all pass → pass:true', () => {
     const v = computeGateVerdict([ok(), ok()], 0);
@@ -329,6 +349,15 @@ describe('computeGateVerdict (strict signoff + baselined structural)', () => {
 
   it('signoff failure + structural within baseline → still pass:false', () => {
     const v = computeGateVerdict([signoffFail(), structuralFail()], 3);
+    expect(v.pass).toBe(false);
+  });
+
+  it('schema-invalid file that ALSO misses signoff fails even with generous baseline', () => {
+    // Structural budget has ample headroom (1 <= 100) but the signoff failure is
+    // strict → pass:false. Guards the "signoff never baselined" invariant.
+    const v = computeGateVerdict([structuralAndSignoffFail()], 100);
+    expect(v.overBaseline).toBe(false);
+    expect(v.approvalFailCount).toBe(1);
     expect(v.pass).toBe(false);
   });
 });

--- a/apps/web/scripts/mockup-annotations/validate-fidelity.mjs
+++ b/apps/web/scripts/mockup-annotations/validate-fidelity.mjs
@@ -264,7 +264,13 @@ export async function validate(filePath) {
   const parsed = FidelitySchema.safeParse(raw);
   if (!parsed.success) {
     const errs = parsed.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`);
-    return { ok: false, file: filePath, errors: errs, approvalErrors: [] };
+    // Signoff is STRICT and must not be reclassifiable as baseline-tolerated
+    // structural drift when the file ALSO fails schema validation. Compute it
+    // from the raw (pre-zod) input so a design_intent:"current" file with an
+    // empty designer_approved_by is still flagged as a signoff failure even when
+    // another field is malformed (e.g. an invalid state name). checkApprovalStatus
+    // defaults an absent design_intent to "current", matching the zod schema.
+    return { ok: false, file: filePath, errors: errs, approvalErrors: checkApprovalStatus(raw) };
   }
 
   // Designer signoff attestation is computed independently of structural

--- a/apps/web/scripts/mockup-annotations/validate-fidelity.mjs
+++ b/apps/web/scripts/mockup-annotations/validate-fidelity.mjs
@@ -12,11 +12,18 @@
  * Usage:
  *   node validate-fidelity.mjs <file.json|file.yml>
  *   node validate-fidelity.mjs --all                  # scan repo for *.fidelity.{json,yml}
+ *   node validate-fidelity.mjs --all --max-baseline N # tolerate N pre-existing structural failures
  *   node validate-fidelity.mjs --schema               # print zod schema as JSON Schema
  *
+ * Designer signoff (ADR-077, Option D): design_intent="current" fidelity files
+ * MUST carry a non-empty acceptance.designer_approved_by (the "self-waiver P250"
+ * token is accepted for solo-maintainer context). Signoff failures are strict
+ * and never baselined. Structural (schema/cross-ref) failures are whitelist-
+ * incremental via --max-baseline (mirrors lint:tokens:mockups / lint:bgg-mockups).
+ *
  * Exit codes:
- *   0  all validations passed
- *   1  schema mismatch or missing referenced file
+ *   0  all validations passed (structural failures within --max-baseline; signoff OK)
+ *   1  signoff missing on a 'current' surface, OR structural failures exceed baseline
  *   2  invocation error (missing arg, file not found)
  *
  * Refs:
@@ -170,44 +177,135 @@ function crossReferenceCheck(fidelity, fidelityFilePath) {
 }
 
 // ---------------------------------------------------------------------------
+// Designer signoff attestation (ADR-077, Option D)
+// ---------------------------------------------------------------------------
+
+// A fidelity file whose design_intent is "current" represents a live design
+// surface and MUST carry a non-empty acceptance.designer_approved_by. The
+// solo-maintainer P250 self-waiver (e.g.
+// "user@meepleAi (self-waiver P250, single-person team)") is an explicitly
+// accepted approval token — it documents the developer-is-designer exception
+// rather than bypassing a real review. forward-refactor / -obsolete / deferred
+// intents are speculative or not-yet-built surfaces and are NOT approval-gated
+// (advisory only). See docs/for-claude/architecture/adr/adr-077-designer-signoff-ci-gate.md
+export const P250_WAIVER_TOKEN = 'self-waiver P250';
+
+/**
+ * Returns approval errors for a parsed fidelity object. Empty array = signoff OK.
+ * Only `design_intent: "current"` surfaces are gated. Any non-empty
+ * designer_approved_by (including the P250 self-waiver) satisfies the gate.
+ */
+export function checkApprovalStatus(fidelity) {
+  const errors = [];
+  const acc = (fidelity && fidelity.acceptance) || {};
+  // Mirror the schema default: an absent design_intent is "current".
+  const intent = acc.design_intent ?? 'current';
+  if (intent !== 'current') {
+    return errors; // advisory intents are not approval-gated
+  }
+  const approver = String(acc.designer_approved_by ?? '').trim();
+  if (!approver) {
+    errors.push(
+      `acceptance.design_intent='current' requires a non-empty acceptance.designer_approved_by. ` +
+        `Fill in the designer signoff or use the '${P250_WAIVER_TOKEN}' token for solo-maintainer ` +
+        `context (e.g. "you@meepleAi (self-waiver P250, single-person team)"). See ADR-077.`
+    );
+  }
+  return errors;
+}
+
+/**
+ * Pure gate-verdict decision over an array of validate() results.
+ *
+ * Two failure classes with different severities (ADR-077 Option D):
+ *  - approval failures: `design_intent: current` missing signoff. ALWAYS hard —
+ *    never baselined (the attestation is a deliberate 5-second ceremony).
+ *  - structural failures: schema / cross-reference errors. Whitelist-incremental
+ *    via `maxBaseline` (mirrors lint:tokens:mockups / lint:bgg-mockups) so
+ *    pre-existing drift is tolerated while NEW drift fails.
+ */
+export function computeGateVerdict(results, maxBaseline = 0) {
+  const structural = results.filter((r) => !r.ok);
+  const approval = results.filter((r) => ((r.approvalErrors && r.approvalErrors.length) || 0) > 0);
+  const structuralFailCount = structural.length;
+  const approvalFailCount = approval.length;
+  const overBaseline = structuralFailCount > maxBaseline;
+  return {
+    pass: approvalFailCount === 0 && !overBaseline,
+    structural,
+    approval,
+    structuralFailCount,
+    approvalFailCount,
+    maxBaseline,
+    overBaseline,
+    baselinedCount: Math.min(structuralFailCount, maxBaseline),
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Main validator
 // ---------------------------------------------------------------------------
 
 export async function validate(filePath) {
   if (!existsSync(filePath)) {
-    return { ok: false, file: filePath, errors: [`File not found: ${filePath}`] };
+    return { ok: false, file: filePath, errors: [`File not found: ${filePath}`], approvalErrors: [] };
   }
   if (statSync(filePath).isDirectory()) {
-    return { ok: false, file: filePath, errors: [`Path is a directory, not a file: ${filePath}`] };
+    return { ok: false, file: filePath, errors: [`Path is a directory, not a file: ${filePath}`], approvalErrors: [] };
   }
 
   let raw;
   try {
     raw = await parseFile(filePath);
   } catch (err) {
-    return { ok: false, file: filePath, errors: [`Parse error: ${err.message}`] };
+    return { ok: false, file: filePath, errors: [`Parse error: ${err.message}`], approvalErrors: [] };
   }
 
   const parsed = FidelitySchema.safeParse(raw);
   if (!parsed.success) {
     const errs = parsed.error.issues.map((i) => `${i.path.join('.')}: ${i.message}`);
-    return { ok: false, file: filePath, errors: errs };
+    return { ok: false, file: filePath, errors: errs, approvalErrors: [] };
   }
+
+  // Designer signoff attestation is computed independently of structural
+  // validity so the CLI gate can treat it as a strict (never-baselined) class.
+  const approvalErrors = checkApprovalStatus(parsed.data);
 
   const crossErrors = crossReferenceCheck(parsed.data, filePath);
   if (crossErrors.length > 0) {
-    return { ok: false, file: filePath, errors: crossErrors };
+    return { ok: false, file: filePath, errors: crossErrors, approvalErrors, data: parsed.data };
   }
 
-  return { ok: true, file: filePath, data: parsed.data };
+  return { ok: true, file: filePath, data: parsed.data, errors: [], approvalErrors };
 }
 
 // ---------------------------------------------------------------------------
 // CLI entry
 // ---------------------------------------------------------------------------
 
+/**
+ * Parse `--max-baseline N` / `--max-baseline=N`. Default 0 (strict).
+ * Caps the number of tolerated PRE-EXISTING structural (schema/cross-ref)
+ * failures; does NOT relax the strict designer-signoff attestation.
+ */
+function parseMaxBaseline(args) {
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === '--max-baseline') {
+      const v = Number(args[i + 1]);
+      return Number.isFinite(v) && v >= 0 ? Math.floor(v) : 0;
+    }
+    if (a.startsWith('--max-baseline=')) {
+      const v = Number(a.slice('--max-baseline='.length));
+      return Number.isFinite(v) && v >= 0 ? Math.floor(v) : 0;
+    }
+  }
+  return 0;
+}
+
 async function main() {
   const args = process.argv.slice(2);
+  const maxBaseline = parseMaxBaseline(args);
 
   if (args.includes('--schema')) {
     // Print zod schema as a navigable shape (simplified — full JSON Schema conversion is out of scope)
@@ -220,7 +318,13 @@ async function main() {
   if (args.includes('--all')) {
     files = globSync('**/*.fidelity.{json,yml,yaml}', {
       cwd: REPO_ROOT,
-      ignore: ['**/node_modules/**', '**/.next/**', '**/.claude/**', '**/dist/**'],
+      // templates/** holds illustrative fidelity examples (ADR-077 surface
+      // definition: doc templates are not gated design surfaces). The canonical
+      // copy-me template (docs/.../templates/examples/sp4-library-desktop.fidelity.json,
+      // referenced in CLAUDE.md) intentionally ships with a blank
+      // designer_approved_by + placeholder mockup.source — excluded here so the
+      // signoff + cross-reference gate only scans real mockup surfaces.
+      ignore: ['**/node_modules/**', '**/.next/**', '**/.claude/**', '**/dist/**', '**/templates/**'],
       absolute: true,
     });
     if (files.length === 0) {
@@ -228,28 +332,65 @@ async function main() {
       process.exit(0);
     }
   } else if (args.length === 0 || args[0].startsWith('--')) {
-    console.error('Usage: validate-fidelity.mjs <file> | --all | --schema');
+    console.error('Usage: validate-fidelity.mjs <file> | --all [--max-baseline N] | --schema');
     process.exit(2);
   } else {
     files = [resolve(args[0])];
   }
 
-  let allOk = true;
+  const results = [];
   for (const f of files) {
     const result = await validate(f);
-    const rel = relative(REPO_ROOT, f);
-    if (result.ok) {
-      console.log(`PASS  ${rel}`);
-    } else {
-      allOk = false;
-      console.error(`FAIL  ${rel}`);
-      for (const err of result.errors) {
-        console.error(`      - ${err}`);
-      }
-    }
+    result.rel = relative(REPO_ROOT, f).split('\\').join('/');
+    results.push(result);
   }
 
-  process.exit(allOk ? 0 : 1);
+  for (const r of results) {
+    const hasApproval = ((r.approvalErrors && r.approvalErrors.length) || 0) > 0;
+    if (r.ok && !hasApproval) {
+      console.log(`PASS     ${r.rel}`);
+      continue;
+    }
+    if (r.ok && hasApproval) {
+      // Structurally valid but missing the designer signoff (hard failure).
+      console.error(`SIGNOFF  ${r.rel}`);
+      for (const err of r.approvalErrors) console.error(`         - ${err}`);
+      continue;
+    }
+    // Structural failure (schema / cross-reference); may also lack signoff.
+    console.error(`FAIL     ${r.rel}`);
+    for (const err of r.errors) console.error(`         - ${err}`);
+    if (hasApproval) for (const err of r.approvalErrors) console.error(`         - [signoff] ${err}`);
+  }
+
+  const verdict = computeGateVerdict(results, maxBaseline);
+
+  console.error('');
+  console.error(
+    `Fidelity gate: ${results.length - verdict.structuralFailCount} passed structural checks, ` +
+      `${verdict.structuralFailCount} structural failure(s) (baseline ${maxBaseline}), ` +
+      `${verdict.approvalFailCount} signoff failure(s).`
+  );
+  if (verdict.approvalFailCount > 0) {
+    console.error(
+      `ERROR: ${verdict.approvalFailCount} 'current' fidelity file(s) missing designer_approved_by. ` +
+        `Signoff is strict and never baselined (ADR-077).`
+    );
+  }
+  if (verdict.structuralFailCount > 0 && !verdict.overBaseline) {
+    console.error(
+      `NOTE: ${verdict.structuralFailCount} pre-existing structural drift file(s) tolerated ` +
+        `(<= baseline ${maxBaseline}). Reconcile the mockup.source references to ratchet the baseline down.`
+    );
+  }
+  if (verdict.overBaseline) {
+    console.error(
+      `ERROR: structural failures (${verdict.structuralFailCount}) exceed baseline (${maxBaseline}). ` +
+        `A NEW fidelity file with a broken schema/cross-reference was introduced — fix it or raise the baseline deliberately.`
+    );
+  }
+
+  process.exit(verdict.pass ? 0 : 1);
 }
 
 // CLI guard — only run main() when invoked directly (not when imported as module)

--- a/docs/for-claude/architecture/adr/adr-077-designer-signoff-ci-gate.md
+++ b/docs/for-claude/architecture/adr/adr-077-designer-signoff-ci-gate.md
@@ -1,8 +1,8 @@
 # ADR-077 — Designer Signoff CI Gate
 
-**Status**: Proposed
-**Date**: 2026-06-15
-**Deciders**: @badsworm (pending ratification at PR review)
+**Status**: Accepted — Implemented 2026-07-16 ([#2997](https://github.com/meepleAi-app/meepleai-monorepo/issues/2997), umbrella #2993)
+**Date**: 2026-06-15 (proposed) · 2026-07-16 (ratified + implemented)
+**Deciders**: @badsworm
 **Tracking**: [#2363](https://github.com/meepleAi-app/meepleai-monorepo/issues/2363) Wave 4 — US-INT-6 (CI/CD quality gates)
 **Related**: [umbrella #2342](https://github.com/meepleAi-app/meepleai-monorepo/issues/2342) · mockup audit DS-17 Phase B (#2127) · fidelity.json pattern · `ci.yml`
 
@@ -31,10 +31,10 @@ This pattern acknowledges that the developer and the designer are the same perso
 - `pnpm lint:tokens` — blocking (token canonicalization).
 - `pnpm mockup-annotations:audit --threshold 80` — blocking (mockup annotation coverage).
 - `pnpm lint:bgg` — blocking (BGG URL guard).
-- `pnpm lint:fidelity` — runs but validates schema only, not approval status.
+- `pnpm lint:fidelity` — **at proposal time (2026-06-15) this ran only locally** (a `package.json` script, not referenced by any workflow) and validated schema + cross-references only, not approval status. ⚠️ Earlier drafts of this ADR erroneously described it as running "in CI"; it did not until #2997 wired it into the `frontend-lint` job.
 - `Frontend - A11y E2E` — blocking (0 axe AA violations required).
 
-The `designer_approved_by` field has no current CI enforcement. Mockups flow through the audit queue (`docs/for-developers/frontend/mockup-designer-review-queue.md`) but there is no mechanical gate preventing a PR from merging a new `design_intent: "current"` component without setting `designer_approved_by`.
+The `designer_approved_by` field had no CI enforcement at proposal time. Mockups flow through the audit queue (`docs/for-developers/frontend/mockup-designer-review-queue.md`) but there is no mechanical gate preventing a PR from merging a new `design_intent: "current"` component without setting `designer_approved_by`.
 
 **Design surface definition**: "designer review" applies to PRs that modify `apps/web/src/` components tagged with `area/frontend` **and** that implement or modify a user-facing UI surface mapped in `admin-mockups/MOCKUPS_INDEX.md`. Infrastructure-only, backend-only, and documentation PRs are explicitly excluded.
 
@@ -145,6 +145,20 @@ This maps the P250 pattern from an informal convention to a formally recognised 
 
 **Rationale**: Option A blocks too broadly (all frontend PRs, not just mockup-surface changes). Option B provides no enforcement signal. Option C adds 48h time tax + GHA bot complexity without quality benefit. Option D is surgical: it blocks only when a current-design surface is added or modified without documented approval, and explicitly codifies the solo-maintainer exception without blocking velocity.
 
+## Implementation (2026-07-16, #2997)
+
+Shipped as an extension of `validate-fidelity.mjs` + a new `frontend-lint` step, with three refinements discovered during implementation:
+
+1. **Backfill was a no-op.** The proposal (Consequences → Negative) anticipated backfilling ~38 `design_intent: "current"` fidelity files. In practice **all 72** current-intent fidelity files under `admin-mockups/design_files/` already carried the P250 self-waiver (`designer_approved_by` non-empty), so signoff enforcement shipped **strict from day one with zero backfill and zero red PRs**.
+
+2. **Two failure classes, different severity.** `validate-fidelity.mjs` now distinguishes:
+   - **Signoff failures** (`design_intent: "current"` with empty `designer_approved_by`) — **strict, never baselined**. `checkApprovalStatus()` accepts any non-empty approver; the `self-waiver P250` token is the documented solo-maintainer form.
+   - **Structural failures** (schema / `mockup.source` cross-reference) — **whitelist-incremental** via `--max-baseline N` (mirrors `lint:tokens:mockups` / `lint:bgg-mockups`). Baseline set to **3** for the pre-existing orphaned fidelity files whose source mockups were deleted (`sp4-play-records-data`, `scaffold`, `pr-form-core`). Reconcile these to ratchet the baseline down. A NEW structural failure (4th) fails the gate.
+
+3. **Doc templates excluded.** `--all` now ignores `**/templates/**`. The canonical copy-me template `docs/for-developers/frontend/templates/examples/sp4-library-desktop.fidelity.json` (referenced in CLAUDE.md) intentionally ships with a blank `designer_approved_by` + placeholder `mockup.source` — it is an illustration, not a gated design surface (per the "Design surface definition" above).
+
+**Wiring**: `pnpm lint:fidelity` (= `validate-fidelity.mjs --all --max-baseline 3`) runs as the `Designer signoff + fidelity gate (ADR-077 / #2997)` step in the `ci.yml` `frontend-lint` job — active on PRs targeting `main` / `main-staging` (the release boundary), same trigger scope as the sibling mockup/token/BGG gates. Unit coverage: `apps/web/scripts/mockup-annotations/__tests__/validate-fidelity.test.ts` (`checkApprovalStatus` + `computeGateVerdict` + `validate()` `approvalErrors`).
+
 ## Consequences
 
 **Positive**:
@@ -154,8 +168,8 @@ This maps the P250 pattern from an informal convention to a formally recognised 
 - `forward-refactor` and `forward-refactor-obsolete` files remain advisory — no friction for speculative design work.
 
 **Negative**:
-- Requires existing `design_intent: "current"` fidelity files with empty `designer_approved_by` to be backfilled (either with the P250 waiver or with a genuine approval) before the gate is enabled. Audit scope: ~38 `design_intent: "current"` fidelity files (per DS-17 Phase B audit count).
-- If the gate is enabled before backfill, any PR that touches a fidelity file with empty `designer_approved_by` will fail CI — gate should be enabled only after the backfill PR merges.
+- ~~Requires existing `design_intent: "current"` fidelity files with empty `designer_approved_by` to be backfilled before the gate is enabled.~~ **Resolved at implementation**: all 72 current-intent fidelity files already carried the P250 waiver, so no backfill was needed (see Implementation § 1).
+- 3 pre-existing structurally-orphaned fidelity files (deleted `mockup.source`) are tolerated via `--max-baseline 3` rather than fixed in this PR (out of the strict "designer signoff" scope). They remain as tracked drift to reconcile.
 
 **Trade-offs**:
 - The gate does not prevent a developer from pre-filling the self-waiver without actually reviewing the design. The gate is a documentation discipline tool, not a proof-of-review mechanism. In a solo-maintainer context, this is the correct trade-off: the waiver documents the exception, not bypasses a real review.
@@ -169,7 +183,7 @@ This maps the P250 pattern from an informal convention to a formally recognised 
      - Otherwise (real approver name) → pass.
    - For `design_intent != "current"`: emit advisory warning only, do not fail.
 
-2. **Backfill PR**: before enabling the check, submit a single PR that populates `designer_approved_by: "badsworm@gmail.com (self-waiver P250, single-person team)"` and `designer_approved_on: "2026-06-15"` on all existing `design_intent: "current"` fidelity files with empty approval fields.
+2. **Backfill PR**: ✅ **not required** — all `design_intent: "current"` fidelity files already carried the P250 self-waiver when #2997 shipped (see Implementation § 1). Had any been empty, the recommended value was `designer_approved_by: "<you>@meepleAi (self-waiver P250, single-person team)"` + `designer_approved_on: "<ISO date>"`.
 
 3. **CI integration** (`ci.yml`): add `pnpm lint:fidelity:approvals` (or extend the existing `pnpm lint:fidelity` script) as a step in the frontend job, after the existing `pnpm lint:fidelity` schema validation. Gate on `if: steps.changes.outputs.frontend == 'true'` (same condition as other frontend checks).
 

--- a/docs/for-developers/frontend/mockup-fidelity-acceptance.md
+++ b/docs/for-developers/frontend/mockup-fidelity-acceptance.md
@@ -20,7 +20,7 @@ Ogni mockup migration deve essere accompagnata da un file `<mockup-name>.fidelit
 
 - ✅ **Phase 2+** (DS-17-6): ogni story `*.stories.tsx` deve avere `*.fidelity.yml` co-located
 - ✅ **Phase 1** (oggi): pilot per `sp4-dashboard` come standalone esempio
-- ⏭️ **Phase 3**: enforcement designer sign-off (campi `designer_approved_by` + `designer_approved_on` required pre-merge)
+- ✅ **Signoff gate SHIPPED** (#2997, [ADR-077](../../for-claude/architecture/adr/adr-077-designer-signoff-ci-gate.md)): `designer_approved_by` **required non-empty** per ogni `design_intent: "current"`, enforced in CI via `pnpm lint:fidelity` (step `frontend-lint`). Il token `self-waiver P250` è un'approvazione accettata (contesto solo-maintainer).
 - ⏭️ **Phase 4**: visual gate scoped legge `visual_diff_max_px` + `color_delta_e_max` come threshold
 
 ---
@@ -87,7 +87,11 @@ Breakpoint px da testare. Default copre mobile/tablet/desktop/wide.
 
 ### `acceptance.designer_approved_by` (string, default "")
 
-GitHub handle del designer che ha approvato (es. `@design-lead`). Required Phase 3+.
+Approvazione del designer. **Enforced (#2997, ADR-077)**: per `design_intent: "current"` deve essere **non-vuoto** o il gate `pnpm lint:fidelity` fallisce (signoff strict, mai baselined). Valori accettati:
+- Nome/handle reale del designer (es. `Jane Designer`, `@design-lead`).
+- Token solo-maintainer `self-waiver P250`, es. `"you@meepleAi (self-waiver P250, single-person team)"` — documenta l'eccezione developer-è-designer.
+
+Intenti `forward-refactor` / `forward-refactor-obsolete` / `deferred` **non** sono signoff-gated (advisory: superfici speculative o non-ancora-costruite).
 
 ### `acceptance.designer_approved_on` (string ISO date, default "")
 
@@ -111,10 +115,11 @@ node apps/web/scripts/mockup-annotations/validate-fidelity.mjs docs/for-develope
 # PASS  docs/for-developers/frontend/templates/examples/sp4-dashboard.fidelity.json
 ```
 
-### Scan all fidelity files in repo
+### Scan all fidelity files in repo (CI gate)
 ```bash
-node apps/web/scripts/mockup-annotations/validate-fidelity.mjs --all
+pnpm lint:fidelity   # = validate-fidelity.mjs --all --max-baseline 3
 ```
+`--all` esclude `**/templates/**` (i file di esempio in `templates/examples/` sono illustrazioni, non superfici gated). `--max-baseline N` tollera fino a N fallimenti **strutturali** pre-esistenti (schema / `mockup.source` cross-ref); NON rilassa il signoff (sempre strict). Baseline attuale = 3 (fidelity orfani con `mockup.source` cancellato: `sp4-play-records-data` / `scaffold` / `pr-form-core` — da riconciliare per abbassare la baseline).
 
 ### Print schema
 ```bash
@@ -125,8 +130,8 @@ node apps/web/scripts/mockup-annotations/validate-fidelity.mjs --schema
 
 | Code | Meaning |
 |------|---------|
-| 0 | All validations passed |
-| 1 | Schema mismatch or missing referenced file |
+| 0 | Signoff OK **e** fallimenti strutturali ≤ `--max-baseline` |
+| 1 | Signoff mancante su una superficie `current`, **oppure** fallimenti strutturali oltre baseline |
 | 2 | Invocation error (missing arg, file not found) |
 
 ---
@@ -161,7 +166,7 @@ or wait for Phase 2 (DS-17-5) which adds yaml devDep. Template .yml is reference
 - ❌ **`tokens_used: mixed_legacy_allowed` permanente** → waiver dovrebbe essere temporary con TODO in commit
 - ❌ **`states_covered` ≠ `mockup.states`** → validator FAIL (set inequality)
 - ❌ **Path mockup.source relativo al fidelity file** → validator richiede path relativo al repo root
-- ❌ **Skip designer sign-off Phase 3+** → contro DEC-3 spec doc, blocking gate (Phase 4)
+- ❌ **`design_intent: "current"` con `designer_approved_by` vuoto** → gate `pnpm lint:fidelity` FAIL (#2997, ADR-077). Compila il signoff o usa il token `self-waiver P250`.
 
 ---
 


### PR DESCRIPTION
## Summary

Ships **ADR-077 (Option D)** — the designer signoff attestation gate — and corrects the ADR's stale "runs in CI" claim.

Previously `validate-fidelity.mjs` *read* `designer_approved_by` but never enforced it, and `pnpm lint:fidelity` ran **only locally** (never referenced by any workflow), so the ADR's claim that it "runs in CI" was false.

## What changed

- **`validate-fidelity.mjs`**
  - `checkApprovalStatus()` — `design_intent: "current"` fidelity files MUST carry a non-empty `acceptance.designer_approved_by`. The `self-waiver P250` token is an accepted approval (solo-maintainer developer-is-designer exception). `forward-refactor` / `-obsolete` / `deferred` intents are advisory (not gated).
  - `computeGateVerdict()` — two failure classes: **signoff** (strict, never baselined) + **structural** (schema / `mockup.source` cross-ref, whitelist-incremental via `--max-baseline`).
  - `--all` now excludes `**/templates/**` (doc illustration fidelity files, incl. the canonical copy-me template with an intentionally blank approver — not a gated surface per the ADR's surface definition).
- **`ci.yml`** — `pnpm lint:fidelity` wired as the `Designer signoff + fidelity gate (ADR-077 / #2997)` step in `frontend-lint`.
- **`package.json`** — `lint:fidelity` → `... --all --max-baseline 3`.
- **ADR-077** — Proposed → Accepted/Implemented; stale "runs in CI" claim corrected; documents the zero-backfill reality.
- **Docs** — `mockup-fidelity-acceptance.md` refreshed.
- **Tests** — `validate-fidelity.test.ts` +15 cases (signoff + verdict + `approvalErrors`), 29/29 green.

## Why no "sea of red"

- All **72** `design_intent: "current"` fidelity files already carry the P250 waiver → **0 backfill needed**, signoff strict from day one.
- 3 pre-existing structural orphans (deleted `mockup.source`: `sp4-play-records-data` / `scaffold` / `pr-form-core`) are tolerated via `--max-baseline 3` (repo `--max-baseline` convention). Signoff stays strict; a NEW structural drift (4th) or a new `current` file without approver fails the gate.

## Verification (local)

- `pnpm lint:fidelity` → exit 0 (93 pass, 3 baselined structural, 0 signoff failures).
- Single-file smoke: `current` + empty approver → exit 1 (SIGNOFF); + P250 waiver → exit 0.
- `vitest run validate-fidelity.test.ts` → 29/29.

> Non-blocking-by-design note: the gate is strict but wired into `ci.yml` which runs on PRs to `main`/`main-staging` (the release boundary), same trigger scope as the sibling mockup/token/BGG gates.

Closes #2997 (umbrella 2993)

🤖 Generated with [Claude Code](https://claude.com/claude-code)