### PR TITLE
fix(dashboard): #3084 real session count on Recenti completed cards

### DIFF
--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/GameNights/GameNightDto.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/GameNights/GameNightDto.cs
@@ -21,6 +21,10 @@ public sealed record GameNightDto(
     int AcceptedCount,
     int PendingCount,
     int TotalInvited,
+    // #3084: number of sessions (games) played that night. A completed GameNight
+    // has >= 1 session by invariant, so the dashboard "Recenti" card never shows
+    // a misleading "0 partite".
+    int SessionCount,
     DateTimeOffset CreatedAt,
     DateTimeOffset? UpdatedAt,
     RsvpStatus? ViewerRsvpStatus = null);

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/GameNights/GameNightMapperHelper.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/GameNights/GameNightMapperHelper.cs
@@ -28,6 +28,9 @@ internal static class GameNightMapperHelper
             AcceptedCount: gameNight.AcceptedCount,
             PendingCount: gameNight.Rsvps.Count(r => r.Status == RsvpStatus.Pending),
             TotalInvited: gameNight.Rsvps.Count,
+            // #3084: the sessions collection is already eager-loaded on the read paths
+            // (e.g. GetCompletedAsync .Include(e => e.Sessions)), so this is in-memory.
+            SessionCount: gameNight.Sessions.Count,
             CreatedAt: gameNight.CreatedAt,
             UpdatedAt: gameNight.UpdatedAt,
             ViewerRsvpStatus: viewerId.HasValue ? gameNight.GetRsvp(viewerId.Value)?.Status : null);

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/GameNights/GameNightMapperHelperTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/GameNights/GameNightMapperHelperTests.cs
@@ -1,0 +1,46 @@
+using Api.BoundedContexts.GameManagement.Application.DTOs.GameNights;
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Application.GameNights;
+
+/// <summary>
+/// Tests for <see cref="GameNightMapperHelper"/> — specifically the #3084
+/// SessionCount field that drives the dashboard "Recenti" card ("N partite").
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+public class GameNightMapperHelperTests
+{
+    private static GameNightEvent CreatePublishedEvent()
+    {
+        var evt = GameNightEvent.Create(
+            Guid.NewGuid(), "Friday Night", DateTimeOffset.UtcNow.AddHours(1),
+            gameIds: [Guid.NewGuid(), Guid.NewGuid()]);
+        evt.Publish([Guid.NewGuid()]);
+        return evt;
+    }
+
+    [Fact]
+    public void MapToDto_SetsSessionCount_FromAggregateSessions()
+    {
+        var evt = CreatePublishedEvent();
+        evt.AddSession(Guid.NewGuid(), evt.GameIds[0], "Catan");
+        evt.AddSession(Guid.NewGuid(), evt.GameIds[1], "Dixit");
+
+        var dto = GameNightMapperHelper.MapToDto(evt, "Organizer");
+
+        dto.SessionCount.Should().Be(2);
+    }
+
+    [Fact]
+    public void MapToDto_SessionCountIsZero_WhenNoSessions()
+    {
+        var evt = CreatePublishedEvent();
+
+        var dto = GameNightMapperHelper.MapToDto(evt, "Organizer");
+
+        dto.SessionCount.Should().Be(0);
+    }
+}

