### PR TITLE
fix(session-tracking): #3157 C1 restore max-1-live partial unique index

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/FinalizeSessionCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/FinalizeSessionCommandHandler.cs
@@ -7,6 +7,7 @@ using Api.BoundedContexts.SessionTracking.Domain.Entities;
 using Api.BoundedContexts.SessionTracking.Domain.Events;
 using Api.BoundedContexts.SessionTracking.Domain.Repositories;
 using Api.BoundedContexts.SessionTracking.Domain.Services;
+using Api.BoundedContexts.GameManagement.Domain.Enums;
 using Api.Infrastructure;
 using Api.Infrastructure.Entities.SessionTracking;
 using Api.Infrastructure.Extensions;
@@ -148,6 +149,23 @@ public class FinalizeSessionCommandHandler : IRequestHandler<FinalizeSessionComm
         // Resolve GameNightId via the link row (if any) so the diary entry is
         // correlated with the cross-game timeline.
         var gameNightId = await _db.ResolveGameNightIdAsync(session.Id, cancellationToken).ConfigureAwait(false);
+
+        // Issue #3157 C1 — close this session's game_night_sessions link so a finalized
+        // session does not leave an orphaned InProgress live-slot. Without this, once the
+        // restored ix_game_night_sessions_unique_active partial unique index is in place a
+        // NEW session in the same night (minting a fresh InProgress link) would hit a unique
+        // violation. Guarded on InProgress → idempotent and a no-op when Path B
+        // (CompleteGameNightSession) already closed the link.
+        var liveLink = await _db.GameNightSessions
+            .FirstOrDefaultAsync(
+                l => l.SessionId == session.Id && l.Status == nameof(GameNightSessionStatus.InProgress),
+                cancellationToken)
+            .ConfigureAwait(false);
+        if (liveLink is not null)
+        {
+            liveLink.Status = nameof(GameNightSessionStatus.Completed);
+            liveLink.CompletedAt = _timeProvider.GetUtcNow().UtcDateTime;
+        }
 
         var finalizedAt = session.FinalizedAt ?? _timeProvider.GetUtcNow().UtcDateTime;
         var durationSeconds = (int)(finalizedAt - session.SessionDate).TotalSeconds;

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/GameManagement/GameNightSessionEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/GameManagement/GameNightSessionEntityConfiguration.cs
@@ -35,5 +35,15 @@ internal class GameNightSessionEntityConfiguration : IEntityTypeConfiguration<Ga
 
         builder.HasIndex(s => s.GameId)
             .HasDatabaseName("IX_game_night_sessions_game_id");
+
+        // Issue #3157 C1 — restore the "max 1 live session per GameNight" invariant as a
+        // DB constraint. The original raw-SQL partial unique index (T1 #365) was silently
+        // dropped by the #2875 migration flatten (ef migrations add Initial only reflects the
+        // model). Declaring it on the MODEL here makes it EF-tracked, so it survives future
+        // flattens — fixing the root cause, not just restoring the symptom.
+        builder.HasIndex(s => s.GameNightEventId)
+            .HasDatabaseName("ix_game_night_sessions_unique_active")
+            .IsUnique()
+            .HasFilter("status = 'InProgress'");
     }
 }

