### PR TITLE
fix(frontend): resolve GameNight InProgress status i18n key (#3263 discovery)

### DIFF
--- a/apps/web/src/app/(authenticated)/game-nights/[id]/_components/GameNightDetailView.tsx
+++ b/apps/web/src/app/(authenticated)/game-nights/[id]/_components/GameNightDetailView.tsx
@@ -50,6 +50,7 @@ import { useSharedGames } from '@/hooks/queries/useSharedGames';
 import { useNetworkStatus } from '@/hooks/useNetworkStatus';
 import { useToast } from '@/hooks/useToast';
 import { useTranslation } from '@/hooks/useTranslation';
+import type { GameNightStatus } from '@/lib/api/schemas/game-nights.schemas';
 import type { RsvpResponse } from '@/lib/game-nights/rsvp-state-machine';
 import { cn } from '@/lib/utils';
 import { useGameNightStore } from '@/stores/game-night';
@@ -252,8 +253,18 @@ export function GameNightDetailView({ id }: { id: string }): React.JSX.Element {
   const showDetailsContent = !votingTabActive;
   const hasActiveSession = activeSessions.some(s => s.status === 'in_progress');
 
-  const statusKey = event.status.toLowerCase() as 'draft' | 'published' | 'completed' | 'cancelled';
-  const statusLabel = t(`gameNightDetail.status.${statusKey}`);
+  // Explicit status → i18n key map. Deriving the key via toLowerCase() produced
+  // 'inprogress' for the 'InProgress' status, which did not match the camelCase
+  // locale key 'inProgress' and leaked the raw key to the badge (#3263 discovery).
+  // Record<GameNightStatus, …> makes a future enum addition fail to compile.
+  const statusLabelKey: Record<GameNightStatus, string> = {
+    Draft: 'draft',
+    Published: 'published',
+    InProgress: 'inProgress',
+    Completed: 'completed',
+    Cancelled: 'cancelled',
+  };
+  const statusLabel = t(`gameNightDetail.status.${statusLabelKey[event.status]}`);
 
   const scheduledLine = dateFormatter.format(new Date(event.scheduledAt));
   const organizedByLine = t('gameNightDetail.hero.organizedBy', { name: event.organizerName });

--- a/apps/web/src/app/(authenticated)/game-nights/[id]/_components/__tests__/GameNightDetailView.statusLabel.test.tsx
+++ b/apps/web/src/app/(authenticated)/game-nights/[id]/_components/__tests__/GameNightDetailView.statusLabel.test.tsx
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+import { GameNightDetailView } from '../GameNightDetailView';
+
+const detailMock = vi.fn();
+const getTabMock = vi.fn<(key: string) => string | null>();
+
+vi.mock('@/hooks/queries/useGameNightDetail', () => ({
+  useGameNightDetail: () => detailMock(),
+}));
+vi.mock('@/hooks/queries/useCurrentUser', () => ({
+  useCurrentUser: () => ({ data: { id: 'org-1' } }),
+}));
+vi.mock('@/hooks/queries/useGameNights', () => ({
+  usePublishGameNight: () => ({ mutate: vi.fn(), isPending: false }),
+  useCancelGameNight: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+vi.mock('@/hooks/queries/useSharedGames', () => ({
+  useSharedGames: () => ({ data: { items: [] } }),
+}));
+vi.mock('@/stores/game-night', () => ({
+  useGameNightStore: () => ({
+    addPlayer: vi.fn(),
+    addGame: vi.fn(),
+    reset: vi.fn(),
+    activeSessions: [],
+  }),
+}));
+vi.mock('@/hooks/useToast', () => ({ useToast: () => ({ toast: vi.fn() }) }));
+// t returns the key verbatim so the resolved i18n KEY is observable in the DOM.
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => ({ t: (k: string) => k, locale: 'it-IT' }),
+}));
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  useSearchParams: () => ({ get: getTabMock }),
+}));
+
+// Expose the statusLabel the caller computes — the real Hero renders it via a badge.
+vi.mock('@/components/features/game-night-detail', () => ({
+  GameNightDetailHero: ({ labels }: { labels: { statusLabel: string } }) => (
+    <div data-testid="hero-status">{labels.statusLabel}</div>
+  ),
+  GameNightCancelledBanner: () => null,
+  GameNightRsvpActionBar: () => null,
+  GameNightRsvpRow: () => <div data-testid="rsvp-row" />,
+}));
+vi.mock('@/components/game-night/GameNightActions', () => ({
+  GameNightActions: () => <div data-testid="game-night-actions" />,
+}));
+vi.mock('@/components/game-night/GameNightSessionsList', () => ({
+  GameNightSessionsList: () => <div data-testid="sessions-list" />,
+}));
+vi.mock('@/components/game-night/GameNightDiaryPanel', () => ({
+  GameNightDiaryPanel: () => <div data-testid="diary-panel" />,
+}));
+vi.mock('@/components/game-night/planning/GameNightPlanningLayout', () => ({
+  GameNightPlanningLayout: () => null,
+}));
+vi.mock('../GameNightEditDrawer', () => ({ GameNightEditDrawer: () => null }));
+vi.mock('@/components/features/game-night-detail/voting/VotingPanel', () => ({
+  VotingPanel: () => <div data-testid="voting-panel" />,
+}));
+
+const baseEvent = {
+  id: 'gn-1',
+  organizerId: 'org-1',
+  organizerName: 'Marco',
+  title: 'Serata',
+  description: null,
+  scheduledAt: '2026-08-01T20:00:00.000Z',
+  location: null,
+  maxPlayers: null,
+  gameIds: [] as string[],
+  acceptedCount: 1,
+};
+
+function mockEventWithStatus(status: string) {
+  detailMock.mockReturnValue({
+    event: { ...baseEvent, status },
+    rsvps: [{ id: 'r1', userId: 'org-1', userName: 'Marco', status: 'Accepted' }],
+    actor: { actor: 'host' },
+    isLoading: false,
+    isError: false,
+    currentResponse: undefined,
+    pendingResponse: null,
+    submitRsvp: vi.fn(),
+    isSubmitting: false,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getTabMock.mockReturnValue(null);
+});
+
+describe('GameNightDetailView — status i18n key (#3263 discovery)', () => {
+  it('resolves the InProgress status to the camelCase key, not the toLowerCase one', () => {
+    mockEventWithStatus('InProgress');
+    render(<GameNightDetailView id="gn-1" />);
+
+    // Bug: event.status.toLowerCase() -> 'inprogress', but the locale key is
+    // 'inProgress' (camelCase), so the raw key leaked to the badge.
+    expect(screen.getByTestId('hero-status')).toHaveTextContent(
+      'gameNightDetail.status.inProgress'
+    );
+  });
+
+  it('resolves the Published status to its i18n key', () => {
+    mockEventWithStatus('Published');
+    render(<GameNightDetailView id="gn-1" />);
+
+    expect(screen.getByTestId('hero-status')).toHaveTextContent('gameNightDetail.status.published');
+  });
+});


### PR DESCRIPTION
From the 2026-07-21 adversarial discovery sweep (untracked defect #3, HIGH).

## Bug

`GameNightDetailView` derived the status i18n key via `event.status.toLowerCase()`:

```ts
const statusKey = event.status.toLowerCase() as 'draft' | 'published' | 'completed' | 'cancelled';
const statusLabel = t(`gameNightDetail.status.${statusKey}`);
```

For the `'InProgress'` status this yields `'inprogress'`, but the locale key is camelCase `'inProgress'` (`it.json`/`en.json`). JSON keys are case-sensitive, so react-intl fell back to rendering the **raw key** `gameNightDetail.status.inprogress` as the hero status badge. `InProgress` is a normal reachable state (a Published night is promoted on first session start). The `as` cast also silently omitted `'inprogress'` from its union.

## Fix

Replace the `toLowerCase()` derivation with an explicit exhaustive `Record<GameNightStatus, string>` map:

```ts
const statusLabelKey: Record<GameNightStatus, string> = {
  Draft: 'draft', Published: 'published', InProgress: 'inProgress',
  Completed: 'completed', Cancelled: 'cancelled',
};
const statusLabel = t(`gameNightDetail.status.${statusLabelKey[event.status]}`);
```

The `Record<GameNightStatus, …>` makes a future enum addition fail to compile.

## Test (TDD)

New `GameNightDetailView.statusLabel.test.tsx` (Hero mock exposes `labels.statusLabel`, `t` returns the key verbatim):
- **RED**: `InProgress` resolved to `gameNightDetail.status.inprogress` (raw, wrong-case key).
- **GREEN**: resolves to `gameNightDetail.status.inProgress`; `Published` regression guard passes.

6 GameNightDetailView test files (25 tests) green; `pnpm typecheck` + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)