### PR TITLE
feat(game-night): #3146 draft-save-while-live warning (wave 3 slice 3, full-stack)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/PlayRecords/UpdatePlayRecordCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/PlayRecords/UpdatePlayRecordCommand.cs
@@ -17,4 +17,12 @@ internal record UpdatePlayRecordCommand(
     string? Notes = null,
     string? Location = null,
     uint? Xmin = null
-) : ICommand;
+) : ICommand<UpdatePlayRecordResult>;
+
+/// <summary>
+/// Result of an update. #13 / Invariante 4: when the update succeeds while the same
+/// user has another live session in progress, the save is non-blocking but the caller
+/// surfaces a warning. <see cref="SavedWhileLiveActive"/> flags that case and
+/// <see cref="LiveSessionId"/> is the in-progress session's id for the "go to live" deep-link.
+/// </summary>
+internal sealed record UpdatePlayRecordResult(bool SavedWhileLiveActive, Guid? LiveSessionId);

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/PlayRecords/UpdatePlayRecordCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/PlayRecords/UpdatePlayRecordCommandHandler.cs
@@ -1,6 +1,5 @@
 using Api.BoundedContexts.GameManagement.Application.Commands.PlayRecords;
 using Api.BoundedContexts.GameManagement.Application.Services;
-using Api.BoundedContexts.GameManagement.Domain.Enums;
 using Api.BoundedContexts.GameManagement.Domain.Repositories;
 using Api.BoundedContexts.GameManagement.Infrastructure.Persistence;
 using Api.Middleware.Exceptions;
@@ -140,15 +139,14 @@ internal class UpdatePlayRecordCommandHandler : ICommandHandler<UpdatePlayRecord
 
         // #13 / Invariante 4: the save is non-blocking, but if the same user has ANOTHER
         // session genuinely live (InProgress) right now, surface a non-blocking warning so
-        // they can double-check the games were recorded in the right order. Setup/Paused are
-        // "active" per the repository but not "live" — only InProgress counts.
-        var activeSessions = await _liveSessionRepository
-            .GetActiveByUserIdAsync(command.UserId, cancellationToken)
+        // they can double-check the games were recorded in the right order. The repository
+        // projects only the id (Setup/Paused do not count as "live").
+        var liveSessionId = await _liveSessionRepository
+            .GetActiveInProgressSessionIdAsync(command.UserId, cancellationToken)
             .ConfigureAwait(false);
-        var liveSession = activeSessions.FirstOrDefault(s => s.Status == LiveSessionStatus.InProgress);
 
-        return liveSession is null
+        return liveSessionId is null
             ? new UpdatePlayRecordResult(false, null)
-            : new UpdatePlayRecordResult(true, liveSession.Id);
+            : new UpdatePlayRecordResult(true, liveSessionId.Value);
     }
 }

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/PlayRecords/UpdatePlayRecordCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/PlayRecords/UpdatePlayRecordCommandHandler.cs
@@ -1,5 +1,6 @@
 using Api.BoundedContexts.GameManagement.Application.Commands.PlayRecords;
 using Api.BoundedContexts.GameManagement.Application.Services;
+using Api.BoundedContexts.GameManagement.Domain.Enums;
 using Api.BoundedContexts.GameManagement.Domain.Repositories;
 using Api.BoundedContexts.GameManagement.Infrastructure.Persistence;
 using Api.Middleware.Exceptions;
@@ -15,13 +16,14 @@ namespace Api.BoundedContexts.GameManagement.Application.Commands.PlayRecords;
 /// Issue #2437-3: snapshot pre-edit state as a version before mutating, cap to 5 most-recent.
 /// Issue #2461: retry on version-number unique conflict (transparent server-side retry, no 500).
 /// </summary>
