### PR TITLE
feat(frontend): promote /legal placeholder to real legal hub (#564)

### DIFF
--- a/apps/web/src/app/(public)/legal/__tests__/page.test.tsx
+++ b/apps/web/src/app/(public)/legal/__tests__/page.test.tsx
@@ -1,0 +1,38 @@
+/** @vitest-environment jsdom */
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import LegalHubPage, { metadata } from '../page';
+
+// The page renders LegalPageLayout, which is a client component that supplies
+// its own LegalLocaleProvider (+ IntlProvider) — no extra wrapper needed here.
+describe('LegalHubPage', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('exposes SEO metadata (title + canonical)', () => {
+    expect(metadata.title).toMatch(/legal/i);
+    expect(metadata.alternates?.canonical).toBe('https://meepleai.com/legal');
+  });
+
+  it('renders the legal hub heading (default IT locale)', () => {
+    render(<LegalHubPage />);
+    // Page heading uses the pageKey testid from LegalPageLayout.
+    expect(screen.getByTestId('hub-heading')).toBeInTheDocument();
+  });
+
+  it('links to all four legal documents', () => {
+    render(<LegalHubPage />);
+    const hrefs = screen.getAllByRole('link').map(a => a.getAttribute('href'));
+    expect(hrefs).toContain('/terms');
+    expect(hrefs).toContain('/privacy');
+    expect(hrefs).toContain('/cookies');
+    expect(hrefs).toContain('/legal/takedown');
+  });
+
+  it('is a real hub, not the old "Coming Soon" redirect placeholder', () => {
+    render(<LegalHubPage />);
+    expect(screen.queryByText(/coming soon/i)).toBeNull();
+  });
+});

--- a/apps/web/src/app/(public)/legal/page.tsx
+++ b/apps/web/src/app/(public)/legal/page.tsx
@@ -1,28 +1,42 @@
-// TODO: implement this route (see docs/superpowers/specs/route-gap-analysis.md)
-// Mockup: sp3-legal.jsx — legal hub combining /terms and /privacy.
-// This placeholder redirects to /terms until a unified /legal hub is built.
-'use client';
+/**
+ * Legal Hub Page — /legal (#564, route-gap-analysis).
+ *
+ * Landing hub linking to all of MeepleAI's legal documents (Terms, Privacy,
+ * Cookies, Takedown). Promotes the former redirect placeholder to a real hub.
+ *
+ * Mirrors the established legal-page pattern (see `terms/page.tsx`): shared
+ * `LegalPageLayout`, i18n-driven `legal.hub.*` content, IT/EN toggle, and
+ * JSON-LD structured data. The two linked sub-pages already exist.
+ */
 
-import { useEffect } from 'react';
+import { LegalPageLayout } from '@/components/legal';
 
-import { useRouter } from 'next/navigation';
+import type { Metadata } from 'next';
 
-export default function LegalPlaceholderPage() {
-  const router = useRouter();
+export const metadata: Metadata = {
+  title: 'Legal | MeepleAI',
+  description:
+    "MeepleAI's legal documents and policies — Terms of Service, Privacy Policy, Cookie Policy, and copyright takedown requests.",
+  openGraph: {
+    title: 'Legal | MeepleAI',
+    description: "All of MeepleAI's legal documents and policies in one place.",
+    url: 'https://meepleai.com/legal',
+    type: 'website',
+  },
+  alternates: {
+    canonical: 'https://meepleai.com/legal',
+  },
+};
 
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      router.replace('/terms');
-    }, 2000);
-    return () => clearTimeout(timer);
-  }, [router]);
+const HUB_SECTIONS = ['documents'] as const;
 
+export default function LegalHubPage() {
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center gap-4 bg-background p-8">
-      <h1 className="text-2xl font-semibold text-foreground">Coming Soon</h1>
-      <p className="text-muted-foreground">
-        This page is not yet implemented. Redirecting to <code>/terms</code>...
-      </p>
-    </main>
+    <LegalPageLayout
+      pageKey="hub"
+      sections={HUB_SECTIONS}
+      defaultOpenSection="documents"
+      lastUpdated={new Date('2026-07-21')}
+    />
   );
 }

--- a/apps/web/src/components/legal/LegalPageLayout.tsx
+++ b/apps/web/src/components/legal/LegalPageLayout.tsx
@@ -33,7 +33,7 @@ import { LegalLocaleProvider, LegalLocaleToggle } from './LegalLocaleToggle';
 import { LegalMarkdown } from './LegalMarkdown';
 import { StructuredData, legalPageSchema, breadcrumbSchema } from './StructuredData';
 
