### PR TITLE
feat(auth): ToS acceptance foundation (F1)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/Registration/RegisterCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/Registration/RegisterCommand.cs
@@ -20,7 +20,11 @@ internal record RegisterCommand(
     // hasn't been set yet, the resulting user is provisioned as Admin. All
     // other inputs land Role.User regardless of the registration order
     // (replaces the race-prone HasAnyUsersAsync first-user-is-admin path).
-    string? BootstrapToken = null
+    string? BootstrapToken = null,
+    // #2954 F1: whether the user accepted the ToS on the register form. When true,
+    // the handler records an append-only TermsAcceptance (Context=Registration) in
+    // the same transaction as the new user. Enforced server-side at the endpoint.
+    bool TermsAccepted = false
 ) : ICommand<RegisterResponse>;
 
 /// <summary>

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/Registration/RegisterCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/Registration/RegisterCommandHandler.cs
@@ -1,6 +1,9 @@
 using System.Security.Cryptography;
 using System.Text;
+using Api.BoundedContexts.Authentication.Domain.Constants;
 using Api.BoundedContexts.Authentication.Domain.Entities;
+using Api.BoundedContexts.Authentication.Domain.Enums;
+using Api.BoundedContexts.Authentication.Domain.Repositories;
 using Api.BoundedContexts.Authentication.Domain.ValueObjects;
 using Api.SharedKernel.Domain.ValueObjects;
 using Api.BoundedContexts.Authentication.Infrastructure.Persistence;
@@ -38,6 +41,7 @@ internal class RegisterCommandHandler : ICommandHandler<RegisterCommand, Registe
     private readonly TimeProvider _timeProvider;
     private readonly ILogger<RegisterCommandHandler> _logger;
     private readonly Api.BoundedContexts.SecurityAudit.Application.Services.IAuditLogger _auditLogger;
+    private readonly ITermsAcceptanceRepository _termsAcceptanceRepository;
 
     public RegisterCommandHandler(
         IUserRepository userRepository,
@@ -48,7 +52,8 @@ internal class RegisterCommandHandler : ICommandHandler<RegisterCommand, Registe
         MeepleAiDbContext db,
         TimeProvider timeProvider,
         ILogger<RegisterCommandHandler> logger,
-        Api.BoundedContexts.SecurityAudit.Application.Services.IAuditLogger auditLogger)
+        Api.BoundedContexts.SecurityAudit.Application.Services.IAuditLogger auditLogger,
+        ITermsAcceptanceRepository termsAcceptanceRepository)
     {
         _userRepository = userRepository ?? throw new ArgumentNullException(nameof(userRepository));
         _sessionRepository = sessionRepository ?? throw new ArgumentNullException(nameof(sessionRepository));
@@ -59,6 +64,7 @@ internal class RegisterCommandHandler : ICommandHandler<RegisterCommand, Registe
         _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         _auditLogger = auditLogger ?? throw new ArgumentNullException(nameof(auditLogger));
+        _termsAcceptanceRepository = termsAcceptanceRepository ?? throw new ArgumentNullException(nameof(termsAcceptanceRepository));
     }
 
     public async Task<RegisterResponse> Handle(RegisterCommand command, CancellationToken cancellationToken)
@@ -133,6 +139,20 @@ internal class RegisterCommandHandler : ICommandHandler<RegisterCommand, Registe
         // into a 409 ConflictException.
         await _userRepository.AddAsync(user, cancellationToken).ConfigureAwait(false);
         await _sessionRepository.AddAsync(session, cancellationToken).ConfigureAwait(false);
