### PR TITLE
fix(rag): fuse hybrid RRF arms on shared PdfDocumentId key

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Entities/Embedding.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Entities/Embedding.cs
@@ -30,6 +30,14 @@ internal sealed class Embedding : Entity<Guid>
     public int RoleTags { get; private set; }
 
     /// <summary>
+    /// The owning PDF document id (via <c>vector_documents.PdfDocumentId</c>). Resolved by the
+    /// scored pgvector search so hybrid fusion can key vector results on the SAME
+    /// <c>{PdfDocumentId}_{ChunkIndex}</c> identity the keyword arm uses. <see cref="Guid.Empty"/>
+    /// on paths that don't need it (only the hybrid-search read populates it).
+    /// </summary>
+    public Guid PdfDocumentId { get; private set; }
+
+    /// <summary>
     /// Private constructor for EF Core.
     /// </summary>
 #pragma warning disable CS8618
@@ -52,7 +60,8 @@ internal sealed class Embedding : Entity<Guid>
         string language = "en",
         Guid? sourceChunkId = null,
         bool isTranslation = false,
-        int roleTags = 0) : base(id)
+        int roleTags = 0,
+        Guid pdfDocumentId = default) : base(id)
     {
         if (string.IsNullOrWhiteSpace(textContent))
             throw new ArgumentException("Text content cannot be empty", nameof(textContent));
@@ -77,6 +86,7 @@ internal sealed class Embedding : Entity<Guid>
         SourceChunkId = sourceChunkId;
         IsTranslation = isTranslation;
         RoleTags = roleTags;
+        PdfDocumentId = pdfDocumentId;
     }
 
     /// <summary>

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/Persistence/PgVectorStoreAdapter.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/Persistence/PgVectorStoreAdapter.cs
@@ -135,23 +135,27 @@ internal sealed class PgVectorStoreAdapter : IVectorStoreAdapter
         var connection = _context.Database.GetDbConnection();
         await EnsureConnectionOpenAsync(connection, cancellationToken).ConfigureAwait(false);
 
-        // Identical SQL to SearchAsync — similarity column is at index 7 and is now surfaced.
+        // RRF fusion-key fix: JOIN vector_documents to resolve the owning PdfDocumentId so hybrid
+        // fusion can key vector results on {PdfDocumentId}_{ChunkIndex} (matching the keyword arm).
+        // PdfDocumentId is column 7, similarity column 8.
         var sql = $"""
-            SELECT id, vector_document_id, text_content, model, chunk_index, page_number, role_tags,
-                   1 - (vector <=> @queryVector) AS similarity
-            FROM {TableName}
-            WHERE game_id = @gameId
-              AND 1 - (vector <=> @queryVector) >= @minScore
+            SELECT e.id, e.vector_document_id, e.text_content, e.model, e.chunk_index, e.page_number, e.role_tags,
+                   vd."PdfDocumentId",
+                   1 - (e.vector <=> @queryVector) AS similarity
+            FROM {TableName} e
+            JOIN vector_documents vd ON vd."Id" = e.vector_document_id
+            WHERE e.game_id = @gameId
+              AND 1 - (e.vector <=> @queryVector) >= @minScore
             """;
 
         if (documentIds is { Count: > 0 })
         {
-            sql += "\n  AND vector_document_id = ANY(@documentIds)";
+            sql += "\n  AND e.vector_document_id = ANY(@documentIds)";
         }
 
         sql += $"""
 
-            ORDER BY vector <=> @queryVector
+            ORDER BY e.vector <=> @queryVector
             LIMIT @topK
             """;
 
@@ -185,8 +189,9 @@ internal sealed class PgVectorStoreAdapter : IVectorStoreAdapter
                     var chunkIndex = reader.GetInt32(4);
                     var pageNumber = reader.GetInt32(5);
                     var roleTags = reader.GetInt32(6);
