### PR TITLE
chore(deps): bump Magick.NET-Q8-AnyCPU to 14.15.0 to clear NuGet audit

### DIFF
--- a/apps/api/src/Api/Api.csproj
+++ b/apps/api/src/Api/Api.csproj
@@ -74,7 +74,7 @@
     <PackageReference Include="itext7.bouncy-castle-adapter" Version="9.4.0" />
     <!-- Magick.NET-Q8-AnyCPU (Apache 2.0): replaces SixLabors.ImageSharp 3.x (Split License,
          requires commercial paid). DEC-3d-1 LOCKED 2026-06-20, issue #2055 Phase G AC-G2. -->
-    <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="14.14.0" />
+    <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="14.15.0" />
     <PackageReference Include="MediatR" Version="14.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.11" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.8" />

--- a/apps/api/tests/Api.Tests/Api.Tests.csproj
+++ b/apps/api/tests/Api.Tests/Api.Tests.csproj
@@ -38,7 +38,7 @@
     <PackageReference Include="FluentValidation" Version="12.1.1" />
     <!-- Mirror DEC-3d-1 (ADR-2026-06-09): Magick.NET-Q8-AnyCPU replaces SixLabors.ImageSharp.
          Test fixtures rely on the same image library used by production code. -->
-    <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="14.14.0" />
+    <PackageReference Include="Magick.NET-Q8-AnyCPU" Version="14.15.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.0.11" />
     <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.0.0" />
     <PackageReference Include="Moq" Version="4.20.72" />


### PR DESCRIPTION
## Problem

`Magick.NET-Q8-AnyCPU` **14.14.0** gained multiple NuGet security advisories (NU1901 low + NU1902 moderate — e.g. `GHSA-422r-8c97-xcg4`, `GHSA-qhmf-7fc4-8q3h`, `GHSA-56m6-8q75-f2rw`). With `TreatWarningsAsErrors=true` (Api.csproj:10) these are promoted to build errors, so `dotnet restore` fails and takes down **Backend Fast**, **Dependency Vulnerabilities**, and (transitively, because the C# build fails) **CodeQL (csharp)** on every backend PR.

This is a **repo-wide baseline break** triggered by newly-published advisories — not by any code change — currently blocking all backend PRs (including #3292).

## Fix

Bump `Magick.NET-Q8-AnyCPU` to **14.15.0** (latest; advisories cleared) in **both** `apps/api/src/Api/Api.csproj` and `apps/api/tests/Api.Tests/Api.Tests.csproj`. The test project references the package directly (to share the same image library as production), so both must move in lockstep or `NU1605` package-downgrade fails.

Mirrors the existing patched-version override convention already in this repo: `Snappier 1.3.1`, `Scriban.Signed 7.2.1`, `SQLitePCLRaw.bundle_e_sqlite3 3.0.3`.

## Verification (local)

- ✅ `dotnet restore` clean — **0** `NU19xx` advisories (was 30+ on 14.14.0)
- ✅ `Api.csproj` build clean — 0 errors (no API breakage, no new warnings-as-errors)
- ✅ 693 Magick.NET-dependent tests pass (webp variant / thumbnail / PDF cover / photo upload / attachment)

## Notes

- Minor bump within major `14.x` — API-stable.
- Unblocks the whole backend CI lane, including PR #3292 (#3288) which is otherwise ready.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
