### PR TITLE
fix(frontend): #564 wire self-contained collapse on RecentActivityRail

### DIFF
--- a/apps/web/src/components/features/library/RecentActivityRail.tsx
+++ b/apps/web/src/components/features/library/RecentActivityRail.tsx
@@ -34,7 +34,7 @@
  *   icon/styling can be layered without touching the component contract.
  */
 
-import type { ReactElement } from 'react';
+import { useState, type ReactElement } from 'react';
 
 import clsx from 'clsx';
 
@@ -120,6 +120,7 @@ export function RecentActivityRail({
   className,
 }: RecentActivityRailProps): ReactElement {
   const { t } = useTranslation();
+  const [collapsed, setCollapsed] = useState(false);
   const state: RailState = error
     ? 'error'
     : isLoading
@@ -134,145 +135,171 @@ export function RecentActivityRail({
     <aside
       data-slot="library-activity-rail"
       data-state={state}
+      data-collapsed={collapsed || undefined}
       aria-busy={isLoading || undefined}
       aria-live="polite"
       className={clsx(
         // Mockup jsx:950-954 — sidebar 280px, bg-card, left border, padded scrollable.
         // Hidden under `lg` so the rail collapses on tablet/mobile (preserves
-        // pre-Task-2.4 responsive contract).
-        'hidden lg:flex lg:w-[280px] lg:flex-shrink-0 lg:flex-col',
-        'overflow-y-auto border-l border-border bg-card px-4 py-4',
+        // pre-Task-2.4 responsive contract). When collapsed (#564) the aside
+        // narrows to a rail strip; being a flex sibling of the library content
+        // means the grid reclaims the freed width — no parent coordination.
+        'hidden lg:flex lg:flex-shrink-0 lg:flex-col',
+        collapsed ? 'lg:w-[52px] lg:items-center px-2' : 'lg:w-[280px] px-4',
+        'overflow-y-auto border-l border-border bg-card py-4',
         className
       )}
     >
-      {/* Header (jsx:955-969) */}
-      <div className="mb-3.5 flex items-center justify-between">
-        <h3 className="m-0 flex items-center gap-1.5 font-display text-[13px] font-extrabold text-foreground">
-          <span aria-hidden="true">🕐</span>
-          {t('pages.library.activityRail.title')}
-        </h3>
-        {/* Collapse button: static (no onClick) until follow-up wires it.
-            TODO: collapse not yet wired (#follow-up TBD). */}
+      {/* Header (jsx:955-969) — collapse/expand disclosure toggle (#564). */}
+      <div
+        className={clsx(
+          'flex items-center',
+          collapsed ? 'flex-col gap-2' : 'mb-3.5 justify-between'
+        )}
+      >
+        {collapsed ? (
+          <span aria-hidden="true" className="text-[13px]">
+            🕐
+          </span>
+        ) : (
+          <h3 className="m-0 flex items-center gap-1.5 font-display text-[13px] font-extrabold text-foreground">
+            <span aria-hidden="true">🕐</span>
+            {t('pages.library.activityRail.title')}
+          </h3>
+        )}
         <button
           type="button"
-          aria-label={t('pages.library.activityRail.collapseAriaLabel')}
+          aria-label={t(
+            collapsed
+              ? 'pages.library.activityRail.expandAriaLabel'
+              : 'pages.library.activityRail.collapseAriaLabel'
+          )}
+          aria-expanded={!collapsed}
+          onClick={() => setCollapsed(prev => !prev)}
           className="h-6 w-6 cursor-pointer rounded-sm border border-border bg-transparent text-[11px] text-muted-foreground"
         >
-          <span aria-hidden="true">›</span>
+          <span aria-hidden="true">{collapsed ? '‹' : '›'}</span>
         </button>
       </div>
 
-      {state === 'loading' ? (
-        <div className="flex flex-col gap-2">
-          {Array.from({ length: SKELETON_LINES }, (_, index) => (
-            <Skeleton
-              key={index}
-              data-slot="library-activity-skeleton"
-              data-testid="library-activity-skeleton"
-              className="h-12 w-full rounded-lg"
-            />
-          ))}
-        </div>
-      ) : null}
+      {collapsed ? null : (
+        <>
+          {state === 'loading' ? (
+            <div className="flex flex-col gap-2">
+              {Array.from({ length: SKELETON_LINES }, (_, index) => (
+                <Skeleton
+                  key={index}
+                  data-slot="library-activity-skeleton"
+                  data-testid="library-activity-skeleton"
+                  className="h-12 w-full rounded-lg"
+                />
+              ))}
+            </div>
+          ) : null}
 
-      {state === 'empty' ? (
-        <p
-          className="text-sm text-muted-foreground"
-          data-slot="library-activity-empty"
-          data-testid="library-activity-empty-text"
-        >
-          {t('pages.library.activityRail.empty')}
-        </p>
-      ) : null}
+          {state === 'empty' ? (
+            <p
+              className="text-sm text-muted-foreground"
+              data-slot="library-activity-empty"
+              data-testid="library-activity-empty-text"
+            >
+              {t('pages.library.activityRail.empty')}
+            </p>
+          ) : null}
 
-      {state === 'error' ? (
-        <p
-          className="text-sm text-destructive"
-          role="alert"
-          data-slot="library-activity-error"
-          data-testid="library-activity-error"
-        >
-          {t('pages.library.activityRail.error')}
-        </p>
-      ) : null}
+          {state === 'error' ? (
+            <p
+              className="text-sm text-destructive"
+              role="alert"
+              data-slot="library-activity-error"
+              data-testid="library-activity-error"
+            >
+              {t('pages.library.activityRail.error')}
+            </p>
+          ) : null}
 
-      {state === 'populated' ? (
-        <div className="relative">
-          {visibleItems.map((item, index) => {
-            const entity = ACTIVITY_KIND_ENTITY[item.kind];
-            const isLast = index === visibleItems.length - 1;
-            return (
-              <div
-                key={item.id}
-                data-slot="library-activity-item"
-                data-activity-kind={item.kind}
-                className={clsx('flex gap-2.5', !isLast && 'mb-2.5')}
-              >
-                {/* Left rail: circle + connector */}
-                <div className="flex flex-shrink-0 flex-col items-center">
+          {state === 'populated' ? (
+            <div className="relative">
+              {visibleItems.map((item, index) => {
+                const entity = ACTIVITY_KIND_ENTITY[item.kind];
+                const isLast = index === visibleItems.length - 1;
+                return (
                   <div
-                    data-slot="library-activity-rail-circle"
-                    aria-hidden="true"
-                    className={clsx(
-                      'flex h-[22px] w-[22px] items-center justify-center rounded-full border text-[10px]',
-                      ENTITY_CIRCLE_CLASS[entity]
-                    )}
+                    key={item.id}
+                    data-slot="library-activity-item"
+                    data-activity-kind={item.kind}
+                    className={clsx('flex gap-2.5', !isLast && 'mb-2.5')}
                   >
-                    {KIND_ICON[item.kind]}
+                    {/* Left rail: circle + connector */}
+                    <div className="flex flex-shrink-0 flex-col items-center">
+                      <div
+                        data-slot="library-activity-rail-circle"
+                        aria-hidden="true"
+                        className={clsx(
+                          'flex h-[22px] w-[22px] items-center justify-center rounded-full border text-[10px]',
+                          ENTITY_CIRCLE_CLASS[entity]
+                        )}
+                      >
+                        {KIND_ICON[item.kind]}
+                      </div>
+                      {!isLast ? (
+                        <div
+                          data-slot="library-activity-rail-connector"
+                          aria-hidden="true"
+                          className="mt-0.5 min-h-3.5 w-[1.5px] flex-1 bg-border"
+                        />
+                      ) : null}
+                    </div>
+                    {/* Right column: timestamp + body line */}
+                    <div className="min-w-0 flex-1 pb-0.5">
+                      <div className="font-mono text-[9px] font-bold uppercase tracking-[0.06em] text-muted-foreground">
+                        {item.timestamp}
+                      </div>
+                      <div className="text-[11.5px] leading-[1.4] text-foreground">
+                        <span
+                          className={clsx('font-bold no-underline', ENTITY_ANCHOR_CLASS[entity])}
+                        >
+                          {item.entityTitle}
+                        </span>
+                      </div>
+                    </div>
                   </div>
-                  {!isLast ? (
-                    <div
-                      data-slot="library-activity-rail-connector"
-                      aria-hidden="true"
-                      className="mt-0.5 min-h-3.5 w-[1.5px] flex-1 bg-border"
-                    />
-                  ) : null}
-                </div>
-                {/* Right column: timestamp + body line */}
-                <div className="min-w-0 flex-1 pb-0.5">
-                  <div className="font-mono text-[9px] font-bold uppercase tracking-[0.06em] text-muted-foreground">
-                    {item.timestamp}
-                  </div>
-                  <div className="text-[11.5px] leading-[1.4] text-foreground">
-                    <span className={clsx('font-bold no-underline', ENTITY_ANCHOR_CLASS[entity])}>
-                      {item.entityTitle}
-                    </span>
-                  </div>
-                </div>
-              </div>
-            );
-          })}
-        </div>
-      ) : null}
+                );
+              })}
+            </div>
+          ) : null}
 
-      {/* Keyboard shortcuts box (jsx:1004-1015). Always rendered so the rail
-          has a consistent footer across loading/empty/populated states. */}
-      <div className="mt-3 rounded-md bg-muted px-3 py-2.5 text-[11px] leading-relaxed text-muted-foreground">
-        <strong className="mb-0.5 block text-foreground/80">
-          <span aria-hidden="true">⌨ </span>
-          {t('pages.library.activityRail.shortcuts.heading')}
-        </strong>
-        <div className="flex flex-col gap-0.5 font-mono text-[10px]">
-          <span>
-            <kbd className="mr-1 rounded-[3px] border border-border bg-card px-1.5 font-mono font-extrabold text-foreground/80">
-              /
-            </kbd>
-            {t('pages.library.activityRail.shortcuts.focusSearch')}
-          </span>
-          <span>
-            <kbd className="mr-1 rounded-[3px] border border-border bg-card px-1.5 font-mono font-extrabold text-foreground/80">
-              f
-            </kbd>
-            {t('pages.library.activityRail.shortcuts.advancedFilters')}
-          </span>
-          <span>
-            <kbd className="mr-1 rounded-[3px] border border-border bg-card px-1.5 font-mono font-extrabold text-foreground/80">
-              ?
-            </kbd>
-            {t('pages.library.activityRail.shortcuts.allShortcuts')}
-          </span>
-        </div>
-      </div>
+          {/* Keyboard shortcuts box (jsx:1004-1015). Rendered in every
+          expanded state (loading/empty/populated) for a consistent footer;
+          hidden when the rail is collapsed (#564). */}
+          <div className="mt-3 rounded-md bg-muted px-3 py-2.5 text-[11px] leading-relaxed text-muted-foreground">
+            <strong className="mb-0.5 block text-foreground/80">
+              <span aria-hidden="true">⌨ </span>
+              {t('pages.library.activityRail.shortcuts.heading')}
+            </strong>
+            <div className="flex flex-col gap-0.5 font-mono text-[10px]">
+              <span>
+                <kbd className="mr-1 rounded-[3px] border border-border bg-card px-1.5 font-mono font-extrabold text-foreground/80">
+                  /
+                </kbd>
+                {t('pages.library.activityRail.shortcuts.focusSearch')}
+              </span>
+              <span>
+                <kbd className="mr-1 rounded-[3px] border border-border bg-card px-1.5 font-mono font-extrabold text-foreground/80">
+                  f
+                </kbd>
+                {t('pages.library.activityRail.shortcuts.advancedFilters')}
+              </span>
+              <span>
+                <kbd className="mr-1 rounded-[3px] border border-border bg-card px-1.5 font-mono font-extrabold text-foreground/80">
+                  ?
+                </kbd>
+                {t('pages.library.activityRail.shortcuts.allShortcuts')}
+              </span>
+            </div>
+          </div>
+        </>
+      )}
     </aside>
   );
 }

--- a/apps/web/src/components/features/library/__tests__/RecentActivityRail.test.tsx
+++ b/apps/web/src/components/features/library/__tests__/RecentActivityRail.test.tsx
@@ -15,7 +15,7 @@
  */
 
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { IntlProvider } from 'react-intl';
 import { describe, expect, it } from 'vitest';
 
@@ -27,6 +27,7 @@ const messages: Record<string, string> = {
   'pages.library.activityRail.empty': 'Nessuna attività recente.',
   'pages.library.activityRail.error': "Impossibile caricare l'attività.",
   'pages.library.activityRail.collapseAriaLabel': 'Comprimi pannello',
+  'pages.library.activityRail.expandAriaLabel': 'Espandi pannello',
   'pages.library.activityRail.shortcuts.heading': 'Shortcuts',
   'pages.library.activityRail.shortcuts.focusSearch': 'focus search',
   'pages.library.activityRail.shortcuts.advancedFilters': 'filtri avanzati',
@@ -194,6 +195,42 @@ describe('RecentActivityRail (Wave B.3)', () => {
         screen.getByRole('heading', { level: 3, name: /Ultime modifiche/i })
       ).toBeInTheDocument();
       expect(screen.getByRole('button', { name: /Comprimi pannello/i })).toBeInTheDocument();
+    });
+  });
+
+  describe('Collapse toggle (#564)', () => {
+    it('exposes the toggle as an expanded disclosure by default', () => {
+      renderRail();
+      const toggle = screen.getByRole('button', { name: /Comprimi pannello/i });
+      expect(toggle).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    it('collapses the rail and swaps the toggle to an expand affordance on click', () => {
+      renderRail();
+      // Expanded by default: the always-rendered shortcuts box is visible.
+      expect(screen.getByText(/Shortcuts/i)).toBeInTheDocument();
+
+      fireEvent.click(screen.getByRole('button', { name: /Comprimi pannello/i }));
+
+      // Collapsed: body content (shortcuts box + empty copy) is gone, and the
+      // toggle is now a working expand button reflecting the collapsed state.
+      expect(screen.queryByText(/Shortcuts/i)).not.toBeInTheDocument();
+      expect(screen.queryByTestId('library-activity-empty-text')).not.toBeInTheDocument();
+      const expandToggle = screen.getByRole('button', { name: /Espandi pannello/i });
+      expect(expandToggle).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it('re-expands the rail when the expand button is clicked', () => {
+      renderRail();
+      fireEvent.click(screen.getByRole('button', { name: /Comprimi pannello/i }));
+      fireEvent.click(screen.getByRole('button', { name: /Espandi pannello/i }));
+
+      // Back to the expanded layout: body content and collapse affordance return.
+      expect(screen.getByText(/Shortcuts/i)).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /Comprimi pannello/i })).toHaveAttribute(
+        'aria-expanded',
+        'true'
+      );
     });
   });
 });

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -1973,6 +1973,7 @@
         "viewAll": "View all",
         "viewAllAriaLabel": "Open the full activity history",
         "collapseAriaLabel": "Collapse panel",
