### PR TITLE
feat(notifications): quiet-hours enforcement e2e + preferences completeness (#2994 #2995)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Commands/UpdateQuietHoursCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Commands/UpdateQuietHoursCommand.cs
@@ -1,0 +1,20 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.UserNotifications.Application.Commands;
+
+/// <summary>
+/// Command to update a user's quiet-hours window (ADR-076, issue #2995).
+/// <para>
+/// Quiet hours gate time-sensitive channels (email + Slack DM) server-side during a
+/// user-defined window; in-app notifications are never suppressed. Times are transported
+/// as "HH:mm" strings (matching the HTML <c>&lt;input type="time"&gt;</c> value format) and
+/// parsed to <see cref="TimeOnly"/> in the handler. Pass null/empty start AND end to clear
+/// (disable) quiet hours.
+/// </para>
+/// </summary>
+internal record UpdateQuietHoursCommand(
+    Guid UserId,
+    string TimeZone,
+    string? QuietHoursStart,
+    string? QuietHoursEnd
+) : ICommand;

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Commands/UpdateQuietHoursCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Commands/UpdateQuietHoursCommandHandler.cs
@@ -1,0 +1,55 @@
+using System.Globalization;
+using Api.BoundedContexts.UserNotifications.Domain.Aggregates;
+using Api.BoundedContexts.UserNotifications.Domain.Repositories;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Infrastructure.Persistence;
+
+namespace Api.BoundedContexts.UserNotifications.Application.Commands;
+
+/// <summary>
+/// Handles <see cref="UpdateQuietHoursCommand"/> (ADR-076, issue #2995).
+/// <para>
+/// Load-or-create the user's preferences, apply the quiet-hours window via the domain mutator,
+/// then persist. The repository maps the domain object to a fresh entity and calls
+/// <c>DbContext.Update(...)</c> (force-modified), so persistence is correct even under the global
+/// PERF-06 NoTracking policy. The explicit <see cref="IUnitOfWork.SaveChangesAsync"/> is required
+/// (ADR-060): the repository Add/Update only stages the change.
+/// </para>
+/// </summary>
+internal sealed class UpdateQuietHoursCommandHandler : ICommandHandler<UpdateQuietHoursCommand>
+{
+    private readonly INotificationPreferencesRepository _repository;
+    private readonly IUnitOfWork _unitOfWork;
+
+    public UpdateQuietHoursCommandHandler(
+        INotificationPreferencesRepository repository, IUnitOfWork unitOfWork)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+    }
+
+    public async Task Handle(UpdateQuietHoursCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var existing = await _repository.GetByUserIdAsync(command.UserId, cancellationToken).ConfigureAwait(false);
+        var prefs = existing ?? new NotificationPreferences(command.UserId);
+
+        var start = ParseTime(command.QuietHoursStart);
+        var end = ParseTime(command.QuietHoursEnd);
+
+        prefs.UpdateQuietHours(command.TimeZone, start, end);
+
+        if (existing is null)
+            await _repository.AddAsync(prefs, cancellationToken).ConfigureAwait(false);
+        else
+            await _repository.UpdateAsync(prefs, cancellationToken).ConfigureAwait(false);
+
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    private static TimeOnly? ParseTime(string? value) =>
+        string.IsNullOrWhiteSpace(value)
+            ? null
+            : TimeOnly.Parse(value, CultureInfo.InvariantCulture);
+}

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Commands/UpdateSlackPreferencesCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Commands/UpdateSlackPreferencesCommandHandler.cs
@@ -34,8 +34,13 @@ internal class UpdateSlackPreferencesCommandHandler : ICommandHandler<UpdateSlac
     {
         ArgumentNullException.ThrowIfNull(command);
 
-        var prefs = await _repository.GetByUserIdAsync(command.UserId, cancellationToken).ConfigureAwait(false)
-            ?? new NotificationPreferences(command.UserId);
+        // Capture the load result once. The previous double-read (a second GetByUserIdAsync to decide
+        // Add-vs-Update) is the TOCTOU pattern #2849/#2872 removed from the sibling handler: on a
+        // first-time save it could pick UpdateAsync against a freshly-generated Id, affecting 0 rows and
+        // throwing DbUpdateConcurrencyException (spurious 409). This PR makes the Slack save path live
+        // (FE now calls it on every save), so we apply the same one-read fix here.
+        var existing = await _repository.GetByUserIdAsync(command.UserId, cancellationToken).ConfigureAwait(false);
+        var prefs = existing ?? new NotificationPreferences(command.UserId);
 
         prefs.UpdateSlackPreferences(
             command.SlackEnabled,
@@ -48,7 +53,7 @@ internal class UpdateSlackPreferencesCommandHandler : ICommandHandler<UpdateSlac
             command.SlackOnShareRequestApproved,
             command.SlackOnBadgeEarned);
 
-        if (await _repository.GetByUserIdAsync(command.UserId, cancellationToken).ConfigureAwait(false) == null)
+        if (existing is null)
             await _repository.AddAsync(prefs, cancellationToken).ConfigureAwait(false);
         else
             await _repository.UpdateAsync(prefs, cancellationToken).ConfigureAwait(false);

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/DTOs/NotificationPreferencesDto.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/DTOs/NotificationPreferencesDto.cs
@@ -3,6 +3,8 @@ namespace Api.BoundedContexts.UserNotifications.Application.DTOs;
 /// <summary>
 /// User notification preferences response.
 /// Issue #4220: Multi-channel notification configuration.
+/// Issue #2994: surfaces quiet-hours (ADR-076) and Slack channel preferences so the FE
+/// Preferences UI can round-trip them (previously modelled BE-side but not exposed).
 /// </summary>
 internal record NotificationPreferencesDto(
     Guid UserId,
@@ -16,5 +18,21 @@ internal record NotificationPreferencesDto(
     bool InAppOnDocumentFailed,
     bool InAppOnRetryAvailable,
     bool HasPushSubscription,
-    bool EmailOnCardSuppressed // #535/#2832: opt-in admin email on mechanic-card suppression
+    bool EmailOnCardSuppressed, // #535/#2832: opt-in admin email on mechanic-card suppression
+
+    // Quiet hours (ADR-076 / #2995). Times are "HH:mm" strings; null when not configured.
+    string TimeZone,
+    string? QuietHoursStart,
+    string? QuietHoursEnd,
+
+    // Slack channel preferences (written via PUT /notifications/preferences/slack).
+    bool SlackEnabled,
+    bool SlackOnDocumentReady,
+    bool SlackOnDocumentFailed,
+    bool SlackOnRetryAvailable,
+    bool SlackOnGameNightInvitation,
+    bool SlackOnGameNightReminder,
+    bool SlackOnShareRequestCreated,
+    bool SlackOnShareRequestApproved,
+    bool SlackOnBadgeEarned
 );

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Queries/GetNotificationPreferencesQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Queries/GetNotificationPreferencesQueryHandler.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using Api.BoundedContexts.UserNotifications.Application.DTOs;
 using Api.BoundedContexts.UserNotifications.Application.Queries;
 using Api.BoundedContexts.UserNotifications.Domain.Repositories;
@@ -27,7 +28,19 @@ internal class GetNotificationPreferencesQueryHandler : IQueryHandler<GetNotific
             prefs.PushOnDocumentReady, prefs.PushOnDocumentFailed, prefs.PushOnRetryAvailable,
             prefs.InAppOnDocumentReady, prefs.InAppOnDocumentFailed, prefs.InAppOnRetryAvailable,
             prefs.HasPushSubscription,
-            prefs.EmailOnCardSuppressed
+            prefs.EmailOnCardSuppressed,
+            // Quiet hours (ADR-076) — TimeOnly? formatted as "HH:mm" for a stable FE contract.
+            prefs.TimeZone,
+            FormatTime(prefs.QuietHoursStart),
+            FormatTime(prefs.QuietHoursEnd),
+            // Slack channel preferences.
+            prefs.SlackEnabled,
+            prefs.SlackOnDocumentReady, prefs.SlackOnDocumentFailed, prefs.SlackOnRetryAvailable,
+            prefs.SlackOnGameNightInvitation, prefs.SlackOnGameNightReminder,
+            prefs.SlackOnShareRequestCreated, prefs.SlackOnShareRequestApproved, prefs.SlackOnBadgeEarned
         );
     }
+
+    private static string? FormatTime(TimeOnly? value) =>
+        value?.ToString("HH:mm", CultureInfo.InvariantCulture);
 }

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Validators/UpdateQuietHoursCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Validators/UpdateQuietHoursCommandValidator.cs
@@ -1,0 +1,53 @@
+using System.Globalization;
+using Api.BoundedContexts.UserNotifications.Application.Commands;
+using FluentValidation;
+using TimeZoneConverter;
+
+namespace Api.BoundedContexts.UserNotifications.Application.Validators;
+
+/// <summary>
+/// Validates <see cref="UpdateQuietHoursCommand"/> (ADR-076, issue #2995).
+/// <para>
+/// Guards the domain invariants BEFORE the aggregate mutator runs so a bad payload returns
+/// 400 (FluentValidation) rather than bubbling a domain <see cref="ArgumentException"/> up to a
+/// 500 (project rule #2568). Enforces: valid IANA/Windows timezone, parseable HH:mm times, and
+/// the both-set-or-both-null pairing that <see cref="Api.BoundedContexts.UserNotifications.Domain.Aggregates.NotificationPreferences.UpdateQuietHours"/> requires.
+/// </para>
+/// </summary>
+internal sealed class UpdateQuietHoursCommandValidator : AbstractValidator<UpdateQuietHoursCommand>
+{
+    public UpdateQuietHoursCommandValidator()
+    {
+        RuleFor(x => x.UserId)
+            .NotEmpty()
+            .WithMessage("UserId is required");
+
+        RuleFor(x => x.TimeZone)
+            .Cascade(CascadeMode.Stop)
+            .NotEmpty()
+            .WithMessage("TimeZone is required")
+            .Must(BeAValidTimeZone)
+            .WithMessage("TimeZone must be a valid IANA or Windows time zone identifier");
+
+        RuleFor(x => x.QuietHoursStart)
+            .Must(BeAValidTimeOrEmpty)
+            .WithMessage("QuietHoursStart must be a valid time in HH:mm format");
+
+        RuleFor(x => x.QuietHoursEnd)
+            .Must(BeAValidTimeOrEmpty)
+            .WithMessage("QuietHoursEnd must be a valid time in HH:mm format");
+
+        // Both-set-or-both-null: mirrors the domain invariant so a partial window is a 400.
+        RuleFor(x => x)
+            .Must(x => string.IsNullOrWhiteSpace(x.QuietHoursStart) == string.IsNullOrWhiteSpace(x.QuietHoursEnd))
+            .WithName("QuietHours")
+            .WithMessage("QuietHoursStart and QuietHoursEnd must both be set or both be empty");
+    }
+
+    private static bool BeAValidTimeZone(string? timeZone) =>
+        !string.IsNullOrWhiteSpace(timeZone) && TZConvert.TryGetTimeZoneInfo(timeZone, out _);
+
+    private static bool BeAValidTimeOrEmpty(string? value) =>
+        string.IsNullOrWhiteSpace(value)
+        || TimeOnly.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.None, out _);
+}

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Services/NotificationDispatcher.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Services/NotificationDispatcher.cs
@@ -118,7 +118,7 @@ internal sealed class NotificationDispatcher : INotificationDispatcher
 #pragma warning restore CA1031
 
         // ADR-076 / #2995 quiet hours: when the user is inside their configured window, suppress the
