### PR TITLE
fix(a11y): #3289 clear entity-token contrast debt + re-promote frontend-a11y gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1217,11 +1217,12 @@ jobs:
           # Onda A (2026-05-25): 'frontend' was split into frontend-lint,
           # frontend-typecheck, frontend-test (3-shard matrix). All three are
           # required gates.
-          for job in frontend-lint frontend-typecheck frontend-test backend-unit python-tests e2e; do
+          for job in frontend-lint frontend-typecheck frontend-test frontend-a11y backend-unit python-tests e2e; do
             case "$job" in
               frontend-lint) result="${{ needs.frontend-lint.result }}" ;;
               frontend-typecheck) result="${{ needs.frontend-typecheck.result }}" ;;
               frontend-test) result="${{ needs.frontend-test.result }}" ;;
+              frontend-a11y) result="${{ needs.frontend-a11y.result }}" ;;
               backend-unit) result="${{ needs.backend-unit.result }}" ;;
               python-tests) result="${{ needs.python-tests.result }}" ;;
               e2e) result="${{ needs.e2e.result }}" ;;
@@ -1235,17 +1236,16 @@ jobs:
           done
 
           # Advisory jobs (warn but don't block).
-          # frontend-a11y TEMPORARILY DEMOTED to advisory (2026-07-21, product
-          # decision): pre-existing systemic WCAG AA color-contrast debt in the
-          # entity-token chips (bg-entity-*/… tints) + a couple shared components
-          # is a design-system effort tracked separately, and the app is pre-prod.
-          # RE-PROMOTE frontend-a11y to the required-jobs loop above before the
-          # prod promotion (this reverts the #1094 Phase-D gate flip temporarily).
-          # backend-integration is advisory because integration tests depend on CI
-          # service containers.
-          for advisory in frontend-a11y backend-integration; do
+          # frontend-a11y was RE-PROMOTED to the required-jobs loop above on
+          # 2026-07-26 (#3289) after clearing the systemic WCAG AA color-contrast
+          # debt (entity-token game/kb/document chips swapped to the AA `-text`
+          # variants) plus the shared-component (MenuPlaceholder, PauseOverlay,
+          # SessionShareCard) + session-live/library a11y spec fixes. This restores
+          # the #1094 Phase-D gate flip that #3290 had temporarily reverted
+          # (2026-07-21). backend-integration remains advisory because integration
+          # tests depend on CI service containers.
+          for advisory in backend-integration; do
             case "$advisory" in
-              frontend-a11y) result="${{ needs.frontend-a11y.result }}" ;;
               backend-integration) result="${{ needs.backend-integration.result }}" ;;
             esac
             if [ "$result" == "failure" ]; then

--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -11,3 +11,6 @@ e2e/.memory-log.json
 e2e/.memory-log.json.tmp
 # Transient typecheck logs
 tsc_out.txt
+
+# a11y e2e generated report (local runs)
+playwright-report-a11y/

--- a/apps/web/e2e/_helpers/seedAuthSession.ts
+++ b/apps/web/e2e/_helpers/seedAuthSession.ts
@@ -194,3 +194,76 @@ export async function mockAuthEndpoints(
     await route.continue();
   });
 }
+
+/**
+ * Mocks the four "sibling" data sources that the `/library` hybrid hub
+ * (`useHybridHubItems`) fans out to besides the games source (Issue #3289).
+ *
+ * **Why this is needed** (root cause):
+ *   `useHybridHubItems` computes `isLoading` as the OR of 5 query sources
+ *   (games / sessions / chat / agents / kb). The a11y specs use `?fixture=default`
+ *   (or `?state=…`) which short-circuits ONLY the games source (`useLibrary`)
+ *   client-side. The other 4 sources always issue REAL network calls:
+ *     - `useActiveSessions(20)`      → GET /api/v1/sessions/active
+ *     - `useRecentChatSessions(50)`  → GET /api/v1/users/{id}/chat-sessions/recent
+ *     - `useAgents({scope})`         → GET /api/v1/agents?scope=my-library
+ *     - `useUserKbDocs()`            → GET /api/v1/kb-docs
+ *   In the visual-test prod build there is no backend; those 4 requests hang
+ *   through TanStack retry backoff, so `isLoading` never settles, the hub FSM
+ *   stays stuck in 'loading', `LibraryHybridGrid` never mounts, and the specs
+ *   time out waiting for the first `[data-slot="library-grid-card"]`.
+ *
+ * **Schema-valid EMPTY payloads are mandatory**: a 200 that fails the source's
+ * Zod schema throws a `SchemaValidationError` in `httpClient.validateResponse`
+ * → TanStack retries → the query stays pending past the 5s timeout → still red.
+ * Each payload below therefore includes every required field (empty arrays +
+ * `total`/`page`/`pageSize`), matching the exact response envelope each fetcher
+ * validates. Note `page`/`pageSize` MUST be positive integers, and the chat
+ * source returns a BARE array (not an envelope) per `ChatSessionArraySchema`.
+ *
+ * Host-agnostic regexes (no `^` anchor, `(\?.*)?$` tail) match both the relative
+ * URLs the browser `httpClient` issues (proxied via localhost:3000) and any
+ * absolute `:8080` form, tolerant of trailing query strings — same pattern as
+ * `mockAuthEndpoints`. Non-GET methods fall through via `route.continue()`.
+ *
+ * Call AFTER `mockAuthEndpoints` and BEFORE the first `page.goto`.
+ */
+export async function mockLibraryHubSiblingSources(page: Page): Promise<void> {
+  const fulfillGet = (body: unknown) => async (route: Route) => {
+    if (route.request().method() === 'GET') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(body),
+      });
+      return;
+    }
+    await route.continue();
+  };
+
+  // sessions — PaginatedSessionsResponse { sessions, total, page(>0), pageSize(>0) }
+  await page
+    .context()
+    .route(
+      /\/api\/v1\/sessions\/active(\?.*)?$/,
+      fulfillGet({ sessions: [], total: 0, page: 1, pageSize: 20 })
+    );
+
+  // chat — ChatSessionArraySchema is a BARE array of ChatSessionSummaryDto
+  await page
+    .context()
+    .route(/\/api\/v1\/users\/[^/]+\/chat-sessions\/recent(\?.*)?$/, fulfillGet([]));
+
+  // agents — GetAllAgentsResponse { success, agents, count }
+  await page
+    .context()
+    .route(/\/api\/v1\/agents(\?.*)?$/, fulfillGet({ success: true, agents: [], count: 0 }));
+
+  // kb — KbDocsListResponse (STRICT) { items, total, page(>0), pageSize(>0) }
+  await page
+    .context()
+    .route(
+      /\/api\/v1\/kb-docs(\?.*)?$/,
+      fulfillGet({ items: [], total: 0, page: 1, pageSize: 20 })
+    );
+}

--- a/apps/web/e2e/a11y/games-library.spec.ts
+++ b/apps/web/e2e/a11y/games-library.spec.ts
@@ -34,7 +34,11 @@
 import AxeBuilder from '@axe-core/playwright';
 import { test, expect, type Page } from '@playwright/test';
 
-import { mockAuthEndpoints, seedAuthSession } from '../_helpers/seedAuthSession';
+import {
+  mockAuthEndpoints,
+  mockLibraryHubSiblingSources,
+  seedAuthSession,
+} from '../_helpers/seedAuthSession';
 import { seedCookieConsent } from '../_helpers/seedCookieConsent';
 
 const WCAG_TAGS = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'];
@@ -43,6 +47,9 @@ async function gotoLibraryReady(page: Page, search = '', waitForGrid = true): Pr
   await seedAuthSession(page);
   await seedCookieConsent(page);
   await mockAuthEndpoints(page);
+  // #3289: mock the 4 sibling hub sources so `useHybridHubItems.isLoading`
+  // settles and the games results grid mounts (fixture only short-circuits games).
+  await mockLibraryHubSiblingSources(page);
   // LibraryHub does not read ?tab= from the URL; navigate to /library then click
   // the Giochi tab. The optional `search` (e.g. 'state=filtered-empty') is applied
   // to the /library URL so the dev/visual-test ?state= override still works.

--- a/apps/web/e2e/a11y/library.spec.ts
+++ b/apps/web/e2e/a11y/library.spec.ts
@@ -27,7 +27,11 @@
 import AxeBuilder from '@axe-core/playwright';
 import { test, expect, type Page } from '@playwright/test';
 
-import { mockAuthEndpoints, seedAuthSession } from '../_helpers/seedAuthSession';
+import {
+  mockAuthEndpoints,
+  mockLibraryHubSiblingSources,
+  seedAuthSession,
+} from '../_helpers/seedAuthSession';
 import { seedCookieConsent } from '../_helpers/seedCookieConsent';
 
 const WCAG_TAGS = ['wcag2a', 'wcag2aa', 'wcag21a', 'wcag21aa'];
@@ -36,6 +40,9 @@ async function gotoLibraryReady(page: Page, search = ''): Promise<void> {
   await seedAuthSession(page);
   await seedCookieConsent(page);
   await mockAuthEndpoints(page);
+  // #3289: mock the 4 sibling hub sources so `useHybridHubItems.isLoading`
+  // settles and LibraryHybridGrid mounts (fixture only short-circuits games).
+  await mockLibraryHubSiblingSources(page);
   await page.goto(`/library${search}`, { waitUntil: 'domcontentloaded' });
   await page.waitForSelector('[data-slot="library-hub-v2"]', { timeout: 30_000 });
 }

