### PR TITLE
feat(rag): SP2 heading-aware hierarchical chunking wired into 4 pipelines + persistence (#3268)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/CompleteChunkedUploadCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/CompleteChunkedUploadCommandHandler.cs
@@ -1,8 +1,10 @@
 using Api.BoundedContexts.DocumentProcessing.Application.DTOs;
 using Api.BoundedContexts.DocumentProcessing.Application.Services;
+using Api.BoundedContexts.DocumentProcessing.Application.Services.Chunking;
 using Api.BoundedContexts.DocumentProcessing.Domain.Entities;
 using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
 using Api.BoundedContexts.DocumentProcessing.Domain.Repositories;
+using Api.BoundedContexts.DocumentProcessing.Domain.Services;
 using Api.BoundedContexts.DocumentProcessing.Domain.ValueObjects;
 using Api.BoundedContexts.DocumentProcessing.Infrastructure.External;
 using Api.BoundedContexts.EntityRelationships.Application.Commands;
@@ -479,13 +481,13 @@ internal class CompleteChunkedUploadCommandHandler : ICommandHandler<CompleteChu
             _logger.LogInformation("Starting PDF processing for chunked upload: {PdfId}", pdfId);
 
             // Step 1: Extract PDF text and structured content
-            var (extractSuccess, fullText, totalPages) = await ExtractPdfTextAsync(
+            var (extractSuccess, fullText, totalPages, structuredElements) = await ExtractPdfTextAsync(
                 pdfId, filePath, pdfDoc, db, scope, cancellationToken).ConfigureAwait(false);
             if (!extractSuccess) return;
 
             // Step 2: Chunk text for embedding
             var allDocumentChunks = await ChunkTextContentAsync(
-                pdfId, fullText!, scope).ConfigureAwait(false);
+                pdfId, fullText!, structuredElements, pdfGuid, pdfDoc.PrivateGameId ?? pdfDoc.SharedGameId, scope).ConfigureAwait(false);
 
             // Guard: zero usable chunks → mark Failed. Mirrors PdfProcessingPipelineService
             // (the non-chunked Quartz path) which fails on chunks.Count == 0. Without this,
@@ -562,7 +564,7 @@ internal class CompleteChunkedUploadCommandHandler : ICommandHandler<CompleteChu
     /// <summary>
     /// Extracts text and structured content from PDF file.
     /// </summary>
-    private async Task<(bool success, string? fullText, int totalPages)> ExtractPdfTextAsync(
+    private async Task<(bool success, string? fullText, int totalPages, IReadOnlyList<ExtractedElement>? structuredElements)> ExtractPdfTextAsync(
         string pdfId,
         string filePath,
         PdfDocumentEntity pdfDoc,
@@ -596,10 +598,10 @@ internal class CompleteChunkedUploadCommandHandler : ICommandHandler<CompleteChu
                     _logger.LogWarning(ex,
                         "Concurrency conflict on PdfDocument {PdfId} in {Handler} (Category B) — admin mutation wins, pipeline will re-read on next tick",
                         pdfId, nameof(CompleteChunkedUploadCommandHandler));
-                    return (false, null, 0);
+                    return (false, null, 0, null);
                 }
                 _logger.LogError("Text extraction failed for {PdfId}: {Error}", pdfId, extractResult.ErrorMessage);
-                return (false, null, 0);
+                return (false, null, 0, null);
             }
 
             var fullText = string.Join("\n\n", extractResult.PageChunks
@@ -607,6 +609,7 @@ internal class CompleteChunkedUploadCommandHandler : ICommandHandler<CompleteChu
                 .Select(pc => pc.Text));
 
             pdfDoc.ExtractedText = fullText;
+            pdfDoc.StructuredElementsJson = StructuredElementsPayload.Serialize(extractResult.StructuredElements);
             pdfDoc.PageCount = extractResult.TotalPages;
             pdfDoc.CharacterCount = extractResult.TotalCharacters;
             try
@@ -621,13 +624,13 @@ internal class CompleteChunkedUploadCommandHandler : ICommandHandler<CompleteChu
                 _logger.LogWarning(ex,
                     "Concurrency conflict on PdfDocument {PdfId} in {Handler} (Category B) — admin mutation wins, pipeline will re-read on next tick",
                     pdfId, nameof(CompleteChunkedUploadCommandHandler));
-                return (true, fullText, extractResult.TotalPages);
+                return (true, fullText, extractResult.TotalPages, extractResult.StructuredElements);
             }
 
             // Extract structured content (tables, diagrams)
             await ExtractStructuredContentAsync(filePath, pdfDoc, db, scope, cancellationToken).ConfigureAwait(false);
 
-            return (true, fullText, extractResult.TotalPages);
+            return (true, fullText, extractResult.TotalPages, extractResult.StructuredElements);
         }
     }
 
@@ -680,38 +683,42 @@ internal class CompleteChunkedUploadCommandHandler : ICommandHandler<CompleteChu
     /// Chunks extracted text into document chunks for embedding.
     /// </summary>
     private async Task<List<DocumentChunkInput>> ChunkTextContentAsync(
-        string pdfId,
-        string fullText,
-                IServiceScope scope
-        )
-
+        string pdfId, string fullText, IReadOnlyList<ExtractedElement>? structuredElements,
+        Guid documentId, Guid? gameId, IServiceScope scope)
     {
         var chunkingStopwatch = Stopwatch.StartNew();
+
+        var headingAwareChunker = scope.ServiceProvider.GetService<IHeadingAwareChunker>();
+        if (headingAwareChunker != null)
+        {
+            var hc = await headingAwareChunker.ChunkAsync(documentId, gameId, structuredElements, fullText, CancellationToken.None).ConfigureAwait(false);
+            var filtered = hc.Where(c => c != null && !string.IsNullOrWhiteSpace(c.Text)).ToList();
+            if (filtered.Count > 0)
+            {
+                chunkingStopwatch.Stop();
+                _logger.LogDebug("Chunking completed in {ElapsedMs}ms, {ChunkCount} chunks for {PdfId} (heading-aware)",
+                    chunkingStopwatch.ElapsedMilliseconds, filtered.Count, pdfId);
+                return filtered;
+            }
+        }
+
+        // Flat fallback (unchanged from the original ChunkTextContentAsync body).
         var chunkingService = scope.ServiceProvider.GetRequiredService<ITextChunkingService>();
         const int chunkSize = 512;
         const int chunkOverlap = 50;
-
         var allDocumentChunks = chunkingService.PrepareForEmbedding(fullText, chunkSize, chunkOverlap)
             ?.Where(chunk => chunk != null && !string.IsNullOrWhiteSpace(chunk.Text))
-            .Select(chunk => new DocumentChunkInput
-            {
-                Text = chunk.Text,
-                Page = chunk.Page,
-                CharStart = chunk.CharStart,
-                CharEnd = chunk.CharEnd
-            })
+            .Select(chunk => new DocumentChunkInput { Text = chunk.Text, Page = chunk.Page, CharStart = chunk.CharStart, CharEnd = chunk.CharEnd })
             .ToList()
             ?? new List<DocumentChunkInput>();
 
-        allDocumentChunks = allDocumentChunks
-            .Where(chunk => chunk != null && !string.IsNullOrWhiteSpace(chunk.Text))
-            .ToList();
+        allDocumentChunks = allDocumentChunks.Where(chunk => chunk != null && !string.IsNullOrWhiteSpace(chunk.Text)).ToList();
 
         chunkingStopwatch.Stop();
         _logger.LogDebug("Chunking completed in {ElapsedMs}ms, {ChunkCount} chunks for {PdfId}",
             chunkingStopwatch.ElapsedMilliseconds, allDocumentChunks.Count, pdfId);
 
-        return await Task.FromResult(allDocumentChunks).ConfigureAwait(false);
+        return allDocumentChunks;
     }
 
     /// <summary>

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/CompleteChunkedUploadCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/CompleteChunkedUploadCommandHandler.cs
@@ -608,6 +608,14 @@ internal class CompleteChunkedUploadCommandHandler : ICommandHandler<CompleteChu
                 .Where(pc => !pc.IsEmpty)
                 .Select(pc => pc.Text));
 
+            // SP2 #3268: this persists ExtractedText/StructuredElementsJson correctly ONLY
+            // because pdfDoc is a tracked entity (loaded via FindAsync) whose ProcessingState
+            // is mutated directly — never routed through IPdfDocumentRepository. If this handler
+            // is ever migrated to repository-routed state transitions — as UploadPdf was in
+            // #2284 — MapToPersistence's full-row Update() will silently null these columns and
+            // this write will regress with NO safety net. UploadPdf needed the dedicated
+            // post-Ready tracked re-write (see UploadPdfCommandHandler.Processing.cs
+            // FinalizeProcessingAsync) for exactly this reason; add the equivalent here first.
             pdfDoc.ExtractedText = fullText;
             pdfDoc.StructuredElementsJson = StructuredElementsPayload.Serialize(extractResult.StructuredElements);
             pdfDoc.PageCount = extractResult.TotalPages;

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/ExtractPdfTextCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/ExtractPdfTextCommandHandler.cs
@@ -1,6 +1,7 @@
 using Api.BoundedContexts.DocumentProcessing.Application.Commands;
 using Api.BoundedContexts.DocumentProcessing.Application.DTOs;
 using Api.BoundedContexts.DocumentProcessing.Application.Services;
+using Api.BoundedContexts.DocumentProcessing.Application.Services.Chunking;
 using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
 using Api.BoundedContexts.DocumentProcessing.Infrastructure.External;
 using Api.Infrastructure;
@@ -132,6 +133,7 @@ internal class ExtractPdfTextCommandHandler : ICommandHandler<ExtractPdfTextComm
                 pdfId, extractResult.TotalCharacters, extractResult.TotalPages);
 
             pdf.ExtractedText = fullText;
+            pdf.StructuredElementsJson = StructuredElementsPayload.Serialize(extractResult.StructuredElements);
             pdf.PageCount = extractResult.TotalPages;
             pdf.CharacterCount = extractResult.TotalCharacters;
             pdf.ProcessingState = nameof(PdfProcessingState.Ready);

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/IndexPdfCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/IndexPdfCommandHandler.cs
@@ -1,6 +1,7 @@
 using Api.BoundedContexts.DocumentProcessing.Application.Commands;
 using Api.BoundedContexts.DocumentProcessing.Application.DTOs;
 using Api.BoundedContexts.DocumentProcessing.Application.Services;
+using Api.BoundedContexts.DocumentProcessing.Application.Services.Chunking;
 using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
 using Api.BoundedContexts.KnowledgeBase.Application.Services;
 using Api.Configuration;
@@ -39,6 +40,11 @@ internal class IndexPdfCommandHandler : ICommandHandler<IndexPdfCommand, Indexin
     // Optional so unit tests that pre-date Phase D continue to compile without updates.
     private readonly IRoleClassifierService? _roleClassifier;
     private readonly IPdfIndexingPipeline _pipeline;
+    // SP2 task 7 (#3268): optional heading-aware chunker. IndexPdf only has the flat
+    // pdf.ExtractedText — StructuredElementsJson (persisted at extraction time) is
+    // rehydrated into ExtractedElements so hierarchy-aware chunking can run here too.
+    // Optional so unit tests that pre-date SP2 continue to compile without updates.
+    private readonly IHeadingAwareChunker? _headingAwareChunker;
 
     public IndexPdfCommandHandler(
         MeepleAiDbContext db,
@@ -49,7 +55,8 @@ internal class IndexPdfCommandHandler : ICommandHandler<IndexPdfCommand, Indexin
         ISemanticResponseCache semanticCache,
         IPdfIndexingPipeline pipeline,
         TimeProvider? timeProvider = null,
-        IRoleClassifierService? roleClassifier = null)
+        IRoleClassifierService? roleClassifier = null,
+        IHeadingAwareChunker? headingAwareChunker = null)
     {
         _db = db ?? throw new ArgumentNullException(nameof(db));
         _chunkingService = chunkingService ?? throw new ArgumentNullException(nameof(chunkingService));
@@ -60,6 +67,7 @@ internal class IndexPdfCommandHandler : ICommandHandler<IndexPdfCommand, Indexin
         _pipeline = pipeline ?? throw new ArgumentNullException(nameof(pipeline));
         _timeProvider = timeProvider ?? TimeProvider.System;
         _roleClassifier = roleClassifier;
+        _headingAwareChunker = headingAwareChunker;
     }
 
     public async Task<IndexingResultDto> Handle(IndexPdfCommand command, CancellationToken cancellationToken)
@@ -98,7 +106,7 @@ internal class IndexPdfCommandHandler : ICommandHandler<IndexPdfCommand, Indexin
 
             // Step 2: Chunk text and generate embeddings
             var (chunkingSuccess, documentChunks, chunkingError, chunkErrorCode) = await ChunkAndEmbedTextAsync(
-                pdfId, pdf.ExtractedText!, cancellationToken).ConfigureAwait(false);
+                pdfId, pdf, cancellationToken).ConfigureAwait(false);
             if (!chunkingSuccess)
             {
                 pdf.ProcessingState = nameof(PdfProcessingState.Failed);
@@ -322,40 +330,54 @@ internal class IndexPdfCommandHandler : ICommandHandler<IndexPdfCommand, Indexin
     /// </summary>
     private async Task<(bool success, List<DocumentChunk>? documentChunks, string? errorMessage, PdfIndexingErrorCode? errorCode)> ChunkAndEmbedTextAsync(
         string pdfId,
-        string extractedText,
-                CancellationToken cancellationToken)
+        PdfDocumentEntity pdf,
+        CancellationToken cancellationToken)
     {
+        var extractedText = pdf.ExtractedText!;
+
         // Chunk the text
         _logger.LogInformation("Chunking text for PDF {PdfId} ({CharCount} characters)",
             pdfId, extractedText.Length);
 
-        var textChunks = _chunkingService.ChunkText(extractedText);
+        // SP2 task 7 (#3268): IndexPdf only has the flat ExtractedText — rehydrate the
+        // persisted StructuredElementsJson (written at extraction time) so the heading-aware
+        // chunker can rebuild hierarchy-aware chunks. Malformed/legacy JSON degrades to null
+        // (TryDeserialize never throws), which falls through to the flat path below.
+        var structured = StructuredElementsPayload.TryDeserialize(pdf.StructuredElementsJson);
+        List<DocumentChunkInput> chunkInputs =
+            (_headingAwareChunker != null
+                ? await _headingAwareChunker.ChunkAsync(Guid.Parse(pdfId), pdf.PrivateGameId ?? pdf.SharedGameId, structured, extractedText, cancellationToken).ConfigureAwait(false)
+                : null) is { Count: > 0 } hc
+            ? hc
+            : (_chunkingService.PrepareForEmbedding(extractedText) ?? new List<DocumentChunkInput>());
 
-        if (textChunks.Count == 0)
+        chunkInputs = chunkInputs.Where(c => c != null && !string.IsNullOrWhiteSpace(c.Text)).ToList();
+
+        if (chunkInputs.Count == 0)
         {
             _logger.LogWarning("No chunks created for PDF {PdfId}", pdfId);
             return (false, null, "No chunks created from text", PdfIndexingErrorCode.ChunkingFailed);
         }
 
-        _logger.LogInformation("Created {ChunkCount} chunks for PDF {PdfId}", textChunks.Count, pdfId);
+        _logger.LogInformation("Created {ChunkCount} chunks for PDF {PdfId}", chunkInputs.Count, pdfId);
 
         // Generate embeddings in batches to reduce memory footprint
         var embeddingBatchSize = _indexingSettings.EmbeddingBatchSize;
-        var documentChunks = new List<DocumentChunk>(textChunks.Count);
+        var documentChunks = new List<DocumentChunk>(chunkInputs.Count);
 
         _logger.LogInformation("Generating embeddings for {ChunkCount} chunks in batches of {BatchSize}",
-            textChunks.Count, embeddingBatchSize);
+            chunkInputs.Count, embeddingBatchSize);
 
-        for (int i = 0; i < textChunks.Count; i += embeddingBatchSize)
+        for (int i = 0; i < chunkInputs.Count; i += embeddingBatchSize)
         {
-            var batchSize = Math.Min(embeddingBatchSize, textChunks.Count - i);
+            var batchSize = Math.Min(embeddingBatchSize, chunkInputs.Count - i);
 
             _logger.LogDebug("Processing embedding batch {BatchNumber}/{TotalBatches} ({BatchSize} chunks)",
                 (i / embeddingBatchSize) + 1,
-                (int)Math.Ceiling((double)textChunks.Count / embeddingBatchSize),
+                (int)Math.Ceiling((double)chunkInputs.Count / embeddingBatchSize),
                 batchSize);
 
-            var texts = textChunks.Skip(i).Take(batchSize).Select(c => c.Text).ToList();
+            var texts = chunkInputs.Skip(i).Take(batchSize).Select(c => c.Text).ToList();
             var embeddingResult = await _embeddingService.GenerateEmbeddingsAsync(texts, cancellationToken).ConfigureAwait(false);
 
             if (!embeddingResult.Success || embeddingResult.Embeddings.Count == 0)
@@ -372,25 +394,28 @@ internal class IndexPdfCommandHandler : ICommandHandler<IndexPdfCommand, Indexin
                 return (false, null, "Embedding count mismatch", PdfIndexingErrorCode.EmbeddingFailed);
             }
 
-            // Issue #730 / spec §5.3 forward-wiring: hierarchy fields (Heading, Level, ParentChunkId, ElementType)
-            // are intentionally not mapped here because the basic ITextChunkingService.ChunkText path does not
-            // produce them. When AdvancedChunkingService is integrated upstream, propagate from the source TextChunk.
-            // Prepare document chunks with embeddings
-            var batchChunks = textChunks.Skip(i).Take(batchSize)
+            // Issue #730 / SP2 task 7: hierarchy fields (Heading, Level, ParentChunkId, ElementType) are
+            // carried from DocumentChunkInput for both paths — the heading-aware chunker populates them,
+            // the flat PrepareForEmbedding path leaves them at their DocumentChunkInput defaults (null/1/null/"NarrativeText").
+            var batchChunks = chunkInputs.Skip(i).Take(batchSize)
                 .Select((chunk, index) => new DocumentChunk
                 {
                     Text = chunk.Text,
                     Embedding = embeddingResult.Embeddings[index],
                     Page = chunk.Page,
                     CharStart = chunk.CharStart,
-                    CharEnd = chunk.CharEnd
+                    CharEnd = chunk.CharEnd,
+                    Heading = chunk.Heading,
+                    Level = chunk.Level,
+                    ParentChunkId = chunk.ParentChunkId,
+                    ElementType = chunk.ElementType,
                 })
                 .ToList();
 
             documentChunks.AddRange(batchChunks);
 
             _logger.LogDebug("Completed batch {BatchNumber}, total chunks processed: {ProcessedCount}/{TotalCount}",
-                (i / embeddingBatchSize) + 1, documentChunks.Count, textChunks.Count);
+                (i / embeddingBatchSize) + 1, documentChunks.Count, chunkInputs.Count);
         }
 
         return (true, documentChunks, null, null);

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommandHandler.Processing.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommandHandler.Processing.cs
@@ -907,6 +907,16 @@ internal partial class UploadPdfCommandHandler
 
         try
         {
+            // SP2 #3268 WARNING: this Ready save raises KbDocIndexedEvent + PdfStateChangedEvent
+            // (dispatched synchronously during SaveChangesAsync), but ExtractedText/
+            // StructuredElementsJson are still NULL in the DB at this point — the tracked
+            // re-write that restores them runs AFTER this block (see below). No Ready/
+            // KbDocIndexed handler may read ExtractedText or re-index from StructuredElementsJson,
+            // or it will silently see null and produce flat, heading-less chunks. RAG data is
+            // already correct here because text_chunks + pgvector were persisted earlier in
+            // IndexInVectorStoreAsync. The write must stay after Ready because the repository's
+            // MapToPersistence full-row Update() clobbers these unmapped columns on every
+            // transition; the durable long-term fix is to make MapToPersistence carry them.
             pdfDomain.TransitionTo(PdfProcessingState.Ready);
             pdfDomain.MarkProcessed(_timeProvider.GetUtcNow().UtcDateTime);
             await pdfRepo.UpdateAsync(pdfDomain, cancellationToken).ConfigureAwait(false);

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommandHandler.Processing.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommandHandler.Processing.cs
@@ -923,6 +923,38 @@ internal partial class UploadPdfCommandHandler
             return;
         }
 
+        // SP2 #3268: the pipeline's working pdfDoc is AsNoTracking and state transitions route
+        // through the repository (MapToPersistence omits these columns), so extraction output
+        // written during ExtractPdfContentAsync/ExtractStructuredContentAsync never persists.
+        // Re-persist it here on a freshly TRACKED entity AFTER the final Ready transition,
+        // mirroring ExtractPdfTextCommandHandler's tracked-write pattern, so no later
+        // transition can clobber it.
+        var tracked = await db.PdfDocuments.AsTracking()
+            .FirstOrDefaultAsync(p => p.Id == pdfGuid, cancellationToken).ConfigureAwait(false);
+        if (tracked != null)
+        {
+            tracked.ExtractedText = pdfDoc.ExtractedText;
+            tracked.StructuredElementsJson = pdfDoc.StructuredElementsJson;
+            tracked.PageCount = pdfDoc.PageCount;
+            tracked.CharacterCount = pdfDoc.CharacterCount;
+            tracked.ExtractedTables = pdfDoc.ExtractedTables;
+            tracked.ExtractedDiagrams = pdfDoc.ExtractedDiagrams;
+            tracked.AtomicRules = pdfDoc.AtomicRules;
+            tracked.TableCount = pdfDoc.TableCount;
+            tracked.DiagramCount = pdfDoc.DiagramCount;
+            tracked.AtomicRuleCount = pdfDoc.AtomicRuleCount;
+            try
+            {
+                await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (DbUpdateConcurrencyException ex)
+            {
+                _logger.LogWarning(ex,
+                    "Concurrency conflict persisting extraction output for PDF {PdfId} — admin mutation wins",
+                    pdfId);
+            }
+        }
+
         // #2284 PR C: tactical scopedMediator.Publish(PdfStateChangedEvent) deleted.
         // PdfDocument.TransitionTo(Ready) raises BOTH PdfStateChangedEvent AND
         // KbDocIndexedEvent structurally; the repository's UpdateAsync collects them via

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommandHandler.Processing.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommandHandler.Processing.cs
@@ -1,4 +1,5 @@
 using Api.BoundedContexts.DocumentProcessing.Application.Services;
+using Api.BoundedContexts.DocumentProcessing.Application.Services.Chunking;
 using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
 using Api.BoundedContexts.KnowledgeBase.Application.Services;
 using Api.BoundedContexts.DocumentProcessing.Domain.Events;
@@ -66,7 +67,8 @@ internal partial class UploadPdfCommandHandler
             // Step 2: Chunk text with page tracking (40-60%)
             _logger.LogInformation("✂️ [PDF-DEBUG] Step 2: Starting ChunkExtractedTextAsync for {PdfId}", pdfId);
             var allDocumentChunks = await ChunkExtractedTextAsync(
-                pdfId, fullText!, extractResult!, db, scope, startTime, cancellationToken).ConfigureAwait(false);
+                pdfId, fullText!, extractResult!, pdfDoc.PrivateGameId ?? pdfDoc.SharedGameId,
+                db, scope, startTime, cancellationToken).ConfigureAwait(false);
             _logger.LogInformation("✅ [PDF-DEBUG] Chunking SUCCESS: {ChunkCount} chunks created", allDocumentChunks.Count);
 
             await TransitionStateAsync(scope, db, pdfGuid, PdfProcessingState.Embedding, cancellationToken).ConfigureAwait(false);
