### PR TITLE
test(api): fail-closed guard so automated tests never consume paid AI tokens

### DIFF
--- a/apps/api/tests/Api.Tests/E2E/Infrastructure/E2ETestBase.cs
+++ b/apps/api/tests/Api.Tests/E2E/Infrastructure/E2ETestBase.cs
@@ -597,9 +597,7 @@ internal sealed class E2EWebApplicationFactory : WebApplicationFactory<Program>
             // REQ-AI-TEST-001: automated tests must not consume AI tokens. Fail-closed at two layers:
             // (1) PaidAiHostGuard blocks paid AI hosts at the HTTP layer; (2) TestFailingLlmService
             // replaces the real LLM service with a network-free deterministic fake.
-            Api.Tests.Infrastructure.PaidAiHostGuardExtensions.AddPaidAiHostGuard(services);
-            services.RemoveAll(typeof(Api.Services.ILlmService));
-            services.AddScoped<Api.Services.ILlmService, Api.Tests.TestHelpers.TestFailingLlmService>();
+            Api.Tests.Infrastructure.PaidAiHostGuardExtensions.AddFailClosedAiTestDoubles(services);
         });
     }
 }

--- a/apps/api/tests/Api.Tests/E2E/Infrastructure/E2ETestBase.cs
+++ b/apps/api/tests/Api.Tests/E2E/Infrastructure/E2ETestBase.cs
@@ -527,6 +527,9 @@ internal sealed class E2EWebApplicationFactory : WebApplicationFactory<Program>
                 ["Jwt:Secret"] = "test-secret-key-for-e2e-tests-minimum-32-characters-long",
                 ["Jwt:Issuer"] = "MeepleAI-Test",
                 ["Jwt:Audience"] = "MeepleAI-Test",
+                // OpenRouter:BaseUrl is IGNORED by OpenRouterLlmClient (hardcoded openrouter.ai,
+                // OpenRouterLlmClient.cs:67), so it does NOT prevent a real paid call. Real safeguards
+                // are PaidAiHostGuard + TestFailingLlmService, registered below. REQ-AI-TEST-001.
                 ["OpenRouter:ApiKey"] = "test-key",
                 ["OpenRouter:BaseUrl"] = "https://test.local",
                 ["BoardGameGeek:Enabled"] = "false",
@@ -590,6 +593,13 @@ internal sealed class E2EWebApplicationFactory : WebApplicationFactory<Program>
             });
 
             services.AddScoped<IDbContextMigrator, TestDbContextMigrator>();
+
+            // REQ-AI-TEST-001: automated tests must not consume AI tokens. Fail-closed at two layers:
+            // (1) PaidAiHostGuard blocks paid AI hosts at the HTTP layer; (2) TestFailingLlmService
+            // replaces the real LLM service with a network-free deterministic fake.
+            Api.Tests.Infrastructure.PaidAiHostGuardExtensions.AddPaidAiHostGuard(services);
+            services.RemoveAll(typeof(Api.Services.ILlmService));
+            services.AddScoped<Api.Services.ILlmService, Api.Tests.TestHelpers.TestFailingLlmService>();
         });
     }
 }

--- a/apps/api/tests/Api.Tests/Infrastructure/IntegrationWebApplicationFactory.cs
+++ b/apps/api/tests/Api.Tests/Infrastructure/IntegrationWebApplicationFactory.cs
@@ -207,9 +207,7 @@ internal static class IntegrationWebApplicationFactory
                     // service with a network-free deterministic fake. A test needing a positive LLM
                     // response overrides ILlmService in its own WithWebHostBuilder(...).ConfigureTestServices,
                     // which runs after this and therefore wins (e.g. GlobalKbAskStreamEndpointTests).
-                    services.AddPaidAiHostGuard();
-                    services.RemoveAll(typeof(Api.Services.ILlmService));
-                    services.AddScoped<Api.Services.ILlmService, Api.Tests.TestHelpers.TestFailingLlmService>();
+                    services.AddFailClosedAiTestDoubles();
                 });
             });
     }

