### PR TITLE
fix(game-night): #2989 disable RSVP CTAs while offline (gap 5)

### DIFF
--- a/apps/web/src/app/(authenticated)/game-nights/[id]/_components/GameNightDetailView.tsx
+++ b/apps/web/src/app/(authenticated)/game-nights/[id]/_components/GameNightDetailView.tsx
@@ -47,6 +47,7 @@ import { useCurrentUser } from '@/hooks/queries/useCurrentUser';
 import { useGameNightDetail } from '@/hooks/queries/useGameNightDetail';
 import { useCancelGameNight, usePublishGameNight } from '@/hooks/queries/useGameNights';
 import { useSharedGames } from '@/hooks/queries/useSharedGames';
+import { useNetworkStatus } from '@/hooks/useNetworkStatus';
 import { useToast } from '@/hooks/useToast';
 import { useTranslation } from '@/hooks/useTranslation';
 import type { RsvpResponse } from '@/lib/game-nights/rsvp-state-machine';
@@ -91,6 +92,8 @@ export function GameNightDetailView({ id }: { id: string }): React.JSX.Element {
   const searchParams = useSearchParams();
   const { t, locale } = useTranslation();
   const { toast } = useToast();
+  // #2989 gap 5: RSVP CTAs are disabled while offline (can't reach the server).
+  const { isOffline } = useNetworkStatus();
 
   const { data: viewer } = useCurrentUser();
   const detail = useGameNightDetail(id, viewer?.id);
@@ -453,6 +456,7 @@ export function GameNightDetailView({ id }: { id: string }): React.JSX.Element {
             currentResponse={currentResponse}
             pendingResponse={pendingResponse}
             onSelect={handleRsvp}
+            disabled={isOffline}
             compact
           />
         </MobileStickyBar>

--- a/apps/web/src/app/(authenticated)/game-nights/[id]/_components/__tests__/GameNightDetailView.mobileSticky.test.tsx
+++ b/apps/web/src/app/(authenticated)/game-nights/[id]/_components/__tests__/GameNightDetailView.mobileSticky.test.tsx
@@ -12,6 +12,7 @@ import { GameNightDetailView } from '../GameNightDetailView';
 const detailMock = vi.fn();
 const getTabMock = vi.fn<(key: string) => string | null>();
 const currentUserMock = vi.fn();
+const networkStatusMock = vi.fn<() => { isOffline: boolean }>();
 
 vi.mock('@/hooks/queries/useGameNightDetail', () => ({
   useGameNightDetail: () => detailMock(),
@@ -38,6 +39,10 @@ vi.mock('@/hooks/useToast', () => ({ useToast: () => ({ toast: vi.fn() }) }));
 vi.mock('@/hooks/useTranslation', () => ({
   useTranslation: () => ({ t: (k: string) => k, locale: 'it-IT' }),
 }));
+// #2989 gap 5: RSVP CTAs are offline-disabled from useNetworkStatus.
+vi.mock('@/hooks/useNetworkStatus', () => ({
+  useNetworkStatus: () => networkStatusMock(),
+}));
 vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
   useSearchParams: () => ({ get: getTabMock }),
@@ -46,7 +51,9 @@ vi.mock('next/navigation', () => ({
 vi.mock('@/components/features/game-night-detail', () => ({
   GameNightDetailHero: () => <div data-testid="hero" />,
   GameNightCancelledBanner: () => null,
-  GameNightRsvpActionBar: () => <div data-testid="rsvp-action-bar" />,
+  GameNightRsvpActionBar: (props: { disabled?: boolean }) => (
+    <div data-testid="rsvp-action-bar" data-disabled={String(Boolean(props.disabled))} />
+  ),
   GameNightRsvpRow: () => <div data-testid="rsvp-row" />,
 }));
 vi.mock('@/components/game-night/GameNightActions', () => ({
@@ -106,6 +113,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   getTabMock.mockReturnValue(null);
   currentUserMock.mockReturnValue({ data: { id: 'guest-1' } });
+  networkStatusMock.mockReturnValue({ isOffline: false });
 });
 
 describe('GameNightDetailView — mobile sticky action bars (#2989 Screen C)', () => {
@@ -117,6 +125,24 @@ describe('GameNightDetailView — mobile sticky action bars (#2989 Screen C)', (
     expectMobileSticky(bar);
     // The action bar itself lives inside the sticky wrapper.
     expect(bar.querySelector('[data-testid="rsvp-action-bar"]')).not.toBeNull();
+  });
+
+  // #2989 gap 5: while offline the guest RSVP CTAs must be disabled (they can't
+  // reach the server) and re-enable on reconnect.
+  it('disables the guest RSVP action bar while offline', () => {
+    networkStatusMock.mockReturnValue({ isOffline: true });
+    mockDetail({ actor: { actor: 'guest' } });
+    render(<GameNightDetailView id="gn-1" />);
+
+    expect(screen.getByTestId('rsvp-action-bar').getAttribute('data-disabled')).toBe('true');
+  });
+
+  it('leaves the guest RSVP action bar enabled while online', () => {
+    networkStatusMock.mockReturnValue({ isOffline: false });
+    mockDetail({ actor: { actor: 'guest' } });
+    render(<GameNightDetailView id="gn-1" />);
+
+    expect(screen.getByTestId('rsvp-action-bar').getAttribute('data-disabled')).toBe('false');
   });
 
   it('wraps the host "Invia inviti" CTA in a mobile sticky bottom bar on a Draft night', () => {

--- a/apps/web/src/components/features/home/HomeFeed.tsx
+++ b/apps/web/src/components/features/home/HomeFeed.tsx
@@ -27,6 +27,7 @@ import { useRecentChatSessions } from '@/hooks/queries/useChatSessions';
 import { useRsvpGameNight, useUpcomingGameNights } from '@/hooks/queries/useGameNights';
 import { useRecentlyAddedGames } from '@/hooks/queries/useLibrary';
 import { useNavigation } from '@/hooks/useNavigation';
+import { useNetworkStatus } from '@/hooks/useNetworkStatus';
 
 import { RecentSection } from './RecentSection';
 
@@ -34,6 +35,8 @@ export function HomeFeed() {
   const router = useRouter();
   const { openDetail } = useNavigation();
   const rsvpMutation = useRsvpGameNight();
+  // #2989 gap 5: pending-RSVP CTAs are disabled while offline (can't reach the server).
+  const { isOffline } = useNetworkStatus();
 
   const { data: activeSessions, isLoading: sessionsLoading } = useActiveSessions(5);
   const { data: recentGames, isLoading: gamesLoading } = useRecentlyAddedGames(6);
@@ -140,7 +143,9 @@ export function HomeFeed() {
                   eventId={night.id}
                   title={night.title}
                   inviterName={night.organizerName}
-                  disabled={rsvpMutation.isPending && rsvpMutation.variables?.id === night.id}
+                  disabled={
+                    isOffline || (rsvpMutation.isPending && rsvpMutation.variables?.id === night.id)
+                  }
                   onConfirm={() => rsvpMutation.mutate({ id: night.id, response: 'Accepted' })}
                   onDecline={() => rsvpMutation.mutate({ id: night.id, response: 'Declined' })}
                 />

--- a/apps/web/src/components/features/home/__tests__/HomeFeed.offlineRsvp.test.tsx
+++ b/apps/web/src/components/features/home/__tests__/HomeFeed.offlineRsvp.test.tsx
@@ -8,12 +8,13 @@ import { HomeFeed } from '../HomeFeed';
 
 const networkStatusMock = vi.fn<() => { isOffline: boolean }>();
 const upcomingNightsMock = vi.fn();
+const rsvpMutationMock = vi.fn();
 
 vi.mock('@/hooks/useNetworkStatus', () => ({
   useNetworkStatus: () => networkStatusMock(),
 }));
 vi.mock('@/hooks/queries/useGameNights', () => ({
-  useRsvpGameNight: () => ({ mutate: vi.fn(), isPending: false, variables: undefined }),
+  useRsvpGameNight: () => rsvpMutationMock(),
   useUpcomingGameNights: () => upcomingNightsMock(),
 }));
 vi.mock('@/hooks/queries/useActiveSessions', () => ({
@@ -60,6 +61,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   networkStatusMock.mockReturnValue({ isOffline: false });
   upcomingNightsMock.mockReturnValue({ data: [pendingNight], isLoading: false });
+  rsvpMutationMock.mockReturnValue({ mutate: vi.fn(), isPending: false, variables: undefined });
 });
 
 describe('HomeFeed — offline-disabled pending RSVP (#2989 gap 5)', () => {
@@ -72,6 +74,34 @@ describe('HomeFeed — offline-disabled pending RSVP (#2989 gap 5)', () => {
 
   it('leaves the pending-RSVP card enabled while online', () => {
     networkStatusMock.mockReturnValue({ isOffline: false });
+    render(<HomeFeed />);
+
+    expect(screen.getByTestId('pending-rsvp-card').getAttribute('data-disabled')).toBe('false');
+  });
+
+  // Guards the other half of `isOffline || (isPending && variables?.id === night.id)`:
+  // an in-flight RSVP for THIS night disables its card even while online, so the
+  // double-submit guard survives a regression to the correlation check.
+  it('disables the pending-RSVP card while its own RSVP mutation is in flight (online)', () => {
+    networkStatusMock.mockReturnValue({ isOffline: false });
+    rsvpMutationMock.mockReturnValue({
+      mutate: vi.fn(),
+      isPending: true,
+      variables: { id: 'gn-1' },
+    });
+    render(<HomeFeed />);
+
+    expect(screen.getByTestId('pending-rsvp-card').getAttribute('data-disabled')).toBe('true');
+  });
+
+  // Correlation guard: an in-flight RSVP for a DIFFERENT night must NOT disable this card.
+  it("keeps the card enabled when a different night's RSVP is in flight (online)", () => {
+    networkStatusMock.mockReturnValue({ isOffline: false });
+    rsvpMutationMock.mockReturnValue({
+      mutate: vi.fn(),
+      isPending: true,
+      variables: { id: 'other-night' },
+    });
     render(<HomeFeed />);
 
     expect(screen.getByTestId('pending-rsvp-card').getAttribute('data-disabled')).toBe('false');

--- a/apps/web/src/components/features/home/__tests__/HomeFeed.offlineRsvp.test.tsx
+++ b/apps/web/src/components/features/home/__tests__/HomeFeed.offlineRsvp.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { HomeFeed } from '../HomeFeed';
+
+// #2989 gap 5: the pending-RSVP card on the mobile home dashboard is offline-disabled
+// (it can't reach the server), driven by useNetworkStatus, and re-enables on reconnect.
+
+const networkStatusMock = vi.fn<() => { isOffline: boolean }>();
+const upcomingNightsMock = vi.fn();
+
+vi.mock('@/hooks/useNetworkStatus', () => ({
+  useNetworkStatus: () => networkStatusMock(),
+}));
+vi.mock('@/hooks/queries/useGameNights', () => ({
+  useRsvpGameNight: () => ({ mutate: vi.fn(), isPending: false, variables: undefined }),
+  useUpcomingGameNights: () => upcomingNightsMock(),
+}));
+vi.mock('@/hooks/queries/useActiveSessions', () => ({
+  useActiveSessions: () => ({ data: { sessions: [] }, isLoading: false }),
+}));
+vi.mock('@/hooks/queries/useLibrary', () => ({
+  useRecentlyAddedGames: () => ({ data: { items: [] }, isLoading: false }),
+}));
+vi.mock('@/hooks/queries/useChatSessions', () => ({
+  useRecentChatSessions: () => ({ data: { sessions: [] }, isLoading: false }),
+}));
+vi.mock('@/hooks/useNavigation', () => ({ useNavigation: () => ({ openDetail: vi.fn() }) }));
+vi.mock('next/navigation', () => ({ useRouter: () => ({ push: vi.fn() }) }));
+
+vi.mock('@/components/game-night/PendingRsvpCard', () => ({
+  PendingRsvpCard: (props: { disabled?: boolean }) => (
+    <div data-testid="pending-rsvp-card" data-disabled={String(Boolean(props.disabled))} />
+  ),
+}));
+// Stub the rest of the dashboard surface so the test is scoped to the RSVP card.
+vi.mock('@/components/chat-unified/MeepleChatCard', () => ({ MeepleChatCard: () => null }));
+vi.mock('@/components/features/common', () => ({
+  EmptyStateCard: () => null,
+  SkeletonCardGrid: () => null,
+}));
+vi.mock('@/components/game-night/MeepleEventCard', () => ({ MeepleEventCard: () => null }));
+vi.mock('@/components/library/MeepleLibraryGameCard', () => ({
+  MeepleLibraryGameCard: () => null,
+}));
+vi.mock('@/components/ui/data-display/meeple-card', () => ({
+  MeepleCard: () => null,
+  entityHsl: () => 'hsl(0 0% 0%)',
+}));
+vi.mock('../RecentSection', () => ({ RecentSection: () => null }));
+
+const pendingNight = {
+  id: 'gn-1',
+  title: 'Serata',
+  organizerName: 'Marco',
+  viewerRsvpStatus: 'Pending',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  networkStatusMock.mockReturnValue({ isOffline: false });
+  upcomingNightsMock.mockReturnValue({ data: [pendingNight], isLoading: false });
+});
+
+describe('HomeFeed — offline-disabled pending RSVP (#2989 gap 5)', () => {
+  it('disables the pending-RSVP card while offline', () => {
+    networkStatusMock.mockReturnValue({ isOffline: true });
+    render(<HomeFeed />);
+
+    expect(screen.getByTestId('pending-rsvp-card').getAttribute('data-disabled')).toBe('true');
+  });
+
+  it('leaves the pending-RSVP card enabled while online', () => {
+    networkStatusMock.mockReturnValue({ isOffline: false });
+    render(<HomeFeed />);
+
+    expect(screen.getByTestId('pending-rsvp-card').getAttribute('data-disabled')).toBe('false');
+  });
+});


### PR DESCRIPTION
## Cosa

Chiude **gap 5** dell'audit offline-state di #2989: le CTA di RSVP restano **abilitate anche offline**, così un utente senza connettività può innescare una mutation RSVP che poi fallisce contro il server.

Ora due superfici leggono `useNetworkStatus` e propagano `isOffline` nel prop `disabled` delle CTA di RSVP:

- **Screen A** — `HomeFeed` (dashboard mobile): `PendingRsvpCard` → `disabled={isOffline || (rsvpMutation.isPending && rsvpMutation.variables?.id === night.id)}`. Il componente reale già mostra il title-hint `"Offline — RSVP disponibile alla riconnessione"` e opacizza la card quando disabilitato.
- **Screen C** — `GameNightDetailView` (dettaglio serata, guest): `GameNightRsvpActionBar` → `disabled={isOffline}`. Il componente reale fa l'OR in `allDisabled` → tutti e tre i bottoni (Accetta/Forse/Rifiuta) si disabilitano.

Entrambe le CTA si riabilitano alla riconnessione (`useNetworkStatus` è già reattivo agli eventi `online`/`offline`).

## Perché

Gap 5 era l'unico rimasto aperto dopo #3008 (Screen A/B social) e #3136 (Screen C sticky bars). Nessuno dei due disabilitava le CTA offline: la mutation partiva comunque e falliva silenziosamente lato server. Questo è il fix mirato.

## Test (RED → GREEN)

- **`HomeFeed.offlineRsvp.test.tsx`** (nuovo): la pending-RSVP card è `data-disabled=true` offline / `false` online.
- **`GameNightDetailView.mobileSticky.test.tsx`** (+2 casi): la guest action bar è `data-disabled=true` offline / `false` online.
- Verificato che entrambi i componenti reali (`GameNightRsvpActionBar` line 159, `PendingRsvpCard` line 47/55) consumano davvero `disabled` sui bottoni — non è un no-op.
- Suite completa dei 2 file: **11/11 GREEN**. Typecheck FE pulito.

## Scope

Solo il wiring `isOffline → disabled`. Nessun cambio di comportamento online, nessuna modifica ai componenti RSVP (già pronti al prop). 4 file, +35/-2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Code review (2 reviewer avversariali)

- **Correttezza**: `[]` — nessun bug. `isOffline` è un booleano reattivo (store `online`/`offline`), `disabled` disabilita davvero i bottoni in entrambi i componenti (non no-op), entrambi client component, nessuna collisione col pending. Rischio hydration-mismatch indagato e **non materiale** (le CTA sono gated dietro dati react-query client-fetched → nessun HTML server-rendered divergente).
- **Completezza**: wiring corretto + test reali (no false-green). Rilevato 1 gap di copertura (ramo `isPending`) → **fixato** in questa PR (commit hardening, 4 casi HomeFeed). Rilevate 3 superfici RSVP sibling non protette offline (`/dashboard` Prossimi, `/game-nights` list, public-join) → **fuori scope** delle 2 schermate mobile #2989, tracciate in **#3191**.
