### PR TITLE
fix(api): serialize SSE response-body writes (heartbeat + event loop) (#3263)

### DIFF
--- a/apps/api/src/Api/Routing/DashboardEndpoints.cs
+++ b/apps/api/src/Api/Routing/DashboardEndpoints.cs
@@ -290,6 +290,10 @@ with the current user scheduled within the last 90 days.
 
             // Create heartbeat task for keep-alive (30s interval)
             using var heartbeatCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            // #3263: the heartbeat task and the main loop below both write to the same
+            // response body; Kestrel forbids concurrent response-body writes, so all
+            // frames go through this single-writer gate.
+            using var writeGate = new SemaphoreSlim(1, 1);
             var heartbeatTask = Task.Run(async () =>
             {
                 while (!heartbeatCts.Token.IsCancellationRequested)
@@ -297,9 +301,11 @@ with the current user scheduled within the last 90 days.
                     try
                     {
                         await Task.Delay(TimeSpan.FromSeconds(30), heartbeatCts.Token).ConfigureAwait(false);
-                        await context.Response.WriteAsync("event: heartbeat\n", heartbeatCts.Token).ConfigureAwait(false);
-                        await context.Response.WriteAsync($"data: {{\"timestamp\":\"{DateTime.UtcNow:O}\"}}\n\n", heartbeatCts.Token).ConfigureAwait(false);
-                        await context.Response.Body.FlushAsync(heartbeatCts.Token).ConfigureAwait(false);
+                        await Sse.SseFrameWriter.WriteFrameAsync(
+                            context.Response,
+                            writeGate,
+                            $"event: heartbeat\ndata: {{\"timestamp\":\"{DateTime.UtcNow:O}\"}}\n\n",
+                            heartbeatCts.Token).ConfigureAwait(false);
                     }
                     catch (OperationCanceledException)
                     {
@@ -316,9 +322,11 @@ with the current user scheduled within the last 90 days.
                     var eventType = evt.GetType().Name;
                     var json = JsonSerializer.Serialize(evt, evt.GetType(), JsonOptions);
 
-                    await context.Response.WriteAsync($"event: {eventType}\n", ct).ConfigureAwait(false);
-                    await context.Response.WriteAsync($"data: {json}\n\n", ct).ConfigureAwait(false);
-                    await context.Response.Body.FlushAsync(ct).ConfigureAwait(false);
+                    await Sse.SseFrameWriter.WriteFrameAsync(
+                        context.Response,
+                        writeGate,
+                        $"event: {eventType}\ndata: {json}\n\n",
+                        ct).ConfigureAwait(false);
                 }
             }
             finally

--- a/apps/api/src/Api/Routing/NotificationEndpoints.cs
+++ b/apps/api/src/Api/Routing/NotificationEndpoints.cs
@@ -176,6 +176,10 @@ internal static class NotificationEndpoints
             await response.Body.FlushAsync(ct).ConfigureAwait(false);
 
             using var heartbeatCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            // #3263: the heartbeat task and the main loop below both write to the same
+            // response body; Kestrel forbids concurrent response-body writes, so all
+            // frames go through this single-writer gate.
+            using var writeGate = new SemaphoreSlim(1, 1);
 
             var heartbeatTask = Task.Run(async () =>
             {
@@ -184,8 +188,7 @@ internal static class NotificationEndpoints
                     try
                     {
                         await Task.Delay(TimeSpan.FromSeconds(30), heartbeatCts.Token).ConfigureAwait(false);
-                        await response.WriteAsync(": heartbeat\n\n", heartbeatCts.Token).ConfigureAwait(false);
-                        await response.Body.FlushAsync(heartbeatCts.Token).ConfigureAwait(false);
+                        await Sse.SseFrameWriter.WriteFrameAsync(response, writeGate, ": heartbeat\n\n", heartbeatCts.Token).ConfigureAwait(false);
                     }
                     catch (OperationCanceledException)
                     {
@@ -199,8 +202,7 @@ internal static class NotificationEndpoints
                 await foreach (var notification in broadcaster.SubscribeAsync(userId, ct).ConfigureAwait(false))
                 {
                     var json = JsonSerializer.Serialize(notification, SseJsonOptions);
-                    await response.WriteAsync($"event: notification\ndata: {json}\n\n", ct).ConfigureAwait(false);
-                    await response.Body.FlushAsync(ct).ConfigureAwait(false);
+                    await Sse.SseFrameWriter.WriteFrameAsync(response, writeGate, $"event: notification\ndata: {json}\n\n", ct).ConfigureAwait(false);
                 }
             }
             finally

--- a/apps/api/src/Api/Routing/SessionTracking/SessionQueryEndpoints.cs
+++ b/apps/api/src/Api/Routing/SessionTracking/SessionQueryEndpoints.cs
@@ -259,6 +259,10 @@ internal static class SessionQueryEndpoints
 
             // Create heartbeat task for keep-alive
             using var heartbeatCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+            // #3263: the heartbeat task and the main loop below both write to the same
+            // response body; Kestrel forbids concurrent response-body writes, so all
+            // frames go through this single-writer gate.
+            using var writeGate = new SemaphoreSlim(1, 1);
             var heartbeatTask = Task.Run(async () =>
             {
                 while (!heartbeatCts.Token.IsCancellationRequested)
@@ -266,9 +270,11 @@ internal static class SessionQueryEndpoints
                     try
                     {
                         await Task.Delay(TimeSpan.FromSeconds(30), heartbeatCts.Token).ConfigureAwait(false);
-                        await context.Response.WriteAsync("event: heartbeat\n", heartbeatCts.Token).ConfigureAwait(false);
-                        await context.Response.WriteAsync($"data: {{\"timestamp\":\"{DateTime.UtcNow:O}\"}}\n\n", heartbeatCts.Token).ConfigureAwait(false);
-                        await context.Response.Body.FlushAsync(heartbeatCts.Token).ConfigureAwait(false);
+                        await Sse.SseFrameWriter.WriteFrameAsync(
+                            context.Response,
+                            writeGate,
+                            $"event: heartbeat\ndata: {{\"timestamp\":\"{DateTime.UtcNow:O}\"}}\n\n",
+                            heartbeatCts.Token).ConfigureAwait(false);
                     }
                     catch (OperationCanceledException)
                     {
@@ -285,9 +291,11 @@ internal static class SessionQueryEndpoints
                     var eventType = evt.GetType().Name;
                     var json = JsonSerializer.Serialize(evt, JsonOptions);
 
-                    await context.Response.WriteAsync($"event: {eventType}\n", ct).ConfigureAwait(false);
-                    await context.Response.WriteAsync($"data: {json}\n\n", ct).ConfigureAwait(false);
-                    await context.Response.Body.FlushAsync(ct).ConfigureAwait(false);
+                    await Sse.SseFrameWriter.WriteFrameAsync(
+                        context.Response,
+                        writeGate,
+                        $"event: {eventType}\ndata: {json}\n\n",
+                        ct).ConfigureAwait(false);
                 }
             }
             finally

--- a/apps/api/src/Api/Routing/Sse/SseFrameWriter.cs
+++ b/apps/api/src/Api/Routing/Sse/SseFrameWriter.cs
@@ -1,0 +1,39 @@
+using System.Text;
+
+namespace Api.Routing.Sse;
+
+/// <summary>
+/// Serializes writes to a single Server-Sent Events response body (#3263).
+///
+/// A live SSE stream has two concurrent writers — a keep-alive heartbeat task and
+/// the main event loop — that both write to the same <see cref="HttpResponse"/>.
+/// Kestrel forbids concurrent response-body writes ("Concurrent writes to the
+/// response body are not supported") and interleaving corrupts SSE frames, so
+/// every writer on a connection MUST go through the same gate.
+/// </summary>
+internal static class SseFrameWriter
+{
+    /// <summary>
+    /// Writes a complete SSE frame (including its trailing blank line) and flushes,
+    /// holding <paramref name="gate"/> so no other frame on the same connection
+    /// interleaves. Callers share one <see cref="SemaphoreSlim"/> per connection.
+    /// </summary>
+    public static async Task WriteFrameAsync(
+        HttpResponse response,
+        SemaphoreSlim gate,
+        string frame,
+        CancellationToken cancellationToken)
+    {
+        var bytes = Encoding.UTF8.GetBytes(frame);
+        await gate.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            await response.Body.WriteAsync(bytes.AsMemory(), cancellationToken).ConfigureAwait(false);
+            await response.Body.FlushAsync(cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            gate.Release();
+        }
+    }
+}

--- a/apps/api/tests/Api.Tests/Routing/Sse/SseFrameWriterTests.cs
+++ b/apps/api/tests/Api.Tests/Routing/Sse/SseFrameWriterTests.cs
@@ -1,0 +1,83 @@
+using Api.Routing.Sse;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Xunit;
+
+namespace Api.Tests.Routing.Sse;
+
+/// <summary>
+/// #3263: the SSE endpoints' heartbeat task and main event loop both write to the
+/// same response body. SseFrameWriter must serialize those writes so they never
+/// overlap (Kestrel forbids concurrent response-body writes).
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+public class SseFrameWriterTests
+{
+    /// <summary>
+    /// A response-body stream that records the maximum number of writes observed
+    /// in flight at the same time. Each write holds the "in flight" state across an
+    /// await, so unsynchronized concurrent callers push the observed maximum above 1.
+    /// </summary>
+    private sealed class ConcurrencyTrackingStream : Stream
+    {
+        private int _current;
+        private int _max;
+
+        public int MaxConcurrent => Volatile.Read(ref _max);
+
+        public override async ValueTask WriteAsync(
+            ReadOnlyMemory<byte> buffer,
+            CancellationToken cancellationToken = default)
+        {
+            var inFlight = Interlocked.Increment(ref _current);
+            int observed;
+            while (inFlight > (observed = Volatile.Read(ref _max)))
+            {
+                Interlocked.CompareExchange(ref _max, inFlight, observed);
+            }
+
+            try
+            {
+                // Hold the "in flight" window open so a concurrent write would overlap.
+                await Task.Delay(5, cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+                Interlocked.Decrement(ref _current);
+            }
+        }
+
+        public override Task FlushAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+        public override void Flush() { }
+        public override bool CanRead => false;
+        public override bool CanSeek => false;
+        public override bool CanWrite => true;
+        public override long Length => throw new NotSupportedException();
+        public override long Position { get => 0; set { } }
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) => throw new NotSupportedException();
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+
+    [Fact]
+    public async Task WriteFrameAsync_ConcurrentCallers_NeverOverlapOnTheResponseBody()
+    {
+        var tracker = new ConcurrencyTrackingStream();
+        var context = new DefaultHttpContext();
+        context.Response.Body = tracker;
+        using var gate = new SemaphoreSlim(1, 1);
+
+        // Fire many writers concurrently, exactly like the heartbeat task racing the
+        // main event loop.
+        var writers = Enumerable.Range(0, 25)
+            .Select(i => SseFrameWriter.WriteFrameAsync(
+                context.Response, gate, $"data: {i}\n\n", CancellationToken.None))
+            .ToArray();
+
+        await Task.WhenAll(writers);
+
+        tracker.MaxConcurrent.Should().Be(1, "writes to a single SSE response body must be serialized");
+    }
+}


### PR DESCRIPTION
From the 2026-07-21 adversarial discovery sweep (untracked defects #5/#11/#12 — one root cause).

## Bug

The live-session (`SessionQueryEndpoints`), dashboard (`DashboardEndpoints`), and notification (`NotificationEndpoints`) SSE endpoints each run a **heartbeat `Task.Run`** alongside the main **`await foreach`** loop. Both write to the **same `context.Response`** with **no synchronization**.

Kestrel forbids concurrent response-body writes (`InvalidOperationException: Concurrent writes to the response body are not supported`) — when a heartbeat lands mid-event the connection can abort (the user silently stops receiving updates). SessionQuery/Dashboard write each frame as **two** `WriteAsync` calls (`event:` line + `data:` line), so a heartbeat can also interleave **between** them, corrupting the SSE frame (the last `event:` wins → an activity payload dispatched as `heartbeat`).

## Fix

Introduce `SseFrameWriter.WriteFrameAsync(response, gate, frame, ct)` — writes a whole frame + flush while holding a per-connection `SemaphoreSlim(1,1)`. Each endpoint now declares one `writeGate` and routes **every** heartbeat + event frame through it, so the two writers are serialized. This mirrors the newer `LiveSessionStreamGateway` (ADR-083 SP2), which fans all sources into a single writer for exactly this reason. Deadlock-free: one gate, acquire→try→write→finally-release, no nesting; disposed after the heartbeat task is awaited.

## Test (TDD)

New `SseFrameWriterTests`: a `ConcurrencyTrackingStream` response body records the max writes in flight; 25 writers fire concurrently through one gate.
- **RED** (no gate): observed **25** overlapping writes.
- **GREEN** (gate): max **1**.

Build green; 9 SSE/endpoint tests pass, no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)