### PR TITLE
feat(library): #3197 add 1-level Back guard to filters drawer (A-03)

### DIFF
--- a/apps/web/src/components/features/library/AdvancedFiltersDrawer/AdvancedFiltersDrawer.tsx
+++ b/apps/web/src/components/features/library/AdvancedFiltersDrawer/AdvancedFiltersDrawer.tsx
@@ -36,6 +36,7 @@ import {
 import clsx from 'clsx';
 
 import { Drawer, DrawerContent, DrawerDescription, DrawerTitle } from '@/components/ui/drawer';
+import { useHistoryBackGuard } from '@/hooks/useHistoryBackGuard';
 import { useTranslation } from '@/hooks/useTranslation';
 
 import {
@@ -67,6 +68,10 @@ export function AdvancedFiltersDrawer({
   useEffect(() => {
     if (open) setDraft(activeFilters);
   }, [open, activeFilters]);
+
+  // Gap A-03 (#3197): 1-level Back guard — the hardware/browser Back button
+  // closes the drawer instead of navigating away from the /library route.
+  useHistoryBackGuard(open, () => onOpenChange(false));
 
   const handleApply = () => {
     onApply(draft);

--- a/apps/web/src/components/features/library/AdvancedFiltersDrawer/__tests__/AdvancedFiltersDrawer.backGuard.test.tsx
+++ b/apps/web/src/components/features/library/AdvancedFiltersDrawer/__tests__/AdvancedFiltersDrawer.backGuard.test.tsx
@@ -1,0 +1,72 @@
+/**
+ * AdvancedFiltersDrawer — Android/browser Back guard (gap A-03, issue #3197).
+ *
+ * The filters drawer is a transient overlay opened from LibraryHub. Without a
+ * history guard, the hardware/gesture Back (Android) or the browser Back button
+ * would navigate away from the /library route instead of just closing the drawer.
+ * The drawer wires `useHistoryBackGuard(open, () => onOpenChange(false))`, so a
+ * Back press (popstate) closes the drawer and stays on the route.
+ *
+ * `installMatchMedia(true)` forces desktop (Radix Dialog) mode; the guard is
+ * window-level so it is orthogonal to the Vaul/Radix breakpoint swap.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { IntlProvider } from 'react-intl';
+
+import { AdvancedFiltersDrawer } from '../AdvancedFiltersDrawer';
+import type { LibraryFilters } from '../types';
+
+function installMatchMedia(matches: boolean) {
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: vi.fn().mockReturnValue({
+      matches,
+      media: '(min-width: 768px)',
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      onchange: null,
+    }),
+  });
+}
+
+const noop = () => {};
+const emptyFilters: LibraryFilters = {};
+
+function renderDrawer(open: boolean, onOpenChange: (o: boolean) => void) {
+  return render(
+    <IntlProvider locale="it" messages={{}} onError={() => {}}>
+      <AdvancedFiltersDrawer
+        open={open}
+        onOpenChange={onOpenChange}
+        activeFilters={emptyFilters}
+        onApply={noop}
+        onClear={noop}
+      />
+    </IntlProvider>
+  );
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('AdvancedFiltersDrawer — Android Back guard (A-03, #3197)', () => {
+  it('closes via onOpenChange(false) when the user presses Back while open', () => {
+    installMatchMedia(true);
+    const onOpenChange = vi.fn();
+    renderDrawer(true, onOpenChange);
+
+    window.dispatchEvent(new PopStateEvent('popstate'));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('does not arm the guard when the drawer is closed (no pushState)', () => {
+    installMatchMedia(true);
+    const pushSpy = vi.spyOn(window.history, 'pushState');
+    renderDrawer(false, vi.fn());
+
+    expect(pushSpy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/hooks/__tests__/useHistoryBackGuard.test.ts
+++ b/apps/web/src/hooks/__tests__/useHistoryBackGuard.test.ts
@@ -1,0 +1,76 @@
+/**
+ * useHistoryBackGuard — 1-level Back guard for transient overlays (gap A-03, #3197).
+ *
+ * Verifies the history-stack contract:
+ *   - push exactly one entry on the open transition
+ *   - Android/browser Back (popstate) → onClose
+ *   - listener cleanup on unmount (no stale onClose)
+ *   - non-Back close (open→false) balances the stack via history.back()
+ *   - a Back-driven close does NOT also call history.back() (no double-pop)
+ *   - open=false is a no-op
+ */
+
+import { renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { useHistoryBackGuard } from '../useHistoryBackGuard';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('useHistoryBackGuard (A-03, #3197)', () => {
+  it('pushes exactly one history entry when open becomes true', () => {
+    const pushSpy = vi.spyOn(window.history, 'pushState');
+    renderHook(() => useHistoryBackGuard(true, () => {}));
+    expect(pushSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does nothing when open is false (no pushState)', () => {
+    const pushSpy = vi.spyOn(window.history, 'pushState');
+    renderHook(() => useHistoryBackGuard(false, () => {}));
+    expect(pushSpy).not.toHaveBeenCalled();
+  });
+
+  it('calls onClose when the user presses Back (popstate)', () => {
+    const onClose = vi.fn();
+    renderHook(() => useHistoryBackGuard(true, onClose));
+    window.dispatchEvent(new PopStateEvent('popstate'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('removes the popstate listener on unmount (no stale onClose)', () => {
+    const onClose = vi.fn();
+    const { unmount } = renderHook(() => useHistoryBackGuard(true, onClose));
+    unmount();
+    window.dispatchEvent(new PopStateEvent('popstate'));
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('balances the stack with history.back() on a non-Back close (open→false)', () => {
+    const backSpy = vi.spyOn(window.history, 'back').mockImplementation(() => {});
+    const onClose = vi.fn();
+    const { rerender } = renderHook(({ open }) => useHistoryBackGuard(open, onClose), {
+      initialProps: { open: true },
+    });
+    // ESC/backdrop/programmatic close: parent flips open to false.
+    rerender({ open: false });
+    expect(backSpy).toHaveBeenCalledTimes(1);
+    // onClose is NOT re-fired: the reconciling pop happens after the listener is gone.
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('does NOT call history.back() after a Back-driven close (no double-pop)', () => {
+    const backSpy = vi.spyOn(window.history, 'back').mockImplementation(() => {});
+    const onClose = vi.fn();
+    const { rerender } = renderHook(({ open }) => useHistoryBackGuard(open, onClose), {
+      initialProps: { open: true },
+    });
+    // User presses Back → popstate consumes the guard entry, onClose fires.
+    window.dispatchEvent(new PopStateEvent('popstate'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+    // Parent reacts by closing; cleanup must NOT pop again (entry already gone).
+    rerender({ open: false });
+    expect(backSpy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/hooks/useHistoryBackGuard.ts
+++ b/apps/web/src/hooks/useHistoryBackGuard.ts
@@ -1,0 +1,50 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+/**
+ * useHistoryBackGuard — 1-level Android/browser Back guard for transient overlays.
+ *
+ * When `open` is true it pushes exactly one history entry so the hardware/gesture
+ * Back button (and the browser Back button) pops that entry and closes the overlay
+ * via `onClose` instead of navigating away from the current route.
+ *
+ * On a non-Back close (ESC / backdrop / programmatic — `open` flips to false while
+ * the guard entry is still on the stack) the pushed entry is reconciled with
+ * `history.back()` so the history stack stays balanced (no phantom entry). The
+ * popstate listener is removed *before* that reconciling pop, so it does not
+ * re-fire `onClose` (no double-close).
+ *
+ * Extracted from the inline pattern in `OverlayHybrid.tsx` (gap A-03, issue #3197).
+ *
+ * @param open    whether the guarded overlay is currently open
+ * @param onClose called when the user dismisses the overlay via Back/popstate
+ */
+export function useHistoryBackGuard(open: boolean, onClose: () => void): void {
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !open) return;
+
+    // Push exactly one guard entry per open transition (deps: [open]).
+    let poppedByBack = false;
+    window.history.pushState({ backGuard: true }, '');
+
+    const handlePopState = () => {
+      poppedByBack = true;
+      onCloseRef.current();
+    };
+    window.addEventListener('popstate', handlePopState);
+
+    return () => {
+      window.removeEventListener('popstate', handlePopState);
+      // Non-Back close: the guard entry is still on the stack — pop it to keep
+      // history balanced. The listener is already gone, so this reconciling pop
+      // does not re-trigger onClose.
+      if (!poppedByBack) {
+        window.history.back();
+      }
+    };
+  }, [open]);
+}


### PR DESCRIPTION
## Gap A-03 (audit mobile SP8) — back-guard 1-livello sui sheet di `/library`

Chiude il gap **A-03** di #3197 (ultimo dei 3). Il tasto **Back di Android** (e il Back del browser) usciva dalla route `/library` invece di chiudere l'`AdvancedFiltersDrawer`: la primitive `Drawer` (Vaul mobile / Radix desktop) gestisce solo ESC + backdrop, **non** la history.

### Nuovo hook riutilizzabile `useHistoryBackGuard(open, onClose)`
Estratto dal pattern inline di `OverlayHybrid.tsx` (finora l'unica implementazione, non riusabile):
- pusha **1 sola** history entry alla transizione `open→true`;
- `popstate` (Back) → `onClose`;
- **footgun risolto** — chiusura non-Back (ESC/backdrop/programmatica): bilancia lo stack con `history.back()` nel cleanup, rimuovendo **prima** il listener così la pop di riconciliazione non ri-scatena `onClose` (niente double-close né phantom entry, che `OverlayHybrid` non gestiva).

### Applicazione
`AdvancedFiltersDrawer` — unico sheet dell'hub `/library` privo di guard. `AddGameDrawer` ha già il back via URL param `?action=add` → non toccato.

### Test (TDD, RED→GREEN)
- `useHistoryBackGuard.test.ts` — **6 test**: push singolo, `popstate→onClose`, cleanup listener, bilanciamento `history.back()` su close non-Back, no double-pop dopo Back, `open=false` no-op.
- `AdvancedFiltersDrawer.backGuard.test.tsx` — **2 test**: Back chiude via `onOpenChange(false)`; nessun `pushState` a drawer chiuso.
- typecheck + lint puliti; **51 test drawer verdi**, +203/-0 righe (produzione: +5 wiring).

### Follow-up (stesso hook, fuori scope A-03)
I drawer di `/library/[gameId]` mobile (`GameDetailsDrawer`, `StartSessionSheet`, `CustomCoverDialog`) hanno lo stesso bug e possono adottare l'hook.

Closes #3197 (gap A-01 #3198 + A-02 #3206 + A-03 qui → 3/3 CRITICO /library chiusi).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
