### PR TITLE
chore(observability): #3082 P1 alert for BGG ToS SLO=0 metric

### DIFF
--- a/infra/compose.prod.yml
+++ b/infra/compose.prod.yml
@@ -227,6 +227,8 @@ services:
       - ./prometheus-rules.yml:/etc/prometheus/prometheus-rules.yml:ro
       # Issue #2470 — Wikidata SSE plane starvation alert.
       - ./prometheus/alerts/wikidata-sse.yml:/etc/prometheus/wikidata-sse.yml:ro
+      # Issue #3082 — BGG ToS-compliance SLO=0 alert.
+      - ./prometheus/alerts/bgg-tos-compliance.yml:/etc/prometheus/bgg-tos-compliance.yml:ro
       - prometheus-prod:/prometheus
     deploy:
       resources:

--- a/infra/compose.staging.yml
+++ b/infra/compose.staging.yml
@@ -334,6 +334,8 @@ services:
       - ./prometheus/alerts/runner-availability.yml:/etc/prometheus/runner-availability.yml:ro
       # Issue #2470 — Wikidata SSE plane starvation alert.
       - ./prometheus/alerts/wikidata-sse.yml:/etc/prometheus/wikidata-sse.yml:ro
+      # Issue #3082 — BGG ToS-compliance SLO=0 alert.
+      - ./prometheus/alerts/bgg-tos-compliance.yml:/etc/prometheus/bgg-tos-compliance.yml:ro
       - prometheus-staging:/prometheus
 
   alertmanager:

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -347,6 +347,8 @@ services:
       # Issue #2019 — additional rule file for self-hosted GitHub Actions
       # runner availability (referenced from prometheus.yml + prometheus.staging.yml).
       - ./prometheus/alerts/runner-availability.yml:/etc/prometheus/runner-availability.yml:ro
+      # Issue #3082 — BGG ToS-compliance SLO=0 alert (referenced from prometheus.yml rule_files).
+      - ./prometheus/alerts/bgg-tos-compliance.yml:/etc/prometheus/bgg-tos-compliance.yml:ro
       - prometheus_data:/prometheus
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "http://localhost:9090/-/healthy"]

--- a/infra/prometheus.prod.yml
+++ b/infra/prometheus.prod.yml
@@ -23,6 +23,8 @@ rule_files:
   - '/etc/prometheus/prometheus-rules.yml'
   # Issue #2470 — Wikidata SSE plane starvation alerts.
   - '/etc/prometheus/wikidata-sse.yml'
+  # Issue #3082 — BGG ToS-compliance SLO=0 alert (any nonzero render attempt = P1).
+  - '/etc/prometheus/bgg-tos-compliance.yml'
 
 scrape_configs:
   - job_name: 'prometheus'

--- a/infra/prometheus.staging.yml
+++ b/infra/prometheus.staging.yml
@@ -25,6 +25,8 @@ rule_files:
   - '/etc/prometheus/runner-availability.yml'
   # Issue #2470 — Wikidata SSE plane starvation alerts.
   - '/etc/prometheus/wikidata-sse.yml'
+  # Issue #3082 — BGG ToS-compliance SLO=0 alert (any nonzero render attempt = P1).
+  - '/etc/prometheus/bgg-tos-compliance.yml'
 
 scrape_configs:
   - job_name: 'prometheus'

--- a/infra/prometheus.yml
+++ b/infra/prometheus.yml
@@ -30,6 +30,8 @@ rule_files:
   - '/etc/prometheus/runner-availability.yml'
   # Issue #2470 — Wikidata SSE plane starvation alerts.
   - '/etc/prometheus/wikidata-sse.yml'
+  # Issue #3082 — BGG ToS-compliance SLO=0 alert (any nonzero render attempt = P1).
+  - '/etc/prometheus/bgg-tos-compliance.yml'
 
 # Scrape configurations
 scrape_configs:

--- a/infra/prometheus/alerts/bgg-tos-compliance.test.yml
+++ b/infra/prometheus/alerts/bgg-tos-compliance.test.yml
@@ -1,0 +1,42 @@
+# promtool unit tests for bgg-tos-compliance.yml (#3082).
+#
+# Run locally (Windows/Git Bash, from repo root):
+#   docker run --rm -v "$(pwd)/infra/prometheus/alerts:/work" prom/prometheus:v3.7.0 \
+#     promtool test rules /work/bgg-tos-compliance.test.yml
+#
+# There is no promtool CI gate in this repo (see recon in #3082); this file
+# documents + verifies the alert's SLO=0 behaviour on demand.
+rule_files:
+  - bgg-tos-compliance.yml
+
+evaluation_interval: 1m
+
+tests:
+  # A single render attempt (counter 0 -> 1) must fire the P1 alert with the
+  # offending FE route surfaced in the summary.
+  - interval: 1m
+    input_series:
+      - series: 'meepleai_bgg_url_attempted_render_total{path="/library"}'
+        values: '0 0 1 1 1 1'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: BggAssetRenderAttempted
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              subsystem: catalog-covers
+              path: "/library"
+            exp_annotations:
+              summary: "BGG ToS violation attempt on /library (SLO=0 P1)"
+              description: "meepleai_bgg_url_attempted_render_total incremented: a browser attempted to load an image from a banned BGG host. SLO for this metric is ZERO; any nonzero rate is a P1 ToS-compliance incident (#2123, ADR-059)."
+              runbook_url: "https://github.com/meepleAi-app/meepleai-monorepo/blob/main-dev/docs/for-developers/operations/operations-manual.md#20-catalog-covers--bgg-tos-compliance-2123"
+
+  # No attempts (counter flat at 0) must NOT fire — SLO=0 holds, no page.
+  - interval: 1m
+    input_series:
+      - series: 'meepleai_bgg_url_attempted_render_total{path="/library"}'
+        values: '0 0 0 0 0 0'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: BggAssetRenderAttempted
+        exp_alerts: []

--- a/infra/prometheus/alerts/bgg-tos-compliance.yml
+++ b/infra/prometheus/alerts/bgg-tos-compliance.yml
@@ -1,0 +1,25 @@
+# Issue #3082 — BGG ToS-compliance SLO=0 alert.
+#
+# Metric source (apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.CatalogCovers.cs):
+#   - meepleai_bgg_url_attempted_render_total (Counter<long>, label: path)
+#     SLO=0: any nonzero increment means a browser attempted to render a
+#     BGG-hosted asset (hard ban #2123 / ADR-059 §5). Every increment is a P1
+#     ToS-violation attempt; the metric is beaconed by the FE image safe-loader
+#     (apps/web/src/lib/images/safe-loader.ts) to POST /metrics/bgg-attempt.
+#
+# Routing: severity=critical hits the page-grade `critical-alerts` route in
+# alertmanager.yml (0s group_wait, immediate email rendering runbook_url).
+# `severity: P1` is NOT a routing key in this repo, so `critical` is used to page.
+groups:
+  - name: meepleai_bgg_tos_compliance_alerts
+    rules:
+      - alert: BggAssetRenderAttempted
+        expr: rate(meepleai_bgg_url_attempted_render_total[5m]) > 0
+        for: 0m
+        labels:
+          severity: critical
+          subsystem: catalog-covers
+        annotations:
+          summary: "BGG ToS violation attempt on {{ $labels.path }} (SLO=0 P1)"
+          description: "meepleai_bgg_url_attempted_render_total incremented: a browser attempted to load an image from a banned BGG host. SLO for this metric is ZERO; any nonzero rate is a P1 ToS-compliance incident (#2123, ADR-059)."
+          runbook_url: "https://github.com/meepleAi-app/meepleai-monorepo/blob/main-dev/docs/for-developers/operations/operations-manual.md#20-catalog-covers--bgg-tos-compliance-2123"


### PR DESCRIPTION
## Summary

Closes #3082. The BGG ToS-compliance guard metric `meepleai_bgg_url_attempted_render_total` (hard ban #2123 / ADR-059 §5) is emitted end-to-end and CLAUDE.md declares it **SLO=0 / P1**, but **no Prometheus alert existed anywhere in `infra/`** — a ToS-violation attempt in production incremented the counter and logged a warning but **paged no one**.

## Fix

New rule `infra/prometheus/alerts/bgg-tos-compliance.yml`:
- `expr: rate(meepleai_bgg_url_attempted_render_total[5m]) > 0`, `for: 0m` (the prescribed SLO=0 expression from the metric's own doc-comment)
- `severity: critical` — the **page-grade** alertmanager route (0s group_wait, immediate email rendering `runbook_url`). `severity: P1` is not a routing key in this repo, so `critical` is used to actually page.
- `subsystem: catalog-covers`, summary surfaces the offending FE `path`, `runbook_url` → operations-manual § 20.

## Wiring (file-by-file — this repo does not dir-mount rules)

Mirrors the `wikidata-sse.yml` precedent across all three environments:
- `rule_files:` in `prometheus.yml` / `prometheus.staging.yml` / `prometheus.prod.yml`
- compose bind mount in `docker-compose.yml` / `compose.staging.yml` / `compose.prod.yml`

## Verification

- **`promtool test rules`** on the new `bgg-tos-compliance.test.yml` → **SUCCESS**: the alert fires on a single 0→1 increment (with `severity: critical` + `path` label + rendered summary/runbook), and stays silent when the counter is flat at 0.
- All 6 touched config YAMLs + the rule parse cleanly.
- No application code change (the metric was already emitted).

Note: the repo has no promtool CI gate, so `bgg-tos-compliance.test.yml` is a runnable/documenting local check (`docker run … promtool test rules …`), not a CI gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)