### PR TITLE
fix(rag): add cross-encoder reranker to playground retrieval

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/PlaygroundChatCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/PlaygroundChatCommandHandler.cs
@@ -5,10 +5,12 @@ using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
 using System.Text;
 using Api.BoundedContexts.KnowledgeBase.Application.Commands;
+using Api.BoundedContexts.KnowledgeBase.Application.Services;
 using Api.BoundedContexts.KnowledgeBase.Domain.Models;
 using Api.BoundedContexts.KnowledgeBase.Domain.Entities;
 using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
 using Api.BoundedContexts.KnowledgeBase.Domain.Services;
+using Api.BoundedContexts.KnowledgeBase.Domain.Services.Reranking;
 using Api.Models;
 using Api.Services;
 using Api.Services.LlmClients;
@@ -27,6 +29,12 @@ internal sealed partial class PlaygroundChatCommandHandler : IStreamingQueryHand
 {
     private static readonly string[] DefaultConsensusModels = { "gpt-4", "claude-3-opus" };
 
+    // Issue #2708 parity: retrieve a wider candidate pool, then let the cross-encoder narrow it to
+    // the final top-K by semantic relevance — the same retrieve-wide/rerank-narrow wiring the
+    // /agents/qa path uses. The playground previously took the raw top-5 with no reranker.
+    private const int RerankCandidatePoolSize = 20;
+    private const int FinalTopK = 5;
+
     /// <summary>
     /// In-memory query cache for playground sessions.
     /// Key: SHA256(gameId + query), Value: (searchResults JSON hash, cachedAt).
@@ -41,6 +49,7 @@ internal sealed partial class PlaygroundChatCommandHandler : IStreamingQueryHand
     private readonly ILlmCostCalculator _costCalculator;
     private readonly ILlmCostLogRepository _costLogRepository;
     private readonly IRagExecutionRepository _ragExecutionRepository;
+    private readonly ICrossEncoderReranker _reranker;
     private readonly ILogger<PlaygroundChatCommandHandler> _logger;
 
     public PlaygroundChatCommandHandler(
@@ -50,6 +59,7 @@ internal sealed partial class PlaygroundChatCommandHandler : IStreamingQueryHand
         ILlmCostCalculator costCalculator,
         ILlmCostLogRepository costLogRepository,
         IRagExecutionRepository ragExecutionRepository,
+        ICrossEncoderReranker reranker,
         ILogger<PlaygroundChatCommandHandler> logger)
     {
         _agentDefinitionRepository = agentDefinitionRepository ?? throw new ArgumentNullException(nameof(agentDefinitionRepository));
@@ -58,6 +68,7 @@ internal sealed partial class PlaygroundChatCommandHandler : IStreamingQueryHand
         _costCalculator = costCalculator ?? throw new ArgumentNullException(nameof(costCalculator));
         _costLogRepository = costLogRepository ?? throw new ArgumentNullException(nameof(costLogRepository));
         _ragExecutionRepository = ragExecutionRepository ?? throw new ArgumentNullException(nameof(ragExecutionRepository));
+        _reranker = reranker ?? throw new ArgumentNullException(nameof(reranker));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -238,7 +249,7 @@ internal sealed partial class PlaygroundChatCommandHandler : IStreamingQueryHand
                     command.Message,
                     command.GameId.Value,
                     SearchMode.Hybrid,
-                    limit: 5,
+                    limit: RerankCandidatePoolSize,
                     cancellationToken: cancellationToken).ConfigureAwait(false);
             }
             catch (Exception ex)
@@ -266,6 +277,15 @@ internal sealed partial class PlaygroundChatCommandHandler : IStreamingQueryHand
 
             searchStopwatch.Stop();
 
