### PR TITLE
fix(i18n): add missing catalog keys rendered as raw key / wrong locale

### DIFF
--- a/apps/web/__tests__/i18n-missing-keys.test.ts
+++ b/apps/web/__tests__/i18n-missing-keys.test.ts
@@ -1,0 +1,53 @@
+/**
+ * i18n missing-key regression (#3193)
+ *
+ * Each dot-path below is consumed through a RAW translator (`useTranslation()`)
+ * but was absent from BOTH locale catalogs, so react-intl rendered either the
+ * raw dot-path id (when no defaultMessage was passed) or a hardcoded
+ * `defaultMessage` in the wrong locale. This guard fails if any key regresses
+ * out of either catalog.
+ */
+
+import enMessages from '@/locales/en.json';
+import itMessages from '@/locales/it.json';
+
+const REQUIRED_KEYS = [
+  // Rendered as the raw id in an aria-label for every user (NotificationCenter).
+  'notificationCenter.preferences',
+  // Invite-only request-access form (/register) — was fully English for IT users.
+  'auth.requestAccess.successTitle',
+  'auth.requestAccess.successMessage',
+  'auth.requestAccess.email',
+  'auth.requestAccess.emailPlaceholder',
+  'auth.requestAccess.submitting',
+  'auth.requestAccess.submit',
+  // 2FA disable validation error — was English for IT users.
+  'validation.passwordRequired',
+  // 2FA setup/recovery toasts — were English for IT users.
+  'common.copied',
+  'common.downloaded',
+  // Session summary error state + gamebook aria — defaulted to Italian, broke EN.
+  'common.errorTitle',
+  'common.retry',
+  'common.selected',
+] as const;
+
+function getNested(obj: unknown, path: string): unknown {
+  return path
+    .split('.')
+    .reduce<unknown>(
+      (acc, key) =>
+        acc && typeof acc === 'object' ? (acc as Record<string, unknown>)[key] : undefined,
+      obj
+    );
+}
+
+describe('i18n missing-key regression (#3193)', () => {
+  it.each(REQUIRED_KEYS)('IT catalog defines "%s"', key => {
+    expect(getNested(itMessages, key)).toBeTruthy();
+  });
+
+  it.each(REQUIRED_KEYS)('EN catalog defines "%s"', key => {
+    expect(getNested(enMessages, key)).toBeTruthy();
+  });
+});

