### PR TITLE
fix(notifications): scope Slack queue health check to Slack channels

### DIFF
--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Domain/Repositories/INotificationQueueRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Domain/Repositories/INotificationQueueRepository.cs
@@ -11,6 +11,14 @@ internal interface INotificationQueueRepository
     Task<IReadOnlyList<NotificationQueueItem>> GetPendingByChannelAsync(
         NotificationChannelType channelType, int batchSize, CancellationToken ct = default);
     Task<int> GetPendingCountAsync(CancellationToken ct = default);
+    /// <summary>
+    /// Counts pending (or retry-due failed) queue items limited to the given channels.
+    /// Uses the same "pending" predicate as <see cref="GetPendingCountAsync"/> but scoped
+    /// to a set of channels, so per-channel health checks are not tripped by an unrelated
+    /// backlog on another channel (e.g. an email backlog must not fail the Slack check).
+    /// </summary>
+    Task<int> GetPendingCountByChannelsAsync(
+        IReadOnlyCollection<NotificationChannelType> channels, CancellationToken ct = default);
     Task<int> GetDeadLetterCountAsync(CancellationToken ct = default);
     Task<IReadOnlyList<NotificationQueueItem>> GetDeadLetterItemsAsync(
         int batchSize, CancellationToken ct = default);

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/HealthChecks/SlackQueueHealthCheck.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/HealthChecks/SlackQueueHealthCheck.cs
@@ -1,4 +1,5 @@
 using Api.BoundedContexts.UserNotifications.Domain.Repositories;
+using Api.BoundedContexts.UserNotifications.Domain.ValueObjects;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 namespace Api.BoundedContexts.UserNotifications.Infrastructure.HealthChecks;
@@ -31,7 +32,13 @@ internal class SlackQueueHealthCheck : IHealthCheck
         {
             using var scope = _scopeFactory.CreateScope();
             var repository = scope.ServiceProvider.GetRequiredService<INotificationQueueRepository>();
-            var pendingCount = await repository.GetPendingCountAsync(cancellationToken).ConfigureAwait(false);
+
+            // Scope the backlog count to the Slack channels only: an unrelated backlog on
+            // another channel (e.g. email) must not trip this Slack-specific health check
+            // and mis-attribute an aggregate /health 503 to Slack.
+            var pendingCount = await repository.GetPendingCountByChannelsAsync(
+                new[] { NotificationChannelType.SlackUser, NotificationChannelType.SlackTeam },
+                cancellationToken).ConfigureAwait(false);
 
             var data = new Dictionary<string, object>(StringComparer.Ordinal)
             {

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Persistence/NotificationQueueRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Persistence/NotificationQueueRepository.cs
@@ -92,6 +92,21 @@ internal class NotificationQueueRepository : RepositoryBase, INotificationQueueR
                 ct).ConfigureAwait(false);
     }
 
+    public async Task<int> GetPendingCountByChannelsAsync(
+        IReadOnlyCollection<NotificationChannelType> channels, CancellationToken ct = default)
+    {
+        var now = DateTime.UtcNow;
+        var channelValues = channels.Select(c => c.Value).ToArray();
+
+        return await DbContext.Set<NotificationQueueEntity>()
+            .AsNoTracking()
+            .CountAsync(e =>
+                channelValues.Contains(e.ChannelType) &&
+                ((e.Status == "pending") ||
+                 (e.Status == "failed" && e.NextRetryAt != null && e.NextRetryAt <= now)),
+                ct).ConfigureAwait(false);
+    }
+
     public async Task<int> GetDeadLetterCountAsync(CancellationToken ct = default)
     {
         return await DbContext.Set<NotificationQueueEntity>()

--- a/apps/api/tests/Api.Tests/BoundedContexts/UserNotifications/Infrastructure/HealthChecks/SlackQueueHealthCheckTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/UserNotifications/Infrastructure/HealthChecks/SlackQueueHealthCheckTests.cs
@@ -1,4 +1,5 @@
 using Api.BoundedContexts.UserNotifications.Domain.Repositories;
+using Api.BoundedContexts.UserNotifications.Domain.ValueObjects;
 using Api.BoundedContexts.UserNotifications.Infrastructure.HealthChecks;
 using Api.Tests.Constants;
 using Microsoft.Extensions.DependencyInjection;
@@ -36,12 +37,21 @@ public class SlackQueueHealthCheckTests
         _healthCheck = new SlackQueueHealthCheck(scopeFactory.Object, _loggerMock.Object);
     }
 