+
+        // #2954 F1: record ToS acceptance in the SAME transaction as the new user.
+        // The endpoint already rejects registration without acceptance; the guard here
+        // keeps direct-command callers (tests) that omit the flag from writing a row.
+        if (command.TermsAccepted)
+        {
+            var termsAcceptance = TermsAcceptance.Create(
+                userId,
+                TermsVersion.Current,
+                TermsAcceptanceContext.Registration,
+                command.IpAddress,
+                command.UserAgent);
+            await _termsAcceptanceRepository.AddAsync(termsAcceptance, cancellationToken).ConfigureAwait(false);
+        }
 
         try
         {

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/TermsAcceptance/RecordTermsAcceptanceCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/TermsAcceptance/RecordTermsAcceptanceCommand.cs
@@ -1,0 +1,58 @@
+using Api.BoundedContexts.Authentication.Application.DTOs;
+using Api.BoundedContexts.Authentication.Domain.Constants;
+using Api.BoundedContexts.Authentication.Domain.Entities;
+using Api.BoundedContexts.Authentication.Domain.Enums;
+using Api.BoundedContexts.Authentication.Domain.Repositories;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Infrastructure.Persistence;
+
+#pragma warning disable MA0048 // File name must match type name - Command + Handler in one file
+namespace Api.BoundedContexts.Authentication.Application.Commands;
+
+/// <summary>
+/// Records that a user accepted the current ToS version (#2954 F1). Used by the
+/// /users/me/terms/accept endpoint (Context = ReConsent). Idempotent: no new row
+/// when the user's latest accepted version already equals TermsVersion.Current.
+/// </summary>
+internal record RecordTermsAcceptanceCommand(
+    Guid UserId,
+    string? IpAddress = null,
+    string? UserAgent = null
+) : ICommand<TermsConsentStatusDto>;
+
+internal sealed class RecordTermsAcceptanceCommandHandler
+    : ICommandHandler<RecordTermsAcceptanceCommand, TermsConsentStatusDto>
+{
+    private readonly ITermsAcceptanceRepository _repository;
+    private readonly IUnitOfWork _unitOfWork;
+
+    public RecordTermsAcceptanceCommandHandler(ITermsAcceptanceRepository repository, IUnitOfWork unitOfWork)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+    }
+
+    public async Task<TermsConsentStatusDto> Handle(RecordTermsAcceptanceCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var latest = await _repository.GetLatestByUserIdAsync(command.UserId, cancellationToken).ConfigureAwait(false);
+
+        if (latest is null || !string.Equals(latest.TermsVersion, TermsVersion.Current, StringComparison.Ordinal))
+        {
+            var acceptance = TermsAcceptance.Create(
+                command.UserId,
+                TermsVersion.Current,
+                TermsAcceptanceContext.ReConsent,
+                command.IpAddress,
+                command.UserAgent);
+
+            await _repository.AddAsync(acceptance, cancellationToken).ConfigureAwait(false);
+            await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+            return new TermsConsentStatusDto(TermsVersion.Current, TermsVersion.Current, acceptance.AcceptedAt, NeedsReAcceptance: false);
+        }
+
+        return new TermsConsentStatusDto(TermsVersion.Current, latest.TermsVersion, latest.AcceptedAt, NeedsReAcceptance: false);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/DTOs/TermsConsentStatusDto.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/DTOs/TermsConsentStatusDto.cs
@@ -1,0 +1,11 @@
+namespace Api.BoundedContexts.Authentication.Application.DTOs;
+
+/// <summary>
+/// Read model describing a user's ToS acceptance status (#2954 F1).
+/// NeedsReAcceptance is computed but intentionally NOT enforced by any gate in this scope.
+/// </summary>
+public sealed record TermsConsentStatusDto(
+    string CurrentVersion,
+    string? AcceptedVersion,
+    DateTime? AcceptedAt,
+    bool NeedsReAcceptance);

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/Queries/TermsAcceptance/GetTermsConsentStatusQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/Queries/TermsAcceptance/GetTermsConsentStatusQuery.cs
@@ -1,0 +1,32 @@
+using Api.BoundedContexts.Authentication.Application.DTOs;
+using Api.BoundedContexts.Authentication.Domain.Constants;
+using Api.BoundedContexts.Authentication.Domain.Repositories;
+using Api.SharedKernel.Application.Interfaces;
+
+#pragma warning disable MA0048 // File name must match type name - Query + Handler in one file
+namespace Api.BoundedContexts.Authentication.Application.Queries;
+
+/// <summary>Returns the ToS acceptance status for a user (#2954 F1).</summary>
+internal record GetTermsConsentStatusQuery(Guid UserId) : IQuery<TermsConsentStatusDto>;
+
+internal sealed class GetTermsConsentStatusQueryHandler
+    : IQueryHandler<GetTermsConsentStatusQuery, TermsConsentStatusDto>
+{
+    private readonly ITermsAcceptanceRepository _repository;
+
+    public GetTermsConsentStatusQueryHandler(ITermsAcceptanceRepository repository)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+    }
+
+    public async Task<TermsConsentStatusDto> Handle(GetTermsConsentStatusQuery query, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var latest = await _repository.GetLatestByUserIdAsync(query.UserId, cancellationToken).ConfigureAwait(false);
+        var acceptedVersion = latest?.TermsVersion;
+        var needsReAcceptance = !string.Equals(acceptedVersion, TermsVersion.Current, StringComparison.Ordinal);
+
+        return new TermsConsentStatusDto(TermsVersion.Current, acceptedVersion, latest?.AcceptedAt, needsReAcceptance);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/Authentication/Domain/Constants/TermsVersion.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Domain/Constants/TermsVersion.cs
@@ -1,0 +1,13 @@
+namespace Api.BoundedContexts.Authentication.Domain.Constants;
+
+/// <summary>
+/// Single server-side source of truth for the current Terms of Service version
+/// (#2954 F1). The ToS text lives in the frontend locales (it.json/en.json) and its
+/// display date in apps/web/src/app/(public)/terms/page.tsx (lastUpdated). This
+/// constant MUST be bumped in the same change whenever that text materially changes.
+/// </summary>
+public static class TermsVersion
+{
+    /// <summary>Current ToS version identifier (date-based; matches terms/page.tsx lastUpdated).</summary>
+    public const string Current = "2026-07-15";
+}

--- a/apps/api/src/Api/BoundedContexts/Authentication/Domain/Entities/TermsAcceptance.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Domain/Entities/TermsAcceptance.cs
@@ -1,0 +1,52 @@
+using Api.BoundedContexts.Authentication.Domain.Enums;
+
+namespace Api.BoundedContexts.Authentication.Domain.Entities;
+
+/// <summary>
+/// Append-only record of a user's acceptance of a specific Terms of Service version
+/// (#2954 F1). One row per acceptance event — never updated in place — so the history
+/// of which version was accepted when is preserved for legal defensibility.
+/// </summary>
+public sealed class TermsAcceptance
+{
+    public Guid Id { get; private set; }
+    public Guid UserId { get; private set; }
+    public string TermsVersion { get; private set; } = string.Empty;
+    public DateTime AcceptedAt { get; private set; }
+    public TermsAcceptanceContext Context { get; private set; }
+    public string? IpAddress { get; private set; }
+    public string? UserAgent { get; private set; }
+    public DateTime CreatedAt { get; private set; }
+
+    // EF Core
+    private TermsAcceptance() { }
+
+    private TermsAcceptance(
+        Guid userId, string termsVersion, TermsAcceptanceContext context, string? ipAddress, string? userAgent)
+    {
+        var now = DateTime.UtcNow;
+        Id = Guid.NewGuid();
+        UserId = userId;
+        TermsVersion = termsVersion;
+        AcceptedAt = now;
+        Context = context;
+        IpAddress = ipAddress;
+        UserAgent = userAgent;
+        CreatedAt = now;
+    }
+
+    public static TermsAcceptance Create(
+        Guid userId,
+        string termsVersion,
+        TermsAcceptanceContext context,
+        string? ipAddress = null,
+        string? userAgent = null)
+    {
+        if (userId == Guid.Empty)
+            throw new ArgumentException("User ID cannot be empty", nameof(userId));
+        if (string.IsNullOrWhiteSpace(termsVersion))
+            throw new ArgumentException("Terms version is required", nameof(termsVersion));
+
+        return new TermsAcceptance(userId, termsVersion, context, ipAddress, userAgent);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/Authentication/Domain/Enums/TermsAcceptanceContext.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Domain/Enums/TermsAcceptanceContext.cs
@@ -1,0 +1,14 @@
+namespace Api.BoundedContexts.Authentication.Domain.Enums;
+
+/// <summary>
+/// Why a ToS acceptance row was recorded (#2954 F1). Persisted as its string
+/// name (never as an int) so growing the enum never requires a DB constraint change.
+/// </summary>
+public enum TermsAcceptanceContext
+{
+    /// <summary>Recorded during initial account registration.</summary>
+    Registration,
+
+    /// <summary>Recorded when the user re-accepts an updated ToS version.</summary>
+    ReConsent,
+}

--- a/apps/api/src/Api/BoundedContexts/Authentication/Domain/Repositories/ITermsAcceptanceRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Domain/Repositories/ITermsAcceptanceRepository.cs
@@ -1,0 +1,19 @@
+using Api.BoundedContexts.Authentication.Domain.Entities;
+
+namespace Api.BoundedContexts.Authentication.Domain.Repositories;
+
+/// <summary>
+/// Repository for the append-only TermsAcceptance record (#2954 F1).
+/// </summary>
+public interface ITermsAcceptanceRepository
+{
+    /// <summary>
+    /// Adds a new acceptance row to the change tracker. Does NOT SaveChanges — the
+    /// caller commits via its Unit of Work, so registration can batch it into one
+    /// transaction with the new user (mirrors SessionRepository).
+    /// </summary>
+    Task AddAsync(TermsAcceptance acceptance, CancellationToken cancellationToken = default);
+
+    /// <summary>Returns the user's most recent acceptance (by AcceptedAt), or null if none.</summary>
+    Task<TermsAcceptance?> GetLatestByUserIdAsync(Guid userId, CancellationToken cancellationToken = default);
+}

--- a/apps/api/src/Api/BoundedContexts/Authentication/Infrastructure/DependencyInjection/AuthenticationServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Infrastructure/DependencyInjection/AuthenticationServiceExtensions.cs
@@ -27,6 +27,7 @@ internal static class AuthenticationServiceExtensions
         services.AddScoped<IInvitationTokenRepository, InvitationTokenRepository>(); // ISSUE-124
         services.AddScoped<IAccessRequestRepository, AccessRequestRepository>(); // ISSUE-124: Access request management
         services.AddScoped<IWaitlistEntryRepository, WaitlistEntryRepository>(); // ISSUE-589: Public Alpha waitlist (Wave A.2)
+        services.AddScoped<ITermsAcceptanceRepository, TermsAcceptanceRepository>(); // #2954 F1: ToS acceptance record
 
         // Register Unit of Work
         services.AddScoped<IUnitOfWork, EfCoreUnitOfWork>();

--- a/apps/api/src/Api/BoundedContexts/Authentication/Infrastructure/Persistence/TermsAcceptanceRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Infrastructure/Persistence/TermsAcceptanceRepository.cs
@@ -1,0 +1,35 @@
+using Api.BoundedContexts.Authentication.Domain.Entities;
+using Api.BoundedContexts.Authentication.Domain.Repositories;
+using Api.Infrastructure;
+using Api.SharedKernel.Application.Services;
+using Api.SharedKernel.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.Authentication.Infrastructure.Persistence;
+
+/// <summary>
+/// EF Core repository for the append-only TermsAcceptance record (#2954 F1).
+/// </summary>
+public sealed class TermsAcceptanceRepository : RepositoryBase, ITermsAcceptanceRepository
+{
+    public TermsAcceptanceRepository(MeepleAiDbContext dbContext, IDomainEventCollector eventCollector)
+        : base(dbContext, eventCollector)
+    {
+    }
+
+    public async Task AddAsync(TermsAcceptance acceptance, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(acceptance);
+        // No SaveChanges here — the caller's Unit of Work commits (mirrors SessionRepository).
+        await DbContext.Set<TermsAcceptance>().AddAsync(acceptance, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<TermsAcceptance?> GetLatestByUserIdAsync(Guid userId, CancellationToken cancellationToken = default)
+    {
+        return await DbContext.Set<TermsAcceptance>()
+            .AsNoTracking()
+            .Where(t => t.UserId == userId)
+            .OrderByDescending(t => t.AcceptedAt)
+            .FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/Authentication/TermsAcceptanceEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/Authentication/TermsAcceptanceEntityConfiguration.cs
@@ -1,0 +1,45 @@
+using Api.BoundedContexts.Authentication.Domain.Entities;
+using Api.Infrastructure.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Api.Infrastructure.EntityConfigurations.Authentication;
+
+/// <summary>
+/// EF Core configuration for the append-only TermsAcceptance entity (#2954 F1).
+/// Auto-applied via ApplyConfigurationsFromAssembly (mirrors UserAiConsent).
+/// </summary>
+internal sealed class TermsAcceptanceEntityConfiguration : IEntityTypeConfiguration<TermsAcceptance>
+{
+    public void Configure(EntityTypeBuilder<TermsAcceptance> builder)
+    {
+        builder.ToTable("user_terms_acceptances");
+
+        builder.HasKey(e => e.Id);
+
+        builder.Property(e => e.UserId).IsRequired();
+        builder.Property(e => e.TermsVersion).IsRequired().HasMaxLength(50);
+        builder.Property(e => e.AcceptedAt).IsRequired();
+
+        // Persisted as the enum's string name (not int) → no CHECK-range drift
+        // when the enum grows (avoids the #2974 constraint pitfall).
+        builder.Property(e => e.Context)
+            .IsRequired()
+            .HasConversion<string>()
+            .HasMaxLength(32);
+
+        builder.Property(e => e.IpAddress).HasMaxLength(45);
+        builder.Property(e => e.UserAgent).HasMaxLength(512);
+        builder.Property(e => e.CreatedAt).IsRequired();
+
+        // FK to users with cascade delete (no navigation property needed).
+        builder.HasOne<UserEntity>()
+            .WithMany()
+            .HasForeignKey(e => e.UserId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        // Latest-acceptance lookup. Append-only: intentionally NO unique index on UserId.
+        builder.HasIndex(e => new { e.UserId, e.AcceptedAt })
+            .HasDatabaseName("ix_user_terms_acceptances_user_accepted");
+    }
+}

--- a/apps/api/src/Api/Infrastructure/Migrations/20260719172606_AddUserTermsAcceptances.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260719172606_AddUserTermsAcceptances.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260719172606_AddUserTermsAcceptances")]
+    partial class AddUserTermsAcceptances
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260719172606_AddUserTermsAcceptances.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260719172606_AddUserTermsAcceptances.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUserTermsAcceptances : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "user_terms_acceptances",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    UserId = table.Column<Guid>(type: "uuid", nullable: false),
+                    TermsVersion = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: false),
+                    AcceptedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    Context = table.Column<string>(type: "character varying(32)", maxLength: 32, nullable: false),
+                    IpAddress = table.Column<string>(type: "character varying(45)", maxLength: 45, nullable: true),
+                    UserAgent = table.Column<string>(type: "character varying(512)", maxLength: 512, nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_user_terms_acceptances", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_user_terms_acceptances_users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_user_terms_acceptances_user_accepted",
+                table: "user_terms_acceptances",
+                columns: new[] { "UserId", "AcceptedAt" });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "user_terms_acceptances");
+        }
+    }
+}

--- a/apps/api/src/Api/Models/AuthContracts.cs
+++ b/apps/api/src/Api/Models/AuthContracts.cs
@@ -32,6 +32,13 @@ internal class RegisterPayload
     /// fall back to User role. Accepts both casing variants.
     /// </summary>
     public string? BootstrapToken { get; set; }
+
+    /// <summary>
+    /// #2954 F1: whether the user checked the required "I accept the Terms of Service"
+    /// box. Enforced server-side at the endpoint (400 when false/absent). Accepts both
+    /// "termsAccepted" (camelCase) and "TermsAccepted" (PascalCase).
+    /// </summary>
+    public bool TermsAccepted { get; set; }
 }
 
 /// <summary>

--- a/apps/api/src/Api/Program.cs
+++ b/apps/api/src/Api/Program.cs
@@ -850,6 +850,7 @@ Api.Routing.SharedGameCatalogPublicEndpoints.Map(v1Api);
 v1Api.MapPermissionEndpoints(); // Epic #4068: Permission system endpoints
 v1Api.MapShareLinkEndpoints(); // ISSUE-2052: Shareable chat thread links
 v1Api.MapUserAiConsentEndpoints(); // Issue #5512: GDPR AI consent
+v1Api.MapTermsConsentEndpoints(); // #2954 F1: ToS acceptance foundation
 v1Api.MapUserLlmDataEndpoints(); // Issue #5509: GDPR right to erasure for LLM data
 v1Api.MapUserUsageEndpoints(); // E2-2: User tier usage endpoint
 v1Api.MapDeviceEndpoints();            // Issue #3340: Device tracking and management

--- a/apps/api/src/Api/Routing/AuthenticationEndpoints.cs
+++ b/apps/api/src/Api/Routing/AuthenticationEndpoints.cs
@@ -97,6 +97,13 @@ internal static class AuthenticationEndpoints
                 return Results.BadRequest(new { error = "Email and password are required" });
             }
 
+            // #2954 F1: server-side enforcement of ToS acceptance. The register form's
+            // checkbox is client-cosmetic; reject a direct API call that omits acceptance.
+            if (!payload.TermsAccepted)
+            {
+                return Results.BadRequest(new { error = "You must accept the Terms of Service to register" });
+            }
+
             // R3 (auth security fixes): generate a random "Player-{ShortGuid}"
             // when the client doesn't supply a display name. The legacy
             // fallback used the email-prefix (e.g. "alice" from
@@ -116,7 +123,8 @@ internal static class AuthenticationEndpoints
                 Role: null,
                 IpAddress: context.Connection.RemoteIpAddress?.ToString(),
                 UserAgent: context.Request.Headers.UserAgent.ToString(),
-                BootstrapToken: payload.BootstrapToken);
+                BootstrapToken: payload.BootstrapToken,
+                TermsAccepted: payload.TermsAccepted);
 
             logger.LogInformation("User registration attempt for {Email}", DataMasking.MaskEmail(payload.Email));
             var result = await mediator.Send(command, ct).ConfigureAwait(false);

--- a/apps/api/src/Api/Routing/TermsConsentEndpoints.cs
+++ b/apps/api/src/Api/Routing/TermsConsentEndpoints.cs
@@ -1,0 +1,72 @@
+using Api.BoundedContexts.Authentication.Application.Commands;
+using Api.BoundedContexts.Authentication.Application.DTOs;
+using Api.BoundedContexts.Authentication.Application.Queries;
+using Api.Extensions;
+using MediatR;
+
+namespace Api.Routing;
+
+/// <summary>
+/// Terms-of-Service acceptance endpoints (#2954 F1). Foundation only: records/reads
+/// acceptance; no blocking gate is wired to needsReAcceptance in this scope.
+/// </summary>
+internal static class TermsConsentEndpoints
+{
+    public static RouteGroupBuilder MapTermsConsentEndpoints(this RouteGroupBuilder group)
+    {
+        MapGetTermsStatus(group);
+        MapAcceptTerms(group);
+        return group;
+    }
+
+    private static void MapGetTermsStatus(RouteGroupBuilder group)
+    {
+        group.MapGet("/users/me/terms/status", async (
+            HttpContext context,
+            IMediator mediator,
+            CancellationToken ct) =>
+        {
+            var session = (SessionStatusDto)context.Items[nameof(SessionStatusDto)]!;
+            var status = await mediator.Send(
+                new GetTermsConsentStatusQuery(session.Principal!.Subject.Id), ct).ConfigureAwait(false);
+            return Results.Json(status);
+        })
+        .RequireSession()
+        .RequireAuthorization()
+        .WithName("GetTermsConsentStatus")
+        .WithTags("User Profile", "Terms")
+        .WithSummary("Get current user's ToS acceptance status")
+        .WithDescription(@"Returns the authenticated user's Terms-of-Service acceptance status (#2954 F1).
+
+**Response**: TermsConsentStatusDto with the current server version, the user's last
+accepted version (nullable), the acceptance timestamp, and a computed needsReAcceptance flag.")
+        .Produces(200)
+        .Produces(401);
+    }
+
+    private static void MapAcceptTerms(RouteGroupBuilder group)
+    {
+        group.MapPost("/users/me/terms/accept", async (
+            HttpContext context,
+            IMediator mediator,
+            CancellationToken ct) =>
+        {
+            var session = (SessionStatusDto)context.Items[nameof(SessionStatusDto)]!;
+            var status = await mediator.Send(new RecordTermsAcceptanceCommand(
+                UserId: session.Principal!.Subject.Id,
+                IpAddress: context.Connection.RemoteIpAddress?.ToString(),
+                UserAgent: context.Request.Headers.UserAgent.ToString()), ct).ConfigureAwait(false);
+            return Results.Json(status);
+        })
+        .RequireSession()
+        .RequireAuthorization()
+        .WithName("AcceptTerms")
+        .WithTags("User Profile", "Terms")
+        .WithSummary("Record acceptance of the current ToS version")
+        .WithDescription(@"Records that the authenticated user accepted the current Terms-of-Service
+version (#2954 F1). Idempotent: no new row is written when the user's latest accepted
+version already equals the current one.")
+        .Produces(200)
+        .Produces(401);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/Authentication/Application/GetTermsConsentStatusQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Authentication/Application/GetTermsConsentStatusQueryHandlerTests.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Api.BoundedContexts.Authentication.Application.Queries;
+using Api.BoundedContexts.Authentication.Domain.Constants;
+using Api.BoundedContexts.Authentication.Domain.Entities;
+using Api.BoundedContexts.Authentication.Domain.Enums;
+using Api.BoundedContexts.Authentication.Domain.Repositories;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.Authentication.Application;
+
+[Trait("Category", TestCategories.Unit)]
+public sealed class GetTermsConsentStatusQueryHandlerTests
+{
+    private readonly Mock<ITermsAcceptanceRepository> _repo = new();
+
+    private GetTermsConsentStatusQueryHandler CreateSut() => new(_repo.Object);
+
+    [Fact]
+    public async Task Handle_NoAcceptance_NeedsReAcceptanceTrue()
+    {
+        _repo.Setup(r => r.GetLatestByUserIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((TermsAcceptance?)null);
+
+        var result = await CreateSut().Handle(new GetTermsConsentStatusQuery(Guid.NewGuid()), CancellationToken.None);
+
+        result.CurrentVersion.Should().Be(TermsVersion.Current);
+        result.AcceptedVersion.Should().BeNull();
+        result.AcceptedAt.Should().BeNull();
+        result.NeedsReAcceptance.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Handle_StaleVersion_NeedsReAcceptanceTrue()
+    {
+        var userId = Guid.NewGuid();
+        _repo.Setup(r => r.GetLatestByUserIdAsync(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(TermsAcceptance.Create(userId, "2026-03-09", TermsAcceptanceContext.Registration));
+
+        var result = await CreateSut().Handle(new GetTermsConsentStatusQuery(userId), CancellationToken.None);
+
+        result.AcceptedVersion.Should().Be("2026-03-09");
+        result.NeedsReAcceptance.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Handle_CurrentVersion_NeedsReAcceptanceFalse()
+    {
+        var userId = Guid.NewGuid();
+        _repo.Setup(r => r.GetLatestByUserIdAsync(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(TermsAcceptance.Create(userId, TermsVersion.Current, TermsAcceptanceContext.ReConsent));
+
+        var result = await CreateSut().Handle(new GetTermsConsentStatusQuery(userId), CancellationToken.None);
+
+        result.AcceptedVersion.Should().Be(TermsVersion.Current);
+        result.NeedsReAcceptance.Should().BeFalse();
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/Authentication/Application/RecordTermsAcceptanceCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Authentication/Application/RecordTermsAcceptanceCommandHandlerTests.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Api.BoundedContexts.Authentication.Application.Commands;
+using Api.BoundedContexts.Authentication.Domain.Constants;
+using Api.BoundedContexts.Authentication.Domain.Entities;
+using Api.BoundedContexts.Authentication.Domain.Enums;
+using Api.BoundedContexts.Authentication.Domain.Repositories;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.Authentication.Application;
+
+[Trait("Category", TestCategories.Unit)]
+public sealed class RecordTermsAcceptanceCommandHandlerTests
+{
+    private readonly Mock<ITermsAcceptanceRepository> _repo = new();
+    private readonly Mock<IUnitOfWork> _uow = new();
+
+    private RecordTermsAcceptanceCommandHandler CreateSut() => new(_repo.Object, _uow.Object);
+
+    [Fact]
+    public async Task Handle_NoPriorAcceptance_AppendsCurrentVersion()
+    {
+        _repo.Setup(r => r.GetLatestByUserIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((TermsAcceptance?)null);
+
+        var result = await CreateSut().Handle(
+            new RecordTermsAcceptanceCommand(Guid.NewGuid()), CancellationToken.None);
+
+        _repo.Verify(r => r.AddAsync(
+            It.Is<TermsAcceptance>(a => a.TermsVersion == TermsVersion.Current
+                                        && a.Context == TermsAcceptanceContext.ReConsent),
+            It.IsAny<CancellationToken>()), Times.Once);
+        _uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+        result.AcceptedVersion.Should().Be(TermsVersion.Current);
+        result.NeedsReAcceptance.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Handle_AlreadyAcceptedCurrent_IsNoOp()
+    {
+        var userId = Guid.NewGuid();
+        _repo.Setup(r => r.GetLatestByUserIdAsync(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(TermsAcceptance.Create(userId, TermsVersion.Current, TermsAcceptanceContext.Registration));
+
+        var result = await CreateSut().Handle(
+            new RecordTermsAcceptanceCommand(userId), CancellationToken.None);
+
+        _repo.Verify(r => r.AddAsync(It.IsAny<TermsAcceptance>(), It.IsAny<CancellationToken>()), Times.Never);
+        _uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+        result.NeedsReAcceptance.Should().BeFalse();
+        result.AcceptedVersion.Should().Be(TermsVersion.Current);
+    }
+
+    [Fact]
+    public async Task Handle_StalePriorAcceptance_AppendsNewRow()
+    {
+        var userId = Guid.NewGuid();
+        _repo.Setup(r => r.GetLatestByUserIdAsync(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(TermsAcceptance.Create(userId, "2026-03-09", TermsAcceptanceContext.Registration));
+
+        await CreateSut().Handle(new RecordTermsAcceptanceCommand(userId), CancellationToken.None);
+
+        _repo.Verify(r => r.AddAsync(It.IsAny<TermsAcceptance>(), It.IsAny<CancellationToken>()), Times.Once);
+        _uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/Authentication/Domain/TermsAcceptanceTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Authentication/Domain/TermsAcceptanceTests.cs
@@ -1,0 +1,58 @@
+using System;
+using Api.BoundedContexts.Authentication.Domain.Entities;
+using Api.BoundedContexts.Authentication.Domain.Enums;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.Authentication.Domain;
+
+[Trait("Category", TestCategories.Unit)]
+public sealed class TermsAcceptanceTests
+{
+    [Fact]
+    public void Create_WithValidInput_SetsAllFields()
+    {
+        var userId = Guid.NewGuid();
+
+        var acceptance = TermsAcceptance.Create(
+            userId, "2026-07-15", TermsAcceptanceContext.Registration, "1.2.3.4", "UA/1.0");
+
+        acceptance.Id.Should().NotBe(Guid.Empty);
+        acceptance.UserId.Should().Be(userId);
+        acceptance.TermsVersion.Should().Be("2026-07-15");
+        acceptance.Context.Should().Be(TermsAcceptanceContext.Registration);
+        acceptance.IpAddress.Should().Be("1.2.3.4");
+        acceptance.UserAgent.Should().Be("UA/1.0");
+        acceptance.AcceptedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(5));
+        acceptance.CreatedAt.Should().Be(acceptance.AcceptedAt);
+    }
+
+    [Fact]
+    public void Create_WithEmptyUserId_Throws()
+    {
+        var act = () => TermsAcceptance.Create(
+            Guid.Empty, "2026-07-15", TermsAcceptanceContext.Registration);
+        act.Should().Throw<ArgumentException>().WithParameterName("userId");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Create_WithBlankVersion_Throws(string? version)
+    {
+        var act = () => TermsAcceptance.Create(
+            Guid.NewGuid(), version!, TermsAcceptanceContext.ReConsent);
+        act.Should().Throw<ArgumentException>().WithParameterName("termsVersion");
+    }
+
+    [Fact]
+    public void Create_AllowsNullAuditFields()
+    {
+        var acceptance = TermsAcceptance.Create(
+            Guid.NewGuid(), "2026-07-15", TermsAcceptanceContext.ReConsent);
+        acceptance.IpAddress.Should().BeNull();
+        acceptance.UserAgent.Should().BeNull();
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/Authentication/Endpoints/ChangePasswordSessionRevokeEndpointTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Authentication/Endpoints/ChangePasswordSessionRevokeEndpointTests.cs
@@ -152,6 +152,7 @@ public sealed class ChangePasswordSessionRevokeEndpointTests : IAsyncLifetime
             Email = email,
             Password = password,
             DisplayName = "C7 Revoke Test",
+            TermsAccepted = true,
         });
         response.EnsureSuccessStatusCode();
         return ExtractSessionCookie(response)

--- a/apps/api/tests/Api.Tests/BoundedContexts/Authentication/Endpoints/RegisterRaceConditionEndpointTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Authentication/Endpoints/RegisterRaceConditionEndpointTests.cs
@@ -114,7 +114,8 @@ public sealed class RegisterRaceConditionEndpointTests : IAsyncLifetime
             {
                 Email = email,
                 Password = "ValidUnusualPwd123!",
-                DisplayName = $"Racer {i}"
+                DisplayName = $"Racer {i}",
+                TermsAccepted = true
             }))).ToArray();
 
         var responses = await Task.WhenAll(tasks);
@@ -153,7 +154,8 @@ public sealed class RegisterRaceConditionEndpointTests : IAsyncLifetime
             Email = email,
             Password = "ValidUnusualPwd123!",
             DisplayName = "First Admin",
-            BootstrapToken
+            BootstrapToken,
+            TermsAccepted = true
         });
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -171,7 +173,8 @@ public sealed class RegisterRaceConditionEndpointTests : IAsyncLifetime
         {
             Email = email,
             Password = "ValidUnusualPwd123!",
-            DisplayName = "Plain User"
+            DisplayName = "Plain User",
+            TermsAccepted = true
         });
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -188,7 +191,8 @@ public sealed class RegisterRaceConditionEndpointTests : IAsyncLifetime
             Email = email,
             Password = "ValidUnusualPwd123!",
             DisplayName = "Wrong Token",
-            BootstrapToken = BootstrapToken + "-tampered"
+            BootstrapToken = BootstrapToken + "-tampered",
+            TermsAccepted = true
         });
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -209,7 +213,8 @@ public sealed class RegisterRaceConditionEndpointTests : IAsyncLifetime
         {
             Email = email,
             Password = "ValidUnusualPwd123!",
-            DisplayName = "First User No Token"
+            DisplayName = "First User No Token",
+            TermsAccepted = true
         });
 
         response.StatusCode.Should().Be(HttpStatusCode.OK);
@@ -235,7 +240,8 @@ public sealed class RegisterRaceConditionEndpointTests : IAsyncLifetime
                 Email = $"bootstrap-race-{i}-{Guid.NewGuid():N}@test.local",
                 Password = "ValidUnusualPwd123!",
                 DisplayName = $"Bootstrap Racer {i}",
-                BootstrapToken
+                BootstrapToken,
+                TermsAccepted = true
             }))).ToArray();
 
         var responses = await Task.WhenAll(tasks);
@@ -286,7 +292,8 @@ public sealed class RegisterRaceConditionEndpointTests : IAsyncLifetime
                 Email = $"timing-match-{Guid.NewGuid():N}@test.local",
                 Password = "ValidUnusualPwd123!",
                 DisplayName = $"Match {i}",
-                BootstrapToken
+                BootstrapToken,
+                TermsAccepted = true
             });
             sw.Stop();
             matchTimings.Add(sw.ElapsedMilliseconds);
@@ -297,7 +304,8 @@ public sealed class RegisterRaceConditionEndpointTests : IAsyncLifetime
                 Email = $"timing-miss-{Guid.NewGuid():N}@test.local",
                 Password = "ValidUnusualPwd123!",
                 DisplayName = $"Miss {i}",
-                BootstrapToken = nearMiss
+                BootstrapToken = nearMiss,
+                TermsAccepted = true
             });
             sw.Stop();
             missTimings.Add(sw.ElapsedMilliseconds);

--- a/apps/api/tests/Api.Tests/E2E/Authentication/AuthenticationE2ETests.cs
+++ b/apps/api/tests/Api.Tests/E2E/Authentication/AuthenticationE2ETests.cs
@@ -61,8 +61,9 @@ public sealed class AuthenticationE2ETests : E2ETestBase
         // Clear cookies for second registration attempt
         ClearAuthentication();
 
-        // Act - Second registration with same email
-        var payload = new { email, password, displayName = "Another User" };
+        // Act - Second registration with same email (termsAccepted=true so the request
+        // reaches the email-uniqueness check rather than short-circuiting on the ToS guard).
+        var payload = new { email, password, displayName = "Another User", termsAccepted = true };
         var response = await Client.PostAsJsonAsync("/api/v1/auth/register", payload);
 
         // Assert - May return BadRequest or Conflict depending on validation order
@@ -75,8 +76,9 @@ public sealed class AuthenticationE2ETests : E2ETestBase
     [InlineData("valid@email.com", "short", "Password")]  // Changed to match actual API error
     public async Task Register_WithInvalidInput_ReturnsBadRequest(string email, string password, string expectedError)
     {
-        // Arrange
-        var payload = new { email, password };
+        // Arrange - termsAccepted=true so the request reaches the field validator (which
+        // produces the field-specific error) instead of the ToS-acceptance guard (400).
+        var payload = new { email, password, termsAccepted = true };
 
         // Act
         var response = await Client.PostAsJsonAsync("/api/v1/auth/register", payload);

--- a/apps/api/tests/Api.Tests/E2E/Infrastructure/E2ETestBase.cs
+++ b/apps/api/tests/Api.Tests/E2E/Infrastructure/E2ETestBase.cs
@@ -135,7 +135,8 @@ public abstract class E2ETestBase : IAsyncLifetime
         {
             email,
             password,
-            displayName = displayName ?? email.Split('@')[0]
+            displayName = displayName ?? email.Split('@')[0],
+            termsAccepted = true
         };
 
         var response = await Client.PostAsJsonAsync("/api/v1/auth/register", payload);

--- a/apps/api/tests/Api.Tests/E2E/SharedGameCatalog/AdminGameCreationJourneyE2ETests.cs
+++ b/apps/api/tests/Api.Tests/E2E/SharedGameCatalog/AdminGameCreationJourneyE2ETests.cs
@@ -820,7 +820,8 @@ public sealed class AdminGameCreationJourneyE2ETests : E2ETestBase
             {
                 email = "admin@test.local",
                 password = "TestUnusualAdm123!",
-                displayName = "Test Admin"
+                displayName = "Test Admin",
+                termsAccepted = true
             };
 
             var registerResponse = await Client.PostAsJsonAsync("/api/v1/auth/register", registerPayload);

--- a/apps/api/tests/Api.Tests/E2E/SharedGameCatalog/ShareRequestE2ETests.cs
+++ b/apps/api/tests/Api.Tests/E2E/SharedGameCatalog/ShareRequestE2ETests.cs
@@ -399,7 +399,8 @@ public sealed class ShareRequestE2ETests : E2ETestBase
             {
                 email = "admin@test.local",
                 password = "TestUnusualAdm123!",
-                displayName = "Test Admin"
+                displayName = "Test Admin",
+                termsAccepted = true
             };
 
             var registerResponse = await Client.PostAsJsonAsync("/api/v1/auth/register", registerPayload);

--- a/apps/api/tests/Api.Tests/Integration/Administration/S3AcceptanceScenariosTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/Administration/S3AcceptanceScenariosTests.cs
@@ -123,7 +123,7 @@ public sealed class S3AcceptanceScenariosTests : IAsyncLifetime
     private async Task<(Guid UserId, Guid SessionId)> SeedAdminAsync(string email, string password, string role = "admin")
     {
         var registerResponse = await _client.PostAsJsonAsync("/api/v1/auth/register",
-            new { Email = email, Password = password, DisplayName = email.Split('@')[0] });
+            new { Email = email, Password = password, DisplayName = email.Split('@')[0], TermsAccepted = true });
         registerResponse.StatusCode.Should().Be(HttpStatusCode.OK,
             $"the test fixture expects a clean registration; got {await registerResponse.Content.ReadAsStringAsync()}");
 

--- a/apps/api/tests/Api.Tests/Integration/Authentication/AuthenticationEndpointsIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/Authentication/AuthenticationEndpointsIntegrationTests.cs
@@ -86,7 +86,8 @@ public sealed class AuthenticationEndpointsIntegrationTests : IAsyncLifetime
         {
             Email = $"test-{Guid.NewGuid():N}@test.com",
             Password = "SecureUnusualPwd123!",
-            DisplayName = "Test User"
+            DisplayName = "Test User",
+            TermsAccepted = true
         };
 
         // Act
@@ -110,7 +111,7 @@ public sealed class AuthenticationEndpointsIntegrationTests : IAsyncLifetime
     {
         // Arrange - Create first user
         var email = $"duplicate-{Guid.NewGuid():N}@test.com";
-        var payload1 = new { Email = email, Password = "UnusualPwd123!", DisplayName = "User 1" };
+        var payload1 = new { Email = email, Password = "UnusualPwd123!", DisplayName = "User 1", TermsAccepted = true };
         await _client.PostAsJsonAsync("/api/v1/auth/register", payload1);
 
         // Act - Try to register same email
@@ -173,7 +174,8 @@ public sealed class AuthenticationEndpointsIntegrationTests : IAsyncLifetime
         {
             Email = email,
             Password = password,
-            DisplayName = "Login Test User"
+            DisplayName = "Login Test User",
+            TermsAccepted = true
         });
 
         // Act - Login with credentials
@@ -204,7 +206,8 @@ public sealed class AuthenticationEndpointsIntegrationTests : IAsyncLifetime
         {
             Email = email,
             Password = "CorrectUnusualPwd123!",
-            DisplayName = "Test User"
+            DisplayName = "Test User",
+            TermsAccepted = true
         });
 
         // Act - Login with wrong password
@@ -260,7 +263,8 @@ public sealed class AuthenticationEndpointsIntegrationTests : IAsyncLifetime
         {
             Email = email,
             Password = password,
-            DisplayName = "Logout Test User"
+            DisplayName = "Logout Test User",
+            TermsAccepted = true
         });
 
         var loginResponse = await _client.PostAsJsonAsync("/api/v1/auth/login", new
@@ -317,7 +321,8 @@ public sealed class AuthenticationEndpointsIntegrationTests : IAsyncLifetime
         {
             Email = email,
             Password = password,
-            DisplayName = displayName
+            DisplayName = displayName,
+            TermsAccepted = true
         });
 
         var loginResponse = await _client.PostAsJsonAsync("/api/v1/auth/login", new

--- a/apps/api/tests/Api.Tests/Integration/Authentication/AuthenticationEndpointsIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/Authentication/AuthenticationEndpointsIntegrationTests.cs
@@ -114,8 +114,9 @@ public sealed class AuthenticationEndpointsIntegrationTests : IAsyncLifetime
         var payload1 = new { Email = email, Password = "UnusualPwd123!", DisplayName = "User 1", TermsAccepted = true };
         await _client.PostAsJsonAsync("/api/v1/auth/register", payload1);
 
-        // Act - Try to register same email
-        var payload2 = new { Email = email, Password = "UnusualPwd456!", DisplayName = "User 2" };
+        // Act - Try to register same email (TermsAccepted=true so the request reaches the
+        // email-uniqueness check rather than short-circuiting on the ToS-acceptance guard).
+        var payload2 = new { Email = email, Password = "UnusualPwd456!", DisplayName = "User 2", TermsAccepted = true };
         var response = await _client.PostAsJsonAsync("/api/v1/auth/register", payload2);
 
         // Assert - C5: the pre-flight email-existence check is removed; the DB
@@ -132,7 +133,8 @@ public sealed class AuthenticationEndpointsIntegrationTests : IAsyncLifetime
         {
             Email = $"test-{Guid.NewGuid():N}@test.com",
             Password = "weak",
-            DisplayName = "Test User"
+            DisplayName = "Test User",
+            TermsAccepted = true // reach the password validator (422), not the ToS guard (400)
         };
 
         // Act
@@ -150,7 +152,8 @@ public sealed class AuthenticationEndpointsIntegrationTests : IAsyncLifetime
         {
             Email = "not-an-email",
             Password = "SecureUnusualPwd123!",
-            DisplayName = "Test User"
+            DisplayName = "Test User",
+            TermsAccepted = true // reach the email validator (422), not the ToS guard (400)
         };
 
         // Act

--- a/apps/api/tests/Api.Tests/Integration/Authentication/TermsAcceptanceIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/Authentication/TermsAcceptanceIntegrationTests.cs
@@ -6,6 +6,7 @@ using System.Net.Http;
 using System.Net.Http.Json;
 using System.Text.Json;
 using System.Threading.Tasks;
+using Api.BoundedContexts.Authentication.Application.DTOs;
 using Api.BoundedContexts.Authentication.Domain.Constants;
 using Api.BoundedContexts.Authentication.Domain.Entities;
 using Api.BoundedContexts.Authentication.Domain.Enums;
@@ -78,7 +79,15 @@ public sealed class TermsAcceptanceIntegrationTests : IAsyncLifetime
             await dbContext.Database.MigrateAsync();
         }
 
-        _client = _factory.CreateClient();
+        // HandleCookies=false: TestServer's CookieContainer is unreliable at carrying the
+        // session cookie to subsequent authenticated requests (see the lenient asserts in
+        // AuthenticationFlowTests). RegisterUserAsync attaches the Set-Cookie manually — the
+        // deterministic pattern used by AdminUserFactory.
+        _client = _factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false,
+            HandleCookies = false,
+        });
     }
 
     public async ValueTask DisposeAsync()
@@ -133,6 +142,114 @@ public sealed class TermsAcceptanceIntegrationTests : IAsyncLifetime
         }
     }
 
