### PR TITLE
fix(notifications): tolerate jsonb $type reorder in payload deserialization (3057)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Domain/Repositories/INotificationQueueRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Domain/Repositories/INotificationQueueRepository.cs
@@ -8,6 +8,16 @@ internal interface INotificationQueueRepository
     Task AddAsync(NotificationQueueItem item, CancellationToken ct = default);
     Task AddRangeAsync(IEnumerable<NotificationQueueItem> items, CancellationToken ct = default);
     Task UpdateAsync(NotificationQueueItem item, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns the next batch of pending (or retry-due failed) items for the channel.
+    /// </summary>
+    /// <remarks>
+    /// NOT a pure read: a row whose payload cannot be materialized is dead-lettered as a
+    /// self-healing side-effect (best-effort, independently committed) so a single poison row
+    /// can never stall the whole batch (#3057). Intended for the drainer jobs — do NOT call from a
+    /// read-only path (metrics, preview, admin count) where silently mutating rows is undesirable.
+    /// </remarks>
     Task<IReadOnlyList<NotificationQueueItem>> GetPendingByChannelAsync(
         NotificationChannelType channelType, int batchSize, CancellationToken ct = default);
     Task<int> GetPendingCountAsync(CancellationToken ct = default);

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Domain/ValueObjects/NotificationPayloads.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Domain/ValueObjects/NotificationPayloads.cs
@@ -46,7 +46,13 @@ public static class NotificationPayloadSerializer
         return new JsonSerializerOptions
         {
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-            WriteIndented = false
+            WriteIndented = false,
+            // #3057: payloads are persisted in a jsonb column, and Postgres reorders object keys
+            // by (length, then bytewise). For GenericPayload that moves the "$type" discriminator
+            // out of first position ({"body":..,"$type":..,"title":..}), which STJ polymorphic
+            // deserialization rejects by default. Tolerate the discriminator at any position so
+            // round-tripping through jsonb never throws (net9 feature).
+            AllowOutOfOrderMetadataProperties = true
         };
     }
 }

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Persistence/NotificationQueueRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Persistence/NotificationQueueRepository.cs
@@ -174,8 +174,11 @@ internal class NotificationQueueRepository : RepositoryBase, INotificationQueueR
 
     /// <summary>
     /// Best-effort dead-letters rows that could not be materialized, via a targeted UPDATE — the
-    /// domain aggregate cannot be reconstituted from an undeserializable payload, so this bypasses
-    /// the aggregate. Stops a poison row from being re-queried (and re-logged) every cycle. #3057.
+    /// domain aggregate cannot be reconstituted from an unmappable payload, so this bypasses the
+    /// aggregate. Stops a poison row from being re-queried (and re-logged) every cycle. #3057.
+    /// Genuinely best-effort: its own failure is swallowed so it can never discard the batch's
+    /// already-materialized deliverable items — the poison rows simply stay isolated (they never
+    /// re-enter the good set) and are re-attempted next cycle.
     /// </summary>
     private async Task DeadLetterUnmappableAsync(IReadOnlyCollection<Guid> poisonIds, CancellationToken ct)
     {
@@ -184,13 +187,26 @@ internal class NotificationQueueRepository : RepositoryBase, INotificationQueueR
             return;
         }
 
-        await DbContext.Set<NotificationQueueEntity>()
-            .Where(e => poisonIds.Contains(e.Id))
-            .ExecuteUpdateAsync(s => s
-                .SetProperty(e => e.Status, "dead_letter")
-                .SetProperty(e => e.LastError, "Payload could not be deserialized (isolated by #3057 guard)"),
-                ct)
-            .ConfigureAwait(false);
+        try
+        {
+            await DbContext.Set<NotificationQueueEntity>()
+                .Where(e => poisonIds.Contains(e.Id))
+                .ExecuteUpdateAsync(s => s
+                    .SetProperty(e => e.Status, "dead_letter")
+                    .SetProperty(e => e.NextRetryAt, (DateTime?)null)
+                    .SetProperty(e => e.LastError, "Row could not be materialized (unmappable payload); isolated by #3057 guard"),
+                    ct)
+                .ConfigureAwait(false);
+        }
+#pragma warning disable CA1031 // best-effort: dead-lettering must never discard the batch's deliverable items
+        catch (Exception ex)
+#pragma warning restore CA1031
+        {
+            _logger.LogError(
+                ex,
+                "Failed to dead-letter {Count} unmappable notification_queue_items row(s); they stay isolated from the batch and are re-attempted next cycle",
+                poisonIds.Count);
+        }
     }
 
     private static NotificationQueueEntity MapToPersistence(NotificationQueueItem item)

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Persistence/NotificationQueueRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Persistence/NotificationQueueRepository.cs
@@ -7,6 +7,7 @@ using Api.Infrastructure.Entities.UserNotifications;
 using Api.SharedKernel.Application.Services;
 using Api.SharedKernel.Infrastructure;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 
 namespace Api.BoundedContexts.UserNotifications.Infrastructure.Persistence;
 