-internal class UpdatePlayRecordCommandHandler : ICommandHandler<UpdatePlayRecordCommand>
+internal class UpdatePlayRecordCommandHandler : ICommandHandler<UpdatePlayRecordCommand, UpdatePlayRecordResult>
 {
     private readonly IPlayRecordRepository _recordRepository;
     private readonly IPlayRecordVersionRepository _versionRepository;
     private readonly IUnitOfWork _unitOfWork;
     private readonly TimeProvider _timeProvider;
     private readonly PlayRecordPermissionChecker _permissionChecker;
+    private readonly ILiveSessionRepository _liveSessionRepository;
     private readonly Func<DbUpdateException, bool> _isVersionConflict;
 
     public UpdatePlayRecordCommandHandler(
@@ -29,9 +31,10 @@ internal class UpdatePlayRecordCommandHandler : ICommandHandler<UpdatePlayRecord
         IPlayRecordVersionRepository versionRepository,
         IUnitOfWork unitOfWork,
         TimeProvider timeProvider,
-        PlayRecordPermissionChecker permissionChecker)
+        PlayRecordPermissionChecker permissionChecker,
+        ILiveSessionRepository liveSessionRepository)
         : this(recordRepository, versionRepository, unitOfWork, timeProvider, permissionChecker,
-               PlayRecordVersionRepository.IsVersionNumberConflict)
+               liveSessionRepository, PlayRecordVersionRepository.IsVersionNumberConflict)
     {
     }
 
@@ -46,6 +49,7 @@ internal class UpdatePlayRecordCommandHandler : ICommandHandler<UpdatePlayRecord
         IUnitOfWork unitOfWork,
         TimeProvider timeProvider,
         PlayRecordPermissionChecker permissionChecker,
+        ILiveSessionRepository liveSessionRepository,
         Func<DbUpdateException, bool> isVersionConflict)
     {
         _recordRepository = recordRepository ?? throw new ArgumentNullException(nameof(recordRepository));
@@ -53,6 +57,7 @@ internal class UpdatePlayRecordCommandHandler : ICommandHandler<UpdatePlayRecord
         _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
         _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
         _permissionChecker = permissionChecker ?? throw new ArgumentNullException(nameof(permissionChecker));
+        _liveSessionRepository = liveSessionRepository ?? throw new ArgumentNullException(nameof(liveSessionRepository));
         _isVersionConflict = isVersionConflict ?? throw new ArgumentNullException(nameof(isVersionConflict));
     }
 
@@ -63,7 +68,7 @@ internal class UpdatePlayRecordCommandHandler : ICommandHandler<UpdatePlayRecord
     /// </summary>
     private const int MaxVersionConflictRetries = 5;
 
-    public async Task Handle(UpdatePlayRecordCommand command, CancellationToken cancellationToken)
+    public async Task<UpdatePlayRecordResult> Handle(UpdatePlayRecordCommand command, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(command);
 
@@ -132,5 +137,18 @@ internal class UpdatePlayRecordCommandHandler : ICommandHandler<UpdatePlayRecord
             command.RecordId, PlayRecordVersionSnapshotter.MaxVersions, cancellationToken)
             .ConfigureAwait(false);
         await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        // #13 / Invariante 4: the save is non-blocking, but if the same user has ANOTHER
+        // session genuinely live (InProgress) right now, surface a non-blocking warning so
+        // they can double-check the games were recorded in the right order. Setup/Paused are
+        // "active" per the repository but not "live" — only InProgress counts.
+        var activeSessions = await _liveSessionRepository
+            .GetActiveByUserIdAsync(command.UserId, cancellationToken)
+            .ConfigureAwait(false);
+        var liveSession = activeSessions.FirstOrDefault(s => s.Status == LiveSessionStatus.InProgress);
+
+        return liveSession is null
+            ? new UpdatePlayRecordResult(false, null)
+            : new UpdatePlayRecordResult(true, liveSession.Id);
     }
 }

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Repositories/ILiveSessionRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Repositories/ILiveSessionRepository.cs
@@ -13,6 +13,13 @@ internal interface ILiveSessionRepository
     Task<LiveGameSession?> GetByCodeAsync(string sessionCode, CancellationToken cancellationToken = default);
     Task<IReadOnlyList<LiveGameSession>> GetActiveByUserIdAsync(Guid userId, CancellationToken cancellationToken = default);
 
