### PR TITLE
fix(i18n): add wizard-chrome keys to playRecords.edit (#3168)

### DIFF
--- a/apps/web/src/locales/__tests__/index.test.ts
+++ b/apps/web/src/locales/__tests__/index.test.ts
@@ -107,4 +107,28 @@ describe('i18n locales', () => {
       expect(keys).toEqual(EXPECTED_KEYS);
     });
   });
+
+  // Issue #3168: /play-records/[id]/edit reuses SessionCreateForm with the scoped translator
+  // ns='playRecords.edit'. Every wizard-chrome key the form resolves in create mode
+  // (playRecords.new.*) must therefore also exist under playRecords.edit, otherwise edit mode
+  // renders raw ids (step1.title, step2.dateLabel, actions.next, aria-labels, ...).
+  describe('playRecords.edit ⊇ playRecords.new (Issue #3168)', () => {
+    it.each([
+      ['it', LOCALES.IT],
+      ['en', LOCALES.EN],
+    ])('playRecords.edit contains every playRecords.new key in the %s catalog', (name, locale) => {
+      const catalog = getMessages(locale) as Record<string, unknown>;
+      const playRecords = (catalog.playRecords ?? {}) as Record<string, unknown>;
+
+      const newKeys = Object.keys(
+        flattenMessages((playRecords.new ?? {}) as Record<string, unknown>)
+      );
+      const editKeys = new Set(
+        Object.keys(flattenMessages((playRecords.edit ?? {}) as Record<string, unknown>))
+      );
+
+      const missing = newKeys.filter(key => !editKeys.has(key)).sort();
+      expect(missing, `${name}.json playRecords.edit is missing wizard-chrome keys`).toEqual([]);
+    });
+  });
 });

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -5027,19 +5027,77 @@
       "error": {
         "loadFailed": "Could not load the record",
         "updateFailed": "Update failed",
-        "deleteFailed": "Delete failed"
+        "deleteFailed": "Delete failed",
+        "saveFailed": "Save failed",
+        "saveFailedDescription": "Unable to save the game. Please try again.",
+        "retry": "↻ Retry save"
       },
       "a11y": {
         "formLabel": "Edit play record form",
         "readonlyFieldsLabel": "Non-editable fields",
-        "ariaReadonly": "This field is not editable"
+        "ariaReadonly": "This field is not editable",
+        "wizardLabel": "Game recording wizard",
+        "stepIndicatorLabel": "Recording progress",
+        "backButton": "Go back to previous step",
+        "closeButton": "Close",
+        "previewLabel": "Live preview play record",
+        "backToList": "Back to play records"
       },
       "actions": {
         "save": "Save changes",
         "saving": "Saving…",
         "delete": "Delete",
         "cancel": "Cancel",
-        "back": "← Back"
+        "back": "← Back",
+        "next": "Next →",
+        "draft": "Draft"
+      },
+      "stepIndicatorLabel": "Step {current} of 3",
+      "step1Label": "Game",
+      "step2Label": "When",
+      "step3Label": "Scores",
+      "step1": {
+        "title": "Which game did you play?",
+        "subtitle": "Choose from your library. Scoring and players adapt to the game.",
+        "searchPlaceholder": "Search your library…",
+        "emptyLibraryHint": "↑ Select a game to continue",
+        "freeformLabel": "Game name (free text)",
+        "freeformPlaceholder": "e.g. Catan, Puerto Rico…",
+        "freeformHint": "Enter the game name if it's not in the catalog"
+      },
+      "step2": {
+        "title": "When did you play?",
+        "subtitle": "Date, start time and duration. Duration is optional.",
+        "dateLabel": "Date",
+        "timeLabel": "Start time",
+        "durationLabel": "Duration (optional)",
+        "locationLabel": "Location (optional)",
+        "locationPlaceholder": "e.g. Marco's place",
+        "notesLabel": "Notes (optional)",
+        "notesPlaceholder": "Add a comment about the session…",
+        "durationHint": "Approximate — used for total hours statistics"
+      },
+      "step3": {
+        "title": "Who played and what were the scores?",
+        "subtitle": "Enter scores: the winner is automatically the highest scorer.",
+        "playersLabel": "Players and scores ({count})",
+        "addPlayerPlaceholder": "Player name…",
+        "addPlayerButton": "Add player",
+        "winnerBadge": "Winner",
+        "noPlayersHint": "Add at least one player to save the game"
+      },
+      "preview": {
+        "sectionLabel": "Live preview · Play record",
+        "noGameSelected": "Select a game",
+        "rankingLabel": "Ranking · {count} players",
+        "tip": "The winner is determined by the highest score. Updates in real time as you fill in the form."
+      },
+      "draft": {
+        "saving": "Saving…",
+        "saved": "Draft saved {time}"
+      },
+      "loading": {
+        "library": "Loading library…"
       }
     },
     "share": {

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -5039,19 +5039,77 @@
       "error": {
         "loadFailed": "Impossibile caricare la partita",
         "updateFailed": "Aggiornamento non riuscito",
-        "deleteFailed": "Eliminazione non riuscita"
+        "deleteFailed": "Eliminazione non riuscita",
+        "saveFailed": "Salvataggio non riuscito",
+        "saveFailedDescription": "Impossibile salvare la partita. Riprova fra un momento.",
+        "retry": "↻ Riprova salvataggio"
       },
       "a11y": {
         "formLabel": "Modulo modifica partita",
         "readonlyFieldsLabel": "Campi non modificabili",
-        "ariaReadonly": "Questo campo non è modificabile"
+        "ariaReadonly": "Questo campo non è modificabile",
+        "wizardLabel": "Wizard registrazione partita",
+        "stepIndicatorLabel": "Avanzamento registrazione",
+        "backButton": "Torna al passo precedente",
+        "closeButton": "Chiudi",
+        "previewLabel": "Anteprima live record partita",
+        "backToList": "Torna alle partite"
       },
       "actions": {
         "save": "Salva modifiche",
         "saving": "Salvataggio…",
         "delete": "Elimina",
         "cancel": "Annulla",
-        "back": "← Indietro"
+        "back": "← Indietro",
+        "next": "Avanti →",
+        "draft": "Bozza"
+      },
+      "stepIndicatorLabel": "Step {current} di 3",
+      "step1Label": "Gioco",
+      "step2Label": "Quando",
+      "step3Label": "Punteggi",
+      "step1": {
+        "title": "Quale gioco avete giocato?",
+        "subtitle": "Scegli dalla tua libreria. Il punteggio e i giocatori si adattano al gioco.",
+        "searchPlaceholder": "Cerca nella libreria…",
+        "emptyLibraryHint": "↑ Seleziona un gioco per continuare",
+        "freeformLabel": "Nome gioco (testo libero)",
+        "freeformPlaceholder": "Es. Catan, Puerto Rico…",
+        "freeformHint": "Inserisci il nome del gioco se non è in catalogo"
+      },
+      "step2": {
+        "title": "Quando l'avete giocata?",
+        "subtitle": "Data, ora di inizio e durata. La durata è opzionale.",
+        "dateLabel": "Data",
+        "timeLabel": "Ora di inizio",
+        "durationLabel": "Durata (opzionale)",
+        "locationLabel": "Luogo (opzionale)",
+        "locationPlaceholder": "Es. Casa di Marco",
+        "notesLabel": "Note (opzionale)",
+        "notesPlaceholder": "Aggiungi un commento sulla partita…",
+        "durationHint": "Approssimativa — usa per le statistiche ore"
+      },
+      "step3": {
+        "title": "Chi ha giocato e con che punteggio?",
+        "subtitle": "Inserisci i punteggi: il vincitore è calcolato automaticamente dal punteggio più alto.",
+        "playersLabel": "Giocatori e punteggi ({count})",
+        "addPlayerPlaceholder": "Nome giocatore…",
+        "addPlayerButton": "Aggiungi giocatore",
+        "winnerBadge": "Vincitore",
+        "noPlayersHint": "Aggiungi almeno un giocatore per salvare la partita"
+      },
+      "preview": {
+        "sectionLabel": "Anteprima live · Record partita",
+        "noGameSelected": "Seleziona un gioco",
+        "rankingLabel": "Classifica · {count} giocatori",
+        "tip": "Il vincitore è calcolato dal punteggio più alto. Si aggiorna in tempo reale mentre compili."
+      },
+      "draft": {
+        "saving": "Salvataggio…",
+        "saved": "Bozza salvata {time}"
+      },
+      "loading": {
+        "library": "Caricamento libreria…"
       }
     },
     "share": {


### PR DESCRIPTION
Closes #3168

## Problema
`/play-records/[id]/edit` riusa `SessionCreateForm` con lo scoped translator `ns='playRecords.edit'`. Quel namespace era scritto per un layout flat/readonly (pageTitle, banner, delete, conflict) e **mancava del wizard chrome**, quindi in edit mode l'utente vedeva id grezzi: `step1.title`, `step2.dateLabel`, `step3.playersLabel`, `actions.next`, aria-label rotti.

## Fix
Copiate le **46 chiavi wizard-chrome** che `playRecords.new` definisce ma `playRecords.edit` non aveva, dentro `playRecords.edit` (it + en), preservando le chiavi override di edit (banner, delete, conflict, savedWhileLive). Diff chirurgico (round-trip JSON identico). Non tocca il componente (i test esistenti mockano `useTranslation`).

## Test (TDD)
`index.test.ts` asserisce `flatten(playRecords.new) ⊆ flatten(playRecords.edit)` in it+en come guard anti-drift (RED: 46 mancanti → GREEN). 12/12 locales + 237 play-records verdi, 0 regressioni.

_Scoperto durante discovery /sc:spec-panel._

🤖 Generated with [Claude Code](https://claude.com/claude-code)