### PR TITLE
fix(health-monitor): cut flapping warning-mail noise for non-critical services

### DIFF
--- a/apps/api/src/Api/BoundedContexts/Administration/Application/EventHandlers/HealthStatusChangedEventHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/EventHandlers/HealthStatusChangedEventHandler.cs
@@ -72,6 +72,15 @@ internal sealed class HealthStatusChangedEventHandler
             ["_slack_category"] = category
         };
 
+        // Non-critical health transitions (Degraded=warning, recovery=info) are routed to
+        // Slack/DB/dashboard but kept OFF email — only Unhealthy (critical) transitions
+        // email. The flag is scoped to THIS alert, so budget/security/dead-letter warning
+        // emails from other producers are unaffected. See EmailAlertChannel.IsEmailSuppressed.
+        if (ShouldSuppressEmail(severity))
+        {
+            metadata[EmailAlertChannel.SuppressEmailMetadataKey] = true;
+        }
+
         try
         {
             await alertingService.SendAlertAsync(alertType, severity, message, metadata, cancellationToken)
@@ -125,6 +134,15 @@ internal sealed class HealthStatusChangedEventHandler
         "Degraded" => "warning",
         _ => "info"
     };
+
+    /// <summary>
+    /// Whether a health alert of the given severity should be kept off the email channel.
+    /// Only "critical" (an Unhealthy transition) emails; "warning" (Degraded) and "info"
+    /// (recovery) are suppressed to avoid flapping-mail alert fatigue for non-critical
+    /// services. Other channels (Slack, DB) are unaffected.
+    /// </summary>
+    internal static bool ShouldSuppressEmail(string severity) =>
+        !string.Equals(severity, "critical", StringComparison.OrdinalIgnoreCase);
 
     private static string TruncateAlertType(string alertType) =>
         alertType.Length > 100 ? alertType[..100] : alertType;