+    // ---- Task 4: registration records acceptance ----------------------------
+
+    [Fact]
+    public async Task Register_WithTermsAccepted_WritesExactlyOneRegistrationRow()
+    {
+        var userId = await RegisterUserAsync(termsAccepted: true);
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var rows = await db.Set<TermsAcceptance>()
+            .AsNoTracking()
+            .Where(t => t.UserId == userId)
+            .ToListAsync();
+
+        rows.Should().HaveCount(1);
+        rows[0].TermsVersion.Should().Be(TermsVersion.Current);
+        rows[0].Context.Should().Be(TermsAcceptanceContext.Registration);
+    }
+
+    [Fact]
+    public async Task Register_WithoutTermsAccepted_Returns400()
+    {
+        var response = await _client.PostAsJsonAsync(RegisterEndpoint, new
+        {
+            email = $"noterms-{Guid.NewGuid():N}@test.local",
+            password = "ValidUnusualPwd123!",
+            displayName = "No Terms",
+            // termsAccepted omitted → defaults false
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+    }
+
+    // ---- Task 5: accept + status endpoints ----------------------------------
+
+    [Fact]
+    public async Task Status_AfterRegister_ReturnsCurrentAccepted()
+    {
+        await RegisterUserAsync(termsAccepted: true); // _client is now authenticated
+
+        var status = await _client.GetFromJsonAsync<TermsConsentStatusDto>(StatusEndpoint);
+
+        status.Should().NotBeNull();
+        status!.CurrentVersion.Should().Be(TermsVersion.Current);
+        status.AcceptedVersion.Should().Be(TermsVersion.Current);
+        status.NeedsReAcceptance.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Status_Unauthenticated_Returns401()
+    {
+        // No registration/login on this fresh client → no session cookie.
+        var response = await _client.GetAsync(StatusEndpoint);
+
+        response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+    }
+
+    [Fact]
+    public async Task Accept_WhenAlreadyCurrent_IsIdempotent()
+    {
+        var userId = await RegisterUserAsync(termsAccepted: true); // 1 Current row
+
+        var accept = await _client.PostAsync(AcceptEndpoint, content: null);
+        accept.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var currentRows = await db.Set<TermsAcceptance>()
+            .AsNoTracking()
+            .CountAsync(t => t.UserId == userId && t.TermsVersion == TermsVersion.Current);
+        currentRows.Should().Be(1, "accepting the already-current version must not append a second row");
+    }
+
+    [Fact]
+    public async Task StaleAcceptance_Accept_TransitionsToCurrent()
+    {
+        var userId = await RegisterUserAsync(termsAccepted: true);
+
+        // Force the registration row stale (older version + older timestamp).
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            await db.Set<TermsAcceptance>()
+                .Where(t => t.UserId == userId)
+                .ExecuteUpdateAsync(s => s
+                    .SetProperty(t => t.TermsVersion, "2026-03-09")
+                    .SetProperty(t => t.AcceptedAt, new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc)));
+        }
+
+        var before = await _client.GetFromJsonAsync<TermsConsentStatusDto>(StatusEndpoint);
+        before!.NeedsReAcceptance.Should().BeTrue();
+        before.AcceptedVersion.Should().Be("2026-03-09");
+
+        var accept = await _client.PostAsync(AcceptEndpoint, content: null);
+        accept.StatusCode.Should().Be(HttpStatusCode.OK);
+
+        var after = await _client.GetFromJsonAsync<TermsConsentStatusDto>(StatusEndpoint);
+        after!.NeedsReAcceptance.Should().BeFalse();
+        after.AcceptedVersion.Should().Be(TermsVersion.Current);
+
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            var total = await db.Set<TermsAcceptance>().CountAsync(t => t.UserId == userId);
+            total.Should().Be(2, "append-only: the stale row is preserved and a new current row is added");
+        }
+    }
+
     // ---- Helpers ------------------------------------------------------------
 
     /// <summary>
@@ -150,6 +267,15 @@ public sealed class TermsAcceptanceIntegrationTests : IAsyncLifetime
         });
 
         response.StatusCode.Should().Be(HttpStatusCode.OK, "registration should succeed for the happy path");
+
+        // Attach the session cookie manually so subsequent authenticated requests
+        // (GET /status, POST /accept) carry it deterministically.
+        if (response.Headers.TryGetValues("Set-Cookie", out var setCookies))
+        {
+            var cookieHeader = string.Join("; ", setCookies.Select(c => c.Split(';')[0]));
+            _client.DefaultRequestHeaders.Remove("Cookie");
+            _client.DefaultRequestHeaders.Add("Cookie", cookieHeader);
+        }
 
         var body = await response.Content.ReadFromJsonAsync<JsonElement>();
         var idString = body.GetProperty("user").GetProperty("id").GetString();

--- a/apps/api/tests/Api.Tests/Integration/Authentication/TermsAcceptanceIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/Authentication/TermsAcceptanceIntegrationTests.cs
@@ -1,0 +1,158 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Api.BoundedContexts.Authentication.Domain.Constants;
+using Api.BoundedContexts.Authentication.Domain.Entities;
+using Api.BoundedContexts.Authentication.Domain.Enums;
+using Api.BoundedContexts.Authentication.Domain.Repositories;
+using Api.Infrastructure;
+using Api.Services;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.Integration.Authentication;
+
+/// <summary>
+/// Integration tests for the ToS acceptance foundation (#2954 F1): the append-only
+/// user_terms_acceptances persistence, the registration recording path, and the
+/// me-scoped accept/status endpoints. Uses real PostgreSQL via Testcontainers.
+/// </summary>
+[Collection("Integration-GroupB")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "Authentication")]
+public sealed class TermsAcceptanceIntegrationTests : IAsyncLifetime
+{
+    private const string RegisterEndpoint = "/api/v1/auth/register";
+    private const string StatusEndpoint = "/api/v1/users/me/terms/status";
+    private const string AcceptEndpoint = "/api/v1/users/me/terms/accept";
+
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly string _testDbName;
+    private WebApplicationFactory<Program> _factory = null!;
+    private HttpClient _client = null!;
+
+    public TermsAcceptanceIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+        _testDbName = $"terms_accept_{Guid.NewGuid():N}";
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_testDbName);
+
+        _factory = IntegrationWebApplicationFactory.Create(connectionString)
+            .WithWebHostBuilder(builder =>
+            {
+                builder.ConfigureTestServices(services =>
+                {
+                    // Public registration must be enabled so /auth/register skips the
+                    // 403 RequirePublicRegistration filter.
+                    services.RemoveAll(typeof(IConfigurationService));
+                    var mockConfig = new Mock<IConfigurationService>();
+                    mockConfig
+                        .Setup(c => c.GetValueAsync<bool?>(
+                            "Registration:PublicEnabled", It.IsAny<bool?>(), It.IsAny<string?>()))
+                        .ReturnsAsync(true);
+                    services.AddSingleton<IConfigurationService>(mockConfig.Object);
+                });
+            });
+
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            await dbContext.Database.MigrateAsync();
+        }
+
+        _client = _factory.CreateClient();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _client?.Dispose();
+        _factory?.Dispose();
+        await _fixture.DropIsolatedDatabaseAsync(_testDbName);
+    }
+
+    // ---- Task 2: persistence round-trip -------------------------------------
+
+    [Fact]
+    public async Task Repository_AppendsRows_AndGetLatestReturnsMostRecent()
+    {
+        var userId = await RegisterUserAsync(termsAccepted: true);
+
+        // Age every existing acceptance row (the register row, if any) so the row we
+        // add next is unambiguously the most recent by AcceptedAt.
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            await db.Set<TermsAcceptance>()
+                .Where(t => t.UserId == userId)
+                .ExecuteUpdateAsync(s => s.SetProperty(
+                    t => t.AcceptedAt, new DateTime(2020, 1, 1, 0, 0, 0, DateTimeKind.Utc)));
+        }
+
+        int countBefore;
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            countBefore = await db.Set<TermsAcceptance>().CountAsync(t => t.UserId == userId);
+
+            var repo = scope.ServiceProvider.GetRequiredService<ITermsAcceptanceRepository>();
+            var uow = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+            await repo.AddAsync(TermsAcceptance.Create(userId, TermsVersion.Current, TermsAcceptanceContext.ReConsent));
+            await uow.SaveChangesAsync();
+        }
+
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var repo = scope.ServiceProvider.GetRequiredService<ITermsAcceptanceRepository>();
+            var latest = await repo.GetLatestByUserIdAsync(userId);
+
+            latest.Should().NotBeNull();
+            latest!.TermsVersion.Should().Be(TermsVersion.Current);
+            latest.Context.Should().Be(TermsAcceptanceContext.ReConsent);
+
+            var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            var total = await db.Set<TermsAcceptance>().CountAsync(t => t.UserId == userId);
+            total.Should().Be(countBefore + 1, "append-only: the new row is added, not overwritten");
+        }
+    }
+
+    // ---- Helpers ------------------------------------------------------------
+
+    /// <summary>
+    /// Registers a user and returns the created user's id. Always sends termsAccepted;
+    /// the field is ignored by the endpoint until the T4 change lands and required after.
+    /// </summary>
+    private async Task<Guid> RegisterUserAsync(bool termsAccepted)
+    {
+        var response = await _client.PostAsJsonAsync(RegisterEndpoint, new
+        {
+            email = $"terms-{Guid.NewGuid():N}@test.local",
+            password = "ValidUnusualPwd123!",
+            displayName = "Terms User",
+            termsAccepted,
+        });
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK, "registration should succeed for the happy path");
+
+        var body = await response.Content.ReadFromJsonAsync<JsonElement>();
+        var idString = body.GetProperty("user").GetProperty("id").GetString();
+        return Guid.Parse(idString!);
+    }
+}

--- a/apps/api/tests/Api.Tests/Integration/FrontendSdk/AuthenticationFlowTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/FrontendSdk/AuthenticationFlowTests.cs
@@ -93,7 +93,8 @@ public class AuthenticationFlowTests : IAsyncLifetime
         {
             email,
             password = "SecureP@ssw0rd123!",
-            displayName = "Test User"
+            displayName = "Test User",
+            termsAccepted = true
         };
 
         // Act
