### PR TITLE
fix(notifications): #3058 allow admin_manual_notification email template in validator

### DIFF
--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Validators/EnqueueEmailCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Validators/EnqueueEmailCommandValidator.cs
@@ -9,7 +9,7 @@ namespace Api.BoundedContexts.UserNotifications.Application.Validators;
 /// </summary>
 internal sealed class EnqueueEmailCommandValidator : AbstractValidator<EnqueueEmailCommand>
 {
-    private static readonly string[] ValidTemplates = ["document_ready", "document_failed", "retry_available"];
+    private static readonly string[] ValidTemplates = ["document_ready", "document_failed", "retry_available", "admin_manual_notification"];
 
     public EnqueueEmailCommandValidator()
     {
@@ -33,7 +33,7 @@ internal sealed class EnqueueEmailCommandValidator : AbstractValidator<EnqueueEm
             .NotEmpty()
             .WithMessage("TemplateName is required")
             .Must(t => ValidTemplates.Contains(t, StringComparer.Ordinal))
-            .WithMessage("TemplateName must be one of: document_ready, document_failed, retry_available");
+            .WithMessage("TemplateName must be one of: document_ready, document_failed, retry_available, admin_manual_notification");
 
         RuleFor(x => x.UserName)
             .NotEmpty()

--- a/apps/api/tests/Api.Tests/UserNotifications/Application/Validators/EnqueueEmailCommandValidatorTests.cs
+++ b/apps/api/tests/Api.Tests/UserNotifications/Application/Validators/EnqueueEmailCommandValidatorTests.cs
@@ -82,6 +82,7 @@ public sealed class EnqueueEmailCommandValidatorTests
     [InlineData("document_ready")]
     [InlineData("document_failed")]
     [InlineData("retry_available")]
+    [InlineData("admin_manual_notification")]
     public void Validate_ValidTemplateNames_Pass(string templateName)
     {
         var command = CreateValidCommand() with { TemplateName = templateName };


### PR DESCRIPTION
## Problema

Il feature admin **Send Manual Notification** (`POST /api/v1/admin/notifications/send`) non consegnava mai il canale **email** (`dispatched:0, skipped:N`). Il canale in-app funzionava; l'email no. Verificato live su staging 2026-07-16 (#3058).

## Root cause (confermata da investigazione avversariale)

`EnqueueEmailCommandValidator.ValidTemplates` **non includeva** `"admin_manual_notification"`. La validazione FluentValidation falliva nel `ValidationBehavior` MediatR **prima** dell'handler; l'eccezione veniva ingoiata dal `catch` per-recipient in `SendManualNotificationCommandHandler` (recipient contato come `skipped`, email mai accodata).

Il vero difetto è **drift della allow-list duplicata**: i template esistono in due punti indipendenti — il gate del validator e lo switch di rendering in `EnqueueEmailCommandHandler` (righe 74-85). Lo switch era già stato aggiornato con `admin_manual_notification` (→ `RenderAdminNotification`), il validator no.

## Fix

Aggiunto `"admin_manual_notification"` alla allow-list del validator + sincronizzato il testo `WithMessage`. **Nessuna modifica a handler/template/worker**: il body è già renderizzato da `EmailTemplateService.RenderAdminNotification` a enqueue-time e inviato da `EmailProcessorJob`.

## Test (TDD)

Esteso il theory `Validate_ValidTemplateNames_Pass` con il nuovo template. **RED** sul codice precedente (template rifiutato), **GREEN** dopo il fix. Suite `EnqueueEmail*` verde (22 test).

## Note

- Sistema email separato `EmailNotificationProcessorJob`/`notification_queue_items` (#3026) **non toccato**.
- Debito residuo (fuori scope): centralizzare la lista template in una sola sorgente per eliminare il drift.

Closes #3058

🤖 Generated with [Claude Code](https://claude.com/claude-code)