### PR TITLE
feat(observability): #3248 copyright enforcement dashboard + alert rules

### DIFF
--- a/infra/compose.prod.yml
+++ b/infra/compose.prod.yml
@@ -235,6 +235,8 @@ services:
       - ./prometheus/alerts/audit-outbox.yml:/etc/prometheus/audit-outbox.yml:ro
       # Issue #1965 — domain_event_outbox duplicate-publish trigger (referenced from prometheus.prod.yml rule_files).
       - ./prometheus/alerts/domain-event-outbox-duplicate-publish.yml:/etc/prometheus/domain-event-outbox-duplicate-publish.yml:ro
+      # Issue #3248 (epic #448 C5) — copyright enforcement observability alerts.
+      - ./prometheus/alerts/copyright-enforcement.yml:/etc/prometheus/copyright-enforcement.yml:ro
       - prometheus-prod:/prometheus
     deploy:
       resources:

--- a/infra/compose.staging.yml
+++ b/infra/compose.staging.yml
@@ -342,6 +342,8 @@ services:
       - ./prometheus/alerts/audit-outbox.yml:/etc/prometheus/audit-outbox.yml:ro
       # Issue #1965 — domain_event_outbox duplicate-publish trigger (referenced from prometheus.staging.yml rule_files).
       - ./prometheus/alerts/domain-event-outbox-duplicate-publish.yml:/etc/prometheus/domain-event-outbox-duplicate-publish.yml:ro
+      # Issue #3248 (epic #448 C5) — copyright enforcement observability alerts.
+      - ./prometheus/alerts/copyright-enforcement.yml:/etc/prometheus/copyright-enforcement.yml:ro
       - prometheus-staging:/prometheus
 
   alertmanager:

