### PR TITLE
fix(admin/rag): #3122 sample-weight aggregate metrics instead of mean-of-means

### DIFF
--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Queries/GetAgentStatsQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Queries/GetAgentStatsQueryHandler.cs
@@ -85,13 +85,17 @@ internal sealed class GetAgentStatsQueryHandler : IQueryHandler<GetAgentStatsQue
                     .OrderByDescending(a => a.ExecutionCount)
                     .ToList();
 
+                var totalExecutions = agents.Sum(a => a.ExecutionCount);
                 var totals = new AgentAggregateStats
                 {
                     TotalAgents = AgentMetadataMap.Count,
                     ActiveAgents = agents.Count(a => a.IsActive),
-                    TotalExecutions = agents.Sum(a => a.ExecutionCount),
+                    TotalExecutions = totalExecutions,
                     TotalTokens = agents.Sum(a => a.TotalTokens),
-                    AverageLatency = agents.Count > 0 ? agents.Average(a => a.AverageLatencyMs) : 0
+                    // #3122: sample-weighted mean; a mean-of-means over-weights low-volume agents.
+                    AverageLatency = totalExecutions > 0
+                        ? agents.Sum(a => a.AverageLatencyMs * a.ExecutionCount) / totalExecutions
+                        : 0
                 };
 
                 return new AgentStatsResult { Agents = agents, Totals = totals };

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/RagDashboardQueryHandlers.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/RagDashboardQueryHandlers.cs
@@ -231,26 +231,34 @@ internal sealed class GetRagDashboardOverviewQueryHandler : IQueryHandler<GetRag
 
         var strategyMetrics = rawMetrics.Select(RagDashboardMapping.MapToStrategyMetricsDto).ToList();
 
-        // Calculate aggregated metrics across all strategies
+        // Calculate aggregated metrics across all strategies.
+        // #3122: pool by sample count instead of a mean-of-means. Averaging per-strategy
+        // averages/rates over-weights low-volume strategies, so weight the per-strategy
+        // means by TotalQueries and derive rates from summed count components.
         var totalQueries = strategyMetrics.Sum(m => m.TotalQueries);
