### PR TITLE
fix(tests): repoint validate-fidelity REAL_MOCKUP dopo rimozione sp4-dashboard (#3048)

### DIFF
--- a/apps/web/scripts/mockup-annotations/__tests__/validate-fidelity.test.ts
+++ b/apps/web/scripts/mockup-annotations/__tests__/validate-fidelity.test.ts
@@ -24,7 +24,9 @@ const TMP_DIR = resolve(tmpdir(), `mockup-fidelity-tests-${process.pid}`);
 
 // Mockup source file we reference in fidelity fixtures must actually exist.
 // Use a real file from admin-mockups/design_files/ for cross-reference success.
-const REAL_MOCKUP = 'admin-mockups/design_files/sp4-dashboard.html';
+// sp4-dashboard.html was deleted as obsolete (#2114, PR #3048) → repointed to
+// 00-hub.html (stable dev-fixture mockup), matching the Python inspector test.
+const REAL_MOCKUP = 'admin-mockups/design_files/00-hub.html';
 
 beforeAll(() => {
   if (!existsSync(TMP_DIR)) {


### PR DESCRIPTION
## Cosa

Follow-up a #3048 (rimozione mockup obsoleto `sp4-dashboard`, #2114): completa un coupling repoint mancato.

`scripts/mockup-annotations/__tests__/validate-fidelity.test.ts` usava
`admin-mockups/design_files/sp4-dashboard.html` come `REAL_MOCKUP` — il file che le fixture di cross-reference devono trovare **esistente** per far ritornare `validate() → ok:true`. #3048 lo ha eliminato, quindi 4 test fallivano:

- `validate() cross-reference checks > PASS — valid fixture referencing existing mockup`
- `validate() surfaces approvalErrors separately from structural ok > current + empty approver …`
- `… > current + P250 waiver …`
- `… > forward-refactor + empty approver …`

## Perché non era emerso al merge di #3048

#3048 era **mockup-only** (`admin-mockups/` + `scripts/`), quindi `Detect Changes` ha **skippato i Frontend Tests**. In #3048 avevo repuntato il gemello Python `test_mockup_inspector.py` → `00-hub.html`, ma ho mancato questo secondo test TypeScript. La regressione emerge ora su qualsiasi PR che tocca `apps/web/src` (fa girare i Frontend Tests) — è stata scoperta durante la PR delle storie chat #3053.

## Fix

Repointato `REAL_MOCKUP` → `admin-mockups/design_files/00-hub.html` (dev-fixture mockup stabile, stessa scelta di #3048 per il test Python). Il test verifica solo l'esistenza del file referenziato, quindi qualsiasi mockup esistente è valido.

## Verifica

- `pnpm vitest run scripts/mockup-annotations/__tests__/validate-fidelity.test.ts` → **31/31 passed** (prima: 27 passed, 4 failed).
- `pnpm lint:fidelity` verde (92 ok, 3 drift tollerati sotto baseline — invariato).

Nota: `Frontend Static` risulterà rossa per il baseline pre-esistente `catan-palette.ts` (3 `no-inline-hsl-v2`, introdotto da #3051), non da questa PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
