### PR TITLE
fix(sessions): #3196 score editor mobile touch-targets

### DIFF
--- a/apps/web/src/components/sessions/score-strategies/BinaryWinEditor.tsx
+++ b/apps/web/src/components/sessions/score-strategies/BinaryWinEditor.tsx
@@ -61,7 +61,7 @@ export function BinaryWinEditor({
             <span className="flex-1 font-medium">{player.displayName}</span>
             <fieldset className="flex gap-3" disabled={disabled}>
               <legend className="sr-only">{`Risultato per ${player.displayName}`}</legend>
-              <label className="flex items-center gap-1">
+              <label className="flex min-h-[44px] items-center gap-2 rounded-md border border-border px-3 md:min-h-0 md:gap-1 md:rounded-none md:border-0 md:px-0">
                 <input
                   type="radio"
                   name={`binary-${player.id}`}
@@ -71,7 +71,7 @@ export function BinaryWinEditor({
                 />
                 <span>Win</span>
               </label>
-              <label className="flex items-center gap-1">
+              <label className="flex min-h-[44px] items-center gap-2 rounded-md border border-border px-3 md:min-h-0 md:gap-1 md:rounded-none md:border-0 md:px-0">
                 <input
                   type="radio"
                   name={`binary-${player.id}`}

--- a/apps/web/src/components/sessions/score-strategies/ObjectivesEditor.tsx
+++ b/apps/web/src/components/sessions/score-strategies/ObjectivesEditor.tsx
@@ -98,13 +98,14 @@ export function ObjectivesEditor({
                 return (
                   <label
                     key={objective}
-                    className="inline-flex items-center gap-1 rounded-md border border-border-strong px-2 py-1 text-sm"
+                    className="inline-flex min-h-[44px] items-center gap-2 rounded-md border border-border-strong px-3 py-2 text-sm md:min-h-0 md:gap-1 md:px-2 md:py-1"
                   >
                     <input
                       type="checkbox"
                       checked={checked}
                       onChange={() => toggle(player.id, objective)}
                       data-testid={testId}
+                      className="size-5 md:size-4"
                     />
                     <span>{objective}</span>
                   </label>

--- a/apps/web/src/components/sessions/score-strategies/PointsEditor.tsx
+++ b/apps/web/src/components/sessions/score-strategies/PointsEditor.tsx
@@ -64,12 +64,13 @@ export function PointsEditor({ players, initialData, onChange, disabled }: Point
           <input
             id={`points-${player.id}`}
             type="number"
+            inputMode="numeric"
             min={0}
             value={scores[player.id] ?? 0}
             onChange={e => handleChange(player.id, e.target.value)}
             disabled={disabled}
             data-testid={`points-input-${player.id}`}
-            className="w-24 rounded-md border border-border bg-background px-3 py-1 text-right tabular-nums"
+            className="w-24 min-h-[44px] rounded-md border border-border bg-background px-3 py-1 text-right tabular-nums md:min-h-0"
           />
         </div>
       ))}

--- a/apps/web/src/components/sessions/score-strategies/RankingEditor.tsx
+++ b/apps/web/src/components/sessions/score-strategies/RankingEditor.tsx
@@ -56,10 +56,23 @@ interface RankableItemProps {
   id: string;
   displayName: string;
   position: number;
+  isFirst: boolean;
+  isLast: boolean;
+  onMoveUp: () => void;
+  onMoveDown: () => void;
   disabled?: boolean;
 }
 
-function RankableItem({ id, displayName, position, disabled }: RankableItemProps) {
+function RankableItem({
+  id,
+  displayName,
+  position,
+  isFirst,
+  isLast,
+  onMoveUp,
+  onMoveDown,
+  disabled,
+}: RankableItemProps) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id,
     disabled,
@@ -90,10 +103,33 @@ function RankableItem({ id, displayName, position, disabled }: RankableItemProps
         disabled={disabled}
         aria-label={`Trascina ${displayName}`}
         data-testid={`ranking-handle-${id}`}
-        className="cursor-grab disabled:cursor-not-allowed"
+        className="inline-flex min-h-[44px] min-w-[44px] cursor-grab items-center justify-center disabled:cursor-not-allowed md:min-h-0 md:min-w-0"
       >
         ⋮⋮
       </button>
+      {/* #3196: touch-friendly reorder — mobile-only; drag stays the desktop path. */}
+      <div className="flex gap-1 md:hidden">
+        <button
+          type="button"
+          onClick={onMoveUp}
+          disabled={disabled || isFirst}
+          aria-label={`Sposta ${displayName} su`}
+          data-testid={`ranking-up-${id}`}
+          className="inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-md border border-border disabled:opacity-40"
+        >
+          ▲
+        </button>
+        <button
+          type="button"
+          onClick={onMoveDown}
+          disabled={disabled || isLast}
+          aria-label={`Sposta ${displayName} giù`}
+          data-testid={`ranking-down-${id}`}
+          className="inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-md border border-border disabled:opacity-40"
+        >
+          ▼
+        </button>
+      </div>
     </li>
   );
 }
@@ -123,6 +159,15 @@ export function RankingEditor({ players, initialData, onChange, disabled }: Rank
     });
   };
 
+  // #3196: mobile arrow reorder — shares the same arrayMove path as drag.
+  const move = (index: number, dir: -1 | 1) => {
+    setIds(prev => {
+      const target = index + dir;
+      if (target < 0 || target >= prev.length) return prev;
+      return arrayMove(prev, index, target);
+    });
+  };
+
   const playerMap = new Map(players.map(p => [p.id, p]));
 
   return (
@@ -138,6 +183,10 @@ export function RankingEditor({ players, initialData, onChange, disabled }: Rank
                 id={id}
                 displayName={player.displayName}
                 position={idx + 1}
+                isFirst={idx === 0}
+                isLast={idx === ids.length - 1}
+                onMoveUp={() => move(idx, -1)}
+                onMoveDown={() => move(idx, 1)}
                 disabled={disabled}
               />
             );

--- a/apps/web/src/components/sessions/score-strategies/__tests__/BinaryWinEditor.test.tsx
+++ b/apps/web/src/components/sessions/score-strategies/__tests__/BinaryWinEditor.test.tsx
@@ -99,4 +99,13 @@ describe('BinaryWinEditor', () => {
       ],
     });
   });
+
+  // #3196: mobile touch-target on the Win/Lose rows.
+  it('gives each Win/Lose row a 44px touch target', () => {
+    render(<BinaryWinEditor players={PLAYERS} onChange={vi.fn()} />);
+    const winLabel = screen.getByTestId('binary-win-p1').closest('label');
+    const loseLabel = screen.getByTestId('binary-lose-p1').closest('label');
+    expect(winLabel).toHaveClass('min-h-[44px]');
+    expect(loseLabel).toHaveClass('min-h-[44px]');
+  });
 });