+        var totalCacheHits = strategyMetrics.Sum(m => m.CacheHits);
+        var totalCacheMisses = strategyMetrics.Sum(m => m.CacheMisses);
+        var totalCacheLookups = totalCacheHits + totalCacheMisses;
+        var totalErrorCount = strategyMetrics.Sum(m => m.ErrorCount);
+        var totalCost = strategyMetrics.Sum(m => m.TotalCost);
         var aggregated = new StrategyMetricsDto
         {
             StrategyId = "all",
             StrategyName = "All Strategies",
             TotalQueries = totalQueries,
-            AverageLatencyMs = strategyMetrics.Count > 0 ? strategyMetrics.Average(m => m.AverageLatencyMs) : 0,
+            AverageLatencyMs = totalQueries > 0 ? strategyMetrics.Sum(m => m.AverageLatencyMs * m.TotalQueries) / totalQueries : 0,
             P95LatencyMs = strategyMetrics.Count > 0 ? strategyMetrics.Max(m => m.P95LatencyMs) : 0,
             P99LatencyMs = strategyMetrics.Count > 0 ? strategyMetrics.Max(m => m.P99LatencyMs) : 0,
-            AverageRelevanceScore = strategyMetrics.Count > 0 ? strategyMetrics.Average(m => m.AverageRelevanceScore) : 0,
-            AverageConfidenceScore = strategyMetrics.Count > 0 ? strategyMetrics.Average(m => m.AverageConfidenceScore) : 0,
-            CacheHits = strategyMetrics.Sum(m => m.CacheHits),
-            CacheMisses = strategyMetrics.Sum(m => m.CacheMisses),
-            CacheHitRate = strategyMetrics.Count > 0 ? strategyMetrics.Average(m => m.CacheHitRate) : 0,
+            AverageRelevanceScore = totalQueries > 0 ? strategyMetrics.Sum(m => m.AverageRelevanceScore * m.TotalQueries) / totalQueries : 0,
+            AverageConfidenceScore = totalQueries > 0 ? strategyMetrics.Sum(m => m.AverageConfidenceScore * m.TotalQueries) / totalQueries : 0,
+            CacheHits = totalCacheHits,
+            CacheMisses = totalCacheMisses,
+            CacheHitRate = totalCacheLookups > 0 ? (double)totalCacheHits / totalCacheLookups : 0,
             TotalTokensUsed = strategyMetrics.Sum(m => m.TotalTokensUsed),
-            TotalCost = strategyMetrics.Sum(m => m.TotalCost),
-            AverageCostPerQuery = strategyMetrics.Count > 0 ? strategyMetrics.Average(m => m.AverageCostPerQuery) : 0,
-            ErrorCount = strategyMetrics.Sum(m => m.ErrorCount),
-            ErrorRate = strategyMetrics.Count > 0 ? strategyMetrics.Average(m => m.ErrorRate) : 0,
+            TotalCost = totalCost,
+            AverageCostPerQuery = totalQueries > 0 ? (double)(totalCost / totalQueries) : 0,
+            ErrorCount = totalErrorCount,
+            ErrorRate = totalQueries > 0 ? (double)totalErrorCount / totalQueries : 0,
             LastUpdated = DateTimeOffset.UtcNow
         };
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/Administration/Handlers/GetAgentStatsQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Administration/Handlers/GetAgentStatsQueryHandlerTests.cs
@@ -1,0 +1,93 @@
+using Api.BoundedContexts.Administration.Application.Queries;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Tests.Constants;
+using Api.Tests.Services;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Time.Testing;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.Administration.Handlers;
+
+/// <summary>
+/// Unit tests for GetAgentStatsQueryHandler.
+/// #3122: the aggregate AverageLatency must be sample-weighted, not a mean-of-means
+/// (which over-weights low-volume agents).
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+public class GetAgentStatsQueryHandlerTests : IDisposable
+{
+    private static readonly DateTimeOffset FixedNow = new(2026, 6, 15, 12, 0, 0, TimeSpan.Zero);
+
+    private readonly MeepleAiDbContext _dbContext;
+    private readonly FakeHybridCache _cache;
+    private readonly FakeTimeProvider _timeProvider;
+    private readonly GetAgentStatsQueryHandler _handler;
+
+    public GetAgentStatsQueryHandlerTests()
+    {
+        _dbContext = TestDbContextFactory.CreateInMemoryDbContext();
+        _cache = new FakeHybridCache();
+        _timeProvider = new FakeTimeProvider(FixedNow);
+        _handler = new GetAgentStatsQueryHandler(
+            _dbContext,
+            _cache,
+            Mock.Of<ILogger<GetAgentStatsQueryHandler>>(),
+            _timeProvider);
+    }
+
+    public void Dispose()
+    {
+        _dbContext?.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public async Task Handle_AggregatesLatency_SampleWeighted_NotMeanOfMeans()
+    {
+        // qa-agent: 10 executions @ 100ms; rules-agent: 1 execution @ 1000ms.
+        // Per-agent means are 100 and 1000 → mean-of-means = 550.
+        // Sample-weighted mean: (100*10 + 1000*1) / 11 = 2000/11 ≈ 181.8.
+        SeedAgentLogs("qa-agent", count: 10, latencyMs: 100);
+        SeedAgentLogs("rules-agent", count: 1, latencyMs: 1000);
+        await _dbContext.SaveChangesAsync();
+
+        var result = await _handler.Handle(new GetAgentStatsQuery(), CancellationToken.None);
+
+        result.Totals.TotalExecutions.Should().Be(11);
+        result.Totals.AverageLatency.Should().BeApproximately(2000.0 / 11.0, 0.01);
+        result.Totals.AverageLatency.Should().BeLessThan(300); // must NOT be the 550 mean-of-means
+    }
+
+    [Fact]
+    public async Task Handle_NoLogs_ReturnsZeroAverageLatency()
+    {
+        var result = await _handler.Handle(new GetAgentStatsQuery(), CancellationToken.None);
+
+        result.Totals.TotalExecutions.Should().Be(0);
+        result.Totals.AverageLatency.Should().Be(0);
+    }
+
+    private void SeedAgentLogs(string agent, int count, int latencyMs)
+    {
+        // Within the default 30-day window and the 7-day "active" window.
+        var createdAt = FixedNow.UtcDateTime.AddDays(-1);
+        for (var i = 0; i < count; i++)
+        {
+            _dbContext.AiRequestLogs.Add(new AiRequestLogEntity
+            {
+                Id = Guid.NewGuid(),
+                Endpoint = $"/agents/{agent}",
+                LatencyMs = latencyMs,
+                Status = "Success",
+                CreatedAt = createdAt,
+                TokenCount = 100,
+                PromptTokens = 80,
+                CompletionTokens = 20,
+            });
+        }
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/RagDashboard/GetRagDashboardOverviewQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/RagDashboard/GetRagDashboardOverviewQueryHandlerTests.cs
@@ -210,4 +210,68 @@ public sealed class GetRagDashboardOverviewQueryHandlerTests
             It.IsAny<string?>(),
             It.IsAny<CancellationToken>()), Times.Once);
     }
