### PR TITLE
feat(ui): restore per-entity coloring on 10 UI primitives (2955)

### DIFF
--- a/apps/web/src/app/(authenticated)/notifications/__tests__/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/notifications/__tests__/page.test.tsx
@@ -370,8 +370,10 @@ describe('NotificationsPage', () => {
 
     render(<NotificationsPage />);
 
-    // Claude Design v1: all | sessions | agents | events | system
-    const filterBar = screen.getByRole('tablist', { name: /categoria notifiche/i });
+    // Claude Design v1: all | sessions | agents | events | system.
+    // The filter bar is a labelled role="group" (not a tablist — its pills are
+    // buttons, not tabs; see page.tsx / axe aria-required-children fix).
+    const filterBar = screen.getByRole('group', { name: /categoria notifiche/i });
     expect(within(filterBar).getByRole('button', { name: /^tutte$/i })).toBeInTheDocument();
     expect(within(filterBar).getByRole('button', { name: /sessioni/i })).toBeInTheDocument();
     expect(within(filterBar).getByRole('button', { name: /agenti/i })).toBeInTheDocument();
@@ -563,15 +565,21 @@ describe('NotificationsPage', () => {
       // Scope to the per-entity NotificationCard list (all six sample
       // notifications land in the "Oggi" group), which is the surface #2955
       // recoloured — six entity-coloured cards rendered together.
-      // NOTE: a whole-page scan additionally trips a PRE-EXISTING, coloring-
-      // unrelated `aria-required-children` violation on the filter bar
-      // (`role="tablist"` holding <button> children, page.tsx:281). That is a
-      // real finding surfaced separately, not a regression from the restored
-      // coloring, and fixing it is a source change out of scope for this
-      // test-only Fase 3.
       const cardList = container.querySelector('section[aria-labelledby="notif-group-oggi"]');
       expect(cardList).not.toBeNull();
       expect(await axe(cardList as HTMLElement)).toHaveNoViolations();
+    });
+
+    // Whole-surface scan (no modal open): the category filter bar renders
+    // alongside the entity-coloured NotificationCard list. Guards the blocking
+    // axe AA gate against the `aria-required-children` finding on the filter
+    // bar — the row of category pills is a labelled `role="group"`, NOT a
+    // `role="tablist"` (its `Btn` pills expose role=button, not role=tab, so a
+    // tablist would be an invalid parent). See page.tsx filter bar.
+    it('has no violations across the full page surface including the filter bar', async () => {
+      setupStore({ notifications: mixedEntityNotifications(), unreadCount: 4 });
+      const { container } = render(<NotificationsPage />);
+      expect(await axe(container)).toHaveNoViolations();
     });
 
     it('has no violations with the per-entity detail Drawer open', async () => {

--- a/apps/web/src/app/(authenticated)/notifications/__tests__/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/notifications/__tests__/page.test.tsx
@@ -15,6 +15,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { axe, toHaveNoViolations } from 'jest-axe';
 
 import NotificationsPage from '../page';
 import type { NotificationDto } from '@/lib/api';
@@ -26,6 +27,8 @@ import { EMPTY } from '../../../../__tests__/fixtures/test-strings';
 import { renderWithIntl } from '../../../../__tests__/fixtures/common-fixtures';
 
 const render = renderWithIntl;
+
+expect.extend(toHaveNoViolations);
 
 // ============================================================================
 // Mocks
@@ -535,6 +538,67 @@ describe('NotificationsPage', () => {
           value: originalLocation,
         });
       }
+    });
+  });
+
+  // ── axe AA gate (#2955 Fase 3) ───────────────────────────────────
+  // The restored per-entity coloring puts several primitives on this
+  // consumer surface at once: the 5 entity-coloured filter `Btn` pills,
+  // one `NotificationCard` per entity, the CTA `Btn`, and (when opened)
+  // the per-entity detail `Drawer`. This guards the blocking axe AA gate
+  // against a regression when they all render together.
+  describe('axe AA gate (#2955 Fase 3)', () => {
+    const mixedEntityNotifications = () => [
+      createNotification({ title: 'Session ended', type: 'session_terminated', isRead: false }),
+      createNotification({ title: 'Agent ready', type: 'agent_ready', isRead: false }),
+      createNotification({ title: 'Night invite', type: 'game_night_invitation', isRead: true }),
+      createNotification({ title: 'PDF ready', type: 'document_ready', isRead: false }),
+      createNotification({ title: 'Badge earned', type: 'badge_earned', isRead: true }),
+      createNotification({ title: 'Rate limit', type: 'rate_limit_reached', isRead: false }),
+    ];
+
+    it('has no violations across the multi-entity NotificationCard list', async () => {
+      setupStore({ notifications: mixedEntityNotifications(), unreadCount: 4 });
+      const { container } = render(<NotificationsPage />);
+      // Scope to the per-entity NotificationCard list (all six sample
+      // notifications land in the "Oggi" group), which is the surface #2955
+      // recoloured — six entity-coloured cards rendered together.
+      // NOTE: a whole-page scan additionally trips a PRE-EXISTING, coloring-
+      // unrelated `aria-required-children` violation on the filter bar
+      // (`role="tablist"` holding <button> children, page.tsx:281). That is a
+      // real finding surfaced separately, not a regression from the restored
+      // coloring, and fixing it is a source change out of scope for this
+      // test-only Fase 3.
+      const cardList = container.querySelector('section[aria-labelledby="notif-group-oggi"]');
+      expect(cardList).not.toBeNull();
+      expect(await axe(cardList as HTMLElement)).toHaveNoViolations();
+    });
+
+    it('has no violations with the per-entity detail Drawer open', async () => {
+      const user = userEvent.setup();
+      setupStore({
+        notifications: [
+          createNotification({
+            title: 'Drawer target',
+            message: 'Detail body content',
+            type: 'agent_ready',
+            link: '/games/abc-123',
+            isRead: true,
+          }),
+        ],
+        unreadCount: 0,
+      });
+      render(<NotificationsPage />);
+
+      // The card renders as role=button when only onClick is wired; clicking
+      // opens the detail Drawer. "Apri" only exists inside the open drawer
+      // (link is truthy), so its presence confirms the per-entity Drawer +
+      // Btn are mounted before we scan.
+      await user.click(screen.getByRole('button', { name: /drawer target/i }));
+      await screen.findByRole('button', { name: /^apri$/i });
+
+      // The Drawer portals to document.body, so scan the whole document.
+      expect(await axe(document.body)).toHaveNoViolations();
     });
   });
 });

