### PR TITLE
fix(session-tracking): #3119 enforce owner/participant access on export/media/chat (IDOR)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/ChatQueries.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/ChatQueries.cs
@@ -9,7 +9,8 @@ namespace Api.BoundedContexts.SessionTracking.Application.Queries;
 public record GetSessionChatQuery(
     Guid SessionId,
     int? Limit,
-    int? Offset
+    int? Offset,
+    Guid RequestedBy
 ) : IRequest<SessionChatResultDto>;
 
 /// <summary>

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/ChatQueryHandlers.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/ChatQueryHandlers.cs
@@ -1,6 +1,7 @@
 using MediatR;
 using Api.BoundedContexts.SessionTracking.Application.Queries;
 using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using Api.Middleware.Exceptions;
 
 namespace Api.BoundedContexts.SessionTracking.Application.Queries;
 
@@ -11,14 +12,23 @@ namespace Api.BoundedContexts.SessionTracking.Application.Queries;
 public class GetSessionChatQueryHandler : IRequestHandler<GetSessionChatQuery, SessionChatResultDto>
 {
     private readonly ISessionChatRepository _chatRepository;
+    private readonly ISessionRepository _sessionRepository;
 
-    public GetSessionChatQueryHandler(ISessionChatRepository chatRepository)
+    public GetSessionChatQueryHandler(ISessionChatRepository chatRepository, ISessionRepository sessionRepository)
     {
         _chatRepository = chatRepository;
+        _sessionRepository = sessionRepository;
     }
 
     public async Task<SessionChatResultDto> Handle(GetSessionChatQuery request, CancellationToken cancellationToken)
     {
+        // #3119: session chat is owner/participant-only — enforce access before returning it.
+        var session = await _sessionRepository.GetByIdAsync(request.SessionId, cancellationToken).ConfigureAwait(false);
+        if (session is null)
+            throw new NotFoundException($"Session {request.SessionId} not found.");
+        if (!session.IsAccessibleBy(request.RequestedBy))
+            throw new ForbiddenException("You do not have access to this session.");
+
         var messages = await _chatRepository.GetBySessionIdAsync(
             request.SessionId,
             request.Limit,

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/ExportSessionHandlers.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/ExportSessionHandlers.cs
@@ -49,6 +49,12 @@ public sealed class ExportSessionPdfQueryHandler : IRequestHandler<ExportSession
             throw new NotFoundException($"Session {request.SessionId} not found.");
         }
 
+        // #3119: PDF export is owner/participant-only.
+        if (!session.IsAccessibleBy(request.RequestedBy))
+        {
+            throw new ForbiddenException("You do not have access to this session.");
+        }
+
         // Get related data
         var scores = await _scoreEntryRepository.GetBySessionIdAsync(request.SessionId, cancellationToken).ConfigureAwait(false);
         var diceRolls = request.IncludeDiceHistory
@@ -327,9 +333,8 @@ public sealed class GenerateSessionShareLinkQueryHandler : IRequestHandler<Gener
             throw new NotFoundException($"Session {request.SessionId} not found.");
         }
 
-        // Verify user has access to the session
-        if (session.UserId != request.RequestedBy &&
-            !session.Participants.Any(p => p.UserId == request.RequestedBy))
+        // Verify user has access to the session (#3119: shared IsAccessibleBy predicate).
+        if (!session.IsAccessibleBy(request.RequestedBy))
         {
             throw new ForbiddenException("You do not have access to this session.");
         }

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/MediaQueries.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/MediaQueries.cs
@@ -6,7 +6,7 @@ namespace Api.BoundedContexts.SessionTracking.Application.Queries;
 /// Query to get all media for a session.
 /// Issue #4760
 /// </summary>
-public record GetSessionMediaQuery(Guid SessionId) : IRequest<IReadOnlyList<SessionMediaDto>>;
+public record GetSessionMediaQuery(Guid SessionId, Guid RequestedBy) : IRequest<IReadOnlyList<SessionMediaDto>>;
 
 /// <summary>
 /// Query to get media by snapshot.

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/MediaQueryHandlers.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/MediaQueryHandlers.cs
@@ -1,6 +1,7 @@
 using MediatR;
 using Api.BoundedContexts.SessionTracking.Application.Queries;
 using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using Api.Middleware.Exceptions;
 
 namespace Api.BoundedContexts.SessionTracking.Application.Queries;
 
@@ -11,14 +12,23 @@ namespace Api.BoundedContexts.SessionTracking.Application.Queries;
 public class GetSessionMediaQueryHandler : IRequestHandler<GetSessionMediaQuery, IReadOnlyList<SessionMediaDto>>
 {
     private readonly ISessionMediaRepository _mediaRepository;
+    private readonly ISessionRepository _sessionRepository;
 
-    public GetSessionMediaQueryHandler(ISessionMediaRepository mediaRepository)
+    public GetSessionMediaQueryHandler(ISessionMediaRepository mediaRepository, ISessionRepository sessionRepository)
     {
         _mediaRepository = mediaRepository;
+        _sessionRepository = sessionRepository;
     }
 
     public async Task<IReadOnlyList<SessionMediaDto>> Handle(GetSessionMediaQuery request, CancellationToken cancellationToken)
     {
+        // #3119: session media is owner/participant-only — enforce access before returning it.
+        var session = await _sessionRepository.GetByIdAsync(request.SessionId, cancellationToken).ConfigureAwait(false);
+        if (session is null)
+            throw new NotFoundException($"Session {request.SessionId} not found.");
+        if (!session.IsAccessibleBy(request.RequestedBy))
+            throw new ForbiddenException("You do not have access to this session.");
+
         var media = await _mediaRepository.GetBySessionIdAsync(request.SessionId, cancellationToken).ConfigureAwait(false);
 
         return media.Select(m => new SessionMediaDto(

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Entities/Session.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Entities/Session.cs
@@ -200,6 +200,13 @@ public class Session : IDomainEventSource
     public IReadOnlyCollection<Participant> Participants => _participants.AsReadOnly();
 
     /// <summary>
+    /// Whether <paramref name="userId"/> may read this session: the owner or any
+    /// participant. Single source of truth for session read-access authorization (#3119).
+    /// </summary>
+    public bool IsAccessibleBy(Guid userId) =>
+        UserId == userId || _participants.Any(p => p.UserId == userId);
+
+    /// <summary>
     /// Private constructor for EF Core.
     /// </summary>
     private Session()

--- a/apps/api/src/Api/Routing/SessionTracking/SessionQueryEndpoints.cs
+++ b/apps/api/src/Api/Routing/SessionTracking/SessionQueryEndpoints.cs
@@ -401,10 +401,17 @@ internal static class SessionQueryEndpoints
     {
         group.MapGet("/game-sessions/{sessionId:guid}/media", async (
             Guid sessionId,
+            HttpContext httpContext,
             IMediator mediator,
             CancellationToken ct) =>
         {
-            var query = new GetSessionMediaQuery(sessionId);
+            var userId = httpContext.User.GetUserId();
+            if (userId == Guid.Empty)
+            {
+                return Results.Unauthorized();
+            }
+
+            var query = new GetSessionMediaQuery(sessionId, userId);
             var result = await mediator.Send(query, ct).ConfigureAwait(false);
             return Results.Ok(result);
         })
@@ -413,7 +420,8 @@ internal static class SessionQueryEndpoints
         .WithTags("SessionTracking", "Media")
         .WithSummary("Get all media for a session")
         .Produces(200)
-        .Produces(401);
+        .Produces(401)
+        .Produces(403);
     }
 
     // ========== Chat Endpoints (Issue #4760) ==========
@@ -422,12 +430,19 @@ internal static class SessionQueryEndpoints
     {
         group.MapGet("/game-sessions/{sessionId:guid}/chat", async (
             Guid sessionId,
+            HttpContext httpContext,
             IMediator mediator,
             int? limit = null,
             int? offset = null,
             CancellationToken ct = default) =>
         {
-            var query = new GetSessionChatQuery(sessionId, limit, offset);
+            var userId = httpContext.User.GetUserId();
+            if (userId == Guid.Empty)
+            {
+                return Results.Unauthorized();
+            }
+
+            var query = new GetSessionChatQuery(sessionId, limit, offset, userId);
             var result = await mediator.Send(query, ct).ConfigureAwait(false);
             return Results.Ok(result);
         })
@@ -436,7 +451,8 @@ internal static class SessionQueryEndpoints
         .WithTags("SessionTracking", "Chat")
         .WithSummary("Get chat messages for a session (paginated)")
         .Produces(200)
-        .Produces(401);
+        .Produces(401)
+        .Produces(403);
     }
 
     // ========== Toolkit Session State Endpoints (Issue #5148 — Epic B5) ==========

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Handlers/ChatCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Handlers/ChatCommandHandlerTests.cs
@@ -394,17 +394,23 @@ public class DeleteChatMessageCommandHandlerTests
 public class MediaQueryHandlerTests
 {
     private readonly Mock<ISessionMediaRepository> _mockMediaRepo;
+    private readonly Mock<ISessionRepository> _mockSessionRepo;
 
     public MediaQueryHandlerTests()
     {
         _mockMediaRepo = new Mock<ISessionMediaRepository>();
+        _mockSessionRepo = new Mock<ISessionRepository>();
     }
 
     [Fact]
-    public async Task GetSessionMedia_ReturnsMediaDtos()
+    public async Task GetSessionMedia_WhenOwner_ReturnsMediaDtos()
     {
         // Arrange
-        var sessionId = Guid.NewGuid();
+        var ownerId = Guid.NewGuid();
+        var session = Session.Create(ownerId, Guid.NewGuid(), SessionType.Generic);
+        var sessionId = session.Id;
+        _mockSessionRepo.Setup(r => r.GetByIdAsync(sessionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(session);
         var media1 = SessionMedia.Create(
             sessionId, Guid.NewGuid(), "f1", "a.jpg", "image/jpeg", 100, SessionMediaType.Photo);
         var media2 = SessionMedia.Create(
@@ -413,8 +419,8 @@ public class MediaQueryHandlerTests
         _mockMediaRepo.Setup(r => r.GetBySessionIdAsync(sessionId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<SessionMedia> { media1, media2 });
 
-        var handler = new GetSessionMediaQueryHandler(_mockMediaRepo.Object);
-        var query = new Api.BoundedContexts.SessionTracking.Application.Queries.GetSessionMediaQuery(sessionId);
+        var handler = new GetSessionMediaQueryHandler(_mockMediaRepo.Object, _mockSessionRepo.Object);
+        var query = new GetSessionMediaQuery(sessionId, ownerId);
 
         // Act
         var result = await handler.Handle(query, TestContext.Current.CancellationToken);
@@ -423,6 +429,25 @@ public class MediaQueryHandlerTests
         result.Count.Should().Be(2);
         result[0].FileName.Should().Be("a.jpg");
         result[1].FileName.Should().Be("b.png");
+    }
+
+    [Fact]
+    public async Task GetSessionMedia_WhenNotOwnerOrParticipant_ThrowsForbidden()
+    {
+        // #3119 IDOR guard: a non-owner/non-participant must not read another user's session media.
+        var session = Session.Create(Guid.NewGuid(), Guid.NewGuid(), SessionType.Generic);
+        _mockSessionRepo.Setup(r => r.GetByIdAsync(session.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(session);
+
+        var handler = new GetSessionMediaQueryHandler(_mockMediaRepo.Object, _mockSessionRepo.Object);
+        var query = new GetSessionMediaQuery(session.Id, Guid.NewGuid());
+
+        var act = () => handler.Handle(query, TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<ForbiddenException>();
+        _mockMediaRepo.Verify(
+            r => r.GetBySessionIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 
     [Fact]
@@ -454,17 +479,23 @@ public class MediaQueryHandlerTests
 public class ChatQueryHandlerTests
 {
     private readonly Mock<ISessionChatRepository> _mockChatRepo;
+    private readonly Mock<ISessionRepository> _mockSessionRepo;
 
     public ChatQueryHandlerTests()
     {
         _mockChatRepo = new Mock<ISessionChatRepository>();
+        _mockSessionRepo = new Mock<ISessionRepository>();
     }
 
     [Fact]
-    public async Task GetSessionChat_ReturnsMessagesAndTotalCount()
+    public async Task GetSessionChat_WhenOwner_ReturnsMessagesAndTotalCount()
     {
         // Arrange
-        var sessionId = Guid.NewGuid();
+        var ownerId = Guid.NewGuid();
+        var session = Session.Create(ownerId, Guid.NewGuid(), SessionType.Generic);
+        var sessionId = session.Id;
+        _mockSessionRepo.Setup(r => r.GetByIdAsync(sessionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(session);
         var msg1 = SessionChatMessage.CreateTextMessage(sessionId, Guid.NewGuid(), "Hi", 1);
         var msg2 = SessionChatMessage.CreateSystemEvent(sessionId, "Game started", 2);
 
@@ -473,8 +504,8 @@ public class ChatQueryHandlerTests
         _mockChatRepo.Setup(r => r.GetCountBySessionIdAsync(sessionId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(2);
 
-        var handler = new GetSessionChatQueryHandler(_mockChatRepo.Object);
-        var query = new Api.BoundedContexts.SessionTracking.Application.Queries.GetSessionChatQuery(sessionId, 50, 0);
+        var handler = new GetSessionChatQueryHandler(_mockChatRepo.Object, _mockSessionRepo.Object);
+        var query = new GetSessionChatQuery(sessionId, 50, 0, ownerId);
 
         // Act
         var result = await handler.Handle(query, TestContext.Current.CancellationToken);
@@ -484,5 +515,24 @@ public class ChatQueryHandlerTests
         result.TotalCount.Should().Be(2);
         result.Messages[0].MessageType.Should().Be("Text");
         result.Messages[1].MessageType.Should().Be("SystemEvent");
+    }
+
+    [Fact]
+    public async Task GetSessionChat_WhenNotOwnerOrParticipant_ThrowsForbidden()
+    {
+        // #3119 IDOR guard: a non-owner/non-participant must not read another user's session chat.
+        var session = Session.Create(Guid.NewGuid(), Guid.NewGuid(), SessionType.Generic);
+        _mockSessionRepo.Setup(r => r.GetByIdAsync(session.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(session);
+
+        var handler = new GetSessionChatQueryHandler(_mockChatRepo.Object, _mockSessionRepo.Object);
+        var query = new GetSessionChatQuery(session.Id, 50, 0, Guid.NewGuid());
+
+        var act = () => handler.Handle(query, TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<ForbiddenException>();
+        _mockChatRepo.Verify(
+            r => r.GetBySessionIdAsync(It.IsAny<Guid>(), It.IsAny<int?>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()),
+            Times.Never);
     }
 }


### PR DESCRIPTION
Closes #3119

## Security (IDOR — broken object-level authorization)

Tre endpoint autenticati di SessionTracking ritornavano i dati di **qualsiasi** sessione a **qualsiasi** utente autenticato:
- `GET /game-sessions/{id}/export/pdf` (scoreboard, storia dadi/carte)
- `GET /game-sessions/{id}/media` (foto)
- `GET /game-sessions/{id}/chat` (messaggi)

Tutti e tre usavano `.RequireAuthenticatedUser()` ma **omettevano** il check di ownership che la sorella `GenerateSessionShareLink` già applicava. Gli endpoint intenzionalmente pubblici usano `.AllowAnonymous()` → conferma che questi erano owner-only.

## Modifiche

- **`Session.IsAccessibleBy(userId)`** domain method = singola fonte di verità del predicato di accesso (owner o participant); `GenerateSessionShareLink` refactorato per usarlo.
- **Export handler**: enforce `IsAccessibleBy` (caricava già la sessione).
- **Media/Chat handler**: iniettano `ISessionRepository`, caricano la sessione, enforce access; aggiunto `RequestedBy` a `GetSessionMediaQuery`/`GetSessionChatQuery`; gli endpoint passano l'id del **caller** (da `httpContext.User.GetUserId()`, non spoofabile).
- **Test**: un non-owner/non-participant riceve `ForbiddenException` (403) e il repo dati NON viene interrogato; happy-path owner preservato.

## Verifica

- ✅ `dotnet test`: 5/5 unit test modificati verdi (owner + IDOR-403 media/chat); suite SessionTracking completa **994 pass / 0 fail** (l'exit non-zero era un crash testhost di un integration test Testcontainers non correlato)
- ✅ pre-commit + pre-push (backend build) verdi

## Scope

Fix limitato ai 3 endpoint della issue. `GetMediaBySnapshot`, `GetSessionDetails`, `GetScoreboard` non sono in scope (l'agent li aveva esclusi per cautela — possibile design pubblico; da valutare separatamente).

---
🤖 Emersa da tech-debt discovery workflow (multi-modal sweep → verifica avversariale). IDOR confermato.

🤖 Generated with [Claude Code](https://claude.com/claude-code)