### PR TITLE
fix(i18n): add missing en.json sections for KB/PDF/notifications (#3130)

### DIFF
--- a/apps/web/src/locales/__tests__/index.test.ts
+++ b/apps/web/src/locales/__tests__/index.test.ts
@@ -2,7 +2,7 @@
  * Tests for i18n locales configuration and fallback logic
  */
 
-import { getMessages, messages, LOCALES, DEFAULT_LOCALE } from '../index';
+import { getMessages, messages, flattenMessages, LOCALES, DEFAULT_LOCALE } from '../index';
 
 describe('i18n locales', () => {
   it('should return Italian messages for Italian locale', () => {
@@ -38,4 +38,27 @@ describe('i18n locales', () => {
 
     expect(invalidMessages).toBe(defaultMessages);
   });
+
+  // Issue #3130: guard against it/en drift for the sections that were missing
+  // from en.json (KbStatusBadge / PdfProcessingStatus / NotificationCenter use
+  // a non-scoped `t`, so a missing en section leaves EN users without translations).
+  it.each(['pdfIndexing', 'kbStatus', 'notificationCenter'])(
+    'should have matching "%s" keys in the it and en catalogs',
+    section => {
+      const itCatalog = getMessages(LOCALES.IT) as Record<string, unknown>;
+      const enCatalog = getMessages(LOCALES.EN) as Record<string, unknown>;
+
+      expect(itCatalog[section], `it.json is missing "${section}"`).toBeDefined();
+      expect(enCatalog[section], `en.json is missing "${section}"`).toBeDefined();
+
+      const itKeys = Object.keys(
+        flattenMessages(itCatalog[section] as Record<string, unknown>)
+      ).sort();
+      const enKeys = Object.keys(
+        flattenMessages(enCatalog[section] as Record<string, unknown>)
+      ).sort();
+
+      expect(enKeys).toEqual(itKeys);
+    }
+  );
 });

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -698,6 +698,47 @@
     },
     "title": "PDF Import Wizard"
   },
+  "pdfIndexing": {
+    "pending": "Awaiting processing",
+    "processing": "Processing...",
+    "indexed": "Knowledge Base ready!",
+    "failed": "Indexing failed",
+    "progress": "{progress}%",
+    "chunksCount": "{count} chunks indexed",
+    "backgroundNote": "You can keep going — indexing will finish in the background.",
+    "continueToAgent": "Continue: configure agent",
+    "stageCompleted": "completed",
+    "stageActive": "in progress...",
+    "stageFailed": "error",
+    "stagePending": "pending",
+    "steps": {
+      "uploading": "Uploading file",
+      "extracting": "Extracting text",
+      "chunking": "Semantic chunking",
+      "indexing": "Vector indexing"
+    }
+  },
+  "kbStatus": {
+    "pending": "Pending",
+    "processing": "Processing",
+    "indexed": "Knowledge Base ready",
+    "failed": "Indexing failed",
+    "createAgent": "Create agent",
+    "retry": "Retry"
+  },
+  "notificationCenter": {
+    "title": "Notifications",
+    "newSection": "NEW",
+    "previousSection": "EARLIER",
+    "markAllRead": "Mark all as read",
+    "empty": "No notifications",
+    "emptySubtext": "Your notifications will appear here",
+    "viewAll": "View all",
+    "loading": "Loading notifications...",
+    "kbReady": {
+      "cta": "→ Create your agent"
+    }
+  },
   "legal": {
     "tableOfContents": "Table of Contents",
     "lastUpdated": "Last updated: {date}",


### PR DESCRIPTION
## Summary
`pdfIndexing` (13 keys), `kbStatus` (6) and `notificationCenter` (9) existed in `it.json` but were **entirely absent** from `en.json`. `KbStatusBadge`, `PdfProcessingStatus` and `NotificationCenter` call a **non-scoped** `t('kbStatus.processing')` etc., so an EN-locale user got no English translation for those surfaces (drift it↔en).

## Changes
- Add the 3 sections to `en.json` (translated, same key structure as `it.json`, inserted after `wizard` to mirror it.json order — **surgical 41-line additive diff**).
- Parity test (`it.each`) guarding these 3 sections against future it/en drift.

## Validation
- Parity test 8/8 green; `pnpm typecheck` clean.
- Key structure verified 1:1 against `it.json` at generation time.

> Replaces #3118 (closed as a false positive — that component uses a scoped translator, so there was no bug).

Closes #3130

🤖 Generated with [Claude Code](https://claude.com/claude-code)