### PR TITLE
fix(session-live): #3055 omit previous session's cursor on SSE session change

### DIFF
--- a/apps/web/src/lib/session-live/__tests__/use-session-live-stream.test.ts
+++ b/apps/web/src/lib/session-live/__tests__/use-session-live-stream.test.ts
@@ -472,6 +472,56 @@ describe('useSessionLiveStream — sessionId change', () => {
     });
     expect(result.current.events).toHaveLength(1);
   });
+
+  it("#3055: session B first connect URL omits the previous session's lastEventId cursor", () => {
+    const { rerender } = renderHook(
+      ({ sessionId }) => useSessionLiveStream({ sessionId, enabled: true }),
+      { initialProps: { sessionId: 'session-A' } }
+    );
+
+    act(() => {
+      MockEventSource.lastInstance()!.triggerOpen();
+      MockEventSource.lastInstance()!.triggerEvent(
+        'session:score',
+        JSON.stringify({ participantId: 'p1', score: 5, sessionId: 'session-A' }),
+        'evt-A-9'
+      );
+    });
+
+    act(() => {
+      rerender({ sessionId: 'session-B' });
+    });
+
+    const bUrl = MockEventSource.lastInstance()!.url;
+    expect(bUrl).toContain('/api/v1/live-sessions/session-B/stream');
+    // Before the fix this opened as ?lastEventId=evt-A-9 (session A's cursor bleeding into B).
+    expect(bUrl).not.toContain('lastEventId');
+  });
+
+  it('#3055: same-session retry reconnect still sends the last cursor for replay', () => {
+    const { result } = makeHook({ sessionId: 'session-1' });
+
+    act(() => {
+      MockEventSource.lastInstance()!.triggerOpen();
+      MockEventSource.lastInstance()!.triggerEvent(
+        'session:score',
+        JSON.stringify({ participantId: 'p1', score: 5, sessionId: 'session-1' }),
+        'evt-1'
+      );
+    });
+
+    // Retryable error (not 429) → schedules a same-session reconnect at RETRY_BUDGET_MS[0].
+    act(() => {
+      MockEventSource.lastInstance()!.triggerError(false);
+    });
+    act(() => {
+      vi.advanceTimersByTime(1001);
+    });
+
+    // The reconnect MUST replay from the last cursor — the fix only strips it on session change.
+    expect(result.current).toBeDefined();
+    expect(MockEventSource.lastInstance()!.url).toContain('lastEventId=evt-1');
+  });
 });
 
 describe('useSessionLiveStream — retryAt', () => {

--- a/apps/web/src/lib/session-live/__tests__/use-session-live-stream.test.ts
+++ b/apps/web/src/lib/session-live/__tests__/use-session-live-stream.test.ts
@@ -522,6 +522,64 @@ describe('useSessionLiveStream — sessionId change', () => {
     expect(result.current).toBeDefined();
     expect(MockEventSource.lastInstance()!.url).toContain('lastEventId=evt-1');
   });
+
+  it('#3055: a retry AFTER a session change does not resurrect the previous session cursor', () => {
+    const { rerender } = renderHook(
+      ({ sessionId }) => useSessionLiveStream({ sessionId, enabled: true }),
+      { initialProps: { sessionId: 'session-A' } }
+    );
+
+    act(() => {
+      MockEventSource.lastInstance()!.triggerOpen();
+      MockEventSource.lastInstance()!.triggerEvent(
+        'session:score',
+        JSON.stringify({ participantId: 'p1', score: 5, sessionId: 'session-A' }),
+        'evt-A-9'
+      );
+    });
+
+    // Switch to B (first connect already omits A's cursor); then B errors before any B event.
+    act(() => {
+      rerender({ sessionId: 'session-B' });
+    });
+    act(() => {
+      MockEventSource.lastInstance()!.triggerError(false);
+    });
+    act(() => {
+      vi.advanceTimersByTime(1001);
+    });
+
+    // The retry reads the CLEARed (null) cursor, not A's evt-A-9 — the connect(false)-after-CLEAR branch.
+    const retryUrl = MockEventSource.lastInstance()!.url;
+    expect(retryUrl).toContain('/api/v1/live-sessions/session-B/stream');
+    expect(retryUrl).not.toContain('lastEventId');
+  });
+
+  it('#3055: toggling enabled false→true on the same session preserves the replay cursor', () => {
+    const { rerender } = renderHook(
+      ({ sessionId, enabled }) => useSessionLiveStream({ sessionId, enabled }),
+      { initialProps: { sessionId: 'session-1', enabled: true } }
+    );
+
+    act(() => {
+      MockEventSource.lastInstance()!.triggerOpen();
+      MockEventSource.lastInstance()!.triggerEvent(
+        'session:score',
+        JSON.stringify({ participantId: 'p1', score: 5, sessionId: 'session-1' }),
+        'evt-1'
+      );
+    });
+
+    // Disable (no CLEAR — same session) then re-enable: the reconnect must still replay from evt-1.
+    act(() => {
+      rerender({ sessionId: 'session-1', enabled: false });
+    });
+    act(() => {
+      rerender({ sessionId: 'session-1', enabled: true });
+    });
+
+    expect(MockEventSource.lastInstance()!.url).toContain('lastEventId=evt-1');
+  });
 });
 
 describe('useSessionLiveStream — retryAt', () => {

--- a/apps/web/src/lib/session-live/use-session-live-stream.ts
+++ b/apps/web/src/lib/session-live/use-session-live-stream.ts
@@ -211,37 +211,65 @@ export function useSessionLiveStream(input: UseSessionLiveStreamInput): UseSessi
     }
   }, []);
 
