### PR TITLE
fix(system-config): map duplicate tier name to 409 instead of 500

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SystemConfiguration/Application/Commands/Tier/CreateTierDefinitionCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SystemConfiguration/Application/Commands/Tier/CreateTierDefinitionCommandHandler.cs
@@ -1,6 +1,7 @@
 using Api.BoundedContexts.SystemConfiguration.Application.DTOs;
 using Api.BoundedContexts.SystemConfiguration.Domain.Entities;
 using Api.Infrastructure;
+using Api.Middleware.Exceptions;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 
@@ -26,7 +27,7 @@ internal class CreateTierDefinitionCommandHandler
             .ConfigureAwait(false);
 
         if (existing)
-            throw new InvalidOperationException($"Tier '{request.Name}' already exists");
+            throw new ConflictException($"Tier '{request.Name}' already exists");
 
         var limits = request.Limits.ToValueObject();
         var tier = TierDefinition.Create(

--- a/apps/api/tests/Api.Tests/BoundedContexts/SystemConfiguration/Unit/Tier/CreateTierDefinitionCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SystemConfiguration/Unit/Tier/CreateTierDefinitionCommandHandlerTests.cs
@@ -2,6 +2,7 @@ using Api.BoundedContexts.SystemConfiguration.Application.Commands.Tier;
 using Api.BoundedContexts.SystemConfiguration.Application.DTOs;
 using Api.BoundedContexts.SystemConfiguration.Domain.Entities;
 using Api.BoundedContexts.SystemConfiguration.Domain.ValueObjects;
+using Api.Middleware.Exceptions;
 using Api.Tests.Constants;
 using Api.Tests.TestHelpers;
 using FluentAssertions;
@@ -55,7 +56,7 @@ public sealed class CreateTierDefinitionCommandHandlerTests : IDisposable
     }
 
     [Fact]
-    public async Task Handle_WithDuplicateName_ThrowsInvalidOperationException()
+    public async Task Handle_WithDuplicateName_ThrowsConflictException()
     {
         // Arrange
         var existing = TierDefinition.Create("free", "Free Tier", TierLimits.FreeTier, "free");
@@ -68,8 +69,8 @@ public sealed class CreateTierDefinitionCommandHandlerTests : IDisposable
         // Act
         var act = () => _handler.Handle(command, TestContext.Current.CancellationToken);
 
-        // Assert
-        await act.Should().ThrowAsync<InvalidOperationException>()
+        // Assert — a duplicate name is a conflict (409), not a 500. #3190
+        await act.Should().ThrowAsync<ConflictException>()
             .WithMessage("*already exists*");
     }
 
@@ -88,7 +89,7 @@ public sealed class CreateTierDefinitionCommandHandlerTests : IDisposable
     }
 
     [Fact]
-    public async Task Handle_WithCaseDuplicateName_ThrowsInvalidOperationException()
+    public async Task Handle_WithCaseDuplicateName_ThrowsConflictException()
     {
         // Arrange — seed lowercase
         var existing = TierDefinition.Create("free", "Free Tier", TierLimits.FreeTier, "free");
@@ -102,8 +103,8 @@ public sealed class CreateTierDefinitionCommandHandlerTests : IDisposable
         // Act
         var act = () => _handler.Handle(command, TestContext.Current.CancellationToken);
 
-        // Assert
-        await act.Should().ThrowAsync<InvalidOperationException>()
+        // Assert — case-insensitive duplicate is also a conflict (409). #3190
+        await act.Should().ThrowAsync<ConflictException>()
             .WithMessage("*already exists*");
     }
 }


### PR DESCRIPTION
## Problema

`CreateTierDefinitionCommandHandler` lanciava `InvalidOperationException` sul nome tier duplicato. Il middleware (`ApiExceptionHandlerMiddleware.cs:452`) mappa `InvalidOperationException` a 404 **solo** se il messaggio contiene "not found", altrimenti al fallback `_ => 500`. Il messaggio "already exists" → **HTTP 500** su un conflitto perfettamente user-reachable (admin che crea un tier con nome esistente, endpoint E2-1 Admin Tier CRUD).

## Fix

Uso `ConflictException` (→409), coerente con il gemello `UpdateTierDefinitionCommandHandler` che già usa `KeyNotFoundException` (→404) per il caso not-found. Regola progetto #2568: mai `InvalidOperationException` (→500) per condizioni user-reachable.

## Test (TDD)

- RED: i 2 test duplicate-name asserivano `InvalidOperationException` → aggiornati ad asserire `ConflictException` → falliti (l'handler lanciava ancora il vecchio tipo).
- GREEN: fix applicato → 4/4 test verdi.

Nessun cambiamento di comportamento oltre il codice HTTP; il messaggio ("... already exists") è invariato.

Closes #3190

🤖 Generated with [Claude Code](https://claude.com/claude-code)