### PR TITLE
fix(admin-reports): #3081 real metrics in System Health report

### DIFF
--- a/apps/api/src/Api/BoundedContexts/Administration/Infrastructure/Services/ReportGeneratorService.SystemHealth.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Infrastructure/Services/ReportGeneratorService.SystemHealth.cs
@@ -62,19 +62,80 @@ internal sealed partial class ReportGeneratorService
 
         var sections = CreateSystemHealthSections(hours, userMetrics, contentMetrics);
 
+        // Real health metrics from Prometheus (#3081). These were previously
+        // hardcoded to 0.0 placeholders (and a mislabeled "uptime" = window param)
+        // yet exported to admins as if real. When Prometheus is unavailable or has
+        // no data, the key is OMITTED rather than fabricating a misleading zero.
+        var metadata = new Dictionary<string, object>(StringComparer.Ordinal)
+        {
+            ["hours"] = hours,
+            ["since"] = since,
+        };
+
+        var (errorRate, responseTimeMs) =
+            await GetSystemHealthMetricsAsync(cancellationToken).ConfigureAwait(false);
+        if (errorRate.HasValue)
+            metadata["errorRate"] = errorRate.Value;
+        if (responseTimeMs.HasValue)
+            metadata["responseTime"] = responseTimeMs.Value;
+
         return new ReportContent(
             Title: "System Health Report",
             Description: $"System health metrics for the last {hours} hours",
             GeneratedAt: DateTime.UtcNow,
-            Metadata: new Dictionary<string, object>(StringComparer.Ordinal)
-            {
-                ["hours"] = hours,
-                ["since"] = since,
-                ["uptime"] = hours, // System uptime in hours
-                ["errorRate"] = 0.0, // Error rate percentage (placeholder for future implementation)
-                ["responseTime"] = 0.0 // Average response time in ms (placeholder for future implementation)
-            },
+            Metadata: metadata,
             Sections: sections);
+    }
+
+    /// <summary>
+    /// Fetches the current error rate (ratio 0..1) and average response time (ms)
+    /// from Prometheus, using the same queries as <c>InfrastructureDetailsService</c>.
+    /// Returns null for a metric when Prometheus is unavailable or has no data, so
+    /// the caller can omit it rather than reporting a fabricated 0 (#3081).
+    /// </summary>
+    private async Task<(double? ErrorRate, double? ResponseTimeMs)> GetSystemHealthMetricsAsync(
+        CancellationToken cancellationToken)
+    {
+        var end = DateTime.UtcNow;
+        var start = end.AddHours(-1);
+
+        var errorRate = await QueryLatestPrometheusValueAsync(
+            "sum(rate(http_requests_total{status=~\"5..\"}[1h])) / sum(rate(http_requests_total[1h]))",
+            start, end, cancellationToken).ConfigureAwait(false);
+
+        var latencySeconds = await QueryLatestPrometheusValueAsync(
+            "avg(rate(http_request_duration_seconds_sum[1h]) / rate(http_request_duration_seconds_count[1h]))",
+            start, end, cancellationToken).ConfigureAwait(false);
+
+        return (errorRate, latencySeconds.HasValue ? latencySeconds.Value * 1000 : null);
+    }
+
+    /// <summary>
+    /// Runs a Prometheus range query and returns the most recent data point's value,
+    /// or null when there is no data or the query fails (honest degradation).
+    /// </summary>
+    private async Task<double?> QueryLatestPrometheusValueAsync(
+        string query, DateTime start, DateTime end, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var result = await _prometheusService
+                .QueryRangeAsync(query, start, end, "5m", cancellationToken)
+                .ConfigureAwait(false);
+
+            var latest = result.TimeSeries
+                .SelectMany(ts => ts.Values)
+                .OrderByDescending(v => v.Timestamp)
+                .FirstOrDefault();
+
+            return latest?.Value;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex, "Failed to query Prometheus for a system-health metric; omitting it from the report");
+            return null;
+        }
     }
 
     private async Task<UserMetrics> GetUserMetricsAsync(DateTime since, CancellationToken ct)