-        // time-sensitive push channels (email + Slack DM). The in-app notification row is always created
+        // time-sensitive channels (email + Slack DM). The in-app notification row is always created
         // above; the config-driven Slack TEAM broadcast (step 5) is not user-scoped so it is not gated;
         // push is delegated to device DND. MVP is suppression-only (not deferral) per ADR-076.
         var inQuietHours = preferences?.IsQuietHoursActive(_timeProvider.GetUtcNow()) ?? false;

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Services/NotificationDispatcher.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Services/NotificationDispatcher.cs
@@ -20,6 +20,7 @@ internal sealed class NotificationDispatcher : INotificationDispatcher
     private readonly INotificationPreferencesRepository _preferencesRepository;
     private readonly ISlackConnectionRepository _slackConnectionRepository;
     private readonly SlackNotificationConfiguration _slackConfig;
+    private readonly TimeProvider _timeProvider;
     private readonly ILogger<NotificationDispatcher> _logger;
 
     public NotificationDispatcher(
@@ -28,6 +29,7 @@ internal sealed class NotificationDispatcher : INotificationDispatcher
         INotificationPreferencesRepository preferencesRepository,
         ISlackConnectionRepository slackConnectionRepository,
         IOptions<SlackNotificationConfiguration> slackConfig,
+        TimeProvider timeProvider,
         ILogger<NotificationDispatcher> logger)
     {
         _notificationRepository = notificationRepository ?? throw new ArgumentNullException(nameof(notificationRepository));
@@ -35,6 +37,7 @@ internal sealed class NotificationDispatcher : INotificationDispatcher
         _preferencesRepository = preferencesRepository ?? throw new ArgumentNullException(nameof(preferencesRepository));
         _slackConnectionRepository = slackConnectionRepository ?? throw new ArgumentNullException(nameof(slackConnectionRepository));
         _slackConfig = slackConfig?.Value ?? throw new ArgumentNullException(nameof(slackConfig));
+        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -114,10 +117,22 @@ internal sealed class NotificationDispatcher : INotificationDispatcher
         }
 #pragma warning restore CA1031
 