--- a/apps/web/src/components/sessions/score-strategies/__tests__/ObjectivesEditor.test.tsx
+++ b/apps/web/src/components/sessions/score-strategies/__tests__/ObjectivesEditor.test.tsx
@@ -113,4 +113,13 @@ describe('ObjectivesEditor', () => {
     );
     OBJECTIVES.forEach(o => expect(screen.getByTestId(`obj-p1-${o}`)).toBeDisabled());
   });
+
+  // #3196: mobile touch-target on the objective chips.
+  it('gives each objective chip a 44px touch target', () => {
+    render(
+      <ObjectivesEditor players={PLAYERS} availableObjectives={OBJECTIVES} onChange={vi.fn()} />
+    );
+    const chip = screen.getByTestId(`obj-p1-${OBJECTIVES[0]}`).closest('label');
+    expect(chip).toHaveClass('min-h-[44px]');
+  });
 });

--- a/apps/web/src/components/sessions/score-strategies/__tests__/PointsEditor.test.tsx
+++ b/apps/web/src/components/sessions/score-strategies/__tests__/PointsEditor.test.tsx
@@ -82,4 +82,12 @@ describe('PointsEditor', () => {
       ],
     });
   });
+
+  // #3196: mobile touch-target.
+  it('sizes the input for touch (min-h-[44px]) with a numeric keypad', () => {
+    render(<PointsEditor players={PLAYERS} onChange={vi.fn()} />);
+    const input = screen.getByTestId('points-input-p1');
+    expect(input).toHaveClass('min-h-[44px]');
+    expect(input).toHaveAttribute('inputmode', 'numeric');
+  });
 });

--- a/apps/web/src/components/sessions/score-strategies/__tests__/RankingEditor.test.tsx
+++ b/apps/web/src/components/sessions/score-strategies/__tests__/RankingEditor.test.tsx
@@ -10,7 +10,7 @@
  * Asse D follow-up P1 (#1899) T3.
  */
 
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
 import { RankingEditor } from '../RankingEditor';
@@ -107,5 +107,57 @@ describe('RankingEditor', () => {
     );
     expect(screen.getByTestId('ranking-item-p1')).toBeInTheDocument();
     expect(screen.queryByTestId('ranking-item-p2')).not.toBeInTheDocument();
+  });
+
+  // #3196: mobile touch-targets — enlarged handle + touch-friendly up/down reorder.
+  it('enlarges the drag handle to a 44px touch target', () => {
+    render(<RankingEditor players={PLAYERS} onChange={vi.fn()} />);
+    const handle = screen.getByTestId('ranking-handle-p1');
+    expect(handle).toHaveClass('min-h-[44px]');
+    expect(handle).toHaveClass('min-w-[44px]');
+  });
+
+  it('reorders via the mobile up arrow', () => {
+    const onChange = vi.fn();
+    render(<RankingEditor players={PLAYERS} onChange={onChange} />);
+    fireEvent.click(screen.getByTestId('ranking-up-p2'));
+    expect(onChange).toHaveBeenLastCalledWith({
+      positions: [
+        { playerId: 'p2', position: 1 },
+        { playerId: 'p1', position: 2 },
+        { playerId: 'p3', position: 3 },
+      ],
+    });
+  });
+
+  it('reorders via the mobile down arrow', () => {
+    const onChange = vi.fn();
+    render(<RankingEditor players={PLAYERS} onChange={onChange} />);
+    fireEvent.click(screen.getByTestId('ranking-down-p1'));
+    expect(onChange).toHaveBeenLastCalledWith({
+      positions: [
+        { playerId: 'p2', position: 1 },
+        { playerId: 'p1', position: 2 },
+        { playerId: 'p3', position: 3 },
+      ],
+    });
+  });
+
+  it('disables up on the first item and down on the last', () => {
+    render(<RankingEditor players={PLAYERS} onChange={vi.fn()} />);
+    expect(screen.getByTestId('ranking-up-p1')).toBeDisabled();
+    expect(screen.getByTestId('ranking-down-p3')).toBeDisabled();
+  });
+
+  it('disables reorder arrows when the disabled prop is set', () => {
+    render(<RankingEditor players={PLAYERS} onChange={vi.fn()} disabled />);
+    expect(screen.getByTestId('ranking-up-p2')).toBeDisabled();
+    expect(screen.getByTestId('ranking-down-p2')).toBeDisabled();
+  });
+
+  it('hides the reorder arrows on desktop (md:hidden wrapper)', () => {
+    render(<RankingEditor players={PLAYERS} onChange={vi.fn()} />);
+    // The md:hidden lives on the wrapper div, not the buttons.
+    expect(screen.getByTestId('ranking-up-p2').closest('div')).toHaveClass('md:hidden');
   });
 });

