### PR TITLE
fix(toolkit-history): #3080 surface polymorphic winner score in session history

### DIFF
--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/GameSessionDto.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/GameSessionDto.cs
@@ -16,7 +16,13 @@ internal record GameSessionDto(
     IReadOnlyList<SessionPlayerDto> Players,
     string? WinnerName,
     string? Notes,
-    int DurationMinutes
+    int DurationMinutes,
+    // #3080: polymorphic score surfaced in session history. Null when the session
+    // has no correlated live/tracking session (e.g. legacy or non-live sessions).
+    // ScoringType ∈ { "Points", "BinaryWin", "Objectives", "Ranking" };
+    // ScoreData is the raw JSON payload (shape varies by ScoringType).
+    string? ScoringType = null,
+    string? ScoreData = null
 );
 
 /// <summary>

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GetSessionHistoryQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GetSessionHistoryQueryHandler.cs
@@ -12,10 +12,14 @@ namespace Api.BoundedContexts.GameManagement.Application.Queries;
 internal class GetSessionHistoryQueryHandler : IQueryHandler<GetSessionHistoryQuery, List<GameSessionDto>>
 {
     private readonly IGameSessionRepository _sessionRepository;
+    private readonly IHistorySessionScoreProvider _scoreProvider;
 
-    public GetSessionHistoryQueryHandler(IGameSessionRepository sessionRepository)
+    public GetSessionHistoryQueryHandler(
+        IGameSessionRepository sessionRepository,
+        IHistorySessionScoreProvider scoreProvider)
     {
         _sessionRepository = sessionRepository ?? throw new ArgumentNullException(nameof(sessionRepository));
+        _scoreProvider = scoreProvider ?? throw new ArgumentNullException(nameof(scoreProvider));
     }
 
     public async Task<List<GameSessionDto>> Handle(GetSessionHistoryQuery query, CancellationToken cancellationToken)
@@ -37,6 +41,23 @@ internal class GetSessionHistoryQueryHandler : IQueryHandler<GetSessionHistoryQu
             cancellationToken: cancellationToken
         ).ConfigureAwait(false);
 
-        return sessions.Select(s => s.ToDto()).ToList();
+        var dtos = sessions.Select(s => s.ToDto()).ToList();
+        if (dtos.Count == 0)
+            return dtos;
+
+        // Enrich with the polymorphic score, which lives in the SessionTracking
+        // context and is bridged only via LiveGameSession (#3080). Sessions with no
+        // resolvable score are left with null ScoringType/ScoreData.
+        var scores = await _scoreProvider
+            .GetScoresAsync(dtos.Select(d => d.Id).ToList(), cancellationToken)
+            .ConfigureAwait(false);
+        if (scores.Count == 0)
+            return dtos;
+
+        return dtos
+            .Select(d => scores.TryGetValue(d.Id, out var score)
+                ? d with { ScoringType = score.ScoringType, ScoreData = score.ScoreData }
+                : d)
+            .ToList();
     }
 }

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/IHistorySessionScoreProvider.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/IHistorySessionScoreProvider.cs
@@ -1,0 +1,30 @@
+namespace Api.BoundedContexts.GameManagement.Application.Queries;
+
+/// <summary>
+/// Read-model provider that resolves the polymorphic score payload for a set of
+/// GameManagement <c>GameSession</c>s shown in session history.
+///
+/// The score lives in a different bounded context (<c>SessionTracking.Session</c>,
+/// table <c>session_tracking_sessions</c>) and is bridged to the history session
+/// only through the <c>LiveGameSession</c> aggregate, which carries both
+/// <c>CorrelatedGameSessionId</c> (→ GameSession) and <c>TrackingSessionId</c>
+/// (→ SessionTracking.Session). This provider isolates that cross-context read so
+/// the history query handler stays free of the join (read-model concern, #3080).
+/// </summary>
+internal interface IHistorySessionScoreProvider
+{
+    /// <summary>
+    /// Resolves the score payload for the given GameSession ids. Only ids that have
+    /// a correlated live session with a tracking session are present in the result;
+    /// ids with no resolvable score are simply absent from the dictionary.
+    /// </summary>
+    Task<IReadOnlyDictionary<Guid, HistorySessionScore>> GetScoresAsync(
+        IReadOnlyCollection<Guid> gameSessionIds,
+        CancellationToken cancellationToken);
+}
+
+/// <summary>
+/// Polymorphic score payload for a single session: the scoring type name
+/// ("Points" | "BinaryWin" | "Objectives" | "Ranking") and the raw JSON score data.
+/// </summary>
+internal readonly record struct HistorySessionScore(string ScoringType, string ScoreData);

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/DependencyInjection/GameManagementServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/DependencyInjection/GameManagementServiceExtensions.cs
@@ -1,3 +1,4 @@
+using Api.BoundedContexts.GameManagement.Application.Queries;
 using Api.BoundedContexts.GameManagement.Application.Services;
 using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
 using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightPlaylist;
