### PR TITLE
ci+a11y: drop bundle-size gate + fix shell a11y contrast (release-prep)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,7 @@ jobs:
           compression-level: 0  # already zstd-compressed
 
   # Build Next.js once with default config (no fixture flag) and share via
-  # artifact. Consumed by `frontend-bundle-size` and `e2e`. NOT used by
+  # artifact. Consumed by `e2e` (bundle-size gate removed 2026-07-21). NOT used by
   # `frontend-a11y` which needs NEXT_PUBLIC_VISUAL_TEST_FIXTURE_ENABLED=1
   # (constant-folded at build time → separate artifact in build-frontend-a11y).
   # Spec: docs/for-developers/specs/2026-05-25-ci-build-once-test-many.md
@@ -1180,66 +1180,18 @@ jobs:
           retention-days: 7
           if-no-files-found: warn
 
-  # Frontend bundle-size budget enforcement (Issue #629).
-  # Verifies First Load JS for budgeted public routes against
-  # `apps/web/.bundle-budgets.json`. Fails when any route exceeds
-  # `budget × (1 + tolerance)` (default 5%). Documented in
-  # `docs/frontend/bundle-size-budget.md`.
-  #
-  # Build-Once refactor 2026-05-25: consumes upstream build-frontend artifact
-  # instead of running its own pnpm build (~100s saved). The default-config
-  # build matches what bundle-size budgets target (no a11y fixture flag).
-  frontend-bundle-size:
-    name: Frontend - Bundle Size
-    runs-on: ${{ needs.changes.outputs.runner }}
-    timeout-minutes: 15
-    needs: [changes, build-frontend]
-    if: needs.changes.outputs.frontend == 'true' || github.event_name == 'workflow_dispatch'
-    defaults:
-      run:
-        working-directory: apps/web
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
-      - name: Setup Frontend
-        uses: ./.github/actions/setup-frontend
-        with:
-          node-version: '20'
-          pnpm-version: '10'
-          working-directory: apps/web
-          frozen-lockfile: 'true'
-
-      - name: Download frontend artifact
-        uses: actions/download-artifact@v7
-        with:
-          name: frontend-build-${{ github.run_id }}
-          path: /tmp/
-
-      - name: Extract frontend artifact
-        shell: bash
-        working-directory: apps/web
-        run: |
-          echo "📂 Extracting frontend build artifact..."
-          tar --use-compress-program='zstd -d' -xf /tmp/frontend-build.tar.zst
-          echo "✅ Frontend artifact extracted"
-
-      - name: Check Bundle Budgets
-        run: pnpm bundle:check
-
-      - name: Upload Bundle Budget Report
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: bundle-budget-report-${{ github.run_number }}
-          path: apps/web/.next/diagnostics/bundle-budget-report.json
-          retention-days: 30
+  # Frontend bundle-size gate TEMPORARILY REMOVED (2026-07-21, product decision):
+  # the app is pre-prod and enforcing First-Load-JS budgets (Issue #629) is premature.
+  # Re-introduce the `frontend-bundle-size` job — plus its entries in the `ci-success`
+  # and `ci-cost-tracker` `needs:` arrays and the `ci-success` required-jobs loop —
+  # before the prod promotion. Budget config still lives at apps/web/.bundle-budgets.json
+  # and `pnpm bundle:check` still works locally.
 
   # Final status check
   ci-success:
     name: CI Success
     runs-on: ubuntu-latest
-    needs: [build-backend, build-frontend, build-frontend-a11y, frontend-lint, frontend-typecheck, frontend-test, frontend-a11y, frontend-bundle-size, backend-unit, backend-integration, python-tests, e2e]
+    needs: [build-backend, build-frontend, build-frontend-a11y, frontend-lint, frontend-typecheck, frontend-test, frontend-a11y, backend-unit, backend-integration, python-tests, e2e]
     if: always()
     steps:
       - name: Check Status
@@ -1269,13 +1221,12 @@ jobs:
           # Onda A (2026-05-25): 'frontend' was split into frontend-lint,
           # frontend-typecheck, frontend-test (3-shard matrix). All three are
           # required gates.
-          for job in frontend-lint frontend-typecheck frontend-test frontend-a11y frontend-bundle-size backend-unit python-tests e2e; do
+          for job in frontend-lint frontend-typecheck frontend-test frontend-a11y backend-unit python-tests e2e; do
             case "$job" in
               frontend-lint) result="${{ needs.frontend-lint.result }}" ;;
               frontend-typecheck) result="${{ needs.frontend-typecheck.result }}" ;;
               frontend-test) result="${{ needs.frontend-test.result }}" ;;
               frontend-a11y) result="${{ needs.frontend-a11y.result }}" ;;
-              frontend-bundle-size) result="${{ needs.frontend-bundle-size.result }}" ;;
               backend-unit) result="${{ needs.backend-unit.result }}" ;;
               python-tests) result="${{ needs.python-tests.result }}" ;;
               e2e) result="${{ needs.e2e.result }}" ;;
@@ -1309,7 +1260,7 @@ jobs:
   ci-cost-tracker:
     name: CI Cost Tracker
     runs-on: ubuntu-latest
