### PR TITLE
fix(shared-games): invalidate catalog cache on PDF cover propagation (#3143)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/EventHandlers/PdfCoverGeneratedEventHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/EventHandlers/PdfCoverGeneratedEventHandler.cs
@@ -1,5 +1,6 @@
 using Api.BoundedContexts.DocumentProcessing.Domain.Events;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Services;
 using Api.SharedKernel.Infrastructure.Persistence;
 using MediatR;
 using Microsoft.Extensions.Logging;
@@ -15,15 +16,21 @@ internal sealed class PdfCoverGeneratedEventHandler : INotificationHandler<PdfCo
 {
     private readonly ISharedGameRepository _repository;
     private readonly IUnitOfWork _unitOfWork;
+    private readonly IHybridCacheService _cache;
+    private readonly ICacheInvalidationRetryPolicy _cacheRetryPolicy;
     private readonly ILogger<PdfCoverGeneratedEventHandler> _logger;
 
     public PdfCoverGeneratedEventHandler(
         ISharedGameRepository repository,
         IUnitOfWork unitOfWork,
+        IHybridCacheService cache,
+        ICacheInvalidationRetryPolicy cacheRetryPolicy,
         ILogger<PdfCoverGeneratedEventHandler> logger)
     {
         _repository = repository ?? throw new ArgumentNullException(nameof(repository));
         _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+        _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+        _cacheRetryPolicy = cacheRetryPolicy ?? throw new ArgumentNullException(nameof(cacheRetryPolicy));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -59,6 +66,22 @@ internal sealed class PdfCoverGeneratedEventHandler : INotificationHandler<PdfCo
         game.SetPdfCoverR2Key(notification.CoverR2Key);
         _repository.Update(game);
         await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        // Issue #3143: the PDF-extracted cover (which OUTRANKS the Wikidata cover in
+        // CoverUrlResolver precedence) changed on an existing game — evict the catalog
+        // read-model caches so /shared-games and /shared-games/{id} reflect the new
+        // coverUrl immediately instead of waiting for the 15min/1h TTL. Cross-replica
+        // L1+L2 eviction via Redis Pub/Sub, mirroring #3138 / VectorDocumentIndexedForKbFlagHandler
+        // (ADR-062). Only reached after the real key change (the three early returns above are no-ops).
+        await _cacheRetryPolicy.ExecuteAsync(
+            token => new ValueTask(_cache.RemoveByTagAcrossReplicasAsync("search-games", token)),
+            "shared-games.list",
+            cancellationToken).ConfigureAwait(false);
+
+        await _cacheRetryPolicy.ExecuteAsync(
+            token => new ValueTask(_cache.RemoveByTagAcrossReplicasAsync($"shared-game:{sharedGameId}", token)),
+            "shared-games.detail",
+            cancellationToken).ConfigureAwait(false);
 
         _logger.LogInformation(
             "Propagated cover key to SharedGame {SharedGameId} from PDF {PdfDocumentId}.",

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/EventHandlers/PdfCoverGeneratedEventHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/EventHandlers/PdfCoverGeneratedEventHandlerTests.cs
@@ -2,7 +2,9 @@ using Api.BoundedContexts.DocumentProcessing.Domain.Events;
 using Api.BoundedContexts.SharedGameCatalog.Application.EventHandlers;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Services;
 using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Tests.TestHelpers;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -16,10 +18,17 @@ public sealed class PdfCoverGeneratedEventHandlerTests
 {
     private readonly Mock<ISharedGameRepository> _repo = new();
     private readonly Mock<IUnitOfWork> _uow = new();
+    private readonly Mock<IHybridCacheService> _cache = new();
     private readonly Mock<ILogger<PdfCoverGeneratedEventHandler>> _logger = new();
 
+    public PdfCoverGeneratedEventHandlerTests()
+    {
+        _cache.Setup(c => c.RemoveByTagAcrossReplicasAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+              .ReturnsAsync(0);
+    }
+
     private PdfCoverGeneratedEventHandler Handler() =>
-        new(_repo.Object, _uow.Object, _logger.Object);
+        new(_repo.Object, _uow.Object, _cache.Object, new PassthroughRetryPolicy(), _logger.Object);
 
     [Fact]
     public async Task Handle_NullSharedGameId_SkipsAndDoesNotCallRepo()
@@ -104,6 +113,38 @@ public sealed class PdfCoverGeneratedEventHandlerTests
         // Assert
         game.PdfCoverR2Key.Should().Be("new-key");
         _uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_DifferentKey_InvalidatesSearchAndDetailCache()
+    {
+        // Issue #3143: propagating a new PDF cover onto an existing game must evict the
+        // catalog read-model caches so the new coverUrl is served immediately.
+        var sgId = Guid.NewGuid();
+        var game = CreateValidGame();
+        game.SetPdfCoverR2Key("old-key");
+        _repo.Setup(r => r.GetByIdAsync(sgId, It.IsAny<CancellationToken>())).ReturnsAsync(game);
+        var evt = new PdfCoverGeneratedEvent(Guid.NewGuid(), sgId, "new-key", 0);
+
+        await Handler().Handle(evt, default);
+
+        _cache.Verify(c => c.RemoveByTagAcrossReplicasAsync("search-games", It.IsAny<CancellationToken>()), Times.Once);
+        _cache.Verify(c => c.RemoveByTagAcrossReplicasAsync($"shared-game:{sgId}", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_AlreadySameKey_DoesNotInvalidateCache()
+    {
+        // No-op path (key unchanged) must NOT evict.
+        var sgId = Guid.NewGuid();
+        var game = CreateValidGame();
+        game.SetPdfCoverR2Key("existing-key");
+        _repo.Setup(r => r.GetByIdAsync(sgId, It.IsAny<CancellationToken>())).ReturnsAsync(game);
+        var evt = new PdfCoverGeneratedEvent(Guid.NewGuid(), sgId, "existing-key", 0);
+
+        await Handler().Handle(evt, default);
+
+        _cache.Verify(c => c.RemoveByTagAcrossReplicasAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
     // Inlined from SharedGameTests.CreateValidGame (same assembly, Task 5 pattern).


### PR DESCRIPTION
## Summary
Same class as #3138, on a **higher-precedence** cover column. `PdfCoverGeneratedEventHandler` propagates the PDF-extracted cover key onto an **existing** SharedGame (`SetPdfCoverR2Key` + `SaveChanges`) but **never invalidated** the read-model caches → `GET /shared-games` and `/shared-games/{id}` kept serving the stale `coverUrl` until the `HybridCache` TTL (15min/1h). The PDF cover **outranks** the Wikidata cover in `CoverUrlResolver`, so it's even more user-visible than #3138.

## Changes
- Inject `IHybridCacheService` + `ICacheInvalidationRetryPolicy` (DI Singletons) and, after the cover-key `SaveChangesAsync` (only past the three early-return no-ops), evict `search-games` + `shared-game:{id}` across replicas — mirroring #3138 / `VectorDocumentIndexedForKbFlagHandler` (ADR-062).

## Validation
`PdfCoverGeneratedEventHandlerTests` 7/7: different-key propagate → both tags `Times.Once`; already-same-key no-op → `Times.Never`.

> The originally-framed "BGG cover" gap is **not** a bug — `BggCoverR2Key` is set only at game *creation* (one atomic insert, no stale-cache window). This PDF path is the real #3138 analog.
> Candidate follow-up: `ApproveGameProposalCommandHandler.ApproveCoverChangeAsync` also sets `PdfCoverR2Key` on an existing game without invalidation.

Closes #3143

🤖 Generated with [Claude Code](https://claude.com/claude-code)