### PR TITLE
fix(api): #3263 derive private-notes identity from auth (IDOR)

### DIFF
--- a/apps/api/src/Api/Routing/SessionTracking/SessionNotesEndpoints.cs
+++ b/apps/api/src/Api/Routing/SessionTracking/SessionNotesEndpoints.cs
@@ -7,6 +7,12 @@ namespace Api.Routing;
 
 /// <summary>
 /// Private notes endpoints (Issue #3344): save, reveal, hide, delete, get notes.
+///
+/// Ownership identity (Issue #3263): every endpoint derives the caller identity from
+/// the authenticated principal (ClaimsPrincipal.GetUserId) and uses it as the note
+/// owner / requester. The client-supplied requesterId/participantId are NEVER trusted —
+/// doing so was an IDOR (any authenticated user could read/mutate another participant's
+/// private notes by spoofing their id).
 /// </summary>
 internal static class SessionNotesEndpoints
 {
@@ -25,15 +31,23 @@ internal static class SessionNotesEndpoints
         group.MapPost("/game-sessions/{sessionId:guid}/private-notes", async (
             Guid sessionId,
             SaveNoteCommand command,
+            HttpContext httpContext,
             IMediator mediator,
             CancellationToken ct) =>
         {
+            var userId = httpContext.User.GetUserId();
+            if (userId == Guid.Empty)
+            {
+                return Results.Unauthorized();
+            }
+
             if (sessionId != command.SessionId)
             {
                 return Results.BadRequest(new { error = "Session ID mismatch" });
             }
 
-            var result = await mediator.Send(command, ct).ConfigureAwait(false);
+            // Owner identity comes from the authenticated principal, not the request body.
+            var result = await mediator.Send(command with { ParticipantId = userId }, ct).ConfigureAwait(false);
             return Results.Created($"/api/v1/game-sessions/{sessionId}/private-notes/{result.NoteId}", result);
         })
         .RequireAuthenticatedUser()
@@ -53,15 +67,22 @@ internal static class SessionNotesEndpoints
             Guid sessionId,
             Guid noteId,
             RevealNoteCommand command,
+            HttpContext httpContext,
             IMediator mediator,
             CancellationToken ct) =>
         {
+            var userId = httpContext.User.GetUserId();
+            if (userId == Guid.Empty)
+            {
+                return Results.Unauthorized();
+            }
+
             if (sessionId != command.SessionId || noteId != command.NoteId)
             {
                 return Results.BadRequest(new { error = "Session or Note ID mismatch" });
             }
 
-            var result = await mediator.Send(command, ct).ConfigureAwait(false);
+            var result = await mediator.Send(command with { ParticipantId = userId }, ct).ConfigureAwait(false);
             return Results.Ok(result);
         })
         .RequireAuthenticatedUser()
@@ -82,15 +103,22 @@ internal static class SessionNotesEndpoints
             Guid sessionId,
             Guid noteId,
             HideNoteCommand command,
+            HttpContext httpContext,
             IMediator mediator,
             CancellationToken ct) =>
         {
+            var userId = httpContext.User.GetUserId();
+            if (userId == Guid.Empty)
+            {
+                return Results.Unauthorized();
+            }
+
             if (sessionId != command.SessionId || noteId != command.NoteId)
             {
                 return Results.BadRequest(new { error = "Session or Note ID mismatch" });
             }
 
-            var result = await mediator.Send(command, ct).ConfigureAwait(false);
+            var result = await mediator.Send(command with { ParticipantId = userId }, ct).ConfigureAwait(false);
             return Results.Ok(result);
         })
         .RequireAuthenticatedUser()
