### PR TITLE
chore(infra): #3039 cadvisor in monitoring-essential profile

### DIFF
--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -480,7 +480,12 @@ services:
     image: gcr.io/cadvisor/cadvisor:v0.49.1
     container_name: meepleai-cadvisor
     restart: unless-stopped
-    profiles: [monitoring]
+    # #3039: also in monitoring-essential so per-container metrics reach the
+    # single-tester staging deploy (CI uses --profile monitoring-essential).
+    # Mirrors node-exporter; Prometheus already has a `cadvisor:8080` scrape job
+    # + the Grafana infra dashboard already has container_* panels — both were
+    # DOWN/empty on staging until now. Footprint: 512M limit / 256M reservation.
+    profiles: [monitoring, monitoring-essential]
     devices:
       - /dev/kmsg:/dev/kmsg
     volumes:


### PR DESCRIPTION
## Sommario

Epic **#3040** (admin observability) sub-issue **#3039** (P3, opzionale) — abilita `cadvisor` nel profilo `monitoring-essential`, così le metriche per-container arrivano al deploy staging single-tester.

### Diagnosi
- Il deploy staging reale (CI `deploy-staging.yml:1141` + `make staging-minimal`) usa `--profile ai-essential --profile monitoring-essential`.
- `cadvisor` era `profiles: [monitoring]`-only → **non partiva** su staging single-tester.
- Ma sia Prometheus (`prometheus.staging.yml` → `job_name: cadvisor` / `cadvisor:8080`) sia la dashboard Grafana `infrastructure-monitoring.json` (6 pannelli `container_*`) **lo aspettano già** → target DOWN + pannelli vuoti su staging.

### Fix
1 riga: `profiles: [monitoring]` → `profiles: [monitoring, monitoring-essential]` (mirror di `node-exporter`, righe 456-460).

### Validazione
`docker compose -f docker-compose.yml --profile monitoring-essential config --services` → cadvisor ora incluso (con prometheus/grafana/alertmanager/node-exporter). ✅

## Footprint (⚠️ owner-gated per issue)
- Host staging **CAX21 (8GB)**, profilo `monitoring-essential` volutamente stretto (~3GB).
- cadvisor: **+512M limit / +256M reservation** → ~3.3GB, ampio margine sugli 8GB.
- Non-critical: `restart: unless-stopped`, **nessun `depends_on`** lo referenzia → un eventuale fail-to-start sul CAX21 non blocca gli altri servizi. Reversibile con revert di 1 riga.
- **Nota**: è la prima volta che cadvisor gira sul CAX21 (finora solo `make staging` full su CAX31+). La validazione runtime avviene al prossimo deploy staging; se fallisse resta isolato.

### Relazione con #3042
Indipendente: #3042 (per-container CPU/mem in-app) legge Docker `/stats` **direttamente**, NON cadvisor. cadvisor alimenta solo la dashboard Grafana infra + lo scrape Prometheus.

Closes #3039

🤖 Generated with [Claude Code](https://claude.com/claude-code)