### PR TITLE
fix(mechanic-extractor): #2953 ME E2E polish (4 fix)

### DIFF
--- a/apps/api/src/Api/Middleware/ApiExceptionHandlerMiddleware.cs
+++ b/apps/api/src/Api/Middleware/ApiExceptionHandlerMiddleware.cs
@@ -59,14 +59,34 @@ internal class ApiExceptionHandlerMiddleware
 
     private async Task HandleExceptionAsync(HttpContext context, Exception ex)
     {
-        // Log the exception with full details
         var sanitizedPath = LogSanitizer.SanitizePath(context.Request.Path);
+        var sanitizedMethod = LogSanitizer.Sanitize(context.Request.Method);
 
-        _logger.LogError(ex,
-            "Unhandled exception in API endpoint. Path: {Path}, Method: {Method}, TraceId: {TraceId}",
-            sanitizedPath,
-            LogSanitizer.Sanitize(context.Request.Method),
-            context.TraceIdentifier);
+        // #2953 (#6): classify severity up-front. Expected client errors (4xx, e.g. NotFound)
+        // log Warning and are NOT counted as unhandled, so they don't pollute error dashboards
+        // or mask real 500s. The branch-specific handlers below keep their own status + metrics;
+        // this generic mapping drives the shared log level and — on the generic path — the
+        // status/isUnhandled reused further down.
+        var (statusCode, errorType, message) = MapExceptionToResponse(ex);
+        var isServerError = statusCode >= 500;
+
+        if (isServerError)
+        {
+            _logger.LogError(ex,
+                "Unhandled exception in API endpoint. Path: {Path}, Method: {Method}, TraceId: {TraceId}",
+                sanitizedPath,
+                sanitizedMethod,
+                context.TraceIdentifier);
+        }
+        else
+        {
+            _logger.LogWarning(ex,
+                "Handled {StatusCode} client error in API endpoint. Path: {Path}, Method: {Method}, TraceId: {TraceId}",
+                statusCode,
+                sanitizedPath,
+                sanitizedMethod,
+                context.TraceIdentifier);
+        }
 
         // Special handling for FluentValidation exceptions (Issue #1449)
         if (ex is FluentValidation.ValidationException fluentValidationEx)
@@ -115,17 +135,17 @@ internal class ApiExceptionHandlerMiddleware
             return;
         }
 
-        // Determine status code and error type based on exception type
-        var (statusCode, errorType, message) = MapExceptionToResponse(ex);
-
-        // OPS-05: Record error metrics for monitoring and alerting
-        // Use route pattern for endpoint to avoid high cardinality (e.g., /api/v1/games instead of /api/v1/games/{id})
+        // OPS-05: Record error metrics for monitoring and alerting. Reuses the status computed
+        // above. Use route pattern for endpoint to avoid high cardinality (e.g., /api/v1/games
+        // instead of /api/v1/games/{id}).
+        // #2953 (#6): isUnhandled tracks genuine server errors only — an expected 4xx that reached
+        // here (e.g. NotFound) is handled-by-mapping, not an unhandled bug.
         var endpoint = GetRoutePattern(context) ?? context.Request.Path.ToString();
         MeepleAiMetrics.RecordApiError(
             exception: ex,
             httpStatusCode: statusCode,
             endpoint: endpoint,
-            isUnhandled: true); // This is unhandled since it reached middleware
+            isUnhandled: isServerError);
 
         context.Response.StatusCode = statusCode;
         context.Response.ContentType = "application/json";

