### PR TITLE
fix(http): #3210 exception mapping 500→409/404 su 3 handler

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DatabaseSync/Application/Queries/CompareTableDataHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DatabaseSync/Application/Queries/CompareTableDataHandler.cs
@@ -3,6 +3,7 @@ using Api.BoundedContexts.DatabaseSync.Domain.Interfaces;
 using Api.BoundedContexts.DatabaseSync.Domain.Models;
 using Api.BoundedContexts.DatabaseSync.Infrastructure;
 using Api.Infrastructure;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Application.Interfaces;
 using Microsoft.EntityFrameworkCore;
 using Npgsql;
@@ -33,8 +34,7 @@ internal class CompareTableDataHandler : IQueryHandler<CompareTableDataQuery, Da
 
         if (!await TableExistsAsync(localConn, query.TableName, cancellationToken).ConfigureAwait(false))
         {
-            throw new InvalidOperationException(
-                "Table does not exist on local database: " + query.TableName);
+            throw new NotFoundException("Table", query.TableName);
         }
 
         var remoteConn = await _remoteConnector.OpenConnectionAsync(cancellationToken).ConfigureAwait(false);
@@ -42,8 +42,7 @@ internal class CompareTableDataHandler : IQueryHandler<CompareTableDataQuery, Da
         {
             if (!await TableExistsAsync(remoteConn, query.TableName, cancellationToken).ConfigureAwait(false))
             {
-                throw new InvalidOperationException(
-                    "Table does not exist on staging database: " + query.TableName);
+                throw new NotFoundException("Table", query.TableName);
             }
 
             var localRowCount = await DataDiffEngine.GetEstimatedRowCountAsync(

--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Commands/GenerateToolkitFromKbHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Commands/GenerateToolkitFromKbHandler.cs
@@ -121,7 +121,7 @@ internal class GenerateToolkitFromKbHandler
             .ConfigureAwait(false);
 
         if (accessibleCardIds.Count == 0)
-            throw new InvalidOperationException(
+            throw new ConflictException(
                 $"No documents found in knowledge base for game {command.GameId}. Upload and index PDF rulebooks first.");
 
         // 3. Fan-out hybrid search across extraction query categories

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/AbTest/GetAbTestQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/AbTest/GetAbTestQueryHandler.cs
@@ -3,6 +3,7 @@ using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
 using Api.BoundedContexts.KnowledgeBase.Application.Queries.AbTest;
 using Api.BoundedContexts.KnowledgeBase.Domain.Enums;
 using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Application.Interfaces;
 
 namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.AbTest;
@@ -47,7 +48,7 @@ internal sealed class RevealAbTestQueryHandler : IQueryHandler<RevealAbTestQuery
             return null;
 
         if (session.Status != AbTestStatus.Evaluated)
-            throw new InvalidOperationException("Cannot reveal models before evaluation is complete");
+            throw new ConflictException("Cannot reveal models before evaluation is complete");
 
         return AbTestMapper.ToRevealedDto(session);
     }

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameToolkit/Application/Handlers/GenerateToolkitFromKbHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameToolkit/Application/Handlers/GenerateToolkitFromKbHandlerTests.cs
@@ -70,7 +70,7 @@ public class GenerateToolkitFromKbHandlerTests
     }
 
     [Fact]
-    public async Task Handle_NoAccessibleKbCards_ThrowsInvalidOperationException()
+    public async Task Handle_NoAccessibleKbCards_ThrowsConflictException()
     {
         SetupGameCoreData("Catan");
         _ragAccessMock
@@ -80,7 +80,8 @@ public class GenerateToolkitFromKbHandlerTests
         var command = new GenerateToolkitFromKbCommand(GameId, UserId);
         var act = () => _handler.Handle(command, TestContext.Current.CancellationToken);
 
-        await act.Should().ThrowAsync<InvalidOperationException>()
+        // Issue #3210: empty KB is a state conflict (409), not a 500.
+        await act.Should().ThrowAsync<Api.Middleware.Exceptions.ConflictException>()
             .WithMessage("*knowledge base*");
     }
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/AbTest/RevealAbTestQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/AbTest/RevealAbTestQueryHandlerTests.cs
@@ -1,0 +1,54 @@
+using Api.BoundedContexts.KnowledgeBase.Application.Queries.AbTest;
+using Api.BoundedContexts.KnowledgeBase.Domain.Entities;
+using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Handlers.AbTest;
+
+/// <summary>
+/// Unit tests for RevealAbTestQueryHandler.
+/// Issue #3210: revealing an A/B test before evaluation is complete is a conflict with the
+/// current resource state (409), not an internal server error (500). Before this fix the
+/// handler threw a bare <see cref="InvalidOperationException"/> which the middleware mapped to 500.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "KnowledgeBase")]
+[Trait("Issue", "3210")]
+public sealed class RevealAbTestQueryHandlerTests
+{
+    private readonly Mock<IAbTestSessionRepository> _repoMock = new();
+    private static readonly Guid UserId = Guid.NewGuid();
+
+    private RevealAbTestQueryHandler CreateSut() => new(_repoMock.Object);
+
+    [Fact]
+    public async Task Handle_SessionNotEvaluated_ThrowsConflictException()
+    {
+        // A freshly created session is in Draft status (not Evaluated).
+        var session = AbTestSession.Create(UserId, "Which model answers better?");
+        _repoMock.Setup(r => r.GetByIdWithVariantsAsync(session.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(session);
+
+        var sut = CreateSut();
+        Func<Task> act = () => sut.Handle(new RevealAbTestQuery(session.Id), CancellationToken.None);
+
+        await act.Should().ThrowAsync<ConflictException>()
+            .WithMessage("*before evaluation*");
+    }
+
+    [Fact]
+    public async Task Handle_SessionNotFound_ReturnsNull()
+    {
+        _repoMock.Setup(r => r.GetByIdWithVariantsAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((AbTestSession?)null);
+
+        var sut = CreateSut();
+        var result = await sut.Handle(new RevealAbTestQuery(Guid.NewGuid()), CancellationToken.None);
+
+        result.Should().BeNull();
+    }
+}

--- a/apps/api/tests/Api.Tests/Integration/DatabaseSync/CompareTableDataHandlerIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/DatabaseSync/CompareTableDataHandlerIntegrationTests.cs
@@ -1,0 +1,51 @@
+using Api.BoundedContexts.DatabaseSync.Application.Queries;
+using Api.BoundedContexts.DatabaseSync.Domain.Interfaces;
+using Api.Infrastructure;
+using Api.Middleware.Exceptions;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.Integration.DatabaseSync;
+
+/// <summary>
+/// Integration tests for <see cref="CompareTableDataHandler"/> against a real PostgreSQL backend.
+///
+/// Issue #3210: requesting a diff for a table that does not exist is a 404 Not Found, not a 500.
+/// Before this fix the handler threw a bare <see cref="InvalidOperationException"/> ("Table does not
+/// exist on local database: ...") which the middleware mapped to 500.
+///
+/// A unit/mock test cannot catch this: the handler runs raw information_schema queries on a live
+/// <c>NpgsqlConnection</c> obtained from the DbContext, so only a real relational provider exercises
+/// the table-existence check. The handler is <c>internal</c>, so it is constructed inside the test
+/// (via InternalsVisibleTo) rather than exposed through the public base-class type parameter.
+/// </summary>
+[Trait("Category", TestCategories.Integration)]
+[Trait("Dependency", "PostgreSQL")]
+[Trait("BoundedContext", "DatabaseSync")]
+[Trait("Issue", "3210")]
+public sealed class CompareTableDataHandlerIntegrationTests
+    : IntegrationTestBase<MeepleAiDbContext>
+{
+    // The local-table-missing branch throws before the remote connector is ever used,
+    // so an unconfigured mock is sufficient.
+    private readonly Mock<IRemoteDatabaseConnector> _remoteConnectorMock = new();
+
+    protected override string DatabaseName => "test_compare_table_data";
+
+    // TRepository is bound to the (public) DbContext; the handler under test is built per-test.
+    protected override MeepleAiDbContext CreateRepository(MeepleAiDbContext dbContext) => dbContext;
+
+    [Fact]
+    public async Task Handle_LocalTableDoesNotExist_ThrowsNotFoundException()
+    {
+        var handler = new CompareTableDataHandler(DbContext, _remoteConnectorMock.Object);
+        var query = new CompareTableDataQuery("nonexistent_table_xyz");
+
+        Func<Task> act = () => handler.Handle(query, TestContext.Current.CancellationToken);
+
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+}


### PR DESCRIPTION
## Cosa

Corregge il mapping HTTP di 3 handler backend che lanciavano `InvalidOperationException` — mappata a **500** dal middleware — dove la semantica corretta è **409** (conflitto di stato) o **404** (risorsa non trovata).

| Handler | Condizione | Prima | Dopo |
|---|---|---|---|
| `RevealAbTestQueryHandler` | reveal A/B prima della valutazione completa | 500 | **409** `ConflictException` |
| `GenerateToolkitFromKbHandler` | generazione toolkit con KB vuota | 500 | **409** `ConflictException` |
| `CompareTableDataHandler` | diff su tabella inesistente (local/staging) | 500 | **404** `NotFoundException` |

## Perché

`ApiExceptionHandlerMiddleware.MapExceptionToResponse` mappa `InvalidOperationException` → 404 **solo** se il messaggio contiene `"not found"`, altrimenti cade nel default → **500**. I 3 casi qui sono conflitti di stato / risorse mancanti, non errori server: l'utente riceveva un 500 improprio.

## Come (TDD RED→GREEN)

- unit `RevealAbTestQueryHandlerTests` — sessione non-`Evaluated` → 409
- unit `GenerateToolkitFromKbHandlerTests` — KB vuota → 409 (test esistente aggiornato)
- integration `CompareTableDataHandlerIntegrationTests` — tabella inesistente → 404 (Testcontainers Postgres reale; l'handler esegue query `information_schema` su `NpgsqlConnection` live, non testabile con mock)

Ogni test è stato visto **fallire** con `InvalidOperationException` prima del fix. **Regression guard**: 20 test correlati verdi (happy-path, LLM-failed, cache, reveal endpoint invariati).

## Fuori scope (deliberato)

- Altre `throw` di `CompareTableDataHandler` (row-limit / no-primary-key / no-comparable-columns → semantica 400/422) restano invariate.
- Il ramo *LLM-failed* di `GenerateToolkitFromKbHandler` (`:176`) è un genuino 500 → invariato.
- Nessun tocco a `SessionTracking` / `GameManagement`.

Scoperta via `/sc:spec-panel` discovery (fan-out Explore avversariale, aree lontane da #3188).

Closes #3210

🤖 Generated with [Claude Code](https://claude.com/claude-code)
