### PR TITLE
fix(shared-games): trim EnrichFromProvenance to persisting scalars (#3154)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/EventHandlers/CatalogSeedApprovedEventHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/EventHandlers/CatalogSeedApprovedEventHandler.cs
@@ -106,16 +106,17 @@ internal sealed class CatalogSeedApprovedEventHandler : INotificationHandler<Cat
             return;
         }
 
-        // Issue #3147 — the sparse Wikidata-primary (BGG-fallback) scalars/lists to
+        // Issue #3147/#3154 — the sparse Wikidata-primary (BGG-fallback) SCALARS to
         // carry onto a freshly-materialised skeleton. `GetValue<T?>` yields null when
         // a field is absent; SharedGame.EnrichFromProvenance applies each only when
-        // present and internally consistent (see its leniency rules).
+        // present and internally consistent (see its leniency rules). Designers/
+        // publishers are deliberately NOT read here — the aggregate's M:N collections
+        // are read-only through SharedGameRepository, so they'd be dropped on persist
+        // (tracked by #3153).
         var provYear = provenance.GetValue<int?>("yearPublished");
         var provMinPlayers = provenance.GetValue<int?>("minPlayers");
         var provMaxPlayers = provenance.GetValue<int?>("maxPlayers");
         var provPlayingTime = provenance.GetValue<int?>("playingTimeMinutes");
-        var provDesigners = provenance.GetValue<List<string>>("designers");
-        var provPublishers = provenance.GetValue<List<string>>("publishers");
 
         // Idempotency: if a draft was approved twice, or if a SharedGame already
         // exists for the same BGG ID (collision with prior import path), reuse it.
@@ -167,7 +168,7 @@ internal sealed class CatalogSeedApprovedEventHandler : INotificationHandler<Cat
                 skeleton.AssignWikidataQid(draft.WikidataQid, notification.ApprovedByUserId);
             }
 
-            // Issue #3147 — carry the Wikidata-primary properties onto the skeleton
+            // Issue #3147/#3154 — carry the Wikidata-primary scalars onto the skeleton
             // instead of dropping them (the M5 follow-up flagged in this handler's
             // remarks). Only the new-skeleton branch enriches: a BggId collision
             // (existing branch) is already covered by the BGG enrichment queue
@@ -179,8 +180,6 @@ internal sealed class CatalogSeedApprovedEventHandler : INotificationHandler<Cat
                 minPlayers: provMinPlayers,
                 maxPlayers: provMaxPlayers,
                 playingTimeMinutes: provPlayingTime,
-                designers: provDesigners,
-                publishers: provPublishers,
                 modifiedBy: notification.ApprovedByUserId);
 
             await _games.AddAsync(skeleton, cancellationToken).ConfigureAwait(false);

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Aggregates/SharedGame.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Domain/Aggregates/SharedGame.cs
@@ -593,19 +593,25 @@ public sealed class SharedGame : AggregateRoot<Guid>
 
     /// <summary>
     /// Partially enriches this aggregate from sparse catalog-seed provenance
-    /// (Wikidata-primary, BGG fallback) at draft → game promotion. Issue #3147.
+    /// (Wikidata-primary, BGG fallback) at draft → game promotion. Issues #3147, #3154.
     /// </summary>
     /// <remarks>
     /// Unlike <see cref="EnrichFromBgg"/>, this is <b>lenient and stateless</b>:
     /// each scalar is applied only when present AND internally consistent;
     /// missing / implausible values are skipped rather than throwing, because
     /// catalog-seed provenance is frequently partial (a Wikidata entity may
-    /// expose player counts but no year, designers but no playtime, etc.). It
-    /// does <b>not</b> drive the <see cref="GameDataStatus"/> state machine — the
+    /// expose player counts but no year, a year but no playtime, etc.). It does
+    /// <b>not</b> drive the <see cref="GameDataStatus"/> state machine — the
     /// aggregate stays a <c>Skeleton</c> so the BGG enrichment queue (#1874) can
     /// still complete it later. Audit fields are stamped only when something
     /// actually changed (mirrors <see cref="AssignWikidataQid"/>), so a no-op
     /// call (all fields absent / implausible) leaves the aggregate untouched.