--- a/apps/api/src/Api/Infrastructure/BackgroundServices/HealthStateMachine.cs
+++ b/apps/api/src/Api/Infrastructure/BackgroundServices/HealthStateMachine.cs
@@ -20,11 +20,15 @@ public record ServiceHealthState(
 /// <summary>
 /// Pure-function state machine for health check status transitions.
 /// Implements hysteresis to prevent flapping:
-/// - Healthy → Degraded after DegradedThreshold failures (default: 1)
-/// - Degraded → Unhealthy after UnhealthyThreshold total failures (default: 3)
+/// - Healthy → Degraded after DegradedThreshold consecutive failures (default: 3)
+/// - Degraded → Unhealthy after UnhealthyThreshold total failures (default: 5)
 /// - Degraded → Healthy on any success
 /// - Unhealthy → Healthy after RecoveryThreshold consecutive successes (default: 2)
 /// - Unhealthy + failure resets consecutive success counter
+///
+/// The DegradedThreshold hysteresis-in absorbs transient single-poll blips
+/// (external API slow, ML cold-start, FTS latency spike) that would otherwise flap
+/// Healthy↔Degraded and spam warning alerts for non-critical services.
 /// </summary>
 internal static class HealthStateMachine
 {
@@ -42,19 +46,13 @@ internal static class HealthStateMachine
 
         return current.CurrentStatus switch
         {
-            "Healthy" when isFailure => current with
-            {
-                CurrentStatus = "Degraded",
-                PreviousStatus = "Healthy",
-                ConsecutiveFailures = 1,
-                ConsecutiveSuccesses = 0,
-                LastTransitionAt = now,
-                LastDescription = $"Health check returned {checkResult}"
-            },
+            "Healthy" when isFailure =>
+                HandleHealthyFailure(current, checkResult, options, now),
 
             "Healthy" => current with
             {
-                PreviousStatus = "Healthy"
+                PreviousStatus = "Healthy",
+                ConsecutiveFailures = 0
             },
 
             "Degraded" when isFailure =>
@@ -105,6 +103,37 @@ internal static class HealthStateMachine
 
         var elapsed = DateTime.UtcNow - state.LastNotifiedAt.Value;
         return elapsed.TotalMinutes > options.ReminderIntervalMinutes;
+    }
+
+    private static ServiceHealthState HandleHealthyFailure(
+        ServiceHealthState current, HealthStatus checkResult, HealthMonitorOptions options, DateTime now)
+    {
+        var newFailures = current.ConsecutiveFailures + 1;
+
+        // Hysteresis-in: only transition to Degraded (which fires an alert) once the
+        // failure streak reaches DegradedThreshold. Below it the service stays Healthy —
+        // no transition, so no alert — and we just accumulate the streak. A single
+        // success (below) resets it, so isolated transient blips never emit an alert.
+        if (newFailures >= options.DegradedThreshold)
+        {
+            return current with
+            {
+                CurrentStatus = "Degraded",
+                PreviousStatus = "Healthy",
+                ConsecutiveFailures = newFailures,
+                ConsecutiveSuccesses = 0,
+                LastTransitionAt = now,
+                LastDescription = $"Health check returned {checkResult}"
+            };
+        }
+
+        return current with
+        {
+            PreviousStatus = "Healthy",
+            ConsecutiveFailures = newFailures,
+            ConsecutiveSuccesses = 0,
+            LastDescription = $"Health check degraded ({newFailures}/{options.DegradedThreshold})"
+        };
     }
 
     private static ServiceHealthState HandleDegradedFailure(

--- a/apps/api/src/Api/Infrastructure/Configuration/HealthMonitorOptions.cs
+++ b/apps/api/src/Api/Infrastructure/Configuration/HealthMonitorOptions.cs
@@ -6,7 +6,12 @@ public sealed class HealthMonitorOptions
     public int PollingIntervalSeconds { get; set; } = 60;
     public int StartupDelaySeconds { get; set; } = 10;
     public int ReminderIntervalMinutes { get; set; } = 30;
-    public int DegradedThreshold { get; set; } = 1;
-    public int UnhealthyThreshold { get; set; } = 3;
+
+    // Anti-flapping hysteresis-in: require a persistent failure streak before a service
+    // is considered Degraded (and an alert fires). At the 60s poll interval, 3 = ~3 min
+    // of sustained degradation, which filters out transient single-poll blips of
+    // non-critical services (external BGG API slow, ML cold-start, FTS latency spike).
+    public int DegradedThreshold { get; set; } = 3;
+    public int UnhealthyThreshold { get; set; } = 5;
     public int RecoveryThreshold { get; set; } = 2;
 }

--- a/apps/api/src/Api/Infrastructure/Health/Checks/BggApiHealthCheck.cs
+++ b/apps/api/src/Api/Infrastructure/Health/Checks/BggApiHealthCheck.cs
@@ -26,7 +26,11 @@ public class BggApiHealthCheck : IHealthCheck
         {
             var client = _httpClientFactory.CreateClient("BggApi");
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            cts.CancelAfter(TimeSpan.FromSeconds(5));
+            // BGG's XML API is an external, frequently-slow/rate-limited third party.
+            // 5s tripped Degraded on routine latency spikes; 8s tolerates them (the client
+            // itself allows 30s). Registration timeout in HealthCheckServiceExtensions is
+            // 10s, above this, so this cts is the effective bound.
+            cts.CancelAfter(TimeSpan.FromSeconds(8));
 
             // Simple connectivity test with BGG API
             var response = await client.GetAsync("/xmlapi2/search?query=test&type=boardgame", cts.Token).ConfigureAwait(false);
@@ -37,7 +41,7 @@ public class BggApiHealthCheck : IHealthCheck
         }
         catch (OperationCanceledException ex)
         {
-            _logger.LogWarning(ex, "BGG API health check timeout (>5s)");
+            _logger.LogWarning(ex, "BGG API health check timeout (>8s)");
             return HealthCheckResult.Degraded("Timeout checking BGG API connectivity");
         }
         catch (HttpRequestException ex)

--- a/apps/api/src/Api/Infrastructure/Health/Checks/EmbeddingServiceHealthCheck.cs
+++ b/apps/api/src/Api/Infrastructure/Health/Checks/EmbeddingServiceHealthCheck.cs
@@ -26,7 +26,10 @@ public class EmbeddingServiceHealthCheck : IHealthCheck
         {
             var client = _httpClientFactory.CreateClient("EmbeddingService");
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            cts.CancelAfter(TimeSpan.FromSeconds(5));
+            // Python ML microservice: model load / GC pauses / cold-start make 5s too
+            // tight and trip Degraded on healthy-but-busy nodes. 10s absorbs those blips.
+            // Registration timeout (HealthCheckServiceExtensions) is 12s, above this.
+            cts.CancelAfter(TimeSpan.FromSeconds(10));
 
             var response = await client.GetAsync("/health", cts.Token).ConfigureAwait(false);
 
@@ -36,7 +39,7 @@ public class EmbeddingServiceHealthCheck : IHealthCheck
         }
         catch (OperationCanceledException ex)
         {
-            _logger.LogWarning(ex, "Embedding service health check timeout (>5s)");
+            _logger.LogWarning(ex, "Embedding service health check timeout (>10s)");
             return HealthCheckResult.Degraded("Timeout checking embedding service");
         }
         catch (HttpRequestException ex)

--- a/apps/api/src/Api/Infrastructure/Health/Checks/RerankerHealthCheck.cs
+++ b/apps/api/src/Api/Infrastructure/Health/Checks/RerankerHealthCheck.cs
@@ -36,7 +36,10 @@ public class RerankerHealthCheck : IHealthCheck
             using var client = _httpClientFactory.CreateClient();
             client.BaseAddress = new Uri(rerankerUrl);
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
-            cts.CancelAfter(TimeSpan.FromSeconds(5));
+            // Python ML microservice: model load / GC pauses / cold-start make 5s too
+            // tight and trip Degraded on healthy-but-busy nodes. 10s absorbs those blips.
+            // Registration timeout (HealthCheckServiceExtensions) is 12s, above this.
+            cts.CancelAfter(TimeSpan.FromSeconds(10));
 
             var response = await client.GetAsync("/health", cts.Token).ConfigureAwait(false);
 
@@ -46,7 +49,7 @@ public class RerankerHealthCheck : IHealthCheck
         }
         catch (OperationCanceledException ex)
         {
-            _logger.LogWarning(ex, "Reranker service health check timeout (>5s)");
+            _logger.LogWarning(ex, "Reranker service health check timeout (>10s)");
             return HealthCheckResult.Degraded("Timeout checking reranker service");
         }
         catch (HttpRequestException ex)

--- a/apps/api/src/Api/Infrastructure/Health/Extensions/HealthCheckServiceExtensions.cs
+++ b/apps/api/src/Api/Infrastructure/Health/Extensions/HealthCheckServiceExtensions.cs
@@ -44,7 +44,9 @@ public static class HealthCheckServiceExtensions
             "embedding",
             HealthStatus.Degraded,
             tags: new[] { HealthCheckTags.Ai, HealthCheckTags.NonCritical },
-            timeout: TimeSpan.FromSeconds(5));
+            // ML microservice: 12s registration ceiling above the check's 10s internal
+            // cts, so model-load / cold-start latency does not flap Degraded.
+            timeout: TimeSpan.FromSeconds(12));
 
         // Embedding dimension validation — catches provider/schema mismatch at startup.
         // Uses factory registration because IEmbeddingService is internal (CS0051 prevents
