### PR TITLE
fix(rule-comments): map thread-depth to 409 and bad line-number to 400 (#3115)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/ReplyToRuleCommentCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/ReplyToRuleCommentCommandHandler.cs
@@ -3,6 +3,7 @@ using Api.BoundedContexts.GameManagement.Application.Commands;
 using Api.BoundedContexts.GameManagement.Application.Mappers;
 using Api.Infrastructure;
 using Api.Infrastructure.Entities;
+using Api.Middleware.Exceptions;
 using Api.Models;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
@@ -54,7 +55,7 @@ internal partial class ReplyToRuleCommentCommandHandler : IRequestHandler<ReplyT
         var threadDepth = await CalculateThreadDepthAsync(command.ParentCommentId, cancellationToken).ConfigureAwait(false);
         if (threadDepth >= MaxThreadDepth - 1)
         {
-            throw new InvalidOperationException(
+            throw new ConflictException(
                 $"Maximum thread depth of {MaxThreadDepth} exceeded. Cannot reply to this comment.");
         }
 

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GetCommentsForLineQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GetCommentsForLineQueryHandler.cs
@@ -1,6 +1,7 @@
 using Api.BoundedContexts.GameManagement.Application.Queries;
 using Api.Infrastructure;
 using Api.Infrastructure.Entities;
+using Api.Middleware.Exceptions;
 using Api.Models;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
@@ -27,7 +28,7 @@ internal class GetCommentsForLineQueryHandler : IRequestHandler<GetCommentsForLi
     {
         if (query.LineNumber < 1)
         {
-            throw new InvalidOperationException("Line number must be positive");
+            throw new BadRequestException("Line number must be positive");
         }
 
         var comments = await _dbContext.RuleSpecComments

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Queries/GetCommentsForLineQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Queries/GetCommentsForLineQueryHandlerTests.cs
@@ -1,0 +1,65 @@
+using Api.BoundedContexts.GameManagement.Application.Queries;
+using Api.Infrastructure;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Application.Services;
+using Api.Tests.Constants;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Application.Queries;
+
+/// <summary>
+/// Unit tests for <see cref="GetCommentsForLineQueryHandler"/>.
+/// Issue #3115: a non-positive LineNumber is invalid input and must map to
+/// 400 Bad Request (BadRequestException), not 500 (InvalidOperationException).
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "GameManagement")]
+public sealed class GetCommentsForLineQueryHandlerTests : IDisposable
+{
+    private readonly MeepleAiDbContext _dbContext;
+    private readonly GetCommentsForLineQueryHandler _sut;
+
+    public GetCommentsForLineQueryHandlerTests()
+    {
+        var options = new DbContextOptionsBuilder<MeepleAiDbContext>()
+            .UseInMemoryDatabase($"GetCommentsForLineTests_{Guid.NewGuid()}")
+            .Options;
+
+        _dbContext = new MeepleAiDbContext(
+            options,
+            new Mock<IMediator>().Object,
+            new Mock<IDomainEventCollector>().Object);
+
+        _sut = new GetCommentsForLineQueryHandler(
+            _dbContext,
+            NullLogger<GetCommentsForLineQueryHandler>.Instance);
+    }
+
+    public void Dispose()
+    {
+        _dbContext.Dispose();
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(-100)]
+    public async Task Handle_NonPositiveLineNumber_ThrowsBadRequestException(int lineNumber)
+    {
+        // Arrange
+        var query = new GetCommentsForLineQuery(
+            GameId: Guid.NewGuid().ToString(),
+            Version: "v1",
+            LineNumber: lineNumber);
+
+        // Act & Assert
+        var act = () => _sut.Handle(query, TestContext.Current.CancellationToken);
+        await act.Should().ThrowAsync<BadRequestException>()
+            .WithMessage("*Line number must be positive*");
+    }
+}

--- a/apps/api/tests/Api.Tests/Integration/GameManagement/ReplyToRuleCommentIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/GameManagement/ReplyToRuleCommentIntegrationTests.cs
@@ -4,6 +4,7 @@ using Api.BoundedContexts.GameManagement.Application.Queries;
 using Api.Infrastructure;
 using Api.Infrastructure.Entities;
 using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Application.Services;
 using FluentAssertions;
 using Npgsql;
@@ -231,7 +232,7 @@ public sealed class ReplyToRuleCommentIntegrationTests : IAsyncLifetime
         result.LineNumber.Should().Be(42); // Inherited from parent
     }
     [Fact]
-    public async Task ReplyToComment_AtMaxDepth_ThrowsInvalidOperation()
+    public async Task ReplyToComment_AtMaxDepth_ThrowsConflict()
     {
         // Arrange
         await ResetDatabaseAsync();
@@ -254,7 +255,7 @@ public sealed class ReplyToRuleCommentIntegrationTests : IAsyncLifetime
         Func<Task> act = async () => await handler.Handle(command, TestCancellationToken);
 
         // Assert
-        await act.Should().ThrowAsync<InvalidOperationException>()
+        await act.Should().ThrowAsync<ConflictException>()
             .WithMessage("*Maximum thread depth*");
     }
 


### PR DESCRIPTION
## Summary
Two GameManagement handlers threw `InvalidOperationException` for user-side error conditions, which `ApiExceptionHandlerMiddleware` maps to **HTTP 500**.

## Changes
- `ReplyToRuleCommentCommandHandler`: exceeding the max thread depth (5) is a state conflict → `ConflictException` (**409**). The "parent comment not found" throw is unchanged (still 404).
- `GetCommentsForLineQueryHandler`: a non-positive `LineNumber` is malformed input → `BadRequestException` (**400**).

## Tests
- New `GetCommentsForLineQueryHandlerTests` unit suite (0 / -1 / -100 → 400), 3 cases green.
- Updated the integration thread-depth assertion to `ConflictException` + renamed the test.
- 15 unit tests green, full assembly compiles.

Closes #3115

🤖 Generated with [Claude Code](https://claude.com/claude-code)