@@ -17,9 +18,15 @@ namespace Api.BoundedContexts.UserNotifications.Infrastructure.Persistence;
 /// </summary>
 internal class NotificationQueueRepository : RepositoryBase, INotificationQueueRepository
 {
-    public NotificationQueueRepository(MeepleAiDbContext dbContext, IDomainEventCollector eventCollector)
+    private readonly ILogger<NotificationQueueRepository> _logger;
+
+    public NotificationQueueRepository(
+        MeepleAiDbContext dbContext,
+        IDomainEventCollector eventCollector,
+        ILogger<NotificationQueueRepository> logger)
         : base(dbContext, eventCollector)
     {
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
     public async Task AddAsync(NotificationQueueItem item, CancellationToken ct = default)
@@ -78,7 +85,9 @@ internal class NotificationQueueRepository : RepositoryBase, INotificationQueueR
             .Take(batchSize)
             .ToListAsync(ct).ConfigureAwait(false);
 
-        return entities.Select(MapToDomain).ToList();
+        var (items, poisonIds) = MaterializeResilient(entities);
+        await DeadLetterUnmappableAsync(poisonIds, ct).ConfigureAwait(false);
+        return items;
     }
 
     public async Task<int> GetPendingCountAsync(CancellationToken ct = default)
@@ -124,7 +133,64 @@ internal class NotificationQueueRepository : RepositoryBase, INotificationQueueR
             .Take(batchSize)
             .ToListAsync(ct).ConfigureAwait(false);
 
-        return entities.Select(MapToDomain).ToList();
+        // These rows are already dead-lettered; an unmappable one is just skipped (no re-dead-letter).
+        var (items, _) = MaterializeResilient(entities);
+        return items;
+    }
+
+    /// <summary>
+    /// Materializes entities to domain items, isolating any row whose payload cannot be
+    /// deserialized (unknown "$type", corrupt JSON, …) so a single poison row can never fail the
+    /// whole batch — the root cause of the #3057 email-notification outage, where one malformed
+    /// row made the entire <c>GetPendingByChannelAsync</c> query throw and no email was processed.
+    /// Returns the successfully mapped items plus the ids of the rows that failed to map.
+    /// </summary>
+    private (List<NotificationQueueItem> Items, List<Guid> PoisonIds) MaterializeResilient(
+        IReadOnlyList<NotificationQueueEntity> entities)
+    {
+        var items = new List<NotificationQueueItem>(entities.Count);
+        var poisonIds = new List<Guid>();
+
+        foreach (var entity in entities)
+        {
+            try
+            {
+                items.Add(MapToDomain(entity));
+            }
+#pragma warning disable CA1031 // one malformed row must not abort the batch — isolate + dead-letter it
+            catch (Exception ex)
+#pragma warning restore CA1031
+            {
+                _logger.LogError(
+                    ex,
+                    "notification_queue_items {NotificationQueueItemId} could not be materialized (payload deserialization failed); dead-lettering it so it cannot block the batch",
+                    entity.Id);
+                poisonIds.Add(entity.Id);
+            }
+        }
+
+        return (items, poisonIds);
+    }
+
+    /// <summary>
+    /// Best-effort dead-letters rows that could not be materialized, via a targeted UPDATE — the
+    /// domain aggregate cannot be reconstituted from an undeserializable payload, so this bypasses
+    /// the aggregate. Stops a poison row from being re-queried (and re-logged) every cycle. #3057.
+    /// </summary>
+    private async Task DeadLetterUnmappableAsync(IReadOnlyCollection<Guid> poisonIds, CancellationToken ct)
+    {
+        if (poisonIds.Count == 0)
+        {
+            return;
+        }
+
+        await DbContext.Set<NotificationQueueEntity>()
+            .Where(e => poisonIds.Contains(e.Id))
+            .ExecuteUpdateAsync(s => s
+                .SetProperty(e => e.Status, "dead_letter")
+                .SetProperty(e => e.LastError, "Payload could not be deserialized (isolated by #3057 guard)"),
+                ct)
+            .ConfigureAwait(false);
     }
 
     private static NotificationQueueEntity MapToPersistence(NotificationQueueItem item)

