### PR TITLE
fix(game-management): fix untranslatable ExportRuleSpecs query + 404 on empty (#3175)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/ExportRuleSpecsCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/ExportRuleSpecsCommandHandler.cs
@@ -1,6 +1,7 @@
 using Api.BoundedContexts.GameManagement.Application.Commands;
 using Api.Helpers;
 using Api.Infrastructure;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Application.Interfaces;
 using Microsoft.EntityFrameworkCore;
 using System.IO.Compression;
@@ -42,24 +43,23 @@ internal class ExportRuleSpecsCommandHandler : ICommandHandler<ExportRuleSpecsCo
             throw new ArgumentException("Cannot export more than 100 rule specs at once", nameof(command));
         }
 
-        // Fetch all rule specs with their latest versions
-        // Note: Include must come AFTER GroupBy projection to materialize navigation properties
-        var latestSpecIds = await _dbContext.RuleSpecs
-            .AsNoTracking()
-            .Where(rs => command.GameIds.Contains(rs.GameId))
-            .GroupBy(rs => rs.GameId)
-            .Select(g => g.MaxBy(rs => rs.CreatedAt)!.Id)
-            .ToListAsync(cancellationToken).ConfigureAwait(false);
-
-        var ruleSpecs = await _dbContext.RuleSpecs
+        // Fetch the candidate rule specs (with atoms) for the requested games, then pick the
+        // latest version per game client-side. EF Core cannot translate GroupBy + MaxBy to SQL
+        // ("The LINQ expression could not be translated"), so the grouping must run in memory.
+        var candidateSpecs = await _dbContext.RuleSpecs
             .AsNoTracking()
             .Include(rs => rs.Atoms)
-            .Where(rs => latestSpecIds.Contains(rs.Id))
+            .Where(rs => command.GameIds.Contains(rs.GameId))
             .ToListAsync(cancellationToken).ConfigureAwait(false);
+
+        var ruleSpecs = candidateSpecs
+            .GroupBy(rs => rs.GameId)
+            .Select(g => g.MaxBy(rs => rs.CreatedAt)!)
+            .ToList();
 
         if (ruleSpecs.Count == 0)
         {
-            throw new InvalidOperationException("No rule specs found for the provided game IDs");
+            throw new NotFoundException("No rule specs found for the provided game IDs");
         }
 
         // Create ZIP archive in memory

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/Integration/ExportRuleSpecsCommandHandlerIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/Integration/ExportRuleSpecsCommandHandlerIntegrationTests.cs
@@ -1,0 +1,70 @@
+using Api.BoundedContexts.GameManagement.Application.Commands;
+using Api.Infrastructure;
+using Api.Middleware.Exceptions;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Application.Handlers.Integration;
+
+/// <summary>
+/// Issue #3175 - ExportRuleSpecsCommandHandler threw InvalidOperationException("No rule specs
+/// found ...") when no rule specs matched the requested game IDs. The message does NOT contain
+/// the substring "not found", so the middleware fell through to 500 instead of 404. The handler
+/// must surface NotFoundException (404).
+///
+/// Integration test (real Postgres): the handler's latest-version query
+/// (GroupBy + MaxBy) is not translatable by the EF InMemory provider, so a real provider
+/// is required to exercise the count == 0 branch.
+/// </summary>
+[Collection("Integration-GroupD")]
+[Trait("Category", TestCategories.Integration)]
+public sealed class ExportRuleSpecsCommandHandlerIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private MeepleAiDbContext _dbContext = null!;
+    private ExportRuleSpecsCommandHandler _handler = null!;
+
+    public ExportRuleSpecsCommandHandlerIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        var dbName = $"test_export_rulespecs_{Guid.NewGuid():N}";
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(dbName);
+
+        var options = new DbContextOptionsBuilder<MeepleAiDbContext>()
+            .UseNpgsql(connectionString, o => o.UseVector())
+            .Options;
+
+        _dbContext = new MeepleAiDbContext(
+            options,
+            TestDbContextFactory.CreateMockMediator().Object,
+            TestDbContextFactory.CreateMockEventCollector().Object);
+        await _dbContext.Database.MigrateAsync();
+
+        _handler = new ExportRuleSpecsCommandHandler(_dbContext);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _dbContext.DisposeAsync();
+    }
+
+    [Fact]
+    public async Task Handle_NoRuleSpecsForProvidedGameIds_ThrowsNotFoundException()
+    {
+        // The database has no rule specs for this random game id, so the handler must
+        // surface NotFoundException (404), not InvalidOperationException (500).
+        var command = new ExportRuleSpecsCommand(new List<Guid> { Guid.NewGuid() });
+
+        var act = () => _handler.Handle(command, CancellationToken.None);
+
+        await act.Should().ThrowAsync<NotFoundException>().WithMessage("*rule specs*");
+    }
+}


### PR DESCRIPTION
## Sommario

Durante l'implementazione del fix exception-mapping è emerso un bug **più grave** dell'atteso: `ExportRuleSpecsCommandHandler` costruiva la lista delle versioni più recenti con `GroupBy(...).Select(g => g.MaxBy(...))`, che **EF Core non traduce in SQL** (`The LINQ expression could not be translated`). Verificato con Postgres reale: il handler lanciava `InvalidOperationException` (500) su **ogni** chiamata → l'endpoint export era completamente rotto, e il `throw` per il caso "nessuna rule spec" era **dead code irraggiungibile**.

## Fix

1. **Query riparata**: materializzo le candidate specs (`Where` + `Include`) e scelgo la versione più recente per gioco **client-side** (LINQ to Objects, dove `MaxBy` funziona).
2. **Exception mapping**: `throw new NotFoundException(...)` (404) quando nessuna rule spec corrisponde ai game ID richiesti (il middleware mappava `"No rule specs found"` a 500 perché il messaggio non contiene la substring `"not found"`).

## Test (TDD)

`ExportRuleSpecsCommandHandlerIntegrationTests` (Testcontainers Postgres — l'InMemory provider non traduce la query GroupBy+MaxBy). RED: `InvalidOperationException` (LINQ translation) → GREEN: `NotFoundException` sul caso vuoto.

Closes #3175

🤖 Generated with [Claude Code](https://claude.com/claude-code)