+        // ADR-076 / #2995 quiet hours: when the user is inside their configured window, suppress the
+        // time-sensitive push channels (email + Slack DM). The in-app notification row is always created
+        // above; the config-driven Slack TEAM broadcast (step 5) is not user-scoped so it is not gated;
+        // push is delegated to device DND. MVP is suppression-only (not deferral) per ADR-076.
+        var inQuietHours = preferences?.IsQuietHoursActive(_timeProvider.GetUtcNow()) ?? false;
+        if (inQuietHours)
+        {
+            _logger.LogDebug(
+                "Quiet hours active for user {UserId}; suppressing email + Slack DM channels (in-app preserved)",
+                message.RecipientUserId);
+        }
+
         // 3. Check Email channel
         try
         {
-            if (preferences == null || IsEmailEnabledForType(preferences, message.Type))
+            if (!inQuietHours && (preferences == null || IsEmailEnabledForType(preferences, message.Type)))
             {
                 var emailItem = NotificationQueueItem.Create(
                     channelType: NotificationChannelType.Email,
@@ -143,7 +158,7 @@ internal sealed class NotificationDispatcher : INotificationDispatcher
         // 4. Check Slack DM channel
         try
         {
-            if (preferences is { SlackEnabled: true } && IsSlackEnabledForType(preferences, message.Type))
+            if (!inQuietHours && preferences is { SlackEnabled: true } && IsSlackEnabledForType(preferences, message.Type))
             {
                 var slackConnection = await _slackConnectionRepository.GetActiveByUserIdAsync(message.RecipientUserId, ct).ConfigureAwait(false);
                 if (slackConnection is { IsActive: true })

--- a/apps/api/src/Api/Routing/NotificationPreferencesEndpoints.cs
+++ b/apps/api/src/Api/Routing/NotificationPreferencesEndpoints.cs
@@ -62,6 +62,25 @@ internal static class NotificationPreferencesEndpoints
         .RequireSession()
         .WithName("UpdateCardSuppressionEmailPreference");
 
+        // ADR-076 / issue #2995: dedicated quiet-hours window (timezone + start/end). Separate from the
+        // Document-preferences PUT so a partial FE save never resets it, mirroring the card-suppression pattern.
+        group.MapPut("/notifications/preferences/quiet-hours", async (
+            UpdateQuietHoursCommand command,
+            HttpContext context,
+            IMediator mediator,
+            CancellationToken ct) =>
+        {
+            var (authenticated, session, error) = context.TryGetActiveSession();
+            if (!authenticated) return error!;
+
+            var updatedCommand = command with { UserId = session!.Principal!.Subject.Id };
+            await mediator.Send(updatedCommand, ct).ConfigureAwait(false);
+            return Results.NoContent();
+        })
+        .RequireSession()
+        .Produces(204)
+        .WithName("UpdateQuietHours");
+
         // Issue #4416: Push notification subscription management
         group.MapPost("/notifications/push/subscribe", async (
             SubscribePushNotificationsCommand command,

--- a/apps/api/tests/Api.Tests/BoundedContexts/UserNotifications/Application/Validators/UpdateQuietHoursCommandValidatorTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/UserNotifications/Application/Validators/UpdateQuietHoursCommandValidatorTests.cs
@@ -1,0 +1,81 @@
+using Api.BoundedContexts.UserNotifications.Application.Commands;
+using Api.BoundedContexts.UserNotifications.Application.Validators;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.UserNotifications.Application.Validators;
+
+/// <summary>
+/// Issue #2995: validation guards that turn a bad quiet-hours payload into a 400 (FluentValidation)
+/// instead of a 500 from a bubbling domain <see cref="ArgumentException"/> (project rule #2568).
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "UserNotifications")]
+public sealed class UpdateQuietHoursCommandValidatorTests
+{
+    private readonly UpdateQuietHoursCommandValidator _validator = new();
+
+    private static UpdateQuietHoursCommand Cmd(
+        string timeZone = "Europe/Rome", string? start = "22:00", string? end = "08:00", Guid? userId = null) =>
+        new(userId ?? Guid.NewGuid(), timeZone, start, end);
+
+    [Fact]
+    public void Valid_WindowWithIanaTimeZone_Passes()
+    {
+        _validator.Validate(Cmd()).IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Valid_ClearedWindow_NullStartAndEnd_Passes()
+    {
+        _validator.Validate(Cmd(timeZone: "UTC", start: null, end: null)).IsValid.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Invalid_EmptyUserId_Fails()
+    {
+        var result = _validator.Validate(Cmd(userId: Guid.Empty));
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(UpdateQuietHoursCommand.UserId));
+    }
+
+    [Fact]
+    public void Invalid_EmptyTimeZone_Fails()
+    {
+        var result = _validator.Validate(Cmd(timeZone: ""));
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(UpdateQuietHoursCommand.TimeZone));
+    }
+
+    [Fact]
+    public void Invalid_UnknownTimeZone_Fails()
+    {
+        var result = _validator.Validate(Cmd(timeZone: "Not/AZone"));
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(UpdateQuietHoursCommand.TimeZone));
+    }
+
+    [Fact]
+    public void Invalid_OnlyStartSet_Fails()
+    {
+        var result = _validator.Validate(Cmd(start: "22:00", end: null));
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "QuietHours");
+    }
+
+    [Fact]
+    public void Invalid_OnlyEndSet_Fails()
+    {
+        var result = _validator.Validate(Cmd(start: null, end: "08:00"));
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == "QuietHours");
+    }
+
+    [Fact]
+    public void Invalid_UnparseableTime_Fails()
+    {
+        var result = _validator.Validate(Cmd(start: "25:99", end: "08:00"));
+        result.IsValid.Should().BeFalse();
+        result.Errors.Should().Contain(e => e.PropertyName == nameof(UpdateQuietHoursCommand.QuietHoursStart));
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/UserNotifications/Infrastructure/Services/NotificationDispatcherTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/UserNotifications/Infrastructure/Services/NotificationDispatcherTests.cs
@@ -7,6 +7,7 @@ using Api.BoundedContexts.UserNotifications.Infrastructure.Services;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Time.Testing;
 using Moq;
 using Xunit;
 
@@ -22,6 +23,11 @@ public class NotificationDispatcherTests
     private readonly Mock<ISlackConnectionRepository> _slackConnRepoMock = new();
     private readonly Mock<ILogger<NotificationDispatcher>> _loggerMock = new();
     private readonly SlackNotificationConfiguration _slackConfig = new();
+
+    // Fixed default (midnight UTC) so existing tests — which never configure quiet hours — are
+    // deterministic and unaffected. Quiet-hours tests advance it via SetUtcNow(...) (FakeTimeProvider
+    // forbids moving backwards, so anchor at 00:00 to let every test set a same-day time forward).
+    private readonly FakeTimeProvider _timeProvider = new(new DateTimeOffset(2026, 1, 15, 0, 0, 0, TimeSpan.Zero));
 
     public NotificationDispatcherTests()
     {
@@ -43,6 +49,7 @@ public class NotificationDispatcherTests
             _prefsRepoMock.Object,
             _slackConnRepoMock.Object,
             Options.Create(_slackConfig),
+            _timeProvider,
             _loggerMock.Object);
     }
 
@@ -140,6 +147,98 @@ public class NotificationDispatcherTests
                         i.SlackTeamId == "T01ABC")),
                 It.IsAny<CancellationToken>()),
             Times.Once);
