### PR TITLE
fix(scripts): #2988 resilient build-claude-design-bundle after Storybook migration

### DIFF
--- a/scripts/build-claude-design-bundle.sh
+++ b/scripts/build-claude-design-bundle.sh
@@ -12,7 +12,11 @@
 # Usage:  scripts/build-claude-design-bundle.sh [sp6|sp7|sp8|sp9|all]   (default: all)
 #
 # Tracking issues: SP6 → #1888 (libro-game) · SP7 → #1889 (game-night agent-builder)
-#                  SP8 → #1890 (mobile parity + libro-game companion)
+#                  SP8 → #1890 (mobile parity + libro-game companion) · SP9 → #2989 (mobile gamenight)
+#
+# NOTE (#2988): the DS-17-16 cleanup migrated most SP6/SP7/SP8 page-mocks to Storybook and
+# deleted them from design_files/. Those bundles now build partially — missing mockups are
+# skipped with a warning (see build_bundle) rather than aborting. SP9 is unaffected.
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
@@ -98,6 +102,11 @@ copy_sp9_briefs() {
   echo "[built] +2 briefs → $dest/"
 }
 
+# git ref holding the pre-#2988 mockups (parent of the DS-17-16 cleanup commit that
+# migrated many page-mocks to Storybook and deleted them from design_files/). Referenced
+# only in the skip hint below so a maintainer can recover an individual mockup on demand.
+MIGRATION_RECOVER_REF="90f731b4f^"
+
 build_bundle() {
   local name="$1"; shift
   local dest="claude-design-bundle/$name"
@@ -106,15 +115,29 @@ build_bundle() {
   for f in "${SCAFFOLD[@]}"; do
     cp "$SRC/$f" "$dest/$f"
   done
+  # Copy the requested mockups. Post-#2988 (DS-17-16 Storybook migration) many SP6/SP7/SP8
+  # page-mocks no longer live in design_files/. A missing mockup is skipped with a warning
+  # instead of aborting the build (set -e would otherwise kill it), so a bundle degrades
+  # gracefully to whatever still exists. SCAFFOLD stays strict — it is structural.
+  local total=$# copied=0 missing=()
   for f in "$@"; do
-    cp "$SRC/$f" "$dest/mockups/$f"
+    if [ -f "$SRC/$f" ]; then
+      cp "$SRC/$f" "$dest/mockups/$f"
+      copied=$((copied + 1))
+    else
+      missing+=("$f")
+    fi
   done
   # Mockups reference shared assets as siblings (href="tokens.css"), so mirror them into
   # mockups/ too — otherwise the relative refs break in the structured bundle (#1890 demo finding).
   for f in tokens.css components.css data.js; do
     cp "$SRC/$f" "$dest/mockups/$f"
   done
-  echo "[built] $dest — scaffold ${#SCAFFOLD[@]} + mockups $# (+3 mirrored assets in mockups/)"
+  echo "[built] $dest — scaffold ${#SCAFFOLD[@]} + mockups $copied/$total (+3 mirrored assets in mockups/)"
+  if [ "${#missing[@]}" -gt 0 ]; then
+    echo "  ⚠ ${#missing[@]} skipped (migrated to Storybook, #2988): ${missing[*]}"
+    echo "     recover: git show $MIGRATION_RECOVER_REF:$SRC/<file>"
+  fi
   for f in 00-system-prompt.md 01-manifest.md README.md; do
     [ -f "$dest/$f" ] || echo "  ⚠ companion missing: $dest/$f (restore from git / claude-design-demo-prompts.md)"
   done


### PR DESCRIPTION
## Cosa

Risolve il debito emerso dal cleanup **#2988** (già merged), tracciato in #2989: lo script `scripts/build-claude-design-bundle.sh` crashava (`cp: cannot stat`) sui target `sp6`/`sp7`/`sp8`/`all`.

## Root cause

Il cleanup **DS-17-16 (#2988, `90f731b4f`)** ha migrato la maggior parte dei page-mock SP6/SP7/SP8 a Storybook e li ha **eliminati** da `admin-mockups/design_files/`. `build_bundle` copiava i mockup con un `cp` stretto sotto `set -e` → abortiva sul primo file mancante. Verificato: nessuna rinomina, i file sono genuinamente rimossi (recuperabili solo da git history).

## Fix (Approach B — skip-and-warn resiliente)

Il loop di copia dei mockup ora **salta con warning** i file mancanti invece di abortire:
- summary per-target `mockups <copiati>/<totali>`
- lista dei file skippati + hint di recovery (`git show 90f731b4f^:admin-mockups/design_files/<file>`)
- `SCAFFOLD` resta **stretto** (è strutturale)
- header del file documenta la realtà post-#2988

## Verifica (before → after)

| Target | Prima | Dopo |
|---|---|---|
| `sp6` | 💥 crash | ✅ exit 0 · mockups 5/17 · 12 skipped |
| `sp7` | 💥 crash | ✅ exit 0 · mockups 3/15 · 12 skipped |
| `sp8` | 💥 crash | ✅ exit 0 · mockups 2/9 · 7 skipped + briefs |
| `sp9` | ✅ | ✅ exit 0 · mockups 4/4 (intatto) |
| `all` | 💥 crash | ✅ exit 0 |

`bash -n` OK · recovery ref `90f731b4f^` validato (contiene i file rimossi).

## Note

- `claude-design-bundle/` è gitignored — nessun artefatto generato committato, solo lo script.
- Fuori scope (osservazione): `all` non include `sp9` (quirk pre-esistente, non toccato).

Debito tracciato in #2989 (causato dal cleanup #2988, già merged) — nessuna issue dedicata da chiudere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
