### PR TITLE
fix(rag): carry role_tags through vector arm of hybrid fusion

### DIFF
--- a/apps/api/src/Api/Services/HybridSearchService.cs
+++ b/apps/api/src/Api/Services/HybridSearchService.cs
@@ -283,7 +283,10 @@ internal class HybridSearchService : IHybridSearchService
             Text = se.Embedding.TextContent,
             PdfId = se.Embedding.VectorDocumentId.ToString(),
             ChunkIndex = se.Embedding.ChunkIndex,
-            Page = se.Embedding.PageNumber
+            Page = se.Embedding.PageNumber,
+            // Slice C: carry role_tags through so vector-only chunks get the role-match boost in
+            // fusion (same cast as the semantic-only path). pgvector already SELECTs role_tags.
+            RoleTags = (GameBookRole)se.Embedding.RoleTags
         }).ToArray();
 
         _logger.LogInformation(
@@ -435,12 +438,17 @@ internal class HybridSearchService : IHybridSearchService
                 keywordRrfScore = keywordItem != null ? keywordWeight / (rrfK + keywordItem.Rank) : 0f;
             }
 
-            // Phase D (D6): role-match boost — only the keyword side currently carries RoleTags
-            // (pgvector_embeddings table does not store role_tags). When the chunk overlaps the
-            // user's classified intent, apply an additive boost on top of the fused RRF score.
-            var chunkRoleTags = hasKeyword && keywordItem != null
+            // Phase D (D6) + Slice C: role-match boost. Both arms denormalize the same
+            // text_chunks.role_tags (keyword from text_chunks, vector from pgvector_embeddings.role_tags),
+            // so union the two — a chunk surfacing via EITHER arm carries its role. When the chunk
+            // overlaps the user's classified intent, apply an additive boost on top of the fused RRF.
+            var vectorRoleTags = hasVector && vectorItem != null
+                ? vectorItem.Result.RoleTags
+                : GameBookRole.None;
+            var keywordRoleTags = hasKeyword && keywordItem != null
                 ? keywordItem.Result.RoleTags
                 : GameBookRole.None;
+            var chunkRoleTags = vectorRoleTags | keywordRoleTags;
             var roleBoost = ComputeRoleMatchBoost(queryRoleHint, chunkRoleTags);
 
             // Use data from whichever result has it (prefer vector for metadata consistency)

--- a/apps/api/src/Api/Services/HybridSearchService.cs
+++ b/apps/api/src/Api/Services/HybridSearchService.cs
@@ -438,10 +438,14 @@ internal class HybridSearchService : IHybridSearchService
                 keywordRrfScore = keywordItem != null ? keywordWeight / (rrfK + keywordItem.Rank) : 0f;
             }
 
-            // Phase D (D6) + Slice C: role-match boost. Both arms denormalize the same
-            // text_chunks.role_tags (keyword from text_chunks, vector from pgvector_embeddings.role_tags),
-            // so union the two — a chunk surfacing via EITHER arm carries its role. When the chunk
-            // overlaps the user's classified intent, apply an additive boost on top of the fused RRF.
+            // Phase D (D6) + Slice C: role-match boost. Take the role tags from whichever arm
+            // surfaced the chunk (both denormalize the same text_chunks.role_tags — keyword from
+            // text_chunks, vector from pgvector_embeddings.role_tags). The union is defensive: with
+            // the current fusion keying the two arms never share a key (vector = "{VectorDocumentId}
+            // _{ChunkIndex}", keyword = raw text_chunks.Id), so each entry is single-arm and the OR
+            // reduces to the present arm — a genuine both-arm merge awaits the fusion-key alignment
+            // follow-up. When the chunk overlaps the user's classified intent, apply an additive
+            // boost on top of the fused RRF.
             var vectorRoleTags = hasVector && vectorItem != null
                 ? vectorItem.Result.RoleTags
                 : GameBookRole.None;

--- a/apps/api/src/Api/Services/IHybridSearchService.cs
+++ b/apps/api/src/Api/Services/IHybridSearchService.cs
@@ -117,8 +117,9 @@ internal record HybridSearchResult
 
     /// <summary>
     /// Phase D (D6): role classification of the underlying text chunk (multi-label bitflag).
-    /// Sourced from text_chunks.role_tags. <see cref="GameBookRole.None"/> when unclassified
-    /// or when the result came from the vector path (pgvector_embeddings table lacks role_tags).
+    /// Sourced from text_chunks.role_tags (keyword arm) and the denormalized
+    /// pgvector_embeddings.role_tags (vector arm); the two are unioned in fusion (Slice C).
+    /// <see cref="GameBookRole.None"/> when the chunk is unclassified.
     /// </summary>
     public GameBookRole RoleTags { get; init; } = GameBookRole.None;
 }

--- a/apps/api/src/Api/Services/VectorSearchModels.cs
+++ b/apps/api/src/Api/Services/VectorSearchModels.cs
@@ -1,3 +1,5 @@
+using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
+
 namespace Api.Services;
 
 /// <summary>
@@ -56,6 +58,13 @@ internal record SearchResultItem
     public string PdfId { get; init; } = string.Empty;
     public int Page { get; init; }
     public int ChunkIndex { get; init; }
+
+    /// <summary>
+    /// Role classification of the underlying chunk (multi-label bitflag from text_chunks.role_tags,
+    /// denormalized onto pgvector_embeddings.role_tags). Carried through the vector-arm projection so
+    /// HYBRID fusion can apply the role-match boost to vector-only chunks (Slice C).
+    /// </summary>
+    public GameBookRole RoleTags { get; init; } = GameBookRole.None;
 }
 
 /// <summary>

