### PR TITLE
fix(alerting): send alert emails via EmailService (issue 3026)

### DIFF
--- a/apps/api/src/Api/Services/EmailAlertChannel.cs
+++ b/apps/api/src/Api/Services/EmailAlertChannel.cs
@@ -1,6 +1,4 @@
 using System.Globalization;
-using System.Net;
-using System.Net.Mail;
 using Api.Helpers;
 using Api.Infrastructure.Security;
 using Microsoft.Extensions.Options;
@@ -8,21 +6,29 @@ using Microsoft.Extensions.Options;
 namespace Api.Services;
 
 /// <summary>
-/// Email alert channel using SMTP.
+/// Email alert channel for health/monitoring alerts.
 /// OPS-07: Email notifications for alerts.
+/// Delivery is delegated to <see cref="IEmailService"/> — the shared, authenticated
+/// SMTP_* transport used by all other outbound mail — instead of a self-configured
+/// SmtpClient. The former channel-local SmtpClient was built from Alerting:Email:*
+/// (Username/Password/From), which is empty on staging, so alert mail went out
+/// unauthenticated and Gmail rejected it with "5.7.0 Authentication Required".
 /// </summary>
 internal class EmailAlertChannel : IAlertChannel
 {
     private readonly EmailConfiguration _config;
+    private readonly IEmailService _emailService;
     private readonly ILogger<EmailAlertChannel> _logger;
 
     public string ChannelName => "Email";
 
     public EmailAlertChannel(
         IOptions<AlertingConfiguration> config,
+        IEmailService emailService,
         ILogger<EmailAlertChannel> logger)
     {
         _config = config.Value.Email;
+        _emailService = emailService;
         _logger = logger;
     }
 
@@ -39,45 +45,32 @@ internal class EmailAlertChannel : IAlertChannel
             return false;
         }
 
-        if (string.IsNullOrEmpty(_config.SmtpHost) || _config.To.Count == 0)
+        if (_config.To.Count == 0)
         {
-            _logger.LogWarning("Email channel is not properly configured (missing SMTP host or recipients)");
+            _logger.LogWarning("Email channel is not properly configured (no recipients)");
             return false;
         }
 
