### PR TITLE
feat(session-live): #3025 L1 — generic live game-state projection + streaming

### DIFF
--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/LiveSessions/UpdateLiveGameStateCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/LiveSessions/UpdateLiveGameStateCommand.cs
@@ -1,0 +1,19 @@
+using System.Text.Json;
+
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.GameManagement.Application.Commands.LiveSessions;
+
+/// <summary>
+/// Updates the free-form live game-state (#3025 L1). Host/participant only.
+/// <para>
+/// <see cref="State"/> is a <see cref="JsonElement"/> — it binds cleanly from the request
+/// body and carries no <see cref="JsonDocument"/> disposal concern. The handler parses it
+/// into an owned <see cref="JsonDocument"/> that ownership is transferred to the aggregate.
+/// </para>
+/// </summary>
+internal record UpdateLiveGameStateCommand(
+    Guid SessionId,
+    Guid RequestedByUserId,
+    JsonElement State
+) : ICommand;

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/LiveSessions/UpdateLiveGameStateCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/LiveSessions/UpdateLiveGameStateCommandHandler.cs
@@ -1,0 +1,51 @@
+using Api.BoundedContexts.GameManagement.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Infrastructure.Persistence;
+
+namespace Api.BoundedContexts.GameManagement.Application.Commands.LiveSessions;
+
+/// <summary>
+/// Handles <see cref="UpdateLiveGameStateCommand"/>: replaces the live session's opaque
+/// game-state (host/participant only) and streams the change (#3025 L1).
+///
+/// Pattern mirrors <see cref="AddDiaryEntryCommandHandler"/>. ADR-060: <c>SaveChangesAsync</c>
+/// after <c>UpdateAsync</c>; the <see cref="Domain.Events.LiveSessionGameStateEvent"/> raised
+/// by the domain dispatches post-commit. <see cref="ConflictException"/> (Completed session)
+/// propagates → HTTP 409.
+/// </summary>
+internal sealed class UpdateLiveGameStateCommandHandler : ICommandHandler<UpdateLiveGameStateCommand>
+{
+    private readonly ILiveSessionRepository _sessionRepository;
+    private readonly IUnitOfWork _unitOfWork;
+
+    public UpdateLiveGameStateCommandHandler(
+        ILiveSessionRepository sessionRepository,
+        IUnitOfWork unitOfWork)
+    {
+        _sessionRepository = sessionRepository ?? throw new ArgumentNullException(nameof(sessionRepository));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+    }
+
+    public async Task Handle(UpdateLiveGameStateCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var session = await _sessionRepository
+            .GetByIdAsync(command.SessionId, cancellationToken)
+            .ConfigureAwait(false)
+            ?? throw new NotFoundException("LiveGameSession", command.SessionId.ToString());
+
+        // Authz: caller must be the session creator or an active linked player.
+        if (!session.IsAuthorizedParticipant(command.RequestedByUserId))
+            throw new ForbiddenException("Only the session creator or an active participant may update game state.");
+
+        // Parse the JsonElement into an OWNED JsonDocument. UpdateGameState takes ownership
+        // (stores it + disposes the prior). Do NOT wrap in `using` — the aggregate owns it now.
+        var doc = System.Text.Json.JsonDocument.Parse(command.State.GetRawText());
+        session.UpdateGameState(doc);
+
+        await _sessionRepository.UpdateAsync(session, cancellationToken).ConfigureAwait(false);
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/LiveSessions/LiveSessionDto.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/LiveSessions/LiveSessionDto.cs
@@ -1,3 +1,5 @@
+using System.Text.Json;
+
 using Api.BoundedContexts.GameManagement.Domain.Enums;
 
 namespace Api.BoundedContexts.GameManagement.Application.DTOs.LiveSessions;
@@ -26,6 +28,8 @@ internal record LiveSessionDto(
     Guid? CurrentTurnPlayerId,
     AgentSessionMode AgentMode,
     string? Notes,
+    // #3025 L1: opaque live game-state. JsonElement (serializable) — the domain holds a JsonDocument.
+    JsonElement? GameState,
     IReadOnlyList<LiveSessionPlayerDto> Players,
     IReadOnlyList<LiveSessionTeamDto> Teams,
     IReadOnlyList<LiveSessionRoundScoreDto> RoundScores,

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/EventHandlers/LiveSessionStreamForwarder.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/EventHandlers/LiveSessionStreamForwarder.cs
@@ -17,7 +17,8 @@ internal sealed class LiveSessionStreamForwarder :
     INotificationHandler<LiveSessionPausedEvent>,
     INotificationHandler<LiveSessionResumedEvent>,
     INotificationHandler<LiveSessionCompletedEvent>,
-    INotificationHandler<LiveSessionDiaryEntryAddedEvent>
+    INotificationHandler<LiveSessionDiaryEntryAddedEvent>,
+    INotificationHandler<LiveSessionGameStateEvent>
 {
     private readonly ILiveSessionStreamGateway _gateway;
     private readonly ILogger<LiveSessionStreamForwarder> _logger;
@@ -150,6 +151,21 @@ internal sealed class LiveSessionStreamForwarder :
                 content = notification.Text,
                 timestamp = notification.CreatedAt.ToString("o")
             }),
+            cancellationToken);
+    }
+
+    public Task Handle(LiveSessionGameStateEvent notification, CancellationToken cancellationToken)
+    {
+        _logger.LogDebug("Broadcasting session:game-state for session {SessionId}", notification.SessionId);
+        // The event carries the RAW JSON string (not the aggregate's disposable JsonDocument,
+        // which System.Text.Json cannot serialize). Re-parse into a JsonNode (serializable, not
+        // disposable) so `state` serializes as a nested OBJECT — not an escaped string.
+        var stateNode = notification.RawStateJson is null
+            ? null
+            : System.Text.Json.Nodes.JsonNode.Parse(notification.RawStateJson);
+        return _gateway.BroadcastAsync(
+            notification.SessionId,
+            new LiveSessionStreamEvent("session:game-state", new { state = stateNode }),
             cancellationToken);
     }
 }

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/LiveSessions/QueryHandlers.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/LiveSessions/QueryHandlers.cs
@@ -56,6 +56,7 @@ internal class GetLiveSessionQueryHandler : IQueryHandler<GetLiveSessionQuery, L
             currentTurnPlayerId == Guid.Empty ? null : currentTurnPlayerId,
             session.AgentMode,
             session.Notes,
