### PR TITLE
feat(ci): #2998 implement State Matrix Sync + Enforcement gate

### DIFF
--- a/.github/release-gates.yml
+++ b/.github/release-gates.yml
@@ -193,7 +193,7 @@ checks:
     owner: devops
     override_path: fix-forward
     pre_existing_in_main_dev: false
-    notes: "Verifies v2-migration-matrix.md consistency. Failure indicates row drift vs implementation."
+    notes: "Implemented #2998 via .github/workflows/state-matrix-sync.yml (scripts/v2_audit --check). Non-blocking: v2-migration-matrix.md row drift is reported as ::warning:: annotations (exit 0), so drift alone never reds this check — a red status means the v2_audit self-tests regressed. Reconcile drift fix-forward. Matrix sync is now automated (was manual)."
 
   - check_name: "codecov/patch"
     severity: warning

--- a/.github/workflows/state-matrix-sync.yml
+++ b/.github/workflows/state-matrix-sync.yml
@@ -1,0 +1,72 @@
+# State Matrix Sync + Enforcement (#2998, umbrella 2342/2993)
+#
+# Automates the previously-manual consistency check between
+# docs/for-developers/frontend/v2-migration-matrix.md and the codebase.
+# Runs the `scripts/v2_audit` Phase-A drift detector (matrix rows whose
+# component/mockup path no longer exists) and reports drift as GitHub
+# ::warning:: annotations + a step summary.
+#
+# Severity: WARNING / NON-BLOCKING by design (coherent with the pre-registered
+# `State Matrix Sync + Enforcement` entry in .github/release-gates.yml).
+#   - This workflow is NOT in branch-protection required checks.
+#   - The `--check` step exits 0 regardless of drift (pure report), so drift
+#     alone can never turn the check red. A red status can only come from the
+#     module self-tests (a regression in the gate's own code).
+#   - To promote drift to an enforced ceiling later, add `--max-baseline <N>`
+#     to the --check step (N = a drift count captured from a green CI run); the
+#     step then exits 1 when drift exceeds N. Left off intentionally for now.
+#
+# This workflow does NOT create GitHub issues (scripts/v2_audit/create_issues.py
+# is a separate, opt-in cron concern that WOULD require `issues: write` + the
+# ADR-078 `concurrency: group: monitor-<type>-...` convention). Keeping this a
+# read-only PR gate avoids those requirements.
+
+name: State Matrix Sync
+
+on:
+  pull_request:
+    branches: [main-dev, main-staging, main]
+    paths:
+      - 'docs/for-developers/frontend/v2-migration-matrix.md'
+      - 'apps/web/src/components/**'
+      - 'admin-mockups/design_files/**'
+      - 'scripts/v2_audit/**'
+      - '.github/workflows/state-matrix-sync.yml'
+  workflow_dispatch:
+
+# Cancel superseded runs for the same PR/branch (run hygiene; not the ADR-078
+# monitor-concurrency case — this workflow is PR-triggered and calls no Issues API).
+concurrency:
+  group: state-matrix-sync-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  state-matrix-sync:
+    name: State Matrix Sync + Enforcement
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install test deps
+        run: python -m pip install --disable-pip-version-check pytest
+
+      # Self-test the drift classifier + parser before trusting its output.
+      # A failure here means the gate's OWN code regressed — surfaces as a red
+      # (non-required, so non-blocking) check.
+      - name: v2_audit self-tests
+        run: python -m pytest scripts/v2_audit/tests -q
+
+      # State Matrix Sync: report v2-migration-matrix.md drift as non-blocking
+      # ::warning:: annotations + a step summary. Exits 0 (no --max-baseline).
+      - name: Matrix sync drift report (non-blocking)
+        run: python -m scripts.v2_audit.run --check

--- a/docs/for-developers/frontend/v2-migration-matrix.md
+++ b/docs/for-developers/frontend/v2-migration-matrix.md
@@ -18,6 +18,15 @@ row binds a mockup definition to a target component path, route, and acceptance 
 so that downstream PRs can pick up an entry and turn it from `pending` → `done` without
 ambiguity. Each route is also classified by **Tier** (S/M/L) to gate dispatch strategy.
 
