### PR TITLE
chore(wikidata): alert on enrichment dead-letter and queue depth (#3117)

### DIFF
--- a/docs/for-developers/operations/operations-manual.md
+++ b/docs/for-developers/operations/operations-manual.md
@@ -2982,6 +2982,29 @@ Background metric contract:
 
 ---
 
+## Wikidata Enrichment Alerts
+
+Defined in `infra/prometheus/alerts/wikidata-enrichment.yml` (#3117). Distinct from the
+SSE-transport alert above (§22, `wikidata-sse.yml`): this covers the enrichment **pipeline**
+health. The gauges are emitted by `MeepleAiMetrics.WikidataEnrichment.cs` and routed via
+`severity: warning` → the `warning-alerts` receiver in `alertmanager.yml` (throttled email).
+Gauges report `0` when idle, so the expressions never fire on an idle queue.
+
+| Alert | Trigger | Sustained | Meaning / first action |
+|---|---|---|---|
+| `WikidataDeadLetterHigh` | `meepleai_wikidata_dead_letter_count > 100` | 1h | Operator triage backlog building. Investigate via the M13 admin dead-letter page — likely a license-whitelist or SPARQL schema drift. |
+| `WikidataDeadLetterSpike` | `delta(meepleai_wikidata_dead_letter_count[5m]) > 50` | — | A sudden burst of dead-letters: systemic upstream failure or license-whitelist drift. Cross-check `WikidataSparqlLatency` p95 and Wikidata/Commons endpoint health. |
+| `WikidataQueueBacklogHigh` | `meepleai_wikidata_queue_depth > 5000` | 1h | Enrichment backlog building; scheduler under-provisioned relative to enrichment rate. Consider tuning batch size or the DEC-3e rate-limiter. |
+
+### Investigation steps
+
+1. **Dead-letter accumulation** (`WikidataDeadLetterHigh` / `WikidataDeadLetterSpike`): open the M13 admin dead-letter page. A steady climb usually means a license-whitelist entry went stale or the SPARQL query drifted; a sharp spike points at a Wikidata/Commons outage. Cross-check the enrichment attempt outcomes (`meepleai_wikidata_enrichment_attempts_total{outcome="dead_letter"}`).
+2. **Queue not draining** (`WikidataQueueBacklogHigh`): the M9 scheduler is enqueuing faster than the enrichment runner drains. Check the Quartz job health and the DEC-3e rate-limiter; consider raising the batch size if the SPARQL endpoint has headroom.
+
+Alert unit tests live in `infra/prometheus/alerts/wikidata-enrichment.test.yml` (run `promtool test rules` per the header comment; there is no CI promtool gate, so run on demand).
+
+---
+
 ## Appendix A: Complete Command Reference
 
 ### Service Management

--- a/infra/compose.prod.yml
+++ b/infra/compose.prod.yml
@@ -227,6 +227,7 @@ services:
       - ./prometheus-rules.yml:/etc/prometheus/prometheus-rules.yml:ro
       # Issue #2470 — Wikidata SSE plane starvation alert.
       - ./prometheus/alerts/wikidata-sse.yml:/etc/prometheus/wikidata-sse.yml:ro
+      - ./prometheus/alerts/wikidata-enrichment.yml:/etc/prometheus/wikidata-enrichment.yml:ro
       # Issue #3082 — BGG ToS-compliance SLO=0 alert.
       - ./prometheus/alerts/bgg-tos-compliance.yml:/etc/prometheus/bgg-tos-compliance.yml:ro
       # Issue #3112 — OPS-02 Slack delivery observability alerts.

--- a/infra/compose.staging.yml
+++ b/infra/compose.staging.yml
@@ -334,6 +334,7 @@ services:
       - ./prometheus/alerts/runner-availability.yml:/etc/prometheus/runner-availability.yml:ro
       # Issue #2470 — Wikidata SSE plane starvation alert.
       - ./prometheus/alerts/wikidata-sse.yml:/etc/prometheus/wikidata-sse.yml:ro
+      - ./prometheus/alerts/wikidata-enrichment.yml:/etc/prometheus/wikidata-enrichment.yml:ro
       # Issue #3082 — BGG ToS-compliance SLO=0 alert.
       - ./prometheus/alerts/bgg-tos-compliance.yml:/etc/prometheus/bgg-tos-compliance.yml:ro
       # Issue #3112 — OPS-02 Slack delivery observability alerts.

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -352,6 +352,7 @@ services:
       # Issue #3112 — OPS-02 Slack delivery alerts (referenced from prometheus.yml rule_files).
       - ./prometheus/alerts/slack-delivery.yml:/etc/prometheus/slack-delivery.yml:ro
       - ./prometheus/alerts/audit-outbox.yml:/etc/prometheus/audit-outbox.yml:ro
+      - ./prometheus/alerts/wikidata-enrichment.yml:/etc/prometheus/wikidata-enrichment.yml:ro
       - prometheus_data:/prometheus
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "http://localhost:9090/-/healthy"]

--- a/infra/prometheus.prod.yml
+++ b/infra/prometheus.prod.yml
@@ -23,6 +23,8 @@ rule_files:
   - '/etc/prometheus/prometheus-rules.yml'
   # Issue #2470 — Wikidata SSE plane starvation alerts.
   - '/etc/prometheus/wikidata-sse.yml'
+  # Issue #3117 — Wikidata enrichment pipeline-health alerts (dead-letter / queue depth).
+  - '/etc/prometheus/wikidata-enrichment.yml'
   # Issue #3082 — BGG ToS-compliance SLO=0 alert (any nonzero render attempt = P1).
   - '/etc/prometheus/bgg-tos-compliance.yml'
   # Issue #3112 — OPS-02 Slack delivery observability alerts.

--- a/infra/prometheus.staging.yml
+++ b/infra/prometheus.staging.yml
@@ -25,6 +25,8 @@ rule_files:
   - '/etc/prometheus/runner-availability.yml'
   # Issue #2470 — Wikidata SSE plane starvation alerts.
   - '/etc/prometheus/wikidata-sse.yml'
+  # Issue #3117 — Wikidata enrichment pipeline-health alerts (dead-letter / queue depth).
+  - '/etc/prometheus/wikidata-enrichment.yml'
   # Issue #3082 — BGG ToS-compliance SLO=0 alert (any nonzero render attempt = P1).
   - '/etc/prometheus/bgg-tos-compliance.yml'
   # Issue #3112 — OPS-02 Slack delivery observability alerts.

--- a/infra/prometheus.yml
+++ b/infra/prometheus.yml
@@ -30,6 +30,8 @@ rule_files:
   - '/etc/prometheus/runner-availability.yml'
   # Issue #2470 — Wikidata SSE plane starvation alerts.
   - '/etc/prometheus/wikidata-sse.yml'
+  # Issue #3117 — Wikidata enrichment pipeline-health alerts (dead-letter / queue depth).
+  - '/etc/prometheus/wikidata-enrichment.yml'
   # Issue #3082 — BGG ToS-compliance SLO=0 alert (any nonzero render attempt = P1).
   - '/etc/prometheus/bgg-tos-compliance.yml'
   # Issue #3112 — OPS-02 Slack delivery observability alerts.

--- a/infra/prometheus/alerts/wikidata-enrichment.test.yml
+++ b/infra/prometheus/alerts/wikidata-enrichment.test.yml
@@ -1,0 +1,94 @@
+# promtool unit tests for wikidata-enrichment.yml (#3117).
+#
+# Run locally (Windows/Git Bash, from repo root):
+#   docker run --rm -v "$(pwd)/infra/prometheus/alerts:/work" prom/prometheus:v3.7.0 \
+#     promtool test rules /work/wikidata-enrichment.test.yml
+#
+# There is no promtool CI gate in this repo (see recon in #3082); this file documents +
+# verifies the alert behaviour on demand.
+rule_files:
+  - wikidata-enrichment.yml
+
+evaluation_interval: 1m
+
+tests:
+  # Dead-letter backlog above 100 sustained >1h -> WikidataDeadLetterHigh fires.
+  - interval: 1m
+    input_series:
+      - series: 'meepleai_wikidata_dead_letter_count'
+        values: '150x65'
+    alert_rule_test:
+      - eval_time: 62m
+        alertname: WikidataDeadLetterHigh
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              subsystem: wikidata-enrichment
+            exp_annotations:
+              summary: "Wikidata dead-letter backlog above 100 (sustained 1h)"
+              description: "meepleai_wikidata_dead_letter_count has stayed above 100 for 1h: an operator triage backlog is building. Investigate via the M13 admin dead-letter page — likely a license-whitelist drift or SPARQL schema drift in the enrichment pipeline."
+              runbook_url: "https://github.com/meepleAi-app/meepleai-monorepo/blob/main-dev/docs/for-developers/operations/operations-manual.md#wikidata-enrichment-alerts"
+
+  # Below threshold (50) -> no alert. Idle (0) is also below threshold.
+  - interval: 1m
+    input_series:
+      - series: 'meepleai_wikidata_dead_letter_count'
+        values: '50x65'
+    alert_rule_test:
+      - eval_time: 62m
+        alertname: WikidataDeadLetterHigh
+        exp_alerts: []
+
+  # A sharp jump (0 -> 300 over 5m, +60/min) -> WikidataDeadLetterSpike fires.
+  - interval: 1m
+    input_series:
+      - series: 'meepleai_wikidata_dead_letter_count'
+        values: '0+60x6'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: WikidataDeadLetterSpike
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              subsystem: wikidata-enrichment
+            exp_annotations:
+              summary: "Wikidata dead-letter count jumped by more than 50 in 5m"
+              description: "meepleai_wikidata_dead_letter_count rose by more than 50 within 5 minutes: a systemic upstream failure or a license-whitelist drift. Cross-check WikidataSparqlLatency p95 and the Wikidata/Commons endpoint health."
+              runbook_url: "https://github.com/meepleAi-app/meepleai-monorepo/blob/main-dev/docs/for-developers/operations/operations-manual.md#wikidata-enrichment-alerts"
+
+  # Stable dead-letter count (no growth) -> delta ~0 -> WikidataDeadLetterSpike does not fire.
+  - interval: 1m
+    input_series:
+      - series: 'meepleai_wikidata_dead_letter_count'
+        values: '120x6'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: WikidataDeadLetterSpike
+        exp_alerts: []
+
+  # Queue depth above 5000 sustained >1h -> WikidataQueueBacklogHigh fires.
+  - interval: 1m
+    input_series:
+      - series: 'meepleai_wikidata_queue_depth'
+        values: '6000x65'
+    alert_rule_test:
+      - eval_time: 62m
+        alertname: WikidataQueueBacklogHigh
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              subsystem: wikidata-enrichment
+            exp_annotations:
+              summary: "Wikidata enrichment queue depth above 5000 (sustained 1h)"
+              description: "meepleai_wikidata_queue_depth has stayed above 5000 for 1h: the enrichment backlog is building and the scheduler is under-provisioned relative to the enrichment rate. Consider tuning the batch size or the DEC-3e rate-limiter."
+              runbook_url: "https://github.com/meepleAi-app/meepleai-monorepo/blob/main-dev/docs/for-developers/operations/operations-manual.md#wikidata-enrichment-alerts"
+
+  # Idle queue (0) -> no alert.
+  - interval: 1m
+    input_series:
+      - series: 'meepleai_wikidata_queue_depth'
+        values: '0x65'
+    alert_rule_test:
+      - eval_time: 62m
+        alertname: WikidataQueueBacklogHigh
+        exp_alerts: []

--- a/infra/prometheus/alerts/wikidata-enrichment.yml
+++ b/infra/prometheus/alerts/wikidata-enrichment.yml
@@ -1,0 +1,50 @@
+# Issue #3117 — Wikidata enrichment pipeline-health alerts.
+#
+# Distinct from wikidata-sse.yml (#2470), which alerts only the SSE *transport* (admin
+# dead-letter page subscribers/messages). This file alerts the enrichment *pipeline* health.
+#
+# Metric source (apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.WikidataEnrichment.cs).
+# ObservableGauges; Prometheus names = the C# dotted names with dots -> underscores, NO unit
+# suffix:
+#   - meepleai_wikidata_dead_letter_count  (cumulative dead-letter enrichment rows; can drop
+#                                            when the retention job prunes)
+#   - meepleai_wikidata_queue_depth        (#SharedGames due for enrichment in the last batch)
+# Both are populated in prod (WikidataCoverEnrichmentRunner / RetentionJob / EnrichmentJob) but
+# had NO alert rule — dead-letter accumulation and a non-draining queue stayed invisible.
+#
+# Thresholds are taken verbatim from the "Suggested alerting" blocks in the metric source.
+# Routing: severity=warning -> `warning-alerts` route in alertmanager.yml (throttled email),
+# operational signal. Gauges report 0 when idle, so the expressions never fire on an idle queue.
+groups:
+  - name: meepleai_wikidata_enrichment_alerts
+    rules:
+      - alert: WikidataDeadLetterHigh
+        expr: meepleai_wikidata_dead_letter_count > 100
+        for: 1h
+        labels:
+          severity: warning
+          subsystem: wikidata-enrichment
+        annotations:
+          summary: "Wikidata dead-letter backlog above 100 (sustained 1h)"
+          description: "meepleai_wikidata_dead_letter_count has stayed above 100 for 1h: an operator triage backlog is building. Investigate via the M13 admin dead-letter page — likely a license-whitelist drift or SPARQL schema drift in the enrichment pipeline."
+          runbook_url: "https://github.com/meepleAi-app/meepleai-monorepo/blob/main-dev/docs/for-developers/operations/operations-manual.md#wikidata-enrichment-alerts"
+      - alert: WikidataDeadLetterSpike
+        expr: delta(meepleai_wikidata_dead_letter_count[5m]) > 50
+        for: 0m
+        labels:
+          severity: warning
+          subsystem: wikidata-enrichment
+        annotations:
+          summary: "Wikidata dead-letter count jumped by more than 50 in 5m"
+          description: "meepleai_wikidata_dead_letter_count rose by more than 50 within 5 minutes: a systemic upstream failure or a license-whitelist drift. Cross-check WikidataSparqlLatency p95 and the Wikidata/Commons endpoint health."
+          runbook_url: "https://github.com/meepleAi-app/meepleai-monorepo/blob/main-dev/docs/for-developers/operations/operations-manual.md#wikidata-enrichment-alerts"
+      - alert: WikidataQueueBacklogHigh
+        expr: meepleai_wikidata_queue_depth > 5000
+        for: 1h
+        labels:
+          severity: warning
+          subsystem: wikidata-enrichment
+        annotations:
+          summary: "Wikidata enrichment queue depth above 5000 (sustained 1h)"
+          description: "meepleai_wikidata_queue_depth has stayed above 5000 for 1h: the enrichment backlog is building and the scheduler is under-provisioned relative to the enrichment rate. Consider tuning the batch size or the DEC-3e rate-limiter."
+          runbook_url: "https://github.com/meepleAi-app/meepleai-monorepo/blob/main-dev/docs/for-developers/operations/operations-manual.md#wikidata-enrichment-alerts"


### PR DESCRIPTION
## Summary
The enrichment pipeline gauges `meepleai_wikidata_dead_letter_count` and `meepleai_wikidata_queue_depth` are populated in prod but had **no alert rule** — only the SSE *transport* is alerted (`wikidata-sse.yml`, #2470), not the pipeline health. Dead-letter accumulation and a non-draining queue stayed invisible.

## Changes
- New `infra/prometheus/alerts/wikidata-enrichment.yml` — 3 warning alerts: `WikidataDeadLetterHigh` (>100/1h), `WikidataDeadLetterSpike` (`delta[5m]>50`), `WikidataQueueBacklogHigh` (>5000/1h). **All thresholds verbatim from the metric-source "Suggested alerting" blocks.**
- New `wikidata-enrichment.test.yml` promtool companion.
- `rule_files` wiring in the 3 prometheus configs + volume mounts in the 3 compose files (anchored after `wikidata-sse` to avoid churn).
- operations-manual runbook (`#wikidata-enrichment-alerts`).
- No application code changes.

## Validation
`promtool check rules` + `promtool test rules`: **SUCCESS** (verified locally via `prom/prometheus:v3.7.0`).

Closes #3117

🤖 Generated with [Claude Code](https://claude.com/claude-code)