### PR TITLE
fix(game-night): #3217 make startGame retry-safe (no orphan drafts)

### DIFF
--- a/apps/web/src/lib/domain-hooks/__tests__/useGameNightOrchestrator.test.ts
+++ b/apps/web/src/lib/domain-hooks/__tests__/useGameNightOrchestrator.test.ts
@@ -2,7 +2,8 @@ import { renderHook, act } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 import { useGameNightOrchestrator } from '../useGameNightOrchestrator';
-import { createSession, goLive } from '@/lib/api/clients/gameSessionsClient';
+import { createSession, goLive, finalizeSession } from '@/lib/api/clients/gameSessionsClient';
+import { ConflictError } from '@/lib/api/core/errors';
 import { useSessionStore } from '@/stores/session/store';
 
 // Mock API call
@@ -23,8 +24,19 @@ describe('useGameNightOrchestrator', () => {
   beforeEach(() => {
     localStorage.clear();
     useSessionStore.getState().reset();
-    vi.mocked(createSession).mockClear();
-    vi.mocked(goLive).mockClear();
+    // Reset implementations too so per-test *Once overrides don't leak between tests.
+    vi.mocked(createSession).mockReset();
+    vi.mocked(goLive).mockReset();
+    vi.mocked(finalizeSession).mockReset();
+    vi.mocked(createSession).mockResolvedValue({ sessionId: 'new-sess-1', code: 'ABC-123' });
+    vi.mocked(finalizeSession).mockResolvedValue(undefined);
+    vi.mocked(goLive).mockResolvedValue({
+      sessionId: 'new-sess-1',
+      gameNightId: 'night-1',
+      gameNightSessionId: 'gns-1',
+      playOrder: 1,
+      status: 'InProgress',
+    });
   });
 
   it('startGame crea una sessione DRAFT, la porta live e aggiorna lo store', async () => {
@@ -75,5 +87,139 @@ describe('useGameNightOrchestrator', () => {
     const store = useSessionStore.getState();
     expect(store.gameTitle).toBe('Dixit');
     expect(store.currentTurn).toBe(1); // reset per nuovo gioco
+  });
+
+  it('riprova lo stesso gioco dopo un go-live fallito: riusa il draft (createSession una sola volta)', async () => {
+    // Issue #3217: go-live fallisce alla prima, poi riesce. Il draft NON deve essere ricreato.
+    vi.mocked(goLive).mockRejectedValueOnce(new Error('network blip'));
+
+    const { result } = renderHook(() => useGameNightOrchestrator('night-1'));
+    const payload = {
+      gameId: 'game-1',
+      gameTitle: 'Catan',
+      participants: [{ id: 'p1', displayName: 'Marco', isGuest: false }],
+    };
+
+    // 1° tentativo: go-live rigetta → il draft resta "pending" (nessun orfano ricreato dopo)
+    await act(async () => {
+      await expect(result.current.startGame(payload)).rejects.toThrow('network blip');
+    });
+
+    // 2° tentativo: stesso gioco → riusa il draft, go-live riesce, store live
+    await act(async () => {
+      await result.current.startGame(payload);
+    });
+
+    // Il draft è stato creato UNA SOLA VOLTA (nessun orfano accumulato)
+    expect(createSession).toHaveBeenCalledTimes(1);
+    // go-live è stato invocato due volte (fail + retry self-healing)
+    expect(goLive).toHaveBeenCalledTimes(2);
+    // Nessuna compensazione: stesso gioco → nessun finalize del draft
+    expect(finalizeSession).not.toHaveBeenCalled();
+
+    const store = useSessionStore.getState();
+    expect(store.status).toBe('live');
+    expect(store.sessionId).toBe('new-sess-1');
+  });
+
+  it('nessun accumulo di orfani su double-tap: createSession al massimo una volta', async () => {
+    const { result } = renderHook(() => useGameNightOrchestrator('night-1'));
+    const payload = {
+      gameId: 'game-1',
+      gameTitle: 'Catan',
+      participants: [{ id: 'p1', displayName: 'Marco', isGuest: false }],
+    };
+
+    // Due chiamate ravvicinate (double-tap): la seconda deve essere bloccata dal guard.
+    await act(async () => {
+      const first = result.current.startGame(payload);
+      const second = result.current.startGame(payload);
+      await Promise.all([first, second]);
+    });
+
+    expect(vi.mocked(createSession).mock.calls.length).toBeLessThanOrEqual(1);
+    expect(createSession).toHaveBeenCalledTimes(1);
+
+    const store = useSessionStore.getState();
+    expect(store.status).toBe('live');
+  });
+
+  it('gioco diverso dopo un fallimento: compensa il draft abbandonato e ne crea uno nuovo', async () => {
+    // Draft per il gioco A
+    vi.mocked(createSession)
+      .mockResolvedValueOnce({ sessionId: 'A-id', code: 'AAA-111' })
+      .mockResolvedValueOnce({ sessionId: 'B-id', code: 'BBB-222' });
+    // go-live del gioco A fallisce; quello del gioco B (default) riesce
+    vi.mocked(goLive).mockRejectedValueOnce(new Error('go-live A failed'));
+
+    const { result } = renderHook(() => useGameNightOrchestrator('night-1'));
+
+    // Tentativo gioco A → go-live fallisce, draft 'A-id' resta pending
+    await act(async () => {
+      await expect(
+        result.current.startGame({
+          gameId: 'game-A',
+          gameTitle: 'Catan',
+          participants: [{ id: 'p1', displayName: 'Marco', isGuest: false }],
+        })
+      ).rejects.toThrow('go-live A failed');
+    });
+
+    // Tentativo gioco B → compensa 'A-id', crea draft 'B-id'
+    await act(async () => {
+      await result.current.startGame({
+        gameId: 'game-B',
+        gameTitle: 'Dixit',
+        participants: [{ id: 'p1', displayName: 'Marco', isGuest: false }],
+      });
+    });
+
+    // Compensazione del draft abbandonato del gioco A
+    expect(finalizeSession).toHaveBeenCalledWith('A-id');
+    // Due draft creati (A abbandonato, B nuovo)
+    expect(createSession).toHaveBeenCalledTimes(2);
+
+    const store = useSessionStore.getState();
+    expect(store.status).toBe('live');
+    expect(store.sessionId).toBe('B-id');
+    expect(store.gameTitle).toBe('Dixit');
+  });
+
+  it('mantiene lo stato di errore ConflictError e rilancia', async () => {
+    vi.mocked(goLive).mockRejectedValueOnce(new ConflictError({ message: 'already live' }));
+
+    const { result } = renderHook(() => useGameNightOrchestrator('night-1'));
+
+    await act(async () => {
+      await expect(
+        result.current.startGame({
+          gameId: 'game-1',
+          gameTitle: 'Catan',
+          participants: [{ id: 'p1', displayName: 'Marco', isGuest: false }],
+        })
+      ).rejects.toBeInstanceOf(ConflictError);
+    });
+
+    expect(result.current.error).toBe(
+      'Una partita è già attiva per questa serata. Finalizzala prima di iniziarne una nuova.'
+    );
+  });
+
+  it('mantiene lo stato di errore generico e rilancia', async () => {
+    vi.mocked(goLive).mockRejectedValueOnce(new Error('boom'));
+
+    const { result } = renderHook(() => useGameNightOrchestrator('night-1'));
+
+    await act(async () => {
+      await expect(
+        result.current.startGame({
+          gameId: 'game-1',
+          gameTitle: 'Catan',
+          participants: [{ id: 'p1', displayName: 'Marco', isGuest: false }],
+        })
+      ).rejects.toThrow('boom');
+    });
+
+    expect(result.current.error).toBe('Impossibile avviare la partita. Riprova.');
   });
 });

--- a/apps/web/src/lib/domain-hooks/useGameNightOrchestrator.ts
+++ b/apps/web/src/lib/domain-hooks/useGameNightOrchestrator.ts
@@ -35,33 +35,71 @@ export function useGameNightOrchestrator(gameNightId: string): UseGameNightOrche
   const [isStarting, setIsStarting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const isStartingRef = useRef(false);
+  // Issue #3217: tracks the draft created but not yet promoted to live. If go-live fails, the
+  // draft would otherwise be orphaned — an Active tracking session counting against the global
+  // session quota (SessionQuotaService, Free tier = 3). Keeping the ref lets a same-game retry
+  // REUSE the existing draft (go-live is idempotent/self-healing since #3218) instead of piling
+  // up new drafts, so at most ONE pending draft exists at any time.
+  const pendingDraftRef = useRef<{ sessionId: string; gameId: string } | null>(null);
 
-  const startGame = useCallback(
+  // Core start routine WITHOUT the double-tap guard. Both public entry points (startGame,
+  // startNextGame) acquire the shared isStartingRef guard exactly once, then delegate here —
+  // this keeps ONE guard consistent across the two and avoids the self-deadlock that would
+  // occur if startNextGame set the ref and then called a self-guarding startGame.
+  const startGameCore = useCallback(
     async (payload: StartGamePayload) => {
       setIsStarting(true);
       setError(null);
       try {
-        // Epic #3188 Slice 3 (D5): create now yields a DRAFT (Pending). startGame's intent is to
-        // START PLAYING, so promote the fresh draft to live via the explicit go-live sub-resource.
-        const response = await createSession({
-          gameNightId,
-          gameId: payload.gameId,
-          participants: payload.participants.map(p => ({
-            displayName: p.displayName,
-            userId: p.userId,
-            isGuest: p.isGuest,
-          })),
-        });
+        // Resolve the sessionId to promote WITHOUT accumulating orphan drafts.
+        let sessionId: string;
+        const pending = pendingDraftRef.current;
 
-        await goLive(response.sessionId);
+        if (pending && pending.gameId === payload.gameId) {
+          // Same-game retry: a previous attempt already created this draft but go-live failed.
+          // Reuse it (go-live self-heals per #3218) — do NOT create a duplicate draft.
+          sessionId = pending.sessionId;
+        } else {
+          // A draft for a DIFFERENT game is lingering — best-effort compensate it so it doesn't
+          // count against the quota, then fall through to create a fresh draft.
+          if (pending) {
+            try {
+              await finalizeSession(pending.sessionId);
+            } catch {
+              // best-effort compensation — swallow; the draft can still be reaped server-side
+            }
+            pendingDraftRef.current = null;
+          }
+
+          // Epic #3188 Slice 3 (D5): create now yields a DRAFT (Pending). startGame's intent is
+          // to START PLAYING, so promote the fresh draft to live via the go-live sub-resource.
+          const response = await createSession({
+            gameNightId,
+            gameId: payload.gameId,
+            participants: payload.participants.map(p => ({
+              displayName: p.displayName,
+              userId: p.userId,
+              isGuest: p.isGuest,
+            })),
+          });
+          sessionId = response.sessionId;
+          pendingDraftRef.current = { sessionId, gameId: payload.gameId };
+        }
+
+        await goLive(sessionId);
+
+        // Success: the draft is now live — it is no longer "pending". Clear the ref so a later
+        // start doesn't mistake this (now-live) session for an abandoned draft.
+        pendingDraftRef.current = null;
 
         startSession({
-          sessionId: response.sessionId,
+          sessionId,
           gameId: payload.gameId,
           gameTitle: payload.gameTitle,
           participants: payload.participants,
         });
       } catch (err: unknown) {
+        // Keep pendingDraftRef so a same-game retry reuses the draft instead of creating a new one.
         if (err instanceof ConflictError) {
           setError(
             'Una partita è già attiva per questa serata. Finalizzala prima di iniziarne una nuova.'
@@ -77,9 +115,25 @@ export function useGameNightOrchestrator(gameNightId: string): UseGameNightOrche
     [gameNightId, startSession]
   );
 
+  const startGame = useCallback(
+    async (payload: StartGamePayload) => {
+      // Synchronous ref-based guard against double-tap (state updates are async). Previously
+      // startGame lacked this, so a double-tap created multiple orphan drafts (issue #3217).
+      if (isStartingRef.current) return;
+      isStartingRef.current = true;
+      try {
+        await startGameCore(payload);
+      } finally {
+        isStartingRef.current = false;
+      }
+    },
+    [startGameCore]
+  );
+
   const startNextGame = useCallback(
     async (payload: StartGamePayload) => {
-      // Synchronous ref-based guard against double-tap (state updates are async)
+      // Same shared guard as startGame; acquire it here and delegate to startGameCore (NOT
+      // startGame) so the guard isn't re-checked from within — that would self-deadlock.
       if (isStartingRef.current) return;
       isStartingRef.current = true;
 
@@ -108,13 +162,13 @@ export function useGameNightOrchestrator(gameNightId: string): UseGameNightOrche
         // 2. Reset store per il nuovo gioco
         reset();
 
-        // 3. Avvia nuovo gioco
-        await startGame(payload);
+        // 3. Avvia nuovo gioco (senza riacquisire il guard condiviso)
+        await startGameCore(payload);
       } finally {
         isStartingRef.current = false;
       }
     },
-    [reset, startGame]
+    [reset, startGameCore]
   );
 
   return { completedGames, isStarting, error, startGame, startNextGame };


### PR DESCRIPTION
**Follow-up** dalla holistic review di #3188 (finding MEDIUM, blast radius latente).

## Problema
`useGameNightOrchestrator.startGame` crea un **draft** (`createSession`, Pending per D1) poi va live (`goLive`) in due chiamate. Se il go-live fallisce, il draft resta **orfano** (Session `Active`); e senza double-tap guard su `startGame`, tap ripetuti creano N draft orfani che erodono la quota sessioni globale dell'utente (`SessionQuotaService` conta qualsiasi sessione non-`Finalized`; free = 3).

## Fix — retry-safe & idempotente (al massimo 1 draft pendente)
- Estratto `startGameCore` (senza guard); `startGame` + `startNextGame` acquisiscono lo stesso `isStartingRef` guard **una volta** e delegano a `startGameCore` → nessun self-deadlock, double-tap coperto.
- `pendingDraftRef{sessionId,gameId}`: retry **stesso gioco** → **riusa** il draft (il go-live ora **self-heals**, #3218) invece di crearne uno nuovo; **gioco diverso** → finalizza best-effort il draft stale; successo → pulisce il ref; fallimento → lo tiene per il retry.

Sfrutta il self-heal di #3218 → nessun endpoint "discard" necessario, nessun accumulo di orfani.

## Test
7 pass: retry-stesso-gioco (`createSession` una volta, `goLive` due, no finalize), no accumulo su double-tap, gioco-diverso con finalize compensativo, ConflictError vs errore generico preservati. tsc + eslint clean.

Closes #3217 · Refs #3188

🤖 Generated with [Claude Code](https://claude.com/claude-code)