--- a/apps/api/src/Api/Services/LlmClients/DeepSeekLlmClient.cs
+++ b/apps/api/src/Api/Services/LlmClients/DeepSeekLlmClient.cs
@@ -491,10 +491,28 @@ internal class DeepSeekLlmClient : ILlmClient
 
         try
         {
-            using var request = new HttpRequestMessage(HttpMethod.Get, "models");
+            // #2953 (#5): GET /models returns 200 even when the account is out of credit — the
+            // 402 only surfaces on chat/completions, so /models is blind to exhaustion. Query
+            // /user/balance instead: is_available=false means the balance can't cover paid calls
+            // (credit exhausted), so the provider must be reported unhealthy. Zero token cost.
+            using var request = new HttpRequestMessage(HttpMethod.Get, "user/balance");
             ApplyAuthorization(request, apiKey);
             using var response = await _httpClient.SendAsync(request, ct).ConfigureAwait(false);
-            return response.IsSuccessStatusCode;
+            if (!response.IsSuccessStatusCode)
+            {
+                return false;
+            }
+
+            var body = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+            using var doc = JsonDocument.Parse(body);
+            if (doc.RootElement.TryGetProperty("is_available", out var isAvailable)
+                && isAvailable.ValueKind == JsonValueKind.False)
+            {
+                _logger.LogWarning("DeepSeek health check: account balance not available (credit exhausted).");
+                return false;
+            }
+
+            return true;
         }
         catch (Exception ex)
         {

--- a/apps/api/tests/Api.Tests/Middleware/ApiExceptionHandlerMiddlewareTests.cs
+++ b/apps/api/tests/Api.Tests/Middleware/ApiExceptionHandlerMiddlewareTests.cs
@@ -38,6 +38,52 @@ public class ApiExceptionHandlerMiddlewareTests
         _httpContext.Request.Method = "GET";
     }
 
+    private void VerifyLogLevel(LogLevel level, Times times)
+    {
+        _loggerMock.Verify(
+            x => x.Log(
+                level,
+                It.IsAny<EventId>(),
+                It.IsAny<It.IsAnyType>(),
+                It.IsAny<Exception>(),
+                (Func<It.IsAnyType, Exception?, string>)It.IsAny<object>()),
+            times);
+    }
+
+    [Fact]
+    public async Task InvokeAsync_NotFoundException_LogsWarningNotError()
+    {
+        // #2953 (#6): an expected 4xx (NotFound) must log Warning, not Error, so it doesn't
+        // pollute error dashboards or mask real 500s.
+        var middleware = new ApiExceptionHandlerMiddleware(
+            next: (context) => throw new NotFoundException("Game", "abc-123"),
+            _loggerMock.Object,
+            _environmentMock.Object);
+        _httpContext.Response.Body = new MemoryStream();
+
+        await middleware.InvokeAsync(_httpContext);
+
+        _httpContext.Response.StatusCode.Should().Be(404);
+        VerifyLogLevel(LogLevel.Warning, Times.AtLeastOnce());
+        VerifyLogLevel(LogLevel.Error, Times.Never());
+    }
+
+    [Fact]
+    public async Task InvokeAsync_UnhandledException_LogsError()
+    {
+        // #2953 (#6): a genuine 5xx (unmapped exception → 500) still logs Error.
+        var middleware = new ApiExceptionHandlerMiddleware(
+            next: (context) => throw new InvalidOperationException("boom"),
+            _loggerMock.Object,
+            _environmentMock.Object);
+        _httpContext.Response.Body = new MemoryStream();
+
+        await middleware.InvokeAsync(_httpContext);
+
+        _httpContext.Response.StatusCode.Should().Be(500);
+        VerifyLogLevel(LogLevel.Error, Times.AtLeastOnce());
+    }
+
     [Fact]
     public async Task InvokeAsync_NoException_PassesThrough()
     {

--- a/apps/api/tests/Api.Tests/Services/LlmClients/DeepSeekLlmClientTests.cs
+++ b/apps/api/tests/Api.Tests/Services/LlmClients/DeepSeekLlmClientTests.cs
@@ -8,6 +8,9 @@ using FluentAssertions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Moq;
+using Moq.Protected;
+using System.Net;
+using System.Text;
 using Xunit;
 using Api.Tests.Constants;
 
@@ -130,6 +133,42 @@ public class DeepSeekLlmClientTests
         healthy.Should().BeFalse();
     }
 
