### PR TITLE
fix(game-sessions): map AddPlayer domain conflicts to 409 instead of 500 (#3114)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/GameSession.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/GameSession.cs
@@ -1,5 +1,6 @@
 using Api.BoundedContexts.GameManagement.Domain.Events;
 using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Domain.Entities;
 using Api.SharedKernel.Domain.Exceptions;
 
@@ -168,13 +169,13 @@ internal sealed class GameSession : AggregateRoot<Guid>
         ArgumentNullException.ThrowIfNull(player);
 
         if (Status.IsFinished)
-            throw new InvalidOperationException($"Cannot add player to finished session (status: {Status})");
+            throw new ConflictException($"Cannot add player to finished session (status: {Status})");
 
         if (_players.Count >= 100)
-            throw new InvalidOperationException("Session cannot have more than 100 players");
+            throw new ConflictException("Session cannot have more than 100 players");
 
         if (HasPlayer(player.PlayerName))
-            throw new InvalidOperationException($"Player '{player.PlayerName}' is already in this session");
+            throw new ConflictException($"Player '{player.PlayerName}' is already in this session");
 
         _players.Add(player);
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/AddPlayerToSessionCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/AddPlayerToSessionCommandHandlerTests.cs
@@ -8,6 +8,7 @@ using Api.Tests.BoundedContexts.GameManagement.TestHelpers;
 using Moq;
 using Xunit;
 using FluentAssertions;
+using Api.Middleware.Exceptions;
 using Api.Tests.Constants;
 
 namespace Api.Tests.BoundedContexts.GameManagement.Application.Handlers;
@@ -250,7 +251,7 @@ public class AddPlayerToSessionCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_CompletedSession_ThrowsInvalidOperationException()
+    public async Task Handle_CompletedSession_ThrowsConflictException()
     {
         // Arrange - Cannot add players to finished session
         var sessionId = Guid.NewGuid();
@@ -271,13 +272,13 @@ public class AddPlayerToSessionCommandHandlerTests
         // Act & Assert
         var act =
             () => _handler.Handle(command, TestContext.Current.CancellationToken);
-        var exception = (await act.Should().ThrowAsync<InvalidOperationException>()).Which;
+        var exception = (await act.Should().ThrowAsync<ConflictException>()).Which;
 
         exception.Message.Should().ContainEquivalentOf("Cannot add player to finished session");
     }
 
     [Fact]
-    public async Task Handle_AbandonedSession_ThrowsInvalidOperationException()
+    public async Task Handle_AbandonedSession_ThrowsConflictException()
     {
         // Arrange - Cannot add players to abandoned session
         var sessionId = Guid.NewGuid();
@@ -300,13 +301,13 @@ public class AddPlayerToSessionCommandHandlerTests
         // Act & Assert
         var act =
             () => _handler.Handle(command, TestContext.Current.CancellationToken);
-        var exception = (await act.Should().ThrowAsync<InvalidOperationException>()).Which;
+        var exception = (await act.Should().ThrowAsync<ConflictException>()).Which;
 
         exception.Message.Should().ContainEquivalentOf("Cannot add player to finished session");
     }
 
     [Fact]
-    public async Task Handle_DuplicatePlayerName_ThrowsInvalidOperationException()
+    public async Task Handle_DuplicatePlayerName_ThrowsConflictException()
     {
         // Arrange - Player already exists
         var sessionId = Guid.NewGuid();
@@ -327,13 +328,13 @@ public class AddPlayerToSessionCommandHandlerTests
         // Act & Assert
         var act =
             () => _handler.Handle(command, TestContext.Current.CancellationToken);
-        var exception = (await act.Should().ThrowAsync<InvalidOperationException>()).Which;
+        var exception = (await act.Should().ThrowAsync<ConflictException>()).Which;
 
         exception.Message.Should().ContainEquivalentOf("Player 'Alice' is already in this session");
     }
 
     [Fact]
-    public async Task Handle_DuplicatePlayerNameCaseInsensitive_ThrowsInvalidOperationException()
+    public async Task Handle_DuplicatePlayerNameCaseInsensitive_ThrowsConflictException()
     {
         // Arrange - Player name check is case-insensitive
         var sessionId = Guid.NewGuid();
@@ -354,7 +355,7 @@ public class AddPlayerToSessionCommandHandlerTests
         // Act & Assert
         var act =
             () => _handler.Handle(command, TestContext.Current.CancellationToken);
-        var exception = (await act.Should().ThrowAsync<InvalidOperationException>()).Which;
+        var exception = (await act.Should().ThrowAsync<ConflictException>()).Which;
 
         exception.Message.Should().ContainEquivalentOf("already in this session");
     }

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/Entities/GameSessionTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/Entities/GameSessionTests.cs
@@ -1,6 +1,7 @@
 using Api.BoundedContexts.GameManagement.Domain.Entities;
 using Api.BoundedContexts.GameManagement.Domain.Events;
 using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Domain.Exceptions;
 using FluentAssertions;
 using Xunit;
@@ -671,7 +672,7 @@ public sealed class GameSessionTests
     }
 
     [Fact]