--- a/apps/web/e2e/a11y/session-live.spec.ts
+++ b/apps/web/e2e/a11y/session-live.spec.ts
@@ -202,29 +202,38 @@ test.describe('Session live — accessibility @a11y', () => {
     await expect(asideLandmark).toBeVisible();
   });
 
-  test('G1 RightColumnTabs — 4 tab buttons (score/turn/widget/notes) in mockup order', async ({
+  test('G1 RightColumnTabs — 6 tab buttons (score/turn/widget/notes/photos/agent) in mockup order', async ({
     page,
   }) => {
     await page.setViewportSize({ width: 1280, height: 720 });
     await gotoSessionLive(page, '?fixture=host');
 
+    // #2588 A1+A4 extended the shared BASE_TABS to 6 (added photos/Foto + agent/
+    // Arbitro after the original G1 score/turn/widget/notes four). The generic
+    // host fixture keeps showFlavorTab=false, so the optional 7th flavor tab is
+    // absent → stable count of 6 (mirrors RightColumnTabs.test.tsx:80).
     const tabs = page.locator('[data-slot="right-column-tabs"] [role="tab"]');
-    await expect(tabs).toHaveCount(4);
+    await expect(tabs).toHaveCount(6);
 
-    // Order assertion: Score → Turni/Turn → Widget → Note/Notes (mockup canonical).
-    // Locale is 'it' by default — see jsdoc viewport note above. We accept both
-    // it/en strings to keep the test resilient if the harness flips locales.
+    // Order assertion: Score → Turni/Turn → Widget → Note/Notes → Foto/Photos →
+    // Arbitro/Arbiter (mockup canonical). Locale is 'it' by default — see jsdoc
+    // viewport note above. We accept both it/en strings to keep the test
+    // resilient if the harness flips locales.
     const labels = await tabs.allTextContents();
     expect(labels[0]).toMatch(/^Score$/);
     expect(labels[1]).toMatch(/^Turn[i]?$/);
     expect(labels[2]).toMatch(/^Widget$/);
     expect(labels[3]).toMatch(/^Note[s]?$/);
+    expect(labels[4]).toMatch(/^(Foto|Photos)$/);
+    expect(labels[5]).toMatch(/^(Arbitro|Arbiter)$/);
 
     // First tab (score) is the default-selected per parseLiveTab fallback.
     await expect(tabs.nth(0)).toHaveAttribute('aria-selected', 'true');
     await expect(tabs.nth(1)).toHaveAttribute('aria-selected', 'false');
     await expect(tabs.nth(2)).toHaveAttribute('aria-selected', 'false');
     await expect(tabs.nth(3)).toHaveAttribute('aria-selected', 'false');
+    await expect(tabs.nth(4)).toHaveAttribute('aria-selected', 'false');
+    await expect(tabs.nth(5)).toHaveAttribute('aria-selected', 'false');
   });
 
   test('G1 keyboard traversal — Tab order reaches LEFT column (chat) before RIGHT column tabs', async ({
@@ -233,10 +242,14 @@ test.describe('Session live — accessibility @a11y', () => {
     await page.setViewportSize({ width: 1280, height: 720 });
     await gotoSessionLive(page, '?fixture=host');
 
-    // Wait for the LEFT-column primitives to mount.
-    await expect(page.locator('[data-slot="chat-agent-panel"]')).toBeVisible();
-    await expect(page.locator('[data-slot="action-log-timeline"]')).toBeVisible();
-    await expect(page.locator('[data-slot="right-column-tabs"]')).toBeVisible();
+    // Wait for the LEFT-column primitives to mount. Scope to :visible — the shell
+    // mounts a desktop ChatAgentPanel (in <main>) AND a mobile one (in the
+    // bottom-sheet) so a bare [data-slot="chat-agent-panel"] resolves to 2 nodes
+    // and trips Playwright strict mode; at 1280px only the desktop copy is
+    // visible (the mobile body is display:none), so :visible narrows to 1 (#3289).
+    await expect(page.locator('[data-slot="chat-agent-panel"]:visible')).toBeVisible();
+    await expect(page.locator('[data-slot="action-log-timeline"]:visible')).toBeVisible();
+    await expect(page.locator('[data-slot="right-column-tabs"]:visible')).toBeVisible();
 
     // Walk focus through the document and collect the *highest* data-slot
     // ancestor seen for each step (LEFT-column-side OR RIGHT-column-side).
@@ -353,7 +366,7 @@ test.describe('Session live — accessibility @a11y', () => {
     await expect(page.locator('[data-slot="mobile-body-tab"]')).toHaveCount(0);
   });
 
-  test('WAI-ARIA: mobile FAB opens bottom-sheet drawer with 4 polymorphic tabs', async ({
+  test('WAI-ARIA: mobile FAB opens bottom-sheet drawer with 6 polymorphic tabs', async ({
     page,
   }) => {
     await page.setViewportSize({ width: 375, height: 812 });
@@ -371,19 +384,23 @@ test.describe('Session live — accessibility @a11y', () => {
     await expect(drawer).toHaveAttribute('role', 'dialog');
     await expect(drawer).toHaveAttribute('aria-modal', 'true');
 
-    // Tab strip = role="tablist" with 4 tabs: Score / Turn / Widget / Notes.
+    // Tab strip = role="tablist" with 6 tabs: Score / Turn / Widget / Notes /
+    // Photos / Agent (MobileBottomSheetDrawer BASE_TABS mirrors the desktop set;
+    // #2588 A1+A4 added photos + agent).
     const tablist = drawer.locator('[role="tablist"]');
     await expect(tablist).toBeVisible();
     await expect(tablist).toHaveAttribute('aria-orientation', 'horizontal');
 
     const tabs = drawer.locator('[role="tab"]');
-    await expect(tabs).toHaveCount(4);
+    await expect(tabs).toHaveCount(6);
 
     // Default active tab = score (1st in order).
     await expect(tabs.nth(0)).toHaveAttribute('aria-selected', 'true');
     await expect(tabs.nth(1)).toHaveAttribute('aria-selected', 'false');
     await expect(tabs.nth(2)).toHaveAttribute('aria-selected', 'false');
     await expect(tabs.nth(3)).toHaveAttribute('aria-selected', 'false');
+    await expect(tabs.nth(4)).toHaveAttribute('aria-selected', 'false');
+    await expect(tabs.nth(5)).toHaveAttribute('aria-selected', 'false');
   });
 
   test('axe-core: no WCAG 2.1 AA violations on mobile bottom-sheet open state', async ({

--- a/apps/web/scripts/run-a11y-e2e.mjs
+++ b/apps/web/scripts/run-a11y-e2e.mjs
@@ -48,7 +48,12 @@ function run(cmd, args, env = process.env) {
     // 20.12+/22 hardened spawn (CVE-2024-27980) throws EINVAL on .cmd/.bat with
     // shell:false. POSIX keeps shell:false. Enables local `pnpm test:a11y:e2e`
     // iteration on Windows instead of ~20min CI rounds (issue #3289).
-    const child = spawn(cmd, args, { stdio: 'inherit', env, cwd: repoWeb, shell: process.platform === 'win32' });
+    const isWin = process.platform === 'win32';
+    // cmd.exe word-splits array args on spaces, so quote any arg containing
+    // whitespace (e.g. the absolute reportPath under "C:\\Users\\John Doe\\...")
+    // — otherwise the summarize step receives a truncated path and exits 65.
+    const spawnArgs = isWin ? args.map(a => (/\s/.test(a) ? `"${a}"` : a)) : args;
+    const child = spawn(cmd, spawnArgs, { stdio: 'inherit', env, cwd: repoWeb, shell: isWin });
     child.on('exit', (code, signal) => {
       if (signal) {
         process.stderr.write(`run-a11y-e2e: ${cmd} killed by ${signal}\n`);

--- a/apps/web/scripts/run-a11y-e2e.mjs
+++ b/apps/web/scripts/run-a11y-e2e.mjs
@@ -44,7 +44,11 @@ const playwrightEnv = {
 
 function run(cmd, args, env = process.env) {
   return new Promise((resolveExit) => {
-    const child = spawn(cmd, args, { stdio: 'inherit', env, cwd: repoWeb, shell: false });
+    // shell:true on Windows so `pnpm.cmd` (a batch file) can be spawned — Node
+    // 20.12+/22 hardened spawn (CVE-2024-27980) throws EINVAL on .cmd/.bat with
+    // shell:false. POSIX keeps shell:false. Enables local `pnpm test:a11y:e2e`
+    // iteration on Windows instead of ~20min CI rounds (issue #3289).
+    const child = spawn(cmd, args, { stdio: 'inherit', env, cwd: repoWeb, shell: process.platform === 'win32' });
     child.on('exit', (code, signal) => {
       if (signal) {
         process.stderr.write(`run-a11y-e2e: ${cmd} killed by ${signal}\n`);

--- a/apps/web/src/app/(public)/how-it-works/game-comprehension/page.tsx
+++ b/apps/web/src/app/(public)/how-it-works/game-comprehension/page.tsx
@@ -78,7 +78,7 @@ export default function GameComprehensionPage(): JSX.Element {
         }}
       >
         <div className="mx-auto max-w-3xl text-center">
-          <p className="mb-4 inline-flex items-center gap-2 rounded-full border border-entity-game/30 bg-entity-game/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-entity-game">
+          <p className="mb-4 inline-flex items-center gap-2 rounded-full border border-entity-game/30 bg-entity-game/10 px-3 py-1 text-xs font-semibold uppercase tracking-[0.18em] text-entity-game-text">
             {t('pages.gameComprehension.eyebrow')}
           </p>
           <h1
@@ -120,7 +120,7 @@ export default function GameComprehensionPage(): JSX.Element {
               className="relative flex break-inside-avoid flex-col items-center text-center lg:px-3"
             >
               {/* Numbered node — the anchor point on the thread. */}
-              <span className="relative z-10 flex h-12 w-12 items-center justify-center rounded-full border border-entity-game/30 bg-card text-lg font-bold text-entity-game shadow-sm">
+              <span className="relative z-10 flex h-12 w-12 items-center justify-center rounded-full border border-entity-game/30 bg-card text-lg font-bold text-entity-game-text shadow-sm">
                 <span className="sr-only">{`${idx + 1}. `}</span>
                 {idx + 1}
               </span>
@@ -159,7 +159,7 @@ export default function GameComprehensionPage(): JSX.Element {
           {/* A representative snippet of a published card. */}
           <figure className="mx-auto mt-10 max-w-xl rounded-2xl border border-border bg-card p-6 shadow-sm">
             <figcaption className="flex flex-wrap items-center gap-2 border-b border-border pb-3">
-              <span className="text-sm font-semibold text-entity-game">
+              <span className="text-sm font-semibold text-entity-game-text">
                 {t('pages.gameComprehension.demoGameName')}
               </span>
               <span className="text-xs uppercase tracking-wide text-muted-foreground">
@@ -180,7 +180,7 @@ export default function GameComprehensionPage(): JSX.Element {
                 data-testid="game-comprehension-demo-panel"
               >
                 <div className="flex flex-wrap items-center justify-between gap-2">
-                  <span className="inline-flex items-center rounded-md border border-entity-game/40 bg-entity-game/10 px-2 py-0.5 text-xs font-semibold text-entity-game">
+                  <span className="inline-flex items-center rounded-md border border-entity-game/40 bg-entity-game/10 px-2 py-0.5 text-xs font-semibold text-entity-game-text">
                     {t('pages.gameComprehension.demoReviewedBadge')}
                   </span>
                   <span className="text-xs uppercase tracking-wide text-muted-foreground">

--- a/apps/web/src/components/features/game-nights/GameNightListCard.tsx
+++ b/apps/web/src/components/features/game-nights/GameNightListCard.tsx
@@ -135,7 +135,7 @@ export function GameNightListCard({
               <span aria-hidden="true" className="opacity-40">
                 ·
               </span>
-              <span className="inline-flex items-center gap-1 whitespace-nowrap rounded-full border border-entity-game/22 bg-entity-game/12 px-2 py-0.5 font-display text-[10px] font-extrabold text-entity-game">
+              <span className="inline-flex items-center gap-1 whitespace-nowrap rounded-full border border-entity-game/22 bg-entity-game/12 px-2 py-0.5 font-display text-[10px] font-extrabold text-entity-game-text">
                 {gameTitle}
               </span>
             </>

--- a/apps/web/src/components/features/game-nights/live/NightLiveHub.tsx
+++ b/apps/web/src/components/features/game-nights/live/NightLiveHub.tsx
@@ -556,7 +556,7 @@ function MobileBody({
                 : 'border-t-transparent text-muted-foreground'
               : t.tone === 'game'
                 ? active
-                  ? 'bg-entity-game/[0.08] border-t-entity-game text-entity-game'
+                  ? 'bg-entity-game/[0.08] border-t-entity-game text-entity-game-text'
                   : 'border-t-transparent text-muted-foreground'
                 : active
                   ? 'bg-entity-event/[0.08] border-t-entity-event text-entity-event'

--- a/apps/web/src/components/features/gamebook/GameSearchBar.tsx
+++ b/apps/web/src/components/features/gamebook/GameSearchBar.tsx
@@ -108,7 +108,7 @@ export function GameSearchBar({
         {
           key: 'bgg',
           label: labels.tabsBgg,
-          activeCls: 'border-entity-document text-entity-document',
+          activeCls: 'border-entity-document text-entity-document-text',
         },
       ]
     : [

--- a/apps/web/src/components/features/gamebook/GamebookCard.tsx
+++ b/apps/web/src/components/features/gamebook/GamebookCard.tsx
@@ -165,7 +165,7 @@ function PipStrip({
           key: 'chunks',
           icon: '📄',
           label: chunksLabel,
-          cls: 'bg-entity-document/12 text-entity-document',
+          cls: 'bg-entity-document/12 text-entity-document-text',
         }
       : null,
     qaCount > 0

--- a/apps/web/src/components/features/kb-globale/CitationPill.tsx
+++ b/apps/web/src/components/features/kb-globale/CitationPill.tsx
@@ -55,7 +55,7 @@ export function CitationPill({
       onClick={() => onClick?.(chunkId ? { docId, page, chunkId } : { docId, page })}
       className={cn(
         'inline-flex items-center gap-1 px-1.5 py-0 rounded-full align-baseline',
-        'border border-entity-kb/25 bg-entity-kb/10 text-entity-kb',
+        'border border-entity-kb/25 bg-entity-kb/10 text-entity-kb-text',
         'font-mono text-[10px] font-bold cursor-pointer',
         'focus:outline-none focus:ring-2 focus:ring-entity-kb/40 focus:ring-offset-1',
         'transition-colors duration-150 hover:bg-entity-kb/20',

--- a/apps/web/src/components/features/kb-globale/HeroSearch.tsx
+++ b/apps/web/src/components/features/kb-globale/HeroSearch.tsx
@@ -170,7 +170,7 @@ export function HeroSearch(props: HeroSearchProps): JSX.Element {
               className={`px-4 py-2 rounded-md text-sm font-semibold transition-colors ${
                 mode === modeValue
                   ? 'bg-entity-kb text-white'
-                  : 'bg-entity-kb/10 text-entity-kb border border-entity-kb/20 hover:bg-entity-kb/20'
+                  : 'bg-entity-kb/10 text-entity-kb-text border border-entity-kb/20 hover:bg-entity-kb/20'
               }`}
             >
               {modeLabel}

--- a/apps/web/src/components/features/kb-globale/KbDocViewerMobile.tsx
+++ b/apps/web/src/components/features/kb-globale/KbDocViewerMobile.tsx
@@ -71,7 +71,7 @@ export function KbDocViewerMobile({
         <div className="flex-1 min-w-0">
           <div className="font-display font-bold text-sm truncate">📄 {doc.title}</div>
         </div>
-        <div className="px-2.5 py-1 rounded-full bg-entity-kb/10 text-entity-kb font-mono text-xs font-bold">
+        <div className="px-2.5 py-1 rounded-full bg-entity-kb/10 text-entity-kb-text font-mono text-xs font-bold">
           {labels.pageOfTotal(activePage, doc.pageCount)}
         </div>
       </div>

--- a/apps/web/src/components/features/kb-globale/KbSearchResultsDesktop.tsx
+++ b/apps/web/src/components/features/kb-globale/KbSearchResultsDesktop.tsx
@@ -197,7 +197,7 @@ function ResultRow({
           className={cn(
             'inline-flex items-center gap-1',
             'rounded-full px-2 py-0.5',
-            'bg-entity-kb/10 text-entity-kb',
+            'bg-entity-kb/10 text-entity-kb-text',
             'border border-entity-kb/20',
             'text-xs font-semibold',
             'whitespace-nowrap'

--- a/apps/web/src/components/features/kb-hub/HubDefault.tsx
+++ b/apps/web/src/components/features/kb-hub/HubDefault.tsx
@@ -178,7 +178,7 @@ export function HubDefault(props: HubDefaultProps): ReactElement {
               type="button"
               onClick={onUpload}
               data-slot="kb-hub-default-upload-cta"
-              className="rounded-md border border-entity-kb/25 bg-entity-kb/10 px-3.5 py-2 font-display text-xs font-bold text-entity-kb transition-colors hover:bg-entity-kb/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-entity-kb focus-visible:ring-offset-2"
+              className="rounded-md border border-entity-kb/25 bg-entity-kb/10 px-3.5 py-2 font-display text-xs font-bold text-entity-kb-text transition-colors hover:bg-entity-kb/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-entity-kb focus-visible:ring-offset-2"
             >
               {labels.uploadCta}
             </button>
@@ -279,7 +279,7 @@ export function HubDefault(props: HubDefaultProps): ReactElement {
           type="button"
           onClick={onUpload}
           data-slot="kb-hub-default-drop-zone"
-          className="m-4 flex w-[calc(100%-2rem)] items-center justify-center gap-2 rounded-md border-2 border-dashed border-entity-kb/30 bg-entity-kb/4 px-4 py-5 text-sm font-bold text-entity-kb transition-colors hover:border-entity-kb/55 hover:bg-entity-kb/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-entity-kb focus-visible:ring-offset-2"
+          className="m-4 flex w-[calc(100%-2rem)] items-center justify-center gap-2 rounded-md border-2 border-dashed border-entity-kb/30 bg-entity-kb/4 px-4 py-5 text-sm font-bold text-entity-kb-text transition-colors hover:border-entity-kb/55 hover:bg-entity-kb/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-entity-kb focus-visible:ring-offset-2"
         >
           <span aria-hidden="true" className="text-base">
             ⬆

--- a/apps/web/src/components/features/kb-hub/PdfRow.tsx
+++ b/apps/web/src/components/features/kb-hub/PdfRow.tsx
@@ -112,7 +112,7 @@ export function PdfRow(props: PdfRowProps): ReactElement {
         aria-label={ariaLabel}
         onClick={() => onActionClick(pdf.id)}
         data-slot="kb-hub-pdf-action"
-        className="inline-flex items-center gap-1 whitespace-nowrap rounded-md border border-entity-kb/20 bg-entity-kb/8 px-3 py-1.5 font-display text-xs font-bold text-entity-kb transition-colors hover:bg-entity-kb/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-entity-kb focus-visible:ring-offset-2"
+        className="inline-flex items-center gap-1 whitespace-nowrap rounded-md border border-entity-kb/20 bg-entity-kb/8 px-3 py-1.5 font-display text-xs font-bold text-entity-kb-text transition-colors hover:bg-entity-kb/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-entity-kb focus-visible:ring-offset-2"
       >
         {labels.openCta} →
       </button>

--- a/apps/web/src/components/features/knowledge-base/KbChunkListPanel.tsx
+++ b/apps/web/src/components/features/knowledge-base/KbChunkListPanel.tsx
@@ -58,7 +58,7 @@ function Row({
         {chunk.usedInChats > 0 ? (
           <span
             aria-label={`Usato in ${chunk.usedInChats} chat`}
-            className="rounded-full bg-entity-kb/15 px-1.5 py-0.5 font-mono text-[10px] font-bold text-entity-kb"
+            className="rounded-full bg-entity-kb/15 px-1.5 py-0.5 font-mono text-[10px] font-bold text-entity-kb-text"
           >
             {chunk.usedInChats}× chat
           </span>

--- a/apps/web/src/components/features/knowledge-base/KbChunkPreview.tsx
+++ b/apps/web/src/components/features/knowledge-base/KbChunkPreview.tsx
@@ -37,7 +37,7 @@ const TABS = [
   { key: 'raw' as SubTab, label: 'Raw' },
 ];
 
-const ACCENT_ACTIVE = 'font-extrabold text-entity-kb';
+const ACCENT_ACTIVE = 'font-extrabold text-entity-kb-text';
 const ACCENT_INDICATOR = 'bg-entity-kb';
 const ACCENT_COUNT_ACTIVE = 'bg-entity-kb text-white';
 

--- a/apps/web/src/components/features/knowledge-base/KbHeader.tsx
+++ b/apps/web/src/components/features/knowledge-base/KbHeader.tsx
@@ -53,7 +53,7 @@ export function KbHeader({ document, className }: KbHeaderProps): ReactElement {
         <h1 className="font-display text-lg font-extrabold text-entity-kb">{document.title}</h1>
         <span
           aria-label={`Tipo documento ${document.docType}`}
-          className="rounded-md bg-entity-kb/15 px-2 py-0.5 font-mono text-[11px] font-bold uppercase text-entity-kb"
+          className="rounded-md bg-entity-kb/15 px-2 py-0.5 font-mono text-[11px] font-bold uppercase text-entity-kb-text"
         >
           {document.docType}
         </span>

--- a/apps/web/src/components/features/library/AdvancedFiltersDrawer/AdvancedFiltersDrawer.tsx
+++ b/apps/web/src/components/features/library/AdvancedFiltersDrawer/AdvancedFiltersDrawer.tsx
@@ -453,7 +453,7 @@ function SelectMultiBody({
                 className={clsx(
                   'inline-flex flex-shrink-0 items-center gap-1 rounded-full border px-2 py-1 font-mono text-[10.5px] font-bold focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/60',
                   active
-                    ? 'border-entity-game/40 bg-entity-game/[0.12] text-entity-game'
+                    ? 'border-entity-game/40 bg-entity-game/[0.12] text-entity-game-text'
                     : 'border-transparent bg-muted text-muted-foreground hover:bg-muted/80'
                 )}
               >
@@ -695,11 +695,11 @@ function entityBorderActiveClass(color: EntityColorSlug): string {
 function entityTextClass(color: EntityColorSlug): string {
   switch (color) {
     case 'game':
-      return 'text-entity-game';
+      return 'text-entity-game-text';
     case 'agent':
       return 'text-entity-agent';
     case 'kb':
-      return 'text-entity-kb';
+      return 'text-entity-kb-text';
     case 'session':
       return 'text-entity-session';
     case 'chat':

--- a/apps/web/src/components/features/library/CrossEntityFilters.tsx
+++ b/apps/web/src/components/features/library/CrossEntityFilters.tsx
@@ -98,14 +98,14 @@ function FilterChip({ label, value, hasValue = false, onClick }: FilterChipProps
       className={clsx(
         'inline-flex flex-shrink-0 cursor-pointer items-center gap-1.5 whitespace-nowrap rounded-md px-3 py-1.5 font-display text-[12px] font-bold',
         hasValue
-          ? 'border border-entity-game/30 bg-entity-game/10 text-entity-game'
+          ? 'border border-entity-game/30 bg-entity-game/10 text-entity-game-text'
           : 'border border-border bg-card text-muted-foreground'
       )}
     >
       <span
         className={clsx(
           'font-mono text-[9px] font-extrabold uppercase tracking-[0.06em]',
-          hasValue ? 'text-entity-game' : 'text-muted-foreground'
+          hasValue ? 'text-entity-game-text' : 'text-muted-foreground'
         )}
       >
         {label}

--- a/apps/web/src/components/features/library/LibraryHeroDesktop.tsx
+++ b/apps/web/src/components/features/library/LibraryHeroDesktop.tsx
@@ -94,9 +94,9 @@ const STAT_BORDER_CLASS: Record<EntityType, string> = {
 };
 
 const STAT_TEXT_CLASS: Record<EntityType, string> = {
-  game: 'text-entity-game',
+  game: 'text-entity-game-text',
   agent: 'text-entity-agent',
-  kb: 'text-entity-kb',
+  kb: 'text-entity-kb-text',
   chat: 'text-entity-chat',
   session: 'text-entity-session',
   event: 'text-entity-event',

--- a/apps/web/src/components/features/library/LibraryTabs.tsx
+++ b/apps/web/src/components/features/library/LibraryTabs.tsx
@@ -77,9 +77,9 @@ export interface LibraryTabsProps<K extends string = LibraryEntityKey> {
  * here so the same classnames are also visible to the test grep + lint inventory.
  */
 const ACTIVE_CONTAINER_BG: Record<LibraryTabEntity, string> = {
-  game: 'bg-entity-game/10 text-entity-game',
+  game: 'bg-entity-game/10 text-entity-game-text',
   agent: 'bg-entity-agent/10 text-entity-agent',
-  kb: 'bg-entity-kb/10 text-entity-kb',
+  kb: 'bg-entity-kb/10 text-entity-kb-text',
   session: 'bg-entity-session/10 text-entity-session',
   chat: 'bg-entity-chat/10 text-entity-chat',
 };

--- a/apps/web/src/components/features/library/RecentActivityRail.tsx
+++ b/apps/web/src/components/features/library/RecentActivityRail.tsx
@@ -104,9 +104,9 @@ const ENTITY_CIRCLE_CLASS: Record<EntitySlot, string> = {
 };
 
 const ENTITY_ANCHOR_CLASS: Record<EntitySlot, string> = {
-  game: 'text-entity-game',
+  game: 'text-entity-game-text',
   agent: 'text-entity-agent',
-  kb: 'text-entity-kb',
+  kb: 'text-entity-kb-text',
   session: 'text-entity-session',
   chat: 'text-entity-chat',
 };

--- a/apps/web/src/components/features/library/__tests__/LibraryTabs.test.tsx
+++ b/apps/web/src/components/features/library/__tests__/LibraryTabs.test.tsx
@@ -216,18 +216,18 @@ describe('LibraryTabs (Wave B.3)', () => {
       expect(container.querySelector('[data-slot="library-tabs-indicator"]')).toBeInTheDocument();
     });
 
-    it('applies bg-entity-kb/10 + text-entity-kb on the active "kb" tab', () => {
+    it('applies bg-entity-kb/10 + text-entity-kb-text on the active "kb" tab', () => {
       render(<ControlledLibraryTabs initial="kb" />);
       const kbTab = screen.getByRole('tab', { name: /Con KB/, selected: true });
       expect(kbTab.className).toMatch(/bg-entity-kb\/10/);
-      expect(kbTab.className).toMatch(/text-entity-kb\b/);
+      expect(kbTab.className).toMatch(/text-entity-kb-text\b/);
     });
 
-    it('falls back to game accent (bg-entity-game/10 + text-entity-game) on active "all" tab', () => {
+    it('falls back to game accent (bg-entity-game/10 + text-entity-game-text) on active "all" tab', () => {
       render(<ControlledLibraryTabs initial="all" />);
       const allTab = screen.getByRole('tab', { name: /Tutti/, selected: true });
       expect(allTab.className).toMatch(/bg-entity-game\/10/);
-      expect(allTab.className).toMatch(/text-entity-game\b/);
+      expect(allTab.className).toMatch(/text-entity-game-text\b/);
     });
   });
 });

--- a/apps/web/src/components/features/mechanic-card/MechanicCardView.tsx
+++ b/apps/web/src/components/features/mechanic-card/MechanicCardView.tsx
@@ -213,7 +213,7 @@ function SectionBlock({
             chapter numeral encodes real order rather than decorating. */}
         <span
           aria-hidden="true"
-          className="font-display text-sm font-bold tabular-nums text-entity-game"
+          className="font-display text-sm font-bold tabular-nums text-entity-game-text"
         >
           {String(index + 1).padStart(2, '0')}
         </span>
@@ -366,7 +366,7 @@ export function MechanicCardView({ gameId }: MechanicCardViewProps): ReactElemen
             <Badge
               variant="outline"
               data-slot="mechanic-card-ai-badge"
-              className="border-entity-game/40 bg-entity-game/10 text-entity-game print:border-border print:bg-transparent print:text-foreground"
+              className="border-entity-game/40 bg-entity-game/10 text-entity-game-text print:border-border print:bg-transparent print:text-foreground"
             >
               <Link
                 href={HOW_IT_WORKS_HREF}

--- a/apps/web/src/components/features/mechanic-card/MechanicCardView.tsx
+++ b/apps/web/src/components/features/mechanic-card/MechanicCardView.tsx
@@ -213,7 +213,7 @@ function SectionBlock({
             chapter numeral encodes real order rather than decorating. */}
         <span
           aria-hidden="true"
-          className="font-display text-sm font-bold tabular-nums text-entity-game-text"
+          className="font-display text-sm font-bold tabular-nums text-entity-game"
         >
           {String(index + 1).padStart(2, '0')}
         </span>

--- a/apps/web/src/components/features/mechanic-card/MechanicCitationBadge.tsx
+++ b/apps/web/src/components/features/mechanic-card/MechanicCitationBadge.tsx
@@ -129,7 +129,7 @@ export function MechanicCitationBadge({
             onMouseLeave={handleMouseLeave}
             aria-label={`Citazione regolamento, pagina ${citation.pdfPage}`}
             className={cn(
-              'inline-flex items-center rounded-md border border-entity-game/40 bg-entity-game/10 px-1.5 py-0.5 align-middle text-[11px] font-semibold text-entity-game transition-colors',
+              'inline-flex items-center rounded-md border border-entity-game/40 bg-entity-game/10 px-1.5 py-0.5 align-middle text-[11px] font-semibold text-entity-game-text transition-colors',
               'hover:bg-entity-game/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
               'print:border-border print:bg-transparent print:text-foreground'
             )}

--- a/apps/web/src/components/features/mechanic-card/MechanicCitationPanel.tsx
+++ b/apps/web/src/components/features/mechanic-card/MechanicCitationPanel.tsx
@@ -136,7 +136,7 @@ function PanelBody({
         <div className="flex flex-wrap items-center gap-2">
           <Badge
             variant="outline"
-            className="border-entity-game/40 bg-entity-game/10 text-entity-game"
+            className="border-entity-game/40 bg-entity-game/10 text-entity-game-text"
           >
             AI-generated, human-reviewed
           </Badge>

--- a/apps/web/src/components/features/session-live/PauseOverlay.tsx
+++ b/apps/web/src/components/features/session-live/PauseOverlay.tsx
@@ -92,40 +92,49 @@ export function PauseOverlay({
     };
   }, []);
 
-  // ESC key handler: closes dialog
-  const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent<HTMLDivElement>) => {
+  // ESC dismissal via a document-level listener so it works regardless of where
+  // focus currently sits. The React `onKeyDown` on the dialog div below only
+  // fires when focus is inside the dialog; a click on the dialog chrome (or the
+  // backdrop) moves focus out, after which ESC was silently swallowed (#3289 —
+  // e2e "PauseOverlay ESC closes dialog"). Keydown bubbles to document, so this
+  // fires in both jsdom and real browsers. ESC handling lives ONLY here (removed
+  // from handleKeyDown) to avoid a double onClose.
+  useEffect(() => {
+    function onDocumentKeyDown(e: KeyboardEvent) {
       if (e.key === 'Escape') {
         e.preventDefault();
         onClose();
-        return;
       }
+    }
+    document.addEventListener('keydown', onDocumentKeyDown);
+    return () => document.removeEventListener('keydown', onDocumentKeyDown);
+  }, [onClose]);
 
-      // Focus trap: Tab cycles within focusables
-      if (e.key === 'Tab' && dialogRef.current) {
-        const focusables = getFocusables(dialogRef.current);
-        if (focusables.length === 0) return;
+  // Tab focus-trap handler (ESC is handled by the document listener above).
+  const handleKeyDown = useCallback((e: React.KeyboardEvent<HTMLDivElement>) => {
+    // Focus trap: Tab cycles within focusables
+    if (e.key === 'Tab' && dialogRef.current) {
+      const focusables = getFocusables(dialogRef.current);
+      if (focusables.length === 0) return;
 
-        const firstEl = focusables[0];
-        const lastEl = focusables[focusables.length - 1];
+      const firstEl = focusables[0];
+      const lastEl = focusables[focusables.length - 1];
 
-        if (e.shiftKey) {
-          // Shift+Tab: if first → wrap to last
-          if (document.activeElement === firstEl) {
-            e.preventDefault();
-            lastEl.focus();
-          }
-        } else {
-          // Tab: if last → wrap to first
-          if (document.activeElement === lastEl) {
-            e.preventDefault();
-            firstEl.focus();
-          }
+      if (e.shiftKey) {
+        // Shift+Tab: if first → wrap to last
+        if (document.activeElement === firstEl) {
+          e.preventDefault();
+          lastEl.focus();
+        }
+      } else {
+        // Tab: if last → wrap to first
+        if (document.activeElement === lastEl) {
+          e.preventDefault();
+          firstEl.focus();
         }
       }
-    },
-    [onClose]
-  );
+    }
+  }, []);
 
   return (
     /* Backdrop */

--- a/apps/web/src/components/features/session-summary/AchievementsCarousel.tsx
+++ b/apps/web/src/components/features/session-summary/AchievementsCarousel.tsx
@@ -16,7 +16,8 @@
  * `useSessionAchievements` hook returning deterministic fixture.
  *
  * MeepleCard divergence (Gate C): emoji-first card with locked/unlocked
- * variant inversion (locked → muted, dashed border, opacity 0.45). MeepleCard's
+ * variant inversion (locked → muted, dashed border; no opacity dimming so the
+ * muted text stays WCAG AA — #3289). MeepleCard's
  * subject avatar/title/subtitle pattern doesn't fit the locked-overlay
  * inverted state. DIVERGE.
  *
@@ -135,7 +136,12 @@ export function AchievementsCarousel({
                 '[scroll-snap-align:start]',
                 unlocked
                   ? 'border border-entity-toolkit/30 bg-entity-toolkit/[0.06]'
-                  : 'border border-dashed border-border bg-muted/40 opacity-60'
+                  : // #3289: no `opacity-60` on the whole card — axe composites it
+                    // onto the muted text, dropping SC 1.4.3 contrast to 2.53:1.
+                    // The locked look stays via the dashed border + muted bg + 🔒
+                    // icon; the muted text keeps AA contrast (muted-foreground on
+                    // the light bg-muted/40 tint is ≥ 4.5:1 without the opacity).
+                    'border border-dashed border-border bg-muted/40'
               )}
             >
               <div

--- a/apps/web/src/components/features/session-summary/SessionShareCard.tsx
+++ b/apps/web/src/components/features/session-summary/SessionShareCard.tsx
@@ -197,9 +197,16 @@ export function SessionShareCard({
           })}
         </div>
       </div>
-      {/* Preview surface — theme-driven inline styles to keep page-theme isolated */}
+      {/* Preview surface — carries data-theme so its OWN entity-token colors
+          (winner score var(--color-entity-toolkit), medallion + card borders,
+          border-entity-session) resolve to the PREVIEWED theme. The surface
+          paints an opaque bg (#0f0c1e dark / #fff light), so this dark scope
+          does NOT overhang the light page chrome — that was the #3289 B2 leak:
+          data-theme lived on the transparent <section>, putting a dark
+          --foreground on the light shell (#ece6df on #f7f3ee = 1.12:1). */}
       <div
         data-slot="share-preview"
+        data-theme={theme}
         data-preview-theme={theme}
         className="relative mx-auto w-full max-w-xl overflow-hidden rounded-lg border-2 border-entity-session/30 aspect-[4/3]"
         style={{

--- a/apps/web/src/components/features/session-summary/SessionShareCard.tsx
+++ b/apps/web/src/components/features/session-summary/SessionShareCard.tsx
@@ -153,11 +153,7 @@ export function SessionShareCard({
   })();
 
   return (
-    <section
-      data-slot="session-share-card"
-      data-theme={theme}
-      className={clsx('flex flex-col gap-3', className)}
-    >
+    <section data-slot="session-share-card" className={clsx('flex flex-col gap-3', className)}>
       <div className="flex items-baseline justify-between">
         <h3 className="font-display text-base font-extrabold text-foreground">
           <span aria-hidden="true" className="mr-1.5">

--- a/apps/web/src/components/features/session-summary/__tests__/SessionShareCard.test.tsx
+++ b/apps/web/src/components/features/session-summary/__tests__/SessionShareCard.test.tsx
@@ -83,16 +83,20 @@ describe('SessionShareCard', () => {
     expect(screen.getByText('23 apr 2026 · 1h 24min · 4 giocatori')).toBeTruthy();
   });
 
-  it('marks data-theme="light" by default', () => {
+  it('marks data-preview-theme="light" by default', () => {
     render(<SessionShareCard {...DEFAULT_PROPS} />);
-    const root = document.querySelector('[data-slot="session-share-card"]')!;
-    expect(root.getAttribute('data-theme')).toBe('light');
+    // #3289: the theme marker moved off the <section> (its data-theme leaked a
+    // dark token scope onto the light-page card chrome → #ece6df-on-#f7f3ee
+    // 1.12:1). Theme now scopes ONLY to the self-contained preview surface,
+    // which carries data-preview-theme + inline styles.
+    const preview = document.querySelector('[data-slot="share-preview"]')!;
+    expect(preview.getAttribute('data-preview-theme')).toBe('light');
   });
 
-  it('marks data-theme="dark" when theme prop is dark', () => {
+  it('marks data-preview-theme="dark" when theme prop is dark', () => {
     render(<SessionShareCard {...DEFAULT_PROPS} theme="dark" />);
-    const root = document.querySelector('[data-slot="session-share-card"]')!;
-    expect(root.getAttribute('data-theme')).toBe('dark');
+    const preview = document.querySelector('[data-slot="share-preview"]')!;
+    expect(preview.getAttribute('data-preview-theme')).toBe('dark');
   });
 
   it('renders theme toggle radiogroup with 2 options', () => {

--- a/apps/web/src/components/features/toolkits-index/HubToolkitCardGrid.tsx
+++ b/apps/web/src/components/features/toolkits-index/HubToolkitCardGrid.tsx
@@ -175,7 +175,7 @@ export function HubToolkitCardGrid({
           </div>
         )}
         {toolkit.gameName ? (
-          <div className="inline-flex items-center gap-1 font-mono text-[10px] font-bold text-entity-game">
+          <div className="inline-flex items-center gap-1 font-mono text-[10px] font-bold text-entity-game-text">
             <span aria-hidden="true">🎲</span>
             <span className="truncate">{toolkit.gameName}</span>
           </div>

--- a/apps/web/src/components/layout/ContextMiniNav.tsx
+++ b/apps/web/src/components/layout/ContextMiniNav.tsx
@@ -37,7 +37,7 @@ export function ContextMiniNav({ tabs, activeTab, onTabChange, className }: Cont
             className={cn(
               'px-4 py-1.5 rounded-md font-body font-semibold text-sm transition-all',
               activeTab === tab.id
-                ? 'bg-entity-game/15 text-entity-game'
+                ? 'bg-entity-game/15 text-entity-game-text'
                 : 'text-muted-foreground hover:text-foreground hover:bg-muted/50'
             )}
           >

--- a/apps/web/src/components/play-records/SessionCreateForm.tsx
+++ b/apps/web/src/components/play-records/SessionCreateForm.tsx
@@ -408,7 +408,7 @@ function Step1Gioco({ form, isSubmitting, t, isReadonly }: Step1Props) {
       {gameType === 'catalog' && !form.watch('gameId') && (
         <div
           role="status"
-          className="rounded-lg border border-dashed border-entity-game/30 bg-entity-game/6 px-3 py-2.5 font-mono text-xs font-bold text-entity-game"
+          className="rounded-lg border border-dashed border-entity-game/30 bg-entity-game/6 px-3 py-2.5 font-mono text-xs font-bold text-entity-game-text"
         >
           {t('step1.emptyLibraryHint')}
         </div>

--- a/apps/web/src/components/ui/data-display/meeple-card/parts/MenuPlaceholder.tsx
+++ b/apps/web/src/components/ui/data-display/meeple-card/parts/MenuPlaceholder.tsx
@@ -14,12 +14,23 @@
  * button on every one of the 72 consumer card surfaces. Restore to default
  * (`tabIndex={0}`) when a real `onActionsMenu` handler prop is added.
  *
- * See #1856 DEC-4.
+ * `aria-hidden` removes this decorative-only placeholder from the accessibility
+ * tree so axe stops color-contrast auditing it in its `opacity-0` resting state
+ * (opacity:0 does NOT exempt a node from axe — only aria-hidden/display:none/
+ * visibility:hidden do). The semi-transparent `bg-white/85` glass composited
+ * over varying card covers + theme-reactive `text-foreground` yielded an
+ * unreliable/sub-AA glyph contrast on ~15 nodes per grid (issue #3289).
+ * Safe here because the button is non-functional and already `tabIndex={-1}`
+ * (no aria-hidden-focus conflict). Drop `aria-hidden` + restore focusability
+ * together when a real `onActionsMenu` handler is wired.
+ *
+ * See #1856 DEC-4, #3289.
  */
 export function MenuPlaceholder() {
   return (
     <button
       type="button"
+      aria-hidden="true"
       aria-label="Azioni"
       tabIndex={-1}
       onClick={e => e.stopPropagation()}

--- a/apps/web/src/components/ui/data-display/meeple-card/parts/MenuPlaceholder.tsx
+++ b/apps/web/src/components/ui/data-display/meeple-card/parts/MenuPlaceholder.tsx
@@ -2,41 +2,36 @@
 'use client';
 
 /**
- * Hover-visible glass button placeholder for card actions (3-dot menu).
+ * Hover-visible glass placeholder for card actions (3-dot menu).
  *
  * **No functional handler** — this is a visual-only placeholder matching the SP4
  * mockup at `admin-mockups/design_files/sp4-library-desktop.jsx:709-721`. Click
  * stops propagation so it doesn't trigger the parent card's `onClick`. Future
  * issue may wire a consumer-defined menu action via a prop.
  *
- * `tabIndex={-1}` removes the button from the keyboard tab order — without
- * this, keyboard / screen-reader users would land on a non-functional "Azioni"
- * button on every one of the 72 consumer card surfaces. Restore to default
- * (`tabIndex={0}`) when a real `onActionsMenu` handler prop is added.
- *
- * `aria-hidden` removes this decorative-only placeholder from the accessibility
- * tree so axe stops color-contrast auditing it in its `opacity-0` resting state
- * (opacity:0 does NOT exempt a node from axe — only aria-hidden/display:none/
- * visibility:hidden do). The semi-transparent `bg-white/85` glass composited
- * over varying card covers + theme-reactive `text-foreground` yielded an
- * unreliable/sub-AA glyph contrast on ~15 nodes per grid (issue #3289).
- * Safe here because the button is non-functional and already `tabIndex={-1}`
- * (no aria-hidden-focus conflict). Drop `aria-hidden` + restore focusability
- * together when a real `onActionsMenu` handler is wired.
+ * Rendered as a NON-interactive `<div>` (not a `<button>`) because the consumer
+ * card surface (GridCard) is itself a `<button>`, and a nested `<button>` trips
+ * axe's `nested-interactive` rule regardless of `aria-hidden` (that rule is
+ * structural — it fires on interactive-in-interactive nesting, and aria-hidden
+ * only exempts contrast/name audits, not nesting) (#3289). `aria-hidden` still
+ * removes this decorative element from the a11y tree so axe stops color-contrast
+ * auditing its semi-transparent glass over varying card covers. A plain `<div>`
+ * is not a focusable/interactive control, so there is no tab-order affordance to
+ * suppress and no nesting violation. When a real `onActionsMenu` handler is
+ * wired in a follow-up, promote it back to a `<button>` rendered OUTSIDE the card
+ * button (or make the card a non-button surface) to keep it AA-clean.
  *
  * See #1856 DEC-4, #3289.
  */
 export function MenuPlaceholder() {
   return (
-    <button
-      type="button"
+    <div
+      data-slot="menu-placeholder"
       aria-hidden="true"
-      aria-label="Azioni"
-      tabIndex={-1}
       onClick={e => e.stopPropagation()}
       className="absolute right-2 top-2 z-10 flex h-6 w-6 items-center justify-center rounded-md border-none bg-white/85 text-sm font-extrabold text-foreground opacity-0 backdrop-blur-md transition-opacity duration-200 group-hover:opacity-100"
     >
       ⋯
-    </button>
+    </div>
   );
 }

--- a/apps/web/src/components/ui/data-display/meeple-card/parts/__tests__/MenuPlaceholder.test.tsx
+++ b/apps/web/src/components/ui/data-display/meeple-card/parts/__tests__/MenuPlaceholder.test.tsx
@@ -3,42 +3,45 @@ import { render, fireEvent } from '@testing-library/react';
 
 import { MenuPlaceholder } from '../MenuPlaceholder';
 
-// MenuPlaceholder is a decorative-only, aria-hidden placeholder (#3289), so it
-// is absent from the accessibility tree — getByRole/name queries cannot reach it
-// (aria-hidden also blanks the computed accessible name, so `hidden: true` alone
-// does not help). Query it via the DOM by its stable aria-label instead.
+// MenuPlaceholder is a decorative-only, aria-hidden <div> placeholder (#3289).
+// It is deliberately NOT a <button>: a nested interactive control inside the
+// card <button> trips axe's nested-interactive rule (aria-hidden does not exempt
+// it). It is also absent from the a11y tree, so query it via the DOM by data-slot.
 function renderMenu() {
   const result = render(<MenuPlaceholder />);
-  const btn = result.container.querySelector<HTMLButtonElement>('button[aria-label="Azioni"]');
-  return { ...result, btn };
+  const el = result.container.querySelector<HTMLElement>('[data-slot="menu-placeholder"]');
+  return { ...result, el };
 }
 
 describe('MenuPlaceholder', () => {
-  it('renders an aria-hidden button with aria-label="Azioni"', () => {
-    const { btn } = renderMenu();
-    expect(btn).not.toBeNull();
-    expect(btn).toHaveAttribute('aria-hidden', 'true');
+  it('renders an aria-hidden, non-interactive placeholder (a <div>, not a <button>)', () => {
+    const { el } = renderMenu();
+    expect(el).not.toBeNull();
+    expect(el).toHaveAttribute('aria-hidden', 'true');
+    // Must NOT be a <button> — nesting one inside the card <button> violates
+    // axe nested-interactive regardless of aria-hidden.
+    expect(el?.tagName).toBe('DIV');
   });
 
   it('renders the ⋯ glyph', () => {
-    const { btn } = renderMenu();
-    expect(btn?.textContent).toContain('⋯');
+    const { el } = renderMenu();
+    expect(el?.textContent).toContain('⋯');
   });
 
   it('starts hidden (opacity-0) and becomes visible on parent group-hover', () => {
-    const { btn } = renderMenu();
-    expect(btn?.className).toMatch(/\bopacity-0\b/);
-    expect(btn?.className).toMatch(/group-hover:opacity-100/);
-    expect(btn?.className).toMatch(/transition-opacity/);
+    const { el } = renderMenu();
+    expect(el?.className).toMatch(/\bopacity-0\b/);
+    expect(el?.className).toMatch(/group-hover:opacity-100/);
+    expect(el?.className).toMatch(/transition-opacity/);
   });
 
   it('positions absolute top-2 right-2 with glass style', () => {
-    const { btn } = renderMenu();
-    expect(btn?.className).toMatch(/\babsolute\b/);
-    expect(btn?.className).toMatch(/\btop-2\b/);
-    expect(btn?.className).toMatch(/\bright-2\b/);
-    expect(btn?.className).toMatch(/bg-white\/85/);
-    expect(btn?.className).toMatch(/backdrop-blur-md/);
+    const { el } = renderMenu();
+    expect(el?.className).toMatch(/\babsolute\b/);
+    expect(el?.className).toMatch(/\btop-2\b/);
+    expect(el?.className).toMatch(/\bright-2\b/);
+    expect(el?.className).toMatch(/bg-white\/85/);
+    expect(el?.className).toMatch(/backdrop-blur-md/);
   });
 
   it('stops click event propagation (prevents triggering parent card onClick)', () => {
@@ -48,17 +51,16 @@ describe('MenuPlaceholder', () => {
         <MenuPlaceholder />
       </div>
     );
-    const btn = container.querySelector<HTMLButtonElement>('button[aria-label="Azioni"]');
-    fireEvent.click(btn!);
+    const el = container.querySelector<HTMLElement>('[data-slot="menu-placeholder"]');
+    fireEvent.click(el!);
     expect(parentClick).not.toHaveBeenCalled();
   });
 
-  it('is removed from the keyboard tab order (tabIndex={-1}) — no false a11y affordance', () => {
-    const { btn } = renderMenu();
-    // Without tabIndex={-1}, screen-reader / keyboard users would land on this
-    // non-functional placeholder on every one of the 72 consumer card surfaces.
-    // DEC-4: placeholder is visual-only; restore tabIndex={0} when a real
-    // onActionsMenu handler is wired in a follow-up issue.
-    expect(btn?.tabIndex).toBe(-1);
+  it('is not a focusable/interactive control (no tab-order affordance, no role)', () => {
+    const { el } = renderMenu();
+    // A plain <div> is not focusable by default, so there is no false a11y
+    // affordance for keyboard / screen-reader users. #1856 DEC-4 / #3289.
+    expect(el?.tabIndex).toBe(-1);
+    expect(el?.getAttribute('role')).toBeNull();
   });
 });

--- a/apps/web/src/components/ui/data-display/meeple-card/parts/__tests__/MenuPlaceholder.test.tsx
+++ b/apps/web/src/components/ui/data-display/meeple-card/parts/__tests__/MenuPlaceholder.test.tsx
@@ -1,55 +1,64 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, fireEvent } from '@testing-library/react';
 
 import { MenuPlaceholder } from '../MenuPlaceholder';
 
+// MenuPlaceholder is a decorative-only, aria-hidden placeholder (#3289), so it
+// is absent from the accessibility tree — getByRole/name queries cannot reach it
+// (aria-hidden also blanks the computed accessible name, so `hidden: true` alone
+// does not help). Query it via the DOM by its stable aria-label instead.
+function renderMenu() {
+  const result = render(<MenuPlaceholder />);
+  const btn = result.container.querySelector<HTMLButtonElement>('button[aria-label="Azioni"]');
+  return { ...result, btn };
+}
+
 describe('MenuPlaceholder', () => {
-  it('renders a button with aria-label="Azioni"', () => {
-    render(<MenuPlaceholder />);
-    expect(screen.getByRole('button', { name: 'Azioni' })).toBeInTheDocument();
+  it('renders an aria-hidden button with aria-label="Azioni"', () => {
+    const { btn } = renderMenu();
+    expect(btn).not.toBeNull();
+    expect(btn).toHaveAttribute('aria-hidden', 'true');
   });
 
   it('renders the ⋯ glyph', () => {
-    render(<MenuPlaceholder />);
-    expect(screen.getByRole('button', { name: 'Azioni' }).textContent).toContain('⋯');
+    const { btn } = renderMenu();
+    expect(btn?.textContent).toContain('⋯');
   });
 
   it('starts hidden (opacity-0) and becomes visible on parent group-hover', () => {
-    render(<MenuPlaceholder />);
-    const btn = screen.getByRole('button', { name: 'Azioni' });
-    expect(btn.className).toMatch(/\bopacity-0\b/);
-    expect(btn.className).toMatch(/group-hover:opacity-100/);
-    expect(btn.className).toMatch(/transition-opacity/);
+    const { btn } = renderMenu();
+    expect(btn?.className).toMatch(/\bopacity-0\b/);
+    expect(btn?.className).toMatch(/group-hover:opacity-100/);
+    expect(btn?.className).toMatch(/transition-opacity/);
   });
 
   it('positions absolute top-2 right-2 with glass style', () => {
-    render(<MenuPlaceholder />);
-    const btn = screen.getByRole('button', { name: 'Azioni' });
-    expect(btn.className).toMatch(/\babsolute\b/);
-    expect(btn.className).toMatch(/\btop-2\b/);
-    expect(btn.className).toMatch(/\bright-2\b/);
-    expect(btn.className).toMatch(/bg-white\/85/);
-    expect(btn.className).toMatch(/backdrop-blur-md/);
+    const { btn } = renderMenu();
+    expect(btn?.className).toMatch(/\babsolute\b/);
+    expect(btn?.className).toMatch(/\btop-2\b/);
+    expect(btn?.className).toMatch(/\bright-2\b/);
+    expect(btn?.className).toMatch(/bg-white\/85/);
+    expect(btn?.className).toMatch(/backdrop-blur-md/);
   });
 
   it('stops click event propagation (prevents triggering parent card onClick)', () => {
     const parentClick = vi.fn();
-    render(
+    const { container } = render(
       <div onClick={parentClick}>
         <MenuPlaceholder />
       </div>
     );
-    fireEvent.click(screen.getByRole('button', { name: 'Azioni' }));
+    const btn = container.querySelector<HTMLButtonElement>('button[aria-label="Azioni"]');
+    fireEvent.click(btn!);
     expect(parentClick).not.toHaveBeenCalled();
   });
 
   it('is removed from the keyboard tab order (tabIndex={-1}) — no false a11y affordance', () => {
-    render(<MenuPlaceholder />);
-    const btn = screen.getByRole('button', { name: 'Azioni' });
+    const { btn } = renderMenu();
     // Without tabIndex={-1}, screen-reader / keyboard users would land on this
     // non-functional placeholder on every one of the 72 consumer card surfaces.
     // DEC-4: placeholder is visual-only; restore tabIndex={0} when a real
     // onActionsMenu handler is wired in a follow-up issue.
-    expect(btn.tabIndex).toBe(-1);
+    expect(btn?.tabIndex).toBe(-1);
   });
 });

--- a/apps/web/src/components/ui/data-display/meeple-card/variants/__tests__/GridCard.href.test.tsx
+++ b/apps/web/src/components/ui/data-display/meeple-card/variants/__tests__/GridCard.href.test.tsx
@@ -35,12 +35,10 @@ describe('GridCard href (Issue #2858)', () => {
   it('keeps role=button + onClick when href is absent and onClick is provided', () => {
     const onClick = vi.fn();
     render(<GridCard entity="game" variant="grid" title="Catan" onClick={onClick} />);
-    // Card root has no accessible name; disambiguate from the always-rendered
-    // "Azioni" MenuPlaceholder button (unrelated to this href/onClick prop).
-    const rootButton = screen
-      .getAllByRole('button')
-      .find(button => button.getAttribute('aria-label') !== 'Azioni');
-    fireEvent.click(rootButton as HTMLElement);
+    // The card root is the only <button> — MenuPlaceholder is now a decorative
+    // <div> (#3289), not a nested button, so getByRole('button') is unambiguous.
+    const rootButton = screen.getByRole('button');
+    fireEvent.click(rootButton);
     expect(onClick).toHaveBeenCalledOnce();
   });
 

--- a/apps/web/src/components/ui/data-display/meeple-card/variants/__tests__/GridCard.test.tsx
+++ b/apps/web/src/components/ui/data-display/meeple-card/variants/__tests__/GridCard.test.tsx
@@ -85,7 +85,7 @@ describe('GridCard SP4 mockup conformance (#1856)', () => {
   it('renders MenuPlaceholder button with aria-label="Azioni"', () => {
     const { container } = render(<GridCard entity="game" title="Catan" />);
     // MenuPlaceholder is aria-hidden (#3289) → absent from the a11y tree; query by DOM.
-    expect(container.querySelector('button[aria-label="Azioni"]')).not.toBeNull();
+    expect(container.querySelector('[data-slot="menu-placeholder"]')).not.toBeNull();
   });
 
   it('renders CardFooter with status when status prop is set', () => {
@@ -151,7 +151,7 @@ describe('GridCard SP4 mockup conformance (#1856)', () => {
     // MenuPlaceholder is suppressed because QuickActions occupies the same top-right slot.
     // Query the DOM — MenuPlaceholder is aria-hidden (#3289) → absent from the a11y tree,
     // so a DOM query is the meaningful check for true absence.
-    expect(container.querySelector('button[aria-label="Azioni"]')).toBeNull();
+    expect(container.querySelector('[data-slot="menu-placeholder"]')).toBeNull();
   });
 
   it('DOES render MenuPlaceholder when showQuickActions is true but actions array is empty', () => {
@@ -159,7 +159,7 @@ describe('GridCard SP4 mockup conformance (#1856)', () => {
       <GridCard entity="game" title="Catan" showQuickActions actions={[]} />
     );
     // Empty actions → QuickActions does not render → MenuPlaceholder remains.
-    expect(container.querySelector('button[aria-label="Azioni"]')).not.toBeNull();
+    expect(container.querySelector('[data-slot="menu-placeholder"]')).not.toBeNull();
   });
 });
 

--- a/apps/web/src/components/ui/data-display/meeple-card/variants/__tests__/GridCard.test.tsx
+++ b/apps/web/src/components/ui/data-display/meeple-card/variants/__tests__/GridCard.test.tsx
@@ -83,8 +83,9 @@ describe('GridCard SP4 mockup conformance (#1856)', () => {
   });
 
   it('renders MenuPlaceholder button with aria-label="Azioni"', () => {
-    render(<GridCard entity="game" title="Catan" />);
-    expect(screen.getByRole('button', { name: 'Azioni' })).toBeInTheDocument();
+    const { container } = render(<GridCard entity="game" title="Catan" />);
+    // MenuPlaceholder is aria-hidden (#3289) → absent from the a11y tree; query by DOM.
+    expect(container.querySelector('button[aria-label="Azioni"]')).not.toBeNull();
   });
 
   it('renders CardFooter with status when status prop is set', () => {
@@ -139,7 +140,7 @@ describe('GridCard SP4 mockup conformance (#1856)', () => {
   });
 
   it('does NOT render MenuPlaceholder when QuickActions are active (positional collision avoidance)', () => {
-    render(
+    const { container } = render(
       <GridCard
         entity="game"
         title="Catan"
@@ -148,13 +149,17 @@ describe('GridCard SP4 mockup conformance (#1856)', () => {
       />
     );
     // MenuPlaceholder is suppressed because QuickActions occupies the same top-right slot.
-    expect(screen.queryByRole('button', { name: 'Azioni' })).toBeNull();
+    // Query the DOM — MenuPlaceholder is aria-hidden (#3289) → absent from the a11y tree,
+    // so a DOM query is the meaningful check for true absence.
+    expect(container.querySelector('button[aria-label="Azioni"]')).toBeNull();
   });
 
   it('DOES render MenuPlaceholder when showQuickActions is true but actions array is empty', () => {
-    render(<GridCard entity="game" title="Catan" showQuickActions actions={[]} />);
+    const { container } = render(
+      <GridCard entity="game" title="Catan" showQuickActions actions={[]} />
+    );
     // Empty actions → QuickActions does not render → MenuPlaceholder remains.
-    expect(screen.getByRole('button', { name: 'Azioni' })).toBeInTheDocument();
+    expect(container.querySelector('button[aria-label="Azioni"]')).not.toBeNull();
   });
 });
 

--- a/apps/web/src/components/ui/kb-rules-quick-glance/kb-rules-quick-glance.tsx
+++ b/apps/web/src/components/ui/kb-rules-quick-glance/kb-rules-quick-glance.tsx
@@ -41,7 +41,7 @@ export function KBRulesQuickGlance({
           <span aria-hidden="true" className="text-[13px] leading-none">
             📄
           </span>
-          <span className="font-mono text-[10px] font-extrabold uppercase tracking-wider text-entity-document">
+          <span className="font-mono text-[10px] font-extrabold uppercase tracking-wider text-entity-document-text">
             {title} · loading…
           </span>
         </div>
@@ -66,7 +66,7 @@ export function KBRulesQuickGlance({
           <span aria-hidden="true" className="text-[13px] leading-none">
             📄
           </span>
-          <span className="font-mono text-[10px] font-extrabold uppercase tracking-wider text-entity-document">
+          <span className="font-mono text-[10px] font-extrabold uppercase tracking-wider text-entity-document-text">
             {title}
           </span>
         </div>
@@ -124,7 +124,7 @@ export function KBRulesQuickGlance({
         <span aria-hidden="true" className="text-[13px] leading-none">
           📄
         </span>
-        <span className="font-mono text-[10px] font-extrabold uppercase tracking-wider text-entity-document">
+        <span className="font-mono text-[10px] font-extrabold uppercase tracking-wider text-entity-document-text">
           {title} · {rules.length} bullet
         </span>
       </div>
@@ -150,7 +150,7 @@ export function KBRulesQuickGlance({
                 className={[
                   'shrink-0 rounded-pill px-1.5 py-px',
                   'font-mono text-[9px] font-extrabold tracking-wider',
-                  'bg-[hsl(var(--c-kb)/0.12)] text-entity-document',
+                  'bg-[hsl(var(--c-kb)/0.12)] text-entity-document-text',
                 ].join(' ')}
               >
                 {rule.src}


### PR DESCRIPTION
Closes #3289.

Azzera il debito sistematico di color-contrast WCAG 2.1 AA sugli entity-token e **ri-promuove** il gate `frontend-a11y` a blocking (inverso di #3290). Tutti i 14 test `Frontend - A11y E2E` falliti sono fixati, verificati contro l'output axe reale della release PR #3284 (non su ipotesi).

## Analisi: i 14 fallimenti in 3 gruppi

### 1. Color-contrast (7 specs) — il vero debito #3289
Solo `game` e `kb`/`document` falliscono AA su tint (gli altri 7 entity passano già — axe non li flagga):
- `text-entity-game` su `bg-entity-game/10` → **3.95:1** FAIL (LibraryTabs "My games", chip mechanic)
- `text-entity-document`/`kb` su `/12` → **4.38:1** FAIL (GamebookCard pip-chunks)
- `#ece6df` su `#f7f3ee` → **1.12:1** (B2 — SessionShareCard in `?theme=dark`)

**Fix**: swap `text-entity-{game,kb,document}` → la variante AA `-text` **già esistente** nel blocco `@theme` (nessun nuovo token, nessun design sign-off). Contrasto: game 3.95→**5.20:1**, document/kb 4.38→**4.87:1**. Icone `aria-hidden` e large-text esenti.

### 2. Componenti condivisi
- **MenuPlaceholder**: `aria-hidden` sul placeholder decorativo `⋯` (`opacity-0` non esenta un nodo da axe; risolve anche la violazione `nested-interactive` su players-index).
- **PauseOverlay**: dismiss ESC via listener `document`-level, così scatta indipendentemente dal focus (il React `onKeyDown` sul div veniva ignorato quando il focus usciva dal dialog).
- **SessionShareCard**: rimosso il `data-theme` sulla `<section>` che faceva leak di uno scope dark sul chrome della card (la pagina resta light); il tema ora scopa solo alla preview surface self-contained (`data-preview-theme` + inline styles).

### 3. Drift spec-vs-impl (non contrasto, regressioni accumulate su main-dev)
- **session-live**: RightColumnTabs + mobile bottom-sheet ora rendono **6 tab** (photos #2588 A1 + agent #2588 A4), non i 4 originali di G1; `chat-agent-panel` scopato a `:visible` (desktop `<main>` + mobile bottom-sheet lo montano entrambi → strict-mode fail).
- **library / games-library**: mock delle 4 sorgenti hub siblings (sessions/chat/agents/kb) con payload **schema-valid** così `useHybridHubItems.isLoading` si stabilizza e `LibraryHybridGrid` monta (il fixture `?fixture=default` short-circuita solo la sorgente games).

### Infra
- `run-a11y-e2e.mjs`: `shell:true` su Windows (Node 22 lancia EINVAL su `.cmd` con `shell:false`) — abilita l'iterazione a11y locale invece di round CI da ~20min.

## Verifica locale
- Unit test toccati: **50/50 pass** (LibraryTabs, SessionShareCard, PauseOverlay)
- `pnpm typecheck` ✅ · `pnpm lint` **0 errors** ✅
- Il gate e2e a11y completo (build a11y + Playwright) gira in CI su questa PR.

## Note di scope
Gli usi admin/public non-gated con lo stesso pattern `game/kb` (nessuno spec a11y) sono deferribili a un follow-up di consistency — non richiesti per il gate corrente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
