### PR TITLE
fix(frontend): chat a11y — disable dead controls + keyboard citations (#3263)

### DIFF
--- a/apps/web/src/components/chat-unified/InlineCitationText.tsx
+++ b/apps/web/src/components/chat-unified/InlineCitationText.tsx
@@ -24,6 +24,15 @@ interface InlineCitationTextProps {
 export function InlineCitationText({ text, citations, snippets }: InlineCitationTextProps) {
   const [expandedCitations, setExpandedCitations] = useState<Set<number>>(new Set());
 
+  const toggleCitation = (index: number) => {
+    setExpandedCitations(prev => {
+      const next = new Set(prev);
+      if (next.has(index)) next.delete(index);
+      else next.add(index);
+      return next;
+    });
+  };
+
   if (citations.length === 0) {
     return <p className="whitespace-pre-wrap break-words">{text}</p>;
   }
@@ -44,17 +53,22 @@ export function InlineCitationText({ text, citations, snippets }: InlineCitation
     segments.push(
       <React.Fragment key={`cite-${idx}`}>
         <span
+          role="button"
+          tabIndex={0}
+          aria-expanded={isExpanded}
           className={cn(
             'bg-amber-500/10 border-l-2 border-amber-500 px-1 cursor-pointer',
-            'hover:bg-amber-500/20 transition-colors inline'
+            'hover:bg-amber-500/20 transition-colors inline',
+            'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-500'
           )}
-          onClick={() => {
-            setExpandedCitations(prev => {
-              const next = new Set(prev);
-              if (next.has(idx)) next.delete(idx);
-              else next.add(idx);
-              return next;
-            });
+          onClick={() => toggleCitation(idx)}
+          onKeyDown={e => {
+            // Keyboard-operable disclosure (#3263 discovery): Enter/Space toggle
+            // the inline snippet; preventDefault on Space avoids page scroll.
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              toggleCitation(idx);
+            }
           }}
           title={`Pagina ${citation.pageNumber}`}
           data-testid={`citation-highlight-${idx}`}

--- a/apps/web/src/components/chat-unified/__tests__/InlineCitationText.test.tsx
+++ b/apps/web/src/components/chat-unified/__tests__/InlineCitationText.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect } from 'vitest';
+
+import { InlineCitationText } from '../InlineCitationText';
+
+import type { InlineCitationMatch } from '@/lib/api/clients/chatClient';
+
+const citations = [
+  {
+    startOffset: 0,
+    endOffset: 5,
+    snippetIndex: 0,
+    pageNumber: 3,
+    pdfDocumentId: 'doc-1',
+  },
+] as unknown as InlineCitationMatch[];
+
+const snippets = [{ text: 'snippet body', source: 's', page: 3, line: 1, score: 0.9 }];
+
+describe('InlineCitationText — keyboard-operable disclosure (#3263 discovery)', () => {
+  it('exposes the citation toggle as a focusable button with aria-expanded', () => {
+    render(<InlineCitationText text="Hello world" citations={citations} snippets={snippets} />);
+
+    const toggle = screen.getByTestId('citation-highlight-0');
+    expect(toggle).toHaveAttribute('role', 'button');
+    expect(toggle).toHaveAttribute('tabindex', '0');
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('expands the snippet on Enter and reflects aria-expanded', async () => {
+    const user = userEvent.setup();
+    render(<InlineCitationText text="Hello world" citations={citations} snippets={snippets} />);
+
+    const toggle = screen.getByTestId('citation-highlight-0');
+    toggle.focus();
+    await user.keyboard('{Enter}');
+
+    expect(screen.getByTestId('citation-accordion-0')).toBeInTheDocument();
+    expect(toggle).toHaveAttribute('aria-expanded', 'true');
+  });
+});

--- a/apps/web/src/components/chat/panel/ChatInputBar.tsx
+++ b/apps/web/src/components/chat/panel/ChatInputBar.tsx
@@ -100,7 +100,9 @@ export function ChatInputBar({
           <button
             type="button"
             aria-label="Allega PDF"
-            className="flex h-9 w-9 items-center justify-center rounded-[10px] text-[var(--text-muted)] transition-all hover:bg-[var(--bg)] hover:text-[var(--text)]"
+            title="Prossimamente"
+            disabled
+            className="flex h-9 w-9 items-center justify-center rounded-[10px] text-[var(--text-muted)] transition-all hover:bg-[var(--bg)] hover:text-[var(--text)] disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent"
           >
             📎
           </button>
@@ -116,7 +118,9 @@ export function ChatInputBar({
           <button
             type="button"
             aria-label="Dettatura"
-            className="flex h-9 w-9 items-center justify-center rounded-[10px] text-[var(--text-muted)] transition-all hover:bg-[var(--bg)] hover:text-[var(--text)]"
+            title="Prossimamente"
+            disabled
+            className="flex h-9 w-9 items-center justify-center rounded-[10px] text-[var(--text-muted)] transition-all hover:bg-[var(--bg)] hover:text-[var(--text)] disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent"
           >
             🎤
           </button>

--- a/apps/web/src/components/chat/panel/__tests__/ChatInputBar.test.tsx
+++ b/apps/web/src/components/chat/panel/__tests__/ChatInputBar.test.tsx
@@ -48,4 +48,25 @@ describe('ChatInputBar', () => {
     await user.type(textarea, 'hello{Shift>}{Enter}{/Shift}');
     expect(onSend).not.toHaveBeenCalled();
   });
+
+  // #3263 discovery: the 📎 "Allega PDF" and 🎤 "Dettatura" buttons had an
+  // actionable aria-label but no handler — dead affordances (WCAG 4.1.2). The
+  // features are not implemented, so they must present as unavailable, not dead.
+  describe('placeholder controls (a11y)', () => {
+    it('disables the not-yet-implemented Allega PDF button', () => {
+      render(<ChatInputBar onSend={() => {}} />);
+      expect(screen.getByRole('button', { name: /allega pdf/i })).toBeDisabled();
+    });
+
+    it('disables the not-yet-implemented Dettatura button', () => {
+      render(<ChatInputBar onSend={() => {}} />);
+      expect(screen.getByRole('button', { name: /dettatura/i })).toBeDisabled();
+    });
+
+    it('keeps the working image + send buttons interactive', () => {
+      render(<ChatInputBar onSend={() => {}} onSendWithImages={() => {}} />);
+      expect(screen.getByRole('button', { name: /allega immagine/i })).toBeEnabled();
+      expect(screen.getByRole('button', { name: /invia/i })).toBeEnabled();
+    });
+  });
 });


### PR DESCRIPTION
From the 2026-07-21 adversarial discovery sweep (two a11y defects).

## Defects

1. **ChatInputBar dead buttons** (WCAG 4.1.2) — the 📎 "Allega PDF" and 🎤 "Dettatura" buttons carried an actionable `aria-label` but had **no `onClick`**. A keyboard/screen-reader user activating them heard an actionable control name and got nothing. The features are not implemented.
2. **InlineCitationText citation disclosure** (WCAG 2.1.1 + 4.1.2) — the expand/collapse toggle was a click-only `<span>` (no `role`, `tabIndex`, `aria-expanded`, or key handler). Keyboard/SR users could not focus or operate it.

## Fixes

1. Both placeholder buttons now render `disabled` (`disabled:opacity-40` + `title="Prossimamente"`) — present as **unavailable**, not dead; dropped from the tab order. The working 🖼️ image + ➤ send buttons are untouched.
2. The citation toggle becomes a keyboard-operable disclosure: `role="button"` + `tabIndex={0}` + `aria-expanded` + `onKeyDown` (Enter/Space, `preventDefault` on Space) + a `focus-visible` ring. The handler is extracted to a shared `toggleCitation`.

## Tests (TDD)

- `ChatInputBar.test.tsx` (+3): **RED** the two buttons were not disabled → **GREEN** disabled, working buttons still enabled.
- New `InlineCitationText.test.tsx` (+2): **RED** no role/tabindex/aria-expanded, Enter did nothing → **GREEN** focusable button role, Enter expands + flips `aria-expanded`.

10/10 tests green; `pnpm typecheck` + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)