@@ -110,11 +138,17 @@ internal static class SessionNotesEndpoints
         group.MapDelete("/game-sessions/{sessionId:guid}/private-notes/{noteId:guid}", async (
             Guid sessionId,
             Guid noteId,
-            Guid participantId,
+            HttpContext httpContext,
             IMediator mediator,
             CancellationToken ct) =>
         {
-            var command = new DeleteNoteCommand(noteId, sessionId, participantId);
+            var userId = httpContext.User.GetUserId();
+            if (userId == Guid.Empty)
+            {
+                return Results.Unauthorized();
+            }
+
+            var command = new DeleteNoteCommand(noteId, sessionId, userId);
             var result = await mediator.Send(command, ct).ConfigureAwait(false);
             return Results.Ok(result);
         })
@@ -133,11 +167,17 @@ internal static class SessionNotesEndpoints
     {
         group.MapGet("/game-sessions/{sessionId:guid}/private-notes", async (
             Guid sessionId,
-            Guid requesterId,
+            HttpContext httpContext,
             IMediator mediator,
             CancellationToken ct) =>
         {
-            var query = new GetSessionNotesQuery(sessionId, requesterId);
+            var userId = httpContext.User.GetUserId();
+            if (userId == Guid.Empty)
+            {
+                return Results.Unauthorized();
+            }
+
+            var query = new GetSessionNotesQuery(sessionId, userId);
             var result = await mediator.Send(query, ct).ConfigureAwait(false);
             return Results.Ok(result);
         })
@@ -145,7 +185,7 @@ internal static class SessionNotesEndpoints
         .WithName("GetSessionNotes")
         .WithTags("SessionTracking", "PrivateNotes")
         .WithSummary("Get all visible notes in the session")
-        .WithDescription("Returns the requester's own notes and any revealed notes from other participants.")
+        .WithDescription("Returns the caller's own notes and any revealed notes from other participants.")
         .Produces(200)
         .Produces(401);
     }