+            // Issue #2708 parity: rerank the wider candidate pool down to the final top-K by
+            // semantic relevance (cross-encoder). Reranker failures degrade gracefully to the raw
+            // top-K inside RerankAsync. Runs only on a successful search with something to reorder.
+            if (searchError == null && searchResults.Count > 1)
+            {
+                searchResults = await SearchResultReranker.RerankAsync(
+                    _reranker, command.Message, searchResults, FinalTopK, _logger, cancellationToken).ConfigureAwait(false);
+            }
+
             // Emit search failure notification outside catch block (CS1631: yield not allowed in catch)
             if (searchError != null)
             {
@@ -285,7 +305,7 @@ internal sealed partial class PlaygroundChatCommandHandler : IStreamingQueryHand
                     responseSizeBytes: searchResults.Sum(r => Encoding.UTF8.GetByteCount(r.Content)),
                     statusCode: 200,
                     latencyMs: searchStopwatch.ElapsedMilliseconds,
-                    detail: $"mode=Hybrid, limit=5, results={searchResults.Count}",
+                    detail: $"mode=Hybrid, pool={RerankCandidatePoolSize}, final={searchResults.Count}",
                     requestPreview: command.Message.Length > 500 ? command.Message[..500] : command.Message,
                     responsePreview: searchResults.Count > 0
                         ? (searchResults[0].Content.Length > 500 ? searchResults[0].Content[..500] : searchResults[0].Content)
@@ -370,7 +390,8 @@ internal sealed partial class PlaygroundChatCommandHandler : IStreamingQueryHand
                 new Dictionary<string, string>(StringComparer.Ordinal)
                 {
                     ["mode"] = "Hybrid",
-                    ["limit"] = "5",
+                    ["candidatePool"] = RerankCandidatePoolSize.ToString(CultureInfo.InvariantCulture),
+                    ["finalTopK"] = FinalTopK.ToString(CultureInfo.InvariantCulture),
                     ["resultCount"] = (ragSnippets?.Count ?? 0).ToString(CultureInfo.InvariantCulture),
                     ["latencyMs"] = retrievalStopwatch.ElapsedMilliseconds.ToString(CultureInfo.InvariantCulture),
                     ["cacheStatus"] = cacheInfo?.status ?? "skip",

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/SearchResultReranker.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/SearchResultReranker.cs
@@ -2,6 +2,7 @@ using System.Globalization;
 using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
 using Api.BoundedContexts.KnowledgeBase.Domain.Services.Reranking;
 using Api.Observability;
+using Api.Services;
 using Microsoft.Extensions.Logging;
 
 namespace Api.BoundedContexts.KnowledgeBase.Application.Services;
@@ -21,11 +22,51 @@ namespace Api.BoundedContexts.KnowledgeBase.Application.Services;
 /// </summary>
 internal static class SearchResultReranker
 {
-    public static async Task<List<SearchResultDto>> RerankAsync(
+    /// <summary>
+    /// Reranks <see cref="SearchResultDto"/> results (the /agents/qa[/stream] path).
+    /// </summary>
+    public static Task<List<SearchResultDto>> RerankAsync(
         ICrossEncoderReranker reranker,
         string query,
         IReadOnlyList<SearchResultDto> results,
         int topK,
+        ILogger logger,
+        CancellationToken cancellationToken)
+        => RerankByIndexAsync(
+            reranker, query, results, topK,
+            static r => r.TextContent, static r => r.RelevanceScore,
+            logger, cancellationToken);
+
+    /// <summary>
+    /// Reranks <see cref="HybridSearchResult"/> results (Slice B: the playground path). Uses the
+    /// same index-keyed core so it returns the ORIGINAL objects reordered/trimmed — every field
+    /// (notably <c>ChunkIndex</c>, which a <see cref="SearchResultDto"/> conversion would drop)
+    /// survives untouched.
+    /// </summary>
+    public static Task<List<HybridSearchResult>> RerankAsync(
+        ICrossEncoderReranker reranker,
+        string query,
+        IReadOnlyList<HybridSearchResult> results,
+        int topK,
+        ILogger logger,
+        CancellationToken cancellationToken)
+        => RerankByIndexAsync(
+            reranker, query, results, topK,
+            static r => r.Content, static r => (double)r.HybridScore,
+            logger, cancellationToken);
+
+    /// <summary>
+    /// Index-keyed reranking core shared by both public overloads. The list index is the stable key
+    /// that maps a <see cref="RerankChunk"/> back to its original element, so the reranker only needs
+    /// a text + score projection and all other fields pass through opaquely.
+    /// </summary>
+    private static async Task<List<T>> RerankByIndexAsync<T>(
+        ICrossEncoderReranker reranker,
+        string query,
+        IReadOnlyList<T> results,
+        int topK,
+        Func<T, string> contentSelector,
+        Func<T, double> scoreSelector,
         ILogger logger,
         CancellationToken cancellationToken)
     {
@@ -39,12 +80,11 @@ internal static class SearchResultReranker
             return results.Take(topK).ToList();
         }
 
-        // The list index is the stable key mapping a RerankChunk back to its SearchResultDto.
         var rerankChunks = results
             .Select((r, i) => new RerankChunk(
                 Id: i.ToString(CultureInfo.InvariantCulture),
-                Content: r.TextContent,
-                OriginalScore: r.RelevanceScore))
+                Content: contentSelector(r),
+                OriginalScore: scoreSelector(r)))
             .ToList();
 
         try
@@ -53,14 +93,7 @@ internal static class SearchResultReranker
                 .RerankAsync(query, rerankChunks, topK, cancellationToken)
                 .ConfigureAwait(false);
 
-            var reranked = rerankResult.Chunks
-                .Select(c => int.TryParse(c.Id, NumberStyles.Integer, CultureInfo.InvariantCulture, out var idx) ? idx : -1)
-                .Where(idx => idx >= 0 && idx < results.Count)
-                .Select(idx => results[idx])
-                .ToList();
-
-            // Defensive: a reranker that returns no mappable chunks must not blank the context.
-            return reranked.Count > 0 ? reranked : results.Take(topK).ToList();
+            return MapRerankedIndices(results, rerankResult.Chunks, topK);
         }
         catch (Exception ex)
         {
@@ -68,5 +101,28 @@ internal static class SearchResultReranker
             MeepleAiMetrics.RecordRetrievalFallback(MeepleAiMetrics.RagFallbackTypes.Reranker);
             return results.Take(topK).ToList();
         }
+    }
+
+    /// <summary>
+    /// Pure index-mapping: maps each reranked chunk's list-index id back to its original element,
+    /// dropping unparseable/out-of-range ids. If nothing maps (a reranker that renamed/dropped all
+    /// ids), falls back to the raw top-K so the context is never blanked.
+    /// </summary>
+    internal static List<T> MapRerankedIndices<T>(
+        IReadOnlyList<T> results,
+        IReadOnlyList<RerankedChunk> reranked,
+        int topK)
+    {
+        ArgumentNullException.ThrowIfNull(results);
+        ArgumentNullException.ThrowIfNull(reranked);
+
+        var mapped = reranked
+            .Select(c => int.TryParse(c.Id, NumberStyles.Integer, CultureInfo.InvariantCulture, out var idx) ? idx : -1)
+            .Where(idx => idx >= 0 && idx < results.Count)
+            .Select(idx => results[idx])
+            .ToList();
+
+        // Defensive: a reranker that returns no mappable chunks must not blank the context.
+        return mapped.Count > 0 ? mapped : results.Take(topK).ToList();
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/PlaygroundChatCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/PlaygroundChatCommandHandlerTests.cs
@@ -4,6 +4,7 @@ using Api.BoundedContexts.KnowledgeBase.Application.Queries;
 using Api.BoundedContexts.KnowledgeBase.Domain.Models;
 using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
 using Api.BoundedContexts.KnowledgeBase.Domain.Services;
+using Api.BoundedContexts.KnowledgeBase.Domain.Services.Reranking;
 using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
 using AgentDefinitionEntity = Api.BoundedContexts.KnowledgeBase.Domain.Entities.AgentDefinition;
 using Api.Models;
@@ -31,6 +32,7 @@ public sealed class PlaygroundChatCommandHandlerTests
     private readonly Mock<ILlmCostCalculator> _mockCostCalculator;
     private readonly Mock<ILlmCostLogRepository> _mockCostLogRepository;
     private readonly Mock<IRagExecutionRepository> _mockRagExecutionRepository;
+    private readonly Mock<ICrossEncoderReranker> _mockReranker;
     private readonly Mock<ILogger<PlaygroundChatCommandHandler>> _mockLogger;
     private readonly PlaygroundChatCommandHandler _handler;
 
@@ -49,6 +51,8 @@ public sealed class PlaygroundChatCommandHandlerTests
         _mockCostCalculator = new Mock<ILlmCostCalculator>();
         _mockCostLogRepository = new Mock<ILlmCostLogRepository>();
         _mockRagExecutionRepository = new Mock<IRagExecutionRepository>();
+        _mockReranker = new Mock<ICrossEncoderReranker>();
+        SetupPassthroughReranker(_mockReranker);
         _mockLogger = new Mock<ILogger<PlaygroundChatCommandHandler>>();
 
         // Set up cost calculator to return valid result (avoids NRE in cost logging)
@@ -63,8 +67,24 @@ public sealed class PlaygroundChatCommandHandlerTests
             _mockCostCalculator.Object,
             _mockCostLogRepository.Object,
             _mockRagExecutionRepository.Object,
+            _mockReranker.Object,
             _mockLogger.Object
         );