-    public void AddPlayer_WhenCompleted_ThrowsInvalidOperationException()
+    public void AddPlayer_WhenCompleted_ThrowsConflictException()
     {
         // Arrange
         var session = CreateSetupSession();
@@ -683,12 +684,12 @@ public sealed class GameSessionTests
         var action = () => session.AddPlayer(newPlayer);
 
         // Assert
-        action.Should().Throw<InvalidOperationException>()
+        action.Should().Throw<ConflictException>()
             .WithMessage("*Cannot add player to finished session*");
     }
 
     [Fact]
-    public void AddPlayer_WhenAbandoned_ThrowsInvalidOperationException()
+    public void AddPlayer_WhenAbandoned_ThrowsConflictException()
     {
         // Arrange
         var session = CreateSetupSession();
@@ -699,12 +700,12 @@ public sealed class GameSessionTests
         var action = () => session.AddPlayer(newPlayer);
 
         // Assert
-        action.Should().Throw<InvalidOperationException>()
+        action.Should().Throw<ConflictException>()
             .WithMessage("*Cannot add player to finished session*");
     }
 
     [Fact]
-    public void AddPlayer_WhenAtMaxCapacity_ThrowsInvalidOperationException()
+    public void AddPlayer_WhenAtMaxCapacity_ThrowsConflictException()
     {
         // Arrange
         var maxPlayers = Enumerable.Range(1, 100)
@@ -717,12 +718,12 @@ public sealed class GameSessionTests
         var action = () => session.AddPlayer(newPlayer);
 
         // Assert
-        action.Should().Throw<InvalidOperationException>()
+        action.Should().Throw<ConflictException>()
             .WithMessage("*Session cannot have more than 100 players*");
     }
 
     [Fact]
-    public void AddPlayer_WithDuplicateName_ThrowsInvalidOperationException()
+    public void AddPlayer_WithDuplicateName_ThrowsConflictException()
     {
         // Arrange
         var session = CreateSetupSession();
@@ -732,12 +733,12 @@ public sealed class GameSessionTests
         var action = () => session.AddPlayer(duplicatePlayer);
 
         // Assert
-        action.Should().Throw<InvalidOperationException>()
+        action.Should().Throw<ConflictException>()
             .WithMessage("*Player 'Alice' is already in this session*");
     }
 
     [Fact]
-    public void AddPlayer_WithDuplicateNameDifferentCase_ThrowsInvalidOperationException()
+    public void AddPlayer_WithDuplicateNameDifferentCase_ThrowsConflictException()
     {
         // Arrange
         var session = CreateSetupSession();
@@ -747,7 +748,7 @@ public sealed class GameSessionTests
         var action = () => session.AddPlayer(duplicatePlayer);
 
         // Assert
-        action.Should().Throw<InvalidOperationException>()
+        action.Should().Throw<ConflictException>()
             .WithMessage("*Player 'ALICE' is already in this session*");
     }
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/GameSessionDomainTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/GameSessionDomainTests.cs
@@ -1,5 +1,6 @@
 using Api.BoundedContexts.GameManagement.Domain.Entities;
 using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
+using Api.Middleware.Exceptions;
 using FluentAssertions;
 using Xunit;
 using Api.Tests.Constants;
@@ -330,7 +331,7 @@ public class GameSessionDomainTests
     }
 
     [Fact]
