### PR TITLE
release: main-dev → main-staging (email alert fix #3251 + 2)

### DIFF
--- a/apps/api/src/Api/Services/EmailService.cs
+++ b/apps/api/src/Api/Services/EmailService.cs
@@ -118,7 +118,12 @@ internal partial class EmailService : IEmailService
         await smtpClient.SendMailAsync(message, cancellationToken).ConfigureAwait(false);
     }
 
-    // ISSUE-4417: Raw email sending for queue processor
+    // ISSUE-4417: Raw email sending for queue processor.
+    // #3250: delegate to SendViaTransportAsync so this honors the configured IEmailSender
+    // (Resend/SMTP via EMAIL_PROVIDER) instead of a hardcoded SmtpClient. Previously it
+    // always sent over SMTP, so on a Resend-only prod, alert (EmailAlertChannel) and queued
+    // emails failed silently while templated emails succeeded via Resend. The direct-SMTP
+    // fallback is preserved inside SendViaTransportAsync for the legacy ctor / unit tests.
     public async Task SendRawEmailAsync(
         string toEmail,
         string subject,
@@ -127,22 +132,7 @@ internal partial class EmailService : IEmailService
     {
         try
         {
-            using var message = new MailMessage();
-            message.From = new MailAddress(_fromAddress, _fromName);
-            message.To.Add(new MailAddress(toEmail));
-            message.Subject = subject;
-            message.Body = htmlBody;
-            message.IsBodyHtml = true;
-
-            using var smtpClient = new SmtpClient(_smtpHost, _smtpPort);
-            smtpClient.EnableSsl = _enableSsl;
-
-            if (!string.IsNullOrEmpty(_smtpUsername) && !string.IsNullOrEmpty(_smtpPassword))
-            {
-                smtpClient.Credentials = new NetworkCredential(_smtpUsername, _smtpPassword);
-            }
-
-            await smtpClient.SendMailAsync(message, ct).ConfigureAwait(false);
+            await SendViaTransportAsync(toEmail, subject, htmlBody, ct).ConfigureAwait(false);
 
             _logger.LogInformation(
                 "Raw email sent successfully to {Email}",

--- a/apps/api/src/Api/Services/HybridSearchService.cs
+++ b/apps/api/src/Api/Services/HybridSearchService.cs
@@ -1,3 +1,4 @@
+using System.Text.RegularExpressions;
 using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
 using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
 using Api.BoundedContexts.KnowledgeBase.Infrastructure.Persistence;
@@ -441,7 +442,6 @@ internal class HybridSearchService : IHybridSearchService
                 ? keywordItem.Result.RoleTags
                 : GameBookRole.None;
             var roleBoost = ComputeRoleMatchBoost(queryRoleHint, chunkRoleTags);
-            var hybridScore = vectorRrfScore + keywordRrfScore + roleBoost;
 
             // Use data from whichever result has it (prefer vector for metadata consistency)
             var matchedTerms = hasKeyword && keywordItem != null
@@ -452,6 +452,15 @@ internal class HybridSearchService : IHybridSearchService
             var content = hasVector && vectorItem != null
                 ? vectorItem.Result.Text
                 : (keywordItem?.Result.Content ?? string.Empty);
+
+            // RAG answer-quality fix: demote cross-reference "legend" chunks (dense with
+            // "vedi pag."/"see p." pointers, e.g. the Terraforming Mars component list
+            // "8. Progetti Standard ... vedi pag. 10 ... 9. Milestone ... vedi pag. 10 e 11")
+            // which carry no actionable answer yet score in the same RRF band as real content.
+            // The demotion scales the RRF fusion components only; the role-match boost (#1391)
+            // stays strictly additive on top so its deliberate ~0.15 calibration is not scaled away.
+            var legendFactor = ComputeLegendPenaltyFactor(content);
+            var hybridScore = ((vectorRrfScore + keywordRrfScore) * (1f - legendFactor)) + roleBoost;
 
             var pdfDocumentId = hasVector && vectorItem != null
                 ? vectorItem.Result.PdfId
@@ -506,6 +515,42 @@ internal class HybridSearchService : IHybridSearchService
         }
 
         return (chunkRoleTags & queryRoleHint) != GameBookRole.None ? RoleMatchBoost : 0f;
+    }
+
+    // Matches cross-reference pointers like "vedi pag. 10", "vedi anche pagina 5", "see p. 11",
+    // "cfr. pagg. 4-5". Allows an optional connector word ("anche"/"a") and spelled-out "pagina".
+    private static readonly Regex CrossReferencePointer = new(
+        @"(?i)\b(?:vedi|see|cfr|cf)\b\.?\s+(?:anche\s+|a\s+)?(?:pagine|pagina|pagg|pag|pages|page|pp|p)\b\.?",
+        RegexOptions.Compiled,
+        TimeSpan.FromSeconds(1));
+
+    /// <summary>
+    /// RAG answer-quality fix: computes a multiplicative demotion factor in [0, 0.5] for chunks
+    /// that are cross-reference "legends" (dense with "vedi pag."/"see p." pointers, e.g. a
+    /// component list that only points elsewhere). Such chunks carry no actionable content but
+    /// score in the same RRF band as real answers. Pure function — exposed <c>internal static</c>
+    /// for direct unit testing.
+    /// </summary>
+    internal static float ComputeLegendPenaltyFactor(string? content)
+    {
+        if (string.IsNullOrEmpty(content))
+        {
+            return 0f;
+        }
+
+        var pointers = CrossReferencePointer.Count(content);
+        // A legend is a LIST of pointers; a single incidental page reference is not one.
+        if (pointers < 2)
+        {
+            return 0f;
+        }
+
+        // Density-driven ONLY (pointers per 1000 chars), never the raw count: a short chunk that
+        // is mostly pointers (a legend) has high density and is capped at 0.5, while a long,
+        // substantive section that legitimately cites several pages has low density and is barely
+        // touched. Using the raw count would over-demote long real content with many references.
+        var density = pointers * 1000.0 / content.Length;
+        return (float)Math.Min(0.5, 0.05 * density);
     }
 }
 

--- a/apps/api/src/Api/appsettings.json
+++ b/apps/api/src/Api/appsettings.json
@@ -414,9 +414,9 @@
       "Enabled": true,
       "SmtpHost": "smtp.gmail.com",
       "SmtpPort": 587,
-      "From": "alerts@meepleai.dev",
+      "From": "alerts@meepleai.app",
       "To": [
-        "ops@meepleai.dev"
+        "ops@meepleai.app"
       ],
       "UseTls": true
     },

