### PR TITLE
fix(infra): #2953 #7 root .dockerignore (dropped in #3014 squash race)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,42 @@
+# .dockerignore — ROOT build context for the API image.
+#
+# The API image builds with `context: ..` (repo root) + `apps/api/src/Api/Dockerfile`
+# (infra/docker-compose.yml). Docker transfers the ENTIRE context to the daemon before the
+# COPY steps run, so without this file every rebuild ships ~2GB+ of node_modules, rulebook
+# PDFs, VCS history and agent worktrees. The Dockerfile only COPYs `apps/api/src/Api` + `data`.
+#
+# #2953 (#7): trim the API build context. Keep this in sync with the Dockerfile's COPY steps —
+# never ignore `apps/api/src/Api` (incl. its .csproj) or `data` (except the runtime PDFs below).
+
+# Node dependencies (apps/web + service tooling) — never used by the .NET build.
+**/node_modules/
+
+# .NET build artifacts — the container restores/publishes fresh; local bin/obj are noise.
+**/bin/
+**/obj/
+**/out/
+
+# VCS + agent worktrees (the latter can hold multiple full checkouts).
+.git/
+.claude/
+
+# Rulebook PDFs — seed/runtime data (uploaded to storage at runtime), not needed in the API
+# image. `COPY data` still brings the rest of `data/`. Primary context-bloat driver.
+data/rulebook/
+
+# Docs + archives — never part of any image.
+docs/
+docs-archive/
+
+# Test artifacts.
+**/TestResults/
+**/*.trx
+**/*.coverage
+
+# Web build output (belt-and-suspenders; not copied by the API Dockerfile).
+apps/web/.next/
+
+# Local env + secrets (never bake into an image).
+**/.env
+**/.env.*
+infra/secrets/

--- a/.gitignore
+++ b/.gitignore
@@ -120,6 +120,10 @@ CUsersUtente*
 
 # Docker
 .dockerignore
+# #2953 (#7): the ROOT .dockerignore trims the API build context (context=repo-root per
+# infra/docker-compose.yml). The unqualified pattern above would silently keep it out of git;
+# un-ignore just the root one (nested apps/*/.dockerignore stay ignored for new files).
+!/.dockerignore
 compose.override.yml
 
 # Data


### PR DESCRIPTION
Ships the root `.dockerignore` (fix #7 of #2953) that was silently dropped from PR #3014 by a "squash-merge-too-soon-after-push" race: the #7 commit (`2ae2eeec2`) was pushed but the squash used the pre-#7 head. This is a clean cherry-pick of that commit onto current main-dev.

`.gitignore:122` had an unqualified `.dockerignore` pattern that also matched the repo-root file, so `git add .dockerignore` was a silent no-op. This un-ignores just the root one via `!/.dockerignore` (nested `apps/*/.dockerignore` stay ignored) and commits the file, which trims the API build context (context = repo-root per `infra/docker-compose.yml`).

Refs #2953 — the other three fixes (#4 canSubmitReview, #5 DeepSeek `/user/balance` health-check, #6 log-noise) already landed in #3014 (`eb46860fe`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