+    /// <summary>
+    /// #3146 / Invariante 4: projection-only lookup of the user's most-recent genuinely-LIVE
+    /// (InProgress) session id, or null. Avoids materializing the full aggregate graph on the
+    /// play-record save path where only the id is needed for the non-blocking warning deep-link.
+    /// </summary>
+    Task<Guid?> GetActiveInProgressSessionIdAsync(Guid userId, CancellationToken cancellationToken = default);
+
     /// <summary>Gets all active (in-progress) sessions across all users. Used by the auto-save background service.</summary>
     Task<IReadOnlyList<LiveGameSession>> GetAllActiveAsync(CancellationToken cancellationToken = default);
 

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Persistence/LiveSessionRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Persistence/LiveSessionRepository.cs
@@ -86,6 +86,20 @@ internal sealed class LiveSessionRepository : RepositoryBase, ILiveSessionReposi
         return entities.Select(LiveGameSessionMapper.ToDomain).ToList();
     }
 
+    public async Task<Guid?> GetActiveInProgressSessionIdAsync(
+        Guid userId, CancellationToken cancellationToken = default)
+    {
+        // #3146: projection-only — no Includes, no domain mapping. Only genuinely LIVE
+        // (InProgress) counts (Setup/Paused excluded, unlike GetActiveByUserIdAsync).
+        return await DbContext.LiveGameSessions
+            .AsNoTracking()
+            .Where(e => e.CreatedByUserId == userId && e.Status == (int)LiveSessionStatus.InProgress)
+            .OrderByDescending(e => e.UpdatedAt)
+            .Select(e => (Guid?)e.Id)
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
     public async Task<IReadOnlyList<LiveGameSession>> GetAllActiveAsync(
         CancellationToken cancellationToken = default)
     {

--- a/apps/api/src/Api/Extensions/WebApplicationExtensions.cs
+++ b/apps/api/src/Api/Extensions/WebApplicationExtensions.cs
@@ -250,7 +250,9 @@ internal static class WebApplicationExtensions
                     )
                     .AllowAnyMethod()
                     .AllowCredentials()
-                    .WithExposedHeaders("X-Trace-Id", "X-Span-Id", "traceparent", "tracestate");
+                    // #3146 / Invariante 4: expose the non-blocking save-warning headers so the
+                    // cross-origin FE can read them (mirrors the Program.cs "web" policy).
+                    .WithExposedHeaders("X-Trace-Id", "X-Span-Id", "traceparent", "tracestate", "X-Warning-Code", "X-Live-Session-Id");
             });
         });
 

--- a/apps/api/src/Api/Program.cs
+++ b/apps/api/src/Api/Program.cs
@@ -515,7 +515,10 @@ builder.Services.AddCors(options =>
             )
             .AllowAnyMethod()
             .AllowCredentials()
-            .WithExposedHeaders("X-Trace-Id", "X-Span-Id", "traceparent", "tracestate"); // Issue #1563 (P0-3): Expose trace headers for frontend correlation
+            // Issue #1563 (P0-3): trace headers for frontend correlation.
+            // #3146 / Invariante 4: X-Warning-Code + X-Live-Session-Id must be exposed so the
+            // cross-origin FE (dev/demo :3000→:8080) can read the non-blocking save warning.
+            .WithExposedHeaders("X-Trace-Id", "X-Span-Id", "traceparent", "tracestate", "X-Warning-Code", "X-Live-Session-Id");
     });
 });
 

--- a/apps/api/src/Api/Routing/PlayRecordEndpoints.cs
+++ b/apps/api/src/Api/Routing/PlayRecordEndpoints.cs
@@ -240,7 +240,20 @@ internal static class PlayRecordEndpoints
         CancellationToken cancellationToken)
     {
         var command = new UpdatePlayRecordCommand(recordId, httpContext.User.GetUserId(), request.SessionDate, request.Notes, request.Location, request.Xmin);
-        await mediator.Send(command, cancellationToken).ConfigureAwait(false);
+        var result = await mediator.Send(command, cancellationToken).ConfigureAwait(false);
+
+        // #13 / Invariante 4: non-blocking warning when the save happened while the user has
+        // another session live (InProgress). The FE reads these headers on the 2xx and shows a
+        // 6s amber toast + a "go to live" deep-link built from X-Live-Session-Id.
+        if (result.SavedWhileLiveActive)
+        {
+            httpContext.Response.Headers["X-Warning-Code"] = "SAVED_WHILE_LIVE_ACTIVE";
+            if (result.LiveSessionId.HasValue)
+            {
+                httpContext.Response.Headers["X-Live-Session-Id"] = result.LiveSessionId.Value.ToString();
+            }
+        }
+
         return Results.NoContent();
     }
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/PlayRecords/UpdatePlayRecordCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/PlayRecords/UpdatePlayRecordCommandHandlerTests.cs
@@ -40,12 +40,12 @@ public class UpdatePlayRecordCommandHandlerTests
             PlayRecordVisibility.Private,
             SessionScoringConfig.CreateDefault());
 
