### PR TITLE
fix(wikidata): correct P1872/P1873 player-count swap in BuildSparql (#3137)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Providers/WikidataCatalogProvider.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Providers/WikidataCatalogProvider.cs
@@ -268,17 +268,35 @@ LIMIT 1";
                 ? $"BIND(wd:{q.WikidataQid} AS ?game)"
                 : $"?game rdfs:label \"{q.SearchTerm}\"@en.";
 
+        // Issue #3137: each scalar is aggregated independently inside a GROUP BY
+        // subquery so it can never be paired with a mismatched row of the cartesian
+        // product formed by multi-valued OPTIONALs (designer/publisher/edition).
+        // P1872 = "minimum number of players" -> ?minPlayers (MIN);
+        // P1873 = "maximum number of players" -> ?maxPlayers (MAX). These were
+        // previously bound to the wrong variables (swapped).
         return $@"
 SELECT ?game ?gameLabel ?yearPublished ?designerLabel ?publisherLabel
        ?minPlayers ?maxPlayers ?playingTimeMinutes
 WHERE {{
-  {bind}
-  OPTIONAL {{ ?game wdt:P577 ?yearPublished. }}
-  OPTIONAL {{ ?game wdt:P3300 ?designer. }}
-  OPTIONAL {{ ?game wdt:P123 ?publisher. }}
-  OPTIONAL {{ ?game wdt:P1873 ?minPlayers. }}
-  OPTIONAL {{ ?game wdt:P1872 ?maxPlayers. }}
-  OPTIONAL {{ ?game wdt:P2047 ?playingTimeMinutes. }}
+  {{
+    SELECT ?game
+           (MIN(?yearRaw) AS ?yearPublished)
+           (SAMPLE(?designerRaw) AS ?designer)
+           (SAMPLE(?publisherRaw) AS ?publisher)
+           (MIN(?minRaw) AS ?minPlayers)
+           (MAX(?maxRaw) AS ?maxPlayers)
+           (SAMPLE(?playingTimeRaw) AS ?playingTimeMinutes)
+    WHERE {{
+      {bind}
+      OPTIONAL {{ ?game wdt:P577 ?yearRaw. }}
+      OPTIONAL {{ ?game wdt:P3300 ?designerRaw. }}
+      OPTIONAL {{ ?game wdt:P123 ?publisherRaw. }}
+      OPTIONAL {{ ?game wdt:P1872 ?minRaw. }}
+      OPTIONAL {{ ?game wdt:P1873 ?maxRaw. }}
+      OPTIONAL {{ ?game wdt:P2047 ?playingTimeRaw. }}
+    }}
+    GROUP BY ?game
+  }}
   SERVICE wikibase:label {{ bd:serviceParam wikibase:language ""en"". }}
 }}
 LIMIT 1";
@@ -342,11 +360,11 @@ LIMIT 1";
 
         if (int.TryParse(Get("minPlayers"), System.Globalization.CultureInfo.InvariantCulture, out var mn))
         {
-            fields["minPlayers"] = new FieldProvenance("wikidata", sourceUrl, "P1873", fetchedAt, mn);
+            fields["minPlayers"] = new FieldProvenance("wikidata", sourceUrl, "P1872", fetchedAt, mn);
         }
         if (int.TryParse(Get("maxPlayers"), System.Globalization.CultureInfo.InvariantCulture, out var mx))
         {
-            fields["maxPlayers"] = new FieldProvenance("wikidata", sourceUrl, "P1872", fetchedAt, mx);
+            fields["maxPlayers"] = new FieldProvenance("wikidata", sourceUrl, "P1873", fetchedAt, mx);
         }
         if (int.TryParse(Get("playingTimeMinutes"), System.Globalization.CultureInfo.InvariantCulture, out var pt))
         {

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Providers/WikidataCatalogProviderTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Providers/WikidataCatalogProviderTests.cs
@@ -26,6 +26,22 @@ public sealed class WikidataCatalogProviderTests
         return new HttpClient(handler.Object) { BaseAddress = new Uri("https://query.wikidata.org/") };
     }
 
+    // Captures the outbound HttpRequestMessage so a test can assert the SPARQL shape.
+    private static (HttpClient Client, Func<HttpRequestMessage?> Captured) MakeCapturingClient(string body)
+    {
+        HttpRequestMessage? captured = null;
+        var handler = new Mock<HttpMessageHandler>();
+        handler.Protected()
+            .Setup<Task<HttpResponseMessage>>("SendAsync", ItExpr.IsAny<HttpRequestMessage>(), ItExpr.IsAny<CancellationToken>())
+            .Callback<HttpRequestMessage, CancellationToken>((req, _) => captured = req)
+            .ReturnsAsync(() => new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent(body, System.Text.Encoding.UTF8, "application/sparql-results+json"),
+            });
+        var client = new HttpClient(handler.Object) { BaseAddress = new Uri("https://query.wikidata.org/") };
+        return (client, () => captured);
+    }
+
     [Fact]
     public void Name_Equals_Wikidata()
     {
@@ -123,5 +139,56 @@ public sealed class WikidataCatalogProviderTests
         result.Success.Should().BeTrue();
         result.Fields["title"].Value.Should().Be("Catan");
         result.Fields["wikidataQid"].Value.Should().Be("Q98056728");
+    }
+
+    [Fact]
+    public async Task FetchAsync_BuildsSparql_MapsP1872ToMinAndP1873ToMaxWithAggregation()
+    {
+        // Issue #3137: P1872 = "minimum number of players", P1873 = "maximum number of players".
+        // The old query bound them SWAPPED (P1873 -> ?minPlayers) and used a flat OPTIONAL chain
+        // + LIMIT 1 (cartesian product on multi-valued scalars). The corrected query maps
+        // P1872 -> min / P1873 -> max and aggregates each scalar in a GROUP BY subquery.
+        var (client, getCaptured) = MakeCapturingClient("""{"results":{"bindings":[]}}""");
+        var provider = new WikidataCatalogProvider(client, NullLogger<WikidataCatalogProvider>.Instance, Mock.Of<IWikimediaRateLimiter>());
+
+        await provider.FetchAsync(new CatalogProviderQuery(null, "Q17271", null), default);
+
+        var captured = getCaptured();
+        captured.Should().NotBeNull();
+        var sparql = System.Text.RegularExpressions.Regex.Replace(
+            Uri.UnescapeDataString(captured!.RequestUri!.Query), @"\s+", " ");
+
+        // Minimum sourced from P1872, maximum from P1873 — no swap.
+        sparql.Should().Contain("wdt:P1872 ?minRaw");
+        sparql.Should().Contain("wdt:P1873 ?maxRaw");
+        sparql.Should().Contain("MIN(?minRaw) AS ?minPlayers");
+        sparql.Should().Contain("MAX(?maxRaw) AS ?maxPlayers");
+        // Independent aggregation defuses the cartesian product (multi-valued designer/publisher/edition).
+        sparql.Should().Contain("GROUP BY ?game");
+        // The old swap must be gone.
+        sparql.Should().NotContain("wdt:P1873 ?minPlayers");
+        sparql.Should().NotContain("wdt:P1872 ?maxPlayers");
+    }
+
+    [Fact]
+    public async Task FetchAsync_PlayerCounts_CarryCorrectProvenanceProperties()
+    {
+        // Issue #3137: minPlayers provenance must be P1872, maxPlayers must be P1873.
+        const string body = """
+        { "results": { "bindings": [{
+          "game":       {"value": "http://www.wikidata.org/entity/Q17271"},
+          "gameLabel":  {"value": "Catan"},
+          "minPlayers": {"value": "3"},
+          "maxPlayers": {"value": "4"}
+        }]}}
+        """;
+        var provider = new WikidataCatalogProvider(MakeClient(HttpStatusCode.OK, body), NullLogger<WikidataCatalogProvider>.Instance, Mock.Of<IWikimediaRateLimiter>());
+
+        var result = await provider.FetchAsync(new CatalogProviderQuery(null, "Q17271", null), default);
+
+        result.Fields["minPlayers"].Value.Should().Be(3);
+        result.Fields["minPlayers"].SourceField.Should().Be("P1872");
+        result.Fields["maxPlayers"].Value.Should().Be(4);
+        result.Fields["maxPlayers"].SourceField.Should().Be("P1873");
     }
 }


