### PR TITLE
feat(session-live): #3146 mobile meta strip for session-state chips (wave 3 slice 1)

### DIFF
--- a/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx
@@ -86,6 +86,7 @@ import {
   ActionLogTimeline,
   ChatAgentPanel,
   DesktopBody,
+  LiveMobileMetaStrip,
   LiveTopBar,
   MobileBody,
   PlayerRosterLive,
@@ -129,6 +130,7 @@ import { useSessionAgentChat } from '@/lib/domain-hooks/useSessionAgentChat';
 import { useSignalRSession } from '@/lib/domain-hooks/useSignalrSession';
 import { getNavigationLinks } from '@/lib/navigation';
 import { composeSessionLiveState } from '@/lib/session-live/compose-session-live-state';
+import { formatElapsedTime } from '@/lib/session-live/format-elapsed-time';
 import { formatSessionStartedAt } from '@/lib/session-live/format-session-started-at';
 import { mapConnectionState } from '@/lib/session-live/map-connection-state';
 import { mapTurnDataToTurnState } from '@/lib/session-live/map-turn-data-to-turn-state';
@@ -1689,6 +1691,19 @@ export function SessionLiveView(): ReactElement {
         elapsedMs={elapsedMs}
         startedAtLabel={startedAtLabel}
         connectionState={connectionPipState}
+      />
+
+      {/* #3146 Slice 1 — mobile-only meta strip: surfaces the turn / elapsed /
+          derived-start chips that LiveTopBar hides below lg, so session state
+          stays visible at a glance on phones. */}
+      <LiveMobileMetaStrip
+        turnLabel={topBarLabels.turnLabelResolved}
+        elapsedLabel={elapsedMs != null ? formatElapsedTime(elapsedMs) : undefined}
+        startedAtLabel={startedAtLabel}
+        labels={{
+          elapsedAriaLabel: topBarLabels.elapsedTimeAriaLabel,
+          startedAtAriaLabel: topBarLabels.startedAtChipAriaLabel,
+        }}
       />
 
       {/* ConnectionLostBanner — SSE non-healthy states */}

--- a/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/__tests__/SessionLiveView.test.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/[id]/live/_components/__tests__/SessionLiveView.test.tsx
@@ -722,6 +722,19 @@ describe('SessionLiveView (Wave D.2 Foundation)', () => {
     expect(container.querySelector('[data-slot="mobile-body"]')).toBeInTheDocument();
   });
 
+  // #3146 Slice 1: the mobile meta strip is wired under the top bar and receives
+  // the resolved turn / elapsed / derived-start values. The default fixture has
+  // startedAt set (→ elapsed derived), so all three chips render. Guards against
+  // the wiring being dropped or fed an undefined elapsed label.
+  it('Cell 5: wires LiveMobileMetaStrip with turn + elapsed + derived-start chips', () => {
+    const { container } = renderWithIntl(<SessionLiveView />);
+    const strip = container.querySelector('[data-slot="live-mobile-meta-strip"]');
+    expect(strip).toBeInTheDocument();
+    expect(strip?.querySelector('[data-slot="live-mobile-meta-strip-turn"]')).not.toBeNull();
+    expect(strip?.querySelector('[data-slot="live-mobile-meta-strip-elapsed"]')).not.toBeNull();
+    expect(strip?.querySelector('[data-slot="live-mobile-meta-strip-started-at"]')).not.toBeNull();
+  });
+
   // ─── 3.7: Exit handler ─────────────────────────────────────────────────
 
   it('exit button navigates to /sessions/{sessionId}', () => {

--- a/apps/web/src/components/features/session-live/LiveMobileMetaStrip.tsx
+++ b/apps/web/src/components/features/session-live/LiveMobileMetaStrip.tsx
@@ -1,0 +1,85 @@
+/**
+ * LiveMobileMetaStrip — #3146 Slice 1 (session-live mobile parity).
+ *
+ * A thin, always-visible meta strip rendered directly under the shared
+ * LiveTopBar on the MOBILE layout (<lg). It surfaces the session-state chips
+ * — turn progress, elapsed time (#11), and the read-only derived start time
+ * (#14, Invariante 5) — which the LiveTopBar hides below lg to save space.
+ *
+ * On desktop (lg+) the chips live in the LiveTopBar itself, so this strip is
+ * `lg:hidden`. Presentational only: the orchestrator (SessionLiveView) resolves
+ * all labels (turn ICU plural, formatted elapsed, localized start time) and
+ * passes them in. Renders nothing when it has no content (no empty chrome).
+ *
+ * Gate C: live/real-time meta surface, not a MeepleCard pattern.
+ * Token discipline: semantic tokens only (bg-card / border-border /
+ * text-muted-foreground / text-foreground), no raw color literals.
+ */
+
+import type { ReactElement } from 'react';
+
+export interface LiveMobileMetaStripLabels {
+  /** aria-label for the elapsed-time chip (required when elapsedLabel is set). */
+  readonly elapsedAriaLabel?: string;
+  /** aria-label for the read-only derived start-time chip. */
+  readonly startedAtAriaLabel?: string;
+}
+
+export interface LiveMobileMetaStripProps {
+  /** Resolved turn label (ICU plural "Turno {n}/{total}") — omit/empty to hide. */
+  readonly turnLabel?: string;
+  /** Pre-formatted elapsed time (HH:MM:SS) — omit to hide. */
+  readonly elapsedLabel?: string;
+  /** Pre-formatted read-only derived start-time ("▶ Ora di inizio … · derivata") — omit to hide. */
+  readonly startedAtLabel?: string;
+  readonly labels: LiveMobileMetaStripLabels;
+}
+
+export function LiveMobileMetaStrip({
+  turnLabel,
+  elapsedLabel,
+  startedAtLabel,
+  labels,
+}: LiveMobileMetaStripProps): ReactElement | null {
+  const hasTurn = Boolean(turnLabel);
+  const hasElapsed = elapsedLabel != null;
+  const hasStartedAt = Boolean(startedAtLabel);
+
+  // No content → render nothing (avoid an empty strip on layouts/states where
+  // none of the session-state chips apply).
+  if (!hasTurn && !hasElapsed && !hasStartedAt) return null;
+
+  return (
+    <div
+      data-slot="live-mobile-meta-strip"
+      className="flex shrink-0 flex-wrap items-center gap-x-3 gap-y-1 border-b border-border/60
+        bg-card/40 px-4 py-1.5 text-xs text-muted-foreground lg:hidden"
+    >
+      {hasTurn && (
+        <span data-slot="live-mobile-meta-strip-turn" className="shrink-0 font-medium">
+          {turnLabel}
+        </span>
+      )}
+
+      {hasElapsed && (
+        <span
+          data-slot="live-mobile-meta-strip-elapsed"
+          aria-label={labels.elapsedAriaLabel}
+          className="shrink-0 font-mono tabular-nums text-foreground/90"
+        >
+          {elapsedLabel}
+        </span>
+      )}
+
+      {hasStartedAt && (
+        <span
+          data-slot="live-mobile-meta-strip-started-at"
+          aria-label={labels.startedAtAriaLabel}
+          className="min-w-0 truncate"
+        >
+          {startedAtLabel}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/features/session-live/LiveTopBar.tsx
+++ b/apps/web/src/components/features/session-live/LiveTopBar.tsx
@@ -134,8 +134,12 @@ export function LiveTopBar({
         >
           {statusLabel}
         </span>
+        {/* #3146 Slice 1: the turn/elapsed/start-time chips are gated `lg:inline`
+            — they belong to the desktop layer (lg+). Below lg they move to the
+            always-visible LiveMobileMetaStrip so the cramped h-14 topbar stays
+            legible on phones. */}
         {labels.turnLabelResolved && (
-          <span className="hidden shrink-0 text-xs text-muted-foreground sm:inline">
+          <span className="hidden shrink-0 text-xs text-muted-foreground lg:inline">
             {labels.turnLabelResolved}
           </span>
         )}
@@ -146,7 +150,7 @@ export function LiveTopBar({
             data-slot="session-live-top-bar-timer"
             aria-label={labels.elapsedTimeAriaLabel}
             className="hidden shrink-0 rounded-md bg-card/60 px-2 py-0.5 font-mono text-xs
-              tabular-nums text-foreground/90 sm:inline"
+              tabular-nums text-foreground/90 lg:inline"
           >
             {elapsedFormatted}
           </span>
@@ -158,7 +162,7 @@ export function LiveTopBar({
             data-slot="session-live-top-bar-started-at"
             aria-label={labels.startedAtChipAriaLabel}
             className="hidden shrink-0 rounded-md bg-card/60 px-2 py-0.5 text-xs
-              text-muted-foreground md:inline"
+              text-muted-foreground lg:inline"
           >
             {startedAtLabel}
           </span>

--- a/apps/web/src/components/features/session-live/__tests__/LiveMobileMetaStrip.test.tsx
+++ b/apps/web/src/components/features/session-live/__tests__/LiveMobileMetaStrip.test.tsx
@@ -57,16 +57,50 @@ describe('LiveMobileMetaStrip (#3146 Slice 1)', () => {
     ).toBe('Ora di inizio della sessione (derivata)');
   });
 
-  it('omits the elapsed chip when elapsedLabel is absent', () => {
+  it('omits the elapsed chip when elapsedLabel is absent (siblings survive)', () => {
     renderStrip({ elapsedLabel: undefined });
     expect(document.querySelector('[data-slot="live-mobile-meta-strip-elapsed"]')).toBeNull();
     // …but still renders the others.
-    expect(screen.getByText('Turno 3/8')).toBeInTheDocument();
+    expect(document.querySelector('[data-slot="live-mobile-meta-strip-turn"]')).not.toBeNull();
+    expect(
+      document.querySelector('[data-slot="live-mobile-meta-strip-started-at"]')
+    ).not.toBeNull();
   });
 
-  it('omits the turn chip when turnLabel is absent/empty', () => {
+  it('omits the turn chip when turnLabel is absent/empty (siblings survive)', () => {
     renderStrip({ turnLabel: '' });
     expect(document.querySelector('[data-slot="live-mobile-meta-strip-turn"]')).toBeNull();
+    expect(document.querySelector('[data-slot="live-mobile-meta-strip-elapsed"]')).not.toBeNull();
+    expect(
+      document.querySelector('[data-slot="live-mobile-meta-strip-started-at"]')
+    ).not.toBeNull();
+  });
+
+  it('omits the start-time chip when startedAtLabel is absent (siblings survive)', () => {
+    renderStrip({ startedAtLabel: undefined });
+    expect(document.querySelector('[data-slot="live-mobile-meta-strip-started-at"]')).toBeNull();
+    expect(document.querySelector('[data-slot="live-mobile-meta-strip-turn"]')).not.toBeNull();
+    expect(document.querySelector('[data-slot="live-mobile-meta-strip-elapsed"]')).not.toBeNull();
+  });
+
+  // Single-field renders — guard against an over-narrowed early-return that
+  // would blank a turn-only or start-time-only mobile session.
+  it('renders when turn is the only field', () => {
+    renderStrip({ turnLabel: 'Turno 1/2', elapsedLabel: undefined, startedAtLabel: undefined });
+    expect(document.querySelector('[data-slot="live-mobile-meta-strip"]')).not.toBeNull();
+    expect(screen.getByText('Turno 1/2')).toBeInTheDocument();
+  });
+
+  it('renders when the derived start-time is the only field', () => {
+    renderStrip({
+      turnLabel: '',
+      elapsedLabel: undefined,
+      startedAtLabel: '▶ Ora di inizio 5 lug, 20:35 · derivata',
+    });
+    expect(document.querySelector('[data-slot="live-mobile-meta-strip"]')).not.toBeNull();
+    expect(
+      document.querySelector('[data-slot="live-mobile-meta-strip-started-at"]')?.textContent
+    ).toBe('▶ Ora di inizio 5 lug, 20:35 · derivata');
   });
 
   it('renders nothing when all fields are absent (no empty chrome)', () => {

--- a/apps/web/src/components/features/session-live/__tests__/LiveMobileMetaStrip.test.tsx
+++ b/apps/web/src/components/features/session-live/__tests__/LiveMobileMetaStrip.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * LiveMobileMetaStrip unit tests — #3146 Slice 1 (session-live mobile parity).
+ *
+ * The strip surfaces the session-state chips (turn / elapsed / derived start
+ * time) on the mobile layout (<lg), where the LiveTopBar chips are hidden. It
+ * is the always-visible mobile counterpart to the topbar chips.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import type { LiveMobileMetaStripProps } from '../LiveMobileMetaStrip';
+import { LiveMobileMetaStrip } from '../LiveMobileMetaStrip';
+
+function renderStrip(overrides: Partial<LiveMobileMetaStripProps> = {}) {
+  const props: LiveMobileMetaStripProps = {
+    turnLabel: 'Turno 3/8',
+    elapsedLabel: '02:34:56',
+    startedAtLabel: '▶ Ora di inizio 5 lug, 20:35 · derivata',
+    labels: {
+      elapsedAriaLabel: 'Tempo trascorso',
+      startedAtAriaLabel: 'Ora di inizio della sessione (derivata)',
+    },
+    ...overrides,
+  };
+  return render(<LiveMobileMetaStrip {...props} />);
+}
+
+describe('LiveMobileMetaStrip (#3146 Slice 1)', () => {
+  it('renders turn, elapsed and derived start-time', () => {
+    renderStrip();
+    expect(screen.getByText('Turno 3/8')).toBeInTheDocument();
+    const elapsed = document.querySelector('[data-slot="live-mobile-meta-strip-elapsed"]');
+    expect(elapsed?.textContent).toBe('02:34:56');
+    const started = document.querySelector('[data-slot="live-mobile-meta-strip-started-at"]');
+    expect(started?.textContent).toBe('▶ Ora di inizio 5 lug, 20:35 · derivata');
+  });
+
+  it('is a mobile-only strip (hidden at lg+)', () => {
+    renderStrip();
+    const strip = document.querySelector('[data-slot="live-mobile-meta-strip"]');
+    expect(strip).not.toBeNull();
+    expect(strip?.className).toContain('lg:hidden');
+  });
+
+  it('attaches aria-labels to the elapsed and start-time chips', () => {
+    renderStrip();
+    expect(
+      document
+        .querySelector('[data-slot="live-mobile-meta-strip-elapsed"]')
+        ?.getAttribute('aria-label')
+    ).toBe('Tempo trascorso');
+    expect(
+      document
+        .querySelector('[data-slot="live-mobile-meta-strip-started-at"]')
+        ?.getAttribute('aria-label')
+    ).toBe('Ora di inizio della sessione (derivata)');
+  });
+
+  it('omits the elapsed chip when elapsedLabel is absent', () => {
+    renderStrip({ elapsedLabel: undefined });
+    expect(document.querySelector('[data-slot="live-mobile-meta-strip-elapsed"]')).toBeNull();
+    // …but still renders the others.
+    expect(screen.getByText('Turno 3/8')).toBeInTheDocument();
+  });
+
+  it('omits the turn chip when turnLabel is absent/empty', () => {
+    renderStrip({ turnLabel: '' });
+    expect(document.querySelector('[data-slot="live-mobile-meta-strip-turn"]')).toBeNull();
+  });
+
+  it('renders nothing when all fields are absent (no empty chrome)', () => {
+    const { container } = renderStrip({
+      turnLabel: '',
+      elapsedLabel: undefined,
+      startedAtLabel: undefined,
+    });
+    expect(container.querySelector('[data-slot="live-mobile-meta-strip"]')).toBeNull();
+  });
+});

--- a/apps/web/src/components/features/session-live/__tests__/LiveTopBar.test.tsx
+++ b/apps/web/src/components/features/session-live/__tests__/LiveTopBar.test.tsx
@@ -95,6 +95,34 @@ describe('LiveTopBar — SI-4 start-time chip', () => {
   });
 });
 
+// ─── #3146 Slice 1 — chips are desktop-only (lg+) ──────────────────────────────
+
+describe('LiveTopBar — session-state chips are desktop-only (lg+, #3146)', () => {
+  // Below lg the chips move to LiveMobileMetaStrip (the mobile always-visible
+  // counterpart), so the topbar chips are gated `lg:inline` — they belong to
+  // the desktop layer (which itself switches on lg via DesktopBody/MobileBody).
+  it('gates the start-time chip to lg (not md/sm)', () => {
+    renderTopBar({ startedAtLabel: '▶ Ora di inizio 5 lug, 20:35 · derivata' });
+    const chip = document.querySelector('[data-slot="session-live-top-bar-started-at"]');
+    expect(chip?.className).toContain('lg:inline');
+    expect(chip?.className).not.toContain('md:inline');
+  });
+
+  it('gates the elapsed timer chip to lg (not sm)', () => {
+    renderTopBar({ elapsedMs: 60_000 });
+    const chip = document.querySelector('[data-slot="session-live-top-bar-timer"]');
+    expect(chip?.className).toContain('lg:inline');
+    expect(chip?.className).not.toContain('sm:inline');
+  });
+
+  it('gates the turn label to lg (not sm)', () => {
+    renderTopBar();
+    const turn = screen.getByText('Turno 3/8');
+    expect(turn.className).toContain('lg:inline');
+    expect(turn.className).not.toContain('sm:inline');
+  });
+});
+
 // ─── G4 — Elapsed timer chip ──────────────────────────────────────────────────
 
 describe('LiveTopBar — G4 elapsed timer chip', () => {

--- a/apps/web/src/components/features/session-live/index.ts
+++ b/apps/web/src/components/features/session-live/index.ts
@@ -38,6 +38,12 @@ export type {
 export { DesktopBody } from '@/components/features/session-live/DesktopBody';
 export type { DesktopBodyProps } from '@/components/features/session-live/DesktopBody';
 
+export { LiveMobileMetaStrip } from '@/components/features/session-live/LiveMobileMetaStrip';
+export type {
+  LiveMobileMetaStripLabels,
+  LiveMobileMetaStripProps,
+} from '@/components/features/session-live/LiveMobileMetaStrip';
+
 export { LiveScoringPanel } from '@/components/features/session-live/LiveScoringPanel';
 export type {
   LiveScoringPanelLabels,


### PR DESCRIPTION
## Cosa

**Wave 3 · Slice 1** (di #3146, follow-up gap headline #2989). Parità mobile del flow **session-live**: i chip di stato sessione (turn, elapsed #11, ora-derivata read-only #14) erano `sm:/md:inline` nella `LiveTopBar` condivisa (`h-14`) → **nascosti sui phone**, unica superficie sempre-visibile.

Reframing dalla discovery: lo shell mobile immersivo **esiste già** (epic #2354 G1/G5a) → nessuna design wave, solo fix mirato.

## Modifiche
- **`LiveMobileMetaStrip`** (nuovo, presentazionale, `lg:hidden`): striscia sottile sotto la topbar sul layout mobile, con `turn · ⏱ elapsed · ▶ started` + aria-labels; rende `null` se non ha contenuto.
- **Regate chip `LiveTopBar`** `sm:/md:inline` → `lg:inline`: appartengono al layer desktop (che commuta su `lg` via `DesktopBody`/`MobileBody`). Sotto `lg` la strip è la controparte — nessun chip perso, solo rilocato.
- **Wire in `SessionLiveView`** subito sotto `<LiveTopBar>` (riusa turn label già risolto + `formatElapsedTime(elapsedMs)` + start-time localizzato + aria-labels).

## Test / verifica
- TDD: `LiveMobileMetaStrip.test.tsx` (6) + contratto desktop-only `LiveTopBar` (3). Typecheck + eslint puliti; pre-commit/pre-push (build) verdi.
- Nota: flake pre-esistente `FlavorRenderer` (lazy-load pollution) non correlato — passa in isolamento, file non toccato.

## Follow-up (tracciati in #3146)
Slice 2 (hub `game-nights/[id]/live` responsive) · Slice 3 (#13 draft-save warning, full-stack).

Refs #3146

🤖 Generated with [Claude Code](https://claude.com/claude-code)