### PR TITLE
fix(shared-games): map concurrent rulebook analysis to 409 instead of 500 (#3163)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/AnalyzeRulebookCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/AnalyzeRulebookCommandHandler.cs
@@ -278,8 +278,10 @@ internal sealed class AnalyzeRulebookCommandHandler
                 "Analysis already in progress for game {GameId}, PDF {PdfId}",
                 sharedGameId, pdfDocumentId);
 
-            throw new InvalidOperationException(
-                $"Rulebook analysis already in progress. Please wait for completion.");
+            // #3163: a concurrent analysis (lock already held) is a conflict (409), not a server
+            // error (500). Mirror the ConflictException used for the timeout case above (:265).
+            throw new ConflictException(
+                "Rulebook analysis already in progress. Please wait for completion.");
         }
 
         return AnalyzeRulebookResultDto.CreateBackgroundTask(taskId);

--- a/apps/api/src/Api/Routing/RulebookAnalysisEndpoints.cs
+++ b/apps/api/src/Api/Routing/RulebookAnalysisEndpoints.cs
@@ -22,7 +22,8 @@ internal static class RulebookAnalysisEndpoints
             .Produces<AnalyzeRulebookResultDto>(StatusCodes.Status200OK)
             .Produces(StatusCodes.Status400BadRequest)
             .Produces(StatusCodes.Status401Unauthorized)
-            .Produces(StatusCodes.Status404NotFound);
+            .Produces(StatusCodes.Status404NotFound)
+            .Produces(StatusCodes.Status409Conflict); // #3163: analysis already in progress / non-analyzable category
 
         // GET /api/v1/documents/{documentId}/analysis
         group.MapGet("/documents/{documentId:guid}/analysis", HandleGetActiveAnalysis)

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/AnalyzeRulebookCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/AnalyzeRulebookCommandHandlerTests.cs
@@ -1,0 +1,84 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Commands;
+using Api.BoundedContexts.SharedGameCatalog.Application.Configuration;
+using Api.BoundedContexts.SharedGameCatalog.Application.Services;
+using Api.BoundedContexts.SharedGameCatalog.Application.Services.BackgroundAnalysis;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Infrastructure.BackgroundTasks;
+using Api.Middleware.Exceptions;
+using Api.Services;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Commands;
+
+/// <summary>
+/// Unit tests for <see cref="AnalyzeRulebookCommandHandler"/>.
+/// Issue #3163 — a concurrent analysis (distributed lock not acquired) must map to
+/// HTTP 409 (ConflictException), not HTTP 500 (InvalidOperationException).
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+public class AnalyzeRulebookCommandHandlerTests
+{
+    private static CancellationToken TestCancellationToken => TestContext.Current.CancellationToken;
+
+    [Fact]
+    public async Task Handle_WhenBackgroundLockNotAcquired_ThrowsConflictException()
+    {
+        // Arrange
+        var sharedGameId = Guid.NewGuid();
+        var pdfDocumentId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
+
+        var gameRepo = new Mock<ISharedGameRepository>();
+        var game = SharedGame.CreateSkeleton("Test Game", userId, TimeProvider.System);
+        gameRepo
+            .Setup(r => r.GetByIdAsync(sharedGameId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(game);
+
+        var analysisRepo = new Mock<IRulebookAnalysisRepository>();
+        analysisRepo
+            .Setup(r => r.GetPdfDocumentCategoryAsync(pdfDocumentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string?)null);
+        // Long, OCR-heavy text (single-char words) → complexity score > 0.4 threshold
+        // → RoutingDecision.Background, which is the branch that acquires the distributed lock.
+        var complexContent = string.Concat(Enumerable.Repeat("x y z w ", 20000));
+        analysisRepo
+            .Setup(r => r.GetPdfTextAsync(pdfDocumentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(complexContent);
+
+        var taskOrchestrator = new Mock<IBackgroundTaskOrchestrator>();
+        // Lock already held by a concurrent analysis → ExecuteWithDistributedLockAsync returns false.
+        taskOrchestrator
+            .Setup(o => o.ExecuteWithDistributedLockAsync(
+                It.IsAny<string>(),
+                It.IsAny<Func<CancellationToken, Task>>(),
+                It.IsAny<TimeSpan>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var handler = new AnalyzeRulebookCommandHandler(
+            gameRepo.Object,
+            analysisRepo.Object,
+            Mock.Of<IRulebookAnalyzer>(),
+            Mock.Of<IBackgroundRulebookAnalysisOrchestrator>(),
+            taskOrchestrator.Object,
+            Mock.Of<IUnitOfWork>(),
+            Mock.Of<IHybridCacheService>(),
+            Options.Create(new BackgroundAnalysisOptions()),
+            Mock.Of<ILogger<AnalyzeRulebookCommandHandler>>());
+
+        var command = new AnalyzeRulebookCommand(pdfDocumentId, sharedGameId, userId);
+
+        // Act & Assert — #3163: a concurrent analysis is a conflict (409), not a server error (500).
+        await FluentActions
+            .Awaiting(() => handler.Handle(command, TestCancellationToken))
+            .Should()
+            .ThrowAsync<ConflictException>();
+    }
+}


### PR DESCRIPTION
Closes #3163

## Problema
`AnalyzeRulebookCommandHandler` lanciava `InvalidOperationException` quando il lock distribuito era già occupato (analisi concorrente in corso) → il middleware la mappava a **HTTP 500**. Un'analisi concorrente è un conflitto (**409**): lo stesso file usa già `ConflictException` per il caso timeout (`:265`).

## Fix
- `ConflictException` (→ 409) invece di `InvalidOperationException`.
- Endpoint `AnalyzeRulebook` ora dichiara `.Produces(409)`.

## Test (TDD)
- Nuovo `AnalyzeRulebookCommandHandlerTests`: guida il branch di routing Background (testo OCR-heavy → complexity > 0.4) con il lock che ritorna `false`, e asserisce `ConflictException`. RED reale verificato (`InvalidOperationException: Rulebook analysis already in progress`) → GREEN. 13/13 verdi.

_Sostituisce #3157 nella selezione /sc:spec-panel (rivelatasi refactoring di dominio a 3 assi — analisi documentata su #3157)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)