--- a/apps/api/tests/Api.Tests/Services/Email/EmailServiceRawTransportTests.cs
+++ b/apps/api/tests/Api.Tests/Services/Email/EmailServiceRawTransportTests.cs
@@ -1,0 +1,92 @@
+using Api.Services;
+using Api.Services.Email;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.Services.Email;
+
+/// <summary>
+/// Issue #3250: EmailService.SendRawEmailAsync must delegate to the injected IEmailSender
+/// (Resend/SMTP selected by EMAIL_PROVIDER) instead of instantiating a direct SmtpClient,
+/// so alert (EmailAlertChannel) and queued (EmailProcessorJob) emails honor the configured
+/// transport. Previously it always sent over SMTP, so on a Resend-only prod they failed
+/// silently while templated emails succeeded via Resend.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+public sealed class EmailServiceRawTransportTests
+{
+    private readonly Mock<ILogger<EmailService>> _logger = new();
+    private readonly Mock<IEmailSender> _sender = new();
+    private readonly IConfiguration _configuration;
+
+    public EmailServiceRawTransportTests()
+    {
+        _configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Email:FromAddress"] = "noreply@meepleai.app",
+                ["Email:FromName"] = "MeepleAI",
+                ["Email:EnableSsl"] = "false",
+            })
+            .Build();
+    }
+
+    [Fact]
+    public async Task SendRawEmailAsync_DelegatesToInjectedSender()
+    {
+        // Arrange
+        EmailRequest? captured = null;
+        _sender
+            .Setup(s => s.SendAsync(It.IsAny<EmailRequest>(), It.IsAny<CancellationToken>()))
+            .Callback<EmailRequest, CancellationToken>((req, _) => captured = req)
+            .Returns(Task.CompletedTask);
+
+        var service = new EmailService(_configuration, _logger.Object, _sender.Object);
+
+        // Act
+        await service.SendRawEmailAsync(
+            toEmail: "ops@meepleai.app",
+            subject: "🚨 [CRITICAL] health.postgres - MeepleAI",
+            htmlBody: "<p>alert</p>",
+            ct: CancellationToken.None);
+
+        // Assert
+        _sender.Verify(
+            s => s.SendAsync(It.IsAny<EmailRequest>(), It.IsAny<CancellationToken>()),
+            Times.Once,
+            "SendRawEmailAsync MUST delegate to IEmailSender so it honors EMAIL_PROVIDER (Resend), not a hardcoded SmtpClient.");
+
+        captured.Should().NotBeNull();
+        captured!.ToEmail.Should().Be("ops@meepleai.app");
+        captured.FromEmail.Should().Be("noreply@meepleai.app");
+        captured.FromName.Should().Be("MeepleAI");
+        captured.Subject.Should().Be("🚨 [CRITICAL] health.postgres - MeepleAI");
+        captured.HtmlBody.Should().Be("<p>alert</p>");
+    }
+
+    [Fact]
+    public async Task SendRawEmailAsync_WrapsSenderFailureInInvalidOperationException()
+    {
+        // Arrange
+        _sender
+            .Setup(s => s.SendAsync(It.IsAny<EmailRequest>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("transport down"));
+
+        var service = new EmailService(_configuration, _logger.Object, _sender.Object);
+
+        // Act
+        var act = () => service.SendRawEmailAsync(
+            toEmail: "ops@meepleai.app",
+            subject: "subj",
+            htmlBody: "<p>body</p>",
+            ct: CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<InvalidOperationException>()
+            .WithMessage("Failed to send raw email");
+    }
+}

--- a/apps/api/tests/Api.Tests/Services/HybridSearchServiceRoleBoostTests.cs
+++ b/apps/api/tests/Api.Tests/Services/HybridSearchServiceRoleBoostTests.cs
@@ -117,6 +117,99 @@ public sealed class HybridSearchServiceRoleBoostTests
     }
 
     // -----------------------------------------------------------------------------------------