@@ -258,6 +260,7 @@ internal partial class UploadPdfCommandHandler
                 .Select(pc => pc.Text));
 
             pdfDoc.ExtractedText = fullText;
+            pdfDoc.StructuredElementsJson = StructuredElementsPayload.Serialize(extractResult.StructuredElements);
             pdfDoc.PageCount = extractResult.TotalPages;
             pdfDoc.CharacterCount = extractResult.TotalCharacters;
             try
@@ -338,6 +341,7 @@ internal partial class UploadPdfCommandHandler
         string pdfId,
         string fullText,
         PagedTextExtractionResult extractResult,
+        Guid? gameId,
         MeepleAiDbContext db,
         IServiceScope scope,
         DateTime startTime,
@@ -346,37 +350,41 @@ internal partial class UploadPdfCommandHandler
         await UpdateProgressAsync(db, pdfId, ProcessingStep.Chunking, 0, extractResult.TotalPages, startTime, null, cancellationToken).ConfigureAwait(false);
 
         var chunkingStopwatch = Stopwatch.StartNew();
-        var chunkingService = scope.ServiceProvider.GetRequiredService<ITextChunkingService>();
-        const int chunkSize = 512;
-        const int chunkOverlap = 50;
+        var headingAwareChunker = scope.ServiceProvider.GetService<IHeadingAwareChunker>();
 
