### PR TITLE
fix(api-schemas): accetta id giochi non-RFC via GameIdString (fix /discover)

### DIFF
--- a/apps/web/src/lib/api/schemas/__tests__/game-id-string.test.ts
+++ b/apps/web/src/lib/api/schemas/__tests__/game-id-string.test.ts
@@ -1,0 +1,80 @@
+/**
+ * GameIdString Schema Tests
+ *
+ * Verifies that GAME id/gameId fields accept non-RFC-4122 UUIDs (the root
+ * cause of the /discover validation bug: real backend game ids can have a
+ * version nibble outside 1-5, e.g. seed data like
+ * `81cc97e4-f148-fb7b-db36-bf700d1f4561`), while non-game entity ids
+ * (session, user, etc.) remain strictly validated as RFC UUIDs.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { GameSchema, GameSessionDtoSchema } from '../games.schemas';
+import { NewGameSchema, RecentKbDocSchema } from '../discover.schemas';
+
+// Real non-RFC-4122 ids observed from the backend (version nibble outside 1-5).
+const NON_RFC_GAME_ID = '81cc97e4-f148-fb7b-db36-bf700d1f4561'; // version nibble 'f'
+const NON_RFC_KB_GAME_ID = '0f5e0d2f-4281-d76c-ceea-51c076a149b6'; // version nibble 'd'
+
+describe('GameIdString — accepts non-RFC-UUID game ids', () => {
+  it('GameSchema.parse accepts a game with a non-RFC-UUID id', () => {
+    const game = {
+      id: NON_RFC_GAME_ID,
+      title: 'Azul',
+      publisher: null,
+      yearPublished: null,
+      minPlayers: null,
+      maxPlayers: null,
+      minPlayTimeMinutes: null,
+      maxPlayTimeMinutes: null,
+      bggId: null,
+      createdAt: new Date().toISOString(),
+    };
+
+    expect(() => GameSchema.parse(game)).not.toThrow();
+  });
+
+  it('NewGameSchema.parse accepts a newGame with a non-RFC-UUID id', () => {
+    const newGame = {
+      id: NON_RFC_GAME_ID,
+      name: 'Azul',
+      publisher: null,
+      year: null,
+      imageUrl: null,
+      createdAt: new Date().toISOString(),
+    };
+
+    expect(() => NewGameSchema.parse(newGame)).not.toThrow();
+  });
+
+  it('RecentKbDocSchema.parse accepts a kbDoc with a non-RFC-UUID gameId', () => {
+    const kbDoc = {
+      id: '550e8400-e29b-41d4-a716-446655440000', // doc's own id — a real RFC UUID here, untouched
+      title: 'Azul Rulebook',
+      gameId: NON_RFC_KB_GAME_ID,
+      gameName: 'Azul',
+      docType: 'rulebook' as const,
+      lastIngestedAt: new Date().toISOString(),
+      chunkCount: 3,
+    };
+
+    expect(() => RecentKbDocSchema.parse(kbDoc)).not.toThrow();
+  });
+
+  it('(regression) GameSessionDtoSchema still rejects a malformed session id while accepting a non-RFC-UUID gameId', () => {
+    const session = {
+      id: 'not-a-valid-uuid', // session id — left strict on purpose
+      gameId: NON_RFC_GAME_ID, // gameId — relaxed
+      status: 'completed',
+      startedAt: new Date().toISOString(),
+      completedAt: null,
+      playerCount: 2,
+      players: [],
+      winnerName: null,
+      notes: null,
+      durationMinutes: 30,
+    };
+
+    expect(() => GameSessionDtoSchema.parse(session)).toThrow();
+  });
+});

--- a/apps/web/src/lib/api/schemas/__tests__/kb-globale.schemas.test.ts
+++ b/apps/web/src/lib/api/schemas/__tests__/kb-globale.schemas.test.ts
@@ -73,8 +73,14 @@ describe('KB Globale Schemas', () => {
     expect(() => GlobalKbSearchResponseSchema.parse(envelope)).toThrow();
   });
 
-  it('rejects malformed gameId UUID', () => {
-    const result = { ...validResult, gameId: 'invalid-uuid' };
+  it('accepts non-RFC-UUID gameId (game ids are not guaranteed strict UUIDs, #2247)', () => {
+    const result = { ...validResult, gameId: '81cc97e4-f148-fb7b-db36-bf700d1f4561' };
+    const envelope = { results: [result], hasMore: false, nextCursor: null };
+    expect(() => GlobalKbSearchResponseSchema.parse(envelope)).not.toThrow();
+  });
+
+  it('rejects empty-string gameId', () => {
+    const result = { ...validResult, gameId: '' };
     const envelope = { results: [result], hasMore: false, nextCursor: null };
     expect(() => GlobalKbSearchResponseSchema.parse(envelope)).toThrow();
   });
@@ -157,10 +163,18 @@ describe('GlobalKbSearchRequestSchema — filters (Phase 3 #1737)', () => {
     expect(result.success).toBe(true);
   });
 
-  it('rejects gameId with non-uuid string', () => {
+  it('accepts gameId array with non-RFC-UUID game id (#2247)', () => {
     const result = GlobalKbSearchRequestSchema.safeParse({
       query: 'azul',
-      gameId: ['not-a-uuid'],
+      gameId: ['81cc97e4-f148-fb7b-db36-bf700d1f4561'],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects gameId array containing an empty string', () => {
+    const result = GlobalKbSearchRequestSchema.safeParse({
+      query: 'azul',
+      gameId: [''],
     });
     expect(result.success).toBe(false);
   });

--- a/apps/web/src/lib/api/schemas/admin-knowledge-base.schemas.ts
+++ b/apps/web/src/lib/api/schemas/admin-knowledge-base.schemas.ts
@@ -7,6 +7,8 @@
 
 import { z } from 'zod';
 
+import { GameIdString } from './common.schemas';
+
 // ========== Bulk Delete ==========
 
 export const BulkDeleteItemResultSchema = z.object({
@@ -336,7 +338,7 @@ export type RecentLlmRequestsDto = z.infer<typeof RecentLlmRequestsDtoSchema>;
 // ─── KB Games Status (Admin KB Dashboard) ────────────────────────────────────
 
 export const GameKbStatusItemSchema = z.object({
-  gameId: z.string().uuid(),
+  gameId: GameIdString,
   gameName: z.string(),
   kbStatus: z.enum(['complete', 'partial', 'none']),
   documentCount: z.number(),

--- a/apps/web/src/lib/api/schemas/admin-mechanic-extractor-validation.schemas.ts
+++ b/apps/web/src/lib/api/schemas/admin-mechanic-extractor-validation.schemas.ts
@@ -18,6 +18,8 @@
 
 import { z } from 'zod';
 
+import { GameIdString } from './common.schemas';
+
 // ──────────────────────────────────────────────────────────────────────────
 // Enums (string-serialized — see Program.cs `JsonStringEnumConverter`)
 // ──────────────────────────────────────────────────────────────────────────
@@ -76,7 +78,7 @@ export type MechanicGoldenBggTagDto = z.infer<typeof MechanicGoldenBggTagDtoSche
  * Golden-set bundle for a single shared game. Mirrors `GoldenForGameDto`.
  */
 export const GoldenForGameDtoSchema = z.object({
-  sharedGameId: z.string().uuid(),
+  sharedGameId: GameIdString,
   versionHash: z.string(),
   claims: z.array(MechanicGoldenClaimDtoSchema),
   bggTags: z.array(MechanicGoldenBggTagDtoSchema),
@@ -93,7 +95,7 @@ export type GoldenForGameDto = z.infer<typeof GoldenForGameDtoSchema>;
  * (Routing/AdminMechanicExtractorValidationEndpoints.cs).
  */
 export const CreateGoldenClaimRequestSchema = z.object({
-  sharedGameId: z.string().uuid(),
+  sharedGameId: GameIdString,
   section: MechanicSectionSchema,
   statement: z.string(),
   expectedPage: z.number().int(),
@@ -245,7 +247,7 @@ export type RecalcJobStatusDto = z.infer<typeof RecalcJobStatusDtoSchema>;
  * (Domain/Repositories/IMechanicAnalysisMetricsRepository.cs).
  */
 export const ValidationDashboardRowDtoSchema = z.object({
-  sharedGameId: z.string().uuid(),
+  sharedGameId: GameIdString,
   name: z.string(),
   status: CertificationStatusSchema,
   overallScore: z.number(),
@@ -266,7 +268,7 @@ export type ValidationDashboardDto = z.infer<typeof ValidationDashboardDtoSchema
 export const MechanicAnalysisMetricsDtoSchema = z.object({
   id: z.string().uuid(),
   mechanicAnalysisId: z.string().uuid(),
-  sharedGameId: z.string().uuid(),
+  sharedGameId: GameIdString,
   coveragePct: z.number(),
   pageAccuracyPct: z.number(),
   bggMatchPct: z.number(),

--- a/apps/web/src/lib/api/schemas/admin-share-requests.schemas.ts
+++ b/apps/web/src/lib/api/schemas/admin-share-requests.schemas.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 
+import { GameIdString } from './common.schemas';
 import { ShareRequestStatusSchema, ContributionTypeSchema } from './share-requests.schemas';
 
 // Re-export types from share-requests.schemas for convenience
@@ -121,7 +122,7 @@ export const AdminShareRequestDtoSchema = z.object({
   contributionType: ContributionTypeSchema,
 
   // Game preview
-  sourceGameId: z.string().uuid(),
+  sourceGameId: GameIdString,
   gameTitle: z.string(),
   gameThumbnailUrl: z.string().nullable(),
   bggId: z.number().int().positive().nullable(),
@@ -144,7 +145,7 @@ export const AdminShareRequestDtoSchema = z.object({
   reviewStartedAt: z.string().datetime({ offset: true }).nullable(),
 
   // For additional content
-  targetSharedGameId: z.string().uuid().nullable(),
+  targetSharedGameId: GameIdString.nullable(),
   targetSharedGameTitle: z.string().nullable(),
 });
 
@@ -185,7 +186,7 @@ export type ShareRequestDetailsDto = z.infer<typeof ShareRequestDetailsDtoSchema
 // Active Review DTO (for "My Reviews" page)
 export const ActiveReviewDtoSchema = z.object({
   shareRequestId: z.string().uuid(),
-  sourceGameId: z.string().uuid(),
+  sourceGameId: GameIdString,
   gameTitle: z.string(),
   contributorId: z.string().uuid(),
   contributorName: z.string(),

--- a/apps/web/src/lib/api/schemas/admin/admin-ai.schemas.ts
+++ b/apps/web/src/lib/api/schemas/admin/admin-ai.schemas.ts
@@ -7,12 +7,14 @@
 
 import { z } from 'zod';
 
+import { GameIdString } from '../common.schemas';
+
 // ========== AI Request Logs & Stats ==========
 
 export const AiRequestSchema = z.object({
   id: z.string().uuid(),
   userId: z.string().uuid().nullable(),
-  gameId: z.string().uuid().nullable(),
+  gameId: GameIdString.nullable(),
   endpoint: z.string(),
   query: z.string().nullable(),
   responseSnippet: z.string().nullable(),

--- a/apps/web/src/lib/api/schemas/agents.schemas.ts
+++ b/apps/web/src/lib/api/schemas/agents.schemas.ts
@@ -7,6 +7,8 @@
 
 import { z } from 'zod';
 
+import { GameIdString } from './common.schemas';
+
 /**
  * Agent DTO Schema
  * Matches AgentDto from backend
@@ -24,7 +26,7 @@ export const AgentDtoSchema = z.object({
   isRecentlyUsed: z.boolean(),
   isIdle: z.boolean(),
   // Issue #4914: user-owned agent fields
-  gameId: z.string().uuid().nullable().optional(),
+  gameId: GameIdString.nullable().optional(),
   gameName: z.string().nullable().optional(),
   createdByUserId: z.string().uuid().nullable().optional(),
 });
@@ -48,7 +50,7 @@ export const AgentResponseDtoSchema = z.object({
   searchResults: z.array(
     z.object({
       documentId: z.string().uuid(),
-      gameId: z.string().uuid(),
+      gameId: GameIdString,
       snippet: z.string(),
       score: z.number(),
       pageNumber: z.number().int().nullable(),
@@ -66,7 +68,7 @@ export type AgentResponseDto = z.infer<typeof AgentResponseDtoSchema>;
  */
 export const InvokeAgentRequestSchema = z.object({
   query: z.string().min(1, 'Query is required'),
-  gameId: z.string().uuid().optional(),
+  gameId: GameIdString.optional(),
   chatThreadId: z.string().uuid().optional(),
 });
 
@@ -135,7 +137,7 @@ export type ChessAnalysis = z.infer<typeof ChessAnalysisSchema>;
  */
 export const SnippetSchema = z.object({
   documentId: z.string().uuid(),
-  gameId: z.string().uuid(),
+  gameId: GameIdString,
   snippet: z.string(),
   score: z.number(),
   pageNumber: z.number().int().nullable(),
@@ -201,7 +203,7 @@ export type SetupGuideResponse = z.infer<typeof SetupGuideResponseSchema>;
  */
 export const SelectedDocumentDtoSchema = z.object({
   id: z.string().uuid(),
-  sharedGameId: z.string().uuid(),
+  sharedGameId: GameIdString,
   pdfDocumentId: z.string().uuid(),
   documentType: z.number().int().min(0).max(2), // Rulebook=0, Errata=1, Homerule=2
   version: z.string(),
@@ -313,7 +315,7 @@ export type RecentAgentsResponse = z.infer<typeof RecentAgentsResponseSchema>;
  * Issue #2421: Player Mode UI Controls
  */
 export const PlayerModeSuggestionRequestSchema = z.object({
-  gameId: z.string().uuid(),
+  gameId: GameIdString,
   gameState: z.record(z.string(), z.any()), // Flexible game state object
   query: z.string().optional(), // Optional context/question from player
   chatThreadId: z.string().uuid().optional(),

--- a/apps/web/src/lib/api/schemas/chat-sessions.schemas.ts
+++ b/apps/web/src/lib/api/schemas/chat-sessions.schemas.ts
@@ -7,6 +7,8 @@
 
 import { z } from 'zod';
 
+import { GameIdString } from './common.schemas';
+
 // ========== Session Chat Message ==========
 
 export const SessionChatMessageDtoSchema = z.object({
@@ -24,7 +26,7 @@ export type SessionChatMessageDto = z.infer<typeof SessionChatMessageDtoSchema>;
 export const ChatSessionDtoSchema = z.object({
   id: z.string().uuid(),
   userId: z.string().uuid(),
-  gameId: z.string().uuid(),
+  gameId: GameIdString,
   gameTitle: z.string().nullable().optional(),
   title: z.string().nullable(),
   messageCount: z.number().int().nonnegative(),
@@ -41,7 +43,7 @@ export type ChatSessionDto = z.infer<typeof ChatSessionDtoSchema>;
 export const ChatSessionSummaryDtoSchema = z.object({
   id: z.string().uuid(),
   userId: z.string().uuid(),
-  gameId: z.string().uuid(),
+  gameId: GameIdString,
   gameTitle: z.string().nullable().optional(),
   agentId: z.string().uuid().nullable().optional(),
   agentType: z.string().nullable().optional(),

--- a/apps/web/src/lib/api/schemas/chat.schemas.ts
+++ b/apps/web/src/lib/api/schemas/chat.schemas.ts
@@ -7,6 +7,8 @@
 
 import { z } from 'zod';
 
+import { GameIdString } from './common.schemas';
+
 // ========== Chat Messages ==========
 
 export const ChatMessageResponseSchema = z.object({
@@ -35,7 +37,7 @@ export const ChatThreadMessageDtoSchema = z.object({
   timestamp: z.string().datetime({ offset: true }),
   backendMessageId: z.string().uuid().optional(),
   endpoint: z.string().optional(),
-  gameId: z.string().uuid().optional(),
+  gameId: GameIdString.optional(),
   // Note: Keep in sync with FEEDBACK_OUTCOMES in @/lib/constants/feedback
   feedback: z.enum(['helpful', 'not-helpful', 'incorrect']).nullable().optional(),
   // Populated by BE on assistant messages; null on user messages. R1 — Task 5-FE #2500.
@@ -46,7 +48,7 @@ export type ChatThreadMessageDto = z.infer<typeof ChatThreadMessageDtoSchema>;
 
 export const ChatThreadDtoSchema = z.object({
   id: z.string().uuid(),
-  gameId: z.string().uuid().nullable(),
+  gameId: GameIdString.nullable(),
   agentId: z.string().uuid().nullable().optional(),
   agentType: z.string().nullable().optional(),
   title: z.string().nullable(),
@@ -63,7 +65,7 @@ export type ChatThreadDto = z.infer<typeof ChatThreadDtoSchema>;
 export const RuleSpecCommentSchema: z.ZodType<RuleSpecComment> = z.lazy(() =>
   z.object({
     id: z.string().uuid(),
-    gameId: z.string().uuid(),
+    gameId: GameIdString,
     version: z.string().min(1),
     atomId: z.string().nullable(),
     lineNumber: z.number().int().nullable(),
@@ -105,7 +107,7 @@ export type RuleSpecComment = {
 };
 
 export const RuleSpecCommentsResponseSchema = z.object({
-  gameId: z.string().uuid(),
+  gameId: GameIdString,
   version: z.string().min(1),
   comments: z.array(RuleSpecCommentSchema),
   totalComments: z.number().int().nonnegative(),

--- a/apps/web/src/lib/api/schemas/common.schemas.ts
+++ b/apps/web/src/lib/api/schemas/common.schemas.ts
@@ -1,0 +1,26 @@
+/**
+ * Common / Shared Primitive Schemas
+ *
+ * Cross-cutting Zod primitives reused by multiple domain schema files.
+ */
+
+import { z } from 'zod';
+
+/**
+ * Schema for a GAME identifier (board game / shared game / private game id, or a
+ * gameId/sharedGameId foreign key pointing at one).
+ *
+ * Game ids are NOT guaranteed to be RFC-4122 UUIDs: deterministic seed data and
+ * legacy rows can produce ids whose version nibble is outside the 1-5 range
+ * (e.g. `81cc97e4-f148-fb7b-db36-bf700d1f4561`, version nibble 'f'). Zod's
+ * `z.string().uuid()` enforces strict RFC-4122 and rejects these, which broke
+ * validation of real backend data on the /discover page (root cause of the
+ * bug fixed alongside this schema). Use `GameIdString` instead of
+ * `z.string().uuid()` for any id/gameId field belonging to a GAME entity so
+ * validation doesn't reject real data. Non-game entity ids (session, user,
+ * agent, document, etc.) are always real RFC UUIDs (`Guid.NewGuid()`) and
+ * should keep using `z.string().uuid()`.
+ *
+ * Ref: Issue #2247 (games.schemas.ts precedent), /discover validation root cause.
+ */
+export const GameIdString = z.string().min(1);

--- a/apps/web/src/lib/api/schemas/discover.schemas.ts
+++ b/apps/web/src/lib/api/schemas/discover.schemas.ts
@@ -13,10 +13,12 @@
 
 import { z } from 'zod';
 
+import { GameIdString } from './common.schemas';
+
 // ========== /api/v1/catalog/games/new (PR #732 §4.3.2) ==========
 
 export const NewGameSchema = z.object({
-  id: z.string().uuid(),
+  id: GameIdString,
   name: z.string().min(1),
   publisher: z.string().nullable(),
   // Year is nullable because legacy SharedGame rows can have YearPublished == 0
@@ -38,7 +40,7 @@ export type NewGamesResponse = z.infer<typeof NewGamesResponseSchema>;
 export const PopularAgentSchema = z.object({
   id: z.string().uuid(),
   name: z.string().min(1),
-  gameId: z.string().uuid().nullable(),
+  gameId: GameIdString.nullable(),
   gameName: z.string().nullable(),
   // Schema reality v1 carryover (Gate B): backend always returns 0 until
   // AgentInstallation tracking lands. The field is part of the wire contract
@@ -68,7 +70,7 @@ export type RecentKbDocType = z.infer<typeof RecentKbDocTypeSchema>;
 export const RecentKbDocSchema = z.object({
   id: z.string().uuid(),
   title: z.string(),
-  gameId: z.string().uuid().nullable(),
+  gameId: GameIdString.nullable(),
   gameName: z.string().nullable(),
   docType: RecentKbDocTypeSchema,
   lastIngestedAt: z.string().datetime({ offset: true }),

--- a/apps/web/src/lib/api/schemas/documents.schemas.ts
+++ b/apps/web/src/lib/api/schemas/documents.schemas.ts
@@ -8,6 +8,8 @@
 
 import { z } from 'zod';
 
+import { GameIdString } from './common.schemas';
+
 /**
  * Document types supported in the system
  */
@@ -39,7 +41,7 @@ export type CreateDocumentCollectionRequest = z.infer<typeof createDocumentColle
  */
 export const documentCollectionSchema = z.object({
   id: z.string().uuid(),
-  gameId: z.string().uuid(),
+  gameId: GameIdString,
   name: z.string(),
   description: z.string().nullable(),
   documentCount: z.number().int().min(0),

--- a/apps/web/src/lib/api/schemas/game-nights.schemas.ts
+++ b/apps/web/src/lib/api/schemas/game-nights.schemas.ts
@@ -5,6 +5,8 @@
 
 import { z } from 'zod';
 
+import { GameIdString } from './common.schemas';
+
 // SI-3 #2634: `InProgress` mirrors the BE `GameNightStatus` enum (a Published night is promoted
 // to InProgress when its first session starts, event-driven via SessionStartedHandler). It MUST be
 // listed so the live/detail read of a night mid-play parses instead of failing the whole payload.
@@ -39,7 +41,7 @@ export const GameNightDtoSchema = z.object({
   scheduledAt: z.string(),
   location: z.string().nullable(),
   maxPlayers: z.number().nullable(),
-  gameIds: z.array(z.string().uuid()),
+  gameIds: z.array(GameIdString),
   status: GameNightStatusSchema,
   acceptedCount: z.number(),
   pendingCount: z.number(),
@@ -71,7 +73,7 @@ export type GameNightSessionStatus = z.infer<typeof GameNightSessionStatusSchema
 
 export const GameNightSessionDtoSchema = z.object({
   sessionId: z.string().uuid(),
-  gameId: z.string().uuid(),
+  gameId: GameIdString,
   gameTitle: z.string(),
   playOrder: z.number().int(),
   status: GameNightSessionStatusSchema,
@@ -85,7 +87,7 @@ export const GameNightSessionDtoSchema = z.object({
 export type GameNightSessionDto = z.infer<typeof GameNightSessionDtoSchema>;
 
 export const GameNightLineupItemDtoSchema = z.object({
-  gameId: z.string().uuid(),
+  gameId: GameIdString,
   gameTitle: z.string(),
 });
 export type GameNightLineupItemDto = z.infer<typeof GameNightLineupItemDtoSchema>;
@@ -183,7 +185,7 @@ export const CreateGameNightInputSchema = z.object({
   scheduledAt: z.string(),
   location: z.string().max(500).optional(),
   maxPlayers: z.number().min(2).max(50).optional(),
-  gameIds: z.array(z.string().uuid()).max(20).optional(),
+  gameIds: z.array(GameIdString).max(20).optional(),
   invitedUserIds: z.array(z.string().uuid()).max(49).optional(),
   // Issue #950 W1-PR1: email invitees feeding the token-based
   // GameNightInvitation flow (#607 Wave A.5a).
@@ -224,7 +226,7 @@ export const UpdateGameNightInputSchema = z.object({
   scheduledAt: z.string(),
   location: z.string().max(500).optional(),
   maxPlayers: z.number().min(2).max(50).optional(),
-  gameIds: z.array(z.string().uuid()).max(20).optional(),
+  gameIds: z.array(GameIdString).max(20).optional(),
 });
 export type UpdateGameNightInput = z.infer<typeof UpdateGameNightInputSchema>;
 
@@ -233,7 +235,7 @@ export type UpdateGameNightInput = z.infer<typeof UpdateGameNightInputSchema>;
 // ──────────────────────────────────────────────────────────────────────
 
 export const GameNightCandidateTallyDtoSchema = z.object({
-  gameId: z.string().uuid(),
+  gameId: GameIdString,
   voteCount: z.number().int().nonnegative(),
   votedByMe: z.boolean(),
 });
@@ -242,8 +244,8 @@ export type GameNightCandidateTallyDto = z.infer<typeof GameNightCandidateTallyD
 export const GameNightVoteTallyDtoSchema = z.object({
   isVotingClosed: z.boolean(),
   isTie: z.boolean(),
-  winnerGameId: z.string().uuid().nullable(),
-  leadingCandidateGameIds: z.array(z.string().uuid()),
+  winnerGameId: GameIdString.nullable(),
+  leadingCandidateGameIds: z.array(GameIdString),
   candidates: z.array(GameNightCandidateTallyDtoSchema),
 });
 export type GameNightVoteTallyDto = z.infer<typeof GameNightVoteTallyDtoSchema>;
@@ -268,7 +270,7 @@ export type GameNightSummaryKpisDto = z.infer<typeof GameNightSummaryKpisDtoSche
 
 export const GameNightGameRecapDtoSchema = z.object({
   sessionId: z.string().uuid(),
-  gameId: z.string().uuid(),
+  gameId: GameIdString,
   gameTitle: z.string(),
   playOrder: z.number().int(),
   status: z.string(),

--- a/apps/web/src/lib/api/schemas/games.schemas.ts
+++ b/apps/web/src/lib/api/schemas/games.schemas.ts
@@ -7,10 +7,12 @@
 
 import { z } from 'zod';
 
+import { GameIdString } from './common.schemas';
+
 // ========== Game Entity ==========
 
 export const GameSchema = z.object({
-  id: z.string().uuid(),
+  id: GameIdString,
   title: z.string().min(1),
   publisher: z.string().nullable(),
   yearPublished: z.number().int().nullable(),
@@ -33,7 +35,7 @@ export const GameSchema = z.object({
   faqCount: z.number().int().nonnegative().nullable().optional(),
   averageRating: z.number().nullable().optional(),
   // Issue #2373: SharedGameCatalog integration
-  sharedGameId: z.string().uuid().nullable().optional(),
+  sharedGameId: GameIdString.nullable().optional(),
   // Issue #3481: Publication workflow fields
   isPublished: z.boolean().optional(),
   approvalStatus: z.string().nullable().optional(),
@@ -73,7 +75,7 @@ export const GameLeaderboardEntrySchema = z.object({
 export type GameLeaderboardEntry = z.infer<typeof GameLeaderboardEntrySchema>;
 
 export const GameLeaderboardResponseSchema = z.object({
-  gameId: z.string().uuid(),
+  gameId: GameIdString,
   entries: z.array(GameLeaderboardEntrySchema),
   returnedCount: z.number().int().nonnegative(),
   since: z.string().datetime({ offset: true }).nullable(),
@@ -97,7 +99,7 @@ export type SessionPlayerDto = z.infer<typeof SessionPlayerDtoSchema>;
 
 export const GameSessionDtoSchema = z.object({
   id: z.string().uuid(),
-  gameId: z.string().uuid(),
+  gameId: GameIdString,
   status: z.string().min(1),
   startedAt: z.string().datetime({ offset: true }),
   completedAt: z.string().datetime({ offset: true }).nullable(),
@@ -130,7 +132,7 @@ export type PaginatedSessionsResponse = z.infer<typeof PaginatedSessionsResponse
 
 export const GameFAQSchema = z.object({
   id: z.string().uuid(),
-  gameId: z.string().uuid(),
+  gameId: GameIdString,
   question: z.string().min(1).max(500),
   answer: z.string().min(1).max(5000),
   upvotes: z.number().int().nonnegative(),
@@ -229,7 +231,7 @@ export type RuleAtom = z.infer<typeof RuleAtomSchema>;
  */
 export const RuleSpecSchema = z.object({
   id: z.string().uuid(),
-  gameId: z.string().uuid(),
+  gameId: GameIdString,
   version: z.string(),
   createdAt: z.string().datetime({ offset: true }),
   createdByUserId: z.string().uuid().nullable(),
@@ -257,7 +259,7 @@ export type RuleSpecVersion = z.infer<typeof RuleSpecVersionSchema>;
  * Matches RuleSpecHistoryDto from backend GetVersionHistoryQuery
  */
 export const RuleSpecHistorySchema = z.object({
-  gameId: z.string().uuid(),
+  gameId: GameIdString,
   versions: z.array(RuleSpecVersionSchema),
   totalVersions: z.number().int().nonnegative(),
 });
@@ -284,7 +286,7 @@ export type VersionNode = z.infer<typeof VersionNodeSchema>;
  * Matches VersionTimelineDto from backend GetVersionTimelineQuery
  */
 export const VersionTimelineSchema = z.object({
-  gameId: z.string().uuid(),
+  gameId: GameIdString,
   versions: z.array(VersionNodeSchema),
   totalVersions: z.number().int().nonnegative(),
   authors: z.array(z.string()).optional(),
@@ -345,7 +347,7 @@ export type DiffSummary = z.infer<typeof DiffSummarySchema>;
  * Matches RuleSpecDiff from backend Models
  */
 export const RuleSpecDiffSchema = z.object({
-  gameId: z.string().uuid(),
+  gameId: GameIdString,
   fromVersion: z.string(),
   toVersion: z.string(),
   fromCreatedAt: z.string().datetime({ offset: true }),
@@ -365,7 +367,7 @@ export type RuleSpecDiff = z.infer<typeof RuleSpecDiffSchema>;
  */
 export const QuickQuestionSchema = z.object({
   id: z.string().uuid(),
-  sharedGameId: z.string().uuid(),
+  sharedGameId: GameIdString,
   text: z.string().min(1).max(500),
   emoji: z.string(),
   category: z.number().int().min(0).max(5),
@@ -391,7 +393,7 @@ export type GetQuickQuestionsResult = z.infer<typeof GetQuickQuestionsResultSche
  * Collaborative editing lock information for conflict prevention
  */
 export const EditorLockSchema = z.object({
-  gameId: z.string().uuid(),
+  gameId: GameIdString,
   lockedByUserId: z.string().uuid().nullable(),
   lockedByUserEmail: z.string().nullable(),
   lockedAt: z.string().datetime({ offset: true }).nullable(),
@@ -443,7 +445,7 @@ export type RuleSpecWithETag = z.infer<typeof RuleSpecWithETagSchema>;
  * Game with similarity score and reason
  */
 export const SimilarGameDtoSchema = z.object({
-  id: z.string().uuid(),
+  id: GameIdString,
   title: z.string(),
   thumbnailUrl: z.string().nullable(),
   minPlayers: z.number().int().nullable(),
@@ -463,7 +465,7 @@ export type SimilarGameDto = z.infer<typeof SimilarGameDtoSchema>;
  */
 export const GetSimilarGamesResultSchema = z.object({
   games: z.array(SimilarGameDtoSchema),
-  sourceGameId: z.string().uuid(),
+  sourceGameId: GameIdString,
   sourceGameTitle: z.string(),
 });
 
@@ -473,7 +475,7 @@ export type GetSimilarGamesResult = z.infer<typeof GetSimilarGamesResultSchema>;
 
 export const GameStrategyDtoSchema = z.object({
   id: z.string().uuid(),
-  gameId: z.string().uuid(),
+  gameId: GameIdString,
   title: z.string(),
   content: z.string(),
   author: z.string(),
@@ -497,7 +499,7 @@ export type PagedStrategiesResult = z.infer<typeof PagedStrategiesResultSchema>;
 
 export const GameReviewDtoSchema = z.object({
   id: z.string().uuid(),
-  gameId: z.string().uuid(),
+  gameId: GameIdString,
   authorName: z.string(),
   rating: z.number().int().min(1).max(10),
   content: z.string(),

--- a/apps/web/src/lib/api/schemas/kb-chunks.schemas.ts
+++ b/apps/web/src/lib/api/schemas/kb-chunks.schemas.ts
@@ -20,6 +20,8 @@
 
 import { z } from 'zod';
 
+import { GameIdString } from './common.schemas';
+
 // ========== Wire vocabularies (PR #732 §6.3.1) ==========
 
 export const KbDocTypeSchema = z.enum(['rulebook', 'faq', 'errata', 'guide']);
@@ -34,7 +36,7 @@ export const KbDocDetailSchema = z.object({
   id: z.string().uuid(),
   title: z.string().min(1),
   docType: KbDocTypeSchema,
-  gameId: z.string().uuid().nullable(),
+  gameId: GameIdString.nullable(),
   gameName: z.string().nullable(),
   uploaderName: z.string().min(1),
   uploadedAt: z.string().datetime({ offset: true }),

--- a/apps/web/src/lib/api/schemas/kb-consuming-agents.schemas.ts
+++ b/apps/web/src/lib/api/schemas/kb-consuming-agents.schemas.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 
+import { GameIdString } from './common.schemas';
+
 /**
  * Mirrors backend `KbDocConsumingAgentDto`
  * (BoundedContexts/KnowledgeBase/Application/DTOs/KbDocConsumingAgentDto.cs).
@@ -13,7 +15,7 @@ export const KbDocConsumingAgentSchema = z.object({
   status: z.enum(['Draft', 'Testing', 'Published']),
   isSystemDefined: z.boolean(),
   typologySlug: z.string().nullable(),
-  gameId: z.string().uuid().nullable(),
+  gameId: GameIdString.nullable(),
   gameName: z.string().nullable(),
   invocationCount: z.number().int().nonnegative(),
   lastInvokedAt: z.string().datetime({ offset: true }).nullable(),

--- a/apps/web/src/lib/api/schemas/kb-docs.schemas.ts
+++ b/apps/web/src/lib/api/schemas/kb-docs.schemas.ts
@@ -11,6 +11,8 @@
 
 import { z } from 'zod';
 
+import { GameIdString } from './common.schemas';
+
 /**
  * The 8 raw enum values of `PdfProcessingState` projected as strings by BE-1.
  * @see apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/Enums/PdfProcessingState.cs
@@ -38,7 +40,7 @@ export type ProcessingState = z.infer<typeof ProcessingStateSchema>;
  */
 export const UserKbDocDtoSchema = z.object({
   id: z.string().uuid(),
-  gameId: z.string().uuid().nullable(),
+  gameId: GameIdString.nullable(),
   gameName: z.string().nullable(),
   fileName: z.string().min(1),
   processingState: ProcessingStateSchema,

--- a/apps/web/src/lib/api/schemas/kb-globale.schemas.ts
+++ b/apps/web/src/lib/api/schemas/kb-globale.schemas.ts
@@ -10,6 +10,8 @@
 
 import { z } from 'zod';
 
+import { GameIdString } from './common.schemas';
+
 /**
  * SearchMode enum for the search request.
  * Currently only "Semantic" is supported in v1.
@@ -28,7 +30,7 @@ export const GlobalKbSearchResultSchema = z.object({
   chunkId: z.string(),
   docId: z.string().uuid(),
   docTitle: z.string(),
-  gameId: z.string().uuid(),
+  gameId: GameIdString,
   gameName: z.string(),
   docType: z.string(),
   headingPath: z.string().nullable(),
@@ -52,7 +54,7 @@ export const GlobalKbSearchRequestSchema = z.object({
   cursor: z.string().nullable().optional(),
   mode: SearchModeSchema.optional(),
   docType: z.array(z.string()).optional(),
-  gameId: z.array(z.string().uuid()).optional(),
+  gameId: z.array(GameIdString).optional(),
   language: z.string().optional(),
 });
 

--- a/apps/web/src/lib/api/schemas/library-activity.schemas.ts
+++ b/apps/web/src/lib/api/schemas/library-activity.schemas.ts
@@ -10,11 +10,13 @@
 
 import { z } from 'zod';
 
+import { GameIdString } from './common.schemas';
+
 export const LibraryActivityItemSchema = z.object({
   id: z.string().uuid(),
   type: z.enum(['added', 'state-changed', 'removed', 'session-recorded']),
   timestamp: z.string().datetime({ offset: true }),
-  gameId: z.string().uuid(),
+  gameId: GameIdString,
   gameTitle: z.string(),
   message: z.string(),
 });

--- a/apps/web/src/lib/api/schemas/library.schemas.ts
+++ b/apps/web/src/lib/api/schemas/library.schemas.ts
@@ -11,6 +11,8 @@ import { z } from 'zod';
 
 import { logger } from '@/lib/logger';
 
+import { GameIdString } from './common.schemas';
+
 // Game state types for library filtering (Issue #2866)
 // Valid enum values - strict parsing
 const VALID_GAME_STATES = ['Nuovo', 'InPrestito', 'Wishlist', 'Owned'] as const;
@@ -32,7 +34,7 @@ export const GameStateTypeWithFallbackSchema = z.string().transform(val => {
 export const UserLibraryEntrySchema = z.object({
   id: z.string().uuid(),
   userId: z.string().uuid(),
-  gameId: z.string().uuid(),
+  gameId: GameIdString,
   gameTitle: z.string(),
   gamePublisher: z.string().nullable().optional(),
   gameYearPublished: z.number().nullable().optional(),
@@ -61,7 +63,7 @@ export const UserLibraryEntrySchema = z.object({
   timesPlayed: z.number().int().nonnegative().default(0),
   lastPlayed: z.string().datetime({ offset: true }).nullable().optional(),
   // Issue #3663: Private game distinction fields
-  privateGameId: z.string().uuid().nullable().optional(), // non-null when entry is a private/custom game
+  privateGameId: GameIdString.nullable().optional(), // non-null when entry is a private/custom game
   isPrivateGame: z.boolean().default(false), // computed flag from backend
   canProposeToCatalog: z.boolean().default(false), // whether private game can be proposed
 });
@@ -220,7 +222,7 @@ export type UpdateLibraryShareLinkRequest = z.infer<typeof UpdateLibraryShareLin
 
 // Shared library public view response
 export const SharedLibraryGameSchema = z.object({
-  gameId: z.string().uuid(),
+  gameId: GameIdString,
   title: z.string(),
   publisher: z.string().nullable(),
   yearPublished: z.number().nullable(),
@@ -287,7 +289,7 @@ export type LibraryCustomPdf = z.infer<typeof LibraryCustomPdfSchema>;
 export const GameDetailDtoSchema = z.object({
   id: z.string().uuid(),
   userId: z.string().uuid(),
-  gameId: z.string().uuid(),
+  gameId: GameIdString,
 
   // Game metadata
   gameTitle: z.string(),

--- a/apps/web/src/lib/api/schemas/live-sessions.schemas.ts
+++ b/apps/web/src/lib/api/schemas/live-sessions.schemas.ts
@@ -9,6 +9,8 @@
 
 import { z } from 'zod';
 
+import { GameIdString } from './common.schemas';
+
 // ========== Enums ==========
 
 export const LiveSessionStatusSchema = z.enum([
@@ -112,7 +114,7 @@ export type LiveSessionScoringConfigDto = z.infer<typeof LiveSessionScoringConfi
 export const LiveSessionDtoSchema = z.object({
   id: z.string().uuid(),
   sessionCode: z.string(),
-  gameId: z.string().uuid().nullable(),
+  gameId: GameIdString.nullable(),
   gameName: z.string(),
   gameSlug: z.string(),
   createdByUserId: z.string().uuid(),
@@ -249,7 +251,7 @@ export type TurnPhasesDto = z.infer<typeof TurnPhasesDtoSchema>;
 
 export const CreateLiveSessionRequestSchema = z.object({
   gameName: z.string().min(1).optional(),
-  gameId: z.string().uuid().optional(),
+  gameId: GameIdString.optional(),
   visibility: PlayRecordVisibilitySchema.optional(),
   groupId: z.string().uuid().optional(),
   scoringDimensions: z.array(z.string()).optional(),

--- a/apps/web/src/lib/api/schemas/mechanic-analyses.schemas.ts
+++ b/apps/web/src/lib/api/schemas/mechanic-analyses.schemas.ts
@@ -13,6 +13,8 @@
  */
 import { z } from 'zod';
 
+import { GameIdString } from './common.schemas';
+
 // ========== Enums ==========
 
 export const MechanicAnalysisStatus = {
@@ -187,7 +189,7 @@ export type MechanicSectionRunSummaryDto = z.infer<typeof MechanicSectionRunSumm
 
 export const MechanicAnalysisStatusDtoSchema = z.object({
   id: z.string().uuid(),
-  sharedGameId: z.string().uuid(),
+  sharedGameId: GameIdString,
   pdfDocumentId: z.string().uuid(),
   promptVersion: z.string(),
   status: MechanicAnalysisStatusSchema,
@@ -294,7 +296,7 @@ export const MechanicClaimsListSchema = z.array(MechanicClaimDtoSchema);
  */
 export const MechanicAnalysisListItemDtoSchema = z.object({
   id: z.string().uuid(),
-  sharedGameId: z.string().uuid(),
+  sharedGameId: GameIdString,
   gameTitle: z.string(),
   pdfDocumentId: z.string().uuid(),
   promptVersion: z.string(),

--- a/apps/web/src/lib/api/schemas/mechanic-card.schemas.ts
+++ b/apps/web/src/lib/api/schemas/mechanic-card.schemas.ts
@@ -16,6 +16,7 @@
  */
 import { z } from 'zod';
 
+import { GameIdString } from './common.schemas';
 import { MechanicSectionSchema } from './mechanic-analyses.schemas';
 
 // Re-export for convenience so card consumers can import both from one module.
@@ -65,7 +66,7 @@ export type PublishedMechanicSectionDto = z.infer<typeof PublishedMechanicSectio
 
 export const PublishedMechanicCardDtoSchema = z.object({
   cardId: z.string().uuid(),
-  sharedGameId: z.string().uuid(),
+  sharedGameId: GameIdString,
   title: z.string(),
   version: z.number().int(),
   publishedAt: z.string(),

--- a/apps/web/src/lib/api/schemas/migrations.schemas.ts
+++ b/apps/web/src/lib/api/schemas/migrations.schemas.ts
@@ -7,6 +7,8 @@
 
 import { z } from 'zod';
 
+import { GameIdString } from './common.schemas';
+
 // Migration action choices
 export const MigrationActionSchema = z.enum(['KeepPrivate', 'MigrateToShared']);
 export type MigrationAction = z.infer<typeof MigrationActionSchema>;
@@ -16,8 +18,8 @@ export const PendingMigrationDtoSchema = z.object({
   id: z.string().uuid(),
   userId: z.string().uuid(),
   shareRequestId: z.string().uuid(),
-  privateGameId: z.string().uuid(),
-  sharedGameId: z.string().uuid(),
+  privateGameId: GameIdString,
+  sharedGameId: GameIdString,
   gameTitle: z.string(),
   approvedAt: z.string().datetime({ offset: true }),
   expiresAt: z.string().datetime({ offset: true }),

--- a/apps/web/src/lib/api/schemas/pdf.schemas.ts
+++ b/apps/web/src/lib/api/schemas/pdf.schemas.ts
@@ -7,11 +7,13 @@
 
 import { z } from 'zod';
 
+import { GameIdString } from './common.schemas';
+
 // ========== PDF Document ==========
 
 export const PdfDocumentDtoSchema = z.object({
   id: z.string().uuid(),
-  gameId: z.string().uuid(),
+  gameId: GameIdString,
   fileName: z.string().min(1),
   filePath: z.string().min(1),
   fileSizeBytes: z.number().int().nonnegative(),

--- a/apps/web/src/lib/api/schemas/play-records.schemas.ts
+++ b/apps/web/src/lib/api/schemas/play-records.schemas.ts
@@ -9,6 +9,8 @@
 
 import { z } from 'zod';
 
+import { GameIdString } from './common.schemas';
+
 // ========== Enums ==========
 
 export const PlayRecordStatusSchema = z.enum(['Planned', 'InProgress', 'Completed', 'Archived']);
@@ -87,7 +89,7 @@ export type ShareLinkResponse = z.infer<typeof ShareLinkResponseSchema>;
 
 export const PlayRecordDtoSchema = z.object({
   id: z.string().uuid(),
-  gameId: z.string().uuid().nullable(),
+  gameId: GameIdString.nullable(),
   gameName: z.string(),
   sessionDate: z.string(),
   duration: z.string().nullable(), // .NET TimeSpan (e.g., "02:30:00") or ISO 8601 (e.g., "PT2H30M")
@@ -124,7 +126,7 @@ export const PlayRecordSummarySchema = z.object({
   playerCount: z.number().int().nonnegative(),
   // #1663 Phase 1: enable cover/deep-link + outcome badge in the list view.
   // Optional during BE rollout; tighten once the BE ships the fields.
-  gameId: z.string().uuid().nullable().optional(),
+  gameId: GameIdString.nullable().optional(),
   winnerPlayerIds: z.array(z.string().uuid()).optional(),
   outcomeType: PlayRecordOutcomeTypeSchema.optional(),
 });
@@ -132,7 +134,7 @@ export type PlayRecordSummary = z.infer<typeof PlayRecordSummarySchema>;
 
 // #1663 Phase 2: per-game win/play stats keyed by gameId (gameName fallback).
 export const GameWinStatsSchema = z.object({
-  gameId: z.string().uuid().nullable(),
+  gameId: GameIdString.nullable(),
   gameName: z.string(),
   played: z.number().int().nonnegative(),
   won: z.number().int().nonnegative(),
@@ -140,7 +142,7 @@ export const GameWinStatsSchema = z.object({
 export type GameWinStats = z.infer<typeof GameWinStatsSchema>;
 
 export const GamePlayCountSchema = z.object({
-  gameId: z.string().uuid().nullable(),
+  gameId: GameIdString.nullable(),
   gameName: z.string(),
   plays: z.number().int().nonnegative(),
 });
@@ -175,7 +177,7 @@ export type PlayerStatistics = z.infer<typeof PlayerStatisticsSchema>;
 // ========== Request DTOs ==========
 
 export const CreatePlayRecordRequestSchema = z.object({
-  gameId: z.string().uuid().optional(),
+  gameId: GameIdString.optional(),
   gameName: z.string().min(1).max(255),
   sessionDate: z.string(),
   visibility: PlayRecordVisibilitySchema,
@@ -223,7 +225,7 @@ export type PlayHistoryResponse = z.infer<typeof PlayHistoryResponseSchema>;
 
 export const SessionCreateFormSchema = z.object({
   gameType: z.enum(['catalog', 'freeform']),
-  gameId: z.string().uuid().optional(),
+  gameId: GameIdString.optional(),
   // Allow empty string during multi-step navigation; per-step validation enforces non-empty.
   gameName: z.string().max(255),
   sessionDate: z.date(),

--- a/apps/web/src/lib/api/schemas/playlists.schemas.ts
+++ b/apps/web/src/lib/api/schemas/playlists.schemas.ts
@@ -5,8 +5,10 @@
 
 import { z } from 'zod';
 
+import { GameIdString } from './common.schemas';
+
 export const PlaylistGameDtoSchema = z.object({
-  sharedGameId: z.string().uuid(),
+  sharedGameId: GameIdString,
   position: z.number(),
   addedAt: z.string(),
 });
@@ -47,13 +49,13 @@ export const UpdatePlaylistRequestSchema = z.object({
 export type UpdatePlaylistRequest = z.infer<typeof UpdatePlaylistRequestSchema>;
 
 export const AddGameToPlaylistRequestSchema = z.object({
-  sharedGameId: z.string().uuid(),
+  sharedGameId: GameIdString,
   position: z.number(),
 });
 export type AddGameToPlaylistRequest = z.infer<typeof AddGameToPlaylistRequestSchema>;
 
 export const ReorderPlaylistGamesRequestSchema = z.object({
-  orderedGameIds: z.array(z.string().uuid()),
+  orderedGameIds: z.array(GameIdString),
 });
 export type ReorderPlaylistGamesRequest = z.infer<typeof ReorderPlaylistGamesRequestSchema>;
 

--- a/apps/web/src/lib/api/schemas/private-games.schemas.ts
+++ b/apps/web/src/lib/api/schemas/private-games.schemas.ts
@@ -7,13 +7,15 @@
 
 import { z } from 'zod';
 
+import { GameIdString } from './common.schemas';
+
 // Private game source enum
 export const PrivateGameSourceSchema = z.enum(['Manual', 'BoardGameGeek']);
 export type PrivateGameSource = z.infer<typeof PrivateGameSourceSchema>;
 
 // Private game DTO from backend
 export const PrivateGameDtoSchema = z.object({
-  id: z.string().uuid(),
+  id: GameIdString,
   ownerId: z.string().uuid(),
   source: PrivateGameSourceSchema,
   bggId: z.number().int().positive().nullable().optional(),

--- a/apps/web/src/lib/api/schemas/session-statistics.schemas.ts
+++ b/apps/web/src/lib/api/schemas/session-statistics.schemas.ts
@@ -1,7 +1,9 @@
 import { z } from 'zod';
 
+import { GameIdString } from './common.schemas';
+
 export const GamePlayFrequencySchema = z.object({
-  gameId: z.string().uuid(),
+  gameId: GameIdString,
   gameName: z.string(),
   playCount: z.number(),
 });
@@ -27,7 +29,7 @@ export const SessionStatisticsSchema = z.object({
 });
 
 export const GameStatisticsSchema = z.object({
-  gameId: z.string().uuid(),
+  gameId: GameIdString,
   gameName: z.string(),
   totalPlays: z.number(),
   wins: z.number(),

--- a/apps/web/src/lib/api/schemas/session-tracking.schemas.ts
+++ b/apps/web/src/lib/api/schemas/session-tracking.schemas.ts
@@ -9,6 +9,8 @@
 
 import { z } from 'zod';
 
+import { GameIdString } from './common.schemas';
+
 // ========== Core Session DTOs ==========
 
 export const ParticipantDtoSchema = z.object({
@@ -49,7 +51,7 @@ export type PlayerNoteDto = z.infer<typeof PlayerNoteDtoSchema>;
 export const SessionDtoSchema = z.object({
   id: z.string().uuid(),
   userId: z.string().uuid(),
-  gameId: z.string().uuid().nullable(),
+  gameId: GameIdString.nullable(),
   sessionCode: z.string(),
   sessionType: z.string(),
   status: z.string(),
@@ -217,7 +219,7 @@ export type ShareableSessionDto = z.infer<typeof ShareableSessionDtoSchema>;
 // ========== Request DTOs ==========
 
 export const CreateSessionCommandSchema = z.object({
-  gameId: z.string().uuid().optional(),
+  gameId: GameIdString.optional(),
   gameName: z.string().optional(),
   sessionType: z.string().optional().default('Standard'),
   location: z.string().optional(),

--- a/apps/web/src/lib/api/schemas/share-links.schemas.ts
+++ b/apps/web/src/lib/api/schemas/share-links.schemas.ts
@@ -7,6 +7,8 @@
 
 import { z } from 'zod';
 
+import { GameIdString } from './common.schemas';
+
 // ========== Chat Message DTO for Shared Threads ==========
 
 /**
@@ -61,7 +63,7 @@ export const GetSharedThreadResponseSchema = z.object({
   title: z.string().nullable(),
   messages: z.array(ChatMessageDtoSchema),
   role: z.enum(['view', 'comment']),
-  gameId: z.string().uuid().nullable(),
+  gameId: GameIdString.nullable(),
   createdAt: z.string().datetime({ offset: true }),
   lastMessageAt: z.string().datetime({ offset: true }).nullable(),
 });

--- a/apps/web/src/lib/api/schemas/share-requests.schemas.ts
+++ b/apps/web/src/lib/api/schemas/share-requests.schemas.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 
+import { GameIdString } from './common.schemas';
+
 /**
  * Share Request API Schemas
  * Issue #2743: Frontend - UI Condivisione da Libreria
@@ -37,7 +39,7 @@ export type RateLimitStatusDto = z.infer<typeof RateLimitStatusDtoSchema>;
 // User Share Request DTO
 export const UserShareRequestDtoSchema = z.object({
   id: z.string().uuid(),
-  sourceGameId: z.string().uuid(),
+  sourceGameId: GameIdString,
   gameTitle: z.string(),
   gameThumbnailUrl: z.string().nullable(),
   status: ShareRequestStatusSchema,
@@ -47,14 +49,14 @@ export const UserShareRequestDtoSchema = z.object({
   attachedDocumentCount: z.number().int().nonnegative(),
   createdAt: z.string().datetime({ offset: true }),
   resolvedAt: z.string().datetime({ offset: true }).nullable(),
-  resultingSharedGameId: z.string().uuid().nullable(),
+  resultingSharedGameId: GameIdString.nullable(),
 });
 
 export type UserShareRequestDto = z.infer<typeof UserShareRequestDtoSchema>;
 
 // Create Share Request Command (Request)
 export const CreateShareRequestCommandSchema = z.object({
-  sourceGameId: z.string().uuid(),
+  sourceGameId: GameIdString,
   notes: z.string().max(2000).nullable().optional(),
   attachedDocumentIds: z.array(z.string().uuid()).optional().default([]),
 });

--- a/apps/web/src/lib/api/schemas/shared-games.schemas.ts
+++ b/apps/web/src/lib/api/schemas/shared-games.schemas.ts
@@ -7,6 +7,7 @@
 
 import { z } from 'zod';
 
+import { GameIdString } from './common.schemas';
 // Import and re-export BGG types from games.schemas for convenience
 import {
   BggGameDetailsSchema,
@@ -126,7 +127,7 @@ export type GameErrata = z.infer<typeof GameErrataSchema>;
  */
 export const SharedGameDocumentSchema = z.object({
   id: z.string().uuid(),
-  sharedGameId: z.string().uuid(),
+  sharedGameId: GameIdString,
   pdfDocumentId: z.string().uuid(),
   documentType: SharedGameDocumentTypeNumericSchema,
   version: z.string().regex(/^\d+\.\d+$/),
@@ -195,7 +196,7 @@ export type SharedGameTranslationDto = z.infer<typeof SharedGameTranslationDtoSc
  * Shared game basic DTO (list view)
  */
 export const SharedGameSchema = z.object({
-  id: z.string().uuid(),
+  id: GameIdString,
   bggId: z.number().int().nullable(), // 0 is valid (no BGG match)
   title: z.string().min(1),
   yearPublished: z.number().int(),
@@ -303,7 +304,7 @@ export type PublishedKbPreview = z.infer<typeof PublishedKbPreviewSchema>;
  * Issue #2373 Phase 4: Extended with FAQs, Errata, Designers, Publishers, Categories, Mechanics
  */
 export const SharedGameDetailSchema = z.object({
-  id: z.string().uuid(),
+  id: GameIdString,
   bggId: z.number().int().nullable(), // 0 is valid (no BGG match)
   title: z.string().min(1),
   yearPublished: z.number().int(),
@@ -388,7 +389,7 @@ export type PagedSharedGames = z.infer<typeof PagedSharedGamesSchema>;
  */
 export const DeleteRequestSchema = z.object({
   id: z.string().uuid(),
-  sharedGameId: z.string().uuid(),
+  sharedGameId: GameIdString,
   gameTitle: z.string(),
   requestedBy: z.string().uuid(),
   reason: z.string(),
@@ -642,7 +643,7 @@ export const BulkImportResultSchema = z.object({
   successCount: z.number().int().nonnegative(),
   failureCount: z.number().int().nonnegative(),
   errors: z.array(z.string()),
-  importedGameIds: z.array(z.string().uuid()),
+  importedGameIds: z.array(GameIdString),
 });
 
 export type BulkImportResult = z.infer<typeof BulkImportResultSchema>;
@@ -671,7 +672,7 @@ export type BatchApprovalResult = z.infer<typeof BatchApprovalResultSchema>;
  */
 export const BggDuplicateCheckResultSchema = z.object({
   isDuplicate: z.boolean(),
-  existingGameId: z.string().uuid().nullable(),
+  existingGameId: GameIdString.nullable(),
   existingGame: SharedGameDetailSchema.nullable(),
   bggData: BggGameDetailsSchema.nullable(),
 });
@@ -776,7 +777,7 @@ export type GeneratedFaqDto = z.infer<typeof GeneratedFaqDtoSchema>;
  */
 export const RulebookAnalysisDtoSchema = z.object({
   id: z.string().uuid(),
-  sharedGameId: z.string().uuid(),
+  sharedGameId: GameIdString,
   pdfDocumentId: z.string().uuid(),
   gameTitle: z.string(),
   summary: z.string(),

--- a/apps/web/src/lib/api/schemas/toolbox.schemas.ts
+++ b/apps/web/src/lib/api/schemas/toolbox.schemas.ts
@@ -7,6 +7,8 @@
 
 import { z } from 'zod';
 
+import { GameIdString } from './common.schemas';
+
 // ============================================================================
 // Value Objects
 // ============================================================================
@@ -63,7 +65,7 @@ export type PhaseDto = z.infer<typeof PhaseSchema>;
 export const ToolboxSchema = z.object({
   id: z.string().uuid(),
   name: z.string(),
-  gameId: z.string().uuid().nullable(),
+  gameId: GameIdString.nullable(),
   mode: z.enum(['Freeform', 'Phased']),
   sharedContext: SharedContextSchema,
   currentPhaseId: z.string().uuid().nullable(),
@@ -103,7 +105,7 @@ export type CardDrawResultDto = z.infer<typeof CardDrawResultSchema>;
 export const ToolboxTemplateSchema = z.object({
   id: z.string().uuid(),
   name: z.string(),
-  gameId: z.string().uuid().nullable(),
+  gameId: GameIdString.nullable(),
   mode: z.string(),
   source: z.string(),
   toolsJson: z.string(),

--- a/apps/web/src/lib/api/schemas/toolkit.schemas.ts
+++ b/apps/web/src/lib/api/schemas/toolkit.schemas.ts
@@ -7,6 +7,8 @@
 
 import { z } from 'zod';
 
+import { GameIdString } from './common.schemas';
+
 // ============================================================================
 // Widget type enum
 // ============================================================================
@@ -38,7 +40,7 @@ export type ToolkitWidgetDto = z.infer<typeof ToolkitWidgetDtoSchema>;
 
 export const ToolkitDashboardDtoSchema = z.object({
   id: z.string().uuid(),
-  gameId: z.string().uuid(),
+  gameId: GameIdString,
   ownerUserId: z.string().uuid().nullable(),
   isDefault: z.boolean(),
   displayName: z.string().nullable(),
@@ -204,8 +206,8 @@ export type TemplateStatus = z.infer<typeof TemplateStatusSchema>;
 
 export const GameToolkitTemplateDtoSchema = z.object({
   id: z.string().uuid(),
-  gameId: z.string().uuid().nullable(),
-  privateGameId: z.string().uuid().nullable(),
+  gameId: GameIdString.nullable(),
+  privateGameId: GameIdString.nullable(),
   name: z.string(),
   version: z.number(),
   createdByUserId: z.string().uuid(),

--- a/apps/web/src/lib/api/schemas/wishlist.schemas.ts
+++ b/apps/web/src/lib/api/schemas/wishlist.schemas.ts
@@ -4,10 +4,12 @@
 
 import { z } from 'zod';
 
+import { GameIdString } from './common.schemas';
+
 export const WishlistItemDtoSchema = z.object({
   id: z.string().uuid(),
   userId: z.string().uuid(),
-  gameId: z.string().uuid(),
+  gameId: GameIdString,
   gameName: z.string().optional(),
   priority: z.string(),
   targetPrice: z.number().nullable(),
@@ -19,7 +21,7 @@ export const WishlistItemDtoSchema = z.object({
 export type WishlistItemDto = z.infer<typeof WishlistItemDtoSchema>;
 
 export const AddToWishlistRequestSchema = z.object({
-  gameId: z.string().uuid(),
+  gameId: GameIdString,
   priority: z.string(),
   targetPrice: z.number().nullable().optional(),
   notes: z.string().nullable().optional(),


### PR DESCRIPTION
## Cosa

Risolve gli errori di validazione Zod su `/discover` (sezioni "Giochi nuovi" e "KB recenti" vuote): i 3 endpoint `/api/v1/games`, `/api/v1/catalog/games/new`, `/api/v1/kb-docs/recent` restituivano HTTP 200 ma il body veniva rifiutato dalla validazione.

## Root cause

Gli id dei **giochi** nei dati (seed deterministici / righe legacy) non sono UUID-RFC-4122: il version-nibble cade fuori dal range 1-5 (es. `81cc97e4-f148-`**`f`**`b7b-db36-bf700d1f4561`). Gli schemi usavano `z.string().uuid()` (strict RFC-4122), che rifiuta questi id → `SchemaValidationError` → rail del discover vuote.

In produzione gli id sono `Guid.NewGuid()` (v4, validi), quindi il problema è specifico dei dati seed/legacy — ma la validazione FE deve accettare i dati reali del backend (stesso pattern già adottato in #2247 per `bggId`/`imageUrl` che rompevano `/library`).

## Fix

- Nuovo helper condiviso `apps/web/src/lib/api/schemas/common.schemas.ts`: `export const GameIdString = z.string().min(1)`.
- Applicato a **99 campi** id/gameId di **entità gioco** su 34 file di schema (`gameId`, `sharedGameId`, e `id` degli schemi che rappresentano un gioco: `GameSchema`, `NewGameSchema`, `SimilarGameDtoSchema`, `SharedGameSchema`, ecc.).
- Gli id di **altre entità** (session, user, agent, document, faq, …) restano `z.string().uuid()` strict — sono sempre `Guid.NewGuid()` validi.

## Verifica

- **Unit test**: 185 verdi su `src/lib/api/schemas` (incluso il nuovo `game-id-string.test.ts` — 4 test: `GameSchema`/`NewGameSchema`/`RecentKbDocSchema` accettano id non-RFC; regressione: uno schema non-gioco continua a rifiutare id malformati).
- **Typecheck + lint**: puliti.
- **Verifica visiva (production build)**: `/discover` carica con dati reali — "Giochi nuovi" (Nanolith, Santorini, Sagrada, RONE: Invasion…) e "KB recenti" (villainous_rulebook 47 chunks, townsfolk-tussle 114 chunks…) popolati, **zero errori Zod in console**.

> Nota: nel dev server Turbopack (Next 16) la validazione può ancora mostrare l'errore per un artefatto di module-resolution/caching (non risolto da restart/`rm .next`/tab nuova); è indipendente da questo fix, confermato dai test verdi e dal production build pulito.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