--- a/docs/superpowers/plans/2026-07-20-issue-3196-score-editor-touch-targets.md
+++ b/docs/superpowers/plans/2026-07-20-issue-3196-score-editor-touch-targets.md
@@ -1,0 +1,434 @@
+# Score Editor Mobile Touch-Targets Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bring the 4 polymorphic score-type editors to touch-target ≥44px on mobile without changing desktop or the autosave contract.
+
+**Architecture:** Each editor is a pure controlled component under `apps/web/src/components/sessions/score-strategies/`. Changes are mobile-first Tailwind: base `min-h-[44px]` (+ analogous width/padding), `md:` overrides restore the current compact desktop. `RankingEditor` additionally gets a mobile-only up/down arrow reorder path (`md:hidden`) because drag stays fiddly on touch. No change to `PolymorphicScoreEditor`, `ScoreTabContent`, or `useUpdateSessionScores` — the `onChange` snapshot contract is untouched.
+
+**Tech Stack:** Next.js 16 / React 19 / Tailwind 4 / Vitest + Testing Library / `@dnd-kit` (Ranking).
+
+## Global Constraints
+
+- Mobile-first: base classes ≥44px; restore desktop with `md:` overrides. New Ranking arrows are `md:hidden`.
+- Do NOT touch `onChange` payloads — every editor emits the same snapshot shape as today.
+- Tests assert `toHaveClass('min-h-[44px]')` / `min-w-[44px]` — jsdom `getBoundingClientRect` is always 0, so real px cannot be measured.
+- Semantic tokens only in classNames (`border-border`, `border-border-strong`, …). No hardcoded color utilities (ESLint `local/no-hardcoded-color-utility` is an error).
+- Commit-msg hook: subject `feat|fix|docs|refactor|test|chore(scope): …`, ≤72 chars.
+- Run tests per-file (`pnpm exec vitest run <path>`) — a full single-process run has known mock pollution locally. Working dir for test/lint commands is `apps/web/`.
+- Background `git commit` (the pre-commit hook runs a full FE typecheck, ~5 min).
+
+---
+
+### Task 1: PointsEditor — 44px numeric input
+
+**Files:**
+- Modify: `apps/web/src/components/sessions/score-strategies/PointsEditor.tsx:64-73`
+- Test: `apps/web/src/components/sessions/score-strategies/__tests__/PointsEditor.test.tsx`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: nothing new (props/`onChange` unchanged).
+
+- [ ] **Step 1: Write the failing test** — append inside the `describe('PointsEditor', …)` block (before its closing `});`):
+
+```tsx
+  it('sizes the input for touch (min-h-[44px]) with a numeric keypad', () => {
+    render(<PointsEditor players={PLAYERS} onChange={vi.fn()} />);
+    const input = screen.getByTestId('points-input-p1');
+    expect(input).toHaveClass('min-h-[44px]');
+    expect(input).toHaveAttribute('inputmode', 'numeric');
+  });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/web && pnpm exec vitest run "src/components/sessions/score-strategies/__tests__/PointsEditor.test.tsx"`
+Expected: FAIL — input lacks `min-h-[44px]` and `inputmode`.
+
+- [ ] **Step 3: Write minimal implementation** — replace the `<input>` at `PointsEditor.tsx:64-73`:
+
+```tsx
+          <input
+            id={`points-${player.id}`}
+            type="number"
+            inputMode="numeric"
+            min={0}
+            value={scores[player.id] ?? 0}
+            onChange={e => handleChange(player.id, e.target.value)}
+            disabled={disabled}
+            data-testid={`points-input-${player.id}`}
+            className="w-24 min-h-[44px] rounded-md border border-border bg-background px-3 py-1 text-right tabular-nums md:min-h-0"
+          />
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/web && pnpm exec vitest run "src/components/sessions/score-strategies/__tests__/PointsEditor.test.tsx"`
+Expected: PASS (all tests, including the 6 pre-existing ones).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add "apps/web/src/components/sessions/score-strategies/PointsEditor.tsx" "apps/web/src/components/sessions/score-strategies/__tests__/PointsEditor.test.tsx"
+git commit -m "fix(sessions): #3196 PointsEditor 44px touch target"
+```
+
+---
+
+### Task 2: BinaryWinEditor — 44px Win/Lose rows
+
+**Files:**
+- Modify: `apps/web/src/components/sessions/score-strategies/BinaryWinEditor.tsx:64-83`
+- Test: `apps/web/src/components/sessions/score-strategies/__tests__/BinaryWinEditor.test.tsx`
+
+**Interfaces:**
+- Consumes: nothing new. Existing testids: `binary-win-<id>` / `binary-lose-<id>` (the radio inputs).
+- Produces: nothing new.
+
+- [ ] **Step 1: Write the failing test** — append inside the `describe('BinaryWinEditor', …)` block:
+
+```tsx
+  it('gives each Win/Lose row a 44px touch target', () => {
+    render(<BinaryWinEditor players={PLAYERS} onChange={vi.fn()} />);
+    const winLabel = screen.getByTestId('binary-win-p1').closest('label');
+    const loseLabel = screen.getByTestId('binary-lose-p1').closest('label');
+    expect(winLabel).toHaveClass('min-h-[44px]');
+    expect(loseLabel).toHaveClass('min-h-[44px]');
+  });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/web && pnpm exec vitest run "src/components/sessions/score-strategies/__tests__/BinaryWinEditor.test.tsx"`
+Expected: FAIL — labels lack `min-h-[44px]`.
+
+- [ ] **Step 3: Write minimal implementation** — replace both `<label>` opening tags at `BinaryWinEditor.tsx:64` and `:74` (each currently `<label className="flex items-center gap-1">`) with:
+
+```tsx
+              <label className="flex min-h-[44px] items-center gap-2 rounded-md border border-border px-3 md:min-h-0 md:gap-1 md:rounded-none md:border-0 md:px-0">
+```
+
+(Apply the identical className to both the Win label and the Lose label; the `<input type="radio">` and `<span>` children are unchanged.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/web && pnpm exec vitest run "src/components/sessions/score-strategies/__tests__/BinaryWinEditor.test.tsx"`
+Expected: PASS (all tests, including pre-existing).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add "apps/web/src/components/sessions/score-strategies/BinaryWinEditor.tsx" "apps/web/src/components/sessions/score-strategies/__tests__/BinaryWinEditor.test.tsx"
+git commit -m "fix(sessions): #3196 BinaryWinEditor 44px touch rows"
+```
+
+---
+
+### Task 3: ObjectivesEditor — 44px chips
+
+**Files:**
+- Modify: `apps/web/src/components/sessions/score-strategies/ObjectivesEditor.tsx:99-110`
+- Test: `apps/web/src/components/sessions/score-strategies/__tests__/ObjectivesEditor.test.tsx`
+
+**Interfaces:**
+- Consumes: nothing new. Existing checkbox testid: `obj-<playerId>-<objective>`.
+- Produces: nothing new.
+
+- [ ] **Step 1: Write the failing test** — append inside the `describe('ObjectivesEditor', …)` block. Use the same `availableObjectives` value the file's other tests pass (inspect the top of the test file; if they use e.g. `['Templi', 'Maggioranze']`, reuse it):
+
+```tsx
+  it('gives each objective chip a 44px touch target', () => {
+    render(
+      <ObjectivesEditor
+        players={PLAYERS}
+        availableObjectives={OBJECTIVES}
+        onChange={vi.fn()}
+      />
+    );
+    const chip = screen.getByTestId(`obj-p1-${OBJECTIVES[0]}`).closest('label');
+    expect(chip).toHaveClass('min-h-[44px]');
+  });
+```
+
+(Reuse the existing `PLAYERS` and objectives constant already defined in the test file; if the objectives constant has a different name, use it — do not redeclare.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/web && pnpm exec vitest run "src/components/sessions/score-strategies/__tests__/ObjectivesEditor.test.tsx"`
+Expected: FAIL — chip label lacks `min-h-[44px]`.
+
+- [ ] **Step 3: Write minimal implementation** — at `ObjectivesEditor.tsx`, replace the chip `<label>` className (`:101`) and add a size class to the checkbox (`:103-107`):
+
+```tsx
+                  <label
+                    key={objective}
+                    className="inline-flex min-h-[44px] items-center gap-2 rounded-md border border-border-strong px-3 py-2 text-sm md:min-h-0 md:gap-1 md:px-2 md:py-1"
+                  >
+                    <input
+                      type="checkbox"
+                      checked={checked}
+                      onChange={() => toggle(player.id, objective)}
+                      data-testid={testId}
+                      className="size-5 md:size-4"
+                    />
+                    <span>{objective}</span>
+                  </label>
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/web && pnpm exec vitest run "src/components/sessions/score-strategies/__tests__/ObjectivesEditor.test.tsx"`
+Expected: PASS (all tests, including pre-existing).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add "apps/web/src/components/sessions/score-strategies/ObjectivesEditor.tsx" "apps/web/src/components/sessions/score-strategies/__tests__/ObjectivesEditor.test.tsx"
+git commit -m "fix(sessions): #3196 ObjectivesEditor 44px chips"
+```
+
+---
+
+### Task 4: RankingEditor — 44px handle + mobile up/down arrows
+
+**Files:**
+- Modify: `apps/web/src/components/sessions/score-strategies/RankingEditor.tsx` (`RankableItemProps` `:55-60`, `RankableItem` `:62-99`, `RankingEditor` `:101-148`)
+- Test: `apps/web/src/components/sessions/score-strategies/__tests__/RankingEditor.test.tsx`
+
+**Interfaces:**
+- Consumes: `arrayMove` (already imported from `@dnd-kit/sortable`).
+- Produces (internal to this file, used only by `RankableItem`): `RankableItemProps` gains `isFirst: boolean`, `isLast: boolean`, `onMoveUp: () => void`, `onMoveDown: () => void`. New testids: `ranking-up-<id>`, `ranking-down-<id>`.
+
+- [ ] **Step 1: Write the failing test** — the test file currently imports `{ render, screen }`; change that import line to add `fireEvent`:
+
+```tsx
+import { fireEvent, render, screen } from '@testing-library/react';
+```
+
+Then append inside the `describe('RankingEditor', …)` block:
+
+```tsx
+  it('enlarges the drag handle to a 44px touch target', () => {
+    render(<RankingEditor players={PLAYERS} onChange={vi.fn()} />);
+    const handle = screen.getByTestId('ranking-handle-p1');
+    expect(handle).toHaveClass('min-h-[44px]');
+    expect(handle).toHaveClass('min-w-[44px]');
+  });
+
+  it('reorders via the mobile up arrow', () => {
+    const onChange = vi.fn();
+    render(<RankingEditor players={PLAYERS} onChange={onChange} />);
+    fireEvent.click(screen.getByTestId('ranking-up-p2'));
+    expect(onChange).toHaveBeenLastCalledWith({
+      positions: [
+        { playerId: 'p2', position: 1 },
+        { playerId: 'p1', position: 2 },
+        { playerId: 'p3', position: 3 },
+      ],
+    });
+  });
+
+  it('reorders via the mobile down arrow', () => {
+    const onChange = vi.fn();
+    render(<RankingEditor players={PLAYERS} onChange={onChange} />);
+    fireEvent.click(screen.getByTestId('ranking-down-p1'));
+    expect(onChange).toHaveBeenLastCalledWith({
+      positions: [
+        { playerId: 'p2', position: 1 },
+        { playerId: 'p1', position: 2 },
+        { playerId: 'p3', position: 3 },
+      ],
+    });
+  });
+
+  it('disables up on the first item and down on the last', () => {
+    render(<RankingEditor players={PLAYERS} onChange={vi.fn()} />);
+    expect(screen.getByTestId('ranking-up-p1')).toBeDisabled();
+    expect(screen.getByTestId('ranking-down-p3')).toBeDisabled();
+  });
+
+  it('disables reorder arrows when the disabled prop is set', () => {
+    render(<RankingEditor players={PLAYERS} onChange={vi.fn()} disabled />);
+    expect(screen.getByTestId('ranking-up-p2')).toBeDisabled();
+    expect(screen.getByTestId('ranking-down-p2')).toBeDisabled();
+  });
+
+  it('hides the reorder arrows on desktop (md:hidden wrapper)', () => {
+    render(<RankingEditor players={PLAYERS} onChange={vi.fn()} />);
+    // The md:hidden lives on the wrapper div, not the buttons.
+    expect(screen.getByTestId('ranking-up-p2').closest('div')).toHaveClass('md:hidden');
+  });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/web && pnpm exec vitest run "src/components/sessions/score-strategies/__tests__/RankingEditor.test.tsx"`
+Expected: FAIL — no `ranking-up-*`/`ranking-down-*` elements, handle lacks 44px classes.
+
+- [ ] **Step 3: Write minimal implementation**
+
+3a. Extend `RankableItemProps` (`:55-60`):
+
+```tsx
+interface RankableItemProps {
+  id: string;
+  displayName: string;
+  position: number;
+  isFirst: boolean;
+  isLast: boolean;
+  onMoveUp: () => void;
+  onMoveDown: () => void;
+  disabled?: boolean;
+}
+```
+
+3b. Replace the `RankableItem` function body's destructure + returned `<li>` markup (`:62-99`) — enlarge the handle and add a mobile-only arrow group:
+
+```tsx
+function RankableItem({
+  id,
+  displayName,
+  position,
+  isFirst,
+  isLast,
+  onMoveUp,
+  onMoveDown,
+  disabled,
+}: RankableItemProps) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id,
+    disabled,
+  });
+
+  return (
+    <li
+      ref={setNodeRef}
+      style={{
+        transform: CSS.Transform.toString(transform),
+        transition,
+        opacity: isDragging ? 0.5 : 1,
+      }}
+      className="flex items-center gap-3 rounded-md border border-border bg-card p-3"
+      data-testid={`ranking-item-${id}`}
+    >
+      <span
+        className="w-8 font-mono text-lg font-bold tabular-nums"
+        data-testid={`ranking-position-${id}`}
+      >
+        {position}
+      </span>
+      <span className="flex-1 font-medium">{displayName}</span>
+      <button
+        type="button"
+        {...attributes}
+        {...listeners}
+        disabled={disabled}
+        aria-label={`Trascina ${displayName}`}
+        data-testid={`ranking-handle-${id}`}
+        className="inline-flex min-h-[44px] min-w-[44px] cursor-grab items-center justify-center disabled:cursor-not-allowed md:min-h-0 md:min-w-0"
+      >
+        ⋮⋮
+      </button>
+      <div className="flex gap-1 md:hidden">
+        <button
+          type="button"
+          onClick={onMoveUp}
+          disabled={disabled || isFirst}
+          aria-label={`Sposta ${displayName} su`}
+          data-testid={`ranking-up-${id}`}
+          className="inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-md border border-border disabled:opacity-40"
+        >
+          ▲
+        </button>
+        <button
+          type="button"
+          onClick={onMoveDown}
+          disabled={disabled || isLast}
+          aria-label={`Sposta ${displayName} giù`}
+          data-testid={`ranking-down-${id}`}
+          className="inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-md border border-border disabled:opacity-40"
+        >
+          ▼
+        </button>
+      </div>
+    </li>
+  );
+}
+```
+
+3c. In `RankingEditor` add the `move` handler (after the `handleDragEnd` definition, before `playerMap`):
+
+```tsx
+  const move = (index: number, dir: -1 | 1) => {
+    setIds(prev => {
+      const target = index + dir;
+      if (target < 0 || target >= prev.length) return prev;
+      return arrayMove(prev, index, target);
+    });
+  };
+```
+
+3d. Pass the new props at the `<RankableItem …>` call site (`:136-142`):
+
+```tsx
+              <RankableItem
+                key={id}
+                id={id}
+                displayName={player.displayName}
+                position={idx + 1}
+                isFirst={idx === 0}
+                isLast={idx === ids.length - 1}
+                onMoveUp={() => move(idx, -1)}
+                onMoveDown={() => move(idx, 1)}
+                disabled={disabled}
+              />
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/web && pnpm exec vitest run "src/components/sessions/score-strategies/__tests__/RankingEditor.test.tsx"`
+Expected: PASS (all tests, including the 6 pre-existing ones).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add "apps/web/src/components/sessions/score-strategies/RankingEditor.tsx" "apps/web/src/components/sessions/score-strategies/__tests__/RankingEditor.test.tsx"
+git commit -m "fix(sessions): #3196 RankingEditor 44px handle + touch reorder"
+```
+
+---
+
+### Task 5: Verify — full editor suite + lint + typecheck
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run the whole score-strategies suite**
+
+Run: `cd apps/web && pnpm exec vitest run "src/components/sessions/score-strategies"`
+Expected: PASS — all 4 editors' tests green (new + pre-existing).
+
+- [ ] **Step 2: Run the dispatcher + host consumers (regression)**
+
+Run: `cd apps/web && pnpm exec vitest run "src/components/sessions" "src/app/(authenticated)/sessions/[id]/live/_components/__tests__/ScoreTabContent.test.tsx" "src/app/(authenticated)/sessions/[id]/live/_components/__tests__/SessionLiveView.test.tsx"`
+Expected: PASS — `PolymorphicScoreEditor`, `ScoreTabContent`, `SessionLiveView` unaffected.
+
+- [ ] **Step 3: Lint the 4 changed source files**
+
+Run: `cd apps/web && pnpm exec eslint "src/components/sessions/score-strategies/PointsEditor.tsx" "src/components/sessions/score-strategies/BinaryWinEditor.tsx" "src/components/sessions/score-strategies/ObjectivesEditor.tsx" "src/components/sessions/score-strategies/RankingEditor.tsx"`
+Expected: 0 errors (test files are eslint-ignored — a "File ignored" warning on them is fine).
+
+- [ ] **Step 4: Typecheck**
+
+Run: `cd apps/web && pnpm typecheck`
+Expected: no errors (tsc exits 0).
+
+---
+
+## Self-Review
+
+**Spec coverage** — every spec §4 change maps to a task: Points (T1), BinaryWin (T2), Objectives (T3), Ranking handle + arrows (T4); §5 testing folded per-task + T5 regression; §7 DoD covered by T1-T5. No gaps.
+
+**Placeholder scan** — Task 3's objectives constant is intentionally deferred to the test file's existing value (the implementer reuses it rather than guessing); every other step has complete code. No TBD/TODO.
+
+**Type consistency** — `move(index, dir)`, `isFirst`/`isLast`/`onMoveUp`/`onMoveDown` on `RankableItemProps`, and testids `ranking-up-<id>`/`ranking-down-<id>` are used consistently between the T4 test and implementation. `onChange` payload shapes in T4 tests match the existing `RankingScoreData` positions contract.

