### PR TITLE
fix(session-tracking): #3157 C2a map live-slot index violation to 409

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/CreateSessionCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/CreateSessionCommandHandler.cs
@@ -300,6 +300,16 @@ public class CreateSessionCommandHandler : ICommandHandler<CreateSessionCommand,
                     AgentDefinitionId: agentDefinitionId,
                     ToolkitId: toolkitId);
             }
+            catch (DbUpdateException ex) when (IsGameNightLiveSlotViolation(ex))
+            {
+                // Issue #3157 C2a — the restored ix_game_night_sessions_unique_active index (C1)
+                // makes a concurrent create-in-the-same-night race a real unique violation (the
+                // read-check guard in ResolveGameNightAsync is not atomic with the insert). Map it
+                // to a clean 409 instead of the raw DbUpdateException → 500. NOT retried: the live
+                // slot is genuinely taken by a sibling session.
+                throw new ConflictException(
+                    "This game night already has a live session in progress. Only one live session per game night is allowed.");
+            }
             catch (InvalidOperationException ex) when (attempt < maxRetries - 1)
             {
                 _logger.LogDebug(ex, "Session code collision on attempt {Attempt}, retrying", attempt + 1);
@@ -308,6 +318,13 @@ public class CreateSessionCommandHandler : ICommandHandler<CreateSessionCommand,
 
         throw new ConflictException("Unable to generate unique session code after retries");
     }
+
+    // Issue #3157 C2a — true iff the DbUpdateException is the partial-unique-index violation on
+    // the GameNight live slot (game_night_sessions InProgress per event), not some other constraint.
+    private static bool IsGameNightLiveSlotViolation(DbUpdateException ex) =>
+        ex.InnerException is Npgsql.PostgresException pg
+        && string.Equals(pg.SqlState, Npgsql.PostgresErrorCodes.UniqueViolation, StringComparison.Ordinal)
+        && string.Equals(pg.ConstraintName, "ix_game_night_sessions_unique_active", StringComparison.Ordinal);
 
     /// <summary>
     /// Session Flow v2.1 — T4.

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Commands/PauseResumeSessionTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Commands/PauseResumeSessionTests.cs
@@ -408,4 +408,32 @@ public sealed class PauseResumeSessionTests : IAsyncLifetime
             .FirstAsync(l => l.SessionId == created.SessionId, TestCancellationToken);
         link.Status.Should().Be(nameof(Api.BoundedContexts.GameManagement.Domain.Enums.GameNightSessionStatus.Completed));
     }
+
+    // Issue #3157 C2a — the restored unique index (C1) turns a concurrent create-in-the-same-night
+    // race into a real 23505; the handler must map it to a clean 409 (ConflictException), not a 500.
+    // Reproduced deterministically: leave one InProgress link whose session is NOT Active (so the
+    // read-check guard passes), then create a second session in the same night → the 2nd InProgress
+    // link violates ix_game_night_sessions_unique_active.
+    [Fact]
+    public async Task CreateSession_LiveSlotIndexViolation_MapsTo409()
+    {
+        var (userId, gameId) = await _fixture.SeedUserWithLibraryGameAndIndexedKbAsync(_dbContext!, vectorCount: 2);
+        var first = await _createHandler!.Handle(BuildCreateCommand(userId, gameId), TestCancellationToken);
+        await _pauseHandler!.Handle(new PauseSessionCommand(first.SessionId, userId), TestCancellationToken);
+        _dbContext!.ChangeTracker.Clear();
+
+        // Re-flip the (now Pending) link back to InProgress while its session stays Paused: one
+        // InProgress link the Active-count read-check cannot see. Index still allows exactly 1.
+        var link0 = await _dbContext.GameNightSessions
+            .FirstAsync(l => l.SessionId == first.SessionId, TestCancellationToken);
+        link0.Status = nameof(Api.BoundedContexts.GameManagement.Domain.Enums.GameNightSessionStatus.InProgress);
+        await _dbContext.SaveChangesAsync(TestCancellationToken);
+        _dbContext.ChangeTracker.Clear();
+
+        var act = async () => await _createHandler.Handle(
+            BuildCreateCommand(userId, gameId, first.GameNightEventId), TestCancellationToken);
+
+        (await act.Should().ThrowAsync<ConflictException>())
+            .Which.Message.Should().Contain("live session in progress");
+    }
 }


### PR DESCRIPTION
Partial fix for #3157 (scope **C2a**), building on C1 (#3179).

## Why

C1 restored the `ix_game_night_sessions_unique_active` partial unique index (max 1 `InProgress` link per GameNight). Because the create-path's "max 1 active" check (`ResolveGameNightAsync`) is a **read-check that is not atomic** with the subsequent insert, a genuinely concurrent "two creates in the same game night" race now passes both read-checks and both mint an `InProgress` link — the second `SaveChanges` hits the restored index and raises a raw `DbUpdateException` → **HTTP 500**.

## What

`CreateSessionCommandHandler` now catches that **specific** violation (`PostgresException` `SqlState == 23505` **and** `ConstraintName == "ix_game_night_sessions_unique_active"`) and maps it to a clean **409 `ConflictException`** — per exception rule #2568, and the same pattern just merged in #3181 (`fix(session-tracking): map … to 409 not 500`). It is **not** retried (unlike the session-code-collision retry): the live slot is genuinely taken by a sibling session. The filter is constraint-specific, so session-code collisions and any other constraint are unaffected.

## Test

A deterministic Testcontainers-Postgres test reproduces the race outcome without concurrency: it leaves one `InProgress` link whose session is **not** `Active` (so the Active-count read-check can't see it — the index still allows exactly one), then creates a second session in the same night → the 2nd `InProgress` link violates the index → asserts a `ConflictException` (409), not a 500.

## Out of scope (remaining C2 on #3157)

Guard realignment off `Session.Status==Active`; two-writer-path (raw-EF vs domain-aggregate) reconciliation; warning #13 query. Tracked on the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