--- a/apps/api/tests/Api.Tests/BoundedContexts/UserNotifications/Domain/ValueObjects/NotificationPayloadSerializationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/UserNotifications/Domain/ValueObjects/NotificationPayloadSerializationTests.cs
@@ -147,6 +147,25 @@ public sealed class NotificationPayloadSerializationTests
         result.Body.Should().Be("Maintenance window at 2 AM");
     }
 
+    [Fact]
+    public void Deserialize_GenericPayload_WithDiscriminatorNotFirst_Succeeds()
+    {
+        // Regression #3057: the payload column is jsonb, and Postgres reorders object keys by
+        // (length, then bytewise). For GenericPayload that yields {"body":..,"$type":..,"title":..}
+        // — the "$type" discriminator is NOT the first property. STJ polymorphic deserialization
+        // must tolerate this (AllowOutOfOrderMetadataProperties); otherwise MapToDomain throws,
+        // EmailNotificationProcessorJob crash-loops, and one poison row blocks the whole email batch.
+        const string jsonbReordered =
+            """{"body":"Maintenance window at 2 AM","$type":"GenericPayload","title":"System Update"}""";
+
+        var deserialized = JsonSerializer.Deserialize<INotificationPayload>(jsonbReordered, Options);
+
+        deserialized.Should().BeOfType<GenericPayload>();
+        var result = (GenericPayload)deserialized!;
+        result.Title.Should().Be("System Update");
+        result.Body.Should().Be("Maintenance window at 2 AM");
+    }
+
     #endregion
 
     #region Type Discriminator Behavior Tests

