### PR TITLE
fix(i18n): add missing playerDetail trend section to it/en catalogs (#3166)

### DIFF
--- a/apps/web/src/locales/__tests__/index.test.ts
+++ b/apps/web/src/locales/__tests__/index.test.ts
@@ -61,4 +61,50 @@ describe('i18n locales', () => {
       expect(enKeys).toEqual(itKeys);
     }
   );
+
+  // Issue #3166: PlayerDetailView builds trendLabels via a non-scoped
+  // t('pages.playerDetail.sections.trend.*') with no defaultMessage, so a missing section
+  // makes PlayerTrendCard render raw ids (title, deltas, aria-labels, 12 month labels).
+  describe('pages.playerDetail.sections.trend (Issue #3166)', () => {
+    const EXPECTED_KEYS = [
+      'title',
+      'deltaUp',
+      'deltaDown',
+      'deltaFlat',
+      'deltaUpAriaLabel',
+      'deltaDownAriaLabel',
+      'deltaFlatAriaLabel',
+      'empty',
+      'trendSummaryAriaLabel',
+      'monthsShort.jan',
+      'monthsShort.feb',
+      'monthsShort.mar',
+      'monthsShort.apr',
+      'monthsShort.may',
+      'monthsShort.jun',
+      'monthsShort.jul',
+      'monthsShort.aug',
+      'monthsShort.sep',
+      'monthsShort.oct',
+      'monthsShort.nov',
+      'monthsShort.dec',
+    ].sort();
+
+    const navigateToTrend = (catalog: Record<string, unknown>): unknown =>
+      ['pages', 'playerDetail', 'sections', 'trend'].reduce<unknown>(
+        (acc, key) => (acc as Record<string, unknown> | undefined)?.[key],
+        catalog
+      );
+
+    it.each([
+      ['it', LOCALES.IT],
+      ['en', LOCALES.EN],
+    ])('has the full trend section in the %s catalog', (name, locale) => {
+      const section = navigateToTrend(getMessages(locale) as Record<string, unknown>);
+      expect(section, `${name}.json is missing pages.playerDetail.sections.trend`).toBeDefined();
+
+      const keys = Object.keys(flattenMessages(section as Record<string, unknown>)).sort();
+      expect(keys).toEqual(EXPECTED_KEYS);
+    });
+  });
 });

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -2985,6 +2985,31 @@
           "viewAll": "View all",
           "viewAllAriaLabel": "View all achievements for {playerName}",
           "empty": "No achievements yet"
+        },
+        "trend": {
+          "title": "Trend",
+          "deltaUp": "↗ +{percent}%",
+          "deltaDown": "↘ {percent}%",
+          "deltaFlat": "→ 0%",
+          "deltaUpAriaLabel": "Win rate up by {percent}%",
+          "deltaDownAriaLabel": "Win rate down by {percent}%",
+          "deltaFlatAriaLabel": "Win rate unchanged",
+          "empty": "Not enough data to show a trend",
+          "trendSummaryAriaLabel": "Win rate trend from {from}% to {to}% over the last {count} months",
+          "monthsShort": {
+            "jan": "Jan",
+            "feb": "Feb",
+            "mar": "Mar",
+            "apr": "Apr",
+            "may": "May",
+            "jun": "Jun",
+            "jul": "Jul",
+            "aug": "Aug",
+            "sep": "Sep",
+            "oct": "Oct",
+            "nov": "Nov",
+            "dec": "Dec"
+          }
         }
       },
       "states": {

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -2992,6 +2992,31 @@
           "viewAll": "Vedi tutti",
           "viewAllAriaLabel": "Vedi tutti gli achievement di {playerName}",
           "empty": "Nessun achievement ancora"
+        },
+        "trend": {
+          "title": "Andamento",
+          "deltaUp": "↗ +{percent}%",
+          "deltaDown": "↘ {percent}%",
+          "deltaFlat": "→ 0%",
+          "deltaUpAriaLabel": "Percentuale di vittorie in aumento del {percent}%",
+          "deltaDownAriaLabel": "Percentuale di vittorie in calo del {percent}%",
+          "deltaFlatAriaLabel": "Percentuale di vittorie invariata",
+          "empty": "Dati insufficienti per mostrare l’andamento",
+          "trendSummaryAriaLabel": "Andamento della percentuale di vittorie dal {from}% al {to}% negli ultimi {count} mesi",
+          "monthsShort": {
+            "jan": "Gen",
+            "feb": "Feb",
+            "mar": "Mar",
+            "apr": "Apr",
+            "may": "Mag",
+            "jun": "Giu",
+            "jul": "Lug",
+            "aug": "Ago",
+            "sep": "Set",
+            "oct": "Ott",
+            "nov": "Nov",
+            "dec": "Dic"
+          }
         }
       },
       "states": {


### PR DESCRIPTION
Closes #3166

## Problema
`PlayerDetailView` costruisce `trendLabels` via `t('pages.playerDetail.sections.trend.*')` (non-scoped, senza `defaultMessage`), ma la sezione `trend` era **assente** da `it.json` ed `en.json`. `PlayerTrendCard` mostrava id grezzi per titolo, delta, aria-label, stato vuoto e **tutte le 12 etichette mesi**, in entrambe le lingue.

## Fix
Aggiunta la sezione completa `pages.playerDetail.sections.trend` (title, delta up/down/flat + aria, empty, trendSummaryAriaLabel, monthsShort.jan..dec) con i placeholder corretti (`{percent}`, `{from}/{to}/{count}`). Diff chirurgico (round-trip JSON identico, 25 righe/file).

## Test (TDD)
`index.test.ts` asserisce presenza + parità it↔en della sezione trend (RED: assente → GREEN). 10/10 verdi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)