@@ -31,6 +32,8 @@ internal static class GameManagementServiceExtensions
         // Register repositories
         // NOTE: IGameRepository removed by #1320 (P2c) — Game aggregate deleted.
         services.AddScoped<IGameSessionRepository, GameSessionRepository>();
+        // #3080: cross-context read-model resolving polymorphic score for session history.
+        services.AddScoped<IHistorySessionScoreProvider, HistorySessionScoreProvider>();
         services.AddScoped<IGameSessionStateRepository, GameSessionStateRepository>(); // ISSUE-2403
         services.AddScoped<IPlayRecordRepository, PlayRecordRepository>(); // ISSUE-3889
         services.AddScoped<IPlayRecordVersionRepository, PlayRecordVersionRepository>(); // #2437-3: version history + restore

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Persistence/HistorySessionScoreProvider.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Persistence/HistorySessionScoreProvider.cs
@@ -1,0 +1,64 @@
+using Api.BoundedContexts.GameManagement.Application.Queries;
+using Api.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.GameManagement.Infrastructure.Persistence;
+
+/// <summary>
+/// EF Core read-model provider that resolves the polymorphic score for session
+/// history rows by bridging, within the shared <see cref="MeepleAiDbContext"/>:
+/// <c>GameManagement.GameSession</c> ← <c>LiveGameSession.CorrelatedGameSessionId</c>
+/// and <c>LiveGameSession.TrackingSessionId</c> → <c>SessionTracking.Session</c>
+/// (which owns <c>scoring_type</c> + <c>score_data</c>). Isolates the cross-context
+/// read so the history query handler stays free of the join (#3080).
+/// </summary>
+internal sealed class HistorySessionScoreProvider : IHistorySessionScoreProvider
+{
+    private readonly MeepleAiDbContext _dbContext;
+
+    public HistorySessionScoreProvider(MeepleAiDbContext dbContext)
+    {
+        _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+    }
+
+    public async Task<IReadOnlyDictionary<Guid, HistorySessionScore>> GetScoresAsync(
+        IReadOnlyCollection<Guid> gameSessionIds,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(gameSessionIds);
+
+        if (gameSessionIds.Count == 0)
+            return new Dictionary<Guid, HistorySessionScore>();
+
+        var ids = gameSessionIds as Guid[] ?? gameSessionIds.ToArray();
+
+        var rows = await (
+            from live in _dbContext.LiveGameSessions.AsNoTracking()
+            where live.CorrelatedGameSessionId != null
+                  && ids.Contains(live.CorrelatedGameSessionId.Value)
+            join track in _dbContext.SessionTrackingSessions.AsNoTracking()
+                on live.TrackingSessionId equals (Guid?)track.Id
+            select new
+            {
+                live.CorrelatedGameSessionId,
+                track.ScoringType,
+                track.ScoreData,
+                track.UpdatedAt,
+                track.CreatedAt
+            }
+        ).ToListAsync(cancellationToken).ConfigureAwait(false);
+
+        // A GameSession correlates to at most one live/tracking session. If the data
+        // somehow carries more than one, take the most recently updated tracking row.
+        return rows
+            .Where(r => r.CorrelatedGameSessionId.HasValue)
+            .GroupBy(r => r.CorrelatedGameSessionId!.Value)
+            .ToDictionary(
+                group => group.Key,
+                group =>
+                {
+                    var latest = group.OrderByDescending(r => r.UpdatedAt ?? r.CreatedAt).First();
+                    return new HistorySessionScore(latest.ScoringType, latest.ScoreData);
+                });
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/GetSessionHistoryQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/GetSessionHistoryQueryHandlerTests.cs
@@ -18,12 +18,18 @@ namespace Api.Tests.BoundedContexts.GameManagement.Application.Handlers;
 public class GetSessionHistoryQueryHandlerTests
 {
     private readonly Mock<IGameSessionRepository> _sessionRepositoryMock;
+    private readonly Mock<IHistorySessionScoreProvider> _scoreProviderMock;
     private readonly GetSessionHistoryQueryHandler _handler;
 
     public GetSessionHistoryQueryHandlerTests()
     {
         _sessionRepositoryMock = new Mock<IGameSessionRepository>();
-        _handler = new GetSessionHistoryQueryHandler(_sessionRepositoryMock.Object);
+        _scoreProviderMock = new Mock<IHistorySessionScoreProvider>();
+        // Default: no scores resolved — history DTOs keep null score unless a test says otherwise.
+        _scoreProviderMock
+            .Setup(p => p.GetScoresAsync(It.IsAny<IReadOnlyCollection<Guid>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<Guid, HistorySessionScore>());
+        _handler = new GetSessionHistoryQueryHandler(_sessionRepositoryMock.Object, _scoreProviderMock.Object);
     }
     [Fact]
     public async Task Handle_WithNoFilters_ReturnsAllHistoricalSessions()
@@ -340,6 +346,61 @@ public class GetSessionHistoryQueryHandlerTests
         dto.WinnerName.Should().Be("Alice");
         dto.PlayerCount.Should().Be(session.Players.Count);
         dto.Players.Count.Should().Be(session.Players.Count);
+    }
+
+    [Fact]
+    public async Task Handle_EnrichesDtosWithPolymorphicScore_WhenProviderResolvesScore()
+    {
+        // Arrange
+        var session = new GameSessionBuilder()
+            .WithCompletedStatus()
+            .WithWinner("Alice")
+            .Build();
+
+        _sessionRepositoryMock
+            .Setup(r => r.FindHistoryAsync(
+                null, null, null, null, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<GameSession> { session });
+
+        const string scoreData =
+            "{\"scores\":[{\"playerId\":\"11111111-1111-1111-1111-111111111111\",\"points\":42}]}";
+        _scoreProviderMock
+            .Setup(p => p.GetScoresAsync(
+                It.IsAny<IReadOnlyCollection<Guid>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new Dictionary<Guid, HistorySessionScore>
+            {
+                [session.Id] = new HistorySessionScore("Points", scoreData)
+            });
+
+        // Act
+        var result = await _handler.Handle(
+            new GetSessionHistoryQuery(), TestContext.Current.CancellationToken);
+
+        // Assert
+        result.Should().ContainSingle();
+        result[0].ScoringType.Should().Be("Points");
+        result[0].ScoreData.Should().Be(scoreData);
+    }
+
+    [Fact]
+    public async Task Handle_LeavesScoreNull_WhenProviderHasNoScoreForSession()
+    {
+        // Arrange
+        var session = new GameSessionBuilder().WithCompletedStatus().Build();
+        _sessionRepositoryMock
+            .Setup(r => r.FindHistoryAsync(
+                null, null, null, null, null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<GameSession> { session });
+        // Provider default (ctor) resolves no scores.
+
+        // Act
+        var result = await _handler.Handle(
+            new GetSessionHistoryQuery(), TestContext.Current.CancellationToken);
+
+        // Assert
+        result.Should().ContainSingle();
+        result[0].ScoringType.Should().BeNull();
+        result[0].ScoreData.Should().BeNull();
     }
 }
 

--- a/apps/api/tests/Api.Tests/Integration/GameManagement/HistorySessionScoreProviderTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/GameManagement/HistorySessionScoreProviderTests.cs
@@ -1,0 +1,236 @@
+using System.Text.Json.Nodes;
+using Api.BoundedContexts.GameManagement.Application.Queries;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Infrastructure.Entities.GameManagement;
+using Api.Infrastructure.Entities.SessionTracking;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.Integration.GameManagement;
+
+/// <summary>
+/// Integration tests for #3080 — <see cref="IHistorySessionScoreProvider"/> resolves the
+/// polymorphic score for a history GameSession by bridging, on a real Postgres:
+/// GameSession ← LiveGameSession.CorrelatedGameSessionId, and
+/// LiveGameSession.TrackingSessionId → SessionTracking.Session (score owner).
+/// </summary>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "GameManagement")]
+public sealed class HistorySessionScoreProviderTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly string _databaseName = $"history_score_{Guid.NewGuid():N}";
+    private WebApplicationFactory<Program> _factory = null!;
+
+    public HistorySessionScoreProviderTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+        await TestcontainersWaitHelpers.WaitForPostgresReadyAsync(connectionString);
+
+        _factory = IntegrationWebApplicationFactory.Create(connectionString);
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        db.Database.Migrate();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_factory != null)
+            await _factory.DisposeAsync();
+
+        await _fixture.DropIsolatedDatabaseAsync(_databaseName);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // The correlated live session bridges the completed GameSession to the
+    // SessionTracking.Session that owns scoring_type + score_data → the provider
+    // must return the Points payload keyed by the GameSession id.
+    // ──────────────────────────────────────────────────────────────────────────
+    [Fact]
+    public async Task GetScoresAsync_ResolvesPointsScore_ViaLiveSessionBridge()
+    {
+        // Arrange
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        var userId = await SeedUserAsync(db);
+        var gameId = await SeedSharedGameAsync(db);
+        var gameSessionId = await SeedCompletedGameSessionAsync(db, gameId, userId);
+
+        const string scoreData =
+            "{\"scores\":[{\"playerId\":\"11111111-1111-1111-1111-111111111111\",\"points\":42},"
+            + "{\"playerId\":\"22222222-2222-2222-2222-222222222222\",\"points\":30}]}";
+        var trackingSessionId = await SeedTrackingSessionAsync(db, userId, gameId, "Points", scoreData);
+        await SeedLiveBridgeAsync(db, userId, gameSessionId, trackingSessionId);
+
+        var provider = scope.ServiceProvider.GetRequiredService<IHistorySessionScoreProvider>();
+
+        // Act
+        var result = await provider.GetScoresAsync(
+            new[] { gameSessionId }, TestContext.Current.CancellationToken);
+
+        // Assert. score_data is a jsonb column: Postgres normalizes whitespace and
+        // object-key order on storage, so compare the round-tripped payload
+        // semantically (this is fine for the FE, which JSON.parses it) rather than
+        // byte-for-byte.
+        result.Should().ContainKey(gameSessionId);
+        result[gameSessionId].ScoringType.Should().Be("Points");
+        JsonNode.DeepEquals(
+                JsonNode.Parse(result[gameSessionId].ScoreData),
+                JsonNode.Parse(scoreData))
+            .Should().BeTrue("the round-tripped jsonb score payload must be semantically equal to what was stored");
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // A GameSession with no correlated live session (e.g. legacy / non-live play)
+    // resolves to no score → absent from the result dictionary (renders as '—').
+    // ──────────────────────────────────────────────────────────────────────────
+    [Fact]
+    public async Task GetScoresAsync_OmitsSession_WhenNoCorrelatedLiveSession()
+    {
+        // Arrange
+        await using var scope = _factory.Services.CreateAsyncScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        var userId = await SeedUserAsync(db);
+        var gameId = await SeedSharedGameAsync(db);
+        var gameSessionId = await SeedCompletedGameSessionAsync(db, gameId, userId);
+        // No LiveGameSession / SessionTracking.Session correlated to this game session.
+
+        var provider = scope.ServiceProvider.GetRequiredService<IHistorySessionScoreProvider>();
+
+        // Act
+        var result = await provider.GetScoresAsync(
+            new[] { gameSessionId }, TestContext.Current.CancellationToken);
+
+        // Assert
+        result.Should().NotContainKey(gameSessionId);
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // Helpers
+    // ──────────────────────────────────────────────────────────────────────────
+
+    private static async Task<Guid> SeedUserAsync(MeepleAiDbContext db)
+    {
+        var userId = Guid.NewGuid();
+        db.Users.Add(new UserEntity
+        {
+            Id = userId,
+            Email = $"hist-score-{userId:N}@test.local",
+            DisplayName = "History Score Test User",
+            PasswordHash = "not-a-real-hash",
+            Role = "user",
+            Tier = "free",
+            Status = "Active",
+            EmailVerified = true,
+            CreatedAt = DateTime.UtcNow
+        });
+        await db.SaveChangesAsync();
+        db.ChangeTracker.Clear();
+        return userId;
+    }
+
+    private static async Task<Guid> SeedSharedGameAsync(MeepleAiDbContext db)
+    {
+        var gameId = Guid.NewGuid();
+        db.SharedGames.Add(new SharedGameEntity
+        {
+            Id = gameId,
+            Title = $"History Score Test Game {gameId:N}",
+            YearPublished = 2024,
+            MinPlayers = 1,
+            MaxPlayers = 4,
+            PlayingTimeMinutes = 60,
+            MinAge = 10,
+            ImageUrl = string.Empty,
+            ThumbnailUrl = string.Empty,
+            Description = string.Empty,
+            CreatedBy = Guid.NewGuid(),
+            CreatedAt = DateTime.UtcNow
+        });
+        await db.SaveChangesAsync();
+        db.ChangeTracker.Clear();
+        return gameId;
+    }
+
+    private static async Task<Guid> SeedCompletedGameSessionAsync(MeepleAiDbContext db, Guid gameId, Guid userId)
+    {
+        var id = Guid.NewGuid();
+        db.GameSessions.Add(new GameSessionEntity
+        {
+            Id = id,
+            GameId = gameId,
+            CreatedByUserId = userId,
+            Status = "Completed",
+            StartedAt = DateTime.UtcNow.AddHours(-1),
+            CompletedAt = DateTime.UtcNow,
+            WinnerName = "Alice",
+            Notes = null,
+            PlayersJson = "[]"
+        });
+        await db.SaveChangesAsync();
+        db.ChangeTracker.Clear();
+        return id;
+    }
+
+    private static async Task<Guid> SeedTrackingSessionAsync(
+        MeepleAiDbContext db, Guid userId, Guid gameId, string scoringType, string scoreData)
+    {
+        var id = Guid.NewGuid();
+        db.SessionTrackingSessions.Add(new SessionEntity
+        {
+            Id = id,
+            UserId = userId,
+            GameId = gameId,
+            SessionCode = "SCR001",
+            SessionType = "Standard",
+            Status = "Completed",
+            SessionDate = DateTime.UtcNow,
+            ScoringType = scoringType,
+            ScoreData = scoreData,
+            CreatedAt = DateTime.UtcNow,
+            CreatedBy = userId
+        });
+        await db.SaveChangesAsync();
+        db.ChangeTracker.Clear();
+        return id;
+    }
+
+    private static async Task SeedLiveBridgeAsync(
+        MeepleAiDbContext db, Guid userId, Guid correlatedGameSessionId, Guid trackingSessionId)
+    {
+        db.LiveGameSessions.Add(new LiveGameSessionEntity
+        {
+            Id = Guid.NewGuid(),
+            SessionCode = "LIVE01",
+            GameId = null, // free-form → avoids an extra SharedGame FK
+            GameName = "Test Live Session",
+            CreatedByUserId = userId,
+            Visibility = 0,
+            Status = 4, // Completed
+            ScoringConfigJson = "{}",
+            CreatedAt = DateTime.UtcNow.AddHours(-1),
+            UpdatedAt = DateTime.UtcNow,
+            CompletedAt = DateTime.UtcNow,
+            TrackingSessionId = trackingSessionId,
+            CorrelatedGameSessionId = correlatedGameSessionId
+        });
+        await db.SaveChangesAsync();
+        db.ChangeTracker.Clear();
+    }
+}

--- a/apps/web/src/app/(authenticated)/toolkit/history/__tests__/history-filters.test.ts
+++ b/apps/web/src/app/(authenticated)/toolkit/history/__tests__/history-filters.test.ts
@@ -105,6 +105,50 @@ describe('parseWinScore', () => {
     const dto = makeDto({ scoreData: JSON.stringify({ Alice: 42, Bob: 'DNF' }) });
     expect(parseWinScore(dto)).toBe(42);
   });
+
+  // The real shape produced by the backend PointsScoringStrategy (camelCase):
+  // { "scores": [ { "playerId": "...", "points": N }, ... ] }.
+  it('returns the max points from the nested Points scoreData shape {scores:[{playerId,points}]}', () => {
+    const dto = makeDto({
+      scoringType: 'Points',
+      scoreData: JSON.stringify({
+        scores: [
+          { playerId: '11111111-1111-1111-1111-111111111111', points: 42 },
+          { playerId: '22222222-2222-2222-2222-222222222222', points: 30 },
+        ],
+      }),
+    });
+    expect(parseWinScore(dto)).toBe(42);
+  });
+
+  it('returns null for a Points payload with an empty scores array', () => {
+    expect(parseWinScore(makeDto({ scoreData: JSON.stringify({ scores: [] }) }))).toBeNull();
+  });
+
+  it('ignores non-numeric points entries in the nested Points shape', () => {
+    const dto = makeDto({
+      scoreData: JSON.stringify({
+        scores: [
+          { playerId: '11111111-1111-1111-1111-111111111111', points: 'DNF' },
+          { playerId: '22222222-2222-2222-2222-222222222222', points: 15 },
+        ],
+      }),
+    });
+    expect(parseWinScore(dto)).toBe(15);
+  });
+
+  it('returns null for a non-Points shape with no numeric leaf (BinaryWin results)', () => {
+    const dto = makeDto({
+      scoringType: 'BinaryWin',
+      scoreData: JSON.stringify({
+        results: [
+          { playerId: '11111111-1111-1111-1111-111111111111', isWinner: true },
+          { playerId: '22222222-2222-2222-2222-222222222222', isWinner: false },
+        ],
+      }),
+    });
+    expect(parseWinScore(dto)).toBeNull();
+  });
 });
 
 // ─── toHistoryRow ───────────────────────────────────────────────────────────

--- a/apps/web/src/app/(authenticated)/toolkit/history/_lib/history-filters.ts
+++ b/apps/web/src/app/(authenticated)/toolkit/history/_lib/history-filters.ts
@@ -50,10 +50,16 @@ export interface HistoryRow {
 
 /**
  * Parses the polymorphic `scoreData` JSON payload and returns the highest
- * numeric score found, or `null` when the payload is missing, invalid, or
- * has no numeric values. Supports two shapes:
+ * numeric score found (the "winner score"), or `null` when the payload is
+ * missing, invalid, or carries no single numeric score. Supported shapes:
+ *   - Points (backend `PointsScoringStrategy`, camelCase):
+ *     `{ "scores": [ { "playerId": "…", "points": N }, … ] }` — uses the max `points`
  *   - `Record<string, number>` (e.g. `{ "Alice": 42, "Bob": 30 }`) — uses the values
  *   - `number[]` (e.g. `[10, 20, 30]`)
+ *
+ * Non-Points scoring types (`BinaryWin` / `Objectives` / `Ranking`) have no
+ * single numeric "winner score", so their payloads fall through to `null` and
+ * render as `—` in the table / blank in the CSV export.
  */
 export function parseWinScore(dto: GameSessionDto): number | null {
   if (!dto.scoreData) return null;
@@ -63,6 +69,29 @@ export function parseWinScore(dto: GameSessionDto): number | null {
     parsed = JSON.parse(dto.scoreData);
   } catch {
     return null;
+  }
+
+  // Points shape: an object carrying a `scores` array of `{ points }` entries.
+  // Match it before the generic object branch, whose `Object.values` would see
+  // the array itself (not the nested numbers) and always yield null.
+  if (
+    parsed !== null &&
+    typeof parsed === 'object' &&
+    !Array.isArray(parsed) &&
+    'scores' in parsed
+  ) {
+    const scores = (parsed as { scores: unknown }).scores;
+    if (!Array.isArray(scores)) return null;
+    const points = scores
+      .map(entry =>
+        entry !== null &&
+        typeof entry === 'object' &&
+        typeof (entry as { points?: unknown }).points === 'number'
+          ? (entry as { points: number }).points
+          : null
+      )
+      .filter((v): v is number => v !== null);
+    return points.length > 0 ? Math.max(...points) : null;
   }
 
   let values: number[];


### PR DESCRIPTION
## Summary

Closes #3080. The `/toolkit/history` **score column was dead for every row**, along with its sort control and CSV export.

## Problem (two bugs)

1. `parseWinScore` reads `dto.scoreData`, but `GET /api/v1/sessions/history` **never emitted it** — the GameManagement `GameSessionDto` had no score member.
2. Even if it had, the parser handled `Record<string,number>` / `number[]` but **not** the real nested Points shape `{"scores":[{"playerId","points"}]}` produced by `PointsScoringStrategy`.

## Approach — read-model cross-context join (chosen over denormalization)

The score lives in a **different bounded context** (`SessionTracking.Session` / `session_tracking_sessions`), bridged to the history `GameSession` only via the `LiveGameSession` aggregate (`CorrelatedGameSessionId` + `TrackingSessionId`). All three tables share `MeepleAiDbContext`, so a read-model join resolves the score with **no migration, no write-path change, no backfill**. See the [discovery comment](https://github.com/meepleAi-app/meepleai-monorepo/issues/3080#issuecomment-5004634741).

### Backend
- `GameSessionDto` gains optional `ScoringType` / `ScoreData` (default null).
- New `IHistorySessionScoreProvider` + EF impl isolates the cross-context join (`GameSession ← LiveGameSession.CorrelatedGameSessionId`, `LiveGameSession.TrackingSessionId → SessionTracking.Session`).
- `GetSessionHistoryQueryHandler` enriches the DTOs; sessions with no resolvable score stay null.
- Registered in DI (interface + impl).

### Frontend
- `parseWinScore` now parses the nested Points shape (max `points`). Non-Points scoring types (BinaryWin/Objectives/Ranking) have no single numeric winner score → render as `—` (unchanged behaviour).

## Testing
- **FE unit** (`history-filters.test.ts`): nested Points shape + empty scores + non-numeric points + BinaryWin → null. 52/52 pass; full module 146/146.
- **BE unit** (`GetSessionHistoryQueryHandlerTests`): handler enriches DTO when provider resolves a score; leaves null otherwise. 14/14.
- **BE integration** (`HistorySessionScoreProviderTests`, Testcontainers Postgres): real cross-context join resolves the Points payload; omits sessions with no correlated live session. Asserts the **jsonb round-trip semantically** (Postgres normalizes jsonb on storage — the FE `JSON.parse` is robust to this).
- FE typecheck + lint clean; 35 backend contract tests green (no DTO regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)