--- a/apps/web/src/app/(authenticated)/dashboard/DashboardClient.tsx
+++ b/apps/web/src/app/(authenticated)/dashboard/DashboardClient.tsx
@@ -139,19 +139,19 @@ export function DashboardClient(): ReactElement {
 
   // ── Slot #2: Recenti (completed GameNights) ──────────────────────────────
   // F20 #1974 (audit 2026-06-07): wires the BE `/game-nights/completed`
-  // endpoint shipped alongside this PR. Projection mirrors `prossimiCards`:
-  // map the BE `GameNightDto` to the `RecentiGameNightCard` contract that
-  // `RecentiSection` expects. `sessionCount` defaults to 0 until the BE
-  // surfaces it on the DTO; mini cover thumbnails are not yet exposed
-  // server-side so we pass an empty array (the card primitive already
-  // hides the cover stack in that case).
+  // endpoint. Projection mirrors `prossimiCards`: map the BE `GameNightDto` to
+  // the `RecentiGameNightCard` contract that `RecentiSection` expects.
+  // `sessionCount` now comes from the BE DTO (#3084 — a completed night has >= 1
+  // session, so the card no longer shows a misleading "0 partite"). Mini cover
+  // thumbnails are not yet exposed server-side so we pass an empty array (the
+  // card primitive already hides the cover stack in that case).
   const recentiCards = useMemo<ReadonlyArray<RecentiGameNightCard>>(() => {
     const data = completedGNQuery.data ?? [];
     return data.slice(0, 3).map<RecentiGameNightCard>(gn => ({
       id: gn.id,
       title: gn.title,
       date: gn.scheduledAt,
-      sessionCount: 0,
+      sessionCount: gn.sessionCount,
       gamePreviewThumbnails: [],
     }));
   }, [completedGNQuery.data]);

--- a/apps/web/src/app/(authenticated)/dashboard/__tests__/DashboardClient.test.tsx
+++ b/apps/web/src/app/(authenticated)/dashboard/__tests__/DashboardClient.test.tsx
@@ -188,6 +188,43 @@ describe('DashboardClient (Asse C priority cluster)', () => {
     expect(screen.getByRole('button', { name: 'Conferma' })).toBeInTheDocument();
   });
 
+  // #3084: the Recenti card shows the real per-night session count, not a hardcoded 0.
+  it('renders the real session count on a completed GameNight ("N partite")', async () => {
+    const useCompletedMock = vi.mocked(
+      await import('@/hooks/queries/useGameNights')
+    ).useCompletedGameNights;
+    useCompletedMock.mockReturnValue({
+      data: [
+        {
+          id: '00000000-0000-0000-0000-000000000077',
+          organizerId: '00000000-0000-0000-0000-0000000000aa',
+          organizerName: 'Marco',
+          title: 'Serata conclusa',
+          description: null,
+          scheduledAt: '2024-01-01T20:00:00Z',
+          location: null,
+          maxPlayers: null,
+          gameIds: [],
+          status: 'Completed' as const,
+          acceptedCount: 3,
+          pendingCount: 0,
+          totalInvited: 3,
+          sessionCount: 3,
+          createdAt: '2024-01-01T00:00:00Z',
+          updatedAt: null,
+          viewerRsvpStatus: null,
+        },
+      ],
+      isLoading: false,
+      isError: false,
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof useCompletedMock>);
+
+    render(<DashboardClient />);
+
+    expect(screen.getByText('3 partite')).toBeInTheDocument();
+  });
+
   it('renders priority sections container with flex-column layout', () => {
     const { container } = render(<DashboardClient />);
     const grid = container.querySelector('[data-slot="dashboard-priority-sections"]');

--- a/apps/web/src/lib/api/schemas/game-nights.schemas.ts
+++ b/apps/web/src/lib/api/schemas/game-nights.schemas.ts
@@ -46,6 +46,10 @@ export const GameNightDtoSchema = z.object({
   acceptedCount: z.number(),
   pendingCount: z.number(),
   totalInvited: z.number(),
+  // #3084: number of sessions (games) played that night; drives the dashboard
+  // "Recenti" card ("N partite"). Defaults to 0 defensively so an older BE payload
+  // without the field never crashes the parse.
+  sessionCount: z.number().int().nonnegative().default(0),
   createdAt: z.string(),
   updatedAt: z.string().nullable().optional(),
   // #2989 inv#17: the viewer's RSVP status for this night (null if organizer/not-invited).


### PR DESCRIPTION
## Summary

Closes #3084. On `/dashboard`, the **"Recenti" completed-GameNight cards always rendered "0 partite"**.

## Problem

`DashboardClient` hardcoded `sessionCount: 0` in the `recentiCards` projection, and the completed-game-nights `GameNightDto` had no session count. A completed GameNight has **≥ 1 session by invariant**, so "0 partite" was always factually wrong.

## Fix

**Backend**: `GameNightDto` gains `SessionCount`; `GameNightMapperHelper.MapToDto` sets it from `gameNight.Sessions.Count`. The sessions collection is **already eager-loaded** on the completed-list read path (`GetCompletedAsync` does `.Include(e => e.Sessions)`), so this is an **in-memory count with no new query**.

**Frontend**: `GameNightDtoSchema` gains `sessionCount` (defensive `.default(0)` so an older payload never crashes the parse); the `DashboardClient` projection maps `gn.sessionCount` instead of the hardcoded `0`. `RecentiSection` already renders the pluralized "N partite" / "1 partita".

**Scope note**: the sibling `gamePreviewThumbnails: []` is a deliberate graceful-hide (the card hides the cover stack when empty), left untouched per the issue.

## Testing
- **BE** (`GameNightMapperHelperTests`): `SessionCount` = N from N sessions, and 0 when none.
- **FE** (`DashboardClient.test.tsx`): renders "3 partite" for a completed night with `sessionCount: 3`.
- Full backend build green (`new GameNightDto(` has a single call site — verified), FE typecheck + lint clean, 26 dashboard/section tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)