--- a/apps/api/tests/Api.Tests/Infrastructure/IntegrationWebApplicationFactory.cs
+++ b/apps/api/tests/Api.Tests/Infrastructure/IntegrationWebApplicationFactory.cs
@@ -75,7 +75,11 @@ internal static class IntegrationWebApplicationFactory
                         ["Jwt:Secret"] = "test-secret-key-for-integration-tests-minimum-32-characters-long",
                         ["Jwt:Issuer"] = "MeepleAI-Test",
                         ["Jwt:Audience"] = "MeepleAI-Test",
-                        // OpenRouter
+                        // OpenRouter — NOTE: OpenRouterLlmClient HARDCODES its base address
+                        // (https://openrouter.ai/api/v1/, OpenRouterLlmClient.cs:67) and IGNORES
+                        // OpenRouter:BaseUrl, so this value does NOT prevent a real paid call. The
+                        // real safeguards are PaidAiHostGuard (HTTP layer) + TestFailingLlmService
+                        // (service layer), both registered in ConfigureTestServices. REQ-AI-TEST-001.
                         ["OpenRouter:ApiKey"] = "test-key",
                         ["OpenRouter:BaseUrl"] = "https://test.local",
                         // Disable external services
@@ -196,6 +200,16 @@ internal static class IntegrationWebApplicationFactory
                     // Mock HybridCache — use pass-through implementation that executes factory directly
                     services.RemoveAll(typeof(Api.Services.IHybridCacheService));
                     services.AddScoped<Api.Services.IHybridCacheService, TestHybridCacheService>();
+
+                    // REQ-AI-TEST-001: automated tests must not consume AI tokens. Fail-closed at
+                    // two layers: (1) PaidAiHostGuard blocks paid AI hosts at the HTTP layer (covers
+                    // translation and any HTTP path); (2) TestFailingLlmService replaces the real LLM
+                    // service with a network-free deterministic fake. A test needing a positive LLM
+                    // response overrides ILlmService in its own WithWebHostBuilder(...).ConfigureTestServices,
+                    // which runs after this and therefore wins (e.g. GlobalKbAskStreamEndpointTests).
+                    services.AddPaidAiHostGuard();
+                    services.RemoveAll(typeof(Api.Services.ILlmService));
+                    services.AddScoped<Api.Services.ILlmService, Api.Tests.TestHelpers.TestFailingLlmService>();
                 });
             });
     }

--- a/apps/api/tests/Api.Tests/Infrastructure/PaidAiHostGuardExtensions.cs
+++ b/apps/api/tests/Api.Tests/Infrastructure/PaidAiHostGuardExtensions.cs
@@ -1,21 +1,41 @@
+using Api.Tests.TestHelpers;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Api.Tests.Infrastructure;
 
 /// <summary>
