### PR TITLE
fix(rag): reject unroutable agent model ids + fix seeded Rules Expert

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Validators/AgentDefinition/CreateAgentDefinitionCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Validators/AgentDefinition/CreateAgentDefinitionCommandValidator.cs
@@ -1,6 +1,7 @@
 using Api.BoundedContexts.KnowledgeBase.Application.Commands.AgentDefinition;
 using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
 using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
+using Api.Services.LlmClients;
 using FluentValidation;
 
 namespace Api.BoundedContexts.KnowledgeBase.Application.Validators.AgentDefinition;
@@ -40,7 +41,9 @@ internal sealed class CreateAgentDefinitionCommandValidator : AbstractValidator<
 
         RuleFor(x => x.Model)
             .NotEmpty().WithMessage("Model is required")
-            .MaximumLength(200).WithMessage("Model must not exceed 200 characters");
+            .MaximumLength(200).WithMessage("Model must not exceed 200 characters")
+            .Must(m => !LlmModelRouting.IsUnroutableBareCloudId(m))
+            .WithMessage("Model is not routable: a bare cloud-provider id (e.g. 'claude-haiku-4-5-...') routes to no LLM client. Use a 'provider/model' OpenRouter slug (e.g. 'anthropic/claude-3.5-haiku'), a 'deepseek-*' id, or a local Ollama model.");
 
         RuleFor(x => x.MaxTokens)
             .InclusiveBetween(100, 32000).WithMessage("MaxTokens must be between 100 and 32000");

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Validators/AgentDefinition/UpdateAgentDefinitionCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Validators/AgentDefinition/UpdateAgentDefinitionCommandValidator.cs
@@ -1,6 +1,7 @@
 using Api.BoundedContexts.KnowledgeBase.Application.Commands.AgentDefinition;
 using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
 using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
+using Api.Services.LlmClients;
 using FluentValidation;
 
 namespace Api.BoundedContexts.KnowledgeBase.Application.Validators.AgentDefinition;
@@ -43,7 +44,9 @@ internal sealed class UpdateAgentDefinitionCommandValidator : AbstractValidator<
 
         RuleFor(x => x.Model)
             .NotEmpty().WithMessage("Model is required")
-            .MaximumLength(200).WithMessage("Model must not exceed 200 characters");
+            .MaximumLength(200).WithMessage("Model must not exceed 200 characters")
+            .Must(m => !LlmModelRouting.IsUnroutableBareCloudId(m))
+            .WithMessage("Model is not routable: a bare cloud-provider id (e.g. 'claude-haiku-4-5-...') routes to no LLM client. Use a 'provider/model' OpenRouter slug (e.g. 'anthropic/claude-3.5-haiku'), a 'deepseek-*' id, or a local Ollama model.");
 
         RuleFor(x => x.MaxTokens)
             .InclusiveBetween(100, 32000).WithMessage("MaxTokens must be between 100 and 32000");

--- a/apps/api/src/Api/Infrastructure/Seeders/Catalog/AgentSeeder.cs
+++ b/apps/api/src/Api/Infrastructure/Seeders/Catalog/AgentSeeder.cs
@@ -1,3 +1,4 @@
+using Api.BoundedContexts.KnowledgeBase.Domain;
 using Api.BoundedContexts.KnowledgeBase.Domain.Entities;
 using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
 using Microsoft.EntityFrameworkCore;
@@ -34,7 +35,10 @@ internal static class AgentSeeder
             description: "Specialized agent for board game rules interpretation and clarification.",
             type: AgentType.Custom("RAG", "Rules retrieval-augmented generation"),
             config: AgentDefinitionConfig.Create(
-                model: "claude-haiku-4-5-20251001",
+                // Use the configured default (env-overridable, guaranteed routable). The previous
+                // hardcoded "claude-haiku-4-5-20251001" is a BARE Anthropic id that no LlmClient
+                // routes (OpenRouter needs a "provider/model" slug) → chat 500. See LlmModelRouting.
+                model: AgentDefaults.DefaultModel,
                 maxTokens: 500,
                 temperature: 0.3f),
             typologySlug: "rules-expert",

--- a/apps/api/src/Api/Program.cs
+++ b/apps/api/src/Api/Program.cs
@@ -575,6 +575,20 @@ using (var scope = app.Services.CreateScope())
             provider, model, embeddingDimensions);
     }
 
