### PR TITLE
fix(http): #3224 exception mapping 500→409 su transizioni già-in-stato

### DIFF
--- a/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Commands/ToolkitCommandHandlers.cs
+++ b/apps/api/src/Api/BoundedContexts/GameToolkit/Application/Commands/ToolkitCommandHandlers.cs
@@ -94,6 +94,10 @@ internal class PublishToolkitCommandHandler : ICommandHandler<PublishToolkitComm
         var toolkit = await _repository.GetByIdAsync(command.ToolkitId, cancellationToken).ConfigureAwait(false)
             ?? throw new NotFoundException("GameToolkit", command.ToolkitId.ToString());
 
+        // Issue #3224: pre-check state so an already-published toolkit maps to 409 (not 500).
+        if (toolkit.IsPublished)
+            throw new ConflictException("Toolkit is already published");
+
         toolkit.Publish();
 
         await _repository.UpdateAsync(toolkit, cancellationToken).ConfigureAwait(false);

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/CloseThreadCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/CloseThreadCommandHandler.cs
@@ -1,6 +1,7 @@
 using Api.BoundedContexts.KnowledgeBase.Application.Commands;
 using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
 using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Application.Interfaces;
 using Api.SharedKernel.Infrastructure.Persistence;
 
@@ -29,6 +30,11 @@ internal class CloseThreadCommandHandler : ICommandHandler<CloseThreadCommand, C
         var thread = await _threadRepository.GetByIdAsync(command.ThreadId, cancellationToken).ConfigureAwait(false);
         if (thread == null)
             throw new InvalidOperationException($"Thread with ID {command.ThreadId} not found");
+
+        // Issue #3224: pre-check state so an already-closed thread maps to 409 (not 500); the
+        // domain guard in CloseThread() stays as defense-in-depth.
+        if (thread.Status.IsClosed)
+            throw new ConflictException("Thread is already closed");
 
         // Close thread (domain logic validates state)
         thread.CloseThread();

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/ReopenThreadCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/ReopenThreadCommandHandler.cs
@@ -1,6 +1,7 @@
 using Api.BoundedContexts.KnowledgeBase.Application.Commands;
 using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
 using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Application.Interfaces;
 using Api.SharedKernel.Infrastructure.Persistence;
 
@@ -29,6 +30,11 @@ internal class ReopenThreadCommandHandler : ICommandHandler<ReopenThreadCommand,
         var thread = await _threadRepository.GetByIdAsync(command.ThreadId, cancellationToken).ConfigureAwait(false);
         if (thread == null)
             throw new InvalidOperationException($"Thread with ID {command.ThreadId} not found");
+
+        // Issue #3224: pre-check state so an already-active thread maps to 409 (not 500); the
+        // domain guard in ReopenThread() stays as defense-in-depth.
+        if (thread.Status.IsActive)
+            throw new ConflictException("Thread is already active");
 
         // Reopen thread (domain logic validates state)
         thread.ReopenThread();

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameToolkit/Application/Handlers/ToolkitCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameToolkit/Application/Handlers/ToolkitCommandHandlerTests.cs
@@ -129,6 +129,23 @@ public class ToolkitCommandHandlerTests
         await act3.Should().ThrowAsync<NotFoundException>();
     }
 
