### PR TITLE
fix(session-tracking): persist invite token & join (missing SaveChangesAsync) (#3170)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/InviteHandlers.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/InviteHandlers.cs
@@ -7,6 +7,7 @@ using Api.BoundedContexts.SessionTracking.Domain.Entities;
 using Api.BoundedContexts.SessionTracking.Domain.Repositories;
 using Api.BoundedContexts.SessionTracking.Domain.ValueObjects;
 using Api.Middleware.Exceptions;
+using Api.SharedKernel.Infrastructure.Persistence;
 
 using MediatR;
 
@@ -91,15 +92,18 @@ public sealed class GenerateInviteTokenCommandHandler : IRequestHandler<Generate
 #pragma warning restore S1075
 
     private readonly ISessionRepository _sessionRepository;
+    private readonly IUnitOfWork _unitOfWork;
     private readonly IConfiguration _configuration;
     private readonly ILogger<GenerateInviteTokenCommandHandler> _logger;
 
     public GenerateInviteTokenCommandHandler(
         ISessionRepository sessionRepository,
+        IUnitOfWork unitOfWork,
         IConfiguration configuration,
         ILogger<GenerateInviteTokenCommandHandler> logger)
     {
         _sessionRepository = sessionRepository;
+        _unitOfWork = unitOfWork;
         _configuration = configuration;
         _logger = logger;
     }
@@ -122,8 +126,11 @@ public sealed class GenerateInviteTokenCommandHandler : IRequestHandler<Generate
         // Generate the invite token
         var token = session.GenerateInviteToken(request.ExpiresInHours);
 
-        // Save the session with new invite token
+        // Save the session with new invite token. SessionRepository.UpdateAsync is stage-only
+        // (it mutates the tracked entity without SaveChanges), so the token is only persisted
+        // once the unit of work is committed here.
         await _sessionRepository.UpdateAsync(session, cancellationToken).ConfigureAwait(false);
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
         var baseUrl = _configuration["App:BaseUrl"] ?? DefaultBaseUrl;
         var inviteUrl = $"{baseUrl}/sessions/join/{token}";
@@ -176,13 +183,16 @@ public sealed class GenerateInviteTokenCommandHandler : IRequestHandler<Generate
 public sealed class JoinSessionByInviteCommandHandler : IRequestHandler<JoinSessionByInviteCommand, JoinSessionResponse>
 {
     private readonly ISessionRepository _sessionRepository;
+    private readonly IUnitOfWork _unitOfWork;
     private readonly ILogger<JoinSessionByInviteCommandHandler> _logger;
 
     public JoinSessionByInviteCommandHandler(
         ISessionRepository sessionRepository,
+        IUnitOfWork unitOfWork,
         ILogger<JoinSessionByInviteCommandHandler> logger)
     {
         _sessionRepository = sessionRepository;
+        _unitOfWork = unitOfWork;
         _logger = logger;
     }
 
@@ -233,8 +243,11 @@ public sealed class JoinSessionByInviteCommandHandler : IRequestHandler<JoinSess
 
         session.AddParticipant(participantInfo, request.UserId);
 
-        // Save changes
+        // Save changes. SessionRepository.UpdateAsync is stage-only (it mutates the tracked
+        // entity without SaveChanges), so the new participant is only persisted once the
+        // unit of work is committed here.
         await _sessionRepository.UpdateAsync(session, cancellationToken).ConfigureAwait(false);
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
         var newParticipant = session.Participants.Last();
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Handlers/InviteHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Handlers/InviteHandlerTests.cs
@@ -1,0 +1,145 @@
+using Api.BoundedContexts.SessionTracking.Application.Commands;
+using Api.BoundedContexts.SessionTracking.Application.Queries;
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+using Api.BoundedContexts.SessionTracking.Domain.Enums;
+using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SessionTracking.Application.Handlers;
+
+#region GenerateInviteTokenCommandHandler Tests
+
+/// <summary>
+/// Unit tests for GenerateInviteTokenCommandHandler.
+/// Issue #3170 - the handler staged the invite token via SessionRepository.UpdateAsync
+/// (stage-only) but never called SaveChangesAsync, so the token was never persisted.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SessionTracking")]
+public class GenerateInviteTokenCommandHandlerTests
+{
+    private readonly Mock<ISessionRepository> _mockSessionRepo;
+    private readonly Mock<IUnitOfWork> _mockUnitOfWork;
+    private readonly GenerateInviteTokenCommandHandler _handler;
+
+    public GenerateInviteTokenCommandHandlerTests()
+    {
+        _mockSessionRepo = new Mock<ISessionRepository>();
+        _mockUnitOfWork = new Mock<IUnitOfWork>();
+        var mockConfig = new Mock<IConfiguration>();
+        var mockLogger = new Mock<ILogger<GenerateInviteTokenCommandHandler>>();
+        _handler = new GenerateInviteTokenCommandHandler(
+            _mockSessionRepo.Object,
+            _mockUnitOfWork.Object,
+            mockConfig.Object,
+            mockLogger.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ValidRequest_PersistsInviteTokenViaSaveChanges()
+    {
+        // Arrange
+        var ownerId = Guid.NewGuid();
+        var sessionId = Guid.NewGuid();
+        var session = Session.Create(ownerId, Guid.NewGuid(), SessionType.GameSpecific);
+        typeof(Session).GetProperty("Id")!.SetValue(session, sessionId);
+
+        _mockSessionRepo
+            .Setup(r => r.GetByIdAsync(sessionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(session);
+
+        var command = new GenerateInviteTokenCommand(sessionId, ownerId, 24);
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert - the invite token must be persisted, not merely staged
+        result.InviteToken.Should().NotBeNullOrEmpty();
+        _mockSessionRepo.Verify(r => r.UpdateAsync(session, It.IsAny<CancellationToken>()), Times.Once);
+        _mockUnitOfWork.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+}
+
+#endregion
+
+#region JoinSessionByInviteCommandHandler Tests
+
+/// <summary>
+/// Unit tests for JoinSessionByInviteCommandHandler.
+/// Issue #3170 - the handler staged the new participant via SessionRepository.UpdateAsync
+/// (stage-only) but never called SaveChangesAsync, so the join was never persisted.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SessionTracking")]
+public class JoinSessionByInviteCommandHandlerTests
+{
+    private readonly Mock<ISessionRepository> _mockSessionRepo;
+    private readonly Mock<IUnitOfWork> _mockUnitOfWork;
+    private readonly JoinSessionByInviteCommandHandler _handler;
+
+    public JoinSessionByInviteCommandHandlerTests()
+    {
+        _mockSessionRepo = new Mock<ISessionRepository>();
+        _mockUnitOfWork = new Mock<IUnitOfWork>();
+        var mockLogger = new Mock<ILogger<JoinSessionByInviteCommandHandler>>();
+        _handler = new JoinSessionByInviteCommandHandler(
+            _mockSessionRepo.Object,
+            _mockUnitOfWork.Object,
+            mockLogger.Object);
+    }
+
+    [Fact]
+    public async Task Handle_NewParticipant_PersistsJoinViaSaveChanges()
+    {
+        // Arrange
+        var ownerId = Guid.NewGuid();
+        var session = Session.Create(ownerId, Guid.NewGuid(), SessionType.GameSpecific);
+        var token = session.GenerateInviteToken(24);
+
+        _mockSessionRepo
+            .Setup(r => r.GetByInviteTokenAsync(token, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(session);
+
+        var command = new JoinSessionByInviteCommand(token, Guid.NewGuid(), "New Player");
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert - the new participant must be persisted, not merely staged
+        result.ParticipantId.Should().NotBeEmpty();
+        _mockSessionRepo.Verify(r => r.UpdateAsync(session, It.IsAny<CancellationToken>()), Times.Once);
+        _mockUnitOfWork.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ExistingParticipant_DoesNotSave()
+    {
+        // Arrange - the owner (already a participant) re-joins via invite: no mutation, no save
+        var ownerId = Guid.NewGuid();
+        var session = Session.Create(ownerId, Guid.NewGuid(), SessionType.GameSpecific);
+        var owner = session.Participants.First();
+        typeof(Participant).GetProperty("UserId")!.SetValue(owner, (Guid?)ownerId);
+        var token = session.GenerateInviteToken(24);
+
+        _mockSessionRepo
+            .Setup(r => r.GetByInviteTokenAsync(token, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(session);
+
+        var command = new JoinSessionByInviteCommand(token, ownerId, "Ignored");
+
+        // Act
+        await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        _mockSessionRepo.Verify(r => r.UpdateAsync(It.IsAny<Session>(), It.IsAny<CancellationToken>()), Times.Never);
+        _mockUnitOfWork.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+}
+
+#endregion


### PR DESCRIPTION
## Sommario

`GenerateInviteTokenCommandHandler` e `JoinSessionByInviteCommandHandler` chiamavano `SessionRepository.UpdateAsync` (stage-only: muta l'entity tracciata senza `SaveChanges`) **senza** poi committare la unit of work → invite token e join via invito **non venivano mai persistiti** (silent data loss).

## Fix

Iniettato `IUnitOfWork` in entrambi gli handler e aggiunto `await _unitOfWork.SaveChangesAsync(ct)` dopo `UpdateAsync`, allineandosi al fratello corretto `JoinSessionByCodeCommandHandler`.

## Test (TDD)

- `GenerateInviteTokenCommandHandlerTests.Handle_ValidRequest_PersistsInviteTokenViaSaveChanges`
- `JoinSessionByInviteCommandHandlerTests.Handle_NewParticipant_PersistsJoinViaSaveChanges`
- `JoinSessionByInviteCommandHandlerTests.Handle_ExistingParticipant_DoesNotSave` (nessun save quando non c'è mutazione)

RED verificato (ctor senza `IUnitOfWork`) → GREEN 3/3.

Closes #3170

🤖 Generated with [Claude Code](https://claude.com/claude-code)