+
+    // #3122: aggregate metrics must pool by sample count, not average the per-strategy
+    // averages/rates (mean-of-means over-weights low-volume strategies).
+
+    [Fact]
+    public async Task Handle_AggregatesLatency_SampleWeighted_NotMeanOfMeans()
+    {
+        // High-volume low-latency + low-volume high-latency strategy.
+        // Mean-of-means = (100 + 1000) / 2 = 550; sample-weighted ≈ 108.9.
+        SetupRepo(new List<StrategyAggregateMetrics>
+        {
+            CreateMetrics("HighVolume", queries: 1000, avgLatencyMs: 100.0),
+            CreateMetrics("LowVolume", queries: 10, avgLatencyMs: 1000.0)
+        });
+
+        var result = await _handler.Handle(new GetRagDashboardOverviewQuery(), TestContext.Current.CancellationToken);
+
+        // (100*1000 + 1000*10) / 1010 = 110000/1010 ≈ 108.91
+        result.AggregatedMetrics.AverageLatencyMs.Should().BeApproximately(110000.0 / 1010.0, 0.1);
+        result.AggregatedMetrics.AverageLatencyMs.Should().BeLessThan(200); // not the 550 mean-of-means
+    }
+
+    [Fact]
+    public async Task Handle_AggregatesCacheHitRate_PooledFromCounts_NotMeanOfRates()
+    {
+        // A: 1000 hits / 0 misses (rate 1.0); B: 0 hits / 10 misses (rate 0.0).
+        // Mean-of-rates = 0.5; pooled = 1000/1010 ≈ 0.990.
+        SetupRepo(new List<StrategyAggregateMetrics>
+        {
+            CreateMetrics("HighVolume", cacheHits: 1000, cacheMisses: 0),
+            CreateMetrics("LowVolume", cacheHits: 0, cacheMisses: 10)
+        });
+
+        var result = await _handler.Handle(new GetRagDashboardOverviewQuery(), TestContext.Current.CancellationToken);
+
+        result.AggregatedMetrics.CacheHitRate.Should().BeApproximately(1000.0 / 1010.0, 0.0001);
+        result.AggregatedMetrics.CacheHitRate.Should().BeGreaterThan(0.9); // not the 0.5 mean-of-rates
+    }
+
+    [Fact]
+    public async Task Handle_AggregatesCostPerQuery_PooledFromTotals_NotMeanOfMeans()
+    {
+        // A: 1000 queries @ 0.01; B: 10 queries @ 1.00.
+        // Mean-of-means = 0.505; pooled = (0.01*1000 + 1.00*10) / 1010 = 20/1010 ≈ 0.0198.
+        SetupRepo(new List<StrategyAggregateMetrics>
+        {
+            CreateMetrics("HighVolume", queries: 1000, costPerQuery: 0.01m),
+            CreateMetrics("LowVolume", queries: 10, costPerQuery: 1.00m)
+        });
+
+        var result = await _handler.Handle(new GetRagDashboardOverviewQuery(), TestContext.Current.CancellationToken);
+
+        result.AggregatedMetrics.AverageCostPerQuery.Should().BeApproximately(20.0 / 1010.0, 0.0001);
+        result.AggregatedMetrics.AverageCostPerQuery.Should().BeLessThan(0.1); // not the 0.505 mean-of-means
+    }
+
+    private void SetupRepo(List<StrategyAggregateMetrics> metrics) =>
+        _mockRepo
+            .Setup(r => r.GetAggregatedMetricsAsync(
+                It.IsAny<DateOnly?>(),
+                It.IsAny<DateOnly?>(),
+                It.IsAny<string?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(metrics);
 }


### PR DESCRIPTION
## Problem
Aggregate agent/RAG metrics averaged the per-group averages (mean-of-means), which over-weights low-volume groups vs high-volume ones.

## Fix (in-handler; no query/repository change — the counts are already on the DTO layer)
- **`GetAgentStatsQueryHandler`**: `AverageLatency` weighted by per-agent `ExecutionCount`.
- **`RagDashboardQueryHandlers`**: latency / relevance / confidence weighted by per-strategy `TotalQueries`; `CacheHitRate`, `AverageCostPerQuery`, `ErrorRate` derived **exactly** from summed count components (`hits/(hits+misses)`, `totalCost/totalQueries`, `errorCount/totalQueries`).

## Test
- New `GetAgentStatsQueryHandlerTests` (InMemory): unbalanced-volume agents → weighted latency.
- 3 new `GetRagDashboardOverviewQueryHandlerTests`: weighted latency, pooled cache-hit-rate, pooled cost/query.
- RED watched first (all showed the mean-of-means values: 550 / 0.5 / 0.505). GREEN: 11/11.

Closes #3122

🤖 Generated with [Claude Code](https://claude.com/claude-code)