+            session.GameState?.RootElement, // #3025 L1: opaque live game-state (JsonElement?)
             session.Players.Select(p => new LiveSessionPlayerDto(
                 p.Id,
                 p.UserId,

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Validators/LiveSessions/UpdateLiveGameStateCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Validators/LiveSessions/UpdateLiveGameStateCommandValidator.cs
@@ -1,0 +1,26 @@
+using System.Text;
+
+using Api.BoundedContexts.GameManagement.Application.Commands.LiveSessions;
+
+using FluentValidation;
+
+namespace Api.BoundedContexts.GameManagement.Application.Validators.LiveSessions;
+
+/// <summary>
+/// Validates <see cref="UpdateLiveGameStateCommand"/> (#3025 L1). The state is opaque at L1
+/// (no per-game shape check — that is L2); only guard non-empty ids + a UTF-8 byte size cap.
+/// </summary>
+internal sealed class UpdateLiveGameStateCommandValidator : AbstractValidator<UpdateLiveGameStateCommand>
+{
+    private const int MaxStateBytes = 256 * 1024;
+
+    public UpdateLiveGameStateCommandValidator()
+    {
+        RuleFor(x => x.SessionId).NotEmpty();
+        RuleFor(x => x.RequestedByUserId).NotEmpty();
+        // GetRawText() is a UTF-16 .NET string; count UTF-8 BYTES for an accurate wire-size cap.
+        RuleFor(x => x.State)
+            .Must(s => Encoding.UTF8.GetByteCount(s.GetRawText()) <= MaxStateBytes)
+            .WithMessage($"Game state exceeds the {MaxStateBytes} byte limit.");
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/LiveGameSession.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/LiveGameSession.cs
@@ -837,6 +837,9 @@ internal sealed class LiveGameSession : AggregateRoot<Guid>
         GameState = gameState;
         var now = (timeProvider ?? TimeProvider.System).GetUtcNow().UtcDateTime;
         UpdatedAt = now;
+        // #3025 L1: stream the change. Carry the raw JSON string (copied now) — NOT the
+        // JsonDocument, which this method disposes on the next call.
+        AddDomainEvent(new LiveSessionGameStateEvent(Id, gameState?.RootElement.GetRawText()));
     }
 
     /// <summary>

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Events/LiveSessionGameStateEvent.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Events/LiveSessionGameStateEvent.cs
@@ -1,0 +1,27 @@
+using Api.SharedKernel.Domain.Events;
+
+namespace Api.BoundedContexts.GameManagement.Domain.Events;
+
+/// <summary>
+/// Raised when a live game session's free-form game-state is updated (#3025 L1).
+/// Forwarded to the SSE stream as "session:game-state".
+///
+/// <see cref="RawStateJson"/> is the opaque state serialized to a string, copied at raise
+/// time (via <c>JsonDocument.RootElement.GetRawText()</c>) so the event does NOT hold the
+/// aggregate's disposable <see cref="System.Text.Json.JsonDocument"/> — which is disposed on
+/// the next <c>UpdateGameState</c> call and is not itself serializable by System.Text.Json.
+///
+/// NB: fires on EVERY <c>UpdateGameState</c> call — including snapshot-restore — which is
+/// intentional (streaming a restored state to live clients is transparent).
+/// </summary>
+internal sealed class LiveSessionGameStateEvent : DomainEventBase
+{
+    public Guid SessionId { get; }
+    public string? RawStateJson { get; }
+
+    public LiveSessionGameStateEvent(Guid sessionId, string? rawStateJson)
+    {
+        SessionId = sessionId;
+        RawStateJson = rawStateJson;
+    }
+}

--- a/apps/api/src/Api/Routing/LiveSessionEndpoints.cs
+++ b/apps/api/src/Api/Routing/LiveSessionEndpoints.cs
@@ -203,6 +203,16 @@ internal static class LiveSessionEndpoints
             .WithTags("LiveSessions")
             .WithSummary("Update session notes");
 
+        group.MapPut("/live-sessions/{sessionId}/game-state", HandleUpdateGameState)
+            .RequireAuthenticatedUser()
+            .RequireLiveSessionParticipant()
+            .Produces(204)
+            .Produces(403)
+            .Produces(404)
+            .Produces(409)
+            .WithTags("LiveSessions")
+            .WithSummary("Update the live game-state (#3025 L1)");
+
         group.MapPost("/live-sessions/{sessionId}/scores/parse", HandleParseScore)
             .RequireAuthenticatedUser()
             .RequireLiveSessionParticipant()
@@ -763,6 +773,27 @@ internal static class LiveSessionEndpoints
     }
 
     /// <summary>
+    /// PUT /api/v1/live-sessions/{sessionId}/game-state — #3025 L1.
+    /// Replaces the opaque live game-state. 204 on success; 403 non-participant;
+    /// 404 session not found; 409 if the session is Completed.
+    /// </summary>
+    private static async Task<IResult> HandleUpdateGameState(
+        Guid sessionId,
+        [FromBody] UpdateGameStateRequest request,
+        HttpContext httpContext,
+        [FromServices] IMediator mediator,
+        CancellationToken cancellationToken)
+    {
+        var userId = httpContext.User.GetUserId();
+
+        await mediator.Send(
+            new UpdateLiveGameStateCommand(sessionId, userId, request.State),
+            cancellationToken).ConfigureAwait(false);
+
+        return Results.NoContent();
+    }
+
+    /// <summary>
     /// GET /api/v1/live-sessions/{sessionId}/diary — Issue #2570 SP3 T5.
     /// Returns all diary entries ordered by CreatedAt ascending. 404 if session not found.
     /// 403 if the caller is not the session creator or an active participant.
@@ -1173,6 +1204,9 @@ internal static class LiveSessionEndpoints
 
     // Diary (SP3) request model
     private sealed record AddDiaryEntryRequest(string Text);
+
+    /// <summary>Body for PUT /live-sessions/{id}/game-state. Opaque JSON (#3025 L1).</summary>
+    private sealed record UpdateGameStateRequest(System.Text.Json.JsonElement State);
 
     // Dispute v2 request models
     internal sealed record OpenDisputeRequest(

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/EventHandlers/LiveSessionStreamForwarderGameStateTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/EventHandlers/LiveSessionStreamForwarderGameStateTests.cs
@@ -1,0 +1,33 @@
+using Api.BoundedContexts.GameManagement.Application.EventHandlers;
+using Api.BoundedContexts.GameManagement.Application.Services;
+using Api.BoundedContexts.GameManagement.Domain.Events;
+using Api.Tests.Constants;
+
+using Microsoft.Extensions.Logging.Abstractions;
+
+using Moq;
+
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Application.EventHandlers;
+
+/// <summary>#3025 L1: LiveSessionGameStateEvent is forwarded to SSE "session:game-state".</summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "GameManagement")]
+public sealed class LiveSessionStreamForwarderGameStateTests
+{
+    [Fact]
+    public async Task Handle_GameStateEvent_BroadcastsSessionGameState()
+    {
+        var gateway = new Mock<ILiveSessionStreamGateway>();
+        var sut = new LiveSessionStreamForwarder(gateway.Object, NullLogger<LiveSessionStreamForwarder>.Instance);
+        var sessionId = Guid.NewGuid();
+
+        await sut.Handle(new LiveSessionGameStateEvent(sessionId, """{"k":"v"}"""), CancellationToken.None);
+
+        gateway.Verify(g => g.BroadcastAsync(
+            sessionId,
+            It.Is<LiveSessionStreamEvent>(e => e.Type == "session:game-state"),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/LiveSessions/UpdateLiveGameStateCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/LiveSessions/UpdateLiveGameStateCommandHandlerTests.cs
@@ -1,0 +1,81 @@
+using System.Text.Json;
+
+using Api.BoundedContexts.GameManagement.Application.Commands.LiveSessions;
+using Api.BoundedContexts.GameManagement.Domain.Entities;
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+using Api.BoundedContexts.GameManagement.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Tests.Constants;
+
+using Microsoft.Extensions.Time.Testing;
+
+using Moq;
+
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Application.Handlers.LiveSessions;
+
+/// <summary>#3025 L1: UpdateLiveGameStateCommand — host-authz write path.</summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "GameManagement")]
+public sealed class UpdateLiveGameStateCommandHandlerTests
+{
+    private readonly Mock<ILiveSessionRepository> _repo = new();
+    private readonly Mock<IUnitOfWork> _uow = new();
+    private readonly FakeTimeProvider _timeProvider =
+        new(new DateTimeOffset(2026, 7, 16, 10, 0, 0, TimeSpan.Zero));
+
+    private UpdateLiveGameStateCommandHandler CreateSut() => new(_repo.Object, _uow.Object);
+
+    private static JsonElement State(string json) => JsonDocument.Parse(json).RootElement;
+
+    private LiveGameSession CreateInProgressSession(Guid creator)
+    {
+        var session = LiveGameSession.Create(Guid.NewGuid(), creator, "Mage Knight", _timeProvider);
+        session.AddPlayer(null, "Alice", PlayerColor.Red, _timeProvider);
+        session.Start(_timeProvider);
+        return session;
+    }
+
+    [Fact]
+    public async Task Handle_AuthorizedCreator_UpdatesStateAndSaves()
+    {
+        var creator = Guid.NewGuid();
+        var session = CreateInProgressSession(creator);
+        _repo.Setup(r => r.GetByIdAsync(session.Id, It.IsAny<CancellationToken>())).ReturnsAsync(session);
+
+        await CreateSut().Handle(
+            new UpdateLiveGameStateCommand(session.Id, creator, State("""{"x":1}""")),
+            CancellationToken.None);
+
+        _repo.Verify(r => r.UpdateAsync(session, It.IsAny<CancellationToken>()), Times.Once);
+        _uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_SessionNotFound_ThrowsNotFound()
+    {
+        _repo.Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+             .ReturnsAsync((LiveGameSession?)null);
+
+        await Assert.ThrowsAsync<NotFoundException>(() =>
+            CreateSut().Handle(
+                new UpdateLiveGameStateCommand(Guid.NewGuid(), Guid.NewGuid(), State("{}")),
+                CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Handle_NonParticipant_ThrowsForbiddenAndDoesNotSave()
+    {
+        var session = CreateInProgressSession(Guid.NewGuid());
+        _repo.Setup(r => r.GetByIdAsync(session.Id, It.IsAny<CancellationToken>())).ReturnsAsync(session);
+
+        await Assert.ThrowsAsync<ForbiddenException>(() =>
+            CreateSut().Handle(
+                new UpdateLiveGameStateCommand(session.Id, Guid.NewGuid() /* stranger */, State("{}")),
+                CancellationToken.None));
+
+        _uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Queries/LiveSessions/GetLiveSessionQueryHandlerGameStateTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Queries/LiveSessions/GetLiveSessionQueryHandlerGameStateTests.cs
@@ -1,0 +1,50 @@
+using System.Text.Json;
+
+using Api.BoundedContexts.GameManagement.Application.Queries.LiveSessions;
+using Api.BoundedContexts.GameManagement.Domain.Entities;
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+using Api.Tests.Constants;
+
+using Microsoft.Extensions.Time.Testing;
+
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Application.Queries.LiveSessions;
+
+/// <summary>#3025 L1: LiveSessionDto exposes the opaque GameState.</summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "GameManagement")]
+public sealed class GetLiveSessionQueryHandlerGameStateTests
+{
+    private readonly FakeTimeProvider _tp = new(new DateTimeOffset(2026, 7, 16, 10, 0, 0, TimeSpan.Zero));
+
+    private LiveGameSession CreateInProgressSession()
+    {
+        var session = LiveGameSession.Create(Guid.NewGuid(), Guid.NewGuid(), "Mage Knight", _tp);
+        session.AddPlayer(null, "Alice", PlayerColor.Red, _tp);
+        session.Start(_tp);
+        return session;
+    }
+
+    [Fact]
+    public void MapToDto_ExposesGameState_WhenSet()
+    {
+        var session = CreateInProgressSession();
+        session.UpdateGameState(JsonDocument.Parse("""{"board":7}"""));
+
+        var dto = GetLiveSessionQueryHandler.MapToDto(session);
+
+        Assert.NotNull(dto.GameState);
+        Assert.Equal(7, dto.GameState!.Value.GetProperty("board").GetInt32());
+    }
+
+    [Fact]
+    public void MapToDto_NullGameState_WhenUnset()
+    {
+        var session = CreateInProgressSession();
+
+        var dto = GetLiveSessionQueryHandler.MapToDto(session);
+
+        Assert.Null(dto.GameState);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/Entities/LiveGameSession_GameStateEventTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/Entities/LiveGameSession_GameStateEventTests.cs
@@ -1,0 +1,47 @@
+using System.Text.Json;
+
+using Api.BoundedContexts.GameManagement.Domain.Entities;
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+using Api.BoundedContexts.GameManagement.Domain.Events;
+using Api.Tests.Constants;
+
+using Microsoft.Extensions.Time.Testing;
+
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Domain.Entities;
+
+/// <summary>#3025 L1: UpdateGameState raises LiveSessionGameStateEvent carrying the raw JSON.</summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "GameManagement")]
+public class LiveGameSession_GameStateEventTests
+{
+    private readonly FakeTimeProvider _timeProvider =
+        new(new DateTimeOffset(2026, 7, 16, 10, 0, 0, TimeSpan.Zero));
+
+    private LiveGameSession CreateInProgressSession(Guid? creator = null)
+    {
+        var session = LiveGameSession.Create(
+            Guid.NewGuid(),
+            creator ?? Guid.NewGuid(),
+            "Mage Knight",
+            _timeProvider);
+        session.AddPlayer(null, "Alice", PlayerColor.Red, _timeProvider);
+        session.Start(_timeProvider);
+        return session;
+    }
+
+    [Fact]
+    public void UpdateGameState_RaisesLiveSessionGameStateEvent_WithSessionIdAndRawState()
+    {
+        var session = CreateInProgressSession();
+        var state = JsonDocument.Parse("""{"board":"opaque"}"""); // ownership transferred to the aggregate
+
+        session.UpdateGameState(state);
+
+        var evt = Assert.Single(session.DomainEvents, e => e is LiveSessionGameStateEvent);
+        var gs = Assert.IsType<LiveSessionGameStateEvent>(evt);
+        Assert.Equal(session.Id, gs.SessionId);
+        Assert.Contains("\"board\"", gs.RawStateJson);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/ParseAndRecordScoreCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/ParseAndRecordScoreCommandHandlerTests.cs
@@ -271,6 +271,7 @@ public class ParseAndRecordScoreCommandHandlerTests
             CurrentTurnPlayerId: null,
             AgentMode: AgentSessionMode.None,
             Notes: null,
+            GameState: null,
             Players: new List<LiveSessionPlayerDto>(),
             Teams: new List<LiveSessionTeamDto>(),
             RoundScores: new List<LiveSessionRoundScoreDto>(),

--- a/apps/api/tests/Api.Tests/Integration/GameManagement/LiveGameStateEndpointIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/GameManagement/LiveGameStateEndpointIntegrationTests.cs
@@ -1,0 +1,149 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Api.BoundedContexts.GameManagement.Application.Commands.LiveSessions;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.Integration.GameManagement;
+
+/// <summary>
+/// Integration tests for the #3025 L1 live game-state endpoint
+/// (PUT /api/v1/live-sessions/{id}/game-state), proving end-to-end the write→persist→expose path:
+/// the creator's PUT round-trips onto the GET DTO's <c>gameState</c>, and a non-participant is
+/// blocked with 403 by RequireLiveSessionParticipant. Per-handler behaviour is unit-tested in
+/// UpdateLiveGameStateCommandHandlerTests / GetLiveSessionQueryHandlerGameStateTests.
+///
+/// Mirrors LiveSessionParticipantAuthzEndpointTests (Testcontainers fixture, cookie auth, IMediator setup).
+/// </summary>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "GameManagement")]
+[Trait("Dependency", "PostgreSQL")]
+[Trait("Issue", "3025")]
+public sealed class LiveGameStateEndpointIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly string _databaseName = $"live_gamestate_{Guid.NewGuid():N}";
+    private Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactory<Program> _factory = null!;
+
+    public LiveGameStateEndpointIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+        await TestcontainersWaitHelpers.WaitForPostgresReadyAsync(connectionString);
+
+        _factory = IntegrationWebApplicationFactory.Create(connectionString);
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        await db.Database.MigrateAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_factory != null)
+        {
+            await _factory.DisposeAsync();
+        }
+        await _fixture.DropIsolatedDatabaseAsync(_databaseName);
+    }
+
+    [Fact(DisplayName = "PUT /game-state as creator persists and round-trips on GET")]
+    public async Task UpdateGameState_AsCreator_PersistsAndIsReturnedByGet()
+    {
+        // Arrange: authenticate as the creator + create a live session.
+        var (client, sessionId) = await CreateCreatorSessionAsync();
+
+        // Act: PUT the opaque game-state.
+        var put = await client.PutAsJsonAsync(
+            $"/api/v1/live-sessions/{sessionId}/game-state",
+            new { state = new { k = 1 } });
+
+        // Assert: 204 + round-trips on GET under the camelCase `gameState` field.
+        put.StatusCode.Should().Be(HttpStatusCode.NoContent);
+
+        var dto = await client.GetFromJsonAsync<JsonElement>($"/api/v1/live-sessions/{sessionId}");
+        dto.GetProperty("gameState").GetProperty("k").GetInt32().Should().Be(1);
+    }
+
+    [Fact(DisplayName = "PUT /game-state returns 403 for an authenticated non-participant")]
+    public async Task UpdateGameState_AsNonParticipant_Returns403()
+    {
+        var (_, sessionId) = await CreateCreatorSessionAsync();
+        var (clientB, tokenB) = await CreateOtherUserClientAsync();
+
+        var request = TestSessionHelper.CreateAuthenticatedRequest(
+            HttpMethod.Put, $"/api/v1/live-sessions/{sessionId}/game-state", tokenB);
+        request.Content = JsonContent.Create(new { state = new { k = 1 } });
+
+        var response = await clientB.SendAsync(request);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden,
+            "a non-participant must be blocked by RequireLiveSessionParticipant");
+    }
+
+    // ── Helpers (mirror LiveSessionParticipantAuthzEndpointTests) ───────────────────
+
+    /// <summary>Seeds a user + session, creates a LiveGameSession owned by that user, returns an authenticated client.</summary>
+    private async Task<(HttpClient Client, Guid SessionId)> CreateCreatorSessionAsync()
+    {
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var mediator = scope.ServiceProvider.GetRequiredService<IMediator>();
+
+        var userId = await SeedUserAsync(db);
+        var (_, token) = await TestSessionHelper.CreateUserSessionAsync(db, userId);
+
+        var sessionId = await mediator.Send(new CreateLiveSessionCommand(
+            UserId: userId, GameName: "Game State Test Game", GameId: null));
+
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Add("Cookie", $"{TestSessionHelper.SessionCookieName}={token}");
+        client.DefaultRequestHeaders.Add("X-Test-Session-Token", token);
+        return (client, sessionId);
+    }
+
+    /// <summary>Creates an authenticated client for a different user who is NOT a participant of any session.</summary>
+    private async Task<(HttpClient Client, string Token)> CreateOtherUserClientAsync()
+    {
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var (_, token) = await TestSessionHelper.CreateUserSessionAsync(db);
+
+        var client = _factory.CreateClient();
+        client.DefaultRequestHeaders.Add("Cookie", $"{TestSessionHelper.SessionCookieName}={token}");
+        return (client, token);
+    }
+
+    private static async Task<Guid> SeedUserAsync(MeepleAiDbContext db)
+    {
+        var userId = Guid.NewGuid();
+        db.Users.Add(new UserEntity
+        {
+            Id = userId,
+            Email = $"gamestate-test-{userId:N}@test.local",
+            DisplayName = "Game State Test User",
+            PasswordHash = "not-a-real-hash",
+            Role = "user",
+            Tier = "free",
+            Status = "Active",
+            EmailVerified = true,
+            CreatedAt = DateTime.UtcNow
+        });
+        await db.SaveChangesAsync();
+        return userId;
+    }
+}

--- a/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx
@@ -490,6 +490,16 @@ export function SessionLiveView(): ReactElement {
     };
   }, [fixture, sessionQuery.data, liveStream.events, diaryQuery.data, currentUser?.id]);
 
+  // #3025 L1: mirror the opaque live game-state into the store — hydrate from the DTO,
+  // then let the latest `session:game-state` SSE event win. L3 flavors read `s.gameState`.
+  useEffect(() => {
+    const dtoState = sessionQuery.data?.gameState ?? null;
+    const latest = [...liveStream.events].reverse().find(e => e.type === 'session:game-state');
+    useLiveSessionStore
+      .getState()
+      .setGameState(latest && latest.type === 'session:game-state' ? latest.state : dtoState);
+  }, [sessionQuery.data?.gameState, liveStream.events]);
+
   // #2483 Task 2: reactive selector for turnOrderType — must be declared before
   // turnRendererState useMemo (which appears in the i18n labels section below).
   const storeTurnOrderType = useLiveSessionStore(s => s.turnOrderType);

--- a/apps/web/src/hooks/mutations/__tests__/useUpdateLiveGameState.test.tsx
+++ b/apps/web/src/hooks/mutations/__tests__/useUpdateLiveGameState.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * Tests for useUpdateLiveGameState (#3025 L1).
+ *
+ * Covers:
+ *   - mutate calls api.liveSessions.updateGameState with sessionId + state
+ *   - success → invalidates liveSessionKeys.detail(sessionId)
+ *   - error → does NOT invalidate queries
+ */
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import type { JSX, ReactNode } from 'react';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import { useUpdateLiveGameState } from '../useUpdateLiveGameState';
+import { liveSessionKeys } from '@/hooks/queries/useLiveSession';
+
+// ---------------------------------------------------------------------------
+// Mock @/lib/api
+// ---------------------------------------------------------------------------
+
+const updateGameStateMock = vi.fn<[string, unknown], Promise<void>>();
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    liveSessions: {
+      updateGameState: (sessionId: string, state: unknown) => updateGameStateMock(sessionId, state),
+    },
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Wrapper factory
+// ---------------------------------------------------------------------------
+
+function makeWrapper(qc: QueryClient) {
+  return function Wrapper({ children }: { children: ReactNode }): JSX.Element {
+    return <QueryClientProvider client={qc}>{children}</QueryClientProvider>;
+  };
+}
+
+const SESSION_ID = '00000000-0000-4000-8000-000000003025';
+const STATE = { round: 3, activePlayer: 'p1' };
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useUpdateLiveGameState (#3025 L1)', () => {
+  beforeEach(() => {
+    updateGameStateMock.mockReset();
+  });
+
+  it('calls api.liveSessions.updateGameState with sessionId and state', async () => {
+    updateGameStateMock.mockResolvedValueOnce(undefined);
+
+    const qc = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    const { result } = renderHook(() => useUpdateLiveGameState(SESSION_ID), {
+      wrapper: makeWrapper(qc),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync(STATE);
+    });
+
+    expect(updateGameStateMock).toHaveBeenCalledOnce();
+    expect(updateGameStateMock).toHaveBeenCalledWith(SESSION_ID, STATE);
+  });
+
+  it('invalidates liveSessionKeys.detail on success', async () => {
+    updateGameStateMock.mockResolvedValueOnce(undefined);
+
+    const qc = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    const invalidateSpy = vi.spyOn(qc, 'invalidateQueries');
+
+    const { result } = renderHook(() => useUpdateLiveGameState(SESSION_ID), {
+      wrapper: makeWrapper(qc),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync(STATE);
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queryKey: liveSessionKeys.detail(SESSION_ID),
+      })
+    );
+  });
+
+  it('does NOT invalidate queries on error', async () => {
+    updateGameStateMock.mockRejectedValueOnce(new Error('Network error'));
+
+    const qc = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    const invalidateSpy = vi.spyOn(qc, 'invalidateQueries');
+
+    const { result } = renderHook(() => useUpdateLiveGameState(SESSION_ID), {
+      wrapper: makeWrapper(qc),
+    });
+
+    await act(async () => {
+      try {
+        await result.current.mutateAsync(STATE);
+      } catch {
+        // expected
+      }
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(invalidateSpy).not.toHaveBeenCalled();
+  });
+
+  it('forwards a null state (clearing the game-state)', async () => {
+    updateGameStateMock.mockResolvedValueOnce(undefined);
+
+    const qc = new QueryClient({ defaultOptions: { mutations: { retry: false } } });
+    const { result } = renderHook(() => useUpdateLiveGameState(SESSION_ID), {
+      wrapper: makeWrapper(qc),
+    });
+
+    await act(async () => {
+      await result.current.mutateAsync(null);
+    });
+
+    expect(updateGameStateMock).toHaveBeenCalledWith(SESSION_ID, null);
+  });
+});

--- a/apps/web/src/hooks/mutations/useUpdateLiveGameState.ts
+++ b/apps/web/src/hooks/mutations/useUpdateLiveGameState.ts
@@ -1,0 +1,21 @@
+/**
+ * useUpdateLiveGameState — #3025 L1 host/participant mutation to replace the opaque
+ * live game-state (`PUT /live-sessions/{id}/game-state`). The state is game-agnostic
+ * JSON at L1 (per-game typing = L2). On success, invalidates the live-session query so
+ * the DTO re-hydrates; live consumers also get the `session:game-state` SSE event.
+ */
+
+import { useMutation, useQueryClient, type UseMutationResult } from '@tanstack/react-query';
+
+import { liveSessionKeys } from '@/hooks/queries/useLiveSession';
+import { api } from '@/lib/api';
+
+export function useUpdateLiveGameState(sessionId: string): UseMutationResult<void, Error, unknown> {
+  const queryClient = useQueryClient();
+  return useMutation<void, Error, unknown>({
+    mutationFn: (state: unknown) => api.liveSessions.updateGameState(sessionId, state),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: liveSessionKeys.detail(sessionId) });
+    },
+  });
+}

--- a/apps/web/src/lib/api/clients/liveSessionsClient.ts
+++ b/apps/web/src/lib/api/clients/liveSessionsClient.ts
@@ -179,6 +179,9 @@ export interface LiveSessionsClient {
   /** Update session notes */
   updateNotes(sessionId: string, request: UpdateNotesRequest): Promise<void>;
 
+  /** #3025 L1: replace the opaque live game-state (host/participant only). */
+  updateGameState(sessionId: string, state: unknown): Promise<void>;
+
   // ========== Diary (SP3 #2570 / write-path #2575) ==========
 
   /** Append an immutable diary entry to the session. Returns the new entry id. */
@@ -438,6 +441,10 @@ export function createLiveSessionsClient({
 
     async editScore(sessionId, request) {
       await httpClient.put(`${BASE}/${encodeURIComponent(sessionId)}/scores`, request);
+    },
+
+    async updateGameState(sessionId, state) {
+      await httpClient.put(`${BASE}/${encodeURIComponent(sessionId)}/game-state`, { state });
     },
 
     // ========== Turns & Phases ==========

--- a/apps/web/src/lib/api/schemas/__tests__/live-sessions.game-state.schemas.test.ts
+++ b/apps/web/src/lib/api/schemas/__tests__/live-sessions.game-state.schemas.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+
+import { LiveSessionDtoSchema } from '../live-sessions.schemas';
+
+/**
+ * #3025 L1 — the LiveSessionDto carries an optional, opaque `gameState` field
+ * (game-agnostic JSON; per-game typing is L2). It must be back-compat: absent or
+ * null are both valid, and any JSON value passes through unchanged.
+ */
+const BASE_DTO = {
+  id: '11111111-1111-4111-8111-111111111111',
+  sessionCode: 'ABC123',
+  gameId: null,
+  gameName: 'Mage Knight',
+  gameSlug: 'mage-knight',
+  createdByUserId: '22222222-2222-4222-8222-222222222222',
+  status: 'InProgress' as const,
+  visibility: 'Private' as const,
+  groupId: null,
+  createdAt: '2026-01-01T10:00:00Z',
+  startedAt: '2026-01-01T10:05:00Z',
+  pausedAt: null,
+  completedAt: null,
+  updatedAt: '2026-01-01T10:10:00Z',
+  lastSavedAt: null,
+  currentTurnIndex: 0,
+  currentTurnPlayerId: null,
+  agentMode: 'None' as const,
+  notes: null,
+  players: [],
+  teams: [],
+  roundScores: [],
+  scoringConfig: { enabledDimensions: [], dimensionUnits: {} },
+};
+
+describe('LiveSessionDtoSchema — gameState (#3025 L1)', () => {
+  it('parses a DTO with gameState absent (back-compat)', () => {
+    const parsed = LiveSessionDtoSchema.parse(BASE_DTO);
+    expect(parsed.gameState).toBeUndefined();
+  });
+
+  it('parses a DTO with gameState explicitly null', () => {
+    const parsed = LiveSessionDtoSchema.parse({ ...BASE_DTO, gameState: null });
+    expect(parsed.gameState).toBeNull();
+  });
+
+  it('passes an opaque object through unchanged', () => {
+    const gameState = { round: 3, dev: { catan: { longestRoad: 'p1', points: { p1: 7 } } } };
+    const parsed = LiveSessionDtoSchema.parse({ ...BASE_DTO, gameState });
+    expect(parsed.gameState).toEqual(gameState);
+  });
+
+  it('accepts a primitive gameState (opaque at L1)', () => {
+    const parsed = LiveSessionDtoSchema.parse({ ...BASE_DTO, gameState: 42 });
+    expect(parsed.gameState).toBe(42);
+  });
+});

--- a/apps/web/src/lib/api/schemas/live-sessions.schemas.ts
+++ b/apps/web/src/lib/api/schemas/live-sessions.schemas.ts
@@ -133,6 +133,8 @@ export const LiveSessionDtoSchema = z.object({
   teams: z.array(LiveSessionTeamDtoSchema),
   roundScores: z.array(LiveSessionRoundScoreDtoSchema),
   scoringConfig: LiveSessionScoringConfigDtoSchema,
+  // #3025 L1: opaque live game-state (per-game typing = L2). Optional for back-compat.
+  gameState: z.unknown().nullable().optional(),
 });
 
 export type LiveSessionDto = z.infer<typeof LiveSessionDtoSchema>;

--- a/apps/web/src/lib/session-live/__tests__/parse-sse-event.test.ts
+++ b/apps/web/src/lib/session-live/__tests__/parse-sse-event.test.ts
@@ -933,3 +933,70 @@ describe('parseSseEvent — sessionId resolution', () => {
     }
   });
 });
+
+// ============================================================================
+// #3025 L1 — session:game-state (opaque game-agnostic state)
+// ============================================================================
+
+describe('parseSseEvent — session:game-state (#3025 L1)', () => {
+  it('parses an object state', () => {
+    const state = { round: 2, activePlayer: 'p1', dev: { catan: { longestRoad: 'p2' } } };
+    const result = parseSseEvent('session:game-state', makeJson({ state }), SESSION_ID);
+    expect(result).toMatchObject({ type: 'session:game-state', sessionId: SESSION_ID, state });
+    if (result?.type === 'session:game-state') {
+      expect(typeof result.timestamp).toBe('string');
+    }
+  });
+
+  it('parses a null state (state key present, value null)', () => {
+    const result = parseSseEvent('session:game-state', makeJson({ state: null }), SESSION_ID);
+    expect(result).toMatchObject({
+      type: 'session:game-state',
+      sessionId: SESSION_ID,
+      state: null,
+    });
+  });
+
+  it('carries a server-provided timestamp when present', () => {
+    const result = parseSseEvent(
+      'session:game-state',
+      makeJson({ state: { x: 1 }, timestamp: '2026-01-02T03:04:05Z' }),
+      SESSION_ID
+    );
+    if (result?.type === 'session:game-state') {
+      expect(result.timestamp).toBe('2026-01-02T03:04:05Z');
+    } else {
+      throw new Error('expected session:game-state');
+    }
+  });
+
+  it('preserves a primitive/array state verbatim (opaque at L1)', () => {
+    const result = parseSseEvent('session:game-state', makeJson({ state: [1, 2, 3] }), SESSION_ID);
+    if (result?.type === 'session:game-state') {
+      expect(result.state).toEqual([1, 2, 3]);
+    } else {
+      throw new Error('expected session:game-state');
+    }
+  });
+
+  it('returns null when the `state` key is absent', () => {
+    expect(parseSseEvent('session:game-state', makeJson({ round: 1 }), SESSION_ID)).toBeNull();
+  });
+
+  it('returns null for malformed JSON', () => {
+    expect(parseSseEvent('session:game-state', '{not-json}', SESSION_ID)).toBeNull();
+  });
+
+  it('resolves sessionId from data when the param is empty', () => {
+    const result = parseSseEvent(
+      'session:game-state',
+      makeJson({ state: { x: 1 }, sessionId: 'data-session' }),
+      ''
+    );
+    if (result?.type === 'session:game-state') {
+      expect(result.sessionId).toBe('data-session');
+    } else {
+      throw new Error('expected session:game-state');
+    }
+  });
+});

--- a/apps/web/src/lib/session-live/__tests__/sse-events.test.ts
+++ b/apps/web/src/lib/session-live/__tests__/sse-events.test.ts
@@ -13,9 +13,10 @@ import {
 } from '../sse-events';
 
 describe('SESSION_EVENT_TYPES array', () => {
-  it('contains exactly 13 event types', () => {
+  it('contains exactly 14 event types', () => {
     // T9 SP2 #2561: added session:phase → 13 total
-    expect(SESSION_EVENT_TYPES).toHaveLength(13);
+    // #3025 L1: added session:game-state → 14 total
+    expect(SESSION_EVENT_TYPES).toHaveLength(14);
   });
 
   it('includes all expected event type strings', () => {
@@ -32,6 +33,7 @@ describe('SESSION_EVENT_TYPES array', () => {
       'session:chat',
       'session:tool-execution',
       'session:diary',
+      'session:game-state',
       'heartbeat',
     ];
     for (const type of expected) {
@@ -39,11 +41,12 @@ describe('SESSION_EVENT_TYPES array', () => {
     }
   });
 
-  it('is typed as ReadonlyArray (array with 13 members)', () => {
+  it('is typed as ReadonlyArray (array with 14 members)', () => {
     // ReadonlyArray is a TypeScript type constraint, not a runtime frozen object.
     // T9 SP2 #2561: added session:phase → 13 total
+    // #3025 L1: added session:game-state → 14 total
     expect(Array.isArray(SESSION_EVENT_TYPES)).toBe(true);
-    expect(SESSION_EVENT_TYPES.length).toBe(13);
+    expect(SESSION_EVENT_TYPES.length).toBe(14);
   });
 
   it('contains no duplicates', () => {

--- a/apps/web/src/lib/session-live/parse-sse-event.ts
+++ b/apps/web/src/lib/session-live/parse-sse-event.ts
@@ -437,6 +437,9 @@ export function parseSseEvent(
       case 'session:diary':
         event = parseDiary(data, resolvedSessionId);
         break;
+      case 'session:game-state':
+        event = parseGameState(data, resolvedSessionId);
+        break;
       case 'heartbeat':
         event = parseHeartbeat(data);
         break;
@@ -450,4 +453,18 @@ export function parseSseEvent(
   } catch {
     return null;
   }
+}
+
+/**
+ * #3025 L1: parse a `session:game-state` event. `state` is opaque (game-agnostic) JSON —
+ * per-game typing is L2. Returns null if the payload lacks a `state` key (malformed).
+ */
+function parseGameState(
+  data: Record<string, unknown>,
+  sessionId: string
+): Extract<SessionEvent, { type: 'session:game-state' }> | null {
+  if (!('state' in data)) return null;
+  const timestamp =
+    typeof data['timestamp'] === 'string' ? data['timestamp'] : new Date().toISOString();
+  return { type: 'session:game-state', sessionId, state: data['state'], timestamp };
 }

--- a/apps/web/src/lib/session-live/sse-events.ts
+++ b/apps/web/src/lib/session-live/sse-events.ts
@@ -55,6 +55,7 @@ export type SessionEventType =
   | 'session:chat'
   | 'session:tool-execution'
   | 'session:diary'
+  | 'session:game-state'
   | 'heartbeat';
 
 /**
@@ -74,6 +75,7 @@ export const SESSION_EVENT_TYPES: ReadonlyArray<SessionEventType> = [
   'session:chat',
   'session:tool-execution',
   'session:diary',
+  'session:game-state',
   'heartbeat',
 ];
 
@@ -189,6 +191,19 @@ export type SessionEvent =
       entryId: string;
       authorId: string;
       content: string;
+      timestamp: string;
+    }
+  | {
+      /**
+       * Opaque live game-state updated (#3025 L1). `state` is game-agnostic JSON —
+       * per-game typing is L2, rich rendering is L3. Forwarded from
+       * LiveSessionGameStateEvent as `{ state: <object|null> }`. `timestamp` keeps the
+       * variant uniform with every other SSE event (used only for chronological merge
+       * ordering; game-state is a store mirror, never rendered in the action log).
+       */
+      type: 'session:game-state';
+      sessionId: string;
+      state: unknown;
       timestamp: string;
     }
   | {

--- a/apps/web/src/lib/stores/__tests__/live-session-store.test.ts
+++ b/apps/web/src/lib/stores/__tests__/live-session-store.test.ts
@@ -127,4 +127,33 @@ describe('useLiveSessionStore — Block A #2389 contract evolution', () => {
       expect(useLiveSessionStore.getState().turnOrderType).toBe(variant);
     }
   });
+
+  // #3025 L1 — opaque live game-state field
+  it('initial state — gameState is null', () => {
+    expect(useLiveSessionStore.getState().gameState).toBeNull();
+  });
+
+  it('setGameState writes an opaque object', () => {
+    const state = { round: 3, activePlayer: 'p1', dev: { catan: { longestRoad: 'p2' } } };
+    useLiveSessionStore.getState().setGameState(state);
+    expect(useLiveSessionStore.getState().gameState).toEqual(state);
+  });
+
+  it('setGameState(null) clears the value', () => {
+    useLiveSessionStore.getState().setGameState({ round: 1 });
+    useLiveSessionStore.getState().setGameState(null);
+    expect(useLiveSessionStore.getState().gameState).toBeNull();
+  });
+
+  it('setGameState replaces (not merges) the previous state', () => {
+    useLiveSessionStore.getState().setGameState({ a: 1, b: 2 });
+    useLiveSessionStore.getState().setGameState({ c: 3 });
+    expect(useLiveSessionStore.getState().gameState).toEqual({ c: 3 });
+  });
+
+  it('reset() clears gameState to null', () => {
+    useLiveSessionStore.getState().setGameState({ round: 5 });
+    useLiveSessionStore.getState().reset();
+    expect(useLiveSessionStore.getState().gameState).toBeNull();
+  });
 });

--- a/apps/web/src/lib/stores/live-session-store.ts
+++ b/apps/web/src/lib/stores/live-session-store.ts
@@ -60,6 +60,11 @@ interface LiveSessionState {
   scoringType: ScoreType | null;
   scoreData: ScoreDataByType[ScoreType] | null;
   /**
+   * #3025 L1: opaque live game-state (game-agnostic JSON). Hydrated from the REST DTO
+   * (`gameState`) + kept live by the `session:game-state` SSE event. Per-game typing is L2.
+   */
+  gameState: unknown | null;
+  /**
    * Turn order type for the session — populated from the REST DTO on initial load.
    * Static for the session lifecycle (path B, no SignalR event).
    * Null until the DTO is loaded (or if the session has no toolkit wired).
@@ -87,6 +92,8 @@ interface LiveSessionState {
     scoringType: T;
     scoreData: ScoreDataByType[T];
   }) => void;
+  /** #3025 L1: set the opaque live game-state (hydrate from DTO or a SSE update). */
+  setGameState: (next: unknown | null) => void;
   /** Sets the turn order type from the REST DTO. Issue #2483 Task 2. */
   setTurnOrderType: (type: TurnOrderType | null) => void;
   setRateLimitedUntil: (ts: number | null) => void;
@@ -102,6 +109,7 @@ const initialState: Omit<
   LiveSessionState,
   | 'setSession'
   | 'setScoringConfig'
+  | 'setGameState'
   | 'setTurnOrderType'
   | 'setRateLimitedUntil'
   | 'addProposal'
@@ -119,6 +127,7 @@ const initialState: Omit<
   players: [],
   scoringType: null,
   scoreData: null,
+  gameState: null,
   turnOrderType: null,
   rateLimitedUntil: null,
   pendingProposals: [],
@@ -137,6 +146,8 @@ export const useLiveSessionStore = create<LiveSessionState>()(
 
       setScoringConfig: ({ scoringType, scoreData }) =>
         set({ scoringType, scoreData }, false, 'setScoringConfig'),
+
+      setGameState: next => set({ gameState: next }, false, 'setGameState'),
 
       setTurnOrderType: type => set({ turnOrderType: type }, false, 'setTurnOrderType'),
 

--- a/docs/superpowers/plans/2026-07-16-g6-l1-live-game-state.md
+++ b/docs/superpowers/plans/2026-07-16-g6-l1-live-game-state.md
@@ -1,0 +1,764 @@
+# G6 Epic · L1 Live Game-State Projection+Streaming — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a generic, game-agnostic vertical slice — write → expose → stream → FE — of the existing free-form `LiveGameSession.GameState`, so L2 (per-game schemas) and L3 (rich flavors) can build on live game-state.
+
+**Architecture:** Reuse `LiveGameSession.GameState` (`JsonDocument?`, already on the live aggregate with `UpdateGameState()`). Add: a `PATCH` write endpoint + CQRS command (host-authz), a `LiveSessionGameStateEvent` domain event raised on update, a `LiveSessionStreamForwarder` handler broadcasting SSE `session:game-state`, `GameState` exposed in `LiveSessionDto`, and FE plumbing (schema + client + store slice + SSE parser/route). State stays opaque JSON (per-game typing = L2).
+
+**Tech Stack:** .NET 9 (ASP.NET Minimal APIs + MediatR + EF Core + xUnit + Moq + Testcontainers), Next.js 16 (Zustand + TanStack Query + Zod + Vitest), SSE.
+
+## Global Constraints
+
+- **CQRS (CLAUDE.md)**: endpoints use ONLY `IMediator.Send()` — no repo injection in endpoints.
+- **ADR-060**: every mutating handler calls `_unitOfWork.SaveChangesAsync(ct)` after `UpdateAsync`; domain events dispatch **post-commit** (collector drains after SaveChanges).
+- **Authz/IDOR (#2561)**: mutating game-state requires `session.IsAuthorizedParticipant(userId)` (creator or active linked player; guests `UserId==null` fail) → `ForbiddenException` (403).
+- **Exceptions (#2568)**: `NotFoundException` (404), `ConflictException` (409, on Completed session — already thrown by `UpdateGameState`), `ForbiddenException` (403). Never `InvalidOperationException` (500).
+- **Opaque schema**: `GameState` is free-form `JsonDocument` (C#) / `z.unknown()` (FE) — NO per-game validation at L1 (size cap only).
+- **`JsonDocument` disposal**: `UpdateGameState` already disposes the prior doc (`LiveGameSession.cs:836-837`); do not double-dispose.
+- **Tests**: xUnit `[Trait("Category", TestCategories.Unit)]` + `[Trait("BoundedContext","GameManagement")]`; integration `[Trait("Category", TestCategories.Integration)]` + `[Trait("Dependency","PostgreSQL")]` + `[Collection("Integration-GroupC")]`. Moq is primary. FE vitest, `data-slot` not `data-testid`.
+- **Windows**: kill testhost before BE tests; `rm -rf apps/web/.next/types` if pre-commit typecheck fails on stale types.
+- **Branch**: `feature/g6-l1-live-game-state` (parent `main-dev`, created; spec committed `19f784d6c`).
+
+## Key seams (verified)
+
+- `LiveGameSession.cs:63` `public JsonDocument? GameState`; `:824-840` `UpdateGameState(JsonDocument?, TimeProvider?)` (disposes prior); `:477` example `AddDomainEvent(...)` raise site.
+- `AggregateRoot.cs:40-43` `AddDomainEvent(IDomainEvent)`.
+- Event example: `Domain/Events/LiveSessionStartedEvent.cs`. New events go in `BoundedContexts/GameManagement/Domain/Events/`.
+- Command template: `Application/Commands/LiveSessions/AddDiaryEntryCommand.cs` + `AddDiaryEntryCommandHandler.cs` (`ILiveSessionRepository` + `IUnitOfWork`, `GetByIdAsync`→`IsAuthorizedParticipant`→domain method→`UpdateAsync`→`SaveChangesAsync`).
+- Validator template: `Application/Validators/LiveSessions/AddDiaryEntryCommandValidator.cs`.
+- Forwarder: `Application/EventHandlers/LiveSessionStreamForwarder.cs:11` (`INotificationHandler<T>` per event → `_gateway.BroadcastAsync(sessionId, new LiveSessionStreamEvent("session:X", new {...}), ct)`).
+- Gateway: `Application/Services/ILiveSessionStreamGateway.cs` — `LiveSessionStreamEvent(string Type, object Data, string? Id=null)`; `BroadcastAsync(Guid, LiveSessionStreamEvent, CancellationToken)`.
+- Mapper registry: `SessionTracking/Domain/Services/SseEventTypeMapper.cs:14-86` `EventTypeMap` dict.
+- DTO: `Application/DTOs/LiveSessions/LiveSessionDto.cs:9-33` (`internal record`); mapper `Application/Queries/LiveSessions/QueryHandlers.cs:35-93` `MapToDto` (`new LiveSessionDto(... session.Notes, session.Players.Select(...) ...)`).
+- Endpoints: `Routing/LiveSessionEndpoints.cs` — `group.MapPut("/live-sessions/{sessionId}/notes", HandleUpdateNotes)` (L198) template + handler region (457-859) + `#region Request Models`.
+- FE: `lib/session-live/use-session-live-stream.ts` (`SESSION_EVENT_TYPES` loop L254), `lib/session-live/parse-sse-event.ts` (switch L403-443, `parseScore` L76-95), `lib/session-live/sse-events.ts` (`SESSION_EVENT_TYPES` L64 + `SessionEvent` union), `lib/stores/live-session-store.ts`, `lib/api/clients/liveSessionsClient.ts`, `lib/api/schemas/live-sessions.schemas.ts`.
+
+---
+
+## Task 1: `LiveSessionGameStateEvent` domain event + raise on update
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/GameManagement/Domain/Events/LiveSessionGameStateEvent.cs`
+- Modify: `apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/LiveGameSession.cs` (`UpdateGameState`, ~L824-840)
+- Test: `apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/LiveGameSessionGameStateEventTests.cs`
+
+**Interfaces:**
+- Produces: `LiveSessionGameStateEvent(Guid SessionId, JsonDocument? State)` (a domain event). `LiveGameSession.UpdateGameState` raises it.
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+using System.Text.Json;
+using Api.BoundedContexts.GameManagement.Domain.Entities;
+using Api.BoundedContexts.GameManagement.Domain.Events;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Domain;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "GameManagement")]
+public sealed class LiveGameSessionGameStateEventTests
+{
+    [Fact]
+    public void UpdateGameState_RaisesLiveSessionGameStateEvent_WithSessionIdAndState()
+    {
+        // Arrange: build an in-progress session via the same factory the other domain tests use.
+        var session = LiveGameSessionTestFactory.CreateInProgress(); // see note below
+        using var state = JsonDocument.Parse("""{"board":"opaque"}""");
+
+        // Act
+        session.UpdateGameState(state);
+
+        // Assert
+        var evt = Assert.Single(session.DomainEvents, e => e is LiveSessionGameStateEvent);
+        var gs = Assert.IsType<LiveSessionGameStateEvent>(evt);
+        Assert.Equal(session.Id, gs.SessionId);
+        Assert.NotNull(gs.State);
+    }
+}
+```
+> Reuse the existing test factory/helper the current `LiveGameSession` domain tests use to build an InProgress session (grep `LiveGameSession` under `tests/Api.Tests/.../GameManagement/Domain` for the builder; if none, construct via the public factory `LiveGameSession.Create(...)` + `Start(...)` as those tests do). `session.DomainEvents` is the `AggregateRoot` collection.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test apps/api/tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~LiveGameSessionGameStateEventTests"`
+Expected: FAIL — `LiveSessionGameStateEvent` does not exist / no event raised.
+
+- [ ] **Step 3: Create the event + raise it**
+
+`LiveSessionGameStateEvent.cs` (mirror `LiveSessionStartedEvent.cs` — same base type it uses; read that file for the exact base class name, e.g. `DomainEventBase` / `IDomainEvent`):
+```csharp
+using System.Text.Json;
+using Api.SharedKernel.Domain.Events; // adjust to LiveSessionStartedEvent's base namespace
+
+namespace Api.BoundedContexts.GameManagement.Domain.Events;
+
+/// <summary>
+/// Raised when a live session's free-form game-state is updated (#3025 L1).
+/// Forwarded to the SSE stream as "session:game-state". State is opaque JSON.
+/// </summary>
+public sealed record LiveSessionGameStateEvent(Guid SessionId, JsonDocument? State)
+    : DomainEventBase; // match LiveSessionStartedEvent's base exactly
+```
+
+In `LiveGameSession.UpdateGameState` (after the assignment + `UpdatedAt`), add the raise:
+```csharp
+        GameState?.Dispose();
+        GameState = gameState;
+        var now = (timeProvider ?? TimeProvider.System).GetUtcNow().UtcDateTime;
+        UpdatedAt = now;
+        AddDomainEvent(new LiveSessionGameStateEvent(Id, gameState)); // #3025 L1
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dotnet test apps/api/tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~LiveGameSessionGameStateEventTests"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/GameManagement/Domain/Events/LiveSessionGameStateEvent.cs apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/LiveGameSession.cs apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/LiveGameSessionGameStateEventTests.cs
+git commit -m "feat(session-live): #3025 L1 LiveSessionGameStateEvent raised on UpdateGameState"
+```
+
+---
+
+## Task 2: `UpdateLiveGameStateCommand` + validator + handler (host-authz)
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/LiveSessions/UpdateLiveGameStateCommand.cs`
+- Create: `apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/LiveSessions/UpdateLiveGameStateCommandHandler.cs`
+- Create: `apps/api/src/Api/BoundedContexts/GameManagement/Application/Validators/LiveSessions/UpdateLiveGameStateCommandValidator.cs`
+- Test: `apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/LiveSessions/UpdateLiveGameStateCommandHandlerTests.cs`
+
+**Interfaces:**
+- Consumes: Task 1 event (raised by the domain method the handler calls).
+- Produces: `UpdateLiveGameStateCommand(Guid SessionId, Guid RequestedByUserId, JsonDocument State) : ICommand<Unit>` (or the codebase's `ICommand`/`IRequest` — mirror `AddDiaryEntryCommand`).
+
+- [ ] **Step 1: Write the failing test** (mirror `AddDiaryEntryCommandHandlerTests` / `LiveSessionCommandHandlerTests`, Moq)
+
+```csharp
+using System.Text.Json;
+using Api.BoundedContexts.GameManagement.Application.Commands.LiveSessions;
+using Api.BoundedContexts.GameManagement.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Application.Interfaces;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Application.Handlers.LiveSessions;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "GameManagement")]
+public sealed class UpdateLiveGameStateCommandHandlerTests
+{
+    private readonly Mock<ILiveSessionRepository> _repo = new();
+    private readonly Mock<IUnitOfWork> _uow = new();
+
+    private UpdateLiveGameStateCommandHandler CreateSut() => new(_repo.Object, _uow.Object);
+
+    [Fact]
+    public async Task Handle_AuthorizedParticipant_UpdatesStateAndSaves()
+    {
+        var creator = Guid.NewGuid();
+        var session = LiveGameSessionTestFactory.CreateInProgress(creator); // creator authorized
+        _repo.Setup(r => r.GetByIdAsync(session.Id, It.IsAny<CancellationToken>())).ReturnsAsync(session);
+        using var state = JsonDocument.Parse("""{"x":1}""");
+
+        await CreateSut().Handle(new UpdateLiveGameStateCommand(session.Id, creator, state), CancellationToken.None);
+
+        _repo.Verify(r => r.UpdateAsync(session, It.IsAny<CancellationToken>()), Times.Once);
+        _uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_NotFound_ThrowsNotFound()
+    {
+        _repo.Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+             .ReturnsAsync((LiveGameSession?)null);
+        using var state = JsonDocument.Parse("{}");
+        await Assert.ThrowsAsync<NotFoundException>(() =>
+            CreateSut().Handle(new UpdateLiveGameStateCommand(Guid.NewGuid(), Guid.NewGuid(), state), CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Handle_NonParticipant_ThrowsForbidden()
+    {
+        var session = LiveGameSessionTestFactory.CreateInProgress(Guid.NewGuid());
+        _repo.Setup(r => r.GetByIdAsync(session.Id, It.IsAny<CancellationToken>())).ReturnsAsync(session);
+        using var state = JsonDocument.Parse("{}");
+        await Assert.ThrowsAsync<ForbiddenException>(() =>
+            CreateSut().Handle(new UpdateLiveGameStateCommand(session.Id, Guid.NewGuid() /* stranger */, state), CancellationToken.None));
+        _uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test apps/api/tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~UpdateLiveGameStateCommandHandlerTests"`
+Expected: FAIL — command/handler don't exist.
+
+- [ ] **Step 3: Write the command + validator + handler**
+
+`UpdateLiveGameStateCommand.cs` (mirror `AddDiaryEntryCommand` — same `ICommand<T>` interface it uses):
+```csharp
+using System.Text.Json;
+using Api.SharedKernel.Application.Interfaces; // ICommand<T> — match AddDiaryEntryCommand
+
+namespace Api.BoundedContexts.GameManagement.Application.Commands.LiveSessions;
+
+/// <summary>Updates the free-form live game-state (#3025 L1). Host/participant only.</summary>
+public sealed record UpdateLiveGameStateCommand(
+    Guid SessionId,
+    Guid RequestedByUserId,
+    JsonDocument State) : ICommand<Unit>; // match AddDiaryEntryCommand's return-type convention
+```
+
+`UpdateLiveGameStateCommandValidator.cs` (mirror `AddDiaryEntryCommandValidator`):
+```csharp
+using FluentValidation;
+
+namespace Api.BoundedContexts.GameManagement.Application.Validators.LiveSessions;
+
+public sealed class UpdateLiveGameStateCommandValidator
+    : AbstractValidator<Commands.LiveSessions.UpdateLiveGameStateCommand>
+{
+    // L1 opaque state: only guard non-empty ids + a size cap (reject > 256 KB serialized).
+    public UpdateLiveGameStateCommandValidator()
+    {
+        RuleFor(x => x.SessionId).NotEmpty();
+        RuleFor(x => x.RequestedByUserId).NotEmpty();
+        RuleFor(x => x.State).NotNull()
+            .Must(s => s.RootElement.GetRawText().Length <= 256 * 1024)
+            .WithMessage("Game state exceeds the 256 KB limit.");
+    }
+}
+```
+
+`UpdateLiveGameStateCommandHandler.cs` (copy `AddDiaryEntryCommandHandler` shape verbatim):
+```csharp
+using Api.BoundedContexts.GameManagement.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Application.Interfaces;
+using MediatR;
+
+namespace Api.BoundedContexts.GameManagement.Application.Commands.LiveSessions;
+
+internal sealed class UpdateLiveGameStateCommandHandler : ICommandHandler<UpdateLiveGameStateCommand, Unit>
+{
+    private readonly ILiveSessionRepository _sessionRepository;
+    private readonly IUnitOfWork _unitOfWork;
+
+    public UpdateLiveGameStateCommandHandler(ILiveSessionRepository sessionRepository, IUnitOfWork unitOfWork)
+    {
+        _sessionRepository = sessionRepository ?? throw new ArgumentNullException(nameof(sessionRepository));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+    }
+
+    public async Task<Unit> Handle(UpdateLiveGameStateCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var session = await _sessionRepository
+            .GetByIdAsync(command.SessionId, cancellationToken)
+            .ConfigureAwait(false)
+            ?? throw new NotFoundException("LiveGameSession", command.SessionId.ToString());
+
+        if (!session.IsAuthorizedParticipant(command.RequestedByUserId))
+            throw new ForbiddenException("Only the session creator or an active participant may update game state.");
+
+        // ConflictException (Completed session) propagates → HTTP 409. Domain raises LiveSessionGameStateEvent.
+        session.UpdateGameState(command.State);
+
+        await _sessionRepository.UpdateAsync(session, cancellationToken).ConfigureAwait(false);
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        return Unit.Value;
+    }
+}
+```
+> Match `ICommand<Unit>` / `ICommandHandler<TCommand, Unit>` to the codebase convention (grep an existing `Unit`-returning command; if the codebase uses a non-MediatR `Unit`, mirror it). If `ICommand` handlers here return `Task` (void) instead of `Unit`, drop `Unit` and return `Task`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dotnet test apps/api/tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~UpdateLiveGameStateCommandHandlerTests"`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/LiveSessions/UpdateLiveGameStateCommand.cs apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/LiveSessions/UpdateLiveGameStateCommandHandler.cs apps/api/src/Api/BoundedContexts/GameManagement/Application/Validators/LiveSessions/UpdateLiveGameStateCommandValidator.cs apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/LiveSessions/UpdateLiveGameStateCommandHandlerTests.cs
+git commit -m "feat(session-live): #3025 L1 UpdateLiveGameStateCommand + host-authz handler"
+```
+
+---
+
+## Task 3: `PATCH /live-sessions/{id}/game-state` endpoint
+
+**Files:**
+- Modify: `apps/api/src/Api/Routing/LiveSessionEndpoints.cs` (register route ~L198 area; handler in region L457-859; `UpdateGameStateRequest` in `#region Request Models`)
+
+**Interfaces:**
+- Consumes: `UpdateLiveGameStateCommand` (Task 2).
+
+- [ ] **Step 1: Add the request model, route, and handler** (mirror `HandleUpdateNotes` at `LiveSessionEndpoints.cs:198`)
+
+Register (next to the other `MapPut` live-session routes):
+```csharp
+        group.MapPut("/live-sessions/{sessionId}/game-state", HandleUpdateGameState)
+            .WithName("UpdateLiveGameState")
+            .WithSummary("Update the live game-state (host/participant only).");
+```
+
+Handler (in the Command Handlers region — copy `HandleUpdateNotes`'s signature: how it reads `sessionId`, the authenticated user id, and `IMediator`):
+```csharp
+    private static async Task<IResult> HandleUpdateGameState(
+        Guid sessionId,
+        UpdateGameStateRequest request,
+        HttpContext httpContext,
+        IMediator mediator,
+        CancellationToken ct)
+    {
+        var userId = httpContext.GetAuthenticatedUserId(); // MIRROR HandleUpdateNotes's user-id extraction
+        await mediator.Send(new UpdateLiveGameStateCommand(sessionId, userId, request.State), ct);
+        return Results.NoContent();
+    }
+```
+
+Request model (`#region Request Models`):
+```csharp
+    /// <summary>Body for PATCH/PUT /live-sessions/{id}/game-state. Opaque JSON (#3025 L1).</summary>
+    internal sealed record UpdateGameStateRequest(JsonDocument State);
+```
+> `using System.Text.Json;` at the top if not present. Confirm the exact user-id extraction helper by reading `HandleUpdateNotes` (it already does auth for a mutating live-session route) and copy it verbatim.
+
+- [ ] **Step 2: Build to verify it compiles**
+
+Run: `dotnet build apps/api/src/Api/Api.csproj`
+Expected: build succeeds (endpoint + command wired). (Endpoint behaviour is covered by the Task 6 integration test — no separate unit test here.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/api/src/Api/Routing/LiveSessionEndpoints.cs
+git commit -m "feat(session-live): #3025 L1 PATCH /live-sessions/{id}/game-state endpoint"
+```
+
+---
+
+## Task 4: Stream `session:game-state` (forwarder + SseEventTypeMapper)
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/GameManagement/Application/EventHandlers/LiveSessionStreamForwarder.cs`
+- Modify: `apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Services/SseEventTypeMapper.cs` (`EventTypeMap`, L14-86)
+- Test: `apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/EventHandlers/LiveSessionStreamForwarderGameStateTests.cs`
+
+**Interfaces:**
+- Consumes: `LiveSessionGameStateEvent` (Task 1), `ILiveSessionStreamGateway`.
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+using System.Text.Json;
+using Api.BoundedContexts.GameManagement.Application.EventHandlers;
+using Api.BoundedContexts.GameManagement.Application.Services;
+using Api.BoundedContexts.GameManagement.Domain.Events;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Application.EventHandlers;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "GameManagement")]
+public sealed class LiveSessionStreamForwarderGameStateTests
+{
+    [Fact]
+    public async Task Handle_GameStateEvent_BroadcastsSessionGameState()
+    {
+        var gateway = new Mock<ILiveSessionStreamGateway>();
+        var sut = new LiveSessionStreamForwarder(gateway.Object, NullLogger<LiveSessionStreamForwarder>.Instance);
+        var sessionId = Guid.NewGuid();
+        using var state = JsonDocument.Parse("""{"k":"v"}""");
+
+        await sut.Handle(new LiveSessionGameStateEvent(sessionId, state), CancellationToken.None);
+
+        gateway.Verify(g => g.BroadcastAsync(
+            sessionId,
+            It.Is<LiveSessionStreamEvent>(e => e.Type == "session:game-state"),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test apps/api/tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~LiveSessionStreamForwarderGameStateTests"`
+Expected: FAIL — no `INotificationHandler<LiveSessionGameStateEvent>` on the forwarder.
+
+- [ ] **Step 3: Add the handler + mapper entry**
+
+In `LiveSessionStreamForwarder`, add `INotificationHandler<LiveSessionGameStateEvent>` to the class's interface list, and the handler method (mirror the `session:score` handler):
+```csharp
+    public Task Handle(LiveSessionGameStateEvent notification, CancellationToken cancellationToken)
+    {
+        _logger.LogDebug("Broadcasting session:game-state for session {SessionId}", notification.SessionId);
+        return _gateway.BroadcastAsync(
+            notification.SessionId,
+            new LiveSessionStreamEvent("session:game-state", new
+            {
+                // Opaque state forwarded as-is (L1). L3 flavors parse it per game.
+                state = notification.State,
+            }),
+            cancellationToken);
+    }
+```
+
+In `SseEventTypeMapper.EventTypeMap`, add (before the closing brace, next to `session:score`):
+```csharp
+        [typeof(LiveSessionGameStateEvent)] = "session:game-state",
+```
+> Add `using Api.BoundedContexts.GameManagement.Domain.Events;` to the mapper if not present.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dotnet test apps/api/tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~LiveSessionStreamForwarderGameStateTests"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/GameManagement/Application/EventHandlers/LiveSessionStreamForwarder.cs apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Services/SseEventTypeMapper.cs apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/EventHandlers/LiveSessionStreamForwarderGameStateTests.cs
+git commit -m "feat(session-live): #3025 L1 stream session:game-state via forwarder + mapper"
+```
+
+---
+
+## Task 5: Expose `GameState` in `LiveSessionDto` + mapper
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/LiveSessions/LiveSessionDto.cs:9-33`
+- Modify: `apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/LiveSessions/QueryHandlers.cs:35-93` (`MapToDto`)
+- Test: extend the existing `GetLiveSessionQuery` handler test (grep `GetLiveSession` tests under GameManagement) to assert `GameState` round-trips.
+
+- [ ] **Step 1: Add the DTO field**
+
+In `LiveSessionDto` record, add after `string? Notes` (L28):
+```csharp
+    string? Notes,
+    System.Text.Json.JsonDocument? GameState,
+    IReadOnlyList<LiveSessionPlayerDto> Players,
+```
+
+- [ ] **Step 2: Wire the mapper**
+
+In `QueryHandlers.cs` `MapToDto`, add `session.GameState,` in the `new LiveSessionDto(...)` call, positioned after `session.Notes,` and before `session.Players.Select(...)`:
+```csharp
+            session.Notes,
+            session.GameState,
+            session.Players.Select(/* …unchanged… */),
+```
+
+- [ ] **Step 3: Write/extend the failing test then run**
+
+Add to the existing `GetLiveSessionQueryHandler` test (or create one) a case: seed a session with a non-null `GameState`, run the query, assert `dto.GameState` is not null and round-trips the JSON.
+Run: `dotnet test apps/api/tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~GetLiveSession"`
+Expected: PASS after the mapper change (FAIL before if the assertion is added first).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/LiveSessions/LiveSessionDto.cs apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/LiveSessions/QueryHandlers.cs apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Queries/LiveSessions/
+git commit -m "feat(session-live): #3025 L1 expose GameState in LiveSessionDto + mapper"
+```
+
+---
+
+## Task 6: BE integration test (PATCH → persist → GET)
+
+**Files:**
+- Create: `apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Integration/LiveGameStateEndpointIntegrationTests.cs`
+
+- [ ] **Step 1: Write the integration test** (mirror an existing live-session endpoint integration test — grep `[Collection("Integration-GroupC")]` under GameManagement for the WebApplicationFactory client + auth-seeding helper)
+
+```csharp
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "GameManagement")]
+[Trait("Dependency", "PostgreSQL")]
+[Collection("Integration-GroupC")]
+public sealed class LiveGameStateEndpointIntegrationTests
+{
+    // Arrange: create a live session as the host (reuse the fixture's helper),
+    // PATCH /api/v1/live-sessions/{id}/game-state with { "state": { "k": 1 } } as the host,
+    // then GET /api/v1/sessions/{id}/live (or the live-session GET) and assert the returned
+    // gameState round-trips. Assert a non-participant PATCH → 403, and PATCH on a Completed
+    // session → 409. Follow the existing integration test's HttpClient + auth cookie pattern.
+}
+```
+> This is the end-to-end proof of the write→persist→expose path. Copy the fixture wiring from a sibling `[Collection("Integration-GroupC")]` live-session test verbatim; only the request/assertions are new.
+
+- [ ] **Step 2: Run (requires Docker)**
+
+Run: `dotnet test apps/api/tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~LiveGameStateEndpointIntegrationTests"`
+Expected: PASS (Docker up).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Integration/LiveGameStateEndpointIntegrationTests.cs
+git commit -m "test(session-live): #3025 L1 game-state endpoint integration (PATCH→persist→GET+403/409)"
+```
+
+---
+
+## Task 7: FE schema — `gameState` on `LiveSessionDtoSchema`
+
+**Files:**
+- Modify: `apps/web/src/lib/api/schemas/live-sessions.schemas.ts`
+- Test: `apps/web/src/lib/api/schemas/__tests__/live-sessions.schemas.test.ts` (create or extend)
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, expect, it } from 'vitest';
+import { LiveSessionDtoSchema } from '../live-sessions.schemas';
+
+describe('LiveSessionDtoSchema — gameState (#3025 L1)', () => {
+  it('accepts an opaque gameState object and a null', () => {
+    const base = { /* build a minimal valid LiveSessionDto — copy an existing fixture in this test dir */ } as const;
+    expect(LiveSessionDtoSchema.parse({ ...base, gameState: { board: 'x' } }).gameState).toEqual({ board: 'x' });
+    expect(LiveSessionDtoSchema.parse({ ...base, gameState: null }).gameState).toBeNull();
+  });
+});
+```
+> Reuse an existing valid `LiveSessionDto` fixture from the schema tests / `SessionLiveView.test.tsx` `MOCK_SESSION_DTO` shape for `base`.
+
+- [ ] **Step 2: Run → fail**
+
+Run: `pnpm --dir apps/web exec vitest run src/lib/api/schemas/__tests__/live-sessions.schemas.test.ts`
+Expected: FAIL — `gameState` stripped/rejected.
+
+- [ ] **Step 3: Add the field**
+
+In `LiveSessionDtoSchema` (add after `scoringConfig` or `notes`):
+```ts
+  gameState: z.unknown().nullable().optional(),
+```
+
+- [ ] **Step 4: Run → pass**; **Step 5: Commit**
+
+```bash
+git add apps/web/src/lib/api/schemas/live-sessions.schemas.ts apps/web/src/lib/api/schemas/__tests__/live-sessions.schemas.test.ts
+git commit -m "feat(session-live): #3025 L1 gameState on LiveSessionDtoSchema"
+```
+
+---
+
+## Task 8: FE client + mutation — `updateGameState`
+
+**Files:**
+- Modify: `apps/web/src/lib/api/clients/liveSessionsClient.ts`
+- Create: `apps/web/src/hooks/mutations/useUpdateLiveGameState.ts`
+- Test: `apps/web/src/hooks/mutations/__tests__/useUpdateLiveGameState.test.tsx`
+
+- [ ] **Step 1: Add the client method** (mirror an existing PATCH/PUT method like `updateNotes`/`configurePhases` in `liveSessionsClient.ts`)
+
+```ts
+  /** #3025 L1: update the live game-state (host/participant). */
+  async updateGameState(sessionId, state) {
+    await httpClient.put(`${BASE}/${encodeURIComponent(sessionId)}/game-state`, { state });
+  },
+```
+Add to the client interface: `updateGameState(sessionId: string, state: unknown): Promise<void>;`.
+
+- [ ] **Step 2: Add the mutation hook + test** (mirror `useUpdateSessionScores` / any live-session mutation hook)
+
+```ts
+export function useUpdateLiveGameState(sessionId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (state: unknown) => api.liveSessions.updateGameState(sessionId, state),
+    onSuccess: () => qc.invalidateQueries({ queryKey: liveSessionKeys.detail(sessionId) }),
+  });
+}
+```
+Test: mock `api.liveSessions.updateGameState`, assert the mutation calls it with the state.
+
+- [ ] **Step 3: Run → pass**; **Step 4: Commit**
+
+```bash
+git add apps/web/src/lib/api/clients/liveSessionsClient.ts apps/web/src/hooks/mutations/useUpdateLiveGameState.ts apps/web/src/hooks/mutations/__tests__/useUpdateLiveGameState.test.tsx
+git commit -m "feat(session-live): #3025 L1 updateGameState client + mutation hook"
+```
+
+---
+
+## Task 9: FE store slice — `gameState` + `setGameState`
+
+**Files:**
+- Modify: `apps/web/src/lib/stores/live-session-store.ts`
+- Test: `apps/web/src/lib/stores/__tests__/live-session-store.test.ts` (create or extend)
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+import { describe, expect, it, beforeEach } from 'vitest';
+import { useLiveSessionStore } from '../live-session-store';
+
+describe('useLiveSessionStore — gameState (#3025 L1)', () => {
+  beforeEach(() => useLiveSessionStore.getState().reset());
+  it('setGameState sets + reset clears', () => {
+    useLiveSessionStore.getState().setGameState({ board: 'x' });
+    expect(useLiveSessionStore.getState().gameState).toEqual({ board: 'x' });
+    useLiveSessionStore.getState().reset();
+    expect(useLiveSessionStore.getState().gameState).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run → fail**
+
+Run: `pnpm --dir apps/web exec vitest run src/lib/stores/__tests__/live-session-store.test.ts`
+Expected: FAIL — no `gameState`/`setGameState`.
+
+- [ ] **Step 3: Add the slice** — 4 edits mirroring `turnOrderType`/`setTurnOrderType`:
+  1. `interface LiveSessionState`: `gameState: unknown | null;` and `setGameState: (next: unknown | null) => void;`
+  2. `initialState`: `gameState: null,`
+  3. Add `'setGameState'` to the `Omit<LiveSessionState, ...>` union in the `initialState` type.
+  4. Actions: `setGameState: next => set({ gameState: next }, false, 'setGameState'),`
+
+- [ ] **Step 4: Run → pass**; **Step 5: Commit**
+
+```bash
+git add apps/web/src/lib/stores/live-session-store.ts apps/web/src/lib/stores/__tests__/live-session-store.test.ts
+git commit -m "feat(session-live): #3025 L1 gameState store slice + setGameState"
+```
+
+---
+
+## Task 10: FE SSE — parse + route `session:game-state`
+
+**Files:**
+- Modify: `apps/web/src/lib/session-live/sse-events.ts` (`SESSION_EVENT_TYPES` L64 + `SessionEvent` union)
+- Modify: `apps/web/src/lib/session-live/parse-sse-event.ts` (switch L403-443 + a `parseGameState`)
+- Test: `apps/web/src/lib/session-live/__tests__/parse-sse-event.test.ts` (extend)
+
+**Interfaces:**
+- Produces: a `SessionEvent` variant `{ type: 'session:game-state'; sessionId: string; state: unknown }`.
+
+- [ ] **Step 1: Write the failing test** (mirror the existing `parseScore` test)
+
+```ts
+it('parses a session:game-state event (#3025 L1)', () => {
+  const evt = parseSseEvent('session:game-state', JSON.stringify({ state: { board: 'x' } }), 'sess-1');
+  expect(evt).toEqual({ type: 'session:game-state', sessionId: 'sess-1', state: { board: 'x' } });
+});
+```
+> Match the actual `parseSseEvent` entry-point signature used by the sibling tests.
+
+- [ ] **Step 2: Run → fail**; **Step 3: Implement**
+
+In `sse-events.ts`: add `'session:game-state'` to `SESSION_EVENT_TYPES` and a variant to the `SessionEvent` discriminated union:
+```ts
+  | { type: 'session:game-state'; sessionId: string; state: unknown }
+```
+
+In `parse-sse-event.ts`, add the parser (mirror `parseScore` L76-95 — defensive, returns `null` on bad input) + the switch case (L443):
+```ts
+function parseGameState(data: unknown, sessionId: string): Extract<SessionEvent, { type: 'session:game-state' }> | null {
+  if (typeof data !== 'object' || data === null) return null;
+  const state = (data as { state?: unknown }).state;
+  return { type: 'session:game-state', sessionId, state: state ?? null };
+}
+// …in the switch:
+    case 'session:game-state':
+      event = parseGameState(data, resolvedSessionId);
+      break;
+```
+
+- [ ] **Step 4: Run → pass**; **Step 5: Commit**
+
+```bash
+git add apps/web/src/lib/session-live/sse-events.ts apps/web/src/lib/session-live/parse-sse-event.ts apps/web/src/lib/session-live/__tests__/parse-sse-event.test.ts
+git commit -m "feat(session-live): #3025 L1 parse + type session:game-state SSE event"
+```
+
+---
+
+## Task 11: FE wire — hydrate from DTO + route SSE event → store
+
+**Files:**
+- Modify: `apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx`
+- Test: extend `.../__tests__/SessionLiveView.test.tsx`
+
+- [ ] **Step 1: Hydrate + route**
+
+1. **Hydrate** on load: where the shell seeds the store from `sessionQuery.data` (mirror the `setScoringConfig`/`setTurnOrderType` seeding), add `useLiveSessionStore.getState().setGameState(liveSessionDto?.gameState ?? null)` in the same effect.
+2. **Route the SSE event**: where `liveStream.events` are consumed (the `composeSessionLiveState` / event effect), add handling for `type === 'session:game-state'` → `setGameState(event.state)`. If there is a central reducer over `liveStream.events`, add the case there; otherwise add an effect that scans new events for `session:game-state` and calls `setGameState`.
+
+- [ ] **Step 2: Write the test**
+
+```tsx
+it('#3025 L1 hydrates gameState from the DTO', () => {
+  useLiveSessionMock.mockReturnValue({
+    data: { ...MOCK_SESSION_DTO, gameState: { board: 'x' } } as unknown as LiveSessionDto,
+    isLoading: false, isError: false, isSuccess: true, error: null, refetch: vi.fn(),
+  });
+  renderWithIntl(<SessionLiveView />);
+  expect(useLiveSessionStore.getState().gameState).toEqual({ board: 'x' });
+});
+```
+
+- [ ] **Step 3: Run → pass**
+
+Run: `pnpm --dir apps/web exec vitest run "src/app/(authenticated)/sessions/[id]/live/_components/__tests__/SessionLiveView.test.tsx"`
+Expected: PASS + no regression (all existing tests green).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add "apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx" "apps/web/src/app/(authenticated)/sessions/[id]/live/_components/__tests__/SessionLiveView.test.tsx"
+git commit -m "feat(session-live): #3025 L1 hydrate gameState from DTO + route SSE event to store"
+```
+
+---
+
+## Task 12: Full verification + PR
+
+- [ ] **Step 1: BE quality gate**
+
+Run (kill testhost first if needed): `dotnet test apps/api/tests/Api.Tests/Api.Tests.csproj --filter "Category=Unit&BoundedContext=GameManagement"` then the integration filter with Docker up.
+Expected: all green.
+
+- [ ] **Step 2: FE quality gate**
+
+Run: `rm -rf apps/web/.next/types && pnpm --dir apps/web typecheck && pnpm --dir apps/web exec vitest run src/lib/session-live src/lib/stores src/lib/api "src/app/(authenticated)/sessions/[id]/live"`
+Expected: all green, 0 regressions.
+
+- [ ] **Step 3: Push + PR to `main-dev`**
+
+```bash
+git push -u origin feature/g6-l1-live-game-state
+gh pr create --base main-dev --title "feat(session-live): #3025 L1 live game-state projection + streaming" --body "<summary + DoD + 'opaque at L1, per-game typing = L2' + refs #3025>"
+```
+
+- [ ] **Step 4: Epic update** — tick L1 in #3025; note L2 (per-game schemas) is unblocked.
+
+## Self-Review
+
+**Spec coverage:** write (T2/T3) ✅ · expose (T5) ✅ · stream (T1 event, T4 forwarder+mapper) ✅ · FE schema (T7)/client (T8)/store (T9)/SSE (T10)/wire (T11) ✅ · opaque schema ✅ · host-entered authz/IDOR (T2) ✅ · 409-on-completed (domain, tested T6) ✅ · tests BE unit+integration + FE ✅ · out-of-scope (per-game schema/engine/undo/delta) untouched ✅.
+
+**Placeholder scan:** the remaining `> …` notes are **adapt-points against real files** (test factory name, `ICommand<Unit>` vs `Task` convention, the endpoint user-id helper, an existing DTO fixture) — each names the exact file to copy from. They are verify-seams, not TODOs. No vague "handle errors"/"add validation" steps.
+
+**Type consistency:** `LiveSessionGameStateEvent(Guid SessionId, JsonDocument? State)` consistent across T1/T2/T4. `UpdateLiveGameStateCommand(SessionId, RequestedByUserId, State)` consistent T2/T3. `gameState`/`setGameState` consistent T9/T10/T11. SSE type `"session:game-state"` consistent T4/T10.
+
+## Risks / adapt-points (confirm during implementation)
+
+1. **`ICommand`/`Unit` convention** — confirm whether GameManagement command handlers return `Unit` (MediatR) or `Task`; mirror `AddDiaryEntryCommand` (returns `Guid`) exactly for the interface, using `Unit`/void as that codebase does for no-return commands.
+2. **Domain event base** — read `LiveSessionStartedEvent.cs` for the exact base type/namespace (`DomainEventBase` vs `IDomainEvent`); match it.
+3. **Endpoint user-id extraction** — copy verbatim from `HandleUpdateNotes` (a mutating live-session route already doing auth).
+4. **Raise-in-domain vs handler** — the event is raised in `UpdateGameState` (so restore-snapshot also streams a state change — acceptable; note it). If undesired, move the raise into the command handler after `UpdateGameState` via a dedicated domain method.
+5. **FE SSE routing shape** — confirm whether `liveStream.events` go through a central reducer (add a case) or need an effect (add one) in `SessionLiveView`.
+6. **`JsonDocument` lifetime in the event** — the event holds the same `JsonDocument` the aggregate keeps; the forwarder reads it during post-commit dispatch before any next update disposes it. Fine for L1; if flakiness appears, clone the raw text into the event instead.

--- a/docs/superpowers/plans/2026-07-16-g6-l1-live-game-state.md
+++ b/docs/superpowers/plans/2026-07-16-g6-l1-live-game-state.md
@@ -61,11 +61,12 @@ namespace Api.Tests.BoundedContexts.GameManagement.Domain;
 public sealed class LiveGameSessionGameStateEventTests
 {
     [Fact]
-    public void UpdateGameState_RaisesLiveSessionGameStateEvent_WithSessionIdAndState()
+    public void UpdateGameState_RaisesLiveSessionGameStateEvent_WithSessionIdAndRawState()
     {
-        // Arrange: build an in-progress session via the same factory the other domain tests use.
-        var session = LiveGameSessionTestFactory.CreateInProgress(); // see note below
-        using var state = JsonDocument.Parse("""{"board":"opaque"}""");
+        // Arrange: build an in-progress session with the SAME inline helper the sibling
+        // domain tests use (see note below).
+        var session = CreateInProgressSession();
+        var state = JsonDocument.Parse("""{"board":"opaque"}"""); // ownership transferred to the aggregate
 
         // Act
         session.UpdateGameState(state);
@@ -74,11 +75,11 @@ public sealed class LiveGameSessionGameStateEventTests
         var evt = Assert.Single(session.DomainEvents, e => e is LiveSessionGameStateEvent);
         var gs = Assert.IsType<LiveSessionGameStateEvent>(evt);
         Assert.Equal(session.Id, gs.SessionId);
-        Assert.NotNull(gs.State);
+        Assert.Contains("\"board\"", gs.RawStateJson);
     }
 }
 ```
-> Reuse the existing test factory/helper the current `LiveGameSession` domain tests use to build an InProgress session (grep `LiveGameSession` under `tests/Api.Tests/.../GameManagement/Domain` for the builder; if none, construct via the public factory `LiveGameSession.Create(...)` + `Start(...)` as those tests do). `session.DomainEvents` is the `AggregateRoot` collection.
+> **No `LiveGameSessionTestFactory` exists.** Copy the inline `CreateInProgressSession()` helper from a sibling domain test (e.g. `tests/Api.Tests/.../GameManagement/Domain/LiveGameSession_DiaryTests.cs:31-43`): it does `var session = LiveGameSession.Create(id, creatorUserId, "Game", timeProvider); session.AddPlayer(...); session.Start(...);` (read that file for the exact `Create`/`AddPlayer`/`Start` signatures). `session.DomainEvents` is the `AggregateRoot` collection. Do NOT `using` the `JsonDocument` — `UpdateGameState` takes ownership + disposes it.
 
 - [ ] **Step 2: Run test to verify it fails**
 
@@ -87,28 +88,29 @@ Expected: FAIL — `LiveSessionGameStateEvent` does not exist / no event raised.
 
 - [ ] **Step 3: Create the event + raise it**
 
-`LiveSessionGameStateEvent.cs` (mirror `LiveSessionStartedEvent.cs` — same base type it uses; read that file for the exact base class name, e.g. `DomainEventBase` / `IDomainEvent`):
+`LiveSessionGameStateEvent.cs` (mirror `LiveSessionStartedEvent.cs` — same base type it uses; read that file for the exact base class name, e.g. `DomainEventBase` / `IDomainEvent`).
+**Carry the RAW JSON STRING, not the `JsonDocument`** — the aggregate disposes its `JsonDocument` on the next `UpdateGameState` (`LiveGameSession.cs:836-837`), so holding the object reference in a post-commit-dispatched event risks reading a disposed doc under concurrent updates. `GetRawText()` copies to an immutable string at raise time (safe):
 ```csharp
-using System.Text.Json;
-using Api.SharedKernel.Domain.Events; // adjust to LiveSessionStartedEvent's base namespace
-
 namespace Api.BoundedContexts.GameManagement.Domain.Events;
 
 /// <summary>
 /// Raised when a live session's free-form game-state is updated (#3025 L1).
-/// Forwarded to the SSE stream as "session:game-state". State is opaque JSON.
+/// Forwarded to the SSE stream as "session:game-state". RawStateJson is the opaque
+/// state serialized to a string (copied at raise time to avoid JsonDocument lifetime issues).
+/// NB: fires on EVERY UpdateGameState call — including snapshot-restore (plan risk #4);
+/// streaming a restored state to live clients is intentional/transparent.
 /// </summary>
-public sealed record LiveSessionGameStateEvent(Guid SessionId, JsonDocument? State)
+public sealed record LiveSessionGameStateEvent(Guid SessionId, string? RawStateJson)
     : DomainEventBase; // match LiveSessionStartedEvent's base exactly
 ```
 
-In `LiveGameSession.UpdateGameState` (after the assignment + `UpdatedAt`), add the raise:
+In `LiveGameSession.UpdateGameState` (after the assignment + `UpdatedAt`), add the raise (copy the raw text BEFORE the aggregate could dispose it later):
 ```csharp
         GameState?.Dispose();
         GameState = gameState;
         var now = (timeProvider ?? TimeProvider.System).GetUtcNow().UtcDateTime;
         UpdatedAt = now;
-        AddDomainEvent(new LiveSessionGameStateEvent(Id, gameState)); // #3025 L1
+        AddDomainEvent(new LiveSessionGameStateEvent(Id, gameState?.RootElement.GetRawText())); // #3025 L1
 ```
 
 - [ ] **Step 4: Run test to verify it passes**
@@ -159,15 +161,16 @@ public sealed class UpdateLiveGameStateCommandHandlerTests
 
     private UpdateLiveGameStateCommandHandler CreateSut() => new(_repo.Object, _uow.Object);
 
+    private static JsonElement State(string json) => JsonDocument.Parse(json).RootElement;
+
     [Fact]
     public async Task Handle_AuthorizedParticipant_UpdatesStateAndSaves()
     {
         var creator = Guid.NewGuid();
-        var session = LiveGameSessionTestFactory.CreateInProgress(creator); // creator authorized
+        var session = CreateInProgressSession(creator); // creator authorized — inline helper (Task 1 note)
         _repo.Setup(r => r.GetByIdAsync(session.Id, It.IsAny<CancellationToken>())).ReturnsAsync(session);
-        using var state = JsonDocument.Parse("""{"x":1}""");
 
-        await CreateSut().Handle(new UpdateLiveGameStateCommand(session.Id, creator, state), CancellationToken.None);
+        await CreateSut().Handle(new UpdateLiveGameStateCommand(session.Id, creator, State("""{"x":1}""")), CancellationToken.None);
 
         _repo.Verify(r => r.UpdateAsync(session, It.IsAny<CancellationToken>()), Times.Once);
         _uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
@@ -178,23 +181,22 @@ public sealed class UpdateLiveGameStateCommandHandlerTests
     {
         _repo.Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
              .ReturnsAsync((LiveGameSession?)null);
-        using var state = JsonDocument.Parse("{}");
         await Assert.ThrowsAsync<NotFoundException>(() =>
-            CreateSut().Handle(new UpdateLiveGameStateCommand(Guid.NewGuid(), Guid.NewGuid(), state), CancellationToken.None));
+            CreateSut().Handle(new UpdateLiveGameStateCommand(Guid.NewGuid(), Guid.NewGuid(), State("{}")), CancellationToken.None));
     }
 
     [Fact]
     public async Task Handle_NonParticipant_ThrowsForbidden()
     {
-        var session = LiveGameSessionTestFactory.CreateInProgress(Guid.NewGuid());
+        var session = CreateInProgressSession(Guid.NewGuid());
         _repo.Setup(r => r.GetByIdAsync(session.Id, It.IsAny<CancellationToken>())).ReturnsAsync(session);
-        using var state = JsonDocument.Parse("{}");
         await Assert.ThrowsAsync<ForbiddenException>(() =>
-            CreateSut().Handle(new UpdateLiveGameStateCommand(session.Id, Guid.NewGuid() /* stranger */, state), CancellationToken.None));
+            CreateSut().Handle(new UpdateLiveGameStateCommand(session.Id, Guid.NewGuid() /* stranger */, State("{}")), CancellationToken.None));
         _uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
     }
 }
 ```
+> `CreateInProgressSession(Guid creator)` = the inline helper from Task 1's note. `System.Text.Json` `using` at the top.
 
 - [ ] **Step 2: Run test to verify it fails**
 
@@ -211,10 +213,12 @@ using Api.SharedKernel.Application.Interfaces; // ICommand<T> — match AddDiary
 namespace Api.BoundedContexts.GameManagement.Application.Commands.LiveSessions;
 
 /// <summary>Updates the free-form live game-state (#3025 L1). Host/participant only.</summary>
+/// <remarks>State is a JsonElement (binds cleanly from the request body; no JsonDocument
+/// disposal concern). The handler parses it into an owned JsonDocument for the aggregate.</remarks>
 public sealed record UpdateLiveGameStateCommand(
     Guid SessionId,
     Guid RequestedByUserId,
-    JsonDocument State) : ICommand<Unit>; // match AddDiaryEntryCommand's return-type convention
+    JsonElement State) : ICommand<Unit>; // match AddDiaryEntryCommand's return-type convention
 ```
 
 `UpdateLiveGameStateCommandValidator.cs` (mirror `AddDiaryEntryCommandValidator`):
@@ -226,13 +230,14 @@ namespace Api.BoundedContexts.GameManagement.Application.Validators.LiveSessions
 public sealed class UpdateLiveGameStateCommandValidator
     : AbstractValidator<Commands.LiveSessions.UpdateLiveGameStateCommand>
 {
-    // L1 opaque state: only guard non-empty ids + a size cap (reject > 256 KB serialized).
+    // L1 opaque state: only guard non-empty ids + a size cap (reject > 256 KB of UTF-8).
+    // GetRawText() is a UTF-16 .NET string — count UTF-8 BYTES for an accurate limit.
     public UpdateLiveGameStateCommandValidator()
     {
         RuleFor(x => x.SessionId).NotEmpty();
         RuleFor(x => x.RequestedByUserId).NotEmpty();
-        RuleFor(x => x.State).NotNull()
-            .Must(s => s.RootElement.GetRawText().Length <= 256 * 1024)
+        RuleFor(x => x.State)
+            .Must(s => System.Text.Encoding.UTF8.GetByteCount(s.GetRawText()) <= 256 * 1024)
             .WithMessage("Game state exceeds the 256 KB limit.");
     }
 }
@@ -270,8 +275,11 @@ internal sealed class UpdateLiveGameStateCommandHandler : ICommandHandler<Update
         if (!session.IsAuthorizedParticipant(command.RequestedByUserId))
             throw new ForbiddenException("Only the session creator or an active participant may update game state.");
 
+        // Parse the JsonElement into an OWNED JsonDocument. UpdateGameState takes ownership
+        // (stores it + disposes the prior). Do NOT wrap in `using` — the aggregate owns it now.
+        var doc = System.Text.Json.JsonDocument.Parse(command.State.GetRawText());
         // ConflictException (Completed session) propagates → HTTP 409. Domain raises LiveSessionGameStateEvent.
-        session.UpdateGameState(command.State);
+        session.UpdateGameState(doc);
 
         await _sessionRepository.UpdateAsync(session, cancellationToken).ConfigureAwait(false);
         await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
@@ -312,27 +320,27 @@ Register (next to the other `MapPut` live-session routes):
             .WithSummary("Update the live game-state (host/participant only).");
 ```
 
-Handler (in the Command Handlers region — copy `HandleUpdateNotes`'s signature: how it reads `sessionId`, the authenticated user id, and `IMediator`):
+Handler (in the Command Handlers region — copy **`HandleAddDiaryEntry`** which DOES extract the user id via `httpContext.User.GetUserId()`; `HandleUpdateNotes` does NOT take an `HttpContext`, so it is the wrong template for an authz'd route):
 ```csharp
     private static async Task<IResult> HandleUpdateGameState(
         Guid sessionId,
-        UpdateGameStateRequest request,
+        [FromBody] UpdateGameStateRequest request,
         HttpContext httpContext,
         IMediator mediator,
         CancellationToken ct)
     {
-        var userId = httpContext.GetAuthenticatedUserId(); // MIRROR HandleUpdateNotes's user-id extraction
+        var userId = httpContext.User.GetUserId(); // MIRROR HandleAddDiaryEntry exactly
         await mediator.Send(new UpdateLiveGameStateCommand(sessionId, userId, request.State), ct);
         return Results.NoContent();
     }
 ```
 
-Request model (`#region Request Models`):
+Request model (`#region Request Models`) — **`JsonElement`** (binds cleanly from the body; no `JsonDocument` disposal concern):
 ```csharp
-    /// <summary>Body for PATCH/PUT /live-sessions/{id}/game-state. Opaque JSON (#3025 L1).</summary>
-    internal sealed record UpdateGameStateRequest(JsonDocument State);
+    /// <summary>Body for PUT /live-sessions/{id}/game-state. Opaque JSON (#3025 L1).</summary>
+    internal sealed record UpdateGameStateRequest(JsonElement State);
 ```
-> `using System.Text.Json;` at the top if not present. Confirm the exact user-id extraction helper by reading `HandleUpdateNotes` (it already does auth for a mutating live-session route) and copy it verbatim.
+> `using System.Text.Json;` + `using Microsoft.AspNetCore.Mvc;` (for `[FromBody]`) at the top if not present. Read `HandleAddDiaryEntry` (a mutating live-session route) for the exact `httpContext.User.GetUserId()` call + `IResult` return convention and copy it verbatim.
 
 - [ ] **Step 2: Build to verify it compiles**
 
@@ -381,9 +389,8 @@ public sealed class LiveSessionStreamForwarderGameStateTests
         var gateway = new Mock<ILiveSessionStreamGateway>();
         var sut = new LiveSessionStreamForwarder(gateway.Object, NullLogger<LiveSessionStreamForwarder>.Instance);
         var sessionId = Guid.NewGuid();
-        using var state = JsonDocument.Parse("""{"k":"v"}""");
 
-        await sut.Handle(new LiveSessionGameStateEvent(sessionId, state), CancellationToken.None);
+        await sut.Handle(new LiveSessionGameStateEvent(sessionId, """{"k":"v"}"""), CancellationToken.None);
 
         gateway.Verify(g => g.BroadcastAsync(
             sessionId,
@@ -405,22 +412,25 @@ In `LiveSessionStreamForwarder`, add `INotificationHandler<LiveSessionGameStateE
     public Task Handle(LiveSessionGameStateEvent notification, CancellationToken cancellationToken)
     {
         _logger.LogDebug("Broadcasting session:game-state for session {SessionId}", notification.SessionId);
+        // JsonDocument is NOT serializable by System.Text.Json (throws) AND the aggregate's
+        // doc may already be disposed. The event carries the raw JSON string; re-parse into a
+        // JsonNode (serializable, not disposable) so `state` serializes as a nested OBJECT
+        // (not an escaped string) for the FE.
+        var stateNode = notification.RawStateJson is null
+            ? null
+            : System.Text.Json.Nodes.JsonNode.Parse(notification.RawStateJson);
         return _gateway.BroadcastAsync(
             notification.SessionId,
-            new LiveSessionStreamEvent("session:game-state", new
-            {
-                // Opaque state forwarded as-is (L1). L3 flavors parse it per game.
-                state = notification.State,
-            }),
+            new LiveSessionStreamEvent("session:game-state", new { state = stateNode }),
             cancellationToken);
     }
 ```
 
-In `SseEventTypeMapper.EventTypeMap`, add (before the closing brace, next to `session:score`):
+In `SseEventTypeMapper.EventTypeMap`, add (before the closing brace, next to `session:score`) — the file already has a `using GameNightEvents = Api.BoundedContexts.GameManagement.Domain.Events;` alias, so reference the event through it (or add a direct `using`):
 ```csharp
-        [typeof(LiveSessionGameStateEvent)] = "session:game-state",
+        [typeof(GameNightEvents.LiveSessionGameStateEvent)] = "session:game-state",
 ```
-> Add `using Api.BoundedContexts.GameManagement.Domain.Events;` to the mapper if not present.
+> If you add a direct `using Api.BoundedContexts.GameManagement.Domain.Events;`, use `typeof(LiveSessionGameStateEvent)` instead. Match whichever import style the file already uses to avoid an ambiguity.
 
 - [ ] **Step 4: Run test to verify it passes**
 
@@ -445,19 +455,19 @@ git commit -m "feat(session-live): #3025 L1 stream session:game-state via forwar
 
 - [ ] **Step 1: Add the DTO field**
 
-In `LiveSessionDto` record, add after `string? Notes` (L28):
+In `LiveSessionDto` record, add after `string? Notes` (L28). Use **`JsonElement?`** (System.Text.Json serializes `JsonElement` reliably on the response; a raw `JsonDocument` can throw):
 ```csharp
     string? Notes,
-    System.Text.Json.JsonDocument? GameState,
+    System.Text.Json.JsonElement? GameState,
     IReadOnlyList<LiveSessionPlayerDto> Players,
 ```
 
 - [ ] **Step 2: Wire the mapper**
 
-In `QueryHandlers.cs` `MapToDto`, add `session.GameState,` in the `new LiveSessionDto(...)` call, positioned after `session.Notes,` and before `session.Players.Select(...)`:
+In `QueryHandlers.cs` `MapToDto`, add `session.GameState?.RootElement,` in the `new LiveSessionDto(...)` call (positional — after `session.Notes,`, before `session.Players.Select(...)`). `session.GameState` is `JsonDocument?`; `?.RootElement` yields the `JsonElement?` the DTO now expects:
 ```csharp
             session.Notes,
-            session.GameState,
+            session.GameState?.RootElement,
             session.Players.Select(/* …unchanged… */),
 ```
 
@@ -488,16 +498,44 @@ git commit -m "feat(session-live): #3025 L1 expose GameState in LiveSessionDto +
 [Trait("BoundedContext", "GameManagement")]
 [Trait("Dependency", "PostgreSQL")]
 [Collection("Integration-GroupC")]
-public sealed class LiveGameStateEndpointIntegrationTests
+public sealed class LiveGameStateEndpointIntegrationTests : /* extend the sibling base, e.g. */ IntegrationTestBase
 {
-    // Arrange: create a live session as the host (reuse the fixture's helper),
-    // PATCH /api/v1/live-sessions/{id}/game-state with { "state": { "k": 1 } } as the host,
-    // then GET /api/v1/sessions/{id}/live (or the live-session GET) and assert the returned
-    // gameState round-trips. Assert a non-participant PATCH → 403, and PATCH on a Completed
-    // session → 409. Follow the existing integration test's HttpClient + auth cookie pattern.
+    public LiveGameStateEndpointIntegrationTests(IntegrationTestFixture fixture) : base(fixture) { }
+
+    [Fact]
+    public async Task UpdateGameState_AsHost_PersistsAndIsReturnedByGet()
+    {
+        // Arrange: authenticate as a host + create a live session (copy the exact helpers a
+        // sibling live-session integration test uses — SeedUser/LoginClient/CreateLiveSession).
+        var (client, hostUserId) = await AuthenticateHostAsync();
+        var sessionId = await CreateLiveSessionAsync(client);
+
+        // Act: PATCH the game-state.
+        var patch = await client.PutAsJsonAsync(
+            $"/api/v1/live-sessions/{sessionId}/game-state",
+            new { state = new { k = 1 } });
+
+        // Assert: 204 + round-trips on GET.
+        Assert.Equal(HttpStatusCode.NoContent, patch.StatusCode);
+        var dto = await client.GetFromJsonAsync<JsonElement>($"/api/v1/live-sessions/{sessionId}");
+        Assert.Equal(1, dto.GetProperty("gameState").GetProperty("k").GetInt32());
+    }
+
+    [Fact]
+    public async Task UpdateGameState_AsNonParticipant_Returns403()
+    {
+        var (hostClient, _) = await AuthenticateHostAsync();
+        var sessionId = await CreateLiveSessionAsync(hostClient);
+        var strangerClient = await AuthenticateOtherUserAsync();
+
+        var patch = await strangerClient.PutAsJsonAsync(
+            $"/api/v1/live-sessions/{sessionId}/game-state", new { state = new { k = 1 } });
+
+        Assert.Equal(HttpStatusCode.Forbidden, patch.StatusCode);
+    }
 }
 ```
-> This is the end-to-end proof of the write→persist→expose path. Copy the fixture wiring from a sibling `[Collection("Integration-GroupC")]` live-session test verbatim; only the request/assertions are new.
+> This is the end-to-end proof of the write→persist→expose path. **Copy the base class, fixture ctor, and the `AuthenticateHostAsync`/`CreateLiveSessionAsync`/`AuthenticateOtherUserAsync` helpers verbatim from a sibling `[Collection("Integration-GroupC")]` live-session integration test** (grep for one that creates a live session over HTTP); only the two test bodies above are new. Confirm the GET route + the JSON casing (`gameState`) the API returns.
 
 - [ ] **Step 2: Run (requires Docker)**
 
@@ -668,9 +706,10 @@ In `sse-events.ts`: add `'session:game-state'` to `SESSION_EVENT_TYPES` and a va
 In `parse-sse-event.ts`, add the parser (mirror `parseScore` L76-95 — defensive, returns `null` on bad input) + the switch case (L443):
 ```ts
 function parseGameState(data: unknown, sessionId: string): Extract<SessionEvent, { type: 'session:game-state' }> | null {
-  if (typeof data !== 'object' || data === null) return null;
-  const state = (data as { state?: unknown }).state;
-  return { type: 'session:game-state', sessionId, state: state ?? null };
+  // Require a 'state' key — a malformed event (missing 'state') returns null (ignored),
+  // rather than silently masking it as null state.
+  if (typeof data !== 'object' || data === null || !('state' in data)) return null;
+  return { type: 'session:game-state', sessionId, state: (data as { state: unknown }).state };
 }
 // …in the switch:
     case 'session:game-state':
@@ -761,4 +800,4 @@ gh pr create --base main-dev --title "feat(session-live): #3025 L1 live game-sta
 3. **Endpoint user-id extraction** — copy verbatim from `HandleUpdateNotes` (a mutating live-session route already doing auth).
 4. **Raise-in-domain vs handler** — the event is raised in `UpdateGameState` (so restore-snapshot also streams a state change — acceptable; note it). If undesired, move the raise into the command handler after `UpdateGameState` via a dedicated domain method.
 5. **FE SSE routing shape** — confirm whether `liveStream.events` go through a central reducer (add a case) or need an effect (add one) in `SessionLiveView`.
-6. **`JsonDocument` lifetime in the event** — the event holds the same `JsonDocument` the aggregate keeps; the forwarder reads it during post-commit dispatch before any next update disposes it. Fine for L1; if flakiness appears, clone the raw text into the event instead.
+6. **`JsonDocument` handling — RESOLVED (plan review)**: the event carries the **raw JSON string** (`RootElement.GetRawText()`, copied at raise time) — not the disposable `JsonDocument` — so no disposed-doc race. The forwarder re-parses to a `JsonNode` (serializable, non-disposable) for the SSE payload; the read DTO exposes `JsonElement?` (serializable). The request binds `JsonElement`; the handler parses to an owned `JsonDocument` (ownership transferred to the aggregate — no `using`). This threads System.Text.Json's `JsonDocument`-not-serializable + lifetime pitfalls end-to-end.

--- a/docs/superpowers/specs/2026-07-16-g6-l1-live-game-state-projection-design.md
+++ b/docs/superpowers/specs/2026-07-16-g6-l1-live-game-state-projection-design.md
@@ -1,0 +1,99 @@
+# Design — G6 Epic · L1: Live game-state projection + streaming (generic)
+
+**Track**: G6 per-game rich flavors — **Layer 1 of 3** (L1 generic mechanism → L2 per-game schemas → L3 rich flavors)
+**Parent epic**: [#3025](https://github.com/meepleAi-app/meepleai-monorepo/issues/3025) — Per-game live game-state (backend layer for rich G6 session flavors)
+**Date**: 2026-07-16
+**Status**: design — awaiting user review before writing-plans
+**Scope**: BE (.NET) + FE (Next.js), game-agnostic
+
+---
+
+## 1. Why this exists (the pivot)
+
+Discovery (recon of the 6 remaining G6 mockups #2788–2793) showed every per-game flavor's rich UI (Catan hex board, Codenames word grid, Power Grid market, …) needs **game-specific live state that the `LiveSessionDto` does not carry**. Without it, the 6 MVP flavors collapse to the same themed leaderboard (Catan's) — low-value chrome. Decision: **build the backend live game-state layer first**, then rich flavors faithful to the mockups.
+
+That layer decomposes into 3 independently-shippable pieces:
+- **L1 (this spec)** — a **generic, game-agnostic** mechanism to write, persist, expose, and **stream** an opaque live game-state blob to `/sessions/[id]/live`.
+- **L2** — per-game state **schemas** (the JSON shape each game writes) + per-game host-edit surfaces. One cycle per game.
+- **L3** — per-game **rich flavor** components (FE) that parse L2 state + render faithfully to the mockups. One cycle per game.
+
+L1 keeps the state **opaque** (free-form JSON). L2/L3 add per-game typing. This spec is L1 only.
+
+## 2. Discovery (verified)
+
+- **Container already exists**: `LiveGameSession.GameState` — a `JsonDocument?` (free-form, nullable, mutable) on the **live aggregate the shell loads**, with `UpdateGameState(JsonDocument?)` (`LiveGameSession.cs:828`, disposes prior doc to avoid ArrayPool starvation) + optimistic concurrency via Postgres `xmin`. Same `sessionId` throughout.
+- **Separate snapshot model** (`GameSessionState` + `GameStateSnapshot`, #2403) is for **undo/history**, has its own REST endpoints, and is **NOT** the live state. L1 does **not** touch it.
+- **Write path gap**: `LiveGameSession.GameState` is currently written **only** by `RestoreSessionSnapshotCommandHandler` — there is **no host-editing endpoint** for live play. (The vision `GET /game-state` route is AI-extraction, unrelated.)
+- **Cardinal question answered**: `UpdateGameState` takes the JSON **from the caller** → **host/client-entered, no server game engine**. L3 flavors get host-edit surfaces (like the score editor). Moderate cost, not an engine.
+- **Not exposed**: `LiveSessionDto` mapper (`QueryHandlers.cs` `MapToDto`) **ignores** `GameState`; the SSE stream context does not carry it.
+- **Streaming infra is proven**: SSE `/live-sessions/{id}/stream` via `LiveSessionStreamForwarder` (`INotificationHandler<T>`) → `ILiveSessionStreamGateway.BroadcastAsync(sessionId, new LiveSessionStreamEvent("session:<type>", payload), ct)` + `SseEventTypeMapper`. The **Whiteboard** feature already streams live state exactly this way. Also a SignalR hub path exists.
+- **FE gaps**: no `gameState` slice / `setGameState` in `useLiveSessionStore`; no `session:game-state` SSE consumer; `api.liveSessions` has no live game-state methods (only `getPhases`, tools, snapshots).
+
+## 3. Locked decisions
+
+| # | Decision |
+|---|---|
+| Container | **Reuse `LiveGameSession.GameState`** (not a new aggregate, not `GameSessionState` snapshots, not ToolState) |
+| Schema | **Opaque `JsonDocument` / `unknown` at L1** — per-game typing is L2 |
+| Write path | **Host/client-entered** generic PATCH (no engine); L1 adds the missing generic write command+endpoint |
+| Streaming | Follow the proven `LiveSessionStreamForwarder` → `ILiveSessionStreamGateway` SSE pattern (event `session:game-state`) |
+| Undo/history | Out of scope (the separate `GameStateSnapshot` model); L1 does not integrate it |
+
+## 4. Architecture — the L1 vertical slice (write → expose → stream → FE)
+
+### BE
+1. **Write command** — `UpdateLiveGameStateCommand(Guid sessionId, JsonDocument state)` + handler: load `LiveGameSession`, `session.UpdateGameState(state)`, `AddAsync`/`UpdateAsync` + **`await _unitOfWork.SaveChangesAsync(ct)`** (per ADR-060), then the domain event dispatches **post-commit**. Authorization: host/participant only (mirror the score-update authz + IDOR guard). Opaque state — no schema validation at L1 (size cap only, e.g. reject > N KB).
+2. **Endpoint** — `PATCH /api/v1/live-sessions/{id}/game-state` (CQRS: `IMediator.Send`), body `{ state: <json> }`. Follows the existing live-session endpoints file + auth pattern.
+3. **Domain event** — `GameStateUpdatedDomainEvent(Guid sessionId, JsonDocument state)` (carries the new state so the forwarder needs no re-fetch) raised by `LiveGameSession.UpdateGameState` (or the handler), dispatched post-`SaveChanges`.
+4. **Stream forwarder** — `INotificationHandler<GameStateUpdatedDomainEvent>` → `_gateway.BroadcastAsync(sessionId, new LiveSessionStreamEvent("session:game-state", payload), ct)`. Add `session:game-state` to `SseEventTypeMapper`. Payload = the current `GameState` JSON (full-document; delta/JSON-Patch is a future optimization, not L1).
+5. **Expose on read** — add `GameState` (nullable `JsonDocument`) to `LiveSessionDto` + wire it in `MapToDto` (`QueryHandlers.cs`) so the initial `GET /sessions/[id]/live` hydration carries the current state.
+
+### FE
+6. **Schema** — add `gameState: z.unknown().nullable()` to `LiveSessionDtoSchema` (`live-sessions.schemas.ts`).
+7. **Client + hooks** — `api.liveSessions.updateGameState(sessionId, state)` (PATCH) + optionally `getGameState`; a `useUpdateLiveGameState` mutation (host). Read hydrates from `useLiveSession` (the DTO now carries `gameState`).
+8. **Store slice** — add `gameState: unknown | null` + `setGameState(next)` to `useLiveSessionStore` (mirror the `scoreData`/`setScoringConfig` slice + the `local/no-store-scores-direct`-style discipline).
+9. **SSE consumer** — the existing live SSE consumer handles the new `session:game-state` event → `setGameState(payload)`. Initial value hydrated from the DTO; SSE keeps it live (REST-hydration race guard like the score path).
+
+**Boundary**: L1 ships an **opaque** state end-to-end (a host can PATCH arbitrary JSON, spectators see it live in the store) but renders **nothing game-specific** — no flavor consumes it yet. A tiny dev-only "raw game-state" debug view (behind a flag) MAY be added to prove the pipe; production rendering is L3.
+
+## 5. Out of scope (explicit)
+
+- Per-game state **schemas** / typed contracts (L2).
+- Per-game **rich flavor** rendering (L3).
+- A server-side **game engine** / auto-progression (confirmed not the model — host-entered).
+- **Undo/history** integration with `GameSessionState`/`GameStateSnapshot` (separate model).
+- **Delta / JSON-Patch** streaming (L1 sends full document; optimize later if payloads grow).
+- **Schema validation** of the state shape (opaque at L1; L2 validates per game).
+
+## 6. Error / edge handling
+
+- Update on a `Completed` session → `ConflictException` (409) (already enforced by `UpdateGameState`).
+- Concurrency: `xmin` optimistic — on conflict return 409 (host retries with latest).
+- Null/empty state → allowed (clears the state); FE renders nothing.
+- Oversized payload → 413/400 with a size cap.
+- SSE reconnect → the DTO re-hydration + Last-Event-ID resume already handle it; the store re-seeds from the DTO.
+- IDOR: only session host/participants may PATCH (authz guard + test, mirroring the score IDOR fix).
+
+## 7. Testing
+
+- **BE unit**: `UpdateLiveGameStateCommandHandler` (success, completed→409, authz/IDOR, save-then-event ordering); `GameStateUpdatedDomainEvent` forwarder → gateway broadcast; `MapToDto` includes `GameState`.
+- **BE integration** (Testcontainers): PATCH game-state → persisted → `GET /sessions/[id]/live` returns it; event → SSE broadcast (assert the forwarder fires).
+- **FE unit**: schema parses `gameState`; store `setGameState`; the SSE consumer routes `session:game-state` → `setGameState`; `useUpdateLiveGameState` mutation.
+- **FE E2E skeleton**: host PATCHes state → (mock SSE) store updates. (The rich rendering E2E is L3.)
+
+## 8. Definition of Done (L1)
+
+- [ ] `PATCH /live-sessions/{id}/game-state` writes `LiveGameSession.GameState` (host authz + IDOR + 409 on completed) with `SaveChangesAsync`.
+- [ ] `GameStateUpdatedDomainEvent` streams as SSE `session:game-state` via the forwarder + `SseEventTypeMapper`.
+- [ ] `GameState` exposed in `LiveSessionDto` + FE schema; hydrated on load.
+- [ ] `useLiveSessionStore` `gameState` slice + `setGameState`; SSE consumer wired; `api.liveSessions` client + mutation.
+- [ ] Opaque end-to-end (no game-specific rendering); tests green; 0 regressions; ADR-060 SaveChanges discipline honored.
+- [ ] Epic checklist updated; L2 (per-game schemas) unblocked.
+
+## 9. Risks / adapt-points (confirm in the plan)
+
+1. **Exact SSE forwarder seam** — confirm `ILiveSessionStreamGateway` + `LiveSessionStreamEvent` signatures + the `SseEventTypeMapper` registration (copy the Whiteboard streaming handler).
+2. **Domain-event dispatch** — confirm the post-commit dispatch path (ADR-060) and whether `LiveGameSession` already raises events elsewhere to mirror.
+3. **Authz/IDOR** — reuse the score-update authorization + IDOR guard (the HIGH finding fixed in `c1efb4fb6`).
+4. **Live-session endpoints file** — confirm the exact routing file for `/live-sessions/{id}/*` to add the PATCH route.
+5. **SignalR vs SSE** — L1 uses SSE (the forwarder pattern); confirm whether the FE live consumer is SSE or SignalR for this session surface and wire the matching side.


### PR DESCRIPTION
## L1 — Generic live game-state projection + streaming (epic #3025)

First layer of the per-game live game-state stack: the **write → persist → expose → stream → FE** vertical slice for the opaque `LiveGameSession.GameState`, game-agnostic. Unblocks L2 (per-game schemas) and L3 (rich flavors) for all 6 G6 games.

**Spec:** `docs/superpowers/specs/2026-07-16-g6-l1-live-game-state-projection-design.md`
**Plan:** `docs/superpowers/plans/2026-07-16-g6-l1-live-game-state.md`

### What changed

**Backend** (`dfc671760`)
- `LiveSessionGameStateEvent` domain event (carries the **raw JSON string**, not a `JsonDocument`, to dodge `System.Text.Json` dispose/serialization pitfalls) raised by `LiveGameSession.UpdateGameState`.
- `UpdateLiveGameStateCommand` + handler (`ICommandHandler`, no return): `NotFoundException` (404) → `IsAuthorizedParticipant`/`ForbiddenException` (403) IDOR guard → `UpdateGameState` → `SaveChangesAsync` (ADR-060). Validator caps the payload at 256 KiB **UTF-8 bytes**.
- `PUT /api/v1/live-sessions/{sessionId}/game-state` — `.RequireAuthenticatedUser().RequireLiveSessionParticipant()`, 204/403/404/409.
- `LiveSessionStreamForwarder` re-parses the raw string to a `JsonNode` and broadcasts `session:game-state` `{ state }` over the existing SSE gateway.
- `LiveSessionDto.GameState` (`JsonElement?`) exposed on `GET /{id}`.

**Frontend** (`15e178155`)
- `LiveSessionDtoSchema.gameState` (optional/nullable, back-compat).
- `liveSessionsClient.updateGameState` + `useUpdateLiveGameState` mutation hook.
- `useLiveSessionStore` `gameState` slice + `setGameState` — the store mirror L3 flavors read.
- `session:game-state` SSE variant (uniform `timestamp`) + `parseGameState`.
- `SessionLiveView` effect: hydrates `gameState` from the DTO, latest SSE event wins. `composeSessionLiveState` ignores it via its `default` no-op (store mirror, not an action-log entry).

**Tests** (`91bb90327` + inline)
- BE: 9 new unit (event/handler/validator/forwarder/query) + 2 integration (`LiveGameStateEndpointIntegrationTests`: creator PUT→persist→GET round-trip + non-participant 403).
- FE: store, parser, schema, mutation hook (~30 assertions). SessionLiveView suite 121/121, typecheck clean.

### Verification
- BE: build 0 errors; 169 `GameState` unit + 18 DTO-impacted handler unit + 2 integration all green.
- FE: `tsc --noEmit` clean; affected vitest 242/242.

### Scope
L1 only — opaque state, no per-game typing (L2) and no rich rendering (L3). No server game engine: state is host/client-entered (like the score editor).

Part of #3025.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