@@ -155,11 +195,17 @@ internal static class SessionNotesEndpoints
         group.MapGet("/game-sessions/{sessionId:guid}/private-notes/{noteId:guid}", async (
             Guid sessionId,
             Guid noteId,
-            Guid requesterId,
+            HttpContext httpContext,
             IMediator mediator,
             CancellationToken ct) =>
         {
-            var query = new GetNoteByIdQuery(noteId, requesterId);
+            var userId = httpContext.User.GetUserId();
+            if (userId == Guid.Empty)
+            {
+                return Results.Unauthorized();
+            }
+
+            var query = new GetNoteByIdQuery(noteId, userId);
             var result = await mediator.Send(query, ct).ConfigureAwait(false);
 
             if (result is null)
@@ -173,7 +219,7 @@ internal static class SessionNotesEndpoints
         .WithName("GetNoteById")
         .WithTags("SessionTracking", "PrivateNotes")
         .WithSummary("Get a specific note by ID")
-        .WithDescription("Returns the note if the requester is the owner or if the note is revealed.")
+        .WithDescription("Returns the note if the caller is the owner or if the note is revealed.")
         .Produces(200)
         .Produces(401)
         .Produces(404);

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Endpoints/SessionNotesEndpointsIdorIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Endpoints/SessionNotesEndpointsIdorIntegrationTests.cs
@@ -1,0 +1,161 @@
+using System.Net;
+using System.Net.Http.Json;
+using Api.BoundedContexts.SessionTracking.Application.Commands;
+using Api.BoundedContexts.SessionTracking.Application.Queries;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SessionTracking.Endpoints;
+
+/// <summary>
+/// HTTP-layer IDOR tests for the private-notes endpoints (Issue #3263).
+/// The endpoints must derive the caller identity from the authenticated principal,
+/// NOT from a client-supplied <c>requesterId</c>/<c>participantId</c>. A second
+/// authenticated user must not be able to read, or act on, another participant's
+/// private note by spoofing that participant's id.
+/// </summary>
+[Collection("Integration-GroupC")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "SessionTracking")]
+[Trait("Issue", "3263")]
+public sealed class SessionNotesEndpointsIdorIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly string _testDbName;
+    private WebApplicationFactory<Program> _factory = null!;
+    private HttpClient _ownerClient = null!;
+    private HttpClient _otherClient = null!;
+    private Guid _ownerId;
+    private string _ownerToken = null!;
+    private string _otherToken = null!;
+    private Guid _sessionId;
+
+    public SessionNotesEndpointsIdorIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+        _testDbName = $"sessionnotes_idor_{Guid.NewGuid():N}";
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_testDbName);
+        _factory = IntegrationWebApplicationFactory.Create(connectionString);
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        await db.Database.MigrateAsync();
+
+        (_ownerId, _ownerToken) = await TestSessionHelper.CreateUserSessionAsync(db);
+        (_, _otherToken) = await TestSessionHelper.CreateUserSessionAsync(db);
+
+        // The private-notes SessionId FK targets GameManagement's GameSessions
+        // table. Seed a SharedGame (GameSessions.GameId FK) + a GameSession.
+        var sharedGameId = await TestSessionHelper.SeedSharedGameAsync(db, "IDOR Test Game");
+        var gameSession = new GameSessionEntity
+        {
+            Id = Guid.NewGuid(),
+            GameId = sharedGameId,
+            CreatedByUserId = _ownerId,
+            Status = "InProgress",
+            StartedAt = DateTime.UtcNow,
+            PlayersJson = "[]",
+        };
+        db.GameSessions.Add(gameSession);
+        await db.SaveChangesAsync();
+        _sessionId = gameSession.Id;
+
+        _ownerClient = _factory.CreateClient();
+        _otherClient = _factory.CreateClient();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _ownerClient?.Dispose();
+        _otherClient?.Dispose();
+        _factory?.Dispose();
+        await _fixture.DropIsolatedDatabaseAsync(_testDbName);
+    }
+
+    private string SessionNotesUrl => $"/api/v1/game-sessions/{_sessionId}/private-notes";
+
+    /// <summary>Owner creates a private note and returns its id.</summary>
+    private async Task<Guid> SaveOwnerNoteAsync(string content)
+    {
+        // participantId is deliberately the owner's id so the note is owned by the
+        // owner both before the fix (body-supplied) and after (auth-derived).
+        var command = new { sessionId = _sessionId, participantId = _ownerId, content };
+        var response = await _ownerClient.SendAsync(
+            TestSessionHelper.CreateAuthenticatedRequest(
+                HttpMethod.Post, SessionNotesUrl, _ownerToken, command));
+
+        response.StatusCode.Should().Be(HttpStatusCode.Created, "seeding a note must succeed");
+        var body = await response.Content.ReadFromJsonAsync<SaveNoteResponse>();
+        return body!.NoteId;
+    }
+
+    [Fact(Timeout = 90_000)]
+    public async Task GetNotes_AsOwner_ReturnsOwnNoteContent()
+    {
+        var noteId = await SaveOwnerNoteAsync("owner secret");
+
+        var response = await _ownerClient.SendAsync(
+            TestSessionHelper.CreateAuthenticatedRequest(HttpMethod.Get, SessionNotesUrl, _ownerToken));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<GetSessionNotesResponse>();
+        body!.Notes.Should().ContainSingle(n => n.Id == noteId)
+            .Which.Content.Should().Be("owner secret");
+    }
+
+    [Fact(Timeout = 90_000)]
+    public async Task GetNotes_AsOtherUserSpoofingRequesterId_DoesNotLeakOwnersNote()
+    {
+        var noteId = await SaveOwnerNoteAsync("confidential");
+
+        // IDOR exploit: the attacker passes the victim's id as requesterId.
+        var url = $"{SessionNotesUrl}?requesterId={_ownerId}";
+        var response = await _otherClient.SendAsync(
+            TestSessionHelper.CreateAuthenticatedRequest(HttpMethod.Get, url, _otherToken));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadFromJsonAsync<GetSessionNotesResponse>();
+        body!.Notes.Should().NotContain(
+            n => n.Id == noteId,
+            "identity must derive from the authenticated principal, not the client-supplied requesterId");
+    }
+
+    [Fact(Timeout = 90_000)]
+    public async Task DeleteNote_AsOtherUserSpoofingParticipantId_IsForbidden()
+    {
+        var noteId = await SaveOwnerNoteAsync("do not delete");
+
+        // IDOR exploit: the attacker passes the victim's id as participantId.
+        var url = $"{SessionNotesUrl}/{noteId}?participantId={_ownerId}";
+        var response = await _otherClient.SendAsync(
+            TestSessionHelper.CreateAuthenticatedRequest(HttpMethod.Delete, url, _otherToken));
+
+        response.StatusCode.Should().Be(HttpStatusCode.Forbidden);
+    }
+
+    [Fact(Timeout = 90_000)]
+    public async Task DeleteNote_AsOwner_Succeeds()
+    {
+        var noteId = await SaveOwnerNoteAsync("temporary");
+
+        // The owner deletes without supplying any participant id — identity comes
+        // from the authenticated principal.
+        var url = $"{SessionNotesUrl}/{noteId}";
+        var response = await _ownerClient.SendAsync(
+            TestSessionHelper.CreateAuthenticatedRequest(HttpMethod.Delete, url, _ownerToken));
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+    }
+}