-/// Installs the <see cref="PaidAiHostGuardHandler"/> on every HttpClient produced by
-/// IHttpClientFactory, enforcing REQ-AI-TEST-001 (automated tests must not consume AI tokens).
-///
-/// Uses <c>ConfigureHttpClientDefaults</c>, so the guard applies to all named clients — including
-/// "OpenRouter" registered by the production DI — regardless of registration order. Call this from
-/// every test WebApplicationFactory's <c>ConfigureTestServices</c>.
+/// Test-only DI wiring that enforces REQ-AI-TEST-001 (automated tests must not consume AI tokens).
 /// </summary>
 internal static class PaidAiHostGuardExtensions
 {
+    /// <summary>
+    /// Installs the <see cref="PaidAiHostGuardHandler"/> on every HttpClient produced by
+    /// IHttpClientFactory. Uses <c>ConfigureHttpClientDefaults</c>, so the guard applies to all named
+    /// clients — including "OpenRouter" registered by the production DI — regardless of registration
+    /// order.
+    /// </summary>
     public static IServiceCollection AddPaidAiHostGuard(this IServiceCollection services)
     {
         services.ConfigureHttpClientDefaults(builder =>
             builder.AddHttpMessageHandler(() => new PaidAiHostGuardHandler()));
+        return services;
+    }
+
+    /// <summary>
+    /// Registers BOTH fail-closed layers as a single unit so they cannot drift apart between
+    /// factories: (1) the HTTP-level <see cref="PaidAiHostGuardHandler"/> (covers every paid path),
+    /// and (2) the service-level network-free <see cref="TestFailingLlmService"/> fake.
+    ///
+    /// Call from a test WebApplicationFactory. A test that needs a positive LLM response overrides
+    /// <c>ILlmService</c> in its own <c>WithWebHostBuilder(...).ConfigureTestServices</c>, which runs
+    /// after the factory and therefore wins (e.g. GlobalKbAskStreamEndpointTests).
+    /// </summary>
+    public static IServiceCollection AddFailClosedAiTestDoubles(this IServiceCollection services)
+    {
+        services.AddPaidAiHostGuard();
+        services.RemoveAll(typeof(Api.Services.ILlmService));
+        services.AddScoped<Api.Services.ILlmService, TestFailingLlmService>();
         return services;
     }
 }

--- a/apps/api/tests/Api.Tests/Infrastructure/PaidAiHostGuardExtensions.cs
+++ b/apps/api/tests/Api.Tests/Infrastructure/PaidAiHostGuardExtensions.cs
@@ -1,0 +1,21 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Api.Tests.Infrastructure;
+
+/// <summary>
+/// Installs the <see cref="PaidAiHostGuardHandler"/> on every HttpClient produced by
+/// IHttpClientFactory, enforcing REQ-AI-TEST-001 (automated tests must not consume AI tokens).
+///
+/// Uses <c>ConfigureHttpClientDefaults</c>, so the guard applies to all named clients — including
+/// "OpenRouter" registered by the production DI — regardless of registration order. Call this from
+/// every test WebApplicationFactory's <c>ConfigureTestServices</c>.
+/// </summary>
+internal static class PaidAiHostGuardExtensions
+{
+    public static IServiceCollection AddPaidAiHostGuard(this IServiceCollection services)
+    {
+        services.ConfigureHttpClientDefaults(builder =>
+            builder.AddHttpMessageHandler(() => new PaidAiHostGuardHandler()));
+        return services;
+    }
+}

