### PR TITLE
fix(email): #3250 prod alert recipient + raw emails via IEmailSender

### DIFF
--- a/apps/api/src/Api/Services/EmailService.cs
+++ b/apps/api/src/Api/Services/EmailService.cs
@@ -118,7 +118,12 @@ internal partial class EmailService : IEmailService
         await smtpClient.SendMailAsync(message, cancellationToken).ConfigureAwait(false);
     }
 
-    // ISSUE-4417: Raw email sending for queue processor
+    // ISSUE-4417: Raw email sending for queue processor.
+    // #3250: delegate to SendViaTransportAsync so this honors the configured IEmailSender
+    // (Resend/SMTP via EMAIL_PROVIDER) instead of a hardcoded SmtpClient. Previously it
+    // always sent over SMTP, so on a Resend-only prod, alert (EmailAlertChannel) and queued
+    // emails failed silently while templated emails succeeded via Resend. The direct-SMTP
+    // fallback is preserved inside SendViaTransportAsync for the legacy ctor / unit tests.
     public async Task SendRawEmailAsync(
         string toEmail,
         string subject,
@@ -127,22 +132,7 @@ internal partial class EmailService : IEmailService
     {
         try
         {
-            using var message = new MailMessage();
-            message.From = new MailAddress(_fromAddress, _fromName);
-            message.To.Add(new MailAddress(toEmail));
-            message.Subject = subject;
-            message.Body = htmlBody;
-            message.IsBodyHtml = true;
-
-            using var smtpClient = new SmtpClient(_smtpHost, _smtpPort);
-            smtpClient.EnableSsl = _enableSsl;
-
-            if (!string.IsNullOrEmpty(_smtpUsername) && !string.IsNullOrEmpty(_smtpPassword))
-            {
-                smtpClient.Credentials = new NetworkCredential(_smtpUsername, _smtpPassword);
-            }
-
-            await smtpClient.SendMailAsync(message, ct).ConfigureAwait(false);
+            await SendViaTransportAsync(toEmail, subject, htmlBody, ct).ConfigureAwait(false);
 
             _logger.LogInformation(
                 "Raw email sent successfully to {Email}",

--- a/apps/api/src/Api/appsettings.json
+++ b/apps/api/src/Api/appsettings.json
@@ -414,9 +414,9 @@
       "Enabled": true,
       "SmtpHost": "smtp.gmail.com",
       "SmtpPort": 587,
-      "From": "alerts@meepleai.dev",
+      "From": "alerts@meepleai.app",
       "To": [
-        "ops@meepleai.dev"
+        "ops@meepleai.app"
       ],
       "UseTls": true
     },

--- a/apps/api/tests/Api.Tests/Services/Email/EmailServiceRawTransportTests.cs
+++ b/apps/api/tests/Api.Tests/Services/Email/EmailServiceRawTransportTests.cs
@@ -1,0 +1,92 @@
+using Api.Services;
+using Api.Services.Email;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.Services.Email;
+
+/// <summary>
+/// Issue #3250: EmailService.SendRawEmailAsync must delegate to the injected IEmailSender
+/// (Resend/SMTP selected by EMAIL_PROVIDER) instead of instantiating a direct SmtpClient,
+/// so alert (EmailAlertChannel) and queued (EmailProcessorJob) emails honor the configured
+/// transport. Previously it always sent over SMTP, so on a Resend-only prod they failed
+/// silently while templated emails succeeded via Resend.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+public sealed class EmailServiceRawTransportTests
+{
+    private readonly Mock<ILogger<EmailService>> _logger = new();
+    private readonly Mock<IEmailSender> _sender = new();
+    private readonly IConfiguration _configuration;
+
+    public EmailServiceRawTransportTests()
+    {
+        _configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Email:FromAddress"] = "noreply@meepleai.app",
+                ["Email:FromName"] = "MeepleAI",
+                ["Email:EnableSsl"] = "false",
+            })
+            .Build();
+    }
+
+    [Fact]
+    public async Task SendRawEmailAsync_DelegatesToInjectedSender()
+    {
+        // Arrange
+        EmailRequest? captured = null;
+        _sender
+            .Setup(s => s.SendAsync(It.IsAny<EmailRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<EmailRequest, CancellationToken>((req, _) => captured = req)
+            .Returns(Task.CompletedTask);
+
+        var service = new EmailService(_configuration, _logger.Object, _sender.Object);
+
+        // Act
+        await service.SendRawEmailAsync(
+            toEmail: "ops@meepleai.app",
+            subject: "🚨 [CRITICAL] health.postgres - MeepleAI",
+            htmlBody: "<p>alert</p>",
+            ct: CancellationToken.None);
+
+        // Assert
+        _sender.Verify(
+            s => s.SendAsync(It.IsAny<EmailRequest>(), It.IsAny<CancellationToken>()),
+            Times.Once,
+            "SendRawEmailAsync MUST delegate to IEmailSender so it honors EMAIL_PROVIDER (Resend), not a hardcoded SmtpClient.");
+
+        captured.Should().NotBeNull();
+        captured!.ToEmail.Should().Be("ops@meepleai.app");
+        captured.FromEmail.Should().Be("noreply@meepleai.app");
+        captured.FromName.Should().Be("MeepleAI");
+        captured.Subject.Should().Be("🚨 [CRITICAL] health.postgres - MeepleAI");
+        captured.HtmlBody.Should().Be("<p>alert</p>");
+    }
+
+    [Fact]
+    public async Task SendRawEmailAsync_WrapsSenderFailureInInvalidOperationException()
+    {
+        // Arrange
+        _sender
+            .Setup(s => s.SendAsync(It.IsAny<EmailRequest>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("transport down"));
+
+        var service = new EmailService(_configuration, _logger.Object, _sender.Object);
+
+        // Act
+        var act = () => service.SendRawEmailAsync(
+            toEmail: "ops@meepleai.app",
+            subject: "subj",
+            htmlBody: "<p>body</p>",
+            ct: CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("Failed to send raw email");
+    }
+}

--- a/infra/compose.prod.yml
+++ b/infra/compose.prod.yml
@@ -93,6 +93,11 @@ services:
       Frontend__BaseUrl: "https://${PROD_DOMAIN}"
       Authentication__SessionCookie__Secure: "true"
       Authentication__SessionCookie__SameSite: "Lax"
+      # OPS-07 / #3250: health/monitoring alert recipient — overrides the appsettings.json
+      # placeholder (ops@meepleai.app). Without this, prod alerts go to an unowned mailbox
+      # and are lost. From/transport are owned by EmailService (Resend via prod/email.secret).
+      # Not a secret, just the mailbox that receives alert emails.
+      Alerting__Email__To__0: badsworm@gmail.com
     logging:
       driver: "json-file"
       options: { max-size: "50m", max-file: "10" }

--- a/infra/compose.staging.yml
+++ b/infra/compose.staging.yml
@@ -92,7 +92,7 @@ services:
       Authentication__SessionCookie__Secure: "true"
       Authentication__SessionCookie__SameSite: "Lax"
       # OPS-07: health/monitoring alert recipient — overrides the appsettings.json
-      # placeholder (ops@meepleai.dev). Not a secret, just the mailbox that receives
+      # placeholder (ops@meepleai.app). Not a secret, just the mailbox that receives
       # alert emails. From/credentials are inherited from EmailService's SMTP_* config
       # (email.secret); EmailAlertChannel no longer uses Alerting:Email:From/Username/
       # Password. badsworm@gmail.com is the already allow-listed staging address (Gmail→Gmail).


### PR DESCRIPTION
Follow-up dall'audit della configurazione email (post #3245). Due bug nel percorso di alerting.

## Bug 1 — `SendRawEmailAsync` ignora il provider (HIGH)
`EmailService.SendRawEmailAsync` istanziava un `SmtpClient` diretto invece di usare `_sender` (`IEmailSender`), a differenza di `SendViaTransportAsync`. Gli alert (`EmailAlertChannel`) e le email in coda (`EmailProcessorJob`) partivano **sempre via SMTP** anche con `EMAIL_PROVIDER=resend` → in prod (Resend-only) fallivano silenziosamente.

**Fix**: `SendRawEmailAsync` delega a `SendViaTransportAsync` (usa `_sender` quando presente; fallback SMTP invariato per legacy ctor / unit test). Error-handling preservato (`InvalidOperationException("Failed to send raw email")`).

## Bug 2 — Prod alert recipient black-holed (HIGH)
Solo `staging` aveva l'override OPS-07; **prod** ereditava il default `ops@meepleai.dev` (dominio non verificato) → alert di produzione persi.

**Fix**: `compose.prod.yml` → `Alerting__Email__To__0: badsworm@gmail.com` (parity con staging); default `appsettings.json` spostato dal dominio morto `meepleai.dev` al dominio verificato `meepleai.app`.

## Test
`EmailServiceRawTransportTests` (2 unit TDD): delega a `IEmailSender` + wrap dell'errore. 14/14 unit EmailService verdi. Nessuna regressione (i consumatori mockano l'interfaccia `IEmailService`).

## Review
Code review olistica: 0 finding ≥80 confidence. Config verificata coerente con staging; dominio `meepleai.app` consegnabile via Resend.

Closes #3250

🤖 Generated with [Claude Code](https://claude.com/claude-code)
