### PR TITLE
fix(catalog): #3236 bgg_id unique index respects soft-delete

### DIFF
--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/SharedGameCatalog/SharedGameEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/SharedGameCatalog/SharedGameEntityConfiguration.cs
@@ -184,10 +184,14 @@ internal class SharedGameEntityConfiguration : IEntityTypeConfiguration<SharedGa
             .OnDelete(DeleteBehavior.SetNull);
 
         // Indexes
+        // Issue #3236 — partial on is_deleted so a soft-deleted game does not permanently
+        // reserve its BGG id (mirrors ix_private_games_owner_bgg). Without "AND is_deleted =
+        // false", the unfiltered index blocks any new active game from reusing a bgg_id that a
+        // soft-deleted (app-invisible) row still holds.
         builder.HasIndex(e => e.BggId)
             .IsUnique()
             .HasDatabaseName("ix_shared_games_bgg_id")
-            .HasFilter("bgg_id IS NOT NULL");
+            .HasFilter("bgg_id IS NOT NULL AND is_deleted = false");
 
         builder.HasIndex(e => e.Status)
             .HasDatabaseName("ix_shared_games_status")

--- a/apps/api/src/Api/Infrastructure/Migrations/20260720105148_FixSharedGameBggIdSoftDeleteIndex.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260720105148_FixSharedGameBggIdSoftDeleteIndex.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260720105148_FixSharedGameBggIdSoftDeleteIndex")]
+    partial class FixSharedGameBggIdSoftDeleteIndex
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260720105148_FixSharedGameBggIdSoftDeleteIndex.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260720105148_FixSharedGameBggIdSoftDeleteIndex.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class FixSharedGameBggIdSoftDeleteIndex : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ix_shared_games_bgg_id",
+                table: "shared_games");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_shared_games_bgg_id",
+                table: "shared_games",
+                column: "bgg_id",
+                unique: true,
+                filter: "bgg_id IS NOT NULL AND is_deleted = false");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "ix_shared_games_bgg_id",
+                table: "shared_games");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_shared_games_bgg_id",
+                table: "shared_games",
+                column: "bgg_id",
+                unique: true,
+                filter: "bgg_id IS NOT NULL");
+        }
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Integration/SharedGameBggIdSoftDeleteIndexTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Integration/SharedGameBggIdSoftDeleteIndexTests.cs
@@ -1,0 +1,137 @@
+using System.Data;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Integration;
+
+/// <summary>
+/// Integration tests for the <c>ix_shared_games_bgg_id</c> partial unique index — Issue #3236.
+/// <para>
+/// The index was filtered only on <c>bgg_id IS NOT NULL</c>, missing <c>AND is_deleted = false</c>.
+/// Because <c>shared_games</c> is soft-deleted (a global <c>!IsDeleted</c> query filter hides deleted
+/// rows), a soft-deleted game permanently reserved its BGG id — no new active game could reuse it,
+/// even though every app-layer read excludes the deleted row. The sibling <c>private_games</c> index
+/// gets this right (<c>bgg_id IS NOT NULL AND is_deleted = false</c>).
+/// </para>
+/// Exercised against real Postgres via <see cref="SharedTestcontainersFixture"/> + the actual
+/// migrations (<c>MigrateAsync</c>) so the index definition under test is the real one.
+/// </summary>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("Dependency", "PostgreSQL")]
+[Trait("BoundedContext", "SharedGameCatalog")]
+[Trait("Issue", "3236")]
+public sealed class SharedGameBggIdSoftDeleteIndexTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private string _databaseName = null!;
+    private string _connectionString = null!;
+    private MeepleAiDbContext _dbContext = null!;
+
+    public SharedGameBggIdSoftDeleteIndexTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    private static CancellationToken Ct => TestContext.Current.CancellationToken;
+
+    public async ValueTask InitializeAsync()
+    {
+        _databaseName = $"shared_games_bgg_softdel_{Guid.NewGuid():N}";
+        _connectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+        _dbContext = _fixture.CreateDbContext(_connectionString);
+        await _dbContext.Database.MigrateAsync(Ct);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await _dbContext.DisposeAsync();
+        await _fixture.DropIsolatedDatabaseAsync(_databaseName);
+    }
+
+    private static SharedGameEntity MakeGame(int bggId) => new()
+    {
+        Id = Guid.NewGuid(),
+        Title = $"Game {bggId}",
+        BggId = bggId,
+        YearPublished = 2024,
+        Description = "desc",
+        MinPlayers = 2,
+        MaxPlayers = 4,
+        PlayingTimeMinutes = 60,
+        MinAge = 10,
+        Status = 0,
+        CreatedBy = Guid.NewGuid(),
+        CreatedAt = DateTime.UtcNow,
+    };
+
+    [Fact(DisplayName = "A soft-deleted game's bgg_id can be reused by a new active game")]
+    public async Task SoftDeletedBggId_CanBeReusedByActiveGame()
+    {
+        const int bggId = 555001;
+
+        var first = MakeGame(bggId);
+        _dbContext.SharedGames.Add(first);
+        await _dbContext.SaveChangesAsync(Ct);
+
+        // Soft-delete the first game (IsDeleted only — SharedGameEntity has no DeletedAt).
+        first.IsDeleted = true;
+        await _dbContext.SaveChangesAsync(Ct);
+
+        // Insert a brand-new active game reusing the same BGG id.
+        var second = MakeGame(bggId);
+        _dbContext.SharedGames.Add(second);
+        var act = async () => await _dbContext.SaveChangesAsync(Ct);
+
+        // Before the fix the unfiltered index still reserves the id → 23505; after the fix it succeeds.
+        await act.Should().NotThrowAsync();
+
+        // The active game (query filter excludes the soft-deleted one) is the reused row.
+        var visible = await _dbContext.SharedGames.Where(g => g.BggId == bggId).ToListAsync(Ct);
+        visible.Should().ContainSingle().Which.Id.Should().Be(second.Id);
+    }
+
+    [Fact(DisplayName = "Two active games with the same bgg_id still conflict (unique constraint preserved)")]
+    public async Task TwoActiveGamesWithSameBggId_StillConflict()
+    {
+        const int bggId = 555002;
+
+        _dbContext.SharedGames.Add(MakeGame(bggId));
+        await _dbContext.SaveChangesAsync(Ct);
+
+        _dbContext.SharedGames.Add(MakeGame(bggId));
+        var act = async () => await _dbContext.SaveChangesAsync(Ct);
+
+        await act.Should().ThrowAsync<DbUpdateException>();
+    }
+
+    [Fact(DisplayName = "ix_shared_games_bgg_id is partial on is_deleted after the migration")]
+    public async Task Ix_shared_games_bgg_id_FiltersOnSoftDelete()
+    {
+        var connection = _dbContext.Database.GetDbConnection();
+        if (connection.State != ConnectionState.Open)
+        {
+            await connection.OpenAsync(Ct);
+        }
+
+        await using var cmd = connection.CreateCommand();
+        cmd.CommandText = """
+            SELECT indexdef
+            FROM pg_indexes
+            WHERE tablename = 'shared_games'
+              AND indexname = 'ix_shared_games_bgg_id';
+            """;
+
+        var indexDef = (string?)await cmd.ExecuteScalarAsync(Ct);
+
+        indexDef.Should().NotBeNull("the bgg_id unique index must exist");
+        // Postgres may render "is_deleted = false" as "(NOT is_deleted)"; assert the column
+        // participates in the partial WHERE either way. The pre-fix index had no is_deleted at all.
+        indexDef!.Should().Contain("is_deleted");
+    }
+}


