### PR TITLE
fix(kb): persist comment in AddCommentToSharedThread (missing SaveChangesAsync) (#3171)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/AddCommentToSharedThread/AddCommentToSharedThreadCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/AddCommentToSharedThread/AddCommentToSharedThreadCommandHandler.cs
@@ -2,6 +2,7 @@ using Api.BoundedContexts.Authentication.Application.Queries.ValidateShareLink;
 using Api.SharedKernel.Domain.ValueObjects;
 using Api.BoundedContexts.Authentication.Domain.ValueObjects;
 using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
+using Api.SharedKernel.Infrastructure.Persistence;
 using MediatR;
 using Microsoft.Extensions.Caching.Distributed;
 using System.Globalization;
@@ -18,6 +19,7 @@ internal sealed class AddCommentToSharedThreadCommandHandler
     private readonly IChatThreadRepository _threadRepository;
     private readonly IMediator _mediator;
     private readonly IDistributedCache _cache;
+    private readonly IUnitOfWork _unitOfWork;
 
     // Rate limiting: 10 comments per hour per share link
     private const int MaxCommentsPerHour = 10;
@@ -26,14 +28,17 @@ internal sealed class AddCommentToSharedThreadCommandHandler
     public AddCommentToSharedThreadCommandHandler(
         IChatThreadRepository threadRepository,
         IMediator mediator,
-        IDistributedCache cache)
+        IDistributedCache cache,
+        IUnitOfWork unitOfWork)
     {
         ArgumentNullException.ThrowIfNull(threadRepository);
         ArgumentNullException.ThrowIfNull(mediator);
         ArgumentNullException.ThrowIfNull(cache);
+        ArgumentNullException.ThrowIfNull(unitOfWork);
         _threadRepository = threadRepository;
         _mediator = mediator;
         _cache = cache;
+        _unitOfWork = unitOfWork;
     }
 
     public async Task<AddCommentToSharedThreadResult?> Handle(
@@ -92,8 +97,11 @@ internal sealed class AddCommentToSharedThreadCommandHandler
         // Add user message to thread (domain method)
         thread.AddUserMessage(request.Content);
 
-        // Save changes via repository
+        // Save changes. ChatThreadRepository.UpdateAsync is stage-only (it marks the entity as
+        // modified without SaveChanges), so the comment is only persisted once the unit of work
+        // is committed here.
         await _threadRepository.UpdateAsync(thread, cancellationToken).ConfigureAwait(false);
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 
         // Update rate limit counter
         await _cache.SetStringAsync(

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/AddCommentToSharedThreadCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/AddCommentToSharedThreadCommandHandlerTests.cs
@@ -1,0 +1,102 @@
+using Api.BoundedContexts.Authentication.Application.Queries.ValidateShareLink;
+using Api.BoundedContexts.Authentication.Domain.ValueObjects;
+using Api.BoundedContexts.KnowledgeBase.Application.Commands.AddCommentToSharedThread;
+using Api.BoundedContexts.KnowledgeBase.Domain.Entities;
+using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Tests.Constants;
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Handlers;
+
+/// <summary>
+/// Unit tests for AddCommentToSharedThreadCommandHandler.
+/// Issue #3171 - the handler staged the comment via ChatThreadRepository.UpdateAsync
+/// (stage-only) but never called SaveChangesAsync, so the comment was never persisted.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "KnowledgeBase")]
+public class AddCommentToSharedThreadCommandHandlerTests
+{
+    private readonly Mock<IChatThreadRepository> _mockRepository;
+    private readonly Mock<IMediator> _mockMediator;
+    private readonly Mock<IUnitOfWork> _mockUnitOfWork;
+    private readonly IDistributedCache _cache;
+    private readonly AddCommentToSharedThreadCommandHandler _handler;
+
+    public AddCommentToSharedThreadCommandHandlerTests()
+    {
+        _mockRepository = new Mock<IChatThreadRepository>();
+        _mockMediator = new Mock<IMediator>();
+        _mockUnitOfWork = new Mock<IUnitOfWork>();
+        _cache = new MemoryDistributedCache(Options.Create(new MemoryDistributedCacheOptions()));
+        _handler = new AddCommentToSharedThreadCommandHandler(
+            _mockRepository.Object,
+            _mockMediator.Object,
+            _cache,
+            _mockUnitOfWork.Object);
+    }
+
+    private void SetupValidCommentLink(Guid threadId, Guid shareLinkId)
+    {
+        _mockMediator
+            .Setup(m => m.Send(It.IsAny<ValidateShareLinkQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new ValidateShareLinkResult(
+                ShareLinkId: shareLinkId,
+                ThreadId: threadId,
+                Role: ShareLinkRole.Comment,
+                CreatorId: Guid.NewGuid(),
+                ExpiresAt: DateTime.UtcNow.AddDays(1),
+                IsValid: true));
+    }
+
+    [Fact]
+    public async Task Handle_ValidCommentLink_PersistsCommentViaSaveChanges()
+    {
+        // Arrange
+        var threadId = Guid.NewGuid();
+        var shareLinkId = Guid.NewGuid();
+        var thread = new ChatThread(threadId, Guid.NewGuid());
+        SetupValidCommentLink(threadId, shareLinkId);
+        _mockRepository
+            .Setup(r => r.GetByIdAsync(threadId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(thread);
+
+        var command = new AddCommentToSharedThreadCommand("token", "Great game!");
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert - the comment must be persisted, not merely staged
+        result.Should().NotBeNull();
+        _mockRepository.Verify(r => r.UpdateAsync(thread, It.IsAny<CancellationToken>()), Times.Once);
+        _mockUnitOfWork.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ThreadNotFound_DoesNotSave()
+    {
+        // Arrange
+        var threadId = Guid.NewGuid();
+        SetupValidCommentLink(threadId, Guid.NewGuid());
+        _mockRepository
+            .Setup(r => r.GetByIdAsync(threadId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ChatThread?)null);
+
+        var command = new AddCommentToSharedThreadCommand("token", "Great game!");
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.Should().BeNull();
+        _mockRepository.Verify(r => r.UpdateAsync(It.IsAny<ChatThread>(), It.IsAny<CancellationToken>()), Times.Never);
+        _mockUnitOfWork.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+}


### PR DESCRIPTION
## Sommario

`AddCommentToSharedThreadCommandHandler` chiamava `ChatThreadRepository.UpdateAsync` (stage-only: marca l'entity come modificata senza `SaveChanges`) **senza** committare la unit of work → i commenti postati via share-link con ruolo Comment **non venivano mai persistiti** (silent data loss).

## Fix

Iniettato `IUnitOfWork` nell'handler e aggiunto `await _unitOfWork.SaveChangesAsync(ct)` dopo `UpdateAsync`, allineandosi al fratello corretto `AddMessageCommandHandler`.

## Test (TDD)

- `AddCommentToSharedThreadCommandHandlerTests.Handle_ValidCommentLink_PersistsCommentViaSaveChanges`
- `AddCommentToSharedThreadCommandHandlerTests.Handle_ThreadNotFound_DoesNotSave`

RED verificato (ctor senza `IUnitOfWork`) → GREEN 2/2.

Closes #3171

🤖 Generated with [Claude Code](https://claude.com/claude-code)