+    // ─── CheckHealthAsync — balance-aware (#2953 #5) ─────────────────────────
+
+    [Fact]
+    [Trait("Category", TestCategories.Unit)]
+    public async Task CheckHealthAsync_WhenBalanceAvailable_ReturnsTrue()
+    {
+        // Arrange
+        var client = CreateClientWithResponse(JsonResponse(
+            HttpStatusCode.OK,
+            "{\"is_available\": true, \"balance_infos\": [{\"currency\": \"USD\", \"total_balance\": \"10.00\"}]}"));
+
+        // Act
+        var healthy = await client.CheckHealthAsync(TestCancellationToken);
+
+        // Assert
+        healthy.Should().BeTrue();
+    }
+
+    [Fact]
+    [Trait("Category", TestCategories.Unit)]
+    public async Task CheckHealthAsync_WhenBalanceUnavailable_ReturnsFalse()
+    {
+        // #2953 (#5): credit exhausted → is_available=false. GET /models would still return 200
+        // and hide the exhaustion; /user/balance surfaces it so the provider is marked unhealthy.
+        // Arrange
+        var client = CreateClientWithResponse(JsonResponse(
+            HttpStatusCode.OK,
+            "{\"is_available\": false, \"balance_infos\": [{\"currency\": \"USD\", \"total_balance\": \"0.00\"}]}"));
+
+        // Act
+        var healthy = await client.CheckHealthAsync(TestCancellationToken);
+
+        // Assert
+        healthy.Should().BeFalse();
+    }
+
     // ─── Factory helpers ─────────────────────────────────────────────────────
 
     /// <summary>
@@ -175,4 +214,42 @@ public class DeepSeekLlmClientTests
 
         return new DeepSeekLlmClient(mockFactory.Object, scopeFactory, mockCostCalculator.Object, logger);
     }
+
+    /// <summary>
+    /// Creates a configured DeepSeekLlmClient whose HTTP calls are all served by
+    /// <paramref name="response"/>. The resolver returns a dummy key so CheckHealthAsync reaches
+    /// the HTTP call (unlike <see cref="CreateUnconfiguredClient"/> which short-circuits).
+    /// </summary>
+    private static DeepSeekLlmClient CreateClientWithResponse(HttpResponseMessage response)
+    {
+        var handler = new Mock<HttpMessageHandler>(MockBehavior.Strict);
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>(
+                "SendAsync",
+                ItExpr.IsAny<HttpRequestMessage>(),
+                ItExpr.IsAny<CancellationToken>())
+            .ReturnsAsync(response);
+
+        var httpClient = new HttpClient(handler.Object);
+        var mockFactory = new Mock<IHttpClientFactory>();
+        mockFactory.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(httpClient);
+
+        var resolver = new Mock<IProviderCredentialResolver>();
+        resolver
+            .Setup(r => r.ResolveAsync(DeepSeekLlmClient.ProviderKey, It.IsAny<CancellationToken>()))
+            .ReturnsAsync("test-api-key");
+
+        var services = new ServiceCollection();
+        services.AddSingleton(resolver.Object);
+        var scopeFactory = services.BuildServiceProvider().GetRequiredService<IServiceScopeFactory>();
+
+        return new DeepSeekLlmClient(
+            mockFactory.Object,
+            scopeFactory,
+            Mock.Of<ILlmCostCalculator>(),
+            Mock.Of<ILogger<DeepSeekLlmClient>>());
+    }
+
+    private static HttpResponseMessage JsonResponse(HttpStatusCode statusCode, string json) =>
+        new(statusCode) { Content = new StringContent(json, Encoding.UTF8, "application/json") };
 }

