### PR TITLE
fix(i18n): #3103 add gameDetail stats/chat/houseRules catalog subtrees

### DIFF
--- a/apps/web/src/app/(authenticated)/games/[id]/_components/__tests__/i18n-gamedetail-keys.test.ts
+++ b/apps/web/src/app/(authenticated)/games/[id]/_components/__tests__/i18n-gamedetail-keys.test.ts
@@ -1,0 +1,75 @@
+/**
+ * GameDetail i18n key validation (#3103)
+ *
+ * Ensures the `pages.gameDetail.{stats,chat,houseRules}` subtrees exist in both
+ * IT and EN locale files. These are consumed by GameDetailView (Stats tab, chat
+ * preview, House Rules panel); when absent, react-intl renders the raw dot-path
+ * id to every user.
+ */
+
+import enMessages from '@/locales/en.json';
+import itMessages from '@/locales/it.json';
+
+const STATS_KEYS = [
+  'winRate',
+  'timesPlayed',
+  'lastPlayed',
+  'lastPlayedNever',
+  'lastPlayedDaysAgoUnit',
+  'leaderboardTitle',
+  'leaderboardPlays',
+  'leaderboardAvg',
+  'leaderboardWins',
+  'leaderboardEmpty',
+  'communityGateTitle',
+  'communityGateDescription',
+  'communityGateCta',
+];
+
+const CHAT_KEYS = ['title', 'empty', 'openCta', 'userPrefix', 'assistantPrefix'];
+
+const HOUSE_RULES_KEYS = [
+  'title',
+  'addCta',
+  'addPlaceholder',
+  'addSubmit',
+  'editLabel',
+  'editSubmit',
+  'cancel',
+  'deleteLabel',
+  'deleteConfirmTitle',
+  'deleteConfirmMessage',
+  'deleteConfirm',
+  'empty',
+];
+
+type Catalog = Record<string, unknown> & {
+  pages: { gameDetail: Record<string, Record<string, string>> };
+};
+
+const itGameDetail = (itMessages as Catalog).pages.gameDetail;
+const enGameDetail = (enMessages as Catalog).pages.gameDetail;
+
+describe('GameDetail i18n key validation (#3103)', () => {
+  describe.each([
+    ['stats', STATS_KEYS],
+    ['chat', CHAT_KEYS],
+    ['houseRules', HOUSE_RULES_KEYS],
+  ] as const)('pages.gameDetail.%s subtree', (subtree, keys) => {
+    it.each(keys)(`IT: pages.gameDetail.${subtree}.%s exists and is non-empty`, key => {
+      expect(itGameDetail[subtree]?.[key]).toBeTruthy();
+    });
+
+    it.each(keys)(`EN: pages.gameDetail.${subtree}.%s exists and is non-empty`, key => {
+      expect(enGameDetail[subtree]?.[key]).toBeTruthy();
+    });
+  });
+
+  it('IT and EN have the same keys for stats/chat/houseRules (parity)', () => {
+    for (const subtree of ['stats', 'chat', 'houseRules'] as const) {
+      const itKeys = Object.keys(itGameDetail[subtree] ?? {}).sort();
+      const enKeys = Object.keys(enGameDetail[subtree] ?? {}).sort();
+      expect(itKeys).toEqual(enKeys);
+    }
+  });
+});

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -3245,6 +3245,42 @@
           "subtitle": "Something went wrong. Please try again in a moment.",
           "cta": "Retry"
         }
