### PR TITLE
feat(notifications): drain orphaned email queue items (issue 3026)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Services/IEmailTemplateService.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Services/IEmailTemplateService.cs
@@ -25,4 +25,15 @@ internal interface IEmailTemplateService
     /// Renders email template for admin manual notification.
     /// </summary>
     string RenderAdminNotification(string userName, string title, string message);
+
+    /// <summary>
+    /// Renders a generic branded notification email: title heading + greeting + body paragraph,
+    /// with an optional "Open in MeepleAI" deep-link CTA button. Used by GenericEmailBuilder (issue #3026)
+    /// to render notification-queue email items that have no dedicated per-type template.
+    /// </summary>
+    /// <param name="userName">Recipient display name (or email) for the greeting.</param>
+    /// <param name="title">Friendly notification title, used as the heading and subject.</param>
+    /// <param name="bodyText">Human-readable body paragraph.</param>
+    /// <param name="deepLinkPath">Optional relative path; when present a CTA button links to it.</param>
+    string RenderGenericNotification(string userName, string title, string bodyText, string? deepLinkPath);
 }

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/DependencyInjection/UserNotificationsServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/DependencyInjection/UserNotificationsServiceExtensions.cs
@@ -1,6 +1,7 @@
 using Api.BoundedContexts.UserNotifications.Application.Services;
 using Api.BoundedContexts.UserNotifications.Domain.Repositories;
 using Api.BoundedContexts.UserNotifications.Infrastructure.Configuration;
+using Api.BoundedContexts.UserNotifications.Infrastructure.Email;
 using Api.BoundedContexts.UserNotifications.Infrastructure.Persistence;
 using Api.BoundedContexts.UserNotifications.Infrastructure.Scheduling;
 using Api.BoundedContexts.UserNotifications.Infrastructure.Services;
@@ -50,6 +51,11 @@ internal static class UserNotificationsServiceExtensions
         services.AddSingleton<ISlackMessageBuilder, BadgeSlackBuilder>();
         services.AddSingleton<ISlackMessageBuilder, AdminAlertSlackBuilder>();
         services.AddSingleton<SlackMessageBuilderFactory>();
+
+        // Email message builders (issue #3026). MVP ships only the generic fallback; register per-type
+        // IEmailMessageBuilder implementations here later — the factory resolves them automatically.
+        services.AddSingleton<GenericEmailBuilder>();
+        services.AddSingleton<EmailMessageBuilderFactory>();
 
         // Named HttpClient for Slack API with 10s timeout and circuit breaker.
         // Circuit breaker opens after 5 consecutive 5xx/timeout errors, stays open 2 minutes.
@@ -143,6 +149,23 @@ internal static class UserNotificationsServiceExtensions
                 .WithIdentity("slack-notification-processor-trigger", "notifications")
                 .WithCronSchedule("0/10 * * * * ?")
                 .WithDescription("Processes queued Slack notifications with rate limiting"));