+    // Slice E: surface a misconfigured OPENROUTER_DEFAULT_MODEL at boot (loud) instead of as a
+    // chat-time 500. AgentDefaults.DefaultModel feeds the seeded system agent + routing fallbacks
+    // unguarded (only user-supplied models hit the AgentDefinition validators), so a bare
+    // cloud-provider id here routes to no LLM client.
+    if (Api.Services.LlmClients.LlmModelRouting.IsUnroutableBareCloudId(
+        Api.BoundedContexts.KnowledgeBase.Domain.AgentDefaults.DefaultModel))
+    {
+        app.Logger.LogError(
+            "OPENROUTER_DEFAULT_MODEL='{Model}' is a bare cloud-provider id that routes to no LLM client — " +
+            "seeded agents and routing fallbacks will fail at chat time. Use a 'provider/model' OpenRouter " +
+            "slug (e.g. 'anthropic/claude-3.5-haiku'), a 'deepseek-*' id, or a local Ollama model.",
+            Api.BoundedContexts.KnowledgeBase.Domain.AgentDefaults.DefaultModel);
+    }
+
     // Create read-only projection views for bounded context entity decomposition.
     // Each BC gets its own view of the "users" table to avoid EF Core conflicts
     // when multiple entities map to the same underlying table/view.

