### PR TITLE
chore(audit-outbox): add Prometheus alerts for backlog/stale/failed (#3116)

### DIFF
--- a/docs/for-developers/operations/operations-manual.md
+++ b/docs/for-developers/operations/operations-manual.md
@@ -3269,3 +3269,24 @@ metric series are absent, so the alerts do not fire on absence.
 4. **Broad failure with no token/limit cause** (`http_error`/`unknown`): check Slack API status and the processor logs for transport errors.
 
 Alert unit tests live in `infra/prometheus/alerts/slack-delivery.test.yml` (run `promtool test rules` per the header comment; there is no CI promtool gate, so run on demand).
+
+## Audit Outbox Alerts
+
+Defined in `infra/prometheus/alerts/audit-outbox.yml` (#3116). The three health gauges are
+emitted by `apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.AuditOutbox.cs` (registered
+via `RegisterAuditOutboxGauges` in `Program.cs`) and routed via `severity: warning` → the
+`warning-alerts` receiver in `alertmanager.yml` (throttled email). The gauges report `0` when
+the queue is idle, so the expressions never fire on an empty queue.
+
+| Alert | Trigger | Sustained | Meaning / first action |
+|---|---|---|---|
+| `AuditOutboxBacklogHigh` | `meepleai_audit_outbox_pending_count > 500` | 10m | The audit outbox processor is not draining Pending rows fast enough (or is stalled); audit events accumulate undelivered. Check the processor job logs and DB health. |
+| `AuditOutboxDrainStalled` | `meepleai_audit_outbox_pending_oldest_age_seconds > 60` | 5m | The oldest Pending row is aging past 60s (threshold from the metric source): drain is falling behind ingestion. Check processor cadence and DB latency. |
+| `AuditOutboxFailedMessages` | `meepleai_audit_outbox_failed_count > 0` | — | One or more rows are in Failed status (poison messages) needing operator intervention. Inspect the failed rows and their error payloads via the admin dashboard. |
+
+### Investigation steps
+
+1. **Backlog / drain lag** (`AuditOutboxBacklogHigh` / `AuditOutboxDrainStalled`): confirm the audit outbox processor is running and not throwing. A steadily-rising `pending_count` with a growing `oldest_age_seconds` indicates a stalled or under-provisioned drain — check DB connectivity and the processor job schedule.
+2. **Poison messages** (`AuditOutboxFailedMessages`): inspect the Failed rows via the admin dashboard; a Failed row is a message the processor could not deliver after its retry budget. Resolve the underlying cause, then requeue or discard per the audit-retention policy.
+
+Alert unit tests live in `infra/prometheus/alerts/audit-outbox.test.yml` (run `promtool test rules` per the header comment; there is no CI promtool gate, so run on demand).

--- a/infra/compose.prod.yml
+++ b/infra/compose.prod.yml
@@ -231,6 +231,7 @@ services:
       - ./prometheus/alerts/bgg-tos-compliance.yml:/etc/prometheus/bgg-tos-compliance.yml:ro
       # Issue #3112 — OPS-02 Slack delivery observability alerts.
       - ./prometheus/alerts/slack-delivery.yml:/etc/prometheus/slack-delivery.yml:ro
+      - ./prometheus/alerts/audit-outbox.yml:/etc/prometheus/audit-outbox.yml:ro
       - prometheus-prod:/prometheus
     deploy:
       resources:

--- a/infra/compose.staging.yml
+++ b/infra/compose.staging.yml
@@ -338,6 +338,7 @@ services:
       - ./prometheus/alerts/bgg-tos-compliance.yml:/etc/prometheus/bgg-tos-compliance.yml:ro
       # Issue #3112 — OPS-02 Slack delivery observability alerts.
       - ./prometheus/alerts/slack-delivery.yml:/etc/prometheus/slack-delivery.yml:ro
+      - ./prometheus/alerts/audit-outbox.yml:/etc/prometheus/audit-outbox.yml:ro
       - prometheus-staging:/prometheus
 
   alertmanager:

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -351,6 +351,7 @@ services:
       - ./prometheus/alerts/bgg-tos-compliance.yml:/etc/prometheus/bgg-tos-compliance.yml:ro
       # Issue #3112 — OPS-02 Slack delivery alerts (referenced from prometheus.yml rule_files).
       - ./prometheus/alerts/slack-delivery.yml:/etc/prometheus/slack-delivery.yml:ro
+      - ./prometheus/alerts/audit-outbox.yml:/etc/prometheus/audit-outbox.yml:ro
       - prometheus_data:/prometheus
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "http://localhost:9090/-/healthy"]

--- a/infra/prometheus.prod.yml
+++ b/infra/prometheus.prod.yml
@@ -27,6 +27,8 @@ rule_files:
   - '/etc/prometheus/bgg-tos-compliance.yml'
   # Issue #3112 — OPS-02 Slack delivery observability alerts.
   - '/etc/prometheus/slack-delivery.yml'
+  # Issue #3116 — SP5 Admin Security audit_outbox health alerts.
+  - '/etc/prometheus/audit-outbox.yml'
 
 scrape_configs:
   - job_name: 'prometheus'

--- a/infra/prometheus.staging.yml
+++ b/infra/prometheus.staging.yml
@@ -29,6 +29,8 @@ rule_files:
   - '/etc/prometheus/bgg-tos-compliance.yml'
   # Issue #3112 — OPS-02 Slack delivery observability alerts.
   - '/etc/prometheus/slack-delivery.yml'
+  # Issue #3116 — SP5 Admin Security audit_outbox health alerts.
+  - '/etc/prometheus/audit-outbox.yml'
 
 scrape_configs:
   - job_name: 'prometheus'

--- a/infra/prometheus.yml
+++ b/infra/prometheus.yml
@@ -34,6 +34,8 @@ rule_files:
   - '/etc/prometheus/bgg-tos-compliance.yml'
   # Issue #3112 — OPS-02 Slack delivery observability alerts.
   - '/etc/prometheus/slack-delivery.yml'
+  # Issue #3116 — SP5 Admin Security audit_outbox health alerts.
+  - '/etc/prometheus/audit-outbox.yml'
 
 # Scrape configurations
 scrape_configs:

--- a/infra/prometheus/alerts/audit-outbox.test.yml
+++ b/infra/prometheus/alerts/audit-outbox.test.yml
@@ -1,0 +1,104 @@
+# promtool unit tests for audit-outbox.yml (#3116).
+#
+# Run locally (Windows/Git Bash, from repo root):
+#   docker run --rm -v "$(pwd)/infra/prometheus/alerts:/work" prom/prometheus:v3.7.0 \
+#     promtool test rules /work/audit-outbox.test.yml
+#
+# There is no promtool CI gate in this repo (see recon in #3082); this file documents +
+# verifies the alert behaviour on demand.
+rule_files:
+  - audit-outbox.yml
+
+evaluation_interval: 1m
+
+tests:
+  # Backlog sustained above 500 for >10m -> AuditOutboxBacklogHigh fires.
+  - interval: 1m
+    input_series:
+      - series: 'meepleai_audit_outbox_pending_count'
+        values: '800x15'
+    alert_rule_test:
+      - eval_time: 12m
+        alertname: AuditOutboxBacklogHigh
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              subsystem: audit-outbox
+            exp_annotations:
+              summary: "audit_outbox pending backlog above 500 (sustained 10m)"
+              description: "meepleai_audit_outbox_pending_count has stayed above 500 for 10m: the audit outbox processor is not draining Pending rows fast enough (or is stalled). Audit events are accumulating undelivered. Check the audit outbox processor job logs and database health."
+              runbook_url: "https://github.com/meepleAi-app/meepleai-monorepo/blob/main-dev/docs/for-developers/operations/operations-manual.md#audit-outbox-alerts"
+
+  # Backlog below threshold (100) -> no alert.
+  - interval: 1m
+    input_series:
+      - series: 'meepleai_audit_outbox_pending_count'
+        values: '100x15'
+    alert_rule_test:
+      - eval_time: 12m
+        alertname: AuditOutboxBacklogHigh
+        exp_alerts: []
+
+  # Idle queue (flat 0) -> no alert.
+  - interval: 1m
+    input_series:
+      - series: 'meepleai_audit_outbox_pending_count'
+        values: '0x15'
+    alert_rule_test:
+      - eval_time: 12m
+        alertname: AuditOutboxBacklogHigh
+        exp_alerts: []
+
+  # Oldest Pending age above 60s sustained >5m -> AuditOutboxDrainStalled fires.
+  - interval: 1m
+    input_series:
+      - series: 'meepleai_audit_outbox_pending_oldest_age_seconds'
+        values: '120x10'
+    alert_rule_test:
+      - eval_time: 7m
+        alertname: AuditOutboxDrainStalled
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              subsystem: audit-outbox
+            exp_annotations:
+              summary: "Oldest Pending audit_outbox row older than 60s (sustained 5m)"
+              description: "meepleai_audit_outbox_pending_oldest_age_seconds has exceeded 60s for 5m: the audit outbox drain is falling behind ingestion (threshold from the metric source). Check the processor job cadence and database latency."
+              runbook_url: "https://github.com/meepleAi-app/meepleai-monorepo/blob/main-dev/docs/for-developers/operations/operations-manual.md#audit-outbox-alerts"
+
+  # Oldest age at 0 (idle) -> no alert.
+  - interval: 1m
+    input_series:
+      - series: 'meepleai_audit_outbox_pending_oldest_age_seconds'
+        values: '0x10'
+    alert_rule_test:
+      - eval_time: 7m
+        alertname: AuditOutboxDrainStalled
+        exp_alerts: []
+
+  # A failed (poison) row appears (0 -> 1) -> AuditOutboxFailedMessages fires.
+  - interval: 1m
+    input_series:
+      - series: 'meepleai_audit_outbox_failed_count'
+        values: '0 0 1 1 1'
+    alert_rule_test:
+      - eval_time: 4m
+        alertname: AuditOutboxFailedMessages
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              subsystem: audit-outbox
+            exp_annotations:
+              summary: "audit_outbox has Failed (poison) rows"
+              description: "meepleai_audit_outbox_failed_count is above 0: one or more audit_outbox rows are in Failed status (poison messages) and require operator intervention via the admin dashboard. Inspect the failed rows and their error payloads."
+              runbook_url: "https://github.com/meepleAi-app/meepleai-monorepo/blob/main-dev/docs/for-developers/operations/operations-manual.md#audit-outbox-alerts"
+
+  # No failed rows (flat 0) -> no alert.
+  - interval: 1m
+    input_series:
+      - series: 'meepleai_audit_outbox_failed_count'
+        values: '0x5'
+    alert_rule_test:
+      - eval_time: 4m
+        alertname: AuditOutboxFailedMessages
+        exp_alerts: []

--- a/infra/prometheus/alerts/audit-outbox.yml
+++ b/infra/prometheus/alerts/audit-outbox.yml
@@ -1,0 +1,54 @@
+# Issue #3116 — SP5 Admin Security audit_outbox health alerts.
+#
+# Metric source (apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.AuditOutbox.cs,
+# registered via RegisterAuditOutboxGauges in Program.cs). ObservableGauges; Prometheus
+# names = the C# dotted names with dots -> underscores and NO unit suffix (same convention
+# as the domain-event-outbox gauges meepleai_domain_event_outbox_pending_count /
+# _pending_oldest_age_seconds / _failed_count):
+#   - meepleai_audit_outbox_pending_count               (rows in Pending status)
+#   - meepleai_audit_outbox_pending_oldest_age_seconds  (age of oldest Pending row; 0 when empty)
+#   - meepleai_audit_outbox_failed_count                (rows in Failed status = poison messages)
+# The gauges are wired in prod but previously had NO alert rule — a stalled processor or a
+# poison message stayed invisible until the audit trail was already behind.
+#
+# Thresholds come from the "Suggested alerting" block in the metric source:
+#   oldest_age_seconds > 60 -> drain falling behind; failed_count > 0 -> poison message.
+# The Pending-count source note is qualitative ("steadily increasing -> processor stalled"),
+# so a sustained absolute backlog (>500 for 10m) is used as a stall proxy.
+#
+# Routing: severity=warning matches the `warning-alerts` route in alertmanager.yml (throttled
+# email), operational signals — not P1/paging like the BGG ToS alert. The gauges report 0 when
+# the queue is idle, so the expressions never fire on an empty/idle queue.
+groups:
+  - name: meepleai_audit_outbox_alerts
+    rules:
+      - alert: AuditOutboxBacklogHigh
+        expr: meepleai_audit_outbox_pending_count > 500
+        for: 10m
+        labels:
+          severity: warning
+          subsystem: audit-outbox
+        annotations:
+          summary: "audit_outbox pending backlog above 500 (sustained 10m)"
+          description: "meepleai_audit_outbox_pending_count has stayed above 500 for 10m: the audit outbox processor is not draining Pending rows fast enough (or is stalled). Audit events are accumulating undelivered. Check the audit outbox processor job logs and database health."
+          runbook_url: "https://github.com/meepleAi-app/meepleai-monorepo/blob/main-dev/docs/for-developers/operations/operations-manual.md#audit-outbox-alerts"
+      - alert: AuditOutboxDrainStalled
+        expr: meepleai_audit_outbox_pending_oldest_age_seconds > 60
+        for: 5m
+        labels:
+          severity: warning
+          subsystem: audit-outbox
+        annotations:
+          summary: "Oldest Pending audit_outbox row older than 60s (sustained 5m)"
+          description: "meepleai_audit_outbox_pending_oldest_age_seconds has exceeded 60s for 5m: the audit outbox drain is falling behind ingestion (threshold from the metric source). Check the processor job cadence and database latency."
+          runbook_url: "https://github.com/meepleAi-app/meepleai-monorepo/blob/main-dev/docs/for-developers/operations/operations-manual.md#audit-outbox-alerts"
+      - alert: AuditOutboxFailedMessages
+        expr: meepleai_audit_outbox_failed_count > 0
+        for: 0m
+        labels:
+          severity: warning
+          subsystem: audit-outbox
+        annotations:
+          summary: "audit_outbox has Failed (poison) rows"
+          description: "meepleai_audit_outbox_failed_count is above 0: one or more audit_outbox rows are in Failed status (poison messages) and require operator intervention via the admin dashboard. Inspect the failed rows and their error payloads."
+          runbook_url: "https://github.com/meepleAi-app/meepleai-monorepo/blob/main-dev/docs/for-developers/operations/operations-manual.md#audit-outbox-alerts"


### PR DESCRIPTION
## Summary
The three `audit_outbox` health gauges (`pending_count`, `pending_oldest_age_seconds`, `failed_count`) are registered and emitted in prod (`Program.cs` `RegisterAuditOutboxGauges`) but had **no alert rule** — a stalled processor or poison message stayed invisible.

## Changes
- New `infra/prometheus/alerts/audit-outbox.yml` — 3 warning alerts: `AuditOutboxBacklogHigh` (>500/10m), `AuditOutboxDrainStalled` (oldest_age>60s/5m — threshold from the metric source), `AuditOutboxFailedMessages` (>0).
- New `audit-outbox.test.yml` promtool companion (fire-on-condition + silent when below/idle).
- `rule_files` wiring in the 3 prometheus configs + volume mounts in the 3 compose files.
- operations-manual runbook section (`#audit-outbox-alerts`).
- No application code changes (metrics already emitted).

## Validation
`promtool check rules` + `promtool test rules`: **SUCCESS** (verified locally via `prom/prometheus:v3.7.0`).

Clone of the #3112/#3082 pattern on a different subsystem. Closes #3116

🤖 Generated with [Claude Code](https://claude.com/claude-code)