+    /// <para>Scope: <b>scalars only</b>. Designers/publishers are intentionally
+    /// excluded — the <c>_designers</c>/<c>_publishers</c> aggregate collections
+    /// are read-only through <c>SharedGameRepository</c> (<c>MapToEntity</c> maps
+    /// no M:N navigation), so writing them here would be silently dropped on
+    /// persist. Persisting Wikidata designers/publishers (get-or-create by name +
+    /// join rows + integration coverage) is tracked by #3153.</para>
     /// </remarks>
     /// <param name="yearPublished">Publication year (Wikidata P577); applied when in <c>1901..currentYear+1</c>.</param>
     /// <param name="minPlayers">Minimum player count (P1872).</param>
@@ -615,8 +621,6 @@ public sealed class SharedGame : AggregateRoot<Guid>
     /// range such as "3–0 players" from a lone <paramref name="minPlayers"/>.
     /// </param>
     /// <param name="playingTimeMinutes">Playing time in minutes (P2047); applied when &gt; 0.</param>
-    /// <param name="designers">Designer names (P178) to append, de-duplicated case-insensitively.</param>
-    /// <param name="publishers">Publisher names (P123) to append, de-duplicated case-insensitively.</param>
     /// <param name="modifiedBy">The actor (approving admin) performing the enrichment.</param>
     /// <exception cref="ArgumentException">Thrown when <paramref name="modifiedBy"/> is <see cref="Guid.Empty"/>.</exception>
     public void EnrichFromProvenance(
@@ -624,8 +628,6 @@ public sealed class SharedGame : AggregateRoot<Guid>
         int? minPlayers,
         int? maxPlayers,
         int? playingTimeMinutes,
-        IReadOnlyCollection<string>? designers,
-        IReadOnlyCollection<string>? publishers,
         Guid modifiedBy)
     {
         if (modifiedBy == Guid.Empty)
@@ -655,50 +657,11 @@ public sealed class SharedGame : AggregateRoot<Guid>
             changed = true;
         }
 
-        changed |= AppendUniqueNames(designers, _designers.Select(d => d.Name), n => _designers.Add(GameDesigner.Create(n)));
-        changed |= AppendUniqueNames(publishers, _publishers.Select(p => p.Name), n => _publishers.Add(GamePublisher.Create(n)));
-
         if (changed)
         {
             _modifiedBy = modifiedBy;
             _modifiedAt = DateTime.UtcNow;
         }
-    }
-
-    /// <summary>
-    /// Appends trimmed, non-empty names from <paramref name="incoming"/> that are
-    /// not already present (case-insensitive) and not over the 200-char entity
-    /// limit. Lenient: bad entries are skipped, never thrown. Returns whether any
-    /// name was added. Shared by the designer / publisher branches of
-    /// <see cref="EnrichFromProvenance"/>.
-    /// </summary>
-    private static bool AppendUniqueNames(
-        IReadOnlyCollection<string>? incoming,
-        IEnumerable<string> existingNames,
-        Action<string> add)
-    {
-        if (incoming is null || incoming.Count == 0)
-            return false;
-
-        var seen = new HashSet<string>(existingNames, StringComparer.OrdinalIgnoreCase);
-        var any = false;
-        foreach (var raw in incoming)
-        {
-            if (string.IsNullOrWhiteSpace(raw))
-                continue;
-
-            var name = raw.Trim();
-            if (name.Length > 200)
-                continue;
-
-            if (seen.Add(name))
-            {
-                add(name);
-                any = true;
-            }
-        }
-
-        return any;
     }
 
     /// <summary>

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/EventHandlers/CatalogSeedApprovedEventHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/EventHandlers/CatalogSeedApprovedEventHandlerTests.cs
@@ -376,8 +376,12 @@ public sealed class CatalogSeedApprovedEventHandlerTests
         added.MinPlayers.Should().Be(3);
         added.MaxPlayers.Should().Be(4);
         added.PlayingTimeMinutes.Should().Be(90);
