### PR TITLE
feat(session-summary): #3022 Catan SUMMARY flavor (real per-player scores)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/GameSessionDto.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/GameSessionDto.cs
@@ -22,7 +22,12 @@ internal record GameSessionDto(
     // ScoringType ∈ { "Points", "BinaryWin", "Objectives", "Ranking" };
     // ScoreData is the raw JSON payload (shape varies by ScoringType).
     string? ScoringType = null,
-    string? ScoreData = null
+    string? ScoreData = null,
+    // #3022: identity + score-aligned players for the summary flavor. Populated ONLY on
+    // GET /api/v1/sessions/{id}; null on list/history paths (GameSessionMapper.ToDto).
+    string? GameSlug = null,
+    string? GameName = null,
+    IReadOnlyList<ScorePlayerDto>? ScorePlayers = null
 );
 
 /// <summary>
@@ -31,6 +36,16 @@ internal record GameSessionDto(
 internal record SessionPlayerDto(
     string PlayerName,
     int PlayerOrder,
+    string? Color
+);
+
+/// <summary>
+/// #3022: a player whose Id matches scoreData.scores[].playerId (LiveGameSession player),
+/// carrying the display name and color needed to render per-player scores in the summary.
+/// </summary>
+internal record ScorePlayerDto(
+    Guid Id,
+    string DisplayName,
     string? Color
 );
 

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GetGameSessionByIdQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GetGameSessionByIdQueryHandler.cs
@@ -1,38 +1,63 @@
 using Api.BoundedContexts.GameManagement.Application.DTOs;
-using Api.BoundedContexts.GameManagement.Application.Queries;
 using Api.BoundedContexts.GameManagement.Domain.Entities;
 using Api.BoundedContexts.GameManagement.Domain.Repositories;
+using Api.SharedKernel.Application;
 using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Application.Services;
+using Api.SharedKernel.Domain.ValueObjects;
 
 namespace Api.BoundedContexts.GameManagement.Application.Queries;
 
 /// <summary>
-/// Handles get game session by ID query.
+/// Handles get game session by ID query. On this single-session path (unlike the
+/// list/history path) the DTO is enriched with the game slug/name (#3022) and the
+/// polymorphic score + score-aligned players for the summary flavor.
 /// </summary>
 internal class GetGameSessionByIdQueryHandler : IQueryHandler<GetGameSessionByIdQuery, GameSessionDto?>
 {
     private readonly IGameSessionRepository _sessionRepository;
+    private readonly IGameCoreDataProvider _gameCoreData;
+    private readonly IHistorySessionScoreProvider _scoreProvider;
 
-    public GetGameSessionByIdQueryHandler(IGameSessionRepository sessionRepository)
+    public GetGameSessionByIdQueryHandler(
+        IGameSessionRepository sessionRepository,
+        IGameCoreDataProvider gameCoreData,
+        IHistorySessionScoreProvider scoreProvider)
     {
         _sessionRepository = sessionRepository ?? throw new ArgumentNullException(nameof(sessionRepository));
+        _gameCoreData = gameCoreData ?? throw new ArgumentNullException(nameof(gameCoreData));
+        _scoreProvider = scoreProvider ?? throw new ArgumentNullException(nameof(scoreProvider));
     }
 
     public async Task<GameSessionDto?> Handle(GetGameSessionByIdQuery query, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(query);
         var session = await _sessionRepository.GetByIdAsync(query.SessionId, cancellationToken).ConfigureAwait(false);
+        if (session == null) return null;
 
-        return session != null ? MapToDto(session) : null;
+        var coreData = await _gameCoreData
+            .GetCoreDataAsync(GameRef.Shared(session.GameId), cancellationToken).ConfigureAwait(false);
+        var gameName = coreData?.Title;
+        var gameSlug = gameName is null ? null : Slugifier.Slugify(gameName);
+
+        var scoreboard = await _scoreProvider
+            .GetScoreboardAsync(session.Id, cancellationToken).ConfigureAwait(false);
+
+        return MapToDto(session, gameSlug, gameName, scoreboard);
     }
 
-    private static GameSessionDto MapToDto(GameSession session)
+    private static GameSessionDto MapToDto(
+        GameSession session, string? gameSlug, string? gameName, SessionScoreboard? scoreboard)
     {
         var playerDtos = session.Players.Select(p => new SessionPlayerDto(
             PlayerName: p.PlayerName,
             PlayerOrder: p.PlayerOrder,
             Color: p.Color
         )).ToList();
+
+        var scorePlayers = scoreboard?.Players
+            .Select(sp => new ScorePlayerDto(sp.Id, sp.DisplayName, sp.Color))
+            .ToList();
 
         return new GameSessionDto(
             Id: session.Id,
@@ -44,7 +69,12 @@ internal class GetGameSessionByIdQueryHandler : IQueryHandler<GetGameSessionById
             Players: playerDtos,
             WinnerName: session.WinnerName,
             Notes: session.Notes,
-            DurationMinutes: (int)session.Duration.TotalMinutes
+            DurationMinutes: (int)session.Duration.TotalMinutes,
+            ScoringType: scoreboard?.ScoringType,
+            ScoreData: scoreboard?.ScoreData,
+            GameSlug: gameSlug,
+            GameName: gameName,
+            ScorePlayers: scorePlayers
         );
     }
 }

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/IHistorySessionScoreProvider.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/IHistorySessionScoreProvider.cs
@@ -21,6 +21,13 @@ internal interface IHistorySessionScoreProvider
     Task<IReadOnlyDictionary<Guid, HistorySessionScore>> GetScoresAsync(
         IReadOnlyCollection<Guid> gameSessionIds,
         CancellationToken cancellationToken);
+
+    /// <summary>
+    /// Resolves score + the players aligned to scoreData (LiveGameSession SessionPlayers,
+    /// whose Id == scoreData.scores[].playerId) for a single GameSession. Null when the
+    /// session has no correlated live/tracking session with a score. (#3022)
+    /// </summary>
+    Task<SessionScoreboard?> GetScoreboardAsync(Guid gameSessionId, CancellationToken cancellationToken);
 }
 
 /// <summary>
@@ -28,3 +35,16 @@ internal interface IHistorySessionScoreProvider
 /// ("Points" | "BinaryWin" | "Objectives" | "Ranking") and the raw JSON score data.
 /// </summary>
 internal readonly record struct HistorySessionScore(string ScoringType, string ScoreData);
+
+/// <summary>
+/// Score + the players aligned to scoreData for one session (#3022). Players are the
+/// LiveGameSession SessionPlayers, whose Id matches scoreData.scores[].playerId, so the
+/// FE can join per-player VP to a display name and color without name-matching.
+/// </summary>
+internal readonly record struct SessionScoreboard(
+    string ScoringType,
+    string ScoreData,
+    IReadOnlyList<ScorePlayerReadModel> Players);
+
+/// <summary>A player whose Id matches scoreData.scores[].playerId (#3022).</summary>
+internal readonly record struct ScorePlayerReadModel(Guid Id, string DisplayName, string Color);

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Persistence/HistorySessionScoreProvider.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Persistence/HistorySessionScoreProvider.cs
@@ -61,4 +61,31 @@ internal sealed class HistorySessionScoreProvider : IHistorySessionScoreProvider
                     return new HistorySessionScore(latest.ScoringType, latest.ScoreData);
                 });
     }
+
+    public async Task<SessionScoreboard?> GetScoreboardAsync(
+        Guid gameSessionId,
+        CancellationToken cancellationToken)
+    {
+        // Bridge GameSession → LiveGameSession → SessionTracking.Session (owns score_data).
+        var scoreRow = await (
+            from live in _dbContext.LiveGameSessions.AsNoTracking()
+            where live.CorrelatedGameSessionId == gameSessionId
+            join track in _dbContext.SessionTrackingSessions.AsNoTracking()
+                on live.TrackingSessionId equals (Guid?)track.Id
+            orderby (track.UpdatedAt ?? track.CreatedAt) descending
+            select new { LiveId = live.Id, track.ScoringType, track.ScoreData }
+        ).FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
+
+        if (scoreRow is null)
+            return null;
+
+        // The SessionPlayers on that same LiveGameSession are the identity space of
+        // scoreData.scores[].playerId, and carry DisplayName + Color.
+        var players = await _dbContext.SessionPlayers.AsNoTracking()
+            .Where(p => p.LiveGameSessionId == scoreRow.LiveId)
+            .Select(p => new ScorePlayerReadModel(p.Id, p.DisplayName, p.Color))
+            .ToListAsync(cancellationToken).ConfigureAwait(false);
+
+        return new SessionScoreboard(scoreRow.ScoringType, scoreRow.ScoreData, players);
+    }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/GetGameSessionByIdQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/GetGameSessionByIdQueryHandlerTests.cs
@@ -7,6 +7,9 @@ using Moq;
 using Xunit;
 using FluentAssertions;
 using Api.Tests.Constants;
+using Api.SharedKernel.Application;
+using Api.SharedKernel.Domain.ValueObjects;
+using Api.BoundedContexts.GameManagement.Application.Mappers;
 
 namespace Api.Tests.BoundedContexts.GameManagement.Application.Handlers;
 
@@ -17,12 +20,71 @@ namespace Api.Tests.BoundedContexts.GameManagement.Application.Handlers;
 public class GetGameSessionByIdQueryHandlerTests
 {
     private readonly Mock<IGameSessionRepository> _sessionRepositoryMock;
+    private readonly Mock<IGameCoreDataProvider> _gameCoreDataMock;
+    private readonly Mock<IHistorySessionScoreProvider> _scoreProviderMock;
     private readonly GetGameSessionByIdQueryHandler _handler;
 
     public GetGameSessionByIdQueryHandlerTests()
     {
         _sessionRepositoryMock = new Mock<IGameSessionRepository>();
-        _handler = new GetGameSessionByIdQueryHandler(_sessionRepositoryMock.Object);
+        _gameCoreDataMock = new Mock<IGameCoreDataProvider>();
+        _scoreProviderMock = new Mock<IHistorySessionScoreProvider>();
+        _handler = new GetGameSessionByIdQueryHandler(
+            _sessionRepositoryMock.Object, _gameCoreDataMock.Object, _scoreProviderMock.Object);
+    }
+
+    private static GameCoreData MakeCoreData(string title = "Catan") =>
+        GameCoreData.Create(title, 1995, 3, 4, 90, 10);
+
+    [Fact]
+    public async Task Handle_PopulatesSlugNameAndScoreboard()
+    {
+        var gameId = Guid.NewGuid();
+        var session = CreateSession(gameId);
+        var pid = Guid.NewGuid();
+        _sessionRepositoryMock.Setup(r => r.GetByIdAsync(session.Id, It.IsAny<CancellationToken>())).ReturnsAsync(session);
+        _gameCoreDataMock.Setup(p => p.GetCoreDataAsync(GameRef.Shared(gameId), It.IsAny<CancellationToken>())).ReturnsAsync(MakeCoreData("Catan"));
+        _scoreProviderMock.Setup(p => p.GetScoreboardAsync(session.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new SessionScoreboard("Points", "{\"scores\":[]}",
+                new List<ScorePlayerReadModel> { new(pid, "Alice", "Red") }));
+
+        var result = await _handler.Handle(new GetGameSessionByIdQuery(session.Id), TestContext.Current.CancellationToken);
+
+        result.Should().NotBeNull();
+        result!.GameSlug.Should().Be("catan");
+        result.GameName.Should().Be("Catan");
+        result.ScoringType.Should().Be("Points");
+        result.ScorePlayers.Should().ContainSingle(sp => sp.Id == pid && sp.DisplayName == "Alice" && sp.Color == "Red");
+    }
+
+    [Fact]
+    public async Task Handle_NoScoreboard_LeavesScoreFieldsNull()
+    {
+        var gameId = Guid.NewGuid();
+        var session = CreateSession(gameId);
+        _sessionRepositoryMock.Setup(r => r.GetByIdAsync(session.Id, It.IsAny<CancellationToken>())).ReturnsAsync(session);
+        _gameCoreDataMock.Setup(p => p.GetCoreDataAsync(It.IsAny<GameRef>(), It.IsAny<CancellationToken>())).ReturnsAsync((GameCoreData?)null);
+        _scoreProviderMock.Setup(p => p.GetScoreboardAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync((SessionScoreboard?)null);
+
+        var result = await _handler.Handle(new GetGameSessionByIdQuery(session.Id), TestContext.Current.CancellationToken);
+
+        result.Should().NotBeNull();
+        result!.GameSlug.Should().BeNull();
+        result.GameName.Should().BeNull();
+        result.ScoringType.Should().BeNull();
+        result.ScorePlayers.Should().BeNull();
+    }
+
+    [Fact]
+    public void ToDto_LeavesSummaryOnlyFieldsNull()
+    {
+        var session = CreateSession(Guid.NewGuid());
+
+        var dto = session.ToDto();
+
+        dto.GameSlug.Should().BeNull();
+        dto.GameName.Should().BeNull();
+        dto.ScorePlayers.Should().BeNull();
     }
 
     [Fact]

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Infrastructure/Persistence/HistorySessionScoreProviderScoreboardTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Infrastructure/Persistence/HistorySessionScoreProviderScoreboardTests.cs
@@ -66,4 +66,29 @@ public class HistorySessionScoreProviderScoreboardTests
 
         result.Should().BeNull();
     }
+
+    [Fact]
+    public async Task GetScoreboardAsync_MultipleCorrelated_ReturnsMostRecentTracking()
+    {
+        var db = TestDbContextFactory.CreateInMemoryDbContext();
+        var gameSessionId = Guid.NewGuid();
+        var liveOld = Guid.NewGuid();
+        var liveNew = Guid.NewGuid();
+        var trackOld = Guid.NewGuid();
+        var trackNew = Guid.NewGuid();
+
+        db.LiveGameSessions.AddRange(
+            new LiveGameSessionEntity { Id = liveOld, SessionCode = "S1", GameName = "Catan", ScoringConfigJson = "{}", CorrelatedGameSessionId = gameSessionId, TrackingSessionId = trackOld },
+            new LiveGameSessionEntity { Id = liveNew, SessionCode = "S2", GameName = "Catan", ScoringConfigJson = "{}", CorrelatedGameSessionId = gameSessionId, TrackingSessionId = trackNew });
+        db.SessionTrackingSessions.AddRange(
+            new SessionEntity { Id = trackOld, GameId = Guid.NewGuid(), ScoringType = "Points", ScoreData = "{\"scores\":[]}", UpdatedAt = new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc) },
+            new SessionEntity { Id = trackNew, GameId = Guid.NewGuid(), ScoringType = "BinaryWin", ScoreData = "{\"results\":[]}", UpdatedAt = new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc) });
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var sut = new HistorySessionScoreProvider(db);
+        var result = await sut.GetScoreboardAsync(gameSessionId, TestContext.Current.CancellationToken);
+
+        result.Should().NotBeNull();
+        result!.Value.ScoringType.Should().Be("BinaryWin");
+    }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Infrastructure/Persistence/HistorySessionScoreProviderScoreboardTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Infrastructure/Persistence/HistorySessionScoreProviderScoreboardTests.cs
@@ -1,0 +1,69 @@
+using Api.BoundedContexts.GameManagement.Infrastructure.Persistence;
+using Api.Infrastructure.Entities.GameManagement;
+using Api.Infrastructure.Entities.SessionTracking;
+using Api.Tests.Constants;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Infrastructure.Persistence;
+
+/// <summary>
+/// #3022 — GetScoreboardAsync bridges GameSession → LiveGameSession to return the
+/// polymorphic score plus the SessionPlayers aligned to scoreData.playerId.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+public class HistorySessionScoreProviderScoreboardTests
+{
+    [Fact]
+    public async Task GetScoreboardAsync_ReturnsScoreAndAlignedPlayers()
+    {
+        var db = TestDbContextFactory.CreateInMemoryDbContext();
+        var gameSessionId = Guid.NewGuid();
+        var liveId = Guid.NewGuid();
+        var trackingId = Guid.NewGuid();
+        var p1 = Guid.NewGuid();
+        var p2 = Guid.NewGuid();
+
+        db.LiveGameSessions.Add(new LiveGameSessionEntity
+        {
+            Id = liveId,
+            SessionCode = "S-TEST",
+            GameName = "Catan",
+            ScoringConfigJson = "{}",
+            CorrelatedGameSessionId = gameSessionId,
+            TrackingSessionId = trackingId,
+        });
+        db.SessionPlayers.AddRange(
+            new SessionPlayerEntity { Id = p1, LiveGameSessionId = liveId, DisplayName = "Alice", Color = "Red", Role = "Player" },
+            new SessionPlayerEntity { Id = p2, LiveGameSessionId = liveId, DisplayName = "Bob", Color = "Blue", Role = "Player" });
+        db.SessionTrackingSessions.Add(new SessionEntity
+        {
+            Id = trackingId,
+            GameId = Guid.NewGuid(),
+            ScoringType = "Points",
+            ScoreData = $"{{\"scores\":[{{\"playerId\":\"{p1}\",\"points\":10}},{{\"playerId\":\"{p2}\",\"points\":8}}]}}",
+        });
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var sut = new HistorySessionScoreProvider(db);
+        var result = await sut.GetScoreboardAsync(gameSessionId, TestContext.Current.CancellationToken);
+
+        result.Should().NotBeNull();
+        result!.Value.ScoringType.Should().Be("Points");
+        result.Value.Players.Should().HaveCount(2);
+        result.Value.Players.Should().ContainSingle(p => p.Id == p1 && p.DisplayName == "Alice" && p.Color == "Red");
+        result.Value.Players.Should().ContainSingle(p => p.Id == p2 && p.DisplayName == "Bob" && p.Color == "Blue");
+    }
+
+    [Fact]
+    public async Task GetScoreboardAsync_NoCorrelatedLive_ReturnsNull()
+    {
+        var db = TestDbContextFactory.CreateInMemoryDbContext();
+        var sut = new HistorySessionScoreProvider(db);
+
+        var result = await sut.GetScoreboardAsync(Guid.NewGuid(), TestContext.Current.CancellationToken);
+
+        result.Should().BeNull();
+    }
+}

