### PR TITLE
fix(wikidata): use P178 for designer, not P3300 (#3142)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Providers/WikidataCatalogProvider.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Providers/WikidataCatalogProvider.cs
@@ -289,7 +289,7 @@ WHERE {{
     WHERE {{
       {bind}
       OPTIONAL {{ ?game wdt:P577 ?yearRaw. }}
-      OPTIONAL {{ ?game wdt:P3300 ?designerRaw. }}
+      OPTIONAL {{ ?game wdt:P178 ?designerRaw. }}
       OPTIONAL {{ ?game wdt:P123 ?publisherRaw. }}
       OPTIONAL {{ ?game wdt:P1872 ?minRaw. }}
       OPTIONAL {{ ?game wdt:P1873 ?maxRaw. }}
@@ -349,7 +349,7 @@ LIMIT 1";
         var designer = Get("designerLabel");
         if (!string.IsNullOrWhiteSpace(designer))
         {
-            fields["designers"] = new FieldProvenance("wikidata", sourceUrl, "P3300", fetchedAt, new List<string> { designer });
+            fields["designers"] = new FieldProvenance("wikidata", sourceUrl, "P178", fetchedAt, new List<string> { designer });
         }
 
         var publisher = Get("publisherLabel");

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Providers/WikidataCatalogProviderTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Providers/WikidataCatalogProviderTests.cs
@@ -191,4 +191,43 @@ public sealed class WikidataCatalogProviderTests
         result.Fields["maxPlayers"].Value.Should().Be(4);
         result.Fields["maxPlayers"].SourceField.Should().Be("P1873");
     }
+
+    [Fact]
+    public async Task FetchAsync_BuildsSparql_MapsDesignerToP178NotP3300()
+    {
+        // Issue #3142: P3300 = "musical conductor" (verified live) — NOT a game designer.
+        // The board-game designer is P178, the only candidate returning the correct designer
+        // for Catan/Carcassonne/Pandemic.
+        var (client, getCaptured) = MakeCapturingClient("""{"results":{"bindings":[]}}""");
+        var provider = new WikidataCatalogProvider(client, NullLogger<WikidataCatalogProvider>.Instance, Mock.Of<IWikimediaRateLimiter>());
+
+        await provider.FetchAsync(new CatalogProviderQuery(null, "Q17271", null), default);
+
+        var captured = getCaptured();
+        captured.Should().NotBeNull();
+        var sparql = System.Text.RegularExpressions.Regex.Replace(
+            Uri.UnescapeDataString(captured!.RequestUri!.Query), @"\s+", " ");
+
+        sparql.Should().Contain("wdt:P178 ?designerRaw");
+        sparql.Should().NotContain("wdt:P3300"); // the "musical conductor" property must be gone
+    }
+
+    [Fact]
+    public async Task FetchAsync_Designer_CarriesP178Provenance()
+    {
+        // Issue #3142: designer provenance must be P178, not P3300.
+        const string body = """
+        { "results": { "bindings": [{
+          "game":         {"value": "http://www.wikidata.org/entity/Q17271"},
+          "gameLabel":    {"value": "Catan"},
+          "designerLabel":{"value": "Klaus Teuber"}
+        }]}}
+        """;
+        var provider = new WikidataCatalogProvider(MakeClient(HttpStatusCode.OK, body), NullLogger<WikidataCatalogProvider>.Instance, Mock.Of<IWikimediaRateLimiter>());
+
+        var result = await provider.FetchAsync(new CatalogProviderQuery(null, "Q17271", null), default);
+
+        result.Fields["designers"].Value.Should().BeOfType<List<string>>().Which.Should().Contain("Klaus Teuber");
+        result.Fields["designers"].SourceField.Should().Be("P178");
+    }
 }


### PR DESCRIPTION
## Summary
`BuildSparql` bound the board-game designer via `wdt:P3300`, but **`P3300` = "musical conductor"** (verified live) — designer enrichment returned nothing. **`P178`** is the only candidate returning the correct designer for all probe games.

| Game | P178 | P3300 |
|------|------|-------|
| Catan | Klaus Teuber ✓ | (none) |
| Carcassonne | Klaus-Jürgen Wrede ✓ | (none) |
| Pandemic | Matt Leacock ✓ | (none) |

(P287/P50 cover 1/3, P170 0/3.)

## Changes
- `wdt:P3300 ?designerRaw` → `wdt:P178` in the `BuildSparql` GROUP BY subquery.
- `ParseResponse` designer provenance `SourceField` `"P3300"` → `"P178"`.
- No other logic change (SAMPLE aggregate + `?designer→?designerLabel` auto-resolution verified live under P178).

## Validation
RED-first request-shape test asserts `wdt:P178` (not `P3300`) + a provenance-tag test. `WikidataCatalogProviderTests` 11/11.

> `P178`'s canonical label is "developer" — for these physical board games Wikidata editors populate the human designer there; it's the only full-coverage candidate. Don't "correct" it back without re-checking live data.

Follow-up of the Wikidata enrichment demo (after #3137/#3138). Closes #3142

🤖 Generated with [Claude Code](https://claude.com/claude-code)