+    // RAG answer-quality: legend-chunk demotion in RRF fusion.
+    // -----------------------------------------------------------------------------------------
+
+    [Fact]
+    public void ComputeLegendPenaltyFactor_PlainContent_ReturnsZero()
+    {
+        // Arrange: real actionable setup content with no cross-reference pointers.
+        var content = "Per preparare la partita, ogni giocatore riceve una plancia e le risorse iniziali.";
+
+        // Act & Assert
+        HybridSearchService.ComputeLegendPenaltyFactor(content).Should().Be(0f);
+    }
+
+    [Fact]
+    public void ComputeLegendPenaltyFactor_CrossReferenceLegend_ReturnsStrongDemotion()
+    {
+        // Arrange: the Terraforming Mars legend chunk that outranked the real setup section.
+        var legend = "8. Progetti Standard: possono essere usati da qualunque giocatore (vedi pag. 10). "
+                   + "9. Milestone/Ricompense: sono una buona fonte di PV extra (vedi pag. 10 e 11).";
+
+        // Act
+        var factor = HybridSearchService.ComputeLegendPenaltyFactor(legend);
+
+        // Assert: a short chunk dense with "vedi pag." pointers is strongly demoted.
+        factor.Should().BeGreaterThan(0.2f);
+    }
+
+    [Fact]
+    public void ComputeLegendPenaltyFactor_LongContentWithSinglePageRef_ReturnsMildDemotion()
+    {
+        // Arrange: a long, substantive chunk that happens to reference a page once.
+        var content = new string('a', 1400) + " (vedi pag. 12)";
+
+        // Act
+        var factor = HybridSearchService.ComputeLegendPenaltyFactor(content);
+
+        // Assert: one incidental pointer in a long chunk is not treated as a legend.
+        factor.Should().BeLessThan(0.2f);
+    }
+
+    [Fact]
+    public void ComputeLegendPenaltyFactor_DemotesLegendBelowRealContentAtSameBaseScore()
+    {
+        // Arrange: a legend and a real chunk with identical base RRF score.
+        const float baseScore = 0.011f; // representative collapsed-RRF magnitude from the repro
+        var legendFactor = HybridSearchService.ComputeLegendPenaltyFactor(
+            "8. Progetti Standard (vedi pag. 10). 9. Milestone (vedi pag. 10 e 11).");
+        var realFactor = HybridSearchService.ComputeLegendPenaltyFactor(
+            "Preparazione: disponi le tessere oceano e assegna le risorse iniziali ai giocatori.");
+
+        // Act
+        var legendScore = baseScore * (1f - legendFactor);
+        var realScore = baseScore * (1f - realFactor);
+
+        // Assert: the real setup chunk now outranks the legend.
+        realScore.Should().BeGreaterThan(legendScore);
+    }
+
+    [Fact]
+    public void LegendDemotion_KeepsRoleBoostAdditive()
+    {
+        // The legend penalty scales only the RRF fusion components; the role-match boost (#1391)
+        // stays additive so its ~0.15 calibration is preserved even when a legend shares a role tag.
+        const float baseRrf = 0.011f;
+        var legendFactor = HybridSearchService.ComputeLegendPenaltyFactor(
+            "8. Progetti Standard (vedi pag. 10). 9. Milestone (vedi pag. 10 e 11).");
+        var roleBoost = HybridSearchService.RoleMatchBoost;
+
+        // Mirror FuseSearchResults: (rrf * (1 - factor)) + roleBoost
+        var withRole = (baseRrf * (1f - legendFactor)) + roleBoost;
+        var withoutRole = (baseRrf * (1f - legendFactor)) + 0f;
+
+        // The additive boost is preserved intact, not shrunk by the legend factor.
+        legendFactor.Should().BeGreaterThan(0f, "the sample is a legend and must still be demoted");
+        (withRole - withoutRole).Should().Be(roleBoost);
+    }
+
+    [Fact]
+    public void ComputeLegendPenaltyFactor_LongContentWithManyReferences_IsNotOverDemoted()
+    {
+        // Arrange: a long, substantive section that legitimately cites several pages. Density is
+        // low, so it must NOT be treated as a legend (guards against raw-count over-demotion).
+        var content = new string('a', 4000)
+            + " vedi pag. 1 vedi pag. 2 vedi pag. 3 vedi pag. 4 vedi pag. 5";
+
+        // Act
+        var factor = HybridSearchService.ComputeLegendPenaltyFactor(content);
+
+        // Assert
+        factor.Should().BeLessThan(0.2f);
+    }
+
+    // -----------------------------------------------------------------------------------------
     // Issue #1391: semantic-mode boost end-to-end via HybridSearchService.SearchAsync.
     // pgvector now stores role_tags (denormalized from text_chunks) so SearchSemanticOnlyAsync
     // can apply the same RoleMatchBoost the keyword path already had.

