### PR TITLE
fix(rag-builder): #3083 wire block-node Configure gear to config panel

### DIFF
--- a/apps/web/src/components/rag-dashboard/builder/PipelineCanvas.tsx
+++ b/apps/web/src/components/rag-dashboard/builder/PipelineCanvas.tsx
@@ -357,6 +357,25 @@ export function PipelineCanvas({
     onNodeSelect?.(null);
   }, [onNodeSelect]);
 
+  // #3083: thread a config-open callback into each node's data so a node's
+  // "Configure" gear resolves to the same target as node selection
+  // (StrategyBuilder.handleNodeSelect → setSelectedNodeId → BlockConfigPanel).
+  const handleConfigureNode = useCallback(
+    (nodeId: string) => {
+      onNodeSelect?.(nodeId);
+    },
+    [onNodeSelect]
+  );
+
+  const nodesWithConfigure = useMemo(
+    () =>
+      nodes.map(node => ({
+        ...node,
+        data: { ...(node.data as RagNodeData), onConfigure: handleConfigureNode },
+      })),
+    [nodes, handleConfigureNode]
+  );
+
   // Toolbar actions
   const handleZoomIn = useCallback(() => {
     reactFlowInstance?.zoomIn();
@@ -377,7 +396,7 @@ export function PipelineCanvas({
       data-testid="pipeline-canvas"
     >
       <ReactFlow
-        nodes={nodes}
+        nodes={nodesWithConfigure}
         edges={edges}
         onNodesChange={handleNodesChange}
         onEdgesChange={handleEdgesChange}

--- a/apps/web/src/components/rag-dashboard/builder/RagBlockNode.tsx
+++ b/apps/web/src/components/rag-dashboard/builder/RagBlockNode.tsx
@@ -152,7 +152,7 @@ function RagBlockNodeComponent({ id, data, selected }: RagBlockNodeProps) {
   const { setNodes } = useReactFlow();
 
   const handleDelete = useCallback(() => {
-    setNodes((nodes) => nodes.filter((n) => n.id !== id));
+    setNodes(nodes => nodes.filter(n => n.id !== id));
   }, [id, setNodes]);
 
   return (
@@ -187,9 +187,10 @@ function RagBlockNodeComponent({ id, data, selected }: RagBlockNodeProps) {
                   variant="ghost"
                   size="icon"
                   className="h-6 w-6"
-                  onClick={(e) => {
+                  aria-label="Configure"
+                  onClick={e => {
                     e.stopPropagation();
-                    // TODO: Open config modal
+                    data.onConfigure?.(id);
                   }}
                 >
                   <Settings className="h-3.5 w-3.5" />
@@ -205,7 +206,7 @@ function RagBlockNodeComponent({ id, data, selected }: RagBlockNodeProps) {
                   variant="ghost"
                   size="icon"
                   className="h-6 w-6 text-destructive hover:text-destructive"
-                  onClick={(e) => {
+                  onClick={e => {
                     e.stopPropagation();
                     handleDelete();
                   }}
@@ -222,9 +223,7 @@ function RagBlockNodeComponent({ id, data, selected }: RagBlockNodeProps) {
       {/* Body */}
       <div className="px-3 py-2 space-y-2">
         {/* Description */}
-        <p className="text-xs text-muted-foreground line-clamp-2">
-          {block.description}
-        </p>
+        <p className="text-xs text-muted-foreground line-clamp-2">{block.description}</p>
 
         {/* Metrics */}
         {metrics && (

--- a/apps/web/src/components/rag-dashboard/builder/__tests__/node-config-gear.test.tsx
+++ b/apps/web/src/components/rag-dashboard/builder/__tests__/node-config-gear.test.tsx
@@ -1,0 +1,53 @@
+/**
+ * #3083 — the per-node "Configure" gear must open the config panel by invoking
+ * the `onConfigure` callback threaded into the node's data (which PipelineCanvas
+ * wires to node selection → BlockConfigPanel). Previously the gear was a no-op
+ * that also blocked the working canvas-selection path via stopPropagation.
+ *
+ * React Flow is mocked so the nodes can render standalone (no real canvas).
+ */
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@xyflow/react', () => ({
+  Handle: () => null,
+  Position: { Left: 'left', Right: 'right', Top: 'top', Bottom: 'bottom' },
+  useReactFlow: () => ({ setNodes: vi.fn() }),
+}));
+
+import { BLOCKS_BY_TYPE } from '../block-definitions';
+import { VectorSearchNode } from '../nodes';
+import { RagBlockNode } from '../RagBlockNode';
+
+import type { RagNodeData } from '../types';
+
+const SAMPLE_BLOCK = Object.values(BLOCKS_BY_TYPE)[0];
+
+function makeData(onConfigure: (nodeId: string) => void): RagNodeData {
+  return {
+    block: SAMPLE_BLOCK,
+    params: {},
+    status: 'idle',
+    onConfigure,
+  };
+}
+
+describe('node "Configure" gear (#3083)', () => {
+  it('RagBlockNode: clicking the Configure gear invokes onConfigure with the node id', () => {
+    const onConfigure = vi.fn();
+    render(<RagBlockNode id="node-a" data={makeData(onConfigure)} selected={false} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /configure/i }));
+
+    expect(onConfigure).toHaveBeenCalledWith('node-a');
+  });
+
+  it('specialized node (VectorSearch): clicking the Configure gear invokes onConfigure with the node id', () => {
+    const onConfigure = vi.fn();
+    render(<VectorSearchNode id="node-b" data={makeData(onConfigure)} selected={false} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /configure/i }));
+
+    expect(onConfigure).toHaveBeenCalledWith('node-b');
+  });
+});

--- a/apps/web/src/components/rag-dashboard/builder/nodes/BaseBlockNode.tsx
+++ b/apps/web/src/components/rag-dashboard/builder/nodes/BaseBlockNode.tsx
@@ -13,13 +13,7 @@
 import { memo, useCallback, type ReactNode } from 'react';
 
 import { Handle, Position, useReactFlow } from '@xyflow/react';
-import {
-  Settings,
-  Trash2,
-  AlertCircle,
-  CheckCircle,
-  Loader2,
-} from 'lucide-react';
+import { Settings, Trash2, AlertCircle, CheckCircle, Loader2 } from 'lucide-react';
 
 import { Badge } from '@/components/ui/data-display/badge';
 import {
@@ -31,13 +25,7 @@ import {
 import { Button } from '@/components/ui/primitives/button';
 import { cn } from '@/lib/utils';
 
-import type {
-  RagNodeData,
-  ConnectionPort,
-  NodeStatus,
-  RagBlock,
-  NodeMetrics,
-} from '../types';
+import type { RagNodeData, ConnectionPort, NodeStatus, RagBlock, NodeMetrics } from '../types';
 
 // =============================================================================
 // Types
@@ -152,10 +140,7 @@ function PortHandle({ port, isConnectable }: PortHandleProps) {
             )}
           />
         </TooltipTrigger>
-        <TooltipContent
-          side={port.position === 'left' ? 'left' : 'right'}
-          className="text-xs"
-        >
+        <TooltipContent side={port.position === 'left' ? 'left' : 'right'} className="text-xs">
           <p className="font-medium">{port.name}</p>
           <p className="text-muted-foreground">{port.dataType}</p>
         </TooltipContent>
@@ -183,12 +168,15 @@ function BaseBlockNodeComponent({
   const { setNodes } = useReactFlow();
 
   const handleDelete = useCallback(() => {
-    setNodes((nodes) => nodes.filter((n) => n.id !== id));
+    setNodes(nodes => nodes.filter(n => n.id !== id));
   }, [id, setNodes]);
 
   const handleSettings = useCallback(() => {
-    onSettingsClick?.(id);
-  }, [id, onSettingsClick]);
+    // #3083: prefer the onConfigure callback threaded via node data (wired by
+    // PipelineCanvas to node selection → config panel). onSettingsClick is a
+    // legacy prop kept for direct/standalone use.
+    (data.onConfigure ?? onSettingsClick)?.(id);
+  }, [id, data, onSettingsClick]);
 
   return (
     <div
@@ -211,9 +199,7 @@ function BaseBlockNodeComponent({
           {block.icon}
         </span>
         <div className="flex-1 min-w-0">
-          {headerContent || (
-            <p className="text-sm font-medium truncate">{block.name}</p>
-          )}
+          {headerContent || <p className="text-sm font-medium truncate">{block.name}</p>}
         </div>
         <div className="flex items-center gap-1 flex-shrink-0">
           <TooltipProvider>
@@ -223,7 +209,8 @@ function BaseBlockNodeComponent({
                   variant="ghost"
                   size="icon"
                   className="h-6 w-6"
-                  onClick={(e) => {
+                  aria-label="Configure"
+                  onClick={e => {
                     e.stopPropagation();
                     handleSettings();
                   }}
@@ -241,7 +228,7 @@ function BaseBlockNodeComponent({
                   variant="ghost"
                   size="icon"
                   className="h-6 w-6 text-destructive hover:text-destructive"
-                  onClick={(e) => {
+                  onClick={e => {
                     e.stopPropagation();
                     handleDelete();
                   }}
@@ -258,9 +245,7 @@ function BaseBlockNodeComponent({
       {/* Body */}
       <div className="px-3 py-2 space-y-2">
         {bodyContent || (
-          <p className="text-xs text-muted-foreground line-clamp-2">
-            {block.description}
-          </p>
+          <p className="text-xs text-muted-foreground line-clamp-2">{block.description}</p>
         )}
 
         {/* Metrics or Estimates */}
@@ -283,9 +268,7 @@ function BaseBlockNodeComponent({
       </div>
 
       {/* Footer */}
-      {footerContent && (
-        <div className="px-3 py-2 border-t bg-muted/30">{footerContent}</div>
-      )}
+      {footerContent && <div className="px-3 py-2 border-t bg-muted/30">{footerContent}</div>}
 
       {/* Input Ports */}
       {block.inputs.map((port: ConnectionPort) => (

--- a/apps/web/src/components/rag-dashboard/builder/types.ts
+++ b/apps/web/src/components/rag-dashboard/builder/types.ts
@@ -51,9 +51,8 @@ export type RagBlockType =
   | 'query-rewriting'
   | 'query-decomposition'
   | 'hyde'
-  | 'rag-fusion'
+  | 'rag-fusion';
   // Control (0 dedicated - uses built-in ReactFlow)
-  ;
 
 /** User tier requirements for block access */
 export type UserTier = 'User' | 'Editor' | 'Admin';
@@ -148,13 +147,13 @@ export interface ConnectionPort {
 
 /** Data types that can flow between blocks */
 export type PortDataType =
-  | 'query'      // User query string
-  | 'documents'  // Retrieved documents array
+  | 'query' // User query string
+  | 'documents' // Retrieved documents array
   | 'embeddings' // Vector embeddings
-  | 'scores'     // Relevance/confidence scores
-  | 'response'   // Generated response
+  | 'scores' // Relevance/confidence scores
+  | 'response' // Generated response
   | 'evaluation' // Evaluation result (pass/fail)
-  | 'any';       // Any type (for flexible connections)
+  | 'any'; // Any type (for flexible connections)
 
 // =============================================================================
 // Code Reference Types
@@ -247,18 +246,18 @@ export interface RagNodeData {
   params: Record<string, unknown>;
   status: NodeStatus;
   metrics?: NodeMetrics;
+  /**
+   * #3083: injected into each node's data by PipelineCanvas so a node's
+   * "Configure" gear can open the config panel (resolves to node selection →
+   * setSelectedNodeId → BlockConfigPanel). Undefined in read-only/detached use.
+   */
+  onConfigure?: (nodeId: string) => void;
   // Index signature for ReactFlow compatibility
   [key: string]: unknown;
 }
 
 /** Node execution status */
-export type NodeStatus =
-  | 'idle'
-  | 'running'
-  | 'success'
-  | 'error'
-  | 'warning'
-  | 'disabled';
+export type NodeStatus = 'idle' | 'running' | 'success' | 'error' | 'warning' | 'disabled';
 
 /** Runtime metrics for a node */
 export interface NodeMetrics {
@@ -369,9 +368,9 @@ export interface SelectionState {
 
 /** Canvas interaction mode */
 export type CanvasMode =
-  | 'select'    // Default selection mode
-  | 'pan'       // Pan only (space + drag)
-  | 'connect'   // Drawing connections
+  | 'select' // Default selection mode
+  | 'pan' // Pan only (space + drag)
+  | 'connect' // Drawing connections
   | 'readonly'; // View only
 
 /** Complete canvas state */


### PR DESCRIPTION
## Summary

Closes #3083. In the RAG strategy builder (`/admin/agents/builder`), every block node's **"Configure" gear was a dead no-op** — and actively broke config.

## Problem

`RagBlockNode` / `BaseBlockNode` gear `onClick` called `e.stopPropagation()` + a `// TODO: Open config modal`. The `stopPropagation()` also suppressed the canvas node-click that **is** the working path to open config (node selection → `setSelectedNodeId` → `BlockConfigPanel`). So the gear did nothing AND blocked the one way to configure a node — across all ~22 node types (`BaseBlockNode`'s `onSettingsClick` prop was never supplied by any caller either).

## Fix

Threads a typed `onConfigure(nodeId)` callback into each node's `data` (`RagNodeData`) from `PipelineCanvas` (via `useMemo`), resolving to `onNodeSelect` — the same target as selecting the node. The gear now calls `data.onConfigure(id)` instead of the no-op; `RagBlockNode` and all `BaseBlockNode`-based specialized nodes resolve through it. Also adds `aria-label="Configure"` to the icon-only gear (a11y + testability).

## Testing
- New `node-config-gear.test.tsx`: gear click fires `onConfigure` with the node id on both `RagBlockNode` and a specialized (`VectorSearch`) node.
- **70 builder tests green** (no regression); typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)