### PR TITLE
fix(tests): aggiungi getSystemResources al mock api.admin di containers/page.test (#3052)

### DIFF
--- a/apps/web/src/app/admin/(dashboard)/monitor/containers/__tests__/page.test.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/containers/__tests__/page.test.tsx
@@ -18,6 +18,7 @@ const mockGetDockerContainers = vi.hoisted(() => vi.fn());
 const mockRestartService = vi.hoisted(() => vi.fn());
 const mockGetMetricsTimeSeries = vi.hoisted(() => vi.fn());
 const mockGetAllBatchJobs = vi.hoisted(() => vi.fn());
+const mockGetSystemResources = vi.hoisted(() => vi.fn());
 
 vi.mock('@/lib/api', () => ({
   api: {
@@ -26,6 +27,7 @@ vi.mock('@/lib/api', () => ({
       restartService: mockRestartService,
       getMetricsTimeSeries: mockGetMetricsTimeSeries,
       getAllBatchJobs: mockGetAllBatchJobs,
+      getSystemResources: mockGetSystemResources,
     },
   },
 }));
@@ -56,6 +58,7 @@ describe('ContainerDashboardPage', () => {
     mockGetDockerContainers.mockReturnValue(new Promise(() => {}));
     mockGetMetricsTimeSeries.mockReturnValue(new Promise(() => {}));
     mockGetAllBatchJobs.mockReturnValue(new Promise(() => {}));
+    mockGetSystemResources.mockReturnValue(new Promise(() => {}));
   });
 
   it('renders page with title', () => {


### PR DESCRIPTION
## Cosa

Follow-up a **#3052** (self-contained system resources endpoint CPU/RAM/uptime): sistema 3 test rossi su `admin/(dashboard)/monitor/containers/__tests__/page.test.tsx`.

`ContainerDashboardPage` consuma il hook `use-infrastructure-kpis`, che dopo #3052 chiama `api.admin.getSystemResources()`. #3052 ha aggiornato il mock del test del hook (`use-infrastructure-kpis.test.tsx`) ma **ha mancato** quello della pagina → 3 test falliscono con `TypeError: api.admin.getSystemResources is not a function`.

## Non è un bug runtime

Il metodo client **esiste** (`apps/web/src/lib/api/clients/admin/adminSystemClient.ts:269`), il hook lo usa correttamente, il mock del test del hook lo include. Era **solo** il mock di `page.test.tsx` a essere incompleto.

## Fix

Allineato il mock di `page.test.tsx` al sibling: `mockGetSystemResources` (`vi.hoisted`) + voce nel mock `api.admin` + promise pendente in `beforeEach`, coerente con gli altri 3 endpoint (i test verificano solo la struttura in stato loading).

## Perché non emerso al merge di #3052

I Frontend Tests fallivano già su altri baseline mascherati a strati (catan-palette lint, validate-fidelity). Questo fallimento è emerso solo dopo lo sblocco del Frontend Static (#3059).

## Verifica

`pnpm vitest run "src/app/admin/(dashboard)/monitor/containers/__tests__/page.test.tsx"` → **3/3 passed** (prima: 3 failed). Con questo, "Frontend Tests" torna verde su main-dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