--- a/infra/compose.prod.yml
+++ b/infra/compose.prod.yml
@@ -235,6 +235,8 @@ services:
       - ./prometheus/alerts/audit-outbox.yml:/etc/prometheus/audit-outbox.yml:ro
       # Issue #1965 — domain_event_outbox duplicate-publish trigger (referenced from prometheus.prod.yml rule_files).
       - ./prometheus/alerts/domain-event-outbox-duplicate-publish.yml:/etc/prometheus/domain-event-outbox-duplicate-publish.yml:ro
+      # Issue #3248 (epic #448 C5) — copyright enforcement observability alerts.
+      - ./prometheus/alerts/copyright-enforcement.yml:/etc/prometheus/copyright-enforcement.yml:ro
       - prometheus-prod:/prometheus
     deploy:
       resources:

--- a/infra/compose.prod.yml
+++ b/infra/compose.prod.yml
@@ -93,6 +93,11 @@ services:
       Frontend__BaseUrl: "https://${PROD_DOMAIN}"
       Authentication__SessionCookie__Secure: "true"
       Authentication__SessionCookie__SameSite: "Lax"
+      # OPS-07 / #3250: health/monitoring alert recipient — overrides the appsettings.json
+      # placeholder (ops@meepleai.app). Without this, prod alerts go to an unowned mailbox
+      # and are lost. From/transport are owned by EmailService (Resend via prod/email.secret).
+      # Not a secret, just the mailbox that receives alert emails.
+      Alerting__Email__To__0: badsworm@gmail.com
     logging:
       driver: "json-file"
       options: { max-size: "50m", max-file: "10" }

--- a/infra/compose.staging.yml
+++ b/infra/compose.staging.yml
@@ -342,6 +342,8 @@ services:
       - ./prometheus/alerts/audit-outbox.yml:/etc/prometheus/audit-outbox.yml:ro
       # Issue #1965 — domain_event_outbox duplicate-publish trigger (referenced from prometheus.staging.yml rule_files).
       - ./prometheus/alerts/domain-event-outbox-duplicate-publish.yml:/etc/prometheus/domain-event-outbox-duplicate-publish.yml:ro
