### PR TITLE
fix(frontend): #3231 4 robustness bugs (alert-enum, timer leak, wishlist, PdfVersion)

### DIFF
--- a/apps/web/src/components/admin/providers/CircuitBreakerGrid.tsx
+++ b/apps/web/src/components/admin/providers/CircuitBreakerGrid.tsx
@@ -88,7 +88,11 @@ function CooldownBar({ trippedAtIso, cooldownSec }: CooldownBarProps) {
   useEffect(() => {
     if (remaining <= 0) return;
     const id = setInterval(() => {
-      setRemaining(computeRemaining());
+      const next = computeRemaining();
+      setRemaining(next);
+      // #3231: stop the interval once the countdown hits zero — the effect deps don't include
+      // `remaining`, so without this the timer would tick at 1 Hz forever.
+      if (next <= 0) clearInterval(id);
     }, 1000);
     return () => clearInterval(id);
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/apps/web/src/components/library/PdfVersionManager.tsx
+++ b/apps/web/src/components/library/PdfVersionManager.tsx
@@ -178,11 +178,21 @@ export function PdfVersionManager({ gameId, gameName }: PdfVersionManagerProps) 
   };
 
   const handleReplace = async () => {
-    // Deactivate all currently active PDFs
+    // Deactivate all currently active PDFs.
     const activePdfs = pdfs.filter(p => p.isActiveForRag);
-    await Promise.all(
+    // #3231: allSettled so a partial failure is handled cohesively (no unhandled rejection escapes,
+    // no stuck dialog / skipped refresh).
+    const results = await Promise.allSettled(
       activePdfs.map(pdf => toggleRagMutation.mutateAsync({ pdfId: pdf.id, isActive: false }))
     );
+
+    if (results.some(r => r.status === 'rejected')) {
+      // Keep the dialog open, refresh to reflect the real (partial) state, prompt a retry.
+      void queryClient.invalidateQueries({ queryKey: ['game-pdfs', gameId] });
+      toast.error('Alcune versioni non sono state disattivate. Riprova.');
+      return;
+    }
+
     setShowReplaceDialog(false);
     finishUpload();
     toast.success('Versione sostituita con successo.');
@@ -326,7 +336,9 @@ export function PdfVersionManager({ gameId, gameName }: PdfVersionManagerProps) 
             <table className="w-full text-sm" data-testid="pdf-list-table">
               <thead>
                 <tr className="border-b border-border bg-card">
-                  <th className="px-4 py-2.5 text-left text-xs font-medium text-muted-foreground">File</th>
+                  <th className="px-4 py-2.5 text-left text-xs font-medium text-muted-foreground">
+                    File
+                  </th>
                   <th className="px-4 py-2.5 text-left text-xs font-medium text-muted-foreground">
                     Versione
                   </th>
@@ -336,7 +348,9 @@ export function PdfVersionManager({ gameId, gameName }: PdfVersionManagerProps) 
                   <th className="px-4 py-2.5 text-left text-xs font-medium text-muted-foreground">
                     Stato
                   </th>
-                  <th className="px-4 py-2.5 text-left text-xs font-medium text-muted-foreground">RAG</th>
+                  <th className="px-4 py-2.5 text-left text-xs font-medium text-muted-foreground">
+                    RAG
+                  </th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-slate-700/50">

--- a/apps/web/src/hooks/queries/__tests__/useWishlist.test.tsx
+++ b/apps/web/src/hooks/queries/__tests__/useWishlist.test.tsx
@@ -1,0 +1,48 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * useWishlist mutation hooks — #3231: the "Rimuovi" action must surface failures
+ * (previously useRemoveFromWishlist had no onError, so it failed silently).
+ */
+import { type ReactNode } from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { toast } from '@/components/layout/Toast';
+
+import { useRemoveFromWishlist } from '../useWishlist';
+
+const mockRemove = vi.hoisted(() => vi.fn());
+vi.mock('@/lib/api', () => ({ api: { wishlist: { remove: mockRemove } } }));
+vi.mock('@/components/layout/Toast', () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
+describe('useRemoveFromWishlist', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('shows an error toast when removal fails', async () => {
+    mockRemove.mockRejectedValue(new Error('boom'));
+
+    const { result } = renderHook(() => useRemoveFromWishlist(), { wrapper });
+
+    await expect(result.current.mutateAsync('id-1')).rejects.toThrow('boom');
+    await waitFor(() => expect(vi.mocked(toast.error)).toHaveBeenCalled());
+  });
+
+  it('does not show an error toast on success', async () => {
+    mockRemove.mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useRemoveFromWishlist(), { wrapper });
+
+    await result.current.mutateAsync('id-1');
+    expect(vi.mocked(toast.error)).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/hooks/queries/useWishlist.ts
+++ b/apps/web/src/hooks/queries/useWishlist.ts
@@ -4,6 +4,7 @@
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
+import { toast } from '@/components/layout/Toast';
 import { api } from '@/lib/api';
 import type {
   AddToWishlistRequest,
@@ -57,6 +58,10 @@ export function useRemoveFromWishlist() {
     mutationFn: (id: string) => api.wishlist.remove(id),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: wishlistKeys.all });
+    },
+    // #3231: surface removal failures — the action failed silently before.
+    onError: () => {
+      toast.error('Impossibile rimuovere il gioco dalla wishlist.');
     },
   });
 }

--- a/apps/web/src/lib/api/clients/admin/__tests__/adminMonitorClient.test.ts
+++ b/apps/web/src/lib/api/clients/admin/__tests__/adminMonitorClient.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+
+import { createAdminMonitorClient } from '../adminMonitorClient';
+
+// Minimal HttpClient stub — only `get` is exercised by getAlertHistory.
+const makeHttp = (payload: unknown) =>
+  ({
+    get: async () => payload,
+    post: async () => undefined,
+    put: async () => undefined,
+    patch: async () => undefined,
+    delete: async () => undefined,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  }) as any;
+
+describe('adminMonitorClient.getAlertHistory', () => {
+  it('normalizes lowercase API severities to canonical Title-Case without throwing (#3231)', async () => {
+    // The backend contract (alerts.schemas.ts) emits lowercase 'critical'/'warning'/'error'/'info';
+    // the client previously used a strict PascalCase z.enum().parse() that threw on every real alert.
+    const client = createAdminMonitorClient(
+      makeHttp(
+        ['critical', 'error', 'warning', 'info', 'nonsense'].map((severity, i) => ({
+          id: String(i),
+          alertType: 'x',
+          severity,
+          message: 'm',
+          metadata: null,
+          triggeredAt: 't',
+          resolvedAt: null,
+          isActive: true,
+          channelSent: null,
+        }))
+      )
+    );
+
+    const out = await client.getAlertHistory();
+
+    // error → Critical (the AlertHistoryTab badge has no Error case); unknown → Info.
+    expect(out.map(a => a.severity)).toEqual(['Critical', 'Critical', 'Warning', 'Info', 'Info']);
+  });
+});

--- a/apps/web/src/lib/api/clients/admin/adminMonitorClient.ts
+++ b/apps/web/src/lib/api/clients/admin/adminMonitorClient.ts
@@ -259,7 +259,24 @@ export function createAdminMonitorClient(http: HttpClient) {
       const AlertHistoryItemSchema = z.object({
         id: z.string(),
         alertType: z.string(),
-        severity: z.enum(['Critical', 'Warning', 'Info']),
+        // #3231: the API emits lowercase severities ('critical'/'warning'/'error'/'info'); normalize
+        // to canonical Title-Case (never throw) instead of a strict PascalCase enum that rejected
+        // nearly every real alert. 'error' maps to 'Critical' (the badge/filter have no Error case).
+        severity: z.preprocess(
+          v => {
+            const s = typeof v === 'string' ? v.trim().toLowerCase() : '';
+            switch (s) {
+              case 'critical':
+              case 'error':
+                return 'Critical';
+              case 'warning':
+                return 'Warning';
+              default:
+                return 'Info';
+            }
+          },
+          z.enum(['Critical', 'Warning', 'Info'])
+        ),
         message: z.string(),
         metadata: z.record(z.string(), z.unknown()).nullable(),
         triggeredAt: z.string(),


### PR DESCRIPTION
Bundle di 4 bug di robustezza frontend (discovery avversariale `/sc:spec-panel`), fix piccoli e indipendenti.

| # | File | Bug | Fix |
|---|---|---|---|
| **7** | `adminMonitorClient.ts` | `getAlertHistory` usa `z.enum(['Critical','Warning','Info']).parse()` ma l'API ritorna lowercase → **parse throws per quasi tutti gli alert** | `z.preprocess` normalizzatore never-throw → Title-Case (error→Critical, unknown→Info) |
| **12** | `useWishlist.ts` | `useRemoveFromWishlist` senza `onError` → "Rimuovi" **fallisce silenziosamente** | `onError` con toast di errore |
| **13** | `CircuitBreakerGrid.tsx` | `setInterval` del countdown mai cleared a zero → **timer 1Hz permanente per card** | `clearInterval` dentro il tick a zero |
| **17** | `PdfVersionManager.tsx` | `Promise.all` senza try/catch → **dialog bloccato + stato RAG parziale** su fallimento | `Promise.allSettled`: dialog aperto + invalidate + retry toast; success solo se tutte riescono |

## TDD (Vitest)
- **#7 e #12**: test dedicati RED→GREEN (parse-throw / no-toast prima del fix).
- **#13 e #17**: fix self-contained + **regression guard** sulle suite esistenti (`CircuitBreakerGrid.test`, `PdfVersionManager.test`).
- **27 test verdi** in totale.

Closes #3231

🤖 Generated with [Claude Code](https://claude.com/claude-code)