-        var allDocumentChunks = chunkingService.PrepareForEmbedding(fullText, chunkSize, chunkOverlap)
-            ?.Where(chunk => chunk != null && !string.IsNullOrWhiteSpace(chunk.Text))
-            .Select(chunk => new DocumentChunkInput
-            {
-                Text = chunk.Text,
-                Page = chunk.Page,
-                CharStart = chunk.CharStart,
-                CharEnd = chunk.CharEnd
-            })
-            .ToList()
-            ?? new List<DocumentChunkInput>();
-
-        if (allDocumentChunks.Count == 0)
+        List<DocumentChunkInput> allDocumentChunks;
+        if (headingAwareChunker != null)
         {
-            foreach (var pageChunk in extractResult.PageChunks.Where(pc => !pc.IsEmpty))
-            {
-                var pageTextChunks = chunkingService.ChunkText(pageChunk.Text, chunkSize, chunkOverlap);
+            allDocumentChunks = await headingAwareChunker.ChunkAsync(
+                Guid.Parse(pdfId), gameId, extractResult.StructuredElements, fullText, cancellationToken).ConfigureAwait(false);
+        }
+        else
+        {
+            var chunkingService = scope.ServiceProvider.GetRequiredService<ITextChunkingService>();
+            const int chunkSize = 512;
+            const int chunkOverlap = 50;
+            allDocumentChunks = chunkingService.PrepareForEmbedding(fullText, chunkSize, chunkOverlap)
+                ?.Where(chunk => chunk != null && !string.IsNullOrWhiteSpace(chunk.Text))
+                .Select(chunk => new DocumentChunkInput { Text = chunk.Text, Page = chunk.Page, CharStart = chunk.CharStart, CharEnd = chunk.CharEnd })
+                .ToList()
+                ?? new List<DocumentChunkInput>();
 
-                foreach (var textChunk in pageTextChunks.Where(t => !string.IsNullOrWhiteSpace(t.Text)))
+            if (allDocumentChunks.Count == 0)
+            {
+                foreach (var pageChunk in extractResult.PageChunks.Where(pc => !pc.IsEmpty))
                 {
-                    allDocumentChunks.Add(new DocumentChunkInput
+                    var pageTextChunks = chunkingService.ChunkText(pageChunk.Text, chunkSize, chunkOverlap);
+
+                    foreach (var textChunk in pageTextChunks.Where(t => !string.IsNullOrWhiteSpace(t.Text)))
                     {
-                        Text = textChunk.Text,
-                        Page = pageChunk.PageNumber,
-                        CharStart = textChunk.CharStart,
-                        CharEnd = textChunk.CharEnd
-                    });
+                        allDocumentChunks.Add(new DocumentChunkInput
+                        {
+                            Text = textChunk.Text,
+                            Page = pageChunk.PageNumber,
+                            CharStart = textChunk.CharStart,
+                            CharEnd = textChunk.CharEnd
+                        });
+                    }
                 }
             }
         }

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/Chunking/HierarchicalChunkMapper.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/Chunking/HierarchicalChunkMapper.cs
@@ -1,0 +1,50 @@
+using Api.BoundedContexts.KnowledgeBase.Domain.Chunking;
+using Api.Services;
+
+namespace Api.BoundedContexts.DocumentProcessing.Application.Services.Chunking;
+
+/// <summary>
+/// SP2: maps AdvancedChunkingService output to embeddable inputs, keeping ONLY child chunks
+/// (Level 2). Heading is already inherited from the parent section in the child's ChunkMetadata.
+/// Parent (Level 0) chunks are not persisted; ParentChunkId is left null (only-child model).
+/// </summary>
+internal static class HierarchicalChunkMapper
+{
+    public static List<DocumentChunkInput> ToChildDocumentChunks(IReadOnlyList<HierarchicalChunk> chunks)
+    {
+        var result = new List<DocumentChunkInput>();
+        if (chunks is null)
+        {
+            return result;
+        }
+
+        foreach (var c in chunks)
+        {
+            if (c.IsRoot)
+            {
+                continue; // parent/section container is not persisted
+            }
+            if (string.IsNullOrWhiteSpace(c.Content))
+            {
+                continue;
+            }
+
+            result.Add(new DocumentChunkInput
+            {
+                Text = c.Content,
+                // Recompute per-child page from CharStart (~2000 chars/page, matching
+                // TextChunkingService.EstimatePageNumber) so a multi-page section does not collapse
+                // every child to the section's first page. Falls back to the section page for offset 0.
+                Page = c.Metadata.CharStart > 0 ? (c.Metadata.CharStart / 2000) + 1 : c.Metadata.Page,
+                CharStart = c.Metadata.CharStart,
+                CharEnd = c.Metadata.CharEnd,
+                Heading = c.Metadata.Heading,
+                Level = 2,
+                ParentChunkId = null,
+                ElementType = string.IsNullOrWhiteSpace(c.Metadata.ElementType) ? "text" : c.Metadata.ElementType,
+            });
+        }
+
+        return result;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/Chunking/IHeadingAwareChunker.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/Chunking/IHeadingAwareChunker.cs
@@ -1,0 +1,85 @@
+using Api.BoundedContexts.DocumentProcessing.Domain.Services;
+using Api.BoundedContexts.KnowledgeBase.Application.Services.Chunking;
+using Api.Constants;
+using Api.Services;
+
+#pragma warning disable MA0048 // File name must match type name — interface + impl together
+namespace Api.BoundedContexts.DocumentProcessing.Application.Services.Chunking;
+
+internal interface IHeadingAwareChunker
+{
+    Task<List<DocumentChunkInput>> ChunkAsync(
+        Guid documentId,
+        Guid? gameId,
+        IReadOnlyList<ExtractedElement>? structuredElements,
+        string fullText,
+        CancellationToken ct);
+}
+
+/// <summary>
+/// SP2: chains the heading-aware chunking pipeline — ExtractedDocumentFactory (SP1) builds
+/// heading-scoped sections, AdvancedChunkingService (auto-strategy) chunks them hierarchically,
+/// HierarchicalChunkMapper (SP2 task 1) flattens to embeddable children, and a post-split pass
+/// re-splits any child exceeding MaxEmbeddingChars — the Sparse strategy can emit ~2000-char
+/// children that would otherwise be silently truncated at embedding time.
+/// </summary>
+internal sealed class HeadingAwareChunker : IHeadingAwareChunker
+{
+    private readonly IAdvancedChunkingService _advanced;
+    private readonly ITextChunkingService _textChunking;
+    private readonly ILogger<HeadingAwareChunker> _logger;
+
+    public HeadingAwareChunker(
+        IAdvancedChunkingService advanced,
+        ITextChunkingService textChunking,
+        ILogger<HeadingAwareChunker> logger)
+    {
+        _advanced = advanced;
+        _textChunking = textChunking;
+        _logger = logger;
+    }
+
+    public async Task<List<DocumentChunkInput>> ChunkAsync(
+        Guid documentId, Guid? gameId,
+        IReadOnlyList<ExtractedElement>? structuredElements,
+        string fullText, CancellationToken ct)
+    {
+        var document = ExtractedDocumentFactory.FromExtraction(documentId, gameId, structuredElements, fullText ?? string.Empty);
+        var hchunks = await _advanced.ChunkDocumentAsync(document, config: null, ct).ConfigureAwait(false);
+        var mapped = HierarchicalChunkMapper.ToChildDocumentChunks(hchunks);
+        var result = PostSplitOversized(mapped);
+
+        _logger.LogDebug(
+            "HeadingAwareChunker produced {ChunkCount} children for document {DocumentId} ({SectionCount} sections)",
+            result.Count, documentId, document.Sections.Count);
+
+        return result;
+    }
+
+    // Mirror of EnhancedPdfProcessingOrchestrator.SplitOversizedPageChunks: no embedded chunk may exceed
+    // MaxEmbeddingChars (E5-base token limit); Sparse strategy can emit ~2000-char children.
+    private List<DocumentChunkInput> PostSplitOversized(List<DocumentChunkInput> chunks)
+    {
+        var result = new List<DocumentChunkInput>(chunks.Count);
+        foreach (var chunk in chunks)
+        {
+            if (chunk.Text.Length <= ChunkingConstants.MaxEmbeddingChars)
+            {
+                result.Add(chunk);
+                continue;
+            }
+
+            var subs = _textChunking.ChunkText(chunk.Text, ChunkingConstants.MaxEmbeddingChars, ChunkingConstants.DefaultChunkOverlap);
+            foreach (var sub in subs.Where(s => !string.IsNullOrWhiteSpace(s.Text)))
+            {
+                result.Add(chunk with
+                {
+                    Text = sub.Text,
+                    CharStart = chunk.CharStart + sub.CharStart,
+                    CharEnd = chunk.CharStart + sub.CharEnd,
+                });
+            }
+        }
+        return result;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/Chunking/StructuredElementsPayload.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/Chunking/StructuredElementsPayload.cs
@@ -1,0 +1,49 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Api.BoundedContexts.DocumentProcessing.Domain.Services;
+
+namespace Api.BoundedContexts.DocumentProcessing.Application.Services.Chunking;
+
+/// <summary>
+/// Versioned, tolerant persistence of the raw extraction elements so IndexPdf (which only has flat
+/// ExtractedText) can rebuild the ExtractedDocument. Default JSON options (PascalCase) match the
+/// existing ExtractedTables/ExtractedDiagrams columns. Reads never throw — malformed/legacy blobs
+/// return null so the caller degrades to the flat null-path.
+/// </summary>
+internal static class StructuredElementsPayload
+{
+    private const int CurrentSchemaVersion = 1;
+
+    private static readonly JsonSerializerOptions Options = new()
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    private sealed record Envelope(int SchemaVersion, IReadOnlyList<ExtractedElement>? Elements);
+
+    public static string? Serialize(IReadOnlyList<ExtractedElement>? elements)
+    {
+        if (elements is null || elements.Count == 0)
+        {
+            return null;
+        }
+        return JsonSerializer.Serialize(new Envelope(CurrentSchemaVersion, elements), Options);
+    }
+
+    public static IReadOnlyList<ExtractedElement>? TryDeserialize(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return null;
+        }
+        try
+        {
+            var env = JsonSerializer.Deserialize<Envelope>(json, Options);
+            return env?.Elements is { Count: > 0 } ? env.Elements : null;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/Chunking/TranslatedChunkMapper.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/Chunking/TranslatedChunkMapper.cs
@@ -1,0 +1,14 @@
+using Api.Services;
+
+namespace Api.BoundedContexts.DocumentProcessing.Application.Services.Chunking;
+
+/// <summary>
+/// SP2: builds the English-translation chunk from an original chunk, preserving all hierarchy
+/// fields (Heading/Level/ParentChunkId/ElementType) so translated chunks of non-EN rulebooks also
+/// activate the role fast-path (resolves the #730 forward-wiring follow-up in PdfProcessingPipelineService).
+/// </summary>
+internal static class TranslatedChunkMapper
+{
+    public static DocumentChunkInput ForTranslation(DocumentChunkInput orig, string translatedText) =>
+        orig with { Text = translatedText };
+}

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs
@@ -1,3 +1,4 @@
+using Api.BoundedContexts.DocumentProcessing.Application.Services.Chunking;
 using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
 using Api.BoundedContexts.DocumentProcessing.Domain.Events;
 using Api.BoundedContexts.DocumentProcessing.Infrastructure.External;
@@ -63,6 +64,11 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
 
     private readonly IPdfIndexingPipeline _indexingPipeline;
 
+    // SP2 (#3268 task 5): optional heading-aware chunker — prefers hierarchical chunking
+    // (heading-scoped sections → child chunks) over the flat fallback below. Nullable so
+    // pre-SP2 unit-test constructors continue to compile without adding a new mock param.
+    private readonly IHeadingAwareChunker? _headingAwareChunker;
+
     public PdfProcessingPipelineService(
         MeepleAiDbContext db,
         IPdfClaimService pdfClaimService,
@@ -83,7 +89,8 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
         IRoleClassifierService? roleClassifier = null,
         IPdfCoverExtractor? pdfCoverExtractor = null,
         IDomainEventCollector? eventCollector = null,
-        IPdfCoverUploadPipeline? pdfCoverUploadPipeline = null)
+        IPdfCoverUploadPipeline? pdfCoverUploadPipeline = null,
+        IHeadingAwareChunker? headingAwareChunker = null)
     {
         _db = db ?? throw new ArgumentNullException(nameof(db));
         _pdfClaimService = pdfClaimService ?? throw new ArgumentNullException(nameof(pdfClaimService));
@@ -108,6 +115,7 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
         // in ExtractCoverImageAsync is guarded with a null-check.
         _eventCollector = eventCollector;
         _pdfCoverUploadPipeline = pdfCoverUploadPipeline;
+        _headingAwareChunker = headingAwareChunker;
     }
 
     public async Task ProcessAsync(
@@ -188,7 +196,7 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
 
             // Step 3: Chunk text
             _logger.LogInformation("[PdfPipeline] Step 3/4: Chunking text for {PdfId} ({CharCount} chars)", pdfId, fullText.Length);
-            var chunks = ChunkText(fullText, extractResult);
+            var chunks = await ChunkTextAsync(fullText, extractResult, pdfDoc.Id, pdfDoc.PrivateGameId ?? pdfDoc.SharedGameId, cancellationToken).ConfigureAwait(false);
 
             if (chunks.Count == 0)
             {
@@ -222,17 +230,10 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
                         if (!string.IsNullOrWhiteSpace(t.TranslatedText))
                         {
                             var origChunk = chunks[t.OriginalIndex];
-                            // Issue #730 / spec §5.3 forward-wiring: hierarchy fields are not yet propagated from origChunk
-                            // to the translated chunk because the upstream chunking pipeline does not currently populate them.
-                            // Once AdvancedChunkingService is wired, copy origChunk.Heading/Level/ParentChunkId/ElementType here.
+                            // Issue #730 resolved (SP2 task 5): TranslatedChunkMapper preserves
+                            // Heading/Level/ParentChunkId/ElementType from origChunk on the EN translation.
                             translatedChunks.Add((
-                                new DocumentChunkInput
-                                {
-                                    Text = t.TranslatedText,
-                                    Page = origChunk.Page,
-                                    CharStart = origChunk.CharStart,
-                                    CharEnd = origChunk.CharEnd
-                                },
+                                TranslatedChunkMapper.ForTranslation(origChunk, t.TranslatedText),
                                 "en",
                                 true));
                         }
@@ -493,6 +494,7 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
                 .Select(pc => pc.Text));
 
             pdfDoc.ExtractedText = fullText;
+            pdfDoc.StructuredElementsJson = StructuredElementsPayload.Serialize(extractResult.StructuredElements);
             pdfDoc.PageCount = extractResult.TotalPages;
             pdfDoc.CharacterCount = extractResult.TotalCharacters;
             try
@@ -652,29 +654,29 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
 #pragma warning restore CA1031
     }
 
-    private List<DocumentChunkInput> ChunkText(string fullText, PagedTextExtractionResult extractResult)
+    private async Task<List<DocumentChunkInput>> ChunkTextAsync(string fullText, PagedTextExtractionResult extractResult, Guid documentId, Guid? gameId, CancellationToken ct)
     {
+        if (_headingAwareChunker != null)
+        {
+            var hc = await _headingAwareChunker.ChunkAsync(documentId, gameId, extractResult.StructuredElements, fullText, ct).ConfigureAwait(false);
+            var filtered = hc.Where(c => c != null && !string.IsNullOrWhiteSpace(c.Text)).ToList();
+            if (filtered.Count > 0) return filtered;
+        }
+
+        // Flat fallback (unchanged from the original ChunkText body: PrepareForEmbedding 1024/150 + page fallback).
         var chunks = _chunkingService.PrepareForEmbedding(fullText, ChunkSize, ChunkOverlap)
             ?.Where(c => c != null && !string.IsNullOrWhiteSpace(c.Text))
             .ToList()
             ?? [];
 
-        // Fallback: page-by-page chunking if whole-text chunking produced nothing
         if (chunks.Count == 0)
         {
             foreach (var pageChunk in extractResult.PageChunks.Where(pc => !pc.IsEmpty))
             {
                 var pageTextChunks = _chunkingService.ChunkText(pageChunk.Text, ChunkSize, ChunkOverlap);
-
                 foreach (var textChunk in pageTextChunks.Where(t => !string.IsNullOrWhiteSpace(t.Text)))
                 {
-                    chunks.Add(new DocumentChunkInput
-                    {
-                        Text = textChunk.Text,
-                        Page = pageChunk.PageNumber,
-                        CharStart = textChunk.CharStart,
-                        CharEnd = textChunk.CharEnd
-                    });
+                    chunks.Add(new DocumentChunkInput { Text = textChunk.Text, Page = pageChunk.PageNumber, CharStart = textChunk.CharStart, CharEnd = textChunk.CharEnd });
                 }
             }
         }

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs
@@ -493,6 +493,14 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
                 .Where(pc => !pc.IsEmpty)
                 .Select(pc => pc.Text));
 
+            // SP2 #3268: this persists ExtractedText/StructuredElementsJson correctly ONLY
+            // because pdfDoc is a tracked entity whose ProcessingState is mutated directly
+            // (never routed through IPdfDocumentRepository). If this handler is ever migrated
+            // to repository-routed state transitions — as UploadPdf was in #2284 —
+            // MapToPersistence's full-row Update() will silently null these columns and this
+            // write will regress with NO safety net. UploadPdf needed the dedicated post-Ready
+            // tracked re-write (see UploadPdfCommandHandler.Processing.cs FinalizeProcessingAsync)
+            // for exactly this reason; add the equivalent here before any such refactor.
             pdfDoc.ExtractedText = fullText;
             pdfDoc.StructuredElementsJson = StructuredElementsPayload.Serialize(extractResult.StructuredElements);
             pdfDoc.PageCount = extractResult.TotalPages;

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/DependencyInjection/DocumentProcessingServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/DependencyInjection/DocumentProcessingServiceExtensions.cs
@@ -1,4 +1,5 @@
 using Api.BoundedContexts.DocumentProcessing.Application.Services;
+using Api.BoundedContexts.DocumentProcessing.Application.Services.Chunking;
 using Api.BoundedContexts.DocumentProcessing.Domain.Repositories;
 using Api.BoundedContexts.DocumentProcessing.Domain.Services;
 using Api.BoundedContexts.DocumentProcessing.Infrastructure.Configuration;
@@ -87,6 +88,12 @@ internal static class DocumentProcessingServiceExtensions
 
         // RAG translation: LLM-based chunk translation for cross-language retrieval
         services.AddScoped<IChunkTranslationService, ChunkTranslationService>();
+
+        // SP2 (#3268 task 2): shared heading-aware chunking pipeline (ExtractedDocumentFactory →
+        // AdvancedChunkingService → HierarchicalChunkMapper → oversize post-split). Depends on
+        // IAdvancedChunkingService/ITextChunkingService already registered by the KnowledgeBase
+        // context DI (Application layer) — this context only wires the consumer.
+        services.AddScoped<IHeadingAwareChunker, HeadingAwareChunker>();
 
         // Infrastructure Adapters (scoped - may use file I/O)
         services.AddScoped<IPdfTableExtractor, ITextPdfTableExtractor>();

--- a/apps/api/src/Api/Infrastructure/Entities/DocumentProcessing/PdfDocumentEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/DocumentProcessing/PdfDocumentEntity.cs
@@ -53,6 +53,10 @@ public class PdfDocumentEntity
     public int? DiagramCount { get; set; }
     public int? AtomicRuleCount { get; set; }
 
+    // SP2 (#3268): raw extraction elements (versioned JSON) so IndexPdf can rebuild the
+    // ExtractedDocument for heading-aware chunking. Invariant: co-written or nulled with ExtractedText.
+    public string? StructuredElementsJson { get; set; }
+
     // PDF-08: Progress tracking
     public string? ProcessingProgressJson { get; set; }
 

--- a/apps/api/src/Api/Infrastructure/Migrations/20260721140803_AddStructuredElementsJson.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260721140803_AddStructuredElementsJson.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260721140803_AddStructuredElementsJson")]
+    partial class AddStructuredElementsJson
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260721140803_AddStructuredElementsJson.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260721140803_AddStructuredElementsJson.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddStructuredElementsJson : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "StructuredElementsJson",
+                table: "pdf_documents",
+                type: "text",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "StructuredElementsJson",
+                table: "pdf_documents");
+        }
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Commands/CompleteChunkedUploadHeadingAwareChunkingTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Commands/CompleteChunkedUploadHeadingAwareChunkingTests.cs
@@ -1,0 +1,163 @@
+using Api.BoundedContexts.DocumentProcessing.Application.Commands;
+using Api.BoundedContexts.DocumentProcessing.Application.Services;
+using Api.BoundedContexts.DocumentProcessing.Application.Services.Chunking;
+using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
+using Api.BoundedContexts.DocumentProcessing.Domain.Repositories;
+using Api.BoundedContexts.DocumentProcessing.Domain.Services;
+using Api.BoundedContexts.DocumentProcessing.Infrastructure.External;
+using Api.BoundedContexts.KnowledgeBase.Application.Services;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Services;
+using Api.Services.Pdf;
+using Api.Tests.Constants;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.DocumentProcessing.Application.Commands;
+
+/// <summary>
+/// SP2 task 6 (#3268): pins that the chunked-upload background pipeline
+/// (<see cref="CompleteChunkedUploadCommandHandler.TriggerPdfProcessingAsync"/>)
+/// prefers the scope-resolved <see cref="IHeadingAwareChunker"/> over the flat
+/// <see cref="ITextChunkingService"/> fallback when it is registered, and that the
+/// resulting chunk Heading is persisted on the <c>text_chunks</c> row. Mirrors the
+/// wiring already shipped for UploadPdfCommandHandler (task 4) and
+/// PdfProcessingPipelineService (task 5).
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "DocumentProcessing")]
+public class CompleteChunkedUploadHeadingAwareChunkingTests
+{
+    [Fact]
+    public async Task TriggerPdfProcessing_WithHeadingAwareChunkerRegistered_PersistsHeadingOnTextChunks()
+    {
+        // Arrange ----------------------------------------------------------------
+        var db = TestDbContextFactory.CreateInMemoryDbContext();
+
+        var pdfId = Guid.NewGuid();
+        var sharedGameId = Guid.NewGuid();
+        var entity = new PdfDocumentEntity
+        {
+            Id = pdfId,
+            SharedGameId = sharedGameId,
+            UploadedByUserId = Guid.NewGuid(),
+            FileName = "test.pdf",
+            FilePath = "/test/test.pdf",
+            FileSizeBytes = 1024,
+            ContentType = "application/pdf",
+            UploadedAt = DateTime.UtcNow,
+            ProcessingState = nameof(PdfProcessingState.Extracting)
+        };
+        db.PdfDocuments.Add(entity);
+        await db.SaveChangesAsync();
+
+        // The method opens the file with a real FileStream, so a real temp file
+        // must exist on disk.
+        var tmp = Path.GetTempFileName();
+        await File.WriteAllTextAsync(tmp, "dummy pdf bytes");
+
+        try
+        {
+            var structuredElements = new List<ExtractedElement>
+            {
+                new("Setup", 1, "Title"),
+                new("Place the board in the middle of the table.", 1, "NarrativeText")
+            };
+
+            var extractorMock = new Mock<IPdfTextExtractor>();
+            extractorMock
+                .Setup(e => e.ExtractPagedTextAsync(It.IsAny<Stream>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(PagedTextExtractionResult.CreateSuccess(
+                    new[] { new PageTextChunk(1, "Setup\nPlace the board in the middle of the table.", 0, 48) },
+                    totalPages: 1,
+                    totalCharacters: 48,
+                    ocrTriggered: false,
+                    structuredElements: structuredElements));
+
+            var tableExtractorMock = new Mock<IPdfTableExtractor>();
+            tableExtractorMock
+                .Setup(t => t.ExtractStructuredContentAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(StructuredContentResult.CreateFailure("no structured content in test"));
+
+            // Flat fallback would produce a heading-less chunk; the heading-aware
+            // chunker must be preferred over it when registered.
+            var flatChunkingMock = new Mock<ITextChunkingService>();
+            flatChunkingMock
+                .Setup(c => c.PrepareForEmbedding(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
+                .Returns(new List<DocumentChunkInput>
+                {
+                    new() { Text = "flat fallback chunk", Page = 1, CharStart = 0, CharEnd = 20, Heading = null }
+                });
+
+            var headingChunkerMock = new Mock<IHeadingAwareChunker>();
+            headingChunkerMock
+                .Setup(c => c.ChunkAsync(pdfId, sharedGameId, structuredElements, It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<DocumentChunkInput>
+                {
+                    new() { Text = "Place the board in the middle of the table.", Page = 1, CharStart = 6, CharEnd = 48, Heading = "Setup", Level = 1, ElementType = "NarrativeText" }
+                });
+
+            var embeddingMock = new Mock<IEmbeddingService>();
+            embeddingMock
+                .Setup(e => e.GenerateEmbeddingsAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(EmbeddingResult.CreateSuccess(new List<float[]> { new float[] { 0.1f, 0.2f } }));
+
+            var indexingPipelineMock = new Mock<IPdfIndexingPipeline>();
+            indexingPipelineMock
+                .Setup(p => p.IndexAsync(
+                    It.IsAny<Guid>(), It.IsAny<Guid?>(), It.IsAny<Guid?>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.CompletedTask);
+
+            var sc = new ServiceCollection();
+            sc.AddSingleton(db); // MeepleAiDbContext — same instance for the assert
+            sc.AddSingleton(flatChunkingMock.Object);
+            sc.AddSingleton(headingChunkerMock.Object);
+            sc.AddSingleton(embeddingMock.Object);
+            sc.AddSingleton(indexingPipelineMock.Object);
+            var provider = sc.BuildServiceProvider();
+            var scopeFactory = provider.GetRequiredService<IServiceScopeFactory>();
+
+            var handler = new CompleteChunkedUploadCommandHandler(
+                Mock.Of<IChunkedUploadSessionRepository>(),
+                db,
+                Mock.Of<IBlobStorageService>(),
+                Mock.Of<IBackgroundTaskService>(),
+                NullLogger<CompleteChunkedUploadCommandHandler>.Instance,
+                scopeFactory,
+                extractorMock.Object,
+                tableExtractorMock.Object,
+                Mock.Of<IMediator>(),
+                Mock.Of<IPdfDeduplicationService>(),
+                TimeProvider.System);
+
+            // Act --------------------------------------------------------------------
+            await handler.TriggerPdfProcessingAsync(pdfId.ToString(), tmp, CancellationToken.None);
+
+            // Assert -----------------------------------------------------------------
+            var updatedDoc = await db.PdfDocuments.FindAsync(pdfId);
+            updatedDoc!.ProcessingState.Should().Be(nameof(PdfProcessingState.Ready));
+            updatedDoc.StructuredElementsJson.Should().NotBeNullOrEmpty(
+                "StructuredElementsJson must be co-written alongside ExtractedText");
+
+            var persistedChunks = db.TextChunks.Where(tc => tc.PdfDocumentId == pdfId).ToList();
+            persistedChunks.Should().HaveCount(1);
+            persistedChunks[0].Heading.Should().Be("Setup");
+
+            // The flat fallback must NOT have been used when the heading-aware
+            // chunker produced usable chunks.
+            flatChunkingMock.Verify(
+                c => c.PrepareForEmbedding(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()),
+                Times.Never);
+        }
+        finally
+        {
+            File.Delete(tmp);
+        }
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Commands/ExtractPdfTextCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Commands/ExtractPdfTextCommandHandlerTests.cs
@@ -1,0 +1,149 @@
+using Api.BoundedContexts.DocumentProcessing.Application.Commands;
+using Api.BoundedContexts.DocumentProcessing.Application.Services.Chunking;
+using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
+using Api.BoundedContexts.DocumentProcessing.Domain.Services;
+using Api.BoundedContexts.DocumentProcessing.Infrastructure.External;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Services.Pdf;
+using Api.Tests.Constants;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.DocumentProcessing.Application.Commands;
+
+/// <summary>
+/// SP2 task 8 (#3268): pins the <c>ExtractedText ↔ StructuredElementsJson</c> co-write
+/// invariant on the admin/re-extract path. <see cref="ExtractPdfTextCommandHandler"/>
+/// rewrites <c>pdf.ExtractedText</c> on every re-extraction; without also rewriting
+/// <c>pdf.StructuredElementsJson</c> in the same <c>SaveChanges</c>, a re-extract would
+/// leave stale/mismatched structured elements behind (the persistence invariant every
+/// SP2 chunk-creation writer — Upload/Complete/Pipeline/IndexPdf — already upholds).
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "DocumentProcessing")]
+public class ExtractPdfTextCommandHandlerTests
+{
+    private static PdfDocumentEntity SeedPdf(
+        MeepleAiDbContext db,
+        Guid pdfId,
+        string? initialStructuredElementsJson = null)
+    {
+        var entity = new PdfDocumentEntity
+        {
+            Id = pdfId,
+            SharedGameId = Guid.NewGuid(),
+            UploadedByUserId = Guid.NewGuid(),
+            FileName = "test.pdf",
+            FilePath = "/test/test.pdf",
+            FileSizeBytes = 1024,
+            ContentType = "application/pdf",
+            UploadedAt = DateTime.UtcNow,
+            ProcessingState = nameof(PdfProcessingState.Pending),
+            StructuredElementsJson = initialStructuredElementsJson,
+        };
+        db.PdfDocuments.Add(entity);
+        db.SaveChanges();
+        return entity;
+    }
+
+    private static Mock<IBlobStorageService> CreateBlobStorageMock()
+    {
+        var mock = new Mock<IBlobStorageService>();
+        mock.Setup(b => b.RetrieveAsync(
+                It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(() => new MemoryStream(new byte[] { 0x25, 0x50, 0x44, 0x46 })); // "%PDF"
+        return mock;
+    }
+
+    [Fact]
+    public async Task Handle_WithStructuredElements_PersistsStructuredElementsJsonInSameSaveChanges()
+    {
+        // Arrange
+        var db = TestDbContextFactory.CreateInMemoryDbContext();
+        var pdfId = Guid.NewGuid();
+        // Seed with a stale JSON blob to prove re-extraction REPLACES it, not merely
+        // leaves whatever was there before.
+        var staleElements = new List<ExtractedElement> { new("Stale Title", 1, "Title") };
+        SeedPdf(db, pdfId, StructuredElementsPayload.Serialize(staleElements));
+
+        var newElements = new List<ExtractedElement>
+        {
+            new("Setup", 1, "Title"),
+            new("Place the board in the middle of the table.", 1, "NarrativeText"),
+        };
+
+        var extractorMock = new Mock<IPdfTextExtractor>();
+        extractorMock
+            .Setup(e => e.ExtractPagedTextAsync(It.IsAny<Stream>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(PagedTextExtractionResult.CreateSuccess(
+                new[] { new PageTextChunk(1, "Setup\nPlace the board in the middle of the table.", 0, 48) },
+                totalPages: 1,
+                totalCharacters: 48,
+                ocrTriggered: false,
+                structuredElements: newElements));
+
+        var handler = new ExtractPdfTextCommandHandler(
+            db,
+            CreateBlobStorageMock().Object,
+            extractorMock.Object,
+            NullLogger<ExtractPdfTextCommandHandler>.Instance,
+            TimeProvider.System);
+
+        // Act
+        var result = await handler.Handle(new ExtractPdfTextCommand(pdfId), CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeTrue();
+
+        var updated = await db.PdfDocuments.FindAsync(pdfId);
+        updated!.ExtractedText.Should().Contain("Setup");
+        updated.StructuredElementsJson.Should().NotBeNullOrEmpty(
+            "StructuredElementsJson must be co-written alongside ExtractedText in the same SaveChanges");
+
+        var persisted = StructuredElementsPayload.TryDeserialize(updated.StructuredElementsJson);
+        persisted.Should().NotBeNull();
+        persisted!.Select(e => e.Text).Should().BeEquivalentTo(newElements.Select(e => e.Text),
+            "the co-write must reflect the NEW extraction result, not the stale seeded value");
+    }
+
+    [Fact]
+    public async Task Handle_WithoutStructuredElements_LeavesStructuredElementsJsonNull()
+    {
+        // Arrange
+        var db = TestDbContextFactory.CreateInMemoryDbContext();
+        var pdfId = Guid.NewGuid();
+        SeedPdf(db, pdfId, initialStructuredElementsJson: null);
+
+        var extractorMock = new Mock<IPdfTextExtractor>();
+        extractorMock
+            .Setup(e => e.ExtractPagedTextAsync(It.IsAny<Stream>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(PagedTextExtractionResult.CreateSuccess(
+                new[] { new PageTextChunk(1, "Flat text with no structured elements.", 0, 40) },
+                totalPages: 1,
+                totalCharacters: 40,
+                ocrTriggered: false,
+                structuredElements: null));
+
+        var handler = new ExtractPdfTextCommandHandler(
+            db,
+            CreateBlobStorageMock().Object,
+            extractorMock.Object,
+            NullLogger<ExtractPdfTextCommandHandler>.Instance,
+            TimeProvider.System);
+
+        // Act
+        var result = await handler.Handle(new ExtractPdfTextCommand(pdfId), CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeTrue();
+
+        var updated = await db.PdfDocuments.FindAsync(pdfId);
+        updated!.ExtractedText.Should().Contain("Flat text");
+        updated.StructuredElementsJson.Should().BeNull(
+            "StructuredElementsPayload.Serialize returns null for an absent/empty element list");
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Handlers/IndexPdfCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Handlers/IndexPdfCommandHandlerTests.cs
@@ -1,6 +1,8 @@
 using Api.BoundedContexts.DocumentProcessing.Application.Commands;
 using Api.BoundedContexts.DocumentProcessing.Application.DTOs;
 using Api.BoundedContexts.DocumentProcessing.Application.Queries;
+using Api.BoundedContexts.DocumentProcessing.Application.Services.Chunking;
+using Api.BoundedContexts.DocumentProcessing.Domain.Services;
 using Api.BoundedContexts.KnowledgeBase.Application.Services;
 using Api.Configuration;
 using Api.Infrastructure;
@@ -246,8 +248,8 @@ public class IndexPdfCommandHandlerTests
 
         var textChunks = GenerateTextChunks(250);
         chunkingServiceMock
-            .Setup(x => x.ChunkText(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
-            .Returns(textChunks);
+            .Setup(x => x.PrepareForEmbedding(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
+            .Returns(ToChunkInputs(textChunks));
 
         var embeddingCallCount = 0;
         embeddingServiceMock
@@ -312,8 +314,8 @@ public class IndexPdfCommandHandlerTests
 
         var textChunks = GenerateTextChunks(1200);
         chunkingServiceMock
-            .Setup(x => x.ChunkText(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
-            .Returns(textChunks);
+            .Setup(x => x.PrepareForEmbedding(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
+            .Returns(ToChunkInputs(textChunks));
 
         embeddingServiceMock
             .Setup(x => x.GenerateEmbeddingsAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>()))
@@ -366,8 +368,8 @@ public class IndexPdfCommandHandlerTests
 
         var textChunks = GenerateTextChunks(200);
         chunkingServiceMock
-            .Setup(x => x.ChunkText(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
-            .Returns(textChunks);
+            .Setup(x => x.PrepareForEmbedding(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
+            .Returns(ToChunkInputs(textChunks));
 
         var callCount = 0;
         embeddingServiceMock
@@ -452,7 +454,7 @@ public class IndexPdfCommandHandlerTests
 
         // Verify: No chunking or embedding calls
         chunkingServiceMock.Verify(
-            x => x.ChunkText(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()),
+            x => x.PrepareForEmbedding(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()),
             Times.Never
         );
         embeddingServiceMock.Verify(
@@ -477,8 +479,8 @@ public class IndexPdfCommandHandlerTests
 
         var textChunks = GenerateTextChunks(10);
         chunkingServiceMock
-            .Setup(x => x.ChunkText(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
-            .Returns(textChunks);
+            .Setup(x => x.PrepareForEmbedding(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
+            .Returns(ToChunkInputs(textChunks));
 
         embeddingServiceMock
             .Setup(x => x.GenerateEmbeddingsAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>()))
@@ -522,8 +524,8 @@ public class IndexPdfCommandHandlerTests
 
         // Chunking returns empty list → triggers embedding failure path
         chunkingServiceMock
-            .Setup(x => x.ChunkText(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
-            .Returns(new List<TextChunk>());
+            .Setup(x => x.PrepareForEmbedding(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
+            .Returns(new List<DocumentChunkInput>());
 
         embeddingServiceMock.Setup(x => x.GetEmbeddingDimensions()).Returns(3072);
         embeddingServiceMock.Setup(x => x.GetModelName()).Returns("text-embedding-3-large");
@@ -559,7 +561,7 @@ public class IndexPdfCommandHandlerTests
 
         // Chunking throws an unexpected exception (not a handled failure result)
         chunkingServiceMock
-            .Setup(x => x.ChunkText(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
+            .Setup(x => x.PrepareForEmbedding(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
             .Throws(new InvalidOperationException("Unexpected chunking crash"));
 
         embeddingServiceMock.Setup(x => x.GetEmbeddingDimensions()).Returns(3072);
@@ -620,6 +622,19 @@ public class IndexPdfCommandHandlerTests
             .ToList();
     }
 
+    /// <summary>
+    /// SP2 task 7: since the flat path now calls <c>ITextChunkingService.PrepareForEmbedding</c>
+    /// (not <c>ChunkText</c>), tests that previously stubbed <c>ChunkText</c> must stub
+    /// <c>PrepareForEmbedding</c> instead. This converts the same <see cref="TextChunk"/> fixtures
+    /// into <see cref="DocumentChunkInput"/> so existing test data can be reused.
+    /// </summary>
+    private static List<DocumentChunkInput> ToChunkInputs(List<TextChunk> textChunks)
+    {
+        return textChunks
+            .Select(c => new DocumentChunkInput { Text = c.Text, Page = c.Page, CharStart = c.CharStart, CharEnd = c.CharEnd })
+            .ToList();
+    }
+
     private static float[] GenerateRandomEmbedding(int dimensions)
     {
 #pragma warning disable CA5394 // Random is sufficient for test data generation
@@ -644,8 +659,8 @@ public class IndexPdfCommandHandlerTests
 
         var textChunks = GenerateTextChunks(10);
         chunkingServiceMock
-            .Setup(x => x.ChunkText(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
-            .Returns(textChunks);
+            .Setup(x => x.PrepareForEmbedding(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
+            .Returns(ToChunkInputs(textChunks));
 
         embeddingServiceMock
             .Setup(x => x.GenerateEmbeddingsAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>()))
@@ -731,8 +746,8 @@ public class IndexPdfCommandHandlerTests
 
         var textChunks = GenerateTextChunks(5);
         chunkingServiceMock
-            .Setup(x => x.ChunkText(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
-            .Returns(textChunks);
+            .Setup(x => x.PrepareForEmbedding(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
+            .Returns(ToChunkInputs(textChunks));
 
         embeddingServiceMock
             .Setup(x => x.GenerateEmbeddingsAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>()))
@@ -787,6 +802,141 @@ public class IndexPdfCommandHandlerTests
                 It.IsAny<CancellationToken>()),
             Times.Once,
             "SharedGame PDF indexing MUST pass sharedGameId and the resolved gameId through to the pipeline");
+    }
+
+    // SP2 task 7 (#3268): IndexPdfCommandHandler reads the persisted StructuredElementsJson
+    // (there is no in-memory ExtractedElement list available on the bulk-reindex path — only
+    // the flat pdf.ExtractedText) so it can rebuild heading-aware chunks via IHeadingAwareChunker.
+    [Fact]
+    [Trait("Category", TestCategories.Unit)]
+    [Trait("BoundedContext", "DocumentProcessing")]
+    public async Task Handle_WithHeadingAwareChunkerAndStructuredElementsJson_PersistsHeadingOnChunks()
+    {
+        // Arrange
+        using var context = CreateFreshDbContext();
+        var (chunkingServiceMock, embeddingServiceMock, loggerMock, indexingSettingsMock) = CreateMocks();
+
+        var gameId = Guid.NewGuid();
+        var pdfId = Guid.NewGuid();
+        var structuredElements = new List<ExtractedElement>
+        {
+            new("Setup", 1, "Title"),
+            new("Place the board in the middle of the table.", 1, "NarrativeText")
+        };
+
+        var pdf = CreatePdfDocument(pdfId, gameId, "completed", GenerateExtractedText(5));
+        pdf.StructuredElementsJson = StructuredElementsPayload.Serialize(structuredElements);
+        await context.PdfDocuments.AddAsync(pdf);
+        await context.SaveChangesAsync();
+
+        var headingChunkerMock = new Mock<IHeadingAwareChunker>();
+        headingChunkerMock
+            .Setup(c => c.ChunkAsync(
+                pdfId,
+                It.IsAny<Guid?>(),
+                It.IsAny<IReadOnlyList<ExtractedElement>?>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<DocumentChunkInput>
+            {
+                new()
+                {
+                    Text = "Place the board in the middle of the table.",
+                    Page = 1,
+                    CharStart = 6,
+                    CharEnd = 48,
+                    Heading = "Setup",
+                    Level = 1,
+                    ElementType = "NarrativeText"
+                }
+            });
+
+        embeddingServiceMock
+            .Setup(x => x.GenerateEmbeddingsAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((List<string> texts, CancellationToken ct) =>
+            {
+                var embeddings = texts.Select(_ => GenerateRandomEmbedding(3072)).ToList();
+                return new EmbeddingResult { Success = true, Embeddings = embeddings };
+            });
+        embeddingServiceMock.Setup(x => x.GetEmbeddingDimensions()).Returns(3072);
+        embeddingServiceMock.Setup(x => x.GetModelName()).Returns("text-embedding-3-large");
+
+        var handler = new IndexPdfCommandHandler(
+            context, chunkingServiceMock.Object, embeddingServiceMock.Object,
+            loggerMock.Object, indexingSettingsMock.Object,
+            Mock.Of<ISemanticResponseCache>(),
+            Mock.Of<IPdfIndexingPipeline>(),
+            headingAwareChunker: headingChunkerMock.Object);
+
+        // Act
+        var result = await handler.Handle(new IndexPdfCommand(pdfId.ToString()), CancellationToken.None);
+
+        // Assert
+        result.Success.Should().BeTrue();
+
+        var persistedChunks = await context.TextChunks
+            .Where(tc => tc.PdfDocumentId == pdfId)
+            .ToListAsync();
+        persistedChunks.Should().HaveCount(1);
+        persistedChunks[0].Heading.Should().Be("Setup");
+
+        // The flat fallback must NOT run when the heading-aware chunker produced usable chunks.
+        chunkingServiceMock.Verify(
+            x => x.PrepareForEmbedding(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()),
+            Times.Never,
+            "heading-aware chunker produced usable chunks; flat fallback must not run");
+    }
+
+    [Fact]
+    [Trait("Category", TestCategories.Unit)]
+    [Trait("BoundedContext", "DocumentProcessing")]
+    public async Task Handle_WithMalformedStructuredElementsJson_FallsBackToFlatChunkingWithoutThrowing()
+    {
+        // Arrange
+        using var context = CreateFreshDbContext();
+        var (chunkingServiceMock, embeddingServiceMock, loggerMock, indexingSettingsMock) = CreateMocks();
+
+        var gameId = Guid.NewGuid();
+        var pdfId = Guid.NewGuid();
+        var pdf = CreatePdfDocument(pdfId, gameId, "completed", GenerateExtractedText(5));
+        pdf.StructuredElementsJson = "{malformed"; // malformed JSON must not throw — degrades to flat path
+        await context.PdfDocuments.AddAsync(pdf);
+        await context.SaveChangesAsync();
+
+        var chunkInputs = ToChunkInputs(GenerateTextChunks(5));
+        chunkingServiceMock
+            .Setup(x => x.PrepareForEmbedding(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
+            .Returns(chunkInputs);
+
+        embeddingServiceMock
+            .Setup(x => x.GenerateEmbeddingsAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((List<string> texts, CancellationToken ct) =>
+            {
+                var embeddings = texts.Select(_ => GenerateRandomEmbedding(3072)).ToList();
+                return new EmbeddingResult { Success = true, Embeddings = embeddings };
+            });
+        embeddingServiceMock.Setup(x => x.GetEmbeddingDimensions()).Returns(3072);
+        embeddingServiceMock.Setup(x => x.GetModelName()).Returns("text-embedding-3-large");
+
+        // No IHeadingAwareChunker passed — defaults to null, exercising the pure flat path.
+        var handler = new IndexPdfCommandHandler(
+            context, chunkingServiceMock.Object, embeddingServiceMock.Object,
+            loggerMock.Object, indexingSettingsMock.Object,
+            Mock.Of<ISemanticResponseCache>(),
+            Mock.Of<IPdfIndexingPipeline>());
+
+        // Act
+        var result = await handler.Handle(new IndexPdfCommand(pdfId.ToString()), CancellationToken.None);
+
+        // Assert — succeeds via the flat path, no exception surfaced as UnexpectedError
+        result.Success.Should().BeTrue();
+        result.ErrorCode.Should().BeNull();
+
+        var persistedChunks = await context.TextChunks
+            .Where(tc => tc.PdfDocumentId == pdfId)
+            .ToListAsync();
+        persistedChunks.Should().HaveCount(5);
+        persistedChunks.Should().AllSatisfy(c => c.Heading.Should().BeNull());
     }
 
     // NOTE: Full workflow tests (text chunking, embedding generation, pgvector indexing)

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Services/Chunking/HeadingAwareChunkerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Services/Chunking/HeadingAwareChunkerTests.cs
@@ -1,0 +1,67 @@
+using Api.BoundedContexts.DocumentProcessing.Application.Services.Chunking;
+using Api.BoundedContexts.DocumentProcessing.Domain.Services;
+using Api.BoundedContexts.KnowledgeBase.Application.Services.Chunking;
+using Api.BoundedContexts.KnowledgeBase.Domain.Services;
+using Api.Constants;
+using Api.Services;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+using Api.Tests.Constants;
+
+namespace Api.Tests.BoundedContexts.DocumentProcessing.Application.Services.Chunking;
+
+[Trait("Category", TestCategories.Unit)]
+public class HeadingAwareChunkerTests
+{
+    private static CancellationToken Ct => TestContext.Current.CancellationToken;
+
+    // Real collaborators (all pure/deterministic): TextChunkingService + strategy selector + AdvancedChunkingService.
+    private static HeadingAwareChunker CreateChunker()
+    {
+        var textChunking = new TextChunkingService(NullLogger<TextChunkingService>.Instance);
+        var selector = new ChunkingStrategySelector();
+        var advanced = new AdvancedChunkingService(textChunking, selector, NullLogger<AdvancedChunkingService>.Instance);
+        return new HeadingAwareChunker(advanced, textChunking, NullLogger<HeadingAwareChunker>.Instance);
+    }
+
+    [Fact]
+    public async Task ChunkAsync_WithTitleElement_ProducesChildrenWithHeading()
+    {
+        var elements = new List<ExtractedElement>
+        {
+            new("Preparazione", 1, "Title"),
+            new("Disponi le tessere sul tavolo e mescola il mazzo di carte.", 1, "NarrativeText"),
+        };
+        var chunker = CreateChunker();
+
+        var result = await chunker.ChunkAsync(System.Guid.NewGuid(), null, elements, "flat", Ct);
+
+        result.Should().NotBeEmpty();
+        result.Should().OnlyContain(c => c.Heading == "Preparazione");
+    }
+
+    [Fact]
+    public async Task ChunkAsync_NullElements_ProducesNullHeadingChildren_ContentPreserved()
+    {
+        var chunker = CreateChunker();
+        var flat = "Some flat body text without any structure.";
+        var result = await chunker.ChunkAsync(System.Guid.NewGuid(), null, null, flat, Ct);
+
+        result.Should().NotBeEmpty();
+        result.Should().OnlyContain(c => c.Heading == null);
+        string.Join(" ", result.Select(c => c.Text)).Should().Contain("flat body text");
+    }
+
+    [Fact]
+    public async Task ChunkAsync_NoChildExceedsMaxEmbeddingChars()
+    {
+        var longBody = string.Join(" ", Enumerable.Repeat("parola", 1200)); // > 1800 chars, narrative → Sparse (2000)
+        var elements = new List<ExtractedElement> { new("Regole", 1, "Title"), new(longBody, 1, "NarrativeText") };
+        var chunker = CreateChunker();
+
+        var result = await chunker.ChunkAsync(System.Guid.NewGuid(), null, elements, "flat", Ct);
+
+        result.Should().OnlyContain(c => c.Text.Length <= ChunkingConstants.MaxEmbeddingChars);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Services/Chunking/HierarchicalChunkMapperTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Services/Chunking/HierarchicalChunkMapperTests.cs
@@ -1,0 +1,67 @@
+using Api.BoundedContexts.DocumentProcessing.Application.Services.Chunking;
+using Api.BoundedContexts.KnowledgeBase.Domain.Chunking;
+using FluentAssertions;
+using Xunit;
+using Api.Tests.Constants;
+
+namespace Api.Tests.BoundedContexts.DocumentProcessing.Application.Services.Chunking;
+
+[Trait("Category", TestCategories.Unit)]
+public class HierarchicalChunkMapperTests
+{
+    private static HierarchicalChunk Parent(string heading, string content, int page = 1) =>
+        HierarchicalChunk.CreateParent(content, new ChunkMetadata { Page = page, Heading = heading, ElementType = "heading", CharStart = 0, CharEnd = content.Length, DocumentId = System.Guid.NewGuid() });
+
+    private static HierarchicalChunk Child(string parentId, string content, string? heading, int page, int charStart) =>
+        HierarchicalChunk.CreateChild(content, level: 2, new ChunkMetadata { Page = page, Heading = heading, ElementType = "text", CharStart = charStart, CharEnd = charStart + content.Length, DocumentId = System.Guid.NewGuid() }, parentId);
+
+    [Fact]
+    public void ToChildDocumentChunks_KeepsOnlyChildren_InheritsHeading()
+    {
+        var parent = Parent("Preparazione", "Preparazione body");
+        var c1 = Child(parent.Id, "Disponi le tessere.", "Preparazione", 1, 0);
+        var c2 = Child(parent.Id, "Mescola il mazzo.", "Preparazione", 1, 20);
+
+        var result = HierarchicalChunkMapper.ToChildDocumentChunks(new[] { parent, c1, c2 });
+
+        result.Should().HaveCount(2); // parent excluded
+        result[0].Text.Should().Be("Disponi le tessere.");
+        result[0].Heading.Should().Be("Preparazione");
+        result[0].Level.Should().Be(2);
+        result[0].ElementType.Should().Be("text");
+        result[0].ParentChunkId.Should().BeNull();
+    }
+
+    [Fact]
+    public void ToChildDocumentChunks_NullHeadingPreamble_Preserved()
+    {
+        var parent = Parent(null!, "intro");
+        var c = Child(parent.Id, "intro text", null, 1, 0);
+        var result = HierarchicalChunkMapper.ToChildDocumentChunks(new[] { parent, c });
+        result.Should().ContainSingle();
+        result[0].Heading.Should().BeNull();
+    }
+
+    [Fact]
+    public void ToChildDocumentChunks_OnlyParent_NoChildren_ReturnsEmpty()
+    {
+        // HierarchicalChunk forbids empty content, so the parent must carry text; the mapper still
+        // returns empty because the sole chunk IsRoot and roots are skipped.
+        var parent = Parent("Empty", "section body");
+        HierarchicalChunkMapper.ToChildDocumentChunks(new[] { parent }).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ToChildDocumentChunks_MultiPageSection_RecomputesPagePerChild()
+    {
+        var parent = Parent("Long", "long section body");
+        // two children of the same section at very different char offsets → different pages
+        var c1 = Child(parent.Id, "early text", "Long", page: 1, charStart: 10);
+        var c2 = Child(parent.Id, "late text", "Long", page: 1, charStart: 5000);
+
+        var result = HierarchicalChunkMapper.ToChildDocumentChunks(new[] { parent, c1, c2 });
+
+        result[0].Page.Should().Be(1);           // 10 / 2000 + 1
+        result[1].Page.Should().Be(3);           // 5000 / 2000 + 1  (not collapsed to the section's page 1)
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Services/Chunking/StructuredElementsPayloadTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Services/Chunking/StructuredElementsPayloadTests.cs
@@ -1,0 +1,49 @@
+using Api.BoundedContexts.DocumentProcessing.Application.Services.Chunking;
+using Api.BoundedContexts.DocumentProcessing.Domain.Services;
+using FluentAssertions;
+using Xunit;
+using Api.Tests.Constants;
+
+namespace Api.Tests.BoundedContexts.DocumentProcessing.Application.Services.Chunking;
+
+[Trait("Category", TestCategories.Unit)]
+public class StructuredElementsPayloadTests
+{
+    [Fact]
+    public void RoundTrip_PreservesElements()
+    {
+        var elements = new List<ExtractedElement> { new("Setup", 1, "Title"), new("body", 2, "NarrativeText") };
+        var json = StructuredElementsPayload.Serialize(elements);
+        json.Should().NotBeNullOrEmpty();
+
+        var back = StructuredElementsPayload.TryDeserialize(json);
+        back.Should().NotBeNull();
+        back!.Select(e => (e.Text, e.PageNumber, e.ElementType))
+            .Should().Equal(("Setup", 1, "Title"), ("body", 2, "NarrativeText"));
+    }
+
+    [Fact]
+    public void Serialize_NullOrEmpty_ReturnsNull()
+    {
+        StructuredElementsPayload.Serialize(null).Should().BeNull();
+        StructuredElementsPayload.Serialize(new List<ExtractedElement>()).Should().BeNull();
+    }
+
+    [Fact]
+    public void TryDeserialize_MalformedOrLegacy_ReturnsNull_NeverThrows()
+    {
+        StructuredElementsPayload.TryDeserialize("{ not valid json").Should().BeNull();
+        StructuredElementsPayload.TryDeserialize(null).Should().BeNull();
+        // legacy/unknown shape tolerated (unknown members ignored, missing -> null)
+        StructuredElementsPayload.TryDeserialize("{\"SchemaVersion\":99,\"Elements\":null}").Should().BeNull();
+    }
+
+    [Fact]
+    public void TryDeserialize_FrozenBlob_Reads()
+    {
+        const string frozen = "{\"SchemaVersion\":1,\"Elements\":[{\"Text\":\"Setup\",\"PageNumber\":1,\"ElementType\":\"Title\"}]}";
+        var back = StructuredElementsPayload.TryDeserialize(frozen);
+        back.Should().ContainSingle();
+        back![0].Text.Should().Be("Setup");
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Services/Chunking/TranslatedChunkMapperTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Services/Chunking/TranslatedChunkMapperTests.cs
@@ -1,0 +1,23 @@
+using Api.BoundedContexts.DocumentProcessing.Application.Services.Chunking;
+using Api.Services;
+using FluentAssertions;
+using Xunit;
+using Api.Tests.Constants;
+
+namespace Api.Tests.BoundedContexts.DocumentProcessing.Application.Services.Chunking;
+
+[Trait("Category", TestCategories.Unit)]
+public class TranslatedChunkMapperTests
+{
+    [Fact]
+    public void ForTranslation_PreservesHeadingAndHierarchy()
+    {
+        var orig = new DocumentChunkInput { Text = "Disponi", Page = 3, CharStart = 10, CharEnd = 17, Heading = "Setup", Level = 2, ElementType = "text" };
+        var translated = TranslatedChunkMapper.ForTranslation(orig, "Lay out");
+        translated.Text.Should().Be("Lay out");
+        translated.Heading.Should().Be("Setup");   // heading inherited on the EN chunk (was dropped before SP2)
+        translated.Page.Should().Be(3);
+        translated.Level.Should().Be(2);
+        translated.ElementType.Should().Be("text");
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/RoleClassifierServiceTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/RoleClassifierServiceTests.cs
@@ -151,6 +151,69 @@ public class RoleClassifierServiceTests
     }
 
     [Fact]
+    public async Task ClassifyAsync_HeadingMatchesRule_ResolvesDeterministicallyAndNeverInvokesLlm()
+    {
+        // SP2 task 8 (#3268) role-fast-path regression: a heading that matches a
+        // HeadingRule (here "Setup", HeadingRule 1 → Tutorial|Setup) must resolve
+        // via the rule table alone. The batch contains ONLY rule-matched chunks, so
+        // the ambiguous list stays empty and the LLM fallback must never be reached —
+        // guards against a regression that always calls the LLM regardless of match.
+        var classifier = CreateSut();
+        var chunk = new ChunkInput("Setup", "Place the board in the middle of the table.");
+
+        var result = await classifier.ClassifyAsync(new[] { chunk }, TestContext.Current.CancellationToken);
+
+        result.Should().HaveCount(1);
+        result[0].Should().NotBe(GameBookRole.None);
+        result[0].HasFlag(GameBookRole.Tutorial).Should().BeTrue();
+        result[0].HasFlag(GameBookRole.Setup).Should().BeTrue();
+        _llmServiceMock.Verify(
+            x => x.GenerateJsonAsync<string[][]>(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<RequestSource>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+        _llmServiceMock.Verify(
+            x => x.GenerateCompletionAsync(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<RequestSource>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ClassifyAsync_HeadingMatchesNoRule_RoutesToLlmFallback()
+    {
+        // Companion to the fast-path test above: a heading that matches NO HeadingRule
+        // (SP2 reduces, but does not eliminate, the LLM fallback) must still route
+        // through ClassifyViaLlmAsync exactly once.
+        _llmServiceMock
+            .Setup(x => x.GenerateJsonAsync<string[][]>(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                RequestSource.RagClassification,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new[] { new[] { "lore" } });
+
+        var classifier = CreateSut();
+        var chunk = new ChunkInput("Zzz Random", "Some body text that matches no heading rule.");
+
+        var result = await classifier.ClassifyAsync(new[] { chunk }, TestContext.Current.CancellationToken);
+
+        result.Should().HaveCount(1);
+        result[0].HasFlag(GameBookRole.Lore).Should().BeTrue();
+        _llmServiceMock.Verify(
+            x => x.GenerateJsonAsync<string[][]>(
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                RequestSource.RagClassification,
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
     public async Task ClassifyAsync_AmbiguousChunk_LlmReturnsFewerArrays_PadsRemainingWithRulesReference()
     {
         // Issue #1395: parity with legacy ParseLlmResponse fallback path —

--- a/apps/api/tests/Api.Tests/Integration/UploadPdfIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/UploadPdfIntegrationTests.cs
@@ -1621,18 +1621,17 @@ public sealed class UploadPdfIntegrationTests : IAsyncLifetime
             $"ExtractedTextLen={pdfDoc.ExtractedText?.Length.ToString() ?? "null"}, PageCount={pdfDoc.PageCount}.\n--- LOG TAIL ---\n{logTail}\n--- END ---";
         pdfDoc.ProcessingState.Should().Be("Ready", $"the full pipeline must reach Ready for chunks to be persisted.\n{diagnostics}");
 
-        // NOTE: pdfDoc.StructuredElementsJson is NOT re-asserted here after the Ready re-read —
-        // ExtractPdfContentAsync's `pdfDoc` parameter is fetched AsNoTracking() by
-        // ValidateAndPrepareProcessingAsync, and TransitionStateAsync(Extracting) runs between
-        // that fetch and ExtractPdfContentAsync's mutation, detaching/replacing whatever the
-        // DbContext was tracking for this Id. The subsequent `db.SaveChangesAsync()` in
-        // ExtractPdfContentAsync therefore has no pending changes to write for this entity — a
-        // PRE-EXISTING gap that already affected `pdfDoc.ExtractedText = fullText` before this
-        // task (unrelated to the chunker wiring). See task-4-report.md for detail; out of scope
-        // to fix here since Task 4 only asked to co-locate the StructuredElementsJson write next
-        // to the existing (equally-affected) ExtractedText write. The chunking pipeline itself
-        // does NOT depend on the persisted column — HeadingAwareChunker consumes
-        // extractResult.StructuredElements directly from the in-memory extraction result.
+        // SP2 Task 4b (#3268): ExtractPdfContentAsync's `pdfDoc` parameter is fetched
+        // AsNoTracking() by ValidateAndPrepareProcessingAsync, and every subsequent state
+        // transition routes through IPdfDocumentRepository.UpdateAsync (MapToPersistence
+        // omits these columns), clobbering them back to NULL. FinalizeProcessingAsync now
+        // does a dedicated tracked re-write of the extraction output AFTER the Ready
+        // transition so it survives the full pipeline — verify via a fresh re-query.
+        var persisted = await testDbContext.PdfDocuments
+            .AsNoTracking()
+            .FirstAsync(p => p.Id == pdfGuid, TestCancellationToken);
+        persisted.ExtractedText.Should().NotBeNullOrEmpty(diagnostics);
+        persisted.StructuredElementsJson.Should().NotBeNull(diagnostics); // versioned JSON round-trips for IndexPdf
 
         var chunks = await testDbContext.TextChunks
             .Where(c => c.PdfDocumentId == pdfGuid)

--- a/apps/api/tests/Api.Tests/Integration/UploadPdfIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/UploadPdfIntegrationTests.cs
@@ -9,6 +9,7 @@ using Api.BoundedContexts.DocumentProcessing.Infrastructure.Configuration;
 using Api.BoundedContexts.DocumentProcessing.Infrastructure.External;
 using Api.BoundedContexts.DocumentProcessing.Infrastructure.Persistence;
 using Api.BoundedContexts.DocumentProcessing.Infrastructure.Services;
+using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
 using Api.Infrastructure;
 using Api.Infrastructure.Entities;
 using Api.Infrastructure.Entities.SharedGameCatalog;
@@ -25,6 +26,8 @@ using DotNet.Testcontainers.Containers;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -1461,5 +1464,301 @@ public sealed class UploadPdfIntegrationTests : IAsyncLifetime
         var expectedExpiry = DateTime.UtcNow.AddMinutes(30);
         var timeDiff = Math.Abs((reservationResult.ExpiresAt!.Value - expectedExpiry).TotalSeconds);
         timeDiff.Should().BeLessThan(5);
+    }
+
+    /// <summary>
+    /// SP2 Task 4 (#3268): proves UploadPdfCommandHandler wires the heading-aware chunker
+    /// (Tasks 1-3: HierarchicalChunkMapper, IHeadingAwareChunker, StructuredElementsPayload)
+    /// into the background processing pipeline and persists both StructuredElementsJson and
+    /// per-chunk Heading/RoleTags.
+    ///
+    /// Needs a dedicated harness: the class-level <see cref="_serviceProvider"/> stubs
+    /// <see cref="IBackgroundTaskService"/> to a no-op (chunking never runs) and registers a
+    /// non-functional <see cref="IEmbeddingService"/>/no <see cref="IRoleClassifierService"/>.
+    /// This test builds its own ServiceCollection with: (1) a background task service that
+    /// runs the queued delegate and can be awaited before assertions, (2) a deterministic
+    /// 768-dim <see cref="IEmbeddingService"/> stub, (3) the real SP2 chunking chain
+    /// (IHeadingAwareChunker → IAdvancedChunkingService → ITextChunkingService), (4) a real
+    /// <see cref="RoleClassifierService"/> with a mocked <see cref="ILlmService"/> — the
+    /// "Setup" heading resolves via <c>HeadingRules</c> without an LLM call, and (5) the real
+    /// <see cref="IPdfIndexingPipeline"/> (needed to reach the text-chunk persistence step)
+    /// plus its event handler's dependencies.
+    /// </summary>
+    [Fact(Timeout = 90000)]
+    public async Task UploadPdf_WithTitledStructuredElements_PersistsHeadingAwareChunksWithRoleTags()
+    {
+        // Arrange
+        var services = IntegrationServiceCollectionBuilder.CreateBase(_isolatedDbConnectionString);
+
+        var logSink = new HeadingChunkerListLoggerSink();
+        services.AddLogging(builder =>
+        {
+            builder.ClearProviders();
+            builder.SetMinimumLevel(LogLevel.Debug);
+            builder.AddProvider(new HeadingChunkerListLoggerProvider(logSink));
+        });
+
+        var inlineBgService = new HeadingChunkerInlineBackgroundTaskService();
+        services.AddSingleton<IBackgroundTaskService>(inlineBgService);
+
+        var extractorMock = new Mock<IPdfTextExtractor>();
+        extractorMock
+            .Setup(e => e.ExtractPagedTextAsync(It.IsAny<Stream>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(PagedTextExtractionResult.CreateSuccess(
+                pageChunks: new List<PageTextChunk>
+                {
+                    new PageTextChunk(1, "Setup\n\nDisponi le tessere e mescola il mazzo.", 0, 44)
+                },
+                totalPages: 1,
+                totalCharacters: 44,
+                ocrTriggered: false,
+                structuredElements: new List<ExtractedElement>
+                {
+                    new ExtractedElement("Setup", 1, "Title"),
+                    new ExtractedElement("Disponi le tessere e mescola il mazzo.", 1, "NarrativeText")
+                }));
+        services.AddSingleton<IPdfTextExtractor>(extractorMock.Object);
+
+        // Bare Mock<IPdfTableExtractor> (RegisterMockServices' default) returns a null
+        // StructuredContentResult, which NREs at ExtractStructuredContentAsync (Processing.cs)
+        // when it dereferences .Success. Explicitly return Success=false so the pipeline skips
+        // structured-content extraction (unrelated to this test's chunking assertions).
+        var tableExtractorMock = new Mock<IPdfTableExtractor>();
+        tableExtractorMock
+            .Setup(t => t.ExtractStructuredContentAsync(It.IsAny<string>()!, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new StructuredContentResult { Success = false, ErrorMessage = "Skipped in test" });
+        services.AddSingleton<IPdfTableExtractor>(tableExtractorMock.Object);
+
+        RegisterMockServices(services);
+
+        // Deterministic 768-dim embeddings (CreateBase's bare Mock.Of<IEmbeddingService> is
+        // non-functional — returns a null result, which would NRE inside the batch loop).
+        services.AddSingleton<IEmbeddingService>(new Api.Tests.TestHelpers.MockEmbeddingService(dimensions: 768));
+
+        services.Configure<PdfProcessingOptions>(options => options.MaxFileSizeBytes = 10 * 1024 * 1024);
+        services.AddScoped<UploadPdfCommandHandler>();
+
+        // SP2 heading-aware chunking pipeline (Tasks 1-3, already shipped on this branch).
+        services.AddSingleton<Api.BoundedContexts.KnowledgeBase.Domain.Services.ChunkingStrategySelector>();
+        services.AddScoped<ITextChunkingService, TextChunkingService>();
+        services.AddScoped<
+            Api.BoundedContexts.KnowledgeBase.Application.Services.Chunking.IAdvancedChunkingService,
+            Api.BoundedContexts.KnowledgeBase.Application.Services.Chunking.AdvancedChunkingService>();
+        services.AddScoped<
+            Api.BoundedContexts.DocumentProcessing.Application.Services.Chunking.IHeadingAwareChunker,
+            Api.BoundedContexts.DocumentProcessing.Application.Services.Chunking.HeadingAwareChunker>();
+
+        // Real role classifier — "Setup" resolves via HeadingRules (Tutorial|Setup), so the
+        // mocked LLM fallback is never actually invoked for this fixture.
+        var llmMock = new Mock<Api.Services.ILlmService>();
+        llmMock
+            .Setup(l => l.GenerateJsonAsync<string[][]>(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Api.Services.RequestSource>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string[][]?)null);
+        services.AddSingleton<Api.Services.ILlmService>(llmMock.Object);
+        services.AddScoped<
+            Api.BoundedContexts.KnowledgeBase.Application.Services.IRoleClassifierService,
+            Api.BoundedContexts.KnowledgeBase.Application.Services.RoleClassifierService>();
+
+        // Real PDF indexing pipeline — UpdateVectorDocumentAsync (called before the text-chunk
+        // persistence step) resolves this via GetRequiredService; without it the pipeline
+        // throws before chunks are ever saved. It publishes VectorDocumentIndexedEvent inline
+        // (bypasses the domain-event outbox), so the listening handler's dependencies must
+        // also resolve.
+        services.AddSingleton(Mock.Of<Api.BoundedContexts.DocumentProcessing.Application.Services.IProcessingMetricsService>());
+        services.AddScoped(_ => Mock.Of<Api.BoundedContexts.KnowledgeBase.Domain.Repositories.IVectorDocumentRepository>());
+        services.AddScoped<Api.Services.ICacheInvalidationRetryPolicy>(_ => new Api.Tests.TestHelpers.PassthroughRetryPolicy());
+        services.AddScoped<
+            Api.BoundedContexts.KnowledgeBase.Application.Services.IPdfIndexingPipeline,
+            Api.BoundedContexts.KnowledgeBase.Application.Services.PdfIndexingPipeline>();
+
+        var provider = services.BuildServiceProvider();
+        var testDbContext = provider.GetRequiredService<MeepleAiDbContext>();
+        await testDbContext.Database.MigrateAsync(TestCancellationToken);
+
+        var testUser = await SeedUserInContextAsync(testDbContext);
+        var testGame = await SeedGameInContextAsync(testDbContext);
+
+        var handler = provider.GetRequiredService<UploadPdfCommandHandler>();
+
+        var pdfBytes = CreateValidPdfBytes(1024 * 10);
+        var formFile = CreateMockFormFile("heading_chunker_test.pdf", pdfBytes);
+
+        var command = new UploadPdfCommand(
+            GameId: testGame.Id.ToString(),
+            Metadata: null,
+            PrivateGameId: null,
+            UserId: testUser.Id,
+            File: formFile);
+
+        // Act
+        var result = await handler.Handle(command, TestCancellationToken);
+        await inlineBgService.WaitForAllAsync();
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Success.Should().BeTrue("upload accept-stage must succeed for a valid PDF");
+        result.Document.Should().NotBeNull();
+        var pdfGuid = result.Document!.Id;
+
+        var pdfDoc = await testDbContext.PdfDocuments
+            .AsNoTracking()
+            .SingleAsync(p => p.Id == pdfGuid, TestCancellationToken);
+        var relevantLogs = logSink.Snapshot()
+            .Where(line =>
+                line.Contains("PDF-DEBUG", StringComparison.Ordinal) ||
+                line.Contains("UploadPdfCommandHandler", StringComparison.Ordinal) ||
+                line.Contains("HeadingAwareChunker", StringComparison.Ordinal) ||
+                line.Contains("RoleClassifier", StringComparison.Ordinal) ||
+                line.Contains("[Error]", StringComparison.Ordinal) ||
+                line.Contains("[Critical]", StringComparison.Ordinal) ||
+                line.Contains("Ex=", StringComparison.Ordinal))
+            .TakeLast(150)
+            .ToList();
+        var logTail = string.Join("\n", relevantLogs);
+        var diagnostics =
+            $"State={pdfDoc.ProcessingState}, Error={pdfDoc.ProcessingError}, " +
+            $"ExtractedTextLen={pdfDoc.ExtractedText?.Length.ToString() ?? "null"}, PageCount={pdfDoc.PageCount}.\n--- LOG TAIL ---\n{logTail}\n--- END ---";
+        pdfDoc.ProcessingState.Should().Be("Ready", $"the full pipeline must reach Ready for chunks to be persisted.\n{diagnostics}");
+
+        // NOTE: pdfDoc.StructuredElementsJson is NOT re-asserted here after the Ready re-read —
+        // ExtractPdfContentAsync's `pdfDoc` parameter is fetched AsNoTracking() by
+        // ValidateAndPrepareProcessingAsync, and TransitionStateAsync(Extracting) runs between
+        // that fetch and ExtractPdfContentAsync's mutation, detaching/replacing whatever the
+        // DbContext was tracking for this Id. The subsequent `db.SaveChangesAsync()` in
+        // ExtractPdfContentAsync therefore has no pending changes to write for this entity — a
+        // PRE-EXISTING gap that already affected `pdfDoc.ExtractedText = fullText` before this
+        // task (unrelated to the chunker wiring). See task-4-report.md for detail; out of scope
+        // to fix here since Task 4 only asked to co-locate the StructuredElementsJson write next
+        // to the existing (equally-affected) ExtractedText write. The chunking pipeline itself
+        // does NOT depend on the persisted column — HeadingAwareChunker consumes
+        // extractResult.StructuredElements directly from the in-memory extraction result.
+
+        var chunks = await testDbContext.TextChunks
+            .Where(c => c.PdfDocumentId == pdfGuid)
+            .ToListAsync(TestCancellationToken);
+        chunks.Should().NotBeEmpty(diagnostics);
+        chunks.Should().OnlyContain(c => c.Heading == "Setup", diagnostics);
+        chunks.Should().Contain(c => c.RoleTags != GameBookRole.None, diagnostics); // heading fast-path assigned a role
+    }
+
+    /// <summary>
+    /// Test-only <see cref="IBackgroundTaskService"/> that runs the queued task on a
+    /// thread-pool thread while letting the caller await all in-flight tasks before
+    /// assertions (mirrors <c>PdfIndexingFlowKbFlagIntegrationTests.InlineBackgroundTaskService</c>).
+    /// The production registration is fire-and-forget so the HTTP request returns immediately;
+    /// tests need the background pipeline to finish before inspecting the database.
+    /// </summary>
+    private sealed class HeadingChunkerInlineBackgroundTaskService : IBackgroundTaskService
+    {
+        private readonly List<Task> _running = new();
+        private readonly object _gate = new();
+
+        public void Execute(Func<Task> task)
+        {
+            ArgumentNullException.ThrowIfNull(task);
+            lock (_gate)
+            {
+                _running.Add(Task.Run(task));
+            }
+        }
+
+        public void ExecuteWithCancellation(string taskId, Func<CancellationToken, Task> taskFactory)
+        {
+            ArgumentNullException.ThrowIfNull(taskFactory);
+            lock (_gate)
+            {
+                _running.Add(Task.Run(() => taskFactory(CancellationToken.None)));
+            }
+        }
+
+        public bool CancelTask(string taskId) => false;
+
+        public Task WaitForAllAsync()
+        {
+            Task[] snapshot;
+            lock (_gate)
+            {
+                snapshot = _running.ToArray();
+            }
+            return Task.WhenAll(snapshot);
+        }
+    }
+
+    /// <summary>
+    /// In-memory log sink for diagnosing ProcessPdfAsync pipeline failures, which otherwise
+    /// surface as an opaque ProcessingError string with no stack trace (mirrors
+    /// PdfIndexingFlowKbFlagIntegrationTests.ListLoggerSink).
+    /// </summary>
+    private sealed class HeadingChunkerListLoggerSink
+    {
+        private readonly List<string> _entries = new();
+        private readonly object _gate = new();
+
+        public void Append(string entry)
+        {
+            lock (_gate)
+            {
+                _entries.Add(entry);
+            }
+        }
+
+        public IReadOnlyList<string> Snapshot()
+        {
+            lock (_gate)
+            {
+                return _entries.ToArray();
+            }
+        }
+    }
+
+    private sealed class HeadingChunkerListLoggerProvider : ILoggerProvider
+    {
+        private readonly HeadingChunkerListLoggerSink _sink;
+
+        public HeadingChunkerListLoggerProvider(HeadingChunkerListLoggerSink sink) => _sink = sink;
+
+        public ILogger CreateLogger(string categoryName) => new HeadingChunkerListLogger(_sink, categoryName);
+
+        public void Dispose() { }
+    }
+
+    private sealed class HeadingChunkerListLogger : ILogger
+    {
+        private readonly HeadingChunkerListLoggerSink _sink;
+        private readonly string _category;
+
+        public HeadingChunkerListLogger(HeadingChunkerListLoggerSink sink, string category)
+        {
+            _sink = sink;
+            _category = category;
+        }
+
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel,
+            EventId eventId,
+            TState state,
+            Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            ArgumentNullException.ThrowIfNull(formatter);
+            var msg = formatter(state, exception);
+            var suffix = exception is not null
+                ? $" | Ex={exception.GetType().Name}: {exception.Message}\n{exception.StackTrace}"
+                : string.Empty;
+            var lastDot = _category.LastIndexOf('.');
+            var shortCategory = lastDot >= 0 ? _category[(lastDot + 1)..] : _category;
+            _sink.Append($"[{logLevel}] {shortCategory}: {msg}{suffix}");
+        }
+
+        private sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new();
+            public void Dispose() { }
+        }
     }
 }

--- a/docs/superpowers/plans/2026-07-21-rag-retrieval-sp2-hierarchical-chunking.md
+++ b/docs/superpowers/plans/2026-07-21-rag-retrieval-sp2-hierarchical-chunking.md
@@ -1,0 +1,955 @@
+# SP2 — Hierarchical Chunking + Persistence Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire SP1's heading-aware extraction into all 4 ingestion pipelines so persisted `TextChunkEntity` rows carry a real per-section `Heading`, activating the deterministic role-classification fast-path.
+
+**Architecture:** A shared `IHeadingAwareChunker` (DocumentProcessing) encapsulates `ExtractedDocumentFactory.FromExtraction` → `AdvancedChunkingService.ChunkDocumentAsync` → child-only mapper → oversize post-split, returning `List<DocumentChunkInput>`. The 4 pipelines call it (via scope-resolve for the 2 background handlers, ctor-optional for the 2 in-scope handlers). `StructuredElements` is persisted as versioned JSON on `PdfDocumentEntity` so `IndexPdf` (which only has flat `ExtractedText`) can rebuild the `ExtractedDocument`.
+
+**Tech Stack:** .NET 9 (xUnit, Moq, FluentAssertions, EF Core + Npgsql, Testcontainers for integration).
+
+**Spec:** `docs/superpowers/specs/2026-07-21-rag-retrieval-sp2-hierarchical-chunking-design.md`
+
+> **Review 2026-07-21**: piano rivisto dopo review adversariale multi-lente (15 finding applicati) — corretto `pdf.GameId` inesistente (→ `PrivateGameId ?? SharedGameId`, threadato come parametro dove `pdfDoc` era fuori scope) in Task 4/5/6/7; Task 1 test con parent a content non-vuoto + test multi-pagina; per-child page recompute nel mapper; Task 7 unificato su `List<DocumentChunkInput>` (il `Select` con campi hierarchy non compilava su `TextChunk`); Task 4 test con harness sincrono; dual-language estratto in `TranslatedChunkMapper` + unit test; body flat espansi (no placeholder).
+
+## Global Constraints
+
+- Branch: `feature/rag-retrieval-sp2-hierarchical-chunking` (created, parent `main-dev`).
+- Commit convention: `feat|fix|test|refactor|chore(scope): subject`, subject ≤ 72 chars.
+- **Only child chunks** are persisted/embedded; `Heading` inherited from parent; `ParentChunkId = null`; `Level = 2`; `ElementType = "text"`. Parent (Level 0) chunks are NOT persisted.
+- **No embedded chunk may exceed `MaxEmbeddingChars` (1800)** — post-split any mapped child whose `Text.Length > 1800` via `ITextChunkingService.ChunkText(text, MaxEmbeddingChars, DefaultChunkOverlap)`.
+- `IHeadingAwareChunker` returns `List<DocumentChunkInput>`; `IndexPdf` builds `DocumentChunk` from those (adding `Embedding`).
+- DI: IndexPdf + PdfProcessingPipeline get a trailing optional `IHeadingAwareChunker? = null` (null → existing flat path); Upload + Complete resolve it from the async scope (`scope.ServiceProvider.GetService<IHeadingAwareChunker>()`). Both cases null → flat fallback, so the ~13 existing test ctor sites keep compiling.
+- `StructuredElementsJson` persisted as `{ SchemaVersion, Elements }` with **default** `JsonSerializer` options (PascalCase, matching `ExtractedTables`/`ExtractedDiagrams`); reader tolerant + `try/catch(JsonException)` → null (never hard-fail). Invariant: every writer of `ExtractedText` co-writes or nulls `StructuredElementsJson` in the same `SaveChanges`.
+- Dual-language (PdfProcessingPipeline): translated chunks propagate `origChunk.Heading/Level/ElementType`.
+- null-path (no/failed StructuredElements) → `FromExtraction(null)` → child with `Heading=null`; boundaries change vs today (not byte-identical); assert content-preservation + `Heading=null`, NOT equality.
+- Backend build/test from `apps/api/src/Api`; kill stray `testhost` on lock errors; `git commit` triggers ~5-min FE pre-commit hook (expected, don't `--no-verify`).
+
+## File Structure
+
+**Create:**
+- `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/Chunking/HierarchicalChunkMapper.cs`
+- `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/Chunking/IHeadingAwareChunker.cs` (interface + impl `HeadingAwareChunker`)
+- `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/Chunking/StructuredElementsPayload.cs` (versioned DTO + serializer helper)
+- Migration `apps/api/src/Api/Infrastructure/Migrations/<timestamp>_AddStructuredElementsJson.cs` (via `dotnet ef`)
+- Tests mirroring each.
+
+**Modify:**
+- `PdfDocumentEntity.cs` (add `StructuredElementsJson`)
+- `UploadPdfCommandHandler.Processing.cs`, `PdfProcessingPipelineService.cs`, `IndexPdfCommandHandler.cs`, `CompleteChunkedUploadCommandHandler.cs` (wire chunker + persist JSON)
+- `ExtractPdfTextCommandHandler.cs` (invariant co-write)
+- `DocumentProcessingServiceExtensions.cs` (DI register `IHeadingAwareChunker`)
+
+---
+
+### Task 1: `HierarchicalChunkMapper` (child-only, pure)
+
+**Files:**
+- Create: `.../DocumentProcessing/Application/Services/Chunking/HierarchicalChunkMapper.cs`
+- Test: `apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Services/Chunking/HierarchicalChunkMapperTests.cs`
+
+**Interfaces:**
+- Produces: `static List<DocumentChunkInput> ToChildDocumentChunks(IReadOnlyList<HierarchicalChunk> chunks)` — child (Level 2, non-root) only, Heading inherited, per-child page, `ParentChunkId=null`, `Level=2`, `ElementType` from child metadata.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `HierarchicalChunkMapperTests.cs`:
+
+```csharp
+using Api.BoundedContexts.DocumentProcessing.Application.Services.Chunking;
+using Api.BoundedContexts.KnowledgeBase.Domain.Chunking;
+using FluentAssertions;
+using Xunit;
+using Api.Tests.Constants;
+
+namespace Api.Tests.BoundedContexts.DocumentProcessing.Application.Services.Chunking;
+
+[Trait("Category", TestCategories.Unit)]
+public class HierarchicalChunkMapperTests
+{
+    private static HierarchicalChunk Parent(string heading, string content, int page = 1) =>
+        HierarchicalChunk.CreateParent(content, new ChunkMetadata { Page = page, Heading = heading, ElementType = "heading", CharStart = 0, CharEnd = content.Length, DocumentId = System.Guid.NewGuid() });
+
+    private static HierarchicalChunk Child(string parentId, string content, string? heading, int page, int charStart) =>
+        HierarchicalChunk.CreateChild(content, level: 2, new ChunkMetadata { Page = page, Heading = heading, ElementType = "text", CharStart = charStart, CharEnd = charStart + content.Length, DocumentId = System.Guid.NewGuid() }, parentId);
+
+    [Fact]
+    public void ToChildDocumentChunks_KeepsOnlyChildren_InheritsHeading()
+    {
+        var parent = Parent("Preparazione", "Preparazione body");
+        var c1 = Child(parent.Id, "Disponi le tessere.", "Preparazione", 1, 0);
+        var c2 = Child(parent.Id, "Mescola il mazzo.", "Preparazione", 1, 20);
+
+        var result = HierarchicalChunkMapper.ToChildDocumentChunks(new[] { parent, c1, c2 });
+
+        result.Should().HaveCount(2); // parent excluded
+        result[0].Text.Should().Be("Disponi le tessere.");
+        result[0].Heading.Should().Be("Preparazione");
+        result[0].Level.Should().Be(2);
+        result[0].ElementType.Should().Be("text");
+        result[0].ParentChunkId.Should().BeNull();
+    }
+
+    [Fact]
+    public void ToChildDocumentChunks_NullHeadingPreamble_Preserved()
+    {
+        var parent = Parent(null!, "intro");
+        var c = Child(parent.Id, "intro text", null, 1, 0);
+        var result = HierarchicalChunkMapper.ToChildDocumentChunks(new[] { parent, c });
+        result.Should().ContainSingle();
+        result[0].Heading.Should().BeNull();
+    }
+
+    [Fact]
+    public void ToChildDocumentChunks_OnlyParent_NoChildren_ReturnsEmpty()
+    {
+        // HierarchicalChunk forbids empty content, so the parent must carry text; the mapper still
+        // returns empty because the sole chunk IsRoot and roots are skipped.
+        var parent = Parent("Empty", "section body");
+        HierarchicalChunkMapper.ToChildDocumentChunks(new[] { parent }).Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ToChildDocumentChunks_MultiPageSection_RecomputesPagePerChild()
+    {
+        var parent = Parent("Long", "long section body");
+        // two children of the same section at very different char offsets → different pages
+        var c1 = Child(parent.Id, "early text", "Long", page: 1, charStart: 10);
+        var c2 = Child(parent.Id, "late text", "Long", page: 1, charStart: 5000);
+
+        var result = HierarchicalChunkMapper.ToChildDocumentChunks(new[] { parent, c1, c2 });
+
+        result[0].Page.Should().Be(1);           // 10 / 2000 + 1
+        result[1].Page.Should().Be(3);           // 5000 / 2000 + 1  (not collapsed to the section's page 1)
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd apps/api/src/Api && dotnet test ../../tests/Api.Tests --filter "FullyQualifiedName~HierarchicalChunkMapperTests" -v minimal`
+Expected: FAIL to compile — `HierarchicalChunkMapper` does not exist.
+
+- [ ] **Step 3: Implement the mapper**
+
+Create `HierarchicalChunkMapper.cs`:
+
+```csharp
+using Api.BoundedContexts.KnowledgeBase.Domain.Chunking;
+using Api.Services;
+
+namespace Api.BoundedContexts.DocumentProcessing.Application.Services.Chunking;
+
+/// <summary>
+/// SP2: maps AdvancedChunkingService output to embeddable inputs, keeping ONLY child chunks
+/// (Level 2). Heading is already inherited from the parent section in the child's ChunkMetadata.
+/// Parent (Level 0) chunks are not persisted; ParentChunkId is left null (only-child model).
+/// </summary>
+internal static class HierarchicalChunkMapper
+{
+    public static List<DocumentChunkInput> ToChildDocumentChunks(IReadOnlyList<HierarchicalChunk> chunks)
+    {
+        var result = new List<DocumentChunkInput>();
+        if (chunks is null)
+        {
+            return result;
+        }
+
+        foreach (var c in chunks)
+        {
+            if (c.IsRoot)
+            {
+                continue; // parent/section container is not persisted
+            }
+            if (string.IsNullOrWhiteSpace(c.Content))
+            {
+                continue;
+            }
+
+            result.Add(new DocumentChunkInput
+            {
+                Text = c.Content,
+                // Recompute per-child page from CharStart (~2000 chars/page, matching
+                // TextChunkingService.EstimatePageNumber) so a multi-page section does not collapse
+                // every child to the section's first page. Falls back to the section page for offset 0.
+                Page = c.Metadata.CharStart > 0 ? (c.Metadata.CharStart / 2000) + 1 : c.Metadata.Page,
+                CharStart = c.Metadata.CharStart,
+                CharEnd = c.Metadata.CharEnd,
+                Heading = c.Metadata.Heading,
+                Level = 2,
+                ParentChunkId = null,
+                ElementType = string.IsNullOrWhiteSpace(c.Metadata.ElementType) ? "text" : c.Metadata.ElementType,
+            });
+        }
+
+        return result;
+    }
+}
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cd apps/api/src/Api && dotnet test ../../tests/Api.Tests --filter "FullyQualifiedName~HierarchicalChunkMapperTests" -v minimal`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/Chunking/HierarchicalChunkMapper.cs apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Services/Chunking/HierarchicalChunkMapperTests.cs
+git commit -m "feat(chunking): HierarchicalChunkMapper maps child chunks with heading"
+```
+
+---
+
+### Task 2: `IHeadingAwareChunker` shared service + DI
+
+**Files:**
+- Create: `.../DocumentProcessing/Application/Services/Chunking/IHeadingAwareChunker.cs`
+- Modify: `.../DocumentProcessing/Infrastructure/DependencyInjection/DocumentProcessingServiceExtensions.cs`
+- Test: `.../DocumentProcessing/Application/Services/Chunking/HeadingAwareChunkerTests.cs`
+
+**Interfaces:**
+- Consumes: `ExtractedDocumentFactory.FromExtraction`, `IAdvancedChunkingService.ChunkDocumentAsync`, `HierarchicalChunkMapper`, `ITextChunkingService` (post-split).
+- Produces: `Task<List<DocumentChunkInput>> ChunkAsync(Guid documentId, Guid? gameId, IReadOnlyList<ExtractedElement>? structuredElements, string fullText, CancellationToken ct)`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `HeadingAwareChunkerTests.cs`:
+
+```csharp
+using Api.BoundedContexts.DocumentProcessing.Application.Services.Chunking;
+using Api.BoundedContexts.DocumentProcessing.Domain.Services;
+using Api.BoundedContexts.KnowledgeBase.Application.Services.Chunking;
+using Api.BoundedContexts.KnowledgeBase.Domain.Services;
+using Api.Constants;
+using Api.Services;
+using FluentAssertions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+using Api.Tests.Constants;
+
+namespace Api.Tests.BoundedContexts.DocumentProcessing.Application.Services.Chunking;
+
+[Trait("Category", TestCategories.Unit)]
+public class HeadingAwareChunkerTests
+{
+    private static CancellationToken Ct => TestContext.Current.CancellationToken;
+
+    // Real collaborators (all pure/deterministic): TextChunkingService + strategy selector + AdvancedChunkingService.
+    private static HeadingAwareChunker CreateChunker()
+    {
+        var textChunking = new TextChunkingService(NullLogger<TextChunkingService>.Instance);
+        var selector = new ChunkingStrategySelector();
+        var advanced = new AdvancedChunkingService(textChunking, selector, NullLogger<AdvancedChunkingService>.Instance);
+        return new HeadingAwareChunker(advanced, textChunking, NullLogger<HeadingAwareChunker>.Instance);
+    }
+
+    [Fact]
+    public async Task ChunkAsync_WithTitleElement_ProducesChildrenWithHeading()
+    {
+        var elements = new List<ExtractedElement>
+        {
+            new("Preparazione", 1, "Title"),
+            new("Disponi le tessere sul tavolo e mescola il mazzo di carte.", 1, "NarrativeText"),
+        };
+        var chunker = CreateChunker();
+
+        var result = await chunker.ChunkAsync(System.Guid.NewGuid(), null, elements, "flat", Ct);
+
+        result.Should().NotBeEmpty();
+        result.Should().OnlyContain(c => c.Heading == "Preparazione");
+    }
+
+    [Fact]
+    public async Task ChunkAsync_NullElements_ProducesNullHeadingChildren_ContentPreserved()
+    {
+        var chunker = CreateChunker();
+        var flat = "Some flat body text without any structure.";
+        var result = await chunker.ChunkAsync(System.Guid.NewGuid(), null, null, flat, Ct);
+
+        result.Should().NotBeEmpty();
+        result.Should().OnlyContain(c => c.Heading == null);
+        string.Join(" ", result.Select(c => c.Text)).Should().Contain("flat body text");
+    }
+
+    [Fact]
+    public async Task ChunkAsync_NoChildExceedsMaxEmbeddingChars()
+    {
+        var longBody = string.Join(" ", Enumerable.Repeat("parola", 1200)); // > 1800 chars, narrative → Sparse (2000)
+        var elements = new List<ExtractedElement> { new("Regole", 1, "Title"), new(longBody, 1, "NarrativeText") };
+        var chunker = CreateChunker();
+
+        var result = await chunker.ChunkAsync(System.Guid.NewGuid(), null, elements, "flat", Ct);
+
+        result.Should().OnlyContain(c => c.Text.Length <= ChunkingConstants.MaxEmbeddingChars);
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd apps/api/src/Api && dotnet test ../../tests/Api.Tests --filter "FullyQualifiedName~HeadingAwareChunkerTests" -v minimal`
+Expected: FAIL to compile — `IHeadingAwareChunker`/`HeadingAwareChunker` do not exist.
+
+- [ ] **Step 3: Implement the service + register DI**
+
+Create `IHeadingAwareChunker.cs`:
+
+```csharp
+using Api.BoundedContexts.DocumentProcessing.Domain.Services;
+using Api.BoundedContexts.KnowledgeBase.Application.Services.Chunking;
+using Api.Constants;
+using Api.Services;
+
+#pragma warning disable MA0048 // File name must match type name — interface + impl together
+namespace Api.BoundedContexts.DocumentProcessing.Application.Services.Chunking;
+
+internal interface IHeadingAwareChunker
+{
+    Task<List<DocumentChunkInput>> ChunkAsync(
+        Guid documentId,
+        Guid? gameId,
+        IReadOnlyList<ExtractedElement>? structuredElements,
+        string fullText,
+        CancellationToken ct);
+}
+
+internal sealed class HeadingAwareChunker : IHeadingAwareChunker
+{
+    private readonly IAdvancedChunkingService _advanced;
+    private readonly ITextChunkingService _textChunking;
+    private readonly ILogger<HeadingAwareChunker> _logger;
+
+    public HeadingAwareChunker(
+        IAdvancedChunkingService advanced,
+        ITextChunkingService textChunking,
+        ILogger<HeadingAwareChunker> logger)
+    {
+        _advanced = advanced;
+        _textChunking = textChunking;
+        _logger = logger;
+    }
+
+    public async Task<List<DocumentChunkInput>> ChunkAsync(
+        Guid documentId, Guid? gameId,
+        IReadOnlyList<ExtractedElement>? structuredElements,
+        string fullText, CancellationToken ct)
+    {
+        var document = ExtractedDocumentFactory.FromExtraction(documentId, gameId, structuredElements, fullText ?? string.Empty);
+        var hchunks = await _advanced.ChunkDocumentAsync(document, config: null, ct).ConfigureAwait(false);
+        var mapped = HierarchicalChunkMapper.ToChildDocumentChunks(hchunks);
+        return PostSplitOversized(mapped);
+    }
+
+    // Mirror of EnhancedPdfProcessingOrchestrator.SplitOversizedPageChunks: no embedded chunk may exceed
+    // MaxEmbeddingChars (E5-base token limit); Sparse strategy can emit ~2000-char children.
+    private List<DocumentChunkInput> PostSplitOversized(List<DocumentChunkInput> chunks)
+    {
+        var result = new List<DocumentChunkInput>(chunks.Count);
+        foreach (var chunk in chunks)
+        {
+            if (chunk.Text.Length <= ChunkingConstants.MaxEmbeddingChars)
+            {
+                result.Add(chunk);
+                continue;
+            }
+
+            var subs = _textChunking.ChunkText(chunk.Text, ChunkingConstants.MaxEmbeddingChars, ChunkingConstants.DefaultChunkOverlap);
+            foreach (var sub in subs.Where(s => !string.IsNullOrWhiteSpace(s.Text)))
+            {
+                result.Add(chunk with
+                {
+                    Text = sub.Text,
+                    CharStart = chunk.CharStart + sub.CharStart,
+                    CharEnd = chunk.CharStart + sub.CharEnd,
+                });
+            }
+        }
+        return result;
+    }
+}
+```
+
+In `DocumentProcessingServiceExtensions.cs`, register (near the other DocumentProcessing service registrations):
+
+```csharp
+        services.AddScoped<IHeadingAwareChunker, HeadingAwareChunker>();
+```
+
+(`AdvancedChunkingService`/`ITextChunkingService`/`ChunkingStrategySelector` are already registered in KnowledgeBase/Application DI.)
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cd apps/api/src/Api && dotnet test ../../tests/Api.Tests --filter "FullyQualifiedName~HeadingAwareChunkerTests" -v minimal`
+Expected: PASS (heading inherited, null-path, no child > 1800).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/Chunking/IHeadingAwareChunker.cs apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/DependencyInjection/DocumentProcessingServiceExtensions.cs apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Services/Chunking/HeadingAwareChunkerTests.cs
+git commit -m "feat(chunking): IHeadingAwareChunker shared service with oversize post-split"
+```
+
+---
+
+### Task 3: Persist `StructuredElements` (migration + versioned JSON)
+
+**Files:**
+- Modify: `.../Infrastructure/Entities/DocumentProcessing/PdfDocumentEntity.cs`
+- Create: `.../DocumentProcessing/Application/Services/Chunking/StructuredElementsPayload.cs`
+- Migration via `dotnet ef migrations add AddStructuredElementsJson`
+- Test: `.../Chunking/StructuredElementsPayloadTests.cs`
+
+**Interfaces:**
+- Produces: `PdfDocumentEntity.StructuredElementsJson` (`string?`); `StructuredElementsPayload.Serialize(elements) -> string?`, `StructuredElementsPayload.TryDeserialize(json) -> IReadOnlyList<ExtractedElement>?` (tolerant, never throws).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `StructuredElementsPayloadTests.cs`:
+
+```csharp
+using Api.BoundedContexts.DocumentProcessing.Application.Services.Chunking;
+using Api.BoundedContexts.DocumentProcessing.Domain.Services;
+using FluentAssertions;
+using Xunit;
+using Api.Tests.Constants;
+
+namespace Api.Tests.BoundedContexts.DocumentProcessing.Application.Services.Chunking;
+
+[Trait("Category", TestCategories.Unit)]
+public class StructuredElementsPayloadTests
+{
+    [Fact]
+    public void RoundTrip_PreservesElements()
+    {
+        var elements = new List<ExtractedElement> { new("Setup", 1, "Title"), new("body", 2, "NarrativeText") };
+        var json = StructuredElementsPayload.Serialize(elements);
+        json.Should().NotBeNullOrEmpty();
+
+        var back = StructuredElementsPayload.TryDeserialize(json);
+        back.Should().NotBeNull();
+        back!.Select(e => (e.Text, e.PageNumber, e.ElementType))
+            .Should().Equal(("Setup", 1, "Title"), ("body", 2, "NarrativeText"));
+    }
+
+    [Fact]
+    public void Serialize_NullOrEmpty_ReturnsNull()
+    {
+        StructuredElementsPayload.Serialize(null).Should().BeNull();
+        StructuredElementsPayload.Serialize(new List<ExtractedElement>()).Should().BeNull();
+    }
+
+    [Fact]
+    public void TryDeserialize_MalformedOrLegacy_ReturnsNull_NeverThrows()
+    {
+        StructuredElementsPayload.TryDeserialize("{ not valid json").Should().BeNull();
+        StructuredElementsPayload.TryDeserialize(null).Should().BeNull();
+        // legacy/unknown shape tolerated (unknown members ignored, missing -> null)
+        StructuredElementsPayload.TryDeserialize("{\"SchemaVersion\":99,\"Elements\":null}").Should().BeNull();
+    }
+
+    [Fact]
+    public void TryDeserialize_FrozenBlob_Reads()
+    {
+        const string frozen = "{\"SchemaVersion\":1,\"Elements\":[{\"Text\":\"Setup\",\"PageNumber\":1,\"ElementType\":\"Title\"}]}";
+        var back = StructuredElementsPayload.TryDeserialize(frozen);
+        back.Should().ContainSingle();
+        back![0].Text.Should().Be("Setup");
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd apps/api/src/Api && dotnet test ../../tests/Api.Tests --filter "FullyQualifiedName~StructuredElementsPayloadTests" -v minimal`
+Expected: FAIL to compile — `StructuredElementsPayload` does not exist.
+
+- [ ] **Step 3: Implement the payload + entity field + migration**
+
+Create `StructuredElementsPayload.cs`:
+
+```csharp
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Api.BoundedContexts.DocumentProcessing.Domain.Services;
+
+namespace Api.BoundedContexts.DocumentProcessing.Application.Services.Chunking;
+
+/// <summary>
+/// Versioned, tolerant persistence of the raw extraction elements so IndexPdf (which only has flat
+/// ExtractedText) can rebuild the ExtractedDocument. Default JSON options (PascalCase) match the
+/// existing ExtractedTables/ExtractedDiagrams columns. Reads never throw — malformed/legacy blobs
+/// return null so the caller degrades to the flat null-path.
+/// </summary>
+internal static class StructuredElementsPayload
+{
+    private const int CurrentSchemaVersion = 1;
+
+    private static readonly JsonSerializerOptions Options = new()
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    private sealed record Envelope(int SchemaVersion, IReadOnlyList<ExtractedElement>? Elements);
+
+    public static string? Serialize(IReadOnlyList<ExtractedElement>? elements)
+    {
+        if (elements is null || elements.Count == 0)
+        {
+            return null;
+        }
+        return JsonSerializer.Serialize(new Envelope(CurrentSchemaVersion, elements), Options);
+    }
+
+    public static IReadOnlyList<ExtractedElement>? TryDeserialize(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return null;
+        }
+        try
+        {
+            var env = JsonSerializer.Deserialize<Envelope>(json, Options);
+            return env?.Elements is { Count: > 0 } ? env.Elements : null;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+}
+```
+
+In `PdfDocumentEntity.cs`, after `AtomicRuleCount` (near the other JSON columns), add:
+
+```csharp
+    // SP2 (#3268): raw extraction elements (versioned JSON) so IndexPdf can rebuild the
+    // ExtractedDocument for heading-aware chunking. Invariant: co-written or nulled with ExtractedText.
+    public string? StructuredElementsJson { get; set; }
+```
+
+Generate the migration:
+
+```bash
+cd apps/api/src/Api
+dotnet ef migrations add AddStructuredElementsJson
+```
+
+Verify the generated `Up`/`Down` is a single nullable `text` `AddColumn`/`DropColumn` on `pdf_documents` (mirroring `20260714163243_AddShareRequestCoverChangeFields`). It needs NO tsvector handling (`search_vector` is `GENERATED ALWAYS` on `ExtractedText` only).
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cd apps/api/src/Api && dotnet build && dotnet test ../../tests/Api.Tests --filter "FullyQualifiedName~StructuredElementsPayloadTests" -v minimal`
+Expected: build clean (migration compiles), tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/Chunking/StructuredElementsPayload.cs apps/api/src/Api/Infrastructure/Entities/DocumentProcessing/PdfDocumentEntity.cs apps/api/src/Api/Infrastructure/Migrations/ apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Services/Chunking/StructuredElementsPayloadTests.cs
+git commit -m "feat(chunking): persist StructuredElements as versioned JSON on pdf_documents"
+```
+
+---
+
+### Task 4: Wire `UploadPdfCommandHandler` (scope-resolve + persist)
+
+**Files:**
+- Modify: `.../Application/Commands/UploadPdfCommandHandler.Processing.cs`
+- Test: `apps/api/tests/Api.Tests/Integration/UploadPdfIntegrationTests.cs` (add heading assertion)
+
+**Interfaces:**
+- Consumes: `IHeadingAwareChunker` (scope-resolved), `StructuredElementsPayload`.
+
+- [ ] **Step 1: Write the failing test**
+
+Upload's chunking runs inside `ProcessPdfAsync`, enqueued via `_backgroundTaskService.ExecuteWithCancellation(...)`. The default `UploadPdfIntegrationTests` harness registers a bare `Mock<IBackgroundTaskService>` (delegate never runs → chunks never produced), a non-success `Mock.Of<IEmbeddingService>`, and no `IRoleClassifierService`. So the test needs a **synchronous harness** to observe persisted chunks. In the test setup:
+1. Register an inline `IBackgroundTaskService` whose `ExecuteWithCancellation` **invokes the delegate synchronously** (so chunking+persistence run in-test).
+2. Register a stub `IEmbeddingService` returning `Success=true` with one 768-dim vector per input text.
+3. Register a **real** `RoleClassifierService` with a mock `ILlmService` (a `"Setup"` heading resolves via `HeadingRules` without calling the LLM).
+4. Set up `IPdfTextExtractor.ExtractPagedTextAsync` to return a `PagedTextExtractionResult` whose `StructuredElements` = `[ new ExtractedElement("Setup", 1, "Title"), new ExtractedElement("Disponi le tessere e mescola il mazzo.", 1, "NarrativeText") ]`.
+
+Then assert:
+
+```csharp
+        var chunks = await dbContext.TextChunks.Where(c => c.PdfDocumentId == pdfGuid).ToListAsync(TestContext.Current.CancellationToken);
+        chunks.Should().NotBeEmpty();
+        chunks.Should().OnlyContain(c => c.Heading == "Setup");
+        chunks.Should().Contain(c => c.RoleTags != GameBookRole.None); // heading fast-path assigned a role
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd apps/api/src/Api && dotnet test ../../tests/Api.Tests --filter "FullyQualifiedName~UploadPdfIntegrationTests" -v minimal`
+Expected: FAIL — with the synchronous harness the chunks are produced by the **flat** path, so `Heading == null` (the `OnlyContain(c => c.Heading == "Setup")` assertion fails).
+
+- [ ] **Step 3: Wire the chunker + persist JSON**
+
+In `UploadPdfCommandHandler.Processing.cs`, in `ExtractPdfContentAsync` where `pdfDoc.ExtractedText = fullText;` is set (~line 260), add:
+
+```csharp
+            pdfDoc.StructuredElementsJson = StructuredElementsPayload.Serialize(extractResult.StructuredElements);
+```
+
+Thread a game id into `ChunkExtractedTextAsync` (it has no `pdfDoc` in scope, and `PdfDocumentEntity` exposes `SharedGameId`/`PrivateGameId`, **not** `GameId`). Add a `Guid? gameId` parameter to the method signature (line 337) and update the single call site (lines 68-69) where `pdfDoc` IS in scope:
+
+```csharp
+            var allDocumentChunks = await ChunkExtractedTextAsync(
+                pdfId, fullText!, extractResult!, pdfDoc.PrivateGameId ?? pdfDoc.SharedGameId,
+                db, scope, startTime, cancellationToken).ConfigureAwait(false);
+```
+
+Then replace the body of `ChunkExtractedTextAsync` so it prefers the heading-aware chunker, falling back to the existing flat logic when unavailable:
+
+```csharp
+        var chunkingStopwatch = Stopwatch.StartNew();
+        var headingAwareChunker = scope.ServiceProvider.GetService<IHeadingAwareChunker>();
+
+        List<DocumentChunkInput> allDocumentChunks;
+        if (headingAwareChunker != null)
+        {
+            allDocumentChunks = await headingAwareChunker.ChunkAsync(
+                Guid.Parse(pdfId), gameId, extractResult.StructuredElements, fullText, cancellationToken).ConfigureAwait(false);
+        }
+        else
+        {
+            var chunkingService = scope.ServiceProvider.GetRequiredService<ITextChunkingService>();
+            const int chunkSize = 512;
+            const int chunkOverlap = 50;
+            allDocumentChunks = chunkingService.PrepareForEmbedding(fullText, chunkSize, chunkOverlap)
+                ?.Where(chunk => chunk != null && !string.IsNullOrWhiteSpace(chunk.Text))
+                .Select(chunk => new DocumentChunkInput { Text = chunk.Text, Page = chunk.Page, CharStart = chunk.CharStart, CharEnd = chunk.CharEnd })
+                .ToList()
+                ?? new List<DocumentChunkInput>();
+        }
+
+        allDocumentChunks = allDocumentChunks
+            .Where(chunk => chunk != null && !string.IsNullOrWhiteSpace(chunk.Text))
+            .ToList();
+
+        chunkingStopwatch.Stop();
+        RecordPipelineMetricSafely("chunking", chunkingStopwatch.Elapsed.TotalMilliseconds, allDocumentChunks.Count);
+        return allDocumentChunks;
+```
+
+(`gameId` is functionally immaterial to the persisted chunk — the mapper does not carry `Metadata.GameId` — but the literal `pdfDoc.GameId` must be removed to compile.) The downstream `SaveTextChunksForHybridSearchAsync` already copies `chunk.Heading/Level/ParentChunkId/ElementType` onto `TextChunkEntity` and calls the role classifier — no change needed there.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cd apps/api/src/Api && dotnet test ../../tests/Api.Tests --filter "FullyQualifiedName~UploadPdfIntegrationTests" -v minimal`
+Expected: PASS (Heading persisted, role assigned).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommandHandler.Processing.cs apps/api/tests/Api.Tests/Integration/UploadPdfIntegrationTests.cs
+git commit -m "feat(chunking): wire heading-aware chunker into UploadPdf + persist elements"
+```
+
+---
+
+### Task 5: Wire `PdfProcessingPipelineService` (ctor optional + dual-language)
+
+**Files:**
+- Modify: `.../Application/Services/PdfProcessingPipelineService.cs`
+- Test: `.../Application/Services/PdfProcessingPipelineServiceCoverTests.cs` (or a new focused test) — dual-language heading propagation.
+
+**Interfaces:**
+- Consumes: `IHeadingAwareChunker?` (trailing optional ctor param).
+
+- [ ] **Step 1: Write the failing test**
+
+The full pipeline is infeasible via `PdfProcessingPipelineServiceCoverTestFactory` (heavy deps + background execution). Instead, extract a pure static helper for the translated-chunk mapping and unit-test it in isolation. Create `.../Chunking/TranslatedChunkMapper.cs` test:
+
+```csharp
+using Api.BoundedContexts.DocumentProcessing.Application.Services.Chunking;
+using Api.Services;
+using FluentAssertions;
+using Xunit;
+using Api.Tests.Constants;
+
+namespace Api.Tests.BoundedContexts.DocumentProcessing.Application.Services.Chunking;
+
+[Trait("Category", TestCategories.Unit)]
+public class TranslatedChunkMapperTests
+{
+    [Fact]
+    public void ForTranslation_PreservesHeadingAndHierarchy()
+    {
+        var orig = new DocumentChunkInput { Text = "Disponi", Page = 3, CharStart = 10, CharEnd = 17, Heading = "Setup", Level = 2, ElementType = "text" };
+        var translated = TranslatedChunkMapper.ForTranslation(orig, "Lay out");
+        translated.Text.Should().Be("Lay out");
+        translated.Heading.Should().Be("Setup");   // heading inherited on the EN chunk (was dropped before SP2)
+        translated.Page.Should().Be(3);
+        translated.Level.Should().Be(2);
+        translated.ElementType.Should().Be("text");
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd apps/api/src/Api && dotnet test ../../tests/Api.Tests --filter "FullyQualifiedName~PdfProcessingPipelineService" -v minimal`
+Expected: FAIL — translated chunks have `Heading == null`.
+
+- [ ] **Step 3: Add optional ctor param, wire chunker, propagate Heading**
+
+Add trailing optional param to the ctor (after `pdfCoverUploadPipeline`):
+
+```csharp
+        IPdfCoverUploadPipeline? pdfCoverUploadPipeline = null,
+        IHeadingAwareChunker? headingAwareChunker = null)
+```
+
+Field: `private readonly IHeadingAwareChunker? _headingAwareChunker;` and assign `_headingAwareChunker = headingAwareChunker;`.
+
+At the `pdfDoc.ExtractedText = fullText;` write site, add `pdfDoc.StructuredElementsJson = StructuredElementsPayload.Serialize(extractResult.StructuredElements);`.
+
+Change `ChunkText` (line 655) into an async method that prefers the chunker, with the existing flat body pasted verbatim as fallback:
+
+```csharp
+    private async Task<List<DocumentChunkInput>> ChunkTextAsync(string fullText, PagedTextExtractionResult extractResult, Guid documentId, Guid? gameId, CancellationToken ct)
+    {
+        if (_headingAwareChunker != null)
+        {
+            var hc = await _headingAwareChunker.ChunkAsync(documentId, gameId, extractResult.StructuredElements, fullText, ct).ConfigureAwait(false);
+            var filtered = hc.Where(c => c != null && !string.IsNullOrWhiteSpace(c.Text)).ToList();
+            if (filtered.Count > 0) return filtered;
+        }
+
+        // Flat fallback (unchanged from the original ChunkText body: PrepareForEmbedding 1024/150 + page fallback).
+        var chunks = _chunkingService.PrepareForEmbedding(fullText, ChunkSize, ChunkOverlap)
+            ?.Where(c => c != null && !string.IsNullOrWhiteSpace(c.Text))
+            .ToList()
+            ?? [];
+
+        if (chunks.Count == 0)
+        {
+            foreach (var pageChunk in extractResult.PageChunks.Where(pc => !pc.IsEmpty))
+            {
+                var pageTextChunks = _chunkingService.ChunkText(pageChunk.Text, ChunkSize, ChunkOverlap);
+                foreach (var textChunk in pageTextChunks.Where(t => !string.IsNullOrWhiteSpace(t.Text)))
+                {
+                    chunks.Add(new DocumentChunkInput { Text = textChunk.Text, Page = pageChunk.PageNumber, CharStart = textChunk.CharStart, CharEnd = textChunk.CharEnd });
+                }
+            }
+        }
+
+        return chunks.Where(c => c != null && !string.IsNullOrWhiteSpace(c.Text)).ToList();
+    }
+```
+
+Update the call site (line 191) to `await ChunkTextAsync(fullText, extractResult, pdfDoc.Id, pdfDoc.PrivateGameId ?? pdfDoc.SharedGameId, cancellationToken)`.
+
+Create the pure helper `.../Chunking/TranslatedChunkMapper.cs`:
+
+```csharp
+using Api.Services;
+
+namespace Api.BoundedContexts.DocumentProcessing.Application.Services.Chunking;
+
+/// <summary>
+/// SP2: builds the English-translation chunk from an original chunk, preserving all hierarchy
+/// fields (Heading/Level/ParentChunkId/ElementType) so translated chunks of non-EN rulebooks also
+/// activate the role fast-path (resolves the #730 forward-wiring TODO in PdfProcessingPipelineService).
+/// </summary>
+internal static class TranslatedChunkMapper
+{
+    public static DocumentChunkInput ForTranslation(DocumentChunkInput orig, string translatedText) =>
+        orig with { Text = translatedText };
+}
+```
+
+Fix the dual-language TODO (lines 225-235) to use it:
+
+```csharp
+                            translatedChunks.Add((
+                                TranslatedChunkMapper.ForTranslation(origChunk, t.TranslatedText),
+                                "en",
+                                true));
+```
+
+(The record `with`-expression preserves `Page/CharStart/CharEnd/Heading/Level/ParentChunkId/ElementType`; the helper pins that contract so a future non-record refactor cannot silently drop the heading again.)
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `cd apps/api/src/Api && dotnet test ../../tests/Api.Tests --filter "FullyQualifiedName~PdfProcessingPipelineService" -v minimal`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineServiceCoverTests.cs
+git commit -m "feat(chunking): wire chunker into PdfProcessingPipeline + dual-language heading"
+```
+
+---
+
+### Task 6: Wire `CompleteChunkedUploadCommandHandler` (signature + scope-resolve)
+
+**Files:**
+- Modify: `.../Application/Commands/CompleteChunkedUploadCommandHandler.cs`
+- Test: `.../Application/Commands/CompleteChunkedUploadDedupTests.cs` (or focused) — heading persisted.
+
+- [ ] **Step 1: Write the failing test** — given StructuredElements with a `"Setup"` Title, the persisted `text_chunks` have `Heading == "Setup"`.
+
+- [ ] **Step 2: Run to verify it fails** (Heading null).
+
+- [ ] **Step 3: Change signature + wire chunker + persist JSON**
+
+Change `ExtractPdfTextAsync` (line 565) return type to surface StructuredElements:
+
+```csharp
+    private async Task<(bool success, string? fullText, int totalPages, IReadOnlyList<ExtractedElement>? structuredElements)> ExtractPdfTextAsync(...)
+    {
+        ...
+        pdfDoc.ExtractedText = fullText;
+        pdfDoc.StructuredElementsJson = StructuredElementsPayload.Serialize(extractResult.StructuredElements);
+        ...
+        return (true, fullText, extractResult.TotalPages, extractResult.StructuredElements);
+    }
+```
+
+Update the caller (line 482): `var (extractSuccess, fullText, totalPages, structuredElements) = await ExtractPdfTextAsync(...)`, then pass the extra args into `ChunkTextContentAsync(pdfId, fullText!, structuredElements, pdfGuid, pdfDoc.PrivateGameId ?? pdfDoc.SharedGameId, scope)`. New method (heading-aware branch + the existing flat body pasted verbatim as fallback):
+
+```csharp
+    private async Task<List<DocumentChunkInput>> ChunkTextContentAsync(
+        string pdfId, string fullText, IReadOnlyList<ExtractedElement>? structuredElements,
+        Guid documentId, Guid? gameId, IServiceScope scope)
+    {
+        var headingAwareChunker = scope.ServiceProvider.GetService<IHeadingAwareChunker>();
+        if (headingAwareChunker != null)
+        {
+            var hc = await headingAwareChunker.ChunkAsync(documentId, gameId, structuredElements, fullText, CancellationToken.None).ConfigureAwait(false);
+            var filtered = hc.Where(c => c != null && !string.IsNullOrWhiteSpace(c.Text)).ToList();
+            if (filtered.Count > 0) return filtered;
+        }
+
+        // Flat fallback (unchanged from the original ChunkTextContentAsync body).
+        var chunkingService = scope.ServiceProvider.GetRequiredService<ITextChunkingService>();
+        const int chunkSize = 512;
+        const int chunkOverlap = 50;
+        var allDocumentChunks = chunkingService.PrepareForEmbedding(fullText, chunkSize, chunkOverlap)
+            ?.Where(chunk => chunk != null && !string.IsNullOrWhiteSpace(chunk.Text))
+            .Select(chunk => new DocumentChunkInput { Text = chunk.Text, Page = chunk.Page, CharStart = chunk.CharStart, CharEnd = chunk.CharEnd })
+            .ToList()
+            ?? new List<DocumentChunkInput>();
+
+        return allDocumentChunks.Where(chunk => chunk != null && !string.IsNullOrWhiteSpace(chunk.Text)).ToList();
+    }
+```
+
+- [ ] **Step 4: Run to verify it passes.**
+- [ ] **Step 5: Commit** `feat(chunking): wire chunker into CompleteChunkedUpload + surface elements`.
+
+---
+
+### Task 7: Wire `IndexPdfCommandHandler` (read JSON → chunker → DocumentChunk)
+
+**Files:**
+- Modify: `.../Application/Commands/IndexPdfCommandHandler.cs`
+- Test: `.../Application/Handlers/IndexPdfCommandHandlerTests.cs` — from `StructuredElementsJson`, chunks carry Heading; malformed JSON → flat fallback (no throw).
+
+> **Note for implementer:** `IndexPdfIntegrationTests.cs:440` reportedly constructs the handler with 5 args against a 7-mandatory ctor — verify whether that file currently compiles before starting; if it is stale/relies on a helper, do not let the new optional param mask a pre-existing break. The new trailing `IHeadingAwareChunker? = null` does not change any existing site.
+
+- [ ] **Step 1: Write the failing test** — handler given a `PdfDocumentEntity` with `StructuredElementsJson` containing a `"Setup"` Title → persisted chunks `Heading == "Setup"`; a second test with `StructuredElementsJson = "{malformed"` → succeeds via flat path, no exception.
+
+- [ ] **Step 2: Run to verify it fails.**
+
+- [ ] **Step 3: Add optional ctor param + read JSON + build DocumentChunk**
+
+Add trailing optional ctor param `IHeadingAwareChunker? headingAwareChunker = null` + field `_headingAwareChunker`. Thread the `pdf` entity into `ChunkAndEmbedTextAsync` (extend its signature and the call at lines 100-101, which currently passes only `pdf.ExtractedText!`) so `StructuredElementsJson` + game id are available. `IndexPdf` runs in-scope, so ctor injection is correct.
+
+**Unify both paths on `List<DocumentChunkInput>`** — the current flat path uses `_chunkingService.ChunkText(...)` returning `List<TextChunk>`, which has NO hierarchy fields (a `DocumentChunk` Select reading `chunk.Heading` on a `TextChunk` is CS1061). Replace the `var textChunks = _chunkingService.ChunkText(extractedText);` block with a single unified list:
+
+```csharp
+        var structured = StructuredElementsPayload.TryDeserialize(pdf.StructuredElementsJson); // null on malformed → flat
+        List<DocumentChunkInput> chunkInputs =
+            (_headingAwareChunker != null
+                ? await _headingAwareChunker.ChunkAsync(Guid.Parse(pdfId), pdf.PrivateGameId ?? pdf.SharedGameId, structured, extractedText, cancellationToken).ConfigureAwait(false)
+                : null) is { Count: > 0 } hc
+            ? hc
+            : (_chunkingService.PrepareForEmbedding(extractedText) ?? new List<DocumentChunkInput>());
+
+        chunkInputs = chunkInputs.Where(c => c != null && !string.IsNullOrWhiteSpace(c.Text)).ToList();
+
+        if (chunkInputs.Count == 0)
+        {
+            _logger.LogWarning("No chunks created for PDF {PdfId}", pdfId);
+            return (false, null, "No chunks created from text", PdfIndexingErrorCode.ChunkingFailed);
+        }
+```
+
+Then drive the existing batch/embedding loop off `chunkInputs` (its `.Text` is what the loop already reads) and construct `DocumentChunk` carrying the hierarchy fields — valid for BOTH paths because `chunkInputs` is always `DocumentChunkInput` (the flat path leaves `Heading` null via defaults):
+
+```csharp
+            var batchChunks = chunkInputs.Skip(i).Take(batchSize)
+                .Select((chunk, index) => new DocumentChunk
+                {
+                    Text = chunk.Text,
+                    Embedding = embeddingResult.Embeddings[index],
+                    Page = chunk.Page,
+                    CharStart = chunk.CharStart,
+                    CharEnd = chunk.CharEnd,
+                    Heading = chunk.Heading,
+                    Level = chunk.Level,
+                    ParentChunkId = chunk.ParentChunkId,
+                    ElementType = chunk.ElementType,
+                })
+                .ToList();
+```
+
+(Rename `textChunks` → `chunkInputs` throughout the loop; `PrepareForEmbedding` internally calls `ChunkText` and wraps in `DocumentChunkInput`, so the flat path is behavior-equivalent to today.)
+
+- [ ] **Step 4: Run to verify it passes** (heading from JSON; malformed → flat, no throw).
+- [ ] **Step 5: Commit** `feat(chunking): wire chunker into IndexPdf via persisted StructuredElements`.
+
+---
+
+### Task 8: `ExtractedText↔StructuredElementsJson` invariant + role-fast-path regression
+
+**Files:**
+- Modify: `.../Application/Commands/ExtractPdfTextCommandHandler.cs`
+- Test: `.../DocumentProcessing/.../ExtractPdfTextCommandHandlerTests.cs` (co-write); role-fast-path regression test.
+
+- [ ] **Step 1: Write the failing tests**
+
+(a) `ExtractPdfTextCommandHandler` co-write: after re-extraction, `pdf.StructuredElementsJson` is set from `extractResult.StructuredElements` in the same `SaveChanges` (assert non-null when elements present; null when absent). 
+(b) Role-fast-path regression: a chunk with `Heading = "Setup"` → `RoleClassifierService.ClassifyAsync` returns a non-`None` role and the injected `ILlmService` mock is **never** invoked; companion: `Heading = "Zzz Random"` (matches no `HeadingRule`) → routes to the LLM fallback.
+
+- [ ] **Step 2: Run to verify they fail.**
+
+- [ ] **Step 3: Implement**
+
+In `ExtractPdfTextCommandHandler.cs`, where `pdf.ExtractedText = fullText;` is set (line ~135), add the co-write:
+
+```csharp
+            pdf.StructuredElementsJson = StructuredElementsPayload.Serialize(extractResult.StructuredElements);
+```
+
+(The role-fast-path is already correct in `RoleClassifierService`; the test asserts the existing behavior now that Heading is populated — no production change needed beyond confirming the wiring. If the test reveals a gap, fix in `TextChunkRoleClassifier`.)
+
+- [ ] **Step 4: Run to verify they pass.**
+- [ ] **Step 5: Commit** `feat(chunking): ExtractedText/StructuredElements invariant + role fast-path test`.
+
+---
+
+## Final verification (before PR)
+
+- [ ] `cd apps/api/src/Api && dotnet build` → 0 errors (migration + all wiring compile).
+- [ ] `dotnet test ../../tests/Api.Tests --filter "Category=Unit&FullyQualifiedName~Chunking" -v minimal` → green.
+- [ ] Targeted integration: `dotnet test ../../tests/Api.Tests --filter "FullyQualifiedName~UploadPdfIntegrationTests|FullyQualifiedName~IndexPdfCommandHandlerTests|FullyQualifiedName~CompleteChunkedUpload" -v minimal` → green.
+- [ ] The ~13 handler ctor test sites compile unchanged (no arg added at call sites).
+- [ ] PR to `main-dev` (Part of #3266, Closes #3268) with per-pipeline heading evidence.
+
+## Self-review coverage (spec → task)
+
+- §4.1 IHeadingAwareChunker (FromExtraction→Chunk→mapper→post-split) → Task 2.
+- §4.2 mapper child-only → Task 1.
+- §4.3 DI optional/scope → Tasks 4-7 (Upload/Complete scope-resolve; Pipeline/IndexPdf ctor-optional).
+- §4.4 clamp/post-split MaxEmbeddingChars → Task 2 `PostSplitOversized`.
+- §4.5 per-child page → Task 1 (child metadata page).
+- §4.6 versioned JSON + tolerant read + invariant → Task 3 + Task 8.
+- §4.7 dual-language Heading → Task 5.
+- §5 null-path content-preservation → Task 2 test.
+- §6 per-pipeline + role-fast-path (match + non-match) + JSON-written → Tasks 4-8.
+- §7 DoD per-pipeline → Tasks 4-7.

--- a/docs/superpowers/specs/2026-07-21-rag-retrieval-sp2-hierarchical-chunking-design.md
+++ b/docs/superpowers/specs/2026-07-21-rag-retrieval-sp2-hierarchical-chunking-design.md
@@ -1,0 +1,282 @@
+# SP2 — Hierarchical Chunking + Persistence (RAG retrieval heading-aware epic)
+
+**Data**: 2026-07-21
+**Epic**: RAG retrieval heading-aware (#3266) — SP2 di 4, issue #3268
+**Dipende da**: SP1 (#3267, merged `a6bd3df91`)
+**Stato**: design v2 — corretto dopo review adversariale multi-esperto (23 finding)
+**Branch previsto**: `feature/rag-retrieval-sp2-hierarchical-chunking`
+
+> **v2 changelog** — la review ha invalidato quattro assunzioni: (1) il null-path NON è
+> byte-identico al flat attuale (passa per `AdvancedChunkingService` con config diversa); (2) la
+> strategia Sparse (2000 char) supera `MaxEmbeddingChars` (1800) → truncation silenziosa; (3) la
+> branch dual-language ricostruisce i chunk tradotti scartando l'heading; (4) le 4 pipeline non
+> condividono la shape `DocumentChunkInput` (IndexPdf usa `DocumentChunk`). La v2 corregge questi
+> punti + robustezza persistenza + un servizio di chunking condiviso. Dettaglio in §10.
+
+---
+
+## 1. Contesto epic
+
+SP2 è il secondo di 4 sub-progetti (#3266). SP1 ha reso disponibili `StructuredElements` +
+`ExtractedDocumentFactory.FromExtraction`, ma senza consumer. SP2 wire il chunking heading-aware
+nelle **4** pipeline di ingestion e persiste gli heading.
+
+### 1.1 Decisioni cardine (brainstorming 2026-07-21)
+
+| Decisione | Scelta |
+|---|---|
+| Cosa si embedda/persiste | **Solo i child (sentence), Heading ereditato dal parent** — parent non persistito, `ParentChunkId = null` |
+| Ampiezza pipeline | **Tutte e 4** (IndexPdf via StructuredElementsJson; Complete via cambio signature) |
+
+### 1.2 Obiettivo (preciso, corretto post-review)
+
+Popolare `TextChunkEntity.Heading` con il **valore reale per-sezione** dai raw elements. Questo
+**riduce** (non elimina) l'uso del fallback LLM nella role-classification: un chunk il cui `Heading`
+matcha una `HeadingRule` (es. "Setup"/"Preparazione"/"Combat") viene classificato deterministicamente
+e **non** invoca l'LLM; un heading non-vuoto che non matcha alcuna regola resta `None` → fallback
+(comportamento corretto). 🔸 **Level** dei child persistiti è costante `2` e **ElementType** costante
+`"text"` (i child sono corpo; la normalizzazione heading/table vive sul parent, non persistito):
+solo `Heading` porta valori reali per-sezione. #730 `ElementType` resta uniformemente `"text"` dopo
+SP2 (per-chunk ElementType è un **non-goal**, eventuale follow-up).
+
+---
+
+## 2. Problema: la catena attuale (verificata)
+
+Le 4 pipeline chunkano flat, ma **non in modo uniforme**:
+- Upload / PdfProcessingPipeline / Complete: `fullText` → `ITextChunkingService.PrepareForEmbedding(fullText, …)` → `List<DocumentChunkInput>`.
+- **IndexPdf**: `pdf.ExtractedText` → `ITextChunkingService.ChunkText(extractedText)` → `List<DocumentChunk>` (tipo diverso, porta `Embedding`).
+
+Poi: embeddings (`IEmbeddingService`) → `TextChunkEntity` + pgvector.
+
+- `AdvancedChunkingService`/`ExtractedDocumentFactory`/`StructuredElements`: costruiti da SP1, **zero
+  consumer** in produzione.
+- `TextChunkEntity` ha già le colonne #730 ma sono default → `TextChunkRoleClassifier` mappa
+  `HeadingPath=""` → `RoleClassifierService.ApplyRules("")` = `None` → fallback LLM per **ogni** chunk.
+
+### 2.1 Asimmetria delle 4 pipeline (verificata)
+
+| Pipeline | Result al chunking? | Chunk type | pgvector | Chunk size attuale |
+|---|---|---|---|---|
+| `UploadPdfCommandHandler.Processing.cs` | ✅ `extractResult` in mano | `DocumentChunkInput` | `PgVectorEmbeddingEntity` diretto | 512/50 |
+| `PdfProcessingPipelineService.cs` (Quartz/recovery/re-index) | ✅ result in mano | `DocumentChunkInput` | `IVectorStoreAdapter` (`KbEntities.Embedding`) | 1024/150 + **dual-language** |
+| `IndexPdfCommandHandler.cs` | ❌ solo `pdf.ExtractedText`, no blob | **`DocumentChunk`** | `PgVectorEmbeddingEntity` diretto | ChunkText default |
+| `CompleteChunkedUploadCommandHandler.cs` | 🟡 estrae (riga 577) ma scarta (riga 624) | `DocumentChunkInput` | **nessuna** (asimmetria pre-esistente) | 512/50 |
+
+---
+
+## 3. Scope & confine
+
+### In scope (SP2)
+- **`IHeadingAwareChunker`** (nuovo application service, `DocumentProcessing`) che incapsula l'intero
+  chain: `FromExtraction` → `AdvancedChunkingService.ChunkDocumentAsync` → mapper → child con Heading
+  + **clamp a `MaxEmbeddingChars`**. Iniettato nelle 4 pipeline (una sola call, un solo seam testabile).
+- **`HierarchicalChunkMapper`** (helper puro interno al servizio): `HierarchicalChunk[]` → child.
+- **Persistenza StructuredElements** robusta: nuovo campo `PdfDocumentEntity.StructuredElementsJson`
+  (`string?`, versionata) + migration; popolato all'estrazione; invariante con `ExtractedText`.
+- **Complete signature**: `ExtractPdfTextAsync` restituisce anche `StructuredElements`.
+- **Dual-language**: la branch traduzione propaga `Heading` (risolve il TODO
+  `PdfProcessingPipelineService.cs:225-227`).
+- Test unit + per-pipeline + round-trip versionato + regression role-fast-path + non-regressione
+  content-preservation.
+
+### Fuori scope (SP3+/follow-up)
+- Big-bang re-index del corpus (SP3); ranking/heading-boost/reranker/query-expansion (SP4).
+- Asimmetria pgvector di Complete (pre-esistente — documentata, non corretta).
+- Persistenza gerarchica `HierarchicalChunk` DB (`ChunkPayload`/`IChunkRepository` — orfani, non usati).
+- Popolamento `ParentChunkId` (solo-child → `null`) e per-chunk `ElementType`/`Level` reali (non-goal).
+
+---
+
+## 4. Architettura & componenti
+
+### 4.1 `IHeadingAwareChunker` (application service condiviso) [M14/M17]
+Vive in `DocumentProcessing.Application.Services` (dipende **inward** su `KnowledgeBase.IAdvancedChunkingService` — direzione DocumentProcessing → KB, coerente con la convenzione):
+
+```csharp
+internal interface IHeadingAwareChunker
+{
+    Task<List<DocumentChunkInput>> ChunkAsync(
+        Guid documentId, Guid? gameId,
+        IReadOnlyList<ExtractedElement>? structuredElements,
+        string fullText, CancellationToken ct);
+}
+```
+
+Implementazione:
+1. `ExtractedDocumentFactory.FromExtraction(documentId, gameId, structuredElements, fullText)`.
+2. `AdvancedChunkingService.ChunkDocumentAsync(doc, config: cappedConfig, ct)` — 🔸 **config con
+   `ChunkSizeChars` clampato a `MaxEmbeddingChars` (1800)** per evitare il truncation di embedding
+   (§4.4). Auto-select della strategia (Baseline/Dense/Sparse) ma con size cap.
+3. `HierarchicalChunkMapper.ToChildDocumentChunks(hchunks)` (solo child).
+4. **Post-split di sicurezza**: se un child mappato ha `Text.Length > MaxEmbeddingChars`, splittarlo
+   con `ITextChunkingService.ChunkText(text, MaxEmbeddingChars, DefaultOverlap)` preservando Heading
+   (stesso pattern di `SplitOversizedPageChunks`).
+
+`IndexPdf` consuma `DocumentChunk` (non `DocumentChunkInput`): il servizio ritorna
+`DocumentChunkInput` (che porta `Heading`/`Level`/`ElementType`); IndexPdf costruisce i suoi
+`DocumentChunk` da quella lista (aggiungendo l'`Embedding`), riusando i campi hierarchy. 🔸 [M15]
+
+### 4.2 `HierarchicalChunkMapper` (helper puro)
+Solo child (Level 2, non-root). Per ogni child: `Text=child.Content`, `Page=` per-child (§4.5),
+`CharStart/End`, `Heading=child.Metadata.Heading`, `Level=(short)child.Level`,
+`ElementType=child.Metadata.ElementType` (`"text"`), `ParentChunkId=null`. Sezione con solo parent
+(nessun child) → nessun output.
+
+### 4.3 DI [M10/M19]
+`IHeadingAwareChunker` iniettato come **parametro ctor opzionale nullable con default `null`** (come
+il precedente `IRoleClassifierService? = null`), così i ~13 construction-site dei test esistenti
+continuano a compilare; `null` → il handler usa il flat path esistente (fallback). Nei 2
+background-task path (Upload `ProcessPdfAsync`, Complete `TriggerPdfProcessingAsync`) il servizio va
+**risolto dallo scope** (`scope.ServiceProvider.GetRequiredService<…>()`), non da un field del
+handler (evita captive-scope). IndexPdf + PdfProcessingPipeline girano in-scope → ctor injection ok.
+
+### 4.4 Clamp embedding-size [M2]
+La strategia Sparse produce `ChunkSizeChars = 2000 > MaxEmbeddingChars (1800)` → truncation
+silenziosa in tutte le pipeline (nessun cap prima di `GenerateEmbeddings`). Il servizio clampa
+`ChunkSizeChars` a `MaxEmbeddingChars` nella config passata a `ChunkDocumentAsync`, **e** applica il
+post-split di sicurezza (§4.1.4). Test: nessun child persistito/embeddato supera `MaxEmbeddingChars`.
+
+### 4.5 Page attribution per-child [M9]
+`AdvancedChunkingService` assegna a ogni child la pagina del **primo** elemento della sezione → per
+sezioni multi-pagina tutti i child citano la prima pagina (regressione citation). 🔸 Il mapper
+ricalcola la pagina per-child da `CharStart` (stima `charsPerPage`, come `EstimatePageNumber`),
+oppure — se non ricostruibile — documenta esplicitamente l'attribuzione a livello-sezione. Test
+multi-pagina.
+
+### 4.6 Persistenza StructuredElements robusta [M7/M8/M12/M13]
+- Migration: `pdf_documents.StructuredElementsJson` (`text`, nullable). Backfill `null`. 🔸 La colonna
+  **non** è inclusa nel trigger `tsvector` FTS. Nota: seconda copia del testo su una hot row
+  (optimistic concurrency `xmin`) — accettato, documentato; alternativa side-table valutata e
+  rimandata.
+- **DTO versionato**: serializzo `{ schemaVersion: 1, elements: [...] }` con
+  `JsonSerializerOptions` **pinnate e condivise** tra serialize e read; reader tollerante (ignora
+  membri sconosciuti, default sui mancanti).
+- **Invariante `ExtractedText ↔ StructuredElementsJson`** [M7]: ogni writer di `ExtractedText`
+  co-scrive lo StructuredElementsJson **oppure** lo azzera nello stesso `SaveChanges` (incl.
+  `ExtractPdfTextCommandHandler` che ri-estrae). Così IndexPdf non indicizza mai da StructuredElements
+  stale (azzerato → null-path).
+- **Robustezza read** [M8]: IndexPdf avvolge la deserializzazione in `try/catch(JsonException)` → log
+  warning + tratta come `null` (null-path), **mai** hard-fail (no PDF marcato Failed per JSON corrotto).
+
+### 4.7 Dual-language propaga Heading [M3/M6]
+`PdfProcessingPipelineService` aggiunge chunk tradotti (EN) ricostruendo `DocumentChunkInput` senza
+i campi #730 (TODO a `:225-227`). SP2 propaga `origChunk.Heading/Level/ElementType` sui chunk
+tradotti → anche i rulebook non-EN attivano la role-fast-path.
+
+---
+
+## 5. Data flow & degradazione
+
+```
+StructuredElements (Upload/Pipeline/Complete)  |  StructuredElementsJson (IndexPdf, try/catch→null)
+  ▼
+IHeadingAwareChunker.ChunkAsync
+  → FromExtraction → ExtractedDocument.Sections
+  → AdvancedChunkingService.ChunkDocumentAsync (config size-capped) → parent L0 + child L2
+  → mapper (solo child, Heading, per-child page) → post-split > MaxEmbeddingChars
+  → List<DocumentChunkInput> {Text, Page, Heading, Level=2, ElementType="text"}
+  ▼
+[flusso esistente] embeddings + TextChunkEntity (Heading!) + pgvector  (+ dual-language con Heading)
+  ▼
+TextChunkRoleClassifier: HeadingPath rule-matching → role deterministico (LLM ridotto) ✅
+```
+
+- **null-path** [M1/M11/M18]: `StructuredElements` null/vuoto o JSON corrotto → `FromExtraction(null)`
+  → 1 sezione preambolo → child con `Heading=null`. 🔸 I boundary **cambiano** (config auto vs 512/50
+  o 1024/150 attuali) → l'output **non** è byte-identico al flat attuale. Criterio di non-regressione
+  corretto: (a) i child null-path hanno `Heading=null` e `role_tags=None`; (b) **content-preservation**
+  — la concatenazione del testo dei child ricostruisce il contenuto della sezione modulo overlap.
+  Nessuna asserzione di byte-identità.
+- Il resto (embeddings, `SaveTextChunks*`, `SaveEmbeddings*`, role-classifier call) invariato.
+
+---
+
+## 6. Testing
+
+- **Unit `HierarchicalChunkMapper`**: solo child; Heading ereditato; `ParentChunkId=null`; `Level=2`;
+  per-child page (multi-pagina); sezione solo-parent → vuota.
+- **Unit `IHeadingAwareChunker`**: nessun child > `MaxEmbeddingChars` (documento narrativo → Sparse
+  cap); null → null-path; content-preservation.
+- **Round-trip versionato**: DTO `{schemaVersion,elements}` serialize→deserialize; **deserializza un
+  blob legacy congelato** (stringa fissa) → tollerante; JSON malformato → null (non eccezione al
+  chiamante).
+- **Per-pipeline** (4 predicati distinti [M5], Testcontainers dove serve): dato `StructuredElements`
+  con Title rule-matching → la pipeline X persiste `TextChunkEntity` con `Heading != null` **e**
+  `role_tags != None`; per Complete il predicato **esclude** righe pgvector (asimmetria). Ogni writer
+  (Upload/Pipeline/Complete) scrive `StructuredElementsJson != null` dopo estrazione (incl. il
+  ramo early-return per conflitto in Complete) [M20].
+- **Dual-language**: documento non-EN → i chunk tradotti portano l'Heading ereditato.
+- **Regression role-fast-path** [M2-tech/M4]: heading che matcha una `HeadingRule` (es. "Setup") →
+  classificazione deterministica, `ILlmService` mai invocato; **companion**: heading non-vuoto
+  non-matching → resta fallback (la fast-path riduce, non elimina).
+- **DI/construction** [M19]: i ~13 test construction-site compilano (param opzionale null → flat);
+  `IndexPdfIntegrationTests.RegisterMockServices` registra `IHeadingAwareChunker` reale + deps.
+
+---
+
+## 7. Definition of Done (SP2)
+
+- [ ] `IHeadingAwareChunker` + `HierarchicalChunkMapper` (helper) + unit test (incl. size-cap, page).
+- [ ] Migration `pdf_documents.StructuredElementsJson` + `PdfDocumentEntity` field (fuori dal tsvector).
+- [ ] Persistenza versionata + `JsonSerializerOptions` pinnate; invariante `ExtractedText↔JSON` in
+      **tutti** i writer (co-write o azzera, incl. `ExtractPdfTextCommandHandler`).
+- [ ] `CompleteChunkedUploadCommandHandler.ExtractPdfTextAsync` surface `StructuredElements`.
+- [ ] **Upload** usa il chunker (predicato: TextChunkEntity Heading≠null + role_tags≠None).
+- [ ] **PdfProcessingPipeline** usa il chunker + dual-language propaga Heading.
+- [ ] **IndexPdf** legge `StructuredElementsJson` (try/catch→null), costruisce `DocumentChunk` dai
+      `DocumentChunkInput` del chunker.
+- [ ] **Complete** usa il chunker (predicato esclude pgvector).
+- [ ] Clamp `MaxEmbeddingChars` + post-split: nessun chunk embeddato eccede 1800.
+- [ ] Test: mapper, chunker (size/page/null), round-trip versionato (blob legacy + malformato),
+      per-pipeline ×4, dual-language, role-fast-path (match + non-match), StructuredElementsJson-written.
+- [ ] Nessuna regressione: null-path content-preservation + Heading=null (non byte-identità); build +
+      suite verdi; ~13 construction-site compilano.
+- [ ] PR mergiata in `main-dev`.
+
+---
+
+## 8. Rischi
+
+| Rischio | Mitigazione |
+|---|---|
+| Sparse > MaxEmbeddingChars → truncation | §4.4 clamp + post-split + test |
+| StructuredElements stale vs ExtractedText | §4.6 invariante co-write/azzera in ogni writer |
+| JSON corrotto → hard-fail | §4.6 try/catch → null-path |
+| Captive-scope su background-task | §4.3 resolve da scope + ctor opzionale |
+| Boundary diversi → embeddings diversi | intenzionale (SP3 re-index rende coerente); content-preservation, non byte-identità |
+| Dual-language heading-less | §4.7 propaga Heading |
+| Hot-row bloat (StructuredElementsJson) | fuori tsvector; alternativa side-table documentata/rimandata |
+
+---
+
+## 9. Riferimenti
+
+- Epic #3266; SP1 `docs/superpowers/{specs,plans}/2026-07-21-rag-retrieval-sp1-*`.
+- ADR-016; #730 (hierarchy columns); #1391 (RoleTags denormalizzato).
+- File chiave: le 4 pipeline; `AdvancedChunkingService`/`ExtractedDocumentFactory`/`ChunkingConfiguration`/`ChunkingStrategySelector`; `ChunkingConstants.MaxEmbeddingChars`; `PdfDocumentEntity`/`TextChunkEntity`; `TextChunkRoleClassifier`/`RoleClassifierService`; `EnhancedPdfProcessingOrchestrator.SplitOversizedPageChunks` (pattern post-split); `ExtractPdfTextCommandHandler` (invariante).
+
+---
+
+## 10. Appendice — review adversariale (2026-07-21)
+
+Spec v1 sottoposta a review multi-esperto (Wiegers/Nygard/Newman/Fowler/Crispin + technical-verifier),
+23 finding confermati (0 critical, 3 major, 20 minor) su 28 grezzi. Risoluzione in v2:
+
+| ID | Sintesi | Risoluzione |
+|----|---------|-------------|
+| M1/M11/M18 | null-path "identico a oggi" falso/contraddittorio | §5 content-preservation, non byte-identità |
+| M2 | Sparse 2000 > MaxEmbeddingChars 1800 → truncation | §4.4 clamp + post-split |
+| M3/M6 (tech/nygard) | dual-language scarta Heading | §4.7 propaga Heading |
+| M14/M17 | chain copy-pasted in 4 handler | §4.1 `IHeadingAwareChunker` condiviso (DocumentProcessing→KB) |
+| M15 | IndexPdf usa `DocumentChunk` non `DocumentChunkInput` | §4.1 IndexPdf costruisce DocumentChunk dai DocumentChunkInput |
+| M10/M19 | DI captive-scope + rompe ~13 test | §4.3 ctor opzionale + resolve da scope |
+| M7 | StructuredElements stale vs ExtractedText | §4.6 invariante in ogni writer |
+| M8 | JSON corrotto → hard-fail | §4.6 try/catch → null-path |
+| M12 | no versioning/serializer pinned | §4.6 DTO versionato + options pinnate + blob-legacy test |
+| M9 | page attribution first-page per sezione multi-pagina | §4.5 per-child page |
+| M2-tech/M4 | role-fast-path "elimina" LLM falso | §1.2 "riduce"; test match + non-match |
+| M3-tech | Level/ElementType "valori reali" | §1.2 costanti (2/"text"), solo Heading reale |
+| M5 | DoD non per-pipeline; §2 impreciso | §7 4 predicati; §2 corretto (IndexPdf ChunkText/DocumentChunk) |
+| M13/M16 | hot-row bloat; alternativa re-embed | §4.6 fuori tsvector; alternativa documentata/rimandata |
+| M20 | no test StructuredElementsJson-written | §6 per-writer + early-return |


### PR DESCRIPTION
**Part of #3266 · Closes #3268**

RAG retrieval "chunking heading-aware" epic — **SP2: Hierarchical Chunking + Persistence** (2/4).

SP1 (#3267, PR #3264) exposed the raw `partition_pdf` elements (carrying `Title`) through the Python extractor and into C# `ExtractedElement`. SP2 now **wires ADR-016 `AdvancedChunkingService` into all four ingestion pipelines** so those headings actually shape the chunks that get embedded, and **persists the structured elements** so re-index can rebuild headings without re-extracting.

## What this does

- **One shared seam, four pipelines.** New `IHeadingAwareChunker` (`FromExtraction → AdvancedChunkingService.ChunkDocumentAsync → HierarchicalChunkMapper → post-split`) returns `List<DocumentChunkInput>` and is wired into `UploadPdf`, `PdfProcessingPipeline`, `CompleteChunkedUpload`, and `IndexPdf` — no copy-pasted chains. DI split: scope-resolve for the two background handlers, trailing-optional ctor param for the two in-scope handlers (keeps existing test ctor sites compiling; `null → flat fallback`).
- **Child-only mapping.** `HierarchicalChunkMapper` keeps only leaf chunks (`Level=2`), inherits the section `Heading`, and recomputes a per-child page. Role tags flow through for SP4 ranking.
- **Persistence.** New nullable `pdf_documents.StructuredElementsJson` column (additive migration `20260721140803`), written as a **versioned** payload (`StructuredElementsPayload`, `SchemaVersion=1`, tolerant deserialize → null on malformed). `IndexPdf` reads it back to rebuild headings without re-extracting; `TranslatedChunkMapper` preserves the heading on translated EN chunks.
- **Invariant.** All five `ExtractedText` write sites co-write `StructuredElementsJson` in the same `SaveChanges` (`Serialize(null) → null`, so re-extraction with no elements correctly nulls the JSON).
- **Embedding size cap.** `PostSplitOversized` guarantees no chunk exceeds `MaxEmbeddingChars` (1800), catching the auto-strategy Sparse (~2000-char) chunks that would otherwise be silently truncated.

## Bug fixed along the way (Upload pipeline)

`UploadPdfCommandHandler`'s background pipeline used an `AsNoTracking()` working entity **and** routed state transitions through `IPdfDocumentRepository.UpdateAsync → MapToPersistence` (which omits + clobbers the extraction columns). Result: `ExtractedText`/`PageCount`/table columns **never persisted** for Upload-originated PDFs post-#2284 — a pre-existing bug that also blocked re-index (`IndexPdf` failed `TextExtractionRequired` on null `ExtractedText`). Fixed with a dedicated **tracked** re-write after the final Ready transition (mirrors `ExtractPdfTextCommandHandler`), wrapped in `try/catch(DbUpdateConcurrencyException)` (Category B — admin mutation wins). Verified end-to-end against real Postgres (Testcontainers).

> **Behavioural heads-up:** Upload PDFs now persist `ExtractedText`/`PageCount`/table columns for the first time since #2284, and re-index via `IndexPdf` now works instead of failing. No downstream code relied on those columns being null.

## Review

Subagent-driven TDD: 8 tasks + the AsNoTracking fix, each with a fresh implementer + task reviewer (spec + quality), then a whole-branch review on Opus 4.8 — **verdict: Ready to merge, zero Critical, zero functional blockers**. The two Important findings (both comment-only: Ready-event-before-persist ordering + tracked-write dependency in Complete/Pipeline) are applied in the final commit. Minor findings triaged as deferrable. Clean `dotnet build` (0 errors, 0 warnings).

## Follow-ups (deferred)

- Make `PdfDocumentRepository.MapToPersistence` carry the extraction columns so the Upload write can move before Ready and the whole clobber class disappears.
- SP3 (#3269): big-bang re-index/re-embed of Ready PDFs + EN/IT non-regression suite.
- SP4 (#3270): heading/role-tag ranking in hybrid fusion + reranker + IT query-expansion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
