### PR TITLE
fix(admin-reports): #3104 report distinct active users instead of registrations

### DIFF
--- a/apps/api/src/Api/BoundedContexts/Administration/Infrastructure/Services/ReportGeneratorService.UserActivity.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Infrastructure/Services/ReportGeneratorService.UserActivity.cs
@@ -132,6 +132,16 @@ internal sealed partial class ReportGeneratorService
         var totalRegistrations = registrations.Sum(r => r.Count);
         var totalLogins = logins.Sum(l => l.Count);
 
+        // Active users = distinct users with >=1 session (login) in the period — NOT the
+        // count of new registrations (the previous value was semantically wrong). UserSession.UserId
+        // is non-nullable, so every session maps to a user (#3104).
+        var activeUsers = await _dbContext.UserSessions
+            .Where(s => s.CreatedAt >= startDate && s.CreatedAt <= endDate)
+            .Select(s => s.UserId)
+            .Distinct()
+            .CountAsync(cancellationToken)
+            .ConfigureAwait(false);
+
         return new ReportContent(
             Title: "User Activity Report",
             Description: $"User engagement from {startDate:yyyy-MM-dd} to {endDate:yyyy-MM-dd}",
@@ -143,7 +153,7 @@ internal sealed partial class ReportGeneratorService
                 ["endDate"] = endDate,
                 ["totalRegistrations"] = totalRegistrations,
                 ["totalLogins"] = totalLogins,
-                ["activeUsers"] = totalRegistrations // Active users count (new registrations in period)
+                ["activeUsers"] = activeUsers
             },
             Sections: sections);
     }

--- a/apps/api/tests/Api.Tests/BoundedContexts/Administration/Services/ReportGeneratorServiceTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Administration/Services/ReportGeneratorServiceTests.cs
@@ -3,6 +3,7 @@ using Api.BoundedContexts.Administration.Domain.Services;
 using Api.BoundedContexts.Administration.Domain.ValueObjects;
 using Api.BoundedContexts.Administration.Infrastructure.Services;
 using Api.Infrastructure;
+using Api.Infrastructure.Entities;
 using Api.SharedKernel.Application.Services;
 using Api.SharedKernel.Domain.Events;
 using Api.Tests.TestHelpers;
@@ -141,6 +142,48 @@ public sealed class ReportGeneratorServiceTests : IDisposable
         content.Should().ContainEquivalentOf("\"activeUsers\"");
         content.Should().ContainEquivalentOf("\"totalLogins\"");
     }
+
+    [Fact]
+    public async Task GenerateAsync_UserActivityReport_ActiveUsers_CountsDistinctSessionUsers_NotRegistrations()
+    {
+        // #3104: "active users" must be the count of DISTINCT users with >=1 session in the
+        // window, NOT the number of new registrations. Seed 3 sessions from 2 distinct users
+        // and ZERO registrations in the window: the old code reported activeUsers = registrations = 0;
+        // the correct value is 2.
+        var now = DateTime.UtcNow;
+        var startDate = now.AddDays(-30);
+        var endDate = now.AddDays(1);
+
+        var userA = Guid.NewGuid();
+        var userB = Guid.NewGuid();
+        _dbContext.UserSessions.AddRange(
+            NewSession(userA, now.AddDays(-5)),
+            NewSession(userA, now.AddDays(-3)),
+            NewSession(userB, now.AddDays(-2)));
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _sut.GenerateAsync(
+            ReportTemplate.UserActivity,
+            ReportFormat.Json,
+            new Dictionary<string, object> { ["startDate"] = startDate, ["endDate"] = endDate },
+            CancellationToken.None);
+
+        var content = System.Text.Encoding.UTF8.GetString(result.Content);
+        using var doc = System.Text.Json.JsonDocument.Parse(content);
+        var metadata = doc.RootElement.GetProperty("metadata");
+        metadata.GetProperty("activeUsers").GetInt32().Should().Be(2);
+        metadata.GetProperty("totalRegistrations").GetInt32().Should().Be(0);
+    }
+
+    private static UserSessionEntity NewSession(Guid userId, DateTime createdAt) => new()
+    {
+        Id = Guid.NewGuid(),
+        UserId = userId,
+        TokenHash = Guid.NewGuid().ToString(),
+        CreatedAt = createdAt,
+        ExpiresAt = createdAt.AddHours(1),
+        User = null!
+    };
 
     [Fact]
     public async Task GenerateAsync_AIUsageReport_ContainsCostMetrics()


### PR DESCRIPTION
Closes #3104

## Cosa

`ReportGeneratorService.UserActivity` impostava `activeUsers` nella metadata del report a `totalRegistrations` (le nuove registrazioni del periodo) — un valore auto-contraddittorio ("Active users count (new registrations in period)") mostrato agli admin nel JSON/PDF esportato. Utenti attivi ≠ nuove registrazioni.

## Modifiche

- Calcolo `activeUsers` come conteggio degli **utenti distinti** con ≥1 `UserSession` (login) nel periodo (`UserSession.UserId` è non-nullable). Il handler già interroga `UserSessions` per la serie di login → nessuna nuova sorgente dati.
- Test discriminante: 3 sessioni da 2 utenti distinti + 0 registrazioni nel periodo → il report riporta `activeUsers=2` (il codice vecchio riportava 0). Il test esistente di presenza chiave continua a passare.

## Nota di scope

Il conteggio usa tutte le `UserSessions` (coerente con le serie "Logins"/"Sessions" dello stesso report). Le sessioni di impersonation (rare, feature admin) contano il subject come attivo — coerente con la serie login esistente; escluderle sarebbe un refinement separato (che toccherebbe anche logins/sessions per coerenza). In ogni caso vastamente meglio di "= registrazioni".

## Verifica

- ✅ `dotnet test --filter ReportGeneratorServiceTests`: **80/80 pass** (nuovo discriminante + esistenti + i test SystemHealth di #3081), build clean
- ✅ pre-commit + pre-push (backend build) verdi

---
🤖 Emersa da tech-debt discovery workflow (multi-modal sweep → verifica avversariale).

🤖 Generated with [Claude Code](https://claude.com/claude-code)