### PR TITLE
fix(shared-games): #3099 throw 409 ConflictException for duplicate BGG ID

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/CreateSharedGameCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/CreateSharedGameCommandHandler.cs
@@ -1,6 +1,7 @@
 using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Application.Interfaces;
 using Api.SharedKernel.Infrastructure.Persistence;
 
@@ -39,7 +40,7 @@ internal sealed class CreateSharedGameCommandHandler : ICommandHandler<CreateSha
             var exists = await _repository.ExistsByBggIdAsync(command.BggId.Value, cancellationToken).ConfigureAwait(false);
             if (exists)
             {
-                throw new InvalidOperationException($"A game with BGG ID {command.BggId.Value} already exists in the catalog");
+                throw new ConflictException($"A game with BGG ID {command.BggId.Value} already exists in the catalog");
             }
         }
 

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/ImportGameFromBggCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/ImportGameFromBggCommandHandler.cs
@@ -3,6 +3,7 @@ using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using Api.BoundedContexts.SharedGameCatalog.Domain.ValueObjects;
 using Api.Infrastructure;
 using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Middleware.Exceptions;
 using Api.Services;
 using Api.SharedKernel.Application.Interfaces;
 using Api.SharedKernel.Infrastructure.Persistence;
@@ -51,7 +52,7 @@ internal sealed class ImportGameFromBggCommandHandler : ICommandHandler<ImportGa
         var exists = await _repository.ExistsByBggIdAsync(command.BggId, cancellationToken).ConfigureAwait(false);
         if (exists)
         {
-            throw new InvalidOperationException($"A game with BGG ID {command.BggId} already exists in the catalog");
+            throw new ConflictException($"A game with BGG ID {command.BggId} already exists in the catalog");
         }
 
         // Fetch game details from BGG API

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/CreateSharedGameCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/CreateSharedGameCommandHandlerTests.cs
@@ -2,6 +2,7 @@ using Api.BoundedContexts.SharedGameCatalog.Application;
 using Api.BoundedContexts.SharedGameCatalog.Application.Commands;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Infrastructure.Persistence;
 using Api.Tests.Constants;
 using Microsoft.Extensions.Logging;
@@ -82,7 +83,7 @@ public class CreateSharedGameCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_WithDuplicateBggId_ThrowsInvalidOperationException()
+    public async Task Handle_WithDuplicateBggId_ThrowsConflictException()
     {
         // Arrange
         var command = new CreateSharedGameCommand(
@@ -108,7 +109,8 @@ public class CreateSharedGameCommandHandlerTests
         // Act & Assert
         var act = () =>
             _handler.Handle(command, TestContext.Current.CancellationToken);
-        await act.Should().ThrowAsync<InvalidOperationException>();
+        await act.Should().ThrowAsync<ConflictException>()
+            .WithMessage("*already exists in the catalog*");
 
         _repositoryMock.Verify(
             r => r.AddAsync(It.IsAny<SharedGame>(), It.IsAny<CancellationToken>()),

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/ImportGameFromBggCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Handlers/ImportGameFromBggCommandHandlerTests.cs
@@ -1,0 +1,88 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Commands;
+using Api.Infrastructure;
+using Api.Middleware.Exceptions;
+using Api.Services;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Application.Services;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Tests.Constants;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Handlers;
+
+/// <summary>
+/// Unit tests for <see cref="ImportGameFromBggCommandHandler"/>.
+/// Issue #3099: duplicate BGG ID must surface as 409 Conflict (ConflictException),
+/// not a fabricated 500 via InvalidOperationException.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+[Trait("Issue", "3099")]
+public sealed class ImportGameFromBggCommandHandlerTests : IDisposable
+{
+    private readonly Mock<ISharedGameRepository> _repositoryMock;
+    private readonly Mock<IUnitOfWork> _unitOfWorkMock;
+    private readonly Mock<IBggApiService> _bggApiServiceMock;
+    private readonly MeepleAiDbContext _dbContext;
+    private readonly Mock<ILogger<ImportGameFromBggCommandHandler>> _loggerMock;
+    private readonly ImportGameFromBggCommandHandler _handler;
+
+    public ImportGameFromBggCommandHandlerTests()
+    {
+        _repositoryMock = new Mock<ISharedGameRepository>();
+        _unitOfWorkMock = new Mock<IUnitOfWork>();
+        _bggApiServiceMock = new Mock<IBggApiService>();
+        _loggerMock = new Mock<ILogger<ImportGameFromBggCommandHandler>>();
+
+        var options = new DbContextOptionsBuilder<MeepleAiDbContext>()
+            .UseInMemoryDatabase(databaseName: $"ImportBggTests_{Guid.NewGuid()}")
+            .Options;
+
+        _dbContext = new MeepleAiDbContext(
+            options,
+            new Mock<IMediator>().Object,
+            new Mock<IDomainEventCollector>().Object);
+
+        _handler = new ImportGameFromBggCommandHandler(
+            _repositoryMock.Object,
+            _unitOfWorkMock.Object,
+            _bggApiServiceMock.Object,
+            _dbContext,
+            _loggerMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_WithDuplicateBggId_ThrowsConflictException()
+    {
+        // Arrange
+        var command = new ImportGameFromBggCommand(BggId: 13, UserId: Guid.NewGuid());
+
+        _repositoryMock
+            .Setup(r => r.ExistsByBggIdAsync(13, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        // Act & Assert
+        var act = () => _handler.Handle(command, TestContext.Current.CancellationToken);
+        await act.Should().ThrowAsync<ConflictException>()
+            .WithMessage("*already exists in the catalog*");
+
+        // The conflict must short-circuit before any BGG API call or persistence.
+        _bggApiServiceMock.Verify(
+            s => s.GetGameDetailsAsync(It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _repositoryMock.Verify(
+            r => r.AddAsync(It.IsAny<Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates.SharedGame>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    public void Dispose()
+    {
+        _dbContext.Dispose();
+    }
+}


### PR DESCRIPTION
## Summary

Closes #3099.

`CreateSharedGameCommandHandler` e `ImportGameFromBggCommandHandler` lanciavano `InvalidOperationException` per BGG ID duplicato. Il middleware globale (`ApiExceptionHandlerMiddleware:452`) mappa `InvalidOperationException` a 404 **solo** se il messaggio contiene `"not found"`; il messaggio `"...already exists in the catalog"` cadeva quindi nel fallback **500 Internal Server Error** (`:464`).

Tutte e 3 le call-site (`SharedGameCatalogAdminEndpoints` create `:551` + import `:800`, `AdminGameImportWizardEndpoints` confirm `:184`) fanno `Send` → `Results.Created` **senza try/catch** → l'admin/editor riceveva un 500 opaco invece di un 409 actionable. Viola la convenzione #2568.

## Change

Entrambi gli handler lanciano ora `ConflictException` (deriva da `HttpException` → **409 Conflict**).

## Test (TDD)

- `CreateSharedGameCommandHandlerTests` — test duplicato aggiornato: ora aspetta `ConflictException` (RED → GREEN verificato)
- `ImportGameFromBggCommandHandlerTests` (**nuovo**) — copre lo short-circuit del conflict (BGG API + persistence mai invocati)
- 7/7 test verdi nel cluster

## Review avversariale

Verificato che i molti `catch (InvalidOperationException)` in `SharedGameCatalogAdminEndpoints` sono in *altri* handler (update/delete/approve), NON nelle 3 call-site del duplicato BGG → nessun catch reso morto, premessa 500 confermata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)