### PR TITLE
feat(compare): #2999 greenfield side-by-side mockup↔live compare tool (GAP-6.3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -297,3 +297,6 @@ loc.png
 
 # Windows temp diff files accidentally created by harness tools
 C*UsersUtenteAppDataLocalTemp*-diff.txt
+
+# Mockup<->live compare tool output (#2999) - screenshots, mai committare
+apps/web/mockup-compare-output/

--- a/apps/web/e2e/mockup-compare/README.md
+++ b/apps/web/e2e/mockup-compare/README.md
@@ -1,0 +1,70 @@
+# Mockup↔Live Compare Tool (#2999)
+
+Dev-tool locale per la review **manuale** di fedeltà mockup↔implementazione live.
+Genera una gallery HTML statica che affianca lo screenshot del page-mock e quello
+della route live reale, con slider drag-to-reveal.
+
+**NON è un gate CI** (nessuna baseline, nessun pixel-diff → immune al problema
+baseline win32↔linux che ha descopato la suite pixel Storybook, #2063).
+
+## Uso
+
+```bash
+cd apps/web
+pnpm compare:mockups        # capture + genera gallery.html (stampa il path)
+pnpm compare:mockups:open   # idem + apre nel browser
+```
+
+Output (gitignored): `apps/web/mockup-compare-output/gallery.html` + PNG.
+
+### 🔴 Prerequisito: server con auth-bypass
+
+La route live si cattura solo se il server Next gira con
+`PLAYWRIGHT_AUTH_BYPASS=true` (attivo solo in dev). Il config **avvia lui** un
+dev server con il bypass **se la :3000 è libera**. Se la :3000 è già occupata da
+un server SENZA bypass (tipico: lo stack Docker `make dev`), `reuseExistingServer`
+lo riusa e il gate SSR di `proxy.ts` **reindirizza a `/login`** → il capture live
+mostra la pagina di login invece della route.
+
+In quel caso punta a un dev server con bypass su una porta libera:
+
+```bash
+# in un terminale: dev server con bypass su 3100
+PLAYWRIGHT_AUTH_BYPASS=true pnpm exec next dev -p 3100
+# in un altro: capture contro quella porta
+COMPARE_APP_PORT=3100 pnpm compare:mockups
+```
+
+## Aggiungere una coppia
+
+Aggiungi una riga a `e2e/mockup-compare/manifest.ts`:
+
+- `mockupHtml`: nome file in `admin-mockups/design_files/`.
+- `route`: path live.
+- `auth`: `'user'` | `'admin'`.
+- `mock` (opzionale): `page.route` per popolare i dati — **glob host-agnostici**
+  `**/api/v1/...` (l'app usa URL relativi nel browser), MAI `localhost:8080` —
+  **oppure** usa il seam built-in `?fixture=default` dove supportato (es.
+  `useLibrary`).
+
+## Come funziona
+
+`manifest.ts` → `capture.spec.ts` (screenshot mockup via http-server :5175 +
+route live via app :3000 auth-bypass + mock) → `captures.json` →
+`scripts/mockup-compare/generate.mjs` → `gallery.html`.
+
+Auth della route live: `seedMockRoleCookies` (gate SSR di `proxy.ts`) +
+`mockAuthEndpoints` (client `/auth/me` + `/auth/session/status`), entrambi da
+`e2e/_helpers/seedAuthSession`.
+
+## Note / limiti
+
+- **Il mockup capture richiede rete** a `unpkg.com`: molti page-mock caricano
+  React/ReactDOM/Babel da CDN e transpilano JSX in-browser. La capture attende
+  il mount reale (`waitForFunction`); se unpkg è irraggiungibile la gallery
+  mostra un placeholder "mockup capture failed" invece di uno screenshot vuoto.
+- Alcuni page-mock `.html` sono standalone e possono divergere dalla sorgente
+  che l'implementazione ha effettivamente tracciato (es. `sp4-library-wishlist`
+  cita un `-ui.jsx`); un po' di drift è atteso e va giudicato manualmente.
+- **Non è un gate CI**: la cattura è locale, l'output gitignored, il giudizio
+  di fedeltà è umano.

--- a/apps/web/e2e/mockup-compare/README.md
+++ b/apps/web/e2e/mockup-compare/README.md
@@ -19,21 +19,23 @@ Output (gitignored): `apps/web/mockup-compare-output/gallery.html` + PNG.
 
 ### 🔴 Prerequisito: server con auth-bypass
 
-La route live si cattura solo se il server Next gira con
+La route live si cattura autenticata solo se il server Next gira con
 `PLAYWRIGHT_AUTH_BYPASS=true` (attivo solo in dev). Il config **avvia lui** un
-dev server con il bypass **se la :3000 è libera**. Se la :3000 è già occupata da
-un server SENZA bypass (tipico: lo stack Docker `make dev`), `reuseExistingServer`
-lo riusa e il gate SSR di `proxy.ts` **reindirizza a `/login`** → il capture live
-mostra la pagina di login invece della route.
+dev server con il bypass (via `cross-env` nel comando webServer, propagazione
+env affidabile anche su Windows) **se la porta è libera**.
 
-In quel caso punta a un dev server con bypass su una porta libera:
+Se la :3000 è già occupata da un server SENZA bypass (tipico: lo stack Docker
+`make dev`, build prod → bypass disabilitato), `reuseExistingServer` lo riusa e
+il gate SSR di `proxy.ts` **reindirizza a `/login`** → il capture live mostra la
+pagina di login. In quel caso punta a una porta libera (il config vi avvia da
+solo un dev server con bypass):
 
 ```bash
-# in un terminale: dev server con bypass su 3100
-PLAYWRIGHT_AUTH_BYPASS=true pnpm exec next dev -p 3100
-# in un altro: capture contro quella porta
 COMPARE_APP_PORT=3100 pnpm compare:mockups
 ```
+
+> Verificato 2026-07-17: su :3100 libera la coppia `/library/wishlist` cattura la
+> wishlist autenticata con le fixture mockate (Fixture User loggato).
 
 ## Aggiungere una coppia
 

--- a/apps/web/e2e/mockup-compare/__tests__/manifest.test.ts
+++ b/apps/web/e2e/mockup-compare/__tests__/manifest.test.ts
@@ -1,0 +1,24 @@
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { PAIRS, DESIGN_FILES_DIR } from '../manifest';
+
+describe('mockup-compare manifest', () => {
+  it('has at least one pair', () => {
+    expect(PAIRS.length).toBeGreaterThan(0);
+  });
+
+  it('has unique ids', () => {
+    const ids = PAIRS.map(p => p.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('references mockup HTML files that exist on disk', () => {
+    for (const pair of PAIRS) {
+      const abs = path.join(DESIGN_FILES_DIR, pair.mockupHtml);
+      expect(existsSync(abs), `${pair.id}: missing ${abs}`).toBe(true);
+    }
+  });
+});

--- a/apps/web/e2e/mockup-compare/__tests__/manifest.test.ts
+++ b/apps/web/e2e/mockup-compare/__tests__/manifest.test.ts
@@ -15,6 +15,14 @@ describe('mockup-compare manifest', () => {
     expect(new Set(ids).size).toBe(ids.length);
   });
 
+  it('has slug-safe ids (kebab-case)', () => {
+    // Gli id finiscono in attributi HTML E in selettori CSS/JS della gallery:
+    // vincolarli a [a-z0-9-] rende l'escape HTML-only provabilmente sufficiente.
+    for (const pair of PAIRS) {
+      expect(pair.id, `${pair.id} non è slug-safe`).toMatch(/^[a-z0-9-]+$/);
+    }
+  });
+
   it('references mockup HTML files that exist on disk', () => {
     for (const pair of PAIRS) {
       const abs = path.join(DESIGN_FILES_DIR, pair.mockupHtml);

--- a/apps/web/e2e/mockup-compare/capture.spec.ts
+++ b/apps/web/e2e/mockup-compare/capture.spec.ts
@@ -34,7 +34,6 @@ test.afterAll(() => {
 for (const pair of PAIRS) {
   test(`capture ${pair.id}`, async ({ page }) => {
     const viewport = pair.viewport ?? { width: 1920, height: 1080 };
-    await page.setViewportSize(viewport);
     const rec: CaptureRecord = {
       id: pair.id,
       label: pair.label,
@@ -43,6 +42,10 @@ for (const pair of PAIRS) {
       mockupPng: null,
       livePng: null,
     };
+    // Push SUBITO: la coppia deve apparire SEMPRE nel report (fail-visible),
+    // anche se una riga fuori dai try (es. setViewportSize) lancia.
+    records.push(rec);
+    await page.setViewportSize(viewport);
 
     // 1) MOCKUP statico via http-server. NB: molti page-mock caricano
     // React/ReactDOM/Babel da unpkg.com e transpilano JSX in-browser → serve
@@ -75,17 +78,24 @@ for (const pair of PAIRS) {
       await seedMockRoleCookies(page, pair.auth === 'admin' ? 'Admin' : 'User');
       await mockAuthEndpoints(page, { role: pair.auth === 'admin' ? 'admin' : 'user' });
       if (pair.mock) await pair.mock(page);
-      await page.goto(pair.route, { waitUntil: 'networkidle' });
+      // 'load' (non 'networkidle'): route con SSE/EventSource aperto non
+      // raggiungerebbero mai networkidle → hang fino al timeout.
+      await page.goto(pair.route, { waitUntil: 'load' });
       await page.waitForTimeout(1000);
-      const liveFile = `${pair.id}__live.png`;
-      await page.screenshot({ path: path.join(OUTPUT_DIR, liveFile), fullPage: true });
-      rec.livePng = liveFile;
+      // Guard: se il gate SSR ha reindirizzato a /login (server senza bypass),
+      // il capture sarebbe una login page fuorviante → segnala come liveError.
+      if (/(^|\/)login(\/|$)/.test(new URL(page.url()).pathname)) {
+        rec.liveError =
+          'redirected to /login (auth-bypass non ingaggiato — usa COMPARE_APP_PORT su una porta libera)';
+        console.log(`[compare] ${pair.id}: ${rec.liveError}`);
+      } else {
+        const liveFile = `${pair.id}__live.png`;
+        await page.screenshot({ path: path.join(OUTPUT_DIR, liveFile), fullPage: true });
+        rec.livePng = liveFile;
+      }
     } catch (err) {
       rec.liveError = (err as Error).message;
-
       console.log(`[compare] ${pair.id}: live capture failed — ${rec.liveError}`);
     }
-
-    records.push(rec);
   });
 }

--- a/apps/web/e2e/mockup-compare/capture.spec.ts
+++ b/apps/web/e2e/mockup-compare/capture.spec.ts
@@ -1,0 +1,91 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { test } from '@playwright/test';
+
+import { PAIRS, OUTPUT_DIR } from './manifest';
+import { mockAuthEndpoints, seedMockRoleCookies } from '../_helpers/seedAuthSession';
+
+const MOCKUP_PORT = 5175;
+
+interface CaptureRecord {
+  id: string;
+  label: string;
+  route: string;
+  viewport: { width: number; height: number };
+  mockupPng: string | null;
+  mockupError?: string;
+  livePng: string | null;
+  liveError?: string;
+}
+
+const records: CaptureRecord[] = [];
+
+test.beforeAll(() => {
+  mkdirSync(OUTPUT_DIR, { recursive: true });
+});
+
+test.afterAll(() => {
+  writeFileSync(path.join(OUTPUT_DIR, 'captures.json'), JSON.stringify(records, null, 2), 'utf8');
+
+  console.log(`[compare] captures.json scritto (${records.length} coppie)`);
+});
+
+for (const pair of PAIRS) {
+  test(`capture ${pair.id}`, async ({ page }) => {
+    const viewport = pair.viewport ?? { width: 1920, height: 1080 };
+    await page.setViewportSize(viewport);
+    const rec: CaptureRecord = {
+      id: pair.id,
+      label: pair.label,
+      route: pair.route,
+      viewport,
+      mockupPng: null,
+      livePng: null,
+    };
+
+    // 1) MOCKUP statico via http-server. NB: molti page-mock caricano
+    // React/ReactDOM/Babel da unpkg.com e transpilano JSX in-browser → serve
+    // RETE (unpkg) + attesa del MOUNT reale, non un timeout fisso.
+    try {
+      await page.goto(`http://127.0.0.1:${MOCKUP_PORT}/${pair.mockupHtml}`, {
+        waitUntil: 'networkidle',
+      });
+      await page.waitForFunction(
+        () => {
+          const root = document.querySelector('#root');
+          if (root) return root.childElementCount > 0;
+          return document.body.childElementCount > 0;
+        },
+        { timeout: 15_000 }
+      );
+      const mockupFile = `${pair.id}__mockup.png`;
+      await page.screenshot({ path: path.join(OUTPUT_DIR, mockupFile), fullPage: true });
+      rec.mockupPng = mockupFile;
+    } catch (err) {
+      rec.mockupError = (err as Error).message;
+
+      console.log(`[compare] ${pair.id}: mockup capture failed — ${rec.mockupError}`);
+    }
+
+    // 2) LIVE route reale. Auth = seed cookie (proxy SSR gate) + mockAuthEndpoints
+    // (client /auth/me + /auth/session/status, regex host-agnostico). Dati via
+    // pair.mock (glob host-agnostici). NESSUN mock auth hand-rolled.
+    try {
+      await seedMockRoleCookies(page, pair.auth === 'admin' ? 'Admin' : 'User');
+      await mockAuthEndpoints(page, { role: pair.auth === 'admin' ? 'admin' : 'user' });
+      if (pair.mock) await pair.mock(page);
+      await page.goto(pair.route, { waitUntil: 'networkidle' });
+      await page.waitForTimeout(1000);
+      const liveFile = `${pair.id}__live.png`;
+      await page.screenshot({ path: path.join(OUTPUT_DIR, liveFile), fullPage: true });
+      rec.livePng = liveFile;
+    } catch (err) {
+      rec.liveError = (err as Error).message;
+
+      console.log(`[compare] ${pair.id}: live capture failed — ${rec.liveError}`);
+    }
+
+    records.push(rec);
+  });
+}

--- a/apps/web/e2e/mockup-compare/manifest.ts
+++ b/apps/web/e2e/mockup-compare/manifest.ts
@@ -1,0 +1,101 @@
+/**
+ * Mockup↔live compare — pairing manifest (#2999).
+ *
+ * Ogni entry accoppia un page-mock HTML statico (admin-mockups/design_files)
+ * con la route live reale. La capture spec screenshotta entrambi.
+ * Estensione: aggiungi righe qui (+ un `mock` page.route se la route non
+ * supporta il seam `?fixture=`).
+ *
+ * 🔴 URL host-agnostici: l'app usa URL RELATIVI nel browser
+ * (getApiBase()→'', httpClient.ts:51-55) → richieste a localhost:3000/api/...
+ * via proxy Next. I mock page.route DEVONO usare glob **\/api/v1/... , MAI
+ * URL assoluti localhost:8080 (non intercetterebbero).
+ */
+import path from 'node:path';
+
+import type { Page } from '@playwright/test';
+
+export interface MockupComparePair {
+  /** Slug stabile (kebab-case) — usato nei nomi file e nella gallery. */
+  readonly id: string;
+  /** Titolo umano mostrato nella gallery. */
+  readonly label: string;
+  /** Nome file HTML dentro admin-mockups/design_files/. */
+  readonly mockupHtml: string;
+  /** Route live (path relativo, es. "/library/wishlist"). */
+  readonly route: string;
+  /** Ruolo auth per il bypass E2E. Default 'user'. */
+  readonly auth?: 'user' | 'admin';
+  /** Setup page.route opzionale per mockare le API della route (glob host-agnostici). */
+  readonly mock?: (page: Page) => Promise<void>;
+  /** Viewport override. Default 1920x1080. */
+  readonly viewport?: { readonly width: number; readonly height: number };
+}
+
+/** apps/web/e2e/mockup-compare → repo root → admin-mockups/design_files. */
+export const DESIGN_FILES_DIR = path.resolve(
+  process.cwd(),
+  '..',
+  '..',
+  'admin-mockups',
+  'design_files'
+);
+
+/** apps/web/mockup-compare-output (gitignored). */
+export const OUTPUT_DIR = path.resolve(process.cwd(), 'mockup-compare-output');
+
+/** Wishlist fixture — WishlistItemDto[] con gameName inline (no library map). */
+const WISHLIST_FIXTURE = [
+  {
+    id: '11111111-1111-4111-8111-111111111111',
+    userId: '99999999-9999-4999-8999-999999999999',
+    gameId: '22222222-2222-4222-8222-222222222222',
+    gameName: 'Terraforming Mars',
+    priority: 'high',
+    targetPrice: 45.0,
+    notes: 'Aspetto un saldo sotto i 50€',
+    addedAt: '2026-07-01T10:00:00.000Z',
+    updatedAt: null,
+    visibility: 'private',
+  },
+  {
+    id: '33333333-3333-4333-8333-333333333333',
+    userId: '99999999-9999-4999-8999-999999999999',
+    gameId: '44444444-4444-4444-8444-444444444444',
+    gameName: 'Wingspan',
+    priority: 'medium',
+    targetPrice: null,
+    notes: null,
+    addedAt: '2026-06-15T09:30:00.000Z',
+    updatedAt: '2026-06-20T12:00:00.000Z',
+    visibility: 'private',
+  },
+];
+
+export const PAIRS: readonly MockupComparePair[] = [
+  {
+    id: 'library-wishlist',
+    label: 'Library · Wishlist',
+    mockupHtml: 'sp4-library-wishlist.html',
+    route: '/library/wishlist',
+    auth: 'user',
+    // Glob HOST-AGNOSTICI — vedi nota in testa al file.
+    mock: async page => {
+      await page.route('**/api/v1/wishlist', route =>
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(WISHLIST_FIXTURE),
+        })
+      );
+      await page.route('**/api/v1/wishlist/highlights', route =>
+        route.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+      );
+      // La wishlist page usa useLibrary per la mappa gameId→title; i fixture
+      // portano già gameName inline, quindi la library può essere vuota.
+      await page.route('**/api/v1/library**', route =>
+        route.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+      );
+    },
+  },
+];

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -33,6 +33,8 @@
     "test:e2e:visual:admin:ui": "dotenv -e .env.test -- playwright test e2e/visual/admin-dashboard-visual.spec.ts --project=desktop-chrome --ui",
     "test:storybook:snapshots": "dotenv -e .env.test -- playwright test --config playwright.storybook.config.ts",
     "test:storybook:snapshots:update": "dotenv -e .env.test -- playwright test --config playwright.storybook.config.ts --update-snapshots",
+    "compare:mockups": "dotenv -e .env.test -- playwright test --config playwright.mockup-compare.config.ts && node scripts/mockup-compare/generate.mjs",
+    "compare:mockups:open": "dotenv -e .env.test -- playwright test --config playwright.mockup-compare.config.ts && node scripts/mockup-compare/generate.mjs --open",
     "test:e2e:shard1": "dotenv -e .env.test -- playwright test --shard=1/6",
     "test:e2e:shard2": "dotenv -e .env.test -- playwright test --shard=2/6",
     "test:e2e:shard3": "dotenv -e .env.test -- playwright test --shard=3/6",

--- a/apps/web/playwright.mockup-compare.config.ts
+++ b/apps/web/playwright.mockup-compare.config.ts
@@ -38,7 +38,11 @@ export default defineConfig({
   ],
   webServer: [
     {
-      command: `node --max-old-space-size=8192 ./node_modules/next/dist/bin/next dev -p ${APP_PORT}`,
+      // cross-env garantisce che PLAYWRIGHT_AUTH_BYPASS raggiunga il processo
+      // Next: il webServer.env di Playwright NON propaga in modo affidabile su
+      // Windows → il gate SSR di proxy.ts reindirizzava a /login. Con l'env nel
+      // comando, il bypass ingaggia e le route (authenticated) renderizzano.
+      command: `cross-env PLAYWRIGHT_AUTH_BYPASS=true node --max-old-space-size=8192 ./node_modules/next/dist/bin/next dev -p ${APP_PORT}`,
       url: APP_URL,
       reuseExistingServer: true,
       timeout: 180_000,

--- a/apps/web/playwright.mockup-compare.config.ts
+++ b/apps/web/playwright.mockup-compare.config.ts
@@ -1,0 +1,54 @@
+/**
+ * Config Playwright del tool mockup↔live compare (#2999).
+ * NON è un gate CI — dev-tool locale. Avvia il Next app (auth-bypass) +
+ * http-server per i mockup statici. La capture spec produce screenshot, non
+ * assert.
+ */
+import { defineConfig, devices } from '@playwright/test';
+
+const MOCKUP_PORT = 5175;
+
+// La route live richiede un server con PLAYWRIGHT_AUTH_BYPASS attivo. Se la
+// :3000 è occupata da un server SENZA bypass (es. lo stack Docker `make dev`),
+// il gate SSR di proxy.ts reindirizza a /login e il capture prende la pagina
+// di login. Punta a un dev server con bypass via COMPARE_APP_PORT.
+const APP_PORT = process.env.COMPARE_APP_PORT ?? '3000';
+const APP_URL = `http://localhost:${APP_PORT}`;
+
+export default defineConfig({
+  testDir: './e2e/mockup-compare',
+  testMatch: 'capture.spec.ts',
+  fullyParallel: false,
+  workers: 1,
+  retries: 0,
+  reporter: 'list',
+  timeout: 60_000,
+  use: {
+    baseURL: APP_URL,
+    trace: 'retain-on-failure',
+    locale: 'it-IT',
+    timezoneId: 'UTC',
+    colorScheme: 'light',
+  },
+  projects: [
+    {
+      name: 'compare-desktop',
+      use: { ...devices['Desktop Chrome'], viewport: { width: 1920, height: 1080 } },
+    },
+  ],
+  webServer: [
+    {
+      command: `node --max-old-space-size=8192 ./node_modules/next/dist/bin/next dev -p ${APP_PORT}`,
+      url: APP_URL,
+      reuseExistingServer: true,
+      timeout: 180_000,
+      env: { PLAYWRIGHT_AUTH_BYPASS: 'true' },
+    },
+    {
+      command: `pnpm exec http-server ../../admin-mockups/design_files -p ${MOCKUP_PORT} -s --cors`,
+      url: `http://127.0.0.1:${MOCKUP_PORT}`,
+      reuseExistingServer: true,
+      timeout: 30_000,
+    },
+  ],
+});

--- a/apps/web/scripts/mockup-compare/__tests__/build-report.test.ts
+++ b/apps/web/scripts/mockup-compare/__tests__/build-report.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+
+// @ts-expect-error — .mjs senza tipi, import runtime
+import { buildReportHtml } from '../build-report.mjs';
+
+const baseEntry = {
+  id: 'library-wishlist',
+  label: 'Library · Wishlist',
+  route: '/library/wishlist',
+  viewport: { width: 1920, height: 1080 },
+  mockupDataUri: 'data:image/png;base64,MOCKUP',
+  liveDataUri: 'data:image/png;base64,LIVE',
+  designIntent: 'current',
+};
+
+describe('buildReportHtml', () => {
+  it('produces a full self-contained HTML document', () => {
+    const html = buildReportHtml([baseEntry]);
+    expect(html).toContain('<!doctype html>');
+    expect(html).toContain('Library · Wishlist');
+    expect(html).toContain('/library/wishlist');
+  });
+
+  it('embeds both mockup and live images as data URIs', () => {
+    const html = buildReportHtml([baseEntry]);
+    expect(html).toContain('data:image/png;base64,MOCKUP');
+    expect(html).toContain('data:image/png;base64,LIVE');
+  });
+
+  it('renders a slider control per pair', () => {
+    const html = buildReportHtml([baseEntry]);
+    expect(html).toContain('type="range"');
+    expect(html).toContain('data-pair-id="library-wishlist"');
+  });
+
+  it('shows an error placeholder when live capture failed', () => {
+    const html = buildReportHtml([
+      { ...baseEntry, liveDataUri: null, liveError: 'Timeout 30000ms' },
+    ]);
+    expect(html).toContain('live capture failed');
+    expect(html).toContain('Timeout 30000ms');
+    expect(html).not.toContain('data:image/png;base64,LIVE');
+  });
+
+  it('shows an error placeholder when mockup capture failed', () => {
+    const html = buildReportHtml([
+      { ...baseEntry, mockupDataUri: null, mockupError: 'unpkg unreachable' },
+    ]);
+    expect(html).toContain('mockup capture failed');
+    expect(html).toContain('unpkg unreachable');
+    expect(html).not.toContain('data:image/png;base64,MOCKUP');
+  });
+
+  it('escapes HTML in labels and errors', () => {
+    const html = buildReportHtml([
+      { ...baseEntry, label: '<script>x</script>', liveError: '<b>bad</b>', liveDataUri: null },
+    ]);
+    expect(html).not.toContain('<script>x</script>');
+    expect(html).toContain('&lt;script&gt;');
+  });
+});

--- a/apps/web/scripts/mockup-compare/__tests__/build-report.test.ts
+++ b/apps/web/scripts/mockup-compare/__tests__/build-report.test.ts
@@ -58,4 +58,12 @@ describe('buildReportHtml', () => {
     expect(html).not.toContain('<script>x</script>');
     expect(html).toContain('&lt;script&gt;');
   });
+
+  it('renders a side-by-side (sbs) block so the toggle shows both images', () => {
+    const html = buildReportHtml([baseEntry]);
+    expect(html).toContain('class="sbs"');
+    // Entrambe le immagini compaiono 2 volte: overlay (stage) + side-by-side (sbs).
+    expect((html.match(/data:image\/png;base64,MOCKUP/g) ?? []).length).toBeGreaterThanOrEqual(2);
+    expect((html.match(/data:image\/png;base64,LIVE/g) ?? []).length).toBeGreaterThanOrEqual(2);
+  });
 });

--- a/apps/web/scripts/mockup-compare/build-report.mjs
+++ b/apps/web/scripts/mockup-compare/build-report.mjs
@@ -1,0 +1,91 @@
+/**
+ * Report builder per il tool mockup↔live compare (#2999).
+ * `buildReportHtml` è puro (nessun I/O) → unit-testabile.
+ */
+
+/** Escape minimale per testo iniettato in HTML. */
+export function escapeHtml(s) {
+  return String(s)
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;');
+}
+
+function renderPair(e) {
+  const vp = `${e.viewport.width}×${e.viewport.height}`;
+  const intent = e.designIntent ? `<span class="intent">${escapeHtml(e.designIntent)}</span>` : '';
+  const mockup = e.mockupDataUri
+    ? `<img class="layer mockup" src="${e.mockupDataUri}" alt="mockup ${escapeHtml(e.id)}" />`
+    : `<div class="live-error">⚠ mockup capture failed<br /><code>${escapeHtml(e.mockupError ?? 'unknown')}</code></div>`;
+  const live = e.liveDataUri
+    ? `<img class="layer live" src="${e.liveDataUri}" alt="live ${escapeHtml(e.id)}" />`
+    : `<div class="live-error">⚠ live capture failed<br /><code>${escapeHtml(e.liveError ?? 'unknown')}</code></div>`;
+  // Slider ha senso solo se ENTRAMBE le catture esistono.
+  const slider =
+    e.mockupDataUri && e.liveDataUri
+      ? `<input type="range" min="0" max="100" value="50" class="slider"
+         data-pair-id="${escapeHtml(e.id)}" aria-label="reveal live over mockup" />`
+      : '';
+  return `
+  <section class="pair" data-pair="${escapeHtml(e.id)}">
+    <header>
+      <h2>${escapeHtml(e.label)} ${intent}</h2>
+      <p class="meta"><code>${escapeHtml(e.route)}</code> · ${vp}</p>
+    </header>
+    <div class="compare" data-mode="overlay">
+      <div class="stage">
+        ${mockup}
+        <div class="live-wrap" data-pair-id="${escapeHtml(e.id)}">${live}</div>
+      </div>
+      ${slider}
+      <button class="toggle" data-pair-id="${escapeHtml(e.id)}">side-by-side ⇄ overlay</button>
+    </div>
+  </section>`;
+}
+
+export function buildReportHtml(entries) {
+  const body = entries.map(renderPair).join('\n');
+  const css = `
+    :root { color-scheme: light dark; }
+    body { margin: 0; font: 14px/1.5 system-ui, sans-serif; background: #f7f3ee; color: #1a1a1a; }
+    header.top { padding: 16px 24px; border-bottom: 1px solid #ccc; }
+    .pair { padding: 24px; border-bottom: 1px solid #ddd; }
+    .pair h2 { margin: 0 0 4px; font-size: 16px; }
+    .intent { font-size: 11px; padding: 2px 6px; border-radius: 6px; background: #e5dccb; margin-left: 8px; }
+    .meta { margin: 0 0 12px; color: #666; }
+    .stage { position: relative; max-width: 1200px; border: 1px solid #bbb; overflow: hidden; }
+    .layer { display: block; width: 100%; height: auto; }
+    .live-wrap { position: absolute; inset: 0; overflow: hidden; }
+    .compare[data-mode="overlay"] .live-wrap { width: 50%; }
+    .compare[data-mode="sbs"] .stage { display: none; }
+    .slider { width: 100%; max-width: 1200px; margin: 8px 0; }
+    .toggle { font: inherit; padding: 4px 10px; cursor: pointer; }
+    .live-error { padding: 40px; text-align: center; color: #a00; background: #fdd; }
+    @media (prefers-color-scheme: dark) { body { background: #1a1a1a; color: #eee; } }
+  `;
+  const js = `
+    document.querySelectorAll('.slider').forEach(function (s) {
+      s.addEventListener('input', function () {
+        var wrap = document.querySelector('.live-wrap[data-pair-id="' + s.dataset.pairId + '"]');
+        if (wrap) wrap.style.width = s.value + '%';
+      });
+    });
+    document.querySelectorAll('.toggle').forEach(function (b) {
+      b.addEventListener('click', function () {
+        var c = b.closest('.compare');
+        c.dataset.mode = c.dataset.mode === 'overlay' ? 'sbs' : 'overlay';
+      });
+    });
+  `;
+  return `<!doctype html>
+<html lang="it"><head><meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Mockup↔Live Compare (#2999)</title>
+<style>${css}</style></head>
+<body>
+<header class="top"><strong>Mockup↔Live Compare</strong> — ${entries.length} coppie · confronto manuale (#2999)</header>
+${body}
+<script>${js}</script>
+</body></html>`;
+}

--- a/apps/web/scripts/mockup-compare/build-report.mjs
+++ b/apps/web/scripts/mockup-compare/build-report.mjs
@@ -38,8 +38,12 @@ function renderPair(e) {
         ${mockup}
         <div class="live-wrap" data-pair-id="${escapeHtml(e.id)}">${live}</div>
       </div>
+      <div class="sbs">
+        <figure><figcaption>mockup</figcaption>${mockup}</figure>
+        <figure><figcaption>live</figcaption>${live}</figure>
+      </div>
       ${slider}
-      <button class="toggle" data-pair-id="${escapeHtml(e.id)}">side-by-side ⇄ overlay</button>
+      <button class="toggle">side-by-side ⇄ overlay</button>
     </div>
   </section>`;
 }
@@ -59,6 +63,11 @@ export function buildReportHtml(entries) {
     .live-wrap { position: absolute; inset: 0; overflow: hidden; }
     .compare[data-mode="overlay"] .live-wrap { width: 50%; }
     .compare[data-mode="sbs"] .stage { display: none; }
+    .sbs { display: none; }
+    .compare[data-mode="sbs"] .sbs { display: flex; gap: 12px; max-width: 1200px; }
+    .sbs figure { flex: 1; margin: 0; border: 1px solid #bbb; }
+    .sbs figcaption { font-size: 11px; color: #666; padding: 2px 6px; }
+    .sbs .layer { position: static; }
     .slider { width: 100%; max-width: 1200px; margin: 8px 0; }
     .toggle { font: inherit; padding: 4px 10px; cursor: pointer; }
     .live-error { padding: 40px; text-align: center; color: #a00; background: #fdd; }

--- a/apps/web/scripts/mockup-compare/generate.mjs
+++ b/apps/web/scripts/mockup-compare/generate.mjs
@@ -31,7 +31,13 @@ function main() {
     );
     process.exit(1);
   }
-  const captures = JSON.parse(readFileSync(CAPTURES, 'utf8'));
+  let captures;
+  try {
+    captures = JSON.parse(readFileSync(CAPTURES, 'utf8'));
+  } catch {
+    console.error(`[compare] captures.json corrotto in ${OUTPUT_DIR} — riesegui la capture spec.`);
+    process.exit(1);
+  }
   const entries = captures.map((c) => ({
     id: c.id,
     label: c.label,
@@ -51,9 +57,14 @@ function main() {
   console.log(`[compare] ${entries.length} coppie (${failed} con cattura fallita)`);
 
   if (process.argv.includes('--open')) {
-    const opener =
-      process.platform === 'win32' ? 'start' : process.platform === 'darwin' ? 'open' : 'xdg-open';
-    spawn(opener, [out], { shell: true, stdio: 'ignore', detached: true }).unref();
+    // win32: `start "" "<path>"` — il primo arg quotato di start è il TITOLO
+    // finestra, quindi un path con spazi va passato come 2° arg con titolo vuoto.
+    if (process.platform === 'win32') {
+      spawn('cmd', ['/c', 'start', '', out], { stdio: 'ignore', detached: true }).unref();
+    } else {
+      const opener = process.platform === 'darwin' ? 'open' : 'xdg-open';
+      spawn(opener, [out], { stdio: 'ignore', detached: true }).unref();
+    }
   }
 }
 

--- a/apps/web/scripts/mockup-compare/generate.mjs
+++ b/apps/web/scripts/mockup-compare/generate.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+/**
+ * CLI glue del report builder (#2999): legge captures.json + i PNG,
+ * li converte in data-URI, chiama buildReportHtml, scrive gallery.html.
+ */
+import { spawn } from 'node:child_process';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { buildReportHtml } from './build-report.mjs';
+
+const OUTPUT_DIR = path.resolve(process.cwd(), 'mockup-compare-output');
+const CAPTURES = path.join(OUTPUT_DIR, 'captures.json');
+
+function pngToDataUri(relPath) {
+  if (!relPath) return null;
+  const abs = path.join(OUTPUT_DIR, relPath);
+  if (!existsSync(abs)) return null;
+  return `data:image/png;base64,${readFileSync(abs).toString('base64')}`;
+}
+
+function readDesignIntent(_id) {
+  // fidelity companion opzionale (design_intent) — estensione futura.
+  return undefined;
+}
+
+function main() {
+  if (!existsSync(CAPTURES)) {
+    console.error(
+      `[compare] captures.json non trovato in ${OUTPUT_DIR}. Esegui prima la capture spec.`
+    );
+    process.exit(1);
+  }
+  const captures = JSON.parse(readFileSync(CAPTURES, 'utf8'));
+  const entries = captures.map((c) => ({
+    id: c.id,
+    label: c.label,
+    route: c.route,
+    viewport: c.viewport,
+    mockupDataUri: pngToDataUri(c.mockupPng),
+    mockupError: c.mockupError,
+    liveDataUri: pngToDataUri(c.livePng),
+    liveError: c.liveError,
+    designIntent: readDesignIntent(c.id),
+  }));
+  const html = buildReportHtml(entries);
+  const out = path.join(OUTPUT_DIR, 'gallery.html');
+  writeFileSync(out, html, 'utf8');
+  console.log(`[compare] gallery generata: ${out}`);
+  const failed = entries.filter((e) => e.liveError || e.mockupError).length;
+  console.log(`[compare] ${entries.length} coppie (${failed} con cattura fallita)`);
+
+  if (process.argv.includes('--open')) {
+    const opener =
+      process.platform === 'win32' ? 'start' : process.platform === 'darwin' ? 'open' : 'xdg-open';
+    spawn(opener, [out], { shell: true, stdio: 'ignore', detached: true }).unref();
+  }
+}
+
+main();

--- a/docs/superpowers/plans/2026-07-17-mockup-compare-tool.md
+++ b/docs/superpowers/plans/2026-07-17-mockup-compare-tool.md
@@ -14,7 +14,9 @@
 - Il tool è un **dev-tool locale**, MAI un gate CI (immune al problema baseline win32↔linux di #2063). Nessuna baseline PNG committata.
 - Output dir `apps/web/mockup-compare-output/` è **gitignored** (mai committare screenshot).
 - Confronto **manuale** — il tool mostra, non giudica: niente pixel-diff, niente soglie.
-- Auth E2E via seam esistente: `seedMockRoleCookies(page, 'Admin'|'User')` (da `apps/web/e2e/_helpers/seedAuthSession`) + mock `${apiBase}/api/v1/auth/me`, con `apiBase = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8080'`. Il webServer parte con `PLAYWRIGHT_AUTH_BYPASS=true`.
+- Auth E2E (host-agnostic): `seedMockRoleCookies(page, 'Admin'|'User')` (gate SSR di `proxy.ts`) **+** `mockAuthEndpoints(page, { role: 'admin'|'user' })` (client `/auth/me` + `/auth/session/status`, regex host-agnostica, `onboardingCompleted:true`) — entrambi da `apps/web/e2e/_helpers/seedAuthSession`. Webserver con `PLAYWRIGHT_AUTH_BYPASS=true`.
+- 🔴 **URL host-agnostici**: l'app usa URL RELATIVI nel browser (`getApiBase()`→`''`, `apps/web/src/lib/api/core/httpClient.ts:51-55`) → richieste a `localhost:3000/api/v1/...` via proxy Next. I mock `page.route` DEVONO usare glob `**/api/v1/...`, MAI URL assoluti `localhost:8080` (non intercettano). Verificato dalla review avversariale del piano (2026-07-17).
+- Il **mockup capture NON è offline**: molti page-mock caricano React/ReactDOM/Babel da `unpkg.com` e transpilano JSX in-browser → serve rete a unpkg + attesa del mount reale (`waitForFunction`, non timeout fisso).
 - Nessun cap silenzioso: coppie del manifest non catturabili → `console.log` esplicito + record con `liveError`.
 - Comandi eseguiti da `apps/web/`. `pnpm test` = Vitest; test file glob `**/__tests__/**/*.{test,spec}.{ts,tsx}`.
 - Mockup HTML sorgente: `admin-mockups/design_files/` (repo root, cioè `../../admin-mockups/design_files/` rispetto a `apps/web/`).
@@ -119,8 +121,6 @@ export const DESIGN_FILES_DIR = path.resolve(
 /** apps/web/mockup-compare-output (gitignored). */
 export const OUTPUT_DIR = path.resolve(process.cwd(), 'mockup-compare-output');
 
-const apiBase = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8080';
-
 /** Wishlist fixture — WishlistItemDto[] con gameName inline (no library map). */
 const WISHLIST_FIXTURE = [
   {
@@ -156,20 +156,23 @@ export const PAIRS: readonly MockupComparePair[] = [
     mockupHtml: 'sp4-library-wishlist.html',
     route: '/library/wishlist',
     auth: 'user',
+    // 🔴 Glob HOST-AGNOSTICI: l'app usa URL relativi nel browser
+    // (getApiBase()→'' , httpClient.ts:51-55) → richieste a localhost:3000/api/...
+    // via proxy Next. URL assoluti localhost:8080 NON intercetterebbero.
     mock: async (page) => {
-      await page.route(`${apiBase}/api/v1/wishlist`, (route) =>
+      await page.route('**/api/v1/wishlist', (route) =>
         route.fulfill({
           status: 200,
           contentType: 'application/json',
           body: JSON.stringify(WISHLIST_FIXTURE),
         })
       );
-      await page.route(`${apiBase}/api/v1/wishlist/highlights`, (route) =>
+      await page.route('**/api/v1/wishlist/highlights', (route) =>
         route.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
       );
       // La wishlist page usa useLibrary per la mappa gameId→title; i fixture
       // portano già gameName inline, quindi la library può essere vuota.
-      await page.route(`${apiBase}/api/v1/library**`, (route) =>
+      await page.route('**/api/v1/library**', (route) =>
         route.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
       );
     },
@@ -249,6 +252,15 @@ describe('buildReportHtml', () => {
     expect(html).not.toContain('data:image/png;base64,LIVE');
   });
 
+  it('shows an error placeholder when mockup capture failed', () => {
+    const html = buildReportHtml([
+      { ...baseEntry, mockupDataUri: null, mockupError: 'unpkg unreachable' },
+    ]);
+    expect(html).toContain('mockup capture failed');
+    expect(html).toContain('unpkg unreachable');
+    expect(html).not.toContain('data:image/png;base64,MOCKUP');
+  });
+
   it('escapes HTML in labels and errors', () => {
     const html = buildReportHtml([
       { ...baseEntry, label: '<script>x</script>', liveError: '<b>bad</b>', liveDataUri: null },
@@ -285,10 +297,14 @@ export function escapeHtml(s) {
 function renderPair(e) {
   const vp = `${e.viewport.width}×${e.viewport.height}`;
   const intent = e.designIntent ? `<span class="intent">${escapeHtml(e.designIntent)}</span>` : '';
+  const mockup = e.mockupDataUri
+    ? `<img class="layer mockup" src="${e.mockupDataUri}" alt="mockup ${escapeHtml(e.id)}" />`
+    : `<div class="live-error">⚠ mockup capture failed<br /><code>${escapeHtml(e.mockupError ?? 'unknown')}</code></div>`;
   const live = e.liveDataUri
     ? `<img class="layer live" src="${e.liveDataUri}" alt="live ${escapeHtml(e.id)}" />`
     : `<div class="live-error">⚠ live capture failed<br /><code>${escapeHtml(e.liveError ?? 'unknown')}</code></div>`;
-  const slider = e.liveDataUri
+  // Slider ha senso solo se ENTRAMBE le catture esistono.
+  const slider = e.mockupDataUri && e.liveDataUri
     ? `<input type="range" min="0" max="100" value="50" class="slider"
          data-pair-id="${escapeHtml(e.id)}" aria-label="reveal live over mockup" />`
     : '';
@@ -300,7 +316,7 @@ function renderPair(e) {
     </header>
     <div class="compare" data-mode="overlay">
       <div class="stage">
-        <img class="layer mockup" src="${e.mockupDataUri ?? ''}" alt="mockup ${escapeHtml(e.id)}" />
+        ${mockup}
         <div class="live-wrap" data-pair-id="${escapeHtml(e.id)}">${live}</div>
       </div>
       ${slider}
@@ -365,7 +381,7 @@ ${body}
 - [ ] **Step 4: Esegui il test — deve passare**
 
 Run: `pnpm vitest run scripts/mockup-compare/__tests__/build-report.test.ts`
-Expected: PASS (5 test).
+Expected: PASS (6 test).
 
 - [ ] **Step 5: Commit**
 
@@ -428,6 +444,7 @@ function main() {
     route: c.route,
     viewport: c.viewport,
     mockupDataUri: pngToDataUri(c.mockupPng),
+    mockupError: c.mockupError,
     liveDataUri: pngToDataUri(c.livePng),
     liveError: c.liveError,
     designIntent: readDesignIntent(c.id),
@@ -566,12 +583,11 @@ import path from 'node:path';
 
 import { test } from '@playwright/test';
 
-import { seedMockRoleCookies } from '../_helpers/seedAuthSession';
+import { mockAuthEndpoints, seedMockRoleCookies } from '../_helpers/seedAuthSession';
 
 import { PAIRS, OUTPUT_DIR } from './manifest';
 
 const MOCKUP_PORT = 5175;
-const apiBase = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8080';
 
 interface CaptureRecord {
   id: string;
@@ -579,6 +595,7 @@ interface CaptureRecord {
   route: string;
   viewport: { width: number; height: number };
   mockupPng: string | null;
+  mockupError?: string;
   livePng: string | null;
   liveError?: string;
 }
@@ -607,38 +624,35 @@ for (const pair of PAIRS) {
       livePng: null,
     };
 
-    // 1) MOCKUP statico via http-server
+    // 1) MOCKUP statico via http-server. NB: molti page-mock caricano
+    // React/ReactDOM/Babel da unpkg.com e transpilano JSX in-browser → serve
+    // RETE (unpkg) + attesa del MOUNT reale, non un timeout fisso.
     try {
       await page.goto(`http://127.0.0.1:${MOCKUP_PORT}/${pair.mockupHtml}`, {
         waitUntil: 'networkidle',
       });
-      await page.waitForTimeout(800);
+      await page.waitForFunction(
+        () => {
+          const root = document.querySelector('#root');
+          if (root) return root.childElementCount > 0;
+          return document.body.childElementCount > 0;
+        },
+        { timeout: 15_000 }
+      );
       const mockupFile = `${pair.id}__mockup.png`;
       await page.screenshot({ path: path.join(OUTPUT_DIR, mockupFile), fullPage: true });
       rec.mockupPng = mockupFile;
     } catch (err) {
-      console.log(`[compare] ${pair.id}: mockup capture failed — ${(err as Error).message}`);
+      rec.mockupError = (err as Error).message;
+      console.log(`[compare] ${pair.id}: mockup capture failed — ${rec.mockupError}`);
     }
 
-    // 2) LIVE route reale (auth-bypass + mock)
+    // 2) LIVE route reale. Auth = seed cookie (proxy SSR gate) + mockAuthEndpoints
+    // (client /auth/me + /auth/session/status, regex host-agnostico). Dati via
+    // pair.mock (glob host-agnostici). NESSUN mock auth hand-rolled.
     try {
       await seedMockRoleCookies(page, pair.auth === 'admin' ? 'Admin' : 'User');
-      const role = pair.auth === 'admin' ? 'Admin' : 'User';
-      await page.route(`${apiBase}/api/v1/auth/me`, (route) =>
-        route.fulfill({
-          status: 200,
-          contentType: 'application/json',
-          body: JSON.stringify({
-            user: {
-              id: 'compare-user-id',
-              email: 'compare@meepleai.dev',
-              displayName: 'Compare User',
-              role,
-            },
-            expiresAt: new Date(Date.now() + 3_600_000).toISOString(),
-          }),
-        })
-      );
+      await mockAuthEndpoints(page, { role: pair.auth === 'admin' ? 'admin' : 'user' });
       if (pair.mock) await pair.mock(page);
       await page.goto(pair.route, { waitUntil: 'networkidle' });
       await page.waitForTimeout(1000);
@@ -654,8 +668,6 @@ for (const pair of PAIRS) {
   });
 }
 ```
-
-> `new Date(Date.now() + …)` è ammesso qui: è codice di test Playwright, non uno script workflow.
 
 - [ ] **Step 2: Esegui la capture spec sullo slice MVP**
 
@@ -732,6 +744,16 @@ Aggiungi una riga a `e2e/mockup-compare/manifest.ts`:
 `manifest.ts` → `capture.spec.ts` (screenshot mockup via http-server :5175 +
 route live via app :3000 auth-bypass + mock) → `captures.json` →
 `scripts/mockup-compare/generate.mjs` → `gallery.html`.
+
+## Note / limiti
+
+- **Il mockup capture richiede rete** a `unpkg.com`: molti page-mock caricano
+  React/ReactDOM/Babel da CDN e transpilano JSX in-browser. La capture attende
+  il mount reale (`waitForFunction`); se unpkg è irraggiungibile la gallery
+  mostra un placeholder "mockup capture failed" invece di uno screenshot vuoto.
+- Alcuni page-mock `.html` sono standalone e possono divergere dalla sorgente
+  che l'implementazione ha effettivamente tracciato (es. `sp4-library-wishlist`
+  cita un `-ui.jsx`); un po' di drift è atteso e va giudicato manualmente.
 ```
 
 - [ ] **Step 4: Verifica finale (typecheck + lint + report builder test)**

--- a/docs/superpowers/plans/2026-07-17-mockup-compare-tool.md
+++ b/docs/superpowers/plans/2026-07-17-mockup-compare-tool.md
@@ -1,0 +1,759 @@
+# Mockup↔Live Compare Tool Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Un dev-tool locale (`pnpm compare:mockups`) che genera una gallery HTML statica affiancando, per ogni coppia mockup↔route, lo screenshot del mockup e quello della route live reale, con slider drag-to-reveal — per una review di fedeltà **manuale** (nessuna baseline, nessun pixel-diff).
+
+**Architecture:** 4 unità isolate. Un **manifest** dichiara le coppie `{mockupHtml, route, auth, mock}`. Una **capture spec** Playwright (riusa `playwright.config.ts` con `PLAYWRIGHT_AUTH_BYPASS`) screenshotta il mockup (servito da `http-server`) e la route live (auth-bypass + `page.route` mock), emettendo `captures.json` + PNG in una dir gitignored. Un **report builder** (funzione pura Node) trasforma i capture in `gallery.html` self-contained (PNG come data-URI, slider inline). Output NON è un gate CI.
+
+**Tech Stack:** Playwright (`@playwright/test`), `http-server` (già dep `^14.1.1`), Node ESM (`.mjs`), Vitest (unit test del report builder), TypeScript.
+
+## Global Constraints
+
+- Runtime: Node ESM per lo script builder (`.mjs`, `import`/`export`).
+- Il tool è un **dev-tool locale**, MAI un gate CI (immune al problema baseline win32↔linux di #2063). Nessuna baseline PNG committata.
+- Output dir `apps/web/mockup-compare-output/` è **gitignored** (mai committare screenshot).
+- Confronto **manuale** — il tool mostra, non giudica: niente pixel-diff, niente soglie.
+- Auth E2E via seam esistente: `seedMockRoleCookies(page, 'Admin'|'User')` (da `apps/web/e2e/_helpers/seedAuthSession`) + mock `${apiBase}/api/v1/auth/me`, con `apiBase = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8080'`. Il webServer parte con `PLAYWRIGHT_AUTH_BYPASS=true`.
+- Nessun cap silenzioso: coppie del manifest non catturabili → `console.log` esplicito + record con `liveError`.
+- Comandi eseguiti da `apps/web/`. `pnpm test` = Vitest; test file glob `**/__tests__/**/*.{test,spec}.{ts,tsx}`.
+- Mockup HTML sorgente: `admin-mockups/design_files/` (repo root, cioè `../../admin-mockups/design_files/` rispetto a `apps/web/`).
+
+---
+
+### Task 1: Manifest + gitignore
+
+**Files:**
+- Modify: `.gitignore` (repo root) — aggiungi la output dir
+- Create: `apps/web/e2e/mockup-compare/manifest.ts`
+- Test: `apps/web/e2e/mockup-compare/__tests__/manifest.test.ts`
+
+**Interfaces:**
+- Produces: `MockupComparePair` interface + `PAIRS: readonly MockupComparePair[]` + `DESIGN_FILES_DIR` (path assoluto della dir mockup) + `OUTPUT_DIR` (path assoluto output).
+
+- [ ] **Step 1: Aggiungi la output dir a `.gitignore`**
+
+Aggiungi in fondo a `.gitignore` (repo root):
+```
+# Mockup↔live compare tool output (#2999) — screenshots, mai committare
+apps/web/mockup-compare-output/
+```
+
+- [ ] **Step 2: Scrivi il test del manifest (RED)**
+
+Create `apps/web/e2e/mockup-compare/__tests__/manifest.test.ts`:
+```ts
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { PAIRS, DESIGN_FILES_DIR } from '../manifest';
+
+describe('mockup-compare manifest', () => {
+  it('has at least one pair', () => {
+    expect(PAIRS.length).toBeGreaterThan(0);
+  });
+
+  it('has unique ids', () => {
+    const ids = PAIRS.map(p => p.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it('references mockup HTML files that exist on disk', () => {
+    for (const pair of PAIRS) {
+      const abs = path.join(DESIGN_FILES_DIR, pair.mockupHtml);
+      expect(existsSync(abs), `${pair.id}: missing ${abs}`).toBe(true);
+    }
+  });
+});
+```
+
+- [ ] **Step 3: Esegui il test — deve fallire (modulo mancante)**
+
+Run: `pnpm vitest run e2e/mockup-compare/__tests__/manifest.test.ts`
+Expected: FAIL con `Failed to resolve import "../manifest"`.
+
+- [ ] **Step 4: Crea il manifest**
+
+Create `apps/web/e2e/mockup-compare/manifest.ts`:
+```ts
+/**
+ * Mockup↔live compare — pairing manifest (#2999).
+ *
+ * Ogni entry accoppia un page-mock HTML statico (admin-mockups/design_files)
+ * con la route live reale. La capture spec screenshotta entrambi.
+ * Estensione: aggiungi righe qui (+ un `mock` page.route se la route non
+ * supporta il seam `?fixture=`).
+ */
+import path from 'node:path';
+
+import type { Page } from '@playwright/test';
+
+export interface MockupComparePair {
+  /** Slug stabile (kebab-case) — usato nei nomi file e nella gallery. */
+  readonly id: string;
+  /** Titolo umano mostrato nella gallery. */
+  readonly label: string;
+  /** Nome file HTML dentro admin-mockups/design_files/. */
+  readonly mockupHtml: string;
+  /** Route live (path relativo, es. "/library/wishlist"). */
+  readonly route: string;
+  /** Ruolo auth per il bypass E2E. Default 'user'. */
+  readonly auth?: 'user' | 'admin';
+  /** Setup page.route opzionale per mockare le API della route. */
+  readonly mock?: (page: Page) => Promise<void>;
+  /** Viewport override. Default 1920x1080. */
+  readonly viewport?: { readonly width: number; readonly height: number };
+}
+
+/** apps/web/e2e/mockup-compare → repo root → admin-mockups/design_files. */
+export const DESIGN_FILES_DIR = path.resolve(
+  process.cwd(),
+  '..',
+  '..',
+  'admin-mockups',
+  'design_files'
+);
+
+/** apps/web/mockup-compare-output (gitignored). */
+export const OUTPUT_DIR = path.resolve(process.cwd(), 'mockup-compare-output');
+
+const apiBase = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8080';
+
+/** Wishlist fixture — WishlistItemDto[] con gameName inline (no library map). */
+const WISHLIST_FIXTURE = [
+  {
+    id: '11111111-1111-4111-8111-111111111111',
+    userId: '99999999-9999-4999-8999-999999999999',
+    gameId: '22222222-2222-4222-8222-222222222222',
+    gameName: 'Terraforming Mars',
+    priority: 'high',
+    targetPrice: 45.0,
+    notes: 'Aspetto un saldo sotto i 50€',
+    addedAt: '2026-07-01T10:00:00.000Z',
+    updatedAt: null,
+    visibility: 'private',
+  },
+  {
+    id: '33333333-3333-4333-8333-333333333333',
+    userId: '99999999-9999-4999-8999-999999999999',
+    gameId: '44444444-4444-4444-8444-444444444444',
+    gameName: 'Wingspan',
+    priority: 'medium',
+    targetPrice: null,
+    notes: null,
+    addedAt: '2026-06-15T09:30:00.000Z',
+    updatedAt: '2026-06-20T12:00:00.000Z',
+    visibility: 'private',
+  },
+];
+
+export const PAIRS: readonly MockupComparePair[] = [
+  {
+    id: 'library-wishlist',
+    label: 'Library · Wishlist',
+    mockupHtml: 'sp4-library-wishlist.html',
+    route: '/library/wishlist',
+    auth: 'user',
+    mock: async (page) => {
+      await page.route(`${apiBase}/api/v1/wishlist`, (route) =>
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(WISHLIST_FIXTURE),
+        })
+      );
+      await page.route(`${apiBase}/api/v1/wishlist/highlights`, (route) =>
+        route.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+      );
+      // La wishlist page usa useLibrary per la mappa gameId→title; i fixture
+      // portano già gameName inline, quindi la library può essere vuota.
+      await page.route(`${apiBase}/api/v1/library**`, (route) =>
+        route.fulfill({ status: 200, contentType: 'application/json', body: '[]' })
+      );
+    },
+  },
+];
+```
+
+- [ ] **Step 5: Esegui il test — deve passare**
+
+Run: `pnpm vitest run e2e/mockup-compare/__tests__/manifest.test.ts`
+Expected: PASS (3 test). Se "missing …sp4-library-wishlist.html", verifica `ls ../../admin-mockups/design_files/sp4-library-wishlist.html`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .gitignore apps/web/e2e/mockup-compare/manifest.ts apps/web/e2e/mockup-compare/__tests__/manifest.test.ts
+git commit -m "feat(compare): #2999 mockup↔live pairing manifest + wishlist pair"
+```
+
+---
+
+### Task 2: Report builder — funzione pura `buildReportHtml`
+
+**Files:**
+- Create: `apps/web/scripts/mockup-compare/build-report.mjs`
+- Test: `apps/web/scripts/mockup-compare/__tests__/build-report.test.ts`
+
+**Interfaces:**
+- Produces: `buildReportHtml(entries)` → `string` (HTML completo self-contained).
+  - `entries`: `Array<{ id, label, route, viewport: {width,height}, mockupDataUri: string|null, liveDataUri: string|null, liveError?: string, designIntent?: string }>`.
+
+- [ ] **Step 1: Scrivi il test (RED)**
+
+Create `apps/web/scripts/mockup-compare/__tests__/build-report.test.ts`:
+```ts
+import { describe, expect, it } from 'vitest';
+
+// @ts-expect-error — .mjs senza tipi, import runtime
+import { buildReportHtml } from '../build-report.mjs';
+
+const baseEntry = {
+  id: 'library-wishlist',
+  label: 'Library · Wishlist',
+  route: '/library/wishlist',
+  viewport: { width: 1920, height: 1080 },
+  mockupDataUri: 'data:image/png;base64,MOCKUP',
+  liveDataUri: 'data:image/png;base64,LIVE',
+  designIntent: 'current',
+};
+
+describe('buildReportHtml', () => {
+  it('produces a full self-contained HTML document', () => {
+    const html = buildReportHtml([baseEntry]);
+    expect(html).toContain('<!doctype html>');
+    expect(html).toContain('Library · Wishlist');
+    expect(html).toContain('/library/wishlist');
+  });
+
+  it('embeds both mockup and live images as data URIs', () => {
+    const html = buildReportHtml([baseEntry]);
+    expect(html).toContain('data:image/png;base64,MOCKUP');
+    expect(html).toContain('data:image/png;base64,LIVE');
+  });
+
+  it('renders a slider control per pair', () => {
+    const html = buildReportHtml([baseEntry]);
+    expect(html).toContain('type="range"');
+    expect(html).toContain('data-pair-id="library-wishlist"');
+  });
+
+  it('shows an error placeholder when live capture failed', () => {
+    const html = buildReportHtml([
+      { ...baseEntry, liveDataUri: null, liveError: 'Timeout 30000ms' },
+    ]);
+    expect(html).toContain('live capture failed');
+    expect(html).toContain('Timeout 30000ms');
+    expect(html).not.toContain('data:image/png;base64,LIVE');
+  });
+
+  it('escapes HTML in labels and errors', () => {
+    const html = buildReportHtml([
+      { ...baseEntry, label: '<script>x</script>', liveError: '<b>bad</b>', liveDataUri: null },
+    ]);
+    expect(html).not.toContain('<script>x</script>');
+    expect(html).toContain('&lt;script&gt;');
+  });
+});
+```
+
+- [ ] **Step 2: Esegui il test — deve fallire**
+
+Run: `pnpm vitest run scripts/mockup-compare/__tests__/build-report.test.ts`
+Expected: FAIL con `Failed to resolve import "../build-report.mjs"`.
+
+- [ ] **Step 3: Implementa `build-report.mjs` (solo la funzione pura, per ora)**
+
+Create `apps/web/scripts/mockup-compare/build-report.mjs`:
+```js
+/**
+ * Report builder per il tool mockup↔live compare (#2999).
+ * `buildReportHtml` è puro (nessun I/O) → unit-testabile.
+ */
+
+/** Escape minimale per testo iniettato in HTML. */
+export function escapeHtml(s) {
+  return String(s)
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;');
+}
+
+function renderPair(e) {
+  const vp = `${e.viewport.width}×${e.viewport.height}`;
+  const intent = e.designIntent ? `<span class="intent">${escapeHtml(e.designIntent)}</span>` : '';
+  const live = e.liveDataUri
+    ? `<img class="layer live" src="${e.liveDataUri}" alt="live ${escapeHtml(e.id)}" />`
+    : `<div class="live-error">⚠ live capture failed<br /><code>${escapeHtml(e.liveError ?? 'unknown')}</code></div>`;
+  const slider = e.liveDataUri
+    ? `<input type="range" min="0" max="100" value="50" class="slider"
+         data-pair-id="${escapeHtml(e.id)}" aria-label="reveal live over mockup" />`
+    : '';
+  return `
+  <section class="pair" data-pair="${escapeHtml(e.id)}">
+    <header>
+      <h2>${escapeHtml(e.label)} ${intent}</h2>
+      <p class="meta"><code>${escapeHtml(e.route)}</code> · ${vp}</p>
+    </header>
+    <div class="compare" data-mode="overlay">
+      <div class="stage">
+        <img class="layer mockup" src="${e.mockupDataUri ?? ''}" alt="mockup ${escapeHtml(e.id)}" />
+        <div class="live-wrap" data-pair-id="${escapeHtml(e.id)}">${live}</div>
+      </div>
+      ${slider}
+      <button class="toggle" data-pair-id="${escapeHtml(e.id)}">side-by-side ⇄ overlay</button>
+    </div>
+  </section>`;
+}
+
+export function buildReportHtml(entries) {
+  const body = entries.map(renderPair).join('\n');
+  const css = `
+    :root { color-scheme: light dark; }
+    body { margin: 0; font: 14px/1.5 system-ui, sans-serif; background: #f7f3ee; color: #1a1a1a; }
+    header.top { padding: 16px 24px; border-bottom: 1px solid #ccc; }
+    .pair { padding: 24px; border-bottom: 1px solid #ddd; }
+    .pair h2 { margin: 0 0 4px; font-size: 16px; }
+    .intent { font-size: 11px; padding: 2px 6px; border-radius: 6px; background: #e5dccb; margin-left: 8px; }
+    .meta { margin: 0 0 12px; color: #666; }
+    .stage { position: relative; max-width: 1200px; border: 1px solid #bbb; overflow: hidden; }
+    .layer { display: block; width: 100%; height: auto; }
+    .live-wrap { position: absolute; inset: 0; overflow: hidden; }
+    .compare[data-mode="overlay"] .live-wrap { width: 50%; }
+    .compare[data-mode="sbs"] .stage { display: none; }
+    .compare[data-mode="sbs"] .sbs { display: flex; gap: 12px; }
+    .sbs { display: none; }
+    .sbs figure { flex: 1; margin: 0; }
+    .sbs img { width: 100%; height: auto; border: 1px solid #bbb; }
+    .slider { width: 100%; max-width: 1200px; margin: 8px 0; }
+    .toggle { font: inherit; padding: 4px 10px; cursor: pointer; }
+    .live-error { padding: 40px; text-align: center; color: #a00; background: #fdd; }
+    @media (prefers-color-scheme: dark) { body { background: #1a1a1a; color: #eee; } }
+  `;
+  const js = `
+    document.querySelectorAll('.slider').forEach(function (s) {
+      s.addEventListener('input', function () {
+        var wrap = document.querySelector('.live-wrap[data-pair-id="' + s.dataset.pairId + '"]');
+        if (wrap) wrap.style.width = s.value + '%';
+      });
+    });
+    document.querySelectorAll('.toggle').forEach(function (b) {
+      b.addEventListener('click', function () {
+        var c = b.closest('.compare');
+        c.dataset.mode = c.dataset.mode === 'overlay' ? 'sbs' : 'overlay';
+      });
+    });
+  `;
+  return `<!doctype html>
+<html lang="it"><head><meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Mockup↔Live Compare (#2999)</title>
+<style>${css}</style></head>
+<body>
+<header class="top"><strong>Mockup↔Live Compare</strong> — ${entries.length} coppie · confronto manuale (#2999)</header>
+${body}
+<script>${js}</script>
+</body></html>`;
+}
+```
+
+> Nota: il template include l'hook `.sbs` per la vista side-by-side; la generazione del blocco `.sbs` è omessa qui per minimalità (overlay+slider è il default). Se vuoi anche il side-by-side reale, aggiungi in `renderPair` un `<div class="sbs">` con due `<figure>` (mockup/live) — coperto da un test aggiuntivo. YAGNI: non richiesto dal MVP.
+
+- [ ] **Step 4: Esegui il test — deve passare**
+
+Run: `pnpm vitest run scripts/mockup-compare/__tests__/build-report.test.ts`
+Expected: PASS (5 test).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/scripts/mockup-compare/build-report.mjs apps/web/scripts/mockup-compare/__tests__/build-report.test.ts
+git commit -m "feat(compare): #2999 pure report builder (buildReportHtml) + tests"
+```
+
+---
+
+### Task 3: Report builder CLI (fs glue)
+
+**Files:**
+- Create: `apps/web/scripts/mockup-compare/generate.mjs`
+
+**Interfaces:**
+- Consumes: `buildReportHtml`, `escapeHtml` da `./build-report.mjs`; `OUTPUT_DIR` da `../../e2e/mockup-compare/manifest.ts` — **NO**: il manifest è TS; lo script `.mjs` non lo importa. Ridefinisci `OUTPUT_DIR` localmente (stesso valore: `apps/web/mockup-compare-output`).
+- Legge `captures.json` scritto dalla capture spec (Task 5): `Array<{ id, label, route, viewport, mockupPng, livePng, liveError? }>` (path relativi a OUTPUT_DIR).
+- Produces: `mockup-compare-output/gallery.html`; stampa il path assoluto; con `--open` tenta l'apertura best-effort.
+
+- [ ] **Step 1: Implementa la CLI**
+
+Create `apps/web/scripts/mockup-compare/generate.mjs`:
+```js
+#!/usr/bin/env node
+/**
+ * CLI glue del report builder (#2999): legge captures.json + i PNG,
+ * li converte in data-URI, chiama buildReportHtml, scrive gallery.html.
+ */
+import { spawn } from 'node:child_process';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { buildReportHtml } from './build-report.mjs';
+
+const OUTPUT_DIR = path.resolve(process.cwd(), 'mockup-compare-output');
+const CAPTURES = path.join(OUTPUT_DIR, 'captures.json');
+
+function pngToDataUri(relPath) {
+  if (!relPath) return null;
+  const abs = path.join(OUTPUT_DIR, relPath);
+  if (!existsSync(abs)) return null;
+  return `data:image/png;base64,${readFileSync(abs).toString('base64')}`;
+}
+
+function readDesignIntent(id) {
+  // fidelity companion opzionale: admin-mockups/design_files/<mockupBase>.fidelity.json
+  return undefined; // MVP: intent non risolto; estensione futura.
+}
+
+function main() {
+  if (!existsSync(CAPTURES)) {
+    console.error(`[compare] captures.json non trovato in ${OUTPUT_DIR}. Esegui prima la capture spec.`);
+    process.exit(1);
+  }
+  const captures = JSON.parse(readFileSync(CAPTURES, 'utf8'));
+  const entries = captures.map((c) => ({
+    id: c.id,
+    label: c.label,
+    route: c.route,
+    viewport: c.viewport,
+    mockupDataUri: pngToDataUri(c.mockupPng),
+    liveDataUri: pngToDataUri(c.livePng),
+    liveError: c.liveError,
+    designIntent: readDesignIntent(c.id),
+  }));
+  const html = buildReportHtml(entries);
+  const out = path.join(OUTPUT_DIR, 'gallery.html');
+  writeFileSync(out, html, 'utf8');
+  console.log(`[compare] gallery generata: ${out}`);
+  console.log(`[compare] ${entries.length} coppie (${entries.filter((e) => e.liveError).length} live falliti)`);
+
+  if (process.argv.includes('--open')) {
+    const opener = process.platform === 'win32' ? 'start' : process.platform === 'darwin' ? 'open' : 'xdg-open';
+    spawn(opener, [out], { shell: true, stdio: 'ignore', detached: true }).unref();
+  }
+}
+
+main();
+```
+
+- [ ] **Step 2: Smoke test manuale della CLI su un captures fittizio**
+
+```bash
+cd apps/web
+mkdir -p mockup-compare-output
+printf '[{"id":"x","label":"X","route":"/x","viewport":{"width":100,"height":100},"mockupPng":null,"livePng":null,"liveError":"smoke"}]' > mockup-compare-output/captures.json
+node scripts/mockup-compare/generate.mjs
+```
+Expected: stampa `gallery generata: …/gallery.html` e `1 coppie (1 live falliti)`; `mockup-compare-output/gallery.html` esiste e contiene `live capture failed`.
+
+- [ ] **Step 3: Pulisci l'artefatto di smoke**
+
+```bash
+rm -rf apps/web/mockup-compare-output
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/scripts/mockup-compare/generate.mjs
+git commit -m "feat(compare): #2999 report CLI (captures.json → gallery.html)"
+```
+
+---
+
+### Task 4: Config Playwright dedicata
+
+**Files:**
+- Create: `apps/web/playwright.mockup-compare.config.ts`
+
+**Interfaces:**
+- Produces: config Playwright che avvia (a) il Next webServer con `PLAYWRIGHT_AUTH_BYPASS=true`, (b) `http-server` su `admin-mockups/design_files` porta 5175; `testDir` = `e2e/mockup-compare`, `testMatch` = `capture.spec.ts`. Espone la porta mockup via `process.env.MOCKUP_HTTP_PORT`.
+
+- [ ] **Step 1: Crea la config**
+
+Create `apps/web/playwright.mockup-compare.config.ts`:
+```ts
+/**
+ * Config Playwright del tool mockup↔live compare (#2999).
+ * NON è un gate CI — dev-tool locale. Avvia il Next app (auth-bypass) +
+ * http-server per i mockup statici. La capture spec produce screenshot, non
+ * assert.
+ */
+import { defineConfig, devices } from '@playwright/test';
+
+const MOCKUP_PORT = 5175;
+
+export default defineConfig({
+  testDir: './e2e/mockup-compare',
+  testMatch: 'capture.spec.ts',
+  fullyParallel: false,
+  workers: 1,
+  retries: 0,
+  reporter: 'list',
+  timeout: 60_000,
+  use: {
+    baseURL: 'http://localhost:3000',
+    trace: 'retain-on-failure',
+    locale: 'it-IT',
+    timezoneId: 'UTC',
+    colorScheme: 'light',
+  },
+  projects: [
+    {
+      name: 'compare-desktop',
+      use: { ...devices['Desktop Chrome'], viewport: { width: 1920, height: 1080 } },
+    },
+  ],
+  webServer: [
+    {
+      command:
+        'node --max-old-space-size=8192 ./node_modules/next/dist/bin/next dev -p 3000',
+      url: 'http://localhost:3000',
+      reuseExistingServer: true,
+      timeout: 180_000,
+      env: { PLAYWRIGHT_AUTH_BYPASS: 'true' },
+    },
+    {
+      command: `pnpm exec http-server ../../admin-mockups/design_files -p ${MOCKUP_PORT} -s --cors`,
+      url: `http://127.0.0.1:${MOCKUP_PORT}`,
+      reuseExistingServer: true,
+      timeout: 30_000,
+    },
+  ],
+});
+```
+
+- [ ] **Step 2: Verifica che la config parsi (typecheck)**
+
+Run: `pnpm typecheck`
+Expected: nessun errore TS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/playwright.mockup-compare.config.ts
+git commit -m "chore(compare): #2999 dedicated Playwright config (next auth-bypass + mockup http-server)"
+```
+
+---
+
+### Task 5: Capture spec
+
+**Files:**
+- Create: `apps/web/e2e/mockup-compare/capture.spec.ts`
+
+**Interfaces:**
+- Consumes: `PAIRS`, `OUTPUT_DIR` da `./manifest`; `seedMockRoleCookies` da `../_helpers/seedAuthSession`.
+- Produces: per ogni pair, `mockup-compare-output/<id>__mockup.png` + `<id>__live.png` (o `liveError`); e `mockup-compare-output/captures.json`.
+
+- [ ] **Step 1: Implementa la capture spec**
+
+Create `apps/web/e2e/mockup-compare/capture.spec.ts`:
+```ts
+import { mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { test } from '@playwright/test';
+
+import { seedMockRoleCookies } from '../_helpers/seedAuthSession';
+
+import { PAIRS, OUTPUT_DIR } from './manifest';
+
+const MOCKUP_PORT = 5175;
+const apiBase = process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8080';
+
+interface CaptureRecord {
+  id: string;
+  label: string;
+  route: string;
+  viewport: { width: number; height: number };
+  mockupPng: string | null;
+  livePng: string | null;
+  liveError?: string;
+}
+
+const records: CaptureRecord[] = [];
+
+test.beforeAll(() => {
+  mkdirSync(OUTPUT_DIR, { recursive: true });
+});
+
+test.afterAll(() => {
+  writeFileSync(path.join(OUTPUT_DIR, 'captures.json'), JSON.stringify(records, null, 2), 'utf8');
+  console.log(`[compare] captures.json scritto (${records.length} coppie)`);
+});
+
+for (const pair of PAIRS) {
+  test(`capture ${pair.id}`, async ({ page }) => {
+    const viewport = pair.viewport ?? { width: 1920, height: 1080 };
+    await page.setViewportSize(viewport);
+    const rec: CaptureRecord = {
+      id: pair.id,
+      label: pair.label,
+      route: pair.route,
+      viewport,
+      mockupPng: null,
+      livePng: null,
+    };
+
+    // 1) MOCKUP statico via http-server
+    try {
+      await page.goto(`http://127.0.0.1:${MOCKUP_PORT}/${pair.mockupHtml}`, {
+        waitUntil: 'networkidle',
+      });
+      await page.waitForTimeout(800);
+      const mockupFile = `${pair.id}__mockup.png`;
+      await page.screenshot({ path: path.join(OUTPUT_DIR, mockupFile), fullPage: true });
+      rec.mockupPng = mockupFile;
+    } catch (err) {
+      console.log(`[compare] ${pair.id}: mockup capture failed — ${(err as Error).message}`);
+    }
+
+    // 2) LIVE route reale (auth-bypass + mock)
+    try {
+      await seedMockRoleCookies(page, pair.auth === 'admin' ? 'Admin' : 'User');
+      const role = pair.auth === 'admin' ? 'Admin' : 'User';
+      await page.route(`${apiBase}/api/v1/auth/me`, (route) =>
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            user: {
+              id: 'compare-user-id',
+              email: 'compare@meepleai.dev',
+              displayName: 'Compare User',
+              role,
+            },
+            expiresAt: new Date(Date.now() + 3_600_000).toISOString(),
+          }),
+        })
+      );
+      if (pair.mock) await pair.mock(page);
+      await page.goto(pair.route, { waitUntil: 'networkidle' });
+      await page.waitForTimeout(1000);
+      const liveFile = `${pair.id}__live.png`;
+      await page.screenshot({ path: path.join(OUTPUT_DIR, liveFile), fullPage: true });
+      rec.livePng = liveFile;
+    } catch (err) {
+      rec.liveError = (err as Error).message;
+      console.log(`[compare] ${pair.id}: live capture failed — ${rec.liveError}`);
+    }
+
+    records.push(rec);
+  });
+}
+```
+
+> `new Date(Date.now() + …)` è ammesso qui: è codice di test Playwright, non uno script workflow.
+
+- [ ] **Step 2: Esegui la capture spec sullo slice MVP**
+
+Run: `cd apps/web && dotenv -e .env.test -- playwright test --config playwright.mockup-compare.config.ts`
+Expected: 1 test `capture library-wishlist` PASS; log `captures.json scritto (1 coppie)`; esistono `mockup-compare-output/library-wishlist__mockup.png` e `library-wishlist__live.png`.
+
+> Se il live fallisce (auth/route), il test resta verde (screenshot mockup ok, `liveError` valorizzato). Investiga il log: la route `/library/wishlist` richiede il seed cookie User + `/auth/me` mock; se mostra empty-state, verifica che il mock `**/api/v1/wishlist` intercetti (l'`apiBase` deve combaciare con quello che l'app chiama).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/e2e/mockup-compare/capture.spec.ts
+git commit -m "feat(compare): #2999 Playwright capture spec (mockup + live route screenshots)"
+```
+
+---
+
+### Task 6: Script `compare:mockups` + smoke end-to-end + README
+
+**Files:**
+- Modify: `apps/web/package.json` (scripts)
+- Create: `apps/web/e2e/mockup-compare/README.md`
+
+**Interfaces:**
+- Produces: `pnpm compare:mockups` (capture → generate) e `pnpm compare:mockups:open` (con `--open`).
+
+- [ ] **Step 1: Aggiungi gli script a `apps/web/package.json`**
+
+Nella sezione `"scripts"`, accanto a `test:storybook:snapshots`:
+```json
+"compare:mockups": "dotenv -e .env.test -- playwright test --config playwright.mockup-compare.config.ts && node scripts/mockup-compare/generate.mjs",
+"compare:mockups:open": "dotenv -e .env.test -- playwright test --config playwright.mockup-compare.config.ts && node scripts/mockup-compare/generate.mjs --open"
+```
+
+- [ ] **Step 2: Smoke end-to-end**
+
+Run: `cd apps/web && pnpm compare:mockups`
+Expected: capture PASS → `gallery generata: …/mockup-compare-output/gallery.html` → apri il file nel browser: mostra la riga "Library · Wishlist" con mockup a sinistra, route live sotto lo slider; trascinando lo slider si rivela il live sul mockup.
+
+- [ ] **Step 3: Scrivi il README del tool**
+
+Create `apps/web/e2e/mockup-compare/README.md`:
+```markdown
+# Mockup↔Live Compare Tool (#2999)
+
+Dev-tool locale per la review **manuale** di fedeltà mockup↔implementazione live.
+Genera una gallery HTML statica che affianca lo screenshot del page-mock e quello
+della route live reale, con slider drag-to-reveal.
+
+**NON è un gate CI** (nessuna baseline, nessun pixel-diff → immune al problema
+baseline win32↔linux che ha descopato la suite pixel Storybook, #2063).
+
+## Uso
+
+```bash
+cd apps/web
+pnpm compare:mockups        # capture + genera gallery.html (stampa il path)
+pnpm compare:mockups:open   # idem + apre nel browser
+```
+
+Output (gitignored): `apps/web/mockup-compare-output/gallery.html` + PNG.
+
+## Aggiungere una coppia
+
+Aggiungi una riga a `e2e/mockup-compare/manifest.ts`:
+- `mockupHtml`: nome file in `admin-mockups/design_files/`.
+- `route`: path live.
+- `auth`: `'user'` | `'admin'`.
+- `mock` (opzionale): `page.route` per popolare i dati, **oppure** usa il seam
+  built-in `?fixture=default` dove supportato (es. `useLibrary`).
+
+## Come funziona
+
+`manifest.ts` → `capture.spec.ts` (screenshot mockup via http-server :5175 +
+route live via app :3000 auth-bypass + mock) → `captures.json` →
+`scripts/mockup-compare/generate.mjs` → `gallery.html`.
+```
+
+- [ ] **Step 4: Verifica finale (typecheck + lint + report builder test)**
+
+Run: `cd apps/web && pnpm typecheck && pnpm vitest run scripts/mockup-compare e2e/mockup-compare`
+Expected: typecheck pulito; test manifest + build-report verdi.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/package.json apps/web/e2e/mockup-compare/README.md
+git commit -m "feat(compare): #2999 compare:mockups script + tool README"
+```
+
+---
+
+## Self-Review (compilato in fase di planning)
+
+- **Spec coverage**: §4.1 manifest → Task 1 · §4.3 report builder → Task 2+3 · §4.4 template gallery → Task 2 · §4.2 capture spec → Task 5 · §5 config+script → Task 4+6 · §6 slice `/library/wishlist` → Task 1+5 · §7 error handling (liveError placeholder) → Task 2 (test) + Task 5 · §8 testing (report builder pure) → Task 2 · §9 gitignore → Task 1.
+- **Placeholder scan**: nessun TBD; `readDesignIntent` è dichiaratamente MVP-stub che ritorna `undefined` (comportamento definito, non placeholder) — l'intent è un nice-to-have §9, non un requisito MVP.
+- **Type consistency**: `MockupComparePair` (Task 1) usato in Task 5; `CaptureRecord` (Task 5) ↔ shape letto da `generate.mjs` (Task 3) ↔ `entries` di `buildReportHtml` (Task 2) — campi allineati (`id/label/route/viewport/mockupPng→mockupDataUri/livePng→liveDataUri/liveError`). `OUTPUT_DIR` definito in manifest (Task 1) e ridefinito localmente in `generate.mjs` (Task 3, nota esplicita: lo `.mjs` non importa il TS) — stesso valore `apps/web/mockup-compare-output`.
+
+## Note di rischio per l'esecutore
+- Il **live capture di `/library/wishlist`** è il punto più incerto: dipende dal fatto che `apiBase` nel mock combaci con l'endpoint reale chiamato dall'app e che il seed-cookie User sblocchi la route sotto `PLAYWRIGHT_AUTH_BYPASS`. Se il live mostra empty/redirect, NON è un blocco del tool: il record porta `liveError`/empty e la gallery lo evidenzia. Investiga con `--headed` o guardando `mockup-compare-output/library-wishlist__live.png`.
+- Se `sp4-library-wishlist.html` fosse un mockup "shell" senza dati inline, lo screenshot mockup sarà comunque valido (è ciò che il designer confronta).

--- a/docs/superpowers/specs/2026-07-17-mockup-compare-tool-design.md
+++ b/docs/superpowers/specs/2026-07-17-mockup-compare-tool-design.md
@@ -118,6 +118,7 @@ La capture spec **`log()`-a** le coppie del manifest ancora scoperte (nessun cap
 - **Manifest** = dati; un test minimale asserisce id univoci + path mockup esistenti.
 
 ## 9. Rischi / note
+- **Correzioni post-review avversariale del piano (2026-07-17)**: (a) l'app usa URL RELATIVI nel browser (`getApiBase()`→`''`) → i mock `page.route` usano glob host-agnostici `**/api/v1/...` (NON `localhost:8080`); (b) l'auth live usa `seedMockRoleCookies` + `mockAuthEndpoints` (helper esistenti), non un mock `/auth/me` hand-rolled; (c) il **mockup capture NON è offline** — i page-mock caricano React/Babel da `unpkg.com` → serve rete + `waitForFunction` sul mount (con `mockupError` se fallisce). La §3 D2 "offline" vale per il lato LIVE (mock), non per il lato mockup. Il builder è `scripts/mockup-compare/{build-report,generate}.mjs` (§4.3/§5 lo nominava diversamente — il piano è la fonte).
 - **Fedeltà mockup vs live**: molte route mostreranno drift legittimo (il tool serve proprio a evidenziarlo); la gallery non giudica, mostra.
 - **Full-page screenshot height**: mockup e live avranno altezze diverse → lo slider allinea in alto; nota nel template.
 - **Manutenzione manifest**: per non divergere da `MOCKUPS_INDEX.md`, un test asserisce che i `mockupHtml` del manifest esistano su disco.

--- a/docs/superpowers/specs/2026-07-17-mockup-compare-tool-design.md
+++ b/docs/superpowers/specs/2026-07-17-mockup-compare-tool-design.md
@@ -1,0 +1,130 @@
+# Design — Tool side-by-side mockup↔live route (GAP-6.3, #2999)
+
+**Data**: 2026-07-17
+**Issue**: [#2999](https://github.com/meepleAi-app/meepleai-monorepo/issues/2999) (GAP-6.3, sub di #2993, umbrella #2342)
+**Decisione**: Opzione **A** — build greenfield di un tool side-by-side mockup↔live (scelta dall'utente su A vs B "re-promote pixel gate").
+
+---
+
+## 1. Contesto e problema
+
+#2999 constata che **non esiste alcun tool side-by-side mockup↔live**. Il più vicino è la suite Storybook pixel-snapshot (`playwright.storybook.config.ts` + `e2e/storybook/*.snapshot.spec.ts`), **descoped dalla CI il 2026-07-15 (#2063)** perché:
+
+- confronta **story-vs-baseline PNG** (deriva live-vs-live nel tempo), **non** mockup-vs-live;
+- le baseline committate sono `*-win32.png` mentre la CI gira su ubuntu → nessun segnale reale (green theatre).
+
+Il gap reale: un designer/dev non ha modo di vedere **il mockup di riferimento accanto all'implementazione live** per valutare la fedeltà. La ragione del descope (baseline win32↔linux divergono) è esattamente ciò che un tool di **confronto visivo manuale** (nessuna baseline, nessun pixel-diff, nessun gate CI) evita per costruzione — il senso di aver scelto A su B.
+
+## 2. Goals / Non-goals
+
+**Goals**
+- Generare una **gallery HTML statica self-contained** che, per ogni coppia mockup↔route, mostri i due screenshot affiancati con uno **slider drag-to-reveal** per la sovrapposizione.
+- Catturare il "live" dalle **route reali** dell'app (fedeltà produzione), rese deterministiche via **auth-bypass + mock API `page.route()`**.
+- Riusare l'infrastruttura Playwright esistente (`playwright.config.ts`, `AdminHelper`, fixture `mockup-pilots/`).
+- Essere un **dev tool locale** eseguibile con un solo comando (`pnpm compare:mockups`).
+
+**Non-goals**
+- **NON** è un gate CI né un pixel-diff automatico (immune al problema win32↔linux). Il giudizio di fedeltà resta umano.
+- **NON** copre tutte le ~68 route al primo colpo — MVP su slice verticale, estensione via manifest.
+- **NON** tocca la suite pixel Storybook descoped (resta dev-tool separato).
+- **NON** richiede backend/DB seedati (i dati arrivano da mock `page.route()`).
+
+## 3. Decisioni fissate (dalla sessione di brainstorming)
+
+| # | Decisione | Alternativa scartata | Perché |
+|---|---|---|---|
+| D1 | Live = **route reali** app (`localhost:3000`) | Storybook story | Fedeltà produzione richiesta dall'utente |
+| D2 | Dati = **auth-bypass + `page.route()` mock per-route** | rendering default / stack seedato reale | Deterministico, offline, dati comparabili al mockup; riusa pattern `admin-dashboard-visual.spec.ts` |
+| D3 | Output = **gallery HTML statica con slider** | pannello iframe live / solo PNG | Portabile, si apre senza server, ottima UX; confronto manuale = niente baseline |
+
+## 4. Architettura — 4 unità isolate
+
+### 4.1 Manifest — `apps/web/e2e/mockup-compare/manifest.ts`
+Dichiara le coppie. Nessun'altra responsabilità.
+```ts
+export interface MockupComparePair {
+  id: string;                 // slug stabile, es. "library-desktop"
+  label: string;              // titolo umano nella gallery
+  mockupHtml: string;         // path relativo a admin-mockups/design_files/*.html
+  route: string;              // route live, es. "/library"
+  viewport?: { width: number; height: number }; // default 1920x1080
+  auth?: 'user' | 'admin' | 'none';             // default 'user'
+  mock?: (page: Page) => Promise<void>;         // page.route() setup opzionale
+}
+export const PAIRS: readonly MockupComparePair[] = [ /* ... */ ];
+```
+Sorgente del pairing: righe **page-mock** di `admin-mockups/MOCKUPS_INDEX.md` + annotazioni `@mockup` sui `page.tsx`.
+
+### 4.2 Capture spec — `apps/web/e2e/mockup-compare/capture.spec.ts`
+Playwright, riusa `playwright.config.ts` (webServer con `PLAYWRIGHT_AUTH_BYPASS=true`, `AdminHelper`, `page.route`). Per ogni pair:
+1. **Mockup**: naviga al file HTML statico servito da `http-server` (già dep `^14.1.1`) su una porta dedicata (es. 5175), screenshot full-page → `<id>__mockup.png`.
+2. **Live**: setup auth (`AdminHelper.setupAdminAuth` per admin, bypass per user), applica `pair.mock?.(page)`, naviga `pair.route`, attende `networkidle` + settle, screenshot full-page → `<id>__live.png`.
+3. Emette un record in `captures.json` (`{ id, label, route, viewport, mockupPng, livePng, liveError? }`).
+
+Output in `apps/web/mockup-compare-output/` (**gitignored**). Su fallimento live: cattura assente, `liveError` valorizzato, si prosegue (no crash).
+
+### 4.3 Report builder — `apps/web/scripts/build-mockup-compare-report.mjs`
+**Funzione pura** `buildReport(captures, fidelityMeta) → htmlString`. Legge `captures.json`, embedda i PNG come `data:` URI (self-contained), impagina una **gallery**: una riga per pair con:
+- header (label, route, viewport, `design_intent` dal `.fidelity.json` se presente);
+- **comparatore slider** (drag-to-reveal) + toggle side-by-side/overlay;
+- placeholder "live capture failed — <error>" se `liveError`.
+Scrive `apps/web/mockup-compare-output/gallery.html`.
+
+### 4.4 Template gallery
+HTML/CSS/JS **inline** (nessuna risorsa esterna). Slider: due immagini sovrapposte + input range che regola `clip-path`/width del layer superiore. Toggle side-by-side. Vanilla JS, zero dipendenze.
+
+## 5. Data flow
+
+```
+manifest.ts
+   │
+   ▼
+capture.spec.ts  ── http-server (mockup) ──▶  <id>__mockup.png
+   │             ── app :3000 (live+mock) ──▶  <id>__live.png
+   ▼
+captures.json
+   │
+   ▼
+build-mockup-compare-report.mjs  ──▶  gallery.html  ──▶  open
+```
+
+Orchestrazione: script npm **`compare:mockups`** in `apps/web/package.json`:
+```
+"compare:mockups": "dotenv -e .env.test -- playwright test --config playwright.mockup-compare.config.ts && node scripts/build-mockup-compare-report.mjs"
+```
+Il report builder, al termine, **stampa il path assoluto** di `gallery.html` (non auto-apre, per determinismo cross-platform e per non bloccare in CI/headless). Un flag opzionale `--open` tenta un best-effort cross-platform (`start`/`open`/`xdg-open`).
+
+Config Playwright dedicata `playwright.mockup-compare.config.ts` (deriva da quella principale; avvia sia il Next webServer auth-bypass sia `http-server` per i mockup su porta dedicata).
+
+## 6. Scope MVP (YAGNI — slice verticale)
+
+Prima release su **3-4 coppie che hanno già fixture/pattern**, per provare l'harness end-to-end senza scrivere molte mock:
+- `/library` (fixture `mockup-pilots/library.ts`) ↔ `sp4-library-desktop.html`
+- `/games/[id]` (fixture `mockup-pilots/game-detail.ts`) ↔ mockup game-detail
+- `/admin` (pattern mock già in `admin-dashboard-visual.spec.ts`) ↔ mockup admin dashboard
+
+La capture spec **`log()`-a** le coppie del manifest ancora scoperte (nessun cap silenzioso). Estensione = aggiungere righe al manifest + fixture mock dove serve.
+
+## 7. Error handling
+- Route live fallisce load/auth → `liveError` nel record; gallery mostra mockup + placeholder rosso, gli altri pair non sono impattati.
+- Mockup HTML mancante → pair skippato con `log()` esplicito.
+- `http-server`/webServer non parte → Playwright fallisce fast; messaggio actionable nel config.
+
+## 8. Testing
+- **Report builder** = funzione pura → unit test Vitest: input `captures.json` fixture (con e senza `liveError`) → asserzioni su struttura HTML (presenza righe, data-URI, placeholder errore, slider markup).
+- **Capture spec**: validata eseguendo `pnpm compare:mockups` sullo slice MVP (smoke: 3-4 PNG generati + gallery aperta).
+- **Manifest** = dati; un test minimale asserisce id univoci + path mockup esistenti.
+
+## 9. Rischi / note
+- **Fedeltà mockup vs live**: molte route mostreranno drift legittimo (il tool serve proprio a evidenziarlo); la gallery non giudica, mostra.
+- **Full-page screenshot height**: mockup e live avranno altezze diverse → lo slider allinea in alto; nota nel template.
+- **Manutenzione manifest**: per non divergere da `MOCKUPS_INDEX.md`, un test asserisce che i `mockupHtml` del manifest esistano su disco.
+- **Output gitignored**: aggiungere `apps/web/mockup-compare-output/` a `.gitignore`.
+
+## 10. Riferimenti
+- Issue #2999 · umbrella #2993/#2342 · descope #2063 · Linux-baseline #2095
+- `apps/web/playwright.config.ts` (auth-bypass webServer, `AdminHelper`)
+- `apps/web/e2e/visual/admin-dashboard-visual.spec.ts` (pattern page.route mock)
+- `apps/web/src/__tests__/fixtures/mockup-pilots/` (fixture riusabili)
+- `admin-mockups/MOCKUPS_INDEX.md` (pairing page-mock↔route)
+- `docs/for-developers/frontend/page-mock-story-pattern.md` (§ descope pixel gate)

--- a/docs/superpowers/specs/2026-07-17-mockup-compare-tool-design.md
+++ b/docs/superpowers/specs/2026-07-17-mockup-compare-tool-design.md
@@ -98,12 +98,14 @@ Config Playwright dedicata `playwright.mockup-compare.config.ts` (deriva da quel
 
 ## 6. Scope MVP (YAGNI — slice verticale)
 
-Prima release su **3-4 coppie che hanno già fixture/pattern**, per provare l'harness end-to-end senza scrivere molte mock:
-- `/library` (fixture `mockup-pilots/library.ts`) ↔ `sp4-library-desktop.html`
-- `/games/[id]` (fixture `mockup-pilots/game-detail.ts`) ↔ mockup game-detail
-- `/admin` (pattern mock già in `admin-dashboard-visual.spec.ts`) ↔ mockup admin dashboard
+> **Correzione post-investigazione (2026-07-17)**: lo slice originariamente ipotizzato (`sp4-library-desktop` / game-detail / admin-dashboard) usava mockup **eliminati in #2988** (DS-17-16, migrati a story). Lo slice reale usa i page-mock HTML **superstiti** in `design_files/`.
 
-La capture spec **`log()`-a** le coppie del manifest ancora scoperte (nessun cap silenzioso). Estensione = aggiungere righe al manifest + fixture mock dove serve.
+Prima release su **1 coppia end-to-end reale** (l'harness resta generico, esteso via manifest):
+- **`/library/wishlist` ↔ `sp4-library-wishlist.html`** — mockup esistente; la route usa `useWishlist` → `GET /api/v1/wishlist`. Cattura live via:
+  - auth: `seedMockRoleCookies(page, 'User')` + mock `${apiBase}/api/v1/auth/me` (pattern `AdminHelper`, ma ruolo User);
+  - dati: `page.route('**/api/v1/wishlist', …)` → `WishlistItemDto[]` fixture + `page.route('**/api/v1/library**', …)` → `[]`.
+
+La capture spec **`log()`-a** le coppie del manifest ancora scoperte (nessun cap silenzioso). Estensione = aggiungere righe al manifest + mock `page.route` **oppure** il seam built-in `?fixture=default` (già supportato da `useLibrary`, vedi `useLibrary.ts:76`) dove disponibile. Candidati estensione: `/toolkit/history` (`sp4-toolkit-history.html`), session summary (`sp4-session-*-summary.html`).
 
 ## 7. Error handling
 - Route live fallisce load/auth → `liveError` nel record; gallery mostra mockup + placeholder rosso, gli altri pair non sono impattati.


### PR DESCRIPTION
## Cosa

Tool greenfield **side-by-side mockup↔live route** (opzione **A** di #2999). Genera una **gallery HTML statica** che affianca, per ogni coppia, lo screenshot del page-mock e quello della **route live reale**, con **slider drag-to-reveal**. Confronto **manuale** — nessuna baseline, nessun pixel-diff → **immune al problema baseline win32↔linux** che ha descopato la suite pixel Storybook (#2063). NON è un gate CI.

```bash
cd apps/web && pnpm compare:mockups        # capture + genera gallery.html
                pnpm compare:mockups:open   # + apre nel browser
```

## Architettura (4 unità isolate)

1. `e2e/mockup-compare/manifest.ts` — pairing mockup↔route (mock `page.route` **host-agnostici** `**/api/v1/...`).
2. `e2e/mockup-compare/capture.spec.ts` — Playwright: screenshot mockup (http-server :5175 + `waitForFunction` sul mount) + route live (`seedMockRoleCookies` + `mockAuthEndpoints`).
3. `scripts/mockup-compare/build-report.mjs` — `buildReportHtml()` **puro** → gallery self-contained (data-URI, slider, placeholder `mockupError`/`liveError`, escape HTML).
4. `scripts/mockup-compare/generate.mjs` — CLI `captures.json → gallery.html`.
- `playwright.mockup-compare.config.ts` (next auth-bypass via `cross-env` + http-server; port app via `COMPARE_APP_PORT`).

## Processo (SDD)

brainstorming → **spec** → **plan** → **review avversariale del piano** (2 verificatori) → implementazione TDD → **verifica visiva end-to-end**.

La review del piano ha catturato **1 BLOCKER**: l'app usa URL **relativi** nel browser (`getApiBase()`→`''`) → i mock con URL assoluti `localhost:8080` non intercettano. Fix: glob host-agnostici + `mockAuthEndpoints` (helper esistente).

## Verifica

- ✅ **9 unit test** verdi (3 manifest + 6 report builder), typecheck + lint puliti.
- ✅ **Happy-path verificato visivamente**: `COMPARE_APP_PORT=3100 pnpm compare:mockups` cattura la coppia `/library/wishlist` con la **wishlist autenticata reale** + le fixture mockate (Fixture User loggato, Terraforming Mars ALTA + Wingspan MEDIA), affiancata al mockup. 0 catture fallite.

### 🔧 Bug trovato e risolto durante la verifica

Il primo run catturava la **pagina di login** invece della wishlist: `PLAYWRIGHT_AUTH_BYPASS` passato via **`webServer.env` di Playwright NON propagava** al processo Next su Windows → il gate SSR di `proxy.ts` reindirizzava a `/login`. **Fix**: prefissare il comando webServer con **`cross-env PLAYWRIGHT_AUTH_BYPASS=true`** (propagazione env affidabile cross-platform). Con il fix, il config avvia da solo un server con bypass e la route autenticata renderizza.

> Nota: se la :3000 è occupata da un server SENZA bypass (stack Docker `make dev`, build prod), `reuseExistingServer` lo riusa e il capture mostra il login — usa `COMPARE_APP_PORT=<porta libera>` (documentato nel README).

Closes #2999

🤖 Generated with [Claude Code](https://claude.com/claude-code)