### PR TITLE
fix(session-tracking): #3218 make go-live idempotent (self-heal)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/GoLiveSessionCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/GoLiveSessionCommandHandler.cs
@@ -1,4 +1,5 @@
 using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.BoundedContexts.GameManagement.Domain.Enums;
 using Api.BoundedContexts.GameManagement.Domain.Exceptions;
 using Api.BoundedContexts.SessionTracking.Application.Commands;
 using Api.Infrastructure.EntityConfigurations.GameManagement;
@@ -12,34 +13,50 @@ namespace Api.BoundedContexts.GameManagement.Application.Commands.GameNights;
 
 /// <summary>
 /// Handles <see cref="GoLiveSessionCommand"/> — the explicit go-live sub-resource (epic #3188
-/// Slice 2). Mirrors phases 2+3 of <see cref="StartGameNightSessionCommandHandler"/>, minus the
-/// cross-BC session create (the draft already exists):
+/// Slice 2, made idempotent / self-healing in #3218). Mirrors phases 2+3 of
+/// <see cref="StartGameNightSessionCommandHandler"/>, minus the cross-BC session create (the draft
+/// already exists).
 ///
-/// <list type="number">
-///   <item><b>Phase 2</b> — resolve the owning <c>GameNightEvent</c> by the tracking-session id
-///     and promote that specific draft (<c>Pending → InProgress</c>) via
-///     <see cref="GameNightEvent.StartSession"/>, then persist (the aggregate root's xmin write
-///     detects a concurrent live-slot race).</item>
-///   <item><b>Phase 3</b> — dispatch <see cref="OpenSessionLiveModeCommand"/> LAST, AFTER the
-///     promotion is committed, so <c>Session.OpenLiveMode()</c>'s <c>SessionStartedDomainEvent</c>
-///     resolves the parent unambiguously and drives the invariante #15 night promotion.</item>
+/// <para><b>#3218 self-healing:</b> the go-live is a multi-phase, multi-SaveChanges flow — phase 2
+/// (the link promotion <c>Pending → InProgress</c>) commits in its own transaction, then phase 3
+/// (<see cref="OpenSessionLiveModeCommand"/>) commits the tracking-Session live-mode transition in a
+/// second one. If phase 3 fails after phase 2 committed, the link is stuck <c>InProgress</c> while
+/// the tracking Session is not yet live — a split-brain. To let the natural retry affordance heal it,
+/// the handler branches on the TARGET link's current status AFTER authorization:</para>
+///
+/// <list type="bullet">
+///   <item><b>link <c>Pending</c></b> — promote (<c>Pending → InProgress</c>) via
+///     <see cref="GameNightEvent.StartSession"/> + persist (the aggregate root's xmin write detects a
+///     concurrent live-slot race), THEN dispatch <see cref="OpenSessionLiveModeCommand"/>.</item>
+///   <item><b>link <c>InProgress</c></b> (a prior attempt already committed phase 2) — SELF-HEAL:
+///     SKIP the promotion + the aggregate write entirely and go straight to dispatching
+///     <see cref="OpenSessionLiveModeCommand"/>. That handler is idempotent (<c>if (session.IsLive)
+///     return;</c>), so this brings a not-yet-live Session live and is a harmless no-op if it is
+///     already live. Returns the current promoted state — no 409 on retry.</item>
+///   <item><b>link terminal</b> (<c>Completed</c>/<c>Skipped</c>/<c>Corrupted</c>) —
+///     <see cref="ConflictException"/> → 409: a finished session cannot go live.</item>
 /// </list>
 ///
-/// <para>Because the draft already exists, there is exactly ONE aggregate write here — a single
-/// <c>SaveChangesAsync</c> is inherently atomic, so (unlike the create orchestrator) no explicit
-/// transaction wrapper is needed.</para>
+/// <para>Phase 3 is dispatched LAST — AFTER the promotion is committed (or skipped) — so
+/// <c>Session.OpenLiveMode()</c>'s <c>SessionStartedDomainEvent</c> resolves the parent unambiguously
+/// and drives the invariante #15 night promotion (Published → InProgress).</para>
 ///
 /// <para>Error mapping (never 500):
 /// <list type="bullet">
