### PR TITLE
fix(gamebook): #3101 close EventSource on unmount in useTranslateSegmentSSE

### DIFF
--- a/apps/web/src/lib/gamebook/hooks/__tests__/useTranslateSegmentSSE.test.tsx
+++ b/apps/web/src/lib/gamebook/hooks/__tests__/useTranslateSegmentSSE.test.tsx
@@ -132,6 +132,19 @@ describe('useTranslateSegmentSSE', () => {
     expect(captured?.close).toHaveBeenCalled();
   });
 
+  // #3101 — cleanup on unmount to prevent a dangling EventSource + setState-after-unmount
+  // when the user navigates away mid-translate (browser back, route change).
+  it('closes EventSource on unmount', () => {
+    const { result, unmount } = renderHook(() => useTranslateSegmentSSE());
+
+    act(() => result.current.start(CAMPAIGN_ID, PHOTO_ID, 5, BOOK_ID));
+    const captured = lastInstance;
+
+    unmount();
+
+    expect(captured?.close).toHaveBeenCalled();
+  });
+
   it('resets state on new start() call', () => {
     const { result } = renderHook(() => useTranslateSegmentSSE());
 

--- a/apps/web/src/lib/gamebook/hooks/useTranslateSegmentSSE.ts
+++ b/apps/web/src/lib/gamebook/hooks/useTranslateSegmentSSE.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import type { SourceLangCode } from '@/lib/gamebook/lang-codes';
 
@@ -36,6 +36,15 @@ export function useTranslateSegmentSSE() {
   const stop = useCallback(() => {
     sourceRef.current?.close();
     sourceRef.current = null;
+  }, []);
+
+  // #3101: close the EventSource on unmount to prevent a dangling connection and
+  // setState-after-unmount when the user navigates away mid-translate (browser
+  // back, route change). Mirrors the sibling useTranslateTextSSE (#1560).
+  useEffect(() => {
+    return () => {
+      sourceRef.current?.close();
+    };
   }, []);
 
   const start = useCallback(


### PR DESCRIPTION
## Summary

Closes #3101.

`useTranslateSegmentSSE` apriva un `EventSource` in `start()` ma **non aveva alcun `useEffect` di cleanup** (importava solo `useCallback/useRef/useState`), quindi la connessione veniva chiusa solo su `stop()` esplicito o a fine stream. Se l'utente navigava via a metà traduzione (back del browser, cambio route), l'`EventSource` restava aperto contro il server e `onmessage`/`onerror` chiamavano `setState` su un componente smontato.

## Change

Aggiunto un `useEffect` di cleanup che chiude l'`EventSource` su unmount, coerente con il gemello `useTranslateTextSSE` (fix #1560).

## Test (TDD)

Nuovo test `closes EventSource on unmount` (RED → GREEN). 15/15 nel file di test dell'hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)