+    /// <summary>
+    /// Sets up the channel-scoped pending count that the (fixed) health check must consume.
+    /// </summary>
+    private void SetupSlackPendingCount(int count)
+    {
+        _repositoryMock.Setup(r => r.GetPendingCountByChannelsAsync(
+                It.IsAny<IReadOnlyCollection<NotificationChannelType>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(count);
+    }
+
     [Fact]
     public async Task CheckHealthAsync_PendingBelowThreshold_ReturnsHealthy()
     {
         // Arrange
-        _repositoryMock.Setup(r => r.GetPendingCountAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(50);
+        SetupSlackPendingCount(50);
 
         // Act
         var result = await _healthCheck.CheckHealthAsync(
@@ -56,8 +66,7 @@ public class SlackQueueHealthCheckTests
     public async Task CheckHealthAsync_PendingAboveThreshold_ReturnsUnhealthy()
     {
         // Arrange
-        _repositoryMock.Setup(r => r.GetPendingCountAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(150);
+        SetupSlackPendingCount(150);
 
         // Act
         var result = await _healthCheck.CheckHealthAsync(
@@ -73,8 +82,7 @@ public class SlackQueueHealthCheckTests
     public async Task CheckHealthAsync_ExactlyAtThreshold_ReturnsHealthy()
     {
         // Arrange
-        _repositoryMock.Setup(r => r.GetPendingCountAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(100);
+        SetupSlackPendingCount(100);
 
         // Act
         var result = await _healthCheck.CheckHealthAsync(
@@ -88,7 +96,8 @@ public class SlackQueueHealthCheckTests
     public async Task CheckHealthAsync_RepositoryThrows_ReturnsUnhealthy()
     {
         // Arrange
-        _repositoryMock.Setup(r => r.GetPendingCountAsync(It.IsAny<CancellationToken>()))
+        _repositoryMock.Setup(r => r.GetPendingCountByChannelsAsync(
+                It.IsAny<IReadOnlyCollection<NotificationChannelType>>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("DB connection failed"));
 
         // Act
@@ -104,8 +113,7 @@ public class SlackQueueHealthCheckTests
     public async Task CheckHealthAsync_ZeroPending_ReturnsHealthy()
     {
         // Arrange
-        _repositoryMock.Setup(r => r.GetPendingCountAsync(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(0);
+        SetupSlackPendingCount(0);
 
         // Act
         var result = await _healthCheck.CheckHealthAsync(
@@ -114,5 +122,52 @@ public class SlackQueueHealthCheckTests
         // Assert
         result.Status.Should().Be(HealthStatus.Healthy);
         result.Description!.Should().Contain("0");
+    }
+
+    /// <summary>
+    /// Regression for the mis-attributed 503 on staging: a large backlog on a NON-Slack
+    /// channel (310 pending email items) must NOT trip the Slack queue health check.
+    /// The check must count only Slack-channel pending items — here zero — and report Healthy.
+    /// Before the fix the check called the unfiltered <c>GetPendingCountAsync</c> and returned
+    /// Unhealthy (the aggregate /health then returned 503, blamed on Slack).
+    /// </summary>
+    [Fact]
+    public async Task CheckHealthAsync_OtherChannelBacklog_IgnoresNonSlackAndReturnsHealthy()
+    {
+        // Arrange — 310 pending items exist overall (the staging email backlog) but ZERO
+        // belong to a Slack channel.
+        _repositoryMock.Setup(r => r.GetPendingCountAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(310);
+        SetupSlackPendingCount(0);
+
+        // Act
+        var result = await _healthCheck.CheckHealthAsync(
+            new HealthCheckContext(), CancellationToken.None);
+
+        // Assert — the Slack check ignores the email backlog and stays Healthy
+        result.Status.Should().Be(HealthStatus.Healthy);
+    }
+
+    /// <summary>
+    /// The health check must query the channel-scoped count restricted to the two Slack
+    /// channels (slack_user + slack_team), never the unfiltered all-channel count.
+    /// </summary>
+    [Fact]
+    public async Task CheckHealthAsync_QueriesOnlySlackChannels()
+    {
+        // Arrange
+        SetupSlackPendingCount(5);
+
+        // Act
+        await _healthCheck.CheckHealthAsync(new HealthCheckContext(), CancellationToken.None);
+
+        // Assert — the Slack channels (and only those) were passed to the filtered query
+        _repositoryMock.Verify(r => r.GetPendingCountByChannelsAsync(
+            It.Is<IReadOnlyCollection<NotificationChannelType>>(c =>
+                c.Contains(NotificationChannelType.SlackUser)
+                && c.Contains(NotificationChannelType.SlackTeam)
+                && !c.Contains(NotificationChannelType.Email)),
+            It.IsAny<CancellationToken>()), Times.Once);
+        _repositoryMock.Verify(r => r.GetPendingCountAsync(It.IsAny<CancellationToken>()), Times.Never);
     }
 }

--- a/apps/api/tests/Api.Tests/Integration/UserNotifications/NotificationQueueRepositoryGetPendingCountByChannelsIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/UserNotifications/NotificationQueueRepositoryGetPendingCountByChannelsIntegrationTests.cs
@@ -1,0 +1,185 @@
+using Api.BoundedContexts.UserNotifications.Domain.Repositories;
+using Api.BoundedContexts.UserNotifications.Domain.ValueObjects;
+using Api.BoundedContexts.UserNotifications.Infrastructure.Persistence;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.UserNotifications;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Npgsql;
+using Xunit;
+
+namespace Api.Tests.Integration.UserNotifications;
+
+/// <summary>
+/// Integration tests for <see cref="NotificationQueueRepository.GetPendingCountByChannelsAsync"/>
+/// against a real Testcontainers PostgreSQL instance.
+///
+/// Guards the fix for the mis-attributed <c>/health</c> 503: the Slack queue health check must
+/// count pending items scoped to the Slack channels only, so an unrelated backlog on another
+/// channel (e.g. 310 pending email items on staging) does not trip the Slack check. The
+/// unfiltered <see cref="NotificationQueueRepository.GetPendingCountAsync"/> is asserted alongside
+/// to make the channel-leak contrast explicit.
+/// </summary>
+[Collection("Integration-GroupD")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("Dependency", "PostgreSQL")]
+[Trait("BoundedContext", "UserNotifications")]
+public sealed class NotificationQueueRepositoryGetPendingCountByChannelsIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private string _databaseName = string.Empty;
+    private MeepleAiDbContext? _dbContext;
+    private INotificationQueueRepository? _repository;
+    private IServiceProvider? _serviceProvider;
+
+    private static CancellationToken TestCancellationToken => TestContext.Current.CancellationToken;
+
+    public NotificationQueueRepositoryGetPendingCountByChannelsIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        _databaseName = $"test_notifqueuepending_{Guid.NewGuid():N}";
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+
+        var services = IntegrationServiceCollectionBuilder.CreateBase(connectionString);
+        services.AddScoped<INotificationQueueRepository, NotificationQueueRepository>();
+
+        _serviceProvider = services.BuildServiceProvider();
+        _dbContext = _serviceProvider.GetRequiredService<MeepleAiDbContext>();
+        _repository = _serviceProvider.GetRequiredService<INotificationQueueRepository>();
+
+        for (var attempt = 0; attempt < 3; attempt++)
+        {
+            try
+            {
+                await _dbContext.Database.MigrateAsync(TestCancellationToken);
+                break;
+            }
+            catch (NpgsqlException) when (attempt < 2)
+            {
+                await Task.Delay(TestConstants.Timing.RetryDelay, TestCancellationToken);
+            }
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _dbContext?.Dispose();
+        if (!string.IsNullOrEmpty(_databaseName))
+        {
+            try
+            {
+                await _fixture.DropIsolatedDatabaseAsync(_databaseName);
+            }
+            catch (NpgsqlException)
+            {
+                // Best-effort cleanup.
+            }
+        }
+    }
+
+    [Fact]
+    public async Task GetPendingCountByChannelsAsync_SlackChannels_CountsOnlySlackPending_ExcludingOtherChannels()
+    {
+        // Arrange — a mixed queue mirroring the staging incident: a large email backlog
+        // plus a handful of genuine Slack items and some non-eligible rows.
+        var pastRetry = DateTime.UtcNow.AddMinutes(-5);   // failed + retry-due  → counts as pending
+        var futureRetry = DateTime.UtcNow.AddMinutes(30); // failed + not yet due → excluded
+
+        await SeedAsync(
+            // email — must be excluded from the Slack-scoped count
+            NewItem(NotificationChannelType.Email, status: "pending"),
+            NewItem(NotificationChannelType.Email, status: "pending"),
+            NewItem(NotificationChannelType.Email, status: "pending"),
+            NewItem(NotificationChannelType.Email, status: "failed", nextRetryAt: pastRetry),
+            // slack_user — included
+            NewItem(NotificationChannelType.SlackUser, status: "pending"),
+            NewItem(NotificationChannelType.SlackUser, status: "pending"),
+            NewItem(NotificationChannelType.SlackUser, status: "failed", nextRetryAt: pastRetry),
+            NewItem(NotificationChannelType.SlackUser, status: "failed", nextRetryAt: futureRetry), // excluded: not due
+            // slack_team — included
+            NewItem(NotificationChannelType.SlackTeam, status: "pending"),
+            NewItem(NotificationChannelType.SlackTeam, status: "sent")); // excluded: not pending
+
+        // Act
+        var slackPending = await _repository!.GetPendingCountByChannelsAsync(
+            new[] { NotificationChannelType.SlackUser, NotificationChannelType.SlackTeam },
+            TestCancellationToken);
+        var allChannelsPending = await _repository!.GetPendingCountAsync(TestCancellationToken);
+
+        // Assert — Slack-scoped count = 2 su pending + 1 su failed-due + 1 st pending = 4,
+        // and it excludes the email backlog that the unfiltered count still sees (4 email eligible).
+        slackPending.Should().Be(4, "only slack_user + slack_team pending/retry-due rows count");
+        allChannelsPending.Should().Be(8, "unfiltered count also includes the 4 eligible email rows");
+        slackPending.Should().BeLessThan(allChannelsPending,
+            "the email backlog must not be attributed to the Slack channels");
+    }
+
+    [Fact]
+    public async Task GetPendingCountByChannelsAsync_SingleChannel_ScopesToThatChannelOnly()
+    {
+        // Arrange
+        await SeedAsync(
+            NewItem(NotificationChannelType.Email, status: "pending"),
+            NewItem(NotificationChannelType.SlackUser, status: "pending"),
+            NewItem(NotificationChannelType.SlackUser, status: "pending"),
+            NewItem(NotificationChannelType.SlackTeam, status: "pending"));
+
+        // Act
+        var slackTeamOnly = await _repository!.GetPendingCountByChannelsAsync(
+            new[] { NotificationChannelType.SlackTeam }, TestCancellationToken);
+
+        // Assert
+        slackTeamOnly.Should().Be(1, "only the single slack_team pending row matches");
+    }
+
+    [Fact]
+    public async Task GetPendingCountByChannelsAsync_NoSlackBacklog_ReturnsZeroDespiteEmailBacklog()
+    {
+        // Arrange — the exact staging shape: backlog exists, but none of it is Slack.
+        await SeedAsync(
+            NewItem(NotificationChannelType.Email, status: "pending"),
+            NewItem(NotificationChannelType.Email, status: "pending"),
+            NewItem(NotificationChannelType.Email, status: "pending"));
+
+        // Act
+        var slackPending = await _repository!.GetPendingCountByChannelsAsync(
+            new[] { NotificationChannelType.SlackUser, NotificationChannelType.SlackTeam },
+            TestCancellationToken);
+
+        // Assert
+        slackPending.Should().Be(0, "an email-only backlog leaves the Slack-scoped count at zero");
+    }
+
+    private async Task SeedAsync(params NotificationQueueEntity[] items)
+    {
+        await _dbContext!.Set<NotificationQueueEntity>().AddRangeAsync(items, TestCancellationToken);
+        await _dbContext.SaveChangesAsync(TestCancellationToken);
+    }
+
+    private static NotificationQueueEntity NewItem(
+        NotificationChannelType channel, string status, DateTime? nextRetryAt = null)
+    {
+        return new NotificationQueueEntity
+        {
+            Id = Guid.NewGuid(),
+            ChannelType = channel.Value,
+            RecipientUserId = null,
+            NotificationType = "share_request_created",
+            Payload = "{}",
+            Status = status,
+            RetryCount = 0,
+            MaxRetries = 3,
+            NextRetryAt = nextRetryAt,
+            CreatedAt = DateTime.UtcNow,
+            CorrelationId = Guid.NewGuid(),
+            SourceEventId = null,
+        };
+    }
+}


### PR DESCRIPTION
## Bug A — lo Slack queue health check contava tutti i canali (503 mis-attribuito)

Emerso durante l'investigazione del 503-degraded del cutover 2772.

### Problema
`SlackQueueHealthCheck` → `INotificationQueueRepository.GetPendingCountAsync()` conta i pending di **tutti** i canali. Un backlog su un altro canale (310 email `pending` su staging) faceva fallire il check *Slack* → `/health` aggregato = 503 mis-attribuito a Slack, **mentre la coda Slack era vuota**. Il worker Slack invece filtrava già per canale (`GetPendingByChannelAsync`).

### Fix
- Nuovo `GetPendingCountByChannelsAsync(channels)` — stesso predicato "pending" di `GetPendingCountAsync` + filtro canale (`channelValues.Contains(e.ChannelType)`).
- `SlackQueueHealthCheck` ora conta solo `[SlackUser, SlackTeam]`.
- `GetPendingCountAsync` invariato (nessun altro consumer); semantica messaggio/soglia (100) invariata.

### Test (TDD RED→GREEN, Testcontainers Postgres)
- Unit (`SlackQueueHealthCheckTests`): +2 — backlog di altro canale (310 unfiltered / 0 Slack) → **Healthy**; verifica che raggiungano il filtered method solo `[SlackUser, SlackTeam]` e che `GetPendingCountAsync` non sia mai chiamato.
- Integration (nuovo, Testcontainers): coda mista → filtered count = 4 (solo Slack) vs unfiltered = 8.
- **67 test pass**.

### Scope
Questo fixa solo il **mis-conteggio** (Bug A). L'issue separata del backlog email + SMTP send rotto su staging è tracciata in **issue 3026** (non fixata qui — richiede investigazione EmailProcessorJob/SMTP). La coda email stale è già stata svuotata manualmente su staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