### PR DESCRIPTION
## Summary

The unique index on `shared_games.bgg_id` was filtered only on `bgg_id IS NOT NULL`, missing `AND is_deleted = false`. Because `shared_games` is soft-deleted (a global `!IsDeleted` query filter hides deleted rows), a **soft-deleted game permanently reserved its BGG id** — no new active game could reuse it, even though every app-layer read excludes the deleted row. The sibling `private_games` index already does this correctly (`ix_private_games_owner_bgg` → `bgg_id IS NOT NULL AND is_deleted = false`).

## Changes
- `SharedGameEntityConfiguration`: partial filter → `bgg_id IS NOT NULL AND is_deleted = false`.
- Migration `20260720105148_FixSharedGameBggIdSoftDeleteIndex`: drop + recreate `ix_shared_games_bgg_id` (index-only → passes the migration safety gate; symmetric `Down`).
- New integration tests `SharedGameBggIdSoftDeleteIndexTests` (Testcontainers Postgres).

## Testing
- `dotnet test --filter "FullyQualifiedName~SharedGameBggIdSoftDeleteIndexTests"` → 3 passed.
  - RED before fix: reuse-after-soft-delete threw `23505`; indexdef lacked `is_deleted`.
  - GREEN after: reuse succeeds; two active games with same `bgg_id` still conflict (guard); recreated index is partial on `is_deleted`.

Closes #3236

🤖 Generated with [Claude Code](https://claude.com/claude-code)