+    }
+
+    /// <summary>
+    /// Default reranker mock: preserves input order and returns the top-K (Issue #2708 wiring).
+    /// </summary>
+    private static void SetupPassthroughReranker(Mock<ICrossEncoderReranker> mock)
+    {
+        mock
+            .Setup(r => r.RerankAsync(It.IsAny<string>(), It.IsAny<IReadOnlyList<RerankChunk>>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string _, IReadOnlyList<RerankChunk> chunks, int? topK, CancellationToken _) =>
+                new RerankResult(
+                    chunks.Take(topK ?? chunks.Count)
+                        .Select((c, i) => new RerankedChunk(c.Id, c.Content, c.OriginalScore, 0.9 - (i * 0.1)))
+                        .ToList(),
+                    "test-model", 1.0));
     }
 
     [Fact]
@@ -448,9 +468,10 @@ public sealed class PlaygroundChatCommandHandlerTests
             .Setup(r => r.GetByIdAsync(agentDefId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(agentDef);
 
+        // limit is now the wider rerank candidate pool (20), not the final top-K (Issue #2708).
         _mockHybridSearchService
             .Setup(s => s.SearchAsync(
-                It.IsAny<string>(), gameId, SearchMode.Hybrid, 5,
+                It.IsAny<string>(), gameId, SearchMode.Hybrid, 20,
                 null, 0.7f, 0.3f, It.IsAny<double>(), It.IsAny<GameBookRole>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new List<HybridSearchResult>
             {
@@ -488,6 +509,74 @@ public sealed class PlaygroundChatCommandHandlerTests
         var complete = completeEvent.Data.Should().BeOfType<PlaygroundStreamingComplete>().Which;
         complete.confidence.Should().NotBeNull();
         (complete.confidence > 0).Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task Should_Rerank_CandidatePool_To_FinalTopK_PreservingChunkIndex()
+    {
+        // Arrange — a 20-chunk candidate pool that the cross-encoder narrows to the final top-5.
+        var agentDefId = Guid.NewGuid();
+        var gameId = Guid.NewGuid();
+        var agentDef = CreateActiveAgentDefinition(agentDefId, "RAG Agent");
+        var command = new PlaygroundChatCommand(agentDefId, "How do I set up the game?", gameId);
+
+        _mockAgentDefinitionRepository
+            .Setup(r => r.GetByIdAsync(agentDefId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(agentDef);
+
+        var pool = Enumerable.Range(0, 20)
+            .Select(i => new HybridSearchResult
+            {
+                ChunkId = $"chunk-{i}",
+                Content = $"passage {i}",
+                PdfDocumentId = Guid.NewGuid().ToString(),
+                GameId = gameId,
+                ChunkIndex = i,
+                PageNumber = 1,
+                HybridScore = 0.90f - (i * 0.01f),
+                Mode = SearchMode.Hybrid
+            })
+            .ToList();
+
+        _mockHybridSearchService
+            .Setup(s => s.SearchAsync(
+                It.IsAny<string>(), gameId, SearchMode.Hybrid, 20,
+                null, 0.7f, 0.3f, It.IsAny<double>(), It.IsAny<GameBookRole>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(pool);
+
+        // Reranker REVERSES the pool and returns the top-5 — proves the final order follows the
+        // cross-encoder, not the raw RRF order, and that the pool was actually narrowed.
+        _mockReranker
+            .Setup(r => r.RerankAsync(It.IsAny<string>(), It.IsAny<IReadOnlyList<RerankChunk>>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string _, IReadOnlyList<RerankChunk> chunks, int? topK, CancellationToken _) =>
+                new RerankResult(
+                    chunks.Reverse().Take(topK ?? chunks.Count)
+                        .Select((c, i) => new RerankedChunk(c.Id, c.Content, c.OriginalScore, 1.0 - (i * 0.1)))
+                        .ToList(),
+                    "test-model", 1.0));
+
+        SetupLlmClientStream(new[] { new StreamChunk("ok") });
+
+        // Act
+        var events = new List<RagStreamingEvent>();
+        await foreach (var @event in _handler.Handle(command, CancellationToken.None))
+        {
+            events.Add(@event);
+        }
+
+        // Assert — 20-chunk pool reranked and narrowed to the final top-5, in reranker order.
+        var citations = events.First(e => e.Type == StreamingEventType.Citations)
+            .Data.Should().BeOfType<StreamingCitations>().Which.citations;
+        citations.Should().HaveCount(5);
+        citations.Select(c => c.text).Should().Equal("passage 19", "passage 18", "passage 17", "passage 16", "passage 15");
+        // Snippet.line == HybridSearchResult.ChunkIndex — survives the rerank (a SearchResultDto
+        // conversion would have dropped it).
+        citations.Select(c => c.line).Should().Equal(19, 18, 17, 16, 15);
+
+        // The reranker was invoked once with the final top-K (5), not the pool size.
+        _mockReranker.Verify(
+            r => r.RerankAsync(It.IsAny<string>(), It.IsAny<IReadOnlyList<RerankChunk>>(), It.Is<int?>(k => k == 5), It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 
     [Fact]

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/SearchResultRerankerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/SearchResultRerankerTests.cs
@@ -208,6 +208,64 @@ public class SearchResultRerankerTests
     }
 
     // ---------------------------------------------------------------------
+    // Projection guards: the reranker must receive the CONTENT + score of each
+    // result (a real cross-encoder reranks on text). MapRerankedIndices reorders
+    // by list-index and rebuilds from the originals, so a wrong contentSelector
+    // (e.g. projecting ChunkId instead of Content) would otherwise ship green.
+    // ---------------------------------------------------------------------
+
+    private static Mock<ICrossEncoderReranker> CapturingReranker(out Func<IReadOnlyList<RerankChunk>?> captured)
+    {
+        IReadOnlyList<RerankChunk>? seen = null;
+        captured = () => seen;
+        var mock = new Mock<ICrossEncoderReranker>();
+        mock
+            .Setup(r => r.RerankAsync(It.IsAny<string>(), It.IsAny<IReadOnlyList<RerankChunk>>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
+            .Callback((string _, IReadOnlyList<RerankChunk> chunks, int? _, CancellationToken _) => seen = chunks)
+            .ReturnsAsync((string _, IReadOnlyList<RerankChunk> chunks, int? topK, CancellationToken _) =>
+                new RerankResult(
+                    chunks.Take(topK ?? chunks.Count).Select(c => new RerankedChunk(c.Id, c.Content, c.OriginalScore, 0.9)).ToList(),
+                    "test-model", 1.0));
+        return mock;
+    }
+
+    [Fact]
+    public async Task RerankAsync_HybridResults_FeedsContentAndHybridScoreToReranker()
+    {
+        var results = new List<HybridSearchResult>
+        {
+            Hybrid("chunk-a", "Pawns move forward.", 0.80f, 5),
+            Hybrid("chunk-b", "Knights move in an L.", 0.78f, 6),
+        };
+        var reranker = CapturingReranker(out var captured);
+
+        await SearchResultReranker.RerankAsync(
+            reranker.Object, "how do pawns move", results, topK: 2, _loggerMock.Object, CancellationToken.None);
+
+        captured().Should().NotBeNull();
+        captured()!.Select(c => c.Content).Should().Equal("Pawns move forward.", "Knights move in an L.");
+        captured()!.Select(c => c.OriginalScore).Should().Equal(results.Select(r => (double)r.HybridScore));
+    }
+
+    [Fact]
+    public async Task RerankAsync_DtoResults_FeedsTextContentAndRelevanceScoreToReranker()
+    {
+        var results = new List<SearchResultDto>
+        {
+            Dto("doc-a", "text alpha", 0.80),
+            Dto("doc-b", "text beta", 0.78),
+        };
+        var reranker = CapturingReranker(out var captured);
+
+        await SearchResultReranker.RerankAsync(
+            reranker.Object, "query", results, topK: 2, _loggerMock.Object, CancellationToken.None);
+
+        captured().Should().NotBeNull();
+        captured()!.Select(c => c.Content).Should().Equal("text alpha", "text beta");
+        captured()!.Select(c => c.OriginalScore).Should().Equal(0.80, 0.78);
+    }
+
+    // ---------------------------------------------------------------------
     // Pure index-mapping seam shared by both overloads (no infra/mocks).
     // ---------------------------------------------------------------------
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/SearchResultRerankerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/SearchResultRerankerTests.cs
@@ -1,6 +1,8 @@
+using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
 using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
 using Api.BoundedContexts.KnowledgeBase.Application.Services;
 using Api.BoundedContexts.KnowledgeBase.Domain.Services.Reranking;
+using Api.Services;
 using Api.Tests.Constants;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
@@ -110,5 +112,134 @@ public class SearchResultRerankerTests
         reranker.Verify(
             r => r.RerankAsync(It.IsAny<string>(), It.IsAny<IReadOnlyList<RerankChunk>>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()),
             Times.Never);
+    }
+
+    // ---------------------------------------------------------------------
+    // Slice B: HybridSearchResult overload — lets the PLAYGROUND path rerank
+    // its List<HybridSearchResult> WITHOUT a lossy conversion to SearchResultDto
+    // (which lacks ChunkIndex and would need a throwing Guid.Parse). The overload
+    // returns the ORIGINAL objects reordered/trimmed, so every field survives.
+    // ---------------------------------------------------------------------
+
+    private static HybridSearchResult Hybrid(string chunkId, string content, float score, int chunkIndex)
+        => new()
+        {
+            ChunkId = chunkId,
+            Content = content,
+            PdfDocumentId = "pdf-1",
+            GameId = Guid.Empty,
+            ChunkIndex = chunkIndex,
+            PageNumber = 3,
+            HybridScore = score,
+            Mode = SearchMode.Hybrid,
+            MatchedTerms = new List<string>(),
+            RoleTags = GameBookRole.None,
+        };
+
+    [Fact]
+    public async Task RerankAsync_HybridResults_ReordersBySemanticRelevance()
+    {
+        var results = new List<HybridSearchResult>
+        {
+            Hybrid("chunk-a", "Pawns move forward.", 0.80f, 0),
+            Hybrid("chunk-b", "Knights move in an L.", 0.78f, 1),
+            Hybrid("chunk-c", "Castling rules.", 0.76f, 2),
+        };
+        var reranker = ReverseReranker();
+
+        var reranked = await SearchResultReranker.RerankAsync(
+            reranker.Object, "how do pawns move", results, topK: 3, _loggerMock.Object, CancellationToken.None);
+
+        reranked.Select(r => r.ChunkId).Should().Equal("chunk-c", "chunk-b", "chunk-a");
+    }
+
+    [Fact]
+    public async Task RerankAsync_HybridResults_SelectsTopKFromLargerPool_PreservingChunkIndex()
+    {
+        // 20 candidates in, top 5 out — mirrors the playground retrieve-wide/rerank-narrow wiring.
+        var results = Enumerable.Range(0, 20)
+            .Select(i => Hybrid($"chunk-{i}", $"content {i}", 0.90f - (i * 0.01f), chunkIndex: i * 10))
+            .ToList();
+        var reranker = ReverseReranker();
+
+        var reranked = await SearchResultReranker.RerankAsync(
+            reranker.Object, "query", results, topK: 5, _loggerMock.Object, CancellationToken.None);
+
+        reranked.Should().HaveCount(5);
+        // ChunkIndex (dropped by any SearchResultDto conversion) must survive intact.
+        reranked.Select(r => r.ChunkIndex).Should().Equal(190, 180, 170, 160, 150);
+        reranked.Select(r => r.ChunkId).Should().Equal("chunk-19", "chunk-18", "chunk-17", "chunk-16", "chunk-15");
+    }
+
+    [Fact]
+    public async Task RerankAsync_HybridResults_WhenRerankerThrows_FallsBackToRawTopK()
+    {
+        var results = new List<HybridSearchResult>
+        {
+            Hybrid("chunk-a", "x", 0.80f, 0),
+            Hybrid("chunk-b", "y", 0.78f, 1),
+            Hybrid("chunk-c", "z", 0.76f, 2),
+        };
+        var reranker = new Mock<ICrossEncoderReranker>();
+        reranker
+            .Setup(r => r.RerankAsync(It.IsAny<string>(), It.IsAny<IReadOnlyList<RerankChunk>>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("reranker service down"));
+
+        var reranked = await SearchResultReranker.RerankAsync(
+            reranker.Object, "query", results, topK: 2, _loggerMock.Object, CancellationToken.None);
+
+        reranked.Should().HaveCount(2);
+        reranked.Select(r => r.ChunkId).Should().Equal("chunk-a", "chunk-b");
+    }
+
+    [Fact]
+    public async Task RerankAsync_HybridResults_SingleResult_SkipsRerankerCall()
+    {
+        var results = new List<HybridSearchResult> { Hybrid("chunk-a", "only chunk", 0.80f, 0) };
+        var reranker = new Mock<ICrossEncoderReranker>();
+
+        var reranked = await SearchResultReranker.RerankAsync(
+            reranker.Object, "query", results, topK: 5, _loggerMock.Object, CancellationToken.None);
+
+        reranked.Should().ContainSingle().Which.ChunkId.Should().Be("chunk-a");
+        reranker.Verify(
+            r => r.RerankAsync(It.IsAny<string>(), It.IsAny<IReadOnlyList<RerankChunk>>(), It.IsAny<int?>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    // ---------------------------------------------------------------------
+    // Pure index-mapping seam shared by both overloads (no infra/mocks).
+    // ---------------------------------------------------------------------
+
+    private static RerankedChunk Ranked(string id) => new(id, "c", 0.5, 0.9);
+
+    [Fact]
+    public void MapRerankedIndices_MapsIdsBackToOriginalsInOrder()
+    {
+        var results = new List<string> { "a", "b", "c" };
+        var reranked = new List<RerankedChunk> { Ranked("2"), Ranked("0") };
+
+        SearchResultReranker.MapRerankedIndices(results, reranked, topK: 3)
+            .Should().Equal("c", "a");
+    }
+
+    [Fact]
+    public void MapRerankedIndices_FiltersUnparseableAndOutOfRangeIds()
+    {
+        var results = new List<string> { "a", "b", "c" };
+        var reranked = new List<RerankedChunk> { Ranked("5"), Ranked("x"), Ranked("1") };
+
+        SearchResultReranker.MapRerankedIndices(results, reranked, topK: 3)
+            .Should().Equal("b");
+    }
+
+    [Fact]
+    public void MapRerankedIndices_NoMappableChunks_FallsBackToRawTopK()
+    {
+        var results = new List<string> { "a", "b", "c" };
+        var reranked = new List<RerankedChunk> { Ranked("9"), Ranked("bad") };
+
+        SearchResultReranker.MapRerankedIndices(results, reranked, topK: 2)
+            .Should().Equal("a", "b");
     }
 }


### PR DESCRIPTION
## Slice B — Cross-encoder reranker on the playground path (RAG answer-quality epic)

Part of the RAG answer-quality epic. Follows #3254 (slice A).

### Problem
The playground path (`PlaygroundChatCommandHandler`) took the raw hybrid **top-5** with **no reranker**, while `/agents/qa` already retrieves a wider pool and reranks to the final top-K (Issue #2708). The playground under-discriminated relevant chunks.

### Fix
Bring the playground to parity — retrieve-wide (20), rerank-narrow (5).

- **`SearchResultReranker`**: add a `HybridSearchResult` overload via a shared index-keyed core (`RerankByIndexAsync<T>`) + a pure, unit-tested `MapRerankedIndices<T>` seam. The overload returns the **original objects** reordered/trimmed, so every field survives — notably **`ChunkIndex`**, which a `SearchResultDto` conversion would drop (and needs a throwing `Guid.Parse`).
- **Handler**: inject `ICrossEncoderReranker` (auto-DI; already registered + used by AskQuestion), pool `20` → rerank `5`. Reranker failure degrades gracefully to the raw top-K inside `RerankAsync`.
- **No post-rerank MinScore**: `HybridScore` is RRF-fused, not a cosine — a cosine-style floor would be semantically wrong (matches Issue #2708 rationale).
- Debug apiTrace/dataFlow updated to report pool/final honestly.

### Verification
- **9 new tests**: HybridSearchResult overload (reorder, top-K-from-pool, ChunkIndex preservation, throw→fallback, single-skip) + pure `MapRerankedIndices` seam (parse-failure, out-of-range, empty→fallback) + 2 handler tests (rerank narrows 20→5 preserving ChunkIndex).
- Existing `SearchResultDto` reranker tests unchanged & green (delegation is faithful).

🤖 Generated with [Claude Code](https://claude.com/claude-code)