### PR TITLE
feat(rag): #3281 heading-aware chunking on 3 fresh-ingest paths + persistence fixes

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/CompleteChunkedUploadCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/CompleteChunkedUploadCommandHandler.cs
@@ -1,14 +1,17 @@
 using Api.BoundedContexts.DocumentProcessing.Application.DTOs;
 using Api.BoundedContexts.DocumentProcessing.Application.Services;
+using Api.BoundedContexts.DocumentProcessing.Application.Services.Chunking;
 using Api.BoundedContexts.DocumentProcessing.Domain.Entities;
 using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
 using Api.BoundedContexts.DocumentProcessing.Domain.Repositories;
+using Api.BoundedContexts.DocumentProcessing.Domain.Services;
 using Api.BoundedContexts.DocumentProcessing.Domain.ValueObjects;
 using Api.BoundedContexts.DocumentProcessing.Infrastructure.External;
 using Api.BoundedContexts.EntityRelationships.Application.Commands;
 using Api.BoundedContexts.EntityRelationships.Domain.Enums;
 using Api.BoundedContexts.EntityRelationships.Domain.Exceptions;
 using Api.BoundedContexts.KnowledgeBase.Application.Services;
+using Api.BoundedContexts.KnowledgeBase.Application.Services.Chunking;
 using Api.Infrastructure;
 using Api.Infrastructure.Entities;
 using Api.Infrastructure.Security;
@@ -479,13 +482,13 @@ internal class CompleteChunkedUploadCommandHandler : ICommandHandler<CompleteChu
             _logger.LogInformation("Starting PDF processing for chunked upload: {PdfId}", pdfId);
 
             // Step 1: Extract PDF text and structured content
-            var (extractSuccess, fullText, totalPages) = await ExtractPdfTextAsync(
+            var (extractSuccess, fullText, totalPages, structuredElements) = await ExtractPdfTextAsync(
                 pdfId, filePath, pdfDoc, db, scope, cancellationToken).ConfigureAwait(false);
             if (!extractSuccess) return;
 
             // Step 2: Chunk text for embedding
             var allDocumentChunks = await ChunkTextContentAsync(
-                pdfId, fullText!, scope).ConfigureAwait(false);
+                pdfId, fullText!, pdfDoc, structuredElements, scope).ConfigureAwait(false);
 
             // Guard: zero usable chunks → mark Failed. Mirrors PdfProcessingPipelineService
             // (the non-chunked Quartz path) which fails on chunks.Count == 0. Without this,
@@ -562,7 +565,7 @@ internal class CompleteChunkedUploadCommandHandler : ICommandHandler<CompleteChu
     /// <summary>
     /// Extracts text and structured content from PDF file.
     /// </summary>
-    private async Task<(bool success, string? fullText, int totalPages)> ExtractPdfTextAsync(
+    private async Task<(bool success, string? fullText, int totalPages, IReadOnlyList<ExtractedElement>? structuredElements)> ExtractPdfTextAsync(
         string pdfId,
         string filePath,
         PdfDocumentEntity pdfDoc,
@@ -596,10 +599,10 @@ internal class CompleteChunkedUploadCommandHandler : ICommandHandler<CompleteChu
                     _logger.LogWarning(ex,
                         "Concurrency conflict on PdfDocument {PdfId} in {Handler} (Category B) — admin mutation wins, pipeline will re-read on next tick",
                         pdfId, nameof(CompleteChunkedUploadCommandHandler));
-                    return (false, null, 0);
+                    return (false, null, 0, null);
                 }
                 _logger.LogError("Text extraction failed for {PdfId}: {Error}", pdfId, extractResult.ErrorMessage);
-                return (false, null, 0);
+                return (false, null, 0, null);
             }
 
             var fullText = string.Join("\n\n", extractResult.PageChunks
@@ -607,8 +610,15 @@ internal class CompleteChunkedUploadCommandHandler : ICommandHandler<CompleteChu
                 .Select(pc => pc.Text));
 
             pdfDoc.ExtractedText = fullText;
+            pdfDoc.StructuredElementsJson = extractResult.StructuredElements is null
+                ? null
+                : System.Text.Json.JsonSerializer.Serialize(extractResult.StructuredElements);
             pdfDoc.PageCount = extractResult.TotalPages;
             pdfDoc.CharacterCount = extractResult.TotalCharacters;
+            // 🔴 pdfDoc came from a bare FindAsync under the NoTracking default → detached.
+            // Mark it Modified so these columns actually persist (the pre-existing SaveChanges
+            // was a silent no-op).
+            db.PdfDocuments.Update(pdfDoc);
             try
             {
                 await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
@@ -621,13 +631,13 @@ internal class CompleteChunkedUploadCommandHandler : ICommandHandler<CompleteChu
                 _logger.LogWarning(ex,
                     "Concurrency conflict on PdfDocument {PdfId} in {Handler} (Category B) — admin mutation wins, pipeline will re-read on next tick",
                     pdfId, nameof(CompleteChunkedUploadCommandHandler));
-                return (true, fullText, extractResult.TotalPages);
+                return (true, fullText, extractResult.TotalPages, extractResult.StructuredElements);
             }
 
             // Extract structured content (tables, diagrams)
             await ExtractStructuredContentAsync(filePath, pdfDoc, db, scope, cancellationToken).ConfigureAwait(false);
 
-            return (true, fullText, extractResult.TotalPages);
+            return (true, fullText, extractResult.TotalPages, extractResult.StructuredElements);
         }
     }
 
@@ -682,26 +692,43 @@ internal class CompleteChunkedUploadCommandHandler : ICommandHandler<CompleteChu
     private async Task<List<DocumentChunkInput>> ChunkTextContentAsync(
         string pdfId,
         string fullText,
-                IServiceScope scope
-        )
-
+        PdfDocumentEntity pdfDoc,
+        IReadOnlyList<ExtractedElement>? structuredElements,
+        IServiceScope scope)
     {
         var chunkingStopwatch = Stopwatch.StartNew();
         var chunkingService = scope.ServiceProvider.GetRequiredService<ITextChunkingService>();
         const int chunkSize = 512;
         const int chunkOverlap = 50;
 
-        var allDocumentChunks = chunkingService.PrepareForEmbedding(fullText, chunkSize, chunkOverlap)
-            ?.Where(chunk => chunk != null && !string.IsNullOrWhiteSpace(chunk.Text))
-            .Select(chunk => new DocumentChunkInput
-            {
-                Text = chunk.Text,
-                Page = chunk.Page,
-                CharStart = chunk.CharStart,
-                CharEnd = chunk.CharEnd
-            })
-            .ToList()
-            ?? new List<DocumentChunkInput>();
+        // Issue #3281: heading-aware production when AdvancedChunkingService is available in scope.
+        var advancedChunking = scope.ServiceProvider.GetService<IAdvancedChunkingService>();
+        List<DocumentChunkInput> allDocumentChunks;
+        if (advancedChunking != null)
+        {
+            var hierarchical = await HeadingAwareChunker.BuildAsync(
+                structuredElements,
+                fullText,
+                pdfDoc.Id,
+                pdfDoc.PrivateGameId ?? pdfDoc.SharedGameId,
+                advancedChunking,
+                CancellationToken.None).ConfigureAwait(false);
+            allDocumentChunks = HeadingAwareChunkAdapter.ToChunkInputs(hierarchical);
+        }
+        else
+        {
+            allDocumentChunks = chunkingService.PrepareForEmbedding(fullText, chunkSize, chunkOverlap)
+                ?.Where(chunk => chunk != null && !string.IsNullOrWhiteSpace(chunk.Text))
+                .Select(chunk => new DocumentChunkInput
+                {
+                    Text = chunk.Text,
+                    Page = chunk.Page,
+                    CharStart = chunk.CharStart,
+                    CharEnd = chunk.CharEnd
+                })
+                .ToList()
+                ?? new List<DocumentChunkInput>();
+        }
 
         allDocumentChunks = allDocumentChunks
             .Where(chunk => chunk != null && !string.IsNullOrWhiteSpace(chunk.Text))
@@ -727,7 +754,7 @@ internal class CompleteChunkedUploadCommandHandler : ICommandHandler<CompleteChu
     {
         var embeddingStopwatch = Stopwatch.StartNew();
         var embeddingService = scope.ServiceProvider.GetRequiredService<IEmbeddingService>();
-        var texts = allDocumentChunks.Select(c => c.Text).ToList();
+        var texts = allDocumentChunks.Select(c => HeadingAwareChunkAdapter.CapForEmbedding(c.Text)).ToList();
         var embeddingResult = await embeddingService.GenerateEmbeddingsAsync(texts).ConfigureAwait(false);
         embeddingStopwatch.Stop();
 

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommandHandler.Processing.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommandHandler.Processing.cs
@@ -260,6 +260,14 @@ internal partial class UploadPdfCommandHandler
                 .Select(pc => pc.Text));
 
             pdfDoc.ExtractedText = fullText;
+            // Issue #3281: keep StructuredElementsJson in-memory on the (AsNoTracking) pdfDoc so the
+            // tracked re-write in FinalizeProcessingAsync can copy it after the Ready transition. This
+            // assignment + the SaveChangesAsync below are a no-op on the DB for this column (see the
+            // FinalizeProcessingAsync comment for why), but the in-memory value must be set here since
+            // extractResult is not in scope at finalize time.
+            pdfDoc.StructuredElementsJson = extractResult.StructuredElements is null
+                ? null
+                : System.Text.Json.JsonSerializer.Serialize(extractResult.StructuredElements);
             pdfDoc.PageCount = extractResult.TotalPages;
             pdfDoc.CharacterCount = extractResult.TotalCharacters;
             try
@@ -933,6 +941,46 @@ internal partial class UploadPdfCommandHandler
                 "Concurrency conflict on PdfDocument {PdfId} (TransitionTo Ready) in {Handler} (Category B) — admin mutation wins, pipeline will re-read on next tick",
                 pdfId, nameof(UploadPdfCommandHandler));
             return;
+        }
+
+        // Issue #3281 / pre-existing AsNoTracking bug: the pipeline's working pdfDoc is AsNoTracking
+        // and state transitions route through IPdfDocumentRepository (MapToPersistence omits + clobbers
+        // ExtractedText/StructuredElementsJson/content columns), so extraction output written during
+        // ExtractPdfContentAsync/ExtractStructuredContentAsync never persists. Re-persist it here on a
+        // freshly TRACKED entity AFTER the final Ready transition (mirrors ExtractPdfTextCommandHandler),
+        // so no later repository transition can clobber it. Needed for re-index parity: IndexPdf reads
+        // StructuredElementsJson and requires non-null ExtractedText.
+        // 🟡 Use CancellationToken.None (NOT cancellationToken): the PDF is already Ready+indexed at
+        // this point, so this persist MUST complete regardless of pipeline cancellation. Mirrors
+        // ConfirmQuotaAsync's post-Ready CancellationToken.None convention. If cancellation were
+        // threaded here, an OperationCanceledException would escape this DbUpdateConcurrencyException-only
+        // catch → ProcessPdfAsync's cancellation handler → TransitionToFailedAsync → MarkAsFailed on a
+        // Ready aggregate → InvalidOperationException("Cannot transition from Ready state"), AND the
+        // extraction output would be silently lost.
+        var tracked = await db.PdfDocuments.AsTracking()
+            .FirstOrDefaultAsync(p => p.Id == pdfGuid, CancellationToken.None).ConfigureAwait(false);
+        if (tracked != null)
+        {
+            tracked.ExtractedText = pdfDoc.ExtractedText;
+            tracked.StructuredElementsJson = pdfDoc.StructuredElementsJson;
+            tracked.PageCount = pdfDoc.PageCount;
+            tracked.CharacterCount = pdfDoc.CharacterCount;
+            tracked.ExtractedTables = pdfDoc.ExtractedTables;
+            tracked.ExtractedDiagrams = pdfDoc.ExtractedDiagrams;
+            tracked.AtomicRules = pdfDoc.AtomicRules;
+            tracked.TableCount = pdfDoc.TableCount;
+            tracked.DiagramCount = pdfDoc.DiagramCount;
+            tracked.AtomicRuleCount = pdfDoc.AtomicRuleCount;
+            try
+            {
+                await db.SaveChangesAsync(CancellationToken.None).ConfigureAwait(false);
+            }
+            catch (DbUpdateConcurrencyException ex)
+            {
+                _logger.LogWarning(ex,
+                    "Concurrency conflict persisting extraction output for PDF {PdfId} — admin mutation wins",
+                    pdfId);
+            }
         }
 
         // #2284 PR C: tactical scopedMediator.Publish(PdfStateChangedEvent) deleted.

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommandHandler.Processing.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommandHandler.Processing.cs
@@ -1,6 +1,8 @@
 using Api.BoundedContexts.DocumentProcessing.Application.Services;
+using Api.BoundedContexts.DocumentProcessing.Application.Services.Chunking;
 using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
 using Api.BoundedContexts.KnowledgeBase.Application.Services;
+using Api.BoundedContexts.KnowledgeBase.Application.Services.Chunking;
 using Api.BoundedContexts.DocumentProcessing.Domain.Events;
 using Api.BoundedContexts.DocumentProcessing.Domain.Services;
 using Api.BoundedContexts.DocumentProcessing.Infrastructure.External;
@@ -66,7 +68,7 @@ internal partial class UploadPdfCommandHandler
             // Step 2: Chunk text with page tracking (40-60%)
             _logger.LogInformation("✂️ [PDF-DEBUG] Step 2: Starting ChunkExtractedTextAsync for {PdfId}", pdfId);
             var allDocumentChunks = await ChunkExtractedTextAsync(
-                pdfId, fullText!, extractResult!, db, scope, startTime, cancellationToken).ConfigureAwait(false);
+                pdfId, fullText!, extractResult!, pdfDoc, db, scope, startTime, cancellationToken).ConfigureAwait(false);
             _logger.LogInformation("✅ [PDF-DEBUG] Chunking SUCCESS: {ChunkCount} chunks created", allDocumentChunks.Count);
 
             await TransitionStateAsync(scope, db, pdfGuid, PdfProcessingState.Embedding, cancellationToken).ConfigureAwait(false);
@@ -338,6 +340,7 @@ internal partial class UploadPdfCommandHandler
         string pdfId,
         string fullText,
         PagedTextExtractionResult extractResult,
+        PdfDocumentEntity pdfDoc,
         MeepleAiDbContext db,
         IServiceScope scope,
         DateTime startTime,
@@ -350,33 +353,50 @@ internal partial class UploadPdfCommandHandler
         const int chunkSize = 512;
         const int chunkOverlap = 50;
 
-        var allDocumentChunks = chunkingService.PrepareForEmbedding(fullText, chunkSize, chunkOverlap)
-            ?.Where(chunk => chunk != null && !string.IsNullOrWhiteSpace(chunk.Text))
-            .Select(chunk => new DocumentChunkInput
-            {
-                Text = chunk.Text,
-                Page = chunk.Page,
-                CharStart = chunk.CharStart,
-                CharEnd = chunk.CharEnd
-            })
-            .ToList()
-            ?? new List<DocumentChunkInput>();
-
-        if (allDocumentChunks.Count == 0)
+        // Issue #3281: heading-aware production when AdvancedChunkingService is available in scope.
+        var advancedChunking = scope.ServiceProvider.GetService<IAdvancedChunkingService>();
+        List<DocumentChunkInput> allDocumentChunks;
+        if (advancedChunking != null)
         {
-            foreach (var pageChunk in extractResult.PageChunks.Where(pc => !pc.IsEmpty))
-            {
-                var pageTextChunks = chunkingService.ChunkText(pageChunk.Text, chunkSize, chunkOverlap);
-
-                foreach (var textChunk in pageTextChunks.Where(t => !string.IsNullOrWhiteSpace(t.Text)))
+            var hierarchical = await HeadingAwareChunker.BuildAsync(
+                extractResult.StructuredElements,
+                fullText,
+                pdfDoc.Id,
+                pdfDoc.PrivateGameId ?? pdfDoc.SharedGameId,
+                advancedChunking,
+                cancellationToken).ConfigureAwait(false);
+            allDocumentChunks = HeadingAwareChunkAdapter.ToChunkInputs(hierarchical);
+        }
+        else
+        {
+            allDocumentChunks = chunkingService.PrepareForEmbedding(fullText, chunkSize, chunkOverlap)
+                ?.Where(chunk => chunk != null && !string.IsNullOrWhiteSpace(chunk.Text))
+                .Select(chunk => new DocumentChunkInput
                 {
-                    allDocumentChunks.Add(new DocumentChunkInput
+                    Text = chunk.Text,
+                    Page = chunk.Page,
+                    CharStart = chunk.CharStart,
+                    CharEnd = chunk.CharEnd
+                })
+                .ToList()
+                ?? new List<DocumentChunkInput>();
+
+            if (allDocumentChunks.Count == 0)
+            {
+                foreach (var pageChunk in extractResult.PageChunks.Where(pc => !pc.IsEmpty))
+                {
+                    var pageTextChunks = chunkingService.ChunkText(pageChunk.Text, chunkSize, chunkOverlap);
+
+                    foreach (var textChunk in pageTextChunks.Where(t => !string.IsNullOrWhiteSpace(t.Text)))
                     {
-                        Text = textChunk.Text,
-                        Page = pageChunk.PageNumber,
-                        CharStart = textChunk.CharStart,
-                        CharEnd = textChunk.CharEnd
-                    });
+                        allDocumentChunks.Add(new DocumentChunkInput
+                        {
+                            Text = textChunk.Text,
+                            Page = pageChunk.PageNumber,
+                            CharStart = textChunk.CharStart,
+                            CharEnd = textChunk.CharEnd
+                        });
+                    }
                 }
             }
         }
