### PR TITLE
fix(build): keep golden JSON in API docker context (staging hotfix)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -21,8 +21,12 @@
 .claude/
 
 # Rulebook PDFs — seed/runtime data (uploaded to storage at runtime), not needed in the API
-# image. `COPY data` still brings the rest of `data/`. Primary context-bloat driver.
-data/rulebook/
+# image. Exclude ONLY the PDFs (~1.2GB, the context-bloat driver), NOT the whole dir:
+# Api.csproj embeds `data/rulebook/golden/**/*.json` as resources, so ignoring `data/rulebook/`
+# wholesale breaks the API build with CS1566 (missing embedded resource). `COPY data` keeps
+# data/rulebook/golden/. Regression fix: the wholesale ignore shipped in #2953 (#7).
+data/rulebook/*.pdf
+data/rulebook/**/*.pdf
 
 # Docs + archives — never part of any image.
 docs/


### PR DESCRIPTION
## Hotfix staging deploy
Il deploy staging (release main-dev→main-staging #3038) è **fallito** allo step "Build Images": la `.dockerignore` di #2953 (#7) escludeva tutta `data/rulebook/`, ma `Api.csproj` embedda `data/rulebook/golden/**/*.json` → `CS1566` (embedded resource mancante).

## Fix
Escludi solo i PDF (`data/rulebook/*.pdf` + `**/*.pdf`), tieni `data/rulebook/golden/`. Stesso fix aperto su main-dev (source of truth). Questa PR sblocca il ri-deploy staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)