--- a/apps/api/tests/Api.Tests/Integration/UserNotifications/NotificationQueueRepositoryPayloadResilienceIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/UserNotifications/NotificationQueueRepositoryPayloadResilienceIntegrationTests.cs
@@ -1,0 +1,160 @@
+using System.Text.Json;
+using Api.BoundedContexts.UserNotifications.Domain.Repositories;
+using Api.BoundedContexts.UserNotifications.Domain.ValueObjects;
+using Api.BoundedContexts.UserNotifications.Infrastructure.Persistence;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.UserNotifications;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Npgsql;
+using Xunit;
+
+namespace Api.Tests.Integration.UserNotifications;
+
+/// <summary>
+/// Integration tests for <see cref="NotificationQueueRepository"/> payload materialization against a
+/// real Testcontainers PostgreSQL instance — the only harness that reproduces jsonb key reordering.
+///
+/// Regression guards for #3057: the <c>payload</c> jsonb column reorders object keys by
+/// (length, then bytewise), moving the polymorphic <c>"$type"</c> discriminator out of first
+/// position for <see cref="GenericPayload"/> ({"body":..,"$type":..,"title":..}). STJ rejected that,
+/// so <see cref="NotificationQueueRepository.GetPendingByChannelAsync"/> threw for the whole batch,
+/// <c>EmailNotificationProcessorJob</c> crash-looped, and one poison row blocked every email.
+/// </summary>
+[Collection("Integration-GroupD")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("Dependency", "PostgreSQL")]
+[Trait("BoundedContext", "UserNotifications")]
+public sealed class NotificationQueueRepositoryPayloadResilienceIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private string _databaseName = string.Empty;
+    private MeepleAiDbContext? _dbContext;
+    private INotificationQueueRepository? _repository;
+    private IServiceProvider? _serviceProvider;
+
+    private static CancellationToken TestCancellationToken => TestContext.Current.CancellationToken;
+
+    public NotificationQueueRepositoryPayloadResilienceIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        _databaseName = $"test_notifqueuepayload_{Guid.NewGuid():N}";
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+
+        var services = IntegrationServiceCollectionBuilder.CreateBase(connectionString);
+        services.AddScoped<INotificationQueueRepository, NotificationQueueRepository>();
+
+        _serviceProvider = services.BuildServiceProvider();
+        _dbContext = _serviceProvider.GetRequiredService<MeepleAiDbContext>();
+        _repository = _serviceProvider.GetRequiredService<INotificationQueueRepository>();
+
+        for (var attempt = 0; attempt < 3; attempt++)
+        {
+            try
+            {
+                await _dbContext.Database.MigrateAsync(TestCancellationToken);
+                break;
+            }
+            catch (NpgsqlException) when (attempt < 2)
+            {
+                await Task.Delay(TestConstants.Timing.RetryDelay, TestCancellationToken);
+            }
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _dbContext?.Dispose();
+        if (!string.IsNullOrEmpty(_databaseName))
+        {
+            try
+            {
+                await _fixture.DropIsolatedDatabaseAsync(_databaseName);
+            }
+            catch (NpgsqlException)
+            {
+                // Best-effort cleanup.
+            }
+        }
+    }
+
+    [Fact]
+    public async Task GetPendingByChannelAsync_GenericPayloadEmailItem_RoundTripsThroughJsonb()
+    {
+        // A GenericPayload serialized with "$type" first, stored in the jsonb column, comes back
+        // reordered ("$type" no longer first). Post-#3057 it must still deserialize to GenericPayload.
+        var id = Guid.NewGuid();
+        await SeedRawAsync(RawEmailEntity(
+            id,
+            payload: Serialize(new GenericPayload("System Update", "Maintenance window at 2 AM"))));
+
+        var pending = await _repository!.GetPendingByChannelAsync(
+            NotificationChannelType.Email, 10, TestCancellationToken);
+
+        pending.Should().ContainSingle();
+        pending[0].Payload.Should().BeOfType<GenericPayload>();
+        var payload = (GenericPayload)pending[0].Payload;
+        payload.Title.Should().Be("System Update");
+        payload.Body.Should().Be("Maintenance window at 2 AM");
+    }
+
+    [Fact]
+    public async Task GetPendingByChannelAsync_PoisonRowAmongGoodRows_ReturnsGoodAndDeadLettersPoison()
+    {
+        // A row whose payload can never be deserialized (no discriminator at all) must not fail the
+        // whole batch: the good row is returned and the poison row is dead-lettered so it stops being
+        // re-queried every cycle.
+        var poisonId = Guid.NewGuid();
+        var goodId = Guid.NewGuid();
+        await SeedRawAsync(
+            RawEmailEntity(poisonId, payload: "{\"missing\":\"discriminator\"}"),
+            RawEmailEntity(goodId, payload: Serialize(
+                new BadgePayload(Guid.NewGuid(), "First Upload", "Uploaded your first PDF"))));
+
+        var pending = await _repository!.GetPendingByChannelAsync(
+            NotificationChannelType.Email, 10, TestCancellationToken);
+
+        pending.Should().ContainSingle().Which.Id.Should().Be(goodId);
+
+        var poisonRow = await _dbContext!.Set<NotificationQueueEntity>()
+            .AsNoTracking()
+            .FirstAsync(e => e.Id == poisonId, TestCancellationToken);
+        poisonRow.Status.Should().Be("dead_letter");
+    }
+
+    private static string Serialize(INotificationPayload payload) =>
+        JsonSerializer.Serialize(payload, NotificationPayloadSerializer.CreateOptions());
+
+    private async Task SeedRawAsync(params NotificationQueueEntity[] items)
+    {
+        await _dbContext!.Set<NotificationQueueEntity>().AddRangeAsync(items, TestCancellationToken);
+        await _dbContext.SaveChangesAsync(TestCancellationToken);
+        _dbContext.ChangeTracker.Clear();
+    }
+
+    private static NotificationQueueEntity RawEmailEntity(Guid id, string payload)
+    {
+        return new NotificationQueueEntity
+        {
+            Id = id,
+            ChannelType = NotificationChannelType.Email.Value,
+            RecipientUserId = Guid.NewGuid(),
+            NotificationType = "badge_earned",
+            Payload = payload,
+            Status = "pending",
+            RetryCount = 0,
+            MaxRetries = 3,
+            NextRetryAt = null,
+            CreatedAt = DateTime.UtcNow,
+            CorrelationId = Guid.NewGuid(),
+            SourceEventId = null,
+        };
+    }
+}