@@ -62,7 +64,9 @@ public static class HealthCheckServiceExtensions
             "reranker",
             HealthStatus.Degraded,
             tags: new[] { HealthCheckTags.Ai, HealthCheckTags.NonCritical },
-            timeout: TimeSpan.FromSeconds(5));
+            // ML microservice: 12s registration ceiling above the check's 10s internal
+            // cts, so model-load / cold-start latency does not flap Degraded.
+            timeout: TimeSpan.FromSeconds(12));
 
         // Conditional: PDF extractor providers — only register the check when the
         // provider is actually in use. The "Orchestrator" provider routes to both
@@ -117,7 +121,9 @@ public static class HealthCheckServiceExtensions
             "bggapi",
             HealthStatus.Degraded,
             tags: new[] { HealthCheckTags.External, HealthCheckTags.NonCritical },
-            timeout: TimeSpan.FromSeconds(5));
+            // External third-party API: 10s registration ceiling above the check's 8s
+            // internal cts, so routine BGG latency/rate-limiting does not flap Degraded.
+            timeout: TimeSpan.FromSeconds(10));
 
         builder.AddCheck<OAuthProvidersHealthCheck>(
             "oauth",

--- a/apps/api/src/Api/Infrastructure/HealthChecks/SharedGameCatalogHealthCheck.cs
+++ b/apps/api/src/Api/Infrastructure/HealthChecks/SharedGameCatalogHealthCheck.cs
@@ -11,15 +11,15 @@ namespace Api.Infrastructure.HealthChecks;
 /// and enrichment queue depth monitoring.
 ///
 /// Validates:
-/// - PostgreSQL FTS index (ix_shared_games_fts) usage
-/// - Search query performance (P95 target less than 200ms)
+/// - Search query performance against the FTS query
 /// - Category/Mechanic taxonomy data availability
 /// - Enrichment queue depth (Degraded if greater than 500 pending items)
 ///
-/// Health Status:
-/// - Healthy: P95 less than 200ms (target met) and queue depth less than or equal to 500
-/// - Degraded: P95 200-500ms OR queue depth greater than 500
-/// - Unhealthy: P95 greater than 500ms OR query failure
+/// Health Status (health-alert bands; the product P95 target stays under 200ms and is
+/// tracked separately via Prometheus — these coarser bands exist to avoid alert flapping):
+/// - Healthy: latency less than 400ms and queue depth less than or equal to 500
+/// - Degraded: latency 400-800ms OR queue depth greater than 500
+/// - Unhealthy: latency greater than or equal to 800ms OR query failure
 /// </summary>
 internal sealed class SharedGameCatalogHealthCheck : IHealthCheck
 {
@@ -89,13 +89,20 @@ internal sealed class SharedGameCatalogHealthCheck : IHealthCheck
                     enrichmentQueueDepth, queueDegradedThreshold);
             }
 
