### PR TITLE
fix(catalog): #3239 dispose HttpResponseMessage in DownloadPdfAsync

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/SsrfSafeHttpClient.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Infrastructure/Services/SsrfSafeHttpClient.cs
@@ -30,13 +30,19 @@ internal sealed class SsrfSafeHttpClient
         ValidateUrlScheme(url);
         await ValidateResolvedIpAsync(url, ct).ConfigureAwait(false);
 
-        var response = await _httpClient.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, ct).ConfigureAwait(false);
+        // Dispose the response on every exit path: with ResponseHeadersRead it holds the live
+        // connection open until disposed. Disposing the response also disposes its content and
+        // the stream returned by ReadAsStreamAsync (the content owns that stream), so the source
+        // is fully released once this scope exits. The validated payload is copied into an
+        // independent MemoryStream before this method returns, so scope-exit disposal is safe.
+        using var response = await _httpClient.GetAsync(url, HttpCompletionOption.ResponseHeadersRead, ct).ConfigureAwait(false);
         response.EnsureSuccessStatusCode();
 
         // Validate size from Content-Length header if available
         if (response.Content.Headers.ContentLength > MaxPdfSizeBytes)
             throw new InvalidOperationException($"PDF exceeds maximum size of {MaxPdfSizeBytes / (1024 * 1024)}MB");
 
+        // Owned by `response`; disposed together with it at scope exit (see comment above).
         var stream = await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
 
         // Validate PDF magic bytes (%PDF)

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Services/SsrfSafeHttpClientTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Infrastructure/Services/SsrfSafeHttpClientTests.cs
@@ -106,4 +106,66 @@ public class SsrfSafeHttpClientTests
     }
 
     #endregion
+
+    #region DownloadPdfAsync Disposal Tests (Issue #3239)
+
+    [Fact]
+    public async Task DownloadPdfAsync_DisposesResponseContentStream()
+    {
+        // %PDF magic bytes so the download passes the PDF-signature validation.
+        var pdfBytes = System.Text.Encoding.ASCII.GetBytes("%PDF-1.4\nfake-content");
+        var sourceStream = new DisposeTrackingStream(pdfBytes);
+        using var handler = new StubHttpMessageHandler(() => new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StreamContent(sourceStream),
+        });
+        using var httpClient = new HttpClient(handler);
+        var sut = new SsrfSafeHttpClient(httpClient);
+
+        // Host is a public IP literal: Dns.GetHostAddressesAsync short-circuits (no network call),
+        // and IsPrivateOrReserved(8.8.8.8) is false, so the SSRF guard passes hermetically.
+        var result = await sut.DownloadPdfAsync("https://8.8.8.8/rules.pdf", CancellationToken.None);
+
+        // The full payload is copied into an independent stream returned to the caller...
+        using var reader = new StreamReader(result);
+        (await reader.ReadToEndAsync()).Should().Be("%PDF-1.4\nfake-content");
+
+        // ...and the source HttpResponseMessage content stream must be disposed (it was leaked before the fix).
+        sourceStream.Disposed.Should().BeTrue(
+            "DownloadPdfAsync must dispose the HttpResponseMessage and its content stream");
+    }
+
+    private sealed class StubHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly Func<HttpResponseMessage> _responder;
+
+        public StubHttpMessageHandler(Func<HttpResponseMessage> responder) => _responder = responder;
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken) => Task.FromResult(_responder());
+    }
+
+    private sealed class DisposeTrackingStream : MemoryStream
+    {
+        public DisposeTrackingStream(byte[] buffer) : base(buffer, writable: false)
+        {
+        }
+
+        public bool Disposed { get; private set; }
+
+        protected override void Dispose(bool disposing)
+        {
+            Disposed = true;
+            base.Dispose(disposing);
+        }
+
+        public override ValueTask DisposeAsync()
+        {
+            Disposed = true;
+            return base.DisposeAsync();
+        }
+    }
+
+    #endregion
 }


### PR DESCRIPTION
## Summary

`SsrfSafeHttpClient.DownloadPdfAsync` never disposed the `HttpResponseMessage` returned by `GetAsync(..., ResponseHeadersRead, ...)`. With `ResponseHeadersRead` the response holds the live connection open until disposed, so every download leaked the response — and its content stream (which the content owns) — until GC, delaying return of the connection to the pool.

## Fix
Scope the response with `using`. Disposing the `HttpResponseMessage` also disposes its content and the stream returned by `ReadAsStreamAsync` (the content owns that stream), so the source is fully released at scope exit. The validated payload is already copied into an independent `MemoryStream` before the method returns, so scope-exit disposal is safe. (An explicit `await using` on the stream tripped analyzer MA0004; disposal via the owning response is the idiomatic fix.)

## Testing
- New unit test `SsrfSafeHttpClientTests.DownloadPdfAsync_DisposesResponseContentStream` with a dispose-tracking `HttpMessageHandler` + stream. Hermetic: a public IP-literal host (`8.8.8.8`) short-circuits DNS and passes the SSRF guard, so no network is needed.
- RED before fix (`Disposed` == false); GREEN after. Full class: 28 passed.

Closes #3239

🤖 Generated with [Claude Code](https://claude.com/claude-code)