### PR TITLE
fix(rag): populate pgvector role_tags at index time (activates Slice C)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/IndexPdfCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/IndexPdfCommandHandler.cs
@@ -2,6 +2,7 @@ using Api.BoundedContexts.DocumentProcessing.Application.Commands;
 using Api.BoundedContexts.DocumentProcessing.Application.DTOs;
 using Api.BoundedContexts.DocumentProcessing.Application.Services;
 using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
+using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
 using Api.BoundedContexts.KnowledgeBase.Application.Services;
 using Api.Configuration;
 using Api.Infrastructure;
@@ -105,12 +106,20 @@ internal class IndexPdfCommandHandler : ICommandHandler<IndexPdfCommand, Indexin
                 return await MarkIndexingFailedAsync(vectorDoc!, chunkingError!, chunkErrorCode!.Value, cancellationToken).ConfigureAwait(false);
             }
 
+            // Classify chunk roles ONCE, before pgvector ingestion, so BOTH sinks get role_tags.
+            // Previously classification ran only in SaveTextChunksToPostgresAsync (after the vector
+            // COPY), leaving pgvector_embeddings.role_tags at 0 — so the vector-arm role-match boost
+            // (hybrid + semantic) had no data. Classifier faults degrade to None per chunk.
+            var chunkRoles = await TextChunkRoleClassifier
+                .ClassifyRolesAsync(_roleClassifier, documentChunks!, _logger, cancellationToken)
+                .ConfigureAwait(false);
+
             // Step 3: Update VectorDocument status
             // For private PDFs GameId is null — fall back to PrivateGameId so vectors are scoped
             // to the correct private game rather than collapsed under Guid.Empty.
             var effectiveGameId = pdf.PrivateGameId ?? pdf.SharedGameId ?? Guid.Empty;
             var indexingSuccess = await IndexChunksInVectorStoreAsync(
-                pdfId, effectiveGameId.ToString(), pdf.ExtractedText!, documentChunks!, vectorDoc!, cancellationToken).ConfigureAwait(false);
+                pdfId, effectiveGameId.ToString(), pdf.ExtractedText!, documentChunks!, chunkRoles, vectorDoc!, cancellationToken).ConfigureAwait(false);
             if (!indexingSuccess)
             {
                 pdf.ProcessingState = nameof(PdfProcessingState.Failed);
@@ -133,7 +142,7 @@ internal class IndexPdfCommandHandler : ICommandHandler<IndexPdfCommand, Indexin
             // Step 4: Save text chunks to PostgreSQL for hybrid search
             // text_chunks.GameId is FK to games.Id (NOT shared_games.id) — resolve via PdfGameIdResolver.
             var chunkGameId = await PdfGameIdResolver.ResolveAsync(_db, pdf, cancellationToken).ConfigureAwait(false);
-            await SaveTextChunksToPostgresAsync(pdfId, chunkGameId, pdf.SharedGameId, documentChunks!, cancellationToken).ConfigureAwait(false);
+            await SaveTextChunksToPostgresAsync(pdfId, chunkGameId, pdf.SharedGameId, documentChunks!, chunkRoles, cancellationToken).ConfigureAwait(false);
 
             // Mark processing complete
             pdf.ProcessingState = nameof(PdfProcessingState.Ready);
@@ -404,6 +413,7 @@ internal class IndexPdfCommandHandler : ICommandHandler<IndexPdfCommand, Indexin
         string gameId,
         string extractedText,
         List<DocumentChunk> documentChunks,
+        IReadOnlyList<GameBookRole> roles,
         VectorDocumentEntity vectorDoc,
         CancellationToken cancellationToken)
     {
@@ -435,18 +445,26 @@ internal class IndexPdfCommandHandler : ICommandHandler<IndexPdfCommand, Indexin
         for (var batchIdx = 0; batchIdx < batchCount; batchIdx++)
         {
             var batchChunks = documentChunks.Skip(batchIdx * saveBatchSize).Take(saveBatchSize).ToList();
-            var entities = batchChunks.Select((chunk, i) => new PgVectorEmbeddingEntity
+            var entities = batchChunks.Select((chunk, i) =>
             {
-                Id = Guid.NewGuid(),
-                VectorDocumentId = vectorDoc.Id,
-                GameId = gameGuid,
-                TextContent = chunk.Text,
-                Vector = new Pgvector.Vector(chunk.Embedding),
-                Model = modelName,
-                ChunkIndex = batchIdx * saveBatchSize + i,
-                PageNumber = Math.Max(1, chunk.Page),
-                Lang = language,
-                CreatedAt = DateTimeOffset.UtcNow
+                var globalIndex = batchIdx * saveBatchSize + i;
+                return new PgVectorEmbeddingEntity
+                {
+                    Id = Guid.NewGuid(),
+                    VectorDocumentId = vectorDoc.Id,
+                    GameId = gameGuid,
+                    TextContent = chunk.Text,
+                    Vector = new Pgvector.Vector(chunk.Embedding),
+                    Model = modelName,
+                    ChunkIndex = globalIndex,
+                    PageNumber = Math.Max(1, chunk.Page),
+                    Lang = language,
+                    CreatedAt = DateTimeOffset.UtcNow,
+                    // role_tags population: denormalize the pre-computed role so the vector-arm
+                    // role-match boost has data (was always 0 — classification used to run only
+                    // after this COPY). Guarded against a None/mismatched roles list.
+                    RoleTags = globalIndex < roles.Count ? (int)roles[globalIndex] : 0,
+                };
             }).ToList();
 
             await _db.PgVectorEmbeddings.AddRangeAsync(entities, cancellationToken).ConfigureAwait(false);
@@ -484,6 +502,7 @@ internal class IndexPdfCommandHandler : ICommandHandler<IndexPdfCommand, Indexin
         Guid? gameId,
         Guid? sharedGameId,
         List<DocumentChunk> documentChunks,
+        IReadOnlyList<GameBookRole> roles,
         CancellationToken cancellationToken)
     {
         var pdfGuid = Guid.Parse(pdfId);
@@ -518,11 +537,9 @@ internal class IndexPdfCommandHandler : ICommandHandler<IndexPdfCommand, Indexin
             })
             .ToList();
 
-        // Phase D4: classify chunks by GameBookRole before persistence so
-        // text_chunks.role_tags is populated on insert.
-        await TextChunkRoleClassifier.AssignRoleTagsAsync(
-            _roleClassifier, textChunkEntities, documentChunks, _logger, cancellationToken)
-            .ConfigureAwait(false);
+        // Phase D4: apply the roles classified once up-front (Handle) so text_chunks.role_tags
+        // matches the pgvector_embeddings.role_tags written for the same chunks (single classify).
+        TextChunkRoleClassifier.ApplyRoles(textChunkEntities, roles);
 
         _db.TextChunks.AddRange(textChunkEntities);
         _logger.LogInformation("Saved {ChunkCount} text chunks to PostgreSQL for hybrid search (PDF {PdfId})",

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/TextChunkRoleClassifier.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/TextChunkRoleClassifier.cs
@@ -54,6 +54,34 @@ internal static class TextChunkRoleClassifier
             return;
         }
 
+        var roles = await ClassifyRolesAsync(classifier, sources, logger, cancellationToken).ConfigureAwait(false);
+        ApplyRoles(textChunks, roles);
+    }
+
+    /// <summary>
+    /// Classifies each source chunk into a <see cref="GameBookRole"/> WITHOUT mutating any entity,
+    /// so the caller can apply the result to multiple sinks (text_chunks AND pgvector_embeddings).
+    /// This is the seam that fixes the vector-arm role_tags gap: classification used to run only
+    /// after pgvector ingestion, leaving <c>pgvector_embeddings.role_tags</c> at 0.
+    ///
+    /// Returns an all-<see cref="GameBookRole.None"/> list (sized to <paramref name="sources"/>) when
+    /// the classifier is null/absent, faults (must NOT block ingestion), or returns a mismatched count.
+    /// </summary>
+    public static async Task<IReadOnlyList<GameBookRole>> ClassifyRolesAsync(
+        IRoleClassifierService? classifier,
+        IReadOnlyList<DocumentChunkInput> sources,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(sources);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        var none = new GameBookRole[sources.Count]; // default(GameBookRole) == None
+        if (classifier is null || sources.Count == 0)
+        {
+            return none;
+        }
+
         var classifierInputs = new ChunkInput[sources.Count];
         for (var i = 0; i < sources.Count; i++)
         {
@@ -78,15 +106,62 @@ internal static class TextChunkRoleClassifier
             logger.LogWarning(
                 ex,
                 "[RoleClassifier] classification failed for {Count} chunks; leaving role_tags at None",
-                textChunks.Count);
-            return;
+                sources.Count);
+            return none;
         }
 