+            // FTS alert bands — raised from 200/500ms to 400/800ms so transient latency
+            // spikes (staging FTS is normally ~60ms) don't flap Degraded and spam alerts.
+            // The product P95 target stays <200ms (tracked via Prometheus); these coarser
+            // bands are for health-alert status only.
+            const double degradedLatencyMs = 400;
+            const double unhealthyLatencyMs = 800;
+
             // Determine health status based on performance and queue depth
-            if (ftsLatencyMs < 200 && !queueDegraded)
+            if (ftsLatencyMs < degradedLatencyMs && !queueDegraded)
             {
-                // Healthy: Target met (P95 < 200ms) and queue within bounds
+                // Healthy: latency within the alert band and queue within bounds
                 return HealthCheckResult.Healthy(
                     $"SharedGameCatalog FTS operational. " +
-                    $"Latency: {ftsLatencyMs:F2}ms (target: <200ms). " +
+                    $"Latency: {ftsLatencyMs:F2}ms (alert ≥ {degradedLatencyMs:F0}ms). " +
                     $"Games: {publishedGamesCount}, Categories: {categoriesCount}, Mechanics: {mechanicsCount}. " +
                     $"Enrichment queue: {enrichmentQueueDepth}",
                     new Dictionary<string, object>(StringComparer.Ordinal)
@@ -108,12 +115,12 @@ internal sealed class SharedGameCatalogHealthCheck : IHealthCheck
                         ["performance_status"] = "optimal"
                     });
             }
-            else if (ftsLatencyMs < 500)
+            else if (ftsLatencyMs < unhealthyLatencyMs)
             {
-                // Degraded: FTS suboptimal (200-500ms) or queue depth exceeded
+                // Degraded: FTS in the 400-800ms alert band or queue depth exceeded
                 var reasons = new List<string>();
-                if (ftsLatencyMs >= 200)
-                    reasons.Add($"FTS latency {ftsLatencyMs:F2}ms (target: <200ms)");
+                if (ftsLatencyMs >= degradedLatencyMs)
+                    reasons.Add($"FTS latency {ftsLatencyMs:F2}ms (alert ≥ {degradedLatencyMs:F0}ms)");
                 if (queueDegraded)
                     reasons.Add($"Enrichment queue depth {enrichmentQueueDepth} (threshold: {queueDegradedThreshold})");
 
@@ -135,14 +142,14 @@ internal sealed class SharedGameCatalogHealthCheck : IHealthCheck
             }
             else
             {
-                // Unhealthy: Severe performance degradation (> 500ms)
+                // Unhealthy: severe performance degradation (≥ 800ms alert band)
                 _logger.LogError(
-                    "SharedGameCatalog FTS unhealthy: {Latency}ms (target: <200ms)",
-                    ftsLatencyMs);
+                    "SharedGameCatalog FTS unhealthy: {Latency}ms (alert ≥ {Threshold}ms)",
+                    ftsLatencyMs, unhealthyLatencyMs);
 
                 return HealthCheckResult.Unhealthy(
                     $"SharedGameCatalog FTS performance critical. " +
-                    $"Latency: {ftsLatencyMs:F2}ms (target: <200ms). " +
+                    $"Latency: {ftsLatencyMs:F2}ms (alert ≥ {unhealthyLatencyMs:F0}ms). " +
                     $"Enrichment queue: {enrichmentQueueDepth}. " +
                     $"Immediate database maintenance required.",
                     data: new Dictionary<string, object>(StringComparer.Ordinal)

--- a/apps/api/src/Api/Services/EmailAlertChannel.cs
+++ b/apps/api/src/Api/Services/EmailAlertChannel.cs
@@ -45,6 +45,19 @@ internal class EmailAlertChannel : IAlertChannel
             return false;
         }
 
