### PR TITLE
fix(frontend): icone-titolo mancanti (6 pagine) + larghezza /toolkit/templates

### DIFF
--- a/apps/web/src/app/(authenticated)/games/[id]/faqs/page.tsx
+++ b/apps/web/src/app/(authenticated)/games/[id]/faqs/page.tsx
@@ -94,9 +94,14 @@ export default function GameFaqsPage() {
             <span aria-hidden="true">←</span>
             <span>Gioco</span>
           </Link>
-          <h1 className="mt-1 font-quicksand text-2xl font-bold tracking-tight text-foreground">
-            FAQ
-          </h1>
+          <div className="mt-1 flex items-center gap-2">
+            <span aria-hidden="true" className="text-2xl">
+              📚
+            </span>
+            <h1 className="font-quicksand text-2xl font-bold tracking-tight text-foreground">
+              FAQ
+            </h1>
+          </div>
         </header>
 
         {/* Loading */}

--- a/apps/web/src/app/(authenticated)/games/[id]/rules/page.tsx
+++ b/apps/web/src/app/(authenticated)/games/[id]/rules/page.tsx
@@ -101,9 +101,14 @@ export default function GameRulesPage() {
             <span aria-hidden="true">←</span>
             <span>Gioco</span>
           </Link>
-          <h1 className="mt-1 font-quicksand text-2xl font-bold tracking-tight text-foreground">
-            Regolamento
-          </h1>
+          <div className="mt-1 flex items-center gap-2">
+            <span aria-hidden="true" className="text-2xl">
+              🎲
+            </span>
+            <h1 className="font-quicksand text-2xl font-bold tracking-tight text-foreground">
+              Regolamento
+            </h1>
+          </div>
         </header>
 
         {/* Loading */}

--- a/apps/web/src/app/(authenticated)/toolkit/history/client.tsx
+++ b/apps/web/src/app/(authenticated)/toolkit/history/client.tsx
@@ -216,9 +216,14 @@ export default function ToolkitHistoryPage(): JSX.Element {
       {/* hero */}
       <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
         <div>
-          <h1 className="font-quicksand text-2xl font-bold text-foreground sm:text-3xl">
-            {t('pages.toolkitHistory.hero.title')}
-          </h1>
+          <div className="flex items-center gap-2">
+            <span aria-hidden="true" className="text-2xl sm:text-3xl">
+              🧰
+            </span>
+            <h1 className="font-quicksand text-2xl font-bold text-foreground sm:text-3xl">
+              {t('pages.toolkitHistory.hero.title')}
+            </h1>
+          </div>
           <p className="mt-1 text-sm text-muted-foreground">
             {t('pages.toolkitHistory.hero.subtitle')}
           </p>

--- a/apps/web/src/app/(authenticated)/toolkit/play/page.tsx
+++ b/apps/web/src/app/(authenticated)/toolkit/play/page.tsx
@@ -33,7 +33,12 @@ export default function ToolkitPlayPage() {
   return (
     <div className="mx-auto max-w-2xl space-y-6 p-4">
       <div className="flex items-center justify-between">
-        <h1 className="text-xl font-bold text-foreground">Toolkit</h1>
+        <div className="flex items-center gap-2">
+          <span aria-hidden="true" className="text-xl">
+            🎮
+          </span>
+          <h1 className="text-xl font-bold text-foreground">Toolkit</h1>
+        </div>
         <input
           type="text"
           value={actorLabel}
@@ -46,7 +51,9 @@ export default function ToolkitPlayPage() {
 
       {/* Dadi */}
       <section>
-        <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-muted-foreground">Dadi</h2>
+        <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+          Dadi
+        </h2>
         <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
           {DEFAULT_TOOLKIT.dice.map(config => (
             <DiceRoller

--- a/apps/web/src/app/(authenticated)/toolkit/stats/client.tsx
+++ b/apps/web/src/app/(authenticated)/toolkit/stats/client.tsx
@@ -33,7 +33,12 @@ export default function SessionStatsPage() {
   return (
     <div className="space-y-8 p-6">
       <div>
-        <h1 className="font-quicksand text-2xl font-bold">Session Analytics</h1>
+        <div className="flex items-center gap-2">
+          <span aria-hidden="true" className="text-2xl">
+            🧰
+          </span>
+          <h1 className="font-quicksand text-2xl font-bold">Session Analytics</h1>
+        </div>
         <p className="text-sm text-muted-foreground">
           Your gaming activity over the last 12 months
         </p>

--- a/apps/web/src/app/(authenticated)/toolkit/templates/page.tsx
+++ b/apps/web/src/app/(authenticated)/toolkit/templates/page.tsx
@@ -107,7 +107,12 @@ export default function ToolkitTemplatesPage() {
     <div className="container max-w-6xl space-y-6 py-6">
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold">Toolkit Templates</h1>
+          <div className="flex items-center gap-2">
+            <span aria-hidden="true" className="text-2xl">
+              🧰
+            </span>
+            <h1 className="text-2xl font-bold">Toolkit Templates</h1>
+          </div>
           <p className="text-sm text-muted-foreground">
             Browse approved templates and clone them for your games
           </p>

--- a/apps/web/src/app/(authenticated)/toolkit/templates/page.tsx
+++ b/apps/web/src/app/(authenticated)/toolkit/templates/page.tsx
@@ -104,7 +104,7 @@ export default function ToolkitTemplatesPage() {
   };
 
   return (
-    <div className="container max-w-6xl space-y-6 py-6">
+    <div className="container mx-auto max-w-[1440px] space-y-6 px-4 py-6">
       <div className="flex items-center justify-between">
         <div>
           <div className="flex items-center gap-2">
@@ -142,7 +142,7 @@ export default function ToolkitTemplatesPage() {
       )}
 
       <div
-        className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3"
+        className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"
         data-testid="templates-grid"
       >
         {templates?.map(t => (


### PR DESCRIPTION
## Cosa

Allinea 6 pagine ai rispettivi mockup aggiungendo l'**emoji-icona accanto al titolo H1**, dove il design la prevede ma la pagina live la ometteva. Stesso pattern già applicato a `/library/wishlist` (PR #3028).

Deriva da un audit di fidelity mockup↔live: l'icona-titolo mancante era il gap ricorrente più frequente.

| Pagina | Icona | Mockup di riferimento |
|---|---|---|
| `/toolkit/history` | 🧰 | `sp4-toolkit-history-ui.jsx` (`th-ico`) |
| `/toolkit/play` | 🎮 | `sp4-toolkit-play-ui.jsx` (`tp-ico`) |
| `/toolkit/stats` | 🧰 | `sp4-toolkit-stats.jsx` |
| `/toolkit/templates` | 🧰 | `sp4-toolkit-templates-ui.jsx` (`tt-ico`) |
| `/games/[id]/faqs` | 📚 | `sp4-game-detail-tab-faqs.html` |
| `/games/[id]/rules` | 🎲 | `sp4-game-detail-tab-rules.html` |

## Accessibilità

Ogni emoji è decorativa: `aria-hidden="true"` e collocata come **sibling fuori dall'`<h1>`** (in un flex row), quindi l'accessible name dell'heading resta invariato.

## Verifica

- `pnpm typecheck` + `pnpm eslint` (6 file) puliti.
- Test esistenti delle pagine toccate: **35/35 verdi** (gli assert `getByRole('heading', {name})` continuano a passare).
- Verifica visiva su `/toolkit/history` e `/toolkit/templates`: icona presente accanto al titolo.

## Larghezza container — `/toolkit/templates`

Il mockup mostra la griglia template a piena larghezza (1440px, 4 colonne); la live usava `container max-w-6xl` (1152px) con max 3 colonne → allineato a **1440px + `xl:grid-cols-4`**. Lint + test (9/9) verdi.

**`/toolkit/play` escluso**: il mockup ha un layout a **2 colonne** (tools + sidebar log 360px fissa); la live è una colonna singola `max-w-2xl` (dadi/timer/contatori/log impilati). Allargare solo il container stirerebbe le sezioni senza la sidebar → serve un redesign a parte, non un fix di larghezza.

## Note / fuori scope (in questa PR)

- **Tab-nav `/toolkit/templates`**: il mockup ha una tab-strip con icone (📊📜🎨🎮) ma la pagina live **non ha** una tab-nav (redesign non ancora implementato) → non toccata. La tab-strip di `/toolkit/history`, l'unica presente live, aveva già le icone corrette.
- **FAQ/Rules**: il mockup mostra un *entity-chip* con emoji **+ label** (`📚 KB`, `🎲 Game`) dentro l'h1; qui è stata aggiunta solo l'emoji (fuori dall'h1) per non alterare l'accessible name — il chip con label è un raffinamento successivo (i mockup FAQ/Rules sono peraltro placeholder AI, pending designer review #2148).
- Larghezza container di `/toolkit/play` e `/toolkit/templates`: intervento separato.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
