### PR TITLE
fix(admin): #3123 ContentMetrics ActiveGames counts AI-ready games, not all

### DIFF
--- a/apps/api/src/Api/BoundedContexts/Administration/Infrastructure/Services/ReportGeneratorService.ContentMetrics.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Infrastructure/Services/ReportGeneratorService.ContentMetrics.cs
@@ -73,7 +73,9 @@ internal sealed partial class ReportGeneratorService
                 ["totalPdfs"] = totalPdfs,
                 ["totalVectorDocs"] = totalVectorDocs,
                 ["totalDocuments"] = totalPdfs, // Total documents (PDFs)
-                ["vectorEmbeddings"] = totalVectorDocs // Vector embeddings count
+                ["vectorEmbeddings"] = totalVectorDocs, // Vector embeddings count
+                ["totalGames"] = gameMetrics?.TotalGames ?? 0,
+                ["activeGames"] = gameMetrics?.ActiveGames ?? 0 // #3123: AI-ready games (HasKnowledgeBase)
             },
             Sections: sections);
     }
@@ -126,7 +128,8 @@ internal sealed partial class ReportGeneratorService
             .GroupBy(g => 1)
             .Select(g => new GameMetric(
                 g.Count(),
-                g.Count(game => true) // Simplified, can add active criteria
+                // #3123: "active" = AI-ready (has an indexed knowledge base), not every game.
+                g.Count(game => game.HasKnowledgeBase)
             ))
             .FirstOrDefaultAsync(ct)
             .ConfigureAwait(false);
@@ -184,6 +187,10 @@ internal sealed partial class ReportGeneratorService
                     new(new Dictionary<string, object>(StringComparer.Ordinal) {
                         ["Metric"] = "Total Games",
                         ["Value"] = gameMetrics?.TotalGames ?? 0
+                    }),
+                    new(new Dictionary<string, object>(StringComparer.Ordinal) {
+                        ["Metric"] = "Active Games",
+                        ["Value"] = gameMetrics?.ActiveGames ?? 0
                     })
                 })
         };

--- a/apps/api/tests/Api.Tests/BoundedContexts/Administration/Services/ReportGeneratorServiceTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Administration/Services/ReportGeneratorServiceTests.cs
@@ -4,6 +4,7 @@ using Api.BoundedContexts.Administration.Domain.ValueObjects;
 using Api.BoundedContexts.Administration.Infrastructure.Services;
 using Api.Infrastructure;
 using Api.Infrastructure.Entities;
+using Api.Infrastructure.Entities.SharedGameCatalog;
 using Api.SharedKernel.Application.Services;
 using Api.SharedKernel.Domain.Events;
 using Api.Tests.TestHelpers;
@@ -223,6 +224,79 @@ public sealed class ReportGeneratorServiceTests : IDisposable
         var content = System.Text.Encoding.UTF8.GetString(result.Content);
         content.Should().ContainEquivalentOf("\"totalDocuments\"");
         content.Should().ContainEquivalentOf("\"vectorEmbeddings\"");
+    }
+
+    [Fact]
+    public async Task GenerateAsync_ContentMetricsReport_ActiveGamesCountsOnlyAiReadyGames()
+    {
+        // #3123: "active" = AI-ready (HasKnowledgeBase). 3 AI-ready + 2 plain → Active=3, Total=5.
+        SeedSharedGame("AI-ready A", hasKnowledgeBase: true);
+        SeedSharedGame("AI-ready B", hasKnowledgeBase: true);
+        SeedSharedGame("AI-ready C", hasKnowledgeBase: true);
+        SeedSharedGame("Plain D", hasKnowledgeBase: false);
+        SeedSharedGame("Plain E", hasKnowledgeBase: false);
+        await _dbContext.SaveChangesAsync();
+
+        var parameters = new Dictionary<string, object>
+        {
+            ["startDate"] = DateTime.UtcNow.AddDays(-30),
+            ["endDate"] = DateTime.UtcNow
+        };
+
+        var result = await _sut.GenerateAsync(
+            ReportTemplate.ContentMetrics,
+            ReportFormat.Json,
+            parameters,
+            CancellationToken.None);
+
+        var content = System.Text.Encoding.UTF8.GetString(result.Content);
+        using var doc = System.Text.Json.JsonDocument.Parse(content);
+        var totalGames = FindNumber(doc.RootElement, "totalGames");
+        var activeGames = FindNumber(doc.RootElement, "activeGames");
+
+        totalGames.Should().Be(5);
+        activeGames.Should().Be(3);              // only AI-ready games, not all 5
+        activeGames.Should().NotBe(totalGames);  // regression guard: Active must not equal Total
+    }
+
+    private void SeedSharedGame(string title, bool hasKnowledgeBase)
+    {
+        _dbContext.SharedGames.Add(new SharedGameEntity
+        {
+            Id = Guid.NewGuid(),
+            Title = title,
+            HasKnowledgeBase = hasKnowledgeBase,
+            CreatedAt = DateTime.UtcNow
+        });
+    }
+
+    private static int? FindNumber(System.Text.Json.JsonElement element, string propertyName)
+    {
+        switch (element.ValueKind)
+        {
+            case System.Text.Json.JsonValueKind.Object:
+                foreach (var prop in element.EnumerateObject())
+                {
+                    if (string.Equals(prop.Name, propertyName, StringComparison.OrdinalIgnoreCase)
+                        && prop.Value.ValueKind == System.Text.Json.JsonValueKind.Number)
+                    {
+                        return prop.Value.GetInt32();
+                    }
+
+                    var nested = FindNumber(prop.Value, propertyName);
+                    if (nested.HasValue) return nested;
+                }
+                break;
+            case System.Text.Json.JsonValueKind.Array:
+                foreach (var item in element.EnumerateArray())
+                {
+                    var nested = FindNumber(item, propertyName);
+                    if (nested.HasValue) return nested;
+                }
+                break;
+        }
+
+        return null;
     }
 
     [Fact]


### PR DESCRIPTION
## Problem
`ContentMetrics.ActiveGames` was `g.Count(game => true)` → always equal to `TotalGames`, making the metric meaningless (and it was computed but never rendered).

## Fix
- **Definition (product decision)**: "active" = **AI-ready** games (`HasKnowledgeBase` — an indexed knowledge base usable by the RAG assistant). `SharedGameEntity` has no play/last-played data (that lives in other bounded contexts), so a play-based definition would need a cross-context query.
- Count only `HasKnowledgeBase` games.
- Surface the metric so it is observable: `totalGames`/`activeGames` added to report metadata + an "Active Games" row in the Game Catalog Summary section.

## Test
Seed 3 AI-ready + 2 plain games → Active=3, Total=5 (RED watched: `activeGames` found 5). 81/81 green in `ReportGeneratorServiceTests`.

Closes #3123

🤖 Generated with [Claude Code](https://claude.com/claude-code)