-  const connect = useCallback(() => {
-    if (!isMountedRef.current || !sessionId || !enabled) return;
+  const connect = useCallback(
+    (forceFreshCursor = false) => {
+      if (!isMountedRef.current || !sessionId || !enabled) return;
 
-    cleanup();
-    receivedFirstMessageRef.current = false;
-    dispatch({ type: 'CONNECTING' });
+      cleanup();
+      receivedFirstMessageRef.current = false;
+      dispatch({ type: 'CONNECTING' });
 
-    const lastEventId = state.lastEventId;
-    const url = `${baseUrl}/api/v1/live-sessions/${sessionId}/stream${
-      lastEventId ? `?lastEventId=${encodeURIComponent(lastEventId)}` : ''
-    }`;
+      // #3055: on a genuine session change the reducer CLEAR that nulls lastEventId
+      // has not flushed yet, so state.lastEventId still holds the previous session's
+      // cursor. Force a fresh (cursor-less) connect for the new session; same-session
+      // reconnects (retry timer, manual reconnect) pass no arg and keep replaying.
+      const lastEventId = forceFreshCursor ? null : state.lastEventId;
+      const url = `${baseUrl}/api/v1/live-sessions/${sessionId}/stream${
+        lastEventId ? `?lastEventId=${encodeURIComponent(lastEventId)}` : ''
+      }`;
 
-    let es: EventSource;
-    try {
-      es = new EventSource(url, { withCredentials: true });
-    } catch {
-      // EventSource not supported or CORS error
-      dispatch({ type: 'DEGRADED_POLLING' });
-      return;
-    }
-    eventSourceRef.current = es;
+      let es: EventSource;
+      try {
+        es = new EventSource(url, { withCredentials: true });
+      } catch {
+        // EventSource not supported or CORS error
+        dispatch({ type: 'DEGRADED_POLLING' });
+        return;
+      }
+      eventSourceRef.current = es;
 
-    es.onopen = () => {
-      if (!isMountedRef.current) return;
-      dispatch({ type: 'CONNECTED' });
-      retryCountRef.current = 0;
-    };
+      es.onopen = () => {
+        if (!isMountedRef.current) return;
+        dispatch({ type: 'CONNECTED' });
+        retryCountRef.current = 0;
+      };
 
-    // Listen for each typed event by name
-    const handleTypedEvent = (eventType: SessionEventType) => {
-      es.addEventListener(eventType, (e: MessageEvent) => {
+      // Listen for each typed event by name
+      const handleTypedEvent = (eventType: SessionEventType) => {
+        es.addEventListener(eventType, (e: MessageEvent) => {
+          if (!isMountedRef.current) return;
+
+          if (!receivedFirstMessageRef.current) {
+            receivedFirstMessageRef.current = true;
+            dispatch({ type: 'CONNECTED' });
+            retryCountRef.current = 0;
+          }
+
+          // sessionId comes from the URL, not the SSE envelope; e.lastEventId is the dedup key
+          const sseId = e.lastEventId || '';
+          const event = parseSseEvent(eventType, e.data, sessionId ?? '');
+          if (event) {
+            dispatch({ type: 'EVENT', event, sseId });
+          }
+        });
+      };
+
+      for (const eventType of SESSION_EVENT_TYPES) {
+        handleTypedEvent(eventType);
+      }
+
+      // Fallback: handle unnamed messages (onmessage) for servers sending default event type
+      es.onmessage = (e: MessageEvent) => {
         if (!isMountedRef.current) return;
 
         if (!receivedFirstMessageRef.current) {
@@ -250,78 +278,57 @@ export function useSessionLiveStream(input: UseSessionLiveStreamInput): UseSessi
           retryCountRef.current = 0;
         }
 
-        // sessionId comes from the URL, not the SSE envelope; e.lastEventId is the dedup key
-        const sseId = e.lastEventId || '';
-        const event = parseSseEvent(eventType, e.data, sessionId ?? '');
-        if (event) {
-          dispatch({ type: 'EVENT', event, sseId });
+        // Try to parse as heartbeat or typed via type field in data
+        try {
+          const parsed = JSON.parse(e.data) as Record<string, unknown>;
+          const type = typeof parsed['type'] === 'string' ? parsed['type'] : 'heartbeat';
+          const sseId = e.lastEventId || '';
+          const event = parseSseEvent(type, e.data, sessionId ?? '');
+          if (event) {
+            dispatch({ type: 'EVENT', event, sseId });
+          }
+        } catch {
+          // Ignore malformed messages
         }
-      });
-    };
+      };
 
-    for (const eventType of SESSION_EVENT_TYPES) {
-      handleTypedEvent(eventType);
-    }
+      es.onerror = () => {
+        if (!isMountedRef.current) return;
 
-    // Fallback: handle unnamed messages (onmessage) for servers sending default event type
-    es.onmessage = (e: MessageEvent) => {
-      if (!isMountedRef.current) return;
+        // 429 heuristic: immediate CLOSED state with no messages received
+        const isImmediateClosed =
+          !receivedFirstMessageRef.current && es.readyState === EventSource.CLOSED;
 
-      if (!receivedFirstMessageRef.current) {
-        receivedFirstMessageRef.current = true;
-        dispatch({ type: 'CONNECTED' });
-        retryCountRef.current = 0;
-      }
+        cleanup();
 
-      // Try to parse as heartbeat or typed via type field in data
-      try {
-        const parsed = JSON.parse(e.data) as Record<string, unknown>;
-        const type = typeof parsed['type'] === 'string' ? parsed['type'] : 'heartbeat';
-        const sseId = e.lastEventId || '';
-        const event = parseSseEvent(type, e.data, sessionId ?? '');
-        if (event) {
-          dispatch({ type: 'EVENT', event, sseId });
+        if (isImmediateClosed && retryCountRef.current === 0) {
+          // Treat as 429 — backend closed before any data
+          dispatch({ type: 'FAILED' });
+          return;
         }
-      } catch {
-        // Ignore malformed messages
-      }
-    };
 
-    es.onerror = () => {
-      if (!isMountedRef.current) return;
+        const nextRetryCount = retryCountRef.current + 1;
 
-      // 429 heuristic: immediate CLOSED state with no messages received
-      const isImmediateClosed =
-        !receivedFirstMessageRef.current && es.readyState === EventSource.CLOSED;
-
-      cleanup();
-
-      if (isImmediateClosed && retryCountRef.current === 0) {
-        // Treat as 429 — backend closed before any data
-        dispatch({ type: 'FAILED' });
-        return;
-      }
-
-      const nextRetryCount = retryCountRef.current + 1;
-
-      if (nextRetryCount > MAX_RETRIES) {
-        dispatch({ type: 'DEGRADED_POLLING' });
-        return;
-      }
-
-      retryCountRef.current = nextRetryCount;
-      const delayMs = RETRY_BUDGET_MS[nextRetryCount - 1] ?? RETRY_BUDGET_MS[MAX_RETRIES - 1];
-      const retryAt = new Date(Date.now() + delayMs);
-
-      dispatch({ type: 'RETRY', retryCount: nextRetryCount, retryAt });
-
-      retryTimerRef.current = setTimeout(() => {
-        if (isMountedRef.current) {
-          connectRef.current();
+        if (nextRetryCount > MAX_RETRIES) {
+          dispatch({ type: 'DEGRADED_POLLING' });
+          return;
         }
-      }, delayMs);
-    };
-  }, [sessionId, enabled, baseUrl, cleanup, state.lastEventId]);
+
+        retryCountRef.current = nextRetryCount;
+        const delayMs = RETRY_BUDGET_MS[nextRetryCount - 1] ?? RETRY_BUDGET_MS[MAX_RETRIES - 1];
+        const retryAt = new Date(Date.now() + delayMs);
+
+        dispatch({ type: 'RETRY', retryCount: nextRetryCount, retryAt });
+
+        retryTimerRef.current = setTimeout(() => {
+          if (isMountedRef.current) {
+            connectRef.current();
+          }
+        }, delayMs);
+      };
+    },
+    [sessionId, enabled, baseUrl, cleanup, state.lastEventId]
+  );
 
   // Keep connectRef stable for retry timer closures
   connectRef.current = connect;
@@ -345,7 +352,8 @@ export function useSessionLiveStream(input: UseSessionLiveStreamInput): UseSessi
     // #3050: on a genuine sessionId change, clear the previous session's accumulated
     // events/seenIds/lastEventId so they cannot bleed into this session (App Router
     // reuses the /sessions/[id]/live component across navigations — no remount).
-    if (prevSessionIdRef.current !== sessionId) {
+    const sessionChanged = prevSessionIdRef.current !== sessionId;
+    if (sessionChanged) {
       prevSessionIdRef.current = sessionId;
       retryCountRef.current = 0;
       receivedFirstMessageRef.current = false;
@@ -353,7 +361,8 @@ export function useSessionLiveStream(input: UseSessionLiveStreamInput): UseSessi
     }
 
     if (sessionId && enabled) {
-      connect();
+      // #3055: pass the change flag so B's first connect omits A's stale cursor.
+      connect(sessionChanged);
     } else {
       cleanup();
     }


### PR DESCRIPTION
## Problema

Su un cambio di sessione **A→B** genuino, `useSessionLiveStream` apre il **primo** EventSource di B come `/live-sessions/B/stream?lastEventId=<id di A>` — un cursore di replay estraneo. L'effetto dispatcha `CLEAR` (che azzera `state.lastEventId`) e poi chiama `connect()` **sincronicamente** nello stesso tick: la `CLEAR` non è ancora stata flushata, quindi `connect()` legge il valore di closure pre-flush (il cursore di A).

Benigno (nessun evento perso/duplicato — `seenIds` è azzerato), ma l'URL è scorretto. Scoperto durante la review avversariale di #3050, filed come follow-up L1.

## Fix (Option B — thread `forceFreshCursor`)

`connect()` prende un parametro opzionale `forceFreshCursor` (default `false`). Solo il branch session-change passa `connect(sessionChanged)`, quindi il primo connect di B **omette** il cursore. I reconnect same-session (retry timer + `reconnect()` manuale) chiamano `connectRef.current()` **senza argomento** → `forceFreshCursor=false` → continuano a inviare `lastEventId` per il replay. La dispatch `CLEAR` è invariata.

Scelta Option B su Option A (ref) perché evita una scrittura di ref in fase di render e la dipendenza dall'ordine di reset — meno righe e nessun timing cross-render da ragionare.

> Nota: il pre-commit prettier ha riformattato l'intero blocco `useCallback` (wrapping multi-linea) → il diff appare grande ma la modifica semantica è di 3 righe (param + read + call site).

## Test (TDD)

- **(A) regressione**: il primo URL di B non contiene `lastEventId` — **RED** prima del fix (riceveva `?lastEventId=evt-A-9`), **GREEN** dopo.
- **(B) guardia**: un retry-reconnect same-session invia ancora `lastEventId=evt-1` — verde prima e dopo, blocca il path di replay contro un fix troppo aggressivo.

28/28 test verdi, typecheck + eslint puliti.

## Scope

`apps/web/src/lib/session-live/use-session-live-stream.ts` (hook L1). Area epic #3025. La dispatch `CLEAR` di #3050 resta invariata.

Closes #3055

🤖 Generated with [Claude Code](https://claude.com/claude-code)