### PR TITLE
fix(kb): map invalid arbitro/decisore feedback enum input to 400 not 500 (#3174)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/SubmitDecisoreMoveFeedbackCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/SubmitDecisoreMoveFeedbackCommandHandler.cs
@@ -52,10 +52,10 @@ internal sealed class SubmitDecisoreMoveFeedbackCommandHandler : IRequestHandler
             throw new ConflictException($"Feedback already submitted for suggestion {request.SuggestionId}");
 
         if (!Enum.TryParse<MoveQualityAssessment>(request.Quality, ignoreCase: true, out var quality))
-            throw new InvalidOperationException($"Invalid quality value: {request.Quality}");
+            throw new BadRequestException($"Invalid quality value: {request.Quality}");
 
         if (!Enum.TryParse<GameOutcome>(request.Outcome, ignoreCase: true, out var outcome))
-            throw new InvalidOperationException($"Invalid outcome value: {request.Outcome}");
+            throw new BadRequestException($"Invalid outcome value: {request.Outcome}");
 
         var feedback = DecisoreMoveFeedback.Create(
             suggestionId: request.SuggestionId,

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/SubmitValidationFeedbackCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/SubmitValidationFeedbackCommandHandler.cs
@@ -71,7 +71,7 @@ internal sealed class SubmitValidationFeedbackCommandHandler : IRequestHandler<S
         // Parse accuracy enum
         if (!Enum.TryParse<AccuracyAssessment>(request.Accuracy, ignoreCase: true, out var accuracy))
         {
-            throw new InvalidOperationException($"Invalid accuracy value: {request.Accuracy}");
+            throw new BadRequestException($"Invalid accuracy value: {request.Accuracy}");
         }
 
         // Create feedback entity

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/FeedbackInvalidEnumMappingTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/FeedbackInvalidEnumMappingTests.cs
@@ -1,0 +1,131 @@
+using Api.BoundedContexts.GameManagement.Domain.Entities;
+using Api.BoundedContexts.GameManagement.Domain.Repositories;
+using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
+using Api.BoundedContexts.KnowledgeBase.Application.Commands;
+using Api.BoundedContexts.KnowledgeBase.Domain.Entities;
+using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Handlers;
+
+/// <summary>
+/// Issue #3174 - the arbitro/decisore feedback handlers threw InvalidOperationException on an
+/// invalid enum value supplied by the client, which the middleware maps to 500 instead of 400.
+/// These tests assert the handlers surface BadRequestException (400) for invalid enum input.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "KnowledgeBase")]
+public class SubmitValidationFeedbackInvalidEnumTests
+{
+    private static GameSession ActiveSession() => new(
+        id: Guid.NewGuid(),
+        gameId: Guid.NewGuid(),
+        players: new List<SessionPlayer> { new("Player 1", 1, "Red") },
+        createdByUserId: Guid.NewGuid());
+
+    [Fact]
+    public async Task Handle_InvalidAccuracy_ThrowsBadRequestException()
+    {
+        var gameSessionId = Guid.NewGuid();
+        var mockFeedbackRepo = new Mock<IArbitroValidationFeedbackRepository>();
+        var mockSessionRepo = new Mock<IGameSessionRepository>();
+        var mockUow = new Mock<IUnitOfWork>();
+        var mockLogger = new Mock<ILogger<SubmitValidationFeedbackCommandHandler>>();
+
+        mockSessionRepo
+            .Setup(r => r.GetByIdAsync(gameSessionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ActiveSession());
+        mockFeedbackRepo
+            .Setup(r => r.GetByValidationIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ArbitroValidationFeedback?)null);
+
+        var handler = new SubmitValidationFeedbackCommandHandler(
+            mockFeedbackRepo.Object, mockSessionRepo.Object, mockUow.Object, mockLogger.Object, TimeProvider.System);
+
+        var command = new SubmitValidationFeedbackCommand
+        {
+            ValidationId = Guid.NewGuid(),
+            GameSessionId = gameSessionId,
+            UserId = Guid.NewGuid(),
+            Rating = 5,
+            Accuracy = "not-a-valid-enum",
+            AiDecision = "approved",
+            AiConfidence = 0.9,
+            HadConflicts = false,
+        };
+
+        var act = () => handler.Handle(command, CancellationToken.None);
+        await act.Should().ThrowAsync<BadRequestException>().WithMessage("*accuracy*");
+    }
+}
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "KnowledgeBase")]
+public class SubmitDecisoreMoveFeedbackInvalidEnumTests
+{
+    private static GameSession ActiveSession() => new(
+        id: Guid.NewGuid(),
+        gameId: Guid.NewGuid(),
+        players: new List<SessionPlayer> { new("Player 1", 1, "Red") },
+        createdByUserId: Guid.NewGuid());
+
+    private static (SubmitDecisoreMoveFeedbackCommandHandler handler, Guid gameSessionId) BuildHandler()
+    {
+        var gameSessionId = Guid.NewGuid();
+        var mockFeedbackRepo = new Mock<IDecisoreMoveFeedbackRepository>();
+        var mockSessionRepo = new Mock<IGameSessionRepository>();
+        var mockUow = new Mock<IUnitOfWork>();
+        var mockLogger = new Mock<ILogger<SubmitDecisoreMoveFeedbackCommandHandler>>();
+
+        mockSessionRepo
+            .Setup(r => r.GetByIdAsync(gameSessionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(ActiveSession());
+        mockFeedbackRepo
+            .Setup(r => r.GetBySuggestionIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((DecisoreMoveFeedback?)null);
+
+        var handler = new SubmitDecisoreMoveFeedbackCommandHandler(
+            mockFeedbackRepo.Object, mockSessionRepo.Object, mockUow.Object, mockLogger.Object, TimeProvider.System);
+        return (handler, gameSessionId);
+    }
+
+    private static SubmitDecisoreMoveFeedbackCommand Command(Guid gameSessionId, string quality, string outcome) => new()
+    {
+        SuggestionId = Guid.NewGuid(),
+        GameSessionId = gameSessionId,
+        UserId = Guid.NewGuid(),
+        Rating = 4,
+        Quality = quality,
+        Outcome = outcome,
+        SuggestionFollowed = true,
+        TopSuggestedMove = "e4",
+        PositionStrength = 0.5,
+        AnalysisDepth = "Deep",
+    };
+
+    [Fact]
+    public async Task Handle_InvalidQuality_ThrowsBadRequestException()
+    {
+        var (handler, gameSessionId) = BuildHandler();
+        var command = Command(gameSessionId, quality: "not-a-valid-enum", outcome: "Win");
+
+        var act = () => handler.Handle(command, CancellationToken.None);
+        await act.Should().ThrowAsync<BadRequestException>().WithMessage("*quality*");
+    }
+
+    [Fact]
+    public async Task Handle_InvalidOutcome_ThrowsBadRequestException()
+    {
+        var (handler, gameSessionId) = BuildHandler();
+        var command = Command(gameSessionId, quality: "Helpful", outcome: "not-a-valid-enum");
+
+        var act = () => handler.Handle(command, CancellationToken.None);
+        await act.Should().ThrowAsync<BadRequestException>().WithMessage("*outcome*");
+    }
+}


### PR DESCRIPTION
## Sommario

`SubmitValidationFeedbackCommandHandler` e `SubmitDecisoreMoveFeedbackCommandHandler` lanciavano `InvalidOperationException` quando il client forniva un valore enum invalido (`accuracy` / `quality` / `outcome`). Il middleware mappa IOE a **500** (salvo msg con `"not found"`) → input client invalido restituiva **500** invece di **400**.

## Fix

`throw new BadRequestException(...)` (400) per tutti e 3 i parse falliti.

## Test (TDD)

Nuovo `FeedbackInvalidEnumMappingTests` (3 test: accuracy/quality/outcome invalidi → `BadRequestException`). RED (IOE) → GREEN 3/3. Nessun test esistente asseriva il vecchio comportamento.

Closes #3174

🤖 Generated with [Claude Code](https://claude.com/claude-code)