+      # Issue #3248 (epic #448 C5) — copyright enforcement observability alerts.
+      - ./prometheus/alerts/copyright-enforcement.yml:/etc/prometheus/copyright-enforcement.yml:ro
       - prometheus-staging:/prometheus
 
   alertmanager:

--- a/infra/compose.staging.yml
+++ b/infra/compose.staging.yml
@@ -92,7 +92,7 @@ services:
       Authentication__SessionCookie__Secure: "true"
       Authentication__SessionCookie__SameSite: "Lax"
       # OPS-07: health/monitoring alert recipient — overrides the appsettings.json
-      # placeholder (ops@meepleai.dev). Not a secret, just the mailbox that receives
+      # placeholder (ops@meepleai.app). Not a secret, just the mailbox that receives
       # alert emails. From/credentials are inherited from EmailService's SMTP_* config
       # (email.secret); EmailAlertChannel no longer uses Alerting:Email:From/Username/
       # Password. badsworm@gmail.com is the already allow-listed staging address (Gmail→Gmail).

--- a/infra/dashboards/copyright-enforcement.json
+++ b/infra/dashboards/copyright-enforcement.json
@@ -1,0 +1,296 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Copyright leak guard observability (#447 metrics, epic #448 C5). Injection/detection/error/latency for the RAG response-body copyright gate. NOTE: recovery is single-path 'fallback' today; a per-action counter (fallback vs redact vs error) is future backend work (epic #448 C4). Verbatim detections are aggregated by run_length, never by document_id (UUID high-cardinality).",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "description": "Share of RAG system prompts that included the copyright paraphrase instruction because Protected chunks were retrieved.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "unit": "percentunit",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 6, "w": 8, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+          "editorMode": "code",
+          "expr": "sum(rate(meepleai_rag_copyright_instruction_injected_total{has_protected=\"true\"}[5m])) / clamp_min(sum(rate(meepleai_rag_copyright_instruction_injected_total[5m])), 1) or on() vector(0)",
+          "legendFormat": "injection rate",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Copyright instruction injection rate",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "description": "Verbatim-run detections / protected-chunk queries. Sustained >20% (warning alert) means the LLM is ignoring the paraphrase instruction.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "unit": "percentunit",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 0.2 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 6, "w": 16, "x": 8, "y": 0 },
+      "id": 2,
+      "options": {
+        "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "single", "sort": "none" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+          "editorMode": "code",
+          "expr": "sum(rate(meepleai_rag_copyright_verbatim_run_detected_total[5m])) / clamp_min(sum(rate(meepleai_rag_copyright_instruction_injected_total{has_protected=\"true\"}[5m])), 1) or on() vector(0)",
+          "legendFormat": "detection rate",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Verbatim detection rate (warning >20%)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "description": "Scan errors / total scan attempts. The guard fails open on error, so sustained >1% (critical alert) means leaks may reach clients undetected.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "unit": "percentunit",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "red", "value": 0.01 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 6, "w": 8, "x": 0, "y": 6 },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+          "editorMode": "code",
+          "expr": "sum(rate(meepleai_rag_copyright_guard_scan_errors_total[5m])) / clamp_min(sum(rate(meepleai_rag_copyright_guard_scan_errors_total[5m])) + sum(rate(meepleai_rag_copyright_guard_scan_duration_count[5m])), 1) or on() vector(0)",
+          "legendFormat": "scan error rate",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Scan error rate (critical >1%)",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "description": "Copyright leak guard scan latency. Budget is 50ms p99 (#447).",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 5,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "unit": "ms",
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "green", "value": null },
+              { "color": "orange", "value": 50 }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 6, "w": 16, "x": 8, "y": 6 },
+      "id": 4,
+      "options": {
+        "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "none" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum(rate(meepleai_rag_copyright_guard_scan_duration_bucket[5m])) by (le))",
+          "legendFormat": "p50",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.99, sum(rate(meepleai_rag_copyright_guard_scan_duration_bucket[5m])) by (le))",
+          "legendFormat": "p99",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.999, sum(rate(meepleai_rag_copyright_guard_scan_duration_bucket[5m])) by (le))",
+          "legendFormat": "p999",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Scan latency p50 / p99 / p999",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "description": "Verbatim detections broken down by run length (token count). Aggregated by run_length only — NEVER by document_id (UUID high-cardinality). Long runs = stronger leak signal; a spike of short runs suggests false positives on canonical game phraseology (calibration input for epic #448 C1 glossary whitelist).",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "bars",
+            "fillOpacity": 60,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "stacking": { "group": "A", "mode": "normal" }
+          },
+          "mappings": [],
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 12 },
+      "id": 5,
+      "options": {
+        "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+          "editorMode": "code",
+          "expr": "sum(rate(meepleai_rag_copyright_verbatim_run_detected_total[5m])) by (run_length)",
+          "legendFormat": "run_length={{run_length}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Verbatim detections by run_length",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+      "description": "Scan errors by exception type — explains WHY the guard is failing open (e.g. timeouts vs other). Drives the critical scan-error-rate alert.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "lineWidth": 1,
+            "showPoints": "never",
+            "spanNulls": false
+          },
+          "mappings": [],
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 12 },
+      "id": 6,
+      "options": {
+        "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "PBFA97CFB590B2093" },
+          "editorMode": "code",
+          "expr": "sum(rate(meepleai_rag_copyright_guard_scan_errors_total[5m])) by (error_type)",
+          "legendFormat": "{{error_type}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Scan errors by error_type",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": ["copyright", "rag", "observability", "epic-448"],
+  "templating": { "list": [] },
+  "time": { "from": "now-6h", "to": "now" },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Copyright Enforcement",
+  "uid": "copyright-enforcement",
+  "version": 1,
+  "weekStart": ""
+}

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -355,6 +355,8 @@ services:
       # Issue #1965 — domain_event_outbox duplicate-publish trigger (referenced from prometheus.yml rule_files).
       - ./prometheus/alerts/domain-event-outbox-duplicate-publish.yml:/etc/prometheus/domain-event-outbox-duplicate-publish.yml:ro
       - ./prometheus/alerts/wikidata-enrichment.yml:/etc/prometheus/wikidata-enrichment.yml:ro