-        added.Designers.Should().ContainSingle(d => d.Name == "Klaus Teuber");
-        added.Publishers.Should().ContainSingle(p => p.Name == "Kosmos");
+        // #3154: RichProvenance carries designers ("Klaus Teuber") + publishers, but
+        // scalar-only enrichment intentionally does NOT apply them — the aggregate's
+        // M:N collections are read-only through SharedGameRepository (they'd be
+        // silently dropped on persist). Proper M:N persistence is tracked by #3153.
+        added.Designers.Should().BeEmpty("designers are excluded from scalar-only enrichment (#3154)");
+        added.Publishers.Should().BeEmpty("publishers are excluded from scalar-only enrichment (#3154)");
     }
 
     [Fact]

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Domain/SharedGameSkeletonTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Domain/SharedGameSkeletonTests.cs
@@ -249,10 +249,15 @@ public class SharedGameSkeletonTests
 
     #endregion
 
-    #region EnrichFromProvenance (Issue #3147)
+    #region EnrichFromProvenance (Issues #3147, #3154)
+
+    // NOTE: scalars only — designers/publishers are intentionally excluded from
+    // EnrichFromProvenance (they are read-only through SharedGameRepository, so
+    // writing them would be silently dropped on persist). M:N persistence tracked
+    // by #3153.
 
     [Fact]
-    public void EnrichFromProvenance_AllFieldsPresent_AppliesAllAndStampsAudit()
+    public void EnrichFromProvenance_AllScalarsPresent_AppliesAllAndStampsAudit()
     {
         var game = SharedGame.CreateSkeleton("Catan", AdminUserId, TimeProvider);
         game.ModifiedBy.Should().BeNull("precondition: skeleton has no modifier");
@@ -261,16 +266,12 @@ public class SharedGameSkeletonTests
             yearPublished: 1995,
             minPlayers: 3, maxPlayers: 4,
             playingTimeMinutes: 90,
-            designers: new[] { "Klaus Teuber" },
-            publishers: new[] { "Kosmos" },
             modifiedBy: AdminUserId);
 
         game.YearPublished.Should().Be(1995);
         game.MinPlayers.Should().Be(3);
         game.MaxPlayers.Should().Be(4);
         game.PlayingTimeMinutes.Should().Be(90);
-        game.Designers.Should().ContainSingle(d => d.Name == "Klaus Teuber");
-        game.Publishers.Should().ContainSingle(p => p.Name == "Kosmos");
         game.ModifiedBy.Should().Be(AdminUserId, "a real change stamps the audit actor");
         game.GameDataStatus.Should().Be(GameDataStatus.Skeleton, "enrichment must NOT drive the state machine");
     }
@@ -284,16 +285,12 @@ public class SharedGameSkeletonTests
             yearPublished: null,
             minPlayers: null, maxPlayers: null,
             playingTimeMinutes: null,
-            designers: null,
-            publishers: null,
             modifiedBy: AdminUserId);
 
         game.YearPublished.Should().Be(0);
         game.MinPlayers.Should().Be(0);
         game.MaxPlayers.Should().Be(0);
         game.PlayingTimeMinutes.Should().Be(0);
-        game.Designers.Should().BeEmpty();
-        game.Publishers.Should().BeEmpty();
         game.ModifiedBy.Should().BeNull("a no-op must not stamp the audit actor");
     }
 
@@ -310,7 +307,6 @@ public class SharedGameSkeletonTests
             yearPublished: badYear,
             minPlayers: 2, maxPlayers: 5,
             playingTimeMinutes: null,
-            designers: null, publishers: null,
             modifiedBy: AdminUserId);
 
         game.YearPublished.Should().Be(0, "an implausible year is skipped, not applied");
@@ -327,7 +323,6 @@ public class SharedGameSkeletonTests
             yearPublished: DateTime.UtcNow.Year + 5,
             minPlayers: null, maxPlayers: null,
             playingTimeMinutes: null,
-            designers: null, publishers: null,
             modifiedBy: AdminUserId);
 
         game.YearPublished.Should().Be(0);
@@ -347,7 +342,6 @@ public class SharedGameSkeletonTests
             yearPublished: null,
             minPlayers: min, maxPlayers: max,
             playingTimeMinutes: null,
-            designers: null, publishers: null,
             modifiedBy: AdminUserId);
 
         game.MinPlayers.Should().Be(0, "player counts are applied only as a consistent pair");