-///   <item>Owning night / session not found → <see cref="NotFoundException"/> → 404.</item>
-///   <item>Another session already live (in-memory guard) → <see cref="MaxLiveSessionsExceededException"/> → 409.</item>
-///   <item>Targeted session not Pending → <see cref="InvalidOperationException"/> re-mapped to
-///     <see cref="ConflictException"/> → 409 (parity with the create orchestrator).</item>
-///   <item>Concurrent go-live loses the xmin race → <see cref="DbUpdateConcurrencyException"/>
-///     re-mapped to <see cref="MaxLiveSessionsExceededException"/> → 409.</item>
-///   <item>Concurrent promotion trips the partial-unique live-slot index (Postgres 23505) →
-///     re-mapped to <see cref="MaxLiveSessionsExceededException"/> → 409.</item>
+///   <item>Owning night / target link not found → <see cref="NotFoundException"/> → 404.</item>
+///   <item>Caller is not the organizer → <see cref="ForbiddenException"/> → 403 (checked AFTER the
+///     404 resolution so a bad id never leaks existence via a 403).</item>
+///   <item>Terminal target link → <see cref="ConflictException"/> → 409.</item>
+///   <item>Another session already live (in-memory guard, Pending path only) →
+///     <see cref="MaxLiveSessionsExceededException"/> → 409.</item>
+///   <item>Concurrent go-live loses the xmin race (Pending path only) →
+///     <see cref="DbUpdateConcurrencyException"/> re-mapped to
+///     <see cref="MaxLiveSessionsExceededException"/> → 409.</item>
+///   <item>Concurrent promotion trips the partial-unique live-slot index (Postgres 23505, Pending
+///     path only) → re-mapped to <see cref="MaxLiveSessionsExceededException"/> → 409.</item>
 /// </list></para>