+        "expandAriaLabel": "Expand panel",
         "error": "Failed to load activity.",
         "fallback": {
           "agent": "New agent created",

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -1980,6 +1980,7 @@
         "viewAll": "Vedi tutto",
         "viewAllAriaLabel": "Vai allo storico completo dell'attività",
         "collapseAriaLabel": "Comprimi pannello",
+        "expandAriaLabel": "Espandi pannello",
         "error": "Impossibile caricare l'attività.",
         "fallback": {
           "agent": "Nuovo agent creato",


### PR DESCRIPTION
## Contesto

2° residuo actionable del triage Q3 di **#564** (commento 2026-07-20): il collapse button morto in `RecentActivityRail` (`/library` desktop).

## Il difetto (a11y)

L'header del rail renderizzava un `<button aria-label="Comprimi pannello">` **senza `onClick`** — un'affordance a11y morta (**WCAG 4.1.2 Name/Role/Value**): uno screen reader annunciava un controllo "comprimi pannello" che, se attivato, non faceva nulla. Il mockup sorgente (`sp4-library-desktop.jsx`) è stato rimosso in DS-17 e il collapse non aveva follow-up tracciato.

## Fix — collapse self-contained

Wire come disclosure self-contained (scelta confermata dall'owner vs rimozione del bottone):
- `useState(collapsed)` locale; l'`<aside>` alterna tra `lg:w-[280px]` e una strip `lg:w-[52px]`.
- Il rail è **flex sibling** del contenuto library `flex-1` (`LibraryHub` row `lg:flex-row`, verificato), quindi restringendolo il grid **riprende lo spazio senza coordinamento del parent**.
- Il bottone ottiene `aria-expanded` e alterna label/glifo (comprimi `›` / espandi `‹`) + nuova chiave i18n `expandAriaLabel` (parità it/en).
- Quando collassato, il corpo (loading/empty/error/populated + shortcuts box) è nascosto; resta la strip con icona 🕐 + bottone espandi.

## Test (TDD)

- **RED**: 3 nuovi test (`Collapse toggle (#564)`) — fallivano perché il bottone non aveva `aria-expanded` né `onClick`.
- **GREEN**: **19/19** in `RecentActivityRail.test.tsx` (16 preesistenti + 3 nuovi). Suite library completa: **396 passed, 0 regressioni** (31 file). `pnpm typecheck` pulito, lint 0 errori, parità i18n it/en verificata.

Chiude il 2° dei 3 residui di #564. Rimane solo `sidebar-filters.tsx:32` (refactor token, genuinamente gated finché `meeple-card/tokens` non copre `player`/`event` senza rompere il contrasto AA di #636).

🤖 Generated with [Claude Code](https://claude.com/claude-code)