+      # Issue #3248 (epic #448 C5) — copyright enforcement observability alerts.
+      - ./prometheus/alerts/copyright-enforcement.yml:/etc/prometheus/copyright-enforcement.yml:ro
       - prometheus_data:/prometheus
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "http://localhost:9090/-/healthy"]

--- a/infra/prometheus.prod.yml
+++ b/infra/prometheus.prod.yml
@@ -33,6 +33,8 @@ rule_files:
   - '/etc/prometheus/audit-outbox.yml'
   # Issue #1965 — domain_event_outbox duplicate-publish trigger (dormant until API >=2 replicas).
   - '/etc/prometheus/domain-event-outbox-duplicate-publish.yml'
+  # Issue #3248 (epic #448 C5) — copyright enforcement observability alerts.
+  - '/etc/prometheus/copyright-enforcement.yml'
 
 scrape_configs:
   - job_name: 'prometheus'

--- a/infra/prometheus.staging.yml
+++ b/infra/prometheus.staging.yml
@@ -35,6 +35,8 @@ rule_files:
   - '/etc/prometheus/audit-outbox.yml'
   # Issue #1965 — domain_event_outbox duplicate-publish trigger (dormant until API >=2 replicas).
   - '/etc/prometheus/domain-event-outbox-duplicate-publish.yml'
+  # Issue #3248 (epic #448 C5) — copyright enforcement observability alerts.
+  - '/etc/prometheus/copyright-enforcement.yml'
 
 scrape_configs:
   - job_name: 'prometheus'

--- a/infra/prometheus.yml
+++ b/infra/prometheus.yml
@@ -40,6 +40,8 @@ rule_files:
   - '/etc/prometheus/audit-outbox.yml'
   # Issue #1965 — domain_event_outbox duplicate-publish trigger (dormant until API >=2 replicas).
   - '/etc/prometheus/domain-event-outbox-duplicate-publish.yml'
+  # Issue #3248 (epic #448 C5) — copyright enforcement observability alerts.
+  - '/etc/prometheus/copyright-enforcement.yml'
 
 # Scrape configurations
 scrape_configs:

