### PR TITLE
fix(perf): #3228 serialize parallel queries sharing one scoped DbContext (EF concurrency)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/ExportUserDataCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/ExportUserDataCommandHandler.cs
@@ -49,20 +49,14 @@ internal sealed class ExportUserDataCommandHandler
         if (user is null)
             throw new NotFoundException("User", command.UserId.ToString());
 
-        // Gather data from all bounded contexts in parallel
-        var libraryTask = _libraryRepository.GetUserGamesAsync(command.UserId, cancellationToken: cancellationToken);
-        var chatThreadsTask = _chatThreadRepository.FindByUserIdAsync(command.UserId, cancellationToken);
-        var notificationsTask = _notificationRepository.GetByUserIdAsync(command.UserId, unreadOnly: false, limit: 10000, cancellationToken: cancellationToken);
-        var aiConsentTask = _aiConsentRepository.GetByUserIdAsync(command.UserId, cancellationToken);
-        var memoryCountTask = _conversationMemoryRepository.CountByUserIdAsync(command.UserId, cancellationToken);
-
-        await Task.WhenAll(libraryTask, chatThreadsTask, notificationsTask, aiConsentTask, memoryCountTask).ConfigureAwait(false);
-
-        var library = await libraryTask.ConfigureAwait(false);
-        var chatThreads = await chatThreadsTask.ConfigureAwait(false);
-        var notifications = await notificationsTask.ConfigureAwait(false);
-        var aiConsent = await aiConsentTask.ConfigureAwait(false);
-        var memoryCount = await memoryCountTask.ConfigureAwait(false);
+        // Issue #3228: the 5 repositories share one scoped DbContext, so await sequentially — EF
+        // forbids concurrent operations on the same context (Task.WhenAll trips the
+        // ConcurrencyDetector). No real parallelism is lost.
+        var library = await _libraryRepository.GetUserGamesAsync(command.UserId, cancellationToken: cancellationToken).ConfigureAwait(false);
+        var chatThreads = await _chatThreadRepository.FindByUserIdAsync(command.UserId, cancellationToken).ConfigureAwait(false);
+        var notifications = await _notificationRepository.GetByUserIdAsync(command.UserId, unreadOnly: false, limit: 10000, cancellationToken: cancellationToken).ConfigureAwait(false);
+        var aiConsent = await _aiConsentRepository.GetByUserIdAsync(command.UserId, cancellationToken).ConfigureAwait(false);
+        var memoryCount = await _conversationMemoryRepository.CountByUserIdAsync(command.UserId, cancellationToken).ConfigureAwait(false);
 
         // Map to export DTOs
         var profile = new ExportedUserProfile(

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetDistinctMetadataQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetDistinctMetadataQueryHandler.cs
@@ -20,40 +20,41 @@ internal sealed class GetDistinctMetadataQueryHandler : IRequestHandler<GetDisti
 
     public async Task<DistinctMetadataDto> Handle(GetDistinctMetadataQuery query, CancellationToken cancellationToken)
     {
-        var categoriesTask = _context.Set<GameCategoryEntity>()
+        // Issue #3228: await sequentially — a single scoped DbContext cannot run queries
+        // concurrently (EF's ConcurrencyDetector throws), so the parallelism was illusory and
+        // these Distinct lookups are cheap.
+        var categories = await _context.Set<GameCategoryEntity>()
             .AsNoTracking()
             .Select(c => c.Name)
             .Distinct()
             .OrderBy(n => n)
-            .ToListAsync(cancellationToken);
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
 
-        var mechanicsTask = _context.Set<GameMechanicEntity>()
+        var mechanics = await _context.Set<GameMechanicEntity>()
             .AsNoTracking()
             .Select(m => m.Name)
             .Distinct()
             .OrderBy(n => n)
-            .ToListAsync(cancellationToken);
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
 
-        var designersTask = _context.Set<GameDesignerEntity>()
+        var designers = await _context.Set<GameDesignerEntity>()
             .AsNoTracking()
             .Select(d => d.Name)
             .Distinct()
             .OrderBy(n => n)
-            .ToListAsync(cancellationToken);
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
 
-        var publishersTask = _context.Set<GamePublisherEntity>()
+        var publishers = await _context.Set<GamePublisherEntity>()
             .AsNoTracking()
             .Select(p => p.Name)
             .Distinct()
             .OrderBy(n => n)
-            .ToListAsync(cancellationToken);
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
 
-        await Task.WhenAll(categoriesTask, mechanicsTask, designersTask, publishersTask).ConfigureAwait(false);
-
-        return new DistinctMetadataDto(
-            categoriesTask.Result,
-            mechanicsTask.Result,
-            designersTask.Result,
-            publishersTask.Result);
+        return new DistinctMetadataDto(categories, mechanics, designers, publishers);
     }
 }