--- a/apps/api/tests/Api.Tests/Services/HybridSearchServiceRoleBoostTests.cs
+++ b/apps/api/tests/Api.Tests/Services/HybridSearchServiceRoleBoostTests.cs
@@ -439,4 +439,59 @@ public sealed class HybridSearchServiceRoleBoostTests
         results.Should().HaveCount(1);
         results[0].VectorScore.Should().BeApproximately((float)cosine, 0.0001f);
     }
+
+    // -----------------------------------------------------------------------------------------
+    // Slice C: role-match boost on the VECTOR arm of HYBRID fusion. The pgvector query already
+    // SELECTs role_tags (Embedding.RoleTags), but the SearchResultItem projection used to drop it,
+    // so a chunk surfacing ONLY via the vector arm got no boost even when its role matched the
+    // query intent. These pin that vector-only chunks now receive the boost.
+    // Default config: VectorWeight=0.7, RrfK=60 -> single vector-only chunk RRF = 0.7/61.
+    // -----------------------------------------------------------------------------------------
+
+    [Fact]
+    public async Task SearchAsync_HybridMode_VectorOnlyChunk_RoleMatchesHint_HybridScoreIncludesBoost()
+    {
+        var vectorStore = new Mock<IVectorStoreAdapter>();
+        vectorStore
+            .Setup(v => v.SearchWithScoresAsync(
+                It.IsAny<Guid>(), It.IsAny<Vector>(), It.IsAny<int>(),
+                It.IsAny<double>(), It.IsAny<IReadOnlyList<Guid>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Scored(BuildEmbedding(chunkIndex: 0, GameBookRole.Tutorial)));
+
+        // Empty keyword arm → the chunk is vector-only.
+        var sut = BuildSut(vectorStore, BuildEmbeddingMock(), BuildEmptyKeywordMock());
+
+        var results = await sut.SearchAsync(
+            "anything", Guid.NewGuid(), SearchMode.Hybrid,
+            queryRoleHint: GameBookRole.Tutorial,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        results.Should().HaveCount(1);
+        results[0].RoleTags.Should().Be(GameBookRole.Tutorial);
+        results[0].HybridScore.Should().BeApproximately((0.7f / 61f) + HybridSearchService.RoleMatchBoost, 0.0001f);
+    }
+
+    [Fact]
+    public async Task SearchAsync_HybridMode_VectorOnlyChunk_RoleDisjoint_NoBoost()
+    {
+        var vectorStore = new Mock<IVectorStoreAdapter>();
+        vectorStore
+            .Setup(v => v.SearchWithScoresAsync(
+                It.IsAny<Guid>(), It.IsAny<Vector>(), It.IsAny<int>(),
+                It.IsAny<double>(), It.IsAny<IReadOnlyList<Guid>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Scored(BuildEmbedding(chunkIndex: 0, GameBookRole.RulesReference)));
+
+        var sut = BuildSut(vectorStore, BuildEmbeddingMock(), BuildEmptyKeywordMock());
+
+        var results = await sut.SearchAsync(
+            "anything", Guid.NewGuid(), SearchMode.Hybrid,
+            queryRoleHint: GameBookRole.Tutorial,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        results.Should().HaveCount(1);
+        // RoleTags still flows through (proves the projection carries it), but a disjoint role
+        // means no boost.
+        results[0].RoleTags.Should().Be(GameBookRole.RulesReference);
+        results[0].HybridScore.Should().BeApproximately(0.7f / 61f, 0.0001f);
+    }
 }


### PR DESCRIPTION
## Slice C — Vector-arm role_tags in hybrid fusion (RAG answer-quality epic)

Part of the RAG answer-quality epic. Follows #3254 (A) and #3258 (B).

### Problem
In `SearchHybridAsync`, the vector-arm results are projected into `SearchResultItem`, which **dropped `RoleTags`**. So a chunk surfacing **only** via the vector arm got no role-match boost even when its role matched the query intent — the keyword arm already carried it. The pgvector query already `SELECT`s `role_tags`, so **no SQL/migration** is needed.

### Fix (3 in-memory edits)
- Add `RoleTags` to `SearchResultItem`; populate it from `Embedding.RoleTags` in the vector projection (same cast as the semantic-only path).
- Union the role tags of whichever arm(s) surfaced the chunk (`vectorRoleTags | keywordRoleTags`) — both denormalize the same `text_chunks.role_tags`, so union preserves the tag for vector-only, keyword-only, and both-arm chunks.
- Fix now-stale comments + XML docs claiming the vector path lacks role_tags.

### ⚠️ Latent until backfill (tracked follow-up)
Observed on **real data**: `pgvector_embeddings.role_tags` is **0** for the whole corpus while `text_chunks.role_tags` **is populated** (RulesReference 9841, Setup 592, …). `IndexChunksInVectorStoreAsync` builds `PgVectorEmbeddingEntity` **without setting `RoleTags`**, so the vector-arm boost (this fix **and** semantic mode) currently has no data to act on. This PR is the required **fusion-side prerequisite**; populating `role_tags` at index time + re-index is a separate follow-up (epic re-index).

### Verification
- **2 new hybrid tests** (RED before fix): vector-only chunk gets the boost when its role matches; `RoleTags` flows through but no boost when disjoint.
- Broader hybrid regression: 71/71 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)