+      },
+      "stats": {
+        "winRate": "Win rate",
+        "timesPlayed": "Times played",
+        "lastPlayed": "Last played",
+        "lastPlayedNever": "Never",
+        "lastPlayedDaysAgoUnit": "d ago",
+        "leaderboardTitle": "Leaderboard",
+        "leaderboardPlays": "Plays",
+        "leaderboardAvg": "Avg score",
+        "leaderboardWins": "Wins",
+        "leaderboardEmpty": "No leaderboard data yet.",
+        "communityGateTitle": "Your stats",
+        "communityGateDescription": "Add this game to your library to unlock your play stats.",
+        "communityGateCta": "Add to library"
+      },
+      "chat": {
+        "title": "Chat with the assistant",
+        "empty": "No messages yet. Ask a question about the game's rules.",
+        "openCta": "Open chat",
+        "userPrefix": "You",
+        "assistantPrefix": "Assistant"
+      },
+      "houseRules": {
+        "title": "House rules",
+        "addCta": "Add rule",
+        "addPlaceholder": "Write a house rule...",
+        "addSubmit": "Add",
+        "editLabel": "Edit",
+        "editSubmit": "Save",
+        "cancel": "Cancel",
+        "deleteLabel": "Delete",
+        "deleteConfirmTitle": "Delete rule?",
+        "deleteConfirmMessage": "This house rule will be permanently deleted.",
+        "deleteConfirm": "Delete",
+        "empty": "No house rules yet. Add one to customize the game's rules."
       }
     },
     "sharedGames": {

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -3293,6 +3293,42 @@
           "subtitle": "Si è verificato un errore. Riprova tra qualche istante.",
           "cta": "Riprova"
         }
+      },
+      "stats": {
+        "winRate": "Percentuale vittorie",
+        "timesPlayed": "Partite giocate",
+        "lastPlayed": "Ultima partita",
+        "lastPlayedNever": "Mai",
+        "lastPlayedDaysAgoUnit": "g fa",
+        "leaderboardTitle": "Classifica",
+        "leaderboardPlays": "Partite",
+        "leaderboardAvg": "Punteggio medio",
+        "leaderboardWins": "Vittorie",
+        "leaderboardEmpty": "Ancora nessun dato in classifica.",
+        "communityGateTitle": "Le tue statistiche",
+        "communityGateDescription": "Aggiungi questo gioco alla tua libreria per sbloccare le tue statistiche di gioco.",
+        "communityGateCta": "Aggiungi alla libreria"
+      },
+      "chat": {
+        "title": "Chat con l'assistente",
+        "empty": "Nessun messaggio. Fai una domanda sulle regole del gioco.",
+        "openCta": "Apri la chat",
+        "userPrefix": "Tu",
+        "assistantPrefix": "Assistente"
+      },
+      "houseRules": {
+        "title": "Regole della casa",
+        "addCta": "Aggiungi regola",
+        "addPlaceholder": "Scrivi una regola della casa...",
+        "addSubmit": "Aggiungi",
+        "editLabel": "Modifica",
+        "editSubmit": "Salva",
+        "cancel": "Annulla",
+        "deleteLabel": "Elimina",
+        "deleteConfirmTitle": "Eliminare la regola?",
+        "deleteConfirmMessage": "Questa regola della casa verrà eliminata definitivamente.",
+        "deleteConfirm": "Elimina",
+        "empty": "Nessuna regola della casa. Aggiungine una per personalizzare le regole del gioco."
       }
     },
     "sharedGames": {


### PR DESCRIPTION
## Summary

Closes #3103.

`GameDetailView` consuma `pages.gameDetail.{stats,chat,houseRules}.*` ma questi sottoalberi **erano assenti da entrambi `it.json` e `en.json`** (mancavano solo `stats`/`chat`/`houseRules`; il fratello `tabs` esisteva già). I `t()` non hanno `defaultMessage`, quindi react-intl renderizzava gli **id grezzi** (es. `pages.gameDetail.houseRules.deleteConfirmMessage`) a **tutti** gli utenti sul tab Stats, l'anteprima chat inline e l'intero pannello House Rules.

## Change

Aggiunti i 3 sottoalberi (**30 chiavi**) a entrambi i cataloghi con parità it/en. Diff pulito: 72 inserimenti, 0 modifiche al resto del file (round-trip JSON preservato).

## Test (TDD)

`i18n-gamedetail-keys.test.ts` (**nuovo**): verifica che ogni chiave esista in IT+EN e che i due cataloghi restino allineati (RED 60 falliti → GREEN 61 verdi). Nessuna regressione in `GameDetailView.test.tsx` / `i18n-legal-keys.test.ts` (166 pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)