+    }
+
+    // ADR-076 / #2995 quiet hours: email + Slack DM suppressed while active; in-app always kept.
+    [Fact]
+    public async Task DispatchAsync_QuietHoursActive_SuppressesEmailAndSlackDm_ButKeepsInApp()
+    {
+        // Arrange — cross-midnight window 22:00 -> 08:00, clock at 23:00 UTC (inside).
+        var userId = Guid.NewGuid();
+        var message = CreateMessage(type: NotificationType.ShareRequestCreated, recipientUserId: userId);
+
+        var prefs = new NotificationPreferences(userId);
+        prefs.UpdateQuietHours("UTC", new TimeOnly(22, 0), new TimeOnly(8, 0));
+        _prefsRepoMock.Setup(r => r.GetByUserIdAsync(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(prefs);
+
+        var slackConnection = SlackConnection.Create(
+            userId, "U01ABC", "T01ABC", "TestWorkspace", "xoxb-token", "D01ABC");
+        _slackConnRepoMock.Setup(r => r.GetActiveByUserIdAsync(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(slackConnection);
+
+        _timeProvider.SetUtcNow(new DateTimeOffset(2026, 1, 15, 23, 0, 0, TimeSpan.Zero));
+        var sut = CreateSut();
+
+        // Act
+        await sut.DispatchAsync(message);
+
+        // Assert — in-app notification is still created...
+        _notificationRepoMock.Verify(
+            r => r.AddAndCommitAsync(It.IsAny<Notification>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        // ...but no channel queue items are enqueued (email + Slack DM both suppressed, no team channels).
+        _queueRepoMock.Verify(
+            r => r.AddRangeAsync(It.IsAny<IEnumerable<NotificationQueueItem>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task DispatchAsync_QuietHoursInactive_EnqueuesEmailAndSlackDm()
+    {
+        // Arrange — same window, clock at noon UTC (outside 22:00 -> 08:00).
+        var userId = Guid.NewGuid();
+        var message = CreateMessage(type: NotificationType.ShareRequestCreated, recipientUserId: userId);
+
+        var prefs = new NotificationPreferences(userId);
+        prefs.UpdateQuietHours("UTC", new TimeOnly(22, 0), new TimeOnly(8, 0));
+        _prefsRepoMock.Setup(r => r.GetByUserIdAsync(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(prefs);
+
+        var slackConnection = SlackConnection.Create(
+            userId, "U01ABC", "T01ABC", "TestWorkspace", "xoxb-token", "D01ABC");
+        _slackConnRepoMock.Setup(r => r.GetActiveByUserIdAsync(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(slackConnection);
+
+        _timeProvider.SetUtcNow(new DateTimeOffset(2026, 1, 15, 12, 0, 0, TimeSpan.Zero));
+        var sut = CreateSut();
+
+        // Act
+        await sut.DispatchAsync(message);
+
+        // Assert — both email and Slack DM items are enqueued outside quiet hours.
+        _queueRepoMock.Verify(
+            r => r.AddRangeAsync(
+                It.Is<IEnumerable<NotificationQueueItem>>(items =>
+                    items.Any(i => i.ChannelType == NotificationChannelType.Email) &&
+                    items.Any(i => i.ChannelType == NotificationChannelType.SlackUser)),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task DispatchAsync_QuietHoursCrossMidnight_ActiveOvernight_Suppresses()
+    {
+        // Arrange — cross-midnight window 22:00 -> 08:00, clock at 02:00 UTC (inside the overnight span).
+        var userId = Guid.NewGuid();
+        var message = CreateMessage(type: NotificationType.ShareRequestCreated, recipientUserId: userId);
+
+        var prefs = new NotificationPreferences(userId);
+        prefs.UpdateQuietHours("UTC", new TimeOnly(22, 0), new TimeOnly(8, 0));
+        _prefsRepoMock.Setup(r => r.GetByUserIdAsync(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(prefs);
+
+        _timeProvider.SetUtcNow(new DateTimeOffset(2026, 1, 15, 2, 0, 0, TimeSpan.Zero));
+        var sut = CreateSut();
+
+        // Act
+        await sut.DispatchAsync(message);
+
+        // Assert — email suppressed overnight; no queue items enqueued.
+        _queueRepoMock.Verify(
+            r => r.AddRangeAsync(It.IsAny<IEnumerable<NotificationQueueItem>>(), It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 
     [Fact]

--- a/apps/api/tests/Api.Tests/BoundedContexts/UserNotifications/Infrastructure/UpdateQuietHoursHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/UserNotifications/Infrastructure/UpdateQuietHoursHandlerTests.cs
@@ -1,0 +1,124 @@
+using Api.BoundedContexts.UserNotifications.Application.Commands;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.UserNotifications;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using MediatR;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.UserNotifications.Infrastructure;
+
+/// <summary>
+/// Issue #2995 (ADR-076): quiet-hours are settable e2e via <c>UpdateQuietHoursCommand</c>. These drive
+/// the command through the real MediatR pipeline (Testcontainers Postgres) and re-read the persisted
+/// COLUMNS in a fresh NoTracking scope — the guard against the PERF-06 "load+mutate+save is a silent
+/// no-op" class of bug the project rules call out.
+/// </summary>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "UserNotifications")]
+public sealed class UpdateQuietHoursHandlerTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly string _testDbName;
+    private WebApplicationFactory<Program> _factory = null!;
+    private Guid _userId;
+
+    public UpdateQuietHoursHandlerTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+        _testDbName = $"t2995_quiethours_{Guid.NewGuid():N}";
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        var conn = await _fixture.CreateIsolatedDatabaseAsync(_testDbName);
+        _factory = IntegrationWebApplicationFactory.Create(conn);
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        await db.Database.MigrateAsync();
+        (_userId, _) = await TestSessionHelper.CreateUserSessionAsync(db, Guid.NewGuid());
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_factory is not null)
+        {
+            await _factory.DisposeAsync();
+        }
+        await _fixture.DropIsolatedDatabaseAsync(_testDbName);
+    }
+
+    private async Task SendAsync(UpdateQuietHoursCommand command)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+        await mediator.Send(command);
+    }
+
+    private async Task<NotificationPreferencesEntity> ReadRowAsync()
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        return await db.Set<NotificationPreferencesEntity>()
+            .AsNoTracking()
+            .SingleAsync(p => p.UserId == _userId);
+    }
+
+    [Fact]
+    public async Task Command_PersistsQuietHoursWindow_WhenMissing()
+    {
+        await SendAsync(new UpdateQuietHoursCommand(_userId, "Europe/Rome", "22:00", "08:00"));
+
+        var row = await ReadRowAsync();
+        row.TimeZone.Should().Be("Europe/Rome");
+        row.QuietHoursStart.Should().Be(new TimeOnly(22, 0));
+        row.QuietHoursEnd.Should().Be(new TimeOnly(8, 0));
+    }
+
+    [Fact]
+    public async Task Command_UpdatesExistingQuietHours()
+    {
+        // Seed an existing prefs row with a different window.
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            db.Set<NotificationPreferencesEntity>().Add(new NotificationPreferencesEntity
+            {
+                Id = Guid.NewGuid(),
+                UserId = _userId,
+                TimeZone = "UTC",
+                QuietHoursStart = new TimeOnly(9, 0),
+                QuietHoursEnd = new TimeOnly(17, 0),
+            });
+            await db.SaveChangesAsync();
+        }
+
+        await SendAsync(new UpdateQuietHoursCommand(_userId, "America/New_York", "23:30", "07:15"));
+
+        var row = await ReadRowAsync();
+        row.TimeZone.Should().Be("America/New_York");
+        row.QuietHoursStart.Should().Be(new TimeOnly(23, 30));
+        row.QuietHoursEnd.Should().Be(new TimeOnly(7, 15));
+    }
+
+    [Fact]
+    public async Task Command_ClearsQuietHours_WhenTimesNull()
+    {
+        // Seed a configured window first.
+        await SendAsync(new UpdateQuietHoursCommand(_userId, "Europe/Rome", "22:00", "08:00"));
+
+        // Then clear it by passing null start/end (timezone is retained).
+        await SendAsync(new UpdateQuietHoursCommand(_userId, "Europe/Rome", null, null));
+
+        var row = await ReadRowAsync();
+        row.TimeZone.Should().Be("Europe/Rome");
+        row.QuietHoursStart.Should().BeNull();
+        row.QuietHoursEnd.Should().BeNull();
+    }
+}

--- a/apps/web/src/components/notifications/NotificationPreferences.tsx
+++ b/apps/web/src/components/notifications/NotificationPreferences.tsx
@@ -8,9 +8,9 @@
 
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
-import { Bell, Calendar, Loader2, Mail, MessageSquare, Save, Smartphone } from 'lucide-react';
+import { Bell, Calendar, Loader2, Mail, MessageSquare, Moon, Save, Smartphone } from 'lucide-react';
 
 import { Switch } from '@/components/ui/forms/switch';
 import { Button } from '@/components/ui/primitives/button';
@@ -23,7 +23,28 @@ import { cn } from '@/lib/utils';
 // Types
 // ============================================================================
 
-type PreferenceKey = keyof Omit<NotificationPreferencesType, 'userId' | 'hasPushSubscription'>;
+// Boolean-only preference keys (Switch rows). Quiet-hours fields are string/nullable and handled by
+// the dedicated Quiet Hours section, so they are excluded here.
+type PreferenceKey = keyof Omit<
+  NotificationPreferencesType,
+  'userId' | 'hasPushSubscription' | 'timeZone' | 'quietHoursStart' | 'quietHoursEnd'
+>;
+
+// Curated IANA timezone options for the quiet-hours picker (the user's current value is always merged in).
+const COMMON_TIMEZONES = [
+  'UTC',
+  'Europe/Rome',
+  'Europe/London',
+  'Europe/Paris',
+  'Europe/Berlin',
+  'Europe/Madrid',
+  'America/New_York',
+  'America/Chicago',
+  'America/Los_Angeles',
+  'America/Sao_Paulo',
+  'Asia/Tokyo',
+  'Australia/Sydney',
+] as const;
 
 interface PreferenceRow {
   key: PreferenceKey;
@@ -191,6 +212,70 @@ const PREFERENCE_CATEGORIES: PreferenceCategory[] = [
       },
     ],
   },
+  {
+    // Issue #2994: Slack channel preferences (persisted via the dedicated Slack endpoint).
+    id: 'slack',
+    title: 'Slack',
+    description: 'Ricevi notifiche come messaggio diretto su Slack (richiede un account collegato)',
+    icon: MessageSquare,
+    iconColor: 'bg-purple-100 dark:bg-purple-900/20 text-purple-600 dark:text-purple-400',
+    rows: [
+      {
+        key: 'slackEnabled',
+        icon: MessageSquare,
+        label: 'Slack attivo',
+        description: 'Abilita globalmente le notifiche Slack',
+      },
+      {
+        key: 'slackOnDocumentReady',
+        icon: MessageSquare,
+        label: 'Documento pronto',
+        description: 'Messaggio Slack quando il documento è pronto',
+      },
+      {
+        key: 'slackOnDocumentFailed',
+        icon: MessageSquare,
+        label: 'Elaborazione fallita',
+        description: 'Messaggio Slack in caso di errore',
+      },
+      {
+        key: 'slackOnRetryAvailable',
+        icon: MessageSquare,
+        label: 'Retry disponibile',
+        description: 'Messaggio Slack quando inizia il retry',
+      },
+      {
+        key: 'slackOnGameNightInvitation',
+        icon: MessageSquare,
+        label: 'Inviti serata',
+        description: 'Messaggio Slack per nuovi inviti a serate giochi',
+      },
+      {
+        key: 'slackOnGameNightReminder',
+        icon: MessageSquare,
+        label: 'Promemoria serata',
+        description: 'Messaggio Slack di promemoria serata',
+      },
+      {
+        key: 'slackOnShareRequestCreated',
+        icon: MessageSquare,
+        label: 'Share request creata',
+        description: 'Messaggio Slack per nuove share request',
+      },
+      {
+        key: 'slackOnShareRequestApproved',
+        icon: MessageSquare,
+        label: 'Share request approvata',
+        description: 'Messaggio Slack quando una share request è approvata',
+      },
+      {
+        key: 'slackOnBadgeEarned',
+        icon: MessageSquare,
+        label: 'Badge ottenuto',
+        description: 'Messaggio Slack quando ottieni un badge',
+      },
+    ],
+  },
 ];
 
 // ============================================================================
@@ -234,6 +319,36 @@ export function NotificationPreferences() {
     [prefs]
   );
 
+  // Quiet hours (ADR-076 / #2995): "enabled" is derived from both bounds being set.
+  const quietHoursEnabled = Boolean(prefs?.quietHoursStart && prefs?.quietHoursEnd);
+
+  const setQuietHoursEnabled = useCallback(
+    (enabled: boolean) => {
+      if (!prefs) return;
+      setPrefs({
+        ...prefs,
+        // Enabling defaults to a 22:00 → 08:00 overnight window; disabling clears both bounds.
+        quietHoursStart: enabled ? (prefs.quietHoursStart ?? '22:00') : null,
+        quietHoursEnd: enabled ? (prefs.quietHoursEnd ?? '08:00') : null,
+      });
+    },
+    [prefs]
+  );
+
+  const setQuietHoursField = useCallback(
+    (key: 'timeZone' | 'quietHoursStart' | 'quietHoursEnd', value: string) => {
+      if (!prefs) return;
+      setPrefs({ ...prefs, [key]: value });
+    },
+    [prefs]
+  );
+
+  const timezoneOptions = useMemo(() => {
+    const base = [...COMMON_TIMEZONES] as string[];
+    const current = prefs?.timeZone;
+    return current && !base.includes(current) ? [current, ...base] : base;
+  }, [prefs?.timeZone]);
+
   const handleSave = useCallback(async () => {
     if (!prefs) return;
 
@@ -246,6 +361,23 @@ export function NotificationPreferences() {
       await api.notifications.updateCardSuppressionEmailPreference(
         prefs.emailOnCardSuppressed ?? false
       );
+      // #2994: Slack + quiet-hours each round-trip through their own endpoint (the generic PUT ignores them).
+      await api.notifications.updateSlackPreferences({
+        slackEnabled: prefs.slackEnabled ?? true,
+        slackOnDocumentReady: prefs.slackOnDocumentReady ?? true,
+        slackOnDocumentFailed: prefs.slackOnDocumentFailed ?? true,
+        slackOnRetryAvailable: prefs.slackOnRetryAvailable ?? false,
+        slackOnGameNightInvitation: prefs.slackOnGameNightInvitation ?? true,
+        slackOnGameNightReminder: prefs.slackOnGameNightReminder ?? true,
+        slackOnShareRequestCreated: prefs.slackOnShareRequestCreated ?? true,
+        slackOnShareRequestApproved: prefs.slackOnShareRequestApproved ?? true,
+        slackOnBadgeEarned: prefs.slackOnBadgeEarned ?? true,
+      });
+      await api.notifications.updateQuietHours({
+        timeZone: prefs.timeZone ?? 'UTC',
+        quietHoursStart: prefs.quietHoursStart ?? null,
+        quietHoursEnd: prefs.quietHoursEnd ?? null,
+      });
       toast({
         title: 'Salvato',
         description: 'Preferenze di notifica aggiornate',
@@ -367,6 +499,84 @@ export function NotificationPreferences() {
           </div>
         );
       })}
+
+      {/* Quiet hours (ADR-076 / #2995) — custom section: time-range + timezone, not boolean toggles */}
+      <div
+        className="bg-card rounded-xl p-6 border border-border/50"
+        data-testid="pref-category-quiet-hours"
+      >
+        <div className="flex items-start gap-4 mb-6">
+          <div className="p-2 rounded-lg bg-indigo-100 dark:bg-indigo-900/20 text-indigo-600 dark:text-indigo-400">
+            <Moon className="h-6 w-6" />
+          </div>
+          <div className="flex-1">
+            <h2 className="text-xl font-bold mb-1">Ore di silenzio</h2>
+            <p className="text-sm text-muted-foreground">
+              Sospendi email e Slack durante una fascia oraria (le notifiche in-app restano sempre
+              visibili)
+            </p>
+          </div>
+        </div>
+
+        <div className="space-y-4">
+          <div className="flex items-center justify-between py-2">
+            <div className="flex items-center gap-3">
+              <Moon className="h-5 w-5 text-muted-foreground" />
+              <div>
+                <p className="font-medium">Attiva ore di silenzio</p>
+                <p className="text-sm text-muted-foreground">
+                  Email e Slack non verranno inviati nella fascia impostata
+                </p>
+              </div>
+            </div>
+            <Switch
+              checked={quietHoursEnabled}
+              onCheckedChange={setQuietHoursEnabled}
+              data-testid="pref-quietHoursEnabled"
+            />
+          </div>
+
+          {quietHoursEnabled && (
+            <div className="grid gap-4 sm:grid-cols-3">
+              <label className="flex flex-col gap-1">
+                <span className="text-sm font-medium">Fuso orario</span>
+                <select
+                  value={prefs.timeZone ?? 'UTC'}
+                  onChange={e => setQuietHoursField('timeZone', e.target.value)}
+                  data-testid="pref-quietHoursTimeZone"
+                  className="rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground"
+                >
+                  {timezoneOptions.map(tz => (
+                    <option key={tz} value={tz}>
+                      {tz}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label className="flex flex-col gap-1">
+                <span className="text-sm font-medium">Inizio</span>
+                <input
+                  type="time"
+                  value={prefs.quietHoursStart ?? '22:00'}
+                  onChange={e => setQuietHoursField('quietHoursStart', e.target.value)}
+                  data-testid="pref-quietHoursStart"
+                  className="rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground"
+                />
+              </label>
+              <label className="flex flex-col gap-1">
+                <span className="text-sm font-medium">Fine</span>
+                <input
+                  type="time"
+                  value={prefs.quietHoursEnd ?? '08:00'}
+                  onChange={e => setQuietHoursField('quietHoursEnd', e.target.value)}
+                  data-testid="pref-quietHoursEnd"
+                  className="rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground"
+                />
+              </label>
+            </div>
+          )}
+        </div>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/components/notifications/__tests__/NotificationPreferences.cardSuppression.test.tsx
+++ b/apps/web/src/components/notifications/__tests__/NotificationPreferences.cardSuppression.test.tsx
@@ -7,6 +7,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 const mockGetPreferences = vi.hoisted(() => vi.fn());
 const mockUpdatePreferences = vi.hoisted(() => vi.fn());
 const mockUpdateCardSuppression = vi.hoisted(() => vi.fn());
+const mockUpdateSlackPreferences = vi.hoisted(() => vi.fn());
+const mockUpdateQuietHours = vi.hoisted(() => vi.fn());
 
 vi.mock('@/lib/api', () => ({
   api: {
@@ -14,6 +16,8 @@ vi.mock('@/lib/api', () => ({
       getPreferences: mockGetPreferences,
       updatePreferences: mockUpdatePreferences,
       updateCardSuppressionEmailPreference: mockUpdateCardSuppression,
+      updateSlackPreferences: mockUpdateSlackPreferences,
+      updateQuietHours: mockUpdateQuietHours,
     },
   },
 }));
@@ -43,6 +47,18 @@ function fullPrefs(overrides: Record<string, unknown> = {}) {
     emailOnGameNightReminder: true,
     pushOnGameNightReminder: true,
     emailOnCardSuppressed: false,
+    timeZone: 'UTC',
+    quietHoursStart: null,
+    quietHoursEnd: null,
+    slackEnabled: true,
+    slackOnDocumentReady: true,
+    slackOnDocumentFailed: true,
+    slackOnRetryAvailable: false,
+    slackOnGameNightInvitation: true,
+    slackOnGameNightReminder: true,
+    slackOnShareRequestCreated: true,
+    slackOnShareRequestApproved: true,
+    slackOnBadgeEarned: true,
     ...overrides,
   };
 }
@@ -53,6 +69,8 @@ describe('NotificationPreferences — card-suppression email opt-in (#2832)', ()
     mockGetPreferences.mockResolvedValue(fullPrefs());
     mockUpdatePreferences.mockResolvedValue(undefined);
     mockUpdateCardSuppression.mockResolvedValue(undefined);
+    mockUpdateSlackPreferences.mockResolvedValue(undefined);
+    mockUpdateQuietHours.mockResolvedValue(undefined);
   });
 
   it('renders the card-suppression toggle reflecting the loaded (off) state', async () => {

--- a/apps/web/src/components/notifications/__tests__/NotificationPreferences.quietHoursSlack.test.tsx
+++ b/apps/web/src/components/notifications/__tests__/NotificationPreferences.quietHoursSlack.test.tsx
@@ -1,0 +1,185 @@
+/**
+ * #2994: quiet-hours (ADR-076) + Slack channel toggles render and round-trip through their
+ * dedicated save endpoints.
+ */
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockGetPreferences = vi.hoisted(() => vi.fn());
+const mockUpdatePreferences = vi.hoisted(() => vi.fn());
+const mockUpdateCardSuppression = vi.hoisted(() => vi.fn());
+const mockUpdateSlackPreferences = vi.hoisted(() => vi.fn());
+const mockUpdateQuietHours = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    notifications: {
+      getPreferences: mockGetPreferences,
+      updatePreferences: mockUpdatePreferences,
+      updateCardSuppressionEmailPreference: mockUpdateCardSuppression,
+      updateSlackPreferences: mockUpdateSlackPreferences,
+      updateQuietHours: mockUpdateQuietHours,
+    },
+  },
+}));
+
+// Stable toast reference: the component's load effect depends on `toast`, and the real hook returns
+// a useCallback-stable function. A fresh vi.fn() per render would re-trigger the fetch and clobber edits.
+const mockToast = vi.hoisted(() => vi.fn());
+vi.mock('@/hooks/useToast', () => ({
+  useToast: () => ({ toast: mockToast }),
+}));
+
+import { NotificationPreferences } from '../NotificationPreferences';
+
+function fullPrefs(overrides: Record<string, unknown> = {}) {
+  return {
+    userId: 'u1',
+    emailOnDocumentReady: true,
+    emailOnDocumentFailed: true,
+    emailOnRetryAvailable: false,
+    pushOnDocumentReady: true,
+    pushOnDocumentFailed: true,
+    pushOnRetryAvailable: false,
+    inAppOnDocumentReady: true,
+    inAppOnDocumentFailed: true,
+    inAppOnRetryAvailable: true,
+    hasPushSubscription: false,
+    inAppOnGameNightInvitation: true,
+    emailOnGameNightInvitation: true,
+    pushOnGameNightInvitation: true,
+    emailOnGameNightReminder: true,
+    pushOnGameNightReminder: true,
+    emailOnCardSuppressed: false,
+    timeZone: 'UTC',
+    quietHoursStart: null,
+    quietHoursEnd: null,
+    slackEnabled: true,
+    slackOnDocumentReady: true,
+    slackOnDocumentFailed: true,
+    slackOnRetryAvailable: false,
+    slackOnGameNightInvitation: true,
+    slackOnGameNightReminder: true,
+    slackOnShareRequestCreated: true,
+    slackOnShareRequestApproved: true,
+    slackOnBadgeEarned: true,
+    ...overrides,
+  };
+}
+
+describe('NotificationPreferences — Slack toggles (#2994)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetPreferences.mockResolvedValue(fullPrefs());
+    mockUpdatePreferences.mockResolvedValue(undefined);
+    mockUpdateCardSuppression.mockResolvedValue(undefined);
+    mockUpdateSlackPreferences.mockResolvedValue(undefined);
+    mockUpdateQuietHours.mockResolvedValue(undefined);
+  });
+
+  it('renders the Slack master toggle reflecting the loaded (on) state', async () => {
+    render(<NotificationPreferences />);
+    const toggle = await screen.findByTestId('pref-slackEnabled');
+    expect(toggle).toBeInTheDocument();
+    expect(toggle).toHaveAttribute('aria-checked', 'true');
+  });
+
+  it('persists a per-type Slack toggle change via the dedicated endpoint on save', async () => {
+    render(<NotificationPreferences />);
+    const toggle = await screen.findByTestId('pref-slackOnBadgeEarned');
+    expect(toggle).toHaveAttribute('aria-checked', 'true');
+
+    fireEvent.click(toggle); // on → off
+    fireEvent.click(screen.getByTestId('save-preferences'));
+
+    await waitFor(() =>
+      expect(mockUpdateSlackPreferences).toHaveBeenCalledWith(
+        expect.objectContaining({ slackOnBadgeEarned: false, slackEnabled: true })
+      )
+    );
+  });
+});
+
+describe('NotificationPreferences — quiet hours (#2995)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUpdatePreferences.mockResolvedValue(undefined);
+    mockUpdateCardSuppression.mockResolvedValue(undefined);
+    mockUpdateSlackPreferences.mockResolvedValue(undefined);
+    mockUpdateQuietHours.mockResolvedValue(undefined);
+  });
+
+  it('renders disabled by default with the time inputs hidden', async () => {
+    mockGetPreferences.mockResolvedValue(fullPrefs());
+    render(<NotificationPreferences />);
+
+    const toggle = await screen.findByTestId('pref-quietHoursEnabled');
+    expect(toggle).toHaveAttribute('aria-checked', 'false');
+    expect(screen.queryByTestId('pref-quietHoursStart')).not.toBeInTheDocument();
+  });
+
+  it('enabling reveals the time inputs and saves the default 22:00 → 08:00 window', async () => {
+    mockGetPreferences.mockResolvedValue(fullPrefs());
+    render(<NotificationPreferences />);
+
+    const toggle = await screen.findByTestId('pref-quietHoursEnabled');
+    fireEvent.click(toggle); // off → on
+
+    expect(await screen.findByTestId('pref-quietHoursStart')).toHaveValue('22:00');
+    expect(screen.getByTestId('pref-quietHoursEnd')).toHaveValue('08:00');
+
+    fireEvent.click(screen.getByTestId('save-preferences'));
+
+    await waitFor(() =>
+      expect(mockUpdateQuietHours).toHaveBeenCalledWith({
+        timeZone: 'UTC',
+        quietHoursStart: '22:00',
+        quietHoursEnd: '08:00',
+      })
+    );
+  });
+
+  it('hydrates an existing window and persists an edited start time', async () => {
+    mockGetPreferences.mockResolvedValue(
+      fullPrefs({ timeZone: 'Europe/Rome', quietHoursStart: '23:00', quietHoursEnd: '07:00' })
+    );
+    render(<NotificationPreferences />);
+
+    const enableToggle = await screen.findByTestId('pref-quietHoursEnabled');
+    expect(enableToggle).toHaveAttribute('aria-checked', 'true');
+
+    const start = screen.getByTestId('pref-quietHoursStart');
+    expect(start).toHaveValue('23:00');
+
+    fireEvent.change(start, { target: { value: '22:30' } });
+    fireEvent.click(screen.getByTestId('save-preferences'));
+
+    await waitFor(() =>
+      expect(mockUpdateQuietHours).toHaveBeenCalledWith({
+        timeZone: 'Europe/Rome',
+        quietHoursStart: '22:30',
+        quietHoursEnd: '07:00',
+      })
+    );
+  });
+
+  it('disabling an existing window persists null bounds', async () => {
+    mockGetPreferences.mockResolvedValue(
+      fullPrefs({ timeZone: 'Europe/Rome', quietHoursStart: '23:00', quietHoursEnd: '07:00' })
+    );
+    render(<NotificationPreferences />);
+
+    const toggle = await screen.findByTestId('pref-quietHoursEnabled');
+    fireEvent.click(toggle); // on → off
+
+    fireEvent.click(screen.getByTestId('save-preferences'));
+
+    await waitFor(() =>
+      expect(mockUpdateQuietHours).toHaveBeenCalledWith({
+        timeZone: 'Europe/Rome',
+        quietHoursStart: null,
+        quietHoursEnd: null,
+      })
+    );
+  });
+});

--- a/apps/web/src/lib/api/clients/notifications.ts
+++ b/apps/web/src/lib/api/clients/notifications.ts
@@ -19,6 +19,8 @@ import {
   type MarkNotificationReadResponse,
   type NotificationDto,
   type NotificationPreferences,
+  type QuietHoursInput,
+  type SlackPreferencesInput,
 } from '../schemas/notifications.schemas';
 
 import type { HttpClient } from '../core/httpClient';
@@ -35,6 +37,8 @@ export interface NotificationsClient {
   getPreferences(): Promise<NotificationPreferences>;
   updatePreferences(prefs: Omit<NotificationPreferences, 'userId'>): Promise<void>;
   updateCardSuppressionEmailPreference(enabled: boolean): Promise<void>;
+  updateSlackPreferences(prefs: SlackPreferencesInput): Promise<void>;
+  updateQuietHours(input: QuietHoursInput): Promise<void>;
 }
 
 export interface GetNotificationsParams {
@@ -142,6 +146,22 @@ export function createNotificationsClient({
       await httpClient.put('/api/v1/notifications/preferences/card-suppression', {
         emailOnCardSuppressed: enabled,
       });
+    },
+
+    /**
+     * Update Slack notification channel preferences (Issue #2994).
+     * Dedicated endpoint so the generic preferences save never resets Slack toggles.
+     */
+    async updateSlackPreferences(prefs: SlackPreferencesInput): Promise<void> {
+      await httpClient.put('/api/v1/notifications/preferences/slack', prefs);
+    },
+
+    /**
+     * Update the quiet-hours window (ADR-076 / Issue #2995). Pass null start + end to disable.
+     * Times are "HH:mm" strings; the server suppresses email + Slack DM during the window.
+     */
+    async updateQuietHours(input: QuietHoursInput): Promise<void> {
+      await httpClient.put('/api/v1/notifications/preferences/quiet-hours', input);
     },
   };
 }

--- a/apps/web/src/lib/api/schemas/notifications.schemas.ts
+++ b/apps/web/src/lib/api/schemas/notifications.schemas.ts
@@ -94,8 +94,44 @@ export const NotificationPreferencesSchema = z.object({
   pushOnGameNightReminder: z.boolean().optional().default(true),
   // #535 / #2832: opt-in admin email when a mechanic card is suppressed (default off).
   emailOnCardSuppressed: z.boolean().optional().default(false),
+  // Quiet hours (ADR-076 / Issue #2995). Times are "HH:mm" strings; null when not configured.
+  // Server-side gating suppresses email + Slack DM during the window (in-app is never suppressed).
+  timeZone: z.string().optional().default('UTC'),
+  quietHoursStart: z.string().nullable().optional(),
+  quietHoursEnd: z.string().nullable().optional(),
+  // Slack channel preferences (Issue #2994) — persisted via PUT /notifications/preferences/slack.
+  slackEnabled: z.boolean().optional().default(true),
+  slackOnDocumentReady: z.boolean().optional().default(true),
+  slackOnDocumentFailed: z.boolean().optional().default(true),
+  slackOnRetryAvailable: z.boolean().optional().default(false),
+  slackOnGameNightInvitation: z.boolean().optional().default(true),
+  slackOnGameNightReminder: z.boolean().optional().default(true),
+  slackOnShareRequestCreated: z.boolean().optional().default(true),
+  slackOnShareRequestApproved: z.boolean().optional().default(true),
+  slackOnBadgeEarned: z.boolean().optional().default(true),
 });
 export type NotificationPreferences = z.infer<typeof NotificationPreferencesSchema>;
+
+// Issue #2994: dedicated payloads for the Slack + quiet-hours save endpoints.
+export const SlackPreferencesInputSchema = NotificationPreferencesSchema.pick({
+  slackEnabled: true,
+  slackOnDocumentReady: true,
+  slackOnDocumentFailed: true,
+  slackOnRetryAvailable: true,
+  slackOnGameNightInvitation: true,
+  slackOnGameNightReminder: true,
+  slackOnShareRequestCreated: true,
+  slackOnShareRequestApproved: true,
+  slackOnBadgeEarned: true,
+});
+export type SlackPreferencesInput = z.infer<typeof SlackPreferencesInputSchema>;
+
+export const QuietHoursInputSchema = z.object({
+  timeZone: z.string(),
+  quietHoursStart: z.string().nullable(),
+  quietHoursEnd: z.string().nullable(),
+});
+export type QuietHoursInput = z.infer<typeof QuietHoursInputSchema>;
 
 export const MarkNotificationReadResponseSchema = z.object({
   success: z.boolean(),

--- a/docs/for-claude/architecture/adr/adr-076-quiet-hours-timezone.md
+++ b/docs/for-claude/architecture/adr/adr-076-quiet-hours-timezone.md
@@ -1,10 +1,18 @@
 # ADR-076 — Quiet Hours Timezone Enforcement
 
-**Status**: Proposed
-**Date**: 2026-06-15
-**Deciders**: @badsworm (pending ratification at PR review)
+**Status**: Accepted — implemented (server-side enforcement + preferences UI) in #2994/#2995
+**Date**: 2026-06-15 (ratified/implemented 2026-07-16)
+**Deciders**: @badsworm
 **Tracking**: [#2363](https://github.com/meepleAi-app/meepleai-monorepo/issues/2363) Wave 4 — US-INT-5 (notifications & deep links)
 **Related**: [umbrella #2342](https://github.com/meepleAi-app/meepleai-monorepo/issues/2342) · `NotificationPreferences` aggregate · Resend email provider (issue #1632)
+
+> **Implementation note (2026-07-16, #2994/#2995).** Option C shipped: the server-side gate lives in
+> `NotificationDispatcher.DispatchAsync` (`preferences.IsQuietHoursActive(TimeProvider.GetUtcNow())` suppresses
+> the email + Slack DM enqueue; in-app is always created; the config-driven Slack **team** broadcast is not
+> user-scoped so it is not gated). The window is set via `UpdateQuietHoursCommand` (`PUT /api/v1/notifications/preferences/quiet-hours`)
+> and surfaced through `NotificationPreferencesDto` + the Preferences UI (`NotificationPreferences.tsx` "Ore di silenzio" section).
+> MVP is **suppression-only** (not deferral), exactly as decided below. The client-side toast-suppression hook
+> (Implementation Guidance §4) and the deferred-send queue remain future enhancements.
 
 ## Context
 


### PR DESCRIPTION
Closes #2994
Closes #2995
Sub-issue dell'umbrella 2992 (Tier 5, #2342).

## GAP-5.2 (#2995) — Quiet-hours enforcement e2e
Il dominio modellava già `NotificationPreferences.IsQuietHoursActive()` (con midnight-crossing) + colonne DB, ma era **dead-code**: zero caller e nessun comando per settarlo.

- `UpdateQuietHoursCommand` + validator (tz IANA/Windows valido, `HH:mm`, both-set-or-both-null → **400** via FluentValidation, non 500) + handler (load/mutate/save con commit ADR-060).
- `PUT /api/v1/notifications/preferences/quiet-hours`.
- `NotificationDispatcher` inietta `TimeProvider` e **sopprime email + Slack DM** quando `IsQuietHoursActive(now)`. In-app è sempre creato; lo Slack **team broadcast** (config-driven, non user-scoped) non è gated; il push è delegato al DND del device.
- **Suppression-only** (non deferral): è l'MVP ratificato da **ADR-076** (il deferral richiederebbe una colonna `suppressed_until` + job di re-dispatch → esplicitamente follow-up). L'AC citava "delivery differita" ma l'ADR ha deciso suppression.

## GAP-5.1 (#2994) — Preferences completeness
La UI esponeva solo i toggle canale; quiet-hours e Slack erano modellati BE-side ma non nel contratto FE né in UI, quindi un singolo save non round-trippava tutto.

- `NotificationPreferencesDto` + query handler ora ritornano `timeZone`/`quietHoursStart`/`quietHoursEnd` (stringhe `HH:mm`) + i 9 campi Slack. (Nessuna migration: colonne già presenti nella baseline `Initial`.)
- FE: `NotificationPreferencesSchema` esteso; api client con `updateSlackPreferences` + `updateQuietHours`.
- `NotificationPreferences.tsx`: nuova categoria **Slack** (9 toggle) + sezione custom **"Ore di silenzio"** (toggle attiva + select fuso + input `time` start/end). Il save **compone** i 4 endpoint (generic + card-suppression + slack + quiet-hours).

## Test
- BE: `NotificationDispatcherTests` (soppressione + midnight-crossing), `UpdateQuietHoursCommandValidatorTests`, `UpdateQuietHoursHandlerTests` (Testcontainers, verifica la **colonna persistita** con context NoTracking fresco — guardia PERF-06).
- FE: `NotificationPreferences.quietHoursSlack.test.tsx` (Slack toggle + quiet-hours enable/hydrate/edit/disable round-trip) + update del test card-suppression esistente.
- Verde localmente: 152 unit UserNotifications, handler integration 3/3, FE 688 (notifiche+api), typecheck, lint (0 errori).

Docs: ADR-076 → **Accepted/Implemented**.

Nota: `Dep Vulnerabilities` (SQLitePCLRaw High transitive) è rosso su tutte le PR — ininfluente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)