### PR TITLE
fix(security): #3222 PDF access control — IDOR + missing authz su active/classify

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Queries/GetPdfTextQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Queries/GetPdfTextQuery.cs
@@ -8,7 +8,9 @@ namespace Api.BoundedContexts.DocumentProcessing.Application.Queries;
 /// Returns full text content for display/download.
 /// </summary>
 internal sealed record GetPdfTextQuery(
-    Guid PdfId
+    Guid PdfId,
+    Guid UserId,
+    bool IsAdmin
 ) : IQuery<PdfTextResult?>;
 
 /// <summary>

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Queries/GetPdfTextQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Queries/GetPdfTextQueryHandler.cs
@@ -31,7 +31,8 @@ internal class GetPdfTextQueryHandler : IQueryHandler<GetPdfTextQuery, PdfTextRe
             var pdf = await _dbContext.PdfDocuments
                 .Where(p => p.Id == query.PdfId)
                 .AsNoTracking()
-                .Select(p => new PdfTextResult(
+                .Select(p => new
+                {
                     p.Id,
                     p.FileName,
                     p.ExtractedText,
@@ -39,16 +40,41 @@ internal class GetPdfTextQueryHandler : IQueryHandler<GetPdfTextQuery, PdfTextRe
                     p.ProcessedAt,
                     p.PageCount,
                     p.CharacterCount,
-                    p.ProcessingError
-                ))
+                    p.ProcessingError,
+                    p.SharedGameId,
+                    p.UploadedByUserId
+                })
                 .FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
 
             if (pdf == null)
             {
                 _logger.LogWarning("PDF {PdfId} not found", query.PdfId);
+                return null;
             }
 
-            return pdf;
+            // Issue #3222 — Authorization: shared-game PDFs are public (citation viewer); private
+            // PDFs require ownership; admins bypass (the admin-queue extracted-text tool reads any
+            // PDF). Return null (→ 404, no info leak) otherwise, so a non-owner cannot read another
+            // user's private rulebook text.
+            var isSharedGamePdf = pdf.SharedGameId.HasValue;
+            var isOwner = pdf.UploadedByUserId == query.UserId;
+            if (!query.IsAdmin && !isSharedGamePdf && !isOwner)
+            {
+                _logger.LogWarning(
+                    "User {UserId} denied access to PDF text for {PdfId} (owner: {OwnerId})",
+                    query.UserId, query.PdfId, pdf.UploadedByUserId);
+                return null;
+            }
+
+            return new PdfTextResult(
+                pdf.Id,
+                pdf.FileName,
+                pdf.ExtractedText,
+                pdf.ProcessingState,
+                pdf.ProcessedAt,
+                pdf.PageCount,
+                pdf.CharacterCount,
+                pdf.ProcessingError);
         }
 #pragma warning disable CA1031 // Do not catch general exception types
 #pragma warning disable S125 // Sections of code should not be commented out

--- a/apps/api/src/Api/Routing/AdminQueueEndpoints.cs
+++ b/apps/api/src/Api/Routing/AdminQueueEndpoints.cs
@@ -339,10 +339,15 @@ internal static class AdminQueueEndpoints
 
     private static async Task<IResult> HandleGetExtractedText(
         Guid pdfDocumentId,
+        HttpContext context,
         IMediator mediator,
         CancellationToken ct)
     {
-        var result = await mediator.Send(new GetPdfTextQuery(pdfDocumentId), ct).ConfigureAwait(false);
+        // Issue #3222: admin-only queue tool (group is admin-gated) that must read the extracted
+        // text of any PDF, so it authorizes as admin.
+        var (_, session, _) = context.RequireAdminSession();
+        var userId = session.Principal!.Subject.Id;
+        var result = await mediator.Send(new GetPdfTextQuery(pdfDocumentId, userId, IsAdmin: true), ct).ConfigureAwait(false);
         return result is null ? Results.NotFound() : Results.Ok(result);
     }
 