-    /// <summary>Default live-session repo mock: the user has no active live session.</summary>
+    /// <summary>Default live-session repo mock: the user has no live (InProgress) session.</summary>
     private static Mock<ILiveSessionRepository> NoActiveLiveRepo()
     {
         var live = new Mock<ILiveSessionRepository>();
-        live.Setup(r => r.GetActiveByUserIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(Array.Empty<LiveGameSession>());
+        live.Setup(r => r.GetActiveInProgressSessionIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Guid?)null);
         return live;
     }
 
@@ -86,15 +86,6 @@ public class UpdatePlayRecordCommandHandlerTests
             isVersionConflict);
     }
 
-    /// <summary>Builds a genuinely-live (InProgress) session owned by <paramref name="userId"/>.</summary>
-    private static LiveGameSession MakeInProgressLive(Guid userId, Guid liveId)
-    {
-        var live = LiveGameSession.Create(liveId, userId, "Wingspan");
-        live.AddPlayer(userId, "Host", PlayerColor.Red);
-        live.Start();
-        return live;
-    }
-
     private static (Mock<IPlayRecordRepository>, Mock<IPlayRecordVersionRepository>, Mock<IUnitOfWork>) EditableRecordMocks(PlayRecord record)
     {
         var repo = new Mock<IPlayRecordRepository>();
@@ -115,8 +106,8 @@ public class UpdatePlayRecordCommandHandlerTests
         var (repo, versionRepo, uow) = EditableRecordMocks(record);
         var liveId = Guid.NewGuid();
         var liveRepo = new Mock<ILiveSessionRepository>();
-        liveRepo.Setup(r => r.GetActiveByUserIdAsync(CreatorId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new[] { MakeInProgressLive(CreatorId, liveId) });
+        liveRepo.Setup(r => r.GetActiveInProgressSessionIdAsync(CreatorId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(liveId);
 
         var result = await CreateSut(repo, versionRepo, uow, liveRepo: liveRepo).Handle(
             new UpdatePlayRecordCommand(record.Id, CreatorId, Notes: "x"), CancellationToken.None);
@@ -136,22 +127,6 @@ public class UpdatePlayRecordCommandHandlerTests
 
         result.SavedWhileLiveActive.Should().BeFalse();
         result.LiveSessionId.Should().BeNull();
-    }
-
-    [Fact]
-    public async Task Handle_OnlyNonInProgressActive_DoesNotFlagWarning()
-    {
-        // A Created (not-yet-live) session must NOT trigger the warning — only InProgress counts.
-        var record = MakeRecord();
-        var (repo, versionRepo, uow) = EditableRecordMocks(record);
-        var liveRepo = new Mock<ILiveSessionRepository>();
-        liveRepo.Setup(r => r.GetActiveByUserIdAsync(CreatorId, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new[] { LiveGameSession.Create(Guid.NewGuid(), CreatorId, "Azul") });
-
-        var result = await CreateSut(repo, versionRepo, uow, liveRepo: liveRepo).Handle(
-            new UpdatePlayRecordCommand(record.Id, CreatorId, Notes: "x"), CancellationToken.None);
-
-        result.SavedWhileLiveActive.Should().BeFalse();
     }
 
     // -------------------------------------------------------------------------

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/PlayRecords/UpdatePlayRecordCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/PlayRecords/UpdatePlayRecordCommandHandlerTests.cs
@@ -40,18 +40,29 @@ public class UpdatePlayRecordCommandHandlerTests
             PlayRecordVisibility.Private,
             SessionScoringConfig.CreateDefault());
 
+    /// <summary>Default live-session repo mock: the user has no active live session.</summary>
+    private static Mock<ILiveSessionRepository> NoActiveLiveRepo()
+    {
+        var live = new Mock<ILiveSessionRepository>();
+        live.Setup(r => r.GetActiveByUserIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<LiveGameSession>());
+        return live;
+    }
+
     private static UpdatePlayRecordCommandHandler CreateSut(
         Mock<IPlayRecordRepository> repo,
         Mock<IPlayRecordVersionRepository> versionRepo,
         Mock<IUnitOfWork> uow,
-        TimeProvider? timeProvider = null)
+        TimeProvider? timeProvider = null,
+        Mock<ILiveSessionRepository>? liveRepo = null)
     {
         return new UpdatePlayRecordCommandHandler(
             repo.Object,
             versionRepo.Object,
             uow.Object,
             timeProvider ?? TimeProvider.System,
-            new PlayRecordPermissionChecker(repo.Object));
+            new PlayRecordPermissionChecker(repo.Object),
+            (liveRepo ?? NoActiveLiveRepo()).Object);
     }
 
     /// <summary>
@@ -71,7 +82,76 @@ public class UpdatePlayRecordCommandHandlerTests
             uow.Object,
             timeProvider ?? TimeProvider.System,
             new PlayRecordPermissionChecker(repo.Object),
+            NoActiveLiveRepo().Object,
             isVersionConflict);
