### PR TITLE
fix(design-tokens): register entity-document in @theme so kb color renders (#3161)

### DIFF
--- a/apps/web/src/components/ui/entity-tokens.test.ts
+++ b/apps/web/src/components/ui/entity-tokens.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { ENTITY_TOKENS, getEntityToken, type EntityType } from './entity-tokens';
 
 describe('entity-tokens', () => {
@@ -29,5 +31,25 @@ describe('entity-tokens', () => {
 
   it('returns emoji for toolkit as 🧰', () => {
     expect(getEntityToken('toolkit').emoji).toBe('🧰');
+  });
+
+  // #3161: In Tailwind v4, only CSS variables declared inside an @theme block emit
+  // `entity-<key>` utilities. `kb` maps to the tailwind class `document`, but
+  // `--color-entity-document` was missing from the @theme inline block (it lived only in
+  // a plain :root in design-tokens.css), so `bg/text/border/ring-entity-document` produced
+  // no CSS and the knowledge-base accent silently resolved to nothing.
+  it('registers a @theme entity utility for every tailwind key (TW v4)', () => {
+    const globalsCss = readFileSync(resolve(process.cwd(), 'src/styles/globals.css'), 'utf8');
+    const themeStart = globalsCss.indexOf('@theme inline');
+    expect(themeStart).toBeGreaterThan(-1);
+    const braceStart = globalsCss.indexOf('{', themeStart);
+    const braceEnd = globalsCss.indexOf('}', braceStart);
+    const themeBlock = globalsCss.slice(braceStart, braceEnd);
+
+    const missing = ENTITY_TOKENS.map(t => getEntityToken(t).bg.replace('bg-entity-', '')).filter(
+      key => !themeBlock.includes(`--color-entity-${key}:`)
+    );
+
+    expect(missing).toEqual([]);
   });
 });

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -545,6 +545,10 @@
   --color-entity-agent-text: hsl(var(--c-agent-text));     /* #2955: AA text-on-tint */
   --color-entity-kb:      hsl(var(--c-kb));
   --color-entity-kb-text: hsl(var(--c-kb-text));           /* #2955: AA text-on-tint */
+  /* #3161: `kb` maps to the tailwind class `document` (entity-tokens.ts). Alias it to the
+     kb color here so `entity-document` utilities actually emit in TW v4 (only @theme vars do). */
+  --color-entity-document:      hsl(var(--c-kb));
+  --color-entity-document-text: hsl(var(--c-kb-text));
   --color-entity-chat:    hsl(var(--c-chat));
   --color-entity-chat-text: hsl(var(--c-chat-text));       /* #2955: AA text-on-tint */
   --color-entity-event:   hsl(var(--c-event));


### PR DESCRIPTION
Closes #3161

## Problema
L'entity `kb` renderizza via l'alias di classe `document` (`entity-tokens.ts` mappa `kb -> document`), ma `--color-entity-document` mancava dal blocco `@theme inline` di `globals.css` (viveva solo in un `:root` di `design-tokens.css`). In Tailwind v4 **solo** le variabili in `@theme` emettono utility, quindi `bg/text/border/ring-entity-document` non producevano CSS e l'accento "knowledge-base" (gamebook cards, kb-rules-quick-glance, kpi kb) risolveva a nulla.

## Fix
Aliasato `--color-entity-document` a `--c-kb` dentro `@theme inline` (kb e document sono lo stesso concetto/colore; `entity-table-view` migrò document→kb in #2955). **Zero modifiche ai consumer.**

## Test (TDD)
- Nuovo regression guard in `entity-tokens.test.ts`: ogni valore di `TAILWIND_KEY` deve avere un `--color-entity-<key>` registrato nel blocco `@theme inline`. RED reale verificato (`missing=['document']`) → GREEN.
- Suite consumer (gamebook, kpi-stat-grid, entity-*): **635 passed**, 0 regressioni.

🤖 Generated with [Claude Code](https://claude.com/claude-code)