-    public void GameSession_AddPlayer_ToCompletedSession_ThrowsInvalidOperationException()
+    public void GameSession_AddPlayer_ToCompletedSession_ThrowsConflictException()
     {
         // Arrange
         var session = CreateDefaultSession();
@@ -340,12 +341,12 @@ public class GameSessionDomainTests
 
         // Act & Assert
         var act = () => session.AddPlayer(newPlayer);
-        var exception = act.Should().Throw<InvalidOperationException>().Which;
+        var exception = act.Should().Throw<ConflictException>().Which;
         exception.Message.Should().ContainEquivalentOf("Cannot add player to finished session");
     }
 
     [Fact]
-    public void GameSession_AddPlayer_ToAbandonedSession_ThrowsInvalidOperationException()
+    public void GameSession_AddPlayer_ToAbandonedSession_ThrowsConflictException()
     {
         // Arrange
         var session = CreateDefaultSession();
@@ -355,12 +356,12 @@ public class GameSessionDomainTests
 
         // Act & Assert
         var act = () => session.AddPlayer(newPlayer);
-        var exception = act.Should().Throw<InvalidOperationException>().Which;
+        var exception = act.Should().Throw<ConflictException>().Which;
         exception.Message.Should().Contain("Cannot add player to finished session");
     }
 
     [Fact]
-    public void GameSession_AddPlayer_DuplicateName_ThrowsInvalidOperationException()
+    public void GameSession_AddPlayer_DuplicateName_ThrowsConflictException()
     {
         // Arrange
         var session = CreateDefaultSession(); // Has "Alice" and "Bob"
@@ -368,13 +369,13 @@ public class GameSessionDomainTests
 
         // Act & Assert
         var act = () => session.AddPlayer(duplicatePlayer);
-        var exception = act.Should().Throw<InvalidOperationException>().Which;
+        var exception = act.Should().Throw<ConflictException>().Which;
         exception.Message.Should().ContainEquivalentOf("already in this session");
         exception.Message.Should().ContainEquivalentOf("Alice");
     }
 
     [Fact]
-    public void GameSession_AddPlayer_DuplicateNameCaseInsensitive_ThrowsInvalidOperationException()
+    public void GameSession_AddPlayer_DuplicateNameCaseInsensitive_ThrowsConflictException()
     {
         // Arrange
         var session = CreateDefaultSession(); // Has "Alice"
@@ -382,12 +383,12 @@ public class GameSessionDomainTests
 
         // Act & Assert
         var act = () => session.AddPlayer(duplicatePlayer);
-        var exception = act.Should().Throw<InvalidOperationException>().Which;
+        var exception = act.Should().Throw<ConflictException>().Which;
         exception.Message.Should().ContainEquivalentOf("already in this session");
     }
 
     [Fact]
-    public void GameSession_AddPlayer_Exceeds100Players_ThrowsInvalidOperationException()
+    public void GameSession_AddPlayer_Exceeds100Players_ThrowsConflictException()
     {
         // Arrange - Create session with 100 players
         var players = Enumerable.Range(1, 100)
@@ -399,7 +400,7 @@ public class GameSessionDomainTests
 
         // Act & Assert
         var act = () => session.AddPlayer(oneMorePlayer);
-        var exception = act.Should().Throw<InvalidOperationException>().Which;
+        var exception = act.Should().Throw<ConflictException>().Which;
         exception.Message.Should().ContainEquivalentOf("cannot have more than 100 players");
     }
 


### PR DESCRIPTION
## Summary
`GameSession.AddPlayer` threw `InvalidOperationException` for three state conflicts (finished session, >100 players, duplicate player). None of the messages contain "not found", so `ApiExceptionHandlerMiddleware` fell through to the **500** default — but these are user-side **409** conflicts.

## Changes
- `GameSession.cs`: the three conflict `throw`s now use `ConflictException` (409 via `HttpException`), matching the existing domain-layer convention in this bounded context (`PlayRecord`, `LiveGameSession`). Messages unchanged.
- The `session not found` throw in the handler stays `InvalidOperationException` (already 404).
- Updated the 14 affected domain/handler assertions + renamed tests to reflect the `ConflictException` contract.

## Tests
148 tests green (`GameSessionTests` 104, `GameSessionDomainTests` + `AddPlayerToSessionCommandHandlerTests` 44), 0 regressions.

Closes #3114

🤖 Generated with [Claude Code](https://claude.com/claude-code)