+    }
+
+    /// <summary>Builds a genuinely-live (InProgress) session owned by <paramref name="userId"/>.</summary>
+    private static LiveGameSession MakeInProgressLive(Guid userId, Guid liveId)
+    {
+        var live = LiveGameSession.Create(liveId, userId, "Wingspan");
+        live.AddPlayer(userId, "Host", PlayerColor.Red);
+        live.Start();
+        return live;
+    }
+
+    private static (Mock<IPlayRecordRepository>, Mock<IPlayRecordVersionRepository>, Mock<IUnitOfWork>) EditableRecordMocks(PlayRecord record)
+    {
+        var repo = new Mock<IPlayRecordRepository>();
+        repo.Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>())).ReturnsAsync(record);
+        repo.Setup(r => r.CanUserEditAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        return (repo, new Mock<IPlayRecordVersionRepository>(), new Mock<IUnitOfWork>());
+    }
+
+    // -------------------------------------------------------------------------
+    // #13 / Invariante 4 — draft-save-while-live warning
+    // -------------------------------------------------------------------------
+
+    [Fact]
+    public async Task Handle_UserHasInProgressLive_FlagsSavedWhileLiveActiveWithSessionId()
+    {
+        var record = MakeRecord();
+        var (repo, versionRepo, uow) = EditableRecordMocks(record);
+        var liveId = Guid.NewGuid();
+        var liveRepo = new Mock<ILiveSessionRepository>();
+        liveRepo.Setup(r => r.GetActiveByUserIdAsync(CreatorId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { MakeInProgressLive(CreatorId, liveId) });
+
+        var result = await CreateSut(repo, versionRepo, uow, liveRepo: liveRepo).Handle(
+            new UpdatePlayRecordCommand(record.Id, CreatorId, Notes: "x"), CancellationToken.None);
+
+        result.SavedWhileLiveActive.Should().BeTrue();
+        result.LiveSessionId.Should().Be(liveId);
+    }
+
+    [Fact]
+    public async Task Handle_NoActiveLive_DoesNotFlagWarning()
+    {
+        var record = MakeRecord();
+        var (repo, versionRepo, uow) = EditableRecordMocks(record);
+
+        var result = await CreateSut(repo, versionRepo, uow).Handle(
+            new UpdatePlayRecordCommand(record.Id, CreatorId, Notes: "x"), CancellationToken.None);
+
+        result.SavedWhileLiveActive.Should().BeFalse();
+        result.LiveSessionId.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_OnlyNonInProgressActive_DoesNotFlagWarning()
+    {
+        // A Created (not-yet-live) session must NOT trigger the warning — only InProgress counts.
+        var record = MakeRecord();
+        var (repo, versionRepo, uow) = EditableRecordMocks(record);
+        var liveRepo = new Mock<ILiveSessionRepository>();
+        liveRepo.Setup(r => r.GetActiveByUserIdAsync(CreatorId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { LiveGameSession.Create(Guid.NewGuid(), CreatorId, "Azul") });
+
+        var result = await CreateSut(repo, versionRepo, uow, liveRepo: liveRepo).Handle(
+            new UpdatePlayRecordCommand(record.Id, CreatorId, Notes: "x"), CancellationToken.None);
+
+        result.SavedWhileLiveActive.Should().BeFalse();
     }
 
     // -------------------------------------------------------------------------

--- a/apps/web/src/app/(authenticated)/play-records/[id]/edit/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/play-records/[id]/edit/page.test.tsx
@@ -453,6 +453,35 @@ describe('EditPlayRecordPage', () => {
     expect(mockRouterPush).toHaveBeenCalledWith('/sessions/live-1/live');
   });
 
+  it('#13: fires the warning toast WITHOUT an action when liveSessionId is missing', async () => {
+    const user = userEvent.setup();
+    mockUseUpdateRecord.mockReturnValue({
+      mutateAsync: vi
+        .fn()
+        .mockResolvedValue({ warningCode: 'SAVED_WHILE_LIVE_ACTIVE', liveSessionId: undefined }),
+      isPending: false,
+    });
+
+    const queryClient = new QueryClient();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <EditPlayRecordPage />
+      </QueryClientProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('session-form')).toBeInTheDocument();
+    });
+    await user.click(screen.getByTestId('session-form').querySelector('button[type="submit"]')!);
+
+    await waitFor(() => {
+      expect(toast.warning).toHaveBeenCalledTimes(1);
+    });
+    const [, opts] = (toast.warning as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(opts).toMatchObject({ duration: 6000 });
+    expect(opts.action).toBeUndefined();
+  });
+
   it('#13: does NOT fire the warning toast on a normal save (no warning code)', async () => {
     const user = userEvent.setup();
     mockUseUpdateRecord.mockReturnValue({

--- a/apps/web/src/app/(authenticated)/play-records/[id]/edit/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/play-records/[id]/edit/page.test.tsx
@@ -17,6 +17,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { toast } from 'sonner';
 
 import EditPlayRecordPage from './page';
 import { playRecordsEditMessages } from '@/__tests__/fixtures/i18n-test-messages';
@@ -414,6 +415,67 @@ describe('EditPlayRecordPage', () => {
     await waitFor(() => {
       expect(screen.getByText(/Failed to load record/i)).toBeInTheDocument();
     });
+  });
+
+  it('#13: fires the non-blocking amber toast + go-to-live action on SAVED_WHILE_LIVE_ACTIVE', async () => {
+    const user = userEvent.setup();
+
+    // The update succeeds but the user had another session live → warning headers.
+    mockUseUpdateRecord.mockReturnValue({
+      mutateAsync: vi
+        .fn()
+        .mockResolvedValue({ warningCode: 'SAVED_WHILE_LIVE_ACTIVE', liveSessionId: 'live-1' }),
+      isPending: false,
+    });
+
+    const queryClient = new QueryClient();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <EditPlayRecordPage />
+      </QueryClientProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('session-form')).toBeInTheDocument();
+    });
+
+    const form = screen.getByTestId('session-form');
+    await user.click(form.querySelector('button[type="submit"]')!);
+
+    await waitFor(() => {
+      expect(toast.warning).toHaveBeenCalledTimes(1);
+    });
+    const [, opts] = (toast.warning as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(opts).toMatchObject({ duration: 6000 });
+    expect(opts.action).toMatchObject({ label: expect.any(String) });
+    // The action deep-links to the live session.
+    opts.action.onClick();
+    expect(mockRouterPush).toHaveBeenCalledWith('/sessions/live-1/live');
+  });
+
+  it('#13: does NOT fire the warning toast on a normal save (no warning code)', async () => {
+    const user = userEvent.setup();
+    mockUseUpdateRecord.mockReturnValue({
+      mutateAsync: vi.fn().mockResolvedValue({ warningCode: undefined, liveSessionId: undefined }),
+      isPending: false,
+    });
+
+    const queryClient = new QueryClient();
+    render(
+      <QueryClientProvider client={queryClient}>
+        <EditPlayRecordPage />
+      </QueryClientProvider>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('session-form')).toBeInTheDocument();
+    });
+    await user.click(screen.getByTestId('session-form').querySelector('button[type="submit"]')!);
+
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalled();
+    });
+    expect(toast.warning).not.toHaveBeenCalled();
   });
 
   it('#2437-1: shows conflict dialog when updateRecord rejects with kind="conflict"', async () => {

--- a/apps/web/src/app/(authenticated)/play-records/[id]/edit/page.tsx
+++ b/apps/web/src/app/(authenticated)/play-records/[id]/edit/page.tsx
@@ -57,13 +57,29 @@ export default function EditPlayRecordPage() {
       location: data.location,
       xmin,
     });
-    await updateMutation.mutateAsync(validated);
+    const result = await updateMutation.mutateAsync(validated);
     queryClient.invalidateQueries({ queryKey: ['play-records', 'detail', recordId] });
     queryClient.invalidateQueries({ queryKey: ['play-records', 'history'] });
     queryClient.invalidateQueries({ queryKey: ['play-records', 'stats'] });
     toast.success(t('playRecords.edit.success.toast'), {
       description: t('playRecords.edit.success.toastDescription'),
     });
+    // #13 / Invariante 4: non-blocking amber warning when the save happened while the
+    // user had another session live. Additive to the success toast; the deep-link jumps
+    // to that live session so they can double-check the recording order.
+    if (result?.warningCode === 'SAVED_WHILE_LIVE_ACTIVE') {
+      toast.warning(t('playRecords.edit.savedWhileLive.toast'), {
+        duration: 6000,
+        ...(result.liveSessionId
+          ? {
+              action: {
+                label: t('playRecords.edit.savedWhileLive.goToLive'),
+                onClick: () => router.push(`/sessions/${result.liveSessionId}/live`),
+              },
+            }
+          : {}),
+      });
+    }
     router.push(`/play-records/${recordId}`);
   };
 