--- a/apps/api/src/Api/Services/UserDashboardService.cs
+++ b/apps/api/src/Api/Services/UserDashboardService.cs
@@ -49,20 +49,18 @@ internal class UserDashboardService : IUserDashboardService
             {
                 _logger.LogInformation("Cache miss for user dashboard {UserId}, generating fresh data", userId);
 
-                // Parallel execution of independent queries for performance (Issue #2854)
-                var recentGamesTask = GetRecentGamesAsync(userId, cancel);
-                var activeSessionsTask = GetActiveSessionsAsync(userId, cancel);
-                var recentChatsTask = GetRecentChatsAsync(userId, cancel);
-                var libraryQuotaTask = GetLibraryQuotaAsync(userId, cancel);
-
-                await Task.WhenAll(recentGamesTask, activeSessionsTask, recentChatsTask, libraryQuotaTask)
-                    .ConfigureAwait(false);
+                // Issue #3228: await sequentially — these queries share one scoped DbContext, which
+                // cannot run queries in parallel (Task.WhenAll trips EF's ConcurrencyDetector).
+                var recentGames = await GetRecentGamesAsync(userId, cancel).ConfigureAwait(false);
+                var activeSessions = await GetActiveSessionsAsync(userId, cancel).ConfigureAwait(false);
+                var recentChats = await GetRecentChatsAsync(userId, cancel).ConfigureAwait(false);
+                var libraryQuota = await GetLibraryQuotaAsync(userId, cancel).ConfigureAwait(false);
 
                 return new UserDashboardDto(
-                    RecentGames: await recentGamesTask.ConfigureAwait(false),
-                    ActiveSessions: await activeSessionsTask.ConfigureAwait(false),
-                    RecentChats: await recentChatsTask.ConfigureAwait(false),
-                    LibraryQuota: await libraryQuotaTask.ConfigureAwait(false)
+                    RecentGames: recentGames,
+                    ActiveSessions: activeSessions,
+                    RecentChats: recentChats,
+                    LibraryQuota: libraryQuota
                 );
             },
             new HybridCacheEntryOptions

--- a/apps/api/tests/Api.Tests/Integration/SharedGameCatalog/GetDistinctMetadataQueryHandlerIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/SharedGameCatalog/GetDistinctMetadataQueryHandlerIntegrationTests.cs
@@ -1,0 +1,45 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Queries;
+using Api.Infrastructure;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.Integration.SharedGameCatalog;
+
+/// <summary>
+/// Issue #3228: <see cref="GetDistinctMetadataQueryHandler"/> ran 4 queries with Task.WhenAll on a
+/// single scoped <see cref="MeepleAiDbContext"/>. EF Core's ConcurrencyDetector forbids concurrent
+/// operations on the same context and throws InvalidOperationException ("A second operation was
+/// started on this context instance before a previous operation completed").
+///
+/// Only a real relational provider exercises the concurrency guard (a mock/in-memory context does
+/// not), so this is an integration test. Before the fix the handler throws; after serializing the
+/// queries it completes.
+/// </summary>
+[Trait("Category", TestCategories.Integration)]
+[Trait("Dependency", "PostgreSQL")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+[Trait("Issue", "3228")]
+public sealed class GetDistinctMetadataQueryHandlerIntegrationTests : IntegrationTestBase<MeepleAiDbContext>
+{
+    protected override string DatabaseName => "test_distinct_metadata_concurrency";
+
+    protected override MeepleAiDbContext CreateRepository(MeepleAiDbContext dbContext) => dbContext;
+
+    [Fact]
+    public async Task Handle_MultipleQueries_DoesNotThrowConcurrencyException()
+    {
+        var handler = new GetDistinctMetadataQueryHandler(DbContext);
+
+        // With Task.WhenAll on one scoped context this trips EF's ConcurrencyDetector and throws;
+        // serialized queries complete normally and return a non-null DTO (empty lists on a fresh DB).
+        var result = await handler.Handle(new GetDistinctMetadataQuery(), TestContext.Current.CancellationToken);
+
+        result.Should().NotBeNull();
+        result.Categories.Should().NotBeNull();
+        result.Mechanics.Should().NotBeNull();
+        result.Designers.Should().NotBeNull();
+        result.Publishers.Should().NotBeNull();
+    }
+}


### PR DESCRIPTION
## Cosa
Tre handler eseguivano più query con `Task.WhenAll` condividendo lo **stesso `MeepleAiDbContext` scoped**. EF Core vieta operazioni concorrenti sullo stesso context → il `ConcurrencyDetector` lancia `InvalidOperationException` ("A second operation was started..."). Il parallelismo era illusorio (un context serializza comunque) e poteva fallire in modo intermittente in produzione.

| Handler | Query | Fix |
|---|---|---|
| `GetDistinctMetadataQueryHandler` | 4 Distinct | await sequenziali |
| `ExportUserDataCommandHandler` | 5 repository (export GDPR) | await sequenziali |
| `UserDashboardService` | 4 query dashboard | await sequenziali |

## Come
**TDD**: integration test (Testcontainers) su `GetDistinctMetadata` riproduce il throw del `ConcurrencyDetector` in modo **deterministico** (RED: `A second operation was started...` alla riga `Task.WhenAll`) e passa dopo la serializzazione (GREEN). #2/#3 applicano lo stesso fix meccanico; i loro handler test esistenti restano verdi (regression guard). 8 test verdi.

Nessuna perdita di performance reale (un singolo context non esegue query in parallelo).

Scoperta via discovery avversariale `/sc:spec-panel`.

Closes #3228

🤖 Generated with [Claude Code](https://claude.com/claude-code)