### PR TITLE
fix(kb): #3100 GetTestResults totalCount reflects real total, not page size

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetTestResultsQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetTestResultsQueryHandler.cs
@@ -47,7 +47,9 @@ internal sealed class GetTestResultsQueryHandler : IRequestHandler<GetTestResult
                 request.Skip,
                 request.Take,
                 cancellationToken).ConfigureAwait(false);
-            totalCount = results.Count; // Simplified for now
+            totalCount = await _testResultRepository.GetSavedCountAsync(
+                request.ExecutedBy,
+                cancellationToken).ConfigureAwait(false);
         }
         else if (request.TypologyId.HasValue)
         {
@@ -67,7 +69,9 @@ internal sealed class GetTestResultsQueryHandler : IRequestHandler<GetTestResult
                 request.Skip,
                 request.Take,
                 cancellationToken).ConfigureAwait(false);
-            totalCount = results.Count; // Simplified for now
+            totalCount = await _testResultRepository.GetCountByExecutedByAsync(
+                request.ExecutedBy.Value,
+                cancellationToken).ConfigureAwait(false);
         }
         else if (request.From.HasValue && request.To.HasValue)
         {
@@ -77,7 +81,10 @@ internal sealed class GetTestResultsQueryHandler : IRequestHandler<GetTestResult
                 request.Skip,
                 request.Take,
                 cancellationToken).ConfigureAwait(false);