--- a/apps/api/src/Api/Routing/Pdf/PdfRetrievalEndpoints.cs
+++ b/apps/api/src/Api/Routing/Pdf/PdfRetrievalEndpoints.cs
@@ -129,9 +129,10 @@ internal static class PdfRetrievalEndpoints
         .WithName("SetActiveForRag");
 
         // Issue #5447: Reclassify document (category, base document, version label)
+        // Issue #3222: admin-only (was any authenticated user) — reclassify can re-parent
+        // BaseDocumentId across documents owned by other users.
         group.MapPatch("/documents/{pdfId:guid}/classify", HandleReclassifyDocument)
-        .RequireSession()
-        .RequireAuthorization()
+        .RequireAdminSession()
         .WithName("ReclassifyDocument");
     }
 
@@ -155,9 +156,15 @@ internal static class PdfRetrievalEndpoints
         return Results.Json(new { pdfs });
     }
 
-    private static async Task<IResult> HandleGetPdfText(Guid pdfId, IMediator mediator, CancellationToken ct)
+    private static async Task<IResult> HandleGetPdfText(Guid pdfId, HttpContext context, IMediator mediator, CancellationToken ct)
     {
-        var pdf = await mediator.Send(new GetPdfTextQuery(pdfId), ct).ConfigureAwait(false);
+        // Issue #3222: pass the caller's id + admin flag so the handler can enforce
+        // owner-or-shared-game access (admins bypass).
+        var session = (SessionStatusDto)context.Items[nameof(SessionStatusDto)]!;
+        var userId = session!.Principal!.Subject.Id;
+        bool isAdmin = string.Equals(session!.Principal!.EffectiveActor.Role, UserRole.Admin.ToString(), StringComparison.OrdinalIgnoreCase);
+
+        var pdf = await mediator.Send(new GetPdfTextQuery(pdfId, userId, isAdmin), ct).ConfigureAwait(false);
 
         if (pdf == null)
         {
@@ -344,13 +351,38 @@ internal static class PdfRetrievalEndpoints
 
     /// <summary>
     /// Issue #5446: Toggle RAG active flag for a PDF document.
+    /// Issue #3222: owner-or-admin only (mirror HandleSetPdfVisibility); the RAG-active flag is a
+    /// shared document-level field, so an arbitrary authenticated user must not toggle it.
     /// </summary>
     private static async Task<IResult> HandleSetActiveForRag(
         Guid pdfId,
+        HttpContext context,
         [FromBody] SetActiveForRagRequest request,
         IMediator mediator,
+        AuditService auditService,
+        ILogger<Program> logger,
         CancellationToken ct)
     {
+        var session = (SessionStatusDto)context.Items[nameof(SessionStatusDto)]!;
+        var userId = session!.Principal!.Subject.Id;
+
+        var pdf = await mediator.Send(new GetPdfOwnershipQuery(pdfId), ct).ConfigureAwait(false);
+
+        if (pdf == null)
+        {
+            return Results.NotFound(new { error = "PDF not found" });
+        }
+
+        if (!CheckPdfAuthorization(session.Principal!.Subject, pdf))
+        {
+            await LogPdfAccessDeniedAsync(auditService, userId.ToString(), "change RAG-active flag of", pdfId.ToString(), session.Principal!.EffectiveActor.Role ?? "Unknown", pdf.UploadedByUserId, ct).ConfigureAwait(false);
+
+            logger.LogWarning("User {UserId} denied access to change RAG-active flag of PDF {PdfId} (owner: {OwnerId})",
+                userId, pdfId, pdf.UploadedByUserId);
+
+            return Results.Forbid();
+        }
+
         var result = await mediator.Send(new SetActiveForRagCommand(pdfId, request.IsActive), ct).ConfigureAwait(false);
 
         if (!result.Success)

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Handlers/GetPdfTextQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Handlers/GetPdfTextQueryHandlerTests.cs
@@ -68,16 +68,19 @@ public class GetPdfTextQueryHandlerTests
         act.Should().Throw<ArgumentNullException>();
     }
     [Fact]
-    public void Query_HasCorrectPdfIdProperty()
+    public void Query_HasCorrectProperties()
     {
         // Arrange
         var pdfId = Guid.NewGuid();
+        var userId = Guid.NewGuid();
 
         // Act
-        var query = new GetPdfTextQuery(pdfId);
+        var query = new GetPdfTextQuery(pdfId, userId, IsAdmin: true);
 
         // Assert
         query.PdfId.Should().Be(pdfId);
+        query.UserId.Should().Be(userId);
+        query.IsAdmin.Should().BeTrue();
     }
     [Fact]
     public void PdfTextResult_ConstructsCorrectly()

--- a/apps/api/tests/Api.Tests/Integration/DocumentProcessing/PdfAuthorizationIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/DocumentProcessing/PdfAuthorizationIntegrationTests.cs
@@ -1,0 +1,194 @@
+using System.Net;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.Integration.DocumentProcessing;
+
+/// <summary>
+/// HTTP-layer authorization tests for PDF retrieval/mutation endpoints (issue #3222).
+///
+/// Covers three broken-access-control gaps, each mirroring a sibling that already checks correctly:
+/// - #4 IDOR: GET /api/v1/pdfs/{id}/text must not expose a private PDF's text to a non-owner
+///   (mirror of GetPdfPageTextQueryHandler: shared-game PDFs public, private PDFs owner-only, 404 otherwise).
+/// - #5 missing authz: PATCH /api/v1/documents/{id}/active must be owner-or-admin (mirror HandleSetPdfVisibility).
+/// - #6 missing admin gate: PATCH /api/v1/documents/{id}/classify must be admin-only.
+/// </summary>
+[Collection("Integration-GroupA")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "DocumentProcessing")]
+[Trait("Issue", "3222")]
+public sealed class PdfAuthorizationIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly string _testDbName;
+    private WebApplicationFactory<Program> _factory = null!;
+    private HttpClient _ownerClient = null!;
+    private HttpClient _otherClient = null!;
+    private HttpClient _adminClient = null!;
+    private string _ownerToken = null!;
+    private string _otherToken = null!;
+    private string _adminToken = null!;
+    private Guid _privatePdfId;
+    private Guid _sharedPdfId;
+
+    public PdfAuthorizationIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+        _testDbName = $"pdf_authz_{Guid.NewGuid():N}";
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_testDbName);
+        _factory = IntegrationWebApplicationFactory.Create(connectionString);
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        await db.Database.MigrateAsync();
+
+        Guid ownerId;
+        (ownerId, _ownerToken) = await TestSessionHelper.CreateUserSessionAsync(db);
+        (_, _otherToken) = await TestSessionHelper.CreateUserSessionAsync(db);
+        (_, _adminToken) = await TestSessionHelper.CreateAdminSessionAsync(db);
+
+        var sharedGameId = await TestSessionHelper.SeedSharedGameAsync(db, "Catan");
+
+        _privatePdfId = Guid.NewGuid();
+        _sharedPdfId = Guid.NewGuid();
+        db.PdfDocuments.Add(new PdfDocumentEntity
+        {
+            Id = _privatePdfId,
+            FileName = "private.pdf",
+            FilePath = "pdfs/private.pdf",
+            FileSizeBytes = 1024,
+            UploadedByUserId = ownerId,
+            UploadedAt = DateTime.UtcNow,
+            SharedGameId = null,
+            ExtractedText = "PRIVATE RULEBOOK TEXT",
+            ProcessingState = "Ready",
+            PageCount = 5,
+            CharacterCount = 21,
+        });
+        db.PdfDocuments.Add(new PdfDocumentEntity
+        {
+            Id = _sharedPdfId,
+            FileName = "shared.pdf",
+            FilePath = "pdfs/shared.pdf",
+            FileSizeBytes = 1024,
+            UploadedByUserId = ownerId,
+            UploadedAt = DateTime.UtcNow,
+            SharedGameId = sharedGameId,
+            ExtractedText = "SHARED CATALOG RULEBOOK TEXT",
+            ProcessingState = "Ready",
+            PageCount = 5,
+            CharacterCount = 28,
+        });
+        await db.SaveChangesAsync();
+
+        _ownerClient = _factory.CreateClient();
+        _otherClient = _factory.CreateClient();
+        _adminClient = _factory.CreateClient();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _ownerClient?.Dispose();
+        _otherClient?.Dispose();
+        _adminClient?.Dispose();
+        _factory?.Dispose();
+        await _fixture.DropIsolatedDatabaseAsync(_testDbName);
+    }
+
+    private string TextUrl(Guid id) => $"/api/v1/pdfs/{id}/text";
+    private string ActiveUrl(Guid id) => $"/api/v1/documents/{id}/active";
+    private string ClassifyUrl(Guid id) => $"/api/v1/documents/{id}/classify";
+
+    // ---- #4 IDOR on GET /pdfs/{id}/text ----
+
+    [Fact(Timeout = 90_000)]
+    public async Task GetPdfText_Owner_PrivatePdf_Returns200()
+    {
+        var resp = await _ownerClient.SendAsync(
+            TestSessionHelper.CreateAuthenticatedRequest(HttpMethod.Get, TextUrl(_privatePdfId), _ownerToken));
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact(Timeout = 90_000)]
+    public async Task GetPdfText_NonOwner_PrivatePdf_Returns404()
+    {
+        var resp = await _otherClient.SendAsync(
+            TestSessionHelper.CreateAuthenticatedRequest(HttpMethod.Get, TextUrl(_privatePdfId), _otherToken));
+        resp.StatusCode.Should().Be(HttpStatusCode.NotFound);
+    }
+
+    [Fact(Timeout = 90_000)]
+    public async Task GetPdfText_NonOwner_SharedGamePdf_Returns200()
+    {
+        var resp = await _otherClient.SendAsync(
+            TestSessionHelper.CreateAuthenticatedRequest(HttpMethod.Get, TextUrl(_sharedPdfId), _otherToken));
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact(Timeout = 90_000)]
+    public async Task GetPdfText_Admin_PrivatePdf_Returns200()
+    {
+        // Admins bypass ownership (mirrors the admin-queue extracted-text tool).
+        var resp = await _adminClient.SendAsync(
+            TestSessionHelper.CreateAuthenticatedRequest(HttpMethod.Get, TextUrl(_privatePdfId), _adminToken));
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    // ---- #5 missing authz on PATCH /documents/{id}/active ----
+
+    [Fact(Timeout = 90_000)]
+    public async Task SetActiveForRag_Owner_Returns200()
+    {
+        var resp = await _ownerClient.SendAsync(
+            TestSessionHelper.CreateAuthenticatedRequest(HttpMethod.Patch, ActiveUrl(_privatePdfId), _ownerToken, new { isActive = false }));
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    [Fact(Timeout = 90_000)]
+    public async Task SetActiveForRag_NonOwnerNonAdmin_Returns403()
+    {
+        var resp = await _otherClient.SendAsync(
+            TestSessionHelper.CreateAuthenticatedRequest(HttpMethod.Patch, ActiveUrl(_privatePdfId), _otherToken, new { isActive = false }));
+        resp.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact(Timeout = 90_000)]
+    public async Task SetActiveForRag_Admin_Returns200()
+    {
+        var resp = await _adminClient.SendAsync(
+            TestSessionHelper.CreateAuthenticatedRequest(HttpMethod.Patch, ActiveUrl(_privatePdfId), _adminToken, new { isActive = true }));
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+
+    // ---- #6 missing admin gate on PATCH /documents/{id}/classify ----
+
+    [Fact(Timeout = 90_000)]
+    public async Task Reclassify_NonAdmin_Returns403()
+    {
+        var resp = await _otherClient.SendAsync(
+            TestSessionHelper.CreateAuthenticatedRequest(HttpMethod.Patch, ClassifyUrl(_privatePdfId), _otherToken,
+                new { category = "Rulebook", baseDocumentId = (Guid?)null, versionLabel = (string?)null }));
+        resp.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact(Timeout = 90_000)]
+    public async Task Reclassify_Admin_Returns200()
+    {
+        var resp = await _adminClient.SendAsync(
+            TestSessionHelper.CreateAuthenticatedRequest(HttpMethod.Patch, ClassifyUrl(_privatePdfId), _adminToken,
+                new { category = "Rulebook", baseDocumentId = (Guid?)null, versionLabel = (string?)null }));
+        resp.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+}


### PR DESCRIPTION
## 🔒 Cosa

Corregge tre gap di **broken access control** su endpoint PDF. In ogni caso un **sibling nello stesso codebase applica già il check corretto** — questi tre erano omissioni.

| # | Endpoint | Prima | Dopo |
|---|---|---|---|
| **4** | `GET /api/v1/pdfs/{id}/text` (IDOR) | qualsiasi utente legge il testo di PDF privati altrui | shared-game pubblici; privati **owner-only**; admin bypass → non-owner **404** |
| **5** | `PATCH /api/v1/documents/{id}/active` | qualsiasi utente toggla il flag RAG-active | **owner-or-admin** → **403** |
| **6** | `PATCH /api/v1/documents/{id}/classify` | qualsiasi utente riclassifica/ri-parenta | **admin-only** → **403** |

## Perché

- **#4** `GetPdfTextQueryHandler` proiettava `ExtractedText` (corpo completo) filtrando solo su `Id`, senza ownership → un utente poteva leggere il rulebook privato di un altro enumerando i GUID. Il gemello `GetPdfPageTextQueryHandler` applica già `isSharedGamePdf || isOwner` (→ 404, no info-leak).
- **#5** Il flag RAG-active è document-level condiviso; senza check un utente poteva escludere dal RAG i rulebook curati da admin/altri. Il sibling `HandleSetPdfVisibility` fa già owner-or-admin.
- **#6** L'endpoint è documentato "Admin can reclassify" ma era gated solo `RequireAuthorization`; `Reclassify` può ri-parentare `BaseDocumentId` su documenti altrui.

## Come

- `GetPdfTextQuery` acquisisce `UserId` + `IsAdmin`; entrambi i chiamanti aggiornati (`PdfRetrievalEndpoints.HandleGetPdfText` utente, `AdminQueueEndpoints.HandleGetExtractedText` admin-bypass) + unit test.
- `HandleSetActiveForRag` replica il blocco `GetPdfOwnershipQuery` → `CheckPdfAuthorization` → `Results.Forbid()` + audit log.
- `classify` passa da `.RequireSession().RequireAuthorization()` a `.RequireAdminSession()`.
- Command/handler delle mutazioni **invariati** (l'auth resta a livello endpoint/query).

**TDD**: integration HTTP `PdfAuthorizationIntegrationTests` (`IntegrationWebApplicationFactory` + `TestSessionHelper` owner/other/admin), 9 casi RED→GREEN. Ogni test negativo visto fallire con 200 prima del fix. **Regression guard**: DocumentProcessing E2E **10/10** verde.

## Non-goals
- `/language` (`HandleOverridePdfLanguage`) ha lo stesso gap → follow-up separato.

Scoperta via discovery avversariale `/sc:spec-panel` (fan-out finder + verifica per-finding).

Closes #3222

🤖 Generated with [Claude Code](https://claude.com/claude-code)
