### PR TITLE
fix(api): map GameManagement precondition failures to 4xx not 500 (#3263)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNight/OpenStructuredDisputeCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNight/OpenStructuredDisputeCommandHandler.cs
@@ -59,10 +59,12 @@ internal sealed class OpenStructuredDisputeCommandHandler
             .ConfigureAwait(false)
             ?? throw new NotFoundException("LiveGameSession", command.SessionId.ToString());
 
-        // 3. Verify session has a GameId
+        // 3. Verify session has a GameId. A free-form session (no GameId) cannot
+        // host a dispute — that is a precondition conflict (409), not an unhandled
+        // InvalidOperationException (500). (#3263 discovery)
         if (session.GameId is null)
         {
-            throw new InvalidOperationException("Session has no associated game");
+            throw new ConflictException("Session has no associated game");
         }
 
         // 4. Create dispute via factory method

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/LiveSessions/GenerateSetupChecklistCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/LiveSessions/GenerateSetupChecklistCommandHandler.cs
@@ -61,10 +61,12 @@ internal class GenerateSetupChecklistCommandHandler
             .ConfigureAwait(false)
             ?? throw new NotFoundException("LiveGameSession", command.SessionId.ToString());
 
-        // 3. Verify session has a GameId
+        // 3. Verify session has a GameId. A free-form session (no GameId) cannot
+        // generate a setup checklist — that is a precondition conflict (409), not
+        // an unhandled InvalidOperationException (500). (#3263 discovery)
         if (session.GameId is null)
         {
-            throw new InvalidOperationException("Session has no associated game");
+            throw new ConflictException("Session has no associated game");
         }
 
         // 4. Stream setup guide from KnowledgeBase

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GetGameDetailsQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GetGameDetailsQueryHandler.cs
@@ -36,6 +36,14 @@ internal class GetGameDetailsQueryHandler : IQueryHandler<GetGameDetailsQuery, G
     {
         ArgumentNullException.ThrowIfNull(query);
 
+        // Guid.Empty short-circuits to null (→ HTTP 404) instead of letting
+        // GameRef.Shared(Guid.Empty) throw ArgumentException (→ HTTP 400), matching
+        // the sibling GetGameByIdQueryHandler + the endpoint's 404 contract. (#3263)
+        if (query.GameId == Guid.Empty)
+        {
+            return null;
+        }
+
         var coreData = await _gameCoreData
             .GetCoreDataAsync(GameRef.Shared(query.GameId), cancellationToken)
             .ConfigureAwait(false);

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/GameNight/OpenStructuredDisputeCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/GameNight/OpenStructuredDisputeCommandHandlerTests.cs
@@ -158,6 +158,24 @@ public class OpenStructuredDisputeCommandHandlerTests
     }
 
     [Fact]
+    public async Task OpenStructuredDispute_SessionWithoutGameId_ThrowsConflictException()
+    {
+        // Arrange — a free-form session (no GameId) cannot host a dispute. This is
+        // a precondition conflict (409), not an unhandled InvalidOperationException (500).
+        SetupFeatureFlagEnabled();
+        SetupSessionGetById(DefaultSessionId, CreateSessionWithoutGameId());
+
+        var command = new OpenStructuredDisputeCommand(
+            DefaultSessionId,
+            DefaultInitiatorPlayerId,
+            "Some claim");
+
+        // Act & Assert
+        var act = () => _openHandler.Handle(command, CancellationToken.None);
+        await act.Should().ThrowAsync<ConflictException>();
+    }
+
+    [Fact]
     public async Task OpenStructuredDispute_SessionNotFound_ThrowsNotFoundException()
     {
         // Arrange
@@ -175,26 +193,6 @@ public class OpenStructuredDisputeCommandHandlerTests
         await act.Should().ThrowAsync<NotFoundException>();
     }
 
-    [Fact]
-    public async Task OpenStructuredDispute_SessionWithoutGameId_ThrowsInvalidOperationException()
-    {
-        // Arrange
-        var session = CreateSessionWithoutGameId();
-        SetupFeatureFlagEnabled();
-        SetupSessionGetById(DefaultSessionId, session);
-
-        var command = new OpenStructuredDisputeCommand(
-            DefaultSessionId,
-            DefaultInitiatorPlayerId,
-            "Some claim");
-
-        // Act & Assert
-        var act =
-            () => _openHandler.Handle(command, CancellationToken.None);
-        var ex = (await act.Should().ThrowAsync<InvalidOperationException>()).Which;
-
-        ex.Message.Should().Contain("no associated game");
-    }
 
     [Fact]
     public async Task OpenStructuredDispute_WithExistingGameHistory_SetsRelatedDisputeIds()

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/GetGameDetailsQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/GetGameDetailsQueryHandlerTests.cs
@@ -1,0 +1,49 @@
+using Api.BoundedContexts.GameManagement.Application.Queries;
+using Api.BoundedContexts.GameManagement.Domain.Repositories;
+using Api.SharedKernel.Application;
+using Api.SharedKernel.Domain.ValueObjects;
+using Moq;
+using Xunit;
+using FluentAssertions;
+using Api.Tests.Constants;
+using Api.Tests.TestHelpers;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Application.Handlers;
+
+/// <summary>
+/// Unit tests for GetGameDetailsQueryHandler. #3263 discovery: the handler must
+/// short-circuit on Guid.Empty (→ null → HTTP 404) instead of letting
+/// GameRef.Shared(Guid.Empty) throw ArgumentException (→ HTTP 400), matching the
+/// sibling GetGameByIdQueryHandler and the endpoint's advertised 404 contract.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "GameManagement")]
+public class GetGameDetailsQueryHandlerTests
+{
+    private readonly Mock<IGameCoreDataProvider> _gameCoreDataMock = new();
+    private readonly Mock<IGameSessionRepository> _sessionRepositoryMock = new();
+    private readonly GetGameDetailsQueryHandler _handler;
+
+    public GetGameDetailsQueryHandlerTests()
+    {
+        var db = TestDbContextFactory.CreateInMemoryDbContext();
+        _handler = new GetGameDetailsQueryHandler(
+            _gameCoreDataMock.Object,
+            _sessionRepositoryMock.Object,
+            db);
+    }
+
+    [Fact]
+    public async Task Handle_EmptyGuid_ReturnsNull()
+    {
+        var query = new GetGameDetailsQuery(Guid.Empty);
+
+        var result = await _handler.Handle(query, TestContext.Current.CancellationToken);
+
+        result.Should().BeNull();
+        // The core-data provider must never be consulted for an empty id.
+        _gameCoreDataMock.Verify(
+            x => x.GetCoreDataAsync(It.IsAny<GameRef>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/LiveSessions/GenerateSetupChecklistCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Handlers/LiveSessions/GenerateSetupChecklistCommandHandlerTests.cs
@@ -159,9 +159,11 @@ public class GenerateSetupChecklistCommandHandlerTests
     // === Session without GameId ===
 
     [Fact]
-    public async Task Handle_SessionWithoutGameId_ThrowsInvalidOperationException()
+    public async Task Handle_SessionWithoutGameId_ThrowsConflictException()
     {
-        // Arrange
+        // Arrange — a free-form session (no GameId) cannot generate a setup
+        // checklist. This is a precondition conflict (409), not an unhandled
+        // InvalidOperationException (500).
         SetupFeatureFlagEnabled();
         var session = CreateSessionWithoutGameId();
         SetupRepoGetById(DefaultSessionId, session);
@@ -170,7 +172,7 @@ public class GenerateSetupChecklistCommandHandlerTests
         // Act & Assert
         var act =
             () => _handler.Handle(command, CancellationToken.None);
-        var ex = (await act.Should().ThrowAsync<InvalidOperationException>()).Which;
+        var ex = (await act.Should().ThrowAsync<ConflictException>()).Which;
 
         ex.Message.Should().Be("Session has no associated game");
     }


### PR DESCRIPTION
From the 2026-07-21 adversarial discovery sweep (3 untracked HTTP-status defects, MEDIUM).

## Bugs

Three GameManagement handlers surfaced client/precondition errors as **HTTP 500**:

1. **`OpenStructuredDisputeCommandHandler`** + **`GenerateSetupChecklistCommandHandler`** threw `InvalidOperationException("Session has no associated game")` when the target is a **free-form session** (`LiveGameSession.GameId is null` — a legitimate persisted state). The message has no "not found" substring, so `ApiExceptionHandlerMiddleware` fell through to the default branch → **500**. A participant opening a dispute / generating a checklist on a free-form session got a spurious 500.
2. **`GetGameDetailsQueryHandler`** had no `Guid.Empty` guard, so `GET /games/{empty}/details` let `GameRef.Shared(Guid.Empty)` throw `ArgumentException` → **400**, inconsistent with the sibling `GetGameByIdQueryHandler` (short-circuits to `null` → **404**) and the endpoint's advertised `.Produces(404)`.

## Fix

1. Both handlers now throw `ConflictException` (**409**) for the null-GameId precondition (the repo's #2568 pattern for domain-precondition-500s).
2. `GetGameDetailsQueryHandler` gets the same `if (query.GameId == Guid.Empty) return null;` short-circuit as its sibling.

## Tests (TDD)

- `OpenStructuredDisputeCommandHandlerTests` — updated the null-GameId test to expect `ConflictException` (was `InvalidOperationException`). **RED** 500 → **GREEN** 409.
- `GenerateSetupChecklistCommandHandlerTests` — same update. **RED** → **GREEN**.
- New `GetGameDetailsQueryHandlerTests.Handle_EmptyGuid_ReturnsNull` (asserts the provider is never consulted). **RED** `ArgumentException` → **GREEN** `null`.

17/17 tests across the 3 handler classes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)