### PR TITLE
fix(frontend): defer IntlProvider browser-locale detection to after mount (#3263)

### DIFF
--- a/apps/web/src/components/providers/IntlProvider.tsx
+++ b/apps/web/src/components/providers/IntlProvider.tsx
@@ -17,7 +17,7 @@
  * @see https://formatjs.io/docs/react-intl
  */
 
-import { ReactNode, useMemo } from 'react';
+import { ReactNode, useEffect, useMemo, useState } from 'react';
 
 import { IntlProvider as ReactIntlProvider } from 'react-intl';
 
@@ -71,8 +71,20 @@ function getBrowserLocale(): Locale {
  * ```
  */
 export function IntlProvider({ children, locale }: IntlProviderProps) {
-  // Use provided locale or detect from browser
-  const currentLocale = locale || getBrowserLocale();
+  // #3263: detect the browser locale only AFTER mount. On the server and on the
+  // first client (hydration) render we use the same value — an explicit prop, or
+  // DEFAULT_LOCALE — so the SSR HTML matches the first client render and a
+  // non-Italian browser no longer triggers a hydration mismatch. The browser
+  // locale is then adopted by the effect below (a brief, intentional swap).
+  const [detectedLocale, setDetectedLocale] = useState<Locale | null>(null);
+
+  useEffect(() => {
+    if (!locale) {
+      setDetectedLocale(getBrowserLocale());
+    }
+  }, [locale]);
+
+  const currentLocale = locale ?? detectedLocale ?? DEFAULT_LOCALE;
 
   // Get messages for current locale and flatten for react-intl
   const flatMessages = useMemo(() => {

--- a/apps/web/src/components/providers/__tests__/IntlProvider.test.tsx
+++ b/apps/web/src/components/providers/__tests__/IntlProvider.test.tsx
@@ -116,4 +116,35 @@ describe('IntlProvider', () => {
       consoleSpy.mockRestore();
     });
   });
+
+  describe('Browser-locale detection deferral (#3263)', () => {
+    it('uses the default locale on first render and adopts the browser locale after mount', () => {
+      // Bypass the test-env short-circuit in getBrowserLocale so navigator.language wins.
+      process.env.NODE_ENV = 'production';
+      Object.defineProperty(window.navigator, 'language', {
+        value: 'en-US',
+        configurable: true,
+      });
+
+      const renders: string[] = [];
+      function LocaleRecorder() {
+        const { locale } = useTranslation();
+        renders.push(locale);
+        return null;
+      }
+
+      render(
+        <IntlProvider>
+          <LocaleRecorder />
+        </IntlProvider>
+      );
+
+      // First (SSR-matching) render must use the default locale — browser-locale
+      // detection is deferred to a post-mount effect, so a non-Italian browser no
+      // longer produces a server/client hydration mismatch.
+      expect(renders[0]).toBe('it');
+      // After mount the effect adopts the real browser locale.
+      expect(renders[renders.length - 1]).toBe('en');
+    });
+  });
 });


### PR DESCRIPTION
From the 2026-07-21 adversarial discovery sweep (untracked defect #4, HIGH — SSR).

## Bug

`IntlProvider` computed `locale || getBrowserLocale()` **during render**. The app-wide mount (`providers.tsx`) passes no `locale` prop, so:
- **Server** (`typeof window === 'undefined'`) → `DEFAULT_LOCALE` ('it').
- **First client hydration render** for a non-Italian browser → `navigator.language` ('en').

Every SSR'd translated string (public login/register/join routes use `FormattedMessage`) therefore differed between the server HTML and the first client render → **React hydration mismatch + flash for every non-Italian browser**. `suppressHydrationWarning` on `html`/`body` does not cover deep descendant text.

## Fix

Defer browser-locale detection to a post-mount `useEffect`:
- First render (server + client hydration) uses the explicit prop or `DEFAULT_LOCALE` → server HTML matches the first client render.
- The effect then adopts the real browser locale (a brief, intentional swap — no mismatch).
- Explicit-locale callers (`<IntlProvider locale="en">`) are unchanged.

## Test (TDD)

The `getBrowserLocale` `NODE_ENV==='test'` short-circuit normally makes this untestable in jsdom, but the existing suite already toggles `NODE_ENV` (restored in `afterEach`). New test sets `NODE_ENV='production'` + `navigator.language='en-US'` and records the locale on **every** render:
- **RED**: the first render was `'en'` (detection during render).
- **GREEN**: the first render is `'it'` (default), then `'en'` after mount.

18/18 tests across both IntlProvider suites green; `pnpm typecheck` + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)