@@ -426,7 +446,7 @@ internal partial class UploadPdfCommandHandler
         {
             var skip = batchIndex * BATCH_SIZE;
             var batchChunks = allDocumentChunks.Skip(skip).Take(BATCH_SIZE).ToList();
-            var batchTexts = batchChunks.Select(c => c.Text).ToList();
+            var batchTexts = batchChunks.Select(c => HeadingAwareChunkAdapter.CapForEmbedding(c.Text)).ToList();
 
             _logger.LogInformation("📦 [BATCH-EMBED] Processing batch {Current}/{Total}: {ChunkCount} chunks",
                 batchIndex + 1, batchCount, batchTexts.Count);

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/Chunking/HeadingAwareChunkAdapter.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/Chunking/HeadingAwareChunkAdapter.cs
@@ -1,0 +1,41 @@
+using Api.Constants;
+using Api.Services;
+
+namespace Api.BoundedContexts.DocumentProcessing.Application.Services.Chunking;
+
+/// <summary>
+/// Bridges <see cref="HeadingAwareChunker"/>'s <see cref="DocumentChunk"/> output to the
+/// <see cref="DocumentChunkInput"/> the fresh-upload ingest handlers embed + persist, and
+/// caps embedding-input text at <see cref="ChunkingConstants.MaxEmbeddingChars"/> (the full
+/// text is still persisted for retrieval; only the vector-provider input is capped). Shared
+/// by all 3 fresh-ingest paths (Issue #3281) so the map + cap logic lives in one tested place.
+/// </summary>
+internal static class HeadingAwareChunkAdapter
+{
+    public static List<DocumentChunkInput> ToChunkInputs(IReadOnlyList<DocumentChunk> chunks)
+    {
+        ArgumentNullException.ThrowIfNull(chunks);
+        return chunks
+            .Select(c => new DocumentChunkInput
+            {
+                Id = c.Id,
+                Text = c.Text,
+                Page = c.Page,
+                CharStart = c.CharStart,
+                CharEnd = c.CharEnd,
+                Heading = c.Heading,
+                Level = c.Level,
+                ParentChunkId = c.ParentChunkId,
+                ElementType = c.ElementType,
+            })
+            .ToList();
+    }
+
+    public static string CapForEmbedding(string text)
+    {
+        ArgumentNullException.ThrowIfNull(text);
+        return text.Length <= ChunkingConstants.MaxEmbeddingChars
+            ? text
+            : text[..ChunkingConstants.MaxEmbeddingChars];
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs
@@ -1,8 +1,10 @@
+using Api.BoundedContexts.DocumentProcessing.Application.Services.Chunking;
 using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
 using Api.BoundedContexts.DocumentProcessing.Domain.Events;
 using Api.BoundedContexts.DocumentProcessing.Infrastructure.External;
 using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
 using Api.BoundedContexts.KnowledgeBase.Application.Services;
+using Api.BoundedContexts.KnowledgeBase.Application.Services.Chunking;
 using Api.BoundedContexts.KnowledgeBase.Domain.Services.Enhancements;
 using Api.BoundedContexts.KnowledgeBase.Infrastructure.Persistence;
 using Api.Infrastructure;
@@ -63,6 +65,10 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
 
     private readonly IPdfIndexingPipeline _indexingPipeline;
 
+    // Issue #3281: optional so pre-existing test constructors compile. When null,
+    // chunk production falls back to the flat ITextChunkingService path (pre-Slice-D behaviour).
+    private readonly IAdvancedChunkingService? _advancedChunking;
+
     public PdfProcessingPipelineService(
         MeepleAiDbContext db,
         IPdfClaimService pdfClaimService,
@@ -83,7 +89,8 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
         IRoleClassifierService? roleClassifier = null,
         IPdfCoverExtractor? pdfCoverExtractor = null,
         IDomainEventCollector? eventCollector = null,
-        IPdfCoverUploadPipeline? pdfCoverUploadPipeline = null)
+        IPdfCoverUploadPipeline? pdfCoverUploadPipeline = null,
+        IAdvancedChunkingService? advancedChunking = null)
     {
         _db = db ?? throw new ArgumentNullException(nameof(db));
         _pdfClaimService = pdfClaimService ?? throw new ArgumentNullException(nameof(pdfClaimService));
@@ -108,6 +115,7 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
         // in ExtractCoverImageAsync is guarded with a null-check.
         _eventCollector = eventCollector;
         _pdfCoverUploadPipeline = pdfCoverUploadPipeline;
+        _advancedChunking = advancedChunking;
     }
 
     public async Task ProcessAsync(
@@ -188,7 +196,12 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
 
             // Step 3: Chunk text
             _logger.LogInformation("[PdfPipeline] Step 3/4: Chunking text for {PdfId} ({CharCount} chars)", pdfId, fullText.Length);
-            var chunks = ChunkText(fullText, extractResult);
+            var chunks = await ChunkTextAsync(
+                fullText,
+                extractResult,
+                pdfDoc.Id,
+                pdfDoc.PrivateGameId ?? pdfDoc.SharedGameId,
+                cancellationToken).ConfigureAwait(false);
 
             if (chunks.Count == 0)
             {
@@ -222,16 +235,19 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
                         if (!string.IsNullOrWhiteSpace(t.TranslatedText))
                         {
                             var origChunk = chunks[t.OriginalIndex];
-                            // Issue #730 / spec §5.3 forward-wiring: hierarchy fields are not yet propagated from origChunk
-                            // to the translated chunk because the upstream chunking pipeline does not currently populate them.
-                            // Once AdvancedChunkingService is wired, copy origChunk.Heading/Level/ParentChunkId/ElementType here.
                             translatedChunks.Add((
                                 new DocumentChunkInput
                                 {
+                                    // Id intentionally omitted → defaults to Guid.Empty → fresh Guid at persist.
+                                    // Copying origChunk.Id here duplicates a primary key and fails non-English PDFs.
                                     Text = t.TranslatedText,
                                     Page = origChunk.Page,
                                     CharStart = origChunk.CharStart,
-                                    CharEnd = origChunk.CharEnd
+                                    CharEnd = origChunk.CharEnd,
+                                    Heading = origChunk.Heading,
+                                    Level = origChunk.Level,
+                                    ParentChunkId = origChunk.ParentChunkId,
+                                    ElementType = origChunk.ElementType
                                 },
                                 "en",
                                 true));
@@ -655,8 +671,27 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
 #pragma warning restore CA1031
     }
 
-    private List<DocumentChunkInput> ChunkText(string fullText, PagedTextExtractionResult extractResult)
+    private async Task<List<DocumentChunkInput>> ChunkTextAsync(
+        string fullText,
+        PagedTextExtractionResult extractResult,
+        Guid documentId,
+        Guid? gameId,
+        CancellationToken cancellationToken)
     {
+        // Issue #3281: heading-aware production when AdvancedChunkingService is available.
+        if (_advancedChunking != null)
+        {
+            var hierarchical = await HeadingAwareChunker.BuildAsync(
+                extractResult.StructuredElements,
+                fullText,
+                documentId,
+                gameId,
+                _advancedChunking,
+                cancellationToken).ConfigureAwait(false);
+            return HeadingAwareChunkAdapter.ToChunkInputs(hierarchical);
+        }
+
+        // Fallback: flat production (pre-Slice-D behaviour) when the chunker is unavailable.
         var chunks = _chunkingService.PrepareForEmbedding(fullText, ChunkSize, ChunkOverlap)
             ?.Where(c => c != null && !string.IsNullOrWhiteSpace(c.Text))
             .ToList()
@@ -698,7 +733,9 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
             cancellationToken.ThrowIfCancellationRequested();
 
             var skip = batchIndex * EmbeddingBatchSize;
-            var batchTexts = chunks.Skip(skip).Take(EmbeddingBatchSize).Select(c => c.Text).ToList();
+            var batchTexts = chunks.Skip(skip).Take(EmbeddingBatchSize)
+                .Select(c => HeadingAwareChunkAdapter.CapForEmbedding(c.Text))
+                .ToList();
 
             _logger.LogInformation("[PdfPipeline] Embedding batch {Current}/{Total} ({Count} texts)",
                 batchIndex + 1, batchCount, batchTexts.Count);

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/KnowledgeBase/TextChunkEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/KnowledgeBase/TextChunkEntityConfiguration.cs
@@ -25,7 +25,12 @@ internal class TextChunkEntityConfiguration : IEntityTypeConfiguration<TextChunk
         // Issue #730: Chunk hierarchy fields
         builder.Property(e => e.Heading).HasMaxLength(500).IsRequired(false);
         builder.Property(e => e.ParentChunkId).IsRequired(false);
-        builder.Property(e => e.Level).IsRequired().HasDefaultValue<short>(1);
+        // #3281: ValueGeneratedNever() so EF always sends the explicit CLR Level, even Level=0
+        // (parent/section chunks). Without it, HasDefaultValue(1) marks the property ValueGeneratedOnAdd,
+        // and EF omits it from INSERT when the value equals the CLR default (0 for short) → Npgsql
+        // substitutes the store default 1, silently corrupting Level-0 parent rows to Level-1. The
+        // CLR default of TextChunkEntity.Level is 1, so creators that never set it still persist 1.
+        builder.Property(e => e.Level).IsRequired().HasDefaultValue<short>(1).ValueGeneratedNever();
         builder.Property(e => e.ElementType).IsRequired().HasMaxLength(20).HasDefaultValue("NarrativeText");
 
         // #2311 BE-1 — UsageCount counter (DEC-D2 start-from-0)

--- a/apps/api/tests/Api.Tests/Api.Tests.csproj
+++ b/apps/api/tests/Api.Tests/Api.Tests.csproj
@@ -104,7 +104,6 @@
     <ProjectReference Include="..\..\src\Api\Api.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Remove="Integration\DocumentProcessing\IndexPdfIntegrationTests.cs" />
     <Compile Remove="Integration\DocumentProcessing\PrivatePdfUploadIntegrationTests.cs" />
   </ItemGroup>
   <!--

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Commands/CompleteChunkedUploadCommandHandlerHeadingAwareTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Commands/CompleteChunkedUploadCommandHandlerHeadingAwareTests.cs
@@ -1,0 +1,213 @@
+using Api.BoundedContexts.DocumentProcessing.Application.Commands;
+using Api.BoundedContexts.DocumentProcessing.Application.Services;
+using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
+using Api.BoundedContexts.DocumentProcessing.Domain.Repositories;
+using Api.BoundedContexts.DocumentProcessing.Domain.Services;
+using Api.BoundedContexts.DocumentProcessing.Infrastructure.External;
+using Api.BoundedContexts.KnowledgeBase.Application.Services;
+using Api.BoundedContexts.KnowledgeBase.Application.Services.Chunking;
+using Api.BoundedContexts.KnowledgeBase.Domain.Chunking;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Services;
+using Api.Services.Pdf;
+using Api.Tests.Constants;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.DocumentProcessing.Application.Commands;
+
+/// <summary>
+/// Issue #3281 (Task 5): heading-aware chunking wiring for the chunked-upload background
+/// pipeline (<see cref="CompleteChunkedUploadCommandHandler.TriggerPdfProcessingAsync"/>).
+///
+/// Two things are pinned here:
+///  1. When <see cref="IAdvancedChunkingService"/> is available in the background scope, the
+///     handler must route through <c>HeadingAwareChunker.BuildAsync</c> so persisted
+///     <c>text_chunks</c> carry Heading/Level/ParentChunkId (not the flat chunker's output).
+///  2. <c>pdf_documents.StructuredElementsJson</c> must actually persist. The <c>pdfDoc</c> the
+///     handler mutates comes from a bare <c>db.PdfDocuments.FindAsync(...)</c> under the
+///     production <c>QueryTrackingBehavior.NoTracking</c> default (PERF-06) — so it is detached,
+///     and a save without an explicit tracked-write is a silent no-op. This test configures the
+///     in-memory context with the SAME NoTracking default as production
+///     (<c>InfrastructureServiceExtensions.cs:178</c>) and re-queries via a FRESH DbContext
+///     instance (new change tracker, same in-memory store) so a masking pre-tracked identity map
+///     cannot hide the bug.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "DocumentProcessing")]
+public class CompleteChunkedUploadCommandHandlerHeadingAwareTests
+{
+    /// <summary>
+    /// Builds an in-memory <see cref="MeepleAiDbContext"/> configured with
+    /// <see cref="QueryTrackingBehavior.NoTracking"/> as the default — mirroring the production
+    /// Npgsql registration (PERF-06) — so <c>FindAsync</c> returns detached entities exactly like
+    /// production, unlike <see cref="TestDbContextFactory"/> (which leaves the EF Core default,
+    /// i.e. tracked, and would mask this class of bug).
+    /// </summary>
+    private static MeepleAiDbContext CreateNoTrackingInMemoryDbContext(string dbName)
+    {
+        var options = new DbContextOptionsBuilder<MeepleAiDbContext>()
+            .UseInMemoryDatabase(databaseName: dbName)
+            .UseQueryTrackingBehavior(QueryTrackingBehavior.NoTracking)
+            .ConfigureWarnings(warnings =>
+            {
+                warnings.Ignore(Microsoft.EntityFrameworkCore.Diagnostics.RelationalEventId.PendingModelChangesWarning);
+                warnings.Ignore(Microsoft.EntityFrameworkCore.Diagnostics.InMemoryEventId.TransactionIgnoredWarning);
+            })
+            .Options;
+
+        return new MeepleAiDbContext(
+            options,
+            Mock.Of<IMediator>(),
+            TestDbContextFactory.CreateMockEventCollector().Object);
+    }
+
+    [Fact]
+    public async Task TriggerPdfProcessing_WithStructuredElements_PersistsHeadingHierarchyAndStructuredElementsJson()
+    {
+        // Arrange ----------------------------------------------------------------
+        var dbName = $"complete_chunked_heading_{Guid.NewGuid():N}";
+        var pdfId = Guid.NewGuid();
+        var gameId = Guid.NewGuid();
+
+        await using (var seedDb = CreateNoTrackingInMemoryDbContext(dbName))
+        {
+            seedDb.PdfDocuments.Add(new PdfDocumentEntity
+            {
+                Id = pdfId,
+                SharedGameId = gameId,
+                UploadedByUserId = Guid.NewGuid(),
+                FileName = "test.pdf",
+                FilePath = "/test/test.pdf",
+                FileSizeBytes = 1024,
+                ContentType = "application/pdf",
+                UploadedAt = DateTime.UtcNow,
+                ProcessingState = nameof(PdfProcessingState.Extracting)
+            });
+            await seedDb.SaveChangesAsync();
+        }
+
+        // The method opens the file with a real FileStream, so a real temp file must exist.
+        var tmp = Path.GetTempFileName();
+        await File.WriteAllTextAsync(tmp, "dummy pdf bytes");
+
+        try
+        {
+            var structuredElements = new List<ExtractedElement>
+            {
+                new("Setup", 1, "Title"),
+                new("Place the board in the middle of the table.", 1, "NarrativeText")
+            };
+
+            var extractorMock = new Mock<IPdfTextExtractor>();
+            extractorMock
+                .Setup(e => e.ExtractPagedTextAsync(It.IsAny<Stream>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(PagedTextExtractionResult.CreateSuccess(
+                    new[] { new PageTextChunk(1, "Setup\n\nPlace the board in the middle of the table.", 0, 50) },
+                    totalPages: 1,
+                    totalCharacters: 50,
+                    ocrTriggered: false,
+                    structuredElements: structuredElements));
+
+            // Structured-content (tables/diagrams) extraction fails so the method returns
+            // early without touching ExtractedTables/Diagrams/AtomicRules — out of scope here.
+            var tableExtractorMock = new Mock<IPdfTableExtractor>();
+            tableExtractorMock
+                .Setup(t => t.ExtractStructuredContentAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(StructuredContentResult.CreateFailure("no structured content in test"));
+
+            // One parent (section-level, Heading "Setup", Level 0) + one child (Level 2) linked via
+            // the parent's auto-generated "N"-format Id — mirrors what AdvancedChunkingService
+            // actually produces (HierarchicalChunk.Create always self-assigns its own Id).
+            var parentMetadata = new ChunkMetadata { Heading = "Setup", Page = 1, ElementType = "Title" };
+            var parent = HierarchicalChunk.CreateParent("Setup section", parentMetadata);
+            var childMetadata = new ChunkMetadata { Heading = "Setup", Page = 1, ElementType = "NarrativeText" };
+            var child = HierarchicalChunk.CreateChild("Place the board in the middle of the table.", 2, childMetadata, parent.Id);
+
+            var advancedChunkingMock = new Mock<IAdvancedChunkingService>();
+            advancedChunkingMock
+                .Setup(x => x.ChunkDocumentAsync(It.IsAny<ExtractedDocument>(), It.IsAny<ChunkingConfiguration?>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new List<HierarchicalChunk> { parent, child });
+
+            // Flat fallback chunker: intentionally unconfigured. If the handler regresses to the
+            // pre-#3281 flat path, PrepareForEmbedding returns null (Moq default), which the
+            // handler already null-coalesces to zero chunks — driving the "zero usable chunks"
+            // failure branch instead of the heading-aware path, so this test would fail loudly.
+            var chunkingServiceMock = new Mock<ITextChunkingService>();
+
+            var embeddingMock = new Mock<IEmbeddingService>();
+            embeddingMock
+                .Setup(e => e.GenerateEmbeddingsAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync((List<string> texts, CancellationToken _) =>
+                    EmbeddingResult.CreateSuccess(texts.Select(t => new float[] { 0.1f, 0.2f, 0.3f }).ToList()));
+
+            var sc = new ServiceCollection();
+            // Each scope resolves a FRESH DbContext instance backed by the same in-memory store —
+            // never the seeding instance — so pdfDoc arrives via FindAsync exactly like production.
+            sc.AddScoped<MeepleAiDbContext>(_ => CreateNoTrackingInMemoryDbContext(dbName));
+            sc.AddScoped(_ => chunkingServiceMock.Object);
+            sc.AddScoped(_ => advancedChunkingMock.Object);
+            sc.AddScoped(_ => embeddingMock.Object);
+            sc.AddScoped(_ => Mock.Of<IPdfIndexingPipeline>());
+            var provider = sc.BuildServiceProvider();
+            var scopeFactory = provider.GetRequiredService<IServiceScopeFactory>();
+
+            var handler = new CompleteChunkedUploadCommandHandler(
+                Mock.Of<IChunkedUploadSessionRepository>(),
+                CreateNoTrackingInMemoryDbContext(dbName),
+                Mock.Of<IBlobStorageService>(),
+                Mock.Of<IBackgroundTaskService>(),
+                NullLogger<CompleteChunkedUploadCommandHandler>.Instance,
+                scopeFactory,
+                extractorMock.Object,
+                tableExtractorMock.Object,
+                Mock.Of<IMediator>(),
+                Mock.Of<IPdfDeduplicationService>(),
+                TimeProvider.System);
+
+            // Act --------------------------------------------------------------------
+            await handler.TriggerPdfProcessingAsync(pdfId.ToString(), tmp, CancellationToken.None);
+
+            // Assert -----------------------------------------------------------------
+            // 🔴 Fresh context (new change tracker) — NOT the seeding context — so a pre-tracked
+            // identity map cannot mask the detached-write bug this task fixes.
+            await using var assertDb = CreateNoTrackingInMemoryDbContext(dbName);
+
+            var updatedPdf = await assertDb.PdfDocuments.FirstOrDefaultAsync(p => p.Id == pdfId);
+            updatedPdf.Should().NotBeNull();
+            updatedPdf!.StructuredElementsJson.Should().NotBeNull(
+                "the pdfDoc mutated during extraction is detached (NoTracking FindAsync) and must be " +
+                "explicitly re-attached (db.PdfDocuments.Update) for the write to persist");
+            updatedPdf.ProcessingState.Should().Be(nameof(PdfProcessingState.Ready),
+                "once pdfDoc is attached, every downstream mutation on the SAME db instance " +
+                "(including the final Ready transition) should persist too");
+
+            var savedChunks = await assertDb.TextChunks
+                .Where(tc => tc.PdfDocumentId == pdfId)
+                .OrderBy(tc => tc.ChunkIndex)
+                .ToListAsync();
+            savedChunks.Should().HaveCount(2);
+
+            var parentEntity = savedChunks.Single(c => c.ParentChunkId == null);
+            parentEntity.Heading.Should().Be("Setup");
+            parentEntity.Level.Should().Be((short)0);
+            parentEntity.Id.Should().Be(Guid.ParseExact(parent.Id, "N"));
+
+            var childEntity = savedChunks.Single(c => c.ParentChunkId != null);
+            childEntity.Heading.Should().Be("Setup");
+            childEntity.Level.Should().Be((short)2);
+            childEntity.ParentChunkId.Should().Be(parentEntity.Id);
+        }
+        finally
+        {
+            File.Delete(tmp);
+        }
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Services/Chunking/HeadingAwareChunkAdapterTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Services/Chunking/HeadingAwareChunkAdapterTests.cs
@@ -1,0 +1,50 @@
+using Api.BoundedContexts.DocumentProcessing.Application.Services.Chunking;
+using Api.Constants;
+using Api.Services;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.DocumentProcessing.Application.Services.Chunking;
+
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "DocumentProcessing")]
+public class HeadingAwareChunkAdapterTests
+{
+    [Fact]
+    public void ToChunkInputs_PreservesIdentityAndHierarchyFields()
+    {
+        var parentId = Guid.NewGuid();
+        var childId = Guid.NewGuid();
+        var chunks = new List<DocumentChunk>
+        {
+            new() { Id = parentId, Text = "Setup", Page = 2, CharStart = 10, CharEnd = 15,
+                    Heading = "Setup", Level = 0, ParentChunkId = null, ElementType = "Title" },
+            new() { Id = childId, Text = "Place 3 tiles", Page = 2, CharStart = 16, CharEnd = 29,
+                    Heading = "Setup", Level = 2, ParentChunkId = parentId, ElementType = "NarrativeText" },
+        };
+
+        var result = HeadingAwareChunkAdapter.ToChunkInputs(chunks);
+
+        result.Should().HaveCount(2);
+        result[0].Id.Should().Be(parentId);
+        result[0].Heading.Should().Be("Setup");
+        result[0].Level.Should().Be((short)0);
+        result[0].ElementType.Should().Be("Title");
+        result[1].Id.Should().Be(childId);
+        result[1].ParentChunkId.Should().Be(parentId);
+        result[1].Level.Should().Be((short)2);
+        result[1].Text.Should().Be("Place 3 tiles");
+        result[1].CharStart.Should().Be(16);
+    }
+
+    [Fact]
+    public void CapForEmbedding_TruncatesOnlyWhenOverLimit()
+    {
+        var under = new string('a', ChunkingConstants.MaxEmbeddingChars);
+        var over = new string('b', ChunkingConstants.MaxEmbeddingChars + 500);
+
+        HeadingAwareChunkAdapter.CapForEmbedding(under).Should().HaveLength(ChunkingConstants.MaxEmbeddingChars);
+        HeadingAwareChunkAdapter.CapForEmbedding(over).Should().HaveLength(ChunkingConstants.MaxEmbeddingChars);
+        HeadingAwareChunkAdapter.CapForEmbedding("short").Should().Be("short");
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineHeadingAwareTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineHeadingAwareTests.cs
@@ -1,0 +1,271 @@
+using Api.BoundedContexts.DocumentProcessing.Application.Services;
+using Api.BoundedContexts.DocumentProcessing.Domain.Services;
+using Api.BoundedContexts.DocumentProcessing.Infrastructure.External;
+using Api.BoundedContexts.KnowledgeBase.Application.Services.Chunking;
+using Api.BoundedContexts.KnowledgeBase.Domain.Chunking;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Services;
+using Api.Services.Pdf;
+using Api.SharedKernel.Application.Services;
+using Api.Tests.Constants;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.DocumentProcessing.Application.Services;
+
+/// <summary>
+/// Issue #3281 (Task 2): wires <see cref="HeadingAwareChunker.BuildAsync"/> into
+/// <see cref="PdfProcessingPipelineService"/> — the Quartz/stale-recovery + shared-game
+/// upload ingest path. Covers the English (no translation) production of heading-bearing
+/// chunks, and the non-English translation branch REGRESSION guard: translated chunks
+/// must NOT copy <c>origChunk.Id</c> (a non-empty stable Guid post-producer-swap), else
+/// <c>db.TextChunks.AddRange</c> throws an EF identity-map collision and every
+/// non-English PDF is marked Failed.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "DocumentProcessing")]
+public sealed class PdfProcessingPipelineHeadingAwareTests : IDisposable
+{
+    private readonly MeepleAiDbContext _db;
+    private readonly Mock<IPdfTextExtractor> _pdfTextExtractorMock = new();
+    private readonly Mock<IPdfTableExtractor> _tableExtractorMock = new();
+    private readonly Mock<ITextChunkingService> _chunkingServiceMock = new();
+    private readonly Mock<IEmbeddingService> _embeddingServiceMock = new();
+    private readonly Mock<IBlobStorageService> _blobStorageServiceMock = new();
+    private readonly Mock<IAdvancedChunkingService> _advancedChunkingMock = new();
+    private readonly Mock<IChunkTranslationService> _chunkTranslationServiceMock = new();
+    private readonly TimeProvider _timeProvider = TimeProvider.System;
+    private readonly ILogger<PdfProcessingPipelineService> _logger =
+        NullLogger<PdfProcessingPipelineService>.Instance;
+
+    private readonly Guid _pdfDocumentId = Guid.NewGuid();
+    private readonly Guid _gameId = Guid.NewGuid();
+
+    public PdfProcessingPipelineHeadingAwareTests()
+    {
+        var options = new DbContextOptionsBuilder<MeepleAiDbContext>()
+            .UseInMemoryDatabase(databaseName: $"PdfPipelineHeadingAwareTest_{Guid.NewGuid()}")
+            .Options;
+        _db = new MeepleAiDbContext(
+            options,
+            new Mock<IMediator>().Object,
+            new Mock<IDomainEventCollector>().Object);
+    }
+
+    public void Dispose()
+    {
+        _db.Dispose();
+        GC.SuppressFinalize(this);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_English_ProducesHeadingBearingChunksWithHierarchy()
+    {
+        // Arrange
+        SeedPdfDocument();
+        SetupExtractorToReturn("chunk1. chunk2.", 2);
+        SetupBlobStorageToReturn();
+        SetupHierarchicalChunking(out var parentId);
+        SetupEmbeddingsToReturn(2);
+
+        var sut = CreatePipelineService(languageCode: "en");
+
+        // Act
+        await sut.ProcessAsync(_pdfDocumentId, "/fake/path.pdf", Guid.NewGuid(), CancellationToken.None);
+
+        // Assert: pipeline reaches Ready
+        var doc = await _db.PdfDocuments.FindAsync(_pdfDocumentId);
+        doc!.ProcessingState.Should().Be("Ready");
+
+        var savedChunks = await _db.TextChunks
+            .Where(tc => tc.PdfDocumentId == _pdfDocumentId)
+            .ToListAsync();
+
+        savedChunks.Should().HaveCount(2);
+        savedChunks.Should().Contain(c => c.Heading == "Setup" && c.Level == 0 && c.ParentChunkId == null);
+        savedChunks.Should().Contain(c => c.Heading == "Setup" && c.Level == 2 && c.ParentChunkId == parentId);
+
+        // English document: translation branch must not run.
+        _chunkTranslationServiceMock.Verify(
+            t => t.TranslateChunksAsync(
+                It.IsAny<IReadOnlyList<string>>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task ProcessAsync_NonEnglish_TranslatedChunksGetFreshIds_NoPrimaryKeyCollision()
+    {
+        // Arrange — regression guard for the PK-collision fix (plan Task 2, CRITICAL note):
+        // after the producer swap, origChunk.Id is a non-empty stable Guid (from
+        // HierarchicalChunkMapper). If the translation branch copied that Id onto the
+        // translated DocumentChunkInput, db.TextChunks.AddRange would throw an EF
+        // identity-map InvalidOperationException (uncaught — only DbUpdateConcurrencyException
+        // is handled) and the PDF would be marked Failed for every non-English document.
+        SeedPdfDocument();
+        SetupExtractorToReturn("chunk1. chunk2.", 2);
+        SetupBlobStorageToReturn();
+        SetupHierarchicalChunking(out var parentId);
+        SetupTranslation();
+        SetupEmbeddingsToReturn(4); // 2 originals + 2 EN translations
+
+        var sut = CreatePipelineService(languageCode: "it");
+
+        // Act
+        await sut.ProcessAsync(_pdfDocumentId, "/fake/path.pdf", Guid.NewGuid(), CancellationToken.None);
+
+        // Assert: pipeline completes WITHOUT the PDF being marked Failed.
+        var doc = await _db.PdfDocuments.FindAsync(_pdfDocumentId);
+        doc!.ProcessingState.Should().Be("Ready");
+        doc.ProcessingError.Should().BeNull();
+
+        var savedChunks = await _db.TextChunks
+            .Where(tc => tc.PdfDocumentId == _pdfDocumentId)
+            .ToListAsync();
+
+        // 2 originals + 2 EN translations, all with DISTINCT Ids (no PK collision).
+        savedChunks.Should().HaveCount(4);
+        savedChunks.Select(c => c.Id).Should().OnlyHaveUniqueItems();
+
+        // Translated rows still carry the hierarchy fields copied from origChunk.
+        savedChunks.Should().Contain(c => c.Heading == "Setup" && c.Level == 2 && c.ParentChunkId == parentId);
+    }
+
+    private PdfProcessingPipelineService CreatePipelineService(string languageCode)
+    {
+        var languageDetectorMock = new Mock<ILanguageDetector>();
+        languageDetectorMock
+            .Setup(l => l.Detect(It.IsAny<string>()))
+            .Returns(new LanguageDetectionResult(languageCode, true, 0.95));
+
+        return new PdfProcessingPipelineService(
+            _db,
+            new Api.Tests.TestHelpers.InMemoryPdfClaimService(_db),
+            _pdfTextExtractorMock.Object,
+            _tableExtractorMock.Object,
+            _chunkingServiceMock.Object,
+            _embeddingServiceMock.Object,
+            _blobStorageServiceMock.Object,
+            _timeProvider,
+            _logger,
+            languageDetectorMock.Object,
+            _chunkTranslationServiceMock.Object,
+            Mock.Of<Api.BoundedContexts.KnowledgeBase.Application.Services.IPdfIndexingPipeline>(),
+            advancedChunking: _advancedChunkingMock.Object);
+    }
+
+    private PdfDocumentEntity SeedPdfDocument()
+    {
+        // Use PrivateGameId so PdfGameIdResolver returns _gameId directly without a
+        // games-table lookup (mirrors RaptorPipelineIntegrationTests.SeedPdfDocument).
+        var pdfDoc = new PdfDocumentEntity
+        {
+            Id = _pdfDocumentId,
+            PrivateGameId = _gameId,
+            FileName = "test.pdf",
+            FilePath = "/fake/path/test.pdf",
+            ContentType = "application/pdf",
+            FileSizeBytes = 1024,
+            UploadedByUserId = Guid.NewGuid(),
+            ProcessingState = "Pending",
+            UploadedAt = DateTime.UtcNow
+        };
+        _db.PdfDocuments.Add(pdfDoc);
+        _db.SaveChanges();
+        return pdfDoc;
+    }
+
+    private void SetupBlobStorageToReturn()
+    {
+        _blobStorageServiceMock
+            .Setup(b => b.RetrieveAsync(It.IsAny<string>(), It.IsAny<BlobCategory>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new MemoryStream(new byte[] { 0x25, 0x50, 0x44, 0x46 })); // %PDF header
+    }
+
+    private void SetupExtractorToReturn(string fullText, int pageCount)
+    {
+        var pageChunks = Enumerable.Range(1, pageCount)
+            .Select(p => new PageTextChunk(
+                PageNumber: p,
+                Text: $"chunk{p} text",
+                CharStartIndex: (p - 1) * 50,
+                CharEndIndex: p * 50))
+            .ToList();
+
+        var structuredElements = new List<ExtractedElement>
+        {
+            new("Setup", 1, "Title"),
+            new("Place the tiles.", 1, "NarrativeText")
+        };
+
+        var result = PagedTextExtractionResult.CreateSuccess(
+            pageChunks: pageChunks,
+            totalPages: pageCount,
+            totalCharacters: fullText.Length,
+            ocrTriggered: false,
+            structuredElements: structuredElements);
+
+        _pdfTextExtractorMock
+            .Setup(e => e.ExtractPagedTextAsync(It.IsAny<Stream>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(result);
+
+        _tableExtractorMock
+            .Setup(t => t.ExtractStructuredContentAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(StructuredContentResult.CreateFailure("Not applicable"));
+    }
+
+    /// <summary>
+    /// Mocks <see cref="IAdvancedChunkingService.ChunkDocumentAsync"/> to return a parent
+    /// (Level 0, Heading "Setup") + child (Level 2, ParentChunkId=parent, Heading "Setup") —
+    /// the minimal hierarchy shape <c>HeadingAwareChunker.BuildAsync</c> /
+    /// <c>HierarchicalChunkMapper</c> produce (mirrors HeadingAwareChunkerTests).
+    /// </summary>
+    private void SetupHierarchicalChunking(out Guid parentId)
+    {
+        var parent = HierarchicalChunk.CreateParent(
+            "Setup section content",
+            new ChunkMetadata { Page = 1, Heading = "Setup", ElementType = "Title", DocumentId = _pdfDocumentId });
+        var child = HierarchicalChunk.CreateChild(
+            "Place the tiles.",
+            level: 2,
+            new ChunkMetadata { Page = 1, Heading = "Setup", ElementType = "NarrativeText", DocumentId = _pdfDocumentId },
+            parent.Id);
+
+        _advancedChunkingMock
+            .Setup(s => s.ChunkDocumentAsync(
+                It.IsAny<ExtractedDocument>(),
+                It.IsAny<ChunkingConfiguration?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<HierarchicalChunk> { parent, child });
+
+        parentId = Guid.ParseExact(parent.Id, "N");
+    }
+
+    private void SetupTranslation()
+    {
+        _chunkTranslationServiceMock
+            .Setup(t => t.TranslateChunksAsync(
+                It.IsAny<IReadOnlyList<string>>(),
+                It.IsAny<string>(),
+                It.IsAny<string>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyList<string> texts, string src, string tgt, CancellationToken _) =>
+                texts.Select((text, idx) => new TranslatedChunk(idx, text, $"EN: {text}", src, tgt)).ToList());
+    }
+
+    private void SetupEmbeddingsToReturn(int count)
+    {
+        var embeddings = Enumerable.Range(0, count)
+            .Select(_ => new float[] { 0.1f, 0.2f, 0.3f })
+            .ToList();
+
+        _embeddingServiceMock
+            .Setup(e => e.GenerateEmbeddingsAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new EmbeddingResult { Success = true, Embeddings = embeddings });
+    }
+}

--- a/apps/api/tests/Api.Tests/Integration/DocumentProcessing/IndexPdfIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/DocumentProcessing/IndexPdfIntegrationTests.cs
@@ -3,11 +3,15 @@ using Api.SharedKernel.Domain.ValueObjects;
 using Api.BoundedContexts.Authentication.Infrastructure.Persistence;
 using Api.BoundedContexts.DocumentProcessing.Application.Commands;
 using Api.BoundedContexts.DocumentProcessing.Application.DTOs;
-using Api.BoundedContexts.DocumentProcessing.Application.Commands;
 using Api.BoundedContexts.DocumentProcessing.Application.Queries;
 using Api.BoundedContexts.DocumentProcessing.Domain.Repositories;
+using Api.BoundedContexts.DocumentProcessing.Domain.Services;
 using Api.BoundedContexts.DocumentProcessing.Infrastructure.External;
 using Api.BoundedContexts.DocumentProcessing.Infrastructure.Persistence;
+using Api.BoundedContexts.KnowledgeBase.Application.Queries.GetKbChunks;
+using Api.BoundedContexts.KnowledgeBase.Application.Services;
+using Api.BoundedContexts.KnowledgeBase.Application.Services.Chunking;
+using Api.BoundedContexts.KnowledgeBase.Domain.Services;
 using Api.Configuration;
 using Api.Infrastructure;
 using Api.Infrastructure.Entities;
@@ -18,14 +22,13 @@ using Api.SharedKernel.Application.Services;
 using Api.SharedKernel.Infrastructure.Persistence;
 using Api.Tests.Constants;
 using Api.Tests.Infrastructure;
-using DotNet.Testcontainers.Builders;
+using Api.Tests.TestHelpers;
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Npgsql;
-using Testcontainers.Qdrant;
 using Xunit;
 using AuthRole = Api.SharedKernel.Domain.ValueObjects.Role;
 
@@ -41,7 +44,7 @@ namespace Api.Tests.Integration.DocumentProcessing;
 /// 1. Happy Path: Index valid PDF with all steps
 /// 2. Text Extraction: Index with text extraction completion check
 /// 3. Vector Generation: Index with embedding generation
-/// 4. pgvector Storage: Index with Qdrant persistence
+/// 4. pgvector Storage: Index with pgvector persistence
 /// 5. Large PDF: Index large PDF with chunking
 /// 6. Failure Recovery: Index with failure scenarios
 /// 7. Re-indexing: Re-index existing PDF
@@ -58,7 +61,6 @@ public sealed class IndexPdfIntegrationTests : IAsyncLifetime
     private readonly SharedTestcontainersFixture _fixture;
     private string _isolatedDbConnectionString = string.Empty;
     private string _databaseName = string.Empty;
-    private QdrantContainer? _qdrantContainer;
     private MeepleAiDbContext? _dbContext;
     private IServiceProvider? _serviceProvider;
 
@@ -83,20 +85,7 @@ public sealed class IndexPdfIntegrationTests : IAsyncLifetime
         _databaseName = $"test_indexpdf_{Guid.NewGuid():N}";
         _isolatedDbConnectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
 
-        // Start Qdrant container (kept separate - not in SharedTestcontainersFixture)
-        _qdrantContainer = new QdrantBuilder()
-            .WithImage("qdrant/qdrant:v1.7.4")
-            .WithPortBinding(6333, true)
-            .WithWaitStrategy(Wait.ForUnixContainer()
-                .UntilHttpRequestIsSucceeded(r => r.ForPort(6333).ForPath("/healthz")))
-            .Build();
-
-        await _qdrantContainer.StartAsync(TestCancellationToken);
-
         // Setup services
-        var qdrantPort = _qdrantContainer.GetMappedPublicPort(6333);
-        var qdrantUrl = $"http://localhost:{qdrantPort}";
-
         var services = IntegrationServiceCollectionBuilder.CreateBase(_isolatedDbConnectionString);
 
         // Register repositories
@@ -107,7 +96,7 @@ public sealed class IndexPdfIntegrationTests : IAsyncLifetime
         services.AddScoped<IndexPdfCommandHandler>();
 
         // Register mock services
-        RegisterMockServices(services, qdrantUrl);
+        RegisterMockServices(services);
 
         _serviceProvider = services.BuildServiceProvider();
         _dbContext = _serviceProvider.GetRequiredService<MeepleAiDbContext>();
@@ -151,77 +140,57 @@ public sealed class IndexPdfIntegrationTests : IAsyncLifetime
                 // Ignore cleanup errors
             }
         }
-
-        // Qdrant container still managed individually
-        if (_qdrantContainer != null)
-        {
-            await _qdrantContainer.StopAsync(TestCancellationToken);
-            await _qdrantContainer.DisposeAsync();
-        }
     }
 
-    private void RegisterMockServices(IServiceCollection services, string _)
+    private void RegisterMockServices(IServiceCollection services)
     {
-        // Mock TextChunking service (returns realistic chunks)
-        var chunkingMock = new Mock<ITextChunkingService>();
-        chunkingMock.Setup(c => c.ChunkText(It.IsAny<string>(), It.IsAny<int>(), It.IsAny<int>()))
-            .Returns((string text, int chunkSize, int overlap) =>
-            {
-                // Simple chunking: split by paragraphs, max 500 chars each
-                var chunks = new List<TextChunk>();
-                var paragraphs = text.Split(new[] { "\n\n", "\r\n\r\n" }, StringSplitOptions.RemoveEmptyEntries);
-                int charStart = 0;
-                int index = 0;
+        // Issue #3281: IndexPdfCommandHandler no longer calls ITextChunkingService directly —
+        // it chunks via HeadingAwareChunker.BuildAsync(IAdvancedChunkingService). Register the
+        // REAL chunking stack (not a mock) so ChunkCount assertions reflect genuine chunker
+        // output proportional to input size (relative thresholds like "> 10"/"> 100" rely on
+        // this). ITextChunkingService is still needed as AdvancedChunkingService's own
+        // sentence-splitting dependency.
+        services.AddSingleton<ITextChunkingService, TextChunkingService>();
+        services.AddScoped<ChunkingStrategySelector>();
+        services.AddScoped<IAdvancedChunkingService, AdvancedChunkingService>();
 
-                for (int i = 0; i < paragraphs.Length; i++)
-                {
-                    var para = paragraphs[i];
-                    if (para.Length > 500)
-                    {
-                        // Split large paragraphs
-                        for (int j = 0; j < para.Length; j += 500)
-                        {
-                            var chunk = para.Substring(j, Math.Min(500, para.Length - j));
-                            chunks.Add(new TextChunk
-                            {
-                                Text = chunk,
-                                Index = index++,
-                                Page = i + 1,
-                                CharStart = charStart,
-                                CharEnd = charStart + chunk.Length
-                            });
-                            charStart += chunk.Length;
-                        }
-                    }
-                    else
-                    {
-                        chunks.Add(new TextChunk
-                        {
-                            Text = para,
-                            Index = index++,
-                            Page = i + 1,
-                            CharStart = charStart,
-                            CharEnd = charStart + para.Length
-                        });
-                        charStart += para.Length;
-                    }
-                }
+        // ISemanticResponseCache: only exercised for the post-index InvalidateGameAsync
+        // cache-bust call; not asserted by these tests, so a bare mock is sufficient.
+        services.AddScoped<ISemanticResponseCache>(_ => Mock.Of<ISemanticResponseCache>());
 
-                return chunks;
-            });
-        services.AddSingleton<ITextChunkingService>(chunkingMock.Object);
+        // IPdfIndexingPipeline (#2244/#2242): centralised VectorDocument processing->completed
+        // write path. Real implementation so the "completed" transition actually happens
+        // (asserted via vectorDoc.IndexingStatus) and VectorDocumentIndexedEvent is published.
+        services.AddScoped<IPdfIndexingPipeline, PdfIndexingPipeline>();
 
-        // Mock Embedding service (returns mock embeddings)
+        // VectorDocumentIndexedEvent (published by PdfIndexingPipeline.IndexAsync on every
+        // successful index) fans out to 2 notification handlers:
+        //  - VectorDocumentIndexedForKbFlagHandler needs ICacheInvalidationRetryPolicy.
+        //  - VectorDocumentIndexedEventHandler needs IVectorDocumentRepository; a bare
+        //    unconfigured mock returns null from GetByIdAsync, which makes the handler
+        //    short-circuit before it publishes the downstream VectorDocumentReadyIntegrationEvent
+        //    (5 further handlers spanning UserNotifications/GameManagement/Administration) —
+        //    deliberately avoids wiring that whole cascade for these tests.
+        services.AddScoped<Api.Services.ICacheInvalidationRetryPolicy>(_ => new PassthroughRetryPolicy());
+        services.AddScoped(_ =>
+            Mock.Of<Api.BoundedContexts.KnowledgeBase.Domain.Repositories.IVectorDocumentRepository>());
+
+        // Mock Embedding service (returns mock embeddings). Dimensions MUST match the real
+        // pgvector schema's vector(768) column (PgVectorEmbeddingEntityConfiguration.cs) —
+        // a mismatched dimension fails at INSERT time with a Postgres error ("expected 768
+        // dimensions, not N"), surfacing as an opaque DbUpdateException/UnexpectedError from
+        // IndexPdfCommandHandler's top-level catch. This was the stale-file drift (previously
+        // 384) that made every real-Postgres indexing scenario in this class fail.
         var embeddingMock = new Mock<IEmbeddingService>();
-        embeddingMock.Setup(e => e.GetEmbeddingDimensions()).Returns(384);
+        embeddingMock.Setup(e => e.GetEmbeddingDimensions()).Returns(768);
         embeddingMock.Setup(e => e.GetModelName()).Returns("test-embedding-model");
         embeddingMock.Setup(e => e.GenerateEmbeddingsAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync((List<string> texts, CancellationToken ct) =>
             {
                 var embeddings = texts.Select(_ =>
                 {
-                    // Generate deterministic 384-dimensional embeddings for testing
-                    return Enumerable.Range(0, 384).Select(i => (float)(i * 0.001)).ToArray();
+                    // Generate deterministic 768-dimensional embeddings for testing
+                    return Enumerable.Range(0, 768).Select(i => (float)(i * 0.001)).ToArray();
                 }).ToList();
 
                 return new EmbeddingResult
@@ -272,7 +241,7 @@ public sealed class IndexPdfIntegrationTests : IAsyncLifetime
 
     private async Task<Guid> CreateTestPdfAsync(
         string name = "Test.pdf",
-        string? extractedText = null,
+        string? extractedText = "This is test extracted text.\n\nIt has multiple paragraphs.\n\nEach paragraph will become a chunk during indexing.",
         string status = "completed",
         bool withVectorDoc = false)
     {
@@ -282,14 +251,27 @@ public sealed class IndexPdfIntegrationTests : IAsyncLifetime
         var pdfDoc = new PdfDocumentEntity
         {
             Id = Guid.NewGuid(),
-            GameId = gameId,
+            SharedGameId = gameId,
             UploadedByUserId = userId,
             FileName = name,
             FilePath = $"/test/{name}",
             FileSizeBytes = 1024,
             UploadedAt = DateTime.UtcNow,
             PageCount = 10,
-            ExtractedText = extractedText ?? "This is test extracted text.\n\nIt has multiple paragraphs.\n\nEach paragraph will become a chunk during indexing."
+            // Note: the default value lives on the parameter (not via `?? fallback` in the
+            // initializer) so callers can pass extractedText: null and actually get a null
+            // ExtractedText — previously `extractedText ?? "default text"` silently replaced
+            // an explicit null with the default, defeating IndexPdfWithoutExtractedText_
+            // ReturnsTextExtractionRequired (issue #3281 stale-file drift).
+            //
+            // status != "completed" (e.g. "pending"/"processing") forces ExtractedText to null
+            // regardless of what the caller passed: IndexPdfCommandHandler's current validation
+            // (ValidateAndPreparePdfForIndexingAsync) determines "extraction not done" purely by
+            // ExtractedText being empty — it does not read a separate status/ProcessingState
+            // field (that check predates the 7-state PdfProcessingState model, issue #4215).
+            // Mirroring that here keeps IndexPdfWithIncompleteProcessing_ReturnsTextExtractionRequired's
+            // "processing" scenario meaningful against the current handler.
+            ExtractedText = string.Equals(status, "completed", StringComparison.Ordinal) ? extractedText : null
         };
 
         _dbContext.PdfDocuments.Add(pdfDoc);
@@ -306,7 +288,7 @@ public sealed class IndexPdfIntegrationTests : IAsyncLifetime
                 IndexedAt = DateTime.UtcNow,
                 IndexingStatus = "completed",
                 EmbeddingModel = "test-model",
-                EmbeddingDimensions = 384
+                EmbeddingDimensions = 768
             };
             _dbContext.Set<VectorDocumentEntity>().Add(vectorDoc);
         }
@@ -389,7 +371,10 @@ public sealed class IndexPdfIntegrationTests : IAsyncLifetime
         result.Should().NotBeNull();
         result.Success.Should().BeFalse();
         result.ErrorCode.Should().Be(PdfIndexingErrorCode.TextExtractionRequired);
-        result.ErrorMessage.Should().Contain("not completed");
+        // Re-baselined (#3281): the current handler uses one generic message for "no text yet"
+        // regardless of cause (no separate ProcessingState check — see CreateTestPdfAsync note
+        // above), so this no longer asserts the old "not completed" substring.
+        result.ErrorMessage.Should().Contain("extraction");
     }
     [Fact]
     public async Task IndexPdf_GeneratesEmbeddings_Success()
@@ -414,7 +399,7 @@ public sealed class IndexPdfIntegrationTests : IAsyncLifetime
         vectorDoc.Should().NotBeNull();
         vectorDoc!.ChunkCount.Should().BeGreaterThan(0);
         vectorDoc.EmbeddingModel.Should().Be("test-embedding-model");
-        vectorDoc.EmbeddingDimensions.Should().Be(384);
+        vectorDoc.EmbeddingDimensions.Should().Be(768);
     }
 
     [Fact]
@@ -427,7 +412,7 @@ public sealed class IndexPdfIntegrationTests : IAsyncLifetime
 
         // Create handler with failing embedding service
         var embeddingMock = new Mock<IEmbeddingService>();
-        embeddingMock.Setup(e => e.GetEmbeddingDimensions()).Returns(384);
+        embeddingMock.Setup(e => e.GetEmbeddingDimensions()).Returns(768);
         embeddingMock.Setup(e => e.GetModelName()).Returns("test-model");
         embeddingMock.Setup(e => e.GenerateEmbeddingsAsync(It.IsAny<List<string>>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new EmbeddingResult
@@ -439,10 +424,12 @@ public sealed class IndexPdfIntegrationTests : IAsyncLifetime
 
         var handler = new IndexPdfCommandHandler(
             _dbContext!,
-            _serviceProvider!.GetRequiredService<ITextChunkingService>(),
+            _serviceProvider!.GetRequiredService<IAdvancedChunkingService>(),
             embeddingMock.Object,
             _serviceProvider!.GetRequiredService<ILogger<IndexPdfCommandHandler>>(),
-            CreateIndexingSettings()
+            CreateIndexingSettings(),
+            _serviceProvider!.GetRequiredService<ISemanticResponseCache>(),
+            _serviceProvider!.GetRequiredService<IPdfIndexingPipeline>()
         );
 
         var command = new IndexPdfCommand(pdfId.ToString());
@@ -607,5 +594,83 @@ public sealed class IndexPdfIntegrationTests : IAsyncLifetime
         updatedVectorDoc!.Id.Should().Be(originalVectorDoc.Id, "same entity should be updated");
         updatedVectorDoc.IndexedAt.Should().BeAfter(originalIndexedAt!.Value, "IndexedAt should be updated");
         updatedVectorDoc.IndexingStatus.Should().Be("completed");
+    }
+
+    /// <summary>
+    /// Issue #3281 (Task 6): real-Postgres round-trip proving the recursive HeadingPath CTE
+    /// (<see cref="GetKbChunksHandler"/>) resolves for chunks produced by the heading-aware
+    /// ingest path. Seeds a PdfDocument with a non-empty StructuredElementsJson (a titled
+    /// document), indexes it via IndexPdfCommandHandler (real IAdvancedChunkingService), then
+    /// asserts both the raw persisted columns AND the CTE-backed retrieval query surface the
+    /// heading hierarchy.
+    /// </summary>
+    [Fact]
+    public async Task IndexPdf_WithStructuredElements_PersistsHeadingAwareChunksAndCteResolvesHeadingPath()
+    {
+        // Arrange
+        await ResetDatabaseAsync();
+        var gameId = (await _dbContext!.SharedGames.FirstAsync(TestCancellationToken)).Id;
+        var userId = (await _dbContext.Users.FirstAsync(TestCancellationToken)).Id;
+
+        var text = "Setup\n\nPlace your components on the board and read the rules carefully before starting the game.";
+        var structuredElements = new List<ExtractedElement>
+        {
+            new("Setup", 1, "Title"),
+            new("Place your components on the board and read the rules carefully before starting the game.", 1, "NarrativeText")
+        };
+
+        var pdfDoc = new PdfDocumentEntity
+        {
+            Id = Guid.NewGuid(),
+            SharedGameId = gameId,
+            UploadedByUserId = userId,
+            FileName = "HeadingAware.pdf",
+            FilePath = "/test/HeadingAware.pdf",
+            FileSizeBytes = 1024,
+            UploadedAt = DateTime.UtcNow,
+            PageCount = 1,
+            ExtractedText = text,
+            // Mirrors PdfProcessingPipelineService.cs:496-498 serialization convention.
+            StructuredElementsJson = System.Text.Json.JsonSerializer.Serialize(structuredElements)
+        };
+        _dbContext.PdfDocuments.Add(pdfDoc);
+        await _dbContext.SaveChangesAsync(TestCancellationToken);
+
+        var handler = _serviceProvider!.GetRequiredService<IndexPdfCommandHandler>();
+        var command = new IndexPdfCommand(pdfDoc.Id.ToString());
+
+        // Act
+        var result = await handler.Handle(command, TestCancellationToken);
+
+        // Assert: indexing succeeded
+        result.Should().NotBeNull();
+        result.Success.Should().BeTrue($"indexing must succeed for a titled document. Error='{result.ErrorMessage}'");
+
+        // Direct column check (real Postgres): the titled section produces a Level-0 parent
+        // chunk (Heading="Setup") and at least one Level-2 child chunk (Heading="Setup",
+        // ParentChunkId=parent.Id) — see AdvancedChunkingService.ProcessSections.
+        var chunks = await _dbContext.TextChunks.AsNoTracking()
+            .Where(t => t.PdfDocumentId == pdfDoc.Id)
+            .ToListAsync(TestCancellationToken);
+        chunks.Should().Contain(c => c.Heading != null, "the titled section's parent/child chunks must carry the heading");
+        chunks.Should().Contain(c => c.ParentChunkId != null, "child chunks must reference the parent chunk id");
+
+        // CTE via retrieval handler. Instantiated directly (rather than resolved through the
+        // shared _serviceProvider, which registers a bare Mock.Of<IHybridCacheService>() that
+        // returns null WITHOUT invoking the factory) with PassthroughHybridCache so
+        // GetOrCreateAsync actually runs ComputeAsync — and therefore the recursive
+        // HeadingPath CTE — instead of silently short-circuiting to a cache miss.
+        var kbLogger = _serviceProvider.GetRequiredService<ILogger<GetKbChunksHandler>>();
+        var kbChunksHandler = new GetKbChunksHandler(_dbContext, new PassthroughHybridCache(), kbLogger);
+        var resp = await kbChunksHandler.Handle(
+            new GetKbChunksQuery(
+                DocumentId: pdfDoc.Id,
+                RequestingUserId: userId,
+                Cursor: null,
+                Limit: 100,
+                UserIsAdmin: true),
+            TestCancellationToken);
+
+        resp.Items.Should().Contain(c => c.HeadingPath.Count > 0, "the recursive CTE must resolve the heading path for at least one chunk");
     }
 }

--- a/apps/api/tests/Api.Tests/Integration/DocumentProcessing/UploadPdfExtractionPersistenceIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/DocumentProcessing/UploadPdfExtractionPersistenceIntegrationTests.cs
@@ -1,0 +1,426 @@
+using System.Security.Cryptography;
+using Api.BoundedContexts.Authentication.Infrastructure.Persistence;
+using Api.BoundedContexts.DocumentProcessing.Application.Commands;
+using Api.BoundedContexts.DocumentProcessing.Domain.Repositories;
+using Api.BoundedContexts.DocumentProcessing.Domain.Services;
+using Api.BoundedContexts.DocumentProcessing.Infrastructure.Configuration;
+using Api.BoundedContexts.DocumentProcessing.Infrastructure.External;
+using Api.BoundedContexts.DocumentProcessing.Infrastructure.Persistence;
+using Api.BoundedContexts.DocumentProcessing.Infrastructure.Services;
+using Api.BoundedContexts.KnowledgeBase.Application.Services.Chunking;
+using Api.BoundedContexts.KnowledgeBase.Domain.Chunking;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Services;
+using Api.Services.Pdf;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using StackExchange.Redis;
+using Xunit;
+
+namespace Api.Tests.Integration.DocumentProcessing;
+
+/// <summary>
+/// Issue #3281 (Task 4): regression test for the pre-existing AsNoTracking persistence bug in
+/// <see cref="UploadPdfCommandHandler"/>'s background pipeline. The pipeline's working
+/// <c>pdfDoc</c> is loaded <c>AsNoTracking()</c> and state transitions route through
+/// <c>IPdfDocumentRepository.UpdateAsync</c> (whose <c>MapToPersistence</c> omits +
+/// whole-row-clobbers the extraction content columns), so <c>ExtractedText</c> and
+/// <c>StructuredElementsJson</c> written during extraction never durably persisted for
+/// Upload-originated PDFs — blocking re-index parity (<c>IndexPdfCommandHandler</c> reads
+/// <c>StructuredElementsJson</c> and requires non-null <c>ExtractedText</c>).
+///
+/// Modeled on <c>UploadPdfHeadingAwareIntegrationTests</c>'s harness (Task 3): real Postgres via
+/// <see cref="SharedTestcontainersFixture"/>, <c>InlineBackgroundTaskService</c> so the BG
+/// pipeline (extract → chunk → embed → index → finalize) runs synchronously before assertions.
+/// </summary>
+[Collection("Integration-GroupB")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "DocumentProcessing")]
+[Trait("Issue", "3281")]
+public sealed class UploadPdfExtractionPersistenceIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private string _databaseName = string.Empty;
+    private MeepleAiDbContext? _dbContext;
+    private IServiceProvider? _serviceProvider;
+    private IConnectionMultiplexer? _redis;
+    private string? _testDataDirectory;
+    private InlineBackgroundTaskService? _inlineBgService;
+
+    private static CancellationToken TestCancellationToken => TestContext.Current.CancellationToken;
+
+    public UploadPdfExtractionPersistenceIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        _databaseName = $"test_extractionpersist_{Guid.NewGuid():N}";
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+
+        _testDataDirectory = Path.Combine(Path.GetTempPath(), "meepleai-test-extractionpersist-" + Guid.NewGuid());
+        Directory.CreateDirectory(_testDataDirectory);
+
+        var services = IntegrationServiceCollectionBuilder.CreateBase(connectionString);
+
+        _redis = await ConnectionMultiplexer.ConnectAsync(_fixture.RedisConnectionString);
+        services.AddSingleton<IConnectionMultiplexer>(_redis);
+
+        services.AddScoped<IUserRepository, UserRepository>();
+        services.AddScoped<IPdfDocumentRepository, PdfDocumentRepository>();
+
+        services.AddScoped<UploadPdfCommandHandler>();
+
+        services.Configure<PdfProcessingOptions>(options =>
+        {
+            options.MaxFileSizeBytes = 10 * 1024 * 1024;
+        });
+
+        // Inline background task service so the BG pipeline runs synchronously before assertions
+        // (mirrors UploadPdfHeadingAwareIntegrationTests / PdfIndexingFlowKbFlagIntegrationTests).
+        _inlineBgService = new InlineBackgroundTaskService();
+        services.AddSingleton<IBackgroundTaskService>(_inlineBgService);
+
+        services.AddSingleton<IEmbeddingService>(new MockEmbeddingService(dimensions: 768));
+
+        // Extractor returns a paged result WITH non-empty StructuredElements (a Title + body
+        // element) so ExtractPdfContentAsync has something to serialize into StructuredElementsJson.
+        var extractorMock = new Mock<IPdfTextExtractor>();
+        extractorMock
+            .Setup(e => e.ExtractTextAsync(It.IsAny<Stream>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(TextExtractionResult.CreateSuccess(
+                extractedText: "Setup. Place 3 tiles on the board.",
+                pageCount: 1,
+                characterCount: 34,
+                ocrTriggered: false,
+                quality: ExtractionQuality.High));
+        extractorMock
+            .Setup(e => e.ExtractPagedTextAsync(It.IsAny<Stream>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(PagedTextExtractionResult.CreateSuccess(
+                pageChunks: new[]
+                {
+                    new PageTextChunk(
+                        PageNumber: 1,
+                        Text: "Setup. Place 3 tiles on the board.",
+                        CharStartIndex: 0,
+                        CharEndIndex: 34)
+                },
+                totalPages: 1,
+                totalCharacters: 34,
+                ocrTriggered: false,
+                structuredElements: new List<ExtractedElement>
+                {
+                    new("Setup", 1, "Title"),
+                    new("Place 3 tiles on the board.", 1, "NarrativeText")
+                }));
+        services.AddSingleton<IPdfTextExtractor>(extractorMock.Object);
+
+        var tableExtractorMock = new Mock<IPdfTableExtractor>();
+        tableExtractorMock
+            .Setup(t => t.ExtractStructuredContentAsync(It.IsAny<string>()!, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new StructuredContentResult
+            {
+                Success = false,
+                ErrorMessage = "Skipped in test"
+            });
+        services.AddSingleton<IPdfTableExtractor>(tableExtractorMock.Object);
+
+        // Mocked IAdvancedChunkingService so ChunkExtractedTextAsync (Task 3 wiring) takes the
+        // heading-aware branch — irrelevant to this test's assertions but keeps the pipeline shape
+        // identical to production (avoids depending on the flat-fallback branch by coincidence).
+        var advancedChunkingMock = new Mock<IAdvancedChunkingService>();
+        advancedChunkingMock
+            .Setup(s => s.ChunkDocumentAsync(
+                It.IsAny<ExtractedDocument>(),
+                It.IsAny<ChunkingConfiguration?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ExtractedDocument doc, ChunkingConfiguration? _, CancellationToken _) =>
+            {
+                var parent = HierarchicalChunk.CreateParent(
+                    "Setup section content",
+                    new ChunkMetadata { Page = 1, Heading = "Setup", ElementType = "Title", DocumentId = doc.Id });
+                var child = HierarchicalChunk.CreateChild(
+                    "Place 3 tiles on the board.",
+                    level: 2,
+                    new ChunkMetadata { Page = 1, Heading = "Setup", ElementType = "NarrativeText", DocumentId = doc.Id },
+                    parent.Id);
+                return new List<HierarchicalChunk> { parent, child };
+            });
+        services.AddSingleton<IAdvancedChunkingService>(advancedChunkingMock.Object);
+
+        var blobStorageMock = new Mock<IBlobStorageService>();
+        blobStorageMock
+            .Setup(b => b.StoreAsync(
+                It.IsAny<Stream>(),
+                It.IsAny<string>()!,
+                It.IsAny<BlobCategory>(),
+                It.IsAny<string>()!,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Stream stream, string fileName, BlobCategory category, string resourceKey, CancellationToken ct) =>
+            {
+                var safeKey = resourceKey.Replace('/', '_').Replace('\\', '_');
+                var filePath = Path.Combine(_testDataDirectory!, $"{safeKey}_{fileName}");
+                using var fileStream = File.Create(filePath);
+                stream.CopyTo(fileStream);
+                return new BlobStorageResult(true, Guid.NewGuid().ToString(), filePath, stream.Length, null);
+            });
+        blobStorageMock
+            .Setup(b => b.RetrieveAsync(It.IsAny<string>()!, It.IsAny<BlobCategory>(), It.IsAny<string>()!, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string path, BlobCategory category, string resourceKey, CancellationToken ct) =>
+                File.Exists(path) ? (Stream?)File.OpenRead(path) : null);
+        blobStorageMock
+            .Setup(b => b.DeleteAsync(It.IsAny<string>()!, It.IsAny<BlobCategory>(), It.IsAny<string>()!, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        services.AddSingleton<IBlobStorageService>(blobStorageMock.Object);
+
+        var cacheMock = new Mock<IAiResponseCacheService>();
+        cacheMock
+            .Setup(c => c.InvalidateGameAsync(It.IsAny<string>()!, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        services.AddSingleton<IAiResponseCacheService>(cacheMock.Object);
+
+        var configServiceMock = new Mock<IConfigurationService>();
+        configServiceMock
+            .Setup(c => c.GetValueAsync<int?>(It.IsAny<string>()!, It.IsAny<int?>(), It.IsAny<string>()))
+            .Returns(Task.FromResult<int?>(null));
+        services.AddSingleton<IConfigurationService>(configServiceMock.Object);
+
+        services.AddScoped<IPdfUploadQuotaService, PdfUploadQuotaService>();
+
+        // Real TextChunkingService still registered so the (unexercised in this test) flat
+        // fallback path continues to resolve — mirrors production DI shape.
+        services.AddSingleton<ITextChunkingService, TextChunkingService>();
+
+        services.AddSingleton(Mock.Of<Api.BoundedContexts.DocumentProcessing.Application.Services.IProcessingMetricsService>());
+
+        services.AddScoped(_ => Mock.Of<Api.BoundedContexts.KnowledgeBase.Domain.Repositories.IVectorDocumentRepository>());
+
+        services.AddScoped<Api.BoundedContexts.KnowledgeBase.Application.Services.IPdfIndexingPipeline,
+            Api.BoundedContexts.KnowledgeBase.Application.Services.PdfIndexingPipeline>();
+
+        services.AddSingleton<IMemoryCache, MemoryCache>();
+        services.AddSingleton<IDistributedCache>(new MemoryDistributedCache(
+            Options.Create(new MemoryDistributedCacheOptions())));
+        services.AddHybridCache();
+        services.AddScoped<Api.Services.ICacheInvalidationRetryPolicy>(_ => new PassthroughRetryPolicy());
+
+        services.Configure<Api.Configuration.HybridCacheConfiguration>(opts =>
+        {
+            opts.EnableL2Cache = true;
+            opts.EnableTags = true;
+            opts.DefaultExpiration = TimeSpan.FromMinutes(5);
+            opts.MaxTagsPerEntry = 10;
+        });
+        services.AddSingleton<Api.Services.IHybridCacheService, Api.Services.HybridCacheService>();
+
+        _serviceProvider = services.BuildServiceProvider();
+        _dbContext = _serviceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        await _dbContext.Database.MigrateAsync(TestCancellationToken);
+
+        await SeedTestDataAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_testDataDirectory != null && Directory.Exists(_testDataDirectory))
+        {
+            try
+            {
+                Directory.Delete(_testDataDirectory, true);
+            }
+            catch (IOException)
+            {
+                // Best effort cleanup
+            }
+        }
+
+        if (_dbContext != null)
+        {
+            await _dbContext.DisposeAsync();
+        }
+
+        _redis?.Dispose();
+
+        if (_serviceProvider is IAsyncDisposable asyncDisposable)
+        {
+            await asyncDisposable.DisposeAsync();
+        }
+        else
+        {
+            (_serviceProvider as IDisposable)?.Dispose();
+        }
+
+        if (!string.IsNullOrEmpty(_databaseName))
+        {
+            try
+            {
+                await _fixture.DropIsolatedDatabaseAsync(_databaseName);
+            }
+            catch
+            {
+                // Ignore cleanup errors
+            }
+        }
+    }
+
+    private async Task SeedTestDataAsync()
+    {
+        var user = new UserEntity
+        {
+            Id = Guid.NewGuid(),
+            Email = $"extractionpersist-{Guid.NewGuid():N}@test.com",
+            DisplayName = "Extraction Persistence Test User",
+            Role = "User",
+            Tier = "Free",
+            CreatedAt = DateTime.UtcNow
+        };
+        _dbContext!.Users.Add(user);
+
+        var game = new SharedGameEntity
+        {
+            Id = Guid.NewGuid(),
+            Title = $"Extraction Persistence Test Game {Guid.NewGuid():N}",
+            BggId = RandomNumberGenerator.GetInt32(100000, 1_000_000),
+            YearPublished = 2024,
+            MinPlayers = 2,
+            MaxPlayers = 4,
+            PlayingTimeMinutes = 30,
+            HasKnowledgeBase = false,
+            CreatedAt = DateTime.UtcNow
+        };
+        _dbContext.SharedGames.Add(game);
+
+        await _dbContext.SaveChangesAsync(TestCancellationToken);
+    }
+
+    private static IFormFile CreateMockFormFile(string fileName, byte[] content, string contentType = "application/pdf")
+    {
+        var formFile = new Mock<IFormFile>();
+        formFile.Setup(f => f.FileName).Returns(fileName);
+        formFile.Setup(f => f.Length).Returns(content.Length);
+        formFile.Setup(f => f.ContentType).Returns(contentType);
+        formFile.Setup(f => f.OpenReadStream()).Returns(() => new MemoryStream(content));
+        return formFile.Object;
+    }
+
+    private static byte[] CreateValidPdfBytes(int sizeInBytes)
+    {
+        var header = "%PDF-1.4\n"u8.ToArray();
+        var trailer = "%%EOF\n"u8.ToArray();
+        var padding = new byte[Math.Max(0, sizeInBytes - header.Length - trailer.Length)];
+
+        var pdf = new byte[header.Length + padding.Length + trailer.Length];
+        Buffer.BlockCopy(header, 0, pdf, 0, header.Length);
+        Buffer.BlockCopy(padding, 0, pdf, header.Length, padding.Length);
+        Buffer.BlockCopy(trailer, 0, pdf, header.Length + padding.Length, trailer.Length);
+
+        return pdf;
+    }
+
+    [Fact(Timeout = 90000)]
+    public async Task ProcessPdfAsync_UploadPathReachesReady_PersistsExtractedTextAndStructuredElementsJson()
+    {
+        // Arrange
+        var handler = _serviceProvider!.GetRequiredService<UploadPdfCommandHandler>();
+        var testUser = await _dbContext!.Users.FirstAsync(TestCancellationToken);
+        var testGame = await _dbContext.SharedGames.FirstAsync(TestCancellationToken);
+
+        var pdfBytes = CreateValidPdfBytes(1024);
+        var formFile = CreateMockFormFile("extraction-persistence.pdf", pdfBytes);
+
+        var command = new Api.BoundedContexts.DocumentProcessing.Application.Commands.UploadPdfCommand(
+            GameId: testGame.Id.ToString(),
+            Metadata: null,
+            PrivateGameId: null,
+            UserId: testUser.Id,
+            File: formFile);
+
+        // Act
+        var result = await handler.Handle(command, TestCancellationToken);
+        await _inlineBgService!.WaitForAllAsync();
+
+        // Assert: upload accept-stage succeeded
+        result.Should().NotBeNull();
+        result.Success.Should().BeTrue("upload accept-stage must succeed for a valid PDF");
+        result.Document.Should().NotBeNull();
+
+        var pdfDocId = Guid.Parse(result.Document!.Id.ToString());
+
+        // Re-query from a FRESH AsNoTracking projection (bypasses the change tracker
+        // entirely) so this assertion actually exercises the durable DB row, not an
+        // in-memory reference that happens to still carry the value.
+        var persisted = await _dbContext.PdfDocuments
+            .AsNoTracking()
+            .FirstAsync(p => p.Id == pdfDocId, TestCancellationToken);
+
+        persisted.ProcessingState.Should().Be(
+            nameof(Api.BoundedContexts.DocumentProcessing.Domain.Enums.PdfProcessingState.Ready),
+            $"BG pipeline must reach Ready for this regression test to be meaningful. ProcessingError='{persisted.ProcessingError}'.");
+
+        // Regression assertions for Issue #3281 Task 4 (pre-existing AsNoTracking bug): before
+        // the fix, both columns are null here because the working pdfDoc is AsNoTracking and the
+        // Ready transition routes through IPdfDocumentRepository.UpdateAsync, whose
+        // MapToPersistence omits + whole-row-clobbers ExtractedText/StructuredElementsJson.
+        persisted.ExtractedText.Should().NotBeNullOrEmpty(
+            "ExtractedText must durably persist for Upload-originated PDFs (re-index parity: " +
+            "IndexPdfCommandHandler requires non-null ExtractedText)");
+        persisted.StructuredElementsJson.Should().NotBeNull(
+            "StructuredElementsJson must durably persist for Upload-originated PDFs (re-index " +
+            "parity: IndexPdfCommandHandler reads it to rebuild headings)");
+    }
+
+    /// <summary>
+    /// Test-only IBackgroundTaskService that runs the queued task synchronously
+    /// while still letting the caller await all in-flight tasks before assertions.
+    /// Mirrors UploadPdfHeadingAwareIntegrationTests.InlineBackgroundTaskService.
+    /// </summary>
+    internal sealed class InlineBackgroundTaskService : IBackgroundTaskService
+    {
+        private readonly List<Task> _running = new();
+        private readonly Lock _gate = new();
+
+        public void Execute(Func<Task> task)
+        {
+            ArgumentNullException.ThrowIfNull(task);
+            lock (_gate)
+            {
+                _running.Add(Task.Run(task));
+            }
+        }
+
+        public void ExecuteWithCancellation(string taskId, Func<CancellationToken, Task> taskFactory)
+        {
+            ArgumentNullException.ThrowIfNull(taskFactory);
+            lock (_gate)
+            {
+                _running.Add(Task.Run(() => taskFactory(CancellationToken.None)));
+            }
+        }
+
+        public bool CancelTask(string taskId) => false;
+
+        public Task WaitForAllAsync()
+        {
+            Task[] snapshot;
+            lock (_gate)
+            {
+                snapshot = _running.ToArray();
+            }
+            return Task.WhenAll(snapshot);
+        }
+    }
+}

--- a/apps/api/tests/Api.Tests/Integration/DocumentProcessing/UploadPdfHeadingAwareIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/DocumentProcessing/UploadPdfHeadingAwareIntegrationTests.cs
@@ -1,0 +1,440 @@
+using System.Security.Cryptography;
+using Api.BoundedContexts.Authentication.Infrastructure.Persistence;
+using Api.BoundedContexts.DocumentProcessing.Application.Commands;
+using Api.BoundedContexts.DocumentProcessing.Domain.Repositories;
+using Api.BoundedContexts.DocumentProcessing.Domain.Services;
+using Api.BoundedContexts.DocumentProcessing.Infrastructure.Configuration;
+using Api.BoundedContexts.DocumentProcessing.Infrastructure.External;
+using Api.BoundedContexts.DocumentProcessing.Infrastructure.Persistence;
+using Api.BoundedContexts.DocumentProcessing.Infrastructure.Services;
+using Api.BoundedContexts.KnowledgeBase.Application.Services.Chunking;
+using Api.BoundedContexts.KnowledgeBase.Domain.Chunking;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Services;
+using Api.Services.Pdf;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using StackExchange.Redis;
+using Xunit;
+
+namespace Api.Tests.Integration.DocumentProcessing;
+
+/// <summary>
+/// Issue #3281 (Task 3): wires <see cref="HeadingAwareChunker.BuildAsync"/> into
+/// <see cref="UploadPdfCommandHandler"/>'s background processing pipeline
+/// (<c>ChunkExtractedTextAsync</c>). Proves that when an <see cref="IAdvancedChunkingService"/>
+/// is resolvable from the background-task scope, the fresh Upload ingest path (regular +
+/// private-game upload) produces and persists heading-bearing <c>text_chunks</c> rows with
+/// parent/child hierarchy, instead of the flat <c>ITextChunkingService.PrepareForEmbedding</c>
+/// production.
+///
+/// Modeled on <c>PdfIndexingFlowKbFlagIntegrationTests</c>'s harness: real Postgres via
+/// <see cref="SharedTestcontainersFixture"/>, <c>InlineBackgroundTaskService</c> so the BG
+/// pipeline (extract → chunk → embed → index → finalize) runs synchronously before assertions.
+/// </summary>
+[Collection("Integration-GroupB")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "DocumentProcessing")]
+[Trait("Issue", "3281")]
+public sealed class UploadPdfHeadingAwareIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private string _databaseName = string.Empty;
+    private MeepleAiDbContext? _dbContext;
+    private IServiceProvider? _serviceProvider;
+    private IConnectionMultiplexer? _redis;
+    private string? _testDataDirectory;
+    private InlineBackgroundTaskService? _inlineBgService;
+
+    private static CancellationToken TestCancellationToken => TestContext.Current.CancellationToken;
+
+    public UploadPdfHeadingAwareIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        _databaseName = $"test_headingaware_{Guid.NewGuid():N}";
+        var connectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+
+        _testDataDirectory = Path.Combine(Path.GetTempPath(), "meepleai-test-headingaware-" + Guid.NewGuid());
+        Directory.CreateDirectory(_testDataDirectory);
+
+        var services = IntegrationServiceCollectionBuilder.CreateBase(connectionString);
+
+        _redis = await ConnectionMultiplexer.ConnectAsync(_fixture.RedisConnectionString);
+        services.AddSingleton<IConnectionMultiplexer>(_redis);
+
+        services.AddScoped<IUserRepository, UserRepository>();
+        services.AddScoped<IPdfDocumentRepository, PdfDocumentRepository>();
+
+        services.AddScoped<UploadPdfCommandHandler>();
+
+        services.Configure<PdfProcessingOptions>(options =>
+        {
+            options.MaxFileSizeBytes = 10 * 1024 * 1024;
+        });
+
+        // Inline background task service so the BG pipeline runs synchronously before assertions
+        // (mirrors PdfIndexingFlowKbFlagIntegrationTests — Mock<IBackgroundTaskService> never executes).
+        _inlineBgService = new InlineBackgroundTaskService();
+        services.AddSingleton<IBackgroundTaskService>(_inlineBgService);
+
+        services.AddSingleton<IEmbeddingService>(new MockEmbeddingService(dimensions: 768));
+
+        // Extractor returns a paged result WITH non-empty StructuredElements (a Title + body
+        // element) so ChunkExtractedTextAsync feeds them into HeadingAwareChunker.BuildAsync.
+        var extractorMock = new Mock<IPdfTextExtractor>();
+        extractorMock
+            .Setup(e => e.ExtractTextAsync(It.IsAny<Stream>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(TextExtractionResult.CreateSuccess(
+                extractedText: "Setup. Place 3 tiles on the board.",
+                pageCount: 1,
+                characterCount: 34,
+                ocrTriggered: false,
+                quality: ExtractionQuality.High));
+        extractorMock
+            .Setup(e => e.ExtractPagedTextAsync(It.IsAny<Stream>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(PagedTextExtractionResult.CreateSuccess(
+                pageChunks: new[]
+                {
+                    new PageTextChunk(
+                        PageNumber: 1,
+                        Text: "Setup. Place 3 tiles on the board.",
+                        CharStartIndex: 0,
+                        CharEndIndex: 34)
+                },
+                totalPages: 1,
+                totalCharacters: 34,
+                ocrTriggered: false,
+                structuredElements: new List<ExtractedElement>
+                {
+                    new("Setup", 1, "Title"),
+                    new("Place 3 tiles on the board.", 1, "NarrativeText")
+                }));
+        services.AddSingleton<IPdfTextExtractor>(extractorMock.Object);
+
+        var tableExtractorMock = new Mock<IPdfTableExtractor>();
+        tableExtractorMock
+            .Setup(t => t.ExtractStructuredContentAsync(It.IsAny<string>()!, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new StructuredContentResult
+            {
+                Success = false,
+                ErrorMessage = "Skipped in test"
+            });
+        services.AddSingleton<IPdfTableExtractor>(tableExtractorMock.Object);
+
+        // CRITICAL for this test: mocked IAdvancedChunkingService registered in the container so
+        // scope.ServiceProvider.GetService<IAdvancedChunkingService>() (Processing.cs) resolves it
+        // (non-null) and ChunkExtractedTextAsync takes the heading-aware branch instead of the
+        // flat ITextChunkingService.PrepareForEmbedding fallback.
+        var advancedChunkingMock = new Mock<IAdvancedChunkingService>();
+        advancedChunkingMock
+            .Setup(s => s.ChunkDocumentAsync(
+                It.IsAny<ExtractedDocument>(),
+                It.IsAny<ChunkingConfiguration?>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ExtractedDocument doc, ChunkingConfiguration? _, CancellationToken _) =>
+            {
+                var parent = HierarchicalChunk.CreateParent(
+                    "Setup section content",
+                    new ChunkMetadata { Page = 1, Heading = "Setup", ElementType = "Title", DocumentId = doc.Id });
+                var child = HierarchicalChunk.CreateChild(
+                    "Place 3 tiles on the board.",
+                    level: 2,
+                    new ChunkMetadata { Page = 1, Heading = "Setup", ElementType = "NarrativeText", DocumentId = doc.Id },
+                    parent.Id);
+                return new List<HierarchicalChunk> { parent, child };
+            });
+        services.AddSingleton<IAdvancedChunkingService>(advancedChunkingMock.Object);
+
+        var blobStorageMock = new Mock<IBlobStorageService>();
+        blobStorageMock
+            .Setup(b => b.StoreAsync(
+                It.IsAny<Stream>(),
+                It.IsAny<string>()!,
+                It.IsAny<BlobCategory>(),
+                It.IsAny<string>()!,
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Stream stream, string fileName, BlobCategory category, string resourceKey, CancellationToken ct) =>
+            {
+                var safeKey = resourceKey.Replace('/', '_').Replace('\\', '_');
+                var filePath = Path.Combine(_testDataDirectory!, $"{safeKey}_{fileName}");
+                using var fileStream = File.Create(filePath);
+                stream.CopyTo(fileStream);
+                return new BlobStorageResult(true, Guid.NewGuid().ToString(), filePath, stream.Length, null);
+            });
+        blobStorageMock
+            .Setup(b => b.RetrieveAsync(It.IsAny<string>()!, It.IsAny<BlobCategory>(), It.IsAny<string>()!, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((string path, BlobCategory category, string resourceKey, CancellationToken ct) =>
+                File.Exists(path) ? (Stream?)File.OpenRead(path) : null);
+        blobStorageMock
+            .Setup(b => b.DeleteAsync(It.IsAny<string>()!, It.IsAny<BlobCategory>(), It.IsAny<string>()!, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+        services.AddSingleton<IBlobStorageService>(blobStorageMock.Object);
+
+        var cacheMock = new Mock<IAiResponseCacheService>();
+        cacheMock
+            .Setup(c => c.InvalidateGameAsync(It.IsAny<string>()!, It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        services.AddSingleton<IAiResponseCacheService>(cacheMock.Object);
+
+        var configServiceMock = new Mock<IConfigurationService>();
+        configServiceMock
+            .Setup(c => c.GetValueAsync<int?>(It.IsAny<string>()!, It.IsAny<int?>(), It.IsAny<string>()))
+            .Returns(Task.FromResult<int?>(null));
+        services.AddSingleton<IConfigurationService>(configServiceMock.Object);
+
+        services.AddScoped<IPdfUploadQuotaService, PdfUploadQuotaService>();
+
+        // Real TextChunkingService still registered so the (unexercised in this test) flat
+        // fallback path continues to resolve — mirrors production DI shape.
+        services.AddSingleton<ITextChunkingService, TextChunkingService>();
+
+        services.AddSingleton(Mock.Of<Api.BoundedContexts.DocumentProcessing.Application.Services.IProcessingMetricsService>());
+
+        services.AddScoped(_ => Mock.Of<Api.BoundedContexts.KnowledgeBase.Domain.Repositories.IVectorDocumentRepository>());
+
+        services.AddScoped<Api.BoundedContexts.KnowledgeBase.Application.Services.IPdfIndexingPipeline,
+            Api.BoundedContexts.KnowledgeBase.Application.Services.PdfIndexingPipeline>();
+
+        services.AddSingleton<IMemoryCache, MemoryCache>();
+        services.AddSingleton<IDistributedCache>(new MemoryDistributedCache(
+            Options.Create(new MemoryDistributedCacheOptions())));
+        services.AddHybridCache();
+        services.AddScoped<Api.Services.ICacheInvalidationRetryPolicy>(_ => new PassthroughRetryPolicy());
+
+        services.Configure<Api.Configuration.HybridCacheConfiguration>(opts =>
+        {
+            opts.EnableL2Cache = true;
+            opts.EnableTags = true;
+            opts.DefaultExpiration = TimeSpan.FromMinutes(5);
+            opts.MaxTagsPerEntry = 10;
+        });
+        services.AddSingleton<Api.Services.IHybridCacheService, Api.Services.HybridCacheService>();
+
+        _serviceProvider = services.BuildServiceProvider();
+        _dbContext = _serviceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        await _dbContext.Database.MigrateAsync(TestCancellationToken);
+
+        await SeedTestDataAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_testDataDirectory != null && Directory.Exists(_testDataDirectory))
+        {
+            try
+            {
+                Directory.Delete(_testDataDirectory, true);
+            }
+            catch (IOException)
+            {
+                // Best effort cleanup
+            }
+        }
+
+        if (_dbContext != null)
+        {
+            await _dbContext.DisposeAsync();
+        }
+
+        _redis?.Dispose();
+
+        if (_serviceProvider is IAsyncDisposable asyncDisposable)
+        {
+            await asyncDisposable.DisposeAsync();
+        }
+        else
+        {
+            (_serviceProvider as IDisposable)?.Dispose();
+        }
+
+        if (!string.IsNullOrEmpty(_databaseName))
+        {
+            try
+            {
+                await _fixture.DropIsolatedDatabaseAsync(_databaseName);
+            }
+            catch
+            {
+                // Ignore cleanup errors
+            }
+        }
+    }
+
+    private async Task SeedTestDataAsync()
+    {
+        var user = new UserEntity
+        {
+            Id = Guid.NewGuid(),
+            Email = $"headingaware-{Guid.NewGuid():N}@test.com",
+            DisplayName = "Heading Aware Test User",
+            Role = "User",
+            Tier = "Free",
+            CreatedAt = DateTime.UtcNow
+        };
+        _dbContext!.Users.Add(user);
+
+        var game = new SharedGameEntity
+        {
+            Id = Guid.NewGuid(),
+            Title = $"Heading Aware Test Game {Guid.NewGuid():N}",
+            BggId = RandomNumberGenerator.GetInt32(100000, 1_000_000),
+            YearPublished = 2024,
+            MinPlayers = 2,
+            MaxPlayers = 4,
+            PlayingTimeMinutes = 30,
+            HasKnowledgeBase = false,
+            CreatedAt = DateTime.UtcNow
+        };
+        _dbContext.SharedGames.Add(game);
+
+        await _dbContext.SaveChangesAsync(TestCancellationToken);
+    }
+
+    private static IFormFile CreateMockFormFile(string fileName, byte[] content, string contentType = "application/pdf")
+    {
+        var formFile = new Mock<IFormFile>();
+        formFile.Setup(f => f.FileName).Returns(fileName);
+        formFile.Setup(f => f.Length).Returns(content.Length);
+        formFile.Setup(f => f.ContentType).Returns(contentType);
+        formFile.Setup(f => f.OpenReadStream()).Returns(() => new MemoryStream(content));
+        return formFile.Object;
+    }
+
+    private static byte[] CreateValidPdfBytes(int sizeInBytes)
+    {
+        var header = "%PDF-1.4\n"u8.ToArray();
+        var trailer = "%%EOF\n"u8.ToArray();
+        var padding = new byte[Math.Max(0, sizeInBytes - header.Length - trailer.Length)];
+
+        var pdf = new byte[header.Length + padding.Length + trailer.Length];
+        Buffer.BlockCopy(header, 0, pdf, 0, header.Length);
+        Buffer.BlockCopy(padding, 0, pdf, header.Length, padding.Length);
+        Buffer.BlockCopy(trailer, 0, pdf, header.Length + padding.Length, trailer.Length);
+
+        return pdf;
+    }
+
+    [Fact(Timeout = 90000)]
+    public async Task ChunkExtractedText_WithAdvancedChunking_PersistsHeadingBearingChunks()
+    {
+        // Arrange
+        var handler = _serviceProvider!.GetRequiredService<UploadPdfCommandHandler>();
+        var testUser = await _dbContext!.Users.FirstAsync(TestCancellationToken);
+        var testGame = await _dbContext.SharedGames.FirstAsync(TestCancellationToken);
+
+        var pdfBytes = CreateValidPdfBytes(1024);
+        var formFile = CreateMockFormFile("heading-aware.pdf", pdfBytes);
+
+        var command = new Api.BoundedContexts.DocumentProcessing.Application.Commands.UploadPdfCommand(
+            GameId: testGame.Id.ToString(),
+            Metadata: null,
+            PrivateGameId: null,
+            UserId: testUser.Id,
+            File: formFile);
+
+        // Act
+        var result = await handler.Handle(command, TestCancellationToken);
+        await _inlineBgService!.WaitForAllAsync();
+
+        // Assert: upload accept-stage succeeded
+        result.Should().NotBeNull();
+        result.Success.Should().BeTrue("upload accept-stage must succeed for a valid PDF");
+        result.Document.Should().NotBeNull();
+
+        var pdfDocId = Guid.Parse(result.Document!.Id.ToString());
+        var pdfDoc = await _dbContext.PdfDocuments
+            .AsNoTracking()
+            .SingleAsync(p => p.Id == pdfDocId, TestCancellationToken);
+        pdfDoc.ProcessingState.Should().Be(
+            nameof(Api.BoundedContexts.DocumentProcessing.Domain.Enums.PdfProcessingState.Ready),
+            $"BG pipeline must reach Ready when the heading-aware chunk production succeeds. " +
+            $"ProcessingError='{pdfDoc.ProcessingError}'.");
+
+        // Assert: persisted text_chunks carry the heading-aware hierarchy produced by the
+        // mocked IAdvancedChunkingService (parent Level0 "Setup" + child Level2 with ParentChunkId).
+        var chunks = await _dbContext.TextChunks
+            .AsNoTracking()
+            .Where(tc => tc.PdfDocumentId == pdfDocId)
+            .ToListAsync(TestCancellationToken);
+
+        chunks.Should().HaveCount(2, "the mocked IAdvancedChunkingService returns exactly one parent + one child");
+
+        var parentChunk = chunks.SingleOrDefault(c => c.ParentChunkId == null);
+        parentChunk.Should().NotBeNull("the parent (section) chunk has no ParentChunkId");
+        parentChunk!.Heading.Should().Be("Setup");
+        // The parent/section chunk is Level 0 (HeadingAwareChunker / HierarchicalChunk.CreateParent).
+        // This round-trips correctly through real Npgsql because TextChunkEntityConfiguration.cs
+        // now declares Level with .ValueGeneratedNever() (#3281) — without it, HasDefaultValue(1)
+        // would coerce the explicit 0 to the store default 1 on INSERT. This assertion is the
+        // regression guard for that fix: it fails against real Postgres if ValueGeneratedNever() is removed.
+        parentChunk.Level.Should().Be((short)0,
+            "parent/section chunks are Level 0 and must persist as 0 (ValueGeneratedNever fix)");
+
+        var childChunk = chunks.SingleOrDefault(c => c.ParentChunkId != null);
+        childChunk.Should().NotBeNull("the child chunk must reference the parent via ParentChunkId");
+        childChunk!.Heading.Should().Be("Setup");
+        // Level=2 != default(short) so it is NOT subject to the default-value substitution above,
+        // and round-trips correctly — this is the meaningful signal that Level pass-through works.
+        childChunk.Level.Should().Be((short)2);
+        childChunk.ParentChunkId.Should().Be(parentChunk.Id,
+            "the child's ParentChunkId must point at the persisted parent row's Id");
+    }
+
+    /// <summary>
+    /// Test-only IBackgroundTaskService that runs the queued task synchronously
+    /// while still letting the caller await all in-flight tasks before assertions.
+    /// Mirrors PdfIndexingFlowKbFlagIntegrationTests.InlineBackgroundTaskService.
+    /// </summary>
+    internal sealed class InlineBackgroundTaskService : IBackgroundTaskService
+    {
+        private readonly List<Task> _running = new();
+        private readonly Lock _gate = new();
+
+        public void Execute(Func<Task> task)
+        {
+            ArgumentNullException.ThrowIfNull(task);
+            lock (_gate)
+            {
+                _running.Add(Task.Run(task));
+            }
+        }
+
+        public void ExecuteWithCancellation(string taskId, Func<CancellationToken, Task> taskFactory)
+        {
+            ArgumentNullException.ThrowIfNull(taskFactory);
+            lock (_gate)
+            {
+                _running.Add(Task.Run(() => taskFactory(CancellationToken.None)));
+            }
+        }
+
+        public bool CancelTask(string taskId) => false;
+
+        public Task WaitForAllAsync()
+        {
+            Task[] snapshot;
+            lock (_gate)
+            {
+                snapshot = _running.ToArray();
+            }
+            return Task.WhenAll(snapshot);
+        }
+    }
+}

--- a/docs/superpowers/plans/2026-07-21-rag-issue-3281-fresh-ingest-heading-parity.md
+++ b/docs/superpowers/plans/2026-07-21-rag-issue-3281-fresh-ingest-heading-parity.md
@@ -1,0 +1,646 @@
+# Issue #3281 — Fresh-Upload Ingest Heading-Aware Parity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire heading-aware hierarchical chunking into the 3 fresh-upload ingest paths (so freshly-uploaded PDFs get the same heading-bearing chunks the re-index path already produces), fix the pre-existing Upload-path persistence bug, and add a real-Postgres round-trip test.
+
+**Architecture:** PR #3282 ("Slice D") already shipped the shared infrastructure — `HeadingAwareChunker.BuildAsync`, `HierarchicalChunkMapper`, `PdfDocumentEntity.StructuredElementsJson` + migration, the `MaxEmbeddingChars` cap, and the `IndexPdfCommandHandler` (re-index) wiring. This plan **reuses that infra unchanged** and routes the 3 fresh-ingest handlers' chunk production through the same `HeadingAwareChunker.BuildAsync`. The persist sites (`new TextChunkEntity { … Heading, Level, ParentChunkId, ElementType … }` + `Id == Guid.Empty ? Guid.NewGuid()` fallback) already carry hierarchy fields in all 3 handlers — they just receive flat chunks today. So each task swaps the *producer* (`PrepareForEmbedding`/`ChunkText` → `BuildAsync`), maps `DocumentChunk → DocumentChunkInput`, and caps embedding-input text. The Upload path additionally needs a persistence fix because its working entity is `AsNoTracking()` and its state transitions route through a repository that clobbers content columns.
+
+**Tech Stack:** .NET 9, EF Core (pgvector), MediatR/CQRS, xUnit + Moq + FluentAssertions + Testcontainers.
+
+## Global Constraints
+
+- **Reuse, do NOT duplicate.** Use the merged `HeadingAwareChunker.BuildAsync` — do NOT create a second chunker, mapper, migration, or `StructuredElementsJson` column. Its exact signature (static class, namespace `Api.BoundedContexts.DocumentProcessing.Application.Services`):
+  ```csharp
+  public static Task<List<DocumentChunk>> BuildAsync(
+      IReadOnlyList<ExtractedElement>? structuredElements,
+      string flatText,
+      Guid documentId,
+      Guid? gameId,
+      IAdvancedChunkingService advancedChunking,
+      CancellationToken cancellationToken)
+  ```
+- `IAdvancedChunkingService` — namespace `Api.BoundedContexts.KnowledgeBase.Application.Services.Chunking`, registered `AddScoped` in `KnowledgeBaseServiceExtensions.cs:542`.
+- `ExtractedElement` — `Api.BoundedContexts.DocumentProcessing.Domain.Services.ExtractedElement`, a `record ExtractedElement(string Text, int PageNumber, string ElementType)`. `PagedTextExtractionResult.StructuredElements` is `IReadOnlyList<ExtractedElement>?`.
+- `DocumentChunk` (`Api.Services`, `apps/api/src/Api/Services/VectorSearchModels.cs:9`) and `DocumentChunkInput` (`Api.Services`, `apps/api/src/Api/Services/TextChunkingService.cs:391`) are both init-only `record`s carrying: `Guid Id` (default `Guid.Empty`), `string Text`, `int Page`, `int CharStart`, `int CharEnd`, `string? Heading`, `short Level` (default `1`), `Guid? ParentChunkId`, `string ElementType` (default `"NarrativeText"`). `DocumentChunk` also has `float[] Embedding`.
+- **Embedding cap:** `ChunkingConstants.MaxEmbeddingChars = 1800` (namespace `Api.Constants`). Cap ONLY the text sent to the embedding provider; the persisted `Content`/`text_chunks`/pgvector row keeps the FULL `chunk.Text`. Mirror `IndexPdfCommandHandler`'s `CapTextForEmbedding`.
+- **StructuredElementsJson serialize** (mirror `PdfProcessingPipelineService.cs:496-498`):
+  ```csharp
+  extractResult.StructuredElements is null ? null : JsonSerializer.Serialize(extractResult.StructuredElements)
+  ```
+- **Do NOT route Upload's extraction-column persistence through `IPdfDocumentRepository`** — `PdfDocumentRepository.MapToPersistence` omits `ExtractedText`/`StructuredElementsJson`/`CharacterCount`/`ExtractedTables` and `DbSet.Update()` marks the whole row Modified, nulling them. Persist on a **tracked** entity.
+- **Backward-compat DI:** when `IAdvancedChunkingService` is unavailable (null), fall back to the existing flat chunk production so pre-existing test constructors/scopes keep compiling and passing. Pipeline → trailing optional nullable ctor param; Upload/Complete → `scope.ServiceProvider.GetService<IAdvancedChunkingService>()` (nullable). `null → flat fallback`.
+- **Persist sites are already correct** — do NOT re-edit the `new TextChunkEntity { … }` blocks (they carry `Id == Guid.Empty ? Guid.NewGuid()` + `Heading`/`Level`/`ParentChunkId`/`ElementType` + role-tagging). Just feed them hierarchy-bearing chunks.
+- **Out of scope** (per #3281): `EnhancedPdfProcessorOrchestrator.SplitOversizedPageChunks` (pre-extraction page-level splitting on `PageTextChunk`, no hierarchy/identity).
+- **Git:** branch `feature/issue-3281-fresh-ingest-heading-parity` (already created, parent `main-dev`). Commit per task. PR → `main-dev`, body `Closes #3281`. Commit/PR footer `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`. Background all `git commit` (slow pre-commit hook). Never `--no-verify`.
+
+---
+
+### Task 1: Shared `HeadingAwareChunkAdapter` (DocumentChunk→DocumentChunkInput map + embedding cap)
+
+Both `BuildAsync`'s output (`List<DocumentChunk>`) and the 3 handlers' downstream embed/persist code (`List<DocumentChunkInput>`) need bridging, and all 3 handlers need the same embedding-input cap. One tested static helper removes the duplication.
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/Chunking/HeadingAwareChunkAdapter.cs`
+- Test: `apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Services/Chunking/HeadingAwareChunkAdapterTests.cs`
+
+**Interfaces:**
+- Consumes: `DocumentChunk` (`Api.Services`), `DocumentChunkInput` (`Api.Services`), `ChunkingConstants.MaxEmbeddingChars` (`Api.Constants`).
+- Produces:
+  - `static List<DocumentChunkInput> ToChunkInputs(IReadOnlyList<DocumentChunk> chunks)` — preserves `Id`, `Text`, `Page`, `CharStart`, `CharEnd`, `Heading`, `Level`, `ParentChunkId`, `ElementType`.
+  - `static string CapForEmbedding(string text)` — returns `text` unchanged if `text.Length <= MaxEmbeddingChars`, else `text[..MaxEmbeddingChars]`.
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+using Api.BoundedContexts.DocumentProcessing.Application.Services.Chunking;
+using Api.Constants;
+using Api.Services;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.DocumentProcessing.Application.Services.Chunking;
+
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "DocumentProcessing")]
+public class HeadingAwareChunkAdapterTests
+{
+    [Fact]
+    public void ToChunkInputs_PreservesIdentityAndHierarchyFields()
+    {
+        var parentId = Guid.NewGuid();
+        var childId = Guid.NewGuid();
+        var chunks = new List<DocumentChunk>
+        {
+            new() { Id = parentId, Text = "Setup", Page = 2, CharStart = 10, CharEnd = 15,
+                    Heading = "Setup", Level = 0, ParentChunkId = null, ElementType = "Title" },
+            new() { Id = childId, Text = "Place 3 tiles", Page = 2, CharStart = 16, CharEnd = 29,
+                    Heading = "Setup", Level = 2, ParentChunkId = parentId, ElementType = "NarrativeText" },
+        };
+
+        var result = HeadingAwareChunkAdapter.ToChunkInputs(chunks);
+
+        result.Should().HaveCount(2);
+        result[0].Id.Should().Be(parentId);
+        result[0].Heading.Should().Be("Setup");
+        result[0].Level.Should().Be((short)0);
+        result[0].ElementType.Should().Be("Title");
+        result[1].Id.Should().Be(childId);
+        result[1].ParentChunkId.Should().Be(parentId);
+        result[1].Level.Should().Be((short)2);
+        result[1].Text.Should().Be("Place 3 tiles");
+        result[1].CharStart.Should().Be(16);
+    }
+
+    [Fact]
+    public void CapForEmbedding_TruncatesOnlyWhenOverLimit()
+    {
+        var under = new string('a', ChunkingConstants.MaxEmbeddingChars);
+        var over = new string('b', ChunkingConstants.MaxEmbeddingChars + 500);
+
+        HeadingAwareChunkAdapter.CapForEmbedding(under).Should().HaveLength(ChunkingConstants.MaxEmbeddingChars);
+        HeadingAwareChunkAdapter.CapForEmbedding(over).Should().HaveLength(ChunkingConstants.MaxEmbeddingChars);
+        HeadingAwareChunkAdapter.CapForEmbedding("short").Should().Be("short");
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test ../../tests/Api.Tests --filter "FullyQualifiedName~HeadingAwareChunkAdapterTests" -v minimal` (from `apps/api/src/Api`)
+Expected: FAIL — `HeadingAwareChunkAdapter` does not exist.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```csharp
+using Api.Constants;
+using Api.Services;
+
+namespace Api.BoundedContexts.DocumentProcessing.Application.Services.Chunking;
+
+/// <summary>
+/// Bridges <see cref="HeadingAwareChunker"/>'s <see cref="DocumentChunk"/> output to the
+/// <see cref="DocumentChunkInput"/> the fresh-upload ingest handlers embed + persist, and
+/// caps embedding-input text at <see cref="ChunkingConstants.MaxEmbeddingChars"/> (the full
+/// text is still persisted for retrieval; only the vector-provider input is capped). Shared
+/// by all 3 fresh-ingest paths (Issue #3281) so the map + cap logic lives in one tested place.
+/// </summary>
+internal static class HeadingAwareChunkAdapter
+{
+    public static List<DocumentChunkInput> ToChunkInputs(IReadOnlyList<DocumentChunk> chunks)
+    {
+        ArgumentNullException.ThrowIfNull(chunks);
+        return chunks
+            .Select(c => new DocumentChunkInput
+            {
+                Id = c.Id,
+                Text = c.Text,
+                Page = c.Page,
+                CharStart = c.CharStart,
+                CharEnd = c.CharEnd,
+                Heading = c.Heading,
+                Level = c.Level,
+                ParentChunkId = c.ParentChunkId,
+                ElementType = c.ElementType,
+            })
+            .ToList();
+    }
+
+    public static string CapForEmbedding(string text)
+    {
+        ArgumentNullException.ThrowIfNull(text);
+        return text.Length <= ChunkingConstants.MaxEmbeddingChars
+            ? text
+            : text[..ChunkingConstants.MaxEmbeddingChars];
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `dotnet test ../../tests/Api.Tests --filter "FullyQualifiedName~HeadingAwareChunkAdapterTests" -v minimal`
+Expected: PASS (2/2).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/Chunking/HeadingAwareChunkAdapter.cs apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Services/Chunking/HeadingAwareChunkAdapterTests.cs
+git commit -m "feat(chunking): shared DocumentChunk→Input adapter + embedding cap (#3281)"
+```
+
+---
+
+### Task 2: Wire `PdfProcessingPipelineService` (re-process/Quartz path) + translation hierarchy copy
+
+The stale-recovery/shared-game path. `pdfDoc` is a **tracked** entity (`FindAsync`), `extractResult.StructuredElements` is in scope, and this path **already persists `StructuredElementsJson`** — so only the producer + translation copy change here.
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs`
+  - ctor (lines 66-111): add trailing optional `IAdvancedChunkingService? advancedChunking = null` + field.
+  - `ChunkText` (line 658) → make it `async Task<List<DocumentChunkInput>> ChunkTextAsync(...)` threading `Guid documentId, Guid? gameId`, call `BuildAsync` when `_advancedChunking != null`.
+  - call site (line 191) → `await ChunkTextAsync(fullText, extractResult, pdfDoc.Id, pdfDoc.PrivateGameId ?? pdfDoc.SharedGameId, cancellationToken)`.
+  - translation branch (lines 224-238) → copy hierarchy fields from `origChunk`.
+  - `GenerateEmbeddingsAsync` (line 688) → cap batch texts via `HeadingAwareChunkAdapter.CapForEmbedding`.
+- Test: `apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineHeadingAwareTests.cs` (new)
+
+**Interfaces:**
+- Consumes: `HeadingAwareChunker.BuildAsync`, `HeadingAwareChunkAdapter.ToChunkInputs`/`CapForEmbedding`, `IAdvancedChunkingService`.
+- Produces: heading-bearing `DocumentChunkInput` list from `ChunkTextAsync`; translated chunks carrying `Heading`/`Level`/`ParentChunkId`/`ElementType`.
+
+- [ ] **Step 1: Write the failing test**
+
+Model it on the existing pipeline unit tests in the same folder (look for `PdfProcessingPipeline*Tests.cs` — reuse their fixture/mocks). The test builds a `PdfProcessingPipelineService` with a mocked `IAdvancedChunkingService` whose `ChunkDocumentAsync` returns a parent (`Level 0`, `Heading "Setup"`) + child (`Level 2`, `ParentChunkId = parent`), drives `ProcessAsync` (or calls the now-`internal` `ChunkTextAsync` via `InternalsVisibleTo`-exposed access if the class exposes it — otherwise assert through the persisted `text_chunks` in an in-memory `MeepleAiDbContext`), and asserts the produced chunk inputs carry `Heading == "Setup"` and a non-null `ParentChunkId` on the child.
+
+```csharp
+// Skeleton — adapt mocks to the existing pipeline test fixture in this folder.
+[Fact]
+public async Task ChunkTextAsync_WithAdvancedChunking_ProducesHeadingBearingChunks()
+{
+    // Arrange: mock IAdvancedChunkingService.ChunkDocumentAsync → [parent Level0 "Setup", child Level2]
+    // Build PdfProcessingPipelineService with that mock in the new trailing ctor slot.
+    // Act: invoke the chunk production for a doc whose extractResult.StructuredElements is non-empty.
+    // Assert: result has a chunk with Heading "Setup"; a child chunk with ParentChunkId != null and Level 2.
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test ../../tests/Api.Tests --filter "FullyQualifiedName~PdfProcessingPipelineHeadingAware" -v minimal`
+Expected: FAIL (flat production, no `Heading`).
+
+- [ ] **Step 3: Write the implementation**
+
+ctor — add field + trailing optional param (after `IPdfCoverUploadPipeline? pdfCoverUploadPipeline = null`):
+```csharp
+    // Issue #3281: optional so pre-existing test constructors compile. When null,
+    // chunk production falls back to the flat ITextChunkingService path (pre-Slice-D behaviour).
+    private readonly IAdvancedChunkingService? _advancedChunking;
+    // ...ctor params: add `IAdvancedChunkingService? advancedChunking = null,` in the trailing-optional block
+    // ...ctor body:
+    _advancedChunking = advancedChunking;
+```
+Add `using Api.BoundedContexts.DocumentProcessing.Application.Services.Chunking;` and `using Api.BoundedContexts.KnowledgeBase.Application.Services.Chunking;` (for `IAdvancedChunkingService`).
+
+Replace `ChunkText` (line 658) with:
+```csharp
+    private async Task<List<DocumentChunkInput>> ChunkTextAsync(
+        string fullText,
+        PagedTextExtractionResult extractResult,
+        Guid documentId,
+        Guid? gameId,
+        CancellationToken cancellationToken)
+    {
+        // Issue #3281: heading-aware production when AdvancedChunkingService is available.
+        if (_advancedChunking != null)
+        {
+            var hierarchical = await HeadingAwareChunker.BuildAsync(
+                extractResult.StructuredElements,
+                fullText,
+                documentId,
+                gameId,
+                _advancedChunking,
+                cancellationToken).ConfigureAwait(false);
+            return HeadingAwareChunkAdapter.ToChunkInputs(hierarchical);
+        }
+
+        // Fallback: flat production (pre-Slice-D behaviour) when the chunker is unavailable.
+        var chunks = _chunkingService.PrepareForEmbedding(fullText, ChunkSize, ChunkOverlap)
+            ?.Where(c => c != null && !string.IsNullOrWhiteSpace(c.Text))
+            .ToList()
+            ?? [];
+        if (chunks.Count == 0)
+        {
+            foreach (var pageChunk in extractResult.PageChunks.Where(pc => !pc.IsEmpty))
+            {
+                var pageTextChunks = _chunkingService.ChunkText(pageChunk.Text, ChunkSize, ChunkOverlap);
+                foreach (var textChunk in pageTextChunks.Where(t => !string.IsNullOrWhiteSpace(t.Text)))
+                {
+                    chunks.Add(new DocumentChunkInput
+                    {
+                        Text = textChunk.Text,
+                        Page = pageChunk.PageNumber,
+                        CharStart = textChunk.CharStart,
+                        CharEnd = textChunk.CharEnd
+                    });
+                }
+            }
+        }
+        return chunks.Where(c => c != null && !string.IsNullOrWhiteSpace(c.Text)).ToList();
+    }
+```
+
+Call site (line 191): `var chunks = await ChunkTextAsync(fullText, extractResult, pdfDoc.Id, pdfDoc.PrivateGameId ?? pdfDoc.SharedGameId, cancellationToken).ConfigureAwait(false);`
+
+Translation branch (lines 224-238) — copy hierarchy fields + remove the stale `// Issue #730 / spec §5.3 forward-wiring` TODO comment (now done):
+```csharp
+        var origChunk = chunks[t.OriginalIndex];
+        translatedChunks.Add((
+            new DocumentChunkInput
+            {
+                Id = origChunk.Id,
+                Text = t.TranslatedText,
+                Page = origChunk.Page,
+                CharStart = origChunk.CharStart,
+                CharEnd = origChunk.CharEnd,
+                Heading = origChunk.Heading,
+                Level = origChunk.Level,
+                ParentChunkId = origChunk.ParentChunkId,
+                ElementType = origChunk.ElementType
+            },
+            "en",
+            true));
+```
+
+`GenerateEmbeddingsAsync` (line 688) — cap the batch text list. Find the `.Select(... => ....Text)` that builds `batchTexts` and wrap each with `HeadingAwareChunkAdapter.CapForEmbedding(...)`.
+
+- [ ] **Step 4: Run tests**
+
+Run: `dotnet test ../../tests/Api.Tests --filter "FullyQualifiedName~PdfProcessingPipeline" -v minimal`
+Expected: new heading-aware test PASS; pre-existing pipeline tests still PASS (flat fallback path unchanged when no chunker injected).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineHeadingAwareTests.cs
+git commit -m "feat(chunking): heading-aware chunking in PdfProcessingPipeline + translation hierarchy copy (#3281)"
+```
+
+---
+
+### Task 3: Wire `UploadPdfCommandHandler.Processing` (regular + private-game upload)
+
+Widen `ChunkExtractedTextAsync` to thread `pdfDoc` (for `gameId`/`documentId`) and consume `extractResult.StructuredElements`, resolve `IAdvancedChunkingService` from the async scope (nullable → flat fallback), and cap embedding input. **StructuredElementsJson persistence is Task 4** — this task only makes the produced chunks heading-aware.
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommandHandler.Processing.cs`
+  - `ChunkExtractedTextAsync` (line 337): add `PdfDocumentEntity pdfDoc` param; resolve `IAdvancedChunkingService?` from `scope`; `BuildAsync` when non-null else existing flat body.
+  - call site (line 68): pass `pdfDoc`.
+  - `GenerateAndValidateEmbeddingsAsync` batch texts (line 429): cap via `HeadingAwareChunkAdapter.CapForEmbedding`.
+- Test: extend/add a handler-driven test asserting produced chunks carry `Heading` when a mocked `IAdvancedChunkingService` is registered in the scope.
+
+**Interfaces:**
+- Consumes: `HeadingAwareChunker.BuildAsync`, `HeadingAwareChunkAdapter`, `IAdvancedChunkingService` (scope-resolved), `extractResult.StructuredElements`.
+- Produces: heading-bearing `DocumentChunkInput` from `ChunkExtractedTextAsync`.
+
+- [ ] **Step 1: Write the failing test**
+
+Locate the existing Upload processing tests (grep `ChunkExtractedTextAsync` / `UploadPdfCommandHandler` tests) and follow their scope-building pattern. Register a mocked `IAdvancedChunkingService` in the test scope returning a parent+child hierarchy; drive the chunk step; assert the persisted `text_chunks` (in-memory DbContext) carry `Heading` non-null + a child `ParentChunkId`. If no such harness exists, add a focused test that constructs the handler, builds a scope with the mock + an in-memory `MeepleAiDbContext`, and invokes the processing entrypoint for a small PDF.
+
+```csharp
+[Fact]
+public async Task ChunkExtractedText_WithAdvancedChunking_PersistsHeadingBearingChunks()
+{
+    // Arrange: scope with mocked IAdvancedChunkingService → [parent Level0 "Setup", child Level2],
+    //          in-memory MeepleAiDbContext, a Ready-bound small PDF with non-empty StructuredElements.
+    // Act: run the upload processing pipeline.
+    // Assert: text_chunks for the pdf have a row with Heading "Setup" and a child with ParentChunkId != null.
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test ../../tests/Api.Tests --filter "FullyQualifiedName~UploadPdf&FullyQualifiedName~HeadingAware" -v minimal` (adjust filter to the test name)
+Expected: FAIL (flat chunks, `Heading` null).
+
+- [ ] **Step 3: Write the implementation**
+
+Add usings: `using Api.BoundedContexts.DocumentProcessing.Application.Services.Chunking;` and `using Api.BoundedContexts.KnowledgeBase.Application.Services.Chunking;`.
+
+`ChunkExtractedTextAsync` (line 337) — add `PdfDocumentEntity pdfDoc` param (place it before `db`), and replace the primary production:
+```csharp
+    private async Task<List<DocumentChunkInput>> ChunkExtractedTextAsync(
+        string pdfId,
+        string fullText,
+        PagedTextExtractionResult extractResult,
+        PdfDocumentEntity pdfDoc,
+        MeepleAiDbContext db,
+        IServiceScope scope,
+        DateTime startTime,
+        CancellationToken cancellationToken)
+    {
+        var chunkingService = scope.ServiceProvider.GetRequiredService<ITextChunkingService>();
+        const int chunkSize = 512;
+        const int chunkOverlap = 50;
+
+        // Issue #3281: heading-aware production when AdvancedChunkingService is available in scope.
+        var advancedChunking = scope.ServiceProvider.GetService<IAdvancedChunkingService>();
+        if (advancedChunking != null)
+        {
+            var hierarchical = await HeadingAwareChunker.BuildAsync(
+                extractResult.StructuredElements,
+                fullText,
+                pdfDoc.Id,
+                pdfDoc.PrivateGameId ?? pdfDoc.SharedGameId,
+                advancedChunking,
+                cancellationToken).ConfigureAwait(false);
+            return HeadingAwareChunkAdapter.ToChunkInputs(hierarchical);
+        }
+
+        // Fallback: existing flat production (primary PrepareForEmbedding + per-page ChunkText fallback).
+        // ... KEEP the existing body from `var allDocumentChunks = chunkingService.PrepareForEmbedding(...)`
+        //     through the fallback loop and return, unchanged ...
+    }
+```
+(Preserve the existing flat body verbatim under the fallback — do not delete it.)
+
+Call site (line 68): `var allDocumentChunks = await ChunkExtractedTextAsync(pdfId, fullText!, extractResult!, pdfDoc, db, scope, startTime, cancellationToken).ConfigureAwait(false);`
+
+`GenerateAndValidateEmbeddingsAsync` (line 429): `var batchTexts = batchChunks.Select(c => HeadingAwareChunkAdapter.CapForEmbedding(c.Text)).ToList();`
+
+- [ ] **Step 4: Run tests**
+
+Run: `dotnet test ../../tests/Api.Tests --filter "FullyQualifiedName~UploadPdf" -v minimal`
+Expected: new heading-aware test PASS; pre-existing Upload tests PASS (scopes without the chunker registered → flat fallback).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommandHandler.Processing.cs apps/api/tests/Api.Tests/...
+git commit -m "feat(chunking): heading-aware chunking in UploadPdf ingest path (#3281)"
+```
+
+---
+
+### Task 4: Persist `ExtractedText` + `StructuredElementsJson` for the Upload path (AsNoTracking fix)
+
+Pre-existing bug (not in #3281's original body): the Upload pipeline's working `pdfDoc` is `AsNoTracking()` (`Processing.cs:205`) AND state transitions route through `IPdfDocumentRepository.UpdateAsync → MapToPersistence` (which omits the extraction columns and clobbers them to NULL via whole-row `Update()`), so `ExtractedText`/`StructuredElementsJson`/`PageCount`/table columns **never persist** for Upload PDFs. This blocks re-index parity (`IndexPdfCommandHandler` reads `pdf.StructuredElementsJson` to rebuild headings, and fails `TextExtractionRequired` on null `ExtractedText`). Fix: set `StructuredElementsJson` in-memory at extraction, then re-persist all extraction columns on a freshly **tracked** entity AFTER the final Ready transition (mirrors `ExtractPdfTextCommandHandler`'s tracked-write pattern).
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommandHandler.Processing.cs`
+  - `ExtractPdfContentAsync` (~line 260): set `pdfDoc.StructuredElementsJson = …Serialize(…)` in-memory (so the tracked re-write can copy it).
+  - `FinalizeProcessingAsync` (~lines 872-916): after the Ready `SaveChangesAsync`, add a dedicated tracked re-write.
+- Test: `apps/api/tests/Api.Tests/Integration/DocumentProcessing/UploadPdfExtractionPersistenceIntegrationTests.cs` (Testcontainers) OR extend an existing Upload integration test — assert persisted `ExtractedText` + `StructuredElementsJson` non-null after the pipeline reaches Ready.
+
+**Interfaces:**
+- Consumes: `StructuredElementsJson` column, `DbUpdateConcurrencyException`, `db.PdfDocuments.AsTracking()`.
+- Produces: durable `pdf_documents.ExtractedText` + `StructuredElementsJson` for Upload-originated PDFs.
+
+- [ ] **Step 1: Write the failing test (Testcontainers)**
+
+Use the `SharedTestcontainersFixture` pattern from `apps/api/tests/Api.Tests/Integration/DocumentProcessing/PdfPipelineIntegrationTests.cs`. Drive a small titled PDF through the Upload background pipeline to Ready, then re-query:
+```csharp
+var persisted = await dbContext.PdfDocuments.AsNoTracking()
+    .FirstAsync(p => p.Id == pdfGuid, TestContext.Current.CancellationToken);
+persisted.ExtractedText.Should().NotBeNullOrEmpty();
+persisted.StructuredElementsJson.Should().NotBeNull();
+```
+Run → RED (both null today).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test ../../tests/Api.Tests --filter "FullyQualifiedName~UploadPdfExtractionPersistence" -v minimal`
+Expected: FAIL — `ExtractedText`/`StructuredElementsJson` null.
+
+- [ ] **Step 3: Write the implementation**
+
+At `ExtractPdfContentAsync` (~line 260), alongside `pdfDoc.ExtractedText = fullText;`:
+```csharp
+        pdfDoc.ExtractedText = fullText;
+        pdfDoc.StructuredElementsJson = extractResult.StructuredElements is null
+            ? null
+            : System.Text.Json.JsonSerializer.Serialize(extractResult.StructuredElements);
+```
+(This assignment is a no-op on the untracked entity for the DB, but keeps the value in-memory for the tracked re-write. The `db.SaveChangesAsync` here stays as-is.)
+
+In `FinalizeProcessingAsync`, AFTER the Ready transition's `try { … TransitionTo(Ready); … SaveChangesAsync } catch (DbUpdateConcurrencyException …) { return; }` block:
+```csharp
+        // Issue #3281 / pre-existing AsNoTracking bug: the pipeline's working pdfDoc is AsNoTracking
+        // and state transitions route through IPdfDocumentRepository (MapToPersistence omits + clobbers
+        // ExtractedText/StructuredElementsJson/content columns), so extraction output written during
+        // ExtractPdfContentAsync/ExtractStructuredContentAsync never persists. Re-persist it here on a
+        // freshly TRACKED entity AFTER the final Ready transition (mirrors ExtractPdfTextCommandHandler),
+        // so no later repository transition can clobber it. Needed for re-index parity: IndexPdf reads
+        // StructuredElementsJson and requires non-null ExtractedText.
+        var tracked = await db.PdfDocuments.AsTracking()
+            .FirstOrDefaultAsync(p => p.Id == pdfGuid, cancellationToken).ConfigureAwait(false);
+        if (tracked != null)
+        {
+            tracked.ExtractedText = pdfDoc.ExtractedText;
+            tracked.StructuredElementsJson = pdfDoc.StructuredElementsJson;
+            tracked.PageCount = pdfDoc.PageCount;
+            tracked.CharacterCount = pdfDoc.CharacterCount;
+            tracked.ExtractedTables = pdfDoc.ExtractedTables;
+            tracked.ExtractedDiagrams = pdfDoc.ExtractedDiagrams;
+            tracked.AtomicRules = pdfDoc.AtomicRules;
+            tracked.TableCount = pdfDoc.TableCount;
+            tracked.DiagramCount = pdfDoc.DiagramCount;
+            tracked.AtomicRuleCount = pdfDoc.AtomicRuleCount;
+            try
+            {
+                await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (DbUpdateConcurrencyException ex)
+            {
+                _logger.LogWarning(ex,
+                    "Concurrency conflict persisting extraction output for PDF {PdfId} — admin mutation wins",
+                    pdfId);
+            }
+        }
+```
+Verify the in-scope names (`pdfGuid`, `db`, `pdfDoc`, `cancellationToken`, `_logger`, `pdfId`) against the actual `FinalizeProcessingAsync` signature; thread/resolve `db` from `scope` if not already a param.
+
+- [ ] **Step 4: Run tests**
+
+Run: `dotnet test ../../tests/Api.Tests --filter "FullyQualifiedName~UploadPdfExtractionPersistence" -v minimal`
+Expected: PASS (both columns non-null). Re-run `FullyQualifiedName~UploadPdf` to confirm no regression.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommandHandler.Processing.cs apps/api/tests/Api.Tests/Integration/DocumentProcessing/UploadPdfExtractionPersistenceIntegrationTests.cs
+git commit -m "fix(pdf): persist ExtractedText/StructuredElementsJson after Ready in Upload pipeline (#3281)"
+```
+
+---
+
+### Task 5: Wire `CompleteChunkedUploadCommandHandler` + carry StructuredElements
+
+`ChunkTextContentAsync` (line 682) takes neither `pdfDoc` nor `extractResult`, and `ExtractPdfTextAsync` (line 565) **discards** `PagedTextExtractionResult`/`StructuredElements` (returns `(bool, string?, int)`). Widen the tuple to carry structured elements, persist `StructuredElementsJson` on the tracked `pdfDoc` (this handler mutates state directly — no AsNoTracking bug), thread `pdfDoc` + structured elements into the chunker, and cap embedding input.
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/CompleteChunkedUploadCommandHandler.cs`
+  - `ExtractPdfTextAsync` (line 565): widen return to `(bool success, string? fullText, int totalPages, IReadOnlyList<ExtractedElement>? structuredElements)`; at the extraction write (lines 609-611) also set `pdfDoc.StructuredElementsJson`; update ALL return sites.
+  - `ChunkTextContentAsync` (line 682): add `PdfDocumentEntity pdfDoc, IReadOnlyList<ExtractedElement>? structuredElements`; resolve `IAdvancedChunkingService?`; `BuildAsync` when non-null else flat.
+  - call sites (line 487 for the extract tuple, line 487-488 for chunk) updated.
+  - `GenerateEmbeddingsAsync` (line 720): cap texts.
+- Test: handler-driven test asserting heading-bearing chunks + `StructuredElementsJson` persisted.
+
+**Interfaces:**
+- Consumes: `HeadingAwareChunker.BuildAsync`, `HeadingAwareChunkAdapter`, `IAdvancedChunkingService`, `ExtractedElement`.
+- Produces: heading-bearing `DocumentChunkInput` + persisted `StructuredElementsJson` for chunked uploads.
+
+- [ ] **Step 1: Write the failing test**
+
+Follow the existing `CompleteChunkedUploadCommandHandler` tests. Register a mocked `IAdvancedChunkingService` (parent+child) in the scope; assert persisted `text_chunks` carry `Heading` + child `ParentChunkId`, and `pdf_documents.StructuredElementsJson` is non-null after completion.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `dotnet test ../../tests/Api.Tests --filter "FullyQualifiedName~CompleteChunkedUpload&FullyQualifiedName~HeadingAware" -v minimal`
+Expected: FAIL.
+
+- [ ] **Step 3: Write the implementation**
+
+Add usings (`…Application.Services.Chunking`, `…KnowledgeBase.Application.Services.Chunking`, `…DocumentProcessing.Domain.Services` for `ExtractedElement`).
+
+`ExtractPdfTextAsync` (line 565): change signature to
+```csharp
+    private async Task<(bool success, string? fullText, int totalPages, IReadOnlyList<ExtractedElement>? structuredElements)> ExtractPdfTextAsync(
+```
+At the extraction write (lines 609-611):
+```csharp
+        pdfDoc.ExtractedText = fullText;
+        pdfDoc.StructuredElementsJson = extractResult.StructuredElements is null
+            ? null
+            : System.Text.Json.JsonSerializer.Serialize(extractResult.StructuredElements);
+        pdfDoc.PageCount = extractResult.TotalPages;
+        pdfDoc.CharacterCount = extractResult.TotalCharacters;
+```
+Update every `return` in this method to include the 4th element (success returns `extractResult.StructuredElements`; failure/early returns `null`).
+
+Call site (line 487): destructure the 4-tuple; pass `structuredElements` + `pdfDoc` to `ChunkTextContentAsync`.
+
+`ChunkTextContentAsync` (line 682):
+```csharp
+    private async Task<List<DocumentChunkInput>> ChunkTextContentAsync(
+        string pdfId,
+        string fullText,
+        PdfDocumentEntity pdfDoc,
+        IReadOnlyList<ExtractedElement>? structuredElements,
+        IServiceScope scope)
+    {
+        var chunkingService = scope.ServiceProvider.GetRequiredService<ITextChunkingService>();
+        const int chunkSize = 512;
+        const int chunkOverlap = 50;
+
+        var advancedChunking = scope.ServiceProvider.GetService<IAdvancedChunkingService>();
+        if (advancedChunking != null)
+        {
+            var hierarchical = await HeadingAwareChunker.BuildAsync(
+                structuredElements,
+                fullText,
+                pdfDoc.Id,
+                pdfDoc.PrivateGameId ?? pdfDoc.SharedGameId,
+                advancedChunking,
+                CancellationToken.None).ConfigureAwait(false);
+            return HeadingAwareChunkAdapter.ToChunkInputs(hierarchical);
+        }
+
+        // Fallback: existing flat PrepareForEmbedding body, unchanged.
+        // ... keep existing body ...
+    }
+```
+
+`GenerateEmbeddingsAsync` (line 720): wrap the batch texts with `HeadingAwareChunkAdapter.CapForEmbedding`.
+
+- [ ] **Step 4: Run tests**
+
+Run: `dotnet test ../../tests/Api.Tests --filter "FullyQualifiedName~CompleteChunkedUpload" -v minimal`
+Expected: new test PASS; pre-existing PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/CompleteChunkedUploadCommandHandler.cs apps/api/tests/Api.Tests/...
+git commit -m "feat(chunking): heading-aware chunking + StructuredElements persist in CompleteChunkedUpload (#3281)"
+```
+
+---
+
+### Task 6: Revive `IndexPdfIntegrationTests` + HeadingPath CTE round-trip (Testcontainers)
+
+Repo rule #1555 wants a real-Postgres round-trip proving the recursive `HeadingPath` CTE resolves. The stale `IndexPdfIntegrationTests.cs` is `<Compile Remove>`-excluded and references a pre-`ISemanticResponseCache`/`IPdfIndexingPipeline` ctor + a removed `PdfDocumentEntity.GameId`. Fix those, un-exclude it, and add a heading-aware assertion via `GetKbChunksHandler`.
+
+**Files:**
+- Modify: `apps/api/tests/Api.Tests/Api.Tests.csproj:107` — remove the `<Compile Remove="Integration\DocumentProcessing\IndexPdfIntegrationTests.cs" />` line.
+- Modify: `apps/api/tests/Api.Tests/Integration/DocumentProcessing/IndexPdfIntegrationTests.cs` — fix the stale ctor + `PdfDocumentEntity.GameId`; add a heading-aware round-trip assertion.
+
+**Interfaces:**
+- Consumes: current `IndexPdfCommandHandler` ctor `(MeepleAiDbContext, IAdvancedChunkingService, IEmbeddingService, ILogger<IndexPdfCommandHandler>, IOptions<IndexingSettings>, ISemanticResponseCache, IPdfIndexingPipeline, TimeProvider?, IRoleClassifierService?)`; `GetKbChunksHandler` → `KbChunksListResponse` (`KbChunkSummaryDto.HeadingPath`).
+
+- [ ] **Step 1: Un-exclude + build to surface all drift**
+
+Remove the `<Compile Remove>` line for `IndexPdfIntegrationTests.cs`. Run `dotnet build ../../tests/Api.Tests` and collect every compile error (the 2 known + any further drift). Fix each:
+- Constructor: supply `_serviceProvider.GetRequiredService<IAdvancedChunkingService>()` as arg 2 (NOT `ITextChunkingService`), add `ISemanticResponseCache` + `IPdfIndexingPipeline` (real from the container SP, or `Mock.Of<>()`).
+- Remove the `GameId = gameId` initializer on the `PdfDocumentEntity` (line ~285); set `SharedGameId`/`PrivateGameId` as the other tests do. Leave `VectorDocumentEntity.GameId` (still valid).
+- Remove/replace the `ITextChunkingService.ChunkText` mock setup (handler now calls `IAdvancedChunkingService`) — register the real `AddChunkingAndRerankingServices` set instead.
+
+- [ ] **Step 2: Run to verify it compiles + runs (may be RED on the new assertion)**
+
+Run: `dotnet test ../../tests/Api.Tests --filter "FullyQualifiedName~IndexPdfIntegrationTests" -v minimal`
+Expected: compiles; existing scenarios pass; the new heading assertion (Step 3) not yet added.
+
+- [ ] **Step 3: Add the heading-aware round-trip assertion**
+
+Add a test that seeds a `pdf_documents` row with non-empty `StructuredElementsJson` (a titled document), runs `IndexPdfCommandHandler`, then:
+```csharp
+// direct column check (EF InMemory can't do the CTE, but this is real Postgres):
+var chunks = await dbContext.TextChunks.AsNoTracking()
+    .Where(t => t.PdfDocumentId == pdfGuid).ToListAsync(ct);
+chunks.Should().Contain(c => c.Heading != null);
+chunks.Should().Contain(c => c.ParentChunkId != null);
+
+// CTE via retrieval handler:
+var resp = await mediator.Send(new GetKbChunksQuery(/* kb doc id */), ct);
+resp.Chunks.Should().Contain(c => c.HeadingPath.Count > 0);
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `dotnet test ../../tests/Api.Tests --filter "FullyQualifiedName~IndexPdfIntegrationTests" -v minimal`
+Expected: PASS. If drift beyond the 2 known issues is unexpectedly large, report it (do not silently rewrite unrelated scenarios).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/tests/Api.Tests/Api.Tests.csproj apps/api/tests/Api.Tests/Integration/DocumentProcessing/IndexPdfIntegrationTests.cs
+git commit -m "test(chunking): revive IndexPdf integration test + HeadingPath CTE round-trip (#3281)"
+```
+
+---
+
+## Final Verification (before PR)
+
+- [ ] `dotnet build` (from `apps/api/src/Api`) — 0 errors, 0 warnings (`TreatWarningsAsErrors`).
+- [ ] `dotnet test ../../tests/Api.Tests --filter "FullyQualifiedName~HeadingAware|FullyQualifiedName~PdfProcessingPipeline|FullyQualifiedName~UploadPdf|FullyQualifiedName~CompleteChunkedUpload"` — all green.
+- [ ] Whole-branch review (opus) via superpowers:requesting-code-review.
+- [ ] PR → `main-dev`, body `Closes #3281`, footer.

--- a/docs/superpowers/plans/2026-07-21-rag-issue-3281-fresh-ingest-heading-parity.md
+++ b/docs/superpowers/plans/2026-07-21-rag-issue-3281-fresh-ingest-heading-parity.md
@@ -189,18 +189,20 @@ The stale-recovery/shared-game path. `pdfDoc` is a **tracked** entity (`FindAsyn
 
 - [ ] **Step 1: Write the failing test**
 
-Model it on the existing pipeline unit tests in the same folder (look for `PdfProcessingPipeline*Tests.cs` — reuse their fixture/mocks). The test builds a `PdfProcessingPipelineService` with a mocked `IAdvancedChunkingService` whose `ChunkDocumentAsync` returns a parent (`Level 0`, `Heading "Setup"`) + child (`Level 2`, `ParentChunkId = parent`), drives `ProcessAsync` (or calls the now-`internal` `ChunkTextAsync` via `InternalsVisibleTo`-exposed access if the class exposes it — otherwise assert through the persisted `text_chunks` in an in-memory `MeepleAiDbContext`), and asserts the produced chunk inputs carry `Heading == "Setup"` and a non-null `ParentChunkId` on the child.
+**⚠️ Fixture guidance (verified):** the `PdfProcessingPipeline*Tests.cs` in this folder is only the *Cover* test, which mocks `IPdfClaimService` so `TryClaimPendingAsync` returns false → `ProcessAsync` early-returns before chunking and can NOT exercise this path. Model instead on **`apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Unit/RaptorPipelineIntegrationTests.cs`** — a full `ProcessAsync`-driving harness (constructs the service at ~:285 with a real `InMemoryPdfClaimService(_db)` so claim=true, an extractor returning `StructuredElements`, and embeddings with matching counts, then calls `ProcessAsync` at ~:94). Add the new trailing `IAdvancedChunkingService` mock to that construction. Assert on the persisted `text_chunks` in the in-memory `MeepleAiDbContext` after `ProcessAsync`.
+
+Write **two** tests:
 
 ```csharp
-// Skeleton — adapt mocks to the existing pipeline test fixture in this folder.
-[Fact]
-public async Task ChunkTextAsync_WithAdvancedChunking_ProducesHeadingBearingChunks()
-{
-    // Arrange: mock IAdvancedChunkingService.ChunkDocumentAsync → [parent Level0 "Setup", child Level2]
-    // Build PdfProcessingPipelineService with that mock in the new trailing ctor slot.
-    // Act: invoke the chunk production for a doc whose extractResult.StructuredElements is non-empty.
-    // Assert: result has a chunk with Heading "Setup"; a child chunk with ParentChunkId != null and Level 2.
-}
+// Test A — English (no translation): mock IAdvancedChunkingService.ChunkDocumentAsync →
+// [parent Level0 "Setup", child Level2 ParentChunkId=parent]; drive ProcessAsync;
+// assert persisted text_chunks contain Heading == "Setup" and a child row with ParentChunkId != null, Level 2.
+
+// Test B — NON-ENGLISH (translation branch) REGRESSION for the PK-collision fix:
+// language detector → non-English (so the translate branch at ProcessAsync runs), same chunker mock;
+// assert ProcessAsync completes WITHOUT the PDF being marked Failed, and that the original + translated
+// text_chunks rows have DISTINCT Ids (no primary-key collision). This test MUST fail if a future edit
+// re-introduces `Id = origChunk.Id` on the translated chunk.
 ```
 
 - [ ] **Step 2: Run test to verify it fails**
@@ -271,13 +273,14 @@ Replace `ChunkText` (line 658) with:
 
 Call site (line 191): `var chunks = await ChunkTextAsync(fullText, extractResult, pdfDoc.Id, pdfDoc.PrivateGameId ?? pdfDoc.SharedGameId, cancellationToken).ConfigureAwait(false);`
 
-Translation branch (lines 224-238) — copy hierarchy fields + remove the stale `// Issue #730 / spec §5.3 forward-wiring` TODO comment (now done):
+Translation branch (lines 224-238) — copy hierarchy fields + remove the stale `// Issue #730 / spec §5.3 forward-wiring` TODO comment (now done). **🔴 CRITICAL: do NOT copy `Id`.** After the producer swap, `origChunk.Id` is a non-empty stable Guid (from `HierarchicalChunkMapper`). A translation is a SEPARATE persisted `text_chunks` row; copying the Id would give the original and its EN translation the SAME primary key → `db.TextChunks.AddRange` throws an EF identity-map `InvalidOperationException` (NOT caught by the `DbUpdateConcurrencyException`-only handler → PDF marked Failed) for **every non-English document**. Leave `Id` at its default (`Guid.Empty`) so `SaveTextChunksAsync` mints a fresh Guid. `ParentChunkId` still references the original-language parent row (a valid persisted row; `ParentChunkId` has no FK — index-only), which is acceptable.
 ```csharp
         var origChunk = chunks[t.OriginalIndex];
         translatedChunks.Add((
             new DocumentChunkInput
             {
-                Id = origChunk.Id,
+                // Id intentionally omitted → defaults to Guid.Empty → fresh Guid at persist.
+                // Copying origChunk.Id here duplicates a primary key and fails non-English PDFs.
                 Text = t.TranslatedText,
                 Page = origChunk.Page,
                 CharStart = origChunk.CharStart,
@@ -346,24 +349,13 @@ Expected: FAIL (flat chunks, `Heading` null).
 
 Add usings: `using Api.BoundedContexts.DocumentProcessing.Application.Services.Chunking;` and `using Api.BoundedContexts.KnowledgeBase.Application.Services.Chunking;`.
 
-`ChunkExtractedTextAsync` (line 337) — add `PdfDocumentEntity pdfDoc` param (place it before `db`), and replace the primary production:
+`ChunkExtractedTextAsync` (line 337) — add `PdfDocumentEntity pdfDoc` param (place it before `db`). **🟢 Do a LOCALIZED change, do NOT hoist or drop existing locals.** The method has a `chunkingStopwatch` (declared ~line 348, used at the metric ~388-389), plus `UpdateProgressAsync`/`RecordPipelineMetricSafely` calls. Keep the entire prologue and epilogue VERBATIM; change ONLY the chunk-production expression, and reuse the method's *existing* `chunkingService`/`chunkSize`/`chunkOverlap` locals (do not re-declare them). Concretely:
+- Add the `PdfDocumentEntity pdfDoc` param to the signature.
+- Where the method currently does `var allDocumentChunks = chunkingService.PrepareForEmbedding(...)...` (the primary production + its `if (allDocumentChunks.Count == 0) { …fallback… }`), change the declaration to a bare `List<DocumentChunkInput> allDocumentChunks;` and wrap the production like this:
 ```csharp
-    private async Task<List<DocumentChunkInput>> ChunkExtractedTextAsync(
-        string pdfId,
-        string fullText,
-        PagedTextExtractionResult extractResult,
-        PdfDocumentEntity pdfDoc,
-        MeepleAiDbContext db,
-        IServiceScope scope,
-        DateTime startTime,
-        CancellationToken cancellationToken)
-    {
-        var chunkingService = scope.ServiceProvider.GetRequiredService<ITextChunkingService>();
-        const int chunkSize = 512;
-        const int chunkOverlap = 50;
-
         // Issue #3281: heading-aware production when AdvancedChunkingService is available in scope.
         var advancedChunking = scope.ServiceProvider.GetService<IAdvancedChunkingService>();
+        List<DocumentChunkInput> allDocumentChunks;
         if (advancedChunking != null)
         {
             var hierarchical = await HeadingAwareChunker.BuildAsync(
@@ -373,15 +365,23 @@ Add usings: `using Api.BoundedContexts.DocumentProcessing.Application.Services.C
                 pdfDoc.PrivateGameId ?? pdfDoc.SharedGameId,
                 advancedChunking,
                 cancellationToken).ConfigureAwait(false);
-            return HeadingAwareChunkAdapter.ToChunkInputs(hierarchical);
+            allDocumentChunks = HeadingAwareChunkAdapter.ToChunkInputs(hierarchical);
         }
-
-        // Fallback: existing flat production (primary PrepareForEmbedding + per-page ChunkText fallback).
-        // ... KEEP the existing body from `var allDocumentChunks = chunkingService.PrepareForEmbedding(...)`
-        //     through the fallback loop and return, unchanged ...
-    }
+        else
+        {
+            // EXISTING flat body verbatim, but ASSIGN (no `var`) to the already-declared allDocumentChunks:
+            allDocumentChunks = chunkingService.PrepareForEmbedding(fullText, chunkSize, chunkOverlap)
+                ?.Where(chunk => chunk != null && !string.IsNullOrWhiteSpace(chunk.Text))
+                .Select(chunk => new DocumentChunkInput { Text = chunk.Text, Page = chunk.Page, CharStart = chunk.CharStart, CharEnd = chunk.CharEnd })
+                .ToList()
+                ?? new List<DocumentChunkInput>();
+            if (allDocumentChunks.Count == 0)
+            {
+                // ... existing per-page ChunkText fallback loop, unchanged (still assigning into allDocumentChunks) ...
+            }
+        }
 ```
-(Preserve the existing flat body verbatim under the fallback — do not delete it.)
+Everything before (`chunkingStopwatch`, `UpdateProgressAsync`, `chunkingService`/consts) and after (metric, `return allDocumentChunks`) stays exactly as-is. This avoids CS0103 (dropped `chunkingStopwatch`) / CS0128 (re-declared locals) and keeps progress + metric on both paths.
 
 Call site (line 68): `var allDocumentChunks = await ChunkExtractedTextAsync(pdfId, fullText!, extractResult!, pdfDoc, db, scope, startTime, cancellationToken).ConfigureAwait(false);`
 
@@ -451,8 +451,15 @@ In `FinalizeProcessingAsync`, AFTER the Ready transition's `try { … Transition
         // freshly TRACKED entity AFTER the final Ready transition (mirrors ExtractPdfTextCommandHandler),
         // so no later repository transition can clobber it. Needed for re-index parity: IndexPdf reads
         // StructuredElementsJson and requires non-null ExtractedText.
+        // 🟡 Use CancellationToken.None (NOT cancellationToken): the PDF is already Ready+indexed at
+        // this point, so this persist MUST complete regardless of pipeline cancellation. Mirrors
+        // ConfirmQuotaAsync's post-Ready CancellationToken.None convention. If cancellation were
+        // threaded here, an OperationCanceledException would escape this DbUpdateConcurrencyException-only
+        // catch → ProcessPdfAsync's cancellation handler → TransitionToFailedAsync → MarkAsFailed on a
+        // Ready aggregate → InvalidOperationException("Cannot transition from Ready state"), AND the
+        // extraction output would be silently lost.
         var tracked = await db.PdfDocuments.AsTracking()
-            .FirstOrDefaultAsync(p => p.Id == pdfGuid, cancellationToken).ConfigureAwait(false);
+            .FirstOrDefaultAsync(p => p.Id == pdfGuid, CancellationToken.None).ConfigureAwait(false);
         if (tracked != null)
         {
             tracked.ExtractedText = pdfDoc.ExtractedText;
@@ -467,7 +474,7 @@ In `FinalizeProcessingAsync`, AFTER the Ready transition's `try { … Transition
             tracked.AtomicRuleCount = pdfDoc.AtomicRuleCount;
             try
             {
-                await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+                await db.SaveChangesAsync(CancellationToken.None).ConfigureAwait(false);
             }
             catch (DbUpdateConcurrencyException ex)
             {
@@ -477,7 +484,7 @@ In `FinalizeProcessingAsync`, AFTER the Ready transition's `try { … Transition
             }
         }
 ```
-Verify the in-scope names (`pdfGuid`, `db`, `pdfDoc`, `cancellationToken`, `_logger`, `pdfId`) against the actual `FinalizeProcessingAsync` signature; thread/resolve `db` from `scope` if not already a param.
+Verify the in-scope names (`pdfGuid`, `db`, `pdfDoc`, `_logger`, `pdfId`) against the actual `FinalizeProcessingAsync` signature; thread/resolve `db` from `scope` if not already a param. (Use `CancellationToken.None` for both the query and the save as shown — do NOT thread the pipeline `cancellationToken` into this post-Ready re-write.)
 
 - [ ] **Step 4: Run tests**
 
@@ -495,11 +502,13 @@ git commit -m "fix(pdf): persist ExtractedText/StructuredElementsJson after Read
 
 ### Task 5: Wire `CompleteChunkedUploadCommandHandler` + carry StructuredElements
 
-`ChunkTextContentAsync` (line 682) takes neither `pdfDoc` nor `extractResult`, and `ExtractPdfTextAsync` (line 565) **discards** `PagedTextExtractionResult`/`StructuredElements` (returns `(bool, string?, int)`). Widen the tuple to carry structured elements, persist `StructuredElementsJson` on the tracked `pdfDoc` (this handler mutates state directly — no AsNoTracking bug), thread `pdfDoc` + structured elements into the chunker, and cap embedding input.
+`ChunkTextContentAsync` (line 682) takes neither `pdfDoc` nor `extractResult`, and `ExtractPdfTextAsync` (line 565) **discards** `PagedTextExtractionResult`/`StructuredElements` (returns `(bool, string?, int)`). Widen the tuple to carry structured elements, persist `StructuredElementsJson`, thread `pdfDoc` + structured elements into the chunker, and cap embedding input.
+
+**🔴 CRITICAL — the `pdfDoc` here is NOT tracked.** It comes from `db.PdfDocuments.FindAsync(...)` (~line 472) on a fresh background scope/DbContext whose default is `QueryTrackingBehavior.NoTracking` (`InfrastructureServiceExtensions.cs:178`, PERF-06) — so under production DI it is **detached**, and the existing `pdfDoc.ExtractedText = …` write + its `SaveChanges` are silently dropped (same anti-pattern the codebase fixes with `.AsTracking()` — see `UploadPdfCommandHandler.Processing.cs:153-156`, `InvitationTokenRepository.cs:63-67`). Do NOT assume state mutations persist. Persist the extraction columns via an explicit tracked write: after setting the fields on `pdfDoc`, call `db.PdfDocuments.Update(pdfDoc);` immediately before the `SaveChangesAsync` (marks the detached entity Modified so all columns persist). The Task 5 **test MUST re-query from a FRESH `MeepleAiDbContext`/scope** (or Testcontainers) to actually exercise the detached path — an InMemory test that `Add()`s the entity into a singleton context pre-tracks it and would falsely pass (`CompleteChunkedUploadCommandHandlerZeroChunkTests.cs:55` is exactly this masking pattern).
 
 **Files:**
 - Modify: `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/CompleteChunkedUploadCommandHandler.cs`
-  - `ExtractPdfTextAsync` (line 565): widen return to `(bool success, string? fullText, int totalPages, IReadOnlyList<ExtractedElement>? structuredElements)`; at the extraction write (lines 609-611) also set `pdfDoc.StructuredElementsJson`; update ALL return sites.
+  - `ExtractPdfTextAsync` (line 565): widen return to `(bool success, string? fullText, int totalPages, IReadOnlyList<ExtractedElement>? structuredElements)`; at the extraction write (lines 609-611) also set `pdfDoc.StructuredElementsJson`, then `db.PdfDocuments.Update(pdfDoc);` before its `SaveChangesAsync`; update ALL return sites.
   - `ChunkTextContentAsync` (line 682): add `PdfDocumentEntity pdfDoc, IReadOnlyList<ExtractedElement>? structuredElements`; resolve `IAdvancedChunkingService?`; `BuildAsync` when non-null else flat.
   - call sites (line 487 for the extract tuple, line 487-488 for chunk) updated.
   - `GenerateEmbeddingsAsync` (line 720): cap texts.
@@ -511,7 +520,7 @@ git commit -m "fix(pdf): persist ExtractedText/StructuredElementsJson after Read
 
 - [ ] **Step 1: Write the failing test**
 
-Follow the existing `CompleteChunkedUploadCommandHandler` tests. Register a mocked `IAdvancedChunkingService` (parent+child) in the scope; assert persisted `text_chunks` carry `Heading` + child `ParentChunkId`, and `pdf_documents.StructuredElementsJson` is non-null after completion.
+Follow the existing `CompleteChunkedUploadCommandHandler` tests. Register a mocked `IAdvancedChunkingService` (parent+child) in the scope; assert persisted `text_chunks` carry `Heading` + child `ParentChunkId`, and `pdf_documents.StructuredElementsJson` is non-null after completion. **The assertion re-query MUST use a FRESH `MeepleAiDbContext` (new scope), not the one that `Add()`ed the seed entity** — otherwise the change-tracker pre-tracks `pdfDoc` and masks the detached-write bug this task fixes.
 
 - [ ] **Step 2: Run test to verify it fails**
 
@@ -526,7 +535,7 @@ Add usings (`…Application.Services.Chunking`, `…KnowledgeBase.Application.Se
 ```csharp
     private async Task<(bool success, string? fullText, int totalPages, IReadOnlyList<ExtractedElement>? structuredElements)> ExtractPdfTextAsync(
 ```
-At the extraction write (lines 609-611):
+At the extraction write (lines 609-611) — add the `StructuredElementsJson` set AND an explicit `db.PdfDocuments.Update(pdfDoc)` (the entity is detached, per the Critical note above):
 ```csharp
         pdfDoc.ExtractedText = fullText;
         pdfDoc.StructuredElementsJson = extractResult.StructuredElements is null
@@ -534,12 +543,15 @@ At the extraction write (lines 609-611):
             : System.Text.Json.JsonSerializer.Serialize(extractResult.StructuredElements);
         pdfDoc.PageCount = extractResult.TotalPages;
         pdfDoc.CharacterCount = extractResult.TotalCharacters;
+        // 🔴 pdfDoc came from a bare FindAsync under the NoTracking default → detached.
+        // Mark it Modified so these columns actually persist (the pre-existing SaveChanges was a no-op).
+        db.PdfDocuments.Update(pdfDoc);
 ```
-Update every `return` in this method to include the 4th element (success returns `extractResult.StructuredElements`; failure/early returns `null`).
+(`db` is the handler's `MeepleAiDbContext` — confirm it is in scope at this write site; it is the same context `pdfDoc` was `FindAsync`'d from.) Update every `return` in this method to include the 4th element (success returns `extractResult.StructuredElements`; failure/early returns `null`).
 
 Call site (line 487): destructure the 4-tuple; pass `structuredElements` + `pdfDoc` to `ChunkTextContentAsync`.
 
-`ChunkTextContentAsync` (line 682):
+`ChunkTextContentAsync` (line 682) — **🟢 localized change** (this method has a `chunkingStopwatch` ~line 689 + metric; do NOT hoist/drop it). Add the two params + resolve `advancedChunking`, then assign `allDocumentChunks` from the heading-aware branch or the existing flat body (change `var allDocumentChunks =` to `allDocumentChunks =`, no re-declare), keeping the stopwatch/metric prologue+epilogue verbatim:
 ```csharp
     private async Task<List<DocumentChunkInput>> ChunkTextContentAsync(
         string pdfId,
@@ -548,11 +560,9 @@ Call site (line 487): destructure the 4-tuple; pass `structuredElements` + `pdfD
         IReadOnlyList<ExtractedElement>? structuredElements,
         IServiceScope scope)
     {
-        var chunkingService = scope.ServiceProvider.GetRequiredService<ITextChunkingService>();
-        const int chunkSize = 512;
-        const int chunkOverlap = 50;
-
+        // ... keep existing prologue verbatim (chunkingStopwatch, chunkingService, consts) ...
         var advancedChunking = scope.ServiceProvider.GetService<IAdvancedChunkingService>();
+        List<DocumentChunkInput> allDocumentChunks;
         if (advancedChunking != null)
         {
             var hierarchical = await HeadingAwareChunker.BuildAsync(
@@ -562,11 +572,18 @@ Call site (line 487): destructure the 4-tuple; pass `structuredElements` + `pdfD
                 pdfDoc.PrivateGameId ?? pdfDoc.SharedGameId,
                 advancedChunking,
                 CancellationToken.None).ConfigureAwait(false);
-            return HeadingAwareChunkAdapter.ToChunkInputs(hierarchical);
+            allDocumentChunks = HeadingAwareChunkAdapter.ToChunkInputs(hierarchical);
         }
-
-        // Fallback: existing flat PrepareForEmbedding body, unchanged.
-        // ... keep existing body ...
+        else
+        {
+            // EXISTING flat PrepareForEmbedding body, verbatim, ASSIGNED (no `var`) to allDocumentChunks.
+            allDocumentChunks = chunkingService.PrepareForEmbedding(fullText, chunkSize, chunkOverlap)
+                ?.Where(chunk => chunk != null && !string.IsNullOrWhiteSpace(chunk.Text))
+                .Select(chunk => new DocumentChunkInput { Text = chunk.Text, Page = chunk.Page, CharStart = chunk.CharStart, CharEnd = chunk.CharEnd })
+                .ToList()
+                ?? new List<DocumentChunkInput>();
+        }
+        // ... keep existing epilogue verbatim (stopwatch stop, metric, return allDocumentChunks) ...
     }
 ```
 
@@ -588,46 +605,52 @@ git commit -m "feat(chunking): heading-aware chunking + StructuredElements persi
 
 ### Task 6: Revive `IndexPdfIntegrationTests` + HeadingPath CTE round-trip (Testcontainers)
 
-Repo rule #1555 wants a real-Postgres round-trip proving the recursive `HeadingPath` CTE resolves. The stale `IndexPdfIntegrationTests.cs` is `<Compile Remove>`-excluded and references a pre-`ISemanticResponseCache`/`IPdfIndexingPipeline` ctor + a removed `PdfDocumentEntity.GameId`. Fix those, un-exclude it, and add a heading-aware assertion via `GetKbChunksHandler`.
+Repo rule #1555 wants a real-Postgres round-trip proving the recursive `HeadingPath` CTE resolves. The stale `IndexPdfIntegrationTests.cs` is `<Compile Remove>`-excluded and references a pre-`ISemanticResponseCache`/`IPdfIndexingPipeline` ctor + a removed `PdfDocumentEntity.GameId`.
+
+**⚠️ This is a mock-infrastructure REWRITE, not a 2-line fix** (verified). There are TWO ctor call sites AND the test SP is missing three registrations. Budget accordingly.
 
 **Files:**
 - Modify: `apps/api/tests/Api.Tests/Api.Tests.csproj:107` — remove the `<Compile Remove="Integration\DocumentProcessing\IndexPdfIntegrationTests.cs" />` line.
-- Modify: `apps/api/tests/Api.Tests/Integration/DocumentProcessing/IndexPdfIntegrationTests.cs` — fix the stale ctor + `PdfDocumentEntity.GameId`; add a heading-aware round-trip assertion.
+- Modify: `apps/api/tests/Api.Tests/Integration/DocumentProcessing/IndexPdfIntegrationTests.cs` — fix BOTH ctor sites + the test-SP registrations + `PdfDocumentEntity.GameId`; add a heading-aware round-trip assertion.
 
 **Interfaces:**
-- Consumes: current `IndexPdfCommandHandler` ctor `(MeepleAiDbContext, IAdvancedChunkingService, IEmbeddingService, ILogger<IndexPdfCommandHandler>, IOptions<IndexingSettings>, ISemanticResponseCache, IPdfIndexingPipeline, TimeProvider?, IRoleClassifierService?)`; `GetKbChunksHandler` → `KbChunksListResponse` (`KbChunkSummaryDto.HeadingPath`).
+- Consumes: current `IndexPdfCommandHandler` ctor `(MeepleAiDbContext, IAdvancedChunkingService, IEmbeddingService, ILogger<IndexPdfCommandHandler>, IOptions<IndexingSettings>, ISemanticResponseCache, IPdfIndexingPipeline, TimeProvider?, IRoleClassifierService?)`; `GetKbChunksHandler` → `KbChunksListResponse` exposing **`.Items`** (`KbChunkSummaryDto.HeadingPath`, `IReadOnlyList<string>`). `GetKbChunksQuery(Guid DocumentId, Guid RequestingUserId, string? Cursor, int Limit, bool UserIsAdmin)`.
 
-- [ ] **Step 1: Un-exclude + build to surface all drift**
+- [ ] **Step 1: Un-exclude + fix BOTH ctor sites + register the 3 missing services**
 
-Remove the `<Compile Remove>` line for `IndexPdfIntegrationTests.cs`. Run `dotnet build ../../tests/Api.Tests` and collect every compile error (the 2 known + any further drift). Fix each:
-- Constructor: supply `_serviceProvider.GetRequiredService<IAdvancedChunkingService>()` as arg 2 (NOT `ITextChunkingService`), add `ISemanticResponseCache` + `IPdfIndexingPipeline` (real from the container SP, or `Mock.Of<>()`).
-- Remove the `GameId = gameId` initializer on the `PdfDocumentEntity` (line ~285); set `SharedGameId`/`PrivateGameId` as the other tests do. Leave `VectorDocumentEntity.GameId` (still valid).
-- Remove/replace the `ITextChunkingService.ChunkText` mock setup (handler now calls `IAdvancedChunkingService`) — register the real `AddChunkingAndRerankingServices` set instead.
+Remove the `<Compile Remove>` line. Then:
+- **Direct-`new` ctor site (~line 440):** it passes 5 args with arg2 = `GetRequiredService<ITextChunkingService>()`. Fix to the current 7-required-arg ctor: arg2 → `GetRequiredService<IAdvancedChunkingService>()`, and add `GetRequiredService<ISemanticResponseCache>()` + `GetRequiredService<IPdfIndexingPipeline>()`.
+- **DI-resolved handler (~line 107, `services.AddScoped<IndexPdfCommandHandler>()`, used by ~9 of the tests):** the test SP registers NONE of `IAdvancedChunkingService` / `ISemanticResponseCache` / `IPdfIndexingPipeline`. `AddChunkingAndRerankingServices` (`KnowledgeBaseServiceExtensions.cs:542`) supplies ONLY `IAdvancedChunkingService`; `IPdfIndexingPipeline` (registered ~`:498`) and `ISemanticResponseCache` (in `AddCachingServices` ~`:600`) are separate. Register all three in the test SP (real from the container SP, or `Mock.Of<>()` where a real isn't needed) — otherwise all DI-resolved scenarios throw at resolution.
+- Remove the `GameId = gameId` initializer on the `PdfDocumentEntity` (~line 285); set `SharedGameId`/`PrivateGameId` as the other tests do. Leave `VectorDocumentEntity.GameId` (still valid).
+- Remove the `ITextChunkingService.ChunkText` mock setup (handler now calls `IAdvancedChunkingService`).
 
-- [ ] **Step 2: Run to verify it compiles + runs (may be RED on the new assertion)**
+- [ ] **Step 2: Build + run — re-baseline any ChunkCount assertions against the real chunker**
 
-Run: `dotnet test ../../tests/Api.Tests --filter "FullyQualifiedName~IndexPdfIntegrationTests" -v minimal`
-Expected: compiles; existing scenarios pass; the new heading assertion (Step 3) not yet added.
+Run: `dotnet build ../../tests/Api.Tests` then `dotnet test ../../tests/Api.Tests --filter "FullyQualifiedName~IndexPdfIntegrationTests" -v minimal`.
+Fix any remaining compile drift. Existing internal-consistency assertions (`Be(result.ChunkCount)`) hold regardless of chunker; relative thresholds (`> 10`, `> 100`) on large seed texts survive a real ~512-char chunker — only re-baseline if a specific count assertion breaks against real-chunker output (do NOT weaken assertions to force green; adjust the expected number).
 
-- [ ] **Step 3: Add the heading-aware round-trip assertion**
+- [ ] **Step 3: Add the heading-aware round-trip assertion (with the HybridCache passthrough fix)**
 
-Add a test that seeds a `pdf_documents` row with non-empty `StructuredElementsJson` (a titled document), runs `IndexPdfCommandHandler`, then:
+**🟡 `GetKbChunksHandler.Handle` wraps its work in `_cache.GetOrCreateAsync`.** The default test SP registers `Mock.Of<IHybridCacheService>()` which returns null WITHOUT invoking the factory → the CTE never runs and the assertion silently observes null. Build this test's SP with **`CreateBase(connectionString, useHybridCachePassthrough: true)`** (or instantiate `GetKbChunksHandler` directly with a passthrough cache). Seed a `pdf_documents` row with non-empty `StructuredElementsJson` (a titled document), run `IndexPdfCommandHandler`, then:
 ```csharp
-// direct column check (EF InMemory can't do the CTE, but this is real Postgres):
+// direct column check (real Postgres):
 var chunks = await dbContext.TextChunks.AsNoTracking()
     .Where(t => t.PdfDocumentId == pdfGuid).ToListAsync(ct);
 chunks.Should().Contain(c => c.Heading != null);
 chunks.Should().Contain(c => c.ParentChunkId != null);
 
-// CTE via retrieval handler:
-var resp = await mediator.Send(new GetKbChunksQuery(/* kb doc id */), ct);
-resp.Chunks.Should().Contain(c => c.HeadingPath.Count > 0);
+// CTE via retrieval handler — note .Items (NOT .Chunks) and the 5-arg query with owner/admin so
+// the access-control check passes (else ForbiddenException):
+var resp = await mediator.Send(
+    new GetKbChunksQuery(DocumentId: kbDocId, RequestingUserId: ownerUserId, Cursor: null, Limit: 100, UserIsAdmin: true),
+    ct);
+resp.Items.Should().Contain(c => c.HeadingPath.Count > 0);
 ```
 
 - [ ] **Step 4: Run tests**
 
 Run: `dotnet test ../../tests/Api.Tests --filter "FullyQualifiedName~IndexPdfIntegrationTests" -v minimal`
-Expected: PASS. If drift beyond the 2 known issues is unexpectedly large, report it (do not silently rewrite unrelated scenarios).
+Expected: PASS. If drift beyond the above is unexpectedly large, report it (do not silently rewrite unrelated scenarios).
 
 - [ ] **Step 5: Commit**
 


### PR DESCRIPTION
**Closes #3281 · Part of #3266**

RAG retrieval "chunking heading-aware" epic — **fresh-upload ingest parity** (the follow-up to Slice D / #3282).

PR #3282 shipped the shared heading-aware chunking infra (`HeadingAwareChunker.BuildAsync`, `HierarchicalChunkMapper`, `PdfDocumentEntity.StructuredElementsJson`, embedding cap) but wired it into the **re-index path only**, explicitly deferring the fresh-upload ingest paths to this issue. This PR wires that **same merged infra** (no duplication) into the 3 fresh-ingest handlers, so freshly-uploaded PDFs get the same heading-bearing hierarchical chunks the re-index path already produces — and fixes three pre-existing persistence bugs found along the way.

## What ships

- **Shared adapter** (`HeadingAwareChunkAdapter`): maps `HeadingAwareChunker.BuildAsync`'s `List<DocumentChunk>` → the `DocumentChunkInput` the ingest handlers embed/persist, and caps embedding-input text at `MaxEmbeddingChars` (full text still persisted; only the vector-provider input is capped). One tested place, reused by all 3 paths.
- **3 fresh-ingest paths wired**: `PdfProcessingPipelineService` (Quartz/stale-recovery/shared-game), `UploadPdfCommandHandler.Processing` (regular + private-game upload), `CompleteChunkedUploadCommandHandler` (chunked upload). Each resolves `IAdvancedChunkingService` (null → unchanged flat fallback, so pre-existing test ctors compile), threads document/game identity, and routes chunk production through `BuildAsync`. The persist sites already carried the hierarchy fields — they just receive heading-bearing chunks now.
- **Translation-branch hierarchy copy** (`PdfProcessingPipelineService`): translated (EN) chunks now carry `Heading`/`Level`/`ParentChunkId`/`ElementType`. Deliberately does **not** copy the chunk `Id` — sharing the now-stable Id would collide the `text_chunks` primary key and fail every non-English PDF (regression-guarded by a dedicated test).

## Persistence fixes (pre-existing bugs)

1. **Upload AsNoTracking** (`UploadPdfCommandHandler.FinalizeProcessingAsync`): the pipeline's working `pdfDoc` is `AsNoTracking()` and its state transitions route through the repository (which omits + clobbers the extraction columns), so `ExtractedText`/`StructuredElementsJson` never persisted for Upload PDFs — blocking re-index parity. Fixed with a dedicated tracked re-write after the Ready transition, using `CancellationToken.None` (the PDF is already Ready+indexed; a threaded token would risk an `OperationCanceledException` escaping to a spurious Ready→Failed + lost output).
2. **Complete detached entity** (`CompleteChunkedUploadCommandHandler`): its `pdfDoc` comes from a bare `FindAsync` under the NoTracking default → detached, so the `StructuredElementsJson` write was a silent no-op. Fixed with `db.PdfDocuments.Update(pdfDoc)` before `SaveChanges`.
3. **Level `ValueGeneratedNever`** (`TextChunkEntityConfiguration`): `HasDefaultValue(1)` without `.ValueGeneratedNever()` made Npgsql coerce explicit `Level = 0` (parent/section chunks) to `1` on INSERT, silently corrupting the parent/child level hierarchy across **all** ingest paths (incl. the merged #3282 re-index path). Fixed. Regression-free (the CLR default is `1`, so no-set creators still persist 1); no migration needed (`ValueGenerated` is not schema-affecting; `has-pending-model-changes` is clean).

## Testing

Subagent-driven TDD: 6 tasks + the Level fix, each with a fresh implementer + a spec+quality reviewer, then an **adversarial multi-lens plan review** (9 findings fixed before implementation, incl. both Critical PK-collision + detached-entity issues) and a **whole-branch review on Opus** — verdict: **Ready to merge, 0 Critical / 0 Important**.

- Revived `IndexPdfIntegrationTests` (un-excluded + mock-infra rewrite) with a **real-Postgres HeadingPath CTE round-trip** proving the recursive heading-path resolves for freshly-indexed heading-aware chunks (repo rule #1555).
- Load-bearing regression guards: non-English PK-distinctness, Upload/Complete detached-write persistence (verified RED via `git stash`), parent `Level == 0` on real Postgres.
- Local gate: production build 0 warnings/0 errors; targeted heading-aware + integration filters **22/22 green** (Testcontainers).

## Follow-up (deferred, tracked separately)

- Complete's failure-path status writes share the same detached-entity exposure (a failed chunked upload can stay non-terminal) — pre-existing on `main-dev`, out of this PR's success-path scope, not worsened here.
- Two `IndexPdfIntegrationTests` "extraction required" scenarios are now functionally identical (production no longer distinguishes them) — keep-or-delete decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