-                    // Column 7: similarity = 1 - (vector <=> @queryVector)
-                    var score = reader.GetDouble(7);
+                    var pdfDocumentId = reader.GetGuid(7);
+                    // Column 8: similarity = 1 - (vector <=> @queryVector)
+                    var score = reader.GetDouble(8);
 
                     var placeholderVector = DomainVector.CreatePlaceholder(queryVector.Dimensions);
                     var embedding = new Embedding(
@@ -197,7 +202,8 @@ internal sealed class PgVectorStoreAdapter : IVectorStoreAdapter
                         model: model,
                         chunkIndex: chunkIndex,
                         pageNumber: Math.Max(1, pageNumber),
-                        roleTags: roleTags);
+                        roleTags: roleTags,
+                        pdfDocumentId: pdfDocumentId);
 
                     results.Add(new ScoredEmbedding(embedding, score));
                 }

--- a/apps/api/src/Api/Services/HybridSearchService.cs
+++ b/apps/api/src/Api/Services/HybridSearchService.cs
@@ -281,7 +281,11 @@ internal class HybridSearchService : IHybridSearchService
         {
             Score = (float)se.Score,
             Text = se.Embedding.TextContent,
-            PdfId = se.Embedding.VectorDocumentId.ToString(),
+            // RRF fusion-key fix: key on the owning PdfDocumentId (resolved by the scored pgvector
+            // search) so a chunk found by BOTH arms fuses on the same {PdfDocumentId}_{ChunkIndex}
+            // identity the keyword arm uses. (Was VectorDocumentId, which also wrongly surfaced as
+            // HybridSearchResult.PdfDocumentId for vector-only citations.)
+            PdfId = se.Embedding.PdfDocumentId.ToString(),
             ChunkIndex = se.Embedding.ChunkIndex,
             Page = se.Embedding.PageNumber,
             // Slice C: carry role_tags through so vector-only chunks get the role-match boost in
@@ -403,8 +407,11 @@ internal class HybridSearchService : IHybridSearchService
             })
             .ToDictionary(x => x.ChunkId, StringComparer.Ordinal);
 
+        // RRF fusion-key fix: key the keyword arm on the SAME {PdfDocumentId}_{ChunkIndex} composite
+        // as the vector arm (was the raw text_chunks.Id, which never matched the vector key — so a
+        // doubly-retrieved chunk was emitted as two half-strength duplicates instead of being fused).
         var keywordLookup = keywordResults
-            .Select((r, index) => new { ChunkId = r.ChunkId, Result = r, Rank = index + 1 })
+            .Select((r, index) => new { ChunkId = $"{r.PdfDocumentId}_{r.ChunkIndex}", Result = r, Rank = index + 1 })
             .ToDictionary(x => x.ChunkId, StringComparer.Ordinal);
 
         // Collect all unique chunk IDs from both result sets

--- a/apps/api/src/Api/Services/HybridSearchService.cs
+++ b/apps/api/src/Api/Services/HybridSearchService.cs
@@ -134,9 +134,12 @@ internal class HybridSearchService : IHybridSearchService
             var roleBoost = ComputeRoleMatchBoost(queryRoleHint, chunkRoleTags);
             return new HybridSearchResult
             {
-                ChunkId = $"{embedding.VectorDocumentId}_{embedding.ChunkIndex}",
+                // RRF fusion-key fix: key on the resolved PdfDocumentId (now populated by the scored
+                // pgvector search) so Semantic-mode results share the Hybrid/keyword identity and
+                // surface the real pdf id in citations + the global-KB-search enrichment join.
+                ChunkId = $"{embedding.PdfDocumentId}_{embedding.ChunkIndex}",
                 Content = embedding.TextContent,
-                PdfDocumentId = embedding.VectorDocumentId.ToString(),
+                PdfDocumentId = embedding.PdfDocumentId.ToString(),
                 GameId = gameId,
                 ChunkIndex = embedding.ChunkIndex,
                 PageNumber = embedding.PageNumber,
@@ -410,9 +413,13 @@ internal class HybridSearchService : IHybridSearchService
         // RRF fusion-key fix: key the keyword arm on the SAME {PdfDocumentId}_{ChunkIndex} composite
         // as the vector arm (was the raw text_chunks.Id, which never matched the vector key — so a
         // doubly-retrieved chunk was emitted as two half-strength duplicates instead of being fused).
+        // The composite is backed by a NON-unique index, so GroupBy (keep the best-ranked row —
+        // keyword results are relevance-DESC, so the first) instead of ToDictionary, which would
+        // throw on an abnormal duplicate (PdfDocumentId, ChunkIndex) and 500 the whole search.
         var keywordLookup = keywordResults
             .Select((r, index) => new { ChunkId = $"{r.PdfDocumentId}_{r.ChunkIndex}", Result = r, Rank = index + 1 })
-            .ToDictionary(x => x.ChunkId, StringComparer.Ordinal);
+            .GroupBy(x => x.ChunkId, StringComparer.Ordinal)
+            .ToDictionary(g => g.Key, g => g.First(), StringComparer.Ordinal);
 
         // Collect all unique chunk IDs from both result sets
         var allChunkIds = vectorLookup.Keys
@@ -445,14 +452,14 @@ internal class HybridSearchService : IHybridSearchService
                 keywordRrfScore = keywordItem != null ? keywordWeight / (rrfK + keywordItem.Rank) : 0f;
             }
 