--- a/apps/api/src/Api/Infrastructure/Migrations/20260719111334_RestoreGameNightSessionInProgressUniqueIndex.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260719111334_RestoreGameNightSessionInProgressUniqueIndex.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260719111334_RestoreGameNightSessionInProgressUniqueIndex")]
+    partial class RestoreGameNightSessionInProgressUniqueIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260719111334_RestoreGameNightSessionInProgressUniqueIndex.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260719111334_RestoreGameNightSessionInProgressUniqueIndex.cs
@@ -1,0 +1,58 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class RestoreGameNightSessionInProgressUniqueIndex : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            // Issue #3157 C1 — reconcile pre-existing violations of the "max 1 InProgress
+            // link per GameNight" invariant BEFORE the unique index is created, otherwise
+            // CREATE UNIQUE INDEX would fail on any environment carrying duplicate/orphaned
+            // InProgress rows (the invariant was only app-enforced since the #2875 flatten
+            // silently dropped the original partial unique index, and FinalizeSessionCommand
+            // left finalized sessions' links stuck at InProgress).
+
+            // (a) Orphaned live slots: link is InProgress but its session is finalized → close it.
+            migrationBuilder.Sql(@"
+                UPDATE game_night_sessions gns
+                SET status = 'Completed', completed_at = COALESCE(gns.completed_at, NOW())
+                FROM session_tracking_sessions s
+                WHERE gns.status = 'InProgress'
+                  AND s.id = gns.session_id
+                  AND s.finalized_at IS NOT NULL;");
+
+            // (b) Any remaining duplicates per night: keep the most-recently-started link
+            //     InProgress and demote the rest to Pending (the same demotion PauseSession uses).
+            migrationBuilder.Sql(@"
+                WITH ranked AS (
+                    SELECT id, ROW_NUMBER() OVER (
+                        PARTITION BY game_night_event_id
+                        ORDER BY started_at DESC NULLS LAST, id) AS rn
+                    FROM game_night_sessions
+                    WHERE status = 'InProgress')
+                UPDATE game_night_sessions
+                SET status = 'Pending'
+                WHERE id IN (SELECT id FROM ranked WHERE rn > 1);");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_game_night_sessions_unique_active",
+                table: "game_night_sessions",
+                column: "game_night_event_id",
+                unique: true,
+                filter: "status = 'InProgress'");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ix_game_night_sessions_unique_active",
+                table: "game_night_sessions");
+        }
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Commands/PauseResumeSessionTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Commands/PauseResumeSessionTests.cs
@@ -354,7 +354,11 @@ public sealed class PauseResumeSessionTests : IAsyncLifetime
 
         var act = async () => await SeedAdditionalActiveSessionInNightAsync(userId, gameId, first.GameNightEventId);
 
-        await act.Should().ThrowAsync<DbUpdateException>();
+        // Assert the specific partial-unique-index violation (23505) so a future constraint
+        // that trips first cannot produce a false green.
+        var ex = await act.Should().ThrowAsync<DbUpdateException>();
+        ex.Which.InnerException.Should().BeOfType<PostgresException>()
+            .Which.SqlState.Should().Be(PostgresErrorCodes.UniqueViolation);
     }
 
     // Issue #3157 C1 — finalizing a session must close its game_night_sessions link

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Commands/PauseResumeSessionTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Commands/PauseResumeSessionTests.cs
@@ -340,4 +340,68 @@ public sealed class PauseResumeSessionTests : IAsyncLifetime
             },
             GameNightEventId: gameNightEventId,
             GuestNames: null);
