### PR TITLE
feat(session-live): #2788 Wingspan L2+L3 flavor (themed scoring + round context)

### DIFF
--- a/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx
@@ -104,7 +104,6 @@ import {
   LiveSessionNotes,
   RightColumnTabs,
   ToolkitRenderer,
-  type CatanLiveFlavorLabels,
   type ConnectionLostBannerLabels,
   type LiveAgentChatLabels,
   type LiveSessionNotesLabels,
@@ -1131,46 +1130,6 @@ export function SessionLiveView(): ReactElement {
   const phasesQuery = useLiveSessionPhases(sessionId ?? '', showFlavorTab && sessionId != null);
   const catanPhaseName = phasesQuery.data?.currentPhaseName ?? null;
 
-  // Placeholder-bearing templates ({n}/{name}/{score}) are read RAW from
-  // intl.messages so react-intl does NOT ICU-interpolate them — the flavor
-  // component does the runtime .replace. Same pattern as the toolkitRenderer
-  // aria templates above. Non-placeholder labels use t() normally.
-  const catanFlavorLabels = useMemo<CatanLiveFlavorLabels>(
-    () => ({
-      panelAriaLabel: t('pages.sessionLive.flavor.catan.panelAriaLabel'),
-      roundTemplate:
-        (intl.messages['pages.sessionLive.flavor.catan.roundTemplate'] as string) ?? 'Round {n}',
-      activePlayerTemplate:
-        (intl.messages['pages.sessionLive.flavor.catan.activePlayerTemplate'] as string) ??
-        'Turno di {name}',
-      phaseTemplate:
-        (intl.messages['pages.sessionLive.flavor.catan.phaseTemplate'] as string) ?? 'Fase: {name}',
-      initBoardCta: t('pages.sessionLive.flavor.catan.initBoardCta'),
-      viewerWaiting: t('pages.sessionLive.flavor.catan.viewerWaiting'),
-      hexAriaTemplate:
-        (intl.messages['pages.sessionLive.flavor.catan.hexAriaTemplate'] as string) ??
-        '{terrain} {number}',
-      robberLabel: t('pages.sessionLive.flavor.catan.robberLabel'),
-      diceLastLabel: t('pages.sessionLive.flavor.catan.diceLastLabel'),
-      diceHistoryLabel: t('pages.sessionLive.flavor.catan.diceHistoryLabel'),
-      rollAriaTemplate:
-        (intl.messages['pages.sessionLive.flavor.catan.rollAriaTemplate'] as string) ??
-        'Registra tiro {n}',
-      vpLabel: t('pages.sessionLive.flavor.catan.vpLabel'),
-      handLabel: t('pages.sessionLive.flavor.catan.handLabel'),
-      devLabel: t('pages.sessionLive.flavor.catan.devLabel'),
-      settlementsLabel: t('pages.sessionLive.flavor.catan.settlementsLabel'),
-      citiesLabel: t('pages.sessionLive.flavor.catan.citiesLabel'),
-      roadsLabel: t('pages.sessionLive.flavor.catan.roadsLabel'),
-      longestRoadLabel: t('pages.sessionLive.flavor.catan.longestRoadLabel'),
-      largestArmyLabel: t('pages.sessionLive.flavor.catan.largestArmyLabel'),
-      incAriaTemplate:
-        (intl.messages['pages.sessionLive.flavor.catan.incAriaTemplate'] as string) ?? '{field} +1',
-      decAriaTemplate:
-        (intl.messages['pages.sessionLive.flavor.catan.decAriaTemplate'] as string) ?? '{field} -1',
-    }),
-    [t, intl.messages]
-  );
   // #2787: never strand the user on ?tab=flavor / ?mtab=flavor when the game has
   // no flavor (e.g. a stale bookmark carried to a non-catan session) — the flavor
   // tab button is hidden (showFlavorTab=false), so fall the panel back to 'score'.
@@ -1410,7 +1369,6 @@ export function SessionLiveView(): ReactElement {
             gameSlug={liveSessionDto.gameSlug}
             view="live"
             session={liveSessionDto}
-            labels={catanFlavorLabels}
             viewerRole={activeSession.viewerRole}
             sessionId={liveSessionDto.id}
             livePoints={catanLivePoints}
@@ -1495,7 +1453,6 @@ export function SessionLiveView(): ReactElement {
     effectiveMobileTab,
     activeSession,
     liveSessionDto,
-    catanFlavorLabels,
     catanLivePoints,
     catanPhaseName,
     sessionId,
@@ -1636,7 +1593,6 @@ export function SessionLiveView(): ReactElement {
           gameSlug={liveSessionDto.gameSlug}
           view="live"
           session={liveSessionDto}
-          labels={catanFlavorLabels}
           viewerRole={activeSession.viewerRole}
           sessionId={liveSessionDto.id}
           livePoints={catanLivePoints}

--- a/apps/web/src/components/features/session-live/FlavorRenderer.tsx
+++ b/apps/web/src/components/features/session-live/FlavorRenderer.tsx
@@ -9,11 +9,21 @@ import type { ParticipantRole } from '@/lib/session-live/participant-role';
 
 import { FlavorLoadingSkeleton } from './FlavorLoadingSkeleton';
 
-import type { CatanLiveFlavorLabels, CatanLiveFlavorProps } from './flavors/catan/CatanLiveFlavor';
-
 export type FlavorView = 'live';
 
-type FlavorComponent = ComponentType<CatanLiveFlavorProps>;
+/** Game-agnostic props every per-game flavor component must accept. */
+export interface FlavorProps {
+  readonly session: LiveSessionDto;
+  readonly viewerRole: ParticipantRole;
+  readonly sessionId: string;
+  readonly className?: string;
+  /** #2787: live SignalR points (playerId→points) forwarded to the flavor. */
+  readonly livePoints?: ReadonlyMap<string, number> | null;
+  /** #2787: current phase name forwarded to the flavor. */
+  readonly phaseName?: string | null;
+}
+
+type FlavorComponent = ComponentType<FlavorProps>;
 
 // Lazy chunks are created at MODULE scope — NEVER inside render (that would
 // mint a new component identity every render → remount loop). The loader
@@ -21,6 +31,14 @@ type FlavorComponent = ComponentType<CatanLiveFlavorProps>;
 // KbGlobaleView.tsx) and satisfy next/dynamic's TS loader type.
 const CatanLiveFlavorLazy: FlavorComponent = dynamic(
   () => import('./flavors/catan/CatanLiveFlavor').then(m => ({ default: m.CatanLiveFlavor })),
+  { ssr: false, loading: () => <FlavorLoadingSkeleton /> }
+);
+
+const WingspanLiveFlavorLazy: FlavorComponent = dynamic(
+  () =>
+    import('./flavors/wingspan/WingspanLiveFlavor').then(m => ({
+      default: m.WingspanLiveFlavor,
+    })),
   { ssr: false, loading: () => <FlavorLoadingSkeleton /> }
 );
 
@@ -32,31 +50,22 @@ const CatanLiveFlavorLazy: FlavorComponent = dynamic(
  */
 const FLAVOR_MAP: Record<string, Partial<Record<FlavorView, FlavorComponent>>> = {
   catan: { live: CatanLiveFlavorLazy },
+  wingspan: { live: WingspanLiveFlavorLazy },
 };
 
 export function hasFlavor(gameSlug: string | null | undefined): boolean {
   return gameSlug != null && FLAVOR_MAP[gameSlug]?.live != null;
 }
 
-export interface FlavorRendererProps {
+export interface FlavorRendererProps extends FlavorProps {
   readonly gameSlug: string | null | undefined;
   readonly view: FlavorView;
-  readonly session: LiveSessionDto;
-  readonly labels: CatanLiveFlavorLabels;
-  readonly viewerRole: ParticipantRole;
-  readonly sessionId: string;
-  readonly className?: string;
-  /** #2787: live SignalR points (playerId→points) forwarded to the flavor. */
-  readonly livePoints?: ReadonlyMap<string, number> | null;
-  /** #2787: current phase name forwarded to the flavor. */
-  readonly phaseName?: string | null;
 }
 
 export function FlavorRenderer({
   gameSlug,
   view,
   session,
-  labels,
   viewerRole,
   sessionId,
   className,
@@ -68,7 +77,6 @@ export function FlavorRenderer({
   return (
     <LazyFlavor
       session={session}
-      labels={labels}
       viewerRole={viewerRole}
       sessionId={sessionId}
       className={className}

--- a/apps/web/src/components/features/session-live/__tests__/FlavorRenderer.test.tsx
+++ b/apps/web/src/components/features/session-live/__tests__/FlavorRenderer.test.tsx
@@ -1,38 +1,28 @@
 import { render, screen } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
 import { describe, expect, it, vi } from 'vitest';
 
 import type { LiveSessionDto } from '@/lib/api/schemas/live-sessions.schemas';
 
-import type { CatanLiveFlavorLabels } from '../flavors/catan/CatanLiveFlavor';
 import { FlavorRenderer, hasFlavor } from '../FlavorRenderer';
 
 vi.mock('@/hooks/mutations/useUpdateLiveGameState', () => ({
   useUpdateLiveGameState: () => ({ mutate: vi.fn() }),
 }));
 
-const LABELS: CatanLiveFlavorLabels = {
-  panelAriaLabel: 'Pannello Catan',
-  roundTemplate: 'Round {n}',
-  activePlayerTemplate: 'Turno di {name}',
-  phaseTemplate: 'Fase: {name}',
-  initBoardCta: 'Genera board Catan',
-  viewerWaiting: 'In attesa dell’host',
-  hexAriaTemplate: '{terrain} {number}',
-  robberLabel: 'Ladro',
-  diceLastLabel: 'Ultimo tiro',
-  diceHistoryLabel: 'Cronologia',
-  rollAriaTemplate: 'Registra tiro {n}',
-  vpLabel: 'PV',
-  handLabel: 'Mano',
-  devLabel: 'Sviluppo',
-  settlementsLabel: 'Insediamenti',
-  citiesLabel: 'Città',
-  roadsLabel: 'Strade',
-  longestRoadLabel: 'Strada+',
-  largestArmyLabel: 'Armata+',
-  incAriaTemplate: '{field} +1',
-  decAriaTemplate: '{field} -1',
-};
+// #2788: flavor components self-build labels via useTranslation/useIntl now,
+// so tests render through an IntlProvider. `onError` swallows react-intl
+// MISSING_TRANSLATION noise (empty messages → t() returns the raw key).
+const PANEL_ARIA_KEY = 'pages.sessionLive.flavor.catan.panelAriaLabel';
+const WAITING_KEY = 'pages.sessionLive.flavor.catan.viewerWaiting';
+
+function renderWithIntl(ui: React.ReactElement) {
+  return render(
+    <IntlProvider locale="en" messages={{}} onError={() => {}}>
+      {ui}
+    </IntlProvider>
+  );
+}
 
 const SESSION = {
   gameSlug: 'catan',
@@ -58,9 +48,10 @@ const SESSION = {
 } as unknown as LiveSessionDto;
 
 describe('hasFlavor', () => {
-  it('is true for catan, false for unknown / null / undefined', () => {
+  it('is true for catan and wingspan, false for unknown / null / undefined', () => {
     expect(hasFlavor('catan')).toBe(true);
-    expect(hasFlavor('wingspan')).toBe(false);
+    expect(hasFlavor('wingspan')).toBe(true);
+    expect(hasFlavor('chess')).toBe(false);
     expect(hasFlavor(null)).toBe(false);
     expect(hasFlavor(undefined)).toBe(false);
   });
@@ -73,7 +64,6 @@ describe('FlavorRenderer', () => {
         gameSlug="chess"
         view="live"
         session={SESSION}
-        labels={LABELS}
         viewerRole="Player"
         sessionId="s1"
       />
@@ -82,20 +72,19 @@ describe('FlavorRenderer', () => {
   });
 
   it('lazy-loads and renders the Catan flavor for gameSlug=catan, forwarding viewerRole/sessionId', async () => {
-    render(
+    renderWithIntl(
       <FlavorRenderer
         gameSlug="catan"
         view="live"
         session={SESSION}
-        labels={LABELS}
         viewerRole="Player"
         sessionId="s1"
       />
     );
-    // <section aria-label="Pannello Catan"> → implicit role="region"
-    expect(await screen.findByRole('region', { name: 'Pannello Catan' })).toBeInTheDocument();
+    // <section aria-label={t(...)}> → implicit role="region"
+    expect(await screen.findByRole('region', { name: PANEL_ARIA_KEY })).toBeInTheDocument();
     // Player (non-Host) sees the waiting message, not the host CTA — proves
     // viewerRole was actually forwarded through to the lazy flavor.
-    expect(screen.getByText('In attesa dell’host')).toBeInTheDocument();
+    expect(screen.getByText(WAITING_KEY)).toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/features/session-live/flavors/catan/CatanLiveFlavor.tsx
+++ b/apps/web/src/components/features/session-live/flavors/catan/CatanLiveFlavor.tsx
@@ -2,6 +2,9 @@
 
 import { type ReactElement } from 'react';
 
+import { useIntl } from 'react-intl';
+
+import { useTranslation } from '@/hooks/useTranslation';
 import type { LiveSessionDto } from '@/lib/api/schemas/live-sessions.schemas';
 import { hasRequiredRole, type ParticipantRole } from '@/lib/session-live/participant-role';
 import { useLiveSessionStore } from '@/lib/stores/live-session-store';
@@ -12,7 +15,8 @@ import { CatanHexBoard } from './CatanHexBoard';
 import { CatanPlayerCard, type CatanPlayerCardLabels } from './CatanPlayerCard';
 import { useCatanStateEditor } from './use-catan-state-editor';
 
-export interface CatanLiveFlavorLabels extends CatanPlayerCardLabels {
+/** Internal-only — no longer a component prop; the flavor self-builds it via i18n. */
+interface CatanLiveFlavorLabels extends CatanPlayerCardLabels {
   readonly panelAriaLabel: string;
   readonly roundTemplate: string; // "Round {n}"
   readonly activePlayerTemplate: string; // "Turno di {name}"
@@ -28,7 +32,6 @@ export interface CatanLiveFlavorLabels extends CatanPlayerCardLabels {
 
 export interface CatanLiveFlavorProps {
   readonly session: LiveSessionDto;
-  readonly labels: CatanLiveFlavorLabels;
   readonly viewerRole: ParticipantRole;
   readonly sessionId: string;
   readonly className?: string;
@@ -38,16 +41,55 @@ export interface CatanLiveFlavorProps {
 
 export function CatanLiveFlavor({
   session,
-  labels,
   viewerRole,
   sessionId,
   className,
   livePoints,
   phaseName,
 }: CatanLiveFlavorProps): ReactElement {
+  const { t } = useTranslation();
+  const intl = useIntl();
   const isHost = hasRequiredRole(viewerRole, 'Host');
   const playerIds = session.players.map(p => p.id);
   const editor = useCatanStateEditor(sessionId, playerIds);
+
+  // Placeholder-bearing templates ({n}/{name}/{score}) are read RAW from
+  // intl.messages so react-intl does NOT ICU-interpolate them — the flavor
+  // component does the runtime .replace. Same pattern as the toolkitRenderer
+  // aria templates. Non-placeholder labels use t() normally.
+  const labels: CatanLiveFlavorLabels = {
+    panelAriaLabel: t('pages.sessionLive.flavor.catan.panelAriaLabel'),
+    roundTemplate:
+      (intl.messages['pages.sessionLive.flavor.catan.roundTemplate'] as string) ?? 'Round {n}',
+    activePlayerTemplate:
+      (intl.messages['pages.sessionLive.flavor.catan.activePlayerTemplate'] as string) ??
+      'Turno di {name}',
+    phaseTemplate:
+      (intl.messages['pages.sessionLive.flavor.catan.phaseTemplate'] as string) ?? 'Fase: {name}',
+    initBoardCta: t('pages.sessionLive.flavor.catan.initBoardCta'),
+    viewerWaiting: t('pages.sessionLive.flavor.catan.viewerWaiting'),
+    hexAriaTemplate:
+      (intl.messages['pages.sessionLive.flavor.catan.hexAriaTemplate'] as string) ??
+      '{terrain} {number}',
+    robberLabel: t('pages.sessionLive.flavor.catan.robberLabel'),
+    diceLastLabel: t('pages.sessionLive.flavor.catan.diceLastLabel'),
+    diceHistoryLabel: t('pages.sessionLive.flavor.catan.diceHistoryLabel'),
+    rollAriaTemplate:
+      (intl.messages['pages.sessionLive.flavor.catan.rollAriaTemplate'] as string) ??
+      'Registra tiro {n}',
+    vpLabel: t('pages.sessionLive.flavor.catan.vpLabel'),
+    handLabel: t('pages.sessionLive.flavor.catan.handLabel'),
+    devLabel: t('pages.sessionLive.flavor.catan.devLabel'),
+    settlementsLabel: t('pages.sessionLive.flavor.catan.settlementsLabel'),
+    citiesLabel: t('pages.sessionLive.flavor.catan.citiesLabel'),
+    roadsLabel: t('pages.sessionLive.flavor.catan.roadsLabel'),
+    longestRoadLabel: t('pages.sessionLive.flavor.catan.longestRoadLabel'),
+    largestArmyLabel: t('pages.sessionLive.flavor.catan.largestArmyLabel'),
+    incAriaTemplate:
+      (intl.messages['pages.sessionLive.flavor.catan.incAriaTemplate'] as string) ?? '{field} +1',
+    decAriaTemplate:
+      (intl.messages['pages.sessionLive.flavor.catan.decAriaTemplate'] as string) ?? '{field} -1',
+  };
 
   const rawGameState = useLiveSessionStore(s => s.gameState);
   // Parse defensively; a non-catan gameState (or none) → empty view.

--- a/apps/web/src/components/features/session-live/flavors/catan/__tests__/CatanLiveFlavor.test.tsx
+++ b/apps/web/src/components/features/session-live/flavors/catan/__tests__/CatanLiveFlavor.test.tsx
@@ -1,8 +1,9 @@
 import { describe, expect, it, beforeEach, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
 import { axe, toHaveNoViolations } from 'jest-axe';
 
-import { CatanLiveFlavor, type CatanLiveFlavorLabels } from '../CatanLiveFlavor';
+import { CatanLiveFlavor } from '../CatanLiveFlavor';
 import { useLiveSessionStore } from '@/lib/stores/live-session-store';
 import { generateStandardBoard } from '../catan-board-preset';
 import { emptyCatanPlayerState } from '../catan-state';
@@ -13,29 +14,19 @@ vi.mock('@/hooks/mutations/useUpdateLiveGameState', () => ({
   useUpdateLiveGameState: () => ({ mutate: vi.fn() }),
 }));
 
-const labels: CatanLiveFlavorLabels = {
-  panelAriaLabel: 'Catan',
-  roundTemplate: 'Round {n}',
-  activePlayerTemplate: 'Turno di {name}',
-  phaseTemplate: 'Fase: {name}',
-  initBoardCta: 'Genera board Catan',
-  viewerWaiting: 'In attesa dell’host',
-  hexAriaTemplate: '{terrain} {number}',
-  robberLabel: 'Ladro',
-  diceLastLabel: 'Ultimo tiro',
-  diceHistoryLabel: 'Cronologia',
-  rollAriaTemplate: 'Registra tiro {n}',
-  vpLabel: 'PV',
-  handLabel: 'Mano',
-  devLabel: 'Sviluppo',
-  settlementsLabel: 'Insediamenti',
-  citiesLabel: 'Città',
-  roadsLabel: 'Strade',
-  longestRoadLabel: 'Strada+',
-  largestArmyLabel: 'Armata+',
-  incAriaTemplate: '{field} +1',
-  decAriaTemplate: '{field} -1',
-};
+// #2788: CatanLiveFlavor now self-builds its labels via useTranslation/useIntl,
+// so tests must supply the IntlProvider. `onError` swallows react-intl
+// MISSING_TRANSLATION noise (empty messages → t() returns the raw key).
+const CTA_KEY = 'pages.sessionLive.flavor.catan.initBoardCta';
+const WAITING_KEY = 'pages.sessionLive.flavor.catan.viewerWaiting';
+
+function renderFlavor(props: Parameters<typeof CatanLiveFlavor>[0]) {
+  return render(
+    <IntlProvider locale="en" messages={{}} onError={() => {}}>
+      <CatanLiveFlavor {...props} />
+    </IntlProvider>
+  );
+}
 
 const session = {
   id: 's1',
@@ -94,16 +85,14 @@ beforeEach(() => useLiveSessionStore.getState().reset());
 
 describe('CatanLiveFlavor', () => {
   it('empty state — host sees the "Genera board" CTA', () => {
-    render(<CatanLiveFlavor session={session} labels={labels} viewerRole="Host" sessionId="s1" />);
-    expect(screen.getByRole('button', { name: 'Genera board Catan' })).toBeInTheDocument();
+    renderFlavor({ session, viewerRole: 'Host', sessionId: 's1' });
+    expect(screen.getByRole('button', { name: CTA_KEY })).toBeInTheDocument();
   });
 
   it('empty state — non-host sees the waiting message, no CTA', () => {
-    render(
-      <CatanLiveFlavor session={session} labels={labels} viewerRole="Player" sessionId="s1" />
-    );
-    expect(screen.queryByRole('button', { name: 'Genera board Catan' })).toBeNull();
-    expect(screen.getByText('In attesa dell’host')).toBeInTheDocument();
+    renderFlavor({ session, viewerRole: 'Player', sessionId: 's1' });
+    expect(screen.queryByRole('button', { name: CTA_KEY })).toBeNull();
+    expect(screen.getByText(WAITING_KEY)).toBeInTheDocument();
   });
 
   it('populated — renders board + dice + one card per player', () => {
@@ -114,9 +103,7 @@ describe('CatanLiveFlavor', () => {
       dice: { last: 8, history: [8] },
       players: { p1: emptyCatanPlayerState(), p2: emptyCatanPlayerState() },
     });
-    const { container } = render(
-      <CatanLiveFlavor session={session} labels={labels} viewerRole="Player" sessionId="s1" />
-    );
+    const { container } = renderFlavor({ session, viewerRole: 'Player', sessionId: 's1' });
     expect(container.querySelector('[data-slot="catan-board"]')).not.toBeNull();
     expect(container.querySelector('[data-slot="catan-dice"]')).not.toBeNull();
     expect(container.querySelectorAll('[data-slot="catan-player-card"]')).toHaveLength(2);
@@ -130,9 +117,7 @@ describe('CatanLiveFlavor', () => {
       dice: { last: 8, history: [8] },
       players: { p1: emptyCatanPlayerState(), p2: emptyCatanPlayerState() },
     });
-    const { container } = render(
-      <CatanLiveFlavor session={session} labels={labels} viewerRole="Host" sessionId="s1" />
-    );
+    const { container } = renderFlavor({ session, viewerRole: 'Host', sessionId: 's1' });
     expect(await axe(container)).toHaveNoViolations();
   });
 });

--- a/apps/web/src/components/features/session-live/flavors/wingspan/WingspanCategoryBreakdown.tsx
+++ b/apps/web/src/components/features/session-live/flavors/wingspan/WingspanCategoryBreakdown.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import { type ReactElement } from 'react';
+
+import type { LiveSessionDto, LiveSessionPlayerDto } from '@/lib/api/schemas/live-sessions.schemas';
+
+import { WINGSPAN_CATEGORIES } from './wingspan-state';
+
+export interface WingspanCategoryBreakdownProps {
+  readonly players: ReadonlyArray<LiveSessionPlayerDto>;
+  readonly roundScores: LiveSessionDto['roundScores'];
+  readonly categoryLabels: Record<string, string>;
+  readonly heading: string;
+}
+
+function sumCategory(
+  roundScores: LiveSessionDto['roundScores'],
+  playerId: string,
+  categoryId: string
+): number {
+  return roundScores
+    .filter(rs => rs.playerId === playerId && rs.dimension === categoryId)
+    .reduce((sum, rs) => sum + rs.value, 0);
+}
+
+export function WingspanCategoryBreakdown({
+  players,
+  roundScores,
+  categoryLabels,
+  heading,
+}: WingspanCategoryBreakdownProps): ReactElement {
+  return (
+    <section data-slot="wingspan-breakdown" className="flex flex-col gap-2">
+      <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+        {heading}
+      </h3>
+      <ul role="list" className="flex flex-col gap-1">
+        {players.map(player => (
+          <li key={player.id} className="flex flex-col gap-1 rounded-lg bg-card px-2 py-1.5">
+            <span className="text-xs font-semibold text-foreground">{player.displayName}</span>
+            <span className="flex flex-wrap gap-x-3 gap-y-0.5">
+              {WINGSPAN_CATEGORIES.map(cat => (
+                <span
+                  key={cat.id}
+                  data-player={player.id}
+                  data-category={cat.id}
+                  className="inline-flex items-center gap-1 text-xs text-muted-foreground"
+                  title={categoryLabels[cat.id] ?? cat.id}
+                >
+                  <span aria-hidden="true">{cat.emoji}</span>
+                  <span className="font-semibold tabular-nums text-foreground">
+                    {sumCategory(roundScores, player.id, cat.id)}
+                  </span>
+                </span>
+              ))}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/apps/web/src/components/features/session-live/flavors/wingspan/WingspanLiveFlavor.tsx
+++ b/apps/web/src/components/features/session-live/flavors/wingspan/WingspanLiveFlavor.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import { type ReactElement } from 'react';
+
+import { useIntl } from 'react-intl';
+
+import { useTranslation } from '@/hooks/useTranslation';
+import type { LiveSessionDto } from '@/lib/api/schemas/live-sessions.schemas';
+import { hasRequiredRole, type ParticipantRole } from '@/lib/session-live/participant-role';
+
+import { useWingspanStateEditor } from './use-wingspan-state-editor';
+import { WINGSPAN_CATEGORIES } from './wingspan-state';
+import { WingspanCategoryBreakdown } from './WingspanCategoryBreakdown';
+import { WingspanRoundTracker } from './WingspanRoundTracker';
+
+export interface WingspanLiveFlavorProps {
+  readonly session: LiveSessionDto;
+  readonly viewerRole: ParticipantRole;
+  readonly sessionId: string;
+  readonly className?: string;
+  readonly livePoints?: ReadonlyMap<string, number> | null;
+  readonly phaseName?: string | null;
+}
+
+const K = 'pages.sessionLive.flavor.wingspan';
+
+export function WingspanLiveFlavor({
+  session,
+  viewerRole,
+  sessionId,
+  className,
+  livePoints,
+}: WingspanLiveFlavorProps): ReactElement {
+  const { t } = useTranslation();
+  const intl = useIntl();
+  const isHost = hasRequiredRole(viewerRole, 'Host');
+  const editor = useWingspanStateEditor(sessionId);
+  const state = editor.state;
+
+  const tmpl = (id: string, fallback: string) =>
+    (intl.messages[`${K}.${id}`] as string) ?? fallback;
+
+  const categoryLabels: Record<string, string> = Object.fromEntries(
+    WINGSPAN_CATEGORIES.map(c => [c.id, t(`${K}.category.${c.id}`)])
+  );
+
+  const scoreOf = (playerId: string): number =>
+    livePoints?.get(playerId) ?? session.players.find(p => p.id === playerId)?.totalScore ?? 0;
+  const sorted = [...session.players].sort((a, b) => scoreOf(b.id) - scoreOf(a.id));
+
+  return (
+    <section
+      aria-label={t(`${K}.panelAriaLabel`)}
+      data-slot="wingspan-flavor-live"
+      className={`flex flex-col gap-4 ${className ?? ''}`.trim()}
+    >
+      {/* Leaderboard (always rendered — from scoring, not gameState) */}
+      <div data-slot="wingspan-leaderboard" className="flex flex-col gap-2">
+        <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          {t(`${K}.leaderboardHeading`)}
+        </h3>
+        <ul role="list" className="flex flex-col gap-1">
+          {sorted.map((player, idx) => (
+            <li
+              key={player.id}
+              data-slot="wingspan-leaderboard-row"
+              className={[
+                'flex items-center gap-2 rounded-lg px-2 py-1.5',
+                idx === 0
+                  ? 'border border-entity-session/40 bg-entity-session/10'
+                  : 'border border-transparent bg-card',
+              ].join(' ')}
+            >
+              <span className="min-w-0 flex-1 truncate text-xs font-medium text-foreground">
+                {player.displayName}
+                {idx === 0 && <span aria-hidden="true"> 🏆</span>}
+              </span>
+              <span
+                aria-label={tmpl('scoreAriaTemplate', '{name}: {score}')
+                  .replace('{name}', player.displayName)
+                  .replace('{score}', String(scoreOf(player.id)))}
+                className="shrink-0 tabular-nums text-sm font-bold text-foreground"
+              >
+                {scoreOf(player.id)}
+              </span>
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      {/* Category breakdown (always rendered — from roundScores) */}
+      <WingspanCategoryBreakdown
+        players={session.players}
+        roundScores={session.roundScores}
+        categoryLabels={categoryLabels}
+        heading={t(`${K}.categoriesHeading`)}
+      />
+
+      {/* Round tracker (gameState-gated) */}
+      {state != null ? (
+        <WingspanRoundTracker
+          state={state}
+          editable={isHost}
+          onAdvanceRound={editor.advanceRound}
+          onSetRoundGoal={editor.setRoundGoal}
+          labels={{
+            heading: t(`${K}.roundHeading`),
+            roundTemplate: tmpl('roundTemplate', 'Round {n}/4'),
+            turnBudgetTemplate: tmpl('turnBudgetTemplate', '{n} turni'),
+            goalsHeading: t(`${K}.goalsHeading`),
+            goalPlaceholderTemplate: tmpl('goalPlaceholderTemplate', 'Obiettivo round {n}'),
+            advanceRoundLabel: t(`${K}.advanceRoundLabel`),
+          }}
+        />
+      ) : isHost ? (
+        <button
+          type="button"
+          data-slot="wingspan-round-init"
+          onClick={editor.initializeState}
+          className="self-start rounded-lg border border-entity-session/40 bg-entity-session/10 px-3 py-2 text-sm font-semibold text-entity-session hover:bg-entity-session/20"
+        >
+          {t(`${K}.initRoundCta`)}
+        </button>
+      ) : (
+        <p role="status" aria-live="polite" className="text-xs text-muted-foreground">
+          {t(`${K}.viewerWaiting`)}
+        </p>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/components/features/session-live/flavors/wingspan/WingspanRoundTracker.tsx
+++ b/apps/web/src/components/features/session-live/flavors/wingspan/WingspanRoundTracker.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import { type ReactElement } from 'react';
+
+import { WINGSPAN_ROUND_TURN_BUDGET, type WingspanGameState } from './wingspan-state';
+
+export interface WingspanRoundTrackerLabels {
+  readonly heading: string;
+  readonly roundTemplate: string; // "Round {n}/4"
+  readonly turnBudgetTemplate: string; // "{n} turni"
+  readonly goalsHeading: string;
+  readonly goalPlaceholderTemplate: string; // "Obiettivo round {n}"
+  readonly advanceRoundLabel: string;
+}
+
+export interface WingspanRoundTrackerProps {
+  readonly state: WingspanGameState;
+  readonly editable: boolean;
+  readonly onAdvanceRound?: () => void;
+  readonly onSetRoundGoal?: (index: number, label: string) => void;
+  readonly labels: WingspanRoundTrackerLabels;
+}
+
+export function WingspanRoundTracker({
+  state,
+  editable,
+  onAdvanceRound,
+  onSetRoundGoal,
+  labels,
+}: WingspanRoundTrackerProps): ReactElement {
+  const budget = WINGSPAN_ROUND_TURN_BUDGET[Math.min(Math.max(state.round, 1), 4) - 1];
+  // Always render 4 goal slots for the host; read-only shows only the entered ones.
+  const slots = editable ? 4 : state.roundGoals.length;
+
+  return (
+    <section
+      data-slot="wingspan-round-tracker"
+      className="flex flex-col gap-2 rounded-lg border border-border bg-card p-3"
+    >
+      <div className="flex items-center gap-2">
+        <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          {labels.heading}
+        </h3>
+        <span data-slot="wingspan-round" className="text-sm font-bold text-foreground">
+          {labels.roundTemplate.replace('{n}', String(state.round))}
+        </span>
+        <span className="text-xs text-muted-foreground">
+          {labels.turnBudgetTemplate.replace('{n}', String(budget))}
+        </span>
+        {editable && (
+          <button
+            type="button"
+            onClick={() => onAdvanceRound?.()}
+            className="ml-auto rounded-md border border-border bg-background px-2 py-1 text-xs font-semibold text-foreground hover:bg-muted"
+          >
+            {labels.advanceRoundLabel}
+          </button>
+        )}
+      </div>
+
+      <div data-slot="wingspan-goals" className="flex flex-col gap-1">
+        <span className="text-[10px] uppercase tracking-wide text-muted-foreground">
+          {labels.goalsHeading}
+        </span>
+        {Array.from({ length: slots }, (_, i) => {
+          const label = state.roundGoals[i]?.label ?? '';
+          const placeholder = labels.goalPlaceholderTemplate.replace('{n}', String(i + 1));
+          return editable ? (
+            <input
+              key={i}
+              type="text"
+              aria-label={placeholder}
+              placeholder={placeholder}
+              value={label}
+              onChange={e => onSetRoundGoal?.(i, e.target.value)}
+              className="rounded-md border border-border bg-background px-2 py-1 text-xs text-foreground"
+            />
+          ) : (
+            <span key={i} className="rounded bg-muted px-2 py-1 text-xs text-foreground">
+              {label || placeholder}
+            </span>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/features/session-live/flavors/wingspan/__tests__/WingspanCategoryBreakdown.test.tsx
+++ b/apps/web/src/components/features/session-live/flavors/wingspan/__tests__/WingspanCategoryBreakdown.test.tsx
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { WingspanCategoryBreakdown } from '../WingspanCategoryBreakdown';
+
+const players = [
+  {
+    id: 'p1',
+    userId: null,
+    displayName: 'Marco',
+    avatarUrl: null,
+    color: 'Red',
+    role: 'Host',
+    teamId: null,
+    totalScore: 12,
+    currentRank: 1,
+    joinedAt: '',
+    isActive: true,
+  },
+] as const;
+
+const roundScores = [
+  { playerId: 'p1', round: 1, dimension: 'eggs', value: 3, unit: null, recordedAt: '' },
+  { playerId: 'p1', round: 2, dimension: 'eggs', value: 4, unit: null, recordedAt: '' },
+  { playerId: 'p1', round: 1, dimension: 'birds', value: 5, unit: null, recordedAt: '' },
+];
+
+const categoryLabels = {
+  birds: 'Uccelli',
+  bonusCards: 'Bonus',
+  endOfRoundGoals: 'Obiettivi',
+  eggs: 'Uova',
+  cachedFood: 'Cibo',
+  tuckedCards: 'Infilate',
+};
+
+describe('WingspanCategoryBreakdown', () => {
+  it('sums roundScores per player per category', () => {
+    const { container } = render(
+      <WingspanCategoryBreakdown
+        players={players}
+        roundScores={roundScores}
+        categoryLabels={categoryLabels}
+        heading="Categorie"
+      />
+    );
+    // eggs = 3 + 4 = 7 for p1
+    const eggs = container.querySelector('[data-player="p1"][data-category="eggs"]');
+    expect(eggs?.textContent).toContain('7');
+    const birds = container.querySelector('[data-player="p1"][data-category="birds"]');
+    expect(birds?.textContent).toContain('5');
+    // a category with no scores shows 0
+    const food = container.querySelector('[data-player="p1"][data-category="cachedFood"]');
+    expect(food?.textContent).toContain('0');
+  });
+
+  it('renders the player name and all 6 categories', () => {
+    const { container } = render(
+      <WingspanCategoryBreakdown
+        players={players}
+        roundScores={roundScores}
+        categoryLabels={categoryLabels}
+        heading="Categorie"
+      />
+    );
+    expect(screen.getByText('Marco')).toBeInTheDocument();
+    expect(container.querySelectorAll('[data-player="p1"][data-category]')).toHaveLength(6);
+  });
+});

--- a/apps/web/src/components/features/session-live/flavors/wingspan/__tests__/WingspanLiveFlavor.test.tsx
+++ b/apps/web/src/components/features/session-live/flavors/wingspan/__tests__/WingspanLiveFlavor.test.tsx
@@ -1,0 +1,110 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
+import { axe, toHaveNoViolations } from 'jest-axe';
+
+import { WingspanLiveFlavor } from '../WingspanLiveFlavor';
+import { useLiveSessionStore } from '@/lib/stores/live-session-store';
+
+expect.extend(toHaveNoViolations);
+
+vi.mock('@/hooks/mutations/useUpdateLiveGameState', () => ({
+  useUpdateLiveGameState: () => ({ mutate: vi.fn() }),
+}));
+
+const session = {
+  id: 's1',
+  sessionCode: 'ABC',
+  gameId: null,
+  gameName: 'Wingspan',
+  gameSlug: 'wingspan',
+  createdByUserId: 'u1',
+  status: 'InProgress',
+  visibility: 'Private',
+  groupId: null,
+  createdAt: '',
+  startedAt: '',
+  pausedAt: null,
+  completedAt: null,
+  updatedAt: '',
+  lastSavedAt: null,
+  currentTurnIndex: 0,
+  currentTurnPlayerId: 'p1',
+  agentMode: 'None',
+  notes: null,
+  players: [
+    {
+      id: 'p1',
+      userId: null,
+      displayName: 'Marco',
+      avatarUrl: null,
+      color: 'Red',
+      role: 'Host',
+      teamId: null,
+      totalScore: 12,
+      currentRank: 1,
+      joinedAt: '',
+      isActive: true,
+    },
+    {
+      id: 'p2',
+      userId: null,
+      displayName: 'Anna',
+      avatarUrl: null,
+      color: 'Blue',
+      role: 'Player',
+      teamId: null,
+      totalScore: 9,
+      currentRank: 2,
+      joinedAt: '',
+      isActive: false,
+    },
+  ],
+  teams: [],
+  roundScores: [
+    { playerId: 'p1', round: 1, dimension: 'eggs', value: 3, unit: null, recordedAt: '' },
+  ],
+  scoringConfig: { enabledDimensions: [], dimensionUnits: {} },
+} as const;
+
+function renderFlavor(props: Partial<Parameters<typeof WingspanLiveFlavor>[0]> = {}) {
+  return render(
+    // onError swallows react-intl MISSING_TRANSLATION noise (empty messages → t() returns the key).
+    <IntlProvider locale="en" messages={{}} onError={() => {}}>
+      <WingspanLiveFlavor session={session} viewerRole="Player" sessionId="s1" {...props} />
+    </IntlProvider>
+  );
+}
+
+beforeEach(() => useLiveSessionStore.getState().reset());
+
+describe('WingspanLiveFlavor', () => {
+  it('renders the leaderboard + category breakdown even with null gameState', () => {
+    const { container } = renderFlavor();
+    expect(container.querySelector('[data-slot="wingspan-breakdown"]')).not.toBeNull();
+    expect(container.querySelectorAll('[data-slot="wingspan-leaderboard-row"]')).toHaveLength(2);
+    // no round tracker (gameState null) — but for a host, a CTA appears
+    expect(container.querySelector('[data-slot="wingspan-round-tracker"]')).toBeNull();
+  });
+
+  it('host sees the init-round CTA when gameState is null', () => {
+    const { container } = renderFlavor({ viewerRole: 'Host' });
+    expect(container.querySelector('[data-slot="wingspan-round-init"]')).not.toBeNull();
+  });
+
+  it('renders the round tracker when gameState is present', () => {
+    useLiveSessionStore
+      .getState()
+      .setGameState({ v: 1, game: 'wingspan', round: 2, roundGoals: [] });
+    const { container } = renderFlavor({ viewerRole: 'Host' });
+    expect(container.querySelector('[data-slot="wingspan-round-tracker"]')).not.toBeNull();
+  });
+
+  it('has no axe violations (host, populated)', async () => {
+    useLiveSessionStore
+      .getState()
+      .setGameState({ v: 1, game: 'wingspan', round: 2, roundGoals: [{ label: 'Nidi' }] });
+    const { container } = renderFlavor({ viewerRole: 'Host' });
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});

--- a/apps/web/src/components/features/session-live/flavors/wingspan/__tests__/WingspanRoundTracker.test.tsx
+++ b/apps/web/src/components/features/session-live/flavors/wingspan/__tests__/WingspanRoundTracker.test.tsx
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { WingspanRoundTracker } from '../WingspanRoundTracker';
+
+const labels = {
+  heading: 'Round',
+  roundTemplate: 'Round {n}/4',
+  turnBudgetTemplate: '{n} turni',
+  goalsHeading: 'Obiettivi',
+  goalPlaceholderTemplate: 'Obiettivo round {n}',
+  advanceRoundLabel: 'Avanza round',
+};
+const state = {
+  v: 1 as const,
+  game: 'wingspan' as const,
+  round: 2,
+  roundGoals: [{ label: 'Nidi' }],
+};
+
+describe('WingspanRoundTracker', () => {
+  it('shows the current round and its turn budget', () => {
+    render(<WingspanRoundTracker state={state} editable={false} labels={labels} />);
+    expect(screen.getByText('Round 2/4')).toBeInTheDocument();
+    expect(screen.getByText('7 turni')).toBeInTheDocument(); // budget[1] = 7
+  });
+
+  it('read-only mode exposes no controls', () => {
+    render(<WingspanRoundTracker state={state} editable={false} labels={labels} />);
+    expect(screen.queryByRole('button')).toBeNull();
+    expect(screen.queryByRole('textbox')).toBeNull();
+  });
+
+  it('host mode: advance-round button fires onAdvanceRound', async () => {
+    const onAdvanceRound = vi.fn();
+    render(
+      <WingspanRoundTracker
+        state={state}
+        editable
+        onAdvanceRound={onAdvanceRound}
+        labels={labels}
+      />
+    );
+    await userEvent.click(screen.getByRole('button', { name: 'Avanza round' }));
+    expect(onAdvanceRound).toHaveBeenCalledOnce();
+  });
+
+  it('host mode: editing a goal input fires onSetRoundGoal', async () => {
+    const onSetRoundGoal = vi.fn();
+    render(
+      <WingspanRoundTracker
+        state={{ ...state, roundGoals: [] }}
+        editable
+        onSetRoundGoal={onSetRoundGoal}
+        labels={labels}
+      />
+    );
+    const firstGoal = screen.getAllByRole('textbox')[0];
+    await userEvent.type(firstGoal, 'X');
+    expect(onSetRoundGoal).toHaveBeenCalledWith(0, 'X');
+  });
+});

--- a/apps/web/src/components/features/session-live/flavors/wingspan/__tests__/use-wingspan-state-editor.test.tsx
+++ b/apps/web/src/components/features/session-live/flavors/wingspan/__tests__/use-wingspan-state-editor.test.tsx
@@ -1,0 +1,72 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+
+import { useWingspanStateEditor } from '../use-wingspan-state-editor';
+import { useLiveSessionStore } from '@/lib/stores/live-session-store';
+
+const mutateMock = vi.fn<[unknown], void>();
+vi.mock('@/hooks/mutations/useUpdateLiveGameState', () => ({
+  useUpdateLiveGameState: () => ({ mutate: mutateMock }),
+}));
+
+const SID = 'sess-1';
+
+beforeEach(() => {
+  mutateMock.mockReset();
+  useLiveSessionStore.getState().reset();
+});
+
+function current() {
+  return useLiveSessionStore.getState().gameState as
+    | import('../wingspan-state').WingspanGameState
+    | null;
+}
+
+describe('useWingspanStateEditor', () => {
+  it('initializeState writes round 1 + empty goals optimistically', () => {
+    const { result } = renderHook(() => useWingspanStateEditor(SID));
+    act(() => result.current.initializeState());
+    expect(current()).toEqual({ v: 1, game: 'wingspan', round: 1, roundGoals: [] });
+  });
+
+  it('advanceRound increments and caps at 4', () => {
+    const { result } = renderHook(() => useWingspanStateEditor(SID));
+    act(() => result.current.initializeState());
+    act(() => result.current.advanceRound());
+    expect(current()?.round).toBe(2);
+    act(() => result.current.setRound(4));
+    act(() => result.current.advanceRound());
+    expect(current()?.round).toBe(4);
+  });
+
+  it('setRound clamps to 1..4', () => {
+    const { result } = renderHook(() => useWingspanStateEditor(SID));
+    act(() => result.current.initializeState());
+    act(() => result.current.setRound(9));
+    expect(current()?.round).toBe(4);
+    act(() => result.current.setRound(0));
+    expect(current()?.round).toBe(1);
+  });
+
+  it('setRoundGoal writes the label at the index (padding earlier slots)', () => {
+    const { result } = renderHook(() => useWingspanStateEditor(SID));
+    act(() => result.current.initializeState());
+    act(() => result.current.setRoundGoal(1, 'Uova nel forest'));
+    expect(current()?.roundGoals).toEqual([{ label: '' }, { label: 'Uova nel forest' }]);
+  });
+
+  it('mutators are no-ops when state is null (except initializeState)', () => {
+    const { result } = renderHook(() => useWingspanStateEditor(SID));
+    act(() => result.current.advanceRound());
+    expect(current()).toBeNull();
+  });
+
+  it('eventually PUTs the state (debounced)', () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(() => useWingspanStateEditor(SID));
+    act(() => result.current.initializeState());
+    act(() => vi.advanceTimersByTime(600));
+    expect(mutateMock).toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+});

--- a/apps/web/src/components/features/session-live/flavors/wingspan/__tests__/wingspan-state.test.ts
+++ b/apps/web/src/components/features/session-live/flavors/wingspan/__tests__/wingspan-state.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  WINGSPAN_CATEGORIES,
+  WINGSPAN_ROUND_TURN_BUDGET,
+  initialWingspanState,
+  parseWingspanGameState,
+} from '../wingspan-state';
+
+const VALID = {
+  v: 1,
+  game: 'wingspan',
+  round: 3,
+  roundGoals: [{ label: 'Nidi' }, { label: 'Uova nel forest' }],
+};
+
+describe('parseWingspanGameState', () => {
+  it('parses a well-formed state', () => {
+    const parsed = parseWingspanGameState(VALID);
+    expect(parsed?.round).toBe(3);
+    expect(parsed?.roundGoals).toHaveLength(2);
+  });
+
+  it('returns null for a different game', () => {
+    expect(parseWingspanGameState({ ...VALID, game: 'catan' })).toBeNull();
+  });
+
+  it('returns null for a future version', () => {
+    expect(parseWingspanGameState({ ...VALID, v: 2 })).toBeNull();
+  });
+
+  it('returns null for a round out of range', () => {
+    expect(parseWingspanGameState({ ...VALID, round: 0 })).toBeNull();
+    expect(parseWingspanGameState({ ...VALID, round: 5 })).toBeNull();
+  });
+
+  it('returns null for malformed / non-object input', () => {
+    expect(parseWingspanGameState(null)).toBeNull();
+    expect(parseWingspanGameState('nope')).toBeNull();
+    expect(parseWingspanGameState({ v: 1, game: 'wingspan' })).toBeNull();
+  });
+
+  it('accepts empty roundGoals', () => {
+    expect(parseWingspanGameState({ ...VALID, roundGoals: [] })?.roundGoals).toEqual([]);
+  });
+});
+
+describe('initialWingspanState', () => {
+  it('starts at round 1 with no goals', () => {
+    expect(initialWingspanState()).toEqual({ v: 1, game: 'wingspan', round: 1, roundGoals: [] });
+  });
+});
+
+describe('constants', () => {
+  it('has the standard 4-round turn budget', () => {
+    expect(WINGSPAN_ROUND_TURN_BUDGET).toEqual([8, 7, 6, 5]);
+  });
+
+  it('exposes the 6 canonical VP category ids', () => {
+    expect(WINGSPAN_CATEGORIES.map(c => c.id)).toEqual([
+      'birds',
+      'bonusCards',
+      'endOfRoundGoals',
+      'eggs',
+      'cachedFood',
+      'tuckedCards',
+    ]);
+  });
+});

--- a/apps/web/src/components/features/session-live/flavors/wingspan/use-wingspan-state-editor.ts
+++ b/apps/web/src/components/features/session-live/flavors/wingspan/use-wingspan-state-editor.ts
@@ -1,0 +1,81 @@
+'use client';
+
+import { useCallback, useEffect, useMemo } from 'react';
+
+import { useUpdateLiveGameState } from '@/hooks/mutations/useUpdateLiveGameState';
+import { useDebouncedCallback } from '@/lib/session-live/use-debounced-callback';
+import { useLiveSessionStore } from '@/lib/stores/live-session-store';
+
+import {
+  initialWingspanState,
+  parseWingspanGameState,
+  type WingspanGameState,
+  type WingspanRoundGoal,
+} from './wingspan-state';
+
+export interface WingspanStateEditor {
+  state: WingspanGameState | null;
+  initializeState: () => void;
+  setRound: (round: number) => void;
+  advanceRound: () => void;
+  setRoundGoal: (index: number, label: string) => void;
+}
+
+const clampRound = (n: number) => (n < 1 ? 1 : n > 4 ? 4 : n);
+
+export function useWingspanStateEditor(sessionId: string): WingspanStateEditor {
+  const raw = useLiveSessionStore(s => s.gameState);
+  const state = useMemo(() => parseWingspanGameState(raw), [raw]);
+  const { mutate } = useUpdateLiveGameState(sessionId);
+  const [debouncedMutate, flush] = useDebouncedCallback(
+    (next: WingspanGameState) => mutate(next),
+    500
+  );
+
+  useEffect(() => () => flush(), [flush]);
+
+  const commit = useCallback(
+    (next: WingspanGameState) => {
+      useLiveSessionStore.getState().setGameState(next); // optimistic
+      debouncedMutate(next);
+    },
+    [debouncedMutate]
+  );
+
+  const readState = useCallback(
+    (): WingspanGameState | null =>
+      parseWingspanGameState(useLiveSessionStore.getState().gameState),
+    []
+  );
+
+  const initializeState = useCallback(() => commit(initialWingspanState()), [commit]);
+
+  const setRound = useCallback(
+    (round: number) => {
+      const cur = readState();
+      if (cur == null) return;
+      commit({ ...cur, round: clampRound(round) });
+    },
+    [commit, readState]
+  );
+
+  const advanceRound = useCallback(() => {
+    const cur = readState();
+    if (cur == null) return;
+    commit({ ...cur, round: clampRound(cur.round + 1) });
+  }, [commit, readState]);
+
+  const setRoundGoal = useCallback(
+    (index: number, label: string) => {
+      const cur = readState();
+      if (cur == null || index < 0 || index > 3) return;
+      const goals: WingspanRoundGoal[] = [...cur.roundGoals];
+      while (goals.length <= index) goals.push({ label: '' });
+      goals[index] = { label };
+      commit({ ...cur, roundGoals: goals });
+    },
+    [commit, readState]
+  );
+
+  return { state, initializeState, setRound, advanceRound, setRoundGoal };
+}

--- a/apps/web/src/components/features/session-live/flavors/wingspan/wingspan-state.ts
+++ b/apps/web/src/components/features/session-live/flavors/wingspan/wingspan-state.ts
@@ -1,0 +1,40 @@
+import { z } from 'zod';
+
+export const WINGSPAN_STATE_VERSION = 1;
+
+/** Turns available per round (base game), rounds 1..4. Derived constant, never stored. */
+export const WINGSPAN_ROUND_TURN_BUDGET = [8, 7, 6, 5] as const;
+
+/**
+ * The 6 canonical Wingspan VP categories. `id` is the scoring dimension name the flavor
+ * sums over `roundScores`; `emoji` is language-agnostic display. Labels come from i18n.
+ */
+export const WINGSPAN_CATEGORIES: ReadonlyArray<{ id: string; emoji: string }> = [
+  { id: 'birds', emoji: '🐦' },
+  { id: 'bonusCards', emoji: '🎴' },
+  { id: 'endOfRoundGoals', emoji: '🎯' },
+  { id: 'eggs', emoji: '🥚' },
+  { id: 'cachedFood', emoji: '🌰' },
+  { id: 'tuckedCards', emoji: '🍃' },
+];
+
+export const WingspanRoundGoalSchema = z.object({ label: z.string() });
+export type WingspanRoundGoal = z.infer<typeof WingspanRoundGoalSchema>;
+
+export const WingspanGameStateSchema = z.object({
+  v: z.literal(WINGSPAN_STATE_VERSION),
+  game: z.literal('wingspan'),
+  round: z.number().int().min(1).max(4),
+  roundGoals: z.array(WingspanRoundGoalSchema).max(4),
+});
+export type WingspanGameState = z.infer<typeof WingspanGameStateSchema>;
+
+/** Safe-parse the opaque L1 gameState. Returns null (never throws) on wrong game/version/shape. */
+export function parseWingspanGameState(raw: unknown): WingspanGameState | null {
+  const result = WingspanGameStateSchema.safeParse(raw);
+  return result.success ? result.data : null;
+}
+
+export function initialWingspanState(): WingspanGameState {
+  return { v: WINGSPAN_STATE_VERSION, game: 'wingspan', round: 1, roundGoals: [] };
+}

--- a/apps/web/src/components/features/session-live/index.ts
+++ b/apps/web/src/components/features/session-live/index.ts
@@ -143,16 +143,14 @@ export type {
   RightColumnTabsProps,
 } from '@/components/features/session-live/RightColumnTabs';
 
-// ─── G6a #2787 Catan flavor (ADR-070 lazy per-game modules) ───────────────────
+// ─── G6a #2787 / #2788 per-game flavor registry (ADR-070 lazy per-game modules) ─
 export { FlavorRenderer, hasFlavor } from '@/components/features/session-live/FlavorRenderer';
 export type {
+  FlavorProps,
   FlavorRendererProps,
   FlavorView,
 } from '@/components/features/session-live/FlavorRenderer';
-export type {
-  CatanLiveFlavorLabels,
-  CatanLiveFlavorProps,
-} from '@/components/features/session-live/flavors/catan/CatanLiveFlavor';
+export type { CatanLiveFlavorProps } from '@/components/features/session-live/flavors/catan/CatanLiveFlavor';
 
 export { SessionToolsRail } from '@/components/features/session-live/SessionToolsRail';
 export type {

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -3595,6 +3595,28 @@
           "largestArmyLabel": "Big Army",
           "incAriaTemplate": "{field} +1",
           "decAriaTemplate": "{field} -1"
+        },
+        "wingspan": {
+          "panelAriaLabel": "Wingspan",
+          "leaderboardHeading": "Standings",
+          "scoreAriaTemplate": "{name}: {score} PV",
+          "categoriesHeading": "Points by category",
+          "roundHeading": "Round",
+          "roundTemplate": "Round {n}/4",
+          "turnBudgetTemplate": "{n} turns",
+          "goalsHeading": "Round goals",
+          "goalPlaceholderTemplate": "Round {n} goal",
+          "advanceRoundLabel": "Advance round",
+          "initRoundCta": "Start the round",
+          "viewerWaiting": "Waiting for the host…",
+          "category": {
+            "birds": "Birds",
+            "bonusCards": "Bonus cards",
+            "endOfRoundGoals": "End-of-round goals",
+            "eggs": "Eggs",
+            "cachedFood": "Cached food",
+            "tuckedCards": "Tucked cards"
+          }
         }
       },
       "photosTab": {

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -3700,6 +3700,28 @@
           "largestArmyLabel": "Armata+",
           "incAriaTemplate": "{field} +1",
           "decAriaTemplate": "{field} −1"
+        },
+        "wingspan": {
+          "panelAriaLabel": "Wingspan",
+          "leaderboardHeading": "Classifica",
+          "scoreAriaTemplate": "{name}: {score} PV",
+          "categoriesHeading": "Punti per categoria",
+          "roundHeading": "Round",
+          "roundTemplate": "Round {n}/4",
+          "turnBudgetTemplate": "{n} turni",
+          "goalsHeading": "Obiettivi di round",
+          "goalPlaceholderTemplate": "Obiettivo round {n}",
+          "advanceRoundLabel": "Avanza round",
+          "initRoundCta": "Inizia il round",
+          "viewerWaiting": "In attesa dell'host…",
+          "category": {
+            "birds": "Uccelli",
+            "bonusCards": "Carte bonus",
+            "endOfRoundGoals": "Obiettivi di fine round",
+            "eggs": "Uova",
+            "cachedFood": "Cibo accumulato",
+            "tuckedCards": "Carte infilate"
+          }
         }
       },
       "photosTab": {

--- a/docs/superpowers/plans/2026-07-16-wingspan-l2-l3-flavor.md
+++ b/docs/superpowers/plans/2026-07-16-wingspan-l2-l3-flavor.md
@@ -1,0 +1,1131 @@
+# Wingspan L2+L3 Flavor Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a Wingspan live flavor — a themed category-scoring breakdown (reusing the existing scoring system) plus a small round-context `gameState` — on the L1 game-state layer, and generalize the flavor plumbing so flavors self-build their i18n labels.
+
+**Architecture:** FE-only, reuses the proven Catan L2/L3 pattern under `flavors/wingspan/` but lighter (Wingspan's live richness is scoring, not a board). The 6 Wingspan VP categories are existing scoring dimensions; the new `gameState` carries only round context. `FlavorRenderer` becomes game-agnostic and each flavor self-builds its labels via `useIntl` (Catan refactored to match).
+
+**Tech Stack:** Next.js 16 · React 19 · TypeScript · Zod · Zustand (`useLiveSessionStore`) · TanStack Query (`useUpdateLiveGameState`) · react-intl (`useIntl`) + `@/hooks/useTranslation` · Vitest + Testing Library + jest-axe · Tailwind semantic tokens.
+
+## Global Constraints
+
+- **Issue:** #2788 (G6b, epic #3025). Spec: `docs/superpowers/specs/2026-07-16-wingspan-l2-l3-flavor-design.md`.
+- **Zero backend changes.** Scores use the existing scoring editor/endpoints; `gameState` is the opaque L1 blob.
+- **State schema:** `v: 1`, discriminator `game: 'wingspan'`. `parseWingspanGameState` returns `null` (never throws) on wrong game/version/shape.
+- **`gameState` carries round context ONLY:** `{ v, game, round: 1..4, roundGoals: {label}[] (≤4) }`. Never scores (VP stays in scoring).
+- **Round turn budget** (derived constant, not stored): `[8, 7, 6, 5]` for rounds 1..4.
+- **6 canonical VP category ids** (match scoring dimension names): `birds · bonusCards · endOfRoundGoals · eggs · cachedFood · tuckedCards`.
+- **Host-edit only** (`viewerRole === 'Host'`); autosave debounced **500 ms**; optimistic `setGameState` first; flush on unmount.
+- **Scoring renders unconditionally** (from `roundScores`/`livePoints`); only the round tracker is `gameState`-gated (host CTA when null).
+- **Flavors self-build i18n labels** via `useIntl` + `useTranslation`; `FlavorRenderer` passes only game-agnostic props (`session`, `viewerRole`, `sessionId`, `className`, `livePoints`, `phaseName`).
+- **Colors:** semantic Tailwind tokens + entity utilities; no hardcoded color utilities. i18n templates (`{n}`/`{name}`) read via `intl.messages[id] as string ?? fallback` (react-intl does not ICU-interpolate these); static labels via `t(id)`.
+- **Tests:** Vitest, TDD, output pristine. Query via `data-slot`/roles, not `getByTestId`. Files under `apps/web/src/components/features/session-live/flavors/wingspan/`. Run from `apps/web`.
+- **Windows:** pre-commit runs `pnpm typecheck` (~2 min) — allow ≥5 min for commits; if TS2307 on stale `.next/types`, `rm -rf .next/types` first (never `--no-verify`).
+
+## File Structure
+
+Create:
+- `flavors/wingspan/wingspan-state.ts` — schema/types/`parseWingspanGameState`/`initialWingspanState`/`WINGSPAN_CATEGORIES`/`WINGSPAN_ROUND_TURN_BUDGET`.
+- `flavors/wingspan/use-wingspan-state-editor.ts` — host mutators + optimistic + debounced PUT.
+- `flavors/wingspan/WingspanRoundTracker.tsx` — round + goals (pure).
+- `flavors/wingspan/WingspanCategoryBreakdown.tsx` — per-player category sums (pure).
+- `flavors/wingspan/WingspanLiveFlavor.tsx` — container (self-builds labels).
+- `flavors/wingspan/__tests__/*`.
+
+Modify (Task 6, one commit):
+- `session-live/FlavorRenderer.tsx` — game-agnostic `FlavorProps`; `wingspan` in `FLAVOR_MAP`; drop `labels`.
+- `flavors/catan/CatanLiveFlavor.tsx` — self-build labels via `useIntl`; drop the `labels` prop.
+- `sessions/[id]/live/_components/SessionLiveView.tsx` — remove `catanFlavorLabels` memo + `labels=` prop at both `FlavorRenderer` sites (~L1409, ~L1635).
+- `src/locales/it.json` + `en.json` — add `pages.sessionLive.flavor.wingspan.*`.
+
+---
+
+## Task 1: L2 state schema + parser + categories
+
+**Files:**
+- Create: `apps/web/src/components/features/session-live/flavors/wingspan/wingspan-state.ts`
+- Test: `apps/web/src/components/features/session-live/flavors/wingspan/__tests__/wingspan-state.test.ts`
+
+**Interfaces:**
+- Produces: `WingspanGameState`, `WingspanRoundGoal` types; `parseWingspanGameState(raw): WingspanGameState | null`; `initialWingspanState(): WingspanGameState`; `WINGSPAN_STATE_VERSION = 1`; `WINGSPAN_ROUND_TURN_BUDGET = [8,7,6,5]`; `WINGSPAN_CATEGORIES: ReadonlyArray<{ id: string; emoji: string }>`.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// wingspan-state.test.ts
+import { describe, expect, it } from 'vitest';
+
+import {
+  WINGSPAN_CATEGORIES,
+  WINGSPAN_ROUND_TURN_BUDGET,
+  initialWingspanState,
+  parseWingspanGameState,
+} from '../wingspan-state';
+
+const VALID = {
+  v: 1,
+  game: 'wingspan',
+  round: 3,
+  roundGoals: [{ label: 'Nidi' }, { label: 'Uova nel forest' }],
+};
+
+describe('parseWingspanGameState', () => {
+  it('parses a well-formed state', () => {
+    const parsed = parseWingspanGameState(VALID);
+    expect(parsed?.round).toBe(3);
+    expect(parsed?.roundGoals).toHaveLength(2);
+  });
+
+  it('returns null for a different game', () => {
+    expect(parseWingspanGameState({ ...VALID, game: 'catan' })).toBeNull();
+  });
+
+  it('returns null for a future version', () => {
+    expect(parseWingspanGameState({ ...VALID, v: 2 })).toBeNull();
+  });
+
+  it('returns null for a round out of range', () => {
+    expect(parseWingspanGameState({ ...VALID, round: 0 })).toBeNull();
+    expect(parseWingspanGameState({ ...VALID, round: 5 })).toBeNull();
+  });
+
+  it('returns null for malformed / non-object input', () => {
+    expect(parseWingspanGameState(null)).toBeNull();
+    expect(parseWingspanGameState('nope')).toBeNull();
+    expect(parseWingspanGameState({ v: 1, game: 'wingspan' })).toBeNull();
+  });
+
+  it('accepts empty roundGoals', () => {
+    expect(parseWingspanGameState({ ...VALID, roundGoals: [] })?.roundGoals).toEqual([]);
+  });
+});
+
+describe('initialWingspanState', () => {
+  it('starts at round 1 with no goals', () => {
+    expect(initialWingspanState()).toEqual({ v: 1, game: 'wingspan', round: 1, roundGoals: [] });
+  });
+});
+
+describe('constants', () => {
+  it('has the standard 4-round turn budget', () => {
+    expect(WINGSPAN_ROUND_TURN_BUDGET).toEqual([8, 7, 6, 5]);
+  });
+
+  it('exposes the 6 canonical VP category ids', () => {
+    expect(WINGSPAN_CATEGORIES.map(c => c.id)).toEqual([
+      'birds',
+      'bonusCards',
+      'endOfRoundGoals',
+      'eggs',
+      'cachedFood',
+      'tuckedCards',
+    ]);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm exec vitest run src/components/features/session-live/flavors/wingspan/__tests__/wingspan-state.test.ts`
+Expected: FAIL — `Cannot find module '../wingspan-state'`.
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+// wingspan-state.ts
+import { z } from 'zod';
+
+export const WINGSPAN_STATE_VERSION = 1;
+
+/** Turns available per round (base game), rounds 1..4. Derived constant, never stored. */
+export const WINGSPAN_ROUND_TURN_BUDGET = [8, 7, 6, 5] as const;
+
+/**
+ * The 6 canonical Wingspan VP categories. `id` is the scoring dimension name the flavor
+ * sums over `roundScores`; `emoji` is language-agnostic display. Labels come from i18n.
+ */
+export const WINGSPAN_CATEGORIES: ReadonlyArray<{ id: string; emoji: string }> = [
+  { id: 'birds', emoji: '🐦' },
+  { id: 'bonusCards', emoji: '🎴' },
+  { id: 'endOfRoundGoals', emoji: '🎯' },
+  { id: 'eggs', emoji: '🥚' },
+  { id: 'cachedFood', emoji: '🌰' },
+  { id: 'tuckedCards', emoji: '🍃' },
+];
+
+export const WingspanRoundGoalSchema = z.object({ label: z.string() });
+export type WingspanRoundGoal = z.infer<typeof WingspanRoundGoalSchema>;
+
+export const WingspanGameStateSchema = z.object({
+  v: z.literal(WINGSPAN_STATE_VERSION),
+  game: z.literal('wingspan'),
+  round: z.number().int().min(1).max(4),
+  roundGoals: z.array(WingspanRoundGoalSchema).max(4),
+});
+export type WingspanGameState = z.infer<typeof WingspanGameStateSchema>;
+
+/** Safe-parse the opaque L1 gameState. Returns null (never throws) on wrong game/version/shape. */
+export function parseWingspanGameState(raw: unknown): WingspanGameState | null {
+  const result = WingspanGameStateSchema.safeParse(raw);
+  return result.success ? result.data : null;
+}
+
+export function initialWingspanState(): WingspanGameState {
+  return { v: WINGSPAN_STATE_VERSION, game: 'wingspan', round: 1, roundGoals: [] };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm exec vitest run src/components/features/session-live/flavors/wingspan/__tests__/wingspan-state.test.ts`
+Expected: PASS (10 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add "apps/web/src/components/features/session-live/flavors/wingspan/wingspan-state.ts" "apps/web/src/components/features/session-live/flavors/wingspan/__tests__/wingspan-state.test.ts"
+git commit -m "feat(session-live): #2788 Wingspan L2 state schema + categories"
+```
+
+---
+
+## Task 2: Host-edit hook
+
+**Files:**
+- Create: `apps/web/src/components/features/session-live/flavors/wingspan/use-wingspan-state-editor.ts`
+- Test: `apps/web/src/components/features/session-live/flavors/wingspan/__tests__/use-wingspan-state-editor.test.tsx`
+
+**Interfaces:**
+- Consumes: `WingspanGameState`, `parseWingspanGameState`, `initialWingspanState` from `./wingspan-state`; `useLiveSessionStore` from `@/lib/stores/live-session-store`; `useUpdateLiveGameState` from `@/hooks/mutations/useUpdateLiveGameState`; `useDebouncedCallback` from `@/lib/session-live/use-debounced-callback`.
+- Produces: `useWingspanStateEditor(sessionId: string): WingspanStateEditor` where
+  ```ts
+  interface WingspanStateEditor {
+    state: WingspanGameState | null;
+    initializeState: () => void;
+    setRound: (round: number) => void;      // clamp 1..4
+    advanceRound: () => void;               // min(round+1, 4)
+    setRoundGoal: (index: number, label: string) => void; // index 0..3
+  }
+  ```
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// use-wingspan-state-editor.test.tsx
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+
+import { useWingspanStateEditor } from '../use-wingspan-state-editor';
+import { useLiveSessionStore } from '@/lib/stores/live-session-store';
+
+const mutateMock = vi.fn<[unknown], void>();
+vi.mock('@/hooks/mutations/useUpdateLiveGameState', () => ({
+  useUpdateLiveGameState: () => ({ mutate: mutateMock }),
+}));
+
+const SID = 'sess-1';
+
+beforeEach(() => {
+  mutateMock.mockReset();
+  useLiveSessionStore.getState().reset();
+});
+
+function current() {
+  return useLiveSessionStore.getState().gameState as import('../wingspan-state').WingspanGameState | null;
+}
+
+describe('useWingspanStateEditor', () => {
+  it('initializeState writes round 1 + empty goals optimistically', () => {
+    const { result } = renderHook(() => useWingspanStateEditor(SID));
+    act(() => result.current.initializeState());
+    expect(current()).toEqual({ v: 1, game: 'wingspan', round: 1, roundGoals: [] });
+  });
+
+  it('advanceRound increments and caps at 4', () => {
+    const { result } = renderHook(() => useWingspanStateEditor(SID));
+    act(() => result.current.initializeState());
+    act(() => result.current.advanceRound());
+    expect(current()?.round).toBe(2);
+    act(() => result.current.setRound(4));
+    act(() => result.current.advanceRound());
+    expect(current()?.round).toBe(4);
+  });
+
+  it('setRound clamps to 1..4', () => {
+    const { result } = renderHook(() => useWingspanStateEditor(SID));
+    act(() => result.current.initializeState());
+    act(() => result.current.setRound(9));
+    expect(current()?.round).toBe(4);
+    act(() => result.current.setRound(0));
+    expect(current()?.round).toBe(1);
+  });
+
+  it('setRoundGoal writes the label at the index (padding earlier slots)', () => {
+    const { result } = renderHook(() => useWingspanStateEditor(SID));
+    act(() => result.current.initializeState());
+    act(() => result.current.setRoundGoal(1, 'Uova nel forest'));
+    expect(current()?.roundGoals).toEqual([{ label: '' }, { label: 'Uova nel forest' }]);
+  });
+
+  it('mutators are no-ops when state is null (except initializeState)', () => {
+    const { result } = renderHook(() => useWingspanStateEditor(SID));
+    act(() => result.current.advanceRound());
+    expect(current()).toBeNull();
+  });
+
+  it('eventually PUTs the state (debounced)', () => {
+    vi.useFakeTimers();
+    const { result } = renderHook(() => useWingspanStateEditor(SID));
+    act(() => result.current.initializeState());
+    act(() => vi.advanceTimersByTime(600));
+    expect(mutateMock).toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm exec vitest run src/components/features/session-live/flavors/wingspan/__tests__/use-wingspan-state-editor.test.tsx`
+Expected: FAIL — `Cannot find module '../use-wingspan-state-editor'`.
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+// use-wingspan-state-editor.ts
+'use client';
+
+import { useCallback, useEffect, useMemo } from 'react';
+
+import { useUpdateLiveGameState } from '@/hooks/mutations/useUpdateLiveGameState';
+import { useDebouncedCallback } from '@/lib/session-live/use-debounced-callback';
+import { useLiveSessionStore } from '@/lib/stores/live-session-store';
+
+import {
+  initialWingspanState,
+  parseWingspanGameState,
+  type WingspanGameState,
+  type WingspanRoundGoal,
+} from './wingspan-state';
+
+export interface WingspanStateEditor {
+  state: WingspanGameState | null;
+  initializeState: () => void;
+  setRound: (round: number) => void;
+  advanceRound: () => void;
+  setRoundGoal: (index: number, label: string) => void;
+}
+
+const clampRound = (n: number) => (n < 1 ? 1 : n > 4 ? 4 : n);
+
+export function useWingspanStateEditor(sessionId: string): WingspanStateEditor {
+  const raw = useLiveSessionStore(s => s.gameState);
+  const state = useMemo(() => parseWingspanGameState(raw), [raw]);
+  const { mutate } = useUpdateLiveGameState(sessionId);
+  const [debouncedMutate, flush] = useDebouncedCallback(
+    (next: WingspanGameState) => mutate(next),
+    500
+  );
+
+  useEffect(() => () => flush(), [flush]);
+
+  const commit = useCallback(
+    (next: WingspanGameState) => {
+      useLiveSessionStore.getState().setGameState(next); // optimistic
+      debouncedMutate(next);
+    },
+    [debouncedMutate]
+  );
+
+  const readState = useCallback(
+    (): WingspanGameState | null => parseWingspanGameState(useLiveSessionStore.getState().gameState),
+    []
+  );
+
+  const initializeState = useCallback(() => commit(initialWingspanState()), [commit]);
+
+  const setRound = useCallback(
+    (round: number) => {
+      const cur = readState();
+      if (cur == null) return;
+      commit({ ...cur, round: clampRound(round) });
+    },
+    [commit, readState]
+  );
+
+  const advanceRound = useCallback(() => {
+    const cur = readState();
+    if (cur == null) return;
+    commit({ ...cur, round: clampRound(cur.round + 1) });
+  }, [commit, readState]);
+
+  const setRoundGoal = useCallback(
+    (index: number, label: string) => {
+      const cur = readState();
+      if (cur == null || index < 0 || index > 3) return;
+      const goals: WingspanRoundGoal[] = [...cur.roundGoals];
+      while (goals.length <= index) goals.push({ label: '' });
+      goals[index] = { label };
+      commit({ ...cur, roundGoals: goals });
+    },
+    [commit, readState]
+  );
+
+  return { state, initializeState, setRound, advanceRound, setRoundGoal };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm exec vitest run src/components/features/session-live/flavors/wingspan/__tests__/use-wingspan-state-editor.test.tsx`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add "apps/web/src/components/features/session-live/flavors/wingspan/use-wingspan-state-editor.ts" "apps/web/src/components/features/session-live/flavors/wingspan/__tests__/use-wingspan-state-editor.test.tsx"
+git commit -m "feat(session-live): #2788 Wingspan L2 host-edit hook (round + goals)"
+```
+
+---
+
+## Task 3: WingspanRoundTracker
+
+**Files:**
+- Create: `apps/web/src/components/features/session-live/flavors/wingspan/WingspanRoundTracker.tsx`
+- Test: `apps/web/src/components/features/session-live/flavors/wingspan/__tests__/WingspanRoundTracker.test.tsx`
+
+**Interfaces:**
+- Consumes: `WingspanGameState`, `WINGSPAN_ROUND_TURN_BUDGET` from `./wingspan-state`.
+- Produces: `WingspanRoundTracker` with props
+  ```ts
+  interface WingspanRoundTrackerLabels {
+    heading: string; roundTemplate: string; /* "Round {n}/4" */ turnBudgetTemplate: string; /* "{n} turni" */
+    goalsHeading: string; goalPlaceholderTemplate: string; /* "Obiettivo round {n}" */ advanceRoundLabel: string;
+  }
+  interface WingspanRoundTrackerProps {
+    state: WingspanGameState;
+    editable: boolean;
+    onAdvanceRound?: () => void;
+    onSetRoundGoal?: (index: number, label: string) => void;
+    labels: WingspanRoundTrackerLabels;
+  }
+  ```
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// WingspanRoundTracker.test.tsx
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { WingspanRoundTracker } from '../WingspanRoundTracker';
+
+const labels = {
+  heading: 'Round',
+  roundTemplate: 'Round {n}/4',
+  turnBudgetTemplate: '{n} turni',
+  goalsHeading: 'Obiettivi',
+  goalPlaceholderTemplate: 'Obiettivo round {n}',
+  advanceRoundLabel: 'Avanza round',
+};
+const state = { v: 1 as const, game: 'wingspan' as const, round: 2, roundGoals: [{ label: 'Nidi' }] };
+
+describe('WingspanRoundTracker', () => {
+  it('shows the current round and its turn budget', () => {
+    render(<WingspanRoundTracker state={state} editable={false} labels={labels} />);
+    expect(screen.getByText('Round 2/4')).toBeInTheDocument();
+    expect(screen.getByText('7 turni')).toBeInTheDocument(); // budget[1] = 7
+  });
+
+  it('read-only mode exposes no controls', () => {
+    render(<WingspanRoundTracker state={state} editable={false} labels={labels} />);
+    expect(screen.queryByRole('button')).toBeNull();
+    expect(screen.queryByRole('textbox')).toBeNull();
+  });
+
+  it('host mode: advance-round button fires onAdvanceRound', async () => {
+    const onAdvanceRound = vi.fn();
+    render(
+      <WingspanRoundTracker state={state} editable onAdvanceRound={onAdvanceRound} labels={labels} />
+    );
+    await userEvent.click(screen.getByRole('button', { name: 'Avanza round' }));
+    expect(onAdvanceRound).toHaveBeenCalledOnce();
+  });
+
+  it('host mode: editing a goal input fires onSetRoundGoal', async () => {
+    const onSetRoundGoal = vi.fn();
+    render(
+      <WingspanRoundTracker
+        state={{ ...state, roundGoals: [] }}
+        editable
+        onSetRoundGoal={onSetRoundGoal}
+        labels={labels}
+      />
+    );
+    const firstGoal = screen.getAllByRole('textbox')[0];
+    await userEvent.type(firstGoal, 'X');
+    expect(onSetRoundGoal).toHaveBeenCalledWith(0, 'X');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm exec vitest run src/components/features/session-live/flavors/wingspan/__tests__/WingspanRoundTracker.test.tsx`
+Expected: FAIL — `Cannot find module '../WingspanRoundTracker'`.
+
+- [ ] **Step 3: Write the implementation**
+
+```tsx
+// WingspanRoundTracker.tsx
+'use client';
+
+import { type ReactElement } from 'react';
+
+import { WINGSPAN_ROUND_TURN_BUDGET, type WingspanGameState } from './wingspan-state';
+
+export interface WingspanRoundTrackerLabels {
+  readonly heading: string;
+  readonly roundTemplate: string; // "Round {n}/4"
+  readonly turnBudgetTemplate: string; // "{n} turni"
+  readonly goalsHeading: string;
+  readonly goalPlaceholderTemplate: string; // "Obiettivo round {n}"
+  readonly advanceRoundLabel: string;
+}
+
+export interface WingspanRoundTrackerProps {
+  readonly state: WingspanGameState;
+  readonly editable: boolean;
+  readonly onAdvanceRound?: () => void;
+  readonly onSetRoundGoal?: (index: number, label: string) => void;
+  readonly labels: WingspanRoundTrackerLabels;
+}
+
+export function WingspanRoundTracker({
+  state,
+  editable,
+  onAdvanceRound,
+  onSetRoundGoal,
+  labels,
+}: WingspanRoundTrackerProps): ReactElement {
+  const budget = WINGSPAN_ROUND_TURN_BUDGET[Math.min(Math.max(state.round, 1), 4) - 1];
+  // Always render 4 goal slots for the host; read-only shows only the entered ones.
+  const slots = editable ? 4 : state.roundGoals.length;
+
+  return (
+    <section
+      data-slot="wingspan-round-tracker"
+      className="flex flex-col gap-2 rounded-lg border border-border bg-card p-3"
+    >
+      <div className="flex items-center gap-2">
+        <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          {labels.heading}
+        </h3>
+        <span data-slot="wingspan-round" className="text-sm font-bold text-foreground">
+          {labels.roundTemplate.replace('{n}', String(state.round))}
+        </span>
+        <span className="text-xs text-muted-foreground">
+          {labels.turnBudgetTemplate.replace('{n}', String(budget))}
+        </span>
+        {editable && (
+          <button
+            type="button"
+            onClick={() => onAdvanceRound?.()}
+            className="ml-auto rounded-md border border-border bg-background px-2 py-1 text-xs font-semibold text-foreground hover:bg-muted"
+          >
+            {labels.advanceRoundLabel}
+          </button>
+        )}
+      </div>
+
+      <div data-slot="wingspan-goals" className="flex flex-col gap-1">
+        <span className="text-[10px] uppercase tracking-wide text-muted-foreground">
+          {labels.goalsHeading}
+        </span>
+        {Array.from({ length: slots }, (_, i) => {
+          const label = state.roundGoals[i]?.label ?? '';
+          const placeholder = labels.goalPlaceholderTemplate.replace('{n}', String(i + 1));
+          return editable ? (
+            <input
+              key={i}
+              type="text"
+              aria-label={placeholder}
+              placeholder={placeholder}
+              value={label}
+              onChange={e => onSetRoundGoal?.(i, e.target.value)}
+              className="rounded-md border border-border bg-background px-2 py-1 text-xs text-foreground"
+            />
+          ) : (
+            <span key={i} className="rounded bg-muted px-2 py-1 text-xs text-foreground">
+              {label || placeholder}
+            </span>
+          );
+        })}
+      </div>
+    </section>
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm exec vitest run src/components/features/session-live/flavors/wingspan/__tests__/WingspanRoundTracker.test.tsx`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add "apps/web/src/components/features/session-live/flavors/wingspan/WingspanRoundTracker.tsx" "apps/web/src/components/features/session-live/flavors/wingspan/__tests__/WingspanRoundTracker.test.tsx"
+git commit -m "feat(session-live): #2788 Wingspan L3 round tracker"
+```
+
+---
+
+## Task 4: WingspanCategoryBreakdown
+
+**Files:**
+- Create: `apps/web/src/components/features/session-live/flavors/wingspan/WingspanCategoryBreakdown.tsx`
+- Test: `apps/web/src/components/features/session-live/flavors/wingspan/__tests__/WingspanCategoryBreakdown.test.tsx`
+
+**Interfaces:**
+- Consumes: `WINGSPAN_CATEGORIES` from `./wingspan-state`; `LiveSessionDto`, `LiveSessionPlayerDto` from `@/lib/api/schemas/live-sessions.schemas`.
+- Produces: `WingspanCategoryBreakdown` with props
+  ```ts
+  interface WingspanCategoryBreakdownProps {
+    players: ReadonlyArray<LiveSessionPlayerDto>;
+    roundScores: LiveSessionDto['roundScores'];
+    categoryLabels: Record<string, string>; // by category id
+    heading: string;
+  }
+  ```
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// WingspanCategoryBreakdown.test.tsx
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { WingspanCategoryBreakdown } from '../WingspanCategoryBreakdown';
+
+const players = [
+  { id: 'p1', userId: null, displayName: 'Marco', avatarUrl: null, color: 'Red', role: 'Host', teamId: null, totalScore: 12, currentRank: 1, joinedAt: '', isActive: true },
+] as const;
+
+const roundScores = [
+  { playerId: 'p1', round: 1, dimension: 'eggs', value: 3, unit: null, recordedAt: '' },
+  { playerId: 'p1', round: 2, dimension: 'eggs', value: 4, unit: null, recordedAt: '' },
+  { playerId: 'p1', round: 1, dimension: 'birds', value: 5, unit: null, recordedAt: '' },
+];
+
+const categoryLabels = {
+  birds: 'Uccelli', bonusCards: 'Bonus', endOfRoundGoals: 'Obiettivi',
+  eggs: 'Uova', cachedFood: 'Cibo', tuckedCards: 'Infilate',
+};
+
+describe('WingspanCategoryBreakdown', () => {
+  it('sums roundScores per player per category', () => {
+    const { container } = render(
+      <WingspanCategoryBreakdown players={players} roundScores={roundScores} categoryLabels={categoryLabels} heading="Categorie" />
+    );
+    // eggs = 3 + 4 = 7 for p1
+    const eggs = container.querySelector('[data-player="p1"][data-category="eggs"]');
+    expect(eggs?.textContent).toContain('7');
+    const birds = container.querySelector('[data-player="p1"][data-category="birds"]');
+    expect(birds?.textContent).toContain('5');
+    // a category with no scores shows 0
+    const food = container.querySelector('[data-player="p1"][data-category="cachedFood"]');
+    expect(food?.textContent).toContain('0');
+  });
+
+  it('renders the player name and all 6 categories', () => {
+    const { container } = render(
+      <WingspanCategoryBreakdown players={players} roundScores={roundScores} categoryLabels={categoryLabels} heading="Categorie" />
+    );
+    expect(screen.getByText('Marco')).toBeInTheDocument();
+    expect(container.querySelectorAll('[data-player="p1"][data-category]')).toHaveLength(6);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm exec vitest run src/components/features/session-live/flavors/wingspan/__tests__/WingspanCategoryBreakdown.test.tsx`
+Expected: FAIL — `Cannot find module '../WingspanCategoryBreakdown'`.
+
+- [ ] **Step 3: Write the implementation**
+
+```tsx
+// WingspanCategoryBreakdown.tsx
+'use client';
+
+import { type ReactElement } from 'react';
+
+import type { LiveSessionDto, LiveSessionPlayerDto } from '@/lib/api/schemas/live-sessions.schemas';
+
+import { WINGSPAN_CATEGORIES } from './wingspan-state';
+
+export interface WingspanCategoryBreakdownProps {
+  readonly players: ReadonlyArray<LiveSessionPlayerDto>;
+  readonly roundScores: LiveSessionDto['roundScores'];
+  readonly categoryLabels: Record<string, string>;
+  readonly heading: string;
+}
+
+function sumCategory(
+  roundScores: LiveSessionDto['roundScores'],
+  playerId: string,
+  categoryId: string
+): number {
+  return roundScores
+    .filter(rs => rs.playerId === playerId && rs.dimension === categoryId)
+    .reduce((sum, rs) => sum + rs.value, 0);
+}
+
+export function WingspanCategoryBreakdown({
+  players,
+  roundScores,
+  categoryLabels,
+  heading,
+}: WingspanCategoryBreakdownProps): ReactElement {
+  return (
+    <section data-slot="wingspan-breakdown" className="flex flex-col gap-2">
+      <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+        {heading}
+      </h3>
+      <ul role="list" className="flex flex-col gap-1">
+        {players.map(player => (
+          <li key={player.id} className="flex flex-col gap-1 rounded-lg bg-card px-2 py-1.5">
+            <span className="text-xs font-semibold text-foreground">{player.displayName}</span>
+            <span className="flex flex-wrap gap-x-3 gap-y-0.5">
+              {WINGSPAN_CATEGORIES.map(cat => (
+                <span
+                  key={cat.id}
+                  data-player={player.id}
+                  data-category={cat.id}
+                  className="inline-flex items-center gap-1 text-xs text-muted-foreground"
+                  title={categoryLabels[cat.id] ?? cat.id}
+                >
+                  <span aria-hidden="true">{cat.emoji}</span>
+                  <span className="font-semibold tabular-nums text-foreground">
+                    {sumCategory(roundScores, player.id, cat.id)}
+                  </span>
+                </span>
+              ))}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm exec vitest run src/components/features/session-live/flavors/wingspan/__tests__/WingspanCategoryBreakdown.test.tsx`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add "apps/web/src/components/features/session-live/flavors/wingspan/WingspanCategoryBreakdown.tsx" "apps/web/src/components/features/session-live/flavors/wingspan/__tests__/WingspanCategoryBreakdown.test.tsx"
+git commit -m "feat(session-live): #2788 Wingspan L3 category breakdown"
+```
+
+---
+
+## Task 5: WingspanLiveFlavor container (self-builds labels)
+
+**Files:**
+- Create: `apps/web/src/components/features/session-live/flavors/wingspan/WingspanLiveFlavor.tsx`
+- Test: `apps/web/src/components/features/session-live/flavors/wingspan/__tests__/WingspanLiveFlavor.test.tsx`
+
+**Interfaces:**
+- Consumes: `WingspanRoundTracker`, `WingspanCategoryBreakdown`, `WINGSPAN_CATEGORIES`, `parseWingspanGameState`, `useWingspanStateEditor`; `useLiveSessionStore`; `hasRequiredRole`, `ParticipantRole`; `LiveSessionDto`; `useIntl` (react-intl) + `useTranslation` (`@/hooks/useTranslation`).
+- Produces: `WingspanLiveFlavor` + `WingspanLiveFlavorProps` (the game-agnostic flavor props):
+  ```ts
+  interface WingspanLiveFlavorProps {
+    session: LiveSessionDto;
+    viewerRole: ParticipantRole;
+    sessionId: string;
+    className?: string;
+    livePoints?: ReadonlyMap<string, number> | null;
+    phaseName?: string | null;
+  }
+  ```
+
+- [ ] **Step 1: Write the failing test**
+
+```tsx
+// WingspanLiveFlavor.test.tsx
+import { describe, expect, it, beforeEach, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
+import { axe, toHaveNoViolations } from 'jest-axe';
+
+import { WingspanLiveFlavor } from '../WingspanLiveFlavor';
+import { useLiveSessionStore } from '@/lib/stores/live-session-store';
+
+expect.extend(toHaveNoViolations);
+
+vi.mock('@/hooks/mutations/useUpdateLiveGameState', () => ({
+  useUpdateLiveGameState: () => ({ mutate: vi.fn() }),
+}));
+
+const session = {
+  id: 's1', sessionCode: 'ABC', gameId: null, gameName: 'Wingspan', gameSlug: 'wingspan',
+  createdByUserId: 'u1', status: 'InProgress', visibility: 'Private', groupId: null,
+  createdAt: '', startedAt: '', pausedAt: null, completedAt: null, updatedAt: '', lastSavedAt: null,
+  currentTurnIndex: 0, currentTurnPlayerId: 'p1', agentMode: 'None', notes: null,
+  players: [
+    { id: 'p1', userId: null, displayName: 'Marco', avatarUrl: null, color: 'Red', role: 'Host', teamId: null, totalScore: 12, currentRank: 1, joinedAt: '', isActive: true },
+    { id: 'p2', userId: null, displayName: 'Anna', avatarUrl: null, color: 'Blue', role: 'Player', teamId: null, totalScore: 9, currentRank: 2, joinedAt: '', isActive: false },
+  ],
+  teams: [], roundScores: [{ playerId: 'p1', round: 1, dimension: 'eggs', value: 3, unit: null, recordedAt: '' }],
+  scoringConfig: { enabledDimensions: [], dimensionUnits: {} },
+} as const;
+
+function renderFlavor(props: Partial<Parameters<typeof WingspanLiveFlavor>[0]> = {}) {
+  return render(
+    // onError swallows react-intl MISSING_TRANSLATION noise (empty messages → t() returns the key).
+    <IntlProvider locale="en" messages={{}} onError={() => {}}>
+      <WingspanLiveFlavor session={session} viewerRole="Player" sessionId="s1" {...props} />
+    </IntlProvider>
+  );
+}
+
+beforeEach(() => useLiveSessionStore.getState().reset());
+
+describe('WingspanLiveFlavor', () => {
+  it('renders the leaderboard + category breakdown even with null gameState', () => {
+    const { container } = renderFlavor();
+    expect(container.querySelector('[data-slot="wingspan-breakdown"]')).not.toBeNull();
+    expect(container.querySelectorAll('[data-slot="wingspan-leaderboard-row"]')).toHaveLength(2);
+    // no round tracker (gameState null) — but for a host, a CTA appears
+    expect(container.querySelector('[data-slot="wingspan-round-tracker"]')).toBeNull();
+  });
+
+  it('host sees the init-round CTA when gameState is null', () => {
+    const { container } = renderFlavor({ viewerRole: 'Host' });
+    expect(container.querySelector('[data-slot="wingspan-round-init"]')).not.toBeNull();
+  });
+
+  it('renders the round tracker when gameState is present', () => {
+    useLiveSessionStore.getState().setGameState({ v: 1, game: 'wingspan', round: 2, roundGoals: [] });
+    const { container } = renderFlavor({ viewerRole: 'Host' });
+    expect(container.querySelector('[data-slot="wingspan-round-tracker"]')).not.toBeNull();
+  });
+
+  it('has no axe violations (host, populated)', async () => {
+    useLiveSessionStore.getState().setGameState({ v: 1, game: 'wingspan', round: 2, roundGoals: [{ label: 'Nidi' }] });
+    const { container } = renderFlavor({ viewerRole: 'Host' });
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm exec vitest run src/components/features/session-live/flavors/wingspan/__tests__/WingspanLiveFlavor.test.tsx`
+Expected: FAIL — `Cannot find module '../WingspanLiveFlavor'`.
+
+- [ ] **Step 3: Write the implementation**
+
+```tsx
+// WingspanLiveFlavor.tsx
+'use client';
+
+import { type ReactElement } from 'react';
+
+import { useIntl } from 'react-intl';
+
+import { useTranslation } from '@/hooks/useTranslation';
+import type { LiveSessionDto } from '@/lib/api/schemas/live-sessions.schemas';
+import { hasRequiredRole, type ParticipantRole } from '@/lib/session-live/participant-role';
+
+import { WingspanCategoryBreakdown } from './WingspanCategoryBreakdown';
+import { WingspanRoundTracker } from './WingspanRoundTracker';
+import { WINGSPAN_CATEGORIES } from './wingspan-state';
+import { useWingspanStateEditor } from './use-wingspan-state-editor';
+
+export interface WingspanLiveFlavorProps {
+  readonly session: LiveSessionDto;
+  readonly viewerRole: ParticipantRole;
+  readonly sessionId: string;
+  readonly className?: string;
+  readonly livePoints?: ReadonlyMap<string, number> | null;
+  readonly phaseName?: string | null;
+}
+
+const K = 'pages.sessionLive.flavor.wingspan';
+
+export function WingspanLiveFlavor({
+  session,
+  viewerRole,
+  sessionId,
+  className,
+  livePoints,
+}: WingspanLiveFlavorProps): ReactElement {
+  const { t } = useTranslation();
+  const intl = useIntl();
+  const isHost = hasRequiredRole(viewerRole, 'Host');
+  const editor = useWingspanStateEditor(sessionId);
+  const state = editor.state;
+
+  const tmpl = (id: string, fallback: string) =>
+    (intl.messages[`${K}.${id}`] as string) ?? fallback;
+
+  const categoryLabels: Record<string, string> = Object.fromEntries(
+    WINGSPAN_CATEGORIES.map(c => [c.id, t(`${K}.category.${c.id}`)])
+  );
+
+  const scoreOf = (playerId: string): number =>
+    livePoints?.get(playerId) ?? session.players.find(p => p.id === playerId)?.totalScore ?? 0;
+  const sorted = [...session.players].sort((a, b) => scoreOf(b.id) - scoreOf(a.id));
+
+  return (
+    <section
+      aria-label={t(`${K}.panelAriaLabel`)}
+      data-slot="wingspan-flavor-live"
+      className={`flex flex-col gap-4 ${className ?? ''}`.trim()}
+    >
+      {/* Leaderboard (always rendered — from scoring, not gameState) */}
+      <div data-slot="wingspan-leaderboard" className="flex flex-col gap-2">
+        <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+          {t(`${K}.leaderboardHeading`)}
+        </h3>
+        <ul role="list" className="flex flex-col gap-1">
+          {sorted.map((player, idx) => (
+            <li
+              key={player.id}
+              data-slot="wingspan-leaderboard-row"
+              className={[
+                'flex items-center gap-2 rounded-lg px-2 py-1.5',
+                idx === 0 ? 'border border-entity-session/40 bg-entity-session/10' : 'border border-transparent bg-card',
+              ].join(' ')}
+            >
+              <span className="min-w-0 flex-1 truncate text-xs font-medium text-foreground">
+                {player.displayName}
+                {idx === 0 && <span aria-hidden="true"> 🏆</span>}
+              </span>
+              <span
+                aria-label={tmpl('scoreAriaTemplate', '{name}: {score}')
+                  .replace('{name}', player.displayName)
+                  .replace('{score}', String(scoreOf(player.id)))}
+                className="shrink-0 tabular-nums text-sm font-bold text-foreground"
+              >
+                {scoreOf(player.id)}
+              </span>
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      {/* Category breakdown (always rendered — from roundScores) */}
+      <WingspanCategoryBreakdown
+        players={session.players}
+        roundScores={session.roundScores}
+        categoryLabels={categoryLabels}
+        heading={t(`${K}.categoriesHeading`)}
+      />
+
+      {/* Round tracker (gameState-gated) */}
+      {state != null ? (
+        <WingspanRoundTracker
+          state={state}
+          editable={isHost}
+          onAdvanceRound={editor.advanceRound}
+          onSetRoundGoal={editor.setRoundGoal}
+          labels={{
+            heading: t(`${K}.roundHeading`),
+            roundTemplate: tmpl('roundTemplate', 'Round {n}/4'),
+            turnBudgetTemplate: tmpl('turnBudgetTemplate', '{n} turni'),
+            goalsHeading: t(`${K}.goalsHeading`),
+            goalPlaceholderTemplate: tmpl('goalPlaceholderTemplate', 'Obiettivo round {n}'),
+            advanceRoundLabel: t(`${K}.advanceRoundLabel`),
+          }}
+        />
+      ) : isHost ? (
+        <button
+          type="button"
+          data-slot="wingspan-round-init"
+          onClick={editor.initializeState}
+          className="self-start rounded-lg border border-entity-session/40 bg-entity-session/10 px-3 py-2 text-sm font-semibold text-entity-session hover:bg-entity-session/20"
+        >
+          {t(`${K}.initRoundCta`)}
+        </button>
+      ) : (
+        <p role="status" aria-live="polite" className="text-xs text-muted-foreground">
+          {t(`${K}.viewerWaiting`)}
+        </p>
+      )}
+    </section>
+  );
+}
+```
+
+> Note: `WingspanLiveFlavor` is standalone here (not yet in `FLAVOR_MAP`) — it compiles unused. Task 6 wires it in. The test wraps it in `IntlProvider` (empty messages → `t()` returns the key, `intl.messages` templates fall back), which is enough to assert structure + axe.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm exec vitest run src/components/features/session-live/flavors/wingspan/__tests__/WingspanLiveFlavor.test.tsx`
+Expected: PASS (4 tests). If `t()` returning the raw key trips the axe check (unlikely), assert on `data-slot`s only.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add "apps/web/src/components/features/session-live/flavors/wingspan/WingspanLiveFlavor.tsx" "apps/web/src/components/features/session-live/flavors/wingspan/__tests__/WingspanLiveFlavor.test.tsx"
+git commit -m "feat(session-live): #2788 Wingspan L3 flavor container (self-builds labels)"
+```
+
+---
+
+## Task 6: Generalize FlavorRenderer + Catan self-builds labels + wire Wingspan + i18n (ONE commit)
+
+**Why one commit:** changing `FlavorRenderer`'s props (dropping `labels`) and `CatanLiveFlavor`'s props (dropping `labels`) breaks `tsc` on `SessionLiveView` unless all land together; the pre-commit hook runs `pnpm typecheck`.
+
+**Files:**
+- Modify: `apps/web/src/components/features/session-live/FlavorRenderer.tsx`
+- Modify: `apps/web/src/components/features/session-live/flavors/catan/CatanLiveFlavor.tsx`
+- Modify: `apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx`
+- Modify: `apps/web/src/locales/it.json`, `apps/web/src/locales/en.json`
+
+**Interfaces:**
+- Produces: `FlavorProps` (game-agnostic) exported from `FlavorRenderer.tsx`:
+  ```ts
+  interface FlavorProps {
+    session: LiveSessionDto; viewerRole: ParticipantRole; sessionId: string;
+    className?: string; livePoints?: ReadonlyMap<string, number> | null; phaseName?: string | null;
+  }
+  ```
+
+- [ ] **Step 1: Make `FlavorRenderer` game-agnostic**
+
+Rewrite `FlavorRenderer.tsx` to:
+- Export `interface FlavorProps { session: LiveSessionDto; viewerRole: ParticipantRole; sessionId: string; className?: string; livePoints?: ReadonlyMap<string, number> | null; phaseName?: string | null; }`.
+- `type FlavorComponent = ComponentType<FlavorProps>;` (drop the `CatanLiveFlavorProps` import).
+- Add `WingspanLiveFlavorLazy` (module-scope `dynamic(() => import('./flavors/wingspan/WingspanLiveFlavor').then(m => ({ default: m.WingspanLiveFlavor })), { ssr: false, loading: () => <FlavorLoadingSkeleton /> })`).
+- `FLAVOR_MAP = { catan: { live: CatanLiveFlavorLazy }, wingspan: { live: WingspanLiveFlavorLazy } }`.
+- `FlavorRendererProps` = `FlavorProps & { gameSlug; view }` (drop `labels`).
+- Forward only `session, viewerRole, sessionId, className, livePoints, phaseName` to `<LazyFlavor>`.
+
+- [ ] **Step 2: Refactor `CatanLiveFlavor` to self-build labels**
+
+In `CatanLiveFlavor.tsx`:
+- Change `CatanLiveFlavorProps` to the game-agnostic shape: `{ session, viewerRole, sessionId, className?, livePoints?, phaseName? }` (drop `labels`). Keep `CatanLiveFlavorLabels` as an INTERNAL type (no longer a prop).
+- Add `import { useIntl } from 'react-intl';` and `import { useTranslation } from '@/hooks/useTranslation';`.
+- Inside the component, build `const labels: CatanLiveFlavorLabels = { … }` by moving the object literal currently in `SessionLiveView.tsx:1139-1171` verbatim (uses `t(...)` + `intl.messages[...] as string ?? fallback`). Declare `const { t } = useTranslation(); const intl = useIntl();` at the top of the component.
+- Everywhere the component read `labels` from props, it now reads the locally-built `labels`.
+
+- [ ] **Step 3: Clean up `SessionLiveView`**
+
+In `SessionLiveView.tsx`:
+- Delete the `catanFlavorLabels` `useMemo` (currently `:1138-1173`) and its entry in any dependency array (`:1498`).
+- Remove the `import type { CatanLiveFlavorLabels }` if now unused, and the `type CatanLiveFlavorLabels` usage.
+- At both `<FlavorRenderer ...>` sites (~`:1409` mobile, ~`:1635` desktop), delete the `labels={catanFlavorLabels}` line. Keep `gameSlug`, `view`, `session`, `viewerRole`, `sessionId`, `className`, `livePoints`, `phaseName`.
+
+- [ ] **Step 4: Add Wingspan i18n keys**
+
+In `src/locales/it.json`, under `pages.sessionLive.flavor`, add a `"wingspan"` sibling to `"catan"`:
+
+```json
+"wingspan": {
+  "panelAriaLabel": "Wingspan",
+  "leaderboardHeading": "Classifica",
+  "scoreAriaTemplate": "{name}: {score} PV",
+  "categoriesHeading": "Punti per categoria",
+  "roundHeading": "Round",
+  "roundTemplate": "Round {n}/4",
+  "turnBudgetTemplate": "{n} turni",
+  "goalsHeading": "Obiettivi di round",
+  "goalPlaceholderTemplate": "Obiettivo round {n}",
+  "advanceRoundLabel": "Avanza round",
+  "initRoundCta": "Inizia il round",
+  "viewerWaiting": "In attesa dell'host…",
+  "category": {
+    "birds": "Uccelli",
+    "bonusCards": "Carte bonus",
+    "endOfRoundGoals": "Obiettivi di fine round",
+    "eggs": "Uova",
+    "cachedFood": "Cibo accumulato",
+    "tuckedCards": "Carte infilate"
+  }
+}
+```
+
+Mirror in `src/locales/en.json` with English copy (`"leaderboardHeading": "Standings"`, `"categoriesHeading": "Points by category"`, `"roundHeading": "Round"`, `"turnBudgetTemplate": "{n} turns"`, `"goalsHeading": "Round goals"`, `"goalPlaceholderTemplate": "Round {n} goal"`, `"advanceRoundLabel": "Advance round"`, `"initRoundCta": "Start the round"`, `"viewerWaiting": "Waiting for the host…"`, categories: `Birds / Bonus cards / End-of-round goals / Eggs / Cached food / Tucked cards`; `roundTemplate`/`scoreAriaTemplate` identical).
+
+- [ ] **Step 5: Typecheck + run affected suites**
+
+```bash
+rm -rf .next/types
+pnpm typecheck
+pnpm exec vitest run \
+  src/components/features/session-live/flavors/wingspan \
+  src/components/features/session-live/flavors/catan/__tests__/CatanLiveFlavor.test.tsx \
+  src/components/features/session-live/__tests__/FlavorRenderer.test.tsx \
+  "src/app/(authenticated)/sessions/[id]/live/_components/__tests__/SessionLiveView.test.tsx"
+```
+Expected: typecheck clean; all suites PASS. `CatanLiveFlavor.test.tsx` currently passes a `labels` prop — update it to wrap the component in `<IntlProvider locale="en" messages={{}} onError={() => {}}>` (the `onError` swallows MISSING_TRANSLATION noise) and drop the `labels` prop (the flavor now self-builds labels; its assertions on `data-slot`s / roles hold with `t()` returning raw keys). If `SessionLiveView.test.tsx` referenced `catanFlavorLabels`, remove those references.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add "apps/web/src/components/features/session-live/FlavorRenderer.tsx" "apps/web/src/components/features/session-live/flavors/catan/CatanLiveFlavor.tsx" "apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx" "apps/web/src/locales/it.json" "apps/web/src/locales/en.json"
+# include the updated Catan/FlavorRenderer/SessionLiveView test files if you touched them
+git commit -m "feat(session-live): #2788 game-agnostic FlavorRenderer + wire Wingspan + Catan self-builds labels"
+```
+
+---
+
+## Task 7: Final verification
+
+- [ ] **Step 1: Full typecheck + all flavor suites**
+
+```bash
+rm -rf .next/types
+pnpm typecheck
+pnpm exec vitest run src/components/features/session-live/flavors src/components/features/session-live/__tests__/FlavorRenderer.test.tsx
+```
+Expected: typecheck clean; all Catan + Wingspan flavor tests PASS.
+
+- [ ] **Step 2: Lint the touched files**
+
+```bash
+pnpm exec eslint --max-warnings=0 "src/components/features/session-live/flavors/wingspan/**/*.{ts,tsx}" "src/components/features/session-live/FlavorRenderer.tsx" "src/components/features/session-live/flavors/catan/CatanLiveFlavor.tsx"
+```
+Expected: no errors.
+
+- [ ] **Step 3: Push + open PR to `main-dev`**
+
+```bash
+git push -u origin feature/issue-2788-wingspan-l2-l3
+gh pr create --base main-dev --head feature/issue-2788-wingspan-l2-l3 \
+  --title "feat(session-live): #2788 Wingspan L2+L3 flavor (themed scoring + round context)" \
+  --body "Implements the Wingspan flavor per docs/superpowers/specs/2026-07-16-wingspan-l2-l3-flavor-design.md. FE-only. Generalizes FlavorRenderer (flavors self-build i18n labels). Closes #2788."
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage:**
+- L2 schema + parser + categories + turn budget → Task 1. ✅
+- Host-edit (round/goals, optimistic + debounced) → Task 2. ✅
+- Round tracker → Task 3. Category breakdown (sums roundScores) → Task 4. ✅
+- Container (scoring ungated, round tracker gated, self-builds labels) → Task 5. ✅
+- Generalization (FlavorRenderer game-agnostic, Catan self-builds labels, SessionLiveView cleanup, wire Wingspan, i18n) → Task 6. ✅
+- VP-from-scoring invariant → Tasks 4/5 (reads `roundScores`/`livePoints`, never `gameState`). ✅
+- Known-seam (category id ↔ dimension name) → breakdown shows 0 gracefully (Task 4 test covers `cachedFood`=0). ✅
+- Testing (unit + component + jest-axe) → Tasks 1–5. ✅
+- No backend changes → whole plan FE-only. ✅
+
+**2. Placeholder scan:** No TBD/TODO; every code step has complete code. Task 6 references exact existing lines to move (the `catanFlavorLabels` memo) — the code being moved already exists verbatim in the repo. ✅
+
+**3. Type consistency:** `WingspanGameState`, `parseWingspanGameState`, `initialWingspanState`, `WINGSPAN_CATEGORIES` (`{id,emoji}`), `WINGSPAN_ROUND_TURN_BUDGET`, `useWingspanStateEditor` signature, the three component prop interfaces, and `FlavorProps` are used consistently across Tasks 1→6. Category ids match between `wingspan-state.ts`, the breakdown, and the i18n `category.*` keys. ✅
+
+**Known follow-ups (out of scope):** aligning Wingspan session creation to the 6 canonical dimension names; per-player habitat/bird tableau; Wingspan summary flavor.

--- a/docs/superpowers/specs/2026-07-16-wingspan-l2-l3-flavor-design.md
+++ b/docs/superpowers/specs/2026-07-16-wingspan-l2-l3-flavor-design.md
@@ -1,0 +1,125 @@
+# Wingspan L2+L3 flavor — design
+
+**Issue:** #2788 (G6b, part of epic #3025). **Date:** 2026-07-16. **Status:** approved (brainstorm with owner).
+
+## Goal
+
+Add a rich, mockup-faithful Wingspan live flavor on the L1 game-state layer, reusing the proven Catan L2/L3 pattern (`flavors/<game>/`: state + editor + pure components + container). Wingspan is the 2nd game and the first to be primarily **scoring-centric** rather than board-centric — its richness lives in the 6 Victory-Point categories + the 4-round structure, not a visual board.
+
+## Key finding that shaped the scope
+
+The `sp4-session-wingspan-live` mockup is the **universal session skeleton** (7 right-column tabs, roster, `LiveScoringPanel`, `ActionLog`) with Wingspan theming. The Wingspan-specific live content is **category scoring**: the 6 canonical VP categories (`M.CATS`) with a per-player breakdown (`M.BREAKDOWN[player][cat]`) and a category-tab + `+/-` stepper score-entry panel. There is **no visual board, no bird placement, no habitat tableau** in the live view (that richness is in the post-game summary). So most of Wingspan's live "richness" maps onto the app's **existing scoring system** (`scoringConfig.enabledDimensions` + `roundScores` + the polymorphic score editor), which the Catan MVP flavor already rendered as a per-dimension breakdown.
+
+## Scope decisions (locked)
+
+1. **Themed scoring + round context** (chosen). The 6 Wingspan VP categories are **scoring dimensions** (entered via the existing score editor, read by the flavor from `roundScores`/`livePoints`). The Wingspan-specific `gameState` is small: **round context only** (`round` 1–4 + 4 round-goal tiles).
+2. **VP stays in the existing scoring system** — the same cross-cutting invariant as Catan. `gameState` never carries scores.
+3. **Round-goal tiles = free-text labels** (the canonical goal-tile set varies by edition; free text = zero host-entry friction). The per-round turn budget (8/7/6/5) is a derived constant, not stored.
+4. **Scoring is NOT gated on `gameState`** (divergence from Catan): the leaderboard + category breakdown always render (they come from `roundScores`), independent of whether the round-context `gameState` exists. Only the round tracker shows a host CTA when `gameState` is null — no "generate board" wall.
+5. **Label-provisioning generalization** (motivated by this 2nd game): `FlavorRenderer` currently passes a Catan-specific `labels` prop built in `SessionLiveView`. That does not scale to N games. Each flavor will **self-build its i18n labels via `useIntl`**; `FlavorRenderer` becomes game-agnostic (`session` + `viewerRole` + `sessionId` + `livePoints` + `phaseName`). `CatanLiveFlavor` is refactored the same way for consistency (the `catanFlavorLabels` memo moves into the component).
+
+## Headline: zero backend
+
+L1 (PR #3031) provides the opaque write→persist→stream→expose path. L2 is a FE JSON convention + parser; L3 is the renderer. No backend changes. Scores use the existing scoring endpoints/editor.
+
+## Architecture
+
+All under `apps/web/src/components/features/session-live/flavors/wingspan/`.
+
+### L2 — state contract (`wingspan-state.ts`)
+
+```ts
+export const WINGSPAN_STATE_VERSION = 1;
+export const WINGSPAN_ROUND_TURN_BUDGET = [8, 7, 6, 5] as const; // turns per round 1..4
+
+export interface WingspanRoundGoal { label: string } // free-text; scoredBy resolved via scoring, not here
+
+export interface WingspanGameState {
+  v: 1;
+  game: 'wingspan';
+  round: number;              // 1..4
+  roundGoals: WingspanRoundGoal[]; // up to 4 entries (one per round)
+}
+
+export function parseWingspanGameState(raw: unknown): WingspanGameState | null; // Zod safeParse; null on wrong game/version/shape
+
+export function initialWingspanState(): WingspanGameState; // { v:1, game:'wingspan', round:1, roundGoals:[] }
+
+// The 6 canonical Wingspan VP categories. `id` is the scoring dimension name the flavor
+// sums over `roundScores`; label/emoji are for display. The six ids (fixed):
+//   birds · bonusCards · endOfRoundGoals · eggs · cachedFood · tuckedCards
+export const WINGSPAN_CATEGORIES: ReadonlyArray<{ id: string; label: string; emoji: string }>;
+// KNOWN SEAM: the breakdown sums `roundScores` by these dimension ids. If a Wingspan session
+// was created with differently-named dimensions, the breakdown shows 0 per category (graceful,
+// no crash) while the leaderboard (livePoints/totalScore) is unaffected. Aligning session
+// creation to these dimension names is a follow-up, not part of this FE flavor.
+```
+
+Zod schema: `round` is `z.number().int().min(1).max(4)`; `roundGoals` is `z.array(z.object({ label: z.string() })).max(4)`. `parseWingspanGameState` returns `null` on `game !== 'wingspan'` / `v !== 1` / malformed (degrades to the round-tracker empty state without crashing).
+
+### L2 — host-edit (`use-wingspan-state-editor.ts`)
+
+Mirrors `use-catan-state-editor`: reads `useLiveSessionStore(s => s.gameState)` → `parseWingspanGameState`; wraps `useUpdateLiveGameState(sessionId)` + `useDebouncedCallback(fn, 500)`; each mutator = optimistic `setGameState(next)` + debounced PUT; flush on unmount; `readState()` re-parses fresh at call time.
+
+```ts
+interface WingspanStateEditor {
+  state: WingspanGameState | null;
+  initializeState(): void;                 // host CTA when null → round 1, empty goals
+  setRound(round: number): void;           // clamp 1..4
+  advanceRound(): void;                    // round = min(round+1, 4)
+  setRoundGoal(index: number, label: string): void; // index 0..3
+}
+```
+
+No score mutators — scores flow through the existing score editor.
+
+### L3 — components (pure) + container
+
+- **`WingspanRoundTracker.tsx`** — displays round `n/4` + the per-round turn budget (`WINGSPAN_ROUND_TURN_BUDGET[round-1]`) + the 4 round-goal tiles. Props `{ state, editable, onSetRound?, onAdvanceRound?, onSetRoundGoal?, labels }`. Host (`editable`): advance-round button + inline-editable goal labels (text inputs). Read-only: static.
+- **`WingspanCategoryBreakdown.tsx`** — per-player themed breakdown across `WINGSPAN_CATEGORIES`, summing `roundScores` per category (reuse a `sumDimension(roundScores, playerId, categoryId)` helper mirroring the Catan MVP). Read-only display (scores edited via the score editor). Props `{ players, roundScores, labels }`.
+- **`WingspanLiveFlavor.tsx`** — container. Renders: a themed **leaderboard** (players sorted by `livePoints ?? totalScore`), the **category breakdown**, and the **round tracker**. Scoring sections render unconditionally; the round tracker renders its host CTA (`initializeState`) when `parseWingspanGameState(store.gameState)` is null and the viewer is Host, else a "waiting" note. Self-builds labels via `useIntl`. Props `{ session, viewerRole, sessionId, className?, livePoints?, phaseName? }`.
+
+### Generalization (FlavorRenderer + Catan refactor)
+
+- `FlavorRenderer` drops the `labels` prop; forwards only game-agnostic props (`session`, `viewerRole`, `sessionId`, `className`, `livePoints`, `phaseName`). Its `FLAVOR_MAP` gains `wingspan: { live: WingspanLiveFlavorLazy }`.
+- `CatanLiveFlavor` is refactored to self-build its labels internally via `useIntl` (the `catanFlavorLabels` `useMemo` is removed from `SessionLiveView`, and `CatanLiveFlavorLabels` becomes an internal concern). `SessionLiveView`'s two `FlavorRenderer` sites drop the `labels={catanFlavorLabels}` prop.
+- i18n: add `flavor.wingspan.*`; `flavor.catan.*` values are unchanged (only the build site moves).
+
+## Data flow
+
+- **Scoring** (leaderboard + breakdown): from `roundScores` / `livePoints` (existing), independent of `gameState`.
+- **Round context**: from `useLiveSessionStore(s => s.gameState)` via `parseWingspanGameState`.
+- **Host writes**: round/goal edits → optimistic `setGameState` + debounced `PUT /game-state`; scores → existing score editor.
+
+## Error handling & edge cases
+
+- `gameState` null / wrong game / malformed → round tracker shows host CTA (or viewer waiting); the scoring sections still render. `console.warn` once on malformed.
+- PUT failure → `sonner` toast; optimistic state retained.
+- `setRound` clamps 1..4; `advanceRound` caps at 4; `setRoundGoal` ignores out-of-range indices.
+- A session with no Wingspan scoring dimensions → the breakdown shows 0 per category (no crash).
+
+## Testing
+
+- **Unit:** `parseWingspanGameState` (valid / wrong game / wrong version / malformed / round out-of-range rejected); `initialWingspanState`; editor mutators (setRound clamp, advanceRound cap at 4, setRoundGoal index guard, optimistic `setGameState`, debounce).
+- **Component (RTL + jsdom):** `WingspanRoundTracker` (host advance/goal-edit callbacks vs read-only static); `WingspanCategoryBreakdown` (per-category sums from `roundScores`); `WingspanLiveFlavor` (scoring renders with null gameState; round-tracker host CTA vs viewer waiting; populated compose). `jest-axe` AA on the flavor.
+- **E2E:** the existing `session-live-catan-flavor.smoke.spec.ts` regression guard (a non-Wingspan/Catan fixture shows no game flavor tab) already covers the gating; the fixture Wingspan session already exercises "no Catan tab". A Wingspan positive path is `test.fixme()` (same `?fixture=host` limitation). No new E2E file.
+
+## File map
+
+Create:
+- `flavors/wingspan/wingspan-state.ts`
+- `flavors/wingspan/use-wingspan-state-editor.ts`
+- `flavors/wingspan/WingspanRoundTracker.tsx`
+- `flavors/wingspan/WingspanCategoryBreakdown.tsx`
+- `flavors/wingspan/WingspanLiveFlavor.tsx`
+- `flavors/wingspan/__tests__/*`
+
+Modify:
+- `session-live/FlavorRenderer.tsx` — game-agnostic props + `wingspan` in `FLAVOR_MAP`.
+- `flavors/catan/CatanLiveFlavor.tsx` — self-build labels via `useIntl` (remove the labels prop dependency).
+- `sessions/[id]/live/_components/SessionLiveView.tsx` — remove `catanFlavorLabels` memo + `labels=` prop at both `FlavorRenderer` sites.
+- `src/locales/it.json` + `en.json` — add `flavor.wingspan.*`.
+
+## Out of scope (YAGNI)
+
+Per-player habitat/bird tableau (a summary-view concern, not in the live mockup); individual bird-card placement; food/egg supply tracking; the canonical round-goal-tile picker (free text instead); Wingspan summary flavor (separate follow-up like Catan's #3022); any backend change.


### PR DESCRIPTION
## Wingspan L2+L3 flavor (#2788 G6b, epic #3025)

Adds the Wingspan live flavor, reusing the proven Catan L2/L3 pattern (`flavors/<game>/`) — the 2nd per-game flavor and the first **scoring-centric** one.

**Spec:** `docs/superpowers/specs/2026-07-16-wingspan-l2-l3-flavor-design.md`
**Plan:** `docs/superpowers/plans/2026-07-16-wingspan-l2-l3-flavor.md`
**Closes #2788.**

### Key finding that shaped the scope
Wingspan's live mockup is the universal session skeleton with theming — its richness is **category scoring** (the 6 canonical VP categories), not a visual board. So most of it maps onto the **existing scoring system**; the new `gameState` carries only round context.

### What changed (FE-only, zero backend)
**L2**
- `wingspan-state.ts` — versioned Zod schema (`{ round 1-4, roundGoals: free-text[] }`) + `parseWingspanGameState`→null + `WINGSPAN_CATEGORIES` (6 ids) + `WINGSPAN_ROUND_TURN_BUDGET [8,7,6,5]`.
- `use-wingspan-state-editor.ts` — host mutators (init/setRound/advanceRound/setRoundGoal), optimistic + debounced-500ms PUT (L1).

**L3**
- `WingspanRoundTracker` (round + goal tiles) · `WingspanCategoryBreakdown` (per-player sums over `roundScores`) · `WingspanLiveFlavor` container. **Scoring (leaderboard + breakdown) renders unconditionally**; only the round tracker is `gameState`-gated (host CTA / viewer waiting). **VP stays in scoring** (`livePoints ?? totalScore`), never in `gameState`.

**Generalization (scales the flavor plumbing to N games)**
- `FlavorRenderer` is now **game-agnostic** (`FlavorProps` — no per-game `labels` prop); each flavor **self-builds its i18n labels** via `useIntl`. `CatanLiveFlavor` was refactored the same way (its 20-key label object moved verbatim into the component); `SessionLiveView` cleaned up. `flavor.wingspan.*` added to it+en.

### Quality gates
- `tsc --noEmit` clean; **14 flavor test files / 66 tests** pass incl. **2 jest-axe AA** checks (Catan + Wingspan) + a FlavorRenderer forwarding test.
- Built with subagent-driven development (implementer + task reviewer per task) + an **Opus final whole-branch review → READY TO MERGE**. The highest-risk item (Catan label refactor) is double-protected: verbatim key-id move + an unmodified `SessionLiveView` integration test that renders the flavor with real Catan i18n keys.

### Follow-ups (non-blocking)
- Align Wingspan session-creation to the 6 canonical scoring-dimension names (the breakdown degrades to 0 gracefully otherwise) — spec'd as a follow-up.
- A cosmetic `console.warn` on malformed gameState (consistent with Catan's current silent parse).

Part of #3025 — the L2/L3 pattern now covers a board game (Catan) and a scoring game (Wingspan).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
