### PR TITLE
test(storybook): pilot storie canonical-state per le 3 route chat

### DIFF
--- a/apps/web/src/app/(chat)/chat/agents/create/page.stories.tsx
+++ b/apps/web/src/app/(chat)/chat/agents/create/page.stories.tsx
@@ -1,0 +1,161 @@
+/**
+ * Storybook coverage — /chat/agents/create (agent creation wizard).
+ *
+ * No page-mock exists for this route (MOCKUPS_INDEX § Chat is empty). Canonical-state
+ * coverage stories rendering the REAL AgentCreationWizard against MSW fixtures,
+ * mirroring chat/[threadId]/page.stories.tsx — no @mockup tag (no HTML twin).
+ *
+ * The route page.tsx uses next/dynamic(ssr:false); the story imports AgentCreationWizard
+ * directly to skip the dynamic-import spinner.
+ *
+ * Step 1 (GameCollectionPicker) fetches on mount:
+ *   GET /library (paginated { items, ... }) — the user's game collection
+ * The library GET drives the canonical state. States: default (collection) / empty
+ * (LibraryEmpty) / loading (skeleton). There is NO distinct error surface: the step-1
+ * fetch does `.catch(console.error)` and collapses a 500 into the empty view — so `error`
+ * is intentionally NOT declared as a canonical state here.
+ * Fixtures MUST be Zod-valid (uuid v4 id/userId + RFC3339 datetimes with offset).
+ */
+import { http, HttpResponse } from 'msw';
+
+import { AgentCreationWizard } from '@/components/chat-unified/AgentCreationWizard';
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+const LIBRARY_URL = '*/api/v1/library';
+
+const USER_ID = '7f3e9a1c-2b4d-4e6f-8a1b-0c2d4e6f8a1b';
+
+/** PaginatedLibraryResponse — { items: UserLibraryEntry[], page, ... }. entry 1 has a KB. */
+const LIBRARY = {
+  items: [
+    {
+      id: '5e6f7a8b-9c0d-4e1f-8a2b-3c4d5e6f7a8b',
+      userId: USER_ID,
+      gameId: 'catan-seed-0001',
+      gameTitle: 'Catan',
+      gamePublisher: 'Kosmos',
+      gameYearPublished: 1995,
+      gameIconUrl: null,
+      gameImageUrl: null,
+      coverUrl: null,
+      addedAt: '2026-05-20T14:00:00.000Z',
+      notes: null,
+      isFavorite: true,
+      currentState: 'Owned',
+      stateChangedAt: null,
+      stateNotes: null,
+      hasKb: true,
+      kbCardCount: 2,
+      kbIndexedCount: 2,
+      kbProcessingCount: 0,
+      ownershipDeclaredAt: '2026-05-20T14:05:00.000Z',
+      hasRagAccess: true,
+      agentIsOwned: true,
+      minPlayers: 3,
+      maxPlayers: 4,
+      playingTimeMinutes: 75,
+      complexityRating: 2.3,
+      averageRating: 7.1,
+      timesPlayed: 5,
+      lastPlayed: '2026-07-10T20:30:00.000Z',
+      privateGameId: null,
+      isPrivateGame: false,
+      canProposeToCatalog: false,
+    },
+    {
+      id: '6f7a8b9c-0d1e-4f2a-9b3c-4d5e6f7a8b9c',
+      userId: USER_ID,
+      gameId: 'wingspan-seed-0002',
+      gameTitle: 'Wingspan',
+      gamePublisher: 'Stonemaier Games',
+      gameYearPublished: 2019,
+      gameIconUrl: null,
+      gameImageUrl: null,
+      coverUrl: null,
+      addedAt: '2026-06-02T11:15:00.000Z',
+      notes: 'Espansione Oceania da provare',
+      isFavorite: false,
+      currentState: 'Nuovo',
+      stateChangedAt: null,
+      stateNotes: null,
+      hasKb: false,
+      kbCardCount: 0,
+      kbIndexedCount: 0,
+      kbProcessingCount: 0,
+      ownershipDeclaredAt: null,
+      hasRagAccess: false,
+      agentIsOwned: true,
+      minPlayers: 1,
+      maxPlayers: 5,
+      playingTimeMinutes: 60,
+      complexityRating: 2.4,
+      averageRating: 8.0,
+      timesPlayed: 0,
+      lastPlayed: null,
+      privateGameId: null,
+      isPrivateGame: false,
+      canProposeToCatalog: false,
+    },
+  ],
+  page: 1,
+  pageSize: 100,
+  totalCount: 2,
+  totalPages: 1,
+  hasNextPage: false,
+  hasPreviousPage: false,
+};
+
+const emptyLibrary = {
+  items: [],
+  page: 1,
+  pageSize: 100,
+  totalCount: 0,
+  totalPages: 0,
+  hasNextPage: false,
+  hasPreviousPage: false,
+};
+
+const meta: Meta<typeof AgentCreationWizard> = {
+  title: 'Authenticated / chat-agent-create',
+  component: AgentCreationWizard,
+  parameters: {
+    layout: 'fullscreen',
+    canonicalStates: ['default', 'empty', 'loading'],
+    nextjs: { appDirectory: true, navigation: { pathname: '/chat/agents/create' } },
+    viewport: { defaultViewport: 'desktop' },
+    docs: {
+      description: {
+        component:
+          'Agent creation wizard (step 1 = game collection picker). Default = collection ' +
+          'grid; Empty = LibraryEmpty; Loading = skeleton. No error state (a 500 collapses ' +
+          'to empty, by design).',
+      },
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof AgentCreationWizard>;
+
+/** Default: game collection loaded (step 1). */
+export const Default: Story = {
+  parameters: {
+    msw: { handlers: [http.get(LIBRARY_URL, () => HttpResponse.json(LIBRARY))] },
+  },
+};
+
+/** Empty: no games in the collection → LibraryEmpty. */
+export const Empty: Story = {
+  parameters: {
+    msw: { handlers: [http.get(LIBRARY_URL, () => HttpResponse.json(emptyLibrary))] },
+  },
+};
+
+/** Loading: library GET never resolves — collection skeleton. */
+export const Loading: Story = {
+  parameters: {
+    msw: { handlers: [http.get(LIBRARY_URL, () => new Promise<Response>(() => {}))] },
+  },
+};

--- a/apps/web/src/app/(chat)/chat/new/page.stories.tsx
+++ b/apps/web/src/app/(chat)/chat/new/page.stories.tsx
@@ -1,0 +1,159 @@
+/**
+ * Storybook coverage — /chat/new (new-chat entry).
+ *
+ * No page-mock exists for this route (MOCKUPS_INDEX § Chat is empty). Canonical-state
+ * coverage stories rendering the REAL ChatEntryOrchestrator against MSW fixtures,
+ * mirroring chat/[threadId]/page.stories.tsx — no @mockup tag (no HTML twin).
+ *
+ * The route page.tsx uses next/dynamic(ssr:false); the story imports the underlying
+ * ChatEntryOrchestrator directly to skip the dynamic-import spinner (same trick the
+ * [threadId] story uses with ChatThreadView).
+ *
+ * On mount the GameSelector fetches:
+ *   GET /private-games (paginated { items, ... }) — private games grid (on-mount)
+ *   GET /library       (paginated) — shared-library tab (lazy; handler declared anyway)
+ * The private-games GET drives the canonical state. States: default (games) / empty /
+ * loading / error. AgentSelector always renders the 5 system agents (auto default),
+ * so the "Inizia Chat" CTA is enabled without selecting a game.
+ * Fixtures MUST be Zod-valid (uuid v4 ownerId + RFC3339 datetimes with offset).
+ */
+import { http, HttpResponse } from 'msw';
+
+import { ChatEntryOrchestrator } from '@/components/chat/entry';
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+const PRIVATE_GAMES_URL = '*/api/v1/private-games';
+const LIBRARY_URL = '*/api/v1/library';
+
+const OWNER_ID = '7f3e9a1c-2b4d-4e6f-8a1b-0c2d4e6f8a1b';
+
+/** PaginatedPrivateGamesResponse — { items: PrivateGameDto[], page, ... }. */
+const PRIVATE_GAMES = {
+  items: [
+    {
+      id: 'aa11bb22-cc33-dd44-ee55-ff6677889900',
+      ownerId: OWNER_ID,
+      source: 'Manual',
+      bggId: null,
+      title: 'Prototipo Casalingo',
+      minPlayers: 2,
+      maxPlayers: 4,
+      yearPublished: 2025,
+      description: 'Gioco autoprodotto per test.',
+      playingTimeMinutes: 60,
+      minAge: 10,
+      complexityRating: 2.5,
+      imageUrl: null,
+      thumbnailUrl: null,
+      createdAt: '2026-06-01T12:00:00.000Z',
+      updatedAt: null,
+      bggSyncedAt: null,
+      canProposeToCatalog: false,
+      agentDefinitionId: null,
+    },
+    {
+      id: 'bb22cc33-dd44-ee55-ff66-778899001122',
+      ownerId: OWNER_ID,
+      source: 'BoardGameGeek',
+      bggId: 174430,
+      title: 'Gloomhaven (copia personale)',
+      minPlayers: 1,
+      maxPlayers: 4,
+      yearPublished: 2017,
+      description: null,
+      playingTimeMinutes: 120,
+      minAge: 14,
+      complexityRating: 3.9,
+      imageUrl: null,
+      thumbnailUrl: null,
+      createdAt: '2026-06-10T08:30:00.000Z',
+      updatedAt: '2026-06-11T09:00:00.000Z',
+      bggSyncedAt: '2026-06-10T08:30:05.000Z',
+      canProposeToCatalog: true,
+      agentDefinitionId: null,
+    },
+  ],
+  page: 1,
+  pageSize: 100,
+  totalCount: 2,
+  totalPages: 1,
+  hasNextPage: false,
+  hasPreviousPage: false,
+};
+
+const emptyPaginated = {
+  items: [],
+  page: 1,
+  pageSize: 100,
+  totalCount: 0,
+  totalPages: 0,
+  hasNextPage: false,
+  hasPreviousPage: false,
+};
+
+/** Shared-library tab is lazy; keep it populated across states so a tab-switch isn't broken. */
+const okLibrary = http.get(LIBRARY_URL, () => HttpResponse.json(emptyPaginated));
+
+const meta: Meta<typeof ChatEntryOrchestrator> = {
+  title: 'Authenticated / chat-new',
+  component: ChatEntryOrchestrator,
+  parameters: {
+    layout: 'fullscreen',
+    canonicalStates: ['default', 'empty', 'loading', 'error'],
+    nextjs: { appDirectory: true, navigation: { pathname: '/chat/new' } },
+    viewport: { defaultViewport: 'desktop' },
+    docs: {
+      description: {
+        component:
+          'New-chat entry. Default = private games grid + agent selector; Empty = no ' +
+          'private games; Loading = games skeleton; Error = games load error alert.',
+      },
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ChatEntryOrchestrator>;
+
+/** Default: private games grid loaded. */
+export const Default: Story = {
+  parameters: {
+    msw: {
+      handlers: [http.get(PRIVATE_GAMES_URL, () => HttpResponse.json(PRIVATE_GAMES)), okLibrary],
+    },
+  },
+};
+
+/** Empty: no private games. */
+export const Empty: Story = {
+  parameters: {
+    msw: {
+      handlers: [http.get(PRIVATE_GAMES_URL, () => HttpResponse.json(emptyPaginated)), okLibrary],
+    },
+  },
+};
+
+/** Loading: private-games GET never resolves — games skeleton. */
+export const Loading: Story = {
+  parameters: {
+    msw: {
+      handlers: [http.get(PRIVATE_GAMES_URL, () => new Promise<Response>(() => {})), okLibrary],
+    },
+  },
+};
+
+/** Error: private-games GET returns 500 → error alert. */
+export const Error: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.get(PRIVATE_GAMES_URL, () =>
+          HttpResponse.json({ error: 'server_error' }, { status: 500 })
+        ),
+        okLibrary,
+      ],
+    },
+  },
+};

--- a/apps/web/src/app/(chat)/chat/page.stories.tsx
+++ b/apps/web/src/app/(chat)/chat/page.stories.tsx
@@ -1,0 +1,139 @@
+/**
+ * Storybook coverage — /chat (chat list).
+ *
+ * No page-mock exists for this route (MOCKUPS_INDEX § Chat is empty; a
+ * chat-fullscreen page-mock is tracked by #2971). These are canonical-state
+ * coverage stories that render the REAL ChatListPage against MSW fixtures,
+ * mirroring the sibling pattern in chat/[threadId]/page.stories.tsx — hence no
+ * @mockup tag (there is no HTML twin to mirror).
+ *
+ * Route /chat → ChatListPage. Auth-gated via useAuth (Storybook preview's
+ * MockAuthProvider supplies user.id='storybook-user', so the queries run). On mount:
+ *   GET /users/:userId/chat-sessions/recent → ChatSessionSummaryDto[] (bare array, Zod-validated)
+ *   GET /users/:userId/chat-sessions/limit  → { limit, used, tier }
+ * States: default (sessions) / empty / loading / error. The recent fixtures MUST be
+ * Zod-valid (uuid v4 ids + RFC3339 datetimes WITH offset) or the client throws
+ * SchemaValidationError and the query lands in error.
+ */
+import { http, HttpResponse } from 'msw';
+
+import ChatListPage from './page';
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+const RECENT_URL = '*/api/v1/users/:userId/chat-sessions/recent';
+const LIMIT_URL = '*/api/v1/users/:userId/chat-sessions/limit';
+
+/** ChatSessionSummaryDto[] — bare array (client wraps into { sessions, totalCount }). */
+const RECENT_SESSIONS = [
+  {
+    id: '1a2b3c4d-5e6f-4a7b-8c9d-0e1f2a3b4c5d',
+    userId: '7f3e9a1c-2b4d-4e6f-8a1b-0c2d4e6f8a1b',
+    gameId: 'catan-seed-0001',
+    gameTitle: 'Catan',
+    agentId: '3c4d5e6f-7a8b-4c9d-8e0f-1a2b3c4d5e6f',
+    agentType: 'rules',
+    agentName: 'Arbitro Regole',
+    title: 'Setup iniziale a 4 giocatori',
+    messageCount: 6,
+    lastMessagePreview: 'Quindi il ladro si sposta sul deserto?',
+    createdAt: '2026-07-15T09:12:00.000Z',
+    lastMessageAt: '2026-07-15T09:41:00.000Z',
+    isArchived: false,
+  },
+  {
+    id: '2b3c4d5e-6f7a-4b8c-9d0e-1f2a3b4c5d6e',
+    userId: '7f3e9a1c-2b4d-4e6f-8a1b-0c2d4e6f8a1b',
+    gameId: 'wingspan-seed-0002',
+    gameTitle: 'Wingspan',
+    agentId: null,
+    agentType: null,
+    agentName: null,
+    title: 'Dubbi punteggio uova',
+    messageCount: 2,
+    lastMessagePreview: 'Le uova valgono 1 punto ciascuna?',
+    createdAt: '2026-07-14T18:03:00.000Z',
+    lastMessageAt: '2026-07-14T18:07:30.000Z',
+    isArchived: false,
+  },
+];
+
+const LIMIT_LOW = { limit: 50, used: 3, tier: 'free' };
+const LIMIT_NEAR_CAP = { limit: 50, used: 45, tier: 'free' };
+
+/** Limit handler always resolves; the recent handler drives the canonical state. */
+const okLimit = http.get(LIMIT_URL, () => HttpResponse.json(LIMIT_LOW));
+
+const meta: Meta<typeof ChatListPage> = {
+  title: 'Authenticated / chat-list',
+  component: ChatListPage,
+  parameters: {
+    layout: 'fullscreen',
+    // DS-17 #2063: on-mount http.get (no quoted state literal) → declare states.
+    canonicalStates: ['default', 'empty', 'loading', 'error'],
+    nextjs: { appDirectory: true, navigation: { pathname: '/chat' } },
+    viewport: { defaultViewport: 'desktop' },
+    docs: {
+      description: {
+        component:
+          'Chat list. Default = grouped recent sessions; Empty = no sessions; ' +
+          'Loading = skeleton; Error = 500. TierNearCap = quota banner (used/limit ≥ 0.8).',
+      },
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ChatListPage>;
+
+/** Default: recent sessions grouped by agent. */
+export const Default: Story = {
+  parameters: {
+    msw: {
+      handlers: [http.get(RECENT_URL, () => HttpResponse.json(RECENT_SESSIONS)), okLimit],
+    },
+  },
+};
+
+/** Empty: no chat sessions yet. */
+export const Empty: Story = {
+  parameters: {
+    msw: {
+      handlers: [http.get(RECENT_URL, () => HttpResponse.json([])), okLimit],
+    },
+  },
+};
+
+/** Loading: recent GET never resolves — shows the skeleton. */
+export const Loading: Story = {
+  parameters: {
+    msw: {
+      handlers: [http.get(RECENT_URL, () => new Promise<Response>(() => {})), okLimit],
+    },
+  },
+};
+
+/** Error: recent GET returns 500 → error alert. */
+export const Error: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.get(RECENT_URL, () => HttpResponse.json({ error: 'server_error' }, { status: 500 })),
+        okLimit,
+      ],
+    },
+  },
+};
+
+/** TierNearCap: sessions load AND the tier banner shows (45/50 = 0.9 ≥ 0.8). */
+export const TierNearCap: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.get(RECENT_URL, () => HttpResponse.json(RECENT_SESSIONS)),
+        http.get(LIMIT_URL, () => HttpResponse.json(LIMIT_NEAR_CAP)),
+      ],
+    },
+  },
+};


