### PR TITLE
fix(ledger-mode): map concurrent-edit conflict to 409 instead of 500 (#3159)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/ConfirmStateChangeCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/ConfirmStateChangeCommandHandler.cs
@@ -95,9 +95,11 @@ internal sealed class ConfirmStateChangeCommandHandler
                 "Concurrency conflict for session {SessionId}. State was modified by another user.",
                 command.SessionId);
 
-            throw new InvalidOperationException(
-                "The game state was modified by another user. Please refresh and try again.",
-                ex);
+            // #3159: propagate the DbUpdateConcurrencyException so the middleware
+            // (ApiExceptionHandlerMiddleware.HandleConcurrencyConflictAsync) maps it to HTTP 409 with
+            // header X-Warning-Code: concurrent-edit, enabling the FE "reload & retry" prompt.
+            // Wrapping it as InvalidOperationException made the middleware return 500.
+            throw;
         }
 
         _logger.LogInformation(

--- a/apps/api/src/Api/Routing/LedgerModeEndpoints.cs
+++ b/apps/api/src/Api/Routing/LedgerModeEndpoints.cs
@@ -105,6 +105,7 @@ internal static class LedgerModeEndpoints
         .Produces(400)
         .Produces(401)
         .Produces(404)
+        .Produces(409) // #3159: optimistic-concurrency conflict → X-Warning-Code: concurrent-edit
         .Produces(500);
     }
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/ConfirmStateChangeCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/ConfirmStateChangeCommandHandlerTests.cs
@@ -268,7 +268,7 @@ public class ConfirmStateChangeCommandHandlerTests
     #region Concurrency Tests
 
     [Fact]
-    public async Task Handle_WithConcurrencyConflict_ThrowsInvalidOperationException()
+    public async Task Handle_WithConcurrencyConflict_PropagatesDbUpdateConcurrencyException()
     {
         // Arrange
         var sessionId = Guid.NewGuid();
@@ -283,12 +283,12 @@ public class ConfirmStateChangeCommandHandlerTests
         var stateChanges = new Dictionary<string, object> { { "score", 10 } };
         var command = new ConfirmStateChangeCommand(sessionId, stateChanges, userId);
 
-        // Act & Assert
+        // Act & Assert — #3159: the handler must PROPAGATE DbUpdateConcurrencyException so the
+        // middleware (ApiExceptionHandlerMiddleware.HandleConcurrencyConflictAsync) maps it to
+        // HTTP 409 with header X-Warning-Code: concurrent-edit. Wrapping it as
+        // InvalidOperationException made the middleware return 500, hiding the "reload & retry" prompt.
         Func<Task> act = async () => await _handler.Handle(command, TestCancellationToken);
-        var exception = (await act.Should().ThrowAsync<InvalidOperationException>()).Which;
-
-        exception.Message.Should().Contain("modified by another user");
-        exception.InnerException.Should().BeOfType<DbUpdateConcurrencyException>();
+        await act.Should().ThrowAsync<DbUpdateConcurrencyException>();
     }
 
     #endregion


### PR DESCRIPTION
Closes #3159

## Problema
`ConfirmStateChangeCommandHandler` catturava `DbUpdateConcurrencyException` e la ri-lanciava come `InvalidOperationException` → il middleware la mappava a **HTTP 500**. L'endpoint `POST /api/v1/sessions/{id}/ledger/confirm` ritornava quindi 500 su edit concorrente, impedendo al FE il prompt "reload & retry".

Il middleware ha già un handler dedicato (`ApiExceptionHandlerMiddleware.HandleConcurrencyConflictAsync`) che mappa `DbUpdateConcurrencyException` → **409** con header `X-Warning-Code: concurrent-edit` — il wrap lo neutralizzava.

## Fix
- Mantenuto il log di warning, ma propagata l'eccezione originale (`throw;`) invece di trasformarla.
- Endpoint ora dichiara `.Produces(409)`.

## Test (TDD)
- Riscritto `Handle_WithConcurrencyConflict_*` per asserire la propagazione di `DbUpdateConcurrencyException` (RED→GREEN verificato).
- Classe `ConfirmStateChangeCommandHandlerTests`: **17/17 verdi**, 0 regressioni.

🤖 Generated with [Claude Code](https://claude.com/claude-code)