### PR TITLE
fix(admin-monitor): #3092 drop hardcoded "0 crashed" from container KPI

### DIFF
--- a/apps/web/src/app/admin/(dashboard)/monitor/containers/KPISparklineStrip.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/containers/KPISparklineStrip.tsx
@@ -138,7 +138,7 @@ export function KPISparklineStrip() {
             <span className="text-sm text-muted-foreground font-semibold">/{containers.total}</span>
           </p>
           <p className="mt-1 font-mono text-[11px] text-muted-foreground">
-            ▬ {containers.stopped} stopped · 0 crashed
+            ▬ {containers.stopped} stopped
           </p>
         </article>
       )}

--- a/apps/web/src/app/admin/(dashboard)/monitor/containers/__tests__/KPISparklineStrip.test.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/containers/__tests__/KPISparklineStrip.test.tsx
@@ -61,6 +61,16 @@ describe('KPISparklineStrip', () => {
     expect(screen.getByText('/8')).toBeInTheDocument();
   });
 
+  it('shows the real stopped count and no fabricated "crashed" figure (#3092)', () => {
+    // defaultKpis has containers.stopped === 1; there is no data source for "crashed",
+    // so the card must never render a hardcoded crashed figure.
+    useInfrastructureKpisMock.mockReturnValue(makeKpis());
+    render(<KPISparklineStrip />);
+    const card = screen.getByLabelText(/Container attivi 7 su 8/);
+    expect(card).toHaveTextContent(/1 stopped/);
+    expect(card).not.toHaveTextContent(/crashed/i);
+  });
+
   it('shows CPU percentage with sparkline svg', () => {
     useInfrastructureKpisMock.mockReturnValue(makeKpis());
     render(<KPISparklineStrip />);


### PR DESCRIPTION
Closes #3092

## Cosa

La KPI "Container attivi" renderizzava un letterale **"· 0 crashed"** (`KPISparklineStrip.tsx:141`) senza alcuna sorgente dati: il hook `use-infrastructure-kpis` deriva solo `active` (`state==='running'`) e `stopped` (`total - active`), e l'`aria-label` della card non citava mai "crashed". Il numero era quindi sempre 0 a prescindere dalla realtà → dato fabbricato mostrato agli admin.

## Modifiche

- Rimosso il letterale `· 0 crashed`; il testo visibile è ora `▬ {stopped} stopped`, coerente con l'aria-label già corretto (`:130`).
- Aggiunto un test che asserisce che la card mostra lo `stopped` reale e **non** renderizza mai una figura "crashed".

## Scope / decisione

Un conteggio "crashed" *reale* richiederebbe l'exit code per container: il list endpoint Docker (`/containers/json`) espone solo `State`/`Status` (stringa "Exited (137)…"); derivarlo da `state==='dead'` sotto-conterrebbe i crash → reintrodurrebbe un dato fuorviante (stessa classe di difetto). La rimozione è il fix onesto e atomico; il conteggio reale (campo exit-code dal BE) è un **follow-up separato**.

Nota: il mockup statico `sp5-admin-infra.html:280` hardcoda "0 crashed" — è un artefatto di design, non una sorgente dati; il visual gate è stato rimosso (2026-05-20) quindi nessuna regressione visiva.

## Verifica

- ✅ `pnpm test` scoped monitor/containers: **7 file, 102 test** (KPISparklineStrip ora 17 test, incluso il nuovo discriminante)
- ✅ `pnpm typecheck`: exit 0
- ✅ `pnpm lint`: 0 errori
- ✅ pre-commit + pre-push hook verdi

---
🤖 Emersa da tech-debt discovery workflow (multi-modal sweep → verifica avversariale).

🤖 Generated with [Claude Code](https://claude.com/claude-code)