--- a/infra/prometheus/alerts/copyright-enforcement.test.yml
+++ b/infra/prometheus/alerts/copyright-enforcement.test.yml
@@ -1,0 +1,84 @@
+# promtool unit tests for copyright-enforcement.yml (#3248, epic #448 C5).
+#
+# Run locally (Windows/Git Bash, from repo root):
+#   docker run --rm -v "$(pwd)/infra/prometheus/alerts:/work" prom/prometheus:v3.7.0 \
+#     promtool test rules /work/copyright-enforcement.test.yml
+#
+# There is no promtool CI gate in this repo (see recon in #3082); this file
+# documents + verifies the two alerts (scan-error-rate critical, detection-rate
+# warning) that page ops per epic #448 C5.
+rule_files:
+  - copyright-enforcement.yml
+
+evaluation_interval: 1m
+
+tests:
+  # 1. scan_errors sustained at 2% of scan attempts (2 err / 100 scans per min)
+  #    must fire the CRITICAL alert once the 15m `for` window elapses — the
+  #    leak guard is failing open silently on >1% of protected-chunk queries.
+  - interval: 1m
+    input_series:
+      - series: 'meepleai_rag_copyright_guard_scan_errors_total'
+        values: '0+2x30'
+      - series: 'meepleai_rag_copyright_guard_scan_duration_count'
+        values: '0+98x30'
+    alert_rule_test:
+      - eval_time: 25m
+        alertname: CopyrightScanErrorRateHigh
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              service: meepleai-api
+              category: copyright
+            exp_annotations:
+              summary: "Copyright leak guard is failing open (>1% scan errors)"
+              description: "Copyright leak guard scan-error rate exceeded the 1% threshold of protected-chunk queries; the guard fails open, so verbatim leaks may reach clients undetected. Check LLM latency, scan timeout budget, and the error_type breakdown."
+              runbook_url: "https://github.com/meepleAi-app/meepleai-monorepo/blob/main-dev/docs/for-claude/architecture/copyright-tier-rag.md"
+              dashboard_url: "http://localhost:3001/d/copyright-enforcement"
+
+  # 2. Zero scan errors (guard healthy) must NOT fire — no page on green.
+  - interval: 1m
+    input_series:
+      - series: 'meepleai_rag_copyright_guard_scan_errors_total'
+        values: '0+0x30'
+      - series: 'meepleai_rag_copyright_guard_scan_duration_count'
+        values: '0+100x30'
+    alert_rule_test:
+      - eval_time: 25m
+        alertname: CopyrightScanErrorRateHigh
+        exp_alerts: []
+
+  # 3. Detection rate at 30% (30 verbatim runs / 100 protected-chunk queries)
+  #    must fire the WARNING alert after the 30m `for` window — the LLM is
+  #    ignoring the prompt-gate paraphrase instruction at scale.
+  - interval: 1m
+    input_series:
+      - series: 'meepleai_rag_copyright_verbatim_run_detected_total'
+        values: '0+30x45'
+      - series: 'meepleai_rag_copyright_instruction_injected_total{has_protected="true"}'
+        values: '0+100x45'
+    alert_rule_test:
+      - eval_time: 40m
+        alertname: CopyrightDetectionRateHigh
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              service: meepleai-api
+              category: copyright
+            exp_annotations:
+              summary: "Copyright verbatim-detection rate is high (>20%)"
+              description: "Verbatim-run detections exceeded the 20% threshold of protected-chunk queries; the LLM is not following the copyright paraphrase instruction. Review prompt-gate wording and recent model/routing changes."
+              runbook_url: "https://github.com/meepleAi-app/meepleai-monorepo/blob/main-dev/docs/for-claude/architecture/copyright-tier-rag.md"
+              dashboard_url: "http://localhost:3001/d/copyright-enforcement"
+
+  # 4. Detection rate at 10% (below the 20% threshold) must NOT fire.
+  - interval: 1m
+    input_series:
+      - series: 'meepleai_rag_copyright_verbatim_run_detected_total'
+        values: '0+10x45'
+      - series: 'meepleai_rag_copyright_instruction_injected_total{has_protected="true"}'
+        values: '0+100x45'
+    alert_rule_test:
+      - eval_time: 40m
+        alertname: CopyrightDetectionRateHigh
+        exp_alerts: []