--- a/apps/web/src/app/admin/(dashboard)/knowledge-base/mechanic-extractor/analyses/__tests__/lifecycle-guards.test.ts
+++ b/apps/web/src/app/admin/(dashboard)/knowledge-base/mechanic-extractor/analyses/__tests__/lifecycle-guards.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+
+import { MechanicAnalysisStatus } from '@/lib/api/schemas/mechanic-analyses.schemas';
+import type { MechanicAnalysisStatusDto } from '@/lib/api/schemas/mechanic-analyses.schemas';
+
+import { canSubmitAnalysisForReview, isPipelineRunning } from '../lifecycle-guards';
+
+function makeStatus(over: Partial<MechanicAnalysisStatusDto> = {}): MechanicAnalysisStatusDto {
+  return {
+    status: MechanicAnalysisStatus.Rejected,
+    isSuppressed: false,
+    claimsCount: 3,
+    sectionRuns: [],
+    ...over,
+  } as unknown as MechanicAnalysisStatusDto;
+}
+
+describe('isPipelineRunning', () => {
+  it('is false for a null status', () => {
+    expect(isPipelineRunning(null)).toBe(false);
+  });
+
+  it('is true for a queued Draft (0 section runs)', () => {
+    expect(
+      isPipelineRunning(makeStatus({ status: MechanicAnalysisStatus.Draft, sectionRuns: [] }))
+    ).toBe(true);
+  });
+
+  it('is false for a terminal status', () => {
+    expect(
+      isPipelineRunning(makeStatus({ status: MechanicAnalysisStatus.PartiallyExtracted }))
+    ).toBe(false);
+  });
+});
+
+describe('canSubmitAnalysisForReview', () => {
+  it('allows a Rejected analysis', () => {
+    expect(
+      canSubmitAnalysisForReview(makeStatus({ status: MechanicAnalysisStatus.Rejected }))
+    ).toBe(true);
+  });
+
+  // #2953 (#4): the domain allows PartiallyExtracted → InReview (MechanicAnalysis valid
+  // transitions), so a partial-salvage analysis must be promotable from the UI too.
+  it('allows a PartiallyExtracted analysis (ADR-051 Sprint 2 salvage state)', () => {
+    expect(
+      canSubmitAnalysisForReview(makeStatus({ status: MechanicAnalysisStatus.PartiallyExtracted }))
+    ).toBe(true);
+  });
+
+  it('blocks an InReview analysis', () => {
+    expect(
+      canSubmitAnalysisForReview(makeStatus({ status: MechanicAnalysisStatus.InReview }))
+    ).toBe(false);
+  });
+
+  it('blocks a suppressed analysis', () => {
+    expect(
+      canSubmitAnalysisForReview(
+        makeStatus({ status: MechanicAnalysisStatus.PartiallyExtracted, isSuppressed: true })
+      )
+    ).toBe(false);
+  });
+
+  it('blocks when there are no claims', () => {
+    expect(
+      canSubmitAnalysisForReview(
+        makeStatus({ status: MechanicAnalysisStatus.PartiallyExtracted, claimsCount: 0 })
+      )
+    ).toBe(false);
+  });
+
+  it('blocks while the pipeline is still running (Draft, queued)', () => {
+    expect(
+      canSubmitAnalysisForReview(
+        makeStatus({ status: MechanicAnalysisStatus.Draft, sectionRuns: [] })
+      )
+    ).toBe(false);
+  });
+});

--- a/apps/web/src/app/admin/(dashboard)/knowledge-base/mechanic-extractor/analyses/lifecycle-guards.ts
+++ b/apps/web/src/app/admin/(dashboard)/knowledge-base/mechanic-extractor/analyses/lifecycle-guards.ts
@@ -1,0 +1,42 @@
+/**
+ * Lifecycle guards for the Mechanic Analyses admin UI (ISSUE-524 / ADR-051).
+ *
+ * Extracted from `page.tsx` so the derived-state logic is unit-testable without
+ * rendering the whole (heavy, `'use client'`) page component.
+ */
+
+import { MechanicAnalysisStatus } from '@/lib/api/schemas/mechanic-analyses.schemas';
+import type { MechanicAnalysisStatusDto } from '@/lib/api/schemas/mechanic-analyses.schemas';
+
+/**
+ * True while the async extraction pipeline is still running (Draft with incomplete
+ * section runs). Any terminal status (InReview/Published/Rejected/PartiallyExtracted)
+ * returns false. Drives the `/status` poll interval + lifecycle button gating.
+ */
+export function isPipelineRunning(status: MechanicAnalysisStatusDto | null | undefined): boolean {
+  if (!status) return false;
+  if (status.status !== MechanicAnalysisStatus.Draft) return false;
+  if (status.sectionRuns.length === 0) return true;
+  // All 9 sections should complete (v1.1.0 added Setup/Components/Endgame).
+  return status.sectionRuns.length < 9;
+}
+
+/**
+ * Whether the "Submit for review" lifecycle action is available for the given analysis.
+ */
+export function canSubmitAnalysisForReview(
+  status: MechanicAnalysisStatusDto | null | undefined
+): boolean {
+  return (
+    !!status &&
+    !status.isSuppressed &&
+    // #2953 (#4): the domain allows PartiallyExtracted → InReview (MechanicAnalysis valid
+    // transitions + SubmitForReview branch), so a partial-salvage analysis (ADR-051 Sprint 2)
+    // must be promotable from the UI too — not only Draft/Rejected.
+    (status.status === MechanicAnalysisStatus.Draft ||
+      status.status === MechanicAnalysisStatus.Rejected ||
+      status.status === MechanicAnalysisStatus.PartiallyExtracted) &&
+    status.claimsCount > 0 &&
+    !isPipelineRunning(status)
+  );
+}