+    [Fact]
+    public async Task PublishToolkit_AlreadyPublished_ThrowsConflictException()
+    {
+        // Issue #3224: re-publishing an already-published toolkit is a 409, not a 500.
+        var toolkit = CreateTestToolkit();
+        toolkit.Publish(); // now Published
+        _repoMock.Setup(r => r.GetByIdAsync(toolkit.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(toolkit);
+
+        var handler = new PublishToolkitCommandHandler(_repoMock.Object, _uowMock.Object);
+
+        var act = () =>
+            handler.Handle(new PublishToolkitCommand(toolkit.Id), TestContext.Current.CancellationToken);
+        await act.Should().ThrowAsync<ConflictException>().WithMessage("*already published*");
+        _uowMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
     // ========================================================================
     // AddDiceToolCommandHandler
     // ========================================================================

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/ThreadLifecycleConflictTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/ThreadLifecycleConflictTests.cs
@@ -1,0 +1,54 @@
+using Api.BoundedContexts.KnowledgeBase.Application.Commands;
+using Api.BoundedContexts.KnowledgeBase.Domain.Entities;
+using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Handlers;
+
+/// <summary>
+/// Issue #3224: closing an already-closed thread / reopening an already-active thread must map to
+/// 409 Conflict, not 500. Before the fix the handlers let the domain guard throw a bare
+/// InvalidOperationException which the middleware maps to 500.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "KnowledgeBase")]
+[Trait("Issue", "3224")]
+public sealed class ThreadLifecycleConflictTests
+{
+    private readonly Mock<IChatThreadRepository> _threadRepoMock = new();
+    private readonly Mock<IUnitOfWork> _uowMock = new();
+
+    [Fact]
+    public async Task CloseThread_AlreadyClosed_ThrowsConflictException()
+    {
+        var thread = new ChatThread(Guid.NewGuid(), Guid.NewGuid());
+        thread.CloseThread(); // now Closed
+        _threadRepoMock.Setup(r => r.GetByIdAsync(thread.Id, It.IsAny<CancellationToken>())).ReturnsAsync(thread);
+
+        var handler = new CloseThreadCommandHandler(_threadRepoMock.Object, _uowMock.Object);
+        Func<Task> act = () => handler.Handle(new CloseThreadCommand(thread.Id), CancellationToken.None);
+
+        await act.Should().ThrowAsync<ConflictException>().WithMessage("*already closed*");
+        _threadRepoMock.Verify(r => r.UpdateAsync(It.IsAny<ChatThread>(), It.IsAny<CancellationToken>()), Times.Never);
+        _uowMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task ReopenThread_AlreadyActive_ThrowsConflictException()
+    {
+        var thread = new ChatThread(Guid.NewGuid(), Guid.NewGuid()); // Active by default
+        _threadRepoMock.Setup(r => r.GetByIdAsync(thread.Id, It.IsAny<CancellationToken>())).ReturnsAsync(thread);
+
+        var handler = new ReopenThreadCommandHandler(_threadRepoMock.Object, _uowMock.Object);
+        Func<Task> act = () => handler.Handle(new ReopenThreadCommand(thread.Id), CancellationToken.None);
+
+        await act.Should().ThrowAsync<ConflictException>().WithMessage("*already active*");
+        _threadRepoMock.Verify(r => r.UpdateAsync(It.IsAny<ChatThread>(), It.IsAny<CancellationToken>()), Times.Never);
+        _uowMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Never);
+    }
+}


### PR DESCRIPTION
## Cosa

Tre command handler transizionano lo stato di un aggregato **senza pre-check**: quando lo stato è già quello finale, il metodo di dominio lancia `InvalidOperationException` → il middleware la mappa a **500**. La semantica corretta è **409 Conflict** (doppio click / retry / UI stale).

| Handler | Condizione | Prima → Dopo |
|---|---|---|
| `CloseThreadCommandHandler` | thread già `Closed` | 500 → **409** |
| `ReopenThreadCommandHandler` | thread già `Active` | 500 → **409** |
| `PublishToolkitCommandHandler` | toolkit già `Published` | 500 → **409** |

## Come

Pre-check di stato → `ConflictException` prima della transizione, replicando il pattern già presente (`CloneFromTemplateCommandHandler`, `LinkAgentToPrivateGameCommandHandler`). Il domain guard resta come difesa in profondità.

**TDD**: unit test (mock repo + `IUnitOfWork`) RED→GREEN per ciascuno; `UpdateAsync`/`SaveChangesAsync` mai chiamati sul path di conflitto. **Regression guard**: ChatThread domain + Chat E2E **69** verdi; ToolkitCommandHandler **20** verdi.

Scoperta via discovery avversariale `/sc:spec-panel`.

Closes #3224

🤖 Generated with [Claude Code](https://claude.com/claude-code)