--- a/apps/web/src/components/notifications/NotificationCenter.tsx
+++ b/apps/web/src/components/notifications/NotificationCenter.tsx
@@ -197,7 +197,7 @@ export function NotificationCenter({ open, onOpenChange }: NotificationCenterPro
                 onClick={() => onOpenChange(false)}
                 className="flex items-center gap-1 p-2 text-sm text-muted-foreground hover:text-primary transition-colors rounded-md hover:bg-accent"
                 data-testid="notification-center-preferences"
-                aria-label={t('notificationCenter.preferences') || 'Preferenze notifiche'}
+                aria-label={t('notificationCenter.preferences')}
               >
                 <Settings className="h-4 w-4" />
               </Link>

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -114,6 +114,14 @@
     "title": "MeepleAI - AI Board Game Rules Assistant"
   },
   "auth": {
+    "requestAccess": {
+      "successTitle": "Request submitted!",
+      "successMessage": "If your email is eligible, you'll receive an invitation shortly.",
+      "email": "Email address",
+      "emailPlaceholder": "you@example.com",
+      "submitting": "Submitting...",
+      "submit": "Request Access"
+    },
     "2fa": {
       "setupTitle": "Set Up Two-Factor Authentication",
       "setupSubtitle": "Scan this QR code with your authenticator app (Google Authenticator, Authy, etc.)",
@@ -377,13 +385,16 @@
     "close": "Close",
     "confirm": "Confirm",
     "copy": "Copy",
+    "copied": "Copied!",
     "cut": "Cut",
     "delete": "Delete",
     "deselect": "Deselect",
     "deselectAll": "Deselect all",
     "download": "Download",
+    "downloaded": "Downloaded!",
     "edit": "Edit",
     "error": "Error",
+    "errorTitle": "Error",
     "export": "Export",
     "filter": "Filter",
     "import": "Import",
@@ -399,10 +410,12 @@
     "previous": "Previous",
     "refresh": "Refresh",
     "reset": "Reset",
+    "retry": "Retry",
     "save": "Save",
     "search": "Search",
     "select": "Select",
     "selectAll": "Select all",
+    "selected": "Selected",
     "submit": "Submit",
     "success": "Success",
     "upload": "Upload",
@@ -708,6 +721,7 @@
     "passwordMatch": "Passwords do not match",
     "passwordMax": "Password must not exceed 128 characters",
     "passwordMin": "Password must be at least 12 characters",
+    "passwordRequired": "Password is required",
     "required": "This field is required"
   },
   "wizard": {
@@ -765,6 +779,7 @@
     "empty": "No notifications",
     "emptySubtext": "Your notifications will appear here",
     "viewAll": "View all",
+    "preferences": "Notification preferences",
     "loading": "Loading notifications...",
     "kbReady": {
       "cta": "→ Create your agent"

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -105,6 +105,14 @@
     "title": "MeepleAI - Assistente AI per Regolamenti di Giochi da Tavolo"
   },
   "auth": {
+    "requestAccess": {
+      "successTitle": "Richiesta inviata!",
+      "successMessage": "Se la tua email è idonea, riceverai a breve un invito.",
+      "email": "Indirizzo email",
+      "emailPlaceholder": "tu@esempio.com",
+      "submitting": "Invio in corso...",
+      "submit": "Richiedi accesso"
+    },
     "2fa": {
       "setupTitle": "Configura l'autenticazione a due fattori",
       "setupSubtitle": "Scansiona questo codice QR con la tua app di autenticazione (Google Authenticator, Authy, ecc.)",
@@ -368,13 +376,16 @@
     "close": "Chiudi",
     "confirm": "Conferma",
     "copy": "Copia",
+    "copied": "Copiato!",
     "cut": "Taglia",
     "delete": "Elimina",
     "deselect": "Deseleziona",
     "deselectAll": "Deseleziona tutto",
     "download": "Scarica",
+    "downloaded": "Scaricato!",
     "edit": "Modifica",
     "error": "Errore",
+    "errorTitle": "Errore",
     "export": "Esporta",
     "filter": "Filtra",
     "import": "Importa",
@@ -390,10 +401,12 @@
     "previous": "Precedente",
     "refresh": "Aggiorna",
     "reset": "Reimposta",
+    "retry": "Riprova",
     "save": "Salva",
     "search": "Cerca",
     "select": "Seleziona",
     "selectAll": "Seleziona tutto",
+    "selected": "Selezionato",
     "submit": "Invia",
     "success": "Successo",
     "upload": "Carica",
@@ -699,6 +712,7 @@
     "passwordMatch": "Le password non coincidono",
     "passwordMax": "La password non può superare 128 caratteri",
     "passwordMin": "La password deve essere di almeno 12 caratteri",
+    "passwordRequired": "Password obbligatoria",
     "required": "Questo campo è obbligatorio"
   },
   "privateGames": {
@@ -821,6 +835,7 @@
     "empty": "Nessuna notifica",
     "emptySubtext": "Le tue notifiche appariranno qui",
     "viewAll": "Vedi tutte",
+    "preferences": "Preferenze notifiche",
     "loading": "Caricamento notifiche...",
     "kbReady": {
       "cta": "→ Crea il tuo agente"


### PR DESCRIPTION
## Problema

Diverse chiavi `t('...')` consumate tramite un translator **RAW** (`useTranslation()`) erano **assenti da entrambi i cataloghi** (`it.json` + `en.json`), quindi react-intl renderizzava la chiave grezza o un `defaultMessage` hardcoded con **locale sbagliato**. `DEFAULT_LOCALE='it'` (maggioranza utenti), nessun fallback cross-locale per singola chiave.

| Chiave | Componente | Sintomo |
|---|---|---|
| `notificationCenter.preferences` | `NotificationCenter.tsx:200` | id grezzo in un `aria-label` per **tutti** gli utenti (il `\|\| 'Preferenze notifiche'` era codice morto: react-intl ritorna l'id truthy) |
| `auth.requestAccess.*` (6) | `RequestAccessForm.tsx` | form invite-only su `/register` interamente in inglese per utenti IT |
| `validation.passwordRequired` | `TwoFactorDisable.tsx:69` | errore validazione in inglese per IT |
| `common.copied` / `common.downloaded` | `TwoFactorRecoveryCodes/Setup.tsx` | toast 2FA in inglese per IT |
| `common.errorTitle` / `common.retry` / `common.selected` | `SessionSummaryView.tsx`, `GamebookUploadView.tsx` | default **italiano** → rompe la locale EN |

## Fix

- Aggiunte le 13 chiavi a `it.json` + `en.json` (ordine alfabetico preservato nei blocchi `common`/`validation`; nuovo blocco `auth.requestAccess`; `notificationCenter.preferences`).
- Rimosso il fallback morto `|| 'Preferenze notifiche'` in `NotificationCenter.tsx`.

## Test (TDD)

Nuovo `__tests__/i18n-missing-keys.test.ts` che asserisce l'esistenza di ogni dot-path in **entrambi** i cataloghi (stesso pattern di `i18n-gamedetail-keys.test.ts` #3103).
- RED (cataloghi stashati, senza chiavi): 26/26 falliti.
- GREEN (chiavi presenti): 26/26 verdi. Typecheck pulito.

Closes #3193

🤖 Generated with [Claude Code](https://claude.com/claude-code)