+        });
+
+        // Issue #3026: Email notification processor job - every 30 seconds.
+        // Drains channel_type=email items from notification_queue_items (previously orphaned — nothing
+        // consumed that channel). 30s cadence matches the sibling email-delivery EmailProcessorJob:
+        // email is not latency-critical, and a slower tick keeps SMTP throughput/backoff sane.
+        services.AddQuartz(q =>
+        {
+            q.AddJob<EmailNotificationProcessorJob>(opts => opts
+                .WithIdentity("email-notification-processor-job", "notifications")
+                .StoreDurably(true));
+
+            q.AddTrigger(opts => opts
+                .ForJob("email-notification-processor-job", "notifications")
+                .WithIdentity("email-notification-processor-trigger", "notifications")
+                .WithCronSchedule("0/30 * * * * ?")  // Every 30 seconds
+                .WithDescription("Processes queued email notifications (notification_queue_items, channel=email)"));
         });
 
         // ISSUE-40: Dead letter monitor job - hourly

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Email/EmailMessageBuilderFactory.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Email/EmailMessageBuilderFactory.cs
@@ -1,0 +1,26 @@
+using Api.BoundedContexts.UserNotifications.Domain.ValueObjects;
+
+namespace Api.BoundedContexts.UserNotifications.Infrastructure.Email;
+
+/// <summary>
+/// Resolves the correct <see cref="IEmailMessageBuilder"/> for a given <see cref="NotificationType"/>.
+/// Falls back to <see cref="GenericEmailBuilder"/> for unhandled types.
+/// Mirrors <c>SlackMessageBuilderFactory</c> so richer per-payload-type email builders can be added
+/// later without touching the processor job (issue #3026).
+/// </summary>
+internal sealed class EmailMessageBuilderFactory
+{
+    private readonly IEnumerable<IEmailMessageBuilder> _builders;
+    private readonly GenericEmailBuilder _fallback;
+
+    public EmailMessageBuilderFactory(IEnumerable<IEmailMessageBuilder> builders, GenericEmailBuilder fallback)
+    {
+        _builders = builders;
+        _fallback = fallback;
+    }
+
+    public IEmailMessageBuilder GetBuilder(NotificationType type)
+    {
+        return _builders.FirstOrDefault(b => b.CanHandle(type)) ?? _fallback;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Email/GenericEmailBuilder.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Email/GenericEmailBuilder.cs
@@ -1,0 +1,45 @@
+using Api.BoundedContexts.UserNotifications.Application.Services;
+using Api.BoundedContexts.UserNotifications.Domain.ValueObjects;
+
+namespace Api.BoundedContexts.UserNotifications.Infrastructure.Email;
+
+/// <summary>
+/// Fallback email builder for notification types without a dedicated per-type builder (MVP, issue #3026).
+/// Subject = friendly title from <see cref="NotificationTitleResolver"/>; body = <c>GenericPayload.Body</c>
+/// when present, else the title, wrapped in the branded shell with an optional deep-link CTA button.
+/// Always returns false from <see cref="CanHandle"/> — used only as the factory fallback, mirroring
+/// <c>GenericSlackBuilder</c>.
+/// </summary>
+internal sealed class GenericEmailBuilder : IEmailMessageBuilder
+{
+    private readonly IEmailTemplateService _templateService;
+
+    public GenericEmailBuilder(IEmailTemplateService templateService)
+    {
+        _templateService = templateService ?? throw new ArgumentNullException(nameof(templateService));
+    }
+
+    /// <summary>
+    /// Always false: the factory selects this builder only as the fallback, never via CanHandle.
+    /// </summary>
+    public bool CanHandle(NotificationType type) => false;
+
+    public EmailMessage BuildMessage(EmailBuildContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        var subject = NotificationTitleResolver.ResolveTitle(context.Type);
+
+        // Prefer the human-readable body carried by GenericPayload; typed payloads (share request,
+        // game night, badge, …) have no generic prose, so fall back to the friendly title. A future
+        // per-type IEmailMessageBuilder can render those richly (mirrors the per-type Slack builders).
+        var bodyText = context.Payload is GenericPayload generic && !string.IsNullOrWhiteSpace(generic.Body)
+            ? generic.Body
+            : subject;
+
+        var htmlBody = _templateService.RenderGenericNotification(
+            context.RecipientName, subject, bodyText, context.DeepLinkPath);
+
+        return new EmailMessage(subject, htmlBody);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Email/IEmailMessageBuilder.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Email/IEmailMessageBuilder.cs
@@ -1,0 +1,41 @@
+using Api.BoundedContexts.UserNotifications.Domain.ValueObjects;
+
+namespace Api.BoundedContexts.UserNotifications.Infrastructure.Email;
+
+/// <summary>
+/// Context passed to an <see cref="IEmailMessageBuilder"/> to render a notification into email content.
+/// </summary>
+/// <param name="Type">The notification type (drives subject/title resolution).</param>
+/// <param name="Payload">The polymorphic notification payload carrying per-type data.</param>
+/// <param name="DeepLinkPath">Optional relative deep-link path used to build an "Open in MeepleAI" CTA.</param>
+/// <param name="RecipientName">Display name (or email) used for the greeting.</param>
+internal sealed record EmailBuildContext(
+    NotificationType Type,
+    INotificationPayload Payload,
+    string? DeepLinkPath,
+    string RecipientName);
+
+/// <summary>
+/// Rendered email content: subject line + branded HTML body, ready for
+/// <c>IEmailService.SendRawEmailAsync</c>.
+/// </summary>
+internal sealed record EmailMessage(string Subject, string HtmlBody);
+
+/// <summary>
+/// Renders a notification (type + payload + deep link) into an <see cref="EmailMessage"/>.
+/// Mirrors <c>ISlackMessageBuilder</c>: <see cref="EmailMessageBuilderFactory"/> resolves the correct
+/// builder per <see cref="NotificationType"/>, falling back to <c>GenericEmailBuilder</c> (issue #3026).
+/// </summary>
+internal interface IEmailMessageBuilder
+{
+    /// <summary>
+    /// Returns true when this builder produces a dedicated email layout for the given type.
+    /// The generic fallback returns false (selected only when no specific builder matches).
+    /// </summary>
+    bool CanHandle(NotificationType type);
+
+    /// <summary>
+    /// Builds the subject + HTML body for the given notification context.
+    /// </summary>
+    EmailMessage BuildMessage(EmailBuildContext context);
+}

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Email/NotificationTitleResolver.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Email/NotificationTitleResolver.cs
@@ -1,0 +1,59 @@
+using Api.BoundedContexts.UserNotifications.Domain.ValueObjects;
+
+namespace Api.BoundedContexts.UserNotifications.Infrastructure.Email;
+
+/// <summary>
+/// Resolves a human-readable title for a <see cref="NotificationType"/>, used as the email subject
+/// by <see cref="GenericEmailBuilder"/> (issue #3026).
+///
+/// NOTE: this intentionally mirrors the private <c>ResolveTitle</c> map in
+/// <c>NotificationDispatcher</c>. Issue #3026 scoped the fix to add the missing email-channel
+/// processor with ZERO changes to the dispatcher, so the map is duplicated here rather than
+/// extracted. A follow-up cleanup should unify both call sites onto this resolver.
+/// </summary>
+internal static class NotificationTitleResolver
+{
+    public static string ResolveTitle(NotificationType type)
+    {
+        if (type == NotificationType.DocumentReady) return "Documento pronto";
+        if (type == NotificationType.RuleSpecGenerated) return "Specifiche generate";
+        if (type == NotificationType.DocumentProcessingFailed) return "Elaborazione fallita";
+        if (type == NotificationType.ShareRequestCreated) return "Nuova Share Request";
+        if (type == NotificationType.ShareRequestApproved) return "Share Request approvata";
+        if (type == NotificationType.ShareRequestRejected) return "Share Request rifiutata";
+        if (type == NotificationType.ShareRequestChangesRequested) return "Modifiche richieste";
+        if (type == NotificationType.BadgeEarned) return "Badge ottenuto";
+        if (type == NotificationType.GameNightInvitation) return "Invito Serata";
+        if (type == NotificationType.GameNightRsvpReceived) return "RSVP ricevuto";
+        if (type == NotificationType.GameNightReminder) return "Promemoria Serata";
+        if (type == NotificationType.GameNightCancelled) return "Serata annullata";
+        if (type == NotificationType.AgentReady) return "Agente pronto";
+        if (type == NotificationType.AgentCreationFailed) return "Creazione agent fallita";
+        if (type == NotificationType.LoanReminder) return "Promemoria prestito";
+        if (type == NotificationType.RateLimitApproaching) return "Quota in avvicinamento";
+        if (type == NotificationType.RateLimitReached) return "Quota raggiunta";
+        if (type == NotificationType.SessionTerminated) return "Sessione terminata";
+        if (type == NotificationType.GdprDataExportReady) return "Export dati pronto";
+        if (type == NotificationType.GdprAccountDeleted) return "Account eliminato";
+        if (type == NotificationType.GdprAiConsentUpdated) return "Consenso AI aggiornato";
+        if (type == NotificationType.SlackConnectionRevoked) return "Slack disconnesso";
+        if (type == NotificationType.MechanicAnalysisReady) return "Analisi meccaniche pronta";
+        if (type == NotificationType.MechanicAnalysisRejected) return "Analisi meccaniche rifiutata";
+
+        // Admin types
+        if (type == NotificationType.AdminNewShareRequest) return "[Admin] Nuova Share Request";
+        if (type == NotificationType.AdminStaleShareRequests) return "[Admin] Share Request in attesa";
+        if (type == NotificationType.AdminReviewLockExpiring) return "[Admin] Lock revisione in scadenza";
+        if (type == NotificationType.AdminSharedGameSubmitted) return "[Admin] Gioco condiviso inviato";
+        if (type == NotificationType.AdminOpenRouterThresholdAlert) return "[Admin] Soglia OpenRouter";
+        if (type == NotificationType.AdminOpenRouterDailySummary) return "[Admin] Digest giornaliero";
+        if (type == NotificationType.AdminSystemHealthAlert) return "[Admin] Alerta sistema";
+        if (type == NotificationType.AdminModelStatusChanged) return "[Admin] Stato modello cambiato";
+        if (type == NotificationType.AdminAccessRequestCreated) return "[Admin] Nuova richiesta accesso";
+        if (type == NotificationType.AdminManualNotification) return "[Admin] Notifica manuale";
+        if (type == NotificationType.AdminPdfProcessingStarted) return "[Admin] Elaborazione PDF avviata";
+        if (type == NotificationType.AdminMechanicCardSuppressed) return "[Admin] Scheda Meccanica Soppressa";
+
+        return "Notifica MeepleAI";
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Scheduling/EmailNotificationProcessorJob.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Scheduling/EmailNotificationProcessorJob.cs
@@ -1,0 +1,217 @@
+using Api.BoundedContexts.UserNotifications.Domain.Aggregates;
+using Api.BoundedContexts.UserNotifications.Domain.Repositories;
+using Api.BoundedContexts.UserNotifications.Domain.ValueObjects;
+using Api.BoundedContexts.UserNotifications.Infrastructure.Email;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Quartz;
+
+namespace Api.BoundedContexts.UserNotifications.Infrastructure.Scheduling;
+
+/// <summary>
+/// Quartz.NET job for processing queued EMAIL notifications from the shared
+/// <c>notification_queue_items</c> table (channel_type=email).
+///
+/// Issue #3026: prior to this job, <c>NotificationDispatcher</c> enqueued email-channel items into
+/// <c>notification_queue_items</c> but the only drainer of that table
+/// (<c>SlackNotificationProcessorJob</c>) fetched Slack channels only — so email items were orphaned
+/// and never sent (310 stuck on staging). This job mirrors the Slack processor: it drains pending
+/// Email items, resolves the recipient address, renders via <see cref="EmailMessageBuilderFactory"/>,
+/// and sends via <c>IEmailService.SendRawEmailAsync</c>. Reuses the <see cref="NotificationQueueItem"/>
+/// retry/dead-letter state machine.
+/// </summary>
+[DisallowConcurrentExecution]
+internal sealed class EmailNotificationProcessorJob : IJob
+{
+    private readonly INotificationQueueRepository _queueRepository;
+    private readonly EmailMessageBuilderFactory _builderFactory;
+    private readonly IEmailService _emailService;
+    private readonly MeepleAiDbContext _dbContext;
+    private readonly ILogger<EmailNotificationProcessorJob> _logger;
+
+    private const int BatchSize = 10;
+
+    public EmailNotificationProcessorJob(
+        INotificationQueueRepository queueRepository,
+        EmailMessageBuilderFactory builderFactory,
+        IEmailService emailService,
+        MeepleAiDbContext dbContext,
+        ILogger<EmailNotificationProcessorJob> logger)
+    {
+        _queueRepository = queueRepository ?? throw new ArgumentNullException(nameof(queueRepository));
+        _builderFactory = builderFactory ?? throw new ArgumentNullException(nameof(builderFactory));
+        _emailService = emailService ?? throw new ArgumentNullException(nameof(emailService));
+        _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task Execute(IJobExecutionContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+
+        _logger.LogDebug("Starting email notification processor job: FireTime={FireTime}", context.FireTimeUtc);
+
+        var sentCount = 0;
+        var failedCount = 0;
+        var deadLetteredCount = 0;
+
+        try
+        {
+            var pending = await _queueRepository
+                .GetPendingByChannelAsync(NotificationChannelType.Email, BatchSize, context.CancellationToken)
+                .ConfigureAwait(false);
+
+            if (pending.Count == 0)
+            {
+                _logger.LogDebug("No pending email notifications to process");
+                context.Result = new { Success = true, Sent = 0, Failed = 0, DeadLettered = 0 };
+                return;
+            }
+
+            _logger.LogInformation("Processing {Count} pending email notifications", pending.Count);
+
+            // Batch-resolve recipient addresses to avoid an N+1 lookup per item
+            // (mirrors SendManualNotificationCommandHandler's email-resolution pattern).
+            var userIds = pending
+                .Where(i => i.RecipientUserId.HasValue)
+                .Select(i => i.RecipientUserId!.Value)
+                .Distinct()
+                .ToList();
+
+            var recipientsById = await _dbContext.Set<UserEntity>()
+                .AsNoTracking()
+                .Where(u => userIds.Contains(u.Id))
+                .Select(u => new { u.Id, u.Email, u.DisplayName })
+                .ToDictionaryAsync(u => u.Id, u => (u.Email, u.DisplayName), context.CancellationToken)
+                .ConfigureAwait(false);
+
+            foreach (var item in pending)
+            {
+                if (context.CancellationToken.IsCancellationRequested)
+                    break;
+
+                try
+                {
+                    item.MarkAsProcessing();
+                    await _queueRepository.UpdateAsync(item, context.CancellationToken).ConfigureAwait(false);
+                    await _dbContext.SaveChangesAsync(context.CancellationToken).ConfigureAwait(false);
+
+                    string? address = null;
+                    string? displayName = null;
+                    if (item.RecipientUserId.HasValue
+                        && recipientsById.TryGetValue(item.RecipientUserId.Value, out var recipient))
+                    {
+                        address = recipient.Email;
+                        displayName = recipient.DisplayName;
+                    }
+
+                    if (string.IsNullOrWhiteSpace(address))
+                    {
+                        // No address on file: dead-letter this one item (do NOT crash the batch).
+                        await DeadLetterAsync(
+                            item,
+                            $"No email address on file for recipient user {item.RecipientUserId}",
+                            context.CancellationToken).ConfigureAwait(false);
+                        deadLetteredCount++;
+                        continue;
+                    }
+
+                    var builder = _builderFactory.GetBuilder(item.NotificationType);
+                    var email = builder.BuildMessage(new EmailBuildContext(
+                        item.NotificationType,
+                        item.Payload,
+                        item.DeepLinkPath,
+                        string.IsNullOrWhiteSpace(displayName) ? address : displayName));
+
+                    await _emailService
+                        .SendRawEmailAsync(address, email.Subject, email.HtmlBody, context.CancellationToken)
+                        .ConfigureAwait(false);
+
+                    item.MarkAsSent(DateTime.UtcNow);
+                    await _queueRepository.UpdateAsync(item, context.CancellationToken).ConfigureAwait(false);
+                    await _dbContext.SaveChangesAsync(context.CancellationToken).ConfigureAwait(false);
+
+                    sentCount++;
+                    _logger.LogInformation(
+                        "Email notification {ItemId} sent successfully to user {UserId}",
+                        item.Id, item.RecipientUserId);
+                }
+#pragma warning disable CA1031 // best-effort delivery: a single item's failure must not abort the batch
+                catch (Exception ex)
+#pragma warning restore CA1031
+                {
+                    failedCount++;
+                    _logger.LogError(
+                        ex, "Failed to send email notification {ItemId} to user {UserId}",
+                        item.Id, item.RecipientUserId);
+                    await HandleFailureAsync(item, ex.Message, context.CancellationToken).ConfigureAwait(false);
+                }
+            }
+
+            _logger.LogInformation(
+                "Email notification processor completed: Sent={Sent}, Failed={Failed}, DeadLettered={DeadLettered}",
+                sentCount, failedCount, deadLetteredCount);
+
+            context.Result = new { Success = true, Sent = sentCount, Failed = failedCount, DeadLettered = deadLetteredCount };
+        }
+#pragma warning disable CA1031 // top-level guard: a job must never surface an unhandled exception to Quartz
+        catch (Exception ex)
+#pragma warning restore CA1031
+        {
+            _logger.LogError(ex, "Email notification processor job failed");
+            context.Result = new { Success = false, Error = ex.Message };
+        }
+    }
+
+    /// <summary>
+    /// Dead-letters a single item (no further retries) and persists the transition. Self-contained:
+    /// swallows its own persistence errors so it never propagates into the per-item catch (which would
+    /// otherwise try to MarkAsFailed on an already dead-lettered item).
+    /// </summary>
+    private async Task DeadLetterAsync(NotificationQueueItem item, string reason, CancellationToken ct)
+    {
+        try
+        {
+            item.MarkAsDeadLetter(reason);
+            await _queueRepository.UpdateAsync(item, ct).ConfigureAwait(false);
+            await _dbContext.SaveChangesAsync(ct).ConfigureAwait(false);
+            _logger.LogWarning("Email notification {ItemId} dead-lettered: {Reason}", item.Id, reason);
+        }
+#pragma warning disable CA1031
+        catch (Exception ex)
+#pragma warning restore CA1031
+        {
+            _logger.LogError(ex, "Failed to dead-letter email notification {ItemId}", item.Id);
+        }
+    }
+
+    /// <summary>
+    /// Records a delivery failure with exponential-backoff retry scheduling (escalating to dead letter
+    /// after MaxRetries). Mirrors SlackNotificationProcessorJob.HandleFailureAsync.
+    /// </summary>
+    private async Task HandleFailureAsync(NotificationQueueItem item, string errorMessage, CancellationToken ct)
+    {
+        try
+        {
+            item.MarkAsFailed(errorMessage);
+            await _queueRepository.UpdateAsync(item, ct).ConfigureAwait(false);
+            await _dbContext.SaveChangesAsync(ct).ConfigureAwait(false);
+
+            if (item.Status.IsDeadLetter)
+            {
+                _logger.LogWarning(
+                    "Email notification {ItemId} moved to dead letter after {RetryCount} retries",
+                    item.Id, item.RetryCount);
+            }
+        }
+#pragma warning disable CA1031
+        catch (Exception updateEx)
+#pragma warning restore CA1031
+        {
+            _logger.LogError(updateEx, "Failed to update email notification {ItemId} status after failure", item.Id);
+        }
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Services/EmailTemplateService.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Services/EmailTemplateService.cs
@@ -136,6 +136,34 @@ internal sealed class EmailTemplateService : IEmailTemplateService
         return WrapInBaseTemplate($"{Escape(title)} - MeepleAI", content);
     }
 
+    public string RenderGenericNotification(string userName, string title, string bodyText, string? deepLinkPath)
+    {
+        var cta = string.Empty;
+        if (!string.IsNullOrWhiteSpace(deepLinkPath))
+        {
+            var url = $"{_frontendBaseUrl.TrimEnd('/')}{deepLinkPath}";
+            cta = $@"
+        <div style=""text-align: center; margin: 30px 0;"">
+            <a href=""{Escape(url)}"" style=""background-color: #2c3e50; color: white; padding: 12px 30px; text-decoration: none; border-radius: 5px; display: inline-block; font-weight: bold;"">Open in MeepleAI</a>
+        </div>";
+        }
+
+        var content = $@"
+        <div style=""background-color: #f8f9fa; padding: 20px; border-radius: 8px; border: 2px solid #2c3e50; margin-bottom: 20px;"">
+            <h2 style=""color: #2c3e50; margin-top: 0;"">{Escape(title)}</h2>
+        </div>
+
+        <p>Hello {Escape(userName)},</p>
+
+        <p>{Escape(bodyText)}</p>
+        {cta}
+        <p style=""margin-top: 30px; padding-top: 20px; border-top: 1px solid #e0e0e0; font-size: 14px; color: #666;"">
+            You are receiving this because of your MeepleAI notification settings.
+        </p>";
+
+        return WrapInBaseTemplate($"{title} - MeepleAI", content);
+    }
+
     private string WrapInBaseTemplate(string title, string content)
     {
         var preferencesUrl = $"{_frontendBaseUrl}/settings/notifications";

--- a/apps/api/tests/Api.Tests/BoundedContexts/UserNotifications/Infrastructure/Email/EmailMessageBuilderTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/UserNotifications/Infrastructure/Email/EmailMessageBuilderTests.cs
@@ -1,0 +1,87 @@
+using Api.BoundedContexts.UserNotifications.Domain.ValueObjects;
+using Api.BoundedContexts.UserNotifications.Infrastructure.Email;
+using Api.BoundedContexts.UserNotifications.Infrastructure.Services;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.UserNotifications.Infrastructure.Email;
+
+/// <summary>
+/// Unit tests for the email builder layer (issue #3026): the generic MVP builder and the factory
+/// fallback resolution. Mirrors the Slack builder tests.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "UserNotifications")]
+public class EmailMessageBuilderTests
+{
+    private static GenericEmailBuilder CreateBuilder()
+    {
+        var templateService = new EmailTemplateService(new ConfigurationBuilder().Build());
+        return new GenericEmailBuilder(templateService);
+    }
+
+    [Fact]
+    public void BuildMessage_GenericPayload_UsesFriendlyTitleAsSubject_AndPayloadBody_WithCta()
+    {
+        // Arrange
+        var builder = CreateBuilder();
+        var context = new EmailBuildContext(
+            NotificationType.ShareRequestCreated,
+            new GenericPayload("ignored-title", "Please review the pending share request."),
+            "/share-requests/9",
+            "Alice");
+
+        // Act
+        var message = builder.BuildMessage(context);
+
+        // Assert — subject is the friendly ResolveTitle mapping (not the C# type name)
+        message.Subject.Should().Be("Nuova Share Request");
+        message.HtmlBody.Should().Contain("Please review the pending share request.");
+        message.HtmlBody.Should().Contain("Open in MeepleAI");   // CTA present because deep link supplied
+        message.HtmlBody.Should().Contain("Alice");              // greeting uses recipient name
+    }
+
+    [Fact]
+    public void BuildMessage_TypedPayloadWithoutDeepLink_FallsBackToTitleBody_NoCta_NoTypeDump()
+    {
+        // Arrange
+        var builder = CreateBuilder();
+        var context = new EmailBuildContext(
+            NotificationType.DocumentReady,
+            new PdfProcessingPayload(Guid.NewGuid(), "catan.pdf", "Ready"),
+            DeepLinkPath: null,
+            RecipientName: "Bob");
+
+        // Act
+        var message = builder.BuildMessage(context);
+
+        // Assert
+        message.Subject.Should().Be("Documento pronto");
+        message.HtmlBody.Should().Contain("Documento pronto");
+        message.HtmlBody.Should().NotContain("Open in MeepleAI");      // no deep link => no CTA
+        message.HtmlBody.Should().NotContain("PdfProcessingPayload");  // never leak the C# record dump
+    }
+
+    [Fact]
+    public void CanHandle_AlwaysFalse_UsedOnlyAsFallback()
+    {
+        var builder = CreateBuilder();
+        builder.CanHandle(NotificationType.ShareRequestCreated).Should().BeFalse();
+        builder.CanHandle(NotificationType.DocumentReady).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Factory_WithNoSpecificBuilders_ResolvesGenericFallback()
+    {
+        // Arrange
+        var generic = CreateBuilder();
+        var factory = new EmailMessageBuilderFactory(Enumerable.Empty<IEmailMessageBuilder>(), generic);
+
+        // Act
+        var resolved = factory.GetBuilder(NotificationType.GameNightInvitation);
+
+        // Assert
+        resolved.Should().BeSameAs(generic);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/UserNotifications/Infrastructure/Scheduling/EmailNotificationProcessorJobTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/UserNotifications/Infrastructure/Scheduling/EmailNotificationProcessorJobTests.cs
@@ -1,0 +1,211 @@
+using Api.BoundedContexts.UserNotifications.Domain.Aggregates;
+using Api.BoundedContexts.UserNotifications.Domain.Repositories;
+using Api.BoundedContexts.UserNotifications.Domain.ValueObjects;
+using Api.BoundedContexts.UserNotifications.Infrastructure.Email;
+using Api.BoundedContexts.UserNotifications.Infrastructure.Scheduling;
+using Api.BoundedContexts.UserNotifications.Infrastructure.Services;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Services;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Quartz;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.UserNotifications.Infrastructure.Scheduling;
+
+/// <summary>
+/// Unit tests for <see cref="EmailNotificationProcessorJob"/> (issue #3026).
+/// Verifies the job drains the Email channel of notification_queue_items, renders via the generic
+/// builder, sends via IEmailService.SendRawEmailAsync with the resolved recipient + friendly subject,
+/// and drives the queue-item state machine (Sent / Failed-retry / dead-letter on missing address).
+/// Mirrors SlackNotificationProcessorJobTests.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "UserNotifications")]
+#pragma warning disable S3881
+public class EmailNotificationProcessorJobTests : IDisposable
+#pragma warning restore S3881
+{
+    private readonly Mock<INotificationQueueRepository> _queueRepoMock = new();
+    private readonly Mock<IEmailService> _emailServiceMock = new();
+    private readonly MeepleAiDbContext _dbContext;
+    private readonly Mock<ILogger<EmailNotificationProcessorJob>> _loggerMock = new();
+    private readonly Mock<IJobExecutionContext> _jobContextMock = new();
+    private bool _disposed;
+
+    public EmailNotificationProcessorJobTests()
+    {
+        _dbContext = TestDbContextFactory.CreateInMemoryDbContext();
+        _jobContextMock.Setup(c => c.FireTimeUtc).Returns(DateTimeOffset.UtcNow);
+        _jobContextMock.Setup(c => c.CancellationToken).Returns(CancellationToken.None);
+    }
+
+    public void Dispose()
+    {
+        if (!_disposed)
+        {
+            _dbContext.Dispose();
+            _disposed = true;
+        }
+    }
+
+    private EmailNotificationProcessorJob CreateSut()
+    {
+        var templateService = new EmailTemplateService(new ConfigurationBuilder().Build());
+        var genericBuilder = new GenericEmailBuilder(templateService);
+        var builderFactory = new EmailMessageBuilderFactory(
+            Enumerable.Empty<IEmailMessageBuilder>(), genericBuilder);
+
+        return new EmailNotificationProcessorJob(
+            _queueRepoMock.Object,
+            builderFactory,
+            _emailServiceMock.Object,
+            _dbContext,
+            _loggerMock.Object);
+    }
+
+    private async Task SeedUserAsync(Guid userId, string email, string? displayName)
+    {
+        _dbContext.Set<UserEntity>().Add(new UserEntity { Id = userId, Email = email, DisplayName = displayName });
+        await _dbContext.SaveChangesAsync(TestContext.Current.CancellationToken);
+    }
+
+    private static NotificationQueueItem CreateEmailItem(
+        Guid recipientUserId,
+        NotificationType? type = null,
+        INotificationPayload? payload = null,
+        string? deepLinkPath = "/share-requests/1")
+    {
+        return NotificationQueueItem.Create(
+            channelType: NotificationChannelType.Email,
+            recipientUserId: recipientUserId,
+            notificationType: type ?? NotificationType.ShareRequestCreated,
+            payload: payload ?? new GenericPayload("Share request", "You have a pending share request."),
+            deepLinkPath: deepLinkPath);
+    }
+
+    private void SetupPending(params NotificationQueueItem[] items)
+    {
+        _queueRepoMock
+            .Setup(r => r.GetPendingByChannelAsync(NotificationChannelType.Email, 10, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(items.ToList());
+    }
+
+    [Fact]
+    public async Task Execute_PendingEmailItem_ResolvesRecipient_SendsRawEmail_MarksSent()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        await SeedUserAsync(userId, "alice@example.com", "Alice");
+        var item = CreateEmailItem(
+            userId,
+            NotificationType.ShareRequestCreated,
+            new GenericPayload("t", "Please review the pending share request."),
+            "/share-requests/9");
+        SetupPending(item);
+
+        var sut = CreateSut();
+
+        // Act
+        await sut.Execute(_jobContextMock.Object);
+
+        // Assert — fetched the EMAIL channel specifically
+        _queueRepoMock.Verify(
+            r => r.GetPendingByChannelAsync(NotificationChannelType.Email, 10, It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        // Sent via SendRawEmailAsync with resolved To + friendly subject + rendered body
+        _emailServiceMock.Verify(
+            s => s.SendRawEmailAsync(
+                "alice@example.com",
+                "Nuova Share Request",
+                It.Is<string>(b =>
+                    b.Contains("Please review the pending share request.") && b.Contains("Open in MeepleAI")),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        item.Status.IsSent.Should().BeTrue();
+        // processing + sent => two persistence transitions
+        _queueRepoMock.Verify(
+            r => r.UpdateAsync(item, It.IsAny<CancellationToken>()),
+            Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task Execute_SendThrows_MarksFailedForRetry_NotDeadLetter()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        await SeedUserAsync(userId, "bob@example.com", "Bob");
+        var item = CreateEmailItem(userId);
+        SetupPending(item);
+
+        _emailServiceMock
+            .Setup(s => s.SendRawEmailAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("smtp relay unavailable"));
+
+        var sut = CreateSut();
+
+        // Act
+        await sut.Execute(_jobContextMock.Object);
+
+        // Assert — first failure schedules a retry, does not dead-letter (MaxRetries = 3)
+        item.Status.IsFailed.Should().BeTrue();
+        item.RetryCount.Should().Be(1);
+        _emailServiceMock.Verify(
+            s => s.SendRawEmailAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+        // processing + failed => two persistence transitions
+        _queueRepoMock.Verify(
+            r => r.UpdateAsync(item, It.IsAny<CancellationToken>()),
+            Times.Exactly(2));
+    }
+
+    [Fact]
+    public async Task Execute_RecipientHasNoEmailOnFile_DeadLetters_WithoutSending()
+    {
+        // Arrange — recipient user is NOT seeded, so no address can be resolved
+        var userId = Guid.NewGuid();
+        var item = CreateEmailItem(userId);
+        SetupPending(item);
+
+        var sut = CreateSut();
+
+        // Act
+        await sut.Execute(_jobContextMock.Object);
+
+        // Assert — never attempts SMTP, dead-letters with a clear reason (does not crash the batch)
+        _emailServiceMock.Verify(
+            s => s.SendRawEmailAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        item.Status.IsDeadLetter.Should().BeTrue();
+        item.LastError.Should().Contain("No email address");
+    }
+
+    [Fact]
+    public async Task Execute_NoPendingItems_DoesNothing()
+    {
+        // Arrange
+        SetupPending();
+        var sut = CreateSut();
+
+        // Act
+        await sut.Execute(_jobContextMock.Object);
+
+        // Assert
+        _emailServiceMock.Verify(
+            s => s.SendRawEmailAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _queueRepoMock.Verify(
+            r => r.UpdateAsync(It.IsAny<NotificationQueueItem>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+}


### PR DESCRIPTION
## Fix routing: drain orphaned email notifications (issue 3026)

Emerso durante il cutover 2772 (investigazione 503-degraded). **Opzione A** (scelta dopo l'escape-hatch dell'analisi: B richiedeva lo stesso renderer + un refactor hot-path del dispatcher, A no).

### Problema
`NotificationDispatcher` enqueue le email in `notification_queue_items` (channel=email), ma l'unico processor di quella tabella (`SlackNotificationProcessorJob`) drena solo i canali Slack → le email erano **orfane** (310 accumulate su staging, mai inviate). `EmailProcessorJob` drena una tabella diversa e inutilizzata (`email_queue_items`).

### Fix
Nuovo **`EmailNotificationProcessorJob`** che drena il canale Email di `notification_queue_items` — **specchio del `SlackNotificationProcessorJob`** — riusando la state machine retry/dead-letter di `NotificationQueueItem`. Rendering via nuovo `EmailMessageBuilderFactory` + `GenericEmailBuilder` MVP (subject dal notification-type, body da payload/title, CTA deep-link opzionale, wrap nel template brandizzato); invio via `IEmailService.SendRawEmailAsync`. Email destinatario risolta da `RecipientUserId` a process-time; email mancante → dead-letter. Trigger Quartz 30s accanto al job Slack.

**Zero modifiche** a `NotificationDispatcher` + `SlackQueueHealthCheck`. Le 310 orfane drenano da sole appena il job gira. Builder email per-`NotificationType` aggiungibili via factory in seguito, senza toccare il job.

### Test
TDD RED→GREEN, **8 test** (builder + job): invia + marca Sent; send-failure → Failed/retry (non dead-letter); email mancante → dead-letter senza inviare; no-pending → no-op.

### Resta aperto (issue 3026)
L'**invio SMTP su staging è comunque rotto** (`SmtpClient.SendMailCallback`) — gli item faranno retry→dead-letter finché la config SMTP staging (auth/TLS/from) non è sistemata. È il secondo problema (config/infra) tracciato in issue 3026, **non** fixato qui.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
