### PR TITLE
fix(api): persist CompleteChunkedUpload status writes (#3288)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/CompleteChunkedUploadCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/CompleteChunkedUploadCommandHandler.cs
@@ -472,7 +472,16 @@ internal class CompleteChunkedUploadCommandHandler : ICommandHandler<CompleteChu
                 return;
             }
 
-            var pdfDoc = await db.PdfDocuments.FindAsync(new object[] { pdfGuid }, cancellationToken).ConfigureAwait(false);
+            // AsTracking required: DbContext default is NoTracking (PERF-06), and FindAsync
+            // does not override the per-DbContext default — the entity would otherwise be
+            // returned untracked and every ProcessingState/extraction write below would be
+            // silently dropped at SaveChangesAsync (#3288). Mirrors the sibling
+            // UploadPdfCommandHandler.Processing.cs. The catch-all HandleProcessingFailureAsync
+            // reuses this same db scope, so its FindAsync resolves the now-tracked instance.
+            var pdfDoc = await db.PdfDocuments
+                .AsTracking()
+                .FirstOrDefaultAsync(p => p.Id == pdfGuid, cancellationToken)
+                .ConfigureAwait(false);
             if (pdfDoc == null)
             {
                 _logger.LogError("PDF document {PdfId} not found for processing", pdfId);
@@ -615,10 +624,10 @@ internal class CompleteChunkedUploadCommandHandler : ICommandHandler<CompleteChu
                 : System.Text.Json.JsonSerializer.Serialize(extractResult.StructuredElements);
             pdfDoc.PageCount = extractResult.TotalPages;
             pdfDoc.CharacterCount = extractResult.TotalCharacters;
-            // 🔴 pdfDoc came from a bare FindAsync under the NoTracking default → detached.
-            // Mark it Modified so these columns actually persist (the pre-existing SaveChanges
-            // was a silent no-op).
-            db.PdfDocuments.Update(pdfDoc);
+            // pdfDoc is tracked (loaded with .AsTracking() at the top of TriggerPdfProcessingAsync,
+            // #3288), so these scalar writes are picked up by change detection — no manual Update()
+            // needed. The previous db.Update() workaround was a partial patch for the NoTracking
+            // silent no-op and is now redundant given the root-cause fix.
             try
             {
                 await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);

--- a/apps/api/tests/Api.Tests/Integration/DocumentProcessing/CompleteChunkedUploadNoTrackingPersistenceIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/DocumentProcessing/CompleteChunkedUploadNoTrackingPersistenceIntegrationTests.cs
@@ -1,0 +1,149 @@
+using Api.BoundedContexts.DocumentProcessing.Application.Commands;
+using Api.BoundedContexts.DocumentProcessing.Application.Services;
+using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
+using Api.BoundedContexts.DocumentProcessing.Domain.Repositories;
+using Api.BoundedContexts.DocumentProcessing.Infrastructure.External;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Services;
+using Api.Services.Pdf;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using MediatR;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.Integration.DocumentProcessing;
+
+/// <summary>
+/// Regression for #3288: <see cref="CompleteChunkedUploadCommandHandler.TriggerPdfProcessingAsync"/>
+/// loads the PdfDocument via a bare <c>db.PdfDocuments.FindAsync(...)</c>. The DbContext defaults to
+/// <c>QueryTrackingBehavior.NoTracking</c> (PERF-06) and — as the sibling
+/// <c>UploadPdfCommandHandler.Processing.cs</c> documents — <c>FindAsync</c> does NOT override the
+/// per-DbContext default, so the entity is returned untracked. Every subsequent
+/// <c>pdfDoc.ProcessingState</c> write is therefore a silent no-op at <c>SaveChangesAsync</c>: a PDF
+/// whose text extraction fails never records the <c>Failed</c> state and is stuck in-flight forever.
+///
+/// This runs against a real Postgres (NoTracking default) with a fresh background-task scope, so it
+/// exercises the true EF pipeline. The existing Category=Unit
+/// <c>CompleteChunkedUploadCommandHandlerZeroChunkTests</c> misses this because it pre-Adds the entity
+/// to an in-memory tracked context and shares that same context with the handler's scope, masking the
+/// detached behavior.
+/// </summary>
+[Collection("Integration-GroupA")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "DocumentProcessing")]
+[Trait("Issue", "3288")]
+public sealed class CompleteChunkedUploadNoTrackingPersistenceIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private readonly string _databaseName = $"complete_chunked_notracking_{Guid.NewGuid():N}";
+    private WebApplicationFactory<Program> _factory = null!;
+
+    public CompleteChunkedUploadNoTrackingPersistenceIntegrationTests(SharedTestcontainersFixture fixture) => _fixture = fixture;
+
+    public async ValueTask InitializeAsync()
+    {
+        var conn = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+        await TestcontainersWaitHelpers.WaitForPostgresReadyAsync(conn);
+        _factory = IntegrationWebApplicationFactory.Create(conn);
+        using var scope = _factory.Services.CreateScope();
+        await scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>().Database.MigrateAsync();
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_factory != null) await _factory.DisposeAsync();
+        await _fixture.DropIsolatedDatabaseAsync(_databaseName);
+    }
+
+    [Fact(DisplayName = "#3288: TriggerPdfProcessingAsync persists the Failed state when extraction fails (NoTracking silent no-op)")]
+    public async Task TriggerPdfProcessing_WhenExtractionFails_PersistsFailedState()
+    {
+        var pdfId = Guid.NewGuid();
+
+        // Arrange — seed a user (required FK) and a PDF stuck in Extracting, via one scope.
+        await using (var scope = _factory.Services.CreateAsyncScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            var userId = Guid.NewGuid();
+            db.Users.Add(new UserEntity
+            {
+                Id = userId,
+                Email = $"test-{userId:N}@example.com",
+                DisplayName = "Test User",
+                Role = "user",
+                CreatedAt = DateTime.UtcNow
+            });
+            db.PdfDocuments.Add(new PdfDocumentEntity
+            {
+                Id = pdfId,
+                FileName = "test.pdf",
+                FilePath = $"pdfs/{pdfId:N}/test.pdf",
+                FileSizeBytes = 1024,
+                ContentType = "application/pdf",
+                UploadedByUserId = userId,
+                UploadedAt = DateTime.UtcNow,
+                ProcessingState = nameof(PdfProcessingState.Extracting),
+                Language = "en"
+            });
+            await db.SaveChangesAsync();
+        }
+
+        // The handler's background scope resolves a *fresh* NoTracking MeepleAiDbContext from the
+        // real IServiceScopeFactory — so FindAsync must query the DB and returns the entity untracked.
+        var scopeFactory = _factory.Services.GetRequiredService<IServiceScopeFactory>();
+
+        // Extraction fails so the handler takes the failure path (sets ProcessingState = Failed).
+        var extractorMock = new Mock<IPdfTextExtractor>();
+        extractorMock
+            .Setup(e => e.ExtractPagedTextAsync(It.IsAny<Stream>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(PagedTextExtractionResult.CreateFailure("simulated extraction failure"));
+
+        using var ctorScope = _factory.Services.CreateScope();
+        var ctorDb = ctorScope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        var handler = new CompleteChunkedUploadCommandHandler(
+            Mock.Of<IChunkedUploadSessionRepository>(),
+            ctorDb, // ctor dependency only; TriggerPdfProcessingAsync uses the scope-resolved context
+            Mock.Of<IBlobStorageService>(),
+            Mock.Of<IBackgroundTaskService>(),
+            NullLogger<CompleteChunkedUploadCommandHandler>.Instance,
+            scopeFactory,
+            extractorMock.Object,
+            Mock.Of<IPdfTableExtractor>(),
+            Mock.Of<IMediator>(),
+            Mock.Of<IPdfDeduplicationService>(),
+            TimeProvider.System);
+
+        // The method opens the file with a real FileStream, so a real temp file must exist.
+        var tmp = Path.GetTempFileName();
+        await File.WriteAllTextAsync(tmp, "dummy pdf bytes");
+
+        // Act
+        try
+        {
+            await handler.TriggerPdfProcessingAsync(pdfId.ToString(), tmp, CancellationToken.None);
+        }
+        finally
+        {
+            File.Delete(tmp);
+        }
+
+        // Assert — read with a fresh NoTracking context; the Failed write must have persisted.
+        await using (var scope = _factory.Services.CreateAsyncScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+            var entity = await db.PdfDocuments.AsNoTracking().FirstAsync(x => x.Id == pdfId);
+            entity.ProcessingState.Should().Be(nameof(PdfProcessingState.Failed),
+                "TriggerPdfProcessingAsync must load pdfDoc with .AsTracking() so the Failed state write is persisted (#3288 — NoTracking silent no-op)");
+            entity.ProcessingError.Should().NotBeNullOrEmpty(
+                "the extraction error message must be recorded alongside the Failed state");
+        }
+    }
+}


### PR DESCRIPTION
## Problem (#3288)

`CompleteChunkedUploadCommandHandler.TriggerPdfProcessingAsync` loaded the `PdfDocument` via a bare `db.PdfDocuments.FindAsync(...)`. The DbContext defaults to `QueryTrackingBehavior.NoTracking` (PERF-06) and — as the sibling `UploadPdfCommandHandler.Processing.cs` already documents — `FindAsync` does **not** override the per-DbContext default, so the entity was returned **untracked**. Every subsequent `pdfDoc.ProcessingState` / extraction write was therefore a silent no-op at `SaveChangesAsync`: a chunked upload whose text extraction fails never recorded the `Failed` state and stayed stuck in-flight forever.

PR #3281 had added a *partial* workaround (`db.PdfDocuments.Update(pdfDoc)`) on the extraction-**success** path only, leaving the failure / zero-chunk / embedding-failure / `Ready` / structured-content paths all still dropping their writes.

## Fix (root cause)

Load the entity once with `.AsTracking().FirstOrDefaultAsync(...)` (mirrors the sibling handler). With the entity tracked from the single load site, **every** write path persists, and the redundant `db.PdfDocuments.Update(pdfDoc)` workaround is removed. The catch-all `HandleProcessingFailureAsync` reuses the same `db` scope, so its `FindAsync` now resolves the already-tracked instance from the change-tracker cache.

## Test (TDD)

New `CompleteChunkedUploadNoTrackingPersistenceIntegrationTests` drives the extraction-failure branch against a **real Postgres** (NoTracking default) with a fresh background-task scope resolved from the real `IServiceScopeFactory`:
- **Fails on pre-fix code**: state stays `Extracting` (write silently dropped).
- **Passes with the fix**: state persists as `Failed`.

The existing `Category=Unit` `CompleteChunkedUploadCommandHandlerZeroChunkTests` missed this because it pre-Adds the entity to an in-memory *tracked* context and shares it with the handler's scope, masking the detached behavior.

## Verification

- ✅ New regression test: RED (state `Extracting`) → GREEN (state `Failed`)
- ✅ All 4 `CompleteChunkedUpload*` tests pass
- ✅ 442 `Category=Unit&BoundedContext=DocumentProcessing` tests pass (0 regressions)
- ✅ Adversarial code review: no query-filter divergence (`PdfDocumentEntity` has no `HasQueryFilter`), scalar writes persist via change tracking, concurrency `catch` blocks (previously dead for these paths) now live but follow the established Category B convention

## Notes

- `FirstOrDefaultAsync` applies global query filters where `FindAsync` does not — verified `PdfDocumentEntity` has no `HasQueryFilter`, and the test empirically confirms the freshly-created row is still found.
- Out of scope (pre-existing, ~40% confidence edge case): if the *first* load itself throws a transient error before `pdfDoc` is assigned, `HandleProcessingFailureAsync`'s bare `FindAsync` could run untracked. Not introduced by this change; left as-is.

Closes #3288

🤖 Generated with [Claude Code](https://claude.com/claude-code)