-        if (roles.Count != textChunks.Count)
+        if (roles.Count != sources.Count)
         {
             logger.LogWarning(
                 "[RoleClassifier] classifier returned {ResultCount} results for {ExpectedCount} chunks; leaving role_tags at None",
-                roles.Count, textChunks.Count);
+                roles.Count, sources.Count);
+            return none;
+        }
+
+        return roles;
+    }
+
+    /// <summary>
+    /// <see cref="DocumentChunk"/> convenience overload of <see cref="ClassifyRolesAsync(IRoleClassifierService?, IReadOnlyList{DocumentChunkInput}, ILogger, CancellationToken)"/>.
+    /// </summary>
+    public static async Task<IReadOnlyList<GameBookRole>> ClassifyRolesAsync(
+        IRoleClassifierService? classifier,
+        IReadOnlyList<DocumentChunk> sources,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(sources);
+
+        var inputs = new DocumentChunkInput[sources.Count];
+        for (var i = 0; i < sources.Count; i++)
+        {
+            inputs[i] = new DocumentChunkInput
+            {
+                Text = sources[i].Text,
+                Page = sources[i].Page,
+                CharStart = sources[i].CharStart,
+                CharEnd = sources[i].CharEnd,
+                Heading = sources[i].Heading,
+                Level = sources[i].Level,
+                ParentChunkId = sources[i].ParentChunkId,
+                ElementType = sources[i].ElementType,
+            };
+        }
+
+        return await ClassifyRolesAsync(classifier, inputs, logger, cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Applies pre-computed <paramref name="roles"/> to <paramref name="textChunks"/> in index order.
+    /// No-op on a count mismatch (defensive — the caller aligns the two lists by construction).
+    /// </summary>
+    public static void ApplyRoles(IReadOnlyList<TextChunkEntity> textChunks, IReadOnlyList<GameBookRole> roles)
+    {
+        ArgumentNullException.ThrowIfNull(textChunks);
+        ArgumentNullException.ThrowIfNull(roles);
+
+        if (textChunks.Count != roles.Count)
+        {
             return;
         }
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Handlers/IndexPdfCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Handlers/IndexPdfCommandHandlerTests.cs
@@ -1,6 +1,7 @@
 using Api.BoundedContexts.DocumentProcessing.Application.Commands;
 using Api.BoundedContexts.DocumentProcessing.Application.DTOs;
 using Api.BoundedContexts.DocumentProcessing.Application.Queries;
+using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
 using Api.BoundedContexts.KnowledgeBase.Application.Services;
 using Api.Configuration;
 using Api.Infrastructure;
@@ -228,6 +229,75 @@ public class IndexPdfCommandHandlerTests
     {
         // Assert
         Enum.IsDefined(typeof(PdfIndexingErrorCode), errorCode).Should().BeTrue();
+    }
+
+    // role_tags index-population (review #1555): handler-driven test that the classified role
+    // reaches BOTH persisted sinks — pgvector_embeddings.role_tags AND text_chunks.role_tags — in
+    // sync, per chunk. Without a classifier this is invisible (roles default to None), so this is
+    // the only test that actually observes the fix.
+    [Fact]
+    public async Task Handle_WithRoleClassifier_PopulatesRoleTagsOnBothSinksInSync()
+    {
+        // Arrange
+        using var context = CreateFreshDbContext();
+        var (chunkingServiceMock, embeddingServiceMock, loggerMock, indexingSettingsMock) = CreateMocks();
+
+        var gameId = Guid.NewGuid();
+        var pdfId = Guid.NewGuid();
+        var pdf = CreatePdfDocument(pdfId, gameId, "completed", GenerateExtractedText(120));
+        await context.PdfDocuments.AddAsync(pdf);
+        await context.SaveChangesAsync();
+
+        var textChunks = GenerateTextChunks(4);
+        chunkingServiceMock
+            .Setup(x => x.ChunkText(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
+            .Returns(textChunks);
+        embeddingServiceMock
+            .Setup(x => x.GenerateEmbeddingsAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((List<string> texts, CancellationToken ct) =>
+                new EmbeddingResult { Success = true, Embeddings = texts.Select(_ => GenerateRandomEmbedding(3072)).ToList() });
+        embeddingServiceMock.Setup(x => x.GetEmbeddingDimensions()).Returns(3072);
+        embeddingServiceMock.Setup(x => x.GetModelName()).Returns("text-embedding-3-large");
+
+        // Distinct role per chunk proves per-chunk alignment (not a uniform value).
+        var expectedRoles = new[] { GameBookRole.Setup, GameBookRole.RulesReference, GameBookRole.Lore, GameBookRole.Setup };
+        var classifierMock = new Mock<IRoleClassifierService>();
+        classifierMock
+            .Setup(x => x.ClassifyAsync(It.IsAny<IReadOnlyList<ChunkInput>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expectedRoles);
+
+        var handler = new IndexPdfCommandHandler(
+            context,
+            chunkingServiceMock.Object,
+            embeddingServiceMock.Object,
+            loggerMock.Object,
+            indexingSettingsMock.Object,
+            Mock.Of<ISemanticResponseCache>(),
+            Mock.Of<IPdfIndexingPipeline>(),
+            timeProvider: null,
+            roleClassifier: classifierMock.Object);
+
+        // Act
+        var result = await handler.Handle(new IndexPdfCommand(pdfId.ToString()), CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeTrue();
+
+        var vectorRoleTags = await context.PgVectorEmbeddings
+            .OrderBy(e => e.ChunkIndex)
+            .Select(e => e.RoleTags)
+            .ToListAsync();
+        var textChunkRoleTags = await context.TextChunks
+            .Where(tc => tc.PdfDocumentId == pdfId)
+            .OrderBy(tc => tc.ChunkIndex)
+            .Select(tc => tc.RoleTags)
+            .ToListAsync();
+
+        var expectedInts = expectedRoles.Select(r => (int)r).ToList();
+        // pgvector_embeddings.role_tags is now populated (was always 0) and matches per chunk...
+        vectorRoleTags.Should().Equal(expectedInts);
+        // ...and text_chunks.role_tags is the SAME per chunk (single classification, two sinks).
+        textChunkRoleTags.Should().Equal(expectedRoles);
     }
 
     // ISSUE-3197: Batch processing tests for memory optimization

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Services/TextChunkRoleClassifierTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Services/TextChunkRoleClassifierTests.cs
@@ -111,6 +111,109 @@ public class TextChunkRoleClassifierTests
         classifierMock.VerifyAll();
     }
 
+    // ---------------------------------------------------------------------
+    // role_tags index-population: ClassifyRolesAsync computes the roles ONCE
+    // (from DocumentChunk sources) so the caller can apply them to BOTH
+    // text_chunks AND pgvector_embeddings — the vector arm previously got 0
+    // because classification ran after pgvector ingestion. ApplyRoles is the
+    // sync assignment half.
+    // ---------------------------------------------------------------------
+
+    private static DocumentChunk DocChunk(string text, string? heading = null) =>
+        new() { Text = text, Heading = heading };
+
+    [Fact]
+    public async Task ClassifyRolesAsync_HappyPath_ReturnsRolesInOrder()
+    {
+        var sources = new List<DocumentChunk>
+        {
+            DocChunk("Place pieces on the board.", "Setup > Components"),
+            DocChunk("The wizard rolls 1d6 for damage.", "Combat > Magic"),
+        };
+        var returnedRoles = new[] { GameBookRole.Setup, GameBookRole.RulesReference };
+
+        var classifierMock = new Mock<IRoleClassifierService>();
+        classifierMock
+            .Setup(x => x.ClassifyAsync(
+                It.Is<IReadOnlyList<ChunkInput>>(i =>
+                    i.Count == 2 && i[0].HeadingPath == "Setup > Components" && i[0].BodyText == "Place pieces on the board."),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(returnedRoles);
+
+        var roles = await TextChunkRoleClassifier.ClassifyRolesAsync(
+            classifierMock.Object, sources, Logger, TestContext.Current.CancellationToken);
+
+        roles.Should().Equal(GameBookRole.Setup, GameBookRole.RulesReference);
+    }
+
+    [Fact]
+    public async Task ClassifyRolesAsync_NullClassifier_ReturnsAllNone()
+    {
+        var sources = new List<DocumentChunk> { DocChunk("a"), DocChunk("b") };
+
+        var roles = await TextChunkRoleClassifier.ClassifyRolesAsync(
+            classifier: null, sources, Logger, TestContext.Current.CancellationToken);
+
+        roles.Should().Equal(GameBookRole.None, GameBookRole.None);
+    }
+
+    [Fact]
+    public async Task ClassifyRolesAsync_ClassifierThrows_ReturnsAllNone_DoesNotBlockIngest()
+    {
+        var sources = new List<DocumentChunk> { DocChunk("a"), DocChunk("b") };
+        var classifierMock = new Mock<IRoleClassifierService>();
+        classifierMock
+            .Setup(x => x.ClassifyAsync(It.IsAny<IReadOnlyList<ChunkInput>>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("classifier down"));
+
+        var roles = await TextChunkRoleClassifier.ClassifyRolesAsync(
+            classifierMock.Object, sources, Logger, TestContext.Current.CancellationToken);
+
+        roles.Should().Equal(GameBookRole.None, GameBookRole.None);
+    }
+
+    [Fact]
+    public async Task ClassifyRolesAsync_CountMismatch_ReturnsAllNone()
+    {
+        var sources = new List<DocumentChunk> { DocChunk("a"), DocChunk("b") };
+        var classifierMock = new Mock<IRoleClassifierService>();
+        classifierMock
+            .Setup(x => x.ClassifyAsync(It.IsAny<IReadOnlyList<ChunkInput>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { GameBookRole.Setup }); // 1 role for 2 chunks
+
+        var roles = await TextChunkRoleClassifier.ClassifyRolesAsync(
+            classifierMock.Object, sources, Logger, TestContext.Current.CancellationToken);
+
+        roles.Should().Equal(GameBookRole.None, GameBookRole.None);
+    }
+
+    [Fact]
+    public void ApplyRoles_AssignsInOrder()
+    {
+        var chunks = new[]
+        {
+            new TextChunkEntity { Id = Guid.NewGuid(), Content = "a" },
+            new TextChunkEntity { Id = Guid.NewGuid(), Content = "b" },
+        };
+        var roles = new[] { GameBookRole.Setup, GameBookRole.RulesReference };
+
+        TextChunkRoleClassifier.ApplyRoles(chunks, roles);
+
+        chunks[0].RoleTags.Should().Be(GameBookRole.Setup);
+        chunks[1].RoleTags.Should().Be(GameBookRole.RulesReference);
+    }
+
+    [Fact]
+    public void ApplyRoles_CountMismatch_NoOp()
+    {
+        var chunks = new[] { new TextChunkEntity { Id = Guid.NewGuid(), Content = "a" } };
+        var roles = new[] { GameBookRole.Setup, GameBookRole.RulesReference };
+
+        TextChunkRoleClassifier.ApplyRoles(chunks, roles);
+
+        chunks[0].RoleTags.Should().Be(GameBookRole.None);
+    }
+
     [Fact]
     public async Task AssignRoleTagsAsync_NullSourceFields_PassesEmptyStringToClassifier()
     {


### PR DESCRIPTION
## role_tags index-population (RAG answer-quality epic)

Activates the vector-arm role boost shipped in #3260 (Slice C). Follows #3254/#3258/#3260/#3262/#3265.

### Problem
`pgvector_embeddings.role_tags` was **0** for the whole corpus while `text_chunks.role_tags` **was** populated. `IndexPdfCommandHandler` classified chunk roles **last** (in `SaveTextChunksToPostgresAsync`, after the pgvector COPY), so the vector-arm role-match boost (hybrid #3260 + semantic) had **no data**. `PgVectorEmbeddingEntity.RoleTags`' own XML doc documents this staleness.

### Fix — classify once, apply to both sinks
- Extract `TextChunkRoleClassifier.ClassifyRolesAsync` (compute roles without mutating entities; `None` per chunk on null/fault/mismatch — never blocks ingest) + `ApplyRoles` (sync assignment). `AssignRoleTagsAsync` now delegates to them (behaviour-preserving).
- `IndexChunksInVectorStoreAsync` sets `PgVectorEmbeddingEntity.RoleTags` from the pre-computed role (guarded, aligned by global chunk index).
- `SaveTextChunksToPostgresAsync` applies the **same** roles to `text_chunks`, so the two tables stay in sync (single classification).

### Effect
After a re-index, `pgvector_embeddings.role_tags` is populated and the vector-arm + semantic role boosts activate. **Latent until re-index** (ingest-time field). Same-pattern gap in `UploadPdfCommandHandler.Processing` (fresh uploads) is a tracked follow-up.

### Tests
- 6 new (`ClassifyRolesAsync` happy/null/throw/mismatch + `ApplyRoles` assign/mismatch); `AssignRoleTagsAsync` + IndexPdf handler tests unchanged & green (14 classifier + 25 handler).

🤖 Generated with [Claude Code](https://claude.com/claude-code)