-            // Phase D (D6) + Slice C: role-match boost. Take the role tags from whichever arm
-            // surfaced the chunk (both denormalize the same text_chunks.role_tags — keyword from
-            // text_chunks, vector from pgvector_embeddings.role_tags). The union is defensive: with
-            // the current fusion keying the two arms never share a key (vector = "{VectorDocumentId}
-            // _{ChunkIndex}", keyword = raw text_chunks.Id), so each entry is single-arm and the OR
-            // reduces to the present arm — a genuine both-arm merge awaits the fusion-key alignment
-            // follow-up. When the chunk overlaps the user's classified intent, apply an additive
-            // boost on top of the fused RRF.
+            // Phase D (D6) + Slice C + RRF fusion-key fix: role-match boost. Both arms now key on
+            // {PdfDocumentId}_{ChunkIndex}, so a chunk retrieved by BOTH arms is a single fused entry
+            // and chunkRoleTags is a genuine cross-arm union. Both denormalize the same
+            // text_chunks.role_tags (keyword from text_chunks, vector from pgvector_embeddings.role_tags);
+            // for a single-arm chunk the OR selects the present arm, and for a both-arm chunk it takes
+            // whichever is populated (pgvector role_tags is currently un-backfilled → keyword wins).
+            // When the chunk overlaps the user's classified intent, apply an additive boost on top of
+            // the fused RRF.
             var vectorRoleTags = hasVector && vectorItem != null
                 ? vectorItem.Result.RoleTags
                 : GameBookRole.None;

--- a/apps/api/tests/Api.Tests/Services/HybridSearchServiceRoleBoostTests.cs
+++ b/apps/api/tests/Api.Tests/Services/HybridSearchServiceRoleBoostTests.cs
@@ -253,7 +253,7 @@ public sealed class HybridSearchServiceRoleBoostTests
     private static List<ScoredEmbedding> Scored(params Embedding[] embeddings)
         => embeddings.Select((e, i) => new ScoredEmbedding(e, 0.9 - i * 0.1)).ToList();
 
-    private static Embedding BuildEmbedding(int chunkIndex, GameBookRole roleTags)
+    private static Embedding BuildEmbedding(int chunkIndex, GameBookRole roleTags, Guid? pdfDocumentId = null)
     {
         var vector = Vector.CreatePlaceholder(8);
         return new Embedding(
@@ -264,7 +264,10 @@ public sealed class HybridSearchServiceRoleBoostTests
             model: "test-model",
             chunkIndex: chunkIndex,
             pageNumber: 1,
-            roleTags: (int)roleTags);
+            roleTags: (int)roleTags,
+            // Default a UNIQUE pdf per embedding so fusion keys don't collide across chunks; the
+            // fusion test passes an explicit shared id to make a chunk appear in both arms.
+            pdfDocumentId: pdfDocumentId ?? Guid.NewGuid());
     }
 
     private static Mock<IEmbeddingService> BuildEmbeddingMock()
@@ -493,5 +496,64 @@ public sealed class HybridSearchServiceRoleBoostTests
         // means no boost.
         results[0].RoleTags.Should().Be(GameBookRole.RulesReference);
         results[0].HybridScore.Should().BeApproximately(0.7f / 61f, 0.0001f);