+
+    // Issue #3157 C1 — the restored ix_game_night_sessions_unique_active partial unique
+    // index must reject a second InProgress link in the same GameNight. session1's link is
+    // born InProgress and is NOT paused here, so directly seeding a second InProgress link
+    // for the same night violates the index.
+    [Fact]
+    public async Task RestoredUniqueIndex_RejectsSecondInProgressLinkInSameNight()
+    {
+        var (userId, gameId) = await _fixture.SeedUserWithLibraryGameAndIndexedKbAsync(_dbContext!, vectorCount: 2);
+        var first = await _createHandler!.Handle(BuildCreateCommand(userId, gameId), TestCancellationToken);
+        _dbContext!.ChangeTracker.Clear();
+
+        var act = async () => await SeedAdditionalActiveSessionInNightAsync(userId, gameId, first.GameNightEventId);
+
+        await act.Should().ThrowAsync<DbUpdateException>();
+    }
+
+    // Issue #3157 C1 — finalizing a session must close its game_night_sessions link
+    // (InProgress -> Completed) so it does not leave an orphaned live slot that would block
+    // the restored unique index from admitting the next session in the same night.
+    [Fact]
+    public async Task Finalize_ClosesInProgressLink()
+    {
+        var (userId, gameId) = await _fixture.SeedUserWithLibraryGameAndIndexedKbAsync(_dbContext!, vectorCount: 2);
+        var created = await _createHandler!.Handle(BuildCreateCommand(userId, gameId), TestCancellationToken);
+        _dbContext!.ChangeTracker.Clear();
+
+        var ownerParticipantId = await _dbContext.Set<Api.Infrastructure.Entities.SessionTracking.ParticipantEntity>()
+            .AsNoTracking()
+            .Where(p => p.SessionId == created.SessionId)
+            .Select(p => p.Id)
+            .FirstAsync(TestCancellationToken);
+
+        var eventCollector = _serviceProvider!.GetRequiredService<IDomainEventCollector>();
+        var unitOfWork = _serviceProvider.GetRequiredService<IUnitOfWork>();
+        var sessionRepo = new SessionRepository(_dbContext, eventCollector);
+        // IScoreEntryRepository / ISessionSyncService are not registered by the integration
+        // service builder — mock them (this test targets the game_night_sessions link close,
+        // not scoring/SSE). The Session itself is the real persisted aggregate.
+        var scoreRepoMock = new Mock<IScoreEntryRepository>();
+        scoreRepoMock.Setup(r => r.GetBySessionIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<ScoreEntry>());
+        var syncMock = new Mock<ISessionSyncService>();
+        syncMock.Setup(s => s.PublishEventAsync(It.IsAny<Guid>(), It.IsAny<INotification>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        var finalizeHandler = new FinalizeSessionCommandHandler(
+            sessionRepo,
+            scoreRepoMock.Object,
+            unitOfWork,
+            syncMock.Object,
+            _dbContext,
+            TimeProvider.System,
+            new DiaryStreamService());
+
+        await finalizeHandler.Handle(
+            new FinalizeSessionCommand(created.SessionId, new Dictionary<Guid, int> { [ownerParticipantId] = 1 }),
+            TestCancellationToken);
+
+        _dbContext.ChangeTracker.Clear();
+        var link = await _dbContext.GameNightSessions
+            .AsNoTracking()
+            .FirstAsync(l => l.SessionId == created.SessionId, TestCancellationToken);
+        link.Status.Should().Be(nameof(Api.BoundedContexts.GameManagement.Domain.Enums.GameNightSessionStatus.Completed));
+    }
 }

--- a/docs/superpowers/specs/2026-07-19-3157-c1-restore-gamenight-inprogress-unique-index.md
+++ b/docs/superpowers/specs/2026-07-19-3157-c1-restore-gamenight-inprogress-unique-index.md
@@ -1,0 +1,98 @@
+# Design — #3157 C1: Restore the dropped `max 1 live per GameNight` partial unique index
+
+**Issue**: [#3157](https://github.com/meepleAi-app/meepleai-monorepo/issues/3157) (scope C1) · **Branch**: `feature/issue-3157-session-live-canonicalization` · **Parent**: `main-dev` · **Date**: 2026-07-19
+
+## 1. Problem (verified via deep discovery)
+
+The invariant **"max 1 InProgress session-link per GameNight"** is referenced across `PauseSessionCommandHandler`, `ResumeSessionCommandHandler`, and `CreateSessionCommandHandler` as being enforced by *"the partial unique index from T1"* on `game_night_sessions`. **That index does not exist.**
+
+- It was created in the T1 migration `AddSessionTurnOrderAndGameNightInProgress` (#365, commit `7fe20e96d`) as a raw `migrationBuilder.Sql()` partial unique index:
+  ```sql
+  CREATE UNIQUE INDEX IF NOT EXISTS "ix_game_night_sessions_unique_active"
+  ON "game_night_sessions" ("game_night_event_id") WHERE "status" = 'InProgress';
+  ```
+- It was **silently dropped** when 14 migrations were consolidated into `20260712200111_Initial` (#2875 / PR #2880, 2026-07-12): `ef migrations add Initial` only reflects the EF *model*, so raw-SQL DDL is lost and `has-pending-model-changes` reports none. This is the documented pitfall `feedback_migration_flatten_drops_raw_sql`. Verified: 0 occurrences of `ix_game_night_sessions_unique_active` in `Migrations/`, 0 raw `migrationBuilder.Sql(` in the Initial baseline.
+
+Today "max 1 live per night" is held only by application logic (a read-check in `ResolveGameNightAsync`, a domain guard `MaxLiveSessionsExceededException` in Path B, and `ResumeSessionCommandHandler`'s demote-then-promote transaction ordering) — none race-safe.
+
+**Companion bug (must fix together):** `FinalizeSessionCommandHandler` (Path A) does **not** transition the link status — a finalized session leaves its `game_night_sessions` row stuck at `InProgress` (orphaned live slot). Path B (`CompleteGameNightSessionCommandHandler`) already closes it. Restoring the unique index **without** fixing this would make a legitimate sequential flow fail: session1 finalized (link1 orphaned `InProgress`) → session2 created in the same night mints link2 `InProgress` → **UNIQUE violation → 500**.
+
+## 2. Scope (C1, user-approved)
+
+Restore the DB-enforced invariant + stop the orphaning that would make it unsafe. **Out of scope** (deferred / part of C2): setting `Session.StartedAt` at create (would violate domain invariante #5/#14 — StartedAt is set ONLY via `OpenLiveMode`), realigning the guard off `Status==Active`, reconciling the two writer paths, changing the warning #13 query.
+
+## 3. Design
+
+### 3.1 Add the partial unique index to the EF model (root-cause fix)
+
+In `GameNightSessionEntityConfiguration` add:
+```csharp
+builder.HasIndex(s => s.GameNightEventId)
+    .HasDatabaseName("ix_game_night_sessions_unique_active")
+    .IsUnique()
+    .HasFilter("status = 'InProgress'");
+```
+Adding it to the **model** (not raw SQL) means it is EF-tracked and recorded in the model snapshot, so it will **survive a future flatten** — fixing the root cause of the original silent drop, not just the symptom.
+
+### 3.2 Migration `RestoreGameNightSessionInProgressUniqueIndex`
+
+Generate via `dotnet ef migrations add RestoreGameNightSessionInProgressUniqueIndex` (from `apps/api/src/Api`). EF emits the filtered `CreateIndex`. **Manually prepend** a data-cleanup block to `Up` (before the `CreateIndex`) so the index can be built on environments that already carry orphaned/duplicate `InProgress` rows:
+
+```csharp
+// Reconcile pre-existing violations of the restored invariant before the unique index.
+// (a) Orphaned live slots: link InProgress but its session is finalized → close it.
+migrationBuilder.Sql(@"
+    UPDATE game_night_sessions gns
+    SET status = 'Completed', completed_at = COALESCE(gns.completed_at, NOW())
+    FROM session_tracking_sessions s
+    WHERE gns.status = 'InProgress'
+      AND s.id = gns.session_id
+      AND s.finalized_at IS NOT NULL;");
+// (b) Any remaining duplicates per night: keep the most-recently-started, demote the rest to Pending.
+migrationBuilder.Sql(@"
+    WITH ranked AS (
+        SELECT id, ROW_NUMBER() OVER (
+            PARTITION BY game_night_event_id
+            ORDER BY started_at DESC NULLS LAST, id) AS rn
+        FROM game_night_sessions WHERE status = 'InProgress')
+    UPDATE game_night_sessions
+    SET status = 'Pending'
+    WHERE id IN (SELECT id FROM ranked WHERE rn > 1);");
+```
+`Down` drops the index (EF-generated). Verify the Session PK column is `id` at implement time.
+
+### 3.3 Fix Path A orphaning — `FinalizeSessionCommandHandler` closes the link
+
+After the existing finalize logic, close this session's `InProgress` link (idempotent, guarded so Path B's prior close is a no-op):
+```csharp
+var link = await _db.GameNightSessions
+    .FirstOrDefaultAsync(l => l.SessionId == session.Id
+        && l.Status == nameof(GameNightSessionStatus.InProgress), cancellationToken)
+    .ConfigureAwait(false);
+if (link is not null)
+{
+    link.Status = nameof(GameNightSessionStatus.Completed);
+    link.CompletedAt = _timeProvider.GetUtcNow().UtcDateTime;
+}
+```
+Path B safety: `CompleteGameNightSessionCommandHandler` already sets the link `Completed`; the `Status == InProgress` filter makes this a no-op there (and idempotent). Confirm at implement time that Path B and this handler resolve the SAME `GameNightSessionEntity` instance (identity resolution) to avoid a double-tracked conflict; if they diverge, guard accordingly.
+
+## 4. Testing (integration, Testcontainers Postgres)
+
+1. **Index blocks a 2nd live slot**: seed a GameNight + 1 `InProgress` link; inserting a 2nd `InProgress` link for the same `game_night_event_id` throws `DbUpdateException` (unique violation). A `Pending`/`Completed` 2nd link is allowed.
+2. **Finalize frees the slot**: create session1 in a night (link `InProgress`) → `FinalizeSessionCommand` → assert its link is `Completed`; then a 2nd session in the same night persists (no violation).
+3. **Cleanup migration** is exercised implicitly (tests run `MigrateAsync`, which applies it on a fresh DB — asserting no dup data path).
+
+## 5. Files touched
+
+| File | Change |
+|---|---|
+| `…/EntityConfigurations/GameManagement/GameNightSessionEntityConfiguration.cs` | Add the partial unique index |
+| `…/Infrastructure/Migrations/<ts>_RestoreGameNightSessionInProgressUniqueIndex.cs` (+ Designer + snapshot) | EF-generated `CreateIndex` + prepended cleanup SQL |
+| `…/SessionTracking/Application/Commands/FinalizeSessionCommandHandler.cs` | Close the `InProgress` link on finalize |
+| `apps/api/tests/Api.Tests/…/SessionTracking/…` | Integration tests (index + finalize-frees-slot) |
+
+## 6. Out of scope / follow-up (record on the issue)
+
+- Realign the guard off `Status==Active` onto the link/IsLive; reconcile Path A/B writer semantics; warning #13 query — the broader C2 canonicalization.
+- Optional hardening: catch `DbUpdateException`(23505) in `CreateSessionCommandHandler` and map to a clean 409 instead of 500 (the index now makes the race a real DB error).


### PR DESCRIPTION
Partial fix for #3157 (scope **C1**). Full analysis + re-scope recorded on the issue.

## What deep discovery found

The original issue framed #3157 as "align the max-1-live guard (`Status==Active`) with the warning #13 query (`StartedAt/FinalizedAt`)". Grounding the design in the domain-model spec + real schema revealed the premise was off:

- **The DB-enforced "max 1 live per GameNight" invariant does not exist.** The partial unique index `ix_game_night_sessions_unique_active` on `game_night_sessions (game_night_event_id) WHERE status='InProgress'` — referenced as live-enforcement by `Pause`/`Resume`/`Create` handler comments ("the partial unique index from T1") — was created in #365 as raw `migrationBuilder.Sql()` and **silently dropped** by the #2875 migration flatten (`ef migrations add Initial` only reflects the model). The `feedback_migration_flatten_drops_raw_sql` pitfall. Today the invariant is held only by application logic — not race-safe.
- **Setting `Session.StartedAt` at create (the originally-approved "Option B") would violate the domain model** — invariante #5/#14 (`StartedAt` is derived from "Apri Live mode", not user input) + Fatto #2 (live is explicit, never a default). The FE create-draft path correctly leaves `StartedAt` null.

So C1 restores the real missing invariant (the highest-value, lowest-risk slice) instead.

## Changes

1. **Restore the partial unique index — on the EF model** (`GameNightSessionEntityConfiguration`): `HasIndex(GameNightEventId).IsUnique().HasFilter("status = 'InProgress'")`. Declaring it on the *model* (not raw SQL) makes it EF-tracked, so it **survives a future flatten** — fixing the root cause, not just the symptom.
2. **Migration** `RestoreGameNightSessionInProgressUniqueIndex`: reconciles pre-existing violations before the index build — (a) closes orphaned `InProgress` links whose session is finalized (`→ Completed`), (b) demotes any remaining per-night duplicates to `Pending` (keep the most-recently-started) — then `CreateIndex`.
3. **`FinalizeSessionCommandHandler` closes the link** (`InProgress → Completed`) on finalize. Companion fix: without it a finalized session leaves an orphaned live slot, and the restored index would then reject a legitimate next session in the same night. Idempotent (guarded on `InProgress`), so Path B (`CompleteGameNightSession`, which already closes the link) is a no-op.

## Out of scope (recorded on the issue as follow-ups)

The broader C2 canonicalization: realign the guard off `Status==Active`, reconcile the two writer paths (raw-EF vs domain-aggregate), change the warning #13 query. Optional hardening: map `DbUpdateException`(23505) → 409 in `CreateSessionCommandHandler` (the index now makes the concurrent-create race a real DB error rather than a silent invariant violation).

## Testing

2 Testcontainers-Postgres integration tests (green): the restored index rejects a 2nd `InProgress` link in the same night (asserts inner `PostgresException` `23505`); `FinalizeSessionCommand` closes the session's link.

Regression: the SessionTracking bounded-context full-suite shows ~26 pre-existing failures that are **load-induced flakiness** (they pass in isolation on both `main-dev` and this branch — verified) + the known baseline `Resume_Paused_...` (fails identically on `main-dev` due to an `NpgsqlRetryingExecutionStrategy` vs user-transaction issue in `ResumeSessionCommandHandler`, unrelated to this change). None introduced here.

Reviewed by an adversarial correctness pass (verdict: safe to merge; cleanup SQL guarantees ≤1 `InProgress` per night before the index build; cross-path Finalize is conflict-free).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