@@ -364,48 +358,10 @@ public class SharedGameSkeletonTests
             yearPublished: null,
             minPlayers: null, maxPlayers: null,
             playingTimeMinutes: 0,
-            designers: null, publishers: null,
             modifiedBy: AdminUserId);
 
         game.PlayingTimeMinutes.Should().Be(0);
         game.ModifiedBy.Should().BeNull();
-    }
-
-    [Fact]
-    public void EnrichFromProvenance_Designers_DedupeCaseInsensitiveAndTrim()
-    {
-        var game = SharedGame.CreateSkeleton("Catan", AdminUserId, TimeProvider);
-        game.AddDesigner("Klaus Teuber");
-
-        game.EnrichFromProvenance(
-            yearPublished: null,
-            minPlayers: null, maxPlayers: null,
-            playingTimeMinutes: null,
-            designers: new[] { "klaus teuber", "  Alan R. Moon  ", "   ", "Alan R. Moon" },
-            publishers: null,
-            modifiedBy: AdminUserId);
-
-        game.Designers.Select(d => d.Name).Should().BeEquivalentTo(
-            new[] { "Klaus Teuber", "Alan R. Moon" },
-            "existing designers, whitespace, and case/exact duplicates are all de-duplicated; names are trimmed");
-    }
-
-    [Fact]
-    public void EnrichFromProvenance_OverlongName_IsSkippedNotThrown()
-    {
-        var game = SharedGame.CreateSkeleton("Catan", AdminUserId, TimeProvider);
-        var overlong = new string('x', 201);
-
-        var act = () => game.EnrichFromProvenance(
-            yearPublished: null,
-            minPlayers: null, maxPlayers: null,
-            playingTimeMinutes: null,
-            designers: new[] { overlong, "Alan R. Moon" },
-            publishers: null,
-            modifiedBy: AdminUserId);
-
-        act.Should().NotThrow("a single bad name must not abort the whole enrichment");
-        game.Designers.Select(d => d.Name).Should().ContainSingle().Which.Should().Be("Alan R. Moon");
     }
 
     [Fact]
@@ -417,7 +373,6 @@ public class SharedGameSkeletonTests
             yearPublished: 1995,
             minPlayers: 3, maxPlayers: 4,
             playingTimeMinutes: 90,
-            designers: null, publishers: null,
             modifiedBy: Guid.Empty);
 
         act.Should().Throw<ArgumentException>();


### PR DESCRIPTION
## Summary
**Live verification** of #3147 (approving a Wikidata-seeded Catan draft, QID `Q17271`) proved the scalars persist — `year=1995, min=3, max=4, playtime=75` on the materialised SharedGame — but **designers/publishers were silently dropped**: `SharedGameRepository.MapToEntity` maps only scalar columns onto `SharedGameEntity`, never the `Designers`/`Publishers` M:N navigations, so names added to the aggregate never reach the entity (no exception thrown). #3147's unit tests couldn't catch this — they mock the repository, so `MapToEntity` is never exercised.

## Changes
- Remove the `designers`/`publishers` parameters + the `AppendUniqueNames` helper from `SharedGame.EnrichFromProvenance`; it now applies only the **persisting scalars** (year / min-max players / playtime). The XML-doc documents why designers/publishers are excluded.
- `CatalogSeedApprovedEventHandler` stops reading designers/publishers from provenance.
- Tests: drop the two now-moot dedup/overlong-name domain tests; the handler test now asserts `added.Designers`/`Publishers` are **empty** even though `RichProvenance` still carries them — a regression guard for the exclusion. 63/63 green.

## Verification
Re-confirmed live post-trim is unnecessary (scalar behaviour unchanged); the trim only removes the never-persisted M:N writes.

Proper Wikidata designer/publisher persistence (get-or-create by name + join rows + **Testcontainers integration test** — the class of coverage that would have caught this) is tracked by **#3153**.

> Backend-only (4 .NET files, zero frontend). Pushed with `--no-verify` — the pre-push hook builds Next.js and OOM-crashes in the local env (same as #3149, user-authorised). Backend Fast + GitGuardian are the real gates.

Closes #3154
Refs #3147, #3153