+        // Per-alert email suppression. The health monitor tags non-critical Degraded
+        // (warning) transitions with `_suppress_email` so they reach Slack/DB/dashboard
+        // but do NOT email — only Unhealthy (critical) health transitions email. This is
+        // scoped to the alert (via metadata), so budget/security/dead-letter warning
+        // emails are unaffected. Returns false (not routed) rather than throwing.
+        if (IsEmailSuppressed(metadata))
+        {
+            _logger.LogDebug(
+                "Email channel: alert {AlertType} flagged _suppress_email; skipping email delivery",
+                LogSanitizer.Sanitize(alertType));
+            return false;
+        }
+
         if (_config.To.Count == 0)
         {
             _logger.LogWarning("Email channel is not properly configured (no recipients)");
@@ -92,6 +105,28 @@ internal class EmailAlertChannel : IAlertChannel
             _logger.LogError(ex, "Failed to send email alert for {AlertType}", LogSanitizer.Sanitize(alertType));
             return false;
         }
+    }
+
+    /// <summary>
+    /// Metadata key set by the alert producer to route an alert to every channel
+    /// EXCEPT email. Used by the health monitor to keep non-critical Degraded (warning)
+    /// transitions off the mail channel while still surfacing them on Slack/dashboard.
+    /// </summary>
+    internal const string SuppressEmailMetadataKey = "_suppress_email";
+
+    private static bool IsEmailSuppressed(IDictionary<string, object>? metadata)
+    {
+        if (metadata is null || !metadata.TryGetValue(SuppressEmailMetadataKey, out var value) || value is null)
+        {
+            return false;
+        }
+
+        return value switch
+        {
+            bool b => b,
+            string s => bool.TryParse(s, out var parsed) && parsed,
+            _ => false
+        };
     }
 
     private static string FormatEmailBody(

--- a/apps/api/src/Api/appsettings.json
+++ b/apps/api/src/Api/appsettings.json
@@ -653,11 +653,12 @@
     }
   },
   "HealthMonitor": {
+    "Comment": "Anti-flapping hysteresis. DegradedThreshold=3 requires ~3min of sustained degradation (at the 60s poll interval) before a service is flagged Degraded and an alert fires — filters transient single-poll blips of non-critical services (external BGG API, ML cold-start, FTS latency spike). UnhealthyThreshold=5 leaves a 2-poll Degraded buffer before escalating to Unhealthy (critical).",
     "PollingIntervalSeconds": 60,
     "StartupDelaySeconds": 10,
     "ReminderIntervalMinutes": 30,
-    "DegradedThreshold": 1,
-    "UnhealthyThreshold": 3,
+    "DegradedThreshold": 3,
+    "UnhealthyThreshold": 5,
     "RecoveryThreshold": 2
   }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/Administration/EventHandlers/HealthStatusChangedEventHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Administration/EventHandlers/HealthStatusChangedEventHandlerTests.cs
@@ -127,6 +127,34 @@ public class HealthStatusChangedEventHandlerTests
         severity.Should().Be("info");
     }
 
+    // ── Email suppression tests ────────────────────────────────────────
+    // Non-critical health transitions (Degraded=warning, recovery=info) must reach
+    // Slack/DB/dashboard but NOT email; only Unhealthy (critical) transitions email.
+
+    [Fact]
+    public void Warning_severity_suppresses_email()
+    {
+        HealthStatusChangedEventHandler.ShouldSuppressEmail("warning").Should().BeTrue();
+    }
+
+    [Fact]
+    public void Info_severity_suppresses_email()
+    {
+        HealthStatusChangedEventHandler.ShouldSuppressEmail("info").Should().BeTrue();
+    }
+
+    [Fact]
+    public void Critical_severity_does_not_suppress_email()
+    {
+        HealthStatusChangedEventHandler.ShouldSuppressEmail("critical").Should().BeFalse();
+    }
+
+    [Fact]
+    public void ShouldSuppressEmail_is_case_insensitive()
+    {
+        HealthStatusChangedEventHandler.ShouldSuppressEmail("CRITICAL").Should().BeFalse();
+    }
+
     // ── AlertType format tests ─────────────────────────────────────────
 
     [Fact]

