### PR TITLE
fix(session-tracking): map DeleteChatMessage non-text to 409 not 500 (#3173)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/ChatCommandHandlers.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/ChatCommandHandlers.cs
@@ -289,7 +289,7 @@ public class DeleteChatMessageCommandHandler : IRequestHandler<DeleteChatMessage
             ?? throw new NotFoundException($"Message {request.MessageId} not found");
 
         if (message.MessageType != SessionChatMessageType.Text)
-            throw new InvalidOperationException("Only text messages can be deleted.");
+            throw new ConflictException("Only text messages can be deleted.");
 
         // #2655 IDOR guard: resolve the sending participant server-side from the
         // authenticated caller — never trust a client-supplied requester id. Only

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Handlers/ChatCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Handlers/ChatCommandHandlerTests.cs
@@ -373,10 +373,12 @@ public class DeleteChatMessageCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_SystemEventMessage_ThrowsInvalidOperationException()
+    public async Task Handle_SystemEventMessage_ThrowsConflictException()
     {
         // Non-text messages are rejected by the type check, which runs before the
-        // ownership resolution — so no session lookup is needed here.
+        // ownership resolution — so no session lookup is needed here. Deleting a
+        // non-text message is a conflicting request on the resource state, so it must
+        // surface as 409 (ConflictException), not a 500 (InvalidOperationException). (#3173)
         var message = SessionChatMessage.CreateSystemEvent(Guid.NewGuid(), "event", 1);
 
         _mockChatRepo.Setup(r => r.GetByIdAsync(message.Id, It.IsAny<CancellationToken>()))
@@ -385,7 +387,8 @@ public class DeleteChatMessageCommandHandlerTests
         var command = new DeleteChatMessageCommand(message.Id, Guid.NewGuid());
 
         var act7 = () => _handler.Handle(command, TestContext.Current.CancellationToken);
-        await act7.Should().ThrowAsync<InvalidOperationException>();
+        await act7.Should().ThrowAsync<ConflictException>()
+            .WithMessage("*text messages*");
     }
 }
 


### PR DESCRIPTION
## Sommario

`DeleteChatMessageCommandHandler` lanciava `InvalidOperationException` quando il messaggio non è di tipo `Text`. Il middleware mappa `InvalidOperationException` a **500** salvo che il messaggio contenga la substring `"not found"` → eliminare un messaggio system-event restituiva **500** invece di **409**.

## Fix

`throw new ConflictException("Only text messages can be deleted.")` (409).

## Test (TDD)

Aggiornato `Handle_SystemEventMessage_ThrowsConflictException` (era `ThrowsInvalidOperationException`). RED (atteso ConflictException, lanciato IOE) → GREEN 4/4.

Closes #3173

🤖 Generated with [Claude Code](https://claude.com/claude-code)