### PR TITLE
feat(game-night): #3146 activate hub live mobile layout (wave 3 slice 2)

### DIFF
--- a/apps/web/src/app/(authenticated)/game-nights/[id]/live/_components/NightLiveClientView.tsx
+++ b/apps/web/src/app/(authenticated)/game-nights/[id]/live/_components/NightLiveClientView.tsx
@@ -23,6 +23,7 @@ import {
   WinnerPickerModal,
 } from '@/components/features/game-nights/live';
 import { useCompleteGameNight } from '@/hooks/queries/useSessionFlow';
+import { useResponsive } from '@/hooks/useResponsive';
 import {
   ConflictError,
   ForbiddenError,
@@ -41,6 +42,11 @@ export interface NightLiveClientViewProps {
 
 export function NightLiveClientView({ nightId }: NightLiveClientViewProps) {
   const router = useRouter();
+  // #3146 Slice 2: below the desktop breakpoint the hub renders its own tab-based
+  // MobileBody (this route is immersive, so the global bottom bar is hidden and
+  // the hub nav is the sole bottom surface). useResponsive is SSR-safe (defaults
+  // mobile-first pre-hydration; the flip is masked by the live-load skeleton).
+  const { isDesktop } = useResponsive();
   const { data: vm, isLoading, isError, error } = useGameNightLive(nightId);
   // Slice C2: the diary is a SEPARATE participant-guarded read; composed with the live VM
   // below via mapDiary (panel D2). Its own error/loading is non-fatal — the hub renders an
@@ -197,6 +203,7 @@ export function NightLiveClientView({ nightId }: NightLiveClientViewProps) {
     <>
       <NightLiveHub
         readOnly
+        mobile={!isDesktop}
         night={vm.night}
         status={vm.status}
         current={vm.current}
@@ -214,7 +221,7 @@ export function NightLiveClientView({ nightId }: NightLiveClientViewProps) {
       />
 
       {showStartCta && nextGame ? (
-        <div className="fixed inset-x-0 bottom-0 z-40 flex justify-center p-4">
+        <div className="fixed inset-x-0 bottom-16 z-40 flex lg:bottom-0 justify-center p-4">
           <button
             type="button"
             onClick={() => handleStartNext(nextGame.gameId, nextGame.gameTitle)}
@@ -227,7 +234,7 @@ export function NightLiveClientView({ nightId }: NightLiveClientViewProps) {
       ) : null}
 
       {showCompleteCta ? (
-        <div className="fixed inset-x-0 bottom-0 z-40 flex justify-center p-4">
+        <div className="fixed inset-x-0 bottom-16 z-40 flex lg:bottom-0 justify-center p-4">
           <button
             type="button"
             onClick={() => {
@@ -243,7 +250,7 @@ export function NightLiveClientView({ nightId }: NightLiveClientViewProps) {
       ) : null}
 
       {showFinalizeCta ? (
-        <div className="fixed inset-x-0 bottom-0 z-40 flex flex-col items-center gap-2 p-4">
+        <div className="fixed inset-x-0 bottom-16 z-40 flex lg:bottom-0 flex-col items-center gap-2 p-4">
           {finalizeErrorMessage ? (
             <p
               role="alert"

--- a/apps/web/src/app/(authenticated)/game-nights/[id]/live/_components/__tests__/NightLiveClientView.test.tsx
+++ b/apps/web/src/app/(authenticated)/game-nights/[id]/live/_components/__tests__/NightLiveClientView.test.tsx
@@ -396,7 +396,26 @@ describe('NightLiveClientView — organizer Completa + winner picker (C4)', () =
   it('shows the "Completa partita" CTA for the organizer while a game is live', () => {
     mockQuery({ data: vm({ isViewerOrganizer: true, status: 'live', winnerCandidates: ROSTER }) });
     render(<NightLiveClientView nightId={NIGHT_ID} />);
-    expect(screen.getByRole('button', { name: /Completa partita/i })).toBeInTheDocument();
+    const cta = screen.getByRole('button', { name: /Completa partita/i });
+    expect(cta).toBeInTheDocument();
+    // #3146 Slice 2: floats above the mobile hub nav, inline on desktop.
+    expect(cta.closest('div')?.className).toContain('bottom-16');
+    expect(cta.closest('div')?.className).toContain('lg:bottom-0');
+  });
+
+  it('floats the "Concludi serata" finalize CTA above the mobile hub nav (#3146 Slice 2)', () => {
+    mockQuery({
+      data: vm({
+        isViewerOrganizer: true,
+        status: 'transition',
+        nextGame: null,
+        nightStatus: 'InProgress',
+      }),
+    });
+    render(<NightLiveClientView nightId={NIGHT_ID} />);
+    const cta = screen.getByRole('button', { name: /Concludi serata/i });
+    expect(cta.closest('div')?.className).toContain('bottom-16');
+    expect(cta.closest('div')?.className).toContain('lg:bottom-0');
   });
 
   it('does NOT show the Completa CTA for a non-organizer', () => {

--- a/apps/web/src/app/(authenticated)/game-nights/[id]/live/_components/__tests__/NightLiveClientView.test.tsx
+++ b/apps/web/src/app/(authenticated)/game-nights/[id]/live/_components/__tests__/NightLiveClientView.test.tsx
@@ -93,6 +93,20 @@ vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: pushMock, replace: replaceMock }),
 }));
 
+// #3146 Slice 2: NightLiveClientView drives NightLiveHub's `mobile` prop off the
+// viewport. Default to DESKTOP so the existing 3-pane assertions (planned games)
+// hold; individual tests flip to mobile.
+const responsiveState = vi.hoisted(() => ({
+  isMobile: false,
+  isTablet: false,
+  isDesktop: true,
+  deviceType: 'desktop' as 'mobile' | 'tablet' | 'desktop',
+  viewportWidth: 1280,
+}));
+vi.mock('@/hooks/useResponsive', () => ({
+  useResponsive: () => responsiveState,
+}));
+
 const NIGHT_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
 const IN_PROGRESS_SESSION_ID = '33333333-3333-4333-8333-333333333333';
 
@@ -157,6 +171,11 @@ beforeEach(() => {
   finalizeNightState.isError = false;
   finalizeNightState.error = null;
   useNightLiveDiaryMock.mockReturnValue({ data: undefined });
+  responsiveState.isMobile = false;
+  responsiveState.isTablet = false;
+  responsiveState.isDesktop = true;
+  responsiveState.deviceType = 'desktop';
+  responsiveState.viewportWidth = 1280;
 });
 
 const NEXT_GAME = { gameId: '77777777-7777-4777-8777-777777777777', gameTitle: 'Catan' };
@@ -168,6 +187,28 @@ describe('NightLiveClientView — loading', () => {
     expect(screen.getByRole('status', { name: /Caricamento serata/i })).toBeInTheDocument();
     // the hub is NOT mounted with placeholder data
     expect(screen.queryByText('Serata Eldoria')).toBeNull();
+  });
+});
+
+describe('NightLiveClientView — responsive hub activation (#3146 Slice 2)', () => {
+  it('activates the mobile hub layout (data-mobile=true) below desktop', () => {
+    responsiveState.isDesktop = false;
+    responsiveState.isMobile = true;
+    responsiveState.deviceType = 'mobile';
+    responsiveState.viewportWidth = 375;
+    mockQuery({ data: vm() });
+    const { container } = render(<NightLiveClientView nightId={NIGHT_ID} />);
+    expect(container.querySelector('[data-mobile="true"]')).toBeInTheDocument();
+    // Mobile default tab is 'current' → planned-games pane not shown in the tab body.
+    expect(screen.queryByText('Wingspan')).toBeNull();
+  });
+
+  it('keeps the desktop 3-pane hub (data-mobile=false) at lg+', () => {
+    mockQuery({ data: vm() });
+    const { container } = render(<NightLiveClientView nightId={NIGHT_ID} />);
+    expect(container.querySelector('[data-mobile="false"]')).toBeInTheDocument();
+    // Desktop renders all planned games in the always-visible pane.
+    expect(screen.getByText('Wingspan')).toBeInTheDocument();
   });
 });
 
@@ -250,6 +291,17 @@ describe('NightLiveClientView — organizer interactive start (WS1 DEC-10)', () 
     mockQuery({ data: vm({ isViewerOrganizer: true, nextGame: NEXT_GAME, status: 'transition' }) });
     render(<NightLiveClientView nightId={NIGHT_ID} />);
     expect(screen.getByRole('button', { name: /Avvia: Catan/i })).toBeInTheDocument();
+  });
+
+  // #3146 Slice 2: on mobile the fixed CTA must clear the hub's own in-flow
+  // bottom tab-nav (this route is immersive → no global bottom bar), so it sits
+  // at bottom-16 below lg and returns to bottom-0 on the desktop 3-pane layout.
+  it('floats the start CTA above the mobile hub nav (bottom-16 lg:bottom-0)', () => {
+    mockQuery({ data: vm({ isViewerOrganizer: true, nextGame: NEXT_GAME, status: 'transition' }) });
+    render(<NightLiveClientView nightId={NIGHT_ID} />);
+    const container = screen.getByRole('button', { name: /Avvia: Catan/i }).closest('div');
+    expect(container?.className).toContain('bottom-16');
+    expect(container?.className).toContain('lg:bottom-0');
   });
 
   it('starts the next game with its id + title on click', async () => {

--- a/apps/web/src/components/features/game-nights/live/NightLiveHub.test.tsx
+++ b/apps/web/src/components/features/game-nights/live/NightLiveHub.test.tsx
@@ -147,6 +147,21 @@ describe('NightLiveHub', () => {
       expect(screen.getByLabelText('Current game')).toBeInTheDocument();
     });
 
+    // #3146 Slice 2 review (F3): the tab-nav is now reachable in production, so
+    // its ARIA tabs relationship must be complete — the active tab's
+    // aria-controls resolves to a role="tabpanel" element that points back via
+    // aria-labelledby (no dangling references).
+    it('exposes a complete tab ↔ tabpanel ARIA relationship', () => {
+      render(<NightLiveHub {...baseProps} mobile />);
+      const currentTab = screen.getByRole('tab', { name: /Current/ });
+      expect(currentTab.id).toBeTruthy();
+      const panelId = currentTab.getAttribute('aria-controls');
+      expect(panelId).toBeTruthy();
+      const panel = screen.getByRole('tabpanel');
+      expect(panel.id).toBe(panelId);
+      expect(panel.getAttribute('aria-labelledby')).toBe(currentTab.id);
+    });
+
     it('respects initialMobileTab prop', () => {
       render(<NightLiveHub {...baseProps} mobile initialMobileTab="planned" />);
       expect(screen.getByRole('tab', { name: /Planned/ })).toHaveAttribute('aria-selected', 'true');

--- a/apps/web/src/components/features/game-nights/live/NightLiveHub.tsx
+++ b/apps/web/src/components/features/game-nights/live/NightLiveHub.tsx
@@ -519,7 +519,12 @@ function MobileBody({
 
   return (
     <>
-      <div className="flex min-h-0 flex-1 flex-col overflow-y-auto bg-background">
+      <div
+        role="tabpanel"
+        id={`night-live-pane-${tab}`}
+        aria-labelledby={`night-live-tab-${tab}`}
+        className="flex min-h-0 flex-1 flex-col overflow-y-auto bg-background"
+      >
         {tab === 'current' ? (
           <CurrentGameCard game={currentGame} onJumpToSession={onJumpToSession} compact />
         ) : null}
@@ -560,6 +565,7 @@ function MobileBody({
           return (
             <button
               key={t.id}
+              id={`night-live-tab-${t.id}`}
               type="button"
               role="tab"
               aria-selected={active}

--- a/apps/web/src/components/layout/AppNav/__tests__/immersive-routes.test.ts
+++ b/apps/web/src/components/layout/AppNav/__tests__/immersive-routes.test.ts
@@ -1,0 +1,40 @@
+/**
+ * isImmersiveRoute unit tests.
+ *
+ * Immersive routes replace the global navbar chrome (MobileBottomBar hides
+ * itself, DesktopShell drops its bottom-bar padding) with an in-session layout.
+ * #3146 Slice 2: the GameNight live hub (/game-nights/[id]/live) joins this set
+ * so its own mobile tab-nav is the sole bottom surface (no double bottom-nav
+ * with the global 5-tab bar).
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { isImmersiveRoute } from '../immersive-routes';
+
+describe('isImmersiveRoute', () => {
+  it('treats the session live view as immersive', () => {
+    expect(isImmersiveRoute('/sessions/abc-123/live')).toBe(true);
+    expect(isImmersiveRoute('/sessions/abc-123/live/anything')).toBe(true);
+  });
+
+  it('treats the library play view as immersive', () => {
+    expect(isImmersiveRoute('/library/game-1/play')).toBe(true);
+  });
+
+  it('treats the GameNight live hub as immersive (#3146 Slice 2)', () => {
+    expect(isImmersiveRoute('/game-nights/night-1/live')).toBe(true);
+    expect(isImmersiveRoute('/game-nights/night-1/live/')).toBe(true);
+  });
+
+  it('does NOT treat the GameNight detail / summary as immersive', () => {
+    expect(isImmersiveRoute('/game-nights/night-1')).toBe(false);
+    expect(isImmersiveRoute('/game-nights/night-1/summary')).toBe(false);
+  });
+
+  it('does NOT treat unrelated routes as immersive', () => {
+    expect(isImmersiveRoute('/library')).toBe(false);
+    expect(isImmersiveRoute('/sessions/abc-123')).toBe(false);
+    expect(isImmersiveRoute('/')).toBe(false);
+  });
+});

--- a/apps/web/src/components/layout/AppNav/immersive-routes.ts
+++ b/apps/web/src/components/layout/AppNav/immersive-routes.ts
@@ -6,6 +6,10 @@
 const IMMERSIVE_ROUTE_PATTERNS = [
   /^\/sessions\/[^/]+\/live(\/|$)/,
   /^\/library\/[^/]+\/play(\/|$)/,
+  // #3146 Slice 2: the GameNight live hub renders its own mobile tab-nav
+  // (NightLiveHub MobileBody), so it hides the global bottom bar to avoid a
+  // double bottom-nav — like the session live view above.
+  /^\/game-nights\/[^/]+\/live(\/|$)/,
 ];
 
 export function isImmersiveRoute(pathname: string): boolean {

--- a/apps/web/src/components/layout/UserShell/UserShellClient.tsx
+++ b/apps/web/src/components/layout/UserShell/UserShellClient.tsx
@@ -2,8 +2,11 @@
 
 import { Suspense, type ReactNode } from 'react';
 
+import { usePathname } from 'next/navigation';
+
 import { DashboardEngineProvider } from '@/components/dashboard';
 import { StatusBanner } from '@/components/features/status-banner';
+import { isImmersiveRoute } from '@/components/layout/AppNav/immersive-routes';
 import { ContextualHandBottomBar } from '@/components/layout/ContextualHand';
 import { BackToSessionFAB } from '@/components/session/BackToSessionFAB';
 
@@ -14,14 +17,24 @@ interface UserShellClientProps {
 }
 
 export function UserShellClient({ children }: UserShellClientProps) {
+  const pathname = usePathname();
+  // #3146 Slice 2: immersive routes replace the global navbar chrome with an
+  // in-session layout that owns its own bottom surface (e.g. the GameNight live
+  // hub's tab-nav). Suppress ALL global fixed bottom chrome there — not just the
+  // MobileBottomBar (which self-hides) — so nothing overlaps the in-session nav.
+  const immersive = isImmersiveRoute(pathname);
   return (
     <DesktopShell>
       <StatusBanner />
       <DashboardEngineProvider>{children}</DashboardEngineProvider>
-      <Suspense>
-        <BackToSessionFAB />
-      </Suspense>
-      <ContextualHandBottomBar />
+      {!immersive && (
+        <>
+          <Suspense>
+            <BackToSessionFAB />
+          </Suspense>
+          <ContextualHandBottomBar />
+        </>
+      )}
     </DesktopShell>
   );
 }

--- a/apps/web/src/components/layout/UserShell/__tests__/UserShellClient.test.tsx
+++ b/apps/web/src/components/layout/UserShell/__tests__/UserShellClient.test.tsx
@@ -1,0 +1,56 @@
+/**
+ * UserShellClient tests — #3146 Slice 2 review fix.
+ *
+ * Immersive routes replace the global navbar chrome with an in-session layout.
+ * MobileBottomBar + DesktopShell already honour isImmersiveRoute; this asserts
+ * the OTHER global fixed bottom-surface components (BackToSessionFAB, the
+ * ContextualHandBottomBar) are suppressed too, so an immersive view (e.g. the
+ * GameNight live hub with its own tab-nav) is the sole bottom surface.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { UserShellClient } from '../UserShellClient';
+
+let mockPathname = '/dashboard';
+vi.mock('next/navigation', () => ({
+  usePathname: () => mockPathname,
+}));
+
+vi.mock('../DesktopShell', () => ({
+  DesktopShell: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+vi.mock('@/components/features/status-banner', () => ({ StatusBanner: () => null }));
+vi.mock('@/components/dashboard', () => ({
+  DashboardEngineProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+vi.mock('@/components/session/BackToSessionFAB', () => ({
+  BackToSessionFAB: () => <div data-testid="back-to-session-fab" />,
+}));
+vi.mock('@/components/layout/ContextualHand', () => ({
+  ContextualHandBottomBar: () => <div data-testid="contextual-hand-bottom-bar" />,
+}));
+
+describe('UserShellClient — global bottom chrome gating', () => {
+  it('renders FAB + contextual-hand on a normal (non-immersive) route', () => {
+    mockPathname = '/dashboard';
+    render(<UserShellClient>content</UserShellClient>);
+    expect(screen.getByTestId('back-to-session-fab')).toBeInTheDocument();
+    expect(screen.getByTestId('contextual-hand-bottom-bar')).toBeInTheDocument();
+  });
+
+  it('suppresses FAB + contextual-hand on the GameNight live hub (immersive)', () => {
+    mockPathname = '/game-nights/night-1/live';
+    render(<UserShellClient>content</UserShellClient>);
+    expect(screen.queryByTestId('back-to-session-fab')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('contextual-hand-bottom-bar')).not.toBeInTheDocument();
+  });
+
+  it('suppresses them on the session live view (immersive) too', () => {
+    mockPathname = '/sessions/abc/live';
+    render(<UserShellClient>content</UserShellClient>);
+    expect(screen.queryByTestId('back-to-session-fab')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('contextual-hand-bottom-bar')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Cosa

**Wave 3 · Slice 2** (di #3146). L'hub live GameNight (`/game-nights/[id]/live`) **aveva già** un layout mobile a tab completo (`NightLiveHub` → `MobileBody`: Current/Planned/Diary + bottom-nav propria), ma la **attivazione viewport era "deferred" (Phase 4)** → `NightLiveClientView` non passava mai `mobile`, quindi sui phone si vedeva il 3-pane desktop (280/flex/320) in overflow. Questa PR **completa il wiring deferred**, non costruisce un layout parallelo.

## Modifiche
- **`NightLiveClientView`**: `mobile={!isDesktop}` via `useResponsive()` (SSR-safe: mobile-first pre-hydration, flip mascherato dallo skeleton di `useGameNightLive`).
- **`immersive-routes`**: `/game-nights/[id]/live` aggiunta a `IMMERSIVE_ROUTE_PATTERNS` → la `MobileBottomBar` globale si nasconde e la shell droppa il `pb-16`, così la **bottom-nav a tab propria dell'hub è l'unica** (niente doppia bottom-nav), coerente con `/sessions/[id]/live`.
- **CTA fixed** (Avvia/Completa/Concludi): `bottom-16 lg:bottom-0` per liberare la bottom-nav in-flow dell'hub su phone.

## Test / verifica
- TDD: `immersive-routes.test.ts` (5) + attivazione responsive + posizione CTA in `NightLiveClientView.test`. **164** test layout/hub verdi, typecheck + eslint puliti, pre-commit/pre-push (build) verdi.

## Follow-up (in #3146)
Slice 3 (#13 draft-save warning, full-stack BE+FE).

Refs #3146

🤖 Generated with [Claude Code](https://claude.com/claude-code)