### PR TITLE
fix(session-live): #3050 clear SSE accumulator on session change (no cross-session bleed)

### DIFF
--- a/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx
@@ -492,13 +492,17 @@ export function SessionLiveView(): ReactElement {
 
   // #3025 L1: mirror the opaque live game-state into the store — hydrate from the DTO,
   // then let the latest `session:game-state` SSE event win. L3 flavors read `s.gameState`.
+  // #3050: match the event's sessionId so a previous session's game-state (still in the
+  // accumulator for the frame before it clears) can never bleed into this session's store.
   useEffect(() => {
     const dtoState = sessionQuery.data?.gameState ?? null;
-    const latest = [...liveStream.events].reverse().find(e => e.type === 'session:game-state');
+    const latest = [...liveStream.events]
+      .reverse()
+      .find(e => e.type === 'session:game-state' && e.sessionId === sessionId);
     useLiveSessionStore
       .getState()
       .setGameState(latest && latest.type === 'session:game-state' ? latest.state : dtoState);
-  }, [sessionQuery.data?.gameState, liveStream.events]);
+  }, [sessionQuery.data?.gameState, liveStream.events, sessionId]);
 
   // #2483 Task 2: reactive selector for turnOrderType — must be declared before
   // turnRendererState useMemo (which appears in the i18n labels section below).

--- a/apps/web/src/lib/session-live/__tests__/use-session-live-stream.test.ts
+++ b/apps/web/src/lib/session-live/__tests__/use-session-live-stream.test.ts
@@ -417,6 +417,61 @@ describe('useSessionLiveStream — sessionId change', () => {
     expect(MockEventSource.instances).toHaveLength(2);
     expect(MockEventSource.lastInstance()?.url).toContain('session-B');
   });
