### PR TITLE
fix(game-management): #3096 throw 409 for orphaned-PDF RuleSpec instead of Guid.Empty

### DIFF
--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GenerateRuleSpecFromPdfCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GenerateRuleSpecFromPdfCommandHandler.cs
@@ -60,13 +60,24 @@ internal class GenerateRuleSpecFromPdfCommandHandler : ICommandHandler<GenerateR
             atoms.Add(_parsingService.CreateRuleAtom(rules[index], index + 1));
         }
 
+        // A RuleSpec is always game-scoped. When the PDF is not linked to any game
+        // (both PrivateGameId and SharedGameId are null) we must not fabricate a
+        // Guid.Empty GameId — surface a 409 so the caller links the PDF to a game
+        // before generating a RuleSpec (#3096).
+        var gameId = pdf.PrivateGameId ?? pdf.SharedGameId;
+        if (gameId is null)
+        {
+            throw new ConflictException(
+                $"PDF document {command.PdfDocumentId} is not linked to a game; link it to a game before generating a RuleSpec.");
+        }
+
         // Generate version
         var timestamp = _timeProvider.GetUtcNow().UtcDateTime;
         var version = $"ingest-{timestamp:yyyyMMddHHmmss}";
 
         return new RuleSpecDto(
             Id: Guid.NewGuid(), // Temporary - will be assigned by DB
-            GameId: pdf.PrivateGameId ?? pdf.SharedGameId ?? Guid.Empty,
+            GameId: gameId.Value,
             Version: version,
             CreatedAt: timestamp,
             CreatedByUserId: null,

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Commands/GenerateRuleSpecFromPdfCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Commands/GenerateRuleSpecFromPdfCommandHandlerTests.cs
@@ -1,0 +1,101 @@
+using Api.BoundedContexts.GameManagement.Application.Commands;
+using Api.BoundedContexts.GameManagement.Domain.Services;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Application.Services;
+using Api.Tests.Constants;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Application.Commands;
+
+/// <summary>
+/// Unit tests for GenerateRuleSpecFromPdfCommandHandler.
+/// Issue #3096: an orphaned PDF (not linked to any game) must surface a 409 instead of
+/// fabricating a RuleSpec with GameId = Guid.Empty.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "GameManagement")]
+public class GenerateRuleSpecFromPdfCommandHandlerTests
+{
+    private readonly MeepleAiDbContext _db;
+    private readonly GenerateRuleSpecFromPdfCommandHandler _handler;
+
+    public GenerateRuleSpecFromPdfCommandHandlerTests()
+    {
+        var options = new DbContextOptionsBuilder<MeepleAiDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+        _db = new MeepleAiDbContext(options, new Mock<IMediator>().Object, new Mock<IDomainEventCollector>().Object);
+        _handler = new GenerateRuleSpecFromPdfCommandHandler(
+            _db, new RuleAtomParsingDomainService(), TimeProvider.System);
+    }
+
+    private PdfDocumentEntity SeedPdf(Guid? privateGameId, Guid? sharedGameId)
+    {
+        var pdf = new PdfDocumentEntity
+        {
+            Id = Guid.NewGuid(),
+            PrivateGameId = privateGameId,
+            SharedGameId = sharedGameId,
+            FileName = "Rules.pdf",
+            FilePath = "/tmp/rules.pdf",
+            FileSizeBytes = 1000,
+            UploadedByUserId = Guid.NewGuid(),
+            UploadedAt = DateTime.UtcNow,
+            AtomicRules = "[\"Rule one\", \"Rule two\"]"
+        };
+        _db.PdfDocuments.Add(pdf);
+        return pdf;
+    }
+
+    [Fact]
+    public async Task Handle_WhenPdfLinkedToPrivateGame_ReturnsRuleSpecWithThatGameId()
+    {
+        var gameId = Guid.NewGuid();
+        var pdf = SeedPdf(privateGameId: gameId, sharedGameId: null);
+        await _db.SaveChangesAsync();
+
+        var result = await _handler.Handle(new GenerateRuleSpecFromPdfCommand(pdf.Id), CancellationToken.None);
+
+        result.GameId.Should().Be(gameId);
+        result.Atoms.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task Handle_WhenPdfLinkedOnlyToSharedGame_FallsBackToSharedGameId()
+    {
+        var sharedGameId = Guid.NewGuid();
+        var pdf = SeedPdf(privateGameId: null, sharedGameId: sharedGameId);
+        await _db.SaveChangesAsync();
+
+        var result = await _handler.Handle(new GenerateRuleSpecFromPdfCommand(pdf.Id), CancellationToken.None);
+
+        result.GameId.Should().Be(sharedGameId);
+    }
+
+    [Fact]
+    public async Task Handle_WhenPdfNotLinkedToAnyGame_ThrowsConflictInsteadOfFabricatingEmptyGuid()
+    {
+        // Regression for #3096: previously this fell back to `?? Guid.Empty` and returned a
+        // RuleSpec claiming to belong to the empty game.
+        var pdf = SeedPdf(privateGameId: null, sharedGameId: null);
+        await _db.SaveChangesAsync();
+
+        var act = () => _handler.Handle(new GenerateRuleSpecFromPdfCommand(pdf.Id), CancellationToken.None);
+
+        await act.Should().ThrowAsync<ConflictException>();
+    }
+
+    [Fact]
+    public async Task Handle_WhenPdfDoesNotExist_ThrowsNotFound()
+    {
+        var act = () => _handler.Handle(new GenerateRuleSpecFromPdfCommand(Guid.NewGuid()), CancellationToken.None);
+
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+}


### PR DESCRIPTION
Closes #3096

## Cosa

`GenerateRuleSpecFromPdfCommandHandler` risolveva il `GameId` del RuleSpec generato con `pdf.PrivateGameId ?? pdf.SharedGameId ?? Guid.Empty`. Entrambe le colonne sono nullable e nessun guard impone il link a un game → un PDF orfano faceva ritornare all'endpoint (`Results.Json`) un RuleSpec che dichiarava di appartenere al **game vuoto** (`00000000-…`), un valore sentinella fabbricato in una response API servita ad admin/editor.

## Modifiche

- Risolvo `gameId = PrivateGameId ?? SharedGameId`; se `null`, lancio `ConflictException` (409 via `ApiExceptionHandlerMiddleware`) che dice al chiamante di linkare il PDF a un game, invece di fabbricare `Guid.Empty`.
- Aggiunto `GenerateRuleSpecFromPdfCommandHandlerTests` (il handler era **senza copertura**): happy path private-game, fallback shared-game, orphan → `ConflictException`, PDF mancante → `NotFoundException`.

## Cambio di comportamento

Per un PDF orfano, l'endpoint `HandleGenerateRuleSpec` passa da `200 + RuleSpec{GameId=Guid.Empty}` a `409 Conflict` con messaggio. È il comportamento corretto (dato non fabbricato; l'admin deve linkare il PDF prima). L'endpoint è admin/editor-only; il caso orfano è raro. La middleware globale già gestiva `NotFoundException` dallo stesso handler (stesso path di propagazione, non intercettato dal `catch (InvalidOperationException)` dell'endpoint).

## Verifica

- ✅ `dotnet test --filter GenerateRuleSpecFromPdfCommandHandlerTests`: **4/4 pass**, build clean
- ✅ pre-commit + pre-push (backend build) verdi

---
🤖 Emersa da tech-debt discovery workflow (multi-modal sweep → verifica avversariale).

🤖 Generated with [Claude Code](https://claude.com/claude-code)