@@ -124,7 +125,8 @@ public class AuthenticationFlowTests : IAsyncLifetime
         {
             email,
             password = "SecureP@ssw0rd123!",
-            displayName = "First User"
+            displayName = "First User",
+            termsAccepted = true
         };
         await _client.PostAsJsonAsync("/api/v1/auth/register", firstRequest);
 
@@ -176,7 +178,8 @@ public class AuthenticationFlowTests : IAsyncLifetime
         {
             email,
             password,
-            displayName = "Login Test User"
+            displayName = "Login Test User",
+            termsAccepted = true
         });
 
         // Act - Login
@@ -229,7 +232,8 @@ public class AuthenticationFlowTests : IAsyncLifetime
         {
             email,
             password,
-            displayName = "Me Test User"
+            displayName = "Me Test User",
+            termsAccepted = true
         });
 
         await _client.PostAsJsonAsync("/api/v1/auth/login", new { email, password });
@@ -261,7 +265,7 @@ public class AuthenticationFlowTests : IAsyncLifetime
         var email = $"logout-test-{Guid.NewGuid()}@example.com";
         var password = "SecureP@ssw0rd123!";
 
-        await _client.PostAsJsonAsync("/api/v1/auth/register", new { email, password, displayName = "Logout Test" });
+        await _client.PostAsJsonAsync("/api/v1/auth/register", new { email, password, displayName = "Logout Test", termsAccepted = true });
         await _client.PostAsJsonAsync("/api/v1/auth/login", new { email, password });
 
         // Act - Logout
@@ -284,7 +288,7 @@ public class AuthenticationFlowTests : IAsyncLifetime
         var password = "SecureP@ssw0rd123!";
 
         // Register and login
-        await _client.PostAsJsonAsync("/api/v1/auth/register", new { email, password, displayName = "API Key Test" });
+        await _client.PostAsJsonAsync("/api/v1/auth/register", new { email, password, displayName = "API Key Test", termsAccepted = true });
         await _client.PostAsJsonAsync("/api/v1/auth/login", new { email, password });
 
         // Create API key
@@ -329,7 +333,7 @@ public class AuthenticationFlowTests : IAsyncLifetime
         var email = $"concurrent-session-{Guid.NewGuid()}@example.com";
         var password = "SecureP@ssw0rd123!";
 
-        await _client.PostAsJsonAsync("/api/v1/auth/register", new { email, password, displayName = "Concurrent Test" });
+        await _client.PostAsJsonAsync("/api/v1/auth/register", new { email, password, displayName = "Concurrent Test", termsAccepted = true });
         var loginResponse = await _client.PostAsJsonAsync("/api/v1/auth/login", new { email, password });
 
         // Extract session cookie for concurrent requests
@@ -373,7 +377,7 @@ public class AuthenticationFlowTests : IAsyncLifetime
         var email = $"sessions-list-{Guid.NewGuid()}@example.com";
         var password = "SecureP@ssw0rd123!";
 
-        await _client.PostAsJsonAsync("/api/v1/auth/register", new { email, password, displayName = "Sessions Test" });
+        await _client.PostAsJsonAsync("/api/v1/auth/register", new { email, password, displayName = "Sessions Test", termsAccepted = true });
         await _client.PostAsJsonAsync("/api/v1/auth/login", new { email, password });
 
         // Act
@@ -429,7 +433,7 @@ public class AuthenticationFlowTests : IAsyncLifetime
         var email = $"security-headers-{Guid.NewGuid()}@example.com";
         var password = "SecureP@ssw0rd123!";
 
-        await _client.PostAsJsonAsync("/api/v1/auth/register", new { email, password, displayName = "Security Test" });
+        await _client.PostAsJsonAsync("/api/v1/auth/register", new { email, password, displayName = "Security Test", termsAccepted = true });
 
         // Act
         var response = await _client.PostAsJsonAsync("/api/v1/auth/login", new { email, password });

--- a/apps/api/tests/Api.Tests/Integration/FrontendSdk/EdgeCaseTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/FrontendSdk/EdgeCaseTests.cs
@@ -91,7 +91,7 @@ public class EdgeCaseTests : IAsyncLifetime
         var email = $"streaming-test-{Guid.NewGuid()}@example.com";
         var password = "SecureP@ssw0rd123!";
 
-        await _client.PostAsJsonAsync("/api/v1/auth/register", new { email, password, displayName = "Streaming Test" });
+        await _client.PostAsJsonAsync("/api/v1/auth/register", new { email, password, displayName = "Streaming Test", termsAccepted = true });
         await _client.PostAsJsonAsync("/api/v1/auth/login", new { email, password });
 
         // Prepare chat request
@@ -136,7 +136,7 @@ public class EdgeCaseTests : IAsyncLifetime
         var email = $"stream-interrupt-{Guid.NewGuid()}@example.com";
         var password = "SecureP@ssw0rd123!";
 
-        await _client.PostAsJsonAsync("/api/v1/auth/register", new { email, password, displayName = "Interrupt Test" });
+        await _client.PostAsJsonAsync("/api/v1/auth/register", new { email, password, displayName = "Interrupt Test", termsAccepted = true });
         await _client.PostAsJsonAsync("/api/v1/auth/login", new { email, password });
 
         // Create request with cancellation
@@ -172,7 +172,7 @@ public class EdgeCaseTests : IAsyncLifetime
         var email = $"upload-test-{Guid.NewGuid()}@example.com";
         var password = "SecureP@ssw0rd123!";
 
-        await _client.PostAsJsonAsync("/api/v1/auth/register", new { email, password, displayName = "Upload Test" });
+        await _client.PostAsJsonAsync("/api/v1/auth/register", new { email, password, displayName = "Upload Test", termsAccepted = true });
         await _client.PostAsJsonAsync("/api/v1/auth/login", new { email, password });
 
         // Create minimal valid PDF (PDF header)
@@ -208,7 +208,7 @@ public class EdgeCaseTests : IAsyncLifetime
         var email = $"large-upload-{Guid.NewGuid()}@example.com";
         var password = "SecureP@ssw0rd123!";
 
-        await _client.PostAsJsonAsync("/api/v1/auth/register", new { email, password, displayName = "Large Upload Test" });
+        await _client.PostAsJsonAsync("/api/v1/auth/register", new { email, password, displayName = "Large Upload Test", termsAccepted = true });
         await _client.PostAsJsonAsync("/api/v1/auth/login", new { email, password });
 
         // Create large PDF (10MB)
@@ -247,7 +247,7 @@ public class EdgeCaseTests : IAsyncLifetime
         var email = $"invalid-upload-{Guid.NewGuid()}@example.com";
         var password = "SecureP@ssw0rd123!";
 
-        await _client.PostAsJsonAsync("/api/v1/auth/register", new { email, password, displayName = "Invalid Upload Test" });
+        await _client.PostAsJsonAsync("/api/v1/auth/register", new { email, password, displayName = "Invalid Upload Test", termsAccepted = true });
         await _client.PostAsJsonAsync("/api/v1/auth/login", new { email, password });
 
         // Create non-PDF file
@@ -330,7 +330,7 @@ public class EdgeCaseTests : IAsyncLifetime
         var email = $"unicode-test-{Guid.NewGuid()}@example.com";
         var password = "SecureP@ssw0rd123!";
 
-        await _client.PostAsJsonAsync("/api/v1/auth/register", new { email, password, displayName = "Unicode Test" });
+        await _client.PostAsJsonAsync("/api/v1/auth/register", new { email, password, displayName = "Unicode Test", termsAccepted = true });
         await _client.PostAsJsonAsync("/api/v1/auth/login", new { email, password });
 
         var request = new
@@ -367,7 +367,8 @@ public class EdgeCaseTests : IAsyncLifetime
         {
             email,
             password,
-            displayName
+            displayName,
+            termsAccepted = true
         });
 
         // Assert

--- a/apps/api/tests/Api.Tests/Integration/FrontendSdk/ErrorHandlingTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/FrontendSdk/ErrorHandlingTests.cs
@@ -146,12 +146,12 @@ public class ErrorHandlingTests : IAsyncLifetime
         // We need to create an admin user first, then create a regular user
         var adminEmail = $"admin-{Guid.NewGuid()}@example.com";
         var adminPassword = "SecureP@ssw0rd123!";
-        await _client.PostAsJsonAsync("/api/v1/auth/register", new { email = adminEmail, password = adminPassword, displayName = "Admin User" });
+        await _client.PostAsJsonAsync("/api/v1/auth/register", new { email = adminEmail, password = adminPassword, displayName = "Admin User", termsAccepted = true });
 
         // Now create and login as a regular user (second user gets Role.User)
         var email = $"regular-user-{Guid.NewGuid()}@example.com";
         var password = "SecureP@ssw0rd123!";
-        await _client.PostAsJsonAsync("/api/v1/auth/register", new { email, password, displayName = "Regular User" });
+        await _client.PostAsJsonAsync("/api/v1/auth/register", new { email, password, displayName = "Regular User", termsAccepted = true });
         await _client.PostAsJsonAsync("/api/v1/auth/login", new { email, password });
 
         // Act - Try to access admin-only endpoint
@@ -197,7 +197,7 @@ public class ErrorHandlingTests : IAsyncLifetime
         var email = $"conflict-test-{Guid.NewGuid()}@example.com";
         var password = "SecureP@ssw0rd123!";
 
-        await _client.PostAsJsonAsync("/api/v1/auth/register", new { email, password, displayName = "First User" });
+        await _client.PostAsJsonAsync("/api/v1/auth/register", new { email, password, displayName = "First User", termsAccepted = true });
 
         // Act - Try to register same email again
         var response = await _client.PostAsJsonAsync("/api/v1/auth/register", new { email, password, displayName = "Second User" });

--- a/apps/api/tests/Api.Tests/TestHelpers/AdminUserFactory.cs
+++ b/apps/api/tests/Api.Tests/TestHelpers/AdminUserFactory.cs
@@ -70,7 +70,8 @@ internal static class AdminUserFactory
         {
             Email = adminEmail,
             Password = adminPassword,
-            DisplayName = adminDisplayName
+            DisplayName = adminDisplayName,
+            TermsAccepted = true
         });
 
         registerResponse.StatusCode.Should().Be(HttpStatusCode.OK);