--- a/infra/dashboards/copyright-enforcement.json
+++ b/infra/dashboards/copyright-enforcement.json
@@ -1,0 +1,296 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Copyright leak guard observability (#447 metrics, epic #448 C5). Injection/detection/error/latency for the RAG response-body copyright gate. NOTE: recovery is single-path 'fallback' today; a per-action counter (fallback vs redact vs error) is future backend work (epic #448 C4). Verbatim detections are aggregated by run_length, never by document_id (UUID high-cardinality).",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "description": "Share of RAG system prompts that included the copyright paraphrase instruction because Protected chunks were retrieved.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "unit": "percentunit",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 6, "w": 8, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+          "editorMode": "code",
+          "expr": "sum(rate(meepleai_rag_copyright_instruction_injected_total{has_protected=\"true\"}[5m])) / clamp_min(sum(rate(meepleai_rag_copyright_instruction_injected_total[5m])), 1) or on() vector(0)",
+          "legendFormat": "injection rate",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Copyright instruction injection rate",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "description": "Verbatim-run detections / protected-chunk queries. Sustained >20% (warning alert) means the LLM is ignoring the paraphrase instruction.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "unit": "percentunit",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 0.2 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 6, "w": 16, "x": 8, "y": 0 },
+      "id": 2,
+      "options": {
+        "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "single", "sort": "none" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+          "editorMode": "code",
+          "expr": "sum(rate(meepleai_rag_copyright_verbatim_run_detected_total[5m])) / clamp_min(sum(rate(meepleai_rag_copyright_instruction_injected_total{has_protected=\"true\"}[5m])), 1) or on() vector(0)",
+          "legendFormat": "detection rate",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Verbatim detection rate (warning >20%)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "description": "Scan errors / total scan attempts. The guard fails open on error, so sustained >1% (critical alert) means leaks may reach clients undetected.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "unit": "percentunit",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 0.01 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 6, "w": 8, "x": 0, "y": 6 },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+          "editorMode": "code",
+          "expr": "sum(rate(meepleai_rag_copyright_guard_scan_errors_total[5m])) / clamp_min(sum(rate(meepleai_rag_copyright_guard_scan_errors_total[5m])) + sum(rate(meepleai_rag_copyright_guard_scan_duration_count[5m])), 1) or on() vector(0)",
+          "legendFormat": "scan error rate",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Scan error rate (critical >1%)",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "description": "Copyright leak guard scan latency. Budget is 50ms p99 (#447).",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 5,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "unit": "ms",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 50 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 6, "w": 16, "x": 8, "y": 6 },
+      "id": 4,
+      "options": {
+        "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum(rate(meepleai_rag_copyright_guard_scan_duration_bucket[5m])) by (le))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum(rate(meepleai_rag_copyright_guard_scan_duration_bucket[5m])) by (le))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.999, sum(rate(meepleai_rag_copyright_guard_scan_duration_bucket[5m])) by (le))",
+          "legendFormat": "p999",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Scan latency p50 / p99 / p999",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "description": "Verbatim detections broken down by run length (token count). Aggregated by run_length only — NEVER by document_id (UUID high-cardinality). Long runs = stronger leak signal; a spike of short runs suggests false positives on canonical game phraseology (calibration input for epic #448 C1 glossary whitelist).",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "bars",
+            "fillOpacity": 60,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "stacking": { "group": "A", "mode": "normal" }
+          },
+          "mappings": [],
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 12 },
+      "id": 5,
+      "options": {
+        "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+          "editorMode": "code",
+          "expr": "sum(rate(meepleai_rag_copyright_verbatim_run_detected_total[5m])) by (run_length)",
+          "legendFormat": "run_length={{run_length}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Verbatim detections by run_length",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "description": "Scan errors by exception type — explains WHY the guard is failing open (e.g. timeouts vs other). Drives the critical scan-error-rate alert.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 12 },
+      "id": 6,
+      "options": {
+        "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+          "editorMode": "code",
+          "expr": "sum(rate(meepleai_rag_copyright_guard_scan_errors_total[5m])) by (error_type)",
+          "legendFormat": "{{error_type}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Scan errors by error_type",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["copyright", "rag", "observability", "epic-448"],
+  "templating": { "list": [] },
+  "time": { "from": "now-6h", "to": "now" },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Copyright Enforcement",
+  "uid": "copyright-enforcement",
+  "version": 1,
+  "weekStart": ""
+}

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -355,6 +355,8 @@ services:
       # Issue #1965 — domain_event_outbox duplicate-publish trigger (referenced from prometheus.yml rule_files).
       - ./prometheus/alerts/domain-event-outbox-duplicate-publish.yml:/etc/prometheus/domain-event-outbox-duplicate-publish.yml:ro
       - ./prometheus/alerts/wikidata-enrichment.yml:/etc/prometheus/wikidata-enrichment.yml:ro
+      # Issue #3248 (epic #448 C5) — copyright enforcement observability alerts.
+      - ./prometheus/alerts/copyright-enforcement.yml:/etc/prometheus/copyright-enforcement.yml:ro
       - prometheus_data:/prometheus
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "http://localhost:9090/-/healthy"]

--- a/infra/prometheus.prod.yml
+++ b/infra/prometheus.prod.yml
@@ -33,6 +33,8 @@ rule_files:
   - '/etc/prometheus/audit-outbox.yml'
   # Issue #1965 — domain_event_outbox duplicate-publish trigger (dormant until API >=2 replicas).
   - '/etc/prometheus/domain-event-outbox-duplicate-publish.yml'
+  # Issue #3248 (epic #448 C5) — copyright enforcement observability alerts.
+  - '/etc/prometheus/copyright-enforcement.yml'
 
 scrape_configs:
   - job_name: 'prometheus'

--- a/infra/prometheus.staging.yml
+++ b/infra/prometheus.staging.yml
@@ -35,6 +35,8 @@ rule_files:
   - '/etc/prometheus/audit-outbox.yml'
   # Issue #1965 — domain_event_outbox duplicate-publish trigger (dormant until API >=2 replicas).
   - '/etc/prometheus/domain-event-outbox-duplicate-publish.yml'
+  # Issue #3248 (epic #448 C5) — copyright enforcement observability alerts.
+  - '/etc/prometheus/copyright-enforcement.yml'
 
 scrape_configs:
   - job_name: 'prometheus'

--- a/infra/prometheus.yml
+++ b/infra/prometheus.yml
@@ -40,6 +40,8 @@ rule_files:
   - '/etc/prometheus/audit-outbox.yml'
   # Issue #1965 — domain_event_outbox duplicate-publish trigger (dormant until API >=2 replicas).
   - '/etc/prometheus/domain-event-outbox-duplicate-publish.yml'
+  # Issue #3248 (epic #448 C5) — copyright enforcement observability alerts.
+  - '/etc/prometheus/copyright-enforcement.yml'
 
 # Scrape configurations
 scrape_configs:

--- a/infra/prometheus/alerts/copyright-enforcement.test.yml
+++ b/infra/prometheus/alerts/copyright-enforcement.test.yml
@@ -1,0 +1,84 @@
+# promtool unit tests for copyright-enforcement.yml (#3248, epic #448 C5).
+#
+# Run locally (Windows/Git Bash, from repo root):
+#   docker run --rm -v "$(pwd)/infra/prometheus/alerts:/work" prom/prometheus:v3.7.0 \
+#     promtool test rules /work/copyright-enforcement.test.yml
+#
+# There is no promtool CI gate in this repo (see recon in #3082); this file
+# documents + verifies the two alerts (scan-error-rate critical, detection-rate
+# warning) that page ops per epic #448 C5.
+rule_files:
+  - copyright-enforcement.yml
+
+evaluation_interval: 1m
+
+tests:
+  # 1. scan_errors sustained at 2% of scan attempts (2 err / 100 scans per min)
+  #    must fire the CRITICAL alert once the 15m `for` window elapses — the
+  #    leak guard is failing open silently on >1% of protected-chunk queries.
+  - interval: 1m
+    input_series:
+      - series: 'meepleai_rag_copyright_guard_scan_errors_total'
+        values: '0+2x30'
+      - series: 'meepleai_rag_copyright_guard_scan_duration_count'
+        values: '0+98x30'
+    alert_rule_test:
+      - eval_time: 25m
+        alertname: CopyrightScanErrorRateHigh
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              service: meepleai-api
+              category: copyright
+            exp_annotations:
+              summary: "Copyright leak guard is failing open (>1% scan errors)"
+              description: "Copyright leak guard scan-error rate exceeded the 1% threshold of protected-chunk queries; the guard fails open, so verbatim leaks may reach clients undetected. Check LLM latency, scan timeout budget, and the error_type breakdown."
+              runbook_url: "https://github.com/meepleAi-app/meepleai-monorepo/blob/main-dev/docs/for-claude/architecture/copyright-tier-rag.md"
+              dashboard_url: "http://localhost:3001/d/copyright-enforcement"
+
+  # 2. Zero scan errors (guard healthy) must NOT fire — no page on green.
+  - interval: 1m
+    input_series:
+      - series: 'meepleai_rag_copyright_guard_scan_errors_total'
+        values: '0+0x30'
+      - series: 'meepleai_rag_copyright_guard_scan_duration_count'
+        values: '0+100x30'
+    alert_rule_test:
+      - eval_time: 25m
+        alertname: CopyrightScanErrorRateHigh
+        exp_alerts: []
+
+  # 3. Detection rate at 30% (30 verbatim runs / 100 protected-chunk queries)
+  #    must fire the WARNING alert after the 30m `for` window — the LLM is
+  #    ignoring the prompt-gate paraphrase instruction at scale.
+  - interval: 1m
+    input_series:
+      - series: 'meepleai_rag_copyright_verbatim_run_detected_total'
+        values: '0+30x45'
+      - series: 'meepleai_rag_copyright_instruction_injected_total{has_protected="true"}'
+        values: '0+100x45'
+    alert_rule_test:
+      - eval_time: 40m
+        alertname: CopyrightDetectionRateHigh
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              service: meepleai-api
+              category: copyright
+            exp_annotations:
+              summary: "Copyright verbatim-detection rate is high (>20%)"
+              description: "Verbatim-run detections exceeded the 20% threshold of protected-chunk queries; the LLM is not following the copyright paraphrase instruction. Review prompt-gate wording and recent model/routing changes."
+              runbook_url: "https://github.com/meepleAi-app/meepleai-monorepo/blob/main-dev/docs/for-claude/architecture/copyright-tier-rag.md"
+              dashboard_url: "http://localhost:3001/d/copyright-enforcement"
+
+  # 4. Detection rate at 10% (below the 20% threshold) must NOT fire.
+  - interval: 1m
+    input_series:
+      - series: 'meepleai_rag_copyright_verbatim_run_detected_total'
+        values: '0+10x45'
+      - series: 'meepleai_rag_copyright_instruction_injected_total{has_protected="true"}'
+        values: '0+100x45'
+    alert_rule_test:
+      - eval_time: 40m
+        alertname: CopyrightDetectionRateHigh
+        exp_alerts: []

--- a/infra/prometheus/alerts/copyright-enforcement.yml
+++ b/infra/prometheus/alerts/copyright-enforcement.yml
@@ -1,0 +1,62 @@
+# Issue #3248 (epic #448 C5) — copyright enforcement observability alerts.
+#
+# Metric source (apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.Rag.cs:297-344,
+# #447 observability). OTel Prometheus exporter (1.13.1-beta.1) sanitizes dots to
+# underscores and appends `_total` to monotonic counters (unit is NOT appended —
+# cf. meepleai_bgg_url_attempted_render_total). Exported names:
+#   - meepleai_rag_copyright_guard_scan_errors_total   (counter; tag error_type)
+#   - meepleai_rag_copyright_guard_scan_duration_*     (histogram; _count/_sum/_bucket)
+#   - meepleai_rag_copyright_verbatim_run_detected_total (counter; tags run_length, document_id)
+#   - meepleai_rag_copyright_instruction_injected_total  (counter; tags has_protected, agent_language)
+#
+# Verify the exact scraped names in staging before relying on these:
+#   curl -s localhost:8080/metrics | grep copyright
+#
+# Two alerts per epic #448 C5: page ops when scan-error rate > 1% (guard failing
+# open) or verbatim-detection rate > 20% (LLM ignoring the prompt-gate).
+# Routing: severity=critical pages immediately (alertmanager.yml critical-alerts);
+# severity=warning goes to the warning route. Unit tests: copyright-enforcement.test.yml.
+groups:
+  - name: meepleai_copyright_enforcement_alerts
+    rules:
+      # CRITICAL: >1% of copyright scans on protected-chunk queries error out.
+      # The guard is fail-open (ChatWithSessionAgentCommandHandler.cs:522), so a
+      # sustained error rate means verbatim leaks can reach clients undetected.
+      - alert: CopyrightScanErrorRateHigh
+        expr: |
+          sum(rate(meepleai_rag_copyright_guard_scan_errors_total[5m]))
+          /
+          (
+            sum(rate(meepleai_rag_copyright_guard_scan_errors_total[5m]))
+            +
+            sum(rate(meepleai_rag_copyright_guard_scan_duration_count[5m]))
+          ) > 0.01
+        for: 15m
+        labels:
+          severity: critical
+          service: meepleai-api
+          category: copyright
+        annotations:
+          summary: "Copyright leak guard is failing open (>1% scan errors)"
+          description: "Copyright leak guard scan-error rate exceeded the 1% threshold of protected-chunk queries; the guard fails open, so verbatim leaks may reach clients undetected. Check LLM latency, scan timeout budget, and the error_type breakdown."
+          runbook_url: "https://github.com/meepleAi-app/meepleai-monorepo/blob/main-dev/docs/for-claude/architecture/copyright-tier-rag.md"
+          dashboard_url: "http://localhost:3001/d/copyright-enforcement"
+
+      # WARNING: >20% of protected-chunk queries trigger a verbatim-run detection,
+      # i.e. the LLM is not following the copyright paraphrase instruction at scale.
+      - alert: CopyrightDetectionRateHigh
+        expr: |
+          sum(rate(meepleai_rag_copyright_verbatim_run_detected_total[5m]))
+          /
+          sum(rate(meepleai_rag_copyright_instruction_injected_total{has_protected="true"}[5m]))
+          > 0.20
+        for: 30m
+        labels:
+          severity: warning
+          service: meepleai-api
+          category: copyright
+        annotations:
+          summary: "Copyright verbatim-detection rate is high (>20%)"
+          description: "Verbatim-run detections exceeded the 20% threshold of protected-chunk queries; the LLM is not following the copyright paraphrase instruction. Review prompt-gate wording and recent model/routing changes."
+          runbook_url: "https://github.com/meepleAi-app/meepleai-monorepo/blob/main-dev/docs/for-claude/architecture/copyright-tier-rag.md"
+          dashboard_url: "http://localhost:3001/d/copyright-enforcement"


### PR DESCRIPTION
## Cosa

Sub-issue **C5** dell'epic #448 (copyright enforcement long-term), estratta via `/sc:spec-panel`. Il copyright leak guard di #447 emette già 4 metriche Prometheus ma **nessuno le osserva** (zero dashboard, zero alert). Questa PR cabla il layer di observability.

**Finding chiave della review**: i trigger che gated il resto dell'epic (C1 `FP-rate >15%`, C5 `30gg di metriche in produzione`) **non sono misurabili senza questo dashboard** → C5 è observability pura, non cambia il comportamento runtime del guard, e *abilita* la misurabilità del resto. Si auto-de-gate.

## Contenuto

- **Dashboard** `infra/dashboards/copyright-enforcement.json` (uid `copyright-enforcement`, 6 pannelli): injection rate, detection rate, scan-error rate, latency p50/p99/p999, detections **by run_length**, errors by error_type.
  - ⚠️ Aggrega **solo per `run_length`**, mai per `document_id` (UUID high-cardinality, cfr. `MeepleAiMetrics.Rag.cs:351-353`).
- **Alert rules** `infra/prometheus/alerts/copyright-enforcement.yml`:
  - `CopyrightScanErrorRateHigh` (**critical**, >1%): guard che fallisce open silenziosamente.
  - `CopyrightDetectionRateHigh` (**warning**, >20%): LLM che ignora il prompt-gate.
- **TDD** `copyright-enforcement.test.yml`: 4 casi promtool (2 fire + 2 no-fire), tutti verdi.
- Registrato in `rule_files` + volume mount su **dev/prod/staging** (6 punti).

## Test

```
docker run --rm -v "$(pwd)/infra/prometheus/alerts:/work" --entrypoint promtool \
  prom/prometheus:v3.7.0 test rules /work/copyright-enforcement.test.yml
# → SUCCESS (4/4)
```
+ JSON dashboard validato (jq) + YAML lint su tutti i file config.

## Scope / note onestà

- **Recovery-action distribution** (fallback vs redact vs error) richiesto dall'epic: pannello **omesso** deliberatamente — non esiste una metrica per-azione (single-path `fallback` oggi). Documentato come future backend work (epic #448 C4), non un grafico fuorviante.
- Nomi metriche derivati dalla convenzione OTel exporter (counter → `_total`); il file rules documenta come verificarli in staging (`curl /metrics | grep copyright`).
- **Out of scope** (restano gated nell'epic): C1 glossary whitelist, C2 streaming-aware, C3 legal sign-off, C4 alternative detection.

Closes #3248. Sblocca (non chiude) la misurabilità dei task residui di #448.

🤖 Generated with [Claude Code](https://claude.com/claude-code)