--- a/apps/api/tests/Api.Tests/Infrastructure/PaidAiHostGuardExtensionsTests.cs
+++ b/apps/api/tests/Api.Tests/Infrastructure/PaidAiHostGuardExtensionsTests.cs
@@ -1,0 +1,62 @@
+using System.Net;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.Infrastructure;
+
+/// <summary>
+/// Unit tests for <see cref="PaidAiHostGuardExtensions"/> — the wiring that installs the
+/// fail-closed guard on every HttpClient produced by IHttpClientFactory (REQ-AI-TEST-001).
+/// Uses a counting primary handler so no real network I/O ever occurs.
+/// </summary>
+public class PaidAiHostGuardExtensionsTests
+{
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task AddPaidAiHostGuard_BlocksPaidAiCall_OnNamedClient()
+    {
+        var primary = new CountingPrimaryHandler();
+        var services = new ServiceCollection();
+        services.AddHttpClient("OpenRouter").ConfigurePrimaryHttpMessageHandler(() => primary);
+        services.AddPaidAiHostGuard();
+
+        using var provider = services.BuildServiceProvider();
+        var client = provider.GetRequiredService<IHttpClientFactory>().CreateClient("OpenRouter");
+
+        await Assert.ThrowsAsync<PaidAiCallInTestException>(
+            () => client.PostAsync("https://openrouter.ai/api/v1/chat/completions", new StringContent("{}")));
+
+        // Fail-closed: the guard blocked the call before it reached the (mocked) network handler.
+        Assert.Equal(0, primary.Calls);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task AddPaidAiHostGuard_AllowsLocalCall_OnNamedClient()
+    {
+        var primary = new CountingPrimaryHandler();
+        var services = new ServiceCollection();
+        services.AddHttpClient("Embedding").ConfigurePrimaryHttpMessageHandler(() => primary);
+        services.AddPaidAiHostGuard();
+
+        using var provider = services.BuildServiceProvider();
+        var client = provider.GetRequiredService<IHttpClientFactory>().CreateClient("Embedding");
+
+        var response = await client.PostAsync("http://localhost:8000/embed", new StringContent("{}"));
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        Assert.Equal(1, primary.Calls);
+    }
+
+    private sealed class CountingPrimaryHandler : HttpMessageHandler
+    {
+        public int Calls { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Calls++;
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+        }
+    }
+}

--- a/apps/api/tests/Api.Tests/Infrastructure/PaidAiHostGuardExtensionsTests.cs
+++ b/apps/api/tests/Api.Tests/Infrastructure/PaidAiHostGuardExtensionsTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using Microsoft.Extensions.DependencyInjection;
+using Moq;
 using Xunit;
 
 namespace Api.Tests.Infrastructure;
@@ -46,6 +47,31 @@ public class PaidAiHostGuardExtensionsTests
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         Assert.Equal(1, primary.Calls);
+    }
+
+    [Fact]
+    [Trait("Category", "Unit")]
+    public async Task AddFailClosedAiTestDoubles_ReplacesLlmWithFake_AndInstallsGuard()
+    {
+        var primary = new CountingPrimaryHandler();
+        var services = new ServiceCollection();
+        // Simulate the production ILlmService registration that the factory must override.
+        services.AddScoped(_ => Mock.Of<Api.Services.ILlmService>());
+        services.AddHttpClient("OpenRouter").ConfigurePrimaryHttpMessageHandler(() => primary);
+
+        services.AddFailClosedAiTestDoubles();
+
+        using var provider = services.BuildServiceProvider();
+
+        // (1) ILlmService is now the network-free deterministic fake.
+        Assert.IsType<Api.Tests.TestHelpers.TestFailingLlmService>(
+            provider.GetRequiredService<Api.Services.ILlmService>());
+
+        // (2) the HTTP guard is installed.
+        var client = provider.GetRequiredService<IHttpClientFactory>().CreateClient("OpenRouter");
+        await Assert.ThrowsAsync<PaidAiCallInTestException>(
+            () => client.PostAsync("https://openrouter.ai/api/v1/chat/completions", new StringContent("{}")));
+        Assert.Equal(0, primary.Calls);
     }
 
     private sealed class CountingPrimaryHandler : HttpMessageHandler

