### PR TITLE
fix(play-records): #3087 tighten Zod schema — winnerPlayerIds/outcomeType required

### DIFF
--- a/apps/web/src/components/play-records/PlayRecordDetailBody.tsx
+++ b/apps/web/src/components/play-records/PlayRecordDetailBody.tsx
@@ -171,13 +171,13 @@ export function PlayRecordDetailBody({
   const perspective = derivePerspective({
     currentUserId,
     players: record.players,
-    winnerPlayerIds: record.winnerPlayerIds ?? [],
+    winnerPlayerIds: record.winnerPlayerIds,
     outcomeType: record.outcomeType,
     status: record.status,
   });
 
   // ── Build variant for hero ──────────────────────────────────────────────────
-  let heroVariant = perspectiveToHeroVariant(perspective.kind, record.winnerPlayerIds?.length ?? 0);
+  let heroVariant = perspectiveToHeroVariant(perspective.kind, record.winnerPlayerIds.length);
   // Override pending → planned/inprogress based on actual status
   if (perspective.kind === 'pending') {
     heroVariant = record.status === 'Planned' ? 'planned' : 'inprogress';
@@ -207,8 +207,8 @@ export function PlayRecordDetailBody({
   };
 
   // ── Data derivatives ────────────────────────────────────────────────────────
-  const rankedScores = buildRankedScores(record.players, record.winnerPlayerIds ?? []);
-  const clasificaRows = buildClassificaRows(record.players, record.winnerPlayerIds ?? []);
+  const rankedScores = buildRankedScores(record.players, record.winnerPlayerIds);
+  const clasificaRows = buildClassificaRows(record.players, record.winnerPlayerIds);
   const breakdownRows = buildBreakdownRows(record.players);
   const { topScore, avgScore, spread } = computeKpis(record.players);
 
@@ -216,7 +216,7 @@ export function PlayRecordDetailBody({
   const formattedDate = formatRelativeDate(record.sessionDate);
 
   // #2437-1 MVP chip: derive from winnerPlayerIds — only when exactly 1 winner.
-  const winnerIds = record.winnerPlayerIds ?? [];
+  const winnerIds = record.winnerPlayerIds;
   const mvpName =
     winnerIds.length === 1
       ? (record.players.find(p => p.id === winnerIds[0])?.displayName ?? null)

--- a/apps/web/src/components/play-records/index/RecordCardGrid.tsx
+++ b/apps/web/src/components/play-records/index/RecordCardGrid.tsx
@@ -50,9 +50,9 @@ export function RecordCardGrid({ record }: RecordCardGridProps) {
     ? 'planned'
     : record.outcomeType === 'none'
       ? 'cooperative'
-      : record.winnerPlayerIds?.length === 1
+      : record.winnerPlayerIds.length === 1
         ? 'won'
-        : record.winnerPlayerIds?.length === 2
+        : record.winnerPlayerIds.length === 2
           ? 'tie'
           : 'tie';
 

--- a/apps/web/src/components/play-records/index/RecordCardList.tsx
+++ b/apps/web/src/components/play-records/index/RecordCardList.tsx
@@ -57,9 +57,9 @@ export function RecordCardList({ record }: RecordCardListProps) {
       ? 'planned'
       : record.outcomeType === 'none'
         ? 'cooperative'
-        : record.winnerPlayerIds?.length === 1
+        : record.winnerPlayerIds.length === 1
           ? 'won'
-          : record.winnerPlayerIds?.length === 2
+          : record.winnerPlayerIds.length === 2
             ? 'tie'
             : 'tie';
 

--- a/apps/web/src/lib/api/schemas/__tests__/play-records-outcome.schema.test.ts
+++ b/apps/web/src/lib/api/schemas/__tests__/play-records-outcome.schema.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+
+import { PlayRecordDtoSchema, PlayRecordSummarySchema } from '../play-records.schemas';
+
+// #3087: winnerPlayerIds + outcomeType are now REQUIRED. The BE always emits them —
+// they are non-nullable positional params on PlayRecordDto/PlayRecordSummaryDto, populated
+// unconditionally by PlayRecordDtoMapper via PlayRecordOutcomeCalculator. A response that
+// dropped either field must fail fast, not parse to `undefined`.
+
+const baseDto = {
+  id: '550e8400-e29b-41d4-a716-446655440000',
+  gameId: null,
+  gameName: 'Catan',
+  sessionDate: '2026-07-17',
+  duration: null,
+  status: 'Completed' as const,
+  players: [],
+  scoringConfig: { enabledDimensions: [], dimensionUnits: {} },
+  createdByUserId: '550e8400-e29b-41d4-a716-446655440001',
+  visibility: 'Private' as const,
+  startTime: null,
+  endTime: null,
+  notes: null,
+  location: null,
+  createdAt: '2026-07-17T10:00:00Z',
+  updatedAt: '2026-07-17T10:00:00Z',
+  winnerPlayerIds: ['550e8400-e29b-41d4-a716-446655440002'],
+  outcomeType: 'competitive' as const,
+};
+
+const baseSummary = {
+  id: '550e8400-e29b-41d4-a716-446655440000',
+  gameName: 'Catan',
+  sessionDate: '2026-07-17',
+  duration: null,
+  status: 'Completed' as const,
+  playerCount: 2,
+  gameId: null,
+  winnerPlayerIds: ['550e8400-e29b-41d4-a716-446655440002'],
+  outcomeType: 'competitive' as const,
+};
+
+describe('PlayRecordDtoSchema outcome fields (#3087)', () => {
+  it('parses a record carrying winnerPlayerIds + outcomeType', () => {
+    const parsed = PlayRecordDtoSchema.parse(baseDto);
+    expect(parsed.winnerPlayerIds).toEqual(['550e8400-e29b-41d4-a716-446655440002']);
+    expect(parsed.outcomeType).toBe('competitive');
+  });
+
+  it('rejects a record missing winnerPlayerIds', () => {
+    const invalid: Partial<typeof baseDto> = { ...baseDto };
+    delete invalid.winnerPlayerIds;
+    expect(() => PlayRecordDtoSchema.parse(invalid)).toThrow();
+  });
+
+  it('rejects a record missing outcomeType', () => {
+    const invalid: Partial<typeof baseDto> = { ...baseDto };
+    delete invalid.outcomeType;
+    expect(() => PlayRecordDtoSchema.parse(invalid)).toThrow();
+  });
+});
+
+describe('PlayRecordSummarySchema outcome fields (#3087)', () => {
+  it('parses a summary carrying gameId + winnerPlayerIds + outcomeType', () => {
+    const parsed = PlayRecordSummarySchema.parse(baseSummary);
+    expect(parsed.outcomeType).toBe('competitive');
+    expect(parsed.gameId).toBeNull();
+  });
+
+  it('rejects a summary missing winnerPlayerIds', () => {
+    const invalid: Partial<typeof baseSummary> = { ...baseSummary };
+    delete invalid.winnerPlayerIds;
+    expect(() => PlayRecordSummarySchema.parse(invalid)).toThrow();
+  });
+
+  it('rejects a summary missing outcomeType', () => {
+    const invalid: Partial<typeof baseSummary> = { ...baseSummary };
+    delete invalid.outcomeType;
+    expect(() => PlayRecordSummarySchema.parse(invalid)).toThrow();
+  });
+});

--- a/apps/web/src/lib/api/schemas/__tests__/play-records-photo.schema.test.ts
+++ b/apps/web/src/lib/api/schemas/__tests__/play-records-photo.schema.test.ts
@@ -47,6 +47,8 @@ describe('PlayRecordPhotoSchema', () => {
       location: null,
       createdAt: '2026-06-20T10:00:00Z',
       updatedAt: '2026-06-20T10:00:00Z',
+      winnerPlayerIds: [],
+      outcomeType: 'none' as const,
     };
     expect(PlayRecordDtoSchema.parse(base).photos).toBeUndefined();
     expect(PlayRecordDtoSchema.parse({ ...base, photos: [] }).photos).toEqual([]);

--- a/apps/web/src/lib/api/schemas/__tests__/play-records-share.schema.test.ts
+++ b/apps/web/src/lib/api/schemas/__tests__/play-records-share.schema.test.ts
@@ -20,6 +20,8 @@ const basePr = {
   location: null,
   createdAt: '2026-06-21T10:00:00Z',
   updatedAt: '2026-06-21T10:00:00Z',
+  winnerPlayerIds: [],
+  outcomeType: 'none' as const,
 };
 
 describe('ShareLinkResponseSchema (#2437-2)', () => {

--- a/apps/web/src/lib/api/schemas/__tests__/play-records-xmin.schema.test.ts
+++ b/apps/web/src/lib/api/schemas/__tests__/play-records-xmin.schema.test.ts
@@ -19,6 +19,8 @@ const base = {
   location: null,
   createdAt: '2026-06-21T10:00:00Z',
   updatedAt: '2026-06-21T10:00:00Z',
+  winnerPlayerIds: [],
+  outcomeType: 'none' as const,
 };
 
 describe('xmin schemas (#2437-1)', () => {

--- a/apps/web/src/lib/api/schemas/play-records.schemas.ts
+++ b/apps/web/src/lib/api/schemas/play-records.schemas.ts
@@ -105,9 +105,9 @@ export const PlayRecordDtoSchema = z.object({
   createdAt: z.string(),
   updatedAt: z.string(),
   // #1663 Phase 1: derived on-read (winner = players with "wins" dimension > 0).
-  // Optional during BE rollout; tighten once the BE ships the fields.
-  winnerPlayerIds: z.array(z.string().uuid()).optional(),
-  outcomeType: PlayRecordOutcomeTypeSchema.optional(),
+  // BE always emits these (PlayRecordDtoMapper -> PlayRecordOutcomeCalculator); required (#3087).
+  winnerPlayerIds: z.array(z.string().uuid()),
+  outcomeType: PlayRecordOutcomeTypeSchema,
   // #2436 PR-C: photos exposed on read. Optional during BE rollout; tighten later.
   photos: z.array(PlayRecordPhotoSchema).optional(),
   // #2437-1: Postgres xmin optimistic-concurrency token (uint). Optional during rollout.
@@ -125,10 +125,11 @@ export const PlayRecordSummarySchema = z.object({
   status: PlayRecordStatusSchema,
   playerCount: z.number().int().nonnegative(),
   // #1663 Phase 1: enable cover/deep-link + outcome badge in the list view.
-  // Optional during BE rollout; tighten once the BE ships the fields.
-  gameId: GameIdString.nullable().optional(),
-  winnerPlayerIds: z.array(z.string().uuid()).optional(),
-  outcomeType: PlayRecordOutcomeTypeSchema.optional(),
+  // BE always emits these (PlayRecordSummaryDto non-nullable); required (#3087).
+  // gameId stays nullable (freeform records) but is always present, matching the detail schema.
+  gameId: GameIdString.nullable(),
+  winnerPlayerIds: z.array(z.string().uuid()),
+  outcomeType: PlayRecordOutcomeTypeSchema,
 });
 export type PlayRecordSummary = z.infer<typeof PlayRecordSummarySchema>;
 


### PR DESCRIPTION
Closes #3087

## Cosa

Lo schema Zod di play-records dichiarava `winnerPlayerIds` e `outcomeType` come `.optional()` con la nota *"#1663 Phase 1 — Optional during BE rollout; tighten once the BE ships the field"*. Il BE ora li **emette sempre** (parametri posizionali non-nullable su `PlayRecordDto`/`PlayRecordSummaryDto`, popolati incondizionatamente da `PlayRecordDtoMapper` via `PlayRecordOutcomeCalculator`) → la precondizione del rollout è soddisfatta.

## Modifiche

- `winnerPlayerIds` + `outcomeType` → **required** su `PlayRecordDtoSchema` e `PlayRecordSummarySchema`.
- `PlayRecordSummary.gameId` allineato allo schema detail: `.nullable()` (drop `.optional()`) — sempre presente, può null per record freeform.
- `photos` / `xmin` / `shareToken` **restano optional** (rollout genuino tuttora in corso, con test dedicati; il mock MSW detail li omette).
- Rimossi gli accessi difensivi ora ridondanti (`?.` / `?? []`) in `RecordCardList`, `RecordCardGrid`, `PlayRecordDetailBody`.
- Nuovo `play-records-outcome.schema.test.ts`: asserisce che lo schema **rifiuta** un payload senza `winnerPlayerIds`/`outcomeType` e parse-a uno completo. Fixture `xmin`/`share`/`photo` aggiornati coi campi ora required.

## Verifica

- ✅ `pnpm test` scoped play-records: **48 file, 364 test verdi** (incluso il nuovo test contract)
- ✅ `pnpm typecheck`: exit 0 (il tightening di `gameId` non rompe fixture/story tipizzate)
- ✅ `pnpm lint`: 0 errori sui file toccati
- ✅ pre-commit + pre-push hook (lint-staged, typecheck, backend build) verdi

## Scope / rischio

FE-only, atomico. Nessuna modifica BE (il contratto era già conforme). Verifica avversariale: confermato campo-per-campo contro i DTO C# quali sono sempre emessi, per non stringere campi che romperebbero il parsing a runtime.

---
🤖 Emersa da tech-debt discovery workflow (multi-modal sweep → verifica avversariale).

🤖 Generated with [Claude Code](https://claude.com/claude-code)