--- a/docs/superpowers/specs/2026-07-20-issue-3196-score-editor-touch-targets-design.md
+++ b/docs/superpowers/specs/2026-07-20-issue-3196-score-editor-touch-targets-design.md
@@ -1,0 +1,104 @@
+# #3196 — Score editor mobile touch-targets (design)
+
+**Issue**: [#3196](https://github.com/meepleAi-app/meepleai-monorepo/issues/3196) · **Date**: 2026-07-20 · **Parent audit**: #2989 · **Branch**: `feature/issue-3196-score-editor-touch-targets`
+
+## 1. Context & corrected premise
+
+The issue title is `[design] Parità mobile session-live + session editor (wave #3)` and lists two surfaces. Discovery (code + test read, 2026-07-20) corrected the premise:
+
+- **Surface 1 — "session live immersiva mobile" is already shipped.** `SessionLiveView` (`apps/web/src/app/(authenticated)/sessions/[id]/live/_components/SessionLiveView.tsx`) already renders a full mobile shell (`MobileBody` `lg:hidden` → FAB → `MobileBottomSheetDrawer` Radix Sheet hosting the same polymorphic tabs, `LiveMobileMetaStrip`, mobile URL SSOT `?msheet`/`?mtab`/`?mchat`), covered by unit tests. This landed with epic #2374 T9; the CLAUDE.md "in-progress" note is stale. **No work needed.**
+- **Route correction**: the shell lives at **`/sessions/[id]/live`**, not `/game-nights/[id]/live` (which is the unrelated `NightLiveClientView`, #1255).
+- The referenced gap report (`2026-07-15-...-mobile.md` §2) registers session-live as a deferred "gap headline" with **no acceptance criteria** → this is genuinely a *design* task.
+
+**Real remaining scope: Surface 2 — the score editor touch-targets.** The 4 score-type editors have interactive controls below the 44px touch minimum. This spec covers only that.
+
+## 2. Scope
+
+**In scope** — bring the 4 editors in `apps/web/src/components/sessions/score-strategies/` to touch-target ≥44px on mobile:
+
+| Editor | Current control | Measured | Fix |
+|---|---|---|---|
+| `PointsEditor` | number input `px-3 py-1` | ~34px | enlarge input to ≥44px + `inputMode="numeric"` |
+| `BinaryWinEditor` | native radio + label row | radio ~16px, row ~24px | enlarge Win/Lose label rows to ≥44px (bordered tap area on mobile) |
+| `ObjectivesEditor` | chip `label` + native checkbox | chip ~30px, checkbox ~16px | enlarge chip to ≥44px, scale checkbox |
+| `RankingEditor` | drag-handle `⋮⋮` | ~24px | enlarge handle to ≥44px **+** add mobile-only up/down arrow reorder |
+
+**Out of scope**:
+- `SessionLiveView` mobile shell (already shipped).
+- Autosave / debounce / optimistic / rate-limit logic — lives entirely in `ScoreTabContent.tsx` (`useDebouncedCallback` 500ms → `useUpdateSessionScores`), **not** in the editors. Every editor is a dumb controlled component emitting a full snapshot via `onChange`; changing layout does not touch that contract.
+- `ScoreTabContent` wrapper (`<div className={className}>`) — no change.
+- Pre-existing hardcoded Italian strings in `BinaryWinEditor` ("Win"/"Lose") and `RankingEditor` aria-labels — out of scope for a layout-only pass.
+- Horizontal-overflow work — none needed; all editors are already single-column (`space-y-*`, `flex-wrap`).
+
+## 3. Design decisions (approved 2026-07-20)
+
+1. **Strategy = Hybrid.** Minimal `min-h-[44px]` enlargement on all existing controls (matches the SP8 B-02 regression-guard pattern, lowest risk) **plus** a targeted redesign only where the native control is genuinely unusable on touch: `RankingEditor` gains up/down arrows (drag stays fiddly on a 375px touchscreen even when the handle is enlarged).
+2. **Mobile-first, desktop preserved via `md:`.** Base classes apply ≥44px; `md:` overrides restore the current compact desktop sizing. New Ranking arrows are **mobile-only** (`md:hidden`); the drag handle stays as the desktop reorder path. Desktop layout is unchanged.
+3. **Test assertion = class-based.** Assert `toHaveClass('min-h-[44px]')` on the controls. jsdom's `getBoundingClientRect` is always 0, so real pixel height cannot be measured in unit tests; class assertion is deterministic and is the existing SP8 B-02 convention. A pixel-accurate check is deferred to an optional E2E skeleton (not part of this scope).
+
+## 4. Per-editor changes (exact)
+
+### 4.1 PointsEditor.tsx
+Input at `:64-73`: add `inputMode="numeric"` and prepend `min-h-[44px]` to the className, with `md:min-h-0` to restore desktop:
+```
+className="w-24 min-h-[44px] rounded-md border border-border bg-background px-3 py-1 text-right tabular-nums md:min-h-0"
+```
+
+### 4.2 BinaryWinEditor.tsx
+The two Win/Lose `<label>`s at `:64` and `:74`: give each a ≥44px bordered tap row on mobile, compact on desktop. Native radios + `fieldset`/`legend` a11y unchanged:
+```
+className="flex min-h-[44px] items-center gap-2 rounded-md border border-border px-3 md:min-h-0 md:gap-1 md:rounded-none md:border-0 md:px-0"
+```
+
+### 4.3 ObjectivesEditor.tsx
+Chip `<label>` at `:99-101`: enlarge on mobile, revert desktop; scale the checkbox:
+```
+className="inline-flex min-h-[44px] items-center gap-2 rounded-md border border-border-strong px-3 py-2 text-sm md:min-h-0 md:gap-1 md:px-2 md:py-1"
+```
+Checkbox at `:103`: add `className="size-5 md:size-4"`.
+
+### 4.4 RankingEditor.tsx
+1. **Handle** button at `:86-96`: enlarge to a 44×44 hit area on mobile, revert desktop:
+```
+className="inline-flex min-h-[44px] min-w-[44px] cursor-grab items-center justify-center disabled:cursor-not-allowed md:min-h-0 md:min-w-0"
+```
+2. **Up/down arrows (new, mobile-only).** Add a `move(index, dir)` handler in `RankingEditor`:
+```ts
+const move = (index: number, dir: -1 | 1) => {
+  setIds(prev => {
+    const target = index + dir;
+    if (target < 0 || target >= prev.length) return prev;
+    return arrayMove(prev, index, target);
+  });
+};
+```
+Thread `index`, `isFirst`, `isLast`, `onMoveUp`, `onMoveDown` into `RankableItem` and render a mobile-only pair of 44×44 buttons (`▲`/`▼`, `aria-label` "Sposta <name> su/giù", `data-testid` `ranking-up-<id>`/`ranking-down-<id>`, disabled at bounds, wrapped in `md:hidden`). Drag (`dnd-kit` PointerSensor + KeyboardSensor) and the `onChange` positions contract are untouched — the arrows call the same `setIds`/`arrayMove` path.
+
+## 5. Testing (TDD, RED→GREEN)
+
+Extend each editor's existing test in `apps/web/src/components/sessions/score-strategies/__tests__/`:
+- **Points**: input has `min-h-[44px]` and `inputMode="numeric"`.
+- **BinaryWin**: each Win/Lose label has `min-h-[44px]`.
+- **Objectives**: each chip label has `min-h-[44px]`.
+- **Ranking**:
+  - handle has `min-h-[44px]` and `min-w-[44px]`;
+  - up/down arrows render, are `md:hidden`, and reorder correctly — clicking `▲` on the 2nd item promotes it to position 1 and emits `positions` with the swapped order; clicking `▼` on the last item does nothing;
+  - first item's `▲` and last item's `▼` are `disabled`.
+
+**Invariant**: every existing editor test must stay green — the `onChange` snapshot contract is unchanged. No change to `PolymorphicScoreEditor`, `ScoreTabContent`, or `useUpdateSessionScores`.
+
+## 6. Files touched
+
+Source (4): `PointsEditor.tsx`, `BinaryWinEditor.tsx`, `ObjectivesEditor.tsx`, `RankingEditor.tsx` (all under `apps/web/src/components/sessions/score-strategies/`).
+Tests (4): the matching `__tests__/*.test.tsx`.
+
+No new dependencies, no backend change, no i18n key additions (arrow aria-labels reuse the existing inline Italian-string convention of the file).
+
+## 7. Acceptance criteria (DoD)
+
+- [ ] All interactive controls in the 4 editors are ≥44px on mobile (asserted via `min-h-[44px]`/`min-w-[44px]` classes).
+- [ ] Desktop sizing unchanged (verified by `md:` overrides + existing tests staying green).
+- [ ] Ranking has a touch-friendly up/down reorder path (mobile-only), drag preserved on desktop.
+- [ ] Autosave/debounce untouched; `onChange` contracts unchanged.
+- [ ] TDD test coverage added; full suite green; typecheck + eslint clean.
+- [ ] PR merged to `main-dev`.


### PR DESCRIPTION
Closes #3196.

## Premessa corretta durante il brainstorming

L'issue `[design] Parità mobile session-live + session editor` elencava 2 superfici. La discovery (lettura codice + test) ha corretto la premessa:

- **Surface 1 (shell mobile session-live) è già shippata** — `SessionLiveView` ha già `MobileBody` (`lg:hidden`) → FAB → `MobileBottomSheetDrawer` con gli stessi tab polimorfici + `LiveMobileMetaStrip` + URL SSOT mobile, coperto da test (epic #2374 T9). Il CLAUDE.md che la dice "in-progress" è stale.
- **Route corretta**: `/sessions/[id]/live` (non `/game-nights/[id]/live`, che è `NightLiveClientView`, #1255).
- Il gap report referenziato non contiene criteri per session-live → task di *design*.

Dettaglio nel commento sull'issue + spec/plan in `docs/superpowers/`.

## Scope reale: touch-target ≥44px sui 4 score editor

I 4 editor in `components/sessions/score-strategies/` avevano controlli sotto i 44px. Approccio **Hybrid** (mobile-first `min-h-[44px]`, desktop preservato via `md:`):

| Editor | Fix |
|---|---|
| **Points** | `min-h-[44px]` input + `inputMode="numeric"` |
| **BinaryWin** | righe Win/Lose ≥44px (bordo tap su mobile) |
| **Objectives** | chip ≥44px + checkbox `size-5` |
| **Ranking** | handle ≥44px **+** frecce su/giù mobile-only (`md:hidden`); drag dnd-kit resta il path desktop |

Il contratto `onChange` di ogni editor è **invariato** → autosave/debounce in `ScoreTabContent` non toccato.

## Testing & qualità

- **TDD** (RED→GREEN) sui 4 editor: **33/33** test (9 nuovi). Assert via `toHaveClass('min-h-[44px]')` (jsdom non misura px).
- **Regressione**: 190/190 su consumer (`PolymorphicScoreEditor`, `ScoreTabContent`, `SessionLiveView` 122 test). `typecheck` + `eslint` puliti.
- **Review**: piano verificato contro il codice (arrayMove, costanti, casing) + review olistica del diff = **0 difetti** (logica frecce, a11y/axe, contratto `md:`, invarianza `onChange`, token).

## DoD
- [x] Controlli ≥44px su mobile nei 4 editor
- [x] Desktop invariato (`md:` + test verdi)
- [x] Ranking riordino touch-friendly (frecce mobile-only), drag desktop preservato
- [x] Autosave/`onChange` intatti
- [x] TDD + regressione + lint + typecheck verdi
- [ ] Merge in `main-dev`

🤖 Generated with [Claude Code](https://claude.com/claude-code)