### PR DESCRIPTION
Closes #3263.

## 🔴 Critical IDOR — private-notes endpoints trusted client-supplied identity

`SessionNotesEndpoints` decided note ownership from **client-supplied** `requesterId`/`participantId` (query params + command bodies) instead of the authenticated principal. `.RequireAuthenticatedUser()` only proves *someone* is logged in.

- **Read (CRITICAL)** — `GET /api/v1/game-sessions/{sessionId}/private-notes?requesterId={id}` flowed the raw id into `GetVisibleNotesAsync` (`n.ParticipantId == requesterId || n.IsRevealed`) and `SessionNote.CanView(requesterId)` → decrypt. Any authenticated user could **read another participant's decrypted private notes** by passing the victim's (non-secret) id.
- **Write (HIGH)** — `DELETE ...?participantId={id}` + `Save/Reveal/Hide` body `ParticipantId` were compared `note.ParticipantId != request.ParticipantId` — a **self-comparison against attacker input** → delete/reveal/hide/forge another user's notes.

## Fix (Option A — minimal, correct)

Every endpoint now derives `userId = httpContext.User.GetUserId()` (guard `Guid.Empty → 401`) and uses it as `RequesterId`/`ParticipantId`; the `requesterId`/`participantId` query params are dropped and the body `ParticipantId` is overridden. Note callers are always user-linked (guests can't authenticate), so a server-derived identity is always available.

**Zero churn to handlers / repository / domain** — they keep comparing `Guid`s, now trustworthy. Matches the `GetUserId()` pattern already used across `SessionQueryEndpoints.cs`.

Bonus: the `DELETE` endpoint previously required a `participantId` query param the FE never sent (a latent 400); deriving from auth repairs it. The FE `SaveNoteCommandSchema` never carried `participantId`, so **no FE change is needed**.

## Test (TDD)

New HTTP-layer IDOR integration test `SessionNotesEndpointsIdorIntegrationTests` (2-user harness, mirrors `ChatSessionEndpointsIdorIntegrationTests`):
- **RED verified** on current code: attacker spoofing `requesterId` **saw** the owner's note; spoofing `participantId` on DELETE returned **200** (deleted the victim's note); owner GET/DELETE without the params returned **400**.
- **GREEN** after fix: owner reads own note (200) + deletes own note (200); attacker cannot read (note absent) nor delete (403) another user's note.

4/4 new tests pass; full SessionTracking note suite **79/79** green, handlers unchanged.

## Scope / notes
- Adversarial discovery sweep also surfaced a pre-existing FE method/body mismatch on `revealNote`/`hideNote` (PUT `{}` vs backend POST + command body) — **out of scope**, tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)