### PR TITLE
refactor(admin): AdminPipeline health via MediatR pass-through queries (#3176)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Queries/GetServiceHealthStatusesQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Queries/GetServiceHealthStatusesQuery.cs
@@ -1,0 +1,30 @@
+using Api.BoundedContexts.Administration.Domain.Services;
+using Api.SharedKernel.Application.Interfaces;
+using MediatR;
+
+namespace Api.BoundedContexts.Administration.Application.Queries;
+
+/// <summary>
+/// Query returning the raw health status of all monitored infrastructure services.
+/// Unlike <see cref="GetInfrastructureHealthQuery"/> (which returns a transformed DTO with a
+/// string State), this preserves the domain <see cref="ServiceHealthStatus"/> records — including
+/// the <c>HealthState</c> enum — for consumers that need the full detail, e.g. the RAG pipeline
+/// health endpoint. Issue #3176 (CQRS conformity: endpoints must use IMediator, not services).
+/// </summary>
+internal record GetServiceHealthStatusesQuery : IQuery<IReadOnlyCollection<ServiceHealthStatus>>;
+
+internal sealed class GetServiceHealthStatusesQueryHandler
+    : IRequestHandler<GetServiceHealthStatusesQuery, IReadOnlyCollection<ServiceHealthStatus>>
+{
+    private readonly IInfrastructureHealthService _healthService;
+
+    public GetServiceHealthStatusesQueryHandler(IInfrastructureHealthService healthService)
+    {
+        _healthService = healthService ?? throw new ArgumentNullException(nameof(healthService));
+    }
+
+    public Task<IReadOnlyCollection<ServiceHealthStatus>> Handle(
+        GetServiceHealthStatusesQuery request,
+        CancellationToken cancellationToken)
+        => _healthService.GetAllServicesHealthAsync(cancellationToken);
+}

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Queries/GetStepDurationStatsQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Queries/GetStepDurationStatsQuery.cs
@@ -1,0 +1,31 @@
+using Api.BoundedContexts.DocumentProcessing.Application.Services;
+using Api.BoundedContexts.DocumentProcessing.Domain.ValueObjects;
+using Api.SharedKernel.Application.Interfaces;
+using MediatR;
+
+namespace Api.BoundedContexts.DocumentProcessing.Application.Queries;
+
+/// <summary>
+/// Query returning the raw per-step duration statistics. Unlike
+/// <see cref="GetProcessingMetricsQuery"/> (which returns a transformed ProcessingMetricsDto that
+/// splits averages and percentiles), this preserves the <see cref="StepDurationStats"/> records the
+/// RAG pipeline health endpoint consumes. Issue #3176 (CQRS conformity: endpoints must use
+/// IMediator, not services).
+/// </summary>
+internal record GetStepDurationStatsQuery : IQuery<Dictionary<string, StepDurationStats>>;
+
+internal sealed class GetStepDurationStatsQueryHandler
+    : IRequestHandler<GetStepDurationStatsQuery, Dictionary<string, StepDurationStats>>
+{
+    private readonly IProcessingMetricsService _metricsService;
+
+    public GetStepDurationStatsQueryHandler(IProcessingMetricsService metricsService)
+    {
+        _metricsService = metricsService ?? throw new ArgumentNullException(nameof(metricsService));
+    }
+
+    public Task<Dictionary<string, StepDurationStats>> Handle(
+        GetStepDurationStatsQuery request,
+        CancellationToken cancellationToken)
+        => _metricsService.GetAllStepStatisticsAsync(cancellationToken);
+}

--- a/apps/api/src/Api/Routing/AdminPipelineEndpoints.cs
+++ b/apps/api/src/Api/Routing/AdminPipelineEndpoints.cs
@@ -1,8 +1,8 @@
 using System.Globalization;
+using Api.BoundedContexts.Administration.Application.Queries;
 using Api.BoundedContexts.Administration.Domain.Services;
 using Api.BoundedContexts.DocumentProcessing.Application.Queries;
 using Api.BoundedContexts.DocumentProcessing.Application.Queries.Queue;
-using Api.BoundedContexts.DocumentProcessing.Application.Services;
 using Api.BoundedContexts.DocumentProcessing.Domain.ValueObjects;
 using Api.Filters;
 using MediatR;
@@ -36,16 +36,15 @@ internal static class AdminPipelineEndpoints
     }
 
     private static async Task<IResult> GetPipelineHealth(
-        IInfrastructureHealthService healthService,
-        IProcessingMetricsService metricsService,
         IHttpClientFactory httpClientFactory,
         IMediator mediator,
         ILogger<Program> logger,
         CancellationToken ct)
     {
-        // Run independent queries in parallel
-        var healthTask = healthService.GetAllServicesHealthAsync(ct);
-        var metricsTask = metricsService.GetAllStepStatisticsAsync(ct);
+        // Run independent queries in parallel. CQRS #3176: infrastructure health and step metrics
+        // are fetched via IMediator (pass-through queries) instead of injecting the services.
+        var healthTask = mediator.Send(new GetServiceHealthStatusesQuery(), ct);
+        var metricsTask = mediator.Send(new GetStepDurationStatsQuery(), ct);
         var storageTask = mediator.Send(new GetPdfStorageHealthQuery(), ct);
         var queueTask = mediator.Send(new GetProcessingQueueQuery(
             StatusFilter: null,

--- a/apps/api/tests/Api.Tests/BoundedContexts/Administration/Application/Handlers/GetServiceHealthStatusesQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Administration/Application/Handlers/GetServiceHealthStatusesQueryHandlerTests.cs
@@ -1,0 +1,35 @@
+using Api.BoundedContexts.Administration.Application.Queries;
+using Api.BoundedContexts.Administration.Domain.Services;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.Administration.Application.Handlers;
+
+/// <summary>
+/// Issue #3176 - GetServiceHealthStatusesQuery is a CQRS pass-through so the RAG pipeline
+/// health endpoint can obtain the raw ServiceHealthStatus collection via IMediator instead of
+/// injecting IInfrastructureHealthService directly.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "Administration")]
+public class GetServiceHealthStatusesQueryHandlerTests
+{
+    [Fact]
+    public async Task Handle_ReturnsAllServiceHealthStatusesFromService()
+    {
+        IReadOnlyCollection<ServiceHealthStatus> expected = new List<ServiceHealthStatus>();
+        var mockService = new Mock<IInfrastructureHealthService>();
+        mockService
+            .Setup(s => s.GetAllServicesHealthAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expected);
+
+        var handler = new GetServiceHealthStatusesQueryHandler(mockService.Object);
+
+        var result = await handler.Handle(new GetServiceHealthStatusesQuery(), CancellationToken.None);
+
+        result.Should().BeSameAs(expected);
+        mockService.Verify(s => s.GetAllServicesHealthAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Handlers/GetStepDurationStatsQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Handlers/GetStepDurationStatsQueryHandlerTests.cs
@@ -1,0 +1,36 @@
+using Api.BoundedContexts.DocumentProcessing.Application.Queries;
+using Api.BoundedContexts.DocumentProcessing.Application.Services;
+using Api.BoundedContexts.DocumentProcessing.Domain.ValueObjects;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.DocumentProcessing.Application.Handlers;
+
+/// <summary>
+/// Issue #3176 - GetStepDurationStatsQuery is a CQRS pass-through so the RAG pipeline health
+/// endpoint can obtain the raw per-step StepDurationStats via IMediator instead of injecting
+/// IProcessingMetricsService directly.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "DocumentProcessing")]
+public class GetStepDurationStatsQueryHandlerTests
+{
+    [Fact]
+    public async Task Handle_ReturnsAllStepStatisticsFromService()
+    {
+        var expected = new Dictionary<string, StepDurationStats>();
+        var mockService = new Mock<IProcessingMetricsService>();
+        mockService
+            .Setup(s => s.GetAllStepStatisticsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expected);
+
+        var handler = new GetStepDurationStatsQueryHandler(mockService.Object);
+
+        var result = await handler.Handle(new GetStepDurationStatsQuery(), CancellationToken.None);
+
+        result.Should().BeSameAs(expected);
+        mockService.Verify(s => s.GetAllStepStatisticsAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+}


### PR DESCRIPTION
## Sommario

`AdminPipelineEndpoints.GetPipelineHealth` iniettava `IInfrastructureHealthService` e `IProcessingMetricsService` **direttamente**, chiamandoli affianco a `mediator.Send` nello stesso metodo — violazione della regola CQRS (#2568): gli endpoint devono usare **solo** `IMediator`.

## Perché non riusare le query esistenti

`GetInfrastructureHealthQuery` / `GetProcessingMetricsQuery` esistono ma ritornano DTO **trasformati e lossy** per questo endpoint:
- `InfrastructureHealthResponse.Services` usa `ServiceHealthDto` con `State` come **string**, mentre la logica downstream confronta l'enum `HealthState`.
- `ProcessingMetricsDto` separa `Averages`/`Percentiles`, mentre l'endpoint usa l'unico `StepDurationStats` (con `P95DurationSeconds` ecc.).

Riusarle avrebbe richiesto di riscrivere tutta la logica `Build*Stage` su un endpoint **senza test**.

## Fix

Aggiunte due query **pass-through** che preservano i tipi raw consumati dall'endpoint:
- `GetServiceHealthStatusesQuery` → `IReadOnlyCollection<ServiceHealthStatus>`
- `GetStepDurationStatsQuery` → `Dictionary<string, StepDurationStats>`

L'endpoint ora dipende solo da `IMediator`; la logica downstream è **invariata**. Rimosso l'import inutilizzato (build Release verde con `TreatWarningsAsErrors`).

## Test (TDD)

Unit test per entrambi gli handler (delega al service, `Times.Once`). RED (handler inesistenti) → GREEN 2/2. Build Release Api: 0 errori.

Closes #3176

🤖 Generated with [Claude Code](https://claude.com/claude-code)