### PR TITLE
fix(frontend): #564 add onError rollback to useRecordGameSession

### DIFF
--- a/apps/web/src/lib/domain-hooks/__tests__/useGameDetail.test.ts
+++ b/apps/web/src/lib/domain-hooks/__tests__/useGameDetail.test.ts
@@ -285,4 +285,30 @@ describe('useRecordGameSession', () => {
 
     expect(result.current.error?.message).toBe('Failed to record session');
   });
+
+  it('clears the recording flag and the optimistic id and records the error on failure', async () => {
+    const { api } = await import('@/lib/api');
+    vi.mocked(api.library.recordGameSession).mockRejectedValueOnce(
+      new Error('Failed to record session')
+    );
+
+    const { result } = renderHook(() => useRecordGameSession('game-456'), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate({
+      playedAt: new Date(),
+      durationMinutes: 90,
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    // Loading flag must be released (was stuck at true without onError).
+    expect(storeMocks.setIsRecordingSession).toHaveBeenLastCalledWith(false);
+    // The optimistic session id must be cleared, not left pointing at a
+    // session that was never created.
+    expect(storeMocks.setOptimisticSessionId).toHaveBeenLastCalledWith(null);
+    // Error must be surfaced to the store.
+    expect(storeMocks.setError).toHaveBeenCalledWith('Failed to record session');
+  });
 });

--- a/apps/web/src/lib/domain-hooks/useGameDetail.ts
+++ b/apps/web/src/lib/domain-hooks/useGameDetail.ts
@@ -180,6 +180,15 @@ export function useRecordGameSession(gameId: string) {
 
       return { optimisticId };
     },
+    onError: error => {
+      // Release the recording flag and clear the dangling optimistic session
+      // id. Without this, a failed record leaves isRecordingSession stuck at
+      // true and optimisticSessionId pointing at a session that was never
+      // created.
+      setIsRecordingSession(false);
+      setOptimisticSessionId(null);
+      setError(error instanceof Error ? error.message : 'Failed to record session');
+    },
     onSuccess: sessionId => {
       // Invalidate to refetch with updated stats
       queryClient.invalidateQueries({ queryKey: GAME_DETAIL_QUERY_KEY(gameId) });


### PR DESCRIPTION
## Contesto

Residuo actionable segnalato dal triage Q3 di **#564** (commento 2026-07-20): `useRecordGameSession` condivide con `useUpdateGameState` la forma "optimistic `onMutate` senza `onError`". Il gemello `useUpdateGameState` è stato fixato in #3255; questo chiude l'altra metà.

## Il bug

`useRecordGameSession` (`apps/web/src/lib/domain-hooks/useGameDetail.ts`) in `onMutate` imposta:
- `setIsRecordingSession(true)`
- `setOptimisticSessionId(optimistic-<ts>)`

`onSuccess` li resetta, ma **mancava `onError`**. Su una mutation fallita (rete / 5xx da `api.library.recordGameSession`):
- `isRecordingSession` resta **stuck a `true`** → UI di recording bloccata (spinner/disabled infinito);
- `optimisticSessionId` resta un **id fantasma** che punta a una sessione mai creata;
- nessun `setError` → zero feedback all'utente.

React Query **non** compensa automaticamente scritture su store Zustand.

## Fix

Aggiunto `onError` simmetrico al gemello `useUpdateGameState`: rilascia il flag, azzera l'optimistic id, propaga il messaggio d'errore allo store.

## Test (TDD)

- **RED**: nuovo test `clears the recording flag and the optimistic id and records the error on failure` — falliva perché `setIsRecordingSession` restava all'ultima chiamata `true`.
- **GREEN**: 10/10 test verdi in `__tests__/useGameDetail.test.ts` (9 preesistenti + 1 nuovo). `pnpm typecheck` pulito, lint hook ok.

## Verifica di completezza del bug-class

Sweep per-blocco su **tutti i 19 file** del frontend con `useMutation`+`onMutate` (62 blocchi analizzati, verifica avversariale sui candidati): **0 altri siti** con optimistic `onMutate` privo di compensazione d'errore. Ogni altra mutation ha già `onError`, `onSettled` di cleanup, o nessun side-effect persistente in `onMutate`. `useRecordGameSession` era l'ultimo gemello di questo bug-class.

Chiude un item del residuo actionable di #564 (gli altri 2 — `sidebar-filters.tsx:32` token-gated, `RecentActivityRail.tsx:155` a11y minore — restano per il prossimo gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)