-            totalCount = results.Count; // Simplified for now
+            totalCount = await _testResultRepository.GetCountByDateRangeAsync(
+                request.From.Value,
+                request.To.Value,
+                cancellationToken).ConfigureAwait(false);
         }
         else
         {

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Repositories/IAgentTestResultRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Repositories/IAgentTestResultRepository.cs
@@ -56,6 +56,24 @@ internal interface IAgentTestResultRepository
     Task<int> GetCountByTypologyIdAsync(Guid typologyId, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Gets the total count of saved/favorited test results, optionally scoped to a user.
+    /// Mirrors the predicate of <see cref="GetSavedAsync"/>.
+    /// </summary>
+    Task<int> GetSavedCountAsync(Guid? userId = null, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the total count of test results executed by a specific user.
+    /// Mirrors the predicate of <see cref="GetByExecutedByAsync"/>.
+    /// </summary>
+    Task<int> GetCountByExecutedByAsync(Guid userId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets the total count of test results within a date range.
+    /// Mirrors the predicate of <see cref="GetByDateRangeAsync"/>.
+    /// </summary>
+    Task<int> GetCountByDateRangeAsync(DateTime from, DateTime to, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Adds a new test result.
     /// </summary>
     Task AddAsync(AgentTestResult testResult, CancellationToken cancellationToken = default);

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/Persistence/AgentTestResultRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/Persistence/AgentTestResultRepository.cs
@@ -110,6 +110,31 @@ internal class AgentTestResultRepository : RepositoryBase, IAgentTestResultRepos
             .CountAsync(r => r.TypologyId == typologyId, cancellationToken).ConfigureAwait(false);
     }
 
+    public async Task<int> GetSavedCountAsync(Guid? userId = null, CancellationToken cancellationToken = default)
+    {
+        var query = DbContext.Set<AgentTestResultEntity>()
+            .Where(r => r.IsSaved);
+
+        if (userId.HasValue)
+        {
+            query = query.Where(r => r.ExecutedBy == userId.Value);
+        }
+
+        return await query.CountAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<int> GetCountByExecutedByAsync(Guid userId, CancellationToken cancellationToken = default)
+    {
+        return await DbContext.Set<AgentTestResultEntity>()
+            .CountAsync(r => r.ExecutedBy == userId, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<int> GetCountByDateRangeAsync(DateTime from, DateTime to, CancellationToken cancellationToken = default)
+    {
+        return await DbContext.Set<AgentTestResultEntity>()
+            .CountAsync(r => r.ExecutedAt >= from && r.ExecutedAt <= to, cancellationToken).ConfigureAwait(false);
+    }
+
     public async Task AddAsync(AgentTestResult testResult, CancellationToken cancellationToken = default)
     {
         CollectDomainEvents(testResult);

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetTestResultsQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/GetTestResultsQueryHandlerTests.cs
@@ -1,0 +1,147 @@
+using Api.BoundedContexts.KnowledgeBase.Application.Queries;
+using Api.BoundedContexts.KnowledgeBase.Domain.Entities;
+using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Queries;
+
+/// <summary>
+/// Unit tests for <see cref="GetTestResultsQueryHandler"/>.
+/// Issue #3100: totalCount must reflect the real total count, not the current page size.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "KnowledgeBase")]
+[Trait("Issue", "3100")]
+public sealed class GetTestResultsQueryHandlerTests
+{
+    private readonly Mock<IAgentTestResultRepository> _repositoryMock;
+    private readonly GetTestResultsQueryHandler _handler;
+
+    // The mocked page always returns fewer rows than the true total,
+    // so a handler that (wrongly) uses results.Count would report `PageSize`, not `TrueTotal`.
+    private const int PageSize = 2;
+    private const int TrueTotal = 25;
+
+    public GetTestResultsQueryHandlerTests()
+    {
+        _repositoryMock = new Mock<IAgentTestResultRepository>();
+        _handler = new GetTestResultsQueryHandler(
+            _repositoryMock.Object,
+            new Mock<ILogger<GetTestResultsQueryHandler>>().Object);
+    }
+
+    private static List<AgentTestResult> Page(int count)
+    {
+        var list = new List<AgentTestResult>(count);
+        for (var i = 0; i < count; i++)
+        {
+            list.Add(AgentTestResult.Create(
+                typologyId: Guid.NewGuid(),
+                query: $"q{i}",
+                response: $"r{i}",
+                modelUsed: "gpt-test",
+                confidenceScore: 0.9,
+                tokensUsed: 100,
+                costEstimate: 0.01m,
+                latencyMs: 50,
+                executedBy: Guid.NewGuid()));
+        }
+
+        return list;
+    }
+
+    [Fact]
+    public async Task Handle_SavedOnly_TotalCountReflectsRepositoryCountNotPageSize()
+    {
+        // Arrange
+        var executedBy = Guid.NewGuid();
+        var query = new GetTestResultsQuery(SavedOnly: true, ExecutedBy: executedBy, Skip: 0, Take: PageSize);
+
+        _repositoryMock
+            .Setup(r => r.GetSavedAsync(executedBy, 0, PageSize, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Page(PageSize));
+        _repositoryMock
+            .Setup(r => r.GetSavedCountAsync(executedBy, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(TrueTotal);
+
+        // Act
+        var result = await _handler.Handle(query, TestContext.Current.CancellationToken);
+
+        // Assert
+        result.Results.Should().HaveCount(PageSize);
+        result.TotalCount.Should().Be(TrueTotal);
+        _repositoryMock.Verify(r => r.GetSavedCountAsync(executedBy, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ExecutedBy_TotalCountReflectsRepositoryCountNotPageSize()
+    {
+        // Arrange
+        var executedBy = Guid.NewGuid();
+        var query = new GetTestResultsQuery(ExecutedBy: executedBy, Skip: 0, Take: PageSize);
+
+        _repositoryMock
+            .Setup(r => r.GetByExecutedByAsync(executedBy, 0, PageSize, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Page(PageSize));
+        _repositoryMock
+            .Setup(r => r.GetCountByExecutedByAsync(executedBy, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(TrueTotal);
+
+        // Act
+        var result = await _handler.Handle(query, TestContext.Current.CancellationToken);
+
+        // Assert
+        result.Results.Should().HaveCount(PageSize);
+        result.TotalCount.Should().Be(TrueTotal);
+        _repositoryMock.Verify(r => r.GetCountByExecutedByAsync(executedBy, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_DateRange_TotalCountReflectsRepositoryCountNotPageSize()
+    {
+        // Arrange
+        var from = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var to = new DateTime(2026, 12, 31, 0, 0, 0, DateTimeKind.Utc);
+        var query = new GetTestResultsQuery(From: from, To: to, Skip: 0, Take: PageSize);
+
+        _repositoryMock
+            .Setup(r => r.GetByDateRangeAsync(from, to, 0, PageSize, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Page(PageSize));
+        _repositoryMock
+            .Setup(r => r.GetCountByDateRangeAsync(from, to, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(TrueTotal);
+
+        // Act
+        var result = await _handler.Handle(query, TestContext.Current.CancellationToken);
+
+        // Assert
+        result.Results.Should().HaveCount(PageSize);
+        result.TotalCount.Should().Be(TrueTotal);
+        _repositoryMock.Verify(r => r.GetCountByDateRangeAsync(from, to, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_TypologyId_TotalCountReflectsRepositoryCount()
+    {
+        // Arrange (regression guard: this branch already used the count method)
+        var typologyId = Guid.NewGuid();
+        var query = new GetTestResultsQuery(TypologyId: typologyId, Skip: 0, Take: PageSize);
+
+        _repositoryMock
+            .Setup(r => r.GetByTypologyIdAsync(typologyId, 0, PageSize, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Page(PageSize));
+        _repositoryMock
+            .Setup(r => r.GetCountByTypologyIdAsync(typologyId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(TrueTotal);
+
+        // Act
+        var result = await _handler.Handle(query, TestContext.Current.CancellationToken);
+
+        // Assert
+        result.TotalCount.Should().Be(TrueTotal);
+    }
+}


### PR DESCRIPTION
## Summary

Closes #3100.

`GetTestResultsQueryHandler` calcolava `totalCount` come `results.Count` (la pagina corrente, limitata da `Take`) nei rami **SavedOnly / ExecutedBy / DateRange** — solo il ramo `TypologyId` usava una vera query di conteggio. Un dataset più grande della pagina riportava quindi **una sola pagina**, rendendo le pagine successive irraggiungibili nella UI admin.

## Change

Aggiunti 3 metodi count a `IAgentTestResultRepository` / `AgentTestResultRepository`, con predicati che **rispecchiano** i rispettivi query-method:
- `GetSavedCountAsync(Guid? userId)` → `IsSaved` [+ `ExecutedBy`], come `GetSavedAsync`
- `GetCountByExecutedByAsync(Guid userId)` → `ExecutedBy`, come `GetByExecutedByAsync`
- `GetCountByDateRangeAsync(from, to)` → `ExecutedAt` range, come `GetByDateRangeAsync`

I 3 rami del handler ora usano questi count.

## Test (TDD)

`GetTestResultsQueryHandlerTests` (**nuovo**): pagina di 2 vs totale reale di 25 su tutti e 4 i rami filtro (SavedOnly/ExecutedBy/DateRange RED→GREEN; TypologyId regression-guard). 4/4 verdi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)