### PR DESCRIPTION
## Cosa

Pilota di storie Storybook **canonical-state** per le 3 route chat che ne erano prive:

- `/chat` → `ChatListPage` — `default` / `empty` / `loading` / `error` + `TierNearCap` (banner quota, used/limit ≥ 0.8)
- `/chat/new` → `ChatEntryOrchestrator` — `default` / `empty` / `loading` / `error`
- `/chat/agents/create` → `AgentCreationWizard` — `default` / `empty` / `loading`

## Perché così

Nessuna delle 3 route ha un **page-mock** (`MOCKUPS_INDEX § Chat` è vuota; il gap chat-fullscreen è tracciato da #2971). Non sono quindi migrazioni di mockup DS-17, ma **storie di copertura canonical-state pura**, sul modello della sorella già in repo `chat/[threadId]/page.stories.tsx` (stessa route-group `(chat)`, `parameters.canonicalStates` + MSW inline + import del componente reale). Niente `@mockup` verso file inesistenti.

Scelte specifiche:
- `/chat/new` e `/chat/agents/create` usano `next/dynamic(ssr:false)` nel `page.tsx` → le storie importano i componenti reali (`ChatEntryOrchestrator`, `AgentCreationWizard`) per saltare lo spinner del dynamic import (stesso trucco di `[threadId]` con `ChatThreadView`).
- `/chat/agents/create` **non** dichiara `error`: lo step-1 fa `.catch(console.error)` e un 500 collassa in `LibraryEmpty` — nessuna UI di errore distinta, quindi niente stato fantasma.
- `/chat` è auth-gated (`useAuth`): funziona senza decorator perché il `preview.tsx` globale fornisce già `MockAuthProvider` (`user.id='storybook-user'`).

## Verifica

- `pnpm typecheck` ok · `eslint` **pulito** sui 3 file.
- `pnpm build-storybook` ok (tutte le storie compilano e si registrano).
- **Rendering confermato in browser** sulle 3 storie `Default` (server `storybook-static`): MSW intercetta gli endpoint reali con `200 OK`, contenuto reale renderizzato (`Catan`/`Wingspan`/`Prototipo Casalingo`/`Gloomhaven` + selettori agente/wizard), **nessun errore Zod/provider** (fixture Zod-valide: uuid v4 strict + datetime con offset + forme paginato/array corrette).

## Impatto sui gate

**Gate-neutrale**: nessun mockup / `.fidelity.json` / `MOCKUPS_INDEX` toccato → i 5 gate anti-drift (`lint:storybook-states`, `lint:fidelity`, `mockup-annotations:audit`, `lint:tokens:mockups`, `lint:bgg-mockups`) non sono impattati (il gate states è mockup-driven: le storie senza fidelity gli sono invisibili).

⚠️ **CI "Frontend Static" sarà rossa per un baseline pre-esistente, NON per questa PR**: i 3 errori `meepleai/no-inline-hsl-v2` in `apps/web/src/components/features/session-live/flavors/catan/catan-palette.ts` (stesso baseline di #3036/#3035). I 3 file di questa PR lintano puliti. Nota collaterale: lo step `lint:storybook-states` gira DOPO il lint nello stesso job, quindi su branch fresco non viene raggiunto — e c'è una contract-violation baseline mascherata (`sp4-library-wishlist.html missing: default`) indipendente da questa PR, da triagliare a parte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