--- a/apps/web/src/app/admin/(dashboard)/knowledge-base/mechanic-extractor/analyses/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/knowledge-base/mechanic-extractor/analyses/page.tsx
@@ -72,6 +72,8 @@ import {
   type SuppressionRequestSourceValue,
 } from '@/lib/api/schemas/mechanic-analyses.schemas';
 
+import { canSubmitAnalysisForReview, isPipelineRunning } from './lifecycle-guards';
+
 const httpClient = new HttpClient();
 const adminClient = createAdminClient({ httpClient });
 
@@ -124,18 +126,6 @@ function formatDate(iso: string | null | undefined): string {
   const d = new Date(iso);
   if (Number.isNaN(d.getTime())) return iso;
   return d.toLocaleString();
-}
-
-function isPipelineRunning(status: MechanicAnalysisStatusDto | null | undefined): boolean {
-  if (!status) return false;
-  // Draft + 0 section runs = queued; Draft + incomplete runs = running.
-  // Once any terminal status is reached we stop polling:
-  //   - InReview / Published / Rejected: standard terminal states
-  //   - PartiallyExtracted: ADR-051 Sprint 2 salvage state (also terminal)
-  if (status.status !== MechanicAnalysisStatus.Draft) return false;
-  if (status.sectionRuns.length === 0) return true;
-  // All 9 sections should complete; stop when each has a completedAt (v1.1.0 added Setup/Components/Endgame).
-  return status.sectionRuns.length < 9;
 }
 
 export default function MechanicAnalysesPage() {
@@ -378,13 +368,7 @@ export default function MechanicAnalysesPage() {
   });
 
   // ========== Derived lifecycle guards ==========
-  const canSubmitReview =
-    !!status &&
-    !status.isSuppressed &&
-    (status.status === MechanicAnalysisStatus.Draft ||
-      status.status === MechanicAnalysisStatus.Rejected) &&
-    status.claimsCount > 0 &&
-    !isPipelineRunning(status);
+  const canSubmitReview = canSubmitAnalysisForReview(status);
 
   const canApprove =
     !!status && !status.isSuppressed && status.status === MechanicAnalysisStatus.InReview;


### PR DESCRIPTION
## #2953 — ME E2E polish (4 fix)

Closes #2953. Follow-up minori dal test E2E della pipeline Mechanic Extractor (epic #539). Ogni fix ha TDD RED→GREEN.

### #4 — Guard FE PartiallyExtracted
`PartiallyExtracted → InReview` è una transizione valida del dominio, ma la UI disabilitava "Submit for review" per quello stato. Estratta la logica in un modulo puro `analyses/lifecycle-guards.ts` (`canSubmitAnalysisForReview` + `isPipelineRunning`) unit-testato (page.tsx è troppo pesante per un test); PartiallyExtracted ora promuovibile.

### #5 — Health-check DeepSeek cieco al 402
`CheckHealthAsync` faceva `GET /models` (200 anche a credito zero — il 402 emerge solo su chat/completions), quindi l'exhaustion era invisibile. Ora `GET /user/balance` + `is_available=false` → unhealthy (zero token). Endpoint/schema verificati sulla doc ufficiale DeepSeek.

### #6 — Log-noise 404
`ApiExceptionHandlerMiddleware` loggava `Error` + `isUnhandled=true` per ogni eccezione prima del remap a 4xx. Ora la severità è classificata up-front via `MapExceptionToResponse`: le 4xx attese (es. NotFound) loggano `Warning` e non contano come `isUnhandled` → niente inquinamento dei dashboard errori / mascheramento dei 500 reali.

### #7 — Docker build context
Il build API usa `context=repo-root` (`infra/docker-compose.yml`), quindi l'`apps/api/.dockerignore` era inerte (mai applicato). Aggiunto un `.dockerignore` di **root** che esclude node_modules, `data/rulebook` PDFs, `.git`, `.claude` worktrees, docs.

### Test
- BE: DeepSeek 8/8, middleware 43/43 (verdi). FE: lifecycle-guards 9/9 (verdi).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
