### PR TITLE
fix(build): keep data/rulebook/golden in API docker context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -21,8 +21,12 @@
 .claude/
 
 # Rulebook PDFs — seed/runtime data (uploaded to storage at runtime), not needed in the API
-# image. `COPY data` still brings the rest of `data/`. Primary context-bloat driver.
-data/rulebook/
+# image. Exclude ONLY the PDFs (~1.2GB, the context-bloat driver), NOT the whole dir:
+# Api.csproj embeds `data/rulebook/golden/**/*.json` as resources, so ignoring `data/rulebook/`
+# wholesale breaks the API build with CS1566 (missing embedded resource). `COPY data` keeps
+# data/rulebook/golden/. Regression fix: the wholesale ignore shipped in #2953 (#7).
+data/rulebook/*.pdf
+data/rulebook/**/*.pdf
 
 # Docs + archives — never part of any image.
 docs/


### PR DESCRIPTION
## Problema
La `.dockerignore` introdotta in #2953 (#7) ignorava **tutta** la dir `data/rulebook/` per togliere i ~1.2GB di PDF dal build context dell'API. Ma `Api.csproj` embedda `data/rulebook/golden/**/*.json` (Puerto Rico golden-claims + bgg-tags) come `EmbeddedResource`, quindi l'ignore wholesale rompe il **build docker dell'API**:

```
CSC error CS1566: Error reading resource 'puerto-rico-golden-claims.json'
-- Could not find '/src/data/rulebook/golden/puerto-rico/golden-claims.json'
```

La CI delle PR **non** fa il docker-build dell'API con `.dockerignore` → è passato inosservato; il primo a inciamparci è lo step "Build Images" del deploy staging (romperebbe anche prod).

## Fix
Escludere **solo i PDF** (`data/rulebook/*.pdf` + `data/rulebook/**/*.pdf`), tenendo `data/rulebook/golden/` nel context. `COPY data` continua a portare i golden JSON. Il context-trim (obiettivo di #2953 #7) resta: i PDF sono il driver di bloat, i JSON golden sono ~pochi KB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)