### PR TITLE
fix(infra): Docker integration mode staging connectivity

### DIFF
--- a/infra/compose.integration.yml
+++ b/infra/compose.integration.yml
@@ -46,10 +46,12 @@ services:
       ASPNETCORE_URLS: http://+:8080
       SkipMigrations: "true"
       POSTGRES_HOST: host.docker.internal
-      POSTGRES_PORT: "15432"
+      # Ports MUST match the forwards in scripts/integration-tunnel.sh (25432/26379),
+      # not 15432/16379 (stale — the tunnel never binds those).
+      POSTGRES_PORT: "25432"
       POSTGRES_SSL_MODE: Disable
       REDIS_HOST: host.docker.internal
-      REDIS_PORT: "16379"
+      REDIS_PORT: "26379"
       # AI services via meepleai.app
       EMBEDDING_PROVIDER: external
       Embedding__Provider: External
@@ -70,4 +72,10 @@ services:
     extra_hosts: ["host.docker.internal:host-gateway"]
     environment:
       NODE_ENV: development
+      # Server-side proxy (src/proxy.ts, src/app/api/v1/[...path]/route.ts) forwards ALL
+      # browser API calls to the backend. It reads API_BASE_URL first; without it the
+      # fallback is NEXT_PUBLIC_API_BASE=localhost:8080 = the web container itself →
+      # undici "fetch failed" (ECONNREFUSED) on login and every API call. api:8080 is the
+      # backend on the docker network (matches compose.dev/prod/staging/test.yml).
+      API_BASE_URL: http://api:8080
       NEXT_PUBLIC_API_BASE: http://localhost:8080

--- a/infra/scripts/integration-tunnel.sh
+++ b/infra/scripts/integration-tunnel.sh
@@ -5,8 +5,8 @@
 #   bash infra/scripts/integration-tunnel.sh [start|stop|status]
 #
 # Opens SSH tunnels to staging server (meepleai.app) for:
-#   - PostgreSQL  :15432 -> staging container (dynamic IP)
-#   - Redis       :16379 -> staging container (dynamic IP)
+#   - PostgreSQL  :25432 -> staging container (dynamic IP)
+#   - Redis       :26379 -> staging container (dynamic IP)
 #   - AI/monitoring services -> staging host ports
 #
 # Then run:


### PR DESCRIPTION
## Problem

`infra/compose.integration.yml` (run local Docker `api`+`web` against **staging** services) had two config bugs that broke it out of the box — the mode described in its own header as pointing local containers at staging.

### 1. `web` missing `API_BASE_URL` → login (and every API call) fails with `fetch failed`
The Next.js server-side proxy (`apps/web/src/proxy.ts`, `apps/web/src/app/api/v1/[...path]/route.ts`) forwards **all** browser API calls to the backend. It reads `API_BASE_URL` first, then falls back to `NEXT_PUBLIC_API_BASE` (`http://localhost:8080`). Inside the `web` container `localhost:8080` is the container itself → undici **`fetch failed` (ECONNREFUSED)** on login and on every request.

Every other compose sets it — `compose.dev.yml:106`, `compose.prod.yml`, `compose.staging.yml`, `compose.test.yml` all have `API_BASE_URL: http://api:8080`. Only `compose.integration.yml` omitted it.

### 2. DB/Redis ports didn't match the tunnel
`POSTGRES_PORT`/`REDIS_PORT` were `15432`/`16379`, but `scripts/integration-tunnel.sh` forwards **`25432`/`26379`** (and `scripts/integration-start.sh` uses those). The Docker path pointed at ports the tunnel never binds.

## Fix
- `web.environment.API_BASE_URL: http://api:8080`
- `POSTGRES_PORT: 25432`, `REDIS_PORT: 26379`

## Verification
Reproduced live against staging and applied the same values via a throwaway override:
- Before: `POST /api/v1/auth/login` through the web proxy → `fetch failed`.
- After: returns a real backend `400 Invalid email or password` with an ASP.NET `correlationId` (proxy reaches the API), and the catalog reads staging data (`Games: 160`).

## Note (out of scope)
On **Windows**, the SSH tunnel must be bound to `0.0.0.0` (not the default loopback) for containers to reach it via `host.docker.internal`. That's a runtime step in the tunnel script, not a compose concern — left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)