--- a/infra/prometheus/alerts/copyright-enforcement.yml
+++ b/infra/prometheus/alerts/copyright-enforcement.yml
@@ -1,0 +1,62 @@
+# Issue #3248 (epic #448 C5) — copyright enforcement observability alerts.
+#
+# Metric source (apps/api/src/Api/Observability/Metrics/MeepleAiMetrics.Rag.cs:297-344,
+# #447 observability). OTel Prometheus exporter (1.13.1-beta.1) sanitizes dots to
+# underscores and appends `_total` to monotonic counters (unit is NOT appended —
+# cf. meepleai_bgg_url_attempted_render_total). Exported names:
+#   - meepleai_rag_copyright_guard_scan_errors_total   (counter; tag error_type)
+#   - meepleai_rag_copyright_guard_scan_duration_*     (histogram; _count/_sum/_bucket)
+#   - meepleai_rag_copyright_verbatim_run_detected_total (counter; tags run_length, document_id)
+#   - meepleai_rag_copyright_instruction_injected_total  (counter; tags has_protected, agent_language)
+#
+# Verify the exact scraped names in staging before relying on these:
+#   curl -s localhost:8080/metrics | grep copyright
+#
+# Two alerts per epic #448 C5: page ops when scan-error rate > 1% (guard failing
+# open) or verbatim-detection rate > 20% (LLM ignoring the prompt-gate).
+# Routing: severity=critical pages immediately (alertmanager.yml critical-alerts);
+# severity=warning goes to the warning route. Unit tests: copyright-enforcement.test.yml.
+groups:
+  - name: meepleai_copyright_enforcement_alerts
+    rules:
+      # CRITICAL: >1% of copyright scans on protected-chunk queries error out.
+      # The guard is fail-open (ChatWithSessionAgentCommandHandler.cs:522), so a
+      # sustained error rate means verbatim leaks can reach clients undetected.
+      - alert: CopyrightScanErrorRateHigh
+        expr: |
+          sum(rate(meepleai_rag_copyright_guard_scan_errors_total[5m]))
+          /
+          (
+            sum(rate(meepleai_rag_copyright_guard_scan_errors_total[5m]))
+            +
+            sum(rate(meepleai_rag_copyright_guard_scan_duration_count[5m]))
+          ) > 0.01
+        for: 15m
+        labels:
+          severity: critical
+          service: meepleai-api
+          category: copyright
+        annotations:
+          summary: "Copyright leak guard is failing open (>1% scan errors)"
+          description: "Copyright leak guard scan-error rate exceeded the 1% threshold of protected-chunk queries; the guard fails open, so verbatim leaks may reach clients undetected. Check LLM latency, scan timeout budget, and the error_type breakdown."
+          runbook_url: "https://github.com/meepleAi-app/meepleai-monorepo/blob/main-dev/docs/for-claude/architecture/copyright-tier-rag.md"
+          dashboard_url: "http://localhost:3001/d/copyright-enforcement"
+
+      # WARNING: >20% of protected-chunk queries trigger a verbatim-run detection,
+      # i.e. the LLM is not following the copyright paraphrase instruction at scale.
+      - alert: CopyrightDetectionRateHigh
+        expr: |
+          sum(rate(meepleai_rag_copyright_verbatim_run_detected_total[5m]))
+          /
+          sum(rate(meepleai_rag_copyright_instruction_injected_total{has_protected="true"}[5m]))
+          > 0.20
+        for: 30m
+        labels:
+          severity: warning
+          service: meepleai-api
+          category: copyright
+        annotations:
+          summary: "Copyright verbatim-detection rate is high (>20%)"
+          description: "Verbatim-run detections exceeded the 20% threshold of protected-chunk queries; the LLM is not following the copyright paraphrase instruction. Review prompt-gate wording and recent model/routing changes."
+          runbook_url: "https://github.com/meepleAi-app/meepleai-monorepo/blob/main-dev/docs/for-claude/architecture/copyright-tier-rag.md"
+          dashboard_url: "http://localhost:3001/d/copyright-enforcement"


### PR DESCRIPTION
Release di accumulo: **3 commit** da `main-dev` a `main-staging`.

- **fix(email) #3251** — prod alert recipient (era black-holed su ops@meepleai.dev) + `SendRawEmailAsync` ora rispetta `EMAIL_PROVIDER` (Resend) invece di SMTP hardcoded. Segue #3246 (alert-fatigue).
- feat(observability) #3249 — copyright enforcement dashboard + alert rules.
- fix(rag) #3243 — demote legend chunks in ranking (retrieval epic 2/3).

Ogni commit validato dalla CI sul rispettivo PR verso `main-dev`. Il merge triggera **Deploy to Staging**.