--- a/apps/api/src/Api/BoundedContexts/Administration/Infrastructure/Services/ReportGeneratorService.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Infrastructure/Services/ReportGeneratorService.cs
@@ -15,14 +15,17 @@ internal sealed partial class ReportGeneratorService : IReportGeneratorService
 {
     private readonly MeepleAiDbContext _dbContext;
     private readonly ILogger<ReportGeneratorService> _logger;
+    private readonly IPrometheusQueryService _prometheusService;
     private readonly Dictionary<ReportFormat, IReportFormatter> _formatters;
 
     public ReportGeneratorService(
         MeepleAiDbContext dbContext,
-        ILogger<ReportGeneratorService> logger)
+        ILogger<ReportGeneratorService> logger,
+        IPrometheusQueryService prometheusService)
     {
         _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        _prometheusService = prometheusService ?? throw new ArgumentNullException(nameof(prometheusService));
 
         // Initialize formatters
         _formatters = new Dictionary<ReportFormat, IReportFormatter>

--- a/apps/api/tests/Api.Tests/BoundedContexts/Administration/Services/ReportGeneratorServiceTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Administration/Services/ReportGeneratorServiceTests.cs
@@ -1,3 +1,4 @@
+using System.Net.Http;
 using Api.BoundedContexts.Administration.Domain.Services;
 using Api.BoundedContexts.Administration.Domain.ValueObjects;
 using Api.BoundedContexts.Administration.Infrastructure.Services;
@@ -24,13 +25,22 @@ public sealed class ReportGeneratorServiceTests : IDisposable
 {
     private readonly MeepleAiDbContext _dbContext;
     private readonly Mock<ILogger<ReportGeneratorService>> _loggerMock;
+    private readonly Mock<IPrometheusQueryService> _prometheusMock;
     private readonly ReportGeneratorService _sut;
 
     public ReportGeneratorServiceTests()
     {
         _dbContext = TestDbContextFactory.CreateInMemoryDbContext();
         _loggerMock = new Mock<ILogger<ReportGeneratorService>>();
-        _sut = new ReportGeneratorService(_dbContext, _loggerMock.Object);
+        _prometheusMock = new Mock<IPrometheusQueryService>();
+        // Default: Prometheus returns no data → health metrics are omitted from
+        // reports (unless a test sets up specific values).
+        _prometheusMock
+            .Setup(p => p.QueryRangeAsync(
+                It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(),
+                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PrometheusQueryResult("matrix", Array.Empty<PrometheusTimeSeries>()));
+        _sut = new ReportGeneratorService(_dbContext, _loggerMock.Object, _prometheusMock.Object);
     }
 
     public void Dispose()
@@ -63,13 +73,12 @@ public sealed class ReportGeneratorServiceTests : IDisposable
     }
 
     [Fact]
-    public async Task GenerateAsync_SystemHealthReport_ContainsExpectedMetrics()
+    public async Task GenerateAsync_SystemHealthReport_WithPrometheusData_ContainsRealMetrics()
     {
-        var parameters = new Dictionary<string, object>
-        {
-            ["startDate"] = DateTime.UtcNow.AddDays(-7),
-            ["endDate"] = DateTime.UtcNow
-        };
+        // Prometheus reports a 5% error rate and 0.25s (250ms) average latency.
+        SetupPrometheusMetrics(errorRateRatio: 0.05, avgLatencySeconds: 0.25);
+
+        var parameters = new Dictionary<string, object> { ["hours"] = 24 };
 
         var result = await _sut.GenerateAsync(
             ReportTemplate.SystemHealth,
@@ -78,9 +87,39 @@ public sealed class ReportGeneratorServiceTests : IDisposable
             CancellationToken.None);
 
         var content = System.Text.Encoding.UTF8.GetString(result.Content);
-        content.Should().ContainEquivalentOf("\"uptime\"");
         content.Should().ContainEquivalentOf("\"errorRate\"");
         content.Should().ContainEquivalentOf("\"responseTime\"");
+        // Real values, not the old hardcoded 0.0 placeholder.
+        content.Should().Contain("0.05");
+        content.Should().Contain("250");
+        // The fabricated "uptime" (which was just the window param) is gone.
+        content.Should().NotContainEquivalentOf("\"uptime\"");
+    }
+
+    [Fact]
+    public async Task GenerateAsync_SystemHealthReport_WhenPrometheusUnavailable_OmitsMetricsInsteadOfFabricatingZero()
+    {
+        _prometheusMock
+            .Setup(p => p.QueryRangeAsync(
+                It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(),
+                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("prometheus unavailable"));
+
+        var parameters = new Dictionary<string, object> { ["hours"] = 24 };
+
+        var result = await _sut.GenerateAsync(
+            ReportTemplate.SystemHealth,
+            ReportFormat.Json,
+            parameters,
+            CancellationToken.None);
+
+        var content = System.Text.Encoding.UTF8.GetString(result.Content);
+        // No fabricated metric keys when Prometheus is unavailable — omit, don't zero.
+        content.Should().NotContainEquivalentOf("\"errorRate\"");
+        content.Should().NotContainEquivalentOf("\"responseTime\"");
+        content.Should().NotContainEquivalentOf("\"uptime\"");
+        // The report still renders with its real section data + window metadata.
+        content.Should().ContainEquivalentOf("\"hours\"");
     }
 
     [Fact]
@@ -338,6 +377,35 @@ public sealed class ReportGeneratorServiceTests : IDisposable
             ["endDate"] = DateTime.UtcNow
         };
     }
+
+    /// <summary>
+    /// Wires the Prometheus mock so the error-rate query returns <paramref name="errorRateRatio"/>
+    /// and the latency query returns <paramref name="avgLatencySeconds"/> (seconds; the service
+    /// converts to ms). Queries are told apart by a substring of their PromQL.
+    /// </summary>
+    private void SetupPrometheusMetrics(double errorRateRatio, double avgLatencySeconds)
+    {
+        _prometheusMock
+            .Setup(p => p.QueryRangeAsync(
+                It.Is<string>(q => q.Contains("status=~", StringComparison.Ordinal)),
+                It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SingleValueResult(errorRateRatio));
+        _prometheusMock
+            .Setup(p => p.QueryRangeAsync(
+                It.Is<string>(q => q.Contains("http_request_duration_seconds", StringComparison.Ordinal)),
+                It.IsAny<DateTime>(), It.IsAny<DateTime>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SingleValueResult(avgLatencySeconds));
+    }
+
+    private static PrometheusQueryResult SingleValueResult(double value) =>
+        new PrometheusQueryResult(
+            "matrix",
+            new[]
+            {
+                new PrometheusTimeSeries(
+                    new Dictionary<string, string>(StringComparer.Ordinal),
+                    new[] { new PrometheusDataPoint(DateTime.UtcNow, value) })
+            });
 
     #endregion
 }

--- a/apps/api/tests/Api.Tests/Integration/Administration/ReportingWorkflowTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/Administration/ReportingWorkflowTests.cs
@@ -48,7 +48,13 @@ public sealed class ReportingWorkflowTests : IDisposable
         _executionRepository = new ReportExecutionRepository(_dbContext, eventCollector.Object);
 
         var loggerMock = new Mock<ILogger<ReportGeneratorService>>();
-        _reportGenerator = new ReportGeneratorService(_dbContext, loggerMock.Object);
+        var prometheusMock = new Mock<IPrometheusQueryService>();
+        prometheusMock
+            .Setup(p => p.QueryRangeAsync(
+                It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<DateTime>(),
+                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PrometheusQueryResult("matrix", Array.Empty<PrometheusTimeSeries>()));
+        _reportGenerator = new ReportGeneratorService(_dbContext, loggerMock.Object, prometheusMock.Object);
 
         _schedulerFactory = new StdSchedulerFactory();
     }


### PR DESCRIPTION
## Summary

Closes #3081. The Admin **System Health report** presented **fabricated metrics** to admins, exported into both the JSON and PDF artifacts.

## Problem

`ReportGeneratorService.SystemHealth.cs` hardcoded three metadata fields:
- `errorRate = 0.0` — literal placeholder ("for future implementation")
- `responseTime = 0.0` — literal placeholder
- `uptime = hours` — **mislabeled**: it was just the request window param, not real uptime

All three flow into admin output via `ReportContent.Metadata` → `JsonReportFormatter` + `PdfReportFormatter`. A 0% error / 0ms latency figure presented as real is worse than omitting it.

## Fix

`ReportGeneratorService` now injects **`IPrometheusQueryService`** (the typed, well-tested abstraction already used by `InfrastructureDetailsService`) and computes:
- **error rate**: `sum(rate(http_requests_total{status=~"5.."}[1h])) / sum(rate(http_requests_total[1h]))`
- **avg response time**: `avg(rate(http_request_duration_seconds_sum[1h]) / rate(http_request_duration_seconds_count[1h]))` × 1000 ms

**Honest degradation**: when Prometheus is unavailable or has no data, the metric key is **omitted** rather than reporting a fabricated `0`. The bogus `uptime` key is removed. No new DI registration (the service was already registered); no write-path change.

## Testing
- `WithPrometheusData_ContainsRealMetrics`: mocked Prometheus → `errorRate`/`responseTime` present with real values (0.05 / 250ms), no `uptime`.
- `WhenPrometheusUnavailable_OmitsMetricsInsteadOfFabricatingZero`: Prometheus throws → keys omitted, report still renders.
- Updated `ReportingWorkflowTests` call site for the new ctor. **100 reporting tests green** (unit + workflow), full backend build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)