### PR TITLE
chore(notifications): #2979 remove game_night_published dead-entry + resolve SP7 cleanup

### DIFF
--- a/apps/web/src/app/(authenticated)/notifications/page.tsx
+++ b/apps/web/src/app/(authenticated)/notifications/page.tsx
@@ -81,7 +81,6 @@ const FILTERS: readonly FilterDef[] = [
     types: [
       'game_night_invitation',
       'game_night_rsvp_received',
-      'game_night_published',
       'game_night_cancelled',
       'game_night_reminder',
     ],

--- a/apps/web/src/components/notifications/NotificationItem.tsx
+++ b/apps/web/src/components/notifications/NotificationItem.tsx
@@ -177,7 +177,6 @@ function getTypeIcon(type: string): React.ComponentType<{ className?: string }> 
       return Bot;
     case 'game_night_invitation':
     case 'game_night_rsvp_received':
-    case 'game_night_published':
     case 'game_night_cancelled':
     case 'game_night_reminder':
       return Calendar;

--- a/apps/web/src/lib/api/schemas/notifications.schemas.ts
+++ b/apps/web/src/lib/api/schemas/notifications.schemas.ts
@@ -34,7 +34,6 @@ export const KNOWN_NOTIFICATION_TYPES = [
   'agent_ready',
   'game_night_invitation',
   'game_night_rsvp_received',
-  'game_night_published',
   'game_night_cancelled',
   'game_night_reminder',
 ] as const;

--- a/docs/for-developers/audits/2026-07-15-sp7-spec-panel-invariant-diff.md
+++ b/docs/for-developers/audits/2026-07-15-sp7-spec-panel-invariant-diff.md
@@ -207,4 +207,17 @@ Runtime cablato end-to-end (`GameNightPublishedNotificationHandler` → `Notific
 
 ---
 
-*Prodotto da spec-panel critique statico (Opus 4.8) — 2026-07-15, addendum §6 stessa data. Nessun file di prodotto modificato oltre a questo audit + annotazione mockup.*
+## § 7 — Risoluzione #2979 (2026-07-17)
+
+Chiusura dei 4 residui di #2979. Verifica dello stato reale del repo (i mockup referenziati sono cambiati dopo il 2026-07-15):
+
+1. **Notifiche I/J vs #16/#17** (doc) — già coperto da §6.3: runtime cablato end-to-end, i mockup `notifications.jsx`/preferences sono demo statici non collegati. Nessuna azione di codice; annotazione qui è sufficiente.
+2. **Dead-entry `game_night_published`** (contract cleanup) — ✅ **RISOLTO**. Confermato che il BE (`NotificationType.cs`) definisce solo 4 tipi game-night (`invitation`, `rsvp_received`, `reminder`, `cancelled`) e **non emette mai** `game_night_published`. Rimosso dai 3 punti FE (`notifications.schemas.ts` `KNOWN_NOTIFICATION_TYPES`, `NotificationItem.tsx` `getTypeIcon`, `notifications/page.tsx` filtro `events`). Nessun test lo referenziava.
+3. **Tensione Auto-RSVP regulars** (domain question) — ⚪ **MOOT**. Il mockup `sp7-game-night-new.jsx` che conteneva il toggle "Auto-RSVP per i regular" è stato **eliminato** in `90f731b4f` (DS-17-16, PR #2988, "remove migrated page-mocks"). La stringa "Auto-RSVP"/"confermati automaticamente" **non esiste più in alcun artefatto live** (né runtime, né story/fixture migrate, né brief SP9). Nessuna superficie da correggere; l'invariante #16 (tag silente) resta la legge. Se una futura wave mobile game-night (SP9) reintroduce un affordance "auto-conferma al tag", deve onorare #16 (pre-check UI di selezione invito, **non** RSVP=confermato al tagging).
+4. **Re-sync `sp7-game-night-detail-rsvp.jsx`** (mockup) — ⚪ **MOOT**. Mockup **eliminato** nello stesso commit #2988 e migrato a story (`game-nights/[id]/game-night-detail-rsvp.stories.tsx`) che renderizza il componente runtime reale `GameNightDetailView` — il quale **ha già la CTA "Invia inviti"** (#16, PR #2969, con test `GameNightDetailView.inviteCta.test.tsx`). La story è in-sync per costruzione col runtime; il gap chiuso non può ri-emergere da un mockup statico che non esiste più.
+
+**Esito**: 1 fix di codice (item 2) + 3 item chiusi come già-coperti/moot. Issue #2979 chiudibile.
+
+---
+
+*Prodotto da spec-panel critique statico (Opus 4.8) — 2026-07-15, addendum §6 stessa data, §7 risoluzione 2026-07-17.*


### PR DESCRIPTION
## Contesto

Chiusura dei 4 residui low-priority di #2979 (follow-up SP7 di #1889). **Verificato lo stato reale del repo**: l'issue è del 2026-07-15 e i mockup referenziati sono cambiati da allora → 3 dei 4 item sono già coperti o moot.

## Item risolti

### 2. Dead-entry `game_night_published` — ✅ FIX di codice
Il FE elencava un tipo notifica `game_night_published` in **3 punti** (`KNOWN_NOTIFICATION_TYPES`, `NotificationItem.getTypeIcon`, filtro `events` della pagina) che il BE **non emette mai**: `NotificationType.cs` definisce solo `game_night_{invitation,rsvp_received,reminder,cancelled}`. Al publish il runtime dispatcha `game_night_invitation`, non `_published`. Drift della allow-list senza sorgente runtime → rimosso dai 3 punti FE.

- Nessun test referenziava il tipo; 40 test notifiche + typecheck verdi.
- Schema difensivo (`NotificationTypeSchema = z.string()`) → degrada con grazia se il BE un giorno aggiungesse il tipo (icona generica finché non re-inserito).

### 1. Notifiche I/J vs #16/#17 — già coperto
Già documentato in audit §6.3: runtime cablato end-to-end, i mockup `notifications.jsx`/preferences sono demo statici non collegati. Nessuna azione di codice.

### 3. Tensione Auto-RSVP regulars — ⚪ MOOT
Il mockup `sp7-game-night-new.jsx` col toggle "Auto-RSVP per i regular" è stato **eliminato** in `90f731b4f` (DS-17-16, PR #2988). La stringa non esiste più in **alcun artefatto live** (runtime, story/fixture migrate, brief SP9). L'invariante #16 (tag silente) resta la legge; nessuna superficie da correggere.

### 4. Re-sync `sp7-game-night-detail-rsvp.jsx` — ⚪ MOOT
Mockup **eliminato** nello stesso #2988 e migrato a story (`game-night-detail-rsvp.stories.tsx`) che renderizza il componente runtime reale `GameNightDetailView` — che **ha già la CTA "Invia inviti"** (#16, PR #2969, con test dedicato). In-sync per costruzione; il gap chiuso non può ri-emergere da un mockup che non esiste più.

## Documentazione

Aggiunta §7 "Risoluzione #2979 (2026-07-17)" all'audit `2026-07-15-sp7-spec-panel-invariant-diff.md` con la disposizione dei 4 item.

Closes #2979

🤖 Generated with [Claude Code](https://claude.com/claude-code)