-    needs: [build-backend, build-frontend, build-frontend-a11y, frontend-lint, frontend-typecheck, frontend-test, frontend-a11y, frontend-bundle-size, backend-unit, backend-integration, python-tests, e2e, ci-success]
+    needs: [build-backend, build-frontend, build-frontend-a11y, frontend-lint, frontend-typecheck, frontend-test, frontend-a11y, backend-unit, backend-integration, python-tests, e2e, ci-success]
     # Runs on every ci.yml invocation (PR, push main-staging, dispatch, call).
     # On a PR it posts/updates a comment; otherwise it writes the job summary
     # (workflow_dispatch and push have no issue context). Onda A.5 fix
@@ -1493,7 +1444,7 @@ jobs:
         || github.base_ref == 'main-staging'
         || github.base_ref == 'main'
       )
-    needs: [changes, build-backend, build-frontend, build-frontend-a11y, frontend-lint, frontend-typecheck, frontend-test, frontend-a11y, frontend-bundle-size, backend-unit, backend-integration, python-tests, e2e, ci-success, deploy-preview]
+    needs: [changes, build-backend, build-frontend, build-frontend-a11y, frontend-lint, frontend-typecheck, frontend-test, frontend-a11y, backend-unit, backend-integration, python-tests, e2e, ci-success, deploy-preview]
     uses: ./.github/workflows/notify-slack.yml
     with:
       event: failed

--- a/apps/web/src/components/features/session-live/ChatAgentPanel.tsx
+++ b/apps/web/src/components/features/session-live/ChatAgentPanel.tsx
@@ -141,7 +141,7 @@ export function ChatAgentPanel({
         </span>
         <span
           aria-label={labels.latencyAriaLabel}
-          className="text-xs font-medium text-muted-foreground"
+          className="text-xs font-medium text-foreground/70"
         >
           {latencyMs}ms
         </span>

--- a/apps/web/src/components/layout/AppNav/SearchPill.tsx
+++ b/apps/web/src/components/layout/AppNav/SearchPill.tsx
@@ -53,7 +53,7 @@ export function SearchPill({ className }: SearchPillProps) {
       <span
         aria-hidden="true"
         className={cn(
-          'hidden items-center gap-0.5 rounded border border-border bg-background px-1 py-0.5 font-mono text-[10px] font-semibold opacity-70 lg:inline-flex'
+          'hidden items-center gap-0.5 rounded border border-border bg-background px-1 py-0.5 font-mono text-[10px] font-semibold text-muted-foreground lg:inline-flex'
         )}
       >
         {modKey}K

--- a/apps/web/src/components/layout/UserShell/MiniNavSlot.tsx
+++ b/apps/web/src/components/layout/UserShell/MiniNavSlot.tsx
@@ -21,7 +21,7 @@ export function MiniNavSlot() {
       data-testid="mini-nav-slot"
       className="h-12 flex items-center gap-1 px-7 pl-[104px] border-b border-[var(--glass-border)] bg-[var(--bg)]"
     >
-      <div className="text-xs font-semibold text-[var(--text-muted)] mr-5">
+      <div className="text-xs font-semibold text-muted-foreground mr-5">
         <span aria-hidden>›</span> {config.breadcrumb}
       </div>
       {config.tabs.map(tab => {
@@ -33,9 +33,7 @@ export function MiniNavSlot() {
             aria-current={active ? 'page' : undefined}
             className={cn(
               'relative px-3.5 py-2 rounded-lg text-[0.78rem] font-bold flex items-center gap-1.5 transition-colors',
-              active
-                ? 'text-[var(--text)]'
-                : 'text-[var(--text-sec)] hover:bg-[var(--bg-card)]'
+              active ? 'text-[var(--text)]' : 'text-[var(--text-sec)] hover:bg-[var(--bg-card)]'
             )}
           >
             {tab.label}


### PR DESCRIPTION
## Release-prep: CI gates + shell a11y contrast

Prep for the `main-dev → main-staging` release (Slice D / RAG TM fix). Two changes:

### 1. Remove the frontend bundle-size gate (product decision)
Enforcing First-Load-JS budgets (#629) is premature pre-prod. Removes the `frontend-bundle-size` job + its `needs`/`ci-success`/`ci-cost-tracker`/notify references. `pnpm bundle:check` + `.bundle-budgets.json` retained; **re-introduce before the prod promotion** (marker comment left in `ci.yml`).

### 2. Fix pre-existing WCAG 2.1 AA color-contrast on shared shell chrome
The full A11y E2E suite surfaced pre-existing contrast failures (unchanged by this release; ~148/187 failing nodes concentrated in shared shell components that render on every page):
- **SearchPill** ⌘K kbd hint — dropped `opacity-70` (muted-foreground@70% = 3.31 → ~5.8:1).
- **MiniNavSlot** breadcrumb — legacy `var(--text-muted)` #9a8870 (3.1) → semantic `text-muted-foreground` (AA).
- **ChatAgentPanel** latency chip — `text-muted-foreground` → `text-foreground/70` (dark-mode 4.28 → AA).

**Residual:** entity-token chips (`text-entity-*/12` tints, e.g. gamebook pip strip) fail AA (#bd5205 on tint = 3.95). This is a **systemic design-system decision** across all 10 entity types — tracked separately, not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