--- a/apps/web/src/app/(authenticated)/notifications/page.tsx
+++ b/apps/web/src/app/(authenticated)/notifications/page.tsx
@@ -277,10 +277,13 @@ export default function NotificationsPage() {
         </Btn>
       </div>
 
-      {/* Filters bar (Claude Design v1: entity-colored outline pills) */}
+      {/* Filters bar (Claude Design v1: entity-colored outline pills).
+          A labelled `role="group"` — not a `tablist` — because the pills are
+          `Btn`s exposing role=button (not role=tab); a tablist would be an
+          invalid ARIA parent (aria-required-children). */}
       <div
         className="flex items-center gap-2 mb-4 flex-wrap"
-        role="tablist"
+        role="group"
         aria-label="Categoria notifiche"
       >
         {FILTERS.map(f => {

--- a/apps/web/src/app/(public)/cookie-settings/__tests__/page.test.tsx
+++ b/apps/web/src/app/(public)/cookie-settings/__tests__/page.test.tsx
@@ -1,9 +1,12 @@
 import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { axe, toHaveNoViolations } from 'jest-axe';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import CookieSettingsPage from '../page';
 import { CONSENT_KEY, CONSENT_VERSION, type CookieConsent } from '@/lib/cookie-consent';
+
+expect.extend(toHaveNoViolations);
 
 // Toast is a visual side-effect; assert it was called, don't render it.
 vi.mock('sonner', () => ({
@@ -132,6 +135,16 @@ describe('CookieSettingsPage', () => {
     const parsed = JSON.parse(localStorage.getItem(CONSENT_KEY)!) as CookieConsent;
     expect(parsed.analytics).toBe(false);
     expect(parsed.functional).toBe(false);
+  });
+
+  // #2955 Fase 3: three default entity="game" ToggleSwitch primitives plus
+  // three Btns render together here; guard the blocking axe AA gate.
+  it('has no axe AA violations with the toggles + Btns rendered together', async () => {
+    let container!: HTMLElement;
+    await act(async () => {
+      ({ container } = render(<CookieSettingsPage />));
+    });
+    expect(await axe(container)).toHaveNoViolations();
   });
 
   it('essential toggle is always checked and disabled', async () => {

--- a/apps/web/src/components/admin/agents/__tests__/TopAgentsTable.axe.test.tsx
+++ b/apps/web/src/components/admin/agents/__tests__/TopAgentsTable.axe.test.tsx
@@ -1,0 +1,57 @@
+/**
+ * TopAgentsTable — axe AA accessibility gate (#2955 Fase 3).
+ *
+ * The only existing consumer test (analytics-tabs.test.tsx) mocks this
+ * component out, so there is no jest-axe coverage on the real render. This
+ * component is pure props-based (no fetch / router / providers), so it mounts
+ * directly — mirroring the sibling `__tests__/*-table.test.tsx` fixtures and
+ * the standalone axe precedents (wizard-modal-axe, entity-table-view).
+ *
+ * Guards the restored entity="agent" per-entity coloring (row border + badge)
+ * across multiple rows on this admin consumer surface.
+ */
+import { render } from '@testing-library/react';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import { describe, expect, it } from 'vitest';
+
+import { TopAgentsTable } from '../TopAgentsTable';
+
+import type { TopAgent } from '@/app/(authenticated)/admin/agents/metrics/client';
+
+expect.extend(toHaveNoViolations);
+
+// Spread across the confidence-badge colour buckets (>=90 / >=70 / >=50 / <50)
+// so every branch of the table's cell renderers is exercised in one scan.
+const AGENTS: TopAgent[] = [
+  {
+    agentDefinitionId: 'a1',
+    typologyName: 'Rules Expert',
+    invocations: 1280,
+    cost: 4.21,
+    avgConfidence: 0.93,
+    avgLatencyMs: 820,
+  },
+  {
+    agentDefinitionId: 'a2',
+    typologyName: 'Setup Helper',
+    invocations: 342,
+    cost: 0.087,
+    avgConfidence: 0.71,
+    avgLatencyMs: 1450,
+  },
+  {
+    agentDefinitionId: 'a3',
+    typologyName: 'Scorekeeper',
+    invocations: 58,
+    cost: 0.0043,
+    avgConfidence: 0.44,
+    avgLatencyMs: 260,
+  },
+];
+
+describe('TopAgentsTable — axe AA gate (#2955 Fase 3)', () => {
+  it('has no axe violations rendering the entity="agent" metrics table', async () => {
+    const { container } = render(<TopAgentsTable agents={AGENTS} />);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/apps/web/src/components/admin/shared-games/__tests__/CategoriesTable.axe.test.tsx
+++ b/apps/web/src/components/admin/shared-games/__tests__/CategoriesTable.axe.test.tsx
@@ -1,0 +1,30 @@
+/**
+ * CategoriesTable (EntityTableView) — axe AA accessibility gate (#2955 Fase 3).
+ *
+ * This is the EntityTableView entity="game" table (Issue #4862), distinct from
+ * the bespoke `categories-table.tsx` admin CRUD table. It is pure props-based
+ * (no fetch / router / providers), so it mounts directly — mirroring the
+ * sibling axe precedents (TopAgentsTable.axe, entity-table-view). Guards the
+ * restored entity="game" per-entity coloring (row border + badge) across
+ * multiple rows on this admin consumer surface.
+ */
+import { render } from '@testing-library/react';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import { describe, expect, it } from 'vitest';
+
+import { CategoriesTable, type GameCategory } from '../CategoriesTable';
+
+expect.extend(toHaveNoViolations);
+
+const CATEGORIES: GameCategory[] = [
+  { id: 'c1', name: 'Strategy', gameCount: 42, description: 'Deep decision-making' },
+  { id: 'c2', name: 'Party', gameCount: 28, description: 'Large groups, light rules' },
+  { id: 'c3', name: 'Cooperative', gameCount: 19 },
+];
+
+describe('CategoriesTable (EntityTableView) — axe AA gate (#2955 Fase 3)', () => {
+  it('has no axe violations rendering the entity="game" categories table', async () => {
+    const { container } = render(<CategoriesTable categories={CATEGORIES} />);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/apps/web/src/components/admin/shared-games/__tests__/categories-table.axe.test.tsx
+++ b/apps/web/src/components/admin/shared-games/__tests__/categories-table.axe.test.tsx
@@ -1,0 +1,72 @@
+/**
+ * categories-table.tsx (admin CRUD table) — axe AA accessibility gate.
+ *
+ * Distinct from the sibling `CategoriesTable.axe.test.tsx`, which guards the
+ * EntityTableView `CategoriesTable.tsx`. This one guards the bespoke admin CRUD
+ * `categories-table.tsx` (#1440), whose drag-handle header column was an empty
+ * `<th>` (axe `empty-table-header`). Renders the live table via mocked
+ * admin-category hooks + axe.
+ */
+import { render } from '@testing-library/react';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { CategoryDto } from '@/lib/api/admin-categories';
+
+vi.mock('@/lib/logger', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  getLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+  resetLogger: vi.fn(),
+  LogLevel: { DEBUG: 'debug', INFO: 'info', WARN: 'warn', ERROR: 'error' },
+}));
+
+const mocks = vi.hoisted(() => ({
+  queryState: {
+    data: undefined as CategoryDto[] | undefined,
+    isLoading: false,
+    isError: false,
+    error: null as unknown,
+  },
+}));
+
+vi.mock('@/hooks/queries/useAdminCategories', () => ({
+  useAdminCategories: () => ({
+    data: mocks.queryState.data,
+    isLoading: mocks.queryState.isLoading,
+    isError: mocks.queryState.isError,
+    error: mocks.queryState.error,
+  }),
+  useCreateAdminCategory: () => ({ mutateAsync: vi.fn() }),
+  useUpdateAdminCategory: () => ({ mutateAsync: vi.fn() }),
+  useDeleteAdminCategory: () => ({ mutateAsync: vi.fn() }),
+}));
+
+import { CategoriesTable } from '../categories-table';
+
+const CATEGORIES: CategoryDto[] = [
+  {
+    id: 'cat-strategy',
+    name: 'Strategy',
+    slug: 'strategy',
+    emoji: '♟️',
+    color: '#3b82f6',
+    gameCount: 42,
+  },
+  { id: 'cat-party', name: 'Party', slug: 'party', emoji: '🎉', color: '#ec4899', gameCount: 28 },
+];
+
+expect.extend(toHaveNoViolations);
+
+beforeEach(() => {
+  mocks.queryState.data = CATEGORIES;
+  mocks.queryState.isLoading = false;
+  mocks.queryState.isError = false;
+  mocks.queryState.error = null;
+});
+
+describe('categories-table.tsx (admin CRUD) — axe AA gate', () => {
+  it('has no axe violations rendering the admin categories table', async () => {
+    const { container } = render(<CategoriesTable />);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/apps/web/src/components/admin/shared-games/categories-table.tsx
+++ b/apps/web/src/components/admin/shared-games/categories-table.tsx
@@ -166,6 +166,7 @@ export function CategoriesTable() {
               <tr>
                 <th className="px-6 py-3 text-left text-xs font-medium text-foreground dark:text-zinc-300 uppercase tracking-wider w-12">
                   {/* Drag handle column */}
+                  <span className="sr-only">Reorder</span>
                 </th>
                 <th className="px-6 py-3 text-left text-xs font-medium text-foreground dark:text-zinc-300 uppercase tracking-wider">
                   Category Name

--- a/apps/web/src/components/features/settings/__tests__/AiConsentSection.test.tsx
+++ b/apps/web/src/components/features/settings/__tests__/AiConsentSection.test.tsx
@@ -1,6 +1,9 @@
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { axe, toHaveNoViolations } from 'jest-axe';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { AiConsentSection } from '../sections/AiConsentSection';
+
+expect.extend(toHaveNoViolations);
 
 // useToast mock
 vi.mock('@/hooks/useToast', () => ({ useToast: () => ({ toast: vi.fn() }) }));
@@ -29,6 +32,14 @@ describe('AiConsentSection', () => {
     render(<AiConsentSection />);
     await waitFor(() => expect(screen.getByTestId('ai-processing-toggle')).toBeInTheDocument());
     expect(screen.getByTestId('external-providers-toggle')).toBeInTheDocument();
+  });
+
+  // #2955 Fase 3: two entity="agent" ToggleSwitch primitives render together
+  // here; guard the blocking axe AA gate on this consumer surface.
+  it('has no axe AA violations with the entity="agent" consent toggles', async () => {
+    const { container } = render(<AiConsentSection />);
+    await waitFor(() => expect(screen.getByTestId('ai-processing-toggle')).toBeInTheDocument());
+    expect(await axe(container)).toHaveNoViolations();
   });
 
   it('saves via PUT to /api/v1/users/me/ai-consent', async () => {

--- a/apps/web/src/components/ui/__tests__/entity-coloring-aa-matrix.test.tsx
+++ b/apps/web/src/components/ui/__tests__/entity-coloring-aa-matrix.test.tsx
@@ -1,0 +1,292 @@
+/**
+ * Entity coloring AA matrix — issue #2955 Fase 3 (test hardening)
+ *
+ * A single comprehensive regression matrix. Every primitive restored in Fase 1+2
+ * is rendered in its ENTITY-ACTIVE state across ALL NINE canonical EntityType
+ * values and asserts, per combination:
+ *   (a) jest-axe `toHaveNoViolations`, and
+ *   (b) the expected registered `*-entity-*` / `text-entity-*-text` utility is
+ *       present on the design-sensitive element.
+ * For `kb` it additionally asserts the class resolves to the registered TEAL
+ * `-kb` token and NEVER the slate `-document` token (which lives only in
+ * `@layer tokens` and is absent from `@theme inline`).
+ *
+ * This is COVERAGE of already-correct behaviour — it must pass on a clean tree.
+ * A failure here is a real regression in per-entity coloring or accessibility.
+ */
+import { render, screen } from '@testing-library/react';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+
+import { Btn } from '@/components/ui/btn/btn';
+import { EntityTableView } from '@/components/ui/data-display/entity-list-view/components/entity-table-view';
+import {
+  Drawer,
+  DrawerContent,
+  DrawerDescription,
+  DrawerHeader,
+  DrawerTitle,
+} from '@/components/ui/drawer/drawer';
+import { EntityCard } from '@/components/ui/entity-card/entity-card';
+import { EntityPip } from '@/components/ui/entity-pip/entity-pip';
+import type { EntityType } from '@/components/ui/entity-tokens';
+import { NotificationCard } from '@/components/ui/notification-card/notification-card';
+import { SettingsRow } from '@/components/ui/settings-row/settings-row';
+import { StepProgress, type Step } from '@/components/ui/step-progress/step-progress';
+import { ToggleSwitch } from '@/components/ui/toggle-switch/toggle-switch';
+
+expect.extend(toHaveNoViolations);
+
+/** The 9 canonical EntityType values (kb → teal `-kb`, never slate `-document`). */
+const ENTITIES: EntityType[] = [
+  'game',
+  'player',
+  'session',
+  'agent',
+  'kb',
+  'chat',
+  'event',
+  'toolkit',
+  'tool',
+];
+
+/**
+ * Matches an exact entity utility token and NOT a longer sibling token. This is
+ * critical because `tool` is a prefix of `toolkit`: a naive `/bg-entity-tool/`
+ * would wrongly match `bg-entity-toolkit`. Entity tokens are always followed by
+ * a space, `/` (opacity), `-text`, or end-of-string in a className, so a
+ * negative lookahead for a following lowercase letter disambiguates them.
+ */
+const token = (util: string, entity: string): RegExp => new RegExp(`${util}${entity}(?![a-z])`);
+
+/** The unregistered slate token that kb must NEVER resolve to. */
+const DOCUMENT = /entity-document/;
+
+// ---------------------------------------------------------------------------
+// Btn — primary (per-entity fill, white text) — #2955 Fase 1
+// ---------------------------------------------------------------------------
+describe('Btn variant="primary" — per-entity fill (#2955 Fase 1)', () => {
+  it.each(ENTITIES)('%s → bg-entity fill + no axe violations', async entity => {
+    const { container } = render(
+      <Btn variant="primary" entity={entity}>
+        Label
+      </Btn>
+    );
+    const btn = screen.getByRole('button');
+    expect(btn.className).toMatch(token('bg-entity-', entity));
+    if (entity === 'kb') expect(btn.className).not.toMatch(DOCUMENT);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Btn — outline (per-entity border + AA text-on-tint label) — #2955 Fase 2
+// ---------------------------------------------------------------------------
+describe('Btn variant="outline" — per-entity border + AA -text label (#2955 Fase 2)', () => {
+  it.each(ENTITIES)('%s → border-entity + text-entity-*-text + no axe violations', async entity => {
+    const { container } = render(
+      <Btn variant="outline" entity={entity}>
+        Label
+      </Btn>
+    );
+    const btn = screen.getByRole('button');
+    expect(btn.className).toMatch(token('border-entity-', entity));
+    expect(btn.className).toMatch(new RegExp(`text-entity-${entity}-text`));
+    if (entity === 'kb') expect(btn.className).not.toMatch(DOCUMENT);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// EntityCard — per-entity left border — #2955
+// ---------------------------------------------------------------------------
+describe('EntityCard — per-entity left border (#2955)', () => {
+  it.each(ENTITIES)('%s → border-l-entity + no axe violations', async entity => {
+    const { container } = render(
+      <EntityCard entity={entity}>
+        <p>Body</p>
+      </EntityCard>
+    );
+    const el = container.querySelector<HTMLElement>(`[data-entity="${entity}"]`);
+    expect(el?.className).toMatch(token('border-l-entity-', entity));
+    if (entity === 'kb') expect(el?.className).not.toMatch(DOCUMENT);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// NotificationCard — left border + unread dot fill — #2955
+// ---------------------------------------------------------------------------
+describe('NotificationCard — left border + unread dot (#2955)', () => {
+  it.each(ENTITIES)('%s → border-l-entity + unread dot bg-entity + no axe', async entity => {
+    const { container } = render(
+      <NotificationCard entity={entity} title="Titolo" timestamp="ora" unread />
+    );
+    const el = container.querySelector<HTMLElement>(`[data-entity="${entity}"]`);
+    expect(el?.className).toMatch(token('border-l-entity-', entity));
+    const dot = screen.getByTestId('unread-dot');
+    expect(dot.className).toMatch(token('bg-entity-', entity));
+    if (entity === 'kb') {
+      expect(el?.className).not.toMatch(DOCUMENT);
+      expect(dot.className).not.toMatch(DOCUMENT);
+    }
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// EntityPip — active ring + fill — #2955
+// ---------------------------------------------------------------------------
+describe('EntityPip — active ring + fill (#2955)', () => {
+  it.each(ENTITIES)('%s → ring-entity (active) + bg-entity + no axe', async entity => {
+    const { container } = render(<EntityPip entity={entity} count={2} active />);
+    const el = container.querySelector<HTMLElement>(`[data-entity="${entity}"]`);
+    expect(el?.className).toMatch(token('ring-entity-', entity));
+    expect(el?.className).toMatch(token('bg-entity-', entity));
+    if (entity === 'kb') expect(el?.className).not.toMatch(DOCUMENT);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// StepProgress — completed/current fill + current ring — #2955
+// ---------------------------------------------------------------------------
+const STEPS: Step[] = [{ label: 'Uno' }, { label: 'Due' }, { label: 'Tre' }];
+
+describe('StepProgress — completed/current fill + current ring (#2955)', () => {
+  it.each(ENTITIES)('%s → bg-entity + ring-entity + no axe', async entity => {
+    // currentIndex=2 over 3 steps → steps 0,1 completed, step 2 current.
+    const { container } = render(<StepProgress steps={STEPS} currentIndex={2} entity={entity} />);
+    const current = container.querySelector<HTMLElement>(
+      '[data-step-status="current"] [data-step-circle]'
+    );
+    expect(current?.className).toMatch(token('bg-entity-', entity));
+    expect(current?.className).toMatch(token('ring-entity-', entity));
+    const completed = container.querySelector<HTMLElement>(
+      '[data-step-status="completed"] [data-step-circle]'
+    );
+    expect(completed?.className).toMatch(token('bg-entity-', entity));
+    if (entity === 'kb') {
+      const root = container.querySelector('[role="progressbar"]');
+      expect(root?.innerHTML).not.toMatch(DOCUMENT);
+    }
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ToggleSwitch — checked track fill + focus ring — #2955
+// ---------------------------------------------------------------------------
+describe('ToggleSwitch — checked track + ring (#2955)', () => {
+  it.each(ENTITIES)('%s → bg-entity track + ring-entity + no axe', async entity => {
+    const { container } = render(
+      <ToggleSwitch checked onCheckedChange={() => {}} entity={entity} ariaLabel="Attiva" />
+    );
+    const sw = screen.getByRole('switch');
+    expect(sw.className).toMatch(token('bg-entity-', entity));
+    expect(sw.className).toMatch(token('ring-entity-', entity));
+    if (entity === 'kb') expect(sw.className).not.toMatch(DOCUMENT);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SettingsRow — leading icon AA text-on-tint shade — #2955 Fase 2
+// (wrapped in <ul> so the semantic <li> root does not trip the axe `listitem` rule)
+// ---------------------------------------------------------------------------
+describe('SettingsRow — leading icon AA -text shade (#2955 Fase 2)', () => {
+  it.each(ENTITIES)('%s → text-entity-*-text icon + no axe', async entity => {
+    const { container } = render(
+      <ul>
+        <SettingsRow label="Impostazione" icon={<span>◆</span>} entity={entity} />
+      </ul>
+    );
+    const icon = screen.getByTestId('settings-row-icon');
+    expect(icon.className).toMatch(new RegExp(`text-entity-${entity}-text`));
+    if (entity === 'kb') expect(icon.className).not.toMatch(DOCUMENT);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Drawer — desktop (Radix) entity accent strip — #2955 Fase 1
+// ---------------------------------------------------------------------------
+describe('Drawer — desktop entity accent (#2955 Fase 1)', () => {
+  beforeAll(() => {
+    // Force the desktop (Radix Dialog) render path deterministically. The
+    // breakpoint hook degrades to "mobile" without matchMedia, but side=
+    // "desktop-right" already forces desktop mode; this mirrors the proven
+    // desktop drawer test setup and removes any ambiguity.
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: vi.fn().mockReturnValue({
+        matches: true,
+        media: '(min-width: 768px)',
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        onchange: null,
+      }),
+    });
+  });
+
+  it.each(ENTITIES)('%s → bg-entity accent strip + no axe', async entity => {
+    render(
+      <Drawer open onOpenChange={() => {}} side="desktop-right" entity={entity}>
+        <DrawerContent>
+          <DrawerHeader>
+            <DrawerTitle>Titolo</DrawerTitle>
+            <DrawerDescription>Descrizione</DrawerDescription>
+          </DrawerHeader>
+          <p>Contenuto</p>
+        </DrawerContent>
+      </Drawer>
+    );
+    const dialog = screen.getByRole('dialog');
+    // Radix portals the dialog to document.body — scan the dialog subtree (which
+    // contains its own aria-labelledby/‑describedby targets) rather than the RTL
+    // container, and avoid the body-level focus guards Radix installs.
+    const accent = dialog.querySelector<HTMLElement>(`[data-drawer-accent="${entity}"]`);
+    expect(accent).not.toBeNull();
+    expect(accent?.className).toMatch(token('bg-entity-', entity));
+    if (entity === 'kb') expect(accent?.className).not.toMatch(DOCUMENT);
+    expect(await axe(dialog)).toHaveNoViolations();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// EntityTableView — row accent border + badge pill — #2955 Fase 2
+// ---------------------------------------------------------------------------
+interface TableRow {
+  id: string;
+  name: string;
+  tag: string;
+}
+const TABLE_ITEMS: TableRow[] = [{ id: 'r1', name: 'Catan', tag: 'NEW' }];
+const renderRow = (item: TableRow) => ({ id: item.id, title: item.name, badge: item.tag });
+
+describe('EntityTableView — row border + badge pill (#2955 Fase 2)', () => {
+  it.each(ENTITIES)(
+    '%s → border-entity row + bg-entity/10 + text-entity-*-text badge + no axe',
+    async entity => {
+      const { container } = render(
+        <EntityTableView
+          entity={entity}
+          displayItems={TABLE_ITEMS}
+          items={TABLE_ITEMS}
+          renderItem={renderRow}
+        />
+      );
+      const layout = screen.getByTestId('table-layout');
+      expect(layout.className).toMatch(token('border-entity-', entity));
+      const badge = screen.getByText('NEW');
+      expect(badge.className).toMatch(new RegExp(`bg-entity-${entity}\\/10`));
+      expect(badge.className).toMatch(new RegExp(`text-entity-${entity}-text`));
+      if (entity === 'kb') {
+        expect(layout.className).not.toMatch(DOCUMENT);
+        expect(badge.className).not.toMatch(DOCUMENT);
+      }
+      expect(await axe(container)).toHaveNoViolations();
+    }
+  );
+});

--- a/apps/web/src/components/ui/__tests__/entity-coloring-aa-matrix.test.tsx
+++ b/apps/web/src/components/ui/__tests__/entity-coloring-aa-matrix.test.tsx
@@ -267,7 +267,7 @@ const renderRow = (item: TableRow) => ({ id: item.id, title: item.name, badge: i
 
 describe('EntityTableView — row border + badge pill (#2955 Fase 2)', () => {
   it.each(ENTITIES)(
-    '%s → border-entity row + bg-entity/10 + text-entity-*-text badge + no axe',
+    '%s → border-l-entity row (on <tr>) + bg-entity/10 + text-entity-*-text badge + no axe',
     async entity => {
       const { container } = render(
         <EntityTableView
@@ -278,7 +278,10 @@ describe('EntityTableView — row border + badge pill (#2955 Fase 2)', () => {
         />
       );
       const layout = screen.getByTestId('table-layout');
-      expect(layout.className).toMatch(token('border-entity-', entity));
+      // Color targets the <tr> via the `[&_tbody_tr]:` descendant variant (same
+      // element as `[&_tbody_tr]:border-l-4` width) — a plain `border-entity-*` on
+      // this wrapper would be a no-op (no border-width; color doesn't inherit).
+      expect(layout.className).toMatch(token('border-l-entity-', entity));
       const badge = screen.getByText('NEW');
       expect(badge.className).toMatch(new RegExp(`bg-entity-${entity}\\/10`));
       expect(badge.className).toMatch(new RegExp(`text-entity-${entity}-text`));

--- a/apps/web/src/components/ui/btn/btn.test.tsx
+++ b/apps/web/src/components/ui/btn/btn.test.tsx
@@ -53,7 +53,7 @@ describe('Btn', () => {
     expect(screen.getByRole('button')).toHaveClass('bg-transparent');
   });
 
-  it('entity prop sets data-entity and no inline color on primary variant', () => {
+  it('entity prop applies per-entity bg utility on primary variant (no inline color)', () => {
     render(
       <Btn variant="primary" entity="game">
         x
@@ -61,10 +61,17 @@ describe('Btn', () => {
     );
     const btn = screen.getByRole('button');
     expect(btn).toHaveAttribute('data-entity', 'game');
+    // Issue #2955 Fase 1: primary variant restores per-entity background via the
+    // registered `bg-entity-*` utility (not an inline style, not flat bg-primary).
+    expect(btn.className).toMatch(/bg-entity-game/);
+    // hover parity (#2955): entity primary dims its OWN hue on hover, it must not
+    // revert to theme `bg-primary/90` (which would flip a purple button to orange).
+    expect(btn.className).toMatch(/hover:bg-entity-game\/90/);
+    expect(btn.className).not.toMatch(/\bbg-primary\b/);
     expect(btn.style.backgroundColor).toBe('');
   });
 
-  it('entity=kb sets data-entity="kb"', () => {
+  it('entity=kb uses the registered -kb (teal) utility, not the unregistered document slate', () => {
     render(
       <Btn variant="primary" entity="kb">
         x
@@ -72,6 +79,15 @@ describe('Btn', () => {
     );
     const btn = screen.getByRole('button');
     expect(btn).toHaveAttribute('data-entity', 'kb');
+    expect(btn.className).toMatch(/bg-entity-kb/);
+    expect(btn.className).not.toMatch(/bg-entity-document/);
+  });
+
+  it('primary variant without entity keeps flat bg-primary', () => {
+    render(<Btn variant="primary">x</Btn>);
+    const btn = screen.getByRole('button');
+    expect(btn).toHaveClass('bg-primary');
+    expect(btn.className).not.toMatch(/bg-entity-/);
   });
 
   it('entity prop no longer inline-colors the outline variant', () => {

--- a/apps/web/src/components/ui/btn/btn.test.tsx
+++ b/apps/web/src/components/ui/btn/btn.test.tsx
@@ -102,6 +102,46 @@ describe('Btn', () => {
     expect(btn.style.color).toBe('');
   });
 
+  it('outline variant restores per-entity border + AA -text label when entity is provided', () => {
+    render(
+      <Btn variant="outline" entity="agent">
+        x
+      </Btn>
+    );
+    const btn = screen.getByRole('button');
+    expect(btn).toHaveAttribute('data-entity', 'agent');
+    // Issue #2955 Fase 2: outline restores the entity-colored border + AA
+    // text-on-tint label via the registered `-entity-*` / `-text` utilities.
+    expect(btn.className).toMatch(/border-entity-agent/);
+    expect(btn.className).toMatch(/text-entity-agent-text/);
+    // still transparent fill with muted hover (outline affordance preserved)
+    expect(btn.className).toMatch(/bg-transparent/);
+    expect(btn.className).toMatch(/hover:bg-muted/);
+    // className-only — never inline styles
+    expect(btn.style.borderColor).toBe('');
+    expect(btn.style.color).toBe('');
+  });
+
+  it('outline entity=kb uses the registered -kb (teal) utilities, not the document slate', () => {
+    render(
+      <Btn variant="outline" entity="kb">
+        x
+      </Btn>
+    );
+    const btn = screen.getByRole('button');
+    expect(btn.className).toMatch(/border-entity-kb/);
+    expect(btn.className).toMatch(/text-entity-kb-text/);
+    expect(btn.className).not.toMatch(/entity-document/);
+  });
+
+  it('outline variant without entity keeps the neutral border token', () => {
+    render(<Btn variant="outline">x</Btn>);
+    const btn = screen.getByRole('button');
+    expect(btn.className).toMatch(/border-border/);
+    expect(btn.className).not.toMatch(/border-entity-/);
+    expect(btn.className).not.toMatch(/text-entity-/);
+  });
+
   it('entity prop has no inline style effect on ghost/secondary/destructive', () => {
     const { rerender } = render(
       <Btn variant="ghost" entity="game">

--- a/apps/web/src/components/ui/btn/btn.tsx
+++ b/apps/web/src/components/ui/btn/btn.tsx
@@ -40,6 +40,43 @@ const VARIANT_CLASSES: Record<BtnVariant, string> = {
   destructive: 'bg-destructive text-destructive-foreground hover:bg-destructive/90',
 };
 
+/**
+ * Per-entity solid background for the primary variant (issue #2955, Fase 1).
+ * Literal class strings so Tailwind's content scanner emits the utilities — a
+ * dynamic `bg-entity-${entity}` would not be generated. `kb` maps to the
+ * registered `-kb` (teal) token, NOT `-document` (slate), which lives only in
+ * `@layer tokens` and is absent from `@theme inline`, so it would not render.
+ */
+const ENTITY_BG: Record<EntityType, string> = {
+  game: 'bg-entity-game',
+  player: 'bg-entity-player',
+  session: 'bg-entity-session',
+  agent: 'bg-entity-agent',
+  kb: 'bg-entity-kb',
+  chat: 'bg-entity-chat',
+  event: 'bg-entity-event',
+  toolkit: 'bg-entity-toolkit',
+  tool: 'bg-entity-tool',
+};
+
+/**
+ * Hover shade for the entity primary variant (issue #2955, Fase 1). Dims the
+ * entity's OWN hue to 90% opacity, preserving the hover affordance without
+ * reverting to theme `bg-primary/90` (which would flip e.g. a purple `player`
+ * button to orange). Literal strings for Tailwind's content scanner.
+ */
+const ENTITY_BG_HOVER: Record<EntityType, string> = {
+  game: 'hover:bg-entity-game/90',
+  player: 'hover:bg-entity-player/90',
+  session: 'hover:bg-entity-session/90',
+  agent: 'hover:bg-entity-agent/90',
+  kb: 'hover:bg-entity-kb/90',
+  chat: 'hover:bg-entity-chat/90',
+  event: 'hover:bg-entity-event/90',
+  toolkit: 'hover:bg-entity-toolkit/90',
+  tool: 'hover:bg-entity-tool/90',
+};
+
 function Spinner(): JSX.Element {
   return (
     <svg
@@ -79,12 +116,20 @@ export function Btn({
 }: BtnProps): JSX.Element {
   const isDisabled = disabled || loading;
 
+  // Fase 1 (#2955): the primary variant carries the per-entity background when an
+  // `entity` is supplied; the label stays on `text-primary-foreground`. Other
+  // variants are unaffected, and primary without an entity keeps the flat token.
+  const variantClasses =
+    variant === 'primary' && entity
+      ? clsx('text-primary-foreground', ENTITY_BG[entity], ENTITY_BG_HOVER[entity])
+      : VARIANT_CLASSES[variant];
+
   const classes = clsx(
     'inline-flex items-center justify-center gap-2 font-semibold rounded-xl transition-colors',
     'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2',
     'disabled:opacity-50 disabled:pointer-events-none',
     SIZE_CLASSES[size],
-    VARIANT_CLASSES[variant],
+    variantClasses,
     fullWidth && 'w-full',
     className
   );

--- a/apps/web/src/components/ui/btn/btn.tsx
+++ b/apps/web/src/components/ui/btn/btn.tsx
@@ -77,6 +77,41 @@ const ENTITY_BG_HOVER: Record<EntityType, string> = {
   tool: 'hover:bg-entity-tool/90',
 };
 
+/**
+ * Per-entity border for the outline variant (issue #2955, Fase 2). Literal
+ * class strings for Tailwind's content scanner. `kb` maps to the registered
+ * `-kb` (teal) token, NOT `-document` (slate).
+ */
+const ENTITY_BORDER: Record<EntityType, string> = {
+  game: 'border-entity-game',
+  player: 'border-entity-player',
+  session: 'border-entity-session',
+  agent: 'border-entity-agent',
+  kb: 'border-entity-kb',
+  chat: 'border-entity-chat',
+  event: 'border-entity-event',
+  toolkit: 'border-entity-toolkit',
+  tool: 'border-entity-tool',
+};
+
+/**
+ * Per-entity AA text-on-tint label for the outline variant (issue #2955, Fase
+ * 2). The `-text` variant (verified >=4.5:1 in Fase 0) keeps the outline label
+ * readable on the transparent surface and the blocking axe AA gate green.
+ * Literal strings for Tailwind's content scanner; `kb` -> registered `-kb-text`.
+ */
+const ENTITY_TEXT: Record<EntityType, string> = {
+  game: 'text-entity-game-text',
+  player: 'text-entity-player-text',
+  session: 'text-entity-session-text',
+  agent: 'text-entity-agent-text',
+  kb: 'text-entity-kb-text',
+  chat: 'text-entity-chat-text',
+  event: 'text-entity-event-text',
+  toolkit: 'text-entity-toolkit-text',
+  tool: 'text-entity-tool-text',
+};
+
 function Spinner(): JSX.Element {
   return (
     <svg
@@ -117,12 +152,16 @@ export function Btn({
   const isDisabled = disabled || loading;
 
   // Fase 1 (#2955): the primary variant carries the per-entity background when an
-  // `entity` is supplied; the label stays on `text-primary-foreground`. Other
-  // variants are unaffected, and primary without an entity keeps the flat token.
+  // `entity` is supplied; the label stays on `text-primary-foreground`.
+  // Fase 2 (#2955): the outline variant carries the per-entity border + AA
+  // text-on-tint label. Both fall back to the flat token when no entity is set,
+  // and the other variants (secondary/ghost/destructive) are unaffected.
   const variantClasses =
     variant === 'primary' && entity
       ? clsx('text-primary-foreground', ENTITY_BG[entity], ENTITY_BG_HOVER[entity])
-      : VARIANT_CLASSES[variant];
+      : variant === 'outline' && entity
+        ? clsx('border bg-transparent hover:bg-muted', ENTITY_BORDER[entity], ENTITY_TEXT[entity])
+        : VARIANT_CLASSES[variant];
 
   const classes = clsx(
     'inline-flex items-center justify-center gap-2 font-semibold rounded-xl transition-colors',

--- a/apps/web/src/components/ui/data-display/entity-list-view/components/entity-table-view.test.tsx
+++ b/apps/web/src/components/ui/data-display/entity-list-view/components/entity-table-view.test.tsx
@@ -1,0 +1,177 @@
+/**
+ * EntityTableView — per-entity coloring regression tests (Issue #2955 Fase 2)
+ *
+ * Asserts the design-sensitive primitive uses CANONICAL entity tokens:
+ *   - Row accent border → `border-entity-<e>` (base token, borders need only 3:1)
+ *   - Badge pill → soft tint `bg-entity-<e>/10` + AA label `text-entity-<e>-text`
+ *
+ * Guards against regressions:
+ *   - No hardcoded inline HSL (`border-l-[hsl(...)]`) on the row accent.
+ *   - kb resolves to the registered TEAL `-kb` / `-kb-text`, NEVER `-document`.
+ *   - Badge is no longer the flat `bg-muted` neutral.
+ */
+import { render, screen } from '@testing-library/react';
+import { axe } from 'jest-axe';
+import { describe, expect, it } from 'vitest';
+
+import { EntityTableView } from './entity-table-view';
+
+import type { MeepleEntityType } from '../../meeple-card';
+
+interface Row {
+  id: string;
+  name: string;
+  tag: string;
+}
+
+const ITEMS: Row[] = [{ id: 'r1', name: 'Catan', tag: 'NEW' }];
+
+const renderItem = (item: Row) => ({
+  id: item.id,
+  title: item.name,
+  badge: item.tag,
+});
+
+function renderTable(entity: MeepleEntityType) {
+  return render(
+    <EntityTableView entity={entity} displayItems={ITEMS} items={ITEMS} renderItem={renderItem} />
+  );
+}
+
+// The 9 canonical entities → their expected literal canonical classes.
+const CANONICAL: Array<{
+  entity: MeepleEntityType;
+  border: RegExp;
+  badgeBg: RegExp;
+  text: RegExp;
+}> = [
+  {
+    entity: 'game',
+    border: /border-entity-game(?!-)/,
+    badgeBg: /bg-entity-game\/10/,
+    text: /text-entity-game-text/,
+  },
+  {
+    entity: 'player',
+    border: /border-entity-player(?!-)/,
+    badgeBg: /bg-entity-player\/10/,
+    text: /text-entity-player-text/,
+  },
+  {
+    entity: 'session',
+    border: /border-entity-session(?!-)/,
+    badgeBg: /bg-entity-session\/10/,
+    text: /text-entity-session-text/,
+  },
+  {
+    entity: 'agent',
+    border: /border-entity-agent(?!-)/,
+    badgeBg: /bg-entity-agent\/10/,
+    text: /text-entity-agent-text/,
+  },
+  {
+    entity: 'kb',
+    border: /border-entity-kb(?!-)/,
+    badgeBg: /bg-entity-kb\/10/,
+    text: /text-entity-kb-text/,
+  },
+  {
+    entity: 'chat',
+    border: /border-entity-chat(?!-)/,
+    badgeBg: /bg-entity-chat\/10/,
+    text: /text-entity-chat-text/,
+  },
+  {
+    entity: 'event',
+    border: /border-entity-event(?!-)/,
+    badgeBg: /bg-entity-event\/10/,
+    text: /text-entity-event-text/,
+  },
+  {
+    entity: 'toolkit',
+    border: /border-entity-toolkit(?!-)/,
+    badgeBg: /bg-entity-toolkit\/10/,
+    text: /text-entity-toolkit-text/,
+  },
+  {
+    entity: 'tool',
+    border: /border-entity-tool(?!-)/,
+    badgeBg: /bg-entity-tool\/10/,
+    text: /text-entity-tool-text/,
+  },
+];
+
+describe('EntityTableView — canonical per-entity row border (#2955 Fase 2)', () => {
+  it.each(CANONICAL)(
+    'row border uses canonical border-entity-$entity token',
+    ({ entity, border }) => {
+      renderTable(entity);
+      const layout = screen.getByTestId('table-layout');
+      expect(layout.className).toMatch(border);
+    }
+  );
+
+  it('row border carries NO hardcoded inline HSL (arbitrary value or style attr)', () => {
+    renderTable('agent');
+    const layout = screen.getByTestId('table-layout');
+    expect(layout.className).not.toMatch(/hsl\(/);
+    expect(layout.className).not.toMatch(/border-l-\[/);
+    // The old design applied colour via an arbitrary class; nothing should set it inline now.
+    expect(layout.getAttribute('style')).toBeNull();
+  });
+});
+
+describe('EntityTableView — canonical per-entity badge pill (#2955 Fase 2)', () => {
+  it.each(CANONICAL)(
+    'badge for $entity uses soft tint bg-entity-$entity/10 + AA -text label',
+    ({ entity, badgeBg, text }) => {
+      renderTable(entity);
+      const badge = screen.getByText('NEW');
+      expect(badge.className).toMatch(badgeBg);
+      expect(badge.className).toMatch(text);
+    }
+  );
+
+  it('badge is no longer the flat neutral bg-muted', () => {
+    renderTable('game');
+    const badge = screen.getByText('NEW');
+    expect(badge.className).not.toMatch(/bg-muted/);
+    expect(badge.className).not.toMatch(/text-muted-foreground/);
+  });
+});
+
+describe('EntityTableView — kb uses registered teal token, never -document (#2955)', () => {
+  it('kb row border resolves to -kb (teal), never -document, no inline HSL', () => {
+    renderTable('kb');
+    const layout = screen.getByTestId('table-layout');
+    expect(layout.className).toMatch(/border-entity-kb(?!-)/);
+    expect(layout.className).not.toMatch(/entity-document/);
+    expect(layout.className).not.toMatch(/hsl\(/);
+  });
+
+  it('kb badge uses -kb tint + -kb-text, never -document', () => {
+    renderTable('kb');
+    const badge = screen.getByText('NEW');
+    expect(badge.className).toMatch(/bg-entity-kb\/10/);
+    expect(badge.className).toMatch(/text-entity-kb-text/);
+    expect(badge.className).not.toMatch(/entity-document/);
+  });
+});
+
+describe('EntityTableView — gameNightEvent reuses canonical event token (#1929 WP2)', () => {
+  it('maps gameNightEvent border + badge to canonical event token', () => {
+    renderTable('gameNightEvent');
+    const layout = screen.getByTestId('table-layout');
+    expect(layout.className).toMatch(/border-entity-event(?!-)/);
+    const badge = screen.getByText('NEW');
+    expect(badge.className).toMatch(/bg-entity-event\/10/);
+    expect(badge.className).toMatch(/text-entity-event-text/);
+  });
+});
+
+describe('EntityTableView — a11y (#2955 Fase 2)', () => {
+  it('has no axe AA violations with an entity-coloured badge', async () => {
+    const { container } = renderTable('game');
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/apps/web/src/components/ui/data-display/entity-list-view/components/entity-table-view.test.tsx
+++ b/apps/web/src/components/ui/data-display/entity-list-view/components/entity-table-view.test.tsx
@@ -2,7 +2,7 @@
  * EntityTableView — per-entity coloring regression tests (Issue #2955 Fase 2)
  *
  * Asserts the design-sensitive primitive uses CANONICAL entity tokens:
- *   - Row accent border → `border-entity-<e>` (base token, borders need only 3:1)
+ *   - Row accent border → `border-l-entity-<e>` (base token, borders need only 3:1)
  *   - Badge pill → soft tint `bg-entity-<e>/10` + AA label `text-entity-<e>-text`
  *
  * Guards against regressions:
@@ -47,55 +47,55 @@ const CANONICAL: Array<{
 }> = [
   {
     entity: 'game',
-    border: /border-entity-game(?!-)/,
+    border: /border-l-entity-game(?!-)/,
     badgeBg: /bg-entity-game\/10/,
     text: /text-entity-game-text/,
   },
   {
     entity: 'player',
-    border: /border-entity-player(?!-)/,
+    border: /border-l-entity-player(?!-)/,
     badgeBg: /bg-entity-player\/10/,
     text: /text-entity-player-text/,
   },
   {
     entity: 'session',
-    border: /border-entity-session(?!-)/,
+    border: /border-l-entity-session(?!-)/,
     badgeBg: /bg-entity-session\/10/,
     text: /text-entity-session-text/,
   },
   {
     entity: 'agent',
-    border: /border-entity-agent(?!-)/,
+    border: /border-l-entity-agent(?!-)/,
     badgeBg: /bg-entity-agent\/10/,
     text: /text-entity-agent-text/,
   },
   {
     entity: 'kb',
-    border: /border-entity-kb(?!-)/,
+    border: /border-l-entity-kb(?!-)/,
     badgeBg: /bg-entity-kb\/10/,
     text: /text-entity-kb-text/,
   },
   {
     entity: 'chat',
-    border: /border-entity-chat(?!-)/,
+    border: /border-l-entity-chat(?!-)/,
     badgeBg: /bg-entity-chat\/10/,
     text: /text-entity-chat-text/,
   },
   {
     entity: 'event',
-    border: /border-entity-event(?!-)/,
+    border: /border-l-entity-event(?!-)/,
     badgeBg: /bg-entity-event\/10/,
     text: /text-entity-event-text/,
   },
   {
     entity: 'toolkit',
-    border: /border-entity-toolkit(?!-)/,
+    border: /border-l-entity-toolkit(?!-)/,
     badgeBg: /bg-entity-toolkit\/10/,
     text: /text-entity-toolkit-text/,
   },
   {
     entity: 'tool',
-    border: /border-entity-tool(?!-)/,
+    border: /border-l-entity-tool(?!-)/,
     badgeBg: /bg-entity-tool\/10/,
     text: /text-entity-tool-text/,
   },
@@ -103,7 +103,7 @@ const CANONICAL: Array<{
 
 describe('EntityTableView — canonical per-entity row border (#2955 Fase 2)', () => {
   it.each(CANONICAL)(
-    'row border uses canonical border-entity-$entity token',
+    'row border uses canonical border-l-entity-$entity token',
     ({ entity, border }) => {
       renderTable(entity);
       const layout = screen.getByTestId('table-layout');
@@ -144,7 +144,7 @@ describe('EntityTableView — kb uses registered teal token, never -document (#2
   it('kb row border resolves to -kb (teal), never -document, no inline HSL', () => {
     renderTable('kb');
     const layout = screen.getByTestId('table-layout');
-    expect(layout.className).toMatch(/border-entity-kb(?!-)/);
+    expect(layout.className).toMatch(/border-l-entity-kb(?!-)/);
     expect(layout.className).not.toMatch(/entity-document/);
     expect(layout.className).not.toMatch(/hsl\(/);
   });
@@ -162,7 +162,7 @@ describe('EntityTableView — gameNightEvent reuses canonical event token (#1929
   it('maps gameNightEvent border + badge to canonical event token', () => {
     renderTable('gameNightEvent');
     const layout = screen.getByTestId('table-layout');
-    expect(layout.className).toMatch(/border-entity-event(?!-)/);
+    expect(layout.className).toMatch(/border-l-entity-event(?!-)/);
     const badge = screen.getByText('NEW');
     expect(badge.className).toMatch(/bg-entity-event\/10/);
     expect(badge.className).toMatch(/text-entity-event-text/);

--- a/apps/web/src/components/ui/data-display/entity-list-view/components/entity-table-view.tsx
+++ b/apps/web/src/components/ui/data-display/entity-list-view/components/entity-table-view.tsx
@@ -27,21 +27,53 @@ import type { TableColumnConfig } from '../entity-list-view.types';
 import type { ColumnDef, SortingState } from '@tanstack/react-table';
 
 // ============================================================================
-// Entity color map for row accents
+// Entity color maps (canonical tokens — Issue #2955 Fase 2)
+//
+// Literal static maps (ESLint-friendly, no template literals / getEntityToken).
+// - Row accent border → `border-entity-<e>` base token (`--c-<e>`); borders
+//   only need 3:1, so the base — not the darker `-text` — is correct.
+// - Badge pill → soft tint `bg-entity-<e>/10` + AA label `text-entity-<e>-text`.
+// kb resolves to the registered TEAL `-kb` / `-kb-text`, NEVER `-document`.
+// gameNightEvent reuses the canonical `event` token (#1929 WP2).
 // ============================================================================
 
-const ENTITY_BORDER_COLORS: Record<MeepleEntityType, string> = {
-  game: 'border-l-[hsl(25,95%,45%)]',
-  player: 'border-l-[hsl(262,83%,58%)]',
-  session: 'border-l-[hsl(240,60%,55%)]',
-  agent: 'border-l-[hsl(38,92%,50%)]',
-  kb: 'border-l-[hsl(174,60%,40%)]',
-  chat: 'border-l-[hsl(220,80%,55%)]',
-  event: 'border-l-[hsl(350,89%,60%)]',
-  toolkit: 'border-l-[hsl(142,70%,45%)]',
-  tool: 'border-l-[hsl(195,80%,50%)]',
-  // #1929 WP2: GameNight reuses event/rose palette
-  gameNightEvent: 'border-l-[hsl(350,89%,60%)]',
+const ENTITY_BORDER: Record<MeepleEntityType, string> = {
+  game: 'border-entity-game',
+  player: 'border-entity-player',
+  session: 'border-entity-session',
+  agent: 'border-entity-agent',
+  kb: 'border-entity-kb',
+  chat: 'border-entity-chat',
+  event: 'border-entity-event',
+  toolkit: 'border-entity-toolkit',
+  tool: 'border-entity-tool',
+  gameNightEvent: 'border-entity-event',
+};
+
+const ENTITY_BADGE_BG: Record<MeepleEntityType, string> = {
+  game: 'bg-entity-game/10',
+  player: 'bg-entity-player/10',
+  session: 'bg-entity-session/10',
+  agent: 'bg-entity-agent/10',
+  kb: 'bg-entity-kb/10',
+  chat: 'bg-entity-chat/10',
+  event: 'bg-entity-event/10',
+  toolkit: 'bg-entity-toolkit/10',
+  tool: 'bg-entity-tool/10',
+  gameNightEvent: 'bg-entity-event/10',
+};
+
+const ENTITY_TEXT: Record<MeepleEntityType, string> = {
+  game: 'text-entity-game-text',
+  player: 'text-entity-player-text',
+  session: 'text-entity-session-text',
+  agent: 'text-entity-agent-text',
+  kb: 'text-entity-kb-text',
+  chat: 'text-entity-chat-text',
+  event: 'text-entity-event-text',
+  toolkit: 'text-entity-toolkit-text',
+  tool: 'text-entity-tool-text',
+  gameNightEvent: 'text-entity-event-text',
 };
 
 // ============================================================================
@@ -84,7 +116,8 @@ export interface EntityTableViewProps<T> {
 // Auto-generate columns from MeepleCardProps
 // ============================================================================
 
-function createDefaultColumns(): ColumnDef<TableRowData, unknown>[] {
+function createDefaultColumns(entity: MeepleEntityType): ColumnDef<TableRowData, unknown>[] {
+  const badgeClass = cn(ENTITY_BADGE_BG[entity], ENTITY_TEXT[entity]);
   return [
     {
       accessorKey: 'title',
@@ -104,7 +137,7 @@ function createDefaultColumns(): ColumnDef<TableRowData, unknown>[] {
               <span
                 className={cn(
                   'ml-2 inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-semibold uppercase',
-                  'bg-muted text-muted-foreground'
+                  badgeClass
                 )}
               >
                 {row.original.badge}
@@ -218,8 +251,8 @@ export function EntityTableView<T>({
     if (customColumns && customColumns.length > 0) {
       return createColumnsFromConfig(customColumns);
     }
-    return createDefaultColumns();
-  }, [customColumns]);
+    return createDefaultColumns(entity);
+  }, [customColumns, entity]);
 
   // Row click handler
   const handleRowClick = useMemo(() => {
@@ -230,8 +263,8 @@ export function EntityTableView<T>({
     };
   }, [onItemClick, displayItems]);
 
-  // Entity-colored row styling via CSS class override
-  const borderClass = ENTITY_BORDER_COLORS[entity] || '';
+  // Entity-colored row styling via canonical token class (#2955 Fase 2)
+  const borderClass = ENTITY_BORDER[entity] || '';
 
   return (
     <div

--- a/apps/web/src/components/ui/data-display/entity-list-view/components/entity-table-view.tsx
+++ b/apps/web/src/components/ui/data-display/entity-list-view/components/entity-table-view.tsx
@@ -37,17 +37,23 @@ import type { ColumnDef, SortingState } from '@tanstack/react-table';
 // gameNightEvent reuses the canonical `event` token (#1929 WP2).
 // ============================================================================
 
-const ENTITY_BORDER: Record<MeepleEntityType, string> = {
-  game: 'border-entity-game',
-  player: 'border-entity-player',
-  session: 'border-entity-session',
-  agent: 'border-entity-agent',
-  kb: 'border-entity-kb',
-  chat: 'border-entity-chat',
-  event: 'border-entity-event',
-  toolkit: 'border-entity-toolkit',
-  tool: 'border-entity-tool',
-  gameNightEvent: 'border-entity-event',
+// Entity-colored LEFT accent on each row (#2955 Fase 2). The color MUST target
+// the same element as the width — the `<tr>` — via the `[&_tbody_tr]:` descendant
+// variant. A plain `border-entity-*` on the wrapper div is a no-op: the wrapper
+// has no border-width, and `border-color` does not inherit to the rows (whose own
+// `border-border/50` would otherwise win). kb → registered `-kb` (teal), never
+// `-document`. Pairs with the `[&_tbody_tr]:border-l-4` width class on the wrapper.
+const ENTITY_ROW_BORDER: Record<MeepleEntityType, string> = {
+  game: '[&_tbody_tr]:border-l-entity-game',
+  player: '[&_tbody_tr]:border-l-entity-player',
+  session: '[&_tbody_tr]:border-l-entity-session',
+  agent: '[&_tbody_tr]:border-l-entity-agent',
+  kb: '[&_tbody_tr]:border-l-entity-kb',
+  chat: '[&_tbody_tr]:border-l-entity-chat',
+  event: '[&_tbody_tr]:border-l-entity-event',
+  toolkit: '[&_tbody_tr]:border-l-entity-toolkit',
+  tool: '[&_tbody_tr]:border-l-entity-tool',
+  gameNightEvent: '[&_tbody_tr]:border-l-entity-event',
 };
 
 const ENTITY_BADGE_BG: Record<MeepleEntityType, string> = {
@@ -264,7 +270,7 @@ export function EntityTableView<T>({
   }, [onItemClick, displayItems]);
 
   // Entity-colored row styling via canonical token class (#2955 Fase 2)
-  const borderClass = ENTITY_BORDER[entity] || '';
+  const borderClass = ENTITY_ROW_BORDER[entity] || '';
 
   return (
     <div

--- a/apps/web/src/components/ui/drawer/drawer.test.tsx
+++ b/apps/web/src/components/ui/drawer/drawer.test.tsx
@@ -184,10 +184,13 @@ describe('Drawer (desktop / Radix)', () => {
     const dialog = screen.getByRole('dialog');
     const accent = dialog.querySelector('[data-drawer-accent="game"]');
     expect(accent).toBeInTheDocument();
-    expect(accent?.className).toContain('bg-primary');
+    // Issue #2955 Fase 1: the accent strip restores the per-entity color via the
+    // registered `bg-entity-*` utility instead of the flattened `bg-primary`.
+    expect(accent?.className).toContain('bg-entity-game');
+    expect(accent?.className).not.toContain('bg-primary');
   });
 
-  it('renders the desktop accent for kb entity', () => {
+  it('renders the desktop accent for kb entity using the registered -kb (teal) utility', () => {
     render(
       <Drawer open onOpenChange={() => {}} side="desktop-right" entity="kb">
         <DrawerContent>
@@ -199,7 +202,10 @@ describe('Drawer (desktop / Radix)', () => {
     );
     const accent = screen.getByRole('dialog').querySelector('[data-drawer-accent="kb"]');
     expect(accent).toBeInTheDocument();
-    expect(accent?.className).toContain('bg-primary');
+    // kb must use `-kb` (teal), never the unregistered `-document` (slate) token.
+    expect(accent?.className).toContain('bg-entity-kb');
+    expect(accent?.className).not.toContain('bg-entity-document');
+    expect(accent?.className).not.toContain('bg-primary');
   });
 
   it('has no a11y violations on desktop', async () => {
@@ -269,7 +275,9 @@ describe('Drawer (mobile / vaul)', () => {
     await screen.findByText('player drawer');
     const accent = document.querySelector('[data-drawer-accent="player"]');
     expect(accent).not.toBeNull();
-    expect(accent?.className).toContain('bg-primary');
+    // Issue #2955 Fase 1: mobile handle restores the per-entity color utility.
+    expect(accent?.className).toContain('bg-entity-player');
+    expect(accent?.className).not.toContain('bg-primary');
   });
 
   it('DrawerClose triggers onOpenChange(false) on mobile', async () => {

--- a/apps/web/src/components/ui/drawer/drawer.tsx
+++ b/apps/web/src/components/ui/drawer/drawer.tsx
@@ -83,6 +83,25 @@ const MOBILE_CONTENT_CLS =
 const DESKTOP_CONTENT_CLS =
   'fixed inset-y-0 right-0 z-50 flex w-[480px] max-w-full flex-col rounded-l-2xl bg-card shadow-lg outline-none';
 
+/**
+ * Per-entity accent color (issue #2955, Fase 1) for the mobile handle and the
+ * desktop accent strip. Literal class strings so Tailwind's content scanner
+ * emits the utilities — a dynamic `bg-entity-${entity}` would not be generated.
+ * `kb` maps to the registered `-kb` (teal) token, NOT `-document` (slate), which
+ * lives only in `@layer tokens` and is absent from `@theme inline`.
+ */
+const ENTITY_BG: Record<EntityType, string> = {
+  game: 'bg-entity-game',
+  player: 'bg-entity-player',
+  session: 'bg-entity-session',
+  agent: 'bg-entity-agent',
+  kb: 'bg-entity-kb',
+  chat: 'bg-entity-chat',
+  event: 'bg-entity-event',
+  toolkit: 'bg-entity-toolkit',
+  tool: 'bg-entity-tool',
+};
+
 export interface DrawerContentProps extends HTMLAttributes<HTMLDivElement> {
   readonly children: ReactNode;
 }
@@ -102,7 +121,7 @@ export const DrawerContent = forwardRef<HTMLDivElement, DrawerContentProps>(func
             aria-hidden="true"
             className={clsx(
               'mx-auto mt-2 h-1 w-12 rounded-full',
-              entity ? 'bg-primary' : 'bg-border'
+              entity ? ENTITY_BG[entity] : 'bg-border'
             )}
           />
           {children}
@@ -118,7 +137,7 @@ export const DrawerContent = forwardRef<HTMLDivElement, DrawerContentProps>(func
           <div
             data-drawer-accent={entity}
             aria-hidden="true"
-            className="absolute inset-y-0 left-0 w-1 rounded-l-2xl bg-primary"
+            className={clsx('absolute inset-y-0 left-0 w-1 rounded-l-2xl', ENTITY_BG[entity])}
           />
         )}
         {children}

--- a/apps/web/src/components/ui/entity-card/entity-card.test.tsx
+++ b/apps/web/src/components/ui/entity-card/entity-card.test.tsx
@@ -33,10 +33,11 @@ describe('EntityCard', () => {
     );
     const el = container.querySelector<HTMLElement>('[data-entity="game"]');
     expect(el?.className).toMatch(/border-l-4/);
+    expect(el?.className).toMatch(/border-l-entity-game/);
     expect(el?.style.borderLeftColor).toBe('');
   });
 
-  it('renders with data-entity="kb" and no inline border color', () => {
+  it('uses the registered -kb (teal) utility for kb, not the unregistered document slate', () => {
     const { container } = render(
       <EntityCard entity="kb">
         <span>x</span>
@@ -44,6 +45,8 @@ describe('EntityCard', () => {
     );
     const el = container.querySelector<HTMLElement>('[data-entity="kb"]');
     expect(el).toBeInTheDocument();
+    expect(el?.className).toMatch(/border-l-entity-kb/);
+    expect(el?.className).not.toMatch(/border-l-entity-document/);
     expect(el?.style.borderLeftColor).toBe('');
   });
 

--- a/apps/web/src/components/ui/entity-card/entity-card.tsx
+++ b/apps/web/src/components/ui/entity-card/entity-card.tsx
@@ -6,6 +6,24 @@ import type { EntityType } from '@/components/ui/entity-tokens';
 
 export type EntityCardVariant = 'default' | 'elevated' | 'flat';
 
+/**
+ * Per-entity left-border accent (issue #2955). Literal class strings so Tailwind's
+ * content scanner generates the utilities (dynamic `border-l-entity-${e}` would not
+ * be emitted). `kb` uses the registered `-kb` (teal) token — NOT `-document` (slate),
+ * which lives only in `@layer tokens` and is not exposed via `@theme inline`.
+ */
+const ENTITY_BORDER_L: Record<EntityType, string> = {
+  game: 'border-l-entity-game',
+  player: 'border-l-entity-player',
+  session: 'border-l-entity-session',
+  agent: 'border-l-entity-agent',
+  kb: 'border-l-entity-kb',
+  chat: 'border-l-entity-chat',
+  event: 'border-l-entity-event',
+  toolkit: 'border-l-entity-toolkit',
+  tool: 'border-l-entity-tool',
+};
+
 export interface EntityCardProps {
   readonly entity: EntityType;
   readonly variant?: EntityCardVariant;
@@ -38,6 +56,7 @@ export function EntityCard({
   const classes = clsx(
     'bg-card rounded-xl p-4 text-foreground transition-colors',
     entityBorder && 'border-l-4',
+    entityBorder && ENTITY_BORDER_L[entity],
     variant === 'default' && 'border border-border',
     variant === 'elevated' && 'shadow-md',
     isInteractive && 'cursor-pointer transition-transform hover:-translate-y-0.5 hover:bg-muted/40',

--- a/apps/web/src/components/ui/entity-pip/entity-pip.test.tsx
+++ b/apps/web/src/components/ui/entity-pip/entity-pip.test.tsx
@@ -21,7 +21,7 @@ describe('EntityPip', () => {
 
   it('applies entity color class via background token', () => {
     const { container } = render(<EntityPip entity="session" count={2} />);
-    // bg-entity-<key> class from getEntityToken
+    // bg-entity-<key> class from the literal ENTITY_BG map
     expect(container.querySelector('.bg-entity-session')).toBeInTheDocument();
   });
 
@@ -70,6 +70,27 @@ describe('EntityPip', () => {
     const { container } = render(<EntityPip entity="kb" count={5} active />);
     const el = container.querySelector('[data-entity="kb"]');
     expect(el?.className).toMatch(/ring-2/);
+  });
+
+  it('applies the entity-colored active ring via a literal ring-entity-* utility', () => {
+    const { container } = render(<EntityPip entity="player" count={2} active />);
+    const el = container.querySelector('[data-entity="player"]');
+    expect(el?.className).toMatch(/ring-2/);
+    expect(el?.className).toMatch(/ring-entity-player/);
+  });
+
+  it('does not add an entity ring when not active', () => {
+    const { container } = render(<EntityPip entity="player" count={2} />);
+    const el = container.querySelector('[data-entity="player"]');
+    expect(el?.className).not.toMatch(/ring-entity-player/);
+  });
+
+  it('uses the registered -kb (teal) utilities for kb bg + active ring, not the unregistered document slate', () => {
+    const { container } = render(<EntityPip entity="kb" count={5} active />);
+    const el = container.querySelector('[data-entity="kb"]');
+    expect(el?.className).toMatch(/bg-entity-kb/);
+    expect(el?.className).toMatch(/ring-entity-kb/);
+    expect(el?.className).not.toMatch(/entity-document/);
   });
 
   it('applies opacity-40 when count === 0', () => {

--- a/apps/web/src/components/ui/entity-pip/entity-pip.tsx
+++ b/apps/web/src/components/ui/entity-pip/entity-pip.tsx
@@ -2,7 +2,38 @@ import type { JSX } from 'react';
 
 import clsx from 'clsx';
 
-import { getEntityToken, type EntityType } from '@/components/ui/entity-tokens';
+import type { EntityType } from '@/components/ui/entity-tokens';
+
+/**
+ * Per-entity solid background (issue #2955). Literal class strings so Tailwind's
+ * content scanner emits the utilities (a dynamic `bg-entity-${entity}` would NOT be
+ * generated). `kb` uses the registered `-kb` (teal) token — NEVER `-document` (slate),
+ * which lives only in `@layer tokens` and is not exposed via `@theme inline`.
+ */
+const ENTITY_BG: Record<EntityType, string> = {
+  game: 'bg-entity-game',
+  player: 'bg-entity-player',
+  session: 'bg-entity-session',
+  agent: 'bg-entity-agent',
+  kb: 'bg-entity-kb',
+  chat: 'bg-entity-chat',
+  event: 'bg-entity-event',
+  toolkit: 'bg-entity-toolkit',
+  tool: 'bg-entity-tool',
+};
+
+/** Per-entity active/focus ring (issue #2955). Same literal-map discipline as ENTITY_BG. */
+const ENTITY_RING: Record<EntityType, string> = {
+  game: 'ring-entity-game',
+  player: 'ring-entity-player',
+  session: 'ring-entity-session',
+  agent: 'ring-entity-agent',
+  kb: 'ring-entity-kb',
+  chat: 'ring-entity-chat',
+  event: 'ring-entity-event',
+  toolkit: 'ring-entity-toolkit',
+  tool: 'ring-entity-tool',
+};
 
 export interface EntityPipProps {
   readonly entity: EntityType;
@@ -29,7 +60,6 @@ export function EntityPip({
     );
   }
 
-  const token = getEntityToken(entity);
   const hasCount = typeof count === 'number';
   const isEmpty = count === 0;
 
@@ -40,9 +70,10 @@ export function EntityPip({
 
   const baseClasses = clsx(
     'inline-flex items-center justify-center rounded-full font-medium',
-    token.bg,
+    ENTITY_BG[entity],
     hasCount ? `${pillSize} text-white tabular-nums` : dotSize,
     active && 'ring-2 ring-offset-1',
+    active && ENTITY_RING[entity],
     isEmpty && 'opacity-40 cursor-default',
     className
   );

--- a/apps/web/src/components/ui/notification-card/notification-card.test.tsx
+++ b/apps/web/src/components/ui/notification-card/notification-card.test.tsx
@@ -46,20 +46,38 @@ describe('NotificationCard', () => {
     expect(screen.getByTestId('n-icon')).toBeInTheDocument();
   });
 
-  it('entity=game keeps the border-l-4 accent (no inline color)', () => {
+  it('entity=game keeps the border-l-4 accent with the entity color (no inline color)', () => {
     const { container } = render(<NotificationCard entity="game" title="x" timestamp="ora" />);
     const el = container.querySelector<HTMLElement>('[data-entity="game"]');
     expect(el?.className).toMatch(/border-l-4/);
+    expect(el?.className).toMatch(/border-l-entity-game/);
     expect(el?.style.borderLeftColor).toBe('');
   });
 
-  it('renders with data-entity="kb" and no inline border color', () => {
+  it('uses the registered -kb (teal) left border for kb, not the unregistered -document slate', () => {
     const { container } = render(
       <NotificationCard entity="kb" title="Nuova regola" timestamp="ieri" />
     );
     const el = container.querySelector<HTMLElement>('[data-entity="kb"]');
     expect(el).toBeInTheDocument();
+    expect(el?.className).toMatch(/border-l-entity-kb/);
+    expect(el?.className).not.toMatch(/entity-document/);
     expect(el?.style.borderLeftColor).toBe('');
+  });
+
+  it('unread dot uses the entity color for game (not bg-primary)', () => {
+    render(<NotificationCard entity="game" title="x" timestamp="ora" unread />);
+    const dot = screen.getByTestId('unread-dot');
+    expect(dot.className).toMatch(/bg-entity-game/);
+    expect(dot.className).not.toMatch(/bg-primary/);
+  });
+
+  it('unread dot uses -kb (teal) for kb, not -document slate or bg-primary', () => {
+    render(<NotificationCard entity="kb" title="x" timestamp="ora" unread />);
+    const dot = screen.getByTestId('unread-dot');
+    expect(dot.className).toMatch(/bg-entity-kb/);
+    expect(dot.className).not.toMatch(/entity-document/);
+    expect(dot.className).not.toMatch(/bg-primary/);
   });
 
   it('unread=true shows unread dot pip', () => {

--- a/apps/web/src/components/ui/notification-card/notification-card.tsx
+++ b/apps/web/src/components/ui/notification-card/notification-card.tsx
@@ -4,6 +4,36 @@ import clsx from 'clsx';
 
 import type { EntityType } from '@/components/ui/entity-tokens';
 
+/**
+ * Per-entity color maps (issue #2955). Literal class strings so Tailwind's content
+ * scanner emits the utilities (a dynamic `border-l-entity-${entity}` would NOT be
+ * generated). `kb` uses the registered `-kb` (teal) token — NEVER `-document` (slate),
+ * which lives only in `@layer tokens` and is not exposed via `@theme inline`.
+ */
+const ENTITY_BORDER_L: Record<EntityType, string> = {
+  game: 'border-l-entity-game',
+  player: 'border-l-entity-player',
+  session: 'border-l-entity-session',
+  agent: 'border-l-entity-agent',
+  kb: 'border-l-entity-kb',
+  chat: 'border-l-entity-chat',
+  event: 'border-l-entity-event',
+  toolkit: 'border-l-entity-toolkit',
+  tool: 'border-l-entity-tool',
+};
+
+const ENTITY_BG: Record<EntityType, string> = {
+  game: 'bg-entity-game',
+  player: 'bg-entity-player',
+  session: 'bg-entity-session',
+  agent: 'bg-entity-agent',
+  kb: 'bg-entity-kb',
+  chat: 'bg-entity-chat',
+  event: 'bg-entity-event',
+  toolkit: 'bg-entity-toolkit',
+  tool: 'bg-entity-tool',
+};
+
 export interface NotificationCardProps {
   readonly entity: EntityType;
   readonly title: string;
@@ -50,6 +80,7 @@ export function NotificationCard({
 }: NotificationCardProps): JSX.Element {
   const containerClasses = clsx(
     'group relative flex gap-3 rounded-xl border-l-4 bg-card p-4 text-foreground transition-colors',
+    ENTITY_BORDER_L[entity],
     unread && 'bg-muted/20',
     onClick && 'w-full cursor-pointer text-left hover:bg-muted/40',
     className
@@ -74,7 +105,7 @@ export function NotificationCard({
             <span
               data-testid="unread-dot"
               aria-hidden="true"
-              className="inline-block h-2 w-2 flex-shrink-0 rounded-full bg-primary"
+              className={clsx('inline-block h-2 w-2 flex-shrink-0 rounded-full', ENTITY_BG[entity])}
             />
           )}
           <span className={titleClasses}>{title}</span>

--- a/apps/web/src/components/ui/settings-row/settings-row.test.tsx
+++ b/apps/web/src/components/ui/settings-row/settings-row.test.tsx
@@ -104,4 +104,25 @@ describe('SettingsRow', () => {
     const li = container.querySelector('li');
     expect(li).toHaveClass('my-li');
   });
+
+  it('colors the leading icon with the AA -text entity variant when entity is provided', () => {
+    // Issue #2955 Fase 2: the leading icon adopts the per-entity AA text-on-tint
+    // shade (`text-entity-*-text`, verified >=4.5:1) rather than plain currentColor.
+    render(<SettingsRow label="Game" icon={<span>🎲</span>} entity="game" />);
+    const icon = screen.getByTestId('settings-row-icon');
+    expect(icon.className).toMatch(/text-entity-game-text/);
+  });
+
+  it('uses the registered -kb-text (teal) for entity=kb, never the -document slate', () => {
+    render(<SettingsRow label="KB" icon={<span>📚</span>} entity="kb" />);
+    const icon = screen.getByTestId('settings-row-icon');
+    expect(icon.className).toMatch(/text-entity-kb-text/);
+    expect(icon.className).not.toMatch(/entity-document/);
+  });
+
+  it('leaves the icon on currentColor when no entity is provided', () => {
+    render(<SettingsRow label="Plain" icon={<span>🎨</span>} />);
+    const icon = screen.getByTestId('settings-row-icon');
+    expect(icon.className).not.toMatch(/text-entity-/);
+  });
 });

--- a/apps/web/src/components/ui/settings-row/settings-row.tsx
+++ b/apps/web/src/components/ui/settings-row/settings-row.tsx
@@ -4,6 +4,26 @@ import clsx from 'clsx';
 
 import type { EntityType } from '@/components/ui/entity-tokens';
 
+/**
+ * Per-entity AA text-on-tint shade for the leading icon (issue #2955, Fase 2).
+ * Literal class strings so Tailwind's content scanner emits the utilities — a
+ * dynamic `text-entity-${entity}-text` would not be generated. The `-text`
+ * variant (verified >=4.5:1 in Fase 0) keeps the blocking axe AA gate green.
+ * `kb` maps to the registered `-kb-text` (teal), NOT `-document` (slate), which
+ * lives only in `@layer tokens` and would not render.
+ */
+const ENTITY_TEXT: Record<EntityType, string> = {
+  game: 'text-entity-game-text',
+  player: 'text-entity-player-text',
+  session: 'text-entity-session-text',
+  agent: 'text-entity-agent-text',
+  kb: 'text-entity-kb-text',
+  chat: 'text-entity-chat-text',
+  event: 'text-entity-event-text',
+  toolkit: 'text-entity-toolkit-text',
+  tool: 'text-entity-tool-text',
+};
+
 export interface SettingsRowProps {
   readonly icon?: ReactNode;
   readonly label: string;
@@ -72,7 +92,10 @@ export function SettingsRow({
   const body = (
     <>
       {icon !== undefined ? (
-        <span data-testid="settings-row-icon" className="flex-shrink-0 text-lg">
+        <span
+          data-testid="settings-row-icon"
+          className={clsx('flex-shrink-0 text-lg', entity && ENTITY_TEXT[entity])}
+        >
           {icon}
         </span>
       ) : null}

--- a/apps/web/src/components/ui/step-progress/step-progress.test.tsx
+++ b/apps/web/src/components/ui/step-progress/step-progress.test.tsx
@@ -19,12 +19,13 @@ describe('StepProgress', () => {
     expect(screen.getByText('Step 3')).toBeInTheDocument();
   });
 
-  it('completed steps have completed styling (bg-primary fill)', () => {
+  it('completed steps use the entity-colored fill (default entity=game)', () => {
     const { container } = render(<StepProgress steps={makeSteps(4)} currentIndex={2} />);
     const completed = container.querySelector('[data-step-status="completed"]');
     expect(completed).toBeInTheDocument();
     const circle = completed?.querySelector('[data-step-circle]') as HTMLElement | null;
-    expect(circle?.className).toMatch(/bg-primary/);
+    expect(circle?.className).toMatch(/bg-entity-game/);
+    expect(circle?.className).not.toMatch(/bg-primary/);
   });
 
   it('current step has current styling (ring and scale)', () => {
@@ -68,22 +69,72 @@ describe('StepProgress', () => {
     expect(items[3]?.getAttribute('data-step-status')).toBe('pending');
   });
 
-  it('completed circles use the bg-primary fill', () => {
+  it('completed circles use the entity-colored fill (entity=session)', () => {
     const { container } = render(
       <StepProgress steps={makeSteps(3)} currentIndex={2} entity="session" />
     );
     const completed = container.querySelector(
       '[data-step-status="completed"] [data-step-circle]'
     ) as HTMLElement | null;
-    expect(completed?.className).toMatch(/bg-primary/);
+    expect(completed?.className).toMatch(/bg-entity-session/);
+    expect(completed?.className).not.toMatch(/bg-primary/);
   });
 
-  it('current + completed circles are branded with bg-primary', () => {
+  it('current + completed circles are branded with the entity fill (default game)', () => {
     const { container } = render(<StepProgress steps={makeSteps(3)} currentIndex={2} />);
     const completed = container.querySelector(
       '[data-step-status="completed"] [data-step-circle]'
     ) as HTMLElement | null;
-    expect(completed?.className).toMatch(/bg-primary/);
+    expect(completed?.className).toMatch(/bg-entity-game/);
+    const current = container.querySelector(
+      '[data-step-status="current"] [data-step-circle]'
+    ) as HTMLElement | null;
+    expect(current?.className).toMatch(/bg-entity-game/);
+  });
+
+  it('current step ring uses the entity ring utility, not ring-primary', () => {
+    const { container } = render(
+      <StepProgress steps={makeSteps(3)} currentIndex={1} entity="event" />
+    );
+    const current = container.querySelector(
+      '[data-step-status="current"] [data-step-circle]'
+    ) as HTMLElement | null;
+    expect(current?.className).toMatch(/ring-entity-event/);
+    expect(current?.className).not.toMatch(/ring-primary/);
+  });
+
+  it('filled connector uses the entity fill, not bg-primary', () => {
+    const { container } = render(
+      <StepProgress steps={makeSteps(3)} currentIndex={2} entity="agent" />
+    );
+    const filled = container.querySelector(
+      '[data-step-connector-filled="true"]'
+    ) as HTMLElement | null;
+    expect(filled).toBeInTheDocument();
+    expect(filled?.className).toMatch(/bg-entity-agent/);
+    expect(filled?.className).not.toMatch(/bg-primary/);
+  });
+
+  it('uses the registered -kb (teal) utilities for kb, not the unregistered document slate', () => {
+    const { container } = render(
+      <StepProgress steps={makeSteps(3)} currentIndex={2} entity="kb" />
+    );
+    const completed = container.querySelector(
+      '[data-step-status="completed"] [data-step-circle]'
+    ) as HTMLElement | null;
+    expect(completed?.className).toMatch(/bg-entity-kb/);
+    const current = container.querySelector(
+      '[data-step-status="current"] [data-step-circle]'
+    ) as HTMLElement | null;
+    expect(current?.className).toMatch(/bg-entity-kb/);
+    expect(current?.className).toMatch(/ring-entity-kb/);
+    const filled = container.querySelector(
+      '[data-step-connector-filled="true"]'
+    ) as HTMLElement | null;
+    expect(filled?.className).toMatch(/bg-entity-kb/);
+    // the whole progressbar must never reference the unregistered slate token
+    const root = container.querySelector('[role="progressbar"]') as HTMLElement | null;
+    expect(root?.innerHTML).not.toMatch(/entity-document/);
   });
 
   it('sets role="progressbar" and aria-valuenow reflects currentIndex+1', () => {

--- a/apps/web/src/components/ui/step-progress/step-progress.tsx
+++ b/apps/web/src/components/ui/step-progress/step-progress.tsx
@@ -20,6 +20,38 @@ export interface Step {
   readonly status?: StepStatus;
 }
 
+/**
+ * Per-entity solid fill for completed/current circles + filled connectors (issue #2955).
+ * Literal class strings so Tailwind's content scanner emits the utilities (a dynamic
+ * `bg-entity-${entity}` would NOT be generated). `kb` uses the registered `-kb` (teal)
+ * token — NEVER `-document` (slate), which lives only in `@layer tokens` and is not
+ * exposed via `@theme inline`.
+ */
+const ENTITY_BG: Record<StepEntityKey, string> = {
+  game: 'bg-entity-game',
+  player: 'bg-entity-player',
+  session: 'bg-entity-session',
+  agent: 'bg-entity-agent',
+  kb: 'bg-entity-kb',
+  chat: 'bg-entity-chat',
+  event: 'bg-entity-event',
+  toolkit: 'bg-entity-toolkit',
+  tool: 'bg-entity-tool',
+};
+
+/** Per-entity focus ring for the current step (issue #2955). Same literal-map discipline. */
+const ENTITY_RING: Record<StepEntityKey, string> = {
+  game: 'ring-entity-game',
+  player: 'ring-entity-player',
+  session: 'ring-entity-session',
+  agent: 'ring-entity-agent',
+  kb: 'ring-entity-kb',
+  chat: 'ring-entity-chat',
+  event: 'ring-entity-event',
+  toolkit: 'ring-entity-toolkit',
+  tool: 'ring-entity-tool',
+};
+
 export interface StepProgressProps {
   readonly steps: Step[];
   readonly currentIndex: number;
@@ -67,9 +99,13 @@ export function StepProgress({
 
           const circleClasses = clsx(
             'flex h-8 w-8 items-center justify-center rounded-full text-xs font-semibold transition-transform',
-            status === 'completed' && 'bg-primary text-primary-foreground',
+            status === 'completed' && clsx(ENTITY_BG[entity], 'text-primary-foreground'),
             status === 'current' &&
-              'bg-primary text-primary-foreground ring-2 ring-primary ring-offset-2 ring-offset-background scale-110',
+              clsx(
+                ENTITY_BG[entity],
+                ENTITY_RING[entity],
+                'text-primary-foreground ring-2 ring-offset-2 ring-offset-background scale-110'
+              ),
             status === 'pending' && 'bg-muted text-muted-foreground'
           );
 
@@ -105,7 +141,7 @@ export function StepProgress({
                     data-step-connector-filled={connectorFilled}
                     className={clsx(
                       'mx-2 h-0.5 flex-1 rounded-full',
-                      connectorFilled ? 'bg-primary' : 'bg-muted'
+                      connectorFilled ? ENTITY_BG[entity] : 'bg-muted'
                     )}
                     aria-hidden="true"
                   />

--- a/apps/web/src/components/ui/toggle-switch/toggle-switch.test.tsx
+++ b/apps/web/src/components/ui/toggle-switch/toggle-switch.test.tsx
@@ -46,10 +46,25 @@ describe('ToggleSwitch', () => {
     expect(onCheckedChange).not.toHaveBeenCalled();
   });
 
-  it('active state uses the bg-primary track', () => {
+  it('active (checked) track uses the entity color, not bg-primary', () => {
     render(<ToggleSwitch checked onCheckedChange={() => {}} entity="game" ariaLabel="T" />);
     const sw = screen.getByRole('switch');
-    expect(sw.className).toMatch(/bg-primary/);
+    expect(sw.className).toMatch(/bg-entity-game/);
+    expect(sw.className).not.toMatch(/bg-primary/);
+  });
+
+  it('inactive (unchecked) track uses bg-muted, not the entity color', () => {
+    render(<ToggleSwitch checked={false} onCheckedChange={() => {}} entity="game" ariaLabel="T" />);
+    const sw = screen.getByRole('switch');
+    expect(sw.className).toMatch(/bg-muted/);
+    expect(sw.className).not.toMatch(/bg-entity-game/);
+  });
+
+  it('focus ring uses the entity ring color, not ring-primary', () => {
+    render(<ToggleSwitch checked onCheckedChange={() => {}} entity="event" ariaLabel="T" />);
+    const sw = screen.getByRole('switch');
+    expect(sw.className).toMatch(/ring-entity-event/);
+    expect(sw.className).not.toMatch(/ring-primary/);
   });
 
   it('default entity is "game"', () => {
@@ -57,10 +72,12 @@ describe('ToggleSwitch', () => {
     expect(screen.getByRole('switch')).toHaveAttribute('data-entity', 'game');
   });
 
-  it('kb entity sets data-entity="kb"', () => {
+  it('kb entity uses the registered -kb (teal) track, not the -document slate', () => {
     render(<ToggleSwitch checked onCheckedChange={() => {}} entity="kb" ariaLabel="T" />);
     const sw = screen.getByRole('switch');
     expect(sw).toHaveAttribute('data-entity', 'kb');
+    expect(sw.className).toMatch(/bg-entity-kb/);
+    expect(sw.className).not.toMatch(/entity-document/);
   });
 
   it('size "sm" uses smaller track dimensions', () => {

--- a/apps/web/src/components/ui/toggle-switch/toggle-switch.tsx
+++ b/apps/web/src/components/ui/toggle-switch/toggle-switch.tsx
@@ -6,6 +6,36 @@ import type { EntityType } from '@/components/ui/entity-tokens';
 
 export type ToggleSwitchSize = 'sm' | 'md';
 
+/**
+ * Per-entity color maps (issue #2955). Literal class strings so Tailwind's content
+ * scanner emits the utilities (a dynamic `bg-entity-${entity}` would NOT be generated).
+ * `kb` uses the registered `-kb` (teal) token — NEVER `-document` (slate), which lives
+ * only in `@layer tokens` and is not exposed via `@theme inline`.
+ */
+const ENTITY_BG: Record<EntityType, string> = {
+  game: 'bg-entity-game',
+  player: 'bg-entity-player',
+  session: 'bg-entity-session',
+  agent: 'bg-entity-agent',
+  kb: 'bg-entity-kb',
+  chat: 'bg-entity-chat',
+  event: 'bg-entity-event',
+  toolkit: 'bg-entity-toolkit',
+  tool: 'bg-entity-tool',
+};
+
+const ENTITY_RING: Record<EntityType, string> = {
+  game: 'ring-entity-game',
+  player: 'ring-entity-player',
+  session: 'ring-entity-session',
+  agent: 'ring-entity-agent',
+  kb: 'ring-entity-kb',
+  chat: 'ring-entity-chat',
+  event: 'ring-entity-event',
+  toolkit: 'ring-entity-toolkit',
+  tool: 'ring-entity-tool',
+};
+
 export interface ToggleSwitchProps {
   readonly checked: boolean;
   readonly onCheckedChange: (next: boolean) => void;
@@ -50,9 +80,10 @@ export function ToggleSwitch({
 
   const trackClasses = clsx(
     'relative inline-flex items-center rounded-full transition-colors',
-    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2',
+    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2',
+    ENTITY_RING[entity],
     TRACK_CLASSES[size],
-    checked ? 'bg-primary' : 'bg-muted',
+    checked ? ENTITY_BG[entity] : 'bg-muted',
     disabled && 'opacity-50 cursor-not-allowed',
     className
   );

--- a/apps/web/src/styles/design-tokens-canonical.css
+++ b/apps/web/src/styles/design-tokens-canonical.css
@@ -50,6 +50,11 @@
   --c-event-text: 350 89% 32%;   /* #2862 C5: ~5.2:1 on cream/white (from JS entityTextOverrides) */
   --c-agent-text: 38 92% 24%;    /* #2862 C5: ~5.7:1 on cream/white */
   --c-chat-text:  220 80% 38%;   /* #2862 C5: ~5.4:1 on cream/white */
+  /* #2955: player + tool text variants (were missing entirely). Darkened from the base
+   * --c-player/--c-tool per the ~13% pattern above for AA 4.5:1 as text on cream.
+   * Ratios computed via sRGB linearization + WCAG relative-luminance (conservative floor). */
+  --c-player-text: 262 83% 38%;  /* ≈ #4b10b1 vs cream #f7f3ee = 9.47:1 ✅ */
+  --c-tool-text:  195 80% 26%;   /* ≈ #0d5d77 vs cream #f7f3ee = 6.67:1 ✅ */
 
   /* AAA contrast token (#1561 J — Aaron CORE spec 2026-05-23 §1b)
    * Light: hsl(32 36% 4%) ≈ #0f0a05 vs cream #f7f3ee = 15.1:1 (AAA-large + AAA-normal)
@@ -245,6 +250,9 @@
   --c-event-text: 350 85% 78%;   /* #2862 C5: lighter for AA on dark card */
   --c-agent-text: 38 92% 72%;    /* #2862 C5: lighter for AA on dark card */
   --c-chat-text:  218 85% 80%;   /* #2862 C5: lighter for AA on dark card */
+  /* #2955: player + tool text variants — lighter for AA on dark surfaces (#14100a). */
+  --c-player-text: 262 85% 82%;  /* ≈ #c7aaf8 vs dark = 9.50:1 ✅ */
+  --c-tool-text:  195 75% 70%;   /* ≈ #79cfec vs dark = 10.78:1 ✅ */
 
   /* AAA contrast dark — see :root docblock */
   --c-text-high-contrast: 0 0% 100%;

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -538,14 +538,21 @@
   --color-entity-game:    hsl(var(--c-game));
   --color-entity-game-text: hsl(var(--c-game-text));  /* darker variant for AA when used as text on light bg (#1094 Real-C-B) */
   --color-entity-player:  hsl(var(--c-player));
+  --color-entity-player-text: hsl(var(--c-player-text));    /* #2955: AA text-on-tint */
   --color-entity-session: hsl(var(--c-session));
+  --color-entity-session-text: hsl(var(--c-session-text)); /* #2955: AA text-on-tint */
   --color-entity-agent:   hsl(var(--c-agent));
+  --color-entity-agent-text: hsl(var(--c-agent-text));     /* #2955: AA text-on-tint */
   --color-entity-kb:      hsl(var(--c-kb));
+  --color-entity-kb-text: hsl(var(--c-kb-text));           /* #2955: AA text-on-tint */
   --color-entity-chat:    hsl(var(--c-chat));
+  --color-entity-chat-text: hsl(var(--c-chat-text));       /* #2955: AA text-on-tint */
   --color-entity-event:   hsl(var(--c-event));
+  --color-entity-event-text: hsl(var(--c-event-text));     /* #2955: AA text-on-tint */
   --color-entity-toolkit: hsl(var(--c-toolkit));
   --color-entity-toolkit-text: hsl(var(--c-toolkit-text));  /* darker variant for AA when used as text on light bg (#1094 Real-C-E gamebook ready pill) */
   --color-entity-tool:    hsl(var(--c-tool));
+  --color-entity-tool-text: hsl(var(--c-tool-text));       /* #2955: AA text-on-tint */
 
   /* Font family utilities */
   --font-heading: var(--font-quicksand), system-ui, sans-serif;

--- a/docs/for-developers/specs/2026-07-16-issue-2955-restore-entity-coloring-design.md
+++ b/docs/for-developers/specs/2026-07-16-issue-2955-restore-entity-coloring-design.md
@@ -1,0 +1,86 @@
+# Issue #2955 — Restore per-entity coloring on UI primitives — Design Review
+
+**Data**: 2026-07-16 · **Branch**: `feature/issue-2955-restore-entity-coloring` · **Tipo**: **design review** (l'implementazione segue in una PR successiva, dopo approvazione di questo spec).
+
+## Contesto
+
+La PR FU-2 (`feature/fu2-remove-dead-entity-tokens`) ha rimosso i dead composite entity tokens `--e-<entity>` (undefined a runtime dal #2857 → colori inline resi trasparenti) e, per non shippare componenti visibilmente rotti, ha uniformato **9 primitive** a `bg-primary` / `text-primary-foreground` / `border-primary`. Il per-entity coloring (game=orange, player=purple, session=indigo, agent=amber, kb=teal, chat=blue, event=rose, toolkit=green, tool=cyan) è quindi **perso** su queste primitive.
+
+**Goal**: ripristinarlo usando le utility className **già funzionanti** `bg-entity-*` / `text-entity-*` / `border-entity-*` / `ring-entity-*` (risolvono via `--color-entity-*` → `--c-*` in `@theme inline` di `globals.css`; già usate in `EntityPip`/`EntityTableView`). Mantenere **AA su light + dark** (varianti `-text` per il testo su tinta).
+
+## Sorgente del colore (metodo)
+
+- **Nessun** CSS attribute-selector colora `[data-entity]` / `[data-drawer-accent]` / `[data-step-*]` (grep su tutti i `.css` = 0 match). Il colore vive **interamente** nelle className Tailwind; gli attributi `data-*` sono solo hook per test/QA.
+- Le utility `*-entity-*` sono generate da **`@theme inline`** in `apps/web/src/styles/globals.css` (righe 537-548), **non** da `tailwind.config.js` (che ha un commento esplicito, righe 10-13, che demanda a globals).
+
+## Mapping per-primitiva
+
+Tutte espongono già la prop `entity` (tranne dove annotato) — oggi emessa solo come `data-*`, non usata per il colore.
+
+| # | Primitiva (path) | Elemento da ri-colorare | Stato attuale | Utility da applicare | `-text` AA? |
+|---|---|---|---|---|---|
+| 1 | `ui/btn/btn.tsx` | primary bg (r.36); outline border+text (r.38) | `bg-primary` / `border-border` | `bg-entity-*` (testo bianco); outline `border-entity-*` + testo | **SÌ** (outline) |
+| 2 | `ui/drawer/drawer.tsx` | mobile handle (r.106); desktop strip (r.121) | `bg-primary` | `bg-entity-*` | no (decorativo) |
+| 3 | `ui/entity-card/entity-card.tsx` | left border (r.40) | **`border-border`** (non primary!) | `border-l-entity-*` | no |
+| 4 | `ui/notification-card/notification-card.tsx` | left border (r.52); unread dot (r.77) | border=`border-border`; dot=`bg-primary` | `border-l-entity-*`; `bg-entity-*` | no |
+| 5 | `ui/entity-pip/entity-pip.tsx` | active ring (r.46) | ring senza colore (bg **già** entity) | `ring-entity-*` | no |
+| 6 | `ui/settings-row/settings-row.tsx` | icon (r.74-78) | `currentColor` (entity mai usato) | `text-entity-*` | **SÌ** se testo |
+| 7 | `ui/step-progress/step-progress.tsx` | circle completed/current (r.70-72); connector (r.108); ring | `bg-primary` / `ring-primary` | `bg-entity-*` (testo bianco); `ring-entity-*` | no |
+| 8 | `ui/toggle-switch/toggle-switch.tsx` | checked track (r.55); focus ring (r.53) | `bg-primary` / `ring-primary` | `bg-entity-*`; `ring-entity-*` | no |
+| 9 | `ui/data-display/entity-list-view/components/entity-table-view.tsx` | row border (r.33-45,234); badge pill (r.104-112) | border=**HSL hardcoded**; badge=`bg-muted` | `border-entity-*`; badge `bg-entity-*/10` + testo | **SÌ** (badge) |
+
+## ⚠️ Gap AA — decisione chiave per la review
+
+Le utility `text-entity-<entity>-text` esistono **solo per `game` e `toolkit`** (`globals.css:539,547`). Mancano per **player, session, agent, kb, chat, event, tool** (7/9).
+
+- Token grezzi `--c-*-text` (in `design-tokens-canonical.css:46-52`): esistono per **session/agent/kb/chat/event**; **mancano del tutto per `player` e `tool`**.
+- I punti che richiedono `-text` (testo su tinta): **btn outline**, **entity-table-view badge**, **settings-row icon** (se trattata come testo).
+
+→ Per coprire AA su tutte le 9 entity servono:
+1. **Esporre a `@theme inline`** i 5 mapping `--color-entity-{session,agent,kb,chat,event}-text` (i token grezzi esistono già).
+2. **Creare + auditare** `--c-player-text` e `--c-tool-text` prima di esporli.
+
+Audit AA esistente (riferimento): tutti i 9 `--c-*` verificati ≥ 4.5:1 su `bg-card` bianco (#807 Iter 2, deliverable `docs/for-developers/frontend/v2-a11y-token-audit.md`); `--c-game-text` 6.14:1, `--c-kb-text` 4.95:1, `--c-toolkit-text` ~5.6:1 (refs #1094, #2862 C5, PR #1721). Nota: `--c-game` a 38% come **testo su cream #f7f3ee** fallisce (4.34:1) → da qui la necessità del `-text` a 32% (`globals.css:576`).
+
+**Regola operativa AA**:
+- Fill pieni con testo bianco (btn primary, step circle, toggle track, unread dot) → base `--c-*` OK.
+- Bordi/ring (entity-card, notification border, entity-pip ring, connettori) → base OK (≥3:1).
+- **Testo colorato su superficie chiara/tinta → richiede `-text`** (btn outline, table badge, settings-row icon).
+
+## Discrepanze vs l'issue (da correggere nell'implementazione)
+
+1. **entity-card** + **notification-card**: il left border oggi è `border-border` (default globale `* { @apply border-border }`), **non** `border-primary` come dice l'issue. Il fix applica `border-l-entity-*`.
+2. **entity-table-view**: il row border è **già** per-entity ma via **HSL hardcoded** (`ENTITY_BORDER_COLORS` r.33-45, valori diversi dai canonici `--c-*`) e il badge è `bg-muted` (uniforme). Migrare a `border-entity-*` **scurisce leggermente** il bordo in light (es. agent 50%→32%) — verifica designer.
+
+## Caveat kb → `document`
+
+`entity-tokens.ts:27` mappa `kb → 'document'` e `getEntityToken('kb').bg = 'bg-entity-document'`. Ma `@theme inline` registra `--color-entity-kb`, **non** `--color-entity-document` (che vive solo in `@layer tokens` di `design-tokens.css:358` → in Tailwind v4 **non genera utility**). Quindi `bg-entity-document` / `text-entity-document` **rischiano di non risolvere a runtime**. Per la primitiva kb: usare `bg-entity-kb` (registrato) **oppure** aggiungere `--color-entity-document` a `@theme inline`. Da verificare visivamente.
+
+## Consumer live a rischio (superfici QA)
+
+- **`notifications/page.tsx`** — punto caldo prioritario: `Btn` (filter tabs r.290-300 + CTA drawer r.426-434), `NotificationCard` (lista r.378-386), `Drawer` (dettaglio r.407-413) — tutti per-entity contemporaneamente.
+- **Public** (game→primary shift, molte pagine): `pricing-card`, `hero-gradient`, `how-it-works/game-comprehension`, `contact`.
+- **Settings**: `AiConsentSection` toggle (`entity="agent"`, amber); `cookie-settings` toggle (default `game`).
+- **Admin**: `TopAgentsTable` (`entity="agent"`), `CategoriesTable` (`entity="game"`) via `EntityListView`.
+- **Dormanti** (basso rischio visivo, ma test da aggiornare): `entity-card` (nessun consumer live), `step-progress` (primitiva non consumata — il wizard admin usa un `./step-progress` locale), `settings-row` icon (`entity` mai passato dai consumer).
+
+## Piano di implementazione proposto (fasi)
+
+- **Fase 0 — Token AA** (prerequisito): esporre i 5 mapping `-text` mancanti in `@theme inline`; creare + auditare `--c-player-text` / `--c-tool-text`; risolvere kb→document.
+- **Fase 1 — Primitive "safe"** (fill/border/ring, nessun `-text`): btn primary, drawer, entity-card, notification-card, entity-pip ring, step-progress, toggle-switch.
+- **Fase 2 — Primitive con `-text`** (dopo Fase 0): btn outline, entity-table-view badge, settings-row icon.
+- **Fase 3 — Test**: aggiornare `entity-card.test` + `entity-utilities-render`; aggiungere/estendere axe AA sui consumer a rischio (notifications, settings, cookie-settings, admin tables).
+
+## Rischi
+
+- L'**axe AA gate** (blocking) deve restare verde → `-text` obbligatorio su ogni testo-su-tinta prima di mergiare.
+- Shift di tonalità `game→primary` su pagine public → verifica visiva designer.
+- entity-table-view: scurimento bordo light-mode → verifica.
+- `bg-entity-document` non risolvibile → verifica runtime.
+
+## Decisioni aperte per la review
+
+1. **Colori `--c-player-text` / `--c-tool-text`**: quali valori HSL (chi li decide/audita)? Bloccano la Fase 2 per player/tool.
+2. **kb→document**: usare `bg-entity-kb` (rapido) o registrare `--color-entity-document` in `@theme` (coerente col mapping)?
+3. **Scope PR**: tutte e 9 le primitive in una PR, o Fase 1 (safe) + Fase 2 (AA-gated) separate?
+4. **entity-table-view**: accettare lo scurimento del bordo (migrazione ai canonici) o preservare i valori HSL attuali come override entity?


### PR DESCRIPTION
## Restore per-entity coloring — spec + implementazione (Fase 0 + 1 + 2)

Ripristino del per-entity coloring su 10 primitive UI dopo che FU-2 le ha uniformate a `bg-primary` / `border-primary`.

Contiene lo **spec** + **Fase 0** (token AA) + **Fase 1** (7 primitive base-color) + **Fase 2** (3 primitive testo-su-tinta). **Fase 3** (axe AA esteso sui consumer) opzionale. **Non chiude l'issue** (link: https://github.com/meepleAi-app/meepleai-monorepo/issues/2955).

> ✅ **Build di produzione Next.js verde in pre-push** (158/158 pagine) → token + utility entity (`bg/border/ring/text-entity-*` + `hover:bg-entity-*/90` + `text-entity-*-text`) compilano realmente, non solo su CI.
> ⚠️ **1 punto richiede sign-off designer**: la migrazione del bordo di `entity-table-view` (tabella shift sotto).

### ✅ Fase 0 — token AA (`12c04ebd9`)
Creati `--c-player-text`/`--c-tool-text` (light+dark); esposti tutti e 9 i `-text` in `@theme inline`. Contrasto verificato (sRGB+WCAG, floor): player 9.47:1 / tool 6.67:1 su cream; player 9.50:1 / tool 10.78:1 su dark. Tutti ≥ 4.5:1.

### ✅ Fase 1 — 7 primitive base-color (`3153658e5`)
`btn` primary+hover · `drawer` handle+strip · `entity-card` left border · `notification-card` border+dot · `entity-pip` ring (+fix kb bg) · `step-progress` circle+connector+ring · `toggle-switch` track+ring. 155 test verdi.

### ✅ Fase 2 — 3 primitive testo-su-tinta (usano i `-text` AA)
- `btn` **outline**: `border-entity-*` + `text-entity-*-text` (fill trasparente/hover muted preservati)
- `settings-row`: icona → `text-entity-*-text`
- `entity-table-view`: bordo riga da **HSL hardcoded** → canonici `border-entity-*`; badge da `bg-muted` → `bg-entity-*/10` + `text-entity-*-text`

77 test verdi (incl. jest-axe). Pattern: mappe statiche literal, **kb=teal registrato** (mai `-document`/`getEntityToken`).

#### ⚠️ Sign-off designer — shift bordo `entity-table-view` (light mode)
La migrazione ai canonici mantiene **hue+saturazione identici**; cala solo la **lightness** → tutti i bordi riga **uniformemente più scuri**:

| entity | old HSL | new `--c-*` | shift |
|---|---|---|---|
| game | 25 95% 45% | 25 95% 38% | −7 L |
| player | 262 83% 58% | 262 83% 45% | −13 L |
| session | 240 60% 55% | 240 60% 35% | −20 L |
| agent | 38 92% 50% | 38 92% 32% | −18 L |
| kb | 174 60% 40% | 174 60% 30% | −10 L |
| chat | 220 80% 55% | 220 80% 40% | −15 L |
| event | 350 89% 60% | 350 89% 38% | −22 L |
| toolkit | 142 70% 45% | 142 70% 30% | −15 L |
| tool | 195 80% 50% | 195 80% 32% | −18 L |

(`gameNightEvent` riusa il token `event`.) Nessuna regressione AA (i bordi passano 3:1; i badge usano `-text` ≥4.5:1).

### Decisione kb risolta
Le due palette kb (teal `-kb` vs slate `-document`) → scelto **teal `-kb`/`-kb-text`** ovunque (registrato in `@theme`, = design intent "kb=teal"). L'unificazione della legacy `getEntityToken('kb')→document` resta cleanup separato ([[feedback-entity-kb-dual-palette]]).

### ✅ Fase 3 — axe AA hardening (test-only)
- **Matrix test** (nuovo `entity-coloring-aa-matrix`): 10 primitive × 9 entity, ogni combo asserisce jest-axe `toHaveNoViolations` + la classe entity registrata (kb=teal, mai `-document`). **90/90 verdi, zero finding**.
- **Consumer**: axe aggiunto a `notifications/page` (lista multi-entity + drawer per-entity), settings toggle (AiConsent agent, cookie-settings game), admin `EntityTableView` (TopAgentsTable agent, CategoriesTable game). **127 test verdi** sui 6 file.
- **Caveat**: axe in jsdom non valuta color-contrast (no CSS) → questo gate copre ARIA/ruoli/label/struttura; il contrasto pixel è coperto dall'a11y E2E CI + dalla matematica WCAG di Fase 0.

### ✅ Code review + follow-up fixes (round finale)
Code review (nessun blocker) → 1 HIGH + i 2 ARIA fixati **in-branch**:
- **HIGH — row border tabella non renderizzava**: `border-entity-*` stava sul `<div>` wrapper (border-width 0 → no-op; `border-color` non eredita alle righe, il cui `border-border/50` vinceva). Ora colora il `<tr>` via `[&_tbody_tr]:border-l-entity-*` (stesso elemento della larghezza). I test Fase 2/3 asserivano la classe wrapper **non-renderizzata** → aggiornati ad asserire la variante sul `<tr>` (RED→GREEN). Difetto **pre-esistente** (anche il vecchio `border-l-[hsl()]` ce l'aveva), ora risolto come parte del restore.
- **ARIA 1**: notifications filter bar `role="tablist"` con figli `<button>` → `role="group"` + axe test full-surface (il test precedente passava solo perché il Drawer Radix `aria-hidden`-eva la barra).
- **ARIA 2**: `categories-table.tsx` `<th>` drag-handle senza testo screen-reader → header `sr-only`.

140 test verdi sui 4 file toccati.

### Resta
- **Sign-off designer** sullo shift bordo `entity-table-view` (tabella sopra) — nota: ora il bordo riga **renderizza davvero** il colore entity (prima era un no-op silenzioso su wrapper).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