--- a/apps/web/src/app/(authenticated)/sessions/[id]/_components/SessionSummaryView.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/[id]/_components/SessionSummaryView.tsx
@@ -67,6 +67,10 @@ import { Suspense, useCallback, useEffect, useMemo, useState, type ReactElement 
 import { useParams, usePathname, useRouter, useSearchParams } from 'next/navigation';
 
 import {
+  SummaryFlavorRenderer,
+  hasSummaryFlavor,
+} from '@/components/features/session-live/SummaryFlavorRenderer';
+import {
   AchievementsCarousel,
   ChatHighlights,
   ConnectionBar,
@@ -892,6 +896,18 @@ export function SessionSummaryView({
       data-ui-state={fsmCell.kind}
       className="mx-auto max-w-[1200px] pb-12"
     >
+      {/* #3022: per-game summary flavor (Catan…), completed sessions only. */}
+      {sessionQuery.data != null &&
+        sessionQuery.data.status === 'Completed' &&
+        hasSummaryFlavor(sessionQuery.data.gameSlug) && (
+          <div className="px-4 pt-4 sm:px-6">
+            <SummaryFlavorRenderer
+              gameSlug={sessionQuery.data.gameSlug}
+              session={sessionQuery.data}
+            />
+          </div>
+        )}
+
       <SessionSummaryHero
         rankedParticipants={rankedParticipants}
         showConfetti={showConfetti}

--- a/apps/web/src/app/(authenticated)/sessions/[id]/_components/__tests__/SessionSummaryView.test.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/[id]/_components/__tests__/SessionSummaryView.test.tsx
@@ -76,6 +76,17 @@ vi.mock('@/hooks/queries/useSessionSnapshots', () => ({
   useSessionVisionSnapshots: () => useSessionVisionSnapshotsMock(),
 }));
 
+// #3022: the flavor renderer is a lazy (next/dynamic) module tested on its own
+// (CatanSummaryFlavor.test + SummaryFlavorRenderer.test). Here we mock it with a
+// synchronous marker so this suite exercises the *wiring* (status/slug gate) without
+// the dynamic-import loading race.
+vi.mock('@/components/features/session-live/SummaryFlavorRenderer', () => ({
+  hasSummaryFlavor: (slug: string | null | undefined) => slug === 'catan',
+  SummaryFlavorRenderer: ({ gameSlug }: { gameSlug: string | null | undefined }) => (
+    <div data-testid="summary-flavor-mounted" data-slug={gameSlug ?? ''} />
+  ),
+}));
+
 // ─── visual-test-fixture mock (STATE_OVERRIDE_ENABLED stays true in test) ─
 
 // In test env (NODE_ENV=test), STATE_OVERRIDE_ENABLED = true → ?fixture= active.
@@ -144,6 +155,12 @@ const MESSAGES: Record<string, string> = {
   'pages.sessionSummary.states.notFound.backToSessions': 'Torna alle sessioni',
   'common.errorTitle': 'Errore',
   'common.retry': 'Riprova',
+  // #3022 Catan summary flavor
+  'pages.sessionSummary.flavor.catan.winnerTemplate': '{name} vince!',
+  'pages.sessionSummary.flavor.catan.vpUnit': 'PV',
+  'pages.sessionSummary.flavor.catan.durationTemplate': '{minutes} min',
+  'pages.sessionSummary.flavor.catan.standingsTitle': 'Classifica finale',
+  'pages.sessionSummary.flavor.catan.empty': 'Riepilogo non disponibile',
 };
 
 // ─── Test renderer with IntlProvider ─────────────────────────────────────
@@ -599,5 +616,46 @@ describe('SessionSummaryView — handlers', () => {
     renderView();
     fireEvent.click(screen.getByText('Torna alle sessioni'));
     expect(routerPush).toHaveBeenCalledWith('/sessions');
+  });
+});
+
+// ─── #3022 Catan summary flavor wiring ─────────────────────────────────────
+
+describe('SessionSummaryView — Catan summary flavor (#3022)', () => {
+  const catanSession = (overrides: Partial<GameSessionDto> = {}): GameSessionDto =>
+    makeGameSession({
+      gameSlug: 'catan',
+      scoringType: 'Points',
+      scoreData: JSON.stringify({
+        scores: [
+          { playerId: 'p1', points: 10 },
+          { playerId: 'p2', points: 8 },
+        ],
+      }),
+      scorePlayers: [
+        { id: 'p1', displayName: 'Marco Rossi', color: 'Red' },
+        { id: 'p2', displayName: 'Anna Bianchi', color: 'Blue' },
+      ],
+      ...overrides,
+    });
+
+  it('mounts the summary flavor for a completed Catan session, forwarding the slug', () => {
+    setHookSuccess(catanSession());
+    renderView();
+    const mounted = screen.getByTestId('summary-flavor-mounted');
+    expect(mounted).toBeInTheDocument();
+    expect(mounted).toHaveAttribute('data-slug', 'catan');
+  });
+
+  it('does NOT mount for a non-Catan game', () => {
+    setHookSuccess(catanSession({ gameSlug: 'wingspan' }));
+    renderView();
+    expect(screen.queryByTestId('summary-flavor-mounted')).toBeNull();
+  });
+
+  it('does NOT mount for a non-completed (Abandoned) session', () => {
+    setHookSuccess(catanSession({ status: 'Abandoned' }));
+    renderView();
+    expect(screen.queryByTestId('summary-flavor-mounted')).toBeNull();
   });
 });

--- a/apps/web/src/components/features/session-live/SummaryFlavorRenderer.tsx
+++ b/apps/web/src/components/features/session-live/SummaryFlavorRenderer.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import type { ComponentType } from 'react';
+
+import dynamic from 'next/dynamic';
+
+import type { GameSessionDto } from '@/lib/api/schemas/games.schemas';
+
+import { FlavorLoadingSkeleton } from './FlavorLoadingSkeleton';
+
+export interface SummaryFlavorProps {
+  readonly session: GameSessionDto;
+  readonly className?: string;
+}
+
+type SummaryFlavorComponent = ComponentType<SummaryFlavorProps>;
+
+// Lazy chunks minted at MODULE scope (never inside render) — same rule as FlavorRenderer.
+// This is the SUMMARY twin of FlavorRenderer: props are keyed on GameSessionDto (not the
+// live LiveSessionDto), so the two dispatchers stay type-disjoint.
+const CatanSummaryFlavorLazy: SummaryFlavorComponent = dynamic(
+  () => import('./flavors/catan/CatanSummaryFlavor').then(m => ({ default: m.CatanSummaryFlavor })),
+  { ssr: false, loading: () => <FlavorLoadingSkeleton /> }
+);
+
+const SUMMARY_FLAVOR_MAP: Record<string, SummaryFlavorComponent> = {
+  catan: CatanSummaryFlavorLazy,
+};
+
+export function hasSummaryFlavor(gameSlug: string | null | undefined): boolean {
+  return gameSlug != null && SUMMARY_FLAVOR_MAP[gameSlug] != null;
+}
+
+interface SummaryFlavorRendererProps extends SummaryFlavorProps {
+  readonly gameSlug: string | null | undefined;
+}
+
+export function SummaryFlavorRenderer({
+  gameSlug,
+  session,
+  className,
+}: SummaryFlavorRendererProps): React.JSX.Element | null {
+  const LazyFlavor = gameSlug != null ? SUMMARY_FLAVOR_MAP[gameSlug] : undefined;
+  if (LazyFlavor == null) return null;
+  return <LazyFlavor session={session} className={className} />;
+}

--- a/apps/web/src/components/features/session-live/__tests__/SummaryFlavorRenderer.test.tsx
+++ b/apps/web/src/components/features/session-live/__tests__/SummaryFlavorRenderer.test.tsx
@@ -1,5 +1,27 @@
-import { describe, it, expect } from 'vitest';
-import { hasSummaryFlavor } from '../SummaryFlavorRenderer';
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+import { SummaryFlavorRenderer, hasSummaryFlavor } from '../SummaryFlavorRenderer';
+import type { GameSessionDto } from '@/lib/api/schemas/games.schemas';
+
+// Replace the lazy Catan flavor with a synchronous marker so the dispatcher's
+// dynamic-import mapping resolves deterministically in the test.
+vi.mock('../flavors/catan/CatanSummaryFlavor', () => ({
+  CatanSummaryFlavor: () => <div data-testid="catan-flavor-marker" />,
+}));
+
+const session = {
+  id: '00000000-0000-4000-8000-000000000001',
+  gameId: '00000000-0000-4000-8000-0000000000aa',
+  status: 'Completed',
+  startedAt: '2026-01-01T00:00:00Z',
+  completedAt: '2026-01-01T00:47:00Z',
+  playerCount: 1,
+  players: [],
+  winnerName: null,
+  notes: null,
+  durationMinutes: 10,
+} as unknown as GameSessionDto;
 
 describe('hasSummaryFlavor', () => {
   it('is true for catan', () => {
@@ -10,5 +32,22 @@ describe('hasSummaryFlavor', () => {
     expect(hasSummaryFlavor('wingspan')).toBe(false);
     expect(hasSummaryFlavor(null)).toBe(false);
     expect(hasSummaryFlavor(undefined)).toBe(false);
+  });
+});
+
+describe('SummaryFlavorRenderer dispatch', () => {
+  it('lazy-loads and renders the Catan flavor for gameSlug=catan', async () => {
+    render(<SummaryFlavorRenderer gameSlug="catan" session={session} />);
+    expect(await screen.findByTestId('catan-flavor-marker')).toBeInTheDocument();
+  });
+
+  it('renders nothing for an unknown slug', () => {
+    const { container } = render(<SummaryFlavorRenderer gameSlug="wingspan" session={session} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing for a null slug', () => {
+    const { container } = render(<SummaryFlavorRenderer gameSlug={null} session={session} />);
+    expect(container).toBeEmptyDOMElement();
   });
 });

--- a/apps/web/src/components/features/session-live/__tests__/SummaryFlavorRenderer.test.tsx
+++ b/apps/web/src/components/features/session-live/__tests__/SummaryFlavorRenderer.test.tsx
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest';
+import { hasSummaryFlavor } from '../SummaryFlavorRenderer';
+
+describe('hasSummaryFlavor', () => {
+  it('is true for catan', () => {
+    expect(hasSummaryFlavor('catan')).toBe(true);
+  });
+
+  it('is false for unknown slug / null / undefined', () => {
+    expect(hasSummaryFlavor('wingspan')).toBe(false);
+    expect(hasSummaryFlavor(null)).toBe(false);
+    expect(hasSummaryFlavor(undefined)).toBe(false);
+  });
+});

--- a/apps/web/src/components/features/session-live/flavors/catan/CatanSummaryFlavor.tsx
+++ b/apps/web/src/components/features/session-live/flavors/catan/CatanSummaryFlavor.tsx
@@ -23,7 +23,8 @@ export function CatanSummaryFlavor({
   const rows = buildCatanSummaryStandings(
     session.scoringType,
     session.scoreData,
-    session.scorePlayers
+    session.scorePlayers,
+    session.winnerName
   );
 
   if (rows.length === 0) {
@@ -40,15 +41,12 @@ export function CatanSummaryFlavor({
   const standingsTitle = t('pages.sessionSummary.flavor.catan.standingsTitle');
   const vpUnit = t('pages.sessionSummary.flavor.catan.vpUnit');
 
-  // Winner precedence: BE-authoritative winnerName (matched to a row) → scoreData isWinner
-  // → none (never auto-crown when nobody won).
-  const heroRow =
-    (session.winnerName != null
-      ? rows.find(r => r.playerName === session.winnerName)
-      : undefined) ??
-    rows.find(r => r.isWinner) ??
-    null;
-  const heroName = heroRow?.playerName ?? session.winnerName ?? null;
+  // The builder reconciles winnerName into `isWinner`, so the hero is the single
+  // winning row. Fallback to the raw winnerName when it matches no row (BE/scorePlayers
+  // drift); null → no hero (never auto-crown when nobody won). Matching is by name —
+  // two guests sharing a display name is a known limitation (winnerName has no id).
+  const heroRow = rows.find(r => r.isWinner) ?? null;
+  const heroName = heroRow?.playerName ?? session.winnerName?.trim() ?? null;
   const maxScore = rows.reduce((m, r) => Math.max(m, r.score), 0);
 
   return (

--- a/apps/web/src/components/features/session-live/flavors/catan/CatanSummaryFlavor.tsx
+++ b/apps/web/src/components/features/session-live/flavors/catan/CatanSummaryFlavor.tsx
@@ -1,0 +1,113 @@
+'use client';
+
+import { useTranslation } from '@/hooks/useTranslation';
+import type { GameSessionDto } from '@/lib/api/schemas/games.schemas';
+
+import { catanPieceColor } from './catan-palette';
+import { buildCatanSummaryStandings } from './catan-summary-standings';
+
+interface CatanSummaryFlavorProps {
+  readonly session: GameSessionDto;
+  readonly className?: string;
+}
+
+/**
+ * #3022 — presentational Catan summary: winner hero + final standings from real
+ * per-player scores (scoreData joined to scorePlayers by id) + colors.
+ */
+export function CatanSummaryFlavor({
+  session,
+  className,
+}: CatanSummaryFlavorProps): React.JSX.Element {
+  const { t } = useTranslation();
+  const rows = buildCatanSummaryStandings(
+    session.scoringType,
+    session.scoreData,
+    session.scorePlayers
+  );
+
+  if (rows.length === 0) {
+    return (
+      <section
+        data-slot="catan-summary-flavor"
+        className={`rounded-2xl border border-border bg-card p-4 text-center text-[13px] text-muted-foreground ${className ?? ''}`}
+      >
+        {t('pages.sessionSummary.flavor.catan.empty')}
+      </section>
+    );
+  }
+
+  const standingsTitle = t('pages.sessionSummary.flavor.catan.standingsTitle');
+  const vpUnit = t('pages.sessionSummary.flavor.catan.vpUnit');
+
+  // Winner precedence: BE-authoritative winnerName (matched to a row) → scoreData isWinner
+  // → none (never auto-crown when nobody won).
+  const heroRow =
+    (session.winnerName != null
+      ? rows.find(r => r.playerName === session.winnerName)
+      : undefined) ??
+    rows.find(r => r.isWinner) ??
+    null;
+  const heroName = heroRow?.playerName ?? session.winnerName ?? null;
+  const maxScore = rows.reduce((m, r) => Math.max(m, r.score), 0);
+
+  return (
+    <section
+      data-slot="catan-summary-flavor"
+      aria-label={standingsTitle}
+      className={`flex flex-col gap-4 rounded-2xl border border-border bg-card p-4 ${className ?? ''}`}
+    >
+      {heroName != null && (
+        <header data-slot="catan-summary-hero" className="flex items-center gap-3">
+          <span
+            aria-hidden="true"
+            className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-border-strong text-lg"
+            style={{ backgroundColor: catanPieceColor(heroRow?.color ?? '') }}
+          >
+            👑
+          </span>
+          <div className="flex flex-col">
+            <span className="text-base font-semibold text-foreground">
+              {t('pages.sessionSummary.flavor.catan.winnerTemplate', { name: heroName })}
+            </span>
+            <span className="text-[13px] text-muted-foreground">
+              {heroRow != null ? `${heroRow.score} ${vpUnit} · ` : ''}
+              {t('pages.sessionSummary.flavor.catan.durationTemplate', {
+                minutes: session.durationMinutes,
+              })}
+            </span>
+          </div>
+        </header>
+      )}
+
+      <ol data-slot="catan-summary-standings" className="flex flex-col gap-1.5">
+        {rows.map((row, i) => (
+          <li
+            key={`${row.playerName}-${i}`}
+            data-slot="catan-summary-row"
+            className="flex items-center gap-2 text-[13px]"
+          >
+            <span className="w-5 tabular-nums text-muted-foreground">{i + 1}°</span>
+            <span
+              aria-hidden="true"
+              className="h-3.5 w-3.5 shrink-0 rounded-full border border-border-strong"
+              style={{ backgroundColor: catanPieceColor(row.color ?? '') }}
+            />
+            <span data-testid="catan-summary-row-name" className="flex-1 truncate text-foreground">
+              {row.playerName}
+            </span>
+            <span className="h-1.5 w-24 overflow-hidden rounded-full bg-muted" aria-hidden="true">
+              <span
+                className="block h-full rounded-full bg-entity-session"
+                style={{ width: `${maxScore > 0 ? (row.score / maxScore) * 100 : 0}%` }}
+              />
+            </span>
+            <span className="w-12 text-right tabular-nums text-foreground">
+              {row.score} {vpUnit}
+            </span>
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+}

--- a/apps/web/src/components/features/session-live/flavors/catan/__tests__/CatanSummaryFlavor.test.tsx
+++ b/apps/web/src/components/features/session-live/flavors/catan/__tests__/CatanSummaryFlavor.test.tsx
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
+import type { ReactElement } from 'react';
+import { CatanSummaryFlavor } from '../CatanSummaryFlavor';
+import type { GameSessionDto } from '@/lib/api/schemas/games.schemas';
+
+const MESSAGES = {
+  'pages.sessionSummary.flavor.catan.winnerTemplate': '{name} vince!',
+  'pages.sessionSummary.flavor.catan.vpUnit': 'PV',
+  'pages.sessionSummary.flavor.catan.durationTemplate': '{minutes} min',
+  'pages.sessionSummary.flavor.catan.standingsTitle': 'Classifica finale',
+  'pages.sessionSummary.flavor.catan.empty': 'Riepilogo non disponibile',
+};
+
+const renderWithIntl = (ui: ReactElement) =>
+  render(
+    <IntlProvider locale="it" messages={MESSAGES} onError={() => {}}>
+      {ui}
+    </IntlProvider>
+  );
+
+const base: GameSessionDto = {
+  id: '00000000-0000-4000-8000-000000000001',
+  gameId: '00000000-0000-4000-8000-0000000000aa',
+  status: 'Completed',
+  startedAt: '2026-01-01T00:00:00Z',
+  completedAt: '2026-01-01T00:47:00Z',
+  playerCount: 2,
+  players: [],
+  winnerName: 'Alice',
+  notes: null,
+  durationMinutes: 47,
+  scoringType: 'Points',
+  scoreData: JSON.stringify({
+    scores: [
+      { playerId: 'p1', points: 10 },
+      { playerId: 'p2', points: 8 },
+    ],
+  }),
+  gameSlug: 'catan',
+  gameName: 'Catan',
+  scorePlayers: [
+    { id: 'p1', displayName: 'Alice', color: 'Red' },
+    { id: 'p2', displayName: 'Bob', color: 'Blue' },
+  ],
+};
+
+describe('CatanSummaryFlavor', () => {
+  it('renders winner hero (winnerName) + ordered standings', () => {
+    renderWithIntl(<CatanSummaryFlavor session={base} />);
+    expect(screen.getByText('Alice vince!')).toBeInTheDocument();
+    expect(screen.getAllByTestId('catan-summary-row-name').map(n => n.textContent)).toEqual([
+      'Alice',
+      'Bob',
+    ]);
+  });
+
+  it('does not auto-crown when no isWinner and winnerName null', () => {
+    const noWinner: GameSessionDto = {
+      ...base,
+      winnerName: null,
+      scoreData: JSON.stringify({
+        scores: [
+          { playerId: 'p1', points: 0 },
+          { playerId: 'p2', points: 0 },
+        ],
+      }),
+    };
+    renderWithIntl(<CatanSummaryFlavor session={noWinner} />);
+    expect(screen.queryByText(/vince!/)).toBeNull();
+    expect(screen.getAllByTestId('catan-summary-row-name').length).toBe(2);
+  });
+
+  it('renders empty state when no scorePlayers', () => {
+    renderWithIntl(
+      <CatanSummaryFlavor session={{ ...base, scorePlayers: null, scoreData: null }} />
+    );
+    expect(screen.getByText('Riepilogo non disponibile')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/features/session-live/flavors/catan/__tests__/CatanSummaryFlavor.test.tsx
+++ b/apps/web/src/components/features/session-live/flavors/catan/__tests__/CatanSummaryFlavor.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from '@testing-library/react';
 import { IntlProvider } from 'react-intl';
 import type { ReactElement } from 'react';
 import { CatanSummaryFlavor } from '../CatanSummaryFlavor';
+import { CATAN_NEUTRAL_HSL } from '../catan-palette';
 import type { GameSessionDto } from '@/lib/api/schemas/games.schemas';
 
 const MESSAGES = {
@@ -77,5 +78,23 @@ describe('CatanSummaryFlavor', () => {
       <CatanSummaryFlavor session={{ ...base, scorePlayers: null, scoreData: null }} />
     );
     expect(screen.getByText('Riepilogo non disponibile')).toBeInTheDocument();
+  });
+
+  it('falls back to the scoreData isWinner row when winnerName is null', () => {
+    renderWithIntl(<CatanSummaryFlavor session={{ ...base, winnerName: null }} />);
+    expect(screen.getByText('Alice vince!')).toBeInTheDocument();
+  });
+
+  it('uses the neutral piece color for a null player color', () => {
+    const nullColor: GameSessionDto = {
+      ...base,
+      winnerName: null,
+      scorePlayers: [{ id: 'p1', displayName: 'Alice', color: null }],
+      scoreData: JSON.stringify({ scores: [{ playerId: 'p1', points: 10 }] }),
+    };
+    const { container } = renderWithIntl(<CatanSummaryFlavor session={nullColor} />);
+    const dot = container.querySelector('[data-slot="catan-summary-row"] span.rounded-full');
+    // jsdom normalises the inline hsl() to rgb(); toHaveStyle compares computed colors.
+    expect(dot).toHaveStyle({ backgroundColor: CATAN_NEUTRAL_HSL });
   });
 });

--- a/apps/web/src/components/features/session-live/flavors/catan/__tests__/catan-summary-standings.test.ts
+++ b/apps/web/src/components/features/session-live/flavors/catan/__tests__/catan-summary-standings.test.ts
@@ -42,4 +42,29 @@ describe('buildCatanSummaryStandings', () => {
     expect(warn).toHaveBeenCalled();
     warn.mockRestore();
   });
+
+  const tieJson = JSON.stringify({
+    scores: [
+      { playerId: 'p1', points: 10 },
+      { playerId: 'p2', points: 10 },
+      { playerId: 'p3', points: 6 },
+    ],
+  });
+
+  it('deterministic order on a max-score tie with no winnerName (first-max crowned)', () => {
+    const rows = buildCatanSummaryStandings('Points', tieJson, players);
+    expect(rows.map(r => r.playerName)).toEqual(['Alice', 'Bob', 'Carol']);
+    expect(rows.filter(r => r.isWinner).map(r => r.playerName)).toEqual(['Alice']);
+  });
+
+  it('reconciles winnerName on a tie: declared winner sorts first and is the sole winner', () => {
+    const rows = buildCatanSummaryStandings('Points', tieJson, players, 'Bob');
+    expect(rows[0].playerName).toBe('Bob');
+    expect(rows.filter(r => r.isWinner).map(r => r.playerName)).toEqual(['Bob']);
+  });
+
+  it('trims winnerName before matching a row', () => {
+    const rows = buildCatanSummaryStandings('Points', pointsJson, players, '  Alice  ');
+    expect(rows[0]).toMatchObject({ playerName: 'Alice', isWinner: true });
+  });
 });

--- a/apps/web/src/components/features/session-live/flavors/catan/__tests__/catan-summary-standings.test.ts
+++ b/apps/web/src/components/features/session-live/flavors/catan/__tests__/catan-summary-standings.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from 'vitest';
+import { buildCatanSummaryStandings } from '../catan-summary-standings';
+import type { ScorePlayerDto } from '@/lib/api/schemas/games.schemas';
+
+const players: ScorePlayerDto[] = [
+  { id: 'p1', displayName: 'Alice', color: 'Red' },
+  { id: 'p2', displayName: 'Bob', color: 'Blue' },
+  { id: 'p3', displayName: 'Carol', color: 'Orange' },
+];
+
+const pointsJson = JSON.stringify({
+  scores: [
+    { playerId: 'p1', points: 10 },
+    { playerId: 'p2', points: 8 },
+    { playerId: 'p3', points: 6 },
+  ],
+});
+
+describe('buildCatanSummaryStandings', () => {
+  it('joins by id, orders winner-first then score DESC, zips color', () => {
+    const rows = buildCatanSummaryStandings('Points', pointsJson, players);
+    expect(rows.map(r => r.playerName)).toEqual(['Alice', 'Bob', 'Carol']);
+    expect(rows[0]).toMatchObject({ playerName: 'Alice', score: 10, isWinner: true, color: 'Red' });
+    expect(rows[2]).toMatchObject({
+      playerName: 'Carol',
+      score: 6,
+      isWinner: false,
+      color: 'Orange',
+    });
+  });
+
+  it('returns [] for null score / null-or-empty scorePlayers / unknown type', () => {
+    expect(buildCatanSummaryStandings(null, null, players)).toEqual([]);
+    expect(buildCatanSummaryStandings('Points', pointsJson, null)).toEqual([]);
+    expect(buildCatanSummaryStandings('Points', pointsJson, [])).toEqual([]);
+    expect(buildCatanSummaryStandings('Nope', pointsJson, players)).toEqual([]);
+  });
+
+  it('returns [] and warns on malformed JSON', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(buildCatanSummaryStandings('Points', '{bad', players)).toEqual([]);
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+});

--- a/apps/web/src/components/features/session-live/flavors/catan/__tests__/i18n-catan-summary-keys.test.ts
+++ b/apps/web/src/components/features/session-live/flavors/catan/__tests__/i18n-catan-summary-keys.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import enMessages from '@/locales/en.json';
+import itMessages from '@/locales/it.json';
+
+const KEYS = ['winnerTemplate', 'vpUnit', 'durationTemplate', 'standingsTitle', 'empty'];
+
+type Catalog = { pages: { sessionSummary: { flavor: { catan: Record<string, string> } } } };
+const it_ = (itMessages as Catalog).pages.sessionSummary?.flavor?.catan ?? {};
+const en_ = (enMessages as Catalog).pages.sessionSummary?.flavor?.catan ?? {};
+
+describe('Catan summary i18n keys (#3022)', () => {
+  it.each(KEYS)('IT has %s', k => expect(it_[k]).toBeTruthy());
+  it.each(KEYS)('EN has %s', k => expect(en_[k]).toBeTruthy());
+  it('IT and EN have the same keys (parity)', () => {
+    expect(Object.keys(it_).sort()).toEqual(Object.keys(en_).sort());
+  });
+});

--- a/apps/web/src/components/features/session-live/flavors/catan/catan-summary-standings.ts
+++ b/apps/web/src/components/features/session-live/flavors/catan/catan-summary-standings.ts
@@ -23,7 +23,8 @@ const SCORE_TYPES: readonly ScoreType[] = ['Points', 'BinaryWin', 'Objectives', 
 export function buildCatanSummaryStandings(
   scoringType: string | null | undefined,
   scoreDataJson: string | null | undefined,
-  scorePlayers: readonly ScorePlayerDto[] | null | undefined
+  scorePlayers: readonly ScorePlayerDto[] | null | undefined,
+  winnerName?: string | null
 ): CatanSummaryRow[] {
   if (
     scoringType == null ||
@@ -55,5 +56,15 @@ export function buildCatanSummaryStandings(
     color: scorePlayers[i]?.color ?? null,
   }));
 
-  return withColor.sort((a, b) => Number(b.isWinner) - Number(a.isWinner) || b.score - a.score);
+  // Reconcile with the BE-authoritative winnerName (trimmed, mirroring
+  // adaptGameSessionToDetails): when it matches a row, that row becomes the sole
+  // winner so the hero and the ordered standings agree — even on score ties where
+  // the adapter's first-max heuristic would otherwise crown a different player.
+  const trimmedWinner = winnerName?.trim() ? winnerName.trim() : null;
+  const winnerIdx =
+    trimmedWinner != null ? withColor.findIndex(r => r.playerName.trim() === trimmedWinner) : -1;
+  const reconciled =
+    winnerIdx >= 0 ? withColor.map((r, i) => ({ ...r, isWinner: i === winnerIdx })) : withColor;
+
+  return reconciled.sort((a, b) => Number(b.isWinner) - Number(a.isWinner) || b.score - a.score);
 }

--- a/apps/web/src/components/features/session-live/flavors/catan/catan-summary-standings.ts
+++ b/apps/web/src/components/features/session-live/flavors/catan/catan-summary-standings.ts
@@ -1,0 +1,59 @@
+/**
+ * buildCatanSummaryStandings (#3022) — pure adapter from the raw GameSessionDto score
+ * fields + score-aligned players (scorePlayers[].id === scoreData.scores[].playerId) to
+ * ordered summary rows enriched with each player's color.
+ *
+ * mapScoreDataToEndgameSummary maps players.map() preserving order, so the FinalScoreEntry[]
+ * is index-parallel to `scorePlayers`, which lets us zip the color by index before sorting.
+ */
+
+import type { ScoreDataByType, ScoreType } from '@/components/sessions/score-strategies/types';
+import type { ScorePlayerDto } from '@/lib/api/schemas/games.schemas';
+import { mapScoreDataToEndgameSummary } from '@/lib/session-live/score-data-to-endgame-summary';
+
+export interface CatanSummaryRow {
+  readonly playerName: string;
+  readonly score: number;
+  readonly isWinner: boolean;
+  readonly color: string | null;
+}
+
+const SCORE_TYPES: readonly ScoreType[] = ['Points', 'BinaryWin', 'Objectives', 'Ranking'];
+
+export function buildCatanSummaryStandings(
+  scoringType: string | null | undefined,
+  scoreDataJson: string | null | undefined,
+  scorePlayers: readonly ScorePlayerDto[] | null | undefined
+): CatanSummaryRow[] {
+  if (
+    scoringType == null ||
+    scoreDataJson == null ||
+    scorePlayers == null ||
+    scorePlayers.length === 0
+  ) {
+    return [];
+  }
+  if (!SCORE_TYPES.includes(scoringType as ScoreType)) return [];
+
+  let parsed: ScoreDataByType[ScoreType];
+  try {
+    parsed = JSON.parse(scoreDataJson) as ScoreDataByType[ScoreType];
+  } catch {
+    console.warn(`buildCatanSummaryStandings: malformed scoreData JSON for "${scoringType}"`);
+    return [];
+  }
+
+  const adapterPlayers = scorePlayers.map(p => ({ id: p.id, name: p.displayName }));
+  const entries = mapScoreDataToEndgameSummary(scoringType as ScoreType, parsed, adapterPlayers);
+  if (entries.length === 0) return [];
+
+  // entries is index-parallel to scorePlayers (adapter preserves order) → zip color.
+  const withColor: CatanSummaryRow[] = entries.map((e, i) => ({
+    playerName: e.playerName,
+    score: e.score,
+    isWinner: e.isWinner,
+    color: scorePlayers[i]?.color ?? null,
+  }));
+
+  return withColor.sort((a, b) => Number(b.isWinner) - Number(a.isWinner) || b.score - a.score);
+}

--- a/apps/web/src/lib/api/schemas/__tests__/games.schemas.test.ts
+++ b/apps/web/src/lib/api/schemas/__tests__/games.schemas.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { GameSessionDtoSchema } from '../games.schemas';
+
+const base = {
+  id: '00000000-0000-4000-8000-000000000001',
+  gameId: '00000000-0000-4000-8000-0000000000aa',
+  status: 'Completed',
+  startedAt: '2026-01-01T00:00:00Z',
+  completedAt: '2026-01-01T01:00:00Z',
+  playerCount: 1,
+  players: [{ playerName: 'Alice', playerOrder: 1, color: 'Red' }],
+  winnerName: 'Alice',
+  notes: null,
+  durationMinutes: 47,
+};
+
+describe('GameSessionDtoSchema #3022', () => {
+  it('parses gameSlug/gameName/scorePlayers when present', () => {
+    const parsed = GameSessionDtoSchema.parse({
+      ...base,
+      gameSlug: 'catan',
+      gameName: 'Catan',
+      scorePlayers: [{ id: 'x', displayName: 'Alice', color: 'Red' }],
+    });
+    expect(parsed.gameSlug).toBe('catan');
+    expect(parsed.gameName).toBe('Catan');
+    expect(parsed.scorePlayers?.[0]).toEqual({ id: 'x', displayName: 'Alice', color: 'Red' });
+  });
+
+  it('accepts absent and null new fields (back-compat)', () => {
+    expect(GameSessionDtoSchema.parse(base).scorePlayers).toBeUndefined();
+    expect(
+      GameSessionDtoSchema.parse({ ...base, scorePlayers: null, gameSlug: null }).scorePlayers
+    ).toBeNull();
+  });
+});

--- a/apps/web/src/lib/api/schemas/games.schemas.ts
+++ b/apps/web/src/lib/api/schemas/games.schemas.ts
@@ -97,6 +97,16 @@ export const SessionPlayerDtoSchema = z.object({
 
 export type SessionPlayerDto = z.infer<typeof SessionPlayerDtoSchema>;
 
+// #3022: player aligned to scoreData.playerId (LiveGameSession player), carrying the
+// display name + color needed to render per-player scores in the summary flavor.
+export const ScorePlayerDtoSchema = z.object({
+  id: z.string(),
+  displayName: z.string(),
+  color: z.string().nullable(),
+});
+
+export type ScorePlayerDto = z.infer<typeof ScorePlayerDtoSchema>;
+
 export const GameSessionDtoSchema = z.object({
   id: z.string().uuid(),
   gameId: GameIdString,
@@ -115,6 +125,10 @@ export const GameSessionDtoSchema = z.object({
   // #2483 Task 1 BE: turnOrderType derived from the game's toolkit (static for the session).
   // Null when the game has no toolkit wired. Path B: no SignalR event, populated from DTO.
   turnOrderType: z.string().nullable().optional(),
+  // #3022: summary flavor identity + score-aligned players (single-session GET only).
+  gameSlug: z.string().nullable().optional(),
+  gameName: z.string().nullable().optional(),
+  scorePlayers: z.array(ScorePlayerDtoSchema).nullable().optional(),
 });
 
 export type GameSessionDto = z.infer<typeof GameSessionDtoSchema>;

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -3908,6 +3908,15 @@
       }
     },
     "sessionSummary": {
+      "flavor": {
+        "catan": {
+          "winnerTemplate": "{name} wins!",
+          "vpUnit": "VP",
+          "durationTemplate": "{minutes} min",
+          "standingsTitle": "Final standings",
+          "empty": "Summary not available"
+        }
+      },
       "hero": {
         "title": "Session summary",
         "podiumLabel": "Final podium",

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -4013,6 +4013,15 @@
       }
     },
     "sessionSummary": {
+      "flavor": {
+        "catan": {
+          "winnerTemplate": "{name} vince!",
+          "vpUnit": "PV",
+          "durationTemplate": "{minutes} min",
+          "standingsTitle": "Classifica finale",
+          "empty": "Riepilogo non disponibile"
+        }
+      },
       "hero": {
         "title": "Riepilogo partita",
         "podiumLabel": "Podio finale",

--- a/docs/superpowers/plans/2026-07-17-issue-3022-catan-summary-flavor.md
+++ b/docs/superpowers/plans/2026-07-17-issue-3022-catan-summary-flavor.md
@@ -1,56 +1,212 @@
-# Catan SUMMARY flavor (#3022) — Implementation Plan
+# Catan SUMMARY flavor (#3022) — Implementation Plan (rev. 2 — VP reali / BE bridge)
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development or superpowers:executing-plans. Steps use checkbox (`- [ ]`) syntax.
 
-**Goal:** Ship a presentational Catan SUMMARY flavor (winner hero + final standings from real `scoreData` + player colors) mounted on `/sessions/[id]` via an isolated summary-flavor dispatcher.
+**Goal:** Ship a Catan SUMMARY flavor (winner hero + final standings with REAL per-player scores + colors) on `/sessions/[id]`, backed by a BE read-model that bridges GameSession→LiveGameSession to surface score + aligned players.
 
-**Architecture:** BE enriches `GameSessionDto` with nullable `GameSlug`/`GameName` (only on the single-session GET path, resolved via `IGameCoreDataProvider` + `Slugifier`). FE adds a *twin* dispatcher `SummaryFlavorRenderer` (props `= { session: GameSessionDto }`, disjoint from the live `FlavorRenderer` typed on `LiveSessionDto`), plus `CatanSummaryFlavor` that reuses the pure adapter `mapScoreDataToEndgameSummary` and the `catanPieceColor` palette.
+**Architecture:** Extend `IHistorySessionScoreProvider` with `GetScoreboardAsync` (score + `SessionPlayers` aligned to `scoreData.playerId`). `GetGameSessionByIdQueryHandler` injects it (+ `IGameCoreDataProvider` for slug) and enriches `GameSessionDto` with `ScoringType/ScoreData/ScorePlayers/GameSlug/GameName`. FE adds a twin `SummaryFlavorRenderer` + `CatanSummaryFlavor` that joins scoreData↔scorePlayers by id.
 
-**Tech Stack:** .NET 9 (MediatR/CQRS, xUnit + Moq + FluentAssertions), Next.js 16 / React 19, Zod, react-intl, Vitest.
+**Tech Stack:** .NET 9 (xUnit + Moq + FluentAssertions + EF InMemory), Next.js 16 / React 19, Zod, react-intl, Vitest.
 
 ## Global Constraints
 
-- **Backend test path**: `apps/api/tests/Api.Tests` (NOT `tests/Api.Tests`).
-- **CQRS**: no endpoint changes here; only the existing query handler + DTO.
-- **i18n**: every new key exists in BOTH `apps/web/src/locales/it.json` AND `en.json`, with key parity. Italian text keeps correct accents (à, è, ù, …).
-- **Design tokens**: semantic tokens + entity utilities only; the only allowed raw inline HSL are the Catan piece colors via `catanPieceColor()` (already carry line-level `eslint-disable meepleai/no-inline-hsl-v2`).
-- **TDD**: RED → GREEN → REFACTOR, one behavior per test, frequent commits.
-- **Branch**: `feature/issue-3022-catan-summary-flavor` (parent `main-dev`).
+- **Backend test path**: `apps/api/tests/Api.Tests`.
+- **Identity fact**: `scoreData.scores[].playerId` == `SessionPlayerEntity.Id` (LiveGameSession, table `session_players`). Bridge: `GameSession.Id ← LiveGameSession.CorrelatedGameSessionId`, `LiveGameSession.Id = SessionPlayers.LiveGameSessionId`.
+- **i18n**: new keys in BOTH catalogs, parity, correct Italian accents. Placeholders via native ICU `t(key, { name })`.
+- **Design tokens**: semantic + entity utilities; raw inline HSL only via `catanPieceColor()`.
+- **Mount gate**: flavor mounts only when `status === 'Completed'` AND `hasSummaryFlavor(gameSlug)` AND `sessionQuery.data != null`.
+- **TDD**: RED → GREEN → REFACTOR, frequent commits.
+- **Branch**: `feature/issue-3022-catan-summary-flavor`.
 
 ---
 
 ## File Structure
 
 **Backend**
-- Modify `apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/GameSessionDto.cs` — add `GameSlug?`, `GameName?`.
-- Modify `apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GetGameSessionByIdQueryHandler.cs` — inject `IGameCoreDataProvider`, resolve slug/name.
-- Modify `apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/GetGameSessionByIdQueryHandlerTests.cs` — new ctor arg + coverage.
+- Modify `apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/IHistorySessionScoreProvider.cs` — `GetScoreboardAsync` + `SessionScoreboard` + `ScorePlayerReadModel`.
+- Modify `apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Persistence/HistorySessionScoreProvider.cs` — impl.
+- Modify `apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/GameSessionDto.cs` — `GameSlug?`, `GameName?`, `ScorePlayers?`, `ScorePlayerDto`.
+- Modify `apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GetGameSessionByIdQueryHandler.cs` — 2 deps + enrichment.
+- Test: `.../Handlers/GetGameSessionByIdQueryHandlerTests.cs` (unit) + new `.../Persistence/HistorySessionScoreProviderScoreboardTests.cs` (integration InMemory).
 
 **Frontend**
-- Modify `apps/web/src/lib/api/schemas/games.schemas.ts` — Zod `gameSlug`/`gameName`.
-- Create `apps/web/src/components/features/session-live/SummaryFlavorRenderer.tsx` — dispatcher + `SummaryFlavorProps` + `SUMMARY_FLAVOR_MAP` + `hasSummaryFlavor`.
-- Create `apps/web/src/components/features/session-live/flavors/catan/catan-summary-standings.ts` — pure standings builder (colors + ordering).
-- Create `apps/web/src/components/features/session-live/flavors/catan/CatanSummaryFlavor.tsx` — hero + standings render.
-- Modify `apps/web/src/app/(authenticated)/sessions/[id]/_components/SessionSummaryView.tsx` — conditional mount.
-- Modify `apps/web/src/locales/it.json` + `en.json` — new subtree.
-- Create `apps/web/src/components/features/session-live/flavors/catan/__tests__/i18n-catan-summary-keys.test.ts` — parity guard.
+- Modify `apps/web/src/lib/api/schemas/games.schemas.ts`.
+- Create `apps/web/src/components/features/session-live/SummaryFlavorRenderer.tsx`.
+- Create `apps/web/src/components/features/session-live/flavors/catan/catan-summary-standings.ts`.
+- Create `apps/web/src/components/features/session-live/flavors/catan/CatanSummaryFlavor.tsx`.
+- Modify `apps/web/src/app/(authenticated)/sessions/[id]/_components/SessionSummaryView.tsx`.
+- Modify `apps/web/src/locales/it.json` + `en.json`.
+- Create i18n guard test.
 
 ---
 
-## Task 1: BE — `GameSessionDto` gains `GameSlug`/`GameName`, resolved on single-session GET
+## Task 1: BE — `GetScoreboardAsync` on the score provider
 
 **Files:**
-- Modify: `apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/GameSessionDto.cs`
-- Modify: `apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GetGameSessionByIdQueryHandler.cs`
-- Test: `apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/GetGameSessionByIdQueryHandlerTests.cs`
+- Modify: `IHistorySessionScoreProvider.cs`
+- Modify: `HistorySessionScoreProvider.cs`
+- Test: `apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Infrastructure/Persistence/HistorySessionScoreProviderScoreboardTests.cs`
 
 **Interfaces:**
-- Consumes: `IGameCoreDataProvider.GetCoreDataAsync(GameRef, CancellationToken) → Task<GameCoreData?>` (`GameCoreData.Title`); `GameRef.Shared(Guid)`; `Slugifier.Slugify(string) → string` (namespace `Api.SharedKernel.Application.Services`, returns `"unknown"` on null/empty).
-- Produces: `GameSessionDto` with new trailing fields `string? GameSlug`, `string? GameName` (default `null`).
+- Produces: `Task<SessionScoreboard?> GetScoreboardAsync(Guid, CancellationToken)`; `readonly record struct SessionScoreboard(string ScoringType, string ScoreData, IReadOnlyList<ScorePlayerReadModel> Players)`; `readonly record struct ScorePlayerReadModel(Guid Id, string DisplayName, string Color)`.
 
-- [ ] **Step 1: Add the two fields to the DTO record**
+- [ ] **Step 1: Add interface members + records**
 
-In `GameSessionDto.cs`, append two nullable params to the `GameSessionDto` record (after `ScoreData`):
+In `IHistorySessionScoreProvider.cs`, add to the interface and below `HistorySessionScore`:
+
+```csharp
+    /// <summary>
+    /// Resolves score + the players aligned to scoreData (LiveGameSession SessionPlayers,
+    /// whose Id == scoreData.scores[].playerId) for a single GameSession. Null when the
+    /// session has no correlated live/tracking session with a score. (#3022)
+    /// </summary>
+    Task<SessionScoreboard?> GetScoreboardAsync(Guid gameSessionId, CancellationToken cancellationToken);
+```
+
+```csharp
+/// <summary>Score + players aligned to scoreData for one session (#3022).</summary>
+internal readonly record struct SessionScoreboard(
+    string ScoringType,
+    string ScoreData,
+    IReadOnlyList<ScorePlayerReadModel> Players);
+
+/// <summary>A player whose Id matches scoreData.scores[].playerId (#3022).</summary>
+internal readonly record struct ScorePlayerReadModel(Guid Id, string DisplayName, string Color);
+```
+
+- [ ] **Step 2: Write the failing integration test**
+
+Create `HistorySessionScoreProviderScoreboardTests.cs`. Seed a LiveGameSession (with `CorrelatedGameSessionId` + `TrackingSessionId` + 2 `SessionPlayers`) and a SessionTracking session (with `ScoringType`/`ScoreData`), then assert the scoreboard aligns. Use `TestDbContextFactory.CreateInMemoryDbContext()` (precedent: `GetGameByIdQueryHandlerTests.cs:42`).
+
+```csharp
+using Api.BoundedContexts.GameManagement.Application.Queries;
+using Api.BoundedContexts.GameManagement.Infrastructure.Persistence;
+using Api.Infrastructure.Entities.GameManagement;
+using Api.Infrastructure.Entities.SessionTracking;
+using Api.Tests.Constants;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Infrastructure.Persistence;
+
+[Trait("Category", TestCategories.Unit)]
+public class HistorySessionScoreProviderScoreboardTests
+{
+    [Fact]
+    public async Task GetScoreboardAsync_ReturnsScoreAndAlignedPlayers()
+    {
+        var db = TestDbContextFactory.CreateInMemoryDbContext();
+        var gameSessionId = Guid.NewGuid();
+        var liveId = Guid.NewGuid();
+        var trackingId = Guid.NewGuid();
+        var p1 = Guid.NewGuid();
+        var p2 = Guid.NewGuid();
+
+        db.LiveGameSessions.Add(new LiveGameSessionEntity
+        {
+            Id = liveId,
+            CorrelatedGameSessionId = gameSessionId,
+            TrackingSessionId = trackingId,
+        });
+        db.SessionPlayers.AddRange(
+            new SessionPlayerEntity { Id = p1, LiveGameSessionId = liveId, DisplayName = "Alice", Color = "Red", Role = "Player" },
+            new SessionPlayerEntity { Id = p2, LiveGameSessionId = liveId, DisplayName = "Bob", Color = "Blue", Role = "Player" });
+        db.SessionTrackingSessions.Add(new SessionEntity
+        {
+            Id = trackingId,
+            ScoringType = "Points",
+            ScoreData = $"{{\"scores\":[{{\"playerId\":\"{p1}\",\"points\":10}},{{\"playerId\":\"{p2}\",\"points\":8}}]}}",
+        });
+        await db.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+        var sut = new HistorySessionScoreProvider(db);
+        var result = await sut.GetScoreboardAsync(gameSessionId, TestContext.Current.CancellationToken);
+
+        result.Should().NotBeNull();
+        result!.Value.ScoringType.Should().Be("Points");
+        result.Value.Players.Should().HaveCount(2);
+        result.Value.Players.Should().ContainSingle(p => p.Id == p1 && p.DisplayName == "Alice" && p.Color == "Red");
+    }
+
+    [Fact]
+    public async Task GetScoreboardAsync_NoCorrelatedLive_ReturnsNull()
+    {
+        var db = TestDbContextFactory.CreateInMemoryDbContext();
+        var sut = new HistorySessionScoreProvider(db);
+        var result = await sut.GetScoreboardAsync(Guid.NewGuid(), TestContext.Current.CancellationToken);
+        result.Should().BeNull();
+    }
+}
+```
+
+> Seed note: `SessionEntity`/`LiveGameSessionEntity`/`SessionPlayerEntity` may have additional required scalar columns (e.g. status/timestamps). If EF InMemory rejects a save, set the minimal required fields the compiler/EF reports — do NOT add unrelated data. Verify field names against the entity classes before running.
+
+- [ ] **Step 3: Run test — verify it fails**
+
+Run: `cd apps/api && dotnet test --filter "FullyQualifiedName~HistorySessionScoreProviderScoreboardTests"`
+Expected: compile error (`GetScoreboardAsync` not implemented).
+
+- [ ] **Step 4: Implement `GetScoreboardAsync`**
+
+Append to `HistorySessionScoreProvider`:
+
+```csharp
+    public async Task<SessionScoreboard?> GetScoreboardAsync(
+        Guid gameSessionId,
+        CancellationToken cancellationToken)
+    {
+        var scoreRow = await (
+            from live in _dbContext.LiveGameSessions.AsNoTracking()
+            where live.CorrelatedGameSessionId == gameSessionId
+            join track in _dbContext.SessionTrackingSessions.AsNoTracking()
+                on live.TrackingSessionId equals (Guid?)track.Id
+            orderby (track.UpdatedAt ?? track.CreatedAt) descending
+            select new { LiveId = live.Id, track.ScoringType, track.ScoreData }
+        ).FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
+
+        if (scoreRow is null)
+            return null;
+
+        var players = await _dbContext.SessionPlayers.AsNoTracking()
+            .Where(p => p.LiveGameSessionId == scoreRow.LiveId)
+            .Select(p => new ScorePlayerReadModel(p.Id, p.DisplayName, p.Color))
+            .ToListAsync(cancellationToken).ConfigureAwait(false);
+
+        return new SessionScoreboard(scoreRow.ScoringType, scoreRow.ScoreData, players);
+    }
+```
+
+- [ ] **Step 5: Run test — verify it passes**
+
+Run: `cd apps/api && dotnet test --filter "FullyQualifiedName~HistorySessionScoreProviderScoreboardTests"`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/IHistorySessionScoreProvider.cs \
+        apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Persistence/HistorySessionScoreProvider.cs \
+        apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Infrastructure/Persistence/HistorySessionScoreProviderScoreboardTests.cs
+git commit -m "feat(session-summary): #3022 BE — GetScoreboardAsync (score + aligned players)"
+```
+
+---
+
+## Task 2: BE — enrich `GameSessionDto` on the single-session GET
+
+**Files:**
+- Modify: `GameSessionDto.cs`
+- Modify: `GetGameSessionByIdQueryHandler.cs`
+- Test: `.../Handlers/GetGameSessionByIdQueryHandlerTests.cs`
+
+**Interfaces:**
+- Consumes: `IGameCoreDataProvider.GetCoreDataAsync`, `GameRef.Shared`, `Slugifier.Slugify`, `IHistorySessionScoreProvider.GetScoreboardAsync` (Task 1).
+- Produces: `GameSessionDto` with `GameSlug?`, `GameName?`, `IReadOnlyList<ScorePlayerDto>? ScorePlayers`; `internal record ScorePlayerDto(Guid Id, string DisplayName, string? Color)`.
+
+- [ ] **Step 1: Add DTO fields + `ScorePlayerDto`**
+
+In `GameSessionDto.cs`, extend the record and add the sub-DTO:
 
 ```csharp
 internal record GameSessionDto(
@@ -66,84 +222,100 @@ internal record GameSessionDto(
     int DurationMinutes,
     string? ScoringType = null,
     string? ScoreData = null,
-    // #3022: game identity for the summary flavor dispatch. Populated ONLY on
+    // #3022: identity + score-aligned players for the summary flavor. Populated ONLY on
     // GET /api/v1/sessions/{id}; null on list/history paths (GameSessionMapper.ToDto).
     string? GameSlug = null,
-    string? GameName = null
+    string? GameName = null,
+    IReadOnlyList<ScorePlayerDto>? ScorePlayers = null
 );
+
+/// <summary>Player aligned to scoreData.playerId (LiveGameSession player). #3022.</summary>
+internal record ScorePlayerDto(Guid Id, string DisplayName, string? Color);
 ```
 
-- [ ] **Step 2: Write the failing handler test — slug/name populated from the catalog**
+- [ ] **Step 2: Write the failing handler tests**
 
-In `GetGameSessionByIdQueryHandlerTests.cs`, first update the ctor to inject a mock provider (this is required for ALL existing tests too — do it now):
+Update the test ctor to inject all three mocks (fixes ALL existing tests), then add coverage. Add imports `using Api.SharedKernel.Application;`, `using Api.SharedKernel.Domain.ValueObjects;`.
 
 ```csharp
 private readonly Mock<IGameSessionRepository> _sessionRepositoryMock;
 private readonly Mock<IGameCoreDataProvider> _gameCoreDataMock;
+private readonly Mock<IHistorySessionScoreProvider> _scoreProviderMock;
 private readonly GetGameSessionByIdQueryHandler _handler;
 
 public GetGameSessionByIdQueryHandlerTests()
 {
     _sessionRepositoryMock = new Mock<IGameSessionRepository>();
     _gameCoreDataMock = new Mock<IGameCoreDataProvider>();
-    _handler = new GetGameSessionByIdQueryHandler(_sessionRepositoryMock.Object, _gameCoreDataMock.Object);
+    _scoreProviderMock = new Mock<IHistorySessionScoreProvider>();
+    _handler = new GetGameSessionByIdQueryHandler(
+        _sessionRepositoryMock.Object, _gameCoreDataMock.Object, _scoreProviderMock.Object);
 }
 
 private static GameCoreData MakeCoreData(string title = "Catan") =>
     GameCoreData.Create(title, 1995, 3, 4, 90, 10);
 ```
 
-Add imports at top: `using Api.SharedKernel.Application;` and `using Api.SharedKernel.Domain.ValueObjects;`.
-
-Then add the new test:
+New tests:
 
 ```csharp
 [Fact]
-public async Task Handle_ExistingSession_PopulatesGameSlugAndName_FromCatalog()
+public async Task Handle_PopulatesSlugNameAndScoreboard()
 {
     var gameId = Guid.NewGuid();
     var session = CreateSession(gameId);
-    _sessionRepositoryMock
-        .Setup(r => r.GetByIdAsync(session.Id, It.IsAny<CancellationToken>()))
-        .ReturnsAsync(session);
-    _gameCoreDataMock
-        .Setup(p => p.GetCoreDataAsync(GameRef.Shared(gameId), It.IsAny<CancellationToken>()))
-        .ReturnsAsync(MakeCoreData("Catan"));
+    var pid = Guid.NewGuid();
+    _sessionRepositoryMock.Setup(r => r.GetByIdAsync(session.Id, It.IsAny<CancellationToken>())).ReturnsAsync(session);
+    _gameCoreDataMock.Setup(p => p.GetCoreDataAsync(GameRef.Shared(gameId), It.IsAny<CancellationToken>())).ReturnsAsync(MakeCoreData("Catan"));
+    _scoreProviderMock.Setup(p => p.GetScoreboardAsync(session.Id, It.IsAny<CancellationToken>()))
+        .ReturnsAsync(new SessionScoreboard("Points", "{\"scores\":[]}",
+            new List<ScorePlayerReadModel> { new(pid, "Alice", "Red") }));
 
     var result = await _handler.Handle(new GetGameSessionByIdQuery(session.Id), TestContext.Current.CancellationToken);
 
-    result.Should().NotBeNull();
-    result!.GameName.Should().Be("Catan");
-    result.GameSlug.Should().Be("catan");
+    result!.GameSlug.Should().Be("catan");
+    result.GameName.Should().Be("Catan");
+    result.ScoringType.Should().Be("Points");
+    result.ScorePlayers.Should().ContainSingle(sp => sp.Id == pid && sp.DisplayName == "Alice" && sp.Color == "Red");
 }
 
 [Fact]
-public async Task Handle_GameNotInCatalog_LeavesSlugAndNameNull()
+public async Task Handle_NoScoreboard_LeavesScoreFieldsNull()
 {
     var gameId = Guid.NewGuid();
     var session = CreateSession(gameId);
-    _sessionRepositoryMock
-        .Setup(r => r.GetByIdAsync(session.Id, It.IsAny<CancellationToken>()))
-        .ReturnsAsync(session);
-    _gameCoreDataMock
-        .Setup(p => p.GetCoreDataAsync(It.IsAny<GameRef>(), It.IsAny<CancellationToken>()))
-        .ReturnsAsync((GameCoreData?)null);
+    _sessionRepositoryMock.Setup(r => r.GetByIdAsync(session.Id, It.IsAny<CancellationToken>())).ReturnsAsync(session);
+    _gameCoreDataMock.Setup(p => p.GetCoreDataAsync(It.IsAny<GameRef>(), It.IsAny<CancellationToken>())).ReturnsAsync((GameCoreData?)null);
+    _scoreProviderMock.Setup(p => p.GetScoreboardAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync((SessionScoreboard?)null);
 
     var result = await _handler.Handle(new GetGameSessionByIdQuery(session.Id), TestContext.Current.CancellationToken);
 
-    result!.GameName.Should().BeNull();
-    result.GameSlug.Should().BeNull();
+    result!.GameSlug.Should().BeNull();
+    result.ScoringType.Should().BeNull();
+    result.ScorePlayers.Should().BeNull();
 }
 ```
 
-- [ ] **Step 3: Run tests to verify they fail**
+Also add the mapper guard test in the existing `GameSessionMapper` test file (or here if none):
+
+```csharp
+[Fact]
+public void ToDto_LeavesSummaryOnlyFieldsNull()
+{
+    var session = CreateSession(Guid.NewGuid());
+    var dto = session.ToDto();   // GameSessionMapper.ToDto
+    dto.GameSlug.Should().BeNull();
+    dto.GameName.Should().BeNull();
+    dto.ScorePlayers.Should().BeNull();
+}
+```
+
+- [ ] **Step 3: Run tests — verify they fail**
 
 Run: `cd apps/api && dotnet test --filter "FullyQualifiedName~GetGameSessionByIdQueryHandlerTests"`
-Expected: compile error (`GetGameSessionByIdQueryHandler` has no 2-arg ctor) — this is the RED for the whole task, including the ctor migration.
+Expected: compile error (ctor arity).
 
 - [ ] **Step 4: Implement the handler**
-
-Rewrite `GetGameSessionByIdQueryHandler.cs`:
 
 ```csharp
 using Api.BoundedContexts.GameManagement.Application.DTOs;
@@ -160,13 +332,16 @@ internal class GetGameSessionByIdQueryHandler : IQueryHandler<GetGameSessionById
 {
     private readonly IGameSessionRepository _sessionRepository;
     private readonly IGameCoreDataProvider _gameCoreData;
+    private readonly IHistorySessionScoreProvider _scoreProvider;
 
     public GetGameSessionByIdQueryHandler(
         IGameSessionRepository sessionRepository,
-        IGameCoreDataProvider gameCoreData)
+        IGameCoreDataProvider gameCoreData,
+        IHistorySessionScoreProvider scoreProvider)
     {
         _sessionRepository = sessionRepository ?? throw new ArgumentNullException(nameof(sessionRepository));
         _gameCoreData = gameCoreData ?? throw new ArgumentNullException(nameof(gameCoreData));
+        _scoreProvider = scoreProvider ?? throw new ArgumentNullException(nameof(scoreProvider));
     }
 
     public async Task<GameSessionDto?> Handle(GetGameSessionByIdQuery query, CancellationToken cancellationToken)
@@ -176,21 +351,25 @@ internal class GetGameSessionByIdQueryHandler : IQueryHandler<GetGameSessionById
         if (session == null) return null;
 
         var coreData = await _gameCoreData
-            .GetCoreDataAsync(GameRef.Shared(session.GameId), cancellationToken)
-            .ConfigureAwait(false);
+            .GetCoreDataAsync(GameRef.Shared(session.GameId), cancellationToken).ConfigureAwait(false);
         var gameName = coreData?.Title;
         var gameSlug = gameName is null ? null : Slugifier.Slugify(gameName);
 
-        return MapToDto(session, gameSlug, gameName);
+        var scoreboard = await _scoreProvider
+            .GetScoreboardAsync(session.Id, cancellationToken).ConfigureAwait(false);
+
+        return MapToDto(session, gameSlug, gameName, scoreboard);
     }
 
-    private static GameSessionDto MapToDto(GameSession session, string? gameSlug, string? gameName)
+    private static GameSessionDto MapToDto(
+        GameSession session, string? gameSlug, string? gameName, SessionScoreboard? scoreboard)
     {
         var playerDtos = session.Players.Select(p => new SessionPlayerDto(
-            PlayerName: p.PlayerName,
-            PlayerOrder: p.PlayerOrder,
-            Color: p.Color
-        )).ToList();
+            PlayerName: p.PlayerName, PlayerOrder: p.PlayerOrder, Color: p.Color)).ToList();
+
+        var scorePlayers = scoreboard?.Players
+            .Select(sp => new ScorePlayerDto(sp.Id, sp.DisplayName, sp.Color))
+            .ToList();
 
         return new GameSessionDto(
             Id: session.Id,
@@ -203,17 +382,20 @@ internal class GetGameSessionByIdQueryHandler : IQueryHandler<GetGameSessionById
             WinnerName: session.WinnerName,
             Notes: session.Notes,
             DurationMinutes: (int)session.Duration.TotalMinutes,
+            ScoringType: scoreboard?.ScoringType,
+            ScoreData: scoreboard?.ScoreData,
             GameSlug: gameSlug,
-            GameName: gameName
+            GameName: gameName,
+            ScorePlayers: scorePlayers
         );
     }
 }
 ```
 
-- [ ] **Step 5: Run tests to verify they pass**
+- [ ] **Step 5: Run tests — verify they pass**
 
-Run: `cd apps/api && dotnet test --filter "FullyQualifiedName~GetGameSessionByIdQueryHandlerTests"`
-Expected: PASS (all 6 pre-existing + 2 new).
+Run: `cd apps/api && dotnet test --filter "FullyQualifiedName~GetGameSessionByIdQueryHandlerTests"` then `--filter "BoundedContext=GameManagement"`.
+Expected: PASS (existing 6 + new). Fix any other `new GetGameSessionByIdQueryHandler(` call sites the compiler flags (integration tests); the DI container resolves the 3 deps automatically since all are registered.
 
 - [ ] **Step 6: Commit**
 
@@ -221,23 +403,21 @@ Expected: PASS (all 6 pre-existing + 2 new).
 git add apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/GameSessionDto.cs \
         apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GetGameSessionByIdQueryHandler.cs \
         apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/GetGameSessionByIdQueryHandlerTests.cs
-git commit -m "feat(session-summary): #3022 BE — enrich GameSessionDto with GameSlug/GameName"
+git commit -m "feat(session-summary): #3022 BE — enrich GameSessionDto (slug/name/scoreboard) on single GET"
 ```
 
 ---
 
-## Task 2: FE — Zod schema exposes `gameSlug`/`gameName`
+## Task 3: FE — Zod schema (`gameSlug`/`gameName`/`scorePlayers`)
 
 **Files:**
-- Modify: `apps/web/src/lib/api/schemas/games.schemas.ts:100-120`
-- Test: `apps/web/src/lib/api/schemas/__tests__/games.schemas.test.ts` (create if absent)
+- Modify: `apps/web/src/lib/api/schemas/games.schemas.ts`
+- Test: `apps/web/src/lib/api/schemas/__tests__/games.schemas.test.ts`
 
 **Interfaces:**
-- Produces: `GameSessionDto` (inferred) gains `gameSlug?: string | null`, `gameName?: string | null`.
+- Produces: `ScorePlayerDtoSchema` / `ScorePlayerDto = { id: string; displayName: string; color: string | null }`; `GameSessionDto` gains `gameSlug?`, `gameName?`, `scorePlayers?`.
 
-- [ ] **Step 1: Write the failing schema test**
-
-Create/append `apps/web/src/lib/api/schemas/__tests__/games.schemas.test.ts`:
+- [ ] **Step 1: Write the failing test**
 
 ```ts
 import { describe, it, expect } from 'vitest';
@@ -246,136 +426,125 @@ import { GameSessionDtoSchema } from '../games.schemas';
 const base = {
   id: '00000000-0000-4000-8000-000000000001',
   gameId: '00000000-0000-4000-8000-0000000000aa',
-  status: 'Completed',
-  startedAt: '2026-01-01T00:00:00Z',
-  completedAt: '2026-01-01T01:00:00Z',
-  playerCount: 2,
-  players: [{ playerName: 'Alice', playerOrder: 1, color: 'Red' }],
-  winnerName: 'Alice',
-  notes: null,
-  durationMinutes: 47,
+  status: 'Completed', startedAt: '2026-01-01T00:00:00Z', completedAt: '2026-01-01T01:00:00Z',
+  playerCount: 1, players: [{ playerName: 'Alice', playerOrder: 1, color: 'Red' }],
+  winnerName: 'Alice', notes: null, durationMinutes: 47,
 };
 
 describe('GameSessionDtoSchema #3022', () => {
-  it('parses gameSlug/gameName when present', () => {
-    const parsed = GameSessionDtoSchema.parse({ ...base, gameSlug: 'catan', gameName: 'Catan' });
-    expect(parsed.gameSlug).toBe('catan');
-    expect(parsed.gameName).toBe('Catan');
+  it('parses gameSlug/gameName/scorePlayers', () => {
+    const p = GameSessionDtoSchema.parse({
+      ...base, gameSlug: 'catan', gameName: 'Catan',
+      scorePlayers: [{ id: 'x', displayName: 'Alice', color: 'Red' }],
+    });
+    expect(p.gameSlug).toBe('catan');
+    expect(p.scorePlayers?.[0]).toEqual({ id: 'x', displayName: 'Alice', color: 'Red' });
   });
-
-  it('accepts null and absent gameSlug/gameName (back-compat)', () => {
-    expect(GameSessionDtoSchema.parse({ ...base, gameSlug: null, gameName: null }).gameSlug).toBeNull();
-    expect(GameSessionDtoSchema.parse(base).gameSlug).toBeUndefined();
+  it('accepts absent/null new fields (back-compat)', () => {
+    expect(GameSessionDtoSchema.parse(base).scorePlayers).toBeUndefined();
+    expect(GameSessionDtoSchema.parse({ ...base, scorePlayers: null }).scorePlayers).toBeNull();
   });
 });
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [ ] **Step 2: Run — verify fail**
 
-Run: `cd apps/web && pnpm vitest run games.schemas`
-Expected: FAIL — `parsed.gameSlug` is `undefined` (schema strips unknown keys), first assertion fails.
+Run: `cd apps/web && pnpm vitest run games.schemas` — FAIL (fields stripped).
 
-- [ ] **Step 3: Add the fields to the schema**
+- [ ] **Step 3: Add to schema**
 
-In `games.schemas.ts`, inside `GameSessionDtoSchema` (after `turnOrderType`):
+In `games.schemas.ts`, before `GameSessionDtoSchema`:
 
 ```ts
-  // #3022: game identity for the summary flavor dispatch. Populated only on the
-  // single-session GET; null/absent on list/history responses.
-  gameSlug: z.string().nullable().optional(),
-  gameName: z.string().nullable().optional(),
+export const ScorePlayerDtoSchema = z.object({
+  id: z.string(),
+  displayName: z.string(),
+  color: z.string().nullable(),
+});
+export type ScorePlayerDto = z.infer<typeof ScorePlayerDtoSchema>;
 ```
 
-- [ ] **Step 4: Run test to verify it passes**
+Inside `GameSessionDtoSchema` (after `turnOrderType`):
 
-Run: `cd apps/web && pnpm vitest run games.schemas`
-Expected: PASS.
+```ts
+  // #3022: summary flavor identity + score-aligned players (single-session GET only).
+  gameSlug: z.string().nullable().optional(),
+  gameName: z.string().nullable().optional(),
+  scorePlayers: z.array(ScorePlayerDtoSchema).nullable().optional(),
+```
+
+- [ ] **Step 4: Run — verify pass**
+
+Run: `cd apps/web && pnpm vitest run games.schemas` — PASS.
 
 - [ ] **Step 5: Commit**
 
 ```bash
 git add apps/web/src/lib/api/schemas/games.schemas.ts apps/web/src/lib/api/schemas/__tests__/games.schemas.test.ts
-git commit -m "feat(session-summary): #3022 FE — gameSlug/gameName on GameSessionDto schema"
+git commit -m "feat(session-summary): #3022 FE — gameSlug/gameName/scorePlayers on schema"
 ```
 
 ---
 
-## Task 3: FE — pure standings builder `buildCatanSummaryStandings`
+## Task 4: FE — pure standings builder (uses `scorePlayers`)
 
 **Files:**
 - Create: `apps/web/src/components/features/session-live/flavors/catan/catan-summary-standings.ts`
-- Test: `apps/web/src/components/features/session-live/flavors/catan/__tests__/catan-summary-standings.test.ts`
+- Test: `.../catan/__tests__/catan-summary-standings.test.ts`
 
 **Interfaces:**
-- Consumes: `mapScoreDataToEndgameSummary(scoringType, scoreData, players) → readonly FinalScoreEntry[]` from `@/lib/session-live/score-data-to-endgame-summary`; `SessionPlayerDto` (`{ id?, playerName, playerOrder, color }`) from `@/lib/api/schemas/games.schemas`; `ScoreType`, `ScoreDataByType` from `@/components/sessions/score-strategies/types`.
-- Produces: `CatanSummaryRow = { playerName: string; score: number; isWinner: boolean; color: string | null }`; `buildCatanSummaryStandings(scoringType: string | null | undefined, scoreDataJson: string | null | undefined, players: readonly SessionPlayerDto[]) → CatanSummaryRow[]` (winner-first, then score DESC; `[]` when unusable).
+- Consumes: `mapScoreDataToEndgameSummary`; `ScorePlayerDto`; `ScoreType`/`ScoreDataByType`.
+- Produces: `CatanSummaryRow = { playerName: string; score: number; isWinner: boolean; color: string | null }`; `buildCatanSummaryStandings(scoringType: string|null|undefined, scoreDataJson: string|null|undefined, scorePlayers: readonly ScorePlayerDto[] | null | undefined) => CatanSummaryRow[]`.
 
 - [ ] **Step 1: Write the failing test**
-
-Create `catan-summary-standings.test.ts`:
 
 ```ts
 import { describe, it, expect, vi } from 'vitest';
 import { buildCatanSummaryStandings } from '../catan-summary-standings';
-import type { SessionPlayerDto } from '@/lib/api/schemas/games.schemas';
+import type { ScorePlayerDto } from '@/lib/api/schemas/games.schemas';
 
-const players: SessionPlayerDto[] = [
-  { id: 'p1', playerName: 'Alice', playerOrder: 1, color: 'Red' },
-  { id: 'p2', playerName: 'Bob', playerOrder: 2, color: 'Blue' },
-  { id: 'p3', playerName: 'Carol', playerOrder: 3, color: 'Orange' },
+const players: ScorePlayerDto[] = [
+  { id: 'p1', displayName: 'Alice', color: 'Red' },
+  { id: 'p2', displayName: 'Bob', color: 'Blue' },
+  { id: 'p3', displayName: 'Carol', color: 'Orange' },
 ];
-
-const pointsJson = JSON.stringify({
-  scores: [
-    { playerId: 'p1', points: 10 },
-    { playerId: 'p2', points: 8 },
-    { playerId: 'p3', points: 6 },
-  ],
-});
+const pointsJson = JSON.stringify({ scores: [
+  { playerId: 'p1', points: 10 }, { playerId: 'p2', points: 8 }, { playerId: 'p3', points: 6 } ] });
 
 describe('buildCatanSummaryStandings', () => {
-  it('orders winner-first then score DESC, zipping the player color', () => {
+  it('joins by id, orders winner-first then score DESC, zips color', () => {
     const rows = buildCatanSummaryStandings('Points', pointsJson, players);
     expect(rows.map(r => r.playerName)).toEqual(['Alice', 'Bob', 'Carol']);
     expect(rows[0]).toMatchObject({ playerName: 'Alice', score: 10, isWinner: true, color: 'Red' });
-    expect(rows[2]).toMatchObject({ playerName: 'Carol', score: 6, isWinner: false, color: 'Orange' });
   });
-
-  it('returns [] when scoringType/scoreData is null', () => {
+  it('returns [] for null score / null-or-empty scorePlayers / unknown type', () => {
     expect(buildCatanSummaryStandings(null, null, players)).toEqual([]);
-    expect(buildCatanSummaryStandings('Points', null, players)).toEqual([]);
+    expect(buildCatanSummaryStandings('Points', pointsJson, null)).toEqual([]);
+    expect(buildCatanSummaryStandings('Points', pointsJson, [])).toEqual([]);
+    expect(buildCatanSummaryStandings('Nope', pointsJson, players)).toEqual([]);
   });
-
   it('returns [] and warns on malformed JSON', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    expect(buildCatanSummaryStandings('Points', '{not json', players)).toEqual([]);
+    expect(buildCatanSummaryStandings('Points', '{bad', players)).toEqual([]);
     expect(warn).toHaveBeenCalled();
     warn.mockRestore();
   });
 });
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [ ] **Step 2: Run — verify fail** (`pnpm vitest run catan-summary-standings`, module missing).
 
-Run: `cd apps/web && pnpm vitest run catan-summary-standings`
-Expected: FAIL — module not found.
-
-- [ ] **Step 3: Implement the builder**
-
-Create `catan-summary-standings.ts`:
+- [ ] **Step 3: Implement**
 
 ```ts
 /**
- * buildCatanSummaryStandings — pure adapter from the raw GameSessionDto scoring
- * fields to ordered summary rows enriched with each player's color.
- *
- * #3022. The upstream adapter (mapScoreDataToEndgameSummary) maps players.map()
- * preserving order, so the FinalScoreEntry[] is index-parallel to `players`,
- * which lets us zip the color by index before sorting.
+ * buildCatanSummaryStandings (#3022) — pure adapter: raw GameSessionDto score fields
+ * + score-aligned players (scorePlayers[].id === scoreData.scores[].playerId) → ordered
+ * rows with color. mapScoreDataToEndgameSummary preserves player order, so the output is
+ * index-parallel to scorePlayers → zip color by index before sorting.
  */
-
 import { mapScoreDataToEndgameSummary } from '@/lib/session-live/score-data-to-endgame-summary';
-import type { SessionPlayerDto } from '@/lib/api/schemas/games.schemas';
+import type { ScorePlayerDto } from '@/lib/api/schemas/games.schemas';
 import type { ScoreDataByType, ScoreType } from '@/components/sessions/score-strategies/types';
 
 export interface CatanSummaryRow {
@@ -387,77 +556,62 @@ export interface CatanSummaryRow {
 
 const SCORE_TYPES: readonly ScoreType[] = ['Points', 'BinaryWin', 'Objectives', 'Ranking'];
 
-function parseScoreData(
-  scoringType: string | null | undefined,
-  scoreDataJson: string | null | undefined
-): { scoringType: ScoreType; scoreData: ScoreDataByType[ScoreType] } | null {
-  if (scoringType == null || scoreDataJson == null) return null;
-  if (!SCORE_TYPES.includes(scoringType as ScoreType)) return null;
-  try {
-    return {
-      scoringType: scoringType as ScoreType,
-      scoreData: JSON.parse(scoreDataJson) as ScoreDataByType[ScoreType],
-    };
-  } catch {
-    console.warn(`buildCatanSummaryStandings: malformed scoreData JSON for "${scoringType}"`);
-    return null;
-  }
-}
-
 export function buildCatanSummaryStandings(
   scoringType: string | null | undefined,
   scoreDataJson: string | null | undefined,
-  players: readonly SessionPlayerDto[]
+  scorePlayers: readonly ScorePlayerDto[] | null | undefined
 ): CatanSummaryRow[] {
-  const parsed = parseScoreData(scoringType, scoreDataJson);
-  if (parsed === null) return [];
+  if (scoringType == null || scoreDataJson == null || scorePlayers == null || scorePlayers.length === 0) {
+    return [];
+  }
+  if (!SCORE_TYPES.includes(scoringType as ScoreType)) return [];
 
-  const adapterPlayers = players.map(p => ({ id: p.id ?? p.playerName, name: p.playerName }));
-  const entries = mapScoreDataToEndgameSummary(parsed.scoringType, parsed.scoreData, adapterPlayers);
+  let parsed: ScoreDataByType[ScoreType];
+  try {
+    parsed = JSON.parse(scoreDataJson) as ScoreDataByType[ScoreType];
+  } catch {
+    console.warn(`buildCatanSummaryStandings: malformed scoreData JSON for "${scoringType}"`);
+    return [];
+  }
+
+  const adapterPlayers = scorePlayers.map(p => ({ id: p.id, name: p.displayName }));
+  const entries = mapScoreDataToEndgameSummary(scoringType as ScoreType, parsed, adapterPlayers);
   if (entries.length === 0) return [];
 
-  // entries is index-parallel to `players` (adapter preserves order) → zip color.
   const withColor: CatanSummaryRow[] = entries.map((e, i) => ({
     playerName: e.playerName,
     score: e.score,
     isWinner: e.isWinner,
-    color: players[i]?.color ?? null,
+    color: scorePlayers[i]?.color ?? null,
   }));
 
-  return withColor.sort(
-    (a, b) => Number(b.isWinner) - Number(a.isWinner) || b.score - a.score
-  );
+  return withColor.sort((a, b) => Number(b.isWinner) - Number(a.isWinner) || b.score - a.score);
 }
 ```
 
-- [ ] **Step 4: Run test to verify it passes**
-
-Run: `cd apps/web && pnpm vitest run catan-summary-standings`
-Expected: PASS.
+- [ ] **Step 4: Run — verify pass**.
 
 - [ ] **Step 5: Commit**
 
 ```bash
 git add apps/web/src/components/features/session-live/flavors/catan/catan-summary-standings.ts \
         apps/web/src/components/features/session-live/flavors/catan/__tests__/catan-summary-standings.test.ts
-git commit -m "feat(session-summary): #3022 pure Catan standings builder (scoreData → rows + color)"
+git commit -m "feat(session-summary): #3022 pure Catan standings builder (join by id + color)"
 ```
 
 ---
 
-## Task 4: FE — `CatanSummaryFlavor` component (hero + standings)
+## Task 5: FE — `CatanSummaryFlavor` (winnerName-preferred hero, no auto-crown)
 
 **Files:**
-- Create: `apps/web/src/components/features/session-live/flavors/catan/CatanSummaryFlavor.tsx`
-- Test: `apps/web/src/components/features/session-live/flavors/catan/__tests__/CatanSummaryFlavor.test.tsx`
+- Create: `.../catan/CatanSummaryFlavor.tsx`
+- Test: `.../catan/__tests__/CatanSummaryFlavor.test.tsx`
 
 **Interfaces:**
-- Consumes: `buildCatanSummaryStandings` (Task 3); `catanPieceColor(color)` from `./catan-palette`; `SummaryFlavorProps` (Task 5 — `{ session: GameSessionDto; className? }`). To avoid a circular task dependency, this component declares its own local props interface `{ session: GameSessionDto; className?: string }` (Catan flavor precedent: `CatanLiveFlavor` re-declares props locally instead of importing `FlavorProps`).
-- Produces: named export `CatanSummaryFlavor`.
+- Consumes: `buildCatanSummaryStandings` (Task 4); `catanPieceColor` from `./catan-palette`; `GameSessionDto`, `useTranslation`.
+- Produces: named export `CatanSummaryFlavor` (local props `{ session: GameSessionDto; className?: string }`).
 
 - [ ] **Step 1: Write the failing test**
-
-Create `CatanSummaryFlavor.test.tsx`:
 
 ```tsx
 import { describe, it, expect } from 'vitest';
@@ -474,59 +628,46 @@ const MESSAGES = {
   'pages.sessionSummary.flavor.catan.standingsTitle': 'Classifica finale',
   'pages.sessionSummary.flavor.catan.empty': 'Riepilogo non disponibile',
 };
+const renderWithIntl = (ui: ReactElement) =>
+  render(<IntlProvider locale="it" messages={MESSAGES} onError={() => {}}>{ui}</IntlProvider>);
 
-function renderWithIntl(ui: ReactElement) {
-  return render(<IntlProvider locale="it" messages={MESSAGES}>{ui}</IntlProvider>);
-}
-
-const baseSession: GameSessionDto = {
-  id: '00000000-0000-4000-8000-000000000001',
-  gameId: '00000000-0000-4000-8000-0000000000aa',
-  status: 'Completed',
-  startedAt: '2026-01-01T00:00:00Z',
-  completedAt: '2026-01-01T00:47:00Z',
-  playerCount: 2,
-  players: [
-    { id: 'p1', playerName: 'Alice', playerOrder: 1, color: 'Red' },
-    { id: 'p2', playerName: 'Bob', playerOrder: 2, color: 'Blue' },
-  ],
-  winnerName: 'Alice',
-  notes: null,
-  durationMinutes: 47,
+const base: GameSessionDto = {
+  id: '00000000-0000-4000-8000-000000000001', gameId: '00000000-0000-4000-8000-0000000000aa',
+  status: 'Completed', startedAt: '2026-01-01T00:00:00Z', completedAt: '2026-01-01T00:47:00Z',
+  playerCount: 2, players: [], winnerName: 'Alice', notes: null, durationMinutes: 47,
   scoringType: 'Points',
   scoreData: JSON.stringify({ scores: [{ playerId: 'p1', points: 10 }, { playerId: 'p2', points: 8 }] }),
-  gameSlug: 'catan',
-  gameName: 'Catan',
+  gameSlug: 'catan', gameName: 'Catan',
+  scorePlayers: [{ id: 'p1', displayName: 'Alice', color: 'Red' }, { id: 'p2', displayName: 'Bob', color: 'Blue' }],
 };
 
 describe('CatanSummaryFlavor', () => {
-  it('renders the winner hero and ordered standings', () => {
-    renderWithIntl(<CatanSummaryFlavor session={baseSession} />);
+  it('renders winner hero (winnerName) + ordered standings', () => {
+    renderWithIntl(<CatanSummaryFlavor session={base} />);
     expect(screen.getByText('Alice vince!')).toBeInTheDocument();
-    const names = screen.getAllByTestId('catan-summary-row-name').map(n => n.textContent);
-    expect(names).toEqual(['Alice', 'Bob']);
+    expect(screen.getAllByTestId('catan-summary-row-name').map(n => n.textContent)).toEqual(['Alice', 'Bob']);
   });
-
-  it('renders the empty state when scoreData is null', () => {
-    renderWithIntl(<CatanSummaryFlavor session={{ ...baseSession, scoringType: null, scoreData: null }} />);
+  it('no auto-crown when no isWinner and winnerName null', () => {
+    const noWinner = { ...base, winnerName: null,
+      scoreData: JSON.stringify({ scores: [{ playerId: 'p1', points: 0 }, { playerId: 'p2', points: 0 }] }) };
+    renderWithIntl(<CatanSummaryFlavor session={noWinner} />);
+    expect(screen.queryByText(/vince!/)).toBeNull();
+    expect(screen.getAllByTestId('catan-summary-row-name').length).toBe(2);
+  });
+  it('empty state when no scorePlayers', () => {
+    renderWithIntl(<CatanSummaryFlavor session={{ ...base, scorePlayers: null, scoreData: null }} />);
     expect(screen.getByText('Riepilogo non disponibile')).toBeInTheDocument();
   });
 });
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [ ] **Step 2: Run — verify fail**.
 
-Run: `cd apps/web && pnpm vitest run CatanSummaryFlavor`
-Expected: FAIL — module not found.
-
-- [ ] **Step 3: Implement the component**
-
-Create `CatanSummaryFlavor.tsx`:
+- [ ] **Step 3: Implement**
 
 ```tsx
 'use client';
 
-import { useIntl } from 'react-intl';
 import { useTranslation } from '@/hooks/useTranslation';
 import type { GameSessionDto } from '@/lib/api/schemas/games.schemas';
 import { buildCatanSummaryStandings } from './catan-summary-standings';
@@ -539,17 +680,7 @@ interface CatanSummaryFlavorProps {
 
 export function CatanSummaryFlavor({ session, className }: CatanSummaryFlavorProps): React.JSX.Element {
   const { t } = useTranslation();
-  const intl = useIntl();
-
-  const winnerTemplate =
-    (intl.messages['pages.sessionSummary.flavor.catan.winnerTemplate'] as string) ?? '{name} vince!';
-  const durationTemplate =
-    (intl.messages['pages.sessionSummary.flavor.catan.durationTemplate'] as string) ?? '{minutes} min';
-  const vpUnit = t('pages.sessionSummary.flavor.catan.vpUnit');
-  const standingsTitle = t('pages.sessionSummary.flavor.catan.standingsTitle');
-  const emptyLabel = t('pages.sessionSummary.flavor.catan.empty');
-
-  const rows = buildCatanSummaryStandings(session.scoringType, session.scoreData, session.players);
+  const rows = buildCatanSummaryStandings(session.scoringType, session.scoreData, session.scorePlayers);
 
   if (rows.length === 0) {
     return (
@@ -557,12 +688,20 @@ export function CatanSummaryFlavor({ session, className }: CatanSummaryFlavorPro
         data-slot="catan-summary-flavor"
         className={`rounded-2xl border border-border bg-card p-4 text-center text-[13px] text-muted-foreground ${className ?? ''}`}
       >
-        {emptyLabel}
+        {t('pages.sessionSummary.flavor.catan.empty')}
       </section>
     );
   }
 
-  const winner = rows.find(r => r.isWinner) ?? rows[0];
+  const standingsTitle = t('pages.sessionSummary.flavor.catan.standingsTitle');
+  const vpUnit = t('pages.sessionSummary.flavor.catan.vpUnit');
+
+  // Winner precedence: BE-authoritative winnerName (matched to a row) → scoreData isWinner → none.
+  const heroRow =
+    (session.winnerName != null ? rows.find(r => r.playerName === session.winnerName) : undefined) ??
+    rows.find(r => r.isWinner) ??
+    null;
+  const heroName = heroRow?.playerName ?? (session.winnerName ?? null);
   const maxScore = rows.reduce((m, r) => Math.max(m, r.score), 0);
 
   return (
@@ -571,49 +710,42 @@ export function CatanSummaryFlavor({ session, className }: CatanSummaryFlavorPro
       aria-label={standingsTitle}
       className={`flex flex-col gap-4 rounded-2xl border border-border bg-card p-4 ${className ?? ''}`}
     >
-      <header data-slot="catan-summary-hero" className="flex items-center gap-3">
-        <span
-          aria-hidden="true"
-          className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-border-strong text-lg"
-          style={{ backgroundColor: catanPieceColor(winner.color ?? '') }}
-        >
-          👑
-        </span>
-        <div className="flex flex-col">
-          <span className="text-base font-semibold text-foreground">
-            {winnerTemplate.replace('{name}', winner.playerName)}
+      {heroName != null && (
+        <header data-slot="catan-summary-hero" className="flex items-center gap-3">
+          <span
+            aria-hidden="true"
+            className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-border-strong text-lg"
+            style={{ backgroundColor: catanPieceColor(heroRow?.color ?? '') }}
+          >
+            👑
           </span>
-          <span className="text-[13px] text-muted-foreground">
-            {winner.score} {vpUnit} · {durationTemplate.replace('{minutes}', String(session.durationMinutes))}
-          </span>
-        </div>
-      </header>
+          <div className="flex flex-col">
+            <span className="text-base font-semibold text-foreground">
+              {t('pages.sessionSummary.flavor.catan.winnerTemplate', { name: heroName })}
+            </span>
+            <span className="text-[13px] text-muted-foreground">
+              {heroRow != null ? `${heroRow.score} ${vpUnit} · ` : ''}
+              {t('pages.sessionSummary.flavor.catan.durationTemplate', { minutes: session.durationMinutes })}
+            </span>
+          </div>
+        </header>
+      )}
 
       <ol data-slot="catan-summary-standings" className="flex flex-col gap-1.5">
         {rows.map((row, i) => (
-          <li
-            key={row.playerName}
-            data-slot="catan-summary-row"
-            className="flex items-center gap-2 text-[13px]"
-          >
+          <li key={`${row.playerName}-${i}`} data-slot="catan-summary-row" className="flex items-center gap-2 text-[13px]">
             <span className="w-5 tabular-nums text-muted-foreground">{i + 1}°</span>
             <span
               aria-hidden="true"
               className="h-3.5 w-3.5 shrink-0 rounded-full border border-border-strong"
               style={{ backgroundColor: catanPieceColor(row.color ?? '') }}
             />
-            <span data-testid="catan-summary-row-name" className="flex-1 truncate text-foreground">
-              {row.playerName}
-            </span>
+            <span data-testid="catan-summary-row-name" className="flex-1 truncate text-foreground">{row.playerName}</span>
             <span className="h-1.5 w-24 overflow-hidden rounded-full bg-muted" aria-hidden="true">
-              <span
-                className="block h-full rounded-full bg-entity-session"
-                style={{ width: `${maxScore > 0 ? (row.score / maxScore) * 100 : 0}%` }}
-              />
+              <span className="block h-full rounded-full bg-entity-session"
+                style={{ width: `${maxScore > 0 ? (row.score / maxScore) * 100 : 0}%` }} />
             </span>
-            <span className="w-12 text-right tabular-nums text-foreground">
-              {row.score} {vpUnit}
-            </span>
+            <span className="w-12 text-right tabular-nums text-foreground">{row.score} {vpUnit}</span>
           </li>
         ))}
       </ol>
@@ -622,44 +754,38 @@ export function CatanSummaryFlavor({ session, className }: CatanSummaryFlavorPro
 }
 ```
 
-- [ ] **Step 4: Run test to verify it passes**
+> Verify at implementation: the exact return type used by sibling flavors (`React.JSX.Element` vs `JSX.Element`) — match `CatanLiveFlavor.tsx`. And that `useTranslation().t` supports `t(key, values)` ICU interpolation (`useTranslation.ts:122-132`).
 
-Run: `cd apps/web && pnpm vitest run CatanSummaryFlavor`
-Expected: PASS.
+- [ ] **Step 4: Run — verify pass**.
 
 - [ ] **Step 5: Commit**
 
 ```bash
 git add apps/web/src/components/features/session-live/flavors/catan/CatanSummaryFlavor.tsx \
         apps/web/src/components/features/session-live/flavors/catan/__tests__/CatanSummaryFlavor.test.tsx
-git commit -m "feat(session-summary): #3022 CatanSummaryFlavor (winner hero + standings)"
+git commit -m "feat(session-summary): #3022 CatanSummaryFlavor (winnerName-preferred hero + standings)"
 ```
 
 ---
 
-## Task 5: FE — `SummaryFlavorRenderer` dispatcher
+## Task 6: FE — `SummaryFlavorRenderer` dispatcher
 
 **Files:**
 - Create: `apps/web/src/components/features/session-live/SummaryFlavorRenderer.tsx`
-- Test: `apps/web/src/components/features/session-live/__tests__/SummaryFlavorRenderer.test.tsx`
+- Test: `.../session-live/__tests__/SummaryFlavorRenderer.test.tsx`
 
 **Interfaces:**
-- Consumes: `CatanSummaryFlavor` (Task 4); `FlavorLoadingSkeleton` from `./FlavorLoadingSkeleton`; `GameSessionDto` from `@/lib/api/schemas/games.schemas`.
-- Produces: `SummaryFlavorProps = { session: GameSessionDto; className?: string }`; `SummaryFlavorRenderer(props & { gameSlug: string | null | undefined })`; `hasSummaryFlavor(gameSlug: string | null | undefined): boolean`.
+- Produces: `SummaryFlavorProps = { session: GameSessionDto; className?: string }`; `hasSummaryFlavor(gameSlug)`; `SummaryFlavorRenderer(props & { gameSlug })`.
 
 - [ ] **Step 1: Write the failing test**
-
-Create `SummaryFlavorRenderer.test.tsx`:
 
 ```tsx
 import { describe, it, expect } from 'vitest';
 import { hasSummaryFlavor } from '../SummaryFlavorRenderer';
 
 describe('hasSummaryFlavor', () => {
-  it('is true for catan', () => {
-    expect(hasSummaryFlavor('catan')).toBe(true);
-  });
-  it('is false for unknown slug / null / undefined', () => {
+  it('true for catan', () => expect(hasSummaryFlavor('catan')).toBe(true));
+  it('false for unknown/null/undefined', () => {
     expect(hasSummaryFlavor('wingspan')).toBe(false);
     expect(hasSummaryFlavor(null)).toBe(false);
     expect(hasSummaryFlavor(undefined)).toBe(false);
@@ -667,14 +793,9 @@ describe('hasSummaryFlavor', () => {
 });
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
+- [ ] **Step 2: Run — verify fail**.
 
-Run: `cd apps/web && pnpm vitest run SummaryFlavorRenderer`
-Expected: FAIL — module not found.
-
-- [ ] **Step 3: Implement the dispatcher**
-
-Create `SummaryFlavorRenderer.tsx`:
+- [ ] **Step 3: Implement**
 
 ```tsx
 'use client';
@@ -691,7 +812,6 @@ export interface SummaryFlavorProps {
 
 type SummaryFlavorComponent = ComponentType<SummaryFlavorProps>;
 
-// Lazy chunks minted at MODULE scope (never inside render) — same rule as FlavorRenderer.
 const CatanSummaryFlavorLazy: SummaryFlavorComponent = dynamic(
   () => import('./flavors/catan/CatanSummaryFlavor').then(m => ({ default: m.CatanSummaryFlavor })),
   { ssr: false, loading: () => <FlavorLoadingSkeleton /> }
@@ -710,9 +830,7 @@ interface SummaryFlavorRendererProps extends SummaryFlavorProps {
 }
 
 export function SummaryFlavorRenderer({
-  gameSlug,
-  session,
-  className,
+  gameSlug, session, className,
 }: SummaryFlavorRendererProps): React.JSX.Element | null {
   const LazyFlavor = gameSlug != null ? SUMMARY_FLAVOR_MAP[gameSlug] : undefined;
   if (LazyFlavor == null) return null;
@@ -720,10 +838,7 @@ export function SummaryFlavorRenderer({
 }
 ```
 
-- [ ] **Step 4: Run test to verify it passes**
-
-Run: `cd apps/web && pnpm vitest run SummaryFlavorRenderer`
-Expected: PASS.
+- [ ] **Step 4: Run — verify pass**.
 
 - [ ] **Step 5: Commit**
 
@@ -735,18 +850,13 @@ git commit -m "feat(session-summary): #3022 SummaryFlavorRenderer twin dispatche
 
 ---
 
-## Task 6: FE — i18n keys + parity guard
+## Task 7: FE — i18n keys + parity guard
 
 **Files:**
-- Modify: `apps/web/src/locales/it.json`, `apps/web/src/locales/en.json`
-- Test: `apps/web/src/components/features/session-live/flavors/catan/__tests__/i18n-catan-summary-keys.test.ts`
-
-**Interfaces:**
-- Produces: subtree `pages.sessionSummary.flavor.catan.{winnerTemplate,vpUnit,durationTemplate,standingsTitle,empty}` in both catalogs.
+- Modify: `apps/web/src/locales/it.json`, `en.json`
+- Test: `.../catan/__tests__/i18n-catan-summary-keys.test.ts`
 
 - [ ] **Step 1: Write the failing guard test**
-
-Create `i18n-catan-summary-keys.test.ts`:
 
 ```ts
 import { describe, it, expect } from 'vitest';
@@ -761,53 +871,39 @@ const en_ = (enMessages as Catalog).pages.sessionSummary?.flavor?.catan ?? {};
 describe('Catan summary i18n keys (#3022)', () => {
   it.each(KEYS)('IT has %s', k => expect(it_[k]).toBeTruthy());
   it.each(KEYS)('EN has %s', k => expect(en_[k]).toBeTruthy());
-  it('IT/EN parity', () => {
-    expect(Object.keys(it_).sort()).toEqual(Object.keys(en_).sort());
-  });
+  it('parity', () => expect(Object.keys(it_).sort()).toEqual(Object.keys(en_).sort()));
 });
 ```
 
-- [ ] **Step 2: Run test to verify it fails**
-
-Run: `cd apps/web && pnpm vitest run i18n-catan-summary-keys`
-Expected: FAIL — subtree absent.
+- [ ] **Step 2: Run — verify fail**.
 
 - [ ] **Step 3: Add the subtree to both catalogs**
 
-In `it.json`, under `pages.sessionSummary` (create the `flavor.catan` path):
+First check: `node -e "console.log(!!require('./src/locales/it.json').pages.sessionSummary)"` (run in `apps/web`). Merge into existing `pages.sessionSummary` if present; else create it.
 
+IT (`it.json`), under `pages.sessionSummary`:
 ```json
-"flavor": {
-  "catan": {
-    "winnerTemplate": "{name} vince!",
-    "vpUnit": "PV",
-    "durationTemplate": "{minutes} min",
-    "standingsTitle": "Classifica finale",
-    "empty": "Riepilogo non disponibile"
-  }
-}
+"flavor": { "catan": {
+  "winnerTemplate": "{name} vince!",
+  "vpUnit": "PV",
+  "durationTemplate": "{minutes} min",
+  "standingsTitle": "Classifica finale",
+  "empty": "Riepilogo non disponibile"
+} }
 ```
 
-In `en.json`, same path:
-
+EN (`en.json`), same path:
 ```json
-"flavor": {
-  "catan": {
-    "winnerTemplate": "{name} wins!",
-    "vpUnit": "VP",
-    "durationTemplate": "{minutes} min",
-    "standingsTitle": "Final standings",
-    "empty": "Summary not available"
-  }
-}
+"flavor": { "catan": {
+  "winnerTemplate": "{name} wins!",
+  "vpUnit": "VP",
+  "durationTemplate": "{minutes} min",
+  "standingsTitle": "Final standings",
+  "empty": "Summary not available"
+} }
 ```
 
-> Note: if `pages.sessionSummary` already exists in a catalog, merge `flavor` into it rather than duplicating the parent key. Verify with `node -e "console.log(!!require('./src/locales/it.json').pages.sessionSummary)"` before editing.
-
-- [ ] **Step 4: Run test to verify it passes**
-
-Run: `cd apps/web && pnpm vitest run i18n-catan-summary-keys`
-Expected: PASS.
+- [ ] **Step 4: Run — verify pass**.
 
 - [ ] **Step 5: Commit**
 
@@ -819,60 +915,60 @@ git commit -m "feat(session-summary): #3022 i18n Catan summary keys + parity gua
 
 ---
 
-## Task 7: FE — wire the flavor into `SessionSummaryView`
+## Task 8: FE — wire into `SessionSummaryView` (status-gated)
 
 **Files:**
 - Modify: `apps/web/src/app/(authenticated)/sessions/[id]/_components/SessionSummaryView.tsx`
-- Test: `apps/web/src/app/(authenticated)/sessions/[id]/_components/__tests__/SessionSummaryView.test.tsx` (extend)
+- Test: `.../__tests__/SessionSummaryView.test.tsx`
 
 **Interfaces:**
-- Consumes: `SummaryFlavorRenderer`, `hasSummaryFlavor` (Task 5); the raw `sessionQuery.data: GameSessionDto | null` already present in the component (line ~402).
+- Consumes: `SummaryFlavorRenderer`, `hasSummaryFlavor`; the raw `sessionQuery.data: GameSessionDto | null`.
 
-- [ ] **Step 1: Write the failing wiring test**
+- [ ] **Step 1: Write positive + negative wiring tests**
 
-Append to `SessionSummaryView.test.tsx` a case asserting the flavor mounts for a completed Catan session (real-data path, not fixture). Use the existing test's render harness/mocks; assert on the flavor slot:
+Reuse this file's existing real-data harness for `useSessionDetail`. Positive: completed Catan DTO (`gameSlug:'catan'`, `status:'Completed'`, scoreData + scorePlayers) → `catan-summary-row-name` present. Negatives: `gameSlug:'wingspan'` → absent; `status:'InProgress'` (Catan) → absent. If the file lacks a real-data harness, add `vi.mock('@/hooks/queries/useSessionDetail', () => ({ useSessionDetail: () => ({ data: dto, isLoading: false, isError: false, isSuccess: true }) }))` and drive the DTO per case.
 
 ```tsx
-it('mounts the Catan summary flavor for a completed Catan session (#3022)', async () => {
-  // Arrange: mock useSessionDetail to return a completed GameSessionDto with
-  // gameSlug='catan' + Points scoreData (mirror the harness already used in this file).
-  // Act: render SessionSummaryView for that session id.
-  // Assert:
+it('mounts Catan flavor for completed Catan (#3022)', async () => {
+  // arrange: useSessionDetail → completed catan dto with scoreData+scorePlayers
   expect(await screen.findByTestId('catan-summary-row-name')).toBeInTheDocument();
+});
+it('does NOT mount for non-catan', async () => {
+  // arrange: gameSlug 'wingspan'
+  expect(screen.queryByTestId('catan-summary-row-name')).toBeNull();
+});
+it('does NOT mount for non-completed status', async () => {
+  // arrange: catan but status 'InProgress'
+  expect(screen.queryByTestId('catan-summary-row-name')).toBeNull();
 });
 ```
 
-> The exact mock wiring mirrors the existing `useSessionDetail`/fixture mocks already in this test file — reuse that harness; only the returned DTO changes (add `gameSlug:'catan'`, `scoringType:'Points'`, `scoreData` JSON). If the file has no real-data harness, add a `vi.mock('@/hooks/queries/useSessionDetail', ...)` returning `{ data: <dto>, isLoading:false, isError:false, isSuccess:true }`.
+- [ ] **Step 2: Run — verify fail**.
 
-- [ ] **Step 2: Run test to verify it fails**
+- [ ] **Step 3: Wire the mount (inside the default+partial return block only)**
 
-Run: `cd apps/web && pnpm vitest run SessionSummaryView`
-Expected: FAIL — flavor slot not rendered.
-
-- [ ] **Step 3: Wire the mount**
-
-In `SessionSummaryView.tsx`, add the import near the other imports:
-
+Import:
 ```tsx
 import { SummaryFlavorRenderer, hasSummaryFlavor } from '@/components/features/session-live/SummaryFlavorRenderer';
 ```
 
-Then, as the FIRST child of the main container (`<div data-slot="session-summary-view">`, before `<SessionSummaryHero>`):
+As the FIRST child of the `<div data-slot="session-summary-view">` in the **default+partial full-render block** (the one containing `<SessionSummaryHero>`, ~line 895 — NOT the loading/error/not-found/not-completed shells):
 
 ```tsx
-{sessionQuery.data != null && hasSummaryFlavor(sessionQuery.data.gameSlug) && (
-  <div className="px-4 pt-4 sm:px-6">
-    <SummaryFlavorRenderer gameSlug={sessionQuery.data.gameSlug} session={sessionQuery.data} />
-  </div>
-)}
+{sessionQuery.data != null &&
+  sessionQuery.data.status === 'Completed' &&
+  hasSummaryFlavor(sessionQuery.data.gameSlug) && (
+    <div className="px-4 pt-4 sm:px-6">
+      <SummaryFlavorRenderer gameSlug={sessionQuery.data.gameSlug} session={sessionQuery.data} />
+    </div>
+  )}
 ```
 
-- [ ] **Step 4: Run test to verify it passes**
+- [ ] **Step 4: Run — verify pass + no regression**
 
-Run: `cd apps/web && pnpm vitest run SessionSummaryView`
-Expected: PASS, and the pre-existing SessionSummaryView tests stay green.
+Run: `cd apps/web && pnpm vitest run SessionSummaryView` — new tests pass, existing green.
 
-- [ ] **Step 5: Full FE + typecheck gate**
+- [ ] **Step 5: Full FE gate**
 
 Run: `cd apps/web && pnpm typecheck && pnpm vitest run SummaryFlavorRenderer CatanSummaryFlavor catan-summary-standings i18n-catan-summary-keys SessionSummaryView games.schemas`
 Expected: all green, no type errors.
@@ -882,17 +978,17 @@ Expected: all green, no type errors.
 ```bash
 git add apps/web/src/app/(authenticated)/sessions/[id]/_components/SessionSummaryView.tsx \
         apps/web/src/app/(authenticated)/sessions/[id]/_components/__tests__/SessionSummaryView.test.tsx
-git commit -m "feat(session-summary): #3022 wire CatanSummaryFlavor into SessionSummaryView"
+git commit -m "feat(session-summary): #3022 wire CatanSummaryFlavor (status-gated) into SessionSummaryView"
 ```
 
 ---
 
 ## Final verification (before PR)
 
-- [ ] `cd apps/api && dotnet test --filter "BoundedContext=GameManagement"` — BE green.
-- [ ] `cd apps/web && pnpm typecheck && pnpm lint && pnpm test` — FE green, no new lint violations (watch `meepleai/no-hardcoded-color-utility`; inline HSL only via `catanPieceColor`).
-- [ ] Manual (optional): open a completed Catan session summary → hero + standings render with real scores/colors; a non-Catan completed session → unchanged generic layout.
+- [ ] `cd apps/api && dotnet test --filter "BoundedContext=GameManagement"` — green.
+- [ ] `cd apps/web && pnpm typecheck && pnpm lint && pnpm test` — green, no new lint violations.
+- [ ] Manual (optional): a completed Catan session with recorded polymorphic scores → hero + standings with real VP/colors; a non-Catan or non-completed session → generic layout unchanged.
 
-## Out of scope (documented in the spec)
+## Out of scope (documented)
 
-Board snapshot, DiceChart, TradeBars, robber-move counter, longest-production-run, biggest-hand, 5-category scoreboard breakdown, longest-road/largest-army badges — all require persisted end-game `gameState`, absent on the summary DTO.
+Board snapshot, DiceChart, TradeBars, robber-move counter, longest-production-run, biggest-hand, 5-category breakdown, longest-road/largest-army badges — require persisted end-game `gameState`, absent on the summary DTO.

--- a/docs/superpowers/plans/2026-07-17-issue-3022-catan-summary-flavor.md
+++ b/docs/superpowers/plans/2026-07-17-issue-3022-catan-summary-flavor.md
@@ -1,0 +1,898 @@
+# Catan SUMMARY flavor (#3022) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a presentational Catan SUMMARY flavor (winner hero + final standings from real `scoreData` + player colors) mounted on `/sessions/[id]` via an isolated summary-flavor dispatcher.
+
+**Architecture:** BE enriches `GameSessionDto` with nullable `GameSlug`/`GameName` (only on the single-session GET path, resolved via `IGameCoreDataProvider` + `Slugifier`). FE adds a *twin* dispatcher `SummaryFlavorRenderer` (props `= { session: GameSessionDto }`, disjoint from the live `FlavorRenderer` typed on `LiveSessionDto`), plus `CatanSummaryFlavor` that reuses the pure adapter `mapScoreDataToEndgameSummary` and the `catanPieceColor` palette.
+
+**Tech Stack:** .NET 9 (MediatR/CQRS, xUnit + Moq + FluentAssertions), Next.js 16 / React 19, Zod, react-intl, Vitest.
+
+## Global Constraints
+
+- **Backend test path**: `apps/api/tests/Api.Tests` (NOT `tests/Api.Tests`).
+- **CQRS**: no endpoint changes here; only the existing query handler + DTO.
+- **i18n**: every new key exists in BOTH `apps/web/src/locales/it.json` AND `en.json`, with key parity. Italian text keeps correct accents (à, è, ù, …).
+- **Design tokens**: semantic tokens + entity utilities only; the only allowed raw inline HSL are the Catan piece colors via `catanPieceColor()` (already carry line-level `eslint-disable meepleai/no-inline-hsl-v2`).
+- **TDD**: RED → GREEN → REFACTOR, one behavior per test, frequent commits.
+- **Branch**: `feature/issue-3022-catan-summary-flavor` (parent `main-dev`).
+
+---
+
+## File Structure
+
+**Backend**
+- Modify `apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/GameSessionDto.cs` — add `GameSlug?`, `GameName?`.
+- Modify `apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GetGameSessionByIdQueryHandler.cs` — inject `IGameCoreDataProvider`, resolve slug/name.
+- Modify `apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/GetGameSessionByIdQueryHandlerTests.cs` — new ctor arg + coverage.
+
+**Frontend**
+- Modify `apps/web/src/lib/api/schemas/games.schemas.ts` — Zod `gameSlug`/`gameName`.
+- Create `apps/web/src/components/features/session-live/SummaryFlavorRenderer.tsx` — dispatcher + `SummaryFlavorProps` + `SUMMARY_FLAVOR_MAP` + `hasSummaryFlavor`.
+- Create `apps/web/src/components/features/session-live/flavors/catan/catan-summary-standings.ts` — pure standings builder (colors + ordering).
+- Create `apps/web/src/components/features/session-live/flavors/catan/CatanSummaryFlavor.tsx` — hero + standings render.
+- Modify `apps/web/src/app/(authenticated)/sessions/[id]/_components/SessionSummaryView.tsx` — conditional mount.
+- Modify `apps/web/src/locales/it.json` + `en.json` — new subtree.
+- Create `apps/web/src/components/features/session-live/flavors/catan/__tests__/i18n-catan-summary-keys.test.ts` — parity guard.
+
+---
+
+## Task 1: BE — `GameSessionDto` gains `GameSlug`/`GameName`, resolved on single-session GET
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/GameSessionDto.cs`
+- Modify: `apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GetGameSessionByIdQueryHandler.cs`
+- Test: `apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/GetGameSessionByIdQueryHandlerTests.cs`
+
+**Interfaces:**
+- Consumes: `IGameCoreDataProvider.GetCoreDataAsync(GameRef, CancellationToken) → Task<GameCoreData?>` (`GameCoreData.Title`); `GameRef.Shared(Guid)`; `Slugifier.Slugify(string) → string` (namespace `Api.SharedKernel.Application.Services`, returns `"unknown"` on null/empty).
+- Produces: `GameSessionDto` with new trailing fields `string? GameSlug`, `string? GameName` (default `null`).
+
+- [ ] **Step 1: Add the two fields to the DTO record**
+
+In `GameSessionDto.cs`, append two nullable params to the `GameSessionDto` record (after `ScoreData`):
+
+```csharp
+internal record GameSessionDto(
+    Guid Id,
+    Guid GameId,
+    string Status,
+    DateTime StartedAt,
+    DateTime? CompletedAt,
+    int PlayerCount,
+    IReadOnlyList<SessionPlayerDto> Players,
+    string? WinnerName,
+    string? Notes,
+    int DurationMinutes,
+    string? ScoringType = null,
+    string? ScoreData = null,
+    // #3022: game identity for the summary flavor dispatch. Populated ONLY on
+    // GET /api/v1/sessions/{id}; null on list/history paths (GameSessionMapper.ToDto).
+    string? GameSlug = null,
+    string? GameName = null
+);
+```
+
+- [ ] **Step 2: Write the failing handler test — slug/name populated from the catalog**
+
+In `GetGameSessionByIdQueryHandlerTests.cs`, first update the ctor to inject a mock provider (this is required for ALL existing tests too — do it now):
+
+```csharp
+private readonly Mock<IGameSessionRepository> _sessionRepositoryMock;
+private readonly Mock<IGameCoreDataProvider> _gameCoreDataMock;
+private readonly GetGameSessionByIdQueryHandler _handler;
+
+public GetGameSessionByIdQueryHandlerTests()
+{
+    _sessionRepositoryMock = new Mock<IGameSessionRepository>();
+    _gameCoreDataMock = new Mock<IGameCoreDataProvider>();
+    _handler = new GetGameSessionByIdQueryHandler(_sessionRepositoryMock.Object, _gameCoreDataMock.Object);
+}
+
+private static GameCoreData MakeCoreData(string title = "Catan") =>
+    GameCoreData.Create(title, 1995, 3, 4, 90, 10);
+```
+
+Add imports at top: `using Api.SharedKernel.Application;` and `using Api.SharedKernel.Domain.ValueObjects;`.
+
+Then add the new test:
+
+```csharp
+[Fact]
+public async Task Handle_ExistingSession_PopulatesGameSlugAndName_FromCatalog()
+{
+    var gameId = Guid.NewGuid();
+    var session = CreateSession(gameId);
+    _sessionRepositoryMock
+        .Setup(r => r.GetByIdAsync(session.Id, It.IsAny<CancellationToken>()))
+        .ReturnsAsync(session);
+    _gameCoreDataMock
+        .Setup(p => p.GetCoreDataAsync(GameRef.Shared(gameId), It.IsAny<CancellationToken>()))
+        .ReturnsAsync(MakeCoreData("Catan"));
+
+    var result = await _handler.Handle(new GetGameSessionByIdQuery(session.Id), TestContext.Current.CancellationToken);
+
+    result.Should().NotBeNull();
+    result!.GameName.Should().Be("Catan");
+    result.GameSlug.Should().Be("catan");
+}
+
+[Fact]
+public async Task Handle_GameNotInCatalog_LeavesSlugAndNameNull()
+{
+    var gameId = Guid.NewGuid();
+    var session = CreateSession(gameId);
+    _sessionRepositoryMock
+        .Setup(r => r.GetByIdAsync(session.Id, It.IsAny<CancellationToken>()))
+        .ReturnsAsync(session);
+    _gameCoreDataMock
+        .Setup(p => p.GetCoreDataAsync(It.IsAny<GameRef>(), It.IsAny<CancellationToken>()))
+        .ReturnsAsync((GameCoreData?)null);
+
+    var result = await _handler.Handle(new GetGameSessionByIdQuery(session.Id), TestContext.Current.CancellationToken);
+
+    result!.GameName.Should().BeNull();
+    result.GameSlug.Should().BeNull();
+}
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `cd apps/api && dotnet test --filter "FullyQualifiedName~GetGameSessionByIdQueryHandlerTests"`
+Expected: compile error (`GetGameSessionByIdQueryHandler` has no 2-arg ctor) — this is the RED for the whole task, including the ctor migration.
+
+- [ ] **Step 4: Implement the handler**
+
+Rewrite `GetGameSessionByIdQueryHandler.cs`:
+
+```csharp
+using Api.BoundedContexts.GameManagement.Application.DTOs;
+using Api.BoundedContexts.GameManagement.Domain.Entities;
+using Api.BoundedContexts.GameManagement.Domain.Repositories;
+using Api.SharedKernel.Application;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Application.Services;
+using Api.SharedKernel.Domain.ValueObjects;
+
+namespace Api.BoundedContexts.GameManagement.Application.Queries;
+
+internal class GetGameSessionByIdQueryHandler : IQueryHandler<GetGameSessionByIdQuery, GameSessionDto?>
+{
+    private readonly IGameSessionRepository _sessionRepository;
+    private readonly IGameCoreDataProvider _gameCoreData;
+
+    public GetGameSessionByIdQueryHandler(
+        IGameSessionRepository sessionRepository,
+        IGameCoreDataProvider gameCoreData)
+    {
+        _sessionRepository = sessionRepository ?? throw new ArgumentNullException(nameof(sessionRepository));
+        _gameCoreData = gameCoreData ?? throw new ArgumentNullException(nameof(gameCoreData));
+    }
+
+    public async Task<GameSessionDto?> Handle(GetGameSessionByIdQuery query, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        var session = await _sessionRepository.GetByIdAsync(query.SessionId, cancellationToken).ConfigureAwait(false);
+        if (session == null) return null;
+
+        var coreData = await _gameCoreData
+            .GetCoreDataAsync(GameRef.Shared(session.GameId), cancellationToken)
+            .ConfigureAwait(false);
+        var gameName = coreData?.Title;
+        var gameSlug = gameName is null ? null : Slugifier.Slugify(gameName);
+
+        return MapToDto(session, gameSlug, gameName);
+    }
+
+    private static GameSessionDto MapToDto(GameSession session, string? gameSlug, string? gameName)
+    {
+        var playerDtos = session.Players.Select(p => new SessionPlayerDto(
+            PlayerName: p.PlayerName,
+            PlayerOrder: p.PlayerOrder,
+            Color: p.Color
+        )).ToList();
+
+        return new GameSessionDto(
+            Id: session.Id,
+            GameId: session.GameId,
+            Status: session.Status.Value,
+            StartedAt: session.StartedAt,
+            CompletedAt: session.CompletedAt,
+            PlayerCount: session.PlayerCount,
+            Players: playerDtos,
+            WinnerName: session.WinnerName,
+            Notes: session.Notes,
+            DurationMinutes: (int)session.Duration.TotalMinutes,
+            GameSlug: gameSlug,
+            GameName: gameName
+        );
+    }
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd apps/api && dotnet test --filter "FullyQualifiedName~GetGameSessionByIdQueryHandlerTests"`
+Expected: PASS (all 6 pre-existing + 2 new).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/GameSessionDto.cs \
+        apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GetGameSessionByIdQueryHandler.cs \
+        apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/GetGameSessionByIdQueryHandlerTests.cs
+git commit -m "feat(session-summary): #3022 BE — enrich GameSessionDto with GameSlug/GameName"
+```
+
+---
+
+## Task 2: FE — Zod schema exposes `gameSlug`/`gameName`
+
+**Files:**
+- Modify: `apps/web/src/lib/api/schemas/games.schemas.ts:100-120`
+- Test: `apps/web/src/lib/api/schemas/__tests__/games.schemas.test.ts` (create if absent)
+
+**Interfaces:**
+- Produces: `GameSessionDto` (inferred) gains `gameSlug?: string | null`, `gameName?: string | null`.
+
+- [ ] **Step 1: Write the failing schema test**
+
+Create/append `apps/web/src/lib/api/schemas/__tests__/games.schemas.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { GameSessionDtoSchema } from '../games.schemas';
+
+const base = {
+  id: '00000000-0000-4000-8000-000000000001',
+  gameId: '00000000-0000-4000-8000-0000000000aa',
+  status: 'Completed',
+  startedAt: '2026-01-01T00:00:00Z',
+  completedAt: '2026-01-01T01:00:00Z',
+  playerCount: 2,
+  players: [{ playerName: 'Alice', playerOrder: 1, color: 'Red' }],
+  winnerName: 'Alice',
+  notes: null,
+  durationMinutes: 47,
+};
+
+describe('GameSessionDtoSchema #3022', () => {
+  it('parses gameSlug/gameName when present', () => {
+    const parsed = GameSessionDtoSchema.parse({ ...base, gameSlug: 'catan', gameName: 'Catan' });
+    expect(parsed.gameSlug).toBe('catan');
+    expect(parsed.gameName).toBe('Catan');
+  });
+
+  it('accepts null and absent gameSlug/gameName (back-compat)', () => {
+    expect(GameSessionDtoSchema.parse({ ...base, gameSlug: null, gameName: null }).gameSlug).toBeNull();
+    expect(GameSessionDtoSchema.parse(base).gameSlug).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/web && pnpm vitest run games.schemas`
+Expected: FAIL — `parsed.gameSlug` is `undefined` (schema strips unknown keys), first assertion fails.
+
+- [ ] **Step 3: Add the fields to the schema**
+
+In `games.schemas.ts`, inside `GameSessionDtoSchema` (after `turnOrderType`):
+
+```ts
+  // #3022: game identity for the summary flavor dispatch. Populated only on the
+  // single-session GET; null/absent on list/history responses.
+  gameSlug: z.string().nullable().optional(),
+  gameName: z.string().nullable().optional(),
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/web && pnpm vitest run games.schemas`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/lib/api/schemas/games.schemas.ts apps/web/src/lib/api/schemas/__tests__/games.schemas.test.ts
+git commit -m "feat(session-summary): #3022 FE — gameSlug/gameName on GameSessionDto schema"
+```
+
+---
+
+## Task 3: FE — pure standings builder `buildCatanSummaryStandings`
+
+**Files:**
+- Create: `apps/web/src/components/features/session-live/flavors/catan/catan-summary-standings.ts`
+- Test: `apps/web/src/components/features/session-live/flavors/catan/__tests__/catan-summary-standings.test.ts`
+
+**Interfaces:**
+- Consumes: `mapScoreDataToEndgameSummary(scoringType, scoreData, players) → readonly FinalScoreEntry[]` from `@/lib/session-live/score-data-to-endgame-summary`; `SessionPlayerDto` (`{ id?, playerName, playerOrder, color }`) from `@/lib/api/schemas/games.schemas`; `ScoreType`, `ScoreDataByType` from `@/components/sessions/score-strategies/types`.
+- Produces: `CatanSummaryRow = { playerName: string; score: number; isWinner: boolean; color: string | null }`; `buildCatanSummaryStandings(scoringType: string | null | undefined, scoreDataJson: string | null | undefined, players: readonly SessionPlayerDto[]) → CatanSummaryRow[]` (winner-first, then score DESC; `[]` when unusable).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `catan-summary-standings.test.ts`:
+
+```ts
+import { describe, it, expect, vi } from 'vitest';
+import { buildCatanSummaryStandings } from '../catan-summary-standings';
+import type { SessionPlayerDto } from '@/lib/api/schemas/games.schemas';
+
+const players: SessionPlayerDto[] = [
+  { id: 'p1', playerName: 'Alice', playerOrder: 1, color: 'Red' },
+  { id: 'p2', playerName: 'Bob', playerOrder: 2, color: 'Blue' },
+  { id: 'p3', playerName: 'Carol', playerOrder: 3, color: 'Orange' },
+];
+
+const pointsJson = JSON.stringify({
+  scores: [
+    { playerId: 'p1', points: 10 },
+    { playerId: 'p2', points: 8 },
+    { playerId: 'p3', points: 6 },
+  ],
+});
+
+describe('buildCatanSummaryStandings', () => {
+  it('orders winner-first then score DESC, zipping the player color', () => {
+    const rows = buildCatanSummaryStandings('Points', pointsJson, players);
+    expect(rows.map(r => r.playerName)).toEqual(['Alice', 'Bob', 'Carol']);
+    expect(rows[0]).toMatchObject({ playerName: 'Alice', score: 10, isWinner: true, color: 'Red' });
+    expect(rows[2]).toMatchObject({ playerName: 'Carol', score: 6, isWinner: false, color: 'Orange' });
+  });
+
+  it('returns [] when scoringType/scoreData is null', () => {
+    expect(buildCatanSummaryStandings(null, null, players)).toEqual([]);
+    expect(buildCatanSummaryStandings('Points', null, players)).toEqual([]);
+  });
+
+  it('returns [] and warns on malformed JSON', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(buildCatanSummaryStandings('Points', '{not json', players)).toEqual([]);
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/web && pnpm vitest run catan-summary-standings`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the builder**
+
+Create `catan-summary-standings.ts`:
+
+```ts
+/**
+ * buildCatanSummaryStandings — pure adapter from the raw GameSessionDto scoring
+ * fields to ordered summary rows enriched with each player's color.
+ *
+ * #3022. The upstream adapter (mapScoreDataToEndgameSummary) maps players.map()
+ * preserving order, so the FinalScoreEntry[] is index-parallel to `players`,
+ * which lets us zip the color by index before sorting.
+ */
+
+import { mapScoreDataToEndgameSummary } from '@/lib/session-live/score-data-to-endgame-summary';
+import type { SessionPlayerDto } from '@/lib/api/schemas/games.schemas';
+import type { ScoreDataByType, ScoreType } from '@/components/sessions/score-strategies/types';
+
+export interface CatanSummaryRow {
+  readonly playerName: string;
+  readonly score: number;
+  readonly isWinner: boolean;
+  readonly color: string | null;
+}
+
+const SCORE_TYPES: readonly ScoreType[] = ['Points', 'BinaryWin', 'Objectives', 'Ranking'];
+
+function parseScoreData(
+  scoringType: string | null | undefined,
+  scoreDataJson: string | null | undefined
+): { scoringType: ScoreType; scoreData: ScoreDataByType[ScoreType] } | null {
+  if (scoringType == null || scoreDataJson == null) return null;
+  if (!SCORE_TYPES.includes(scoringType as ScoreType)) return null;
+  try {
+    return {
+      scoringType: scoringType as ScoreType,
+      scoreData: JSON.parse(scoreDataJson) as ScoreDataByType[ScoreType],
+    };
+  } catch {
+    console.warn(`buildCatanSummaryStandings: malformed scoreData JSON for "${scoringType}"`);
+    return null;
+  }
+}
+
+export function buildCatanSummaryStandings(
+  scoringType: string | null | undefined,
+  scoreDataJson: string | null | undefined,
+  players: readonly SessionPlayerDto[]
+): CatanSummaryRow[] {
+  const parsed = parseScoreData(scoringType, scoreDataJson);
+  if (parsed === null) return [];
+
+  const adapterPlayers = players.map(p => ({ id: p.id ?? p.playerName, name: p.playerName }));
+  const entries = mapScoreDataToEndgameSummary(parsed.scoringType, parsed.scoreData, adapterPlayers);
+  if (entries.length === 0) return [];
+
+  // entries is index-parallel to `players` (adapter preserves order) → zip color.
+  const withColor: CatanSummaryRow[] = entries.map((e, i) => ({
+    playerName: e.playerName,
+    score: e.score,
+    isWinner: e.isWinner,
+    color: players[i]?.color ?? null,
+  }));
+
+  return withColor.sort(
+    (a, b) => Number(b.isWinner) - Number(a.isWinner) || b.score - a.score
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/web && pnpm vitest run catan-summary-standings`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/features/session-live/flavors/catan/catan-summary-standings.ts \
+        apps/web/src/components/features/session-live/flavors/catan/__tests__/catan-summary-standings.test.ts
+git commit -m "feat(session-summary): #3022 pure Catan standings builder (scoreData → rows + color)"
+```
+
+---
+
+## Task 4: FE — `CatanSummaryFlavor` component (hero + standings)
+
+**Files:**
+- Create: `apps/web/src/components/features/session-live/flavors/catan/CatanSummaryFlavor.tsx`
+- Test: `apps/web/src/components/features/session-live/flavors/catan/__tests__/CatanSummaryFlavor.test.tsx`
+
+**Interfaces:**
+- Consumes: `buildCatanSummaryStandings` (Task 3); `catanPieceColor(color)` from `./catan-palette`; `SummaryFlavorProps` (Task 5 — `{ session: GameSessionDto; className? }`). To avoid a circular task dependency, this component declares its own local props interface `{ session: GameSessionDto; className?: string }` (Catan flavor precedent: `CatanLiveFlavor` re-declares props locally instead of importing `FlavorProps`).
+- Produces: named export `CatanSummaryFlavor`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `CatanSummaryFlavor.test.tsx`:
+
+```tsx
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
+import type { ReactElement } from 'react';
+import { CatanSummaryFlavor } from '../CatanSummaryFlavor';
+import type { GameSessionDto } from '@/lib/api/schemas/games.schemas';
+
+const MESSAGES = {
+  'pages.sessionSummary.flavor.catan.winnerTemplate': '{name} vince!',
+  'pages.sessionSummary.flavor.catan.vpUnit': 'PV',
+  'pages.sessionSummary.flavor.catan.durationTemplate': '{minutes} min',
+  'pages.sessionSummary.flavor.catan.standingsTitle': 'Classifica finale',
+  'pages.sessionSummary.flavor.catan.empty': 'Riepilogo non disponibile',
+};
+
+function renderWithIntl(ui: ReactElement) {
+  return render(<IntlProvider locale="it" messages={MESSAGES}>{ui}</IntlProvider>);
+}
+
+const baseSession: GameSessionDto = {
+  id: '00000000-0000-4000-8000-000000000001',
+  gameId: '00000000-0000-4000-8000-0000000000aa',
+  status: 'Completed',
+  startedAt: '2026-01-01T00:00:00Z',
+  completedAt: '2026-01-01T00:47:00Z',
+  playerCount: 2,
+  players: [
+    { id: 'p1', playerName: 'Alice', playerOrder: 1, color: 'Red' },
+    { id: 'p2', playerName: 'Bob', playerOrder: 2, color: 'Blue' },
+  ],
+  winnerName: 'Alice',
+  notes: null,
+  durationMinutes: 47,
+  scoringType: 'Points',
+  scoreData: JSON.stringify({ scores: [{ playerId: 'p1', points: 10 }, { playerId: 'p2', points: 8 }] }),
+  gameSlug: 'catan',
+  gameName: 'Catan',
+};
+
+describe('CatanSummaryFlavor', () => {
+  it('renders the winner hero and ordered standings', () => {
+    renderWithIntl(<CatanSummaryFlavor session={baseSession} />);
+    expect(screen.getByText('Alice vince!')).toBeInTheDocument();
+    const names = screen.getAllByTestId('catan-summary-row-name').map(n => n.textContent);
+    expect(names).toEqual(['Alice', 'Bob']);
+  });
+
+  it('renders the empty state when scoreData is null', () => {
+    renderWithIntl(<CatanSummaryFlavor session={{ ...baseSession, scoringType: null, scoreData: null }} />);
+    expect(screen.getByText('Riepilogo non disponibile')).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/web && pnpm vitest run CatanSummaryFlavor`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the component**
+
+Create `CatanSummaryFlavor.tsx`:
+
+```tsx
+'use client';
+
+import { useIntl } from 'react-intl';
+import { useTranslation } from '@/hooks/useTranslation';
+import type { GameSessionDto } from '@/lib/api/schemas/games.schemas';
+import { buildCatanSummaryStandings } from './catan-summary-standings';
+import { catanPieceColor } from './catan-palette';
+
+interface CatanSummaryFlavorProps {
+  readonly session: GameSessionDto;
+  readonly className?: string;
+}
+
+export function CatanSummaryFlavor({ session, className }: CatanSummaryFlavorProps): React.JSX.Element {
+  const { t } = useTranslation();
+  const intl = useIntl();
+
+  const winnerTemplate =
+    (intl.messages['pages.sessionSummary.flavor.catan.winnerTemplate'] as string) ?? '{name} vince!';
+  const durationTemplate =
+    (intl.messages['pages.sessionSummary.flavor.catan.durationTemplate'] as string) ?? '{minutes} min';
+  const vpUnit = t('pages.sessionSummary.flavor.catan.vpUnit');
+  const standingsTitle = t('pages.sessionSummary.flavor.catan.standingsTitle');
+  const emptyLabel = t('pages.sessionSummary.flavor.catan.empty');
+
+  const rows = buildCatanSummaryStandings(session.scoringType, session.scoreData, session.players);
+
+  if (rows.length === 0) {
+    return (
+      <section
+        data-slot="catan-summary-flavor"
+        className={`rounded-2xl border border-border bg-card p-4 text-center text-[13px] text-muted-foreground ${className ?? ''}`}
+      >
+        {emptyLabel}
+      </section>
+    );
+  }
+
+  const winner = rows.find(r => r.isWinner) ?? rows[0];
+  const maxScore = rows.reduce((m, r) => Math.max(m, r.score), 0);
+
+  return (
+    <section
+      data-slot="catan-summary-flavor"
+      aria-label={standingsTitle}
+      className={`flex flex-col gap-4 rounded-2xl border border-border bg-card p-4 ${className ?? ''}`}
+    >
+      <header data-slot="catan-summary-hero" className="flex items-center gap-3">
+        <span
+          aria-hidden="true"
+          className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full border border-border-strong text-lg"
+          style={{ backgroundColor: catanPieceColor(winner.color ?? '') }}
+        >
+          👑
+        </span>
+        <div className="flex flex-col">
+          <span className="text-base font-semibold text-foreground">
+            {winnerTemplate.replace('{name}', winner.playerName)}
+          </span>
+          <span className="text-[13px] text-muted-foreground">
+            {winner.score} {vpUnit} · {durationTemplate.replace('{minutes}', String(session.durationMinutes))}
+          </span>
+        </div>
+      </header>
+
+      <ol data-slot="catan-summary-standings" className="flex flex-col gap-1.5">
+        {rows.map((row, i) => (
+          <li
+            key={row.playerName}
+            data-slot="catan-summary-row"
+            className="flex items-center gap-2 text-[13px]"
+          >
+            <span className="w-5 tabular-nums text-muted-foreground">{i + 1}°</span>
+            <span
+              aria-hidden="true"
+              className="h-3.5 w-3.5 shrink-0 rounded-full border border-border-strong"
+              style={{ backgroundColor: catanPieceColor(row.color ?? '') }}
+            />
+            <span data-testid="catan-summary-row-name" className="flex-1 truncate text-foreground">
+              {row.playerName}
+            </span>
+            <span className="h-1.5 w-24 overflow-hidden rounded-full bg-muted" aria-hidden="true">
+              <span
+                className="block h-full rounded-full bg-entity-session"
+                style={{ width: `${maxScore > 0 ? (row.score / maxScore) * 100 : 0}%` }}
+              />
+            </span>
+            <span className="w-12 text-right tabular-nums text-foreground">
+              {row.score} {vpUnit}
+            </span>
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/web && pnpm vitest run CatanSummaryFlavor`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/features/session-live/flavors/catan/CatanSummaryFlavor.tsx \
+        apps/web/src/components/features/session-live/flavors/catan/__tests__/CatanSummaryFlavor.test.tsx
+git commit -m "feat(session-summary): #3022 CatanSummaryFlavor (winner hero + standings)"
+```
+
+---
+
+## Task 5: FE — `SummaryFlavorRenderer` dispatcher
+
+**Files:**
+- Create: `apps/web/src/components/features/session-live/SummaryFlavorRenderer.tsx`
+- Test: `apps/web/src/components/features/session-live/__tests__/SummaryFlavorRenderer.test.tsx`
+
+**Interfaces:**
+- Consumes: `CatanSummaryFlavor` (Task 4); `FlavorLoadingSkeleton` from `./FlavorLoadingSkeleton`; `GameSessionDto` from `@/lib/api/schemas/games.schemas`.
+- Produces: `SummaryFlavorProps = { session: GameSessionDto; className?: string }`; `SummaryFlavorRenderer(props & { gameSlug: string | null | undefined })`; `hasSummaryFlavor(gameSlug: string | null | undefined): boolean`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `SummaryFlavorRenderer.test.tsx`:
+
+```tsx
+import { describe, it, expect } from 'vitest';
+import { hasSummaryFlavor } from '../SummaryFlavorRenderer';
+
+describe('hasSummaryFlavor', () => {
+  it('is true for catan', () => {
+    expect(hasSummaryFlavor('catan')).toBe(true);
+  });
+  it('is false for unknown slug / null / undefined', () => {
+    expect(hasSummaryFlavor('wingspan')).toBe(false);
+    expect(hasSummaryFlavor(null)).toBe(false);
+    expect(hasSummaryFlavor(undefined)).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/web && pnpm vitest run SummaryFlavorRenderer`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the dispatcher**
+
+Create `SummaryFlavorRenderer.tsx`:
+
+```tsx
+'use client';
+
+import dynamic from 'next/dynamic';
+import type { ComponentType } from 'react';
+import type { GameSessionDto } from '@/lib/api/schemas/games.schemas';
+import { FlavorLoadingSkeleton } from './FlavorLoadingSkeleton';
+
+export interface SummaryFlavorProps {
+  readonly session: GameSessionDto;
+  readonly className?: string;
+}
+
+type SummaryFlavorComponent = ComponentType<SummaryFlavorProps>;
+
+// Lazy chunks minted at MODULE scope (never inside render) — same rule as FlavorRenderer.
+const CatanSummaryFlavorLazy: SummaryFlavorComponent = dynamic(
+  () => import('./flavors/catan/CatanSummaryFlavor').then(m => ({ default: m.CatanSummaryFlavor })),
+  { ssr: false, loading: () => <FlavorLoadingSkeleton /> }
+);
+
+const SUMMARY_FLAVOR_MAP: Record<string, SummaryFlavorComponent> = {
+  catan: CatanSummaryFlavorLazy,
+};
+
+export function hasSummaryFlavor(gameSlug: string | null | undefined): boolean {
+  return gameSlug != null && SUMMARY_FLAVOR_MAP[gameSlug] != null;
+}
+
+interface SummaryFlavorRendererProps extends SummaryFlavorProps {
+  readonly gameSlug: string | null | undefined;
+}
+
+export function SummaryFlavorRenderer({
+  gameSlug,
+  session,
+  className,
+}: SummaryFlavorRendererProps): React.JSX.Element | null {
+  const LazyFlavor = gameSlug != null ? SUMMARY_FLAVOR_MAP[gameSlug] : undefined;
+  if (LazyFlavor == null) return null;
+  return <LazyFlavor session={session} className={className} />;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/web && pnpm vitest run SummaryFlavorRenderer`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/features/session-live/SummaryFlavorRenderer.tsx \
+        apps/web/src/components/features/session-live/__tests__/SummaryFlavorRenderer.test.tsx
+git commit -m "feat(session-summary): #3022 SummaryFlavorRenderer twin dispatcher"
+```
+
+---
+
+## Task 6: FE — i18n keys + parity guard
+
+**Files:**
+- Modify: `apps/web/src/locales/it.json`, `apps/web/src/locales/en.json`
+- Test: `apps/web/src/components/features/session-live/flavors/catan/__tests__/i18n-catan-summary-keys.test.ts`
+
+**Interfaces:**
+- Produces: subtree `pages.sessionSummary.flavor.catan.{winnerTemplate,vpUnit,durationTemplate,standingsTitle,empty}` in both catalogs.
+
+- [ ] **Step 1: Write the failing guard test**
+
+Create `i18n-catan-summary-keys.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import enMessages from '@/locales/en.json';
+import itMessages from '@/locales/it.json';
+
+const KEYS = ['winnerTemplate', 'vpUnit', 'durationTemplate', 'standingsTitle', 'empty'];
+type Catalog = { pages: { sessionSummary: { flavor: { catan: Record<string, string> } } } };
+const it_ = (itMessages as Catalog).pages.sessionSummary?.flavor?.catan ?? {};
+const en_ = (enMessages as Catalog).pages.sessionSummary?.flavor?.catan ?? {};
+
+describe('Catan summary i18n keys (#3022)', () => {
+  it.each(KEYS)('IT has %s', k => expect(it_[k]).toBeTruthy());
+  it.each(KEYS)('EN has %s', k => expect(en_[k]).toBeTruthy());
+  it('IT/EN parity', () => {
+    expect(Object.keys(it_).sort()).toEqual(Object.keys(en_).sort());
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/web && pnpm vitest run i18n-catan-summary-keys`
+Expected: FAIL — subtree absent.
+
+- [ ] **Step 3: Add the subtree to both catalogs**
+
+In `it.json`, under `pages.sessionSummary` (create the `flavor.catan` path):
+
+```json
+"flavor": {
+  "catan": {
+    "winnerTemplate": "{name} vince!",
+    "vpUnit": "PV",
+    "durationTemplate": "{minutes} min",
+    "standingsTitle": "Classifica finale",
+    "empty": "Riepilogo non disponibile"
+  }
+}
+```
+
+In `en.json`, same path:
+
+```json
+"flavor": {
+  "catan": {
+    "winnerTemplate": "{name} wins!",
+    "vpUnit": "VP",
+    "durationTemplate": "{minutes} min",
+    "standingsTitle": "Final standings",
+    "empty": "Summary not available"
+  }
+}
+```
+
+> Note: if `pages.sessionSummary` already exists in a catalog, merge `flavor` into it rather than duplicating the parent key. Verify with `node -e "console.log(!!require('./src/locales/it.json').pages.sessionSummary)"` before editing.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/web && pnpm vitest run i18n-catan-summary-keys`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/locales/it.json apps/web/src/locales/en.json \
+        apps/web/src/components/features/session-live/flavors/catan/__tests__/i18n-catan-summary-keys.test.ts
+git commit -m "feat(session-summary): #3022 i18n Catan summary keys + parity guard"
+```
+
+---
+
+## Task 7: FE — wire the flavor into `SessionSummaryView`
+
+**Files:**
+- Modify: `apps/web/src/app/(authenticated)/sessions/[id]/_components/SessionSummaryView.tsx`
+- Test: `apps/web/src/app/(authenticated)/sessions/[id]/_components/__tests__/SessionSummaryView.test.tsx` (extend)
+
+**Interfaces:**
+- Consumes: `SummaryFlavorRenderer`, `hasSummaryFlavor` (Task 5); the raw `sessionQuery.data: GameSessionDto | null` already present in the component (line ~402).
+
+- [ ] **Step 1: Write the failing wiring test**
+
+Append to `SessionSummaryView.test.tsx` a case asserting the flavor mounts for a completed Catan session (real-data path, not fixture). Use the existing test's render harness/mocks; assert on the flavor slot:
+
+```tsx
+it('mounts the Catan summary flavor for a completed Catan session (#3022)', async () => {
+  // Arrange: mock useSessionDetail to return a completed GameSessionDto with
+  // gameSlug='catan' + Points scoreData (mirror the harness already used in this file).
+  // Act: render SessionSummaryView for that session id.
+  // Assert:
+  expect(await screen.findByTestId('catan-summary-row-name')).toBeInTheDocument();
+});
+```
+
+> The exact mock wiring mirrors the existing `useSessionDetail`/fixture mocks already in this test file — reuse that harness; only the returned DTO changes (add `gameSlug:'catan'`, `scoringType:'Points'`, `scoreData` JSON). If the file has no real-data harness, add a `vi.mock('@/hooks/queries/useSessionDetail', ...)` returning `{ data: <dto>, isLoading:false, isError:false, isSuccess:true }`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/web && pnpm vitest run SessionSummaryView`
+Expected: FAIL — flavor slot not rendered.
+
+- [ ] **Step 3: Wire the mount**
+
+In `SessionSummaryView.tsx`, add the import near the other imports:
+
+```tsx
+import { SummaryFlavorRenderer, hasSummaryFlavor } from '@/components/features/session-live/SummaryFlavorRenderer';
+```
+
+Then, as the FIRST child of the main container (`<div data-slot="session-summary-view">`, before `<SessionSummaryHero>`):
+
+```tsx
+{sessionQuery.data != null && hasSummaryFlavor(sessionQuery.data.gameSlug) && (
+  <div className="px-4 pt-4 sm:px-6">
+    <SummaryFlavorRenderer gameSlug={sessionQuery.data.gameSlug} session={sessionQuery.data} />
+  </div>
+)}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/web && pnpm vitest run SessionSummaryView`
+Expected: PASS, and the pre-existing SessionSummaryView tests stay green.
+
+- [ ] **Step 5: Full FE + typecheck gate**
+
+Run: `cd apps/web && pnpm typecheck && pnpm vitest run SummaryFlavorRenderer CatanSummaryFlavor catan-summary-standings i18n-catan-summary-keys SessionSummaryView games.schemas`
+Expected: all green, no type errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/app/(authenticated)/sessions/[id]/_components/SessionSummaryView.tsx \
+        apps/web/src/app/(authenticated)/sessions/[id]/_components/__tests__/SessionSummaryView.test.tsx
+git commit -m "feat(session-summary): #3022 wire CatanSummaryFlavor into SessionSummaryView"
+```
+
+---
+
+## Final verification (before PR)
+
+- [ ] `cd apps/api && dotnet test --filter "BoundedContext=GameManagement"` — BE green.
+- [ ] `cd apps/web && pnpm typecheck && pnpm lint && pnpm test` — FE green, no new lint violations (watch `meepleai/no-hardcoded-color-utility`; inline HSL only via `catanPieceColor`).
+- [ ] Manual (optional): open a completed Catan session summary → hero + standings render with real scores/colors; a non-Catan completed session → unchanged generic layout.
+
+## Out of scope (documented in the spec)
+
+Board snapshot, DiceChart, TradeBars, robber-move counter, longest-production-run, biggest-hand, 5-category scoreboard breakdown, longest-road/largest-army badges — all require persisted end-game `gameState`, absent on the summary DTO.

--- a/docs/superpowers/specs/2026-07-17-issue-3022-catan-summary-flavor-design.md
+++ b/docs/superpowers/specs/2026-07-17-issue-3022-catan-summary-flavor-design.md
@@ -1,0 +1,144 @@
+# #3022 — Catan SUMMARY flavor: design
+
+- **Issue**: [#3022](https://github.com/meepleAi-app/meepleai-monorepo/issues/3022) — `[#2377 G6a-2] feat(session-live): Catan flavor SUMMARY view (deferred from #2787)`
+- **Parent**: #2377 (G6 umbrella) · **Epic**: #2354 · **Enabler**: #3025 (per-game live game-state)
+- **Branch**: `feature/issue-3022-catan-summary-flavor` (parent `main-dev`)
+- **Data**: 2026-07-17
+
+## 1. Contesto
+
+La vista LIVE di Catan è già in produzione (#2787 / PR #3021). La vista SUMMARY (recap fine partita su `/sessions/[id]`) fu **deliberatamente rinviata** in #3022 perché porta debito che la LIVE non ha: il suo data-path passa da un DTO diverso (`GameSessionDto`, non `LiveSessionDto`) che non conosce lo slug del gioco né il game-state per-partita.
+
+### Decisioni prese (brainstorming 2026-07-17)
+
+| Decisione | Scelta | Conseguenza |
+|---|---|---|
+| **Scope MVP** | Presentational core | Hero vincitore + final standings (punteggi reali + colori) + KPI base (durata; turni/round se presenti). **Niente** board snapshot / dice-chart / trade-bars / breakdown 5-categorie / badge longest-road-largest-army. |
+| **Fonte `gameSlug`** | Backend | `GameSessionDto` arricchito con `GameSlug`/`GameName` (nullable). |
+
+Il mockup `admin-mockups/design_files/sp4-session-catan-summary.*` è marcato `design_intent: "deferred"` (fidelity.json, tracking #2234 — track Storybook già chiusa): vale come **guida di layout**, non come pixel-gate.
+
+## 2. Fatti verificati dalla discovery
+
+1. **I dati core del summary esistono già nel DTO, ma vengono scartati.** `GameSessionDto` (da `GET /api/v1/sessions/{id}`) espone `scoringType` + `scoreData` (punteggi reali per-player, JSON-encoded, formato #2389/#3080), `durationMinutes`, `players[].color`, `winnerName`. L'adapter `adaptGameSessionToDetails` (`SessionSummaryView.tsx:158-193`) li appiattisce a placeholder (`score = isWinner ? 1 : 0`, `duration = '—'`, `color` ignorato). Il summary flavor **bypassa** l'adapter e legge i campi grezzi.
+2. **Manca `gameSlug`/`gameName`** su `GameSessionDto` (solo `GameId` Guid). Serve per il dispatch del flavor.
+3. **Manca `gameState`** sul summary DTO: vive **solo** su `LiveSessionDto` (`live-sessions.schemas.ts:139`). → tutti gli elementi che richiedono lo stato per-partita sono fuori scope MVP.
+4. **`FlavorRenderer` è cablato sul solo LIVE**: `FlavorView = 'live'`, `FlavorProps.session: LiveSessionDto`, e `CatanLiveFlavor` legge lo stato da `useLiveSessionStore`/SignalR — nulla di ciò esiste in pagina summary. Il summary ha bisogno di **props proprie**.
+5. **Adapter riusabile già pronto**: `mapScoreDataToEndgameSummary(scoringType, scoreData, players)` (`lib/session-live/score-data-to-endgame-summary.ts`) → `FinalScoreEntry[]` (`{playerName, score, isWinner}`), gestisce i 4 `ScoreType`, ritorna `[]` su null, e mappa `players.map()` **preservando l'ordine** (output parallelo-per-indice all'input).
+6. **Pattern BE per lo slug**: il LIVE deriva `GameSlug = Slugifier.Slugify(GameName)` (`QueryHandlers.cs:44`); `SharedGame` non ha un campo `Slug`. `GameName` = `SharedGame.Title`, risolvibile da `GameId` col pattern esistente `_db.SharedGames.Where(g => g.Id == gameId).Select(g => g.Title)`.
+
+## 3. Architettura
+
+### 3.1 Dispatcher summary gemello (non estensione del renderer live)
+
+**Scelta**: un dispatcher parallelo e isolato, **non** una modifica a `FlavorRenderer`.
+
+- **Motivo**: `FlavorProps.session` è `LiveSessionDto` e i flavor live dipendono da `useLiveSessionStore`/SignalR. Il summary consuma `GameSessionDto` e non ha store live. Rendere `FlavorRenderer` generico sulle props per-view toccherebbe codice condiviso da 7 flavor live → rischio sproporzionato per un MVP.
+- **Componenti nuovi** (in `apps/web/src/components/features/session-live/`):
+  - `SummaryFlavorRenderer.tsx` — dispatcher lazy gemello di `FlavorRenderer`.
+  - `SummaryFlavorProps` — `{ session: GameSessionDto; className?: string }` (props proprie, disaccoppiate dal live).
+  - `SUMMARY_FLAVOR_MAP` — `Record<string, LazyExoticComponent<...>>`, inizialmente `{ catan: CatanSummaryFlavorLazy }`.
+  - `hasSummaryFlavor(slug: string | null | undefined): boolean` — per il mount condizionale.
+- `FlavorRenderer.tsx` e i 7 flavor live **restano invariati**.
+
+### 3.2 Data flow (FE, tutto sui campi grezzi del DTO)
+
+```
+GameSessionDto
+ ├─ scoreData (JSON string) ──JSON.parse[try/catch → warn → null]──▶ oggetto polimorfico
+ ├─ scoringType ──────────────────────────────────────────────────┐
+ ├─ players[] (id, name, color) ──▶ AdapterPlayer[] ───────────────┤
+ │                                                                  ▼
+ │                                       mapScoreDataToEndgameSummary()
+ │                                          → FinalScoreEntry[] (parallelo-per-indice a players)
+ │                                                                  │
+ │              zip color: standings[i].color = players[i].color ◀──┘
+ │                                                                  ▼
+ │                              standings ordinate (winner-first, poi score DESC)
+ ├─ durationMinutes ──────────────────────────────────────────────▶ KPI durata
+ └─ winnerName / playerCount ─────────────────────────────────────▶ hero + KPI
+```
+
+Lo zip per-indice è sicuro perché l'adapter costruisce l'output con `players.map(...)` senza riordinare (verificato, `score-data-to-endgame-summary.ts:49,67,78,97`).
+
+## 4. Backend
+
+### 4.1 `GameSessionDto`
+
+Aggiungere due campi **nullable** in coda al record (`GameSessionDto.cs`):
+
+```csharp
+string? GameSlug = null,   // populated only on GET /api/v1/sessions/{id}
+string? GameName = null    // Title from the shared-game catalog; null on list/history paths
+```
+
+Nullable perché il DTO è condiviso da molti endpoint (history, active, complete, abandon, pause, resume, end): solo il path a singola sessione li popola.
+
+### 4.2 Popolamento (solo path GET singola sessione)
+
+`GetGameSessionByIdQueryHandler.MapToDto` risolve `GameName`/`GameSlug`:
+- Inietta accesso in lettura al catalogo `SharedGames` (via `DbContext` condiviso, come `UploadPdfCommandHandler.cs:141` — pattern già accettato nel codebase, oppure repository catalogo se disponibile — dettaglio del piano).
+- `gameName = SharedGames.Where(g => g.Id == session.GameId).Select(g => g.Title).FirstOrDefault()`.
+- `gameSlug = gameName is null ? null : Slugifier.Slugify(gameName)` (identico a `QueryHandlers.cs:44`).
+- Se il gioco non è nel catalogo → entrambi `null` → il FE cade sul layout generico.
+
+`GameSessionMapper.ToDto` (extension statico usato dagli **altri** endpoint) resta invariato: `GameSlug`/`GameName` restano `null` (nessun accesso al catalogo, nessun cambio di comportamento sugli altri path).
+
+### 4.3 Schema Zod FE
+
+`GameSessionDtoSchema` (`games.schemas.ts`) += `gameSlug: z.string().nullable().optional()`, `gameName: z.string().nullable().optional()`.
+
+## 5. Frontend — `CatanSummaryFlavor`
+
+- **Input**: `SummaryFlavorProps` (`session: GameSessionDto`).
+- **Parsing**: `JSON.parse(session.scoreData)` in `try/catch`; su errore `console.warn` + trattamento come `null`.
+- **Standings**: `mapScoreDataToEndgameSummary(session.scoringType, parsed, adapterPlayers)` + zip `color` per indice + ordinamento winner-first/score-DESC.
+- **Render**:
+  - **Hero**: avatar del vincitore (hue derivato da `player.color`), titolo `"{nome} vince!"`, punteggio del vincitore + `durationMinutes`.
+  - **Standings strip**: per riga → posizione, `PlayerDot` color-coded, nome, barra di progresso, punteggio. Riuso di palette/atomi del pattern `CatanLiveFlavor`.
+- **i18n**: label auto-costruite via `useIntl` (stesso pattern del flavor live).
+
+### 5.1 Wire in `SessionSummaryView`
+
+Additivo e a basso rischio: se `hasSummaryFlavor(session.gameSlug)` → monta `<SummaryFlavorRenderer session={dto} />` come **sezione** in cima al layout summary esistente; altrimenti la pagina resta invariata. L'MVP **non** rimuove il layout generico né introduce una nuova route (`/sessions/[id]/summary` con tab è fuori scope; il posizionamento fine è dettaglio del piano).
+
+## 6. Error / null handling
+
+| Condizione | Comportamento |
+|---|---|
+| `gameSlug` null / gioco senza flavor summary | `SummaryFlavorRenderer` → `null` → layout summary generico invariato |
+| `scoringType`/`scoreData` null | adapter → `[]` → empty state gentile del flavor |
+| `scoreData` malformed JSON | `try/catch` + `console.warn` → trattato come null |
+| `player.color` null | `PlayerDot` con colore neutro di fallback |
+| catalogo non risolve il gioco | `gameName`/`gameSlug` null dal BE → come "gameSlug null" |
+
+## 7. i18n
+
+Nuovo sottoalbero (naming da confermare nel piano, es. `features.sessionLive.catanSummary.*`) in `it.json` **e** `en.json`, coprendo hero/standings/KPI/empty. **Guard di parità** dedicato (stesso pattern di `i18n-gamedetail-keys.test.ts`, #3103).
+
+## 8. Testing (TDD, RED-first)
+
+- **FE unit `CatanSummaryFlavor`**: `scoreData` Points reale → hero mostra il vincitore, standings ordinate con colori; `scoreData` null → empty; JSON malformato → empty + `console.warn`.
+- **FE unit `SummaryFlavorRenderer`**: dispatch `catan` → componente montato; slug sconosciuto/null → `null`.
+- **FE `SessionSummaryView` wiring**: `gameSlug='catan'` → flavor montato; altro slug → non montato; nessuna regressione sul test esistente.
+- **BE unit `GetGameSessionByIdQueryHandler`**: popola `GameSlug`/`GameName` dal catalogo; gioco assente → null. Verifica che `GameSessionMapper.ToDto` (altri path) lasci null.
+- **Guard i18n**: nuove chiavi presenti e a parità IT/EN.
+
+## 9. Fuori scope MVP (deferred — richiedono `gameState` end-game persistito)
+
+Board snapshot (`HexBoard` finale), `DiceChart` (istogramma 2D6 storico), `TradeBars`, contatore mosse del ladro, "serie di produzione più lunga", "mano più grande", breakdown per le 5 categorie di scoring, badge `LongestRoad`/`LargestArmy` nelle standings. Nessuno di questi è alimentabile dal summary DTO attuale.
+
+## 10. File toccati (checklist)
+
+**Backend**
+- `GameSessionDto.cs` — +`GameSlug?`, +`GameName?`
+- `GetGameSessionByIdQueryHandler.cs` — DI catalogo + risoluzione slug/name
+- (test) `GetGameSessionByIdQueryHandler` test
+
+**Frontend**
+- `components/features/session-live/SummaryFlavorRenderer.tsx` (nuovo: renderer + `SummaryFlavorProps` + `SUMMARY_FLAVOR_MAP` + `hasSummaryFlavor`)
+- `components/features/session-live/flavors/catan/CatanSummaryFlavor.tsx` (nuovo, + eventuali sub-componenti hero/standings)
+- `lib/api/**/games.schemas.ts` — Zod `gameSlug`/`gameName`
+- `app/(authenticated)/sessions/[id]/_components/SessionSummaryView.tsx` — wire condizionale
+- `locales/it.json`, `locales/en.json` + guard i18n
+- test FE (flavor, renderer, wiring, guard)

--- a/docs/superpowers/specs/2026-07-17-issue-3022-catan-summary-flavor-design.md
+++ b/docs/superpowers/specs/2026-07-17-issue-3022-catan-summary-flavor-design.md
@@ -1,144 +1,122 @@
-# #3022 — Catan SUMMARY flavor: design
+# #3022 — Catan SUMMARY flavor: design (rev. 2 — scope VP reali / BE bridge)
 
 - **Issue**: [#3022](https://github.com/meepleAi-app/meepleai-monorepo/issues/3022) — `[#2377 G6a-2] feat(session-live): Catan flavor SUMMARY view (deferred from #2787)`
 - **Parent**: #2377 (G6 umbrella) · **Epic**: #2354 · **Enabler**: #3025 (per-game live game-state)
 - **Branch**: `feature/issue-3022-catan-summary-flavor` (parent `main-dev`)
-- **Data**: 2026-07-17
+- **Data**: 2026-07-18 (rev. 2)
+
+> **Rev. 2 changelog**: la rev. 1 assumeva "presentational FE-only con punteggi reali già sul summary DTO". Una review avversariale del piano l'ha smentita su due punti critici (§2). Scelta utente: **VP reali via BE bridge**. Questa revisione ridisegna il backend di conseguenza.
 
 ## 1. Contesto
 
-La vista LIVE di Catan è già in produzione (#2787 / PR #3021). La vista SUMMARY (recap fine partita su `/sessions/[id]`) fu **deliberatamente rinviata** in #3022 perché porta debito che la LIVE non ha: il suo data-path passa da un DTO diverso (`GameSessionDto`, non `LiveSessionDto`) che non conosce lo slug del gioco né il game-state per-partita.
+La vista LIVE di Catan è in produzione (#2787). La SUMMARY (recap su `/sessions/[id]`) fu rinviata in #3022. Scope confermato: **presentational core con punteggi reali** — Hero vincitore + final standings (VP reali per-player + colori) + KPI durata. Fuori scope: board snapshot, dice-chart, trade-bars, breakdown 5-categorie, badge longest-road/largest-army (richiedono `gameState` end-game non persistito). Il mockup `sp4-session-catan-summary.*` è `design_intent: "deferred"` → guida di layout, non pixel-gate.
 
-### Decisioni prese (brainstorming 2026-07-17)
+## 2. I due difetti critici che hanno ridisegnato il backend (verificati nel codice)
 
-| Decisione | Scelta | Conseguenza |
-|---|---|---|
-| **Scope MVP** | Presentational core | Hero vincitore + final standings (punteggi reali + colori) + KPI base (durata; turni/round se presenti). **Niente** board snapshot / dice-chart / trade-bars / breakdown 5-categorie / badge longest-road-largest-army. |
-| **Fonte `gameSlug`** | Backend | `GameSessionDto` arricchito con `GameSlug`/`GameName` (nullable). |
+1. **`GET /api/v1/sessions/{id}` non popola `scoreData`/`scoringType`.** Il `GetGameSessionByIdQueryHandler.MapToDto` costruisce il DTO senza score; l'enrichment esiste **solo** sul path history (`GetSessionHistoryQueryHandler.cs:51-61` via `IHistorySessionScoreProvider`). → sul summary `scoreData` è sempre `null`.
+2. **Identity mismatch dei player.** `scoreData.scores[].playerId` sono `SessionPlayerEntity.Id` (aggregato **LiveGameSession**, tabella `session_players`), mentre `GameSessionDto.Players` (`SessionPlayerDto`) espone solo `playerName/order/color` senza quell'id. → il join VP↔giocatore non ha chiave comune.
 
-Il mockup `admin-mockups/design_files/sp4-session-catan-summary.*` è marcato `design_intent: "deferred"` (fidelity.json, tracking #2234 — track Storybook già chiusa): vale come **guida di layout**, non come pixel-gate.
-
-## 2. Fatti verificati dalla discovery
-
-1. **I dati core del summary esistono già nel DTO, ma vengono scartati.** `GameSessionDto` (da `GET /api/v1/sessions/{id}`) espone `scoringType` + `scoreData` (punteggi reali per-player, JSON-encoded, formato #2389/#3080), `durationMinutes`, `players[].color`, `winnerName`. L'adapter `adaptGameSessionToDetails` (`SessionSummaryView.tsx:158-193`) li appiattisce a placeholder (`score = isWinner ? 1 : 0`, `duration = '—'`, `color` ignorato). Il summary flavor **bypassa** l'adapter e legge i campi grezzi.
-2. **Manca `gameSlug`/`gameName`** su `GameSessionDto` (solo `GameId` Guid). Serve per il dispatch del flavor.
-3. **Manca `gameState`** sul summary DTO: vive **solo** su `LiveSessionDto` (`live-sessions.schemas.ts:139`). → tutti gli elementi che richiedono lo stato per-partita sono fuori scope MVP.
-4. **`FlavorRenderer` è cablato sul solo LIVE**: `FlavorView = 'live'`, `FlavorProps.session: LiveSessionDto`, e `CatanLiveFlavor` legge lo stato da `useLiveSessionStore`/SignalR — nulla di ciò esiste in pagina summary. Il summary ha bisogno di **props proprie**.
-5. **Adapter riusabile già pronto**: `mapScoreDataToEndgameSummary(scoringType, scoreData, players)` (`lib/session-live/score-data-to-endgame-summary.ts`) → `FinalScoreEntry[]` (`{playerName, score, isWinner}`), gestisce i 4 `ScoreType`, ritorna `[]` su null, e mappa `players.map()` **preservando l'ordine** (output parallelo-per-indice all'input).
-6. **Pattern BE per lo slug**: il LIVE deriva `GameSlug = Slugifier.Slugify(GameName)` (`QueryHandlers.cs:44`); `SharedGame` non ha un campo `Slug`. `GameName` = `SharedGame.Title`, risolvibile da `GameId` col pattern esistente `_db.SharedGames.Where(g => g.Id == gameId).Select(g => g.Title)`.
+**Bridge risolto** (verificato end-to-end): i `playerId` in `scoreData` = `SessionPlayerEntity.Id`, che porta **anche** `DisplayName` e `Color`. Percorso: `GameSession.Id ← LiveGameSession.CorrelatedGameSessionId`; `LiveGameSession.Id = SessionPlayers.LiveGameSessionId`. Gli stessi `SessionPlayers` vivono sullo stesso `LiveGameSession` che il score-provider già attraversa → allineamento esatto, **nessun name-matching**.
 
 ## 3. Architettura
 
-### 3.1 Dispatcher summary gemello (non estensione del renderer live)
+### 3.1 Backend — read-model esteso (una sola chiamata provider)
 
-**Scelta**: un dispatcher parallelo e isolato, **non** una modifica a `FlavorRenderer`.
-
-- **Motivo**: `FlavorProps.session` è `LiveSessionDto` e i flavor live dipendono da `useLiveSessionStore`/SignalR. Il summary consuma `GameSessionDto` e non ha store live. Rendere `FlavorRenderer` generico sulle props per-view toccherebbe codice condiviso da 7 flavor live → rischio sproporzionato per un MVP.
-- **Componenti nuovi** (in `apps/web/src/components/features/session-live/`):
-  - `SummaryFlavorRenderer.tsx` — dispatcher lazy gemello di `FlavorRenderer`.
-  - `SummaryFlavorProps` — `{ session: GameSessionDto; className?: string }` (props proprie, disaccoppiate dal live).
-  - `SUMMARY_FLAVOR_MAP` — `Record<string, LazyExoticComponent<...>>`, inizialmente `{ catan: CatanSummaryFlavorLazy }`.
-  - `hasSummaryFlavor(slug: string | null | undefined): boolean` — per il mount condizionale.
-- `FlavorRenderer.tsx` e i 7 flavor live **restano invariati**.
-
-### 3.2 Data flow (FE, tutto sui campi grezzi del DTO)
-
-```
-GameSessionDto
- ├─ scoreData (JSON string) ──JSON.parse[try/catch → warn → null]──▶ oggetto polimorfico
- ├─ scoringType ──────────────────────────────────────────────────┐
- ├─ players[] (id, name, color) ──▶ AdapterPlayer[] ───────────────┤
- │                                                                  ▼
- │                                       mapScoreDataToEndgameSummary()
- │                                          → FinalScoreEntry[] (parallelo-per-indice a players)
- │                                                                  │
- │              zip color: standings[i].color = players[i].color ◀──┘
- │                                                                  ▼
- │                              standings ordinate (winner-first, poi score DESC)
- ├─ durationMinutes ──────────────────────────────────────────────▶ KPI durata
- └─ winnerName / playerCount ─────────────────────────────────────▶ hero + KPI
-```
-
-Lo zip per-indice è sicuro perché l'adapter costruisce l'output con `players.map(...)` senza riordinare (verificato, `score-data-to-endgame-summary.ts:49,67,78,97`).
-
-## 4. Backend
-
-### 4.1 `GameSessionDto`
-
-Aggiungere due campi **nullable** in coda al record (`GameSessionDto.cs`):
+Nuovo metodo sul provider esistente (`IHistorySessionScoreProvider`), che lascia `GetScoresAsync` (history list) **invariato**:
 
 ```csharp
-string? GameSlug = null,   // populated only on GET /api/v1/sessions/{id}
-string? GameName = null    // Title from the shared-game catalog; null on list/history paths
+Task<SessionScoreboard?> GetScoreboardAsync(Guid gameSessionId, CancellationToken ct);
+
+internal readonly record struct SessionScoreboard(
+    string ScoringType,
+    string ScoreData,
+    IReadOnlyList<ScorePlayerReadModel> Players);
+
+internal readonly record struct ScorePlayerReadModel(Guid Id, string DisplayName, string Color);
 ```
 
-Nullable perché il DTO è condiviso da molti endpoint (history, active, complete, abandon, pause, resume, end): solo il path a singola sessione li popola.
+Implementazione (mirror del join esistente `HistorySessionScoreProvider.cs:35-49`, + proiezione dei `SessionPlayers`):
+1. `LiveGameSessions.Where(CorrelatedGameSessionId == gameSessionId)` join `SessionTrackingSessions on TrackingSessionId == track.Id` → `(live.Id, track.ScoringType, track.ScoreData, updatedAt)`, prendi il più recente. Se nessuno → `null`.
+2. `SessionPlayers.Where(LiveGameSessionId == live.Id).Select(p => new ScorePlayerReadModel(p.Id, p.DisplayName, p.Color))`.
+3. `new SessionScoreboard(scoringType, scoreData, players)`.
 
-### 4.2 Popolamento (solo path GET singola sessione)
+### 3.2 Backend — DTO + handler
 
-`GetGameSessionByIdQueryHandler.MapToDto` risolve `GameName`/`GameSlug`:
-- Inietta accesso in lettura al catalogo `SharedGames` (via `DbContext` condiviso, come `UploadPdfCommandHandler.cs:141` — pattern già accettato nel codebase, oppure repository catalogo se disponibile — dettaglio del piano).
-- `gameName = SharedGames.Where(g => g.Id == session.GameId).Select(g => g.Title).FirstOrDefault()`.
-- `gameSlug = gameName is null ? null : Slugifier.Slugify(gameName)` (identico a `QueryHandlers.cs:44`).
-- Se il gioco non è nel catalogo → entrambi `null` → il FE cade sul layout generico.
+- `GameSessionDto` (record) += (tutti nullable, popolati **solo** su GET singola sessione):
+  - `string? GameSlug`, `string? GameName` (via `IGameCoreDataProvider` + `Slugifier.Slugify`).
+  - `IReadOnlyList<ScorePlayerDto>? ScorePlayers` con `internal record ScorePlayerDto(Guid Id, string DisplayName, string? Color)`.
+  - `ScoringType`/`ScoreData` **esistono già** (default null): ora popolati dal scoreboard.
+- `GetGameSessionByIdQueryHandler` inietta `IGameCoreDataProvider` + `IHistorySessionScoreProvider`. Dopo aver caricato la session: risolve slug/name; chiama `GetScoreboardAsync(session.Id, ct)`; se presente, popola `ScoringType`/`ScoreData`/`ScorePlayers`.
+- `GameSessionMapper.ToDto` (altri endpoint) **invariato**: i nuovi campi restano null.
 
-`GameSessionMapper.ToDto` (extension statico usato dagli **altri** endpoint) resta invariato: `GameSlug`/`GameName` restano `null` (nessun accesso al catalogo, nessun cambio di comportamento sugli altri path).
+### 3.3 Frontend — flavor
 
-### 4.3 Schema Zod FE
+- Zod `GameSessionDtoSchema` += `gameSlug`/`gameName` (nullable optional) + `scorePlayers: z.array(ScorePlayerDtoSchema).nullable().optional()`, con `ScorePlayerDtoSchema = { id: string, displayName: string, color: string|null }`.
+- Dispatcher summary **gemello** isolato (`SummaryFlavorRenderer`, props `{ session: GameSessionDto }`) — non tocca il `FlavorRenderer` live (tipizzato su `LiveSessionDto` + `useLiveSessionStore`).
+- `CatanSummaryFlavor` usa **`session.scorePlayers`** (id+displayName+color, allineati a scoreData) come master-list:
+  - `buildCatanSummaryStandings(scoringType, scoreData, scorePlayers)` → `mapScoreDataToEndgameSummary(scoringType, parsed, scorePlayers.map(p => ({id, name: displayName})))` + zip `color` per indice.
+  - **Winner hero**: preferisce `session.winnerName` (BE-autoritativo, coerente col resto del summary); fallback alla row `isWinner`; **nessun auto-crowning** quando né `winnerName` né una `isWinner` esistono.
+  - **Durata**: `session.durationMinutes`.
 
-`GameSessionDtoSchema` (`games.schemas.ts`) += `gameSlug: z.string().nullable().optional()`, `gameName: z.string().nullable().optional()`.
+### 3.4 Data flow
 
-## 5. Frontend — `CatanSummaryFlavor`
+```
+GET /sessions/{id}
+  handler → GetScoreboardAsync(session.Id)  ─┐
+          → IGameCoreDataProvider(gameId)    ─┤→ GameSessionDto {
+                                               │    scoringType, scoreData,        (from scoreboard)
+                                               │    scorePlayers[{id,displayName,color}],
+                                               │    gameSlug, gameName, winnerName, durationMinutes, players }
+FE SessionSummaryView (status==='Completed' && hasSummaryFlavor(gameSlug))
+  → SummaryFlavorRenderer → CatanSummaryFlavor(session)
+      buildCatanSummaryStandings(scoringType, scoreData, scorePlayers)
+        → mapScoreDataToEndgameSummary (join playerId↔scorePlayers[].id) → FinalScoreEntry[]
+        → zip color per indice → sort winner-first, score DESC
+      hero: winnerName ?? row.isWinner ?? (none)   standings: rows con color
+```
 
-- **Input**: `SummaryFlavorProps` (`session: GameSessionDto`).
-- **Parsing**: `JSON.parse(session.scoreData)` in `try/catch`; su errore `console.warn` + trattamento come `null`.
-- **Standings**: `mapScoreDataToEndgameSummary(session.scoringType, parsed, adapterPlayers)` + zip `color` per indice + ordinamento winner-first/score-DESC.
-- **Render**:
-  - **Hero**: avatar del vincitore (hue derivato da `player.color`), titolo `"{nome} vince!"`, punteggio del vincitore + `durationMinutes`.
-  - **Standings strip**: per riga → posizione, `PlayerDot` color-coded, nome, barra di progresso, punteggio. Riuso di palette/atomi del pattern `CatanLiveFlavor`.
-- **i18n**: label auto-costruite via `useIntl` (stesso pattern del flavor live).
-
-### 5.1 Wire in `SessionSummaryView`
-
-Additivo e a basso rischio: se `hasSummaryFlavor(session.gameSlug)` → monta `<SummaryFlavorRenderer session={dto} />` come **sezione** in cima al layout summary esistente; altrimenti la pagina resta invariata. L'MVP **non** rimuove il layout generico né introduce una nuova route (`/sessions/[id]/summary` con tab è fuori scope; il posizionamento fine è dettaglio del piano).
-
-## 6. Error / null handling
+## 4. Error / null handling
 
 | Condizione | Comportamento |
 |---|---|
-| `gameSlug` null / gioco senza flavor summary | `SummaryFlavorRenderer` → `null` → layout summary generico invariato |
-| `scoringType`/`scoreData` null | adapter → `[]` → empty state gentile del flavor |
+| `gameSlug` null / non-Catan | `SummaryFlavorRenderer` → `null` → layout generico invariato |
+| `status !== 'Completed'` (incl. `Abandoned`) | flavor **non montato** (no winner-hero su partite non concluse) |
+| `scoreData`/`scoringType`/`scorePlayers` null (nessuna live correlata) | adapter → `[]` → empty state gentile del flavor |
 | `scoreData` malformed JSON | `try/catch` + `console.warn` → trattato come null |
-| `player.color` null | `PlayerDot` con colore neutro di fallback |
-| catalogo non risolve il gioco | `gameName`/`gameSlug` null dal BE → come "gameSlug null" |
+| standings presenti ma nessun `isWinner` e `winnerName` null | standings senza hero-winner (nessun auto-crown) |
+| `player.color` null | `PlayerDot` colore neutro (`CATAN_NEUTRAL_HSL`) |
 
-## 7. i18n
+## 5. i18n
 
-Nuovo sottoalbero (naming da confermare nel piano, es. `features.sessionLive.catanSummary.*`) in `it.json` **e** `en.json`, coprendo hero/standings/KPI/empty. **Guard di parità** dedicato (stesso pattern di `i18n-gamedetail-keys.test.ts`, #3103).
+Sottoalbero `pages.sessionSummary.flavor.catan.{winnerTemplate,vpUnit,durationTemplate,standingsTitle,empty}` in `it.json` **e** `en.json`, con **guard di parità**. Template con placeholder usano l'interpolazione ICU nativa di `t(key, { name })` (non `.replace` manuale).
 
-## 8. Testing (TDD, RED-first)
+## 6. Testing (TDD, RED-first)
 
-- **FE unit `CatanSummaryFlavor`**: `scoreData` Points reale → hero mostra il vincitore, standings ordinate con colori; `scoreData` null → empty; JSON malformato → empty + `console.warn`.
-- **FE unit `SummaryFlavorRenderer`**: dispatch `catan` → componente montato; slug sconosciuto/null → `null`.
-- **FE `SessionSummaryView` wiring**: `gameSlug='catan'` → flavor montato; altro slug → non montato; nessuna regressione sul test esistente.
-- **BE unit `GetGameSessionByIdQueryHandler`**: popola `GameSlug`/`GameName` dal catalogo; gioco assente → null. Verifica che `GameSessionMapper.ToDto` (altri path) lasci null.
-- **Guard i18n**: nuove chiavi presenti e a parità IT/EN.
+- **BE unit `GetScoreboardAsync`** (provider): test integration (Testcontainers/InMemory) — seed `LiveGameSession`(CorrelatedGameSessionId)+`SessionTrackingSession`(scoreData)+`SessionPlayers` → asserisce `SessionScoreboard` con score + players allineati (id == scoreData playerId). Real pipeline, non fixture DTO.
+- **BE unit handler** (mock provider + core-data): popola scoringType/scoreData/scorePlayers/gameSlug/gameName; scoreboard null → campi null; gioco assente → slug/name null. Aggiornare i 6 test esistenti al nuovo ctor. + test `GameSessionMapper.ToDto` lascia i nuovi campi null (guard altri path).
+- **FE `buildCatanSummaryStandings`**: Points reale (join per id) → standings ordinate + color; scorePlayers vuoto → `[]`; scoreData null → `[]`; JSON malformato → `[]` + warn; tie a punteggio max → ordine deterministico; scoringType sconosciuto → `[]`.
+- **FE `CatanSummaryFlavor`**: hero da winnerName; nessun isWinner + winnerName null → nessun auto-crown; empty su standings vuote; color null → dot neutro.
+- **FE `SummaryFlavorRenderer`**: dispatch catan→component, unknown/null→null.
+- **FE wiring `SessionSummaryView`**: `gameSlug='catan'` + `status='Completed'` → montato; non-Catan → non montato; `status!='Completed'` → non montato; nessuna regressione. Harness IntlProvider con `onError={() => {}}` (precedente `FlavorRenderer.test.tsx:21`).
 
-## 9. Fuori scope MVP (deferred — richiedono `gameState` end-game persistito)
+## 7. Fuori scope MVP (deferred)
 
-Board snapshot (`HexBoard` finale), `DiceChart` (istogramma 2D6 storico), `TradeBars`, contatore mosse del ladro, "serie di produzione più lunga", "mano più grande", breakdown per le 5 categorie di scoring, badge `LongestRoad`/`LargestArmy` nelle standings. Nessuno di questi è alimentabile dal summary DTO attuale.
+Board snapshot, `DiceChart`, `TradeBars`, robber-move counter, longest-production-run, biggest-hand, breakdown 5-categorie, badge longest-road/largest-army. Tutti richiedono `gameState` end-game persistito, assente sul summary path.
 
-## 10. File toccati (checklist)
+## 8. File toccati (checklist)
 
 **Backend**
-- `GameSessionDto.cs` — +`GameSlug?`, +`GameName?`
-- `GetGameSessionByIdQueryHandler.cs` — DI catalogo + risoluzione slug/name
-- (test) `GetGameSessionByIdQueryHandler` test
+- `IHistorySessionScoreProvider.cs` — +`GetScoreboardAsync`, +`SessionScoreboard`, +`ScorePlayerReadModel`
+- `HistorySessionScoreProvider.cs` — impl `GetScoreboardAsync`
+- `GameSessionDto.cs` — +`GameSlug?`, +`GameName?`, +`ScorePlayers?`, +`record ScorePlayerDto`
+- `GetGameSessionByIdQueryHandler.cs` — +2 dipendenze, popolamento
+- (test) provider integration + handler unit + mapper guard
 
 **Frontend**
-- `components/features/session-live/SummaryFlavorRenderer.tsx` (nuovo: renderer + `SummaryFlavorProps` + `SUMMARY_FLAVOR_MAP` + `hasSummaryFlavor`)
-- `components/features/session-live/flavors/catan/CatanSummaryFlavor.tsx` (nuovo, + eventuali sub-componenti hero/standings)
-- `lib/api/**/games.schemas.ts` — Zod `gameSlug`/`gameName`
-- `app/(authenticated)/sessions/[id]/_components/SessionSummaryView.tsx` — wire condizionale
+- `lib/api/schemas/games.schemas.ts` — Zod `gameSlug`/`gameName`/`scorePlayers`
+- `components/features/session-live/SummaryFlavorRenderer.tsx` (nuovo)
+- `components/features/session-live/flavors/catan/catan-summary-standings.ts` (nuovo)
+- `components/features/session-live/flavors/catan/CatanSummaryFlavor.tsx` (nuovo)
+- `app/(authenticated)/sessions/[id]/_components/SessionSummaryView.tsx` — wire (status-gated)
 - `locales/it.json`, `locales/en.json` + guard i18n
-- test FE (flavor, renderer, wiring, guard)
+- test FE (builder, flavor, renderer, wiring, guard)


### PR DESCRIPTION
## Cosa

Vista SUMMARY per Catan su `/sessions/[id]` (deferred da #2787): **hero vincitore + final standings con punteggi VP reali per-player + colori**, montata via un dispatcher summary gemello (`SummaryFlavorRenderer`), status-gated (solo sessioni `Completed`).

## Perché il backend (scoperta della plan-review)

Una review avversariale del piano ha trovato 2 difetti critici che avrebbero reso la feature "verde in test / morta in prod":
1. `GET /api/v1/sessions/{id}` **non popolava** `scoreData`/`scoringType` (solo il path *history* lo faceva).
2. I `playerId` in `scoreData` sono `SessionPlayerEntity.Id` (aggregato **LiveGameSession**), **non** i player del summary DTO → join VP↔giocatore senza chiave comune.

Decisione (utente): **VP reali** via BE bridge, non un MVP degradato.

## Approccio

**Backend**
- `IHistorySessionScoreProvider.GetScoreboardAsync(gameSessionId)` — nuovo read-model: bridge `GameSession ← LiveGameSession.CorrelatedGameSessionId` → `SessionTracking.Session` (score) + `LiveGameSession.SessionPlayers` (id/displayName/color **allineati** a `scoreData.playerId`). `GetScoresAsync` (history) invariato.
- `GameSessionDto` arricchito su **solo** il GET singola sessione con `GameSlug`/`GameName` (via `IGameCoreDataProvider` + `Slugifier`) + `ScoreData`/`ScoringType` + `ScorePlayers`. Gli altri endpoint (`GameSessionMapper.ToDto`) restano `null`.

**Frontend**
- `buildCatanSummaryStandings` — adapter puro: join `scoreData.playerId ↔ scorePlayers[].id` (riusa `mapScoreDataToEndgameSummary`), zip colore per indice, ordine winner-first.
- `CatanSummaryFlavor` — hero con precedenza a `winnerName` (BE-autoritativo), **nessun auto-crowning** se nessuno ha vinto; standings con colori; ICU nativo.
- `SummaryFlavorRenderer` — dispatcher gemello isolato (props su `GameSessionDto`, disgiunto dal `FlavorRenderer` live).
- Wire in `SessionSummaryView`, gated su `status === 'Completed'`.

## Test

- **BE**: `GetScoreboardAsync` integration (InMemory, seed bridge reale) + handler unit (slug/name/scoreboard + mapper-guard-null). Suite **GameManagement 1645/1645 verde**.
- **FE**: builder (join per id, edge case null/empty/malformed), flavor (hero/no-auto-crown/empty), dispatcher, i18n parity guard, wiring gate (positivo + 2 negativi). **48 test feature verdi**, `typecheck` pulito, `lint` 0 errori.
- Nota: il rendering *lazy* (`next/dynamic`) è coperto dai unit di `CatanSummaryFlavor`/`SummaryFlavorRenderer`; nel test di `SessionSummaryView` il renderer è mockato per esercitare il **gate** (status/slug) senza la race del dynamic-import.

## Fuori scope (documentato)

Board snapshot, DiceChart, TradeBars, robber-move counter, breakdown 5-categorie, badge longest-road/largest-army — richiedono `gameState` end-game persistito, assente sul summary path.

Spec: `docs/superpowers/specs/2026-07-17-issue-3022-catan-summary-flavor-design.md` · Plan: `docs/superpowers/plans/2026-07-17-issue-3022-catan-summary-flavor.md`

Closes #3022

🤖 Generated with [Claude Code](https://claude.com/claude-code)