### PR TITLE
fix(game-nights): #3191 disable RSVP CTAs offline on sibling surfaces

### DIFF
--- a/apps/web/src/app/(authenticated)/dashboard/DashboardClient.tsx
+++ b/apps/web/src/app/(authenticated)/dashboard/DashboardClient.tsx
@@ -47,6 +47,7 @@ import {
 } from '@/hooks/queries/useGameNights';
 import { useLibrary, useLibraryStats } from '@/hooks/queries/useLibrary';
 import { useFriendsActivity } from '@/hooks/use-friends-activity';
+import { useNetworkStatus } from '@/hooks/useNetworkStatus';
 import { useTranslation } from '@/hooks/useTranslation';
 
 import { DashboardHero, type DashboardHeroKpi } from './_components/DashboardHero';
@@ -88,6 +89,8 @@ export function DashboardClient(): ReactElement {
   const upcomingGNQuery = useUpcomingGameNights();
   // #2978 (invariante #17): inline RSVP for pending-invitee cards on the dashboard.
   const rsvpMutation = useRsvpGameNight();
+  // #3191: offline state gates the inline RSVP CTAs (parity with HomeFeed / PR #3189).
+  const { isOffline } = useNetworkStatus();
   // F20 #1974: dashboard "Recenti" slot — recently completed game nights.
   const completedGNQuery = useCompletedGameNights({ limit: 5 });
   const sessionsQuery = useActiveSessions(10);
@@ -281,6 +284,10 @@ export function DashboardClient(): ReactElement {
         <ProssimiSection
           state={prossimiState}
           gameNights={prossimiCards}
+          isOffline={isOffline}
+          // #3191: derive the in-flight night id so the card can lock its own CTAs
+          // (anti-double-submit) without freezing sibling cards.
+          pendingRsvpId={rsvpMutation.isPending ? (rsvpMutation.variables?.id ?? null) : null}
           onRsvp={(id, response) => rsvpMutation.mutate({ id, response })}
           onRetry={() => {
             void upcomingGNQuery.refetch();

--- a/apps/web/src/app/(authenticated)/dashboard/__tests__/DashboardClient.test.tsx
+++ b/apps/web/src/app/(authenticated)/dashboard/__tests__/DashboardClient.test.tsx
@@ -59,7 +59,14 @@ vi.mock('@/hooks/queries/useGameNights', () => ({
     refetch: vi.fn(),
   })),
   // #2978 (invariante #17): inline RSVP mutation from the pending-invitee card.
-  useRsvpGameNight: vi.fn(() => ({ mutate: vi.fn() })),
+  // #3191: expose isPending/variables so DashboardClient can derive `pendingRsvpId`.
+  useRsvpGameNight: vi.fn(() => ({ mutate: vi.fn(), isPending: false, variables: undefined })),
+}));
+
+// #3191: control offline state for the RSVP-guard wiring tests. Default online (set in beforeEach).
+const networkStatusMock = vi.fn<() => { isOffline: boolean }>();
+vi.mock('@/hooks/useNetworkStatus', () => ({
+  useNetworkStatus: () => networkStatusMock(),
 }));
 
 vi.mock('@/hooks/queries/useLibrary', () => ({
@@ -125,9 +132,32 @@ vi.mock('@/lib/stores/cascade-navigation-store', () => ({
 
 import { DashboardClient } from '../DashboardClient';
 
+// #3191: shared fixture — a Published upcoming night where the viewer is a pending invitee,
+// so the Prossimi card renders the inline RSVP CTAs that the offline/double-submit guard targets.
+const PENDING_UPCOMING_NIGHT = {
+  id: '00000000-0000-0000-0000-000000000042',
+  organizerId: '00000000-0000-0000-0000-0000000000aa',
+  organizerName: 'Marco',
+  title: 'Serata su invito',
+  description: null,
+  scheduledAt: '2030-01-01T20:00:00Z',
+  location: null,
+  maxPlayers: null,
+  gameIds: [],
+  status: 'Published' as const,
+  acceptedCount: 1,
+  pendingCount: 2,
+  totalInvited: 3,
+  createdAt: '2024-01-01T00:00:00Z',
+  updatedAt: null,
+  viewerRsvpStatus: 'Pending' as const,
+};
+
 describe('DashboardClient (Asse C priority cluster)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // #3191: default to online; individual tests flip to offline.
+    networkStatusMock.mockReturnValue({ isOffline: false });
   });
 
   it('renders the dashboard hero with greeting + user name', () => {
@@ -186,6 +216,48 @@ describe('DashboardClient (Asse C priority cluster)', () => {
 
     expect(screen.getByText('Da confermare')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Conferma' })).toBeInTheDocument();
+  });
+
+  // #3191: the dashboard forwards `isOffline` to ProssimiSection so the inline RSVP
+  // CTAs are disabled while offline (parity with HomeFeed / PR #3189).
+  it('disables the pending-invitee RSVP CTAs when offline', async () => {
+    networkStatusMock.mockReturnValue({ isOffline: true });
+    const useUpcomingMock = vi.mocked(
+      await import('@/hooks/queries/useGameNights')
+    ).useUpcomingGameNights;
+    useUpcomingMock.mockReturnValueOnce({
+      data: [PENDING_UPCOMING_NIGHT],
+      isLoading: false,
+      isError: false,
+      refetch: refetchUpcoming,
+    } as unknown as ReturnType<typeof useUpcomingMock>);
+
+    render(<DashboardClient />);
+
+    expect(screen.getByRole('button', { name: 'Conferma' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Forse' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Declina' })).toBeDisabled();
+  });
+
+  // #3191: the dashboard derives `pendingRsvpId` from the in-flight mutation and forwards it,
+  // so the CTAs lock during an in-flight RSVP for that same night (anti-double-submit).
+  it('disables the RSVP CTAs while that night RSVP mutation is in flight', async () => {
+    const gameNights = vi.mocked(await import('@/hooks/queries/useGameNights'));
+    gameNights.useUpcomingGameNights.mockReturnValueOnce({
+      data: [PENDING_UPCOMING_NIGHT],
+      isLoading: false,
+      isError: false,
+      refetch: refetchUpcoming,
+    } as unknown as ReturnType<typeof gameNights.useUpcomingGameNights>);
+    gameNights.useRsvpGameNight.mockReturnValueOnce({
+      mutate: vi.fn(),
+      isPending: true,
+      variables: { id: PENDING_UPCOMING_NIGHT.id },
+    } as unknown as ReturnType<typeof gameNights.useRsvpGameNight>);
+
+    render(<DashboardClient />);
+
+    expect(screen.getByRole('button', { name: 'Conferma' })).toBeDisabled();
   });
 
   // #3084: the Recenti card shows the real per-night session count, not a hardcoded 0.

--- a/apps/web/src/app/(authenticated)/dashboard/_components/sections/ProssimiSection.tsx
+++ b/apps/web/src/app/(authenticated)/dashboard/_components/sections/ProssimiSection.tsx
@@ -52,6 +52,13 @@ export interface ProssimiSectionProps {
   readonly onRetry?: () => void;
   // #2978 (invariante #17): inline RSVP handler for pending-invitee cards.
   readonly onRsvp?: (id: string, response: RsvpStatus) => void;
+  // #3191: disable the inline RSVP CTAs when the viewer is offline
+  // (mirrors HomeFeed / PR #3189 — a doomed request against an unreachable server).
+  readonly isOffline?: boolean;
+  // #3191: id of the game night whose RSVP mutation is currently in flight
+  // (anti-double-submit), or null/undefined when idle. Threaded from DashboardClient,
+  // which owns the `useRsvpGameNight` mutation.
+  readonly pendingRsvpId?: string | null;
 }
 
 const STATUS_BADGE_LABEL: Record<ProssimiStatus, string> = {
@@ -70,6 +77,8 @@ export function ProssimiSection({
   gameNights,
   onRetry,
   onRsvp,
+  isOffline,
+  pendingRsvpId,
 }: ProssimiSectionProps): JSX.Element {
   const openDrawer = useCascadeNavigationStore(s => s.openDrawer);
 
@@ -173,6 +182,10 @@ export function ProssimiSection({
           // badge + inline RSVP bar. The RSVP buttons live OUTSIDE the card <button> to avoid
           // nested interactive elements.
           const isPending = gn.viewerRsvpStatus === 'Pending';
+          // #3191: block the RSVP CTAs when offline, or while THIS card's RSVP is in
+          // flight (double-submit). Correlate by id so a sibling card's in-flight RSVP
+          // does not freeze the others.
+          const rsvpDisabled = Boolean(isOffline) || pendingRsvpId === gn.id;
           return (
             <li key={gn.id}>
               <button
@@ -218,25 +231,32 @@ export function ProssimiSection({
                 </p>
               </button>
               {isPending && onRsvp && (
-                <div data-testid={`prossimi-rsvp-${gn.id}`} className="mt-1.5 flex gap-1.5">
+                <div
+                  data-testid={`prossimi-rsvp-${gn.id}`}
+                  className="mt-1.5 flex gap-1.5"
+                  title={isOffline ? 'Offline — RSVP disponibile alla riconnessione' : undefined}
+                >
                   <button
                     type="button"
                     onClick={() => onRsvp(gn.id, 'Accepted')}
-                    className="rounded-md bg-entity-toolkit px-2.5 py-1 font-quicksand text-[11px] font-extrabold text-[#fff]"
+                    disabled={rsvpDisabled}
+                    className="rounded-md bg-entity-toolkit px-2.5 py-1 font-quicksand text-[11px] font-extrabold text-[#fff] disabled:cursor-not-allowed disabled:opacity-50"
                   >
                     Conferma
                   </button>
                   <button
                     type="button"
                     onClick={() => onRsvp(gn.id, 'Maybe')}
-                    className="rounded-md border border-border px-2.5 py-1 font-quicksand text-[11px] font-bold text-muted-foreground"
+                    disabled={rsvpDisabled}
+                    className="rounded-md border border-border px-2.5 py-1 font-quicksand text-[11px] font-bold text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50"
                   >
                     Forse
                   </button>
                   <button
                     type="button"
                     onClick={() => onRsvp(gn.id, 'Declined')}
-                    className="rounded-md border border-border px-2.5 py-1 font-quicksand text-[11px] font-bold text-muted-foreground"
+                    disabled={rsvpDisabled}
+                    className="rounded-md border border-border px-2.5 py-1 font-quicksand text-[11px] font-bold text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50"
                   >
                     Declina
                   </button>

--- a/apps/web/src/app/(authenticated)/dashboard/_components/sections/__tests__/ProssimiSection.test.tsx
+++ b/apps/web/src/app/(authenticated)/dashboard/_components/sections/__tests__/ProssimiSection.test.tsx
@@ -182,4 +182,73 @@ describe('ProssimiSection', () => {
       expect(openDrawerMock).toHaveBeenCalledWith('gameNightEvent', 'gn-3');
     });
   });
+
+  // #3191: extend the offline-disabled RSVP pattern (PR #3189, HomeFeed) to the
+  // dashboard "Prossimi" inline CTAs, plus the anti-double-submit guard that this
+  // surface never had. Props are threaded from DashboardClient (parent owns the mutation).
+  describe('offline + double-submit guard (#3191)', () => {
+    const pendingCard: ProssimiGameNightCard = {
+      id: 'gn-3',
+      title: 'Casa Luca',
+      date: TOMORROW,
+      status: 'Published',
+      rsvpConfirmedCount: 1,
+      rsvpPendingCount: 2,
+      rsvpTotalCount: 3,
+      viewerRsvpStatus: 'Pending',
+    };
+
+    const rsvpButtonNames = ['Conferma', 'Forse', 'Declina'] as const;
+
+    it('disables all RSVP buttons when offline', () => {
+      render(
+        <ProssimiSection state="default" gameNights={[pendingCard]} onRsvp={vi.fn()} isOffline />
+      );
+      for (const name of rsvpButtonNames) {
+        expect(screen.getByRole('button', { name })).toBeDisabled();
+      }
+    });
+
+    it('keeps RSVP buttons enabled when online and idle', () => {
+      render(
+        <ProssimiSection
+          state="default"
+          gameNights={[pendingCard]}
+          onRsvp={vi.fn()}
+          isOffline={false}
+        />
+      );
+      for (const name of rsvpButtonNames) {
+        expect(screen.getByRole('button', { name })).not.toBeDisabled();
+      }
+    });
+
+    it('disables RSVP buttons while this card is submitting (double-submit guard)', () => {
+      render(
+        <ProssimiSection
+          state="default"
+          gameNights={[pendingCard]}
+          onRsvp={vi.fn()}
+          pendingRsvpId="gn-3"
+        />
+      );
+      for (const name of rsvpButtonNames) {
+        expect(screen.getByRole('button', { name })).toBeDisabled();
+      }
+    });
+
+    it('keeps RSVP buttons enabled while a different card is submitting', () => {
+      render(
+        <ProssimiSection
+          state="default"
+          gameNights={[pendingCard]}
+          onRsvp={vi.fn()}
+          pendingRsvpId="other-night"
+        />
+      );
+      for (const name of rsvpButtonNames) {
+        expect(screen.getByRole('button', { name })).not.toBeDisabled();
+      }
+    });
+  });
 });

--- a/apps/web/src/app/(authenticated)/game-nights/__tests__/_content.test.tsx
+++ b/apps/web/src/app/(authenticated)/game-nights/__tests__/_content.test.tsx
@@ -39,11 +39,20 @@ vi.mock('@/hooks/useTranslation', () => ({
 const useUpcomingMock = vi.fn();
 const useMineMock = vi.fn();
 const rsvpMutateMock = vi.fn();
+// #3191: controllable RSVP mutation state so a test can simulate an in-flight RSVP.
+const rsvpMock =
+  vi.fn<() => { mutate: typeof rsvpMutateMock; isPending: boolean; variables?: { id: string } }>();
+// #3191: controllable network status so a test can simulate offline.
+const networkStatusMock = vi.fn<() => { isOffline: boolean }>();
 
 vi.mock('@/hooks/queries/useGameNights', () => ({
   useUpcomingGameNights: () => useUpcomingMock(),
   useMyGameNights: () => useMineMock(),
-  useRsvpGameNight: () => ({ mutate: rsvpMutateMock }),
+  useRsvpGameNight: () => rsvpMock(),
+}));
+
+vi.mock('@/hooks/useNetworkStatus', () => ({
+  useNetworkStatus: () => networkStatusMock(),
 }));
 
 const useCurrentUserMock = vi.fn();
@@ -105,6 +114,9 @@ beforeEach(() => {
   for (const k of Object.keys(searchParamsState)) delete searchParamsState[k];
 
   useCurrentUserMock.mockReturnValue({ data: { id: VIEWER_ID } });
+  // #3191: default online + idle mutation; individual tests override.
+  rsvpMock.mockReturnValue({ mutate: rsvpMutateMock, isPending: false, variables: undefined });
+  networkStatusMock.mockReturnValue({ isOffline: false });
 });
 
 // ─── Tests ────────────────────────────────────────────────────────────────
@@ -358,6 +370,138 @@ describe('GameNightsContent (orchestrator)', () => {
     expect(rsvpMutateMock).toHaveBeenCalledWith({
       id: '88888888-8888-8888-8888-888888888888',
       response: 'Declined',
+    });
+  });
+
+  // #3191: offline-disable the inline RSVP CTAs (parity with HomeFeed / PR #3189) across
+  // BOTH surfaces that funnel through handleCardAction — the list card and the calendar drawer.
+  describe('offline + double-submit guard (#3191)', () => {
+    const LIST_INVITEE_ID = '99999999-9999-9999-9999-999999999999';
+
+    function setUpPendingListInvitee(id: string = LIST_INVITEE_ID): string {
+      searchParamsState.view = 'list';
+      const invited = makeDto({
+        id,
+        organizerId: 'someone-else-id-00000000000000000000',
+        viewerRsvpStatus: 'Pending',
+        title: 'Serata su invito',
+      });
+      useUpcomingMock.mockReturnValue({
+        data: [invited],
+        isLoading: false,
+        error: null,
+        refetch: vi.fn(),
+      });
+      useMineMock.mockReturnValue({ data: [], isLoading: false, error: null, refetch: vi.fn() });
+      return id;
+    }
+
+    it('does not fire the RSVP mutation from the list card when offline', () => {
+      networkStatusMock.mockReturnValue({ isOffline: true });
+      setUpPendingListInvitee();
+
+      render(<GameNightsContent />);
+
+      fireEvent.click(screen.getByRole('button', { name: 'gameNightsIndex.list.cta.decline' }));
+      expect(rsvpMutateMock).not.toHaveBeenCalled();
+    });
+
+    it('visually disables the list-card RSVP buttons when offline', () => {
+      networkStatusMock.mockReturnValue({ isOffline: true });
+      setUpPendingListInvitee();
+
+      render(<GameNightsContent />);
+
+      const decline = screen.getByRole('button', {
+        name: 'gameNightsIndex.list.cta.decline',
+      });
+      expect(decline).toBeDisabled();
+      expect(decline).toHaveAttribute('data-disabled', 'true');
+    });
+
+    it('does not fire the RSVP mutation from the day-detail drawer when offline', () => {
+      networkStatusMock.mockReturnValue({ isOffline: true });
+      const invited = makeDto({
+        id: '88888888-8888-8888-8888-888888888888',
+        organizerId: 'someone-else-id-00000000000000000000',
+        viewerRsvpStatus: 'Pending',
+        title: 'Serata drawer',
+      });
+      useUpcomingMock.mockReturnValue({
+        data: [invited],
+        isLoading: false,
+        error: null,
+        refetch: vi.fn(),
+      });
+      useMineMock.mockReturnValue({ data: [], isLoading: false, error: null, refetch: vi.fn() });
+
+      render(<GameNightsContent />);
+
+      const todayCell = screen
+        .getAllByTestId('game-nights-calendar-day-cell')
+        .find(c => c.hasAttribute('data-today'));
+      fireEvent.click(todayCell as HTMLElement);
+      const drawer = screen.getByTestId('game-nights-day-detail-drawer');
+      fireEvent.click(
+        within(drawer).getByRole('button', { name: 'gameNightsIndex.list.cta.decline' })
+      );
+      expect(rsvpMutateMock).not.toHaveBeenCalled();
+    });
+
+    it('visually disables the drawer RSVP buttons while that night is submitting', () => {
+      const id = '88888888-8888-8888-8888-888888888888';
+      const invited = makeDto({
+        id,
+        organizerId: 'someone-else-id-00000000000000000000',
+        viewerRsvpStatus: 'Pending',
+        title: 'Serata drawer',
+      });
+      useUpcomingMock.mockReturnValue({
+        data: [invited],
+        isLoading: false,
+        error: null,
+        refetch: vi.fn(),
+      });
+      useMineMock.mockReturnValue({ data: [], isLoading: false, error: null, refetch: vi.fn() });
+      // In-flight (not offline) — exercises resolveCtaDisabled's id correlation in the drawer.
+      rsvpMock.mockReturnValue({ mutate: rsvpMutateMock, isPending: true, variables: { id } });
+
+      render(<GameNightsContent />);
+
+      const todayCell = screen
+        .getAllByTestId('game-nights-calendar-day-cell')
+        .find(c => c.hasAttribute('data-today'));
+      fireEvent.click(todayCell as HTMLElement);
+      const drawer = screen.getByTestId('game-nights-day-detail-drawer');
+      const decline = within(drawer).getByRole('button', {
+        name: 'gameNightsIndex.list.cta.decline',
+      });
+      expect(decline).toHaveAttribute('data-disabled', 'true');
+      expect(decline).toBeDisabled();
+    });
+
+    it('does not fire a second RSVP while this night is already submitting (double-submit)', () => {
+      const id = setUpPendingListInvitee();
+      rsvpMock.mockReturnValue({ mutate: rsvpMutateMock, isPending: true, variables: { id } });
+
+      render(<GameNightsContent />);
+
+      fireEvent.click(screen.getByRole('button', { name: 'gameNightsIndex.list.cta.decline' }));
+      expect(rsvpMutateMock).not.toHaveBeenCalled();
+    });
+
+    it('still fires the RSVP when a different night is submitting (correlation guard)', () => {
+      const id = setUpPendingListInvitee();
+      rsvpMock.mockReturnValue({
+        mutate: rsvpMutateMock,
+        isPending: true,
+        variables: { id: 'other-night-id' },
+      });
+
+      render(<GameNightsContent />);
+
+      fireEvent.click(screen.getByRole('button', { name: 'gameNightsIndex.list.cta.decline' }));
+      expect(rsvpMutateMock).toHaveBeenCalledWith({ id, response: 'Declined' });
     });
   });
 });

--- a/apps/web/src/app/(authenticated)/game-nights/_content.tsx
+++ b/apps/web/src/app/(authenticated)/game-nights/_content.tsx
@@ -40,6 +40,7 @@ import {
   useRsvpGameNight,
   useUpcomingGameNights,
 } from '@/hooks/queries/useGameNights';
+import { useNetworkStatus } from '@/hooks/useNetworkStatus';
 import { useTranslation, type TranslationFunction } from '@/hooks/useTranslation';
 import type { RsvpStatus } from '@/lib/api/schemas/game-nights.schemas';
 import type { MonthCell } from '@/lib/game-nights/calendar-grid';
@@ -128,18 +129,33 @@ export function GameNightsContent(): React.JSX.Element {
   const { data: viewer } = useCurrentUser();
   const upcoming = useUpcomingGameNights();
   const mine = useMyGameNights();
-  const { mutate: rsvpMutate } = useRsvpGameNight();
+  const {
+    mutate: rsvpMutate,
+    isPending: rsvpPending,
+    variables: rsvpVariables,
+  } = useRsvpGameNight();
+  // #3191: offline state gates the inline RSVP CTAs (parity with HomeFeed / PR #3189).
+  const { isOffline } = useNetworkStatus();
+
+  // #3191: an RSVP CTA is disabled when offline, or while THIS night's RSVP is already in
+  // flight (double-submit). Correlate by id so a sibling card's in-flight RSVP doesn't freeze
+  // the others (the day drawer can list several nights).
+  const isRsvpDisabled = useCallback(
+    (id: string): boolean => isOffline || (rsvpPending && rsvpVariables?.id === id),
+    [isOffline, rsvpPending, rsvpVariables]
+  );
 
   // #2978 (invariante #17): inline RSVP from the list card AND the calendar day-detail drawer.
   // Non-RSVP actions (edit/viewSummary/reschedule) are navigation concerns out of scope here.
   const handleCardAction = useCallback(
     (id: string, action: GameNightListCardAction): void => {
       const response = RSVP_ACTION_TO_STATUS[action];
-      if (response) {
-        rsvpMutate({ id, response });
-      }
+      if (!response) return;
+      // #3191: block the RSVP when offline or already submitting for this night.
+      if (isRsvpDisabled(id)) return;
+      rsvpMutate({ id, response });
     },
-    [rsvpMutate]
+    [rsvpMutate, isRsvpDisabled]
   );
 
   // Merge + dedup by id; map to VMs.
@@ -369,6 +385,7 @@ export function GameNightsContent(): React.JSX.Element {
           t={t}
           statusLabels={statusLabels}
           onAction={handleCardAction}
+          resolveCtaDisabled={isRsvpDisabled}
           emptyTitle={t(`${K}.states.filteredEmpty.title`)}
           emptyBody={t(`${K}.states.filteredEmpty.body`)}
         />
@@ -380,6 +397,7 @@ export function GameNightsContent(): React.JSX.Element {
           events={dayEvents}
           labels={drawerLabels}
           onCardAction={handleCardAction}
+          resolveCtaDisabled={vm => isRsvpDisabled(vm.id)}
           onClose={() => setDrawerTarget(null)}
           onAddOnDay={() => router.push('/game-nights/new')}
         />
@@ -396,6 +414,8 @@ interface ListViewProps {
   readonly t: TranslationFunction;
   readonly statusLabels: StatusPillLabels;
   readonly onAction?: (id: string, action: GameNightListCardAction) => void;
+  // #3191: per-card disabled resolver for the RSVP CTAs (offline / in-flight).
+  readonly resolveCtaDisabled?: (id: string) => boolean;
   readonly emptyTitle: string;
   readonly emptyBody: string;
 }
@@ -406,6 +426,7 @@ function ListView({
   t,
   statusLabels,
   onAction,
+  resolveCtaDisabled,
   emptyTitle,
   emptyBody,
 }: ListViewProps): React.JSX.Element {
@@ -447,6 +468,7 @@ function ListView({
                   vm={vm}
                   labels={makeCardLabels(t, statusLabels, vm)}
                   onAction={onAction}
+                  ctaDisabled={resolveCtaDisabled?.(vm.id)}
                 />
               ))}
             </div>

--- a/apps/web/src/app/(public)/join/event/[code]/_components/PublicJoinEventView.tsx
+++ b/apps/web/src/app/(public)/join/event/[code]/_components/PublicJoinEventView.tsx
@@ -35,6 +35,7 @@ import {
   type PublicRsvpFormLabels,
 } from '@/components/features/game-night-detail';
 import { useGameNightInvitation } from '@/hooks/useGameNightInvitation';
+import { useNetworkStatus } from '@/hooks/useNetworkStatus';
 import { useRespondToInvitation } from '@/hooks/useRespondToInvitation';
 import { useTranslation } from '@/hooks/useTranslation';
 import {
@@ -68,6 +69,9 @@ export function PublicJoinEventView({ code }: PublicJoinEventViewProps): JSX.Ele
 
   const invitationQuery = useGameNightInvitation({ token: code });
   const respond = useRespondToInvitation({ token: code });
+  // #3191: the anonymous invite link is the highest-offline-probability RSVP surface
+  // (opened from email/SMS on mobile) — gate its CTAs like the authenticated surfaces.
+  const { isOffline } = useNetworkStatus();
 
   const invitation = invitationQuery.data;
 
@@ -227,6 +231,7 @@ export function PublicJoinEventView({ code }: PublicJoinEventViewProps): JSX.Ele
             formatMessage={formatMessage}
             submittingAction={respond.state === 'submitting' ? lastSubmittedAction(respond) : null}
             onSubmit={handleSubmit}
+            isOffline={isOffline}
             errorBanner={
               respond.state === 'error'
                 ? t('pages.gameNightJoin.error.generic.body')
@@ -282,6 +287,8 @@ interface RsvpSurfaceProps {
   readonly formatMessage: ReturnType<typeof useTranslation>['formatMessage'];
   readonly submittingAction: RsvpAction | null;
   readonly onSubmit: (action: RsvpAction, displayName: string | null) => void;
+  // #3191: disable the RSVP CTAs while offline.
+  readonly isOffline: boolean;
   readonly errorBanner: string | null;
 }
 
@@ -293,6 +300,7 @@ function RsvpSurface({
   formatMessage,
   submittingAction,
   onSubmit,
+  isOffline,
   errorBanner,
 }: RsvpSurfaceProps): JSX.Element {
   // Map backend DTO `status` (covers Expired/Cancelled too) onto the union
@@ -394,6 +402,7 @@ function RsvpSurface({
           currentResponse={currentResponse}
           initialDisplayName={respondedByName}
           submittingAction={submittingAction}
+          disabled={isOffline}
           onSubmit={onSubmit}
         />
       </div>

--- a/apps/web/src/app/(public)/join/event/[code]/_components/__tests__/PublicJoinEventView.test.tsx
+++ b/apps/web/src/app/(public)/join/event/[code]/_components/__tests__/PublicJoinEventView.test.tsx
@@ -31,9 +31,14 @@ vi.mock('@/hooks/useGameNightInvitation', () => ({
 vi.mock('@/hooks/useRespondToInvitation', () => ({
   useRespondToInvitation: vi.fn(),
 }));
+// #3191: control offline state to gate the public RSVP CTAs.
+vi.mock('@/hooks/useNetworkStatus', () => ({
+  useNetworkStatus: vi.fn(),
+}));
 
 const { useGameNightInvitation } = await import('@/hooks/useGameNightInvitation');
 const { useRespondToInvitation } = await import('@/hooks/useRespondToInvitation');
+const { useNetworkStatus } = await import('@/hooks/useNetworkStatus');
 
 // Local provider stack — the global renderWithProviders pulls in
 // ChatStoreProvider via a stale path, and this orchestrator only needs
@@ -125,6 +130,10 @@ function mockRespondHook(
 describe('PublicJoinEventView (issue #1169)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // #3191: default online; the offline test overrides.
+    vi.mocked(useNetworkStatus).mockReturnValue({
+      isOffline: false,
+    } as unknown as ReturnType<typeof useNetworkStatus>);
   });
 
   describe('surface routing', () => {
@@ -221,6 +230,32 @@ describe('PublicJoinEventView (issue #1169)', () => {
       // Form rendered with Accept / Decline CTAs.
       expect(screen.getByRole('button', { name: /I'm in/i })).toBeInTheDocument();
       expect(screen.getByRole('button', { name: /Can't make it/i })).toBeInTheDocument();
+    });
+
+    // #3191: the public invite RSVP surface is the highest-offline-probability one
+    // (anonymous link opened from email/SMS on mobile). Gate its CTAs like the
+    // authenticated surfaces (parity with HomeFeed / PR #3189).
+    it('disables the Accept + Decline CTAs when offline', () => {
+      vi.mocked(useNetworkStatus).mockReturnValue({
+        isOffline: true,
+      } as unknown as ReturnType<typeof useNetworkStatus>);
+      vi.mocked(useGameNightInvitation).mockReturnValue(mockInvitationHook());
+      vi.mocked(useRespondToInvitation).mockReturnValue(mockRespondHook());
+
+      renderWithIntl(<PublicJoinEventView code="tok-1169" />);
+
+      expect(screen.getByRole('button', { name: /I'm in/i })).toBeDisabled();
+      expect(screen.getByRole('button', { name: /Can't make it/i })).toBeDisabled();
+    });
+
+    it('keeps the Accept + Decline CTAs enabled when online', () => {
+      vi.mocked(useGameNightInvitation).mockReturnValue(mockInvitationHook());
+      vi.mocked(useRespondToInvitation).mockReturnValue(mockRespondHook());
+
+      renderWithIntl(<PublicJoinEventView code="tok-1169" />);
+
+      expect(screen.getByRole('button', { name: /I'm in/i })).not.toBeDisabled();
+      expect(screen.getByRole('button', { name: /Can't make it/i })).not.toBeDisabled();
     });
 
     it('routes to token-cancelled when invitation.status === "Cancelled"', () => {

--- a/apps/web/src/components/features/game-nights/DayDetailDrawer.tsx
+++ b/apps/web/src/components/features/game-nights/DayDetailDrawer.tsx
@@ -46,6 +46,8 @@ export interface DayDetailDrawerProps {
   readonly onCardAction?: (id: string, action: GameNightListCardAction) => void;
   readonly resolvePlayers?: (vm: GameNightVM) => readonly AvatarPlayer[];
   readonly resolveGameTitle?: (vm: GameNightVM) => string | undefined;
+  // #3191: per-card disabled resolver for the RSVP CTAs (offline / in-flight).
+  readonly resolveCtaDisabled?: (vm: GameNightVM) => boolean;
 }
 
 export function DayDetailDrawer({
@@ -59,6 +61,7 @@ export function DayDetailDrawer({
   onCardAction,
   resolvePlayers,
   resolveGameTitle,
+  resolveCtaDisabled,
 }: DayDetailDrawerProps): React.JSX.Element | null {
   const headingId = useId();
   const closeBtnRef = useRef<HTMLButtonElement | null>(null);
@@ -148,6 +151,7 @@ export function DayDetailDrawer({
               onAction={onCardAction}
               gameTitle={resolveGameTitle?.(vm)}
               players={resolvePlayers?.(vm)}
+              ctaDisabled={resolveCtaDisabled?.(vm)}
             />
           ))}
           {onAddOnDay && (

--- a/apps/web/src/components/features/game-nights/GameNightListCard.tsx
+++ b/apps/web/src/components/features/game-nights/GameNightListCard.tsx
@@ -49,6 +49,9 @@ export interface GameNightListCardProps {
   readonly onAction?: (id: string, action: GameNightListCardAction) => void;
   readonly gameTitle?: string;
   readonly players?: readonly AvatarPlayer[];
+  // #3191: disable the inline RSVP CTAs (offline / in-flight). Gates ONLY the 3 RSVP
+  // buttons — navigation branches (edit/viewSummary/reschedule) stay interactive.
+  readonly ctaDisabled?: boolean;
 }
 
 export function GameNightListCard({
@@ -58,6 +61,7 @@ export function GameNightListCard({
   onAction,
   gameTitle,
   players,
+  ctaDisabled,
 }: GameNightListCardProps): React.JSX.Element {
   const isCancelled = vm.statusKey === 'cancelled';
   // #2978 (invariante #17): the viewer is an invitee who has not yet responded.
@@ -149,7 +153,7 @@ export function GameNightListCard({
             {labels.participants(participantCount)}
           </span>
           <div className="flex-1" />
-          <CardCta vm={vm} labels={labels.cta} onAction={dispatch} />
+          <CardCta vm={vm} labels={labels.cta} onAction={dispatch} rsvpDisabled={ctaDisabled} />
         </div>
       </div>
     </article>
@@ -160,6 +164,8 @@ interface CardCtaProps {
   readonly vm: GameNightVM;
   readonly labels: GameNightListCardCtaLabels;
   readonly onAction: (action: GameNightListCardAction) => void;
+  // #3191: disable the 3 RSVP buttons (offline / in-flight). Nav branches are unaffected.
+  readonly rsvpDisabled?: boolean;
 }
 
 // #2978 (invariante #17): the 3 RSVP actions, mapped to their RsvpStatus + selected-state style.
@@ -184,7 +190,7 @@ const RSVP_BUTTONS = [
   },
 ] as const;
 
-function CardCta({ vm, labels, onAction }: CardCtaProps): React.JSX.Element | null {
+function CardCta({ vm, labels, onAction, rsvpDisabled }: CardCtaProps): React.JSX.Element | null {
   if (vm.statusKey === 'completed') {
     return (
       <button
@@ -233,10 +239,13 @@ function CardCta({ vm, labels, onAction }: CardCtaProps): React.JSX.Element | nu
             key={action}
             type="button"
             onClick={() => onAction(action)}
+            disabled={rsvpDisabled}
+            data-disabled={rsvpDisabled ? 'true' : 'false'}
             data-selected={isSelected ? 'true' : 'false'}
             aria-pressed={isSelected}
             className={clsx(
               'rounded-md border px-3 py-1.5 font-display text-xs font-extrabold',
+              'disabled:cursor-not-allowed disabled:opacity-50',
               isSelected ? selectedClass : 'border-border text-muted-foreground'
             )}
           >

--- a/apps/web/src/components/features/game-nights/__tests__/GameNightListCard.test.tsx
+++ b/apps/web/src/components/features/game-nights/__tests__/GameNightListCard.test.tsx
@@ -206,4 +206,45 @@ describe('GameNightListCard', () => {
       expect(screen.queryByTestId('game-nights-pending-badge')).not.toBeInTheDocument();
     });
   });
+
+  // #3191: offline / in-flight disable of ONLY the inline RSVP CTAs.
+  describe('ctaDisabled RSVP guard (#3191)', () => {
+    const rsvpNames = ['✓ Partecipo', 'Forse', 'Declina'];
+
+    it('disables all 3 RSVP buttons + marks data-disabled when ctaDisabled', () => {
+      render(
+        <GameNightListCard
+          vm={makeVM('planned', 'invited', { viewerRsvpStatus: 'Pending' })}
+          labels={labels}
+          ctaDisabled
+        />
+      );
+      for (const name of rsvpNames) {
+        const btn = screen.getByRole('button', { name });
+        expect(btn).toBeDisabled();
+        expect(btn).toHaveAttribute('data-disabled', 'true');
+      }
+    });
+
+    it('keeps the RSVP buttons enabled by default (ctaDisabled omitted)', () => {
+      render(
+        <GameNightListCard
+          vm={makeVM('planned', 'invited', { viewerRsvpStatus: 'Pending' })}
+          labels={labels}
+        />
+      );
+      for (const name of rsvpNames) {
+        const btn = screen.getByRole('button', { name });
+        expect(btn).not.toBeDisabled();
+        expect(btn).toHaveAttribute('data-disabled', 'false');
+      }
+    });
+
+    it('does NOT disable the organizer edit CTA (navigation branch, out of scope)', () => {
+      render(
+        <GameNightListCard vm={makeVM('confirmed', 'organizer')} labels={labels} ctaDisabled />
+      );
+      expect(screen.getByRole('button', { name: 'Modifica' })).not.toBeDisabled();
+    });
+  });
 });


### PR DESCRIPTION
Closes #3191.

## Contesto

La PR #3189 aveva chiuso il gap 5 (offline) dell'audit mobile #2989 disabilitando le CTA di RSVP quando `useNetworkStatus().isOffline`, ma **solo su HomeFeed (Screen A) e GameNightDetailView (Screen C)**. Una code review avversariale su #3189 aveva rilevato che la stessa mutation è innescabile da altre superfici in-app rimaste cliccabili offline. Questa PR estende il pattern alle 3 superfici sibling.

## Superfici coperte

| # | Superficie | Fix |
|---|-----------|-----|
| **1** | `/dashboard` → `ProssimiSection` | Thread `isOffline` + `pendingRsvpId` da `DashboardClient` (che possiede la mutation). Aggiunge anche il guard **anti-double-submit** `isPending` che questa superficie non aveva. |
| **2** | `/game-nights` list card + calendar day-detail drawer | Guard funzionale sul chokepoint condiviso `handleCardAction` (offline / in-flight, correlato per id) **+** disable visivo via `GameNightListCard.ctaDisabled` e `DayDetailDrawer.resolveCtaDisabled` — solo i 3 bottoni RSVP, le CTA di navigazione restano attive. |
| **3** | `/join/event/[code]` → `PublicJoinEventView` | `disabled={isOffline}` a `PublicRsvpForm`. **Inclusa** (non deferita): è la superficie a più alta probabilità offline — link invito anonimo aperto da email/SMS su mobile. |

## Pattern

Guard identico al reference (HomeFeed): disabilitato quando **offline** OPPURE mentre l'RSVP di **questa** serata è in flight, correlato per `id` così le card sibling restano interattive. Tutti i nuovi prop sono opzionali/backward-compatible.

## Testing

- **TDD** (RED→GREEN) su tutti e 6 i file: offline / double-submit / correlation-guard / drawer in-flight / wiring parent→child.
- **89 assertion** aggiunte, **419/419** sweep di regressione sulle directory consumatrici, `typecheck` + `eslint` puliti.
- **Review avversariale multi-lente** (correttezza / a11y / qualità-test / aderenza-pattern / regression): **0 bug confermati** (correttezza e regression senza rilievi; nit di stile/UX tutti refutati con verifica).

## DoD
- [x] Guard offline su tutte e 3 le superfici sibling
- [x] Guard anti-double-submit su ProssimiSection (gap pre-esistente)
- [x] Solo i bottoni RSVP disabilitati (nav intatta)
- [x] Test TDD + regressione verdi
- [ ] Merge in `main-dev`

Ref: #2989 (parent audit), #3189 (pattern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)