+        var subject = severity.ToUpper(CultureInfo.InvariantCulture) switch
+        {
+            "CRITICAL" => $"🚨 [CRITICAL] {alertType} - MeepleAI",
+            "WARNING" => $"⚠️ [WARNING] {alertType} - MeepleAI",
+            _ => $"ℹ️ [INFO] {alertType} - MeepleAI"
+        };
+
+        var body = FormatEmailBody(alertType, severity, message, metadata);
+
         try
         {
-            using var client = new SmtpClient(_config.SmtpHost, _config.SmtpPort)
-            {
-                EnableSsl = _config.UseTls,
-                Credentials = !string.IsNullOrEmpty(_config.Username)
-                    ? new NetworkCredential(_config.Username, _config.Password)
-                    : null
-            };
-
-            var subject = severity.ToUpper(CultureInfo.InvariantCulture) switch
-            {
-                "CRITICAL" => $"🚨 [CRITICAL] {alertType} - MeepleAI",
-                "WARNING" => $"⚠️ [WARNING] {alertType} - MeepleAI",
-                _ => $"ℹ️ [INFO] {alertType} - MeepleAI"
-            };
-
-            var body = FormatEmailBody(alertType, severity, message, metadata);
-
-            using var mailMessage = new MailMessage
-            {
-                From = new MailAddress(_config.From),
-                Subject = subject,
-                Body = body,
-                IsBodyHtml = true
-            };
-
+            // Transport (SMTP auth, From address, TLS) is owned by EmailService, which uses
+            // the authenticated SMTP_* credentials. All-or-nothing: a throw on any recipient
+            // stops the loop and yields false, mirroring the original single-try semantics.
             foreach (var recipient in _config.To)
             {
-                mailMessage.To.Add(recipient);
+                await _emailService
+                    .SendRawEmailAsync(recipient, subject, body, cancellationToken)
+                    .ConfigureAwait(false);
             }
-
-            await client.SendMailAsync(mailMessage, cancellationToken).ConfigureAwait(false);
 
             _logger.LogInformation(
                 "Email alert sent to {Recipients} for {AlertType}",
@@ -94,7 +87,8 @@ internal class EmailAlertChannel : IAlertChannel
             // Rationale: Alert channels implement IAlertChannel which requires returning success/
             // failure status. Throwing would prevent other channels from executing (Slack, PagerDuty).
             // Caller (AlertingService) tracks per-channel results for graceful degradation.
-            // Context: Email failures are typically external (SMTP down, authentication expired)
+            // Context: Email failures are typically external (SMTP down, authentication expired);
+            // EmailService.SendRawEmailAsync surfaces them as InvalidOperationException.
             _logger.LogError(ex, "Failed to send email alert for {AlertType}", LogSanitizer.Sanitize(alertType));
             return false;
         }

--- a/apps/api/tests/Api.Tests/Services/EmailAlertChannelTests.cs
+++ b/apps/api/tests/Api.Tests/Services/EmailAlertChannelTests.cs
@@ -1,0 +1,119 @@
+using Api.Services;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.Services;
+
+/// <summary>
+/// Unit tests for <see cref="EmailAlertChannel"/>.
+/// Validates that health/monitoring alerts are delivered through the shared
+/// <see cref="IEmailService"/>.SendRawEmailAsync transport (authenticated SMTP_* creds),
+/// NOT the channel's former self-configured SmtpClient — which on staging sent
+/// unauthenticated (empty Alerting:Email:Username/Password) → Gmail rejected with
+/// "5.7.0 Authentication Required".
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+public class EmailAlertChannelTests
+{
+    private readonly Mock<IEmailService> _emailService = new();
+    private readonly Mock<ILogger<EmailAlertChannel>> _logger = new();
+
+    private EmailAlertChannel CreateChannel(EmailConfiguration emailConfig)
+    {
+        var alertingConfig = new AlertingConfiguration { Email = emailConfig };
+        return new EmailAlertChannel(
+            Options.Create(alertingConfig),
+            _emailService.Object,
+            _logger.Object);
+    }
+
+    private static EmailConfiguration EnabledConfig(params string[] recipients) => new()
+    {
+        Enabled = true,
+        To = recipients.ToList()
+    };
+
+    [Fact]
+    public async Task SendAsync_SendsOncePerRecipient_WithSeverityPrefixedSubjectAndHtmlBody_ReturnsTrue()
+    {
+        // Arrange
+        var channel = CreateChannel(EnabledConfig("ops1@example.com", "ops2@example.com"));
+
+        // Act
+        var result = await channel.SendAsync("health.postgres", "critical", "DB down");
+
+        // Assert
+        result.Should().BeTrue();
+
+        const string expectedSubject = "🚨 [CRITICAL] health.postgres - MeepleAI";
+        foreach (var recipient in new[] { "ops1@example.com", "ops2@example.com" })
+        {
+            _emailService.Verify(s => s.SendRawEmailAsync(
+                recipient,
+                expectedSubject,
+                It.Is<string>(body => body.Contains("DB down") && body.Contains("CRITICAL ALERT")),
+                It.IsAny<CancellationToken>()),
+                Times.Once);
+        }
+
+        _emailService.VerifyNoOtherCalls();
+    }
+
+    [Fact]
+    public async Task SendAsync_WhenTransportThrows_ReturnsFalse_AndDoesNotPropagate()
+    {
+        // Arrange
+        var channel = CreateChannel(EnabledConfig("ops@example.com"));
+        _emailService
+            .Setup(s => s.SendRawEmailAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("SMTP auth failed"));
+
+        // Act — resilience contract (IAlertChannel): a transport failure must NOT
+        // propagate (would abort sibling channels), it must be swallowed → false.
+        var result = await channel.SendAsync("health.redis", "warning", "Redis degraded");
+
+        // Assert
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task SendAsync_WhenDisabled_ReturnsFalse_WithoutCallingTransport()
+    {
+        // Arrange
+        var channel = CreateChannel(new EmailConfiguration
+        {
+            Enabled = false,
+            To = { "ops@example.com" }
+        });
+
+        // Act
+        var result = await channel.SendAsync("health.test", "info", "test message");
+
+        // Assert
+        result.Should().BeFalse();
+        _emailService.Verify(s => s.SendRawEmailAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task SendAsync_WhenNoRecipients_ReturnsFalse_WithoutCallingTransport()
+    {
+        // Arrange — Enabled but empty To list
+        var channel = CreateChannel(new EmailConfiguration { Enabled = true });
+
+        // Act
+        var result = await channel.SendAsync("health.test", "info", "test message");
+
+        // Assert
+        result.Should().BeFalse();
+        _emailService.Verify(s => s.SendRawEmailAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+}

--- a/infra/compose.staging.yml
+++ b/infra/compose.staging.yml
@@ -91,6 +91,12 @@ services:
       Frontend__BaseUrl: "https://meepleai.app"
       Authentication__SessionCookie__Secure: "true"
       Authentication__SessionCookie__SameSite: "Lax"
+      # OPS-07: health/monitoring alert recipient — overrides the appsettings.json
+      # placeholder (ops@meepleai.dev). Not a secret, just the mailbox that receives
+      # alert emails. From/credentials are inherited from EmailService's SMTP_* config
+      # (email.secret); EmailAlertChannel no longer uses Alerting:Email:From/Username/
+      # Password. badsworm@gmail.com is the already allow-listed staging address (Gmail→Gmail).
+      Alerting__Email__To__0: badsworm@gmail.com
       # Ollama disabled in staging — all LLM traffic goes to OpenRouter
       AI__Providers__Ollama__Enabled: "false"
       # AI extraction services — URLs must be valid for startup validation.


### PR DESCRIPTION
## Fix: alert emails via EmailService transport (issue 3026, parte SMTP)

Seconda parte di issue 3026 (la prima — routing email notifiche — è già in main-dev via #3032).

### Problema
`EmailAlertChannel` costruiva un proprio `SmtpClient` da `Alerting:Email:Username/Password`, **vuoti su staging** → invio senza auth → Gmail `5.7.0 Authentication Required`. E il `From` (`alerts@meepleai.dev`) non era l'account autenticato, il `To` (`ops@meepleai.dev`) un placeholder.

### Fix
- **Code**: `EmailAlertChannel` delega a **`IEmailService.SendRawEmailAsync`** — il transport SMTP condiviso e **autenticato** (`SMTP_*`, credenziali già verificate valide + From = `SMTP_FROM_EMAIL`). Niente più config SMTP separata. Preservati: gate `Enabled`/`To`, subject per severità, body HTML, contratto resilienza `IAlertChannel` (mai throw → `false`).
- **Config staging** (`compose.staging.yml`): `Alerting__Email__To__0 = badsworm@gmail.com` (recipient reale, allow-listed; Gmail→Gmail consegna) al posto del placeholder `ops@meepleai.dev`.

### Test
TDD RED→GREEN, **4 test**: un send per recipient con subject+body → `true`; throw transport → `false` senza propagare; disabled → `false` (no send); `To` vuoto → `false`.

### Contesto
Il path email delle **notifiche** era già a posto (credenziali SMTP valide, testato `AUTH_OK`); era solo l'`EmailAlertChannel` (config separata vuota) a fallire. Con questo, **entrambe le parti di issue 3026 sono risolte** (attive al prossimo deploy staging).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
