### PR TITLE
feat(observability): #1965 domain-event-outbox duplicate-publish trigger

### DIFF
--- a/docs/for-developers/operations/operations-manual.md
+++ b/docs/for-developers/operations/operations-manual.md
@@ -3313,3 +3313,31 @@ the queue is idle, so the expressions never fire on an empty queue.
 2. **Poison messages** (`AuditOutboxFailedMessages`): inspect the Failed rows via the admin dashboard; a Failed row is a message the processor could not deliver after its retry budget. Resolve the underlying cause, then requeue or discard per the audit-retention policy.
 
 Alert unit tests live in `infra/prometheus/alerts/audit-outbox.test.yml` (run `promtool test rules` per the header comment; there is no CI promtool gate, so run on demand).
+
+## Domain Event Outbox Alerts
+
+Defined in `infra/prometheus/alerts/domain-event-outbox-duplicate-publish.yml` (#1965). This is the
+**companion trigger observability** for the dormant multi-instance work-stealing follow-up
+(`FOR UPDATE SKIP LOCKED`) — NOT its implementation. It makes issue #1965's reactivation condition
+self-detecting instead of relying on a manual dashboard check. The counters are emitted by
+`apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.DomainEventOutbox.cs` (#1535 T6) and routed
+via `severity: warning` → the `warning-alerts` receiver in `alertmanager.yml` (throttled email).
+
+> **Dormant by design.** With a single API instance (the current staging + prod topology — no
+> `deploy.replicas` in `infra/compose.{staging,prod}.yml`) the `dispatched/enqueued` ratio is
+> structurally ~1.0, so this alert cannot fire. It self-fires only once **(a)** the API scales to
+> **≥2 replicas** AND **(b)** the duplicate rate breaches **>1.05** — exactly the #1965 refined
+> reactivation condition. The `enqueued rate > 0` guard suppresses the `0/0=NaN` idle case.
+
+| Rule | Type | Trigger | Sustained | Meaning / first action |
+|---|---|---|---|---|
+| `meepleai_domain_event_outbox:dispatch_enqueue_ratio1h` | recording | — | — | Materialised dispatched/enqueued ratio (1h window) for dashboards + manual gate inspection. |
+| `DomainEventOutboxDuplicatePublish` | alert | `ratio > 1.05 and enqueued rate > 0` | 2h | Domain events are being published more than once. Dominant cause: ≥2 API instances SELECT-ing the same Pending rows concurrently (#1965 premise). |
+
+### Investigation steps
+
+1. **Confirm the topology.** Check whether the API is now running ≥2 replicas. If yes, this is the gate to implement `FOR UPDATE SKIP LOCKED` per issue #1965 (move the Pending `SELECT` inside the batch transaction — see the #1965 audit comment for the spec corrections). If the API is still single-instance, the alert should not have fired: investigate an abnormal crash-recovery re-publish loop instead.
+2. **Duplicate publishing is safe but not free.** Dispatch is at-least-once and consumer idempotency (audited in `docs/for-developers/architecture/domain-events-post-commit-contract.md`) keeps duplicates correct; the concern is wasted downstream I/O (Redis/SSE/email), not data corruption. Do NOT weaken the consumer idempotency contract in response to this alert.
+3. The `2h` window absorbs transient duplicates from crash-recovery re-publish and rolling-deploy windows (old pods do not honour new pods' row-locks); a sustained breach past 2h is the real signal.
+
+Alert unit tests live in `infra/prometheus/alerts/domain-event-outbox-duplicate-publish.test.yml` (run `promtool test rules` per the header comment; there is no CI promtool gate, so run on demand).

--- a/infra/compose.prod.yml
+++ b/infra/compose.prod.yml
@@ -233,6 +233,8 @@ services:
       # Issue #3112 — OPS-02 Slack delivery observability alerts.
       - ./prometheus/alerts/slack-delivery.yml:/etc/prometheus/slack-delivery.yml:ro
       - ./prometheus/alerts/audit-outbox.yml:/etc/prometheus/audit-outbox.yml:ro
+      # Issue #1965 — domain_event_outbox duplicate-publish trigger (referenced from prometheus.prod.yml rule_files).
+      - ./prometheus/alerts/domain-event-outbox-duplicate-publish.yml:/etc/prometheus/domain-event-outbox-duplicate-publish.yml:ro
       - prometheus-prod:/prometheus
     deploy:
       resources:

--- a/infra/compose.staging.yml
+++ b/infra/compose.staging.yml
@@ -340,6 +340,8 @@ services:
       # Issue #3112 — OPS-02 Slack delivery observability alerts.
       - ./prometheus/alerts/slack-delivery.yml:/etc/prometheus/slack-delivery.yml:ro
       - ./prometheus/alerts/audit-outbox.yml:/etc/prometheus/audit-outbox.yml:ro
+      # Issue #1965 — domain_event_outbox duplicate-publish trigger (referenced from prometheus.staging.yml rule_files).
+      - ./prometheus/alerts/domain-event-outbox-duplicate-publish.yml:/etc/prometheus/domain-event-outbox-duplicate-publish.yml:ro
       - prometheus-staging:/prometheus
 
   alertmanager:

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -352,6 +352,8 @@ services:
       # Issue #3112 — OPS-02 Slack delivery alerts (referenced from prometheus.yml rule_files).
       - ./prometheus/alerts/slack-delivery.yml:/etc/prometheus/slack-delivery.yml:ro
       - ./prometheus/alerts/audit-outbox.yml:/etc/prometheus/audit-outbox.yml:ro
+      # Issue #1965 — domain_event_outbox duplicate-publish trigger (referenced from prometheus.yml rule_files).
+      - ./prometheus/alerts/domain-event-outbox-duplicate-publish.yml:/etc/prometheus/domain-event-outbox-duplicate-publish.yml:ro
       - ./prometheus/alerts/wikidata-enrichment.yml:/etc/prometheus/wikidata-enrichment.yml:ro
       - prometheus_data:/prometheus
     healthcheck:

--- a/infra/prometheus.prod.yml
+++ b/infra/prometheus.prod.yml
@@ -31,6 +31,8 @@ rule_files:
   - '/etc/prometheus/slack-delivery.yml'
   # Issue #3116 — SP5 Admin Security audit_outbox health alerts.
   - '/etc/prometheus/audit-outbox.yml'
+  # Issue #1965 — domain_event_outbox duplicate-publish trigger (dormant until API >=2 replicas).
+  - '/etc/prometheus/domain-event-outbox-duplicate-publish.yml'
 
 scrape_configs:
   - job_name: 'prometheus'

--- a/infra/prometheus.staging.yml
+++ b/infra/prometheus.staging.yml
@@ -33,6 +33,8 @@ rule_files:
   - '/etc/prometheus/slack-delivery.yml'
   # Issue #3116 — SP5 Admin Security audit_outbox health alerts.
   - '/etc/prometheus/audit-outbox.yml'
+  # Issue #1965 — domain_event_outbox duplicate-publish trigger (dormant until API >=2 replicas).
+  - '/etc/prometheus/domain-event-outbox-duplicate-publish.yml'
 
 scrape_configs:
   - job_name: 'prometheus'

--- a/infra/prometheus.yml
+++ b/infra/prometheus.yml
@@ -38,6 +38,8 @@ rule_files:
   - '/etc/prometheus/slack-delivery.yml'
   # Issue #3116 — SP5 Admin Security audit_outbox health alerts.
   - '/etc/prometheus/audit-outbox.yml'
+  # Issue #1965 — domain_event_outbox duplicate-publish trigger (dormant until API >=2 replicas).
+  - '/etc/prometheus/domain-event-outbox-duplicate-publish.yml'
 
 # Scrape configurations
 scrape_configs:

--- a/infra/prometheus/alerts/domain-event-outbox-duplicate-publish.test.yml
+++ b/infra/prometheus/alerts/domain-event-outbox-duplicate-publish.test.yml
@@ -1,0 +1,71 @@
+# promtool unit tests for domain-event-outbox-duplicate-publish.yml (#1965).
+#
+# Run locally (Windows/Git Bash, from repo root):
+#   docker run --rm -v "$(pwd)/infra/prometheus/alerts:/work" prom/prometheus:v3.7.0 \
+#     promtool test rules /work/domain-event-outbox-duplicate-publish.test.yml
+#
+# There is no promtool CI gate in this repo (see recon in #3082); this file documents +
+# verifies the alert behaviour on demand — same convention as audit-outbox.test.yml (#3116).
+rule_files:
+  - domain-event-outbox-duplicate-publish.yml
+
+evaluation_interval: 1m
+
+tests:
+  # Sustained duplicate-publish (dispatched rate 1.25x enqueued rate for >2h) fires the alert.
+  # This models the #1965 premise: >=2 API instances work-stealing the same Pending rows so
+  # each event is dispatched more than once.
+  - interval: 1m
+    input_series:
+      - series: 'meepleai_domain_event_outbox_enqueued_total'
+        values: '0+120x180'
+      - series: 'meepleai_domain_event_outbox_dispatched_total'
+        values: '0+150x180'
+    alert_rule_test:
+      - eval_time: 150m
+        alertname: DomainEventOutboxDuplicatePublish
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              team: platform
+              component: domain_event_outbox
+            exp_annotations:
+              summary: "Domain event outbox duplicate-publish ratio above 1.05 (#1965 reactivation trigger)"
+              description: "dispatched/enqueued ratio has stayed above 1.05 for 2h: domain events are being published more than once. The dominant cause is >=2 API instances SELECT-ing the same Pending outbox rows concurrently (the #1965 multi-instance work-stealing premise). Consumer idempotency keeps duplicates safe but not free. If the API is now running >=2 replicas, this is the gate to implement FOR UPDATE SKIP LOCKED per issue #1965; if it is still single-instance, investigate an abnormal crash-recovery re-publish loop."
+              runbook_url: "https://github.com/meepleAi-app/meepleai-monorepo/blob/main-dev/docs/for-developers/operations/operations-manual.md#domain-event-outbox-alerts"
+
+  # Steady state (dispatched rate == enqueued rate, ratio ~1.0) -> no alert.
+  - interval: 1m
+    input_series:
+      - series: 'meepleai_domain_event_outbox_enqueued_total'
+        values: '0+120x180'
+      - series: 'meepleai_domain_event_outbox_dispatched_total'
+        values: '0+120x180'
+    alert_rule_test:
+      - eval_time: 150m
+        alertname: DomainEventOutboxDuplicatePublish
+        exp_alerts: []
+
+  # Mild excess below the 1.05 threshold (ratio ~1.033) -> no alert (guards the boundary).
+  - interval: 1m
+    input_series:
+      - series: 'meepleai_domain_event_outbox_enqueued_total'
+        values: '0+120x180'
+      - series: 'meepleai_domain_event_outbox_dispatched_total'
+        values: '0+124x180'
+    alert_rule_test:
+      - eval_time: 150m
+        alertname: DomainEventOutboxDuplicatePublish
+        exp_alerts: []
+
+  # Idle queue (no enqueue/dispatch traffic -> 0/0 = NaN) -> no alert on empty queue.
+  - interval: 1m
+    input_series:
+      - series: 'meepleai_domain_event_outbox_enqueued_total'
+        values: '0x180'
+      - series: 'meepleai_domain_event_outbox_dispatched_total'
+        values: '0x180'
+    alert_rule_test:
+      - eval_time: 150m
+        alertname: DomainEventOutboxDuplicatePublish
+        exp_alerts: []

--- a/infra/prometheus/alerts/domain-event-outbox-duplicate-publish.yml
+++ b/infra/prometheus/alerts/domain-event-outbox-duplicate-publish.yml
@@ -1,0 +1,57 @@
+# Prometheus recording + alerting rules — Domain Event Outbox duplicate-publish trigger.
+#
+# Issue #1965 — companion "trigger observability" for the dormant multi-instance
+# work-stealing follow-up (FOR UPDATE SKIP LOCKED). This is deliberately NOT the
+# implementation of #1965; it is the PRE-implementation gate watch so the issue's
+# reactivation condition becomes self-detecting once the API scales to >=2 replicas,
+# instead of relying on a manual dashboard check (see #1965 audit comment 2026-06-22).
+#
+# Distinct from #1535 T6 AC#4 (which would monitor POST-implementation regression of an
+# exactly-once guarantee). This watches the PRE-implementation trigger: the observed
+# duplicate-publish ratio.
+#
+# NOTE ON FILE SPLIT: infra/prometheus/alerts/domain-event-outbox.yml already exists but is
+# in Grafana unified-alerting provisioning format (apiVersion: 1 / uid / model.expr) and is
+# NOT wired into any Prometheus rule_files or compose mount. This file is Prometheus-native +
+# promtool-tested + wired into rule_files, matching the ACTIVE audit-outbox.yml pattern (#3116).
+# Rewiring the orphaned Grafana file is out of scope for #1965.
+#
+# Metric source: apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.DomainEventOutbox.cs
+# (#1535 T6). Counter instrument names `meepleai.domain_event_outbox.{enqueued,dispatched}.total`
+# export to Prometheus as `meepleai_domain_event_outbox_{enqueued,dispatched}_total`
+# (dots -> underscores, no doubled _total suffix — same convention noted in audit-outbox.yml).
+#
+# DORMANCY: with a single API instance (the current staging + prod topology, verified 2026-07-19
+# — no `deploy.replicas` in infra/compose.{staging,prod}.yml) the ratio is structurally ~1.0, so
+# this alert cannot fire. It self-fires only after (a) scaling to >=2 replicas AND (b) the
+# duplicate rate breaching >1.05 — exactly the #1965 refined reactivation condition. The
+# `enqueued rate > 0` guard suppresses the 0/0=NaN case on an idle queue; the 2h `for` absorbs
+# the transient duplicates from crash-recovery re-publish (dispatch is at-least-once) and from
+# rolling-deploy windows (old pods do not honour new pods' locks).
+groups:
+  - name: meepleai_domain_event_outbox_duplicate_publish
+    rules:
+      # Recording rule — dispatched/enqueue publish ratio over a 1h window.
+      # ~1.0 in steady state; trends toward the instance count N when >=2 pods work-steal
+      # the same Pending rows. Materialised for dashboards + manual gate inspection.
+      - record: meepleai_domain_event_outbox:dispatch_enqueue_ratio1h
+        expr: |
+          sum(rate(meepleai_domain_event_outbox_dispatched_total[1h]))
+          /
+          sum(rate(meepleai_domain_event_outbox_enqueued_total[1h]))
+
+      # Alert — duplicate-publish ratio breaches the #1965 reactivation gate.
+      - alert: DomainEventOutboxDuplicatePublish
+        expr: |
+          meepleai_domain_event_outbox:dispatch_enqueue_ratio1h > 1.05
+          and
+          sum(rate(meepleai_domain_event_outbox_enqueued_total[1h])) > 0
+        for: 2h
+        labels:
+          severity: warning
+          team: platform
+          component: domain_event_outbox
+        annotations:
+          summary: "Domain event outbox duplicate-publish ratio above 1.05 (#1965 reactivation trigger)"
+          description: "dispatched/enqueued ratio has stayed above 1.05 for 2h: domain events are being published more than once. The dominant cause is >=2 API instances SELECT-ing the same Pending outbox rows concurrently (the #1965 multi-instance work-stealing premise). Consumer idempotency keeps duplicates safe but not free. If the API is now running >=2 replicas, this is the gate to implement FOR UPDATE SKIP LOCKED per issue #1965; if it is still single-instance, investigate an abnormal crash-recovery re-publish loop."
+          runbook_url: "https://github.com/meepleAi-app/meepleai-monorepo/blob/main-dev/docs/for-developers/operations/operations-manual.md#domain-event-outbox-alerts"


### PR DESCRIPTION
## Cosa

Companion **trigger-observability** per il follow-up dormiente #1965 (multi-instance work-stealing via `FOR UPDATE SKIP LOCKED`). **Non** è l'implementazione del core: aggiunge solo la regola Prometheus che rende il gate di riattivazione *self-detecting*.

## Perché

#1965 è gated su `dispatched/enqueued > 1.05 over 7d`, **strutturalmente non scattabile** finché l'API è single-instance — verificato 2026-07-19: nessun `deploy.replicas` in `infra/compose.{staging,prod}.yml`. Finora il trigger richiedeva un controllo manuale su dashboard (peraltro assente). Questa PR aggiunge il watch pre-implementazione, così quando l'API scalerà a ≥2 repliche il gate si accende da solo.

Distinto da #1535 T6 AC#4 (che monitorerebbe la regressione *post*-implementazione).

## Contenuto

- **Recording rule** `meepleai_domain_event_outbox:dispatch_enqueue_ratio1h`
- **Alert** `DomainEventOutboxDuplicatePublish` (`> 1.05`, `for: 2h`, guard `enqueued rate > 0` contro il caso idle `0/0=NaN`)
- **Test promtool** (`.test.yml`, 4 casi: fires / steady-state / borderline-sotto-soglia / idle) — TDD RED→GREEN
- **Wiring**: `rule_files` (dev/staging/prod) + mount nei 3 compose, come il pattern **attivo** `audit-outbox.yml` (#3116)
- **Runbook** nell'operations manual (`#domain-event-outbox-alerts`)

## Note

- Il file preesistente `domain-event-outbox.yml` è in formato **Grafana-provisioning orfano** (non cablato in alcun `rule_files`/mount): lasciato intatto, rewiring fuori scope.
- **Dormiente by design**: in single-instance il ratio è ~1.0, l'alert non può scattare. Self-fires solo con ≥2 repliche AND ratio >1.05.
- **Nessuna modifica all'hot-path**: solo config Prometheus. Il core #1965 resta **OPEN + dormiente**.

## Verifica

- `promtool test rules` → SUCCESS (4/4 casi)
- `promtool check config` staging + prod → SUCCESS (regola caricata insieme a tutte le altre)
- `docker compose config` / YAML parse dei 6 file wiring → validi

Refs #1965

🤖 Generated with [Claude Code](https://claude.com/claude-code)