### PR DESCRIPTION
## Summary
`BuildSparql` bound `P1873`→`?minPlayers` and `P1872`→`?maxPlayers`, but on Wikidata **`P1872` = minimum, `P1873` = maximum** — a deterministic swap. Verified live: Catan `Q17271` (P1872=3, P1873=4) emitted **minPlayers=4/maxPlayers=3**; Carcassonne 6/2 (truth 2/6); Pandemic 4/2 (truth 2/4). A second latent defect: the flat `OPTIONAL` chain + `LIMIT 1` forms a **cartesian product** on multi-valued scalars (Wingspan `Q65784798`: 78 rows without LIMIT).

## Changes
- Rewrite `BuildSparql` with a `GROUP BY ?game` subquery aggregating each scalar independently: `MIN(P1872)→minPlayers`, `MAX(P1873)→maxPlayers` (swap fixed + `min<=max` guaranteed), `SAMPLE` for designer/publisher/playtime (cartesian removed). Outer SELECT aliases byte-identical → `ParseResponse` unchanged.
- Fix the two swapped provenance `SourceField` tags in `ParseResponse`.

## Validation
Corrected query verified **live** on `query.wikidata.org`: Catan 3/4, Carcassonne 2/6, Pandemic 2/4, Wingspan 1/7 — all coherent, labels bind, values parse. Added a RED-first request-shape test (captures the outbound SPARQL, asserts `P1872→min`/`P1873→max` mapping + `GROUP BY`) that closes the gap that let the swap ship, plus a provenance-tag test. `WikidataCatalogProviderTests` 9/9, `WikidataContractTests` 25/25.

> Out of scope (follow-up): `P3300` maps to "musical conductor" not designer — a separate mapping defect, behaviourally unchanged here.

Closes #3137

🤖 Generated with [Claude Code](https://claude.com/claude-code)