+
+  it('#3050: clears accumulated events on sessionId change (no cross-session bleed)', () => {
+    const { result, rerender } = renderHook(
+      ({ sessionId }) => useSessionLiveStream({ sessionId, enabled: true }),
+      { initialProps: { sessionId: 'session-A' } }
+    );
+
+    act(() => {
+      MockEventSource.lastInstance()!.triggerOpen();
+      MockEventSource.lastInstance()!.triggerEvent(
+        'session:score',
+        JSON.stringify({ participantId: 'p1', score: 5, sessionId: 'session-A' }),
+        'evt-A-1'
+      );
+    });
+    expect(result.current.events).toHaveLength(1);
+
+    // Navigating to another session must not carry session-A's events over.
+    act(() => {
+      rerender({ sessionId: 'session-B' });
+    });
+    expect(result.current.events).toHaveLength(0);
+    expect(result.current.lastEventId).toBeNull();
+
+    // A fresh session-B event accumulates onto the cleared array.
+    act(() => {
+      MockEventSource.lastInstance()!.triggerOpen();
+      MockEventSource.lastInstance()!.triggerEvent(
+        'session:score',
+        JSON.stringify({ participantId: 'p9', score: 3, sessionId: 'session-B' }),
+        'evt-B-1'
+      );
+    });
+    expect(result.current.events).toHaveLength(1);
+  });
+
+  it('#3050: does NOT clear events on a same-session reconnect (RESET preserves)', () => {
+    const { result } = makeHook({ sessionId: 'session-1' });
+
+    act(() => {
+      MockEventSource.lastInstance()!.triggerOpen();
+      MockEventSource.lastInstance()!.triggerEvent(
+        'session:score',
+        JSON.stringify({ participantId: 'p1', score: 5, sessionId: 'session-1' }),
+        'evt-1'
+      );
+    });
+    expect(result.current.events).toHaveLength(1);
+
+    // A manual reconnect (same session) must preserve accumulated events.
+    act(() => {
+      result.current.reconnect();
+    });
+    expect(result.current.events).toHaveLength(1);
+  });
 });
 
 describe('useSessionLiveStream — retryAt', () => {

--- a/apps/web/src/lib/session-live/use-session-live-stream.ts
+++ b/apps/web/src/lib/session-live/use-session-live-stream.ts
@@ -106,7 +106,8 @@ type StreamAction =
   | { type: 'RETRY'; retryCount: number; retryAt: Date }
   | { type: 'DEGRADED_POLLING' }
   | { type: 'FAILED' }
-  | { type: 'RESET' };
+  | { type: 'RESET' }
+  | { type: 'CLEAR' };
 
 const INITIAL_STATE: StreamState = {
   events: [],
@@ -168,6 +169,13 @@ function streamReducer(state: StreamState, action: StreamAction): StreamState {
         seenIds: state.seenIds,
         lastEventId: state.lastEventId,
       };
+
+    case 'CLEAR':
+      // #3050: full reset (events + seenIds + lastEventId) on a genuine sessionId
+      // change, so a previous session's accumulated events / Last-Event-ID never
+      // bleed into the new session's stream or the shared game-state store. Distinct
+      // from RESET, which deliberately preserves events across same-session reconnects.
+      return { ...INITIAL_STATE, seenIds: new Set<string>() };
 
     default:
       return state;
@@ -318,6 +326,10 @@ export function useSessionLiveStream(input: UseSessionLiveStreamInput): UseSessi
   // Keep connectRef stable for retry timer closures
   connectRef.current = connect;
 
+  // #3050: track the sessionId across renders to detect a genuine session change
+  // (vs. a same-session reconnect) so the accumulator can be fully cleared.
+  const prevSessionIdRef = useRef<string | null>(sessionId);
+
   // Manual reconnect — resets retry state
   const reconnect = useCallback(() => {
     retryCountRef.current = 0;
@@ -329,6 +341,16 @@ export function useSessionLiveStream(input: UseSessionLiveStreamInput): UseSessi
   // (Re)connect when sessionId/enabled changes
   useEffect(() => {
     isMountedRef.current = true;
+
+    // #3050: on a genuine sessionId change, clear the previous session's accumulated
+    // events/seenIds/lastEventId so they cannot bleed into this session (App Router
+    // reuses the /sessions/[id]/live component across navigations — no remount).
+    if (prevSessionIdRef.current !== sessionId) {
+      prevSessionIdRef.current = sessionId;
+      retryCountRef.current = 0;
+      receivedFirstMessageRef.current = false;
+      dispatch({ type: 'CLEAR' });
+    }
 
     if (sessionId && enabled) {
       connect();


### PR DESCRIPTION
Fixes the cross-session state bleed discovered in the #3033 Catan L2/L3 final review.

## Root cause
App Router reuses `/sessions/[id]/live` across navigations (no per-session `key` on `page.tsx`), so `useSessionLiveStream`'s `useReducer` `events` accumulator persisted across a `sessionId` change. `RESET` deliberately preserves events (same-session reconnects) and the `(re)connect` effect never cleared them → a previous session's SSE events (game-state, player-join, chat/tool/diary) bled into the new session via `composeSessionLiveState` + the L1 game-state hydration mirror.

## Fix (root cause)
- New `CLEAR` reducer action (full reset: events + seenIds + lastEventId), dispatched from the `(re)connect` effect **only on a genuine `sessionId` change** (tracked via `prevSessionIdRef`). `RESET` stays reconnect-preserving.
- Defense-in-depth: the game-state hydration effect matches `e.sessionId === sessionId`, eliminating the single-frame flash before `CLEAR` flushes.

## Verification
- 2 new hook tests (events cleared on session change; preserved on same-session reconnect). Hook **26/26**, SessionLiveView **121/121**, `tsc --noEmit` clean.
- **Adversarial review (Opus): READY TO MERGE** — reconnect-regression / prevSessionIdRef / StrictMode / dropped-event-race / game-state-filter all SAFE.

## Follow-up (non-blocking)
- **#3055** — B's first connect after a session change still carries A's `lastEventId` cursor (pre-existing, benign; doesn't drop/dup events). Deferred to avoid touching `connect()` core in this fix.

Closes #3050.

🤖 Generated with [Claude Code](https://claude.com/claude-code)