### PR TITLE
fix(library): #3197 disambiguate /library games tab from nav catalog (A-01)

### DIFF
--- a/apps/web/src/app/(authenticated)/library/_components/__tests__/LibraryHub.test.tsx
+++ b/apps/web/src/app/(authenticated)/library/_components/__tests__/LibraryHub.test.tsx
@@ -153,7 +153,7 @@ const MESSAGES: Record<string, string> = {
   'pages.library.hero.stats.docs': 'Documenti',
   'pages.library.hero.stats.chats': 'Chat',
   'pages.library.hubTabs.all': 'Tutti',
-  'pages.library.hubTabs.games': 'Giochi',
+  'pages.library.hubTabs.games': 'I miei giochi',
   'pages.library.hubTabs.agents': 'Agenti',
   'pages.library.hubTabs.kb': 'KB',
   'pages.library.hubTabs.sessions': 'Sessioni',

--- a/apps/web/src/app/(authenticated)/library/_components/__tests__/i18n-library-hubtab-label.test.ts
+++ b/apps/web/src/app/(authenticated)/library/_components/__tests__/i18n-library-hubtab-label.test.ts
@@ -1,0 +1,45 @@
+/**
+ * i18n /library hub-tab label — gap A-01 (SP8 mobile audit, issue #3197)
+ *
+ * The in-page /library tab for the user's PERSONAL games
+ * (`pages.library.hubTabs.games`, rendered by LibraryHub.tsx) collided with the
+ * global sidebar/nav entry "Games" (the community catalog, id 'hub' →
+ * href '/games', navigation.ts). In EN the clash was literal ("Games" vs "Games");
+ * on mobile the sidebar collapses behind the hamburger, amplifying it.
+ *
+ * Fix: rename the TAB to the disambiguated "I miei giochi" / "My games",
+ * leaving the nav catalog entry ("Games") untouched.
+ *
+ * These tests pin the disambiguated tab label in both catalogs and guard against
+ * regressing to a value that collides with the nav "Games" entry.
+ */
+
+import itMessages from '@/locales/it.json';
+import enMessages from '@/locales/en.json';
+import { flattenMessages } from '@/locales';
+import { UNIFIED_NAV_ITEMS } from '@/config/navigation';
+
+const TAB_GAMES_KEY = 'pages.library.hubTabs.games';
+
+describe('/library hub-tab "games" label disambiguation (A-01, #3197)', () => {
+  const itFlat = flattenMessages(itMessages as Record<string, unknown>);
+  const enFlat = flattenMessages(enMessages as Record<string, unknown>);
+  const navCatalog = UNIFIED_NAV_ITEMS.find(item => item.id === 'hub');
+
+  it('the nav catalog entry is still labelled "Games" (sanity — must not change)', () => {
+    expect(navCatalog?.label).toBe('Games');
+  });
+
+  it('IT personal-games tab is the disambiguated "I miei giochi"', () => {
+    expect(itFlat[TAB_GAMES_KEY]).toBe('I miei giochi');
+  });
+
+  it('EN personal-games tab is the disambiguated "My games"', () => {
+    expect(enFlat[TAB_GAMES_KEY]).toBe('My games');
+  });
+
+  it('the tab label does not collide with the nav catalog "Games" entry (either locale)', () => {
+    expect(itFlat[TAB_GAMES_KEY]).not.toBe(navCatalog?.label);
+    expect(enFlat[TAB_GAMES_KEY]).not.toBe(navCatalog?.label);
+  });
+});

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -1792,7 +1792,7 @@
       },
       "hubTabs": {
         "all": "All",
-        "games": "Games",
+        "games": "My games",
         "agents": "Agents",
         "kb": "KB",
         "sessions": "Sessions",

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -1799,7 +1799,7 @@
       },
       "hubTabs": {
         "all": "Tutti",
-        "games": "Giochi",
+        "games": "I miei giochi",
         "agents": "Agenti",
         "kb": "KB",
         "sessions": "Sessioni",


### PR DESCRIPTION
## Gap A-01 (audit mobile SP8) — rename tab `/library` "Games" → disambiguato

Chiude il gap **A-01** di #3197. Il tab in-page dei giochi **personali** in `/library` (`pages.library.hubTabs.games`, reso da `LibraryHub.tsx:280`) usava la stessa label della voce nav **"Games"** (catalogo community, `navigation.ts` id `hub` → `/games`). In EN la collisione era letterale (`"Games"` tab vs `"Games"` nav); su mobile amplificata dal collasso della sidebar dietro l'hamburger.

### Fix
| Catalogo | Prima | Dopo |
|---|---|---|
| `it.json` `pages.library.hubTabs.games` | "Giochi" | **"I miei giochi"** |
| `en.json` `pages.library.hubTabs.games` | "Games" | **"My games"** |

La voce nav catalogo ("Games") resta **invariata**.

### Test (TDD, RED→GREEN)
- **Nuovo** `i18n-library-hubtab-label.test.ts` (4 test): ancora la label disambiguata su entrambi i cataloghi + guardia anti-regressione contro la collisione con la nav "Games" + sanity che la voce nav resta "Games".
- `LibraryHub.test.tsx`: mock translator allineato al catalogo reale; **39/39** verde (le asserzioni `getByRole('tab', { name: /giochi/i })` continuano a matchare "I miei **giochi**").
- typecheck pulito. E2E del tab library selezionano via `data-tab-key="games"` (locale-agnostic) → non impattati.

### Scope
Scorporo da #2989. Effort XS. Prossimi gap dello stesso audit: A-02 (bulk-mode) e A-03 (back-guard sheet), tracciati in #3197.

Parte di #3197 (gap A-01 di 3 — NON chiude l'issue: restano A-02, A-03).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