--- a/apps/web/src/actions/auth.ts
+++ b/apps/web/src/actions/auth.ts
@@ -151,6 +151,10 @@ export async function registerAction(
     const email = formData.get('email') as string;
     const password = formData.get('password') as string;
     const displayName = formData.get('displayName') as string | undefined;
+    // #2954 F1: forward the ToS-acceptance checkbox. A checkbox posts "on" when checked;
+    // a hidden field may post "true". The backend rejects registration without acceptance.
+    const termsAccepted =
+      formData.get('termsAccepted') === 'on' || formData.get('termsAccepted') === 'true';
 
     if (!email || !password) {
       return {
@@ -167,6 +171,7 @@ export async function registerAction(
       password,
       displayName: displayName || undefined,
       role: 'user', // Default role (lowercase, matching backend Role.cs)
+      termsAccepted,
     });
 
     return {

--- a/apps/web/src/app/(auth)/register/__tests__/_content.test.tsx
+++ b/apps/web/src/app/(auth)/register/__tests__/_content.test.tsx
@@ -188,6 +188,7 @@ describe('RegisterPageContent (v2 AuthCard)', () => {
         expect(mockAuth.register).toHaveBeenCalledWith({
           email: 'new@example.com',
           password: 'StrongPassword1',
+          termsAccepted: true,
         });
       });
 

--- a/apps/web/src/app/(auth)/register/_content.tsx
+++ b/apps/web/src/app/(auth)/register/_content.tsx
@@ -87,6 +87,9 @@ export function RegisterPageContent({ oauthDisabled = false }: RegisterPageConte
         await register({
           email: data.email,
           password: data.password,
+          // #2954 F1: the form only submits when the required ToS checkbox is checked,
+          // so acceptance is always true here. The backend records + stamps it server-side.
+          termsAccepted: true,
         });
         trackSignUp({ method: 'email' });
 

--- a/apps/web/src/app/(public)/terms/page.tsx
+++ b/apps/web/src/app/(public)/terms/page.tsx
@@ -49,6 +49,8 @@ export default function TermsPage() {
       pageKey="terms"
       sections={TERMS_SECTIONS}
       defaultOpenSection="acceptance"
+      // #2954 F1: keep this date in sync with the backend TermsVersion.Current constant
+      // (apps/api/src/Api/BoundedContexts/Authentication/Domain/Constants/TermsVersion.cs).
       lastUpdated={new Date('2026-07-15')}
       prevLink={{
         href: '/privacy',

--- a/apps/web/src/components/auth/AuthModal.tsx
+++ b/apps/web/src/components/auth/AuthModal.tsx
@@ -205,6 +205,9 @@ export function AuthModal({
         const user = await register({
           email: data.email,
           password: data.password,
+          // #2954 F1: RegisterForm gates submission on the required ToS checkbox, so
+          // acceptance is always true here. The backend records + stamps it server-side.
+          termsAccepted: true,
         });
         trackSignUp({ method: 'email' });
         onSuccess?.(user);

--- a/apps/web/src/components/auth/AuthProvider.tsx
+++ b/apps/web/src/components/auth/AuthProvider.tsx
@@ -30,6 +30,8 @@ import { AuthUser } from '@/types';
 export interface RegisterData {
   email: string;
   password: string;
+  // #2954 F1: user's ToS acceptance, forwarded to the register API.
+  termsAccepted?: boolean;
   displayName?: string;
   role?: string;
 }

--- a/apps/web/src/hooks/useAuth.ts
+++ b/apps/web/src/hooks/useAuth.ts
@@ -35,6 +35,8 @@ export interface RegisterData {
   password: string;
   displayName?: string;
   role?: string;
+  // #2954 F1: user's ToS acceptance, forwarded to the register API.
+  termsAccepted?: boolean;
 }
 
 export interface LoginData {
@@ -158,6 +160,7 @@ export function useAuth(): UseAuthReturn {
         password: data.password,
         displayName: data.displayName || undefined,
         role: data.role || 'User',
+        termsAccepted: data.termsAccepted,
       });
 
       setUser(authUser);

--- a/apps/web/src/lib/api/clients/__tests__/authClient.edge-cases.test.ts
+++ b/apps/web/src/lib/api/clients/__tests__/authClient.edge-cases.test.ts
@@ -66,6 +66,24 @@ describe('authClient - Edge Cases (Issue #2309)', () => {
       ).rejects.toThrow('Email already exists');
     });
 
+    it('should include termsAccepted in the register POST body (#2954 F1)', async () => {
+      mockHttpClient.post.mockResolvedValueOnce({
+        user: { id: '1', email: 'a@b.com', role: 'user' },
+      });
+
+      await authClient.register({
+        email: 'a@b.com',
+        password: 'ValidUnusualPwd123!',
+        termsAccepted: true,
+      });
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith(
+        '/api/v1/auth/register',
+        expect.objectContaining({ termsAccepted: true }),
+        expect.anything()
+      );
+    });
+
     it('should propagate errors from updateProfile', async () => {
       mockHttpClient.put.mockRejectedValueOnce(new Error('Profile update failed'));
 

--- a/apps/web/src/lib/api/clients/authClient.ts
+++ b/apps/web/src/lib/api/clients/authClient.ts
@@ -76,6 +76,10 @@ export interface RegisterRequest {
   password: string;
   displayName?: string;
   role?: string;
+  // #2954 F1: user's ToS acceptance. Optional in the type (multiple register call
+  // paths), but the backend rejects registration without it (400) — the register
+  // form always sends `true`.
+  termsAccepted?: boolean;
 }
 
 export interface UpdateProfileRequest {

--- a/docs/superpowers/plans/2026-07-19-tos-acceptance-foundation.md
+++ b/docs/superpowers/plans/2026-07-19-tos-acceptance-foundation.md
@@ -1,0 +1,1217 @@
+# ToS Acceptance Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Persist an append-only per-user ToS acceptance record with a server-authoritative version, record acceptance at registration (and via a re-consent endpoint), and expose a `needsReAcceptance` status — WITHOUT any enforcement gate.
+
+**Architecture:** New `TermsAcceptance` entity in the Authentication bounded context, configured directly as an EF entity (mirrors `UserAiConsent`), persisted in append-only table `user_terms_acceptances`. A repository (add + latest-lookup), one command (record/accept), one query (status), two `me`-scoped endpoints, and a register-pipeline extension (payload flag + endpoint 400 enforcement + handler recording). Frontend forwards the acceptance boolean.
+
+**Tech Stack:** .NET 9, EF Core (Postgres), MediatR CQRS, FluentValidation, xUnit + Testcontainers; Next.js 16 + Vitest.
+
+## Global Constraints
+
+- CQRS: endpoints use `IMediator` only — no direct service injection (project rule).
+- DI: register both interface and implementation (#2565).
+- Exceptions: `ConflictException` (409) / `NotFoundException` (404), never `InvalidOperationException` (#2568). None expected here.
+- Enum persisted as **string** (`.HasConversion<string>()`), never int+CHECK (avoids #2974 constraint drift).
+- Append-only: `user_terms_acceptances` has **no** unique index on `UserId`.
+- Migration is pure EF (no `migrationBuilder.Sql()`).
+- ToS version literal: `TermsVersion.Current = "2026-07-15"` (single BE source of truth; matches `terms/page.tsx` `lastUpdated`).
+- Test project root: `apps/api/tests/Api.Tests` (NOT `tests/Api.Tests`).
+- Backend commands run from `apps/api/src/Api`; tests from `apps/api`.
+- Namespaces (verified): `RepositoryBase` → `Api.SharedKernel.Infrastructure`; `IDomainEventCollector` → `Api.SharedKernel.Application.Services`; `IUnitOfWork` → `Api.SharedKernel.Infrastructure.Persistence`; `SessionStatusDto` → `Api.BoundedContexts.Authentication.Application.DTOs`; CQRS interfaces → `Api.SharedKernel.Application.Interfaces`.
+- Kill testhost before running backend tests (`tasklist | grep testhost` → `taskkill //PID <PID> //F`) if a run hangs.
+
+---
+
+## File Structure
+
+**Create (BE):**
+- `apps/api/src/Api/BoundedContexts/Authentication/Domain/Enums/TermsAcceptanceContext.cs` — the acceptance-context enum.
+- `apps/api/src/Api/BoundedContexts/Authentication/Domain/Constants/TermsVersion.cs` — current ToS version constant.
+- `apps/api/src/Api/BoundedContexts/Authentication/Domain/Entities/TermsAcceptance.cs` — append-only entity + factory.
+- `apps/api/src/Api/BoundedContexts/Authentication/Domain/Repositories/ITermsAcceptanceRepository.cs`
+- `apps/api/src/Api/BoundedContexts/Authentication/Infrastructure/Persistence/TermsAcceptanceRepository.cs`
+- `apps/api/src/Api/Infrastructure/EntityConfigurations/Authentication/TermsAcceptanceEntityConfiguration.cs`
+- `apps/api/src/Api/BoundedContexts/Authentication/Application/DTOs/TermsConsentStatusDto.cs`
+- `apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/TermsAcceptance/RecordTermsAcceptanceCommand.cs` (+ handler in same file)
+- `apps/api/src/Api/BoundedContexts/Authentication/Application/Queries/TermsAcceptance/GetTermsConsentStatusQuery.cs` (+ handler in same file)
+- `apps/api/src/Api/Routing/TermsConsentEndpoints.cs`
+- EF migration `AddUserTermsAcceptances` (generated).
+
+**Modify (BE):**
+- `apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/Registration/RegisterCommand.cs` — `+ bool TermsAccepted = false`.
+- `apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/Registration/RegisterCommandHandler.cs` — inject repo + record on registration.
+- `apps/api/src/Api/Models/AuthContracts.cs` — `RegisterPayload.TermsAccepted`.
+- `apps/api/src/Api/Routing/AuthenticationEndpoints.cs` — 400 enforcement + pass flag.
+- `apps/api/src/Api/BoundedContexts/Authentication/Infrastructure/DependencyInjection/AuthenticationServiceExtensions.cs` — DI.
+- `apps/api/src/Api/Program.cs` — endpoint group wiring.
+- `apps/api/tests/Api.Tests/BoundedContexts/Authentication/Endpoints/RegisterRaceConditionEndpointTests.cs` — send `termsAccepted:true`.
+
+**Create (BE tests):**
+- `apps/api/tests/Api.Tests/BoundedContexts/Authentication/Domain/TermsAcceptanceTests.cs`
+- `apps/api/tests/Api.Tests/BoundedContexts/Authentication/Application/RecordTermsAcceptanceCommandHandlerTests.cs`
+- `apps/api/tests/Api.Tests/BoundedContexts/Authentication/Application/GetTermsConsentStatusQueryHandlerTests.cs`
+- `apps/api/tests/Api.Tests/Integration/Authentication/TermsAcceptanceIntegrationTests.cs`
+
+**Modify (FE):**
+- `apps/web/src/lib/api/clients/authClient.ts` — `RegisterRequest.termsAccepted`.
+- `apps/web/src/app/(auth)/register/_content.tsx` — forward `termsAccepted: true`.
+- `apps/web/src/app/(public)/terms/page.tsx` — cross-ref comment on `lastUpdated`.
+- FE tests as noted in Task 6.
+
+---
+
+## Task 1: Domain primitives — enum, version constant, entity
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/Authentication/Domain/Enums/TermsAcceptanceContext.cs`
+- Create: `apps/api/src/Api/BoundedContexts/Authentication/Domain/Constants/TermsVersion.cs`
+- Create: `apps/api/src/Api/BoundedContexts/Authentication/Domain/Entities/TermsAcceptance.cs`
+- Test: `apps/api/tests/Api.Tests/BoundedContexts/Authentication/Domain/TermsAcceptanceTests.cs`
+
+**Interfaces:**
+- Produces: `enum TermsAcceptanceContext { Registration, ReConsent }`; `static class TermsVersion { const string Current }`; `TermsAcceptance.Create(Guid userId, string termsVersion, TermsAcceptanceContext context, string? ipAddress = null, string? userAgent = null) : TermsAcceptance` with readable properties `Id, UserId, TermsVersion, AcceptedAt, Context, IpAddress, UserAgent, CreatedAt`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/api/tests/Api.Tests/BoundedContexts/Authentication/Domain/TermsAcceptanceTests.cs`:
+
+```csharp
+using System;
+using Api.BoundedContexts.Authentication.Domain.Entities;
+using Api.BoundedContexts.Authentication.Domain.Enums;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.Authentication.Domain;
+
+[Trait("Category", TestCategories.Unit)]
+public sealed class TermsAcceptanceTests
+{
+    [Fact]
+    public void Create_WithValidInput_SetsAllFields()
+    {
+        var userId = Guid.NewGuid();
+
+        var acceptance = TermsAcceptance.Create(
+            userId, "2026-07-15", TermsAcceptanceContext.Registration, "1.2.3.4", "UA/1.0");
+
+        acceptance.Id.Should().NotBe(Guid.Empty);
+        acceptance.UserId.Should().Be(userId);
+        acceptance.TermsVersion.Should().Be("2026-07-15");
+        acceptance.Context.Should().Be(TermsAcceptanceContext.Registration);
+        acceptance.IpAddress.Should().Be("1.2.3.4");
+        acceptance.UserAgent.Should().Be("UA/1.0");
+        acceptance.AcceptedAt.Should().BeCloseTo(DateTime.UtcNow, TimeSpan.FromSeconds(5));
+        acceptance.CreatedAt.Should().Be(acceptance.AcceptedAt);
+    }
+
+    [Fact]
+    public void Create_WithEmptyUserId_Throws()
+    {
+        var act = () => TermsAcceptance.Create(
+            Guid.Empty, "2026-07-15", TermsAcceptanceContext.Registration);
+        act.Should().Throw<ArgumentException>().WithParameterName("userId");
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Create_WithBlankVersion_Throws(string? version)
+    {
+        var act = () => TermsAcceptance.Create(
+            Guid.NewGuid(), version!, TermsAcceptanceContext.ReConsent);
+        act.Should().Throw<ArgumentException>().WithParameterName("termsVersion");
+    }
+
+    [Fact]
+    public void Create_AllowsNullAuditFields()
+    {
+        var acceptance = TermsAcceptance.Create(
+            Guid.NewGuid(), "2026-07-15", TermsAcceptanceContext.ReConsent);
+        acceptance.IpAddress.Should().BeNull();
+        acceptance.UserAgent.Should().BeNull();
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet build apps/api/src/Api/Api.csproj`
+Expected: FAIL — `TermsAcceptance` / `TermsAcceptanceContext` do not exist.
+
+- [ ] **Step 3: Create the enum**
+
+Create `apps/api/src/Api/BoundedContexts/Authentication/Domain/Enums/TermsAcceptanceContext.cs`:
+
+```csharp
+namespace Api.BoundedContexts.Authentication.Domain.Enums;
+
+/// <summary>
+/// Why a ToS acceptance row was recorded (#2954 F1). Persisted as its string
+/// name (never as an int) so growing the enum never requires a DB constraint change.
+/// </summary>
+public enum TermsAcceptanceContext
+{
+    /// <summary>Recorded during initial account registration.</summary>
+    Registration,
+
+    /// <summary>Recorded when the user re-accepts an updated ToS version.</summary>
+    ReConsent,
+}
+```
+
+- [ ] **Step 4: Create the version constant**
+
+Create `apps/api/src/Api/BoundedContexts/Authentication/Domain/Constants/TermsVersion.cs`:
+
+```csharp
+namespace Api.BoundedContexts.Authentication.Domain.Constants;
+
+/// <summary>
+/// Single server-side source of truth for the current Terms of Service version
+/// (#2954 F1). The ToS text lives in the frontend locales (it.json/en.json) and its
+/// display date in apps/web/src/app/(public)/terms/page.tsx (lastUpdated). This
+/// constant MUST be bumped in the same change whenever that text materially changes.
+/// </summary>
+public static class TermsVersion
+{
+    /// <summary>Current ToS version identifier (date-based; matches terms/page.tsx lastUpdated).</summary>
+    public const string Current = "2026-07-15";
+}
+```
+
+- [ ] **Step 5: Create the entity**
+
+Create `apps/api/src/Api/BoundedContexts/Authentication/Domain/Entities/TermsAcceptance.cs`:
+
+```csharp
+using Api.BoundedContexts.Authentication.Domain.Enums;
+
+namespace Api.BoundedContexts.Authentication.Domain.Entities;
+
+/// <summary>
+/// Append-only record of a user's acceptance of a specific Terms of Service version
+/// (#2954 F1). One row per acceptance event — never updated in place — so the history
+/// of which version was accepted when is preserved for legal defensibility.
+/// </summary>
+public sealed class TermsAcceptance
+{
+    public Guid Id { get; private set; }
+    public Guid UserId { get; private set; }
+    public string TermsVersion { get; private set; } = string.Empty;
+    public DateTime AcceptedAt { get; private set; }
+    public TermsAcceptanceContext Context { get; private set; }
+    public string? IpAddress { get; private set; }
+    public string? UserAgent { get; private set; }
+    public DateTime CreatedAt { get; private set; }
+
+    // EF Core
+    private TermsAcceptance() { }
+
+    private TermsAcceptance(
+        Guid userId, string termsVersion, TermsAcceptanceContext context, string? ipAddress, string? userAgent)
+    {
+        var now = DateTime.UtcNow;
+        Id = Guid.NewGuid();
+        UserId = userId;
+        TermsVersion = termsVersion;
+        AcceptedAt = now;
+        Context = context;
+        IpAddress = ipAddress;
+        UserAgent = userAgent;
+        CreatedAt = now;
+    }
+
+    public static TermsAcceptance Create(
+        Guid userId,
+        string termsVersion,
+        TermsAcceptanceContext context,
+        string? ipAddress = null,
+        string? userAgent = null)
+    {
+        if (userId == Guid.Empty)
+            throw new ArgumentException("User ID cannot be empty", nameof(userId));
+        if (string.IsNullOrWhiteSpace(termsVersion))
+            throw new ArgumentException("Terms version is required", nameof(termsVersion));
+
+        return new TermsAcceptance(userId, termsVersion, context, ipAddress, userAgent);
+    }
+}
+```
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `dotnet test apps/api/tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~TermsAcceptanceTests"`
+Expected: PASS (4 tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/Authentication/Domain apps/api/tests/Api.Tests/BoundedContexts/Authentication/Domain/TermsAcceptanceTests.cs
+git commit -m "feat(auth): TermsAcceptance domain entity + version constant (#2954 F1)"
+```
+
+---
+
+## Task 2: Persistence — EF config, repository, DI, migration
+
+**Files:**
+- Create: `apps/api/src/Api/Infrastructure/EntityConfigurations/Authentication/TermsAcceptanceEntityConfiguration.cs`
+- Create: `apps/api/src/Api/BoundedContexts/Authentication/Domain/Repositories/ITermsAcceptanceRepository.cs`
+- Create: `apps/api/src/Api/BoundedContexts/Authentication/Infrastructure/Persistence/TermsAcceptanceRepository.cs`
+- Modify: `apps/api/src/Api/BoundedContexts/Authentication/Infrastructure/DependencyInjection/AuthenticationServiceExtensions.cs:29`
+- Create (generated): EF migration `AddUserTermsAcceptances`
+- Test: `apps/api/tests/Api.Tests/Integration/Authentication/TermsAcceptanceIntegrationTests.cs` (repo round-trip subset here; full endpoint tests in Task 5)
+
+**Interfaces:**
+- Consumes: `TermsAcceptance` (Task 1).
+- Produces: `ITermsAcceptanceRepository { Task AddAsync(TermsAcceptance, CancellationToken); Task<TermsAcceptance?> GetLatestByUserIdAsync(Guid, CancellationToken); }`; table `user_terms_acceptances`.
+
+- [ ] **Step 1: Create the repository interface**
+
+Create `apps/api/src/Api/BoundedContexts/Authentication/Domain/Repositories/ITermsAcceptanceRepository.cs`:
+
+```csharp
+using Api.BoundedContexts.Authentication.Domain.Entities;
+
+namespace Api.BoundedContexts.Authentication.Domain.Repositories;
+
+/// <summary>
+/// Repository for the append-only TermsAcceptance record (#2954 F1).
+/// </summary>
+public interface ITermsAcceptanceRepository
+{
+    /// <summary>
+    /// Adds a new acceptance row to the change tracker. Does NOT SaveChanges — the
+    /// caller commits via its Unit of Work, so registration can batch it into one
+    /// transaction with the new user (mirrors SessionRepository).
+    /// </summary>
+    Task AddAsync(TermsAcceptance acceptance, CancellationToken cancellationToken = default);
+
+    /// <summary>Returns the user's most recent acceptance (by AcceptedAt), or null if none.</summary>
+    Task<TermsAcceptance?> GetLatestByUserIdAsync(Guid userId, CancellationToken cancellationToken = default);
+}
+```
+
+- [ ] **Step 2: Create the EF configuration**
+
+Create `apps/api/src/Api/Infrastructure/EntityConfigurations/Authentication/TermsAcceptanceEntityConfiguration.cs`:
+
+```csharp
+using Api.BoundedContexts.Authentication.Domain.Entities;
+using Api.Infrastructure.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Api.Infrastructure.EntityConfigurations.Authentication;
+
+/// <summary>
+/// EF Core configuration for the append-only TermsAcceptance entity (#2954 F1).
+/// Auto-applied via ApplyConfigurationsFromAssembly (mirrors UserAiConsent).
+/// </summary>
+internal sealed class TermsAcceptanceEntityConfiguration : IEntityTypeConfiguration<TermsAcceptance>
+{
+    public void Configure(EntityTypeBuilder<TermsAcceptance> builder)
+    {
+        builder.ToTable("user_terms_acceptances");
+
+        builder.HasKey(e => e.Id);
+
+        builder.Property(e => e.UserId).IsRequired();
+        builder.Property(e => e.TermsVersion).IsRequired().HasMaxLength(50);
+        builder.Property(e => e.AcceptedAt).IsRequired();
+
+        // Persisted as the enum's string name (not int) → no CHECK-range drift
+        // when the enum grows (avoids the #2974 constraint pitfall).
+        builder.Property(e => e.Context)
+            .IsRequired()
+            .HasConversion<string>()
+            .HasMaxLength(32);
+
+        builder.Property(e => e.IpAddress).HasMaxLength(45);
+        builder.Property(e => e.UserAgent).HasMaxLength(512);
+        builder.Property(e => e.CreatedAt).IsRequired();
+
+        // FK to users with cascade delete (no navigation property needed).
+        builder.HasOne<UserEntity>()
+            .WithMany()
+            .HasForeignKey(e => e.UserId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        // Latest-acceptance lookup. Append-only: intentionally NO unique index on UserId.
+        builder.HasIndex(e => new { e.UserId, e.AcceptedAt })
+            .HasDatabaseName("ix_user_terms_acceptances_user_accepted");
+    }
+}
+```
+
+- [ ] **Step 3: Create the repository**
+
+Create `apps/api/src/Api/BoundedContexts/Authentication/Infrastructure/Persistence/TermsAcceptanceRepository.cs`:
+
+```csharp
+using Api.BoundedContexts.Authentication.Domain.Entities;
+using Api.BoundedContexts.Authentication.Domain.Repositories;
+using Api.Infrastructure;
+using Api.SharedKernel.Application.Services;
+using Api.SharedKernel.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.Authentication.Infrastructure.Persistence;
+
+/// <summary>
+/// EF Core repository for the append-only TermsAcceptance record (#2954 F1).
+/// </summary>
+public sealed class TermsAcceptanceRepository : RepositoryBase, ITermsAcceptanceRepository
+{
+    public TermsAcceptanceRepository(MeepleAiDbContext dbContext, IDomainEventCollector eventCollector)
+        : base(dbContext, eventCollector)
+    {
+    }
+
+    public async Task AddAsync(TermsAcceptance acceptance, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(acceptance);
+        // No SaveChanges here — the caller's Unit of Work commits (mirrors SessionRepository).
+        await DbContext.Set<TermsAcceptance>().AddAsync(acceptance, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task<TermsAcceptance?> GetLatestByUserIdAsync(Guid userId, CancellationToken cancellationToken = default)
+    {
+        return await DbContext.Set<TermsAcceptance>()
+            .AsNoTracking()
+            .Where(t => t.UserId == userId)
+            .OrderByDescending(t => t.AcceptedAt)
+            .FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
+    }
+}
+```
+
+- [ ] **Step 4: Register in DI**
+
+Modify `apps/api/src/Api/BoundedContexts/Authentication/Infrastructure/DependencyInjection/AuthenticationServiceExtensions.cs`. After line 29 (`services.AddScoped<IWaitlistEntryRepository, WaitlistEntryRepository>();`), add:
+
+```csharp
+        services.AddScoped<ITermsAcceptanceRepository, TermsAcceptanceRepository>(); // #2954 F1: ToS acceptance record
+```
+
+(The `using Api.BoundedContexts.Authentication.Domain.Repositories;` and `...Infrastructure.Persistence;` imports are already present in that file.)
+
+- [ ] **Step 5: Build to verify it compiles**
+
+Run: `dotnet build apps/api/src/Api/Api.csproj`
+Expected: PASS (0 errors).
+
+- [ ] **Step 6: Generate the migration**
+
+Run (from repo root):
+```bash
+cd apps/api/src/Api && dotnet ef migrations add AddUserTermsAcceptances && cd -
+```
+Expected: creates `Migrations/<timestamp>_AddUserTermsAcceptances.cs` + snapshot update.
+
+- [ ] **Step 7: Verify the migration is correct**
+
+Open the generated migration. Confirm: `CreateTable("user_terms_acceptances")` with columns `Id, UserId, TermsVersion, AcceptedAt, Context (text), IpAddress, UserAgent, CreatedAt`; a FK to `users` with `onDelete: ReferentialAction.Cascade`; index `ix_user_terms_acceptances_user_accepted` on `(UserId, AcceptedAt)`; **NO** `migrationBuilder.Sql(...)`; **NO** unique index on `UserId`. If any of these is wrong, fix the config in Step 2 and regenerate (`dotnet ef migrations remove` then re-add).
+
+- [ ] **Step 8: Write the repository round-trip integration test**
+
+Create `apps/api/tests/Api.Tests/Integration/Authentication/TermsAcceptanceIntegrationTests.cs` with the repository round-trip test (endpoint tests are added in Task 5; keep this file and extend it there). Use the existing integration fixture pattern for the BC — locate a sibling integration test in `apps/api/tests/Api.Tests/Integration/` for the exact fixture base class/attribute, and mirror it. The single test for this step:
+
+```csharp
+// NOTE: mirror the Testcontainers fixture used by sibling tests in
+// apps/api/tests/Api.Tests/Integration/ (base class + [Collection]/[Trait] attributes).
+[Fact]
+public async Task AddAsync_ThenGetLatest_ReturnsMostRecentAcceptance()
+{
+    // Arrange: seed a user via the existing user-seed helper of the integration fixture,
+    // then resolve ITermsAcceptanceRepository + IUnitOfWork from the scope.
+    var userId = /* seeded user id */;
+    var repo = /* resolve ITermsAcceptanceRepository */;
+    var uow = /* resolve IUnitOfWork */;
+
+    var older = TermsAcceptance.Create(userId, "2026-03-09", TermsAcceptanceContext.Registration);
+    await repo.AddAsync(older);
+    await uow.SaveChangesAsync();
+
+    var newer = TermsAcceptance.Create(userId, "2026-07-15", TermsAcceptanceContext.ReConsent);
+    await repo.AddAsync(newer);
+    await uow.SaveChangesAsync();
+
+    // Act
+    var latest = await repo.GetLatestByUserIdAsync(userId);
+
+    // Assert
+    latest.Should().NotBeNull();
+    latest!.TermsVersion.Should().Be("2026-07-15");
+    latest.Context.Should().Be(TermsAcceptanceContext.ReConsent);
+}
+```
+
+> The implementer MUST fill the `/* ... */` slots by copying the exact fixture wiring (Testcontainers Postgres, user seeding, DI scope resolution) from a sibling integration test in the same folder. This is the only place in the plan where the surrounding fixture cannot be shown verbatim — inspect one neighbor first.
+
+- [ ] **Step 9: Run the integration test**
+
+Run: `dotnet test apps/api/tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~TermsAcceptanceIntegrationTests"`
+Expected: PASS. (Requires Docker for Testcontainers.)
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add apps/api/src/Api/Infrastructure/EntityConfigurations/Authentication apps/api/src/Api/BoundedContexts/Authentication/Domain/Repositories apps/api/src/Api/BoundedContexts/Authentication/Infrastructure/Persistence/TermsAcceptanceRepository.cs apps/api/src/Api/BoundedContexts/Authentication/Infrastructure/DependencyInjection/AuthenticationServiceExtensions.cs apps/api/src/Api/Migrations apps/api/tests/Api.Tests/Integration/Authentication/TermsAcceptanceIntegrationTests.cs
+git commit -m "feat(auth): persist append-only user_terms_acceptances (#2954 F1)"
+```
+
+---
+
+## Task 3: Application — command, query, DTO, handlers
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/Authentication/Application/DTOs/TermsConsentStatusDto.cs`
+- Create: `apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/TermsAcceptance/RecordTermsAcceptanceCommand.cs` (command + handler)
+- Create: `apps/api/src/Api/BoundedContexts/Authentication/Application/Queries/TermsAcceptance/GetTermsConsentStatusQuery.cs` (query + handler)
+- Test: `apps/api/tests/Api.Tests/BoundedContexts/Authentication/Application/RecordTermsAcceptanceCommandHandlerTests.cs`
+- Test: `apps/api/tests/Api.Tests/BoundedContexts/Authentication/Application/GetTermsConsentStatusQueryHandlerTests.cs`
+
+**Interfaces:**
+- Consumes: `ITermsAcceptanceRepository`, `TermsVersion.Current`, `TermsAcceptance`, `IUnitOfWork`.
+- Produces: `TermsConsentStatusDto(string CurrentVersion, string? AcceptedVersion, DateTime? AcceptedAt, bool NeedsReAcceptance)`; `RecordTermsAcceptanceCommand(Guid UserId, string? IpAddress = null, string? UserAgent = null) : ICommand<TermsConsentStatusDto>`; `GetTermsConsentStatusQuery(Guid UserId) : IQuery<TermsConsentStatusDto>`.
+
+- [ ] **Step 1: Write the failing handler tests**
+
+Create `apps/api/tests/Api.Tests/BoundedContexts/Authentication/Application/RecordTermsAcceptanceCommandHandlerTests.cs`:
+
+```csharp
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Api.BoundedContexts.Authentication.Application.Commands;
+using Api.BoundedContexts.Authentication.Domain.Constants;
+using Api.BoundedContexts.Authentication.Domain.Entities;
+using Api.BoundedContexts.Authentication.Domain.Enums;
+using Api.BoundedContexts.Authentication.Domain.Repositories;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.Authentication.Application;
+
+[Trait("Category", TestCategories.Unit)]
+public sealed class RecordTermsAcceptanceCommandHandlerTests
+{
+    private readonly Mock<ITermsAcceptanceRepository> _repo = new();
+    private readonly Mock<IUnitOfWork> _uow = new();
+
+    private RecordTermsAcceptanceCommandHandler CreateSut() => new(_repo.Object, _uow.Object);
+
+    [Fact]
+    public async Task Handle_NoPriorAcceptance_AppendsCurrentVersion()
+    {
+        _repo.Setup(r => r.GetLatestByUserIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((TermsAcceptance?)null);
+
+        var result = await CreateSut().Handle(
+            new RecordTermsAcceptanceCommand(Guid.NewGuid()), CancellationToken.None);
+
+        _repo.Verify(r => r.AddAsync(
+            It.Is<TermsAcceptance>(a => a.TermsVersion == TermsVersion.Current
+                                        && a.Context == TermsAcceptanceContext.ReConsent),
+            It.IsAny<CancellationToken>()), Times.Once);
+        _uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+        result.AcceptedVersion.Should().Be(TermsVersion.Current);
+        result.NeedsReAcceptance.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task Handle_AlreadyAcceptedCurrent_IsNoOp()
+    {
+        var userId = Guid.NewGuid();
+        _repo.Setup(r => r.GetLatestByUserIdAsync(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(TermsAcceptance.Create(userId, TermsVersion.Current, TermsAcceptanceContext.Registration));
+
+        var result = await CreateSut().Handle(
+            new RecordTermsAcceptanceCommand(userId), CancellationToken.None);
+
+        _repo.Verify(r => r.AddAsync(It.IsAny<TermsAcceptance>(), It.IsAny<CancellationToken>()), Times.Never);
+        _uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+        result.NeedsReAcceptance.Should().BeFalse();
+        result.AcceptedVersion.Should().Be(TermsVersion.Current);
+    }
+
+    [Fact]
+    public async Task Handle_StalePriorAcceptance_AppendsNewRow()
+    {
+        var userId = Guid.NewGuid();
+        _repo.Setup(r => r.GetLatestByUserIdAsync(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(TermsAcceptance.Create(userId, "2026-03-09", TermsAcceptanceContext.Registration));
+
+        await CreateSut().Handle(new RecordTermsAcceptanceCommand(userId), CancellationToken.None);
+
+        _repo.Verify(r => r.AddAsync(It.IsAny<TermsAcceptance>(), It.IsAny<CancellationToken>()), Times.Once);
+        _uow.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+}
+```
+
+Create `apps/api/tests/Api.Tests/BoundedContexts/Authentication/Application/GetTermsConsentStatusQueryHandlerTests.cs`:
+
+```csharp
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Api.BoundedContexts.Authentication.Application.Queries;
+using Api.BoundedContexts.Authentication.Domain.Constants;
+using Api.BoundedContexts.Authentication.Domain.Entities;
+using Api.BoundedContexts.Authentication.Domain.Enums;
+using Api.BoundedContexts.Authentication.Domain.Repositories;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.Authentication.Application;
+
+[Trait("Category", TestCategories.Unit)]
+public sealed class GetTermsConsentStatusQueryHandlerTests
+{
+    private readonly Mock<ITermsAcceptanceRepository> _repo = new();
+
+    private GetTermsConsentStatusQueryHandler CreateSut() => new(_repo.Object);
+
+    [Fact]
+    public async Task Handle_NoAcceptance_NeedsReAcceptanceTrue()
+    {
+        _repo.Setup(r => r.GetLatestByUserIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((TermsAcceptance?)null);
+
+        var result = await CreateSut().Handle(new GetTermsConsentStatusQuery(Guid.NewGuid()), CancellationToken.None);
+
+        result.CurrentVersion.Should().Be(TermsVersion.Current);
+        result.AcceptedVersion.Should().BeNull();
+        result.AcceptedAt.Should().BeNull();
+        result.NeedsReAcceptance.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Handle_StaleVersion_NeedsReAcceptanceTrue()
+    {
+        var userId = Guid.NewGuid();
+        _repo.Setup(r => r.GetLatestByUserIdAsync(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(TermsAcceptance.Create(userId, "2026-03-09", TermsAcceptanceContext.Registration));
+
+        var result = await CreateSut().Handle(new GetTermsConsentStatusQuery(userId), CancellationToken.None);
+
+        result.AcceptedVersion.Should().Be("2026-03-09");
+        result.NeedsReAcceptance.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Handle_CurrentVersion_NeedsReAcceptanceFalse()
+    {
+        var userId = Guid.NewGuid();
+        _repo.Setup(r => r.GetLatestByUserIdAsync(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(TermsAcceptance.Create(userId, TermsVersion.Current, TermsAcceptanceContext.ReConsent));
+
+        var result = await CreateSut().Handle(new GetTermsConsentStatusQuery(userId), CancellationToken.None);
+
+        result.AcceptedVersion.Should().Be(TermsVersion.Current);
+        result.NeedsReAcceptance.Should().BeFalse();
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `dotnet build apps/api/src/Api/Api.csproj`
+Expected: FAIL — DTO/command/query/handlers do not exist.
+
+- [ ] **Step 3: Create the DTO**
+
+Create `apps/api/src/Api/BoundedContexts/Authentication/Application/DTOs/TermsConsentStatusDto.cs`:
+
+```csharp
+namespace Api.BoundedContexts.Authentication.Application.DTOs;
+
+/// <summary>
+/// Read model describing a user's ToS acceptance status (#2954 F1).
+/// NeedsReAcceptance is computed but intentionally NOT enforced by any gate in this scope.
+/// </summary>
+public sealed record TermsConsentStatusDto(
+    string CurrentVersion,
+    string? AcceptedVersion,
+    DateTime? AcceptedAt,
+    bool NeedsReAcceptance);
+```
+
+- [ ] **Step 4: Create the command + handler**
+
+Create `apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/TermsAcceptance/RecordTermsAcceptanceCommand.cs`:
+
+```csharp
+using Api.BoundedContexts.Authentication.Application.DTOs;
+using Api.BoundedContexts.Authentication.Domain.Constants;
+using Api.BoundedContexts.Authentication.Domain.Entities;
+using Api.BoundedContexts.Authentication.Domain.Enums;
+using Api.BoundedContexts.Authentication.Domain.Repositories;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Infrastructure.Persistence;
+
+#pragma warning disable MA0048 // File name must match type name - Command + Handler in one file
+namespace Api.BoundedContexts.Authentication.Application.Commands;
+
+/// <summary>
+/// Records that a user accepted the current ToS version (#2954 F1). Used by the
+/// /users/me/terms/accept endpoint (Context = ReConsent). Idempotent: no new row
+/// when the user's latest accepted version already equals TermsVersion.Current.
+/// </summary>
+internal record RecordTermsAcceptanceCommand(
+    Guid UserId,
+    string? IpAddress = null,
+    string? UserAgent = null
+) : ICommand<TermsConsentStatusDto>;
+
+internal sealed class RecordTermsAcceptanceCommandHandler
+    : ICommandHandler<RecordTermsAcceptanceCommand, TermsConsentStatusDto>
+{
+    private readonly ITermsAcceptanceRepository _repository;
+    private readonly IUnitOfWork _unitOfWork;
+
+    public RecordTermsAcceptanceCommandHandler(ITermsAcceptanceRepository repository, IUnitOfWork unitOfWork)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+    }
+
+    public async Task<TermsConsentStatusDto> Handle(RecordTermsAcceptanceCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var latest = await _repository.GetLatestByUserIdAsync(command.UserId, cancellationToken).ConfigureAwait(false);
+
+        if (latest is null || !string.Equals(latest.TermsVersion, TermsVersion.Current, StringComparison.Ordinal))
+        {
+            var acceptance = TermsAcceptance.Create(
+                command.UserId,
+                TermsVersion.Current,
+                TermsAcceptanceContext.ReConsent,
+                command.IpAddress,
+                command.UserAgent);
+
+            await _repository.AddAsync(acceptance, cancellationToken).ConfigureAwait(false);
+            await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+            return new TermsConsentStatusDto(TermsVersion.Current, TermsVersion.Current, acceptance.AcceptedAt, NeedsReAcceptance: false);
+        }
+
+        return new TermsConsentStatusDto(TermsVersion.Current, latest.TermsVersion, latest.AcceptedAt, NeedsReAcceptance: false);
+    }
+}
+```
+
+- [ ] **Step 5: Create the query + handler**
+
+Create `apps/api/src/Api/BoundedContexts/Authentication/Application/Queries/TermsAcceptance/GetTermsConsentStatusQuery.cs`:
+
+```csharp
+using Api.BoundedContexts.Authentication.Application.DTOs;
+using Api.BoundedContexts.Authentication.Domain.Constants;
+using Api.BoundedContexts.Authentication.Domain.Repositories;
+using Api.SharedKernel.Application.Interfaces;
+
+#pragma warning disable MA0048 // File name must match type name - Query + Handler in one file
+namespace Api.BoundedContexts.Authentication.Application.Queries;
+
+/// <summary>Returns the ToS acceptance status for a user (#2954 F1).</summary>
+internal record GetTermsConsentStatusQuery(Guid UserId) : IQuery<TermsConsentStatusDto>;
+
+internal sealed class GetTermsConsentStatusQueryHandler
+    : IQueryHandler<GetTermsConsentStatusQuery, TermsConsentStatusDto>
+{
+    private readonly ITermsAcceptanceRepository _repository;
+
+    public GetTermsConsentStatusQueryHandler(ITermsAcceptanceRepository repository)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+    }
+
+    public async Task<TermsConsentStatusDto> Handle(GetTermsConsentStatusQuery query, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var latest = await _repository.GetLatestByUserIdAsync(query.UserId, cancellationToken).ConfigureAwait(false);
+        var acceptedVersion = latest?.TermsVersion;
+        var needsReAcceptance = !string.Equals(acceptedVersion, TermsVersion.Current, StringComparison.Ordinal);
+
+        return new TermsConsentStatusDto(TermsVersion.Current, acceptedVersion, latest?.AcceptedAt, needsReAcceptance);
+    }
+}
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `dotnet test apps/api/tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~RecordTermsAcceptanceCommandHandlerTests|FullyQualifiedName~GetTermsConsentStatusQueryHandlerTests"`
+Expected: PASS (6 tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/Authentication/Application apps/api/tests/Api.Tests/BoundedContexts/Authentication/Application
+git commit -m "feat(auth): record/status CQRS for ToS acceptance (#2954 F1)"
+```
+
+---
+
+## Task 4: Register pipeline — flag, enforcement, recording
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/Registration/RegisterCommand.cs:11-24`
+- Modify: `apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/Registration/RegisterCommandHandler.cs`
+- Modify: `apps/api/src/Api/Models/AuthContracts.cs:10-35`
+- Modify: `apps/api/src/Api/Routing/AuthenticationEndpoints.cs:95-119`
+- Modify: `apps/api/tests/Api.Tests/BoundedContexts/Authentication/Endpoints/RegisterRaceConditionEndpointTests.cs`
+- Test (extend): `apps/api/tests/Api.Tests/Integration/Authentication/TermsAcceptanceIntegrationTests.cs`
+
+**Interfaces:**
+- Consumes: `RegisterCommand`, `RegisterPayload`, `ITermsAcceptanceRepository`, `TermsAcceptance`, `TermsVersion.Current`.
+- Produces: register records a `Registration`-context acceptance; `/auth/register` returns 400 when `termsAccepted` is missing/false.
+
+- [ ] **Step 1: Add `TermsAccepted` to the command**
+
+Modify `RegisterCommand.cs`: add `bool TermsAccepted = false` as the LAST positional parameter (after `BootstrapToken`):
+
+```csharp
+internal record RegisterCommand(
+    string Email,
+    string Password,
+    string DisplayName,
+    string? Role = null,
+    string? IpAddress = null,
+    string? UserAgent = null,
+    string? BootstrapToken = null,
+    // #2954 F1: user's ToS acceptance from the register form. When true, the
+    // handler records an append-only TermsAcceptance (Context=Registration).
+    bool TermsAccepted = false
+) : ICommand<RegisterResponse>;
+```
+
+- [ ] **Step 2: Add `TermsAccepted` to the payload**
+
+Modify `AuthContracts.cs` `RegisterPayload` — add after `BootstrapToken` (line 34):
+
+```csharp
+    /// <summary>
+    /// #2954 F1: whether the user checked the required "I accept the Terms of Service"
+    /// box. Enforced server-side at the endpoint (400 when false/absent). Accepts both
+    /// "termsAccepted" (camelCase) and "TermsAccepted" (PascalCase).
+    /// </summary>
+    public bool TermsAccepted { get; set; }
+```
+
+- [ ] **Step 3: Enforce + forward at the endpoint**
+
+Modify `AuthenticationEndpoints.cs` `MapRegisterEndpoint`. After the email/password check block (currently ending line 98), add:
+
+```csharp
+            // #2954 F1: server-side enforcement of ToS acceptance. The register form's
+            // checkbox is client-cosmetic; reject a direct API call that omits acceptance.
+            if (!payload.TermsAccepted)
+            {
+                return Results.BadRequest(new { error = "You must accept the Terms of Service to register" });
+            }
+```
+
+Then extend the `new DddRegisterCommand(...)` construction (currently ends `BootstrapToken: payload.BootstrapToken);` at line 119) to pass the flag:
+
+```csharp
+            var command = new DddRegisterCommand(
+                Email: payload.Email,
+                Password: payload.Password,
+                DisplayName: displayName,
+                Role: null,
+                IpAddress: context.Connection.RemoteIpAddress?.ToString(),
+                UserAgent: context.Request.Headers.UserAgent.ToString(),
+                BootstrapToken: payload.BootstrapToken,
+                TermsAccepted: payload.TermsAccepted);
+```
+
+- [ ] **Step 4: Record acceptance in the handler**
+
+Modify `RegisterCommandHandler.cs`:
+
+(a) Add usings at the top:
+```csharp
+using Api.BoundedContexts.Authentication.Domain.Constants;
+using Api.BoundedContexts.Authentication.Domain.Enums;
+using Api.BoundedContexts.Authentication.Domain.Repositories;
+```
+
+(b) Add a field + constructor parameter. Add field near the other `private readonly` fields:
+```csharp
+    private readonly ITermsAcceptanceRepository _termsAcceptanceRepository;
+```
+Add the parameter to the constructor signature (append after `auditLogger`) and assign it:
+```csharp
+        Api.BoundedContexts.SecurityAudit.Application.Services.IAuditLogger auditLogger,
+        ITermsAcceptanceRepository termsAcceptanceRepository)
+    {
+        ...
+        _auditLogger = auditLogger ?? throw new ArgumentNullException(nameof(auditLogger));
+        _termsAcceptanceRepository = termsAcceptanceRepository ?? throw new ArgumentNullException(nameof(termsAcceptanceRepository));
+    }
+```
+
+(c) In `Handle`, immediately AFTER `await _sessionRepository.AddAsync(session, cancellationToken)...` (currently line 135) and BEFORE the `try { await _unitOfWork.SaveChangesAsync ... }` block, add:
+
+```csharp
+        // #2954 F1: record ToS acceptance in the SAME transaction as the new user.
+        // The endpoint already rejects registration without acceptance; the guard here
+        // keeps direct-command callers (tests) that omit the flag from writing a row.
+        if (command.TermsAccepted)
+        {
+            var termsAcceptance = TermsAcceptance.Create(
+                userId,
+                TermsVersion.Current,
+                TermsAcceptanceContext.Registration,
+                command.IpAddress,
+                command.UserAgent);
+            await _termsAcceptanceRepository.AddAsync(termsAcceptance, cancellationToken).ConfigureAwait(false);
+        }
+```
+
+- [ ] **Step 5: Update existing register endpoint tests to send acceptance**
+
+In `RegisterRaceConditionEndpointTests.cs`, every register request payload must include `termsAccepted: true`. Find each JSON body posted to `/auth/register` (anonymous objects or serialized payloads) and add `termsAccepted = true`. Run the file's tests after editing:
+
+Run: `dotnet test apps/api/tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~RegisterRaceConditionEndpointTests"`
+Expected: PASS. If any test now returns 400, its payload is still missing `termsAccepted`.
+
+> Also grep the whole test project for other `"/auth/register"` posters and add `termsAccepted = true` to each: `grep -rl '"/auth/register"' apps/api/tests`.
+
+- [ ] **Step 6: Extend the integration test — registration records a row**
+
+Append to `apps/api/tests/Api.Tests/Integration/Authentication/TermsAcceptanceIntegrationTests.cs`:
+
+```csharp
+[Fact]
+public async Task Register_WithTermsAccepted_WritesExactlyOneRegistrationRow()
+{
+    // Arrange: build the HTTP client from the integration fixture (mirror a sibling
+    // endpoint test's WebApplicationFactory/client setup).
+    var body = new
+    {
+        email = $"terms-{Guid.NewGuid():N}@example.com",
+        password = "ValidUnusualPwd123!",
+        displayName = "Terms User",
+        termsAccepted = true
+    };
+
+    // Act
+    var response = await client.PostAsJsonAsync("/api/v1/auth/register", body);
+
+    // Assert
+    response.StatusCode.Should().Be(HttpStatusCode.OK);
+    // Resolve the created user's id (from the response JSON `user.id`) and assert one row:
+    var acceptances = await dbContext.Set<TermsAcceptance>()
+        .Where(t => t.UserId == createdUserId).ToListAsync();
+    acceptances.Should().HaveCount(1);
+    acceptances[0].TermsVersion.Should().Be(TermsVersion.Current);
+    acceptances[0].Context.Should().Be(TermsAcceptanceContext.Registration);
+}
+
+[Fact]
+public async Task Register_WithoutTermsAccepted_Returns400()
+{
+    var body = new
+    {
+        email = $"noterms-{Guid.NewGuid():N}@example.com",
+        password = "ValidUnusualPwd123!",
+        displayName = "No Terms"
+        // termsAccepted omitted → false
+    };
+
+    var response = await client.PostAsJsonAsync("/api/v1/auth/register", body);
+
+    response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+}
+```
+
+> Fill `client`/`dbContext`/`createdUserId` from the sibling endpoint-test fixture pattern.
+
+- [ ] **Step 7: Run the integration + build**
+
+Run: `dotnet test apps/api/tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~TermsAcceptanceIntegrationTests"`
+Expected: PASS (repo round-trip + register-records-row + register-400).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/Registration apps/api/src/Api/Models/AuthContracts.cs apps/api/src/Api/Routing/AuthenticationEndpoints.cs apps/api/tests/Api.Tests
+git commit -m "feat(auth): record ToS acceptance at registration + enforce checkbox (#2954 F1)"
+```
+
+---
+
+## Task 5: Endpoints — accept + status, wired into routing
+
+**Files:**
+- Create: `apps/api/src/Api/Routing/TermsConsentEndpoints.cs`
+- Modify: `apps/api/src/Api/Program.cs:852` (after `MapUserAiConsentEndpoints`)
+- Test (extend): `apps/api/tests/Api.Tests/Integration/Authentication/TermsAcceptanceIntegrationTests.cs`
+
+**Interfaces:**
+- Consumes: `GetTermsConsentStatusQuery`, `RecordTermsAcceptanceCommand`, `SessionStatusDto`.
+- Produces: `GET /api/v1/users/me/terms/status`, `POST /api/v1/users/me/terms/accept` (both session-authed, me-scoped).
+
+- [ ] **Step 1: Create the endpoints**
+
+Create `apps/api/src/Api/Routing/TermsConsentEndpoints.cs`:
+
+```csharp
+using Api.BoundedContexts.Authentication.Application.Commands;
+using Api.BoundedContexts.Authentication.Application.DTOs;
+using Api.BoundedContexts.Authentication.Application.Queries;
+using Api.Extensions;
+using MediatR;
+
+namespace Api.Routing;
+
+/// <summary>
+/// Terms-of-Service acceptance endpoints (#2954 F1). Foundation only: records/reads
+/// acceptance; no blocking gate is wired to needsReAcceptance in this scope.
+/// </summary>
+internal static class TermsConsentEndpoints
+{
+    public static RouteGroupBuilder MapTermsConsentEndpoints(this RouteGroupBuilder group)
+    {
+        MapGetTermsStatus(group);
+        MapAcceptTerms(group);
+        return group;
+    }
+
+    private static void MapGetTermsStatus(RouteGroupBuilder group)
+    {
+        group.MapGet("/users/me/terms/status", async (
+            HttpContext context,
+            IMediator mediator,
+            CancellationToken ct) =>
+        {
+            var session = (SessionStatusDto)context.Items[nameof(SessionStatusDto)]!;
+            var status = await mediator.Send(
+                new GetTermsConsentStatusQuery(session.Principal!.Subject.Id), ct).ConfigureAwait(false);
+            return Results.Json(status);
+        })
+        .RequireSession()
+        .RequireAuthorization()
+        .WithName("GetTermsConsentStatus")
+        .WithTags("User Profile", "Terms")
+        .WithSummary("Get current user's ToS acceptance status")
+        .Produces(200)
+        .Produces(401);
+    }
+
+    private static void MapAcceptTerms(RouteGroupBuilder group)
+    {
+        group.MapPost("/users/me/terms/accept", async (
+            HttpContext context,
+            IMediator mediator,
+            CancellationToken ct) =>
+        {
+            var session = (SessionStatusDto)context.Items[nameof(SessionStatusDto)]!;
+            var status = await mediator.Send(new RecordTermsAcceptanceCommand(
+                UserId: session.Principal!.Subject.Id,
+                IpAddress: context.Connection.RemoteIpAddress?.ToString(),
+                UserAgent: context.Request.Headers.UserAgent.ToString()), ct).ConfigureAwait(false);
+            return Results.Json(status);
+        })
+        .RequireSession()
+        .RequireAuthorization()
+        .WithName("AcceptTerms")
+        .WithTags("User Profile", "Terms")
+        .WithSummary("Record acceptance of the current ToS version")
+        .Produces(200)
+        .Produces(401);
+    }
+}
+```
+
+- [ ] **Step 2: Wire into routing**
+
+Modify `apps/api/src/Api/Program.cs`. After line 852 (`v1Api.MapUserAiConsentEndpoints();`), add:
+
+```csharp
+v1Api.MapTermsConsentEndpoints(); // #2954 F1: ToS acceptance foundation
+```
+
+- [ ] **Step 3: Build**
+
+Run: `dotnet build apps/api/src/Api/Api.csproj`
+Expected: PASS.
+
+- [ ] **Step 4: Extend the integration test — accept + status + append-only + me-scoped**
+
+Append to `TermsAcceptanceIntegrationTests.cs` (reuse the authenticated-client helper of the fixture; the user must have a session):
+
+```csharp
+[Fact]
+public async Task StatusThenAccept_TransitionsNeedsReAcceptance()
+{
+    // Arrange: authenticated client for a freshly-registered user who accepted at register.
+    // (After registration with termsAccepted:true, status should already be up to date.)
+
+    // A user with NO acceptance (or a stale one) → needsReAcceptance true.
+    // Seed a stale acceptance row for the user, then:
+    var before = await authedClient.GetFromJsonAsync<TermsConsentStatusDto>("/api/v1/users/me/terms/status");
+    before!.NeedsReAcceptance.Should().BeTrue();
+
+    // Act: accept.
+    var accept = await authedClient.PostAsync("/api/v1/users/me/terms/accept", content: null);
+    accept.StatusCode.Should().Be(HttpStatusCode.OK);
+
+    // Assert: status now current.
+    var after = await authedClient.GetFromJsonAsync<TermsConsentStatusDto>("/api/v1/users/me/terms/status");
+    after!.NeedsReAcceptance.Should().BeFalse();
+    after.AcceptedVersion.Should().Be(TermsVersion.Current);
+
+    // Idempotent: second accept adds no row.
+    await authedClient.PostAsync("/api/v1/users/me/terms/accept", content: null);
+    var rows = await dbContext.Set<TermsAcceptance>()
+        .Where(t => t.UserId == userId && t.TermsVersion == TermsVersion.Current).CountAsync();
+    rows.Should().Be(1);
+}
+
+[Fact]
+public async Task Status_Unauthenticated_Returns401()
+{
+    var response = await anonymousClient.GetAsync("/api/v1/users/me/terms/status");
+    response.StatusCode.Should().Be(HttpStatusCode.Unauthorized);
+}
+```
+
+> Fill `authedClient`/`anonymousClient`/`dbContext`/`userId` from the sibling fixture. The me-scoping is inherent: userId comes from the session, so there is no cross-tenant param to attack — the 401 test confirms the auth gate.
+
+- [ ] **Step 5: Run the full integration file**
+
+Run: `dotnet test apps/api/tests/Api.Tests/Api.Tests.csproj --filter "FullyQualifiedName~TermsAcceptanceIntegrationTests"`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/Api/Routing/TermsConsentEndpoints.cs apps/api/src/Api/Program.cs apps/api/tests/Api.Tests/Integration/Authentication/TermsAcceptanceIntegrationTests.cs
+git commit -m "feat(auth): me-scoped ToS accept/status endpoints (#2954 F1)"
+```
+
+---
+
+## Task 6: Frontend — forward acceptance, cross-ref comment
+
+**Files:**
+- Modify: `apps/web/src/lib/api/clients/authClient.ts:74-79`
+- Modify: `apps/web/src/app/(auth)/register/_content.tsx:87-90`
+- Modify: `apps/web/src/app/(public)/terms/page.tsx:52`
+- Test: the client + register-content consumer tests.
+
+**Interfaces:**
+- Consumes: BE `/auth/register` now requires `termsAccepted:true`.
+- Produces: `RegisterRequest.termsAccepted: boolean`; register call sends `termsAccepted: true`.
+
+- [ ] **Step 1: Write/adjust the failing FE test**
+
+Locate the authClient test (e.g. `apps/web/src/lib/api/clients/__tests__/authClient.test.ts` — confirm the path). Add a test asserting the register POST body includes `termsAccepted`:
+
+```ts
+it('register posts termsAccepted', async () => {
+  const httpClient = { post: vi.fn().mockResolvedValue({ user: { id: '1' } }) };
+  const client = createAuthClient({ httpClient: httpClient as never });
+  await client.register({ email: 'a@b.com', password: 'ValidUnusualPwd123!', termsAccepted: true });
+  expect(httpClient.post).toHaveBeenCalledWith(
+    '/api/v1/auth/register',
+    expect.objectContaining({ termsAccepted: true }),
+    expect.anything()
+  );
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `cd apps/web && pnpm test -- authClient`
+Expected: FAIL — `termsAccepted` not on `RegisterRequest` (type error) / not sent.
+
+- [ ] **Step 3: Add the field to the client**
+
+Modify `authClient.ts` `RegisterRequest`:
+
+```ts
+export interface RegisterRequest {
+  email: string;
+  password: string;
+  displayName?: string;
+  role?: string;
+  // #2954 F1: user's ToS acceptance; the backend rejects registration without it.
+  termsAccepted: boolean;
+}
+```
+
+(`register()` already posts `request` as-is, so no change to the method body.)
+
+- [ ] **Step 4: Forward from the register page**
+
+Modify `apps/web/src/app/(auth)/register/_content.tsx` — the `register({ email, password })` call (lines 87-90). The form only submits when the required terms checkbox is checked, so acceptance is always true here:
+
+```tsx
+        await register({
+          email: data.email,
+          password: data.password,
+          termsAccepted: true,
+        });
+```
+
+- [ ] **Step 5: Cross-ref comment on the ToS version literal**
+
+Modify `apps/web/src/app/(public)/terms/page.tsx` line 52:
+
+```tsx
+      // #2954 F1: keep this date in sync with the backend TermsVersion.Current
+      // constant (apps/api/src/Api/BoundedContexts/Authentication/Domain/Constants/TermsVersion.cs).
+      lastUpdated={new Date('2026-07-15')}
+```
+
+- [ ] **Step 6: Run FE unit tests (client + register consumers)**
+
+Run: `cd apps/web && pnpm test -- authClient register`
+Expected: PASS. Fix any register consumer test that mocks `register` and asserts call args (add `termsAccepted: true` to expectations).
+
+- [ ] **Step 7: Typecheck + lint**
+
+Run: `cd apps/web && pnpm typecheck && pnpm lint`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/web/src/lib/api/clients/authClient.ts apps/web/src/app/(auth)/register/_content.tsx apps/web/src/app/(public)/terms/page.tsx apps/web/src/lib/api/clients/__tests__
+git commit -m "feat(web): forward ToS acceptance on register (#2954 F1)"
+```
+
+---
+
+## Final Verification
+
+- [ ] **Backend unit + integration:** `cd apps/api && dotnet test --filter "FullyQualifiedName~TermsAcceptance|FullyQualifiedName~TermsConsent"` → all green.
+- [ ] **Backend full build:** `dotnet build apps/api/src/Api/Api.csproj` → 0 errors.
+- [ ] **No net-new baseline failures:** run the Authentication BC tests (`dotnet test apps/api/tests/Api.Tests/Api.Tests.csproj --filter "BoundedContext=Authentication"` if the trait exists, else the Authentication namespace filter) → no regressions vs. `main-dev` baseline.
+- [ ] **Frontend:** `cd apps/web && pnpm test && pnpm typecheck && pnpm lint` → green.
+- [ ] **Migration applies:** `cd apps/api/src/Api && dotnet ef database update` against a scratch DB → `user_terms_acceptances` created.
+- [ ] **Scope guard:** confirm no blocking gate / middleware / FE modal was added — `needsReAcceptance` is exposed but unconsumed.
+
+## Out of scope (do NOT implement)
+- Blocking login gate / re-accept middleware / FE modal.
+- Backfill or notification for existing users.
+- OAuth / admin-created / seeded users recording acceptance (they legitimately show `needsReAcceptance=true`).
+- The final legal determination (reserved to the professional reviewer; see spec §12).

--- a/docs/superpowers/specs/2026-07-19-tos-acceptance-foundation-design.md
+++ b/docs/superpowers/specs/2026-07-19-tos-acceptance-foundation-design.md
@@ -75,9 +75,9 @@ The frontend `terms/page.tsx` keeps its display literal (`lastUpdated`), annotat
 ## 6. API surface (CQRS — endpoints use `IMediator` only)
 
 ### 6.1 `POST /api/v1/auth/register` — extended
-- Request DTO gains `termsAccepted: bool`; `RegisterCommand` gains `bool TermsAccepted = false`.
-- `RegisterCommandValidator`: `RuleFor(x => x.TermsAccepted).Equal(true)` → **server-side enforcement** (422 via the FluentValidation pipeline, matching the existing validator's behavior) — closes the cosmetic-checkbox gap.
-- `RegisterCommandHandler`: after the user+session `AddAsync`, also `_termsAcceptanceRepository.AddAsync(TermsAcceptance.Create(userId, TermsVersion.Current, Registration, command.IpAddress, command.UserAgent))` — committed in the **same** existing `_unitOfWork.SaveChangesAsync` (FK to the just-added user satisfied within one transaction). `AcceptedAt` from the handler's existing `TimeProvider`.
+- `RegisterPayload` gains `bool TermsAccepted`; `RegisterCommand` gains `bool TermsAccepted = false` (last positional param → existing named-arg call sites stay source-compatible).
+- **Endpoint enforcement** in `MapRegisterEndpoint`: `if (!payload.TermsAccepted) return Results.BadRequest(...)` (**400**, mirroring the existing email/password presence check). Chosen over a `RegisterCommandValidator.Equal(true)` rule to avoid a broad test blast radius across the whole `RegisterCommand` suite (validator/handler/integration); `/auth/register` is the single real entry path, and the endpoint already performs manual presence checks.
+- `RegisterCommandHandler`: after the user+session `AddAsync`, when `command.TermsAccepted` is true, `_termsAcceptanceRepository.AddAsync(TermsAcceptance.Create(userId, TermsVersion.Current, Registration, command.IpAddress, command.UserAgent))` — committed in the **same** existing `_unitOfWork.SaveChangesAsync` (FK to the just-added user satisfied within one transaction). `AcceptedAt` is stamped inside the factory (mirrors `UserAiConsent.Create`).
 
 ### 6.2 `POST /api/v1/users/me/terms/accept` — authenticated
 - `me`-scoped: userId from `session.Principal.Subject.Id` (never a route/body param) → no IDOR.
@@ -112,7 +112,7 @@ Endpoints registered via a `MapTermsConsentEndpoints` `RouteGroupBuilder` extens
 
 ## 9. Security
 
-- **Server-side terms enforcement** at registration (validator) — the checkbox is no longer bypassable via a direct API call.
+- **Server-side terms enforcement** at registration (endpoint check → 400) — the checkbox is no longer bypassable via a direct API call.
 - **Server-stamped `AcceptedAt`** — acceptance time is authoritative, not client-supplied.
 - **`me`-scoped** accept/status endpoints — userId derived from the session; add a cross-tenant test asserting the endpoint ignores any attempt to act on another user (no route/body userId exists).
 - Append-only record = tamper-evident audit trail (no in-place overwrite).
@@ -123,10 +123,9 @@ Endpoints registered via a `MapTermsConsentEndpoints` `RouteGroupBuilder` extens
 - `TermsAcceptance.Create` — happy path + throws on empty userId / blank version.
 - `RecordTermsAcceptanceCommandHandler` — appends a row; **no-op when latest accepted == Current** (idempotency); records `Context = ReConsent`.
 - `GetTermsConsentStatusQueryHandler` — `needsReAcceptance`: no rows → true; stale version → true; current → false; returns latest `acceptedAt`.
-- `RegisterCommandValidator` — `TermsAccepted == false` → validation failure.
 
 **Backend integration (Testcontainers Postgres):**
-- Registration writes exactly one `TermsAcceptance` row with `Current` version + `Registration` context + user's ip/ua.
+- `/auth/register` with `termsAccepted:false` (or absent) → **400** (endpoint enforcement); with `termsAccepted:true` writes exactly one `TermsAcceptance` row with `Current` version + `Registration` context + user's ip/ua.
 - Accept endpoint appends; second call with same current version is a no-op (still one row).
 - Status endpoint returns the correct DTO across the three `needsReAcceptance` states.
 - Append-only: a re-consent to a *new* version yields a second row (history preserved).

--- a/docs/superpowers/specs/2026-07-19-tos-acceptance-foundation-design.md
+++ b/docs/superpowers/specs/2026-07-19-tos-acceptance-foundation-design.md
@@ -1,0 +1,170 @@
+# ToS Acceptance Foundation — Design Spec
+
+**Date:** 2026-07-19
+**Issue:** #2954 (prereq PR-2 of epic #539), finding **F1** (re-consenso)
+**Branch:** `feature/issue-2954-tos-acceptance-foundation` → PR to `main-dev`
+**Parent context:** spec-panel review of ToS/legal docs (2026-07-19 session) + 5-agent investigation workflow.
+
+---
+
+## 1. Context & problem
+
+The Mechanic Extractor ToS §5 was materially changed (PR #3000, merged on `main-dev`, **not** deployed to prod): the OLD §5 stated uploaded content is *"processed for personal use only, not shared with other users"*; the NEW §5 authorizes MeepleAI to **publish derived comprehension cards** visible to other authenticated users. The consultant flagged re-consent for existing users as an **open decision** ("did not exclude"; `domanda 8`; deliverable *"Parere sul re-consenso"* still outstanding).
+
+A 5-agent investigation established (all high-confidence, file:line evidence in the session transcript) that **there is no ToS-acceptance infrastructure at all**:
+
+- **No per-user ToS acceptance record** — no column on `User`/`Session`, no table. Acceptance is never persisted.
+- **New registrations lose the signal too**: `RegisterForm.tsx` builds `termsAcceptedAt: new Date()` (commented *"GDPR audit requirement"*) but `register/_content.tsx` forwards only `{email, password}`; `RegisterRequest` (authClient) has no terms field. The required checkbox is **client-cosmetic only** — no server-side enforcement.
+- **No ToS versioning** — the only version signal is the literal `lastUpdated={new Date('2026-07-15')}` in `terms/page.tsx`.
+- **No re-acceptance gate** — the `EmailVerificationMiddleware` / `User.RequiresVerification` pattern exists as a template but has no ToS analog.
+- The AI-consent versioning (`UserAiConsent`) is nominal (frontend literal `1.0.0`, never enforced, single-row overwriting, AI-specific, check-service is dead code) → **not reusable**.
+
+## 2. Decision this spec implements
+
+Per user decision **"Fondazione ora, gate dopo"**: build the recording/versioning **foundation** now — needed under *every* possible legal answer and also closes the existing "no acceptance record for anyone" gap — and defer the **enforcement-strength** decision (blocking gate vs. active notice) to the final professional legal review that already gates prod deployment.
+
+The data model is an **append-only** record (chosen over 2-columns-on-User and over generalizing `UserAiConsent`), matching the legal analyst's explicit condition that the record preserve an audit history of *which* version was accepted *when*.
+
+## 3. Goal & scope boundary
+
+### In scope (foundation)
+1. Append-only per-user ToS acceptance record + persistence.
+2. Server-authoritative current ToS version (single source of truth).
+3. Record acceptance at registration — fix the dropped `termsAcceptedAt` **and** enforce acceptance server-side (close the cosmetic-checkbox gap).
+4. An authenticated endpoint to record an acceptance (what a *future* re-consent gate will call) + a status read-model (`needsReAcceptance`) the future gate will consume.
+
+### Out of scope (enforcement — deferred to post-legal-opinion)
+- ❌ No blocking login gate / middleware.
+- ❌ No frontend re-accept modal.
+- ❌ No forced re-consent / notification campaign for existing users.
+- ❌ No backfill of existing users.
+
+`needsReAcceptance` is **computed and exposed** but **nothing consumes it yet**. This boundary is a hard requirement of the design — building enforcement now would pre-empt the legal decision.
+
+## 4. Data model
+
+New table **`user_terms_acceptances`** (append-only), in the **Authentication** bounded context (co-located with `User` and registration).
+
+Entity `TermsAcceptance` (sealed, private setters, private EF ctor, static `Create` factory — mirrors `UserAiConsent` conventions):
+
+| Field | Type | Notes |
+|---|---|---|
+| `Id` | `Guid` PK | `Guid.NewGuid()` in factory |
+| `UserId` | `Guid` | FK → `users.Id`, `OnDelete(Cascade)` |
+| `TermsVersion` | `string` (max 50) | e.g. `"2026-07-15"` |
+| `AcceptedAt` | `DateTime` (UTC) | **server-stamped** |
+| `Context` | `string` (max 32) | `"Registration"` \| `"ReConsent"` — **string, not int+CHECK** to avoid the enum-range CHECK-drift pitfall (#2974) |
+| `IpAddress` | `string?` (max 45) | nullable, audit |
+| `UserAgent` | `string?` (max 512) | nullable, audit |
+| `CreatedAt` | `DateTime` (UTC) | standard audit column |
+
+**Factory:** `TermsAcceptance.Create(userId, termsVersion, context, ipAddress?, userAgent?)` — throws `ArgumentException` on empty `userId` / blank `termsVersion` (mirrors `UserAiConsent.Create`).
+
+**Context type:** modeled as a C# `enum TermsAcceptanceContext { Registration, ReConsent }` at the domain boundary, **persisted as its string name** (`.HasConversion<string>()`), so growing the enum never requires a DB constraint change.
+
+**Indexes:** `(UserId, AcceptedAt DESC)` for the "latest acceptance" lookup. **No unique constraint** (append-only allows N rows/user).
+
+**Migration:** `AddUserTermsAcceptances` — `CreateTable` + FK + index. Pure EF-generated (no `migrationBuilder.Sql()`) → immune to the flatten-drops-raw-SQL pitfall. **No backfill**: existing users have no row → `needsReAcceptance = true` once a gate exists (correct semantics).
+
+## 5. Current ToS version — single source of truth
+
+A server-side constant `TermsVersion.Current = "2026-07-15"` (static class in the Authentication BC, e.g. `Domain/Constants/TermsVersion.cs`). Rationale: the ToS text lives in code (`it.json`/`en.json`) and changes via deploy, so its version **co-deploys atomically** with the text.
+
+The frontend `terms/page.tsx` keeps its display literal (`lastUpdated`), annotated with a **cross-reference comment** to the BE constant. No public version endpoint / SSR fetch on a static page (YAGNI); drift risk is low (both change in the same ToS-edit commit). The future gate reads the current version from `GET /terms/status` (§6.3), not from a separate endpoint.
+
+## 6. API surface (CQRS — endpoints use `IMediator` only)
+
+### 6.1 `POST /api/v1/auth/register` — extended
+- Request DTO gains `termsAccepted: bool`; `RegisterCommand` gains `bool TermsAccepted = false`.
+- `RegisterCommandValidator`: `RuleFor(x => x.TermsAccepted).Equal(true)` → **server-side enforcement** (422 via the FluentValidation pipeline, matching the existing validator's behavior) — closes the cosmetic-checkbox gap.
+- `RegisterCommandHandler`: after the user+session `AddAsync`, also `_termsAcceptanceRepository.AddAsync(TermsAcceptance.Create(userId, TermsVersion.Current, Registration, command.IpAddress, command.UserAgent))` — committed in the **same** existing `_unitOfWork.SaveChangesAsync` (FK to the just-added user satisfied within one transaction). `AcceptedAt` from the handler's existing `TimeProvider`.
+
+### 6.2 `POST /api/v1/users/me/terms/accept` — authenticated
+- `me`-scoped: userId from `session.Principal.Subject.Id` (never a route/body param) → no IDOR.
+- `RecordTermsAcceptanceCommand(userId, context: ReConsent)` records acceptance of `TermsVersion.Current`.
+- **Idempotent:** if the user's latest accepted version already equals `Current`, no new row is written (returns 200). This keeps the append-only log meaningful (only real version transitions recorded) while safe to call repeatedly. This endpoint is the integration point a *future* gate/modal calls.
+
+### 6.3 `GET /api/v1/users/me/terms/status` — authenticated
+- `me`-scoped read-model. Returns:
+  ```
+  { currentVersion: string,
+    acceptedVersion: string | null,
+    acceptedAt: string | null,
+    needsReAcceptance: boolean }
+  ```
+- `needsReAcceptance = acceptedVersion != currentVersion` (null accepted → true). This is the flag a future gate consumes; **nothing consumes it in this scope**.
+
+Endpoints registered via a `MapTermsConsentEndpoints` `RouteGroupBuilder` extension (mirrors `UserAiConsentEndpoints`), `.RequireSession().RequireAuthorization()`.
+
+## 7. CQRS / DDD structure
+
+- `TermsAcceptance` entity (Domain) + `ITermsAcceptanceRepository` (Domain) + impl (Infrastructure). **DI registers both interface and impl** (#2565).
+- `RecordTermsAcceptanceCommand` (+ validator + handler) — used by 6.2 and internally callable shape for registration (registration handler uses the repository directly, same BC/transaction).
+- `GetTermsConsentStatusQuery` (+ handler) → status DTO.
+- Typed exceptions only (never `InvalidOperationException`); domain events not needed here.
+
+## 8. Frontend register-pipeline fix
+
+- `authClient.ts`: `RegisterRequest` gains `termsAccepted: boolean`; `register()` posts it.
+- `register/_content.tsx`: forward the acceptance through to `register({ email, password, termsAccepted: true })` (the form already gates submit on the required checkbox; wire the boolean, not the client timestamp — server stamps the authoritative time).
+- `RegisterForm` submit payload already carries the acceptance moment; the consumer now forwards a `termsAccepted: true` boolean.
+- Update consumer tests (register flow) — run the component's own tests, not just the edited module (per prior lesson).
+
+## 9. Security
+
+- **Server-side terms enforcement** at registration (validator) — the checkbox is no longer bypassable via a direct API call.
+- **Server-stamped `AcceptedAt`** — acceptance time is authoritative, not client-supplied.
+- **`me`-scoped** accept/status endpoints — userId derived from the session; add a cross-tenant test asserting the endpoint ignores any attempt to act on another user (no route/body userId exists).
+- Append-only record = tamper-evident audit trail (no in-place overwrite).
+
+## 10. Testing strategy (TDD)
+
+**Backend unit:**
+- `TermsAcceptance.Create` — happy path + throws on empty userId / blank version.
+- `RecordTermsAcceptanceCommandHandler` — appends a row; **no-op when latest accepted == Current** (idempotency); records `Context = ReConsent`.
+- `GetTermsConsentStatusQueryHandler` — `needsReAcceptance`: no rows → true; stale version → true; current → false; returns latest `acceptedAt`.
+- `RegisterCommandValidator` — `TermsAccepted == false` → validation failure.
+
+**Backend integration (Testcontainers Postgres):**
+- Registration writes exactly one `TermsAcceptance` row with `Current` version + `Registration` context + user's ip/ua.
+- Accept endpoint appends; second call with same current version is a no-op (still one row).
+- Status endpoint returns the correct DTO across the three `needsReAcceptance` states.
+- Append-only: a re-consent to a *new* version yields a second row (history preserved).
+- me-scoped: endpoints operate only on the session user.
+
+**Frontend (vitest):**
+- `authClient.register` includes `termsAccepted` in the POST body.
+- `register/_content.tsx` forwards `termsAccepted: true`.
+- Existing register-form / register-page tests updated and green.
+
+## 11. Files
+
+**Create (BE):**
+- `BoundedContexts/Authentication/Domain/Entities/TermsAcceptance.cs`
+- `BoundedContexts/Authentication/Domain/Enums/TermsAcceptanceContext.cs`
+- `BoundedContexts/Authentication/Domain/Constants/TermsVersion.cs`
+- `BoundedContexts/Authentication/Domain/Repositories/ITermsAcceptanceRepository.cs`
+- `BoundedContexts/Authentication/Infrastructure/Persistence/TermsAcceptanceRepository.cs`
+- `Infrastructure/EntityConfigurations/Authentication/TermsAcceptanceEntityConfiguration.cs`
+- `BoundedContexts/Authentication/Application/Commands/TermsAcceptance/RecordTermsAcceptanceCommand.cs` (+ validator + handler)
+- `BoundedContexts/Authentication/Application/Queries/TermsAcceptance/GetTermsConsentStatusQuery.cs` (+ handler + DTO)
+- `Routing/TermsConsentEndpoints.cs`
+- EF migration `AddUserTermsAcceptances`
+
+**Modify (BE):**
+- `RegisterCommand.cs` (+`TermsAccepted`), `RegisterCommandValidator.cs`, `RegisterCommandHandler.cs`
+- `/auth/register` endpoint request DTO (+`termsAccepted`)
+- DI registration (repo interface+impl); endpoint group wiring
+- `MeepleAiDbContext` `DbSet<TermsAcceptance>` if the DbContext enumerates sets explicitly
+
+**Modify (FE):**
+- `lib/api/clients/authClient.ts`, `app/(auth)/register/_content.tsx` (+ tests)
+- `app/(public)/terms/page.tsx` (cross-ref comment on `lastUpdated`)
+
+## 12. Non-goals / deferred to legal reviewer
+
+The **legal determination** of whether re-consent is *required* stays with the professional reviewer. Open questions handed off (from the decision dossier): GDPR Art.6 basis (consent vs. contractual necessity); sufficiency of §10 "continued use = acceptance" for a material change; enforceability of §10 as a unilateral-modification clause (art. 1341-1342 c.c.); retroactive-authorization exposure (cards already live); whether an append-only audit trail is legally required; the decline-path for a future gate; and whether ToS re-consent should be bundled with or kept separate from the §6 AI-consent. This foundation keeps **all** downstream enforcement options open.
+
+---
+
+*Design approved by user 2026-07-19. Enforcement strength intentionally deferred; this spec delivers only the recording/versioning foundation.*


### PR DESCRIPTION
> ⚠️ **Non chiudere issue 2954 né epic 539 al merge.** Sono umbrella aperte: questa PR copre **solo il finding F1**; restano PR-2 (review legale + deploy prod ToS) e altri. Se il bot le auto-chiude al merge, **riaprirle**. (Riferimenti volutamente senza `#` per evitare l'auto-close.)

## Cosa

Implementa la **fondazione di accettazione ToS** (finding **F1** di issue 2954, prereq PR-2 dell'epic 539). Emersa da uno spec-panel + indagine multi-agente: **non esisteva alcuna infrastruttura di accettazione ToS** — nessun record per-utente, nessun versioning, e il form di registrazione catturava `termsAcceptedAt` per poi **buttarlo via** (checkbox puramente cosmetico, backend senza enforcement).

## Scope — fondazione, NON enforcement

Per decisione utente ("fondazione ora, gate dopo"): si costruisce il livello di **registrazione/versioning** (necessario sotto ogni possibile risposta legale + sana il gap esistente) e si **rimanda la forza dell'enforcement** (gate bloccante vs notifica) alla review legale professionale finale che già cancella il deploy prod.

- ✅ Record append-only, versione server-authoritative, recording al register, endpoint di accept/status.
- ❌ **Nessun** gate bloccante / middleware / modal FE / re-consenso forzato. `needsReAcceptance` è **calcolato ed esposto** ma **nulla lo consuma** (intenzionale).

## Modifiche

**Backend (BC Authentication)**
- Nuova entità append-only `TermsAcceptance` + tabella `user_terms_acceptances` (migration `AddUserTermsAcceptances`): `Context` enum persistito come **string** (evita il pitfall CHECK-drift #2974), FK `users` cascade, index `(UserId, AcceptedAt)`, **nessun** unique index.
- `ITermsAcceptanceRepository` (AddAsync senza SaveChanges + GetLatest) + impl + DI (interfaccia+impl, #2565).
- Costante `TermsVersion.Current = "2026-07-15"` (single source of truth server-side; il `lastUpdated` FE ha commento di cross-ref).
- `RecordTermsAcceptanceCommand`/handler (idempotente: no-op se latest==current) + `GetTermsConsentStatusQuery`/handler + `TermsConsentStatusDto`.
- 2 endpoint **me-scoped** (userId dalla sessione, no route/body param → **no IDOR**): `GET /api/v1/users/me/terms/status`, `POST /api/v1/users/me/terms/accept`.
- Register pipeline: `+TermsAccepted` su command/payload, **enforcement 400** all'endpoint quando assente, handler registra l'accettazione nella **stessa transazione** del nuovo utente (guard su `TermsAccepted`).

**Frontend**
- `RegisterRequest.termsAccepted?` threadato su `RegisterData` (useAuth + AuthProvider); form register (`_content` + `AuthModal`) invia `true`; `registerAction` inoltra da formData.

## Test

- **Unit**: factory + 2 handler (idempotenza + needsReAcceptance 3 branch) — verdi.
- **Integration (Testcontainers)**: repo round-trip, register scrive 1 riga, register-senza-ToS → 400, accept idempotente, transizione stale→current, 401 unauth — **19/19**.
- **Regressione**: register-negativi strict corretti per raggiungere la validazione intesa (409/422 invece del 400-ToS) + `RegisterRaceConditionEndpointTests` — **26/26**. E2E register — **4/4**. FE — 84 test verdi.
- **Code review avversariale** (subagent): 1 BLOCKER + 2 MEDIUM (test E2E negativi mascherati + path FE latenti) → **tutti fixati e verificati**; 2 LOW skippati con motivazione.

> **Nota baseline**: le suite `Integration/FrontendSdk/*` falliscono in blocco con NRE all'avvio host (`FrontendSdkTestFactory` non strippa gli `IHostedService`, `IntegrationWebApplicationFactory` sì) — **pre-esistente su `main-dev`** (verificato 14/14 identico su baseline pulito), **non** causato da questa PR.

## Riferimenti
- Spec: `docs/superpowers/specs/2026-07-19-tos-acceptance-foundation-design.md`
- Piano: `docs/superpowers/plans/2026-07-19-tos-acceptance-foundation.md`
- Domande legali aperte (per il revisore) documentate nello spec §12.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