--- a/apps/api/tests/Api.Tests/Integration/UserNotifications/NotificationQueueRepositoryPayloadResilienceIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/UserNotifications/NotificationQueueRepositoryPayloadResilienceIntegrationTests.cs
@@ -127,6 +127,12 @@ public sealed class NotificationQueueRepositoryPayloadResilienceIntegrationTests
             .AsNoTracking()
             .FirstAsync(e => e.Id == poisonId, TestCancellationToken);
         poisonRow.Status.Should().Be("dead_letter");
+        poisonRow.LastError.Should().Contain("#3057");
+
+        // The poison row is now isolated: a second drain no longer re-queries it.
+        var secondPending = await _repository!.GetPendingByChannelAsync(
+            NotificationChannelType.Email, 10, TestCancellationToken);
+        secondPending.Should().NotContain(i => i.Id == poisonId);
     }
 
     private static string Serialize(INotificationPayload payload) =>


### PR DESCRIPTION
## Problema (P1)
`EmailNotificationProcessorJob` (#3032) **crashava** su ogni notifica email con `GenericPayload`, e poiché `GetPendingByChannelAsync` materializza l'intero batch (`.ToList()`), **una sola riga avvelenata bloccava TUTTE le email** — e non veniva mai dead-letterata (fallisce al materialize, prima del loop per-item). Verificato live su staging 2026-07-16.

## Causa radice
`INotificationPayload` è `[JsonPolymorphic(TypeDiscriminatorPropertyName = "$type")]`. STJ esige `$type` come **prima** proprietà. La colonna `payload` è `jsonb`, e Postgres `jsonb` **riordina le chiavi per (lunghezza, poi bytewise)**. Per `GenericPayload` le chiavi sono `body`(4) < `$type`(5) → salvato `{"body":..,"$type":..,"title":..}` → `$type` non è più primo → `NotSupportedException: ... must specify a type discriminator`.

I payload tipizzati (Badge/GameNight/ShareRequest/Pdf) sopravvivono solo perché lì `$type` è la chiave più corta → il bug si nasconde finché una payload "short-key" (GenericPayload) non tocca la colonna. **~12 handler reali emettono `GenericPayload`** (AgentReady, RateLimitApproaching, ShareRequest admin, GameNightRsvp, UserSuspended, …) → attivo, non teorico. I round-trip unit **in-memory** passavano (ordine preservato) → gap catturato solo dal jsonb reale.

## Fix
1. **Causa radice (1 riga)**: `AllowOutOfOrderMetadataProperties = true` in `NotificationPayloadSerializer.CreateOptions()` (feature net9) — STJ tollera il discriminante in qualsiasi posizione, così i payload sopravvivono al round-trip jsonb. Copre serialize + deserialize (entrambi usano `CreateOptions()`).
2. **Defense-in-depth**: `NotificationQueueRepository` materializza il batch in modo resiliente — una riga che comunque non deserializza viene isolata + **dead-letterata** (via `ExecuteUpdateAsync`; l'aggregate non è ricostruibile da un payload corrotto) invece di far fallire l'intera `GetPendingByChannelAsync`.

## Test (TDD)
- **Unit** che riproduce il reorder jsonb (`$type` non primo) — RED (stessa `NotSupportedException` di staging) → GREEN.
- **Testcontainers integration**: round-trip `GenericPayload` attraverso jsonb reale + isolamento poison-row (good ritornato, poison → `dead_letter`).
- 50 unit + 2 integration verdi, 0 regressioni.

## Verifica live
Su staging (`staging-20260716-114a172`): prima del fix il job crashava ogni 30s su una riga `GenericPayload`; una riga `BadgePayload` tipizzata inviava correttamente. Post-merge+deploy si riverifica una notifica `GenericPayload` end-to-end.

Companion (issue separata, non chiusa da questa PR): #3058 — invio notifica manuale admin rotto (`TemplateName` invalido).

Closes #3057

🤖 Generated with [Claude Code](https://claude.com/claude-code)