--- a/apps/web/src/lib/api/__tests__/play-records-update-conflict.test.ts
+++ b/apps/web/src/lib/api/__tests__/play-records-update-conflict.test.ts
@@ -19,6 +19,34 @@ describe('playRecordsApi.updateRecord conflict handling (#2437-1)', () => {
     expect(body.xmin).toBe(99);
   });
 
+  // #13 / Invariante 4: a 2xx save carries the non-blocking warning headers.
+  it('surfaces X-Warning-Code + X-Live-Session-Id on a 2xx save (SAVED_WHILE_LIVE_ACTIVE)', async () => {
+    const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>;
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 204,
+      headers: new Headers({
+        'X-Warning-Code': 'SAVED_WHILE_LIVE_ACTIVE',
+        'X-Live-Session-Id': 'live-abc',
+      }),
+      json: async () => ({}),
+    });
+    const result = await playRecordsApi.updateRecord('r1', { notes: 'hi' });
+    expect(result).toEqual({ warningCode: 'SAVED_WHILE_LIVE_ACTIVE', liveSessionId: 'live-abc' });
+  });
+
+  it('returns undefined warning fields on a normal 2xx save (no headers)', async () => {
+    const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>;
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 204,
+      headers: new Headers(),
+      json: async () => ({}),
+    });
+    const result = await playRecordsApi.updateRecord('r1', { notes: 'hi' });
+    expect(result).toEqual({ warningCode: undefined, liveSessionId: undefined });
+  });
+
   it('throws UpdatePlayRecordError kind=conflict on 409 with X-Warning-Code', async () => {
     const fetchMock = fetch as unknown as ReturnType<typeof vi.fn>;
     fetchMock.mockResolvedValue({

--- a/apps/web/src/lib/api/play-records.api.ts
+++ b/apps/web/src/lib/api/play-records.api.ts
@@ -36,6 +36,17 @@ export class UpdatePlayRecordError extends Error {
   }
 }
 
+/**
+ * #13 / Invariante 4: a successful update carries a non-blocking warning when the
+ * user had another session live (InProgress) at save time. `warningCode` is
+ * `'SAVED_WHILE_LIVE_ACTIVE'` in that case and `liveSessionId` is the live
+ * session's id for the "go to live" deep-link. Both undefined on a normal save.
+ */
+export interface UpdatePlayRecordSuccess {
+  readonly warningCode?: string;
+  readonly liveSessionId?: string;
+}
+
 export interface UploadPlayRecordPhotoResult {
   photoId: string;
   photoUrl: string;
@@ -132,14 +143,24 @@ export const playRecordsApi = {
    * #2437-1: Sends optional `xmin` for optimistic-concurrency; throws `UpdatePlayRecordError`
    * with `kind='conflict'` on 409 + `X-Warning-Code: concurrent-edit`.
    */
-  async updateRecord(recordId: string, updates: UpdatePlayRecordRequest): Promise<void> {
+  async updateRecord(
+    recordId: string,
+    updates: UpdatePlayRecordRequest
+  ): Promise<UpdatePlayRecordSuccess> {
     const res = await fetch(`${BASE_URL}/${recordId}`, {
       method: 'PUT',
       headers: { 'Content-Type': 'application/json' },
       credentials: 'include',
       body: JSON.stringify(updates),
     });
-    if (res.ok) return;
+    // #13: on success, surface the non-blocking warning headers (if any) instead of
+    // discarding them — the caller fires the "saved while live" amber toast.
+    if (res.ok) {
+      return {
+        warningCode: res.headers.get('X-Warning-Code') ?? undefined,
+        liveSessionId: res.headers.get('X-Live-Session-Id') ?? undefined,
+      };
+    }
     const warningCode = res.headers.get('X-Warning-Code') ?? undefined;
     if (res.status === 409) {
       throw new UpdatePlayRecordError(

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -4988,6 +4988,10 @@
         "deleteToast": "Record deleted",
         "deleteToastDescription": "The record was deleted successfully"
       },
+      "savedWhileLive": {
+        "toast": "Record saved while a session is live. Double-check you logged the games in the right order.",
+        "goToLive": "Go to the live session"
+      },
       "conflict": {
         "title": "Concurrent edit",
         "description": "Someone modified this game while you were editing. Reload the latest data or overwrite with your changes.",

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -5000,6 +5000,10 @@
         "deleteToast": "Partita eliminata",
         "deleteToastDescription": "La partita è stata eliminata correttamente"
       },
+      "savedWhileLive": {
+        "toast": "Partita salvata mentre una session è live. Verifica di aver registrato le partite nell'ordine corretto.",
+        "goToLive": "Vai alla session live"
+      },
       "conflict": {
         "title": "Modifica concorrente",
         "description": "Qualcuno ha modificato questa partita mentre la stavi modificando. Ricarica i dati aggiornati o sovrascrivi con le tue modifiche.",


### PR DESCRIPTION
## Cosa

**Wave 3 · Slice 3** (di #3146) — domain **Invariante 4** (#13): salvare un play-record mentre lo stesso utente ha un'altra session **live (InProgress)** è permesso ma **non-bloccante** → il FE mostra un toast ambra 6s + un deep-link "Vai alla session live". Non era implementato né BE né FE.

## Backend (GameManagement)
- `UpdatePlayRecordCommand` ora ritorna `UpdatePlayRecordResult { SavedWhileLiveActive, LiveSessionId }`. Il handler usa `ILiveSessionRepository.GetActiveInProgressSessionIdAsync(userId)` (projection-only, no Includes, solo InProgress — **per-utente**, non il guard bloccante per-GameNight #10).
- `PlayRecordEndpoints.HandleUpdateRecord` setta `X-Warning-Code: SAVED_WHILE_LIVE_ACTIVE` + `X-Live-Session-Id` sul 2xx quando flaggato.
- **CORS**: entrambi gli header aggiunti a `WithExposedHeaders` (Program.cs + WebApplicationExtensions.cs) — senza, il FE cross-origin non li leggerebbe.

## Frontend
- `playRecordsApi.updateRecord` ritorna `{ warningCode, liveSessionId }` (legge gli header sul 2xx).
- L'edit page spara `toast.warning` (6s) + action "Vai alla session live" → `/sessions/{liveId}/live`, additivo al success toast.
- Chiavi i18n it/en `playRecords.edit.savedWhileLive.*`.

## Review adversariale (3 finding fixati)
HIGH CORS expose-headers · LOW projection-only repo (evita eager-load pesante) · NIT test no-action branch.

## Test
TDD: 3 handler test + 2 api-client + 3 edit-page. **17 handler + 17 FE** verdi; Api build pulito (analyzer), typecheck + lint + JSON validi.

Refs #3146 (tracking — chiudibile al merge: completa i 3 slice della wave 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)