-type LegalPageKey = 'privacy' | 'terms' | 'cookies' | 'takedown';
+type LegalPageKey = 'privacy' | 'terms' | 'cookies' | 'takedown' | 'hub';
 
 interface FooterNavLink {
   href: string;
@@ -67,6 +67,7 @@ const PAGE_PATHS: Record<LegalPageKey, string> = {
   terms: '/terms',
   cookies: '/cookies',
   takedown: '/legal/takedown',
+  hub: '/legal',
 };
 
 function LegalPageContent({

--- a/apps/web/src/components/legal/__tests__/i18n-legal-keys.test.ts
+++ b/apps/web/src/components/legal/__tests__/i18n-legal-keys.test.ts
@@ -63,6 +63,9 @@ const COOKIE_SECTIONS = [
 // #529 ME-M1.7 — takedown policy page sections
 const TAKEDOWN_SECTIONS = ['overview', 'whoCanFile', 'whatToInclude', 'howWeRespond', 'contact'];
 
+// #564 — legal hub landing page sections
+const HUB_SECTIONS = ['documents'];
+
 type LegalSections = Record<string, { title: string; content: string }>;
 
 describe('Legal i18n key validation', () => {
@@ -158,6 +161,29 @@ describe('Legal i18n key validation', () => {
     });
   });
 
+  describe('Legal hub sections', () => {
+    const itSections = (
+      itMessages as Record<string, unknown> & { legal: { hub: { sections: LegalSections } } }
+    ).legal.hub.sections;
+    const enSections = (
+      enMessages as Record<string, unknown> & { legal: { hub: { sections: LegalSections } } }
+    ).legal.hub.sections;
+
+    it.each(HUB_SECTIONS)('IT: hub section "%s" exists with title and content', key => {
+      const section = itSections[key];
+      expect(section).toBeDefined();
+      expect(section?.title).toBeTruthy();
+      expect(section?.content).toBeTruthy();
+    });
+
+    it.each(HUB_SECTIONS)('EN: hub section "%s" exists with title and content', key => {
+      const section = enSections[key];
+      expect(section).toBeDefined();
+      expect(section?.title).toBeTruthy();
+      expect(section?.content).toBeTruthy();
+    });
+  });
+
   describe('Takedown form keys', () => {
     const FORM_KEYS = [
       'heading',
@@ -229,7 +255,7 @@ describe('Legal i18n key validation', () => {
   });
 
   describe('Page metadata keys', () => {
-    const pages = ['privacy', 'terms', 'cookies', 'takedown'] as const;
+    const pages = ['privacy', 'terms', 'cookies', 'takedown', 'hub'] as const;
 
     it.each(pages)('IT: "%s" has title and description', page => {
       const legal = (

--- a/apps/web/src/locales/en.json
+++ b/apps/web/src/locales/en.json
@@ -786,6 +786,16 @@
     }
   },
   "legal": {
+    "hub": {
+      "title": "Legal",
+      "description": "All of MeepleAI's legal documents and policies in one place.",
+      "sections": {
+        "documents": {
+          "title": "Legal documents",
+          "content": "- [Terms of Service](/terms) — The terms governing your use of MeepleAI, including AI usage, copyright, and user content policies.\n- [Privacy Policy](/privacy) — How we collect, use, and protect your personal data, in compliance with GDPR.\n- [Cookie Policy](/cookies) — The cookies we use and how to manage your preferences.\n- [Takedown Request](/legal/takedown) — How to report content you believe infringes your copyright."
+        }
+      }
+    },
     "tableOfContents": "Table of Contents",
     "lastUpdated": "Last updated: {date}",
     "cookieBanner": {

--- a/apps/web/src/locales/it.json
+++ b/apps/web/src/locales/it.json
@@ -842,6 +842,16 @@
     }
   },
   "legal": {
+    "hub": {
+      "title": "Note Legali",
+      "description": "Tutti i documenti legali e le policy di MeepleAI in un unico posto.",
+      "sections": {
+        "documents": {
+          "title": "Documenti legali",
+          "content": "- [Termini e Condizioni](/terms) — Le condizioni d'uso di MeepleAI, incluse le policy su intelligenza artificiale, copyright e contenuti degli utenti.\n- [Informativa sulla Privacy](/privacy) — Come raccogliamo, utilizziamo e proteggiamo i tuoi dati personali, in conformità al GDPR.\n- [Cookie Policy](/cookies) — I cookie che utilizziamo e come gestire le tue preferenze.\n- [Richiesta di rimozione](/legal/takedown) — Come segnalare contenuti che ritieni violino il tuo copyright."
+        }
+      }
+    },
     "tableOfContents": "Indice",
     "lastUpdated": "Ultimo aggiornamento: {date}",
     "cookieBanner": {


### PR DESCRIPTION
## Contesto

Dal triage TODO/FIXME dell'umbrella **#564**, la route `/legal` era uno stub *"Coming Soon"* che dopo 2s reindirizzava a `/terms` (via `useRouter`). `docs/superpowers/specs/route-gap-analysis.md` la classifica **priority: high** e ne raccomanda la promozione a hub — *"the two sub-pages already exist"*.

## Cosa cambia

Promuove il placeholder a un **hub legale reale** che linka a tutti i documenti legali esistenti:

- **i18n** `legal.hub` (IT/EN) con una sezione `documents` che elenca **Terms, Privacy, Cookies, Takedown** come link markdown.
- **`LegalPageLayout`**: esteso `LegalPageKey` + `PAGE_PATHS` con `hub → /legal`, così la pagina riusa l'intero layout condiviso (toggle IT/EN, JSON-LD structured data, breadcrumb, SEO).
- **`legal/page.tsx`**: rimosso il redirect `useRouter` + il `// TODO`, esportato `metadata` SEO, reso `<LegalPageLayout pageKey="hub" />`.

Nessun contenuto nuovo di documenti legali: l'hub è pura navigazione verso pagine già esistenti (`/terms`, `/privacy`, `/cookies`, `/legal/takedown`).

## Approccio (TDD)

- Nuovo test render pagina (`legal/__tests__/page.test.tsx`): heading hub + i 4 link ai documenti + assenza del vecchio "Coming Soon".
- Esteso `i18n-legal-keys.test.ts` per coprire la sezione hub + i metadata (IT/EN parity).

## Verifica

- ✅ Test hub page: 4/4
- ✅ Suite legal completa: **190/190** (nessuna regressione dal layout condiviso)
- ✅ ESLint: 0 errori · ✅ `tsc --noEmit`: 0 errori

Closes parziale di #564 (un TODO route-gap eliminato).

🤖 Generated with [Claude Code](https://claude.com/claude-code)