### PR TITLE
fix(chat): #3226 game title con $ corrompe welcome message + system prompt

### DIFF
--- a/apps/web/src/app/api/chat-proxy/__tests__/route.test.ts
+++ b/apps/web/src/app/api/chat-proxy/__tests__/route.test.ts
@@ -243,6 +243,20 @@ describe('POST /api/chat-proxy', () => {
       expect(completeEvents).toHaveLength(1);
     });
 
+    it('injects the game name into the system prompt verbatim even with $ sequences', async () => {
+      // #3226 regression: gameName was the replacement string in buildSystemPrompt.
+      const { fetchCall } = await callProxyAndConsume(
+        fetchMock,
+        createValidBody({ gameContext: { gameName: 'A$$B $& Co', agentTypology: 'Tutor' } })
+      );
+      const sentBody = JSON.parse((fetchCall[1] as RequestInit).body as string);
+      const systemMsg = (sentBody.messages as Array<{ role: string; content: string }>).find(
+        m => m.role === 'system'
+      );
+      expect(systemMsg?.content).toContain('A$$B $& Co');
+      expect(systemMsg?.content).not.toContain('{gameName}');
+    });
+
     it('sends StateUpdate event at stream start', async () => {
       const { events } = await callProxyAndConsume(fetchMock, createValidBody());
 

--- a/apps/web/src/app/api/chat-proxy/route.ts
+++ b/apps/web/src/app/api/chat-proxy/route.ts
@@ -99,7 +99,9 @@ setInterval(() => {
 // ============================================================================
 
 function buildSystemPrompt(gameContext: ChatProxyRequest['gameContext']): string {
-  let prompt = DEFAULT_SYSTEM_PROMPT.replace(/{gameName}/g, gameContext.gameName);
+  // #3226: replacer function inserts gameName verbatim (a title with $&/$$ would otherwise be
+  // interpreted as a replacement pattern and corrupt the system prompt).
+  let prompt = DEFAULT_SYSTEM_PROMPT.replace(/{gameName}/g, () => gameContext.gameName);
 
   if (gameContext.ragContext) {
     prompt += `\n\nContesto dalla knowledge base:\n${gameContext.ragContext}`;

--- a/apps/web/src/config/__tests__/agent-welcome.test.ts
+++ b/apps/web/src/config/__tests__/agent-welcome.test.ts
@@ -58,6 +58,13 @@ describe('agent-welcome config', () => {
       expect(message).not.toContain('{game}');
     });
 
+    it('inserts a game title containing $ sequences verbatim', () => {
+      // #3226 regression: gameName was passed as the replacement string, so $$ / $& were interpreted.
+      const message = buildWelcomeMessage('Tutor', 'A$$B $& Co');
+      expect(message).toContain('A$$B $& Co');
+      expect(message).not.toContain('{game}');
+    });
+
     it('includes capabilities list', () => {
       const message = buildWelcomeMessage('Tutor', 'Catan');
       expect(message).toContain('Cosa posso fare');
@@ -99,6 +106,15 @@ describe('agent-welcome config', () => {
         expect(q).not.toContain('{game}');
       }
       expect(questions.some(q => q.includes('Catan'))).toBe(true);
+    });
+
+    it('inserts a game title containing $ sequences verbatim', () => {
+      // #3226 regression.
+      const questions = getWelcomeFollowUpQuestions('Tutor', 'A$$B $& Co');
+      for (const q of questions) {
+        expect(q).not.toContain('{game}');
+      }
+      expect(questions.some(q => q.includes('A$$B $& Co'))).toBe(true);
     });
 
     it('returns default questions for null typology', () => {

--- a/apps/web/src/config/agent-welcome.ts
+++ b/apps/web/src/config/agent-welcome.ts
@@ -71,15 +71,15 @@ const WELCOME_CONFIGS: Record<string, AgentWelcomeConfig> = {
   },
   Narratore: {
     greeting:
-      'Benvenuto nel mondo di {game}! Lascia che ti racconti la storia e l\'ambientazione di questo gioco straordinario.',
+      "Benvenuto nel mondo di {game}! Lascia che ti racconti la storia e l'ambientazione di questo gioco straordinario.",
     capabilities: [
-      'Raccontare la lore e l\'ambientazione del gioco',
+      "Raccontare la lore e l'ambientazione del gioco",
       'Creare atmosfera durante le partite',
       'Descrivere scenari e personaggi',
-      'Rendere l\'esperienza di gioco più immersiva',
+      "Rendere l'esperienza di gioco più immersiva",
     ],
     followUpQuestions: [
-      'Raccontami l\'ambientazione di {game}',
+      "Raccontami l'ambientazione di {game}",
       'Chi sono i personaggi principali?',
       'Qual è la storia dietro questo gioco?',
     ],
@@ -118,15 +118,12 @@ export function getAgentWelcome(typology: string | null | undefined): AgentWelco
 /**
  * Build a complete welcome message string with capabilities list.
  */
-export function buildWelcomeMessage(
-  typology: string | null | undefined,
-  gameName: string
-): string {
+export function buildWelcomeMessage(typology: string | null | undefined, gameName: string): string {
   const config = getAgentWelcome(typology);
-  const greeting = config.greeting.replace(/{game}/g, gameName);
-  const capabilities = config.capabilities
-    .map(c => `• ${c}`)
-    .join('\n');
+  // #3226: replacer function inserts gameName verbatim (a title with $&/$$ would otherwise be
+  // interpreted as a replacement pattern and corrupt the text).
+  const greeting = config.greeting.replace(/{game}/g, () => gameName);
+  const capabilities = config.capabilities.map(c => `• ${c}`).join('\n');
 
   return `${greeting}\n\n**Cosa posso fare:**\n${capabilities}`;
 }
@@ -139,5 +136,6 @@ export function getWelcomeFollowUpQuestions(
   gameName: string
 ): string[] {
   const config = getAgentWelcome(typology);
-  return config.followUpQuestions.map(q => q.replace(/{game}/g, gameName));
+  // #3226: replacer function inserts gameName verbatim (see buildWelcomeMessage).
+  return config.followUpQuestions.map(q => q.replace(/{game}/g, () => gameName));
 }


### PR DESCRIPTION
## Cosa
Due call-site interpolavano un **game title dinamico** come stringa di sostituzione di `String.prototype.replace`: un titolo con `$&`/`$$`/`` $` ``/`$'` veniva interpretato come replacement pattern e corrompeva l'output.

- `config/agent-welcome.ts` (`buildWelcomeMessage`, `getWelcomeFollowUpQuestions`): welcome message + follow-up questions della chat in-game renderizzavano testo corrotto.
- `app/api/chat-proxy/route.ts` (`buildSystemPrompt`): il system prompt LLM veniva costruito con nome gioco corrotto → grounding degradato.

## Fix
Replacer **function** `(() => value)` → inserisce il valore verbatim.

**TDD (Vitest)**: test con titolo contenente `$$`/`$&` → output verbatim, nessun placeholder re-iniettato. RED→GREEN, 46 test verdi.

Scoperta via discovery avversariale `/sc:spec-panel`.

Closes #3226

🤖 Generated with [Claude Code](https://claude.com/claude-code)