--- a/apps/api/src/Api/Services/LlmClients/LlmModelRouting.cs
+++ b/apps/api/src/Api/Services/LlmClients/LlmModelRouting.cs
@@ -1,0 +1,45 @@
+namespace Api.Services.LlmClients;
+
+/// <summary>
+/// Shared model-id routing knowledge used by both <see cref="OllamaLlmClient"/> (to avoid
+/// misrouting) and the agent-definition validators (to reject unroutable configs at write time),
+/// so the two cannot drift.
+/// </summary>
+internal static class LlmModelRouting
+{
+    /// <summary>
+    /// Bare model-id prefixes that belong to cloud providers Ollama never serves. Ambiguous names
+    /// that also exist as local Ollama models (llama, mistral, qwen, phi, gemma, gpt-oss, …) are
+    /// intentionally NOT listed — hence "gpt-3/4/5" rather than a bare "gpt" (which would wrongly
+    /// reject the local "gpt-oss:20b/120b").
+    /// </summary>
+    internal static readonly string[] BareCloudProviderPrefixes =
+    {
+        "claude", "gpt-3", "gpt-4", "gpt-5", "chatgpt", "gemini", "grok", "o1-", "o3-", "o4-",
+    };
+
+    /// <summary>
+    /// True when <paramref name="modelId"/> is a bare (unprefixed) cloud-provider id that no
+    /// <see cref="ILlmClient"/> can route: OpenRouter needs a "provider/model" slug (a '/'),
+    /// Ollama rejects these prefixes, and DeepSeek only serves "deepseek-*". Such an id makes
+    /// <see cref="LlmProviderFactory"/> throw at chat time. Blank ids are NOT flagged here
+    /// (NotEmpty validation covers them).
+    /// </summary>
+    public static bool IsUnroutableBareCloudId(string? modelId)
+    {
+        if (string.IsNullOrWhiteSpace(modelId) || modelId.Contains('/', StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        foreach (var prefix in BareCloudProviderPrefixes)
+        {
+            if (modelId.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/apps/api/src/Api/Services/LlmClients/OllamaLlmClient.cs
+++ b/apps/api/src/Api/Services/LlmClients/OllamaLlmClient.cs
@@ -54,15 +54,6 @@ internal class OllamaLlmClient : ILlmClient
         _logger.LogInformation("OllamaLlmClient initialized with endpoint: {OllamaUrl} (zero cost - self-hosted)", ollamaUrl);
     }
 
-    // Bare model-id prefixes that belong to cloud providers Ollama never serves.
-    // Ambiguous names that also exist as local Ollama models (llama, mistral, qwen,
-    // phi, gemma, gpt-oss, ...) are intentionally NOT listed — hence "gpt-3/4/5" rather
-    // than a bare "gpt" (which would wrongly reject the local "gpt-oss:20b/120b").
-    private static readonly string[] CloudOnlyModelPrefixes =
-    {
-        "claude", "gpt-3", "gpt-4", "gpt-5", "chatgpt", "gemini", "grok", "o1-", "o3-", "o4-",
-    };
-
     /// <inheritdoc/>
     public bool SupportsModel(string modelId)
     {
@@ -83,7 +74,8 @@ internal class OllamaLlmClient : ILlmClient
         // silently routes here (catch-all) and returns an empty completion, so the caller
         // falls back to dumping raw retrieved chunks. Rejecting makes GetClientForModel raise
         // a loud "no client supports model" error that surfaces the misconfiguration instead.
-        foreach (var prefix in CloudOnlyModelPrefixes)
+        // Shared with the agent-definition validators so routing rules cannot drift.
+        foreach (var prefix in LlmModelRouting.BareCloudProviderPrefixes)
         {
             if (modelId.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
             {

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/AgentDefinition/AgentDefinitionModelRoutabilityValidatorTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/AgentDefinition/AgentDefinitionModelRoutabilityValidatorTests.cs
@@ -1,0 +1,61 @@
+using Api.BoundedContexts.KnowledgeBase.Application.Commands.AgentDefinition;
+using Api.BoundedContexts.KnowledgeBase.Application.Validators.AgentDefinition;
+using Api.BoundedContexts.KnowledgeBase.Domain;
+using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
+using Api.Tests.Constants;
+using FluentValidation.TestHelper;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Handlers.AgentDefinition;
+
+/// <summary>
+/// Slice E: the Create/Update agent-definition validators reject a bare cloud-provider model id
+/// (routes to no LLM client → chat 500). See <see cref="Api.Services.LlmClients.LlmModelRouting"/>.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "KnowledgeBase")]
+public sealed class AgentDefinitionModelRoutabilityValidatorTests
+{
+    private readonly CreateAgentDefinitionCommandValidator _createValidator =
+        new(new Mock<IVectorDocumentRepository>().Object);
+    private readonly UpdateAgentDefinitionCommandValidator _updateValidator =
+        new(new Mock<IVectorDocumentRepository>().Object);
+
+    private static CreateAgentDefinitionCommand CreateWith(string model) =>
+        new(Name: "A", Description: "d", Type: "RAG", Model: model, MaxTokens: 500, Temperature: 0.3f);
+
+    private static UpdateAgentDefinitionCommand UpdateWith(string model) =>
+        new(Id: Guid.NewGuid(), Name: "A", Description: "d", Type: "RAG", Model: model, MaxTokens: 500, Temperature: 0.3f);
+
+    [Fact]
+    public async Task Create_BareCloudModelId_FailsValidation()
+    {
+        var result = await _createValidator.TestValidateAsync(CreateWith("claude-haiku-4-5-20251001"));
+        result.ShouldHaveValidationErrorFor(x => x.Model);
+    }
+
+    [Fact]
+    public async Task Update_BareCloudModelId_FailsValidation()
+    {
+        var result = await _updateValidator.TestValidateAsync(UpdateWith("claude-haiku-4-5-20251001"));
+        result.ShouldHaveValidationErrorFor(x => x.Model);
+    }
+
+    [Theory]
+    [InlineData("anthropic/claude-3.5-haiku")]
+    [InlineData("deepseek-chat")]
+    [InlineData("gpt-oss:20b")]
+    public async Task Create_RoutableModelId_PassesModelRule(string model)
+    {
+        var result = await _createValidator.TestValidateAsync(CreateWith(model));
+        result.ShouldNotHaveValidationErrorFor(x => x.Model);
+    }
+
+    [Fact]
+    public async Task Update_RoutableModelId_PassesModelRule()
+    {
+        var result = await _updateValidator.TestValidateAsync(UpdateWith(AgentDefaults.DefaultModel));
+        result.ShouldNotHaveValidationErrorFor(x => x.Model);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/AgentDefinition/CreateAgentDefinitionCommandValidatorKbCardsTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/AgentDefinition/CreateAgentDefinitionCommandValidatorKbCardsTests.cs
@@ -34,7 +34,7 @@ public sealed class CreateAgentDefinitionCommandValidatorKbCardsTests
             Name: "TestAgent",
             Description: "Test",
             Type: "RAG",
-            Model: "gpt-4",
+            Model: "anthropic/claude-3.5-haiku",
             MaxTokens: 2048,
             Temperature: 0.7f,
             KbCardIds: kbCardIds,

--- a/apps/api/tests/Api.Tests/Services/LlmClients/LlmModelRoutingTests.cs
+++ b/apps/api/tests/Api.Tests/Services/LlmClients/LlmModelRoutingTests.cs
@@ -1,0 +1,63 @@
+using Api.BoundedContexts.KnowledgeBase.Domain;
+using Api.Services.LlmClients;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.Services.LlmClients;
+
+/// <summary>
+/// Slice E (RAG answer-quality): guards against agents configured with a bare cloud-provider
+/// model id (e.g. "claude-haiku-4-5-20251001") that no <see cref="Api.Services.LlmClients.ILlmClient"/>
+/// can route — OpenRouter needs a "provider/model" slug, Ollama rejects cloud ids, DeepSeek only
+/// takes "deepseek-*". Such an id makes GetClientForModel throw at chat time (500).
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "KnowledgeBase")]
+public sealed class LlmModelRoutingTests
+{
+    [Theory]
+    // Bare (unprefixed) cloud-provider ids route to NO client.
+    [InlineData("claude-haiku-4-5-20251001")]
+    [InlineData("claude-3-opus")]
+    [InlineData("gpt-4o")]
+    [InlineData("gpt-3.5-turbo")]
+    [InlineData("chatgpt-4o-latest")]
+    [InlineData("gemini-1.5-pro")]
+    [InlineData("grok-2")]
+    [InlineData("o1-preview")]
+    [InlineData("o3-mini")]
+    public void IsUnroutableBareCloudId_BareCloudId_ReturnsTrue(string modelId)
+    {
+        LlmModelRouting.IsUnroutableBareCloudId(modelId).Should().BeTrue();
+    }
+
+    [Theory]
+    // Prefixed OpenRouter slugs (routable via OpenRouter).
+    [InlineData("anthropic/claude-3.5-haiku")]
+    [InlineData("openai/gpt-4o-mini")]
+    [InlineData("meta-llama/llama-3.3-70b-instruct")]
+    // DeepSeek native ids (routable via DeepSeek).
+    [InlineData("deepseek-chat")]
+    [InlineData("deepseek-reasoner")]
+    // Bare local Ollama ids (routable via Ollama) — incl. OpenAI's open-weight gpt-oss.
+    [InlineData("llama3:8b")]
+    [InlineData("mistral:latest")]
+    [InlineData("qwen:7b")]
+    [InlineData("gpt-oss:20b")]
+    [InlineData("gpt-oss:120b")]
+    // Empty/blank are not this rule's concern (NotEmpty handles them).
+    [InlineData("")]
+    [InlineData("   ")]
+    public void IsUnroutableBareCloudId_RoutableOrBlank_ReturnsFalse(string modelId)
+    {
+        LlmModelRouting.IsUnroutableBareCloudId(modelId).Should().BeFalse();
+    }
+
+    [Fact]
+    public void AgentDefaults_DefaultModel_IsRoutable()
+    {
+        // Regression guard: the seeded/default agent model must always be routable.
+        LlmModelRouting.IsUnroutableBareCloudId(AgentDefaults.DefaultModel).Should().BeFalse();
+    }
+}


### PR DESCRIPTION
## Slice E — Agent model-id routability (RAG answer-quality epic)

Follows #3254 (A), #3258 (B), #3260 (C), #3262 (RRF).

### Problem
The seeded **"Rules Expert"** agent shipped model `claude-haiku-4-5-20251001` — a **bare Anthropic id** that no `LlmClient` routes (OpenRouter needs a `provider/model` slug, Ollama rejects cloud ids, DeepSeek only serves `deepseek-*`). `GetClientForModel` throws at chat time (**500**); the misconfig was only discoverable at runtime.

### Fix
- **Source**: `AgentSeeder` now uses `AgentDefaults.DefaultModel` (env-overridable, guaranteed routable).
- **Shared predicate**: `LlmModelRouting.IsUnroutableBareCloudId` + the single-source `BareCloudProviderPrefixes` list — `OllamaLlmClient` reuses it so the routing rule can't drift.
- **Validator hardening**: Create/Update AgentDefinition validators reject a bare cloud-provider model id at write time (400 with a helpful message) instead of a chat 500.

### Note (ops, NOT in this PR)
The staging DB row for the existing "Rules Expert" (`f4d4bba2-…`) still holds the bad id → needs a one-off `UPDATE` (ops action, pending your go).

### Tests
- 22 predicate cases (incl. an `AgentDefaults.DefaultModel` routability guard) + Create/Update validator reject/accept.
- `OllamaLlmClient.SupportsModel` unchanged (refactor is behaviour-preserving); 220 AgentDefinition/LLM/playground tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)