+> **🔗 Automated sync (2026-07-16, #2998)**: consistency between this matrix and the
+> codebase is no longer maintained purely by hand. The **State Matrix Sync + Enforcement**
+> CI gate (`.github/workflows/state-matrix-sync.yml`, driven by `scripts/v2_audit/run.py --check`)
+> runs on PRs that touch this matrix, `apps/web/src/components/**`, `admin-mockups/design_files/**`,
+> or `scripts/v2_audit/**`, and reports every `done` row whose component/mockup path no longer
+> exists as a **non-blocking** `::warning::` annotation + a step summary. It never blocks merge
+> (registered `severity: warning` in `.github/release-gates.yml`); reconcile flagged rows
+> fix-forward. Run it locally with `python -m scripts.v2_audit.run --check`.
+
 > **Updated 2026-04-30** (Wave B.2 spec-panel review): count refined 46 → 45.
 > `AgentsSidebarList` + `AgentDetailPanel` removed from `/agents` row set (mockup
 > `sp4-agents-index.jsx` is grid-pattern only, not master-detail). `AgentsResultsGrid`

--- a/scripts/v2_audit/run.py
+++ b/scripts/v2_audit/run.py
@@ -2,18 +2,26 @@
 
 Usage:
   python -m scripts.v2_audit.run [--dry-run] [--limit N]
+  python -m scripts.v2_audit.run --check [--max-baseline N]
 
 Phase A: parse matrix, validate paths.
 Phase B: per row, run 4 dimension audits.
 Phase C: write report + input snapshot.
+
+--check runs Phase A ONLY as the "State Matrix Sync + Enforcement" gate: it
+reports v2-migration-matrix.md rows whose component/mockup path no longer exists
+(drift) as NON-BLOCKING GitHub Actions ::warning:: annotations + a step summary.
+It exits 0 unless --max-baseline N is given AND drift exceeds N (opt-in strict
+ceiling; the CI workflow runs without a baseline so it never blocks merge).
 """
 from __future__ import annotations
 from pathlib import Path
 import argparse
 import json
+import os
 import sys
 
-from scripts.v2_audit.matrix_parser import parse_matrix
+from scripts.v2_audit.matrix_parser import parse_matrix_with_skipped
 from scripts.v2_audit.component_inspector import inspect_component
 from scripts.v2_audit.mockup_inspector import inspect_mockup
 from scripts.v2_audit.nav_dimension import audit_nav
@@ -24,13 +32,45 @@ from scripts.v2_audit.report_builder import build_report
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 MATRIX_PATH = REPO_ROOT / "docs" / "for-developers" / "frontend" / "v2-migration-matrix.md"
+MATRIX_REL = "docs/for-developers/frontend/v2-migration-matrix.md"
 MOCKUPS_DIR = REPO_ROOT / "admin-mockups" / "design_files"
 REPORT_PATH = REPO_ROOT / "docs" / "superpowers" / "specs" / "audit-report.md"
 INPUT_SNAPSHOT_PATH = REPO_ROOT / "docs" / "superpowers" / "specs" / "audit-input-validated.json"
 
 
+def classify_rows(rows, repo_root: Path = REPO_ROOT, mockups_dir: Path = MOCKUPS_DIR):
+    """Partition matrix rows into (drift, valid).
+
+    drift: list[(component, missing_path_str)] — a row is drift when its component
+           path OR its mockup file no longer exists (a sibling `.jsx` is accepted
+           as a fallback for a missing `.html`/other mockup).
+    valid: list[(row, comp_path, mockup_path)] — rows ready for the deep audit.
+
+    This is the single source of truth for the "matrix consistency" check shared
+    by run_audit (Phase A) and check_matrix_sync (the CI gate).
+    """
+    drift: list[tuple[str, str]] = []
+    valid: list = []
+    for row in rows:
+        comp_path = repo_root / row.path
+        mockup_path = mockups_dir / row.mockup
+        if not comp_path.exists():
+            drift.append((row.component, row.path))
+            continue
+        if not mockup_path.exists():
+            mockup_jsx = mockup_path.with_suffix(".jsx")
+            if mockup_jsx.exists():
+                mockup_path = mockup_jsx
+            else:
+                # Repo-relative, forward-slash path — symmetric with the
+                # component-missing case (row.path) and CI-portable in reports.
+                drift.append((row.component, mockup_path.relative_to(repo_root).as_posix()))
+                continue
+        valid.append((row, comp_path, mockup_path))
+    return drift, valid
+
+
 def run_audit(limit: int | None = None, dry_run: bool = False) -> dict:
-    from scripts.v2_audit.matrix_parser import parse_matrix_with_skipped
     rows, skipped_done_lines = parse_matrix_with_skipped(MATRIX_PATH)
     if limit:
         rows = rows[:limit]
@@ -38,25 +78,7 @@ def run_audit(limit: int | None = None, dry_run: bool = False) -> dict:
     if skipped_done_lines:
         print(f"Phase A: {len(skipped_done_lines)} done rows SKIPPED by strict parser (see snapshot)")
 
-    matrix_drift = []
-    valid_rows = []
-
-    for row in rows:
-        comp_path = REPO_ROOT / row.path
-        mockup_path = MOCKUPS_DIR / row.mockup
-
-        if not comp_path.exists():
-            matrix_drift.append((row.component, row.path))
-            continue
-        if not mockup_path.exists():
-            mockup_jsx = mockup_path.with_suffix(".jsx")
-            if mockup_jsx.exists():
-                mockup_path = mockup_jsx
-            else:
-                matrix_drift.append((row.component, str(mockup_path)))
-                continue
-
-        valid_rows.append((row, comp_path, mockup_path))
+    matrix_drift, valid_rows = classify_rows(rows)
 
     print(f"Phase A: {len(matrix_drift)} matrix drift entries; {len(valid_rows)} ready for audit")
 
@@ -142,11 +164,101 @@ def run_audit(limit: int | None = None, dry_run: bool = False) -> dict:
     return stats
 
 
+def _write_step_summary(rows, skipped, valid, drift, max_baseline) -> None:
+    """Write a Markdown summary to $GITHUB_STEP_SUMMARY (no-op outside Actions)."""
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not summary_path:
+        return
+    lines = [
+        "## 🔗 State Matrix Sync + Enforcement",
+        "",
+        f"- Matrix: `{MATRIX_REL}`",
+        f"- `done` rows parsed: **{len(rows)}** ({len(skipped)} skipped by the strict parser)",
+        f"- Valid (component + mockup both exist): **{len(valid)}**",
+        (
+            f"- Drifted (component/mockup missing): **{len(drift)}**"
+            + (f" · baseline `{max_baseline}`" if max_baseline is not None else " · _non-blocking report_")
+        ),
+        "",
+    ]
+    if drift:
+        lines.append("<details><summary>Drifted rows</summary>")
+        lines.append("")
+        lines.append("| Component | Missing path |")
+        lines.append("|---|---|")
+        for comp, path in drift:
+            lines.append(f"| `{comp}` | `{path}` |")
+        lines.append("")
+        lines.append("</details>")
+    else:
+        lines.append("✅ No matrix drift.")
+    lines.append("")
+    with open(summary_path, "a", encoding="utf-8") as fh:
+        fh.write("\n".join(lines) + "\n")
+
+
+def check_matrix_sync(max_baseline: int | None = None) -> int:
+    """State Matrix Sync gate (Phase A only). Reports v2-migration-matrix.md drift.
+
+    NON-BLOCKING by design: emits GitHub ::warning:: annotations + a step summary
+    and returns 0, UNLESS max_baseline is set and drift exceeds it (opt-in strict
+    ceiling). The CI workflow runs without a baseline, so a red status can only
+    come from the module self-tests, never from drift — keeping this a warning.
+    """
+    rows, skipped = parse_matrix_with_skipped(MATRIX_PATH)
+    drift, valid = classify_rows(rows)
+    n_drift = len(drift)
+    in_actions = os.environ.get("GITHUB_ACTIONS") == "true"
+
+    print(
+        f"State Matrix Sync: {len(rows)} 'done' rows parsed "
+        f"({len(skipped)} skipped by strict parser); {len(valid)} valid, {n_drift} drifted."
+    )
+    for comp, path in drift[:50]:
+        print(f"  DRIFT  {comp} -> {path}")
+    if n_drift > 50:
+        print(f"  ... and {n_drift - 50} more (see step summary).")
+
+    if in_actions and n_drift:
+        # GitHub caps rendered ::warning:: annotations (~10) — emit one headline
+        # plus a handful of examples rather than spamming one per drift row.
+        print(
+            f"::warning file={MATRIX_REL}::State Matrix Sync: {n_drift} row(s) in "
+            f"{MATRIX_REL} reference a component/mockup that no longer exists (drift). "
+            f"Reconcile the matrix rows (see step summary)."
+        )
+        for comp, path in drift[:9]:
+            print(f"::warning file={MATRIX_REL}::drift: {comp} -> {path}")
+
+    _write_step_summary(rows, skipped, valid, drift, max_baseline)
+
+    if max_baseline is not None and n_drift > max_baseline:
+        print(
+            f"::error file={MATRIX_REL}::State Matrix drift ({n_drift}) exceeds "
+            f"baseline ({max_baseline})."
+        )
+        return 1
+    return 0
+
+
 def main(argv=None):
     p = argparse.ArgumentParser()
     p.add_argument("--limit", type=int, help="Audit only first N rows")
     p.add_argument("--dry-run", action="store_true", help="Phase A only")
+    p.add_argument(
+        "--check",
+        action="store_true",
+        help="State Matrix Sync gate: report matrix drift (Phase A) as non-blocking warnings",
+    )
+    p.add_argument(
+        "--max-baseline",
+        type=int,
+        default=None,
+        help="With --check: exit 1 if drift exceeds this ceiling (opt-in strict; omit for a non-blocking report)",
+    )
     args = p.parse_args(argv)
+    if args.check:
+        return check_matrix_sync(max_baseline=args.max_baseline)
     run_audit(limit=args.limit, dry_run=args.dry_run)
     return 0
 

--- a/scripts/v2_audit/tests/test_mockup_inspector.py
+++ b/scripts/v2_audit/tests/test_mockup_inspector.py
@@ -1,19 +1,22 @@
 from pathlib import Path
 from scripts.v2_audit.mockup_inspector import inspect_mockup, MockupSnapshot
 
-REAL_MOCKUP = Path("admin-mockups/design_files/sp4-game-detail.html")
+# Anchor to repo root so the test is cwd-independent, and target a STABLE mockup.
+# (sp4-game-detail.html was deleted during mockup churn — #2998 fix.)
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+REAL_MOCKUP = _REPO_ROOT / "admin-mockups" / "design_files" / "sp4-dashboard.html"
 
 
 def test_inspect_real_mockup_landmarks():
     snap = inspect_mockup(REAL_MOCKUP)
-    # sp4-game-detail.html should have at least one landmark and one heading
+    # sp4-dashboard.html has HTML landmarks (header/section) and headings (h1..h3)
     assert len(snap.landmarks) >= 1
     assert snap.headings
 
 
 def test_inspect_extracts_link_destinations():
     snap = inspect_mockup(REAL_MOCKUP)
-    # After Phase 1, sp4-game-detail has wired hrefs to actual mockups
+    # sp4-dashboard has wired hrefs to actual .html mockups
     assert any(".html" in dest for dest in snap.link_destinations)
 
 

--- a/scripts/v2_audit/tests/test_run.py
+++ b/scripts/v2_audit/tests/test_run.py
@@ -1,0 +1,87 @@
+"""Tests for run.classify_rows — the matrix-drift classification that powers
+both the deep audit (Phase A) and the State Matrix Sync gate (#2998)."""
+from scripts.v2_audit.matrix_parser import MatrixRow
+from scripts.v2_audit.run import classify_rows
+
+
+def _row(component: str, path: str, mockup: str) -> MatrixRow:
+    return MatrixRow(
+        mockup=mockup, component=component, path=path, route="/x", status="done", pr="#1"
+    )
+
+
+def test_classify_valid_row(tmp_path):
+    repo = tmp_path
+    mockups = repo / "mock"
+    mockups.mkdir()
+    (repo / "comp.tsx").write_text("x", encoding="utf-8")
+    (mockups / "m.html").write_text("x", encoding="utf-8")
+
+    drift, valid = classify_rows([_row("Good", "comp.tsx", "m.html")], repo_root=repo, mockups_dir=mockups)
+
+    assert drift == []
+    assert len(valid) == 1
+    row, comp_path, mockup_path = valid[0]
+    assert row.component == "Good"
+    assert comp_path == repo / "comp.tsx"
+    assert mockup_path == mockups / "m.html"
+
+
+def test_classify_drift_missing_component(tmp_path):
+    repo = tmp_path
+    mockups = repo / "mock"
+    mockups.mkdir()
+    (mockups / "m.html").write_text("x", encoding="utf-8")  # mockup exists, component does not
+
+    drift, valid = classify_rows([_row("NoComp", "missing.tsx", "m.html")], repo_root=repo, mockups_dir=mockups)
+
+    assert valid == []
+    assert drift == [("NoComp", "missing.tsx")]  # reports the (repo-relative) component path
+
+
+def test_classify_drift_missing_mockup(tmp_path):
+    repo = tmp_path
+    mockups = repo / "mock"
+    mockups.mkdir()
+    (repo / "comp.tsx").write_text("x", encoding="utf-8")  # component exists, mockup does not
+
+    drift, valid = classify_rows([_row("NoMock", "comp.tsx", "gone.html")], repo_root=repo, mockups_dir=mockups)
+
+    assert valid == []
+    assert len(drift) == 1
+    comp, path = drift[0]
+    assert comp == "NoMock"
+    assert path == "mock/gone.html"  # repo-relative, forward-slash
+
+
+def test_classify_jsx_fallback_for_missing_html(tmp_path):
+    repo = tmp_path
+    mockups = repo / "mock"
+    mockups.mkdir()
+    (repo / "comp.tsx").write_text("x", encoding="utf-8")
+    (mockups / "m.jsx").write_text("x", encoding="utf-8")  # .html missing, sibling .jsx present
+
+    drift, valid = classify_rows([_row("JsxFallback", "comp.tsx", "m.html")], repo_root=repo, mockups_dir=mockups)
+
+    assert drift == []
+    assert len(valid) == 1
+    assert valid[0][2].name == "m.jsx"  # resolved to the .jsx sibling
+
+
+def test_classify_mixed_batch(tmp_path):
+    repo = tmp_path
+    mockups = repo / "mock"
+    mockups.mkdir()
+    (repo / "ok.tsx").write_text("x", encoding="utf-8")
+    (mockups / "ok.html").write_text("x", encoding="utf-8")
+
+    rows = [
+        _row("Ok", "ok.tsx", "ok.html"),
+        _row("BadComp", "nope.tsx", "ok.html"),
+        _row("BadMock", "ok.tsx", "nope.html"),
+    ]
+    drift, valid = classify_rows(rows, repo_root=repo, mockups_dir=mockups)
+
+    assert len(valid) == 1
+    assert len(drift) == 2
+    assert {c for c, _ in drift} == {"BadComp", "BadMock"}


### PR DESCRIPTION
## Summary

Implements the **State Matrix Sync + Enforcement** check that was *registered* in `.github/release-gates.yml` (`severity: warning`) but had **no workflow behind it** — the `scripts/v2_audit` drift logic was referenced by zero workflows and `v2-migration-matrix.md` was reconciled by hand.

## What changed

- **`scripts/v2_audit/run.py`**
  - New `--check` mode = the gate: Phase-A drift detection reporting `v2-migration-matrix.md` rows whose component/mockup path no longer exists, as **non-blocking** GitHub `::warning::` annotations + a `$GITHUB_STEP_SUMMARY` table.
  - Extracted `classify_rows()` as the single drift classifier (DRY: `run_audit` Phase A + `check_matrix_sync` now share it; behavior preserved — verified `--dry-run` unchanged: 113 drift / 5 valid).
  - `--max-baseline N` is an **opt-in** strict ceiling (exit 1 if drift > N); the CI workflow runs **without** it → exit 0, drift never blocks merge.
  - Drift paths normalized to repo-relative forward-slash; dropped a dead `parse_matrix` import.
- **`.github/workflows/state-matrix-sync.yml`** (new) — job named exactly `State Matrix Sync + Enforcement` (matches the registered gate so the release-gate bot classifies it). Runs the `v2_audit` self-tests + the `--check` drift report on PRs touching the matrix / components / mockups / `scripts/v2_audit`. **Non-blocking by design** (`permissions: contents: read`, no issue creation → ADR-078 monitor-concurrency N/A; a normal `concurrency` group for run hygiene).
- **`.github/release-gates.yml`** — note updated to describe the actual (non-blocking) behavior.
- **`scripts/v2_audit/tests`** — fixed 2 pre-existing failures (`test_mockup_inspector` referenced the deleted `sp4-game-detail.html` fixture → stable `sp4-dashboard.html`, repo-root anchored) + new `test_run.py` (`classify_rows`). **56/56 green** (was 49 pass / 2 fail).
- **`v2-migration-matrix.md`** — documents that sync is now automated.

## Non-blocking guarantee

`--check` exits 0 regardless of drift (pure report). A red status can only come from the `v2_audit` self-tests (a regression in the gate's own code). The check is a brand-new, non-required status → never blocks merge. `severity: warning` in `release-gates.yml`.

## Verification (local)

- `python -m pytest scripts/v2_audit/tests -q` → 56 passed.
- `python -m scripts.v2_audit.run --check` → exit 0 (reports 113 drift as warnings + summary); `--max-baseline 0` → exit 1; `--max-baseline 99999` → exit 0.
- Both workflow YAMLs validate; job name matches the registered gate.

This gate runs on THIS PR (base `main-dev` + touches `scripts/v2_audit/**`), so it self-demonstrates.

Closes #2998 (umbrella 2993/2342)

🤖 Generated with [Claude Code](https://claude.com/claude-code)