--- a/apps/api/tests/Api.Tests/Infrastructure/PaidAiHostGuardHandler.cs
+++ b/apps/api/tests/Api.Tests/Infrastructure/PaidAiHostGuardHandler.cs
@@ -1,0 +1,65 @@
+namespace Api.Tests.Infrastructure;
+
+/// <summary>
+/// Fail-closed network guard enforcing REQ-AI-TEST-001: automated tests must never consume paid
+/// AI tokens. Installed on every HttpClient produced by IHttpClientFactory in the Testing/CI
+/// environment (see <see cref="PaidAiHostGuardExtensions"/>). Any request whose host resolves to a
+/// paid LLM provider is blocked with <see cref="PaidAiCallInTestException"/> — <b>before</b> it
+/// reaches the network — even if a real API key is configured. Local / self-hosted AI (embedding,
+/// reranker, Ollama) is delegated normally.
+/// </summary>
+internal sealed class PaidAiHostGuardHandler : DelegatingHandler
+{
+    /// <summary>
+    /// Registrable suffixes of paid AI providers used anywhere in the codebase. A request is
+    /// blocked when its host equals one of these or is a subdomain of it. Extend this list when a
+    /// new paid provider is added (e.g. a direct OpenAI/Anthropic client).
+    /// </summary>
+    private static readonly string[] PaidAiHostSuffixes =
+    {
+        "openrouter.ai",   // OpenRouterLlmClient — routes OpenAI/Anthropic/Google/DeepSeek
+        "deepseek.com",    // DeepSeekLlmClient
+        "openai.com",      // defensive: any direct OpenAI client
+        "anthropic.com",   // defensive: any direct Anthropic client
+    };
+
+    protected override Task<HttpResponseMessage> SendAsync(
+        HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        var host = request.RequestUri?.Host;
+        if (host != null && IsPaidAiHost(host))
+        {
+            throw new PaidAiCallInTestException(
+                $"Blocked a test-time HTTP call to paid AI host '{host}' ({request.RequestUri}). " +
+                "REQ-AI-TEST-001: automated tests must not consume AI tokens. Mock ILlmService / " +
+                "ILlmClient (or the relevant IHttpClientFactory client) instead of hitting a real provider.");
+        }
+
+        return base.SendAsync(request, cancellationToken);
+    }
+
+    private static bool IsPaidAiHost(string host)
+    {
+        foreach (var suffix in PaidAiHostSuffixes)
+        {
+            if (host.Equals(suffix, StringComparison.OrdinalIgnoreCase) ||
+                host.EndsWith("." + suffix, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}
+
+/// <summary>
+/// Thrown by <see cref="PaidAiHostGuardHandler"/> when a test attempts a network call to a paid
+/// AI provider. Failing the test is intentional (REQ-AI-TEST-001): tests must never spend tokens.
+/// </summary>
+internal sealed class PaidAiCallInTestException : Exception
+{
+    public PaidAiCallInTestException(string message) : base(message)
+    {
+    }
+}

--- a/apps/api/tests/Api.Tests/Infrastructure/PaidAiHostGuardHandler.cs
+++ b/apps/api/tests/Api.Tests/Infrastructure/PaidAiHostGuardHandler.cs
@@ -40,6 +40,9 @@ internal sealed class PaidAiHostGuardHandler : DelegatingHandler
 
     private static bool IsPaidAiHost(string host)
     {
+        // Normalize a trailing-dot absolute FQDN ("openrouter.ai.") so it cannot bypass the match.
+        host = host.TrimEnd('.');
+
         foreach (var suffix in PaidAiHostSuffixes)
         {
             if (host.Equals(suffix, StringComparison.OrdinalIgnoreCase) ||

--- a/apps/api/tests/Api.Tests/Infrastructure/PaidAiHostGuardHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/Infrastructure/PaidAiHostGuardHandlerTests.cs
@@ -1,0 +1,90 @@
+using System.Net;
+using Xunit;
+
+namespace Api.Tests.Infrastructure;
+
+/// <summary>
+/// Unit tests for <see cref="PaidAiHostGuardHandler"/>.
+///
+/// REQ-AI-TEST-001: automated tests must never consume paid AI tokens. This handler is the
+/// fail-closed network guard: in the Testing/CI environment it is installed on every HttpClient
+/// created by IHttpClientFactory, so any attempt to reach a paid LLM provider (OpenRouter,
+/// DeepSeek, OpenAI, Anthropic) throws instead of spending — even if a real API key is present.
+/// </summary>
+public class PaidAiHostGuardHandlerTests
+{
+    private static HttpMessageInvoker CreateInvoker(RecordingInnerHandler inner)
+        => new(new PaidAiHostGuardHandler { InnerHandler = inner });
+
+    [Theory]
+    [Trait("Category", "Unit")]
+    [InlineData("https://openrouter.ai/api/v1/chat/completions")]
+    [InlineData("https://api.openai.com/v1/chat/completions")]
+    [InlineData("https://api.anthropic.com/v1/messages")]
+    [InlineData("https://api.deepseek.com/v1/chat/completions")]
+    public async Task SendAsync_ToPaidAiHost_Throws_WithoutReachingNetwork(string url)
+    {
+        var inner = new RecordingInnerHandler(HttpStatusCode.OK);
+        var invoker = CreateInvoker(inner);
+
+        var ex = await Assert.ThrowsAsync<PaidAiCallInTestException>(
+            () => invoker.SendAsync(new HttpRequestMessage(HttpMethod.Post, url), CancellationToken.None));
+
+        // Fail-closed: the request must be blocked BEFORE it is delegated to the network.
+        Assert.False(inner.WasCalled, "Guard must block the request before the inner (network) handler runs.");
+        Assert.Contains(new Uri(url).Host, ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [Trait("Category", "Unit")]
+    [InlineData("https://sub.openrouter.ai/api/v1/chat/completions")]
+    [InlineData("https://openrouter.ai:443/api/v1/chat/completions")]
+    public async Task SendAsync_ToPaidAiSubdomainOrPort_Throws(string url)
+    {
+        var inner = new RecordingInnerHandler(HttpStatusCode.OK);
+        var invoker = CreateInvoker(inner);
+
+        await Assert.ThrowsAsync<PaidAiCallInTestException>(
+            () => invoker.SendAsync(new HttpRequestMessage(HttpMethod.Post, url), CancellationToken.None));
+
+        Assert.False(inner.WasCalled);
+    }
+
+    [Theory]
+    [Trait("Category", "Unit")]
+    [InlineData("http://localhost:8000/embed")]
+    [InlineData("http://embedding:8000/embed")]
+    [InlineData("http://reranker:8000/rerank")]
+    [InlineData("http://ollama:11434/api/generate")]
+    public async Task SendAsync_ToLocalOrSelfHostedHost_Delegates(string url)
+    {
+        var inner = new RecordingInnerHandler(HttpStatusCode.OK);
+        var invoker = CreateInvoker(inner);
+
+        var response = await invoker.SendAsync(
+            new HttpRequestMessage(HttpMethod.Post, url), CancellationToken.None);
+
+        Assert.True(inner.WasCalled, "Local / self-hosted AI hosts must be delegated, not blocked.");
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    /// <summary>
+    /// Inner handler that records whether it was invoked and returns a canned response.
+    /// Lets each test assert the guard blocked BEFORE any (mocked) network I/O.
+    /// </summary>
+    private sealed class RecordingInnerHandler : HttpMessageHandler
+    {
+        private readonly HttpStatusCode _status;
+
+        public RecordingInnerHandler(HttpStatusCode status) => _status = status;
+
+        public bool WasCalled { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            WasCalled = true;
+            return Task.FromResult(new HttpResponseMessage(_status));
+        }
+    }
+}

--- a/apps/api/tests/Api.Tests/Infrastructure/PaidAiHostGuardHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/Infrastructure/PaidAiHostGuardHandlerTests.cs
@@ -39,6 +39,8 @@ public class PaidAiHostGuardHandlerTests
     [Trait("Category", "Unit")]
     [InlineData("https://sub.openrouter.ai/api/v1/chat/completions")]
     [InlineData("https://openrouter.ai:443/api/v1/chat/completions")]
+    [InlineData("https://openrouter.ai./api/v1/chat/completions")] // trailing-dot FQDN
+    [InlineData("https://OPENROUTER.AI/api/v1/chat/completions")]  // uppercase
     public async Task SendAsync_ToPaidAiSubdomainOrPort_Throws(string url)
     {
         var inner = new RecordingInnerHandler(HttpStatusCode.OK);

--- a/apps/api/tests/Api.Tests/TestHelpers/TestFailingLlmService.cs
+++ b/apps/api/tests/Api.Tests/TestHelpers/TestFailingLlmService.cs
@@ -12,6 +12,8 @@ namespace Api.Tests.TestHelpers;
 /// of whether an <c>OPENROUTER_API_KEY</c> happens to be present in the environment. It returns a
 /// graceful failure — the same observable outcome as today's "provider not configured" path — so
 /// endpoints degrade exactly as they do now (tests that tolerate/skip on failure keep passing).
+/// Streaming methods yield an empty stream, mirroring the real HybridLlmService's yield-break on
+/// non-completion (StreamChunk has no error channel by design).
 ///
 /// Tests that need a positive LLM response override this with their own mock via
 /// <c>WithWebHostBuilder(b =&gt; b.ConfigureTestServices(...))</c>, which runs after the factory and

--- a/apps/api/tests/Api.Tests/TestHelpers/TestFailingLlmService.cs
+++ b/apps/api/tests/Api.Tests/TestHelpers/TestFailingLlmService.cs
@@ -1,0 +1,69 @@
+using System.Runtime.CompilerServices;
+using Api.Services;
+using Api.Services.LlmClients;
+
+namespace Api.Tests.TestHelpers;
+
+/// <summary>
+/// Deterministic <see cref="ILlmService"/> test double that NEVER touches the network.
+///
+/// REQ-AI-TEST-001: automated tests must not consume paid AI tokens. Registered by the integration
+/// and E2E WebApplicationFactories so the LLM path is fail-closed at the service level, independent
+/// of whether an <c>OPENROUTER_API_KEY</c> happens to be present in the environment. It returns a
+/// graceful failure — the same observable outcome as today's "provider not configured" path — so
+/// endpoints degrade exactly as they do now (tests that tolerate/skip on failure keep passing).
+///
+/// Tests that need a positive LLM response override this with their own mock via
+/// <c>WithWebHostBuilder(b =&gt; b.ConfigureTestServices(...))</c>, which runs after the factory and
+/// therefore wins (see e.g. GlobalKbAskStreamEndpointTests).
+///
+/// This is defence-in-depth alongside <c>PaidAiHostGuardHandler</c>: the guard blocks paid AI hosts
+/// at the HTTP layer (covering translation and any other HTTP path), while this fake keeps the
+/// chat/RAG service path deterministic and network-free.
+/// </summary>
+internal sealed class TestFailingLlmService : ILlmService
+{
+    private const string Reason =
+        "LLM is disabled in tests (REQ-AI-TEST-001: automated tests must not consume AI tokens).";
+
+    public Task<LlmCompletionResult> GenerateCompletionAsync(
+        string systemPrompt, string userPrompt,
+        RequestSource source = RequestSource.Manual, CancellationToken ct = default)
+        => Task.FromResult(LlmCompletionResult.CreateFailure(Reason));
+
+    public async IAsyncEnumerable<StreamChunk> GenerateCompletionStreamAsync(
+        string systemPrompt, string userPrompt,
+        RequestSource source = RequestSource.Manual,
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        await Task.CompletedTask;
+        yield break;
+    }
+
+    public Task<T?> GenerateJsonAsync<T>(
+        string systemPrompt, string userPrompt,
+        RequestSource source = RequestSource.Manual, CancellationToken ct = default) where T : class
+        => Task.FromResult<T?>(null);
+
+    public Task<LlmCompletionResult> GenerateMultimodalCompletionAsync(
+        IReadOnlyList<LlmMessage> messages,
+        RequestSource source = RequestSource.Manual, CancellationToken ct = default)
+        => Task.FromResult(LlmCompletionResult.CreateFailure(Reason));
+
+    public async IAsyncEnumerable<StreamChunk> GenerateMultimodalCompletionStreamAsync(
+        IReadOnlyList<LlmMessage> messages,
+        RequestSource source = RequestSource.Manual,
+        [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        await Task.CompletedTask;
+        yield break;
+    }
+
+    public Task<LlmCompletionResult> GenerateCompletionWithModelAsync(
+        string explicitModel, string systemPrompt, string userPrompt,
+        RequestSource source = RequestSource.Manual, int? maxTokens = null, CancellationToken ct = default)
+        => Task.FromResult(LlmCompletionResult.CreateFailure(Reason));
+
+    // GenerateCompletionWithModelFallbackAsync uses the default interface implementation
+    // (delegates to GenerateCompletionWithModelAsync → CreateFailure).
+}


### PR DESCRIPTION
## Contesto

Emerso da una revisione **spec-panel** del requisito _"durante i test automatici non bisogna consumare token di AI"_ → **REQ-AI-TEST-001**.

Ricognizione del codebase: unit test (.NET), frontend (MSW), servizi Python embedding/reranker (locali + modelli mockati) e orchestration-service (Arbitro) sono già ben coperti. Il gap è nei **test integration/E2E backend**: `IntegrationWebApplicationFactory` e `E2EWebApplicationFactory` lasciano il **vero** `ILlmService`/`OpenRouterLlmClient` nel DI. La sola protezione era l'*assenza* di `OPENROUTER_API_KEY` → posture **fail-open**.

Rischi concreti:
- Su una dev machine (o in CI `backend-integration`, che imposta `OPENROUTER_API_KEY=test-key`) il client reale arriva a `SendAsync` verso `openrouter.ai`.
- `OpenRouter:BaseUrl=https://test.local` nelle factory era **falsa sicurezza**: `OpenRouterLlmClient` **ignora** quel valore e usa un base address hardcoded (`OpenRouterLlmClient.cs:67`).

## Soluzione — fail-closed a due livelli

Cablata in entrambe le factory (`IntegrationWebApplicationFactory` + `E2EWebApplicationFactory`):

1. **`PaidAiHostGuardHandler`** — `DelegatingHandler` installato su ogni client di `IHttpClientFactory` (via `ConfigureHttpClientDefaults`). Qualsiasi richiesta verso un host AI a pagamento (`openrouter.ai`, `deepseek.com`, `openai.com`, `anthropic.com`, inclusi sottodomini) lancia `PaidAiCallInTestException` **prima** della rete, anche con una key reale presente. Poiché ogni consumo di token è una chiamata HTTP verso quegli host, questo copre **tutti** i path a pagamento (chat, translation, ecc.).
2. **`TestFailingLlmService`** — fake `ILlmService` deterministico e senza rete. Restituisce una failure graceful (stesso esito osservabile del path odierno "provider non configurato"), così i test tolleranti restano verdi. I test che vogliono una risposta LLM positiva sovrascrivono `ILlmService` nel proprio `WithWebHostBuilder(...).ConfigureTestServices`, che gira **dopo** la factory e quindi vince (es. `GlobalKbAskStreamEndpointTests`).

Corretti anche i commenti fuorvianti su `OpenRouter:BaseUrl` in entrambe le factory.

## Nota tecnica onesta

Il **network guard da solo** soddisfa già REQ-AI-TEST-001 al 100% (ogni spesa di token è HTTP verso host noti). `TestFailingLlmService` è **difesa in profondità + determinismo** (elimina il tentativo di rete e rende il path indipendente dalle credenziali). Ho scelto un fake **failure-deterministico** (non success) per **zero regressioni**: i ~6 test E2E agent-chat/arbitro + SSE translate oggi *tollerano/skippano* il fallimento e continuano a farlo. Un fake **success** darebbe coverage aggiuntiva ma richiederebbe auditare quelle asserzioni latenti — **follow-up separato** se desiderato.

## Verifica

- Build: OK (0 errori/warning nei file nuovi).
- **12/12** nuovi unit test (`PaidAiHostGuardHandlerTests` + `PaidAiHostGuardExtensionsTests`) — TDD RED→GREEN.
- **5/5** `GlobalKbAskStreamEndpointTests` (Testcontainers) — conferma che l'override locale di `ILlmService` vince sulla registrazione della factory.
- **2/2** `GamebookTextTranslateStreamEndpointTests` (Testcontainers) — path translation tollera il guard.
- Suite integration/E2E completa: gira in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)