--- a/apps/api/tests/Api.Tests/BoundedContexts/Administration/EventHandlers/HealthStatusChangedEventHandlerWiringTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Administration/EventHandlers/HealthStatusChangedEventHandlerWiringTests.cs
@@ -1,0 +1,120 @@
+using Api.BoundedContexts.Administration.Application.EventHandlers;
+using Api.BoundedContexts.Administration.Domain.Events;
+using Api.Infrastructure;
+using Api.Infrastructure.Health.Models;
+using Api.Services;
+using Api.Tests.Constants;
+using Api.Tests.TestHelpers;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.Administration.EventHandlers;
+
+/// <summary>
+/// Wiring tests for <see cref="HealthStatusChangedEventHandler.Handle"/>: verify the
+/// handler actually populates the alert metadata with the <c>_suppress_email</c> flag for
+/// non-critical (Degraded/recovery) transitions and omits it for Unhealthy (critical) ones.
+/// This guards the exact code path that stops the flapping warning-mail spam — the static
+/// helper <c>ShouldSuppressEmail</c> is covered separately, but the Handle→metadata wiring
+/// (and its flow into AlertingService→EmailAlertChannel) needs its own coverage.
+///
+/// A relational DB provider is required for the idempotency guard; the InMemory provider
+/// is non-relational (Database.IsRelational() == false), so the handler skips the DB reads
+/// and writes and we can exercise the alerting path in isolation.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "Administration")]
+public sealed class HealthStatusChangedEventHandlerWiringTests
+{
+    private static MeepleAiDbContext CreateInMemoryDb() =>
+        new(
+            new DbContextOptionsBuilder<MeepleAiDbContext>()
+                .UseInMemoryDatabase($"health_handler_wiring_{Guid.NewGuid():N}")
+                .Options,
+            TestDbContextFactory.CreateMockMediator().Object,
+            TestDbContextFactory.CreateMockEventCollector().Object);
+
+    private static HealthStatusChangedEventHandler CreateHandler(
+        MeepleAiDbContext db, Mock<IAlertingService> alerting)
+    {
+        var serviceProvider = new Mock<IServiceProvider>();
+        serviceProvider.Setup(p => p.GetService(typeof(IAlertingService))).Returns(alerting.Object);
+        serviceProvider.Setup(p => p.GetService(typeof(MeepleAiDbContext))).Returns(db);
+
+        var scope = new Mock<IServiceScope>();
+        scope.Setup(s => s.ServiceProvider).Returns(serviceProvider.Object);
+
+        var scopeFactory = new Mock<IServiceScopeFactory>();
+        scopeFactory.Setup(f => f.CreateScope()).Returns(scope.Object);
+
+        return new HealthStatusChangedEventHandler(
+            scopeFactory.Object,
+            NullLogger<HealthStatusChangedEventHandler>.Instance);
+    }
+
+    [Fact]
+    public async Task Handle_DegradedTransition_TagsMetadataForEmailSuppression()
+    {
+        // Arrange — a non-critical service flaps to Degraded (warning)
+        var alerting = new Mock<IAlertingService>();
+        using var db = CreateInMemoryDb();
+        var handler = CreateHandler(db, alerting);
+
+        var evt = new HealthStatusChangedEvent(
+            ServiceName: "bggapi",
+            PreviousStatus: "Healthy",
+            CurrentStatus: "Degraded",
+            Description: "BGG degraded",
+            Tags: new[] { HealthCheckTags.External, HealthCheckTags.NonCritical },
+            TransitionAt: DateTime.UtcNow,
+            IsReminder: false);
+
+        // Act
+        await handler.Handle(evt, CancellationToken.None);
+
+        // Assert — dispatched as a warning WITH the email-suppression flag set
+        alerting.Verify(a => a.SendAlertAsync(
+            "health.bggapi",
+            "warning",
+            It.IsAny<string>(),
+            It.Is<IDictionary<string, object>>(m =>
+                m.ContainsKey(EmailAlertChannel.SuppressEmailMetadataKey)
+                && Equals(m[EmailAlertChannel.SuppressEmailMetadataKey], true)),
+            It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_UnhealthyTransition_DoesNotSuppressEmail()
+    {
+        // Arrange — a service transitions to Unhealthy (critical); email must still go out
+        var alerting = new Mock<IAlertingService>();
+        using var db = CreateInMemoryDb();
+        var handler = CreateHandler(db, alerting);
+
+        var evt = new HealthStatusChangedEvent(
+            ServiceName: "postgres",
+            PreviousStatus: "Degraded",
+            CurrentStatus: "Unhealthy",
+            Description: "DB unreachable",
+            Tags: new[] { HealthCheckTags.Core, HealthCheckTags.Critical },
+            TransitionAt: DateTime.UtcNow,
+            IsReminder: false);
+
+        // Act
+        await handler.Handle(evt, CancellationToken.None);
+
+        // Assert — dispatched as critical WITHOUT the suppression flag
+        alerting.Verify(a => a.SendAlertAsync(
+            "health.postgres",
+            "critical",
+            It.IsAny<string>(),
+            It.Is<IDictionary<string, object>>(m =>
+                !m.ContainsKey(EmailAlertChannel.SuppressEmailMetadataKey)),
+            It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+}

--- a/apps/api/tests/Api.Tests/Infrastructure/BackgroundServices/HealthMonitorStateMachineTests.cs
+++ b/apps/api/tests/Api.Tests/Infrastructure/BackgroundServices/HealthMonitorStateMachineTests.cs
@@ -23,6 +23,61 @@ public class HealthMonitorStateMachineTests
         ReminderIntervalMinutes = 30
     };
 
+    // Anti-flapping hysteresis: a non-critical service must degrade a few polls in a
+    // row before we transition (and alert). DegradedThreshold 3 means ~3 minutes of
+    // persistent degradation at the 60s poll interval.
+    private static readonly HealthMonitorOptions HysteresisOptions = new()
+    {
+        DegradedThreshold = 3,
+        UnhealthyThreshold = 5,
+        RecoveryThreshold = 2,
+        ReminderIntervalMinutes = 30
+    };
+
+    [Fact]
+    public void Healthy_stays_Healthy_before_degraded_threshold()
+    {
+        // Arrange — Healthy, DegradedThreshold 3, first transient failure
+        var state = CreateState("bggapi", "Healthy", consecutiveFailures: 0);
+
+        // Act — a single Degraded reading (e.g. BGG slow for one poll)
+        var result = HealthStateMachine.Evaluate(state, HealthStatus.Degraded, HysteresisOptions);
+
+        // Assert — no transition yet; the failure is merely counted
+        result.CurrentStatus.Should().Be("Healthy");
+        result.PreviousStatus.Should().Be("Healthy");
+        result.ConsecutiveFailures.Should().Be(1);
+    }
+
+    [Fact]
+    public void Healthy_transitions_to_Degraded_at_degraded_threshold()
+    {
+        // Arrange — Healthy with 2 prior failures accumulated (threshold 3)
+        var state = CreateState("bggapi", "Healthy", consecutiveFailures: 2);
+
+        // Act — the third consecutive failure crosses the threshold
+        var result = HealthStateMachine.Evaluate(state, HealthStatus.Degraded, HysteresisOptions);
+
+        // Assert — now (and only now) transition to Degraded
+        result.CurrentStatus.Should().Be("Degraded");
+        result.PreviousStatus.Should().Be("Healthy");
+        result.ConsecutiveFailures.Should().Be(3);
+    }
+
+    [Fact]
+    public void Healthy_failure_streak_resets_on_success_below_threshold()
+    {
+        // Arrange — Healthy accumulating failures but still below threshold
+        var state = CreateState("bggapi", "Healthy", consecutiveFailures: 2);
+
+        // Act — a success arrives before hitting the threshold (transient blip cleared)
+        var result = HealthStateMachine.Evaluate(state, HealthStatus.Healthy, HysteresisOptions);
+
+        // Assert — counter resets, no spurious Degraded transition ever emitted
+        result.CurrentStatus.Should().Be("Healthy");
+        result.ConsecutiveFailures.Should().Be(0);
+    }
+
     [Fact]
     public void Healthy_service_transitions_to_Degraded_after_one_failure()
     {

--- a/apps/api/tests/Api.Tests/Services/EmailAlertChannelTests.cs
+++ b/apps/api/tests/Api.Tests/Services/EmailAlertChannelTests.cs
@@ -64,6 +64,52 @@ public class EmailAlertChannelTests
     }
 
     [Fact]
+    public async Task SendAsync_WhenSuppressEmailMetadataSet_SkipsTransport_ReturnsFalse()
+    {
+        // Arrange — a Degraded (warning) health alert tagged for email suppression.
+        // Non-critical health warnings must NOT email (they still reach Slack/DB); only
+        // Unhealthy (critical) transitions email. This kills the flapping warning-mail
+        // spam from bggapi/reranker/embedding/shared-catalog-fts.
+        var channel = CreateChannel(EnabledConfig("ops@example.com"));
+        var metadata = new Dictionary<string, object>(StringComparer.Ordinal)
+        {
+            ["_suppress_email"] = true
+        };
+
+        // Act
+        var result = await channel.SendAsync("health.bggapi", "warning", "BGG degraded", metadata);
+
+        // Assert — not emailed, but not treated as a transport failure either
+        result.Should().BeFalse();
+        _emailService.Verify(s => s.SendRawEmailAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task SendAsync_WhenSuppressEmailMetadataAbsent_StillSends()
+    {
+        // Arrange — a critical (Unhealthy) health alert carries no suppression flag
+        var channel = CreateChannel(EnabledConfig("ops@example.com"));
+        var metadata = new Dictionary<string, object>(StringComparer.Ordinal)
+        {
+            ["service"] = "bggapi"
+        };
+
+        // Act
+        var result = await channel.SendAsync("health.bggapi", "critical", "BGG down", metadata);
+
+        // Assert — normal delivery is unaffected by the suppression path
+        result.Should().BeTrue();
+        _emailService.Verify(s => s.SendRawEmailAsync(
+            "ops@example.com",
+            It.Is<string>(sub => sub.Contains("CRITICAL", StringComparison.Ordinal)),
+            It.IsAny<string>(),
+            It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
     public async Task SendAsync_WhenTransportThrows_ReturnsFalse_AndDoesNotPropagate()
     {
         // Arrange


### PR DESCRIPTION
## Problema

Lo staging inviava mail ricorrenti `⚠️ [WARNING] health.<service>` per 4 health check **NonCritical**: `bggapi`, `reranker`, `embedding`, `shared-catalog-fts`.

Diagnosi (debugging sistematico + verifica runtime via `GET /api/v1/health`): al momento dell'indagine lo staging era **tutto Healthy** (es. `shared-catalog-fts` a 59ms). La causa non è un incidente ma **flapping transitorio** — questi servizi vanno `Degraded` a un singolo hiccup (BGG lento, cold-start ML, spike FTS) e recuperano. Con `DegradedThreshold=1` + email inviata su ogni `warning`, ogni flap generava una mail.

Flusso: `InfrastructureHealthMonitorService` (poll 60s) → `HealthStateMachine` → `HealthStatusChangedEventHandler` (`Degraded→warning`) → `AlertingService` → `EmailAlertChannel`.

## Fix (3, combinati)

### 1. Isteresi anti-flapping
- `HealthStateMachine` ora **rispetta `DegradedThreshold`** — prima lo ignorava, hardcodando 1 failure (**bug latente**: alzare la soglia in config non aveva effetto).
- Default alzati: `DegradedThreshold 1→3`, `UnhealthyThreshold 3→5`. Serve ~3 min di degrado persistente prima di un alert; cuscinetto di 2 poll in `Degraded` prima di escalare a `Unhealthy`.

### 2. Email solo per `critical` (mirato agli alert health)
- L'handler tagga i `warning` (Degraded) e `info` (recovery) health con `_suppress_email`; `EmailAlertChannel` li salta. Solo le transizioni `Unhealthy` (critical) inviano email.
- **Scoped al singolo alert via metadata** → i warning email di altri produttori (budget LLM, 2FA, dead-letter) **non** sono impattati.

### 3. Tuning per-servizio
- Timeout health check più generosi: `bggapi` cts 5→8s / reg 5→10s; `reranker`+`embedding` cts 5→10s / reg 5→12s (cap di registrazione sempre sopra il cts interno).
- Bande di alert FTS `200/500ms → 400/800ms` (il target di prodotto P95 <200ms resta tracciato via Prometheus).

## Test

+11 unit, **39 verdi**:
- Isteresi: resta Healthy sotto soglia, transisce a soglia, reset su success.
- Soppressione email: canale (`_suppress_email`) + helper statico `ShouldSuppressEmail`.
- **Wiring** `Handle()→metadata` (validato RED→GREEN rimuovendo temporaneamente il wiring).

## Review

Review olistica su subagent: 1 finding Important (copertura del wiring) → risolto con il test dedicato; 0 bug funzionali (isteresi, reset, scope soppressione, timeout tutti verificati).

## Nota di verifica

La logica è coperta dai test unit. La verifica end-to-end definitiva (le mail di warning cessano) è osservabile **solo dopo il deploy in staging** — da locale il monitor non è esercitabile contro l'ambiente reale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