+///
+/// <para>The self-heal path does NO aggregate write, so it needs no concurrency catch.</para>
 /// </summary>
 internal sealed class GoLiveSessionCommandHandler : ICommandHandler<GoLiveSessionCommand, GoLiveSessionResult>
 {
@@ -73,12 +90,64 @@ internal sealed class GoLiveSessionCommandHandler : ICommandHandler<GoLiveSessio
         if (gameNight.OrganizerId != command.UserId)
             throw new ForbiddenException("Only the organizer can start sessions.");
 
+        // Resolve the TARGET link and branch on its current status for idempotent / self-healing
+        // go-live (#3218). GetByLinkedSessionIdAsync returns the OWNING night, so the link should
+        // exist — but guard the lookup so a defensive miss maps to 404, never an unhandled 500.
+        var targetLink = gameNight.Sessions.FirstOrDefault(s => s.SessionId == command.SessionId)
+            ?? throw new NotFoundException("GameNightSession", command.SessionId.ToString());
+
+        switch (targetLink.Status)
+        {
+            case GameNightSessionStatus.Pending:
+                // Normal path — promote (Pending → InProgress) + persist, with the xmin/23505 → 409
+                // and non-Pending → 409 catches scoped to THIS aggregate write.
+                await PromotePendingDraftAsync(gameNight, command.SessionId, cancellationToken).ConfigureAwait(false);
+                break;
+
+            case GameNightSessionStatus.InProgress:
+                // SELF-HEAL (#3218) — a prior go-live attempt already committed the promotion but did
+                // not finish opening live mode (a phase-3 failure split-brain), OR the whole flow
+                // already succeeded and this is a plain retry. Either way SKIP the promotion and the
+                // aggregate write, and fall through to dispatching OpenSessionLiveModeCommand below,
+                // which is idempotent: it brings a not-yet-live Session live and no-ops if already live.
+                break;
+
+            default:
+                // Terminal link (Completed / Skipped / Corrupted): a finished session cannot go live.
+                throw new ConflictException(
+                    $"Cannot go live: session {command.SessionId} is {targetLink.Status} and cannot be started.");
+        }
+
+        var promoted = gameNight.Sessions.First(s => s.SessionId == command.SessionId);
+        var result = new GoLiveSessionResult(
+            command.SessionId,
+            gameNight.Id,
+            promoted.Id,
+            promoted.PlayOrder,
+            promoted.Status.ToString());
+
+        // Phase 3: open live mode LAST — AFTER the session↔night promotion is committed (Pending path)
+        // or skipped (self-heal path) — so the SessionStartedDomainEvent resolves the parent
+        // unambiguously and promotes the night Published → InProgress (invariante #15). Idempotent.
+        await _mediator.Send(new OpenSessionLiveModeCommand(command.SessionId), cancellationToken).ConfigureAwait(false);
+
+        return result;
+    }
+
+    /// <summary>
+    /// Pending-path phase 2: promote the targeted draft (Pending → InProgress) and persist, mapping
+    /// the aggregate write's failure modes to 409 (never a 500). Only ever called for a link the
+    /// caller has already confirmed is <see cref="GameNightSessionStatus.Pending"/>.
+    /// </summary>
+    private async Task PromotePendingDraftAsync(
+        GameNightEvent gameNight, Guid sessionId, CancellationToken cancellationToken)
+    {
         try
         {
-            // Phase 2: promote the targeted draft (Pending → InProgress). NotFound/MaxLive escape this
-            // try uncaught (they already map to 404/409); a non-Pending session throws
-            // InvalidOperationException which the catch below normalises to a 409.
-            gameNight.StartSession(command.SessionId);
+            // Promote the targeted draft (Pending → InProgress). MaxLive (another session already
+            // live) escapes this try uncaught (it already maps to 409); a corrupted-aggregate guard
+            // throws InvalidOperationException which the catch below normalises to a 409.
+            gameNight.StartSession(sessionId);
 
             await _repository.UpdateAsync(gameNight, cancellationToken).ConfigureAwait(false);
             // The aggregate root's xmin write detects a concurrent go-live that already took the
@@ -100,24 +169,10 @@ internal sealed class GoLiveSessionCommandHandler : ICommandHandler<GoLiveSessio
         }
         catch (InvalidOperationException ex)
         {
-            // Targeted session not Pending (or a corrupted-state guard) — a conflict, not a 500.
+            // Corrupted-aggregate guard (or any other domain conflict on the promotion) — a conflict,
+            // not a 500.
             throw new ConflictException(ex.Message);
         }
-
-        var promoted = gameNight.Sessions.First(s => s.SessionId == command.SessionId);
-        var result = new GoLiveSessionResult(
-            command.SessionId,
-            gameNight.Id,
-            promoted.Id,
-            promoted.PlayOrder,
-            promoted.Status.ToString());
-
-        // Phase 3: open live mode LAST — AFTER the session↔night promotion is committed — so the
-        // SessionStartedDomainEvent resolves the parent unambiguously and promotes the night
-        // Published → InProgress (invariante #15). Idempotent.
-        await _mediator.Send(new OpenSessionLiveModeCommand(command.SessionId), cancellationToken).ConfigureAwait(false);
-
-        return result;
     }
 
     // True iff the DbUpdateException is the partial-unique-index violation on the GameNight live slot

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/GameNight/GoLiveSessionCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/GameNight/GoLiveSessionCommandHandlerTests.cs
@@ -144,14 +144,15 @@ public class GoLiveSessionCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_TargetedSessionNotPending_ThrowsConflict()
+    public async Task Handle_TargetedSessionTerminal_ThrowsConflict()
     {
-        // Arrange — the targeted session was already completed; a non-Pending promotion is a conflict
-        // (InvalidOperationException from GameNightSession.Start() → ConflictException 409).
+        // Arrange — the targeted link is terminal (Completed): a finished session cannot go live.
+        // The #3218 status branch maps a terminal target link straight to a ConflictException 409,
+        // BEFORE any promotion, aggregate write, or live-mode dispatch.
         var sessionId = Guid.NewGuid();
         var gameNight = CreatePublishedEventWithDraft(sessionId, out _);
         gameNight.StartSession(sessionId);
-        gameNight.CompleteCurrentSession(winnerId: null); // now Completed
+        gameNight.CompleteCurrentSession(winnerId: null); // now Completed (terminal)
 
         _mockRepository.Setup(r => r.GetByLinkedSessionIdAsync(sessionId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(gameNight);
@@ -160,8 +161,82 @@ public class GoLiveSessionCommandHandlerTests
         await Assert.ThrowsAsync<ConflictException>(
             () => _handler.Handle(new GoLiveSessionCommand(sessionId, gameNight.OrganizerId), CancellationToken.None));
 
+        // A terminal link short-circuits: no promotion write, no live-mode dispatch.
+        _mockRepository.Verify(r => r.UpdateAsync(
+            It.IsAny<Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent.GameNightEvent>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+        _mockUnitOfWork.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
         _mockMediator.Verify(m => m.Send(It.IsAny<OpenSessionLiveModeCommand>(), It.IsAny<CancellationToken>()),
             Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_TargetLinkAlreadyInProgress_SelfHeals_DispatchesOpenLive_WithoutAggregateWrite()
+    {
+        // Arrange — SPLIT-BRAIN (#3218): a prior go-live already committed phase 2 (link promoted
+        // Pending → InProgress) but a phase-3 failure left the tracking Session not-yet-live. A retry
+        // must NOT 409 (the old behavior, because StartSession throws on an already-InProgress link).
+        // Instead the handler SKIPS the promotion + aggregate write and dispatches
+        // OpenSessionLiveModeCommand (idempotent) to heal the Session.
+        var sessionId = Guid.NewGuid();
+        var gameNight = CreatePublishedEventWithDraft(sessionId, out _);
+        gameNight.StartSession(sessionId); // link is InProgress — a prior attempt's phase 2 committed
+
+        _mockRepository.Setup(r => r.GetByLinkedSessionIdAsync(sessionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(gameNight);
+        _mockMediator.Setup(m => m.Send(It.IsAny<OpenSessionLiveModeCommand>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        // Act — must not throw
+        var result = await _handler.Handle(
+            new GoLiveSessionCommand(sessionId, gameNight.OrganizerId), CancellationToken.None);
+
+        // Assert — returns the already-promoted InProgress state
+        Assert.Equal(sessionId, result.SessionId);
+        Assert.Equal(gameNight.Id, result.GameNightId);
+        Assert.Equal(nameof(GameNightSessionStatus.InProgress), result.Status);
+        Assert.Equal(GameNightSessionStatus.InProgress, gameNight.Sessions[0].Status);
+
+        // Self-heal does NO aggregate write — only OpenSessionLiveModeCommand is dispatched (once).
+        _mockRepository.Verify(r => r.UpdateAsync(
+            It.IsAny<Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent.GameNightEvent>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+        _mockUnitOfWork.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+        _mockMediator.Verify(m => m.Send(
+            It.Is<OpenSessionLiveModeCommand>(c => c.SessionId == sessionId), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_TargetLinkInProgress_SessionAlreadyLive_IsIdempotentNoOp()
+    {
+        // Arrange — plain retry of a go-live that already fully succeeded: the link is InProgress AND
+        // the tracking Session is already live. The handler does not special-case an already-live
+        // Session — it still delegates idempotency to OpenSessionLiveModeCommandHandler (which no-ops
+        // on `session.IsLive`). Here the mocked mediator stands in for that no-op. No 409 surfaces.
+        var sessionId = Guid.NewGuid();
+        var gameNight = CreatePublishedEventWithDraft(sessionId, out _);
+        gameNight.StartSession(sessionId); // link InProgress
+
+        _mockRepository.Setup(r => r.GetByLinkedSessionIdAsync(sessionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(gameNight);
+        // OpenLive no-ops on an already-live Session — modelled as a completed task.
+        _mockMediator.Setup(m => m.Send(It.IsAny<OpenSessionLiveModeCommand>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        // Act — must not throw
+        var result = await _handler.Handle(
+            new GoLiveSessionCommand(sessionId, gameNight.OrganizerId), CancellationToken.None);
+
+        // Assert — success no-op, InProgress result, OpenLive still dispatched (idempotency delegated).
+        Assert.Equal(nameof(GameNightSessionStatus.InProgress), result.Status);
+        _mockRepository.Verify(r => r.UpdateAsync(
+            It.IsAny<Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent.GameNightEvent>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+        _mockUnitOfWork.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+        _mockMediator.Verify(m => m.Send(
+            It.Is<OpenSessionLiveModeCommand>(c => c.SessionId == sessionId), It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 
     [Fact]

--- a/apps/api/tests/Api.Tests/Integration/GameManagement/GoLiveSessionConcurrencyTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/GameManagement/GoLiveSessionConcurrencyTests.cs
@@ -25,10 +25,15 @@ namespace Api.Tests.Integration.GameManagement;
 /// exception (via the max-1-live guard, the aggregate xmin race, or the partial-unique live-slot
 /// index). No 500, no orphaned second live session.
 ///
+/// <para>Also covers the #3218 self-healing retry: when a prior go-live committed phase 2 (link
+/// promoted <c>Pending → InProgress</c>) but never finished phase 3 (the tracking Session stayed
+/// not-live — a split-brain), a retry must self-heal the Session live instead of 409-ing.</para>
+///
 /// <para>Mirrors the Testcontainers + full-DI factory pattern of <c>CorrelatedGameSessionOnStartTests</c>.
 /// The <c>DomainEventOutboxProcessor</c> BackgroundService is not running in the test host, so the
 /// invariante #15 night promotion (Published → InProgress) is not asserted here — the contract under
-/// test is the single-live-slot arbitration on <c>game_night_sessions</c>.</para>
+/// test is the single-live-slot arbitration on <c>game_night_sessions</c> plus the self-heal of the
+/// tracking Session's live state.</para>
 /// </summary>
 [Collection("Integration-GroupC")]
 [Trait("Category", TestCategories.Integration)]
@@ -156,6 +161,84 @@ public sealed class GoLiveSessionConcurrencyTests : IAsyncLifetime
             .Should().Be(1, "no more than one session may be live in a game night at a time (invariante #10)");
         links.Count(s => s.Status == nameof(GameNightSessionStatus.Pending))
             .Should().Be(1, "the blocked draft must remain Pending — its promotion rolled back");
+    }
+
+    [Fact(DisplayName = "Go-live retry after a phase-2-only commit self-heals the Session live (no 409)")]
+    public async Task GoLiveRetry_AfterInProgressLinkButNotLiveSession_SelfHealsSessionLive()
+    {
+        // ── Arrange — simulate a #3218 split-brain ──────────────────────────────
+        // Phase 2 committed (the night link is InProgress) but phase 3 never ran (the tracking Session
+        // is still not live). Before #3218 a retry threw a 409 because GameNightEvent.StartSession()
+        // rejects an already-InProgress link; now the retry must SELF-HEAL by (re)opening live mode.
+        Guid userId;
+        Guid gameId;
+        await using (var seedScope = _factory.Services.CreateAsyncScope())
+        {
+            var db = seedScope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            userId = await SeedUserAsync(db);
+            gameId = await SeedSharedGameAsync(db);
+        }
+
+        // A real standalone tracking Session that is NOT live yet (StartedAt == null).
+        var sessionId = await CreateStandaloneSessionAsync(userId, gameId);
+
+        var nightId = Guid.NewGuid();
+        await using (var seedScope = _factory.Services.CreateAsyncScope())
+        {
+            var db = seedScope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            var now = DateTimeOffset.UtcNow;
+            // Night stays Published: the phase-2 commit promotes only the LINK; the night's
+            // Published → InProgress promotion (invariante #15) is a phase-3 side effect that
+            // never ran in this split-brain.
+            db.GameNightEvents.Add(new GameNightEventEntity
+            {
+                Id = nightId,
+                OrganizerId = userId,
+                Title = "Self-Heal Night",
+                ScheduledAt = now,
+                GameIdsJson = System.Text.Json.JsonSerializer.Serialize(new List<Guid> { gameId }),
+                Status = nameof(GameNightStatus.Published),
+                CreatedAt = now,
+                UpdatedAt = now,
+            });
+            db.GameNightSessions.Add(new GameNightSessionEntity
+            {
+                Id = Guid.NewGuid(),
+                GameNightEventId = nightId,
+                SessionId = sessionId,
+                GameId = gameId,
+                GameTitle = "Catan",
+                PlayOrder = 1,
+                Status = nameof(GameNightSessionStatus.InProgress), // link stuck InProgress (phase-3 never ran)
+                StartedAt = now,
+            });
+            await db.SaveChangesAsync();
+        }
+
+        // ── Act — retry go-live on the already-promoted link ─────────────────────
+        var (_, exception) = await GoLiveAsync(sessionId, userId);
+
+        // ── Assert ──────────────────────────────────────────────────────────────
+        exception.Should().BeNull("the retry must self-heal the split-brain, not return a 409");
+
+        await using var verifyScope = _factory.Services.CreateAsyncScope();
+        var verifyDb = verifyScope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        // The tracking Session is now live — phase 3 (OpenLiveMode) ran on retry and healed it.
+        var session = await verifyDb.SessionTrackingSessions
+            .AsNoTracking()
+            .SingleAsync(s => s.Id == sessionId);
+        session.StartedAt.Should().NotBeNull(
+            "the idempotent OpenSessionLiveModeCommand must open live mode on retry, healing the Session");
+        session.FinalizedAt.Should().BeNull("the healed Session is live, not finalized");
+
+        // The link stays a single InProgress — no double-promotion, no rollback to Pending.
+        var links = await verifyDb.GameNightSessions
+            .AsNoTracking()
+            .Where(s => s.GameNightEventId == nightId)
+            .ToListAsync();
+        links.Count(s => s.Status == nameof(GameNightSessionStatus.InProgress))
+            .Should().Be(1, "the already-promoted link stays InProgress; self-heal never touches the aggregate");
     }
 
     // ── Helpers ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
**Follow-up** dalla holistic review di #3188 (finding MEDIUM).

## Problema
Il go-live (`POST /api/v1/sessions/{id}/go-live`) è multi-fase non-transazionale: promuove il link `Pending→InProgress` + salva, poi `OpenSessionLiveModeCommand` setta `Session.IsLive` + promuove la night. Se una fase tardiva fallisce, il link resta `InProgress` e un retry dava **409** (`GameNightEvent.StartSession` fa throw su non-Pending) invece di auto-guarire.

## Fix
`GoLiveSessionCommandHandler` ora ramifica sullo stato del link target:
- **Pending** → promuove (StartSession + save, con i catch xmin/23505→409).
- **InProgress** → **self-heal**: salta la scrittura sull'aggregato e va dritto a dispatchare `OpenSessionLiveModeCommand` (idempotente: guarisce una Session non-ancora-live, no-op se già live).
- **terminale** (Completed/Skipped/Corrupted) → 409.
- not-found → 404; non-organizer → 403 (invariati).

## Test
2 unit nuovi (self-heal + idempotent already-live) + terminale→409 rafforzato + 1 Testcontainers (retry dopo split-brain → Session guarita live). **8 unit + 2 integration, tutti verdi** (Docker girato, 53s). Build clean.

Closes #3218 · Refs #3188

🤖 Generated with [Claude Code](https://claude.com/claude-code)