### PR TITLE
fix(wizard): #3102 stabilize useWizardAutoSave 30s interval during active editing

### DIFF
--- a/apps/web/src/hooks/wizard/__tests__/useWizardAutoSave.test.ts
+++ b/apps/web/src/hooks/wizard/__tests__/useWizardAutoSave.test.ts
@@ -63,6 +63,32 @@ describe('useWizardAutoSave', () => {
     expect(parsed.uploadedPdf.id).toBe('pdf-123');
   });
 
+  it('should keep the 30s auto-save timer stable across store re-renders (active editing)', () => {
+    // The mocked store returns a NEW object reference on every call, reproducing
+    // the real Zustand-without-selector behaviour: each set() (= each re-render)
+    // changes the store reference. With the buggy [store] effect dependency the
+    // 30s interval was cleared+recreated on every edit, so during continuous
+    // editing (edits < 30s apart) the 30s window never elapsed and the draft was
+    // never auto-saved. The fix keeps the interval stable.
+    const { rerender } = renderHook(() => useWizardAutoSave());
+
+    // Simulate frequent edits: re-render every 15s (< 30s apart).
+    act(() => {
+      vi.advanceTimersByTime(15000);
+    });
+    rerender();
+    act(() => {
+      vi.advanceTimersByTime(15000); // wall clock t=30s
+    });
+    rerender();
+    act(() => {
+      vi.advanceTimersByTime(15000); // wall clock t=45s
+    });
+
+    // With a stable interval the draft is saved by t=30s.
+    expect(localStorage.getItem('game_import_wizard_draft')).not.toBeNull();
+  });
+
   it('should restore draft on mount', async () => {
     // Create a draft first
     const draft = {

--- a/apps/web/src/hooks/wizard/useWizardAutoSave.ts
+++ b/apps/web/src/hooks/wizard/useWizardAutoSave.ts
@@ -108,6 +108,14 @@ export function useWizardAutoSave() {
   const store = useGameImportWizardStore();
   const hasRestoredRef = useRef(false);
 
+  // #3102: `useGameImportWizardStore()` (no selector) returns a NEW object reference
+  // on every set(), so depending on `store` in the effects below recreated the 30s
+  // interval on every edit and the auto-save never fired during active editing.
+  // Keep the live store in a ref (updated each render) and use stable `[]` deps so
+  // the interval survives edits while still reading the latest state.
+  const storeRef = useRef(store);
+  storeRef.current = store;
+
   // Restore draft on mount (only once)
   useEffect(() => {
     if (hasRestoredRef.current) return;
@@ -116,37 +124,40 @@ export function useWizardAutoSave() {
     const draft = loadDraft();
     if (!draft) return;
 
+    const s = storeRef.current;
+
     // Restore wizard state
-    if (draft.currentStep) store.setStep(draft.currentStep);
-    if (draft.uploadedPdf) store.setUploadedPdf(draft.uploadedPdf);
-    if (draft.extractedMetadata) store.setReviewedMetadata(draft.extractedMetadata);
+    if (draft.currentStep) s.setStep(draft.currentStep);
+    if (draft.uploadedPdf) s.setUploadedPdf(draft.uploadedPdf);
+    if (draft.extractedMetadata) s.setReviewedMetadata(draft.extractedMetadata);
     if (draft.selectedBggId)
-      store.setSelectedBggId(draft.selectedBggId, draft.bggGameData ?? undefined);
+      s.setSelectedBggId(draft.selectedBggId, draft.bggGameData ?? undefined);
     // Note: enrichedData is not directly restorable as it's typically computed in Step 4
 
     toast.success('Draft restored', {
       description: 'Your previous wizard session has been restored.',
     });
-  }, [store]);
+  }, []);
 
-  // Auto-save wizard state every 30s
+  // Auto-save wizard state every 30s (stable interval, reads latest state via ref)
   useEffect(() => {
     const interval = setInterval(() => {
+      const s = storeRef.current;
       // Only save if there's meaningful progress (beyond step 1)
-      if (store.currentStep > 1 || store.uploadedPdf) {
+      if (s.currentStep > 1 || s.uploadedPdf) {
         saveDraft({
-          currentStep: store.currentStep,
-          uploadedPdf: store.uploadedPdf,
-          extractedMetadata: store.extractedMetadata,
-          selectedBggId: store.selectedBggId,
-          bggGameData: store.bggGameData,
-          enrichedData: store.enrichedData,
+          currentStep: s.currentStep,
+          uploadedPdf: s.uploadedPdf,
+          extractedMetadata: s.extractedMetadata,
+          selectedBggId: s.selectedBggId,
+          bggGameData: s.bggGameData,
+          enrichedData: s.enrichedData,
         });
       }
     }, AUTO_SAVE_INTERVAL_MS);
 
     return () => clearInterval(interval);
-  }, [store]);
+  }, []);
 
   // Clear draft on wizard completion (when enrichedData is submitted)
   // This is handled by the wizard component calling clearDraft() explicitly


### PR DESCRIPTION
## Summary

Closes #3102.

`useWizardAutoSave` sottoscriveva l'intero store via `useGameImportWizardStore()` **senza selector**, quindi `store` era un nuovo riferimento ad ogni `set()`. Entrambi gli effect dipendevano da `[store]`, quindi ogni modifica del wizard (cambio step, digitazione metadata, selezione cover) faceva `clearInterval` + ricreava l'intervallo da 30s, **resettando il timer**. Durante editing continuo (modifiche a < 30s di distanza) la finestra di 30s non si completava mai e il draft **non veniva mai auto-salvato** — proprio lo scenario che la feature vuole coprire.

## Change

Lo store live è tenuto in un `ref` (aggiornato ad ogni render) e gli effect usano deps stabili `[]`, così l'intervallo sopravvive alle modifiche pur leggendo sempre lo stato più recente.

## Test (TDD)

Nuovo test `keeps the 30s auto-save timer stable across store re-renders (active editing)` (RED → GREEN). 5/5 nel file di test dell'hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)