+    }
+
+    // -----------------------------------------------------------------------------------------
+    // RRF fusion-key fix: a chunk retrieved by BOTH arms must fuse into ONE result whose RRF
+    // score SUMS the vector + keyword contributions (the point of Reciprocal Rank Fusion). This
+    // requires both arms to key on the same identity {PdfDocumentId}_{ChunkIndex}. Previously the
+    // vector arm keyed on {VectorDocumentId}_{ChunkIndex} and the keyword arm on the raw
+    // text_chunks.Id, so the keys never matched and the chunk was emitted as two half-strength
+    // duplicates.
+    // -----------------------------------------------------------------------------------------
+
+    [Fact]
+    public async Task SearchAsync_HybridMode_ChunkInBothArms_FusesToSingleResult_WithSummedRrf()
+    {
+        var pdfId = Guid.NewGuid();
+        const int chunkIndex = 5;
+
+        var vectorStore = new Mock<IVectorStoreAdapter>();
+        vectorStore
+            .Setup(v => v.SearchWithScoresAsync(
+                It.IsAny<Guid>(), It.IsAny<Vector>(), It.IsAny<int>(),
+                It.IsAny<double>(), It.IsAny<IReadOnlyList<Guid>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Scored(BuildEmbedding(chunkIndex, GameBookRole.None, pdfDocumentId: pdfId)));
+
+        // Keyword arm returns the SAME chunk (same PdfDocumentId + ChunkIndex).
+        var keywordMock = new Mock<IKeywordSearchService>();
+        keywordMock
+            .Setup(k => k.SearchAsync(
+                It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<int>(), It.IsAny<bool>(),
+                It.IsAny<List<string>?>(), It.IsAny<string>(), It.IsAny<double>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<KeywordSearchResult>
+            {
+                new()
+                {
+                    ChunkId = Guid.NewGuid().ToString(),
+                    Content = $"chunk-{chunkIndex}",
+                    PdfDocumentId = pdfId.ToString(),
+                    GameId = Guid.NewGuid(),
+                    ChunkIndex = chunkIndex,
+                    RelevanceScore = 0.9f,
+                    RoleTags = GameBookRole.None,
+                },
+            });
+
+        var sut = BuildSut(vectorStore, BuildEmbeddingMock(), keywordMock);
+
+        var results = await sut.SearchAsync(
+            "anything", Guid.NewGuid(), SearchMode.Hybrid,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        // Fused into ONE result (not two half-strength duplicates).
+        results.Should().HaveCount(1);
+        results[0].VectorScore.Should().NotBeNull();
+        results[0].KeywordScore.Should().NotBeNull();
+        results[0].VectorRank.Should().Be(1);
+        results[0].KeywordRank.Should().Be(1);
+        // HybridScore = vectorRrf + keywordRrf = (0.7 + 0.3)/(60+1) = 1/61.
+        results[0].HybridScore.Should().BeApproximately(1f / 61f, 0.0001f);
     }
 }

--- a/apps/api/tests/Api.Tests/Services/HybridSearchServiceRoleBoostTests.cs
+++ b/apps/api/tests/Api.Tests/Services/HybridSearchServiceRoleBoostTests.cs
@@ -556,4 +556,64 @@ public sealed class HybridSearchServiceRoleBoostTests
         // HybridScore = vectorRrf + keywordRrf = (0.7 + 0.3)/(60+1) = 1/61.
         results[0].HybridScore.Should().BeApproximately(1f / 61f, 0.0001f);
     }
+
+    [Fact]
+    public async Task SearchAsync_SemanticMode_UsesPdfDocumentId_NotVectorDocumentId()
+    {
+        // Review follow-up: the Semantic path must surface the real PdfDocumentId (now resolved by
+        // the scored pgvector search), not VectorDocumentId — otherwise Semantic-mode citations and
+        // the global-KB-search enrichment join (which matches on pdf_documents.Id) break.
+        var pdfId = Guid.NewGuid();
+        var vectorStore = new Mock<IVectorStoreAdapter>();
+        vectorStore
+            .Setup(v => v.SearchWithScoresAsync(
+                It.IsAny<Guid>(), It.IsAny<Vector>(), It.IsAny<int>(),
+                It.IsAny<double>(), It.IsAny<IReadOnlyList<Guid>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Scored(BuildEmbedding(chunkIndex: 3, GameBookRole.None, pdfDocumentId: pdfId)));
+
+        var sut = BuildSut(vectorStore, BuildEmbeddingMock());
+
+        var results = await sut.SearchAsync(
+            "anything", Guid.NewGuid(), SearchMode.Semantic,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        results.Should().HaveCount(1);
+        results[0].PdfDocumentId.Should().Be(pdfId.ToString());
+    }
+
+    [Fact]
+    public async Task SearchAsync_HybridMode_KeywordDuplicateChunkKeys_DoesNotThrow_AndDedupes()
+    {
+        // Review follow-up: the keyword fusion key is now the composite {PdfDocumentId}_{ChunkIndex}
+        // over a NON-unique index. Two keyword rows sharing that key must NOT crash the fusion
+        // (ToDictionary would throw) — degrade gracefully to a single entry.
+        var pdfId = Guid.NewGuid();
+        var vectorStore = new Mock<IVectorStoreAdapter>();
+        vectorStore
+            .Setup(v => v.SearchWithScoresAsync(
+                It.IsAny<Guid>(), It.IsAny<Vector>(), It.IsAny<int>(),
+                It.IsAny<double>(), It.IsAny<IReadOnlyList<Guid>?>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<ScoredEmbedding>());
+
+        var keywordMock = new Mock<IKeywordSearchService>();
+        keywordMock
+            .Setup(k => k.SearchAsync(
+                It.IsAny<string>(), It.IsAny<Guid>(), It.IsAny<int>(), It.IsAny<bool>(),
+                It.IsAny<List<string>?>(), It.IsAny<string>(), It.IsAny<double>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<KeywordSearchResult>
+            {
+                new() { ChunkId = Guid.NewGuid().ToString(), Content = "a", PdfDocumentId = pdfId.ToString(), GameId = Guid.NewGuid(), ChunkIndex = 7, RelevanceScore = 0.9f, RoleTags = GameBookRole.None },
+                new() { ChunkId = Guid.NewGuid().ToString(), Content = "b", PdfDocumentId = pdfId.ToString(), GameId = Guid.NewGuid(), ChunkIndex = 7, RelevanceScore = 0.8f, RoleTags = GameBookRole.None },
+            });
+
+        var sut = BuildSut(vectorStore, BuildEmbeddingMock(), keywordMock);
+
+        var act = async () => await sut.SearchAsync(
+            "anything", Guid.NewGuid(), SearchMode.Hybrid,
+            cancellationToken: TestContext.Current.CancellationToken);
+
+        var results = await act.Should().NotThrowAsync();
+        results.Which.Should().HaveCount(1);
+    }
 }


### PR DESCRIPTION
## RRF fusion-key fix (RAG answer-quality epic)

Discovered during Slice C review; user-prioritized. Follows #3254 (A), #3258 (B), #3260 (C).

### Problem
`HybridSearchService.FuseSearchResults` keyed the two arms **incompatibly**:
- vector: `{VectorDocumentId}_{ChunkIndex}`
- keyword: raw `text_chunks.Id`

The keys **never intersect**, so a chunk retrieved by **both** arms was emitted as **two half-strength duplicates** instead of being fused — defeating the core of Reciprocal Rank Fusion exactly on the most relevant chunks (those that rank high in both vector and keyword search).

### Fix — key both arms on `{PdfDocumentId}_{ChunkIndex}`
- Resolve the owning `PdfDocumentId` in the scored pgvector search (`SearchWithScoresAsync` joins `vector_documents`) and carry it on `Embedding` (optional ctor param; other construction sites default to `Empty`).
- Vector projection keys on `PdfDocumentId` — also fixes a latent bug where vector-only results surfaced `VectorDocumentId` as `HybridSearchResult.PdfDocumentId` in citations.
- Keyword arm keys on `{PdfDocumentId}_{ChunkIndex}` instead of `text_chunks.Id`.

### Verification (real data)
- The join resolves `PdfDocumentId` for **11036/11036** embeddings.
- `{PdfDocumentId, ChunkIndex}` aligns **1:1** across `pgvector_embeddings` and `text_chunks` for the whole corpus → the fix **activates immediately on existing data (no re-index needed)**.
- New fusion test: a both-arm chunk fuses into **one** result with **summed** vector+keyword RRF (`VectorRank`+`KeywordRank` both set). 94 hybrid/pgvector/embedding tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)